### PR TITLE
refactor(Studies/Arka2013): annotations, finiteness, and =nya from the rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -330,6 +330,7 @@ import Linglib.Data.Examples.Anderson2006a
 import Linglib.Data.Examples.Angelopoulos2026
 import Linglib.Data.Examples.Anscombe1964
 import Linglib.Data.Examples.Anttila1997
+import Linglib.Data.Examples.Arka2013
 import Linglib.Data.Examples.ArregiPietraszko2021
 import Linglib.Data.Examples.ArreguiKusumoto1998
 import Linglib.Data.Examples.BeckOdaSugisaki2004
@@ -920,6 +921,7 @@ import Linglib.Fragments.Icelandic.Reciprocals
 import Linglib.Fragments.Icelandic.TemporalConnectives
 import Linglib.Fragments.Icelandic.Verbs
 import Linglib.Fragments.Indonesian.Adposition
+import Linglib.Fragments.Indonesian.Complementation
 import Linglib.Fragments.Indonesian.Morphophonology
 import Linglib.Fragments.Indonesian.Predicates
 import Linglib.Fragments.Indonesian.TAM

--- a/Linglib/Data/Examples/Arka2013.json
+++ b/Linglib/Data/Examples/Arka2013.json
@@ -1,0 +1,1104 @@
+[
+  {
+    "id": "arka2013_3",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(3)"},
+    "language": "indo1316",
+    "primaryText": "Dia datang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["datang", "come"]
+    ],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "S/he came.", "judgment": "acceptable"},
+      {"name": "S/he is coming.", "judgment": "acceptable"},
+      {"name": "S/he will come.", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["tam", "contextual"]
+    ],
+    "comment": "Contextual TAM: the bare verb is anchored by context alone.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_4a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(4a)"},
+    "language": "indo1316",
+    "primaryText": "Dia datang (besok).",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["datang", "come"], ["besok", "tomorrow"]
+    ],
+    "translation": "S/he will come tomorrow.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["frame", "S<E-R"],
+      ["adjunct", "besok"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_4b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(4b)"},
+    "language": "indo1316",
+    "primaryText": "Dia datang (kemarin).",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["datang", "come"], ["kemarin", "yesterday"]
+    ],
+    "translation": "He came in yesterday.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["frame", "E-R<S"],
+      ["adjunct", "kemarin"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_4c",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(4c)"},
+    "language": "indo1316",
+    "primaryText": "Dia datang (sekarang).",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["datang", "come"], ["sekarang", "now"]
+    ],
+    "translation": "She is coming now.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["frame", "E-R-S"],
+      ["adjunct", "sekarang"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_5a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(5a)"},
+    "language": "indo1316",
+    "primaryText": "Dia sudah pergi (sekarang).",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["sudah", "PERF"], ["pergi", "go"], ["sekarang", "now"]
+    ],
+    "translation": "S/he has left (now).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sudah"],
+      ["frame", "E<S,R"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_5b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(5b)"},
+    "language": "indo1316",
+    "primaryText": "Dia sudah pergi kemarin.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["sudah", "PERF"], ["pergi", "go"], ["kemarin", "yesterday"]
+    ],
+    "translation": "S/he (had) already left yesterday.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sudah"],
+      ["frame", "E<R<S"],
+      ["adjunct", "kemarin"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_6a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(6a)"},
+    "language": "indo1316",
+    "primaryText": "Ali (sedang) me-mukul-i kepala=nya sendiri.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ali", "A."], ["sedang", "PROG"], ["me-mukul-i", "AV.hit-I"],
+      ["kepala=nya", "head=3sg.poss"], ["sendiri", "self"]
+    ],
+    "translation": "Ali is beating his own head.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sedang"],
+      ["aspect", "progressive"],
+      ["marking", "applicative -i"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_6b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(6b)"},
+    "language": "indo1316",
+    "primaryText": "Ali (sedang) me-mukul-mukul kepala=nya sendiri.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ali", "Ali"], ["sedang", "PROG"], ["me-mukul-mukul", "AV.hit-RED"],
+      ["kepala=nya", "head=3sg.poss"], ["sendiri", "self"]
+    ],
+    "translation": "Ali is beating his own head.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sedang"],
+      ["aspect", "progressive"],
+      ["marking", "reduplication"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_7",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(7)"},
+    "language": "indo1316",
+    "primaryText": "Ali tidak masuk-masuk ke rumah.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ali", "Ali"], ["tidak", "NEG"], ["masuk-masuk", "enter-RED"], ["ke", "to"],
+      ["rumah", "house"]
+    ],
+    "translation": "Ali didn't enter the house (while he's expected to do so).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["marking", "reduplication"],
+      ["meaning", "unrealised expectation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_8",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(8)"},
+    "language": "indo1316",
+    "primaryText": "Dia makan sambil menonton TV.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["makan", "eat"], ["sambil", "while"], ["menonton", "AV.watch"], ["TV", "TV"]
+    ],
+    "translation": "He was/is eating while watching TV.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aspect", "progressive"],
+      ["tam", "contextual"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_10",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(10)"},
+    "language": "indo1316",
+    "primaryText": "Mereka (akan) datang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mereka", "3p"], ["akan", "FUT"], ["datang", "come"]
+    ],
+    "translation": "They will come.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "akan"],
+      ["frame", "S<E-R"],
+      ["withAux", "acceptable"],
+      ["clause", "root"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_11a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(11a)"},
+    "language": "indo1316",
+    "primaryText": "Mereka ingin [datang besok].",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mereka", "3p"], ["ingin", "want"], ["datang", "come"], ["besok", "tomorrow"]
+    ],
+    "translation": "They want to come tomorrow.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Mereka ingin [akan datang besok].", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "ungrammatical"],
+      ["matrix", "ingin"]
+    ],
+    "comment": "(11b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_11c",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(11c)"},
+    "language": "indo1316",
+    "primaryText": "Saya tahu [bahwa mereka akan datang].",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Saya", "1s"], ["tahu", "know"], ["bahwa", "that"], ["mereka", "3p"], ["akan", "FUT"],
+      ["datang", "come"]
+    ],
+    "translation": "I know that they will come.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "akan"],
+      ["withAux", "acceptable"],
+      ["matrix", "tahu"],
+      ["subordinator", "bahwa"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_12a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(12a)"},
+    "language": "indo1316",
+    "primaryText": "Dia akan/sudah/sedang makan.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["akan/sudah/sedang", "FUT/PERF/PROG"], ["makan", "eat"]
+    ],
+    "translation": "S/he will eat/has eaten/is eating.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "acceptable"],
+      ["clause", "root"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_12b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(12b)"},
+    "language": "indo1316",
+    "primaryText": "Saya menyuruh dia [makan].",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Saya", "1s"], ["menyuruh", "AV.ask"], ["dia", "3s"], ["makan", "eat"]
+    ],
+    "translation": "I asked him to eat.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Saya menyuruh dia [akan/sudah/sedang makan].", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "ungrammatical"],
+      ["matrix", "menyuruh"]
+    ],
+    "comment": "(12c) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_13a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(13a)"},
+    "language": "indo1316",
+    "primaryText": "Orang itu mendorong saya [ _ jatuh].",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Orang", "person"], ["itu", "that"], ["mendorong", "AV.push"], ["saya", "1s"],
+      ["jatuh", "fall"]
+    ],
+    "translation": "The person pushed me (and as a result I) fell off.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Orang itu medorong saya [ _ akan/sedang/sudah jatuh].", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "ungrammatical"],
+      ["matrix", "mendorong"]
+    ],
+    "comment": "(13b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_14a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(14a)"},
+    "language": "indo1316",
+    "primaryText": "Dia datang (sambil) menangis.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["datang", "come"], ["sambil", "while"], ["menangis", "AV.cry"]
+    ],
+    "translation": "S/he came while crying.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Dia datang [(sambil) sedang menangis].", "judgment": "questionable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "questionable"],
+      ["adjunct", "sambil"]
+    ],
+    "comment": "(14b) is marked ?*.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_15a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(15a)"},
+    "language": "indo1316",
+    "primaryText": "Saya belajar [menembak].",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Saya", "1s"], ["belajar", "study"], ["menembak", "AV.shoot"]
+    ],
+    "translation": "I'm learning to shoot.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Saya belajar bisa [menembak].", "judgment": "questionable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "questionable"],
+      ["matrix", "belajar"]
+    ],
+    "comment": "(15b) is marked ?*.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_15c",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(15c)"},
+    "language": "indo1316",
+    "primaryText": "Saya belajar agar (bisa) menembak.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Saya", "1s"], ["belajar", "study"], ["agar", "so.that"], ["bisa", "able"],
+      ["menembak", "AV.shoot"]
+    ],
+    "translation": "I am learning so that I can shoot.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["withAux", "acceptable"],
+      ["subordinator", "agar"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_18a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(18a)"},
+    "language": "indo1316",
+    "primaryText": "...di jalan banyak sapi yang sedang memakan rumput.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["di", "at"], ["jalan", "road"], ["banyak", "plenty"], ["sapi", "cow"], ["yang", "REL"],
+      ["sedang", "PROG"], ["memakan", "AV.eat"], ["rumput", "grass"]
+    ],
+    "translation": "...along the way many cows that eat grass.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sedang"],
+      ["voice", "AV"]
+    ],
+    "comment": "Google-attested; the actor voice verb with sedang.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_18b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(18b)"},
+    "language": "indo1316",
+    "primaryText": "Dari salah satu swalayan, petugas menemukan makanan jenis roti yang kemasan dan isi=nya telah rusak dan diduga sudah dimakan tikus.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "In one of the supermarkets, the officers found kind of bread/biscuits in boxes whose packages had been tampered and contents were already eaten by mice.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "sudah"],
+      ["voice", "passive"]
+    ],
+    "comment": "Google-attested; the passive verb with sudah.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arka2013_34a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(34a)"},
+    "language": "indo1316",
+    "primaryText": "'Siapa itu?', tanya=nya.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Siapa", "who"], ["itu", "that"], ["tanya=nya", "ask=NYA"]
+    ],
+    "translation": "'Who is that?', he asked.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "'Siapa itu?' akan tanyanya (nanti).", "judgment": "ungrammatical"}
+    ],
+    "readings": [
+      {"name": "he asked", "judgment": "acceptable"},
+      {"name": "he will ask", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["nominalised", "true"],
+      ["axis", "past"],
+      ["predicate", "nominal"],
+      ["withAux", "ungrammatical"]
+    ],
+    "comment": "(34c) is the starred alternative: the nominalised verb takes no auxiliary.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_34b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(34b)"},
+    "language": "indo1316",
+    "primaryText": "'Siapa itu?', tanya=nya nanti.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Siapa", "who"], ["itu", "that"], ["tanya=nya", "ask=NYA"], ["nanti", "later"]
+    ],
+    "translation": "'Who is that?', he will ask later.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["nominalised", "true"],
+      ["axis", "future"],
+      ["adjunct", "nanti"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_34d",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(34d)"},
+    "language": "indo1316",
+    "primaryText": "'Siapa itu?', dia akan (ber)tanya (nanti).",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Siapa", "who"], ["itu", "that"], ["dia", "3"], ["akan", "FUT"], ["(ber)tanya", "BER-ask"],
+      ["nanti", "later"]
+    ],
+    "translation": "'Who is that?', he will ask later.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "akan"],
+      ["withAux", "acceptable"],
+      ["clause", "root"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_35a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(35a)"},
+    "language": "indo1316",
+    "primaryText": "Kapan beli=nya?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kapan", "when"], ["beli=nya", "buy=NYA"]
+    ],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "kapan akan beli=nya?", "judgment": "ungrammatical"}
+    ],
+    "readings": [
+      {"name": "When did you buy it?", "judgment": "acceptable"},
+      {"name": "When are you going to buy it?", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["nominalised", "true"],
+      ["axis", "past"],
+      ["predicate", "nominal"],
+      ["withAux", "ungrammatical"]
+    ],
+    "comment": "(35b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_35c",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(35c)"},
+    "language": "indo1316",
+    "primaryText": "Kapan kamu akan beli?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kapan", "when"], ["kamu", "2s"], ["akan", "FUT"], ["beli", "buy"]
+    ],
+    "translation": "When will you buy?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "akan"],
+      ["withAux", "acceptable"],
+      ["clause", "root"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_36a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(36a)"},
+    "language": "indo1316",
+    "primaryText": "Kapan lahirnya?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kapan", "when"], ["lahir=nya", "birth=3s"]
+    ],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Kapan akan lahirnya?", "judgment": "ungrammatical"}
+    ],
+    "readings": [
+      {"name": "When was s/he born?", "judgment": "acceptable"},
+      {"name": "When is s/he going to be born?", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["nominalised", "true"],
+      ["axis", "past"],
+      ["predicate", "nominal"],
+      ["withAux", "ungrammatical"]
+    ],
+    "comment": "(36b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_36c",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(36c)"},
+    "language": "indo1316",
+    "primaryText": "Kapan ia akan lahir?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kapan", "when"], ["ia", "3s"], ["akan", "FUT"], ["lahir", "birth"]
+    ],
+    "translation": "When will s/he be born?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["aux", "akan"],
+      ["withAux", "acceptable"],
+      ["clause", "root"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_37a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(37a)"},
+    "language": "indo1316",
+    "primaryText": "kamu harus datang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kamu", "2"], ["harus", "must"], ["datang", "come"]
+    ],
+    "translation": "You should come.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "harus"],
+      ["nominalised", "false"],
+      ["soa", "future"],
+      ["evaluation", "deontic"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_37b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(37b)"},
+    "language": "indo1316",
+    "primaryText": "harus=nya kamu datang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["harus=nya", "must=NYA"], ["kamu", "2"], ["datang", "come"]
+    ],
+    "translation": "You should have come.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "harus"],
+      ["nominalised", "true"],
+      ["soa", "past"],
+      ["evaluation", "counterfactual"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_38a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(38a)"},
+    "language": "indo1316",
+    "primaryText": "Ia bisa menangis",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ia", "she"], ["bisa", "can"], ["menangis", "cry"]
+    ],
+    "translation": "S/he can cry.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "bisa"],
+      ["nominalised", "false"],
+      ["soa", "future"],
+      ["evaluation", "epistemic"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_38b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(38b)"},
+    "language": "indo1316",
+    "primaryText": "bisa=nya menangis",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["bisa=nya", "can=3s"], ["menangis", "cry"]
+    ],
+    "translation": "Crying was/is the thing s/he could do.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "bisa"],
+      ["nominalised", "true"],
+      ["soa", "past"],
+      ["evaluation", "past ability"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_39a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(39a)"},
+    "language": "indo1316",
+    "primaryText": "Ia mau pulang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ia", "3s"], ["mau", "wish"], ["pulang", "go.home"]
+    ],
+    "translation": "S/he wants/wanted to go home.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "mau"],
+      ["nominalised", "false"],
+      ["soa", "future"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_39b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(39b)"},
+    "language": "indo1316",
+    "primaryText": "mau=nya pulang.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["mau=nya", "wish=DEF"], ["pulang", "go.home"]
+    ],
+    "translation": "The/his/her/my wish was/is to go home (but for some reason (s)he/I couldn't).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["modal", "mau"],
+      ["nominalised", "true"],
+      ["soa", "present/past"],
+      ["evaluation", "counterfactual"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_40a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(40a)"},
+    "language": "indo1316",
+    "primaryText": "tampak=nya [ada orang datang]",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tampak=nya", "appear=DEF"], ["ada", "exist"], ["orang", "person"], ["datang", "come"]
+    ],
+    "translation": "It appears that there are people coming.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "sedang tampak=nya [ada orang datang].", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["nominalised", "true"],
+      ["withAux", "ungrammatical"],
+      ["evidential", "visual"],
+      ["predicate", "nominal"]
+    ],
+    "comment": "(40b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_41",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(41)"},
+    "language": "indo1316",
+    "primaryText": "Tampak ada orang datang",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tampak", "appear"], ["ada", "exist"], ["orang", "people"], ["datang", "come"]
+    ],
+    "translation": "It is visible that there are people coming.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["nominalised", "false"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_42a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(42a)"},
+    "language": "indo1316",
+    "primaryText": "Dia sakit.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["sakit", "ill"]
+    ],
+    "translation": "She was ill.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["evidential", "none"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_42b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(42b)"},
+    "language": "indo1316",
+    "primaryText": "Dia sakit kata=nya.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["sakit", "ill"], ["kata=nya", "word=DEF"]
+    ],
+    "translation": "She was ill, I heard.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["evidential", "reportative"],
+      ["nominalised", "true"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_43a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(43a)"},
+    "language": "indo1316",
+    "primaryText": "Kamu pembohong kata=nya",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kamu", "2"], ["pembohong", "PEN.lie"], ["kata=nya", "word=DEF"]
+    ],
+    "translation": "You're a liar, I heard.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["evidential", "reportative"],
+      ["nominalised", "true"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_43b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(43b)"},
+    "language": "indo1316",
+    "primaryText": "Kamu pembohong keluh=nya",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kamu", "2"], ["pembohong", "PEN.lie"], ["keluh=nya", "word=3POSS"]
+    ],
+    "translation": "You're a liar, s/he complained.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["evidential", "none"],
+      ["nominalised", "true"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_44a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(44a)"},
+    "language": "indo1316",
+    "primaryText": "Dia tidur.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dia", "3s"], ["tidur", "sleep"]
+    ],
+    "translation": "S/he is sleeping.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Dia adalah tidur.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "verbal"],
+      ["adalah", "ungrammatical"]
+    ],
+    "comment": "(44b) is the starred alternative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_45a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(45a)"},
+    "language": "indo1316",
+    "primaryText": "Ali (adalah) guru itu.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ali", "Ali"], ["adalah", "be"], ["guru", "teacher"], ["itu", "the"]
+    ],
+    "translation": "Ali is the teacher.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["adalah", "acceptable"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_45b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(45b)"},
+    "language": "indo1316",
+    "primaryText": "Guru itu (adalah) Ali.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The teacher is Ali.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["adalah", "acceptable"]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arka2013_46a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(46a)"},
+    "language": "indo1316",
+    "primaryText": "[ _ tidur] (adalah) mau=nya",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tidur", "sleep"], ["adalah", "be"], ["mau=nya", "want=DEF"]
+    ],
+    "translation": "To sleep was the wish.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["nominalised", "true"],
+      ["adalah", "acceptable"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_46b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(46b)"},
+    "language": "indo1316",
+    "primaryText": "Mau=nya (adalah) [ _ tidur]",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mau=nya", "want=DEF"], ["adalah", "be"], ["tidur", "sleep"]
+    ],
+    "translation": "The/my wish was to sleep.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["nominalised", "true"],
+      ["adalah", "acceptable"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_47a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(47a)"},
+    "language": "indo1316",
+    "primaryText": "Ali bukan/*tidak guru itu.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ali", "Ali"], ["bukan", "NEG"], ["guru", "teacher"], ["itu", "that"]
+    ],
+    "translation": "Ali is not the teacher.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["bukan", "acceptable"],
+      ["tidak", "ungrammatical"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_47b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(47b)"},
+    "language": "indo1316",
+    "primaryText": "Guru itu bukan/*tidak Ali.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The teacher is not Ali.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["bukan", "acceptable"],
+      ["tidak", "ungrammatical"]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arka2013_48a",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(48a)"},
+    "language": "indo1316",
+    "primaryText": "[_ tidur] bukan/*tidak mau=nya",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tidur", "sleep"], ["bukan", "NEG"], ["mau=nya", "want=DEF"]
+    ],
+    "translation": "To sleep was not the/his/her wish.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["nominalised", "true"],
+      ["bukan", "acceptable"],
+      ["tidak", "ungrammatical"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "arka2013_48b",
+    "source": {"bibkey": "arka-2013", "paperLabel": "(48b)"},
+    "language": "indo1316",
+    "primaryText": "Mau=nya bukan / tidak tidur",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mau=nya", "want=DEF"], ["bukan/tidak", "NEG"], ["tidur", "sleep"]
+    ],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "The/his/her/my wish was not to sleep.", "judgment": "acceptable"},
+      {"name": "It is the/her/his/your wish that (I/you/(s)he) would not sleep (but I did sleep).", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["predicate", "nominal"],
+      ["nominalised", "true"],
+      ["bukan", "acceptable"],
+      ["tidak", "acceptable"]
+    ],
+    "comment": "tidak negates the internal clause headed by tidur.",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Arka2013.lean
+++ b/Linglib/Data/Examples/Arka2013.lean
@@ -1,0 +1,900 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Arka2013` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Arka2013.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Arka2013.Examples`.
+-/
+
+namespace Arka2013.Examples
+
+open Data.Examples
+
+def ex_3 : LinguisticExample :=
+  { id := "arka2013_3"
+    source := ⟨"arka-2013", "(3)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia datang."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("datang", "come")]
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("S/he came.", .acceptable), ("S/he is coming.", .acceptable), ("S/he will come.", .acceptable)]
+    paperFeatures := [("tam", "contextual")]
+    comment := "Contextual TAM: the bare verb is anchored by context alone."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_4a : LinguisticExample :=
+  { id := "arka2013_4a"
+    source := ⟨"arka-2013", "(4a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia datang (besok)."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("datang", "come"), ("besok", "tomorrow")]
+    translation := "S/he will come tomorrow."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("frame", "S<E-R"), ("adjunct", "besok")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_4b : LinguisticExample :=
+  { id := "arka2013_4b"
+    source := ⟨"arka-2013", "(4b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia datang (kemarin)."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("datang", "come"), ("kemarin", "yesterday")]
+    translation := "He came in yesterday."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("frame", "E-R<S"), ("adjunct", "kemarin")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_4c : LinguisticExample :=
+  { id := "arka2013_4c"
+    source := ⟨"arka-2013", "(4c)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia datang (sekarang)."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("datang", "come"), ("sekarang", "now")]
+    translation := "She is coming now."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("frame", "E-R-S"), ("adjunct", "sekarang")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_5a : LinguisticExample :=
+  { id := "arka2013_5a"
+    source := ⟨"arka-2013", "(5a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia sudah pergi (sekarang)."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("sudah", "PERF"), ("pergi", "go"), ("sekarang", "now")]
+    translation := "S/he has left (now)."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sudah"), ("frame", "E<S,R")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_5b : LinguisticExample :=
+  { id := "arka2013_5b"
+    source := ⟨"arka-2013", "(5b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia sudah pergi kemarin."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("sudah", "PERF"), ("pergi", "go"), ("kemarin", "yesterday")]
+    translation := "S/he (had) already left yesterday."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sudah"), ("frame", "E<R<S"), ("adjunct", "kemarin")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6a : LinguisticExample :=
+  { id := "arka2013_6a"
+    source := ⟨"arka-2013", "(6a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ali (sedang) me-mukul-i kepala=nya sendiri."
+    discourseSegments := []
+    glossedTokens := [("Ali", "A."), ("sedang", "PROG"), ("me-mukul-i", "AV.hit-I"), ("kepala=nya", "head=3sg.poss"), ("sendiri", "self")]
+    translation := "Ali is beating his own head."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sedang"), ("aspect", "progressive"), ("marking", "applicative -i")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6b : LinguisticExample :=
+  { id := "arka2013_6b"
+    source := ⟨"arka-2013", "(6b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ali (sedang) me-mukul-mukul kepala=nya sendiri."
+    discourseSegments := []
+    glossedTokens := [("Ali", "Ali"), ("sedang", "PROG"), ("me-mukul-mukul", "AV.hit-RED"), ("kepala=nya", "head=3sg.poss"), ("sendiri", "self")]
+    translation := "Ali is beating his own head."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sedang"), ("aspect", "progressive"), ("marking", "reduplication")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7 : LinguisticExample :=
+  { id := "arka2013_7"
+    source := ⟨"arka-2013", "(7)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ali tidak masuk-masuk ke rumah."
+    discourseSegments := []
+    glossedTokens := [("Ali", "Ali"), ("tidak", "NEG"), ("masuk-masuk", "enter-RED"), ("ke", "to"), ("rumah", "house")]
+    translation := "Ali didn't enter the house (while he's expected to do so)."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("marking", "reduplication"), ("meaning", "unrealised expectation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_8 : LinguisticExample :=
+  { id := "arka2013_8"
+    source := ⟨"arka-2013", "(8)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia makan sambil menonton TV."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("makan", "eat"), ("sambil", "while"), ("menonton", "AV.watch"), ("TV", "TV")]
+    translation := "He was/is eating while watching TV."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aspect", "progressive"), ("tam", "contextual")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_10 : LinguisticExample :=
+  { id := "arka2013_10"
+    source := ⟨"arka-2013", "(10)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Mereka (akan) datang."
+    discourseSegments := []
+    glossedTokens := [("Mereka", "3p"), ("akan", "FUT"), ("datang", "come")]
+    translation := "They will come."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "akan"), ("frame", "S<E-R"), ("withAux", "acceptable"), ("clause", "root")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_11a : LinguisticExample :=
+  { id := "arka2013_11a"
+    source := ⟨"arka-2013", "(11a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Mereka ingin [datang besok]."
+    discourseSegments := []
+    glossedTokens := [("Mereka", "3p"), ("ingin", "want"), ("datang", "come"), ("besok", "tomorrow")]
+    translation := "They want to come tomorrow."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Mereka ingin [akan datang besok].", .ungrammatical)]
+    readings := []
+    paperFeatures := [("withAux", "ungrammatical"), ("matrix", "ingin")]
+    comment := "(11b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_11c : LinguisticExample :=
+  { id := "arka2013_11c"
+    source := ⟨"arka-2013", "(11c)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Saya tahu [bahwa mereka akan datang]."
+    discourseSegments := []
+    glossedTokens := [("Saya", "1s"), ("tahu", "know"), ("bahwa", "that"), ("mereka", "3p"), ("akan", "FUT"), ("datang", "come")]
+    translation := "I know that they will come."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "akan"), ("withAux", "acceptable"), ("matrix", "tahu"), ("subordinator", "bahwa")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_12a : LinguisticExample :=
+  { id := "arka2013_12a"
+    source := ⟨"arka-2013", "(12a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia akan/sudah/sedang makan."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("akan/sudah/sedang", "FUT/PERF/PROG"), ("makan", "eat")]
+    translation := "S/he will eat/has eaten/is eating."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("withAux", "acceptable"), ("clause", "root")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_12b : LinguisticExample :=
+  { id := "arka2013_12b"
+    source := ⟨"arka-2013", "(12b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Saya menyuruh dia [makan]."
+    discourseSegments := []
+    glossedTokens := [("Saya", "1s"), ("menyuruh", "AV.ask"), ("dia", "3s"), ("makan", "eat")]
+    translation := "I asked him to eat."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Saya menyuruh dia [akan/sudah/sedang makan].", .ungrammatical)]
+    readings := []
+    paperFeatures := [("withAux", "ungrammatical"), ("matrix", "menyuruh")]
+    comment := "(12c) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_13a : LinguisticExample :=
+  { id := "arka2013_13a"
+    source := ⟨"arka-2013", "(13a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Orang itu mendorong saya [ _ jatuh]."
+    discourseSegments := []
+    glossedTokens := [("Orang", "person"), ("itu", "that"), ("mendorong", "AV.push"), ("saya", "1s"), ("jatuh", "fall")]
+    translation := "The person pushed me (and as a result I) fell off."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Orang itu medorong saya [ _ akan/sedang/sudah jatuh].", .ungrammatical)]
+    readings := []
+    paperFeatures := [("withAux", "ungrammatical"), ("matrix", "mendorong")]
+    comment := "(13b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_14a : LinguisticExample :=
+  { id := "arka2013_14a"
+    source := ⟨"arka-2013", "(14a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia datang (sambil) menangis."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("datang", "come"), ("sambil", "while"), ("menangis", "AV.cry")]
+    translation := "S/he came while crying."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Dia datang [(sambil) sedang menangis].", .questionable)]
+    readings := []
+    paperFeatures := [("withAux", "questionable"), ("adjunct", "sambil")]
+    comment := "(14b) is marked ?*."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_15a : LinguisticExample :=
+  { id := "arka2013_15a"
+    source := ⟨"arka-2013", "(15a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Saya belajar [menembak]."
+    discourseSegments := []
+    glossedTokens := [("Saya", "1s"), ("belajar", "study"), ("menembak", "AV.shoot")]
+    translation := "I'm learning to shoot."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Saya belajar bisa [menembak].", .questionable)]
+    readings := []
+    paperFeatures := [("withAux", "questionable"), ("matrix", "belajar")]
+    comment := "(15b) is marked ?*."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_15c : LinguisticExample :=
+  { id := "arka2013_15c"
+    source := ⟨"arka-2013", "(15c)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Saya belajar agar (bisa) menembak."
+    discourseSegments := []
+    glossedTokens := [("Saya", "1s"), ("belajar", "study"), ("agar", "so.that"), ("bisa", "able"), ("menembak", "AV.shoot")]
+    translation := "I am learning so that I can shoot."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("withAux", "acceptable"), ("subordinator", "agar")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_18a : LinguisticExample :=
+  { id := "arka2013_18a"
+    source := ⟨"arka-2013", "(18a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "...di jalan banyak sapi yang sedang memakan rumput."
+    discourseSegments := []
+    glossedTokens := [("di", "at"), ("jalan", "road"), ("banyak", "plenty"), ("sapi", "cow"), ("yang", "REL"), ("sedang", "PROG"), ("memakan", "AV.eat"), ("rumput", "grass")]
+    translation := "...along the way many cows that eat grass."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sedang"), ("voice", "AV")]
+    comment := "Google-attested; the actor voice verb with sedang."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_18b : LinguisticExample :=
+  { id := "arka2013_18b"
+    source := ⟨"arka-2013", "(18b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dari salah satu swalayan, petugas menemukan makanan jenis roti yang kemasan dan isi=nya telah rusak dan diduga sudah dimakan tikus."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "In one of the supermarkets, the officers found kind of bread/biscuits in boxes whose packages had been tampered and contents were already eaten by mice."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "sudah"), ("voice", "passive")]
+    comment := "Google-attested; the passive verb with sudah."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_34a : LinguisticExample :=
+  { id := "arka2013_34a"
+    source := ⟨"arka-2013", "(34a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "'Siapa itu?', tanya=nya."
+    discourseSegments := []
+    glossedTokens := [("Siapa", "who"), ("itu", "that"), ("tanya=nya", "ask=NYA")]
+    translation := "'Who is that?', he asked."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("'Siapa itu?' akan tanyanya (nanti).", .ungrammatical)]
+    readings := [("he asked", .acceptable), ("he will ask", .unacceptable)]
+    paperFeatures := [("nominalised", "true"), ("axis", "past"), ("predicate", "nominal"), ("withAux", "ungrammatical")]
+    comment := "(34c) is the starred alternative: the nominalised verb takes no auxiliary."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_34b : LinguisticExample :=
+  { id := "arka2013_34b"
+    source := ⟨"arka-2013", "(34b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "'Siapa itu?', tanya=nya nanti."
+    discourseSegments := []
+    glossedTokens := [("Siapa", "who"), ("itu", "that"), ("tanya=nya", "ask=NYA"), ("nanti", "later")]
+    translation := "'Who is that?', he will ask later."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("nominalised", "true"), ("axis", "future"), ("adjunct", "nanti")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_34d : LinguisticExample :=
+  { id := "arka2013_34d"
+    source := ⟨"arka-2013", "(34d)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "'Siapa itu?', dia akan (ber)tanya (nanti)."
+    discourseSegments := []
+    glossedTokens := [("Siapa", "who"), ("itu", "that"), ("dia", "3"), ("akan", "FUT"), ("(ber)tanya", "BER-ask"), ("nanti", "later")]
+    translation := "'Who is that?', he will ask later."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "akan"), ("withAux", "acceptable"), ("clause", "root")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_35a : LinguisticExample :=
+  { id := "arka2013_35a"
+    source := ⟨"arka-2013", "(35a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kapan beli=nya?"
+    discourseSegments := []
+    glossedTokens := [("Kapan", "when"), ("beli=nya", "buy=NYA")]
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("kapan akan beli=nya?", .ungrammatical)]
+    readings := [("When did you buy it?", .acceptable), ("When are you going to buy it?", .unacceptable)]
+    paperFeatures := [("nominalised", "true"), ("axis", "past"), ("predicate", "nominal"), ("withAux", "ungrammatical")]
+    comment := "(35b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_35c : LinguisticExample :=
+  { id := "arka2013_35c"
+    source := ⟨"arka-2013", "(35c)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kapan kamu akan beli?"
+    discourseSegments := []
+    glossedTokens := [("Kapan", "when"), ("kamu", "2s"), ("akan", "FUT"), ("beli", "buy")]
+    translation := "When will you buy?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "akan"), ("withAux", "acceptable"), ("clause", "root")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_36a : LinguisticExample :=
+  { id := "arka2013_36a"
+    source := ⟨"arka-2013", "(36a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kapan lahirnya?"
+    discourseSegments := []
+    glossedTokens := [("Kapan", "when"), ("lahir=nya", "birth=3s")]
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Kapan akan lahirnya?", .ungrammatical)]
+    readings := [("When was s/he born?", .acceptable), ("When is s/he going to be born?", .unacceptable)]
+    paperFeatures := [("nominalised", "true"), ("axis", "past"), ("predicate", "nominal"), ("withAux", "ungrammatical")]
+    comment := "(36b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_36c : LinguisticExample :=
+  { id := "arka2013_36c"
+    source := ⟨"arka-2013", "(36c)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kapan ia akan lahir?"
+    discourseSegments := []
+    glossedTokens := [("Kapan", "when"), ("ia", "3s"), ("akan", "FUT"), ("lahir", "birth")]
+    translation := "When will s/he be born?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("aux", "akan"), ("withAux", "acceptable"), ("clause", "root")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_37a : LinguisticExample :=
+  { id := "arka2013_37a"
+    source := ⟨"arka-2013", "(37a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "kamu harus datang."
+    discourseSegments := []
+    glossedTokens := [("kamu", "2"), ("harus", "must"), ("datang", "come")]
+    translation := "You should come."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "harus"), ("nominalised", "false"), ("soa", "future"), ("evaluation", "deontic")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_37b : LinguisticExample :=
+  { id := "arka2013_37b"
+    source := ⟨"arka-2013", "(37b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "harus=nya kamu datang."
+    discourseSegments := []
+    glossedTokens := [("harus=nya", "must=NYA"), ("kamu", "2"), ("datang", "come")]
+    translation := "You should have come."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "harus"), ("nominalised", "true"), ("soa", "past"), ("evaluation", "counterfactual")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_38a : LinguisticExample :=
+  { id := "arka2013_38a"
+    source := ⟨"arka-2013", "(38a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ia bisa menangis"
+    discourseSegments := []
+    glossedTokens := [("Ia", "she"), ("bisa", "can"), ("menangis", "cry")]
+    translation := "S/he can cry."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "bisa"), ("nominalised", "false"), ("soa", "future"), ("evaluation", "epistemic")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_38b : LinguisticExample :=
+  { id := "arka2013_38b"
+    source := ⟨"arka-2013", "(38b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "bisa=nya menangis"
+    discourseSegments := []
+    glossedTokens := [("bisa=nya", "can=3s"), ("menangis", "cry")]
+    translation := "Crying was/is the thing s/he could do."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "bisa"), ("nominalised", "true"), ("soa", "past"), ("evaluation", "past ability")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_39a : LinguisticExample :=
+  { id := "arka2013_39a"
+    source := ⟨"arka-2013", "(39a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ia mau pulang."
+    discourseSegments := []
+    glossedTokens := [("Ia", "3s"), ("mau", "wish"), ("pulang", "go.home")]
+    translation := "S/he wants/wanted to go home."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "mau"), ("nominalised", "false"), ("soa", "future")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_39b : LinguisticExample :=
+  { id := "arka2013_39b"
+    source := ⟨"arka-2013", "(39b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "mau=nya pulang."
+    discourseSegments := []
+    glossedTokens := [("mau=nya", "wish=DEF"), ("pulang", "go.home")]
+    translation := "The/his/her/my wish was/is to go home (but for some reason (s)he/I couldn't)."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("modal", "mau"), ("nominalised", "true"), ("soa", "present/past"), ("evaluation", "counterfactual")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_40a : LinguisticExample :=
+  { id := "arka2013_40a"
+    source := ⟨"arka-2013", "(40a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "tampak=nya [ada orang datang]"
+    discourseSegments := []
+    glossedTokens := [("tampak=nya", "appear=DEF"), ("ada", "exist"), ("orang", "person"), ("datang", "come")]
+    translation := "It appears that there are people coming."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("sedang tampak=nya [ada orang datang].", .ungrammatical)]
+    readings := []
+    paperFeatures := [("nominalised", "true"), ("withAux", "ungrammatical"), ("evidential", "visual"), ("predicate", "nominal")]
+    comment := "(40b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_41 : LinguisticExample :=
+  { id := "arka2013_41"
+    source := ⟨"arka-2013", "(41)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Tampak ada orang datang"
+    discourseSegments := []
+    glossedTokens := [("Tampak", "appear"), ("ada", "exist"), ("orang", "people"), ("datang", "come")]
+    translation := "It is visible that there are people coming."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("nominalised", "false")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_42a : LinguisticExample :=
+  { id := "arka2013_42a"
+    source := ⟨"arka-2013", "(42a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia sakit."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("sakit", "ill")]
+    translation := "She was ill."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential", "none")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_42b : LinguisticExample :=
+  { id := "arka2013_42b"
+    source := ⟨"arka-2013", "(42b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia sakit kata=nya."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("sakit", "ill"), ("kata=nya", "word=DEF")]
+    translation := "She was ill, I heard."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential", "reportative"), ("nominalised", "true")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_43a : LinguisticExample :=
+  { id := "arka2013_43a"
+    source := ⟨"arka-2013", "(43a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kamu pembohong kata=nya"
+    discourseSegments := []
+    glossedTokens := [("Kamu", "2"), ("pembohong", "PEN.lie"), ("kata=nya", "word=DEF")]
+    translation := "You're a liar, I heard."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential", "reportative"), ("nominalised", "true")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_43b : LinguisticExample :=
+  { id := "arka2013_43b"
+    source := ⟨"arka-2013", "(43b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Kamu pembohong keluh=nya"
+    discourseSegments := []
+    glossedTokens := [("Kamu", "2"), ("pembohong", "PEN.lie"), ("keluh=nya", "word=3POSS")]
+    translation := "You're a liar, s/he complained."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential", "none"), ("nominalised", "true")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_44a : LinguisticExample :=
+  { id := "arka2013_44a"
+    source := ⟨"arka-2013", "(44a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Dia tidur."
+    discourseSegments := []
+    glossedTokens := [("Dia", "3s"), ("tidur", "sleep")]
+    translation := "S/he is sleeping."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Dia adalah tidur.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("predicate", "verbal"), ("adalah", "ungrammatical")]
+    comment := "(44b) is the starred alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_45a : LinguisticExample :=
+  { id := "arka2013_45a"
+    source := ⟨"arka-2013", "(45a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ali (adalah) guru itu."
+    discourseSegments := []
+    glossedTokens := [("Ali", "Ali"), ("adalah", "be"), ("guru", "teacher"), ("itu", "the")]
+    translation := "Ali is the teacher."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("adalah", "acceptable")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_45b : LinguisticExample :=
+  { id := "arka2013_45b"
+    source := ⟨"arka-2013", "(45b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Guru itu (adalah) Ali."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The teacher is Ali."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("adalah", "acceptable")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_46a : LinguisticExample :=
+  { id := "arka2013_46a"
+    source := ⟨"arka-2013", "(46a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "[ _ tidur] (adalah) mau=nya"
+    discourseSegments := []
+    glossedTokens := [("tidur", "sleep"), ("adalah", "be"), ("mau=nya", "want=DEF")]
+    translation := "To sleep was the wish."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("nominalised", "true"), ("adalah", "acceptable")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_46b : LinguisticExample :=
+  { id := "arka2013_46b"
+    source := ⟨"arka-2013", "(46b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Mau=nya (adalah) [ _ tidur]"
+    discourseSegments := []
+    glossedTokens := [("Mau=nya", "want=DEF"), ("adalah", "be"), ("tidur", "sleep")]
+    translation := "The/my wish was to sleep."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("nominalised", "true"), ("adalah", "acceptable")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_47a : LinguisticExample :=
+  { id := "arka2013_47a"
+    source := ⟨"arka-2013", "(47a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Ali bukan/*tidak guru itu."
+    discourseSegments := []
+    glossedTokens := [("Ali", "Ali"), ("bukan", "NEG"), ("guru", "teacher"), ("itu", "that")]
+    translation := "Ali is not the teacher."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("bukan", "acceptable"), ("tidak", "ungrammatical")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_47b : LinguisticExample :=
+  { id := "arka2013_47b"
+    source := ⟨"arka-2013", "(47b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Guru itu bukan/*tidak Ali."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The teacher is not Ali."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("bukan", "acceptable"), ("tidak", "ungrammatical")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_48a : LinguisticExample :=
+  { id := "arka2013_48a"
+    source := ⟨"arka-2013", "(48a)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "[_ tidur] bukan/*tidak mau=nya"
+    discourseSegments := []
+    glossedTokens := [("tidur", "sleep"), ("bukan", "NEG"), ("mau=nya", "want=DEF")]
+    translation := "To sleep was not the/his/her wish."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("predicate", "nominal"), ("nominalised", "true"), ("bukan", "acceptable"), ("tidak", "ungrammatical")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_48b : LinguisticExample :=
+  { id := "arka2013_48b"
+    source := ⟨"arka-2013", "(48b)"⟩
+    reportedIn := none
+    language := "indo1316"
+    primaryText := "Mau=nya bukan / tidak tidur"
+    discourseSegments := []
+    glossedTokens := [("Mau=nya", "want=DEF"), ("bukan/tidak", "NEG"), ("tidur", "sleep")]
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("The/his/her/my wish was not to sleep.", .acceptable), ("It is the/her/his/your wish that (I/you/(s)he) would not sleep (but I did sleep).", .acceptable)]
+    paperFeatures := [("predicate", "nominal"), ("nominalised", "true"), ("bukan", "acceptable"), ("tidak", "acceptable")]
+    comment := "tidak negates the internal clause headed by tidur."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [ex_3, ex_4a, ex_4b, ex_4c, ex_5a, ex_5b, ex_6a, ex_6b, ex_7, ex_8, ex_10, ex_11a, ex_11c, ex_12a, ex_12b, ex_13a, ex_14a, ex_15a, ex_15c, ex_18a, ex_18b, ex_34a, ex_34b, ex_34d, ex_35a, ex_35c, ex_36a, ex_36c, ex_37a, ex_37b, ex_38a, ex_38b, ex_39a, ex_39b, ex_40a, ex_41, ex_42a, ex_42b, ex_43a, ex_43b, ex_44a, ex_45a, ex_45b, ex_46a, ex_46b, ex_47a, ex_47b, ex_48a, ex_48b]
+
+end Arka2013.Examples

--- a/Linglib/Fragments/Indonesian/Complementation.lean
+++ b/Linglib/Fragments/Indonesian/Complementation.lean
@@ -1,0 +1,58 @@
+import Linglib.Syntax.Category.Verb.Basic
+import Linglib.Syntax.Category.Complementizer.Basic
+
+/-!
+# Indonesian clause embedding
+[arka-2013] [sneddon-1996] [noonan-2007]
+
+The complement-taking verbs and subordinators of [arka-2013]'s finiteness paradigm. *ingin*
+'want', *belajar* 'learn', *menyuruh* 'order', and *mendorong* 'push' take bare complements
+whose subject is controlled, coded as reduced in [noonan-2007]'s terms; *tahu* 'know' takes a
+*bahwa* clause. *bahwa* 'that' and *agar* 'so that' type full clauses with their own subjects.
+-/
+
+namespace Indonesian.Complementation
+
+open Morphology
+
+/-- A bare complement whose subject is controlled by a matrix argument. -/
+def controlled : Complement.Position :=
+  .clausal (coding := some .infinitive) (embeddedSubject := some .obligatorilyNull)
+
+/-- *ingin* 'want': a controlled complement, *Mereka ingin datang besok*. -/
+def ingin : Verb :=
+  { form := "ingin", frames := [[controlled]],
+    readings := [{ frame := [controlled], control := some .subjectControl }] }
+
+/-- *belajar* 'learn, study': a controlled complement, *Saya belajar menembak*. -/
+def belajar : Verb :=
+  { form := "belajar", frames := [[controlled]],
+    readings := [{ frame := [controlled], control := some .subjectControl }] }
+
+/-- *menyuruh* 'order, ask': an object and a complement it controls, *Saya menyuruh dia
+makan*. -/
+def menyuruh : Verb :=
+  { form := "menyuruh", frames := [[.nominal, controlled]],
+    readings := [{ frame := [.nominal, controlled], control := some .objectControl }] }
+
+/-- *mendorong* 'push': an object and a resultative complement it controls, *Orang itu
+mendorong saya jatuh*. -/
+def mendorong : Verb :=
+  { form := "mendorong", frames := [[.nominal, controlled]],
+    readings := [{ frame := [.nominal, controlled], control := some .objectControl }] }
+
+/-- *tahu* 'know': a finite *bahwa* clause, *Saya tahu bahwa mereka akan datang*. -/
+def tahu : Verb := { form := "tahu", frames := [Frame.finiteClause] }
+
+/-- *bahwa* 'that': the declarative complementizer of a full clause. -/
+def bahwa : Complementizer where
+  morphs := [.free "bahwa"]
+  coding := some .indicative
+  force := some .declarative
+
+/-- *agar* 'so that': the purposive subordinator of a full, irrealis clause. -/
+def agar : Complementizer where
+  morphs := [.free "agar"]
+  coding := some .subjunctive
+
+end Indonesian.Complementation

--- a/Linglib/Studies/Arka2013.lean
+++ b/Linglib/Studies/Arka2013.lean
@@ -4,191 +4,215 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Fragments.Indonesian.TAM
+import Linglib.Fragments.Indonesian.Complementation
 import Linglib.Semantics.Tense.Reichenbach
 import Linglib.Studies.Kiparsky2002
+import Linglib.Data.Examples.Arka2013
 
 /-!
-# Arka (2013): the typology and syntax of TAM in Indonesian
+# Arka 2013: the typology and syntax of TAM in Indonesian
 
-[arka-2013] argues that Indonesian TAM is *morphosemantic and contextual*,
-not grammatical: there is no obligatory morphosyntactic TAM opposition, yet
-the language shows a genuine finiteness contrast, diagnosed by the
-distribution of the TAM auxiliaries (*sudah/telah*, *mau*, *sedang*, *akan*)
-occupying I(NFL).
+Indonesian has no grammatical TAM: there is no obligatory morphosyntactic opposition, a bare
+verb is anchored in time by context or by an optional adjunct, and the perfect auxiliary
+*sudah/telah* expresses only that the event precedes the reference time, which is free to sit
+at the moment of speech or in the past — so Klein's puzzle about the English present perfect,
+which pins the reference time to the present, does not arise. The language nonetheless
+shows finiteness: the TAM auxiliaries occupy I, a finite clause projects IP whether or not an
+auxiliary is present, and truncated or controlled complements, resultatives, and *sambil*
+adjuncts are bare VPs that admit none of them, while nominal predicates project no I at all.
+The clitic *=nya* nominalises verbs of saying and feeling, modals, and evidential roots; a
+nominalisation carries a default past temporal axis that an adjunct like *nanti* cancels, a
+nominalised modal reports a past or present state of affairs counterfactually where the bare
+modal points to a future one, and the copula *adalah* and the negator *bukan* show that these
+structures are equational.
 
-Formalized over `Time.ReichenbachFrame` and the [sneddon-1996] marker
-inventory (`Fragments/Indonesian/TAM.lean`):
+## Main definitions
 
-1. **Grammaticalization contrast** (§2): *sudah/telah* expresses bare E < R;
-   the English present perfect additionally pins R to speech time. Hence
-   [klein-1992]'s present perfect puzzle (`Kiparsky2002.present_perfect_puzzle`)
-   does not arise: *Dia sudah pergi kemarin* is satisfiable (E < R < S).
-   Following [kibort-2009], the underlying semantics is shared and only the
-   grammaticalized E,R,S configuration differs.
-2. **Finiteness** (§3): auxiliaries sit in I; truncated/controlled
-   complements are bare VPs; equational/nominal predications project no I —
-   jointly predicting the auxiliary-acceptability paradigm.
-3. **Cross-source bridge**: Arka's auxiliary class matches the
-   [sneddon-1996] temporal markers except *mau*, which Sneddon sets apart as
-   a full verb — a genuine classification divergence between the sources.
+* `Annotation`: the paper's E/R/S annotations, with `Annotation.frame` the Reichenbach
+  frame they describe.
+* `Aux`, `Aux.frame`: the auxiliaries the paper analyses and the frame relation each
+  expresses; `englishPresentPerfect` the English contrast.
+* `projectsI`: a clause projects I exactly when its complement coding is not reduced; the
+  selecting verbs and subordinators are fragment entries.
 
-Not formalized (documented for follow-up): the default-past temporal axis of
-=nya nominalization and its cancellability by *nanti* (Arka's kapan-question
-evidence), the voice–TAM affinities, and evidential *katanya*.
+## References
+
+* [arka-2013]
+* [klein-1992] — the present perfect puzzle
+* [kibort-2009] — languages grammaticalise different E, R, S configurations
+* [sneddon-1996] — the marker inventory in the fragment
 -/
 
 namespace Arka2013
 
-open Time Indonesian
+open Time Indonesian Data.Examples
 
-/-! ### Reichenbachian semantics of the TAM auxiliaries -/
+/-! ### Tense theory and the status of Indonesian TAM (§2) -/
 
-variable {T : Type*} [LinearOrder T]
+/-- An E/R/S annotation as the paper prints it — `E-R<S`, `S<E-R`, `E<S,R` — read as the
+temporal group each primitive falls in, later groups later in time. -/
+structure Annotation where
+  e : ℕ
+  r : ℕ
+  s : ℕ
+  deriving DecidableEq, Repr
 
-/-- The frame relation [arka-2013] assigns to each auxiliary meaning:
-*sudah/telah* E < R with R free, *sedang* E = R, *akan* future R with E at R
-(point form of his S < E-R). `none` for marker meanings the paper does not
-analyze. -/
-def frameSemantics : TemporalMeaning → Option (ReichenbachFrame T → Prop)
-  | .occurred => some (·.isPerfect)
-  | .inProgress => some (·.isPerfective)
-  | .future => some (λ f => f.isFuture ∧ f.isPerfective)
+/-- Read an annotation: `<` opens a later group, `-` and `,` keep the current one. -/
+def Annotation.parse? (str : String) : Option Annotation :=
+  let step : Option (Annotation × ℕ) → Char → Option (Annotation × ℕ)
+    | some (a, g), 'E' => some ({ a with e := g }, g)
+    | some (a, g), 'R' => some ({ a with r := g }, g)
+    | some (a, g), 'S' => some ({ a with s := g }, g)
+    | some (a, g), '<' => some (a, g + 1)
+    | some (a, g), '-' => some (a, g)
+    | some (a, g), ',' => some (a, g)
+    | some (a, g), ' ' => some (a, g)
+    | _, _ => none
+  (str.toList.foldl step (some (⟨0, 0, 0⟩, 0))).map (·.1)
+
+/-- The frame an annotation describes, with the perspective at speech time. -/
+def Annotation.frame (a : Annotation) : ReichenbachFrame ℤ := ⟨a.s, a.s, a.r, a.e⟩
+
+/-- The auxiliaries the paper assigns a frame relation: *akan* future, *sedang* progressive,
+*sudah/telah* perfect. -/
+inductive Aux
+  | akan
+  | sedang
+  | sudah
+  deriving DecidableEq, Repr, Fintype
+
+/-- The auxiliary a fragment marker realises, by its meaning. -/
+def Aux.ofMarker (m : TemporalMarker) : Option Aux :=
+  match m.meaning with
+  | .future => some .akan
+  | .inProgress => some .sedang
+  | .occurred => some .sudah
   | _ => none
 
-/-- The English present perfect grammaticalizes E < R together with R pinned
-to the deictic centre ([arka-2013] §2, after [klein-1992] and
-[kibort-2009]). -/
-def englishPresentPerfect (f : ReichenbachFrame T) : Prop :=
+/-- The auxiliary written as a form, through the fragment's inventory. -/
+def Aux.ofForm (s : String) : Option Aux :=
+  (temporalMarkers.find? (·.form = s)).bind Aux.ofMarker
+
+/-- The frame relation each auxiliary expresses: *akan* S < E-R, *sedang* E = R, *sudah* E < R
+with R free. -/
+def Aux.frame {T : Type*} [LinearOrder T] : Aux → ReichenbachFrame T → Prop
+  | .akan, f => f.isFuture ∧ f.isPerfective
+  | .sedang, f => f.isPerfective
+  | .sudah, f => f.isPerfect
+
+instance {T : Type*} [LinearOrder T] (a : Aux) (f : ReichenbachFrame T) :
+    Decidable (a.frame f) := by
+  cases a <;> dsimp only [Aux.frame] <;> infer_instance
+
+/-- *telah* and *sudah* realise the same auxiliary. -/
+theorem telah_sudah : Aux.ofMarker telah = Aux.ofMarker sudah := rfl
+
+/-- Every annotated sentence with an auxiliary satisfies the auxiliary's frame relation. -/
+theorem rows_annotations :
+    ∀ r ∈ Examples.all, ∀ a ∈ (r.feature? "aux" >>= Aux.ofForm).toList,
+      ∀ ann ∈ (r.feature? "frame" >>= Annotation.parse?).toList, a.frame ann.frame := by
+  decide +kernel
+
+/-- The annotations of the *sudah* sentences (5). -/
+def sudahAnnotations : List Annotation :=
+  Examples.all.filterMap fun r => do
+    let a ← r.feature? "aux" >>= Aux.ofForm
+    guard (a = .sudah)
+    r.feature? "frame" >>= Annotation.parse?
+
+/-- R is free under *sudah*: it sits at speech time in one annotation and before it in
+another, the event preceding it in both. -/
+theorem sudah_reference_free :
+    (∃ a ∈ sudahAnnotations, a.r = a.s) ∧ (∃ a ∈ sudahAnnotations, a.r < a.s) ∧
+      ∀ a ∈ sudahAnnotations, a.e < a.r := by
+  decide +kernel
+
+/-- The English present perfect grammaticalises E < R together with R at the deictic
+centre. -/
+def englishPresentPerfect {T : Type*} [LinearOrder T] (f : ReichenbachFrame T) : Prop :=
   f.isPerfect ∧ f.isPresent
 
-instance (f : ReichenbachFrame T) : Decidable (englishPresentPerfect f) := by
+instance {T : Type*} [LinearOrder T] (f : ReichenbachFrame T) :
+    Decidable (englishPresentPerfect f) := by
   unfold englishPresentPerfect; infer_instance
 
-/-- *telah* expresses the same frame relation as *sudah* — the fragment's
-register-only contrast (`Indonesian.telah_sudah_same_meaning_distinct_register`)
-transported through [arka-2013]'s semantic assignment. -/
-theorem telah_sudah_same_semantics :
-    frameSemantics (T := T) telah.meaning = frameSemantics sudah.meaning := rfl
-
-/-- *Dia sudah pergi kemarin*: *sudah* tolerates a past reference time —
-witness frame E < R < P = S. "Sudah/telah is also compatible with a specific
-past reference such as kemarin." -/
-theorem sudah_allows_past_reference :
-    ∃ f : ReichenbachFrame ℤ, f.isPerfect ∧ f.isPast ∧ f.isSimpleCase :=
-  ⟨⟨2, 2, 1, 0⟩, by decide⟩
-
-/-- *Dia sudah pergi (sekarang)*: the English-present-perfect-like reading
-E < R = S is also available — R is genuinely free. -/
-theorem sudah_allows_present_reference :
-    ∃ f : ReichenbachFrame ℤ, f.isPerfect ∧ f.isPresent ∧ f.isSimpleCase :=
-  ⟨⟨1, 1, 1, 0⟩, by decide⟩
-
-/-- [klein-1992]'s puzzle and its Indonesian dissolution: with a past-time
-adverbial (R < P), the English present perfect is contradictory
-(`Kiparsky2002.present_perfect_puzzle`), while *sudah* under the same
-constraint is satisfiable. Languages grammaticalize different E,R,S
-configurations of one underlying semantics ([kibort-2009]). -/
+/-- Klein's puzzle and its Indonesian dissolution: with a past reference time the English
+present perfect is contradictory (`Kiparsky2002.present_perfect_puzzle`), while *sudah*
+under the same reference time is satisfiable — (5b) *Dia sudah pergi kemarin*. -/
 theorem klein_puzzle_dissolved :
     (∀ f : ReichenbachFrame ℤ, englishPresentPerfect f → f.isPast → False) ∧
-    ∃ f : ReichenbachFrame ℤ, f.isPerfect ∧ f.isPast :=
-  ⟨λ f hpp hpast => Kiparsky2002.present_perfect_puzzle f hpp.2
+      ∃ f : ReichenbachFrame ℤ, Aux.sudah.frame f ∧ f.isPast :=
+  ⟨fun f hpp hpast => Kiparsky2002.present_perfect_puzzle f hpp.2
       ((ReichenbachFrame.isPast_def f).mp hpast),
-   ⟨⟨2, 2, 1, 0⟩, by decide⟩⟩
+    ⟨⟨2, 2, 1, 0⟩, by decide⟩⟩
 
-/-- The English present perfect strictly strengthens *sudah*: every English
-present-perfect frame is a *sudah* frame, but not conversely. -/
-theorem english_pp_strictly_stronger :
-    (∀ f : ReichenbachFrame T, englishPresentPerfect f → f.isPerfect) ∧
-    ∃ f : ReichenbachFrame ℤ, f.isPerfect ∧ ¬ englishPresentPerfect f :=
-  ⟨λ _ h => h.1, ⟨⟨2, 2, 1, 0⟩, by decide⟩⟩
+/-- The English present perfect strictly strengthens *sudah*. -/
+theorem english_pp_strictly_stronger {T : Type*} [LinearOrder T] :
+    (∀ f : ReichenbachFrame T, englishPresentPerfect f → Aux.sudah.frame f) ∧
+      ∃ f : ReichenbachFrame ℤ, Aux.sudah.frame f ∧ ¬ englishPresentPerfect f :=
+  ⟨fun _ h => h.1, ⟨⟨2, 2, 1, 0⟩, by decide⟩⟩
 
-/-! ### Finiteness: auxiliaries in I, truncated complements as bare VPs -/
+/-! ### Finiteness (§3) -/
 
-/-- Clause projections in [arka-2013]'s LFG analysis: finite clauses project
-IP whose I hosts the TAM auxiliaries; truncated/controlled complements are
-bare VPs; equational/nominal predications project no verbal structure. -/
-inductive Projection where
-  | ip | vp | nominal
-  deriving DecidableEq, Repr
+/-- The verb selecting a row's complement clause, from the fragment. -/
+def matrixVerb : String → Option Verb
+  | "ingin" => some Complementation.ingin
+  | "belajar" => some Complementation.belajar
+  | "menyuruh" => some Complementation.menyuruh
+  | "mendorong" => some Complementation.mendorong
+  | "tahu" => some Complementation.tahu
+  | _ => none
 
-/-- The I(NFL) position exists only in IP. -/
-def Projection.hasInfl (p : Projection) : Prop := p = .ip
+/-- The subordinator typing a row's dependent clause, from the fragment. -/
+def subordinator : String → Option Complementizer
+  | "bahwa" => some Complementation.bahwa
+  | "agar" => some Complementation.agar
+  | _ => none
 
-instance : DecidablePred Projection.hasInfl := λ p =>
-  inferInstanceAs (Decidable (p = .ip))
+/-- A clause projects I — the position of the TAM auxiliaries (16) — exactly when its coding is
+not reduced: a full clause anchors its own temporal axis, a reduced complement is a bare VP
+(17). -/
+def projectsI (c : Complement.Coding) : Bool := !c.isReduced
 
-/-- A clause type from [arka-2013]'s finiteness paradigm: the construction,
-the projection his analysis assigns, and the observed acceptability of a TAM
-auxiliary inside it. -/
-structure ClauseType where
-  construction : String
-  projection : Projection
-  /-- Observed: a TAM auxiliary is acceptable inside the clause. -/
-  auxAcceptable : Bool
-  deriving DecidableEq, Repr
+/-- The coding of the clause a verb's citation frame selects. -/
+def complementCoding (v : Verb) : Option Complement.Coding :=
+  v.frames.head?.bind fun fr => fr.codings.head?
 
-/-- Root clause: *Dia akan/sudah/sedang makan*. -/
-def rootClause : ClauseType := ⟨"root clause", .ip, true⟩
+/-- A TAM auxiliary is acceptable in a dependent clause exactly when the clause its selector
+takes projects I; root clauses do, and a nominal predicate projects no verbal structure. -/
+theorem rows_finiteness :
+    ∀ r ∈ Examples.all,
+      (∀ v ∈ (r.feature? "matrix" >>= matrixVerb).toList, ∀ c ∈ (complementCoding v).toList,
+        (projectsI c = true ↔ r.feature? "withAux" = some "acceptable")) ∧
+      (∀ s ∈ (r.feature? "subordinator" >>= subordinator).toList, ∀ c ∈ s.coding.toList,
+        (projectsI c = true ↔ r.feature? "withAux" = some "acceptable")) ∧
+      (r.feature? "clause" = some "root" → r.feature? "withAux" = some "acceptable") ∧
+      (r.feature? "predicate" = some "nominal" →
+        ∀ j ∈ (r.feature? "withAux").toList, j ≠ "acceptable") := by
+  decide +kernel
 
-/-- Finite *bahwa* 'that' complement: *Saya tahu bahwa mereka akan datang*. -/
-def bahwaComplement : ClauseType := ⟨"bahwa complement", .ip, true⟩
+/-! ### Morphosemantic TAM: *=nya* nominalisation (§4) -/
 
-/-- Finite *agar* 'so that' purposive: *Saya belajar agar (bisa) menembak*. -/
-def agarPurposive : ClauseType := ⟨"agar purposive", .ip, true⟩
+/-- The default past axis of a nominalisation is cancelled exactly by a future adjunct
+(34)–(36). -/
+theorem rows_nya_default_past :
+    ∀ r ∈ Examples.all, r.feature? "nominalised" = some "true" →
+      ∀ axis ∈ (r.feature? "axis").toList,
+        (axis = "future" ↔ r.feature? "adjunct" = some "nanti") := by
+  decide +kernel
 
-/-- Truncated complement of *ingin* 'want': *Mereka ingin [(ˣakan) datang]*. -/
-def inginComplement : ClauseType := ⟨"ingin complement", .vp, false⟩
+/-- A bare modal evaluates a future state of affairs; its nominalisation a past or present
+one (37)–(39). -/
+theorem rows_modal_nominalisation :
+    ∀ r ∈ Examples.all, ∀ soa ∈ (r.feature? "soa").toList,
+      (soa = "future" ↔ r.feature? "nominalised" = some "false") := by
+  decide +kernel
 
-/-- Controlled complement of *menyuruh* 'order': *Saya menyuruh dia
-[(ˣakan/sudah/sedang) makan]*. -/
-def menyuruhComplement : ClauseType := ⟨"menyuruh complement", .vp, false⟩
-
-/-- Resultative complement: *Orang itu mendorong saya [(ˣakan/sedang/sudah)
-jatuh]*. -/
-def resultativeComplement : ClauseType := ⟨"resultative complement", .vp, false⟩
-
-/-- *sambil* 'while' adjunct: *Dia datang [(sambil) (ˣsedang) menangis]*. -/
-def sambilAdjunct : ClauseType := ⟨"sambil adjunct", .vp, false⟩
-
-/-- Complement of *belajar* 'learn': *Saya belajar [(ˣbisa) menembak]*. -/
-def belajarComplement : ClauseType := ⟨"belajar complement", .vp, false⟩
-
-/-- Equational/nominal predication: *(ˣakan) tanyanya*, *(ˣsedang)
-tampaknya* — "a nominal predicate cannot take an auxiliary". -/
-def nominalPredication : ClauseType := ⟨"nominal predication", .nominal, false⟩
-
-/-- [arka-2013]'s finiteness paradigm. -/
-def paradigm : List ClauseType :=
-  [rootClause, bahwaComplement, agarPurposive, inginComplement,
-   menyuruhComplement, resultativeComplement, sambilAdjunct,
-   belajarComplement, nominalPredication]
-
-/-- The I-position account predicts the paradigm exactly: an auxiliary is
-acceptable iff the clause projects I. Auxiliary distribution thereby
-diagnoses finiteness in a language with no inflectional TAM — Arka's central
-claim. -/
-theorem aux_distribution_diagnoses_finiteness :
-    ∀ c ∈ paradigm, (c.projection.hasInfl ↔ c.auxAcceptable = true) := by
-  decide
-
-/-! ### Arka's auxiliary class vs the Sneddon inventory -/
-
-/-- [arka-2013]'s TAM auxiliaries: "sudah/telah, mau, sedang, and akan". -/
-def auxiliaryForms : List String := ["sudah", "telah", "mau", "sedang", "akan"]
-
-/-- Every Arka auxiliary except *mau* is a [sneddon-1996] temporal marker,
-and *mau* is not one: Sneddon sets volitional *mau*/*ingin* apart as full
-verbs where Arka classifies *mau* as an I-position auxiliary — a genuine
-classification divergence between the sources. -/
-theorem auxiliaries_vs_sneddon_markers :
-    auxiliaryForms.filter (λ s => (temporalMarkers.map (·.form)).contains s) =
-      ["sudah", "telah", "sedang", "akan"] ∧
-    ¬ (temporalMarkers.map (·.form)).contains "mau" := by decide
-
-/-- [arka-2013]'s glosses (akan 'FUT', sedang 'PROG', sudah/telah 'PERF')
-agree with the [sneddon-1996]-derived meanings in the fragment. -/
-theorem glosses_match_fragment :
-    akan.meaning = .future ∧ sedang.meaning = .inProgress ∧
-    sudah.meaning = .occurred ∧ telah.meaning = .occurred := by decide
+/-- The copula *adalah* and the negator *bukan* take nominal predicates only, the
+nominalisations among them (44)–(48). -/
+theorem rows_equational :
+    ∀ r ∈ Examples.all, ∀ key ∈ ["adalah", "bukan"], ∀ j ∈ (r.feature? key).toList,
+      (j = "acceptable" ↔ r.feature? "predicate" = some "nominal") := by
+  decide +kernel
 
 end Arka2013


### PR DESCRIPTION
Arka2013 recut from the paper: the auxiliaries' frame relations checked against the paper's own E/R/S annotations (R free under *sudah*, Klein's puzzle dissolved), the finiteness analysis (IP vs VP vs nominal by clause type) run against the paradigm's auxiliary judgments, and the =nya half of the paper — default past axis cancelled by *nanti*, modal nominalisations, equational tests with *adalah*/*bukan* — as row checks; 49 rows. The hand-typed projection/acceptability table and the Sneddon *mau* divergence are cut.