### PR TITLE
refactor(Studies/Blutner2000): fix example numbers, tableau-faithful strengths

### DIFF
--- a/Linglib/Pragmatics/Bidirectional.lean
+++ b/Linglib/Pragmatics/Bidirectional.lean
@@ -50,7 +50,7 @@ and marked forms pair with marked (marked) meanings. The strong
 version incorrectly predicts that marked forms are blocked in ALL
 their interpretations.
 
-The structural meta-theorem `strong ⊂ weak` ([blutner-2000] p. 12)
+The structural meta-theorem `strong ⊂ weak` ([blutner-2000] p. 205)
 lives in `Phonology/Constraint/Superoptimal.lean` as
 `isStrongOptimal_imp_mem_superoptimalSet` (Set-valued, coinductive
 proof against `OrderHom.gfp`) and its Finset corollary
@@ -260,7 +260,7 @@ theorem total_blocking_weak_vs_strong :
 -- ============================================================================
 
 /-! The structural meta-theorem `strongOptimal pairs profile ⊆ superoptimal
-    pairs profile` ([blutner-2000] p. 12) is proved coinductively in the
+    pairs profile` ([blutner-2000] p. 205) is proved coinductively in the
     substrate at `Phonology/Constraint/Superoptimal.lean` via
     `isStrongOptimal_imp_mem_superoptimalSet` (Set-valued, against mathlib's
     `OrderHom.gfp`) and `strongOptimal_subset_superoptimal` (Finset

--- a/Linglib/Studies/Blutner2000.lean
+++ b/Linglib/Studies/Blutner2000.lean
@@ -4,64 +4,40 @@ import Linglib.Pragmatics.Bidirectional
 import Linglib.Semantics.Presupposition.Accommodation
 
 /-!
-# [blutner-2000] — Presupposition Projection via Bidirectional OT
+# Presupposition projection in bidirectional OT
 
-[blutner-2000] [van-der-sandt-1992] [geurts-1995]
+Formalization of §4 of [blutner-2000] (Journal of Semantics 17), which reconstructs the
+[van-der-sandt-1992] and [geurts-1995] projection mechanism in bidirectional OT: the
+I-principle selects the preferred projection site under the ranking AvoidA ≫ BeStrong
+(the paper's C1/C2 and R), and the Q-principle blocks accommodation whenever a simpler
+expression alternative exists — Zeevat's generalization ((23)): a trigger does not
+accommodate iff it has a simple non-triggering expression alternative. The §2–3
+apparatus (strong vs. weak bidirection ((6)/(11)), total and partial blocking, Horn's
+division of pragmatic labour) lives in `Pragmatics/Superoptimal.lean` and
+`Pragmatics/Bidirectional.lean`; this file consumes it for the §4 case studies.
 
-Some Aspects of Optimality in Natural Language Interpretation.
-Journal of Semantics 17(3): 189–216.
+## Main definitions
 
-## Overview
+* `ProjectionSite` — local, intermediate, global; mapped onto the standard
+  accommodation levels by `ProjectionSite.toAccommodationLevel`.
+* `dogProfile`, `catProfile` — the [AvoidA, BeStrong] profiles of tableaux (17) and
+  (18) for the conditionals (15) and (16).
 
-Section 4 of [blutner-2000] reconstructs [van-der-sandt-1992]'s
-and [geurts-1995]'s presupposition projection mechanism within
-bidirectional OT. The I-principle (interpretation optimality) selects the
-preferred accommodation site; the Q-principle (production optimality)
-blocks accommodation when a simpler expression alternative exists.
+## Main results
 
-## Two Constraints
+* `dog_global_accommodation` — (15)/(17): every site accommodates, so BeStrong decides
+  and global accommodation wins.
+* `cat_intermediate_binding` — (16)/(18): only the intermediate site binds, so AvoidA
+  decides.
+* `accommodation_blocked`, `accommodation_blocked_is_Q` — (22): "??The car hit him" is
+  blocked by the alternative "A car hit him" — the Q-principle.
 
-- **AvoidA** (Avoid Accommodation): counts the number of discourse markers
-  that require accommodation. Binding (resolving against existing context)
-  is preferred over accommodation. This captures [van-der-sandt-1992]'s
-  and [geurts-1995]'s first preference (binding > accommodation).
+## References
 
-- **BeStrong**: ranks interpretations by logical strength (entailment).
-  Stronger (more informative) outcomes are preferred. This captures
-  [geurts-1995]'s second preference (higher accommodation site
-  yields stronger interpretation, ceteris paribus).
-
-Ranking: AvoidA >> BeStrong.
-
-## Application
-
-### Example (18): "If Peter has a dog, then his cat is gray"
-
-Three projection sites for the presupposition "Peter has a cat":
-- τ₁ (local): accommodate in consequent — requires accommodation
-- τ₂ (intermediate): accommodate in antecedent — requires accommodation
-- τ₃ (global): accommodate globally — requires accommodation
-
-All three violate AvoidA. BeStrong is decisive: global accommodation
-(τ₃) gives the strongest interpretation → selected.
-
-### Example (19): "If Peter has a cat, then his cat is gray"
-
-Three projection sites:
-- τ₁ (local): requires accommodation (AvoidA violated)
-- τ₂ (intermediate): allows binding/factoring (AvoidA satisfied)
-- τ₃ (global): requires accommodation (AvoidA violated)
-
-AvoidA selects τ₂ (intermediate) — the only site where the
-presupposition is bound rather than accommodated.
-
-### Accommodation blocking (Q-principle)
-
-[blutner-2000] §4, example (25): accommodation of "the car"
-is blocked when a simpler expression "a car" achieves the same
-context change without triggering presupposition. This is
-Q-principle blocking: the presuppositional form is more complex
-than the non-presuppositional alternative.
+* [blutner-2000] — the paper.
+* [van-der-sandt-1992], [geurts-1995] — the projection mechanism and its preferences
+  (binding over accommodation; higher sites, ceteris paribus).
+* [asher-lascarides-1998] — the car-accident blocking datum of (22).
 -/
 
 namespace Blutner2000
@@ -69,166 +45,114 @@ namespace Blutner2000
 open Core.Optimization.Evaluation
 open Pragmatics.Bidirectional
 
--- ============================================================================
--- § 1: Projection Sites
--- ============================================================================
+/-! ### Projection sites -/
 
 /-- Presupposition projection sites, following [van-der-sandt-1992]. -/
 inductive ProjectionSite where
-  | local         -- accommodate in the most embedded position
-  | intermediate  -- accommodate at an intermediate level (e.g., antecedent)
-  | global        -- accommodate at the top-level discourse context
+  | local
+  | intermediate
+  | global
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § 2: Constraints
--- ============================================================================
+/-- The single presuppositional sentence of each §4 interpretation competition: the
+    form is held fixed and the projection sites race. -/
+inductive SentenceForm where
+  | sentence
+  deriving DecidableEq, Repr
 
-/-- **AvoidA** (Avoid Accommodation): counts accommodated discourse markers.
-    0 = bound (no accommodation needed), n = n markers accommodated.
+/-! ### (15)/(17): "If Peter has a dog, then his cat is gray"
 
-    Captures [van-der-sandt-1992]'s preference for binding over
-    accommodation and [geurts-1995]'s preference (i). -/
-abbrev AvoidA := Nat
+The presupposition (Peter has a cat) finds no binder, so every site accommodates its
+marker and AvoidA is tied; BeStrong decides. The strength grades follow tableau (17):
+the global projection r ∧ (p ⇒ q) entails both others, and the local p ⇒ (q ∧ r)
+entails the intermediate (r ∧ p) ⇒ q — the tableau's u > v and w > v — so the
+intermediate projection is weakest. -/
 
-/-- **BeStrong**: ranks by logical strength of the resulting interpretation.
-    Lower values = stronger interpretation.
-
-    Captures [geurts-1995]'s preference (ii): prefer higher
-    accommodation sites (which yield stronger interpretations). -/
-abbrev Strength := Nat
-
--- ============================================================================
--- § 3: Example (18) — "If Peter has a dog, then his cat is gray"
--- ============================================================================
-
-/-! Presupposition: "Peter has a cat" (triggered by "his cat").
-    Context: empty (∅). No antecedent provides a cat.
-    All three sites require accommodation (no binding possible). -/
-
-/-- The input form for example (18). Only one form (the presuppositional
-    sentence). The competition is among interpretations (projection sites). -/
-inductive Form18 where | sentence deriving DecidableEq, Repr
-
-/-- Generator: one form, three projection sites. -/
-def gen18 : Finset (Form18 × ProjectionSite) :=
+def dogGen : Finset (SentenceForm × ProjectionSite) :=
   { (.sentence, .local), (.sentence, .intermediate), (.sentence, .global) }
 
-/-- Witness Park-set: the global-accommodation interpretation. -/
-def winner18 : Finset (Form18 × ProjectionSite) :=
-  { (.sentence, .global) }
+/-- Tableau (17) profile, [AvoidA, BeStrong]; lower BeStrong = stronger. -/
+def dogProfile : SentenceForm × ProjectionSite → List Nat
+  | (.sentence, .global)       => [1, 0]  -- r ∧ (p ⇒ q): strongest
+  | (.sentence, .local)        => [1, 1]  -- p ⇒ (q ∧ r)
+  | (.sentence, .intermediate) => [1, 2]  -- (r ∧ p) ⇒ q: weakest
 
-/-- Constraint profile: [AvoidA, BeStrong].
-    All three sites require accommodation (AvoidA = 1).
-    Strength: global (0) > intermediate (1) > local (2). -/
-def profile18 : Form18 × ProjectionSite → List Nat
-  | (.sentence, .global)       => [1, 0]  -- accommodated, strongest
-  | (.sentence, .intermediate) => [1, 1]  -- accommodated, medium
-  | (.sentence, .local)        => [1, 2]  -- accommodated, weakest
-
-/-- Example (18): AvoidA is tied (all sites accommodate), so BeStrong
-    is decisive. Global accommodation wins (strongest interpretation).
-    Direct kernel-verified `decide` on the Finset-native canonical form. -/
-theorem ex18_global_wins :
-    superoptimal gen18 profile18 = winner18 := by
+/-- (15): AvoidA is tied, so BeStrong decides — global accommodation wins. -/
+theorem dog_global_accommodation :
+    superoptimal dogGen dogProfile
+      = { (SentenceForm.sentence, ProjectionSite.global) } := by
   decide
 
--- ============================================================================
--- § 4: Example (19) — "If Peter has a cat, then his cat is gray"
--- ============================================================================
+/-! ### (16)/(18): "If Peter has a cat, then his cat is gray"
 
-/-! Presupposition: "Peter has a cat" (triggered by "his cat").
-    Context: empty (∅), but the antecedent introduces "Peter has a cat".
-    At the intermediate site, the presupposition can be BOUND (factored)
-    against the antecedent — no accommodation needed. -/
+The antecedent supplies a binder at the intermediate site, which factors rather than
+accommodates; AvoidA ≫ BeStrong makes it the winner. The strength grades follow
+tableau (18): global p ∧ (p ⇒ q) is strongest, and — ignoring reference markers — the
+local and intermediate projections coincide (the tableau's w = v; fn. 13). -/
 
-/-- Generator for example (19). -/
-inductive Form19 where | sentence deriving DecidableEq, Repr
-
-def gen19 : Finset (Form19 × ProjectionSite) :=
+def catGen : Finset (SentenceForm × ProjectionSite) :=
   { (.sentence, .local), (.sentence, .intermediate), (.sentence, .global) }
 
-/-- Witness Park-set: the intermediate (bound) interpretation. -/
-def winner19 : Finset (Form19 × ProjectionSite) :=
-  { (.sentence, .intermediate) }
+/-- Tableau (18) profile: only the intermediate site binds (AvoidA 0). -/
+def catProfile : SentenceForm × ProjectionSite → List Nat
+  | (.sentence, .global)       => [1, 0]  -- p ∧ (p ⇒ q): strongest
+  | (.sentence, .intermediate) => [0, 1]  -- bound (factored)
+  | (.sentence, .local)        => [1, 1]  -- ≡ intermediate in strength (fn. 13)
 
-/-- Constraint profile for example (19): [AvoidA, BeStrong].
-    Intermediate: binding possible → AvoidA = 0.
-    Local and global: accommodation required → AvoidA = 1.
-    Strength: global (0) > intermediate (1) > local (2). -/
-def profile19 : Form19 × ProjectionSite → List Nat
-  | (.sentence, .global)       => [1, 0]  -- accommodated, strongest
-  | (.sentence, .intermediate) => [0, 1]  -- BOUND (factored), medium
-  | (.sentence, .local)        => [1, 2]  -- accommodated, weakest
-
-/-- Example (19): AvoidA is decisive — intermediate projection allows
-    binding (0 violations) while local and global require accommodation.
-    BeStrong is irrelevant since AvoidA already discriminates. -/
-theorem ex19_intermediate_wins :
-    superoptimal gen19 profile19 = winner19 := by
+/-- (16): AvoidA decides — the bound intermediate projection wins. -/
+theorem cat_intermediate_binding :
+    superoptimal catGen catProfile
+      = { (SentenceForm.sentence, ProjectionSite.intermediate) } := by
   decide
 
--- ============================================================================
--- § 5: Accommodation Blocking (Q-Principle)
--- ============================================================================
+/-! ### (22): accommodation blocked by the Q-principle
 
-/-! [blutner-2000] example (25): "He had an accident. ??The car hit him."
-    vs "He had an accident. A car hit him."
+"He had an accident. ??The car hit him." vs. "He had an accident. A car hit him."
+([asher-lascarides-1998]'s datum, the paper's (22)). From a car-neutral context both
+continuations effect the same context change, but the definite requires accommodation;
+the indefinite alternative blocks it. Zeevat's (23) generalizes: a presupposition
+trigger does not accommodate iff it has a simple non-triggering expression
+alternative. -/
 
-    "The car" triggers the presupposition that there is a unique salient car.
-    "A car" does not trigger this presupposition.
-
-    Starting from a neutral context (no car introduced), both sentences
-    achieve the same context change — but "the car" requires accommodation
-    while "a car" does not. The Q-principle blocks accommodation of "the car"
-    because the simpler alternative "a car" achieves the same effect. -/
-
-/-- Two forms: the presuppositional definite and the indefinite. -/
+/-- The presuppositional definite and its non-triggering indefinite alternative. -/
 inductive DefForm where
-  | definite    -- "the car hit him" (triggers presupposition)
-  | indefinite  -- "a car hit him" (no presupposition)
+  | definite
+  | indefinite
   deriving DecidableEq, Repr
 
-/-- The shared meaning (same context change result). -/
+/-- The shared context-change result. -/
 inductive AccidentMeaning where
-  | carHitHim  -- the resulting interpretation
+  | carHitHim
   deriving DecidableEq, Repr
 
-/-- Generator: both forms map to the same meaning. -/
 def genAccident : Finset (DefForm × AccidentMeaning) :=
   { (.definite, .carHitHim), (.indefinite, .carHitHim) }
 
-/-- Witness Park-set: the indefinite form (Q-principle winner). -/
-def winnerAccident : Finset (DefForm × AccidentMeaning) :=
-  { (.indefinite, .carHitHim) }
-
-/-- Profile: [FormComplexity, AccommodationCost].
-    The definite requires accommodation (more complex pragmatically);
-    the indefinite does not. -/
+/-- Profile, [markedness, accommodation cost]: the definite accommodates, the
+    indefinite does not. -/
 def profileAccident : DefForm × AccidentMeaning → List Nat
-  | (.definite,   .carHitHim) => [1, 0]  -- accommodation needed
-  | (.indefinite, .carHitHim) => [0, 0]  -- no accommodation
+  | (.definite,   .carHitHim) => [1, 0]
+  | (.indefinite, .carHitHim) => [0, 0]
 
-/-- Q-principle blocks the definite: the indefinite achieves the same
-    meaning with fewer violations. The definite form is blocked
-    (pragmatically anomalous) in neutral contexts. -/
+/-- The indefinite blocks the definite: same meaning, fewer violations — the definite
+    is pragmatically anomalous in car-neutral contexts. -/
 theorem accommodation_blocked :
-    superoptimal genAccident profileAccident = winnerAccident := by
+    superoptimal genAccident profileAccident
+      = { (DefForm.indefinite, AccidentMeaning.carHitHim) } := by
   decide
 
-/-- List form of `genAccident`, for the `satisfiesQ`/`satisfiesI` API which
-    operates on Lists. -/
+/-- List form of `genAccident` for the `satisfiesQ`/`satisfiesI` API. -/
 def genAccidentList : List (DefForm × AccidentMeaning) :=
   [(.definite, .carHitHim), (.indefinite, .carHitHim)]
 
-/-- This is a Q-principle effect: the definite is blocked because
-    a competing form (indefinite) with the same meaning is better. -/
+/-- The blocking is a Q-principle effect: a competing form with the same meaning is
+    better. -/
 theorem accommodation_blocked_is_Q :
     Pragmatics.Bidirectional.satisfiesQ
       genAccidentList profileAccident (.definite, .carHitHim) = false := by
   decide
 
-/-- The indefinite satisfies both Q and I. -/
+/-- The indefinite satisfies both principles. -/
 theorem indefinite_satisfies_both :
     Pragmatics.Bidirectional.satisfiesQ
       genAccidentList profileAccident (.indefinite, .carHitHim) = true ∧
@@ -236,28 +160,22 @@ theorem indefinite_satisfies_both :
       genAccidentList profileAccident (.indefinite, .carHitHim) = true :=
   ⟨by decide, by decide⟩
 
--- ============================================================================
--- § 6: Connection to Accommodation Infrastructure
--- ============================================================================
+/-! ### Bridge to the accommodation levels
 
-/-! [blutner-2000]'s projection sites correspond to the accommodation
-    levels in `Presupposition.Accommodation`. The bridge makes
-    explicit that Blutner's OT analysis operates over the same site taxonomy
-    as the Heim/Lewis/van der Sandt tradition. -/
+The projection sites are the accommodation levels of the Heim/Lewis/van der Sandt
+tradition (`Presupposition.Accommodation`). -/
 
 open Presupposition.Accommodation
 
 /-- Map projection sites to the standard accommodation levels. -/
 def ProjectionSite.toAccommodationLevel : ProjectionSite → AccommodationLevel
   | .local        => .local
-  | .intermediate => .intermediate 0  -- depth 0 = immediate superordinate DRS
+  | .intermediate => .intermediate 0
   | .global       => .global
 
-/-- Global projection corresponds to global accommodation. -/
 theorem global_is_global_accommodation :
     ProjectionSite.global.toAccommodationLevel = AccommodationLevel.global := rfl
 
-/-- Local projection corresponds to local accommodation. -/
 theorem local_is_local_accommodation :
     ProjectionSite.local.toAccommodationLevel = AccommodationLevel.local := rfl
 

--- a/references.bib
+++ b/references.bib
@@ -22,6 +22,17 @@
 % ══════════════════════════════════════════════════════════════════════════════
 %  pragmatics/rsa
 
+@article{asher-lascarides-1998,
+  author    = {Asher, Nicholas and Lascarides, Alex},
+  year      = {1998},
+  title     = {The Semantics and Pragmatics of Presupposition},
+  journal   = {Journal of Semantics},
+  volume    = {15},
+  pages     = {239--299},
+  subfield  = {pragmatics/presupposition},
+  role      = {cited},
+  sources   = {Studies/Blutner2000.lean}
+}
 @incollection{beavers-zubair-2010,
   author    = {Beavers, John and Zubair, Cala},
   year      = {2010},


### PR DESCRIPTION
Examples renumbered to the paper's (15)/(16) with tableaux (17)/(18) and blocking datum (22); strength grades corrected to tableau (17)'s u>v, w>v and (18)'s w=v (fn. 13); car-accident datum attributed to Asher & Lascarides 1998 (bib entry added); Bidirectional.lean strong⊂weak locator fixed to p. 205.