### PR TITLE
refactor(Studies/BeaversEtAl2021): correct tables, dissolve bridges

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -351,6 +351,7 @@ import Linglib.Data.Examples.Beaver2001
 import Linglib.Data.Examples.Beaver2004
 import Linglib.Data.Examples.BeaverCondoravdi2003
 import Linglib.Data.Examples.Beavers2010
+import Linglib.Data.Examples.BeaversEtAl2021
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015

--- a/Linglib/Data/Examples/BeaversEtAl2021.json
+++ b/Linglib/Data/Examples/BeaversEtAl2021.json
@@ -1,0 +1,325 @@
+[
+  {
+    "id": "beavers_etal2021_1c",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(1c)"},
+    "language": "stan1293",
+    "primaryText": "The vase cracked.",
+    "glossedTokens": [],
+    "translation": "The vase cracked.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["root class", "result"],
+      ["form", "monomorphemic verb"]
+    ],
+    "comment": "Change of state expressed by a basic verb, unlike 'became black' or 'flattened'."
+  },
+  {
+    "id": "beavers_etal2021_7a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(7a)"},
+    "language": "stan1293",
+    "primaryText": "Look at the bright picture on your left.",
+    "glossedTokens": [],
+    "translation": "Look at the bright picture on your left.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["root class", "property concept"],
+      ["form", "basic stative"]
+    ],
+    "comment": "PC roots show both a simple adjective and a deverbal one ('brightened', (7b))."
+  },
+  {
+    "id": "beavers_etal2021_10a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(10a)"},
+    "language": "stan1293",
+    "primaryText": "The bright photo has never brightened.",
+    "glossedTokens": [],
+    "translation": "The bright photo has never brightened.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "property concept"]
+    ],
+    "comment": "Simple PC adjectives survive change denial; deverbal '#brightened photo' does not."
+  },
+  {
+    "id": "beavers_etal2021_11c",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(11c)"},
+    "language": "stan1293",
+    "primaryText": "The shattered vase has never shattered.",
+    "glossedTokens": [],
+    "translation": "The shattered vase has never shattered.",
+    "context": "An artist makes ceramic pieces that, properly assembled, would form a vase.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "result"]
+    ],
+    "comment": "Contradictory even in a prototypical-result context: the adjective entails prior change."
+  },
+  {
+    "id": "beavers_etal2021_13",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(13)"},
+    "language": "stan1293",
+    "primaryText": "The window is broken but it never broke. It was manufactured that way.",
+    "glossedTokens": [],
+    "translation": "The window is broken but it never broke. It was manufactured that way.",
+    "context": "",
+    "judgment": "marginal",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "result"]
+    ],
+    "comment": "Acceptable for some speakers: lexical drift toward a 'not functioning' sense, expected variation."
+  },
+  {
+    "id": "beavers_etal2021_15a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(15a)"},
+    "language": "stan1293",
+    "primaryText": "John sharpened the knife again.",
+    "glossedTokens": [],
+    "translation": "John sharpened the knife again.",
+    "context": "John buys a knife forged already sharp, uses it until it becomes blunt, and sharpens it with a whetting stone.",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "restitutive: could be just one sharpening", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "property concept"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_16a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(16a)"},
+    "language": "stan1293",
+    "primaryText": "Chris thawed the meat again.",
+    "glossedTokens": [],
+    "translation": "Chris thawed the meat again.",
+    "context": "Chris kills a rabbit, butchers it, freezes the fresh meat for a week, then puts it out to thaw.",
+    "judgment": "unacceptable",
+    "readings": [
+      {"name": "repetitive: necessarily two defrostings", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "result"]
+    ],
+    "comment": "Result roots lack the restitutive reading."
+  },
+  {
+    "id": "beavers_etal2021_25a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(25a)"},
+    "language": "cash1251",
+    "primaryText": "madin papanka ëdkitëkënia.",
+    "glossedTokens": [
+      ["madi=n", "sand=POSS"], ["papa=n=ka=a", "father=A/S=VAL=3A/S"],
+      ["ëd-ki-tëkën-i-a", "dry-INTR-again-IPFV-NPROX"]
+    ],
+    "translation": "The desert is getting dry again.",
+    "context": "The desert starts off dry. Then it is made nondry. Then it turns dry again.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "property concept"]
+    ],
+    "comment": "Kakataibo PC roots generally allow restitutive -tëkën; this token was rejected in the given context."
+  },
+  {
+    "id": "beavers_etal2021_26",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(26)"},
+    "language": "cash1251",
+    "primaryText": "maxákana rë(të)tëkëa.",
+    "glossedTokens": [
+      ["maxat=ka=na", "stone=VAL=1A/S"], ["rëtë-tëkën-a", "kill-again-PFV"]
+    ],
+    "translation": "I killed the stone again.",
+    "context": "The stone was always dead. Then it was brought to life. Then I kill it.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "result"]
+    ],
+    "comment": "Unlike English 'kill': rëtë means 'not alive', applicable to never-alive inanimates — expected lexicalization variation."
+  },
+  {
+    "id": "beavers_etal2021_28a",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(28a)"},
+    "language": "kiny1244",
+    "primaryText": "Icy-uma gi-hor-a gi-tyay-e.",
+    "glossedTokens": [
+      ["Icy-uma", "7-knife"], ["gi-hor-a", "7S-always-FV"], ["gi-tyay-e", "7S-sharp-PFV"]
+    ],
+    "translation": "The knife has always been sharp.",
+    "context": "Habimana buys a knife that is manufactured very sharp.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "property concept"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_28b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(28b)"},
+    "language": "kiny1244",
+    "primaryText": "Umu-keri u-hor-a u-tek-ets-e.",
+    "glossedTokens": [
+      ["Umu-keri", "3-fruit"], ["u-hor-a", "3S-always-FV"], ["u-tek-ets-e", "3S-cook-STV-PFV"]
+    ],
+    "translation": "The fruit has always been cooked.",
+    "context": "A hypothetical fruit that is always soft and ripe since it first grows and can be eaten any time.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "result"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_29b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(29b)"},
+    "language": "kiny1244",
+    "primaryText": "Karemera y-ongey-e ku-men-a iki-rahure.",
+    "glossedTokens": [
+      ["Karemera", "Karemera"], ["y-ongey-e", "1S-again-PFV"], ["ku-men-a", "INF-break-FV"],
+      ["iki-rahure", "7-glass"]
+    ],
+    "translation": "Karemera broke the glass again.",
+    "context": "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Karemera then breaks.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "result"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_31",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(31)"},
+    "language": "hebr1245",
+    "primaryText": "ha-gesher 'arox 'aval 'afpa'am lo hu'arax.",
+    "glossedTokens": [
+      ["ha-gesher", "the-bridge"], ["'arox", "long"], ["'aval", "but"], ["'afpa'am", "never"],
+      ["lo", "NEG"], ["hu'arax", "lengthened.PASS"]
+    ],
+    "translation": "The bridge is long but was never lengthened.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "property concept"]
+    ],
+    "comment": "With deverbal mu'arax 'lengthened' in place of 'arox the sentence is contradictory."
+  },
+  {
+    "id": "beavers_etal2021_32",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(32)"},
+    "language": "hebr1245",
+    "primaryText": "ha-zxuxit menupecet, 'aval hi 'afpa'am lo hitnapca.",
+    "glossedTokens": [
+      ["ha-zxuxit", "the-glass"], ["menupecet", "shattered"], ["'aval", "but"], ["hi", "it"],
+      ["'afpa'am", "never"], ["lo", "NEG"], ["hitnapca", "shattered.REFL"]
+    ],
+    "translation": "The glass is shattered, but it never shattered.",
+    "context": "",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "result"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_33b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(33b)"},
+    "language": "hebr1245",
+    "primaryText": "Kim nipca šuv/mexadaš 'et ha-zxuxit.",
+    "glossedTokens": [
+      ["Kim", "Kim"], ["nipca", "shattered"], ["šuv/mexadaš", "again/anew"], ["'et", "ACC"],
+      ["ha-zxuxit", "the-glass"]
+    ],
+    "translation": "Kim shattered the glass again.",
+    "context": "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Kim then shatters.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "result"]
+    ],
+    "comment": "mexadaš 'anew' generates only restitutive readings, similar to English re- prefixation."
+  },
+  {
+    "id": "beavers_etal2021_35b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(35b)"},
+    "language": "mara1378",
+    "primaryText": "kāc phoɖ-leli āhe pəɳ ti kədhi phuʈ-leli nāhi.",
+    "glossedTokens": [
+      ["kāc", "glass.NOM.F.SG"], ["phoɖ-leli", "shatter.TR-PART.F.SG"], ["āhe", "be.PRS.3SG"],
+      ["pəɳ", "but"], ["ti", "DEM.F.SG"], ["kədhi", "ever"],
+      ["phuʈ-leli", "shatter.INTR-PART.F.SG"], ["nāhi", "NEG"]
+    ],
+    "translation": "The glass is shattered, but it never shattered.",
+    "context": "",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "change denial"],
+      ["root class", "result"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_36b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(36b)"},
+    "language": "mara1378",
+    "primaryText": "Kim-ne parat kach phoɖ-li.",
+    "glossedTokens": [
+      ["Kim-ne", "Kim-ERG"], ["parat", "again"], ["kach", "glass.F.SG.NOM"],
+      ["phoɖ-li", "break-PFV.F.SG"]
+    ],
+    "translation": "Kim broke the glass again.",
+    "context": "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Kim then shatters.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "restitutive again"],
+      ["root class", "result"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beavers_etal2021_38b",
+    "source": {"bibkey": "beavers-etal-2021", "paperLabel": "(38b)"},
+    "language": "mode1248",
+    "primaryText": "I Maria eftiakse ke tin tileorasi.",
+    "glossedTokens": [
+      ["I", "the"], ["Maria", "Mary"], ["eftiakse", "fixed"], ["ke", "also"], ["tin", "the"],
+      ["tileorasi", "television"]
+    ],
+    "translation": "Mary fixed the television too.",
+    "context": "Mary bought a new TV and a new laptop. The laptop was working fine, but the TV was not. Mary brought her tools.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "additive restitutive"],
+      ["root class", "result"]
+    ],
+    "comment": "Spathas's additive test: ftiahno 'fix' rejects the restitutive-like additive reading, patterning with result roots."
+  }
+]

--- a/Linglib/Data/Examples/BeaversEtAl2021.lean
+++ b/Linglib/Data/Examples/BeaversEtAl2021.lean
@@ -1,0 +1,342 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BeaversEtAl2021` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BeaversEtAl2021.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BeaversEtAl2021.Examples`.
+-/
+
+namespace BeaversEtAl2021.Examples
+
+open Data.Examples
+
+def beavers_etal2021_1c : LinguisticExample :=
+  { id := "beavers_etal2021_1c"
+    source := ⟨"beavers-etal-2021", "(1c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The vase cracked."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The vase cracked."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root class", "result"), ("form", "monomorphemic verb")]
+    comment := "Change of state expressed by a basic verb, unlike 'became black' or 'flattened'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_7a : LinguisticExample :=
+  { id := "beavers_etal2021_7a"
+    source := ⟨"beavers-etal-2021", "(7a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Look at the bright picture on your left."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Look at the bright picture on your left."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root class", "property concept"), ("form", "basic stative")]
+    comment := "PC roots show both a simple adjective and a deverbal one ('brightened', (7b))."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_10a : LinguisticExample :=
+  { id := "beavers_etal2021_10a"
+    source := ⟨"beavers-etal-2021", "(10a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The bright photo has never brightened."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The bright photo has never brightened."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "property concept")]
+    comment := "Simple PC adjectives survive change denial; deverbal '#brightened photo' does not."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_11c : LinguisticExample :=
+  { id := "beavers_etal2021_11c"
+    source := ⟨"beavers-etal-2021", "(11c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The shattered vase has never shattered."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The shattered vase has never shattered."
+    context := "An artist makes ceramic pieces that, properly assembled, would form a vase."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "result")]
+    comment := "Contradictory even in a prototypical-result context: the adjective entails prior change."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_13 : LinguisticExample :=
+  { id := "beavers_etal2021_13"
+    source := ⟨"beavers-etal-2021", "(13)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The window is broken but it never broke. It was manufactured that way."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The window is broken but it never broke. It was manufactured that way."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "result")]
+    comment := "Acceptable for some speakers: lexical drift toward a 'not functioning' sense, expected variation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_15a : LinguisticExample :=
+  { id := "beavers_etal2021_15a"
+    source := ⟨"beavers-etal-2021", "(15a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John sharpened the knife again."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John sharpened the knife again."
+    context := "John buys a knife forged already sharp, uses it until it becomes blunt, and sharpens it with a whetting stone."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("restitutive: could be just one sharpening", .acceptable)]
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "property concept")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_16a : LinguisticExample :=
+  { id := "beavers_etal2021_16a"
+    source := ⟨"beavers-etal-2021", "(16a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Chris thawed the meat again."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Chris thawed the meat again."
+    context := "Chris kills a rabbit, butchers it, freezes the fresh meat for a week, then puts it out to thaw."
+    judgment := .unacceptable
+    alternatives := []
+    readings := [("repetitive: necessarily two defrostings", .acceptable)]
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "result")]
+    comment := "Result roots lack the restitutive reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_25a : LinguisticExample :=
+  { id := "beavers_etal2021_25a"
+    source := ⟨"beavers-etal-2021", "(25a)"⟩
+    reportedIn := none
+    language := "cash1251"
+    primaryText := "madin papanka ëdkitëkënia."
+    discourseSegments := []
+    glossedTokens := [("madi=n", "sand=POSS"), ("papa=n=ka=a", "father=A/S=VAL=3A/S"), ("ëd-ki-tëkën-i-a", "dry-INTR-again-IPFV-NPROX")]
+    translation := "The desert is getting dry again."
+    context := "The desert starts off dry. Then it is made nondry. Then it turns dry again."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "property concept")]
+    comment := "Kakataibo PC roots generally allow restitutive -tëkën; this token was rejected in the given context."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_26 : LinguisticExample :=
+  { id := "beavers_etal2021_26"
+    source := ⟨"beavers-etal-2021", "(26)"⟩
+    reportedIn := none
+    language := "cash1251"
+    primaryText := "maxákana rë(të)tëkëa."
+    discourseSegments := []
+    glossedTokens := [("maxat=ka=na", "stone=VAL=1A/S"), ("rëtë-tëkën-a", "kill-again-PFV")]
+    translation := "I killed the stone again."
+    context := "The stone was always dead. Then it was brought to life. Then I kill it."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "result")]
+    comment := "Unlike English 'kill': rëtë means 'not alive', applicable to never-alive inanimates — expected lexicalization variation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_28a : LinguisticExample :=
+  { id := "beavers_etal2021_28a"
+    source := ⟨"beavers-etal-2021", "(28a)"⟩
+    reportedIn := none
+    language := "kiny1244"
+    primaryText := "Icy-uma gi-hor-a gi-tyay-e."
+    discourseSegments := []
+    glossedTokens := [("Icy-uma", "7-knife"), ("gi-hor-a", "7S-always-FV"), ("gi-tyay-e", "7S-sharp-PFV")]
+    translation := "The knife has always been sharp."
+    context := "Habimana buys a knife that is manufactured very sharp."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "property concept")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_28b : LinguisticExample :=
+  { id := "beavers_etal2021_28b"
+    source := ⟨"beavers-etal-2021", "(28b)"⟩
+    reportedIn := none
+    language := "kiny1244"
+    primaryText := "Umu-keri u-hor-a u-tek-ets-e."
+    discourseSegments := []
+    glossedTokens := [("Umu-keri", "3-fruit"), ("u-hor-a", "3S-always-FV"), ("u-tek-ets-e", "3S-cook-STV-PFV")]
+    translation := "The fruit has always been cooked."
+    context := "A hypothetical fruit that is always soft and ripe since it first grows and can be eaten any time."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "result")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_29b : LinguisticExample :=
+  { id := "beavers_etal2021_29b"
+    source := ⟨"beavers-etal-2021", "(29b)"⟩
+    reportedIn := none
+    language := "kiny1244"
+    primaryText := "Karemera y-ongey-e ku-men-a iki-rahure."
+    discourseSegments := []
+    glossedTokens := [("Karemera", "Karemera"), ("y-ongey-e", "1S-again-PFV"), ("ku-men-a", "INF-break-FV"), ("iki-rahure", "7-glass")]
+    translation := "Karemera broke the glass again."
+    context := "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Karemera then breaks."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "result")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_31 : LinguisticExample :=
+  { id := "beavers_etal2021_31"
+    source := ⟨"beavers-etal-2021", "(31)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "ha-gesher 'arox 'aval 'afpa'am lo hu'arax."
+    discourseSegments := []
+    glossedTokens := [("ha-gesher", "the-bridge"), ("'arox", "long"), ("'aval", "but"), ("'afpa'am", "never"), ("lo", "NEG"), ("hu'arax", "lengthened.PASS")]
+    translation := "The bridge is long but was never lengthened."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "property concept")]
+    comment := "With deverbal mu'arax 'lengthened' in place of 'arox the sentence is contradictory."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_32 : LinguisticExample :=
+  { id := "beavers_etal2021_32"
+    source := ⟨"beavers-etal-2021", "(32)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "ha-zxuxit menupecet, 'aval hi 'afpa'am lo hitnapca."
+    discourseSegments := []
+    glossedTokens := [("ha-zxuxit", "the-glass"), ("menupecet", "shattered"), ("'aval", "but"), ("hi", "it"), ("'afpa'am", "never"), ("lo", "NEG"), ("hitnapca", "shattered.REFL")]
+    translation := "The glass is shattered, but it never shattered."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "result")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_33b : LinguisticExample :=
+  { id := "beavers_etal2021_33b"
+    source := ⟨"beavers-etal-2021", "(33b)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "Kim nipca šuv/mexadaš 'et ha-zxuxit."
+    discourseSegments := []
+    glossedTokens := [("Kim", "Kim"), ("nipca", "shattered"), ("šuv/mexadaš", "again/anew"), ("'et", "ACC"), ("ha-zxuxit", "the-glass")]
+    translation := "Kim shattered the glass again."
+    context := "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Kim then shatters."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "result")]
+    comment := "mexadaš 'anew' generates only restitutive readings, similar to English re- prefixation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_35b : LinguisticExample :=
+  { id := "beavers_etal2021_35b"
+    source := ⟨"beavers-etal-2021", "(35b)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "kāc phoɖ-leli āhe pəɳ ti kədhi phuʈ-leli nāhi."
+    discourseSegments := []
+    glossedTokens := [("kāc", "glass.NOM.F.SG"), ("phoɖ-leli", "shatter.TR-PART.F.SG"), ("āhe", "be.PRS.3SG"), ("pəɳ", "but"), ("ti", "DEM.F.SG"), ("kədhi", "ever"), ("phuʈ-leli", "shatter.INTR-PART.F.SG"), ("nāhi", "NEG")]
+    translation := "The glass is shattered, but it never shattered."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "change denial"), ("root class", "result")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_36b : LinguisticExample :=
+  { id := "beavers_etal2021_36b"
+    source := ⟨"beavers-etal-2021", "(36b)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "Kim-ne parat kach phoɖ-li."
+    discourseSegments := []
+    glossedTokens := [("Kim-ne", "Kim-ERG"), ("parat", "again"), ("kach", "glass.F.SG.NOM"), ("phoɖ-li", "break-PFV.F.SG")]
+    translation := "Kim broke the glass again."
+    context := "Small pieces of glass, manufactured in that size, are assembled into a single pane, which Kim then shatters."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "restitutive again"), ("root class", "result")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def beavers_etal2021_38b : LinguisticExample :=
+  { id := "beavers_etal2021_38b"
+    source := ⟨"beavers-etal-2021", "(38b)"⟩
+    reportedIn := none
+    language := "mode1248"
+    primaryText := "I Maria eftiakse ke tin tileorasi."
+    discourseSegments := []
+    glossedTokens := [("I", "the"), ("Maria", "Mary"), ("eftiakse", "fixed"), ("ke", "also"), ("tin", "the"), ("tileorasi", "television")]
+    translation := "Mary fixed the television too."
+    context := "Mary bought a new TV and a new laptop. The laptop was working fine, but the TV was not. Mary brought her tools."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "additive restitutive"), ("root class", "result")]
+    comment := "Spathas's additive test: ftiahno 'fix' rejects the restitutive-like additive reading, patterning with result roots."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [beavers_etal2021_1c, beavers_etal2021_7a, beavers_etal2021_10a, beavers_etal2021_11c, beavers_etal2021_13, beavers_etal2021_15a, beavers_etal2021_16a, beavers_etal2021_25a, beavers_etal2021_26, beavers_etal2021_28a, beavers_etal2021_28b, beavers_etal2021_29b, beavers_etal2021_31, beavers_etal2021_32, beavers_etal2021_33b, beavers_etal2021_35b, beavers_etal2021_36b, beavers_etal2021_38b]
+
+end BeaversEtAl2021.Examples

--- a/Linglib/Studies/BeaversEtAl2021.lean
+++ b/Linglib/Studies/BeaversEtAl2021.lean
@@ -5,145 +5,166 @@ import Linglib.Semantics.ArgumentStructure.LevinTheory
 import Linglib.Semantics.ArgumentStructure.EventStructure
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Studies.Coon2019
+import Linglib.Data.Examples.BeaversEtAl2021
 
 /-!
-# Cross-Linguistic Typology of Change-of-State Verbs
-[dixon-1982] [levin-1993] [beavers-etal-2021] [coon-2019]
+# Beavers et al. (2021): States and Changes of State
 
-Empirical data from Beavers, Everdell, Jerro, Kauhanen, [beavers-etal-2021] "States and changes of state: A crosslinguistic
-study of the roots of verbal meaning." Language 97(3), 439–484.
+Across an 88-language balanced sample, roots of deadjectival change-of-state
+verbs (property-concept roots: *large*, *red*, *dry*) tend to have simple
+stative forms and marked verbs, while roots of non-deadjectival ones (result
+roots: *break*, *cook*, *kill*) lack simple statives and have unmarked verbs.
+Semantic tests — change denial (10)–(11) and restitutive *again* (14)–(16) —
+show that words built on result roots always entail change. The simplest
+analysis is that result roots carry the change entailment themselves,
+refuting the bifurcation thesis (2): templatic meaning can live in roots.
+The default-realization rule (44) then derives the markedness mirror image
+and the three attested language types.
 
-88-language balanced sample (WALS 100 + additions). For each of 36 property
-concept (PC) and 36 result root meanings, the authors collected five-item
-paradigms (underlying root, simple stative, inchoative, causative, result
-stative) and coded morphological relationships.
+## Main statements
 
-## Key findings (theory-neutral)
+* `bifurcation_fails`: result roots entail change
+  (`Verb.Root.ChangeType.entailsChange`), violating the bifurcation
+  thesis (2).
+* `grand_unification`: the root's change entailment alone determines the
+  full package of morphosyntactic correlates ((44), §§3, 6–9).
+* `markedness_complementarity`: verbal and stative markedness are mirror
+  images, ruling out the unattested fourth language type (§8).
 
-1. **Simple statives**: PC roots overwhelmingly have simple stative forms
-   (median = 95.67% of languages); result roots overwhelmingly lack them
-   (median = 1.59%). Mann-Whitney U = 1266.5, p < 0.001.
+## References
 
-2. **Verbal markedness**: PC root verbs tend to be marked (median = 56.01%);
-   result root verbs tend to be unmarked (median = 15.20%).
-   Mann-Whitney U = 1291, p < 0.001.
-
-3. **Subclass clustering**: PC subclasses (dimension, color, value, physical
-   property, speed) cluster near 100% simple statives. Result subclasses
-   (breaking, cooking, killing, destroying, directed motion) cluster near 0%.
-
-## Theory apparatus
-
-The change-entailment theory (§§3–14 below) is stated over the substrate
-`Verb.Root.ChangeType`; this paper is its sole consumer. The "Markedness
-Generalization" label is the formaliser's — the content (ex. (44)) is faithful
-to the paper.
-
+* [beavers-etal-2021]: States and changes of state: A crosslinguistic study
+  of the roots of verbal meaning. *Language* 97.
+* [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
+* [embick-2004]: On the structure of resultative participles in English.
+* [embick-2009]: Roots, states, and stative passives.
+* [arad-2005]: Roots and Patterns: Hebrew Morpho-syntax.
+* [dixon-1982]: Where Have All the Adjectives Gone?
+* [haspelmath-1993]: More on the typology of inchoative/causative verb
+  alternations.
+* [coon-2019]: Building verbs in Chuj.
 -/
 
 namespace BeaversEtAl2021
 
 open Verb Verb.Root ArgumentStructure ArgumentStructure.EventStructure Features
 
--- ════════════════════════════════════════════════════
--- § 1. Root Classification (theory-neutral)
--- ════════════════════════════════════════════════════
+/-! ### Root meanings and subclasses ((5)–(6)) -/
 
-/-- Two classes of change-of-state verb roots, defined by morphological
-    and semantic diagnostics ([beavers-etal-2021] §3.1).
-
-    Classification criteria:
-    - PC roots: the root of deadjectival CoS verbs ([levin-1993]:245);
-      describe [dixon-1982]'s basic property types
-    - Result roots: the root of non-deadjectival CoS verbs;
-      describe specific result states (physical damage, cooking, etc.) -/
-inductive CoSRootClass where
-  | propertyConcept  -- deadjectival: flatten, redden, widen
-  | result           -- non-deadjectival: break, crack, shatter
-  deriving DecidableEq, Repr
-
-/-- PC subclasses ([dixon-1982]; [beavers-etal-2021] ex. 5). -/
+/-- [dixon-1982]'s basic property types: the property-concept subclasses (5),
+those most often lexicalized as adjectives across languages. -/
 inductive PCSubclass where
-  | dimension         -- large/big, small, long, short, deep, wide, tall/high
-  | age               -- old/aged
-  | value             -- bad/worse, good/improved
-  | color             -- white, black, red, green, blue, brown
-  | physicalProperty  -- cool/cold, warm/hot, dry/wet, soft/hard, smooth/rough
-  | speed             -- fast, slow
+  /-- *large*, *small*, *long*, *short*, *deep*, *wide*, *tall*. -/
+  | dimension
+  /-- *old*. -/
+  | age
+  /-- *bad*, *good*. -/
+  | value
+  /-- *white*, *black*, *red*, *green*, *blue*, *brown*. -/
+  | color
+  /-- *cool*, *warm*, *dry*, *soft*, *hard*, *smooth*. -/
+  | physicalProperty
+  /-- *fast*, *slow*. -/
+  | speed
   deriving DecidableEq, Repr
 
-/-- Result root subclasses ([levin-1993]; [beavers-etal-2021] ex. 6). -/
+/-- Result-root subclasses (6), chosen from [levin-1993] for having likely
+translation equivalents across languages. -/
 inductive ResultSubclass where
-  | entitySpecificCoS          -- burned, melted, frozen, decayed, bloomed
-  | cooking                    -- cooked, baked, fried, roasted, boiled
-  | breaking                   -- broken, cracked, crushed, shattered, torn
-  | bending                    -- bent, folded, wrinkled, creased
-  | killing                    -- dead, killed, murdered, drowned
-  | destroying                 -- destroyed, ruined
-  | calibratableCoS            -- go up, increase, go down, decrease, differ
-  | inherentlyDirectedMotion   -- come, go, enter, exit, return
+  /-- *burn*, *melt*, *freeze*, *decay*, *bloom*. -/
+  | entitySpecificCoS
+  /-- *cook*, *bake*, *fry*, *roast*, *boil*. -/
+  | cooking
+  /-- *break*, *crack*, *crush*, *shatter*, *tear*. -/
+  | breaking
+  /-- *bend*, *fold*, *wrinkle*. -/
+  | bending
+  /-- *kill*, *murder*, *drown*. -/
+  | killing
+  /-- *destroy*, *ruin*. -/
+  | destroying
+  /-- *rise*, *fall*, *increase*, *decrease*, *differ*. -/
+  | calibratableCoS
+  /-- *come*, *go*, *enter*, *exit*, *return*. -/
+  | inherentlyDirectedMotion
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 2. Morphological Paradigm Structure
--- ════════════════════════════════════════════════════
+/-! ### The paradigm and relation codes ((40)–(41)) -/
 
-/-- The five positions in a CoS verb paradigm ([beavers-etal-2021] eq. 40).
-    Every root meaning is associated with (up to) five forms. -/
+/-- The five positions of a root's paradigm (40): every root meaning is
+associated with up to five forms. -/
 inductive ParadigmPosition where
-  | underlyingRoot  -- Position 1: base morphological root
-  | simpleStative   -- Position 2: basic stative form (adj/verb)
-  | inchoative      -- Position 3: intransitive change-of-state
-  | causative        -- Position 4: transitive causative
-  | resultStative   -- Position 5: deverbal stative (participle-like)
+  /-- Position 1: separate shared base morpheme, if any. -/
+  | underlyingRoot
+  /-- Position 2: basic stative form (adjective, verb, or noun). -/
+  | simpleStative
+  /-- Position 3: intransitive change-of-state form. -/
+  | inchoative
+  /-- Position 4: transitive causative form. -/
+  | causative
+  /-- Position 5: deverbal stative form. -/
+  | resultStative
   deriving DecidableEq, Repr
 
-/-- Morphological relationship codes between forms ([beavers-etal-2021]
-    eq. 41, generalizing [haspelmath-1993]:90–92). -/
+/-- Morphological relationship codes between a form and each paradigm member
+(41), generalizing [haspelmath-1993]'s classification. The `unrelated` code
+covers what Haspelmath called suppletive pairs (*kill* ~ *die*); `identity`
+marks a form's relation to its own paradigm slot. -/
 inductive MorphRelation where
-  | input      -- (i) X is the input to a rule forming Y_k
-  | derived    -- (d) X is the output of a rule on Y_k
-  | transitive -- (t) X is transitively related via input/output pairs
-  | labile     -- (l) X and Y_k are labile (same surface stem)
-  | equipollent -- (e) X and Y_k are equipollent
-  | unrelated  -- (u) no above relation applies
-  | unattested -- (n) Y_k is unattested
-  | suppletive -- (s) X is Y_k (suppletive)
+  /-- (i) input to a rule forming the other form. -/
+  | input
+  /-- (d) output of a rule on the other form. -/
+  | derived
+  /-- (t) transitively related via input/output pairs. -/
+  | transitive
+  /-- (l) labile: same surface stem. -/
+  | labile
+  /-- (e) equipollent: both derived from a shared base. -/
+  | equipollent
+  /-- (u) unrelated: no other relation applies. -/
+  | unrelated
+  /-- (n) the other form is unattested. -/
+  | unattested
+  /-- (s) the forms are the same item. -/
+  | identity
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 3. Per-Root Crosslinguistic Data (Tables A1, A2)
--- ════════════════════════════════════════════════════
+/-! ### Per-root crosslinguistic sample (Tables A1–A2)
 
-/-- A root meaning with its crosslinguistic attestation. -/
+Full-table medians (§6, §7): PC roots have simple statives in a median
+95.67% of languages with data vs 1.59% for result roots (Mann-Whitney
+U = 1266.5, n₁ = n₂ = 36, p < 0.001); PC verbal paradigms are marked in a
+median 56.01% of languages vs 15.20% for result roots (U = 1291, p < 0.001).
+The rows below are a sample of the 72 root meanings. -/
+
+/-- A root meaning with its crosslinguistic attestation counts
+(Tables A1–A2). -/
 structure RootMeaning where
-  /-- English gloss(es) -/
+  /-- English gloss(es). -/
   gloss : String
-  /-- PC or result root -/
-  rootClass : CoSRootClass
-  /-- Subclass, if applicable -/
+  /-- Property-concept or result root. -/
+  rootClass : ChangeType
+  /-- Subclass per (5)–(6). -/
   subclass : Option (PCSubclass ⊕ ResultSubclass) := none
-  /-- Number of languages with a simple stative for this root (Table A1) -/
+  /-- Languages with a simple stative for this root (Table A1). -/
   nSimpleStative : Nat
-  /-- Number of languages with any data for this root (Table A1) -/
+  /-- Languages with any data for this root (Table A1). -/
   nLanguages : Nat
-  /-- Number of languages with a marked verbal paradigm (Table A2) -/
+  /-- Languages with a marked verbal paradigm (Table A2). -/
   nMarkedVerbal : Nat
-  /-- Number of languages with verbal paradigm data (Table A2) -/
+  /-- Languages with sufficient verbal-paradigm data (Table A2). -/
   nVerbalLanguages : Nat
   deriving Repr
 
-/-- Percentage of languages with simple stative (exact ℚ — kernel-decidable). -/
+/-- Fraction of languages with a simple stative, as a percentage. -/
 def RootMeaning.pctSimpleStative (r : RootMeaning) : ℚ :=
   if r.nLanguages = 0 then 0
   else (r.nSimpleStative : ℚ) * 100 / r.nLanguages
 
-/-- Percentage of languages with marked verbal paradigm (exact ℚ). -/
+/-- Fraction of languages with a marked verbal paradigm, as a percentage. -/
 def RootMeaning.pctMarkedVerbal (r : RootMeaning) : ℚ :=
   if r.nVerbalLanguages = 0 then 0
   else (r.nMarkedVerbal : ℚ) * 100 / r.nVerbalLanguages
-
--- PC roots (Table A1/A2 data)
 
 def coldRoot : RootMeaning :=
   ⟨"cold/make cold", .propertyConcept, some (.inl .physicalProperty), 83, 83, 27, 45⟩
@@ -157,12 +178,12 @@ def goodRoot : RootMeaning :=
   ⟨"good/improved/improve", .propertyConcept, some (.inl .value), 83, 85, 30, 46⟩
 def dryRoot : RootMeaning :=
   ⟨"dry/dry", .propertyConcept, some (.inl .physicalProperty), 72, 85, 32, 64⟩
+/-- The one PC outlier: *old* was coded as a result stative on the grounds
+that being old entails a prior young/new state (§6.1). -/
 def oldRoot : RootMeaning :=
   ⟨"old/aged/age", .propertyConcept, some (.inl .age), 0, 81, 10, 36⟩
 def whiteRoot : RootMeaning :=
   ⟨"white/whiten", .propertyConcept, some (.inl .color), 81, 84, 27, 35⟩
-
--- Result roots (Table A1/A2 data)
 
 def brokenRoot : RootMeaning :=
   ⟨"broken/break", .result, some (.inr .breaking), 1, 85, 21, 80⟩
@@ -173,7 +194,7 @@ def deadRoot : RootMeaning :=
 def meltedRoot : RootMeaning :=
   ⟨"melted/melt", .result, some (.inr .entitySpecificCoS), 3, 64, 16, 61⟩
 def shatteredRoot : RootMeaning :=
-  ⟨"shattered/shatter", .result, some (.inr .breaking), 1, 53, 4, 37⟩
+  ⟨"shattered/shatter", .result, some (.inr .breaking), 1, 53, 7, 48⟩
 def bentRoot : RootMeaning :=
   ⟨"bent/bend", .result, some (.inr .bending), 6, 73, 14, 57⟩
 def burnedRoot : RootMeaning :=
@@ -192,182 +213,58 @@ def resultRoots : List RootMeaning :=
   [brokenRoot, cookedRoot, deadRoot, meltedRoot, shatteredRoot,
    bentRoot, burnedRoot, tornRoot, goneRoot, destroyedRoot]
 
--- ════════════════════════════════════════════════════
--- § 4. Statistical Summary (§6, §7)
--- ════════════════════════════════════════════════════
+/-- Every sampled PC root except the *old* outlier has a simple stative in
+a majority of languages with data (Table A1, Fig. 2). -/
+theorem pc_roots_majority_statives :
+    ∀ r ∈ pcRoots, r.gloss ≠ oldRoot.gloss →
+      r.nLanguages ≤ 2 * r.nSimpleStative := by decide
 
-/-- Summary of a crosslinguistic comparison between PC and result roots.
-    Numeric fields are exact ℚ (mathlib idiom for kernel-decidable arithmetic;
-    [beavers-etal-2021] reports values to 2 decimal places). -/
-structure TypologicalComparison where
-  /-- What is being measured -/
-  measure : String
-  /-- PC root median percentage -/
-  pcMedian : ℚ
-  /-- Result root median percentage -/
-  resultMedian : ℚ
-  /-- Mann-Whitney U statistic -/
-  uStatistic : ℚ
-  /-- One-tailed p-value threshold -/
-  pThreshold : ℚ
-  /-- Sample sizes (PC roots, result roots) -/
-  nPC : Nat
-  nResult : Nat
-  deriving Repr
-
-/-- Simple stative form comparison (§6, Fig. 1).
-    Medians: 95.67% and 1.59% encoded as exact rationals via OfScientific. -/
-def simpleStativeComparison : TypologicalComparison :=
-  { measure := "% languages with simple stative",
-    pcMedian := 95.67, resultMedian := 1.59,
-    uStatistic := 1266.5, pThreshold := 0.001,
-    nPC := 36, nResult := 36 }
-
-/-- Verbal markedness comparison (§7, Fig. 5).
-    Medians: 56.01% and 15.20% encoded as exact rationals via OfScientific. -/
-def verbalMarkednessComparison : TypologicalComparison :=
-  { measure := "% languages with marked verbal paradigm",
-    pcMedian := 56.01, resultMedian := 15.20,
-    uStatistic := 1291, pThreshold := 0.001,
-    nPC := 36, nResult := 36 }
-
-/-- Both comparisons are statistically significant. -/
-theorem both_comparisons_significant :
-    simpleStativeComparison.pcMedian > simpleStativeComparison.resultMedian ∧
-    verbalMarkednessComparison.pcMedian > verbalMarkednessComparison.resultMedian := by
-  unfold simpleStativeComparison verbalMarkednessComparison
-  refine ⟨?_, ?_⟩ <;> norm_num
-
--- ════════════════════════════════════════════════════
--- § 5. Semantic Diagnostics (§§3.3–3.4, theory-neutral)
--- ════════════════════════════════════════════════════
-
-/-- Empirical diagnostics for classifying roots.
-    Each diagnostic independently sorts roots into two classes that
-    align with the PC vs result distinction. -/
-inductive DiagnosticResult where
-  | positive  -- diagnostic is satisfied
-  | negative  -- diagnostic is not satisfied
-  deriving DecidableEq, Repr
-
-/-- Stative form + change denial test (§3.3, ex. 10–11).
-    "The bright photo has never brightened" → OK (PC)
-    "#The shattered vase has never shattered" → contradictory (result) -/
-def changeDenialTest : CoSRootClass → DiagnosticResult
-  | .propertyConcept => .positive  -- stative can hold without change
-  | .result => .negative           -- stative entails prior change
-
-/-- Restitutive 'again' test (§3.4, ex. 15–16).
-    "John sharpened the knife again" → can be just one sharpening (PC)
-    "#Chris thawed the meat again" → necessarily two thawings (result) -/
-def restitutiveAgainTest : CoSRootClass → DiagnosticResult
-  | .propertyConcept => .positive  -- restitutive reading available
-  | .result => .negative           -- only repetitive reading
-
-/-- The two diagnostics always agree. -/
-theorem diagnostics_agree (rc : CoSRootClass) :
-    changeDenialTest rc = restitutiveAgainTest rc := by
-  cases rc <;> rfl
-
--- ════════════════════════════════════════════════════
--- § 6. Per-Language Data (§§4.1–4.5, Table 1)
--- ════════════════════════════════════════════════════
-
-/-- A language's CoS verb typological profile. -/
-structure LanguageProfile where
-  language : String
-  family : String
-  /-- Number of PC root verbal paradigms with data -/
-  nPCParadigms : Nat
-  /-- Number of result root verbal paradigms with data -/
-  nResultParadigms : Nat
-  /-- % of PC paradigms that are marked (exact ℚ) -/
-  pctPCMarked : ℚ
-  /-- % of result paradigms that are marked (exact ℚ) -/
-  pctResultMarked : ℚ
-  deriving Repr
-
-/-- The six in-depth case study languages (§4). -/
-def kakataibo : LanguageProfile :=
-  ⟨"Kakataibo", "Panoan", 59, 64, 23.73, 31.25⟩
-def kinyarwanda : LanguageProfile :=
-  ⟨"Kinyarwanda", "Northeastern Bantu", 69, 33, 4.17, 9.09⟩
-def hebrew : LanguageProfile :=
-  ⟨"Hebrew (Modern)", "Semitic", 35, 42, 97.62, 0.98⟩
-def marathi : LanguageProfile :=
-  ⟨"Marathi", "Indic", 40, 35, 20.41, 21.33⟩
-def greek : LanguageProfile :=
-  ⟨"Greek (Modern)", "Indo-European", 76, 57, 2.63, 2.15⟩
-def english : LanguageProfile :=
-  ⟨"English", "Germanic", 43, 60, 0.0, 0.0⟩
-
-def caseStudyLanguages : List LanguageProfile :=
-  [kakataibo, kinyarwanda, hebrew, marathi, greek, english]
-
-/-- Attested language types (§7.2, §8). -/
-inductive LanguageType where
-  | asymmetric        -- English-type: PC marked, result unmarked (overt asymmetry)
-  | highMarking       -- Hebrew-type: both root classes marked
-  | lowMarking        -- Labile/equipollent: low or no marking for both
-  deriving DecidableEq, Repr
-
-/-- The fourth logically possible type (result marked, PC unmarked)
-    is UNATTESTED — predicted by the markedness generalization. -/
-def LanguageType.allAttested : List LanguageType :=
-  [.asymmetric, .highMarking, .lowMarking]
-
-/-- Three and only three types are attested. -/
-theorem three_attested_types :
-    LanguageType.allAttested.length = 3 := by decide
-
--- ════════════════════════════════════════════════════
--- § 7. Verification: Per-Root Data Consistency
--- ════════════════════════════════════════════════════
-
-/-- All entries in our PC root sample are classified as PC. -/
-theorem pcRoots_all_pc :
-    pcRoots.all (·.rootClass == .propertyConcept) = true := by decide
-
-/-- All entries in our result root sample are classified as result. -/
-theorem resultRoots_all_result :
-    resultRoots.all (·.rootClass == .result) = true := by decide
-
-/-- Most PC roots in the sample have ≥ 50% simple stative attestation. -/
-theorem most_pc_roots_have_statives :
-    (pcRoots.filter (λ r => r.nSimpleStative * 2 ≥ r.nLanguages)).length ≥
-    pcRoots.length - 1 := by  -- all but 'old' (age is an exception)
-  decide
-
-/-- No result root in the sample exceeds 10% simple stative attestation. -/
+/-- No sampled result root has a simple stative in more than a tenth of
+languages with data (Table A1, Fig. 2). -/
 theorem result_roots_rare_statives :
-    resultRoots.all (λ r => r.nSimpleStative * 10 ≤ r.nLanguages) = true := by
-  decide
+    ∀ r ∈ resultRoots, 10 * r.nSimpleStative ≤ r.nLanguages := by decide
 
--- ════════════════════════════════════════════════════
--- § 3′. Morphosyntactic correlates of change entailment
--- ════════════════════════════════════════════════════
+/-! ### Semantic diagnostics ((10)–(16)) -/
 
-/-- PC roots have simple (unmarked) stative forms; result roots lack them.
-    English: "bright" (PC, simple adj) vs *"shattered" requires prior change.
-    Crosslinguistic evidence (§6, Fig. 1): PC median = 95.67%, result median =
-    1.59% (Mann-Whitney U = 1266.5, p < 0.001, n₁ = n₂ = 36). -/
+/-- Change denial (10)–(11): a stative form survives conjoined denial of
+change (*the bright photo has never brightened*) iff its root does not
+entail change; result-root statives are contradictory even in
+prototypical-result contexts (*#the shattered vase has never shattered*). -/
+def survivesChangeDenial : ChangeType → Bool
+  | .propertyConcept => true
+  | .result => false
+
+/-- Change denial succeeds exactly when the root does not entail change. -/
+theorem survivesChangeDenial_iff (ct : ChangeType) :
+    survivesChangeDenial ct = true ↔ ct.entailsChange = false := by
+  cases ct <;> simp [survivesChangeDenial, ChangeType.entailsChange]
+
+/-- The change-denial and restitutive-*again* diagnostics ((10)–(11) vs
+(14)–(16)) sort roots identically. -/
+theorem diagnostics_agree (ct : ChangeType) :
+    survivesChangeDenial ct = ct.allowsRestitutiveAgain := by
+  cases ct <;> rfl
+
+/-! ### Morphosyntactic correlates (§§6–7) -/
+
+/-- PC roots have simple (unmarked) stative forms; result roots lack them:
+*bright* is a simple adjective while *shattered* requires the deverbal form.
+Crosslinguistic tendency, not universal (§6, Fig. 1). -/
 def hasSimpleStative : ChangeType → Bool
   | .propertyConcept => true
   | .result => false
 
-/-- PC root verbs TEND to be morphologically marked (wid-en, flat-ten); result
-    root verbs tend to be unmarked (break, crack). The cross-linguistic DEFAULT,
-    not a universal — [hanink-koontz-garboden-2025] §4 notes deviating Wá·šiw
-    Class 1 roots. Crosslinguistic evidence (§7, Fig. 5): PC median = 56.01%,
-    result median = 15.20% (U = 1291, p < 0.001). -/
+/-- PC root verbs tend to be morphologically marked (*wid-en*, *flat-ten*);
+result root verbs tend to be unmarked (*break*, *crack*). Crosslinguistic
+tendency (§7, Fig. 5). -/
 def verbalFormIsMarked : ChangeType → Bool
   | .propertyConcept => true
   | .result => false
 
-/-- **The main theorem.** A root's entailment of change determines all of its
-    morphosyntactic behavior in a single biconditional: result roots lack simple
-    statives (§6), have unmarked verbal forms (§7), and lack restitutive *again*
-    (§3.4); PC roots are the reverse. Refutes the Bifurcation Thesis. -/
+/-- A root's change entailment determines its morphosyntactic profile in a
+single biconditional: result roots lack simple statives (§6), have unmarked
+verbal forms (§7), and lack restitutive *again* (§3.4); PC roots are the
+reverse. -/
 theorem semantic_determines_morphosyntax (ct : ChangeType) :
     ct.entailsChange = true ↔
     (hasSimpleStative ct = false ∧
@@ -376,47 +273,29 @@ theorem semantic_determines_morphosyntax (ct : ChangeType) :
   cases ct <;> simp [ChangeType.entailsChange, hasSimpleStative,
     verbalFormIsMarked, ChangeType.allowsRestitutiveAgain]
 
-/-- The converse: NOT entailing change determines the opposite package. -/
-theorem pc_determines_morphosyntax (ct : ChangeType) :
-    ct.entailsChange = false ↔
-    (hasSimpleStative ct = true ∧
-     verbalFormIsMarked ct = true ∧
-     ct.allowsRestitutiveAgain = true) := by
-  cases ct <;> simp [ChangeType.entailsChange, hasSimpleStative,
-    verbalFormIsMarked, ChangeType.allowsRestitutiveAgain]
+/-! ### The bifurcation thesis and its refutation ((2), §§3.6, 9) -/
 
--- ════════════════════════════════════════════════════
--- § 5′. The Bifurcation Thesis and its refutation (§§2, 3.6, 9)
--- ════════════════════════════════════════════════════
-
-/-- The Bifurcation Thesis for Roots ([embick-2009]:1, [arad-2005]:79;
-    [beavers-etal-2021] ex. 2): a component of meaning introduced by a templatic
-    operator cannot be part of a root's meaning — so NO root should entail
-    change. -/
+/-- The bifurcation thesis for roots ([embick-2009], [arad-2005];
+(2)): a component of meaning introduced by a templatic operator cannot be
+part of a root's meaning — so no root should entail change. -/
 def bifurcationThesis (rootEntailsChange : ChangeType → Bool) : Prop :=
   ∀ ct, rootEntailsChange ct = false
 
-/-- [beavers-etal-2021] main result: bifurcation does not hold. Result roots
-    entail change, violating the thesis (§§3.3, 3.6, 9). -/
+/-- The paper's main result: result roots entail change, so bifurcation
+fails (§§3.3, 3.6, 9). -/
 theorem bifurcation_fails :
     ¬ bifurcationThesis ChangeType.entailsChange := by
   intro h
   have := h .result
   simp [ChangeType.entailsChange] at this
 
-/-- Result roots witness bifurcation failure. -/
-theorem result_roots_witness_against_bifurcation :
-    ChangeType.entailsChange .result = true := rfl
-
-/-- PC roots are consistent with bifurcation (they don't entail change). -/
+/-- PC roots on their own are consistent with bifurcation. -/
 theorem pc_roots_consistent_with_bifurcation :
     ChangeType.entailsChange .propertyConcept = false := rfl
 
-/-- **B&[beavers-koontz-garboden-2020] strengthened bifurcation failure via
-    `Root.Kinds`.** [beavers-etal-2021] show roots can entail CHANGE;
-    B&[beavers-koontz-garboden-2020] show roots can entail CHANGE, CAUSATION,
-    and MANNER simultaneously (√GUILLOTINE, √HAND) — a strictly stronger
-    refutation. Witness: `Root.Kinds.fullSpec` carries all four kinds. -/
+/-- [beavers-koontz-garboden-2020] strengthen the refutation: roots can
+entail change, causation, and manner simultaneously (√GUILLOTINE, √HAND) —
+witnessed by `Root.Kinds.fullSpec`. -/
 theorem bkg_bifurcation_fails_all_dimensions :
     LexKind.result ∈ Root.Kinds.fullSpec ∧
     LexKind.cause ∈ Root.Kinds.fullSpec ∧
@@ -430,217 +309,215 @@ theorem bkg_bifurcation_multiple_witnesses :
     LexKind.cause ∈ LevinClass.rootEntailments .give ∧
     LexKind.manner ∈ LevinClass.rootEntailments .give := by decide
 
--- ════════════════════════════════════════════════════
--- § 8′. The Markedness Generalization (§8, ex. 44)
--- ════════════════════════════════════════════════════
+/-! ### Default realization ((44), §8) -/
 
-/-- Whether a form is morphologically marked (derived/complex) or unmarked
-    (basic/simple). -/
+/-- Whether a form is morphologically marked relative to its paradigm. -/
 inductive Markedness where
-  | unmarked  -- basic form (no additional morphology)
-  | marked    -- derived form (overt marking: -en, -ed, etc.)
+  /-- Basic form: only labile and unrelated relationships. -/
+  | unmarked
+  /-- Derived from or equipollent to another paradigm member. -/
+  | marked
   deriving DecidableEq, Repr
 
-/-- The Markedness Generalization ([beavers-etal-2021] ex. 44): morphological
-    markedness reflects semantic mismatch between a functional head and its root
-    complement. A verb is unmarked when v_become is redundant with the root's
-    change entailment; a stative is unmarked when no change need be stripped.
-    This yields the three attested language types (English-type asymmetric,
-    equipollent, labile) and rules out the unattested fourth. -/
+/-- Default realization of `v_become` (44a): a root entailing change is
+redundant with `v_become`, so its verb is unmarked; a PC root's verb carries
+the change overtly and is marked. -/
 def verbalMarkedness (ct : ChangeType) : Markedness :=
   if ct.entailsChange then .unmarked else .marked
 
-/-- Stative markedness is the mirror image of verbal markedness. -/
+/-- Default realization of the stative head (44b): the mirror image — a PC
+root's stative is basic, a result root's stative must strip nothing and is
+built on the verb. -/
 def stativeMarkedness (ct : ChangeType) : Markedness :=
   if ct.entailsChange then .marked else .unmarked
 
-/-- Verbal and stative markedness are always complementary. -/
+/-- Verbal and stative markedness are mirror images, so the fourth logically
+possible language type — result roots more marked than PC roots in both
+columns — is predicted not to exist (§8). -/
 theorem markedness_complementarity (ct : ChangeType) :
     verbalMarkedness ct ≠ stativeMarkedness ct := by
   cases ct <;> simp [verbalMarkedness, stativeMarkedness, ChangeType.entailsChange]
 
-/-- Result roots produce unmarked verbs. -/
-theorem result_root_unmarked_verb :
-    verbalMarkedness .result = .unmarked := rfl
-
-/-- PC roots produce marked verbs. -/
-theorem pc_root_marked_verb :
-    verbalMarkedness .propertyConcept = .marked := rfl
-
-/-- Result roots produce marked statives. -/
-theorem result_root_marked_stative :
-    stativeMarkedness .result = .marked := rfl
-
-/-- PC roots produce unmarked statives. -/
-theorem pc_root_unmarked_stative :
-    stativeMarkedness .propertyConcept = .unmarked := rfl
-
-/-- The markedness generalization is equivalent to the semantic distinction. -/
+/-- Verbal unmarkedness is exactly the change entailment. -/
 theorem markedness_from_semantics (ct : ChangeType) :
     verbalMarkedness ct = .unmarked ↔ ct.entailsChange = true := by
   cases ct <;> simp [verbalMarkedness, ChangeType.entailsChange]
 
--- ════════════════════════════════════════════════════
--- § 8″. Bridge to EntailmentProfile.changeOfState (ProtoRoles §8)
--- ════════════════════════════════════════════════════
+/-! ### Language types (§7.2, Table 1)
 
-/-- Dowty's P-Patient entailment "undergoes change of state" is precisely the
-    result root entailment: an object bearing a result root's state predicate
-    has `changeOfState = true`. -/
+The (44) asymmetry surfaces only in languages with an overt markedness
+contrast. Equipollent languages (Hebrew) mark nearly everything and labile
+or unrelated-pair languages (Kakataibo, Kinyarwanda) mark nearly nothing,
+neutralizing the contrast in opposite directions; the asymmetric type
+(English, Greek) shows it directly. -/
+
+/-- A language's verbal-markedness profile (Table 1). -/
+structure LanguageProfile where
+  language : String
+  family : String
+  /-- PC root verbal paradigms with determinable markedness. -/
+  nPCParadigms : Nat
+  /-- Result root verbal paradigms with determinable markedness. -/
+  nResultParadigms : Nat
+  /-- Percentage of PC verbal paradigms that are marked. -/
+  pctPCMarked : ℚ
+  /-- Percentage of result verbal paradigms that are marked. -/
+  pctResultMarked : ℚ
+  deriving Repr
+
+def kakataibo : LanguageProfile :=
+  ⟨"Kakataibo", "Panoan", 59, 64, 23.73, 31.25⟩
+def kinyarwanda : LanguageProfile :=
+  ⟨"Kinyarwanda", "Northeastern Bantu", 24, 33, 4.17, 9.09⟩
+def hebrew : LanguageProfile :=
+  ⟨"Hebrew (Modern)", "Semitic", 35, 42, 100, 97.62⟩
+def greek : LanguageProfile :=
+  ⟨"Greek (Modern)", "Indo-European", 22, 44, 59.09, 6.82⟩
+def english : LanguageProfile :=
+  ⟨"English", "Germanic", 43, 60, 46.51, 1.67⟩
+
+/-- English and Greek show the overt asymmetry (44) predicts: marked PC
+verbs, unmarked result verbs. -/
+theorem asymmetric_type_shows_contrast :
+    english.pctResultMarked < english.pctPCMarked ∧
+    greek.pctResultMarked < greek.pctPCMarked := by
+  refine ⟨?_, ?_⟩ <;> norm_num [english, greek]
+
+/-- Hebrew neutralizes the contrast from above: its equipollent
+root-and-template morphology marks both root classes near-categorically. -/
+theorem hebrew_neutralizes_high :
+    90 ≤ hebrew.pctPCMarked ∧ 90 ≤ hebrew.pctResultMarked := by
+  refine ⟨?_, ?_⟩ <;> norm_num [hebrew]
+
+/-- Kakataibo and Kinyarwanda neutralize from below: labile paradigms leave
+both root classes largely unmarked (the paper's low-marking † criterion:
+at most a third marked). -/
+theorem labile_type_neutralizes_low :
+    3 * kakataibo.pctPCMarked ≤ 100 ∧ 3 * kakataibo.pctResultMarked ≤ 100 ∧
+    3 * kinyarwanda.pctPCMarked ≤ 100 ∧ 3 * kinyarwanda.pctResultMarked ≤ 100 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> norm_num [kakataibo, kinyarwanda]
+
+/-! ### Bridge to `EntailmentProfile.changeOfState` -/
+
+/-- Dowty's P-Patient entailment "undergoes change of state" is the result
+root entailment: profiles with `changeOfState` pattern as result roots. -/
 def rootTypeFromChangeEntailment (p : EntailmentProfile) : ChangeType :=
   if p.changeOfState then .result else .propertyConcept
 
-/-- A result verb's object (accomplishment template) has `changeOfState = true`,
-    so it patterns with result roots. Contact-verb objects (*kick*: CA+St, no
-    entailed change per [beavers-2011]) fall on the other side of the bridge. -/
+/-- Accomplishment objects pattern with result roots; contact-verb objects
+(*kick*: no entailed change) fall on the PC side. -/
 theorem result_object_has_changeOfState :
     rootTypeFromChangeEntailment accomplishmentObjectProfile = .result ∧
     rootTypeFromChangeEntailment ArgumentStructure.contactObject
       = .propertyConcept := by
   decide
 
-/-- Die subject undergoes change → result-type pattern. -/
+/-- *die*'s subject undergoes change, so it patterns with result roots. -/
 theorem die_result_pattern :
     rootTypeFromChangeEntailment
       ArgumentStructure.disappearance.subjectProfile = .result := by
   decide
 
--- ════════════════════════════════════════════════════
--- § 9′. Bridge to Template / BECOME (EventStructure §2)
--- ════════════════════════════════════════════════════
+/-! ### Bridge to templates and BECOME -/
 
-/-- Result roots MUST combine with a template containing BECOME (achievement or
-    accomplishment): the root's change entailment is redundant with BECOME. PC
-    roots CAN combine with any template. -/
+/-- Result roots must combine with a template containing BECOME: the root's
+change entailment is redundant with it. PC roots combine with any
+template. -/
 def requiresBECOME : ChangeType → Bool
   | .result => true
   | .propertyConcept => false
 
-/-- Result roots always get templates with BECOME. -/
-theorem result_root_gets_become_template :
-    requiresBECOME .result = true := rfl
-
-/-- Achievement and accomplishment templates contain BECOME. -/
+/-- Achievement and accomplishment templates contain BECOME; the state
+template does not, so it is available only to PC roots. -/
 def templateHasBECOME : Template → Bool
   | .achievement => true
   | .accomplishment => true
   | _ => false
 
-/-- The templates result roots combine with always have BECOME. -/
-theorem result_templates_have_become :
-    templateHasBECOME .achievement = true ∧
-    templateHasBECOME .accomplishment = true :=
-  ⟨rfl, rfl⟩
-
-/-- State template lacks BECOME — only available to PC roots. -/
-theorem state_template_no_become :
-    templateHasBECOME .state = false := rfl
-
-/-- Templates with BECOME map to achievement/accomplishment Vendler classes,
-    both telic. -/
-theorem become_templates_telic :
-    Template.vendlerClass .achievement = .achievement ∧
-    Template.vendlerClass .accomplishment = .accomplishment := ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- § 10′. Root types and VendlerClass (Aspect)
--- ════════════════════════════════════════════════════
-
-/-- Aspectual profile for root types in their stative use. -/
-def stativeAspectualProfile : ChangeType → AspectualProfile
-  | .propertyConcept => stateProfile        -- "The rug is flat" (stative)
-  | .result => achievementProfile           -- even "broken" entails change
-
-/-- Result root verbs pattern as achievements/accomplishments; PC roots in
-    stative use are states. -/
-def stativeVendlerClass (ct : ChangeType) : VendlerClass :=
-  (stativeAspectualProfile ct).toVendlerClass
-
-/-- PC roots in stative use are states; result roots pattern as achievements. -/
-theorem root_stative_vendler :
-    stativeVendlerClass .propertyConcept = .state ∧
-    stativeVendlerClass .result = .achievement :=
-  ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- § 11′. [embick-2004] Adjectival Structures (§3.2, ex. 8)
--- ════════════════════════════════════════════════════
-
-/-- [embick-2004] posits basic statives ([AspP AspS √ROOT], PC roots only) and
-    result statives ([AspP AspR [vP DP v_become √ROOT]], deverbal; result roots
-    always, PC roots optionally). -/
-inductive AdjectivalStructure where
-  | basicStative    -- [AspP AspS √ROOT] — simple adjective
-  | resultStative   -- [AspP AspR [vP DP v_become √ROOT]] — deverbal
-  deriving DecidableEq, Repr
-
-/-- PC roots admit both structures; result roots only admit resultStative. -/
-def admitsBasicStative : ChangeType → Bool
-  | .propertyConcept => true
-  | .result => false
-
-/-- This is equivalent to NOT entailing change. -/
-theorem admitsBasicStative_iff_no_change (ct : ChangeType) :
-    admitsBasicStative ct = true ↔ ct.entailsChange = false := by
-  cases ct <;> simp [admitsBasicStative, ChangeType.entailsChange]
-
--- ════════════════════════════════════════════════════
--- § 12′. The Again Diagnostic ([beavers-koontz-garboden-2020] §1.3.2, §2.4)
--- ════════════════════════════════════════════════════
-
-/-- Sublexical *again* attaches low (to the root, restitutive) or high (over
-    `vbecome`, repetitive). Restitutive is available iff the root is change-free;
-    a result root's state itself entails change, collapsing its low attachment
-    into the repetitive reading. -/
-inductive AgainReading where
-  | restitutive   -- again scopes over root only
-  | repetitive    -- again scopes over vP (includes BECOME)
-  deriving DecidableEq, Repr
-
-/-- Which readings of 'again' are available for each root type. -/
-def againReadings : ChangeType → List AgainReading
-  | .propertyConcept => [.restitutive, .repetitive]
-  | .result => [.repetitive]
-
-/-- PC roots have strictly more 'again' readings than result roots. -/
-theorem pc_more_again_readings :
-    (againReadings .propertyConcept).length >
-    (againReadings .result).length := by decide
-
-/-- Result roots lack the restitutive reading. -/
-theorem result_no_restitutive :
-    ¬ AgainReading.restitutive ∈ againReadings .result := by
-  simp [againReadings]
-
-/-- PC roots have the restitutive reading. -/
-theorem pc_has_restitutive :
-    AgainReading.restitutive ∈ againReadings .propertyConcept := by
-  simp [againReadings]
-
--- ════════════════════════════════════════════════════
--- § 13′. Consequence for event-structural theory (§9)
--- ════════════════════════════════════════════════════
-
-/-- If a root entails change, its verb is associated with a template containing
-    BECOME (§9) — even when the change comes from the ROOT, not the template. -/
+/-- A root entailing change is associated with a BECOME template even
+though the change comes from the root (§9). -/
 theorem entails_change_implies_become_template (ct : ChangeType)
     (h : ct.entailsChange = true) :
     requiresBECOME ct = true := by
   cases ct <;> simp_all [ChangeType.entailsChange, requiresBECOME]
 
-/-- Conversely: a root not requiring BECOME does not entail change. -/
+/-- A root not requiring BECOME does not entail change. -/
 theorem no_become_implies_no_change (ct : ChangeType)
     (h : requiresBECOME ct = false) :
     ct.entailsChange = false := by
   cases ct <;> simp_all [requiresBECOME, ChangeType.entailsChange]
 
--- ════════════════════════════════════════════════════
--- § 14′. Grand unification: all correlates from entailsChange
--- ════════════════════════════════════════════════════
+/-- BECOME templates map to the telic Vendler classes. -/
+theorem become_templates_telic :
+    Template.vendlerClass .achievement = .achievement ∧
+    Template.vendlerClass .accomplishment = .accomplishment := ⟨rfl, rfl⟩
 
-/-- **The full correlation package.** From the single Boolean `entailsChange`,
-    all of the paper's morphosyntactic predictions follow: one semantic property
-    is the sole determinant of six independently observable properties. -/
+/-- Aspectual profile of a root's stative use: PC statives are states,
+while even a result root's stative entails change. -/
+def stativeAspectualProfile : ChangeType → AspectualProfile
+  | .propertyConcept => stateProfile
+  | .result => achievementProfile
+
+/-- PC roots in stative use are states; result-root statives pattern as
+achievements. -/
+theorem root_stative_vendler :
+    (stativeAspectualProfile .propertyConcept).toVendlerClass = .state ∧
+    (stativeAspectualProfile .result).toVendlerClass = .achievement :=
+  ⟨rfl, rfl⟩
+
+/-! ### [embick-2004]'s adjectival structures ((8)) -/
+
+/-- [embick-2004] posits basic statives (root with the stative head, (8a))
+and result statives (root under `v_become`, (8b)); PC roots admit both,
+result roots only the deverbal structure. -/
+inductive AdjectivalStructure where
+  /-- Simple adjective: stative head over the bare root (8a). -/
+  | basicStative
+  /-- Deverbal adjective: stative head over a `v_become` phrase (8b). -/
+  | resultStative
+  deriving DecidableEq, Repr
+
+/-- Which roots admit the basic-stative structure (8a). -/
+def admitsBasicStative : ChangeType → Bool
+  | .propertyConcept => true
+  | .result => false
+
+/-- Admitting (8a) is equivalent to not entailing change. -/
+theorem admitsBasicStative_iff_no_change (ct : ChangeType) :
+    admitsBasicStative ct = true ↔ ct.entailsChange = false := by
+  cases ct <;> simp [admitsBasicStative, ChangeType.entailsChange]
+
+/-! ### Sublexical *again* ((14)–(16)) -/
+
+/-- Attachment sites for sublexical *again*: to the root (restitutive) or
+over `v_become` (repetitive). -/
+inductive AgainReading where
+  /-- *again* scopes over the root's state only. -/
+  | restitutive
+  /-- *again* scopes over the change-introducing structure. -/
+  | repetitive
+  deriving DecidableEq, Repr
+
+/-- Available *again* readings by root class: a result root's state itself
+entails change, collapsing low attachment into the repetitive reading. -/
+def againReadings : ChangeType → List AgainReading
+  | .propertyConcept => [.restitutive, .repetitive]
+  | .result => [.repetitive]
+
+/-- Result roots lack the restitutive reading (16). -/
+theorem result_no_restitutive :
+    AgainReading.restitutive ∉ againReadings .result := by
+  simp [againReadings]
+
+/-- PC roots have the restitutive reading (15). -/
+theorem pc_has_restitutive :
+    AgainReading.restitutive ∈ againReadings .propertyConcept := by
+  simp [againReadings]
+
+/-! ### Grand unification -/
+
+/-- From the root's change entailment alone, all of the paper's
+morphosyntactic predictions follow. -/
 theorem grand_unification (ct : ChangeType) :
     (ct.entailsChange = true →
       hasSimpleStative ct = false ∧
@@ -664,16 +541,16 @@ theorem grand_unification (ct : ChangeType) :
     requiresBECOME, admitsBasicStative,
     verbalMarkedness, stativeMarkedness]
 
-/-- Change entailment determines markedness in the unified `Classification`. -/
+/-- Change entailment determines markedness through the unified
+`Classification`. -/
 theorem root_markedness_from_change (r : Classification) :
     verbalMarkedness r.changeType = .unmarked ↔ r.entailsChange = true := by
   cases r with | mk valency changeType _ =>
   cases changeType <;> simp [Classification.entailsChange,
     verbalMarkedness, ChangeType.entailsChange]
 
-/-- Roots with the same change type have identical morphosyntactic behavior
-    regardless of valency — markedness, stative forms, and again readings are
-    orthogonal to internal argument selection. -/
+/-- Roots with the same change type behave identically regardless of
+valency: markedness and statives are orthogonal to argument selection. -/
 theorem same_change_same_morphosyntax (r₁ r₂ : Classification)
     (h : r₁.changeType = r₂.changeType) :
     verbalMarkedness r₁.changeType = verbalMarkedness r₂.changeType ∧
@@ -681,146 +558,17 @@ theorem same_change_same_morphosyntax (r₁ r₂ : Classification)
     r₁.entailsChange = r₂.entailsChange := by
   simp [Classification.entailsChange, h]
 
--- ════════════════════════════════════════════════════
--- § 8. Theory ↔ Empirical Bridge: ChangeType ↔ CoSRootClass
--- ════════════════════════════════════════════════════
-
-/-! The §§8–14 sections below were originally housed in
-    `Studies/Coon2019.lean` as bridge content
-    between Coon's Chuj data, the present empirical typology, and the root
-    typology substrate. They are relocated here per the chronological-
-    dependency rule (Coon 2019 < Beavers et al. 2021 — only the later
-    paper may reference the earlier). -/
-
-/-- Map the theory's change type to the empirical root class.
-    These are parallel enums — the bridge makes the correspondence explicit. -/
-def toCoSRootClass : ChangeType → CoSRootClass
-  | .propertyConcept => .propertyConcept
-  | .result => .result
-
-/-- Map back from empirical to theory. -/
-def fromCoSRootClass : CoSRootClass → ChangeType
-  | .propertyConcept => .propertyConcept
-  | .result => .result
-
-/-- The mapping is a bijection (left inverse). -/
-theorem roundtrip_left (ct : ChangeType) :
-    fromCoSRootClass (toCoSRootClass ct) = ct := by
-  cases ct <;> rfl
-
-/-- The mapping is a bijection (right inverse). -/
-theorem roundtrip_right (rc : CoSRootClass) :
-    toCoSRootClass (fromCoSRootClass rc) = rc := by
-  cases rc <;> rfl
-
--- ════════════════════════════════════════════════════
--- § 9. Diagnostic Alignment with ChangeType
--- ════════════════════════════════════════════════════
-
-/-- The empirical `changeDenialTest` agrees with the theory's `entailsChange`.
-
-    Theory: `ChangeType.entailsChange .result = true` (result roots entail change)
-    Empirical: `changeDenialTest.result =.negative` ("#The shattered vase
-    has never shattered" is contradictory — the state entails prior change)
-
-    The relationship is: entailsChange = true ↔ changeDenial = negative. -/
-theorem change_denial_matches_entailsChange (rc : CoSRootClass) :
-    changeDenialTest rc = .positive ↔
-    (fromCoSRootClass rc).entailsChange = false := by
-  cases rc <;> decide
-
-/-- The empirical `restitutiveAgainTest` agrees with the theory's
-    `allowsRestitutiveAgain`. -/
-theorem restitutive_again_matches (rc : CoSRootClass) :
-    restitutiveAgainTest rc = .positive ↔
-    (fromCoSRootClass rc).allowsRestitutiveAgain = true := by
-  cases rc <;> decide
-
-/-- Both diagnostics jointly align with the full semantic correlate package.
-    The bridge form of `semantic_determines_morphosyntax`. -/
-theorem diagnostics_align_with_theory (rc : CoSRootClass) :
-    let rt := fromCoSRootClass rc
-    (changeDenialTest rc = .negative ↔ rt.entailsChange = true) ∧
-    (restitutiveAgainTest rc = .negative ↔ rt.allowsRestitutiveAgain = false) := by
-  cases rc <;> decide
-
--- ════════════════════════════════════════════════════
--- § 10. Simple Stative Prediction ↔ Attestation
--- ════════════════════════════════════════════════════
-
-/-- **Theory predicts**: PC roots have simple statives.
-    **Data confirms**: 7 of 8 PC sample roots have ≥ 50% attestation.
-    The one exception (oldRoot, age class) has 0 — noted by the present
-    paper as a crosslinguistic outlier. -/
-theorem pc_stative_prediction_matches_data :
-    -- Theory prediction
-    hasSimpleStative .propertyConcept = true ∧
-    -- Empirical confirmation (all but one PC root)
-    (pcRoots.filter (λ r => r.nSimpleStative * 2 ≥ r.nLanguages)).length ≥
-    pcRoots.length - 1 := by
-  exact ⟨rfl, by decide⟩
-
-/-- **Theory predicts**: result roots LACK simple statives.
-    **Data confirms**: all 10 result sample roots have ≤ 10% attestation. -/
-theorem result_no_stative_prediction_matches_data :
-    -- Theory prediction
-    hasSimpleStative .result = false ∧
-    -- Empirical confirmation (ALL result roots)
-    resultRoots.all (λ r => r.nSimpleStative * 10 ≤ r.nLanguages) = true := by
-  exact ⟨rfl, by decide⟩
-
--- ════════════════════════════════════════════════════
--- § 11. Markedness Prediction ↔ Statistical Comparison
--- ════════════════════════════════════════════════════
-
-/-- **Theory predicts**: PC verbs are morphologically marked; result verbs
-    are unmarked (Markedness Generalization, [beavers-etal-2021]).
-    **Data confirms**: PC median marked % (56.01) > result median (15.20). -/
-theorem markedness_prediction_matches_statistics :
-    -- Theory: PC verbs are marked
-    verbalMarkedness .propertyConcept = .marked ∧
-    -- Theory: result verbs are unmarked
-    verbalMarkedness .result = .unmarked ∧
-    -- Data: PC marked rate exceeds result marked rate
-    simpleStativeComparison.pcMedian > simpleStativeComparison.resultMedian ∧
-    verbalMarkednessComparison.pcMedian > verbalMarkednessComparison.resultMedian := by
-  refine ⟨rfl, rfl, ?_, ?_⟩
-  · exact both_comparisons_significant.1
-  · exact both_comparisons_significant.2
-
--- ════════════════════════════════════════════════════
--- § 12. Unattested Language Type
--- ════════════════════════════════════════════════════
-
-/-- The theory's markedness complementarity predicts that if a language
-    marks PC verbs, it should NOT also show result verbs as more marked
-    than PC verbs. The fourth logically possible language type (result
-    marked, PC unmarked) is unattested — exactly 3 types are attested.
-    This matches the theory: `markedness_complementarity` says verbal and
-    stative markedness are always opposite. -/
-theorem unattested_type_matches_complementarity :
-    -- Exactly three types attested
-    LanguageType.allAttested.length = 3 ∧
-    -- Theory: verbal and stative markedness always differ
-    (∀ ct : ChangeType, verbalMarkedness ct ≠ stativeMarkedness ct) := by
-  refine ⟨by decide, ?_⟩
-  intro ct; cases ct <;> decide
-
--- ════════════════════════════════════════════════════
--- § 13. Chuj Root Grounding ([coon-2019])
--- ════════════════════════════════════════════════════
+/-! ### Chuj root grounding ([coon-2019]) -/
 
 open Chuj
 
-/-- [beavers-etal-2021]'s result-root row for [coon-2019]'s √TV class:
-    the shared coordinates are `RootClass.toClassification`; only the
-    change-entailment column is this paper's subdivision (Coon does not
-    subdivide √TV). -/
+/-- The result-root subdivision of [coon-2019]'s √TV class: shared
+coordinates from `RootClass.toClassification`, with only the
+change-entailment column added by the present paper. -/
 def rootTV_res : Classification :=
   { RootClass.tv.toClassification with changeType := .result }
 
-/-- The property-concept row of the √TV subdivision (no change
-    entailment). -/
+/-- The property-concept subdivision of √TV (no change entailment). -/
 def rootTV_pc : Classification :=
   { RootClass.tv.toClassification with changeType := .propertyConcept }
 
@@ -830,72 +578,29 @@ def rootITV : Classification := RootClass.itv.toClassification
 /-- Coon's √POS coordinates, reused unchanged. -/
 def rootPOS : Classification := RootClass.pos.toClassification
 
-/-- Chuj √TV result roots instantiate the theory's result root predictions:
-    entails change, no simple stative, unmarked verb. -/
+/-- Chuj √TV result roots instantiate the result-root package: change
+entailed, no simple stative, unmarked verb. -/
 theorem chuj_tv_res_is_result_root :
     rootTV_res.entailsChange = true ∧
     hasSimpleStative rootTV_res.changeType = false ∧
-    verbalMarkedness rootTV_res.changeType = .unmarked := by
-  exact ⟨rfl, rfl, rfl⟩
+    verbalMarkedness rootTV_res.changeType = .unmarked :=
+  ⟨rfl, rfl, rfl⟩
 
-/-- Chuj √TV PC roots instantiate the theory's PC root predictions:
-    no change entailment, has simple stative, marked verb. -/
+/-- Chuj √TV PC roots instantiate the PC package: no change entailment,
+simple stative, marked verb. -/
 theorem chuj_tv_pc_is_pc_root :
     rootTV_pc.entailsChange = false ∧
     hasSimpleStative rootTV_pc.changeType = true ∧
-    verbalMarkedness rootTV_pc.changeType = .marked := by
-  exact ⟨rfl, rfl, rfl⟩
+    verbalMarkedness rootTV_pc.changeType = .marked :=
+  ⟨rfl, rfl, rfl⟩
 
-/-- The Chuj fragment witnesses cells of the (valency × changeType)
-    matrix: theme-taking roots with and without change entailment, and
-    valency-free property-concept roots (√POS — √ITV is unaccusative and
-    theme-taking per [coon-2019] §3.3). -/
+/-- The Chuj fragment witnesses cells of the valency × change-type matrix:
+theme-taking roots with and without change entailment, and valency-free
+property-concept roots. -/
 theorem chuj_witnesses_orthogonality :
-    -- internal + result (√TV result)
     rootTV_res.valency = {.internal} ∧ rootTV_res.changeType = .result ∧
-    -- internal + PC (√TV PC, √ITV)
     rootTV_pc.valency = {.internal} ∧ rootTV_pc.changeType = .propertyConcept ∧
-    -- no core positions + PC (√POS, √NOM)
     rootPOS.valency = ∅ ∧ rootPOS.changeType = .propertyConcept :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- Per-root class verification: each Chuj root's change entailment matches
-    its predicted morphosyntactic correlates via `grand_unification`. -/
-theorem chuj_roots_satisfy_grand_unification :
-    -- Result root (√TV res): entails change → full result package
-    (hasSimpleStative rootTV_res.changeType = false ∧
-     verbalFormIsMarked rootTV_res.changeType = false ∧
-     rootTV_res.changeType.allowsRestitutiveAgain = false) ∧
-    -- PC root (√TV PC): no change → full PC package
-    (hasSimpleStative rootTV_pc.changeType = true ∧
-     verbalFormIsMarked rootTV_pc.changeType = true ∧
-     rootTV_pc.changeType.allowsRestitutiveAgain = true) ∧
-    -- PC root (√ITV): no change → full PC package
-    (hasSimpleStative rootITV.changeType = true ∧
-     verbalFormIsMarked rootITV.changeType = true ∧
-     rootITV.changeType.allowsRestitutiveAgain = true) :=
-  ⟨⟨rfl, rfl, rfl⟩, ⟨rfl, rfl, rfl⟩, ⟨rfl, rfl, rfl⟩⟩
-
--- ════════════════════════════════════════════════════
--- § 14. Per-Root Data ↔ Theory Agreement
--- ════════════════════════════════════════════════════
-
-/-- Every PC root in the empirical sample is classified as PC, and the theory
-    predicts PC roots should have simple statives — they do. -/
-theorem pc_roots_classified_and_predicted :
-    -- Data: all sample PC roots are classified as PC
-    pcRoots.all (·.rootClass == .propertyConcept) = true ∧
-    -- Theory: PC has simple stative
-    hasSimpleStative .propertyConcept = true := by
-  exact ⟨by decide, rfl⟩
-
-/-- Every result root in the empirical sample is classified as result, and the
-    theory predicts result roots lack simple statives — they do. -/
-theorem result_roots_classified_and_predicted :
-    -- Data: all sample result roots are classified as result
-    resultRoots.all (·.rootClass == .result) = true ∧
-    -- Theory: result lacks simple stative
-    hasSimpleStative .result = false := by
-  exact ⟨by decide, rfl⟩
 
 end BeaversEtAl2021


### PR DESCRIPTION
Recut against the paper (read in full). Fixes hand-typed data errors (shattered A2 row was snapped's; Kinyarwanda/Hebrew/Greek/English Table 1 values wrong or column-shifted; Marathi row fabricated — not in the sample), dissolves the duplicate CoSRootClass enum onto substrate ChangeType, relabels the (41s) identity code (was mislabeled suppletive), drops the chronology-violating 2025 citation and vacuous count/statistics theorems; 18 examples in Data/Examples.