### PR TITLE
refactor(Studies/BeaversZubair2013): resolve readings as denotations

### DIFF
--- a/Linglib/Fragments/Sinhala/Verbs.lean
+++ b/Linglib/Fragments/Sinhala/Verbs.lean
@@ -72,13 +72,9 @@ def gilann : SinhalaVerb :=
     involitiveForm := some "gilenn",
     causerSort := .any }
 
-/-- *marann* (vol) / *mærenn* (invol) 'kill/die'.
-
-    TODO: B&Z 2013 do not directly classify *marann* on the U/U_E
-    axis; it is included here by analogy with the other alternating
-    roots. Cross-linguistically *kill* often patterns with U_V
-    (effector OK, individual subject pragmatically marked) — see
-    [levin-hovav-1995] ch. 3 on *kill* vs. *murder*. -/
+/-- *marann* (vol) / *mærenn* (invol) 'kill/die'. Listed among the detransitivizing
+    ECOS roots ([beavers-zubair-2013] §3.2, exx. (14) and (17)): the causative admits
+    non-agentive causers, unlike *minimarann* 'murder'. -/
 def marann : SinhalaVerb :=
   { gloss := "kill",
     volitiveForm := "marann",

--- a/Linglib/Semantics/Causation/CauserSort.lean
+++ b/Linglib/Semantics/Causation/CauserSort.lean
@@ -149,6 +149,16 @@ abbrev admitsIndividual (s : CauserSort) : Prop := individual ≤ s
     involitive" ([beavers-zubair-2013] §8). -/
 abbrev admitsVolitive (s : CauserSort) : Prop := event ≤ s
 
+/-- Only `individual` and `any` admit the suppression operator's U_I requirement. -/
+theorem admitsIndividual_iff {s : CauserSort} :
+    admitsIndividual s ↔ s = individual ∨ s = any := by
+  cases s <;> decide
+
+/-- `individual` does not admit the volitive's event requirement: the suppression
+    operator's output subject can never be volitive — anticausatives are always
+    involitive ([beavers-zubair-2013] §8). -/
+theorem not_admitsVolitive_individual : ¬ admitsVolitive individual := by decide
+
 end CauserSort
 
 end Causation

--- a/Linglib/Studies/BeaversZubair2013.lean
+++ b/Linglib/Studies/BeaversZubair2013.lean
@@ -4,220 +4,153 @@ import Linglib.Features.Case.Basic
 import Linglib.Fragments.Sinhala.Verbs
 
 /-!
-# [beavers-zubair-2013] Anticausatives in Sinhala
+# Anticausatives in Sinhala
 
-Beavers, John and Cala Zubair. 2013. Anticausatives in Sinhala:
-involitivity and causer suppression. *Natural Language and Linguistic
-Theory* 31:1–46.
+Formalization of [beavers-zubair-2013] (NLLT 31). Colloquial Sinhala detransitivizes a
+causative root two ways, both formally inchoative: a nominative-subject anticausative
+with no external-causer entailment, and an accusative-subject one entailing a distinct
+external causer. One operation derives both — causer suppression ((77), p. 37), which
+deletes the causer syntactically, preserves CAUSE, and sortally restricts the suppressed
+variable to individuals (U_I) — the two subject cases reflecting reflexive vs.
+existential resolution of that variable ((78), p. 38). The U_I restriction is the
+predictive engine: roots selecting event-sort causers (*minimarann* 'murder', *kapann*
+'cut') fail the operator's well-formedness condition, so they do not anticausativize;
+and since the volitive ((71), p. 35) demands an event-sort subject while suppression
+outputs an individual, anticausatives are obligatorily involitive
+(`Causation.CauserSort.not_admitsVolitive_individual`).
 
-## Empirical core
+The operator is `ArgumentStructure.VoiceSemantics.causerSuppress`; the sort lattice is
+`Causation.CauserSort` ((81), p. 40); the verbs are `Fragments/Sinhala/Verbs`. §6
+rejects [koontz-garboden-2009]'s reflexivization-only analysis because the accusative
+variant's causer is not coidentified with the patient; §4.2 rejects deletion analyses
+([grimshaw-1982], [reinhart-2002], [haertl-2003], [bohnemeyer-2007]) on
+[koontz-garboden-2009]'s Monotonicity-Hypothesis argument and the *ibeem* 'by itself'
+facts. The accusative-as-semantic-case analysis follows [beavers-zubair-2010].
 
-Colloquial Sinhala has two ways to detransitivize a causative root,
-both formally inchoative (no syntactically active causer):
+## Main definitions
 
-- **Nominative subject**: pure anticausative, no entailed external
-  causer. *Nimal giluna* 'Nimal drowned'.
-- **Accusative subject**: still inchoative, but entails an external
-  causer (passive-like reading). *Nimal-wə giluna* 'Nimal was drowned
-  (by someone)'.
+* `Reading`, `Reading.resolve` — the two resolutions of the suppressed causer, as
+  denotations over `causerSuppress`.
+* `caseOfReading` — the §7.3 semantic-case convention: accusative signals existential
+  resolution.
+* `anticausativizes` — the operator's well-formedness condition, read off the verb's
+  `CauserSort`.
 
-The same root that supports both forms (*gilann/gilenn* 'drown')
-also has a volitive transitive (*Aruni Nimal-wə giluwa* 'Aruni
-drowned Nimal deliberately') and an involitive transitive (*Aruni
-atiŋ Nimal-wə giluna* 'Aruni accidentally drowned Nimal'). Roots
-that select for an event-sort causer (*minimarann* 'murder',
-*kapann* 'cut') have *no* involitive form and do not anticausativize.
+## Main results
 
-## Theoretical contribution
+* `causative_entails_existential`, `reflexive_entails_existential` — inchoatives are
+  true in agentive contexts ((51)), so the volitive ban is formal, not
+  truth-conditional (§5.3).
+* `ibeem_incompatible_with_external` — the 'by itself' diagnostic excludes the
+  accusative variant ((58)).
+* `drown_anticausativizes`, `murder_no_anticausative` — the U_I engine on the
+  fragment: the *murder*-class gap is a type-checking failure, not a stipulated
+  exception.
 
-The single mechanism — *causer suppression* — derives all four
-patterns. The operator (their ex. (77), p. 37) is:
+## References
 
-    ⟦+∅_CS⟧ = λPλyλe[P(y, x, e) ∧ x ∈ U_I]
-
-It (a) deletes the causer syntactically, (b) preserves CAUSE
-semantically, and (c) sortally restricts the suppressed causer to
-individuals (U_I). The free variable `x` must be bound externally,
-yielding two readings (their ex. (78), p. 38):
-
-- **Reflexive coindexation** with the patient `y` → nominative subject
-- **Existential closure** of `x` → accusative subject (passive-like)
-
-The U_I restriction is the predictive engine: roots whose causer
-sort is `event` or `eventuality` cannot anticausativize because
-the suppression operator's required sort is incompatible with the
-verb's selectional restriction. This blocks *minimarann* 'murder'
-and *kapann* 'cut' from anticausativizing — a structural
-type-checking failure rather than a stipulated lexical exception.
-
-The volitive stem (their ex. (71), p. 35) is itself a typed operator:
-`⟦+∅_vol⟧ = λP...λv ∈ U_E λe[P(...,v,e)]`. It requires the
-penultimate argument to resolve to an event. After causer
-suppression, the surviving subject is sortally `individual` — so
-the volitive cannot apply. This derives the cross-cutting fact
-that anticausativized roots are always involitive.
-
-## Engagement with sibling analyses
-
-B&Z 2013 §6 explicitly rejects [koontz-garboden-2009]'s
-reflexivization analysis on the grounds that it predicts the
-inchoative is true only when the causer is identified with the
-patient — but Sinhala's accusative-subject anticausative entails an
-external causer *distinct* from the patient (B&Z §7.3). Causer
-suppression admits this reading via existential closure of the
-suppressed variable; reflexivization cannot. The empirical content
-is captured by the `causerSuppress` operator (in `VoiceSemantics`)
-plus the U_I sortal restriction and the binding-mode disjunction in
-`Reading` below.
-
-B&Z 2013 also rejects deletion analyses ([krejci-2012],
-[bohnemeyer-2004], Grimshaw 1982) on Monotonicity-Hypothesis
-grounds: causer suppression preserves CAUSE in the LSR (the *ibeem*
-'by-itself' diagnostic licenses anticausatives, requiring CAUSE),
-while deletion does not. The `causerSuppress_eq_suppressArg`
-factor-through theorem in `VoiceSemantics` makes the
-truth-conditional content of the operator explicit.
-
-The natural next engagement target is [alexiadou-schaefer-2015]'s
-featural Voice typology, which B&Z 2013 contrast against (their fn
-around (71)).
+* [beavers-zubair-2013] — the paper; [beavers-zubair-2010] — the semantic-case and
+  involitive-meaning groundwork.
+* [koontz-garboden-2009], [chierchia-2004], [levin-hovav-1995] — the reflexivization
+  and existential-binding analyses the paper unifies.
+* [grimshaw-1982], [reinhart-2002], [haertl-2003], [bohnemeyer-2007] — deletion
+  analyses rejected in §4.2.
+* [inman-1993], [henadeerage-2002], [gair-paolillo-1997] — the Sinhala sources.
 -/
 
 namespace BeaversZubair2013
 
 open Causation
 open Sinhala.Verbs
+open ArgumentStructure.VoiceSemantics
+open Intensional
 
--- ════════════════════════════════════════════════════
--- § 1. The Causer Suppression Operator (ex. 77)
--- ════════════════════════════════════════════════════
+/-! ### The two resolutions of the suppressed causer -/
 
-/-- The two readings of an anticausativized verb (B&Z's ex. (78),
-    p. 38). Both have the patient as surface subject; they differ in
-    how the suppressed causer variable is bound. -/
+/-- The two readings of an anticausativized verb ((78), p. 38): the suppressed causer
+    is coindexed with the patient, or existentially closed. -/
 inductive Reading where
-  /-- (78a): the suppressed causer `x` is coindexed with the patient
-      `y` (formally bound by the same λ). Single argument is both
-      causer and patient. Nominative subject. -/
   | reflexive
-  /-- (78b): the suppressed causer `x` is existentially closed.
-      Causer is distinct from patient. Accusative subject (the
-      external causer is "marked" via case). -/
   | existential
   deriving DecidableEq, Repr
 
-/-- Case ↔ binding-mode bridge (B&Z 2013 §7.3): accusative case on
-    the surface subject of an anticausative *signals* that the
-    suppressed causer was bound existentially (not coindexed with
-    the patient). Re-uses `Case` (= `UD.Case`) — the canonical
-    cross-linguistic case type — rather than introducing a local
-    nom/acc enum.
+/-- A reading's denotation: `causerSuppress` leaves the causer as an open variable;
+    reflexive resolution binds it to the patient, existential resolution closes it.
+    The verb is causer-first (`vp x y`: causer `x`, patient `y`). -/
+def Reading.resolve {E W : Type} {s : CauserSort} (r : Reading)
+    (h : s.admitsIndividual) (vp : Denot E W (.e ⇒ .e ⇒ .t)) :
+    Denot E W (.e ⇒ .t) :=
+  match r with
+  | .reflexive   => fun y => causerSuppress s h y vp y
+  | .existential => fun y => ∃ x, causerSuppress s h x vp y
 
-    **Caveat (B&Z fn 27, fn 29)**: accusative case is animacy-conditioned
-    and *optional* on animates; it is rare-to-impossible on inanimate
-    patients. So existential binding can surface as nominative when
-    the patient is inanimate. The bidirectional reading below holds
-    only on animate patients with overt accusative; the broader
-    empirical picture requires an animacy parameter that we do not
-    formalize here. -/
+/-- Case ↔ resolution (§7.3): Sinhala accusative is a semantic case marking a patient
+    caused by a distinct external agent ([beavers-zubair-2010]), so it surfaces only
+    under existential resolution; nominative is the elsewhere case. Accusative is
+    animacy-conditioned and optional (fn. 27), so the converse is not stated. -/
 def caseOfReading : Reading → Case
   | .reflexive   => .nom
   | .existential => .acc
 
-/-- One direction (B&Z's strong claim): accusative on the surface
-    subject of an anticausative entails existential binding (i.e.,
-    a distinct external causer). The converse is animacy-conditioned
-    and is therefore not stated here. -/
-theorem accusative_implies_existential :
-    ∀ r : Reading, caseOfReading r = .acc → r = .existential := by
-  intro r; cases r <;> simp [caseOfReading]
+/-- Any causative claim entails the existentially-resolved inchoative: inchoatives are
+    true in agentive contexts ((51), §5.3), so the ban on volitive inchoatives must be
+    formal rather than truth-conditional. -/
+theorem causative_entails_existential {E W : Type} {s : CauserSort}
+    (h : s.admitsIndividual) (vp : Denot E W (.e ⇒ .e ⇒ .t)) (x y : E)
+    (hxy : vp x y) : Reading.existential.resolve h vp y :=
+  ⟨x, hxy⟩
 
-/-- The other strong direction: reflexive binding always surfaces
-    as nominative (no accusative-marked reflexive anticausatives). -/
-theorem reflexive_implies_nominative :
-    ∀ r : Reading, r = .reflexive → caseOfReading r = .nom := by
-  intro r h; subst h; rfl
+/-- The reflexive resolution entails the existential one: (78a) supplies the patient
+    itself as witness for (78b). -/
+theorem reflexive_entails_existential {E W : Type} {s : CauserSort}
+    (h : s.admitsIndividual) (vp : Denot E W (.e ⇒ .e ⇒ .t)) (y : E)
+    (hy : Reading.reflexive.resolve h vp y) : Reading.existential.resolve h vp y :=
+  ⟨y, hy⟩
 
--- ════════════════════════════════════════════════════
--- § 2. The Predictive Engine (ex. 77 + ex. 71)
--- ════════════════════════════════════════════════════
+/-- The *ibeem* 'by itself' diagnostic ((58)): no-external-causation contradicts the
+    accusative's distinct-external-causer requirement — accusative-subject
+    anticausatives reject *ibeem*; nominative ones accept it. -/
+theorem ibeem_incompatible_with_external {E : Type} (vp : E → E → Prop) (y : E) :
+    ¬ ((∀ x, vp x y → x = y) ∧ ∃ x, x ≠ y ∧ vp x y) :=
+  fun ⟨hno, _, hne, hvp⟩ => hne (hno _ hvp)
 
-/-- A verb anticausativizes iff its causer sort admits individuals.
-    This delegates to the canonical `CauserSort.admitsIndividual`
-    predicate, which is the type-level encoding of B&Z's
-    well-formedness constraint on the suppression operator (ex. 77).
+/-! ### The predictive engine -/
 
-    "Well-formedness" rather than "predicate over verbs" is the right
-    framing: the operator is *partial*, defined only when the verb's
-    causer sort is compatible with U_I. The blocking of
-    anticausativization on *murder*-type roots is therefore a
-    type-checking failure, not a stipulated exception. -/
+/-- A verb anticausativizes iff its causer sort admits individuals — the
+    well-formedness condition of the suppression operator ((77)). The operator is
+    partial: `CauserSort.admitsIndividual_iff` confines it to `individual` and `any`. -/
 def anticausativizes (v : SinhalaVerb) : Prop :=
   v.causerSort.admitsIndividual
 
 instance (v : SinhalaVerb) : Decidable (anticausativizes v) :=
   inferInstanceAs (Decidable v.causerSort.admitsIndividual)
 
-/-- *kadann* 'break' anticausativizes (causer sort = `any`). -/
+/-- *kadann* 'break' anticausativizes (causer sort `any`, (76)). -/
 theorem break_anticausativizes : anticausativizes kadann := by decide
 
-/-- *gilann* 'drown' anticausativizes (the canonical example). -/
+/-- *gilann* 'drown' anticausativizes (exx. (2)–(3)). -/
 theorem drown_anticausativizes : anticausativizes gilann := by decide
 
-/-- *minimarann* 'murder' does NOT anticausativize. The U_E causer
-    sort is incompatible with U_I — a structural type-checking
-    failure of the suppression operator, not a stipulated lexical
-    exception. -/
+/-- *minimarann* 'murder' does not anticausativize: its event-sort causer ((65b)) is
+    incompatible with U_I, so `causerSuppress` cannot even be instantiated at this
+    verb. -/
 theorem murder_no_anticausative : ¬ anticausativizes minimarann := by decide
 
-/-- *kapann* 'cut' does NOT anticausativize, for the same reason. -/
+/-- *kapann* 'cut' patterns with *minimarann*. -/
 theorem cut_no_anticausative : ¬ anticausativizes kapann := by decide
 
-/-- The volitive operator (B&Z's ex. (71)) admits a verb iff its
-    causer sort includes events. The generic predicate
-    `CauserSort.admitsVolitive` and the lattice-level theorem
-    `not_admitsVolitive_individual` ("anticausatives are always
-    involitive", B&Z §8) live in `Semantics/Causation/CauserSort.lean`;
-    here we just verify the predictions for the Sinhala fragment. -/
-theorem volitive_admitted_for_murder :
-    CauserSort.admitsVolitive minimarann.causerSort := by decide
+/-- The volitive ((71)) admits both *minimarann* and *kadann* — their causer sorts
+    include events. After suppression the surviving subject is an individual, which
+    `CauserSort.not_admitsVolitive_individual` bars from the volitive: anticausatives
+    are always involitive (§8). -/
+theorem volitive_admitted :
+    CauserSort.admitsVolitive minimarann.causerSort ∧
+      CauserSort.admitsVolitive kadann.causerSort := by
+  decide
 
-theorem volitive_admitted_for_break :
-    CauserSort.admitsVolitive kadann.causerSort := by decide
-
--- ════════════════════════════════════════════════════
--- § 3. Operator-Level Type-Checking (the predictive engine)
--- ════════════════════════════════════════════════════
-
-/-! The `anticausativizes` predicate above is the type
-    checker's view of B&Z's prediction. The semantic operator that
-    actually does the work — `causerSuppress` from
-    `Semantics/ArgumentStructure/VoiceSemantics.lean` — takes
-    a `CauserSort` and a *proof* that it admits individuals as a
-    parameter. The proof obligation IS the predictive engine: a verb
-    that does not anticausativize cannot have its operator
-    instantiated.
-
-    The theorems below demonstrate this at the operator level: for
-    *kadann* 'break' the operator instantiates with a `decide`-discharged
-    obligation; for *minimarann* 'murder' no such proof exists. -/
-
-open ArgumentStructure.VoiceSemantics
-
-/-- The Sinhala suppression operator can be instantiated for *kadann*
-    'break' because its causer sort `.any` admits individuals. The
-    obligation is discharged by `decide` over the lattice. -/
-example {E W : Type} (z : E)
-    (vp : Intensional.Denot E W (.e ⇒ .t)) :
-    Intensional.Denot E W .t :=
+/-- The operator instantiates for *kadann*: the `decide`-discharged obligation is the
+    predictive engine at work. -/
+example {E W : Type} (z : E) (vp : Denot E W (.e ⇒ .t)) : Denot E W .t :=
   causerSuppress kadann.causerSort (by decide) z vp
-
-/-- For *minimarann* 'murder' the obligation `causerSort.admitsIndividual`
-    *cannot* be discharged — the lattice fact `¬ admitsIndividual .event`
-    blocks the operator at the type-checking level, not by a runtime
-    exception. This is the formal content of "anticausativization is a
-    structural type-checking failure". -/
-theorem murder_cannot_instantiate_operator :
-    ¬ minimarann.causerSort.admitsIndividual := by decide
 
 end BeaversZubair2013

--- a/references.bib
+++ b/references.bib
@@ -22,6 +22,19 @@
 % ══════════════════════════════════════════════════════════════════════════════
 %  pragmatics/rsa
 
+@incollection{beavers-zubair-2010,
+  author    = {Beavers, John and Zubair, Cala},
+  year      = {2010},
+  title     = {The Interaction of Transitivity Features in the {Sinhala} Involitive},
+  booktitle = {Transitivity: Form, Meaning, Acquisition, and Processing},
+  editor    = {Brandt, Patrick and Garc{\'i}a, Marco},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  pages     = {69--92},
+  subfield  = {syntax/argument-structure},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
 @article{benz-stevens-2018,
   author    = {Benz, Anton and Stevens, Jon},
   year      = {2018},
@@ -36,6 +49,72 @@
   sources   = {Pragmatics/SignalingGame/Basic.lean}
 }
 
+@article{bohnemeyer-2007,
+  author    = {Bohnemeyer, J{\"u}rgen},
+  year      = {2007},
+  title     = {Morpholexical Transparency and the Argument Structure of Verbs of Cutting and Breaking},
+  journal   = {Cognitive Linguistics},
+  volume    = {18},
+  pages     = {153--177},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
+@incollection{grimshaw-1982,
+  author    = {Grimshaw, Jane},
+  year      = {1982},
+  title     = {On the Lexical Representation of {Romance} Reflexive Clitics},
+  booktitle = {The Mental Representation of Grammatical Relations},
+  editor    = {Bresnan, Joan},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  pages     = {87--148},
+  subfield  = {syntax/argument-structure},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
+@article{haertl-2003,
+  author    = {H{\"a}rtl, Holden},
+  year      = {2003},
+  title     = {Conceptual and Grammatical Characteristics of Argument Alternations: The Case of Decausative Verbs},
+  journal   = {Linguistics},
+  volume    = {41},
+  pages     = {883--916},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
+@phdthesis{henadeerage-2002,
+  author    = {Henadeerage, Deepthi Kumara},
+  year      = {2002},
+  title     = {Topics in {Sinhala} Syntax},
+  school    = {The Australian National University},
+  address   = {Canberra},
+  subfield  = {syntax/descriptive},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
+@phdthesis{inman-1993,
+  author    = {Inman, Michael Vincent},
+  year      = {1993},
+  title     = {Semantics and Pragmatics of Colloquial {Sinhala} Involitive Verbs},
+  school    = {Stanford University},
+  address   = {Stanford, CA},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
+@article{reinhart-2002,
+  author    = {Reinhart, Tanya},
+  year      = {2002},
+  title     = {The Theta System --- An Overview},
+  journal   = {Theoretical Linguistics},
+  volume    = {28},
+  pages     = {229--290},
+  subfield  = {syntax/argument-structure},
+  role      = {cited},
+  sources   = {Studies/BeaversZubair2013.lean}
+}
 @inproceedings{spinoso-di-piano-etal-2025,
   author    = {Spinoso-Di Piano, Cesare and Austin, David Eric and Piantanida, Pablo and Cheung, Jackie Chi Kit},
   year      = {2025},

--- a/references.bib
+++ b/references.bib
@@ -60,6 +60,16 @@
   role      = {cited},
   sources   = {Studies/BeaversZubair2013.lean}
 }
+@book{gair-paolillo-1997,
+  author    = {Gair, James W. and Paolillo, John C.},
+  year      = {1997},
+  title     = {Sinhala},
+  publisher = {Lincom Europa},
+  address   = {M{\"u}nchen},
+  subfield  = {syntax/descriptive},
+  role      = {cited},
+  sources   = {Fragments/Sinhala/Verbs.lean;Studies/BeaversZubair2013.lean}
+}
 @incollection{grimshaw-1982,
   author    = {Grimshaw, Jane},
   year      = {1982},


### PR DESCRIPTION
Deep cleanse (paper read in full). Reading.resolve gives the two (78) resolutions as denotations over causerSuppress, with causative_entails_existential / reflexive_entails_existential (the section 5.3 truth-compatibility point) and the ibeem diagnostic; the two 2-case theorems unpacking caseOfReading and the duplicate operator-blocking theorem are deleted. Header fixes: fabricated [krejci-2012] attribution, Bohnemeyer year (2007, not 2004), forward-cite of Alexiadou-Schaefer 2015 removed; CauserSort gains the not_admitsVolitive_individual and admitsIndividual_iff lemmas the docstrings claimed existed; fragment marann TODO grounded in the section 3.2 ECOS list; 7 verified bib entries.