### PR TITLE
refactor(Studies/Barker2002): derivations, Simulation Theorem, Integrity

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -340,6 +340,7 @@ import Linglib.Data.Examples.BakayEtAl2026
 import Linglib.Data.Examples.BaleEtAl2025
 import Linglib.Data.Examples.BaleSchwarz2022
 import Linglib.Data.Examples.BarAsherSiegal2026
+import Linglib.Data.Examples.Barker2002
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015

--- a/Linglib/Data/Examples/Barker2002.json
+++ b/Linglib/Data/Examples/Barker2002.json
@@ -1,0 +1,323 @@
+[
+  {
+    "id": "barker2002_4a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(4a)"},
+    "language": "stan1293",
+    "primaryText": "John left.",
+    "glossedTokens": [],
+    "translation": "John left.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["translation", "left j"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_4b",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(4b)"},
+    "language": "stan1293",
+    "primaryText": "John saw Mary.",
+    "glossedTokens": [],
+    "translation": "John saw Mary.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["translation", "saw m j"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_14",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(14)"},
+    "language": "stan1293",
+    "primaryText": "John saw everyone.",
+    "glossedTokens": [],
+    "translation": "John saw everyone.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["translation", "∀x.saw x j"],
+      ["quantifiers", "everyone"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_17a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(17a)"},
+    "language": "stan1293",
+    "primaryText": "John saw every man.",
+    "glossedTokens": [],
+    "translation": "John saw every man.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["translation", "∀x.man x → saw x j"],
+      ["quantifiers", "every"]
+    ],
+    "comment": "Printed 'every men'."
+  },
+  {
+    "id": "barker2002_17b",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(17b)"},
+    "language": "stan1293",
+    "primaryText": "John saw most men.",
+    "glossedTokens": [],
+    "translation": "John saw most men.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["translation", "most(man)(λx.saw x j)"],
+      ["quantifiers", "most"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_17c",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(17c)"},
+    "language": "stan1293",
+    "primaryText": "Every man saw a woman.",
+    "glossedTokens": [],
+    "translation": "Every man saw a woman.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "a > every", "judgment": "acceptable"},
+      {"name": "every > a", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "every a"]
+    ],
+    "comment": "(17c) prints the inverse scoping; the surface scoping arrives with subject priority."
+  },
+  {
+    "id": "barker2002_19a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(19a)"},
+    "language": "stan1293",
+    "primaryText": "A raindrop fell on every car.",
+    "glossedTokens": [],
+    "translation": "A raindrop fell on every car.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["quantifiers", "a every"],
+      ["natural_reading", "every > a"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_19b",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(19b)"},
+    "language": "stan1293",
+    "primaryText": "A raindrop fell on the hood of every car.",
+    "glossedTokens": [],
+    "translation": "A raindrop fell on the hood of every car.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["quantifiers", "a every"],
+      ["natural_reading", "every > a"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_19c",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(19c)"},
+    "language": "stan1293",
+    "primaryText": "A raindrop fell on the top of the hood of every car.",
+    "glossedTokens": [],
+    "translation": "A raindrop fell on the top of the hood of every car.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["quantifiers", "a every"],
+      ["natural_reading", "every > a"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_21a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(21a)"},
+    "language": "stan1293",
+    "primaryText": "A man thought everyone saw Mary.",
+    "glossedTokens": [],
+    "translation": "A man thought everyone saw Mary.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["quantifiers", "a everyone"],
+      ["translation", "∃y.man y ∧ thought(∀x.saw m x) y"],
+      ["island", "tensed S"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_22a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(22a)"},
+    "language": "stan1293",
+    "primaryText": "No man from a foreign country was admitted.",
+    "glossedTokens": [],
+    "translation": "No man from a foreign country was admitted.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "no > a", "judgment": "acceptable"},
+      {"name": "a > no", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "no a"]
+    ],
+    "comment": "(22b) linear, (22c) inverse linking."
+  },
+  {
+    "id": "barker2002_23a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(23a)"},
+    "language": "stan1293",
+    "primaryText": "Two politicians spy on someone from every city.",
+    "glossedTokens": [],
+    "translation": "Two politicians spy on someone from every city.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "every > two > someone", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "two someone every"],
+      ["constituent", "someone every"]
+    ],
+    "comment": "May's observation."
+  },
+  {
+    "id": "barker2002_26a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(26a)"},
+    "language": "stan1293",
+    "primaryText": "Most subjects put an object in every box.",
+    "glossedTokens": [],
+    "translation": "Most subjects put an object in every box.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "every > most > an", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "most an every"],
+      ["constituent", "an every"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_27a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(27a)"},
+    "language": "stan1293",
+    "primaryText": "John left and John slept.",
+    "glossedTokens": [],
+    "translation": "John left and John slept.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["coordination", "S"],
+      ["translation", "and(left j)(slept j)"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_27b",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(27b)"},
+    "language": "stan1293",
+    "primaryText": "John left and slept.",
+    "glossedTokens": [],
+    "translation": "John left and slept.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["coordination", "VP"],
+      ["translation", "and(left j)(slept j)"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_27c",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(27c)"},
+    "language": "stan1293",
+    "primaryText": "John saw and liked Mary.",
+    "glossedTokens": [],
+    "translation": "John saw and liked Mary.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["coordination", "Vt"],
+      ["translation", "and(saw m j)(liked m j)"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_27d",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(27d)"},
+    "language": "stan1293",
+    "primaryText": "John and Mary left.",
+    "glossedTokens": [],
+    "translation": "John and Mary left.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["coordination", "NP"],
+      ["translation", "and(left j)(left m)"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_42a",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(42a)"},
+    "language": "stan1293",
+    "primaryText": "Someone saw the friend of the friend of everyone.",
+    "glossedTokens": [],
+    "translation": "Someone saw the friend of the friend of everyone.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "someone > everyone", "judgment": "acceptable"},
+      {"name": "everyone > someone", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "someone everyone"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "barker2002_43",
+    "source": {"bibkey": "barker-2002", "paperLabel": "(43)"},
+    "language": "stan1293",
+    "primaryText": "Someone saw a friend of everyone.",
+    "glossedTokens": [],
+    "translation": "Someone saw a friend of everyone.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "someone > a > everyone", "judgment": "acceptable"},
+      {"name": "someone > everyone > a", "judgment": "acceptable"},
+      {"name": "a > everyone > someone", "judgment": "acceptable"},
+      {"name": "everyone > a > someone", "judgment": "acceptable"},
+      {"name": "everyone > someone > a", "judgment": "unacceptable"},
+      {"name": "a > someone > everyone", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["quantifiers", "someone a everyone"],
+      ["constituent", "a everyone"],
+      ["derivation", "someone saw a friend of everyone"]
+    ],
+    "comment": "Four of the six orders; the two splitting the object's quantifiers are excluded by Integrity."
+  }
+]

--- a/Linglib/Data/Examples/Barker2002.lean
+++ b/Linglib/Data/Examples/Barker2002.lean
@@ -1,0 +1,360 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Barker2002` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Barker2002.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Barker2002.Examples`.
+-/
+
+namespace Barker2002.Examples
+
+open Data.Examples
+
+def ex_4a : LinguisticExample :=
+  { id := "barker2002_4a"
+    source := ⟨"barker-2002", "(4a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John left."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John left."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("translation", "left j")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4b : LinguisticExample :=
+  { id := "barker2002_4b"
+    source := ⟨"barker-2002", "(4b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John saw Mary."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John saw Mary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("translation", "saw m j")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_14 : LinguisticExample :=
+  { id := "barker2002_14"
+    source := ⟨"barker-2002", "(14)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John saw everyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John saw everyone."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("translation", "∀x.saw x j"), ("quantifiers", "everyone")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_17a : LinguisticExample :=
+  { id := "barker2002_17a"
+    source := ⟨"barker-2002", "(17a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John saw every man."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John saw every man."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("translation", "∀x.man x → saw x j"), ("quantifiers", "every")]
+    comment := "Printed 'every men'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_17b : LinguisticExample :=
+  { id := "barker2002_17b"
+    source := ⟨"barker-2002", "(17b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John saw most men."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John saw most men."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("translation", "most(man)(λx.saw x j)"), ("quantifiers", "most")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_17c : LinguisticExample :=
+  { id := "barker2002_17c"
+    source := ⟨"barker-2002", "(17c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every man saw a woman."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Every man saw a woman."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("a > every", .acceptable), ("every > a", .acceptable)]
+    paperFeatures := [("quantifiers", "every a")]
+    comment := "(17c) prints the inverse scoping; the surface scoping arrives with subject priority."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_19a : LinguisticExample :=
+  { id := "barker2002_19a"
+    source := ⟨"barker-2002", "(19a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A raindrop fell on every car."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A raindrop fell on every car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("quantifiers", "a every"), ("natural_reading", "every > a")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_19b : LinguisticExample :=
+  { id := "barker2002_19b"
+    source := ⟨"barker-2002", "(19b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A raindrop fell on the hood of every car."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A raindrop fell on the hood of every car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("quantifiers", "a every"), ("natural_reading", "every > a")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_19c : LinguisticExample :=
+  { id := "barker2002_19c"
+    source := ⟨"barker-2002", "(19c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A raindrop fell on the top of the hood of every car."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A raindrop fell on the top of the hood of every car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("quantifiers", "a every"), ("natural_reading", "every > a")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21a : LinguisticExample :=
+  { id := "barker2002_21a"
+    source := ⟨"barker-2002", "(21a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A man thought everyone saw Mary."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A man thought everyone saw Mary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("quantifiers", "a everyone"), ("translation", "∃y.man y ∧ thought(∀x.saw m x) y"), ("island", "tensed S")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22a : LinguisticExample :=
+  { id := "barker2002_22a"
+    source := ⟨"barker-2002", "(22a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No man from a foreign country was admitted."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "No man from a foreign country was admitted."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("no > a", .acceptable), ("a > no", .acceptable)]
+    paperFeatures := [("quantifiers", "no a")]
+    comment := "(22b) linear, (22c) inverse linking."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23a : LinguisticExample :=
+  { id := "barker2002_23a"
+    source := ⟨"barker-2002", "(23a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Two politicians spy on someone from every city."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Two politicians spy on someone from every city."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("every > two > someone", .unacceptable)]
+    paperFeatures := [("quantifiers", "two someone every"), ("constituent", "someone every")]
+    comment := "May's observation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26a : LinguisticExample :=
+  { id := "barker2002_26a"
+    source := ⟨"barker-2002", "(26a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Most subjects put an object in every box."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Most subjects put an object in every box."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("every > most > an", .unacceptable)]
+    paperFeatures := [("quantifiers", "most an every"), ("constituent", "an every")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_27a : LinguisticExample :=
+  { id := "barker2002_27a"
+    source := ⟨"barker-2002", "(27a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John left and John slept."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John left and John slept."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("coordination", "S"), ("translation", "and(left j)(slept j)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_27b : LinguisticExample :=
+  { id := "barker2002_27b"
+    source := ⟨"barker-2002", "(27b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John left and slept."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John left and slept."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("coordination", "VP"), ("translation", "and(left j)(slept j)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_27c : LinguisticExample :=
+  { id := "barker2002_27c"
+    source := ⟨"barker-2002", "(27c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John saw and liked Mary."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John saw and liked Mary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("coordination", "Vt"), ("translation", "and(saw m j)(liked m j)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_27d : LinguisticExample :=
+  { id := "barker2002_27d"
+    source := ⟨"barker-2002", "(27d)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John and Mary left."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John and Mary left."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("coordination", "NP"), ("translation", "and(left j)(left m)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_42a : LinguisticExample :=
+  { id := "barker2002_42a"
+    source := ⟨"barker-2002", "(42a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Someone saw the friend of the friend of everyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Someone saw the friend of the friend of everyone."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("someone > everyone", .acceptable), ("everyone > someone", .acceptable)]
+    paperFeatures := [("quantifiers", "someone everyone")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_43 : LinguisticExample :=
+  { id := "barker2002_43"
+    source := ⟨"barker-2002", "(43)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Someone saw a friend of everyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Someone saw a friend of everyone."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("someone > a > everyone", .acceptable), ("someone > everyone > a", .acceptable), ("a > everyone > someone", .acceptable), ("everyone > a > someone", .acceptable), ("everyone > someone > a", .unacceptable), ("a > someone > everyone", .unacceptable)]
+    paperFeatures := [("quantifiers", "someone a everyone"), ("constituent", "a everyone"), ("derivation", "someone saw a friend of everyone")]
+    comment := "Four of the six orders; the two splitting the object's quantifiers are excluded by Integrity."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_4a, ex_4b, ex_14, ex_17a, ex_17b, ex_17c, ex_19a, ex_19b, ex_19c, ex_21a, ex_22a, ex_23a, ex_26a, ex_27a, ex_27b, ex_27c, ex_27d, ex_42a, ex_43]
+
+end Barker2002.Examples

--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -1,196 +1,286 @@
 import Linglib.Semantics.Quantification.Defs
 import Linglib.Semantics.Composition.Cont
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Pi
+import Linglib.Data.Examples.Barker2002
 
 /-!
-# Barker (2002): Continuations and the Nature of Quantification
+# Barker 2002: continuations and the nature of quantification
 
-Formalizes the continuized grammar of [barker-2002]: quantificational
-NPs denote functions on their own continuations, so continuizing an
-ordinary grammar derives generalized quantifiers, in-situ scope
-displacement, and scope ambiguity, with no movement, storage, or
-type-shifting. The file states the Continuation Schema at arity 2, the
-fragment with its worked derivations, the scope-island rule with clause
-boundedness, generalized coordination, and the Simulation Theorem,
-following the paper's own proof. Barker's transitive verbs take the
-object first: `saw m j` is "John saw Mary".
+Quantificational noun phrases denote functions on their own continuations. Continuizing an
+ordinary grammar hands every constituent its continuation, so that noun phrases come out as
+generalized quantifiers, *everyone* and *someone* can be stated in situ, and their scope
+falls out of the truth conditions rather than from movement, storage or type-shifting.
+Each rule of arity two continuizes in two ways, one per priority order of its daughters,
+which is where scope ambiguity comes from; making the clause an island is a matter of
+handing the clause's continuation the finished clause. The paper's Simulation Theorem says
+that on quantifier-free derivations the continuized grammar computes what the direct one
+did, and its Integrity constraint that a constituent's quantifiers scope together, which
+leaves *someone saw a friend of everyone* four readings instead of six. Generalized
+coordination distributes the continuation over the conjuncts, with no polymorphic *and*.
 
-The fragment's determiners quantify over choice functions, as in the
-paper's appendix; the generalized-quantifier pair the paper introduces
-for exposition is kept for the derivations whose printed formulas need
-it. The *the friend of* chains are not formalized.
+Derivations are trees over the direct grammar with each binary node marked for priority;
+the schema is `Deriv.continuize`, the direct meaning `Deriv.direct`, and the scope order a
+prioritized derivation induces `Deriv.scopeOrder`. Transitive verbs take the object first,
+so `saw m j` is *John saw Mary*.
+
+## References
+
+* [barker-2002]
+* [montague-1973]
+* [partee-rooth-1983]
+* [heim-kratzer-1998]
 -/
 
 namespace Barker2002
 
 open Quantification (Quantifier individual)
 
-variable {α β γ E : Type} (np : Cont Prop E) (vp : Cont Prop (E → Prop))
-variable (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop))
+variable {α β γ E : Type}
 
-/-! ### The grammar -/
+/-! ### Derivations and the Continuation Schema -/
 
-/-- The S rule with priority to the VP. -/
-def sRuleVP : Cont Prop Prop :=
-  vp <*> np
+/-- A derivation: a lexical item of the direct grammar, a quantificational item stated only
+in continuized terms, a rule of arity one or two applied to its daughters (a binary node
+marked with which daughter takes priority), a clause closed off as a scope island, or a
+coordination. -/
+inductive Deriv : Type → Type 1
+  | lex {α : Type} (a : α) : Deriv α
+  | quant {α : Type} (label : String) (q : Cont Prop α) : Deriv α
+  | unary {α β : Type} (M : α → β) (d : Deriv α) : Deriv β
+  | binary {α β γ : Type} (M : α → β → γ) (first : Bool) (d₁ : Deriv α) (d₂ : Deriv β) :
+      Deriv γ
+  | island (d : Deriv Prop) : Deriv Prop
+  | coord {α : Type} (d₁ d₂ : Deriv α) : Deriv α
 
-/-- The S rule with priority to the subject. -/
-def sRuleNP : Cont Prop Prop :=
-  (λ x P => P x) <$> np <*> vp
+namespace Deriv
 
-/-- The VP rule, verb priority. -/
-def vpRule (vt : Cont Prop (E → E → Prop)) (obj : Cont Prop E) :
-    Cont Prop (E → Prop) :=
-  vt <*> obj
+/-- The Continuation Schema: a lexical item is a unit, a rule nests its daughters'
+continuations in priority order, an island evaluates its clause, and coordination
+distributes the continuation over the conjuncts. -/
+def continuize : ∀ {α : Type}, Deriv α → Cont Prop α
+  | _, lex a => pure a
+  | _, quant _ q => q
+  | _, unary M d => M <$> d.continuize
+  | _, binary M true d₁ d₂ => M <$> d₁.continuize <*> d₂.continuize
+  | _, binary M false d₁ d₂ => flip M <$> d₂.continuize <*> d₁.continuize
+  | _, island d => ContT.reset d.continuize
+  | _, coord d₁ d₂ => λ k => d₁.continuize k ∧ d₂.continuize k
+
+/-- The meaning the direct grammar assigns, where it assigns one. -/
+def direct : ∀ {α : Type}, Deriv α → Option α
+  | _, lex a => some a
+  | _, quant _ _ => none
+  | _, unary M d => d.direct.map M
+  | _, binary M _ d₁ d₂ => d₁.direct.bind λ x => d₂.direct.map (M x)
+  | _, island d => d.direct
+  | _, coord _ _ => none
+
+/-- The quantificational items in the order they take scope; an island's are trapped. -/
+def scopeOrder : ∀ {α : Type}, Deriv α → List String
+  | _, lex _ => []
+  | _, quant l _ => [l]
+  | _, unary _ d => d.scopeOrder
+  | _, binary _ true d₁ d₂ => d₁.scopeOrder ++ d₂.scopeOrder
+  | _, binary _ false d₁ d₂ => d₂.scopeOrder ++ d₁.scopeOrder
+  | _, island _ => []
+  | _, coord d₁ d₂ => d₁.scopeOrder ++ d₂.scopeOrder
+
+/-- The lemma behind the Simulation Theorem: a derivation the direct grammar interprets
+hands any continuation its direct meaning. -/
+theorem continuize_run {d : Deriv α} {a : α} (h : d.direct = some a) (k : α → Prop) :
+    d.continuize.run k = k a := by
+  induction d with
+  | lex b => simp only [direct, Option.some.injEq] at h; subst h; rfl
+  | quant => simp [direct] at h
+  | unary M d ih =>
+    simp only [direct, Option.map_eq_some_iff] at h
+    obtain ⟨b, hb, rfl⟩ := h
+    exact ih hb _
+  | binary M first d₁ d₂ ih₁ ih₂ =>
+    simp only [direct, Option.bind_eq_some_iff, Option.map_eq_some_iff] at h
+    obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := h
+    cases first
+    · exact (ih₂ hb₂ _).trans (ih₁ hb₁ _)
+    · exact (ih₁ hb₁ _).trans (ih₂ hb₂ _)
+  | island d ih => exact congrArg k (ih h id)
+  | coord => simp [direct] at h
+
+/-- The Simulation Theorem: at the trivial continuation the continuized grammar computes the
+direct meaning. -/
+theorem eval_continuize {d : Deriv Prop} {p : Prop} (h : d.direct = some p) :
+    ContT.eval d.continuize = p :=
+  continuize_run h id
+
+/-- The sentence meaning: the continuized meaning at the trivial continuation. -/
+def eval (d : Deriv Prop) : Prop := ContT.eval d.continuize
+
+/-- Integrity: a daughter's quantifiers scope together, before or after the other
+daughter's. -/
+theorem scopeOrder_binary (M : α → β → γ) (first : Bool) (d₁ : Deriv α) (d₂ : Deriv β) :
+    (binary M first d₁ d₂).scopeOrder = d₁.scopeOrder ++ d₂.scopeOrder ∨
+      (binary M first d₁ d₂).scopeOrder = d₂.scopeOrder ++ d₁.scopeOrder := by
+  cases first <;> simp [scopeOrder]
+
+end Deriv
+
+/-! ### The fragment -/
+
+open Deriv
+
+/-- S → NP VP, `VP(NP)`; `first` gives the subject priority. -/
+def S (first : Bool) (np : Deriv E) (vp : Deriv (E → Prop)) : Deriv Prop :=
+  binary (λ x P => P x) first np vp
+
+/-- VP → Vt NP, `Vt(NP)`. -/
+def VP (first : Bool) (vt : Deriv (E → E → Prop)) (obj : Deriv E) : Deriv (E → Prop) :=
+  binary (λ R x => R x) first vt obj
+
+/-- VP → Vs S, `Vs(S)`. -/
+def VS (first : Bool) (vs : Deriv (Prop → E → Prop)) (s : Deriv Prop) : Deriv (E → Prop) :=
+  binary (λ T p => T p) first vs s
+
+/-- NP → Det N, `Det(N)`, determiners denoting choice functions. -/
+def NP (first : Bool) (det : Deriv ((E → Prop) → E)) (n : Deriv (E → Prop)) : Deriv E :=
+  binary (λ D P => D P) first det n
+
+/-- N → Nr PPof, `Nr(PP)`. -/
+def N (first : Bool) (nr : Deriv (E → E → Prop)) (pp : Deriv E) : Deriv (E → Prop) :=
+  binary (λ R x => R x) first nr pp
 
 /-- *everyone*: a universal over the continuation. -/
-def everyone : Quantifier E := λ k => ∀ x, k x
+def everyone : Deriv E := quant "everyone" λ k => ∀ x, k x
 
 /-- *someone*: an existential over the continuation. -/
-def someone : Quantifier E := λ k => ∃ x, k x
+def someone : Deriv E := quant "someone" λ k => ∃ x, k x
 
-/-- *every* quantifies over choice functions; Barker leaves the
-restriction to proper choice functions to the choice-function
-literature, and so do we. -/
-def everyCF : Cont Prop ((E → Prop) → E) := λ D => ∀ f, D f
+/-- *every* quantifies over choice functions; the restriction to proper choice functions is
+left to the choice-function literature, as in the paper. -/
+def every : Deriv ((E → Prop) → E) := quant "every" λ D => ∀ f, D f
 
 /-- *a* as an existential over choice functions. -/
-def aCF : Cont Prop ((E → Prop) → E) := λ D => ∃ f, D f
+def a : Deriv ((E → Prop) → E) := quant "a" λ D => ∃ f, D f
 
-/-- The NP rule, determiner priority. -/
-def npRuleDet : Cont Prop E :=
-  det <*> n
+/-- The expository *every*, typed as a generalized quantifier over the nominal. -/
+def everyGQ (n : Deriv (E → Prop)) : Deriv E :=
+  quant "every" λ k => n.continuize λ P => ∀ x, P x → k x
 
-/-- The NP rule, nominal priority. -/
-def npRuleN : Cont Prop E :=
-  (λ P D => D P) <$> n <*> det
-
-/-- The paper's expository *every*, typed as a generalized quantifier. -/
-def everyGQ (n : Cont Prop (E → Prop)) : Quantifier E :=
-  λ k => n (λ P => ∀ x, P x → k x)
-
-/-- The paper's expository *a*. -/
-def aGQ (n : Cont Prop (E → Prop)) : Quantifier E :=
-  λ k => n (λ P => ∃ x, P x ∧ k x)
-
-/-! ### The worked derivations -/
+/-- The expository *a*. -/
+def aGQ (n : Deriv (E → Prop)) : Deriv E :=
+  quant "a" λ k => n.continuize λ P => ∃ x, P x ∧ k x
 
 variable (j m : E) (left' slept' man' woman' : E → Prop) (saw' : E → E → Prop)
-variable (friendOf : E → E → Prop)
+  (friendOf : E → E → Prop) (thought' : Prop → E → Prop) (the : (E → Prop) → E)
 
-/-- *John left*. -/
-theorem john_left :
-    ContT.eval (sRuleVP (individual j) (pure left')) = left' j := rfl
+/-! ### Worked derivations -/
 
-/-- *Everyone left*. -/
-theorem everyone_left :
-    ContT.eval (sRuleVP everyone (pure left')) = ∀ x, left' x := rfl
+theorem john_left : eval (S false (lex j) (lex left')) = left' j := rfl
+
+theorem everyone_left : eval (S false everyone (lex left')) = ∀ x, left' x :=
+  rfl
 
 /-- *John saw everyone*, in situ. -/
 theorem john_saw_everyone :
-    ContT.eval (sRuleVP (individual j) (vpRule (pure saw') everyone)) =
-    ∀ x, saw' x j := rfl
+    eval (S false (lex j) (VP true (lex saw') everyone)) = ∀ x, saw' x j :=
+  rfl
 
-/-- *Every man saw a woman*, VP priority: the inverse reading. -/
+/-- *Every man saw a woman* with VP priority: the inverse reading. -/
 theorem every_man_saw_a_woman_inverse :
-    ContT.eval (sRuleVP (everyGQ (pure man'))
-      (vpRule (pure saw') (aGQ (pure woman')))) =
-    ∃ y, woman' y ∧ ∀ x, man' x → saw' y x := rfl
+    eval (S false (everyGQ (lex man')) (VP true (lex saw') (aGQ (lex woman'))))
+      = ∃ y, woman' y ∧ ∀ x, man' x → saw' y x := rfl
 
-/-- *Every man saw a woman*, subject priority: the surface reading. -/
+/-- With subject priority: the surface reading. -/
 theorem every_man_saw_a_woman_surface :
-    ContT.eval (sRuleNP (everyGQ (pure man'))
-      (vpRule (pure saw') (aGQ (pure woman')))) =
-    ∀ x, man' x → ∃ y, woman' y ∧ saw' y x := rfl
+    eval (S true (everyGQ (lex man')) (VP true (lex saw') (aGQ (lex woman'))))
+      = ∀ x, man' x → ∃ y, woman' y ∧ saw' y x := rfl
 
-/-- *John saw every man*: for every way of choosing a man, John saw
-him. -/
+/-- *John saw every man*: for every way of choosing a man, John saw him. -/
 theorem john_saw_every_man :
-    ContT.eval (sRuleVP (individual j)
-      (vpRule (pure saw') (npRuleDet everyCF (pure man')))) =
-    ∀ f : (E → Prop) → E, saw' (f man') j := rfl
+    eval (S false (lex j) (VP true (lex saw') (NP true every (lex man')))) =
+      ∀ f : (E → Prop) → E, saw' (f man') j := rfl
 
-/-- *Someone saw a friend of everyone*: subject wide, determiner over
-nominal. -/
-theorem someone_saw_a_friend_of_everyone_yfx :
-    ContT.eval (sRuleNP someone (vpRule (pure saw')
-      (npRuleDet aCF (pure friendOf <*> everyone)))) =
-    ∃ y, ∃ f : (E → Prop) → E, ∀ x, saw' (f (friendOf x)) y := rfl
-
-/-- Subject wide, nominal over determiner. -/
-theorem someone_saw_a_friend_of_everyone_yxf :
-    ContT.eval (sRuleNP someone (vpRule (pure saw')
-      (npRuleN aCF (pure friendOf <*> everyone)))) =
-    ∃ y, ∀ x, ∃ f : (E → Prop) → E, saw' (f (friendOf x)) y := rfl
-
-/-- Object wide, determiner over nominal. -/
-theorem someone_saw_a_friend_of_everyone_fxy :
-    ContT.eval (sRuleVP someone (vpRule (pure saw')
-      (npRuleDet aCF (pure friendOf <*> everyone)))) =
-    ∃ f : (E → Prop) → E, ∀ x, ∃ y, saw' (f (friendOf x)) y := rfl
-
-/-- Object wide, nominal over determiner. -/
-theorem someone_saw_a_friend_of_everyone_xfy :
-    ContT.eval (sRuleVP someone (vpRule (pure saw')
-      (npRuleN aCF (pure friendOf <*> everyone)))) =
-    ∀ x, ∃ f : (E → Prop) → E, ∃ y, saw' (f (friendOf x)) y := rfl
-
-/-! ### Bounding scope displacement -/
-
-/-- The island-adjusted S rule: evaluate the clause, then re-lift. -/
-def sRuleIsland : Cont Prop Prop :=
-  ContT.reset (sRuleVP np vp)
-
-/-- The clausal-complement rule, verb priority. -/
-def vsRule (vs : Cont Prop (Prop → E → Prop)) (s : Cont Prop Prop) :
-    Cont Prop (E → Prop) :=
-  vs <*> s
-
-variable (thought' : Prop → E → Prop)
-
-/-- *A man thought everyone saw Mary*: *everyone* is trapped in the
-complement. -/
+/-- *A man thought everyone saw Mary*: the island traps *everyone*. -/
 theorem a_man_thought_everyone_saw_mary :
-    ContT.eval (sRuleVP (aGQ (pure man'))
-      (vsRule (pure thought')
-        (sRuleIsland everyone (vpRule (pure saw') (individual m))))) =
-    ∃ y, man' y ∧ thought' (∀ x, saw' m x) y := rfl
+    eval (S false (aGQ (lex man'))
+      (VS true (lex thought') (island (S false everyone (VP true (lex saw') (lex m)))))) =
+      ∃ y, man' y ∧ thought' (∀ x, saw' m x) y := rfl
 
-/-- A unit VP makes the matrix priority choice inert: "all scopings are
-logically equivalent". -/
-theorem sRule_priority_inert (P : E → Prop) :
-    sRuleNP np (pure P) = sRuleVP np (pure P) := rfl
+/-- *Someone saw the friend of the friend of everyone*: scope displacement is unbounded, and
+both scopings are available. -/
+theorem someone_saw_the_friend_of_the_friend_of_everyone (first : Bool) :
+    eval (S first someone (VP true (lex saw')
+      (NP true (lex the) (N true (lex friendOf)
+        (NP true (lex the) (N true (lex friendOf) everyone)))))) =
+      if first then ∃ x, ∀ y, saw' (the (friendOf (the (friendOf y)))) x
+        else ∀ y, ∃ x, saw' (the (friendOf (the (friendOf y)))) x := by
+  cases first <;> rfl
+
+/-! ### The four scopings of *someone saw a friend of everyone* -/
+
+/-- The derivation, with a priority bit at the S, VP, NP and N nodes. -/
+def someoneSawAFriendOfEveryone (p : Fin 4 → Bool) : Deriv Prop :=
+  S (p 0) someone (VP (p 1) (lex saw') (NP (p 2) a (N (p 3) (lex friendOf) everyone)))
+
+theorem scoping_yfx :
+    eval (someoneSawAFriendOfEveryone saw' friendOf ![true, true, true, true])
+      = ∃ y, ∃ f : (E → Prop) → E, ∀ x, saw' (f (friendOf x)) y := rfl
+
+theorem scoping_yxf :
+    eval (someoneSawAFriendOfEveryone saw' friendOf ![true, true, false, true])
+      = ∃ y, ∀ x, ∃ f : (E → Prop) → E, saw' (f (friendOf x)) y := rfl
+
+theorem scoping_fxy :
+    eval (someoneSawAFriendOfEveryone saw' friendOf ![false, true, true, true])
+      = ∃ f : (E → Prop) → E, ∀ x, ∃ y, saw' (f (friendOf x)) y := rfl
+
+theorem scoping_xfy :
+    eval (someoneSawAFriendOfEveryone saw' friendOf ![false, true, false, true])
+      = ∀ x, ∃ f : (E → Prop) → E, ∃ y, saw' (f (friendOf x)) y := rfl
+
+/-- Integrity leaves four of the six orders: *a* and *everyone*, sharing the object, scope
+together. -/
+theorem scopeOrders (p : Fin 4 → Bool) :
+    (someoneSawAFriendOfEveryone saw' friendOf p).scopeOrder ∈
+      [["someone", "a", "everyone"], ["someone", "everyone", "a"],
+        ["a", "everyone", "someone"], ["everyone", "a", "someone"]] := by
+  cases h0 : p 0 <;> cases h1 : p 1 <;> cases h2 : p 2 <;> cases h3 : p 3 <;>
+    simp [someoneSawAFriendOfEveryone, S, VP, NP, N, scopeOrder, everyone, someone, a, h0, h1, h2,
+      h3]
+
+/-- The excluded orders split the object's quantifiers around the subject. -/
+theorem no_split_scoping (p : Fin 4 → Bool) :
+    (someoneSawAFriendOfEveryone saw' friendOf p).scopeOrder ≠ ["everyone", "someone", "a"] ∧
+    (someoneSawAFriendOfEveryone saw' friendOf p).scopeOrder ≠ ["a", "someone", "everyone"] := by
+  cases h0 : p 0 <;> cases h1 : p 1 <;> cases h2 : p 2 <;> cases h3 : p 3 <;>
+    simp [someoneSawAFriendOfEveryone, S, VP, NP, N, scopeOrder, everyone, someone, a, h0, h1, h2,
+      h3]
 
 /-! ### Generalized coordination -/
 
-/-- Coordination at any category: the continuation distributes across
-the conjuncts. -/
-def coord (l r : Cont Prop α) : Cont Prop α := λ k => l k ∧ r k
-
-/-- *John left and slept*. -/
 theorem john_left_and_slept :
-    ContT.eval (sRuleVP (individual j) (coord (pure left') (pure slept'))) =
-    (left' j ∧ slept' j) := rfl
+    eval (S false (lex j) (coord (lex left') (lex slept'))) =
+      (left' j ∧ slept' j) := rfl
 
-/-- *John and Mary left*. -/
 theorem john_and_mary_left :
-    ContT.eval (sRuleVP (coord (individual j) (individual m)) (pure left')) =
-    (left' j ∧ left' m) := rfl
+    eval (S false (coord (lex j) (lex m)) (lex left')) =
+      (left' j ∧ left' m) := rfl
 
-/-! ### The Simulation Theorem -/
+/-! ### The paper's examples -/
 
-/-- Simulating in the paper's sense is being a unit. -/
-theorem simulating_iff {c : Cont Prop α} {a : α} :
-    (∀ g, c g = g a) ↔ c = pure a :=
-  ⟨funext, λ h g => by subst h; rfl⟩
+open Data.Examples (LinguisticExample)
 
-/-- "The result is the same, in the absence of quantification": a unit
-daughter makes the priority choice inert. -/
-theorem simulation_orders_agree (M : α → β → γ) (a : α) (c : Cont Prop β) :
-    M <$> (pure a : Cont Prop α) <*> c = flip M <$> c <*> pure a := rfl
+/-- A reading named by its scope order, `someone > a > everyone`. -/
+def order (s : String) : List String :=
+  (s.toList.splitOn '>').map λ cs =>
+    String.ofList ((cs.dropWhile (· = ' ')).reverse.dropWhile (· = ' ') |>.reverse)
 
-/-- A schema-derived sentence evaluates at the trivial continuation to
-its direct meaning. -/
-theorem simulation (M : α → β → Prop) (m₁ : α) (m₂ : β) :
-    ContT.eval (M <$> (pure m₁ : Cont Prop α) <*> pure m₂) = M m₁ m₂ := rfl
+/-- The readings the paper lists for *someone saw a friend of everyone* are exactly the scope
+orders some prioritization of its derivation induces. -/
+theorem rows_scopings : ∀ e ∈ Examples.all,
+    e.feature? "derivation" = some "someone saw a friend of everyone" → ∀ r ∈ e.readings,
+      (r.2 = .acceptable ↔ ∃ p : Fin 4 → Bool,
+        (someoneSawAFriendOfEveryone (E := Unit) (λ _ _ => True) (λ _ _ => True) p).scopeOrder =
+          order r.1) := by
+  decide +kernel
 
 end Barker2002


### PR DESCRIPTION
Derivations of the direct grammar as trees with a priority bit per binary node; `Deriv.continuize` is the Continuation Schema, `continuize_run`/`eval_continuize` the paper's Lemma and Simulation Theorem by induction, `scopeOrder_binary` the Integrity constraint. The four scopings of *someone saw a friend of everyone* are decided over all sixteen prioritizations; 19 example rows.