### PR TITLE
refactor(Studies/Aikhenvald2004): kinds of system from Table 2.1

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2956,3 +2956,4 @@ import Linglib.Data.Examples.Adger2025
 import Linglib.Data.Examples.AfkirZellou2025
 import Linglib.Data.Examples.AghaJeretic2026
 import Linglib.Data.Examples.Ahn2015
+import Linglib.Data.Examples.Aikhenvald2004

--- a/Linglib/Data/Examples/Aikhenvald2004.json
+++ b/Linglib/Data/Examples/Aikhenvald2004.json
@@ -1,0 +1,281 @@
+[
+  {
+    "id": "aikhenvald2004_ex1_1",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(1.1)"},
+    "language": "tari1256",
+    "primaryText": "Juse iɾida di-manika-ka",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Juse", "José"], ["iɾida", "football"], ["di-manika-ka", "3sgnf-play-REC.P.VIS"]
+    ],
+    "translation": "José has played football (we saw it)",
+    "context": "The speaker saw José play.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "D1"],
+      ["cell", "visual"],
+      ["source", "visual"]
+    ],
+    "comment": "Tariana's five-choice system: the evidential -ka is fused with recent past tense; omitting an evidential is ungrammatical."
+  },
+  {
+    "id": "aikhenvald2004_ex1_2",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(1.2)"},
+    "language": "tari1256",
+    "primaryText": "Juse iɾida di-manika-mahka",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Juse", "José"], ["iɾida", "football"], ["di-manika-mahka", "3sgnf-play-REC.P.NONVIS"]
+    ],
+    "translation": "José has played football (we heard it)",
+    "context": "The speaker heard the noise of a game but could not see it.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "D1"],
+      ["cell", "nonvisualSensory"],
+      ["source", "nonvisual"]
+    ],
+    "comment": "Tariana's five-choice system: the evidential -mahka is fused with recent past tense; omitting an evidential is ungrammatical."
+  },
+  {
+    "id": "aikhenvald2004_ex1_3",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(1.3)"},
+    "language": "tari1256",
+    "primaryText": "Juse iɾida di-manika-nihka",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Juse", "José"], ["iɾida", "football"], ["di-manika-nihka", "3sgnf-play-REC.P.INFR"]
+    ],
+    "translation": "José has played football (we infer it from visual evidence)",
+    "context": "The football and José's boots are gone and crowds return from the ground.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "D1"],
+      ["cell", "inferred"],
+      ["source", "inference"]
+    ],
+    "comment": "Tariana's five-choice system: the evidential -nihka is fused with recent past tense; omitting an evidential is ungrammatical."
+  },
+  {
+    "id": "aikhenvald2004_ex1_4",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(1.4)"},
+    "language": "tari1256",
+    "primaryText": "Juse iɾida di-manika-sika",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Juse", "José"], ["iɾida", "football"], ["di-manika-sika", "3sgnf-play-REC.P.ASSUM"]
+    ],
+    "translation": "José has played football (we assume this on the basis of what we already know)",
+    "context": "José is out on a Sunday afternoon, when he usually plays.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "D1"],
+      ["cell", "assumed"],
+      ["source", "assumption"]
+    ],
+    "comment": "Tariana's five-choice system: the evidential -sika is fused with recent past tense; omitting an evidential is ungrammatical."
+  },
+  {
+    "id": "aikhenvald2004_ex1_5",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(1.5)"},
+    "language": "tari1256",
+    "primaryText": "Juse iɾida di-manika-pidaka",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Juse", "José"], ["iɾida", "football"], ["di-manika-pidaka", "3sgnf-play-REC.P.REP"]
+    ],
+    "translation": "José has played football (we were told)",
+    "context": "Someone told the speaker.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "D1"],
+      ["cell", "reported"],
+      ["source", "report"]
+    ],
+    "comment": "Tariana's five-choice system: the evidential -pidaka is fused with recent past tense; omitting an evidential is ungrammatical."
+  },
+  {
+    "id": "aikhenvald2004_ex2_16",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.16)"},
+    "language": "nucl1301",
+    "primaryText": "bakan hasta-ymış",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["bakan", "minister"], ["hasta-ymış", "sick-NONFIRSTH.COP"]
+    ],
+    "translation": "The minister is reportedly sick",
+    "context": "Said by somebody told about the sickness.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "A2"],
+      ["cell", "nonfirsthand"],
+      ["source", "report"]
+    ],
+    "comment": "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+  },
+  {
+    "id": "aikhenvald2004_ex2_17",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.17)"},
+    "language": "nucl1301",
+    "primaryText": "uyu-muş-um",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["uyu-muş-um", "sleep-NONFIRSTH.PAST-1sg"]
+    ],
+    "translation": "I have obviously slept",
+    "context": "Said by somebody who has just woken up.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "A2"],
+      ["cell", "nonfirsthand"],
+      ["source", "inference"]
+    ],
+    "comment": "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+  },
+  {
+    "id": "aikhenvald2004_ex2_18",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.18)"},
+    "language": "nucl1301",
+    "primaryText": "iyi çal-ıyor-muş",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["iyi", "good"], ["çal-ıyor-muş", "play-INTRATERM.ASP-NONFIRSTH.COP"]
+    ],
+    "translation": "She is, as I hear, playing well",
+    "context": "Said by somebody listening to her play.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "A2"],
+      ["cell", "nonfirsthand"],
+      ["source", "nonvisual"]
+    ],
+    "comment": "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+  },
+  {
+    "id": "aikhenvald2004_ex2_40",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.40)"},
+    "language": "jauj1238",
+    "primaryText": "Chay-chruu-mi achka wamla-pis walashr-pis alma-ku-lkaa-ña",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Chay-chruu-mi", "this-LOC-DIR.EV"], ["achka", "many"], ["wamla-pis", "girl-TOO"],
+      ["walashr-pis", "boy-TOO"], ["alma-ku-lkaa-ña", "bathe-REFL-IMPF.PL-NARR.PAST"]
+    ],
+    "translation": "Many girls and boys were swimming (I saw them)",
+    "context": "The speaker saw them.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "B1"],
+      ["cell", "firsthand"],
+      ["source", "visual"]
+    ],
+    "comment": "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+  },
+  {
+    "id": "aikhenvald2004_ex2_41",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.41)"},
+    "language": "jauj1238",
+    "primaryText": "Daañu pawa-shra-si ka-ya-n-chr-ari",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Daañu", "field"], ["pawa-shra-si", "finish-PART-EVEN"],
+      ["ka-ya-n-chr-ari", "be-IMPF-3-INFR-EMPH"]
+    ],
+    "translation": "It (the field) might be completely destroyed (I infer)",
+    "context": "The speaker infers it.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "B1"],
+      ["cell", "inferred"],
+      ["source", "inference"]
+    ],
+    "comment": "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+  },
+  {
+    "id": "aikhenvald2004_ex2_42",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(2.42)"},
+    "language": "jauj1238",
+    "primaryText": "Ancha-p-shi wa'a-chi-nki wamla-a-ta",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ancha-p-shi", "too.much-GEN-REP"], ["wa'a-chi-nki", "cry-CAUS-2"],
+      ["wamla-a-ta", "girl-1p-ACC"]
+    ],
+    "translation": "You make my daughter cry too much (they tell me)",
+    "context": "The speaker was told.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "B1"],
+      ["cell", "reported"],
+      ["source", "report"]
+    ],
+    "comment": "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+  },
+  {
+    "id": "aikhenvald2004_ex4_7",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(4.7)"},
+    "language": "nucl1302",
+    "primaryText": "varsken-s ianvr-is rva-s p'irvel-ad u-c'am-eb-i-a susanik'-i",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["varsken-s", "Varsken-DAT"], ["ianvr-is", "January-GEN"], ["rva-s", "8-DAT"],
+      ["p'irvel-ad", "first-ADV"], ["u-c'am-eb-i-a", "OV-torture-TS-PERF-her"],
+      ["susanik'-i", "Shushanik'-NOM"]
+    ],
+    "translation": "Varsken apparently first tortured Shushanik on 8th January",
+    "context": "A past action the speaker did not witness but assumes from a present result or a report.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["strategy", "perfect"],
+      ["source", "nonfirsthand"]
+    ],
+    "comment": "The Georgian perfect's non-firsthand use is an extension of its resultative meaning, alongside present-perfect, negated-past and optative uses, so the perfect is an evidentiality strategy rather than an evidential; example after Hewitt."
+  },
+  {
+    "id": "aikhenvald2004_ex4_55",
+    "source": {"bibkey": "aikhenvald-2004", "paperLabel": "(4.55)"},
+    "language": "bulg1262",
+    "primaryText": "Dumat, zmejat sljazăl v našata niva",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dumat", "think.PRES.3PL"], ["zmejat", "dragon"], ["sljazăl", "come.down.REPORTIVE.SG"],
+      ["v", "into"], ["našata", "our"], ["niva", "field"]
+    ],
+    "translation": "They think that the dragon would seem to have come down into our field (not very likely)",
+    "context": "Reported information the speaker distances themself from.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["system", "A2"],
+      ["cell", "nonfirsthand"],
+      ["source", "report"],
+      ["extension", "epistemic"]
+    ],
+    "comment": "The Bulgarian non-firsthand carries an epistemic overtone of distance: the speaker is unwilling to bear responsibility for the claim; example after Gvozdanović."
+  }
+]

--- a/Linglib/Data/Examples/Aikhenvald2004.lean
+++ b/Linglib/Data/Examples/Aikhenvald2004.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Aikhenvald2004` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Aikhenvald2004.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Aikhenvald2004.Examples`.
+-/
+
+namespace Aikhenvald2004.Examples
+
+open Data.Examples
+
+def ex1_1 : LinguisticExample :=
+  { id := "aikhenvald2004_ex1_1"
+    source := ⟨"aikhenvald-2004", "(1.1)"⟩
+    reportedIn := none
+    language := "tari1256"
+    primaryText := "Juse iɾida di-manika-ka"
+    discourseSegments := []
+    glossedTokens := [("Juse", "José"), ("iɾida", "football"), ("di-manika-ka", "3sgnf-play-REC.P.VIS")]
+    translation := "José has played football (we saw it)"
+    context := "The speaker saw José play."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "D1"), ("cell", "visual"), ("source", "visual")]
+    comment := "Tariana's five-choice system: the evidential -ka is fused with recent past tense; omitting an evidential is ungrammatical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1_2 : LinguisticExample :=
+  { id := "aikhenvald2004_ex1_2"
+    source := ⟨"aikhenvald-2004", "(1.2)"⟩
+    reportedIn := none
+    language := "tari1256"
+    primaryText := "Juse iɾida di-manika-mahka"
+    discourseSegments := []
+    glossedTokens := [("Juse", "José"), ("iɾida", "football"), ("di-manika-mahka", "3sgnf-play-REC.P.NONVIS")]
+    translation := "José has played football (we heard it)"
+    context := "The speaker heard the noise of a game but could not see it."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "D1"), ("cell", "nonvisualSensory"), ("source", "nonvisual")]
+    comment := "Tariana's five-choice system: the evidential -mahka is fused with recent past tense; omitting an evidential is ungrammatical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1_3 : LinguisticExample :=
+  { id := "aikhenvald2004_ex1_3"
+    source := ⟨"aikhenvald-2004", "(1.3)"⟩
+    reportedIn := none
+    language := "tari1256"
+    primaryText := "Juse iɾida di-manika-nihka"
+    discourseSegments := []
+    glossedTokens := [("Juse", "José"), ("iɾida", "football"), ("di-manika-nihka", "3sgnf-play-REC.P.INFR")]
+    translation := "José has played football (we infer it from visual evidence)"
+    context := "The football and José's boots are gone and crowds return from the ground."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "D1"), ("cell", "inferred"), ("source", "inference")]
+    comment := "Tariana's five-choice system: the evidential -nihka is fused with recent past tense; omitting an evidential is ungrammatical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1_4 : LinguisticExample :=
+  { id := "aikhenvald2004_ex1_4"
+    source := ⟨"aikhenvald-2004", "(1.4)"⟩
+    reportedIn := none
+    language := "tari1256"
+    primaryText := "Juse iɾida di-manika-sika"
+    discourseSegments := []
+    glossedTokens := [("Juse", "José"), ("iɾida", "football"), ("di-manika-sika", "3sgnf-play-REC.P.ASSUM")]
+    translation := "José has played football (we assume this on the basis of what we already know)"
+    context := "José is out on a Sunday afternoon, when he usually plays."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "D1"), ("cell", "assumed"), ("source", "assumption")]
+    comment := "Tariana's five-choice system: the evidential -sika is fused with recent past tense; omitting an evidential is ungrammatical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1_5 : LinguisticExample :=
+  { id := "aikhenvald2004_ex1_5"
+    source := ⟨"aikhenvald-2004", "(1.5)"⟩
+    reportedIn := none
+    language := "tari1256"
+    primaryText := "Juse iɾida di-manika-pidaka"
+    discourseSegments := []
+    glossedTokens := [("Juse", "José"), ("iɾida", "football"), ("di-manika-pidaka", "3sgnf-play-REC.P.REP")]
+    translation := "José has played football (we were told)"
+    context := "Someone told the speaker."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "D1"), ("cell", "reported"), ("source", "report")]
+    comment := "Tariana's five-choice system: the evidential -pidaka is fused with recent past tense; omitting an evidential is ungrammatical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_16 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_16"
+    source := ⟨"aikhenvald-2004", "(2.16)"⟩
+    reportedIn := none
+    language := "nucl1301"
+    primaryText := "bakan hasta-ymış"
+    discourseSegments := []
+    glossedTokens := [("bakan", "minister"), ("hasta-ymış", "sick-NONFIRSTH.COP")]
+    translation := "The minister is reportedly sick"
+    context := "Said by somebody told about the sickness."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "A2"), ("cell", "nonfirsthand"), ("source", "report")]
+    comment := "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_17 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_17"
+    source := ⟨"aikhenvald-2004", "(2.17)"⟩
+    reportedIn := none
+    language := "nucl1301"
+    primaryText := "uyu-muş-um"
+    discourseSegments := []
+    glossedTokens := [("uyu-muş-um", "sleep-NONFIRSTH.PAST-1sg")]
+    translation := "I have obviously slept"
+    context := "Said by somebody who has just woken up."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "A2"), ("cell", "nonfirsthand"), ("source", "inference")]
+    comment := "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_18 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_18"
+    source := ⟨"aikhenvald-2004", "(2.18)"⟩
+    reportedIn := none
+    language := "nucl1301"
+    primaryText := "iyi çal-ıyor-muş"
+    discourseSegments := []
+    glossedTokens := [("iyi", "good"), ("çal-ıyor-muş", "play-INTRATERM.ASP-NONFIRSTH.COP")]
+    translation := "She is, as I hear, playing well"
+    context := "Said by somebody listening to her play."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "A2"), ("cell", "nonfirsthand"), ("source", "nonvisual")]
+    comment := "The Turkish non-firsthand covers report, inference and non-visual perception; examples after Johanson."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_40 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_40"
+    source := ⟨"aikhenvald-2004", "(2.40)"⟩
+    reportedIn := none
+    language := "jauj1238"
+    primaryText := "Chay-chruu-mi achka wamla-pis walashr-pis alma-ku-lkaa-ña"
+    discourseSegments := []
+    glossedTokens := [("Chay-chruu-mi", "this-LOC-DIR.EV"), ("achka", "many"), ("wamla-pis", "girl-TOO"), ("walashr-pis", "boy-TOO"), ("alma-ku-lkaa-ña", "bathe-REFL-IMPF.PL-NARR.PAST")]
+    translation := "Many girls and boys were swimming (I saw them)"
+    context := "The speaker saw them."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "B1"), ("cell", "firsthand"), ("source", "visual")]
+    comment := "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_41 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_41"
+    source := ⟨"aikhenvald-2004", "(2.41)"⟩
+    reportedIn := none
+    language := "jauj1238"
+    primaryText := "Daañu pawa-shra-si ka-ya-n-chr-ari"
+    discourseSegments := []
+    glossedTokens := [("Daañu", "field"), ("pawa-shra-si", "finish-PART-EVEN"), ("ka-ya-n-chr-ari", "be-IMPF-3-INFR-EMPH")]
+    translation := "It (the field) might be completely destroyed (I infer)"
+    context := "The speaker infers it."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "B1"), ("cell", "inferred"), ("source", "inference")]
+    comment := "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2_42 : LinguisticExample :=
+  { id := "aikhenvald2004_ex2_42"
+    source := ⟨"aikhenvald-2004", "(2.42)"⟩
+    reportedIn := none
+    language := "jauj1238"
+    primaryText := "Ancha-p-shi wa'a-chi-nki wamla-a-ta"
+    discourseSegments := []
+    glossedTokens := [("Ancha-p-shi", "too.much-GEN-REP"), ("wa'a-chi-nki", "cry-CAUS-2"), ("wamla-a-ta", "girl-1p-ACC")]
+    translation := "You make my daughter cry too much (they tell me)"
+    context := "The speaker was told."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "B1"), ("cell", "reported"), ("source", "report")]
+    comment := "Wanka Quechua's three-choice system: direct -mi, inferred (conjectural) -chr(a), reported -shi; examples after Floyd."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4_7 : LinguisticExample :=
+  { id := "aikhenvald2004_ex4_7"
+    source := ⟨"aikhenvald-2004", "(4.7)"⟩
+    reportedIn := none
+    language := "nucl1302"
+    primaryText := "varsken-s ianvr-is rva-s p'irvel-ad u-c'am-eb-i-a susanik'-i"
+    discourseSegments := []
+    glossedTokens := [("varsken-s", "Varsken-DAT"), ("ianvr-is", "January-GEN"), ("rva-s", "8-DAT"), ("p'irvel-ad", "first-ADV"), ("u-c'am-eb-i-a", "OV-torture-TS-PERF-her"), ("susanik'-i", "Shushanik'-NOM")]
+    translation := "Varsken apparently first tortured Shushanik on 8th January"
+    context := "A past action the speaker did not witness but assumes from a present result or a report."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("strategy", "perfect"), ("source", "nonfirsthand")]
+    comment := "The Georgian perfect's non-firsthand use is an extension of its resultative meaning, alongside present-perfect, negated-past and optative uses, so the perfect is an evidentiality strategy rather than an evidential; example after Hewitt."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4_55 : LinguisticExample :=
+  { id := "aikhenvald2004_ex4_55"
+    source := ⟨"aikhenvald-2004", "(4.55)"⟩
+    reportedIn := none
+    language := "bulg1262"
+    primaryText := "Dumat, zmejat sljazăl v našata niva"
+    discourseSegments := []
+    glossedTokens := [("Dumat", "think.PRES.3PL"), ("zmejat", "dragon"), ("sljazăl", "come.down.REPORTIVE.SG"), ("v", "into"), ("našata", "our"), ("niva", "field")]
+    translation := "They think that the dragon would seem to have come down into our field (not very likely)"
+    context := "Reported information the speaker distances themself from."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("system", "A2"), ("cell", "nonfirsthand"), ("source", "report"), ("extension", "epistemic")]
+    comment := "The Bulgarian non-firsthand carries an epistemic overtone of distance: the speaker is unwilling to bear responsibility for the claim; example after Gvozdanović."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex1_1, ex1_2, ex1_3, ex1_4, ex1_5, ex2_16, ex2_17, ex2_18, ex2_40, ex2_41, ex2_42, ex4_7, ex4_55]
+
+end Aikhenvald2004.Examples

--- a/Linglib/Fragments/Abkhaz/Evidentiality.lean
+++ b/Linglib/Fragments/Abkhaz/Evidentiality.lean
@@ -1,31 +1,25 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Abkhaz Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Abkhaz evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (verbal-affix coding).
-[aikhenvald-2004] analyzes Abkhaz as 2-way direct/indirect (fused with
-TAM). Studies-side override.
+Abkhaz has a two-choice system of Aikhenvald's type A2: a dedicated, tense-neutral
+non-firsthand affix (*-zaap'* with present, aorist, perfect and one future; *-zaarən* with
+imperfect, past indefinite, pluperfect and one future conditional) covering inference from
+results and verbal report, restricted to declarative main clauses.
+
+## References
+
+* [aikhenvald-2004], §2.1
+* [de-haan-2013]
 -/
 
 namespace Abkhaz.Evidentiality
 
-/-! ### Typed evidential inventory
-
-Abkhaz's 2-way direct/indirect contrast per [aikhenvald-2004]: the
-finite-verb form (direct) vs the nonfinite + copula construction
-(indirect, covering inference and report). Fused with TAM. -/
-
 open Semantics.Evidential
 
+/-- The non-firsthand affixes *-zaap'* and *-zaarən*. -/
 def evidentials : List Entry :=
-  [ .direct      { form := "finite verb",       exponent := .tamFusion },
-    .inferential { form := "nonfinite + copula", exponent := .tamFusion } ]
-
-example : evidentials.length = 2 := by decide
-example : (evidentials.filter Entry.IsDirect).length = 1 := by decide
-example : (evidentials.filter Entry.IsInferential).length = 1 := by decide
-example : (evidentials.filter Entry.IsReportative).length = 0 := by decide
+  [ .nonfirsthand { form := "-zaap'/-zaarən", exponent := .verbalAffix } ]
 
 end Abkhaz.Evidentiality

--- a/Linglib/Fragments/Finnish/Evidentiality.lean
+++ b/Linglib/Fragments/Finnish/Evidentiality.lean
@@ -1,24 +1,20 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Finnish Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Finnish evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (de Haan counts modal verbs
-as grammatical evidentials). [aikhenvald-2004] treats Finnish as having
-no grammatical evidentials; modality via modal verbs (*voida* 'can',
-*täytyä* 'must', *saattaa* 'may'). Studies-side override.
+Finnish has no grammatical evidentials: reportative and inferential meanings are carried by
+modal verbs and by the past participle construction, strategy-level rather than grammatical
+marking, so the inventory is empty. WALS codes the language as indirect-only; the language
+is not discussed in [aikhenvald-2004].
+
+## References
+
+* [de-haan-2013]
 -/
 
 namespace Finnish.Evidentiality
 
-/-! ### Typed evidential inventory (Aikhenvald-strict view)
-
-No grammatical evidentials per [aikhenvald-2004]. WALS divergence
-(modal verbs) is documented in `Studies/Aikhenvald2004.lean`. -/
-
 def evidentials : List Semantics.Evidential.Entry := []
-
-example : evidentials.length = 0 := by decide
 
 end Finnish.Evidentiality

--- a/Linglib/Fragments/Georgian/Evidentiality.lean
+++ b/Linglib/Fragments/Georgian/Evidentiality.lean
@@ -1,30 +1,23 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Georgian Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Georgian evidentiality
 
-WALS [de-haan-2013] F77A: `directAndIndirect`. [aikhenvald-2004]
-analyzes Georgian's evidential perfect ("I screeve") as marking inference
-or report only — `indirectOnly`. Studies-side override.
+Georgian has no grammatical evidentials: the perfect (the "first evidential" screeve) is used
+for past events the speaker did not witness but infers from a present result or was told
+about, yet this is an extension of its resultative meaning alongside present-perfect, negated
+past and optative uses, so Aikhenvald treats it as an evidentiality strategy rather than
+evidentiality proper. WALS codes the language as having direct and indirect evidentials.
+
+## References
+
+* [aikhenvald-2004], §2.1.2, §4.2
+* [de-haan-2013]
 -/
 
 namespace Georgian.Evidentiality
 
-/-! ### Typed evidential inventory
-
-Georgian's evidential perfect (the I screeve), marking inference or
-report. Per [aikhenvald-2004], this is indirect-only. Fused
-with TAM (the perfect/screeve system). -/
-
-open Semantics.Evidential
-
-def evidentials : List Entry :=
-  [ .inferential { form := "evidential perfect (I screeve)",
-                   exponent := .tamFusion } ]
-
-example : evidentials.length = 1 := by decide
-example : (evidentials.filter Entry.IsDirect).length = 0 := by decide
-example : (evidentials.filter Entry.IsInferential).length = 1 := by decide
+/-- No evidentials proper; the perfect is an evidentiality strategy. -/
+def evidentials : List Semantics.Evidential.Entry := []
 
 end Georgian.Evidentiality

--- a/Linglib/Fragments/German/Evidentiality.lean
+++ b/Linglib/Fragments/German/Evidentiality.lean
@@ -1,24 +1,20 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# German Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# German evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (de Haan counts modal verbs
-*sollen* / *wollen* as grammatical reportatives). [aikhenvald-2004]'s
-stricter criterion treats German as having no grammatical evidentials;
-Studies-side override in `Studies/Aikhenvald2004.lean`.
+German has no grammatical evidentials: the reportative use of the present conditional
+(Konjunktiv I) in reported speech is an evidentiality strategy, as are the modal verbs
+*sollen* and *wollen*, so the inventory is empty. WALS codes the language as indirect-only.
+
+## References
+
+* [aikhenvald-2004], §4.8
+* [de-haan-2013]
 -/
 
 namespace German.Evidentiality
 
-/-! ### Typed evidential inventory (Aikhenvald-strict view)
-
-No grammatical evidentials per [aikhenvald-2004]. WALS divergence
-(modal verbs *sollen*/*wollen*) is documented in `Studies/Aikhenvald2004.lean`. -/
-
 def evidentials : List Semantics.Evidential.Entry := []
-
-example : evidentials.length = 0 := by decide
 
 end German.Evidentiality

--- a/Linglib/Fragments/Japanese/Evidentiality.lean
+++ b/Linglib/Fragments/Japanese/Evidentiality.lean
@@ -1,23 +1,22 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Japanese Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Japanese evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (de Haan classifies *soo da*,
-*rashii* as grammatical evidentials). [aikhenvald-2004] treats these as
-modal rather than evidential; Studies-side override.
+Japanese has several optional devices for marking information source — the reported
+*soo da* and the inferential *yoo da*, *rashii* and *soo da* — but no evidentiality as a
+unitary grammatical category, since the specification is not obligatory; at most the reported
+form could be taken as an A3 system on its own. The inventory is empty. WALS codes the
+language as indirect-only.
+
+## References
+
+* [aikhenvald-2004], §3.4
+* [de-haan-2013]
 -/
 
 namespace Japanese.Evidentiality
 
-/-! ### Typed evidential inventory (Aikhenvald-strict view)
-
-No grammatical evidentials per [aikhenvald-2004]. WALS divergence
-(modal *soo da* / *rashii*) is documented in `Studies/Aikhenvald2004.lean`. -/
-
 def evidentials : List Semantics.Evidential.Entry := []
-
-example : evidentials.length = 0 := by decide
 
 end Japanese.Evidentiality

--- a/Linglib/Fragments/Kashaya/Evidentiality.lean
+++ b/Linglib/Fragments/Kashaya/Evidentiality.lean
@@ -44,7 +44,7 @@ def evidentials : List Entry :=
     .inferential { form := "-qá",         exponent := .verbalAffix },
     .inferential { form := "-bi",         exponent := .verbalAffix },
     .reportative { form := "-do",         exponent := .verbalAffix,
-                   sourceIdentity := .identified } ]
+                   sourceIdentity := .unidentified } ]
 
 example : evidentials.length = 6 := by decide
 example : (evidentials.filter Entry.IsDirect).length = 3 := by decide

--- a/Linglib/Fragments/Korean/Evidentiality.lean
+++ b/Linglib/Fragments/Korean/Evidentiality.lean
@@ -1,23 +1,20 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Korean Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Korean evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (de Haan counts *-deo-*
-retrospective as grammatical evidential). [aikhenvald-2004] treats it
-as not classified as grammatical evidential; Studies-side override.
+Korean has no grammatical evidentials: the retrospective mood is not a primarily evidential
+form, and reported and inferential meanings are carried by sentence-final constructions, so
+the inventory is empty. WALS codes the language as indirect-only.
+
+## References
+
+* [aikhenvald-2004], §7.2
+* [de-haan-2013]
 -/
 
 namespace Korean.Evidentiality
 
-/-! ### Typed evidential inventory (Aikhenvald-strict view)
-
-No grammatical evidentials per [aikhenvald-2004]. WALS divergence
-(retrospective `-deo-`) is documented in `Studies/Aikhenvald2004.lean`. -/
-
 def evidentials : List Semantics.Evidential.Entry := []
-
-example : evidentials.length = 0 := by decide
 
 end Korean.Evidentiality

--- a/Linglib/Fragments/Romance/French/Evidentiality.lean
+++ b/Linglib/Fragments/Romance/French/Evidentiality.lean
@@ -1,24 +1,21 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# French Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# French evidentiality
 
-WALS [de-haan-2013] F77A: `indirectOnly` (de Haan codes the conditional
-as a grammatical reportative). [aikhenvald-2004]'s stricter criterion
-treats French as having no grammatical evidentials; Studies-side override
-in `Studies/Aikhenvald2004.lean`.
+French has no grammatical evidentials: the conditional's reportative use (the journalistic
+conditional) is one of the best-known evidentiality strategies, a non-evidential category with
+an evidential extension, so the inventory is empty. WALS, counting the conditional as a
+grammatical reportative, codes the language as indirect-only.
+
+## References
+
+* [aikhenvald-2004], §4.1
+* [de-haan-2013]
 -/
 
 namespace French.Evidentiality
 
-/-! ### Typed evidential inventory (Aikhenvald-strict view)
-
-No grammatical evidentials per [aikhenvald-2004]. WALS divergence
-(conditional reportative use) is documented in `Studies/Aikhenvald2004.lean`. -/
-
 def evidentials : List Semantics.Evidential.Entry := []
-
-example : evidentials.length = 0 := by decide
 
 end French.Evidentiality

--- a/Linglib/Fragments/Slavic/Bulgarian/Evidentiality.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/Evidentiality.lean
@@ -1,35 +1,27 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Bulgarian Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Bulgarian evidentiality
 
-Two-choice direct vs indirect via the aorist (direct) vs l-form (indirect)
-contrast, fused with TAM. The best-known European language with grammatical
-evidentials. Balkan Sprachbund. WALS and Aikhenvald agree.
+Bulgarian marks non-firsthand information with the *l*-form, fused with tense and aspect,
+which covers inference and report and carries epistemic overtones of distance; the aorist is
+the unmarked counterpart. Aikhenvald classes the system as possibly A2, while noting that
+Balkan Slavic has been drifting toward an A1 system in which the unmarked form comes to signal
+firsthand information. The [cumming-2026] tense-evidential paradigm data are in
+`Fragments/Slavic/Bulgarian/Evidentials.lean`.
 
-Sister to `Fragments/Slavic/Bulgarian/Evidentials.lean` which holds the
-[cumming-2026] tense-evidential paradigm data.
+## References
+
+* [aikhenvald-2004], §2.1, §4.8
+* [de-haan-2013]
 -/
 
 namespace Bulgarian.Evidentiality
 
-/-! ### Typed evidential inventory
-
-Bulgarian's 2-way contrast via aorist (direct) vs l-form (indirect),
-fused with TAM. The l-form covers both inferential and reportative
-meanings — represented here as the inferential kind (the dominant
-inference function); reportative extensions are an Aikhenvald-style
-semantic extension. -/
-
 open Semantics.Evidential
 
+/-- The non-firsthand *l*-form; the aorist is its unmarked counterpart. -/
 def evidentials : List Entry :=
-  [ .direct      { form := "aorist", exponent := .tamFusion },
-    .inferential { form := "l-form", exponent := .tamFusion } ]
-
-example : evidentials.length = 2 := by decide
-example : (evidentials.filter Entry.IsDirect).length = 1 := by decide
-example : (evidentials.filter Entry.IsInferential).length = 1 := by decide
+  [ .nonfirsthand { form := "l-form", exponent := .tamFusion } ]
 
 end Bulgarian.Evidentiality

--- a/Linglib/Fragments/Tariana/Evidentiality.lean
+++ b/Linglib/Fragments/Tariana/Evidentiality.lean
@@ -6,8 +6,8 @@ import Linglib.Semantics.Evidential.Defs
 
 Five-term system in the Vaupés multilingual area: visual, nonvisual,
 inferred, assumed, reported. WALS [de-haan-2013] F77A codes Tariana as
-`directAndIndirect`; [aikhenvald-2004]'s richer typology distinguishes
-the 5-way system. Studies-side override.
+`directAndIndirect`; [aikhenvald-2004] classes it as the five-choice type
+D1 (`Studies/Aikhenvald2004.lean`).
 -/
 
 namespace Tariana.Evidentiality

--- a/Linglib/Fragments/Turkish/Evidentiality.lean
+++ b/Linglib/Fragments/Turkish/Evidentiality.lean
@@ -1,31 +1,25 @@
 import Linglib.Semantics.Evidential.Defs
 
 /-!
-# Turkish Evidentiality
-[de-haan-2013] [aikhenvald-2004]
+# Turkish evidentiality
 
-Two-choice direct vs indirect. Past-tense paradigm contrasts *-DI*
-(witnessed) with *-mIş* (inferred or reported). The canonical
-indirect-evidential of a major language. Fused with TAM. WALS and
-Aikhenvald agree.
+Turkish has a two-choice system of Aikhenvald's type A2: the non-firsthand *-mIş*, covering
+report, inference and non-visual perception, contrasts with evidentiality-neutral forms such as
+the *-DI* past, which do not signal firsthand evidence but leave the source unspecified. The
+non-firsthand is fused with tense and the copula.
+
+## References
+
+* [aikhenvald-2004], §2.1
+* [de-haan-2013]
 -/
 
 namespace Turkish.Evidentiality
 
-/-! ### Typed evidential inventory
-
-Turkish's canonical 2-way contrast: `-DI` (direct/witnessed) vs `-mIş`
-(indirect, covering inference and report). Fused with past tense. The
-`-mIş` is Aikhenvald's classic example of an A2 non-firsthand marker. -/
-
 open Semantics.Evidential
 
+/-- The non-firsthand *-mIş*; the *-DI* past is evidentiality-neutral, not a firsthand term. -/
 def evidentials : List Entry :=
-  [ .direct      { form := "-DI",  exponent := .tamFusion },
-    .inferential { form := "-mIş", exponent := .tamFusion } ]
-
-example : evidentials.length = 2 := by decide
-example : (evidentials.filter Entry.IsDirect).length = 1 := by decide
-example : (evidentials.filter Entry.IsInferential).length = 1 := by decide
+  [ .nonfirsthand { form := "-mIş", exponent := .tamFusion } ]
 
 end Turkish.Evidentiality

--- a/Linglib/Fragments/Tuyuca/Evidentiality.lean
+++ b/Linglib/Fragments/Tuyuca/Evidentiality.lean
@@ -9,10 +9,8 @@ Five-term system: visual, nonvisual, apparent (inferential), secondhand
 classic description. Vaupés multilingual area.
 
 WALS [de-haan-2013] F77A codes Tuyuca as `directAndIndirect`, lumping
-the 5-term system into the canonical 2-way bucket. [aikhenvald-2004]'s
-richer typology distinguishes 3-or-more systems; the local `EvidentialSystem`
-enum's `threeOrMore` value is the per-Aikhenvald override (Studies-side).
-The `markers` field below preserves the full 5-term inventory.
+the 5-term system into the canonical 2-way bucket; [aikhenvald-2004]
+classes it as the five-choice type D1 (`Studies/Aikhenvald2004.lean`).
 -/
 
 namespace Tuyuca.Evidentiality

--- a/Linglib/Semantics/Evidential/Basic.lean
+++ b/Linglib/Semantics/Evidential/Basic.lean
@@ -44,6 +44,9 @@ inductive Entry.Cell where
   | reported
   /-- Hearsay from a specifically identified source. -/
   | quotative
+  /-- Everything but firsthand evidence under one term: inference, assumption and hearsay
+  (the marked term of A1 and A2 systems). -/
+  | nonfirsthand
   deriving DecidableEq, BEq, Repr, Inhabited
 
 /-- Project a typed `Entry` to its Aikhenvald paradigm cell. -/
@@ -58,21 +61,25 @@ def Entry.cell : Entry → Entry.Cell
   | .reportative ⟨_, _, .unspecified⟩      => .reported
   | .reportative ⟨_, _, .unidentified⟩     => .reported
   | .reportative ⟨_, _, .identified⟩       => .quotative
+  | .nonfirsthand _                        => .nonfirsthand
 
 /-! ### Coarse source and perspective -/
 
-/-- Collapse an Aikhenvald cell to its [willett-1988] coarse source. -/
-def Entry.Cell.toCoarseSource : Entry.Cell → CoarseSource
-  | .firsthand | .visual | .nonvisualSensory | .auditory => .direct
-  | .inferred | .assumed => .inference
-  | .reported | .quotative => .hearsay
+/-- Collapse an Aikhenvald cell to its [willett-1988] coarse source; a
+    non-firsthand term spans inference and hearsay and has none. -/
+def Entry.Cell.toCoarseSource : Entry.Cell → Option CoarseSource
+  | .firsthand | .visual | .nonvisualSensory | .auditory => some .direct
+  | .inferred | .assumed => some .inference
+  | .reported | .quotative => some .hearsay
+  | .nonfirsthand => none
 
-/-- The coarse source of an entry: the three `Entry` kinds are exactly the
-    [willett-1988] tripartition. -/
-def Entry.toCoarseSource : Entry → CoarseSource
-  | .direct _      => .direct
-  | .reportative _ => .hearsay
-  | .inferential _ => .inference
+/-- The coarse source of an entry: the three coarse `Entry` kinds are exactly
+    the [willett-1988] tripartition; a non-firsthand term has none. -/
+def Entry.toCoarseSource : Entry → Option CoarseSource
+  | .direct _       => some .direct
+  | .reportative _  => some .hearsay
+  | .inferential _  => some .inference
+  | .nonfirsthand _ => none
 
 /-- The taxonomy tower commutes: collapsing an entry's Aikhenvald cell
     gives its coarse source. -/
@@ -82,19 +89,26 @@ theorem Entry.cell_toCoarseSource (e : Entry) :
   | direct d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
   | reportative d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
   | inferential d => obtain ⟨_, _, s⟩ := d; cases s <;> rfl
+  | nonfirsthand _ => rfl
 
-/-- Inventory entries declare their coarse source; the evidential
-    perspective derives via the canonical source mapping. -/
+/-- Inventory entries declare their coarse source. -/
 instance : HasCoarseSource Entry where
-  toCoarseSource e := some e.toCoarseSource
+  toCoarseSource := Entry.toCoarseSource
 
-/-- Every inventory entry is nonfuture: all three coarse sources are
-    causally downstream of the described event (T ≤ A) under the
-    canonical mapping. -/
+/-- The perspective of an entry: through the canonical source mapping, with a
+    non-firsthand term retrospective like the inference and hearsay it spans. -/
+instance : HasEvidentialPerspective Entry where
+  toEvidentialPerspective
+    | .nonfirsthand _ => some .retrospective
+    | e => e.toCoarseSource.bind CoarseSource.toEvidentialPerspective
+
+/-- Every inventory entry is nonfuture: every source is causally downstream
+    of the described event (T ≤ A) under the canonical mapping. -/
 theorem Entry.isNonfuture (e : Entry) : IsNonfuture e := by
   cases e with
   | direct _ => exact .inr rfl
   | reportative _ => exact .inl rfl
   | inferential _ => exact .inl rfl
+  | nonfirsthand _ => exact .inl rfl
 
 end Semantics.Evidential

--- a/Linglib/Semantics/Evidential/Defs.lean
+++ b/Linglib/Semantics/Evidential/Defs.lean
@@ -18,8 +18,9 @@ a language's WALS cell is a theorem about its declared evidentials.
 ## Main declarations
 
 * `Evidential` — the base lexical-item record (just `form`).
-* `DirectEvidential`, `ReportativeEvidential`, `InferentialEvidential` —
-  the three Aikhenvald-coarse specializations.
+* `DirectEvidential`, `ReportativeEvidential`, `InferentialEvidential`,
+  `NonfirsthandEvidential` — the specializations: the three coarse sources and
+  the non-firsthand term that subsumes everything but firsthand evidence.
 * `Evidential.Exponent` — realization-strategy enum (analysis-neutral).
 * `DirectSource`, `ReportativeSource`, `InferentialBasis` — the
   [aikhenvald-2004] fine-grained source taxonomies the specializations carry.
@@ -137,14 +138,23 @@ structure InferentialEvidential extends Evidential where
   basis : InferentialBasis := .unspecified
   deriving DecidableEq, Repr
 
+/-- A non-firsthand evidential: one term covering everything but firsthand
+    evidence — inference, assumption, hearsay, and often non-visual
+    perception — the marked term of [aikhenvald-2004]'s two-choice A1 and
+    A2 systems (Turkish *-mIş*, Abkhaz *-zaap'*). -/
+structure NonfirsthandEvidential extends Evidential where
+  exponent : Semantics.Evidential.Exponent
+  deriving DecidableEq, Repr
+
 namespace Semantics.Evidential
 
 /-- An evidential occurrence in a language's inventory: one of the three
-    coarse kinds, carrying its typed payload. -/
+    coarse kinds or a non-firsthand term, carrying its typed payload. -/
 inductive Entry where
-  | direct      (e : DirectEvidential)
-  | reportative (e : ReportativeEvidential)
-  | inferential (e : InferentialEvidential)
+  | direct       (e : DirectEvidential)
+  | reportative  (e : ReportativeEvidential)
+  | inferential  (e : InferentialEvidential)
+  | nonfirsthand (e : NonfirsthandEvidential)
   deriving DecidableEq, Repr
 
 namespace Entry
@@ -173,17 +183,27 @@ def IsInferential : Entry → Prop
 instance : DecidablePred IsInferential := fun e => by
   cases e <;> unfold IsInferential <;> infer_instance
 
+/-- The occurrence is a non-firsthand evidential. -/
+def IsNonfirsthand : Entry → Prop
+  | .nonfirsthand _ => True
+  | _               => False
+
+instance : DecidablePred IsNonfirsthand := fun e => by
+  cases e <;> unfold IsNonfirsthand <;> infer_instance
+
 /-- The realization strategy of an entry. -/
 def exponent : Entry → Exponent
-  | .direct e      => e.exponent
-  | .reportative e => e.exponent
-  | .inferential e => e.exponent
+  | .direct e       => e.exponent
+  | .reportative e  => e.exponent
+  | .inferential e  => e.exponent
+  | .nonfirsthand e => e.exponent
 
 /-- The surface form of an entry. -/
 def form : Entry → String
-  | .direct e      => e.form
-  | .reportative e => e.form
-  | .inferential e => e.form
+  | .direct e       => e.form
+  | .reportative e  => e.form
+  | .inferential e  => e.form
+  | .nonfirsthand e => e.form
 
 end Entry
 

--- a/Linglib/Studies/Aikhenvald2004.lean
+++ b/Linglib/Studies/Aikhenvald2004.lean
@@ -1,414 +1,196 @@
-import Linglib.Data.WALS.Features.F77A
-import Linglib.Data.WALS.Features.F78A
+import Mathlib.Data.Finset.Card
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Semantics.Evidential.Basic
-import Linglib.Fragments.Romance.French.Evidentiality
-import Linglib.Fragments.Japanese.Evidentiality
 import Linglib.Fragments.Turkish.Evidentiality
+import Linglib.Fragments.Abkhaz.Evidentiality
 import Linglib.Fragments.Slavic.Bulgarian.Evidentiality
-import Linglib.Fragments.Georgian.Evidentiality
 import Linglib.Fragments.Quechua.Evidentiality
 import Linglib.Fragments.Tuyuca.Evidentiality
-import Linglib.Fragments.Kashaya.Evidentiality
 import Linglib.Fragments.Tariana.Evidentiality
-import Linglib.Fragments.Abkhaz.Evidentiality
+import Linglib.Fragments.Kashaya.Evidentiality
+import Linglib.Fragments.Romance.French.Evidentiality
+import Linglib.Fragments.Japanese.Evidentiality
+import Linglib.Data.Examples.Aikhenvald2004
 
 /-!
-# Aikhenvald (2004): Evidentiality typology
-[aikhenvald-2004] [de-haan-2013] [barnes-1984] [oswalt-1986]
+# Evidentiality systems by number of choices
 
-This file holds only the **analytical disagreements**: where
-[aikhenvald-2004]'s own paradigm-type letter for a language differs
-from `AikhenvaldSystem.fromInventory` applied to the
-Fragment-declared inventory, or where the resulting classification differs
-from [de-haan-2013]'s WALS Ch 77 coding.
+Aikhenvald classifies the world's grammatical evidentiality systems by how many information
+sources a speaker must choose among and how those sources are grouped: five kinds with two
+choices (A1–A5), five with three (B1–B5), three with four (C1–C3), and one with five (D1), each
+a grouping of six recurrent semantic parameters — visual, non-visual sensory, inference,
+assumption, hearsay and quotative — into the terms of a paradigm. Four of the kinds (A2, A3,
+A5, B5) are organized around an evidentiality-neutral "everything else" term; the rest oppose
+marked terms only. What counts as an evidential is a form whose main meaning is information
+source: the perfects of Georgian and the Iranian languages, the French conditional and the
+Japanese sentence-final devices are evidentiality strategies, not evidentials.
 
-Per-language Aikhenvald classifications are *derived* in
-`Typology/Evidentiality.lean`; per-language inventories live in
-`Fragments/{Lang}/Evidentiality.lean`. There are no per-language
-verification examples here — those would be unit tests of the derivation
-algorithm, not theorems about the typology.
+Here each kind is the set of cells it distinguishes (`Kind.cells`, Table 2.1 together with the
+marked terms of the everything-else kinds, a firsthand term occupying the visual column), and
+the kind of a language is derived from its Fragment inventory (`kind`). The letters count
+choices (`choices_eq_card_cells`), no system expresses all six parameters
+(`card_cells_le_five`), D1 is the only five-choice kind (`eq_D1_of_choices`), and B1 is the
+grouping that matches Willett's tripartition (`B1_willett`). Turkish, Abkhaz and Bulgarian
+derive as A2 once their unmarked pasts are read as evidentiality-neutral rather than firsthand
+(`turkish`, `abkhaz`, `bulgarian`), Cuzco Quechua as B1, Tuyuca and Tariana as D1, while
+Kashaya's factual/visual, auditory, inferential and reported terms fit no kind
+(`kashaya_unclassified`), and the strategy languages have nothing to classify (`kind_nil`).
+The book's own illustrations exhaust the cells of their systems (`tariana_illustration`,
+`wanka_illustration`, `turkish_illustration`).
 
-## Disagreements recorded
+## References
 
-* **§1**: 4 paper-vs-derived disagreements (Turkish, Bulgarian, Abkhaz,
-  Kashaya). Each is an analytical choice about which morphemes count as
-  marked evidentials.
-* **§2**: Aikhenvald-vs-WALS disagreements for languages where the two
-  classifications diverge. Three representative cases.
+* [aikhenvald-2004]
+* [barnes-1984]
+* [oswalt-1986]
+* [willett-1988]
 -/
 
 namespace Aikhenvald2004
 
 open Semantics.Evidential
-
-/-! ### Evidentiality typology (consolidated from the former Typology/Modality + Typology/Evidentiality; single-paper [aikhenvald-2004] apparatus) -/
-
-
--- ============================================================================
--- §1. Ch 77 / 78 substrate enums
--- ============================================================================
-
-/-- WALS Ch 77: how many evidential distinctions a language grammaticalises.
-    Extends the WALS 3-way classification with a `threeOrMore` value to
-    distinguish Quechua/Tuyuca-style rich systems from canonical 2-way
-    systems (Turkish/Bulgarian). -/
-inductive EvidentialSystem where
-  /-- No grammatical evidentials (e.g. English, French, Mandarin). -/
-  | noGrammatical
-  /-- Indirect evidential only (e.g. Georgian, West Greenlandic). -/
-  | indirectOnly
-  /-- Two-choice direct vs indirect (e.g. Turkish, Bulgarian, Tibetan, Abkhaz). -/
-  | directAndIndirect
-  /-- Three or more evidential choices (e.g. Quechua, Tuyuca, Aymara, Tariana). -/
-  | threeOrMore
-  deriving DecidableEq, BEq, Repr
-
-namespace EvidentialSystem
-
-/-- Whether a language has any grammatical evidential marking. -/
-def HasEvidentials : EvidentialSystem → Prop
-  | .noGrammatical => False
-  | .indirectOnly | .directAndIndirect | .threeOrMore => True
-@[simp] theorem hasEvidentials_iff (s : EvidentialSystem) :
-    s.HasEvidentials ↔ s ≠ .noGrammatical := by cases s <;> simp [HasEvidentials]
-instance : DecidablePred HasEvidentials := fun s => by
-  cases s <;> unfold HasEvidentials <;> infer_instance
-
-/-- Whether a language grammaticalizes a direct evidence category. -/
-def HasDirect : EvidentialSystem → Prop
-  | .directAndIndirect | .threeOrMore => True
-  | .noGrammatical | .indirectOnly => False
-@[simp] theorem hasDirect_iff (s : EvidentialSystem) :
-    s.HasDirect ↔ (s = .directAndIndirect ∨ s = .threeOrMore) := by
-  cases s <;> simp [HasDirect]
-instance : DecidablePred HasDirect := fun s => by
-  cases s <;> unfold HasDirect <;> infer_instance
-
-/-- Number of evidential choices in the system (0, 1, 2, or 3+). -/
-def numChoices : EvidentialSystem → Nat
-  | .noGrammatical => 0
-  | .indirectOnly => 1
-  | .directAndIndirect => 2
-  | .threeOrMore => 3
-
-end EvidentialSystem
-
-/-- WALS Ch 78: how evidentiality is morphologically expressed. -/
-inductive EvidentialCoding where
-  /-- Evidential is a verbal affix or clitic (bound morpheme). Dominant
-      strategy worldwide (131/418 in WALS Ch 78). -/
-  | verbalAffix
-  /-- Evidential is a clitic (phrasal-level, not strictly verbal). -/
-  | clitic
-  /-- Evidential is a free separate particle (65/418). -/
-  | particle
-  /-- Evidential distinctions fused into the TAM paradigm. -/
-  | partOfTAM
-  /-- Not applicable: language has no grammatical evidentials. -/
-  | notApplicable
-  deriving DecidableEq, BEq, Repr
-
-namespace EvidentialCoding
-
-/-- Whether the coding strategy involves a bound morpheme (affix or clitic). -/
-def IsBound : EvidentialCoding → Prop
-  | .verbalAffix | .clitic => True
-  | .particle | .partOfTAM | .notApplicable => False
-@[simp] theorem isBound_iff (c : EvidentialCoding) :
-    c.IsBound ↔ (c = .verbalAffix ∨ c = .clitic) := by cases c <;> simp [IsBound]
-instance : DecidablePred IsBound := fun c => by
-  cases c <;> unfold IsBound <;> infer_instance
-
-end EvidentialCoding
-
--- ============================================================================
--- §2. WALS converters
--- ============================================================================
-
-/-- WALS Ch 77 → `EvidentialSystem`. WALS Ch 77's 3-way classification maps
-    onto our 4-way; `threeOrMore` cannot be reached from WALS alone (WALS
-    lumps three-or-more systems with `directAndIndirect`). -/
-def fromWALS77A : Data.WALS.F77A.EvidentialityDistinctions → EvidentialSystem
-  | .noGrammaticalEvidentials => .noGrammatical
-  | .indirectOnly             => .indirectOnly
-  | .directAndIndirect        => .directAndIndirect
-
-/-- WALS Ch 78 → `EvidentialCoding`. WALS lumps "verbal affix or clitic";
-    the `mixed` and `modalMorpheme` categories are mapped to closest local
-    cells (best-effort). -/
-def fromWALS78A : Data.WALS.F78A.EvidentialityCoding → EvidentialCoding
-  | .noGrammaticalEvidentials => .notApplicable
-  | .verbalAffixOrClitic      => .verbalAffix
-  | .partOfTheTenseSystem     => .partOfTAM
-  | .separateParticle         => .particle
-  | .modalMorpheme            => .particle
-  | .mixed                    => .partOfTAM
-
--- ============================================================================
--- §3. WALS lookup helpers
--- ============================================================================
-
-/-- WALS Ch 77 lookup by ISO 639-3 code. `none` for languages WALS doesn't
-    cover. Used by Aikhenvald-vs-WALS divergence theorems. -/
-def walsEvidentialSystem (iso : String) : Option EvidentialSystem :=
-  (Data.WALS.F77A.lookupISO iso).map (fromWALS77A ·.value)
-
-/-- WALS Ch 78 lookup by ISO 639-3 code. -/
-def walsEvidentialCoding (iso : String) : Option EvidentialCoding :=
-  (Data.WALS.F78A.lookupISO iso).map (fromWALS78A ·.value)
-
-
-
-/-- [aikhenvald-2004] Ch 2 paradigm system-type classification. The
-    letter encodes term count (A=2, B=3, C=4, D=5); the digit encodes
-    paradigm shape. -/
-inductive AikhenvaldSystem where
-  /-- A1: Firsthand vs Non-firsthand. The most common 2-term type
-      (Cherokee, Jarawara, Yukaghir, Tibetan).
-      Aikhenvald 2004 Ch 2 §2.1.1. -/
-  | A1
-  /-- A2: Non-firsthand vs 'everything else'. The single marked term
-      covers inference and report. Common in Turkic and Caucasian
-      languages (Turkish, Abkhaz, Hunzib).
-      Aikhenvald 2004 Ch 2 §2.1.1. -/
-  | A2
-  /-- A3: Reported (or 'hearsay') vs 'everything else'. The single
-      marked term is the reportative. Widespread (Lezgian, Estonian,
-      Enga, Kham, many North American Indian languages).
-      Aikhenvald 2004 Ch 2 §2.1.1. -/
-  | A3
-  /-- A4: Sensory evidence and Reported. Both terms marked (Ngiyambaa,
-      Diyari, Lakondê/Latundê, reduced Wintu).
-      Aikhenvald 2004 Ch 2 §2.1.1. -/
-  | A4
-  /-- A5: Auditory vs 'everything else'. Attested only in Euchee.
-      Aikhenvald 2004 Ch 2 §2.1.1. -/
-  | A5
-  /-- B1: Direct (or Visual) + Inferred + Reported. The most common
-      3-term system. The Quechua family (`-mi`, `-chi`, `-shi`),
-      Wanka Quechua, Shasta, Amdo Tibetan, Qiang, Mosetén.
-      Aikhenvald 2004 Ch 2 §2.2. -/
-  | B1
-  /-- B2: Visual + Non-visual sensory + Inferred. No reportative.
-      Rare (Washo, Siona).
-      Aikhenvald 2004 Ch 2 §2.2. -/
-  | B2
-  /-- B3: Visual + Non-visual sensory + Reported. No inferential.
-      Oksapmin, Maricopa, Dulong.
-      Aikhenvald 2004 Ch 2 §2.2. -/
-  | B3
-  /-- B4: Non-visual sensory + Inferred + Reported. Visual is unmarked
-      default (Nganasan, Enets, Retuarã).
-      Aikhenvald 2004 Ch 2 §2.2. -/
-  | B4
-  /-- B5: Reported + Quotative + 'everything else'. Two distinct
-      reported-type evidentials, similar to A3 with quotative split
-      (Comanche, Dakota, Tonkawa).
-      Aikhenvald 2004 Ch 2 §2.2. -/
-  | B5
-  /-- C1: Visual + Non-visual sensory + Inferred + Reported. The most
-      common 4-term system; East Tucanoan languages (Tucano, Barasano,
-      Tatuyo, Siriano, Macuna), Eastern Pomo, traditional Tariana.
-      Aikhenvald 2004 Ch 2 §2.3. -/
-  | C1
-  /-- C2: Direct (or Visual) + Inferred + Assumed + Reported. The
-      sensory may be just visual (Tsafiki, Shipibo-Konibo, Pawnee,
-      Mamainde).
-      Aikhenvald 2004 Ch 2 §2.3. -/
-  | C2
-  /-- C3: Direct + Inferred + Reported + Quotative. Two distinct
-      reportative types (Cora, Northern Embera, SE Tepehuan).
-      Aikhenvald 2004 Ch 2 §2.3. -/
-  | C3
-  /-- D1: Visual + Non-visual sensory + Inferred + Assumed + Reported.
-      The classical 5-term system: current Tariana, Tuyuca, Desano,
-      traditional Wintu. Kashaya is comparable but distinguishes
-      auditory within non-visual.
-      Aikhenvald 2004 Ch 2 §2.4. -/
-  | D1
-  deriving DecidableEq, BEq, Repr, Inhabited
-
-namespace AikhenvaldSystem
-
-/-- Number of evidential terms in the paradigm. The letter prefix
-    encodes the count directly: A=2, B=3, C=4, D=5. Note: A2/A3/A5
-    have only one *marked* term but Aikhenvald counts the unmarked
-    'everything else' form, giving 2 (see Ch 2 §2.1). -/
-def termCount : AikhenvaldSystem → Nat
-  | .A1 | .A2 | .A3 | .A4 | .A5 => 2
-  | .B1 | .B2 | .B3 | .B4 | .B5 => 3
-  | .C1 | .C2 | .C3             => 4
-  | .D1                         => 5
-
-/-- Projection to the WALS Ch 77 ([de-haan-2013]) classification,
-    extended with `threeOrMore`. A-systems map per their direct/indirect
-    coverage; B/C/D map uniformly to `.threeOrMore`. WALS itself
-    collapses B/C/D into `.directAndIndirect`; the `.threeOrMore`
-    extension is linglib's, preserving Aikhenvald's richer typology
-    (see `Typology/Modality.lean` and Aikhenvald 2004 Ch 2 §2.2). -/
-def toWALS : AikhenvaldSystem → EvidentialSystem
-  | .A1                         => .directAndIndirect
-  | .A2 | .A3                   => .indirectOnly
-  | .A4 | .A5                   => .directAndIndirect
-  | .B1 | .B2 | .B3 | .B4 | .B5 => .threeOrMore
-  | .C1 | .C2 | .C3             => .threeOrMore
-  | .D1                         => .threeOrMore
-
-/-- The Aikhenvald typology is always richer-or-equal to the WALS one:
-    `.threeOrMore` for all 3+-term systems (B/C/D), the appropriate
-    2-way value for 2-term systems (A). -/
-@[simp] theorem termCount_pos (s : AikhenvaldSystem) : 0 < s.termCount := by
-  cases s <;> decide
-
-@[simp] theorem termCount_le_5 (s : AikhenvaldSystem) : s.termCount ≤ 5 := by
-  cases s <;> decide
-
-end AikhenvaldSystem
-
-/-! ### Derivation from a typed inventory -/
-
-open Semantics.Evidential
 open Semantics.Evidential.Entry (Cell)
 
-namespace AikhenvaldSystem
+/-! ### The kinds of system -/
 
-/-- Derive [aikhenvald-2004]'s paradigm system-type letter from a
-    declared inventory by inspecting which cells of her paradigm space are
-    covered. Mirrors `Determiner.Inventory.markingStrategy`'s derivation pattern.
-    Returns `none` for inventories whose cell pattern doesn't fit any
-    standard A–D letter; per-paper editorial overrides for such cases
-    live in the relevant `Studies/AuthorYear.lean`. -/
-def fromInventory (es : List Entry) : Option AikhenvaldSystem :=
-  let cells := es.map Entry.cell
-  let has (c : Cell) : Bool := cells.any (fun x => x == c)
-  let hasF   := has .firsthand
-  let hasV   := has .visual
-  let hasNVS := has .nonvisualSensory
-  let hasA   := has .auditory
-  let hasI   := has .inferred
-  let hasS   := has .assumed
-  let hasR   := has .reported
-  let hasQ   := has .quotative
-  let count : Nat := (if hasF then 1 else 0) + (if hasV then 1 else 0) +
-                     (if hasNVS then 1 else 0) + (if hasA then 1 else 0) +
-                     (if hasI then 1 else 0) + (if hasS then 1 else 0) +
-                     (if hasR then 1 else 0) + (if hasQ then 1 else 0)
-  match count with
-  | 0 => none
-  | 1 =>
-    if hasR then some .A3
-    else if hasA then some .A5
-    else if hasI || hasS then some .A2
-    else none
-  | 2 =>
-    if hasF && (hasI || hasR || hasS) then some .A1
-    else if (hasV || hasNVS || hasA) && hasR then some .A4
-    else none
-  | 3 =>
-    if hasV && hasNVS && hasI && !hasR then some .B2
-    else if hasV && hasNVS && hasR && !hasI then some .B3
-    else if !hasV && !hasF && hasNVS && hasI && hasR then some .B4
-    else if (hasF || hasV) && hasI && hasR then some .B1
-    else if hasR && hasQ then some .B5
-    else none
-  | 4 =>
-    if hasV && hasNVS && hasI && hasR then some .C1
-    else if (hasF || hasV) && hasI && hasS && hasR then some .C2
-    else if (hasF || hasV) && hasI && hasR && hasQ then some .C3
-    else none
-  | 5 =>
-    if hasV && hasNVS && hasI && hasS && hasR then some .D1
-    else none
+/-- The fourteen kinds of evidentiality system: the letter gives the number of choices, the
+digit the grouping of information sources. -/
+inductive Kind
+  | A1 | A2 | A3 | A4 | A5 | B1 | B2 | B3 | B4 | B5 | C1 | C2 | C3 | D1
+  deriving DecidableEq, Repr, Fintype
+
+namespace Kind
+
+/-- The number of evidentiality choices, counting an evidentiality-neutral term. -/
+def choices : Kind → ℕ
+  | .A1 | .A2 | .A3 | .A4 | .A5 => 2
+  | .B1 | .B2 | .B3 | .B4 | .B5 => 3
+  | .C1 | .C2 | .C3 => 4
+  | .D1 => 5
+
+/-- The kinds organized around an evidentiality-neutral "everything else" term. -/
+def HasDefault : Kind → Prop
+  | .A2 | .A3 | .A5 | .B5 => True
+  | _ => False
+
+instance : DecidablePred HasDefault := fun k => by cases k <;> unfold HasDefault <;> infer_instance
+
+/-- The cells a system of each kind distinguishes: the rows of Table 2.1, the marked terms of
+the everything-else kinds, and a firsthand term in the visual column. -/
+def cells : Kind → Finset Cell
+  | .A1 => {.visual, .nonfirsthand}
+  | .A2 => {.nonfirsthand}
+  | .A3 => {.reported}
+  | .A4 => {.visual, .reported}
+  | .A5 => {.auditory}
+  | .B1 => {.visual, .inferred, .reported}
+  | .B2 => {.visual, .nonvisualSensory, .inferred}
+  | .B3 => {.visual, .nonvisualSensory, .reported}
+  | .B4 => {.nonvisualSensory, .inferred, .reported}
+  | .B5 => {.reported, .quotative}
+  | .C1 => {.visual, .nonvisualSensory, .inferred, .reported}
+  | .C2 => {.visual, .inferred, .assumed, .reported}
+  | .C3 => {.visual, .inferred, .reported, .quotative}
+  | .D1 => {.visual, .nonvisualSensory, .inferred, .assumed, .reported}
+
+/-- The letter counts choices: the distinguished cells, plus one for an everything-else term. -/
+theorem choices_eq_card_cells (k : Kind) :
+    k.choices = k.cells.card + if k.HasDefault then 1 else 0 := by cases k <;> decide
+
+/-- No system expresses all six parameters. -/
+theorem card_cells_le_five (k : Kind) : k.cells.card ≤ 5 := by cases k <;> decide
+
+/-- Only one kind of five-choice system has been found. -/
+theorem eq_D1_of_choices (k : Kind) (h : k.choices = 5) : k = .D1 := by
+  cases k <;> first | rfl | exact absurd h (by decide)
+
+/-- Distinct kinds distinguish distinct cells. -/
+theorem cells_injective : Function.Injective cells := by decide
+
+/-- B1 groups the parameters into Willett's three domains: direct, inference and report. -/
+theorem B1_willett :
+    Kind.B1.cells.image Cell.toCoarseSource = {some .direct, some .inference, some .hearsay} := by
+  decide
+
+/-- Every kind, for classification by search. -/
+def all : List Kind := [.A1, .A2, .A3, .A4, .A5, .B1, .B2, .B3, .B4, .B5, .C1, .C2, .C3, .D1]
+
+theorem mem_all (k : Kind) : k ∈ all := by cases k <;> decide
+
+end Kind
+
+/-! ### Classifying an inventory -/
+
+/-- A firsthand term, covering the senses together, occupies the visual column. -/
+def Cell.normalize : Cell → Cell
+  | .firsthand => .visual
+  | c => c
+
+/-- The cells an inventory distinguishes. -/
+def cells (es : List Entry) : Finset Cell := (es.map (Cell.normalize ∘ Entry.cell)).toFinset
+
+/-- The kind of system an inventory instantiates: the kind distinguishing exactly its cells. -/
+def kind (es : List Entry) : Option Kind := Kind.all.find? (·.cells = cells es)
+
+theorem kind_eq_some_iff (es : List Entry) (k : Kind) :
+    kind es = some k ↔ k.cells = cells es := by
+  unfold kind
+  refine ⟨fun h => by simpa using List.find?_some h, fun h => ?_⟩
+  have hs : (Kind.all.find? (fun x => decide (x.cells = cells es))).isSome :=
+    List.find?_isSome.2 ⟨k, Kind.mem_all k, decide_eq_true h⟩
+  obtain ⟨k', hk'⟩ := Option.isSome_iff_exists.1 hs
+  have hk : k'.cells = cells es := by simpa using List.find?_some hk'
+  rw [hk', Kind.cells_injective (hk.trans h.symm)]
+
+/-- An empty inventory — an evidentiality strategy, or none at all — is of no kind. -/
+theorem kind_nil : kind [] = none := by decide
+
+/-! ### The Fragment languages -/
+
+theorem turkish : kind Turkish.Evidentiality.evidentials = some .A2 := by decide
+
+theorem abkhaz : kind Abkhaz.Evidentiality.evidentials = some .A2 := by decide
+
+theorem bulgarian : kind Bulgarian.Evidentiality.evidentials = some .A2 := by decide
+
+theorem quechua : kind Quechua.Evidentiality.evidentials = some .B1 := by decide
+
+theorem tuyuca : kind Tuyuca.Evidentiality.evidentials = some .D1 := by decide
+
+theorem tariana : kind Tariana.Evidentiality.evidentials = some .D1 := by decide
+
+/-- Kashaya distinguishes factual/visual, auditory, inferential and reported terms, a system
+beyond the fourteen kinds. -/
+theorem kashaya_unclassified : kind Kashaya.Evidentiality.evidentials = none := by decide
+
+/-! ### The book's illustrations -/
+
+/-- The cell named by an example's `cell` feature. -/
+def Cell.ofString? : String → Option Cell
+  | "firsthand" => some .firsthand
+  | "visual" => some .visual
+  | "nonvisualSensory" => some .nonvisualSensory
+  | "auditory" => some .auditory
+  | "inferred" => some .inferred
+  | "assumed" => some .assumed
+  | "reported" => some .reported
+  | "quotative" => some .quotative
+  | "nonfirsthand" => some .nonfirsthand
   | _ => none
 
-end AikhenvaldSystem
+/-- The cells illustrated by the examples from a language. -/
+def illustrated (lang : String) : Finset Cell :=
+  ((Examples.all.filter (·.language = lang)).filterMap
+    (fun r => r.feature? "cell" >>= Cell.ofString?)).toFinset.image Cell.normalize
 
-/-! ### Worked examples documenting the API -/
+/-- The Tariana illustration runs through every cell of a D1 system. -/
+theorem tariana_illustration : illustrated "tari1256" = Kind.D1.cells := by decide
 
-example : AikhenvaldSystem.termCount .A1 = 2 := by decide
-example : AikhenvaldSystem.termCount .B1 = 3 := by decide
-example : AikhenvaldSystem.termCount .C1 = 4 := by decide
-example : AikhenvaldSystem.termCount .D1 = 5 := by decide
+/-- The Wanka Quechua examples run through every cell of a B1 system. -/
+theorem wanka_illustration : illustrated "jauj1238" = Kind.B1.cells := by decide
 
-example : AikhenvaldSystem.toWALS .A1 = .directAndIndirect := by decide
-example : AikhenvaldSystem.toWALS .A2 = .indirectOnly := by decide
-example : AikhenvaldSystem.toWALS .A3 = .indirectOnly := by decide
-example : AikhenvaldSystem.toWALS .B1 = .threeOrMore := by decide
-example : AikhenvaldSystem.toWALS .C1 = .threeOrMore := by decide
-example : AikhenvaldSystem.toWALS .D1 = .threeOrMore := by decide
-
-
-/-! ### §1. Paper-vs-derived disagreements
-
-[aikhenvald-2004]'s own letter assignment for the four sample languages
-where it differs from `AikhenvaldSystem.fromInventory`:
-- Turkish, Bulgarian, Abkhaz: Aikhenvald treats one term as unmarked default
-  (A2 = single marked non-firsthand); Fragment counts both terms (A1).
-- Kashaya: Aikhenvald assigns D1 as closest fit; derivation returns `none`
-  because the auditory cell plus missing nonvisualSensory and assumed cells
-  break D1's structural pattern. -/
-
-/-- Aikhenvald 2004's own letter for the four divergent languages. `none`
-    for any language whose derivation matches the paper. -/
-def paperType : String → Option AikhenvaldSystem
-  | "tur" => some .A2  -- paper A2; derivation A1 (counts -DI as marked direct)
-  | "bul" => some .A2  -- paper A2; derivation A1 (counts aorist as marked direct)
-  | "abk" => some .A2  -- paper A2; derivation A1 (counts finite verb as marked)
-  | "kju" => some .D1  -- paper D1 closest-fit; derivation `none` (auditory split)
-  | _     => none
-
-theorem turkish_paper_vs_derived :
-    AikhenvaldSystem.fromInventory Turkish.Evidentiality.evidentials = some .A1 ∧
-    paperType "tur" = some .A2 := by decide
-
-theorem bulgarian_paper_vs_derived :
-    AikhenvaldSystem.fromInventory Bulgarian.Evidentiality.evidentials = some .A1 ∧
-    paperType "bul" = some .A2 := by decide
-
-theorem abkhaz_paper_vs_derived :
-    AikhenvaldSystem.fromInventory Abkhaz.Evidentiality.evidentials = some .A1 ∧
-    paperType "abk" = some .A2 := by decide
-
-theorem kashaya_paper_vs_derived :
-    AikhenvaldSystem.fromInventory Kashaya.Evidentiality.evidentials = none ∧
-    paperType "kju" = some .D1 := by decide
-
-/-! ### §2. Aikhenvald-vs-WALS disagreements
-
-Representative cases — same structural pattern repeats across the other
-indirectOnly-via-modal cases (German, Korean, Finnish) and the other
-WALS-lumps-rich-systems cases (Tariana, Kashaya). -/
-
-/-- Empty inventory per Aikhenvald-strict vs WALS `indirectOnly`. French
-    is the canonical case: the journalistic conditional has reportative
-    use that WALS counts but Aikhenvald excludes. Same pattern holds for
-    German, Japanese, Korean, Finnish. -/
-theorem french_wals_divergence :
-    AikhenvaldSystem.fromInventory French.Evidentiality.evidentials = none ∧
-    walsEvidentialSystem "fra" = some .indirectOnly := by decide
-
-theorem japanese_wals_divergence :
-    AikhenvaldSystem.fromInventory Japanese.Evidentiality.evidentials = none ∧
-    walsEvidentialSystem "jpn" = some .indirectOnly := by decide
-
-/-- The signature divergence: Tuyuca's D1 5-term system per Aikhenvald
-    (projecting to `threeOrMore`) vs WALS's `directAndIndirect` lump. Same
-    paradigm, two classifications, both kernel-verified. -/
-theorem tuyuca_wals_divergence :
-    AikhenvaldSystem.fromInventory Tuyuca.Evidentiality.evidentials = some .D1 ∧
-    AikhenvaldSystem.D1.toWALS = .threeOrMore ∧
-    walsEvidentialSystem "tue" = some .directAndIndirect := by decide
-
-/-- Andean B1: Aikhenvald has classification; WALS has no entry. -/
-theorem quechua_no_wals_entry :
-    AikhenvaldSystem.fromInventory Quechua.Evidentiality.evidentials = some .B1 ∧
-    walsEvidentialSystem "quz" = none := by decide
-
-/-- Turkish: derivation's A1 happens to project to the same WALS coding
-    (`directAndIndirect`) WALS assigns directly; the Aikhenvald *paper*
-    A2 projects to `indirectOnly`. Triple-comparison divergence. -/
-theorem turkish_wals_divergence :
-    AikhenvaldSystem.A2.toWALS = .indirectOnly ∧
-    walsEvidentialSystem "tur" = some .directAndIndirect := by decide
+/-- The Turkish examples show one non-firsthand term covering report, inference and non-visual
+perception. -/
+theorem turkish_illustration : illustrated "nucl1301" = Kind.A2.cells := by decide
 
 end Aikhenvald2004


### PR DESCRIPTION
Deep cleanse of Aikhenvald2004 against the book. The study is now the typology: `Kind` (A1–D1), `Kind.cells` (Table 2.1 plus the marked terms of the everything-else kinds), `kind` deriving a language's kind from its Fragment inventory, and the book's structural claims as theorems (letters count choices, no system expresses all six parameters, D1 is the only five-choice kind, B1 is Willett's grouping); the book's own illustrations are JSON rows that provably exhaust their systems' cells. The stipulated `paperType` table, the dead WALS Ch 77/78 enums, and the de Haan 2013 comparison (newer than the anchor) are cut.
- Substrate: `Semantics/Evidential` gains the non-firsthand term (`NonfirsthandEvidential`, `Entry.nonfirsthand`, `Cell.nonfirsthand`) that A1/A2 systems are built on; coarse source becomes `Option` and `Entry` gets its own perspective instance so `Entry.isNonfuture` still holds.
- Fragments corrected to the book: Turkish, Abkhaz and Bulgarian record one non-firsthand term (their unmarked pasts are evidentiality-neutral, so they derive as A2 instead of the old A1 by miscount); Georgian's perfect is an evidentiality strategy (empty inventory); Kashaya's *-do* is reported, not quotative; the strategy-language fragments (French, Japanese, Korean, German, Finnish) state the book's verdict instead of a 'Studies-side override', and Finnish no longer attributes anything to a book that never discusses it.