### PR TITLE
refactor(Studies/BeaverCondoravdi2003): connective by construction

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -347,6 +347,7 @@ import Linglib.Data.Examples.BarLevFox2020
 import Linglib.Data.Examples.Barker2002
 import Linglib.Data.Examples.BarwiseCooper1981
 import Linglib.Data.Examples.Beaver2001
+import Linglib.Data.Examples.BeaverCondoravdi2003
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015

--- a/Linglib/Data/Examples/BeaverCondoravdi2003.json
+++ b/Linglib/Data/Examples/BeaverCondoravdi2003.json
@@ -1,0 +1,309 @@
+[
+  {
+    "id": "beavercondoravdi2003_1",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(1)"},
+    "language": "stan1293",
+    "primaryText": "Cleo left Europe before David did.",
+    "glossedTokens": [],
+    "translation": "Cleo left Europe before David did.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"]
+    ],
+    "comment": "True iff (2) is — the intuition behind converseness; implies David did in fact leave Europe."
+  },
+  {
+    "id": "beavercondoravdi2003_2",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(2)"},
+    "language": "stan1293",
+    "primaryText": "David left Europe after Cleo did.",
+    "glossedTokens": [],
+    "translation": "David left Europe after Cleo did.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavercondoravdi2003_3",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(3)"},
+    "language": "stan1293",
+    "primaryText": "Cleo was in America before David was in America.",
+    "glossedTokens": [],
+    "translation": "Cleo was in America before David was in America.",
+    "context": "Cleo's stay starts before David's; their stays overlap.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "antisymmetry"]
+    ],
+    "comment": "True iff (4) is false: before is antisymmetric."
+  },
+  {
+    "id": "beavercondoravdi2003_5",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(5)"},
+    "language": "stan1293",
+    "primaryText": "Cleo was in America after David was in America.",
+    "glossedTokens": [],
+    "translation": "Cleo was in America after David was in America.",
+    "context": "Cleo's stay starts before David's; their stays overlap.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "antisymmetry"]
+    ],
+    "comment": "Can be true together with (6) in the overlap situation (7): after is not antisymmetric."
+  },
+  {
+    "id": "beavercondoravdi2003_9",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(9)"},
+    "language": "stan1293",
+    "primaryText": "Fred was dancing after Ginger was.",
+    "glossedTokens": [],
+    "translation": "Fred was dancing after Ginger was.",
+    "context": "Ginger dances continuously; Fred dances in the middle; Delores does a quick routine after Fred stops, while Ginger still dances.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "transitivity"]
+    ],
+    "comment": "Judged true in situation (8)."
+  },
+  {
+    "id": "beavercondoravdi2003_10",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(10)"},
+    "language": "stan1293",
+    "primaryText": "Ginger was dancing after Delores was.",
+    "glossedTokens": [],
+    "translation": "Ginger was dancing after Delores was.",
+    "context": "Same situation (8).",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "transitivity"]
+    ],
+    "comment": "Judged true in situation (8)."
+  },
+  {
+    "id": "beavercondoravdi2003_11",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(11)"},
+    "language": "stan1293",
+    "primaryText": "Fred was dancing after Delores was.",
+    "glossedTokens": [],
+    "translation": "Fred was dancing after Delores was.",
+    "context": "Same situation (8).",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "transitivity"]
+    ],
+    "comment": "Judged false in situation (8): after is not transitive."
+  },
+  {
+    "id": "beavercondoravdi2003_12",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(12)"},
+    "language": "stan1293",
+    "primaryText": "Delores was dancing before Ginger was.",
+    "glossedTokens": [],
+    "translation": "Delores was dancing before Ginger was.",
+    "context": "Same situation (8).",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "converseness"]
+    ],
+    "comment": "Not judged true in situation (8), though (10) is — the direct counterexample to sentential converseness."
+  },
+  {
+    "id": "beavercondoravdi2003_15",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(15)"},
+    "language": "stan1293",
+    "primaryText": "Cleo leapt into action before David moved a muscle.",
+    "glossedTokens": [],
+    "translation": "Cleo leapt into action before David moved a muscle.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "npi-licensing"]
+    ],
+    "comment": "Before licenses NPIs in its clause; also with 'could say a word'."
+  },
+  {
+    "id": "beavercondoravdi2003_16",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(16)"},
+    "language": "stan1293",
+    "primaryText": "Cleo leapt into action after David moved a muscle.",
+    "glossedTokens": [],
+    "translation": "Cleo leapt into action after David moved a muscle.",
+    "context": "",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "npi-licensing"]
+    ],
+    "comment": "After does not license NPIs; main clauses license none regardless of connective ((17), (18))."
+  },
+  {
+    "id": "beavercondoravdi2003_22",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(22)"},
+    "language": "stan1293",
+    "primaryText": "On Dec. 9, the U.S. Supreme Court stopped the hand count before it was completed.",
+    "glossedTokens": [],
+    "translation": "On Dec. 9, the U.S. Supreme Court stopped the hand count before it was completed.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "veridicality"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "Uncounted votes: the before-clause is not instantiated."
+  },
+  {
+    "id": "beavercondoravdi2003_23",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(23)"},
+    "language": "stan1293",
+    "primaryText": "Another booby-trapped bicycle and a bomb hidden in a supermarket cart were discovered and defused by police before they exploded.",
+    "glossedTokens": [],
+    "translation": "Another booby-trapped bicycle and a bomb hidden in a supermarket cart were discovered and defused by police before they exploded.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "veridicality"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "No explosion."
+  },
+  {
+    "id": "beavercondoravdi2003_24",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(24)"},
+    "language": "stan1293",
+    "primaryText": "Mozart died before he finished the Requiem and it was completed by his student, Franz Xavier Suessmayr.",
+    "glossedTokens": [],
+    "translation": "Mozart died before he finished the Requiem and it was completed by his student, Franz Xavier Suessmayr.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "veridicality"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "Unfinished Requiem; simplified as (40), which implies (41): if Mozart had not died when he did, he might/would have finished it."
+  },
+  {
+    "id": "beavercondoravdi2003_25",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(25)"},
+    "language": "stan1293",
+    "primaryText": "Mozart died after he finished the Requiem.",
+    "glossedTokens": [],
+    "translation": "Mozart died after he finished the Requiem.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "veridicality"]
+    ],
+    "comment": "Requiem finished: after-clauses stay veridical under any toying with the examples."
+  },
+  {
+    "id": "beavercondoravdi2003_26",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(26)"},
+    "language": "stan1293",
+    "primaryText": "Mozart finished the Requiem after he died.",
+    "glossedTokens": [],
+    "translation": "Mozart finished the Requiem after he died.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "after"],
+      ["phenomenon", "veridicality"]
+    ],
+    "comment": "Requiem finished post mortem: both clauses veridical."
+  },
+  {
+    "id": "beavercondoravdi2003_32",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(32)"},
+    "language": "stan1293",
+    "primaryText": "David ate lots of ketchup before he made a clean sweep of all the gold medals in the Sydney Olympics.",
+    "glossedTokens": [],
+    "translation": "David ate lots of ketchup before he made a clean sweep of all the gold medals in the Sydney Olympics.",
+    "context": "David never won a gold medal at anything.",
+    "judgment": "marginal",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "overgeneration"]
+    ],
+    "comment": "Predicted true by the classical rendering whenever the before-clause is empty; odd because no context with common-sense assumptions makes the win reasonably probable."
+  },
+  {
+    "id": "beavercondoravdi2003_34",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(34)"},
+    "language": "stan1293",
+    "primaryText": "Cleo left exactly 5 seconds before David sang.",
+    "glossedTokens": [],
+    "translation": "Cleo left exactly 5 seconds before David sang.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "measure-phrase"]
+    ],
+    "comment": "A universal rendering of the before-clause would require leaving exactly 5 seconds before every singing time."
+  },
+  {
+    "id": "beavercondoravdi2003_42",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(42)"},
+    "language": "stan1293",
+    "primaryText": "The police defused the bomb before it exploded.",
+    "glossedTokens": [],
+    "translation": "The police defused the bomb before it exploded.",
+    "context": "It is taken for granted that there was a bomb ticking which ended up not exploding.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "veridicality"],
+      ["reading", "counterfactual"]
+    ],
+    "comment": "New information: the bomb did not explode because the police defused it before the time it would have exploded."
+  },
+  {
+    "id": "beavercondoravdi2003_43",
+    "source": {"bibkey": "beaver-condoravdi-2003", "paperLabel": "(43)"},
+    "language": "stan1293",
+    "primaryText": "I left the party before there was any trouble.",
+    "glossedTokens": [],
+    "translation": "I left the party before there was any trouble.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["connective", "before"],
+      ["phenomenon", "veridicality"],
+      ["reading", "non-committal"]
+    ],
+    "comment": "No commitment to there having been trouble, but trouble seemed likely shortly before the departure."
+  }
+]

--- a/Linglib/Data/Examples/BeaverCondoravdi2003.lean
+++ b/Linglib/Data/Examples/BeaverCondoravdi2003.lean
@@ -1,0 +1,360 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BeaverCondoravdi2003` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BeaverCondoravdi2003.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BeaverCondoravdi2003.Examples`.
+-/
+
+namespace BeaverCondoravdi2003.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "beavercondoravdi2003_1"
+    source := ⟨"beaver-condoravdi-2003", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo left Europe before David did."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo left Europe before David did."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before")]
+    comment := "True iff (2) is — the intuition behind converseness; implies David did in fact leave Europe."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2 : LinguisticExample :=
+  { id := "beavercondoravdi2003_2"
+    source := ⟨"beaver-condoravdi-2003", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "David left Europe after Cleo did."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "David left Europe after Cleo did."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_3 : LinguisticExample :=
+  { id := "beavercondoravdi2003_3"
+    source := ⟨"beaver-condoravdi-2003", "(3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo was in America before David was in America."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo was in America before David was in America."
+    context := "Cleo's stay starts before David's; their stays overlap."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "antisymmetry")]
+    comment := "True iff (4) is false: before is antisymmetric."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5 : LinguisticExample :=
+  { id := "beavercondoravdi2003_5"
+    source := ⟨"beaver-condoravdi-2003", "(5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo was in America after David was in America."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo was in America after David was in America."
+    context := "Cleo's stay starts before David's; their stays overlap."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "antisymmetry")]
+    comment := "Can be true together with (6) in the overlap situation (7): after is not antisymmetric."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_9 : LinguisticExample :=
+  { id := "beavercondoravdi2003_9"
+    source := ⟨"beaver-condoravdi-2003", "(9)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fred was dancing after Ginger was."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Fred was dancing after Ginger was."
+    context := "Ginger dances continuously; Fred dances in the middle; Delores does a quick routine after Fred stops, while Ginger still dances."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "transitivity")]
+    comment := "Judged true in situation (8)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_10 : LinguisticExample :=
+  { id := "beavercondoravdi2003_10"
+    source := ⟨"beaver-condoravdi-2003", "(10)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Ginger was dancing after Delores was."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Ginger was dancing after Delores was."
+    context := "Same situation (8)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "transitivity")]
+    comment := "Judged true in situation (8)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_11 : LinguisticExample :=
+  { id := "beavercondoravdi2003_11"
+    source := ⟨"beaver-condoravdi-2003", "(11)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fred was dancing after Delores was."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Fred was dancing after Delores was."
+    context := "Same situation (8)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "transitivity")]
+    comment := "Judged false in situation (8): after is not transitive."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_12 : LinguisticExample :=
+  { id := "beavercondoravdi2003_12"
+    source := ⟨"beaver-condoravdi-2003", "(12)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Delores was dancing before Ginger was."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Delores was dancing before Ginger was."
+    context := "Same situation (8)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "converseness")]
+    comment := "Not judged true in situation (8), though (10) is — the direct counterexample to sentential converseness."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_15 : LinguisticExample :=
+  { id := "beavercondoravdi2003_15"
+    source := ⟨"beaver-condoravdi-2003", "(15)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo leapt into action before David moved a muscle."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo leapt into action before David moved a muscle."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "npi-licensing")]
+    comment := "Before licenses NPIs in its clause; also with 'could say a word'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_16 : LinguisticExample :=
+  { id := "beavercondoravdi2003_16"
+    source := ⟨"beaver-condoravdi-2003", "(16)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo leapt into action after David moved a muscle."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo leapt into action after David moved a muscle."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "npi-licensing")]
+    comment := "After does not license NPIs; main clauses license none regardless of connective ((17), (18))."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22 : LinguisticExample :=
+  { id := "beavercondoravdi2003_22"
+    source := ⟨"beaver-condoravdi-2003", "(22)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "On Dec. 9, the U.S. Supreme Court stopped the hand count before it was completed."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "On Dec. 9, the U.S. Supreme Court stopped the hand count before it was completed."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "veridicality"), ("reading", "counterfactual")]
+    comment := "Uncounted votes: the before-clause is not instantiated."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23 : LinguisticExample :=
+  { id := "beavercondoravdi2003_23"
+    source := ⟨"beaver-condoravdi-2003", "(23)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Another booby-trapped bicycle and a bomb hidden in a supermarket cart were discovered and defused by police before they exploded."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Another booby-trapped bicycle and a bomb hidden in a supermarket cart were discovered and defused by police before they exploded."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "veridicality"), ("reading", "counterfactual")]
+    comment := "No explosion."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_24 : LinguisticExample :=
+  { id := "beavercondoravdi2003_24"
+    source := ⟨"beaver-condoravdi-2003", "(24)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mozart died before he finished the Requiem and it was completed by his student, Franz Xavier Suessmayr."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mozart died before he finished the Requiem and it was completed by his student, Franz Xavier Suessmayr."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "veridicality"), ("reading", "counterfactual")]
+    comment := "Unfinished Requiem; simplified as (40), which implies (41): if Mozart had not died when he did, he might/would have finished it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25 : LinguisticExample :=
+  { id := "beavercondoravdi2003_25"
+    source := ⟨"beaver-condoravdi-2003", "(25)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mozart died after he finished the Requiem."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mozart died after he finished the Requiem."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "veridicality")]
+    comment := "Requiem finished: after-clauses stay veridical under any toying with the examples."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26 : LinguisticExample :=
+  { id := "beavercondoravdi2003_26"
+    source := ⟨"beaver-condoravdi-2003", "(26)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mozart finished the Requiem after he died."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Mozart finished the Requiem after he died."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "after"), ("phenomenon", "veridicality")]
+    comment := "Requiem finished post mortem: both clauses veridical."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_32 : LinguisticExample :=
+  { id := "beavercondoravdi2003_32"
+    source := ⟨"beaver-condoravdi-2003", "(32)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "David ate lots of ketchup before he made a clean sweep of all the gold medals in the Sydney Olympics."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "David ate lots of ketchup before he made a clean sweep of all the gold medals in the Sydney Olympics."
+    context := "David never won a gold medal at anything."
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "overgeneration")]
+    comment := "Predicted true by the classical rendering whenever the before-clause is empty; odd because no context with common-sense assumptions makes the win reasonably probable."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_34 : LinguisticExample :=
+  { id := "beavercondoravdi2003_34"
+    source := ⟨"beaver-condoravdi-2003", "(34)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Cleo left exactly 5 seconds before David sang."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Cleo left exactly 5 seconds before David sang."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "measure-phrase")]
+    comment := "A universal rendering of the before-clause would require leaving exactly 5 seconds before every singing time."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_42 : LinguisticExample :=
+  { id := "beavercondoravdi2003_42"
+    source := ⟨"beaver-condoravdi-2003", "(42)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The police defused the bomb before it exploded."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The police defused the bomb before it exploded."
+    context := "It is taken for granted that there was a bomb ticking which ended up not exploding."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "veridicality"), ("reading", "counterfactual")]
+    comment := "New information: the bomb did not explode because the police defused it before the time it would have exploded."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_43 : LinguisticExample :=
+  { id := "beavercondoravdi2003_43"
+    source := ⟨"beaver-condoravdi-2003", "(43)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I left the party before there was any trouble."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I left the party before there was any trouble."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("connective", "before"), ("phenomenon", "veridicality"), ("reading", "non-committal")]
+    comment := "No commitment to there having been trouble, but trouble seemed likely shortly before the departure."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1, ex_2, ex_3, ex_5, ex_9, ex_10, ex_11, ex_12, ex_15, ex_16, ex_22, ex_23, ex_24, ex_25, ex_26, ex_32, ex_34, ex_42, ex_43]
+
+end BeaverCondoravdi2003.Examples

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -1,7 +1,6 @@
 import Linglib.Semantics.Tense.SentDenotation
 import Linglib.Studies.Anscombe1964
 import Linglib.Semantics.Modality.HistoricalAlternatives
-import Linglib.Semantics.Degree.Basic
 import Linglib.Data.Examples.BeaverCondoravdi2003
 
 /-!
@@ -14,32 +13,21 @@ for *after*. The paper shows that the classical accounts of [anscombe-1964]
 and [heinamaki-1974] coincide once the temporal clause is instantiated and
 left-bounded, and that both reduce to a single scheme: some main-clause time
 is earlier (*before*) or later (*after*) than the earliest temporal-clause
-time. The two connectives then differ only in the direction of the ordering.
-Veridicality is explained by branching time ([thomason-1984]): the earliest
-time is computed across the historical alternatives of the evaluation world
-at the main-clause time. An event earlier than that time must lie on the
-actual branch, so *after* is veridical; an event later than it may lie on a
-discarded branch, so *before* also has counterfactual and non-committal uses,
-sorted by the context (48).
+time. Veridicality is explained by branching time ([thomason-1984]): the
+earliest time is computed across the historical alternatives of the
+evaluation world at the main-clause time. An event earlier than that time
+must lie on the actual branch, so *after* is veridical; an event later than
+it may lie on a discarded branch, so *before* also has counterfactual and
+non-committal uses, sorted by the context (48).
 
 ## Main statements
 
-* `connective`, `before`, `after`: the uniform truth conditions (47); the two
-  connectives are one operator with opposite orderings, by construction.
-* `mem_earliestAlt_iff_isLeast`: the `earliest` operator (46) picks out the
-  least instantiation time.
-* `after_veridical`: under the initial branch point condition, *after*
-  entails its temporal clause (§6).
-* `connective_singleton_alt`: with trivial alternatives the connectives
-  reduce to the extensional (45).
-* `connective_alt_inst`: even a non-veridical *before* locates the temporal
-  clause in some historical alternative (49).
-* `Veridical`, `Counterfactual`, `NonCommittal`, `readings_partition`: the
-  three readings of *before* partition the nonempty contexts (48).
-* `anscombe_before_complement_DE`, `anscombe_after_complement_UE`,
-  `anscombe_before_of_empty`: the classical rendering's monotonicity — the
-  NPI environments (§3) — and the overgeneration (32) that motivates
-  requiring instantiation.
+* `connective`: the uniform truth conditions (47) — `before` and `after` are
+  one operator with opposite orderings, by construction.
+* `after_veridical`: the initial branch point condition makes *after* entail
+  its temporal clause (§6).
+* `readings_partition`: the veridical, counterfactual and non-committal
+  readings of *before* partition the nonempty contexts (48).
 
 ## References
 
@@ -53,11 +41,24 @@ sorted by the context (48).
 namespace BeaverCondoravdi2003
 
 open Tense
-open Core.Order (maxOnScale)
 
-variable {W T : Type*} [LinearOrder T]
+variable {W T : Type*}
 
-/-! ### Historical alternatives and the initial branch point condition (§6) -/
+/-! ### Instantiation -/
+
+/-- The times at which `B` is instantiated in some world of `worlds` (46). -/
+def instTimes (worlds : Set W) (B : Set (W × T)) : Set T :=
+  { t | ∃ w ∈ worlds, (w, t) ∈ B }
+
+/-- `B` is instantiated in `w`: it holds of some time there. -/
+def Inst (B : Set (W × T)) (w : W) : Prop :=
+  ∃ t, (w, t) ∈ B
+
+section Connective
+
+variable [LinearOrder T]
+
+/-! ### The uniform truth conditions (44)–(47) -/
 
 /-- The initial branch point condition (§6): every historical alternative of
 `w` at `t` agrees with `w` at all earlier times, so branching happens only
@@ -66,32 +67,11 @@ def initialBranchPoint (alt : HistoricalAlternatives W T)
     (agree : T → W → W → Prop) : Prop :=
   ∀ w t, ∀ w' ∈ alt ⟨w, t⟩, ∀ t', t' < t → agree t' w w'
 
-/-! ### The `earliest` operator across alternatives (44)–(46) -/
-
-/-- The times at which `B` is instantiated in some world of `worlds` (46). -/
-def instTimes (worlds : Set W) (B : Set (W × T)) : Set T :=
-  { t | ∃ w ∈ worlds, (w, t) ∈ B }
-
 /-- The earliest `B`-time across the historical alternatives of `w` at `t`
-(46): the least instantiation time, as `maxOnScale .lt`. -/
+(46): the least instantiation time. -/
 def earliestAlt (alt : HistoricalAlternatives W T) (B : Set (W × T))
     (w : W) (t : T) : Set T :=
-  maxOnScale .lt (instTimes (alt ⟨w, t⟩) B)
-
-/-- The `earliest` operator picks out exactly the least instantiation time. -/
-theorem mem_earliestAlt_iff_isLeast (alt : HistoricalAlternatives W T)
-    (B : Set (W × T)) (w : W) (t te : T) :
-    te ∈ earliestAlt alt B w t ↔ IsLeast (instTimes (alt ⟨w, t⟩) B) te := by
-  constructor
-  · rintro ⟨hmem, hmin⟩
-    refine ⟨hmem, λ y hy => ?_⟩
-    by_cases hy_eq : y = te
-    · exact le_of_eq hy_eq.symm
-    · exact le_of_lt (hmin y hy hy_eq)
-  · rintro ⟨hmem, hlb⟩
-    exact ⟨hmem, λ y hy hne => lt_of_le_of_ne (hlb hy) (Ne.symm hne)⟩
-
-/-! ### The uniform truth conditions (47) -/
+  { te | IsLeast (instTimes (alt ⟨w, t⟩) B) te }
 
 /-- The uniform temporal connective (47): some main-clause time in `w` stands
 in `cmp` to the earliest temporal-clause time across the historical
@@ -110,11 +90,7 @@ abbrev after (A B : Set (W × T)) (alt : HistoricalAlternatives W T)
     (w : W) : Prop :=
   connective (· > ·) A B alt w
 
-/-! ### Instantiation and veridicality (§6) -/
-
-/-- `B` is instantiated in `w`: it holds of some time there. -/
-def Inst (B : Set (W × T)) (w : W) : Prop :=
-  ∃ t, (w, t) ∈ B
+/-! ### Veridicality (§6) -/
 
 /-- *After* is veridical (§6): under the initial branch point condition, the
 earliest `B`-time precedes the `A`-time, so branching has not yet happened
@@ -140,7 +116,8 @@ theorem connective_singleton_alt (cmp : T → T → Prop) (A B : Set (W × T))
     rw [h t]; ext t'; simp [instTimes]
   refine exists_congr fun t => and_congr_right fun _ => exists_congr fun te =>
     and_congr_left fun _ => ?_
-  rw [mem_earliestAlt_iff_isLeast, hs t]
+  simp only [earliestAlt, Set.mem_ofPred_eq]
+  rw [hs t]
 
 /-- Even a non-veridical *before* locates `B` on a branch (49): if the
 connective holds at `w`, some main-clause time has a historical alternative
@@ -151,6 +128,8 @@ theorem connective_alt_inst (cmp : T → T → Prop) (A B : Set (W × T))
       ∃ t, (w, t) ∈ A ∧ ∃ w' ∈ alt ⟨w, t⟩, Inst B w' := by
   rintro ⟨t, htA, te, ⟨⟨w', hw', hB⟩, -⟩, -⟩
   exact ⟨t, htA, w', hw', te, hB⟩
+
+end Connective
 
 /-! ### The three readings of *before* (48) -/
 
@@ -174,7 +153,6 @@ do not. -/
 def NonCommittal (B : Set (W × T)) (context : Set W) : Prop :=
   (∃ w ∈ context, Inst B w) ∧ ∃ w ∈ context, ¬Inst B w
 
-omit [LinearOrder T] in
 /-- The three readings are mutually exclusive and exhaust the nonempty
 contexts (48). -/
 theorem readings_partition (B : Set (W × T)) (context : Set W)

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -2,189 +2,86 @@ import Linglib.Semantics.Tense.SentDenotation
 import Linglib.Studies.Anscombe1964
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Degree.Basic
+import Linglib.Data.Examples.BeaverCondoravdi2003
 
 /-!
-# [beaver-condoravdi-2003]: Uniform Analysis with `earliest`
-[beaver-condoravdi-2003] [thomason-1984]
+# Beaver & Condoravdi (2003): a uniform *before* and *after*
 
-A **uniform** semantics for *before* and *after*: both connectives use the
-same `earliest` operator, with the veridicality asymmetry derived from
-**branching time** and historical alternatives rather than quantificational
-asymmetry.
+*Before* and *after* differ in logical properties, NPI licensing and
+veridicality, so since [anscombe-1964] they have been given non-uniform
+semantics — a universal over the temporal clause for *before*, an existential
+for *after*. The paper shows that the classical accounts of [anscombe-1964]
+and [heinamaki-1974] coincide once the temporal clause is instantiated and
+left-bounded, and that both reduce to a single scheme: some main-clause time
+is earlier (*before*) or later (*after*) than the earliest temporal-clause
+time. The two connectives then differ only in the direction of the ordering.
+Veridicality is explained by branching time ([thomason-1984]): the earliest
+time is computed across the historical alternatives of the evaluation world
+at the main-clause time. An event earlier than that time must lie on the
+actual branch, so *after* is veridical; an event later than it may lie on a
+discarded branch, so *before* also has counterfactual and non-committal uses,
+sorted by the context (48).
 
-## Core Architecture
+## Main statements
 
-B&C define temporal connective truth conditions over **world–time pairs**
-(situations) with access to historical alternatives:
+* `connective`, `before`, `after`: the uniform truth conditions (47); the two
+  connectives are one operator with opposite orderings, by construction.
+* `mem_earliestAlt_iff_isLeast`: the `earliest` operator (46) picks out the
+  least instantiation time.
+* `after_veridical`: under the initial branch point condition, *after*
+  entails its temporal clause (§6).
+* `connective_singleton_alt`: with trivial alternatives the connectives
+  reduce to the extensional (45).
+* `connective_alt_inst`: even a non-veridical *before* locates the temporal
+  clause in some historical alternative (49).
+* `Veridical`, `Counterfactual`, `NonCommittal`, `readings_partition`: the
+  three readings of *before* partition the nonempty contexts (48).
+* `anscombe_before_complement_DE`, `anscombe_after_complement_UE`,
+  `anscombe_before_of_empty`: the classical rendering's monotonicity — the
+  NPI environments (§3) — and the overgeneration (32) that motivates
+  requiring instantiation.
 
-- `A after B` true at w iff ∃t : ⟨w,t⟩ ∈ A, t > earliest_{alt(w,t)}(B)
-- `A before B` true at w iff ∃t : ⟨w,t⟩ ∈ A, t < earliest_{alt(w,t)}(B)
+## References
 
-Where `alt(w,t)` is the set of worlds historically accessible from w at t
-(worlds sharing w's history up to t).
-
-## Veridicality from Branching
-
-The veridicality asymmetry falls out from the initial branch point condition:
-
-- **After**: A happens after the earliest B. Since B is in the past of A and
-  `alt(w,t)` only branches in the future of t, B must be on the actual branch.
-  So *after* is always veridical.
-
-- **Before**: A happens before the earliest B. B could be on a different branch
-  (a historical alternative), so B might not be instantiated in w. Three readings
-  arise from context: veridical (all context worlds have B), counterfactual
-  (no context world has B), non-committal (some do, some don't).
-
-## Level
-
-**Level 4 (intensional)**: operates on sets of world–time pairs. The
-`earliest` operator is MAX on the < scale (same as Rett's MAX₍<₎), applied
-across historical alternatives.
-
+* [beaver-condoravdi-2003]: A uniform analysis of *before* and *after*.
+  SALT 13.
+* [anscombe-1964]: Before and after. *The Philosophical Review* 74.
+* [heinamaki-1974]: Semantics of English Temporal Connectives.
+* [thomason-1984]: Combinations of tense and modality.
 -/
 
 namespace BeaverCondoravdi2003
 
 open Tense
-
-/-- The `EARLIEST` definedness presupposition of `before^{B&C}`:
-    `EARLIEST_C` is defined for body `p` iff the set of `C`-times where `p`
-    holds has a least element (mathlib's `IsLeast`). -/
-def hasEarliest {Time : Type*} [LinearOrder Time] (C : Set Time) (p : Time → Prop) : Prop :=
-  ∃ t, IsLeast {t' | t' ∈ C ∧ p t'} t
-
 open Core.Order (maxOnScale)
+
 variable {W T : Type*} [LinearOrder T]
 
--- ============================================================================
--- § 1: Historical Alternatives
--- ============================================================================
+/-! ### Historical alternatives and the initial branch point condition (§6) -/
 
-/-- Historical alternatives: for each world w and time t, the set of worlds
-    sharing w's history up to t but potentially diverging afterwards.
+/-- The initial branch point condition (§6): every historical alternative of
+`w` at `t` agrees with `w` at all earlier times, so branching happens only
+from `t` onwards. -/
+def initialBranchPoint (alt : HistoricalAlternatives W T)
+    (agree : T → W → W → Prop) : Prop :=
+  ∀ w t, ∀ w' ∈ alt ⟨w, t⟩, ∀ t', t' < t → agree t' w w'
 
-    `alt(w,t)` satisfies the initial branch point condition: all worlds in
-    `alt(w,t)` agree with w on all events at times ≤ t. -/
-abbrev HistAlt (W T : Type*) := W → T → Set W
+/-! ### The `earliest` operator across alternatives (44)–(46) -/
 
-/-- Initial branch point condition: worlds in `alt(w,t)` agree with w
-    on all events at times before t.
-
-    `agree t' w w'` means "w and w' are indistinguishable at time t'". -/
-def initialBranchPoint (alt : HistAlt W T) (agree : T → W → W → Prop) : Prop :=
-  ∀ w t, ∀ w' ∈ alt w t, ∀ t', t' < t → agree t' w w'
-
-/-- The actual world is always a historical alternative of itself. -/
-def altReflexive (alt : HistAlt W T) : Prop :=
-  ∀ w t, w ∈ alt w t
-
-/-- Monotonicity of alternatives: later times have fewer alternatives,
-    since more shared history constrains the set of compatible worlds.
-    `alt(w,t') ⊆ alt(w,t)` when `t ≤ t'`.
-
-    Intuitively: if w' shares w's history up to t', it also shares w's
-    history up to any earlier t ≤ t'. -/
-def altMonotone (alt : HistAlt W T) : Prop :=
-  ∀ w t t', t ≤ t' → alt w t' ⊆ alt w t
-
--- ============================================================================
--- § 1b: Bridge to BranchingTime.HistoricalAlternatives
--- ============================================================================
-
-/-- Convert a `HistoricalAlternatives` (situation-indexed) to curried `HistAlt` form. -/
-def histAltOfWorldHistory (h : HistoricalAlternatives W T) :
-    HistAlt W T :=
-  fun w t => h ⟨w, t⟩
-
-/-- Convert curried `HistAlt` to `HistoricalAlternatives` (situation-indexed) form. -/
-def worldHistoryOfHistAlt (a : HistAlt W T) :
-    HistoricalAlternatives W T :=
-  fun s => a s.world s.time
-
-omit [LinearOrder T] in
-/-- Round-trip: `HistoricalAlternatives → HistAlt → HistoricalAlternatives` is identity. -/
-theorem histAlt_worldHistory_roundtrip
-    (h : HistoricalAlternatives W T) :
-    worldHistoryOfHistAlt (histAltOfWorldHistory h) = h := rfl
-
-omit [LinearOrder T] in
-/-- Round-trip: `HistAlt → HistoricalAlternatives → HistAlt` is identity. -/
-theorem worldHistory_histAlt_roundtrip (a : HistAlt W T) :
-    histAltOfWorldHistory (worldHistoryOfHistAlt a) = a := rfl
-
-omit [LinearOrder T] in
-/-- `altReflexive` is equivalent to `HistoricalAlternatives.reflexive`. -/
-theorem altReflexive_iff_reflexive (a : HistAlt W T) :
-    altReflexive a ↔ (worldHistoryOfHistAlt a).reflexive := by
-  unfold altReflexive HistoricalAlternatives.reflexive
-         worldHistoryOfHistAlt
-  constructor
-  · intro h s; exact h s.world s.time
-  · intro h w t; exact h ⟨w, t⟩
-
-/-- `altMonotone` is equivalent to `HistoricalAlternatives.backwardsClosed`. -/
-theorem altMonotone_iff_backwardsClosed (a : HistAlt W T) :
-    altMonotone a ↔ (worldHistoryOfHistAlt a).backwardsClosed := by
-  unfold altMonotone HistoricalAlternatives.backwardsClosed
-         worldHistoryOfHistAlt
-  constructor
-  · intro h w w' t t' hle hw'
-    exact h w t' t hle hw'
-  · intro h w t t' hle w' hw'
-    exact h w w' t' t hle hw'
-
-omit [LinearOrder T] in
-/-- `HistAlt` symmetry is equivalent to `HistoricalAlternatives.symmetric`:
-    if w' ∈ alt(w,t) then w ∈ alt(w',t). -/
-theorem altSymmetric_iff_symmetric (a : HistAlt W T) :
-    (∀ w t, ∀ w' ∈ a w t, w ∈ a w' t) ↔
-    (worldHistoryOfHistAlt a).symmetric := by
-  unfold HistoricalAlternatives.symmetric worldHistoryOfHistAlt
-  constructor
-  · intro h w w' t hw'; exact h w t w' hw'
-  · intro h w t w' hw'; exact h w w' t hw'
-
-omit [LinearOrder T] in
-/-- `HistAlt` transitivity is equivalent to `HistoricalAlternatives.transitive`:
-    if w' ∈ alt(w,t) and w'' ∈ alt(w',t) then w'' ∈ alt(w,t). -/
-theorem altTransitive_iff_transitive (a : HistAlt W T) :
-    (∀ w t, ∀ w' ∈ a w t, ∀ w'' ∈ a w' t, w'' ∈ a w t) ↔
-    (worldHistoryOfHistAlt a).transitive := by
-  unfold HistoricalAlternatives.transitive worldHistoryOfHistAlt
-  constructor
-  · intro h w w' w'' t h₁ h₂; exact h w t w' h₁ w'' h₂
-  · intro h w t w' h₁ w'' h₂; exact h w w' w'' t h₁ h₂
-
-/-- B&C's `alt(w,t)` is exactly the `histEquiv` equivalence class:
-    `w' ∈ alt(w,t)` iff `histEquiv history t w w'`. -/
-theorem histAlt_eq_histEquiv (h : HistoricalAlternatives W T) (w : W) (t : T) :
-    histAltOfWorldHistory h w t = { w' | HistoricalAlternatives.histEquiv h t w w' } := rfl
-
--- ============================================================================
--- § 2: Earliest Across Alternatives
--- ============================================================================
-
-/-- The set of times at which B is instantiated in some world of a world set.
-    `instTimes worlds B` = { t | ∃ w ∈ worlds, ⟨w,t⟩ ∈ B }. -/
+/-- The times at which `B` is instantiated in some world of `worlds` (46). -/
 def instTimes (worlds : Set W) (B : Set (W × T)) : Set T :=
   { t | ∃ w ∈ worlds, (w, t) ∈ B }
 
-/-- `earliest` across alternatives: the earliest time at which B is
-    instantiated in any world of `alt(w,t)`.
+/-- The earliest `B`-time across the historical alternatives of `w` at `t`
+(46): the least instantiation time, as `maxOnScale .lt`. -/
+def earliestAlt (alt : HistoricalAlternatives W T) (B : Set (W × T))
+    (w : W) (t : T) : Set T :=
+  maxOnScale .lt (instTimes (alt ⟨w, t⟩) B)
 
-    Uses `maxOnScale .lt` which selects elements dominated by all others
-    on the < ordering — i.e., the minimum / GLB. This is the same operator
-    [rett-2020] uses for her MAX₍<₎. -/
-def earliestAlt (alt : HistAlt W T) (B : Set (W × T)) (w : W) (t : T) : Set T :=
-  maxOnScale .lt (instTimes (alt w t) B)
-
-/-- Membership in `earliestAlt` is exactly mathlib's `IsLeast` on the
-    instantiation-times set: B&C's `earliest` operator is the least element
-    of `instTimes`, computed via `maxOnScale .lt`. -/
-theorem mem_earliestAlt_iff_isLeast (alt : HistAlt W T) (B : Set (W × T))
-    (w : W) (t te : T) :
-    te ∈ earliestAlt alt B w t ↔ IsLeast (instTimes (alt w t) B) te := by
+/-- The `earliest` operator picks out exactly the least instantiation time. -/
+theorem mem_earliestAlt_iff_isLeast (alt : HistoricalAlternatives W T)
+    (B : Set (W × T)) (w : W) (t te : T) :
+    te ∈ earliestAlt alt B w t ↔ IsLeast (instTimes (alt ⟨w, t⟩) B) te := by
   constructor
   · rintro ⟨hmem, hmin⟩
     refine ⟨hmem, λ y hy => ?_⟩
@@ -194,234 +91,113 @@ theorem mem_earliestAlt_iff_isLeast (alt : HistAlt W T) (B : Set (W × T))
   · rintro ⟨hmem, hlb⟩
     exact ⟨hmem, λ y hy hne => lt_of_le_of_ne (hlb hy) (Ne.symm hne)⟩
 
-/-- B&C's `earliest` is defined (nonempty) exactly when [sharvit-2014]'s
-    `EARLIEST` presupposition (`hasEarliest`, with trivial restrictor)
-    holds of the instantiation times. This is the definedness condition that
-    fails for quantificational
-    pasts on a dense time axis. -/
-theorem earliestAlt_nonempty_iff_hasEarliest (alt : HistAlt W T) (B : Set (W × T))
-    (w : W) (t : T) :
-    (earliestAlt alt B w t).Nonempty ↔
-    hasEarliest Set.univ (· ∈ instTimes (alt w t) B) := by
-  unfold hasEarliest
-  simp only [Set.Nonempty, mem_earliestAlt_iff_isLeast, Set.mem_univ, true_and,
-             Set.setOf_mem_eq]
+/-! ### The uniform truth conditions (47) -/
 
--- ============================================================================
--- § 3: B&C's Truth Conditions
--- ============================================================================
+/-- The uniform temporal connective (47): some main-clause time in `w` stands
+in `cmp` to the earliest temporal-clause time across the historical
+alternatives at that time. *Before* and *after* differ only in `cmp`. -/
+def connective (cmp : T → T → Prop) (A B : Set (W × T))
+    (alt : HistoricalAlternatives W T) (w : W) : Prop :=
+  ∃ t, (w, t) ∈ A ∧ ∃ te ∈ earliestAlt alt B w t, cmp t te
 
-/-- B&C's *after*: ∃t : ⟨w,t⟩ ∈ A, t > earliest_{alt(w,t)}(B).
+/-- *A before B* (47). -/
+abbrev before (A B : Set (W × T)) (alt : HistoricalAlternatives W T)
+    (w : W) : Prop :=
+  connective (· < ·) A B alt w
 
-    "There is a time at which A is true in w, and that time is later than
-    the earliest time at which B is true in any historical alternative." -/
-def BC.after (A B : Set (W × T)) (alt : HistAlt W T) (w : W) : Prop :=
-  ∃ t, (w, t) ∈ A ∧ ∃ te ∈ earliestAlt alt B w t, t > te
+/-- *A after B* (47). -/
+abbrev after (A B : Set (W × T)) (alt : HistoricalAlternatives W T)
+    (w : W) : Prop :=
+  connective (· > ·) A B alt w
 
-/-- B&C's *before*: ∃t : ⟨w,t⟩ ∈ A, t < earliest_{alt(w,t)}(B).
+/-! ### Instantiation and veridicality (§6) -/
 
-    "There is a time at which A is true in w, and that time is earlier than
-    the earliest time at which B is true in any historical alternative." -/
-def BC.before (A B : Set (W × T)) (alt : HistAlt W T) (w : W) : Prop :=
-  ∃ t, (w, t) ∈ A ∧ ∃ te ∈ earliestAlt alt B w t, t < te
-
--- ============================================================================
--- § 4: Instantiation and the Three Readings of *Before*
--- ============================================================================
-
-/-- B is instantiated in world w: ∃t, ⟨w,t⟩ ∈ B. -/
+/-- `B` is instantiated in `w`: it holds of some time there. -/
 def Inst (B : Set (W × T)) (w : W) : Prop :=
   ∃ t, (w, t) ∈ B
 
-/-- B is instantiated in some alternative of w at t. -/
-def InstAlt (B : Set (W × T)) (alt : HistAlt W T) (w : W) (t : T) : Prop :=
-  ∃ w' ∈ alt w t, Inst B w'
+/-- *After* is veridical (§6): under the initial branch point condition, the
+earliest `B`-time precedes the `A`-time, so branching has not yet happened
+there and the `B`-event lies on the actual branch. `eventLocal` says `B` only
+cares about matters of particular fact, which agreeing worlds share. -/
+theorem after_veridical (A B : Set (W × T)) (alt : HistoricalAlternatives W T)
+    (agree : T → W → W → Prop)
+    (hIBP : initialBranchPoint alt agree)
+    (eventLocal : ∀ w w' t, agree t w w' → (w', t) ∈ B → (w, t) ∈ B)
+    (w : W) :
+    after A B alt w → Inst B w := by
+  rintro ⟨t_A, _, t_B, ⟨⟨w', hw'_alt, hw'_B⟩, _⟩, ht_lt⟩
+  exact ⟨t_B, eventLocal w w' t_B (hIBP w t_A w' hw'_alt t_B ht_lt) hw'_B⟩
 
-/-- The three contextual readings of *before* (B&C §5).
+/-- With trivial alternatives — B&C set `alt(w,t) = {w}` whenever `B` is
+instantiated in `w` — the connectives reduce to the extensional (45): the
+earliest `B`-time of `w` itself. -/
+theorem connective_singleton_alt (cmp : T → T → Prop) (A B : Set (W × T))
+    (alt : HistoricalAlternatives W T) (w : W) (h : ∀ t, alt ⟨w, t⟩ = {w}) :
+    connective cmp A B alt w ↔
+      ∃ t, (w, t) ∈ A ∧ ∃ te, IsLeast {t' | (w, t') ∈ B} te ∧ cmp t te := by
+  have hs : ∀ t : T, instTimes (alt ⟨w, t⟩) B = {t' | (w, t') ∈ B} := fun t => by
+    rw [h t]; ext t'; simp [instTimes]
+  refine exists_congr fun t => and_congr_right fun _ => exists_congr fun te =>
+    and_congr_left fun _ => ?_
+  rw [mem_earliestAlt_iff_isLeast, hs t]
 
-    Since *before* quantifies over historical alternatives, the reading
-    depends on whether B is instantiated in the actual world:
-    - **Veridical**: B happens in the actual world and in alternatives
-    - **Counterfactual**: B doesn't happen in the actual world but does
-      in some alternative (the "barely prevented" reading)
-    - **NonCommittal**: context is compatible with both -/
+/-- Even a non-veridical *before* locates `B` on a branch (49): if the
+connective holds at `w`, some main-clause time has a historical alternative
+in which `B` is instantiated. -/
+theorem connective_alt_inst (cmp : T → T → Prop) (A B : Set (W × T))
+    (alt : HistoricalAlternatives W T) (w : W) :
+    connective cmp A B alt w →
+      ∃ t, (w, t) ∈ A ∧ ∃ w' ∈ alt ⟨w, t⟩, Inst B w' := by
+  rintro ⟨t, htA, te, ⟨⟨w', hw', hB⟩, -⟩, -⟩
+  exact ⟨t, htA, w', hw', te, hB⟩
+
+/-! ### The three readings of *before* (48) -/
+
+/-- The three contextual readings of *before* (48). -/
 inductive BeforeReading where
   | veridical
   | counterfactual
   | nonCommittal
   deriving DecidableEq, Repr
 
-/-- Classify a *before* sentence into its reading based on whether B
-    is instantiated in the actual world w.
+/-- Veridical reading (48): every context world instantiates `B`. -/
+def Veridical (B : Set (W × T)) (context : Set W) : Prop :=
+  ∀ w ∈ context, Inst B w
 
-    Uses classical decidability since the underlying propositions involve
-    arbitrary set membership. -/
-noncomputable def classifyBeforeReading [∀ p : Prop, Decidable p]
-    (B : Set (W × T)) (_w : W)
-    (contextWorlds : Set W) : BeforeReading :=
-  if (∀ w' ∈ contextWorlds, Inst B w') then .veridical
-  else if (∀ w' ∈ contextWorlds, ¬Inst B w') then .counterfactual
-  else .nonCommittal
+/-- Counterfactual reading (48): no context world instantiates `B`. -/
+def Counterfactual (B : Set (W × T)) (context : Set W) : Prop :=
+  ∀ w ∈ context, ¬Inst B w
 
--- ============================================================================
--- § 5: Veridicality of *After*
--- ============================================================================
+/-- Non-committal reading (48): some context worlds instantiate `B` and some
+do not. -/
+def NonCommittal (B : Set (W × T)) (context : Set W) : Prop :=
+  (∃ w ∈ context, Inst B w) ∧ ∃ w ∈ context, ¬Inst B w
 
-/-- *After* is veridical under the initial branch point condition: if
-    `after(A,B)` holds at w, then B is instantiated in w.
+omit [LinearOrder T] in
+/-- The three readings are mutually exclusive and exhaust the nonempty
+contexts (48). -/
+theorem readings_partition (B : Set (W × T)) (context : Set W)
+    (hc : context.Nonempty) :
+    (Veridical B context ∨ Counterfactual B context ∨ NonCommittal B context) ∧
+      ¬(Veridical B context ∧ Counterfactual B context) ∧
+      ¬(Veridical B context ∧ NonCommittal B context) ∧
+      ¬(Counterfactual B context ∧ NonCommittal B context) := by
+  obtain ⟨w0, hw0⟩ := hc
+  refine ⟨?_, fun ⟨hv, hcf⟩ => hcf w0 hw0 (hv w0 hw0),
+    fun ⟨hv, _, w, hw, hnw⟩ => hnw (hv w hw),
+    fun ⟨hcf, ⟨w, hw, hiw⟩, _⟩ => hcf w hw hiw⟩
+  by_cases hv : Veridical B context
+  · exact Or.inl hv
+  by_cases hcf : Counterfactual B context
+  · exact Or.inr (Or.inl hcf)
+  refine Or.inr (Or.inr ⟨?_, ?_⟩)
+  · by_contra hno
+    exact hcf fun w hw hi => hno ⟨w, hw, hi⟩
+  · by_contra hno
+    exact hv fun w hw => Classical.byContradiction fun hn => hno ⟨w, hw, hn⟩
 
-    The key reasoning (B&C §4): A is at ⟨w,t_A⟩ and B is at ⟨w',t_B⟩ for
-    some w' ∈ alt(w,t_A). Since t_B < t_A (earliest before A), and
-    alt(w,t_A) branches only after t_A, w and w' agree at t_B. So if
-    ⟨w',t_B⟩ ∈ B, the "same event" exists at ⟨w,t_B⟩.
-
-    We formalize this with `eventLocal`: if w' agrees with w at t_B
-    and ⟨w',t_B⟩ ∈ B, then ⟨w,t_B⟩ ∈ B. -/
-theorem BC.after_veridical
-    (A B : Set (W × T)) (alt : HistAlt W T)
-    (agree : T → W → W → Prop)
-    (hIBP : initialBranchPoint alt agree)
-    (eventLocal : ∀ w w' t, agree t w w' → (w', t) ∈ B → (w, t) ∈ B)
-    (w : W) :
-    BC.after A B alt w → Inst B w := by
-  rintro ⟨t_A, _, t_B, ⟨⟨w', hw'_alt, hw'_B⟩, _⟩, ht_lt⟩
-  -- w' ∈ alt(w, t_A) and (w', t_B) ∈ B, with t_B < t_A
-  -- By IBP: agree t_B w w'. By eventLocal: (w, t_B) ∈ B.
-  exact ⟨t_B, eventLocal w w' t_B (hIBP w t_A w' hw'_alt t_B ht_lt) hw'_B⟩
-
--- ============================================================================
--- § 6: Uniformity
--- ============================================================================
-
-/-- B&C's key claim: *before* and *after* use the same `earliestAlt` operator.
-    The only difference is the comparison direction (< vs >). This is the
-    "uniform analysis" — the veridicality asymmetry is not lexical but
-    structural, following from branching time. -/
-theorem BC.uniform_structure (A B : Set (W × T)) (alt : HistAlt W T) (w : W) :
-    (BC.before A B alt w ↔ ∃ t, (w, t) ∈ A ∧ ∃ te ∈ earliestAlt alt B w t, t < te) ∧
-    (BC.after A B alt w ↔ ∃ t, (w, t) ∈ A ∧ ∃ te ∈ earliestAlt alt B w t, t > te) :=
-  ⟨Iff.rfl, Iff.rfl⟩
-
--- ============================================================================
--- § 7: O&ST Event-Relative Equivalence (def 17)
--- ============================================================================
-
-/-! [ogihara-steinert-threlkeld-2024] §4 propose revising B&C's equivalence
-    relation to be sensitive to both an interval I and an eventuality e. The key
-    idea: alternative worlds must contain a counterpart of e that co-occurs with
-    e throughout the interval [START_w(e₁), START(I)), and worlds must be
-    identical at all earlier intervals.
-
-    This allows w₂ to become distinct from w₁ before I as long as they contain
-    events that start simultaneously, share the same set of participants, and
-    run up until I (not necessarily including I). -/
-
-/-- Counterpart relation on eventualities across worlds
-    ([ogihara-steinert-threlkeld-2024], fn. 18): counterpart eventualities
-    share essential properties such as starting time and thematic participants. -/
-abbrev Counterpart (W T : Type*) := W → T → W → T → Prop
-
-/-- **Event-relative equivalence** ≃_{I,e₁}
-    ([ogihara-steinert-threlkeld-2024], def 17).
-
-    For worlds w₁, w₂ ∈ W, interval I, and eventuality e₁ in w₁,
-    w₁ ≃_{I,e₁} w₂ iff:
-
-    (i) there is an eventuality e₂ in w₂ understood as e₁'s counterpart;
-    (ii) e₁ and e₂ co-occur throughout [START_{w₁}(e₁), START(I));
-    (iii) at all intervals I₁ < START_{w₁}(e₁), w₁ and w₂ are identical.
-
-    The `coOccur` parameter models condition (ii): both eventualities occur
-    throughout the interval [start_e, start_I). The `agree` parameter
-    models condition (iii): world identity at earlier intervals. -/
-def equivIE
-    (counterpart : Counterpart W T)
-    (coOccur : W → T → W → T → T → T → Prop)
-    (agree : T → W → W → Prop)
-    (w₁ w₂ : W) (startI : T) (e₁_start : T) : Prop :=
-  -- (i) counterpart exists
-  counterpart w₁ e₁_start w₂ e₁_start ∧
-  -- (ii) co-occurrence throughout [start_e, start_I)
-  coOccur w₁ e₁_start w₂ e₁_start e₁_start startI ∧
-  -- (iii) identical at all earlier times
-  (∀ t', t' < e₁_start → agree t' w₁ w₂)
-
--- ============================================================================
--- § 8: Revamped Alternative Set (def 18)
--- ============================================================================
-
-/-! The revised alt(w, I, e) uses the eventuality-relative equivalence
-    ([ogihara-steinert-threlkeld-2024], def 18a). -/
-
-/-- **Event-relative alternatives** alt(w, I, e)
-    ([ogihara-steinert-threlkeld-2024], def 18a):
-    alt(w, I, e) ⊆ {w' : w ≃_{I,e} w'}. -/
-def altIE
-    (counterpart : Counterpart W T)
-    (coOccur : W → T → W → T → T → T → Prop)
-    (agree : T → W → W → Prop)
-    (w : W) (startI : T) (e_start : T) : Set W :=
-  { w' | equivIE counterpart coOccur agree w w' startI e_start }
-
-/-- **Event continuation condition** ([ogihara-steinert-threlkeld-2024], def 18b):
-    alt(w, I, e) contains only those worlds w' in which the counterpart
-    eventuality of e develops beyond I, as long as this is reasonable.
-    Modeled as a predicate on the alternative set. -/
-def eventContinuation (alt : Set W) (continues : W → Prop) : Set W :=
-  { w' ∈ alt | continues w' }
-
-/-- **Downward closure** ([ogihara-steinert-threlkeld-2024], def 18c):
-    If w ≃_{I,e} w' and I' < I, then w ≃_{I',e} w'.
-    Earlier equivalence classes are supersets. -/
-theorem equivIE_downward_closed
-    (counterpart : Counterpart W T)
-    (coOccur : W → T → W → T → T → T → Prop)
-    (coOccur_mono : ∀ w₁ e₁ w₂ e₂ s₁ s₂ s₂',
-      s₂' ≤ s₂ → coOccur w₁ e₁ w₂ e₂ s₁ s₂ → coOccur w₁ e₁ w₂ e₂ s₁ s₂')
-    (agree : T → W → W → Prop)
-    (w₁ w₂ : W) (startI startI' : T) (e_start : T)
-    (hle : startI' ≤ startI)
-    (h : equivIE counterpart coOccur agree w₁ w₂ startI e_start) :
-    equivIE counterpart coOccur agree w₁ w₂ startI' e_start :=
-  ⟨h.1, coOccur_mono w₁ e_start w₂ e_start e_start startI startI' hle h.2.1, h.2.2⟩
-
--- ============================================================================
--- § 9: equivIE Generalizes initialBranchPoint
--- ============================================================================
-
-/-! O&ST's eventuality-relative equivalence ≃_{I,e} is a strict generalization
-    of B&C's initial branch point condition. Under trivial counterpart and
-    co-occurrence relations (always true), `equivIE` reduces to condition (iii)
-    alone: identity at all times before the eventuality's start — which is
-    exactly B&C's `initialBranchPoint` restricted to a single world pair.
-
-    This shows that the O&ST framework subsumes B&C: any `HistAlt` satisfying
-    `initialBranchPoint` can be recovered as an `altIE` with trivial parameters. -/
-
-/-- Under trivial counterpart (always holds) and trivial co-occurrence (always
-    holds), `equivIE` reduces to B&C's condition (iii): agreement at all
-    earlier times. This is the per-world-pair content of `initialBranchPoint`. -/
-theorem equivIE_trivial_iff_agree
-    (agree : T → W → W → Prop)
-    (w₁ w₂ : W) (startI e_start : T) :
-    equivIE (fun _ _ _ _ => True) (fun _ _ _ _ _ _ => True) agree w₁ w₂ startI e_start ↔
-    (∀ t', t' < e_start → agree t' w₁ w₂) := by
-  simp [equivIE]
-
-/-- B&C's `alt(w,t)` under `initialBranchPoint` is a subset of `altIE` with
-    trivial counterpart/co-occurrence, when the eventuality starts at t.
-    That is: any world sharing w's history up to t (B&C-style) also satisfies
-    the trivial ≃_{I,e} (O&ST-style). -/
-theorem histAlt_subset_altIE_trivial
-    (alt : HistAlt W T) (agree : T → W → W → Prop)
-    (hIBP : initialBranchPoint alt agree)
-    (w : W) (t : T) :
-    alt w t ⊆ altIE (fun _ _ _ _ => True) (fun _ _ _ _ _ _ => True) agree w t t := by
-  intro w' hw'
-  rw [altIE, Set.mem_ofPred_eq, equivIE_trivial_iff_agree]
-  exact hIBP w t w' hw'
-
-/-! ### The classical rendering: complement monotonicity and overgeneration (§5–§6) -/
+/-! ### The classical rendering: complement monotonicity and overgeneration -/
 
 section Classical
 

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -138,12 +138,12 @@ structure BCCounterexampleDatum where
     branching architecture cannot handle complements whose temporal bound
     falls before the A-time. -/
 theorem bc_cannot_place_bounded_complement
-    {W : Type*} (alt : HistAlt W ℤ)
+    {W : Type*} (alt : HistoricalAlternatives W ℤ)
     (B : Set (W × ℤ)) (w : W) (tA hi : ℤ)
     (hBound : hi ≤ tA)
     (_hBounded : ∀ w' t, (w', t) ∈ B → t ≤ hi)
-    (hNoFuture : ∀ w' ∈ alt w tA, ∀ t, (w', t) ∈ B → t ≤ hi) :
-    ∀ te ∈ instTimes (alt w tA) B, te ≤ tA := by
+    (hNoFuture : ∀ w' ∈ alt ⟨w, tA⟩, ∀ t, (w', t) ∈ B → t ≤ hi) :
+    ∀ te ∈ instTimes (alt ⟨w, tA⟩) B, te ≤ tA := by
   intro te ⟨w', _, hw'B⟩
   exact le_trans (hNoFuture w' ‹_› te hw'B) hBound
 
@@ -947,5 +947,81 @@ theorem bc_readings_in_data :
     before_counterfactual.complementEntailed = false ∧
     before_noncommittal.complementEntailed = false :=
   ⟨rfl, rfl, rfl⟩
+
+
+/-! ### The event-relative equivalence and alternatives (defs 17–18)
+
+The paper's positive proposal replaces [beaver-condoravdi-2003]'s world–time
+equivalence with one relative to an interval `I` and an eventuality `e`:
+alternative worlds must contain a counterpart of `e` that co-occurs with it up
+to `I`, and be identical at all earlier times. -/
+
+section EventRelative
+
+variable {W T : Type*} [LinearOrder T]
+
+/-- Counterpart relation on eventualities across worlds (fn. 18): counterpart
+eventualities share essential properties such as starting time and thematic
+participants. -/
+abbrev Counterpart (W T : Type*) := W → T → W → T → Prop
+
+/-- Event-relative equivalence ≃_{I,e₁} (def 17): (i) a counterpart of `e₁`
+exists in `w₂`; (ii) the two co-occur throughout [START(e₁), START(I)); (iii)
+the worlds are identical at all earlier times. -/
+def equivIE (counterpart : Counterpart W T)
+    (coOccur : W → T → W → T → T → T → Prop)
+    (agree : T → W → W → Prop)
+    (w₁ w₂ : W) (startI : T) (e₁_start : T) : Prop :=
+  counterpart w₁ e₁_start w₂ e₁_start ∧
+  coOccur w₁ e₁_start w₂ e₁_start e₁_start startI ∧
+  (∀ t', t' < e₁_start → agree t' w₁ w₂)
+
+/-- Event-relative alternatives alt(w, I, e) (def 18a). -/
+def altIE (counterpart : Counterpart W T)
+    (coOccur : W → T → W → T → T → T → Prop)
+    (agree : T → W → W → Prop)
+    (w : W) (startI : T) (e_start : T) : Set W :=
+  { w' | equivIE counterpart coOccur agree w w' startI e_start }
+
+/-- Event continuation (def 18b): keep only the alternatives in which the
+counterpart eventuality develops beyond `I`. -/
+def eventContinuation (alt : Set W) (continues : W → Prop) : Set W :=
+  { w' ∈ alt | continues w' }
+
+/-- Downward closure (def 18c): equivalence at `I` implies equivalence at any
+earlier `I'`. -/
+theorem equivIE_downward_closed (counterpart : Counterpart W T)
+    (coOccur : W → T → W → T → T → T → Prop)
+    (coOccur_mono : ∀ w₁ e₁ w₂ e₂ s₁ s₂ s₂',
+      s₂' ≤ s₂ → coOccur w₁ e₁ w₂ e₂ s₁ s₂ → coOccur w₁ e₁ w₂ e₂ s₁ s₂')
+    (agree : T → W → W → Prop)
+    (w₁ w₂ : W) (startI startI' : T) (e_start : T)
+    (hle : startI' ≤ startI)
+    (h : equivIE counterpart coOccur agree w₁ w₂ startI e_start) :
+    equivIE counterpart coOccur agree w₁ w₂ startI' e_start :=
+  ⟨h.1, coOccur_mono w₁ e_start w₂ e_start e_start startI startI' hle h.2.1, h.2.2⟩
+
+/-- With trivial counterpart and co-occurrence, ≃_{I,e} is agreement at all
+earlier times — the per-world-pair content of B&C's initial branch point
+condition. -/
+theorem equivIE_trivial_iff_agree (agree : T → W → W → Prop)
+    (w₁ w₂ : W) (startI e_start : T) :
+    equivIE (fun _ _ _ _ => True) (fun _ _ _ _ _ _ => True) agree w₁ w₂ startI e_start ↔
+    (∀ t', t' < e_start → agree t' w₁ w₂) := by
+  simp [equivIE]
+
+/-- Any B&C alternative set obeying the initial branch point condition lands
+inside the trivial event-relative alternatives: the O&ST equivalence
+generalizes B&C's. -/
+theorem histAlt_subset_altIE_trivial (alt : HistoricalAlternatives W T)
+    (agree : T → W → W → Prop)
+    (hIBP : BeaverCondoravdi2003.initialBranchPoint alt agree)
+    (w : W) (t : T) :
+    alt ⟨w, t⟩ ⊆ altIE (fun _ _ _ _ => True) (fun _ _ _ _ _ _ => True) agree w t t := by
+  intro w' hw'
+  rw [altIE, Set.mem_ofPred_eq, equivIE_trivial_iff_agree]
+  exact hIBP w t w' hw'
+
+end EventRelative
 
 end OgiharaSteinertThrelkeld2024.VeridicalityBridge

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -36,10 +36,25 @@ no-tenseless assumption (§6.1, p. 299).
 
 namespace Sharvit2014
 
-open BeaverCondoravdi2003 (hasEarliest)
 open Tense.Decomposition (sotDeletionApplicable)
 open Tense.TenseAspectComposition (evalPast evalRel)
 open Semantics.Aspect (PointPred)
+
+/-- The `EARLIEST` definedness presupposition of `before^{B&C}`: `EARLIEST_C` is defined for
+    body `p` iff the set of `C`-times where `p` holds has a least element (mathlib's
+    `IsLeast`). -/
+def hasEarliest {Time : Type*} [LinearOrder Time] (C : Set Time) (p : Time → Prop) : Prop :=
+  ∃ t, IsLeast {t' | t' ∈ C ∧ p t'} t
+
+/-- [beaver-condoravdi-2003]'s `earliest` is defined exactly when the `EARLIEST`
+    presupposition holds of the instantiation times, with trivial restrictor. -/
+theorem earliestAlt_nonempty_iff_hasEarliest {W Time : Type*} [LinearOrder Time]
+    (alt : HistoricalAlternatives W Time) (B : Set (W × Time)) (w : W) (t : Time) :
+    (BeaverCondoravdi2003.earliestAlt alt B w t).Nonempty ↔
+      hasEarliest Set.univ (· ∈ BeaverCondoravdi2003.instTimes (alt ⟨w, t⟩) B) := by
+  unfold hasEarliest
+  simp only [Set.Nonempty, BeaverCondoravdi2003.mem_earliestAlt_iff_isLeast, Set.mem_univ,
+    true_and, Set.ofPred_mem_eq]
 
 /-! ### The two lexical types of tense ((30)) -/
 
@@ -74,7 +89,7 @@ theorem evalPast_iff_quantificationalPast {W Time : Type*} [LinearOrder Time]
 /-- IPF ([sharvit-2014] (27), p. 272): when the body of `before^{B&C}` is the
     quantificational past `[[PAST]]^{K,g}(q)`, and the restrictor `C` is
     order-dense (interval-like) with `K ⊆ C`, the `EARLIEST` presupposition
-    (`BeaverCondoravdi2003.hasEarliest`) fails: a witness `t_q < t_min` with `q t_q` lifts
+    (`hasEarliest`) fails: a witness `t_q < t_min` with `q t_q` lifts
     via density to a strictly smaller body-witness. The technical core of the
     thesis that only languages with pronominal tenses license past-under-past
     in `before`-clauses. -/
@@ -349,7 +364,7 @@ theorem eq99c_before_and_no_simultaneous_imply_no_bare_pshift (L : LanguageTense
 /-! ### Substrate connection: IPF and quantificational past
 
 The `wellFormedPastUnderPastBefore` predicate is grounded in the [beaver-condoravdi-2003] IPF
-result formalized via `BeaverCondoravdi2003.hasEarliest`; the two theorems below consume that
+result formalized via `hasEarliest`; the two theorems below consume that
 grounding via `wellFormedPastUnderPastBefore_iff_pronominal`. -/
 
 /-- Quantificational-past languages (Japanese) fail `wellFormedPastUnderPastBefore`, matching the

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -53,7 +53,7 @@ theorem earliestAlt_nonempty_iff_hasEarliest {W Time : Type*} [LinearOrder Time]
     (BeaverCondoravdi2003.earliestAlt alt B w t).Nonempty ↔
       hasEarliest Set.univ (· ∈ BeaverCondoravdi2003.instTimes (alt ⟨w, t⟩) B) := by
   unfold hasEarliest
-  simp only [Set.Nonempty, BeaverCondoravdi2003.mem_earliestAlt_iff_isLeast, Set.mem_univ,
+  simp only [Set.Nonempty, BeaverCondoravdi2003.earliestAlt, Set.mem_ofPred_eq, Set.mem_univ,
     true_and, Set.ofPred_mem_eq]
 
 /-! ### The two lexical types of tense ((30)) -/


### PR DESCRIPTION
Recut against the SALT 13 paper (read in full): before/after as one connective with opposite orderings (uniformity by construction, replacing an Iff.rfl theorem); the curried HistAlt alias and its six bridge lemmas dissolve into the HistoricalAlternatives substrate; the (48) readings become a partition theorem; chronology-violating content moves to its owners (hasEarliest to Sharvit2014, O&ST defs 17-18 to OgiharaSteinertThrelkeld2024); 19 examples in Data/Examples.