### PR TITLE
refactor(Studies/BejarRezac2009): repairs, Nishnaabemwin, rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -356,6 +356,7 @@ import Linglib.Data.Examples.BeaversKoontzGarboden2020
 import Linglib.Data.Examples.BeaversUdayana2022
 import Linglib.Data.Examples.BeckOdaSugisaki2004
 import Linglib.Data.Examples.BeckmanPierrehumbert1986
+import Linglib.Data.Examples.BejarRezac2009
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015
 import Linglib.Data.Examples.Bondarenko2022

--- a/Linglib/Data/Examples/BejarRezac2009.json
+++ b/Linglib/Data/Examples/BejarRezac2009.json
@@ -1,0 +1,312 @@
+[
+  {
+    "id": "br2009_2a",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(2a)"},
+    "language": "basq1248",
+    "primaryText": "ikusi zintudan",
+    "glossedTokens": [
+      ["ikusi", "seen"], ["z-in-t-u-da-n", "2-X-PL-have-1-PAST"]
+    ],
+    "translation": "I saw you.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "1>2 = 2"],
+      ["context", "inverse"]
+    ],
+    "comment": "The core slot tracks the IA: a 2nd-person object fully checks the [u-3-2] probe."
+  },
+  {
+    "id": "br2009_2b",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(2b)"},
+    "language": "basq1248",
+    "primaryText": "ikusi ninduen",
+    "glossedTokens": [
+      ["ikusi", "seen"], ["n-ind-u-en", "1-X-have-PAST"]
+    ],
+    "translation": "He saw me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "3>1 = 1"],
+      ["context", "inverse"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "br2009_2c",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(2c)"},
+    "language": "basq1248",
+    "primaryText": "ikusininduzun",
+    "glossedTokens": [
+      ["ikusi", "seen"], ["n-ind-u-zu-n", "1-X-have-2-PAST"]
+    ],
+    "translation": "You saw me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "2>1 = 1"],
+      ["context", "inverse"]
+    ],
+    "comment": "With (2a): no ranking of person values decides between two SAP arguments — the IA wins both times."
+  },
+  {
+    "id": "br2009_2d",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(2d)"},
+    "language": "basq1248",
+    "primaryText": "ikusi nuen",
+    "glossedTokens": [
+      ["ikusi", "seen"], ["n-u-en", "1-have-PAST"]
+    ],
+    "translation": "I saw him.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "1>3 = 1"],
+      ["context", "direct"]
+    ],
+    "comment": "The 3rd-person IA leaves the [u2] residue, which the SAP EA checks on cycle II: displacement to the EA."
+  },
+  {
+    "id": "br2009_3",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(3)"},
+    "language": "basq1248",
+    "primaryText": "Nik neure burua ikusten nuen.",
+    "glossedTokens": [
+      ["Ni-k", "1-E"], ["neure", "my.own"], ["buru-a", "head-the.A"], ["ikusten", "seeing"],
+      ["n-u-en", "1-have-PAST"]
+    ],
+    "translation": "I saw myself.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "case and binding unaffected"]
+    ],
+    "comment": "Ergative displacement changes neither case marking nor binding: agreement displacement is not movement."
+  },
+  {
+    "id": "br2009_15",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(15)"},
+    "language": "basq1248",
+    "primaryText": "Zuk etsaiari misilak / *ni saldu dizkiozu.",
+    "glossedTokens": [
+      ["Zu-k", "you-E"], ["etsaia-ri", "enemy-D"], ["misil-ak", "missile-A.PL"], ["ni", "me.A"],
+      ["saldu", "sold"], ["d-i-zki-o-zu", "X-have-PL-3.D-2.E"]
+    ],
+    "translation": "You have sold the missiles / *me to the enemy.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["constraint", "Person Case Constraint"]
+    ],
+    "comment": "With a dative goal absorbing the π-probe, a 1st-person theme is unlicensable — the PLC at work."
+  },
+  {
+    "id": "br2009_t9_3_1",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "Table 9"},
+    "language": "basq1248",
+    "primaryText": "niñdduen",
+    "glossedTokens": [
+      ["n-iñdd-u-en", "1.SG-INV-have-PAST"]
+    ],
+    "translation": "He had me.",
+    "context": "Bizkaian dialect of Bolivar.",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "3>1"],
+      ["repair", "added probe (INV)"]
+    ],
+    "comment": "The INV slot spells out the added probe that licenses the EA in inverse contexts."
+  },
+  {
+    "id": "br2009_10",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(10)"},
+    "language": "swah1253",
+    "primaryText": "sijakiona chochote",
+    "glossedTokens": [
+      ["si-ja-ki-ona", "1.SG-NEG-7-see"], ["chochote", "anything"]
+    ],
+    "translation": "I haven't seen anything.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["probe", "flat [u-3]"],
+      ["agreement", "object and subject independent"]
+    ],
+    "comment": "A flat probe is fully checked by any IA: no person-hierarchy interaction, every context inverse."
+  },
+  {
+    "id": "br2009_17a",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(17a)"},
+    "language": "otta1242",
+    "primaryText": "g-waabm-in",
+    "glossedTokens": [
+      ["g-waabm-in", "2-see-1.INV"]
+    ],
+    "translation": "I see you.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "1>2 = 2"],
+      ["context", "inverse"]
+    ],
+    "comment": "Nishnaabemwin (Odawa/Eastern Ojibwe): 2nd person is most specified ([u-3-1-2]), so the 2nd-person IA wins."
+  },
+  {
+    "id": "br2009_17b",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(17b)"},
+    "language": "otta1242",
+    "primaryText": "g-waabm-i",
+    "glossedTokens": [
+      ["g-waabm-i", "2-see-DFLT.1"]
+    ],
+    "translation": "You see me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "2>1 = 2"],
+      ["context", "direct"]
+    ],
+    "comment": "The 1st-person IA leaves the [u2] segment, checked by the 2nd-person EA on cycle II."
+  },
+  {
+    "id": "br2009_17c",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(17c)"},
+    "language": "otta1242",
+    "primaryText": "n-waabm-ig",
+    "glossedTokens": [
+      ["n-waabm-ig", "1-see-3.INV"]
+    ],
+    "translation": "He sees me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "3>1 = 1"],
+      ["context", "inverse"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "br2009_17d",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(17d)"},
+    "language": "otta1242",
+    "primaryText": "g-waabm-ig",
+    "glossedTokens": [
+      ["g-waabm-ig", "2-see-3.INV"]
+    ],
+    "translation": "He sees you.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "3>2 = 2"],
+      ["context", "inverse"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "br2009_18a",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(18a)"},
+    "language": "nucl1302",
+    "primaryText": "m-xedav-s",
+    "glossedTokens": [
+      ["m-xedav-s", "1.I-see-X"]
+    ],
+    "translation": "He sees me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "3>1 = 1"],
+      ["morphology", "first-cycle m-"]
+    ],
+    "comment": "1sg spelled m- when the probe is valued on cycle I (IA controls)."
+  },
+  {
+    "id": "br2009_18b",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(18b)"},
+    "language": "nucl1302",
+    "primaryText": "v-xedav",
+    "glossedTokens": [
+      ["v-xedav", "1.II-see"]
+    ],
+    "translation": "I see him.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "1>3 = 1"],
+      ["morphology", "second-cycle v-"]
+    ],
+    "comment": "Same 1sg value spelled v- when valued on cycle II — a second-cycle effect."
+  },
+  {
+    "id": "br2009_29a",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(29a)"},
+    "language": "kash1277",
+    "primaryText": "bé chusath tsé paréna:va:n",
+    "glossedTokens": [
+      ["bé", "I.N"], ["chu-s-ath", "be.M.SG-1.SG.N-2.SG.E/A"], ["tsé", "you.N"],
+      ["paréna:va:n", "teaching"]
+    ],
+    "translation": "I am teaching you.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "1>2"],
+      ["context", "direct"],
+      ["IA case", "unmarked"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "br2009_29b",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(29b)"},
+    "language": "kash1277",
+    "primaryText": "tsé chukh me paréna:va:n",
+    "glossedTokens": [
+      ["tsé", "you.N"], ["chu-kh", "be.M.SG-2.SG.N"], ["me", "me.D"], ["paréna:va:n", "teaching"]
+    ],
+    "translation": "You are teaching me.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["combination", "2>1"],
+      ["context", "inverse"],
+      ["IA case", "R-Case (dative form)"]
+    ],
+    "comment": "The inverse-context IA takes the special R-Case; the sole agreement slot tracks the EA."
+  },
+  {
+    "id": "br2009_30b",
+    "source": {"bibkey": "bejar-rezac-2009", "paperLabel": "(30b)"},
+    "language": "kash1277",
+    "primaryText": "tsé yikh me hava:lé karné tUm'séndi dUs'",
+    "glossedTokens": [
+      ["tsé", "you.N"], ["yi-kh", "come.FUT-2.SG.N"], ["me", "me.D"], ["hava:lé", "handover"],
+      ["karné", "do.INF.ABL"], ["tUm'séndi", "he.GEN"], ["dUs'", "by"]
+    ],
+    "translation": "You will be handed over to me by him.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "passivization"],
+      ["result", "R-Case disappears"]
+    ],
+    "comment": "R-Case vanishes under passivization, unlike the inherent dative (30a) — it is structural, tied to the inverse configuration."
+  }
+]

--- a/Linglib/Data/Examples/BejarRezac2009.lean
+++ b/Linglib/Data/Examples/BejarRezac2009.lean
@@ -1,0 +1,324 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `BejarRezac2009` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/BejarRezac2009.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace BejarRezac2009.Examples`.
+-/
+
+namespace BejarRezac2009.Examples
+
+open Data.Examples
+
+def br2009_2a : LinguisticExample :=
+  { id := "br2009_2a"
+    source := ⟨"bejar-rezac-2009", "(2a)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "ikusi zintudan"
+    discourseSegments := []
+    glossedTokens := [("ikusi", "seen"), ("z-in-t-u-da-n", "2-X-PL-have-1-PAST")]
+    translation := "I saw you."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "1>2 = 2"), ("context", "inverse")]
+    comment := "The core slot tracks the IA: a 2nd-person object fully checks the [u-3-2] probe."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_2b : LinguisticExample :=
+  { id := "br2009_2b"
+    source := ⟨"bejar-rezac-2009", "(2b)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "ikusi ninduen"
+    discourseSegments := []
+    glossedTokens := [("ikusi", "seen"), ("n-ind-u-en", "1-X-have-PAST")]
+    translation := "He saw me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "3>1 = 1"), ("context", "inverse")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_2c : LinguisticExample :=
+  { id := "br2009_2c"
+    source := ⟨"bejar-rezac-2009", "(2c)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "ikusininduzun"
+    discourseSegments := []
+    glossedTokens := [("ikusi", "seen"), ("n-ind-u-zu-n", "1-X-have-2-PAST")]
+    translation := "You saw me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "2>1 = 1"), ("context", "inverse")]
+    comment := "With (2a): no ranking of person values decides between two SAP arguments — the IA wins both times."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_2d : LinguisticExample :=
+  { id := "br2009_2d"
+    source := ⟨"bejar-rezac-2009", "(2d)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "ikusi nuen"
+    discourseSegments := []
+    glossedTokens := [("ikusi", "seen"), ("n-u-en", "1-have-PAST")]
+    translation := "I saw him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "1>3 = 1"), ("context", "direct")]
+    comment := "The 3rd-person IA leaves the [u2] residue, which the SAP EA checks on cycle II: displacement to the EA."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_3 : LinguisticExample :=
+  { id := "br2009_3"
+    source := ⟨"bejar-rezac-2009", "(3)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "Nik neure burua ikusten nuen."
+    discourseSegments := []
+    glossedTokens := [("Ni-k", "1-E"), ("neure", "my.own"), ("buru-a", "head-the.A"), ("ikusten", "seeing"), ("n-u-en", "1-have-PAST")]
+    translation := "I saw myself."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "case and binding unaffected")]
+    comment := "Ergative displacement changes neither case marking nor binding: agreement displacement is not movement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_15 : LinguisticExample :=
+  { id := "br2009_15"
+    source := ⟨"bejar-rezac-2009", "(15)"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "Zuk etsaiari misilak / *ni saldu dizkiozu."
+    discourseSegments := []
+    glossedTokens := [("Zu-k", "you-E"), ("etsaia-ri", "enemy-D"), ("misil-ak", "missile-A.PL"), ("ni", "me.A"), ("saldu", "sold"), ("d-i-zki-o-zu", "X-have-PL-3.D-2.E")]
+    translation := "You have sold the missiles / *me to the enemy."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("constraint", "Person Case Constraint")]
+    comment := "With a dative goal absorbing the π-probe, a 1st-person theme is unlicensable — the PLC at work."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_t9_3_1 : LinguisticExample :=
+  { id := "br2009_t9_3_1"
+    source := ⟨"bejar-rezac-2009", "Table 9"⟩
+    reportedIn := none
+    language := "basq1248"
+    primaryText := "niñdduen"
+    discourseSegments := []
+    glossedTokens := [("n-iñdd-u-en", "1.SG-INV-have-PAST")]
+    translation := "He had me."
+    context := "Bizkaian dialect of Bolivar."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "3>1"), ("repair", "added probe (INV)")]
+    comment := "The INV slot spells out the added probe that licenses the EA in inverse contexts."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_10 : LinguisticExample :=
+  { id := "br2009_10"
+    source := ⟨"bejar-rezac-2009", "(10)"⟩
+    reportedIn := none
+    language := "swah1253"
+    primaryText := "sijakiona chochote"
+    discourseSegments := []
+    glossedTokens := [("si-ja-ki-ona", "1.SG-NEG-7-see"), ("chochote", "anything")]
+    translation := "I haven't seen anything."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("probe", "flat [u-3]"), ("agreement", "object and subject independent")]
+    comment := "A flat probe is fully checked by any IA: no person-hierarchy interaction, every context inverse."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_17a : LinguisticExample :=
+  { id := "br2009_17a"
+    source := ⟨"bejar-rezac-2009", "(17a)"⟩
+    reportedIn := none
+    language := "otta1242"
+    primaryText := "g-waabm-in"
+    discourseSegments := []
+    glossedTokens := [("g-waabm-in", "2-see-1.INV")]
+    translation := "I see you."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "1>2 = 2"), ("context", "inverse")]
+    comment := "Nishnaabemwin (Odawa/Eastern Ojibwe): 2nd person is most specified ([u-3-1-2]), so the 2nd-person IA wins."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_17b : LinguisticExample :=
+  { id := "br2009_17b"
+    source := ⟨"bejar-rezac-2009", "(17b)"⟩
+    reportedIn := none
+    language := "otta1242"
+    primaryText := "g-waabm-i"
+    discourseSegments := []
+    glossedTokens := [("g-waabm-i", "2-see-DFLT.1")]
+    translation := "You see me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "2>1 = 2"), ("context", "direct")]
+    comment := "The 1st-person IA leaves the [u2] segment, checked by the 2nd-person EA on cycle II."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_17c : LinguisticExample :=
+  { id := "br2009_17c"
+    source := ⟨"bejar-rezac-2009", "(17c)"⟩
+    reportedIn := none
+    language := "otta1242"
+    primaryText := "n-waabm-ig"
+    discourseSegments := []
+    glossedTokens := [("n-waabm-ig", "1-see-3.INV")]
+    translation := "He sees me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "3>1 = 1"), ("context", "inverse")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_17d : LinguisticExample :=
+  { id := "br2009_17d"
+    source := ⟨"bejar-rezac-2009", "(17d)"⟩
+    reportedIn := none
+    language := "otta1242"
+    primaryText := "g-waabm-ig"
+    discourseSegments := []
+    glossedTokens := [("g-waabm-ig", "2-see-3.INV")]
+    translation := "He sees you."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "3>2 = 2"), ("context", "inverse")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_18a : LinguisticExample :=
+  { id := "br2009_18a"
+    source := ⟨"bejar-rezac-2009", "(18a)"⟩
+    reportedIn := none
+    language := "nucl1302"
+    primaryText := "m-xedav-s"
+    discourseSegments := []
+    glossedTokens := [("m-xedav-s", "1.I-see-X")]
+    translation := "He sees me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "3>1 = 1"), ("morphology", "first-cycle m-")]
+    comment := "1sg spelled m- when the probe is valued on cycle I (IA controls)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_18b : LinguisticExample :=
+  { id := "br2009_18b"
+    source := ⟨"bejar-rezac-2009", "(18b)"⟩
+    reportedIn := none
+    language := "nucl1302"
+    primaryText := "v-xedav"
+    discourseSegments := []
+    glossedTokens := [("v-xedav", "1.II-see")]
+    translation := "I see him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "1>3 = 1"), ("morphology", "second-cycle v-")]
+    comment := "Same 1sg value spelled v- when valued on cycle II — a second-cycle effect."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_29a : LinguisticExample :=
+  { id := "br2009_29a"
+    source := ⟨"bejar-rezac-2009", "(29a)"⟩
+    reportedIn := none
+    language := "kash1277"
+    primaryText := "bé chusath tsé paréna:va:n"
+    discourseSegments := []
+    glossedTokens := [("bé", "I.N"), ("chu-s-ath", "be.M.SG-1.SG.N-2.SG.E/A"), ("tsé", "you.N"), ("paréna:va:n", "teaching")]
+    translation := "I am teaching you."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "1>2"), ("context", "direct"), ("IA case", "unmarked")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_29b : LinguisticExample :=
+  { id := "br2009_29b"
+    source := ⟨"bejar-rezac-2009", "(29b)"⟩
+    reportedIn := none
+    language := "kash1277"
+    primaryText := "tsé chukh me paréna:va:n"
+    discourseSegments := []
+    glossedTokens := [("tsé", "you.N"), ("chu-kh", "be.M.SG-2.SG.N"), ("me", "me.D"), ("paréna:va:n", "teaching")]
+    translation := "You are teaching me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("combination", "2>1"), ("context", "inverse"), ("IA case", "R-Case (dative form)")]
+    comment := "The inverse-context IA takes the special R-Case; the sole agreement slot tracks the EA."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def br2009_30b : LinguisticExample :=
+  { id := "br2009_30b"
+    source := ⟨"bejar-rezac-2009", "(30b)"⟩
+    reportedIn := none
+    language := "kash1277"
+    primaryText := "tsé yikh me hava:lé karné tUm'séndi dUs'"
+    discourseSegments := []
+    glossedTokens := [("tsé", "you.N"), ("yi-kh", "come.FUT-2.SG.N"), ("me", "me.D"), ("hava:lé", "handover"), ("karné", "do.INF.ABL"), ("tUm'séndi", "he.GEN"), ("dUs'", "by")]
+    translation := "You will be handed over to me by him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "passivization"), ("result", "R-Case disappears")]
+    comment := "R-Case vanishes under passivization, unlike the inherent dative (30a) — it is structural, tied to the inverse configuration."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [br2009_2a, br2009_2b, br2009_2c, br2009_2d, br2009_3, br2009_15, br2009_t9_3_1, br2009_10, br2009_17a, br2009_17b, br2009_17c, br2009_17d, br2009_18a, br2009_18b, br2009_29a, br2009_29b, br2009_30b]
+
+end BejarRezac2009.Examples

--- a/Linglib/Studies/BejarRezac2009.lean
+++ b/Linglib/Studies/BejarRezac2009.lean
@@ -1,40 +1,43 @@
 import Linglib.Syntax.Minimalist.Agree.Cyclic
 import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
+import Linglib.Data.Examples.BejarRezac2009
 
 /-!
-# Cyclic Agree and Differential P Indexing [bejar-rezac-2009]
+# Béjar & Rezac (2009): Cyclic Agree
 
-[bejar-rezac-2009] derive **agreement displacement** — where
-the agreement controller alternates between the EA and IA based on
-person — from cyclic Agree with articulated φ-probes.
+Person-hierarchy-driven agreement displacement falls out of Agree over
+articulated π-probes in a cyclic syntax: the probe on v meets the IA
+first, checks whatever segments it can, and any active residue meets the
+EA on the next projection. The probe's articulation — flat [u-3], partial
+[u-3-2], full [u-3-1-2] ((7)–(9)) — fixes a language's hierarchy
+sensitivity, and the derivations split into direct contexts, where the EA
+checks residue, and inverse contexts, where the EA never Agrees (22).
+Inverse contexts violate the Person-Licensing Condition
+(`Minimalist.CyclicAgree.plc_violation_iff_inverse`) and are repaired by
+an added probe (Mohawk, Nishnaabemwin, Basque) or R-Case on the IA
+(Kashmiri) — one mechanism, property P (23), with parametric spell-out.
 
-This study file connects the Cyclic Agree theory
-(`Syntax/Minimalism/CyclicAgree.lean`) to the empirical
-fragment data for Basque and Georgian, proving that the **differential
-P indexing** pattern in both languages is predicted by the partial
-probe's direct/inverse classification.
+## Main statements
 
-## Key Result
+* `basque_indexed_iff_always_inverse`, `georgian_indexed_iff_always_inverse`:
+  the Fragment paradigms index an object iff cyclic Agree puts every
+  EA→IA combination into an inverse context.
+* `nishnaabemwin_direct_contexts`, `basque_direct_contexts`,
+  `swahili_all_inverse`: the (22) direct/inverse classifications, derived
+  from the three probe articulations.
+* `repairs_identically_distributed`, `repair_iff_inverse`: Mohawk's
+  added-probe cells (Table 7) and Kashmiri's R-Case cells (Table 11) are
+  the same cells, and they are exactly the inverse contexts of the
+  [u-3-2-1] system — disparately realized, identically distributed (§4).
 
-The central theorem (`basque_indexed_iff_always_inverse`,
-`georgian_indexed_iff_always_inverse`) proves:
+## References
 
-> An object (IA) is indexed on the verb iff the partial probe puts
-> every EA→IA combination into an inverse context.
-
-SAP objects satisfy this because SAP IAs fully check the partial probe
-[uπ, uParticipant], leaving no residue for any EA. 3P objects fail it
-because a SAP EA can match the residue [uParticipant], creating a
-direct context where the EA — not the object — controls agreement.
-
-## Georgian Second-Cycle Morphology
-
-Georgian's *m-*/*v-* prefix split for 1sg objects is predicted by the
-second-cycle information: *m-* appears when valued on cycle I (IA=1P),
-*v-* when valued on cycle II (EA=1P, IA=3P). This connects Georgian
-`objectPrefix` to `cycleSegments`.
-
+* [bejar-rezac-2009]: Cyclic Agree. *Linguistic Inquiry* 40.
+* [bejar-rezac-2003]: Person licensing and the derivation of PCC effects.
+* [bejar-2003]: Phi-syntax: A theory of agreement.
+* [harley-ritter-2002]: Person and number in pronouns: A feature-geometric
+  analysis.
 -/
 
 namespace BejarRezac2009
@@ -42,161 +45,157 @@ namespace BejarRezac2009
 open Minimalist.CyclicAgree
 open Agreement
 
--- ============================================================================
--- § 1: φ-cell → Person Bridge
--- ============================================================================
-
-/-- Person level of a φ-cell (`Agreement.Cell`). Basque and Georgian share the
-    same person→level map. -/
+/-- Person level of a φ-cell (`Agreement.Cell`); Basque and Georgian share
+the same map. -/
 def toLevel (c : Cell) : Person :=
   match c.person with
   | some .first => .first
   | some .second => .second
   | _ => .third
 
--- ============================================================================
--- § 2: Basque — pIsIndexed Matches Inverse Context
--- ============================================================================
+/-- The three core person values the paper's paradigms range over. -/
+def corePersons : List Person := [.first, .second, .third]
 
-/-- Basque `pIsIndexed` agrees with `Person.isSAP` under the bridge. -/
-theorem basque_indexed_eq_sap : ∀ c ∈ Cell.pnCells,
-    Basque.Agreement.pIsIndexed c = decide (toLevel c).IsSAP := by decide
+/-! ### Basque: ergative displacement ((2)) -/
 
-/-- Per-cell verification: each Basque φ-cell's indexing status matches the
-    cyclic agree prediction. -/
-theorem basque_p1sg_indexed :
-    Basque.Agreement.pIsIndexed (.pn .first .Sing) = true ∧
-    basque.isInverse .first .first = true ∧
-    basque.isInverse .second .first = true ∧
-    basque.isInverse .third .first = true := by decide
+/-- The (2) paradigm: the core slot tracks the IA in (2a–c) and displaces
+to the EA only when the 3rd-person IA leaves the [u2] residue (2d) — no
+ranking of person values covers both (2a) 1>2 = 2 and (2c) 2>1 = 1. -/
+theorem basque_displacement_paradigm :
+    basque.value .first .second = .second ∧   -- (2a) 1>2 = 2
+    basque.value .third .first = .first ∧     -- (2b) 3>1 = 1
+    basque.value .second .first = .first ∧    -- (2c) 2>1 = 1
+    basque.value .first .third = .first := by -- (2d) 1>3 = 1
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
-theorem basque_p2sg_indexed :
-    Basque.Agreement.pIsIndexed (.pn .second .Sing) = true ∧
-    basque.isInverse .first .second = true ∧
-    basque.isInverse .second .second = true ∧
-    basque.isInverse .third .second = true := by decide
+/-- Basque's direct contexts (22b): exactly a SAP EA over a 3rd-person IA
+— the only cells where the [u-3-2] probe keeps a residue the EA can
+check. -/
+theorem basque_direct_contexts :
+    ∀ ea ∈ corePersons, ∀ ia ∈ corePersons,
+      (isDirectContext .standard partialProbe ea ia = true ↔
+        (ea = .first ∨ ea = .second) ∧ ia = .third) := by decide
 
-theorem basque_p3sg_not_indexed :
-    Basque.Agreement.pIsIndexed (.pn .third .Sing) = false ∧
-    basque.isInverse .first .third = false ∧
-    basque.isInverse .second .third = false := by decide
-
-/-- Core bridge theorem (Basque): an object is indexed iff cyclic agree
-    puts *every* EA→IA combination into an inverse context.
-
-    When the object (IA) is SAP, the partial probe [uπ, uParticipant] is
-    fully checked by the IA on cycle I, leaving no residue for any EA.
-    Result: IA always controls → agreement tracks the object → indexed.
-
-    When the object is 3P, the IA only checks [uπ], leaving [uParticipant]
-    as active residue. A SAP EA matches this residue on cycle II → EA
-    controls → agreement tracks the subject, not the object → not indexed. -/
+/-- Differential object indexing: the Fragment's `pIsIndexed` (SAP objects
+indexed, textbook Basque) holds of a φ-cell iff cyclic Agree puts *every*
+EA→IA combination with that object into an inverse context — a SAP IA
+fully checks [u-3-2], leaving no residue for any EA. -/
 theorem basque_indexed_iff_always_inverse : ∀ c ∈ Cell.pnCells,
     (Basque.Agreement.pIsIndexed c = true ↔
-     ∀ ea : Person, basque.isInverse ea (toLevel c) = true) := by decide
+      ∀ ea : Person, basque.isInverse ea (toLevel c) = true) := by decide
 
--- ============================================================================
--- § 3: Georgian — isIndexed Matches Inverse Context
--- ============================================================================
+/-! ### Georgian: the same [u-3-2] system, plus second-cycle morphology -/
 
-/-- Georgian `isIndexed` agrees with `Person.isSAP` under the bridge. -/
-theorem georgian_indexed_eq_sap : ∀ c ∈ Cell.pnCells,
-    Georgian.Agreement.isIndexed c = decide (toLevel c).IsSAP := by decide
-
-/-- Per-cell verification: Georgian 1sg object prefix *m-* exists iff inverse. -/
-theorem georgian_1sg_prefix_and_inverse :
-    Georgian.Agreement.objectAgr.realize (.pn .first .Sing) = some "m-" ∧
-    basque.isInverse .first .first = true ∧
-    basque.isInverse .second .first = true ∧
-    basque.isInverse .third .first = true := by decide
-
-/-- Per-cell verification: Georgian 3sg has no object prefix, and
-    there exist direct contexts. -/
-theorem georgian_3sg_no_prefix_and_direct :
-    Georgian.Agreement.objectAgr.realize (.pn .third .Sing) = none ∧
-    isDirectContext .standard partialProbe .first .third = true ∧
-    isDirectContext .standard partialProbe .second .third = true := by decide
-
-/-- Core bridge theorem (Georgian): object is indexed iff always inverse.
-
-    Georgian uses the same partial probe [u-3-2] and standard geometry as
-    Basque, so the same cyclic agree mechanism derives the same SAP/3P
-    split in object agreement. -/
+/-- Georgian's paradigm-derived object indexing (`objectAgr` has an
+exponent for a cell or not) matches the inverse classification of the
+shared standard-geometry [u-3-2] system, exactly as in Basque. -/
 theorem georgian_indexed_iff_always_inverse : ∀ c ∈ Cell.pnCells,
     (Georgian.Agreement.isIndexed c = true ↔
-     ∀ ea : Person, basque.isInverse ea (toLevel c) = true) := by decide
+      ∀ ea ∈ corePersons,
+        isInverseContext .standard partialProbe ea (toLevel c) = true) := by
+  decide
 
--- ============================================================================
--- § 4: Georgian Second-Cycle Morphology
--- ============================================================================
-
-/-- Georgian 1sg agreement: *m-* appears when 1P is the IA (cycle I only),
-    *v-* appears when 1P is the EA (cycle II, IA=3P).
-
-    [bejar-rezac-2009] §3.2: the *m-*/*v-* alternation correlates with
-    whether the probe was valued on the first or second cycle. -/
+/-- 1sg *m-* is first-cycle morphology (18a): whenever the IA is 1st
+person the probe is fully valued on cycle I, whatever the EA. -/
 theorem georgian_m_is_cycle_I :
-    hasSecondCycleEffect .standard partialProbe .third .first = false ∧
-    hasSecondCycleEffect .standard partialProbe .second .first = false ∧
-    hasSecondCycleEffect .standard partialProbe .first .first = false := by
-  exact ⟨by decide, by decide, by decide⟩
+    Georgian.Agreement.objectAgr.realize (.pn .first .Sing) = some "m-" ∧
+    ∀ ea ∈ corePersons,
+      hasSecondCycleEffect .standard partialProbe ea .first = false := by
+  refine ⟨rfl, ?_⟩; decide
 
+/-- 1sg *v-* is second-cycle morphology (18b): with a 3rd-person IA the
+[u2] residue is valued by the SAP EA on cycle II — the same person value,
+spelled by the cycle that valued it. -/
 theorem georgian_v_is_cycle_II :
     hasSecondCycleEffect .standard partialProbe .first .third = true ∧
     hasSecondCycleEffect .standard partialProbe .second .third = true := by
-  exact ⟨by decide, by decide⟩
+  refine ⟨?_, ?_⟩ <;> decide
 
-/-- The *m-*/*v-* split is exactly the inverse/direct split for 1P:
-    - *m-* (1P object = IA, inverse) → cycle I only, no second-cycle effect
-    - *v-* (1P subject = EA, direct) → second-cycle effect present
+/-! ### Nishnaabemwin: the fully articulated probe ((17), Tables 4–5) -/
 
-    This connects Georgian `objectPrefix` morphology to the derivational
-    mechanics of cyclic expansion. -/
-theorem georgian_mv_split_is_inverse_direct :
-    -- m-: 1P as IA (3→1), inverse, no second cycle
-    (basque.isInverse .third .first = true ∧
-     hasSecondCycleEffect .standard partialProbe .third .first = false) ∧
-    -- v-: 1P as EA (1→3), direct, has second cycle
-    (isDirectContext .standard partialProbe .first .third = true ∧
-     hasSecondCycleEffect .standard partialProbe .first .third = true) := by
-  exact ⟨⟨by decide, by decide⟩, ⟨by decide, by decide⟩⟩
+/-- The (17) core-slot paradigm under the [u-3-1-2] probe (2nd person most
+specified, addressee geometry): the 2nd-person IA wins in (17a), the
+2nd-person EA checks the [u2] residue over a 1st-person IA in (17b), and
+3rd-person EAs never displace ((17c–d)). -/
+theorem nishnaabemwin_controllers :
+    nishnaabemwin.value .first .second = .second ∧   -- (17a) 1>2 = 2
+    nishnaabemwin.value .second .first = .second ∧   -- (17b) 2>1 = 2
+    nishnaabemwin.value .third .first = .first ∧     -- (17c) 3>1 = 1
+    nishnaabemwin.value .third .second = .second := by -- (17d) 3>2 = 2
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
--- ============================================================================
--- § 5: Basque Agreement Displacement Paradigm (Table 1)
--- ============================================================================
+/-- Nishnaabemwin's direct contexts (22b): 2>1, 2>3, and 1>3 — the EA
+checks residue exactly when it is more specified than the IA on the
+2>1>3 geometry. -/
+theorem nishnaabemwin_direct_contexts :
+    ∀ ea ∈ corePersons, ∀ ia ∈ corePersons,
+      (isDirectContext .addressee fullProbeAddr ea ia = true ↔
+        (ea = .second ∧ ia ≠ .second) ∨ (ea = .first ∧ ia = .third)) := by
+  decide
 
--- [bejar-rezac-2009] Table 1: Basque paradigm cells showing which
--- argument controls the agreement slot.
--- The notation `x→y = z` means: EA=x, IA=y, agreement tracks z.
--- Underlined forms in the paper track the IA (inverse/displacement);
--- non-underlined forms track the EA (direct/regular).
+/-- A flat-probe language has no direct contexts at all (22a): any IA
+fully checks [u-3], so subject and object agreement never interact
+((10), Swahili). -/
+theorem swahili_all_inverse :
+    ∀ ea ∈ corePersons, ∀ ia ∈ corePersons,
+      swahili.isInverse ea ia = true := by decide
 
-/-- (2a) 1→2 = 2: "I saw you" — IA controls (inverse). -/
-theorem table1_basque_1_2 : basque.value .first .second = .second := by decide
-/-- (2b) 3→1 = 1: "He saw me" — IA controls (inverse/displacement). -/
-theorem table1_basque_3_1 : basque.value .third .first = .first := by decide
-/-- (2c) 2→1 = 1: "You saw me" — IA controls (inverse/displacement). -/
-theorem table1_basque_2_1 : basque.value .second .first = .first := by decide
-/-- (2d) 1→3 = 1: "I saw him" — EA controls (direct/regular). -/
-theorem table1_basque_1_3 : basque.value .first .third = .first := by decide
-/-- 2→3 = 2: "You saw him" — EA controls (direct/regular). -/
-theorem table1_basque_2_3 : basque.value .second .third = .second := by decide
+/-! ### Repairs: added probe and R-Case (§4, Tables 7 and 11)
 
--- ============================================================================
--- § 6: Cross-Linguistic Uniformity
--- ============================================================================
+Inverse contexts leave the EA without π-Agree, violating the PLC
+(`plc_violation_iff_inverse`); property P (23) adds a probe on vII, spelled
+out as extra EA agreement (Mohawk, Bizkaian Basque INV, the Nishnaabemwin
+theme suffix) or, with the alternative spell-out choice (24), as the
+special R-Case on the IA (Kashmiri). -/
 
-/-- Basque and Georgian make the same predictions because they share the
-    same agreement system (standard geometry, partial probe). -/
-theorem basque_georgian_same_system :
-    basque = ⟨.standard, partialProbe⟩ ∧
-    basque = basque := ⟨rfl, rfl⟩
+/-- The seven attested transitive cells of the paper's [u-3-2-1] paradigms
+(1>1 and 2>2 are systematic gaps; 3>3 is attested with differently
+specified 3rd persons). -/
+def attestedCells : List (Person × Person) :=
+  [(.first, .second), (.first, .third), (.second, .first), (.second, .third),
+   (.third, .first), (.third, .second), (.third, .third)]
 
-/-- The differential P indexing pattern is identical for all six
-    person-number φ-cells across both languages. -/
-theorem cross_linguistic_uniformity :
-    (∀ c ∈ Cell.pnCells, Basque.Agreement.pIsIndexed c = decide (toLevel c).IsSAP) ∧
-    (∀ c ∈ Cell.pnCells, Georgian.Agreement.isIndexed c = decide (toLevel c).IsSAP) :=
-  ⟨basque_indexed_eq_sap, georgian_indexed_eq_sap⟩
+/-- Mohawk's added-probe cells (Table 7): the extra agreement slot appears
+in 2>1, 3>1, 3>2, and 3>3. -/
+def mohawkAddedProbe : Person × Person → Bool
+  | (.second, .first) | (.third, .first)
+  | (.third, .second) | (.third, .third) => true
+  | _ => false
+
+/-- Kashmiri's R-Case cells (Table 11): the IA bears the dative-shaped
+structural Case in 2>1, 3>1, 3>2, and 3>3, and only there. -/
+def kashmiriRCase : Person × Person → Bool
+  | (.second, .first) | (.third, .first)
+  | (.third, .second) | (.third, .third) => true
+  | _ => false
+
+/-- The two repairs are identically distributed (§4.1): Mohawk's extra
+agreement and Kashmiri's special Case mark the same cells — one mechanism,
+two spell-outs. -/
+theorem repairs_identically_distributed :
+    ∀ c ∈ attestedCells, mohawkAddedProbe c = kashmiriRCase c := by decide
+
+/-- The repair cells are exactly the inverse contexts of the [u-3-2-1]
+standard-geometry system: repair appears where the EA fails to Agree with
+the core probe. -/
+theorem repair_iff_inverse :
+    ∀ c ∈ attestedCells,
+      kashmiriRCase c = isInverseContext .standard fullProbeStd c.1 c.2 := by
+  decide
+
+/-- The repair cells are exactly those where the EA is not person-licensed
+by the core probe — the PLC connection (13): repair is EA licensing. -/
+theorem repair_marks_unlicensed_ea :
+    ∀ c ∈ attestedCells,
+      (kashmiriRCase c = true ↔
+        eaIsLicensed .standard fullProbeStd c.1 c.2 = false) := by decide
+
+/-- Basque's added probe appears in more cells than Mohawk's because its
+probe is shallower: 1>2 is inverse for [u-3-2] (Bizkaian INV *iñdd*,
+Table 9) but direct for [u-3-2-1] (Mohawk's portmanteau *ku*, Table 7). -/
+theorem shallower_probe_more_inverse :
+    isInverseContext .standard partialProbe .first .second = true ∧
+    isDirectContext .standard fullProbeStd .first .second = true := by
+  refine ⟨?_, ?_⟩ <;> decide
 
 end BejarRezac2009


### PR DESCRIPTION
Paper audit (read in full): Basque/Georgian content verified but the file mislabeled (2a-d) as Table 1, had a vacuous basque = basque conjunct, per-cell decide walls, and omitted the paper's centerpieces. Adds the Nishnaabemwin [u-3-1-2] paradigm, the (22) direct/inverse classifications for all three probe articulations, and the §4 repair unification (Mohawk added-probe and Kashmiri R-Case cells identical and equal to the inverse contexts); 17 example rows across six languages.