### PR TITLE
refactor(Studies/Beltrama2025): register, keys, rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -360,6 +360,7 @@ import Linglib.Data.Examples.BejarRezac2009
 import Linglib.Data.Examples.Belnap1970
 import Linglib.Data.Examples.Belnap1982
 import Linglib.Data.Examples.Belth2026
+import Linglib.Data.Examples.Beltrama2025
 import Linglib.Data.Examples.BeltramaSchwarz2024
 import Linglib.Data.Examples.BergenGoodman2015
 import Linglib.Data.Examples.Bondarenko2022

--- a/Linglib/Data/Examples/Beltrama2025.json
+++ b/Linglib/Data/Examples/Beltrama2025.json
@@ -1,0 +1,241 @@
+[
+  {
+    "id": "beltrama2025_1a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(1a)"},
+    "language": "stan1293",
+    "primaryText": "This pizza is decent.",
+    "glossedTokens": [],
+    "translation": "This pizza is decent.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [
+      {"name": "middling: positive but only moderately so", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["class", "MPA"],
+      ["inference", "middling"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beltrama2025_3c",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(3c)"},
+    "language": "stan1293",
+    "primaryText": "A: Can you recommend a place making a decent pizza around here? B: Mario's! Their pizza is really good!",
+    "glossedTokens": [],
+    "translation": "A: Can you recommend a place making a decent pizza around here? B: Mario's! Their pizza is really good!",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "cancelability"],
+      ["verdict", "middling inference is an implicature"]
+    ],
+    "comment": "Contrast lukewarm (3b): elaborating with the stronger term contradicts lexicalized upper bounds."
+  },
+  {
+    "id": "beltrama2025_4c",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(4c)"},
+    "language": "stan1293",
+    "primaryText": "This pizza is decent—but it's not great.",
+    "glossedTokens": [],
+    "translation": "This pizza is decent—but it's not great.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "reinforceability"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beltrama2025_5c",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(5c)"},
+    "language": "stan1293",
+    "primaryText": "Every customer who thinks their pizza was decent will get a refund.",
+    "glossedTokens": [],
+    "translation": "Every customer who thinks their pizza was decent will get a refund.",
+    "context": "The refund is meant for unhappy customers.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "DE suspension"],
+      ["verdict", "no upper-bounded reading in the restrictor"]
+    ],
+    "comment": "The contradictory flavor shows the middling inference is suspended in downward-entailing contexts."
+  },
+  {
+    "id": "beltrama2025_8a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(8a)"},
+    "language": "stan1293",
+    "primaryText": "This pizza is decent for a US pizza; but for an Italian pizza, it wouldn't be.",
+    "glossedTokens": [],
+    "translation": "This pizza is decent for a US pizza; but for an Italian pizza, it wouldn't be.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "for-phrase"],
+      ["property", "context-sensitivity"]
+    ],
+    "comment": "MPAs are comparison-class sensitive, unlike absolute adjectives."
+  },
+  {
+    "id": "beltrama2025_11a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(11a)"},
+    "language": "stan1293",
+    "primaryText": "The pizza is very/incredibly/super decent.",
+    "glossedTokens": [],
+    "translation": "The pizza is very/incredibly/super decent.",
+    "context": "",
+    "judgment": "marginal",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "strong intensifiers"],
+      ["property", "restricted gradability"]
+    ],
+    "comment": "Moderate modifiers (quite, pretty, somewhat) are fine; high and extreme ones degrade."
+  },
+  {
+    "id": "beltrama2025_12a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(12a)"},
+    "language": "stan1293",
+    "primaryText": "Pizza A is more decent than Pizza B.",
+    "glossedTokens": [],
+    "translation": "Pizza A is more decent than Pizza B.",
+    "context": "Pizza A is exceptionally good.",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "comparative"],
+      ["property", "mildness retained in comparatives"]
+    ],
+    "comment": "Better is fine in the same context: the MPA comparative keeps the middling flavor."
+  },
+  {
+    "id": "beltrama2025_15a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(15a)"},
+    "language": "stan1293",
+    "primaryText": "This pizza is neither acceptable nor unacceptable.",
+    "glossedTokens": [],
+    "translation": "This pizza is neither acceptable nor unacceptable.",
+    "context": "",
+    "judgment": "marginal",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "zone of indifference"],
+      ["verdict", "near-contradiction"]
+    ],
+    "comment": "Good/bad leave a neutral gap (14a); MPAs do not — existential vs universal force clash."
+  },
+  {
+    "id": "beltrama2025_21",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(21)"},
+    "language": "stan1293",
+    "primaryText": "This pizza is barely decent.",
+    "glossedTokens": [],
+    "translation": "This pizza is barely decent.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "barely"],
+      ["property", "crisp boundary"]
+    ],
+    "comment": "#barely good needs a special high-standard context; the necessity standard gives MPAs a crisp edge."
+  },
+  {
+    "id": "beltrama2025_22a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(22a)"},
+    "language": "stan1293",
+    "primaryText": "Ok, this pizza is acceptable. But a pizza any worse than this one—even by just a tiny bit—wouldn't be acceptable.",
+    "glossedTokens": [],
+    "translation": "Ok, this pizza is acceptable. But a pizza any worse than this one—even by just a tiny bit—wouldn't be acceptable.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "crisp judgment"]
+    ],
+    "comment": "The same continuation with good is infelicitous — vague standards resist crisp cutoffs."
+  },
+  {
+    "id": "beltrama2025_24a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(24a)"},
+    "language": "stan1293",
+    "primaryText": "The pizza scene in this town is truly desperate—you can't find even a decent one.",
+    "glossedTokens": [],
+    "translation": "The pizza scene in this town is truly desperate—you can't find even a decent one.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "emphasis in DE"],
+      ["parallel", "minimizers"]
+    ],
+    "comment": "With good or fantastic in place of decent the emphasis collapses."
+  },
+  {
+    "id": "beltrama2025_26a",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(26a)"},
+    "language": "stan1293",
+    "primaryText": "Joe is very low maintenance when it comes to pizza. It takes just a decent one to make him happy.",
+    "glossedTokens": [],
+    "translation": "Joe is very low maintenance when it comes to pizza. It takes just a decent one to make him happy.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "minimal sufficiency exclusive"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "beltrama2025_39",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(39)"},
+    "language": "stan1293",
+    "primaryText": "The pizza is slightly decent.",
+    "glossedTokens": [],
+    "translation": "The pizza is slightly decent.",
+    "context": "",
+    "judgment": "unacceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "slightly"],
+      ["verdict", "against the MinSAA analysis"]
+    ],
+    "comment": "MinSAAs (slightly wet, slightly profitable) accept the modifier; MPAs reject it out of the blue."
+  },
+  {
+    "id": "beltrama2025_51b",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(51b)"},
+    "language": "stan1293",
+    "primaryText": "Pizza A is more decent than Pizza B, but neither is decent. In fact, they're both really bad.",
+    "glossedTokens": [],
+    "translation": "Pizza A is more decent than Pizza B, but neither is decent. In fact, they're both really bad.",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "comparative entailment"],
+      ["verdict", "positive form not entailed"]
+    ],
+    "comment": "For MinSAAs the parallel construction contradicts — the MPA standard is more than nonzero value."
+  },
+  {
+    "id": "beltrama2025_70",
+    "source": {"bibkey": "beltrama-2025", "paperLabel": "(70)"},
+    "language": "stan1293",
+    "primaryText": "A: I heard that pizza sucks. B: Not at all. It's actually extremely decent!",
+    "glossedTokens": [],
+    "translation": "A: I heard that pizza sucks. B: Not at all. It's actually extremely decent!",
+    "context": "",
+    "judgment": "acceptable",
+    "readings": [],
+    "paperFeatures": [
+      ["diagnostic", "strong intensifier rescued"],
+      ["condition", "significance excluded from the QUD"]
+    ],
+    "comment": "When only the necessity standard is at issue, the intensifier clash with the middling flavor disappears."
+  }
+]

--- a/Linglib/Data/Examples/Beltrama2025.lean
+++ b/Linglib/Data/Examples/Beltrama2025.lean
@@ -1,0 +1,288 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Beltrama2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Beltrama2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Beltrama2025.Examples`.
+-/
+
+namespace Beltrama2025.Examples
+
+open Data.Examples
+
+def ex_1a : LinguisticExample :=
+  { id := "beltrama2025_1a"
+    source := ⟨"beltrama-2025", "(1a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This pizza is decent."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This pizza is decent."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("middling: positive but only moderately so", .acceptable)]
+    paperFeatures := [("class", "MPA"), ("inference", "middling")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_3c : LinguisticExample :=
+  { id := "beltrama2025_3c"
+    source := ⟨"beltrama-2025", "(3c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A: Can you recommend a place making a decent pizza around here? B: Mario's! Their pizza is really good!"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A: Can you recommend a place making a decent pizza around here? B: Mario's! Their pizza is really good!"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "cancelability"), ("verdict", "middling inference is an implicature")]
+    comment := "Contrast lukewarm (3b): elaborating with the stronger term contradicts lexicalized upper bounds."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4c : LinguisticExample :=
+  { id := "beltrama2025_4c"
+    source := ⟨"beltrama-2025", "(4c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This pizza is decent—but it's not great."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This pizza is decent—but it's not great."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "reinforceability")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5c : LinguisticExample :=
+  { id := "beltrama2025_5c"
+    source := ⟨"beltrama-2025", "(5c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every customer who thinks their pizza was decent will get a refund."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Every customer who thinks their pizza was decent will get a refund."
+    context := "The refund is meant for unhappy customers."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "DE suspension"), ("verdict", "no upper-bounded reading in the restrictor")]
+    comment := "The contradictory flavor shows the middling inference is suspended in downward-entailing contexts."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_8a : LinguisticExample :=
+  { id := "beltrama2025_8a"
+    source := ⟨"beltrama-2025", "(8a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This pizza is decent for a US pizza; but for an Italian pizza, it wouldn't be."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This pizza is decent for a US pizza; but for an Italian pizza, it wouldn't be."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "for-phrase"), ("property", "context-sensitivity")]
+    comment := "MPAs are comparison-class sensitive, unlike absolute adjectives."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_11a : LinguisticExample :=
+  { id := "beltrama2025_11a"
+    source := ⟨"beltrama-2025", "(11a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The pizza is very/incredibly/super decent."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The pizza is very/incredibly/super decent."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "strong intensifiers"), ("property", "restricted gradability")]
+    comment := "Moderate modifiers (quite, pretty, somewhat) are fine; high and extreme ones degrade."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_12a : LinguisticExample :=
+  { id := "beltrama2025_12a"
+    source := ⟨"beltrama-2025", "(12a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Pizza A is more decent than Pizza B."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Pizza A is more decent than Pizza B."
+    context := "Pizza A is exceptionally good."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "comparative"), ("property", "mildness retained in comparatives")]
+    comment := "Better is fine in the same context: the MPA comparative keeps the middling flavor."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_15a : LinguisticExample :=
+  { id := "beltrama2025_15a"
+    source := ⟨"beltrama-2025", "(15a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This pizza is neither acceptable nor unacceptable."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This pizza is neither acceptable nor unacceptable."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "zone of indifference"), ("verdict", "near-contradiction")]
+    comment := "Good/bad leave a neutral gap (14a); MPAs do not — existential vs universal force clash."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21 : LinguisticExample :=
+  { id := "beltrama2025_21"
+    source := ⟨"beltrama-2025", "(21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This pizza is barely decent."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "This pizza is barely decent."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "barely"), ("property", "crisp boundary")]
+    comment := "#barely good needs a special high-standard context; the necessity standard gives MPAs a crisp edge."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22a : LinguisticExample :=
+  { id := "beltrama2025_22a"
+    source := ⟨"beltrama-2025", "(22a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Ok, this pizza is acceptable. But a pizza any worse than this one—even by just a tiny bit—wouldn't be acceptable."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Ok, this pizza is acceptable. But a pizza any worse than this one—even by just a tiny bit—wouldn't be acceptable."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "crisp judgment")]
+    comment := "The same continuation with good is infelicitous — vague standards resist crisp cutoffs."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_24a : LinguisticExample :=
+  { id := "beltrama2025_24a"
+    source := ⟨"beltrama-2025", "(24a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The pizza scene in this town is truly desperate—you can't find even a decent one."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The pizza scene in this town is truly desperate—you can't find even a decent one."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "emphasis in DE"), ("parallel", "minimizers")]
+    comment := "With good or fantastic in place of decent the emphasis collapses."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26a : LinguisticExample :=
+  { id := "beltrama2025_26a"
+    source := ⟨"beltrama-2025", "(26a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Joe is very low maintenance when it comes to pizza. It takes just a decent one to make him happy."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Joe is very low maintenance when it comes to pizza. It takes just a decent one to make him happy."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "minimal sufficiency exclusive")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_39 : LinguisticExample :=
+  { id := "beltrama2025_39"
+    source := ⟨"beltrama-2025", "(39)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The pizza is slightly decent."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The pizza is slightly decent."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "slightly"), ("verdict", "against the MinSAA analysis")]
+    comment := "MinSAAs (slightly wet, slightly profitable) accept the modifier; MPAs reject it out of the blue."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_51b : LinguisticExample :=
+  { id := "beltrama2025_51b"
+    source := ⟨"beltrama-2025", "(51b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Pizza A is more decent than Pizza B, but neither is decent. In fact, they're both really bad."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Pizza A is more decent than Pizza B, but neither is decent. In fact, they're both really bad."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "comparative entailment"), ("verdict", "positive form not entailed")]
+    comment := "For MinSAAs the parallel construction contradicts — the MPA standard is more than nonzero value."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_70 : LinguisticExample :=
+  { id := "beltrama2025_70"
+    source := ⟨"beltrama-2025", "(70)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A: I heard that pizza sucks. B: Not at all. It's actually extremely decent!"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "A: I heard that pizza sucks. B: Not at all. It's actually extremely decent!"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("diagnostic", "strong intensifier rescued"), ("condition", "significance excluded from the QUD")]
+    comment := "When only the necessity standard is at issue, the intensifier clash with the middling flavor disappears."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1a, ex_3c, ex_4c, ex_5c, ex_8a, ex_11a, ex_12a, ex_15a, ex_21, ex_22a, ex_24a, ex_26a, ex_39, ex_51b, ex_70]
+
+end Beltrama2025.Examples

--- a/Linglib/Studies/Beltrama2025.lean
+++ b/Linglib/Studies/Beltrama2025.lean
@@ -2,41 +2,48 @@ import Linglib.Syntax.Category.Degree.Basic
 import Linglib.Semantics.Degree.Discrete
 import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Basic
-import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Intensification
 import Linglib.Fragments.English.Predicates.Adjectival
 import Linglib.Core.Order.Boundedness
+import Linglib.Data.Examples.Beltrama2025
 
 /-!
-# Beltrama 2025: Evaluation, thresholds, and practical commitments
+# Beltrama (2025): Evaluation, Thresholds, and Practical Commitments
 
-[beltrama-2025]
+Mildly positive adjectives (*decent*, *acceptable*, *adequate*) are a
+hybrid class: context-sensitive and gradable like relative adjectives,
+yet crisp, *barely*-friendly, and gapless like absolute ones (Table 1).
+Their positive form encodes a **necessity standard** — the minimum value
+an object must have for its pursuit to be circumstantially possible
+((64): `s(MPA) = Max({d : ∀w' ∈ Acc(w)[PURSUED(x)(w') → μ_value(x)(w') ≥
+d]})`) — a functional standard in [kagan-alexeyenko-2011]'s sense,
+paralleling *enough* as analyzed by [nadathur-2023]. The middling
+inference ("not great") is a cancelable scalar implicature, and
+[kennedy-2007]'s Interpretive Economy must be generalized to let the
+standard function assign functional standards.
 
-Beltrama, A. (2025). Evaluation, thresholds, and practical commitments:
-the grammar of adjectival mildness. *Natural Language Semantics* 33, 169--205.
+## Main statements
 
-## Core claims
+* `minsaa_hypothesis_rejected`: the four §4.2 diagnostics (slightly,
+  comparison classes, comparative entailments, denials) separate MPAs
+  from minimum-standard absolute adjectives point for point.
+* `necessityStandard` and `mpaPositiveForm`: the (64)–(65) semantics on
+  finite models; `ie_divergence_on_value_scale`: three standard types
+  coexist on one lower-bounded value scale (contextual *good*,
+  functional MPAs, minEndpoint MinSAAs), against unrevised Interpretive
+  Economy.
+* `mpa_entries_mildly_positive`, `mpa_not_endpoint_licensed`: the
+  Fragment entries carry the class as a standard override on an open
+  `.value` scale, not a scale-structure fact.
 
-1. **MPAs** (*decent*, *acceptable*, *adequate*) are a novel class of gradable
-   predicates with a hybrid profile overlapping both relative and absolute adjectives.
+## References
 
-2. MPAs encode a **necessity standard**: the minimum value required for an object's
-   pursuit to be possible given the norms and circumstances in the current world.
-   This is a *functional standard* (cf. [kagan-alexeyenko-2011]), not a
-   distributional (contextual) or endpoint standard.
-
-3. The **middling inference** ("not great") is a scalar implicature, not hardwired
-   semantics: it is cancelable, reinforceable, and suspended in DE contexts.
-
-4. The **standard function s** must be generalized beyond [kennedy-2007]'s
-   Principle of Interpretive Economy to handle functional standards.
-
-## Key formal definitions
-
-- `⟦MPA⟧ = λx. μ_value(x)` — basic entry (measure function returning value)
-- `s(MPA) = Max({d : ∀w' ∈ Acc(w)[PURSUED(x)(w') → μ_value(x)(w') ≥ d]})`
-  — necessity standard (functional)
-- `⟦POS MPA⟧ = λx. μ_value(x)(w) ≥ s(MPA)` — positive form
+* [beltrama-2025]: Evaluation, thresholds, and practical commitments:
+  The grammar of adjectival mildness. *Natural Language Semantics* 33.
+* [kennedy-2007]: Vagueness and grammar.
+* [nadathur-2023]: Actuality Inferences.
+* [kagan-alexeyenko-2011]: Degree modification in Russian morphology.
+* [wolfsdorf-2019]: On Goodness.
 -/
 
 namespace Beltrama2025
@@ -45,9 +52,7 @@ open Core.Order (Boundedness)
 open Degree (PositiveStandard interpretiveEconomy positiveMeaning)
 open Degree (AdjectiveClass)
 
--- ============================================================================
--- § 1. Empirical Profile (Table 1)
--- ============================================================================
+/-! ### Empirical Profile (Table 1) -/
 
 /-- Properties distinguishing MPAs from *good* (Table 1, p. 179).
 
@@ -100,9 +105,7 @@ theorem mpa_good_diverge :
     mpaProfile.emphasisInDE ≠ goodProfile.emphasisInDE := by
   exact ⟨by decide, by decide, by decide, by decide⟩
 
--- ============================================================================
--- § 2. Scale Structure
--- ============================================================================
+/-! ### Scale Structure -/
 
 /-- The value scale is lower-bounded at 0 (purpose-thwarting → purpose-serving),
     open above. Following [wolfsdorf-2019] and [qing-2021]. -/
@@ -115,9 +118,7 @@ def valueScaleBoundedness : Boundedness := .lowerBounded
 theorem ie_underpredicts_for_value_scale :
     interpretiveEconomy valueScaleBoundedness = .minEndpoint := rfl
 
--- ============================================================================
--- § 3. Standard Types: MPA vs Good vs MinSAA
--- ============================================================================
+/-! ### Standard Types: MPA vs Good vs MinSAA -/
 
 /-- *good* receives a contextual standard despite being on a lower-bounded
     scale — an exception to Interpretive Economy. The standard is determined
@@ -148,9 +149,7 @@ theorem mpa_good_both_cc_sensitive :
     goodStandard.RequiresComparisonClass ∧
     ¬ minsaaStandard.RequiresComparisonClass := ⟨trivial, trivial, id⟩
 
--- ============================================================================
--- § 4. MinSAA Rejection ([beltrama-2025] §4)
--- ============================================================================
+/-! ### MinSAA Rejection ([beltrama-2025] §4) -/
 
 /-- The MinSAA hypothesis: MPAs are minimum-standard absolute adjectives.
     This is initially plausible — lower-bounded scale, s(MPA) = 0 — but
@@ -183,9 +182,7 @@ def mpaActual : MinSAAHypothesis :=
 theorem minsaa_hypothesis_rejected :
     minsaaPredictions ≠ mpaActual := by decide
 
--- ============================================================================
--- § 5. Necessity Standard (Formal Definition)
--- ============================================================================
+/-! ### Necessity Standard (Formal Definition) -/
 
 /-- A simplified finite model for the necessity standard.
 
@@ -226,9 +223,7 @@ def necessityStandard {W : Type} (m : NecStandardModel W) : Nat :=
 def mpaPositiveForm {W : Type} (m : NecStandardModel W) (actualValue : Nat) : Bool :=
   actualValue ≥ necessityStandard m
 
--- ============================================================================
--- § 5. Degree Modifier Compatibility
--- ============================================================================
+/-! ### Degree Modifier Compatibility -/
 
 /-- Degree modifier compatibility data for MPAs.
 
@@ -266,9 +261,7 @@ theorem mpa_resists_strong_intensifiers :
     decentModifiers.veryExtremely = false ∧
     goodModifiers.veryExtremely = true := ⟨rfl, rfl⟩
 
--- ============================================================================
--- § 6. Fragment Entry Verification
--- ============================================================================
+/-! ### Fragment Entry Verification -/
 
 open English.Predicates.Adjectival (decent acceptable adequate good)
 
@@ -300,9 +293,7 @@ theorem good_same_scale_as_mpas :
 theorem good_vs_mpa_standard_override :
     goodStandard ≠ mpaStandard := by decide
 
--- ============================================================================
--- § 7. Middling Inference as Scalar Implicature
--- ============================================================================
+/-! ### Middling Inference as Scalar Implicature -/
 
 /-- The middling inference is a scalar implicature, not lexical semantics.
     Evidence: cancelability, reinforceability, suspension in DE contexts.
@@ -338,9 +329,7 @@ theorem decent_implicates_not_good :
 theorem good_no_middling_against_decent :
     middlingInference .good .decent = false := rfl
 
--- ============================================================================
--- § 8. Non-Vague Behavior: No Zone of Indifference
--- ============================================================================
+/-! ### Non-Vague Behavior: No Zone of Indifference -/
 
 /-- MPAs lack a zone of indifference ([beltrama-2025] §6.3, p. 199--200).
 
@@ -358,9 +347,7 @@ theorem mpa_no_indifference_zone :
     mpaProfile.zoneOfIndifference = false ∧
     goodProfile.zoneOfIndifference = true := ⟨rfl, rfl⟩
 
--- ============================================================================
--- § 9. Adjective Class: MPAs as a Novel Category
--- ============================================================================
+/-! ### Adjective Class: MPAs as a Novel Category -/
 
 /-- MPAs don't fit Kennedy's three-way classification. They share
     context-sensitivity with relative adjectives and crisp judgments
@@ -371,9 +358,7 @@ def decentClass : AdjectiveClass := .mildlyPositive
 theorem mpa_not_relative :
     ¬ decentClass.IsRelative := by decide
 
--- ============================================================================
--- § 10. Integration: Kennedy 2007 Licensing Pipeline
--- ============================================================================
+/-! ### Integration: Kennedy 2007 Licensing Pipeline -/
 
 open Core.Order (LicensingPipeline)
 /-- MPAs sit on the open `.value` scale, so [kennedy-2007]'s scale-structure
@@ -392,9 +377,7 @@ theorem mpa_not_endpoint_licensed :
 theorem good_not_endpoint_licensed :
     ¬ LicensingPipeline.IsLicensed good.scaleType := id
 
--- ============================================================================
--- § 11. Integration: Evaluative Valence
--- ============================================================================
+/-! ### Integration: Evaluative Valence -/
 
 open Features (EvaluativeValence)
 
@@ -411,14 +394,12 @@ def goodValence : EvaluativeValence := .positive
 theorem mpa_good_same_valence :
     mpaValence = goodValence := rfl
 
--- ============================================================================
--- § 12. Integration: Head.sufficiency (*enough* parallel)
--- ============================================================================
+/-! ### Integration: Head.sufficiency (*enough* parallel) -/
 
 open Degree (Head)
 
 /-- MPAs encode the same necessity component as *enough*
-    ([beltrama-2025] §5.3; Nadathur 2023): the minimum degree
+    ([beltrama-2025] §5.3; [nadathur-2023]): the minimum degree
     required for the complement/pursuit to be circumstantially possible.
 
     The parallel: "old enough to drink" ≈ "acceptable (for the purpose)".
@@ -427,9 +408,7 @@ open Degree (Head)
     MPAs get their purpose from context (action-guidance). -/
 def enoughParallel : Head := .sufficiency
 
--- ============================================================================
--- § 13. Integration: IE Divergence for Evaluative Predicates
--- ============================================================================
+/-! ### Integration: IE Divergence for Evaluative Predicates -/
 
 /-- Interpretive Economy maps lower-bounded → minEndpoint, but on the
     value scale THREE different standards coexist:


### PR DESCRIPTION
Paper audit (read in full): content verified faithful — (64)-(65), Table 1 p. 179, the four §4.2 anti-MinSAA diagnostics, p. 196 and §5.4/p. 195 locators all exact. Register pass: banners and bare-key header dropped, duplicate import deduped, raw Nadathur citations keyed, 15 example rows added.