### PR TITLE
refactor(Studies/Baker2015): the book's clauses derived by alignment type

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2994,3 +2994,4 @@ import Linglib.Data.Examples.AsherLascarides2003
 import Linglib.Data.Examples.AssmannEtAl2023
 import Linglib.Data.Examples.Asudeh2022
 import Linglib.Data.Examples.AugurzkyEtAl2023
+import Linglib.Data.Examples.Baker2015

--- a/Linglib/Data/Examples/Baker2015.json
+++ b/Linglib/Data/Examples/Baker2015.json
@@ -1,0 +1,417 @@
+[
+  {
+    "id": "baker2015_1a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (1a)"},
+    "reportedIn": null,
+    "language": "yaku1245",
+    "primaryText": "Min kellim.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Min", "I.NOM"], ["kel-li-m", "come-PST-1SG.SBJ"]
+    ],
+    "translation": "I came.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "NOM"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_1b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (1b)"},
+    "reportedIn": null,
+    "language": "yaku1245",
+    "primaryText": "Min oloppohu aldjattym.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Min", "I.NOM"], ["oloppoh-u", "chair-ACC"], ["aldjat-ty-m", "break-PST-1SG.SBJ"]
+    ],
+    "translation": "I broke the chair.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "NOM"],
+      ["objectCase", "ACC"]
+    ],
+    "comment": "From Vinokurova 2005.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_1c",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (1c)"},
+    "reportedIn": null,
+    "language": "yaku1245",
+    "primaryText": "Erel kinigeni atyylasta.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Erel", "Erel.NOM"], ["kinige-ni", "book-ACC"], ["atyylas-ta", "buy-PST.3SG.SBJ"]
+    ],
+    "translation": "Erel bought the book.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "NOM"],
+      ["objectCase", "ACC"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_12a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (12a)"},
+    "reportedIn": null,
+    "language": "ship1254",
+    "primaryText": "Maria-nin-ra ochiti nokoke.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Maria-nin-ra", "Maria-ERG-PRT"], ["ochiti", "dog"], ["noko-ke", "find-PRF"]
+    ],
+    "translation": "Maria found the dog.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "unmarked"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_12b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (12b)"},
+    "reportedIn": null,
+    "language": "ship1254",
+    "primaryText": "Maria-ra kake.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Maria-ra", "Maria-PRT"], ["ka-ke", "go-PRF"]
+    ],
+    "translation": "Maria went.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "unmarked"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_28a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (28a)"},
+    "reportedIn": null,
+    "language": "ship1254",
+    "primaryText": "Jose-kan ochiti benai.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jose-kan", "Jose-ERG"], ["ochiti", "dog"], ["ben-ai", "seek-IPFV"]
+    ],
+    "translation": "José is looking for a/the dog.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "unmarked"],
+      ["genitiveForm", "Jose-kan"]
+    ],
+    "comment": "The ergative suffix is also the genitive of the possessor in Jose-kan ochiti 'José's dog'; only the singular first and third person pronouns have distinct genitive forms.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_28b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (28b)"},
+    "reportedIn": null,
+    "language": "ship1254",
+    "primaryText": "E-n ochiti benai.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["E-n", "I-ERG"], ["ochiti", "dog"], ["ben-ai", "seek-IPFV"]
+    ],
+    "translation": "I am looking for a/the dog.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "unmarked"],
+      ["genitiveForm", "nokon"]
+    ],
+    "comment": "The first-person possessor has the distinct genitive form nokon in nokon ochiti 'my dog'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_30a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (30a)"},
+    "reportedIn": null,
+    "language": "nezp1238",
+    "primaryText": "Hipáayna háama.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hi-páay-na", "3SG.SBJ-arrive-ASP"], ["háama", "man.NOM"]
+    ],
+    "translation": "The man arrived.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "NOM"]
+    ],
+    "comment": "From Rude 1986.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_30b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 1 (30b)"},
+    "reportedIn": null,
+    "language": "nezp1238",
+    "primaryText": "Háamanm hinéec'wiye wewúkiyene.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Háama-nm", "man-ERG"], ["hi-néec-'wi-ye", "3SG.SBJ-PL.OBJ-shoot-ASP"],
+      ["wewúkiye-ne", "elk-ACC"]
+    ],
+    "translation": "The man shot the elk(s).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "ACC"]
+    ],
+    "comment": "From Rude 1986.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_21a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (21a)"},
+    "reportedIn": null,
+    "language": "lezg1247",
+    "primaryText": "Farid atanani?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Farid", "Farid.ABS"], ["ata-na-ni", "come-AOR-Q"]
+    ],
+    "translation": "Has Farid come?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "ABS"]
+    ],
+    "comment": "From Haspelmath 1993.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_21b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (21b)"},
+    "reportedIn": null,
+    "language": "lezg1247",
+    "primaryText": "Sadiq'a jad qhwana.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sadiq'-a", "Sadiq'-ERG"], ["jad", "water.ABS"], ["qhwa-na", "drink-AOR"]
+    ],
+    "translation": "Sadiq' drank water.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "ABS"]
+    ],
+    "comment": "From Haspelmath 1993.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_22a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (22a)"},
+    "reportedIn": null,
+    "language": "west2599",
+    "primaryText": "Ní adapara pírawa.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ní", "I"], ["ada-para", "house-in"], ["píra-wa", "sit-1SG.SBJ"]
+    ],
+    "translation": "I sat in the house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "unmarked"],
+      ["subjectAgreement", "yes"]
+    ],
+    "comment": "From Franklin 1971; Kewa has subject agreement with ergative and absolutive subjects alike and no object agreement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_22b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (22b)"},
+    "reportedIn": null,
+    "language": "west2599",
+    "primaryText": "Némé irikai táwa.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Né-mé", "I-ERG"], ["irikai", "dog"], ["tá-wa", "hit-1SG.SBJ"]
+    ],
+    "translation": "I hit the dog.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "unmarked"],
+      ["subjectAgreement", "yes"]
+    ],
+    "comment": "From Franklin 1971.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_23a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (23a)"},
+    "reportedIn": null,
+    "language": "buru1296",
+    "primaryText": "Dasín háe le hurútumo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dasín", "girl.ABS"], ["há-e", "house-OBL"], ["le", "in"],
+      ["hurút-umo", "sit-PST.3SG.F.SBJ"]
+    ],
+    "translation": "The girl sat in the house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "ABS"],
+      ["subjectAgreement", "yes"]
+    ],
+    "comment": "From Willson 1996.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_23b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (23b)"},
+    "reportedIn": null,
+    "language": "buru1296",
+    "primaryText": "Hilése dasin muyeétsimi.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hilés-e", "boy-ERG"], ["dasin", "girl.ABS"],
+      ["mu-yeéts-imi", "3SG.F.OBJ-see-PST.3SG.M.SBJ"]
+    ],
+    "translation": "The boy saw the girl.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "ABS"],
+      ["subjectAgreement", "yes"],
+      ["objectAgreement", "yes"]
+    ],
+    "comment": "From Willson 1996; the tense suffix agrees with ergative and absolutive subjects alike, the prefix with the absolutive object.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_25a",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (25a)"},
+    "reportedIn": null,
+    "language": "urdu1245",
+    "primaryText": "Nadya nahayi.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Nadya", "Nadya.F.NOM"], ["naha-yi", "bathe-PRF.F.SG"]
+    ],
+    "translation": "Nadya bathed.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "no"],
+      ["subjectCase", "NOM"],
+      ["subjectAgreement", "yes"]
+    ],
+    "comment": "From Butt and King 2003.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "baker2015_25b",
+    "source": {"bibkey": "baker-2015", "paperLabel": "ch. 2 (25b)"},
+    "reportedIn": null,
+    "language": "urdu1245",
+    "primaryText": "Ram=ne gaRi calayi hE.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ram=ne", "Ram.M=ERG"], ["gaRi", "car.F.SG.NOM"], ["cala-yi", "drive-PRF.F.SG"],
+      ["hE", "be.PRS.3SG"]
+    ],
+    "translation": "Ram has driven a car.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["transitive", "yes"],
+      ["subjectCase", "ERG"],
+      ["objectCase", "NOM"],
+      ["subjectAgreement", "no"],
+      ["objectAgreement", "yes"]
+    ],
+    "comment": "From Butt and King 2003; the finite verb agrees with a nominative subject but not with an ergative one.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Baker2015.lean
+++ b/Linglib/Data/Examples/Baker2015.lean
@@ -1,0 +1,324 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Baker2015` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Baker2015.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Baker2015.Examples`.
+-/
+
+namespace Baker2015.Examples
+
+open Data.Examples
+
+def ex_1a : LinguisticExample :=
+  { id := "baker2015_1a"
+    source := ⟨"baker-2015", "ch. 1 (1a)"⟩
+    reportedIn := none
+    language := "yaku1245"
+    primaryText := "Min kellim."
+    discourseSegments := []
+    glossedTokens := [("Min", "I.NOM"), ("kel-li-m", "come-PST-1SG.SBJ")]
+    translation := "I came."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "NOM")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_1b : LinguisticExample :=
+  { id := "baker2015_1b"
+    source := ⟨"baker-2015", "ch. 1 (1b)"⟩
+    reportedIn := none
+    language := "yaku1245"
+    primaryText := "Min oloppohu aldjattym."
+    discourseSegments := []
+    glossedTokens := [("Min", "I.NOM"), ("oloppoh-u", "chair-ACC"), ("aldjat-ty-m", "break-PST-1SG.SBJ")]
+    translation := "I broke the chair."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "NOM"), ("objectCase", "ACC")]
+    comment := "From Vinokurova 2005."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_1c : LinguisticExample :=
+  { id := "baker2015_1c"
+    source := ⟨"baker-2015", "ch. 1 (1c)"⟩
+    reportedIn := none
+    language := "yaku1245"
+    primaryText := "Erel kinigeni atyylasta."
+    discourseSegments := []
+    glossedTokens := [("Erel", "Erel.NOM"), ("kinige-ni", "book-ACC"), ("atyylas-ta", "buy-PST.3SG.SBJ")]
+    translation := "Erel bought the book."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "NOM"), ("objectCase", "ACC")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_12a : LinguisticExample :=
+  { id := "baker2015_12a"
+    source := ⟨"baker-2015", "ch. 1 (12a)"⟩
+    reportedIn := none
+    language := "ship1254"
+    primaryText := "Maria-nin-ra ochiti nokoke."
+    discourseSegments := []
+    glossedTokens := [("Maria-nin-ra", "Maria-ERG-PRT"), ("ochiti", "dog"), ("noko-ke", "find-PRF")]
+    translation := "Maria found the dog."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "unmarked")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_12b : LinguisticExample :=
+  { id := "baker2015_12b"
+    source := ⟨"baker-2015", "ch. 1 (12b)"⟩
+    reportedIn := none
+    language := "ship1254"
+    primaryText := "Maria-ra kake."
+    discourseSegments := []
+    glossedTokens := [("Maria-ra", "Maria-PRT"), ("ka-ke", "go-PRF")]
+    translation := "Maria went."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "unmarked")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_28a : LinguisticExample :=
+  { id := "baker2015_28a"
+    source := ⟨"baker-2015", "ch. 1 (28a)"⟩
+    reportedIn := none
+    language := "ship1254"
+    primaryText := "Jose-kan ochiti benai."
+    discourseSegments := []
+    glossedTokens := [("Jose-kan", "Jose-ERG"), ("ochiti", "dog"), ("ben-ai", "seek-IPFV")]
+    translation := "José is looking for a/the dog."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "unmarked"), ("genitiveForm", "Jose-kan")]
+    comment := "The ergative suffix is also the genitive of the possessor in Jose-kan ochiti 'José's dog'; only the singular first and third person pronouns have distinct genitive forms."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_28b : LinguisticExample :=
+  { id := "baker2015_28b"
+    source := ⟨"baker-2015", "ch. 1 (28b)"⟩
+    reportedIn := none
+    language := "ship1254"
+    primaryText := "E-n ochiti benai."
+    discourseSegments := []
+    glossedTokens := [("E-n", "I-ERG"), ("ochiti", "dog"), ("ben-ai", "seek-IPFV")]
+    translation := "I am looking for a/the dog."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "unmarked"), ("genitiveForm", "nokon")]
+    comment := "The first-person possessor has the distinct genitive form nokon in nokon ochiti 'my dog'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_30a : LinguisticExample :=
+  { id := "baker2015_30a"
+    source := ⟨"baker-2015", "ch. 1 (30a)"⟩
+    reportedIn := none
+    language := "nezp1238"
+    primaryText := "Hipáayna háama."
+    discourseSegments := []
+    glossedTokens := [("Hi-páay-na", "3SG.SBJ-arrive-ASP"), ("háama", "man.NOM")]
+    translation := "The man arrived."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "NOM")]
+    comment := "From Rude 1986."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_30b : LinguisticExample :=
+  { id := "baker2015_30b"
+    source := ⟨"baker-2015", "ch. 1 (30b)"⟩
+    reportedIn := none
+    language := "nezp1238"
+    primaryText := "Háamanm hinéec'wiye wewúkiyene."
+    discourseSegments := []
+    glossedTokens := [("Háama-nm", "man-ERG"), ("hi-néec-'wi-ye", "3SG.SBJ-PL.OBJ-shoot-ASP"), ("wewúkiye-ne", "elk-ACC")]
+    translation := "The man shot the elk(s)."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "ACC")]
+    comment := "From Rude 1986."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21a : LinguisticExample :=
+  { id := "baker2015_21a"
+    source := ⟨"baker-2015", "ch. 2 (21a)"⟩
+    reportedIn := none
+    language := "lezg1247"
+    primaryText := "Farid atanani?"
+    discourseSegments := []
+    glossedTokens := [("Farid", "Farid.ABS"), ("ata-na-ni", "come-AOR-Q")]
+    translation := "Has Farid come?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "ABS")]
+    comment := "From Haspelmath 1993."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21b : LinguisticExample :=
+  { id := "baker2015_21b"
+    source := ⟨"baker-2015", "ch. 2 (21b)"⟩
+    reportedIn := none
+    language := "lezg1247"
+    primaryText := "Sadiq'a jad qhwana."
+    discourseSegments := []
+    glossedTokens := [("Sadiq'-a", "Sadiq'-ERG"), ("jad", "water.ABS"), ("qhwa-na", "drink-AOR")]
+    translation := "Sadiq' drank water."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "ABS")]
+    comment := "From Haspelmath 1993."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22a : LinguisticExample :=
+  { id := "baker2015_22a"
+    source := ⟨"baker-2015", "ch. 2 (22a)"⟩
+    reportedIn := none
+    language := "west2599"
+    primaryText := "Ní adapara pírawa."
+    discourseSegments := []
+    glossedTokens := [("Ní", "I"), ("ada-para", "house-in"), ("píra-wa", "sit-1SG.SBJ")]
+    translation := "I sat in the house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "unmarked"), ("subjectAgreement", "yes")]
+    comment := "From Franklin 1971; Kewa has subject agreement with ergative and absolutive subjects alike and no object agreement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22b : LinguisticExample :=
+  { id := "baker2015_22b"
+    source := ⟨"baker-2015", "ch. 2 (22b)"⟩
+    reportedIn := none
+    language := "west2599"
+    primaryText := "Némé irikai táwa."
+    discourseSegments := []
+    glossedTokens := [("Né-mé", "I-ERG"), ("irikai", "dog"), ("tá-wa", "hit-1SG.SBJ")]
+    translation := "I hit the dog."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "unmarked"), ("subjectAgreement", "yes")]
+    comment := "From Franklin 1971."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23a : LinguisticExample :=
+  { id := "baker2015_23a"
+    source := ⟨"baker-2015", "ch. 2 (23a)"⟩
+    reportedIn := none
+    language := "buru1296"
+    primaryText := "Dasín háe le hurútumo."
+    discourseSegments := []
+    glossedTokens := [("Dasín", "girl.ABS"), ("há-e", "house-OBL"), ("le", "in"), ("hurút-umo", "sit-PST.3SG.F.SBJ")]
+    translation := "The girl sat in the house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "ABS"), ("subjectAgreement", "yes")]
+    comment := "From Willson 1996."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23b : LinguisticExample :=
+  { id := "baker2015_23b"
+    source := ⟨"baker-2015", "ch. 2 (23b)"⟩
+    reportedIn := none
+    language := "buru1296"
+    primaryText := "Hilése dasin muyeétsimi."
+    discourseSegments := []
+    glossedTokens := [("Hilés-e", "boy-ERG"), ("dasin", "girl.ABS"), ("mu-yeéts-imi", "3SG.F.OBJ-see-PST.3SG.M.SBJ")]
+    translation := "The boy saw the girl."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "ABS"), ("subjectAgreement", "yes"), ("objectAgreement", "yes")]
+    comment := "From Willson 1996; the tense suffix agrees with ergative and absolutive subjects alike, the prefix with the absolutive object."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25a : LinguisticExample :=
+  { id := "baker2015_25a"
+    source := ⟨"baker-2015", "ch. 2 (25a)"⟩
+    reportedIn := none
+    language := "urdu1245"
+    primaryText := "Nadya nahayi."
+    discourseSegments := []
+    glossedTokens := [("Nadya", "Nadya.F.NOM"), ("naha-yi", "bathe-PRF.F.SG")]
+    translation := "Nadya bathed."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "no"), ("subjectCase", "NOM"), ("subjectAgreement", "yes")]
+    comment := "From Butt and King 2003."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25b : LinguisticExample :=
+  { id := "baker2015_25b"
+    source := ⟨"baker-2015", "ch. 2 (25b)"⟩
+    reportedIn := none
+    language := "urdu1245"
+    primaryText := "Ram=ne gaRi calayi hE."
+    discourseSegments := []
+    glossedTokens := [("Ram=ne", "Ram.M=ERG"), ("gaRi", "car.F.SG.NOM"), ("cala-yi", "drive-PRF.F.SG"), ("hE", "be.PRS.3SG")]
+    translation := "Ram has driven a car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("transitive", "yes"), ("subjectCase", "ERG"), ("objectCase", "NOM"), ("subjectAgreement", "no"), ("objectAgreement", "yes")]
+    comment := "From Butt and King 2003; the finite verb agrees with a nominative subject but not with an ergative one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1a, ex_1b, ex_1c, ex_12a, ex_12b, ex_28a, ex_28b, ex_30a, ex_30b, ex_21a, ex_21b, ex_22a, ex_22b, ex_23a, ex_23b, ex_25a, ex_25b]
+
+end Baker2015.Examples

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -1,447 +1,101 @@
 import Linglib.Syntax.Case.Dependent
-import Linglib.Syntax.Case.Alignment
-import Linglib.Fragments.German.Case
-import Linglib.Fragments.Turkish.Case
-import Linglib.Fragments.Hindi.Case
-import Linglib.Fragments.Basque.Agreement
-import Linglib.Fragments.Georgian.Agreement
-import Linglib.Fragments.Mayan.Chol.Agreement
-import Linglib.Syntax.Clause.ArgumentRole
+import Linglib.Data.Examples.Baker2015
 
 /-!
-# Baker (2015) — Case: Its Principles and Its Parameters
-[baker-2015] [marantz-1991] [baker-vinokurova-2010]
+# Baker 2015: dependent case
 
-[baker-2015]'s monograph takes the dependent case algorithm
-originally proposed by [marantz-1991] and refined by
-[baker-vinokurova-2010] for Sakha and develops it as a *cross-
-linguistic* theory of morphological case, sweeping accusative,
-ergative, and split-ergative systems under one assignment mechanism.
-The algorithm:
+Structural case cannot in general be read off agreement with a functional head: ergative
+languages let the finite verb agree with ergative and absolutive subjects alike, and the
+subject must already be ergative before Agree applies. The book takes up Marantz's dependent
+case instead. In a spell-out domain, an NP with lexically governed case keeps it; of two
+distinct caseless NPs one of which c-commands the other, the lower is valued accusative or the
+higher ergative — which of these a language does is its alignment parameter, and a tripartite
+language does both; whatever remains is unmarked, nominative in the clause and genitive in the
+noun phrase. Sakha, Shipibo and Nez Perce show the three settings on the simplest transitive
+and intransitive clauses, and the twenty-odd languages the book studies in depth sort into
+those columns together with marked-nominative and marked-absolutive systems, which differ in
+how the unmarked case is realized.
 
-1. **Lexical case** assigned by selecting heads (highest priority)
-2. **Dependent case** assigned to one of two distinct caseless NPs in
-   the same domain — ACC to the lower NP in accusative alignment,
-   ERG to the higher NP in ergative alignment
-3. **Unmarked case** assigned to remaining caseless NPs — NOM in
-   accusative, ABS in ergative
-4. **Default case** as last resort (not modeled here)
+## Main definitions
 
-This study file runs `Syntax/Case/Dependent.lean`'s
-`assignCases` over representative languages from each of Baker's
-typological columns and proves the output matches the surface case
-patterns documented in the Fragment inventories.
+* `alignment?`: the book's sorting of its languages by alignment type.
+* `Observed`, `Realizes`: the case a gloss shows, and when the algorithm's output realizes it.
+* `rows_case`: the book's introductory clauses, each derived by `assignCases` from its
+  alignment type.
 
-## Structure
+## References
 
-- **§ 1**: Split-ergative syncretism (Hindi, Georgian) — the abstract
-  ABS that the algorithm produces realizes morphologically as NOM in
-  these languages.
-- **§ 2**: Concrete derivations for accusative (German, Turkish),
-  ergative (Basque), and split-ergative (Hindi, Georgian) languages.
-
-## The ABS/NOM Mismatch in Split-Ergative Languages
-
-The dependent case algorithm assigns ABS (`.abs`) as the
-unmarked case in ergative alignment. Hindi and Georgian, however,
-realize this function morphologically as NOM (no overt marker), not
-as a distinct ABS form — their inventories contain ERG (the dependent
-case) but not ABS. [baker-2015] treats this as the canonical
-abstract-vs-morphological case distinction inherited from
-[marantz-1991]: many split-ergative languages have a syncretic
-unmarked case serving both nominative (accusative frames) and
-absolutive (ergative frames) functions.
-
-[baker-vinokurova-2010]'s Sakha analysis is the empirical
-foundation of one of Baker's columns; that paper's full derivations
-live in `Studies/BakerVinokurova2010.lean` and are not
-duplicated here. Marantz's original abstract-vs-morphological case
-distinction and its Georgian application live in
-`Studies/Marantz1991.lean`.
+* [baker-2015]
+* [marantz-1991] — the disjunctive hierarchy and dependent case
+* [baker-vinokurova-2010] — the c-command formulation
 -/
 
 namespace Baker2015
 
-open Syntax.Case
+open Data.Examples Syntax.Case
 
--- ============================================================================
--- § 1: Split-Ergative Syncretism
--- ============================================================================
+/-- The book's languages of focus by alignment type: accusative Sakha, Tamil, Amharic, Cuzco
+    Quechua, Korean and Finnish; ergative Shipibo, Burushaski, Chukchi, Lezgian, Ingush,
+    Greenlandic, Kewa and Wardaman; tripartite Nez Perce, Coast Tsimshian, Semelai, Diyari and
+    Warlpiri. The marked-nominative and marked-absolutive languages differ in the realization of
+    the unmarked case, which the algorithm does not fix. -/
+def alignment? : String → Option CaseLanguageType
+  | "yaku1245" | "tami1289" | "amha1245" | "cusc1236" | "kore1280" | "finn1318" =>
+    some .accusative
+  | "ship1254" | "buru1296" | "chuk1273" | "lezg1247" | "ingu1240" | "kala1399" | "west2599"
+  | "ward1246" => some .ergative
+  | "nezp1238" | "coas1300" | "seme1247" | "dier1241" | "warl1254" => some .tripartite
+  | _ => none
 
-/-! Hindi and Georgian are split-ergative: accusative alignment in some
-    tense/aspect contexts, ergative alignment in others. We prove:
-    (1) Full accusative structural coverage (NOM, ACC ∈ inventory)
-    (2) ERG ∈ inventory (the dependent case in ergative frames)
-    (3) ABS ∉ inventory — these languages realize the absolutive function
-        morphologically as NOM, so the algorithm's ABS output maps to a
-        case that is in the inventory under a different label. -/
+/-- The case a gloss shows: a dependent case, or an unmarked form — nominative, absolutive,
+    or no marking at all. -/
+inductive Observed
+  | erg
+  | acc
+  | unmarked
+  deriving DecidableEq, Repr
 
--- Hindi: perfective = ergative, imperfective = accusative
-theorem hindi_accusative_coverage :
-    ∀ cv ∈ structuralCasesFor .accusative, cv ∈ Hindi.Case.caseInventory := by
+/-- The gloss labels of the book's examples. -/
+def Observed.parse? : String → Option Observed
+  | "ERG" => some .erg
+  | "ACC" => some .acc
+  | "NOM" | "ABS" | "unmarked" => some .unmarked
+  | _ => none
+
+/-- An assigned case realizes an observed one: the dependent cases as themselves, and the
+    unmarked case as whatever label the language gives it. -/
+def Realizes (c : Case) (src : CaseSource) : Observed → Prop
+  | .erg => c = .erg ∧ src = .dependent
+  | .acc => c = .acc ∧ src = .dependent
+  | .unmarked => src = .unmarked
+
+instance (c : Case) (src : CaseSource) (o : Observed) : Decidable (Realizes c src o) := by
+  cases o <;> simp only [Realizes] <;> infer_instance
+
+/-- The NPs of a row's clause, subject first: it c-commands the object. -/
+def domain (r : LinguisticExample) : List NPInDomain :=
+  ⟨"subject", none⟩ :: if r.feature? "transitive" = some "yes" then [⟨"object", none⟩] else []
+
+/-- The observed case of a row's NP. -/
+def observed? (r : LinguisticExample) (np : String) : Option Observed :=
+  (r.feature? (np ++ "Case")).bind Observed.parse?
+
+/-- Every clause the book introduces its languages with is derived by the algorithm from the
+    language's alignment type: the ergative and accusative NPs are the dependent-case NPs and
+    the nominative, absolutive and unmarked NPs the leftovers. -/
+theorem rows_case :
+    ∀ r ∈ Examples.all, ∀ lang ∈ alignment? r.language, ∀ np ∈ ["subject", "object"],
+      ∀ o ∈ observed? r np, ∀ c ∈ getCaseOf np (assignCases lang (domain r)),
+        ∀ src ∈ getSourceOf np (assignCases lang (domain r)), Realizes c src o := by
   decide
 
-theorem hindi_erg_in_inventory :
-    .erg ∈ Hindi.Case.caseInventory := by
-  native_decide
-
-/-- ABS is not in Hindi's inventory: the absolutive function (unmarked S/P
-    in perfective) is morphologically NOM. -/
-theorem hindi_abs_not_in_inventory :
-    .abs ∉ Hindi.Case.caseInventory := by decide
-
-/-- But NOM IS in the inventory, documenting the ABS → NOM syncretism. -/
-theorem hindi_nom_covers_abs_function :
-    .nom ∈ Hindi.Case.caseInventory := by decide
-
--- Georgian: aorist = ergative, present/evidential = accusative-like
-theorem georgian_erg_in_inventory :
-    .erg ∈ Georgian.Agreement.fullCaseInventory := by decide
-
-/-- ABS is not in Georgian's inventory: the absolutive function is
-    morphologically NOM in both aorist (ergative) and present (accusative)
-    frames. -/
-theorem georgian_abs_not_in_inventory :
-    .abs ∉ Georgian.Agreement.fullCaseInventory := by decide
-
-/-- NOM covers the absolutive function in Georgian. -/
-theorem georgian_nom_covers_abs_function :
-    .nom ∈ Georgian.Agreement.fullCaseInventory := by decide
-
--- ============================================================================
--- § 2: Concrete Derivation Examples
--- ============================================================================
-
-/-! ## German Derivations
-
-"Der Mann sieht die Frau" (The man sees the woman)
-- Transitive: subject (higher) + object (lower), both without lexical case
-- Subject → NOM (unmarked), Object → ACC (dependent)
-
-"Der Mann schläft" (The man sleeps)
-- Intransitive: single NP without lexical case
-- Subject → NOM (unmarked, no case competitor) -/
-
-def germanTransitiveNPs : List NPInDomain :=
-  [⟨"subject", none⟩, ⟨"object", none⟩]
-
-def germanIntransitiveNPs : List NPInDomain :=
-  [⟨"subject", none⟩]
-
-theorem german_transitive_subject_nom :
-    getCaseOf "subject" (assignCases .accusative germanTransitiveNPs) = some .nom := by
-  native_decide
-
-theorem german_transitive_object_acc :
-    getCaseOf "object" (assignCases .accusative germanTransitiveNPs) = some .acc := by
-  native_decide
-
-theorem german_intransitive_subject_nom :
-    getCaseOf "subject" (assignCases .accusative germanIntransitiveNPs) = some .nom := by
-  native_decide
-
-/-- All cases in the German transitive derivation are in German's inventory. -/
-theorem german_transitive_in_inventory :
-    ∀ np ∈ assignCases .accusative germanTransitiveNPs,
-      np.case ∈ German.Case.caseInventory := by decide
-
-/-- All cases in the German intransitive derivation are in German's inventory. -/
-theorem german_intransitive_in_inventory :
-    ∀ np ∈ assignCases .accusative germanIntransitiveNPs,
-      np.case ∈ German.Case.caseInventory := by decide
-
-/-! ## Turkish Derivations
-
-"Adam kadını gördü" (The man saw the woman)
-- Transitive: subject NOM (∅), object ACC (-I)
-
-"Adam uyudu" (The man slept)
-- Intransitive: subject NOM (∅) -/
-
-def turkishTransitiveNPs : List NPInDomain :=
-  [⟨"subject", none⟩, ⟨"object", none⟩]
-
-def turkishIntransitiveNPs : List NPInDomain :=
-  [⟨"subject", none⟩]
-
-theorem turkish_transitive_cases :
-    getCaseOf "subject" (assignCases .accusative turkishTransitiveNPs) = some .nom ∧
-    getCaseOf "object" (assignCases .accusative turkishTransitiveNPs) = some .acc := by
-  native_decide
-
-theorem turkish_intransitive_case :
-    getCaseOf "subject" (assignCases .accusative turkishIntransitiveNPs) = some .nom := by
-  native_decide
-
-theorem turkish_transitive_in_inventory :
-    ∀ np ∈ assignCases .accusative turkishTransitiveNPs,
-      np.case ∈ Turkish.Case.caseInventory := by decide
-
-/-! ## Basque Derivations (Ergative)
-
-"Gizonak mutila ikusi du" (The man-ERG boy-ABS see AUX)
-- Transitive: agent (higher) → ERG (dependent), patient (lower) → ABS (unmarked)
-
-"Mutila etorri da" (The boy-ABS come AUX)
-- Intransitive: sole NP → ABS (unmarked, no case competitor) -/
-
-def basqueTransitiveNPs : List NPInDomain :=
-  [⟨"agent", none⟩, ⟨"patient", none⟩]
-
-def basqueIntransitiveNPs : List NPInDomain :=
-  [⟨"subject", none⟩]
-
-theorem basque_transitive_agent_erg :
-    getCaseOf "agent" (assignCases .ergative basqueTransitiveNPs) = some .erg := by
-  native_decide
-
-theorem basque_transitive_patient_abs :
-    getCaseOf "patient" (assignCases .ergative basqueTransitiveNPs) = some .abs := by
-  native_decide
-
-theorem basque_intransitive_subject_abs :
-    getCaseOf "subject" (assignCases .ergative basqueIntransitiveNPs) = some .abs := by
-  native_decide
-
-/-- All cases in the Basque transitive derivation are in Basque's inventory. -/
-theorem basque_transitive_in_inventory :
-    ∀ np ∈ assignCases .ergative basqueTransitiveNPs,
-      np.case ∈ Basque.Agreement.fullCaseInventory := by decide
-
-/-- All cases in the Basque intransitive derivation are in Basque's inventory. -/
-theorem basque_intransitive_in_inventory :
-    ∀ np ∈ assignCases .ergative basqueIntransitiveNPs,
-      np.case ∈ Basque.Agreement.fullCaseInventory := by decide
-
-/-! ## Hindi Split-Ergative Derivations
-
-Hindi perfective transitive: "Raam-ne roTii khaayii"
-(Ram-ERG bread-NOM ate) — ergative alignment
-
-Hindi imperfective transitive: "Raam roTii khaataa hai"
-(Ram-NOM bread-ACC eats AUX) — accusative alignment
-
-The same structural configuration (agent + patient) yields different
-case frames depending on the tense/aspect conditioning of the split. -/
-
-def hindiTransitiveNPs : List NPInDomain :=
-  [⟨"agent", none⟩, ⟨"patient", none⟩]
-
--- Imperfective: accusative alignment
-theorem hindi_imperfective_agent_nom :
-    getCaseOf "agent" (assignCases .accusative hindiTransitiveNPs) = some .nom := by
-  native_decide
-
-theorem hindi_imperfective_patient_acc :
-    getCaseOf "patient" (assignCases .accusative hindiTransitiveNPs) = some .acc := by
-  native_decide
-
-theorem hindi_imperfective_in_inventory :
-    ∀ np ∈ assignCases .accusative hindiTransitiveNPs,
-      np.case ∈ Hindi.Case.caseInventory := by decide
-
--- Perfective: ergative alignment
-theorem hindi_perfective_agent_erg :
-    getCaseOf "agent" (assignCases .ergative hindiTransitiveNPs) = some .erg := by
-  native_decide
-
-theorem hindi_perfective_patient_abs :
-    getCaseOf "patient" (assignCases .ergative hindiTransitiveNPs) = some .abs := by
-  native_decide
-
-/-- In the perfective (ergative alignment), ERG is in the inventory
-    but ABS is not — it is realized as NOM. The agent case (ERG) is
-    correctly predicted; the patient case (ABS → NOM) requires the
-    morphological identity documented in § 1. -/
-theorem hindi_perfective_erg_in_inventory :
-    .erg ∈ Hindi.Case.caseInventory := by
-  native_decide
-
-/-! ## Georgian Split-Ergative Derivations
-
-Georgian aorist transitive: "K'ac-ma bavšv-i naxa"
-(Man-ERG child-NOM saw) — ergative alignment
-
-Georgian present transitive: "K'ac-i bavšv-s xedavs"
-(Man-NOM child-DAT sees) — accusative-like, with lexical DAT on object
-
-In the present series, the patient receives lexical DAT from the verb,
-not structural ACC from dependent case. -/
-
-def georgianAoristNPs : List NPInDomain :=
-  [⟨"agent", none⟩, ⟨"patient", none⟩]
-
-def georgianPresentNPs : List NPInDomain :=
-  [⟨"agent", none⟩, ⟨"patient", some .dat⟩]
-
--- Aorist: ergative alignment
-theorem georgian_aorist_agent_erg :
-    getCaseOf "agent" (assignCases .ergative georgianAoristNPs) = some .erg := by
-  native_decide
-
-theorem georgian_aorist_patient_abs :
-    getCaseOf "patient" (assignCases .ergative georgianAoristNPs) = some .abs := by
-  native_decide
-
-/-- The agent ERG in the aorist is in Georgian's inventory. -/
-theorem georgian_aorist_erg_in_inventory :
-    .erg ∈ Georgian.Agreement.fullCaseInventory := by
+/-- Agreement does not enter the algorithm: a subject is ergative in a transitive clause and
+    unmarked in an intransitive one whether or not the verb agrees with it, as in Kewa and
+    Burushaski. -/
+theorem ergative_subject_independent_of_agreement :
+    ∀ r ∈ Examples.all, alignment? r.language = some .ergative →
+      getCaseOf "subject" (assignCases .ergative (domain r)) =
+        some (if r.feature? "transitive" = some "yes" then .erg else .abs) := by
   decide
-
--- Present: accusative-like alignment with lexical DAT on patient
-theorem georgian_present_agent_nom :
-    getCaseOf "agent" (assignCases .accusative georgianPresentNPs) = some .nom := by
-  native_decide
-
-theorem georgian_present_patient_dat :
-    getCaseOf "patient" (assignCases .accusative georgianPresentNPs) = some .dat := by
-  native_decide
-
-/-- In the present series, lexical DAT on the patient bleeds dependent
-    ACC: the agent gets NOM (no case competitor) and the patient gets
-    DAT (lexical from V). Both are in Georgian's inventory. -/
-theorem georgian_present_in_inventory :
-    ∀ np ∈ assignCases .accusative georgianPresentNPs,
-      np.case ∈ Georgian.Agreement.fullCaseInventory := by
-  decide
-
--- ============================================================================
--- § 3: Comparison with [coon-2013]'s inherent-ERG account of Chol
--- ============================================================================
-
-/-! [coon-2013]'s Chol monograph licenses ERG as **inherent** case from
-    transitive *v*. Marantz/Baker dependent case derives the same surface
-    case pattern from a structural-configurational rule (lower NP gets
-    ERG-as-dependent in the higher-NP-as-caseless configuration). The two
-    accounts agree on the surface case table for Chol perfective monotransitive
-    clauses but disagree on the licensing mechanism: Coon's ERG is licensed
-    *lexically* by v⁰; Baker's ERG is licensed *configurationally* by the
-    presence of a c-commanding caseless NP.
-
-    The agreement at the table level is provable here: both Baker's
-    `Alignment.ergative.assignCase` (the Phase-4 typological ground truth) and
-    the Chol fragment's perfective pattern (`Mayan.caseChol .Perf`, the
-    same function by definition) produce identical case for A/S/P. The disagreement
-    is invisible at this level — it shows up only when one asks *why* a given
-    case appears, not *which* case appears.
-
-    See `Studies/Woolford1997.lean` for the inherent-ergative
-    defense against the dependent derivation; see
-    `Studies/CoonMateoPedroPreminger2014.lean` for the
-    Chol-specific extraction-asymmetry argument. -/
-
-section ComparisonWithCoon2013
-
-/-! ### Configurational ↔ functional equivalence (the load-bearing bridge)
-
-The real cross-framework claim isn't that the Chol fragment matches the
-Phase-4 typological function — that holds tautologically by construction
-(Phase 3 derives the Mayan substrate from the Phase-4 functions). The
-non-trivial claim is that **`assignCases` (Marantz/Baker's configurational
-algorithm) and `Alignment.ergative.assignCase` (the typological-functional
-ground truth) compute the same case for each argument role**, even though
-they do so by entirely different mechanisms:
-
-- `assignCases .ergative twoNPs` runs a list-based algorithm that pattern-
-  matches on c-command relations and dispatches via `dependentErgative` /
-  `unmarkedCaseFor`. Output structure: `List CasedNP` with source labels.
-- `Alignment.ergative.assignCase .A` is a direct typological lookup
-  (`| .A => .erg | .S | .P => .abs | ...`).
-
-If the two ever diverged on the surface table, one of the layers would be
-empirically wrong. The equivalence theorems below verify they don't,
-through `decide` over the actual computation.
--/
-
-/-- Bijection from monotransitive ArgumentRole to NP labels in Baker's
-    list-based domain representation. The agent c-commands the patient
-    (Marantz/Baker convention: list-position-first = highest), so A maps
-    to the first NP and P to the second. -/
-def transitiveMonoNPs : List NPInDomain :=
-  [ { label := "agent",   lexicalCase := none }
-  , { label := "patient", lexicalCase := none } ]
-
-/-- Bijection for the intransitive case: a single NP labeled "subject" is
-    the sole argument S. -/
-def intransitiveNPs : List NPInDomain :=
-  [ { label := "subject", lexicalCase := none } ]
-
-/-- **Configurational ↔ functional equivalence on the ergative monotransitive
-    table.** Marantz/Baker's `assignCases .ergative` over a 2-NP domain
-    produces the same case for "agent"/"patient" as the typological
-    `Alignment.ergative.assignCase` produces for `.A`/`.P`. The proof goes
-    through `decide` over the actual list-pattern-match computation in
-    `assignCases` — NOT through definitional equality, since the two
-    functions have completely different bodies. If `dependentErgative`'s
-    c-command rule ever diverged from the typological table, this would
-    fail. -/
-theorem dependent_ergative_matches_alignment_function_transitive :
-    getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)
-      = some (Alignment.ergative.assignCase .A) ∧
-    getCaseOf "patient" (assignCases .ergative transitiveMonoNPs)
-      = some (Alignment.ergative.assignCase .P) := by decide
-
-/-- **Same equivalence for the intransitive case.** `assignCases .ergative`
-    on a single NP returns ABS via the unmarked-case fallback;
-    `Alignment.ergative.assignCase .S` returns ABS via direct lookup. They
-    agree. -/
-theorem dependent_ergative_matches_alignment_function_intransitive :
-    getCaseOf "subject" (assignCases .ergative intransitiveNPs)
-      = some (Alignment.ergative.assignCase .S) := by decide
-
-/-- **Same equivalence for accusative alignment.** Marantz/Baker's
-    accusative dispatch produces the same per-role case as
-    `Alignment.nominativeAccusative.assignCase`. The Mayan fragment doesn't
-    use this branch (Mayan doesn't have nominative-accusative monotransitive
-    clauses), but the equivalence is symmetric — Baker's algorithm and the
-    typological function agree on accusative as well as ergative. -/
-theorem dependent_accusative_matches_alignment_function_transitive :
-    getCaseOf "agent" (assignCases .accusative transitiveMonoNPs)
-      = some (Alignment.nominativeAccusative.assignCase .A) ∧
-    getCaseOf "patient" (assignCases .accusative transitiveMonoNPs)
-      = some (Alignment.nominativeAccusative.assignCase .P) := by decide
-
-/-- The equivalence at the **surface case** level (theorems above) does NOT
-    extend to the **licensing source** level. Marantz/Baker's algorithm
-    labels Chol's perfective ergative case as `.dependent` (configurational
-    — assigned by the c-command rule). [coon-2013]'s inherent-from-v
-    account would label it as `.lexical` (assigned by selecting head v⁰).
-    The two accounts disagree on *what licenses* the case, even though they
-    agree on *which* case appears.
-
-    This theorem makes the disagreement formal: the dependent algorithm
-    assigns source `.dependent` to the agent in a Chol-like ergative
-    transitive — a label distinct from `.lexical`, the source Coon's
-    inherent-from-v account would predict if formalized as a function of
-    the same shape. -/
-theorem dependent_source_distinct_from_inherent :
-    getSourceOf "agent" (assignCases .ergative transitiveMonoNPs)
-      = some .dependent ∧
-    (.dependent : CaseSource) ≠ .lexical := by
-  refine ⟨by decide, by decide⟩
-
-/-- The Chol fragment's case table (Phase 3) inherits the equivalence
-    automatically: since `Mayan.caseChol .Perf .A` is definitionally
-    equal to `Alignment.ergative.assignCase .A` (via the Phase-3 substrate
-    chain), the equivalence theorem above immediately yields
-    `getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)`
-    `= some ArgumentRole.agent.ergCase`. We state this
-    one Chol-specific corollary explicitly so downstream Mayan consumers
-    can cite it directly. -/
-theorem chol_perfective_ergCase_matches_dependent :
-    getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)
-      = some ((Mayan.caseChol .Perf) .A) := by decide
-
-/-- **Dependent case is INSUFFICIENT for extended ergative.** The Chol
-    non-perfective S/A → GEN, P → ABS pattern is a fourth typological
-    arrangement that Baker's algorithm cannot derive without auxiliary
-    nominalization machinery. [coon-2013] supplies that machinery via
-    embedded nominalization; [imanishi-2020] via parameterized
-    inherent vs structural Case. Either way, Baker's algorithm alone is
-    not a complete theory of ergative-class case assignment. -/
-theorem dependent_case_insufficient_for_extended_ergative :
-    Alignment.ergative.assignCase .A ≠ Alignment.extendedErgative.assignCase .A := by decide
-
-end ComparisonWithCoon2013
 
 end Baker2015

--- a/references.bib
+++ b/references.bib
@@ -16881,7 +16881,7 @@
   doi       = {10.1017/cbo9781107295186},
   subfield  = {syntax},
   validated = {true},
-  role      = {cited},
+  role      = {formalized},
   sources   = {Studies/Baker2015.lean}
 }% REF: Baier, N. B. (2018). Anti-agreement.
 @phdthesis{baier-2018,


### PR DESCRIPTION
Verified against the monograph (Marantz's disjunctive hierarchy, the accusative/ergative dependent-case rules, the alignment sorting of the book's languages). Replaces the `native_decide` inventory checks over German/Turkish/Basque/Hindi/Georgian and the Coon 2013 comparison section with 16 of the book's own clauses (Sakha, Shipibo, Nez Perce, Lezgian, Kewa, Burushaski, Urdu), each derived by `assignCases` from the alignment column the book assigns its language, with the unmarked case realized as whatever label the gloss shows.