### PR TITLE
refactor(Features/NounCategorization): dissolve System into fragment fields

### DIFF
--- a/Linglib/Features/NounCategorization/Basic.lean
+++ b/Linglib/Features/NounCategorization/Basic.lean
@@ -1,145 +1,90 @@
-
 /-!
 # Noun categorization devices
-[aikhenvald-2000] [dixon-1982] [downing-1996] [allan-1977] [corbett-1991]
 
-Theory-neutral cross-linguistic typology of noun-categorization devices, following
-[aikhenvald-2000] *Classifiers: A Typology of Noun Categorization Devices*: the
-device-type continuum (`ClassifierType`, with `nounClass` = gender at its agreement
-pole), the semantic parameters classifiers employ, the per-classifier lexical
-schema. Graduated from the dissolved
-`Typology/` drawer as a sibling of `Features/Gender`.
+This file defines the vocabulary of Aikhenvald's typology of noun categorization devices: the
+nine classifier types individuated by morphosyntactic locus, the scopes, assignment principles
+and surface realizations by which a system is described, the semantic parameters classifiers
+encode, a lexical schema for individual classifiers, and the competing compositional strategies
+attributed to classifier constructions. Per-language values of the typological parameters are
+recorded field by field in each Fragment's `ClassifierSystem.lean` (`classifierType`,
+`classifierScopes`, `classifierAssignment`, `classifierRealizations`, `classifierAgreement`,
+`classifierObligatory`, `classifierDefault`, `classifierSemantics`, `obligatoryNumber`); the
+record assembling them is study-local (`Aikhenvald2000.Parameters`). The `nounClass` type
+collapses the finer gender structure of `Features/Gender`.
 
 ## Main definitions
 
-* `ClassifierType` — [aikhenvald-2000]'s noun-categorization device types.
-* `SemanticParameter`, `ShapeDimension` — the semantic axes ([allan-1977], [downing-1996]).
-* `CategorizationScope`, `AssignmentPrinciple`, `SurfaceRealization`; `ClassifierType.locus`, the
-  defining scope of each type (Table 15.1).
-* `ClassifierEntry` — per-classifier lexical schema.
+* `ClassifierType`, `ClassifierType.locus` — the device types and the scope defining each.
+* `CategorizationScope`, `AssignmentPrinciple`, `SurfaceRealization` — the descriptive axes.
+* `SemanticParameter`, `ShapeDimension` — the semantic parameters of noun categorization.
+* `ClassifierEntry`, `ClassifierEntry.Encodes`, `collectSemantics` — the per-classifier schema.
+* `ClassifierStrategy` — the compositional strategies a framework may attribute to classifiers.
 
-Per-language values of Aikhenvald's parameters are field-by-field definitions in each
-Fragment's `ClassifierSystem.lean` (`classifierType`, `classifierScopes`, `classifierAssignment`,
-`classifierRealizations`, `classifierAgreement`, `classifierObligatory`, `classifierDefault`,
-`classifierSemantics`, `obligatoryNumber`); the assembled record is study-local
-(`Aikhenvald2000.Parameters`).
-* `ClassifierStrategy` — competing composition frameworks (theory-laden; consumed by
-  `Semantics/Classifier`, where the cross-paper disagreement is proved as theorems).
+## References
 
-## Implementation notes
-
-The `nounClass` cell collapses what [corbett-1991] separates (target/controller
-gender, gender vs. classifier); the per-language gender structure lives in
-`Features/Gender`.
+* [aikhenvald-2000], §1.5, §2.3, §4.4.1, §10.5, §11.1, Tables 15.1–15.3
+* [corbett-1991]
+* [downing-1996]
+* [allan-1977]
+* [little-moroney-royer-2022]
 -/
 
 namespace NounCategorization
 
--- ════════════════════════════════════════════════════
--- § 1. Classifier Types ([aikhenvald-2000])
--- ════════════════════════════════════════════════════
+/-! ### Classifier types -/
 
-/-- The nine focal classifier types on the noun-categorization continuum,
-    [aikhenvald-2000]'s Table 15.1: "focal points" individuated by
-    morphosyntactic locus and scope rather than discrete types, so a
-    language's system may sit between them (§1.5, §15.2). The `nounClass`
-    cell collapses [corbett-1991]'s finer gender structure. -/
+/-- The nine classifier types, focal points on a continuum individuated by morphosyntactic
+locus and scope rather than discrete classes. -/
 inductive ClassifierType where
-  /-- Noun class / gender: closed agreement system, realized outside the noun
-      on modifiers (head-modifier NP) or predicate (pred-arg agreement).
-      Small inventory (2–20). Examples: Bantu, Indo-European gender. -/
+  /-- Noun class or gender: a closed obligatory system realized by agreement inside and
+  sometimes outside the noun phrase, with an inventory often of two to ten. -/
   | nounClass
-  /-- Noun classifier: independent of other NP elements, characterizes the
-      noun itself. Free forms or affixes on the noun. -/
+  /-- Noun classifier: characterizes the head noun itself, independently of other NP elements,
+  as a free form or an affix on the noun. -/
   | nounClassifier
-  /-- Numeral classifier: appears in numeral/quantifier NPs, required for
-      enumeration. Free forms or affixes on the numeral. -/
+  /-- Numeral classifier: characterizes nouns in numeral and quantifier phrases, as a free form
+  or an affix on the numeral, with an often large inventory. -/
   | numeralClassifier
-  /-- Relational classifier: in possessive NPs, characterizes the possessive
-      relation (how the noun can be possessed/handled). -/
+  /-- Relational classifier: characterizes the possessive relation in a possessive NP. -/
   | relationalClassifier
-  /-- Possessed classifier: in possessive NPs, characterizes the possessed
-      noun in terms of its inherent properties. -/
+  /-- Possessed classifier: characterizes the possessed noun in a possessive NP. -/
   | possessedClassifier
-  /-- Possessor classifier: in possessive NPs, characterizes the possessor.
-      Very rare. -/
+  /-- Possessor classifier: characterizes the possessor; very rare. -/
   | possessorClassifier
-  /-- Verbal classifier: marks agreement on the verb with an S or O argument.
-      Incorporated classifiers, affixes, or suppletive verb stems. -/
+  /-- Verbal classifier: marks agreement on the verb with an S or O argument, as an
+  incorporated classifier, an affix, or a suppletive classificatory stem. -/
   | verbalClassifier
-  /-- Locative classifier: in adpositional NPs, marks agreement with the head
-      noun in locative expressions. -/
+  /-- Locative classifier: marks agreement with the head noun in an adpositional NP. -/
   | locativeClassifier
-  /-- Deictic classifier: appears on deictics, articles, demonstratives.
-      Marks spatial location and/or determination. -/
+  /-- Deictic classifier: occurs with articles and demonstratives, marking spatial location
+  or determination. -/
   | deicticClassifier
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Semantic Parameters ([aikhenvald-2000])
--- ════════════════════════════════════════════════════
+/-! ### Scope, assignment, and realization -/
 
-/-- Universal semantic parameters employed in noun categorization.
-
-    [aikhenvald-2000] §11.1.1 groups them into three large classes —
-    animacy, physical properties, and function — found across all types of
-    noun categorization device with type-specific preferences (Table 11.13). -/
-inductive SemanticParameter where
-  -- (A) Animacy hierarchy — near-universal, the semantic "core"
-  | animacy          -- animate vs. inanimate
-  | humanness        -- human vs. non-human
-  | sex              -- male vs. female
-  -- (B–G) Physical properties
-  | shape            -- dimensionality + shape (1D/2D/3D, round/flat/long)
-  | size             -- large vs. small
-  | consistency      -- rigid vs. flexible
-  | material         -- wooden, metal, etc.
-  | boundedness      -- bounded (ring) vs. unbounded (plain)
-  -- (H) Functional properties
-  | function         -- how the object is used/handled
-  | arrangement      -- configuration (coil, cluster, row)
-  | quanta           -- quantity/measure
-  -- Social
-  | socialStatus     -- honorific status of the referent (kin, age, social rank)
-  | register         -- formality/register of the speech act (formal/written vs casual);
-                     -- distinct from socialStatus, which tracks the referent's status.
-                     -- Japanese 名 mei and Mandarin 位 wèi index register, not referent status.
-  -- Perceptual: salient but never a basis for noun categorization ([aikhenvald-2000] §11.2.1)
-  | colour
-  deriving DecidableEq, Repr
-
-/-- Dimensionality sub-classification for shape-based classifiers.
-
-    [downing-1996] and [allan-1977] show that shape-based
-    classifiers decompose along a dimensionality axis:
-    - 1D: long, slender, elongated (e.g., Japanese 本 hon, Mandarin 条 tiáo)
-    - 2D: flat, thin, planar (e.g., Japanese 枚 mai, Mandarin 张 zhāng)
-    - 3D: round, compact, globular (e.g., Japanese 個 ko) -/
-inductive ShapeDimension where
-  | oneD    -- long, slender (1-dimensional extent)
-  | twoD    -- flat, thin (2-dimensional extent)
-  | threeD  -- round, compact (3-dimensional extent)
-  deriving DecidableEq, Repr
-
--- ════════════════════════════════════════════════════
--- § 3. Structural Properties
--- ════════════════════════════════════════════════════
-
-/-- Morphosyntactic scope of a classifier type. -/
+/-- The morphosyntactic scope a noun categorization device operates in. -/
 inductive CategorizationScope where
-  | headModifierNP     -- Inside a head-modifier NP (noun class agreement)
-  | predicateArgument  -- Outside NP: clause-level pred-arg agreement
-  | noun               -- The noun itself (noun classifiers)
-  | numeralNP          -- Numeral/quantifier NP (numeral classifiers)
-  | possessiveNP       -- Possessive NP (relational/possessed/possessor CL)
-  | clause             -- Clause-level (verbal classifiers)
-  | adpositionalNP     -- Adpositional NP (locative classifiers)
-  | attributiveNP      -- Attributive NP (deictic classifiers)
+  /-- Inside a head-modifier NP: head-modifier agreement. -/
+  | headModifierNP
+  /-- Outside the NP: predicate-argument agreement. -/
+  | predicateArgument
+  /-- The noun itself. -/
+  | noun
+  /-- A numeral or quantifier NP. -/
+  | numeralNP
+  /-- A possessive NP. -/
+  | possessiveNP
+  /-- The clause. -/
+  | clause
+  /-- An adpositional NP. -/
+  | adpositionalNP
+  /-- An attributive NP with a deictic. -/
+  | attributiveNP
   deriving DecidableEq, Repr
 
-/-- The defining morphosyntactic scope of each classifier type ([aikhenvald-2000] Table 15.1):
-noun classes inside a head-modifier NP (clause scope is a further option), numeral
-classifiers in the numeral NP, and so on. -/
+/-- The scope defining each classifier type: noun classes inside a head-modifier NP (clause
+scope is a further option), numeral classifiers in the numeral NP, and so on. -/
 def ClassifierType.locus : ClassifierType → CategorizationScope
   | .nounClass => .headModifierNP
   | .nounClassifier => .noun
@@ -149,97 +94,145 @@ def ClassifierType.locus : ClassifierType → CategorizationScope
   | .locativeClassifier => .adpositionalNP
   | .deicticClassifier => .attributiveNP
 
-/-- Principles governing noun-to-class/classifier assignment. -/
+/-- The principle by which nouns are assigned to classes or classifiers. -/
 inductive AssignmentPrinciple where
-  /-- Purely semantic: class determined by referent meaning -/
+  /-- By the meaning of the referent. -/
   | semantic
-  /-- Morphological: class determined by derivational affix, declension, etc. -/
+  /-- By morphological properties of the noun such as declension or derivational affix. -/
   | morphological
-  /-- Phonological: class determined by initial segment, final vowel, etc. -/
+  /-- By phonological properties of the noun such as its initial segment or final vowel. -/
   | phonological
-  /-- Mixed: semantic core + morphological/phonological overlay -/
+  /-- A semantic core with a morphological or phonological overlay. -/
   | mixed
   deriving DecidableEq, Repr
 
-/-- Surface realization of a classifier morpheme. -/
+/-- The surface realization of a classifier morpheme. -/
 inductive SurfaceRealization where
-  | prefix | suffix | clitic | freeForm
-  | suppletion | stress | reduplication
-  | nounIncorporation | repeater
+  /-- Prefix or proclitic. -/
+  | prefix
+  /-- Suffix or enclitic. -/
+  | suffix
+  /-- Clitic. -/
+  | clitic
+  /-- An independent lexeme. -/
+  | freeForm
+  /-- Stem-internal vowel change. -/
+  | apophony
+  /-- A suppletive stem. -/
+  | suppletion
+  /-- Stress. -/
+  | stress
+  /-- Reduplication. -/
+  | reduplication
+  /-- Noun incorporation. -/
+  | nounIncorporation
+  /-- A repeater: the noun itself, or part of it, serving as its classifier. -/
+  | repeater
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 4. ClassifierEntry — per-classifier lexical entry
--- ════════════════════════════════════════════════════
+/-! ### Semantic parameters -/
 
-/-- A classifier lexical entry with semantic typing.
+/-- The semantic parameters noun categorization devices encode, in three large classes —
+animacy, physical properties, and function — with type-specific preferences. Speech register
+is distinguished from the referent's social status, since honorific classifiers can index the
+style of speech rather than the rank of the referent. -/
+inductive SemanticParameter where
+  /-- Animate versus inanimate. -/
+  | animacy
+  /-- Human versus non-human. -/
+  | humanness
+  /-- Male versus female. -/
+  | sex
+  /-- The social status or rank of a human referent. -/
+  | socialStatus
+  /-- The kinship relationship of a human referent. -/
+  | kinship
+  /-- The speech register (honorific, common, humiliative) rather than the referent's status. -/
+  | register
+  /-- Shape and dimensionality. -/
+  | shape
+  /-- Vertical versus horizontal orientation. -/
+  | direction
+  /-- Differentiation of inside from outside, as between rings and holes. -/
+  | interioricity
+  /-- Whether an outlined entity is delimited. -/
+  | boundedness
+  /-- Large versus small. -/
+  | size
+  /-- Plasticity under manipulation: flexible versus rigid. -/
+  | consistency
+  /-- Physical state, such as liquid or solid. -/
+  | constitution
+  /-- The material an object is made of. -/
+  | material
+  /-- Other inherent, time-stable nature, often realized by classifiers specific to one noun. -/
+  | nature
+  /-- How an object is used or handled. -/
+  | function
+  /-- The configuration of objects, such as a coil or a row. -/
+  | arrangement
+  /-- A quantity of objects, such as a cluster or a flock. -/
+  | quanta
+  /-- Colour: perceptually salient but never a basis for noun categorization. -/
+  | colour
+  deriving DecidableEq, Repr
 
-    Each classifier carries its form, a gloss, and the semantic parameters
-    that motivate its selection — making it possible to verify Aikhenvald's
-    claims about which parameters different classifier types encode. -/
+/-- The three values of dimensionality: one-dimensional (long), two-dimensional (flat), and
+three-dimensional (spherical). -/
+inductive ShapeDimension where
+  | oneD
+  | twoD
+  | threeD
+  deriving DecidableEq, Repr
+
+/-! ### Classifier entries -/
+
+/-- A classifier lexical entry: its form and gloss, the semantic parameters motivating its
+choice, whether it is the general classifier of its system, whether it is mensural rather than
+sortal, and its dimensionality when shape-based. -/
 structure ClassifierEntry where
-  /-- Surface form (e.g. "只", "匹", "本") -/
+  /-- Surface form. -/
   form : String
-  /-- Gloss (e.g. "small.animal", "flat.bound.object") -/
+  /-- Gloss. -/
   gloss : String := ""
-  /-- Semantic parameters motivating selection of this classifier -/
+  /-- The semantic parameters motivating the choice of this classifier. -/
   semantics : List SemanticParameter := []
-  /-- Is this the "general" or "default" classifier? (个 in Mandarin, つ in Japanese) -/
+  /-- Whether this is the general classifier that can replace the specific ones. -/
   isDefault : Bool := false
-  /-- Sortal (inherent properties) vs. mensural (configuration/measure) -/
+  /-- Whether the classifier individuates by measure rather than by inherent properties. -/
   isMensural : Bool := false
-  /-- Shape dimensionality sub-classification ([downing-1996]).
-      Only meaningful when `semantics` includes `.shape`. -/
+  /-- Dimensionality, when the classifier is shape-based. -/
   shapeDimension : Option ShapeDimension := none
-  deriving Repr, BEq
+  deriving Repr, DecidableEq
 
-/-- Whether this classifier encodes a given semantic parameter. -/
-def ClassifierEntry.encodes (c : ClassifierEntry) (p : SemanticParameter) : Bool :=
-  c.semantics.any (· == p)
+/-- `c.Encodes p` when the classifier `c` is motivated by the parameter `p`. -/
+def ClassifierEntry.Encodes (c : ClassifierEntry) (p : SemanticParameter) : Prop :=
+  p ∈ c.semantics
 
-/-- Collect all distinct semantic parameters attested across a classifier inventory.
-    Used to derive a Fragment's `classifierSemantics` from its inventory rather than
-    hand-listing. -/
+instance (c : ClassifierEntry) (p : SemanticParameter) : Decidable (c.Encodes p) :=
+  inferInstanceAs (Decidable (p ∈ c.semantics))
+
+/-- The distinct semantic parameters attested across an inventory of classifiers. -/
 def collectSemantics (cls : List ClassifierEntry) : List SemanticParameter :=
-  let all := cls.foldl (λ acc c => acc ++ c.semantics) []
-  all.eraseDups
+  (cls.flatMap (·.semantics)).eraseDups
 
--- ════════════════════════════════════════════════════
--- § 5. Classifier Strategy ([little-moroney-royer-2022])
--- ════════════════════════════════════════════════════
+/-! ### Compositional strategies -/
 
-/-- The semantic strategy a theoretical framework attributes to classifier
-    constructions. Three competing positions are represented:
-
-    - **forNumeral** (CLF-for-NUM): [krifka-1995b], [bale-coon-2014],
-      [little-moroney-royer-2022]. The classifier is a measure function
-      required by the numeral. The numeral takes the classifier as its first
-      argument: ⟦TWO⟧ = λm⟨e,n⟩λPλx.[P(x) ∧ m(x) = 2]. Predicts: numeral
-      idiosyncrasies in CLF requirement, CLF obligatory even without a noun
-      (counting contexts), CLF + plural marking can co-occur.
-    - **forNoun** (CLF-for-N): [chierchia-1998], [jenks-2011],
-      [nomoto-2013], [little-moroney-royer-2022]. The classifier
-      atomizes the noun denotation so the numeral can count.
-      ⟦CLF⟧ = λPλx.[P(x) ∧ ¬∃y[P(y) ∧ y < x]]. Predicts: noun idiosyncrasies
-      in CLF requirement, CLF appears beyond numerals (with quantifiers,
-      demonstratives, relative clauses), CLF + plural marking in complementary
-      distribution.
-    - **sudoBlocking**: [sudo-2016]. Classifier semantics live with
-      *numerals*, not nouns. Numerals are universally type-n singular terms;
-      a phonologically silent ∪-operator type-shifts them to predicates in
-      languages without classifiers, but is *blocked* (per [chierchia-1998]'s
-      Blocking Principle) in languages whose lexicon contains overt classifiers.
-      Predicts: no numeral or noun idiosyncrasies, CLF appears *with* numerals
-      not beyond them, CLF appears in counting contexts (via the ∩-operator).
-
-    Strategy assignments to specific languages live in study files
-    (`Studies/{NMP,LittleMoroneyRoyer2022,Sudo2016}.lean`),
-    not in this file or in `System`. Each paper owns its
-    own per-language commitments; cross-paper agreement and disagreement
-    are first-class theorems in the study files. -/
+/-- The compositional strategy a framework attributes to classifier constructions. Strategy
+assignments to particular languages are made in the study files of the papers that make them
+(`Chierchia1998`, `LittleMoroneyRoyer2022`, `Sudo2016`), never in the Fragments. -/
 inductive ClassifierStrategy where
+  /-- The classifier is a measure function required by the numeral, which takes it as its
+  first argument ([krifka-1995b], [bale-coon-2014]); predicts classifier–plural co-occurrence
+  and classifiers in counting contexts without a noun. -/
   | forNumeral
+  /-- The classifier atomizes the noun denotation so that the numeral can count
+  ([chierchia-1998]); predicts classifiers beyond numerals and complementary distribution with
+  plural marking. -/
   | forNoun
+  /-- Numerals are type-`n` singular terms shifted to predicates by a silent ∪-operator that
+  overt classifiers in the lexicon block ([sudo-2016]); predicts classifiers with numerals only
+  and no numeral or noun idiosyncrasies. -/
   | sudoBlocking
   deriving DecidableEq, Repr
 

--- a/Linglib/Features/NounCategorization/Basic.lean
+++ b/Linglib/Features/NounCategorization/Basic.lean
@@ -7,7 +7,7 @@ Theory-neutral cross-linguistic typology of noun-categorization devices, followi
 [aikhenvald-2000] *Classifiers: A Typology of Noun Categorization Devices*: the
 device-type continuum (`ClassifierType`, with `nounClass` = gender at its agreement
 pole), the semantic parameters classifiers employ, the per-classifier lexical
-schema, and the per-language paradigm record. Graduated from the dissolved
+schema. Graduated from the dissolved
 `Typology/` drawer as a sibling of `Features/Gender`.
 
 ## Main definitions
@@ -17,16 +17,20 @@ schema, and the per-language paradigm record. Graduated from the dissolved
 * `CategorizationScope`, `AssignmentPrinciple`, `SurfaceRealization`; `ClassifierType.locus`, the
   defining scope of each type (Table 15.1).
 * `ClassifierEntry` — per-classifier lexical schema.
+
+Per-language values of Aikhenvald's parameters are field-by-field definitions in each
+Fragment's `ClassifierSystem.lean` (`classifierType`, `classifierScopes`, `classifierAssignment`,
+`classifierRealizations`, `classifierAgreement`, `classifierObligatory`, `classifierDefault`,
+`classifierSemantics`, `obligatoryNumber`); the assembled record is study-local
+(`Aikhenvald2000.Parameters`).
 * `ClassifierStrategy` — competing composition frameworks (theory-laden; consumed by
   `Semantics/Classifier`, where the cross-paper disagreement is proved as theorems).
-* `System` — Aikhenvald's per-language paradigm record (Bool property fields + `Prop` API).
 
 ## Implementation notes
 
 The `nounClass` cell collapses what [corbett-1991] separates (target/controller
 gender, gender vs. classifier); the per-language gender structure lives in
-`Features/Gender`, and a noun-class `System`'s `inventorySize`/`hasAgreement` should
-derive from a `Gender.System` rather than being stipulated (follow-on).
+`Features/Gender`.
 -/
 
 namespace NounCategorization
@@ -194,7 +198,8 @@ def ClassifierEntry.encodes (c : ClassifierEntry) (p : SemanticParameter) : Bool
   c.semantics.any (· == p)
 
 /-- Collect all distinct semantic parameters attested across a classifier inventory.
-    Used to derive `preferredSemantics` from fragment data rather than hand-listing. -/
+    Used to derive a Fragment's `classifierSemantics` from its inventory rather than
+    hand-listing. -/
 def collectSemantics (cls : List ClassifierEntry) : List SemanticParameter :=
   let all := cls.foldl (λ acc c => acc ++ c.semantics) []
   all.eraseDups
@@ -237,89 +242,5 @@ inductive ClassifierStrategy where
   | forNoun
   | sudoBlocking
   deriving DecidableEq, Repr
-
--- ════════════════════════════════════════════════════
--- § 6. System — paradigm record
--- ════════════════════════════════════════════════════
-
-/-- A noun categorization system in a language, recording
-    [aikhenvald-2000]'s definitional parameters (A)–(G) of §1.5 — the
-    contingent parameters (H)–(K) are not fields:
-    (A) morphosyntactic locus and (B) scope → `classifierType`, `scopes`
-    (C) principles of assignment → `assignment`
-    (D) surface realization → `realizations`
-    (E) agreement → `hasAgreement`
-    (F) markedness relations → `hasUnmarkedDefault`
-    (G) degree of grammaticalization → `isObligatory`. -/
-structure System where
-  /-- Language family (e.g., "Indo-European", "Sino-Tibetan", "Bantu"). -/
-  family : String
-  /-- Aikhenvald classifier type. -/
-  classifierType : ClassifierType
-  /-- Morphosyntactic scopes this system operates in (A, B). -/
-  scopes : List CategorizationScope
-  /-- How nouns are assigned to classes/classifiers (C). -/
-  assignment : AssignmentPrinciple
-  /-- Morphological realization types used (D). -/
-  realizations : List SurfaceRealization
-  /-- Does the system involve agreement? (E) — definitional for noun classes.
-      Stored as `Bool` so the struct stays decidable as a whole; the
-      user-facing predicate is `HasAgreement : Prop`. -/
-  hasAgreement : Bool
-  /-- Inventory size (number of classes or classifiers). -/
-  inventorySize : Nat
-  /-- Is realization obligatory or optional? (G). User-facing predicate:
-      `IsObligatory : Prop`. -/
-  isObligatory : Bool
-  /-- Is there a formally/functionally unmarked default? (F). User-facing
-      predicate: `HasUnmarkedDefault : Prop`. -/
-  hasUnmarkedDefault : Bool := false
-  /-- Preferred semantic parameters (Aikhenvald §11.2). -/
-  preferredSemantics : List SemanticParameter := []
-  /-- Does the language have obligatory grammatical number marking?
-      User-facing predicate: `HasObligatoryNumber : Prop`. -/
-  hasObligatoryNumber : Bool := false
-  /-- Can classifiers and plural marking co-occur? Predicted by CLF-for-NUM
-      ([little-moroney-royer-2022]: CLF and PL are in different
-      projections) but not by CLF-for-N (same projection, complementary
-      distribution per [borer-2005]). User-facing predicate:
-      `PluralClfCooccur : Prop`. -/
-  pluralClfCooccur : Bool := false
-  /-- Citation backing the hand-coded values. -/
-  source : String := ""
-  deriving Repr, DecidableEq
-
-namespace System
-
-/-! ## Prop API for the boolean property fields
-
-The struct's `hasAgreement`/`isObligatory`/`hasUnmarkedDefault`/
-`hasObligatoryNumber`/`pluralClfCooccur` fields are stored as `Bool` so
-the struct itself stays decidably equal. The user-facing predicates are
-the `Prop` versions defined here, each with a `Decidable` instance via
-the underlying `Bool`. Theorem statements should prefer the `Prop` form
-(`s.HasAgreement` rather than `s.hasAgreement = true`); `decide` works
-for either since the Bool projection reduces structurally for concrete
-fragment values. -/
-
-/-- The system involves agreement (E). -/
-abbrev HasAgreement (s : System) : Prop := s.hasAgreement = true
-
-/-- Realization is obligatory (G). -/
-abbrev IsObligatory (s : System) : Prop := s.isObligatory = true
-
-/-- The system has a formally/functionally unmarked default (F). -/
-abbrev HasUnmarkedDefault (s : System) : Prop :=
-  s.hasUnmarkedDefault = true
-
-/-- The language has obligatory grammatical number marking. -/
-abbrev HasObligatoryNumber (s : System) : Prop :=
-  s.hasObligatoryNumber = true
-
-/-- Classifiers and plural marking can co-occur. -/
-abbrev PluralClfCooccur (s : System) : Prop :=
-  s.pluralClfCooccur = true
-
-end System
 
 end NounCategorization

--- a/Linglib/Fragments/Armenian/ClassifierSystem.lean
+++ b/Linglib/Fragments/Armenian/ClassifierSystem.lean
@@ -1,43 +1,49 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# Western Armenian noun-categorization system
-[bale-khanjian-2014] [bale-khanjian-2008]
+# Western Armenian noun-categorization parameters
 
-Classifier-system data for Western Armenian (ISO `hyw`). WALS Ch 55 has
-no direct `hyw` entry; the related `arz`/`hye` entries are Iranian
-Armenian, not Western Armenian. Non-obligatory status follows directly
-from [bale-khanjian-2014]'s data: numerals combine with bare nouns
-(eq. 10a *yergu dəgha vaze-ts* "two boys ran") and also with the plural
-form (eq. 10b *yergu dəgha-ner vaze-ts-in*, same meaning). Plural nouns
-are additionally *incompatible* with classifiers (footnote 3, citing
-[borer-2005] and [bale-khanjian-2008]).
+Western Armenian numerals combine directly with bare nouns (*yergu dəgha vaze-ts* 'two boys
+ran') as well as with plural nouns, so its classifiers are non-obligatory; plural nouns are
+incompatible with classifiers. The numeral-classifier type is retained so that cross-language
+consumers can filter on it, although with no obligatory classifier and an empty inventory the
+language arguably has no classifier system in Aikhenvald's sense.
 
-The Aikhenvald `numeralClassifier` category is a misfit for Western
-Armenian: with `isObligatory := false` and an essentially empty
-inventory, WA arguably has no classifier system in Aikhenvald's sense
-at all. The `.numeralClassifier` tag is retained pragmatically so cross-
-language theorems can filter on `classifierType`.
+## References
+
+* [bale-khanjian-2014], (10) and fn. 3
+* [bale-khanjian-2008]
 -/
 
 namespace Armenian
 
-/-- Western Armenian noun-categorization system: non-obligatory per
-    [bale-khanjian-2014] eq. 10. Empty inventory; plurals are
-    incompatible with classifiers. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Indo-European"
-  , classifierType := .numeralClassifier  -- Aikhenvald misfit, see docstring
-  , scopes := [.numeralNP]
-  , assignment := .semantic
-  , realizations := [.freeForm]
-  , hasAgreement := false
-  , inventorySize := 0
-  , isObligatory := false  -- KEY: numerals combine with bare nouns (BK 2014 eq. 10a)
-  , hasUnmarkedDefault := false
-  , preferredSemantics := []
-  , hasObligatoryNumber := false  -- general-number singular per BK 2014
-  , pluralClfCooccur := false  -- plurals incompatible with CLs (BK 2014 fn 3)
-  , source := "[bale-khanjian-2014] eq. 10; [bale-khanjian-2008]" }
+open NounCategorization
+
+/-- Retained as a numeral-classifier type for filtering; see the module docstring. -/
+def classifierType : ClassifierType := .numeralClassifier
+
+/-- Classifiers, when present, occur in the numeral phrase. -/
+def classifierScopes : List CategorizationScope := [.numeralNP]
+
+/-- Classifier choice is semantic. -/
+def classifierAssignment : AssignmentPrinciple := .semantic
+
+/-- Free morphemes. -/
+def classifierRealizations : List SurfaceRealization := [.freeForm]
+
+def classifierAgreement : Bool := false
+
+/-- Numerals combine with bare nouns. -/
+def classifierObligatory : Bool := false
+
+/-- Whether the inventory has a general classifier. -/
+def classifierDefault : Bool := false
+
+def classifierSemantics : List SemanticParameter := []
+
+def obligatoryNumber : Bool := false
+
+/-- Whether classifiers and plural marking co-occur. -/
+def pluralClassifierCooccur : Bool := false
 
 end Armenian

--- a/Linglib/Fragments/Italian/ClassifierSystem.lean
+++ b/Linglib/Fragments/Italian/ClassifierSystem.lean
@@ -1,29 +1,43 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# Italian noun-categorization system
-[aikhenvald-2000] [chierchia-1998]
+# Italian noun-categorization parameters
 
-Classifier-system data for Italian (ISO `ita`): 2-class gender system
-(masculine/feminine).
+Italian has a two-gender noun-class system (masculine and feminine) with obligatory agreement
+inside the noun phrase and with the predicate, assignment by sex and by the *-o* / *-a* endings,
+masculine as the unmarked gender, and obligatory number.
+
+## References
+
+* [aikhenvald-2000], §2
+* [chierchia-1998]
 -/
 
 namespace Italian
 
-/-- Italian noun-class system: 2-class gender (masculine/feminine);
-    semantic (sex) + morphological (-o / -a endings) assignment. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Indo-European"
-  , classifierType := .nounClass
-  , scopes := [.headModifierNP, .predicateArgument]
-  , assignment := .mixed  -- semantic (sex) + morphological (-o / -a endings)
-  , realizations := [.suffix]  -- agreement inflection on modifiers; noun classes are never free lexemes
-  , hasAgreement := true
-  , inventorySize := 2  -- masculine, feminine
-  , isObligatory := true
-  , hasUnmarkedDefault := true  -- masculine is unmarked
-  , preferredSemantics := [.sex, .animacy]
-  , hasObligatoryNumber := true  -- il/i, la/le, un/una
-  , source := "[aikhenvald-2000] §2; [chierchia-1998]" }
+open NounCategorization
+
+/-- Gender is a noun-class system. -/
+def classifierType : ClassifierType := .nounClass
+
+/-- Agreement inside the head-modifier NP and with the predicate. -/
+def classifierScopes : List CategorizationScope := [.headModifierNP, .predicateArgument]
+
+/-- Sex plus the morphological *-o* / *-a* endings. -/
+def classifierAssignment : AssignmentPrinciple := .mixed
+
+/-- Agreement inflection on modifiers; noun classes are never free lexemes. -/
+def classifierRealizations : List SurfaceRealization := [.suffix]
+
+def classifierAgreement : Bool := true
+
+def classifierObligatory : Bool := true
+
+/-- Masculine is the unmarked gender. -/
+def classifierDefault : Bool := true
+
+def classifierSemantics : List SemanticParameter := [.sex, .animacy]
+
+def obligatoryNumber : Bool := true
 
 end Italian

--- a/Linglib/Fragments/Japanese/Classifier.lean
+++ b/Linglib/Fragments/Japanese/Classifier.lean
@@ -260,7 +260,7 @@ def lookup (s : String) : Option Classifier :=
 
 /-- The list of all semantic parameters encoded by some classifier in the
     inventory (with duplicates removed). Used by
-    `Fragments/Japanese/ClassifierSystem` to compute `preferredSemantics`. -/
+    `Fragments/Japanese/ClassifierSystem` to compute `classifierSemantics`. -/
 def allEncodedParams : List SemanticParameter :=
   (all.flatMap encodes).eraseDups
 

--- a/Linglib/Fragments/Japanese/ClassifierSystem.lean
+++ b/Linglib/Fragments/Japanese/ClassifierSystem.lean
@@ -2,31 +2,44 @@ import Linglib.Features.NounCategorization.Basic
 import Linglib.Fragments.Japanese.Classifier
 
 /-!
-# Japanese noun-categorization system
-[aikhenvald-2000] [downing-1996]
+# Japanese noun-categorization parameters
 
-Classifier-system metadata for Japanese (ISO `jpn`). The lexical
-classifier inventory itself lives in `Fragments/Japanese/Classifier.lean`;
-this file aggregates that inventory into the typological-system summary
-(`System`).
+Japanese classifiers are numeral classifiers suffixed to numerals, chosen on semantic grounds,
+with *tsu* as the general classifier. The lexical inventory is
+`Fragments/Japanese/Classifier.lean`; the semantic parameters and the general classifier are
+read off it.
+
+## References
+
+* [downing-1996]
+* [aikhenvald-2000]
 -/
 
 namespace Japanese
 
-/-- Japanese numeral classifier system: obligatory CL suffixing on
-    numerals; default つ tsu; preferred semantics derived from the
-    lexical inventory. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Japonic"
-  , classifierType := .numeralClassifier
-  , scopes := [.numeralNP]
-  , assignment := .semantic
-  , realizations := [.suffix]  -- classifiers suffix to numerals
-  , hasAgreement := false
-  , inventorySize := Classifier.all.length
-  , isObligatory := true
-  , hasUnmarkedDefault := Classifier.defaultClassifier?.isSome  -- つ tsu
-  , preferredSemantics := Classifier.allEncodedParams
-  , source := "[aikhenvald-2000]; [downing-1996]" }
+open NounCategorization
+
+/-- Classifiers are numeral classifiers. -/
+def classifierType : ClassifierType := .numeralClassifier
+
+/-- Classifiers occur in the numeral phrase. -/
+def classifierScopes : List CategorizationScope := [.numeralNP]
+
+/-- Classifier choice is semantic. -/
+def classifierAssignment : AssignmentPrinciple := .semantic
+
+/-- Suffixes on numerals. -/
+def classifierRealizations : List SurfaceRealization := [.suffix]
+
+def classifierAgreement : Bool := false
+
+def classifierObligatory : Bool := true
+
+/-- Whether the inventory has a general classifier. -/
+def classifierDefault : Bool := Classifier.defaultClassifier?.isSome
+
+def classifierSemantics : List SemanticParameter := Classifier.allEncodedParams
+
+def obligatoryNumber : Bool := false
 
 end Japanese

--- a/Linglib/Fragments/Mandarin/ClassifierSystem.lean
+++ b/Linglib/Fragments/Mandarin/ClassifierSystem.lean
@@ -2,50 +2,46 @@ import Linglib.Features.NounCategorization.Basic
 import Linglib.Fragments.Mandarin.Classifiers
 
 /-!
-# Mandarin noun-categorization system
-[aikhenvald-2000] (typological schema); [li-thompson-1981] §4.2.1
-(Mandarin-specific empirical anchor)
+# Mandarin noun-categorization parameters
 
-Classifier-system metadata for Mandarin (ISO `cmn`). The lexical
-classifier inventory itself lives in `Fragments/Mandarin/Classifiers.lean`;
-this file aggregates that inventory into the typological-system summary
-(`System`) consumed by `Typology/ClassifierSystem.lean`.
+Mandarin classifiers are numeral classifiers: free morphemes obligatory with numerals and
+demonstratives, chosen on semantic grounds with a lexical residue that must be memorized, with
+*ge* as the general classifier that can replace the specific ones. The lexical inventory is
+`Fragments/Mandarin/Classifiers.lean`; the semantic parameters and the general classifier are
+read off it.
 
-The per-language claims (obligatoriness with numerals + demonstratives,
-default 个 gè, semantic-with-lexical-residue assignment) follow
-[li-thompson-1981] §4.2.1, pp. 104–112; [aikhenvald-2000]
-provides the typological schema (the `System` field
-ontology). [li-thompson-1981] in turn cites [chao-1968] §7.9 as
-the canonical inventory source.
+## References
+
+* [li-thompson-1981], §4.2.1
+* [aikhenvald-2000]
 -/
 
 namespace Mandarin
 
-open NounCategorization (collectSemantics) in
-/-- Mandarin numeral classifier system: obligatory CL with numerals and
-    demonstratives ([li-thompson-1981] p. 104: "must occur with a
-    number ... and/or a demonstrative"); default 个 gè (ibid. p. 112: 个
-    "is gradually becoming the general classifier and replacing the more
-    specialized ones"); preferred semantics derived from the lexical
-    inventory. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Sino-Tibetan"
-  , classifierType := .numeralClassifier
-  , scopes := [.numeralNP, .attributiveNP]  -- CLF with numerals AND demonstratives (那本书) per L&T 1981 p. 104
-  , assignment := .semantic
-    -- Substrate gap: L&T 1981 p. 112 explicitly note "which nouns occur with
-    -- which classifier must be memorized, though there is a slight amount of
-    -- regularity with respect to the meanings of groups of nouns." This is
-    -- semantic core + LEXICAL (not morphophonological) overlay; `.mixed`
-    -- would over-claim morphophonological assignment, so `.semantic` remains
-    -- the closest fit available in `AssignmentPrinciple`. A future enum
-    -- enrichment (`.semanticWithLexicalIdiosyncrasy`) would capture this.
-  , realizations := [.freeForm]
-  , hasAgreement := false
-  , inventorySize := Classifiers.allClassifiers.length
-  , isObligatory := true
-  , hasUnmarkedDefault := Classifiers.allClassifiers.any (·.isDefault)  -- 个 gè, L&T 1981 p. 112
-  , preferredSemantics := collectSemantics Classifiers.allClassifiers
-  , source := "[li-thompson-1981] §4.2.1 pp. 104–112; [aikhenvald-2000] (schema)" }
+open NounCategorization
+
+/-- Classifiers are numeral classifiers. -/
+def classifierType : ClassifierType := .numeralClassifier
+
+/-- Classifiers occur with numerals and with demonstratives (那本书). -/
+def classifierScopes : List CategorizationScope := [.numeralNP, .attributiveNP]
+
+/-- Classifier choice is semantic. -/
+def classifierAssignment : AssignmentPrinciple := .semantic
+
+/-- Free morphemes. -/
+def classifierRealizations : List SurfaceRealization := [.freeForm]
+
+def classifierAgreement : Bool := false
+
+/-- Obligatory with numerals and demonstratives. -/
+def classifierObligatory : Bool := true
+
+/-- Whether the inventory has a general classifier. -/
+def classifierDefault : Bool := Classifiers.allClassifiers.any (·.isDefault)
+
+def classifierSemantics : List SemanticParameter := collectSemantics Classifiers.allClassifiers
+
+def obligatoryNumber : Bool := false
 
 end Mandarin

--- a/Linglib/Fragments/Mandarin/Classifiers.lean
+++ b/Linglib/Fragments/Mandarin/Classifiers.lean
@@ -165,13 +165,13 @@ def lookup (form : String) : Option ClassifierEntry :=
 theorem ge_is_default : ge.isDefault = true := rfl
 
 /-- 只 encodes animacy. -/
-theorem zhi_encodes_animacy : zhi.encodes .animacy = true := by decide
+theorem zhi_encodes_animacy : zhi.Encodes .animacy := by decide
 
 /-- 位 encodes humanness. -/
-theorem wei_encodes_humanness : wei.encodes .humanness = true := by decide
+theorem wei_encodes_humanness : wei.Encodes .humanness := by decide
 
 /-- 本 encodes shape. -/
-theorem ben_encodes_shape : ben.encodes .shape = true := by decide
+theorem ben_encodes_shape : ben.Encodes .shape := by decide
 
 /-- All non-default classifiers have at least one semantic parameter. -/
 theorem specific_classifiers_have_semantics :

--- a/Linglib/Fragments/Mayan/Chol/ClassifierSystem.lean
+++ b/Linglib/Fragments/Mayan/Chol/ClassifierSystem.lean
@@ -2,41 +2,50 @@ import Linglib.Features.NounCategorization.Basic
 import Linglib.Fragments.Mayan.Chol.Classifiers
 
 /-!
-# Ch'ol noun-categorization system
+# Ch'ol noun-categorization parameters
 
-Classifier-system metadata for Ch'ol (ISO `ctu`), aggregating the lexical
-classifier inventory into a `System` summary against [aikhenvald-2000]'s
-typological schema, with Ch'ol as the empirical anchor ([bale-coon-2014]).
+Ch'ol classifiers are numeral classifiers suffixed to the numeral stem, obligatory with native
+numerals (Spanish loan numerals reject them), with *-p'ej* as the generic default and attested
+co-occurrence with plural marking. The lexical inventory is
+`Fragments/Mayan/Chol/Classifiers.lean`.
 
-## Implementation notes
+## References
 
-The lexical classifier inventory lives in
-`Fragments/Mayan/Chol/Classifiers.lean`; this file aggregates it.
-Per-language claims (consensus, see [bale-coon-2014], [bale-et-al-2019],
-[little-moroney-royer-2022]): suffix realization on the numeral stem;
-classifier obligatory with Ch'ol-native numerals; Spanish loan numerals are
-ungrammatical *with* CLF; *-p'ej* serves as the generic default; CLF/PL
-co-occurrence is attested. Theoretical-strategy assignments (CLF-for-NUM vs
-CLF-for-N) live in the paper-anchored Studies that consume this profile.
+* [bale-coon-2014]
+* [bale-et-al-2019]
+* [little-moroney-royer-2022]
+* [aikhenvald-2000]
 -/
 
 namespace Chol
 
-open NounCategorization (collectSemantics) in
-/-- Ch'ol numeral classifier system: suffix on the numeral stem,
-restricted to numeralNP scope, with CLF/PL co-occurrence. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Mayan"
-  , classifierType := .numeralClassifier
-  , scopes := [.numeralNP]
-  , assignment := .semantic
-  , realizations := [.suffix]
-  , hasAgreement := false
-  , inventorySize := Classifiers.allClassifiers.length
-  , isObligatory := true
-  , hasUnmarkedDefault := true
-  , preferredSemantics := collectSemantics Classifiers.allClassifiers
-  , pluralClfCooccur := true
-  , source := "[bale-coon-2014]; [aikhenvald-2000] (schema)" }
+open NounCategorization
+
+/-- Classifiers are numeral classifiers. -/
+def classifierType : ClassifierType := .numeralClassifier
+
+/-- Classifiers occur in the numeral phrase. -/
+def classifierScopes : List CategorizationScope := [.numeralNP]
+
+/-- Classifier choice is semantic. -/
+def classifierAssignment : AssignmentPrinciple := .semantic
+
+/-- Suffixes on the numeral stem. -/
+def classifierRealizations : List SurfaceRealization := [.suffix]
+
+def classifierAgreement : Bool := false
+
+/-- Obligatory with native numerals. -/
+def classifierObligatory : Bool := true
+
+/-- Whether the inventory has a general classifier. -/
+def classifierDefault : Bool := Classifiers.allClassifiers.any (·.isDefault)
+
+def classifierSemantics : List SemanticParameter := collectSemantics Classifiers.allClassifiers
+
+def obligatoryNumber : Bool := false
+
+/-- Whether classifiers and plural marking co-occur. -/
+def pluralClassifierCooccur : Bool := true
 
 end Chol

--- a/Linglib/Fragments/Romance/French/ClassifierSystem.lean
+++ b/Linglib/Fragments/Romance/French/ClassifierSystem.lean
@@ -1,29 +1,42 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# French noun-categorization system
-[aikhenvald-2000]
+# French noun-categorization parameters
 
-Classifier-system data for French (ISO `fra`): masculine/feminine
-noun-class system per [aikhenvald-2000] §2.
+French has a two-gender noun-class system (masculine and feminine) with obligatory agreement
+inside the noun phrase and with the predicate, semantic assignment with a morphological
+residue, masculine as the unmarked gender, and obligatory number.
+
+## References
+
+* [aikhenvald-2000], §2
 -/
 
 namespace French
 
-/-- French noun-class system: 2-class gender (masculine/feminine),
-    obligatory agreement, mostly semantic + morphological residue. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Indo-European"
-  , classifierType := .nounClass
-  , scopes := [.headModifierNP, .predicateArgument]
-  , assignment := .mixed  -- mostly semantic + morphological residue
-  , realizations := [.suffix]  -- agreement inflection on modifiers; noun classes are never free lexemes
-  , hasAgreement := true
-  , inventorySize := 2  -- masculine, feminine
-  , isObligatory := true
-  , hasUnmarkedDefault := true  -- masculine is unmarked
-  , preferredSemantics := [.sex, .animacy]
-  , hasObligatoryNumber := true  -- le/les, un/des
-  , source := "[aikhenvald-2000] §2" }
+open NounCategorization
+
+/-- Gender is a noun-class system. -/
+def classifierType : ClassifierType := .nounClass
+
+/-- Agreement inside the head-modifier NP and with the predicate. -/
+def classifierScopes : List CategorizationScope := [.headModifierNP, .predicateArgument]
+
+/-- Semantic core with a morphological residue. -/
+def classifierAssignment : AssignmentPrinciple := .mixed
+
+/-- Agreement inflection on modifiers; noun classes are never free lexemes. -/
+def classifierRealizations : List SurfaceRealization := [.suffix]
+
+def classifierAgreement : Bool := true
+
+def classifierObligatory : Bool := true
+
+/-- Masculine is the unmarked gender. -/
+def classifierDefault : Bool := true
+
+def classifierSemantics : List SemanticParameter := [.sex, .animacy]
+
+def obligatoryNumber : Bool := true
 
 end French

--- a/Linglib/Fragments/Shan/ClassifierSystem.lean
+++ b/Linglib/Fragments/Shan/ClassifierSystem.lean
@@ -2,37 +2,48 @@ import Linglib.Features.NounCategorization.Basic
 import Linglib.Fragments.Shan.Classifiers
 
 /-!
-# Shan noun-categorization system
-[aikhenvald-2000] (typological schema); [moroney-2021] (Shan empirical anchor)
+# Shan noun-categorization parameters
 
-Classifier-system metadata for Shan (ISO `shn`). The lexical classifier
-inventory lives in `Fragments/Shan/Classifiers.lean`; this file
-aggregates that inventory into a `System` summary.
+Shan classifiers are numeral classifiers: free morphemes derived from nominal elements (*tǒ*
+'body'), required uniformly by numerals and extending to quantifiers, demonstratives and
+relative clauses, with a generic classifier and no co-occurrence with plural marking. The
+lexical inventory is `Fragments/Shan/Classifiers.lean`.
 
-Per-language claims (consensus, see [moroney-2021],
-[little-moroney-royer-2022]): free-morpheme classifiers derived
-from nominal elements (e.g. *tǒ* = 'body'); uniform classifier
-requirement on numerals; scope extending beyond numerals to
-quantifiers, demonstratives, and relative clauses.
+## References
+
+* [moroney-2021]
+* [little-moroney-royer-2022]
+* [aikhenvald-2000]
 -/
 
 namespace Shan
 
-open NounCategorization (collectSemantics) in
-/-- Shan numeral classifier system: free morphemes appearing with
-numerals and broader DP scope. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Kra-Dai"
-  , classifierType := .numeralClassifier
-  , scopes := [.numeralNP, .attributiveNP]
-  , assignment := .semantic
-  , realizations := [.freeForm]
-  , hasAgreement := false
-  , inventorySize := Classifiers.allClassifiers.length
-  , isObligatory := true
-  , hasUnmarkedDefault := true
-  , preferredSemantics := collectSemantics Classifiers.allClassifiers
-  , pluralClfCooccur := false
-  , source := "[moroney-2021]; [aikhenvald-2000] (schema)" }
+open NounCategorization
+
+/-- Classifiers are numeral classifiers. -/
+def classifierType : ClassifierType := .numeralClassifier
+
+/-- Classifiers occur with numerals, quantifiers, demonstratives and relative clauses. -/
+def classifierScopes : List CategorizationScope := [.numeralNP, .attributiveNP]
+
+/-- Classifier choice is semantic. -/
+def classifierAssignment : AssignmentPrinciple := .semantic
+
+/-- Free morphemes. -/
+def classifierRealizations : List SurfaceRealization := [.freeForm]
+
+def classifierAgreement : Bool := false
+
+def classifierObligatory : Bool := true
+
+/-- Whether the inventory has a general classifier. -/
+def classifierDefault : Bool := Classifiers.allClassifiers.any (·.isDefault)
+
+def classifierSemantics : List SemanticParameter := collectSemantics Classifiers.allClassifiers
+
+def obligatoryNumber : Bool := false
+
+/-- Whether classifiers and plural marking co-occur. -/
+def pluralClassifierCooccur : Bool := false
 
 end Shan

--- a/Linglib/Fragments/Shona/ClassifierSystem.lean
+++ b/Linglib/Fragments/Shona/ClassifierSystem.lean
@@ -1,29 +1,42 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# Shona noun-categorization system
-[carstens-2026]
+# Shona noun-categorization parameters
 
-Classifier-system metadata for Shona (ISO `sna`): Bantu noun-class
-system with 14 classes and binary human/non-human split.
+Shona has a Bantu noun-class system with prefixal realization and pervasive concord inside
+the noun phrase and on the verb, a human/non-human split, and singular/plural class pairs
+making number obligatory.
+
+## References
+
+* [carstens-2026]
 -/
 
 namespace Shona
 
-/-- Shona Bantu noun-class system: 14-class inventory, prefix
-    realization, agreement-rich. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Bantu"
-  , classifierType := .nounClass
-  , scopes := [.headModifierNP, .predicateArgument]
-  , assignment := .mixed
-  , realizations := [.prefix]
-  , hasAgreement := true
-  , inventorySize := 14  -- cl1-cl14
-  , isObligatory := true
-  , hasUnmarkedDefault := true
-  , preferredSemantics := [.humanness, .animacy]
-  , hasObligatoryNumber := true  -- singular/plural class pairs
-  , source := "[carstens-2026]" }
+open NounCategorization
+
+/-- Gender is a noun-class system. -/
+def classifierType : ClassifierType := .nounClass
+
+/-- Agreement inside the head-modifier NP and with the predicate. -/
+def classifierScopes : List CategorizationScope := [.headModifierNP, .predicateArgument]
+
+/-- Semantic core with morphological residue. -/
+def classifierAssignment : AssignmentPrinciple := .mixed
+
+/-- Class prefixes on the noun and its agreement targets. -/
+def classifierRealizations : List SurfaceRealization := [.prefix]
+
+def classifierAgreement : Bool := true
+
+def classifierObligatory : Bool := true
+
+/-- A default agreement class. -/
+def classifierDefault : Bool := true
+
+def classifierSemantics : List SemanticParameter := [.humanness, .animacy]
+
+def obligatoryNumber : Bool := true
 
 end Shona

--- a/Linglib/Fragments/Swahili/ClassifierSystem.lean
+++ b/Linglib/Fragments/Swahili/ClassifierSystem.lean
@@ -1,29 +1,42 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# Swahili noun-categorization system
-[aikhenvald-2000]
+# Swahili noun-categorization parameters
 
-Classifier-system metadata for Swahili (ISO `swh`): Bantu noun-class
-system with 15 classes and prefix-based concord.
+Swahili has a Bantu noun-class system with prefixal realization and pervasive concord inside
+the noun phrase and on the verb; singular/plural class pairs (M/Wa, Ki/Vi, …) make number
+obligatory.
+
+## References
+
+* [aikhenvald-2000]
 -/
 
 namespace Swahili
 
-/-- Swahili Bantu noun-class system: 15-class inventory, prefix
-    realization, agreement-rich. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Bantu"
-  , classifierType := .nounClass
-  , scopes := [.headModifierNP, .predicateArgument]
-  , assignment := .mixed
-  , realizations := [.prefix]
-  , hasAgreement := true
-  , inventorySize := 15  -- cl1-cl10, cl14-cl18
-  , isObligatory := true
-  , hasUnmarkedDefault := true
-  , preferredSemantics := [.humanness, .animacy]
-  , hasObligatoryNumber := true  -- singular/plural class pairs (M/Wa, Ki/Vi, etc.)
-  , source := "[aikhenvald-2000]" }
+open NounCategorization
+
+/-- Gender is a noun-class system. -/
+def classifierType : ClassifierType := .nounClass
+
+/-- Agreement inside the head-modifier NP and with the predicate. -/
+def classifierScopes : List CategorizationScope := [.headModifierNP, .predicateArgument]
+
+/-- Semantic core with morphological residue. -/
+def classifierAssignment : AssignmentPrinciple := .mixed
+
+/-- Class prefixes on the noun and its agreement targets. -/
+def classifierRealizations : List SurfaceRealization := [.prefix]
+
+def classifierAgreement : Bool := true
+
+def classifierObligatory : Bool := true
+
+/-- A default agreement class. -/
+def classifierDefault : Bool := true
+
+def classifierSemantics : List SemanticParameter := [.humanness, .animacy]
+
+def obligatoryNumber : Bool := true
 
 end Swahili

--- a/Linglib/Fragments/Xhosa/ClassifierSystem.lean
+++ b/Linglib/Fragments/Xhosa/ClassifierSystem.lean
@@ -1,29 +1,43 @@
 import Linglib.Features.NounCategorization.Basic
 
 /-!
-# Xhosa noun-categorization system
-[carstens-2026] [taraldsen-et-al-2018]
+# Xhosa noun-categorization parameters
 
-Classifier-system metadata for Xhosa (ISO `xho`): Bantu noun-class
-system with 11 classes and pervasive concord.
+Xhosa has a Bantu noun-class system with prefixal realization and pervasive concord inside
+the noun phrase and on the verb; class 2 *ba-* and class 8 *zi-* serve as default agreement
+classes, and singular/plural class pairs make number obligatory.
+
+## References
+
+* [carstens-2026]
+* [taraldsen-et-al-2018]
 -/
 
 namespace Xhosa
 
-/-- Xhosa Bantu noun-class system: 11-class inventory, prefix
-    realization, agreement-rich. -/
-def classifierSystem : NounCategorization.System :=
-  { family := "Bantu"
-  , classifierType := .nounClass
-  , scopes := [.headModifierNP, .predicateArgument]
-  , assignment := .mixed
-  , realizations := [.prefix]
-  , hasAgreement := true
-  , inventorySize := 11  -- cl1-cl10 + cl15
-  , isObligatory := true
-  , hasUnmarkedDefault := true  -- class 2 ba- / class 8 zi- as defaults
-  , preferredSemantics := [.humanness, .animacy]
-  , hasObligatoryNumber := true  -- singular/plural class pairs (e.g. cl1/cl2)
-  , source := "[carstens-2026]; [taraldsen-et-al-2018]" }
+open NounCategorization
+
+/-- Gender is a noun-class system. -/
+def classifierType : ClassifierType := .nounClass
+
+/-- Agreement inside the head-modifier NP and with the predicate. -/
+def classifierScopes : List CategorizationScope := [.headModifierNP, .predicateArgument]
+
+/-- Semantic core with morphological residue. -/
+def classifierAssignment : AssignmentPrinciple := .mixed
+
+/-- Class prefixes on the noun and its agreement targets. -/
+def classifierRealizations : List SurfaceRealization := [.prefix]
+
+def classifierAgreement : Bool := true
+
+def classifierObligatory : Bool := true
+
+/-- A default agreement class. -/
+def classifierDefault : Bool := true
+
+def classifierSemantics : List SemanticParameter := [.humanness, .animacy]
+
+def obligatoryNumber : Bool := true
 
 end Xhosa

--- a/Linglib/Studies/Aikhenvald2000.lean
+++ b/Linglib/Studies/Aikhenvald2000.lean
@@ -14,10 +14,11 @@ scope, the definitional parameters (A)–(G) of the book's first chapter, and th
 contingent parameters — interaction with other categories, preferred semantics, evolution,
 acquisition — as correlates of the types so established. The types are focal points on a
 continuum rather than discrete classes, and most generalizations are tendencies with listed
-exceptions. Here the book's summary claims are stated over the `NounCategorization.System`
-records of seven Fragments — the French and Italian gender systems, the Xhosa, Shona and
-Swahili noun-class systems, and the Mandarin and Japanese numeral-classifier systems
-(`allSystems`) — and checked on that sample; none is a universal over the record type.
+exceptions. Here the book's parameter list is the record `Parameters`, assembled from the
+values seven Fragments record field by field — the French and Italian gender systems, the
+Xhosa, Shona and Swahili noun-class systems, and the Mandarin and Japanese numeral-classifier
+systems (`allSystems`) — and the book's summary claims are checked on that sample; none is a
+universal over the record type.
 
 Agreement by a constituent outside the noun is the definitional property of a noun class
 system, a closed obligatory grammatical system (`nounClass_agreement_obligatory`), and noun
@@ -49,24 +50,74 @@ namespace Aikhenvald2000
 
 open NounCategorization
 
-abbrev french := French.classifierSystem
-abbrev italian := Italian.classifierSystem
-abbrev mandarin := Mandarin.classifierSystem
-abbrev japanese := Japanese.classifierSystem
-abbrev xhosa := Xhosa.classifierSystem
-abbrev shona := Shona.classifierSystem
-abbrev swahili := Swahili.classifierSystem
+/-- The definitional parameters (A)–(G) of a noun categorization system, its preferred
+semantics (I), and the language's number marking. -/
+structure Parameters where
+  /-- (A), (B): the device type, individuated by locus and scope. -/
+  classifierType : ClassifierType
+  /-- (B): the scopes the device operates in. -/
+  scopes : List CategorizationScope
+  /-- (C): the principle of assignment. -/
+  assignment : AssignmentPrinciple
+  /-- (D): surface realizations. -/
+  realizations : List SurfaceRealization
+  /-- (E): whether the device participates in agreement. -/
+  agreement : Bool
+  /-- (G): whether the device is obligatory. -/
+  obligatory : Bool
+  /-- (F): a functionally unmarked member, or a general classifier. -/
+  unmarkedMember : Bool
+  /-- (I): preferred semantic parameters. -/
+  semantics : List SemanticParameter
+  /-- Whether the language marks number obligatorily. -/
+  obligatoryNumber : Bool
+  deriving DecidableEq
+
+def french : Parameters :=
+  ⟨French.classifierType, French.classifierScopes, French.classifierAssignment,
+   French.classifierRealizations, French.classifierAgreement, French.classifierObligatory,
+   French.classifierDefault, French.classifierSemantics, French.obligatoryNumber⟩
+
+def italian : Parameters :=
+  ⟨Italian.classifierType, Italian.classifierScopes, Italian.classifierAssignment,
+   Italian.classifierRealizations, Italian.classifierAgreement, Italian.classifierObligatory,
+   Italian.classifierDefault, Italian.classifierSemantics, Italian.obligatoryNumber⟩
+
+def mandarin : Parameters :=
+  ⟨Mandarin.classifierType, Mandarin.classifierScopes, Mandarin.classifierAssignment,
+   Mandarin.classifierRealizations, Mandarin.classifierAgreement, Mandarin.classifierObligatory,
+   Mandarin.classifierDefault, Mandarin.classifierSemantics, Mandarin.obligatoryNumber⟩
+
+def japanese : Parameters :=
+  ⟨Japanese.classifierType, Japanese.classifierScopes, Japanese.classifierAssignment,
+   Japanese.classifierRealizations, Japanese.classifierAgreement, Japanese.classifierObligatory,
+   Japanese.classifierDefault, Japanese.classifierSemantics, Japanese.obligatoryNumber⟩
+
+def xhosa : Parameters :=
+  ⟨Xhosa.classifierType, Xhosa.classifierScopes, Xhosa.classifierAssignment,
+   Xhosa.classifierRealizations, Xhosa.classifierAgreement, Xhosa.classifierObligatory,
+   Xhosa.classifierDefault, Xhosa.classifierSemantics, Xhosa.obligatoryNumber⟩
+
+def shona : Parameters :=
+  ⟨Shona.classifierType, Shona.classifierScopes, Shona.classifierAssignment,
+   Shona.classifierRealizations, Shona.classifierAgreement, Shona.classifierObligatory,
+   Shona.classifierDefault, Shona.classifierSemantics, Shona.obligatoryNumber⟩
+
+def swahili : Parameters :=
+  ⟨Swahili.classifierType, Swahili.classifierScopes, Swahili.classifierAssignment,
+   Swahili.classifierRealizations, Swahili.classifierAgreement, Swahili.classifierObligatory,
+   Swahili.classifierDefault, Swahili.classifierSemantics, Swahili.obligatoryNumber⟩
 
 /-- The sample: two gender systems, three Bantu noun-class systems, two numeral-classifier
 systems. -/
-def allSystems : List System := [french, italian, mandarin, japanese, xhosa, shona, swahili]
+def allSystems : List Parameters := [french, italian, mandarin, japanese, xhosa, shona, swahili]
 
 /-! ### Definitional properties -/
 
 /-- A noun class system is defined by agreement outside the noun and is a closed obligatory
 grammatical system. -/
 theorem nounClass_agreement_obligatory :
-    ∀ s ∈ allSystems, s.classifierType = .nounClass → s.HasAgreement ∧ s.IsObligatory := by
+    ∀ s ∈ allSystems, s.classifierType = .nounClass → s.agreement = true ∧ s.obligatory = true := by
   decide
 
 /-- Noun classes are realized with affixes or clitics, never with free lexemes. -/
@@ -76,7 +127,7 @@ theorem nounClass_bound :
 /-- Numeral classifiers expressed as free morphemes do not participate in agreement. -/
 theorem free_numeralClassifier_no_agreement :
     ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → .freeForm ∈ s.realizations →
-      ¬ s.HasAgreement := by decide
+      s.agreement = false := by decide
 
 /-- Each system operates in the scope that defines its type. -/
 theorem locus_mem_scopes : ∀ s ∈ allSystems, s.classifierType.locus ∈ s.scopes := by decide
@@ -89,7 +140,7 @@ theorem classifier_assignment_semantic :
 /-- Both numeral-classifier systems have a generic classifier that can replace the specific
 ones, Mandarin *ge* and Japanese *tsu*, the analogue of a functionally unmarked noun class. -/
 theorem numeralClassifier_general :
-    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → s.HasUnmarkedDefault := by decide
+    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → s.unmarkedMember = true := by decide
 
 /-- The choice of a specific numeral classifier is semantic: every non-generic sortal classifier
 encodes some semantic parameter. -/
@@ -104,21 +155,21 @@ theorem classifier_choice_semantic :
 /-- Animacy, humanness or sex is basic to noun classes and numeral classifiers. -/
 theorem animacy_basic :
     ∀ s ∈ allSystems, s.classifierType = .nounClass ∨ s.classifierType = .numeralClassifier →
-      ∃ p ∈ s.preferredSemantics, p = .animacy ∨ p = .humanness ∨ p = .sex := by decide
+      ∃ p ∈ s.semantics, p = .animacy ∨ p = .humanness ∨ p = .sex := by decide
 
 /-- Physical properties such as shape are typical of numeral classifiers. -/
 theorem numeralClassifier_shape :
-    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → .shape ∈ s.preferredSemantics := by
+    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → .shape ∈ s.semantics := by
   decide
 
 /-- Colour is never a basis for noun categorization. -/
-theorem colour_never : ∀ s ∈ allSystems, .colour ∉ s.preferredSemantics := by decide
+theorem colour_never : ∀ s ∈ allSystems, .colour ∉ s.semantics := by decide
 
 /-! ### Classifiers and number -/
 
 /-- Numeral-classifier languages usually lack compulsory number marking. -/
 theorem numeralClassifier_no_obligatory_number :
-    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → ¬ s.HasObligatoryNumber := by
+    ∀ s ∈ allSystems, s.classifierType = .numeralClassifier → s.obligatoryNumber = false := by
   decide
 
 end Aikhenvald2000

--- a/Linglib/Studies/BaleKhanjian2014.lean
+++ b/Linglib/Studies/BaleKhanjian2014.lean
@@ -67,9 +67,9 @@ that block the silent ∪-operator — is not present in Western Armenian.
 Sudo's `.sudoBlocking` strategy doesn't apply; the language sits in a
 different typological cell.
 
-The Western Armenian classifier system is recorded in
-`Fragments/Armenian/Typology.lean` with `isObligatory := false` and
-`pluralClfCooccur := false` (per footnote 3, plurals are incompatible
+The Western Armenian classifier parameters are recorded in
+`Fragments/Armenian/ClassifierSystem.lean`: `classifierObligatory := false` and
+`pluralClassifierCooccur := false` (per footnote 3, plurals are incompatible
 with classifiers).
 
 ## What is formalized
@@ -348,7 +348,7 @@ theorem definiteness_asymmetry :
     show *why* the input shape is wrong: Western Armenian numerals
     combine directly with bare nouns (eq. 10a), so there is no overt
     classifier morpheme that the silent ∪-operator would be blocked by.
-    Western Armenian's `classifierSystem` carries `isObligatory := false`,
+    Western Armenian's Fragment records `classifierObligatory := false`,
     structurally failing the input shape that obligatory-CL frameworks
     like [chierchia-1998] and [sudo-2016] presuppose.
 
@@ -356,6 +356,6 @@ theorem definiteness_asymmetry :
     rather than BK 2014 → Sudo 2016 (which would violate the chronology
     rule — study files may reference older papers, not newer ones). -/
 theorem western_armenian_lacks_obligatory_classifier_input :
-    ¬ Armenian.classifierSystem.IsObligatory := by decide
+    Armenian.classifierObligatory = false := rfl
 
 end BaleKhanjian2014

--- a/Linglib/Studies/Chierchia1998.lean
+++ b/Linglib/Studies/Chierchia1998.lean
@@ -1,5 +1,8 @@
 import Linglib.Semantics.Genericity.NominalMappingParameter
-import Linglib.Studies.Aikhenvald2000
+import Linglib.Fragments.Romance.French.ClassifierSystem
+import Linglib.Fragments.Italian.ClassifierSystem
+import Linglib.Fragments.Mandarin.ClassifierSystem
+import Linglib.Fragments.Japanese.ClassifierSystem
 import Linglib.Fragments.Romance.French.Nouns
 import Linglib.Fragments.Mandarin.Nouns
 import Linglib.Fragments.Japanese.Nouns
@@ -9,8 +12,8 @@ import Linglib.Fragments.Italian.Nouns
 Noun Categorization × [chierchia-1998] Nominal Mapping Parameter
 [chierchia-1998]
 
-Connects the cross-linguistic noun categorization typology in
-`Aikhenvald2000` to the Nominal Mapping
+Connects the noun categorization types the Fragments record (in
+Aikhenvald's typology) to the Nominal Mapping
 Parameter from `Semantics.Kinds.NMP`.
 
 ## Predictions verified
@@ -33,8 +36,8 @@ book', Mandarin).
 The NMP-to-classifier bridge is accurate at Aikhenvald's morphosyntactic
 level but does not distinguish between CLF-for-NUM and CLF-for-N within
 the numeral classifier type. Both Ch'ol (CLF-for-NUM) and Shan (CLF-for-N)
-are `numeralClassifier` in Aikhenvald's typology. The `ClassifierStrategy`
-field on `NounCategorizationSystem` captures this finer distinction.
+are `numeralClassifier` in Aikhenvald's typology. `ClassifierStrategy`
+captures this finer distinction.
 
 ## Known gaps
 
@@ -45,7 +48,6 @@ namespace NMP
 
 open NounCategorization
 open Semantics.Kinds.NMP (NominalMapping)
-open Aikhenvald2000 (mandarin japanese french italian)
 
 /-- Map NominalMapping to the expected classifier type.
     [+arg, -pred] languages have numeral classifiers.
@@ -86,22 +88,22 @@ theorem argAndPred_no_system :
 
 /-- Mandarin's actual classifier type matches the Chierchia prediction. -/
 theorem mandarin_chierchia_consistent :
-    some mandarin.classifierType =
+    some Mandarin.classifierType =
       nominalMappingToClassifierType Mandarin.Nouns.mandarinMapping := rfl
 
 /-- Japanese's actual classifier type matches the Chierchia prediction. -/
 theorem japanese_chierchia_consistent :
-    some japanese.classifierType =
+    some Japanese.classifierType =
       nominalMappingToClassifierType Japanese.Nouns.japaneseMapping := rfl
 
 /-- French's actual classifier type matches the Chierchia prediction. -/
 theorem french_chierchia_consistent :
-    some french.classifierType =
+    some French.classifierType =
       nominalMappingToClassifierType French.Nouns.frenchMapping := rfl
 
 /-- Italian's actual classifier type matches the Chierchia prediction. -/
 theorem italian_chierchia_consistent :
-    some italian.classifierType =
+    some Italian.classifierType =
       nominalMappingToClassifierType Italian.Nouns.italianMapping := rfl
 
 /-- French and Italian agree on Chierchia mapping: both are predOnly. -/
@@ -117,8 +119,8 @@ atomizes the noun denotation. The NMP determines that nouns denote kinds
 numeral. This commits Chierchia's framework to a `.forNoun` strategy for
 every [+arg, -pred] language with classifiers.
 
-Per-language assignments live here (in this study file) rather than on
-`NounCategorizationSystem`, where they would silently endorse Chierchia's
+Per-language assignments live here (in this study file) rather than in the
+Fragments, where they would silently endorse Chierchia's
 framework over alternatives like [sudo-2016]'s `.sudoBlocking`. -/
 
 /-- Chierchia's strategy assignment for Japanese: CLF atomizes a kind-denoting

--- a/Linglib/Studies/Downing1996.lean
+++ b/Linglib/Studies/Downing1996.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.NounCategorization.Basic
 import Linglib.Fragments.Japanese.Classifier
 import Linglib.Fragments.Japanese.Nouns
-import Linglib.Studies.Aikhenvald2000
+import Linglib.Fragments.Japanese.ClassifierSystem
 import Linglib.Semantics.Genericity.NominalMappingParameter
 
 /-!
@@ -196,7 +196,7 @@ theorem one_absent_from_anaphoric :
     Witnessed by: Japanese is [+arg, -pred] AND has numeral classifiers. -/
 theorem argOnly_has_classifiers :
     Japanese.Nouns.japaneseMapping = .argOnly ∧
-    Aikhenvald2000.japanese.classifierType = .numeralClassifier := by
+    Japanese.classifierType = .numeralClassifier := by
   exact ⟨rfl, rfl⟩
 
 /-- In [chierchia-1998]'s framework, [+arg, -pred] languages have no
@@ -205,7 +205,7 @@ theorem argOnly_has_classifiers :
 theorem no_blocking_needs_classifiers :
     Japanese.Nouns.japaneseBlocking.iotaBlocked = false ∧
     Japanese.Nouns.japaneseBlocking.existsBlocked = false ∧
-    Aikhenvald2000.japanese.classifierType = .numeralClassifier := by
+    Japanese.classifierType = .numeralClassifier := by
   exact ⟨rfl, rfl, rfl⟩
 
 /-- Non-default classifiers encode at least one semantic parameter,

--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -206,8 +206,7 @@ end
 /-- [borer-2005]'s classifier–plural complementarity holds in Shan, where
 both occupy one projection, and lifts in Ch'ol ((30), §3.4). -/
 theorem plural_cooccurrence :
-    Chol.classifierSystem.PluralClfCooccur ∧ ¬ Shan.classifierSystem.PluralClfCooccur := by
-  decide
+    Chol.pluralClassifierCooccur = true ∧ Shan.pluralClassifierCooccur = false := ⟨rfl, rfl⟩
 
 /-! ### Against a uniform classifier semantics -/
 

--- a/Linglib/Studies/PrasertsonSmithCulbertson2026.lean
+++ b/Linglib/Studies/PrasertsonSmithCulbertson2026.lean
@@ -61,24 +61,24 @@ open NounCategorization
     Derived from `allSystems` data rather than stipulated. -/
 def isAttestedInTypology (p : SemanticParameter) : Bool :=
   Aikhenvald2000.allSystems.any (λ sys =>
-    sys.preferredSemantics.any (· == p))
+    sys.semantics.any (· == p))
 
 /-- Animacy is attested in the typological data. -/
-theorem animacy_attested : isAttestedInTypology .animacy = true := by native_decide
+theorem animacy_attested : isAttestedInTypology .animacy = true := by decide
 
 /-- Humanness is attested in the typological data. -/
-theorem humanness_attested : isAttestedInTypology .humanness = true := by native_decide
+theorem humanness_attested : isAttestedInTypology .humanness = true := by decide
 
 /-- Shape is attested in the typological data. -/
-theorem shape_attested : isAttestedInTypology .shape = true := by native_decide
+theorem shape_attested : isAttestedInTypology .shape = true := by decide
 
 /-- Colour is NOT attested in any system in our typology. -/
-theorem colour_not_attested : isAttestedInTypology .colour = false := by native_decide
+theorem colour_not_attested : isAttestedInTypology .colour = false := by decide
 
 /-- The central asymmetry: animacy is attested, colour is not. -/
 theorem animacy_colour_asymmetry :
     isAttestedInTypology .animacy = true ∧
-    isAttestedInTypology .colour = false := ⟨by native_decide, by native_decide⟩
+    isAttestedInTypology .colour = false := ⟨by decide, by decide⟩
 
 -- ============================================================================
 -- §2: Predictive Power — Conditional Entropy (Table 6)

--- a/Linglib/Studies/Sudo2016.lean
+++ b/Linglib/Studies/Sudo2016.lean
@@ -604,16 +604,10 @@ theorem sudo_disagrees_with_chierchia_on_japanese :
 /-! ## §8: Framework-applicability
 
 Sudo's blocking-principle account (eqs. 10/15/16) presupposes that the
-target language has *obligatory overt classifiers in the lexicon* —
-that is what blocks the silent ∪-operator.
-`System.IsObligatory` is the input-shape requirement;
-Sudo's framework applies iff it holds. Languages where numerals combine
-with bare nouns (no obligatory CL) do not provide the right input. -/
-
-/-- Sudo's framework applies to a language with classifier system `cs`
-    iff `cs.IsObligatory` — the lexical input that Sudo's silent
-    ∪-operator gets blocked by. -/
-abbrev frameworkApplies (cs : NounCategorization.System) : Prop :=
-  cs.IsObligatory
+target language has *obligatory overt classifiers in the lexicon* — that is
+what blocks the silent ∪-operator — so it applies to a language exactly when
+its Fragment records `classifierObligatory := true`; languages where numerals
+combine with bare nouns (`Armenian.classifierObligatory = false`) do not
+provide the right input. -/
 
 end Sudo2016


### PR DESCRIPTION
Retires the bundled `NounCategorization.System` profile record: each `Fragments/<Lang>/ClassifierSystem.lean` now records Aikhenvald's parameters field by field (`classifierType`, `classifierScopes`, `classifierAssignment`, `classifierRealizations`, `classifierAgreement`, `classifierObligatory`, `classifierDefault`, `classifierSemantics`, `obligatoryNumber`, and `pluralClassifierCooccur` where a paper records it), with defaults and semantics derived from the inventories; the assembled (A)–(G) record is study-local `Aikhenvald2000.Parameters`. Downing1996 and Chierchia1998 read the fragment fields instead of importing the 2000 study (chronology); PSC2026 drops `native_decide`; Sudo2016's unconsumed `frameworkApplies` is cut.
- Substrate cleanse of `Features/NounCategorization/Basic.lean` against the book: mathlib register, `ClassifierType` doc corrected (two to ten), `SurfaceRealization` gains apophony (Table 15.3), `SemanticParameter` gains §11.1.1's direction, interioricity, constitution, nature and kinship, `ClassifierEntry` derives `DecidableEq` with a `Prop` `Encodes`.