### PR TITLE
refactor(Studies/Beavers2010): the MAP as weak covering

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -349,6 +349,7 @@ import Linglib.Data.Examples.Barker2002
 import Linglib.Data.Examples.BarwiseCooper1981
 import Linglib.Data.Examples.Beaver2001
 import Linglib.Data.Examples.BeaverCondoravdi2003
+import Linglib.Data.Examples.Beavers2010
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015

--- a/Linglib/Data/Examples/Beavers2010.json
+++ b/Linglib/Data/Examples/Beavers2010.json
@@ -1,0 +1,292 @@
+[
+  {
+    "id": "beavers2010_9a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(9a)"},
+    "language": "stan1293",
+    "primaryText": "John loaded the hay onto the wagon.",
+    "glossedTokens": [],
+    "translation": "John loaded the hay onto the wagon.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["direct", "theme"]
+    ],
+    "comment": "Theme object: all the hay moved (quantized); the wagon at least partly filled (nonquantized)."
+  },
+  {
+    "id": "beavers2010_9b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(9b)"},
+    "language": "stan1293",
+    "primaryText": "John loaded the wagon with the hay.",
+    "glossedTokens": [],
+    "translation": "John loaded the wagon with the hay.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["direct", "location"]
+    ],
+    "comment": "Location object: the wagon completely filled (quantized); the hay at least partly moved (nonquantized) — Anderson's holistic effect."
+  },
+  {
+    "id": "beavers2010_10a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(10a)"},
+    "language": "stan1293",
+    "primaryText": "Kim loaded the hay onto the wagon, but still needed a truck for the rest.",
+    "glossedTokens": [],
+    "translation": "Kim loaded the hay onto the wagon, but still needed a truck for the rest.",
+    "context": "",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["diagnostic", "holistic effect"]
+    ],
+    "comment": "Infelicitous: the theme object entails total movement."
+  },
+  {
+    "id": "beavers2010_18a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(18a)"},
+    "language": "stan1293",
+    "primaryText": "John cut the diamond on the glass.",
+    "glossedTokens": [],
+    "translation": "John cut the diamond on the glass.",
+    "context": "John moves a sharp-edged diamond forcefully into contact with a piece of glass.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["verb class", "cut/slice"]
+    ],
+    "comment": "Diamond affected: the object is damaged (nonquantized), the oblique only potentially (potential)."
+  },
+  {
+    "id": "beavers2010_18b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(18b)"},
+    "language": "stan1293",
+    "primaryText": "John cut the glass with the diamond.",
+    "glossedTokens": [],
+    "translation": "John cut the glass with the diamond.",
+    "context": "Same scenario; the glass is damaged rather than the diamond.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["verb class", "cut/slice"]
+    ],
+    "comment": "No holistic effect, so locative alternations are not in general governed by aspect."
+  },
+  {
+    "id": "beavers2010_20a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(20a)"},
+    "language": "stan1293",
+    "primaryText": "Marie cut the rope.",
+    "glossedTokens": [],
+    "translation": "Marie cut the rope.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "cut"]
+    ],
+    "comment": "The rope is cut, to no specific degree: nonquantized change."
+  },
+  {
+    "id": "beavers2010_20b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(20b)"},
+    "language": "stan1293",
+    "primaryText": "Marie cut at the rope.",
+    "glossedTokens": [],
+    "translation": "Marie cut at the rope.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "cut"]
+    ],
+    "comment": "The rope may or may not be cut: potential for change only."
+  },
+  {
+    "id": "beavers2010_21a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(21a)"},
+    "language": "stan1293",
+    "primaryText": "Marie ate her cake.",
+    "glossedTokens": [],
+    "translation": "Marie ate her cake.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "consumption"]
+    ],
+    "comment": "All (or a contextually significant amount) of the cake consumed: quantized change."
+  },
+  {
+    "id": "beavers2010_21b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(21b)"},
+    "language": "stan1293",
+    "primaryText": "Marie ate at her cake.",
+    "glossedTokens": [],
+    "translation": "Marie ate at her cake.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "consumption"]
+    ],
+    "comment": "At least some consumed, not necessarily all: nonquantized change."
+  },
+  {
+    "id": "beavers2010_22a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(22a)"},
+    "language": "stan1293",
+    "primaryText": "Marie hit Defarge.",
+    "glossedTokens": [],
+    "translation": "Marie hit Defarge.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "impact"]
+    ],
+    "comment": "Defarge is hit but not necessarily affected: potential for change."
+  },
+  {
+    "id": "beavers2010_22b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(22b)"},
+    "language": "stan1293",
+    "primaryText": "Marie hit at Defarge.",
+    "glossedTokens": [],
+    "translation": "Marie hit at Defarge.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "conative"],
+      ["verb class", "impact"]
+    ],
+    "comment": "Defarge not necessarily even hit: unspecified for change (double modality)."
+  },
+  {
+    "id": "beavers2010_24a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(24a)"},
+    "language": "stan1293",
+    "primaryText": "John hit the fence with the stick.",
+    "glossedTokens": [],
+    "translation": "John hit the fence with the stick.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "locative"],
+      ["contrast", "none"]
+    ],
+    "comment": "Alternates with 'John hit the stick against the fence' with no truth-conditional contrast — the equal-role case the MAP permits."
+  },
+  {
+    "id": "beavers2010_29",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(29)"},
+    "language": "stan1293",
+    "primaryText": "The tailor lengthened the jeans to 32ins.",
+    "glossedTokens": [],
+    "translation": "The tailor lengthened the jeans to 32ins.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["degree", "quantized"],
+      ["diagnostic", "telicity"]
+    ],
+    "comment": "Specific predicate-supplied result state: telic, quantized change."
+  },
+  {
+    "id": "beavers2010_30",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(30)"},
+    "language": "stan1293",
+    "primaryText": "The tailor lengthened the jeans.",
+    "glossedTokens": [],
+    "translation": "The tailor lengthened the jeans.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["degree", "nonquantized"],
+      ["diagnostic", "telicity"]
+    ],
+    "comment": "Some result on the length scale, unspecified which: atelic, nonquantized change."
+  },
+  {
+    "id": "beavers2010_81a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(81a)"},
+    "language": "stan1293",
+    "primaryText": "John climbed the stairs.",
+    "glossedTokens": [],
+    "translation": "John climbed the stairs.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "traversal"],
+      ["degree", "totally traversed"]
+    ],
+    "comment": "The stairs all traversed; the affected participant is John (quantized change of location)."
+  },
+  {
+    "id": "beavers2010_81b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(81b)"},
+    "language": "stan1293",
+    "primaryText": "John climbed up the stairs.",
+    "glossedTokens": [],
+    "translation": "John climbed up the stairs.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "traversal"],
+      ["degree", "traversed"]
+    ],
+    "comment": "The stairs all or partly traversed: the oblique weakens total traversal to mere traversal."
+  },
+  {
+    "id": "beavers2010_88a",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(88a)"},
+    "language": "stan1293",
+    "primaryText": "Kim mailed London a ball.",
+    "glossedTokens": [],
+    "translation": "Kim mailed London a ball.",
+    "context": "",
+    "judgment": "marginal",
+    "readings": [
+      {"name": "London as an agency (Scotland Yard reading)", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["alternation", "dative"],
+      ["direct", "recipient"]
+    ],
+    "comment": "Indirect objects must be prospective possessors: the goal-only reading is out."
+  },
+  {
+    "id": "beavers2010_88b",
+    "source": {"bibkey": "beavers-2010", "paperLabel": "(88b)"},
+    "language": "stan1293",
+    "primaryText": "Kim mailed a ball to London.",
+    "glossedTokens": [],
+    "translation": "Kim mailed a ball to London.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["alternation", "dative"],
+      ["oblique", "goal"]
+    ],
+    "comment": "The to-variant needs only a goal: the indirect object monotonically adds prospective possession (90)."
+  }
+]

--- a/Linglib/Data/Examples/Beavers2010.lean
+++ b/Linglib/Data/Examples/Beavers2010.lean
@@ -1,0 +1,342 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Beavers2010` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Beavers2010.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Beavers2010.Examples`.
+-/
+
+namespace Beavers2010.Examples
+
+open Data.Examples
+
+def ex_9a : LinguisticExample :=
+  { id := "beavers2010_9a"
+    source := ⟨"beavers-2010", "(9a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John loaded the hay onto the wagon."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John loaded the hay onto the wagon."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("direct", "theme")]
+    comment := "Theme object: all the hay moved (quantized); the wagon at least partly filled (nonquantized)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_9b : LinguisticExample :=
+  { id := "beavers2010_9b"
+    source := ⟨"beavers-2010", "(9b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John loaded the wagon with the hay."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John loaded the wagon with the hay."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("direct", "location")]
+    comment := "Location object: the wagon completely filled (quantized); the hay at least partly moved (nonquantized) — Anderson's holistic effect."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_10a : LinguisticExample :=
+  { id := "beavers2010_10a"
+    source := ⟨"beavers-2010", "(10a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Kim loaded the hay onto the wagon, but still needed a truck for the rest."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Kim loaded the hay onto the wagon, but still needed a truck for the rest."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("diagnostic", "holistic effect")]
+    comment := "Infelicitous: the theme object entails total movement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_18a : LinguisticExample :=
+  { id := "beavers2010_18a"
+    source := ⟨"beavers-2010", "(18a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John cut the diamond on the glass."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John cut the diamond on the glass."
+    context := "John moves a sharp-edged diamond forcefully into contact with a piece of glass."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("verb class", "cut/slice")]
+    comment := "Diamond affected: the object is damaged (nonquantized), the oblique only potentially (potential)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_18b : LinguisticExample :=
+  { id := "beavers2010_18b"
+    source := ⟨"beavers-2010", "(18b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John cut the glass with the diamond."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John cut the glass with the diamond."
+    context := "Same scenario; the glass is damaged rather than the diamond."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("verb class", "cut/slice")]
+    comment := "No holistic effect, so locative alternations are not in general governed by aspect."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_20a : LinguisticExample :=
+  { id := "beavers2010_20a"
+    source := ⟨"beavers-2010", "(20a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie cut the rope."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie cut the rope."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "cut")]
+    comment := "The rope is cut, to no specific degree: nonquantized change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_20b : LinguisticExample :=
+  { id := "beavers2010_20b"
+    source := ⟨"beavers-2010", "(20b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie cut at the rope."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie cut at the rope."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "cut")]
+    comment := "The rope may or may not be cut: potential for change only."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21a : LinguisticExample :=
+  { id := "beavers2010_21a"
+    source := ⟨"beavers-2010", "(21a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie ate her cake."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie ate her cake."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "consumption")]
+    comment := "All (or a contextually significant amount) of the cake consumed: quantized change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21b : LinguisticExample :=
+  { id := "beavers2010_21b"
+    source := ⟨"beavers-2010", "(21b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie ate at her cake."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie ate at her cake."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "consumption")]
+    comment := "At least some consumed, not necessarily all: nonquantized change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22a : LinguisticExample :=
+  { id := "beavers2010_22a"
+    source := ⟨"beavers-2010", "(22a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie hit Defarge."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie hit Defarge."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "impact")]
+    comment := "Defarge is hit but not necessarily affected: potential for change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22b : LinguisticExample :=
+  { id := "beavers2010_22b"
+    source := ⟨"beavers-2010", "(22b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Marie hit at Defarge."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Marie hit at Defarge."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "conative"), ("verb class", "impact")]
+    comment := "Defarge not necessarily even hit: unspecified for change (double modality)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_24a : LinguisticExample :=
+  { id := "beavers2010_24a"
+    source := ⟨"beavers-2010", "(24a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John hit the fence with the stick."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John hit the fence with the stick."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "locative"), ("contrast", "none")]
+    comment := "Alternates with 'John hit the stick against the fence' with no truth-conditional contrast — the equal-role case the MAP permits."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_29 : LinguisticExample :=
+  { id := "beavers2010_29"
+    source := ⟨"beavers-2010", "(29)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The tailor lengthened the jeans to 32ins."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The tailor lengthened the jeans to 32ins."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("degree", "quantized"), ("diagnostic", "telicity")]
+    comment := "Specific predicate-supplied result state: telic, quantized change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_30 : LinguisticExample :=
+  { id := "beavers2010_30"
+    source := ⟨"beavers-2010", "(30)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The tailor lengthened the jeans."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The tailor lengthened the jeans."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("degree", "nonquantized"), ("diagnostic", "telicity")]
+    comment := "Some result on the length scale, unspecified which: atelic, nonquantized change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_81a : LinguisticExample :=
+  { id := "beavers2010_81a"
+    source := ⟨"beavers-2010", "(81a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John climbed the stairs."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John climbed the stairs."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "traversal"), ("degree", "totally traversed")]
+    comment := "The stairs all traversed; the affected participant is John (quantized change of location)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_81b : LinguisticExample :=
+  { id := "beavers2010_81b"
+    source := ⟨"beavers-2010", "(81b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John climbed up the stairs."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John climbed up the stairs."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "traversal"), ("degree", "traversed")]
+    comment := "The stairs all or partly traversed: the oblique weakens total traversal to mere traversal."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_88a : LinguisticExample :=
+  { id := "beavers2010_88a"
+    source := ⟨"beavers-2010", "(88a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Kim mailed London a ball."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Kim mailed London a ball."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := [("London as an agency (Scotland Yard reading)", .acceptable)]
+    paperFeatures := [("alternation", "dative"), ("direct", "recipient")]
+    comment := "Indirect objects must be prospective possessors: the goal-only reading is out."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_88b : LinguisticExample :=
+  { id := "beavers2010_88b"
+    source := ⟨"beavers-2010", "(88b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Kim mailed a ball to London."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Kim mailed a ball to London."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("alternation", "dative"), ("oblique", "goal")]
+    comment := "The to-variant needs only a goal: the indirect object monotonically adds prospective possession (90)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_9a, ex_9b, ex_10a, ex_18a, ex_18b, ex_20a, ex_20b, ex_21a, ex_21b, ex_22a, ex_22b, ex_24a, ex_29, ex_30, ex_81a, ex_81b, ex_88a, ex_88b]
+
+end Beavers2010.Examples

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -4,33 +4,43 @@ import Linglib.Semantics.ArgumentStructure.Projection
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
 import Linglib.Data.Examples.Levin1993
+import Linglib.Data.Examples.Beavers2010
+import Mathlib.Order.Cover
 
 /-!
-# [beavers-2010] The Structure of Lexical Meaning: Why Semantics Really Matters
+# Beavers (2010): The Structure of Lexical Meaning
 
-Argument realization in direct/oblique alternations is governed not by event
-structure but by **strength of truth conditions**. Direct realization encodes
-monotonically stronger truth conditions than oblique realization. This is
-captured by:
+Direct/oblique alternations are governed not by event structure but by
+strength of truth conditions: the direct realization of an alternating
+argument carries monotonically stronger lexical entailments than the oblique
+(27). In the locative and conative case studies the entailments are the
+degrees of the affectedness hierarchy ([beavers-2011]), each an existential
+weakening of the last; the three implicational entailments (65) admit exactly
+four contentful L-thematic roles (66), which form a chain. The
+Morphosyntactic Alignment Principle (69) requires the oblique role to be a
+minimal weakening (`⊆_M`, (68)) of the direct role — order-theoretically, the
+oblique weakly covers from below: `oblique ⩿ direct`. The same principle
+runs on other implicational hierarchies: traversal for *climb (up) the
+stairs* (85), prospective possession for the dative (90).
 
-1. An **affectedness hierarchy** — four degrees of change, each an existential
-   weakening of the last: quantized ⊃ nonquantized ⊃ potential ⊃ unspecified.
+## Main statements
 
-2. **L-thematic roles** — sets of implicationally related entailments. The
-   three affectedness entailments produce a structured subset hierarchy
-   with exactly 4 semantically non-vacuous roles (of 8 possible).
+* `MAP`: (69) as mathlib's `⩿`; `minimalContrast_iff_wcovby` ties it to the
+  entailment-set form (68).
+* `MAP_holds_all_alternations`: every attested contrast (Tables 3–4, plus
+  the equal-role *hit the fence/stick* type (75)) satisfies the MAP; the
+  reversed, strengthened and level-skipping variants (76)–(77) violate it.
+* `conatives_witness_all_covers`: the three conatives realize exactly the
+  covering pairs of the affectedness hierarchy.
 
-3. The **Morphosyntactic Alignment Principle (MAP)** — when an argument
-   alternates between direct and oblique realization, the direct variant
-   bears L-thematic role R and the oblique bears Q ⊆_M R (minimal weakening).
+## References
 
-## Deepest theorem
-
-`MAP_holds_all_alternations`: for every attested object/oblique alternation
-in the data, the oblique role is the *next-weakest* (minimal, ⊆_M) weakening
-of the direct role. The subset form (direct degree ≥ oblique degree) is the
-derived corollary `MAP_subset` / `MapHolds.oblique_le`, via the substrate's
-`AffectednessDegree` order.
+* [beavers-2010]: The structure of lexical meaning: Why semantics really
+  matters. *Language* 86.
+* [beavers-2011]: On affectedness.
+* [dowty-1991]: Thematic proto-roles and argument selection.
+* [levin-1993]: English Verb Classes and Alternations.
+* [grimm-2011]: The bounds of subjecthood: Evidence from instruments.
 -/
 
 namespace Beavers2010
@@ -39,516 +49,414 @@ open ArgumentStructure
 open ArgumentStructure.Affectedness (AffectednessDegree profileToDegree)
 open ArgumentStructure (DiathesisAlternation)
 
--- ════════════════════════════════════════════════════
--- § 2. L-Thematic Roles as Entailment Sets (§4.3)
--- ════════════════════════════════════════════════════
+/-! ### L-thematic roles as entailment sets ((65)–(67)) -/
 
-/-- An L-thematic role for patienthood: a set of the three affectedness
-    entailments ([beavers-2010]'s reduction of Dowty's 5 P-Patient
-    entailments). -/
+/-- An L-thematic role for patienthood: which of the three affectedness
+entailments (65) it contains. -/
 structure PatientLRole where
-  quantized    : Bool
+  /-- Undergoes a quantized change. -/
+  quantized : Bool
+  /-- Undergoes a nonquantized change. -/
   nonquantized : Bool
-  potential    : Bool
+  /-- Has potential for change. -/
+  potential : Bool
   deriving DecidableEq, Repr
+
+instance : Fintype PatientLRole :=
+  ⟨⟨(↑[(⟨false, false, false⟩ : PatientLRole), ⟨false, false, true⟩,
+      ⟨false, true, false⟩, ⟨false, true, true⟩, ⟨true, false, false⟩,
+      ⟨true, false, true⟩, ⟨true, true, false⟩, ⟨true, true, true⟩] :
+      Multiset PatientLRole), by decide⟩,
+   fun x => by rcases x with ⟨q, n, p⟩; cases q <;> cases n <;> cases p <;> decide⟩
 
 namespace PatientLRole
 
-/-- An L-role is valid iff it respects the implicational chain
-    quantized → nonquantized → potential. -/
-def valid (r : PatientLRole) : Bool :=
-  (!r.quantized || r.nonquantized) &&    -- q → nq
-  (!r.nonquantized || r.potential)         -- nq → p
+/-- A role is on the hierarchy iff it respects the implicational chain
+quantized → nonquantized → potential; the other four combinations are
+semantically vacuous (67). -/
+def Valid (r : PatientLRole) : Prop :=
+  (r.quantized → r.nonquantized) ∧ (r.nonquantized → r.potential)
 
-/-- The four valid L-thematic roles. -/
+instance : DecidablePred Valid := fun r => by unfold Valid; infer_instance
+
+/-- `{quantized, nonquantized, potential}`. -/
 def quantizedRole : PatientLRole := ⟨true, true, true⟩
+
+/-- `{nonquantized, potential}`. -/
 def nonquantizedRole : PatientLRole := ⟨false, true, true⟩
+
+/-- `{potential}`. -/
 def potentialRole : PatientLRole := ⟨false, false, true⟩
+
+/-- `{}`. -/
 def unspecifiedRole : PatientLRole := ⟨false, false, false⟩
 
-/-- Exactly 4 of the 8 combinations are valid: the implicational chain
-    prunes the role space to the four semantically contentful L-roles. -/
+/-- Exactly four of the eight combinations are contentful (66)–(67). -/
 theorem exactly_four_valid_roles :
-    ∀ r : PatientLRole, r.valid = true ↔
+    ∀ r : PatientLRole, Valid r ↔
       (r = quantizedRole ∨ r = nonquantizedRole ∨
-       r = potentialRole ∨ r = unspecifiedRole) := by
-  rintro ⟨q, n, p⟩; revert q n p; decide
+       r = potentialRole ∨ r = unspecifiedRole) := by decide
 
-/-- Subset ordering on L-thematic roles: R₁ ⊆ R₂ iff every entailment
-    in R₁ is also in R₂. -/
-def subset (r₁ r₂ : PatientLRole) : Bool :=
-  (!r₁.quantized || r₂.quantized) &&
-  (!r₁.nonquantized || r₂.nonquantized) &&
-  (!r₁.potential || r₂.potential)
+/-- Entailment-set inclusion. -/
+def Subset (r₁ r₂ : PatientLRole) : Prop :=
+  (r₁.quantized → r₂.quantized) ∧ (r₁.nonquantized → r₂.nonquantized) ∧
+    (r₁.potential → r₂.potential)
 
-/-- Strict subset: ⊂ -/
-def strictSubset (r₁ r₂ : PatientLRole) : Bool :=
-  subset r₁ r₂ && !subset r₂ r₁
+instance : ∀ r₁ r₂, Decidable (Subset r₁ r₂) := fun _ _ => by
+  unfold Subset; infer_instance
 
-/-- The four valid roles form a linear chain under ⊂:
-    {} ⊂ {p} ⊂ {nq,p} ⊂ {q,nq,p} -/
-theorem valid_roles_form_chain :
-    strictSubset unspecifiedRole potentialRole = true ∧
-    strictSubset potentialRole nonquantizedRole = true ∧
-    strictSubset nonquantizedRole quantizedRole = true := ⟨rfl, rfl, rfl⟩
+/-- Minimal contrast (68): `Q ⊆_M R` iff `Q = R` or `Q ⊂ R` with no valid
+role strictly between them. -/
+def MinimalContrast (q r : PatientLRole) : Prop :=
+  q = r ∨ ((Subset q r ∧ q ≠ r) ∧
+    ∀ p, Valid p → ¬((Subset q p ∧ q ≠ p) ∧ (Subset p r ∧ p ≠ r)))
 
-/-- The hierarchy is linear: no incomparable pairs among valid roles. -/
-theorem no_incomparable_valid_pairs :
-    -- Every pair is ordered
-    subset unspecifiedRole potentialRole = true ∧
-    subset unspecifiedRole nonquantizedRole = true ∧
-    subset unspecifiedRole quantizedRole = true ∧
-    subset potentialRole nonquantizedRole = true ∧
-    subset potentialRole quantizedRole = true ∧
-    subset nonquantizedRole quantizedRole = true := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+instance : ∀ q r, Decidable (MinimalContrast q r) := fun _ _ => by
+  unfold MinimalContrast; infer_instance
 
-/-- Minimal contrast: Q ⊆_M R iff Q = R or Q ⊂ R with no valid role
-    strictly between them. -/
-def minimalContrast (q r : PatientLRole) : Bool :=
-  q == r || (strictSubset q r &&
-    !([quantizedRole, nonquantizedRole, potentialRole, unspecifiedRole].any
-        fun p => strictSubset q p && strictSubset p r))
-
-/-- The attested minimal contrasts are exactly the adjacent pairs. -/
-theorem minimal_contrasts_are_adjacent :
-    minimalContrast unspecifiedRole potentialRole = true ∧
-    minimalContrast potentialRole nonquantizedRole = true ∧
-    minimalContrast nonquantizedRole quantizedRole = true := ⟨rfl, rfl, rfl⟩
-
-/-- Skipping a level is NOT a minimal contrast. -/
-theorem skip_not_minimal :
-    minimalContrast unspecifiedRole nonquantizedRole = false ∧
-    minimalContrast unspecifiedRole quantizedRole = false ∧
-    minimalContrast potentialRole quantizedRole = false := ⟨rfl, rfl, rfl⟩
-
-/-- The affectedness degree corresponding to a valid L-thematic role. -/
+/-- The affectedness degree of a valid role, named by its strongest
+entailment. -/
 def toDegree (r : PatientLRole) : AffectednessDegree :=
   if r.quantized then .quantized
   else if r.nonquantized then .nonquantized
   else if r.potential then .potential
   else .unspecified
 
-/-- The valid L-thematic role realizing a degree (section of `toDegree`). -/
+/-- The valid role realizing a degree (a section of `toDegree`). -/
 def ofDegree : AffectednessDegree → PatientLRole
   | .quantized => quantizedRole
   | .nonquantized => nonquantizedRole
   | .potential => potentialRole
   | .unspecified => unspecifiedRole
 
-theorem ofDegree_valid : ∀ d, (ofDegree d).valid = true := by
-  intro d; cases d <;> rfl
+theorem ofDegree_valid : ∀ d, Valid (ofDegree d) := by decide
 
-theorem toDegree_ofDegree : ∀ d, (ofDegree d).toDegree = d := by
-  intro d; cases d <;> rfl
+theorem toDegree_ofDegree : ∀ d, (ofDegree d).toDegree = d := by decide
 
-/-- The subset order on valid roles is the substrate's `AffectednessDegree`
-    order, transported along `toDegree`. -/
+/-- On valid roles, entailment-set inclusion is the degree order (66). -/
 theorem subset_iff_toDegree_le :
-    ∀ q r : PatientLRole, q.valid = true → r.valid = true →
-      (subset q r = true ↔ q.toDegree ≤ r.toDegree) := by
-  rintro ⟨a, b, c⟩ ⟨d, e, f⟩; revert a b c d e f; decide
+    ∀ q r : PatientLRole, Valid q → Valid r →
+      (Subset q r ↔ q.toDegree ≤ r.toDegree) := by decide
 
 end PatientLRole
 
--- ════════════════════════════════════════════════════
--- § 3. Morphosyntactic Alignment Principle (§4.3)
--- ════════════════════════════════════════════════════
+/-! ### The MAP ((68)–(69)) as weak covering -/
 
-/-- The MAP ([beavers-2010]; canonical wording in Beavers' 2023 Sag Lectures
-    handout): when an argument may be either an object or a PP, it bears role
-    R as an object and the *next weakest* role Q ⊆_M R as a PP — a minimal
-    weakening, not mere subset. -/
-def MAP (directRole obliqueRole : PatientLRole) : Bool :=
-  PatientLRole.minimalContrast obliqueRole directRole
+instance : DecidableRel (· ⩿ · : AffectednessDegree → AffectednessDegree → Prop) :=
+  fun a b => decidable_of_iff (a ≤ b ∧ ∀ c, a < c → ¬c < b) Iff.rfl
 
-/-- Derived corollary of the MAP (the weakened form an earlier version of
-    this file stated as the MAP itself): the oblique role's entailments are
-    a subset of the direct role's. -/
-theorem MAP_subset :
-    ∀ d o : PatientLRole, MAP d o = true → PatientLRole.subset o d = true := by
-  rintro ⟨a, b, c⟩ ⟨d, e, f⟩; revert a b c d e f; decide
+instance : DecidableRel (· ⋖ · : AffectednessDegree → AffectednessDegree → Prop) :=
+  fun a b => decidable_of_iff (a < b ∧ ∀ c, a < c → ¬c < b) Iff.rfl
 
-/-- The case the strengthening excludes: a level-skipping weakening
-    (potential oblique under a quantized direct role) satisfies the subset
-    corollary but violates the MAP proper. -/
-theorem skip_violates_MAP :
-    MAP PatientLRole.quantizedRole PatientLRole.potentialRole = false ∧
-    PatientLRole.subset PatientLRole.potentialRole PatientLRole.quantizedRole
-      = true :=
-  ⟨PatientLRole.skip_not_minimal.2.2, rfl⟩
+/-- The Morphosyntactic Alignment Principle (69): when a participant
+alternates, it bears role `R` as a direct argument and the minimally weaker
+`Q ⊆_M R` as an oblique — the oblique degree weakly covers from below. -/
+def MAP (direct oblique : AffectednessDegree) : Prop :=
+  oblique ⩿ direct
 
--- ════════════════════════════════════════════════════
--- § 4. Alternation Contrasts (§3.2)
--- ════════════════════════════════════════════════════
+instance : ∀ d o, Decidable (MAP d o) := fun _ _ => by
+  unfold MAP; infer_instance
 
-/-- An observed alternation contrast: a verb with its direct-object
-    and oblique affectedness degrees. -/
+/-- The entailment-set form of minimal contrast (68) is weak covering of
+degrees: `⊆_M` on the role hierarchy is `⩿` on the affectedness chain. -/
+theorem minimalContrast_iff_wcovby :
+    ∀ q r : PatientLRole, PatientLRole.Valid q → PatientLRole.Valid r →
+      (PatientLRole.MinimalContrast q r ↔ q.toDegree ⩿ r.toDegree) := by decide
+
+/-- The subset corollary of the MAP: the oblique's entailments are among the
+direct realization's (27). -/
+theorem MAP.oblique_le {d o : AffectednessDegree} (h : MAP d o) : o ≤ d :=
+  h.le
+
+/-! ### The attested contrasts (Tables 3–4, (75)) -/
+
+/-- An alternation contrast: a verb with the affectedness degrees of its
+alternating participant as direct object and as oblique. -/
 structure AlternationContrast where
+  /-- The verb. -/
   verb : String
+  /-- The alternation it instantiates. -/
   alternationType : DiathesisAlternation
+  /-- Degree in direct realization. -/
   directDegree : AffectednessDegree
+  /-- Degree in oblique realization. -/
   obliqueDegree : AffectednessDegree
-  deriving Repr, BEq
+  deriving Repr, DecidableEq
 
--- ── Conative alternations (Table 3) ──
-
-/-- *eat* conative: "ate the pizza" (quantized) vs "ate at the pizza" (nonquantized).
-    The object variant entails total consumption; the oblique entails only some
-    consumption occurred. -/
+/-- *ate her cake* / *ate at her cake* (21): quantized ⇔ nonquantized. -/
 def eatConative : AlternationContrast :=
   ⟨"eat", .conative, .quantized, .nonquantized⟩
 
-/-- *cut* conative: "cut the rope" (nonquantized) vs "cut at the rope" (potential).
-    The object variant entails some damage; the oblique entails only that
-    damage was possible (contact under modality). -/
+/-- *cut the rope* / *cut at the rope* (20): nonquantized ⇔ potential. -/
 def cutConative : AlternationContrast :=
   ⟨"cut", .conative, .nonquantized, .potential⟩
 
-/-- *hit* conative: "hit the rope" (potential) vs "hit at the rope" (unspecified).
-    The object variant entails potential for change (if contact, then possible
-    result); the oblique entails only potential contact under double modality. -/
+/-- *hit Defarge* / *hit at Defarge* (22): potential ⇔ unspecified. -/
 def hitConative : AlternationContrast :=
   ⟨"hit", .conative, .potential, .unspecified⟩
 
--- ── Locative alternations (Table 4) ──
-
-/-- *load* locative (location as object): "loaded the wagon" (quantized)
-    vs "loaded hay onto the wagon" — the wagon undergoes quantized change
-    (completely filled), the hay undergoes nonquantized change (moved). -/
+/-- *loaded the wagon (with hay)* (49): the location is completely filled as
+object, partly as oblique. -/
 def loadLocation : AlternationContrast :=
   ⟨"load", .locative, .quantized, .nonquantized⟩
 
-/-- *load* locative (theme as object): "loaded the hay" (quantized)
-    vs "loaded the wagon with the hay" — the hay undergoes quantized
-    change (all moved), the wagon undergoes nonquantized change. -/
+/-- *loaded the hay (onto the wagon)* (49): the theme is all moved as
+object, partly as oblique. -/
 def loadTheme : AlternationContrast :=
   ⟨"load", .locative, .quantized, .nonquantized⟩
 
-/-- *cut/slice* locative (location as object): "cut the window with
-    the diamond" (nonquantized) vs "cut the diamond on the window"
-    — both undergo potential change, but the object has nonquantized. -/
+/-- *cut the window (with the diamond)* (54): damaged as object, potentially
+as oblique. -/
 def cutLocation : AlternationContrast :=
   ⟨"cut", .locative, .nonquantized, .potential⟩
 
-/-- *cut/slice* locative (theme as object): same contrast. -/
+/-- *cut the diamond (on the window)* (54): same contrast for the theme. -/
 def cutTheme : AlternationContrast :=
   ⟨"cut", .locative, .nonquantized, .potential⟩
 
-/-- All attested alternation contrasts. -/
+/-- *hit the fence with the stick* / *hit the stick against the fence* (24),
+(75): both realizations potential — the equal-role alternation the MAP
+permits, with no truth-conditional contrast. -/
+def hitLocative : AlternationContrast :=
+  ⟨"hit", .locative, .potential, .potential⟩
+
+/-- The attested contrasts. -/
 def allContrasts : List AlternationContrast :=
   [eatConative, cutConative, hitConative,
-   loadLocation, loadTheme, cutLocation, cutTheme]
+   loadLocation, loadTheme, cutLocation, cutTheme, hitLocative]
 
--- ════════════════════════════════════════════════════
--- § 5. MAP Verification
--- ════════════════════════════════════════════════════
-
-/-- The MAP holds of a contrast: the oblique role is the next-weakest
-    (minimal) weakening of the direct role. -/
+/-- The MAP holds of a contrast. -/
 def MapHolds (c : AlternationContrast) : Prop :=
-  MAP (.ofDegree c.directDegree) (.ofDegree c.obliqueDegree) = true
+  MAP c.directDegree c.obliqueDegree
 
 instance (c : AlternationContrast) : Decidable (MapHolds c) := by
   unfold MapHolds; infer_instance
 
-/-- Degree-level corollary via `MAP_subset` and the substrate's
-    `AffectednessDegree` order: the direct degree dominates the oblique. -/
+/-- The MAP holds of every attested contrast: each oblique realization is a
+minimal weakening — or exact repetition (75) — of its direct counterpart. -/
+theorem MAP_holds_all_alternations : ∀ c ∈ allContrasts, MapHolds c := by decide
+
+/-- Degree-level corollary: the direct degree dominates the oblique. -/
 theorem MapHolds.oblique_le {c : AlternationContrast} (h : MapHolds c) :
-    c.obliqueDegree ≤ c.directDegree := by
-  have hle := (PatientLRole.subset_iff_toDegree_le _ _
-    (PatientLRole.ofDegree_valid _) (PatientLRole.ofDegree_valid _)).mp
-    (MAP_subset _ _ h)
-  simpa [PatientLRole.toDegree_ofDegree] using hle
+    c.obliqueDegree ≤ c.directDegree :=
+  MAP.oblique_le h
 
--- ── Per-contrast MAP verification ──
+/-- The three conatives realize exactly the covering pairs of the
+affectedness hierarchy: together they tile the chain (Table 3). -/
+theorem conatives_witness_all_covers :
+    ∀ q r : AffectednessDegree, q ⋖ r ↔
+      ∃ c ∈ [eatConative, cutConative, hitConative],
+        c.directDegree = r ∧ c.obliqueDegree = q := by decide
 
-theorem MAP_eat_conative : MapHolds eatConative := by decide
-theorem MAP_cut_conative : MapHolds cutConative := by decide
-theorem MAP_hit_conative : MapHolds hitConative := by decide
-theorem MAP_load_location : MapHolds loadLocation := by decide
-theorem MAP_load_theme : MapHolds loadTheme := by decide
-theorem MAP_cut_location : MapHolds cutLocation := by decide
-theorem MAP_cut_theme : MapHolds cutTheme := by decide
+/-! ### Impossible alternations ((76)–(77)) -/
 
-/-- The MAP — in its strengthened next-weakest form — holds for ALL attested
-    alternation contrasts: every oblique realization is a *minimal* weakening
-    of its direct counterpart. -/
-theorem MAP_holds_all_alternations :
-    ∀ c ∈ allContrasts, MapHolds c := by decide
+/-- A reversed contrast: the oblique strictly outranks the direct (76). -/
+def reversedConative : AlternationContrast :=
+  ⟨"reversed", .conative, .potential, .quantized⟩
 
--- ════════════════════════════════════════════════════
--- § 6. Minimal Contrast Verification
--- ════════════════════════════════════════════════════
-
-/-- The three conatives *tile* the hierarchy — every adjacent pair appears
-    exactly once, so together they exhibit the full implicational chain.
-    (That each is a minimal contrast is the per-contrast `MAP_*_conative`
-    theorem above.) -/
-theorem conatives_cover_hierarchy :
-    eatConative.directDegree = .quantized ∧
-    eatConative.obliqueDegree = .nonquantized ∧
-    cutConative.directDegree = .nonquantized ∧
-    cutConative.obliqueDegree = .potential ∧
-    hitConative.directDegree = .potential ∧
-    hitConative.obliqueDegree = .unspecified := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- § 7. Impossible Alternations
--- ════════════════════════════════════════════════════
-
-/-- A hypothetical alternation whose oblique has *more* entailments than
-    its direct object (potential DO, quantized oblique) — the less prominent
-    realization would carry stronger truth conditions. -/
-def impossibleConative : AlternationContrast :=
-  ⟨"impossible", .conative, .potential, .quantized⟩
-
-/-- A level-skipping alternation: quantized direct, potential oblique.
-    Satisfies the subset corollary but not the MAP proper — the degree-level
-    face of `skip_violates_MAP`. -/
+/-- A level-skipping contrast (77): quantized direct, potential oblique. -/
 def skippingLocative : AlternationContrast :=
   ⟨"skipping", .locative, .quantized, .potential⟩
 
-/-- A reversed alternation: the oblique strictly outranks the direct. -/
-def reversedConative : AlternationContrast :=
-  ⟨"reversed", .conative, .unspecified, .potential⟩
-
 theorem reversed_violates_MAP : ¬ MapHolds reversedConative := by decide
 
-theorem impossible_violates_MAP : ¬ MapHolds impossibleConative := by decide
-
 /-- Skipping a level violates the MAP even though the degree order is
-    respected — `skip_not_minimal` is what excludes it. -/
+respected: `⊆_M` demands the *next-weakest* role, not any weaker one. -/
 theorem skipping_violates_MAP :
     ¬ MapHolds skippingLocative ∧
-    skippingLocative.obliqueDegree ≤ skippingLocative.directDegree :=
+      skippingLocative.obliqueDegree ≤ skippingLocative.directDegree :=
   ⟨by decide, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 8. Bridge to Existing Data and EntailmentProfile
--- ════════════════════════════════════════════════════
+/-! ### Other hierarchies: traversal (85) and the dative (90) -/
 
-/-- Bridge to [levin-1993]'s judgment rows: the conative alternation is
-    attested for *cut* and *hit*, confirming the Table 3 contrasts. -/
+/-- The traversal hierarchy (85): each degree an existential weakening of
+the last, exactly parallel to affectedness but predicated of the scale. -/
+inductive TraversalDegree where
+  /-- No traversal entailment. -/
+  | unspecified
+  /-- Potentially traversed. -/
+  | potentiallyTraversed
+  /-- Some of the scale traversed. -/
+  | traversed
+  /-- All of the scale traversed. -/
+  | totallyTraversed
+  deriving DecidableEq, Fintype, Repr
+
+/-- Strength on the traversal hierarchy. -/
+def TraversalDegree.strength : TraversalDegree → Nat
+  | .unspecified => 0
+  | .potentiallyTraversed => 1
+  | .traversed => 2
+  | .totallyTraversed => 3
+
+instance : LinearOrder TraversalDegree :=
+  .lift' TraversalDegree.strength fun a b => by
+    cases a <;> cases b <;> simp [TraversalDegree.strength]
+
+instance : DecidableRel (· ⩿ · : TraversalDegree → TraversalDegree → Prop) :=
+  fun a b => decidable_of_iff (a ≤ b ∧ ∀ c, a < c → ¬c < b) Iff.rfl
+
+/-- *climbed the stairs* / *climbed up the stairs* (81)–(84): total vs mere
+traversal of the path — a covering pair, so the MAP holds on the traversal
+hierarchy. -/
+theorem climb_traversal_map :
+    (TraversalDegree.traversed) ⩿ TraversalDegree.totallyTraversed := by decide
+
+/-- The dative chain (90): being arrived at, and arrival into the possession
+of. -/
+inductive DativeRole where
+  /-- Goal: arrived at. -/
+  | goal
+  /-- Recipient-goal: arrived into the possession of. -/
+  | recipientGoal
+  deriving DecidableEq, Fintype, Repr
+
+/-- Strength on the dative chain. -/
+def DativeRole.strength : DativeRole → Nat
+  | .goal => 0
+  | .recipientGoal => 1
+
+instance : LinearOrder DativeRole :=
+  .lift' DativeRole.strength fun a b => by
+    cases a <;> cases b <;> simp [DativeRole.strength]
+
+instance : DecidableRel (· ⩿ · : DativeRole → DativeRole → Prop) :=
+  fun a b => decidable_of_iff (a ≤ b ∧ ∀ c, a < c → ¬c < b) Iff.rfl
+
+/-- *mailed Mary the letter* / *mailed the letter to Mary* (88)–(89): the
+indirect object monotonically adds prospective possession to arrival — the
+MAP on the possession chain. -/
+theorem dative_map : DativeRole.goal ⩿ DativeRole.recipientGoal := by decide
+
+/-! ### Bridge to [levin-1993]'s judgment rows -/
+
+/-- The conative alternation is attested for *cut* and *hit* (Table 3). -/
 theorem conative_data_attested :
     Levin1993.Examples.con_cut.judgment = .acceptable ∧
     Levin1993.Examples.con_hit.judgment = .acceptable := ⟨rfl, rfl⟩
 
-/-- Bridge to [levin-1993]'s judgment rows: break does NOT participate
-    in the conative. This is predicted: break objects undergo quantized
-    change (CoS), and the conative would weaken to nonquantized — but
-    break's meaning inherently requires a specific result state, so the
-    weakening is blocked by the verb's lexical semantics. -/
+/-- *break* does not participate in the conative: its object's quantized
+change is inherent to the verb's meaning, so the weakening is blocked. -/
 theorem break_no_conative :
     Levin1993.Examples.con_break.judgment = .ungrammatical := rfl
 
-/-- Bridge to [levin-1993]'s judgment rows: the locative alternation is
-    attested for spray/load verbs, confirming the Table 4 contrasts. -/
+/-- The locative alternation is attested for spray/load verbs (Table 4). -/
 theorem locative_data_attested :
     Levin1993.Examples.loc_spray.judgment = .acceptable ∧
     Levin1993.Examples.loc_load.judgment = .acceptable := ⟨rfl, rfl⟩
 
-/-! The `profileToDegree` bridge (formerly §8) and its verification theorems
-    have been promoted to `Semantics/Events/Affectedness.lean`.
-    They are opened at the top of this file. -/
+/-! ### The MAP and subject selection are orthogonal (§6) -/
 
--- ════════════════════════════════════════════════════
--- § 9. Cross-Study Connection: Decompositions Fill Gaps
--- ════════════════════════════════════════════════════
-
-/-! [beavers-2010] argues that the MAP and event decompositions are
-    *complementary*, not competing (the paper's conclusion, §6):
-
-    | Approach        | Semantics                        | Morphosyntax             |
-    |-----------------|----------------------------------|--------------------------|
-    | Decompositions  | gross causal/temporal structure   | subject/nonsubject       |
-    | MAP             | fine-grained lexical entailments  | direct/oblique           |
-
-    The existing `EntailmentProfile` captures the gross agentivity structure
-    (P-Agent features → subject selection). Beavers 2010 adds the missing
-    piece: fine-grained P-Patient structure → direct/oblique alternations. -/
-
-/-- Subject selection (from [dowty-1991]) and object alternations
-    (from [beavers-2010]) are *independent* principles operating on
-    different argument positions. The ASP governs subjects; the MAP governs
-    direct vs. oblique objects. -/
+/-- Subject selection ([dowty-1991]'s ASP) and object/oblique alternation
+(the MAP) operate on different argument positions: the ASP governs subjects
+via P-Agent entailments, the MAP direct-vs-oblique objects via P-Patient
+strength ((93)). -/
 theorem asp_and_map_orthogonal :
-    -- ASP: kick subject outranks object for subjecthood
     OutranksForSubject mannerContact.subjectProfile contactObject ∧
-    -- MAP: kick object has potential affectedness (surface contact, no
-    -- entailed change — [beavers-2011] eq. (60c), same degree the paper
-    -- assigns the *hit* conative's direct object)
     profileToDegree contactObject = .potential ∧
-    -- The two operate on different dimensions
-    -- (subjecthood is about P-Agent; alternation is about P-Patient strength)
     mannerContact.subjectProfile.pAgentScore > 0 ∧
     contactObject.pPatientScore > 0 :=
   ⟨by decide, rfl, by decide, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 10. Bridge to [grimm-2011] Persistence Lattice
--- ════════════════════════════════════════════════════
+/-! ### Bridge to [grimm-2011]'s persistence lattice
 
-/-! [grimm-2011]'s `PersistenceLevel` reformulates P-Patient as 4
-    persistence dimensions (existential/qualitative × beginning/end).
-    Beavers' affectedness hierarchy maps systematically onto this lattice:
+Higher affectedness corresponds to lower persistence: both formalize degree
+of change. The mapping is not injective — quantized and nonquantized change
+both leave the entity persisting through a qualitative change; the
+difference between them is specificity of the result state, which
+persistence does not record. -/
 
-    | Beavers degree   | Grimm persistence    | Interpretation              |
-    |------------------|----------------------|-----------------------------|
-    | quantized        | exPersEnd            | Entity created/consumed     |
-    |                  | quPersBeginning      | Entity changed to specific  |
-    | nonquantized     | quPersBeginning      | Entity changed (nonspecific)|
-    | potential         | totalPersistence     | Entity may change           |
-    | unspecified       | totalPersistence     | No change entailment        |
-
-    The mapping is not injective: both `quantized` and `nonquantized` can
-    map to `quPersBeginning` (the entity changes but persists). The
-    distinction between them is about *specificity of the result state*,
-    which Grimm's persistence dimensions don't capture — it's a property
-    of the scale, not of persistence. This is where the theories are
-    genuinely complementary. -/
-
-/-- Map affectedness degrees to their most typical persistence level.
-    This captures the systematic correspondence; edge cases (creation verbs
-    mapping to exPersEnd for quantized) require verb-specific information. -/
+/-- The typical persistence level of each affectedness degree. -/
 def degreeToPersistence : AffectednessDegree → PersistenceLevel
-  | .quantized    => .quPersBeginning   -- entity changes (possibly to specific state)
-  | .nonquantized => .quPersBeginning   -- entity changes (nonspecifically)
-  | .potential    => .totalPersistence   -- entity MAY change (but persists)
-  | .unspecified  => .totalPersistence   -- no change entailed
+  | .quantized    => .quPersBeginning
+  | .nonquantized => .quPersBeginning
+  | .potential    => .totalPersistence
+  | .unspecified  => .totalPersistence
 
-/-- The two Grimm levels that correspond to "affected" roles
-    (quPersBeginning = changed, exPersEnd = created/destroyed) are both
-    ranked lower than totalPersistence on Grimm's lattice. Lower persistence
-    = higher affectedness. This is the Grimm-Beavers convergence. -/
+/-- Changed entities sit below unaffected ones on the persistence order. -/
 theorem changed_lower_than_unaffected :
     (PersistenceLevel.quPersBeginning ≤ PersistenceLevel.totalPersistence) := by
   decide
 
-/-- Bridge: kick object has persistence totalPersistence (persists, no
-    entailed change) and affectedness potential — exactly the
-    `degreeToPersistence` correspondence for potential change. Beavers'
-    surface-contact classification ([beavers-2011] eq. (60c)); note
-    [grimm-2011]'s own Fig. 5 instead places contact-verb objects at
-    quPersBeginning (`TransitivityRank.contact.patientType`), a genuine
-    cross-paper disagreement over whether contact entails impingement. -/
+/-- *kick*'s object: potential affectedness, total persistence — Beavers'
+surface-contact classification ([beavers-2011]); [grimm-2011]'s own Fig. 5
+places contact objects at `quPersBeginning` instead, a genuine cross-paper
+disagreement over whether contact entails impingement. -/
 theorem kick_grimm_beavers_consistent :
     PersistenceLevel.fromPatientProfile contactObject = .totalPersistence ∧
     profileToDegree contactObject = .potential := ⟨rfl, rfl⟩
 
-/-- Bridge: build object has persistence exPersEnd (created) and
-    affectedness quantized — both theories agree on maximal patient status. -/
+/-- *build*'s object: created, and quantized — maximal on both scales. -/
 theorem build_grimm_beavers_consistent :
     PersistenceLevel.fromPatientProfile creationObject = .exPersEnd ∧
     profileToDegree creationObject = .quantized := ⟨rfl, rfl⟩
 
-/-- Bridge: eat object has persistence exPersBeginning (consumed) and
-    affectedness quantized — both theories agree on maximal change. -/
+/-- *eat*'s object: consumed, and quantized. -/
 theorem eat_grimm_beavers_consistent :
     PersistenceLevel.fromPatientProfile consumptionObject = .exPersBeginning ∧
     profileToDegree consumptionObject = .quantized := ⟨rfl, rfl⟩
 
-/-- The deepest cross-theory result: Grimm's persistence ordering and
-    Beavers' affectedness ordering are **monotonically related** for
-    canonical verb profiles. Arguments with higher affectedness (Beavers)
-    have lower persistence (Grimm). They formalize the same intuition
-    — degree of change — from complementary perspectives. -/
+/-- Across canonical profiles the two orders move together: more affected
+(Beavers) is less persistent (Grimm). -/
 theorem grimm_beavers_monotone_canonical :
-    -- kick: potential → totalPersistence (may change, persists unchanged)
     profileToDegree contactObject = .potential ∧
     PersistenceLevel.fromPatientProfile contactObject = .totalPersistence ∧
-    -- build: quantized → exPersEnd (created, lower persistence)
     profileToDegree creationObject = .quantized ∧
     PersistenceLevel.fromPatientProfile creationObject = .exPersEnd ∧
-    -- see: unspecified → totalNonPersistence (no P-Patient entailments at all)
     profileToDegree perception.subjectProfile = .unspecified ∧
-    PersistenceLevel.fromPatientProfile perception.subjectProfile = .totalNonPersistence :=
+    PersistenceLevel.fromPatientProfile perception.subjectProfile
+      = .totalNonPersistence :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 11. RoleList → ParticipantType Bridge
--- ════════════════════════════════════════════════════
+/-! ### Projections from `RoleList` templates -/
 
-/-! Cross-framework bridge from Levin/RHL `RoleList` (event-template
-    decomposition) to Grimm's `ParticipantType` (privative agentivity lattice) and
-    Beavers' affectedness degree. Each canonical template is verified to
-    project into the predicted positions in both systems, and the consistency
-    of affectedness ↔ persistence is checked. -/
-
-
-/-- Project an RoleList's subject profile to a ParticipantType. -/
-def _root_.ArgumentStructure.RoleList.subjectGrimm
-    (t : RoleList) : ParticipantType :=
+/-- The Grimm participant type of a template's subject. -/
+def subjectGrimm (t : RoleList) : ParticipantType :=
   ParticipantType.fromSubjectProfile t.subjectProfile
 
-/-- Project an RoleList's object profile (if any) to a ParticipantType. -/
-def _root_.ArgumentStructure.RoleList.objectGrimm
-    (t : RoleList) : Option ParticipantType :=
+/-- The Grimm participant type of a template's object, if any. -/
+def objectGrimm (t : RoleList) : Option ParticipantType :=
   t.objectProfile.map ParticipantType.fromObjectProfile
 
-/-- Project an RoleList's object to its affectedness degree. -/
-def _root_.ArgumentStructure.RoleList.objectAffectedness
-    (t : RoleList) : Option AffectednessDegree :=
+/-- The affectedness degree of a template's object, if any. -/
+def objectAffectedness (t : RoleList) : Option AffectednessDegree :=
   t.objectProfile.map profileToDegree
 
--- ── Per-template ParticipantType verification ──
-
-/-- Manner-contact subject → full agent on the Grimm lattice. -/
+/-- Manner-contact subjects are full agents on the Grimm lattice. -/
 theorem mannerContact_subject_grimm :
-    mannerContact.subjectGrimm.agentivity = ⊤ := by decide
+    (subjectGrimm mannerContact).agentivity = ⊤ := by decide
 
-/-- Manner-contact object → potential affectedness (no CoS entailed). -/
-theorem mannerContact_object_affectedness :
-    mannerContact.objectAffectedness = some AffectednessDegree.potential := rfl
-
-/-- Result-change object → nonquantized affectedness (CoS, no IT). -/
-theorem resultChange_object_affectedness :
-    resultChange.objectAffectedness = some AffectednessDegree.nonquantized := rfl
-
-/-- Creation object → quantized affectedness (CoS + IT). -/
-theorem creation_object_affectedness :
-    creation.objectAffectedness = some AffectednessDegree.quantized := rfl
-
-/-- Consumption object → quantized affectedness (CoS + IT). -/
-theorem consumption_object_affectedness :
-    consumption.objectAffectedness = some AffectednessDegree.quantized := rfl
-
-/-- Self-motion (intransitive) → no object affectedness. -/
-theorem selfMotion_no_object :
-    selfMotion.objectAffectedness = none := rfl
-
-/-- **Affectedness ordering across templates**: the named templates are
-    ordered by truth-conditional strength on the object side, reproducing
-    [beavers-2010]'s hierarchy: creation/consumption (quantized) >
-    resultChange (nonquantized) > mannerContact (potential) > perception
-    (unspecified). -/
+/-- The canonical templates are ordered by object affectedness exactly as
+the paper's hierarchy: creation/consumption > result-change >
+manner-contact > perception. -/
 theorem template_affectedness_hierarchy :
     AffectednessDegree.nonquantized ≤ .quantized ∧
     AffectednessDegree.potential ≤ .nonquantized ∧
-    creation.objectAffectedness = some AffectednessDegree.quantized ∧
-    resultChange.objectAffectedness = some AffectednessDegree.nonquantized ∧
-    mannerContact.objectAffectedness = some AffectednessDegree.potential ∧
-    perception.objectAffectedness = some AffectednessDegree.unspecified :=
+    objectAffectedness creation = some .quantized ∧
+    objectAffectedness resultChange = some .nonquantized ∧
+    objectAffectedness mannerContact = some .potential ∧
+    objectAffectedness perception = some .unspecified :=
   ⟨by decide, by decide, rfl, rfl, rfl, rfl⟩
 
--- ── Cross-projection consistency: affectedness vs. persistence ──
+/-- Intransitive templates have no object affectedness. -/
+theorem selfMotion_no_object : objectAffectedness selfMotion = none := rfl
 
-/-- The affectedness and persistence projections are consistent for
-    manner-contact objects: potential affectedness ↔ totalPersistence
-    (the object may change but the verb doesn't entail it). -/
+/-- Affectedness and persistence projections agree for manner-contact
+objects. -/
 theorem mannerContact_cross_projection :
-    mannerContact.objectAffectedness = some AffectednessDegree.potential ∧
+    objectAffectedness mannerContact = some .potential ∧
     mannerContact.objectProfile.map PersistenceLevel.fromPatientProfile =
       some .totalPersistence := ⟨rfl, by decide⟩
 
-/-- Result-change: nonquantized ↔ quPersBeginning (changed but persists). -/
+/-- Result-change: changed but persisting. -/
 theorem resultChange_cross_projection :
-    resultChange.objectAffectedness = some AffectednessDegree.nonquantized ∧
+    objectAffectedness resultChange = some .nonquantized ∧
     resultChange.objectProfile.map PersistenceLevel.fromPatientProfile =
       some .quPersBeginning := ⟨rfl, by decide⟩
 
-/-- Creation: quantized ↔ exPersEnd (entity comes into existence). -/
+/-- Creation: quantized, coming into existence. -/
 theorem creation_cross_projection :
-    creation.objectAffectedness = some AffectednessDegree.quantized ∧
+    objectAffectedness creation = some .quantized ∧
     creation.objectProfile.map PersistenceLevel.fromPatientProfile =
       some .exPersEnd := ⟨rfl, by decide⟩
 


### PR DESCRIPTION
Recut against the paper (read in full): the MAP (69) is mathlib Wcovby on the affectedness chain, tied to the entailment-set minimal contrast (68) by theorem; adds the equal-role hit-locative (75), the traversal (85) and dative (90) chains, and the conative tiling theorem; Bool predicates become Props, the chronology-violating 2023-handout citation and _root_ substrate-namespace defs are gone; 18 examples in Data/Examples.