### PR TITLE
refactor(Studies/Ariel2001): criteria and factors from the chapter

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2985,3 +2985,4 @@ import Linglib.Data.Examples.Alsop2024
 import Linglib.Data.Examples.AnandHacquard2013
 import Linglib.Data.Examples.AnandHardtMcCloskey2021
 import Linglib.Data.Examples.Anderson2006b
+import Linglib.Data.Examples.Ariel2001

--- a/Linglib/Data/Examples/Ariel2001.json
+++ b/Linglib/Data/Examples/Ariel2001.json
@@ -1,0 +1,244 @@
+[
+  {
+    "id": "ariel2001_1",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(1)"},
+    "language": "stan1293",
+    "primaryText": "Melissa: Well, I'll say awakened, cause that's what I have written. Ron: (Sniff). Frank: Just watch, He'll put a note by it – note by that. I really like that word Melissa.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["marker", "proxDem"],
+      ["marker", "unstressedPron"],
+      ["marker", "distalDem"],
+      ["marker", "distalDemNP"]
+    ],
+    "comment": "Household corpus. The word awakened is referred to by that, it, that, and that word.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_3",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "In the complaint the woman claimed that on May 2, ∅ met Roter … Then the two demanded from her to have sex with them. According to her, when ∅ refused, Roter started punching her …",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["source", "Haaretz"],
+      ["perspective", "victim"],
+      ["victim", "zero"],
+      ["rapists", "lastName"]
+    ],
+    "comment": "Haaretz, 17 May 1995; the paper prints its English rendering. In the second sentence the victim is coded by zero and the rapist by a proper name.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_4",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(4)"},
+    "language": "hebr1245",
+    "primaryText": "According to the police, Roter and the rape victim met in the beginning of May … and at a certain point ∅ asked the rape victim to have sex with them. This one refused, and as a result, the two cruelly raped her …",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["source", "Maariv"],
+      ["perspective", "rapists"],
+      ["victim", "proxDem"],
+      ["rapists", "zero"]
+    ],
+    "comment": "Maariv, 17 May 1995; the paper prints its English rendering. In the second sentence the rapists are coded by zero and the victim by a demonstrative pronoun.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_5",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(5)"},
+    "language": "hebr1245",
+    "primaryText": "But I insisted then. A person devoted two months and a half, ∅ built a whole program, ∅ took care of a budget, it is not as if Minister Katzav gave me, I took care, I went …",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["speaker", "self"]
+    ],
+    "comment": "Mudai, TV interview, 2 November 1998 (Mulokandov and Rieder 1998). The speaker refers to himself by first-person forms and by third-person generic forms.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_6",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(6)"},
+    "language": "stan1293",
+    "primaryText": "In the garden, I saw a young girl kicking a tree. I looked at them for a while.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["antecedent", "girl and tree"],
+      ["marker", "unstressedPron"]
+    ],
+    "comment": "Sanford and Moxey's example: the second sentence is marked ? although both entities are highly accessible.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_7",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(7)"},
+    "language": "stan1293",
+    "primaryText": "Morris: We broke a STRING, Or HE broke a string",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["marker", "stressedPron"]
+    ],
+    "comment": "TV interview with Yo Yo Ma and Mark Morris, Israeli TV, 9 July 1998.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_8a",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(8a)"},
+    "language": "hebr1245",
+    "primaryText": "Arafat invited Kadafi to pray in Jerusalem, when it will be the Palestinian capital",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["position", "headline"],
+      ["marker", "lastName"],
+      ["marker", "lastName"],
+      ["marker", "fullName"],
+      ["marker", "unstressedPron"]
+    ],
+    "comment": "Haaretz, 14 July 1998, headline; the paper prints its English rendering. Markers in order: Arafat, Kadafi, Jerusalem, it.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_8b",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(8b)"},
+    "language": "hebr1245",
+    "primaryText": "The Palestinian authority chair, Yassir Arafat, invited the Lybian leader, Muamar Kadafi, to pray in Eastern Jerusalem, when this one will become the capital of the Palestinian state",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["position", "opening sentence"],
+      ["marker", "fullNameMod"],
+      ["marker", "fullNameMod"],
+      ["marker", "fullNameMod"],
+      ["marker", "proxDem"]
+    ],
+    "comment": "Haaretz, 14 July 1998, opening sentence; the paper prints its English rendering. Markers in order, matching (8a).",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_9",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(9)"},
+    "language": "stan1293",
+    "primaryText": "Frankly, I'm torn my own self as to which way to raise hell",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["marker", "stressedPron"]
+    ],
+    "comment": "Clark Reed, quoted in The International Herald Tribune, 2–3 January 1999: a pronoun lengthened by self.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_10",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(10)"},
+    "language": "stan1293",
+    "primaryText": "REBECCA: put the newspaper on his lap, RICKIE: Yeah, REBECCA: masturbated, and then lifted the paper up, RICKIE: Yeah, REBECCA: for her to see",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "the paper coreferent with the newspaper", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["marker", "shortDefDescription"],
+      ["marker", "shortDefDescription"]
+    ],
+    "comment": "Jury corpus. The shorter description the paper resumes the newspaper; no disjoint reading arises.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_12",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "(12)"},
+    "language": "hebr1245",
+    "primaryText": "It is not as if he looks like a hippie really, or anything like that. … Feil's grey-brown hair … covers his collar from behind. But one day in 93' the officer in charge of him demanded from him to have a haircut … The officer accused him …",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["topicMarker", "unstressedPron"],
+      ["subjectMarker", "shortDefDescription"]
+    ],
+    "comment": "Haaretz, 21 January 1999; the paper prints its English rendering. The discourse topic (officer Feil) is pronominal although the higher officer is the subject of two consecutive clauses.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ariel2001_maya_rachel",
+    "source": {"bibkey": "ariel-2001", "paperLabel": "§1.2"},
+    "language": "stan1293",
+    "primaryText": "Maya kissed Rachel. And then she/SHE …",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "she = Maya", "judgment": "acceptable"},
+      {"name": "SHE = Rachel", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["maya", "unstressedPron"],
+      ["rachel", "stressedPron"]
+    ],
+    "comment": "The first-mentioned, topical but more distant Maya is later coded by an unstressed pronoun; the more recent, non-topical Rachel by a stressed pronoun.",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Ariel2001.lean
+++ b/Linglib/Data/Examples/Ariel2001.lean
@@ -1,0 +1,234 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Ariel2001` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Ariel2001.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Ariel2001.Examples`.
+-/
+
+namespace Ariel2001.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "ariel2001_1"
+    source := ⟨"ariel-2001", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Melissa: Well, I'll say awakened, cause that's what I have written. Ron: (Sniff). Frank: Just watch, He'll put a note by it – note by that. I really like that word Melissa."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("marker", "proxDem"), ("marker", "unstressedPron"), ("marker", "distalDem"), ("marker", "distalDemNP")]
+    comment := "Household corpus. The word awakened is referred to by that, it, that, and that word."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_3 : LinguisticExample :=
+  { id := "ariel2001_3"
+    source := ⟨"ariel-2001", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "In the complaint the woman claimed that on May 2, ∅ met Roter … Then the two demanded from her to have sex with them. According to her, when ∅ refused, Roter started punching her …"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("source", "Haaretz"), ("perspective", "victim"), ("victim", "zero"), ("rapists", "lastName")]
+    comment := "Haaretz, 17 May 1995; the paper prints its English rendering. In the second sentence the victim is coded by zero and the rapist by a proper name."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4 : LinguisticExample :=
+  { id := "ariel2001_4"
+    source := ⟨"ariel-2001", "(4)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "According to the police, Roter and the rape victim met in the beginning of May … and at a certain point ∅ asked the rape victim to have sex with them. This one refused, and as a result, the two cruelly raped her …"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("source", "Maariv"), ("perspective", "rapists"), ("victim", "proxDem"), ("rapists", "zero")]
+    comment := "Maariv, 17 May 1995; the paper prints its English rendering. In the second sentence the rapists are coded by zero and the victim by a demonstrative pronoun."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5 : LinguisticExample :=
+  { id := "ariel2001_5"
+    source := ⟨"ariel-2001", "(5)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "But I insisted then. A person devoted two months and a half, ∅ built a whole program, ∅ took care of a budget, it is not as if Minister Katzav gave me, I took care, I went …"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("speaker", "self")]
+    comment := "Mudai, TV interview, 2 November 1998 (Mulokandov and Rieder 1998). The speaker refers to himself by first-person forms and by third-person generic forms."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_6 : LinguisticExample :=
+  { id := "ariel2001_6"
+    source := ⟨"ariel-2001", "(6)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "In the garden, I saw a young girl kicking a tree. I looked at them for a while."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("antecedent", "girl and tree"), ("marker", "unstressedPron")]
+    comment := "Sanford and Moxey's example: the second sentence is marked ? although both entities are highly accessible."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_7 : LinguisticExample :=
+  { id := "ariel2001_7"
+    source := ⟨"ariel-2001", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Morris: We broke a STRING, Or HE broke a string"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("marker", "stressedPron")]
+    comment := "TV interview with Yo Yo Ma and Mark Morris, Israeli TV, 9 July 1998."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_8a : LinguisticExample :=
+  { id := "ariel2001_8a"
+    source := ⟨"ariel-2001", "(8a)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "Arafat invited Kadafi to pray in Jerusalem, when it will be the Palestinian capital"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("position", "headline"), ("marker", "lastName"), ("marker", "lastName"), ("marker", "fullName"), ("marker", "unstressedPron")]
+    comment := "Haaretz, 14 July 1998, headline; the paper prints its English rendering. Markers in order: Arafat, Kadafi, Jerusalem, it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_8b : LinguisticExample :=
+  { id := "ariel2001_8b"
+    source := ⟨"ariel-2001", "(8b)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "The Palestinian authority chair, Yassir Arafat, invited the Lybian leader, Muamar Kadafi, to pray in Eastern Jerusalem, when this one will become the capital of the Palestinian state"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("position", "opening sentence"), ("marker", "fullNameMod"), ("marker", "fullNameMod"), ("marker", "fullNameMod"), ("marker", "proxDem")]
+    comment := "Haaretz, 14 July 1998, opening sentence; the paper prints its English rendering. Markers in order, matching (8a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_9 : LinguisticExample :=
+  { id := "ariel2001_9"
+    source := ⟨"ariel-2001", "(9)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Frankly, I'm torn my own self as to which way to raise hell"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("marker", "stressedPron")]
+    comment := "Clark Reed, quoted in The International Herald Tribune, 2–3 January 1999: a pronoun lengthened by self."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_10 : LinguisticExample :=
+  { id := "ariel2001_10"
+    source := ⟨"ariel-2001", "(10)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "REBECCA: put the newspaper on his lap, RICKIE: Yeah, REBECCA: masturbated, and then lifted the paper up, RICKIE: Yeah, REBECCA: for her to see"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("the paper coreferent with the newspaper", .acceptable)]
+    paperFeatures := [("marker", "shortDefDescription"), ("marker", "shortDefDescription")]
+    comment := "Jury corpus. The shorter description the paper resumes the newspaper; no disjoint reading arises."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_12 : LinguisticExample :=
+  { id := "ariel2001_12"
+    source := ⟨"ariel-2001", "(12)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "It is not as if he looks like a hippie really, or anything like that. … Feil's grey-brown hair … covers his collar from behind. But one day in 93' the officer in charge of him demanded from him to have a haircut … The officer accused him …"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("topicMarker", "unstressedPron"), ("subjectMarker", "shortDefDescription")]
+    comment := "Haaretz, 21 January 1999; the paper prints its English rendering. The discourse topic (officer Feil) is pronominal although the higher officer is the subject of two consecutive clauses."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def maya_rachel : LinguisticExample :=
+  { id := "ariel2001_maya_rachel"
+    source := ⟨"ariel-2001", "§1.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Maya kissed Rachel. And then she/SHE …"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("she = Maya", .acceptable), ("SHE = Rachel", .acceptable)]
+    paperFeatures := [("maya", "unstressedPron"), ("rachel", "stressedPron")]
+    comment := "The first-mentioned, topical but more distant Maya is later coded by an unstressed pronoun; the more recent, non-topical Rachel by a stressed pronoun."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1, ex_3, ex_4, ex_5, ex_6, ex_7, ex_8a, ex_8b, ex_9, ex_10, ex_12, maya_rachel]
+
+end Ariel2001.Examples

--- a/Linglib/Discourse/Accessibility.lean
+++ b/Linglib/Discourse/Accessibility.lean
@@ -1,5 +1,4 @@
 import Linglib.Features.Givenness
-import Linglib.Features.Prominence
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -7,23 +6,14 @@ import Mathlib.Tactic.DeriveFintype
 
 `AccessibilityLevel`: the 18-tier Accessibility Marking Scale of [ariel-1990],
 reproduced in [ariel-2001]'s overview (least accessible `fullNameMod` to most
-accessible `zero`), with `rank` (and the `LinearOrder` it induces), the three
-form-function criteria (`informativity`, `rigidity`, `attenuation`), the
-coarsening `toDefinitenessLevel` to `Prominence.DefinitenessLevel`, and the
-form-correlate bridge `GivennessStatus.toAccessibility`.
-
-Accessibility and definiteness are **non-monotonically** related (full
-names are less accessible than definite descriptions, yet first/last names
-are more accessible; names are also more prominent for DOM), so they are
-separate types and `toDefinitenessLevel` is many-to-one and non-monotone.
+accessible `zero`), with `rank` (and the `LinearOrder` it induces) and the
+three form-function criteria (`informativity`, `rigidity`, `attenuation`).
 
 Sibling of `Features/Givenness.lean` (GHZ-6): this classifies *forms*,
 `GivennessStatus` classifies *entities*. Also here: `NextMentionBias`.
 -/
 
 namespace Discourse
-
-open Features.Prominence (DefinitenessLevel)
 
 /-! ### Accessibility marking scale -/
 
@@ -145,20 +135,6 @@ def AccessibilityLevel.attenuation : AccessibilityLevel → Nat
   | .verbalAgreement                                  => 4
   | .zero                                             => 5
 
-/-! ### Definiteness coarsening -/
-
-/-- Coarsening: each accessibility level maps to one of the 5
-    `DefinitenessLevel` categories used for differential argument marking.
-    This is a many-to-one, **non-monotone** mapping — names are less
-    accessible than definite descriptions but more prominent for DOM. -/
-def AccessibilityLevel.toDefinitenessLevel : AccessibilityLevel → DefinitenessLevel
-  | .fullNameMod | .fullName | .lastName | .firstName  => .properName
-  | .longDefDescription | .shortDefDescription
-  | .distalDemMod | .proxDemMod | .distalDemNP
-  | .proxDemNP | .distalDem | .proxDem                 => .definite
-  | .stressedPronGesture | .stressedPron | .unstressedPron
-  | .cliticizedPron | .verbalAgreement | .zero          => .personalPronoun
-
 /-! ### Next-mention bias -/
 
 /-- Next-mention bias: how likely a discourse referent is to be
@@ -181,25 +157,5 @@ inductive NextMentionBias where
 def NextMentionBias.predictedForm : NextMentionBias → AccessibilityLevel
   | .high => .unstressedPron
   | .low  => .fullName
-
-/-! ### Givenness projection -/
-
-/-- Prototypical accessibility level for each givenness status. The four
-    definite rows are [gundel-hedberg-zacharski-1993]'s own form correlates
-    (unstressed pronoun, bare demonstrative, demonstrative NP, definite
-    description); the two **indefinite** statuses (`referential` =
-    "indefinite this N", `typeIdentifiable` = "a N") have no form on the
-    accessibility scale, so their rows are editorial rank-alignment, not
-    form identity. [ariel-2001] criticizes the givenness hierarchy (no
-    evidence for scalar distinctions below its top statuses) rather than
-    endorsing such a projection. -/
-def _root_.Features.GivennessStatus.toAccessibility :
-    Features.GivennessStatus → AccessibilityLevel
-  | .inFocus              => .unstressedPron
-  | .activated            => .proxDem
-  | .familiar             => .distalDemNP
-  | .uniquelyIdentifiable => .shortDefDescription
-  | .referential          => .longDefDescription
-  | .typeIdentifiable     => .fullNameMod
 
 end Discourse

--- a/Linglib/Features/Givenness.lean
+++ b/Linglib/Features/Givenness.lean
@@ -22,8 +22,8 @@ categorical view of givenness.
   A-givenness = `isAGiven` in `Studies/KratzerSelkirk2020.lean`);
   a consumer meaning another axis (e.g. discourse-status) should say so.
 
-Sibling GHZ-6 coarsenings/scales: Ariel's 18-tier
-`Features.AccessibilityLevel` (`toAccessibility`) and Centering's
+Sibling GHZ-6 scales: Ariel's 18-tier
+`Discourse.AccessibilityLevel` and Centering's
 [strube-hahn-1999] `StrubeHahnInfoStatus.ofGivenness` (its `mediated`
 tier drawn from `uniquelyIdentifiable`/`referential`). [ariel-2001]
 argues AccessibilityLevel is better grounded — the lower GHZ tiers lack

--- a/Linglib/Studies/Ariel2001.lean
+++ b/Linglib/Studies/Ariel2001.lean
@@ -1,239 +1,304 @@
 import Linglib.Discourse.Accessibility
-import Linglib.Syntax.Category.Pronoun.Basic
-import Linglib.Features.Givenness
+import Linglib.Discourse.Centering.Pronominalization
+import Linglib.Data.Examples.Ariel2001
 
 /-!
-# [ariel-2001]
-[gundel-hedberg-zacharski-1993] [cardinaletti-starke-1999]
+# Ariel 2001: accessibility theory
 
-Accessibility Theory: An Overview. In Sanders, Schilperoord & Spooren (eds.),
-*Text Representation: Linguistic and Psycholinguistic Aspects*, 29–87.
-John Benjamins.
+Referring expressions are accessibility markers: each codes a degree of mental accessibility
+of the representation the addressee is to retrieve, and the eighteen classes of the
+Accessibility Marking Scale run from full name with modifier down to zero. The scale is
+motivated by three partially overlapping criteria — informativity, rigidity, and
+attenuation — each anti-correlated with the accessibility a form codes. The accessibility of
+a representation is a composite of the antecedent's salience (discourse topics, speaker and
+addressee, frame-induced entities), competition among antecedents, distance, and the unity
+between antecedent and anaphor; no single factor decides, as when a topical but distant
+antecedent takes the higher marker over a recent non-topical one. Against the rival
+theories, the Givenness Hierarchy maps many forms of distinct accessibility to one status
+and one form to several, and Centering's pronoun rule is silent on lexical anaphors, so it
+does not predict the repeated-name penalty.
 
-## Core Theory
+## Main definitions
 
-Referential form choice is governed by the **degree of accessibility** of the
-mental representation the speaker intends the addressee to retrieve. More
-accessible representations license more reduced referring expressions.
-Accessibility is gradient (not categorical) and is assessed via a composite
-of multiple factors.
+* `head`, `modified`, `lexical`, `full`, `deixis`, `stressed`, `bound`: the form features
+  the scale's labels name.
+* `Factors`: the accessibility factors, with `Factors.Dominates` the factor-wise comparison.
+* `givenness`: the Givenness Hierarchy statuses of the scale's forms, as the paper reports
+  them.
 
-## The Accessibility Marking Scale
+## References
 
-The 18-level `AccessibilityLevel` type and its three form-function criteria
-(informativity, rigidity, attenuation) live in `Discourse/Accessibility.lean`.
-This study file adds the multi-factor accessibility assessment and
-comparisons with competing theories.
-
-## Form-Function Criteria
-
-The ordering is motivated by three partially overlapping criteria, all
-anti-correlated with accessibility degree:
-
-1. **Informativity**: amount of lexical content (more → lower accessibility)
-2. **Rigidity**: ability to uniquely pick out a referent from form alone
-   (proper names are rigid designators; descriptions are context-dependent)
-3. **Attenuation**: phonological reduction (more reduced → higher accessibility)
-
-## Non-Equivalence with `DefinitenessLevel`
-
-The 5-level `DefinitenessLevel` scale (used for DOM/DSM in `Features.Prominence`)
-is a many-to-one coarsening of the 18-level scale, but the coarsening is
-**not monotone**: proper names are less accessible than definite descriptions
-on Ariel's scale (names are more informative, lower accessibility), but more
-prominent on Aissen's scale (names outrank definites for DOM).
-
-## Competing Theories
-
-Ariel argues accessibility theory subsumes [gundel-hedberg-zacharski-1993]'s
-Givenness Hierarchy (a 6-level coarsening with weaker predictions) and is
-more comprehensive than Centering Theory (which handles only the pronoun/full-NP
-distinction, not the full range of referring expressions).
+* [ariel-2001]
+* [ariel-1990] — the scale and its distributional basis
+* [gundel-hedberg-zacharski-1993] — the Givenness Hierarchy
+* [grosz-joshi-weinstein-1995] — Centering's pronoun rule
 -/
 
 namespace Ariel2001
 
-open Features.Prominence (DefinitenessLevel)
-open Features (GivennessStatus)
-open Discourse
+open Discourse Features Data.Examples
 
--- ════════════════════════════════════════════════════
--- § 1. Form-Function Criteria
--- ════════════════════════════════════════════════════
+/-! ### Form-function criteria (§1.1) -/
 
-/-- The highest-accessibility forms have the lowest informativity. -/
-theorem zero_least_informative :
-    AccessibilityLevel.zero.informativity = 0 ∧
-    AccessibilityLevel.verbalAgreement.informativity = 0 ∧
-    AccessibilityLevel.cliticizedPron.informativity = 0 :=
-  ⟨rfl, rfl, rfl⟩
+/-- The head of a form class on the scale. -/
+inductive Head
+  | name
+  | description
+  | demonstrative
+  | pronoun
+  | inflection
+  | zero
+  deriving DecidableEq, Repr
 
-/-- The highest-accessibility forms have the highest attenuation. -/
-theorem zero_most_attenuated :
-    AccessibilityLevel.zero.attenuation = 5 := rfl
+/-- Demonstrative deixis. -/
+inductive Deixis
+  | distal
+  | proximate
+  deriving DecidableEq, Repr
 
-/-- The three form-function criteria all correlate with accessibility
-    in the predicted direction at the extremes of the scale:
-    - Least accessible (fullNameMod): max informativity, max rigidity, min attenuation
-    - Most accessible (zero): min informativity, min rigidity, max attenuation -/
-theorem criteria_correlate_at_extremes :
-    AccessibilityLevel.fullNameMod.informativity = 4 ∧
-    AccessibilityLevel.fullNameMod.rigidity = 2 ∧
-    AccessibilityLevel.fullNameMod.attenuation = 0 ∧
-    AccessibilityLevel.zero.informativity = 0 ∧
-    AccessibilityLevel.zero.rigidity = 0 ∧
-    AccessibilityLevel.zero.attenuation = 5 :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-- The head named by a scale label. -/
+def head : AccessibilityLevel → Head
+  | .fullNameMod | .fullName | .lastName | .firstName => .name
+  | .longDefDescription | .shortDefDescription => .description
+  | .distalDemMod | .proxDemMod | .distalDemNP | .proxDemNP | .distalDem | .proxDem =>
+    .demonstrative
+  | .stressedPronGesture | .stressedPron | .unstressedPron | .cliticizedPron => .pronoun
+  | .verbalAgreement => .inflection
+  | .zero => .zero
 
-/-- Names are rigid but low-accessibility; pronouns are non-rigid but
-    high-accessibility. This is the rigidity–accessibility anti-correlation. -/
-theorem names_rigid_pronouns_not :
-    AccessibilityLevel.fullName.rigidity > AccessibilityLevel.unstressedPron.rigidity ∧
-    AccessibilityLevel.fullName.rank < AccessibilityLevel.unstressedPron.rank := by
+/-- A modifier, or the long form of a description. -/
+def modified : AccessibilityLevel → Bool
+  | .fullNameMod | .longDefDescription | .distalDemMod | .proxDemMod => true
+  | _ => false
+
+/-- Lexical content beyond the head: a noun or a name. -/
+def lexical : AccessibilityLevel → Bool
+  | .fullNameMod | .fullName | .lastName | .firstName | .longDefDescription
+  | .shortDefDescription | .distalDemMod | .proxDemMod | .distalDemNP | .proxDemNP => true
+  | _ => false
+
+/-- A full rather than partial name. -/
+def full : AccessibilityLevel → Bool
+  | .fullNameMod | .fullName => true
+  | _ => false
+
+/-- The deixis of a demonstrative form. -/
+def deixis : AccessibilityLevel → Option Deixis
+  | .distalDemMod | .distalDemNP | .distalDem => some .distal
+  | .proxDemMod | .proxDemNP | .proxDem => some .proximate
+  | _ => none
+
+/-- A stressed pronoun. -/
+def stressed : AccessibilityLevel → Bool
+  | .stressedPronGesture | .stressedPron => true
+  | _ => false
+
+/-- A bound pronominal: cliticized, or verbal agreement. -/
+def bound : AccessibilityLevel → Bool
+  | .cliticizedPron | .verbalAgreement => true
+  | _ => false
+
+/-- Informativity: a modifier lowers the accessibility a form codes. -/
+theorem informativity_modifier :
+    ∀ a b : AccessibilityLevel, head a = head b → deixis a = deixis b →
+      modified a → ¬ modified b → a < b := by
   decide
 
--- ════════════════════════════════════════════════════
--- § 2. Accessibility Factors
--- ════════════════════════════════════════════════════
-
-/-- Factors contributing to degree of accessibility of a discourse referent.
-    Accessibility is a composite of all four; no single factor suffices. -/
-structure AccessibilityAssessment where
-  /-- Clauses since last mention (0 = same clause). Lower → higher accessibility. -/
-  distance : Nat
-  /-- Discourse salience. 0=non-topic, 1=local topic, 2=global topic. -/
-  topicality : Fin 3
-  /-- Number of competing potential antecedents. Fewer → higher accessibility. -/
-  competition : Nat
-  /-- Syntactic/semantic cohesion. 0=loose (coordination), 1=moderate
-      (subordination), 2=tight (complement). -/
-  unity : Fin 3
-  deriving Repr
-
-/-- Composite accessibility score (simplified additive model).
-    Higher score → higher accessibility → more reduced form predicted. -/
-def AccessibilityAssessment.score (a : AccessibilityAssessment) : Nat :=
-  (a.topicality : Nat) + (a.unity : Nat) + (5 - min a.distance 5) + (3 - min a.competition 3)
-
-def maximallyAccessible : AccessibilityAssessment := ⟨0, 2, 0, 2⟩
-def minimallyAccessible : AccessibilityAssessment := ⟨5, 0, 3, 0⟩
-
-theorem maximal_gt_minimal :
-    maximallyAccessible.score > minimallyAccessible.score := by decide
-
--- ════════════════════════════════════════════════════
--- § 3. Non-Equivalence with DefinitenessLevel
--- ════════════════════════════════════════════════════
-
-/-- The coarsening is NOT monotone: "full name" (accessibility rank 1) maps
-    to properName (definiteness rank 3), but "long definite description"
-    (accessibility rank 2) maps to definite (definiteness rank 2).
-    Higher accessibility maps to LOWER definiteness rank here.
-
-    This proves that Ariel's accessibility scale and Aissen's definiteness
-    scale capture genuinely different orderings: names are less accessible
-    (more informative) but more prominent (higher on the DOM hierarchy). -/
-theorem coarsening_not_monotone :
-    AccessibilityLevel.fullName.rank < AccessibilityLevel.longDefDescription.rank ∧
-    AccessibilityLevel.fullName.toDefinitenessLevel.rank >
-      AccessibilityLevel.longDefDescription.toDefinitenessLevel.rank := by
+/-- Informativity: a demonstrative with a noun codes lower accessibility than a bare one. -/
+theorem informativity_lexical :
+    ∀ a b : AccessibilityLevel, head a = head b → deixis a = deixis b →
+      ¬ modified a → ¬ modified b → lexical a → ¬ lexical b → a < b := by
   decide
 
--- ════════════════════════════════════════════════════
--- § 4. Strength Bridge
--- ════════════════════════════════════════════════════
-
-open Pronoun (Strength)
-
-/-- [cardinaletti-starke-1999]'s three-way pronoun strength maps to
-    positions on the accessibility scale.
-    strong → stressedPron, weak → unstressedPron, clitic → cliticizedPron. -/
-def strengthToAccessibility : Strength → AccessibilityLevel
-  | .strong => .stressedPron
-  | .weak   => .unstressedPron
-  | .clitic => .cliticizedPron
-
-/-- `strengthToAccessibility` is antitone in structural strength: a more
-    deficient pronoun (lower in the deficiency order) marks higher
-    accessibility, so the clitic > weak > strong accessibility ordering
-    follows from the intrinsic deficiency order rather than being restated. -/
-theorem strengthToAccessibility_antitone {a b : Strength}
-    (h : a < b) :
-    (strengthToAccessibility b).rank < (strengthToAccessibility a).rank := by
-  cases a <;> cases b <;> revert h <;> decide
-
-/-- All three pronoun strengths coarsen to the same definiteness level. -/
-theorem strength_coarsening_agrees :
-    (strengthToAccessibility .strong).toDefinitenessLevel = DefinitenessLevel.personalPronoun ∧
-    (strengthToAccessibility .weak).toDefinitenessLevel = DefinitenessLevel.personalPronoun ∧
-    (strengthToAccessibility .clitic).toDefinitenessLevel = DefinitenessLevel.personalPronoun :=
-  ⟨rfl, rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- § 5. Givenness Hierarchy ([gundel-hedberg-zacharski-1993])
--- ════════════════════════════════════════════════════
-
--- `GivennessStatus`, `GivennessStatus.rank`, and the
--- `GivennessStatus.toAccessibility` projection live in the substrate
--- layer (`Features/Givenness.lean`, `Discourse/Accessibility.lean`);
--- the theorems below consume the substrate projection.
-
-/-- The Givenness→Accessibility mapping IS monotone: higher givenness
-    status maps to higher or equal accessibility rank. The Givenness
-    Hierarchy is a well-behaved (but lossy) coarsening of Ariel's scale. -/
-theorem givenness_coarsening_monotone :
-    let all := [GivennessStatus.inFocus, .activated, .familiar,
-                .uniquelyIdentifiable, .referential, .typeIdentifiable]
-    all.all (λ a => all.all (λ b =>
-      if a.rank > b.rank then
-        a.toAccessibility.rank ≥ b.toAccessibility.rank
-      else true)) = true := by decide
-
--- ════════════════════════════════════════════════════
--- § 6. Ariel's Critique: Coarsening Loses Distinctions
--- ════════════════════════════════════════════════════
-
-/-- Four accessibility levels that the Givenness Hierarchy collapses into
-    "in focus" have genuinely different accessibility ranks and different
-    discourse distributions (p. 64). The 6-level hierarchy asks: "How can
-    we distinguish between zeroes and pronouns in a language which uses
-    both as very high accessibility markers... Both must be classified as
-    'in focus' markers, but they each have a distinct distributional
-    pattern." -/
-theorem givenness_collapses_pronominal_distinctions :
-    -- All four are "in focus" on the Givenness Hierarchy (all pronominal)
-    AccessibilityLevel.unstressedPron.toDefinitenessLevel = .personalPronoun ∧
-    AccessibilityLevel.cliticizedPron.toDefinitenessLevel = .personalPronoun ∧
-    AccessibilityLevel.verbalAgreement.toDefinitenessLevel = .personalPronoun ∧
-    AccessibilityLevel.zero.toDefinitenessLevel = .personalPronoun ∧
-    -- Yet they have four distinct accessibility ranks
-    AccessibilityLevel.zero.rank > AccessibilityLevel.verbalAgreement.rank ∧
-    AccessibilityLevel.verbalAgreement.rank > AccessibilityLevel.cliticizedPron.rank ∧
-    AccessibilityLevel.cliticizedPron.rank > AccessibilityLevel.unstressedPron.rank := by
+/-- Informativity: a full name codes lower accessibility than a partial one. -/
+theorem informativity_partial_name :
+    ∀ a b : AccessibilityLevel, head a = .name → head b = .name →
+      ¬ modified a → ¬ modified b → full a → ¬ full b → a < b := by
   decide
 
-/-- Proximate demonstratives code higher accessibility than distal ones.
-    Both are "activated" in the Givenness Hierarchy — the 6-level system
-    cannot capture this contrast. -/
-theorem proximate_more_accessible_than_distal :
-    AccessibilityLevel.proxDem.rank > AccessibilityLevel.distalDem.rank ∧
-    AccessibilityLevel.proxDemNP.rank > AccessibilityLevel.distalDemNP.rank := by
+/-- Rigidity: a full name codes lower accessibility than the description of the same
+length. -/
+theorem rigidity_full_name :
+    ∀ a b : AccessibilityLevel, head a = .name → full a → head b = .description →
+      modified a = modified b → a < b := by
   decide
 
--- ════════════════════════════════════════════════════
--- § 7. Integration: Accessibility ↔ NextMentionBias
--- ════════════════════════════════════════════════════
+/-- The criteria overlap only partially: a partial name is rigid, yet codes higher
+accessibility than a short description. -/
+theorem rigidity_not_sufficient :
+    AccessibilityLevel.shortDefDescription < AccessibilityLevel.lastName := by
+  decide
 
-/-- The `NextMentionBias` prediction directly uses accessibility levels:
-    high bias → unstressed pronoun (high accessibility),
-    low bias → full name (low accessibility). This is the core of
-    [ariel-2001]'s theory: more accessible → more reduced form.
+/-- Attenuation: a stressed pronoun codes lower accessibility than an unstressed one. -/
+theorem attenuation_stress :
+    ∀ a b : AccessibilityLevel, head a = .pronoun → head b = .pronoun →
+      stressed a → ¬ stressed b → a < b := by
+  decide
 
-    The predicted forms are the RIGHT forms, not a coarsened approximation
-    through `DefinitenessLevel`. -/
-theorem predictedForm_uses_accessibility :
-    NextMentionBias.high.predictedForm = .unstressedPron ∧
-    NextMentionBias.low.predictedForm = .fullName :=
-  ⟨rfl, rfl⟩
+/-- Attenuation: a free pronoun codes lower accessibility than a cliticized one, a pronoun
+than verbal agreement, and agreement than zero. -/
+theorem attenuation_reduction :
+    ∀ a b : AccessibilityLevel,
+      (head a = .pronoun ∧ head b = .pronoun ∧ ¬ stressed a ∧ ¬ bound a ∧ bound b) ∨
+        (head a = .pronoun ∧ head b = .inflection) ∨ (head a = .inflection ∧ head b = .zero) →
+      a < b := by
+  decide
+
+/-- The proximate demonstrative codes higher accessibility than the distal one of the same
+shape (§5.1 records Kirsner's Dutch data against this). -/
+theorem deixis_proximate :
+    ∀ a b : AccessibilityLevel, head a = .demonstrative → head b = .demonstrative →
+      modified a = modified b → lexical a = lexical b →
+      deixis a = some .distal → deixis b = some .proximate → a < b := by
+  decide
+
+/-! ### Accessibility as a complex concept (§1.2) -/
+
+/-- The salience of an antecedent by discourse role. -/
+inductive Topicality
+  | nonTopic
+  | localTopic
+  | globalTopic
+  deriving DecidableEq, Repr
+
+/-- Topicality in increasing order. -/
+def Topicality.rank : Topicality → ℕ
+  | .nonTopic => 0
+  | .localTopic => 1
+  | .globalTopic => 2
+
+/-- The factors a degree of accessibility is assessed from: distance since the last mention,
+competing antecedents, topicality, and the unity of antecedent and anaphor. -/
+structure Factors where
+  distance : ℕ
+  competitors : ℕ
+  topicality : Topicality
+  tight : Bool
+  deriving DecidableEq, Repr
+
+/-- `a` is at least as accessible as `b` on every factor. -/
+def Factors.Dominates (a b : Factors) : Prop :=
+  a.distance ≤ b.distance ∧ a.competitors ≤ b.competitors ∧
+    b.topicality.rank ≤ a.topicality.rank ∧ (b.tight → a.tight)
+
+instance (a b : Factors) : Decidable (a.Dominates b) := by unfold Factors.Dominates; infer_instance
+
+/-- *Maya kissed Rachel. And then she/SHE …*: the first-mentioned Maya is topical but more
+distant, Rachel more recent but not topical. -/
+def maya : Factors := ⟨2, 1, .localTopic, false⟩
+
+/-- Rachel's factors in the same example. -/
+def rachel : Factors := ⟨1, 1, .nonTopic, false⟩
+
+/-- Neither antecedent dominates the other: the factors pull apart. -/
+theorem maya_rachel_incomparable : ¬ maya.Dominates rachel ∧ ¬ rachel.Dominates maya := by
+  decide
+
+/-- The scale label of a marker feature. -/
+def ofLabel : String → Option AccessibilityLevel
+  | "fullNameMod" => some .fullNameMod
+  | "fullName" => some .fullName
+  | "longDefDescription" => some .longDefDescription
+  | "shortDefDescription" => some .shortDefDescription
+  | "lastName" => some .lastName
+  | "firstName" => some .firstName
+  | "distalDemMod" => some .distalDemMod
+  | "proxDemMod" => some .proxDemMod
+  | "distalDemNP" => some .distalDemNP
+  | "proxDemNP" => some .proxDemNP
+  | "distalDem" => some .distalDem
+  | "proxDem" => some .proxDem
+  | "stressedPronGesture" => some .stressedPronGesture
+  | "stressedPron" => some .stressedPron
+  | "unstressedPron" => some .unstressedPron
+  | "cliticizedPron" => some .cliticizedPron
+  | "verbalAgreement" => some .verbalAgreement
+  | "zero" => some .zero
+  | _ => none
+
+/-- The marker a row records under a feature. -/
+def marker (r : LinguisticExample) (key : String) : Option AccessibilityLevel :=
+  r.feature? key >>= ofLabel
+
+/-- All the markers a row lists, in order. -/
+def markers (r : LinguisticExample) : List AccessibilityLevel :=
+  r.paperFeatures.filterMap fun p => if p.1 = "marker" then ofLabel p.2 else none
+
+/-- Topicality outranks distance: the topical, more distant Maya takes the higher marker. -/
+theorem rows_topicality_over_distance :
+    ∀ r ∈ Examples.all, ∀ m ∈ (marker r "maya").toList, ∀ c ∈ (marker r "rachel").toList,
+      c < m := by
+  decide +kernel
+
+/-- (3) against (4): the entity whose point of view a newspaper takes is coded by the higher
+marker — the victim by zero and the rapist by a name in Haaretz, the rapists by zero and the
+victim by a demonstrative in Maariv. -/
+theorem rows_perspective :
+    ∀ r ∈ Examples.all, ∀ v ∈ (marker r "victim").toList, ∀ p ∈ (marker r "rapists").toList,
+      (r.feature? "perspective" = some "victim" → p < v) ∧
+        (r.feature? "perspective" = some "rapists" → v < p) := by
+  decide +kernel
+
+/-- (8): every referring expression of the article's opening sentence codes lower
+accessibility than its counterpart in the headline — initial retrievals, but of entities the
+headline has just made accessible. -/
+theorem rows_headline :
+    ∀ a ∈ Examples.all, ∀ b ∈ Examples.all,
+      a.source.paperLabel = "(8a)" → b.source.paperLabel = "(8b)" →
+        ∀ p ∈ (markers a).zip (markers b), p.2 < p.1 := by
+  decide +kernel
+
+/-! ### Competing theories (§4) -/
+
+/-- The Givenness Hierarchy statuses of the scale's forms, as the paper reports them for
+English: the pronominal forms are all *in focus*, *that*, *this*, stressed *IT*, and *this
+N* all *activated*, and a full name *uniquely identifiable* or *familiar*, a partial name
+*familiar* or *activated*. -/
+def givenness : AccessibilityLevel → Finset GivennessStatus
+  | .zero | .verbalAgreement | .cliticizedPron | .unstressedPron => {.inFocus}
+  | .stressedPronGesture | .stressedPron | .proxDem | .distalDem | .proxDemNP
+  | .proxDemMod => {.activated}
+  | .distalDemNP | .distalDemMod => {.familiar}
+  | .longDefDescription | .shortDefDescription => {.uniquelyIdentifiable}
+  | .fullNameMod | .fullName => {.uniquelyIdentifiable, .familiar}
+  | .lastName | .firstName => {.familiar, .activated}
+
+/-- Many forms, one status: four forms of distinct accessibility are all *activated*. -/
+theorem activated_many_forms :
+    (∀ l ∈ [AccessibilityLevel.distalDem, .proxDem, .stressedPron, .proxDemNP],
+      givenness l = {.activated}) ∧
+      ([AccessibilityLevel.distalDem, .proxDem, .stressedPron, .proxDemNP].map
+        AccessibilityLevel.rank).Nodup := by
+  decide
+
+/-- One form, many statuses: a full name is *uniquely identifiable* or *familiar*. -/
+theorem full_name_two_statuses :
+    GivennessStatus.uniquelyIdentifiable ∈ givenness .fullName ∧
+      GivennessStatus.familiar ∈ givenness .fullName := by
+  decide
+
+/-- Zeroes, agreement, cliticized and full pronouns are all *in focus*, though each codes a
+different degree of accessibility and has its own distribution. -/
+theorem in_focus_collapse :
+    (∀ l ∈ [AccessibilityLevel.zero, .verbalAgreement, .cliticizedPron, .unstressedPron],
+      givenness l = {.inFocus}) ∧
+      ([AccessibilityLevel.zero, .verbalAgreement, .cliticizedPron, .unstressedPron].map
+        AccessibilityLevel.rank).Nodup := by
+  decide
+
+open Centering in
+/-- Centering's pronoun rule says nothing when no pronoun is used, so an entity coded by a
+repeated name violates nothing: the repeated-name penalty is not its prediction. -/
+theorem pronominalization_vacuous {E R U : Type*} [CfRankerOf E R] [Realizes U E]
+    [Pronominalizes U E] (prev : Utterance E R) (cur : U) (h : ∀ e, ¬ pronominalizes cur e) :
+    PronominalizationConstraint prev cur :=
+  fun ⟨e, _, he⟩ => absurd he (h e)
+
+/-- (12): the discourse topic is pronominal while the subject of two consecutive clauses is
+a description — the topic, not the local subject, takes the higher marker. -/
+theorem rows_topic_over_subject :
+    ∀ r ∈ Examples.all, ∀ t ∈ (marker r "topicMarker").toList,
+      ∀ s ∈ (marker r "subjectMarker").toList, s < t := by
+  decide +kernel
 
 end Ariel2001

--- a/Linglib/Studies/KwonLee2026.lean
+++ b/Linglib/Studies/KwonLee2026.lean
@@ -4,7 +4,6 @@ import Linglib.Discourse.Centering.Basic
 import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
 import Linglib.Discourse.Accessibility
-import Linglib.Studies.Ariel2001
 import Linglib.Studies.KehlerRohde2013
 import Linglib.Fragments.Korean.Pronouns
 
@@ -24,9 +23,8 @@ holds cross-linguistically while the spread is language-specific.
 `LinearOrder` lifted from `AccessibilityLevel.rank`, so the central
 claim "subject bias increases in accessibility" appears as one
 `StrictMono` lemma (`subjectBias_strictMono`) rather than per-pair
-inequalities. Bridges to [kehler-rohde-2013] (topichood),
-[carminati-2002] (PAH alternative), and Ariel's
-`AccessibilityAssessment` are provided.
+inequalities. Bridges to [kehler-rohde-2013] (topichood) and
+[carminati-2002] (PAH alternative) are provided.
 -/
 
 namespace KwonLee2026
@@ -765,51 +763,6 @@ theorem pah_at_diverge_in_topic_fronting :
 theorem pah_silent_on_fullNP :
     KoreanRefForm.fullNP.pahPosition = none := rfl
 
--- ════════════════════════════════════════════════════
--- § 6c. Bridge to AccessibilityAssessment: What Each Experiment Manipulates
--- ════════════════════════════════════════════════════
-
-open Ariel2001 (AccessibilityAssessment)
-
-/-- Exp 1: a single antecedent in same-clause topic position. Maximally
-    accessible — no competition, tight unity, recently mentioned, topical.
-    Predicts the form should not need to disambiguate. -/
-def exp1_assessment : AccessibilityAssessment := ⟨0, 2, 0, 2⟩
-
-/-- Exp 2 & 3: two antecedents in same clause. Competition = 1 (one
-    additional candidate). The two experiments differ in whether
-    additional cues (gender in Exp 2) disambiguate, but the
-    accessibility-theoretic competition level is identical.
-
-    [ariel-2001]'s `AccessibilityAssessment` does not have a
-    field for "disambiguating cue", which is the gap that the Exp 2
-    naturalness × accuracy correlation (§ 4c) helps fill. -/
-def exp2_3_assessment : AccessibilityAssessment := ⟨0, 2, 1, 2⟩
-
-/-- Distance is held constant across experiments. -/
-theorem exp_distance_constant :
-    exp1_assessment.distance = exp2_3_assessment.distance := rfl
-
-/-- Topicality is held constant. -/
-theorem exp_topicality_constant :
-    exp1_assessment.topicality = exp2_3_assessment.topicality := rfl
-
-/-- Unity is held constant. -/
-theorem exp_unity_constant :
-    exp1_assessment.unity = exp2_3_assessment.unity := rfl
-
-/-- **The manipulation isolates competition**: across the three
-    experiments, only the `competition` field varies; distance, topicality,
-    and unity are held constant. This makes the experimental design a clean
-    test of how competition affects form-function visibility. -/
-theorem exp_competition_increases :
-    exp1_assessment.competition < exp2_3_assessment.competition := by decide
-
-/-- Exp 1 has higher accessibility than Exp 2/3 — the referent is more
-    accessible when there's no competition. -/
-theorem exp1_more_accessible_than_exp23 :
-    exp1_assessment.score > exp2_3_assessment.score := by decide
-
 /-- **Empirical asymmetry consistent with the theory**: in the
     high-accessibility Exp 1 setting (one antecedent), the
     form-function distinction collapses (`exp1_overt_fullNP_close`).
@@ -817,10 +770,8 @@ theorem exp1_more_accessible_than_exp23 :
     distinction emerges as a clean three-way split
     (`accessibility_predicts_subject_bias`).
 
-    This is captured by the assessment-score difference: form-bias
-    strength is *inversely* correlated with the per-referent
-    accessibility score, because forms only need to disambiguate when
-    there is ambiguity to resolve. -/
+    Forms only need to disambiguate when there is ambiguity to
+    resolve. -/
 theorem form_bias_emerges_under_competition :
     -- Exp 1 (high accessibility, no competition): adjacent forms collapse
     exp1_naturalness .fullNP - exp1_naturalness .overt ≤ 1/10 ∧


### PR DESCRIPTION
Ariel2001 recut from the chapter: the three form-function criteria as minimal-pair theorems over the scale via label-derived form features, the accessibility factors with the Maya/Rachel incomparability, the Givenness Hierarchy critique on the paper's own status assignments, Centering's pronoun rule vacuous without pronouns, and 12 rows with point-of-view, headline, and topic checks. The invented additive assessment score, the Aissen coarsening, and the strength bridge are cut.

- Substrate: `AccessibilityLevel.toDefinitenessLevel` and `GivennessStatus.toAccessibility` deleted (no consumers); KwonLee2026 loses its bridge to the assessment score.