### PR TITLE
refactor(Studies/Arnold2026): the two kinds as conditions on rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -331,6 +331,7 @@ import Linglib.Data.Examples.Angelopoulos2026
 import Linglib.Data.Examples.Anscombe1964
 import Linglib.Data.Examples.Anttila1997
 import Linglib.Data.Examples.Arka2013
+import Linglib.Data.Examples.Arnold2026
 import Linglib.Data.Examples.ArregiPietraszko2021
 import Linglib.Data.Examples.ArreguiKusumoto1998
 import Linglib.Data.Examples.BeckOdaSugisaki2004

--- a/Linglib/Data/Examples/Arnold2026.json
+++ b/Linglib/Data/Examples/Arnold2026.json
@@ -1,0 +1,275 @@
+[
+  {
+    "id": "arnold2026_homework",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§1"},
+    "language": "stan1293",
+    "primaryText": "Every student does their homework",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "quantified"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Singular they attested for centuries (Balhorn 2004; Baron 2020).",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_lovato",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§1"},
+    "language": "stan1293",
+    "primaryText": "'I've had the revelation that I identify as non-binary,' they said",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "personal"],
+      ["pronouns", "they/them"],
+      ["representation", "elaborated"]
+    ],
+    "comment": "Article on Demi Lovato (Olson and Fuentes 2022).",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_bed",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§2"},
+    "language": "stan1293",
+    "primaryText": "Everyone should make their bed",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "quantified"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_teacher",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§2"},
+    "language": "stan1293",
+    "primaryText": "A teacher should know their students",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "indefinite"],
+      ["referentGender", "unknown"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Epicene referent.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_clerk",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§2"},
+    "language": "stan1293",
+    "primaryText": "The clerk had their back to me",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "definite"],
+      ["referentGender", "unknown"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Epicene referent.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_neighbor",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§2"},
+    "language": "stan1293",
+    "primaryText": "My neighbor said they would stop by",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "definite"],
+      ["referentGender", "known"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "A known referent whose gender is not important to the story (Bjorkman 2017; Konnelly and Cowper 2020).",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_shakespeare",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "Table 1"},
+    "language": "stan1293",
+    "primaryText": "There's not a man I meet but doth salute me as if I were their well-acquainted friend",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "quantified"],
+      ["referentGender", "known"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Shakespeare, Comedy of Errors, 1623.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_landlord",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "Table 1"},
+    "language": "stan1293",
+    "primaryText": "a single mother and their three children",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "indefinite"],
+      ["referentGender", "known"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Spoken by a landlord interviewed by John Oliver, 29 June 2020.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_son",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "Table 1"},
+    "language": "stan1293",
+    "primaryText": "Me: My son will swing by to pick up my order. Store clerk: just have them call us when they are here so we can bring it out.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "definite"],
+      ["referentGender", "known"],
+      ["representation", "underspecified"]
+    ],
+    "comment": "Phone conversation, July 2020.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_alex",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§4.3"},
+    "language": "stan1293",
+    "primaryText": "Alex made breakfast with Will. They broke some plates.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "Alex broke some plates", "judgment": "acceptable"},
+      {"name": "Alex and Will broke some plates", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["kind", "personal"],
+      ["pronouns", "they/them"],
+      ["representation", "elaborated"],
+      ["ambiguity", "singular or plural"]
+    ],
+    "comment": "Arnold, Mayo and Dong (2021): Alex (they/them), Will (he/him), Liz (she/her); the plural interpretation dominates, explicit pronoun introduction raises the singular one.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_dillon",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§6.1"},
+    "language": "stan1293",
+    "primaryText": "Asia Kate Dillon (born November 15, 1984) is an American actor. They are known for their roles as…",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "personal"],
+      ["pronouns", "they/them"],
+      ["representation", "elaborated"]
+    ],
+    "comment": "Wikipedia, Asia Kate Dillon, retrieved 27 May 2025: a specific person with a well-developed discourse description.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_mother",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "§6.2"},
+    "language": "stan1293",
+    "primaryText": "my mother … they",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "underspecified"],
+      ["antecedent", "definite"],
+      ["referentGender", "known"],
+      ["representation", "elaborated"],
+      ["counterexample", "true"]
+    ],
+    "comment": "Konnelly and Cowper's stage-3 production; underspecified they for a specific representation would be a counterexample to the proposal.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "arnold2026_butler",
+    "source": {"bibkey": "arnold-2026", "paperLabel": "fn. 4"},
+    "language": "stan1293",
+    "primaryText": "… Butler, who uses they/them pronouns, repeatedly affirms that…",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["kind", "personal"],
+      ["pronouns", "they/them"],
+      ["representation", "elaborated"],
+      ["pronounsIntroduced", "true"]
+    ],
+    "comment": "Szalai 2024, New York Times: pronouns introduced explicitly.",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Arnold2026.lean
+++ b/Linglib/Data/Examples/Arnold2026.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Arnold2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Arnold2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Arnold2026.Examples`.
+-/
+
+namespace Arnold2026.Examples
+
+open Data.Examples
+
+def homework : LinguisticExample :=
+  { id := "arnold2026_homework"
+    source := ⟨"arnold-2026", "§1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every student does their homework"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "quantified"), ("representation", "underspecified")]
+    comment := "Singular they attested for centuries (Balhorn 2004; Baron 2020)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def lovato : LinguisticExample :=
+  { id := "arnold2026_lovato"
+    source := ⟨"arnold-2026", "§1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "'I've had the revelation that I identify as non-binary,' they said"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "personal"), ("pronouns", "they/them"), ("representation", "elaborated")]
+    comment := "Article on Demi Lovato (Olson and Fuentes 2022)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bed : LinguisticExample :=
+  { id := "arnold2026_bed"
+    source := ⟨"arnold-2026", "§2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everyone should make their bed"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "quantified"), ("representation", "underspecified")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def teacher : LinguisticExample :=
+  { id := "arnold2026_teacher"
+    source := ⟨"arnold-2026", "§2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A teacher should know their students"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "indefinite"), ("referentGender", "unknown"), ("representation", "underspecified")]
+    comment := "Epicene referent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def clerk : LinguisticExample :=
+  { id := "arnold2026_clerk"
+    source := ⟨"arnold-2026", "§2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The clerk had their back to me"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "definite"), ("referentGender", "unknown"), ("representation", "underspecified")]
+    comment := "Epicene referent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def neighbor : LinguisticExample :=
+  { id := "arnold2026_neighbor"
+    source := ⟨"arnold-2026", "§2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "My neighbor said they would stop by"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "definite"), ("referentGender", "known"), ("representation", "underspecified")]
+    comment := "A known referent whose gender is not important to the story (Bjorkman 2017; Konnelly and Cowper 2020)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def shakespeare : LinguisticExample :=
+  { id := "arnold2026_shakespeare"
+    source := ⟨"arnold-2026", "Table 1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "There's not a man I meet but doth salute me as if I were their well-acquainted friend"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "quantified"), ("referentGender", "known"), ("representation", "underspecified")]
+    comment := "Shakespeare, Comedy of Errors, 1623."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def landlord : LinguisticExample :=
+  { id := "arnold2026_landlord"
+    source := ⟨"arnold-2026", "Table 1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "a single mother and their three children"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "indefinite"), ("referentGender", "known"), ("representation", "underspecified")]
+    comment := "Spoken by a landlord interviewed by John Oliver, 29 June 2020."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def son : LinguisticExample :=
+  { id := "arnold2026_son"
+    source := ⟨"arnold-2026", "Table 1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Me: My son will swing by to pick up my order. Store clerk: just have them call us when they are here so we can bring it out."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "definite"), ("referentGender", "known"), ("representation", "underspecified")]
+    comment := "Phone conversation, July 2020."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def alex : LinguisticExample :=
+  { id := "arnold2026_alex"
+    source := ⟨"arnold-2026", "§4.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Alex made breakfast with Will. They broke some plates."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("Alex broke some plates", .acceptable), ("Alex and Will broke some plates", .acceptable)]
+    paperFeatures := [("kind", "personal"), ("pronouns", "they/them"), ("representation", "elaborated"), ("ambiguity", "singular or plural")]
+    comment := "Arnold, Mayo and Dong (2021): Alex (they/them), Will (he/him), Liz (she/her); the plural interpretation dominates, explicit pronoun introduction raises the singular one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def dillon : LinguisticExample :=
+  { id := "arnold2026_dillon"
+    source := ⟨"arnold-2026", "§6.1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Asia Kate Dillon (born November 15, 1984) is an American actor. They are known for their roles as…"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "personal"), ("pronouns", "they/them"), ("representation", "elaborated")]
+    comment := "Wikipedia, Asia Kate Dillon, retrieved 27 May 2025: a specific person with a well-developed discourse description."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def mother : LinguisticExample :=
+  { id := "arnold2026_mother"
+    source := ⟨"arnold-2026", "§6.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "my mother … they"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "underspecified"), ("antecedent", "definite"), ("referentGender", "known"), ("representation", "elaborated"), ("counterexample", "true")]
+    comment := "Konnelly and Cowper's stage-3 production; underspecified they for a specific representation would be a counterexample to the proposal."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def butler : LinguisticExample :=
+  { id := "arnold2026_butler"
+    source := ⟨"arnold-2026", "fn. 4"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "… Butler, who uses they/them pronouns, repeatedly affirms that…"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "personal"), ("pronouns", "they/them"), ("representation", "elaborated"), ("pronounsIntroduced", "true")]
+    comment := "Szalai 2024, New York Times: pronouns introduced explicitly."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [homework, lovato, bed, teacher, clerk, neighbor, shakespeare, landlord, son, alex, dillon, mother, butler]
+
+end Arnold2026.Examples

--- a/Linglib/Studies/Arnold2026.lean
+++ b/Linglib/Studies/Arnold2026.lean
@@ -1,298 +1,102 @@
-import Linglib.Features.Gender.Interp
-import Linglib.Discourse.CommonGround
-import Linglib.Fragments.English.Pronouns
 import Linglib.Studies.KonnellyCowper2020
+import Linglib.Data.Examples.Arnold2026
 
 /-!
-# [arnold-2026]
+# Arnold 2026: two kinds of singular *they*
 
-Arnold, Jennifer E. 2026. Two kinds of singular *they*: A usage-based model.
-*Glossa: a journal of general linguistics* X(X). 1–14.
-DOI: https://doi.org/10.16995/glossa.23998
+Singular *they* covers two uses with opposite pragmatic conditions. Underspecified *they*,
+attested since Middle English, is used when the speaker intends an underspecified
+representation of the referent — quantified, indefinite, epicene, or simply not developed in
+common ground — and its criterion is discourse specificity rather than gender, since it occurs
+with gendered referents too. Personal *they*, mainstream only since about 2018, is used
+because the referent's personal pronouns are *they/them*, a fact that must be in common
+ground and that tends to come with an elaborated representation. The two share their form
+and their lack of a gender feature, so a grammatical account of the kind Konnelly and Cowper
+give does not separate them: at their first stage *they* is unavailable for any referent of known
+gender, at the second it needs an ungendered lexical entry for the referent, and at the third
+it is unconstrained, whichever kind is intended.
 
-## Core Contribution
+## Main definitions
 
-English singular *they* is not one phenomenon but two, distinguished by
-inversely correlated pragmatic conditions:
+* `Kind`, `Kind.condition`: the two kinds and the discourse condition each requires of a
+  referent's `Representation`.
 
-1. **Underspecified singular *they*** (the older form, attested since Middle
-   English; [balhorn-2004]): licensed when the referent's discourse
-   representation is **underspecified** — quantified, indefinite, epicene,
-   or not elaborated in the discourse. The key criterion is **discourse
-   specificity** ([newman-1992] "solidity", [newman-1998]
-   "individuation", [camilliere-etal-2021] "social distance"), not
-   gender per se.
+## References
 
-2. **Personal singular *they*** (the newer form, emerging ~2018): licensed
-   when the referent's personal pronouns are known to be *they/them* and
-   this fact is in **common ground**. Co-occurs with highly specific
-   discourse representations.
-
-The two uses share phonological form (*they*) and the absence of a
-contrastive gender feature, but have opposite pragmatic preconditions:
-underspecified *they* requires a thin discourse representation, while
-personal *they* requires a thick one.
-
-## Formalization
-
-We model the distinction using three components:
-
-- `DiscourseElaboration`: how developed the referent's discourse
-  representation is (underspecified vs. elaborated)
-- `PronounSet`: what personal pronouns the referent uses (if known)
-- `GenderInfo`: what gender information is available in the discourse
-
-The licensing conditions are predicates over these types, and the central
-claim — that the two kinds of singular *they* are licensed by inversely
-correlated conditions — is a theorem.
-
-## Connection to Grammatical Accounts
-
-[konnelly-cowper-2020] propose a 3-stage grammatical account where
-variation in acceptance of singular *they* reflects changes in the gender
-feature system (contrastive → variably marked → fully underspecified).
-Arnold's account complements this by centering **pragmatic** conditions
-on use, particularly the role of discourse elaboration, which the
-grammatical account does not address.
+* [arnold-2026]
+* [konnelly-cowper-2020] — the three-stage grammatical account
+* [balhorn-2004] — the history of underspecified *they*
 -/
 
 namespace Arnold2026
 
-/-- How elaborated a referent's discourse representation is ([arnold-2026]).
+open Data.Examples KonnellyCowper2020
 
-    [arnold-2026] (§2, UNVERIFIED): the criterion for underspecified
-    singular *they* is "discourse specificity" — whether the speaker
-    intends to evoke a detailed mental representation for the addressee.
-    Extends [newman-1992]'s "solidity" and [newman-1998]'s "individuation".
-    Crucially this is *orthogonal* to a referential form's accessibility:
-    the same reduced form (*they*) spans both an `underspecified` generic
-    and an `elaborated` named individual, so it is assigned from antecedent
-    type (`antecedentElaboration`), not derived from `AccessibilityLevel.rank`. -/
-inductive DiscourseElaboration where
-  /-- Minimal discourse representation: quantified, indefinite, epicene,
-      or not developed. "Everyone should make their bed." -/
+/-- The two kinds of singular *they*. -/
+inductive Kind
   | underspecified
-  /-- Rich, detailed discourse representation: named, described, topical,
-      with known personal attributes. -/
-  | elaborated
-  deriving DecidableEq, Repr, BEq
-
--- ============================================================================
--- § 2: The Two-Kinds Taxonomy
--- ============================================================================
-
-/-- The two kinds of singular *they* ([arnold-2026] §1).
-
-    These are distinguished by their pragmatic licensing conditions:
-    - Underspecified: discourse representation is thin (§2)
-    - Personal: referent's pronouns are known to be *they/them* (§3) -/
-inductive SingTheyKind where
-  /-- Underspecified singular *they*: the older form, licensed by
-      underspecified discourse representation. -/
-  | underspecified
-  /-- Personal singular *they*: the newer form, licensed by knowledge
-      that the referent's personal pronouns are *they/them*. -/
   | personal
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr
 
-/-- The personal pronouns a referent uses — a social fact about the *referent*
-    (not a property of the pronoun system) that may or may not be in common
-    ground. [arnold-2026]: the pragmatic condition for *personal* singular
-    *they* is knowing that the referent's pronouns are *they/them*. Scoped to the
-    three English sets this paper's licensing turns on (neopronouns and other
-    languages are out of scope here). -/
-inductive PronounSet where
-  | heHim    -- he/him/his
-  | sheHer   -- she/her/hers
-  | theyThem -- they/them/theirs
-  deriving DecidableEq, Repr, BEq
+/-- The kind a row records. -/
+def Kind.parse? : String → Option Kind
+  | "underspecified" => some .underspecified
+  | "personal" => some .personal
+  | _ => none
 
--- ============================================================================
--- § 3: Licensing Conditions
--- ============================================================================
+/-- A referent as the discourse portrays it: whether its representation is elaborated, and
+whether its personal pronouns are known in common ground to be *they/them*. -/
+structure Representation where
+  elaborated : Bool
+  theyThem : Bool
+  deriving DecidableEq, Repr
 
-/-- Underspecified singular *they* is licensed when the referent's
-    discourse representation is underspecified.
+/-- The representation a row records. -/
+def Representation.ofRow (r : LinguisticExample) : Representation :=
+  ⟨r.feature? "representation" = some "elaborated", r.feature? "pronouns" = some "they/them"⟩
 
-    [arnold-2026] §2: "Singular *they* is preferred when the
-    speaker intends to evoke an underspecified mental representation
-    for the addressee in the discourse." -/
-def licensesUnderspecified (de : DiscourseElaboration) : Bool :=
-  match de with
-  | .underspecified => true
-  | .elaborated => false
+/-- The pragmatic condition of each kind: underspecified *they* wants a thin representation,
+personal *they* wants the referent's pronouns known. -/
+def Kind.condition : Kind → Representation → Prop
+  | .underspecified, r => r.elaborated = false
+  | .personal, r => r.theyThem = true
 
-/-- Personal singular *they* is licensed when the referent's personal
-    pronouns are known to be *they/them*.
+instance (k : Kind) (r : Representation) : Decidable (k.condition r) := by
+  cases k <;> dsimp only [Kind.condition] <;> infer_instance
 
-    [arnold-2026] §3: "the pragmatic condition for using personal
-    *they* is knowing that the referent's personal pronouns are
-    *they/them*." This knowledge must be in common ground. -/
-def licensesPersonal (spec : Option PronounSet) : Bool :=
-  match spec with
-  | some .theyThem => true
-  | _ => false
+/-- No representation satisfies both conditions unless the pronouns are known of a thinly
+represented referent — which knowing them precludes. -/
+theorem conditions_opposed (r : Representation) (hu : Kind.underspecified.condition r)
+    (hp : Kind.personal.condition r) : r = ⟨false, true⟩ := by
+  cases r; simp_all [Kind.condition]
 
-/-- Classify a singular *they* use given the discourse state. -/
-def classifyUse (de : DiscourseElaboration) (spec : Option PronounSet) :
-    Option SingTheyKind :=
-  if licensesPersonal spec then some .personal
-  else if licensesUnderspecified de then some .underspecified
-  else none
+/-- Every example meets the condition of its kind, apart from the stage-3 production the paper
+flags as a would-be counterexample. -/
+theorem rows_conditions :
+    ∀ r ∈ Examples.all, r.feature? "counterexample" = none →
+      ∀ k ∈ (r.feature? "kind" >>= Kind.parse?).toList, k.condition (Representation.ofRow r) := by
+  decide +kernel
 
--- ============================================================================
--- § 4: Inverse Correlation
--- ============================================================================
+/-- Underspecified *they* occurs with gendered referents: every Table 1 example has a referent
+of known gender. -/
+theorem rows_gendered_referents :
+    ∀ r ∈ Examples.all, r.source.paperLabel = "Table 1" →
+      r.feature? "kind" = some "underspecified" ∧ r.feature? "referentGender" = some "known" := by
+  decide +kernel
 
-/-- **Core theorem**: the licensing conditions for the two kinds of
-    singular *they* are inversely correlated.
+/-- Personal *they* is used for elaborated representations in every example, though its
+criterion mentions only the pronouns. -/
+theorem rows_personal_elaborated :
+    ∀ r ∈ Examples.all, r.feature? "kind" = some "personal" →
+      (Representation.ofRow r).elaborated = true := by
+  decide +kernel
 
-    When the referent has a known *they/them* pronoun specification and
-    an elaborated discourse representation (the typical case for personal
-    *they*), underspecified *they* is NOT licensed. -/
-theorem personal_excludes_underspecified
-    (spec : PronounSet) (hspec : spec = .theyThem)
-    (de : DiscourseElaboration) (hde : de = .elaborated) :
-    licensesPersonal (some spec) = true ∧
-    licensesUnderspecified de = false := by
-  subst hspec; subst hde; exact ⟨rfl, rfl⟩
-
-/-- Conversely, when the discourse representation is underspecified
-    (the typical case for underspecified *they*), personal *they* is
-    NOT licensed — there is not enough information about the referent
-    to know their pronouns. -/
-theorem underspecified_excludes_personal
-    (de : DiscourseElaboration) (hde : de = .underspecified)
-    (spec : Option PronounSet) (hspec : spec = none) :
-    licensesUnderspecified de = true ∧
-    licensesPersonal spec = false := by
-  subst hde; subst hspec; exact ⟨rfl, rfl⟩
-
-/-- The two licensing conditions never simultaneously fire on the
-    same discourse state (when elaboration and pronoun knowledge
-    are consistent). If a referent has *they/them* pronouns, the
-    discourse model is necessarily elaborated (you know enough about
-    them to know their pronouns). -/
-theorem no_simultaneous_licensing
-    (de : DiscourseElaboration) (spec : Option PronounSet)
-    (_h : licensesPersonal spec = true) :
-    -- Personal they fires → elaboration must not be underspecified
-    -- (a referent whose pronouns you know has a rich representation)
-    de = .elaborated →
-    licensesUnderspecified de = false := by
-  intro hde; subst hde; rfl
-
--- ============================================================================
--- § 5: Antecedent Types (Table 1 data)
--- ============================================================================
-
-/-- Antecedent type classification for singular *they*.
-
-    [arnold-2026] Table 1 shows that singular *they* occurs with
-    quantified, indefinite, and definite antecedents, even when the
-    referent has a known gender. What unifies these uses (under the
-    underspecified account) is that the discourse representation is
-    thin, not that gender is unknown. -/
-inductive AntecedentType where
-  /-- "There's not a man I meet but doth salute me as if I were their
-      well-acquainted friend" (Shakespeare, Comedy of Errors, 1623). -/
-  | quantified
-  /-- "a single mother and their three children" -/
-  | indefinite
-  /-- "My son will swing by to pick up my order." / "just have them
-      call us when they are here" — definite but not elaborated. -/
-  | definiteUnelaborated
-  deriving DecidableEq, Repr, BEq
-
-/-- All underspecified-*they* antecedent types have underspecified
-    discourse elaboration. This is Arnold's core claim: the unifying
-    factor is discourse specificity, not antecedent definiteness. -/
-def antecedentElaboration : AntecedentType → DiscourseElaboration
-  | .quantified => .underspecified
-  | .indefinite => .underspecified
-  | .definiteUnelaborated => .underspecified
-
-/-- All Table 1 antecedent types license underspecified singular *they*. -/
-theorem table1_all_license_underspecified (a : AntecedentType) :
-    licensesUnderspecified (antecedentElaboration a) = true := by
-  cases a <;> rfl
-
--- ============================================================================
--- § 6: Connection to Gender Layer
--- ============================================================================
-
-/-- Singular *they* bears no gender feature — the [konnelly-cowper-2020]
-    Elsewhere case: *they* spells out a φ-bundle with none of
-    `[MASC]`/`[FEM]`/`[INANIM]`, so its `gender` field is `none`, not a positive epicene
-    value. -/
-theorem singThey_genderless :
-    English.Pronouns.they.gender = none ∧
-    English.Pronouns.them.gender = none ∧
-    English.Pronouns.themself.gender = none := by
-  exact ⟨rfl, rfl, rfl⟩
-
-/-- Singular *they*'s lexical entry carries no surface gender
-    ([konnelly-cowper-2020]): the `gender` field is `none`, the structural
-    correlate of its Elsewhere status — gender-neutrality is the *absence* of a
-    contrastive feature, not a positive value. -/
-theorem they_no_surface_gender :
-    English.Pronouns.they_sg.gender = none := rfl
-
-/-- Underspecified gender info — where gender is unknown — is the
-    discourse-level condition that licenses underspecified *they*. -/
-theorem underspecified_gender_licenses_underspecified_they :
-    licensesUnderspecified DiscourseElaboration.underspecified = true := rfl
-
--- ============================================================================
--- § 7: Predictions
--- ============================================================================
-
-/-- [arnold-2026] §4.1: the contexts supporting personal *they*
-    are often inconsistent with underspecified *they*. Elaborated
-    discourse representations (naming, describing, narrating about a
-    person) make underspecified *they* infelicitous because the discourse
-    model is no longer thin. -/
-theorem elaborated_blocks_underspecified :
-    licensesUnderspecified DiscourseElaboration.elaborated = false := rfl
-
-/-- [arnold-2026] §4.3: personal *they* is harder than
-    underspecified *they*. This is modeled by the additional requirement:
-    personal *they* needs pronoun knowledge in common ground, while
-    underspecified *they* only needs a thin discourse model. -/
-theorem personal_has_stronger_precondition :
-    -- Underspecified they: one condition (thin discourse)
-    licensesUnderspecified DiscourseElaboration.underspecified = true ∧
-    -- Personal they: requires specific pronoun knowledge
-    licensesPersonal none = false ∧
-    licensesPersonal (some PronounSet.heHim) = false ∧
-    licensesPersonal (some PronounSet.sheHer) = false ∧
-    licensesPersonal (some PronounSet.theyThem) = true := by
-  exact ⟨rfl, rfl, rfl, rfl, rfl⟩
-
--- ============================================================================
--- § 8: Gender feature consistency
--- ============================================================================
-
-/-- Singular and plural *they* share the same (empty) gender feature — the
-    structural `gender` field agrees across number. -/
-theorem structural_gender_consistency :
-    English.Pronouns.they_sg.gender =
-    English.Pronouns.they.gender := rfl
-
--- ============================================================================
--- § 9: Bridge to Konnelly & Cowper 2020 (morphosyntactic stages)
--- ============================================================================
-
-/-- **Bridge to [konnelly-cowper-2020]'s grammatical stages.** Arnold's
-    pragmatic *underspecified they* aligns with their Stage 1: while the grammar
-    still obligatorily projects [MASC]/[FEM] for known-gender referents
-    (`Stage.stage1`, `genderObligatory = true`), *they* surfaces only where
-    gender is unknown — the thin-discourse condition that licenses
-    underspecified *they*. (At the gender-default Stage 3, `genderObligatory =
-    false`, so *they* is produced regardless of discourse state, naturally
-    accommodating personal *they*.) -/
-theorem stage1_aligns_with_underspecified_they :
-    licensesUnderspecified DiscourseElaboration.underspecified = true ∧
-    KonnellyCowper2020.Stage.stage1.genderObligatory = true := ⟨rfl, rfl⟩
+/-- On the grammatical account the two kinds do not differ: *they* for a referent of known
+gender is blocked at stage 1, needs an ungendered lexical entry at stage 2, and is free at
+stage 3. -/
+theorem stages_do_not_separate_kinds :
+    genderObligatoryFor .referentialKnownGender .stage1 = true ∧
+      genderObligatoryFor .ungenderedProperName .stage2 = false ∧
+      genderObligatoryFor .referentialKnownGender .stage3 = false := ⟨rfl, rfl, rfl⟩
 
 end Arnold2026


### PR DESCRIPTION
Arnold2026 recut from the squib: the two kinds of singular *they* as pragmatic conditions on a referent's discourse representation, checked against the paper's examples (Table 1's gendered referents, the personal-*they* cases with elaborated representations, the flagged stage-3 counterexample), and the Konnelly–Cowper stages consumed rather than restated. The rfl unpacking of Bool licensing predicates is cut; 13 rows.