### PR TITLE
feat(Studies/ChampollionAlsopGrosu2019): recut on the kernel pipeline

### DIFF
--- a/Linglib/Core/Probability/Kernel/OfWeights.lean
+++ b/Linglib/Core/Probability/Kernel/OfWeights.lean
@@ -24,6 +24,22 @@ total.
 open MeasureTheory ProbabilityTheory
 open scoped ENNReal
 
+namespace MeasureTheory.Measure
+
+variable {β : Type*} [MeasurableSpace β] [Fintype β] [MeasurableSingletonClass β]
+
+/-- A finite sum of scaled Dirac measures evaluates at a singleton to its weight. -/
+theorem sum_smul_dirac_apply_singleton (w : β → ℝ≥0∞) (b : β) :
+    (∑ b', w b' • dirac b') {b} = w b := by
+  rw [finsetSum_apply,
+    Finset.sum_eq_single_of_mem b (Finset.mem_univ b) fun b' _ hb' => by
+      rw [smul_apply, smul_eq_mul, dirac_apply' _ (.singleton b),
+        Set.indicator_of_notMem (fun h => hb' (Set.mem_singleton_iff.mp h)), mul_zero],
+    smul_apply, smul_eq_mul, dirac_apply' _ (.singleton b),
+    Set.indicator_of_mem (Set.mem_singleton b), Pi.one_apply, mul_one]
+
+end MeasureTheory.Measure
+
 namespace ProbabilityTheory.Kernel
 
 variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
@@ -40,15 +56,9 @@ noncomputable def ofWeights (w : α → β → ℝ≥0∞) : Kernel α β :=
 
 @[simp] theorem ofWeights_apply_singleton (w : α → β → ℝ≥0∞) (a : α) (b : β) :
     ofWeights w a {b} = w a b / ∑ b', w a b' := by
-  have hval : (∑ b', w a b' • Measure.dirac b') {b} = w a b := by
-    rw [Measure.finsetSum_apply,
-      Finset.sum_eq_single_of_mem b (Finset.mem_univ b) fun b' _ hb' => by
-        rw [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ (.singleton b),
-          Set.indicator_of_notMem (fun h => hb' (Set.mem_singleton_iff.mp h)), mul_zero],
-      Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ (.singleton b),
-      Set.indicator_of_mem (Set.mem_singleton b), Pi.one_apply, mul_one]
   show ((∑ b', w a b')⁻¹ • ∑ b', w a b' • Measure.dirac b') {b} = _
-  rw [Measure.smul_apply, smul_eq_mul, hval, ENNReal.div_eq_inv_mul]
+  rw [Measure.smul_apply, smul_eq_mul, Measure.sum_smul_dirac_apply_singleton,
+    ENNReal.div_eq_inv_mul]
 
 omit [MeasurableSingletonClass β] in
 /-- A row with a positive entry and finite entries normalizes to a

--- a/Linglib/Core/Probability/Kernel/Posterior.lean
+++ b/Linglib/Core/Probability/Kernel/Posterior.lean
@@ -56,6 +56,24 @@ theorem posterior_apply_singleton {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (ω
   rw [hrect]
   ring
 
+/-- Comparing posterior masses of finite events reduces to comparing prior-weighted
+likelihood sums; the observation marginal cancels. -/
+theorem posterior_real_finset_lt_iff {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (E₁ E₂ : Finset Ω) :
+    ((κ†μ) x).real ↑E₁ < ((κ†μ) x).real ↑E₂
+      ↔ (∑ ω ∈ E₁, μ.real {ω} * (κ ω).real {x}) < ∑ ω ∈ E₂, μ.real {ω} * (κ ω).real {x} := by
+  have hne : ∀ E : Finset Ω, (∑ ω ∈ E, μ {ω} * κ ω {x}) ≠ ∞ := fun E =>
+    ENNReal.sum_ne_top.mpr fun ω _ => ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
+  rw [measureReal_def, measureReal_def, ← sum_measure_singleton, ← sum_measure_singleton]
+  simp_rw [posterior_apply_singleton κ μ hx, div_eq_mul_inv]
+  rw [← Finset.sum_mul, ← Finset.sum_mul, ← div_eq_mul_inv, ← div_eq_mul_inv,
+    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne E₁) hx) (ENNReal.div_ne_top (hne E₂) hx),
+    ENNReal.div_lt_div_iff_left hx (measure_ne_top _ _),
+    ← ENNReal.toReal_lt_toReal (hne E₁) (hne E₂),
+    ENNReal.toReal_sum (fun ω _ => ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
+    ENNReal.toReal_sum (fun ω _ => ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
+  simp_rw [ENNReal.toReal_mul]
+  exact Iff.rfl
+
 /-- A single state of positive prior mass and positive emission witnesses a
 positive observation marginal. -/
 theorem comp_apply_singleton_ne_zero {Ω' 𝓧' : Type*} [MeasurableSpace Ω']
@@ -88,6 +106,19 @@ theorem snd_apply_singleton [Fintype Ω] (m : Measure (Ω × Θ)) (θ : Θ) :
       ext ⟨a, b⟩; simp [eq_comm],
     ← sum_measure_singleton, Finset.sum_product]
   exact Finset.sum_congr rfl fun ω _ => Finset.sum_singleton _ _
+
+/-- The state marginal at a singleton is the mass of the corresponding product event. -/
+theorem fst_real_singleton [Fintype Θ] (m : Measure (Ω × Θ)) (ω : Ω) :
+    m.fst.real {ω} = m.real ↑(({ω} : Finset Ω) ×ˢ (Finset.univ : Finset Θ)) := by
+  rw [measureReal_def, measureReal_def, fst_apply_singleton, ← sum_measure_singleton,
+    Finset.sum_product, Finset.sum_singleton]
+
+/-- The latent marginal at a singleton is the mass of the corresponding product event. -/
+theorem snd_real_singleton [Fintype Ω] (m : Measure (Ω × Θ)) (θ : Θ) :
+    m.snd.real {θ} = m.real ↑((Finset.univ : Finset Ω) ×ˢ ({θ} : Finset Θ)) := by
+  rw [measureReal_def, measureReal_def, snd_apply_singleton, ← sum_measure_singleton,
+    Finset.sum_product]
+  exact congrArg _ (Finset.sum_congr rfl fun ω _ => (Finset.sum_singleton _ _).symm)
 
 end MeasureTheory.Measure
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -71,6 +71,29 @@ theorem literalListener_apply_singleton [Fintype W] [MeasurableSingletonClass W]
     withDensity_apply _ (.singleton w), lintegral_singleton, withDensity_apply _ MeasurableSet.univ,
     Measure.restrict_univ, lintegral_fintype, ENNReal.div_eq_inv_mul]
 
+theorem literalListener_indicator_apply_singleton [DiscreteMeasurableSpace W] (μ : Measure W)
+    (sem : U → Set W) {u : U} {w : W} (h : w ∈ sem u) :
+    literalListener μ (fun u => (sem u).indicator 1) u {w} = (μ (sem u))⁻¹ * μ {w} := by
+  rw [literalListener_indicator, Kernel.ofFunOfCountable_apply, cond_apply .of_discrete,
+    Set.inter_eq_self_of_subset_right (Set.singleton_subset_iff.mpr h)]
+
+theorem literalListener_indicator_apply_singleton_of_notMem [DiscreteMeasurableSpace W]
+    (μ : Measure W) (sem : U → Set W) {u : U} {w : W} (h : w ∉ sem u) :
+    literalListener μ (fun u => (sem u).indicator 1) u {w} = 0 := by
+  rw [literalListener_indicator, Kernel.ofFunOfCountable_apply, cond_apply .of_discrete,
+    Set.inter_comm, Set.singleton_inter_eq_empty.mpr h, measure_empty, mul_zero]
+
+/-- On a finite-mass extension the literal listener is a subprobability at members. -/
+theorem literalListener_indicator_apply_singleton_le_one [DiscreteMeasurableSpace W]
+    (μ : Measure W) (sem : U → Set W) {u : U} (hfin : μ (sem u) ≠ ∞) {w : W} (h : w ∈ sem u) :
+    literalListener μ (fun u => (sem u).indicator 1) u {w} ≤ 1 := by
+  rw [literalListener_indicator_apply_singleton μ sem h]
+  rcases eq_or_ne (μ (sem u)) 0 with h0 | h0
+  · rw [measure_mono_null (Set.singleton_subset_iff.mpr h) h0, mul_zero]
+    exact zero_le_one
+  · rw [ENNReal.inv_mul_le_iff h0 hfin, mul_one]
+    exact measure_mono (Set.singleton_subset_iff.mpr h)
+
 end LiteralListener
 
 variable [Countable W] [MeasurableSingletonClass W] [Fintype U] [MeasurableSingletonClass U]
@@ -122,6 +145,24 @@ theorem speaker_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {cost : U �
   exact ⟨mul_ne_zero (weight_rpow_ne_zero hα h) (hc0 u),
     ENNReal.sum_ne_top.mpr fun u' _ =>
       ENNReal.mul_ne_top (weight_rpow_ne_top hα (hle u')) (hctop u')⟩
+
+/-- A state with a unique applicable utterance produces it with certainty. -/
+theorem speaker_apply_singleton_eq_one {α : ℝ} (hα : 0 < α) {cost : U → ℝ≥0∞} {u : U}
+    (hc0 : cost u ≠ 0) (hctop : cost u ≠ ∞) {L : Kernel U W} {w : W} (h : L u {w} ≠ 0)
+    (hle : L u {w} ≤ 1) (hother : ∀ u' ≠ u, L u' {w} = 0) : speaker α cost L w {u} = 1 := by
+  rw [speaker_apply_singleton, Finset.sum_eq_single u
+    (fun u' _ hu' => by rw [hother u' hu', ENNReal.zero_rpow_of_pos hα, zero_mul])
+    (fun hu => absurd (Finset.mem_univ u) hu)]
+  exact ENNReal.div_self (mul_ne_zero (weight_rpow_ne_zero hα.le h) hc0)
+    (ENNReal.mul_ne_top (weight_rpow_ne_top hα.le hle) hctop)
+
+omit [MeasurableSingletonClass U] in
+/-- Speaker shares are at most one. -/
+theorem speaker_real_singleton_le_one (α : ℝ) (cost : U → ℝ≥0∞) (L : Kernel U W) (w : W)
+    (u : U) : (speaker α cost L w).real {u} ≤ 1 := by
+  rw [measureReal_def, ← ENNReal.toReal_one]
+  exact ENNReal.toReal_mono ENNReal.one_ne_top
+    ((measure_mono (Set.subset_univ _)).trans (Kernel.ofWeights_apply_univ_le_one _ w))
 
 /-! #### Pragmatic listeners -/
 
@@ -288,6 +329,23 @@ noncomputable def familyListener (L : Λ → Kernel U W) (α : ℝ) (cost : U �
   (familySpeaker L α cost)†μ
 
 variable {μ : Measure (W × Λ)} [IsFiniteMeasure μ]
+
+/-- Exact Bayes for the family listener at a positive-mass utterance. -/
+theorem familyListener_apply_singleton (L : Λ → Kernel U W) (α : ℝ) (cost : U → ℝ≥0∞) {u : U}
+    (hu : (familySpeaker L α cost ∘ₘ μ) {u} ≠ 0) (p : W × Λ) :
+    familyListener L α cost μ u {p}
+      = μ {p} * speaker α cost (L p.2) p.1 {u} / (familySpeaker L α cost ∘ₘ μ) {u} := by
+  rw [familyListener, posterior_apply_singleton _ _ hu, familySpeaker_apply]
+
+/-- Event comparison for the family listener reduces to prior-weighted member speaker
+sums. -/
+theorem familyListener_real_lt_iff (L : Λ → Kernel U W) (α : ℝ) (cost : U → ℝ≥0∞) {u : U}
+    (hu : (familySpeaker L α cost ∘ₘ μ) {u} ≠ 0) (E₁ E₂ : Finset (W × Λ)) :
+    (familyListener L α cost μ u).real ↑E₁ < (familyListener L α cost μ u).real ↑E₂
+      ↔ (∑ p ∈ E₁, μ.real {p} * (speaker α cost (L p.2) p.1).real {u})
+        < ∑ p ∈ E₂, μ.real {p} * (speaker α cost (L p.2) p.1).real {u} := by
+  rw [familyListener, posterior_real_finset_lt_iff _ _ hu]
+  simp_rw [familySpeaker_apply]
 
 /-- State-marginal preference for a latent family at equal priors: the latent pools,
 leaving summed member speaker shares. -/

--- a/Linglib/Pragmatics/RSA/Profile.lean
+++ b/Linglib/Pragmatics/RSA/Profile.lean
@@ -14,8 +14,8 @@ over these multisets (`Linglib.Pragmatics.RSA.Uniform`), so preference certifica
 ## Main definitions
 
 * `RSA.profile`, `RSA.fiberProfile`, `RSA.restProfile` — extension-size multisets.
-* `RSA.pooledDivPowSum` — the ℕ-cleared production mass of a choice pooled over its true
-  states.
+* `RSA.pooledDivPowSum`, `RSA.familyDivPowSum` — ℕ-cleared posterior masses for the
+  evaluation registers.
 
 ## Main results
 
@@ -123,5 +123,22 @@ theorem pooledDivPowSum_eq_sum (D k : ℕ) (c : C) :
           (D / (sem c).card) ^ k * ∏ t' ∈ Finset.univ.erase t, (profile sem t').divPowSum D k
         else 0 := by
   rw [pooledDivPowSum, Finset.mul_sum, Finset.sum_ite_mem, Finset.univ_inter]
+
+/-- The ℕ-cleared posterior mass of an event of (state, latent) pairs given `c` for a
+family of extensions: per pair, its common-denominator speaker weight times the product of
+the other pairs' cleared partition sums. Family evaluation-register hypotheses compare
+these. -/
+def familyDivPowSum {Λ : Type*} [Fintype Λ] [DecidableEq Λ] (sem : Λ → C → Finset T)
+    (D k : ℕ) (c : C) (E : Finset (T × Λ)) : ℕ :=
+  ∑ p ∈ E, (if p.1 ∈ sem p.2 c then (D / (sem p.2 c).card) ^ k else 0)
+    * ∏ q ∈ Finset.univ.erase p, (profile (sem q.2) q.1).divPowSum D k
+
+theorem familyDivPowSum_eq_sum {Λ : Type*} [Fintype Λ] [DecidableEq Λ] (sem : Λ → C → Finset T)
+    (D k : ℕ) (c : C) (E : Finset (T × Λ)) :
+    familyDivPowSum sem D k c E
+      = ∑ p, if p ∈ E then (if p.1 ∈ sem p.2 c then (D / (sem p.2 c).card) ^ k else 0)
+          * ∏ q ∈ Finset.univ.erase p, (profile (sem q.2) q.1).divPowSum D k
+        else 0 := by
+  rw [familyDivPowSum, Finset.sum_ite_mem, Finset.univ_inter]
 
 end RSA

--- a/Linglib/Pragmatics/RSA/Uniform.lean
+++ b/Linglib/Pragmatics/RSA/Uniform.lean
@@ -103,6 +103,14 @@ theorem uniformSpeaker_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {t : 
     (fun c' => uniformListener_apply_singleton_le_one sem c' t)
     (uniformListener_apply_singleton_ne_zero sem h)
 
+/-- A state truly described by a single choice produces it with certainty. -/
+theorem uniformSpeaker_apply_singleton_eq_one {α : ℝ} (hα : 0 < α) {t : T} {c : C}
+    (hmem : t ∈ sem c) (hother : ∀ c' ≠ c, t ∉ sem c') : uniformSpeaker sem α t {c} = 1 :=
+  speaker_apply_singleton_eq_one (L := uniformListener sem) (cost := 1) hα one_ne_zero
+    ENNReal.one_ne_top (uniformListener_apply_singleton_ne_zero sem hmem)
+    (uniformListener_apply_singleton_le_one sem c t) fun c' hc' => by
+      rw [uniformListener_apply_singleton, if_neg (hother c' hc')]
+
 variable [DecidableEq O] (obs : C → O)
 
 theorem sum_rpow_uniformListener {α : ℝ} (hα : 0 < α) (t : T) :
@@ -402,6 +410,52 @@ theorem uniformJointListener_fst_real_lt_of_divPowSum (hsem : ∀ t, ∃ c, t �
   rw [key _ _ (fun n hn => hdvd₁ n (hfsub t₁ n hn)) hdvd₂,
     key _ _ (fun n hn => hdvd₂ n (hfsub t₂ n hn)) hdvd₁,
     div_lt_div_iff_of_pos_right (by have := NeZero.ne D; positivity)]
+  exact_mod_cast hlt
+
+/-! ### Latent families at the uniform prior -/
+
+omit [Nonempty C] in
+/-- The evaluation register for a latent family at a natural rationality and the uniform
+prior on (state, latent) pairs: posterior preference between two events of pairs is the
+ℕ-valued common-denominator comparison — a kernel `decide`. The strict inequality carries
+its own truth witness. -/
+theorem familyListener_uniform_real_lt_of_divPowSum {Λ : Type*} [Fintype Λ] [DecidableEq Λ]
+    [MeasurableSpace Λ] [DiscreteMeasurableSpace Λ] [Nonempty Λ] (sem : Λ → C → Finset T)
+    (hsem : ∀ l t, ∃ c, t ∈ sem l c) {k D : ℕ} [NeZero k] [NeZero D]
+    (hdvd : ∀ l t, ∀ n ∈ profile (sem l) t, n ∣ D) {c : C} {E₁ E₂ : Finset (T × Λ)}
+    (hlt : familyDivPowSum sem D k c E₁ < familyDivPowSum sem D k c E₂) :
+    (familyListener (fun l => uniformListener (sem l)) k 1 (uniformOn Set.univ) c).real ↑E₁
+      < (familyListener (fun l => uniformListener (sem l)) k 1 (uniformOn Set.univ) c).real
+          ↑E₂ := by
+  rw [familyDivPowSum_eq_sum, familyDivPowSum_eq_sum] at hlt
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne k))
+  obtain ⟨p₀, -, hp₀⟩ := Finset.exists_ne_zero_of_sum_ne_zero
+    (Nat.pos_iff_ne_zero.mp (lt_of_le_of_lt (Nat.zero_le _) hlt))
+  have hmem₀ : p₀.1 ∈ sem p₀.2 c := by
+    by_contra h
+    exact hp₀ (by simp [h])
+  have hu : (familySpeaker (fun l => uniformListener (sem l)) k 1 ∘ₘ uniformOn Set.univ) {c}
+      ≠ 0 :=
+    comp_familySpeaker_ne_zero (w := p₀.1) (l := p₀.2) (uniformOn_univ_singleton_ne_zero p₀)
+      (uniformSpeaker_apply_singleton_ne_zero (sem p₀.2) hα.le hmem₀)
+  have key : ∀ E : Finset (T × Λ),
+      (∑ p ∈ E, (uniformOn (Set.univ : Set (T × Λ))).real {p}
+        * (speaker k 1 (uniformListener (sem p.2)) p.1).real {c})
+      = (Fintype.card (T × Λ) : ℝ)⁻¹ * ∑ p, (if p ∈ E then
+          (if p.1 ∈ sem p.2 c then (((D / (sem p.2 c).card) ^ k : ℕ) : ℝ) else 0) else 0)
+            / ((profile (sem p.2) p.1).divPowSum D k : ℝ) := by
+    intro E
+    simp_rw [ite_div, zero_div]
+    rw [Finset.sum_ite_mem, Finset.univ_inter, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun p _ => ?_
+    rw [uniformOn_univ_real_singleton, uniformSpeaker_real_singleton_divPowSum (sem p.2)
+      (hdvd p.2 p.1), ite_div, zero_div]
+  rw [familyListener_real_lt_iff _ _ _ hu, key, key,
+    mul_lt_mul_iff_right₀ (inv_pos.mpr (Nat.cast_pos.mpr Fintype.card_pos)),
+    sum_div_lt_sum_div_iff fun p => by
+    exact_mod_cast Multiset.divPowSum_pos (NeZero.ne D) (hdvd p.2 p.1)
+      (profile_ne_zero (sem p.2) (hsem p.2) p.1)]
+  simp only [ite_mul, zero_mul] at hlt ⊢
   exact_mod_cast hlt
 
 end RSA

--- a/Linglib/Studies/ChampollionAlsopGrosu2019.lean
+++ b/Linglib/Studies/ChampollionAlsopGrosu2019.lean
@@ -1,82 +1,74 @@
-import Linglib.Pragmatics.RSA.Canonical
+import Linglib.Pragmatics.RSA.Uniform
 
 /-!
-# [champollion-alsop-grosu-2019] — Free choice disjunction as a rational speech act
+# Champollion, Alsop & Grosu (2019): free choice disjunction as a rational speech act
 
-RSA model of [champollion-alsop-grosu-2019] (SALT 29): free choice ("You may
-take an apple or a pear" ⤳ "You may take an apple") emerges from RSA once
-**semantic uncertainty** ([bergen-levy-goodman-2016]) is added: agents reason
-over two interpretation functions — ℐ₁ (classical modal logic) and ℐ₂
-(strengthened via [fox-2007]-style exhaustification) — so a bare disjunct
-risks the "Only A" reading; the disjunction avoids that risk and the listener
-inverts the avoidance. States and utterances extend [franke-2011]'s IBR
-model; the recursion is [frank-goodman-2012]'s, with
-`P_L0(w|u,ℐ) ∝ ℐ(u,w)·P(w)`, `P_S1(u|w,ℐ) ∝ [P_L0]^α`, and
-`P_L1(w|u) ∝ P(w)·Σ_ℐ P_S1(u|w,ℐ)`.
+Free choice — *You may take an apple or a pear* conveys that each fruit may be taken by
+itself — does not follow from modal logic, and a speaker who prefers informative utterances
+never has reason to choose the disjunction over a disjunct. The paper adds semantic
+uncertainty: two interpretation functions, the classical (6) and the exhaustified (7), over
+which the pragmatic listener reasons jointly with states and utterances (8). Under the
+exhaustified function a bare disjunct risks the reading *only that fruit*, so at the
+free-choice states Only One and Any Number the disjunction is the speaker's safe choice
+(`speaker_or_onlyOne_exh`, `speaker_prefers_a_at_onlyA_exh`), and the listener inverts the
+avoidance: hearing *or*, each free-choice state outweighs each other state at the paper's
+α = 100 (`fci_derived`, Table 5), and the free-choice states already carry the majority at
+α = 2 (`fci_majority_low_alpha`).
 
-Instantiated on the canonical pipeline: the speaker is `RSA.Canonical.S1` at
-the natural-exponent informativity utility (`RSA.Canonical.powUtility` with
-`α = 2`, i.e. `rsaUtility` at zero cost), the listener `RSA.Canonical.L1`
-(the joint posterior over `FCState × Interp`). Findings are posterior-mass
-comparisons closed by dominance *bounds* on softmax weights — no numeric
-reflection. Since the FCI/EI events constrain only the world coordinate and
-the interpretation prior is uniform, joint-posterior event masses coincide
-with the paper's ℐ-marginalised L1. The paper's tables use `α = 100`; at the
-`α = 2` used here the paper notes L1 assigns "only 70%" to the FCI states
-given Or (our exact masses give ≈ 70.2%).
+Exclusivity — not both — tracks the prior instead: under a prior favouring Any Number the
+listener hearing *or* ranks Any Number above every other state, at every rationality
+(`anyNumber_of_prior`, Table 6) — the paper's account of why exclusivity, unlike free
+choice, is cancelable. Under negation the negated disjunction is unambiguous and maximally
+strong, so the listener assigns no mass to the states at which free choice would survive
+(`no_fci_under_negation`, Table 9). The variants without the conjunctive alternative
+(Tables 7–8) are not formalized.
 
-## Main statements
+## References
 
-* `fci_derived` — given Or, L1 favours the FCI states (Only One,
-  Any Number) under a uniform prior; `ei_uniform` — at α = 2 the EI states
-  also carry more mass (a low-α observation of ours: at the paper's α = 100
-  the EI split is exactly ½/½, and the paper derives EI from priors only).
-* `ei_defeated_by_prior` — with the paper's 75%-Any-Number prior the EI
-  comparison reverses: EI tracks world knowledge.
-* `speaker_or_onlyOne_exh` / `speaker_prefers_a_at_onlyA_exh` — the
-  avoidance mechanism at S1.
-
-## Implementation notes
-
-The paper's FCI-robustness claim (75% prior on Only A leaves FCI intact at
-`α = 100`) is parameter-dependent: at `α = 2` it *reverses* (the non-FCI
-score sum ≈ 0.32 dominates ≈ 0.065 — the low-α speaker does not reliably
-avoid Or at Only A, and the 12× prior swamps the avoidance; at `α = 100` the
-Only-A terms decay like (15/16)^α). The reversal qualifies the paper's
-generally-worded robustness conclusion, which is stated without an α-caveat.
-Per the library's policy on findings whose truth depends on an exact
-parameter value, it is recorded as prose, not as a theorem. The paper's Table-8 null-utterance robustness check is
-recorded as prose for space (its α = 2 values are documented in the final
-section), and the §4 negation model is not formalised.
+* [champollion-alsop-grosu-2019]
+* [franke-2011]
+* [fox-2007]
+* [bergen-levy-goodman-2016]
+* [frank-goodman-2012]
+* [kratzer-shimoyama-2002]
+* [simons-2005]
 -/
 
 namespace ChampollionAlsopGrosu2019
 
+open MeasureTheory ProbabilityTheory RSA
 open scoped ENNReal
-open RSA.Canonical
 
-/-! ### States, utterances, interpretation functions (Table 2, (5), (6), (7)) -/
+/-! ### States, utterances, interpretation functions (Table 2, (5)–(7)) -/
 
-/-- Permission states (Table 2): Franke's All True split into Any Number
-and Only Both. -/
+/-- Permission states (Table 2): Franke's All True split into Any Number and Only Both. -/
 inductive FCState where
-  | onlyA | onlyB
-  | onlyOne   -- either fruit, not both (FCI + EI)
-  | anyNumber -- any combination (FCI, no EI)
-  | onlyBoth  -- only both together (no FCI, no EI)
+  | onlyA | onlyB | onlyOne | anyNumber | onlyBoth
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- The four utterances of (5). -/
+instance : MeasurableSpace FCState := ⊤
+instance : DiscreteMeasurableSpace FCState := ⟨fun _ => trivial⟩
+instance : MeasurableSingletonClass FCState := DiscreteMeasurableSpace.toMeasurableSingletonClass
+
+/-- The four utterances (5). -/
 inductive Utterance where
   | a | b | or_ | and_
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- ℐ₁ literal vs ℐ₂ exhaustified ([fox-2007] innocent exclusion). -/
+instance : MeasurableSpace Utterance := ⊤
+instance : DiscreteMeasurableSpace Utterance := ⟨fun _ => trivial⟩
+instance : MeasurableSingletonClass Utterance := DiscreteMeasurableSpace.toMeasurableSingletonClass
+
+/-- The interpretation functions: classical modal logic and its exhaustification. -/
 inductive Interp where
   | literal | exhaustified
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- Free choice: each item individually permitted, `◇(A∧¬B) ∧ ◇(B∧¬A)`. -/
+instance : MeasurableSpace Interp := ⊤
+instance : DiscreteMeasurableSpace Interp := ⟨fun _ => trivial⟩
+instance : MeasurableSingletonClass Interp := DiscreteMeasurableSpace.toMeasurableSingletonClass
+
+/-- Free choice: each fruit may be taken by itself. -/
 def HasFCI : FCState → Prop
   | .onlyOne | .anyNumber => True
   | _ => False
@@ -85,16 +77,7 @@ instance : DecidablePred HasFCI
   | .onlyA | .onlyB | .onlyBoth => .isFalse id
   | .onlyOne | .anyNumber => .isTrue trivial
 
-/-- Exclusivity: taking both is not permitted, `¬◇(A∧B)`. -/
-def HasEI : FCState → Prop
-  | .onlyA | .onlyB | .onlyOne => True
-  | _ => False
-
-instance : DecidablePred HasEI
-  | .onlyA | .onlyB | .onlyOne => .isTrue trivial
-  | .anyNumber | .onlyBoth => .isFalse id
-
-/-- Interpretation function ℐ₁ (the paper's (6)). -/
+/-- Interpretation function 1 (6): classical modal logic. -/
 def I1 : Utterance → FCState → Prop
   | .a, .onlyB => False
   | .a, _ => True
@@ -107,7 +90,7 @@ def I1 : Utterance → FCState → Prop
 instance : ∀ u, DecidablePred (I1 u) := fun u w => by
   cases u <;> cases w <;> first | exact .isTrue trivial | exact .isFalse id
 
-/-- Interpretation function ℐ₂ (the paper's (7)). -/
+/-- Interpretation function 2 (7): the exhaustified meanings. -/
 def I2 : Utterance → FCState → Prop
   | .a, .onlyA => True
   | .a, _ => False
@@ -130,377 +113,268 @@ instance : ∀ i u, DecidablePred (interpMeaning i u)
   | .literal, u => inferInstanceAs (DecidablePred (I1 u))
   | .exhaustified, u => inferInstanceAs (DecidablePred (I2 u))
 
-/-- ℐ₂ refines ℐ₁: exhaustification only strengthens. -/
+/-- The extension of each utterance under each interpretation function. -/
+def sem (i : Interp) (u : Utterance) : Finset FCState := Finset.univ.filter (interpMeaning i u)
+
+@[simp] theorem mem_sem {i : Interp} {u : Utterance} {w : FCState} :
+    w ∈ sem i u ↔ interpMeaning i u w := by simp [sem]
+
+/-- Every state is truthfully describable under every interpretation function. -/
+theorem expressible : ∀ i w, ∃ u, w ∈ sem i u := by decide
+
+/-- Exhaustification only strengthens. -/
 theorem I2_refines_I1 : ∀ u w, I2 u w → I1 u w := by decide
 
-/-- ℐ₁(Or) is literally true everywhere — maximally uninformative. -/
+/-- The classical disjunction is true everywhere — maximally uninformative. -/
 theorem I1_or_everywhere : ∀ w, I1 .or_ w := by decide
 
-/-- ℐ₂(Or) excludes exactly Only Both. -/
+/-- The exhaustified disjunction excludes exactly Only Both. -/
 theorem I2_or_excludes_onlyBoth : ∀ w, I2 .or_ w ↔ w ≠ .onlyBoth := by decide
 
-/-- ℐ₂(A) singles out exactly Only A — the risk the speaker avoids. -/
+/-- The exhaustified disjunct singles out exactly Only A — the risk the speaker avoids. -/
 theorem I2_a_singleton : ∀ w, I2 .a w ↔ w = .onlyA := by decide
 
-/-! ### ENNReal budget helpers -/
+/-! ### The model (8) at a uniform prior -/
 
-private theorem two_mul_inv_add {c : ℝ≥0∞} (hT : c ≠ ∞) :
-    (2 * c)⁻¹ + (2 * c)⁻¹ = c⁻¹ := by
-  rw [← two_mul, ENNReal.mul_inv (Or.inr hT) (Or.inl ENNReal.ofNat_ne_top),
-      ← mul_assoc, ENNReal.mul_inv_cancel two_ne_zero ENNReal.ofNat_ne_top, one_mul]
+/-- The speaker under a fixed interpretation function (8b). -/
+noncomputable abbrev speaker (i : Interp) (α : ℝ) : Kernel FCState Utterance :=
+  uniformSpeaker (sem i) α
 
-private theorem quarter_add_quarter : (4 : ℝ≥0∞)⁻¹ + 4⁻¹ = 2⁻¹ := by
-  rw [show (4 : ℝ≥0∞) = 2 * 2 from by norm_num, two_mul_inv_add ENNReal.ofNat_ne_top]
+/-- The pragmatic listener (8c): the Bayesian inverse of the interpretation-indexed speaker
+at a uniform prior over states and interpretation functions; `.fst` marginalizes over the
+interpretation. -/
+noncomputable abbrev listener (α : ℝ) : Kernel Utterance (FCState × Interp) :=
+  familyListener (fun i => uniformListener (sem i)) α 1 (uniformOn Set.univ)
 
-/-! ### The FCI / EI events -/
+/-- Under the exhaustified function at Only One, *or* is the only true utterance, so the
+speaker produces it with certainty at every rationality (§3.3). -/
+theorem speaker_or_onlyOne_exh {α : ℝ} (hα : 0 < α) :
+    speaker .exhaustified α .onlyOne {.or_} = 1 :=
+  uniformSpeaker_apply_singleton_eq_one _ hα (by decide) (by decide)
 
-/-- The free-choice event of the joint listener (any interpretation). -/
-def fciPairs : Finset (FCState × Interp) := Finset.univ.filter (fun p => HasFCI p.1)
+/-- Under the exhaustified function at Any Number, *or* is the only true utterance. -/
+theorem speaker_or_anyNumber_exh {α : ℝ} (hα : 0 < α) :
+    speaker .exhaustified α .anyNumber {.or_} = 1 :=
+  uniformSpeaker_apply_singleton_eq_one _ hα (by decide) (by decide)
 
-/-- The complement of `fciPairs`. -/
-def nonFciPairs : Finset (FCState × Interp) := Finset.univ.filter (fun p => ¬ HasFCI p.1)
+/-- Under the exhaustified function at Only Both, *or* is false. -/
+theorem speaker_or_onlyBoth_exh {α : ℝ} (hα : 0 < α) :
+    speaker .exhaustified α .onlyBoth {.or_} = 0 :=
+  uniformSpeaker_apply_singleton_eq_zero _ hα (by decide)
 
-/-- The exclusivity event of the joint listener. -/
-def eiPairs : Finset (FCState × Interp) := Finset.univ.filter (fun p => HasEI p.1)
+/-- The avoidance mechanism at the speaker: under the exhaustified function at Only A the
+bare disjunct beats the disjunction at every rationality. -/
+theorem speaker_prefers_a_at_onlyA_exh {α : ℝ} (hα : 0 < α) :
+    (speaker .exhaustified α .onlyA).real {.or_} < (speaker .exhaustified α .onlyA).real {.a} :=
+  uniformSpeaker_real_singleton_lt_of_card_lt _ hα (by decide) (by decide) (by decide)
 
-/-- The complement of `eiPairs`. -/
-def nonEiPairs : Finset (FCState × Interp) := Finset.univ.filter (fun p => ¬ HasEI p.1)
-
-/-! ### The basic model, uniform prior
-
-At a uniform world prior the paper's `P_L0(w|u,ℐ) ∝ ℐ(u,w)·P(w)` is uniform
-on the extension, i.e. `RSA.Canonical.L0OfPred`. Exact S1(Or) values at
-α = 2, for reference: ℐ₁ row 16/41, 16/41, 8/33, 8/83, 8/83; ℐ₂ row 1/17,
-1/17, 1, 1, 0 (states in Table-2 order). -/
-
-theorem ext_nonempty (i : Interp) (u : Utterance) :
-    (RSA.extensionOf (interpMeaning i) u).Nonempty := by
-  cases i <;> cases u <;>
-    first
-      | exact ⟨.onlyA, by decide⟩
-      | exact ⟨.onlyB, by decide⟩
-      | exact ⟨.anyNumber, by decide⟩
-      | exact ⟨.onlyBoth, by decide⟩
-
-/-- Literal listener of the basic model. -/
-noncomputable abbrev l0 : Interp → Utterance → PMF FCState :=
-  L0OfPred interpMeaning ext_nonempty
-
-instance : ViableSpeaker (powUtility 2 l0) :=
-  viableSpeaker_powUtility_of_witness 2 l0 fun s => by
-    obtain ⟨w, i⟩ := s
-    cases i <;> cases w <;>
-      first
-        | exact ⟨.or_, L0OfPred_ne_zero _ _ (by decide)⟩
-        | exact ⟨.and_, L0OfPred_ne_zero _ _ (by decide)⟩
-
-/-- The pragmatic speaker of the basic model (the paper's `P_S1`, α = 2). -/
-noncomputable abbrev speaker : FCState × Interp → PMF Utterance :=
-  S1 (powUtility 2 l0)
-
-/-- Uniform joint prior over `state × interpretation`. -/
-noncomputable abbrev prior : PMF (FCState × Interp) := PMF.uniformOfFintype _
-
-/-- Under ℐ₂ at Only One, Or is the *only* applicable utterance — the heart
-of the avoidance mechanism (paper §3.3). -/
-theorem speaker_or_onlyOne_exh : speaker (.onlyOne, .exhaustified) .or_ = 1 :=
-  S1_powUtility_eq_one 2 l0 two_ne_zero .or_ fun u' hu' => by
-    cases u' <;> first | exact absurd rfl hu' | exact L0OfPred_eq_zero _ _ (by decide)
-
-/-- Under ℐ₂ at Any Number, Or is the only applicable utterance. -/
-theorem speaker_or_anyNumber_exh : speaker (.anyNumber, .exhaustified) .or_ = 1 :=
-  S1_powUtility_eq_one 2 l0 two_ne_zero .or_ fun u' hu' => by
-    cases u' <;> first | exact absurd rfl hu' | exact L0OfPred_eq_zero _ _ (by decide)
-
-/-- Under ℐ₂ at Only Both, Or is inapplicable. -/
-theorem speaker_or_onlyBoth_exh : speaker (.onlyBoth, .exhaustified) .or_ = 0 :=
-  S1_powUtility_eq_zero 2 l0 two_ne_zero (L0OfPred_eq_zero _ _ (by decide))
-
-/-- The avoidance mechanism at S1: under ℐ₂ at Only A the bare disjunct
-strictly beats the disjunction (16/17 vs 1/17). -/
-theorem speaker_prefers_a_at_onlyA_exh :
-    speaker (.onlyA, .exhaustified) .or_ < speaker (.onlyA, .exhaustified) .a := by
-  show S1 (powUtility 2 l0) (.onlyA, .exhaustified) .or_
-    < S1 (powUtility 2 l0) (.onlyA, .exhaustified) .a
-  rw [S1_powUtility_eq_normalize, PMF.normalize_lt_iff_lt,
-      powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
-      powWeight_L0OfPred_of_mem _ _ 1 (by decide) (by decide)]
-  exact ENNReal.pow_lt_pow_left two_ne_zero
-    (ENNReal.inv_lt_inv.mpr (Nat.cast_lt.mpr (by norm_num)))
-
-theorem marginal_or_ne_zero : PMF.marginal speaker prior .or_ ≠ 0 :=
-  PMF.marginal_ne_zero _ _ _
-    ((prior.mem_support_iff _).mp
-      (PMF.mem_support_uniformOfFintype (.onlyOne, .exhaustified)))
-    (by rw [speaker_or_onlyOne_exh]; exact one_ne_zero)
-
-/-- The pragmatic listener of the basic model (the paper's `P_L1`). -/
-noncomputable abbrev listener (u : Utterance)
-    (h : PMF.marginal speaker prior u ≠ 0) : PMF (FCState × Interp) :=
-  L1 speaker prior u h
-
-private theorem speaker_or_onlyA_lit_lt_half : speaker (.onlyA, .literal) .or_ < 2⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 1) (k := 5) (k' := 4)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_onlyB_lit_lt_half : speaker (.onlyB, .literal) .or_ < 2⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 1) (k := 5) (k' := 4)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_anyNumber_lit_lt_quarter : speaker (.anyNumber, .literal) .or_ < 4⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_onlyBoth_lit_lt_quarter : speaker (.onlyBoth, .literal) .or_ < 4⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_onlyA_exh_lt_quarter : speaker (.onlyA, .exhaustified) .or_ < 4⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 3) (k := 4) (k' := 1)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_onlyB_exh_lt_quarter : speaker (.onlyB, .exhaustified) .or_ < 4⁻¹ :=
-  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 3) (k := 4) (k' := 1)
-    (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
-    (by norm_num)).trans_le (by norm_num)
-
-private theorem speaker_or_onlyA_lit_gt_quarter : 4⁻¹ < speaker (.onlyA, .literal) .or_ :=
-  (inv_succ_lt_S1_powUtility 2 l0 (n := 3) <| by
-    rw [show (Finset.univ.erase Utterance.or_) = {.a, .b, .and_} from by decide,
-        Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_singleton,
-        powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
-        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
-        add_zero, add_zero]
-    exact ENNReal.inv_pow_lt_natCast_mul_inv_pow (by norm_num) (by norm_num)
-      (by norm_num)).trans_le' (by norm_num)
-
-private theorem speaker_or_onlyB_lit_gt_quarter : 4⁻¹ < speaker (.onlyB, .literal) .or_ :=
-  (inv_succ_lt_S1_powUtility 2 l0 (n := 3) <| by
-    rw [show (Finset.univ.erase Utterance.or_) = {.a, .b, .and_} from by decide,
-        Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_singleton,
-        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
-        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
-        zero_add, add_zero]
-    exact ENNReal.inv_pow_lt_natCast_mul_inv_pow (by norm_num) (by norm_num)
-      (by norm_num)).trans_le' (by norm_num)
-
-/-- **Free choice derived** (paper §3.3; uniform prior, α = 2): given Or, L1
-puts strictly more posterior mass on the FCI states than on the rest (the
-exact split is the ≈ 70% / 30% the paper reports for α = 2). -/
+/-- **Free choice derived** (Table 5): hearing *or* at the paper's α = 100, the listener
+ranks each free-choice state — Only One and Any Number, the paper's 0.5 each — above each
+of Only A, Only B, and Only Both (each ≈ 0). -/
 theorem fci_derived :
-    (listener .or_ marginal_or_ne_zero).toOuterMeasure ↑nonFciPairs
-      < (listener .or_ marginal_or_ne_zero).toOuterMeasure ↑fciPairs := by
-  rw [L1_uniform_event_lt_iff]
-  have hub : (∑ p ∈ nonFciPairs, speaker p .or_) < 2 := by
-    rw [show nonFciPairs = {(.onlyA, .literal), (.onlyA, .exhaustified),
-          (.onlyB, .literal), (.onlyB, .exhaustified),
-          (.onlyBoth, .literal), (.onlyBoth, .exhaustified)} from by decide,
-        Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_insert (by decide), Finset.sum_singleton,
-        speaker_or_onlyBoth_exh, add_zero]
-    refine (ENNReal.add_lt_add speaker_or_onlyA_lit_lt_half
-      (ENNReal.add_lt_add speaker_or_onlyA_exh_lt_quarter
-        (ENNReal.add_lt_add speaker_or_onlyB_lit_lt_half
-          (ENNReal.add_lt_add speaker_or_onlyB_exh_lt_quarter
-            speaker_or_onlyBoth_lit_lt_quarter)))).trans ?_
-    rw [show (2 : ℝ≥0∞)⁻¹ + (4⁻¹ + (2⁻¹ + (4⁻¹ + 4⁻¹)))
-          = (2⁻¹ + 2⁻¹) + ((4⁻¹ + 4⁻¹) + 4⁻¹) from by ring,
-        ENNReal.inv_two_add_inv_two, quarter_add_quarter]
-    calc (1 : ℝ≥0∞) + (2⁻¹ + 4⁻¹) < 1 + (2⁻¹ + 2⁻¹) := by
-          refine (ENNReal.add_lt_add_iff_left ENNReal.one_ne_top).mpr ?_
-          exact (ENNReal.add_lt_add_iff_left (ENNReal.inv_ne_top.mpr two_ne_zero)).mpr
-            (ENNReal.inv_lt_inv.mpr (by norm_num))
-      _ = 2 := by rw [ENNReal.inv_two_add_inv_two]; exact one_add_one_eq_two
-  have hlb : (2 : ℝ≥0∞) ≤ ∑ p ∈ fciPairs, speaker p .or_ := by
-    refine le_trans ?_ (Finset.sum_le_sum_of_subset
-      (by decide : ({(.onlyOne, .exhaustified), (.anyNumber, .exhaustified)} :
-        Finset (FCState × Interp)) ⊆ fciPairs))
-    rw [Finset.sum_insert (by decide), Finset.sum_singleton,
-        speaker_or_onlyOne_exh, speaker_or_anyNumber_exh, one_add_one_eq_two]
-  exact hub.trans_le hlb
+    ∀ w ∈ ({.onlyA, .onlyB, .onlyBoth} : Finset FCState),
+      ∀ w' ∈ ({.onlyOne, .anyNumber} : Finset FCState),
+        (listener 100 .or_).fst.real {w} < (listener 100 .or_).fst.real {w'} := by
+  intro w hw w' hw'
+  rw [Measure.fst_real_singleton, Measure.fst_real_singleton]
+  fin_cases hw <;> fin_cases hw' <;>
+    exact familyListener_uniform_real_lt_of_divPowSum sem expressible (k := 100) (D := 20)
+      (by decide +kernel) (by decide +kernel)
 
-/-- **Exclusivity at a uniform prior, α = 2** — a formalizer's observation,
-*not* the paper's claim: at the paper's α = 100 the split given Or is exactly
-0.5/0.5 ("fully half of it is on the non-EI state Any Number"); the paper
-derives EI from prior beliefs, claiming only that FCI is the *stronger*
-inference under uniform priors. At α = 2 the low-α speaker leaks Or-mass to
-the literal-ℐ Only A / Only B states (both EI states), so the EI event
-carries strictly more mass (≈ 64% / 36%) — strictness is an α = 2 artifact.
-Contrast `ei_defeated_by_prior`. -/
-theorem ei_uniform :
-    (listener .or_ marginal_or_ne_zero).toOuterMeasure ↑nonEiPairs
-      < (listener .or_ marginal_or_ne_zero).toOuterMeasure ↑eiPairs := by
-  rw [L1_uniform_event_lt_iff]
-  have hub : (∑ p ∈ nonEiPairs, speaker p .or_) < 1 + 2⁻¹ := by
-    rw [show nonEiPairs = {(.anyNumber, .literal), (.anyNumber, .exhaustified),
-          (.onlyBoth, .literal), (.onlyBoth, .exhaustified)} from by decide,
-        Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_insert (by decide), Finset.sum_singleton,
-        speaker_or_anyNumber_exh, speaker_or_onlyBoth_exh, add_zero]
-    refine (ENNReal.add_lt_add speaker_or_anyNumber_lit_lt_quarter
-      ((ENNReal.add_lt_add_iff_left ENNReal.one_ne_top).mpr
-        speaker_or_onlyBoth_lit_lt_quarter)).trans_eq ?_
-    rw [show (4 : ℝ≥0∞)⁻¹ + (1 + 4⁻¹) = 1 + (4⁻¹ + 4⁻¹) from by ring,
-        quarter_add_quarter]
-  have hlb : (1 : ℝ≥0∞) + 2⁻¹ ≤ ∑ p ∈ eiPairs, speaker p .or_ := by
-    refine le_trans ?_ (Finset.sum_le_sum_of_subset
-      (by decide : ({(.onlyA, .literal), (.onlyB, .literal),
-        (.onlyOne, .exhaustified)} : Finset (FCState × Interp)) ⊆ eiPairs))
-    rw [Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-        Finset.sum_singleton, speaker_or_onlyOne_exh]
-    refine le_of_lt (lt_of_eq_of_lt ?_ (ENNReal.add_lt_add speaker_or_onlyA_lit_gt_quarter
-      ((ENNReal.add_lt_add_iff_right ENNReal.one_ne_top).mpr
-        speaker_or_onlyB_lit_gt_quarter)))
-    rw [show (4 : ℝ≥0∞)⁻¹ + (4⁻¹ + 1) = (4⁻¹ + 4⁻¹) + 1 from by ring,
-        quarter_add_quarter, add_comm]
-  exact hub.trans_le hlb
+/-- The free-choice pairs of the joint listener. -/
+def fciPairs : Finset (FCState × Interp) := Finset.univ.filter fun p => HasFCI p.1
 
-/-! ### Prior sensitivity: the asymmetric-prior model
+/-- The remaining pairs. -/
+def nonFciPairs : Finset (FCState × Interp) := Finset.univ.filter fun p => ¬ HasFCI p.1
 
-The paper shows EI, unlike FCI, tracks world knowledge: with 75% prior on
-Any Number, L1 given Or concentrates on Any Number (92% at α = 100, Table 6).
-Following `P_L0(w|u,ℐ) ∝ ℐ(u,w)·P(w)`, the prior enters the literal
-listener. The complementary FCI-robustness claim (75% on Only A) is
-`α = 100`-dependent and reverses at α = 2 (module docstring): prose only. -/
+/-- At α = 2 the free-choice states still carry the majority of the posterior given *or*
+(the paper's "only 70%"). -/
+theorem fci_majority_low_alpha :
+    (listener 2 .or_).real ↑nonFciPairs < (listener 2 .or_).real ↑fciPairs :=
+  familyListener_uniform_real_lt_of_divPowSum sem expressible (k := 2) (D := 20)
+    (by decide +kernel) (by decide +kernel)
 
-/-- Asymmetric prior weights: 75% on Any Number (12 : 1 : 1 : 1 : 1). -/
+/-! ### Prior sensitivity (Table 6)
+
+The prior enters the literal listener (8a) and the pragmatic listener (8c) alike. -/
+
+/-- Prior weights favouring Any Number: 12 against 1 for each other state (75%). -/
 def biasedWeight : FCState → ℕ
   | .anyNumber => 12
   | _ => 1
 
-private theorem wB_tsum_ne_zero (i : Interp) (u : Utterance) :
-    (∑' w, if interpMeaning i u w then (biasedWeight w : ℝ≥0∞) else 0) ≠ 0 := by
-  intro hz
-  have key : ∀ w : FCState, interpMeaning i u w → False := fun w hw => by
-    have h := ENNReal.tsum_eq_zero.mp hz w
-    rw [if_pos hw, Nat.cast_eq_zero] at h
-    exact absurd h (by cases w <;> simp [biasedWeight])
-  cases i <;> cases u <;>
-    first
-      | exact key .onlyA (by decide)
-      | exact key .onlyB (by decide)
-      | exact key .anyNumber (by decide)
-      | exact key .onlyBoth (by decide)
+/-- The state prior. -/
+noncomputable def priorB : Measure FCState := ∑ w, (biasedWeight w : ℝ≥0∞) • Measure.dirac w
 
-private theorem wB_tsum_ne_top (i : Interp) (u : Utterance) :
-    (∑' w, if interpMeaning i u w then (biasedWeight w : ℝ≥0∞) else 0) ≠ ∞ := by
-  rw [tsum_fintype]
-  refine ENNReal.sum_ne_top.mpr fun w _ => ?_
-  split
-  · exact ENNReal.natCast_ne_top _
-  · exact ENNReal.zero_ne_top
+/-- The joint prior, the interpretation function drawn uniformly. -/
+noncomputable def jointPriorB : Measure (FCState × Interp) :=
+  ∑ p, (biasedWeight p.1 : ℝ≥0∞) • Measure.dirac p
 
-/-- Literal listener with the asymmetric prior (the paper's `P_L0`). -/
-noncomputable abbrev l0B (i : Interp) (u : Utterance) : PMF FCState :=
-  PMF.normalize _ (wB_tsum_ne_zero i u) (wB_tsum_ne_top i u)
+theorem priorB_singleton (w : FCState) : priorB {w} = biasedWeight w :=
+  Measure.sum_smul_dirac_apply_singleton (fun w => (biasedWeight w : ℝ≥0∞)) w
 
-private theorem l0B_ne_zero {i : Interp} {u : Utterance} {w : FCState}
-    (h : interpMeaning i u w) : l0B i u w ≠ 0 := by
-  rw [PMF.normalize_apply, if_pos h]
-  exact mul_ne_zero (by rw [Nat.cast_ne_zero]; cases w <;> simp [biasedWeight])
-    (ENNReal.inv_ne_zero.mpr (wB_tsum_ne_top i u))
+theorem jointPriorB_singleton (p : FCState × Interp) : jointPriorB {p} = biasedWeight p.1 :=
+  Measure.sum_smul_dirac_apply_singleton (fun p : FCState × Interp => (biasedWeight p.1 : ℝ≥0∞)) p
 
-private theorem l0B_eq_zero {i : Interp} {u : Utterance} {w : FCState}
-    (h : ¬ interpMeaning i u w) : l0B i u w = 0 := by
-  rw [PMF.normalize_apply, if_neg h, zero_mul]
+instance : IsFiniteMeasure priorB :=
+  ⟨by
+    rw [priorB, Measure.finsetSum_apply]
+    exact ENNReal.sum_lt_top.mpr fun w _ => by
+      rw [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply_of_mem (Set.mem_univ _), mul_one]
+      exact ENNReal.natCast_lt_top _⟩
 
-instance : ViableSpeaker (powUtility 2 l0B) :=
-  viableSpeaker_powUtility_of_witness 2 l0B fun s => by
-    obtain ⟨w, i⟩ := s
-    cases i <;> cases w <;>
-      first
-        | exact ⟨.or_, l0B_ne_zero (by decide)⟩
-        | exact ⟨.and_, l0B_ne_zero (by decide)⟩
+instance : IsFiniteMeasure jointPriorB :=
+  ⟨by
+    rw [jointPriorB, Measure.finsetSum_apply]
+    exact ENNReal.sum_lt_top.mpr fun p _ => by
+      rw [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply_of_mem (Set.mem_univ _), mul_one]
+      exact ENNReal.natCast_lt_top _⟩
 
-/-- The pragmatic speaker of the asymmetric-prior model. -/
-noncomputable abbrev speakerB : FCState × Interp → PMF Utterance :=
-  S1 (powUtility 2 l0B)
+/-- The extensions as sets. -/
+def semSet (i : Interp) (u : Utterance) : Set FCState := ↑(sem i u)
 
-/-- Or is still the only applicable utterance at (Any Number, ℐ₂),
-independently of the prior weighting. -/
-theorem speakerB_or_anyNumber_exh : speakerB (.anyNumber, .exhaustified) .or_ = 1 :=
-  S1_powUtility_eq_one 2 l0B two_ne_zero .or_ fun u' hu' => by
-    cases u' <;> first | exact absurd rfl hu' | exact l0B_eq_zero (by decide)
+/-- The literal listeners at the biased prior (8a). -/
+noncomputable def famB (i : Interp) : Kernel Utterance FCState :=
+  literalListener priorB fun u => (semSet i u).indicator 1
 
-/-- The asymmetric joint prior `P(w) · 1/2` (weights 12 : 1 : 1 : 1 : 1,
-halved per interpretation; total 32). -/
-noncomputable def priorB : PMF (FCState × Interp) :=
-  PMF.ofFintype (fun p => (biasedWeight p.1 : ℝ≥0∞) * 32⁻¹) (by
-    rw [← Finset.sum_mul, ← Nat.cast_sum,
-        show (∑ p : FCState × Interp, biasedWeight p.1) = 32 from by decide]
-    exact ENNReal.mul_inv_cancel (by norm_num) (by norm_num))
+/-- The pragmatic listener at the biased prior. -/
+noncomputable def listenerB (α : ℝ) : Kernel Utterance (FCState × Interp) :=
+  familyListener famB α 1 jointPriorB
 
-theorem marginalB_or_ne_zero : PMF.marginal speakerB priorB .or_ ≠ 0 :=
-  PMF.marginal_ne_zero (a := (FCState.anyNumber, Interp.exhaustified)) speakerB priorB .or_
-    (mul_ne_zero (by norm_num [biasedWeight]) (ENNReal.inv_ne_zero.mpr (by norm_num)))
-    (by rw [speakerB_or_anyNumber_exh]; exact one_ne_zero)
+theorem jointPriorB_real_singleton (p : FCState × Interp) :
+    jointPriorB.real {p} = biasedWeight p.1 := by
+  rw [measureReal_def, jointPriorB_singleton, ENNReal.toReal_natCast]
 
-/-- The pragmatic listener of the asymmetric-prior model. -/
-noncomputable abbrev listenerB (u : Utterance)
-    (h : PMF.marginal speakerB priorB u ≠ 0) : PMF (FCState × Interp) :=
-  L1 speakerB priorB u h
+/-- **Exclusivity tracks the prior** (Table 6): with 75% of the prior on Any Number, the
+listener hearing *or* ranks Any Number above every other state at every rationality —
+under the exhaustified function *or* is produced there with certainty, and no other state
+has a comparable prior. -/
+theorem anyNumber_of_prior {α : ℝ} (hα : 0 < α) (w : FCState) (hw : w ≠ .anyNumber) :
+    (listenerB α .or_).fst.real {w} < (listenerB α .or_).fst.real {.anyNumber} := by
+  have hone : RSA.speaker α 1 (famB .exhaustified) .anyNumber {.or_} = 1 :=
+    speaker_apply_singleton_eq_one (L := famB .exhaustified) (cost := 1) hα one_ne_zero
+      ENNReal.one_ne_top
+      (by
+        have hL : famB .exhaustified .or_ {.anyNumber}
+            = (priorB (semSet .exhaustified .or_))⁻¹ * priorB {.anyNumber} :=
+          literalListener_indicator_apply_singleton priorB (semSet .exhaustified)
+            (Finset.mem_coe.mpr (by decide))
+        rw [hL]
+        exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _))
+          (by rw [priorB_singleton]; simp [biasedWeight]))
+      (literalListener_indicator_apply_singleton_le_one (sem := semSet .exhaustified)
+        (u := .or_) _ (measure_ne_top _ _) (Finset.mem_coe.mpr (by decide)))
+      fun u' hu' => literalListener_indicator_apply_singleton_of_notMem
+        (sem := semSet .exhaustified) _ fun h =>
+          absurd (Finset.mem_coe.mp h) (by revert hu'; cases u' <;> decide)
+  have hu : (familySpeaker famB α 1 ∘ₘ jointPriorB) {.or_} ≠ 0 :=
+    comp_familySpeaker_ne_zero (w := .anyNumber) (l := .exhaustified)
+      (by rw [jointPriorB_singleton]; simp [biasedWeight]) (by rw [hone]; exact one_ne_zero)
+  rw [Measure.fst_real_singleton, Measure.fst_real_singleton, listenerB,
+    familyListener_real_lt_iff _ _ _ hu, Finset.sum_product, Finset.sum_product,
+    Finset.sum_singleton, Finset.sum_singleton,
+    show (Finset.univ : Finset Interp) = {.literal, .exhaustified} from by decide,
+    Finset.sum_insert (by decide), Finset.sum_singleton, Finset.sum_insert (by decide),
+    Finset.sum_singleton, jointPriorB_real_singleton, jointPriorB_real_singleton,
+    jointPriorB_real_singleton, jointPriorB_real_singleton]
+  have h1 := speaker_real_singleton_le_one α 1 (famB .literal) w .or_
+  have h2 := speaker_real_singleton_le_one α 1 (famB .exhaustified) w .or_
+  have h3 : (RSA.speaker α 1 (famB .exhaustified) .anyNumber).real {.or_} = 1 := by
+    rw [measureReal_def, hone, ENNReal.toReal_one]
+  have h4 := measureReal_nonneg (μ := RSA.speaker α 1 (famB .literal) .anyNumber) (s := {.or_})
+  have hw1 : (biasedWeight w : ℝ) = 1 := by cases w <;> simp_all [biasedWeight]
+  rw [h3, hw1]
+  simp only [biasedWeight]
+  push_cast
+  linarith
 
-/-- **Exclusivity is defeated by world knowledge** (paper §3.3, Table 6
-direction, α = 2): with 75% prior on Any Number, L1 given Or favours the
-non-EI states. The prior's 12/32 share at (Any Number, ℐ₂), where Or is
-produced with certainty, outweighs the EI event's entire 6/32 prior mass. -/
-theorem ei_defeated_by_prior :
-    (listenerB .or_ marginalB_or_ne_zero).toOuterMeasure ↑eiPairs
-      < (listenerB .or_ marginalB_or_ne_zero).toOuterMeasure ↑nonEiPairs := by
-  rw [L1_event_lt_iff]
-  have hL : (∑ p ∈ eiPairs, priorB p * speakerB p .or_) ≤ 6 * 32⁻¹ := by
-    calc ∑ p ∈ eiPairs, priorB p * speakerB p .or_
-        ≤ ∑ p ∈ eiPairs, priorB p * 1 :=
-          Finset.sum_le_sum fun p _ => mul_le_mul_right (PMF.coe_le_one _ _) _
-      _ = 6 * 32⁻¹ := by
-          simp only [mul_one, show ∀ p : FCState × Interp,
-            priorB p = (biasedWeight p.1 : ℝ≥0∞) * 32⁻¹ from fun _ => rfl]
-          rw [← Finset.sum_mul, ← Nat.cast_sum,
-              show (∑ p ∈ eiPairs, biasedWeight p.1) = 6 from by decide]
-          norm_num
-  have hR : (12 : ℝ≥0∞) * 32⁻¹ ≤ ∑ p ∈ nonEiPairs, priorB p * speakerB p .or_ := by
-    have hmem : ((.anyNumber, .exhaustified) : FCState × Interp) ∈ nonEiPairs := by
-      decide
-    calc (12 : ℝ≥0∞) * 32⁻¹
-        = priorB (.anyNumber, .exhaustified)
-            * speakerB (.anyNumber, .exhaustified) .or_ := by
-          rw [speakerB_or_anyNumber_exh, mul_one,
-              show priorB (.anyNumber, .exhaustified)
-                = (biasedWeight FCState.anyNumber : ℝ≥0∞) * 32⁻¹ from rfl]
-          norm_num [biasedWeight]
-      _ ≤ ∑ p ∈ nonEiPairs, priorB p * speakerB p .or_ :=
-          Finset.single_le_sum (f := fun p => priorB p * speakerB p .or_)
-            (fun p _ => zero_le') hmem
-  refine lt_of_le_of_lt hL (lt_of_lt_of_le ?_ hR)
-  exact (ENNReal.mul_lt_mul_iff_left (ENNReal.inv_ne_zero.mpr (by norm_num))
-    (ENNReal.inv_ne_top.mpr (by norm_num))).mpr (by norm_num)
+/-! ### No free choice under negation (§4, Table 9) -/
 
-/-! ### Without the conjunctive alternative (prose)
+/-- The states of the negation model. -/
+inductive NegState where
+  | onlyA | onlyB | onlyOne | neither
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
-The paper's Tables 7–8 show FCI is robust to dropping the conjunctive
-alternative. Table 7 removes the Only Both state along with And; in the
-Table-8 variant described here, And is replaced by a null utterance (saying
-nothing, true at every state under both interpretations) and FCI still
-arises — the null
-utterance also restores well-definedness at Only Both under ℐ₂, where no
-other utterance is true. At α = 2 the S1(Or) values of that model are
-16/57, 16/57, 8/41, 8/41, 8/41 under ℐ₁ and 25/441, 25/441, 25/41, 25/41, 0
-under ℐ₂ (states in Table-2 order), so given Or the FCI score sum 66/41
-again dominates the non-FCI sum ≈ 0.87: the avoidance mechanism between the
-bare disjuncts and Or does not depend on And. The formalisation is omitted
-for space; it instantiates the same `RSA.Canonical.powUtility` pipeline over
-the four-utterance meaning table with `.null` mapped to `fun _ => True`. -/
+instance : MeasurableSpace NegState := ⊤
+instance : DiscreteMeasurableSpace NegState := ⟨fun _ => trivial⟩
+instance : MeasurableSingletonClass NegState := DiscreteMeasurableSpace.toMeasurableSingletonClass
+
+/-- The negated utterances (10). -/
+inductive NegUtterance where
+  | notA | notB | notOr | notAnd
+  deriving DecidableEq, Repr, Inhabited, Fintype
+
+instance : MeasurableSpace NegUtterance := ⊤
+instance : DiscreteMeasurableSpace NegUtterance := ⟨fun _ => trivial⟩
+instance : MeasurableSingletonClass NegUtterance :=
+  DiscreteMeasurableSpace.toMeasurableSingletonClass
+
+/-- Interpretation function 1 under negation (11). -/
+def N1 : NegUtterance → NegState → Prop
+  | .notA, .onlyB | .notA, .neither => True
+  | .notA, _ => False
+  | .notB, .onlyA | .notB, .neither => True
+  | .notB, _ => False
+  | .notOr, .neither => True
+  | .notOr, _ => False
+  | .notAnd, _ => True
+
+/-- Interpretation function 2 under negation (12): weakened, not strengthened. -/
+def N2 : NegUtterance → NegState → Prop
+  | .notA, .onlyA => False
+  | .notA, _ => True
+  | .notB, .onlyB => False
+  | .notB, _ => True
+  | .notOr, .neither => True
+  | .notOr, _ => False
+  | .notAnd, _ => True
+
+instance : ∀ u, DecidablePred (N1 u) := fun u w => by
+  cases u <;> cases w <;> first | exact .isTrue trivial | exact .isFalse id
+
+instance : ∀ u, DecidablePred (N2 u) := fun u w => by
+  cases u <;> cases w <;> first | exact .isTrue trivial | exact .isFalse id
+
+/-- The negated meanings indexed by interpretation function. -/
+def negMeaning : Interp → NegUtterance → NegState → Prop
+  | .literal => N1
+  | .exhaustified => N2
+
+instance : ∀ i u, DecidablePred (negMeaning i u)
+  | .literal, u => inferInstanceAs (DecidablePred (N1 u))
+  | .exhaustified, u => inferInstanceAs (DecidablePred (N2 u))
+
+/-- The extensions of the negation model. -/
+def negSem (i : Interp) (u : NegUtterance) : Finset NegState :=
+  Finset.univ.filter (negMeaning i u)
+
+@[simp] theorem mem_negSem {i : Interp} {u : NegUtterance} {w : NegState} :
+    w ∈ negSem i u ↔ negMeaning i u w := by simp [negSem]
+
+/-- The negated disjunction is unambiguous: true exactly at Neither under both functions. -/
+theorem negSem_notOr : ∀ i, negSem i .notOr = {.neither} := by decide
+
+/-- The listener of the negation model. -/
+noncomputable abbrev negListener (α : ℝ) : Kernel NegUtterance (NegState × Interp) :=
+  familyListener (fun i => uniformListener (negSem i)) α 1 (uniformOn Set.univ)
+
+/-- **No free choice under negation** (Table 9): hearing *you may not take an apple or a
+pear*, the listener assigns no mass to any state other than Neither — in particular none to
+Only A and Only B, where a free-choice reading of the negated disjunction would be true. -/
+theorem no_fci_under_negation {α : ℝ} (hα : 0 < α) (p : NegState × Interp)
+    (hp : p.1 ≠ .neither) : negListener α .notOr {p} = 0 := by
+  have hu : (familySpeaker (fun i => uniformListener (negSem i)) α 1
+      ∘ₘ uniformOn (Set.univ : Set (NegState × Interp))) {NegUtterance.notOr} ≠ 0 :=
+    comp_familySpeaker_ne_zero (L := fun i => uniformListener (negSem i)) (α := α) (cost := 1)
+      (μ := uniformOn Set.univ) (w := .neither) (l := .literal) (u := .notOr)
+      (uniformOn_univ_singleton_ne_zero (NegState.neither, Interp.literal))
+      (uniformSpeaker_apply_singleton_ne_zero (negSem .literal) hα.le (t := .neither)
+        (c := .notOr) (mem_negSem.mpr trivial))
+  have hp' : p.1 ∉ negSem p.2 .notOr := by
+    rw [mem_negSem]
+    obtain ⟨w, i⟩ := p
+    cases w <;> cases i <;> first | exact absurd rfl hp | exact id
+  rw [negListener, familyListener_apply_singleton _ _ _ hu,
+    uniformSpeaker_apply_singleton_eq_zero (negSem p.2) hα hp', mul_zero, ENNReal.zero_div]
 
 end ChampollionAlsopGrosu2019


### PR DESCRIPTION
Second Canonical study onto `RSA.Basic`/`RSA.Uniform`: the paper's interpretation-function uncertainty is `familyListener` over `Interp`. New substrate for it — `posterior_real_finset_lt_iff` (event comparison for `κ†μ`), `Measure.fst/snd_real_singleton`, `Measure.sum_smul_dirac_apply_singleton`, `literalListener_indicator_apply_singleton*` (weighted priors), `speaker_apply_singleton_eq_one`, `speaker_real_singleton_le_one`, `familyListener_apply_singleton`/`_real_lt_iff`, and the family evaluation register `familyListener_uniform_real_lt_of_divPowSum` with `familyDivPowSum`.

- Table 5 free choice at α = 100 (pairwise) and the α = 2 majority as `decide +kernel` certificates; the speaker-level avoidance facts hold at every rationality.
- Table 6 prior sensitivity as a theorem on the general pipeline (prior in L0 and L1), at every rationality.
- §4 negation model: the listener assigns no mass off Neither given the negated disjunction.
- The old `ei_uniform` (an α = 2 observation the paper does not make) and the unverifiable Table-8 prose are cut.