### PR TITLE
refactor(Studies/BeckmanPierrehumbert1986): chronology, locators, rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -355,6 +355,7 @@ import Linglib.Data.Examples.BeaversEtAl2021
 import Linglib.Data.Examples.BeaversKoontzGarboden2020
 import Linglib.Data.Examples.BeaversUdayana2022
 import Linglib.Data.Examples.BeckOdaSugisaki2004
+import Linglib.Data.Examples.BeckmanPierrehumbert1986
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015
 import Linglib.Data.Examples.Bondarenko2022

--- a/Linglib/Data/Examples/BeckmanPierrehumbert1986.json
+++ b/Linglib/Data/Examples/BeckmanPierrehumbert1986.json
@@ -1,0 +1,268 @@
+[
+  {
+    "id": "bp1986_fig3",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 3"},
+    "language": "nucl1643",
+    "primaryText": "Kore-wa toriya-no mawari-no oma'warisan-no hanasi desu.",
+    "glossedTokens": [
+      ["Kore-wa", "this-TOP"], ["toriya-no", "bird.shop-GEN"], ["mawari-no", "vicinity-GEN"],
+      ["oma'warisan-no", "policeman-GEN"], ["hanasi", "story"], ["desu", "COP"]
+    ],
+    "translation": "This is a story about the policeman near the bird shop.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["accentual phrase", "unaccented"],
+      ["tonal pattern", "phrasal H ... boundary L"]
+    ],
+    "comment": "The long unaccented AP shows smooth interpolation from phrasal H to boundary L — no H-tone spreading."
+  },
+  {
+    "id": "bp1986_fig5",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 5"},
+    "language": "nucl1643",
+    "primaryText": "Kore-wa mo'riya-no mawari-no oma'warisan-no hanasi desu.",
+    "glossedTokens": [
+      ["Kore-wa", "this-TOP"], ["mo'riya-no", "Moriya-GEN"], ["mawari-no", "vicinity-GEN"],
+      ["oma'warisan-no", "policeman-GEN"], ["hanasi", "story"], ["desu", "COP"]
+    ],
+    "translation": "This is a story about the policeman near Moriya.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["accentual phrase", "accented"],
+      ["process", "catathesis"]
+    ],
+    "comment": "The boundary L after the accented phrase is realized much lower: catathesis triggered by the accent."
+  },
+  {
+    "id": "bp1986_fig6a",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 6a"},
+    "language": "nucl1643",
+    "primaryText": "Uma'i mame'-wa arimasen.",
+    "glossedTokens": [
+      ["Uma'i", "delicious"], ["mame'-wa", "bean-TOP"], ["arimasen", "exist.NEG.POL"]
+    ],
+    "translation": "There are no delicious beans.",
+    "context": "Adjective and noun grouped in one accentual phrase.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["process", "accent deletion"],
+      ["constraint", "one accent per AP"]
+    ],
+    "comment": "Grouping two accented words into one AP deletes the second accent; the contour equals Fig. 6b's."
+  },
+  {
+    "id": "bp1986_fig6b",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 6b"},
+    "language": "nucl1643",
+    "primaryText": "Uma'i ame-wa arimasen.",
+    "glossedTokens": [
+      ["Uma'i", "delicious"], ["ame-wa", "candy-TOP"], ["arimasen", "exist.NEG.POL"]
+    ],
+    "translation": "There is no delicious candy.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["accentual phrase", "one accent"],
+      ["noun", "unaccented"]
+    ],
+    "comment": "Identical tonal contour to Fig. 6a — deletion neutralizes the mame'/ame accent contrast under grouping."
+  },
+  {
+    "id": "bp1986_fig8",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 8"},
+    "language": "nucl1643",
+    "primaryText": "Amai mame'-wa arimasen.",
+    "glossedTokens": [
+      ["Amai", "sweet"], ["mame'-wa", "bean-TOP"], ["arimasen", "exist.NEG.POL"]
+    ],
+    "translation": "There are no sweet beans.",
+    "context": "Contrastive emphasis on amai.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["focus", "initial"],
+      ["process", "subordination or dephrasing"]
+    ],
+    "comment": "Focus on the unaccented adjective flattens the following accented noun's rise — extreme subordination is phonetically like dephrasing."
+  },
+  {
+    "id": "bp1986_ex2",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "(2)"},
+    "language": "nucl1643",
+    "primaryText": "Kono arai ayaori-no obizi ga.",
+    "glossedTokens": [
+      ["Kono", "this"], ["arai", "rough"], ["ayaori-no", "twill-GEN"], ["obizi", "obi.cloth"],
+      ["ga", "NOM"]
+    ],
+    "translation": "This rough twill obi-cloth.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["intermediate phrase", "break after first modifier"]
+    ],
+    "comment": "Most subjects split this into two intermediate phrases — smaller than an English intonation phrase."
+  },
+  {
+    "id": "bp1986_ex3",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "(3)"},
+    "language": "nucl1643",
+    "primaryText": "be'ika neage hantai u'ndoo",
+    "glossedTokens": [
+      ["be'ika", "rice.price"], ["neage", "price.raise"], ["hantai", "protest"],
+      ["u'ndoo", "movement"]
+    ],
+    "translation": "movement protesting rice-price increases",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["intermediate phrase", "break inside compound"]
+    ],
+    "comment": "Catathesis blocked after neage: an ip boundary can fall inside a compound in Japanese."
+  },
+  {
+    "id": "bp1986_fig36",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 36"},
+    "language": "nucl1643",
+    "primaryText": "Moo tyotto migigawa-ga sagerare'ru.",
+    "glossedTokens": [
+      ["Moo", "more"], ["tyotto", "a.little"], ["migigawa-ga", "right.side-NOM"],
+      ["sagerare'ru", "can.be.lowered"]
+    ],
+    "translation": "The right side can be lowered a little more.",
+    "context": "Declarative vs yes/no question renditions.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["process", "final lowering"],
+      ["domain", "declaratives only"]
+    ],
+    "comment": "Declarative and interrogative F0 match early and diverge at the end: final lowering in declaratives."
+  },
+  {
+    "id": "bp1986_fig1",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 1"},
+    "language": "stan1293",
+    "primaryText": "an orange ballgown",
+    "glossedTokens": [],
+    "translation": "an orange ballgown",
+    "context": "Answers to the question: What's that?",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "H* H* L L%: neutral declarative", "judgment": "acceptable"},
+      {"name": "H*+L H* L L%: downstepping, feigned judiciousness", "judgment": "acceptable"},
+      {"name": "L* H* L L%: surprise-redundancy", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["accent inventory", "postlexical shape choice"]
+    ],
+    "comment": "Accent shape contrasts intonational meanings, never lexical items."
+  },
+  {
+    "id": "bp1986_fig2",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 2"},
+    "language": "stan1293",
+    "primaryText": "I really won't allow Mary.",
+    "glossedTokens": [],
+    "translation": "I really won't allow Mary.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "H* on Mary: peak near end of stressed syllable, impatient reassertion", "judgment": "acceptable"},
+      {"name": "H+L* on Mary: peak just before the stressed syllable, peevish", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["diagnostic", "peak alignment"],
+      ["claim", "bitonal accents are units"]
+    ],
+    "comment": "The unstarred H of H+L* lands mid-word in Marianna — implausible as any phrasal tone."
+  },
+  {
+    "id": "bp1986_fig11",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 11"},
+    "language": "stan1293",
+    "primaryText": "blueberries, boysberries, raspberries, mulberries and brambleberries",
+    "glossedTokens": [],
+    "translation": "blueberries, boysberries, raspberries, mulberries and brambleberries",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["process", "catathesis chain"],
+      ["contour", "descending staircase"]
+    ],
+    "comment": "Iterated catathesis: up to six or seven step levels, ruling out a fixed mid tone."
+  },
+  {
+    "id": "bp1986_ex4",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "(4)"},
+    "language": "stan1293",
+    "primaryText": "'I' means insert.",
+    "glossedTokens": [],
+    "translation": "'I' means insert.",
+    "context": "A text-editor tutor defining a key.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["intermediate phrase", "medial L phrase accent"]
+    ],
+    "comment": "The definiendum is set off as its own intermediate phrase; a full intonation break would be too strong."
+  },
+  {
+    "id": "bp1986_ex7",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "(7)"},
+    "language": "stan1293",
+    "primaryText": "They gave orange marmalade, lemon-oil marmalade, and watermelon-rind marmalade?",
+    "glossedTokens": [],
+    "translation": "They gave orange marmalade, lemon-oil marmalade, and watermelon-rind marmalade?",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["intermediate phrase", "H phrase accent per list item"],
+      ["boundary tone", "one final H%"]
+    ],
+    "comment": "Three H-phrase-accent ips under one intonation phrase whose single H% closes the list."
+  },
+  {
+    "id": "bp1986_ex9",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "(9)"},
+    "language": "stan1293",
+    "primaryText": "A pale orange and yellow ballgown.",
+    "glossedTokens": [],
+    "translation": "A pale orange and yellow ballgown.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "pale | orange and yellow: both conjuncts pale", "judgment": "acceptable"},
+      {"name": "pale orange | and yellow: only the orange pale", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["intermediate phrase", "scope disambiguation"]
+    ],
+    "comment": "Intermediate phrasing disambiguates the scope of the modifier over the conjunction."
+  },
+  {
+    "id": "bp1986_fig34",
+    "source": {"bibkey": "beckman-pierrehumbert-1986", "paperLabel": "Fig. 34"},
+    "language": "stan1293",
+    "primaryText": "it's eleven and nine and one and EIGHTY",
+    "glossedTokens": [],
+    "translation": "it's eleven and nine and one and EIGHTY",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["process", "catathesis blocked at focus"],
+      ["intermediate phrase", "break before focus"]
+    ],
+    "comment": "Downstepping accents on the first three numbers; the focused item is set off by an ip boundary that resets the range."
+  }
+]

--- a/Linglib/Data/Examples/BeckmanPierrehumbert1986.lean
+++ b/Linglib/Data/Examples/BeckmanPierrehumbert1986.lean
@@ -1,0 +1,288 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BeckmanPierrehumbert1986` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BeckmanPierrehumbert1986.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BeckmanPierrehumbert1986.Examples`.
+-/
+
+namespace BeckmanPierrehumbert1986.Examples
+
+open Data.Examples
+
+def bp1986_fig3 : LinguisticExample :=
+  { id := "bp1986_fig3"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 3"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Kore-wa toriya-no mawari-no oma'warisan-no hanasi desu."
+    discourseSegments := []
+    glossedTokens := [("Kore-wa", "this-TOP"), ("toriya-no", "bird.shop-GEN"), ("mawari-no", "vicinity-GEN"), ("oma'warisan-no", "policeman-GEN"), ("hanasi", "story"), ("desu", "COP")]
+    translation := "This is a story about the policeman near the bird shop."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("accentual phrase", "unaccented"), ("tonal pattern", "phrasal H ... boundary L")]
+    comment := "The long unaccented AP shows smooth interpolation from phrasal H to boundary L — no H-tone spreading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig5 : LinguisticExample :=
+  { id := "bp1986_fig5"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 5"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Kore-wa mo'riya-no mawari-no oma'warisan-no hanasi desu."
+    discourseSegments := []
+    glossedTokens := [("Kore-wa", "this-TOP"), ("mo'riya-no", "Moriya-GEN"), ("mawari-no", "vicinity-GEN"), ("oma'warisan-no", "policeman-GEN"), ("hanasi", "story"), ("desu", "COP")]
+    translation := "This is a story about the policeman near Moriya."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("accentual phrase", "accented"), ("process", "catathesis")]
+    comment := "The boundary L after the accented phrase is realized much lower: catathesis triggered by the accent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig6a : LinguisticExample :=
+  { id := "bp1986_fig6a"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 6a"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Uma'i mame'-wa arimasen."
+    discourseSegments := []
+    glossedTokens := [("Uma'i", "delicious"), ("mame'-wa", "bean-TOP"), ("arimasen", "exist.NEG.POL")]
+    translation := "There are no delicious beans."
+    context := "Adjective and noun grouped in one accentual phrase."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("process", "accent deletion"), ("constraint", "one accent per AP")]
+    comment := "Grouping two accented words into one AP deletes the second accent; the contour equals Fig. 6b's."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig6b : LinguisticExample :=
+  { id := "bp1986_fig6b"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 6b"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Uma'i ame-wa arimasen."
+    discourseSegments := []
+    glossedTokens := [("Uma'i", "delicious"), ("ame-wa", "candy-TOP"), ("arimasen", "exist.NEG.POL")]
+    translation := "There is no delicious candy."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("accentual phrase", "one accent"), ("noun", "unaccented")]
+    comment := "Identical tonal contour to Fig. 6a — deletion neutralizes the mame'/ame accent contrast under grouping."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig8 : LinguisticExample :=
+  { id := "bp1986_fig8"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 8"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Amai mame'-wa arimasen."
+    discourseSegments := []
+    glossedTokens := [("Amai", "sweet"), ("mame'-wa", "bean-TOP"), ("arimasen", "exist.NEG.POL")]
+    translation := "There are no sweet beans."
+    context := "Contrastive emphasis on amai."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("focus", "initial"), ("process", "subordination or dephrasing")]
+    comment := "Focus on the unaccented adjective flattens the following accented noun's rise — extreme subordination is phonetically like dephrasing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_ex2 : LinguisticExample :=
+  { id := "bp1986_ex2"
+    source := ⟨"beckman-pierrehumbert-1986", "(2)"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Kono arai ayaori-no obizi ga."
+    discourseSegments := []
+    glossedTokens := [("Kono", "this"), ("arai", "rough"), ("ayaori-no", "twill-GEN"), ("obizi", "obi.cloth"), ("ga", "NOM")]
+    translation := "This rough twill obi-cloth."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("intermediate phrase", "break after first modifier")]
+    comment := "Most subjects split this into two intermediate phrases — smaller than an English intonation phrase."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_ex3 : LinguisticExample :=
+  { id := "bp1986_ex3"
+    source := ⟨"beckman-pierrehumbert-1986", "(3)"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "be'ika neage hantai u'ndoo"
+    discourseSegments := []
+    glossedTokens := [("be'ika", "rice.price"), ("neage", "price.raise"), ("hantai", "protest"), ("u'ndoo", "movement")]
+    translation := "movement protesting rice-price increases"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("intermediate phrase", "break inside compound")]
+    comment := "Catathesis blocked after neage: an ip boundary can fall inside a compound in Japanese."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig36 : LinguisticExample :=
+  { id := "bp1986_fig36"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 36"⟩
+    reportedIn := none
+    language := "nucl1643"
+    primaryText := "Moo tyotto migigawa-ga sagerare'ru."
+    discourseSegments := []
+    glossedTokens := [("Moo", "more"), ("tyotto", "a.little"), ("migigawa-ga", "right.side-NOM"), ("sagerare'ru", "can.be.lowered")]
+    translation := "The right side can be lowered a little more."
+    context := "Declarative vs yes/no question renditions."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("process", "final lowering"), ("domain", "declaratives only")]
+    comment := "Declarative and interrogative F0 match early and diverge at the end: final lowering in declaratives."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig1 : LinguisticExample :=
+  { id := "bp1986_fig1"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "an orange ballgown"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "an orange ballgown"
+    context := "Answers to the question: What's that?"
+    judgment := .acceptable
+    alternatives := []
+    readings := [("H* H* L L%: neutral declarative", .acceptable), ("H*+L H* L L%: downstepping, feigned judiciousness", .acceptable), ("L* H* L L%: surprise-redundancy", .acceptable)]
+    paperFeatures := [("accent inventory", "postlexical shape choice")]
+    comment := "Accent shape contrasts intonational meanings, never lexical items."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig2 : LinguisticExample :=
+  { id := "bp1986_fig2"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I really won't allow Mary."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I really won't allow Mary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("H* on Mary: peak near end of stressed syllable, impatient reassertion", .acceptable), ("H+L* on Mary: peak just before the stressed syllable, peevish", .acceptable)]
+    paperFeatures := [("diagnostic", "peak alignment"), ("claim", "bitonal accents are units")]
+    comment := "The unstarred H of H+L* lands mid-word in Marianna — implausible as any phrasal tone."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig11 : LinguisticExample :=
+  { id := "bp1986_fig11"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 11"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "blueberries, boysberries, raspberries, mulberries and brambleberries"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "blueberries, boysberries, raspberries, mulberries and brambleberries"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("process", "catathesis chain"), ("contour", "descending staircase")]
+    comment := "Iterated catathesis: up to six or seven step levels, ruling out a fixed mid tone."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_ex4 : LinguisticExample :=
+  { id := "bp1986_ex4"
+    source := ⟨"beckman-pierrehumbert-1986", "(4)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "'I' means insert."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "'I' means insert."
+    context := "A text-editor tutor defining a key."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("intermediate phrase", "medial L phrase accent")]
+    comment := "The definiendum is set off as its own intermediate phrase; a full intonation break would be too strong."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_ex7 : LinguisticExample :=
+  { id := "bp1986_ex7"
+    source := ⟨"beckman-pierrehumbert-1986", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "They gave orange marmalade, lemon-oil marmalade, and watermelon-rind marmalade?"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "They gave orange marmalade, lemon-oil marmalade, and watermelon-rind marmalade?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("intermediate phrase", "H phrase accent per list item"), ("boundary tone", "one final H%")]
+    comment := "Three H-phrase-accent ips under one intonation phrase whose single H% closes the list."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_ex9 : LinguisticExample :=
+  { id := "bp1986_ex9"
+    source := ⟨"beckman-pierrehumbert-1986", "(9)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A pale orange and yellow ballgown."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A pale orange and yellow ballgown."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("pale | orange and yellow: both conjuncts pale", .acceptable), ("pale orange | and yellow: only the orange pale", .acceptable)]
+    paperFeatures := [("intermediate phrase", "scope disambiguation")]
+    comment := "Intermediate phrasing disambiguates the scope of the modifier over the conjunction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def bp1986_fig34 : LinguisticExample :=
+  { id := "bp1986_fig34"
+    source := ⟨"beckman-pierrehumbert-1986", "Fig. 34"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "it's eleven and nine and one and EIGHTY"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "it's eleven and nine and one and EIGHTY"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("process", "catathesis blocked at focus"), ("intermediate phrase", "break before focus")]
+    comment := "Downstepping accents on the first three numbers; the focused item is set off by an ip boundary that resets the range."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [bp1986_fig3, bp1986_fig5, bp1986_fig6a, bp1986_fig6b, bp1986_fig8, bp1986_ex2, bp1986_ex3, bp1986_fig36, bp1986_fig1, bp1986_fig2, bp1986_fig11, bp1986_ex4, bp1986_ex7, bp1986_ex9, bp1986_fig34]
+
+end BeckmanPierrehumbert1986.Examples

--- a/Linglib/Studies/BeckmanPierrehumbert1986.lean
+++ b/Linglib/Studies/BeckmanPierrehumbert1986.lean
@@ -1,46 +1,39 @@
 import Linglib.Features.Prosody
 import Linglib.Phonology.Tone.Basic
-import Linglib.Syntax.CCG.Intonation
-import Linglib.Studies.KratzerSelkirk2020
 import Linglib.Fragments.Japanese.Prosody
+import Linglib.Data.Examples.BeckmanPierrehumbert1986
 
 /-!
-# Beckman & Pierrehumbert (1986) [beckman-pierrehumbert-1986]
+# Beckman & Pierrehumbert (1986): Intonational Structure in Japanese and English
 
-Intonational Structure in Japanese and English. *Phonology Yearbook* 3: 255–309.
+Japanese and English share a sparse-tone prosodic hierarchy: pitch accents
+group into accentual phrases (at most one accent each), accentual phrases
+into intermediate phrases, and those into intonation phrases. Bitonal pitch
+accents trigger catathesis — pitch-range compression whose domain is the
+intermediate phrase — in both languages; the languages differ in where
+accents come from (lexical vs postlexical), in inventory size (one shape vs
+six), and in catathesis timing (within vs after the trigger). Catathesis is
+encoded as register downstep on `Tone`'s register tier: each bitonal accent
+contributes a downstep feature, `Tone.realizePitch` yields the descending
+staircase, and the intermediate-phrase boundary resets the register.
 
-## Core Contributions
+## Main statements
 
-This paper establishes the prosodic hierarchy above the word — accentual
-phrase (AP), intermediate phrase (ip), intonation phrase (IP) — via
-cross-linguistic comparison of Japanese and English intonation. It
-introduced three key analytical innovations:
+* `catathesis_terracing`, `split_ips_pitch_independent`: chained bitonal
+  accents produce the staircase (Figs. 11, 13), and an intermediate-phrase
+  boundary resets the register (Fig. 17).
+* `unaccented_no_catathesis`: an unaccented phrase's phrasal H + boundary L
+  does not trigger catathesis — the trigger is the accent's HL, unlike
+  African downdrift (§3.1).
+* `japanese_smaller_inventory`, `japanese_accents_all_bitonal`: the two
+  systems differ in accent inventory and specification, not in
+  architecture (§2.1, §6).
 
-1. **Accentual phrase**: the domain of pitch accent distribution, delimited
-   by a phrasal H and boundary L in Japanese. At most one pitch accent
-   per AP (culminativity at the phrasal level).
+## References
 
-2. **Catathesis**: pitch range compression triggered by bitonal pitch accents.
-   The domain is the intermediate phrase. Blocked by ip boundaries.
-   Chaining produces descending F0 staircases.
-
-3. **Intermediate phrase**: the domain of catathesis. In Japanese, 1–3 APs,
-   bounded by pause or glottalization + L boundary tone. In English,
-   decomposed from [pierrehumbert-1980]'s single "phrase accent" into
-   an ip-terminal tone (phrase accent) distinct from the IP boundary tone.
-
-The paper also demonstrates that Japanese tonal patterns are much sparser
-than earlier autosegmental accounts assumed — closer to English in their
-distribution of tones to tone-bearing units.
-
-## Bridge to RegisterTier
-
-Catathesis is formalized as register-based downstep applied to the
-intonation domain: each bitonal pitch accent within an intermediate
-phrase contributes a register `l` feature, producing cumulative terracing
-via `realizePitch` ([snider-1999], [lionnet-2025]). The ip
-boundary resets the register, preventing catathesis from propagating
-across phrases.
+* [beckman-pierrehumbert-1986]: Intonational structure in Japanese and
+  English. *Phonology Yearbook* 3.
+* [pierrehumbert-1980]: The Phonology and Phonetics of English Intonation.
 -/
 
 namespace BeckmanPierrehumbert1986
@@ -48,27 +41,19 @@ namespace BeckmanPierrehumbert1986
 open Features.Prosody
 open Tone
 
--- ============================================================================
--- § 1: Accentual Phrase (§2.2)
--- ============================================================================
+/-! ### The accentual phrase (§2.2) -/
 
-/-- An accentual phrase: the lowest level of prosodic phrasing defined
-    by the intonation pattern.
-
-    In Japanese, delimited by a phrasal H and boundary L tone. Contains
-    at most one pitch accent. An unaccented AP has the rising pitch shape
-    (L → phrasal H) but no accent HL fall (§2.2).
-
-    In English, the AP is less firmly established. It corresponds to the
-    domain of a single pitch accent plus the surrounding material up to
-    the next accent or phrase boundary (§2.4).
-
-    Accentedness is derived from the accent field: an AP is accented iff
-    its accent is non-null. -/
+/-- An accentual phrase: the lowest level of prosodic phrasing defined by
+the intonation pattern. In Japanese, delimited by a phrasal H and boundary
+L, containing at most one pitch accent — an unaccented AP has the rising
+L–H shape but no accentual fall (§2.2). In English the unit is less firmly
+established: the domain of a single pitch accent (§2.4). Culminativity is
+structural — a single `accent` field; grouping two accented words into one
+AP deletes the second accent (§2.3, Fig. 6). -/
 structure AccentualPhrase where
-  /-- Pitch accent type (null if unaccented) -/
+  /-- Pitch accent type (null if unaccented). -/
   accent : PitchAccent
-  /-- Number of words grouped in this phrase -/
+  /-- Number of words grouped in this phrase. -/
   nWords : Nat
   deriving Repr, DecidableEq
 
@@ -76,42 +61,29 @@ structure AccentualPhrase where
 def AccentualPhrase.isAccented (ap : AccentualPhrase) : Bool :=
   ap.accent != .null
 
--- **Culminativity at the AP level** (§2.2, §2.3): an accentual phrase
--- contains at most one pitch accent. Enforced structurally —
--- `AccentualPhrase` has a single `accent` field. When two lexically
--- accented words are grouped in the same AP, one accent must be deleted.
+/-! ### Catathesis as register downstep (§3) -/
 
--- ============================================================================
--- § 2: Catathesis as Register Downstep (§3)
--- ============================================================================
-
-/-- Convert a sequence of APs into register specifications.
-
-    Each bitonal accent contributes a register `l` (downstep) feature;
-    non-bitonal or null accents contribute no register feature (registerless).
-    This bridges catathesis to [snider-1999]'s RegisterTier: the
-    descending staircase in catathesis chains (Fig. 11) is the same
-    terracing effect produced by cumulative register `l` features. -/
+/-- Register specifications for a sequence of APs: each bitonal accent
+contributes a register downstep; null or monotonal accents contribute
+nothing. The descending staircase of catathesis chains (Figs. 11, 13) is
+register terracing under `Tone.realizePitch`. -/
 def catathesisToRegisterSpecs (aps : List AccentualPhrase) : List TRN :=
   aps.map (λ ap => if ap.accent.isBitonal then TRN.downstep else TRN.empty)
 
-/-- **Catathesis produces terracing** (§3, Fig. 11): a sequence of
-    bitonal accents within an ip produces a descending staircase.
-    This follows from `realizePitch` applied to the register specs. -/
+/-- Two chained bitonal accents produce a two-step staircase (§3, Fig. 11). -/
 theorem catathesis_terracing (n : Int) :
     realizePitch n [TRN.downstep, TRN.downstep] = [n - 1, n - 1 - 1] := rfl
 
-/-- Catathesis lowers pitch: after one bitonal accent, the pitch is
-    strictly lower than the starting level. -/
+/-- Catathesis lowers pitch below the starting level. -/
 theorem catathesis_lowers (n : Int) :
     (realizePitch n [TRN.downstep]).head? = some (n - 1) := rfl
 
-/-- Count catathesis applications in a sequence of APs. -/
+/-- Number of catathesis applications in a sequence of APs. -/
 def catathesisCount (aps : List AccentualPhrase) : Nat :=
-  aps.filter (·.accent.isBitonal) |>.length
+  (aps.filter (·.accent.isBitonal)).length
 
-/-- An ip with no bitonal accents has zero catathesis — no pitch
-    compression occurs. -/
+/-- No bitonal accents, no catathesis: unaccented sequences show no
+compression. -/
 theorem no_bitonal_no_catathesis (aps : List AccentualPhrase)
     (h : ∀ ap ∈ aps, ap.accent.isBitonal = false) :
     catathesisCount aps = 0 := by
@@ -119,124 +91,87 @@ theorem no_bitonal_no_catathesis (aps : List AccentualPhrase)
   rw [List.filter_eq_nil_iff.mpr (by intro a ha; simp [h a ha])]
   simp
 
--- ============================================================================
--- § 3: Catathesis ≠ Downdrift (§3.1)
--- ============================================================================
-
--- [beckman-pierrehumbert-1986] §3.1: catathesis differs fundamentally
--- from downdrift in African tone languages. Downdrift is triggered by any
--- H L H sequence; catathesis is triggered specifically by the HL of the
--- *accent*. In Japanese, every unaccented AP has a phrasal H + boundary L,
--- but only accented APs trigger catathesis.
-
-/-- Catathesis is triggered by the accent HL, not by any HL sequence.
-    An unaccented AP (with phrasal H + boundary L) does NOT trigger
-    catathesis (§3.1). -/
+/-- Catathesis is triggered by the accent's HL, not by any HL sequence:
+every unaccented AP carries a phrasal H + boundary L, yet only accented
+APs trigger — the contrast with African downdrift (§3.1). -/
 theorem unaccented_no_catathesis :
     PitchAccent.null.isBitonal = false := rfl
 
--- ============================================================================
--- § 4: Intermediate Phrase — Domain of Catathesis (§4)
--- ============================================================================
+/-! ### The intermediate phrase (§4) -/
 
-/-- An intermediate phrase: a sequence of accentual phrases terminated
-    by a phrase accent.
-
-    [beckman-pierrehumbert-1986] §4.1: in Japanese, the ip is the
-    domain of catathesis. It can be as short as a single AP and seldom
-    contains more than three. Its boundary is marked by pause or
-    glottalization, and the phrase-final L tone provides evidence for
-    disjuncture.
-
-    §4.3: in English, the ip is reanalyzed from [pierrehumbert-1980]'s
-    framework. The phrase accent (H or L) is terminal to the ip, while
-    the boundary tone is terminal to the IP. -/
+/-- An intermediate phrase: accentual phrases terminated by a phrase
+accent. In Japanese the ip is the catathesis domain, can be a single AP,
+and seldom contains more than three; its boundary is marked by pause or
+glottalization (§4.1). In English, the phrase accent of
+[pierrehumbert-1980] is reanalyzed as the ip-terminal tone, the boundary
+tone as IP-terminal (§4.3). -/
 structure IntermediatePhrase where
-  /-- Accentual phrases within this ip -/
+  /-- Accentual phrases within this ip. -/
   aps : List AccentualPhrase
-  /-- Phrase accent: terminal tone of the ip -/
+  /-- Phrase accent: terminal tone of the ip. -/
   phraseAccent : PhraseAccent
-  /-- Non-empty: an ip contains at least one AP -/
+  /-- An ip contains at least one AP. -/
   aps_nonempty : aps ≠ [] := by decide
   deriving Repr
 
-/-- An intonation phrase: one or more intermediate phrases terminated
-    by a boundary tone (§4.2). -/
+/-- An intonation phrase: one or more intermediate phrases terminated by a
+boundary tone (§4.2–4.3). -/
 structure IntonationPhrase where
-  /-- Intermediate phrases within this IP -/
+  /-- Intermediate phrases within this IP. -/
   ips : List IntermediatePhrase
-  /-- Boundary tone: terminal tone of the IP -/
+  /-- Boundary tone: terminal tone of the IP. -/
   boundaryTone : BoundaryTone
-  /-- Non-empty -/
+  /-- Non-empty. -/
   ips_nonempty : ips ≠ [] := by decide
   deriving Repr
 
-/-- The terminal contour of an IP is composed from the phrase accent
-    of its final ip and the IP boundary tone. This is the structural
-    decomposition that [beckman-pierrehumbert-1986] §4.2–4.3
-    establish and that [steedman-2000] uses in the CCG `Tune` type. -/
+/-- The terminal contour of an IP: the final ip's phrase accent plus the
+IP boundary tone — the §4.3 decomposition of [pierrehumbert-1980]'s
+terminal sequence. -/
 def IntonationPhrase.terminalContour (ip : IntonationPhrase) : TerminalContour :=
   let lastIp := ip.ips.getLast ip.ips_nonempty
   ⟨lastIp.phraseAccent, ip.boundaryTone⟩
 
-/-- Register specs within a single ip: catathesis chains. -/
+/-- Register specs within a single ip: one catathesis chain. -/
 def ipRegisterSpecs (ip : IntermediatePhrase) : List TRN :=
   catathesisToRegisterSpecs ip.aps
 
-/-- Register specs across an IP: each ip resets the register.
-    This is the structural basis for "catathesis is blocked by ip
-    boundaries" (§4.1, §4.4, Figs. 17–18 vs. 12–13).
-
-    Each ip gets independent register specs — the `l` features from
-    one ip do not propagate into the next. -/
-def ipRegisterSpecsAcrossIps (ips : List IntermediatePhrase)
-    : List (List TRN) :=
+/-- Register specs across an IP: each ip resets the register — the
+structural form of "catathesis is blocked by ip boundaries" (§4.1, §4.4;
+Fig. 17 vs Figs. 12–13). -/
+def ipRegisterSpecsAcrossIps (ips : List IntermediatePhrase) : List (List TRN) :=
   ips.map ipRegisterSpecs
 
+/-! ### The two intonation systems (§2, §3.3, §6) -/
 
--- ============================================================================
--- § 5: Cross-linguistic Comparison (§2.5, §3.3, §6)
--- ============================================================================
-
-/-- Where catathesis takes effect relative to the triggering accent.
-
-    [beckman-pierrehumbert-1986] §3.3: in Japanese, catathesis
-    applies within the accent itself (affecting the trailing L). In
-    English, catathesis applies after the second tone of the triggering
-    bitonal accent. -/
+/-- Where catathesis takes effect relative to its trigger (§3.2–3.3): in
+Japanese within the accent itself (the trailing L is already compressed),
+in English only after the second tone of the bitonal accent. -/
 inductive CatathesisTiming where
-  | withinAccent  -- Japanese: affects the L of H*+L
-  | afterAccent   -- English: affects tones after the bitonal accent
+  | withinAccent
+  | afterAccent
   deriving Repr, DecidableEq
 
-/-- Language-specific intonation system parameters.
-
-    [beckman-pierrehumbert-1986] §6: Japanese and English share the
-    same prosodic hierarchy but differ in how accents relate to the lexicon,
-    the size of the pitch accent inventory, and whether unaccented phrases
-    are possible. -/
+/-- A language's intonation-system parameters (§6): how accents are
+specified, the contrastive accent shapes, whether unaccented words exist,
+whether the AP boundary L is always present, and catathesis timing. -/
 structure IntonationSystem where
-  /-- How accents are specified (lexical vs postlexical) -/
   accentSpec : AccentSpecification
-  /-- The set of contrastive pitch accent shapes (excluding null) -/
+  /-- Contrastive pitch-accent shapes (excluding null). -/
   accentShapes : List PitchAccent
-  /-- Whether lexically unaccented words/phrases exist -/
+  /-- Lexically unaccented words/phrases exist. -/
   hasUnaccented : Bool
-  /-- Whether the accentual phrase boundary L is always present -/
+  /-- The AP boundary L is always present. -/
   apBoundaryLAlwaysPresent : Bool
-  /-- When catathesis applies relative to the triggering accent (§3.3) -/
   catathesisTiming : CatathesisTiming
   deriving Repr
 
-/-- Number of contrastive accent shapes — derived, not stipulated. -/
+/-- Accent-inventory size, derived from the shape list. -/
 def IntonationSystem.accentInventorySize (sys : IntonationSystem) : Nat :=
   sys.accentShapes.length
 
-/-- Japanese intonation system (§2, §6):
-    - Accent location is lexical (H*+L at specified mora)
-    - Single accent shape
-    - Unaccented words exist (and are common)
-    - Boundary L is always present -/
+/-- Japanese (§2, §6): lexical accent location, one shape, unaccented words
+common, boundary L always present, catathesis within the accent. -/
 def japanese : IntonationSystem :=
   { accentSpec := .lexical
     accentShapes := [.H_star_plus_L]
@@ -244,11 +179,9 @@ def japanese : IntonationSystem :=
     apBoundaryLAlwaysPresent := true
     catathesisTiming := .withinAccent }
 
-/-- English intonation system (§2, §6):
-    - Accent shape is postlexical (chosen by intonation)
-    - Six contrastive accent shapes
-    - Every content word has an accentable syllable
-    - AP boundary is less clearly defined -/
+/-- English (§2, §6): postlexical accent shape, six contrastive shapes,
+every content word accentable, no AP boundary tone, catathesis after the
+accent. -/
 def english : IntonationSystem :=
   { accentSpec := .postlexical
     accentShapes := [.H_star, .L_star, .H_star_plus_L,
@@ -257,209 +190,113 @@ def english : IntonationSystem :=
     apBoundaryLAlwaysPresent := false
     catathesisTiming := .afterAccent }
 
-/-- Japanese has lexical accent specification. -/
-theorem japanese_lexical : japanese.accentSpec = .lexical := rfl
+/-- Japanese accent location is lexical; English accent shape is
+postlexical (§2.1, §2.5). -/
+theorem accent_specification_differs :
+    japanese.accentSpec = .lexical ∧ english.accentSpec = .postlexical :=
+  ⟨rfl, rfl⟩
 
-/-- English has postlexical accent specification. -/
-theorem english_postlexical : english.accentSpec = .postlexical := rfl
-
-/-- Japanese has fewer accent shapes than English (derived from
-    the actual accent lists, not a stipulated number). -/
+/-- Japanese has a smaller accent inventory than English, derived from the
+shape lists (one vs six). -/
 theorem japanese_smaller_inventory :
     japanese.accentInventorySize < english.accentInventorySize := by decide
 
-/-- Japanese uses exactly one accent shape. -/
-theorem japanese_one_accent : japanese.accentInventorySize = 1 := rfl
-
-/-- English uses exactly six accent shapes. -/
-theorem english_six_accents : english.accentInventorySize = 6 := rfl
-
-/-- All Japanese accents are bitonal (and therefore trigger catathesis). -/
+/-- All Japanese accents are bitonal, so every accented AP triggers
+catathesis. -/
 theorem japanese_accents_all_bitonal :
     japanese.accentShapes.all (·.isBitonal) = true := rfl
 
-/-- Not all English accents are bitonal — H* and L* are monotonal. -/
+/-- Not all English accents are bitonal — H* and L* are monotonal, so an
+accent need not trigger catathesis. -/
 theorem english_has_monotonal :
     english.accentShapes.all (·.isBitonal) = false := rfl
 
--- [beckman-pierrehumbert-1986] §5: two supra-phrasal processes operate
--- above the ip level. **Final lowering** compresses pitch range near the end
--- of a declarative utterance; its domain appears to be discourse-controlled
--- (not a fixed phonological unit). **Declination** is a gradual time-dependent
--- lowering (~10 Hz/sec), independent of prosodic structure. Both exist in
--- Japanese and (probably) English. Neither is catathesis — catathesis is
--- structurally bounded by the ip; these operate above it.
+/-- Catathesis timing separates the systems (§3.3). -/
+theorem catathesis_timing_differs :
+    japanese.catathesisTiming = .withinAccent ∧
+      english.catathesisTiming = .afterAccent := ⟨rfl, rfl⟩
 
--- ============================================================================
--- § 6: Worked Examples
--- ============================================================================
+-- Two supra-phrasal processes operate above the ip (§5): final lowering
+-- (pitch-range compression near the end of a declarative; its domain is
+-- discourse-controlled, not a fixed phonological unit) and declination
+-- (gradual time-dependent lowering, ~10 Hz/sec for the strongest subject,
+-- absent for one). Both exist in Japanese and probably in English; neither
+-- is catathesis, which is structurally bounded by the ip.
 
-/-- An accented AP (e.g., *uma'i* 'delicious', Fig. 6a). -/
+/-! ### Worked configurations (Figs. 5, 11, 13, 17) -/
+
+/-- An accented AP (*uma'i*, *mo'riya-no*). -/
 def accentedAP : AccentualPhrase := ⟨.H_star_plus_L, 1⟩
 
-/-- An unaccented AP (e.g., *mame* 'beans', Fig. 6). -/
+/-- An unaccented AP (*amai*, *toriya-no mawari-no*). -/
 def unaccentedAP : AccentualPhrase := ⟨.null, 1⟩
 
-/-- Two-AP ip: accented + unaccented (Figs. 3, 5). Catathesis
-    applies once — the unaccented AP is in a lower pitch range. -/
+/-- Accented + unaccented AP in one ip (Fig. 5): catathesis applies once,
+placing the second AP in a lowered range. -/
 def twoAP_ip : IntermediatePhrase :=
   { aps := [accentedAP, unaccentedAP], phraseAccent := .L }
 
-/-- The register specs for this ip show one downstep. -/
 theorem twoAP_ip_specs :
     ipRegisterSpecs twoAP_ip = [TRN.downstep, TRN.empty] := rfl
 
-/-- Pitch realization: from baseline 4, the accented AP is at 3
-    (downstepped by catathesis) and the unaccented AP stays at 3. -/
+/-- From baseline 4, the accented AP is downstepped to 3 and the unaccented
+AP stays there. -/
 theorem twoAP_ip_pitch :
     realizePitch 4 (ipRegisterSpecs twoAP_ip) = [3, 3] := by decide
 
-/-- Three-AP ip: accented + accented + unaccented (staircase, Fig. 11). -/
+/-- Two accented APs and an unaccented one in a single ip: the
+two-application chains of Fig. 13. -/
 def threeAP_ip : IntermediatePhrase :=
   { aps := [accentedAP, accentedAP, unaccentedAP], phraseAccent := .L }
 
-/-- Two downsteps produce a two-level staircase. -/
 theorem threeAP_ip_specs :
     ipRegisterSpecs threeAP_ip = [TRN.downstep, TRN.downstep, TRN.empty] := rfl
 
-/-- Pitch realization: 4 → 3 → 2 → 2 (descending staircase). -/
+/-- Pitch realization 4 → 3 → 2 → 2: the descending staircase. -/
 theorem threeAP_ip_pitch :
     realizePitch 4 (ipRegisterSpecs threeAP_ip) = [3, 2, 2] := by decide
 
-/-- Catathesis blocking: same APs split across two ips. The second ip
-    starts at full pitch range, not at the compressed level. -/
+/-- The same APs split across two ips: the second ip starts at full range
+(Fig. 17's blocked catathesis). -/
 def split_ips : List IntermediatePhrase :=
   [{ aps := [accentedAP], phraseAccent := .L },
    { aps := [accentedAP, unaccentedAP], phraseAccent := .L }]
 
-/-- The register specs are independent per ip. -/
 theorem split_ips_specs :
-    ipRegisterSpecsAcrossIps split_ips = [[TRN.downstep], [TRN.downstep, TRN.empty]] := rfl
+    ipRegisterSpecsAcrossIps split_ips
+      = [[TRN.downstep], [TRN.downstep, TRN.empty]] := rfl
 
-/-- Each ip starts from its own baseline — catathesis does not leak
-    across the ip boundary. The first ip has pitch [3] (from baseline 4);
-    the second ip independently has [3, 3]. -/
+/-- Each ip realizes from its own baseline: [3] then [3, 3] — the register
+does not leak across the boundary. -/
 theorem split_ips_pitch_independent :
-    (split_ips.map (realizePitch 4 ∘ ipRegisterSpecs))
-    = [[3], [3, 3]] := by decide
+    (split_ips.map (realizePitch 4 ∘ ipRegisterSpecs)) = [[3], [3, 3]] := by
+  decide
 
-/-- Compare: if there were no ip boundary, all three APs would be in
-    one catathesis chain, producing [3, 2, 2] instead of [3] + [3, 3].
-    The second AP is at pitch 3 (not 2) because the boundary resets
-    the register. -/
+/-- Without the boundary the same APs form one chain, [3, 2, 2]: the second
+accented AP would be a step lower than with the reset. -/
 theorem catathesis_without_boundary :
-    realizePitch 4 (catathesisToRegisterSpecs [accentedAP, accentedAP, unaccentedAP])
-    = [3, 2, 2] := by decide
+    realizePitch 4
+        (catathesisToRegisterSpecs [accentedAP, accentedAP, unaccentedAP])
+      = [3, 2, 2] := by decide
 
--- ============================================================================
--- § 7: Bridge to CCG Intonation ([steedman-2000])
--- ============================================================================
+/-! ### Monotonicity of catathesis -/
 
-open CCG.Intonation
-
-/-- Construct a CCG Tune from a B&P IntonationPhrase and a pitch accent.
-    The tune's terminal contour is the IP's terminal contour —
-    the same phrase accent + boundary tone decomposition that
-    [steedman-2000] uses for prosodic CCG categories. -/
-def ipToTune (ip : IntonationPhrase) (accent : PitchAccent) : Tune :=
-  ⟨accent, ip.terminalContour⟩
-
-/-- The terminal contour of a CCG Tune constructed from a B&P IP
-    is exactly the B&P terminal contour — [steedman-2000]'s
-    Tune decomposition and B&P's IP decomposition produce the same
-    `TerminalContour` by construction. -/
-theorem tune_terminal_eq_bp_terminal (ip : IntonationPhrase) (accent : PitchAccent) :
-    (ipToTune ip accent).terminal = ip.terminalContour := rfl
-
-/-- A declarative IP (L phrase accent, L% boundary tone). -/
-def declarativeIP : IntonationPhrase :=
-  { ips := [{ aps := [accentedAP], phraseAccent := .L }], boundaryTone := .L_pct }
-
-/-- A continuation-rise IP (L phrase accent, H% boundary tone). -/
-def continuationIP : IntonationPhrase :=
-  { ips := [{ aps := [accentedAP], phraseAccent := .L }], boundaryTone := .H_pct }
-
-/-- A declarative IP has the same terminal contour as
-    [steedman-2000]'s rheme tune (H* L L%). -/
-theorem declarative_ip_matches_rheme_terminal :
-    declarativeIP.terminalContour = rhemeTune.terminal := by decide
-
-/-- A continuation-rise IP has the same terminal contour as
-    [steedman-2000]'s theme tune (L+H* L H%). -/
-theorem continuation_ip_matches_theme_terminal :
-    continuationIP.terminalContour = themeTune.terminal := by decide
-
--- ============================================================================
--- § 8: Bridge to Kratzer & Selkirk 2020 — ip as Focus-Prosody Domain
--- ============================================================================
-
-open KratzerSelkirk2020
-
-/-- The ip/φ domain serves two independent functions:
-    1. **Catathesis domain** (B&P §4): register resets at ip boundaries
-    2. **Focus-prosody domain** ([kratzer-selkirk-2020] §7):
-       [FoC] = φ-Level-Head
-
-    Whether focus marking triggers catathesis depends on the accent
-    inventory: guaranteed in Japanese (all accents are bitonal),
-    not guaranteed in English (H* is monotonal). -/
-theorem ip_dual_function :
-    PitchAccent.H_star_plus_L.isBitonal = true ∧
-    PitchAccent.H_star.isBitonal = false := ⟨rfl, rfl⟩
-
-/-- In Japanese, [FoC] spellout at φ-level always triggers catathesis:
-    the only accent shape (H*+L) is bitonal. Focus-marking and catathesis
-    are inseparable in the Japanese system.
-
-    Proof chain: [FoC] → φ-Level-Head (K&S 34) → pitch accent (head =
-    most prominent) → bitonal (Japanese has only H*+L) → catathesis
-    (B&P §3). -/
-theorem japanese_foc_always_triggers_catathesis :
-    japanese.accentShapes.all (·.isBitonal) = true := rfl
-
-/-- In English, [FoC] spellout at φ-level does NOT guarantee catathesis:
-    the default rheme accent H* is monotonal, so catathesis only occurs
-    when the speaker selects a bitonal accent shape (H*+L, H+L*, L*+H,
-    L+H*). -/
-theorem english_foc_may_not_trigger_catathesis :
-    PitchAccent.H_star.isBitonal = false := rfl
-
-
--- ============================================================================
--- § 9: Monotonicity of Catathesis
--- ============================================================================
-
-/-- More catathesis (more bitonal accents) produces lower pitch: replacing
-    a registerless AP with a bitonal-accented one produces pointwise
-    lower-or-equal pitch realization. -/
+/-- More bitonal accents give pointwise lower-or-equal pitch. -/
 theorem more_catathesis_lower_pitch :
     List.Forall₂ (· ≤ ·)
       (realizePitch 4 [TRN.downstep, TRN.downstep, TRN.empty])
       (realizePitch 4 [TRN.downstep, TRN.empty, TRN.empty]) := by decide
 
-/-- **Catathesis blocking**: realizing an ip from the higher (reset)
-    starting offset produces pointwise higher-or-equal pitch than
-    continuing from a compressed offset. When an ip boundary resets the
-    register to offset `n`, subsequent pitches are at least as high as
-    if catathesis had continued from any lower offset `m ≤ n`.
-
-    Direct application of `realizePitch_baseline_mono`. -/
-theorem catathesis_blocking (specs : List TRN) {m n : Int}
-    (h : m ≤ n) :
-    List.Forall₂ (· ≤ ·) (realizePitch m specs) (realizePitch n specs) :=
-  realizePitch_baseline_mono specs h
-
-/-- Concrete catathesis blocking: a fresh ip starting from offset 4
-    (reset) yields higher pitches `[3, 3]` than the same specs continued
-    from a compressed offset 3, which give `[2, 2]`. -/
+/-- A fresh ip starting from the reset baseline 4 sits pointwise above the
+same specs continued from a compressed baseline 3 — blocking raises pitch
+(`Tone.realizePitch_baseline_mono` carries the general fact). -/
 theorem catathesis_blocking_concrete :
     List.Forall₂ (· ≤ ·)
       (realizePitch 3 [TRN.downstep, TRN.empty])
       (realizePitch 4 [TRN.downstep, TRN.empty]) := by decide
 
-/-- Catathesis register specs only contain `TRN.empty` (maintain) or
-    `TRN.downstep` (lower) — never `TRN.upstep` (raise). This ensures
-    catathesis is monotonically compressive. -/
+/-- Catathesis specs never raise the register: catathesis is monotonically
+compressive. -/
 theorem catathesis_specs_no_raising (aps : List AccentualPhrase)
     (s : TRN) (hs : s ∈ catathesisToRegisterSpecs aps) :
     s = TRN.empty ∨ s = TRN.downstep := by
@@ -467,45 +304,36 @@ theorem catathesis_specs_no_raising (aps : List AccentualPhrase)
   obtain ⟨ap, _, rfl⟩ := hs
   rcases Bool.eq_false_or_eq_true (ap.accent.isBitonal) with h | h <;> simp [h]
 
-/-- Japanese catathesis timing: catathesis applies within the accent. -/
-theorem japanese_catathesis_timing :
-    japanese.catathesisTiming = .withinAccent := rfl
-
-/-- English catathesis timing: catathesis applies after the accent. -/
-theorem english_catathesis_timing :
-    english.catathesisTiming = .afterAccent := rfl
-
 /-! ### Japanese accentual phrases from the lexicon
 
 An AP over grouped word entries is accented iff some word is lexically
-accented, its accent shape always H*+L, with grouping deleting all but one
-accent — Fig. 6's contrast between accented *uma'i mame'* and the
-unaccented *amai ame* materials, built from the `Fragments.Japanese.Prosody`
-word entries. -/
+accented, its shape always H*+L, with grouping deleting all but one accent
+(§2.3, Fig. 6) — built from the `Fragments.Japanese.Prosody` word
+entries. -/
 
 section JapaneseAP
 open Japanese.Prosody
 
-/-- The accentual phrase over grouped word entries, accented (always H*+L
-    in Japanese) iff some word is lexically accented (§2.2). -/
+/-- The accentual phrase over grouped word entries: accented (always H*+L
+in Japanese) iff some word is lexically accented (§2.2–2.3). -/
 def AccentualPhrase.ofWords (ws : List ProsodicEntry) : AccentualPhrase :=
   { accent := if ws.any (·.isAccented) then .H_star_plus_L else .null
     nWords := ws.length }
 
-/-- An AP of words triggers catathesis iff some word is accented, since its
-    only accent shape H*+L is bitonal (§3). -/
+/-- An AP of words triggers catathesis iff some word is accented, since the
+only accent shape H*+L is bitonal (§3.1). -/
 theorem ofWords_isBitonal (ws : List ProsodicEntry) :
     (AccentualPhrase.ofWords ws).accent.isBitonal = ws.any (·.isAccented) := by
   unfold AccentualPhrase.ofWords
   split <;> simp_all [PitchAccent.isBitonal]
 
-/-- The AP *uma'i mame'* 'delicious beans' is accented, so it triggers
-    catathesis on the following phrase (Figs. 6, 9). -/
+/-- *uma'i mame'* 'delicious beans' forms an accented AP (Figs. 6, 9), so
+it triggers catathesis on what follows (Figs. 12–13's `a` points). -/
 theorem umai_mame_bitonal :
     (AccentualPhrase.ofWords [umai, mame]).accent.isBitonal = true := rfl
 
-/-- The AP *amai ame* 'sweet candy' is unaccented, so it triggers no
-    catathesis (Figs. 8, 10–13). -/
+/-- *amai ame* 'sweet candy' forms an unaccented AP, so it triggers no
+catathesis (the *amai ame* materials of Figs. 18–21, `u` points). -/
 theorem amai_ame_not_bitonal :
     (AccentualPhrase.ofWords [amai, ameCandy]).accent.isBitonal = false := rfl
 

--- a/Linglib/Studies/KratzerSelkirk2020.lean
+++ b/Linglib/Studies/KratzerSelkirk2020.lean
@@ -2,6 +2,7 @@ import Linglib.Pragmatics.Expressives.Basic
 import Linglib.Semantics.Alternatives.AltMeaning
 import Linglib.Semantics.Focus.Control
 import Linglib.Studies.HartmannZimmermann2007
+import Linglib.Studies.BeckmanPierrehumbert1986
 
 /-!
 # Two-feature decomposition of information structure
@@ -304,5 +305,23 @@ theorem hz_matrix_cells_violate_ks_reading :
     ¬ KSHausaReading HartmannZimmermann2007.exSitu_newInfo ∧
     ¬ KSHausaReading HartmannZimmermann2007.inSitu_corrective := by
   decide
+
+/-! ### Prosodic spellout at the φ level -/
+
+section FocusProsody
+
+open Features.Prosody BeckmanPierrehumbert1986
+
+/-- K&S place [FoC]'s prosodic spellout at the head of a φ-level prosodic
+constituent — [beckman-pierrehumbert-1986]'s intermediate phrase, which is
+also the catathesis domain. Whether focus spellout triggers catathesis
+therefore depends on the accent inventory: guaranteed in Japanese, whose
+only accent shape (H*+L) is bitonal, but not in English, whose default H*
+is monotonal. -/
+theorem foc_catathesis_language_dependent :
+    japanese.accentShapes.all (·.isBitonal) = true ∧
+      PitchAccent.H_star.isBitonal = false := ⟨rfl, rfl⟩
+
+end FocusProsody
 
 end KratzerSelkirk2020

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -7,6 +7,7 @@ import Linglib.Syntax.CCG.Derivation
 import Linglib.Syntax.CCG.Grammar
 import Linglib.Syntax.CCG.Interface
 import Linglib.Syntax.CCG.Intonation
+import Linglib.Studies.BeckmanPierrehumbert1986
 import Linglib.Features.ScopeTypes
 
 /-!
@@ -860,5 +861,36 @@ theorem ccg_predicts_mary_sees_john :
     ccgMeaning ccg_mary_sees_john = some True := rfl
 
 end TruthConditions
+
+/-! ### The Tune terminal is Beckman–Pierrehumbert's ip/IP decomposition -/
+
+section BPTerminal
+
+open Features.Prosody BeckmanPierrehumbert1986 CCG.Intonation
+
+/-- A CCG `Tune` from a [beckman-pierrehumbert-1986] intonation phrase: the
+tune's terminal contour is the IP's final phrase accent plus boundary tone
+— the book's Tune decomposition is B&P's §4.3 ip/IP decomposition. -/
+def ipToTune (ip : IntonationPhrase) (accent : PitchAccent) : Tune :=
+  ⟨accent, ip.terminalContour⟩
+
+theorem ipToTune_terminal (ip : IntonationPhrase) (accent : PitchAccent) :
+    (ipToTune ip accent).terminal = ip.terminalContour := rfl
+
+/-- A declarative B&P IP (L phrase accent, L% boundary). -/
+def declarativeIP : IntonationPhrase :=
+  { ips := [{ aps := [accentedAP], phraseAccent := .L }], boundaryTone := .L_pct }
+
+/-- A continuation-rise B&P IP (L phrase accent, H% boundary). -/
+def continuationIP : IntonationPhrase :=
+  { ips := [{ aps := [accentedAP], phraseAccent := .L }], boundaryTone := .H_pct }
+
+/-- The declarative IP carries the rheme tune's terminal (H* L L%), the
+continuation-rise IP the theme tune's (L+H* L H%). -/
+theorem bp_terminals_match_tunes :
+    declarativeIP.terminalContour = rhemeTune.terminal ∧
+      continuationIP.terminalContour = themeTune.terminal := by decide
+
+end BPTerminal
 
 end Steedman2000


### PR DESCRIPTION
Paper audit (read in full): content faithful; moves the Steedman-2000 and Kratzer-Selkirk-2020 bridges to those papers's study files per the chronology rule, fixes wrong figure locators (amai ame is Figs. 18-21, the Fig. 11 staircase is English), drops an alias wrapper and section numbering, adds 15 example rows.