### PR TITLE
refactor(Fragments): cleanse the pronoun fragments

### DIFF
--- a/Linglib/Fragments/Basque/Pronouns.lean
+++ b/Linglib/Fragments/Basque/Pronouns.lean
@@ -1,51 +1,36 @@
-/-
-# Basque Pronoun & Allocutive Fragment
-
-Personal pronouns and allocutive verbal morphology in Souletian Basque.
-Basque has a T/V distinction (*hi* familiar vs *zu* formal) and SA-based
-allocutive verbal suffixes that are restricted to root clauses. 2nd person
-plural *zuek* is distinct from formal singular *zu*.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Basque pronouns and allocutive markers
+
+Personal pronouns of Basque, with the T/V contrast *hi* (familiar) vs *zu*
+(formal) in the second-person singular, and the Souletin allocutive auxiliary
+suffixes of [alok-bhalla-2026]'s (1): *-k* and *-n* for a nonhonorific male
+and female addressee, *-zü* for an honorific addressee. The same suffixes
+serve as ordinary agreement with a second-person subject.
+-/
 
 namespace Basque.Pronouns
 
 open Pronoun
-open Features.Register (Level)
-
--- ============================================================================
--- First Person
--- ============================================================================
 
 /-- *ni* — 1sg. -/
-def ni : PersonalPronoun :=
-  { form := "ni", person := some .first, number := some .singular }
+def ni : PersonalPronoun := { form := "ni", person := some .first, number := some .singular }
 
 /-- *gu* — 1pl. -/
-def gu : PersonalPronoun :=
-  { form := "gu", person := some .first, number := some .plural }
+def gu : PersonalPronoun := { form := "gu", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (T/V)
--- ============================================================================
-
-/-- *hi* — 2sg familiar (T form). -/
+/-- *hi* — 2sg familiar. -/
 def hi : PersonalPronoun :=
   { form := "hi", person := some .second, number := some .singular, register := .informal }
 
-/-- *zu* — 2sg formal (V form). -/
+/-- *zu* — 2sg formal. -/
 def zu : PersonalPronoun :=
   { form := "zu", person := some .second, number := some .singular, register := .formal }
 
 /-- *zuek* — 2pl. -/
 def zuek : PersonalPronoun :=
   { form := "zuek", person := some .second, number := some .plural }
-
--- ============================================================================
--- Third Person
--- ============================================================================
 
 /-- *hura* — 3sg. -/
 def hura : PersonalPronoun :=
@@ -55,73 +40,19 @@ def hura : PersonalPronoun :=
 def haiek : PersonalPronoun :=
   { form := "haiek", person := some .third, number := some .plural }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun := [ni, gu, hi, zu, zuek, hura, haiek]
 
-def secondPersonPronouns : List PersonalPronoun := [hi, zu]
-
-def allPronouns : List PersonalPronoun :=
-  [ni, gu] ++ secondPersonPronouns ++ [zuek, hura, haiek]
-
--- ============================================================================
--- Allocutive Markers ([alok-bhalla-2026] (1), Oyharçabal 1993)
--- ============================================================================
-
-/-- *-k* — nonhonorific addressee, male. -/
+/-- *-k* — nonhonorific male addressee. -/
 def allocM : AllocutiveEntry := { form := "-k", register := .informal, gloss := "M.NHA" }
 
-/-- *-n* — nonhonorific addressee, female. -/
+/-- *-n* — nonhonorific female addressee. -/
 def allocF : AllocutiveEntry := { form := "-n", register := .informal, gloss := "F.NHA" }
 
 /-- *-zü* — honorific addressee. -/
 def allocH : AllocutiveEntry := { form := "-zü", register := .formal, gloss := "HA" }
 
-def allAllocMarkers : List AllocutiveEntry := [allocM, allocF, allocH]
-
--- ============================================================================
--- Verb Agreement Examples
--- ============================================================================
-
-/-- A verb form showing allocutive inflection. -/
-structure VerbForm where
-  form : String
-  gloss : String
-  register : Level
-  deriving Repr, BEq
-
-/-- *duk* — "you have" (familiar). -/
-def duk : VerbForm := { form := "duk", gloss := "have.2sg.fam", register := .informal }
-
-/-- *duzu* — "you have" (formal). -/
-def duzu : VerbForm := { form := "duzu", gloss := "have.2sg.for", register := .formal }
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- Verb forms have matching register levels with 2nd person pronouns. -/
-theorem verb_register_matches_pronouns :
-    duk.register = hi.register ∧ duzu.register = zu.register := ⟨rfl, rfl⟩
+/-- The Souletin allocutive markers. -/
+def allocutiveMarkers : List AllocutiveEntry := [allocM, allocF, allocH]
 
 end Basque.Pronouns

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -29,11 +29,6 @@ in assumed-identity copular constructions ([keine-et-al-2019],
 namespace German.Pronouns
 
 open Pronoun
-open Features.Register (Level)
-
--- ============================================================================
--- § 1: Strong Pronouns
--- ============================================================================
 
 /-- *ich* — 1sg. -/
 def ich : PersonalPronoun :=
@@ -54,15 +49,15 @@ def sie_polite : PersonalPronoun :=
 
 /-- *er* — 3sg masculine. -/
 def er : PersonalPronoun :=
-  { form := "er", person := some .third, number := some .singular }
+  { form := "er", person := some .third, number := some .singular, gender := some .masculine }
 
 /-- *sie* — 3sg feminine. -/
 def sie_f : PersonalPronoun :=
-  { form := "sie", person := some .third, number := some .singular }
+  { form := "sie", person := some .third, number := some .singular, gender := some .feminine }
 
 /-- *es* — 3sg neuter. -/
 def es : PersonalPronoun :=
-  { form := "es", person := some .third, number := some .singular }
+  { form := "es", person := some .third, number := some .singular, gender := some .neuter }
 
 /-- *wir* — 1pl. -/
 def wir : PersonalPronoun :=
@@ -76,30 +71,8 @@ def ihr : PersonalPronoun :=
 def sie_pl : PersonalPronoun :=
   { form := "sie", person := some .third, number := some .plural }
 
-def allPronouns : List PersonalPronoun :=
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
   [ich, du, sie_polite, er, sie_f, es, wir, ihr, sie_pl]
-
--- ============================================================================
--- § 2: Verification Theorems
--- ============================================================================
-
-/-- T/V distinction: *du* is informal, *Sie* is formal. -/
-theorem tv_distinction :
-    du.register = .informal ∧ sie_polite.register = .formal := ⟨rfl, rfl⟩
-
-/-- SIE has 3rd person (plural) agreement features but 2nd person
-    interpretable features. [adamson-zompi-2025] -/
-theorem sie_polite_dual_person :
-    sie_polite.person = some .third ∧
-    sie_polite.referentialPerson = some .second := ⟨rfl, rfl⟩
-
-/-- SIE uses 3pl, unlike Italian LEI (3sg) and Spanish USTED (3sg). -/
-theorem sie_is_plural : sie_polite.number = some .plural := rfl
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
 
 end German.Pronouns

--- a/Linglib/Fragments/German/Pronouns.lean
+++ b/Linglib/Fragments/German/Pronouns.lean
@@ -20,10 +20,10 @@ refer to either a singular or plural addressee.
 ## Person hierarchy effects
 
 SIE triggers PCC effects in German's limited PCC environments (Wackernagel
-clusters, [anagnostopoulou-2008]), patterning with 2nd person ((47)–(48)).
-In contrast, SIE does NOT trigger the exponence-based person hierarchy effect
-in assumed-identity copular constructions ([keine-et-al-2019],
-[coon-keine-2021]), patterning with 3rd person ((52)–(53)).
+clusters), patterning with 2nd person, but not the exponence-based person
+hierarchy effect in assumed-identity copular constructions, where it patterns
+with 3rd person ([adamson-zompi-2025], whose study file carries both sets of
+examples).
 -/
 
 namespace German.Pronouns

--- a/Linglib/Fragments/Hindi/Pronouns.lean
+++ b/Linglib/Fragments/Hindi/Pronouns.lean
@@ -1,91 +1,43 @@
-/-
-# Hindi Pronoun Fragment
-
-Personal pronouns of Hindi (Indo-Aryan): a three-level honorific system for
-2nd person (non-hon *tuu* / hon *tum* / high-hon *aap*); 3rd person uses
-distal demonstrative forms (*vah* sg / *ve* pl). Hindi has no allocutive
-agreement; an honorific subject co-opts plural verb agreement
-([alok-bhalla-2026] (48), after Bhatt & Davis 2023).
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Hindi pronouns
+
+Personal pronouns of Hindi: a three-level honorific contrast in the second
+person (*tuu* / *tum* / *aap*) and demonstrative-based third-person forms
+(*vah* / *ve*). Hindi has no allocutive agreement; an honorific subject
+co-opts plural verb agreement ([alok-bhalla-2026] (48)).
+-/
 
 namespace Hindi.Pronouns
 
 open Pronoun
 
--- ============================================================================
--- First Person
--- ============================================================================
-
 /-- *maiṃ* — 1sg. -/
-def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .singular }
+def maiN : PersonalPronoun := { form := "maiṃ", person := some .first, number := some .singular }
 
 /-- *ham* — 1pl. -/
-def ham : PersonalPronoun :=
-  { form := "ham", person := some .first, number := some .plural }
+def ham : PersonalPronoun := { form := "ham", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (three-level honorific)
--- ============================================================================
-
-/-- *tuu* — 2sg non-honorific (intimate/inferior). -/
+/-- *tuu* — 2sg nonhonorific. -/
 def tuu : PersonalPronoun :=
   { form := "tuu", person := some .second, number := some .singular, register := .informal }
 
-/-- *tum* — 2sg honorific (neutral). -/
+/-- *tum* — 2sg honorific. -/
 def tum : PersonalPronoun :=
   { form := "tum", person := some .second, number := some .singular, register := .neutral }
 
-/-- *aap* — 2sg high-honorific (respectful). -/
+/-- *aap* — 2sg high honorific. -/
 def aap : PersonalPronoun :=
   { form := "aap", person := some .second, number := some .singular, register := .formal }
 
--- ============================================================================
--- Third Person (demonstrative-based)
--- ============================================================================
+/-- *vah* — 3sg, the distal demonstrative. -/
+def vah : PersonalPronoun := { form := "vah", person := some .third, number := some .singular }
 
-/-- *vah* — 3sg (distal demonstrative, standard pronoun). -/
-def vah : PersonalPronoun :=
-  { form := "vah", person := some .third, number := some .singular }
+/-- *ve* — 3pl, the distal demonstrative plural. -/
+def ve : PersonalPronoun := { form := "ve", person := some .third, number := some .plural }
 
-/-- *ve* — 3pl (distal demonstrative plural). -/
-def ve : PersonalPronoun :=
-  { form := "ve", person := some .third, number := some .plural }
-
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
-
-def secondPersonPronouns : List PersonalPronoun := [tuu, tum, aap]
-
-def allPronouns : List PersonalPronoun :=
-  [maiN, ham] ++ secondPersonPronouns ++ [vah, ve]
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- Three-level register distinction in 2nd person. -/
-theorem three_levels :
-    secondPersonPronouns.map (·.register) = [.informal, .neutral, .formal] := rfl
-
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun := [maiN, ham, tuu, tum, aap, vah, ve]
 
 end Hindi.Pronouns

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -16,8 +16,8 @@ Italian has a T/V distinction in 2nd person:
 
 ## Clitic Paradigm
 
-Italian object clitics show the same syncretism pattern as Spanish: 1sg/2sg are syncretic across accusative, dative,
-and reflexive cases, while 3sg/3pl are not.
+Italian object clitics show the same syncretism pattern as Spanish: 1sg/2sg are
+syncretic across accusative, dative, and reflexive cases, while 3sg/3pl are not.
 
 | Person | ACC    | DAT    | REFL |
 |--------|--------|--------|------|
@@ -33,7 +33,6 @@ and reflexive cases, while 3sg/3pl are not.
 namespace Italian.Pronouns
 
 open Pronoun
-open Features.Register (Level)
 
 -- ============================================================================
 -- § 1: Strong Pronouns
@@ -58,11 +57,11 @@ def lei_formal : PersonalPronoun :=
 
 /-- *lui* — 3sg masculine. -/
 def lui : PersonalPronoun :=
-  { form := "lui", person := some .third, number := some .singular }
+  { form := "lui", person := some .third, number := some .singular, gender := some .masculine }
 
 /-- *lei* — 3sg feminine. -/
 def lei : PersonalPronoun :=
-  { form := "lei", person := some .third, number := some .singular }
+  { form := "lei", person := some .third, number := some .singular, gender := some .feminine }
 
 /-- *noi* — 1pl. -/
 def noi : PersonalPronoun :=
@@ -80,10 +79,8 @@ def loro_formal : PersonalPronoun :=
 def loro : PersonalPronoun :=
   { form := "loro", person := some .third, number := some .plural }
 
-def secondPersonPronouns : List PersonalPronoun := [tu, lei_formal]
-
-def allPronouns : List PersonalPronoun :=
-  [io] ++ secondPersonPronouns ++ [lui, lei, noi, voi, loro_formal, loro]
+/-- The strong-pronoun inventory. -/
+def pronouns : List PersonalPronoun := [io, tu, lei_formal, lui, lei, noi, voi, loro_formal, loro]
 
 -- ============================================================================
 -- § 2: Clitic Paradigm
@@ -96,37 +93,48 @@ open Romance.Clitics (CliticEntry CliticCase)
 (`Fragments/Romance/Clitics.lean`). -/
 
 -- 1sg clitics
-def mi_acc : CliticEntry := { form := "mi", person := .first, number := .Sing, case_ := .accusative }
+def mi_acc : CliticEntry := { form := "mi", person := .first, number := .Sing,
+                              case_ := .accusative }
 def mi_dat : CliticEntry := { form := "mi", person := .first, number := .Sing, case_ := .dative }
-def mi_refl : CliticEntry := { form := "mi", person := .first, number := .Sing, case_ := .reflexive }
+def mi_refl : CliticEntry := { form := "mi", person := .first, number := .Sing,
+                               case_ := .reflexive }
 
 -- 2sg clitics
-def ti_acc : CliticEntry := { form := "ti", person := .second, number := .Sing, case_ := .accusative }
+def ti_acc : CliticEntry := { form := "ti", person := .second, number := .Sing,
+                              case_ := .accusative }
 def ti_dat : CliticEntry := { form := "ti", person := .second, number := .Sing, case_ := .dative }
-def ti_refl : CliticEntry := { form := "ti", person := .second, number := .Sing, case_ := .reflexive }
+def ti_refl : CliticEntry := { form := "ti", person := .second, number := .Sing,
+                               case_ := .reflexive }
 
 -- 3sg clitics
 def lo_cl : CliticEntry := { form := "lo", person := .third, number := .Sing, case_ := .accusative }
 def la_cl : CliticEntry := { form := "la", person := .third, number := .Sing, case_ := .accusative }
 def gli_dat : CliticEntry := { form := "gli", person := .third, number := .Sing, case_ := .dative }
 def le_dat : CliticEntry := { form := "le", person := .third, number := .Sing, case_ := .dative }
-def si_refl : CliticEntry := { form := "si", person := .third, number := .Sing, case_ := .reflexive }
+def si_refl : CliticEntry := { form := "si", person := .third, number := .Sing,
+                               case_ := .reflexive }
 
 -- 1pl clitics
-def ci_acc : CliticEntry := { form := "ci", person := .first, number := .Plur, case_ := .accusative }
+def ci_acc : CliticEntry := { form := "ci", person := .first, number := .Plur,
+                              case_ := .accusative }
 def ci_dat : CliticEntry := { form := "ci", person := .first, number := .Plur, case_ := .dative }
-def ci_refl : CliticEntry := { form := "ci", person := .first, number := .Plur, case_ := .reflexive }
+def ci_refl : CliticEntry := { form := "ci", person := .first, number := .Plur,
+                               case_ := .reflexive }
 
 -- 2pl clitics
-def vi_acc : CliticEntry := { form := "vi", person := .second, number := .Plur, case_ := .accusative }
+def vi_acc : CliticEntry := { form := "vi", person := .second, number := .Plur,
+                              case_ := .accusative }
 def vi_dat : CliticEntry := { form := "vi", person := .second, number := .Plur, case_ := .dative }
-def vi_refl : CliticEntry := { form := "vi", person := .second, number := .Plur, case_ := .reflexive }
+def vi_refl : CliticEntry := { form := "vi", person := .second, number := .Plur,
+                               case_ := .reflexive }
 
 -- 3pl clitics
 def li_cl : CliticEntry := { form := "li", person := .third, number := .Plur, case_ := .accusative }
 def le_cl : CliticEntry := { form := "le", person := .third, number := .Plur, case_ := .accusative }
-def loro_dat : CliticEntry := { form := "loro", person := .third, number := .Plur, case_ := .dative }
-def si_refl_pl : CliticEntry := { form := "si", person := .third, number := .Plur, case_ := .reflexive }
+def loro_dat : CliticEntry := { form := "loro", person := .third, number := .Plur,
+                                case_ := .dative }
+def si_refl_pl : CliticEntry := { form := "si", person := .third, number := .Plur,
+                                  case_ := .reflexive }
 
 -- ============================================================================
 -- § 3: Paradigm and Syncretism
@@ -187,45 +195,11 @@ theorem syncretic_2pl : datReflSyncretic .second .Plur = true := rfl
 /-- 3pl: dative and reflexive are NOT syncretic ("loro" ≠ "si"). -/
 theorem not_syncretic_3pl : datReflSyncretic .third .Plur = false := rfl
 
--- Form identity
-/-- 1sg forms are identical across all three cases. -/
-theorem mi_forms_identical :
-    mi_acc.form = mi_dat.form ∧ mi_dat.form = mi_refl.form := ⟨rfl, rfl⟩
-
-/-- 2sg forms are identical across all three cases. -/
-theorem ti_forms_identical :
-    ti_acc.form = ti_dat.form ∧ ti_dat.form = ti_refl.form := ⟨rfl, rfl⟩
-
-/-- 3sg dative ≠ 3sg reflexive (gli ≠ si). -/
-theorem gli_ne_si : gli_dat.form ≠ si_refl.form := by decide
-
--- T/V distinction
-/-- *tu* is informal, *Lei* is formal. -/
-theorem tv_distinction :
-    tu.register = .informal ∧ lei_formal.register = .formal := ⟨rfl, rfl⟩
-
-/-- *Lei* has 3rd person agreement features but 2nd person interpretable features.
-    [adamson-zompi-2025] -/
-theorem lei_formal_dual_person :
-    lei_formal.person = some .third ∧
-    lei_formal.referentialPerson = some .second := ⟨rfl, rfl⟩
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
 -- ============================================================================
 -- § 5: Cardinaletti–Starke deficiency classes
 -- ============================================================================
 
-/-- Italian's tonic series (`allPronouns`) instantiates the Cardinaletti–Starke
+/-- Italian's tonic series (`pronouns`) instantiates the Cardinaletti–Starke
     `.strong` class ([cardinaletti-starke-1999]). -/
 def strongStrength : Strength := .strong
 

--- a/Linglib/Fragments/Japanese/Pronouns.lean
+++ b/Linglib/Fragments/Japanese/Pronouns.lean
@@ -1,149 +1,76 @@
-/-
-# Japanese Pronoun & Allocutive Fragment
-
-Personal pronouns and allocutive particles in Japanese. Japanese has
-particle-based politeness marking (*-desu*/*-masu*) hosted in the SAP layer,
-restricted to root clauses. 1st person has register-sensitive variants
-(*watashi* neutral, *boku* male informal, *ore* male very informal).
-3rd person pronouns (*kare*, *kanojo*) are literary/modern innovations;
-traditional Japanese relies heavily on null reference.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Japanese pronouns and the addressee-honorific marker
+
+Personal pronouns of Japanese — register-differentiated first-person forms
+(*watashi*, *boku*, *ore*; [ochs-1992] on the masculine stance the latter
+index), the second-person contrast *kimi* vs *anata*, and the third-person
+forms *kare*, *kanojo*, *karera* — the reciprocal *otagai*, and the
+addressee-honorific verbal marker *-mas-*, which is sensitive to the
+complementizer when embedded ([alok-bhalla-2026] (14)–(15), (33)).
+-/
 
 namespace Japanese.Pronouns
 
 open Pronoun
-open Features.Register (Level)
 
--- ============================================================================
--- First Person
--- ============================================================================
-
-/-- 私 *watashi* — 1sg neutral/polite. -/
+/-- 私 *watashi* — 1sg, neutral. -/
 def watashi : PersonalPronoun :=
-  { form := "watashi", script := some "私", person := some .first, number := some .singular, register := .formal }
+  { form := "watashi", script := some "私", person := some .first, number := some .singular,
+    register := .neutral }
 
-/-- 僕 *boku* — 1sg informal, masculine-associated via register
-    (no inherent gender feature; cf. [ochs-1992]). -/
+/-- 僕 *boku* — 1sg informal, masculine-associated through register rather
+    than a gender feature ([ochs-1992]). -/
 def boku : PersonalPronoun :=
-  { form := "boku", script := some "僕", person := some .first, number := some .singular, register := .informal }
+  { form := "boku", script := some "僕", person := some .first, number := some .singular,
+    register := .informal }
 
-/-- 俺 *ore* — 1sg male very informal. Strongly indexes masculine identity
-    through assertive/coarse interactional stance ([ochs-1992]). -/
+/-- 俺 *ore* — 1sg very informal; indexes masculinity through an assertive
+    stance ([ochs-1992]). -/
 def ore : PersonalPronoun :=
-  { form := "ore", script := some "俺", person := some .first, number := some .singular, register := .informal }
+  { form := "ore", script := some "俺", person := some .first, number := some .singular,
+    register := .informal }
 
 /-- 私たち *watashitachi* — 1pl. -/
 def watashitachi : PersonalPronoun :=
-  { form := "watashitachi", script := some "私たち", person := some .first, number := some .plural }
-
--- ============================================================================
--- Second Person (T/V)
--- ============================================================================
+  { form := "watashitachi", script := some "私たち", person := some .first,
+    number := some .plural }
 
 /-- 君 *kimi* — 2sg plain. -/
 def kimi : PersonalPronoun :=
-  { form := "kimi", script := some "君", person := some .second, number := some .singular, register := .informal }
+  { form := "kimi", script := some "君", person := some .second, number := some .singular,
+    register := .informal }
 
 /-- あなた *anata* — 2sg polite. -/
 def anata : PersonalPronoun :=
-  { form := "anata", script := some "あなた", person := some .second, number := some .singular, register := .formal }
-
--- ============================================================================
--- Third Person
--- ============================================================================
+  { form := "anata", script := some "あなた", person := some .second, number := some .singular,
+    register := .formal }
 
 /-- 彼 *kare* — 3sg masculine. -/
 def kare : PersonalPronoun :=
-  { form := "kare", script := some "彼", person := some .third, number := some .singular }
+  { form := "kare", script := some "彼", person := some .third, number := some .singular,
+    gender := some .masculine }
 
 /-- 彼女 *kanojo* — 3sg feminine. -/
 def kanojo : PersonalPronoun :=
-  { form := "kanojo", script := some "彼女", person := some .third, number := some .singular }
+  { form := "kanojo", script := some "彼女", person := some .third, number := some .singular,
+    gender := some .feminine }
 
 /-- 彼ら *karera* — 3pl. -/
 def karera : PersonalPronoun :=
   { form := "karera", script := some "彼ら", person := some .third, number := some .plural }
 
--- ============================================================================
--- Reciprocal Pronoun
--- ============================================================================
+/-- The personal-pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
+  [watashi, boku, ore, watashitachi, kimi, anata, kare, kanojo, karera]
 
-/-- 互い *otagai* — reciprocal pronoun 'each other, one another'.
-    Formally distinct from the reflexive *jibun* (自分). This is an
-    NP/argument reciprocal strategy (reciprocal pronoun), unlike
-    languages that mark reciprocity on the verb. -/
-def otagai : PersonalPronoun :=
-  { form := "otagai", script := some "互い", person := some .third, number := some .plural }
+/-- 互い *otagai* — the reciprocal pronoun, distinct from the reflexive *jibun*. -/
+def otagai : Pronoun :=
+  { form := "otagai", script := some "互い", number := some .plural,
+    bindingClass := some .reciprocal }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
-
-def secondPersonPronouns : List PersonalPronoun := [kimi, anata]
-
-def allPronouns : List PersonalPronoun :=
-  [watashi, boku, ore, watashitachi] ++ secondPersonPronouns ++ [kare, kanojo, karera, otagai]
-
--- ============================================================================
--- Allocutive Particles (SAP-layer)
--- ============================================================================
-
-/-- *-desu* polite copula / *-masu* polite verbal. -/
-def desuMasu : AllocutiveEntry :=
-  { form := "-desu/-masu", register := .formal, gloss := "POL" }
-
-def allAllocParticles : List AllocutiveEntry := [desuMasu]
-
--- ============================================================================
--- Verb Agreement Examples
--- ============================================================================
-
-/-- A verb form showing speech-level inflection. -/
-structure VerbForm where
-  form : String
-  gloss : String
-  register : Level
-  deriving Repr, BEq
-
-/-- 行く *iku* — "go" (plain). -/
-def iku : VerbForm := { form := "iku", gloss := "go.PLN", register := .informal }
-
-/-- 行きます *ikimasu* — "go" (polite). -/
-def ikimasu : VerbForm := { form := "ikimasu", gloss := "go.POL", register := .formal }
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 1st person has register-based distinction. -/
-theorem first_person_register :
-    boku.register = .informal ∧ watashi.register = .formal := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- Verb forms span plain and polite levels. -/
-theorem verb_register_span :
-    iku.register = .informal ∧ ikimasu.register = .formal := ⟨rfl, rfl⟩
+/-- *-mas-* — the addressee-honorific marker on the verb. -/
+def mas : AllocutiveEntry := { form := "-mas-", register := .formal, gloss := "MAS" }
 
 end Japanese.Pronouns

--- a/Linglib/Fragments/Korean/Pronouns.lean
+++ b/Linglib/Fragments/Korean/Pronouns.lean
@@ -1,11 +1,12 @@
 /-
-# Korean Pronoun & Allocutive Fragment
+# Korean pronouns and speech-style particles
 [kwon-lee-2026] [sohn-1999]
 
-Personal pronouns and allocutive particles in Korean. Korean has
-particle-based allocutive marking (*-yo* polite, *-(su)pnida* formal)
-hosted in the SAP layer, restricted to root clauses. 1st person has a
-plain/humble distinction (*na* / *jeo*).
+Personal pronouns of Korean and its sentence-final speech-style particles
+(*-yo* polite, *-(su)pnida* formal), which encode the speaker–addressee
+relation and the formality of the discourse and are confined to root clauses
+([alok-bhalla-2026] (8), (13)). The first person has a plain/humble contrast
+(*na* / *jeo*).
 
 ## 3rd-Person Reference
 
@@ -44,7 +45,6 @@ import Linglib.Syntax.Category.Pronoun.Basic
 namespace Korean.Pronouns
 
 open Pronoun
-open Features.Register (Level)
 
 -- ============================================================================
 -- First Person
@@ -52,11 +52,13 @@ open Features.Register (Level)
 
 /-- 나 *na* — 1sg plain. -/
 def na : PersonalPronoun :=
-  { form := "na", script := some "나", person := some .first, number := some .singular, register := .informal }
+  { form := "na", script := some "나", person := some .first, number := some .singular,
+    register := .informal }
 
 /-- 저 *jeo* — 1sg humble. -/
 def jeo : PersonalPronoun :=
-  { form := "jeo", script := some "저", person := some .first, number := some .singular, register := .formal }
+  { form := "jeo", script := some "저", person := some .first, number := some .singular,
+    register := .formal }
 
 /-- 우리 *uri* — 1pl. -/
 def uri : PersonalPronoun :=
@@ -68,11 +70,13 @@ def uri : PersonalPronoun :=
 
 /-- 너 *neo* — 2sg plain. -/
 def neo : PersonalPronoun :=
-  { form := "neo", script := some "너", person := some .second, number := some .singular, register := .informal }
+  { form := "neo", script := some "너", person := some .second, number := some .singular,
+    register := .informal }
 
 /-- 당신 *dangsin* — 2sg polite. -/
 def dangsin : PersonalPronoun :=
-  { form := "dangsin", script := some "당신", person := some .second, number := some .singular, register := .formal }
+  { form := "dangsin", script := some "당신", person := some .second, number := some .singular,
+    register := .formal }
 
 -- ============================================================================
 -- Third Person
@@ -107,100 +111,18 @@ def geudeul : PersonalPronoun :=
   { form := "geudeul", script := some "그들", person := some .third, number := some .plural
   , register := .formal }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
+/-- The pronoun inventory: the literary third-person forms *geu*, *geunyeo*,
+    *geudeul* and the colloquial *gyae* (Yale *ku*, *kunye*, *kutul*, *kyay*). -/
+def pronouns : List PersonalPronoun :=
+  [na, jeo, uri, neo, dangsin, geu, geunyeo, geudeul, gyae]
 
-def secondPersonPronouns : List PersonalPronoun := [neo, dangsin]
+/-- *-yo* — the polite speech-style particle. -/
+def yo : AllocutiveEntry := { form := "-yo", register := .neutral, gloss := "POL" }
 
-/-- 3rd-person pronouns: literary *geu*/*geunyeo*/*geudeul* and
-    colloquial *gyae*. Yale-romanization variants (*ku*/*kunye*/*kutul*/
-    *kyay*) refer to the same lexical items. -/
-def thirdPersonPronouns : List PersonalPronoun := [geu, geunyeo, geudeul, gyae]
+/-- *-(su)pnida* — the formal speech-style particle. -/
+def supnida : AllocutiveEntry := { form := "-(su)pnida", register := .formal, gloss := "FORM" }
 
-def allPronouns : List PersonalPronoun :=
-  [na, jeo, uri] ++ secondPersonPronouns ++ thirdPersonPronouns
-
--- ============================================================================
--- Allocutive Particles (SAP-layer)
--- ============================================================================
-
-/-- *-yo* polite particle. -/
-def yo : AllocutiveEntry :=
-  { form := "-yo", register := .neutral, gloss := "POL" }
-
-/-- *-(su)pnida* formal particle. -/
-def supnida : AllocutiveEntry :=
-  { form := "-(su)pnida", register := .formal, gloss := "FORM" }
-
-def allAllocParticles : List AllocutiveEntry := [yo, supnida]
-
--- ============================================================================
--- Verb Agreement Examples
--- ============================================================================
-
-/-- A verb form showing speech-level inflection. -/
-structure VerbForm where
-  form : String
-  gloss : String
-  register : Level
-  deriving Repr, BEq
-
-/-- 가 *ga* — "go" (plain/intimate). -/
-def ga : VerbForm := { form := "ga", gloss := "go.PLN", register := .informal }
-
-/-- 가요 *gayo* — "go" (polite). -/
-def gayo : VerbForm := { form := "gayo", gloss := "go.POL", register := .neutral }
-
-/-- 갑니다 *gamnida* — "go" (formal). -/
-def gamnida : VerbForm := { form := "gamnida", gloss := "go.FORM", register := .formal }
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 1st person has plain/humble register distinction. -/
-theorem first_person_humble :
-    na.register = .informal ∧ jeo.register = .formal := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- Verb forms span all three speech levels. -/
-theorem verb_three_levels :
-    ga.register = .informal ∧ gayo.register = .neutral ∧ gamnida.register = .formal := ⟨rfl, rfl, rfl⟩
-
-/-- 3rd-person pronouns split by register: *gyae* is colloquial,
-    *geu*/*geunyeo*/*geudeul* are literary ([kwon-lee-2026] fn. 2). -/
-theorem third_person_register_split :
-    gyae.register = .informal ∧
-    geu.register = .formal ∧
-    geunyeo.register = .formal ∧
-    geudeul.register = .formal := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- *gyae* is gender-neutral; *geu*/*geunyeo* are gendered. This is the
-    central asymmetry of the Korean 3rd-person system: the colloquial
-    pronoun lacks the gender contrast carried by the literary forms. -/
-theorem gyae_gender_neutral :
-    gyae.gender = none ∧
-    geu.gender = some .masculine ∧
-    geunyeo.gender = some .feminine := ⟨rfl, rfl, rfl⟩
+/-- The speech-style particles recorded here. -/
+def allocutiveParticles : List AllocutiveEntry := [yo, supnida]
 
 end Korean.Pronouns

--- a/Linglib/Fragments/Magahi/Pronouns.lean
+++ b/Linglib/Fragments/Magahi/Pronouns.lean
@@ -1,36 +1,28 @@
-/-
-# Magahi Pronoun & Allocutive Fragment
-
-Personal pronouns and allocutive verbal morphology in Magahi (Indo-Aryan).
-Magahi has a three-level honorific system for 2nd person (non-hon / hon /
-high-hon) realized as verbal agreement morphemes. 3rd person uses demonstrative
-forms (*i* proximal / *ũ* distal). AA is Fin-based and freely embeddable.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Magahi pronouns and allocutive markers
+
+Personal pronouns of Magahi, with a three-level honorific contrast in the
+second person (*tõ* / *tũ* / *apne*) and a two-level one in the third
+(*okraa* / *unkaa*), and the allocutive agreement suffixes of
+[alok-bhalla-2026]'s (2)–(6): composites of the subject's and the
+addressee's honorific level (`allocutive`). Allocutive agreement is sourced
+from the finiteness phrase and occurs in every finite embedded clause.
+-/
 
 namespace Magahi.Pronouns
 
 open Pronoun
 
--- ============================================================================
--- First Person
--- ============================================================================
-
 /-- *hum* — 1sg. -/
-def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .singular }
+def hum : PersonalPronoun := { form := "hum", person := some .first, number := some .singular }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
   { form := "hum sab", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (three-level honorific)
--- ============================================================================
-
-/-- *tõ* — 2sg non-honorific. -/
+/-- *tõ* — 2sg nonhonorific. -/
 def toN : PersonalPronoun :=
   { form := "tõ", person := some .second, number := some .singular, register := .informal }
 
@@ -38,38 +30,52 @@ def toN : PersonalPronoun :=
 def tuN : PersonalPronoun :=
   { form := "tũ", person := some .second, number := some .singular, register := .neutral }
 
-/-- *apne* — 2sg high-honorific. -/
+/-- *apne* — 2sg high honorific. -/
 def apne : PersonalPronoun :=
   { form := "apne", person := some .second, number := some .singular, register := .formal }
 
--- ============================================================================
--- Third Person (demonstrative-based)
--- ============================================================================
+/-- *toraa* — 2sg nonhonorific accusative ([alok-bhalla-2026] (39)). -/
+def toraa : PersonalPronoun :=
+  { form := "toraa", person := some .second, number := some .singular, case_ := some .acc,
+    register := .informal }
+
+/-- *tor* — 2sg nonhonorific genitive ([alok-bhalla-2026] (41)). -/
+def tor : PersonalPronoun :=
+  { form := "tor", person := some .second, number := some .singular, case_ := some .gen,
+    register := .informal }
+
+/-- *apne-ke* — 2sg high honorific accusative/dative ([alok-bhalla-2026] (40)). -/
+def apneKe : PersonalPronoun :=
+  { form := "apne-ke", person := some .second, number := some .singular, case_ := some .acc,
+    register := .formal }
 
 /-- *i* — 3sg proximal. -/
-def i_prox : PersonalPronoun :=
-  { form := "i", person := some .third, number := some .singular }
+def iProx : PersonalPronoun := { form := "i", person := some .third, number := some .singular }
 
 /-- *ũ* — 3sg distal. -/
-def uN : PersonalPronoun :=
-  { form := "ũ", person := some .third, number := some .singular }
+def uN : PersonalPronoun := { form := "ũ", person := some .third, number := some .singular }
 
 /-- *ũ sab* — 3pl distal. -/
-def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .plural }
+def uNSab : PersonalPronoun := { form := "ũ sab", person := some .third, number := some .plural }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
+/-- *okraa* — 3sg nonhonorific accusative ([alok-bhalla-2026] (44a)). -/
+def okraa : PersonalPronoun :=
+  { form := "okraa", person := some .third, number := some .singular, case_ := some .acc,
+    register := .informal }
 
-def secondPersonPronouns : List PersonalPronoun := [toN, tuN, apne]
+/-- *okar* — 3sg nonhonorific genitive ([alok-bhalla-2026] (45)). -/
+def okar : PersonalPronoun :=
+  { form := "okar", person := some .third, number := some .singular, case_ := some .gen,
+    register := .informal }
 
-def allPronouns : List PersonalPronoun :=
-  [hum, humSab] ++ secondPersonPronouns ++ [i_prox, uN, uNSab]
+/-- *unkaa* — 3sg honorific accusative/dative ([alok-bhalla-2026] (44b)). -/
+def unkaa : PersonalPronoun :=
+  { form := "unkaa", person := some .third, number := some .singular, case_ := some .acc,
+    register := .neutral }
 
--- ============================================================================
--- Allocutive Markers ([alok-bhalla-2026] (2)–(6), Alok 2021)
--- ============================================================================
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
+  [hum, humSab, toN, tuN, apne, toraa, tor, apneKe, iProx, uN, uNSab, okraa, okar, unkaa]
 
 /-- *-au* — nonhonorific subject, nonhonorific addressee. -/
 def suffNH : AllocutiveEntry := { form := "-au", register := .informal, gloss := "NHS.NHA" }
@@ -80,9 +86,10 @@ def suffH : AllocutiveEntry := { form := "-o", register := .neutral, gloss := "N
 /-- *-ain* — nonhonorific subject, high-honorific addressee. -/
 def suffHH : AllocutiveEntry := { form := "-ain", register := .formal, gloss := "NHS.HHA" }
 
-def allAllocMarkers : List AllocutiveEntry := [suffNH, suffH, suffHH]
+/-- The allocutive markers of a nonhonorific subject. -/
+def allocutiveMarkers : List AllocutiveEntry := [suffNH, suffH, suffHH]
 
-/-- The fused subject/addressee agreement suffix, by the subject's and the
+/-- The fused subject/addressee agreement suffix by the subject's and the
     addressee's honorific level; `none` where no form is attested. -/
 def allocutive : Features.Register.Level → Features.Register.Level → Option String
   | .informal, .informal => some "-au"
@@ -91,32 +98,5 @@ def allocutive : Features.Register.Level → Features.Register.Level → Option 
   | .neutral, .informal => some "-thu(n)"
   | .formal, .formal => some "-thi(n)"
   | _, _ => none
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- Three-level register distinction in 2nd person. -/
-theorem three_levels :
-    secondPersonPronouns.map (·.register) = [.informal, .neutral, .formal] := rfl
-
-/-- Allocutive markers have three levels matching 2nd person pronouns. -/
-theorem markers_three_levels :
-    allAllocMarkers.map (·.register) = [.informal, .neutral, .formal] := rfl
 
 end Magahi.Pronouns

--- a/Linglib/Fragments/Maithili/Pronouns.lean
+++ b/Linglib/Fragments/Maithili/Pronouns.lean
@@ -1,38 +1,27 @@
-/-
-# Maithili Pronoun Fragment
-
-Personal pronouns of Maithili (Indo-Aryan): a three-level honorific system for
-2nd person (non-hon / hon / high-hon); 3rd person also distinguishes honorific
-levels (*ũ* non-hon / *o* hon). Maithili has allocutive agreement, blocked with
-a second-person subject and incompatible with object agreement
-([alok-bhalla-2026], after Kumari 2022); its marker forms are not recorded
-here.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Maithili pronouns
+
+Personal pronouns of Maithili: a three-level honorific contrast in the second
+person (*tõ* / *ahã* / *apne*) and a two-level one in the third (*ũ* / *o*).
+Maithili has allocutive agreement, blocked with a second-person subject and
+incompatible with object agreement ([alok-bhalla-2026], after Kumari 2022);
+its marker forms are not recorded here.
+-/
 
 namespace Maithili.Pronouns
 
 open Pronoun
 
--- ============================================================================
--- First Person
--- ============================================================================
-
 /-- *hum* — 1sg. -/
-def hum : PersonalPronoun :=
-  { form := "hum", person := some .first, number := some .singular }
+def hum : PersonalPronoun := { form := "hum", person := some .first, number := some .singular }
 
 /-- *hum sab* — 1pl. -/
 def humSab : PersonalPronoun :=
   { form := "hum sab", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (three-level honorific)
--- ============================================================================
-
-/-- *tõ* — 2sg non-honorific. -/
+/-- *tõ* — 2sg nonhonorific. -/
 def toN : PersonalPronoun :=
   { form := "tõ", person := some .second, number := some .singular, register := .informal }
 
@@ -40,15 +29,11 @@ def toN : PersonalPronoun :=
 def ahaN : PersonalPronoun :=
   { form := "ahã", person := some .second, number := some .singular, register := .neutral }
 
-/-- *apne* — 2sg high-honorific. -/
+/-- *apne* — 2sg high honorific. -/
 def apne : PersonalPronoun :=
   { form := "apne", person := some .second, number := some .singular, register := .formal }
 
--- ============================================================================
--- Third Person (honorific-sensitive)
--- ============================================================================
-
-/-- *ũ* — 3sg non-honorific (distal). -/
+/-- *ũ* — 3sg nonhonorific. -/
 def uN : PersonalPronoun :=
   { form := "ũ", person := some .third, number := some .singular, register := .informal }
 
@@ -57,43 +42,9 @@ def o : PersonalPronoun :=
   { form := "o", person := some .third, number := some .singular, register := .neutral }
 
 /-- *ũ sab* — 3pl. -/
-def uNSab : PersonalPronoun :=
-  { form := "ũ sab", person := some .third, number := some .plural }
+def uNSab : PersonalPronoun := { form := "ũ sab", person := some .third, number := some .plural }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
-
-def secondPersonPronouns : List PersonalPronoun := [toN, ahaN, apne]
-
-def allPronouns : List PersonalPronoun :=
-  [hum, humSab] ++ secondPersonPronouns ++ [uN, o, uNSab]
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- Three-level register distinction in 2nd person. -/
-theorem three_levels :
-    secondPersonPronouns.map (·.register) = [.informal, .neutral, .formal] := rfl
-
-/-- 3rd person also has a register distinction. -/
-theorem third_person_honorific :
-    uN.register = .informal ∧ o.register = .neutral := ⟨rfl, rfl⟩
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun := [hum, humSab, toN, ahaN, apne, uN, o, uNSab]
 
 end Maithili.Pronouns

--- a/Linglib/Fragments/Punjabi/Pronouns.lean
+++ b/Linglib/Fragments/Punjabi/Pronouns.lean
@@ -1,91 +1,40 @@
-/-
-# Punjabi Pronoun Fragment
-
-Personal pronouns of Punjabi (Indo-Aryan): a two-level honorific system for
-2nd person (non-hon *tũ* / hon *tusii*); 3rd person uses demonstrative forms
-(*uh* for both sg and pl). Punjabi has allocutive agreement with third-person
-subjects only ([alok-bhalla-2026], after Kaur 2020); its marker forms are not
-recorded here.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Punjabi pronouns
+
+Personal pronouns of Punjabi: a two-level honorific contrast in the second
+person (*tũ* / *tusii*, the latter also the plural) and the demonstrative
+*uh* for both third-person numbers. Punjabi has allocutive agreement with
+third-person subjects only ([alok-bhalla-2026], after Kaur 2020); its marker
+forms are not recorded here.
+-/
 
 namespace Punjabi.Pronouns
 
 open Pronoun
 
--- ============================================================================
--- First Person
--- ============================================================================
-
 /-- *maiṃ* — 1sg. -/
-def maiN : PersonalPronoun :=
-  { form := "maiṃ", person := some .first, number := some .singular }
+def maiN : PersonalPronoun := { form := "maiṃ", person := some .first, number := some .singular }
 
 /-- *asiiṃ* — 1pl. -/
-def asiiN : PersonalPronoun :=
-  { form := "asiiṃ", person := some .first, number := some .plural }
+def asiiN : PersonalPronoun := { form := "asiiṃ", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (two-level honorific)
--- ============================================================================
-
-/-- *tũ* — 2sg non-honorific. -/
+/-- *tũ* — 2sg nonhonorific. -/
 def tuN : PersonalPronoun :=
   { form := "tũ", person := some .second, number := some .singular, register := .informal }
 
-/-- *tusii* — 2sg honorific (also 2pl). -/
+/-- *tusii* — 2sg honorific, also 2pl. -/
 def tusii : PersonalPronoun :=
   { form := "tusii", person := some .second, number := some .singular, register := .formal }
 
--- ============================================================================
--- Third Person (demonstrative-based)
--- ============================================================================
+/-- *uh* — 3sg, the distal demonstrative. -/
+def uhSg : PersonalPronoun := { form := "uh", person := some .third, number := some .singular }
 
-/-- *uh* — 3sg (distal demonstrative). -/
-def uh_sg : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .singular }
+/-- *uh* — 3pl, the same form. -/
+def uhPl : PersonalPronoun := { form := "uh", person := some .third, number := some .plural }
 
-/-- *uh* — 3pl (same form as 3sg in standard Punjabi). -/
-def uh_pl : PersonalPronoun :=
-  { form := "uh", person := some .third, number := some .plural }
-
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
-
-def secondPersonPronouns : List PersonalPronoun := [tuN, tusii]
-
-def allPronouns : List PersonalPronoun :=
-  [maiN, asiiN] ++ secondPersonPronouns ++ [uh_sg, uh_pl]
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- 3sg and 3pl share the same form (demonstrative-based). -/
-theorem third_person_homophony :
-    uh_sg.form = uh_pl.form := rfl
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun := [maiN, asiiN, tuN, tusii, uhSg, uhPl]
 
 end Punjabi.Pronouns

--- a/Linglib/Fragments/Romance/Galician/Pronouns.lean
+++ b/Linglib/Fragments/Romance/Galician/Pronouns.lean
@@ -1,139 +1,68 @@
-/-
-# Galician Pronoun & Allocutive Fragment
-
-Personal pronouns and allocutive clitic in Galician (Romance).
-Galician has a T/V distinction (*ti* familiar vs *vostede* formal) and a
-familiar dative clitic *che* that attaches to the verb for allocutive marking.
-2nd person plural distinguishes familiar *vós* from formal *vostedes*.
-3rd person distinguishes masculine and feminine in both singular and plural.
-AA is Fin-based and freely embeddable.
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Galician pronouns and allocutive clitics
+
+Personal pronouns of Galician, with the T/V contrast *ti* / *vostede* in the
+singular and *vós* / *vostedes* in the plural, and the familiar dative
+clitics *che* and *vos* that double as allocutive markers ([alok-bhalla-2026]
+(9)–(10)): the same morphemes serve as thematic datives, and the allocutive
+use occurs in every finite embedded clause and inside infinitives.
+-/
 
 namespace Galician.Pronouns
 
 open Pronoun
-open Features.Register (Level)
-
--- ============================================================================
--- First Person
--- ============================================================================
 
 /-- *eu* — 1sg. -/
-def eu : PersonalPronoun :=
-  { form := "eu", person := some .first, number := some .singular }
+def eu : PersonalPronoun := { form := "eu", person := some .first, number := some .singular }
 
 /-- *nós* — 1pl. -/
-def nos : PersonalPronoun :=
-  { form := "nós", person := some .first, number := some .plural }
+def nos : PersonalPronoun := { form := "nós", person := some .first, number := some .plural }
 
--- ============================================================================
--- Second Person (T/V, sg and pl)
--- ============================================================================
-
-/-- *ti* — 2sg familiar (T form). -/
+/-- *ti* — 2sg familiar. -/
 def ti : PersonalPronoun :=
   { form := "ti", person := some .second, number := some .singular, register := .informal }
 
-/-- *vostede* — 2sg formal (V form). -/
+/-- *vostede* — 2sg formal. -/
 def vostede : PersonalPronoun :=
   { form := "vostede", person := some .second, number := some .singular, register := .formal }
 
 /-- *vós* — 2pl familiar. -/
-def vos_pl : PersonalPronoun :=
+def vosPl : PersonalPronoun :=
   { form := "vós", person := some .second, number := some .plural, register := .informal }
 
 /-- *vostedes* — 2pl formal. -/
 def vostedes : PersonalPronoun :=
   { form := "vostedes", person := some .second, number := some .plural, register := .formal }
 
--- ============================================================================
--- Third Person
--- ============================================================================
-
 /-- *el* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "el", person := some .third, number := some .singular }
+  { form := "el", person := some .third, number := some .singular, gender := some .masculine }
 
 /-- *ela* — 3sg feminine. -/
 def ela : PersonalPronoun :=
-  { form := "ela", person := some .third, number := some .singular }
+  { form := "ela", person := some .third, number := some .singular, gender := some .feminine }
 
 /-- *eles* — 3pl masculine. -/
 def eles : PersonalPronoun :=
-  { form := "eles", person := some .third, number := some .plural }
+  { form := "eles", person := some .third, number := some .plural, gender := some .masculine }
 
 /-- *elas* — 3pl feminine. -/
 def elas : PersonalPronoun :=
-  { form := "elas", person := some .third, number := some .plural }
+  { form := "elas", person := some .third, number := some .plural, gender := some .feminine }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
+  [eu, nos, ti, vostede, vosPl, vostedes, el, ela, eles, elas]
 
-def secondPersonPronouns : List PersonalPronoun := [ti, vostede]
+/-- *che* — familiar dative clitic, singular addressee. -/
+def che : AllocutiveEntry := { form := "che", register := .informal, gloss := "2sg.DAT.fam" }
 
-def allPronouns : List PersonalPronoun :=
-  [eu, nos] ++ secondPersonPronouns ++ [vos_pl, vostedes, el, ela, eles, elas]
-
--- ============================================================================
--- Allocutive Clitic
--- ============================================================================
-
-/-- *che* — familiar dative clitic (2sg ethical dative). -/
-def che : AllocutiveEntry :=
-  { form := "che", register := .informal, gloss := "2sg.DAT.fam" }
-
-/-- *vos* — familiar dative clitic, plural addressee ([alok-bhalla-2026] (9a)). -/
+/-- *vos* — familiar dative clitic, plural addressee. -/
 def vos : AllocutiveEntry := { form := "vos", register := .informal, gloss := "2pl.DAT.fam" }
 
-def allAllocClitics : List AllocutiveEntry := [che, vos]
-
--- ============================================================================
--- Verb Agreement Examples
--- ============================================================================
-
-/-- A verb form with optional allocutive clitic. -/
-structure VerbForm where
-  form : String
-  gloss : String
-  register : Level
-  deriving Repr, BEq
-
-/-- *vas* — "you go" (familiar, can host *che*). -/
-def vas : VerbForm := { form := "vas", gloss := "go.2sg.fam", register := .informal }
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- The allocutive clitic *che* is informal-level. -/
-theorem che_is_informal : che.register = .informal := rfl
-
-/-- 2pl preserves the T/V distinction (vós fam / vostedes form). -/
-theorem plural_tv :
-    vos_pl.register = .informal ∧ vostedes.register = .formal := ⟨rfl, rfl⟩
+/-- The allocutive clitics. -/
+def allocutiveClitics : List AllocutiveEntry := [che, vos]
 
 end Galician.Pronouns

--- a/Linglib/Fragments/Spanish/Pronouns.lean
+++ b/Linglib/Fragments/Spanish/Pronouns.lean
@@ -29,11 +29,6 @@ Unlike Italian LEI, USTED can also be used in *laísta* varieties where
 namespace Spanish.Pronouns
 
 open Pronoun
-open Features.Register (Level)
-
--- ============================================================================
--- § 1: Strong Pronouns
--- ============================================================================
 
 /-- *yo* — 1sg. -/
 def yo : PersonalPronoun :=
@@ -54,11 +49,11 @@ def usted : PersonalPronoun :=
 
 /-- *él* — 3sg masculine. -/
 def el : PersonalPronoun :=
-  { form := "él", person := some .third, number := some .singular }
+  { form := "él", person := some .third, number := some .singular, gender := some .masculine }
 
 /-- *ella* — 3sg feminine. -/
 def ella : PersonalPronoun :=
-  { form := "ella", person := some .third, number := some .singular }
+  { form := "ella", person := some .third, number := some .singular, gender := some .feminine }
 
 /-- *nosotros* — 1pl. -/
 def nosotros : PersonalPronoun :=
@@ -75,34 +70,14 @@ def ustedes : PersonalPronoun :=
 
 /-- *ellos* — 3pl masculine. -/
 def ellos : PersonalPronoun :=
-  { form := "ellos", person := some .third, number := some .plural }
+  { form := "ellos", person := some .third, number := some .plural, gender := some .masculine }
 
-def allPronouns : List PersonalPronoun :=
-  [yo, tu, usted, el, ella, nosotros, vosotros, ustedes, ellos]
+/-- *ellas* — 3pl feminine. -/
+def ellas : PersonalPronoun :=
+  { form := "ellas", person := some .third, number := some .plural, gender := some .feminine }
 
--- ============================================================================
--- § 2: Verification Theorems
--- ============================================================================
-
-/-- T/V distinction: *tú* is informal, *usted* is formal. -/
-theorem tv_distinction :
-    tu.register = .informal ∧ usted.register = .formal := ⟨rfl, rfl⟩
-
-/-- USTED has 3rd person agreement features but 2nd person interpretable
-    features. [adamson-zompi-2025] -/
-theorem usted_dual_person :
-    usted.person = some .third ∧
-    usted.referentialPerson = some .second := ⟨rfl, rfl⟩
-
-/-- *ustedes* (2pl formal) also has dual person features. -/
-theorem ustedes_dual_person :
-    ustedes.person = some .third ∧
-    ustedes.referentialPerson = some .second := ⟨rfl, rfl⟩
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
+/-- The strong-pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
+  [yo, tu, usted, el, ella, nosotros, vosotros, ustedes, ellos, ellas]
 
 end Spanish.Pronouns

--- a/Linglib/Fragments/Tamil/Pronouns.lean
+++ b/Linglib/Fragments/Tamil/Pronouns.lean
@@ -1,128 +1,70 @@
-/-
-# Tamil Pronoun & Allocutive Fragment
-
-Personal pronouns and allocutive verbal morphology in Tamil (Dravidian).
-Tamil has a two-level honorific system (non-hon / hon) realized as verbal
-agreement suffixes. 1st person plural distinguishes inclusive (*naam*) vs
-exclusive (*naangaL*). 3rd person distinguishes masculine (*avan*), feminine
-(*avaL*), and honorific (*avar*). The allocutive marker *-ŋgæ* is the plural
-suffix; it appears twice in root clauses and only below the complementizer
-when embedded ([alok-bhalla-2026]).
-
--/
-
 import Linglib.Syntax.Category.Pronoun.Basic
+
+/-!
+# Tamil pronouns and the allocutive marker
+
+Personal pronouns of Tamil — an inclusive/exclusive contrast in the first
+person plural (*naam* / *naangaL*), the honorific contrast *nii* / *niingaL*
+in the second person, and gendered and honorific third-person forms — and
+the allocutive marker *-ŋgæ*, which is the nominal plural suffix
+([alok-bhalla-2026] (7), Table 1; McFadden 2020). In root clauses the marker
+can appear both below and above the question particle; when embedded, only
+below the complementizer.
+-/
 
 namespace Tamil.Pronouns
 
 open Pronoun
 
--- ============================================================================
--- First Person
--- ============================================================================
-
 /-- *naan* — 1sg. -/
-def naan : PersonalPronoun :=
-  { form := "naan", person := some .first, number := some .singular }
+def naan : PersonalPronoun := { form := "naan", person := some .first, number := some .singular }
 
-/-- *naam* — 1pl inclusive (speaker + addressee). -/
+/-- *naam* — 1pl inclusive. -/
 def naam : PersonalPronoun :=
   { form := "naam", person := some .firstInclusive, number := some .plural }
 
-/-- *naangaL* — 1pl exclusive (speaker + others, not addressee). -/
+/-- *naangaL* — 1pl exclusive. -/
 def naangaL : PersonalPronoun :=
   { form := "naangaL", person := some .firstExclusive, number := some .plural }
 
--- ============================================================================
--- Second Person (two-level honorific)
--- ============================================================================
-
-/-- *nii* — 2sg non-honorific. -/
+/-- *nii* — 2sg nonhonorific. -/
 def nii : PersonalPronoun :=
   { form := "nii", person := some .second, number := some .singular, register := .informal }
 
-/-- *niingaL* — 2sg honorific (also 2pl). -/
+/-- *niingaL* — 2sg honorific, also 2pl. -/
 def niingaL : PersonalPronoun :=
   { form := "niingaL", person := some .second, number := some .singular, register := .formal }
 
--- ============================================================================
--- Third Person
--- ============================================================================
-
 /-- *avan* — 3sg masculine. -/
 def avan : PersonalPronoun :=
-  { form := "avan", person := some .third, number := some .singular }
+  { form := "avan", person := some .third, number := some .singular, gender := some .masculine }
 
 /-- *avaL* — 3sg feminine. -/
 def avaL : PersonalPronoun :=
-  { form := "avaL", person := some .third, number := some .singular }
+  { form := "avaL", person := some .third, number := some .singular, gender := some .feminine }
 
 /-- *avar* — 3sg honorific. -/
 def avar : PersonalPronoun :=
   { form := "avar", person := some .third, number := some .singular, register := .formal }
 
-/-- *avarkaL* — 3pl (human). -/
+/-- *avarkaL* — 3pl human. -/
 def avarkaL : PersonalPronoun :=
   { form := "avarkaL", person := some .third, number := some .plural }
 
--- ============================================================================
--- Pronoun Lists
--- ============================================================================
+/-- The pronoun inventory. -/
+def pronouns : List PersonalPronoun :=
+  [naan, naam, naangaL, nii, niingaL, avan, avaL, avar, avarkaL]
 
-def secondPersonPronouns : List PersonalPronoun := [nii, niingaL]
-
-def allPronouns : List PersonalPronoun :=
-  [naan, naam, naangaL] ++ secondPersonPronouns ++ [avan, avaL, avar, avarkaL]
-
--- ============================================================================
--- Allocutive Marker ([alok-bhalla-2026] (7), Table 1; McFadden 2020)
--- ============================================================================
-
-/-- *-ŋgæ* — politeness to the addressee. -/
-def alloc : AllocutiveEntry := { form := "-ŋgæ", register := .formal, gloss := "ALLOC" }
-
-def allAllocMarkers : List AllocutiveEntry := [alloc]
-
-/-- The nominal plural suffix, homophonous with the allocutive marker. -/
+/-- The nominal plural suffix. -/
 def pluralSuffix : String := "-ŋgæ"
 
-/-- Number marking on nominals (Table 1 of [alok-bhalla-2026], after McFadden
-    2020): singular and plural forms. -/
+/-- *-ŋgæ* — politeness to the addressee; the plural suffix itself. -/
+def alloc : AllocutiveEntry := { form := pluralSuffix, register := .formal, gloss := "ALLOC" }
+
+/-- Number marking on nominals, singular and plural (Table 1 of
+    [alok-bhalla-2026], after McFadden 2020). -/
 def numberPairs : List (String × String) :=
   [("naan", "naan-ŋgæ"), ("nii", "nii-ŋgæ"), ("avan", "avan-ŋgæ"), ("poɳɳǔ", "poɳɳǔ-ŋgæ"),
    ("maram", "maram-ŋgæ")]
-
--- ============================================================================
--- Verification
--- ============================================================================
-
-/-- All three persons are attested. -/
-theorem has_all_persons :
-    allPronouns.any (·.person == some .first) = true ∧
-    allPronouns.any (·.person == some .second) = true ∧
-    allPronouns.any (·.person == some .third) = true := ⟨rfl, rfl, rfl⟩
-
-/-- Both singular and plural are attested. -/
-theorem has_both_numbers :
-    allPronouns.any (·.number == some .singular) = true ∧
-    allPronouns.any (·.number == some .plural) = true := ⟨rfl, rfl⟩
-
-/-- Tamil has the inclusive/exclusive distinction in 1pl — carried on the
-    person values themselves. -/
-theorem has_incl_excl :
-    allPronouns.any (·.person == some .firstInclusive) = true ∧
-    allPronouns.any (·.person == some .firstExclusive) = true := ⟨rfl, rfl⟩
-
-/-- 2nd person pronouns are all second person. -/
-theorem second_person_all_2p :
-    secondPersonPronouns.all (·.person == some .second) = true := rfl
-
-/-- The T/V register distinction is present in 2nd person. -/
-theorem tv_distinction :
-    secondPersonPronouns.any (·.register == .informal) = true ∧
-    secondPersonPronouns.any (·.register == .formal) = true := ⟨rfl, rfl⟩
-
-/-- The allocutive marker is the plural suffix. -/
-theorem alloc_eq_pluralSuffix : alloc.form = pluralSuffix := rfl
 
 end Tamil.Pronouns

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -113,8 +113,8 @@ theorem magahi_fusion_rows :
 /-- The Souletin markers of ex 1 and the Galician clitics are the Fragments'. -/
 theorem marker_rows :
     ∀ row ∈ Examples.all, ∀ m ∈ row.feature? "marker",
-      (row.language = "soul1243" → m ∈ Basque.Pronouns.allAllocMarkers.map (·.form)) ∧
-      (row.language = "gali1258" → m ∈ Galician.Pronouns.allAllocClitics.map (·.form)) ∧
+      (row.language = "soul1243" → m ∈ Basque.Pronouns.allocutiveMarkers.map (·.form)) ∧
+      (row.language = "gali1258" → m ∈ Galician.Pronouns.allocutiveClitics.map (·.form)) ∧
       (row.language = "tami1289" → m = Tamil.Pronouns.pluralSuffix) := by
   decide +kernel
 


### PR DESCRIPTION
Twelve `Fragments/*/Pronouns.lean` files: the per-file `VerbForm` structures and verb examples, the `rfl` data-check theorems (`has_all_persons`, `tv_distinction`, …), and the derivable sublists are gone; inventories are `pronouns`; third-person entries carry their gender; Japanese *otagai* is a reciprocal `Pronoun`; Magahi gains the case-marked honorific forms of the review's examples; docstrings state sources. English, Tagalog and Mam were already in shape.