### PR TITLE
refactor(Studies/Berent2026): derive the sonority cline; fix exp numbers

### DIFF
--- a/Linglib/Phonology/Constraints/Basic.lean
+++ b/Linglib/Phonology/Constraints/Basic.lean
@@ -48,6 +48,15 @@ def mkForbidSingletonOnTier {C α β : Type*} (P : β → Prop) [DecidablePred P
 def adjacentIdentical {α : Type*} [DecidableEq α] : List α → Nat :=
   countAdjacent (· = ·)
 
+theorem adjacentIdentical_cons_self {α : Type*} [DecidableEq α] (a : α) (rest : List α) :
+    adjacentIdentical (a :: a :: rest) = 1 + adjacentIdentical (a :: rest) := by
+  simp [adjacentIdentical, countAdjacent]
+
+theorem adjacentIdentical_cons_of_ne {α : Type*} [DecidableEq α] {a b : α}
+    (h : a ≠ b) (rest : List α) :
+    adjacentIdentical (a :: b :: rest) = adjacentIdentical (b :: rest) := by
+  simp [adjacentIdentical, countAdjacent, h]
+
 /-- An OCP constraint ([mccarthy-1986]): penalizes adjacent identical elements on
 the tier extracted by `project`. Polymorphic over the feature type ([berent-2026]). -/
 def mkOCP {C α : Type*} [DecidableEq α] (project : C → List α) : Constraint C :=

--- a/Linglib/Phonology/OptimalityTheory/Doubling.lean
+++ b/Linglib/Phonology/OptimalityTheory/Doubling.lean
@@ -36,9 +36,6 @@ The `realizeMorphAvailable` predicate encodes both transfer directions:
 REALIZE-MORPH is active for function *f* when (i) the L1 marks *f*
 morphologically AND (ii) the L1 has no negative evidence (does not use
 reduplication for other functions while excluding *f*).
-
-[berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016]
-[berent-2026]
 -/
 
 namespace OptimalityTheory.Doubling
@@ -56,8 +53,11 @@ open OptimalityTheory
     categories. The availability of the reduplication parse for a given
     semantic context depends on the speaker's L1 morphology. -/
 inductive DoublingFunction where
-  | plurality     -- e.g., Indonesian rumah-rumah 'houses'
-  | diminutive    -- e.g., Hebrew seleg -> slaglag 'puppy'
+  /-- E.g. Ilocano *púsa* → *puspúsa* 'cats' ([berent-2026]). -/
+  | plurality
+  /-- E.g. Hebrew *kelev* → *klavlav* 'dog → puppy'
+      ([berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016]). -/
+  | diminutive
   deriving DecidableEq, Repr
 
 /-- Complete enumeration of `DoublingFunction` constructors.

--- a/Linglib/Studies/Berent2026.lean
+++ b/Linglib/Studies/Berent2026.lean
@@ -5,51 +5,48 @@ import Linglib.Phonology.OptimalityTheory.Doubling
 import Linglib.Phonology.OptimalityTheory.TableauSystem
 
 /-!
-# Berent (2026) [berent-2026]
+# Three arguments for abstraction in phonology
 
-Three arguments for abstraction in phonology.
-*Glossa: a journal of general linguistics* 12(1). 1--24.
+Formalization of [berent-2026] (Glossa 12). Three experimental arguments that phonological
+grammar is substance-free: it is *abstract* — the sonority-cline preference on onsets
+(Figure 1, data from [berent-steriade-lennertz-vaknin-2007]) survives print presentation
+and articulatory suppression, engaging Broca's area rather than motor cortex (§3.1);
+*algebraic* — identity restrictions generalize to feature values unattested in the
+speaker's language, Hebrew /θ/ and novel ASL handshapes (§3.2); and *amodal* — English
+speakers project their spoken-language doubling constraints onto novel ASL signs, banning
+identity in phonological contexts and preferring reduplication in morphological ones
+(§3.3).
 
-Three experimental arguments that phonological grammar is substance-free,
-algebraic, and amodal:
+The three properties are carried by the substrate's types rather than restated:
+abstractness is rank-invariance of the markedness function over the featureless `Sonority`
+order; algebraicity is the parametric polymorphism of `mkOCP` (the constraint cannot
+inspect what it compares); amodality is the same polymorphic constraint applying to any
+feature type by construction, with the phonology–morphology reversal in
+`OptimalityTheory.Doubling` and its experimental 2×2 in `Studies/BerentEtAl2016.lean`.
 
-1. **Abstract**: syllable structure constraints (sonority sequencing) persist
-   under articulatory suppression (TMS, mechanical) and in print reading,
-   engaging Broca's area rather than motor cortex. Formalized as gradient
-   markedness over the abstract `Sonority` type — the grammar sees only
-   the ordering, not the articulatory features that correlate with it.
+## Main definitions
 
-2. **Algebraic**: identity restrictions (*XX ban, OCP) generalize to novel
-   feature values unattested in the speaker's language (Hebrew /θ/, novel
-   ASL handshapes). Formalized as the type-polymorphic `mkOCP` constraint —
-   Lean's parametric polymorphism IS the algebraic property.
+* `onsetProfile`, `onsetMarkedness` — the rise/plateau/fall classification and the
+  sonority-distance markedness of a two-consonant onset, on the abstract `Sonority` type.
 
-3. **Amodal**: English speakers project spoken-language doubling constraints
-   onto novel ASL signs, with a phonology--morphology split (identity banned
-   in phonological contexts, reduplication preferred in morphological
-   contexts). Formalized as competing OT parses over `DoublingParse`
-   (see `Phonology/Doubling.lean`).
+## Main results
 
-## Formalization strategy
+* `sonority_cline` — blif ≺ bnif ≺ bdif ≺ lbif: the four-point behavioral cline of
+  Figure 1A derived from rank distance; a three-way profile alone cannot separate blif
+  from bnif.
+* `onsetMarkedness_rank_invariant`, `markedness_vs_profile` — markedness sees only the
+  sonority ordering (substance-freeness), and refines the three-way profile.
+* `amodal_doubling_reversal`, `phonSystem_predict_nonidentical`,
+  `morphSystem_predict_reduplication` — Argument 3's reversal, from the substrate, lifted
+  to probability-1 `ConstraintSystem` predictions.
 
-The paper's central claims are metatheoretical — they argue about the
-*nature* of phonological representations rather than proposing new formal
-machinery. The deepest formalization insight is that Lean's type system
-already embodies the distinctions Berent draws:
+## References
 
-- **Substance-free** = `Sonority` is an abstract ordered type, not
-  defined by articulatory features (refactored in `Syllable.lean`)
-- **Algebraic** = `mkOCP` is parametrically polymorphic over `α`
-  (added to `Constraints.lean`)
-- **Amodal** = the same polymorphic constraint applies to any feature
-  type, spoken or signed, by construction
-
-The doubling theory (types, constraints, L1-parameterized model) is
-factored into `Phonology/Doubling.lean`. The experimental
-data supporting the doubling reversal is in
-[berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016].
-
-[berent-2026]
+* [berent-2026] — the paper.
+* [berent-steriade-lennertz-vaknin-2007] — the onset-cline data (Figure 1A).
+* [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016] — the doubling 2×2, formalized in
+  `Studies/BerentEtAl2016.lean`.
+* [mccarthy-1986] — the OCP.
 -/
 
 open Phonology (Sonority)
@@ -58,115 +55,72 @@ open OptimalityTheory.Doubling
 
 namespace Berent2026
 
-open Core.Optimization Constraints OptimalityTheory Subregular
+open Core.Optimization Constraints OptimalityTheory
 
--- ============================================================================
--- § 1: Onset Markedness — the sonority gradient
--- ============================================================================
+/-! ### Onset markedness: the sonority cline -/
 
-/-- Onset sonority profile: the relationship between C1 and C2 sonority
-    in a two-segment onset.
-
-    The behavioral gradient rise > plateau > fall ([berent-2026],
-    Figure 1A; data from Berent et al. 2007) maps directly to this
-    classification on the abstract `Sonority` type. -/
+/-- Onset sonority profile: the relation between C1 and C2 sonority in a two-consonant
+    onset, on the abstract `Sonority` order. -/
 inductive OnsetProfile where
-  | rise     -- C1 < C2: e.g. /bl/, /pr/ — least marked
-  | plateau  -- C1 = C2: e.g. /bd/ — intermediate
-  | fall     -- C1 > C2: e.g. /lb/, /nb/ — most marked
+  | rise
+  | plateau
+  | fall
   deriving DecidableEq, Repr
 
-/-- Classify a two-segment onset by its sonority profile.
-    Operates on `Sonority` — the abstract hierarchy — not on
-    articulatory features. -/
+/-- Classify a two-consonant onset by its sonority profile. -/
 def onsetProfile (c1 c2 : Sonority) : OnsetProfile :=
   if c1.rank < c2.rank then .rise
   else if c1.rank == c2.rank then .plateau
   else .fall
 
-/-- Onset markedness as an OT constraint: gradient violations by sonority
-    profile. A bare gradient `Constraint OnsetProfile` (a violation-counting
-    function `OnsetProfile → ℕ`).
+/-- Onset markedness from sonority distance: the smaller the rise, the worse (§3.1 —
+    large rises over small rises over plateaus over falls). The pad `5` (the top rank)
+    keeps ℕ-subtraction total; only the ordering of the values matters. -/
+def onsetMarkedness : Constraint (Sonority × Sonority) :=
+  fun (c1, c2) => 5 + c1.rank - c2.rank
 
-    Rise = 0 violations, plateau = 1, fall = 2. This captures the
-    behavioral gradient (blif > bnif > bdif > lbif; [berent-2026],
-    data from Berent et al. 2007). The gradient is determined entirely
-    by the abstract `Sonority` ordering — the grammar does not inspect
-    whether "rise" means "stop-before-liquid" vs. "nasal-before-vowel". -/
-def onsetSSP : Constraint OnsetProfile :=
-  fun
-    | .rise => 0
-    | .plateau => 1
-    | .fall => 2
-
-/-- Gradient markedness of onset sonority profiles (convenience alias). -/
-abbrev onsetMarkedness := onsetSSP
-
-theorem rise_lt_plateau : onsetMarkedness .rise < onsetMarkedness .plateau := by
+/-- The four-point behavioral cline ([berent-2026] Figure 1A, data from
+    [berent-steriade-lennertz-vaknin-2007]): blif ≺ bnif ≺ bdif ≺ lbif — stop+liquid ≺
+    stop+nasal ≺ stop+stop ≺ liquid+stop — derived from rank distance on the abstract
+    type. -/
+theorem sonority_cline :
+    onsetMarkedness (.stop, .liquid) < onsetMarkedness (.stop, .nasal) ∧
+      onsetMarkedness (.stop, .nasal) < onsetMarkedness (.stop, .stop) ∧
+        onsetMarkedness (.stop, .stop) < onsetMarkedness (.liquid, .stop) := by
   decide
 
-theorem plateau_lt_fall : onsetMarkedness .plateau < onsetMarkedness .fall := by
-  decide
+/-- Substance-freeness as invariance: markedness depends only on the sonority ranks —
+    onsets whose segments match in rank are treated identically, whatever their
+    articulatory realization. -/
+theorem onsetMarkedness_rank_invariant (c1 c2 d1 d2 : Sonority)
+    (h1 : c1.rank = d1.rank) (h2 : c2.rank = d2.rank) :
+    onsetMarkedness (c1, c2) = onsetMarkedness (d1, d2) := by
+  simp [onsetMarkedness, h1, h2]
 
-theorem rise_unmarked : onsetMarkedness .rise = 0 := rfl
+/-- The distance markedness refines the three-way profile: below `5` is a rise, `5` a
+    plateau, above `5` a fall. -/
+theorem markedness_vs_profile (c1 c2 : Sonority) :
+    (onsetMarkedness (c1, c2) < 5 ↔ onsetProfile c1 c2 = .rise) ∧
+      (onsetMarkedness (c1, c2) = 5 ↔ onsetProfile c1 c2 = .plateau) ∧
+        (5 < onsetMarkedness (c1, c2) ↔ onsetProfile c1 c2 = .fall) := by
+  cases c1 <;> cases c2 <;> decide
 
-/-- The sonority gradient is determined by abstract rank, not by features.
-    Two segments with the same `Sonority` are treated identically
-    regardless of their articulatory specification. -/
-theorem sonority_gradient_abstract (r1 r2 : Sonority) :
-    onsetMarkedness (onsetProfile r1 r2) =
-    if r1.rank < r2.rank then 0
-    else if r1.rank == r2.rank then 1
-    else 2 := by
-  cases r1 <;> cases r2 <;> rfl
+/-! ### Algebraic OCP (Argument 2)
 
--- ============================================================================
--- § 2: Algebraic OCP — identity avoidance
--- ============================================================================
+`mkOCP` and `adjacentIdentical` (`Phonology/Constraints/Basic.lean`) are parametrically
+polymorphic over the feature type: the constraint cannot inspect what kind of features it
+compares, only whether they are identical. That parametricity is Argument 2's
+algebraicity — the OCP extends to Hebrew /θ/ and to unattested ASL handshapes by
+construction (§3.2). The recursion lemmas `adjacentIdentical_cons_self` and
+`adjacentIdentical_cons_of_ne` live with the definition. -/
 
--- `adjacentIdentical` and `mkOCP` are defined in Constraints.lean and
--- are parametrically polymorphic over the feature type α. That
--- polymorphism IS the algebraic property: the OCP generalizes to novel
--- feature values by construction, because it cannot inspect what kind
--- of features it compares — only whether they are identical.
+/-! ### The doubling reversal (Argument 3) -/
 
-/-- OCP detects adjacent identity. -/
-theorem ocp_detects_aa {α : Type} [DecidableEq α]
-    (a : α) (rest : List α) :
-    adjacentIdentical (a :: a :: rest) =
-    1 + adjacentIdentical (a :: rest) := by
-  simp [adjacentIdentical, countAdjacent]
-
-/-- OCP passes over non-identical adjacency. -/
-theorem ocp_passes_ab {α : Type} [DecidableEq α] (a b : α) (rest : List α)
-    (h : a ≠ b) :
-    adjacentIdentical (a :: b :: rest) =
-    adjacentIdentical (b :: rest) := by
-  simp [adjacentIdentical, countAdjacent, h]
-
--- ============================================================================
--- § 3: The doubling reversal — summary
--- ============================================================================
-
--- The doubling theory (DoublingParse, DoublingGrammar, OT constraints)
--- is defined in Phonology/Doubling.lean. The experimental
--- evidence for the doubling reversal and the L1-morphology dependency
--- is formalized in BerentEtAl2016.lean, which provides the 2×2
--- dissociation between English and Hebrew speakers.
---
--- Here we re-export the core reversal theorem as a summary of the
--- paper's Argument 3 (amodality).
-
-/-- The phonology--morphology reversal: the same OCP-XX produces
-    opposite surface preferences depending on whether the morphological
-    context licenses reduplication.
-
-    This is the core of [berent-2026]'s third argument: the
-    reversal is amodal (it transfers from speech to sign) and
-    L1-dependent (it depends on the speaker's morphological system).
-    See `OptimalityTheory.Doubling.doubling_reversal` for the proof
-    and [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016] for
-    the experimental evidence. -/
+/-- The phonology–morphology reversal: the same identity ban yields opposite surface
+    preferences depending on whether the morphological context licenses reduplication —
+    amodal (it transfers from speech to sign) and L1-dependent. The proof is
+    `OptimalityTheory.Doubling.doubling_reversal`; the experimental 2×2 is
+    [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016]. -/
 theorem amodal_doubling_reversal :
     (Tableau.ofRanking phonCandidates phonRanking).optimal
       = {DoublingParse.nonidentical} ∧
@@ -174,15 +128,11 @@ theorem amodal_doubling_reversal :
       = {DoublingParse.reduplication} :=
   doubling_reversal
 
--- ============================================================================
--- § 4: Generic ConstraintSystem Predictions
--- ============================================================================
+/-! ### Probability-1 predictions
 
-/-! Both doubling tableaux lift to generic `ConstraintSystem`s via
-`tableauSystem`. The phonology--morphology reversal then becomes a
-probability-1 reversal: the same OCP-XX assigns probability 1 to
-`.nonidentical` in phonological contexts and to `.reduplication` in
-morphological contexts. -/
+Both doubling tableaux lift to generic `ConstraintSystem`s via `tableauSystem`: the same
+identity ban assigns probability 1 to `.nonidentical` in phonological contexts and to
+`.reduplication` in morphological ones. -/
 
 section PredictAPI
 open Core.Optimization Constraints
@@ -200,8 +150,8 @@ theorem phonSystem_predict_nonidentical :
 noncomputable def morphSystem : ConstraintSystem DoublingParse (LexProfile Nat 3) :=
   tableauSystem (Tableau.ofRanking morphCandidates morphRanking)
 
-/-- In morphological contexts where reduplication is available,
-    `.reduplication` has probability 1. -/
+/-- In morphological contexts where reduplication is available, `.reduplication` has
+    probability 1. -/
 theorem morphSystem_predict_reduplication :
     morphSystem.predict DoublingParse.reduplication = 1 :=
   tableauSystem_predict_unique_winner _ _ morph_prefers_reduplication

--- a/Linglib/Studies/BerentEtAl2016.lean
+++ b/Linglib/Studies/BerentEtAl2016.lean
@@ -1,51 +1,40 @@
 import Linglib.Phonology.OptimalityTheory.Doubling
 
 /-!
-# Berent, Bat-El, Brentari, Dupuis & Vaknin-Nusbaum (2016) [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016]
+# The double identity of linguistic doubling
 
-The double identity of linguistic doubling.
-*Proceedings of the National Academy of Sciences* 113(48). 13702--13707.
+Formalization of [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016] (PNAS 113). Twelve
+experiments show that the parse of a doubled form XX — banned phonological identity vs.
+preferred morphological reduplication — depends on morphological context and on the
+speaker's L1. With novel English words, doubling is disliked in isolation (experiment 1)
+and preferred once linked to plural meaning over homogeneous object sets (experiments 2,
+4b, 8b); sign-naïve English speakers project the same shift onto novel ASL signs
+(aversion in experiment 5, preference in 6a). The cross-linguistic 2×2 (Table 1,
+experiments 6a and 10a–12a): English speakers prefer XX signs as plurals (6a) but not as
+diminutives (12a); Hebrew speakers show no plural preference (10a — negative transfer:
+Hebrew reduplication marks diminution, never plurality) but favor XX diminutives (11a),
+with a reliable Language × Meaning interaction.
 
-Twelve experiments demonstrating that the interpretation of doubled forms
-(XX) depends on (i) morphological context and (ii) the speaker's L1
-morphological system. The key finding is a 2x2 cross-linguistic
-dissociation between English and Hebrew speakers:
+The OT predictions are categorical and capture the direction of each cell, not the
+gradient magnitudes. The framework (`DoublingParse`, `DoublingGrammar`,
+`realizeMorphAvailable`) lives in `Phonology/OptimalityTheory/Doubling.lean`; this file
+instantiates the two L1 grammars and proves the four cells.
 
-|              | English (no productive redup) | Hebrew (redup for diminutives) |
-|--------------|------------------------------|-------------------------------|
-| **Plurality**  | Prefer XX (Exps 2, 4a, 8a)   | Weak/no XX pref (Exp 10a)     |
-| **Diminutive** | No XX preference (Exp 12)    | Prefer XX (Exp 11a)           |
+## Main definitions
 
-## Gradient vs. categorical
+* `englishGrammar`, `hebrewGrammar` — the two L1 `DoublingGrammar`s.
 
-The experimental data are gradient: participants show *stronger* or *weaker*
-XX preferences across conditions, measured by rating differences and
-reaction times. The OT model here gives categorical predictions
-(reduplication wins or XY wins). The categorical predictions capture the
-*direction* of the preference in each cell — which condition shows an XX
-advantage — not the continuous magnitude of the effect.
+## Main results
 
-## Mechanism: positive and negative transfer
+* `english_plurality_available`, `english_diminutive_unavailable`,
+  `hebrew_plurality_unavailable`, `hebrew_diminutive_available` — REALIZE-MORPH
+  availability from positive and negative transfer.
+* `doubling_dissociation` — the 2×2: reduplication wins exactly where the L1 licenses it.
 
-- **Positive transfer**: if the L1 expresses function *f* morphologically,
-  the speaker can interpret XX as morphological reduplication for *f*,
-  yielding a doubling preference (XX > XY).
+## References
 
-- **Negative transfer**: if the L1 uses reduplication for *other* functions
-  but specifically NOT for *f*, the speaker has positive evidence that
-  reduplication != *f*. This blocks the reduplication interpretation for *f*,
-  even if *f* is morphologically marked by other means (e.g., Hebrew marks
-  plurality by suffixation, not reduplication — so Hebrew speakers do not
-  interpret XX as plural reduplication).
-
-## Formalization
-
-The doubling framework (`DoublingParse`, `DoublingGrammar`,
-`realizeMorphAvailable`) is defined in `Phonology/Doubling.lean`.
-This file defines L1-specific `DoublingGrammar` instances for English and
-Hebrew and proves the four cells of the dissociation table as OT theorems.
-
-[berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016]
+* [berent-bat-el-brentari-dupuis-vaknin-nusbaum-2016] — the paper.
+* [berent-2026] — Argument 3 of the synthesis builds on this dissociation.
 -/
 
 open OptimalityTheory.Doubling
@@ -58,22 +47,18 @@ open Constraints OptimalityTheory
 -- § 1: L1 Morphological Grammars
 -- ============================================================================
 
-/-- English morphological knowledge relevant to doubling.
-
-    English marks plurality morphologically (dog-s) but does not have
-    productive reduplication for any function, and does not have
-    productive diminutive morphology (booklet, doggy are semi-productive
-    at best). -/
+/-- English morphological knowledge relevant to doubling: plurality is marked
+    morphologically (dog-s), but there is no productive reduplication for any function
+    and no productive diminutive morphology (booklet, piglet are attested; -let is not
+    productive). -/
 def englishGrammar : DoublingGrammar :=
   { morphFor := fun | .plurality => true | .diminutive => false
     redupFor := fun | .plurality => false | .diminutive => false }
 
-/-- Hebrew morphological knowledge relevant to doubling.
-
-    Hebrew marks both plurality (sefer -> sfarim 'book -> books') and
-    diminutives morphologically. Crucially, Hebrew uses reduplication
-    specifically for diminutives (seleg -> slaglag 'snow -> puppy')
-    but NOT for plurality (which uses suffixation). -/
+/-- Hebrew morphological knowledge relevant to doubling: both plurality (*shir* →
+    *shirim* 'song → songs') and diminutives are marked morphologically, and
+    reduplication is used specifically for diminutives (*kelev* → *klavlav*
+    'dog → puppy') but never for plurality, which uses suffixation. -/
 def hebrewGrammar : DoublingGrammar :=
   { morphFor := fun | .plurality => true | .diminutive => true
     redupFor := fun | .plurality => false | .diminutive => true }
@@ -118,11 +103,10 @@ theorem hebrew_diminutive_available :
     ranking applies and reduplication wins. When unavailable, the
     phonological ranking applies and XY (nonidentical) wins. -/
 
-/-- English + plurality: reduplication wins (Exps 2, 4a, 8a).
-    English speakers show a gradient XX preference (higher ratings,
-    faster RTs) when signs are paired with homogeneous object sets
-    in a plurality context. The categorical prediction captures the
-    direction of this gradient effect. -/
+/-- English + plurality: reduplication wins (experiment 6a; with spoken words,
+    experiments 2, 4b, 8b). English speakers prefer XX when paired with homogeneous
+    object sets in a plurality context; the heterogeneous controls (4a, 6b, 8a) show no
+    preference or an aversion. -/
 theorem english_plurality_prefers_XX :
     (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .plurality)
@@ -130,11 +114,8 @@ theorem english_plurality_prefers_XX :
       (l1CandidatesFor_ne englishGrammar .plurality)).optimal
     = {.reduplication} := by decide
 
-/-- English + diminutive: XY wins (Exp 12).
-    English speakers show no XX advantage for diminutive signs
-    because English lacks productive diminutive morphology. The model
-    predicts XY wins categorically; the data show absence of the
-    XX preference seen in the plurality condition. -/
+/-- English + diminutive: XY wins (experiment 12a). English speakers show no XX
+    advantage for diminutive signs — English lacks productive diminutive morphology. -/
 theorem english_diminutive_prefers_XY :
     (Tableau.ofRanking
       (l1CandidatesFor englishGrammar .diminutive)
@@ -142,12 +123,9 @@ theorem english_diminutive_prefers_XY :
       (l1CandidatesFor_ne englishGrammar .diminutive)).optimal
     = {.nonidentical} := by decide
 
-/-- Hebrew + plurality: XY wins (Exp 10a).
-    Hebrew speakers show weak/no XX advantage for plural signs
-    because Hebrew uses reduplication for diminutives but NOT plurality —
-    negative transfer blocks the reduplication parse. The model predicts
-    XY categorically; the data show attenuation or absence of the
-    XX preference relative to the diminutive condition. -/
+/-- Hebrew + plurality: XY wins (experiment 10a). Hebrew speakers show no XX advantage
+    for plural signs — Hebrew uses reduplication for diminutives, never plurality, so
+    negative transfer blocks the reduplication parse. -/
 theorem hebrew_plurality_prefers_XY :
     (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .plurality)
@@ -155,11 +133,10 @@ theorem hebrew_plurality_prefers_XY :
       (l1CandidatesFor_ne hebrewGrammar .plurality)).optimal
     = {.nonidentical} := by decide
 
-/-- Hebrew + diminutive: reduplication wins (Exp 11a).
-    Hebrew speakers show a gradient XX preference for diminutive signs
-    because Hebrew has productive reduplicative diminutives — positive
-    transfer makes the reduplication parse available. The categorical
-    prediction captures the direction of the effect. -/
+/-- Hebrew + diminutive: reduplication wins (experiment 11a). Positive transfer from
+    Hebrew's partly productive reduplicative diminutives makes the parse available; the
+    preference is marginal by participants and reliable with items as the sole random
+    effect, which the paper links to that partial productivity. -/
 theorem hebrew_diminutive_prefers_XX :
     (Tableau.ofRanking
       (l1CandidatesFor hebrewGrammar .diminutive)

--- a/references.bib
+++ b/references.bib
@@ -49,6 +49,18 @@
   sources   = {Pragmatics/SignalingGame/Basic.lean}
 }
 
+@article{berent-steriade-lennertz-vaknin-2007,
+  author    = {Berent, Iris and Steriade, Donca and Lennertz, Tracy and Vaknin, Vered},
+  year      = {2007},
+  title     = {What We Know about What We Have Never Heard: Evidence from Perceptual Illusions},
+  journal   = {Cognition},
+  volume    = {104},
+  pages     = {591--630},
+  doi       = {10.1016/j.cognition.2006.05.015},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/Berent2026.lean}
+}
 @article{bohnemeyer-2007,
   author    = {Bohnemeyer, J{\"u}rgen},
   year      = {2007},


### PR DESCRIPTION
Deep cleanse of the Berent pair (both papers read in full). Berent2026: the stipulated 0/1/2 profile table could not represent the paper four-point cline (blif over bnif over bdif over lbif) — markedness is now sonority distance, with the cline derived, substance-freeness stated as rank-invariance, and the profile recovered as a threshold classification; the adjacentIdentical recursion lemmas move next to their definition. BerentEtAl2016: the English-plurality cell cited the null heterogeneous cells (Exps 4a, 8a per Table 1; the preference cells are 2, 4b, 8b, and the ASL 2x2 cell is 6a); garbled Hebrew gloss (seleg to slaglag as dog to puppy) corrected to kelev to klavlav in study and substrate; the 11a marginal-by-participants caveat added; markdown tables and bare-key blocks removed; berent-steriade-lennertz-vaknin-2007 bib entry added.