### PR TITLE
refactor(Semantics/Presupposition): rename namespace to root Presupposition

### DIFF
--- a/Linglib/Features/Polarity.lean
+++ b/Linglib/Features/Polarity.lean
@@ -10,7 +10,7 @@ Note: This is distinct from other polarity-like distinctions in the library:
 - `Core.Lexical.UD.Polarity` — morphological feature (`.Pos`/`.Neg`)
 - `NaturalLogic.ContextPolarity` — monotonicity direction (`.upward`/`.downward`)
 - `Rett2015.Polarity` — adjective markedness
-- `Semantics.Presupposition.Aboutness.EventSentence.polarity` — polarity of the event claim
+- `Presupposition.Aboutness.EventSentence.polarity` — polarity of the event claim
 -/
 
 namespace Features

--- a/Linglib/Fragments/ASL/Height.lean
+++ b/Linglib/Fragments/ASL/Height.lean
@@ -39,7 +39,7 @@ pronouns or proximal/distal on demonstratives.
 
 namespace ASL.Height
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Vertical Height Scale

--- a/Linglib/Fragments/Cantonese/Particles.lean
+++ b/Linglib/Fragments/Cantonese/Particles.lean
@@ -19,7 +19,7 @@ trigger movement to matrix AspP_outer — lives in the Studies file.
 
 namespace Cantonese.Particles
 
-open Semantics.Presupposition.TriggerTypology (PresupTrigger)
+open Presupposition.TriggerTypology
 
 /-- A Cantonese presuppositional particle entry. -/
 structure PresupParticle where

--- a/Linglib/Fragments/Mandarin/Particles.lean
+++ b/Linglib/Fragments/Mandarin/Particles.lean
@@ -23,7 +23,7 @@ competition analysis built on it live in `Studies/Wang2025.lean`.
 
 namespace Mandarin.Particles
 
-open Semantics.Presupposition.TriggerTypology (PresupTrigger)
+open Presupposition.TriggerTypology
 
 /-- Mandarin presupposition triggers studied in [wang-2025] Experiments 1-2. -/
 inductive MandarinTrigger where

--- a/Linglib/Logic/Natural/Strawson/Basic.lean
+++ b/Linglib/Logic/Natural/Strawson/Basic.lean
@@ -152,7 +152,7 @@ Von Fintel's key observation: `only` is NOT classically DE
 "Only x VP" as a `PartialProp`: Horn's asymmetric decomposition.
 -/
 def onlyPartialProp {W : Type*} (x : W → Prop) (scope : Set W) :
-    Semantics.Presupposition.PartialProp W where
+    Presupposition.PartialProp W where
   presup := fun _ => ∃ y, x y ∧ scope y
   assertion := fun _ => ∀ y, x y ∨ ¬ scope y
 

--- a/Linglib/Pragmatics/DecisionTheoretic/Also.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/Also.lean
@@ -32,7 +32,7 @@ open scoped ENNReal
 
 namespace DTS.Also
 
-open Semantics.Presupposition
+open Presupposition
 open DTS
 open DTS.ScalarImplicature (sgnRelevance RelevanceSign)
 

--- a/Linglib/Pragmatics/Expressives/Basic.lean
+++ b/Linglib/Pragmatics/Expressives/Basic.lean
@@ -12,7 +12,7 @@ truth-functional connectives and are blocked only by direct quotation ([potts-20
 
 The at-issue tier carries the Heyting algebra of `W → Prop` (`ᶜ`/`⊓`/`⊔`/`⇨`); the CI tier
 always takes the meet `⊓`. `TwoDimProp.ofPartialProp` bridges
-`Semantics.Presupposition.PartialProp` into this type.
+`Presupposition.PartialProp` into this type.
 
 ## Main definitions
 
@@ -202,7 +202,7 @@ def appositiveProperties : SecondaryMeaningProperties :=
 analysis. Deliberately discards presupposition *filtering*: a CI-tier presupposition projects
 through `and`/`imp` where a real presupposition would be filtered by its local context, which
 is the point — the de re presupposition is evaluated against the common ground instead. -/
-@[simps] def TwoDimProp.ofPartialProp (p : Semantics.Presupposition.PartialProp W) :
+@[simps] def TwoDimProp.ofPartialProp (p : Presupposition.PartialProp W) :
     TwoDimProp W := ⟨p.assertion, p.presup⟩
 
 end Pragmatics.Expressives

--- a/Linglib/Semantics/Aspect/ChangeOfState.lean
+++ b/Linglib/Semantics/Aspect/ChangeOfState.lean
@@ -15,7 +15,7 @@ Each CoS predicate has:
 1. A **presupposition** about the prior state
 2. An **assertion** about the result state
 
-This maps directly to `PartialProp` from `Semantics.Presupposition`:
+This maps directly to `PartialProp` from `Presupposition`:
 - `presup`: the prior state condition
 - `assertion`: the result state condition
 
@@ -34,7 +34,7 @@ import Linglib.Semantics.Presupposition.Basic
 
 namespace Features.ChangeOfState
 
-open Semantics.Presupposition
+open Presupposition
 
 -- Change-of-State Verb Classification
 

--- a/Linglib/Semantics/Attitudes/Desire/QuestionBased.lean
+++ b/Linglib/Semantics/Attitudes/Desire/QuestionBased.lean
@@ -18,7 +18,7 @@ On the finest question the semantics is the best-worlds one (`want_finest_iff`).
 
 namespace Desire.QuestionBased
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 variable {W : Type*} (G N Q : List (Finset W)) (bel p : Set W)
 

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -18,7 +18,7 @@ veridicality and opacity. Its proposition-taking semantics
 verbs require the complement at the evaluation world,
 `veridical_entails_complement`) with the universal modal, and
 `toPartialProp` exposes the same content as a
-`Semantics.Presupposition.PartialProp` — presupposition = veridicality
+`Presupposition.PartialProp` — presupposition = veridicality
 check, assertion = modal — connecting doxastic verbs to the projection
 infrastructure. `HoldsAtQuestion` is the [karttunen-1977]
 question-taking semantics: knowing a question is knowing a true answer.
@@ -126,7 +126,7 @@ theorem veridical_entails_complement (V : DoxasticPredicate W E)
   simp only [hV, VeridicalityHolds] at holds
   exact holds.1
 
-open Semantics.Presupposition in
+open Presupposition in
 /-- The predicate application as a `PartialProp`: presupposition =
     veridicality check, assertion = universal modal. `HoldsAt` is the
     conjunction of the two fields. -/

--- a/Linglib/Semantics/Conditionals/Presupposition.lean
+++ b/Linglib/Semantics/Conditionals/Presupposition.lean
@@ -44,7 +44,7 @@ namespace Semantics.Conditionals.Presupposition
 
 open Semantics.Conditionals
 open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Presupposition
+open _root_.Presupposition
 
 variable {W : Type*}
 

--- a/Linglib/Semantics/Definiteness/Basic.lean
+++ b/Linglib/Semantics/Definiteness/Basic.lean
@@ -15,7 +15,7 @@ the library. The denotational layer itself lives in two canonical pieces:
 
 - `Definiteness.russellIotaList` (the per-context referent selector,
   Russellian iota over a `List E` filtered by a `Bool` predicate), and
-- `Semantics.Presupposition.PartialProp.presupOfReferent` (the combinator lifting a
+- `Presupposition.PartialProp.presupOfReferent` (the combinator lifting a
   referent selector and a scope predicate into a `PartialProp W`).
 
 All variants — uniqueness-based, familiarity-based, anaphoric (ι^x),
@@ -45,7 +45,7 @@ open Intensional (Ty)
 open Quantification (every_sem some_sem)
 open Quantification.Quantifier (Ty.det)
 open Semantics.Composition.TypeShifting (iota)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 -- ============================================================================
 -- §1: Discourse Context

--- a/Linglib/Semantics/Definiteness/Maximality.lean
+++ b/Linglib/Semantics/Definiteness/Maximality.lean
@@ -131,7 +131,7 @@ theorem russellIota_witness_unique
 /-- Computable list-based Russellian iota: returns the unique witness when
     `domain.filter P` is a singleton, `none` otherwise. This is the concrete
     operational counterpart to `russellIota` and the canonical referent
-    selector used by `Semantics.Presupposition.presupOfReferent`. -/
+    selector used by `Presupposition.presupOfReferent`. -/
 def russellIotaList {E : Type*} (domain : List E) (P : E → Bool) : Option E :=
   match domain.filter P with
   | [e] => some e

--- a/Linglib/Semantics/Dynamic/Partial.lean
+++ b/Linglib/Semantics/Dynamic/Partial.lean
@@ -50,7 +50,7 @@ dynamic conjunction, conditional, and disjunction
 
 namespace DynamicSemantics
 
-open Semantics.Presupposition
+open Presupposition
 
 /-- A partial context change potential: a partial function on information
     states, the partial variant of the `CCP` API. The domain condition is

--- a/Linglib/Semantics/Events/Phase.lean
+++ b/Linglib/Semantics/Events/Phase.lean
@@ -7,7 +7,7 @@ The modal signature of an event type: the world-conditions that must hold
 *before* the event is possible (`precondition`), at its occurrence, and
 *after* it (`consequence`). Originates with [roberts-simons-2024]'s account
 of non-anaphoric presupposition, where ontological preconditions are what
-project (`Semantics.Presupposition.Aboutness`).
+project (`Presupposition.Aboutness`).
 
 Complementary decompositions elsewhere in the event API: `Event` (a
 temporal *token* with runtime and sort), and

--- a/Linglib/Semantics/Exhaustification/Presuppositional.lean
+++ b/Linglib/Semantics/Exhaustification/Presuppositional.lean
@@ -42,7 +42,7 @@ assertive from presuppositional content.
 `pexIEII` takes the same IE/II computation from `Operators.lean` and
 produces a `PartialProp World` — a Prop-based partial proposition with separate
 assertive and presuppositional components. This directly integrates with
-the presupposition projection infrastructure in `Semantics.Presupposition`.
+the presupposition projection infrastructure in `Presupposition`.
 
 This file contains only the abstract pex theory (parameterized by an
 arbitrary `World` type and abstract `ALT`, `φ`). The concrete worked
@@ -56,7 +56,7 @@ puzzles from §3–§5 — live in the study file
 namespace Exhaustification.Presuppositional
 
 open Exhaustification
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 variable {World : Type*}
 

--- a/Linglib/Semantics/Genericity/MeaningPreservation.lean
+++ b/Linglib/Semantics/Genericity/MeaningPreservation.lean
@@ -343,7 +343,7 @@ type-shift converts this intensional property into a different semantic type:
 
 These connect the abstract shift-selection machinery to Chierchia's `down`
 operator and the `Definiteness.russellIotaList` /
-`Semantics.Presupposition.PartialProp.presupOfReferent` canonical pieces consumed by
+`Presupposition.PartialProp.presupOfReferent` canonical pieces consumed by
 `Semantics/Definiteness/Basic.lean`.
 -/
 

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -38,7 +38,7 @@ this apparatus live in `Studies/Zheng2025.lean`.
 namespace Modality
 
 open Modality.Kratzer
-open Semantics.Presupposition
+open Presupposition
 open Intensional.Premise
 
 variable {W : Type*}

--- a/Linglib/Semantics/Presupposition/Aboutness.lean
+++ b/Linglib/Semantics/Presupposition/Aboutness.lean
@@ -26,7 +26,7 @@ restrictions), aspectual classification, and suppression conditions live in
 `Studies/RobertsSimons2024.lean`.
 -/
 
-namespace Semantics.Presupposition.Aboutness
+namespace Presupposition.Aboutness
 
 open Features (Polarity)
 
@@ -97,4 +97,4 @@ def EntailmentRelation.projects : EntailmentRelation → Bool
   | .consequence  => false
   | .concomitant  => false
 
-end Semantics.Presupposition.Aboutness
+end Presupposition.Aboutness

--- a/Linglib/Semantics/Presupposition/Accommodation.lean
+++ b/Linglib/Semantics/Presupposition/Accommodation.lean
@@ -35,11 +35,11 @@ paribus — presupposition P comes into existence at t."
 - **Binding preference**: anaphoric resolution is preferred over accommodation
 -/
 
-namespace Semantics.Presupposition.Accommodation
+namespace Presupposition.Accommodation
 
 open Classical
-open Semantics.Presupposition
-open Semantics.Presupposition.Context
+open Presupposition
+open Presupposition.Context
 
 variable {W : Type*}
 
@@ -63,7 +63,7 @@ inductive AccommodationLevel where
 /-- Global accommodation: update the context to include the presupposition.
  [lewis-1979]: "presupposition P comes into existence."
 
- Delegates to `Semantics.Presupposition.Context.accommodate`. -/
+ Delegates to `Presupposition.Context.accommodate`. -/
 abbrev globalAccommodate (c : Set W) (presup : Set W) : Set W :=
  accommodate c presup
 
@@ -84,7 +84,7 @@ instance (bindingDepth : Nat) : DecidablePred (isTrapped bindingDepth) := fun l 
  unfold isTrapped; cases l <;> infer_instance
 
 /-- All constraints bundled together.
- Uses canonical operations from `Semantics.Presupposition.Context`. -/
+ Uses canonical operations from `Presupposition.Context`. -/
 structure AccommodationOK (c : Set W) (presup : Set W) : Prop where
  informative : accommodationInformative c presup
  consistent : accommodationConsistent c presup
@@ -146,4 +146,4 @@ theorem heim_never_intermediate (c : Set W) (presup : Set W) :
  · rw [heim_projection_when_consistent c presup h]; exact AccommodationLevel.noConfusion
  · rw [heim_cancellation_equivalence c presup h]; exact AccommodationLevel.noConfusion
 
-end Semantics.Presupposition.Accommodation
+end Presupposition.Accommodation

--- a/Linglib/Semantics/Presupposition/Basic.lean
+++ b/Linglib/Semantics/Presupposition/Basic.lean
@@ -27,8 +27,8 @@ The canonical connectives, entailment relations, and combinators on
 
 The rival trivalent connective families (Strong Kleene, Belnap / flexible
 accommodation, symmetric K&P, positive-antecedent) live in
-`Semantics.Presupposition.Trivalent`; quantified projection lives in
-`Semantics.Presupposition.Quantified`.
+`Presupposition.Trivalent`; quantified projection lives in
+`Presupposition.Quantified`.
 
 ## Implementation notes
 
@@ -38,7 +38,7 @@ paired with `eval_*` bridge theorems mapping each to the corresponding
 `Trivalent` operator on the evaluation.
 -/
 
-namespace Semantics.Presupposition
+namespace Presupposition
 
 namespace PartialProp
 
@@ -120,7 +120,7 @@ def impFilter (p q : PartialProp W) : PartialProp W where
     Generalizes `disjFilterLeft` to a presuppositional first disjunct
     (`orFilter_ofProp`). The symmetric K&P variant is
     `PartialProp.orKPSymmetric`; the positive-antecedent variant is
-    `PartialProp.orPositive` (`Semantics.Presupposition.Trivalent`). -/
+    `PartialProp.orPositive` (`Presupposition.Trivalent`). -/
 def orFilter (p q : PartialProp W) : PartialProp W where
   presup := fun w => p.presup w ∧ (¬p.assertion w → q.presup w)
   assertion := fun w => p.assertion w ∨ q.assertion w
@@ -421,4 +421,4 @@ theorem presupOfReferent_assertion_none {E : Type*}
 
 end PartialProp
 
-end Semantics.Presupposition
+end Presupposition

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -21,10 +21,10 @@ the attitude holder).
   [delpinal-bassi-sauerland-2024] §3.2.
 -/
 
-namespace Semantics.Presupposition.BeliefEmbedding
+namespace Presupposition.BeliefEmbedding
 
-open Semantics.Presupposition
-open Semantics.Presupposition.Context
+open Presupposition
+open Presupposition.Context
 
 variable {W : Type*} {Agent : Type*}
 
@@ -126,4 +126,4 @@ theorem opaque_implies_transparent_when_reflexive
 
 end OpaqueTransparent
 
-end Semantics.Presupposition.BeliefEmbedding
+end Presupposition.BeliefEmbedding

--- a/Linglib/Semantics/Presupposition/ContentLayer.lean
+++ b/Linglib/Semantics/Presupposition/ContentLayer.lean
@@ -108,7 +108,7 @@ def LayeredProp.get {W : Type*} (lp : LayeredProp W) : ContentLayer → (W → B
 -- § Bridge to PartialProp
 -- ════════════════════════════════════════════════════
 
-open Semantics.Presupposition in
+open Presupposition in
 /-- Project a `LayeredProp` to a `PartialProp` by discarding the implicature layer.
 
     This is the canonical projection: `PartialProp` is the 2-layer special case
@@ -117,7 +117,7 @@ def LayeredProp.toPartialProp {W : Type*} (lp : LayeredProp W) : PartialProp W :
   { presup := fun w => lp.presupposition w = true
   , assertion := fun w => lp.atIssue w = true }
 
-open Semantics.Presupposition Classical in
+open Presupposition Classical in
 /-- Lift a `PartialProp` to a `LayeredProp` with trivially true implicature.
 
     This is the canonical embedding: every `PartialProp` is a `LayeredProp` with
@@ -128,7 +128,7 @@ noncomputable def LayeredProp.ofPartialProp {W : Type*} (p : PartialProp W) : La
   , atIssue := fun w => if p.assertion w then true else false
   , implicature := λ _ => true }
 
-open Semantics.Presupposition Classical in
+open Presupposition Classical in
 /-- The round-trip `PartialProp → LayeredProp → PartialProp` is the identity.
 
     This confirms that `PartialProp` embeds faithfully into `LayeredProp`:

--- a/Linglib/Semantics/Presupposition/Context.lean
+++ b/Linglib/Semantics/Presupposition/Context.lean
@@ -24,9 +24,9 @@ presupposition is *conceivable* in the common ground iff there exists some
 world in the context set satisfying it.
 -/
 
-namespace Semantics.Presupposition.Context
+namespace Presupposition.Context
 
-open Semantics.Presupposition
+open Presupposition
 
 variable {W : Type*}
 
@@ -179,4 +179,4 @@ theorem local_context_matches_disjFilterLeft (c : Set W)
   · intro h w hc hn; exact h ⟨hc, hn⟩
   · intro h w ⟨hc, hn⟩; exact h w hc hn
 
-end Semantics.Presupposition.Context
+end Presupposition.Context

--- a/Linglib/Semantics/Presupposition/Defs.lean
+++ b/Linglib/Semantics/Presupposition/Defs.lean
@@ -22,8 +22,8 @@ points. References: [heim-1983], [belnap-1970], [bale-schwarz-2022].
   presupposition are inert).
 
 The connective families on `PartialProp` live in
-`Semantics.Presupposition.Basic` (classical, filtering, entailment) and
-`Semantics.Presupposition.Trivalent` (rival trivalent families).
+`Presupposition.Basic` (classical, filtering, entailment) and
+`Presupposition.Trivalent` (rival trivalent families).
 
 ## Implementation notes
 
@@ -42,7 +42,7 @@ idiom in logic-heavy files such as `Mathlib/Order/Filter/Basic.lean`.
   to arbitrary at-issue carriers.
 -/
 
-namespace Semantics.Presupposition
+namespace Presupposition
 
 open Trivalent (Prop3)
 
@@ -243,4 +243,4 @@ theorem eval_eq_eval_iff (p q : PartialProp W) :
 
 end PartialProp
 
-end Semantics.Presupposition
+end Presupposition

--- a/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
+++ b/Linglib/Semantics/Presupposition/MaximizePresupposition.lean
@@ -41,7 +41,7 @@ connects it to existing domain-specific implementations:
    constraint hierarchy for presupposition obligatoriness
    ([wang-2025]). The alternative-structure typology driving it lives in
    `Studies/Wang2025.lean`; consensus trigger types in
-   `Semantics.Presupposition.TriggerTypology`.
+   `Presupposition.TriggerTypology`.
 
 ## Core abstraction
 
@@ -65,12 +65,12 @@ strength directly (`mp_reverses_markedness`).
 - §4: Presuppositional strict total order on well-formed cells
 -/
 
-namespace Semantics.Presupposition.MaximizePresupposition
+namespace Presupposition.MaximizePresupposition
 
 open Features (ContainmentPair)
 open Constraints OptimalityTheory
 open Core.Optimization.Evaluation
-open Semantics.Presupposition.PhiFeatures
+open Presupposition.PhiFeatures
 
 -- ============================================================================
 -- §1  Abstract MP and Markedness Constraints
@@ -347,4 +347,4 @@ theorem strength_iff_specLevel (a b : ContainmentPair) :
     presupWeakerThan a b = true ↔ a.specLevel < b.specLevel := by
   simp [presupWeakerThan, decide_eq_true_eq]
 
-end Semantics.Presupposition.MaximizePresupposition
+end Presupposition.MaximizePresupposition

--- a/Linglib/Semantics/Presupposition/PhiFeatures.lean
+++ b/Linglib/Semantics/Presupposition/PhiFeatures.lean
@@ -45,11 +45,11 @@ separate general phi-feature presuppositional theory (which belongs in
 belong in `Studies/`).
 -/
 
-namespace Semantics.Presupposition.PhiFeatures
+namespace Presupposition.PhiFeatures
 
 open Mereology (Atom)
 open Features (ContainmentPair ContainmentPairLike)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 -- ============================================================================
 -- §1  Generic Presuppositional Denotations
@@ -536,7 +536,7 @@ witness, that witness is atomic; if ≥ 2, their sum is non-atomic.
 ### Connection to `PresuppositionContext.presupSatisfiable`
 
 Conceivability = satisfiability in context:
-`presupSatisfiable c p` from `Semantics.Presupposition.Context`
+`presupSatisfiable c p` from `Presupposition.Context`
 checks whether `p.presup` is compatible with context set `c`. The
 conceivability presupposition of an indefinite is the meta-requirement
 that the number feature's entity-level presupposition be satisfiable.
@@ -718,4 +718,4 @@ theorem cardConceivable_mono (witnessCard : W → Nat)
 
 end CardinalityConceivability
 
-end Semantics.Presupposition.PhiFeatures
+end Presupposition.PhiFeatures

--- a/Linglib/Semantics/Presupposition/ProjectiveContent.lean
+++ b/Linglib/Semantics/Presupposition/ProjectiveContent.lean
@@ -23,7 +23,7 @@ files ([tonhauser-beaver-roberts-simons-2013], [solstad-bott-2024],
   `toClass`. The `occasion_verb` case follows [solstad-bott-2024].
 -/
 
-namespace Semantics.Presupposition.ProjectiveContent
+namespace Presupposition.ProjectiveContent
 
 /--
 Strong Contextual Felicity (SCF): whether a trigger requires its
@@ -155,4 +155,4 @@ def ProjectiveTrigger.toClass : ProjectiveTrigger → ProjectiveClass
   | .demonstrative_indication => .classD
   | .focus_salience => .classD
 
-end Semantics.Presupposition.ProjectiveContent
+end Presupposition.ProjectiveContent

--- a/Linglib/Semantics/Presupposition/Quantified.lean
+++ b/Linglib/Semantics/Presupposition/Quantified.lean
@@ -18,7 +18,7 @@ delimit when each reading surfaces.
 * `negExistsPartial` — negated existential, universal projection.
 -/
 
-namespace Semantics.Presupposition
+namespace Presupposition
 
 namespace PartialProp
 
@@ -76,4 +76,4 @@ theorem forallPartial_holds {α : Type*} (S : α → Prop) (φ : α → PartialP
 
 end PartialProp
 
-end Semantics.Presupposition
+end Presupposition

--- a/Linglib/Semantics/Presupposition/TriggerTypology.lean
+++ b/Linglib/Semantics/Presupposition/TriggerTypology.lean
@@ -6,11 +6,11 @@ consensus inventory of the projection literature (cf. [zeevat-1992],
 [tonhauser-beaver-roberts-simons-2013]). Fragment lexical entries carry a
 `PresupTrigger` value as theory-neutral metadata; orthogonal classifications
 of the same inventory are the projection classes of
-`Semantics.Presupposition.ProjectiveContent` and the soft/hard distinction in
+`Presupposition.ProjectiveContent` and the soft/hard distinction in
 `Semantics.Verb`.
 -/
 
-namespace Semantics.Presupposition.TriggerTypology
+namespace Presupposition.TriggerTypology
 
 /-- Presupposition trigger classes, by hosting lexical item. -/
 inductive PresupTrigger where
@@ -50,4 +50,4 @@ inductive PresupTrigger where
   | aspectual
   deriving DecidableEq, Repr
 
-end Semantics.Presupposition.TriggerTypology
+end Presupposition.TriggerTypology

--- a/Linglib/Semantics/Presupposition/Trivalent.lean
+++ b/Linglib/Semantics/Presupposition/Trivalent.lean
@@ -6,7 +6,7 @@ import Mathlib.Data.Finset.Basic
 
 The rival trivalent connective families on `PartialProp`, beyond the
 classical (Weak Kleene) and filtering (middle Kleene) canon of
-`Semantics.Presupposition.Basic`: Strong Kleene ([kleene-1952]), Belnap
+`Presupposition.Basic`: Strong Kleene ([kleene-1952]), Belnap
 conditional assertion / flexible accommodation ([belnap-1970],
 [geurts-2005]), the symmetric K&P disjunction ([karttunen-peters-1979]),
 and the positive-antecedent rival ([sharvit-2025]).
@@ -34,7 +34,7 @@ and the positive-antecedent rival ([sharvit-2025]).
   one definition each, with one bridge theorem instead of eight.
 -/
 
-namespace Semantics.Presupposition
+namespace Presupposition
 
 namespace PartialProp
 
@@ -378,4 +378,4 @@ theorem genuineness_comm (disj : PartialProp W → PartialProp W → PartialProp
 
 end PartialProp
 
-end Semantics.Presupposition
+end Presupposition

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -46,8 +46,8 @@ namespace Semantics.Reference.Donnellan
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid)
-open Semantics.Presupposition (PartialProp)
-open Semantics.Presupposition.PartialProp (presupOfReferent)
+open Presupposition
+open Presupposition.PartialProp
 open Semantics.Reference.Basic
 open Definiteness
 

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -54,7 +54,7 @@ lemma carries the connection.
 
 namespace Semantics.Reference
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-- A presuppositional, context-relative individual denotation.
 

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -15,7 +15,7 @@ selector is the project-canonical variable denotation `interpPronoun`
 variable are the same individual *by construction* — not via a bridge
 theorem. The intrinsic presupposition is the φ-feature presupposition read
 off the entry's person/number/gender via the [sauerland-2003]-style
-cells in `Semantics.Presupposition.PhiFeatures`.
+cells in `Presupposition.PhiFeatures`.
 
 This follows [buring-2012]'s survey: the assignment lookup (his (14)), the
 feature presuppositions (his (49)/(50)), and the absence-of-features treatment
@@ -37,8 +37,8 @@ surface genders contribute the vacuous cell here; the principled route is the
 bridges plus `ContainmentPairLike.toPair`, deferred until a study needs them.
 -/
 
-open Semantics.Presupposition (PartialProp)
-open Semantics.Presupposition.PhiFeatures
+open Presupposition
+open Presupposition.PhiFeatures
 open Semantics.Reference (NominalDenot)
 open Intensional.Variables (interpPronoun DenotGS SitAssignment)
 

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -63,7 +63,7 @@ open Core.Order
 open Tense
 open Semantics.Evidential
 open Features.Mirativity
-open Semantics.Presupposition
+open Presupposition
 
 /-! ### Evidential Frame -/
 

--- a/Linglib/Studies/AlonsoOvalleMenendezBenito2010.lean
+++ b/Linglib/Studies/AlonsoOvalleMenendezBenito2010.lean
@@ -42,7 +42,7 @@ Table 1. The scenario verdicts (24)–(30) are checked in `rows_agree`.
 
 namespace AlonsoOvalleMenendezBenito2010
 
-open Semantics.Presupposition Data.Examples
+open Presupposition Data.Examples
 
 variable {E W : Type*} [DecidableEq E]
 

--- a/Linglib/Studies/AnandHacquard2013.lean
+++ b/Linglib/Studies/AnandHacquard2013.lean
@@ -362,7 +362,7 @@ is `mightS S p ∧ mightS S ¬p`. The doxastic component is what lets
 Truckenbrodt: "Kommt Peter heute?" — "Ich hoffe/*will, dass er heute
 kommt") and distinguishes *hope* from pure-preferential *want*. -/
 
-open Semantics.Presupposition (PartialProp) in
+open Presupposition in
 /-- The (56) entry over the study's information-state semantics:
     presupposition = uncertainty, assertion = doxastic possibility
     plus preference. The doxastic conjunct is entailed by the first

--- a/Linglib/Studies/BaleSchwarz2022.lean
+++ b/Linglib/Studies/BaleSchwarz2022.lean
@@ -52,7 +52,7 @@ namespace BaleSchwarz2022
 open Degree
 open Features.Dimension (Dimension QuotientDimension quotient_components_distinct)
 open English.MeasurePhrases (gram kilo milliliter liter MeasureTermEntry)
-open Semantics.Presupposition (PartialProp PartialValue)
+open Presupposition
 open Features (Acceptability)
 
 -- ============================================================================

--- a/Linglib/Studies/Beaver2001.lean
+++ b/Linglib/Studies/Beaver2001.lean
@@ -42,7 +42,7 @@ whence a non-modal sentence presupposes exactly what both it and its negation en
 
 namespace Beaver2001
 
-open Semantics.Presupposition DynamicSemantics Classical
+open Presupposition DynamicSemantics Classical
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Belnap1970.lean
+++ b/Linglib/Studies/Belnap1970.lean
@@ -69,7 +69,7 @@ suggests restricted quantification is a deep linguistic universal.
 
 namespace Belnap1970
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 open Aristotelian (Square SquareRelations)
 open Quantification
 open Semantics.Montague (ToyEntity)

--- a/Linglib/Studies/Blutner2000.lean
+++ b/Linglib/Studies/Blutner2000.lean
@@ -241,11 +241,11 @@ theorem indefinite_satisfies_both :
 -- ============================================================================
 
 /-! [blutner-2000]'s projection sites correspond to the accommodation
-    levels in `Semantics.Presupposition.Accommodation`. The bridge makes
+    levels in `Presupposition.Accommodation`. The bridge makes
     explicit that Blutner's OT analysis operates over the same site taxonomy
     as the Heim/Lewis/van der Sandt tradition. -/
 
-open Semantics.Presupposition.Accommodation (AccommodationLevel)
+open Presupposition.Accommodation
 
 /-- Map projection sites to the standard accommodation levels. -/
 def ProjectionSite.toAccommodationLevel : ProjectionSite → AccommodationLevel

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -75,7 +75,7 @@ namespace Coppock2018
 
 open Trivalent (Prop3)
 open ModalLogic (box)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 variable {W Ω : Type*}
 

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -31,9 +31,9 @@ The five-world model and alternative set are [bar-lev-fox-2020]'s.
 
 namespace DelPinalBassiSauerland2024
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 open Exhaustification Exhaustification.Presuppositional BarLevFox2020 ModalLogic
-open Semantics.Presupposition.Context (presupSatisfied localCtxSecondDisjunct)
+open Presupposition.Context
 
 /-! ### `pex^{IE+II}` on `◇(p ∨ q)` (§2) -/
 

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -61,9 +61,8 @@ namespace Elbourne2013
 
 open Intensional (Index)
 
-open Semantics.Presupposition (PartialProp)
-open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
-  presupOfReferent_assertion_some presupOfReferent_assertion_none)
+open Presupposition
+open Presupposition.PartialProp
 open Definiteness
 open Definiteness
 open Intensional (SitVarStatus ReferentialMode)

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -68,8 +68,8 @@ conceivability presupposition — not about the entity but about the
 
 namespace Enguehard2024
 
-open Semantics.Presupposition (PartialProp)
-open Semantics.Presupposition.PhiFeatures
+open Presupposition
+open Presupposition.PhiFeatures
 
 -- ============================================================================
 -- §1  Core Types
@@ -664,9 +664,9 @@ theorem constant_presup_satisfied_iff_satisfiable
     {W : Type*} (witnessCard : W → Nat) (conceivable : W → Prop)
     (c : Set W)
     (hne : c.Nonempty) :
-    Semantics.Presupposition.Context.presupSatisfied c
+    Presupposition.Context.presupSatisfied c
       (sgIndefPresup witnessCard conceivable) ↔
-    Semantics.Presupposition.Context.presupSatisfiable c
+    Presupposition.Context.presupSatisfiable c
       (sgIndefPresup witnessCard conceivable) := by
   constructor
   · intro hsat

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -145,7 +145,7 @@ theorem antiAdditive_implies_intolerant {α : Type*} (f : Set α → Prop)
 /-- A **Karttunen-Peters operator**: a function from an argument set to
     a presuppositional proposition (truth + presup). The presupposition
     may depend on the argument (per K&P 1979's heritage function). -/
-abbrev KPOperator (W : Type*) : Type _ := Set W → Semantics.Presupposition.PartialProp W
+abbrev KPOperator (W : Type*) : Type _ := Set W → Presupposition.PartialProp W
 
 /-- The truth-conditional projection of a K&P operator. -/
 def KPOperator.truth {W : Type*} (op : KPOperator W) : Set W → Set W :=
@@ -493,7 +493,7 @@ them to `only` and verify the empirical match: weak NPIs licensed
 -/
 
 open NaturalLogic
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-- The K&P operator for `only x`: assertion = "no y ≠ x has scope",
     presupposition = "some y has x and scope" (Horn 1996). Built directly

--- a/Linglib/Studies/Geurts2005.lean
+++ b/Linglib/Studies/Geurts2005.lean
@@ -90,7 +90,7 @@ substantive move is the LF reanalysis (p.391), not a structural inference.
 namespace Geurts2005
 
 open Modality
-open Semantics.Presupposition
+open Presupposition
 
 variable {W : Type*}
 

--- a/Linglib/Studies/GiorgoloAsudeh2012.lean
+++ b/Linglib/Studies/GiorgoloAsudeh2012.lean
@@ -305,7 +305,7 @@ theorem flow_restriction : sentence.val = sentence_alt_nrrc.val := rfl
     captures this: content projects past all operators without
     requiring prior establishment in context. -/
 
-open Semantics.Presupposition.ProjectiveContent (ProjectiveClass ProjectiveTrigger)
+open Presupposition.ProjectiveContent
 
 theorem nrrc_is_classB : ProjectiveTrigger.nrrc.toClass = .classB := rfl
 theorem appositive_is_classB : ProjectiveTrigger.appositive.toClass = .classB := rfl

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -44,7 +44,7 @@ causal derivation via the Predicate Lexicalization Constraint is
 namespace Glass2025
 
 open Doxastic
-open Semantics.Presupposition
+open Presupposition
 open ArgumentStructure
 open English.Predicates.Verbal
 open Mandarin.Predicates

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -49,7 +49,7 @@ different foils (M = 86.09%, β = 2.28, z = 6.09, p < 0.0001).
 namespace GoldbergShirtz2025
 
 open ConstructionGrammar
-open Semantics.Presupposition
+open Presupposition
 
 /-! ### The Figure 5 constructicon -/
 

--- a/Linglib/Studies/Grove2022.lean
+++ b/Linglib/Studies/Grove2022.lean
@@ -74,7 +74,7 @@ derives it from scope rather than from local-context filtering.
 namespace Grove2022
 
 open Trivalent (Prop3)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-! ## Part I — Apparatus -/
 

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -25,7 +25,7 @@ and the filtering predictions derived from partial context change potentials.
 
 namespace Heim1983
 
-open Semantics.Presupposition
+open Presupposition
 
 /--
 World type for the king example.

--- a/Linglib/Studies/Heim1992.lean
+++ b/Linglib/Studies/Heim1992.lean
@@ -42,8 +42,8 @@ p. 195) needs a non-trivial similarity ordering and is not formalized.
 
 namespace Heim1992
 
-open DynamicSemantics CCP.Partial Semantics.Presupposition Desire.Conditional
-open Semantics.Presupposition.BeliefEmbedding
+open DynamicSemantics CCP.Partial Presupposition Desire.Conditional
+open Presupposition.BeliefEmbedding
   (presupAttributedToHolder transparentProjection opaque_implies_transparent_when_reflexive)
 
 /-! ### Belief reports -/

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -149,7 +149,7 @@ theorem all_evidentialSurvives : ∀ d ∈ presupData, d.evidentialSurvives := b
 /-! ### Bridge: EV operator and modal semantics -/
 
 open Modality.Kratzer
-open Semantics.Presupposition
+open Presupposition
 open Tense.Evidential
 open Bulgarian.Evidentials
 

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -134,7 +134,7 @@ def indexStrength (c : IndexCandidate) : Nat :=
     substrate's general Maximize Presupposition construction at
     strength 1. -/
 def indexConstraint : Constraints.Constraint IndexCandidate :=
-  Semantics.Presupposition.MaximizePresupposition.mpConstraintOf
+  Presupposition.MaximizePresupposition.mpConstraintOf
     1 indexStrength
 
 /-- With a discourse antecedent available, the indexed candidate incurs
@@ -172,7 +172,7 @@ def topicAwareIndexStrength (c : TopicCandidate) : Nat :=
 /-- The topic-aware Index! constraint. -/
 def topicAwareIndexConstraint :
     Constraints.Constraint TopicCandidate :=
-  Semantics.Presupposition.MaximizePresupposition.mpConstraintOf
+  Presupposition.MaximizePresupposition.mpConstraintOf
     1 topicAwareIndexStrength
 
 /-- A bare candidate marked as a continuing topic ties with the indexed

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -25,7 +25,7 @@ other direction open (`force_neg_not_entails`, `beAble_not_entails`,
 
 namespace Karttunen1971
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-- The condition `v(S)` is presupposed to be for the complement. -/
 inductive Condition where

--- a/Linglib/Studies/Karttunen1973.lean
+++ b/Linglib/Studies/Karttunen1973.lean
@@ -34,7 +34,7 @@ the class are plugs (`conj_plug_plug_presup`).
 
 namespace Karttunen1973
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 open ModalLogic (box box_and)
 
 variable {W : Type*} (X : Set W) (p q : PartialProp W) (w : W)
@@ -145,7 +145,7 @@ theorem conj_presup_35 :
       ¬ (conj Set.univ (.ofProp (· ∉ capitalParis)) kingBald).presup .parisNoKing := by
   simp only [conj, Entails, PartialProp.ofProp, kingBald]; decide
 
-open Semantics.Presupposition.PartialProp in
+open Presupposition.PartialProp in
 /-- Strong-Kleene conjunction makes (35b) false at the actual world and so bivalent —
 presupposition-free — while (35a) is undefined. -/
 theorem kleene_35 :

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -198,7 +198,7 @@ theorem wxdy_partially_open :
 
 /-! ### Presupposition (§2.1) -/
 
-open Semantics.Presupposition
+open Presupposition
 
 /-- The incredulity reading presupposes the embedded proposition and has
 trivial assertion: ex. 4's diner presupposes that there is a fly in the

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -219,7 +219,7 @@ asserted. Wh-extraction from presupposed content is blocked. This explains why *
 (the eating is presupposed, so "what" cannot extract from it).
 
 TODO: Full formalization requires bridging to presupposition semantics
-(Semantics.Presupposition) and question semantics (Semantics.Questions). -/
+(Presupposition) and question semantics (Semantics.Questions). -/
 
 /-- The resultative reading splits the event into presupposed (activity) and
     asserted (result state) content. -/

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -184,7 +184,7 @@ while the assertion commits the speaker to p via DECL (72).
 -/
 
 open Core.Order
-open Semantics.Presupposition
+open Presupposition
 open Tense.Evidential
 open Bulgarian.Evidentials
 

--- a/Linglib/Studies/Kubota2026.lean
+++ b/Linglib/Studies/Kubota2026.lean
@@ -76,7 +76,7 @@ open Intensional (Intension)
 open Modality (ModalFlavor)
 open Japanese.OutlookMarkers (OutlookMarkerForm)
 open Data.Examples (LinguisticExample)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-! ### Stance classification -/
 

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -853,7 +853,7 @@ theorem veridicality_from_quantifiers :
 -- § 22: Presupposition Modeling
 -- ============================================================================
 
-open Semantics.Presupposition
+open Presupposition
 
 /-- A temporal connective modeled as a presuppositional proposition.
     Veridical connectives presuppose their complement (like factives);

--- a/Linglib/Studies/PaapeVasishth2026.lean
+++ b/Linglib/Studies/PaapeVasishth2026.lean
@@ -590,9 +590,8 @@ The argument chain:
 section UniquenessBridge
 
 open Definiteness
-open Semantics.Presupposition (PartialProp)
-open Semantics.Presupposition.PartialProp (presupOfReferent presupOfReferent_presup
-  presupOfReferent_assertion_some presupOfReferent_assertion_none)
+open Presupposition
+open Presupposition.PartialProp
 open Definiteness
 
 /-- Toy discourse entity for the uniqueness worked example. -/

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -170,7 +170,7 @@ The PER series is the **weak** article (uniqueness); the marked DEM series the *
 grounding (`Studies/Hanink2021`): there `deixis` filled `Description.demonstrative`'s slot; here the
 `HasPhi.phi` **gender** supplies the restrictor's presupposition. -/
 
-open Semantics.Presupposition.PhiFeatures (femSem)
+open Presupposition.PhiFeatures
 
 /-- `⟦sie⟧` made concrete: the feminine PER's weak-article restrictor **is** the `femSem`
     presupposition — true by construction (`(femSem isFemale).presup = isFemale`), so the gender

--- a/Linglib/Studies/RobertsOzyildiz2025.lean
+++ b/Linglib/Studies/RobertsOzyildiz2025.lean
@@ -34,7 +34,7 @@ topologically ordered vertex list so proofs reduce structurally.
 namespace RobertsOzyildiz2025
 
 open Doxastic Glass2025
-open Semantics.Presupposition
+open Presupposition
 open Causation Causation.Mechanism Causation.SEM
 
 /-! ### The belief-formation causal model -/

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -39,10 +39,10 @@ This study file imports and bridges:
 
 namespace RobertsSimons2024
 
-open Semantics.Presupposition.Aboutness
+open Presupposition.Aboutness
 open Features.ChangeOfState
 open Features
-open Semantics.Presupposition.ProjectiveContent
+open Presupposition.ProjectiveContent
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Roussou2010.lean
+++ b/Linglib/Studies/Roussou2010.lean
@@ -61,7 +61,7 @@ licenses otherwise unselected *pu* (ex. 22) — both left as prose.
 namespace Roussou2010
 
 open Greek.StandardModern.Complementizers
-open Semantics.Presupposition
+open Presupposition
 open Semantics.Composition.Tree
 open Semantics.Composition.TypeShifting
 

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -41,10 +41,10 @@ namespace Sauerland2003
 open Mereology (Atom AlgClosure cum_maximal_unique algClosure_cum not_atom_sup_of_ne)
 open Semantics.Plurality.Algebra (D)
 open Features (ContainmentPair ContainmentPairLike)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 open Constraints OptimalityTheory
-open Semantics.Presupposition.PhiFeatures
-open Semantics.Presupposition.MaximizePresupposition (phiMP phi_mp_selects_maximal)
+open Presupposition.PhiFeatures
+open Presupposition.MaximizePresupposition
 
 variable {E : Type*}
 

--- a/Linglib/Studies/Schlenker2009.lean
+++ b/Linglib/Studies/Schlenker2009.lean
@@ -8,8 +8,8 @@ import Linglib.Studies.Heim1983
 Projection predictions of the local-context theory, applied to the
 King and conditional examples from `Studies.Heim1983`. The
 per-connective local contexts are substrate
-(`Semantics.Presupposition.LocalContext`); belief embedding
-([schlenker-2009] §3.1.2) is `Semantics.Presupposition.BeliefEmbedding`.
+(`Presupposition.LocalContext`); belief embedding
+([schlenker-2009] §3.1.2) is `Presupposition.BeliefEmbedding`.
 
 ## Main declarations
 
@@ -28,9 +28,9 @@ per-connective local contexts are substrate
 
 namespace Schlenker2009
 
-open Semantics.Presupposition
-open Semantics.Presupposition.Context
-open Semantics.Presupposition.BeliefEmbedding
+open Presupposition
+open Presupposition.Context
+open Presupposition.BeliefEmbedding
 open Heim1983
 
 variable {W : Type*} {Agent : Type*}

--- a/Linglib/Studies/ScontrasTonhauser2025.lean
+++ b/Linglib/Studies/ScontrasTonhauser2025.lean
@@ -465,7 +465,7 @@ non-presuppositional items. -/
 
 section FilteringComparison
 
-open Semantics.Presupposition
+open Presupposition
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Sharvit2025.lean
+++ b/Linglib/Studies/Sharvit2025.lean
@@ -28,7 +28,7 @@ worlds to drop from the ∃-reading's quantification domain.
 
 namespace Sharvit2025
 
-open Semantics.Presupposition
+open Presupposition
 
 -- ════════════════════════════════════════════════════════════════
 -- § World type (Sharvit's Mia/Sue scenario)

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -57,12 +57,12 @@ resolution and symmetric filtering — "a cage of their own".
 
 namespace SolstadBott2024
 
-open Semantics.Presupposition.Aboutness
-open Semantics.Presupposition.ProjectiveContent
+open Presupposition.Aboutness
+open Presupposition.ProjectiveContent
 open SolstadBott2022
 open German.Predicates
-open Semantics.Presupposition
-open Semantics.Presupposition.Context
+open Presupposition
+open Presupposition.Context
 open Generalizations.Projectivity
 
 /-! ### Filtering direction and context resolution -/

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -57,7 +57,7 @@ namespace StapsRooryck2024
 
 open Intensional (Index)
 
-open Semantics.Presupposition
+open Presupposition
 open French.Predicates
 open ArgumentStructure
 open ArgumentStructure.Affectedness
@@ -499,7 +499,7 @@ theorem dynamic_follow_high :
 The paper's key semantic contribution: par and de share at-issue content
 (Initiator(x,e)) but carry complementary presuppositions about
 proto-agentivity. Formalized using `PartialProp W` from
-`Semantics.Presupposition`. -/
+`Presupposition`. -/
 
 /-- Parameters for agentive preposition denotations (35a/35b).
     Bundled so the denotation is parametric over the event/entity model. -/

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -27,8 +27,8 @@ substrate's own rendering of that theory, `Context.presupSatisfied` at the matri
 
 namespace TonhauserEtAl2013
 
-open Semantics.Presupposition Semantics.Presupposition.Context
-  Semantics.Presupposition.BeliefEmbedding Semantics.Presupposition.ProjectiveContent
+open Presupposition Presupposition.Context
+  Presupposition.BeliefEmbedding Presupposition.ProjectiveContent
 
 variable {W E : Type*} (m : Set W) (c : Set W)
 

--- a/Linglib/Studies/Wang2023.lean
+++ b/Linglib/Studies/Wang2023.lean
@@ -37,7 +37,7 @@ semantics, plus a single pragmatic constraint (ToD).
 
 This file connects three layers:
 - `Features.ContainmentPair`: the algebraic structure (specLevel ordering)
-- `Semantics.Presupposition.PhiFeatures`: presuppositional
+- `Presupposition.PhiFeatures`: presuppositional
   denotations, semantic markedness, and presuppositional strength ordering
 - `Constraint`: constraint evaluation and factorial typology
 
@@ -57,8 +57,7 @@ namespace Wang2023
 
 open Features (ContainmentPair ContainmentPairLike)
 open Constraints OptimalityTheory
-open Semantics.Presupposition.PhiFeatures (isSemanticUnmarked presupStrength
-  presupWeakerThan wellFormed_specLevel_le_two sgSem plSem)
+open Presupposition.PhiFeatures
 
 -- ============================================================================
 -- §1  Typological Data
@@ -148,7 +147,7 @@ cells, they prefer opposite directions. This is the structural heart
 of [wang-r-2023]'s analysis.
 
 The constraints are defined in terms of `presupStrength` from
-`Semantics.Presupposition.PhiFeatures`, not reimplemented —
+`Presupposition.PhiFeatures`, not reimplemented —
 ToD IS the presuppositional strength ordering.
 -/
 
@@ -199,14 +198,14 @@ theorem mp_maximal_zero : mpConstraint .maximal = 0 := rfl
     `MaximizePresupposition`: the same violation-counting function.
     This connects Wang2023's domain-specific MP! to the general theory. -/
 theorem mpConstraint_eq_phiMP :
-    mpConstraint = Semantics.Presupposition.MaximizePresupposition.phiMP := rfl
+    mpConstraint = Presupposition.MaximizePresupposition.phiMP := rfl
 
 /-- `todConstraint` equals `markednessPenalty presupStrength`.
     ToD is an instance of the general markedness penalty from
     `MaximizePresupposition`. -/
 theorem todConstraint_eval_eq_markednessPenalty (c : ContainmentPair) :
     todConstraint c =
-    (Semantics.Presupposition.MaximizePresupposition.markednessPenalty presupStrength) c := rfl
+    (Presupposition.MaximizePresupposition.markednessPenalty presupStrength) c := rfl
 
 /-- `tod_reverses_mp` is a corollary of the general
     `mp_reverses_markedness` theorem from `MaximizePresupposition`. -/
@@ -214,7 +213,7 @@ theorem tod_reverses_mp_from_general (c₁ c₂ : ContainmentPair)
     (hw₁ : c₁.WellFormed) (hw₂ : c₂.WellFormed) :
     todConstraint c₁ < todConstraint c₂ ↔
     mpConstraint c₁ > mpConstraint c₂ :=
-  Semantics.Presupposition.MaximizePresupposition.phi_mp_reverses_markedness c₁ c₂ hw₁ hw₂
+  Presupposition.MaximizePresupposition.phi_mp_reverses_markedness c₁ c₂ hw₁ hw₂
 
 -- ============================================================================
 -- §3  Binary Case: ToD >> MP! Derives Unmarked Recruitment
@@ -426,7 +425,7 @@ theorem thirdPerson_strategy_is_third :
     Proved via `unmarked_vacuous_presup` from PhiFeatures. -/
 theorem recruited_cells_have_vacuous_presup {E : Type*} (innerP outerP : E → Prop) :
     ∀ s : HonStrategy,
-      ∀ x : E, (Semantics.Presupposition.PhiFeatures.phiPresup innerP outerP
+      ∀ x : E, (Presupposition.PhiFeatures.phiPresup innerP outerP
         (honStrategyCell s)).defined x := by
   intro s x; cases s <;> trivial
 

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -183,7 +183,7 @@ theorem additive_deRe_available : ye_deRe.accepted = true := rfl
 -- Constraint-based Formalization (was: Implicature/Constraints/Wang2025.lean)
 -- ============================================================================
 
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 
 /-- Local Bool-valued accessibility used by Wang2025 for `List.all` evaluation
 of the speaker-K operator. The Prop-valued canonical version lives in

--- a/Linglib/Studies/WangDavidson2026.lean
+++ b/Linglib/Studies/WangDavidson2026.lean
@@ -69,7 +69,7 @@ Type B (EXH¹).
 namespace WangDavidson2026
 
 open Trivalent (Prop3)
-open Semantics.Presupposition (PartialProp)
+open Presupposition
 open Exhaustification (innocent predToFinset altsFromPreds)
 open Exhaustification.Trivalent
 

--- a/Linglib/Studies/Warstadt2022.lean
+++ b/Linglib/Studies/Warstadt2022.lean
@@ -26,7 +26,7 @@ sprinter") triggers stronger accommodation than genus-level ("not runner").
 
 namespace Warstadt2022
 
-open Semantics.Presupposition
+open Presupposition
 open RSA (WithSilence liftMeaning)
 
 

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -78,7 +78,7 @@ definition with disjunction-update survival.
 namespace Yagi2025
 
 open Trivalent (isDefined metaAssert Prop3)
-open Semantics.Presupposition
+open Presupposition
 
 /-! ## World type
 

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -9,7 +9,7 @@ status from event structure, theta-role linking, and so on. Verb classification
 is computed here, not stipulated as enum fields on `Verb`.
 -/
 
-open Semantics.Presupposition
+open Presupposition
 open Features
 open ArgumentStructure
 open Features.ChangeOfState

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -48,7 +48,7 @@ primitive fields in `Syntax/Category/Verb/Basic.lean`, not stipulated as an enum
 [bale-schwarz-2026] [dayal-2025] [heim-1992] [icard-2012] [kennedy-2007] [maier-2015] [qing-uegaki-2025] [rappaport-hovav-levin-2024] [solstad-bott-2024] [rappaport-hovav-levin-1998]
 -/
 
-open Semantics.Presupposition
+open Presupposition
 open Features
 open ArgumentStructure
 open Features.ChangeOfState


### PR DESCRIPTION
`Semantics.Presupposition` → `Presupposition` (umbrella directory prefix, as with `Definiteness` in #2407); selective opens become bare `open Presupposition`. `Semantics/Conditionals/Presupposition.lean` opens `_root_.Presupposition` to avoid shadowing its own namespace.