### PR TITLE
refactor(Studies/Beaver2001): verified locators, examples, terse header

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -346,6 +346,7 @@ import Linglib.Data.Examples.BarLev2021
 import Linglib.Data.Examples.BarLevFox2020
 import Linglib.Data.Examples.Barker2002
 import Linglib.Data.Examples.BarwiseCooper1981
+import Linglib.Data.Examples.Beaver2001
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015

--- a/Linglib/Data/Examples/Beaver2001.json
+++ b/Linglib/Data/Examples/Beaver2001.json
@@ -1,0 +1,191 @@
+[
+  {
+    "id": "beaver2001_e52",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E52"},
+    "language": "stan1293",
+    "primaryText": "If I go to London, my sister will pick me up at the airport.",
+    "glossedTokens": [],
+    "translation": "If I go to London, my sister will pick me up at the airport.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "definite (my sister)"],
+      ["embedding", "consequent of conditional"]
+    ],
+    "comment": "The paradigm conditional presupposition: satisfaction models predict only 'if I go to London I have a sister'; hearers tend to infer the stronger 'I have a sister', which Ch. 9 derives by global accommodation over information orderings."
+  },
+  {
+    "id": "beaver2001_e154",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E154"},
+    "language": "stan1293",
+    "primaryText": "If Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth.",
+    "glossedTokens": [],
+    "translation": "If Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "the fact that + factive bothered by"],
+      ["embedding", "consequent of conditional"]
+    ],
+    "comment": "Presupposes only the conditional: if he lands there, his weight is greater. Natural when Spiff hangs weightless in space, so the unconditional presupposition is wrong; structural accommodation accounts cannot produce the conditional reading."
+  },
+  {
+    "id": "beaver2001_e155",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E155"},
+    "language": "stan1293",
+    "primaryText": "It is unlikely that if Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth.",
+    "glossedTokens": [],
+    "translation": "It is unlikely that if Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "the fact that + factive bothered by"],
+      ["embedding", "conditional under unlikely"]
+    ],
+    "comment": "Preferred reading keeps the conditional implication; accommodation into the consequent is unavailable here."
+  },
+  {
+    "id": "beaver2001_e156",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E156"},
+    "language": "stan1293",
+    "primaryText": "If Spaceman Spiff lands on Planet X and is bothered by the fact that his weight is greater than it would be on Earth, he won't stay long.",
+    "glossedTokens": [],
+    "translation": "If Spaceman Spiff lands on Planet X and is bothered by the fact that his weight is greater than it would be on Earth, he won't stay long.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "the fact that + factive bothered by"],
+      ["embedding", "second conjunct of conditional antecedent"]
+    ],
+    "comment": "Same conditional presupposition, predicted by the treatment of conjunction; accommodation into the consequent is not even available."
+  },
+  {
+    "id": "beaver2001_e198",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E198"},
+    "language": "stan1293",
+    "primaryText": "Bertha is hiding.",
+    "glossedTokens": [],
+    "translation": "Bertha is hiding.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["role", "presupposed content for E168'-E173"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beaver2001_e168prime",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E168'"},
+    "language": "stan1293",
+    "primaryText": "Anna realises that Bertha is hiding.",
+    "glossedTokens": [],
+    "translation": "Anna realises that Bertha is hiding.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "factive realise"],
+      ["embedding", "none"]
+    ],
+    "comment": "Presupposes (and entails) that Bertha is hiding."
+  },
+  {
+    "id": "beaver2001_e169prime",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E169'"},
+    "language": "stan1293",
+    "primaryText": "Anna does not realise that Bertha is hiding.",
+    "glossedTokens": [],
+    "translation": "Anna does not realise that Bertha is hiding.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "factive realise"],
+      ["embedding", "negation"]
+    ],
+    "comment": "Projection through negation (Fact 8.1)."
+  },
+  {
+    "id": "beaver2001_e172prime",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E172'"},
+    "language": "stan1293",
+    "primaryText": "If Anna realises that Bertha is hiding, then she will find her.",
+    "glossedTokens": [],
+    "translation": "If Anna realises that Bertha is hiding, then she will find her.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "factive realise"],
+      ["embedding", "antecedent of conditional"]
+    ],
+    "comment": "Projection from the antecedent (Fact 8.1)."
+  },
+  {
+    "id": "beaver2001_e173",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E173"},
+    "language": "stan1293",
+    "primaryText": "Anna might realise that Bertha is hiding.",
+    "glossedTokens": [],
+    "translation": "Anna might realise that Bertha is hiding.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "factive realise"],
+      ["embedding", "might"]
+    ],
+    "comment": "Projection through the epistemic modals (Fact 8.8)."
+  },
+  {
+    "id": "beaver2001_e175",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E175"},
+    "language": "stan1293",
+    "primaryText": "If Bertha is not in the kitchen, then Anna realises that Bertha is in the attic.",
+    "glossedTokens": [],
+    "translation": "If Bertha is not in the kitchen, then Anna realises that Bertha is in the attic.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["trigger", "factive realise"],
+      ["embedding", "consequent of conditional"]
+    ],
+    "comment": "Presupposes the conditionalised E175c: if Bertha is not in the kitchen, she is in the attic (Fact 8.3) — the paradigmatically CCP behaviour."
+  },
+  {
+    "id": "beaver2001_e206",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E206"},
+    "language": "stan1293",
+    "primaryText": "It is possible there is a happy farmer, but, then again, it is possible that there are no happy farmers.",
+    "glossedTokens": [],
+    "translation": "It is possible there is a happy farmer, but, then again, it is possible that there are no happy farmers.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "might phi and might not phi"]
+    ],
+    "comment": "Consistent as a might-sequence; following it with E207a is consistent, while E207a followed by E206a is not — might is a consistency test on the current state."
+  },
+  {
+    "id": "beaver2001_e207",
+    "source": {"bibkey": "beaver-2001", "paperLabel": "E207"},
+    "language": "stan1293",
+    "primaryText": "No farmer is happy.",
+    "glossedTokens": [],
+    "translation": "No farmer is happy.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "plain assertion"]
+    ],
+    "comment": "Order contrast with E206a: assertion then might-sentence is inconsistent, might-sentence then assertion is fine."
+  }
+]

--- a/Linglib/Data/Examples/Beaver2001.lean
+++ b/Linglib/Data/Examples/Beaver2001.lean
@@ -1,0 +1,234 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Beaver2001` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Beaver2001.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Beaver2001.Examples`.
+-/
+
+namespace Beaver2001.Examples
+
+open Data.Examples
+
+def e52 : LinguisticExample :=
+  { id := "beaver2001_e52"
+    source := ⟨"beaver-2001", "E52"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If I go to London, my sister will pick me up at the airport."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "If I go to London, my sister will pick me up at the airport."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "definite (my sister)"), ("embedding", "consequent of conditional")]
+    comment := "The paradigm conditional presupposition: satisfaction models predict only 'if I go to London I have a sister'; hearers tend to infer the stronger 'I have a sister', which Ch. 9 derives by global accommodation over information orderings."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e154 : LinguisticExample :=
+  { id := "beaver2001_e154"
+    source := ⟨"beaver-2001", "E154"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "If Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "the fact that + factive bothered by"), ("embedding", "consequent of conditional")]
+    comment := "Presupposes only the conditional: if he lands there, his weight is greater. Natural when Spiff hangs weightless in space, so the unconditional presupposition is wrong; structural accommodation accounts cannot produce the conditional reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e155 : LinguisticExample :=
+  { id := "beaver2001_e155"
+    source := ⟨"beaver-2001", "E155"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "It is unlikely that if Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "It is unlikely that if Spaceman Spiff lands on Planet X, he will be bothered by the fact that his weight is greater than it would be on Earth."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "the fact that + factive bothered by"), ("embedding", "conditional under unlikely")]
+    comment := "Preferred reading keeps the conditional implication; accommodation into the consequent is unavailable here."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e156 : LinguisticExample :=
+  { id := "beaver2001_e156"
+    source := ⟨"beaver-2001", "E156"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Spaceman Spiff lands on Planet X and is bothered by the fact that his weight is greater than it would be on Earth, he won't stay long."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "If Spaceman Spiff lands on Planet X and is bothered by the fact that his weight is greater than it would be on Earth, he won't stay long."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "the fact that + factive bothered by"), ("embedding", "second conjunct of conditional antecedent")]
+    comment := "Same conditional presupposition, predicted by the treatment of conjunction; accommodation into the consequent is not even available."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e198 : LinguisticExample :=
+  { id := "beaver2001_e198"
+    source := ⟨"beaver-2001", "E198"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bertha is hiding."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Bertha is hiding."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("role", "presupposed content for E168'-E173")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e168prime : LinguisticExample :=
+  { id := "beaver2001_e168prime"
+    source := ⟨"beaver-2001", "E168'"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Anna realises that Bertha is hiding."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Anna realises that Bertha is hiding."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "factive realise"), ("embedding", "none")]
+    comment := "Presupposes (and entails) that Bertha is hiding."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e169prime : LinguisticExample :=
+  { id := "beaver2001_e169prime"
+    source := ⟨"beaver-2001", "E169'"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Anna does not realise that Bertha is hiding."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Anna does not realise that Bertha is hiding."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "factive realise"), ("embedding", "negation")]
+    comment := "Projection through negation (Fact 8.1)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e172prime : LinguisticExample :=
+  { id := "beaver2001_e172prime"
+    source := ⟨"beaver-2001", "E172'"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Anna realises that Bertha is hiding, then she will find her."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "If Anna realises that Bertha is hiding, then she will find her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "factive realise"), ("embedding", "antecedent of conditional")]
+    comment := "Projection from the antecedent (Fact 8.1)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e173 : LinguisticExample :=
+  { id := "beaver2001_e173"
+    source := ⟨"beaver-2001", "E173"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Anna might realise that Bertha is hiding."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Anna might realise that Bertha is hiding."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "factive realise"), ("embedding", "might")]
+    comment := "Projection through the epistemic modals (Fact 8.8)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e175 : LinguisticExample :=
+  { id := "beaver2001_e175"
+    source := ⟨"beaver-2001", "E175"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Bertha is not in the kitchen, then Anna realises that Bertha is in the attic."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "If Bertha is not in the kitchen, then Anna realises that Bertha is in the attic."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("trigger", "factive realise"), ("embedding", "consequent of conditional")]
+    comment := "Presupposes the conditionalised E175c: if Bertha is not in the kitchen, she is in the attic (Fact 8.3) — the paradigmatically CCP behaviour."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e206 : LinguisticExample :=
+  { id := "beaver2001_e206"
+    source := ⟨"beaver-2001", "E206"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "It is possible there is a happy farmer, but, then again, it is possible that there are no happy farmers."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "It is possible there is a happy farmer, but, then again, it is possible that there are no happy farmers."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "might phi and might not phi")]
+    comment := "Consistent as a might-sequence; following it with E207a is consistent, while E207a followed by E206a is not — might is a consistency test on the current state."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def e207 : LinguisticExample :=
+  { id := "beaver2001_e207"
+    source := ⟨"beaver-2001", "E207"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No farmer is happy."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "No farmer is happy."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "plain assertion")]
+    comment := "Order contrast with E206a: assertion then might-sentence is inconsistent, might-sentence then assertion is fine."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [e52, e154, e155, e156, e198, e168prime, e169prime, e172prime, e173, e175, e206, e207]
+
+end Beaver2001.Examples

--- a/Linglib/Studies/Beaver2001.lean
+++ b/Linglib/Studies/Beaver2001.lean
@@ -1,43 +1,43 @@
 import Linglib.Semantics.Dynamic.Partial
 import Linglib.Semantics.Presupposition.Trivalent
+import Linglib.Data.Examples.Beaver2001
 
 /-!
 # Beaver (2001): Presupposition and Assertion in Dynamic Semantics
 
-[beaver-2001] reviews the theories of presupposition (Part I) and develops a dynamic one
-(Part II): **partial update logic**, [veltman-1996]'s update logic — atomic updates
-eliminate worlds, *not* removes the worlds the negated sentence keeps, *and* sequences, and
-*might*/*must* test the state — with a presupposition operator `∂` whose update is defined
-only in contexts that already satisfy its argument (Ch. 6), then extended to the first-order
-fragment ABLE (Ch. 7). This file formalizes the propositional core over the substrate's
-partial context change potentials: a sentence denotes a partial function on information
-states (`Formula.eval : CCP.Partial W`), a state *satisfies* a sentence when it is a fixed
-point (D29, `Satisfies`), *admits* it when the update is defined (D30, `CCP.Partial.admits`),
-one sentence *presupposes* another when every admitting state satisfies it (D31, D46,
-`Presupposes`), and *entails* it when every update with it lands in a satisfying state (D26,
-D45, `Entails`). Discourse markers, determiners and accommodation (Chs. 7–9) are outside
+Partial update logic (Chs. 6–8): [veltman-1996]-style eliminative updates
+extended with the presupposition operator `∂`, whose update is defined only in
+contexts that already satisfy its argument. A sentence denotes a partial
+function on information states (`Formula.eval`); a state *satisfies* a sentence
+when it is a fixed point (D29) and *admits* it when the update is defined
+(D30); `φ` *presupposes* `ψ` when every admitting state satisfies `ψ` (D31,
+D46) and *entails* it when every update lands in a satisfying state (D26,
+D45). Discourse markers, determiners and accommodation (Chs. 7–9) are outside
 the propositional fragment.
 
-Two results from Part I are stated on the static side: under the Strong Kleene connectives
-presuppositions are *conditionalised* rather than projected or filtered — *φ ∧ ψ*
-presupposes *ψ → π* and *φ ∨ ψ* presupposes *¬ψ → π* when *φ* presupposes *π*, maximally so
-when *ψ* is bivalent (Fact 2.1: `andStrong_presup_iff`, `orStrong_presup_iff`). On the
-dynamic side: *must* is the dual of *might* (Fact 6.1, `eval_must`); every update is
-eliminative (Fact 7.1, `eval_eliminative`); presuppositions project through negation,
-conjunction, the conditional and the modals, and compose (Facts 8.1, 8.2, 8.8:
-`Presupposes.not`, `.and_left`, `.implies_left`, `.might`, `.must`, `.trans`); a presupposition
-of the second conjunct or the consequent projects *conditionalised* on the first conjunct or
-the antecedent (Fact 8.3: `Presupposes.and_right`, `.implies_right`) — so *if Spaceman Spiff
-lands on Planet X, he will be bothered by the fact that his weight is greater than it would be
-on Earth* (E154) presupposes that if he lands there his weight is greater, and not that it is
-(`e154`, `e154_not_unconditional`); *might* is a consistency test and *must* a satisfaction
-test (D61, Fact 8.5, Lemma 8.6, Fact 8.7). Finally, on the sentences without modals Peters'
-trivalent semantics (D70–D71, `tval`: the middle Kleene connectives, `∂φ` undefined unless
-`φ` is true) and the update semantics agree world by world (Lemma 10.1, `trueAt_iff`,
-`falseAt_iff`), the non-modal updates are distributive (Fact A.2, `mem_eval_iff`), and the
-two entailment notions coincide (Lemma 10.2, Fact 10.3: `entails_iff`, `entails_iff_tval`),
-whence a non-modal sentence presupposes exactly what both it and its negation entail
-(`presupposes_iff`).
+## Main statements
+
+* `andStrong_presup_iff`, `orStrong_presup_iff`: Strong Kleene conditionalises
+  presuppositions (Fact 2.1).
+* `eval_must`: *must* is the dual of *might* (Fact 6.1); `eval_eliminative`:
+  every update is eliminative (Facts 7.1, A.1).
+* `Presupposes.not`/`.and_left`/`.implies_left`/`.might`/`.must`/`.trans` and
+  conditionalised `.and_right`/`.implies_right`: projection (Facts 8.1–8.3,
+  8.8); `e154` is the Spaceman Spiff conditional (E154).
+* `satisfies_might_iff`, `satisfies_must_iff`: *might* is a consistency test,
+  *must* a satisfaction test (D61, Facts 8.5–8.7).
+* `trueAt_iff`, `mem_eval_iff`, `entails_iff_tval`, `presupposes_iff`: on the
+  non-modal fragment the updates agree world by world with the trivalent
+  semantics of [peters-1979] (D70–D77, Lemma 10.1), are distributive (Fact A.2), the two
+  entailment notions coincide (Lemma 10.2, Fact 10.3), and presupposition is
+  entailment by the sentence and by its negation.
+
+## References
+
+* [beaver-2001]: Presupposition and Assertion in Dynamic Semantics. CSLI.
+* [veltman-1996]: Defaults in update semantics.
+* [peters-1979]: A truth-conditional formulation of Karttunen's account of
+  presupposition. *Synthese* 40.
 -/
 
 namespace Beaver2001


### PR DESCRIPTION
Full verification pass against the book (all D-numbers, Facts 2.1/6.1/7.1/8.1-8.8/10.3, Lemmas 8.6/10.1/10.2, E154 checked on page images; no discrepancies found); header recut to mathlib register with a References list; 12 examples in Data/Examples/Beaver2001.json.