### PR TITLE
refactor(Studies/BarAsherSiegal2026): CC-selection over forced sufficient sets

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -339,6 +339,7 @@ import Linglib.Data.Examples.AsherPelletier2013
 import Linglib.Data.Examples.BakayEtAl2026
 import Linglib.Data.Examples.BaleEtAl2025
 import Linglib.Data.Examples.BaleSchwarz2022
+import Linglib.Data.Examples.BarAsherSiegal2026
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015
@@ -1552,6 +1553,7 @@ import Linglib.Semantics.Causation.SEM.Bool
 import Linglib.Semantics.Causation.SEM.Counterfactual
 import Linglib.Semantics.Causation.SEM.Defs
 import Linglib.Semantics.Causation.SEM.Deterministic
+import Linglib.Semantics.Causation.SEM.Forced
 import Linglib.Semantics.Causation.Strength
 import Linglib.Semantics.Causation.Sufficiency
 import Linglib.Semantics.Causation.Valuation

--- a/Linglib/Data/Examples/BarAsherSiegal2026.json
+++ b/Linglib/Data/Examples/BarAsherSiegal2026.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "bas2026_1a",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(1a)"},
+    "language": "stan1293",
+    "primaryText": "A kangaroo is a marsupial because it has a pouch.",
+    "glossedTokens": [],
+    "translation": "A kangaroo is a marsupial because it has a pouch.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "because"],
+      ["relation", "grounding"]
+    ],
+    "comment": "Dowty 1979, example 132b: dependency without temporal precedence and counterfactuality."
+  },
+  {
+    "id": "bas2026_1b",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(1b)"},
+    "language": "stan1293",
+    "primaryText": "Mary's living nearby causes John to prefer this neighborhood.",
+    "glossedTokens": [],
+    "translation": "Mary's living nearby causes John to prefer this neighborhood.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "cause"],
+      ["relation", "grounding"]
+    ],
+    "comment": "Dowty 1979, example 132c."
+  },
+  {
+    "id": "bas2026_1c",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(1c)"},
+    "language": "stan1293",
+    "primaryText": "The floor is black because of the ants that might infest it.",
+    "glossedTokens": [],
+    "translation": "The floor is black because of the ants that might infest it.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "because of"],
+      ["relation", "grounding"]
+    ],
+    "comment": "Adapted from Maienborn and Herdtfelder 2017."
+  },
+  {
+    "id": "bas2026_2a",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(2a)"},
+    "language": "stan1293",
+    "primaryText": "Sam opened the door.",
+    "glossedTokens": [],
+    "translation": "Sam opened the door.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "lexical causative"],
+      ["entails", "(2b)"]
+    ],
+    "comment": "Fodor 1970's one-way entailment."
+  },
+  {
+    "id": "bas2026_2b",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(2b)"},
+    "language": "stan1293",
+    "primaryText": "Sam caused the door to open.",
+    "glossedTokens": [],
+    "translation": "Sam caused the door to open.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "Sam opened a window and a gust blew the door open", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["construction", "periphrastic causative"],
+      ["entails", "(2a)"]
+    ],
+    "comment": "Does not entail (2a)."
+  },
+  {
+    "id": "bas2026_i",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(i)"},
+    "language": "stan1293",
+    "primaryText": "The city council denied the demonstrators the permit because they advocated violence.",
+    "glossedTokens": [],
+    "translation": "The city council denied the demonstrators the permit because they advocated violence.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "because"],
+      ["pronoun", "they"],
+      ["antecedent", "the demonstrators"]
+    ],
+    "comment": "Hobbs 1979, discussed in Wolf et al. 2004."
+  },
+  {
+    "id": "bas2026_ii",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(ii)"},
+    "language": "stan1293",
+    "primaryText": "The city council denied the demonstrators the permit because they feared violence.",
+    "glossedTokens": [],
+    "translation": "The city council denied the demonstrators the permit because they feared violence.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "because"],
+      ["pronoun", "they"],
+      ["antecedent", "the city council"]
+    ],
+    "comment": "Hobbs 1979."
+  },
+  {
+    "id": "bas2026_iii",
+    "source": {"bibkey": "bar-asher-siegal-2026", "paperLabel": "(iii)"},
+    "language": "stan1293",
+    "primaryText": "John drank wine at the party, which caused the accident he was involved in later that night as he drove back home.",
+    "glossedTokens": [],
+    "translation": "John drank wine at the party, which caused the accident he was involved in later that night as he drove back home.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "cause"],
+      ["enrichment", "John drank enough wine to impair his driving"]
+    ],
+    "comment": "Bar-Asher Siegal 2020: the causal context enriches the first clause."
+  }
+]

--- a/Linglib/Data/Examples/BarAsherSiegal2026.lean
+++ b/Linglib/Data/Examples/BarAsherSiegal2026.lean
@@ -1,0 +1,162 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BarAsherSiegal2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BarAsherSiegal2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BarAsherSiegal2026.Examples`.
+-/
+
+namespace BarAsherSiegal2026.Examples
+
+open Data.Examples
+
+def bas2026_1a : LinguisticExample :=
+  { id := "bas2026_1a"
+    source := ⟨"bar-asher-siegal-2026", "(1a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A kangaroo is a marsupial because it has a pouch."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A kangaroo is a marsupial because it has a pouch."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "because"), ("relation", "grounding")]
+    comment := "Dowty 1979, example 132b: dependency without temporal precedence and counterfactuality."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_1b : LinguisticExample :=
+  { id := "bas2026_1b"
+    source := ⟨"bar-asher-siegal-2026", "(1b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary's living nearby causes John to prefer this neighborhood."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mary's living nearby causes John to prefer this neighborhood."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "cause"), ("relation", "grounding")]
+    comment := "Dowty 1979, example 132c."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_1c : LinguisticExample :=
+  { id := "bas2026_1c"
+    source := ⟨"bar-asher-siegal-2026", "(1c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The floor is black because of the ants that might infest it."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The floor is black because of the ants that might infest it."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "because of"), ("relation", "grounding")]
+    comment := "Adapted from Maienborn and Herdtfelder 2017."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_2a : LinguisticExample :=
+  { id := "bas2026_2a"
+    source := ⟨"bar-asher-siegal-2026", "(2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Sam opened the door."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Sam opened the door."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "lexical causative"), ("entails", "(2b)")]
+    comment := "Fodor 1970's one-way entailment."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_2b : LinguisticExample :=
+  { id := "bas2026_2b"
+    source := ⟨"bar-asher-siegal-2026", "(2b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Sam caused the door to open."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Sam caused the door to open."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("Sam opened a window and a gust blew the door open", .acceptable)]
+    paperFeatures := [("construction", "periphrastic causative"), ("entails", "(2a)")]
+    comment := "Does not entail (2a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_i : LinguisticExample :=
+  { id := "bas2026_i"
+    source := ⟨"bar-asher-siegal-2026", "(i)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The city council denied the demonstrators the permit because they advocated violence."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The city council denied the demonstrators the permit because they advocated violence."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "because"), ("pronoun", "they"), ("antecedent", "the demonstrators")]
+    comment := "Hobbs 1979, discussed in Wolf et al. 2004."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_ii : LinguisticExample :=
+  { id := "bas2026_ii"
+    source := ⟨"bar-asher-siegal-2026", "(ii)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The city council denied the demonstrators the permit because they feared violence."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The city council denied the demonstrators the permit because they feared violence."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "because"), ("pronoun", "they"), ("antecedent", "the city council")]
+    comment := "Hobbs 1979."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bas2026_iii : LinguisticExample :=
+  { id := "bas2026_iii"
+    source := ⟨"bar-asher-siegal-2026", "(iii)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John drank wine at the party, which caused the accident he was involved in later that night as he drove back home."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John drank wine at the party, which caused the accident he was involved in later that night as he drove back home."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "cause"), ("enrichment", "John drank enough wine to impair his driving")]
+    comment := "Bar-Asher Siegal 2020: the causal context enriches the first clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [bas2026_1a, bas2026_1b, bas2026_1c, bas2026_2a, bas2026_2b, bas2026_i, bas2026_ii, bas2026_iii]
+
+end BarAsherSiegal2026.Examples

--- a/Linglib/Semantics/Causation/CCSelection.lean
+++ b/Linglib/Semantics/Causation/CCSelection.lean
@@ -1,23 +1,25 @@
 import Linglib.Semantics.Causation.Sufficiency
 import Linglib.Semantics.Causation.Necessity
+import Linglib.Semantics.Causation.SEM.Forced
 
 /-!
-# Causative Construction Selection (CC-Selection)
-[baglini-bar-asher-siegal-2020] [baglini-bar-asher-siegal-2025] [bar-asher-siegal-2026]
+# Causative construction selection
 
-CC-selection is the mechanism by which causative constructions constrain
-which element of a causal model can be linguistically realized as
-"the cause."
+A causal model typically offers several sets of conditions each jointly sufficient for an
+effect; causal selection picks one condition as "the cause", and each causative construction
+constrains which conditions it can pick. On the account of Baglini and Bar-Asher Siegal, a
+change-of-state verb (*open*) selects the temporally final condition of a sufficient set,
+the verb *cause* selects any of its conditions, and either way the set must be the only
+minimal sufficient set completed in the world of evaluation. This file defines sufficient
+sets over the forced (Kleene) development of a structural equation model, the two selection
+constraints, and their executable fuel mirrors, alongside the older but-for completion
+test `completesForEffect`.
 
-Two modes:
-- `memberOfSufficientSet` (verb *cause*): any necessary condition
-- `completionOfSufficientSet` (CoS verbs like *open*): the completing
-  condition
+## References
 
-The legacy `CausalDynamics`-based `completesForEffect`,
-`ccConstraintSatisfied`, `typeLevelSufficiency`, `tokenLevelCausation`,
-`actualizationHolds`, `CausalDependency` were deleted in Phase D-H.
-The polymorphic V2 versions are promoted to canonical here.
+* [baglini-bar-asher-siegal-2020]
+* [baglini-bar-asher-siegal-2025]
+* [bar-asher-siegal-2026]
 -/
 
 namespace Causation.CCSelection
@@ -77,5 +79,134 @@ theorem not_completesForEffect_of_developDetOn {V : Type*} [Fintype V] [Decidabl
   have hs' : (M.developDet (bg.extend c true)).get e = some true := hs
   have h1'' : (M.developDet (bg.extend c true)).get e = some false := h1'
   exact Bool.noConfusion (Option.some.inj (hs'.symm.trans h1''))
+
+/-! ### Sufficient sets and the selection constraints -/
+
+section SufficientSets
+
+variable {V : Type*} {α : V → Type*} [DecidableEq V] (M : SEM V α) [SEM.IsDeterministic M]
+  {effect : V} {xE : α effect}
+
+/-- A sufficient set for `effect = xE`: a situation not settling the effect that forces it. -/
+def IsSufficientSet (S : Valuation α) (effect : V) (xE : α effect) : Prop :=
+  S.get effect = none ∧ SEM.Forced M S effect xE
+
+/-- A sufficient set each of whose conditions is necessary within it. -/
+def IsMinimalSufficientSet (S : Valuation α) (effect : V) (xE : α effect) : Prop :=
+  IsSufficientSet M S effect xE ∧ ∀ v, (S.get v).isSome → ¬ SEM.Forced M (S.remove v) effect xE
+
+/-- `S` is the only minimal sufficient set completed in the world `w`. -/
+def IsTheCompletedSet (w S : Valuation α) (effect : V) (xE : α effect) : Prop :=
+  IsMinimalSufficientSet M S effect xE ∧ S ≤ w ∧
+    ∀ S', IsMinimalSufficientSet M S' effect xE → S' ≤ w → S' = S
+
+/-- The verb *cause* selects any condition of the completed sufficient set. -/
+def SelectsMember (w : Valuation α) (c effect : V) (xE : α effect) : Prop :=
+  ∃ S, IsTheCompletedSet M w S effect xE ∧ (S.get c).isSome
+
+/-- A change-of-state verb selects the temporally final condition of the completed sufficient
+set, `time` ordering the world's realizations. -/
+def SelectsFinal (w : Valuation α) (time : V → ℕ) (c effect : V) (xE : α effect) : Prop :=
+  ∃ S, IsTheCompletedSet M w S effect xE ∧ (S.get c).isSome ∧
+    ∀ v, (S.get v).isSome → time v ≤ time c
+
+/-- What a construction of the given mode may select as the cause. -/
+def CCSelectionMode.Selects (mode : CCSelectionMode)
+    (w : Valuation α) (time : V → ℕ) (c effect : V) (xE : α effect) : Prop :=
+  match mode with
+  | .memberOfSufficientSet => SelectsMember M w c effect xE
+  | .completionOfSufficientSet => SelectsFinal M w time c effect xE
+
+variable {M}
+
+/-- The change-of-state verb entails *cause*. -/
+theorem SelectsFinal.selectsMember {w : Valuation α} {time : V → ℕ} {c : V}
+    (h : SelectsFinal M w time c effect xE) : SelectsMember M w c effect xE :=
+  let ⟨S, hS, hc, _⟩ := h; ⟨S, hS, hc⟩
+
+/-- Overdetermination: two completed minimal sufficient sets leave nothing selectable. -/
+theorem not_selectsMember_of_two {w S₁ S₂ : Valuation α} {c : V}
+    (h₁ : IsMinimalSufficientSet M S₁ effect xE) (h₂ : IsMinimalSufficientSet M S₂ effect xE)
+    (hne : S₁ ≠ S₂) (hw₁ : S₁ ≤ w) (hw₂ : S₂ ≤ w) : ¬ SelectsMember M w c effect xE :=
+  λ ⟨_, ⟨_, _, huniq⟩, _⟩ => hne ((huniq S₁ h₁ hw₁).trans (huniq S₂ h₂ hw₂).symm)
+
+theorem not_selectsFinal_of_two {w S₁ S₂ : Valuation α} {time : V → ℕ} {c : V}
+    (h₁ : IsMinimalSufficientSet M S₁ effect xE) (h₂ : IsMinimalSufficientSet M S₂ effect xE)
+    (hne : S₁ ≠ S₂) (hw₁ : S₁ ≤ w) (hw₂ : S₂ ≤ w) : ¬ SelectsFinal M w time c effect xE :=
+  λ h => not_selectsMember_of_two h₁ h₂ hne hw₁ hw₂ h.selectsMember
+
+end SufficientSets
+
+/-! ### Fuel mirrors -/
+
+section Fuel
+
+variable {V : Type*} {α : V → Type*} [DecidableEq V] (M : SEM V α) [SEM.IsDeterministic M] (n : ℕ)
+
+/-- `IsMinimalSufficientSet` with forcing replaced by its fuel form. -/
+def IsMinimalSufficientSetFuel (S : Valuation α) (effect : V) (xE : α effect) : Prop :=
+  (S.get effect = none ∧ SEM.ForcedFuel M S n effect xE) ∧
+    ∀ v, (S.get v).isSome → ¬ SEM.ForcedFuel M (S.remove v) n effect xE
+
+def IsTheCompletedSetFuel (w S : Valuation α) (effect : V) (xE : α effect) : Prop :=
+  IsMinimalSufficientSetFuel M n S effect xE ∧ S ≤ w ∧
+    ∀ S', IsMinimalSufficientSetFuel M n S' effect xE → S' ≤ w → S' = S
+
+def SelectsMemberFuel (w : Valuation α) (c effect : V) (xE : α effect) : Prop :=
+  ∃ S, IsTheCompletedSetFuel M n w S effect xE ∧ (S.get c).isSome
+
+def SelectsFinalFuel (w : Valuation α) (time : V → ℕ) (c effect : V) (xE : α effect) : Prop :=
+  ∃ S, IsTheCompletedSetFuel M n w S effect xE ∧ (S.get c).isSome ∧
+    ∀ v, (S.get v).isSome → time v ≤ time c
+
+section Decidable
+
+variable [Fintype V] [DecidableValuation α] [∀ v, Fintype (α v)]
+
+instance (s₁ s₂ : Valuation α) : Decidable (s₁ ≤ s₂) :=
+  inferInstanceAs (Decidable (∀ v x, s₁.hasValue v x → s₂.hasValue v x))
+
+instance (S : Valuation α) (effect : V) (xE : α effect) :
+    Decidable (IsMinimalSufficientSetFuel M n S effect xE) := by
+  unfold IsMinimalSufficientSetFuel; infer_instance
+
+instance (w S : Valuation α) (effect : V) (xE : α effect) :
+    Decidable (IsTheCompletedSetFuel M n w S effect xE) := by
+  unfold IsTheCompletedSetFuel; infer_instance
+
+instance (w : Valuation α) (c effect : V) (xE : α effect) :
+    Decidable (SelectsMemberFuel M n w c effect xE) := by
+  unfold SelectsMemberFuel; infer_instance
+
+instance (w : Valuation α) (time : V → ℕ) (c effect : V) (xE : α effect) :
+    Decidable (SelectsFinalFuel M n w time c effect xE) := by
+  unfold SelectsFinalFuel; infer_instance
+
+end Decidable
+
+variable (r : CausalGraph.Ranking M.graph) (hn : ∀ v : V, r v < n)
+include hn
+
+theorem isMinimalSufficientSet_iff_fuel (S : Valuation α) (effect : V) (xE : α effect) :
+    IsMinimalSufficientSet M S effect xE ↔ IsMinimalSufficientSetFuel M n S effect xE := by
+  unfold IsMinimalSufficientSet IsSufficientSet IsMinimalSufficientSetFuel
+  simp only [SEM.forced_iff_fuel r (hn effect)]
+
+theorem isTheCompletedSet_iff_fuel (w S : Valuation α) (effect : V) (xE : α effect) :
+    IsTheCompletedSet M w S effect xE ↔ IsTheCompletedSetFuel M n w S effect xE := by
+  unfold IsTheCompletedSet IsTheCompletedSetFuel
+  simp only [isMinimalSufficientSet_iff_fuel M n r hn]
+
+theorem selectsMember_iff_fuel (w : Valuation α) (c effect : V) (xE : α effect) :
+    SelectsMember M w c effect xE ↔ SelectsMemberFuel M n w c effect xE := by
+  unfold SelectsMember SelectsMemberFuel
+  simp only [isTheCompletedSet_iff_fuel M n r hn]
+
+theorem selectsFinal_iff_fuel (w : Valuation α) (time : V → ℕ) (c effect : V) (xE : α effect) :
+    SelectsFinal M w time c effect xE ↔ SelectsFinalFuel M n w time c effect xE := by
+  unfold SelectsFinal SelectsFinalFuel
+  simp only [isTheCompletedSet_iff_fuel M n r hn]
+
+end Fuel
 
 end Causation.CCSelection

--- a/Linglib/Semantics/Causation/SEM/Forced.lean
+++ b/Linglib/Semantics/Causation/SEM/Forced.lean
@@ -1,0 +1,110 @@
+import Linglib.Semantics.Causation.SEM.Deterministic
+
+/-!
+# Forced development
+
+Developing a partial valuation in Kleene's three-valued way. A vertex the valuation leaves
+undetermined is forced to `x` when every completion of its parents' forced values yields `x`
+under its mechanism, so a turned handle on an unlocked door forces the door open while the
+circuit is still undetermined. `ForcedFuel M s n v x` is the `n`-step approximation and
+`Forced M s v x` its limit, which is reached at any fuel above a ranking of the graph. The
+strict development `developDetVtxFuel` settles a vertex only once all its parents are
+settled, so whatever it settles is forced.
+
+## References
+
+* [bar-asher-siegal-2026]
+* [baglini-bar-asher-siegal-2025]
+-/
+
+namespace Causation.SEM
+
+variable {V : Type*} {α : V → Type*} (M : SEM V α) [IsDeterministic M] (s : Valuation α)
+
+/-- `v` is forced to `x` within `n` steps: settled by `s`, or, for an inner vertex, every
+completion of its parents' values forced within `n - 1` steps yields `x`. -/
+def ForcedFuel : ℕ → (v : V) → α v → Prop
+  | 0, v, x => s.get v = some x
+  | n + 1, v, x => s.get v = some x ∨ s.get v = none ∧ M.graph.parents v ≠ ∅ ∧
+      ∀ σ : ∀ u : M.graph.parents v, α u.val,
+        (∀ u y, ForcedFuel n u.val y → σ u = y) →
+          Mechanism.IsDeterministic.toFun (M.mech v) σ = x
+
+/-- `v` is forced to `x`: within some number of steps. -/
+def Forced (v : V) (x : α v) : Prop := ∃ n, ForcedFuel M s n v x
+
+section Decidable
+
+variable [DecidableEq V] [Fintype V] [DecidableValuation α] [∀ v, Fintype (α v)]
+
+/-- Deciding `ForcedFuel` by recursion on the fuel. -/
+def decidableForcedFuel : ∀ (n : ℕ) (v : V) (x : α v), Decidable (ForcedFuel M s n v x)
+  | 0, v, x => inferInstanceAs (Decidable (s.get v = some x))
+  | n + 1, v, x => by
+      letI := decidableForcedFuel n
+      unfold ForcedFuel; infer_instance
+
+instance (n : ℕ) (v : V) (x : α v) : Decidable (ForcedFuel M s n v x) :=
+  decidableForcedFuel M s n v x
+
+end Decidable
+
+variable {M s}
+
+theorem ForcedFuel.succ : ∀ {n : ℕ} {v : V} {x : α v}, ForcedFuel M s n v x →
+    ForcedFuel M s (n + 1) v x
+  | 0, _, _, h => Or.inl h
+  | _ + 1, _, _, h => h.imp_right λ ⟨hn, hp, hσ⟩ =>
+      ⟨hn, hp, λ σ hσ' => hσ σ λ u y hy => hσ' u y hy.succ⟩
+
+theorem ForcedFuel.mono {m n : ℕ} (h : m ≤ n) {v : V} {x : α v} (hf : ForcedFuel M s m v x) :
+    ForcedFuel M s n v x :=
+  Nat.le_induction hf (λ _ _ ih => ih.succ) n h
+
+theorem ForcedFuel.forced {n : ℕ} {v : V} {x : α v} (h : ForcedFuel M s n v x) :
+    Forced M s v x := ⟨n, h⟩
+
+/-- Above a ranking of the graph, more fuel forces nothing new. -/
+theorem forcedFuel_iff_of_lt (r : CausalGraph.Ranking M.graph) {v : V} {n : ℕ} (hn : r v < n)
+    {x : α v} : ForcedFuel M s n v x ↔ ForcedFuel M s (r v + 1) v x := by
+  induction n using Nat.strong_induction_on generalizing v x with
+  | _ n ih =>
+    rcases n with _ | n
+    · omega
+    rcases Nat.lt_or_ge n (r v + 1) with hlt | hge
+    · obtain rfl : n = r v := by omega
+      exact Iff.rfl
+    simp only [ForcedFuel]
+    refine or_congr_right (and_congr_right λ _ => and_congr_right λ _ =>
+      forall_congr' λ σ => imp_congr_left (forall_congr' λ u => forall_congr' λ y => ?_))
+    have hu : r u.val < r v := r.map_rel u.property
+    rw [ih n (by omega) (by omega), ih (r v) (by omega) (by omega)]
+
+/-- The limit is reached at any fuel above a ranking. -/
+theorem forced_iff_fuel (r : CausalGraph.Ranking M.graph) {v : V} {n : ℕ} (hn : r v < n)
+    {x : α v} : Forced M s v x ↔ ForcedFuel M s n v x :=
+  ⟨λ ⟨m, hm⟩ => (Nat.lt_or_ge m n).elim (λ h => hm.mono h.le) λ h =>
+      (forcedFuel_iff_of_lt r hn).2 ((forcedFuel_iff_of_lt r (by omega)).1 hm),
+    ForcedFuel.forced⟩
+
+/-- Whatever the strict development settles is forced. -/
+theorem ForcedFuel.of_developDetVtxFuel [DecidableEq V] : ∀ {n : ℕ} {v : V} {x : α v},
+    developDetVtxFuel M s n v = some x → ForcedFuel M s n v x
+  | 0, _, _, h => h
+  | n + 1, v, x, h => by
+    simp only [developDetVtxFuel] at h
+    split at h
+    · rename_i x' heq
+      exact Or.inl (heq.trans (by simpa using h))
+    · rename_i hnone
+      split at h
+      · simp at h
+      · split at h
+        · rename_i hp hAll
+          refine Or.inr ⟨hnone, hp, λ σ hσ => ?_⟩
+          rw [← Option.some_inj.1 h]
+          congr 1; funext u
+          exact hσ u _ (ForcedFuel.of_developDetVtxFuel (Option.some_get (hAll u)).symm)
+        · simp at h
+
+end Causation.SEM

--- a/Linglib/Studies/BarAsherSiegal2026.lean
+++ b/Linglib/Studies/BarAsherSiegal2026.lean
@@ -1,193 +1,120 @@
-import Linglib.Semantics.Causation.SEM.Counterfactual
 import Linglib.Semantics.Causation.CCSelection
 
 /-!
-# [bar-asher-siegal-2026]: Causation and Causal Relations
-[bar-asher-siegal-2026] [baglini-bar-asher-siegal-2025] [baglini-bar-asher-siegal-2020]
+# Bar-Asher Siegal 2026: causation and causal relations
 
-Formalization of the door-opening scenario from [bar-asher-siegal-2026]
-Figure 1: a structural equation model with two alternative sufficient sets
-for a single effect (the door opening).
+A review of how natural language encodes causation, from causative constructions and
+conditionals to discourse coherence and the progressive, arguing that language is evidence
+for the architecture of causal cognition. Its central proposal takes causal knowledge to be a
+structural equation model in which several sets of conditions are each sufficient for an
+effect: the door of Figure 1 opens when the handle is turned with the lock off, or when the
+circuit is closed with the power on and the lock off. Causative constructions then differ in
+which condition they may select as the cause. A change-of-state verb selects the temporally
+final condition of a sufficient set, *cause* selects any of its conditions, and both select
+only from the one sufficient set completed in the world of evaluation. Fodor's entailment from
+*Sam opened the door* to *Sam caused the door to open* follows, its converse fails, and when
+two sufficient sets are completed at once neither construction applies.
 
-## The Door-Opening Model
+## References
 
-Variables:
-- handle: handle is turned
-- lock: lock is engaged (effect needs ¬lock)
-- circuit: circuit is closed
-- electricity: electricity is running
-- button: button is pressed
-- doorOpens: door opens (the effect)
-
-Mechanism: `doorOpens = (handle ∧ ¬lock) ∨ (circuit ∧ electricity ∧ ¬lock)`,
-plus `circuit := button` for the automatic pathway. Two sufficient sets:
-
-- **Manual** (handle ∧ ¬lock) ⊨ doorOpens
-- **Automatic** (circuit ∧ electricity ∧ ¬lock) ⊨ doorOpens
-
-## Key Result
-
-The model demonstrates CC-selection at work — completion mode (CoS verbs
-like *open*) succeeds when handle alone is the active pathway, but FAILS
-under overdetermination (both pathways active simultaneously). This
-captures [bar-asher-siegal-2026]'s point that *open* is infelicitous
-when an alternative explanation exists.
-
-Member-mode (Def 10b causally-necessary) divergence between *open* and
-*cause* awaits substrate support for multi-parent disjunctive mechanisms.
-
-Sufficiency/completion predicates are imported from the substrate
-(`BoolSEM.causallySufficient`, `CCSelection.completesForEffect`)
-rather than re-stipulated locally — see CLAUDE.md "Theory-hub denotation
-as study-file constraint."
+* [bar-asher-siegal-2026]
+* [baglini-bar-asher-siegal-2025]
+* [fodor-1970]
 -/
 
 namespace BarAsherSiegal2026
 
-open Causation Causation.Mechanism Causation.SEM
+open Causation Causation.Mechanism Causation.SEM Causation.CCSelection
 
-/-- Six-vertex door scenario. Inductive enum so `Fintype.elems`
-    gives a fixed canonical order and `developDet` reduces structurally. -/
+/-- The variables of Figure 1. -/
 inductive V | handle | lock | circuit | electricity | button | doorOpens
   deriving DecidableEq, Fintype, Repr
 
-def varList : List V :=
-  [.handle, .lock, .button, .electricity, .circuit, .doorOpens]
-
-/-- Full graph: button → circuit; (handle, lock) → doorOpens (manual);
-    (circuit, electricity, lock) → doorOpens (automatic). -/
-def fullGraph : CausalGraph V := ⟨fun
-  | .handle => ∅
-  | .lock => ∅
-  | .button => ∅
-  | .electricity => ∅
+/-- The button closes the circuit; handle, lock, circuit and power bear on the door. -/
+def graph : CausalGraph V := ⟨λ
   | .circuit => {.button}
-  | .doorOpens => {.handle, .lock, .circuit, .electricity}⟩
+  | .doorOpens => {.handle, .lock, .circuit, .electricity}
+  | _ => ∅⟩
 
-/-- Manual-only graph: drops the automatic pathway entirely. -/
-def manualGraph : CausalGraph V := ⟨fun
-  | .handle => ∅
-  | .lock => ∅
-  | .button => ∅
-  | .electricity => ∅
-  | .circuit => ∅
-  | .doorOpens => {.handle, .lock}⟩
+def rank : CausalGraph.Ranking graph :=
+  ⟨λ | .circuit => 1 | .doorOpens => 2 | _ => 0,
+    by intro u v h; revert h; cases u <;> cases v <;> decide⟩
 
-/-- Depth certificate for the full graph. -/
-def fullDepth : V → ℕ := fun
-  | .circuit => 1 | .doorOpens => 2 | _ => 0
+instance : CausalGraph.IsDAG graph := rank.isDAG
 
-private lemma fullDepth_lt : ∀ {u v : V},
-    u ∈ fullGraph.parents v → fullDepth u < fullDepth v := by
-  intro u v h; revert h; cases u <;> cases v <;> decide
+/-- The structural entailments G, H and I: the circuit closes when the button is pressed, and
+the door opens manually (handle on, lock off) or automatically (circuit and power on, lock
+off). -/
+noncomputable def model : BoolSEM V where
+  graph := graph
+  mech
+    | .circuit => deterministic λ ρ => ρ ⟨.button, by simp [graph]⟩
+    | .doorOpens => deterministic λ ρ =>
+        let h := ρ ⟨.handle, by simp [graph]⟩
+        let l := ρ ⟨.lock, by simp [graph]⟩
+        let c := ρ ⟨.circuit, by simp [graph]⟩
+        let e := ρ ⟨.electricity, by simp [graph]⟩
+        (h && !l) || (c && e && !l)
+    | _ => const (G := graph) false
 
-instance : CausalGraph.IsDAG fullGraph :=
-  CausalGraph.IsDAG.of_depth fullGraph fullDepth (fun h => fullDepth_lt h)
-
-/-- Depth certificate for the manual graph. -/
-def manualDepth : V → ℕ := fun
-  | .doorOpens => 1 | _ => 0
-
-private lemma manualDepth_lt : ∀ {u v : V},
-    u ∈ manualGraph.parents v → manualDepth u < manualDepth v := by
-  intro u v h; revert h; cases u <;> cases v <;> decide
-
-instance : CausalGraph.IsDAG manualGraph :=
-  CausalGraph.IsDAG.of_depth manualGraph manualDepth (fun h => manualDepth_lt h)
-
-/-- Door-opens mechanism (full model): manual OR automatic, both need ¬lock. -/
-noncomputable def doorOpensFullMech : Mechanism fullGraph (fun _ => Bool) .doorOpens :=
-  deterministic (fun ρ =>
-    let h := ρ ⟨.handle, by simp [fullGraph]⟩
-    let l := ρ ⟨.lock, by simp [fullGraph]⟩
-    let c := ρ ⟨.circuit, by simp [fullGraph]⟩
-    let e := ρ ⟨.electricity, by simp [fullGraph]⟩
-    (h && !l) || (c && e && !l))
-
-/-- Door-opens mechanism (manual model): just handle ∧ ¬lock. -/
-noncomputable def doorOpensManualMech : Mechanism manualGraph (fun _ => Bool) .doorOpens :=
-  deterministic (fun ρ =>
-    let h := ρ ⟨.handle, by simp [manualGraph]⟩
-    let l := ρ ⟨.lock, by simp [manualGraph]⟩
-    h && !l)
-
-noncomputable def fullModel : BoolSEM V :=
-  { graph := fullGraph
-    mech := fun
-      | .handle => const (G := fullGraph) false
-      | .lock => const (G := fullGraph) false
-      | .button => const (G := fullGraph) false
-      | .electricity => const (G := fullGraph) false
-      | .circuit => deterministic (fun ρ => ρ ⟨.button, by simp [fullGraph]⟩)
-      | .doorOpens => doorOpensFullMech }
-
-noncomputable def manualModel : BoolSEM V :=
-  { graph := manualGraph
-    mech := fun
-      | .handle => const (G := manualGraph) false
-      | .lock => const (G := manualGraph) false
-      | .button => const (G := manualGraph) false
-      | .electricity => const (G := manualGraph) false
-      | .circuit => const (G := manualGraph) false
-      | .doorOpens => doorOpensManualMech }
-
-noncomputable instance : SEM.IsDeterministic fullModel where
-  mech_det v := match v with
-    | .handle => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .lock => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .button => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .electricity => inferInstanceAs (Mechanism.IsDeterministic (const _))
+noncomputable instance : SEM.IsDeterministic model where
+  mech_det
     | .circuit => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
     | .doorOpens => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .handle | .lock | .button | .electricity =>
+        inferInstanceAs (Mechanism.IsDeterministic (const _))
 
-noncomputable instance : SEM.IsDeterministic manualModel where
-  mech_det v := match v with
-    | .handle => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .lock => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .button => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .electricity => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .circuit => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .doorOpens => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+instance : CausalGraph.IsDAG model.graph := inferInstanceAs (CausalGraph.IsDAG graph)
 
-instance : CausalGraph.IsDAG fullModel.graph :=
-  inferInstanceAs (CausalGraph.IsDAG fullGraph)
+/-- A valuation from a list of settings. -/
+def valuation (l : List (V × Bool)) : Valuation (λ _ : V => Bool) :=
+  l.foldl (λ s p => s.extend p.1 p.2) Valuation.empty
 
-instance : CausalGraph.IsDAG manualModel.graph :=
-  inferInstanceAs (CausalGraph.IsDAG manualGraph)
+/-- Sufficient set I: handle on, lock off. -/
+def manual := valuation [(.handle, true), (.lock, false)]
 
-/-- Background: lock disengaged. -/
-def unlocked : Valuation (fun _ : V => Bool) :=
-  Valuation.empty.extend .lock false
+/-- Sufficient set H: circuit and power on, lock off. -/
+def automatic := valuation [(.circuit, true), (.electricity, true), (.lock, false)]
 
-open Causation.CCSelection in
-/-- **Manual-only model**: handle completes the sufficient set for
-    doorOpens (full *open* and *cause* felicity, per [bar-asher-siegal-2026]).
-    Both completion and member modes succeed because there's no
-    alternative pathway. -/
-theorem handle_completes_manual :
-    completesForEffect manualModel unlocked .handle true false .doorOpens true :=
-  completesForEffect_of_developDetOn varList 1 (by decide) (by decide)
+/-- The world in which the handle is turned on an unlocked, unpowered door. -/
+def handleWorld := valuation
+  [(.handle, true), (.lock, false), (.button, false), (.electricity, false), (.circuit, false),
+    (.doorOpens, true)]
 
-open Causation.CCSelection in
-/-- **Full model with handle alone**: handle completes the manual
-    sufficient set, satisfying *open*-style completion CC-selection.
-    The automatic pathway doesn't fire because button=false in `unlocked`. -/
-theorem handle_completes_full :
-    completesForEffect fullModel unlocked .handle true false .doorOpens true :=
-  completesForEffect_of_developDetOn varList 2 (by decide) (by decide)
+/-- The overdetermined world: handle turned and button pressed on a powered, unlocked door. -/
+def bothWorld := valuation
+  [(.handle, true), (.lock, false), (.button, true), (.electricity, true), (.circuit, true),
+    (.doorOpens, true)]
 
-open Causation.CCSelection in
-/-- **Overdetermination in the full model**: when both pathways are
-    independently activated (button=true, electricity=true alongside
-    handle=true), removing handle still leaves doorOpens true via the
-    automatic pathway — the but-for half of completion CC-selection
-    FAILS for handle. This captures [bar-asher-siegal-2026]'s point
-    that *open* is infelicitous under overdetermination. -/
-theorem handle_no_completion_overdetermined :
-    ¬ completesForEffect fullModel
-        (unlocked.extend .button true |>.extend .electricity true)
-        .handle true false .doorOpens true :=
-  fun ⟨_, hb⟩ => hb (SEM.developDet_hasValue_of_developDetOn_hasValue
-    (vs := varList) (n := 2) (by decide))
+/-- The lock was disengaged first, the handle turned last. -/
+def time : V → ℕ | .lock => 0 | .handle => 2 | _ => 1
+
+theorem rank_lt : ∀ v, rank v < 3 := by decide
+
+theorem manual_minimal : IsMinimalSufficientSet model manual .doorOpens true :=
+  (isMinimalSufficientSet_iff_fuel model 3 rank rank_lt _ _ _).2 (by decide +kernel)
+
+theorem automatic_minimal : IsMinimalSufficientSet model automatic .doorOpens true :=
+  (isMinimalSufficientSet_iff_fuel model 3 rank rank_lt _ _ _).2 (by decide +kernel)
+
+/-- *John opened the door*, *John caused the door to open*: the handle is the final condition
+of the only completed set. -/
+theorem handle_selectsFinal : SelectsFinal model handleWorld time .handle .doorOpens true :=
+  (selectsFinal_iff_fuel model 3 rank rank_lt _ _ _ _ _).2 (by decide +kernel)
+
+theorem handle_selectsMember : SelectsMember model handleWorld .handle .doorOpens true :=
+  handle_selectsFinal.selectsMember
+
+/-- The converse of Fodor's entailment fails: the unlocked lock is a condition *cause* may
+select but not the final one. -/
+theorem lock_selectsMember : SelectsMember model handleWorld .lock .doorOpens true :=
+  (selectsMember_iff_fuel model 3 rank rank_lt _ _ _ _).2 (by decide +kernel)
+
+theorem lock_not_selectsFinal : ¬ SelectsFinal model handleWorld time .lock .doorOpens true :=
+  λ h => absurd ((selectsFinal_iff_fuel model 3 rank rank_lt _ _ _ _ _).1 h) (by decide +kernel)
+
+/-- With both sets completed, neither construction can select the handle. -/
+theorem overdetermined : ¬ SelectsMember model bothWorld .handle .doorOpens true :=
+  not_selectsMember_of_two manual_minimal automatic_minimal (by decide) (by decide) (by decide)
 
 end BarAsherSiegal2026

--- a/references.bib
+++ b/references.bib
@@ -10943,7 +10943,7 @@
   journal   = {Annual Review of Linguistics},
   volume    = {12},
   pages     = {125--145},
-  doi       = {10.1146/annurev-linguistics-011524-022110},
+  doi       = {10.1146/annurev-linguistics-041824-031335},
   subfield  = {semantics/causation},
   role      = {cited},
   validated = {true},


### PR DESCRIPTION
Recuts the review's Figure 1 on new substrate: `SEM/Forced.lean` develops a partial valuation in Kleene's three-valued way (a vertex is settled when every completion of its parents' settled values agrees), which is what makes the paper's sufficient set *handle on, lock off* sufficient with the circuit undetermined; `CCSelection.lean` gains minimal sufficient sets, the unique-completed-set condition, and the two selection constraints (*cause*: any member; change-of-state verb: the temporally final member) with fuel mirrors. Fodor's entailment, its failing converse, and overdetermination are theorems; the door model decides in the kernel.

- Bib DOI for the review corrected (the old one 404s); 8 example rows.