### PR TITLE
chore(Semantics/Definiteness): namespace Definiteness at root

### DIFF
--- a/Linglib/Features/CoreferenceStatus.lean
+++ b/Linglib/Features/CoreferenceStatus.lean
@@ -29,7 +29,7 @@ inductive CoreferenceStatus where
 
     The *binding-distribution* axis (anaphor/pronominal/r-expression, with the
     anaphor class split into reflexive/reciprocal) — orthogonal to a nominal's
-    `Semantics.Definiteness.Description` (definiteness/reference flavor) and to a
+    `Definiteness.Description` (definiteness/reference flavor) and to a
     pronoun's lexical kind. -/
 inductive BindingClass where
   /-- Reflexive anaphor (*himself*, *herself*, *themselves*). -/

--- a/Linglib/Features/Deixis.lean
+++ b/Linglib/Features/Deixis.lean
@@ -33,7 +33,7 @@ when a fragment actually needs it, not in anticipation. Specifically:
   invisible` constructors when a fragment needs them.
 - **Elevation contrasts** (Dyirbal, Nepali): add when needed.
 
-This is the centralized type referenced by `Semantics.Definiteness.Description.deictic`
+This is the centralized type referenced by `Definiteness.Description.deictic`
 (forthcoming) and by demonstrative entries in `Fragments/`.
 -/
 

--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -16,7 +16,7 @@ This file is therefore word-class-**neutral**: the [haspelmath-1997] feature dim
 coverage, ontology, morphological basis) and the `Indefinite` *capability* (`[Indefinite α]`) that
 exposes them over any carrier. The capability is the indefinite analogue of mathlib's
 `MonoidHomClass`-over-`MonoidHom`: a carrier-class-specific indefinite object (`IndefinitePronoun`
-in `Syntax/Category/Pronoun/Indefinite.lean`; a future `IndefiniteDeterminer` over `Semantics.Definiteness`'s
+in `Syntax/Category/Pronoun/Indefinite.lean`; a future `IndefiniteDeterminer` over `Definiteness`'s
 `Determiner`) supplies one `instance : Indefinite That`, and generic code reads the series data via
 `[Indefinite α]`.
 
@@ -236,7 +236,7 @@ end Indefinite
 
     Word-class-neutral by design (`Indefinite` ≠ pronoun): the sole current carrier is
     `Indefinite.IndefinitePronoun` (`Syntax/Category/Pronoun/Indefinite.lean`), but an indefinite determiner
-    (over `Semantics.Definiteness`'s `Determiner`) or pro-adverb supplies its own `instance : Indefinite That`
+    (over `Definiteness`'s `Determiner`) or pro-adverb supplies its own `instance : Indefinite That`
     and is then read by the same generic `[Indefinite α]` code. This is the indefinite analogue of
     mathlib's `MonoidHomClass`-over-`MonoidHom`/`RingHom`. -/
 class Indefinite (α : Type*) where

--- a/Linglib/Semantics/Composition/TypeShifting.lean
+++ b/Linglib/Semantics/Composition/TypeShifting.lean
@@ -202,7 +202,7 @@ noncomputable def NOM (domain : List E) (P : (E → Prop)) : Option E :=
 
     Maps `⟨e,t⟩ → ⟨⟨e,t⟩,t⟩` (partial). Unlike `A` (which is total), `THE`
     presupposes existence and uniqueness. Connects to the semantics of "the"
-    in `Semantics.Definiteness`. -/
+    in `Definiteness`. -/
 noncomputable def THE (domain : List E) (P : (E → Prop)) : Option (Quantifier E) :=
   (iota domain P).map individual
 

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -13,7 +13,7 @@ import Linglib.Fragments.English.Determiners
 Connective tissue between definite-description denotations and the rest of
 the library. The denotational layer itself lives in two canonical pieces:
 
-- `Semantics.Definiteness.russellIotaList` (the per-context referent selector,
+- `Definiteness.russellIotaList` (the per-context referent selector,
   Russellian iota over a `List E` filtered by a `Bool` predicate), and
 - `Semantics.Presupposition.PartialProp.presupOfReferent` (the combinator lifting a
   referent selector and a scope predicate into a `PartialProp W`).
@@ -39,7 +39,7 @@ This module retains:
 
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 open Intensional (Ty)
 open Quantification (every_sem some_sem)
@@ -57,7 +57,7 @@ open Semantics.Presupposition (PartialProp)
 been introduced into the discourse and are available for anaphoric reference.
 Familiarity-based definites (Schwarz's strong article) are evaluated by
 running the canonical Russellian-iota selector
-(`Semantics.Definiteness.russellIotaList`) over `dc.salient` rather than the full
+(`Definiteness.russellIotaList`) over `dc.salient` rather than the full
 domain. -/
 structure DiscourseContext (E : Type) where
   /-- Entities currently salient/familiar in discourse -/
@@ -154,4 +154,4 @@ def modifierNecessary {E : Type}
     | [_] => true   -- modifier rescues uniqueness
     | _ => false    -- modifier doesn't help
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Definiteness/Defs.lean
+++ b/Linglib/Semantics/Definiteness/Defs.lean
@@ -18,7 +18,7 @@ denotational layer lives in `Semantics/Definiteness/Basic.lean` and
 `Semantics/Definiteness/Description.lean`.
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 /-! ### The core binary distinction -/
 
@@ -39,7 +39,7 @@ def demonstrativePresupType : DefPresupType := .familiarity
 /-! ### Description kinds -/
 
 /-- The kinds of nominal description an inventory can realize — the Frame-free
-skeleton of `Semantics.Definiteness.Description` (one case per constructor,
+skeleton of `Definiteness.Description` (one case per constructor,
 payload erased). Inventory questions (realization, marking typology) depend
 only on this kind, so they are stated over it rather than over the
 entity/index-parameterized `Description`. -/
@@ -55,7 +55,7 @@ inductive DescriptionKind where
 /-- The description kind realizing a [schwarz-2009] article strength: the weak
 article (uniqueness) realizes `unique`, the strong article (familiarity)
 realizes `anaphoric`. The Frame-free counterpart of
-`Semantics.Definiteness.Description.ofPresupType`. -/
+`Definiteness.Description.ofPresupType`. -/
 def DefPresupType.toKind : DefPresupType → DescriptionKind
   | .uniqueness  => .unique
   | .familiarity => .anaphoric
@@ -221,6 +221,8 @@ inductive WeakArticleStrategy where
 
 /-! ### The indefinite–definite contrast -/
 
+end Definiteness
+
 /-- The fundamental semantic contrast between indefinite and definite:
 
 - **Indefinite** (some/a): existential quantification, no presupposition
@@ -234,6 +236,8 @@ inductive Definiteness where
   | indefinite  -- ∃: introduces new dref, no presupposition
   | definite    -- ι/familiar: retrieves existing dref, presupposes availability
   deriving DecidableEq, Repr
+
+namespace Definiteness
 
 /-- Definiteness is a binary contrast. -/
 theorem definite_indefinite_exhaustive :
@@ -295,4 +299,4 @@ theorem strategy_finer_than_articleType :
     DefMarkingStrategy.generallyMarked ≠ .markedAnaphoric :=
   ⟨rfl, by decide⟩
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Definiteness/Description.lean
+++ b/Linglib/Semantics/Definiteness/Description.lean
@@ -57,11 +57,11 @@ unified `Denot E W` machinery rather than ad-hoc `E → Bool` predicates.
 
 - **No semantic interpretation here.** This file only declares the type and
   its Frame-free `kind` projection (classification predicates live on
-  `Semantics.Definiteness.DescriptionKind`). The interpretation function lives
+  `Definiteness.DescriptionKind`). The interpretation function lives
   in `Semantics/Definiteness/Interpret.lean`.
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 open Intensional
 open Intensional.Variables
@@ -119,7 +119,7 @@ namespace Description
 variable {E W : Type}
 
 /-- The Frame-free kind of a description: its constructor with payload erased
-    (`Semantics.Definiteness.DescriptionKind`). Inventory questions
+    (`Definiteness.DescriptionKind`). Inventory questions
     (`Determiner.Inventory.Realizes`, marking typology) depend only on this. -/
 def kind : Description E W → DescriptionKind
   | .bare _           => .bare
@@ -155,4 +155,4 @@ theorem kind_ofPresupType
 
 end Description
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -15,7 +15,7 @@ as `NominalDenot`s — the determiner half of the API whose pronoun half is
 | | pronoun | determiner |
 |---|---|---|
 | lexical record | `PersonalPronoun` | `Article`, `DemonstrativeDeterminer` |
-| selector | `interpPronoun` (`g ↦ g i`) | `Semantics.Definiteness.interpret` |
+| selector | `interpPronoun` (`g ↦ g i`) | `Definiteness.interpret` |
 | intrinsic presupposition | φ-features (`phiPresup`) | deixis (`deixisPresup`) |
 
 The selector is the canonical `Description` interpretation — determiner-as-object
@@ -57,7 +57,7 @@ world coordinate is trivial (`PUnit`), matching the static case of
 individual denotation — it has no `NominalDenot`) remains deferred.
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 open Semantics.Reference (NominalDenot)
 open Intensional.Variables
@@ -272,4 +272,4 @@ theorem Possessive.toDefinite_existsUnique
 
 end DescriptionUnification
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Definiteness/Interpret.lean
+++ b/Linglib/Semantics/Definiteness/Interpret.lean
@@ -30,7 +30,7 @@ and discourse index (the deictic feature is for presupposition checking,
 not referent selection).
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 open Intensional
 open Intensional.Variables
@@ -225,4 +225,4 @@ theorem interpret_anaphoric_eq_unique_of_existsUnique
   rw [interpret_unique_eq_some_of_existsUnique R sIdx g gs (g i) hSat hUniq,
       interpret_anaphoric, if_pos hSat]
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Definiteness/Maximality.lean
+++ b/Linglib/Semantics/Definiteness/Maximality.lean
@@ -50,7 +50,7 @@ predicate's domain.
   presupposition failure at the propositional level.
 -/
 
-namespace Semantics.Definiteness
+namespace Definiteness
 
 /-! ### Coppock–Beaver factorization -/
 
@@ -240,4 +240,4 @@ theorem uniqueness_implies_homogeneous_classical
       rw [hxe] at hSx; exact hS hSx
   · left; intro x hx; exact (h ⟨x, hx⟩).elim
 
-end Semantics.Definiteness
+end Definiteness

--- a/Linglib/Semantics/Genericity/MeaningPreservation.lean
+++ b/Linglib/Semantics/Genericity/MeaningPreservation.lean
@@ -342,7 +342,7 @@ type-shift converts this intensional property into a different semantic type:
 - ∃ (`.exists`): `⟨s,⟨e,t⟩⟩ × s → Prop` — existential closure at a world
 
 These connect the abstract shift-selection machinery to Chierchia's `down`
-operator and the `Semantics.Definiteness.russellIotaList` /
+operator and the `Definiteness.russellIotaList` /
 `Semantics.Presupposition.PartialProp.presupOfReferent` canonical pieces consumed by
 `Semantics/Definiteness/Basic.lean`.
 -/

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -35,7 +35,7 @@ relation), inheriting the possessor's intrinsic presupposition. So:
 namespace Possessive
 
 open Semantics.Reference (NominalDenot)
-open Semantics.Definiteness (russellIota)
+open Definiteness
 
 variable {Ctx : Type*} {W E : Type}
 

--- a/Linglib/Semantics/Possessive/PronounMixing.lean
+++ b/Linglib/Semantics/Possessive/PronounMixing.lean
@@ -29,7 +29,7 @@ i.e. *derived*, not stipulated.
 namespace Possessive
 
 open Semantics.Reference (NominalDenot)
-open Semantics.Definiteness (russellIota)
+open Definiteness
 open Intensional.Variables (interpPronoun)
 
 variable {E : Type} [PartialOrder E]

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -379,7 +379,7 @@ variable {E : Type*}
 /-- ⟦DEF⟧: presupposes the referent satisfies a contextual familiarity
     or uniqueness condition. The predicate `familiar` is abstract —
     concretely it may be Heim's familiarity or Russell's uniqueness
-    (cf. `Semantics.Definiteness.DefPresupType`). -/
+    (cf. `Definiteness.DefPresupType`). -/
 def defSem (familiar : E → Prop) : PartialProp E where
   presup := familiar
   assertion := fun _ => True

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -49,7 +49,7 @@ open Intensional.Intension (rigid IsRigid rigid_isRigid)
 open Semantics.Presupposition (PartialProp)
 open Semantics.Presupposition.PartialProp (presupOfReferent)
 open Semantics.Reference.Basic
-open Semantics.Definiteness (russellIotaList)
+open Definiteness
 
 /-! ## Use Modes -/
 

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -126,7 +126,7 @@ personal/demonstrative split is the [schwarz-2009] weak/strong-article split:
 PER (*er*) the **weak** article (`Description.ofPresupType .uniqueness` = `.unique`),
 "DEM" (*der*) the **strong** article (`…ofPresupType .familiarity` = `.anaphoric`,
 the weak description plus an anaphoric index). PG&G's "DEM = PER + index" is the
-weak/strong refinement `Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`;
+weak/strong refinement `Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`;
 the strength round-trips through `DescriptionKind.presupType`. The extra layer is that index,
 **not** spatial deixis (footnote 1) — *der* is a strong *personal* pronoun, not a
 separate type; genuine deictic demonstratives are `Description.demonstrative`.
@@ -142,13 +142,13 @@ exactly when `g i` is the unique satisfier. -/
 description whenever the restrictor holds of the indexed referent: the
 **strong-article** (`Description.ofPresupType .familiarity`) reading, since the
 anaphoric index *is* the indexed entity. The **weak** reading coincides too when
-that entity is the unique satisfier (`Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`). -/
+that entity is the unique satisfier (`Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`). -/
 theorem PersonalPronoun.denote_selector_eq_ofPresupType {E W : Type} [PartialOrder E]
     (e : PersonalPronoun) (i : ℕ) (R : DenotGS E W .et)
     (speaker addressee : E) (isFemale isInanimate : E → Prop)
     (g : Assignment E) (gs : SitAssignment W) (w : PUnit)
     (h : R g gs (g i)) :
     (e.denote i speaker addressee isFemale isInanimate).selector g w
-      = Semantics.Definiteness.interpret (Semantics.Definiteness.Description.ofPresupType .familiarity R i) g gs := by
-  show some (g i) = Semantics.Definiteness.interpret (.anaphoric R i) g gs
-  rw [Semantics.Definiteness.interpret_anaphoric, if_pos h]
+      = Definiteness.interpret (Definiteness.Description.ofPresupType .familiarity R i) g gs := by
+  show some (g i) = Definiteness.interpret (.anaphoric R i) g gs
+  rw [Definiteness.interpret_anaphoric, if_pos h]

--- a/Linglib/Studies/AhnKocabDavidson2026.lean
+++ b/Linglib/Studies/AhnKocabDavidson2026.lean
@@ -34,7 +34,7 @@ hypothesis over the consultant data and the experimental stimuli.
 namespace AhnKocabDavidson2026
 
 open Pragmatics.Expressives (TwoDimProp)
-open Semantics.Definiteness
+open Definiteness
 
 variable {E L W : Type*}
 

--- a/Linglib/Studies/CoppockBeaver2015.lean
+++ b/Linglib/Studies/CoppockBeaver2015.lean
@@ -19,7 +19,7 @@ one king (Uniqueness), while leaving Existence in the scope of negation.
 The classical Russellian analysis collapses both into the assertion and
 loses this distinction.
 
-The factorization is operationalized in `Semantics.Definiteness` as
+The factorization is operationalized in `Definiteness` as
 `Existence`, `Uniqueness`, and `existsUnique`; this file tests it over a
 tiny frame (`Body`: sun / moon / mars, one situation index).
 
@@ -32,7 +32,7 @@ tiny frame (`Body`: sun / moon / mars, one situation index).
   `planet_not_existsUnique`: Russellian `existsUnique` holds exactly for a
   singleton extension.
 - `interpret_theSun`, `interpret_kingOfFrance`, `interpret_planet`:
-  `Semantics.Definiteness.interpret` on a `.unique` description returns
+  `Definiteness.interpret` on a `.unique` description returns
   `none` precisely in the Russellian failure cases.
 - `uniqueness_projects_through_negation`,
   `existence_does_not_project_through_negation`: the projection contrast —
@@ -43,7 +43,7 @@ namespace CoppockBeaver2015
 
 open Intensional
 open Intensional.Variables
-open Semantics.Definiteness
+open Definiteness
 
 /-! ### A tiny frame for the projection diagnostics -/
 
@@ -118,7 +118,7 @@ theorem planet_not_existsUnique : ¬ ∃! x, planet x := by
   rintro ⟨_, hUniq⟩
   exact planet_existence_without_uniqueness.2 hUniq
 
-/-! ### Alignment with `Semantics.Definiteness.interpret` -/
+/-! ### Alignment with `Definiteness.interpret` -/
 
 /-- A trivial bi-assignment: every entity slot is `sun`, every situation
     slot is `()`. The diagnostics in this file do not bind anything. -/

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -64,10 +64,10 @@ open Intensional (Index)
 open Semantics.Presupposition (PartialProp)
 open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
-open Semantics.Definiteness (russellIotaList)
-open Semantics.Definiteness (DefPresupType)
+open Definiteness
+open Definiteness
 open Intensional (SitVarStatus ReferentialMode)
-open Semantics.Definiteness (qforceToPresupType)
+open Definiteness
 open Semantics.Reference.Donnellan (UseMode definiteNominal)
 
 

--- a/Linglib/Studies/Hanink2021.lean
+++ b/Linglib/Studies/Hanink2021.lean
@@ -22,7 +22,7 @@ The IL substrate operationalizes this in two parallel pieces:
 - **`SitAssignment W := Nat → W`** in `Intensional.Variables`
   is the situation-pronoun assignment, parallel to the entity
   assignment.
-- **`Description.unique R sIdx`** in `Semantics.Definiteness.Description`
+- **`Description.unique R sIdx`** in `Definiteness.Description`
   carries a `situationIdx : Nat` recording *which* situation pronoun
   the description is bound to.
 
@@ -51,8 +51,8 @@ namespace Hanink2021
 
 open Intensional
 open Intensional.Variables
-open Semantics.Definiteness
-open Semantics.Definiteness (DescriptionKind)
+open Definiteness
+open Definiteness
 
 -- ════════════════════════════════════════════════════════════════
 -- §1: A two-room frame for the resource-situation diagnostic
@@ -157,7 +157,7 @@ theorem same_description_different_referents :
 /-- The index argument to `.unique` does not select among situations at
     the interpretation layer — the restrictor `R` already takes the full
     situation assignment, and the index records *which* pronoun is
-    bound. (`Semantics.Definiteness.interpret_unique_index_irrelevant` makes this
+    bound. (`Definiteness.interpret_unique_index_irrelevant` makes this
     explicit.) The Hanink claim is recovered via the restrictor calling
     `interpSitPronoun sIdx`, not via the interpreter inspecting `sIdx`. -/
 theorem unique_index_does_not_alter_referent_directly :

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -32,7 +32,7 @@ is not formalized here. The post-Jenks Shan refutation lives in
 
 namespace Jenks2018
 
-open Semantics.Definiteness
+open Definiteness
 open Semantics.Kinds
 open Intensional
 open Intensional.Variables

--- a/Linglib/Studies/Moroney2021.lean
+++ b/Linglib/Studies/Moroney2021.lean
@@ -41,7 +41,7 @@ and refers to it if it is close (`demDenotation`, her (147)–(148)).
 
 namespace Moroney2021
 
-open Semantics.Definiteness (russellIotaList)
+open Definiteness
 open Semantics.Kinds
 open Features.Deixis (Feature)
 open Mereology (CUM)

--- a/Linglib/Studies/PaapeVasishth2026.lean
+++ b/Linglib/Studies/PaapeVasishth2026.lean
@@ -589,11 +589,11 @@ The argument chain:
 
 section UniquenessBridge
 
-open Semantics.Definiteness (modifierNecessary)
+open Definiteness
 open Semantics.Presupposition (PartialProp)
 open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
   presupOfReferent_assertion_some presupOfReferent_assertion_none)
-open Semantics.Definiteness (russellIotaList)
+open Definiteness
 
 /-- Toy discourse entity for the uniqueness worked example. -/
 inductive DiscEntity where

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -29,7 +29,7 @@ by an added pragmatic effect (emotivity §5.1, disambiguation §5.2, register §
 The contributions are made *true by construction* on shared substrate:
 
 * **DEM = PER + anaphoric index** is the [schwarz-2009] weak/strong refinement
-  `Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`: the strong description
+  `Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`: the strong description
   (DEM, `.anaphoric`) and the weak description (PER, `.unique`) over one restrictor
   pick the same referent exactly when the indexed entity is the unique satisfier —
   off that, DEM is anaphoric in a way PER is not. Both denote via
@@ -55,7 +55,7 @@ modeling absent here.
 
 namespace PatelGroszGrosz2017
 
-open Semantics.Definiteness (ArticleType)
+open Definiteness
 
 /-- The **three** pragmatic contexts that license the strong-article ("DEM") series
     in German ([patel-grosz-grosz-2017] §5): a positive pragmatic effect must
@@ -148,14 +148,14 @@ theorem schwarz_pgg_german_consistent :
     *different* referents. Reusing [schwarz-2009] §8's two-satisfier scenario:
     the weak PER fails uniqueness (two satisfiers → `none`) while the strong DEM
     reads off the discourse index. This is the divergence direction the convergence
-    theorem (`Semantics.Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`) rules out
+    theorem (`Definiteness.interpret_anaphoric_eq_unique_of_existsUnique`) rules out
     only under uniqueness. -/
 theorem der_er_can_diverge :
-    Semantics.Definiteness.interpret
-        (Semantics.Definiteness.Description.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
+    Definiteness.interpret
+        (Definiteness.Description.ofPresupType .uniqueness Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0
-      ≠ Semantics.Definiteness.interpret
-        (Semantics.Definiteness.Description.ofPresupType .familiarity Schwarz2009.studentRestr 0)
+      ≠ Definiteness.interpret
+        (Definiteness.Description.ofPresupType .familiarity Schwarz2009.studentRestr 0)
         Schwarz2009.gAlice Schwarz2009.gs0 :=
   Schwarz2009.two_articles_can_disagree
 
@@ -177,10 +177,10 @@ open Semantics.Presupposition.PhiFeatures (femSem)
     feature *drives* the definite description's restrictor rather than re-stipulating it. -/
 theorem feminine_per_restrictor_is_femSem {E W : Type}
     (isFemale : E → Prop) (sIdx : Nat) :
-    Semantics.Definiteness.Description.ofPresupType .uniqueness
+    Definiteness.Description.ofPresupType .uniqueness
         ((fun _ _ x => (femSem isFemale).presup x) :
           Intensional.Variables.DenotGS E W .et) sIdx
-      = Semantics.Definiteness.Description.unique
+      = Definiteness.Description.unique
           ((fun _ _ x => isFemale x) :
             Intensional.Variables.DenotGS E W .et) sIdx := rfl
 
@@ -189,12 +189,12 @@ theorem feminine_per_restrictor_is_femSem {E W : Type}
 theorem feminine_per_picks_unique_female {E W : Type}
     (isFemale : E → Prop) (sIdx : Nat)
     (g : Assignment E) (gs : Intensional.Variables.SitAssignment W) :
-    Semantics.Definiteness.interpret
-        (Semantics.Definiteness.Description.ofPresupType .uniqueness
+    Definiteness.interpret
+        (Definiteness.Description.ofPresupType .uniqueness
           ((fun _ _ x => (femSem isFemale).presup x) :
             Intensional.Variables.DenotGS E W .et) sIdx) g gs
-      = Semantics.Definiteness.russellIota (E := E) (fun x => isFemale x) :=
-  Semantics.Definiteness.interpret_unique
+      = Definiteness.russellIota (E := E) (fun x => isFemale x) :=
+  Definiteness.interpret_unique
     ((fun _ _ x => isFemale x) : Intensional.Variables.DenotGS E W .et) sIdx g gs
 
 end PatelGroszGrosz2017

--- a/Linglib/Studies/Schwarz2009.lean
+++ b/Linglib/Studies/Schwarz2009.lean
@@ -33,13 +33,13 @@ the distinction at the surface.
 
 The split is operationalized in the Core layer by:
 
-- **`Semantics.Definiteness.Description`** — distinct `.unique` (weak) and
+- **`Definiteness.Description`** — distinct `.unique` (weak) and
   `.anaphoric` (strong) constructors, with different argument shapes
   (`.unique` carries a *situation* index for resource-situation binding;
   `.anaphoric` carries a *discourse* index for antecedent lookup).
-- **`Semantics.Definiteness.DescriptionKind.presupType`** — projects each kind
+- **`Definiteness.DescriptionKind.presupType`** — projects each kind
   to the [schwarz-2009] presupposition type it expresses.
-- **`Semantics.Definiteness.Determiner`** — the declared determiner set records the
+- **`Definiteness.Determiner`** — the declared determiner set records the
   morphological inventory; `Determiner.Inventory.IsSyncretic` is the predicate that
   distinguishes English-style syncretism from German-style bipartition.
 
@@ -66,7 +66,7 @@ We verify:
 
 namespace Schwarz2009
 
-open Semantics.Definiteness
+open Definiteness
 open Intensional
 open Intensional.Variables
 

--- a/Linglib/Studies/Schwarz2013.lean
+++ b/Linglib/Studies/Schwarz2013.lean
@@ -31,7 +31,7 @@ fragment encodes the flipped cell, and the divergence is proved below.
 
 namespace Schwarz2013
 
-open Semantics.Definiteness
+open Definiteness
 
 /-! ### The German/Fering baseline (§3.1) -/
 

--- a/Linglib/Studies/ShenHuang2026.lean
+++ b/Linglib/Studies/ShenHuang2026.lean
@@ -51,7 +51,7 @@ namespace ShenHuang2026
 
 open Minimalist.Linearization
 open ArgumentStructure
-open Semantics.Definiteness
+open Definiteness
 open Syntax.Binding.SpecificityCondition (ExternalOperator blocked)
 
 -- ============================================================================

--- a/Linglib/Syntax/Binding/SpecificityCondition.lean
+++ b/Linglib/Syntax/Binding/SpecificityCondition.lean
@@ -41,7 +41,7 @@ coverage ([shen-huang-2026] §4.1).
 
 namespace Syntax.Binding.SpecificityCondition
 
-open Semantics.Definiteness
+open Definiteness
 
 -- ============================================================================
 -- §1. Specificity

--- a/Linglib/Syntax/Category/Determiner/Basic.lean
+++ b/Linglib/Syntax/Category/Determiner/Basic.lean
@@ -49,9 +49,7 @@ denotation (`Semantics/Quantification`) is supplied externally by its consumers.
 This file stays the Frame-free lexical/typological layer.
 -/
 
-open Semantics.Definiteness
-  (DefPresupType DefiniteUseType DefMarkingStrategy Definiteness ArticleType
-   DescriptionKind useTypeToPresupType strategyToArticleType)
+open Definiteness
 
 namespace Determiner
 

--- a/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
+++ b/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
@@ -33,7 +33,7 @@ assignment keeps them apart by construction.
 /-- A deictic demonstrative pronoun: the general `Pronoun` (form + φ) plus the
     `Features.Deixis.Feature` it encodes — its proximal/medial/distal contrast (or `unspecified`
     for a distance-neutral demonstrative like German *dieser*). Carries no separate denotation here;
-    its meaning is the deictic `Semantics.Definiteness.Description.demonstrative` over its restrictor. -/
+    its meaning is the deictic `Definiteness.Description.demonstrative` over its restrictor. -/
 structure DemonstrativePronoun extends Pronoun where
   /-- Demonstratives are UD `PronType=Dem`; the *type* fixes the morphology. -/
   pronType := some UD.PronType.Dem

--- a/Linglib/Syntax/RelativeClause/Basic.lean
+++ b/Linglib/Syntax/RelativeClause/Basic.lean
@@ -235,7 +235,7 @@ structure Marker where
   /-- Which grammatical positions can be relativized using this marker. -/
   positions : List AHPosition
   /-- Which head-NP definiteness context attests the marker (purely
-      descriptive). Reuses `Semantics.Definiteness.Definiteness` rather
+      descriptive). Reuses `Definiteness` rather
       than introducing a parallel enum. `none` if the language doesn't
       make a comparable definiteness contrast on relative-clause markers
       (the typical case) or if the data hasn't been encoded. Languages
@@ -247,7 +247,7 @@ structure Marker where
       (Wright 1896; Cantarino 1974; [ryding-2005]): MSA *alladhī*
       with definite antecedents vs Ø-relative-pronoun with indefinite
       antecedents. Substrate makes no claim about syntactic mechanism. -/
-  headDefiniteness : Option Semantics.Definiteness.Definiteness := none
+  headDefiniteness : Option Definiteness := none
   /-- Additional notes. -/
   notes : String := ""
   deriving BEq, Repr


### PR DESCRIPTION
`Semantics.Definiteness` → root `Definiteness` (no umbrella directory prefix); the `Definiteness` enum moves to the root, selective opens become bare `open Definiteness`.