### PR TITLE
refactor(Semantics/Evidential): rename namespaces to root Evidential and Epistemicity

### DIFF
--- a/Linglib/Features/Mirativity.lean
+++ b/Linglib/Features/Mirativity.lean
@@ -10,9 +10,9 @@ the two categories are often conveyed by overlapping morphology (e.g.,
 Turkish *-mIş*), but they answer distinct questions ("what is the source of
 the evidence?" vs "is the content surprising?").
 
-This module is intentionally separate from `Semantics.Evidential` to reflect
+This module is intentionally separate from `Evidential` to reflect
 that independence; bundling structures that combine source, authority, and
-mirativity (e.g. `Semantics.Epistemicity.EpistemicProfile`) import both.
+mirativity (e.g. `Epistemicity.EpistemicProfile`) import both.
 
 -/
 

--- a/Linglib/Features/Subjectivity.lean
+++ b/Linglib/Features/Subjectivity.lean
@@ -23,7 +23,7 @@ intersubjectification.
 
 namespace Features.Subjectivity
 
-open Semantics.Epistemicity (EpistemicAuthority)
+open Epistemicity
 
 /-- Synchronic subjectivity scale ([traugott-dasher-2002] Table 1,
     [traugott-2010] cline 2). Diachronic work shows that subjective

--- a/Linglib/Fragments/Abkhaz/Evidentiality.lean
+++ b/Linglib/Fragments/Abkhaz/Evidentiality.lean
@@ -16,7 +16,7 @@ results and verbal report, restricted to declarative main clauses.
 
 namespace Abkhaz.Evidentiality
 
-open Semantics.Evidential
+open Evidential
 
 /-- The non-firsthand affixes *-zaap'* and *-zaarən*. -/
 def evidentials : List Evidential :=

--- a/Linglib/Fragments/Aymara/Evidentiality.lean
+++ b/Linglib/Fragments/Aymara/Evidentiality.lean
@@ -15,7 +15,7 @@ namespace Aymara.Evidentiality
 Aymara's 3-way Andean system: direct `-wa`, reportative `-sa`,
 inferential `-pacha`. Obligatory verbal affixes. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-wa", exponent := .verbalAffix, covers := {.visual, .sensory} },

--- a/Linglib/Fragments/Kashaya/Evidentiality.lean
+++ b/Linglib/Fragments/Kashaya/Evidentiality.lean
@@ -38,7 +38,7 @@ famous feature — is the visual and sensory terms. The performative and the
     parameters of information source; the performative is kept with an empty
     coverage, so the paradigm fits none of Aikhenvald's kinds. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-wela/-mela", exponent := .verbalAffix, covers := ∅ },

--- a/Linglib/Fragments/Quechua/Evidentiality.lean
+++ b/Linglib/Fragments/Quechua/Evidentiality.lean
@@ -20,7 +20,7 @@ Cuzco Quechua's canonical B1 Andean system: direct `-mi`, reportative
 `-si`, conjectural/inferential `-chá`. Obligatory second-position
 clitics on finite clauses. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-mi", exponent := .clitic2P, covers := {.visual, .sensory} },

--- a/Linglib/Fragments/Quechua/SaraguroKichwa/Evidentiality.lean
+++ b/Linglib/Fragments/Quechua/SaraguroKichwa/Evidentiality.lean
@@ -42,7 +42,7 @@ Saraguro Kichwa's 3-way matrix-declarative system per
 inferential `-shi`. The focus-and-verum enclitic `=mi` is intentionally
 excluded (not analyzed as an evidential in this variety). -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-rka", exponent := .verbalAffix, covers := {.visual, .sensory} },

--- a/Linglib/Fragments/Slavic/Bulgarian/Evidentiality.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/Evidentiality.lean
@@ -18,7 +18,7 @@ firsthand information. The [cumming-2026] tense-evidential paradigm data are in
 
 namespace Bulgarian.Evidentiality
 
-open Semantics.Evidential
+open Evidential
 
 /-- The non-firsthand *l*-form; the aorist is its unmarked counterpart. -/
 def evidentials : List Evidential :=

--- a/Linglib/Fragments/Tariana/Evidentiality.lean
+++ b/Linglib/Fragments/Tariana/Evidentiality.lean
@@ -18,7 +18,7 @@ Tariana's classic D1 5-term Vaupés system per [aikhenvald-2004]:
 visual, non-visual sensory, inferred (from result), assumed (from
 reasoning), reported. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-ka", exponent := .verbalAffix, covers := {.visual} },

--- a/Linglib/Fragments/Tibetan/Evidentiality.lean
+++ b/Linglib/Fragments/Tibetan/Evidentiality.lean
@@ -18,7 +18,7 @@ and auxiliary system: `red`/`yod` (direct, personal knowledge) vs
 `'dug`/`yin` (indirect, new information). Grammaticalized lexical
 opposition. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "red", exponent := .lexicalFrame, covers := {.visual, .sensory} },

--- a/Linglib/Fragments/Turkish/Evidentiality.lean
+++ b/Linglib/Fragments/Turkish/Evidentiality.lean
@@ -16,7 +16,7 @@ non-firsthand is fused with tense and the copula.
 
 namespace Turkish.Evidentiality
 
-open Semantics.Evidential
+open Evidential
 
 /-- The non-firsthand *-mIş*; the *-DI* past is evidentiality-neutral, not a firsthand term. -/
 def evidentials : List Evidential :=

--- a/Linglib/Fragments/Tuyuca/Evidentiality.lean
+++ b/Linglib/Fragments/Tuyuca/Evidentiality.lean
@@ -20,7 +20,7 @@ namespace Tuyuca.Evidentiality
 Tuyuca's 5-term D1 system per [aikhenvald-2004] Ch 2 §2.4 and
 [barnes-1984]. -/
 
-open Semantics.Evidential
+open Evidential
 
 /-- Tuyuca evidential inventory in the new typed form. Five entries:
     two `Direct` (visual/non-visual sensory), two `Inferential`

--- a/Linglib/Fragments/WestGreenlandic/Evidentiality.lean
+++ b/Linglib/Fragments/WestGreenlandic/Evidentiality.lean
@@ -15,7 +15,7 @@ namespace WestGreenlandic.Evidentiality
 West Greenlandic's inferential mood: a single verbal-affix marker
 covering inference; no dedicated direct or reportative marker. -/
 
-open Semantics.Evidential
+open Evidential
 
 def evidentials : List Evidential :=
   [ { form := "-gunarpoq", exponent := .verbalAffix, covers := {.inference, .assumption} } ]

--- a/Linglib/Semantics/Evidential/Basic.lean
+++ b/Linglib/Semantics/Evidential/Basic.lean
@@ -13,7 +13,7 @@ firsthand evidence only, retrospective otherwise.
 
 ## Main definitions
 
-* `Semantics.Evidential.CoarseSource.block`, `Parameter.coarse` — the domains as blocks.
+* `Evidential.CoarseSource.block`, `Parameter.coarse` — the domains as blocks.
 * `Evidential.toCoarseSource` — the coarse source of a term, when defined.
 * `Evidential.finpartition` — the paradigm of a well-formed inventory.
 
@@ -27,7 +27,7 @@ firsthand evidence only, retrospective otherwise.
 * [willett-1988]
 -/
 
-namespace Semantics.Evidential
+namespace Evidential
 
 /-- Willett's coarse domains as blocks of parameters. -/
 def CoarseSource.block : CoarseSource → Finset Parameter
@@ -43,11 +43,11 @@ def Parameter.coarse : Parameter → CoarseSource
 
 theorem Parameter.mem_block (p : Parameter) : p ∈ p.coarse.block := by cases p <;> decide
 
-end Semantics.Evidential
+end Evidential
 
 namespace Evidential
 
-open Semantics.Evidential
+open Evidential
 
 /-- The coarse source of an evidential, when its coverage lies within one of Willett's
 domains; a non-firsthand term has none. -/

--- a/Linglib/Semantics/Evidential/Defs.lean
+++ b/Linglib/Semantics/Evidential/Defs.lean
@@ -15,8 +15,8 @@ partition the parameters the language expresses (`Semantics/Evidential/Basic.lea
 
 ## Main definitions
 
-* `Semantics.Evidential.Parameter` — the six semantic parameters of information source.
-* `Semantics.Evidential.Exponent` — how an evidential is realized.
+* `Evidential.Parameter` — the six semantic parameters of information source.
+* `Evidential.Exponent` — how an evidential is realized.
 * `Evidential` — the lexical entry; `Evidential.covers` its information sources.
 * `Evidential.IsDirect`, `IsInferential`, `IsReportative`, `IsNonfirsthand` — the coarse
   kinds of term, as properties of coverage.
@@ -28,7 +28,7 @@ partition the parameters the language expresses (`Semantics/Evidential/Basic.lea
 * [willett-1988]
 -/
 
-namespace Semantics.Evidential
+namespace Evidential
 
 /-- The six recurrent semantic parameters of information source. -/
 inductive Parameter where
@@ -64,21 +64,21 @@ inductive Exponent where
   | toneAblaut
   deriving DecidableEq, Repr
 
-end Semantics.Evidential
+end Evidential
 
 /-- An evidential: its form, its realization, and the information sources it covers. -/
 structure Evidential where
   /-- A representative morpheme or construction label. -/
   form : String
   /-- The realization strategy. -/
-  exponent : Semantics.Evidential.Exponent
+  exponent : Evidential.Exponent
   /-- The semantic parameters the term covers. -/
-  covers : Finset Semantics.Evidential.Parameter
+  covers : Finset Evidential.Parameter
   deriving DecidableEq
 
 namespace Evidential
 
-open Semantics.Evidential
+open Evidential
 
 /-- A direct evidential covers firsthand evidence only. -/
 def IsDirect (e : Evidential) : Prop := e.covers.Nonempty ∧ e.covers ⊆ {.visual, .sensory}

--- a/Linglib/Semantics/Evidential/Epistemicity.lean
+++ b/Linglib/Semantics/Evidential/Epistemicity.lean
@@ -35,9 +35,9 @@ extension respectively) and are left for future work.
 
 -/
 
-namespace Semantics.Epistemicity
+namespace Epistemicity
 
-open Semantics.Evidential
+open Evidential
 open Features.Mirativity
 open Semantics.Context
 
@@ -104,4 +104,4 @@ theorem epistemicAuthority_shift_invariant {W E P T : Type*} [DecidableEq E]
     epistemicAuthority (tower.push σ) knower = epistemicAuthority tower knower := by
   simp only [epistemicAuthority, ContextTower.push_origin]
 
-end Semantics.Epistemicity
+end Epistemicity

--- a/Linglib/Semantics/Evidential/Source.lean
+++ b/Linglib/Semantics/Evidential/Source.lean
@@ -25,7 +25,7 @@ This module supplies the shared vocabulary consumed by both
 evidential lexical API in the sibling `Defs`/`Basic` files.
 -/
 
-namespace Semantics.Evidential
+namespace Evidential
 
 /-- Coarse three-way evidential source classification: [willett-1988]'s
     attested / reported / inferring tripartition. `hearsay` is the umbrella
@@ -132,4 +132,4 @@ instance (priority := 100) {α : Type*} [HasCoarseSource α] :
 instance : HasEvidentialPerspective EvidentialPerspective where
   toEvidentialPerspective := some
 
-end Semantics.Evidential
+end Evidential

--- a/Linglib/Semantics/Reference/Context/Rich.lean
+++ b/Linglib/Semantics/Reference/Context/Rich.lean
@@ -30,7 +30,7 @@ express:
 namespace Semantics.Context
 
 open Semantics.Context (KContext ContextTower ContextShift)
-open Semantics.Evidential
+open Evidential
 
 -- ════════════════════════════════════════════════════════════════
 -- § Rich Context

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -41,17 +41,17 @@ design where paradigm entries stored opaque lambdas.
 
 The tense evidential constraint parallels [von-fintel-gillies-2010]
 `kernelMust` presupposition: both accounts now speak through
-`Semantics.Evidential` (the perspective taxonomy here, the
+`Evidential` (the perspective taxonomy here, the
 `CoarseSource.IsIndirect` restriction in `Studies/VonFintelGillies2010.lean`).
 A frame-level bridge between the two phenomena has not been built.
 
-## Connection to Semantics.Evidential
+## Connection to Evidential
 
 `EPCondition` is a `HasEvidentialPerspective` instance: each of the five EP
 constraint shapes maps to (an `Option` of) the canonical `EvidentialPerspective`
-classification in `Semantics.Evidential`. `EPCondition.IsNonfuture` and
+classification in `Evidential`. `EPCondition.IsNonfuture` and
 `TAMEEntry.IsNonfuture` are dot-notation aliases for the typeclass-derived
-`Semantics.Evidential.IsNonfuture` predicate.
+`Evidential.IsNonfuture` predicate.
 
 -/
 
@@ -61,7 +61,7 @@ namespace Tense.Evidential
 
 open Core.Order
 open Tense
-open Semantics.Evidential
+open _root_.Evidential
 open Features.Mirativity
 open Presupposition
 
@@ -121,15 +121,15 @@ def EPCondition.toEvidentialPerspective : EPCondition → Option EvidentialPersp
 instance : HasEvidentialPerspective EPCondition where
   toEvidentialPerspective := EPCondition.toEvidentialPerspective
 
-/-- Dot-notation alias for the typeclass-derived `Semantics.Evidential.IsNonfuture`
+/-- Dot-notation alias for the typeclass-derived `Evidential.IsNonfuture`
     on EP constraint shapes. Downstream, strict downstream, and contemporaneous
     all project to retrospective/contemporaneous; prospective and unconstrained
     do not. -/
 def EPCondition.IsNonfuture (e : EPCondition) : Prop :=
-  Semantics.Evidential.IsNonfuture e
+  Evidential.IsNonfuture e
 
 instance : DecidablePred EPCondition.IsNonfuture :=
-  fun _ => inferInstanceAs (Decidable (Semantics.Evidential.IsNonfuture _))
+  fun _ => inferInstanceAs (Decidable (Evidential.IsNonfuture _))
 
 /-! ### UP Constraint Enum -/
 
@@ -179,13 +179,13 @@ structure TAMEEntry where
 instance : HasEvidentialPerspective TAMEEntry where
   toEvidentialPerspective p := toEvidentialPerspective p.ep
 
-/-- Dot-notation alias for the typeclass-derived `Semantics.Evidential.IsNonfuture`
+/-- Dot-notation alias for the typeclass-derived `Evidential.IsNonfuture`
     on TAME paradigm rows. A row is nonfuture iff its EP constraint is. -/
 def TAMEEntry.IsNonfuture (p : TAMEEntry) : Prop :=
-  Semantics.Evidential.IsNonfuture p
+  Evidential.IsNonfuture p
 
 instance : DecidablePred TAMEEntry.IsNonfuture :=
-  fun _ => inferInstanceAs (Decidable (Semantics.Evidential.IsNonfuture _))
+  fun _ => inferInstanceAs (Decidable (Evidential.IsNonfuture _))
 
 /-- The EP constraint as a predicate over `EvidentialFrame ℤ`. -/
 def TAMEEntry.epConstraint (p : TAMEEntry) :

--- a/Linglib/Studies/Aikhenvald2004.lean
+++ b/Linglib/Studies/Aikhenvald2004.lean
@@ -50,7 +50,7 @@ systems (`tariana_illustration`, `wanka_illustration`, `turkish_illustration`).
 
 namespace Aikhenvald2004
 
-open Semantics.Evidential
+open Evidential
 
 /-! ### Terms -/
 

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -230,7 +230,7 @@ theorem direct_evidence_blocks_both :
 
 /-! ### Epistemic authority bridge -/
 
-open Semantics.Epistemicity
+open Epistemicity
 
 /-- Strong assertions (ego + direct) correspond to settling kernels.
     When the speaker has privileged access AND direct evidence, the

--- a/Linglib/Studies/Izvorski1997.lean
+++ b/Linglib/Studies/Izvorski1997.lean
@@ -30,7 +30,7 @@ The key empirical contrasts establishing (8):
 
 namespace Izvorski1997
 
-open Semantics.Evidential
+open Evidential
 
 /-! ### Languages with PE -/
 

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -138,7 +138,7 @@ theorem triangle_predicts_all :
 
 /-! ### Evidential Perspective -/
 
-open Semantics.Evidential
+open Evidential
 
 /-- A datum's evidential perspective is read off temporal overlap:
     overlapping learning events are contemporaneous, non-overlapping ones

--- a/Linglib/Studies/Kratzer2012Informational.lean
+++ b/Linglib/Studies/Kratzer2012Informational.lean
@@ -27,7 +27,7 @@ namespace Kratzer2012Informational
 abbrev World := Fin 4
 
 open Modality.Kratzer
-open Semantics.Evidential
+open Evidential
 
 /-! ## Propositions -/
 

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -122,7 +122,7 @@ theorem composeI_eq_composeII (atFn naiFn : (W → Prop) → (W → Prop)) (β :
   · simp [composeI, composeII, hβ]
 
 open Semantics.Highlighting (HighlightingContext Highlighted AddressesQUD addSalient)
-open Semantics.Evidential (CoarseSource)
+open Evidential
 open Discourse (DiscourseRole)
 
 variable {W : Type*}

--- a/Linglib/Studies/Matthewson2016.lean
+++ b/Linglib/Studies/Matthewson2016.lean
@@ -114,7 +114,7 @@ theorem gitksan_circ_factual :
     modals reportative, and factual circumstantials encode no information
     source. -/
 def backgroundCoarseSource :
-    BackgroundClass → Option Semantics.Evidential.CoarseSource
+    BackgroundClass → Option Evidential.CoarseSource
   | .factualEvidential => some .inference
   | .contentEvidential => some .hearsay
   | .factualCircumstantial => none

--- a/Linglib/Studies/Schoter1996.lean
+++ b/Linglib/Studies/Schoter1996.lean
@@ -192,7 +192,7 @@ built from the guard and the semi-designation function `σ`. -/
 
 section Connectives
 
-open Evidential (guard)
+open Evidential
 
 variable {S : Type*} [LinearOrder S] [BoundedOrder S]
 

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -60,7 +60,7 @@ namespace SpeasTenny2003
 open Minimalist
 open Semantics.Context (KContext ContextTower ContextShift)
 open Mood (Illocutionary ClauseType)
-open Semantics.Epistemicity (EpistemicAuthority EpistemicProfile)
+open Epistemicity
 
 /-! ### Pragmatic roles -/
 
@@ -369,7 +369,7 @@ abbrev evalPSpecifier : SAPMood → PRole := seatOfKnowledge
     (direct / inference / hearsay). NB this three-way coarsening merges S&T's
     top tier (personal experience) into "direct"; the paper's full evidence
     hierarchy is personal experience ≫ direct ≫ indirect ≫ hearsay (p.327). -/
-abbrev EvidPSpecifier := Semantics.Evidential.CoarseSource
+abbrev EvidPSpecifier := Evidential.CoarseSource
 
 /-- **Real bridge to `Semantics/Evidential/Epistemicity.lean`.** The Sentience Domain's
     two specifiers ARE the two main fields of an `EpistemicProfile`:

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -42,7 +42,7 @@ must not directly settle the prejacent.
 
 namespace VonFintelGillies2010
 
-open Semantics.Evidential
+open Evidential
 open Data.Examples
 
 /-! ### Evidence types -/
@@ -73,7 +73,7 @@ instance : HasCoarseSource EvidenceType where
 /-- All VF&G evidence types are nonfuture: their perspective is always
     retrospective or contemporaneous (T ≤ A). -/
 theorem all_evidence_types_nonfuture (e : EvidenceType) :
-    Semantics.Evidential.IsNonfuture e := by
+    Evidential.IsNonfuture e := by
   cases e <;> decide
 
 /-! ### Adapters over the example rows -/


### PR DESCRIPTION
`Semantics.Evidential` → `Evidential` (joining the root `Evidential` record's namespace, so `Evidential.Parameter`, `Evidential.CoarseSource`, …) and `Semantics.Epistemicity` → `Epistemicity`, as with `Definiteness`/`Presupposition`; selective opens made bare. `Semantics/Tense/Evidential.lean` sits in `namespace Tense.Evidential` and opens `_root_.Evidential`.