### PR TITLE
refactor(Semantics/Presupposition/ContentLayer): Prop layers under Presupposition

### DIFF
--- a/Linglib/Semantics/Modality/IndefiniteDenotation.lean
+++ b/Linglib/Semantics/Modality/IndefiniteDenotation.lean
@@ -25,7 +25,7 @@ upper bound strengthens the assertion.
 
 namespace Modality
 
-open Modality.Kratzer Presupposition Semantics.ContentLayer
+open Modality.Kratzer Presupposition
 
 variable {W E : Type*} (src : ModalSource W) (D : Finset E) (P Q : E → W → Prop) (w : W)
 

--- a/Linglib/Semantics/Presupposition/ContentLayer.lean
+++ b/Linglib/Semantics/Presupposition/ContentLayer.lean
@@ -1,362 +1,112 @@
+import Mathlib.Tactic.DeriveFintype
+import Mathlib.Data.Fintype.Basic
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
-# Content Layers
-[van-der-sandt-maier-2003]
+# Content layers
 
-Semantic content is stratified into layers that determine its discourse
-behavior: how it projects, what denial can target, and whether it
-addresses the QUD.
+This file defines the three layers of a semantic contribution — presupposition, at-issue
+content, and implicature — the propositions carrying content at each layer, and the layers
+of such a proposition that a correction makes offensive, which a denial targets. The layers
+are [van-der-sandt-maier-2003]'s labels `pr`, `fr`, and `imp` of Layered DRT; `PartialProp`
+is the two-layer case, and `BiLayered` collapses the two backgrounded layers into one
+not-at-issue layer for analyses that only separate proffered from backgrounded content
+([anderbois-brasoveanu-henderson-2015]).
 
-[van-der-sandt-maier-2003] propose Layered DRT (LDRT), where every DRS
-condition carries a label — `pr` (presupposition), `fr` (at-issue), or
-`imp` (implicature) — that determines how it behaves in denial. This
-module extracts the layer system as a standalone type that unifies several
-existing linglib distinctions:
+## Main definitions
 
-- `PartialProp` (presup + assertion) is the 2-layer special case (`pr` + `fr`)
-- `AtIssueness` (atIssue vs notAtIssue) classifies content by whether it
-  addresses the QUD — correlating with `fr` vs `pr`/`imp`
+* `ContentLayer` — the three layers.
+* `LayeredProp` — content at each layer, with `get`, `toPartialProp`, `ofPartialProp`, and
+  `toBiLayered`.
+* `LayeredProp.IsOffensive`, `LayeredProp.offensiveLayers` — the layers inconsistent with a
+  correction.
+* `BiLayered` — at-issue and not-at-issue content, with `ofProp`.
 
-## The Three Layers
+## References
 
-| Layer | Label | Denial example |
-|-------|-------|----------------|
-| Presupposition | `pr` | "The king of France is NOT bald — there is no king" (30b) |
-| At-issue | `fr` | "Mary is NOT happy — she's miserable" (5) |
-| Implicature | `imp` | "It's not POSSIBLE — it's NECESSARY" (29b) |
-
-## Design Note
-
-`ContentLayer` lives in `Semantics/` because it generalizes `PartialProp`.
-The diagnostic SCF/OLE taxonomy of projective content
-([tonhauser-beaver-roberts-simons-2013]) lives in
-`Semantics/Presupposition/ProjectiveContent.lean`.
-
-## Scope
-
-This module captures the layer taxonomy and the `Off` function (which
-layers are offensive = inconsistent with a correction). The directed
-reverse anaphora (RA*) mechanism that uses `Off` to selectively retract
-conditions is defined in `Studies/VanDerSandtMaier2003.lean` as
-`LDRS.directedRA`.
-
-## See also: `Semantics/Composition/Layered.BiLayered`
-
-`Semantics/Composition/Layered.lean` defines a 2-layer Prop-valued
-sibling `BiLayered W` (atIssue / notAtIssue, both `W → Prop`) with
-[martinez-vera-2026]'s composition rules I/II/III. Use `LayeredProp`
-when LDRT's offensive-layer machinery is needed; use `BiLayered` when
-the analysis only distinguishes at-issue from not-at-issue and operates
-over `Set W` (verum, evidential illocution, biased polar questions). A
-future `Layered n` parameterised refactor would consolidate the two.
+* [van-der-sandt-maier-2003]
+* [tonhauser-beaver-roberts-simons-2013]
+* [anderbois-brasoveanu-henderson-2015]
 -/
 
-set_option linter.dupNamespace false
+namespace Presupposition
 
-namespace Semantics.ContentLayer
-
-/-- The layer of a semantic contribution, determining its discourse behavior.
-
-    [van-der-sandt-maier-2003] introduce this three-way distinction in
-    Layered DRT, but the classification is framework-independent: it captures
-    a difference in how content projects, how it can be challenged, and what
-    denial can target. -/
-inductive ContentLayer where
-  /-- Backgrounded precondition. Projects past negation, questions, modals.
-      Targeted by "Hey wait a minute!" challenge.
-      Example: "stop" presupposes prior state; "the king" presupposes existence. -/
+/-- The layer of a semantic contribution: a backgrounded precondition, the proffered
+content, or an enrichment beyond the truth conditions. -/
+inductive ContentLayer
   | presupposition
-  /-- Free/assertoric content. Addresses the QUD directly.
-      Targeted by direct denial ("No, that's not true").
-      Example: "The king is bald" asserts baldness. -/
   | atIssue
-  /-- Enrichment beyond literal truth conditions.
-      Covers both scalar implicature (category D: "possible" implicates "not
-      necessary") and connotation/register (category E: "steed" connotes
-      formality). The paper groups both under `imp` as non-truth-conditional
-      material targetable by denial.
-      Example: "It's not POSSIBLE — it's NECESSARY" (29b). -/
   | implicature
-  deriving DecidableEq, Repr, Inhabited
+  deriving DecidableEq, Fintype, Repr
 
--- ════════════════════════════════════════════════════
--- § Layered Propositions
--- ════════════════════════════════════════════════════
-
-/-- A full layered proposition: content at each layer.
-
-    Generalizes `PartialProp` from 2 layers to 3. When `implicature` is trivially
-    true, a `LayeredProp` degenerates to a `PartialProp`. -/
+/-- Content at each of the three layers; the implicature layer is trivial by default. -/
+@[ext]
 structure LayeredProp (W : Type*) where
-  /-- Presuppositional content (must hold for definedness). -/
-  presupposition : W → Bool
-  /-- At-issue/assertoric content. -/
-  atIssue : W → Bool
-  /-- Implicature content (enrichment beyond truth conditions). Trivially
-      true by default: most utterances carry no relevant implicature, just
-      as `PartialProp.ofProp` sets presupposition to `λ _ => True`. -/
-  implicature : W → Bool := λ _ => true
+  presupposition : W → Prop
+  atIssue : W → Prop
+  implicature : W → Prop := fun _ => True
 
-/-- Access a layer's content by its tag. -/
-def LayeredProp.get {W : Type*} (lp : LayeredProp W) : ContentLayer → (W → Bool)
-  | .presupposition => lp.presupposition
-  | .atIssue => lp.atIssue
-  | .implicature => lp.implicature
-
--- ════════════════════════════════════════════════════
--- § Bridge to PartialProp
--- ════════════════════════════════════════════════════
-
-open Presupposition in
-/-- Project a `LayeredProp` to a `PartialProp` by discarding the implicature layer.
-
-    This is the canonical projection: `PartialProp` is the 2-layer special case
-    where implicature is invisible. -/
-def LayeredProp.toPartialProp {W : Type*} (lp : LayeredProp W) : PartialProp W :=
-  { presup := fun w => lp.presupposition w = true
-  , assertion := fun w => lp.atIssue w = true }
-
-open Presupposition Classical in
-/-- Lift a `PartialProp` to a `LayeredProp` with trivially true implicature.
-
-    This is the canonical embedding: every `PartialProp` is a `LayeredProp` with
-    no implicature content. Noncomputable because Prop → Bool requires
-    classical decidability. -/
-noncomputable def LayeredProp.ofPartialProp {W : Type*} (p : PartialProp W) : LayeredProp W :=
-  { presupposition := fun w => if p.presup w then true else false
-  , atIssue := fun w => if p.assertion w then true else false
-  , implicature := λ _ => true }
-
-open Presupposition Classical in
-/-- The round-trip `PartialProp → LayeredProp → PartialProp` is the identity.
-
-    This confirms that `PartialProp` embeds faithfully into `LayeredProp`:
-    no information is lost or added in the embedding. -/
-theorem LayeredProp.roundtrip_prprop {W : Type*} (p : PartialProp W) :
-    (LayeredProp.ofPartialProp p).toPartialProp = p := by
-  ext w
-  · simp only [ofPartialProp, toPartialProp]
-    by_cases h : p.presup w <;> simp [h]
-  · simp only [ofPartialProp, toPartialProp]
-    by_cases h : p.assertion w <;> simp [h]
-
--- ════════════════════════════════════════════════════
--- § Offensive Layers (Denial Targeting)
--- ════════════════════════════════════════════════════
-
-/-- Layer `l` of `φ` is offensive with respect to a correction when no world
-    satisfies both the layer's content and the correction.
-
-    Off(φ, K) from [van-der-sandt-maier-2003]: the offensive layers are
-    those whose content is inconsistent with the correction context. In
-    propositional denial, only `fr` is offensive; in presuppositional denial,
-    `pr` (and `fr`) are offensive; in implicature denial, `imp` is offensive. -/
-def isOffensive {W : Type*} (φ : LayeredProp W) (l : ContentLayer)
-    (correction : W → Bool) (worlds : List W) : Bool :=
-  !(worlds.any λ w => φ.get l w && correction w)
-
-/-- Collect all offensive layers of `φ` with respect to a correction. -/
-def offensiveLayers {W : Type*} (φ : LayeredProp W)
-    (correction : W → Bool) (worlds : List W) : List ContentLayer :=
-  [.presupposition, .atIssue, .implicature].filter λ l =>
-    isOffensive φ l correction worlds
-
-/-- A non-offensive layer's content is consistent with the correction:
-    some world satisfies both. -/
-def isConsistent {W : Type*} (φ : LayeredProp W) (l : ContentLayer)
-    (correction : W → Bool) (worlds : List W) : Bool :=
-  worlds.any λ w => φ.get l w && correction w
-
-/-- Consistency is the negation of offensiveness. -/
-theorem consistent_iff_not_offensive {W : Type*} (φ : LayeredProp W)
-    (l : ContentLayer) (correction : W → Bool) (worlds : List W) :
-    isConsistent φ l correction worlds = !isOffensive φ l correction worlds := by
-  simp only [isConsistent, isOffensive, Bool.not_not]
-
--- ════════════════════════════════════════════════════
--- § Worked Examples: Off in Action
--- ════════════════════════════════════════════════════
-
-/-! ### Example 1: King of France (30)
-
-"The king of France is bald" has:
-- `pr`: France has a king (definite presupposition)
-- `fr`: The king is bald (at-issue content)
-- `imp`: trivially true (no implicature)
-
-Two corrections disambiguate the denial:
-- "He has a full head of hair" → propositional denial (only `fr` offensive)
-- "France does not have a king" → presuppositional denial (`pr` and `fr` both offensive)
--/
-
-private inductive KFWorld | kingBald | kingHairy | noKing1 | noKing2
-  deriving DecidableEq, Repr
-
-private def kfPresup : KFWorld → Bool
-  | .kingBald | .kingHairy => true | _ => false
-
-private def kfAssert : KFWorld → Bool
-  | .kingBald => true | _ => false
-
-private def kfProp : LayeredProp KFWorld :=
-  { presupposition := kfPresup, atIssue := kfAssert }
-
-private def kfWorlds : List KFWorld := [.kingBald, .kingHairy, .noKing1, .noKing2]
-
-/-- Propositional denial: correction "he has hair" conflicts with `fr` only.
-
-    The presupposition (king exists) is consistent with the correction
-    (world `kingHairy` satisfies both), so `pr` is NOT offensive. But no
-    world is both bald and hairy, so `fr` IS offensive.
-
-    Corresponds to the standard propositional-denial reading of (30). -/
-theorem kf_propositional_denial :
-    offensiveLayers kfProp (λ w => w == .kingHairy) kfWorlds = [.atIssue] := by
-  decide
-
-/-- Presuppositional denial: correction "no king exists" conflicts with
-    both `pr` and `fr`.
-
-    No world has both "king exists" and "no king exists," so `pr` is
-    offensive. No world is both "bald" and "no king," so `fr` is ALSO
-    offensive — the assertion "falls with" the presupposition.
-
-    Corresponds to (30b): "The king of France is NOT bald — France does
-    not have a king." -/
-theorem kf_presuppositional_denial :
-    offensiveLayers kfProp (λ w => w == .noKing1 || w == .noKing2) kfWorlds
-    = [.presupposition, .atIssue] := by
-  decide
-
-/-! ### Example 2: Possibility → Necessity (29)
-
-"It is possible that the pope is right" has:
-- `pr`: trivially true
-- `fr`: ◇p (it is possible)
-- `imp`: ¬□p (not necessary — the scalar implicature of "possible")
-
-Correction: "It is NECESSARY that the pope is right" (□p).
-Only `imp` is offensive: ◇p is consistent with □p (necessity entails
-possibility), but ¬□p contradicts □p.
--/
-
-private inductive ModalW | possNotNec | nec
-  deriving DecidableEq, Repr
-
-private def modalProp : LayeredProp ModalW :=
-  { presupposition := λ _ => true
-  , atIssue := λ _ => true         -- ◇p holds in both worlds
-  , implicature := λ              -- ¬□p: "merely possible, not necessary"
-      | .possNotNec => true
-      | .nec => false }
-
-private def modalWorlds : List ModalW := [.possNotNec, .nec]
-
-/-- Implicature denial: correction "it is necessary" conflicts with `imp` only.
-
-    The presupposition (trivially true) and at-issue content (◇p) are both
-    consistent with the correction (□p entails ◇p). Only the scalar
-    implicature (¬□p) conflicts.
-
-    Corresponds to (29b): "It is not POSSIBLE, it is NECESSARY that the
-    pope is right." -/
-theorem modal_implicature_denial :
-    offensiveLayers modalProp (λ w => w == .nec) modalWorlds
-    = [.implicature] := by
-  decide
-
-/-! ### `BiLayered`: 2-layer ⟨A, N⟩ Prop-valued sibling
-
-A `Prop`-valued 2-layer sibling of `LayeredProp` ([martinez-vera-2026],
-inheriting the percolation discipline of [potts-2005] and the at-issue
-proposal / appositive imposition split of [anderbois-brasoveanu-henderson-2015]):
-the at-issue layer is the proffered content, the not-at-issue layer
-backgrounds presuppositions, conventional implicatures, and evidential
-commitments — collapsing `LayeredProp`'s `presupposition` and
-`implicature` layers into a single `notAtIssue`. The substrate stays
-propositional (`W → Prop`) because the consumers (verum studies,
-evidential illocution, biased polar questions) operate over `Set W`.
-
-| Rule | When to use | At-issue layer | Not-at-issue layer |
-|------|-------------|----------------|--------------------|
-| I    | β has trivial NAI; α brings NAI | `α.A β.A` | `α.N β.A` |
-| II   | both α and β bring NAI | `α.A β.A` | `α.N β.A ∧ β.N` |
-| III  | α is illocutionary, takes the full ⟨A, N⟩ pair | (full pair handed to α) | (full pair handed to α) |
--/
-
-/-- A 2-layer ⟨A, N⟩ proposition. Trivially-true `notAtIssue` is the
-default — most expressions add no not-at-issue content, so the empty
-case should be cheap to construct. -/
+/-- At-issue and not-at-issue content; the not-at-issue layer is trivial by default. -/
 @[ext]
 structure BiLayered (W : Type*) where
-  /-- Proffered, at-issue content. -/
   atIssue : W → Prop
-  /-- Backgrounded, not-at-issue content. Defaults to trivially true. -/
   notAtIssue : W → Prop := fun _ => True
 
 namespace BiLayered
 
 variable {W : Type*}
 
-/-- Lift a single proposition to a `BiLayered` with trivial NAI. -/
-def ofProp (p : W → Prop) : BiLayered W :=
-  { atIssue := p }
+/-- A proposition with no not-at-issue content. -/
+def ofProp (p : W → Prop) : BiLayered W := { atIssue := p }
 
-@[simp] theorem ofProp_atIssue (p : W → Prop) :
-    (ofProp p : BiLayered W).atIssue = p := rfl
+@[simp] theorem ofProp_atIssue (p : W → Prop) : (ofProp p).atIssue = p := rfl
 
-@[simp] theorem ofProp_notAtIssue (p : W → Prop) :
-    (ofProp p : BiLayered W).notAtIssue = fun _ => True := rfl
+@[simp] theorem ofProp_notAtIssue (p : W → Prop) : (ofProp p).notAtIssue = fun _ => True := rfl
 
 end BiLayered
 
-variable {W : Type*}
+namespace LayeredProp
 
-/-- [martinez-vera-2026] Composition rule I: β has empty NAI; α brings
-NAI. The new at-issue layer is `α.A β.A`; the new NAI is `α.N β.A`. -/
-def composeI (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) :
-    BiLayered W :=
-  { atIssue := atFn β.atIssue, notAtIssue := naiFn β.atIssue }
+variable {W : Type*} (φ : LayeredProp W)
 
-/-- [martinez-vera-2026] Composition rule II: both α and β bring NAI.
-The new NAI accumulates `α.N β.A ∧ β.N`. -/
-def composeII (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) :
-    BiLayered W :=
-  { atIssue := atFn β.atIssue
-  , notAtIssue := fun w => naiFn β.atIssue w ∧ β.notAtIssue w }
+/-- The content at a layer. -/
+def get : ContentLayer → W → Prop
+  | .presupposition => φ.presupposition
+  | .atIssue => φ.atIssue
+  | .implicature => φ.implicature
 
-/-- [martinez-vera-2026] Composition rule III: an illocutionary operator
-takes the full ⟨A, N⟩ pair from β and returns a new pair. -/
-def composeIII (op : BiLayered W → BiLayered W) (β : BiLayered W) : BiLayered W :=
-  op β
+instance [DecidablePred φ.presupposition] [DecidablePred φ.atIssue]
+    [DecidablePred φ.implicature] (l : ContentLayer) : DecidablePred (φ.get l) := by
+  cases l <;> simp only [get] <;> infer_instance
 
-@[simp] theorem composeI_atIssue (atFn naiFn : (W → Prop) → (W → Prop))
-    (β : BiLayered W) : (composeI atFn naiFn β).atIssue = atFn β.atIssue := rfl
+/-- The two-layer proposition, discarding the implicature. -/
+def toPartialProp : PartialProp W := ⟨φ.presupposition, φ.atIssue⟩
 
-@[simp] theorem composeI_notAtIssue (atFn naiFn : (W → Prop) → (W → Prop))
-    (β : BiLayered W) : (composeI atFn naiFn β).notAtIssue = naiFn β.atIssue := rfl
+/-- A two-layer proposition, with no implicature. -/
+def ofPartialProp (p : PartialProp W) : LayeredProp W := ⟨p.presup, p.assertion, fun _ => True⟩
 
-@[simp] theorem composeII_atIssue (atFn naiFn : (W → Prop) → (W → Prop))
-    (β : BiLayered W) : (composeII atFn naiFn β).atIssue = atFn β.atIssue := rfl
+@[simp] theorem toPartialProp_ofPartialProp (p : PartialProp W) :
+    (ofPartialProp p).toPartialProp = p := rfl
 
-@[simp] theorem composeII_notAtIssue (atFn naiFn : (W → Prop) → (W → Prop))
-    (β : BiLayered W) :
-    (composeII atFn naiFn β).notAtIssue =
-      fun w => naiFn β.atIssue w ∧ β.notAtIssue w := rfl
+/-- The backgrounded layers collapsed into the not-at-issue layer. -/
+def toBiLayered : BiLayered W := ⟨φ.atIssue, fun w => φ.presupposition w ∧ φ.implicature w⟩
 
-@[simp] theorem composeIII_apply (op : BiLayered W → BiLayered W)
-    (β : BiLayered W) : composeIII op β = op β := rfl
+/-- Layer `l` is offensive against the correction `K` when no `K`-world satisfies its
+content — the layers a denial with correction `K` targets. -/
+def IsOffensive (l : ContentLayer) (K : Set W) : Prop := ∀ w ∈ K, ¬ φ.get l w
 
-/-- Composition I subsumes Composition II when β.N is trivially true:
-the extra `∧ True` conjunct collapses. The formal sense in which
-rule II generalises rule I. -/
-theorem composeI_eq_composeII_on_trivial_naiFn {W : Type*}
-    (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W)
-    (hβ : β.notAtIssue = fun _ => True) :
-    composeI atFn naiFn β = composeII atFn naiFn β := by
-  ext w
-  · rfl
-  · simp [composeI, composeII, hβ]
+theorem isOffensive_iff_disjoint (l : ContentLayer) (K : Set W) :
+    φ.IsOffensive l K ↔ Disjoint {w | φ.get l w} K := by
+  simp [IsOffensive, Set.disjoint_right]
 
-end Semantics.ContentLayer
+instance [Fintype W] (l : ContentLayer) (K : Set W) [DecidablePred (· ∈ K)]
+    [DecidablePred (φ.get l)] : Decidable (φ.IsOffensive l K) :=
+  inferInstanceAs (Decidable (∀ w, w ∈ K → ¬ φ.get l w))
+
+/-- The layers offensive against the correction `K`. -/
+def offensiveLayers (K : Set W) [∀ l, Decidable (φ.IsOffensive l K)] : Finset ContentLayer :=
+  Finset.univ.filter (φ.IsOffensive · K)
+
+end LayeredProp
+
+end Presupposition

--- a/Linglib/Studies/Hohle1992.lean
+++ b/Linglib/Studies/Hohle1992.lean
@@ -46,7 +46,7 @@ suspension of p) and serves to settle that prior issue.
 
 namespace Hohle1992
 
-open Semantics.ContentLayer (BiLayered)
+open Presupposition
 open Semantics.Highlighting (HighlightingContext Highlighted addSalient)
 
 variable {W : Type*}

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -64,7 +64,7 @@ Three empirical signatures:
 
 | Substrate | Provides |
 |-----------|----------|
-| `Semantics/Composition/Layered` | `BiLayered W` ⟨A, N⟩ pair, three composition rules |
+| `Semantics/Presupposition/ContentLayer` | `BiLayered W` ⟨A, N⟩ pair (the composition rules I–III are defined here) |
 | `Semantics/Highlighting` | `HighlightingContext`, `Highlighted`, `AddressesQUD` |
 | `Discourse/EvidentialIllocution` | `assert`, `present`, `EvidentialAct`, `raisedPropositions` |
 | `Semantics/Evidential/Source` | `CoarseSource` (`direct`, `hearsay`, `inference`) |
@@ -83,7 +83,44 @@ in `Fragments/Quechua/SaraguroKichwa/Evidentiality.lean`.
 
 namespace MartinezVera2026
 
-open Semantics.ContentLayer (BiLayered)
+open Presupposition
+
+/-! ### Composition of ⟨A, N⟩ pairs -/
+
+variable {W : Type*}
+
+/-- Composition rule I: β has empty NAI; α brings NAI. The new at-issue layer is `α.A β.A`;
+the new NAI is `α.N β.A`. -/
+def composeI (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) : BiLayered W :=
+  { atIssue := atFn β.atIssue, notAtIssue := naiFn β.atIssue }
+
+/-- Composition rule II: both α and β bring NAI; the new NAI accumulates `α.N β.A ∧ β.N`. -/
+def composeII (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) : BiLayered W :=
+  { atIssue := atFn β.atIssue, notAtIssue := fun w => naiFn β.atIssue w ∧ β.notAtIssue w }
+
+/-- Composition rule III: an illocutionary operator takes the full ⟨A, N⟩ pair. -/
+def composeIII (op : BiLayered W → BiLayered W) (β : BiLayered W) : BiLayered W := op β
+
+@[simp] theorem composeI_atIssue (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) :
+    (composeI atFn naiFn β).atIssue = atFn β.atIssue := rfl
+
+@[simp] theorem composeI_notAtIssue (atFn naiFn : (W → Prop) → (W → Prop))
+    (β : BiLayered W) : (composeI atFn naiFn β).notAtIssue = naiFn β.atIssue := rfl
+
+@[simp] theorem composeII_atIssue (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W) :
+    (composeII atFn naiFn β).atIssue = atFn β.atIssue := rfl
+
+@[simp] theorem composeII_notAtIssue (atFn naiFn : (W → Prop) → (W → Prop))
+    (β : BiLayered W) :
+    (composeII atFn naiFn β).notAtIssue = fun w => naiFn β.atIssue w ∧ β.notAtIssue w := rfl
+
+/-- Rule II generalizes rule I: they coincide when β's NAI is trivial. -/
+theorem composeI_eq_composeII (atFn naiFn : (W → Prop) → (W → Prop)) (β : BiLayered W)
+    (hβ : β.notAtIssue = fun _ => True) : composeI atFn naiFn β = composeII atFn naiFn β := by
+  ext w
+  · rfl
+  · simp [composeI, composeII, hβ]
+
 open Semantics.Highlighting (HighlightingContext Highlighted AddressesQUD addSalient)
 open Semantics.Evidential (CoarseSource)
 open Discourse (DiscourseRole)

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -64,7 +64,7 @@ Three empirical signatures:
 
 | Substrate | Provides |
 |-----------|----------|
-| `Semantics/Presupposition/ContentLayer` | `BiLayered W` ⟨A, N⟩ pair (the composition rules I–III are defined here) |
+| `Semantics/Presupposition/ContentLayer` | `BiLayered W` ⟨A, N⟩ pair (rules I–III defined below) |
 | `Semantics/Highlighting` | `HighlightingContext`, `Highlighted`, `AddressesQUD` |
 | `Discourse/EvidentialIllocution` | `assert`, `present`, `EvidentialAct`, `raisedPropositions` |
 | `Semantics/Evidential/Source` | `CoarseSource` (`direct`, `hearsay`, `inference`) |

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -467,7 +467,7 @@ the trivially-failing `noSemanticValueAccount := ⊥`. A genuine
 predict no semantic value, so the discriminator stays formally sound
 but is currently unfalsifiable: any always-false account produces the
 same negative side. The principled fix is to lift `Account` to range
-over `Semantics.ContentLayer.LayeredProp` so that Camp routes the
+over `Presupposition.LayeredProp` so that Camp routes the
 unavowed content to `.implicature` while coordination routes to
 `.atIssue` — a cross-framework integration deferred until a real Camp
 study lands. -/

--- a/Linglib/Studies/VanDerSandtMaier2003.lean
+++ b/Linglib/Studies/VanDerSandtMaier2003.lean
@@ -1,3 +1,4 @@
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Semantics.Presupposition.ContentLayer
 import Linglib.Data.Examples.VanDerSandtMaier2003
 
@@ -10,7 +11,7 @@ Denials in Discourse. Michigan Linguistics and Philosophy Workshop, 2003.
 Formalization of directed reverse anaphora (RA*) applied to the paper's worked
 examples, connecting:
 
-- `Semantics.ContentLayer` — `offensiveLayers` (which layers are offensive)
+- `Presupposition.LayeredProp.offensiveLayers` — the layers a correction makes offensive
 - `Data/Examples/VanDerSandtMaier2003.json` — the paper's denial/correction
   discourse rows
 
@@ -63,8 +64,7 @@ negation; (3) preserve conditions at non-offensive layers.
 
 namespace VanDerSandtMaier2003
 
-open Semantics.ContentLayer
-open Data.Examples
+open Presupposition Data.Examples
 
 /-! ### Denial taxonomy
 
@@ -136,14 +136,14 @@ def LDRS.merge (k1 k2 : LDRS) : LDRS :=
 
 /-- The offensive conditions of an LDRS w.r.t. a correction: those whose layer is
 in the offensive set. In denial, these are retracted. -/
-def LDRS.offensiveConditions (k : LDRS) (offLayers : List ContentLayer) :
+def LDRS.offensiveConditions (k : LDRS) (offLayers : Finset ContentLayer) :
     List TaggedCondition :=
-  k.conditions.filter (offLayers.contains ·.layer)
+  k.conditions.filter fun c => decide (c.layer ∈ offLayers)
 
 /-- The surviving conditions after denial: those NOT at offensive layers. -/
-def LDRS.survivingConditions (k : LDRS) (offLayers : List ContentLayer) :
+def LDRS.survivingConditions (k : LDRS) (offLayers : Finset ContentLayer) :
     List TaggedCondition :=
-  k.conditions.filter (!offLayers.contains ·.layer)
+  k.conditions.filter fun c => decide (c.layer ∉ offLayers)
 
 /-! ### Assertion vs. denial: monotonicity
 
@@ -153,15 +153,12 @@ is the only operation that removes information from the discourse context. -/
 
 /-- Offensive + surviving = all conditions (partition). -/
 theorem LDRS.offensive_surviving_partition (k : LDRS)
-    (offLayers : List ContentLayer) :
+    (offLayers : Finset ContentLayer) :
     (k.offensiveConditions offLayers).length +
     (k.survivingConditions offLayers).length = k.conditions.length := by
-  simp only [offensiveConditions, survivingConditions]
-  induction k.conditions with
-  | nil => simp
-  | cons hd tl ih =>
-    simp only [List.filter]
-    cases offLayers.contains hd.layer <;> simp_all <;> omega
+  have := (List.filter_append_perm (fun c : TaggedCondition => decide (c.layer ∈ offLayers))
+    k.conditions).length_eq
+  simpa [offensiveConditions, survivingConditions, decide_not] using this
 
 /-- Assertion (merge) is monotonic: the result has at least as many conditions as
 the original LDRS. -/
@@ -171,7 +168,7 @@ theorem merge_monotonic (k1 k2 : LDRS) :
 
 /-- Denial (surviving conditions) is non-monotonic: the result has at most as
 many conditions as the original LDRS. -/
-theorem denial_nonmonotonic (k : LDRS) (offLayers : List ContentLayer) :
+theorem denial_nonmonotonic (k : LDRS) (offLayers : Finset ContentLayer) :
     (k.survivingConditions offLayers).length ≤ k.conditions.length :=
   List.length_filter_le _ _
 
@@ -183,7 +180,7 @@ the main DRS, offensive conditions are moved under a single negation. -/
 
 /-- Directed reverse anaphora (RA*): move offensive-layer conditions under
 negation, preserving non-offensive conditions. -/
-def LDRS.directedRA (k : LDRS) (offLayers : List ContentLayer) : LDRS :=
+def LDRS.directedRA (k : LDRS) (offLayers : Finset ContentLayer) : LDRS :=
   let surviving := k.survivingConditions offLayers
   let offensive := k.offensiveConditions offLayers
   { drefs := k.drefs
@@ -195,14 +192,14 @@ def LDRS.directedRA (k : LDRS) (offLayers : List ContentLayer) : LDRS :=
 /-- Denial pipeline: merge correction, then apply RA*. In an
 assertion-denial-correction sequence, the correction is merged with the discourse
 state, then RA* retracts the offensive layers. -/
-def LDRS.denialUpdate (state correction : LDRS) (offLayers : List ContentLayer) :
+def LDRS.denialUpdate (state correction : LDRS) (offLayers : Finset ContentLayer) :
     LDRS :=
   (state.merge correction).directedRA offLayers
 
 /-- RA* preserves discourse referents — denial retracts conditions, not referent
 introductions, so drefs introduced by σ₁ remain available for anaphora even after
 denial ("A man jumped off the bridge. He didn't jump, he was pushed."). -/
-theorem LDRS.directedRA_preserves_drefs (k : LDRS) (offLayers : List ContentLayer) :
+theorem LDRS.directedRA_preserves_drefs (k : LDRS) (offLayers : Finset ContentLayer) :
     (k.directedRA offLayers).drefs = k.drefs := rfl
 
 /-! ### §1. Presuppositional denial — King of France (§3.5, ex. 49)
@@ -218,18 +215,15 @@ scenario and denial type — presuppositional; the §5 transfer theorem connects
 the Off computation to every row tagged with this scenario. -/
 
 private inductive KFW | kingWalks | kingStands | noKing
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
-private def kfLayered : LayeredProp KFW :=
-  { presupposition := fun | .kingWalks | .kingStands => true | .noKing => false
-  , atIssue := fun | .kingWalks => true | _ => false }
-
-private def kfWorlds : List KFW := [.kingWalks, .kingStands, .noKing]
+private abbrev kfLayered : LayeredProp KFW :=
+  { presupposition := (· ≠ .noKing), atIssue := (· = .kingWalks) }
 
 /-- Off: "no king" conflicts with both pr (king exists) and fr (king walks). -/
 theorem kf_off :
-    offensiveLayers kfLayered (fun w => w == .noKing) kfWorlds
-    = [.presupposition, .atIssue] := by decide
+    kfLayered.offensiveLayers {w | w = .noKing} =
+      ({.presupposition, .atIssue} : Finset ContentLayer) := by decide
 
 /-- LDRS for σ₁. Rel 0 = KF (pr layer), Rel 1 = walkInPark (fr layer). -/
 private def kfAssertion : LDRS :=
@@ -240,13 +234,13 @@ private def kfAssertion : LDRS :=
 /-- After RA* with Off = {pr, fr}: no conditions survive (both offensive); all
 material moves under a single negation wrapper. -/
 theorem kf_ra_length :
-    (kfAssertion.directedRA [.presupposition, .atIssue]).conditions.length
+    (kfAssertion.directedRA {.presupposition, .atIssue}).conditions.length
     = 1 := by decide
 
 /-- The sole surviving condition is at fr level (the negation wrapper is
 assertoric: "it is not the case that ..."). -/
 theorem kf_ra_layers :
-    (kfAssertion.directedRA [.presupposition, .atIssue]).conditions.map (·.layer)
+    (kfAssertion.directedRA {.presupposition, .atIssue}).conditions.map (·.layer)
     = [.atIssue] := by decide
 
 /-! ### §2. Implicature denial — Possible/Necessary (§4.4, ex. 68)
@@ -259,19 +253,15 @@ implicature conflicts with correction □p. At-issue content ◇p survives (□p
 entails ◇p). -/
 
 private inductive ModalW | possNotNec | nec
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
-private def modalLayered : LayeredProp ModalW :=
-  { presupposition := fun _ => true
-  , atIssue := fun _ => true
-  , implicature := fun | .possNotNec => true | .nec => false }
-
-private def modalWorlds : List ModalW := [.possNotNec, .nec]
+private abbrev modalLayered : LayeredProp ModalW :=
+  { presupposition := fun _ => True, atIssue := fun _ => True, implicature := (· = .possNotNec) }
 
 /-- Off: correction "necessary" (□p) conflicts only with imp (¬□p). -/
 theorem modal_off :
-    offensiveLayers modalLayered (fun w => w == .nec) modalWorlds
-    = [.implicature] := by decide
+    modalLayered.offensiveLayers {w | w = .nec} = ({.implicature} : Finset ContentLayer) := by
+  decide
 
 /-- LDRS for σ₁. Rel 0 = pope (pr), Rel 1 = ◇right (fr), Rel 2 = □right; the imp
 layer carries ¬□right. -/
@@ -284,11 +274,11 @@ private def modalAssertion : LDRS :=
 /-- After RA* with Off = {imp}: pr and fr survive; imp moves under negation.
 Result: 2 surviving + 1 negation wrapper = 3 conditions. -/
 theorem modal_ra_length :
-    (modalAssertion.directedRA [.implicature]).conditions.length = 3 := by decide
+    (modalAssertion.directedRA {.implicature}).conditions.length = 3 := by decide
 
 /-- Surviving layers: pr, fr at top level; negated imp tagged fr. -/
 theorem modal_ra_layers :
-    (modalAssertion.directedRA [.implicature]).conditions.map (·.layer)
+    (modalAssertion.directedRA {.implicature}).conditions.map (·.layer)
     = [.presupposition, .atIssue, .atIssue] := by decide
 
 /-! ### §3. Connotation denial — Lady/Wife (§4.4, ex. 69)
@@ -305,21 +295,18 @@ omitted; Off depends only on σ₁ + σ₄. The row `vdsm2003_ex13_lady` uses a
 related sentence (ex. 13) but the same scenario and denial type. -/
 
 private inductive LadyW | ladyStranger | ladyWife | notLadyWife
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
-private def ladyLayered : LayeredProp LadyW :=
-  { presupposition := fun _ => true
-  , atIssue := fun | .ladyStranger | .ladyWife => true | _ => false
-  , implicature := fun | .ladyStranger => true | _ => false }
-
-private def ladyWorlds : List LadyW := [.ladyStranger, .ladyWife, .notLadyWife]
+private abbrev ladyLayered : LayeredProp LadyW :=
+  { presupposition := fun _ => True, atIssue := (· ≠ .notLadyWife),
+    implicature := (· = .ladyStranger) }
 
 /-- Off: correction "wife" conflicts only with imp (stranger). Crucially, lady
 (fr) is consistent with wife — Off does NOT retract the literal predication. -/
 theorem lady_off :
-    offensiveLayers ladyLayered
-      (fun w => w == .ladyWife || w == .notLadyWife) ladyWorlds
-    = [.implicature] := by decide
+    ladyLayered.offensiveLayers {w | w = .ladyWife ∨ w = .notLadyWife} =
+      ({.implicature} : Finset ContentLayer) := by
+  decide
 
 /-- LDRS for σ₁. Rel 0 = pointed_at (pr), Rel 1 = lady (fr), Rel 2 = nice (fr),
 Rel 3 = stranger (imp). -/
@@ -333,11 +320,11 @@ private def ladyAssertion : LDRS :=
 /-- After RA*: pr, fr (lady), fr (nice) survive; imp (stranger) moves under
 negation. Result: 3 surviving + 1 negated = 4. -/
 theorem lady_ra_length :
-    (ladyAssertion.directedRA [.implicature]).conditions.length = 4 := by decide
+    (ladyAssertion.directedRA {.implicature}).conditions.length = 4 := by decide
 
 /-- Surviving layers: pr, fr, fr at top level; negated imp as fr. -/
 theorem lady_ra_layers :
-    (ladyAssertion.directedRA [.implicature]).conditions.map (·.layer)
+    (ladyAssertion.directedRA {.implicature}).conditions.map (·.layer)
     = [.presupposition, .atIssue, .atIssue, .atIssue] := by decide
 
 /-! ### §4. Discourse pipeline: assertion → denial
@@ -364,7 +351,7 @@ theorem assertion_grows :
     φ₁.conditions.length > modalBackground.conditions.length := by decide
 
 /-- Step 2: denial update — merge correction, then apply RA*. -/
-private def φ₃ : LDRS := φ₁.denialUpdate modalCorrection [.implicature]
+private def φ₃ : LDRS := φ₁.denialUpdate modalCorrection {.implicature}
 
 /-- Denial update: 4 conditions = 2 surviving (pr + ◇right) + 1 correction
 (□right) + 1 negated wrapper (¬[¬□right]). -/
@@ -396,22 +383,18 @@ def denialTypeOf (row : LinguisticExample) : Option DenialType :=
 
 /-- The Off computation of the `LayeredProp` scenario named by the row's
 `scenario` feature. -/
-private def scenarioOff (row : LinguisticExample) : Option (List ContentLayer) :=
+private def scenarioOff (row : LinguisticExample) : Option (Finset ContentLayer) :=
   match row.feature? "scenario" with
-  | some "kingOfFrance" =>
-      some (offensiveLayers kfLayered (fun w => w == .noKing) kfWorlds)
-  | some "modal" =>
-      some (offensiveLayers modalLayered (fun w => w == .nec) modalWorlds)
-  | some "lady" =>
-      some (offensiveLayers ladyLayered
-        (fun w => w == .ladyWife || w == .notLadyWife) ladyWorlds)
+  | some "kingOfFrance" => some (kfLayered.offensiveLayers {w | w = .noKing})
+  | some "modal" => some (modalLayered.offensiveLayers {w | w = .nec})
+  | some "lady" => some (ladyLayered.offensiveLayers {w | w = .ladyWife ∨ w = .notLadyWife})
   | _ => none
 
 /-- **Transfer**: the Off computation of every formalized scenario contains
 the target layer of each row classified under that scenario. -/
 theorem off_contains_target_layer :
     ∀ row ∈ Examples.all, ∀ d ∈ denialTypeOf row, ∀ off ∈ scenarioOff row,
-      off.contains d.targetLayer = true := by
+      d.targetLayer ∈ off := by
   decide
 
 /-! ### §6. Denial ≠ negation (§2.1)

--- a/Linglib/Syntax/Category/Determiner/ModalIndefinite.lean
+++ b/Linglib/Syntax/Category/Determiner/ModalIndefinite.lean
@@ -23,7 +23,7 @@ correlate with them.
 * [kratzer-shimoyama-2002]
 -/
 
-open Modality Semantics.ContentLayer
+open Modality Presupposition
 
 /-- A modal indefinite determiner. -/
 structure ModalIndefinite extends Determiner where


### PR DESCRIPTION
Overhaul of `ContentLayer.lean`: namespace `Semantics.ContentLayer` → `Presupposition` (with `PartialProp`), `LayeredProp`/`BiLayered` fields `W → Prop` instead of `Bool`, offensiveness as `IsOffensive l (K : Set W)` with `isOffensive_iff_disjoint` and `offensiveLayers : Finset ContentLayer` (decidable over finite worlds), computable `ofPartialProp` with an `rfl` round-trip, and `LayeredProp.toBiLayered`. The king-of-France/pope worked examples (duplicated in `Studies/VanDerSandtMaier2003`) and the Martínez Vera composition rules I–III (single consumer) leave the substrate for their studies; the VanDerSandtMaier2003 study is adapted to `Finset` offensive layers and `Set` corrections.