### PR TITLE
refactor(Studies/AckermanMalouf2013): implicative structure on the paper's paradigms

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -742,6 +742,7 @@ import Linglib.Fragments.Basque.Relativization
 import Linglib.Fragments.Basque.WordOrder
 import Linglib.Fragments.Bulgarian.Clause
 import Linglib.Fragments.Burmese.Negation
+import Linglib.Fragments.Burmeso.ObjectAgreement
 import Linglib.Fragments.Buryat.Complementizers
 import Linglib.Fragments.Cantonese.Aspect
 import Linglib.Fragments.Cantonese.Determiners
@@ -860,6 +861,7 @@ import Linglib.Fragments.Greek.Case
 import Linglib.Fragments.Greek.Grevena.Possession
 import Linglib.Fragments.Greek.Smyrna.Possession
 import Linglib.Fragments.Greek.StandardModern.Complementizers
+import Linglib.Fragments.Greek.StandardModern.Declension
 import Linglib.Fragments.Greek.StandardModern.Modals
 import Linglib.Fragments.Greek.StandardModern.MoodChoice
 import Linglib.Fragments.Greek.StandardModern.Negation
@@ -1053,6 +1055,7 @@ import Linglib.Fragments.Mayan.Tsotsil.Agreement
 import Linglib.Fragments.Mayan.Tsotsil.Possession
 import Linglib.Fragments.Mayan.Yukatek.Agreement
 import Linglib.Fragments.Mayan.Yukatek.VerbClasses
+import Linglib.Fragments.Mazatec.Verbs
 import Linglib.Fragments.Mixtec.SMPM.Basic
 import Linglib.Fragments.Mongolian.Case
 import Linglib.Fragments.Mwaghavul.Basic
@@ -2947,3 +2950,4 @@ import Linglib.Data.Examples.KeshetAbney2024
 import Linglib.Data.Examples.AbneyKeshet2025
 import Linglib.Data.Examples.AbramskySadrzadeh2014
 import Linglib.Data.Examples.AckemaNeeleman2018
+import Linglib.Data.Examples.AckermanMalouf2013

--- a/Linglib/Data/Examples/AckermanMalouf2013.json
+++ b/Linglib/Data/Examples/AckermanMalouf2013.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "ackermanmalouf2013_1",
+    "source": {"bibkey": "ackerman-malouf-2013", "paperLabel": "(1)"},
+    "reportedIn": null,
+    "language": "kala1399",
+    "primaryText": "ajunngitsuliurviginnittuartuunngilaq",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["aju-", "be.good"], ["nngit-", "NEG"], ["su-", "PART"], ["liur-", "make"],
+      ["vigi-", "have.as.place.of"], ["nnit-", "ANTIP"], ["tuar-", "all.the.time"],
+      ["tu-", "PART"], ["u-", "be"], ["nngil-", "NEG"], ["aq", "3SG.IND"]
+    ],
+    "translation": "He is not (much of) a benefactor.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "polysynthesis"],
+      ["complexity", "enumerative"]
+    ],
+    "comment": "West Greenlandic, cited from Fortescue as a word packaging what English expresses phrasally.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/AckermanMalouf2013.lean
+++ b/Linglib/Data/Examples/AckermanMalouf2013.lean
@@ -1,0 +1,36 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `AckermanMalouf2013` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/AckermanMalouf2013.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace AckermanMalouf2013.Examples`.
+-/
+
+namespace AckermanMalouf2013.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "ackermanmalouf2013_1"
+    source := ⟨"ackerman-malouf-2013", "(1)"⟩
+    reportedIn := none
+    language := "kala1399"
+    primaryText := "ajunngitsuliurviginnittuartuunngilaq"
+    discourseSegments := []
+    glossedTokens := [("aju-", "be.good"), ("nngit-", "NEG"), ("su-", "PART"), ("liur-", "make"), ("vigi-", "have.as.place.of"), ("nnit-", "ANTIP"), ("tuar-", "all.the.time"), ("tu-", "PART"), ("u-", "be"), ("nngil-", "NEG"), ("aq", "3SG.IND")]
+    translation := "He is not (much of) a benefactor."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "polysynthesis"), ("complexity", "enumerative")]
+    comment := "West Greenlandic, cited from Fortescue as a word packaging what English expresses phrasally."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1]
+
+end AckermanMalouf2013.Examples

--- a/Linglib/Fragments/Burmeso/ObjectAgreement.lean
+++ b/Linglib/Fragments/Burmeso/ObjectAgreement.lean
@@ -1,0 +1,35 @@
+import Linglib.Morphology.Paradigm.Basic
+import Mathlib.Data.Fin.VecNotation
+
+/-!
+# Burmeso object agreement
+
+The two classes of Burmeso object agreement prefixes over six noun classes in two numbers,
+after Donohue's description as tabulated in [ackerman-malouf-2013].
+
+## References
+
+* [ackerman-malouf-2013]
+-/
+
+namespace Burmeso.ObjectAgreement
+
+open Morphology
+
+/-- The agreement prefixes. -/
+inductive AgreementPrefix
+  | j
+  | s
+  | g
+  | b
+  | t
+  | n
+  deriving DecidableEq, Repr
+
+/-- The two classes over the cells I.sg, I.pl, …, VI.sg, VI.pl, each with unit weight. -/
+def objectAgreement : ParadigmSystem 12 AgreementPrefix where
+  entries :=
+    [(![.j, .s, .g, .s, .g, .j, .j, .j, .j, .g, .g, .g], 1),
+      (![.b, .t, .n, .t, .n, .b, .b, .b, .b, .n, .n, .n], 1)]
+
+end Burmeso.ObjectAgreement

--- a/Linglib/Fragments/Greek/StandardModern/Declension.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Declension.lean
@@ -1,0 +1,58 @@
+import Linglib.Morphology.Paradigm.Basic
+import Mathlib.Data.Fin.VecNotation
+
+/-!
+# Modern Greek nominal declensions
+
+The eight nominal inflection classes of Modern Greek by their case–number endings, after
+Ralli's description as simplified in [ackerman-malouf-2013] (stem alternations and stress set
+aside), as a weighted paradigm system with uniform class weights.
+
+## References
+
+* [ackerman-malouf-2013]
+-/
+
+namespace Greek.StandardModern.Declension
+
+open Morphology
+
+/-- The nominal endings. -/
+inductive Ending
+  | os
+  | u
+  | on
+  | e
+  | i
+  | us
+  | s
+  | zero
+  | es
+  | is
+  | o
+  | a
+  deriving DecidableEq, Repr
+
+/-- The cells: nominative, genitive, accusative, and vocative, singular then plural. -/
+abbrev nomSg : Fin 8 := 0
+abbrev genSg : Fin 8 := 1
+abbrev accSg : Fin 8 := 2
+abbrev vocSg : Fin 8 := 3
+abbrev nomPl : Fin 8 := 4
+abbrev genPl : Fin 8 := 5
+abbrev accPl : Fin 8 := 6
+abbrev vocPl : Fin 8 := 7
+
+/-- The eight declensions, each with unit weight. -/
+def nominal : ParadigmSystem 8 Ending where
+  entries :=
+    [(![.os, .u, .on, .e, .i, .on, .us, .i], 1),
+      (![.s, .zero, .zero, .zero, .es, .on, .es, .es], 1),
+      (![.zero, .s, .zero, .zero, .es, .on, .es, .es], 1),
+      (![.zero, .s, .zero, .zero, .is, .on, .is, .is], 1),
+      (![.o, .u, .o, .o, .a, .on, .a, .a], 1),
+      (![.zero, .u, .zero, .zero, .a, .on, .a, .a], 1),
+      (![.os, .us, .os, .os, .i, .on, .i, .i], 1),
+      (![.zero, .os, .zero, .zero, .a, .on, .a, .a], 1)]
+
+end Greek.StandardModern.Declension

--- a/Linglib/Fragments/Mazatec/Verbs.lean
+++ b/Linglib/Fragments/Mazatec/Verbs.lean
@@ -1,0 +1,84 @@
+import Linglib.Morphology.Paradigm.Basic
+import Mathlib.Data.Fin.VecNotation
+
+/-!
+# Chiquihuitlán Mazatec verb inflection
+
+Two of the three cross-cutting inflection-class systems of Chiquihuitlán Mazatec verbs over the
+cells 1sg, 2sg, 3, 1incl, 1pl, 2pl, after Jamieson's description as tabulated in
+[ackerman-malouf-2013]: the ten final-vowel classes and the six neutral-aspect tone patterns,
+each with unit weight.
+
+## References
+
+* [ackerman-malouf-2013]
+-/
+
+namespace Mazatec.Verbs
+
+open Morphology
+
+/-- The cells. -/
+abbrev firstSg : Fin 6 := 0
+abbrev secondSg : Fin 6 := 1
+abbrev third : Fin 6 := 2
+abbrev firstIncl : Fin 6 := 3
+abbrev firstPl : Fin 6 := 4
+abbrev secondPl : Fin 6 := 5
+
+/-- Final vowels, nasal ones suffixed `N`. -/
+inductive Vowel
+  | ae
+  | i
+  | e
+  | u
+  | o
+  | a
+  | eN
+  | iN
+  | uN
+  | oN
+  | aN
+  deriving DecidableEq, Repr
+
+/-- The ten final-vowel classes. -/
+def finalVowels : ParadigmSystem 6 Vowel where
+  entries :=
+    [(![.ae, .i, .i, .eN, .iN, .uN], 1),
+      (![.ae, .e, .e, .eN, .iN, .uN], 1),
+      (![.ae, .e, .ae, .eN, .iN, .uN], 1),
+      (![.u, .i, .u, .uN, .iN, .uN], 1),
+      (![.o, .e, .o, .oN, .iN, .uN], 1),
+      (![.a, .e, .a, .aN, .iN, .uN], 1),
+      (![.eN, .iN, .iN, .eN, .iN, .uN], 1),
+      (![.eN, .iN, .eN, .eN, .iN, .uN], 1),
+      (![.uN, .iN, .uN, .uN, .iN, .uN], 1),
+      (![.aN, .iN, .eN, .aN, .iN, .uN], 1)]
+
+/-- Tone patterns, named by their tone numbers. -/
+inductive Tone
+  | t3_1
+  | t3_31
+  | t3_14
+  | t1_1
+  | t2_2
+  | t2_24
+  | t3_2
+  | t1_43
+  | t3_24
+  | t14_42
+  | t14_34
+  | t14_3
+  deriving DecidableEq, Repr
+
+/-- The six neutral-aspect tone patterns. -/
+def tones : ParadigmSystem 6 Tone where
+  entries :=
+    [(![.t3_1, .t3_1, .t3_1, .t3_31, .t3_14, .t3_1], 1),
+      (![.t1_1, .t2_2, .t2_2, .t2_2, .t2_24, .t2_2], 1),
+      (![.t3_1, .t2_2, .t3_2, .t2_2, .t2_24, .t2_2], 1),
+      (![.t1_43, .t1_43, .t3_24, .t14_42, .t14_34, .t14_3], 1),
+      (![.t1_1, .t3_2, .t3_2, .t3_2, .t3_24, .t3_2], 1),
+      (![.t3_1, .t3_2, .t3_2, .t3_2, .t3_24, .t3_2], 1)]
+
+end Mazatec.Verbs

--- a/Linglib/Morphology/Paradigm/Complexity.lean
+++ b/Linglib/Morphology/Paradigm/Complexity.lean
@@ -1,120 +1,195 @@
 import Linglib.Morphology.Paradigm.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
-# Paradigm complexity: entropy and implicative structure over cells
+# Paradigm complexity: implicative structure and entropy over cells
 
-Two views of the Paradigm Cell Filling Problem over a `ParadigmSystem`.
-The **quantitative** layer measures cell distributions: Shannon entropy
-of a cell, conditional entropy between cells (the integrand of
-[ackerman-malouf-2013]'s i-complexity), and the derived
-implicative-structure predicates. The **qualitative** layer is the
-zero-entropy (categorical) case: a set of cells `Predicts` another when
-the forms filling it determine the form filling the target across every
-inflection class — the implicative relation [bonami-beniamine-2016]
-quantify with conditional entropy, here as a plain relation over the
-system's rows. Entropy quantification stays prose-level per repo
-discipline; `Predicts` is its zero-entropy extreme.
+This file defines the two faces of the paradigm cell filling problem over a `ParadigmSystem`.
+The qualitative face is categorical: a set of cells *predicts* another when the forms filling it
+determine the form filling the target across the inflection classes, a *principal-part set*
+predicts every cell, and a system is *vocabularly clear* when every single cell does. The
+quantitative face measures the same relations by entropy: the entropy of the class assignment, of
+the form distribution at a cell, and the conditional entropy of one cell given another — the
+integrand of average conditional entropy. The two faces meet at zero: a cell predicted by another
+has zero conditional entropy given it, so a vocabularly clear system is transparent. Enumerative
+complexity is counted by the realizations of each cell, whose product bounds the number of
+classes.
 
-## Main declarations
+## Main definitions
 
-* `ParadigmSystem.cellEntropy`, `ParadigmSystem.conditionalCellEntropy`
-* `ParadigmSystem.isImplicative`, `ParadigmSystem.isTransparent`
-* `ParadigmSystem.Predicts`, `ParadigmSystem.IsPrincipalPartSet` — the
-  categorical implicative relation and principal-part sets
+* `ParadigmSystem.Predicts`, `ParadigmSystem.IsPrincipalPartSet`,
+  `ParadigmSystem.IsVocabularClear`: the implicative relations.
+* `ParadigmSystem.realizations`, `ParadigmSystem.maxRealizations`,
+  `ParadigmSystem.ParadigmEconomy`: enumerative counts and the paradigm economy principle.
+* `ParadigmSystem.declensionEntropy`, `ParadigmSystem.cellEntropy`,
+  `ParadigmSystem.conditionalCellEntropy`: entropies in nats, from the class weights.
+* `ParadigmSystem.IsImplicative`, `ParadigmSystem.IsTransparent`: zero conditional entropy.
 
-`iComplexity` (the paper-specific average conditional entropy) and
-`LCECHolds` (the LCEC threshold predicate) live in
-`Studies/AckermanMalouf2013.lean` because they are particular
-aggregations the paper defines, not substrate primitives.
+## Main statements
+
+* `ParadigmSystem.conditionalCellEntropy_eq_zero_of_predicts`,
+  `ParadigmSystem.isTransparent_of_isVocabularClear`: prediction is zero conditional entropy.
+* `ParadigmSystem.cellEntropy_eq_zero_of_card_le_one`: a cell with one realization has zero
+  entropy.
+* `ParadigmSystem.card_paradigms_le_prod_card_realizations`: classes are bounded by the product
+  of realizations.
+
+## References
+
+* [ackerman-malouf-2013]
+* [bonami-beniamine-2016]
+* [carstairs-mccarthy-2010]
 -/
 
 namespace Morphology
 
-/-- **Private (ι→ℝ) Shannon entropy** for paradigm-cell complexity computations.
-    Inlined from the deleted `Core.InformationTheory.entropy` (the canonical PMF
-    form is `PMF.entropy`; this Finset-restricted (ι→ℝ) form is natural here
-    because cell distributions are list-derived ad-hoc empirical frequencies). -/
-private noncomputable def entropy {α : Type*} (s : Finset α) (p : α → ℝ) : ℝ :=
-  ∑ a ∈ s, Real.negMulLog (p a)
+namespace ParadigmSystem
 
-/-- **Private conditional entropy** `H(Y|X) = H(X,Y) − H(X)`. -/
-private noncomputable def conditionalEntropy {α β : Type*}
-    (sJoint : Finset (α × β)) (joint : α × β → ℝ)
-    (sX : Finset α) (marginalX : α → ℝ) : ℝ :=
-  entropy sJoint joint - entropy sX marginalX
+variable {n : ℕ} {Form : Type*} (ps : ParadigmSystem n Form)
 
-/-- **Private list-of-pairs → (Finset, function) adapter** (was
-    `Core.InformationTheory.distOfList`). -/
-private noncomputable def distOfList {α : Type*} [DecidableEq α]
-    (dist : List (α × ℚ)) : Finset α × (α → ℝ) :=
-  ((dist.map Prod.fst).toFinset,
-   fun a => (((dist.find? (λ x => x.1 = a)).map Prod.snd).getD 0 : ℚ))
+/-! ### Implicative structure -/
 
-/-- Shannon entropy of the empirical distribution at cell `c` (in nats). -/
-noncomputable def ParadigmSystem.cellEntropy {n : ℕ} {Form : Type*}
-    [DecidableEq Form] (ps : ParadigmSystem n Form) (c : Fin n) : ℝ :=
-  let (support, prob) := distOfList (ps.cellDistribution c)
-  entropy support prob
+/-- A set of cells `S` predicts cell `j` when any two classes agreeing on every cell of `S`
+agree at `j`. -/
+def Predicts (S : Finset (Fin n)) (j : Fin n) : Prop :=
+  ∀ p ∈ ps.entries, ∀ q ∈ ps.entries, (∀ c ∈ S, p.1 c = q.1 c) → p.1 j = q.1 j
 
-/-- Conditional entropy `H(C_i | C_j)` of cell `ci` given cell `cj` (in nats).
-    The integrand of [ackerman-malouf-2013]'s i-complexity. -/
-noncomputable def ParadigmSystem.conditionalCellEntropy {n : ℕ} {Form : Type*}
-    [DecidableEq Form]
-    (ps : ParadigmSystem n Form) (ci cj : Fin n) : ℝ :=
-  let (sJoint, joint) := distOfList (ps.jointCellDistribution ci cj)
-  let (sMargX, margX) := distOfList (ps.cellDistribution cj)
-  conditionalEntropy sJoint joint sMargX margX
+/-- A principal-part set predicts every cell. -/
+def IsPrincipalPartSet (S : Finset (Fin n)) : Prop := ∀ j, ps.Predicts S j
 
-/-- A cell pair `(ci, cj)` is **implicative** iff knowing the form at `cj`
-    perfectly determines the form at `ci` (zero conditional entropy). -/
-def ParadigmSystem.isImplicative {n : ℕ} {Form : Type*} [DecidableEq Form]
-    (ps : ParadigmSystem n Form) (ci cj : Fin n) : Prop :=
-  ps.conditionalCellEntropy ci cj = 0
+/-- Vocabular clarity: every cell on its own predicts every cell — each realization identifies
+the class. -/
+def IsVocabularClear : Prop := ∀ c, ps.IsPrincipalPartSet {c}
 
-/-- A paradigm is **transparent** iff every off-diagonal cell pair is
-    implicative — every cell perfectly predicts every other. -/
-def ParadigmSystem.isTransparent {n : ℕ} {Form : Type*} [DecidableEq Form]
-    (ps : ParadigmSystem n Form) : Prop :=
-  ∀ (ci cj : Fin n), ci ≠ cj → ps.isImplicative ci cj
+variable {ps}
 
-/-! ### Qualitative implicative structure
-
-The categorical (zero-entropy) face of the Paradigm Cell Filling
-Problem [bonami-beniamine-2016]: which sets of known cells determine an
-unknown cell across the inflection classes. -/
-
-/-- A set of cells `S` **predicts** cell `j` when the forms filling `S`
-determine the form filling `j` across the system: any two inflection
-classes agreeing on every cell of `S` also agree at `j`. The
-zero-conditional-entropy case of the implicative relation
-[bonami-beniamine-2016] measure. -/
-def ParadigmSystem.Predicts {n : ℕ} {Form : Type*}
-    (ps : ParadigmSystem n Form) (S : Finset (Fin n)) (j : Fin n) : Prop :=
-  ∀ p ∈ ps.entries, ∀ q ∈ ps.entries,
-    (∀ c ∈ S, p.1 c = q.1 c) → p.1 j = q.1 j
-
-/-- A set of cells is a **principal-part set** when it predicts every cell
-of the system: knowing those forms determines the whole paradigm. -/
-def ParadigmSystem.IsPrincipalPartSet {n : ℕ} {Form : Type*}
-    (ps : ParadigmSystem n Form) (S : Finset (Fin n)) : Prop :=
-  ∀ j, ps.Predicts S j
-
-/-- Prediction is **monotone** in the known cells: enlarging the predictor
-set never destroys a prediction. -/
-theorem ParadigmSystem.Predicts.mono {n : ℕ} {Form : Type*}
-    {ps : ParadigmSystem n Form} {S T : Finset (Fin n)} {j : Fin n}
-    (hST : S ⊆ T) (h : ps.Predicts S j) : ps.Predicts T j :=
+theorem Predicts.mono {S T : Finset (Fin n)} {j : Fin n} (hST : S ⊆ T) (h : ps.Predicts S j) :
+    ps.Predicts T j :=
   fun p hp q hq hag => h p hp q hq fun c hc => hag c (hST hc)
 
-/-- A worked case: a two-class system whose first cell is diagnostic. The
-classes differ at cell `0`, so it is a principal-part set — its form
-determines cell `1`. -/
-private def demoSystem : ParadigmSystem 2 String :=
-  { entries := [(![("a"), ("x")], 1 / 2), (![("b"), ("y")], 1 / 2)] }
+theorem predicts_of_mem {S : Finset (Fin n)} {j : Fin n} (hj : j ∈ S) : ps.Predicts S j :=
+  fun _ _ _ _ hag => hag j hj
 
-private theorem demoSystem_principalPart :
-    demoSystem.IsPrincipalPartSet {0} := by
-  intro j; fin_cases j <;> (unfold ParadigmSystem.Predicts; decide)
+variable (ps) [DecidableEq Form]
+
+instance {S : Finset (Fin n)} {j : Fin n} : Decidable (ps.Predicts S j) :=
+  inferInstanceAs (Decidable (∀ p ∈ ps.entries, ∀ q ∈ ps.entries, _ → _))
+
+instance {S : Finset (Fin n)} : Decidable (ps.IsPrincipalPartSet S) :=
+  inferInstanceAs (Decidable (∀ j, ps.Predicts S j))
+
+instance : Decidable ps.IsVocabularClear :=
+  inferInstanceAs (Decidable (∀ c, ps.IsPrincipalPartSet {c}))
+
+/-! ### Enumerative counts -/
+
+/-- The forms realizing cell `c`. -/
+def realizations (c : Fin n) : Finset Form := (ps.entries.map fun e => e.1 c).toFinset
+
+theorem mem_realizations {c : Fin n} {r : Form} :
+    r ∈ ps.realizations c ↔ ∃ e ∈ ps.entries, e.1 c = r := by
+  simp [realizations]
+
+/-- The largest number of rival realizations of a single cell. -/
+def maxRealizations : ℕ := Finset.univ.sup fun c => (ps.realizations c).card
+
+/-- Paradigm economy: no more classes than rival realizations of the most varied cell. -/
+def ParadigmEconomy : Prop := ps.eComplexity ≤ ps.maxRealizations
+
+instance : Decidable ps.ParadigmEconomy := inferInstanceAs (Decidable (_ ≤ _))
+
+/-- The distinct paradigms of the system are bounded by the product of the realizations of the
+cells. -/
+theorem card_paradigms_le_prod_card_realizations :
+    (ps.entries.map Prod.fst).toFinset.card ≤ ∏ c, (ps.realizations c).card := by
+  rw [← Fintype.card_piFinset]
+  refine Finset.card_le_card_of_injOn id (fun p hp => ?_) (Set.injOn_id _)
+  simp only [Finset.mem_coe, List.mem_toFinset, List.mem_map] at hp
+  obtain ⟨e, he, rfl⟩ := hp
+  exact Finset.mem_coe.2 (Fintype.mem_piFinset.2 fun c => ps.mem_realizations.2 ⟨e, he, rfl⟩)
+
+/-! ### Entropy -/
+
+/-- The total weight of the classes. -/
+def total : ℚ := (ps.entries.map Prod.snd).sum
+
+/-- The weight of the classes realizing `r` at `c`. -/
+def cellWeight (c : Fin n) (r : Form) : ℚ :=
+  ((ps.entries.filter fun e => e.1 c = r).map Prod.snd).sum
+
+/-- The weight of the classes realizing `ri` at `ci` and `rj` at `cj`. -/
+def jointWeight (ci cj : Fin n) (ri rj : Form) : ℚ :=
+  ((ps.entries.filter fun e => e.1 ci = ri ∧ e.1 cj = rj).map Prod.snd).sum
+
+/-- The pairs of forms realized at a pair of cells. -/
+def jointRealizations (ci cj : Fin n) : Finset (Form × Form) :=
+  (ps.entries.map fun e => (e.1 ci, e.1 cj)).toFinset
+
+theorem mem_jointRealizations {ci cj : Fin n} {p : Form × Form} :
+    p ∈ ps.jointRealizations ci cj ↔ ∃ e ∈ ps.entries, (e.1 ci, e.1 cj) = p := by
+  simp [jointRealizations]
+
+/-- The entropy (in nats) of the class assignment. -/
+noncomputable def declensionEntropy : ℝ :=
+  (ps.entries.map fun e => Real.negMulLog ((e.2 / ps.total : ℚ) : ℝ)).sum
+
+/-- The entropy (in nats) of the form distribution at cell `c`. -/
+noncomputable def cellEntropy (c : Fin n) : ℝ :=
+  ∑ r ∈ ps.realizations c, Real.negMulLog ((ps.cellWeight c r / ps.total : ℚ) : ℝ)
+
+/-- The joint entropy (in nats) of two cells. -/
+noncomputable def jointCellEntropy (ci cj : Fin n) : ℝ :=
+  ∑ p ∈ ps.jointRealizations ci cj,
+    Real.negMulLog ((ps.jointWeight ci cj p.1 p.2 / ps.total : ℚ) : ℝ)
+
+/-- The conditional entropy `H(cᵢ | cⱼ) = H(cᵢ, cⱼ) − H(cⱼ)` of cell `ci` given cell `cj`. -/
+noncomputable def conditionalCellEntropy (ci cj : Fin n) : ℝ :=
+  ps.jointCellEntropy ci cj - ps.cellEntropy cj
+
+/-- Knowing cell `cj` leaves no uncertainty about cell `ci`. -/
+def IsImplicative (ci cj : Fin n) : Prop := ps.conditionalCellEntropy ci cj = 0
+
+/-- Every cell predicts every other cell. -/
+def IsTransparent : Prop := ∀ ci cj, ci ≠ cj → ps.IsImplicative ci cj
+
+/-- A cell with at most one realization has zero entropy. -/
+theorem cellEntropy_eq_zero_of_card_le_one {c : Fin n} (h : (ps.realizations c).card ≤ 1) :
+    ps.cellEntropy c = 0 := by
+  refine Finset.sum_eq_zero fun r hr => ?_
+  have hall : ps.cellWeight c r = ps.total := by
+    unfold cellWeight total
+    congr 1
+    exact congrArg _ (List.filter_eq_self.2 fun e he => decide_eq_true
+      (Finset.card_le_one.1 h _ (ps.mem_realizations.2 ⟨e, he, rfl⟩) r hr))
+  rcases eq_or_ne ps.total 0 with h0 | h0 <;> simp [hall, h0]
+
+/-- A cell predicted by another has zero conditional entropy given it. -/
+theorem conditionalCellEntropy_eq_zero_of_predicts {ci cj : Fin n} (h : ps.Predicts {cj} ci) :
+    ps.conditionalCellEntropy ci cj = 0 := by
+  refine sub_eq_zero.2 (Finset.sum_bij (fun p _ => p.2) (fun p hp => ?_) (fun p hp q hq hpq => ?_)
+    (fun r hr => ?_) fun p hp => ?_)
+  · obtain ⟨e, he, rfl⟩ := ps.mem_jointRealizations.1 hp
+    exact ps.mem_realizations.2 ⟨e, he, rfl⟩
+  · obtain ⟨e, he, rfl⟩ := ps.mem_jointRealizations.1 hp
+    obtain ⟨e', he', rfl⟩ := ps.mem_jointRealizations.1 hq
+    exact Prod.ext (h e he e' he' fun _ hc => (Finset.mem_singleton.1 hc) ▸ hpq) hpq
+  · obtain ⟨e, he, rfl⟩ := ps.mem_realizations.1 hr
+    exact ⟨_, ps.mem_jointRealizations.2 ⟨e, he, rfl⟩, rfl⟩
+  · obtain ⟨e, he, rfl⟩ := ps.mem_jointRealizations.1 hp
+    congr 3
+    unfold jointWeight cellWeight
+    congr 1
+    exact congrArg _ (List.filter_congr fun e' he' => by
+      simp only [decide_eq_decide]
+      exact ⟨fun h' => h'.2, fun h' =>
+        ⟨(h e' he' e he fun _ hc => (Finset.mem_singleton.1 hc) ▸ h'), h'⟩⟩)
+
+/-- A vocabularly clear system is transparent. -/
+theorem isTransparent_of_isVocabularClear (h : ps.IsVocabularClear) : ps.IsTransparent :=
+  fun ci cj _ => ps.conditionalCellEntropy_eq_zero_of_predicts (h cj ci)
+
+end ParadigmSystem
 
 end Morphology

--- a/Linglib/Studies/AckermanMalouf2013.lean
+++ b/Linglib/Studies/AckermanMalouf2013.lean
@@ -1,345 +1,114 @@
 import Linglib.Morphology.Paradigm.Complexity
-import Mathlib.Data.Rat.Defs
+import Linglib.Fragments.Greek.StandardModern.Declension
+import Linglib.Fragments.Burmeso.ObjectAgreement
+import Linglib.Fragments.Mazatec.Verbs
+import Linglib.Data.Examples.AckermanMalouf2013
 
 /-!
-# [ackerman-malouf-2013]: The Low Conditional Entropy Conjecture
-[ackerman-malouf-2013] [carstairs-mccarthy-2010]
+# The low conditional entropy conjecture
 
-## E-complexity vs. I-complexity
+Ackerman and Malouf separate the enumerative complexity of an inflectional system — how many
+cells, realizations, and inflection classes it has — from its integrative complexity, the
+average conditional entropy of one paradigm cell given another (`iComplexity`, over
+`Morphology.ParadigmSystem.conditionalCellEntropy`), and conjecture that the latter stays low
+however large the former grows. Their Modern Greek fragment
+(`Greek.StandardModern.Declension.nominal`) carries the argument against enumerative principles:
+its eight declensions exceed the five rival realizations of its most varied cell, violating
+paradigm economy (`greek_not_paradigmEconomy`), while implicative structure keeps the speaker's
+task small — the genitive plural has a single realization (`greek_cellEntropy_genPl`),
+accusative and vocative singular predict each other and the accusative plural predicts the
+nominative plural (`greek_predicts`), an accusative plural in *-i* fixes the genitive singular
+(`greek_accPl_i_genSg`) although the accusative plural alone does not predict it
+(`greek_not_predicts`), and three cells form a principal-part set where two do not
+(`greek_principalParts`).
 
-Languages differ dramatically in their **enumerative complexity** (E-complexity):
-how many inflection classes, allomorphic variants, and paradigm cells they
-have. But this apparent complexity is misleading. The key question is
-**integrative complexity** (I-complexity): given that a speaker knows *some*
-forms of a lexeme, how hard is it to predict the *rest*?
+Synonymy avoidance — each realization of a cell identifying its class — is the zero of the
+measure: a vocabularly clear system is transparent and has integrative complexity zero
+(`Morphology.ParadigmSystem.isTransparent_of_isVocabularClear`, `transparent_iComplexity_zero`),
+as Burmeso's two object-agreement classes are (`burmeso_iComplexity`). Chiquihuitlán Mazatec
+departs from it in both dimensions the paper distinguishes: its final-vowel classes are not
+vocabularly clear (`mazatec_vowels_not_clear`) and two of their cells are constant
+(`mazatec_vowels_constant`), and no cell of its neutral-aspect tone patterns is diagnostic of
+class membership (`mazatec_tones_no_diagnostic_cell`).
 
-## The LCEC
+## References
 
-The Low Conditional Entropy Conjecture states that the average conditional
-entropy of paradigm cells — how uncertain you are about one cell given another —
-is uniformly low across typologically diverse languages, regardless of
-E-complexity. Formally:
-
-    I-complexity(L) = (1 / n(n-1)) · Σᵢ≠ⱼ H(Cᵢ | Cⱼ)
-
-is low for all natural languages L, where Cᵢ ranges over paradigm cells and
-H(Cᵢ | Cⱼ) is the conditional entropy of cell i given cell j.
-
-## Structure
-
-- §0: i-Complexity (paper-specific aggregation; substrate types
-  `Paradigm`/`ParadigmSystem`/`cellEntropy`/`conditionalCellEntropy`
-  live in `Morphology/Paradigm.lean`, hoisted there 0.230.X for shared
-  use with [rathi-hahn-futrell-2026]'s informational fusion)
-- §1: Per-language LCEC verification (all 10 languages)
-- §2: E-complexity / I-complexity dissociation
-- §3: Mazatec case study (observed vs. random baseline)
+* [ackerman-malouf-2013]
+* [carstairs-mccarthy-2010]
+* [bonami-beniamine-2016]
 -/
-
--- ============================================================================
--- §0: i-Complexity (paper-specific aggregation over substrate primitives)
--- ============================================================================
-
-namespace Morphology.WP
-
-open Morphology
-
-/-- [ackerman-malouf-2013]'s **integrative complexity**: average
-    conditional cell entropy across all off-diagonal cell pairs.
-
-    `iComplexity(L) = (1 / n(n-1)) · Σᵢ≠ⱼ H(Cᵢ | Cⱼ)`
-
-    Instantiated at `Form := String` since A&M's paradigms are over
-    natural-language surface forms. -/
-noncomputable def iComplexity {n : Nat} (ps : ParadigmSystem n String) : ℝ :=
-  let cells := List.finRange n
-  let pairs := cells.flatMap λ ci => (cells.filter (· != ci)).map λ cj => (ci, cj)
-  let total := pairs.map λ (ci, cj) => ps.conditionalCellEntropy ci cj
-  let sum := total.sum
-  let numPairs := n * (n - 1)
-  if numPairs == 0 then 0 else sum / (numPairs : ℝ)
-
-/-- The Low Conditional Entropy Conjecture: i-complexity is bounded by
-    a small threshold. The threshold is empirical (typically ≤ 1 nat). -/
-def LCECHolds {n : Nat} (ps : ParadigmSystem n String) (threshold : ℝ) : Prop :=
-  iComplexity ps ≤ threshold
-
-private lemma sum_eq_zero_of_forall_zero {l : List ℝ}
-    (h : ∀ x ∈ l, x = 0) : l.sum = 0 := by
-  induction l with
-  | nil => rfl
-  | cons a as ih =>
-    simp only [List.sum_cons]
-    rw [h a (.head as), ih (fun y hy => h y (.tail a hy)), add_zero]
-
-theorem transparent_iComplexity_zero {n : Nat} (ps : ParadigmSystem n String)
-    (h : ps.isTransparent) : iComplexity ps = 0 := by
-  have hall : ∀ x ∈ ((List.finRange n).flatMap fun ci =>
-      ((List.finRange n).filter (· != ci)).map fun cj =>
-      (ci, cj)).map (fun x => ps.conditionalCellEntropy x.1 x.2),
-      x = 0 := by
-    intro x hx
-    simp only [List.mem_map, List.mem_flatMap, List.mem_filter] at hx
-    obtain ⟨⟨ci, cj⟩, ⟨w, _, f, ⟨_, hfne⟩, hpair⟩, rfl⟩ := hx
-    obtain ⟨rfl, rfl⟩ := Prod.mk.inj hpair
-    exact h w f (by intro heq; simp [heq] at hfne)
-  have hfold := sum_eq_zero_of_forall_zero hall
-  simp only [iComplexity]
-  simp only [hfold]; split <;> simp
-
-end Morphology.WP
 
 namespace AckermanMalouf2013
 
--- ============================================================================
--- LanguageData Sample (Tables 2--3 of [ackerman-malouf-2013])
--- ============================================================================
+open Morphology Greek.StandardModern.Declension Burmeso.ObjectAgreement Mazatec.Verbs
 
-/-- Summary statistics for a language's morphological paradigm system,
-    as reported in published studies.
+variable {n : ℕ} {Form : Type*} [DecidableEq Form]
 
-    Fields correspond to Tables 2--3 of [ackerman-malouf-2013]. -/
-structure LanguageData where
-  /-- Language name -/
-  name : String
-  /-- Language family -/
-  family : String
-  /-- Number of inflection classes (E-complexity) -/
-  numClasses : Nat
-  /-- Number of paradigm cells -/
-  numCells : Nat
-  /-- Average conditional entropy H(Ci|Cj) in bits (I-complexity) -/
-  avgCondEntropy : ℚ
-  /-- Maximum cell entropy max H(Ci) in bits -/
-  maxCellEntropy : ℚ
-  deriving Repr
+/-- Integrative complexity: the average conditional entropy over ordered pairs of distinct
+cells. -/
+noncomputable def iComplexity (ps : ParadigmSystem n Form) : ℝ :=
+  (∑ ci, ∑ cj ∈ Finset.univ.erase ci, ps.conditionalCellEntropy ci cj) / (n * (n - 1))
 
-/-- Fur (Nilo-Saharan, Fur; Sudan). 4 classes, 2 cells. -/
-def fur : LanguageData where
-  name := "Fur"
-  family := "Nilo-Saharan"
-  numClasses := 4
-  numCells := 2
-  avgCondEntropy := 489 / 1000  -- 0.489
-  maxCellEntropy := 1334 / 1000  -- 1.334
+/-- A transparent system has integrative complexity zero. -/
+theorem transparent_iComplexity_zero {ps : ParadigmSystem n Form} (h : ps.IsTransparent) :
+    iComplexity ps = 0 := by
+  rw [iComplexity, Finset.sum_eq_zero, zero_div]
+  exact fun ci _ => Finset.sum_eq_zero fun cj hcj => h ci cj (Finset.ne_of_mem_erase hcj).symm
 
-/-- Ngiti (Nilo-Saharan, Central Sudanic; DRC). 8 classes, 2 cells. -/
-def ngiti : LanguageData where
-  name := "Ngiti"
-  family := "Nilo-Saharan"
-  numClasses := 8
-  numCells := 2
-  avgCondEntropy := 380 / 1000  -- 0.380
-  maxCellEntropy := 1741 / 1000  -- 1.741
+/-! ### Modern Greek -/
 
-/-- Nuer (Nilo-Saharan, Nilotic; Sudan/South Sudan). 31 classes, 4 cells. -/
-def nuer : LanguageData where
-  name := "Nuer"
-  family := "Nilo-Saharan"
-  numClasses := 31
-  numCells := 4
-  avgCondEntropy := 513 / 1000  -- 0.513
-  maxCellEntropy := 3224 / 1000  -- 3.224
+theorem greek_eComplexity : nominal.eComplexity = 8 := rfl
 
-/-- Kwerba (Trans-New Guinea; Papua, Indonesia). 2 classes, 2 cells. -/
-def kwerba : LanguageData where
-  name := "Kwerba"
-  family := "Trans-New Guinea"
-  numClasses := 2
-  numCells := 2
-  avgCondEntropy := 469 / 1000  -- 0.469
-  maxCellEntropy := 529 / 1000  -- 0.529
+theorem greek_maxRealizations : nominal.maxRealizations = 5 := by decide
 
-/-- Chinantec (Oto-Manguean; Oaxaca, Mexico). 62 classes, 4 cells.
-    Comaltepec Chinantec tonal verb paradigms. -/
-def chinantec : LanguageData where
-  name := "Chinantec"
-  family := "Oto-Manguean"
-  numClasses := 62
-  numCells := 4
-  avgCondEntropy := 426 / 1000  -- 0.426
-  maxCellEntropy := 4266 / 1000  -- 4.266
+/-- Eight declensions exceed the five rival realizations of the genitive singular. -/
+theorem greek_not_paradigmEconomy : ¬ nominal.ParadigmEconomy := by decide
 
-/-- Chiquihuitlan Mazatec (Oto-Manguean; Oaxaca, Mexico).
-    109 classes, 4 cells. The paper's primary case study (section 4). -/
-def mazatec : LanguageData where
-  name := "Chiquihuitlan Mazatec"
-  family := "Oto-Manguean"
-  numClasses := 109
-  numCells := 4
-  avgCondEntropy := 709 / 1000  -- 0.709
-  maxCellEntropy := 5248 / 1000  -- 5.248
+/-- The genitive plural has a single realization. -/
+theorem greek_cellEntropy_genPl : nominal.cellEntropy genPl = 0 :=
+  nominal.cellEntropy_eq_zero_of_card_le_one (by decide)
 
-/-- Finnish (Uralic, Finnic). 51 classes, 8 cells. -/
-def finnish : LanguageData where
-  name := "Finnish"
-  family := "Uralic"
-  numClasses := 51
-  numCells := 8
-  avgCondEntropy := 209 / 1000  -- 0.209
-  maxCellEntropy := 3803 / 1000  -- 3.803
+theorem greek_predicts :
+    nominal.Predicts {vocSg} accSg ∧ nominal.Predicts {accSg} vocSg ∧
+      nominal.Predicts {accPl} nomPl := by
+  decide
 
-/-- German (Indo-European, Germanic). 7 classes, 8 cells. -/
-def german : LanguageData where
-  name := "German"
-  family := "Indo-European"
-  numClasses := 7
-  numCells := 8
-  avgCondEntropy := 45 / 1000  -- 0.045
-  maxCellEntropy := 1906 / 1000  -- 1.906
+/-- The accusative plural does not predict the genitive singular: after *-a* two genitives
+remain. -/
+theorem greek_not_predicts : ¬ nominal.Predicts {accPl} genSg := by decide
 
-/-- Russian (Indo-European, Slavic). 8 classes, 8 cells. -/
-def russian : LanguageData where
-  name := "Russian"
-  family := "Indo-European"
-  numClasses := 8
-  numCells := 8
-  avgCondEntropy := 89 / 1000  -- 0.089
-  maxCellEntropy := 2170 / 1000  -- 2.170
+/-- An accusative plural in *-i* fixes the genitive singular in *-us*. -/
+theorem greek_accPl_i_genSg : ∀ e ∈ nominal.entries, e.1 accPl = .i → e.1 genSg = .us := by
+  decide
 
-/-- Spanish (Indo-European, Romance). 3 classes, 57 cells. -/
-def spanish : LanguageData where
-  name := "Spanish"
-  family := "Indo-European"
-  numClasses := 3
-  numCells := 57
-  avgCondEntropy := 3 / 1000  -- 0.003
-  maxCellEntropy := 1522 / 1000  -- 1.522
+/-- Nominative singular, genitive singular, and accusative plural are principal parts; the
+last two alone are not. -/
+theorem greek_principalParts :
+    nominal.IsPrincipalPartSet {nomSg, genSg, accPl} ∧
+      ¬ nominal.IsPrincipalPartSet {genSg, accPl} := by
+  decide
 
-/-- All 10 languages in the [ackerman-malouf-2013] sample (Table 3). -/
-def ackermanMalouf2013 : List LanguageData :=
-  [fur, ngiti, nuer, kwerba, chinantec, mazatec, finnish, german, russian, spanish]
+theorem greek_not_clear : ¬ nominal.IsVocabularClear := by decide
 
-/-- The LCEC threshold: all 10 languages fall below 1 bit of average
-    conditional entropy. Even the most complex system (Mazatec, 109 classes)
-    has I-complexity < 1 bit. -/
-def lcecThreshold : ℚ := 1
+/-! ### Burmeso -/
 
-/-- Expected I-complexity under random class assignment for Mazatec
-    (Monte Carlo baseline). The paper reports the mean of 1000 random
-    permutations as ~5.25 bits, far above the observed 0.709 bits. -/
-def mazatecRandomBaseline : ℚ := 525 / 100  -- 5.25
+/-- Every cell identifies the class. -/
+theorem burmeso_clear : objectAgreement.IsVocabularClear := by decide
 
--- ============================================================================
--- §1. Per-language LCEC Verification
--- ============================================================================
+theorem burmeso_iComplexity : iComplexity objectAgreement = 0 :=
+  transparent_iComplexity_zero (objectAgreement.isTransparent_of_isVocabularClear burmeso_clear)
 
-/-! Each language's reported I-complexity is below the 1-bit threshold.
-    These are "per-datum verification theorems" in linglib's sense:
-    changing a language's avgCondEntropy breaks exactly the corresponding
-    theorem. -/
+/-! ### Chiquihuitlán Mazatec -/
 
-theorem fur_lcec : fur.avgCondEntropy ≤ lcecThreshold := by
-  unfold fur lcecThreshold; norm_num
-theorem ngiti_lcec : ngiti.avgCondEntropy ≤ lcecThreshold := by
-  unfold ngiti lcecThreshold; norm_num
-theorem nuer_lcec : nuer.avgCondEntropy ≤ lcecThreshold := by
-  unfold nuer lcecThreshold; norm_num
-theorem kwerba_lcec : kwerba.avgCondEntropy ≤ lcecThreshold := by
-  unfold kwerba lcecThreshold; norm_num
-theorem chinantec_lcec : chinantec.avgCondEntropy ≤ lcecThreshold := by
-  unfold chinantec lcecThreshold; norm_num
-theorem mazatec_lcec : mazatec.avgCondEntropy ≤ lcecThreshold := by
-  unfold mazatec lcecThreshold; norm_num
-theorem finnish_lcec : finnish.avgCondEntropy ≤ lcecThreshold := by
-  unfold finnish lcecThreshold; norm_num
-theorem german_lcec : german.avgCondEntropy ≤ lcecThreshold := by
-  unfold german lcecThreshold; norm_num
-theorem russian_lcec : russian.avgCondEntropy ≤ lcecThreshold := by
-  unfold russian lcecThreshold; norm_num
-theorem spanish_lcec : spanish.avgCondEntropy ≤ lcecThreshold := by
-  unfold spanish lcecThreshold; norm_num
+theorem mazatec_vowels_not_clear : ¬ finalVowels.IsVocabularClear := by decide
 
-/-- All 10 languages satisfy the LCEC. -/
-theorem all_satisfy_lcec :
-    ∀ l ∈ ackermanMalouf2013, l.avgCondEntropy ≤ lcecThreshold := by
-  intro l hl
-  simp only [ackermanMalouf2013, List.mem_cons, List.mem_nil_iff, or_false] at hl
-  rcases hl with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-  · exact fur_lcec
-  · exact ngiti_lcec
-  · exact nuer_lcec
-  · exact kwerba_lcec
-  · exact chinantec_lcec
-  · exact mazatec_lcec
-  · exact finnish_lcec
-  · exact german_lcec
-  · exact russian_lcec
-  · exact spanish_lcec
+/-- The first and second person plural vowels are constant across classes. -/
+theorem mazatec_vowels_constant :
+    finalVowels.cellEntropy firstPl = 0 ∧ finalVowels.cellEntropy secondPl = 0 :=
+  ⟨finalVowels.cellEntropy_eq_zero_of_card_le_one (by decide),
+    finalVowels.cellEntropy_eq_zero_of_card_le_one (by decide)⟩
 
--- ============================================================================
--- §2. E-complexity / I-complexity Dissociation
--- ============================================================================
-
-/-! The LCEC's key prediction: E-complexity and I-complexity are dissociated.
-    A language can have enormous E-complexity but low I-complexity. -/
-
-/-- Mazatec has maximal E-complexity in the sample (109 classes). -/
-theorem mazatec_max_eComplexity :
-    ∀ l ∈ ackermanMalouf2013, l.numClasses ≤ mazatec.numClasses := by
-  intro l hl
-  simp only [ackermanMalouf2013, List.mem_cons, List.mem_nil_iff, or_false] at hl
-  rcases hl with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-  all_goals simp [mazatec, fur, ngiti, nuer, kwerba, chinantec, finnish, german, russian, spanish]
-
-/-- Mazatec's I-complexity is still below 1 bit despite 109 classes. -/
-theorem mazatec_high_e_low_i :
-    mazatec.numClasses = 109 ∧ mazatec.avgCondEntropy ≤ 1 :=
-  ⟨rfl, by unfold mazatec; norm_num⟩
-
-/-- Kwerba has minimal E-complexity (2 classes) but its I-complexity
-    is *not* the lowest — German (7 classes) has lower I-complexity.
-    This shows E-complexity doesn't predict I-complexity in either direction. -/
-theorem eComplexity_doesnt_predict_iComplexity :
-    kwerba.numClasses < german.numClasses ∧
-    german.avgCondEntropy < kwerba.avgCondEntropy :=
-  ⟨by simp [kwerba, german], by unfold german kwerba; norm_num⟩
-
-/-- Spanish has only 3 classes but 57 cells — yet its I-complexity is
-    the lowest in the sample (0.003 bits). More cells with fewer classes
-    means more implicative structure. -/
-theorem spanish_minimal_iComplexity :
-    ∀ l ∈ ackermanMalouf2013, spanish.avgCondEntropy ≤ l.avgCondEntropy := by
-  intro l hl
-  simp only [ackermanMalouf2013, List.mem_cons, List.mem_nil_iff, or_false] at hl
-  rcases hl with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-  all_goals (first
-    | (unfold spanish fur; norm_num)
-    | (unfold spanish ngiti; norm_num)
-    | (unfold spanish nuer; norm_num)
-    | (unfold spanish kwerba; norm_num)
-    | (unfold spanish chinantec; norm_num)
-    | (unfold spanish mazatec; norm_num)
-    | (unfold spanish finnish; norm_num)
-    | (unfold spanish german; norm_num)
-    | (unfold spanish russian; norm_num)
-    | (unfold spanish; norm_num))
-
--- ============================================================================
--- §3. Mazatec Case Study: Observed vs. Random Baseline
--- ============================================================================
-
-/-! The Mazatec case study (§4 of the paper) demonstrates that the observed
-    I-complexity is far below what random assignment of inflection-class
-    patterns would produce. -/
-
-/-- Mazatec's observed I-complexity is far below the random baseline.
-    Observed: 0.709 bits. Random permutation baseline: ~5.25 bits.
-    The observed value is less than 14% of the random baseline. -/
-theorem mazatec_well_below_random :
-    mazatec.avgCondEntropy < mazatecRandomBaseline := by
-  unfold mazatec mazatecRandomBaseline; norm_num
-
-/-- The ratio of observed to random I-complexity is less than 1/7.
-    (0.709 / 5.25 ≈ 0.135, i.e., ~13.5% of random) -/
-theorem mazatec_ratio_to_random :
-    mazatec.avgCondEntropy * 7 < mazatecRandomBaseline := by
-  unfold mazatec mazatecRandomBaseline; norm_num
-
-/-- Mazatec has nonzero I-complexity: it violates [carstairs-mccarthy-2010]'s synonymy avoidance but satisfies the LCEC. This witnesses
-    that the LCEC is strictly weaker than synonymy avoidance. -/
-theorem mazatec_violates_synonymyAvoidance :
-    mazatec.avgCondEntropy > 0 := by
-  unfold mazatec; norm_num
+/-- No cell of the tone patterns is diagnostic of class membership. -/
+theorem mazatec_tones_no_diagnostic_cell : ∀ c, ¬ tones.IsPrincipalPartSet {c} := by decide
 
 end AckermanMalouf2013

--- a/Linglib/Studies/RathiHahnFutrell2026.lean
+++ b/Linglib/Studies/RathiHahnFutrell2026.lean
@@ -1,6 +1,5 @@
 import Linglib.Processing.Memory.InformationalFusion
 import Linglib.Processing.Memory.SurprisalTradeoff
-import Linglib.Studies.AckermanMalouf2013
 import Linglib.Studies.Bybee1985
 import Linglib.Morphology.Morphotactics.RelevanceHierarchy
 import Linglib.Morphology.Paradigm.Complexity

--- a/references.bib
+++ b/references.bib
@@ -6933,7 +6933,7 @@
   role      = {cited},
   doi       = {10.1093/oxfordhb/9780199541119.013.0047},
   validated = {true},
-  sources   = {Studies/AckermanMalouf2013.lean}
+  sources   = {Morphology/Paradigm/Complexity.lean;Studies/AckermanMalouf2013.lean}
 }% REF: Hofmeister, P. & Sag, I.A. (2010). Cognitive constraints and island effects. Language 86(2):366–415.
 @article{hofmeister-sag-2010,
   author    = {Hofmeister, Philip and Sag, Ivan A.},
@@ -21040,7 +21040,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/AckermanMalouf2013.lean}
+  sources   = {Morphology/Paradigm/Complexity.lean;Studies/AckermanMalouf2013.lean}
 }
 @article{bonami-beniamine-2016,
   author    = {Bonami, Olivier and Beniamine, Sacha},


### PR DESCRIPTION
Deep cleanse against the paper. The old study's Table-3 data was fabricated (wrong languages, cell counts, and Monte Carlo baseline) and its theorems were `x ≤ 1` checks on those numbers. Recuts `Morphology/Paradigm/Complexity.lean` — decidable `Predicts`/`IsPrincipalPartSet`/`IsVocabularClear`, realizations and paradigm economy, entropies as Finset sums over class weights, and the theorems tying prediction to zero conditional entropy — adds the paper's own paradigm tables as fragments (Modern Greek declensions, Burmeso object agreement, Mazatec final vowels and tones), and restates the study on them: paradigm economy fails for Greek, the Table-2 implicative facts and principal parts, Burmeso transparent with i-complexity zero, Mazatec's departures from synonymy avoidance.
- `RathiHahnFutrell2026` no longer imports the study.