### PR TITLE
feat(Studies/AndersonJM2006): subject selection hierarchy from the book

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2982,3 +2982,4 @@ import Linglib.Syntax.Category.Determiner.ModalIndefinite
 import Linglib.Data.Examples.Alsop2024
 import Linglib.Data.Examples.AnandHacquard2013
 import Linglib.Data.Examples.AnandHardtMcCloskey2021
+import Linglib.Data.Examples.AndersonJM2006

--- a/Linglib/Data/Examples/AndersonJM2006.json
+++ b/Linglib/Data/Examples/AndersonJM2006.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": "andersonjm2006_39a",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill read the book",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill read the book",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "erg"],
+      ["arg", "abs"],
+      ["subject", "erg"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_39b",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill fell to the ground",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill fell to the ground",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs"],
+      ["arg", "loc"],
+      ["subject", "abs"]
+    ],
+    "comment": "The locative carries the second-order feature {goal}; the subject is not inherently ergative.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_39c",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39c)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill flew to China",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill flew to China",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs,erg"],
+      ["arg", "loc"],
+      ["subject", "abs,erg"]
+    ],
+    "comment": "The locative carries {goal}.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_39h",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39h)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill knew the answer",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill knew the answer",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "erg,loc"],
+      ["arg", "abs"],
+      ["subject", "erg,loc"]
+    ],
+    "comment": "E (Experiencer) = erg,loc.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_39i",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39i)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill acquired a new shirt",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill acquired a new shirt",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "erg,loc"],
+      ["arg", "abs"],
+      ["subject", "erg,loc"]
+    ],
+    "comment": "Experiencer with {goal} on its locative component: erg,loc{goal} + abs. Also 'a new outlook'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_39j",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (39j)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill suffered from asthma",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill suffered from asthma",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs,erg,loc"],
+      ["arg", "loc"],
+      ["subject", "abs,erg,loc"]
+    ],
+    "comment": "E + abl = abs,erg,loc{goal} + loc{src}. Also 'from delusions'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_34",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (34)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Phil suffered (from asthma)",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Phil suffered (from asthma)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs,erg,loc"],
+      ["arg", "loc"],
+      ["subject", "abs,erg,loc"]
+    ],
+    "comment": "A patient that is at once Experiencer and contactive: all three first-order features combine on one argument; the ablative is loc{src}.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_4_8a",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (4.8a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Sewage flooded into the tank",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Sewage flooded into the tank",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs"],
+      ["arg", "loc"],
+      ["subject", "abs"]
+    ],
+    "comment": "The simple absolutive is subject; the other argument does not combine locative with absolutive.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_4_8b",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (4.8b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "The tank flooded with sewage",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The tank flooded with sewage",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "abs,loc"],
+      ["arg", "abs"],
+      ["subject", "abs,loc"]
+    ],
+    "comment": "Under (38) with its optional comma the complex absolutive abs,loc takes precedence over the simple one; under (38)′ the with-phrase is an adjunct outside subject selection.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "andersonjm2006_23a",
+    "source": {"bibkey": "anderson-jm-2006", "paperLabel": "ch. 6 (23a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill reads lots of books",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Bill reads lots of books",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["arg", "erg"],
+      ["arg", "abs"],
+      ["subject", "erg"]
+    ],
+    "comment": "The object is absolutive but not contactive: no 'intimate contact'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/AndersonJM2006.lean
+++ b/Linglib/Data/Examples/AndersonJM2006.lean
@@ -1,0 +1,198 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `AndersonJM2006` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/AndersonJM2006.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace AndersonJM2006.Examples`.
+-/
+
+namespace AndersonJM2006.Examples
+
+open Data.Examples
+
+def ex_39a : LinguisticExample :=
+  { id := "andersonjm2006_39a"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill read the book"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill read the book"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "erg"), ("arg", "abs"), ("subject", "erg")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39b : LinguisticExample :=
+  { id := "andersonjm2006_39b"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill fell to the ground"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill fell to the ground"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs"), ("arg", "loc"), ("subject", "abs")]
+    comment := "The locative carries the second-order feature {goal}; the subject is not inherently ergative."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39c : LinguisticExample :=
+  { id := "andersonjm2006_39c"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill flew to China"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill flew to China"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs,erg"), ("arg", "loc"), ("subject", "abs,erg")]
+    comment := "The locative carries {goal}."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39h : LinguisticExample :=
+  { id := "andersonjm2006_39h"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39h)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill knew the answer"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill knew the answer"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "erg,loc"), ("arg", "abs"), ("subject", "erg,loc")]
+    comment := "E (Experiencer) = erg,loc."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39i : LinguisticExample :=
+  { id := "andersonjm2006_39i"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39i)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill acquired a new shirt"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill acquired a new shirt"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "erg,loc"), ("arg", "abs"), ("subject", "erg,loc")]
+    comment := "Experiencer with {goal} on its locative component: erg,loc{goal} + abs. Also 'a new outlook'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39j : LinguisticExample :=
+  { id := "andersonjm2006_39j"
+    source := ⟨"anderson-jm-2006", "ch. 6 (39j)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill suffered from asthma"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill suffered from asthma"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs,erg,loc"), ("arg", "loc"), ("subject", "abs,erg,loc")]
+    comment := "E + abl = abs,erg,loc{goal} + loc{src}. Also 'from delusions'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_34 : LinguisticExample :=
+  { id := "andersonjm2006_34"
+    source := ⟨"anderson-jm-2006", "ch. 6 (34)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Phil suffered (from asthma)"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Phil suffered (from asthma)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs,erg,loc"), ("arg", "loc"), ("subject", "abs,erg,loc")]
+    comment := "A patient that is at once Experiencer and contactive: all three first-order features combine on one argument; the ablative is loc{src}."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4_8a : LinguisticExample :=
+  { id := "andersonjm2006_4_8a"
+    source := ⟨"anderson-jm-2006", "ch. 6 (4.8a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Sewage flooded into the tank"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Sewage flooded into the tank"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs"), ("arg", "loc"), ("subject", "abs")]
+    comment := "The simple absolutive is subject; the other argument does not combine locative with absolutive."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4_8b : LinguisticExample :=
+  { id := "andersonjm2006_4_8b"
+    source := ⟨"anderson-jm-2006", "ch. 6 (4.8b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The tank flooded with sewage"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The tank flooded with sewage"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "abs,loc"), ("arg", "abs"), ("subject", "abs,loc")]
+    comment := "Under (38) with its optional comma the complex absolutive abs,loc takes precedence over the simple one; under (38)′ the with-phrase is an adjunct outside subject selection."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23a : LinguisticExample :=
+  { id := "andersonjm2006_23a"
+    source := ⟨"anderson-jm-2006", "ch. 6 (23a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill reads lots of books"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bill reads lots of books"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("arg", "erg"), ("arg", "abs"), ("subject", "erg")]
+    comment := "The object is absolutive but not contactive: no 'intimate contact'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_39a, ex_39b, ex_39c, ex_39h, ex_39i, ex_39j, ex_34, ex_4_8a, ex_4_8b, ex_23a]
+
+end AndersonJM2006.Examples

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -1,520 +1,175 @@
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Finset.Lattice.Fold
-import Mathlib.Data.Finset.Powerset
-import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
-import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.ArgumentStructure.Linking
-import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Semantics.ArgumentStructure.VerbDenotation
+import Linglib.Data.Examples.AndersonJM2006
+import Mathlib.Data.List.MinMax
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Anderson (2006): Modern Grammars of Case [anderson-jm-2006]
+# Anderson 2006: localist case grammar
 
-[anderson-jm-2006] "Modern Grammars of Case: A Retrospective" (OUP)
-develops localist case grammar (LCG), where all semantic relations decompose
-into combinations of three first-order case features: absolutive (abs),
-source/ergative (src), and locative (loc).
+Every semantic relation an argument bears is a bundle of the three first-order case features
+of chapter 6's (11) — absolutive, the semantically empty relation; source, whose
+non-locational form is the ergative; and locative, which may carry source or goal as a
+second-order feature — and all eight combinations occur: the Experiencer is a locative
+source, the contactive patient an absolutive locative (22), and *suffer*'s subject bears all
+three (34). Subject selection ranks ergative above ergative absolutive above absolutive
+((38)′), so only a non-spatial source or an absolutive can be subject, and subject formation
+(40) then marks a selected absolutive as ergative — the neutralization behind subjecthood.
 
-## Anderson's system (Ch. 6, eq. 11)
+`Relation` is a bundle of `Feature`s, `subjectRank` the hierarchy (38)′, `subject` the
+selected argument of a `Predication`, and `subjectFormation` rule (40). `subjects_39` are the
+derivations of (39), `fell_subject_not_src` the one whose subject is ergative only by (40),
+and `rows_subject_selection` runs the hierarchy over the book's examples. `andersonLinking`
+casts the hierarchy as a `LinkingTheory`, with `Relation.toRole` the hom onto the
+project's role labels; the second-order features {goal} and {src} are not represented.
 
-The four simple case relations are:
-- **abs** (∅): the semantically empty base — holistic participant
-- **source/erg** ({src}): first-order source — agent, causer
-- **loc** ({loc}): place/location
-- **abl** ({loc, src²}): second-order source subordinated to loc
+## References
 
-Arguments bear COMBINATIONS of first-order features to define complex
-roles (§6.2–6.3):
-- Agent = src alone ("Bill read the book", eq. 39a)
-- Experiencer = src + loc ("Bill knew the answer", eq. 39h)
-- Contactive/patient = abs + loc (eq. 22)
-- Self-mover = abs + src ("Bill flew to China", eq. 39c)
-
-## Subject selection (eq. 38')
-
-Anderson directly states: **erg > abs**. The argument with first-order
-source becomes subject. If no argument has source, the absolutive
-becomes subject. The hierarchy is NOT derived from feature cardinality.
-
-Subject formation (eq. 40): absolutive ⇒ absolutive{erg}. When an
-absolutive is selected as subject, it acquires the erg feature.
-
-## Improvement over the two-feature model
-
-Our earlier formalization incorrectly used only two features (abs, erg)
-and collapsed experiencer with agent as {abs, erg}. Anderson's actual
-system DISTINGUISHES them: agent = {src}, experiencer = {src, loc}.
-Both have src (so both can be subjects), but they differ in the loc
-feature. The third feature (loc) is essential to Anderson's theory.
-
-## Costs
-
-The three-feature system collapses some Fragment distinctions:
-- {src} collapses **agent**, **source**, **instrument**, **stimulus**
-- {abs} collapses **patient** and **theme**
-But it correctly distinguishes experiencer from agent (unlike the
-two-feature simplification).
+* [anderson-jm-2006]
 -/
 
 namespace AndersonJM2006
 
-open ArgumentStructure.Linking (LinkingTheory GrammaticalFunction)
-open ArgumentStructure
-open English.Predicates.Verbal
+open ArgumentStructure Data.Examples
 
--- ============================================================================
--- § 0: Anderson's Case Features — Substrate
--- ============================================================================
+/-! ### Case features and relations -/
 
-/-! Three first-order case features `[abs, src, loc]`, the 8 case relations
-that arise as their feature bundles, the subject-selection hierarchy over
-those bundles, predicate scenarios (argument-structure tuples of relations),
-and the morphological-case → relation map. Originally landed as standalone
-substrate in `Features/Case/Basic.lean`; inlined here because only this
-study consumes it. -/
-
-/-- Anderson's three first-order case features (Ch. 6). -/
-inductive CaseFeature where
+/-- The three first-order case features (11). -/
+inductive Feature
   | abs
   | src
   | loc
-  deriving DecidableEq, Repr, Fintype
+  deriving DecidableEq, Fintype
 
-/-- An argument's case specification: a bundle of first-order features (Ch. 6).
+/-- A semantic relation is a bundle of first-order features; the eight combinations all
+occur (§6.2). -/
+abbrev Relation := Finset Feature
 
-    A `CaseRelation` is a `Finset CaseFeature` — the powerset of the three
-    primitive features. The 8 possible bundles are exactly `Finset.powerset`
-    of `Finset.univ`. Containment (`⊆`), the empty bundle (`∅`), the full
-    bundle (`Finset.univ`), and meet/join are inherited from `Finset`'s
-    `BooleanAlgebra` instance. -/
-abbrev CaseRelation := Finset CaseFeature
+namespace Relation
 
-namespace CaseRelation
+/-- The semantically empty relation. -/
+abbrev absolutive : Relation := {.abs}
 
-@[reducible] def neutral    : CaseRelation := ∅
-@[reducible] def absolutive : CaseRelation := {.abs}
-@[reducible] def ergative   : CaseRelation := {.src}
-@[reducible] def locative   : CaseRelation := {.loc}
-@[reducible] def srcAbs     : CaseRelation := {.abs, .src}
-@[reducible] def srcLoc     : CaseRelation := {.src, .loc}
-@[reducible] def absLoc     : CaseRelation := {.abs, .loc}
-@[reducible] def absSrcLoc  : CaseRelation := {.abs, .src, .loc}
+/-- Non-locational source. -/
+abbrev ergative : Relation := {.src}
 
-/-- The full feature set is `Finset.univ` and equals the 3-feature top. -/
-theorem absSrcLoc_eq_univ :
-    absSrcLoc = (Finset.univ : Finset CaseFeature) := by decide
+abbrev locative : Relation := {.loc}
 
-/-- Convenience accessors for the three features. -/
-@[reducible] def abs (cr : CaseRelation) : Prop := .abs ∈ cr
-@[reducible] def src (cr : CaseRelation) : Prop := .src ∈ cr
-@[reducible] def loc (cr : CaseRelation) : Prop := .loc ∈ cr
+/-- The self-mover of (39c). -/
+abbrev ergAbs : Relation := {.abs, .src}
 
-end CaseRelation
+/-- The Experiencer, a locative source (39h). -/
+abbrev experiencer : Relation := {.src, .loc}
 
-/-- The subject selection rank (eq. 38').
-    src (agent) outranks abs (patient) outranks loc (spatial).
+/-- The contactive patient (22). -/
+abbrev contactive : Relation := {.abs, .loc}
 
-    Codomain `Fin 3` — three tiers, type-level boundedness. -/
-def CaseRelation.subjectRank (cr : CaseRelation) : Fin 3 :=
-  if .src ∈ cr then 2 else if .abs ∈ cr then 1 else 0
+/-- The hom onto the project's role labels: a locative source is an experiencer, any other
+source an agent, a sourceless absolutive a patient. -/
+def toRole (r : Relation) : Option ThetaRole :=
+  if .src ∈ r then (if .loc ∈ r then some .experiencer else some .agent)
+  else if .abs ∈ r then some .patient else none
 
-/-- The `src` feature alone determines subject rank 2 — regardless of other
-    features. This is why ergative, experiencer (srcLoc), and self-mover
-    (srcAbs) all tie for highest subject rank. -/
-theorem src_determines_subject_rank (cr : CaseRelation) (h : .src ∈ cr) :
-    cr.subjectRank = 2 := by simp [CaseRelation.subjectRank, h]
+end Relation
 
-/-- Without `src`, the `abs` feature determines rank 1. This is why
-    absolutive and contactive (absLoc) tie at the second tier. -/
-theorem abs_without_src_rank (cr : CaseRelation)
-    (h1 : .src ∉ cr) (h2 : .abs ∈ cr) :
-    cr.subjectRank = 1 := by simp [CaseRelation.subjectRank, h1, h2]
+/-! ### Subject selection and subject formation -/
 
-/-- Anderson's `absSrcLoc` is the top of the feature lattice. -/
-theorem absSrcLoc_is_top (cr : CaseRelation) :
-    cr ⊆ CaseRelation.absSrcLoc := by
-  rw [CaseRelation.absSrcLoc_eq_univ]; exact Finset.subset_univ cr
+/-- The subject selection hierarchy (38)′: ergative > ergative absolutive > absolutive; a
+purely spatial argument is ineligible, and the locative feature is irrelevant. -/
+def subjectRank (r : Relation) : ℕ :=
+  if .src ∈ r then (if .abs ∈ r then 2 else 3) else if .abs ∈ r then 1 else 0
 
-/-- Anderson's `neutral` (the empty bundle) is the bottom of the feature
-    lattice. -/
-theorem neutral_is_bottom (cr : CaseRelation) : CaseRelation.neutral ⊆ cr :=
-  Finset.empty_subset cr
-
-/-- The 8 possible case relations are exactly
-    `(Finset.univ : Finset CaseFeature).powerset`.
-    Cardinality follows from `Finset.card_powerset`. -/
-theorem CaseRelation.card_all :
-    (Finset.univ : Finset CaseFeature).powerset.card = 8 := by decide
-
-/-- A predicate's **scenario** (Ch. 6): the case relations assigned to its
-    arguments. -/
-structure Scenario where
-  relations : List CaseRelation
-
-def Scenario.arity (s : Scenario) : Nat := s.relations.length
-
-def Scenario.subjectRelation (s : Scenario) : Option CaseRelation :=
-  s.relations.head?
-
-def Scenario.objectRelation (s : Scenario) : Option CaseRelation :=
-  match s.relations with
-  | _ :: cr :: _ => some cr
-  | _ => none
-
-def Scenario.transitive   : Scenario := ⟨[.ergative, .absolutive]⟩
-def Scenario.unergative   : Scenario := ⟨[.ergative]⟩
-def Scenario.unaccusative : Scenario := ⟨[.absolutive, .locative]⟩
-def Scenario.selfMoving   : Scenario := ⟨[.srcAbs, .locative]⟩
-def Scenario.experiencer  : Scenario := ⟨[.srcLoc, .absolutive]⟩
-
-theorem transitive_subject_object :
-    Scenario.transitive.subjectRelation = some .ergative ∧
-    Scenario.transitive.objectRelation = some .absolutive := ⟨rfl, rfl⟩
-
-theorem unergative_subject_only :
-    Scenario.unergative.subjectRelation = some .ergative ∧
-    Scenario.unergative.objectRelation = none := ⟨rfl, rfl⟩
-
-theorem unaccusative_subject_loc :
-    Scenario.unaccusative.subjectRelation = some .absolutive ∧
-    Scenario.unaccusative.objectRelation = some .locative := ⟨rfl, rfl⟩
-
-theorem selfMoving_subject :
-    Scenario.selfMoving.subjectRelation = some .srcAbs ∧
-    Scenario.selfMoving.objectRelation = some .locative := ⟨rfl, rfl⟩
-
-theorem experiencer_subject_object :
-    Scenario.experiencer.subjectRelation = some .srcLoc ∧
-    Scenario.experiencer.objectRelation = some .absolutive := ⟨rfl, rfl⟩
-
-theorem transitive_subject_outranks_object :
-    CaseRelation.ergative.subjectRank > CaseRelation.absolutive.subjectRank := by
+theorem subjectRank_ergative_gt_ergAbs : subjectRank .ergAbs < subjectRank .ergative := by
   decide
 
-theorem unergative_unaccusative_differ :
-    Scenario.unergative.subjectRelation ≠
-    Scenario.unaccusative.subjectRelation := by decide
+theorem subjectRank_ergAbs_gt_absolutive :
+    subjectRank .absolutive < subjectRank .ergAbs := by decide
 
-end AndersonJM2006
+theorem subjectRank_insert_loc (r : Relation) : subjectRank (insert .loc r) = subjectRank r := by
+  simp [subjectRank]
 
-/-! Anderson's `Case → CaseRelation` map lives under `namespace Syntax` so
-it can be invoked via dot-notation on `c : Case` (mirroring how
-`Case.hierarchyRank` and the Caha containment defs project onto
-the type). -/
-/-- Canonical mapping from Blake's morphological cases to Anderson's
-    case-feature bundles (Ch. 6). -/
-def Case.toCaseRelation : Case → Option AndersonJM2006.CaseRelation
-  | .nom  => some .srcAbs
-  | .acc  => some .absolutive
-  | .erg  => some .srcAbs
-  | .abs  => some .absolutive
-  | .abl  => some .locative
-  | .loc  => some .locative
-  | .inst => some .ergative
-  | _     => none
+/-- The Experiencer and the ergative differ in content but not in rank. -/
+theorem experiencer_ne_ergative :
+    Relation.experiencer ≠ Relation.ergative ∧
+      subjectRank .experiencer = subjectRank .ergative := by decide
 
-theorem Case.nom_erg_same_relation :
-    Case.toCaseRelation .nom = Case.toCaseRelation .erg := rfl
+/-- The relations of a predication's arguments. -/
+abbrev Predication := List Relation
 
-theorem Case.acc_abs_same_relation :
-    Case.toCaseRelation .acc = Case.toCaseRelation .abs := rfl
+/-- The selected subject: the highest-ranked argument. -/
+def subject (p : Predication) : Option Relation := p.argmax subjectRank
 
-namespace AndersonJM2006
+/-- Subject formation (40): the selected argument acquires the ergative feature. -/
+def subjectFormation (r : Relation) : Relation := insert .src r
 
-open ArgumentStructure
-open ArgumentStructure.Linking (LinkingTheory GrammaticalFunction)
-open English.Predicates.Verbal
+/-- Subject marks a non-spatial source, inherent or derived by (40). -/
+theorem src_mem_subjectFormation (r : Relation) : .src ∈ subjectFormation r :=
+  Finset.mem_insert_self _ _
 
--- ============================================================================
--- § 1: Mappings Between Case Relations and Theta Roles
--- ============================================================================
+/-- An inherent source is untouched by (40): the neutralization leaves the residue the
+ergative subjects have in common. -/
+theorem subjectFormation_eq_self {r : Relation} (h : .src ∈ r) : subjectFormation r = r :=
+  Finset.insert_eq_of_mem h
 
-/-- Anderson's canonical mapping from case-feature bundles to theta roles.
+/-! ### The derivations of (39) -/
 
-    The three-feature system makes finer distinctions than the old
-    two-feature version: experiencer ({src, loc}) is now SEPARATE from
-    agent ({src}). -/
-def CaseRelation.canonicalTheta (cr : CaseRelation) : Option ThetaRole :=
-  if CaseFeature.src ∈ cr then
-    if CaseFeature.loc ∈ cr then some .experiencer  -- srcLoc, absSrcLoc
-    else some .agent                                 -- ergative, srcAbs
-  else if CaseFeature.abs ∈ cr then some .patient   -- absolutive, absLoc
-  else none                                          -- neutral, locative
+def read : Predication := [.ergative, .absolutive]
 
-/-- Reverse mapping: from the Fragment's 8-role inventory to Anderson's
-    case relations.
+def fell : Predication := [.absolutive, .locative]
 
-    Key differences from the old two-feature mapping:
-    - experiencer → srcLoc (was absErg, same as agent)
-    - agent → ergative (was absErg, conflated with experiencer)
-    - goal → locative (spatial goal = loc{goal})
+def flew : Predication := [.ergAbs, .locative]
 
-    The many-to-one collapses that remain:
-    - agent, source, instrument, stimulus → ergative {src}
-    - patient, theme → absolutive {abs} -/
-def thetaToCaseRelation : ThetaRole → CaseRelation
-  | .agent       => .ergative    -- src: non-locational source of action
-  | .experiencer => .srcLoc      -- src + loc: locative source (E = erg,loc)
-  | .patient     => .absolutive  -- abs: affected entity
-  | .theme       => .absolutive  -- abs: entity in motion/state
-  | .goal        => .locative    -- loc: spatial goal (loc{goal} in full system)
-  | .source      => .ergative    -- src: source (Anderson unifies with agent)
-  | .instrument  => .ergative    -- src: source of force
-  | .stimulus    => .ergative    -- src: cause of experience
+def knew : Predication := [.experiencer, .absolutive]
 
--- ============================================================================
--- § 2: Anderson's Derivations (eq. 39)
--- ============================================================================
+def suffered : Predication := [{.abs, .src, .loc}, .locative]
 
-/-! Anderson's derivations from Chapter 6 (eq. 39) show how the
-three-feature system assigns case relations to English verb arguments.
-For each verb, the subject is the argument with the highest subjectRank. -/
+theorem subjects_39 :
+    subject read = some .ergative ∧ subject fell = some .absolutive ∧
+      subject flew = some .ergAbs ∧ subject knew = some .experiencer ∧
+      subject suffered = some {.abs, .src, .loc} := by decide
 
-/-- Eq. 39a: "Bill read the book" — erg + abs.
-    Agent (src, rank 2) + patient (abs, rank 1). Agent is subject. -/
-theorem read_derivation :
-    let agent := CaseRelation.ergative
-    let patient := CaseRelation.absolutive
-    agent.subjectRank > patient.subjectRank := by decide
+/-- (39b) is the odd one out: its subject is not inherently ergative and is assimilated to the
+others only by (40). -/
+theorem fell_subject_not_src :
+    ∀ r ∈ (subject fell).toList, .src ∉ r ∧ .src ∈ subjectFormation r := by decide
 
-/-- Eq. 39b: "Bill fell to the ground" — abs + loc{goal}.
-    Theme (abs, rank 1) + locative goal (loc, rank 0). Theme is subject. -/
-theorem fell_derivation :
-    let theme := CaseRelation.absolutive
-    let goal := CaseRelation.locative
-    theme.subjectRank > goal.subjectRank := by decide
+/-! ### The book's examples -/
 
-/-- Eq. 39c: "Bill flew to China" — abs,erg + loc{goal}.
-    Self-mover (abs+src, rank 2) + goal (loc, rank 0). Self-mover is subject. -/
-theorem flew_derivation :
-    let selfMover := CaseRelation.srcAbs
-    let goal := CaseRelation.locative
-    selfMover.subjectRank > goal.subjectRank := by decide
+/-- The relation strings of the example rows. -/
+def Relation.ofString? : String → Option Relation
+  | "abs" => some .absolutive
+  | "erg" => some .ergative
+  | "loc" => some .locative
+  | "abs,erg" => some .ergAbs
+  | "erg,loc" => some .experiencer
+  | "abs,loc" => some .contactive
+  | "abs,erg,loc" => some {.abs, .src, .loc}
+  | _ => none
 
-/-- Eq. 39h: "Bill knew the answer" — E + abs = erg,loc + abs.
-    Experiencer (src+loc, rank 2) + stimulus (abs, rank 1).
-    Experiencer is subject because it has src. -/
-theorem knew_derivation :
-    let experiencer := CaseRelation.srcLoc
-    let stimulus := CaseRelation.absolutive
-    experiencer.subjectRank > stimulus.subjectRank := by decide
+/-- The predication a row records. -/
+def predicationOfRow (r : LinguisticExample) : Predication :=
+  r.paperFeatures.filterMap fun kv => if kv.1 = "arg" then Relation.ofString? kv.2 else none
 
-/-- Anderson's key distinction: experiencer ≠ agent in feature content,
-    but BOTH outrank absolutive. Agent = {src}, experiencer = {src, loc}.
-    The loc feature distinguishes them without affecting subject selection. -/
-theorem experiencer_agent_distinct_same_rank :
-    CaseRelation.srcLoc ≠ CaseRelation.ergative ∧
-    CaseRelation.srcLoc.subjectRank = CaseRelation.ergative.subjectRank := by
-  exact ⟨by decide, rfl⟩
+/-- Across the book's examples, the subject is the argument the hierarchy (38)′ selects — except
+(4.8b), whose complex absolutive outranks the simple one only under (38)'s optional comma. -/
+theorem rows_subject_selection :
+    ∀ r ∈ Examples.all, r.id ≠ "andersonjm2006_4_8b" →
+      subject (predicationOfRow r) = (r.feature? "subject").bind Relation.ofString? := by
+  decide +kernel
 
--- ============================================================================
--- § 3: Verb → Scenario (End-to-End Bridge)
--- ============================================================================
+/-! ### As a linking theory -/
 
-/-- Derive Anderson's `Scenario` from a Fragment verb entry's derived roles
-    (`Verb.subjectRole`/`objectRole`, the canonical theta-grid). -/
-def toScenario (v : Verb) : Scenario :=
-  ⟨(v.subjectRole |>.map thetaToCaseRelation).toList ++
-   (v.objectRole |>.map thetaToCaseRelation).toList⟩
+open Linking in
+/-- Anderson's subject selection as a linking theory over predications: the subject's role is
+the label of the selected relation; the theory is silent on other functions. -/
+def andersonLinking : LinkingTheory Predication Unit where
+  compatible _ := [()]
+  predict p _ pos := match pos with
+    | .subject => (subject p).bind Relation.toRole
+    | _ => none
 
--- ============================================================================
--- § 4: Anderson as LinkingTheory
--- ============================================================================
-
-/-- Anderson's case grammar as a `LinkingTheory` ([anderson-jm-2006]).
-    The verb type is `Scenario`, the context is `Unit` (lexicalist: linking
-    is derived entirely from case-relation rank, no structural input). -/
-def andersonLinking : LinkingTheory Scenario Unit where
-  compatible := λ _ => [()]
-  predict := λ scenario () pos =>
-    match pos with
-    | .subject      => scenario.subjectRelation.bind CaseRelation.canonicalTheta
-    | .directObject => scenario.objectRelation.bind CaseRelation.canonicalTheta
-    | _             => none
-
-/-- Anderson's predicted subject theta role for a verb entry. -/
-def andersonPredictedSubjectTheta (v : Verb) : Option ThetaRole :=
-  andersonLinking.predict (toScenario v) () .subject
-
--- ============================================================================
--- § 5: Linking Predictions — Canonical Verb Types
--- ============================================================================
-
-/-- Anderson correctly predicts argument linking for the canonical
-    verb types, including experiencer (which the old two-feature model
-    collapsed with agent). -/
-theorem anderson_canonical_linking :
-    andersonLinking.predict .transitive () .subject = some .agent ∧
-    andersonLinking.predict .transitive () .directObject = some .patient ∧
-    andersonLinking.predict .unergative () .subject = some .agent ∧
-    andersonLinking.predict .unaccusative () .subject = some .patient ∧
-    andersonLinking.predict .experiencer () .subject = some .experiencer ∧
-    andersonLinking.predict .experiencer () .directObject = some .patient :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- The three-feature system correctly predicts experiencer as subject,
-    which the old two-feature system collapsed into agent. -/
-theorem experiencer_correctly_predicted :
-    andersonLinking.predict .experiencer () .subject = some .experiencer := rfl
-
--- ============================================================================
--- § 6: Linking Accuracy Against the Fragment Lexicon
--- ============================================================================
-
-/-- Anderson's prediction is defined iff the verb's derived subject role
-    maps to a src/abs-bearing case relation. Want-class subjects fall
-    outside that coverage: their [dowty-1991]-honest profile is bare
-    independent existence ((29e), the `desire` class template), whose role
-    label `goal` maps to locative {loc} — a case relation `canonicalTheta`
-    cannot link to subject. For every other verb, prediction definedness
-    tracks role definedness exactly. -/
-theorem anderson_linking_accuracy :
-    (allVerbs.filter λ v =>
-      (andersonPredictedSubjectTheta v.toVerb).isSome ==
-      ((v.toVerb.subjectRole).isSome &&
-        v.toVerb.subjectRole != some .goal)).length = allVerbs.length := by
-  native_decide
-
-/-- The coverage gap is non-vacuous: *want* has a derived subject role
-    (goal, from the desire-class IE-only profile) but no Anderson subject
-    prediction. -/
-theorem want_outside_anderson_coverage :
-    English.Predicates.Verbal.want.toVerb.subjectRole = some .goal ∧
-    andersonPredictedSubjectTheta English.Predicates.Verbal.want.toVerb
-      = none := by
-  refine ⟨by native_decide, by native_decide⟩
-
--- ============================================================================
--- § 7: Role Collapses — What Anderson's Three-Feature System Costs
--- ============================================================================
-
-/-! The three-feature system collapses fewer roles than the old
-two-feature model. Experiencer is now correctly distinguished from
-agent. The remaining collapses are:
-- {src} collapses agent with source, instrument, and stimulus
-- {abs} collapses patient with theme -/
-
--- § 7a: {abs} collapses patient and theme
-
-/-- Patient and theme both map to {abs}, but [dowty-1991] distinguishes
-    them: patient has 3 P-Patient entailments, theme has only 1. -/
-theorem patient_theme_collapse :
-    thetaToCaseRelation .patient = thetaToCaseRelation .theme ∧
-    (ThetaRole.canonicalProfile .patient).pPatientScore = 3 ∧
-    (ThetaRole.canonicalProfile .theme).pPatientScore = 1 := by
-  exact ⟨rfl, by native_decide, by native_decide⟩
-
--- § 7b: {src} collapses agent, source, instrument, stimulus
-
-/-- Agent, source, instrument, and stimulus all map to {src}. -/
-theorem src_collapses :
-    thetaToCaseRelation .agent = thetaToCaseRelation .source ∧
-    thetaToCaseRelation .agent = thetaToCaseRelation .instrument ∧
-    thetaToCaseRelation .agent = thetaToCaseRelation .stimulus := ⟨rfl, rfl, rfl⟩
-
--- § 7c: Experiencer is NOW correctly distinguished
-
-/-- The three-feature system correctly separates experiencer from agent.
-    This is the key improvement over the old two-feature formalization. -/
-theorem experiencer_distinguished :
-    thetaToCaseRelation .agent ≠ thetaToCaseRelation .experiencer := by decide
-
-/-- Experiencer subject verbs are now correctly predicted as experiencer,
-    not collapsed into agent (for verbs with entailment profiles). -/
-theorem experiencer_verbs_correct :
-    (allVerbs.filter λ v =>
-      (v.toVerb.subjectRole) == some .experiencer ∧
-      andersonPredictedSubjectTheta v.toVerb == some .experiencer).length =
-    (allVerbs.filter λ v =>
-      (v.toVerb.subjectRole) == some .experiencer).length := by
-  native_decide
-
--- ============================================================================
--- § 8: Bridge to Blake's Hierarchy
--- ============================================================================
-
-/-- Anderson and Blake are concordant on the core case ordering.
-    Blake: NOM(6) ≥ ACC(6). Anderson: NOM/src+abs outranks ACC/abs
-    (subjectRank 2 > 1). Both are inverse to Caha's containment
-    hierarchy. -/
-theorem anderson_blake_concordant :
-    Case.hierarchyRank .nom ≥ Case.hierarchyRank .acc ∧
-    CaseRelation.srcAbs.subjectRank > CaseRelation.absolutive.subjectRank ∧
-    Case.hierarchyRank .nom = Case.hierarchyRank .acc ∧
-    CaseRelation.srcAbs.subjectRank ≠ CaseRelation.absolutive.subjectRank := by
-  exact ⟨by decide, by decide, rfl, by decide⟩
-
--- ============================================================================
--- § 9: Localist Hypothesis — Spatial Cases Share {loc}
--- ============================================================================
-
-/-- Does a morphological case carry the spatial locative feature?
-    ABL, LOC both map to {loc} — they share the locative feature
-    because they involve spatial location. -/
-def HasSpatialLoc : Case → Prop
-  | .abl  => True
-  | .loc  => True
-  | _     => False
-
-instance : DecidablePred HasSpatialLoc := fun c => by
-  cases c <;> unfold HasSpatialLoc <;> infer_instance
-
-/-- ABL and LOC both map to Anderson's locative case relation. -/
-theorem spatial_cases_are_locative :
-    Case.toCaseRelation .abl = some .locative ∧
-    Case.toCaseRelation .loc = some .locative := ⟨rfl, rfl⟩
-
-/-- INST maps to {src} (source of force), not {loc}. Anderson argues
-    that instrumental is the same semantic relation as agent: both are
-    sources of action. -/
-theorem inst_is_ergative :
-    Case.toCaseRelation .inst = some .ergative := rfl
-
-/-- ABL and LOC share a case relation AND have an extension path
-    between them. Anderson's explanation: a case marker conditioned
-    on {loc} is polysemous across spatial functions. -/
-theorem abl_loc_share_feature :
-    Case.toCaseRelation .abl = Case.toCaseRelation .loc := rfl
-
--- ============================================================================
--- § 10: NOM/ERG and ACC/ABS Unification
--- ============================================================================
-
-/-- Accusative and ergative alignment are different morphological labels
-    for the same two case relations:
-    NOM = ERG = src+abs,  ACC = ABS = abs.
-    The case relations are identical; alignment is labeling. -/
-theorem alignment_is_labeling :
-    Case.toCaseRelation .nom = Case.toCaseRelation .erg ∧
-    Case.toCaseRelation .acc = Case.toCaseRelation .abs ∧
-    Case.toCaseRelation .nom ≠ Case.toCaseRelation .acc := by
-  exact ⟨rfl, rfl, by decide⟩
-
--- ============================================================================
--- § 11: Bridge to Dowty's Proto-Roles
--- ============================================================================
-
-/-- Anderson and Dowty agree on transitive linking despite completely
-    different primitives (features vs entailment profiles). -/
-theorem anderson_dowty_transitive_agree :
-    CaseRelation.canonicalTheta .ergative = some .agent ∧
-    CaseRelation.canonicalTheta .absolutive = some .patient ∧
-    OutranksForSubject
-      (ThetaRole.canonicalProfile .agent)
-      (ThetaRole.canonicalProfile .patient) := by
-  exact ⟨rfl, rfl, by decide⟩
-
-/-- The three-feature system improves on the old two-feature version
-    for the experiencer case: Anderson distinguishes experiencer from
-    agent (via loc), as does Dowty (different P-Agent entailment count). -/
-theorem anderson_dowty_experiencer_agree :
-    -- Anderson: different case relations
-    thetaToCaseRelation .agent ≠ thetaToCaseRelation .experiencer ∧
-    -- Dowty: different entailment profiles
-    (ThetaRole.canonicalProfile .agent).pAgentScore >
-    (ThetaRole.canonicalProfile .experiencer).pAgentScore := by
-  exact ⟨by decide, by native_decide⟩
+theorem andersonLinking_subjects :
+    andersonLinking.predict read () .subject = some .agent ∧
+      andersonLinking.predict fell () .subject = some .patient ∧
+      andersonLinking.predict knew () .subject = some .experiencer := by decide
 
 end AndersonJM2006

--- a/references.bib
+++ b/references.bib
@@ -6769,7 +6769,7 @@
   subfield  = {syntax/case},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/AndersonJM2006.lean}
+  sources   = {Studies/AndersonJM2006.lean;Data/Examples/AndersonJM2006.json}
 }% REF: Anderson, G. D. S. (2006). Auxiliary Verb Constructions. OUP. §1.7.2.
 @book{anderson-2006,
   author    = {Anderson, Gregory D. S.},


### PR DESCRIPTION
Recut of the localist case grammar study on the book's own statements: relations as bundles of the three first-order features (11), the subject selection hierarchy (38)′ (ergative > ergative absolutive > absolutive — the old file tied the first two), subject formation (40), the derivations of (39) with `fell` as the subject assimilated only by (40), and 10 example rows with `rows_subject_selection`.

- Cuts the editorial Blake and Dowty bridges, the morphological-case map, the Fragment-verb `native_decide` count theorems, and the edit-history prose about an earlier two-feature version.