### PR TITLE
refactor(Pragmatics/RSA): zero-mass lemmas for the family listener

### DIFF
--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -164,6 +164,20 @@ theorem speaker_real_singleton_le_one (α : ℝ) (cost : U → ℝ≥0∞) (L : 
   exact ENNReal.toReal_mono ENNReal.one_ne_top
     ((measure_mono (Set.subset_univ _)).trans (Kernel.ofWeights_apply_univ_le_one _ w))
 
+/-- With Boolean meanings, a state whose only true utterance is `u` produces `u` with
+certainty at any prior giving the state positive mass. -/
+theorem speaker_literalListener_indicator_eq_one [DiscreteMeasurableSpace W] {α : ℝ}
+    (hα : 0 < α) {cost : U → ℝ≥0∞} {u : U} (hc0 : cost u ≠ 0) (hctop : cost u ≠ ∞)
+    (μ : Measure W) [IsFiniteMeasure μ] (sem : U → Set W) {w : W} (hμ : μ {w} ≠ 0)
+    (hmem : w ∈ sem u) (hother : ∀ u' ≠ u, w ∉ sem u') :
+    speaker α cost (literalListener μ fun u => (sem u).indicator 1) w {u} = 1 :=
+  speaker_apply_singleton_eq_one hα hc0 hctop
+    (by
+      rw [literalListener_indicator_apply_singleton μ sem hmem]
+      exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _)) hμ)
+    (literalListener_indicator_apply_singleton_le_one μ sem (measure_ne_top _ _) hmem)
+    fun u' hu' => literalListener_indicator_apply_singleton_of_notMem μ sem (hother u' hu')
+
 /-! #### Pragmatic listeners -/
 
 section Listener
@@ -390,6 +404,27 @@ theorem familyListener_snd_real_lt_iff [Fintype W] (L : Λ → Kernel U W) {α :
     posterior_snd_real_lt_iff _ _ (comp_familySpeaker_ne_zero (hμ0 (w₀, l₀)) hs), key, key,
     mul_lt_mul_iff_right₀
       (show (0 : ℝ) < μ.real {p₀} from ENNReal.toReal_pos (hμ0 p₀) (measure_ne_top _ _))]
+
+/-- A pair producing the utterance with certainty outweighs any event of smaller total prior
+mass: the listener's posterior on the pair's event exceeds that event's. -/
+theorem familyListener_real_lt_of_certain (L : Λ → Kernel U W) (α : ℝ) (cost : U → ℝ≥0∞)
+    {u : U} {E₁ E₂ : Finset (W × Λ)} {p₀ : W × Λ} (hp₀ : p₀ ∈ E₂)
+    (hs : speaker α cost (L p₀.2) p₀.1 {u} = 1) (hlt : (∑ p ∈ E₁, μ.real {p}) < μ.real {p₀}) :
+    (familyListener L α cost μ u).real ↑E₁ < (familyListener L α cost μ u).real ↑E₂ := by
+  have hpos : 0 < μ.real {p₀} :=
+    (Finset.sum_nonneg fun _ _ => measureReal_nonneg).trans_lt hlt
+  rw [familyListener_real_lt_iff L α cost
+    (comp_familySpeaker_ne_zero (w := p₀.1) (l := p₀.2) (ENNReal.toReal_pos_iff.mp hpos).1.ne'
+      (hs ▸ one_ne_zero))]
+  calc ∑ p ∈ E₁, μ.real {p} * (speaker α cost (L p.2) p.1).real {u}
+      ≤ ∑ p ∈ E₁, μ.real {p} := Finset.sum_le_sum fun p _ =>
+        mul_le_of_le_one_right measureReal_nonneg (speaker_real_singleton_le_one _ _ _ _ _)
+    _ < μ.real {p₀} := hlt
+    _ = μ.real {p₀} * (speaker α cost (L p₀.2) p₀.1).real {u} := by
+        rw [measureReal_def (μ := speaker α cost (L p₀.2) p₀.1), hs, ENNReal.toReal_one, mul_one]
+    _ ≤ ∑ p ∈ E₂, μ.real {p} * (speaker α cost (L p.2) p.1).real {u} :=
+        Finset.single_le_sum (f := fun p => μ.real {p} * (speaker α cost (L p.2) p.1).real {u})
+          (fun p _ => mul_nonneg measureReal_nonneg measureReal_nonneg) hp₀
 
 end Family
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -337,6 +337,12 @@ theorem familyListener_apply_singleton (L : Λ → Kernel U W) (α : ℝ) (cost 
       = μ {p} * speaker α cost (L p.2) p.1 {u} / (familySpeaker L α cost ∘ₘ μ) {u} := by
   rw [familyListener, posterior_apply_singleton _ _ hu, familySpeaker_apply]
 
+/-- A pair at which the utterance is never produced receives no posterior mass. -/
+theorem familyListener_apply_singleton_eq_zero (L : Λ → Kernel U W) (α : ℝ) (cost : U → ℝ≥0∞)
+    {u : U} (hu : (familySpeaker L α cost ∘ₘ μ) {u} ≠ 0) {p : W × Λ}
+    (hp : speaker α cost (L p.2) p.1 {u} = 0) : familyListener L α cost μ u {p} = 0 := by
+  rw [familyListener_apply_singleton L α cost hu, hp, mul_zero, ENNReal.zero_div]
+
 /-- Event comparison for the family listener reduces to prior-weighted member speaker
 sums. -/
 theorem familyListener_real_lt_iff (L : Λ → Kernel U W) (α : ℝ) (cost : U → ℝ≥0∞) {u : U}

--- a/Linglib/Pragmatics/RSA/Uniform.lean
+++ b/Linglib/Pragmatics/RSA/Uniform.lean
@@ -415,6 +415,21 @@ theorem uniformJointListener_fst_real_lt_of_divPowSum (hsem : ∀ t, ∃ c, t �
 /-! ### Latent families at the uniform prior -/
 
 omit [Nonempty C] in
+/-- A pair whose state the utterance does not describe under its latent receives no
+posterior mass, as soon as some state is described under some latent. -/
+theorem familyListener_uniform_apply_singleton_eq_zero {Λ : Type*} [Fintype Λ]
+    [MeasurableSpace Λ] [DiscreteMeasurableSpace Λ] [Nonempty Λ] (sem : Λ → C → Finset T)
+    {α : ℝ} (hα : 0 < α) {c : C} (hc : ∃ l t, t ∈ sem l c) {p : T × Λ}
+    (hp : p.1 ∉ sem p.2 c) :
+    familyListener (fun l => uniformListener (sem l)) α 1 (uniformOn Set.univ) c {p} = 0 :=
+  let ⟨l, t, h⟩ := hc
+  familyListener_apply_singleton_eq_zero (fun l => uniformListener (sem l)) α 1
+    (comp_familySpeaker_ne_zero (L := fun l => uniformListener (sem l)) (α := α) (cost := 1)
+      (μ := uniformOn Set.univ) (w := t) (l := l) (u := c) (uniformOn_univ_singleton_ne_zero _)
+      (uniformSpeaker_apply_singleton_ne_zero (sem l) hα.le h))
+    (uniformSpeaker_apply_singleton_eq_zero (sem p.2) hα hp)
+
+omit [Nonempty C] in
 /-- The evaluation register for a latent family at a natural rationality and the uniform
 prior on (state, latent) pairs: posterior preference between two events of pairs is the
 ℕ-valued common-denominator comparison — a kernel `decide`. The strict inequality carries

--- a/Linglib/Studies/ChampollionAlsopGrosu2019.lean
+++ b/Linglib/Studies/ChampollionAlsopGrosu2019.lean
@@ -231,7 +231,10 @@ instance : IsFiniteMeasure jointPriorB :=
       exact ENNReal.natCast_lt_top _⟩
 
 /-- The extensions as sets. -/
-def semSet (i : Interp) (u : Utterance) : Set FCState := ↑(sem i u)
+def semSet (i : Interp) (u : Utterance) : Set FCState := {w | interpMeaning i u w}
+
+theorem mem_semSet {i : Interp} {u : Utterance} {w : FCState} :
+    w ∈ semSet i u ↔ interpMeaning i u w := Iff.rfl
 
 /-- The literal listeners at the biased prior (8a). -/
 noncomputable def famB (i : Interp) : Kernel Utterance FCState :=
@@ -249,44 +252,23 @@ theorem jointPriorB_real_singleton (p : FCState × Interp) :
 listener hearing *or* ranks Any Number above every other state at every rationality —
 under the exhaustified function *or* is produced there with certainty, and no other state
 has a comparable prior. -/
-theorem anyNumber_of_prior {α : ℝ} (hα : 0 < α) (w : FCState) (hw : w ≠ .anyNumber) :
+theorem anyNumber_of_prior {α : ℝ} (hα : 0 < α) {w : FCState} (hw : w ≠ .anyNumber) :
     (listenerB α .or_).fst.real {w} < (listenerB α .or_).fst.real {.anyNumber} := by
-  have hone : RSA.speaker α 1 (famB .exhaustified) .anyNumber {.or_} = 1 :=
-    speaker_apply_singleton_eq_one (L := famB .exhaustified) (cost := 1) hα one_ne_zero
-      ENNReal.one_ne_top
-      (by
-        have hL : famB .exhaustified .or_ {.anyNumber}
-            = (priorB (semSet .exhaustified .or_))⁻¹ * priorB {.anyNumber} :=
-          literalListener_indicator_apply_singleton priorB (semSet .exhaustified)
-            (Finset.mem_coe.mpr (by decide))
-        rw [hL]
-        exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _))
-          (by rw [priorB_singleton]; simp [biasedWeight]))
-      (literalListener_indicator_apply_singleton_le_one (sem := semSet .exhaustified)
-        (u := .or_) _ (measure_ne_top _ _) (Finset.mem_coe.mpr (by decide)))
-      fun u' hu' => literalListener_indicator_apply_singleton_of_notMem
-        (sem := semSet .exhaustified) _ fun h =>
-          absurd (Finset.mem_coe.mp h) (by revert hu'; cases u' <;> decide)
-  have hu : (familySpeaker famB α 1 ∘ₘ jointPriorB) {.or_} ≠ 0 :=
-    comp_familySpeaker_ne_zero (w := .anyNumber) (l := .exhaustified)
-      (by rw [jointPriorB_singleton]; simp [biasedWeight]) (by rw [hone]; exact one_ne_zero)
-  rw [Measure.fst_real_singleton, Measure.fst_real_singleton, listenerB,
-    familyListener_real_lt_iff _ _ _ hu, Finset.sum_product, Finset.sum_product,
-    Finset.sum_singleton, Finset.sum_singleton,
-    show (Finset.univ : Finset Interp) = {.literal, .exhaustified} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_singleton, Finset.sum_insert (by decide),
-    Finset.sum_singleton, jointPriorB_real_singleton, jointPriorB_real_singleton,
-    jointPriorB_real_singleton, jointPriorB_real_singleton]
-  have h1 := speaker_real_singleton_le_one α 1 (famB .literal) w .or_
-  have h2 := speaker_real_singleton_le_one α 1 (famB .exhaustified) w .or_
-  have h3 : (RSA.speaker α 1 (famB .exhaustified) .anyNumber).real {.or_} = 1 := by
-    rw [measureReal_def, hone, ENNReal.toReal_one]
-  have h4 := measureReal_nonneg (μ := RSA.speaker α 1 (famB .literal) .anyNumber) (s := {.or_})
-  have hw1 : (biasedWeight w : ℝ) = 1 := by cases w <;> simp_all [biasedWeight]
-  rw [h3, hw1]
-  simp only [biasedWeight]
-  push_cast
-  linarith
+  have hother : ∀ u' ≠ Utterance.or_, FCState.anyNumber ∉ semSet .exhaustified u' := by
+    simp only [ne_eq, mem_semSet]; decide
+  have hμ : priorB {.anyNumber} ≠ 0 := by rw [priorB_singleton]; simp [biasedWeight]
+  have hone := speaker_literalListener_indicator_eq_one (cost := 1) (u := .or_) (w := .anyNumber)
+    hα one_ne_zero ENNReal.one_ne_top priorB (semSet .exhaustified) hμ
+    ((mem_semSet (i := .exhaustified) (u := .or_) (w := .anyNumber)).mpr trivial) hother
+  have hlt : (∑ p ∈ ({w} ×ˢ Finset.univ : Finset (FCState × Interp)), jointPriorB.real {p})
+      < jointPriorB.real {(.anyNumber, .exhaustified)} := by
+    rw [Finset.sum_product, Finset.sum_singleton]
+    simp only [jointPriorB_real_singleton, Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
+      show Fintype.card Interp = 2 from rfl]
+    cases w <;> first | exact absurd rfl hw | norm_num [biasedWeight]
+  rw [Measure.fst_real_singleton, Measure.fst_real_singleton, listenerB]
+  exact familyListener_real_lt_of_certain famB α 1 (p₀ := (.anyNumber, .exhaustified))
+    (by simp) hone hlt
 
 /-! ### No free choice under negation (§4, Table 9) -/
 

--- a/Linglib/Studies/ChampollionAlsopGrosu2019.lean
+++ b/Linglib/Studies/ChampollionAlsopGrosu2019.lean
@@ -361,20 +361,9 @@ noncomputable abbrev negListener (α : ℝ) : Kernel NegUtterance (NegState × I
 /-- **No free choice under negation** (Table 9): hearing *you may not take an apple or a
 pear*, the listener assigns no mass to any state other than Neither — in particular none to
 Only A and Only B, where a free-choice reading of the negated disjunction would be true. -/
-theorem no_fci_under_negation {α : ℝ} (hα : 0 < α) (p : NegState × Interp)
-    (hp : p.1 ≠ .neither) : negListener α .notOr {p} = 0 := by
-  have hu : (familySpeaker (fun i => uniformListener (negSem i)) α 1
-      ∘ₘ uniformOn (Set.univ : Set (NegState × Interp))) {NegUtterance.notOr} ≠ 0 :=
-    comp_familySpeaker_ne_zero (L := fun i => uniformListener (negSem i)) (α := α) (cost := 1)
-      (μ := uniformOn Set.univ) (w := .neither) (l := .literal) (u := .notOr)
-      (uniformOn_univ_singleton_ne_zero (NegState.neither, Interp.literal))
-      (uniformSpeaker_apply_singleton_ne_zero (negSem .literal) hα.le (t := .neither)
-        (c := .notOr) (mem_negSem.mpr trivial))
-  have hp' : p.1 ∉ negSem p.2 .notOr := by
-    rw [mem_negSem]
-    obtain ⟨w, i⟩ := p
-    cases w <;> cases i <;> first | exact absurd rfl hp | exact id
-  rw [negListener, familyListener_apply_singleton _ _ _ hu,
-    uniformSpeaker_apply_singleton_eq_zero (negSem p.2) hα hp', mul_zero, ENNReal.zero_div]
+theorem no_fci_under_negation {α : ℝ} (hα : 0 < α) {p : NegState × Interp}
+    (hp : p.1 ≠ .neither) : negListener α .notOr {p} = 0 :=
+  familyListener_uniform_apply_singleton_eq_zero negSem hα ⟨.literal, .neither, by decide⟩
+    (by rw [negSem_notOr, Finset.mem_singleton]; exact hp)
 
 end ChampollionAlsopGrosu2019


### PR DESCRIPTION
`familyListener_apply_singleton_eq_zero` (Basic) and its uniform-model form `familyListener_uniform_apply_singleton_eq_zero` (Uniform), which derives the positivity witness from a single membership fact; `no_fci_under_negation` in ChampollionAlsopGrosu2019 shrinks to two lines on `negSem_notOr`.