### PR TITLE
feat(Studies/Anderson2021): common-ground update on the kernel pipeline

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -647,6 +647,7 @@ import Linglib.Discourse.Commitment.SourceMarked
 import Linglib.Discourse.Commitment.Space
 import Linglib.Discourse.Commitment.Table
 import Linglib.Discourse.CommonGround
+import Linglib.Discourse.CommonGround.Measure
 import Linglib.Discourse.Gameboard.Basic
 import Linglib.Discourse.Gameboard.Defs
 import Linglib.Discourse.Gameboard.RepriseContent

--- a/Linglib/Core/Probability/Kernel/Posterior.lean
+++ b/Linglib/Core/Probability/Kernel/Posterior.lean
@@ -56,6 +56,12 @@ theorem posterior_apply_singleton {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (ω
   rw [hrect]
   ring
 
+/-- Two states with the same likelihood of the observation and the same prior mass have the
+same posterior mass. -/
+theorem posterior_apply_singleton_congr {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) {ω₁ ω₂ : Ω}
+    (hrow : κ ω₁ {x} = κ ω₂ {x}) (hμ : μ {ω₁} = μ {ω₂}) : (κ†μ) x {ω₁} = (κ†μ) x {ω₂} := by
+  rw [posterior_apply_singleton κ μ hx, posterior_apply_singleton κ μ hx, hrow, hμ]
+
 /-- Comparing posterior masses of finite events reduces to comparing prior-weighted
 likelihood sums; the observation marginal cancels. -/
 theorem posterior_real_finset_lt_iff {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (E₁ E₂ : Finset Ω) :

--- a/Linglib/Discourse/Commitment/Basic.lean
+++ b/Linglib/Discourse/Commitment/Basic.lean
@@ -192,8 +192,8 @@ instance : CommitmentGrade Prop where
   complement := Not
 
 -- No `Bool` instance by default — consumers needing decidable grades
--- declare locally. Anderson 2021's distributional CommonGround is a genuine
--- distribution (`PMF W`, in `Studies/Anderson2021.lean`), not a graded
+-- declare locally. Anderson 2021's distributional common ground is a genuine
+-- measure (`Measure W`, in `Studies/Anderson2021.lean`), not a graded
 -- commitment, so it does not instantiate this hierarchy.
 
 /-! ### Speaker-Indexed Commitments -/

--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -54,7 +54,7 @@ Out of scope (would need substrate extensions):
   substrate has no time index; `rejectFirst` is the closest proxy for
   rescission. True time-indexed commitment dynamics need a separate layer.
 - **Anderson 2021 distributional CommonGround**: a probability distribution
-  over worlds, hosted as `PMF W` in `Studies/Anderson2021.lean`. It is
+  over worlds, hosted as `Measure W` in `Studies/Anderson2021.lean`. It is
   *not* routed through the commitment-space substrate: a `CommitmentSpace W ℝ`
   would carry unconstrained per-world reals (no sum-to-one, no normalisation),
   losing exactly the structure Anderson's entropy/KL criteria depend on. The

--- a/Linglib/Discourse/CommonGround/Measure.lean
+++ b/Linglib/Discourse/CommonGround/Measure.lean
@@ -1,0 +1,35 @@
+import Linglib.Discourse.CommonGround
+import Mathlib.MeasureTheory.Measure.MeasureSpaceDef
+
+/-!
+# The common ground of a measure
+
+This file makes a measure over worlds a discourse state: its common ground is its
+almost-everywhere filter — what holds almost surely is mutually accepted — and its context
+set is the set of positive-mass worlds. A graded common ground of this kind is
+[anderson-2021]'s, updated by mixture rather than by intersection.
+
+## Main results
+
+* `HasCommonGround.contextSet_measure`: the context set of `μ` is `{w | μ {w} ≠ 0}`.
+
+## References
+
+* [stalnaker-2002] — the context set
+* [anderson-2021] — the common ground as a distribution over worlds
+-/
+
+open MeasureTheory
+
+variable {W : Type*} [MeasurableSpace W]
+
+instance : HasCommonGround (Measure W) W := ⟨ae⟩
+
+@[simp] theorem HasCommonGround.commonGround_measure (μ : Measure W) : commonGround μ = ae μ :=
+  rfl
+
+theorem HasCommonGround.contextSet_measure (μ : Measure W) : contextSet μ = {w | μ {w} ≠ 0} := by
+  ext w
+  simp only [contextSet, commonGround_measure, Filter.mem_ker, mem_ae_iff, Set.mem_ofPred_eq]
+  exact ⟨fun h h0 => h {w}ᶜ (by rwa [compl_compl]) rfl, fun h s hs => by_contra fun hw =>
+    h (measure_mono_null (Set.singleton_subset_iff.mpr hw) hs)⟩

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -178,6 +178,18 @@ theorem speaker_literalListener_indicator_eq_one [DiscreteMeasurableSpace W] {α
     (literalListener_indicator_apply_singleton_le_one μ sem (measure_ne_top _ _) hmem)
     fun u' hu' => literalListener_indicator_apply_singleton_of_notMem μ sem (hother u' hu')
 
+/-- Row-preference of the speaker reduces to comparing the weighted listener values; the
+normalization cancels. -/
+theorem speaker_real_singleton_lt_iff {α : ℝ} (hα : 0 ≤ α) {cost : U → ℝ≥0∞}
+    (hctop : ∀ u, cost u ≠ ∞) {L : Kernel U W} {w : W} (hle : ∀ u, L u {w} ≤ 1)
+    (h0 : ∃ u, L u {w} ^ α * cost u ≠ 0) {u u' : U} :
+    (speaker α cost L w).real {u} < (speaker α cost L w).real {u'} ↔
+      L u {w} ^ α * cost u < L u' {w} ^ α * cost u' :=
+  Kernel.ofWeights_real_singleton_lt_iff w
+    (fun h => let ⟨u₀, hu₀⟩ := h0; hu₀ (Finset.sum_eq_zero_iff.mp h u₀ (Finset.mem_univ _)))
+    (ENNReal.sum_ne_top.mpr fun u _ =>
+      ENNReal.mul_ne_top (weight_rpow_ne_top hα (hle u)) (hctop u))
+
 /-! #### Pragmatic listeners -/
 
 section Listener
@@ -187,6 +199,9 @@ variable [StandardBorelSpace W] [Nonempty W] (α : ℝ) (cost : U → ℝ≥0∞
 
 /-- The pragmatic listener (eq. 3): the Bayesian inverse of the speaker against the prior. -/
 noncomputable def pragmaticListener : Kernel U W := (speaker α cost L)†μ
+
+instance : IsMarkovKernel (pragmaticListener α cost L μ) :=
+  inferInstanceAs (IsMarkovKernel ((speaker α cost L)†μ))
 
 variable [DiscreteMeasurableSpace U] [StandardBorelSpace U] [Nonempty U] [DecidableEq O]
   (obs : U → O)

--- a/Linglib/Pragmatics/RSA/Uniform.lean
+++ b/Linglib/Pragmatics/RSA/Uniform.lean
@@ -120,6 +120,14 @@ theorem sum_rpow_uniformListener {α : ℝ} (hα : 0 < α) (t : T) :
   rw [profile, Multiset.invPowSum, Multiset.map_map]
   rfl
 
+/-- The speaker share of a true choice depends on the state only through its profile. -/
+theorem uniformSpeaker_apply_singleton_of_profile_eq {α : ℝ} (hα : 0 < α) {t t' : T}
+    (hprof : profile sem t = profile sem t') {c : C} (hmem : t ∈ sem c) (hmem' : t' ∈ sem c) :
+    uniformSpeaker sem α t {c} = uniformSpeaker sem α t' {c} := by
+  rw [uniformSpeaker_apply_singleton, uniformSpeaker_apply_singleton,
+    sum_rpow_uniformListener sem hα, sum_rpow_uniformListener sem hα, hprof,
+    uniformListener_apply_singleton, uniformListener_apply_singleton, if_pos hmem, if_pos hmem']
+
 theorem sum_fiber_rpow_uniformListener {α : ℝ} (hα : 0 < α) (o : O) (t : T) :
     ∑ c ∈ Finset.univ.filter (obs · = o), uniformListener sem c {t} ^ α
       = (fiberProfile sem obs o t).invPowSum α := by

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -1,768 +1,476 @@
-import Linglib.Core.Learning.Luce
-import Linglib.Core.Probability.Constructions
-import Linglib.Core.Probability.Entropy
-import Linglib.Core.Probability.Scores
-import Linglib.Discourse.CommonGround
+import Linglib.Pragmatics.RSA.Uniform
+import Linglib.Discourse.CommonGround.Measure
 
 /-!
-# [anderson-2021]: conversation update for RSA
-[luce-1959] [stalnaker-2002] [frank-goodman-2012]
+# Anderson 2021: conversation update for the Rational Speech Acts framework
 
-Tell me everything you know (SCiL 2021, 244–253): multi-turn conversation
-in RSA. The common ground is a probability distribution over worlds
-substituted for the RSA world prior (Figure 4), updated each turn by
-convex combination with the pragmatic-listener posterior at a learning
-rate, with weighted, thresholded, and difference sampling for cooperative
-observation selection.
+A single RSA turn leaves no trace. Anderson makes the common ground a distribution over
+worlds, substitutes it for the world prior of every agent in the chain (Figure 4: the literal
+listener conditions the common ground on the utterance, the pragmatic listener inverts the
+speaker against it), and after each turn increments it with the pragmatic listener's
+posterior, discounted by a learning rate. Worlds can then regain probability — the update is
+a mixture, not an intersection, and intersection is the learning-rate-one limit — and a
+speaker whose literal listener reads the common ground prefers what is new to what is
+already established. Observations are sampled from the speaker's private beliefs: by weight,
+above a confidence threshold (a speaker with nothing to say passes with the null utterance),
+or by their positive difference from the common ground.
 
-## Main results
+`L0`, `S1`, `L1` are the Figure-4 agents at a common ground `cg`, `updateCG` the mixture
+update, `step` a Figure-2 turn. On the MutualFriends worlds of Figure 3,
+`s1_turn1_informativity` and `l1_turn1_inferences` are the first turn at the empty common
+ground; `cg₂` is the common ground after *they study a humanity*; `s1_prefers_new` is the
+redundancy aversion of the next speaker at any common ground of that shape, and
+`turn2_breaks_symmetry` the prediction that *they like being outdoors*, which left Nancy and
+Katie tied at the first turn, now favours Nancy. `notMem_contextSet_updateCG_one` and
+`mem_contextSet_updateCG` locate the classical intersection update.
 
-* `updateCG_matches_linear_learning`: the update rule is [luce-1959]'s
-  linear learning rule — multi-turn conversation is iterated learning
-  over distributions.
-* `lr_one_excludes_false_worlds` / `graded_update_keeps_false_world`:
-  set-intersection update is the lr = 1 degenerate limit; the graded
-  common ground is non-monotonic by design (fn. 7).
-* Turn-1 and turn-2 predictions over the MutualFriends worlds
-  (individuals typed by major × location), including
-  `turn2_breaks_symmetry`: an updated common ground changes what the
-  same utterance conveys.
-* `toBToMSharedUpdate`: `Shared := PMF W` instantiates
-  `BToMModel.sharedUpdate` — BToM discourse dynamics with a
-  distributional shared state.
+## References
 
-## Implementation notes
-
-The Figure-4 chain is exact ℚ≥0, parameterized by common-ground weights:
-each agent (`l0Score`/`s1Score`/`l1Score`/`s2Score`) is one
-`PMF.normalizeScores` application over the agent below it, the
-distributions are `PMF.ofScores`, and every prediction closes by the
-`ofScores` comparison family with one kernel certificate.
+* [anderson-2021]
+* [frank-goodman-2012] — the RSA chain
+* [stalnaker-2002] — the common ground and its context set
 -/
-/-! ### Distributional common ground
-
-`PMF W` wraps `PMF W`: [stalnaker-2002]'s context set with
-graded plausibility summing to one (§3.2), so entropy — Anderson's
-success criterion — and KL divergence are available on the carrier.
-`toContextSet` projects to the positive-mass worlds (`PMF.support`),
-`PMF.uniformOfFintype` is the empty common ground; `ofWeights` renormalizes
-non-negative weights (fn. 3). Unlike the classical context set, worlds
-can regain probability (fn. 7); intersection update survives only at
-lr = 1. -/
-namespace Discourse
-
-
-variable {W : Type*}
-
-/-! ### The common ground as a distribution
-
-Anderson's distributional common ground *is* a `PMF W` ([anderson-2021]
-§3.2): graded plausibility summing to one, with `PMF.entropy` — the
-success criterion — and `PMF.toRealFn` (the ℝ-valued masses every RSA
-consumer reads) already on the carrier. The classical context set is the
-support. -/
-
-/-- A distribution's common ground is principal on [stalnaker-2002]'s context
-    set, the positive-mass worlds (the a.e. filter of the induced measure). -/
-instance : HasCommonGround (PMF W) W := ⟨fun p => Filter.principal {w | w ∈ p.support}⟩
-
-@[simp] theorem pmf_contextSet (p : PMF W) (w : W) :
-    w ∈ HasCommonGround.contextSet p ↔ 0 < p.toRealFn w := by
-  show w ∈ Filter.ker (Filter.principal {w | w ∈ p.support}) ↔ _
-  rw [Filter.ker_principal]
-  exact (PMF.mem_support_iff p w).trans
-    ⟨fun h => ENNReal.toReal_pos h (p.apply_ne_top w),
-     fun h => pos_iff_ne_zero.mp (ENNReal.toReal_pos_iff.mp h).1⟩
-
-end Discourse
 
 namespace Anderson2021
 
-open scoped ENNReal NNReal NNRat
+open MeasureTheory ProbabilityTheory RSA
+open scoped ENNReal NNReal
 
-/-! ### MutualFriends Domain -/
+/-! ### Updating the common ground -/
 
-/-- Worlds in the MutualFriends domain: four individuals with different
-feature combinations. -/
-inductive MFWorld where
-  | ina    -- Astronomy, Indoors
-  | katie  -- Astronomy, Outdoors
-  | nancy  -- German, Outdoors
-  | sally  -- German, Indoors
-  deriving DecidableEq, Repr, Inhabited
+section Update
 
-instance : Fintype MFWorld where
-  elems := {.ina, .katie, .nancy, .sally}
-  complete x := by cases x <;> simp
+variable {W : Type*} [MeasurableSpace W]
 
-theorem card_mfworld : Fintype.card MFWorld = 4 := by decide
+/-- §6: the common ground incremented by the pragmatic listener's posterior, discounted by the
+learning rate `lr` — the convex mixture of the two. -/
+noncomputable def updateCG (cg post : Measure W) (lr : ℝ≥0) : Measure W :=
+  (1 - lr) • cg + lr • post
 
-inductive Major where | astronomy | german
-  deriving DecidableEq, Repr
+instance (cg post : Measure W) [IsFiniteMeasure cg] [IsFiniteMeasure post] (lr : ℝ≥0) :
+    IsFiniteMeasure (updateCG cg post lr) :=
+  inferInstanceAs (IsFiniteMeasure ((1 - lr) • cg + lr • post))
 
-inductive Location where | indoors | outdoors
-  deriving DecidableEq, Repr
+theorem updateCG_apply (cg post : Measure W) (lr : ℝ≥0) (s : Set W) :
+    updateCG cg post lr s = ((1 - lr : ℝ≥0) : ℝ≥0∞) * cg s + (lr : ℝ≥0∞) * post s := by
+  rw [updateCG, Measure.add_apply, Measure.smul_apply, Measure.smul_apply, ENNReal.smul_def,
+    ENNReal.smul_def, smul_eq_mul, smul_eq_mul]
 
-def worldMajor : MFWorld → Major
+theorem updateCG_zero (cg post : Measure W) : updateCG cg post 0 = cg := by
+  rw [updateCG, tsub_zero, one_smul, zero_smul, add_zero]
+
+theorem updateCG_one (cg post : Measure W) : updateCG cg post 1 = post := by
+  rw [updateCG, tsub_self, zero_smul, one_smul, zero_add]
+
+/-- At learning rate one the update is Stalnakerian intersection: a world the posterior rules
+out leaves the context set. -/
+theorem notMem_contextSet_updateCG_one (cg post : Measure W) {w : W} (h : post {w} = 0) :
+    w ∉ HasCommonGround.contextSet (updateCG cg post 1) := by
+  rw [updateCG_one, HasCommonGround.contextSet_measure]
+  exact fun hw => hw h
+
+/-- Footnote 7: below learning rate one the prior keeps every world it supports, so a world the
+posterior rules out can regain probability. -/
+theorem mem_contextSet_updateCG (cg post : Measure W) {lr : ℝ≥0} (hlr : lr < 1) {w : W}
+    (hcg : cg {w} ≠ 0) : w ∈ HasCommonGround.contextSet (updateCG cg post lr) := by
+  rw [HasCommonGround.contextSet_measure]
+  show updateCG cg post lr {w} ≠ 0
+  rw [updateCG_apply]
+  exact fun h => hcg ((mul_eq_zero.mp (add_eq_zero.mp h).1).resolve_left
+    (ENNReal.coe_ne_zero.mpr (tsub_pos_of_lt hlr).ne'))
+
+/-! ### Selecting observations (§7) -/
+
+/-- Weighted sampling: a world's weight is its probability under the speaker's beliefs. -/
+noncomputable def weightedSample (bel : Measure W) (w : W) : ℝ := bel.real {w}
+
+/-- Thresholded sampling: worlds below the confidence threshold are dropped. -/
+noncomputable def thresholdedSample (bel : Measure W) (θ : ℝ) (w : W) : ℝ :=
+  if θ ≤ bel.real {w} then bel.real {w} else 0
+
+/-- Difference-based sampling: a world's weight is its positive gain over the common ground
+(footnote 14: reductions are not assertable). -/
+noncomputable def differenceSample (bel cg : Measure W) (w : W) : ℝ :=
+  max 0 (bel.real {w} - cg.real {w})
+
+/-- A speaker with uniform beliefs weights every world alike — the noncommittal speaker of
+Figure 12. -/
+theorem weightedSample_uniformOn [Fintype W] [MeasurableSingletonClass W] (w w' : W) :
+    weightedSample (uniformOn Set.univ) w = weightedSample (uniformOn Set.univ) w' := by
+  simp [weightedSample, uniformOn_univ_real_singleton]
+
+/-- A threshold above one drops every world: the speaker passes (Figure 13). -/
+theorem thresholdedSample_eq_zero (bel : Measure W) [IsProbabilityMeasure bel] {θ : ℝ}
+    (hθ : 1 < θ) (w : W) : thresholdedSample bel θ w = 0 :=
+  if_neg (not_le.mpr (lt_of_le_of_lt measureReal_le_one hθ))
+
+/-- Beliefs already in the common ground contribute nothing (Figure 14). -/
+theorem differenceSample_self (cg : Measure W) (w : W) : differenceSample cg cg w = 0 := by
+  simp [differenceSample]
+
+theorem differenceSample_pos {bel cg : Measure W} {w : W} (h : cg.real {w} < bel.real {w}) :
+    0 < differenceSample bel cg w :=
+  lt_max_of_lt_right (sub_pos.2 h)
+
+end Update
+
+/-! ### The MutualFriends worlds -/
+
+/-- The four individuals of Figure 3. -/
+inductive World
+  | ina
+  | katie
+  | nancy
+  | sally
+  deriving DecidableEq, Fintype
+
+instance : MeasurableSpace World := ⊤
+instance : DiscreteMeasurableSpace World := ⟨fun _ => trivial⟩
+instance : Nonempty World := ⟨.ina⟩
+
+inductive Major
+  | astronomy
+  | german
+  deriving DecidableEq
+
+inductive Location
+  | indoors
+  | outdoors
+  deriving DecidableEq
+
+def World.major : World → Major
   | .ina | .katie => .astronomy
   | .nancy | .sally => .german
 
-def worldLocation : MFWorld → Location
+def World.location : World → Location
   | .ina | .sally => .indoors
   | .katie | .nancy => .outdoors
 
-/-- Utterances available to speakers. Includes a null utterance for
-passing when the speaker has no confident observation to share. -/
-inductive MFUtterance where
-  | studyHumanity   -- "They study a humanity"
-  | studyScience    -- "They study a science"
-  | likeIndoors     -- "They like being indoors"
-  | likeOutdoors    -- "They like being outdoors"
-  | null            -- Speaker passes
-  deriving DecidableEq, Repr, Inhabited
+/-- The utterances of Figure 5, plus the null utterance of §7.1.1. -/
+inductive Utterance
+  | studyHumanity
+  | studyScience
+  | likeIndoors
+  | likeOutdoors
+  | null
+  deriving DecidableEq, Fintype
 
-instance : Fintype MFUtterance where
-  elems := {.studyHumanity, .studyScience, .likeIndoors, .likeOutdoors, .null}
-  complete x := by cases x <;> simp
+instance : MeasurableSpace Utterance := ⊤
+instance : DiscreteMeasurableSpace Utterance := ⟨fun _ => trivial⟩
 
-/-- Truth-conditional semantics for MutualFriends utterances. -/
-def mfMeaning : MFUtterance → MFWorld → Bool
-  | .studyHumanity, w => worldMajor w == .german
-  | .studyScience, w => worldMajor w == .astronomy
-  | .likeIndoors, w => worldLocation w == .indoors
-  | .likeOutdoors, w => worldLocation w == .outdoors
-  | .null, _ => true
+def Utterance.holds : Utterance → World → Prop
+  | .studyHumanity, w => w.major = .german
+  | .studyScience, w => w.major = .astronomy
+  | .likeIndoors, w => w.location = .indoors
+  | .likeOutdoors, w => w.location = .outdoors
+  | .null, _ => True
 
-example : mfMeaning .studyHumanity .nancy = true := rfl
-example : mfMeaning .studyScience .nancy = false := rfl
-example : mfMeaning .likeOutdoors .katie = true := rfl
-example : mfMeaning .null .ina = true := rfl
+instance (u : Utterance) : DecidablePred u.holds := fun _ => by
+  cases u <;> unfold Utterance.holds <;> infer_instance
 
-/-- Each non-null utterance partitions the world space in half. -/
-theorem studyHumanity_partition :
-    (mfMeaning .studyHumanity .nancy = true) ∧
-    (mfMeaning .studyHumanity .sally = true) ∧
-    (mfMeaning .studyHumanity .ina = false) ∧
-    (mfMeaning .studyHumanity .katie = false) := ⟨rfl, rfl, rfl, rfl⟩
+/-- The extension of each utterance. -/
+def sem (u : Utterance) : Finset World := Finset.univ.filter u.holds
 
-/-! ### Distributional Common Ground (re-exported from substrate) -/
+/-- The extension as a set. -/
+abbrev semSet (u : Utterance) : Set World := ↑(sem u)
 
-/-! The `PMF` substrate above supplies the weights; the
-conversation-update and RSA content below consume them. -/
+/-! ### The Figure-4 agents at a common ground -/
 
-/-! ### CommonGround Update -/
+/-- The literal listener conditions the common ground on the utterance. -/
+noncomputable abbrev L0 (cg : Measure World) : Kernel Utterance World :=
+  literalListener cg fun u => (semSet u).indicator 1
 
-/-- Common-ground update ([anderson-2021] §6, Figure 2): the `lr`-mixture
-of the current common ground with the pragmatic-listener posterior —
-`PMF.mix` at the learning rate. -/
-noncomputable def updateCG {W : Type*} (cg post : PMF W)
-    (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) : PMF W :=
-  PMF.mix ⟨lr, hlr⟩ (by exact_mod_cast hlr1) cg post
+/-- The pragmatic speaker, without softmax terms or costs (footnote 3). -/
+noncomputable abbrev S1 (cg : Measure World) : Kernel World Utterance := speaker 1 1 (L0 cg)
 
-/-- The update in ℝ: `(1 − lr)·CG + lr·posterior`, no rescaling needed. -/
-theorem updateCG_eq {W : Type*} (cg post : PMF W)
-    (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG cg post lr h0 h1).toRealFn w =
-    (1 - lr) * cg.toRealFn w + lr * post.toRealFn w :=
-  PMF.toRealFn_mix _ _ cg post w
+/-- The pragmatic listener inverts the speaker against the common ground. -/
+noncomputable abbrev L1 (cg : Measure World) [IsFiniteMeasure cg] : Kernel Utterance World :=
+  pragmaticListener 1 1 (L0 cg) cg
 
-/-- **Bridge to [luce-1959] linear learning**: the CommonGround update has the same
-algebraic form as `LinearLearner.update` with retention rate `1 - lr` and
-reinforcement target `posterior`:
+/-- One Figure-2 turn: the listener's posterior is mixed into the common ground unless the
+speaker passed (§7.1.1). -/
+noncomputable def step (cg : Measure World) [IsFiniteMeasure cg] (u : Utterance) (lr : ℝ≥0) :
+    Measure World :=
+  if u = .null then cg else updateCG cg (L1 cg u) lr
 
-    CommonGround'(w) = (1 - lr) · CommonGround(w) + lr · posterior(w)     [Anderson]
-    v'(a)  = α · v(a) + (1 - α) · r(a)                [Luce §4.C]
+section Agents
 
-Setting `α = 1 - lr` and `r = posterior` makes the formulas identical.
-Multi-turn conversation IS iterated learning over distributions. -/
-theorem updateCG_matches_linear_learning {W : Type*}
-    (cg post : PMF W)
-    (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG cg post lr h0 h1).toRealFn w =
-    ((1 - lr) * cg.toRealFn w + (1 - (1 - lr)) * post.toRealFn w : ℝ) := by
-  rw [updateCG_eq]; ring
+variable (cg : Measure World) [IsFiniteMeasure cg]
 
-/-- With learning rate 0, the CommonGround is unchanged (full retention). -/
-theorem updateCG_lr_zero {W : Type*} (cg post : PMF W)
-    (w : W) :
-    (updateCG cg post 0 (le_refl 0) zero_le_one).toRealFn w = cg.toRealFn w := by
-  rw [updateCG_eq]; ring
+theorem L0_apply_singleton_le_one (u : Utterance) (w : World) : L0 cg u {w} ≤ 1 := by
+  by_cases h : w ∈ sem u
+  · exact literalListener_indicator_apply_singleton_le_one cg semSet (measure_ne_top _ _)
+      (Finset.mem_coe.mpr h)
+  · rw [literalListener_indicator_apply_singleton_of_notMem cg semSet (Finset.mem_coe.not.mpr h)]
+    exact zero_le_one
 
-/-- With learning rate 1, the CommonGround is replaced by the posterior. -/
-theorem updateCG_lr_one {W : Type*} (cg post : PMF W)
-    (w : W) :
-    (updateCG cg post 1 zero_le_one (le_refl 1)).toRealFn w = post.toRealFn w := by
-  rw [updateCG_eq]; ring
+theorem L0_apply_singleton_ne_top (u : Utterance) (w : World) : L0 cg u {w} ≠ ∞ :=
+  ne_top_of_le_ne_top ENNReal.one_ne_top (L0_apply_singleton_le_one cg u w)
 
-/-! ### Conversation State -/
+variable {cg}
 
-/-- The state of a two-participant conversation (Figure 2).
+theorem L0_apply_singleton_ne_zero {u : Utterance} {w : World} (hw : w ∈ sem u)
+    (hcg : cg {w} ≠ 0) : L0 cg u {w} ≠ 0 := by
+  rw [literalListener_indicator_apply_singleton cg semSet (Finset.mem_coe.mpr hw)]
+  exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _)) hcg
 
-Tracks the common ground (distributional), each participant's private
-beliefs, and the learning rate for updates. In the **shared CommonGround** model
-(§5.1, Figure 4), both participants access the same `cg`. In the
-**approximate CommonGround** model (§5.2, Figure 6), each maintains a separate
-approximation (not yet formalized).
+theorem S1_apply_singleton_ne_zero {u : Utterance} {w : World} (hw : w ∈ sem u)
+    (hcg : cg {w} ≠ 0) : S1 cg w {u} ≠ 0 :=
+  speaker_apply_singleton_ne_zero zero_le_one (fun _ => one_ne_zero)
+    (fun _ => ENNReal.one_ne_top) (fun u' => L0_apply_singleton_le_one cg u' w)
+    (L0_apply_singleton_ne_zero hw hcg)
 
-The distributional CommonGround enters the RSA model at two points
-(Figure 4): inside the literal listener and as the pragmatic listener's
-prior. At each turn the chain is rebuilt at the current CommonGround
-(`conversationStep`). -/
-structure ConversationState (W : Type*) where
-  cg : PMF W
-  belA : PMF W
-  belB : PMF W
-  lr : ℝ
-  speakerIsA : Bool
+theorem comp_S1_ne_zero {u : Utterance} {w : World} (hw : w ∈ sem u) (hcg : cg {w} ≠ 0) :
+    (S1 cg ∘ₘ cg) {u} ≠ 0 :=
+  comp_apply_singleton_ne_zero _ _ hcg (S1_apply_singleton_ne_zero hw hcg)
 
-/-- Initial conversation state: uniform CommonGround, specified beliefs, A speaks first. -/
-noncomputable def ConversationState.initial {W : Type*} [Fintype W] [Nonempty W]
-    (belA belB : PMF W) (lr : ℝ) : ConversationState W where
-  cg := PMF.uniformOfFintype W
-  belA := belA
-  belB := belB
-  lr := lr
-  speakerIsA := true
+/-- A world the utterance rules out gets no listener mass. -/
+theorem L1_apply_singleton_eq_zero {u : Utterance} {w : World} (hw : w ∉ sem u)
+    (hx : (S1 cg ∘ₘ cg) {u} ≠ 0) : L1 cg u {w} = 0 := by
+  show ((S1 cg)†cg) u {w} = 0
+  rw [posterior_apply_singleton _ _ hx, speaker_apply_singleton_eq_zero one_pos
+    (literalListener_indicator_apply_singleton_of_notMem cg semSet (Finset.mem_coe.not.mpr hw))]
+  simp
 
-/-! ### Observation Sampling -/
+/-- A world the utterance allows, with positive prior mass, keeps positive listener mass. -/
+theorem L1_apply_singleton_ne_zero {u : Utterance} {w : World} (hw : w ∈ sem u)
+    (hcg : cg {w} ≠ 0) : L1 cg u {w} ≠ 0 := by
+  show ((S1 cg)†cg) u {w} ≠ 0
+  rw [posterior_apply_singleton _ _ (comp_S1_ne_zero hw hcg)]
+  exact fun h => (ENNReal.div_eq_zero_iff.mp h).elim
+    (mul_ne_zero hcg (S1_apply_singleton_ne_zero hw hcg)) (measure_ne_top _ _)
 
-/-- Weighted sampling (§7.1): a world sampled in proportion to the
-speaker's belief — truthful (zero-probability worlds never sampled) but
-flip-flop-prone for noncommittal speakers (Figure 12). -/
-noncomputable def weightedSample {W : Type*} (bel : PMF W) : W → ℝ :=
-  bel.toRealFn
+/-- The speaker's real share of an utterance, as a ratio of literal-listener values. -/
+theorem S1_real_singleton (w : World) (u : Utterance) :
+    (S1 cg w).real {u} = (L0 cg u {w}).toReal / ∑ u', (L0 cg u' {w}).toReal := by
+  rw [measureReal_def, speaker_apply_singleton]
+  simp only [ENNReal.rpow_one, Pi.one_apply, mul_one]
+  rw [ENNReal.toReal_div, ENNReal.toReal_sum fun u' _ => L0_apply_singleton_ne_top cg u' w]
 
-/-- Thresholded sampling (§7.1.1): worlds below the confidence threshold
-are filtered out; with none left the speaker passes with the null
-utterance and "all updates are skipped" (Figure 13). -/
-noncomputable def thresholdedSample {W : Type*}
-    (bel : PMF W) (θ : ℝ) : W → ℝ :=
-  λ w => if bel.toRealFn w ≥ θ then bel.toRealFn w else 0
+theorem L0_toReal {u : Utterance} {w : World} (hw : w ∈ sem u) :
+    (L0 cg u {w}).toReal = cg.real {w} / ∑ x ∈ sem u, cg.real {x} := by
+  rw [literalListener_indicator_apply_singleton cg semSet (Finset.mem_coe.mpr hw),
+    ENNReal.toReal_mul,
+    ENNReal.toReal_inv, sum_measureReal_singleton, measureReal_def, measureReal_def,
+    inv_mul_eq_div]
 
-/-- Difference-based sampling (§7.2.1): worlds weighted by "the largest
-(positive) difference in probability between the speaker's beliefs and
-the Common Ground" — the paper's own truncation at zero (its fn. 14:
-probability *reductions* are also informative but assertions can't convey
-them). Non-redundancy as Gricean Quantity. -/
-noncomputable def differenceSample {W : Type*}
-    (bel cg : PMF W) : W → ℝ :=
-  λ w => max 0 (bel.toRealFn w - cg.toRealFn w)
+omit [IsFiniteMeasure cg] in
+theorem L0_toReal_of_notMem {u : Utterance} {w : World} (hw : w ∉ sem u) :
+    (L0 cg u {w}).toReal = 0 := by
+  rw [literalListener_indicator_apply_singleton_of_notMem cg semSet (Finset.mem_coe.not.mpr hw),
+    ENNReal.toReal_zero]
 
-theorem differenceSample_nonneg {W : Type*}
-    (bel cg : PMF W) (w : W) :
-    0 ≤ differenceSample bel cg w :=
-  le_max_left 0 _
+end Agents
 
-/-! ### BToM Shared-State Update -/
+/-! ### The first turn -/
 
-/-- Linglib bridge (not in the paper): the common-ground update has the
-type `BToMModel.sharedUpdate` expects (`Shared → Action → World → Shared`
-at `Shared := PMF W`), instantiating BToM's discourse dynamics with a
-distributional shared state. The `World` argument is unused — the update
-reads the utterance-derived posterior, never the true world. -/
-noncomputable def toBToMSharedUpdate {W U : Type*} [Fintype W]
-    (posteriorFn : U → PMF W)
-    (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
-    PMF W → U → W → PMF W :=
-  fun cg u _w => updateCG cg (posteriorFn u) lr hlr hlr1
+/-- The empty common ground (Figure 2). -/
+noncomputable abbrev cg₁ : Measure World := uniformOn Set.univ
 
-/-! ### The Figure-5 beliefs
-
-The §5.1.1 scenario — A thinks the person is Nancy, B thinks Katie — is
-qualitative in the paper; the 3:1 peak (renormalised to ½ there, 1/6
-elsewhere) is this file's illustrative instantiation. -/
-
-private theorem mfWorld_sum_peak (peak : ℝ) (p : MFWorld) :
-    (∑ x : MFWorld, if x = p then peak else 1) = peak + 3 := by
-  rw [show (Finset.univ : Finset MFWorld) = {.ina, .katie, .nancy, .sally} from rfl]
-  cases p <;>
-    simp [Finset.sum_insert, Finset.mem_insert] <;> ring
-
-/-- Beliefs peaked on one world: illustrative 3:1 weights, renormalised. -/
-noncomputable def peakedBeliefs (p : MFWorld) : PMF MFWorld :=
-  PMF.ofRealWeightFn (fun w => if w = p then 3 else 1)
-    (fun w => by split <;> norm_num)
-    (by rw [mfWorld_sum_peak]; norm_num)
-
-/-- A believes Nancy; B believes Katie (Figure 5). -/
-noncomputable def beliefsA : PMF MFWorld := peakedBeliefs .nancy
-
-/-- See `beliefsA`. -/
-noncomputable def beliefsB : PMF MFWorld := peakedBeliefs .katie
-
-theorem peakedBeliefs_weight (p w : MFWorld) :
-    (peakedBeliefs p).toRealFn w = (if w = p then 3 else 1) / 6 := by
-  rw [peakedBeliefs, PMF.ofRealWeightFn_toRealFn_apply, mfWorld_sum_peak]; norm_num
-
-/-- Peaked beliefs favor their peak over every other world. -/
-theorem peakedBeliefs_favors (p w : MFWorld) (hw : w ≠ p) :
-    (peakedBeliefs p).toRealFn w < (peakedBeliefs p).toRealFn p := by
-  rw [peakedBeliefs_weight, peakedBeliefs_weight, if_neg hw, if_pos rfl]; norm_num
-
-/-! ### The Figure-4 model on ℚ≥0 scores -/
-
-/-! ### The Figure-4 chain
-
-Shared-CG RSA: `L0 ∝ ⟦u⟧·CG`, `S1 ∝ LitList` (α = 1, fn. 3), `L1 ∝
-PragSpeak·CG`, with the endorsement speaker `S2 ∝ L1`. -/
-/-! ### The score chain -/
-
-/-- CG-weighted literal listener ([anderson-2021] Figure 4: `L0 ∝ ⟦u⟧·CG`). -/
-def l0Score (cg : MFWorld → ℚ≥0) (u : MFUtterance) : MFWorld → ℚ≥0 :=
-  PMF.normalizeScores fun w => if mfMeaning u w then cg w else 0
-
-/-- Pragmatic speaker ([anderson-2021] Figure 4: `S1 ∝ LitList`; fn. 3: the
-softmax terms are omitted and probabilities renormalized, i.e. `α = 1` and
-no cost — the speaker weight IS the literal-listener value). -/
-def s1Score (cg : MFWorld → ℚ≥0) (w : MFWorld) : MFUtterance → ℚ≥0 :=
-  PMF.normalizeScores fun u => l0Score cg u w
-
-/-- Pragmatic listener ([anderson-2021] Figure 4: `L1 ∝ PragSpeak·CG`). -/
-def l1Score (cg : MFWorld → ℚ≥0) (u : MFUtterance) : MFWorld → ℚ≥0 :=
-  PMF.normalizeScores fun w => cg w * s1Score cg w u
-
-/-- Endorsement speaker: `S2(u|w) ∝ L1(w|u)` (uniform utterance prior),
-the standard endorsement inversion of L1 over utterances. -/
-def s2Score (cg : MFWorld → ℚ≥0) (w : MFWorld) : MFUtterance → ℚ≥0 :=
-  PMF.normalizeScores fun u => l1Score cg u w
-
-/-! ### The prior-transparency mechanism
-
-Worlds with the same truth profile get identical speaker columns — the
-common-ground factor cancels out of S1's normalization
-(`PMF.normalizeScores_mul_left`) — so L1 orders them purely by their
-common-ground weights. Every tie and tie-break below is an instance. -/
-
-/-- Same truth profile, same speaker column: the CG weight scales the
-whole L0 row and cancels under normalization. -/
-theorem s1Score_congr (cg : MFWorld → ℚ≥0) {w₁ w₂ : MFWorld}
-    (h₁ : cg w₁ ≠ 0) (h₂ : cg w₂ ≠ 0)
-    (hw : ∀ u, mfMeaning u w₁ = mfMeaning u w₂) :
-    s1Score cg w₁ = s1Score cg w₂ := by
-  have l0_eq : ∀ w : MFWorld, (∀ u, mfMeaning u w = mfMeaning u w₁) →
-      (fun u => l0Score cg u w) = fun u => cg w *
-        ((if mfMeaning u w₁ then 1 else 0) /
-          ∑ w', if mfMeaning u w' then cg w' else 0) := by
-    intro w hwp
-    funext u
-    rw [l0Score, PMF.normalizeScores, ← hwp u]
-    split
-    · rw [mul_one_div]
-    · rw [zero_div, mul_zero]
-  rw [s1Score, s1Score, l0_eq w₁ (fun _ => rfl), l0_eq w₂ (fun u => (hw u).symm),
-    PMF.normalizeScores_mul_left h₁, PMF.normalizeScores_mul_left h₂]
-
-/-- L1 orders same-profile worlds by their CG weights alone. -/
-theorem l1Score_lt_iff (cg : MFWorld → ℚ≥0) {u : MFUtterance} {w₁ w₂ : MFWorld}
-    (h₁ : cg w₁ ≠ 0) (h₂ : cg w₂ ≠ 0)
-    (hw : ∀ u', mfMeaning u' w₁ = mfMeaning u' w₂)
-    (hu : s1Score cg w₁ u ≠ 0) :
-    l1Score cg u w₁ < l1Score cg u w₂ ↔ cg w₁ < cg w₂ := by
-  have hs := s1Score_congr cg h₁ h₂ hw
-  have hZ : (∑ w, cg w * s1Score cg w u) ≠ 0 := by
-    intro h
-    exact hu (by simpa [h₁] using
-      (Finset.sum_eq_zero_iff.mp h w₁ (Finset.mem_univ _)))
-  rw [l1Score, PMF.normalizeScores, PMF.normalizeScores,
-    div_lt_div_iff_of_pos_right (pos_iff_ne_zero.mpr hZ), ← hs,
-    mul_lt_mul_iff_of_pos_right (pos_iff_ne_zero.mpr hu)]
-
-/-- Turn-1 speaker (uniform CommonGround, [anderson-2021] Figure 2:
-`CG = Uniform(worlds)`). -/
-noncomputable def s1Turn1 : MFWorld → PMF MFUtterance :=
-  fun w => .ofScores .uniform (s1Score (fun _ => 1) w)
-
-/-- Turn-1 pragmatic listener. -/
-noncomputable def l1Turn1 : MFUtterance → PMF MFWorld :=
-  fun u => .ofScores .uniform (l1Score (fun _ => 1) u)
-
-/-- Turn-1 endorsement speaker. -/
-noncomputable def s2Turn1 : MFWorld → PMF MFUtterance :=
-  fun w => .ofScores .uniform (s2Score (fun _ => 1) w)
-
-/-- Turn-1 speaker values ([anderson-2021] Figure-4 equations at the uniform
-CG; derived exact rationals — Figure 5 reports the qualitative profile):
-`2/5` on each true specific utterance, `1/5` on `null`, `0` off support. -/
-theorem s1Turn1_true {u : MFUtterance} {w : MFWorld}
-    (hw : mfMeaning u w = true) (hn : u ≠ .null) :
-    s1Turn1 w u = (((2/5 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  PMF.ofScores_eq_ratCast _ (by revert hw hn; cases u <;> cases w <;> decide +kernel)
-
-theorem s1Turn1_null (w : MFWorld) : s1Turn1 w .null = (((1/5 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  PMF.ofScores_eq_ratCast _ (by cases w <;> decide +kernel)
-
-theorem s1Turn1_false {u : MFUtterance} {w : MFWorld}
-    (hw : mfMeaning u w = false) : s1Turn1 w u = 0 := by
-  show PMF.ofScores .uniform (s1Score (fun _ => 1) w) u = 0
-  rw [PMF.ofScores_apply]
-  exact_mod_cast (by revert hw; cases u <;> cases w <;> decide +kernel :
-    PMF.scoresWith .uniform (s1Score (fun _ => 1) w) u = 0)
-
-/-- Turn-1 listener values (derived; `L1 ∝ PragSpeak·CG`, Figure 4): `1/2`
-on each world satisfying a specific utterance, `1/4` on every world after
-`null`, `0` off support. -/
-theorem l1Turn1_true {u : MFUtterance} {w : MFWorld}
-    (hw : mfMeaning u w = true) (hn : u ≠ .null) :
-    l1Turn1 u w = (((1/2 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  PMF.ofScores_eq_ratCast _ (by revert hw hn; cases u <;> cases w <;> decide +kernel)
-
-theorem l1Turn1_null (w : MFWorld) : l1Turn1 .null w = (((1/4 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  PMF.ofScores_eq_ratCast _ (by cases w <;> decide +kernel)
-
-theorem l1Turn1_false {u : MFUtterance} {w : MFWorld}
-    (hw : mfMeaning u w = false) : l1Turn1 u w = 0 := by
-  show PMF.ofScores .uniform (l1Score (fun _ => 1) u) w = 0
-  rw [PMF.ofScores_apply]
-  exact_mod_cast (by revert hw; cases u <;> cases w <;> decide +kernel :
-    PMF.scoresWith .uniform (l1Score (fun _ => 1) u) w = 0)
-
-/-! ### Turn-1 predictions -/
-
-/-- The turn-1 speaker: true-and-specific beats false or uninformative;
-equal literal posteriors tie (`s1Score_congr` at the uniform CG). -/
+/-- The first speaker: a false utterance is never produced, a specific true utterance beats
+the null one, and the two specific true utterances tie. -/
 theorem s1_turn1_informativity :
-    (s1Turn1 .nancy .studyScience < s1Turn1 .nancy .studyHumanity) ∧
-    (s1Turn1 .nancy .null < s1Turn1 .nancy .studyHumanity) ∧
-    (s1Turn1 .nancy .studyHumanity = s1Turn1 .nancy .likeOutdoors) ∧
-    ¬(s1Turn1 .nancy .null < s1Turn1 .nancy .studyScience) ∧
-    (s1Turn1 .ina .studyHumanity < s1Turn1 .ina .studyScience) ∧
-    (s1Turn1 .ina .studyScience = s1Turn1 .ina .likeIndoors) :=
-  ⟨PMF.ofScores_lt _ (by decide +kernel), PMF.ofScores_lt _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel),
-   not_lt.mpr (PMF.ofScores_le_cross _ _ (by decide +kernel)),
-   PMF.ofScores_lt _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel)⟩
+    (S1 cg₁ .nancy).real {.studyScience} = 0 ∧
+    (S1 cg₁ .nancy).real {.null} < (S1 cg₁ .nancy).real {.studyHumanity} ∧
+    (S1 cg₁ .nancy).real {.studyHumanity} = (S1 cg₁ .nancy).real {.likeOutdoors} := by
+  refine ⟨uniformSpeaker_real_singleton_eq_zero sem one_pos (by decide),
+    uniformSpeaker_real_singleton_lt_of_card_lt sem one_pos (by decide) (by decide) (by decide),
+    ?_⟩
+  show (uniformSpeaker sem 1 .nancy).real {.studyHumanity} =
+    (uniformSpeaker sem 1 .nancy).real {.likeOutdoors}
+  rw [uniformSpeaker_real_singleton sem one_pos, uniformSpeaker_real_singleton sem one_pos,
+    if_pos (by decide), if_pos (by decide),
+    show (sem .studyHumanity).card = (sem .likeOutdoors).card by decide]
 
-/-- The turn-1 listener: utterances favor the worlds they discriminate and
-tie same-profile worlds at the uniform CG (`l1Score_lt_iff`). -/
+/-- Every world has the same profile at the first turn: two true specific utterances of
+extension size two and the null utterance. -/
+theorem profile_eq (w w' : World) : profile sem w = profile sem w' := by
+  cases w <;> cases w' <;> decide
+
+/-- The first listener: *they study a humanity* rules out Ina and keeps Nancy, and *they like
+being outdoors* leaves Katie and Nancy tied. -/
 theorem l1_turn1_inferences :
-    (l1Turn1 .studyHumanity .ina < l1Turn1 .studyHumanity .nancy) ∧
-    (l1Turn1 .likeOutdoors .sally < l1Turn1 .likeOutdoors .nancy) ∧
-    (l1Turn1 .studyHumanity .nancy = l1Turn1 .studyHumanity .sally) ∧
-    (l1Turn1 .studyScience .ina = l1Turn1 .studyScience .katie) :=
-  ⟨PMF.ofScores_lt _ (by decide +kernel), PMF.ofScores_lt _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel)⟩
+    L1 cg₁ .studyHumanity {.ina} = 0 ∧ L1 cg₁ .studyHumanity {.nancy} ≠ 0 ∧
+    L1 cg₁ .likeOutdoors {.katie} = L1 cg₁ .likeOutdoors {.nancy} :=
+  ⟨L1_apply_singleton_eq_zero (by decide)
+      (comp_S1_ne_zero (w := .nancy) (by decide) (uniformOn_univ_singleton_ne_zero _)),
+    L1_apply_singleton_ne_zero (by decide) (uniformOn_univ_singleton_ne_zero _),
+    posterior_apply_singleton_congr _ _
+      (comp_S1_ne_zero (u := .likeOutdoors) (w := .nancy) (by decide)
+        (uniformOn_univ_singleton_ne_zero _))
+      (uniformSpeaker_apply_singleton_of_profile_eq sem one_pos (profile_eq _ _)
+        (c := .likeOutdoors) (by decide) (by decide))
+      (uniformOn_univ_singleton_eq _ _)⟩
 
-/-- The null utterance conveys nothing: L1 stays uniform. -/
-theorem l1_null_uniform (w₁ w₂ : MFWorld) :
-    l1Turn1 .null w₁ = l1Turn1 .null w₂ := by
-  rw [l1Turn1_null, l1Turn1_null]
+/-- The null utterance conveys nothing: the listener stays uniform. -/
+theorem l1_null_uniform (w w' : World) : L1 cg₁ .null {w} = L1 cg₁ .null {w'} :=
+  posterior_apply_singleton_congr _ _
+    (comp_S1_ne_zero (u := .null) (w := w) (by cases w <;> decide)
+      (uniformOn_univ_singleton_ne_zero _))
+    (uniformSpeaker_apply_singleton_of_profile_eq sem one_pos (profile_eq _ _) (c := .null)
+      (by cases w <;> decide) (by cases w' <;> decide))
+    (uniformOn_univ_singleton_eq _ _)
 
-/-! ### Turn 2 (Post-Update Prior) -/
+/-! ### The second turn -/
 
-/-- CommonGround weights after hearing "studyHumanity" at turn 1.
+/-- The common ground after *they study a humanity* at learning rate 0.2 (footnote 9). -/
+noncomputable def cg₂ : Measure World := updateCG cg₁ (L1 cg₁ .studyHumanity) (1/5)
 
-After L1 processes "studyHumanity" with uniform prior, the posterior
-concentrates on nancy and sally (the German-studying worlds):
-L1(studyHumanity) = [0, 0, 1/2, 1/2]. Updating the normalized uniform
-CommonGround [1/4, 1/4, 1/4, 1/4] via `updateCG` with lr=0.2 (footnote 9) gives:
+instance : IsFiniteMeasure cg₂ := inferInstanceAs (IsFiniteMeasure (updateCG _ _ _))
 
-    CommonGround'(w) = 0.8 · 1/4 + 0.2 · L1(w)
-    CommonGround' = [1/5, 1/5, 3/10, 3/10]
+theorem cg₂_ina_eq_katie : cg₂ {.ina} = cg₂ {.katie} := by
+  have hx := comp_S1_ne_zero (cg := cg₁) (u := .studyHumanity) (w := .nancy) (by decide)
+    (uniformOn_univ_singleton_ne_zero _)
+  rw [cg₂, updateCG_apply, updateCG_apply, uniformOn_univ_singleton_eq World.ina .katie,
+    L1_apply_singleton_eq_zero (by decide) hx, L1_apply_singleton_eq_zero (by decide) hx]
 
-The weights [2, 2, 3, 3] are proportional to [1/5, 1/5, 3/10, 3/10],
-which is the exact post-update CommonGround from the paper's Figure 5, panel 1A.
-Since RSA normalizes, proportional weights give identical predictions. -/
-def cgTurn2 : MFWorld → ℚ≥0
-  | .ina | .katie => 2
-  | .nancy | .sally => 3
+theorem cg₂_nancy_eq_sally : cg₂ {.nancy} = cg₂ {.sally} := by
+  have h : L1 cg₁ .studyHumanity {.nancy} = L1 cg₁ .studyHumanity {.sally} :=
+    posterior_apply_singleton_congr _ _
+      (comp_S1_ne_zero (u := .studyHumanity) (w := .nancy) (by decide)
+        (uniformOn_univ_singleton_ne_zero _))
+      (uniformSpeaker_apply_singleton_of_profile_eq sem one_pos (profile_eq _ _)
+        (c := .studyHumanity) (by decide) (by decide))
+      (uniformOn_univ_singleton_eq _ _)
+  rw [cg₂, updateCG_apply, updateCG_apply, uniformOn_univ_singleton_eq World.nancy .sally, h]
 
-/-- Turn-2 speaker at the post-update CommonGround. -/
-noncomputable def s1Turn2 : MFWorld → PMF MFUtterance :=
-  fun w => .ofScores .uniform (s1Score cgTurn2 w)
+theorem cg₂_ina_ne_zero : cg₂ {.ina} ≠ 0 := by
+  rw [cg₂, updateCG_apply]
+  exact fun h => uniformOn_univ_singleton_ne_zero _
+    ((mul_eq_zero.mp (add_eq_zero.mp h).1).resolve_left
+    (ENNReal.coe_ne_zero.mpr (tsub_pos_of_lt (by norm_num)).ne'))
 
-/-- Turn-2 pragmatic listener. -/
-noncomputable def l1Turn2 : MFUtterance → PMF MFWorld :=
-  fun u => .ofScores .uniform (l1Score cgTurn2 u)
+theorem cg₂_ina_lt_nancy : cg₂ {.ina} < cg₂ {.nancy} := by
+  have hx := comp_S1_ne_zero (cg := cg₁) (u := .studyHumanity) (w := .nancy) (by decide)
+    (uniformOn_univ_singleton_ne_zero _)
+  rw [cg₂, updateCG_apply, updateCG_apply, uniformOn_univ_singleton_eq World.ina .nancy,
+    L1_apply_singleton_eq_zero (by decide) hx, mul_zero]
+  refine ENNReal.add_lt_add_left (ENNReal.mul_ne_top ENNReal.coe_ne_top (measure_ne_top _ _)) ?_
+  exact ENNReal.mul_pos (ENNReal.coe_ne_zero.mpr (by norm_num))
+    (L1_apply_singleton_ne_zero (by decide) (uniformOn_univ_singleton_ne_zero _))
 
-/-! ### Turn-2 predictions -/
+/-! Predictions at any common ground favouring the German-studying worlds by a common margin,
+as `cg₂` does. -/
 
-/-- After the "studyHumanity" update, L1 orders same-profile worlds by
-their new CG weights (`l1Score_lt_iff`): the outdoor pair breaks toward
-Nancy, the indoor pair toward Sally, equal-weight pairs stay tied. -/
-theorem l1_turn2_prior_effects :
-    (l1Turn2 .likeOutdoors .katie < l1Turn2 .likeOutdoors .nancy) ∧
-    (l1Turn2 .likeIndoors .ina < l1Turn2 .likeIndoors .sally) ∧
-    (l1Turn2 .studyScience .ina = l1Turn2 .studyScience .katie) ∧
-    (l1Turn2 .studyHumanity .nancy = l1Turn2 .studyHumanity .sally) :=
-  ⟨PMF.ofScores_lt _ (by decide +kernel), PMF.ofScores_lt _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel)⟩
+section Shaped
 
-/-- The key multi-turn prediction: turn 1 ties Nancy and Katie under
-"likeOutdoors"; the CG update breaks the tie toward Nancy. -/
+variable (μ : Measure World) [IsFiniteMeasure μ] (hik : μ {.ina} = μ {.katie})
+  (hns : μ {.nancy} = μ {.sally}) (hlt : μ {.ina} < μ {.nancy}) (hi : μ {.ina} ≠ 0)
+
+include hik hns hlt hi
+
+/-- Redundancy aversion: Nancy's speaker now prefers *they like being outdoors* to
+re-asserting *they study a humanity*, and Ina's *they study a science* to *they like being
+indoors* — the literal listener reads the common ground, so an established utterance
+discriminates less. -/
+theorem s1_prefers_new :
+    (S1 μ .nancy).real {.studyHumanity} < (S1 μ .nancy).real {.likeOutdoors} ∧
+    (S1 μ .ina).real {.likeIndoors} < (S1 μ .ina).real {.studyScience} := by
+  have hn : μ {.nancy} ≠ 0 := (zero_le.trans_lt hlt).ne'
+  constructor
+  · rw [speaker_real_singleton_lt_iff (cost := 1) (L := L0 μ) (w := .nancy) zero_le_one
+      (fun _ => ENNReal.one_ne_top) (fun u => L0_apply_singleton_le_one μ u .nancy)
+      ⟨.studyHumanity, by simpa using
+        L0_apply_singleton_ne_zero (cg := μ) (u := .studyHumanity) (w := .nancy) (by decide) hn⟩]
+    simp only [ENNReal.rpow_one, Pi.one_apply, mul_one]
+    rw [literalListener_indicator_apply_singleton μ semSet (u := .studyHumanity) (by decide),
+      literalListener_indicator_apply_singleton μ semSet (u := .likeOutdoors) (by decide),
+      ENNReal.mul_lt_mul_iff_left hn (measure_ne_top _ _), ENNReal.inv_lt_inv,
+      ← sum_measure_singleton, ← sum_measure_singleton,
+      show sem .likeOutdoors = {.katie, .nancy} by decide,
+      show sem .studyHumanity = {.nancy, .sally} by decide, Finset.sum_pair (by decide),
+      Finset.sum_pair (by decide), ← hik, ← hns, add_comm]
+    exact ENNReal.add_lt_add_left (measure_ne_top μ _) hlt
+  · rw [speaker_real_singleton_lt_iff (cost := 1) (L := L0 μ) (w := .ina) zero_le_one
+      (fun _ => ENNReal.one_ne_top) (fun u => L0_apply_singleton_le_one μ u .ina)
+      ⟨.studyScience, by simpa using
+        L0_apply_singleton_ne_zero (cg := μ) (u := .studyScience) (w := .ina) (by decide) hi⟩]
+    simp only [ENNReal.rpow_one, Pi.one_apply, mul_one]
+    rw [literalListener_indicator_apply_singleton μ semSet (u := .likeIndoors) (by decide),
+      literalListener_indicator_apply_singleton μ semSet (u := .studyScience) (by decide),
+      ENNReal.mul_lt_mul_iff_left hi (measure_ne_top _ _), ENNReal.inv_lt_inv,
+      ← sum_measure_singleton, ← sum_measure_singleton,
+      show sem .studyScience = {.ina, .katie} by decide,
+      show sem .likeIndoors = {.ina, .sally} by decide, Finset.sum_pair (by decide),
+      Finset.sum_pair (by decide), ← hik, ← hns]
+    exact ENNReal.add_lt_add_left (measure_ne_top μ _) hlt
+
+omit hik hns hlt hi in
+theorem sum_L0_toReal (w : World) :
+    ∑ u, (L0 μ u {w}).toReal =
+      ∑ u ∈ Finset.univ.filter (w ∈ sem ·), μ.real {w} / ∑ x ∈ sem u, μ.real {x} := by
+  rw [Finset.sum_filter]
+  refine Finset.sum_congr rfl fun u _ => ?_
+  split_ifs with h
+  · exact L0_toReal h
+  · exact L0_toReal_of_notMem h
+
+omit hik hns hlt hi in
+theorem real_univ : μ.real Set.univ =
+    μ.real {.ina} + μ.real {.katie} + μ.real {.nancy} + μ.real {.sally} := by
+  rw [← Finset.coe_univ, ← sum_measureReal_singleton,
+    show (Finset.univ : Finset World) = {.ina, .katie, .nancy, .sally} from rfl,
+    Finset.sum_insert (by decide : World.ina ∉ ({.katie, .nancy, .sally} : Finset World)),
+    Finset.sum_insert (by decide : World.katie ∉ ({.nancy, .sally} : Finset World)),
+    Finset.sum_pair (by decide : World.nancy ≠ .sally), add_assoc, add_assoc]
+
+/-- *They like being outdoors* now favours Nancy over Katie: Nancy's world carries more of
+the common ground, and Nancy's speaker also produces the utterance more readily, since her
+other true utterance discriminates less than Katie's. -/
+theorem l1_katie_lt_nancy :
+    (L1 μ .likeOutdoors).real {.katie} < (L1 μ .likeOutdoors).real {.nancy} := by
+  have hn : μ {.nancy} ≠ 0 := (zero_le.trans_lt hlt).ne'
+  have hx := comp_S1_ne_zero (cg := μ) (u := .likeOutdoors) (w := .nancy) (by decide) hn
+  show (((S1 μ)†μ) .likeOutdoors).real {.katie} < (((S1 μ)†μ) .likeOutdoors).real {.nancy}
+  rw [← Finset.coe_singleton, ← Finset.coe_singleton, posterior_real_finset_lt_iff _ _ hx,
+    Finset.sum_singleton, Finset.sum_singleton, S1_real_singleton, S1_real_singleton,
+    sum_L0_toReal, sum_L0_toReal, L0_toReal (by decide), L0_toReal (by decide),
+    show Finset.univ.filter (World.katie ∈ sem ·) = {.studyScience, .likeOutdoors, .null} by
+      decide,
+    show Finset.univ.filter (World.nancy ∈ sem ·) = {.studyHumanity, .likeOutdoors, .null} by
+      decide,
+    Finset.sum_insert (by decide : Utterance.studyScience ∉
+      ({.likeOutdoors, .null} : Finset Utterance)),
+    Finset.sum_insert (by decide : Utterance.studyHumanity ∉
+      ({.likeOutdoors, .null} : Finset Utterance)),
+    Finset.sum_pair (by decide : Utterance.likeOutdoors ≠ .null),
+    Finset.sum_pair (by decide : Utterance.likeOutdoors ≠ .null),
+    show sem .studyScience = {.ina, .katie} by decide,
+    show sem .studyHumanity = {.nancy, .sally} by decide,
+    show sem .likeOutdoors = {.katie, .nancy} by decide, show sem .null = Finset.univ by decide,
+    Finset.sum_pair (by decide : World.ina ≠ .katie),
+    Finset.sum_pair (by decide : World.nancy ≠ .sally),
+    Finset.sum_pair (by decide : World.katie ≠ .nancy), sum_measureReal_singleton,
+    Finset.coe_univ, real_univ]
+  have hk : μ.real {.katie} = μ.real {.ina} := by rw [measureReal_def, measureReal_def, hik]
+  have hs : μ.real {.sally} = μ.real {.nancy} := by rw [measureReal_def, measureReal_def, hns]
+  have ha : 0 < μ.real {.ina} := ENNReal.toReal_pos hi (measure_ne_top _ _)
+  have hab : μ.real {.ina} < μ.real {.nancy} :=
+    (ENNReal.toReal_lt_toReal (measure_ne_top _ _) (measure_ne_top _ _)).mpr hlt
+  rw [hk, hs]
+  set a := μ.real {.ina}
+  set b := μ.real {.nancy}
+  have hb : 0 < b := ha.trans hab
+  have hSk : a / (a + b) / (a / (a + a) + (a / (a + b) + a / (a + a + b + b))) =
+      2 * a / (4 * a + b) := by
+    field_simp
+    ring
+  have hSn : b / (a + b) / (b / (b + b) + (b / (a + b) + b / (a + a + b + b))) =
+      2 * b / (a + 4 * b) := by
+    field_simp
+    ring
+  rw [hSk, hSn, mul_div_assoc', mul_div_assoc', div_lt_div_iff₀ (by positivity) (by positivity)]
+  nlinarith [mul_pos (mul_pos ha hb) (sub_pos.2 hab),
+    mul_pos (sub_pos.2 hab) (by positivity : 0 < b ^ 2 + a * b + a ^ 2)]
+
+end Shaped
+
+/-- The key multi-turn prediction: *they like being outdoors* tied Katie and Nancy at the
+first turn; at the updated common ground it favours Nancy. -/
 theorem turn2_breaks_symmetry :
-    l1Turn1 .likeOutdoors .nancy = l1Turn1 .likeOutdoors .katie ∧
-    l1Turn2 .likeOutdoors .katie < l1Turn2 .likeOutdoors .nancy :=
-  ⟨PMF.ofScores_eq_cross _ _ (by decide +kernel), l1_turn2_prior_effects.1⟩
-
-/-! ### The CG-adapted speaker -/
-
-/-- The CG-weighted L0 makes speakers prefer new over redundant
-information: after the update, Nancy's speaker switches to "likeOutdoors"
-(re-asserting "studyHumanity" is redundant at 3:3 weights) and Ina's to
-"studyScience" (Sally now dominates the indoor partition). At turn 1 both
-pairs were symmetric (`s1_turn1_informativity`). -/
-theorem s1_turn2_cg_adapted :
-    (s1Turn2 .nancy .studyHumanity < s1Turn2 .nancy .likeOutdoors) ∧
-    (s1Turn2 .ina .likeIndoors < s1Turn2 .ina .studyScience) :=
-  ⟨PMF.ofScores_lt _ (by decide +kernel), PMF.ofScores_lt _ (by decide +kernel)⟩
-
-/-- The endorsement speaker inverts L1: for Nancy, "studyHumanity" beats
-the false "studyScience" and ties the symmetric "likeOutdoors". -/
-theorem s2_endorsement :
-    (s2Turn1 .nancy .studyScience < s2Turn1 .nancy .studyHumanity) ∧
-    (s2Turn1 .nancy .studyHumanity = s2Turn1 .nancy .likeOutdoors) :=
-  ⟨PMF.ofScores_lt _ (by decide +kernel),
-   PMF.ofScores_eq_cross _ _ (by decide +kernel)⟩
-
-/-! ### Parametric RSA and Conversation Step -/
-
-/-- One Figure-2 loop step on the ℚ≥0 face: build the chain at the
-current common ground, take the L1 posterior, and mix it in at the
-learning rate. A dead score row — an utterance contradicting the whole
-common ground — skips the update (§7.1's null behaviour). -/
-noncomputable def conversationStep
-    (cg : MFWorld → ℚ≥0) (u : MFUtterance)
-    (lr : ℝ) (hlr : 0 ≤ lr) (hlr1 : lr ≤ 1) :
-    PMF MFWorld :=
-  if 0 < ∑ w, cg w * s1Score cg w u then
-    updateCG (.ofScores .uniform cg) (.ofScores .uniform (l1Score cg u)) lr hlr hlr1
-  else .ofScores .uniform cg
-
-/-- With lr = 0, the conversation step leaves the CommonGround unchanged. -/
-theorem conversationStep_lr_zero (cg : MFWorld → ℚ≥0) (u : MFUtterance) (w : MFWorld) :
-    (conversationStep cg u 0 (le_refl 0) zero_le_one).toRealFn w
-      = ((.ofScores .uniform cg) : PMF MFWorld).toRealFn w := by
-  unfold conversationStep
-  split
-  · exact updateCG_lr_zero _ _ w
-  · rfl
-
-/-! ### Qualitative information-sharing properties -/
-
-/-- An informative utterance concentrates L1 above the uniform null
-baseline (1/2 vs 1/4 on Nancy). -/
-theorem l1_concentrates_after_utterance :
-    l1Turn1 .null .nancy < l1Turn1 .studyHumanity .nancy :=
-  PMF.ofScores_lt_cross _ _ (by decide +kernel)
-
-/-! ### Bridge to Classical CommonGround Update -/
-
-/-- The [stalnaker-2002] set-intersection update survives only at the
-lr = 1 limit: with the prior discarded, a zero-posterior world leaves
-the context set. -/
-theorem lr_one_excludes_false_worlds (cg post : PMF MFWorld)
-    (w : MFWorld) (h : post.toRealFn w = 0) :
-    w ∉ HasCommonGround.contextSet (updateCG cg post 1 zero_le_one (le_refl 1)) := by
-  rw [Discourse.pmf_contextSet, updateCG_lr_one, h]
-  exact lt_irrefl 0
-
-/-- The graded divergence (fn. 7: "worlds can regain probability"): at
-any lr < 1 the prior keeps a ruled-out world alive with mass
-`(1 − lr)·cg w` — the update never deletes a world the prior supports. -/
-theorem graded_update_keeps_false_world (cg post : PMF MFWorld)
-    (w : MFWorld) (hcg : 0 < cg.toRealFn w) (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr < 1) :
-    w ∈ HasCommonGround.contextSet (updateCG cg post lr h0 h1.le) := by
-  rw [Discourse.pmf_contextSet, updateCG_eq]
-  have : 0 < (1 - lr) * cg.toRealFn w := mul_pos (by linarith) hcg
-  have : 0 ≤ lr * post.toRealFn w :=
-    mul_nonneg h0 (PMF.toRealFn_nonneg _ _)
-  linarith
-
-/-! ### Exact Numerical Predictions (turn 1) -/
-
-/-! ### Exact turn-1 values -/
--- S1(·|nancy): production probabilities given obs = Nancy
-
-theorem s1_nancy_studyHumanity_val :
-    s1Turn1 .nancy .studyHumanity = (((2/5 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  s1Turn1_true (by decide) (by decide)
-
-theorem s1_nancy_studyScience_val :
-    s1Turn1 .nancy .studyScience = 0 :=
-  s1Turn1_false (by decide)
-
-theorem s1_nancy_likeIndoors_val :
-    s1Turn1 .nancy .likeIndoors = 0 :=
-  s1Turn1_false (by decide)
-
-theorem s1_nancy_likeOutdoors_val :
-    s1Turn1 .nancy .likeOutdoors = (((2/5 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  s1Turn1_true (by decide) (by decide)
-
-theorem s1_nancy_null_val :
-    s1Turn1 .nancy .null = (((1/5 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  s1Turn1_null .nancy
-
--- L1(·|studyHumanity): posteriors used in CommonGround update → Figure 5 panel 1A
-
-theorem l1_studyHumanity_nancy_val :
-    l1Turn1 .studyHumanity .nancy = (((1/2 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  l1Turn1_true (by decide) (by decide)
-
-theorem l1_studyHumanity_sally_val :
-    l1Turn1 .studyHumanity .sally = (((1/2 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  l1Turn1_true (by decide) (by decide)
-
-theorem l1_studyHumanity_ina_val :
-    l1Turn1 .studyHumanity .ina = 0 :=
-  l1Turn1_false (by decide)
-
-theorem l1_studyHumanity_katie_val :
-    l1Turn1 .studyHumanity .katie = 0 :=
-  l1Turn1_false (by decide)
-
-/-- Null gives uniform L1: every world has the same S1(null|w) by the
-domain's symmetry, so L1(w|null) = CommonGround(w)/Σ CommonGround = 1/4. -/
-theorem l1_null_val (w : MFWorld) :
-    l1Turn1 .null w = (((1/4 : ℚ≥0) : ℝ≥0) : ℝ≥0∞) :=
-  l1Turn1_null w
-
-/-! ### Approximate CommonGround Model (§5.2, Figure 6) -/
-
-/-! ### Approximate common ground
-
-Separate speaker/listener CG representations (Figure 6): the listener's
-Pragmatic Listener runs on their own beliefs, so divergence can arise
-when those differ from the common ground. -/
-/-- State for the Approximate CommonGround model (§5.2, Figure 6). -/
-structure ApproxCGState (W : Type*) where
-  cgA : PMF W
-  cgB : PMF W
-  belA : PMF W
-  belB : PMF W
-  lr : ℝ
-  speakerIsA : Bool
-
-noncomputable def ApproxCGState.initial {W : Type*} [Fintype W] [Nonempty W]
-    (belA belB : PMF W) (lr : ℝ) : ApproxCGState W where
-  cgA := PMF.uniformOfFintype W
-  cgB := PMF.uniformOfFintype W
-  belA := belA
-  belB := belB
-  lr := lr
-  speakerIsA := true
-
-/-- Approximate comprehension listener ([anderson-2021] Figure 6): L0/S1 run
-over the listener's CommonGround approximation `CG_L`, but the Bayesian
-inversion uses the listener's private beliefs `B_L` as the prior. -/
-noncomputable def approxL1 (cgL belL : MFWorld → ℚ≥0) (u : MFUtterance) : PMF MFWorld :=
-  .ofScores .uniform (PMF.normalizeScores fun w => belL w * s1Score cgL w u)
-
-/-- When beliefs equal the CommonGround, the approximate model reduces to the
-shared CommonGround model — the split is only meaningful when they diverge. -/
-theorem approx_reduces_to_shared (cg : MFWorld → ℚ≥0) (u : MFUtterance) :
-    approxL1 cg cg u = .ofScores .uniform (l1Score cg u) := rfl
-
-/-! ### Belief Update Model (§6, Figure 8) -/
-
-/-! The belief update model extends the conversation system by also
-updating participants' private beliefs. After comprehension, the
-listener updates their beliefs via the same linear rule as CommonGround update:
-
-    Bel'(w) = (1 - lr_bel) · Bel(w) + lr_bel · posterior(w)
-
-The speaker does not update beliefs (they already knew the info).
-Different learning rates for CommonGround vs beliefs allow modeling:
-- §6.2: skeptical listeners (low belief lr, high CommonGround lr)
-- §6.3: uncertainty-based rates (lr scales with entropy) -/
-
-/-- State for the belief update model (Figure 8).
-Extends approximate CommonGround with separate learning rates for CommonGround and beliefs. -/
-structure BeliefUpdateState (W : Type*) where
-  cgA : PMF W
-  cgB : PMF W
-  belA : PMF W
-  belB : PMF W
-  /-- Learning rate for CommonGround updates. -/
-  cgLR : ℝ
-  /-- Learning rate for belief updates (may be lower for skeptical agents). -/
-  belLR : ℝ
-  speakerIsA : Bool
-
-noncomputable def BeliefUpdateState.initial {W : Type*} [Fintype W] [Nonempty W]
-    (belA belB : PMF W) (cgLR belLR : ℝ) :
-    BeliefUpdateState W where
-  cgA := PMF.uniformOfFintype W
-  cgB := PMF.uniformOfFintype W
-  belA := belA
-  belB := belB
-  cgLR := cgLR
-  belLR := belLR
-  speakerIsA := true
-
-/-- Belief update is algebraically identical to CommonGround update — both are
-instances of [luce-1959]'s linear learning rule. The only difference
-is the learning rate parameter and the interpretation (private vs shared). -/
-theorem belief_update_is_linear_learning {W : Type*} [Fintype W]
-    (bel post : PMF W)
-    (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr ≤ 1) (w : W) :
-    (updateCG bel post lr h0 h1).toRealFn w =
-    (1 - lr) * bel.toRealFn w + lr * post.toRealFn w :=
-  updateCG_eq bel post lr h0 h1 w
-
-/-! ### Noncommittal Speaker Problem (§7.1) -/
-
-/-! A speaker with uniform beliefs (no private information) assigns equal
-weight to all worlds under weighted sampling. Since no observation is
-more probable than any other, the speaker makes random assertions about
-worlds they don't know, causing the CommonGround to flip-flop (Figure 12).
-
-Solutions:
-1. **Threshold sampling** (§7.1.1): filter out low-confidence worlds;
-   a noncommittal speaker passes (null utterance) instead of guessing.
-2. **Uncertainty-based lr** (§6.3): scale the CommonGround update rate by the
-   listener's uncertainty, so confident listeners resist random input. -/
-
-/-- Uniform beliefs assign equal weight to all worlds under weighted
-sampling — a noncommittal speaker has no basis for choosing. -/
-theorem uniform_weighted_constant (w₁ w₂ : MFWorld) :
-    weightedSample (PMF.uniformOfFintype MFWorld) w₁ =
-    weightedSample (PMF.uniformOfFintype MFWorld) w₂ := by
-  simp only [weightedSample, PMF.uniformOfFintype_toRealFn]
-
-/-- Threshold sampling filters out all worlds when beliefs don't exceed
-the threshold. Every mass of a distribution is `≤ 1`, so any `θ > 1`
-produces zero weight everywhere — the speaker passes (Figure 13). -/
-theorem threshold_filters_uniform (θ : ℝ) (hθ : 1 < θ) (w : MFWorld) :
-    thresholdedSample (PMF.uniformOfFintype MFWorld) θ w = 0 := by
-  have hle : (PMF.uniformOfFintype MFWorld).toRealFn w ≤ 1 :=
-    PMF.toRealFn_le_one _ _
-  simp only [thresholdedSample]
-  rw [if_neg (by linarith)]
-
-/-- Threshold preserves confident worlds: weights above θ pass through. -/
-theorem threshold_preserves_confident {W : Type*}
-    (bel : PMF W) (θ : ℝ) (w : W) (h : bel.toRealFn w ≥ θ) :
-    thresholdedSample bel θ w = bel.toRealFn w := if_pos h
-
-/-! ### Redundancy and Difference Sampling (§7.2) -/
-
-/-! Under weighted sampling, a speaker whose beliefs match the CommonGround keeps
-repeating already-shared information (Figure 14). Difference-based
-sampling fixes this by weighting worlds by `max(0, Bel(w) - CommonGround(w))`:
-worlds already established in the CommonGround get zero weight.
-
-Combined with thresholding, **thresholded difference-based sampling**
-gives the best behavior (Figure 15): informed speakers contribute new
-information, noncommittal speakers pass. -/
-
-/-- When beliefs match the CommonGround exactly, difference sampling assigns zero
-weight to all worlds — nothing new to contribute. -/
-theorem difference_zero_when_aligned {W : Type*}
-    (cg : PMF W) (w : W) :
-    differenceSample cg cg w = 0 := by
-  simp only [differenceSample, sub_self, max_self]
-
-/-- Difference sampling assigns positive weight when belief exceeds CommonGround —
-these worlds carry new information not yet in the common ground. -/
-theorem difference_positive_when_exceeds {W : Type*}
-    (bel cg : PMF W) (w : W) (h : cg.toRealFn w < bel.toRealFn w) :
-    0 < differenceSample bel cg w := by
-  simp only [differenceSample]
-  exact lt_of_lt_of_le (by linarith : (0 : ℝ) < bel.toRealFn w - cg.toRealFn w) (le_max_right 0 _)
+    L1 cg₁ .likeOutdoors {.katie} = L1 cg₁ .likeOutdoors {.nancy} ∧
+    (L1 cg₂ .likeOutdoors).real {.katie} < (L1 cg₂ .likeOutdoors).real {.nancy} :=
+  ⟨l1_turn1_inferences.2.2,
+    l1_katie_lt_nancy cg₂ cg₂_ina_eq_katie cg₂_nancy_eq_sally cg₂_ina_lt_nancy cg₂_ina_ne_zero⟩
 
 end Anderson2021
-

--- a/references.bib
+++ b/references.bib
@@ -25480,7 +25480,7 @@
   pages     = {244--253},
   subfield  = {pragmatics},
   role      = {primary},
-  sources   = {Studies/Anderson2021.lean}
+  sources   = {Studies/Anderson2021.lean;Discourse/CommonGround/Measure.lean}
 }
 @book{raiffa-schlaifer-1961,
   author    = {Raiffa, Howard and Schlaifer, Robert},


### PR DESCRIPTION
Migrates the Anderson 2021 conversation-update study off the PMF face onto the measure/kernel RSA pipeline: the Figure-4 agents are `literalListener`/`speaker`/`pragmaticListener` at a common-ground measure, `updateCG` is the learning-rate mixture of measures, and the turn-two symmetry breaking (*they like being outdoors* favours Nancy after *they study a humanity*) and redundancy aversion are proved for any common ground of the post-update shape.

- Substrate: `Discourse/CommonGround/Measure.lean` (a measure's common ground is its a.e. filter; context set = positive-mass worlds), `posterior_apply_singleton_congr`, `speaker_real_singleton_lt_iff`, `uniformSpeaker_apply_singleton_of_profile_eq`, an `IsMarkovKernel` instance for `pragmaticListener`.
- Cuts the Luce linear-learning and BToM shared-update bridges (not the paper's), the derived exact-value theorems, and the state-record bundles.