### PR TITLE
refactor(Syntax/Case/Dependent): rules per domain, phase layer under Minimalist

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2998,3 +2998,4 @@ import Linglib.Data.Examples.Asudeh2022
 import Linglib.Data.Examples.AugurzkyEtAl2023
 import Linglib.Data.Examples.Baker2015
 import Linglib.Data.Examples.BakerVinokurova2010
+import Linglib.Syntax.Minimalist.Case.Dependent

--- a/Linglib/Fragments/Mongolian/Case.lean
+++ b/Linglib/Fragments/Mongolian/Case.lean
@@ -1,66 +1,32 @@
 import Linglib.Features.Case.Basic
-import Linglib.Syntax.Case.Dependent
+import Linglib.Syntax.Minimalist.Case.Dependent
 import Linglib.Syntax.Minimalist.LateMerger
 
 /-!
-# Mongolian Case System
-[gong-2022] [baker-vinokurova-2010]
+# Mongolian case
 
-Mongolian (Khalkha/Chakhar) uses a hybrid case assignment system:
+Mongolian (Khalkha and Chakhar) has an accusative-aligned system in which accusative is a
+dependent case, valued on the lower of two NPs in the clause, nominative is assigned by finite T
+under Agree, and dative is nonstructural. Because accusative is configurational it is available
+at intermediate positions of a scrambling chain wherever a case competitor exists, which is what
+Wholesale Late Merger needs to bleed Condition C; Condition C reconstruction tracks these case
+positions rather than scrambling type or the A/A-bar distinction.
 
-- **Accusative**: dependent case, assigned when two argumental NPs in the
-  same phase compete and the higher NP c-commands the lower one
-  (following [baker-vinokurova-2010]'s analysis of Sakha)
-- **Nominative**: assigned by finite T via Agree
-- **Dative**: nonstructural (inherent) case
+## References
 
-This hybrid system is the key to understanding Condition C
-reconstruction effects in Mongolian scrambling ([gong-2022]):
-because ACC is a dependent case, it can be assigned at intermediate
-positions on a scrambling chain (wherever a case competitor exists),
-providing the case positions needed for Wholesale Late Merger.
-
-## Scrambling types
-
-Mongolian has three clause-internal scrambling types (short, intermediate,
-long-distance) and two clause-external types (subject and object
-cross-clausal). All behave like A-movement in terms of anaphor binding
-and WCO amelioration, but differ in Condition C reconstruction —
-tracking case positions, not the A/A-bar distinction.
-
-## Case assignment rules
-
-[gong-2022] (26)/(84):
-a. If two distinct argumental NPs in the same phase are such that NP1
-   c-commands NP2, value NP2 as ACC, unless NP1 is already marked for case.
-b. NOM is assigned by finite T.
-c. DAT is a nonstructural case.
+* [gong-2022]
+* [baker-vinokurova-2010]
 -/
 
 namespace Mongolian.Case
 
-open Minimalist
-open Syntax.Case
+open Minimalist _root_.Case
 
--- ============================================================================
--- S 1: Case System Configuration
--- ============================================================================
-
-/-- Mongolian case system: accusative alignment with Agree-based NOM
-    and nonstructural DAT. -/
-def mongolianCaseConfig : CaseSystemConfig :=
-  { langType := .accusative
-  , nomMode := .agreeT
-  , datMode := .nonstructural }
-
-theorem mongolian_is_accusative :
-    mongolianCaseConfig.langType = .accusative := rfl
-
-theorem mongolian_nom_is_agree :
-    mongolianCaseConfig.nomMode = .agreeT := rfl
-
-theorem mongolian_dat_is_nonstructural :
-    mongolianCaseConfig.datMode = .nonstructural := rfl
+/-- The Mongolian grammar of structural case: accusative on the lower of two NPs in the
+    clause, nominative from T and genitive from D under Agree, and no dependent dative. -/
+def grammar : CaseGrammar where
+  domains := [(.D, {}), (.v, {}), (.C, { low := some .acc })]
+  agree := [(.T, .nom), (.D, .gen)]
 
 -- ============================================================================
 -- S 2: Scrambling Types
@@ -106,36 +72,35 @@ inductive BinderRole where
 def caseInventory : Finset Case :=
   {.nom, .acc, .gen, .dat, .abl, .inst, .com}
 
-/-- Mongolian is an accusative language. -/
-def mongolianLangType : CaseLanguageType := .accusative
-
 -- ============================================================================
 -- S 4: Deriving WLM from Dependent Case
 -- ============================================================================
 
-/-- A Mongolian ditransitive clause has three argumental NPs in the
-    spell-out domain: Subject > DO > IO.
-    The IO bears DAT (nonstructural, so lexically assigned).
-    Subject and DO compete for dependent case. -/
-def ditransSubject : NPInDomain := ⟨"subject", none⟩
-def ditransDO : NPInDomain := ⟨"DO", none⟩
-def ditransIO : NPInDomain := ⟨"IO", some .dat⟩
+/-- A Mongolian ditransitive: the subject above the direct object, shifted to the clause
+    edge, above the dative indirect object. -/
+def ditransitive : List PhasedNP :=
+  [{ label := "subject" }, { label := "DO", phase := .v, shifted := true },
+   { label := "IO", phase := .v, lexicalCase := some .dat }]
 
-/-- Dependent ACC is available for the DO: the subject is a caseless NP
-    above it, so `dependentAccusative` succeeds.
-    This is the key fact that enables WLM above the IO binder. -/
+/-- Its cases, with finite T probing the clause. -/
+def ditransitiveCases : List (NP × Valuation) := grammar.assign [(.T, .C)] ditransitive
+
+/-- The direct object is valued accusative by the dependent rule, the subject being the
+    caseless NP above it: the case position Wholesale Late Merger needs above the indirect
+    object. -/
 theorem do_gets_dependent_acc :
-    dependentAccusative [ditransSubject] ditransDO = some .acc := by decide
+    getCaseOf "DO" ditransitiveCases = some .acc ∧
+    getMechanismOf "DO" ditransitiveCases = some .dependent := by decide
 
-/-- The subject gets NOM (unmarked in an accusative language with no
-    higher competitor). There is no dependent case position above it. -/
-theorem subject_gets_unmarked :
-    dependentAccusative [] ditransSubject = none := by decide
+/-- The subject is valued nominative by T, not by a dependent rule: there is no dependent
+    case position above it. -/
+theorem subject_gets_nom_by_agree :
+    getCaseOf "subject" ditransitiveCases = some .nom ∧
+    getMechanismOf "subject" ditransitiveCases = some .agree := by decide
 
-/-- IO bears DAT (lexical/nonstructural), so it does not compete for
-    dependent case and does not create a case position. -/
-theorem io_has_lexical_case :
-    ditransIO.lexicalCase = some .dat := rfl
+/-- The indirect object keeps its lexical dative and neither competes for dependent case nor
+    creates a case position. -/
+theorem io_has_lexical_case : getMechanismOf "IO" ditransitiveCases = some .lexical := by decide
 
 -- ============================================================================
 -- S 5: Chain Positions for WLM (Derived)
@@ -150,14 +115,14 @@ def specVPHeight : Nat := 3  -- intermediate landing site (edge of VP phase)
 /-- Case positions available on a scrambling chain in Mongolian.
 
     **These are derived from the dependent case algorithm**, not stipulated:
-    - Above IO: `dependentAccusative [subject] do = some .acc`
-      (theorem `do_gets_dependent_acc`), so Spec,VP is a case position
-    - Above Subject: `dependentAccusative [] subject = none`
-      (theorem `subject_gets_unmarked`), so no case position exists -/
+    - Above IO: the direct object is valued dependent accusative
+      (`do_gets_dependent_acc`), so Spec,VP is a case position
+    - Above Subject: the subject is valued by T, not a dependent rule
+      (`subject_gets_nom_by_agree`), so no case position exists -/
 def casePositionsAbove (role : BinderRole) : List ChainPosition :=
   match role with
-  | .io => [⟨specVPHeight, true⟩]  -- derived from do_gets_dependent_acc
-  | .subject => []                  -- derived from subject_gets_unmarked
+  | .io => [⟨specVPHeight, true⟩]
+  | .subject => []
 
 /-- Binder height from its grammatical role. -/
 def binderHeight (role : BinderRole) : Nat :=
@@ -177,14 +142,14 @@ def predictsReconstruction (role : BinderRole) : Bool :=
 
 /-- Scrambling over IO: WLM bleeds Condition C.
     [gong-2022] (4), (18b), (27): dependent ACC is available at
-    Spec,VP (derived from `do_gets_dependent_acc`), so the NP restrictor
+    Spec,VP (`do_gets_dependent_acc`), so the NP restrictor
     can merge above the IO binder without violating Condition C. -/
 theorem io_binder_no_reconstruction :
     predictsReconstruction .io = false := by decide
 
 /-- Scrambling over Subject: WLM forces Condition C reconstruction.
     [gong-2022] (3), (20), (21), (29): no dependent case position
-    exists above the subject (derived from `subject_gets_unmarked`),
+    exists above the subject (`subject_gets_nom_by_agree`),
     so the NP restrictor must merge below the subject binder. -/
 theorem subject_binder_forces_reconstruction :
     predictsReconstruction .subject = true := by decide

--- a/Linglib/Fragments/Yakut/Case.lean
+++ b/Linglib/Fragments/Yakut/Case.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case.Basic
-import Linglib.Syntax.Case.Dependent
+import Linglib.Syntax.Minimalist.Case.Dependent
 
 /-!
 # Yakut (Sakha) case
@@ -15,16 +15,14 @@ homophonous with the nominative except after a third-person possessive suffix.
 
 namespace Yakut.Case
 
-open Syntax.Case
+open Minimalist
 
-/-- The Sakha case system: dependent accusative and dative, nominative and genitive by
-    Agree. -/
-def yakutCaseConfig : CaseSystemConfig where
-  langType := .accusative
-  nomMode := .agreeT
-  datMode := .dependent
-  accMode := .dependent
-  genMode := .agreeD
+/-- The Sakha grammar of structural case: dative on the higher of two NPs in the verb phrase,
+    accusative on the lower of two in the clause, nominative from T and genitive from D under
+    Agree, and no elsewhere case in any domain. -/
+def grammar : CaseGrammar where
+  domains := [(.D, {}), (.v, { high := some .dat }), (.C, { low := some .acc })]
+  agree := [(.T, .nom), (.D, .gen)]
 
 /-- The morphological case inventory: nominative, accusative, genitive, dative, ablative,
     instrumental, comitative and partitive. -/

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -32,14 +32,14 @@ how the unmarked case is realized.
 
 namespace Baker2015
 
-open Data.Examples Syntax.Case
+open Data.Examples Case
 
 /-- The book's languages of focus by alignment type: accusative Sakha, Tamil, Amharic, Cuzco
     Quechua, Korean and Finnish; ergative Shipibo, Burushaski, Chukchi, Lezgian, Ingush,
     Greenlandic, Kewa and Wardaman; tripartite Nez Perce, Coast Tsimshian, Semelai, Diyari and
     Warlpiri. The marked-nominative and marked-absolutive languages differ in the realization of
     the unmarked case, which the algorithm does not fix. -/
-def alignment? : String → Option CaseLanguageType
+def alignment? : String → Option Alignment.AlignmentType
   | "yaku1245" | "tami1289" | "amha1245" | "cusc1236" | "kore1280" | "finn1318" =>
     some .accusative
   | "ship1254" | "buru1296" | "chuk1273" | "lezg1247" | "ingu1240" | "kala1399" | "west2599"
@@ -64,16 +64,16 @@ def Observed.parse? : String → Option Observed
 
 /-- An assigned case realizes an observed one: the dependent cases as themselves, and the
     unmarked case as whatever label the language gives it. -/
-def Realizes (c : Case) (src : CaseSource) : Observed → Prop
+def Realizes (c : Case) (src : Mechanism) : Observed → Prop
   | .erg => c = .erg ∧ src = .dependent
   | .acc => c = .acc ∧ src = .dependent
   | .unmarked => src = .unmarked
 
-instance (c : Case) (src : CaseSource) (o : Observed) : Decidable (Realizes c src o) := by
+instance (c : Case) (src : Mechanism) (o : Observed) : Decidable (Realizes c src o) := by
   cases o <;> simp only [Realizes] <;> infer_instance
 
 /-- The NPs of a row's clause, subject first: it c-commands the object. -/
-def domain (r : LinguisticExample) : List NPInDomain :=
+def domain (r : LinguisticExample) : List NP :=
   ⟨"subject", none⟩ :: if r.feature? "transitive" = some "yes" then [⟨"object", none⟩] else []
 
 /-- The observed case of a row's NP. -/
@@ -86,7 +86,7 @@ def observed? (r : LinguisticExample) (np : String) : Option Observed :=
 theorem rows_case :
     ∀ r ∈ Examples.all, ∀ lang ∈ alignment? r.language, ∀ np ∈ ["subject", "object"],
       ∀ o ∈ observed? r np, ∀ c ∈ getCaseOf np (assignCases lang (domain r)),
-        ∀ src ∈ getSourceOf np (assignCases lang (domain r)), Realizes c src o := by
+        ∀ src ∈ getMechanismOf np (assignCases lang (domain r)), Realizes c src o := by
   decide
 
 /-- Agreement does not enter the algorithm: a subject is ergative in a transitive clause and

--- a/Linglib/Studies/BakerVinokurova2010.lean
+++ b/Linglib/Studies/BakerVinokurova2010.lean
@@ -5,30 +5,37 @@ import Linglib.Data.Examples.BakerVinokurova2010
 # Baker & Vinokurova 2010: two modalities of case assignment in Sakha
 
 Sakha's four structural cases split in half. Accusative and dative are dependent cases: an NP
-is valued accusative when a distinct caseless NP c-commands it in the same phase, and dative
-when it c-commands one in the same VP phase, the dative rule bleeding the accusative rule on
-the VP cycle. Nominative and genitive are assigned by T and D under agreement, and there is
-no default case: an NP that no rule reaches must be pseudo-incorporated into the verb — an
-unshifted VP-internal NP adjacent to it — or the structure is out. Object shift makes
-differential object marking a phase effect; the causee of a causative is dative exactly when
-the base verb is transitive; a passive theme is accusative exactly when a covert agent is
-present; the object of an agentive nominalization is accusative though no v is present; a
-subject raised into an impersonal clause stays unmarked; and a finite verb agrees with an NP
-exactly when it values that NP nominative. A purely configurational grammar with a default
-nominative overgenerates the Case-filter and agreement violations, and a purely Agree-based
-grammar undergenerates the datives.
+is valued accusative when a distinct caseless NP c-commands it in the clause, and dative when
+it c-commands one in the verb phrase, where there is no accusative rule. Nominative and
+genitive are assigned by T and D under agreement, and there is no elsewhere case: an NP that no
+rule and no head reaches must be pseudo-incorporated into the verb — an unshifted VP-internal
+NP adjacent to it — or the structure is out. Object shift makes differential object marking a
+phase effect; the causee of a causative is dative exactly when the base verb is transitive; a
+passive theme is accusative exactly when a covert agent is present; the object of an agentive
+nominalization is accusative though no v is present; a subject raised into an impersonal clause
+stays unmarked; and a finite verb agrees with an NP exactly when it values that NP nominative.
+A purely configurational grammar with elsewhere cases overgenerates the Case-filter and
+agreement violations, and a purely Agree-based grammar never values a dative.
 
 ## Main definitions
 
-* `Slot`, `candidates`: the NPs of a row's domain, highest first, from its stated roles; the
-  covert agent and object shift are the free choices where the paper leaves them free.
-* `derive`: `assignCasesPhased` on the Yakut configuration, with T-Agree switched off in a
-  domain without an agreeing T-like head and D reaching into a relative or nominalized clause
-  whose head noun agrees with its subject.
-* `Licensed`, `Agrees`: the Case filter and the case–agreement link.
-* `Derivable`: some choice of structure yields the row's cases.
+* `pureMarantz`, `pureChomsky`: the two pure grammars beside the Yakut fragment's.
+* `subject`, `internal`, `possessor`, `pro`, `finite`: the NP positions and the finite probe
+  the paper's derivations use.
+* `Slot`, `candidates`: the NPs of a row's domain from the slots the rows name, highest first;
+  the covert agent and object shift are the free choices where the paper leaves them free.
+* `derive`, `Licensed`, `Agrees`, `Derivable`: assignment with the probes a row's morphology
+  shows, the Case filter, the case–agreement link, and derivability under some choice.
+
+## Main results
+
+* `dom`, `ditransitive`, `causative`, `passive`, `agentive_nominal`, `raising`, `promise`,
+  `possessed`: the paper's constructions, for any labels.
+* `no_elsewhere_case`, `pureChomsky_no_dative`: Sakha values nothing as unmarked, and an
+  Agree-only grammar values nothing dative, whatever the domain.
 * `rows_case`: acceptability is derivability under the two-modality grammar.
-* `pure_marantz_overgenerates`, `pure_chomsky_undergenerates`: each modality alone fails.
+* `pure_marantz_overgenerates`: without the Case filter and the agreement link, the
+  configurational grammar derives rejected examples.
 
 ## References
 
@@ -41,10 +48,148 @@ grammar undergenerates the datives.
 
 namespace BakerVinokurova2010
 
-open Data.Examples Syntax.Case Yakut.Case
+open Data.Examples Minimalist Case Yakut.Case
 
-/-- The argument roles a row states, in c-command order. -/
-inductive Role
+/-! ### The grammars -/
+
+/-- A purely configurational grammar: dependent dative and accusative with elsewhere
+    nominative in the clause and verb phrase, elsewhere genitive in the noun phrase, and no
+    Agree. -/
+def pureMarantz : CaseGrammar where
+  domains := [(.D, { unmarked := some .gen }), (.v, { high := some .dat, unmarked := some .nom }),
+    (.C, { low := some .acc, unmarked := some .nom })]
+
+/-- A purely Agree-based grammar: nominative from T, accusative from v, genitive from D, and
+    no dependent rule. -/
+def pureChomsky : CaseGrammar where
+  domains := [(.D, {}), (.v, {}), (.C, {})]
+  agree := [(.T, .nom), (.v, .acc), (.D, .gen)]
+
+/-- Sakha values nothing as unmarked: an NP no rule and no head reaches stays caseless. -/
+theorem no_elsewhere_case (probes : List (Cat × Cat)) {nps : List PhasedNP} {i : ℕ} {np : NP}
+    {c : Case} {m : Mechanism} (h : (grammar.assign probes nps)[i]? = some (np, some (c, m))) :
+    m ≠ .unmarked :=
+  grammar.mechanism_ne_unmarked probes (by decide) h
+
+/-- The Agree-based grammar values nothing dative: a dative NP brought it from the lexicon. -/
+theorem pureChomsky_no_dative (probes : List (Cat × Cat)) {nps : List PhasedNP} {i : ℕ}
+    {np : PhasedNP} {m : Mechanism} (hnp : nps[i]? = some np)
+    (h : (pureChomsky.assign probes nps)[i]? = some (np.toNP, some (.dat, m))) :
+    np.lexicalCase = some .dat := by
+  rcases hlex : np.lexicalCase with _ | c
+  · exact absurd (pureChomsky.case_mem_cases probes hlex h) (by decide)
+  · have := pureChomsky.assign_getElem?_of_some probes hnp hlex
+    rw [this] at h
+    simp only [Option.some.injEq, Prod.mk.injEq, true_and] at h
+    rw [h.1]
+
+/-! ### Positions -/
+
+/-- A caseless NP merged in the clause. -/
+def subject (label : String) : PhasedNP := { label }
+
+/-- A caseless NP merged in the verb phrase, shifted to the clause edge or not. -/
+def internal (label : String) (shifted : Bool) : PhasedNP := { label, phase := .v, shifted }
+
+/-- A caseless NP inside a noun phrase. -/
+def possessor (label : String) : PhasedNP := { label, phase := .D }
+
+/-- The covert agent, merged in the clause. -/
+def pro : PhasedNP := { label := "PRO" }
+
+/-- Finite T probing the clause. -/
+def finite : List (Cat × Cat) := [(.T, .C)]
+
+/-- The cases of a derivation, positionally. -/
+def cases (g : CaseGrammar) (probes : List (Cat × Cat)) (nps : List PhasedNP) :
+    List (Option Case) :=
+  (g.assign probes nps).map (·.2.map (·.1))
+
+/-! ### The constructions -/
+
+attribute [local simp] cases CaseGrammar.assign domainPass probePass agreePass
+  Rules.dependentPass Rules.unmarkedPass eligible markBy markByFrom initial CaseGrammar.rules
+  CaseGrammar.agreeCase grammar pureMarantz PhasedNP.visible PhasedNP.spellOut subject internal
+  possessor pro finite
+
+
+/-- Differential object marking: a shifted object is accusative and an unshifted one caseless,
+    the subject nominative from T either way. -/
+theorem dom (s o : String) (shifted : Bool) :
+    cases grammar finite [subject s, internal o shifted] =
+      [some .nom, if shifted then some .acc else none] := by
+  cases shifted <;> simp
+
+/-- A ditransitive: the goal is dative on the verb-phrase cycle whether or not the theme
+    shifts, and the theme accusative exactly when it does; a causative of a transitive base
+    is the same configuration, with the causee the higher of the two. -/
+theorem ditransitive (s g t : String) (shifted : Bool) :
+    cases grammar finite [subject s, internal g false, internal t shifted] =
+      [some .nom, some .dat, if shifted then some .acc else none] := by
+  cases shifted <;> simp
+
+/-- A causative: the causee of a transitive base is dative, c-commanding the theme in the
+    verb phrase, and the causee of an intransitive base, alone there, is accusative once it
+    shifts and never dative. -/
+theorem causative (c e t : String) (shifted : Bool) :
+    cases grammar finite [subject c, internal e false, internal t shifted] =
+      [some .nom, some .dat, if shifted then some .acc else none] ∧
+    cases grammar finite [subject c, internal e shifted] =
+      [some .nom, if shifted then some .acc else none] :=
+  ⟨ditransitive c e t shifted, dom c e shifted⟩
+
+/-- A passive: the shifted theme is accusative exactly when a covert agent is present, and
+    nominative from T otherwise; a goal is dative either way. -/
+theorem passive (g t : String) :
+    cases grammar finite [pro, internal t true] = [some .nom, some .acc] ∧
+    cases grammar finite [internal t true] = [some .nom] ∧
+    cases grammar finite [pro, internal g false, internal t true] =
+      [some .nom, some .dat, some .acc] ∧
+    cases grammar finite [internal g false, internal t true] = [some .dat, some .nom] := by
+  simp
+
+/-- An agentive nominalization: no T, but the covert agent makes the shifted object
+    accusative; without the agent the object is caseless. -/
+theorem agentive_nominal (o : String) :
+    cases grammar [] [pro, internal o true] = [none, some .acc] ∧
+    cases grammar [] [internal o true] = [none] := by
+  simp
+
+/-- A subject raised to the clause edge is accusative exactly when the matrix clause has
+    another NP; into an impersonal clause it is valued by T alone. -/
+theorem raising (s r : String) :
+    cases grammar finite [subject s, internal r true] = [some .nom, some .acc] ∧
+    cases grammar finite [internal r true] = [some .nom] := by
+  simp
+
+/-- Raising into the complement of *promise*: the goal is dative once the raised subject is
+    below it in the verb phrase, and accusative when nothing is. -/
+theorem promise (s g r : String) :
+    cases grammar finite [subject s, internal g false, internal r true] =
+      [some .nom, some .dat, some .acc] ∧
+    cases grammar finite [subject s, internal g true] = [some .nom, some .acc] := by
+  simp
+
+/-- A possessor is genitive from its D, and invisible to the clause. -/
+theorem possessed (s p o : String) :
+    cases grammar (finite ++ [(.D, .D)]) [subject s, possessor p, internal o true] =
+      [some .nom, some .gen, some .acc] := by
+  simp
+
+/-- Without an elsewhere case, a caseless NP left in the verb phrase or a subject without an
+    agreeing head stays caseless — the Case filter's bite — where the configurational grammar
+    values both. -/
+theorem elsewhere_contrast (s o : String) :
+    cases grammar finite [subject s, internal o false] = [some .nom, none] ∧
+    cases grammar [] [subject s] = [none] ∧
+    cases pureMarantz finite [subject s, internal o false] = [some .nom, some .nom] ∧
+    cases pureMarantz [] [subject s] = [some .nom] := by
+  simp
+
+/-! ### The rows -/
+
+/-- The NP slots the rows name, in c-command order. -/
+inductive Slot
   | subject
   | causee
   | goal
@@ -54,8 +199,8 @@ inductive Role
   | possessor
   deriving DecidableEq, Repr
 
-/-- The prefix of a role's feature keys. -/
-def Role.key : Role → String
+/-- The prefix of a slot's feature keys. -/
+def Slot.key : Slot → String
   | .subject => "subject"
   | .causee => "causee"
   | .goal => "goal"
@@ -64,166 +209,147 @@ def Role.key : Role → String
   | .pObject => "pObject"
   | .possessor => "possessor"
 
-/-- The roles highest first. -/
-def Role.all : List Role :=
+/-- The slots highest first. -/
+def Slot.all : List Slot :=
   [.subject, .causee, .goal, .raised, .object, .pObject, .possessor]
 
-/-- The case a gloss shows; a bare NP shows the nominative. -/
-def parseCase? : String → Option Case
-  | "NOM" | "bare" => some .nom
-  | "ACC" => some .acc
-  | "DAT" => some .dat
-  | "GEN" => some .gen
+/-- The case a gloss shows, or nothing for a bare NP. -/
+def parseCase? : String → Option (Option Case)
+  | "NOM" => some (some .nom)
+  | "bare" => some none
+  | "ACC" => some (some .acc)
+  | "DAT" => some (some .dat)
+  | "GEN" => some (some .gen)
   | _ => none
+
+/-- A valuation realizes a gloss: the case it shows, or, for a bare NP, no case or the
+    nominative, which is unmarked. -/
+def Realizes (v : Valuation) : Option Case → Prop
+  | some c => v.map (·.1) = some c
+  | none => v.map (·.1) = none ∨ v.map (·.1) = some .nom
+
+instance (v : Valuation) (o : Option Case) : Decidable (Realizes v o) := by
+  cases o <;> simp only [Realizes] <;> infer_instance
 
 /-- A row states a yes/no property. -/
 def yes (r : LinguisticExample) (k : String) : Bool := r.feature? k = some "yes"
 
-/-- An NP of a row's domain: its phase data, whether it is covert, whether it is adjacent to
+/-- An NP of a row's domain: its position, whether it is covert, whether it is adjacent to
     the verb, and the case its gloss shows. -/
-structure Slot where
+structure Occupant where
   np : PhasedNP
   covert : Bool := false
   adjacent : Bool := false
-  observed : Case := .nom
+  observed : Option Case := none
   deriving DecidableEq, Repr
 
-/-- Where a role is merged: a possessor inside DP, the objects, goal, causee and raised
-    subject inside VP, and the subject outside it unless the predicate is unaccusative or
-    takes a dative subject. -/
-def Role.basePhase (r : LinguisticExample) : Role → CasePhase
+/-- Where a slot is merged: a possessor in the noun phrase, the objects, goal, causee and
+    raised subject in the verb phrase, the subject in the clause unless the predicate is
+    unaccusative or takes a dative subject. -/
+def Slot.phase (r : LinguisticExample) : Slot → Cat
   | .subject =>
-    if yes r "unaccusative" || r.feature? "subjectPosition" = some "internal" then .vp else .cp
-  | .causee | .goal | .raised | .object => .vp
-  | .pObject | .possessor => .cp
+    if yes r "unaccusative" || r.feature? "subjectPosition" = some "internal" then .v else .C
+  | .causee | .goal | .raised | .object => .v
+  | .pObject => .C
+  | .possessor => .D
 
-/-- Whether a VP-merged NP shifts to the phase edge: a specific one does, a nonspecific one
+/-- Whether a VP-merged NP shifts to the clause edge: a specific one does, a nonspecific one
     does not, a raised subject always does, and the paper leaves the rest free. -/
-def Role.shifts (r : LinguisticExample) (ρ : Role) : List Bool :=
-  match ρ.basePhase r with
-  | .cp => [false]
-  | .vp =>
-    if ρ = .raised then [true]
-    else match r.feature? (ρ.key ++ "Specific") with
+def Slot.shifts (r : LinguisticExample) (s : Slot) : List Bool :=
+  match s.phase r with
+  | .v =>
+    if s = .raised then [true]
+    else match r.feature? (s.key ++ "Specific") with
       | some "yes" => [true]
       | some "no" => [false]
       | _ => [false, true]
+  | _ => [false]
 
-/-- The slots a stated role contributes, one per shift option. -/
-def Role.slots (r : LinguisticExample) (ρ : Role) : Option (List Slot) :=
-  ((r.feature? (ρ.key ++ "Case")).bind parseCase?).map λ c =>
-    (ρ.shifts r).map λ sh =>
-      { np := { label := ρ.key, lexicalCase := none, basePhase := ρ.basePhase r, shifted := sh,
-                inDP := ρ = .possessor },
-        adjacent := yes r (ρ.key ++ "Adjacent"), observed := c }
+/-- The occupants a stated slot contributes, one per shift option. -/
+def Slot.occupants (r : LinguisticExample) (s : Slot) : Option (List Occupant) :=
+  ((r.feature? (s.key ++ "Case")).bind parseCase?).map λ c =>
+    (s.shifts r).map λ sh =>
+      { np := { label := s.key, phase := s.phase r, shifted := sh },
+        adjacent := yes r (s.key ++ "Adjacent"), observed := c }
 
-/-- The covert agent, merged above VP: forced in a passive with an agent-oriented adverb and
-    in an agentive nominalization, excluded when the subject is overt or the predicate
-    unaccusative, and otherwise free in a passive or event nominalization. -/
-def agentOptions (r : LinguisticExample) : List (List Slot) :=
-  let pro : Slot :=
-    { np := { label := "PRO", lexicalCase := none, basePhase := .cp }, covert := true }
+/-- The covert agent: forced in a passive with an agent-oriented adverb and in an agentive
+    nominalization, excluded when the subject is overt or the predicate unaccusative, and
+    otherwise free in a passive or event nominalization. -/
+def agentOptions (r : LinguisticExample) : List (List Occupant) :=
   if (r.feature? "subjectCase").isSome || yes r "unaccusative" then [[]]
   else if yes r "agentOrientedAdverb" || r.feature? "construction" = some "agentiveNominal" then
-    [[pro]]
+    [[{ np := pro, covert := true }]]
   else match r.feature? "construction" with
-    | some "passive" | some "eventNominal" => [[pro], []]
+    | some "passive" | some "eventNominal" => [[{ np := pro, covert := true }], []]
     | _ => [[]]
 
-/-- The domains a row may have: the covert agent, then each stated role under each of its
+/-- The domains a row may have: the covert agent, then each stated slot under each of its
     shift options. -/
-def candidates (r : LinguisticExample) : List (List Slot) :=
-  (Role.all.foldr (λ ρ acc => match ρ.slots r with
+def candidates (r : LinguisticExample) : List (List Occupant) :=
+  (Slot.all.foldr (λ s acc => match s.occupants r with
       | none => acc
-      | some vs => vs.flatMap λ s => acc.map (s :: ·)) [[]]).flatMap λ d =>
+      | some vs => vs.flatMap λ o => acc.map (o :: ·)) [[]]).flatMap λ d =>
     (agentOptions r).map (· ++ d)
 
-/-- The grammar a domain is evaluated under: T-Agree only where the verb bears an agreeing
-    T-like head, D-Agree on a possessor only where the possessed noun agrees. -/
-def config (cfg : CaseSystemConfig) (r : LinguisticExample) : CaseSystemConfig :=
-  { cfg with
-    nomMode := if yes r "verbAgreement" then cfg.nomMode else .unmarkedDefault
-    genMode := if yes r "possesseeAgreement" then cfg.genMode else .nonstructural }
+/-- The probes a row's morphology shows: finite T where the verb agrees, the head noun's D
+    reaching into the clause where it agrees with the subject, and the possessed noun's D
+    where it agrees with its possessor. -/
+def probes (r : LinguisticExample) : List (Cat × Cat) :=
+  (if yes r "verbAgreement" then [(Cat.T, Cat.C)] else []) ++
+    (if yes r "headNounAgreement" then [(Cat.D, Cat.C)] else []) ++
+    (if yes r "possesseeAgreement" then [(Cat.D, Cat.D)] else [])
 
-/-- D on a head noun that agrees with the clause's subject reaches into the relative or
-    nominalized clause and values its highest caseless overt NP genitive. -/
-def dProbe : List (Slot × CasedNP) → List (Slot × CasedNP)
-  | [] => []
-  | (s, c) :: rest =>
-    if !s.covert && c.source == .unmarked && s.np.visibleOnCP then
-      (s, { c with case := .gen, source := .agree }) :: rest
-    else (s, c) :: dProbe rest
-
-/-- The cases of a domain, paired with its slots. -/
-def derive (cfg : CaseSystemConfig) (r : LinguisticExample) (d : List Slot) :
-    List (Slot × CasedNP) :=
-  let out := d.zip (assignCasesPhased (config cfg r) (d.map (·.np)))
-  if yes r "headNounAgreement" && cfg.genMode == .agreeD then dProbe out else out
+/-- The valuations of a domain, paired with its occupants. -/
+def derive (g : CaseGrammar) (r : LinguisticExample) (d : List Occupant) :
+    List (Occupant × Valuation) :=
+  d.zip ((g.assign (probes r) (d.map (·.np))).map (·.2))
 
 /-- The Case filter: a caseless overt NP must be pseudo-incorporated — an unshifted
     VP-internal NP adjacent to the verb. -/
-def Licensed (s : Slot) (c : CasedNP) : Prop :=
-  s.covert = true ∨ c.source ≠ .unmarked ∨
-    (s.np.basePhase = .vp ∧ s.np.shifted = false ∧ s.adjacent = true)
+def Licensed (o : Occupant) (v : Valuation) : Prop :=
+  o.covert = true ∨ v.isSome ∨ (o.np.phase = .v ∧ o.np.shifted = false ∧ o.adjacent = true)
 
-instance (s : Slot) (c : CasedNP) : Decidable (Licensed s c) := by
+instance (o : Occupant) (v : Valuation) : Decidable (Licensed o v) := by
   unfold Licensed; infer_instance
 
-/-- T agrees with the NP it values nominative: where a row states the verb's agreement target,
-    an overt NP is nominative by Agree exactly when it is that target, so default agreement
-    means no NP is. -/
-def Agrees (r : LinguisticExample) (out : List (Slot × CasedNP)) : Prop :=
+/-- T agrees with the NP it values nominative: where a row states the verb's agreement
+    target, an overt NP is nominative by Agree exactly when it is that target, so default
+    agreement means no NP is. -/
+def Agrees (r : LinguisticExample) (out : List (Occupant × Valuation)) : Prop :=
   (r.feature? "agreesWith").isSome → ∀ p ∈ out, p.1.covert = false →
-    ((p.2.case = .nom ∧ p.2.source = .agree) ↔ r.feature? "agreesWith" = some p.1.np.label)
+    (p.2 = some (.nom, .agree) ↔ r.feature? "agreesWith" = some p.1.np.label)
 
-instance (r : LinguisticExample) (out : List (Slot × CasedNP)) : Decidable (Agrees r out) := by
+instance (r : LinguisticExample) (out : List (Occupant × Valuation)) :
+    Decidable (Agrees r out) := by
   unfold Agrees; infer_instance
 
 /-- A domain derives the row under a grammar: every overt NP gets the case its gloss shows,
     and under the Chomskian half — the Case filter and the case–agreement link — is licensed
     and agreed with accordingly. -/
-def Derives (cfg : CaseSystemConfig) (chomskian : Bool) (r : LinguisticExample)
-    (d : List Slot) : Prop :=
-  (∀ p ∈ derive cfg r d, p.1.covert = false →
-    p.2.case = p.1.observed ∧ (chomskian = true → Licensed p.1 p.2)) ∧
-  (chomskian = true → Agrees r (derive cfg r d))
+def Derives (g : CaseGrammar) (chomskian : Bool) (r : LinguisticExample) (d : List Occupant) :
+    Prop :=
+  (∀ p ∈ derive g r d, p.1.covert = false →
+    Realizes p.2 p.1.observed ∧ (chomskian = true → Licensed p.1 p.2)) ∧
+  (chomskian = true → Agrees r (derive g r d))
 
-instance (cfg : CaseSystemConfig) (chomskian : Bool) (r : LinguisticExample) (d : List Slot) :
-    Decidable (Derives cfg chomskian r d) := by
+instance (g : CaseGrammar) (chomskian : Bool) (r : LinguisticExample) (d : List Occupant) :
+    Decidable (Derives g chomskian r d) := by
   unfold Derives; infer_instance
 
 /-- Some choice of structure derives the row. -/
-def Derivable (cfg : CaseSystemConfig) (chomskian : Bool) (r : LinguisticExample) : Prop :=
-  ∃ d ∈ candidates r, Derives cfg chomskian r d
+def Derivable (g : CaseGrammar) (chomskian : Bool) (r : LinguisticExample) : Prop :=
+  ∃ d ∈ candidates r, Derives g chomskian r d
 
-instance (cfg : CaseSystemConfig) (chomskian : Bool) (r : LinguisticExample) :
-    Decidable (Derivable cfg chomskian r) := by
+instance (g : CaseGrammar) (chomskian : Bool) (r : LinguisticExample) :
+    Decidable (Derivable g chomskian r) := by
   unfold Derivable; infer_instance
 
 /-- Each of the paper's Sakha examples is acceptable exactly when some structure derives the
     cases it shows under the two-modality grammar with the Case filter and the
     case–agreement link. -/
 theorem rows_case :
-    ∀ r ∈ Examples.all, r.judgment = .acceptable ↔ Derivable yakutCaseConfig true r := by
+    ∀ r ∈ Examples.all, r.judgment = .acceptable ↔ Derivable grammar true r := by
   decide
-
-/-- A purely configurational grammar: dependent accusative and dative, nominative as the
-    default, no structural genitive. -/
-def pureMarantz : CaseSystemConfig where
-  langType := .accusative
-  nomMode := .unmarkedDefault
-  datMode := .dependent
-  accMode := .dependent
-  genMode := .nonstructural
-
-/-- A purely Agree-based grammar: accusative from v, nominative from T, genitive from D, and
-    no structural dative. -/
-def pureChomsky : CaseSystemConfig where
-  langType := .accusative
-  nomMode := .agreeT
-  datMode := .nonstructural
-  accMode := .agreeV
-  genMode := .agreeD
 
 /-- Without the Case filter and the case–agreement link, the configurational grammar derives
     a rejected example — a bare object separated from the verb, an unagreed-with subject of a
@@ -231,13 +357,6 @@ def pureChomsky : CaseSystemConfig where
     nominative. -/
 theorem pure_marantz_overgenerates :
     ∃ r ∈ Examples.all, r.judgment = .unacceptable ∧ Derivable pureMarantz false r := by
-  decide
-
-/-- The Agree-based grammar, with no structural dative, fails an accepted example with a
-    dative goal. -/
-theorem pure_chomsky_undergenerates :
-    ∃ r ∈ Examples.all, r.judgment = .acceptable ∧ r.feature? "goalCase" = some "DAT" ∧
-      ¬ Derivable pureChomsky true r := by
   decide
 
 end BakerVinokurova2010

--- a/Linglib/Studies/ClemDeal2024.lean
+++ b/Linglib/Studies/ClemDeal2024.lean
@@ -53,7 +53,7 @@ This study file does five things:
 5. **Counterexample** the configurational case rules [clem-deal-2024]
    discusses (§1 (1), after [baker-2015]; §4.1 (37), a
    [barany-sheehan-2024]-style rule) by running linglib's *own* formalized
-   dependent-case algorithm (`Syntax.Case.assignCases`) on Shawi cells,
+   dependent-case algorithm (`Case.assignCases`) on Shawi cells,
    rather than a local strawman.
 
 Genuinely new machinery — bidirectional Agree (goal flagging),
@@ -71,7 +71,7 @@ open Deal2024 (DealGrammar isLicit strictlyDescending dpBears
   sd_off_diagonal_iff_outranks)
 open Kawapanan.Shawi (ObjectPosition ObjectSyntax Phi mustBeHigh
   ergativeMarker oagrOnSMarker objectSyntaxLicit)
-open Syntax.Case (NPInDomain assignCases getCaseOf)
+open Case (NP assignCases getCaseOf)
 
 -- ============================================================================
 -- § 1: Mapping Shawi to Deal-2024
@@ -232,7 +232,7 @@ theorem local_object_must_be_high (p : Person) (h : p.IsSAP) :
     the subject c-commands the object (earlier = structurally higher), and
     neither bears lexical case. Person-blind, exactly as a configurational
     case rule is. -/
-def shawiDomain (_subj _obj : Person) : List NPInDomain :=
+def shawiDomain (_subj _obj : Person) : List NP :=
   [⟨"subj", none⟩, ⟨"obj", none⟩]
 
 /-- Baker's configurational rule for ergative ([baker-2015]; [clem-deal-2024]
@@ -240,7 +240,7 @@ def shawiDomain (_subj _obj : Person) : List NPInDomain :=
     that NP1 c-commands NP2, then value the case feature of NP1 as ergative
     unless NP2 has already been marked for case." Rather than restate this
     as a local strawman, we *run* linglib's own dependent-case algorithm —
-    `Syntax.Case.assignCases .ergative`, which values the higher of two
+    `Case.assignCases .ergative`, which values the higher of two
     caseless NPs ergative — over the Shawi domain. -/
 def configErg (subj obj : Person) : Bool :=
   getCaseOf "subj" (assignCases .ergative (shawiDomain subj obj)) == some .erg

--- a/Linglib/Studies/Gong2022.lean
+++ b/Linglib/Studies/Gong2022.lean
@@ -51,7 +51,7 @@ position is available in the matrix clause.
 namespace Gong2022
 
 open Minimalist
-open Syntax.Case
+open Case
 open Mongolian.Case
 
 -- ============================================================================
@@ -220,21 +220,14 @@ theorem sbg_overpredicts :
 -- S 7: Bridge — Dependent Case Algorithm Determines WLM
 -- ============================================================================
 
-/-- The dependent case algorithm *determines* WLM availability:
-    `dependentAccusative` succeeding at Spec,VP (above IO) is exactly
-    what makes the case position available for late merger.
-
-    This connects the Mongolian fragment's WLM predictions to the
-    theory-layer dependent case algorithm in `Syntax/Case/Dependent.lean`,
-    rather than stipulating case positions independently. -/
+/-- The dependent case algorithm *determines* WLM availability: the direct object being
+    valued dependent accusative at Spec,VP (above IO) is exactly what makes the case position
+    available for late merger, and the subject being valued by T rather than a dependent rule
+    is what leaves none above it. -/
 theorem dependent_acc_determines_wlm :
-    -- The dependent case algorithm assigns ACC to DO above IO
-    dependentAccusative [ditransSubject] ditransDO = some .acc ∧
-    -- Therefore WLM bleeds Condition C over IO
+    Case.getMechanismOf "DO" ditransitiveCases = some .dependent ∧
     predictsReconstruction .io = false ∧
-    -- The dependent case algorithm assigns no ACC above Subject
-    dependentAccusative [] ditransSubject = none ∧
-    -- Therefore WLM forces reconstruction over Subject
+    Case.getMechanismOf "subject" ditransitiveCases ≠ some .dependent ∧
     predictsReconstruction .subject = true := by decide
 
 -- ============================================================================
@@ -303,28 +296,25 @@ other three mechanisms fixed and varying only `datMode`, the algorithm stops
 deriving dative at all, so the dative on a Mongolian goal must be supplied as
 lexical case. -/
 
-open Syntax.Case in
-/-- Mongolian differs from Sakha in `datMode` alone. -/
+/-- Mongolian differs from Sakha in the verb phrase's high case alone: no dependent dative. -/
 theorem mongolian_differs_from_sakha_in_dat_only :
-    Mongolian.Case.mongolianCaseConfig =
-      { Yakut.Case.yakutCaseConfig with datMode := .nonstructural } := rfl
+    Mongolian.Case.grammar.rules .v = { Yakut.Case.grammar.rules .v with high := none } ∧
+    Mongolian.Case.grammar.rules .C = Yakut.Case.grammar.rules .C ∧
+    Mongolian.Case.grammar.agree = Yakut.Case.grammar.agree := by decide
 
-open Syntax.Case in
 /-- The Sakha ditransitive: a subject, a VP-internal goal, and a theme shifted to the
     phase edge. -/
-def sakhaDitransitive : List PhasedNP :=
-  [{ label := "subject", lexicalCase := none, basePhase := .cp },
-   { label := "goal", lexicalCase := none, basePhase := .vp },
-   { label := "theme", lexicalCase := none, basePhase := .vp, shifted := true }]
+def sakhaDitransitive : List Minimalist.PhasedNP :=
+  [{ label := "subject" }, { label := "goal", phase := .v },
+   { label := "theme", phase := .v, shifted := true }]
 
-open Syntax.Case in
-/-- On the Sakha ditransitive, the Mongolian configuration derives no dative
-    at all, and the goal that Sakha values dative is valued differently. -/
+/-- The Mongolian grammar values no NP of the Sakha ditransitive dative — it mentions no
+    dative — so the goal Sakha values dative comes out otherwise. -/
 theorem mongolian_derives_no_dative :
-    (∀ cn ∈ assignCasesPhased Mongolian.Case.mongolianCaseConfig sakhaDitransitive,
-      cn.case ≠ .dat) ∧
-    getCaseOf "goal" (assignCasesPhased Mongolian.Case.mongolianCaseConfig sakhaDitransitive) ≠
-      getCaseOf "goal" (assignCasesPhased Yakut.Case.yakutCaseConfig sakhaDitransitive) := by
+    (∀ s ∈ Mongolian.Case.grammar.assign [(.T, .C)] sakhaDitransitive,
+      s.2.map (·.1) ≠ some .dat) ∧
+    Case.getCaseOf "goal" (Mongolian.Case.grammar.assign [(.T, .C)] sakhaDitransitive) ≠
+      Case.getCaseOf "goal" (Yakut.Case.grammar.assign [(.T, .C)] sakhaDitransitive) := by
   decide
 
 end Gong2022

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -514,7 +514,7 @@ Spanish *a* is dative, not flagged ACC — the fault line between structural
 and semantic case. The pipeline below runs the dependent-case algorithm on a
 prominence-annotated clause to make the divergence explicit. -/
 
-open Syntax.Case
+open Case
 
 /-- An NP annotated with referential prominence. Dependent case ignores the
     annotation; the lattice reads it. -/
@@ -526,7 +526,7 @@ structure ProminentNP where
   deriving DecidableEq, Repr
 
 /-- The NP as the dependent-case algorithm sees it. -/
-def ProminentNP.toNP (pnp : ProminentNP) : NPInDomain := ⟨pnp.label, pnp.lexicalCase⟩
+def ProminentNP.toNP (pnp : ProminentNP) : Case.NP := ⟨pnp.label, pnp.lexicalCase⟩
 
 /-- A transitive clause: subject c-commands object. -/
 structure TransClause where
@@ -535,7 +535,7 @@ structure TransClause where
   deriving DecidableEq, Repr
 
 /-- Abstract case assigned to the object by the dependent-case algorithm. -/
-def objectCase (lang : CaseLanguageType) (tc : TransClause) : Option Case :=
+def objectCase (lang : Alignment.AlignmentType) (tc : TransClause) : Option Case :=
   getCaseOf tc.object.label (assignCases lang [tc.subject.toNP, tc.object.toNP])
 
 /-- A transitive clause with a fixed human-pronoun subject and a

--- a/Linglib/Studies/Haspelmath2021.lean
+++ b/Linglib/Studies/Haspelmath2021.lean
@@ -753,7 +753,7 @@ theorem universal68_scenario_form_frequency :
 /-- [marantz-1991]: Hindi's aspect-conditioned ERG split is derived
     structurally — the *same* `[⟨"agent", none⟩, ⟨"theme", none⟩]` NP
     list produces ERG-marking under perfective and NOM-ACC under
-    imperfective, driven by the `CaseLanguageType` parameter alone.
+    imperfective, driven by the `Alignment.AlignmentType` parameter alone.
     No prominence input enters the algorithm. -/
 theorem marantz_hindi_split_is_structural :
     Marantz1991.hindiTransitive .perfective ≠
@@ -762,13 +762,14 @@ theorem marantz_hindi_split_is_structural :
 
 /-- [marantz-1991]: in ergative mode, the *higher* of two caseless
     NPs gets ERG, regardless of any "prominence" attribute. The function
-    signature `assignCases : CaseLanguageType → List NPInDomain → List CasedNP`
-    has no prominence input — `NPInDomain` carries only `label : String`
+    signature `assignCases : Alignment.AlignmentType → List Case.NP →
+    List (Case.NP × Case.Valuation)`
+    has no prominence input — `Case.NP` carries only `label : String`
     and `lex : Option Case`. The two-NP transitive case witnesses this
     uniformity. -/
 theorem marantz_ergative_uniform_on_higher :
-    Syntax.Case.getCaseOf "agent"
-      (Syntax.Case.assignCases .ergative
+    Case.getCaseOf "agent"
+      (Case.assignCases .ergative
         [⟨"agent", none⟩, ⟨"theme", none⟩]) = some .erg := by
   decide
 
@@ -778,8 +779,8 @@ theorem marantz_ergative_uniform_on_higher :
     derived subjects. The empirical witness is Hindi unaccusatives
     (*siitta (\*ne) aayii*). -/
 theorem marantz_ergative_no_marking_on_sole_np :
-    Syntax.Case.getCaseOf "theme"
-      (Syntax.Case.assignCases .ergative [⟨"theme", none⟩]) = some .abs := by
+    Case.getCaseOf "theme"
+      (Case.assignCases .ergative [⟨"theme", none⟩]) = some .abs := by
   decide
 
 /-- The two frameworks partition the empirical territory of split case
@@ -792,16 +793,16 @@ theorem marantz_ergative_no_marking_on_sole_np :
     and ANY language type, `assignCases` produces the same case sequence
     (up to label relabeling). The labels are uninterpreted strings — the
     function cannot read them as proxies for prominence. There is no
-    prominence input to `assignCases : CaseLanguageType → List NPInDomain
-    → List CasedNP`; `NPInDomain` carries only `label : String` and
+    prominence input to `assignCases : Alignment.AlignmentType → List Case.NP
+    → List (Case.NP × Case.Valuation)`; `Case.NP` carries only `label : String` and
     `lex : Option Case`. A Fore-style prominence-conditioned ERG would
     require an extra parameter not present in the algorithm. -/
 theorem marantz_haspelmath_partition_witness
-    (lang : Syntax.Case.CaseLanguageType) (l₁ l₂ l₁' l₂' : String) :
-    (Syntax.Case.assignCases lang
-        [⟨l₁, none⟩, ⟨l₂, none⟩]).map (·.case) =
-    (Syntax.Case.assignCases lang
-        [⟨l₁', none⟩, ⟨l₂', none⟩]).map (·.case) := by
+    (lang : Alignment.AlignmentType) (l₁ l₂ l₁' l₂' : String) :
+    (Case.assignCases lang
+        [⟨l₁, none⟩, ⟨l₂, none⟩]).map (·.2) =
+    (Case.assignCases lang
+        [⟨l₁', none⟩, ⟨l₂', none⟩]).map (·.2) := by
   cases lang <;> rfl
 
 end Haspelmath2021

--- a/Linglib/Studies/Marantz1991.lean
+++ b/Linglib/Studies/Marantz1991.lean
@@ -24,7 +24,7 @@ Morphological case obeys a disjunctive hierarchy:
 
     lexically governed > dependent (ACC/ERG) > unmarked > default
 
-This is formalized in `Syntax/Case/Dependent.lean` as `CaseSource`
+This is formalized in `Syntax/Case/Dependent.lean` as `Mechanism`
 (lexical > dependent > unmarked). [marantz-1991]'s fourth level,
 **default** case (absolute last resort when no other principle applies),
 is not modeled separately; it is conceptually distinct from unmarked
@@ -39,7 +39,7 @@ ACC and ERG are **dependent cases** — assigned relationally:
 - ACC: dependent case assigned to the lower of two caseless NPs
 - ERG: dependent case assigned to the higher of two caseless NPs
 - The two NPs must be *distinct* (not in the same chain); this is
-  implicit in our list representation where each `NPInDomain` is a
+  implicit in our list representation where each `Case.NP` is a
   distinct structural position.
 
 ## Georgian Split Ergativity
@@ -286,7 +286,7 @@ end Minimalist
 namespace Marantz1991
 
 open Minimalist Minimalist.Voice
-open Syntax.Case
+open Case
 open Georgian.Agreement
 
 -- ============================================================================
@@ -296,12 +296,12 @@ open Georgian.Agreement
 /-- Map alignment family to dependent case language type.
     Bridges the typological description (`Alignment.SplitErgativity`) to
     the case algorithm (`Syntax/Case/Dependent.lean`). -/
-def alignmentToLangType : Alignment.AlignmentFamily → CaseLanguageType
+def alignmentToLangType : Alignment.AlignmentFamily → Alignment.AlignmentType
   | .accusative => .accusative
   | .ergative   => .ergative
 
 /-- Georgian language type for a given tense series. -/
-def georgianLangType (ts : TenseSeries) : CaseLanguageType :=
+def georgianLangType (ts : TenseSeries) : Alignment.AlignmentType :=
   alignmentToLangType (georgianSplit.alignment ts)
 
 theorem present_is_accusative : georgianLangType .present = .accusative := rfl
@@ -320,7 +320,7 @@ theorem aorist_is_ergative : georgianLangType .aorist = .ergative := rfl
       a distinct position for dependent case, explaining why unergatives
       get ERG despite being intransitive.
     - Class 4 (psych): 2 NPs — DAT subject (lexical/quirky) + NOM object -/
-def georgianNPs : VerbClass → List NPInDomain
+def georgianNPs : VerbClass → List NP
   | .class1 => [⟨"subj", none⟩, ⟨"obj", none⟩]
   | .class2 => [⟨"subj", none⟩]
   | .class3 => [⟨"subj", none⟩, ⟨"empty", none⟩]  -- phantom object position
@@ -332,10 +332,10 @@ def georgianNPs : VerbClass → List NPInDomain
 
 /-- Run the dependent case algorithm for a Georgian verb class in a
     given tense series. -/
-def georgianCaseResult (vc : VerbClass) (ts : TenseSeries) : List CasedNP :=
+def georgianCaseResult (vc : VerbClass) (ts : TenseSeries) : List (NP × Valuation) :=
   assignCases (georgianLangType ts) (georgianNPs vc)
 
-private def getCase! (label : String) (results : List CasedNP) : Case :=
+private def getCase! (label : String) (results : List (NP × Valuation)) : Case :=
   match getCaseOf label results with
   | some c => c
   | none   => .dat  -- placeholder; the algorithm always returns every NP
@@ -420,14 +420,14 @@ theorem class3_aorist_erg :
 /-- Class 4: quirky DAT takes priority (lexical > dependent). -/
 theorem class4_lexical_dat :
     getCase! "subj" (georgianCaseResult .class4 .aorist) = .dat ∧
-    getSourceOf "subj" (georgianCaseResult .class4 .aorist) = some .lexical := by
+    getMechanismOf "subj" (georgianCaseResult .class4 .aorist) = some .lexical := by
   native_decide
 
 /-- The Ergative generalization follows from NP count:
     1 NP (unaccusative) → no ERG; ≥2 positions → ERG possible. -/
 theorem ergative_requires_competitor :
-    getSourceOf "sole" (assignCases .ergative [⟨"sole", none⟩]) = some .unmarked ∧
-    getSourceOf "higher" (assignCases .ergative [⟨"higher", none⟩, ⟨"lower", none⟩]) =
+    getMechanismOf "sole" (assignCases .ergative [⟨"sole", none⟩]) = some .unmarked ∧
+    getMechanismOf "higher" (assignCases .ergative [⟨"higher", none⟩, ⟨"lower", none⟩]) =
       some .dependent := by
   native_decide
 
@@ -454,7 +454,7 @@ theorem ergative_requires_competitor :
 /-- Unaccusative: sole NP, no ACC. The "Burzio effect." -/
 theorem burzio_unaccusative_no_acc :
     getCaseOf "theme" (assignCases .accusative [⟨"theme", none⟩]) = some .nom ∧
-    getSourceOf "theme" (assignCases .accusative [⟨"theme", none⟩]) = some .unmarked := by
+    getMechanismOf "theme" (assignCases .accusative [⟨"theme", none⟩]) = some .unmarked := by
   native_decide
 
 /-- Transitive: external argument provides the case competitor → ACC. -/
@@ -486,14 +486,14 @@ theorem anticausative_one_np : npCount anticausative 1 = 1 := rfl
 /-! Hindi has aspect-conditioned split ergativity: perfective triggers
     ERG on the transitive agent (*-ne*), imperfective has NOM-ACC.
     The dependent case algorithm derives both patterns from the same
-    mechanism with different `CaseLanguageType` settings.
+    mechanism with different `Alignment.AlignmentType` settings.
 
     [marantz-1991]: Hindi ERG is prohibited on unaccusative subjects
     (*siitta (\*ne) aayii* 'Sita arrived'), optional on unergatives, and
     obligatory on transitives. The unaccusative prohibition follows from
     dependent case: a sole argument has no competitor. -/
 
-def hindiTransitive (aspect : Alignment.Aspect) : List CasedNP :=
+def hindiTransitive (aspect : Alignment.Aspect) : List (NP × Valuation) :=
   assignCases (alignmentToLangType (Alignment.hindiSplit.alignment aspect))
     [⟨"agent", none⟩, ⟨"theme", none⟩]
 
@@ -519,7 +519,7 @@ theorem hindi_perfective_unaccusative_no_erg :
     let result := assignCases (alignmentToLangType (Alignment.hindiSplit.alignment .perfective))
       [⟨"theme", none⟩]
     getCaseOf "theme" result = some .abs ∧
-    getSourceOf "theme" result = some .unmarked := by
+    getMechanismOf "theme" result = some .unmarked := by
   native_decide
 
 /-- Hindi unergative in the perfective: the unfilled object position
@@ -538,7 +538,7 @@ theorem hindi_perfective_unergative_without_phantom :
     let result := assignCases (alignmentToLangType (Alignment.hindiSplit.alignment .perfective))
       [⟨"subj", none⟩]
     getCaseOf "subj" result = some .abs ∧
-    getSourceOf "subj" result = some .unmarked := by
+    getMechanismOf "subj" result = some .unmarked := by
   native_decide
 
 /-- Cross-linguistic contrast: Georgian obligatorily counts unfilled
@@ -560,23 +560,23 @@ theorem phantom_np_parameter :
 /-! Georgian demonstrates all three levels of [marantz-1991]'s
     case realization hierarchy within a single language:
 
-    | Level     | `CaseSource` | Georgian example |
+    | Level     | `Mechanism` | Georgian example |
     |-----------|-------------|------------------|
     | Lexical   | `.lexical`  | Class 4 DAT (quirky) |
     | Dependent | `.dependent`| Class 1 aorist ERG, present ACC |
     | Unmarked  | `.unmarked` | Class 2 NOM, Class 1 present NOM | -/
 
 theorem all_three_sources_attested :
-    getSourceOf "subj" (georgianCaseResult .class4 .present) = some .lexical ∧
-    getSourceOf "subj" (georgianCaseResult .class1 .aorist) = some .dependent ∧
-    getSourceOf "subj" (georgianCaseResult .class2 .aorist) = some .unmarked := by
+    getMechanismOf "subj" (georgianCaseResult .class4 .present) = some .lexical ∧
+    getMechanismOf "subj" (georgianCaseResult .class1 .aorist) = some .dependent ∧
+    getMechanismOf "subj" (georgianCaseResult .class2 .aorist) = some .unmarked := by
   native_decide
 
 /-- Lexical case bleeds dependent case: Class 4's DAT subject prevents
     ACC on the object (no caseless competitor above it). -/
 theorem lexical_bleeds_dependent_georgian :
-    getSourceOf "obj" (georgianCaseResult .class4 .present) = some .unmarked ∧
-    getSourceOf "obj" (georgianCaseResult .class1 .present) = some .dependent := by
+    getMechanismOf "obj" (georgianCaseResult .class4 .present) = some .unmarked ∧
+    getMechanismOf "obj" (georgianCaseResult .class1 .present) = some .dependent := by
   native_decide
 
 -- ============================================================================
@@ -596,14 +596,14 @@ theorem lexical_bleeds_dependent_georgian :
     unmarked→unmarked. Agree-based case ([baker-vinokurova-2010])
     behaves like unmarked for accessibility — once T values NOM, the NP
     is fully visible to higher probes, just like an unmarked-NOM NP. -/
-def sourceToAccessibility : CaseSource → CaseAccessibility
+def sourceToAccessibility : Mechanism → CaseAccessibility
   | .lexical   => CaseAccessibility.lexical
   | .dependent => CaseAccessibility.dependent
   | .unmarked  => CaseAccessibility.unmarked
   | .agree     => CaseAccessibility.unmarked
 
 /-- The mapping preserves the rank ordering. -/
-theorem accessibility_preserves_rank (s : CaseSource) :
+theorem accessibility_preserves_rank (s : Mechanism) :
     (sourceToAccessibility s).rank = match s with
       | .lexical => 0 | .dependent => 1 | .unmarked => 2 | .agree => 2 := by
   cases s <;> rfl
@@ -613,20 +613,20 @@ theorem accessibility_preserves_rank (s : CaseSource) :
     output to the agreement hierarchy: lexical case DPs are the hardest
     for agreement probes to target. -/
 theorem class4_lexical_low_accessibility :
-    sourceToAccessibility CaseSource.lexical = CaseAccessibility.lexical ∧
+    sourceToAccessibility Mechanism.lexical = CaseAccessibility.lexical ∧
     caseAccessible CaseAccessibility.lexical CaseAccessibility.dependent = false := ⟨rfl, rfl⟩
 
 /-- Class 1 aorist subject has dependent case (ERG), which maps to
     middle accessibility. A probe with threshold = unmarked cannot
     see ERG-marked DPs. -/
 theorem class1_aorist_dependent_accessibility :
-    sourceToAccessibility CaseSource.dependent = CaseAccessibility.dependent ∧
+    sourceToAccessibility Mechanism.dependent = CaseAccessibility.dependent ∧
     caseAccessible CaseAccessibility.dependent CaseAccessibility.unmarked = false := ⟨rfl, rfl⟩
 
 /-- Class 2 aorist subject has unmarked case (NOM), which maps to
     highest accessibility. Unmarked-case DPs are always visible. -/
 theorem class2_unmarked_highest_accessibility :
-    sourceToAccessibility CaseSource.unmarked = CaseAccessibility.unmarked ∧
+    sourceToAccessibility Mechanism.unmarked = CaseAccessibility.unmarked ∧
     caseAccessible CaseAccessibility.unmarked CaseAccessibility.unmarked = true := ⟨rfl, rfl⟩
 
 -- ============================================================================
@@ -648,20 +648,21 @@ theorem class2_unmarked_highest_accessibility :
 
 /-- Build NP list from Voice: if Voice assigns θ, include both subject
     and object; otherwise include only the theme. -/
-def npsFromVoice (voice : Head) : List NPInDomain :=
+def npsFromVoice (voice : Head) : List NP :=
   if voice.AssignsTheta then [⟨"subj", none⟩, ⟨"obj", none⟩]
   else [⟨"theme", none⟩]
 
 /-- End-to-end: agentive Voice → 2 NPs → object gets dependent ACC. -/
 theorem voice_to_case_transitive :
     getCaseOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .acc ∧
-    getSourceOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .dependent := by
+    getMechanismOf "obj" (assignCases .accusative (npsFromVoice agentive)) = some .dependent := by
   native_decide
 
 /-- End-to-end: anticausative Voice → 1 NP → theme gets unmarked NOM. -/
 theorem voice_to_case_unaccusative :
     getCaseOf "theme" (assignCases .accusative (npsFromVoice anticausative)) = some .nom ∧
-    getSourceOf "theme" (assignCases .accusative (npsFromVoice anticausative)) = some .unmarked := by
+    getMechanismOf "theme" (assignCases .accusative (npsFromVoice anticausative)) =
+      some .unmarked := by
   native_decide
 
 /-- The Burzio effect derived end-to-end: ACC presence tracks Voice's

--- a/Linglib/Studies/Ozaki2026.lean
+++ b/Linglib/Studies/Ozaki2026.lean
@@ -293,7 +293,7 @@ theorem alternation_crosses_tsujimura_split :
 -- ============================================================================
 
 open Minimalist Minimalist.Voice
-open Syntax.Case
+open Case
 open Japanese.Predicates
 
 /-! ### The Spell-Out domain of a departure verb
@@ -303,18 +303,18 @@ leaver above the source. *Taroo-ga mura-kara hanare-ta* replaces the source
 with a PP, *kara* assigning it lexical ablative. -/
 
 /-- The accusative variant: leaver and source, both caseless. -/
-def accVariantNPs : List NPInDomain :=
+def accVariantNPs : List NP :=
   [ { label := "leaver", lexicalCase := none },
     { label := "source", lexicalCase := none } ]
 
 /-- The ablative variant: *kara* has valued the source ablative. -/
-def ablVariantNPs : List NPInDomain :=
+def ablVariantNPs : List NP :=
   [ { label := "leaver", lexicalCase := none },
     { label := "source", lexicalCase := some .abl } ]
 
-def accVariantResult : List CasedNP := assignCases .accusative accVariantNPs
+def accVariantResult : List (NP × Valuation) := assignCases .accusative accVariantNPs
 
-def ablVariantResult : List CasedNP := assignCases .accusative ablVariantNPs
+def ablVariantResult : List (NP × Valuation) := assignCases .accusative ablVariantNPs
 
 /-- Departure verbs predict no external argument: non-thematic Voice
     does not assign a θ-role ([kratzer-1996], [schaefer-2025]). -/
@@ -343,17 +343,17 @@ theorem abl_derivation_correct :
 
 /-- In the ACC variant, source case is dependent. -/
 theorem acc_source_from_configuration :
-    getSourceOf "source" accVariantResult = some .dependent := by decide
+    getMechanismOf "source" accVariantResult = some .dependent := by decide
 
 /-- In the ABL variant, source case is lexical. -/
 theorem abl_source_from_lexical_p :
-    getSourceOf "source" ablVariantResult = some .lexical := by decide
+    getMechanismOf "source" ablVariantResult = some .lexical := by decide
 
 /-- The alternation touches only the source: the leaver takes unmarked
     nominative in both variants. -/
 theorem leaver_unmarked_in_both :
-    getSourceOf "leaver" accVariantResult = some .unmarked ∧
-    getSourceOf "leaver" ablVariantResult = some .unmarked := by decide
+    getMechanismOf "leaver" accVariantResult = some .unmarked ∧
+    getMechanismOf "leaver" ablVariantResult = some .unmarked := by decide
 
 /-- Anticausative Voice is not a phase head. -/
 theorem agree_acc_needs_phase_head :
@@ -368,7 +368,7 @@ theorem accusative_unaccusative_paradox :
     ¬ anticausative.AssignsTheta ∧
     ¬ anticausative.IsPhasal ∧
     getCaseOf "source" accVariantResult = some .acc ∧
-    getSourceOf "source" accVariantResult = some .dependent := by
+    getMechanismOf "source" accVariantResult = some .dependent := by
   refine ⟨by decide, by decide, by decide, by decide⟩
 
 /-- Fragment entry for *hanareru* is marked unaccusative. -/

--- a/Linglib/Studies/SadakaneKoizumi1995.lean
+++ b/Linglib/Studies/SadakaneKoizumi1995.lean
@@ -88,7 +88,7 @@ correspondingly coarse.
 - Diagnostic acceptability scores use `Features.Acceptability` (the
   project canon), not a per-paper Grammaticality enum.
 - `Classification.marantz` aligns S&K's 4-way with [baker-2015]'s
-  `Syntax.Case.CaseSource` from `Syntax.Case.Dependent`. The map
+  `Case.Mechanism` from `Syntax/Case/Dependent.lean`. The map
   is partial: copula *ni* lies outside Marantz's case-assignment domain.
   Note: `.niInsertion → .unmarked` (Marantz/Schütze's "default-case"
   fallback) rather than `.agree` — Takezawa's salvage operation is what
@@ -346,8 +346,8 @@ theorem fragment_ni_predicts_inconsistent_signatures :
 /-! ## §6 Alignment with Marantz dependent case
 
 S&K's 4-way classification partially aligns with Marantz/Baker's
-`CaseSource` (`lexical | dependent | unmarked | agree`), encoded in
-`Syntax.Case.Dependent`. Per the cross-framework reasoning:
+`Mechanism` (`lexical | dependent | unmarked | agree`), encoded in
+`Syntax/Case/Dependent.lean`. Per the cross-framework reasoning:
 
 - Dative case marker *ni* — assigned by structural configuration → `dependent`
 - Postposition *ni* — bears inherent meaning, attached to NP via P head → `lexical`
@@ -359,13 +359,13 @@ S&K's 4-way classification partially aligns with Marantz/Baker's
   construction, not case marking) → `none`
 -/
 
-open Syntax.Case (CaseSource)
+open Case (Mechanism)
 
 namespace Classification
 
 /-- Partial map from S&K's 4-way *ni* taxonomy to Marantz/Baker's
-    `CaseSource`. Copula *ni* maps to `none` (outside Marantz's domain). -/
-def marantz : Classification → Option CaseSource
+    `Mechanism`. Copula *ni* maps to `none` (outside Marantz's domain). -/
+def marantz : Classification → Option Mechanism
   | .dativeCaseMarker => some .dependent
   | .postposition     => some .lexical
   | .niInsertion      => some .unmarked
@@ -382,7 +382,7 @@ end Classification
     `.unmarked`; the disagreement is recorded explicitly. -/
 theorem niInsertion_alignment_underdetermined :
     Classification.marantz .niInsertion = some .unmarked ∧
-    (some CaseSource.agree : Option CaseSource) ≠ some .unmarked := by
+    (some Mechanism.agree : Option Mechanism) ≠ some .unmarked := by
   refine ⟨rfl, ?_⟩; decide
 
 /-! ## §7 Affectedness hierarchy (§4, figure 45)

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -72,7 +72,7 @@ namespace Scott2023
 section VoiceCase
 
 open Minimalist Minimalist.Voice
-open Syntax.Case
+open Case
 
 -- ============================================================================
 -- § 1: Voice Assigns Case by Argument Position
@@ -134,10 +134,10 @@ theorem agree_voice_is_phase_head :
     or not the higher NP carries an agent θ-role. The algorithm never
     inspects Voice flavor. -/
 theorem dependent_case_ignores_voice :
-    let transitive : List NPInDomain :=
+    let transitive : List NP :=
       [ { label := "agent", lexicalCase := none },
         { label := "theme", lexicalCase := none } ]
-    let unaccusative : List NPInDomain :=
+    let unaccusative : List NP :=
       [ { label := "experiencer", lexicalCase := none },
         { label := "theme", lexicalCase := none } ]
     getCaseOf "theme" (assignCases .accusative transitive) =
@@ -151,7 +151,7 @@ theorem dependent_case_ignores_voice :
     mechanism, with the assigners keyed to θ-role rather than to NP
     configuration. -/
 theorem dependent_case_tripartite :
-    let nps : List NPInDomain :=
+    let nps : List NP :=
       [ { label := "higher", lexicalCase := none },
         { label := "lower", lexicalCase := none } ]
     getCaseOf "higher" (assignCases .tripartite nps) = some .erg ∧

--- a/Linglib/Studies/Woolford1997.lean
+++ b/Linglib/Studies/Woolford1997.lean
@@ -59,7 +59,7 @@ with Nez Perce as the primary case study.
 
 namespace Woolford1997
 
-open Syntax.Case
+open Case
 
 -- ============================================================================
 -- § 1: Case Inventory (paper's (1)–(2))

--- a/Linglib/Syntax/Case/Assigner.lean
+++ b/Linglib/Syntax/Case/Assigner.lean
@@ -12,8 +12,8 @@ cannot be applied to a *common* stimulus — which is exactly what comparing
 them requires. This file gives them one shared signature.
 
 * The shared stimulus is `List LicensedNP` — the richest of the rivals'
-  inputs (`LicensedNP extends NPInDomain`), so a configural account reads its
-  `NPInDomain` projection and ignores `needsLicensing`, while a licensing
+  inputs (`LicensedNP extends Case.NP`), so a configural account reads its
+  `Case.NP` projection and ignores `needsLicensing`, while a licensing
   account reads the whole thing.
 * An `Assigner` maps that stimulus to a per-label `Verdict` (a surface case
   plus its neutral `Case.Source` provenance). This is the `Predict`-style
@@ -62,9 +62,11 @@ abbrev Assigner := List LicensedNP → String → Option Assignment
 /-- Marantz dependent case as an `Assigner`: it reads the configural
     projection (`needsLicensing` ignored) and is total, so it never produces
     `unassigned`. -/
-def dependentAssigner (lang : CaseLanguageType) : Assigner := fun nps label =>
-  ((assignCases lang (nps.map (·.toNPInDomain))).find? (·.label == label)).map
-    fun r => .assigned r.case r.source.toNeutral
+def dependentAssigner (a : Alignment.AlignmentType) : Assigner := fun nps label =>
+  ((_root_.Case.assignCases a (nps.map (·.toNP))).find? (·.1.label == label)).map fun r =>
+    match r.2 with
+    | some (c, m) => .assigned c m.toSource
+    | none => .unassigned
 
 /-- A licensing outcome as a neutral assignment: primary and secondary
     licensing are structural, lexical pre-licensing inherent, and the crash

--- a/Linglib/Syntax/Case/Dependent.lean
+++ b/Linglib/Syntax/Case/Dependent.lean
@@ -1,661 +1,404 @@
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Capabilities
 import Linglib.Features.Case.Source
+import Linglib.Syntax.Case.Alignment
 
 /-!
 # Dependent case
 
-This file defines the configurational case algorithm of [marantz-1991], in
-the form [baker-2015] gives it. Case is read off the arrangement of NPs in
-a Spell-Out domain under a disjunctive priority hierarchy: lexical case
-assigned by a particular head outranks dependent case, assigned to an NP
-standing in a c-command relation with another caseless NP, which in turn
-outranks the unmarked default. Which case the dependent rule assigns is the
-alignment parameter — accusative on the lower NP, ergative on the higher, or
-both at once in a tripartite system.
-
-`assignCases` runs the hierarchy over a flat Spell-Out domain, list position
-encoding c-command. `assignCasesPhased` runs the two-cycle variant of
-[baker-vinokurova-2010], in which the configurational rules apply once per
-phase and Agree with a functional head values whatever they leave unmarked.
-`CaseSystemConfig` selects a mechanism per case, so a purely configurational
-grammar, a purely Agree-based one ([chomsky-2000]), and the mixed grammars
-in between are parameterizations of a single algorithm rather than rival
-formalisations.
+Structural case read off the arrangement of NPs in a domain, under a disjunctive hierarchy:
+case a lexical head has valued is kept; otherwise an NP that c-commands a distinct caseless NP
+in the domain takes the domain's high case and one c-commanded by such an NP its low case, the
+two rules reading the same configuration, so a domain with both marks the higher NP and the
+lower NP at once; whatever remains takes the domain's elsewhere case. Which of the two
+dependent rules a clause has is its alignment: accusative, ergative, tripartite or neutral.
+The passes are generic in what an NP is, so a phase-cyclic grammar can run them domain by
+domain.
 
 ## Main definitions
 
-* `CaseSource`: how a case was assigned; `CaseSource.toNeutral` projects it
-  onto the account-neutral `Case.Source`. Dependent case is total, which the
-  projection's totality records by construction.
-* `CaseLanguageType`: the alignment parameter fixing the dependent and
-  unmarked cases.
-* `NPInDomain`, `CasedNP`: an NP before and after case assignment.
-* `assignCases`: the one-pass algorithm over a Spell-Out domain.
-* `structuralCasesFor`: the cases the algorithm can assign to a caseless NP.
-* `CaseSystemConfig`: per-case choice of assignment mechanism.
-* `PhasedNP`, `assignCasesPhased`: the two-cycle algorithm.
+* `Mechanism`: what valued a case — a lexical head, a dependent rule, Agree, or the elsewhere
+  case — projecting onto the account-neutral `Case.Source`.
+* `Rules`: the high, low and elsewhere cases of one domain; `Rules.alignment` and
+  `Rules.ofAlignment` relate them to the alignment they show.
+* `NP`, `Valuation`: an NP before assignment, and its case with what valued it.
+* `Rules.dependentPass`, `Rules.unmarkedPass`: the passes, over the NPs a predicate selects.
+* `Rules.assign`, `assignCases`: the one-domain algorithm, and its form for an alignment.
 
 ## Main results
 
-* `lexical_bleeds_dependent`: lexical case pre-empts the dependent rule.
-* `nonlexical_case_mem_structuralCasesFor`: the algorithm assigns a caseless
-  NP only cases its alignment type admits.
-* `assignCases_length`, `assignCasesPhased_length`: both algorithms are
-  total — one `CasedNP` per input NP.
-* `dat_persists_through_assignCasesPhased`: the Elsewhere ordering of the
-  dative rule over the accusative rule is structural, not a stipulated rule
-  ordering.
+* `Rules.dependentPass_high`, `Rules.dependentPass_low`, `Rules.dependentPass_alone`: what the
+  dependent rules do to an NP with a caseless NP below it, above it, or neither.
+* `Rules.assign_length`: the algorithm is total.
+* `Rules.assign_getElem?_of_some`: lexical case is kept, so it bleeds the dependent rules.
+* `Rules.case_mem_cases`: a caseless NP is valued only with a case the rules mention.
+* `alignment_ofAlignment`: the rules of an alignment show that alignment.
 
 ## Implementation notes
 
-List position encodes structural height: earlier is higher, and c-commands
-everything later. NP identity is carried by a `String` label, which
-`getCaseOf` and `getSourceOf` look up; the labels are inert for the
-algorithm, which reads only the lexical-case field and list position.
+List position encodes structural height: earlier is higher, and c-commands everything later.
+Labels are inert; `getCaseOf` and `getMechanismOf` look them up.
 
 ## References
 
 * [marantz-1991]
 * [baker-2015]
-* [baker-vinokurova-2010]
 -/
 
-namespace Syntax.Case
+namespace Case
 
-/-! ### Case sources -/
+variable {α : Type*}
 
-/-- The mechanism that assigned a case, ordered by priority: `lexical`
-    (a specific head, e.g. P or inherent V case) outranks `dependent`
-    (structural configuration), which outranks `unmarked` (the default).
-    `agree` is the Chomskyan alternative to `dependent`, valuation by a
-    functional head. -/
-inductive CaseSource where
+/-! ### Mechanisms -/
+
+/-- What valued a case: a lexical head, a dependent rule, Agree with a functional head, or
+    the elsewhere case of its domain. -/
+inductive Mechanism
   | lexical
   | dependent
-  | unmarked
   | agree
+  | unmarked
   deriving DecidableEq, Repr
 
-/-- The account-neutral provenance of a dependent-case source: configural
-    and Agree-valued cases are `structural`, lexical is `inherent`, and
-    unmarked is `default`. -/
-def CaseSource.toNeutral : CaseSource → _root_.Case.Source
+/-- The account-neutral provenance: lexical case is inherent, dependent and Agree-valued case
+    structural, the elsewhere case default. -/
+def Mechanism.toSource : Mechanism → Source
   | .lexical => .inherent
   | .dependent => .structural
-  | .unmarked => .default
   | .agree => .structural
+  | .unmarked => .default
 
-/-! ### Alignment types -/
+/-! ### Rules -/
 
-/-- The alignment parameter, fixing which case the dependent rule assigns
-    and which case is the default: accusative (dependent ACC on the lower
-    NP, unmarked NOM), ergative (dependent ERG on the higher NP, unmarked
-    ABS), or tripartite (both dependent rules active, unmarked ABS). -/
-inductive CaseLanguageType where
-  | accusative
-  | ergative
-  | tripartite
+/-- The rules of one domain: the case of an NP c-commanding a distinct caseless NP in it, the
+    case of one c-commanded by such an NP, and the elsewhere case. -/
+structure Rules where
+  high : Option Case := none
+  low : Option Case := none
+  unmarked : Option Case := none
   deriving DecidableEq, Repr
 
-/-! ### Spell-Out domains -/
+/-- The cases the rules can value a caseless NP with. -/
+def Rules.cases (r : Rules) : List Case := [r.high, r.low, r.unmarked].filterMap id
 
-/-- An NP in a Spell-Out domain, before case assignment. `lexicalCase` is
-    `some c` when a P or V head has pre-assigned case `c`. -/
-structure NPInDomain where
-  /-- Label identifying this NP. -/
+theorem high_mem_cases {r : Rules} {c : Case} (h : r.high = some c) : c ∈ r.cases := by
+  simp [Rules.cases, h]
+
+theorem low_mem_cases {r : Rules} {c : Case} (h : r.low = some c) : c ∈ r.cases := by
+  simp [Rules.cases, h]
+
+theorem unmarked_mem_cases {r : Rules} {c : Case} (h : r.unmarked = some c) : c ∈ r.cases := by
+  simp [Rules.cases, h]
+
+/-- The alignment a domain's rules show: which of the two dependent rules it has. -/
+def Rules.alignment (r : Rules) : Alignment.AlignmentType :=
+  match r.high, r.low with
+  | none, none => .neutral
+  | none, some _ => .accusative
+  | some _, none => .ergative
+  | some _, some _ => .tripartite
+
+/-- The clausal rules of an alignment: accusative on the lower NP, ergative on the higher,
+    both, or neither, with the elsewhere case nominative where the lower NP is marked and
+    absolutive otherwise. A split-S system is not a dependent-case setting and gets the
+    neutral rules. -/
+def Rules.ofAlignment : Alignment.AlignmentType → Rules
+  | .accusative => { low := some .acc, unmarked := some .nom }
+  | .ergative => { high := some .erg, unmarked := some .abs }
+  | .tripartite => { high := some .erg, low := some .acc, unmarked := some .abs }
+  | .neutral | .active => { unmarked := some .nom }
+
+/-- The rules of an alignment show that alignment. -/
+theorem alignment_ofAlignment (a : Alignment.AlignmentType) (ha : a ≠ .active) :
+    (Rules.ofAlignment a).alignment = a := by
+  cases a <;> first | rfl | exact absurd rfl ha
+
+/-! ### NPs and valuations -/
+
+/-- An NP as the rules see it: its label and any case a lexical head has valued. -/
+structure NP where
   label : String
-  /-- Case pre-assigned by a P or V head, e.g. ablative from Japanese *kara*. -/
-  lexicalCase : Option Case
+  lexicalCase : Option Case := none
   deriving DecidableEq, Repr
 
-/-- An NP after case assignment, carrying its case and the source that
-    assigned it. -/
-structure CasedNP where
-  /-- Label identifying this NP, inherited from its `NPInDomain`. -/
-  label : String
-  /-- The assigned case. -/
-  case : Case
-  /-- The mechanism that assigned it. -/
-  source : CaseSource
-  deriving DecidableEq, Repr
+/-- A case together with what valued it, or nothing if no rule has reached the NP. -/
+abbrev Valuation := Option (Case × Mechanism)
 
-instance : HasCase CasedNP := ⟨fun np => some np.case⟩
+/-- Every NP with its lexical case valued and nothing else. -/
+def initial (lexicalCase : α → Option Case) (xs : List α) : List (α × Valuation) :=
+  xs.map λ x => (x, (lexicalCase x).map (·, .lexical))
 
-/-- The case assigned to the NP labelled `label`, if any. -/
-def getCaseOf (label : String) (results : List CasedNP) : Option Case :=
-  (results.find? (·.label == label)).bind HasCase.caseOf
+/-- The case of the NP labelled `label`, if any. -/
+def getCaseOf (label : String) (out : List (NP × Valuation)) : Option Case :=
+  (out.find? (·.1.label == label)).bind (·.2.map (·.1))
 
-/-- The source of the case assigned to the NP labelled `label`, if any. -/
-def getSourceOf (label : String) (results : List CasedNP) : Option CaseSource :=
-  (results.find? (·.label == label)).map (·.source)
+/-- What valued the NP labelled `label`, if anything. -/
+def getMechanismOf (label : String) (out : List (NP × Valuation)) : Option Mechanism :=
+  (out.find? (·.1.label == label)).bind (·.2.map (·.2))
 
-/-! ### The dependent case rules -/
+/-! ### The passes -/
 
-/-- Some NP in the list has no lexical case, and so can serve as the
-    caseless competitor a dependent rule needs. -/
-def anyLacksCaseIn (nps : List NPInDomain) : Bool :=
-  nps.any (·.lexicalCase.isNone)
+/-- `markBy`, with indices counted from `i`. -/
+def markByFrom (f : ℕ → α × Valuation → Valuation) :
+    ℕ → List (α × Valuation) → List (α × Valuation)
+  | _, [] => []
+  | i, s :: rest => (if s.2.isNone then (s.1, f i s) else s) :: markByFrom f (i + 1) rest
 
-/-- Dependent accusative: a caseless NP c-commanded by a caseless NP gets
-    ACC. `higherNPs` are the NPs c-commanding `np`. -/
-def dependentAccusative (higherNPs : List NPInDomain) (np : NPInDomain) : Option Case :=
-  if np.lexicalCase.isNone && anyLacksCaseIn higherNPs then some .acc else none
+/-- Value every unvalued NP for which `f` proposes a value. -/
+def markBy (f : ℕ → α × Valuation → Valuation) (states : List (α × Valuation)) :
+    List (α × Valuation) :=
+  markByFrom f 0 states
 
-/-- Dependent ergative: a caseless NP c-commanding a caseless NP gets ERG.
-    `lowerNPs` are the NPs `np` c-commands. -/
-def dependentErgative (np : NPInDomain) (lowerNPs : List NPInDomain) : Option Case :=
-  if np.lexicalCase.isNone && anyLacksCaseIn lowerNPs then some .erg else none
+theorem markByFrom_getElem? (f : ℕ → α × Valuation → Valuation) (i j : ℕ)
+    (states : List (α × Valuation)) :
+    (markByFrom f i states)[j]? =
+      states[j]?.map λ s => if s.2.isNone then (s.1, f (i + j) s) else s := by
+  induction states generalizing i j with
+  | nil => simp [markByFrom]
+  | cons s rest ih =>
+    cases j with
+    | zero => simp [markByFrom]
+    | succ j => simp [markByFrom, ih, Nat.add_assoc, Nat.add_comm 1 j]
 
-/-- The default case an alignment type assigns to an NP no other rule
-    reached: NOM in an accusative language, ABS otherwise. -/
-def unmarkedCaseFor : CaseLanguageType → Case
-  | .accusative => .nom
-  | .ergative => .abs
-  | .tripartite => .abs
+theorem markBy_getElem? (f : ℕ → α × Valuation → Valuation) (states : List (α × Valuation))
+    (j : ℕ) :
+    (markBy f states)[j]? = states[j]?.map λ s => if s.2.isNone then (s.1, f j s) else s := by
+  simp [markBy, markByFrom_getElem?]
 
-/-! ### One-pass case assignment -/
+/-- The indices of the unvalued NPs `P` selects, highest first. -/
+def eligible (P : α → Bool) (states : List (α × Valuation)) : List ℕ :=
+  (states.zipIdx.filter λ s => s.1.2.isNone && P s.1.1).map (·.2)
 
-/-- Case for one NP, given the NPs above and below it: lexical case if it
-    has any, else the dependent case its alignment type licenses, else the
-    unmarked default. A tripartite language tries ergative before
-    accusative, so an NP with a caseless competitor on both sides — the
-    middle NP of a caseless triple — surfaces as ERG. -/
-def assignOneCase (lang : CaseLanguageType) (higherNPs lowerNPs : List NPInDomain)
-    (np : NPInDomain) : CasedNP :=
-  let cased c src : CasedNP := { label := np.label, case := c, source := src }
-  let unmarked := cased (unmarkedCaseFor lang) .unmarked
-  match np.lexicalCase with
-  | some c => cased c .lexical
-  | none =>
-    match lang with
-    | .accusative => ((dependentAccusative higherNPs np).map (cased · .dependent)).getD unmarked
-    | .ergative => ((dependentErgative np lowerNPs).map (cased · .dependent)).getD unmarked
-    | .tripartite =>
-      (((dependentErgative np lowerNPs).orElse fun _ => dependentAccusative higherNPs np).map
-        (cased · .dependent)).getD unmarked
+theorem mem_eligible_iff {P : α → Bool} {states : List (α × Valuation)} {i : ℕ} :
+    i ∈ eligible P states ↔ ∃ x, states[i]? = some (x, none) ∧ P x := by
+  simp only [eligible, List.mem_map, List.mem_filter, List.mem_zipIdx_iff_getElem?,
+    Bool.and_eq_true, Option.isNone_iff_eq_none]
+  constructor
+  · rintro ⟨⟨⟨x, v⟩, j⟩, ⟨hj, rfl, hx⟩, rfl⟩
+    exact ⟨x, hj, hx⟩
+  · rintro ⟨x, hx, hP⟩
+    exact ⟨((x, none), i), ⟨hx, rfl, hP⟩, rfl⟩
 
-/-- `assignCases`, with the already-processed NPs accumulated in `higher`. -/
-private def assignCasesGo (lang : CaseLanguageType) (higher : List NPInDomain) :
-    List NPInDomain → List CasedNP
-  | [] => []
-  | np :: rest => assignOneCase lang higher rest np :: assignCasesGo lang (higher ++ [np]) rest
+/-- The dependent rules over the NPs `P` selects: the high case goes to those c-commanding
+    another and the low case to those c-commanded by another, both read off the same
+    configuration; an NP in both positions takes the high case. -/
+def Rules.dependentPass (r : Rules) (P : α → Bool) (states : List (α × Valuation)) :
+    List (α × Valuation) :=
+  let e := eligible P states
+  markBy (λ i _ =>
+    if i ∈ e then
+      if r.high.isSome && e.any (i < ·) then r.high.map (·, .dependent)
+      else if e.any (· < i) then r.low.map (·, .dependent)
+      else none
+    else none) states
 
-/-- Case for every NP in a Spell-Out domain. List order encodes structural
-    height: the first NP is highest and c-commands all the others. -/
-def assignCases (lang : CaseLanguageType) (nps : List NPInDomain) : List CasedNP :=
-  assignCasesGo lang [] nps
+/-- The elsewhere case to the unvalued NPs `P` selects. -/
+def Rules.unmarkedPass (r : Rules) (P : α → Bool) (states : List (α × Valuation)) :
+    List (α × Valuation) :=
+  markBy (λ _ s => if P s.1 then r.unmarked.map (·, .unmarked) else none) states
 
-private theorem assignCasesGo_length (lang : CaseLanguageType)
-    (higher nps : List NPInDomain) : (assignCasesGo lang higher nps).length = nps.length := by
-  induction nps generalizing higher with
+/-- Case for every NP of one domain: the dependent rules, then the elsewhere case. -/
+def Rules.assign (r : Rules) (nps : List NP) : List (NP × Valuation) :=
+  r.unmarkedPass (λ _ => true) (r.dependentPass (λ _ => true) (initial NP.lexicalCase nps))
+
+/-- The one-domain algorithm of an alignment. -/
+def assignCases (a : Alignment.AlignmentType) (nps : List NP) : List (NP × Valuation) :=
+  (Rules.ofAlignment a).assign nps
+
+/-! ### Totality -/
+
+theorem markByFrom_length (f : ℕ → α × Valuation → Valuation) (i : ℕ)
+    (states : List (α × Valuation)) : (markByFrom f i states).length = states.length := by
+  induction states generalizing i with
   | nil => rfl
-  | cons _ _ ih => simp [assignCasesGo, ih]
+  | cons _ _ ih => simp [markByFrom, ih]
 
-/-- The one-pass algorithm is total: exactly one `CasedNP` per input NP. -/
-@[simp] theorem assignCases_length (lang : CaseLanguageType) (nps : List NPInDomain) :
-    (assignCases lang nps).length = nps.length :=
-  assignCasesGo_length lang [] nps
+@[simp] theorem markBy_length (f : ℕ → α × Valuation → Valuation) (states : List (α × Valuation)) :
+    (markBy f states).length = states.length := markByFrom_length ..
 
-/-! ### Priority and alignment -/
+@[simp] theorem Rules.dependentPass_length (r : Rules) (P : α → Bool)
+    (states : List (α × Valuation)) : (r.dependentPass P states).length = states.length :=
+  markBy_length ..
 
-/-- An NP with lexical case keeps it, whatever the configuration. -/
-theorem lexical_bleeds_dependent (lang : CaseLanguageType) (c : Case) (label : String)
-    (higherNPs lowerNPs : List NPInDomain) :
-    (assignOneCase lang higherNPs lowerNPs
-      { label := label, lexicalCase := some c }).source = .lexical := by
-  cases lang <;> rfl
+@[simp] theorem Rules.unmarkedPass_length (r : Rules) (P : α → Bool)
+    (states : List (α × Valuation)) : (r.unmarkedPass P states).length = states.length :=
+  markBy_length ..
 
-/-- Dependent accusative needs only two caseless NPs in one domain, not an
-    agentive Voice head; cf. `Scott2023.dependent_case_ignores_voice`. -/
-theorem no_voice_needed_for_acc :
-    let nps : List NPInDomain :=
-      [ { label := "subj", lexicalCase := none },
-        { label := "obj", lexicalCase := none } ]
-    getCaseOf "obj" (assignCases .accusative nps) = some .acc ∧
-    getSourceOf "obj" (assignCases .accusative nps) = some .dependent := by decide
+@[simp] theorem initial_length (lexicalCase : α → Option Case) (xs : List α) :
+    (initial lexicalCase xs).length = xs.length := List.length_map ..
 
-/-- Two caseless NPs in an ergative language: the higher gets dependent ERG
-    and the lower unmarked ABS, mirroring the accusative pattern. -/
-theorem ergative_mirror :
-    let nps : List NPInDomain :=
-      [ { label := "higher", lexicalCase := none },
-        { label := "lower", lexicalCase := none } ]
-    getCaseOf "higher" (assignCases .ergative nps) = some .erg ∧
-    getCaseOf "lower" (assignCases .ergative nps) = some .abs := by decide
+/-- The algorithm is total: one valuation per NP. -/
+@[simp] theorem Rules.assign_length (r : Rules) (nps : List NP) :
+    (r.assign nps).length = nps.length := by
+  simp [Rules.assign]
 
-/-- A lone caseless NP in an accusative language gets unmarked NOM: with no
-    competitor, no dependent case arises. -/
-theorem single_np_nom :
-    let nps : List NPInDomain := [ { label := "sole", lexicalCase := none } ]
-    getCaseOf "sole" (assignCases .accusative nps) = some .nom ∧
-    getSourceOf "sole" (assignCases .accusative nps) = some .unmarked := by decide
+/-! ### What each pass does -/
 
-/-- A tripartite transitive marks the higher NP ERG and the lower ACC, and
-    a tripartite intransitive marks its sole NP ABS. -/
-theorem tripartite_transitive_and_intransitive :
-    let tr : List NPInDomain :=
-      [ { label := "higher", lexicalCase := none },
-        { label := "lower", lexicalCase := none } ]
-    let intr : List NPInDomain := [ { label := "sole", lexicalCase := none } ]
-    getCaseOf "higher" (assignCases .tripartite tr) = some .erg ∧
-    getCaseOf "lower" (assignCases .tripartite tr) = some .acc ∧
-    getCaseOf "sole" (assignCases .tripartite intr) = some .abs := by decide
+theorem markBy_getElem?_of_some (f : ℕ → α × Valuation → Valuation)
+    {states : List (α × Valuation)} {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : states[i]? = some (x, some v)) : (markBy f states)[i]? = some (x, some v) := by
+  simp [markBy_getElem?, h]
 
-/-- Tripartite alignment subsumes both others: its higher NP gets the case
-    an ergative language would assign, its lower NP the case an accusative
-    language would. -/
-theorem tripartite_subsumes_both :
-    let nps : List NPInDomain :=
-      [ { label := "higher", lexicalCase := none },
-        { label := "lower", lexicalCase := none } ]
-    getCaseOf "higher" (assignCases .tripartite nps) =
-      getCaseOf "higher" (assignCases .ergative nps) ∧
-    getCaseOf "lower" (assignCases .tripartite nps) =
-      getCaseOf "lower" (assignCases .accusative nps) := by decide
+theorem markBy_getElem?_of_none (f : ℕ → α × Valuation → Valuation)
+    {states : List (α × Valuation)} {i : ℕ} {x : α} (h : states[i]? = some (x, none)) :
+    (markBy f states)[i]? = some (x, f i (x, none)) := by
+  simp [markBy_getElem?, h]
 
-/-! ### The structural case inventory -/
+theorem Rules.dependentPass_getElem?_of_some (r : Rules) (P : α → Bool)
+    {states : List (α × Valuation)} {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : states[i]? = some (x, some v)) : (r.dependentPass P states)[i]? = some (x, some v) :=
+  markBy_getElem?_of_some _ h
 
-/-- The cases the algorithm can assign to an NP without lexical case. -/
-def structuralCasesFor : CaseLanguageType → List Case
-  | .accusative => [.nom, .acc]
-  | .ergative => [.abs, .erg]
-  | .tripartite => [.abs, .erg, .acc]
+theorem Rules.unmarkedPass_getElem?_of_some (r : Rules) (P : α → Bool)
+    {states : List (α × Valuation)} {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : states[i]? = some (x, some v)) : (r.unmarkedPass P states)[i]? = some (x, some v) :=
+  markBy_getElem?_of_some _ h
 
-/-- A caseless NP receives one of the cases its alignment type admits. -/
-theorem nonlexical_case_mem_structuralCasesFor (lang : CaseLanguageType)
-    (higherNPs lowerNPs : List NPInDomain) (np : NPInDomain) (h : np.lexicalCase = none) :
-    (assignOneCase lang higherNPs lowerNPs np).case ∈ structuralCasesFor lang := by
-  cases lang <;>
-    by_cases hh : anyLacksCaseIn higherNPs <;> by_cases hl : anyLacksCaseIn lowerNPs <;>
-    simp [assignOneCase, dependentAccusative, dependentErgative, structuralCasesFor,
-      unmarkedCaseFor, h, hh, hl]
+theorem initial_getElem?_of_some (lexicalCase : α → Option Case) {xs : List α} {i : ℕ} {x : α}
+    {c : Case} (hx : xs[i]? = some x) (hc : lexicalCase x = some c) :
+    (initial lexicalCase xs)[i]? = some (x, some (c, .lexical)) := by
+  simp [initial, hx, hc]
 
-/-! ### Per-case assignment mechanisms -/
+/-- A caseless NP with a caseless NP below it in the domain takes the high case. -/
+theorem Rules.dependentPass_high (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i j : ℕ} {x : α} {c : Case} (hx : states[i]? = some (x, none)) (hP : P x)
+    (hj : j ∈ eligible P states) (hij : i < j) (hc : r.high = some c) :
+    (r.dependentPass P states)[i]? = some (x, some (c, .dependent)) := by
+  have hi : i ∈ eligible P states := mem_eligible_iff.2 ⟨x, hx, hP⟩
+  have hany : ∃ k ∈ eligible P states, i < k := ⟨j, hj, hij⟩
+  simp [Rules.dependentPass, markBy_getElem?_of_none _ hx, hi, hany, hc]
 
-/-- How nominative is assigned: by Agree with finite T, or as the elsewhere
-    default. [baker-vinokurova-2010] argue for the former in Sakha, and
-    [gong-2022] for Mongolian. -/
-inductive NomAssignment where
-  | agreeT
-  | unmarkedDefault
-  deriving DecidableEq, Repr
+/-- A caseless NP with a caseless NP above it in the domain, and none below it that the high
+    rule could mark it for, takes the low case. -/
+theorem Rules.dependentPass_low (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i j : ℕ} {x : α} {c : Case} (hx : states[i]? = some (x, none)) (hP : P x)
+    (hj : j ∈ eligible P states) (hji : j < i)
+    (hhigh : r.high = none ∨ ∀ k ∈ eligible P states, ¬ i < k) (hc : r.low = some c) :
+    (r.dependentPass P states)[i]? = some (x, some (c, .dependent)) := by
+  have hi : i ∈ eligible P states := mem_eligible_iff.2 ⟨x, hx, hP⟩
+  have hany : ∃ k ∈ eligible P states, k < i := ⟨j, hj, hji⟩
+  rcases hhigh with h | h
+  · simp [Rules.dependentPass, markBy_getElem?_of_none _ hx, hi, hany, h, hc]
+  · have hno : ¬ ∃ k ∈ eligible P states, i < k := λ ⟨k, hk, hik⟩ => h k hk hik
+    simp [Rules.dependentPass, markBy_getElem?_of_none _ hx, hi, hany, hno, hc]
 
-/-- How dative is assigned: as dependent case, or nonstructurally, in which
-    case it neither competes for dependent case nor is available at
-    intermediate positions ([gong-2022] on Mongolian). -/
-inductive DatAssignment where
-  | nonstructural
-  | dependent
-  deriving DecidableEq, Repr
+/-- A caseless NP alone in its domain is untouched by the dependent rules. -/
+theorem Rules.dependentPass_alone (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i : ℕ} {x : α} (hx : states[i]? = some (x, none))
+    (halone : ∀ j ∈ eligible P states, j = i) :
+    (r.dependentPass P states)[i]? = some (x, none) := by
+  have h1 : ¬ ∃ k ∈ eligible P states, i < k :=
+    λ ⟨k, hk, hik⟩ => lt_irrefl i (halone k hk ▸ hik)
+  have h2 : ¬ ∃ k ∈ eligible P states, k < i :=
+    λ ⟨k, hk, hki⟩ => lt_irrefl i (halone k hk ▸ hki)
+  simp [Rules.dependentPass, markBy_getElem?_of_none _ hx, h1, h2]
 
-/-- How accusative is assigned: as dependent case ([marantz-1991]), or by
-    Agree with v ([chomsky-2000]). -/
-inductive AccAssignment where
-  | dependent
-  | agreeV
-  deriving DecidableEq, Repr
+/-- Lexical case is kept, so it bleeds the dependent rules. -/
+theorem Rules.assign_getElem?_of_some (r : Rules) {nps : List NP} {i : ℕ} {np : NP} {c : Case}
+    (hnp : nps[i]? = some np) (hc : np.lexicalCase = some c) :
+    (r.assign nps)[i]? = some (np, some (c, .lexical)) :=
+  r.unmarkedPass_getElem?_of_some _
+    (r.dependentPass_getElem?_of_some _ (initial_getElem?_of_some _ hnp hc))
 
-/-- How genitive is assigned: by Agree with D, the DP-internal counterpart
-    of T-Agree ([baker-vinokurova-2010]), or nonstructurally, as in the
-    Russian numeric and partitive genitives. -/
-inductive GenAssignment where
-  | agreeD
-  | nonstructural
-  deriving DecidableEq, Repr
+/-! ### The cases the rules value -/
 
-/-- A grammar's choice of mechanism for each structural case, alongside its
-    alignment type. A purely configurational grammar takes `unmarkedDefault`
-    nominative with `dependent` accusative and dative; a purely Agree-based
-    one takes `agreeT`, `agreeD`, `agreeV` and nonstructural dative; the
-    Sakha grammar of [baker-vinokurova-2010] mixes the two, valuing
-    nominative and genitive by Agree but accusative and dative
-    configurationally. -/
-structure CaseSystemConfig where
-  /-- The alignment type, fixing the dependent and unmarked cases. -/
-  langType : CaseLanguageType
-  /-- How nominative is assigned. -/
-  nomMode : NomAssignment
-  /-- How dative is assigned. -/
-  datMode : DatAssignment
-  /-- How accusative is assigned. -/
-  accMode : AccAssignment := .dependent
-  /-- How genitive is assigned. -/
-  genMode : GenAssignment := .agreeD
-  deriving DecidableEq, Repr
+theorem markBy_value {f : ℕ → α × Valuation → Valuation} {states : List (α × Valuation)} {i : ℕ}
+    {x : α} {v : Case × Mechanism} (h : (markBy f states)[i]? = some (x, some v)) :
+    states[i]? = some (x, some v) ∨ ∃ s, states[i]? = some s ∧ s.1 = x ∧ f i s = some v := by
+  simp only [markBy_getElem?] at h
+  obtain ⟨s, hs, hfs⟩ := Option.map_eq_some_iff.1 h
+  by_cases hnone : s.2.isNone
+  · simp only [hnone, ↓reduceIte, Prod.mk.injEq] at hfs
+    exact .inr ⟨s, hs, hfs.1, hfs.2⟩
+  · simp only [hnone, Bool.false_eq_true, ↓reduceIte] at hfs
+    exact .inl (hfs ▸ hs)
 
-/-! ### Phased case assignment -/
+theorem Rules.dependentPass_case (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : (r.dependentPass P states)[i]? = some (x, some v)) :
+    states[i]? = some (x, some v) ∨ v.1 ∈ r.cases := by
+  refine (markBy_value h).imp_right λ ⟨s, _, _, hf⟩ => ?_
+  split_ifs at hf
+  all_goals first
+    | cases hf
+    | (obtain ⟨c, hc, rfl⟩ := Option.map_eq_some_iff.1 hf
+       first | exact high_mem_cases hc | exact low_mem_cases hc)
 
-/-- The cycle a case rule applies on, in the two-phase model: the VP phase
-    or the CP phase. Coarser than `Minimalist.Phase`, which the case
-    algorithm does not need. -/
-inductive CasePhase where
-  | vp
-  | cp
-  deriving DecidableEq, Repr
+theorem Rules.unmarkedPass_case (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : (r.unmarkedPass P states)[i]? = some (x, some v)) :
+    states[i]? = some (x, some v) ∨ v.1 ∈ r.cases := by
+  refine (markBy_value h).imp_right λ ⟨s, _, _, hf⟩ => ?_
+  split_ifs at hf
+  obtain ⟨c, hc, rfl⟩ := Option.map_eq_some_iff.1 hf
+  exact unmarked_mem_cases hc
 
-/-- An NP carrying the phase information the cyclic algorithm reads:
-    where it was merged, whether it moved to a higher phase before case was
-    evaluated, whether it is a case competitor at all, and whether it is
-    DP-internal. -/
-structure PhasedNP extends NPInDomain where
-  /-- The phase the NP was merged in. -/
-  basePhase : CasePhase
-  /-- The NP moved to a higher phase before case was evaluated. -/
-  shifted : Bool := false
-  /-- The NP bears a θ-role with respect to some case assigner. Bare-NP
-      adverbs do not, and so are not competitors for the dependent rules. -/
-  isArgumental : Bool := true
-  /-- The NP is a DP-internal possessor, invisible to the clausal passes and
-      valued instead by D-Agree. -/
-  inDP : Bool := false
-  deriving DecidableEq, Repr
+theorem initial_value {lexicalCase : α → Option Case} {xs : List α} {i : ℕ} {x : α}
+    {v : Case × Mechanism} (h : (initial lexicalCase xs)[i]? = some (x, some v)) :
+    lexicalCase x = some v.1 := by
+  simp only [initial, List.getElem?_map] at h
+  obtain ⟨y, -, hy⟩ := Option.map_eq_some_iff.1 h
+  obtain ⟨rfl, hv⟩ := Prod.mk.injEq .. ▸ hy
+  obtain ⟨c, hc, rfl⟩ := Option.map_eq_some_iff.1 hv
+  exact hc
 
-/-- Every VP-merged NP is visible on the VP cycle: shift happens at the
-    boundary between cycles. -/
-def PhasedNP.visibleOnVP (p : PhasedNP) : Bool := p.basePhase == .vp
+/-- A caseless NP is valued only with a case the rules mention. -/
+theorem Rules.case_mem_cases (r : Rules) {nps : List NP} {i : ℕ} {np : NP} {c : Case}
+    {m : Mechanism} (hlex : np.lexicalCase = none)
+    (h : (r.assign nps)[i]? = some (np, some (c, m))) : c ∈ r.cases := by
+  rcases r.unmarkedPass_case _ h with h | h
+  · rcases r.dependentPass_case _ h with h | h
+    · exact absurd (initial_value h) (by simp [hlex])
+    · exact h
+  · exact h
 
-/-- An NP is visible on the CP cycle when it was merged there or shifted out
-    of VP; an unshifted VP-internal NP has been transferred. -/
-def PhasedNP.visibleOnCP (p : PhasedNP) : Bool :=
-  p.basePhase == .cp || p.shifted
+/-! ### What each pass values as -/
 
-/-- An NP part-way through the derivation. `case = none` means not yet
-    valued; lexical case is valued from the start. -/
-structure PhasedState where
-  /-- The NP being valued. -/
-  np : PhasedNP
-  /-- Its case and the source that valued it, once some pass has. -/
-  case : Option (Case × CaseSource)
-  deriving DecidableEq, Repr
+theorem markBy_none (states : List (α × Valuation)) : markBy (λ _ _ => none) states = states := by
+  apply List.ext_getElem?
+  intro i
+  simp only [markBy_getElem?]
+  rcases states[i]? with _ | ⟨x, _ | v⟩ <;> simp
 
-/-- The NP has been valued, by any mechanism. The dependent rules apply
-    only to unmarked NPs, which is what makes their ordering an Elsewhere
-    ordering rather than a stipulation. -/
-def PhasedState.marked (s : PhasedState) : Bool := s.case.isSome
+/-- With no elsewhere case the pass does nothing. -/
+theorem Rules.unmarkedPass_of_none (r : Rules) (P : α → Bool) (h : r.unmarked = none)
+    (states : List (α × Valuation)) : r.unmarkedPass P states = states := by
+  simp [Rules.unmarkedPass, h, markBy_none]
 
-/-- Value lexical case from each NP, leaving everything else unmarked. -/
-def initStates (nps : List PhasedNP) : List PhasedState :=
-  nps.map fun p => { np := p, case := p.lexicalCase.map (fun c => (c, .lexical)) }
+/-- The dependent rules value as such. -/
+theorem Rules.dependentPass_mechanism (r : Rules) (P : α → Bool) {states : List (α × Valuation)}
+    {i : ℕ} {x : α} {v : Case × Mechanism}
+    (h : (r.dependentPass P states)[i]? = some (x, some v)) :
+    states[i]? = some (x, some v) ∨ v.2 = .dependent := by
+  refine (markBy_value h).imp_right λ ⟨s, _, _, hf⟩ => ?_
+  split_ifs at hf
+  all_goals first
+    | cases hf
+    | (obtain ⟨c, hc, rfl⟩ := Option.map_eq_some_iff.1 hf; rfl)
 
-/-- Value the NP at index `i` as `c` from source `src`. -/
-def setCaseAt (i : Nat) (c : Case) (src : CaseSource)
-    (states : List PhasedState) : List PhasedState :=
-  states.modify i fun s => { s with case := some (c, src) }
+/-- The initial valuation is lexical. -/
+theorem initial_mechanism {lexicalCase : α → Option Case} {xs : List α} {i : ℕ} {x : α}
+    {v : Case × Mechanism} (h : (initial lexicalCase xs)[i]? = some (x, some v)) :
+    v.2 = .lexical := by
+  simp only [initial, List.getElem?_map] at h
+  obtain ⟨y, -, hy⟩ := Option.map_eq_some_iff.1 h
+  obtain ⟨rfl, hv⟩ := Prod.mk.injEq .. ▸ hy
+  obtain ⟨c, -, rfl⟩ := Option.map_eq_some_iff.1 hv
+  rfl
 
-/-- The state is a candidate for a case rule on this cycle: visible,
-    argumental, clause-level, and not yet valued. -/
-def unmarkedEligible (cycle : CasePhase) (s : PhasedState) : Bool :=
-  let visible := match cycle with
-    | .vp => s.np.visibleOnVP
-    | .cp => s.np.visibleOnCP
-  visible && s.np.isArgumental && !s.np.inDP && !s.marked
+/-! ### Alignments on a transitive and an intransitive clause -/
 
-/-- The indices of the states eligible on a cycle, highest first. -/
-def unmarkedVisible (cycle : CasePhase) (states : List PhasedState) : List Nat :=
-  states.zipIdx.filterMap fun p => if unmarkedEligible cycle p.1 then some p.2 else none
+/-- Two caseless NPs: the accusative rules value the lower accusative and leave the higher
+    nominative, the ergative rules mirror this, and the tripartite rules do both. -/
+theorem assignCases_transitive :
+    let nps : List NP := [{ label := "higher" }, { label := "lower" }]
+    (assignCases .accusative nps).map (·.2.map (·.1)) = [some .nom, some .acc] ∧
+    (assignCases .ergative nps).map (·.2.map (·.1)) = [some .erg, some .abs] ∧
+    (assignCases .tripartite nps).map (·.2.map (·.1)) = [some .erg, some .acc] := by
+  decide
 
-/-- The dative rule: on the VP cycle, an NP c-commanding another unmarked NP
-    is valued dative. Its context is the more restrictive one, so it bleeds
-    the accusative rule on that cycle. -/
-def applyDatRule (cfg : CaseSystemConfig) (states : List PhasedState) :
-    List PhasedState :=
-  if cfg.datMode != .dependent then states
-  else match unmarkedVisible .vp states with
-    | i :: _ :: _ => setCaseAt i .dat .dependent states
-    | _ => states
+/-- A sole caseless NP takes the elsewhere case under every alignment. -/
+theorem assignCases_intransitive (a : Alignment.AlignmentType) :
+    getMechanismOf "sole" (assignCases a [{ label := "sole" }]) = some .unmarked := by
+  cases a <;> decide
 
-/-- The accusative rule: on either cycle, an NP c-commanded by another
-    unmarked NP is valued accusative. -/
-def applyAccRule (cfg : CaseSystemConfig) (cycle : CasePhase)
-    (states : List PhasedState) : List PhasedState :=
-  if cfg.accMode != .dependent then states
-  else match (unmarkedVisible cycle states).reverse with
-    | last :: _ :: _ => setCaseAt last .acc .dependent states
-    | _ => states
-
-/-- v-Agree: v probes into its complement and values the closest unmarked
-    goal accusative. The Chomskyan alternative to `applyAccRule`; `accMode`
-    makes the two mutually exclusive. -/
-def applyAccAgree (cfg : CaseSystemConfig) (states : List PhasedState) :
-    List PhasedState :=
-  match cfg.accMode with
-  | .agreeV =>
-    match (unmarkedVisible .cp states).reverse with
-    | last :: _ => setCaseAt last .acc .agree states
-    | [] => states
-  | .dependent => states
-
-/-- T-Agree: T values the highest unmarked NP visible at CP nominative. -/
-def applyNomAgree (cfg : CaseSystemConfig) (states : List PhasedState) :
-    List PhasedState :=
-  match cfg.nomMode with
-  | .agreeT =>
-    match unmarkedVisible .cp states with
-    | first :: _ => setCaseAt first .nom .agree states
-    | [] => states
-  | .unmarkedDefault => states
-
-/-- D-Agree: each D values its unmarked possessor genitive. The clausal
-    passes see a DP as opaque, so this is the only pass that reaches inside
-    one. -/
-def applyGenAgree (cfg : CaseSystemConfig) (states : List PhasedState) :
-    List PhasedState :=
-  match cfg.genMode with
-  | .agreeD =>
-    states.map fun s =>
-      if s.np.inDP && !s.marked then { s with case := some (.gen, .agree) } else s
-  | .nonstructural => states
-
-/-- The last-resort sweep: every still-unmarked NP takes the unmarked case
-    of its alignment type. -/
-def applyDefault (cfg : CaseSystemConfig) (states : List PhasedState) :
-    List PhasedState :=
-  states.map fun s =>
-    if s.marked then s else { s with case := some (unmarkedCaseFor cfg.langType, .unmarked) }
-
-/-- The valued NP, or `none` if no pass reached it. -/
-def PhasedState.toCased (s : PhasedState) : Option CasedNP :=
-  s.case.map fun (c, src) => { label := s.np.label, case := c, source := src }
-
-/-- The two-cycle algorithm: the dative then accusative rule on the VP
-    cycle, the accusative rule again on the CP cycle, then the Agree probes,
-    then the default sweep. The dependent rules and their Agree counterparts
-    are gated on disjoint `CaseSystemConfig` settings, so their relative
-    order matters only where neither fires. -/
-def assignCasesPhased (cfg : CaseSystemConfig) (nps : List PhasedNP) : List CasedNP :=
-  let s0 := initStates nps
-  let s1 := applyDatRule cfg s0
-  let s2 := applyAccRule cfg .vp s1
-  let s3 := applyAccRule cfg .cp s2
-  let s4 := applyAccAgree cfg s3
-  let s5 := applyNomAgree cfg s4
-  let s6 := applyGenAgree cfg s5
-  let s7 := applyDefault cfg s6
-  s7.filterMap PhasedState.toCased
-
-/-! ### Totality of the phased algorithm -/
-
-@[simp] theorem initStates_length (nps : List PhasedNP) :
-    (initStates nps).length = nps.length := List.length_map ..
-
-@[simp] theorem setCaseAt_length (i : Nat) (c : Case) (src : CaseSource)
-    (states : List PhasedState) :
-    (setCaseAt i c src states).length = states.length := List.length_modify ..
-
-@[simp] theorem applyDatRule_length (cfg : CaseSystemConfig) (states : List PhasedState) :
-    (applyDatRule cfg states).length = states.length := by
-  unfold applyDatRule; split <;> [rfl; (split <;> simp)]
-
-@[simp] theorem applyAccRule_length (cfg : CaseSystemConfig) (cycle : CasePhase)
-    (states : List PhasedState) :
-    (applyAccRule cfg cycle states).length = states.length := by
-  unfold applyAccRule; split <;> [rfl; (split <;> simp)]
-
-@[simp] theorem applyAccAgree_length (cfg : CaseSystemConfig) (states : List PhasedState) :
-    (applyAccAgree cfg states).length = states.length := by
-  unfold applyAccAgree; split <;> [(split <;> simp); rfl]
-
-@[simp] theorem applyNomAgree_length (cfg : CaseSystemConfig) (states : List PhasedState) :
-    (applyNomAgree cfg states).length = states.length := by
-  unfold applyNomAgree; split <;> [(split <;> simp); rfl]
-
-@[simp] theorem applyGenAgree_length (cfg : CaseSystemConfig) (states : List PhasedState) :
-    (applyGenAgree cfg states).length = states.length := by
-  unfold applyGenAgree; split <;> simp
-
-@[simp] theorem applyDefault_length (cfg : CaseSystemConfig) (states : List PhasedState) :
-    (applyDefault cfg states).length = states.length := List.length_map ..
-
-/-- The default sweep leaves nothing unvalued. -/
-theorem applyDefault_all_some (cfg : CaseSystemConfig) (states : List PhasedState) :
-    ∀ s ∈ applyDefault cfg states, s.case.isSome := by
-  intro s hs
-  simp only [applyDefault, List.mem_map] at hs
-  obtain ⟨t, _, rfl⟩ := hs
-  unfold PhasedState.marked
-  split <;> simp_all
-
-@[simp] private theorem toCased_isSome (s : PhasedState) :
-    s.toCased.isSome = s.case.isSome := by
-  unfold PhasedState.toCased; cases s.case <;> rfl
-
-/-- The phased algorithm is total: exactly one `CasedNP` per input NP, none
-    dropped and none duplicated. -/
-theorem assignCasesPhased_length (cfg : CaseSystemConfig) (nps : List PhasedNP) :
-    (assignCasesPhased cfg nps).length = nps.length := by
-  rw [assignCasesPhased, List.filterMap_length_eq_length.mpr
-    (fun s hs => by simpa using applyDefault_all_some _ _ s hs)]
-  simp
-
-/-! ### Valued NPs are never overwritten -/
-
-/-- Every index a cycle offers a case rule points at an unvalued state. -/
-private theorem unmarkedVisible_unmarked {cycle : CasePhase} {states : List PhasedState}
-    {i : Nat} (h : i ∈ unmarkedVisible cycle states) :
-    ∃ s, states[i]? = some s ∧ s.marked = false := by
-  rw [unmarkedVisible, List.mem_filterMap] at h
-  obtain ⟨⟨s, k⟩, hmem, hcond⟩ := h
-  rw [List.mem_zipIdx_iff_getElem?] at hmem
-  by_cases hg : unmarkedEligible cycle s
-  · obtain rfl := Option.some.inj (if_pos hg ▸ hcond)
-    exact ⟨s, hmem, by simp_all [unmarkedEligible]⟩
-  · rw [if_neg hg] at hcond; cases hcond
-
-/-- A pass that either leaves the states alone or rewrites a single index
-    drawn from `unmarkedVisible` cannot overwrite a valued NP. This is the
-    structural content of the Elsewhere ordering: `unmarkedVisible` filters
-    valued states out, so no later rule can reach one. -/
-private theorem getElem?_of_spec {cycle : CasePhase} {states out : List PhasedState}
-    {i : Nat} {s : PhasedState} (h_get : states[i]? = some s) (h_marked : s.marked)
-    (hspec : out = states ∨
-      ∃ j ∈ unmarkedVisible cycle states, ∃ f, out = states.modify j f) :
-    out[i]? = some s := by
-  obtain rfl | ⟨j, hj, f, rfl⟩ := hspec
-  · exact h_get
-  · obtain ⟨s', hs', hs'_unmarked⟩ := unmarkedVisible_unmarked hj
-    have hne : j ≠ i := by rintro rfl; rw [h_get] at hs'; cases hs'; simp_all
-    rw [List.getElem?_modify_ne _ _ hne]; exact h_get
-
-private theorem applyAccRule_spec (cfg : CaseSystemConfig) (cycle : CasePhase)
-    (states : List PhasedState) :
-    applyAccRule cfg cycle states = states ∨
-      ∃ j ∈ unmarkedVisible cycle states, ∃ f,
-        applyAccRule cfg cycle states = states.modify j f := by
-  unfold applyAccRule
-  split
-  · exact .inl rfl
-  · split
-    case h_1 last _ _ heq =>
-      have : last ∈ (unmarkedVisible cycle states).reverse := by
-        rw [heq]; exact List.mem_cons_self ..
-      exact .inr ⟨last, by simpa using this, _, rfl⟩
-    case h_2 => exact .inl rfl
-
-private theorem applyAccAgree_spec (cfg : CaseSystemConfig) (states : List PhasedState) :
-    applyAccAgree cfg states = states ∨
-      ∃ j ∈ unmarkedVisible .cp states, ∃ f, applyAccAgree cfg states = states.modify j f := by
-  unfold applyAccAgree
-  split
-  · split
-    case h_1 last _ heq =>
-      have : last ∈ (unmarkedVisible .cp states).reverse := by rw [heq]; exact List.mem_cons_self ..
-      exact .inr ⟨last, by simpa using this, _, rfl⟩
-    case h_2 => exact .inl rfl
-  · exact .inl rfl
-
-private theorem applyNomAgree_spec (cfg : CaseSystemConfig) (states : List PhasedState) :
-    applyNomAgree cfg states = states ∨
-      ∃ j ∈ unmarkedVisible .cp states, ∃ f, applyNomAgree cfg states = states.modify j f := by
-  unfold applyNomAgree
-  split
-  · split
-    case h_1 first _ heq => exact .inr ⟨first, heq ▸ List.mem_cons_self .., _, rfl⟩
-    case h_2 => exact .inl rfl
-  · exact .inl rfl
-
-/-- The accusative rule never overwrites a valued NP. -/
-theorem applyAccRule_preserves_marked_at (cfg : CaseSystemConfig)
-    (cycle : CasePhase) (states : List PhasedState) (i : Nat) (s : PhasedState)
-    (h_get : states[i]? = some s) (h_marked : s.marked = true) :
-    (applyAccRule cfg cycle states)[i]? = some s :=
-  getElem?_of_spec h_get h_marked (applyAccRule_spec cfg cycle states)
-
-/-- v-Agree never overwrites a valued NP. -/
-theorem applyAccAgree_preserves_marked_at (cfg : CaseSystemConfig)
-    (states : List PhasedState) (i : Nat) (s : PhasedState)
-    (h_get : states[i]? = some s) (h_marked : s.marked = true) :
-    (applyAccAgree cfg states)[i]? = some s :=
-  getElem?_of_spec h_get h_marked (applyAccAgree_spec cfg states)
-
-/-- T-Agree never overwrites a valued NP. -/
-theorem applyNomAgree_preserves_marked_at (cfg : CaseSystemConfig)
-    (states : List PhasedState) (i : Nat) (s : PhasedState)
-    (h_get : states[i]? = some s) (h_marked : s.marked = true) :
-    (applyNomAgree cfg states)[i]? = some s :=
-  getElem?_of_spec h_get h_marked (applyNomAgree_spec cfg states)
-
-/-- D-Agree never overwrites a valued NP. -/
-theorem applyGenAgree_preserves_marked_at (cfg : CaseSystemConfig)
-    (states : List PhasedState) (i : Nat) (s : PhasedState)
-    (h_get : states[i]? = some s) (h_marked : s.marked = true) :
-    (applyGenAgree cfg states)[i]? = some s := by
-  unfold applyGenAgree
-  split
-  · rw [List.getElem?_map, h_get]; simp [h_marked]
-  · exact h_get
-
-/-- The default sweep never overwrites a valued NP. -/
-theorem applyDefault_preserves_marked_at (cfg : CaseSystemConfig)
-    (states : List PhasedState) (i : Nat) (s : PhasedState)
-    (h_get : states[i]? = some s) (h_marked : s.marked = true) :
-    (applyDefault cfg states)[i]? = some s := by
-  rw [applyDefault, List.getElem?_map, h_get]; simp [h_marked]
-
-/-- A dative valued by the dative rule survives every later pass, so the
-    Elsewhere ordering of the dative rule over the accusative rule is a
-    consequence of how the passes read `unmarkedVisible`, not a stipulated
-    rule ordering. -/
-theorem dat_persists_through_assignCasesPhased (cfg : CaseSystemConfig)
-    (nps : List PhasedNP) (i : Nat) (s : PhasedState)
-    (h_get : (applyDatRule cfg (initStates nps))[i]? = some s)
-    (h_dat : s.case = some (.dat, .dependent)) :
-    let s0 := initStates nps
-    let s1 := applyDatRule cfg s0
-    let s2 := applyAccRule cfg .vp s1
-    let s3 := applyAccRule cfg .cp s2
-    let s4 := applyAccAgree cfg s3
-    let s5 := applyNomAgree cfg s4
-    let s6 := applyGenAgree cfg s5
-    let s7 := applyDefault cfg s6
-    s7[i]? = some s := by
-  have h_marked : s.marked = true := by rw [PhasedState.marked, h_dat]; rfl
-  exact applyDefault_preserves_marked_at cfg _ i s
-    (applyGenAgree_preserves_marked_at cfg _ i s
-      (applyNomAgree_preserves_marked_at cfg _ i s
-        (applyAccAgree_preserves_marked_at cfg _ i s
-          (applyAccRule_preserves_marked_at cfg .cp _ i s
-            (applyAccRule_preserves_marked_at cfg .vp _ i s h_get h_marked)
-            h_marked) h_marked) h_marked) h_marked) h_marked
-
-end Syntax.Case
+end Case

--- a/Linglib/Syntax/Case/Licensing.lean
+++ b/Linglib/Syntax/Case/Licensing.lean
@@ -74,7 +74,7 @@ structure Licenser where
 
 /-! ### Nominals and their licensing requirement -/
 
-/-- A nominal as seen by the licensing system. Extends `NPInDomain`
+/-- A nominal as seen by the licensing system. Extends `Case.NP`
     (the configural type from `Dependent.lean`) with the
     licensing-requirement flag.
 
@@ -85,10 +85,10 @@ structure Licenser where
     means the NP lacks this feature (the [-specific] / [-definite] /
     [-animate] cell of a DOM language) and is interpretable in situ.
 
-    `lexicalCase` (inherited from `NPInDomain`) records pre-assigned
+    `lexicalCase` (inherited from `Case.NP`) records pre-assigned
     lexical case from a P or V head; lexical case independently values
     [Case] and so satisfies the licensing requirement on its own. -/
-structure LicensedNP extends Syntax.Case.NPInDomain where
+structure LicensedNP extends _root_.Case.NP where
   needsLicensing : Bool
   deriving DecidableEq, Repr
 

--- a/Linglib/Syntax/Minimalist/Case/Dependent.lean
+++ b/Linglib/Syntax/Minimalist/Case/Dependent.lean
@@ -1,0 +1,344 @@
+import Linglib.Syntax.Case.Dependent
+import Linglib.Syntax.Minimalist.Defs
+
+/-!
+# Dependent case by phase
+
+The configurational rules of `Syntax/Case/Dependent.lean` run domain by domain: each phase
+head's spell-out domain has its own high, low and elsewhere cases, the domains spell out
+innermost first, and a case valued in an inner domain — or by a lexical head — is never
+overwritten, so a dative valued in the verb phrase survives the clause. Functional heads may
+also value case under Agree, each probing the highest caseless NP of the domain it agrees
+into. A grammar is the table of domain rules together with the Agree cases, so a purely
+configurational grammar, a purely Agree-based one, and the hybrids are points in one space.
+Which functional heads a derivation contains is a fact about it, so assignment takes the
+probes present with the domain each agrees into.
+
+## Main definitions
+
+* `PhasedNP`: an NP with the phase head whose domain merges it, and whether it has shifted
+  to the clause edge.
+* `CaseGrammar`: the phase heads in spell-out order with their rules, and the Agree cases.
+* `CaseGrammar.assign`: case for every NP of a derivation.
+
+## Main results
+
+* `CaseGrammar.assign_length`: assignment is total.
+* `CaseGrammar.assign_getElem?_of_some`: lexical case is kept.
+* `CaseGrammar.case_mem_cases`: a caseless NP is valued only with a case the grammar
+  mentions.
+
+## References
+
+* [baker-vinokurova-2010]
+* [baker-2015]
+* [chomsky-2000], [chomsky-2001]
+-/
+
+namespace Minimalist
+
+open Case (Rules Mechanism Valuation initial markBy eligible)
+
+/-- An NP with its position: the phase head whose spell-out domain merges it, and whether it
+    has shifted to the clause edge, where C's domain spells it out. -/
+structure PhasedNP extends Case.NP where
+  phase : Cat := .C
+  shifted : Bool := false
+  deriving DecidableEq, Repr
+
+/-- Whether the NP is in the domain of `c` when it spells out. -/
+def PhasedNP.visible (np : PhasedNP) (c : Cat) : Bool := np.phase == c || (np.shifted && c == .C)
+
+/-- The phase head whose elsewhere case the NP falls back on. -/
+def PhasedNP.spellOut (np : PhasedNP) : Cat := if np.shifted then .C else np.phase
+
+/-- A grammar of structural case: the phase heads in spell-out order with the rules of their
+    domains, and the case each functional head values under Agree. -/
+structure CaseGrammar where
+  domains : List (Cat × Rules)
+  agree : List (Cat × Case) := []
+  deriving DecidableEq, Repr
+
+/-- The rules of the domain of `c`. -/
+def CaseGrammar.rules (g : CaseGrammar) (c : Cat) : Rules :=
+  ((g.domains.find? (·.1 == c)).map (·.2)).getD {}
+
+/-- The case `h` values under Agree, if any. -/
+def CaseGrammar.agreeCase (g : CaseGrammar) (h : Cat) : Option Case :=
+  (g.agree.find? (·.1 == h)).map (·.2)
+
+/-- The cases the grammar can value a caseless NP with. -/
+def CaseGrammar.cases (g : CaseGrammar) : List Case :=
+  g.domains.flatMap (·.2.cases) ++ g.agree.map (·.2)
+
+/-- The alignment the clausal rules show. -/
+def CaseGrammar.alignment (g : CaseGrammar) : Alignment.AlignmentType := (g.rules .C).alignment
+
+/-- A head valuing `c` under Agree in the domain `P` selects values its highest unvalued NP. -/
+def agreePass (c : Case) (P : PhasedNP → Bool) (states : List (PhasedNP × Valuation)) :
+    List (PhasedNP × Valuation) :=
+  match eligible P states with
+  | i :: _ => markBy (λ j _ => if j = i then some (c, .agree) else none) states
+  | [] => states
+
+/-- The head `h` probing the domain of `c`: it values what the grammar lets it. -/
+def probePass (g : CaseGrammar) (c h : Cat) (states : List (PhasedNP × Valuation)) :
+    List (PhasedNP × Valuation) :=
+  match g.agreeCase h with
+  | some k => agreePass k (·.visible c) states
+  | none => states
+
+/-- One spell-out domain: its dependent rules, then its probes in order, then its elsewhere
+    case. -/
+def domainPass (g : CaseGrammar) (probes : List (Cat × Cat)) (c : Cat)
+    (states : List (PhasedNP × Valuation)) : List (PhasedNP × Valuation) :=
+  (g.rules c).unmarkedPass (·.spellOut == c) <|
+    (probes.filter (·.2 == c)).foldl (λ st hp => probePass g c hp.1 st)
+      ((g.rules c).dependentPass (·.visible c) states)
+
+/-- Case for every NP, the domains spelling out in the grammar's order. `probes` lists the
+    functional heads present with the phase head whose domain each agrees into. -/
+def CaseGrammar.assign (g : CaseGrammar) (probes : List (Cat × Cat)) (nps : List PhasedNP) :
+    List (Case.NP × Valuation) :=
+  ((g.domains.map (·.1)).foldl (λ st c => domainPass g probes c st)
+    (initial (·.lexicalCase) nps)).map λ s => (s.1.toNP, s.2)
+
+/-! ### Totality -/
+
+@[simp] theorem agreePass_length (c : Case) (P : PhasedNP → Bool)
+    (states : List (PhasedNP × Valuation)) : (agreePass c P states).length = states.length := by
+  unfold agreePass; split <;> simp
+
+@[simp] theorem probePass_length (g : CaseGrammar) (c h : Cat)
+    (states : List (PhasedNP × Valuation)) : (probePass g c h states).length = states.length := by
+  unfold probePass; split <;> simp
+
+private theorem foldlAgree_length (g : CaseGrammar) (c : Cat) (l : List (Cat × Cat))
+    (st : List (PhasedNP × Valuation)) :
+    (l.foldl (λ st hp => probePass g c hp.1 st) st).length = st.length := by
+  induction l generalizing st with
+  | nil => rfl
+  | cons _ _ ih => exact (ih _).trans (probePass_length ..)
+
+@[simp] theorem domainPass_length (g : CaseGrammar) (probes : List (Cat × Cat)) (c : Cat)
+    (states : List (PhasedNP × Valuation)) :
+    (domainPass g probes c states).length = states.length := by
+  rw [domainPass, Rules.unmarkedPass_length, foldlAgree_length, Rules.dependentPass_length]
+
+private theorem foldlDomain_length (g : CaseGrammar) (probes : List (Cat × Cat)) (cs : List Cat)
+    (st : List (PhasedNP × Valuation)) :
+    (cs.foldl (λ st c => domainPass g probes c st) st).length = st.length := by
+  induction cs generalizing st with
+  | nil => rfl
+  | cons _ _ ih => exact (ih _).trans (domainPass_length ..)
+
+/-- Assignment is total: one valuation per NP. -/
+@[simp] theorem CaseGrammar.assign_length (g : CaseGrammar) (probes : List (Cat × Cat))
+    (nps : List PhasedNP) : (g.assign probes nps).length = nps.length := by
+  rw [CaseGrammar.assign, List.length_map, foldlDomain_length, Case.initial_length]
+
+/-! ### Valued NPs persist -/
+
+theorem agreePass_getElem?_of_some (c : Case) (P : PhasedNP → Bool)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : states[i]? = some (np, some v)) : (agreePass c P states)[i]? = some (np, some v) := by
+  unfold agreePass; split
+  · exact Case.markBy_getElem?_of_some _ h
+  · exact h
+
+theorem probePass_getElem?_of_some (g : CaseGrammar) (c hd : Cat)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : states[i]? = some (np, some v)) : (probePass g c hd states)[i]? = some (np, some v) := by
+  unfold probePass; split
+  · exact agreePass_getElem?_of_some _ _ h
+  · exact h
+
+private theorem foldlAgree_getElem?_of_some (g : CaseGrammar) (c : Cat) (l : List (Cat × Cat))
+    {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : st[i]? = some (np, some v)) :
+    (l.foldl (λ st hp => probePass g c hp.1 st) st)[i]? = some (np, some v) := by
+  induction l generalizing st with
+  | nil => exact h
+  | cons hp _ ih => exact ih (probePass_getElem?_of_some g c hp.1 h)
+
+theorem domainPass_getElem?_of_some (g : CaseGrammar) (probes : List (Cat × Cat)) (c : Cat)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : states[i]? = some (np, some v)) :
+    (domainPass g probes c states)[i]? = some (np, some v) :=
+  Rules.unmarkedPass_getElem?_of_some _ _
+    (foldlAgree_getElem?_of_some g c _ (Rules.dependentPass_getElem?_of_some _ _ h))
+
+private theorem foldlDomain_getElem?_of_some (g : CaseGrammar) (probes : List (Cat × Cat))
+    (cs : List Cat) {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP}
+    {v : Case × Mechanism} (h : st[i]? = some (np, some v)) :
+    (cs.foldl (λ st c => domainPass g probes c st) st)[i]? = some (np, some v) := by
+  induction cs generalizing st with
+  | nil => exact h
+  | cons _ _ ih => exact ih (domainPass_getElem?_of_some g probes _ h)
+
+/-- Lexical case is kept through every domain. -/
+theorem CaseGrammar.assign_getElem?_of_some (g : CaseGrammar) (probes : List (Cat × Cat))
+    {nps : List PhasedNP} {i : ℕ} {np : PhasedNP} {c : Case} (hnp : nps[i]? = some np)
+    (hc : np.lexicalCase = some c) :
+    (g.assign probes nps)[i]? = some (np.toNP, some (c, .lexical)) := by
+  rw [CaseGrammar.assign, List.getElem?_map,
+    foldlDomain_getElem?_of_some g probes _ (Case.initial_getElem?_of_some _ hnp hc)]
+  rfl
+
+/-! ### The cases a grammar values -/
+
+theorem CaseGrammar.rules_cases_subset (g : CaseGrammar) (c : Cat) :
+    (g.rules c).cases ⊆ g.cases := by
+  intro x hx
+  unfold CaseGrammar.rules at hx
+  rcases hf : g.domains.find? (·.1 == c) with _ | ⟨d, r⟩
+  · simp [hf, Rules.cases] at hx
+  · simp only [hf, Option.map_some, Option.getD_some] at hx
+    exact List.mem_append_left _ (List.mem_flatMap.2 ⟨(d, r), List.mem_of_find?_eq_some hf, hx⟩)
+
+theorem CaseGrammar.agreeCase_mem_cases {g : CaseGrammar} {h : Cat} {c : Case}
+    (hc : g.agreeCase h = some c) : c ∈ g.cases := by
+  unfold CaseGrammar.agreeCase at hc
+  obtain ⟨⟨d, k⟩, hf, hk⟩ := Option.map_eq_some_iff.1 hc
+  subst hk
+  exact List.mem_append_right _ (List.mem_map.2 ⟨(d, k), List.mem_of_find?_eq_some hf, rfl⟩)
+
+private theorem agreePass_case (c : Case) (P : PhasedNP → Bool)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (agreePass c P states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.1 = c := by
+  unfold agreePass at h
+  split at h
+  · refine (Case.markBy_value h).imp_right λ ⟨s, _, _, hf⟩ => ?_
+    split_ifs at hf
+    obtain rfl := Option.some.inj hf
+    rfl
+  · exact .inl h
+
+private theorem probePass_case (g : CaseGrammar) (c hd : Cat)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (probePass g c hd states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.1 ∈ g.cases := by
+  unfold probePass at h
+  split at h
+  · rename_i k hk
+    exact (agreePass_case k _ h).imp_right λ e => by rw [e]; exact g.agreeCase_mem_cases hk
+  · exact .inl h
+
+private theorem foldlAgree_case (g : CaseGrammar) (c : Cat) (l : List (Cat × Cat))
+    {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (l.foldl (λ st hp => probePass g c hp.1 st) st)[i]? = some (np, some v)) :
+    st[i]? = some (np, some v) ∨ v.1 ∈ g.cases := by
+  induction l generalizing st with
+  | nil => exact .inl h
+  | cons hp _ ih => exact (ih h).elim (probePass_case g c hp.1) .inr
+
+private theorem domainPass_case (g : CaseGrammar) (probes : List (Cat × Cat)) (c : Cat)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (domainPass g probes c states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.1 ∈ g.cases :=
+  ((g.rules c).unmarkedPass_case _ h).elim
+    (λ h => (foldlAgree_case g c _ h).elim
+      (λ h => ((g.rules c).dependentPass_case _ h).imp_right λ h => g.rules_cases_subset c h)
+      .inr)
+    (λ h => .inr (g.rules_cases_subset c h))
+
+private theorem foldlDomain_case (g : CaseGrammar) (probes : List (Cat × Cat)) (cs : List Cat)
+    {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (cs.foldl (λ st c => domainPass g probes c st) st)[i]? = some (np, some v)) :
+    st[i]? = some (np, some v) ∨ v.1 ∈ g.cases := by
+  induction cs generalizing st with
+  | nil => exact .inl h
+  | cons _ _ ih => exact (ih h).elim (domainPass_case g probes _) .inr
+
+/-- A caseless NP is valued only with a case the grammar mentions. -/
+theorem CaseGrammar.case_mem_cases (g : CaseGrammar) (probes : List (Cat × Cat))
+    {nps : List PhasedNP} {i : ℕ} {np : Case.NP} {c : Case} {m : Mechanism}
+    (hlex : np.lexicalCase = none) (h : (g.assign probes nps)[i]? = some (np, some (c, m))) :
+    c ∈ g.cases := by
+  rw [CaseGrammar.assign, List.getElem?_map] at h
+  obtain ⟨⟨np', v⟩, hs, hsv⟩ := Option.map_eq_some_iff.1 h
+  simp only [Prod.mk.injEq] at hsv
+  obtain ⟨hnp, rfl⟩ := hsv
+  rcases foldlDomain_case g probes _ hs with h | h
+  · have := Case.initial_value h
+    rw [← hnp] at hlex
+    simp [hlex] at this
+  · exact h
+
+/-! ### A grammar without an elsewhere case -/
+
+theorem CaseGrammar.rules_unmarked_of (g : CaseGrammar)
+    (hg : ∀ d ∈ g.domains, d.2.unmarked = none) (c : Cat) : (g.rules c).unmarked = none := by
+  unfold CaseGrammar.rules
+  rcases hf : g.domains.find? (·.1 == c) with _ | d
+  · rw [hf]; rfl
+  · rw [hf]; exact hg d (List.mem_of_find?_eq_some hf)
+
+private theorem agreePass_mechanism (c : Case) (P : PhasedNP → Bool)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (agreePass c P states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.2 = .agree := by
+  unfold agreePass at h
+  split at h
+  · refine (Case.markBy_value h).imp_right λ ⟨s, _, _, hf⟩ => ?_
+    split_ifs at hf
+    obtain rfl := Option.some.inj hf
+    rfl
+  · exact .inl h
+
+private theorem probePass_mechanism (g : CaseGrammar) (c hd : Cat)
+    {states : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (probePass g c hd states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.2 = .agree := by
+  unfold probePass at h
+  split at h
+  · exact agreePass_mechanism _ _ h
+  · exact .inl h
+
+private theorem foldlAgree_mechanism (g : CaseGrammar) (c : Cat) (l : List (Cat × Cat))
+    {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (l.foldl (λ st hp => probePass g c hp.1 st) st)[i]? = some (np, some v)) :
+    st[i]? = some (np, some v) ∨ v.2 = .agree := by
+  induction l generalizing st with
+  | nil => exact .inl h
+  | cons hp _ ih => exact (ih h).elim (probePass_mechanism g c hp.1) .inr
+
+private theorem domainPass_mechanism (g : CaseGrammar) (probes : List (Cat × Cat)) (c : Cat)
+    (hu : (g.rules c).unmarked = none) {states : List (PhasedNP × Valuation)} {i : ℕ}
+    {np : PhasedNP} {v : Case × Mechanism}
+    (h : (domainPass g probes c states)[i]? = some (np, some v)) :
+    states[i]? = some (np, some v) ∨ v.2 = .dependent ∨ v.2 = .agree := by
+  unfold domainPass at h
+  rw [Rules.unmarkedPass_of_none _ _ hu] at h
+  rcases foldlAgree_mechanism g c _ h with h | h
+  · exact ((g.rules c).dependentPass_mechanism _ h).imp_right .inl
+  · exact .inr (.inr h)
+
+private theorem foldlDomain_mechanism (g : CaseGrammar) (probes : List (Cat × Cat))
+    (hg : ∀ d ∈ g.domains, d.2.unmarked = none) (cs : List Cat)
+    {st : List (PhasedNP × Valuation)} {i : ℕ} {np : PhasedNP} {v : Case × Mechanism}
+    (h : (cs.foldl (λ st c => domainPass g probes c st) st)[i]? = some (np, some v)) :
+    st[i]? = some (np, some v) ∨ v.2 = .dependent ∨ v.2 = .agree := by
+  induction cs generalizing st with
+  | nil => exact .inl h
+  | cons c _ ih =>
+    exact (ih h).elim (domainPass_mechanism g probes c (g.rules_unmarked_of hg c)) .inr
+
+/-- A grammar with no elsewhere case in any domain never values an NP as unmarked: an NP that
+    no rule and no head reaches stays caseless. -/
+theorem CaseGrammar.mechanism_ne_unmarked (g : CaseGrammar) (probes : List (Cat × Cat))
+    (hg : ∀ d ∈ g.domains, d.2.unmarked = none) {nps : List PhasedNP} {i : ℕ} {np : Case.NP}
+    {c : Case} {m : Mechanism} (h : (g.assign probes nps)[i]? = some (np, some (c, m))) :
+    m ≠ .unmarked := by
+  rw [CaseGrammar.assign, List.getElem?_map] at h
+  obtain ⟨⟨np', v⟩, hs, hsv⟩ := Option.map_eq_some_iff.1 h
+  simp only [Prod.mk.injEq] at hsv
+  obtain ⟨-, rfl⟩ := hsv
+  rcases foldlDomain_mechanism g probes hg _ hs with h | h | h
+  · have := Case.initial_mechanism h
+    intro hm; simp [hm] at this
+  · intro hm; simp [hm] at h
+  · intro hm; simp [hm] at h
+
+end Minimalist


### PR DESCRIPTION
Replaces `CaseSystemConfig` (per-case mode enums plus a redundant alignment field, seven fixed passes) with Baker's rule table: `Case.Rules {high, low, unmarked}` per domain in the framework-lean core, generic in the NP type, and a phase-cyclic `Minimalist.CaseGrammar` (domains keyed by phase head `Cat`, Agree probes as `(head, domain)` pairs) under `Syntax/Minimalist/Case/`; `CaseLanguageType` dissolves into `Alignment.AlignmentType`, `Valuation := Option (Case × Mechanism)` makes caselessness explicit.
- Substrate lemmas: totality, persistence of valued case, `case_mem_cases`, `dependentPass_high/low/alone`, `mechanism_ne_unmarked`.
- `BakerVinokurova2010` restated as label-generic construction theorems plus `no_elsewhere_case` and `pureChomsky_no_dative` from the lemmas; fragments and the other twelve consumers migrated.