### PR TITLE
refactor(Studies/Borer2005): reticule divisions, typology (40), layering fix

### DIFF
--- a/Linglib/Studies/Borer2005.lean
+++ b/Linglib/Studies/Borer2005.lean
@@ -1,118 +1,244 @@
-import Linglib.Features.Number.Interp
+import Linglib.Semantics.Mereology
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
 /-!
-# Borer (2005): the nominal spine and the mass/count distinction
+# Borer 2005: dividing and counting in the nominal spine
 
-[borer-2005] locates the mass/count distinction in functional structure rather than in
-nouns: a root denotes a cumulative predicate, the classifier head (Borer's CL#, the `Q`
-head of the nominal extended projection) individuates it, and the number head (`#`, the
-`Num` head) counts the individuated units. Individuation is the restriction of a predicate
-to its atoms — `Number.atomsOf`, the operation that also interprets singular number — so
-the count reading of any root is quantized (`div_qua`) while its mass reading stays
-cumulative, and classifier and non-classifier languages differ only in whether the
-individuating head is spelled out and further restricted by a classifier (`DivCL`).
+[borer-2005] (*In Name Only*) locates the mass/count distinction in functional
+structure: roots denote cumulative stuff, mass interpretation is the default in
+the absence of dividing structure, the classifier head (⟨e⟩div, the `Q` head of
+the nominal spine) divides the stuff, and the quantity head (⟨e⟩#, the `Num`
+head) counts the divisions — or measures undivided mass, *much salt*. Division
+creates no individuals: bare plurals stay cumulative, and plural marking
+presupposes no singulars (*zero apples*, *0.5 apples*). Individuals emerge only
+when a counter assigns range to ⟨e⟩#, selecting from the divisions — the
+book's reticules — one with the requisite number of complete cells. Singular
+*a*, *one* and *every*, *each* are portmanteau divider-counters assigning
+range to both heads, cardinals are pure counters, and the features count and
+divide generate the book's determiner typology.
 
-The order of the two heads, individuation below counting, follows from their semantic
-types: individuation takes a cumulative predicate to a quantized one, and counting takes a
-quantized predicate to a measured one, so the counting head has no well-typed input unless
-the individuating head is projected below it (`status`, `q_below_num`); this is the order
-the extended projection's F-values encode (`fValue_Q_lt_Num`). Borer sets this against
-[chierchia-1998]'s lexical mass/count distinction and its cross-linguistic parameter: the
-two accounts agree that mass denotations are cumulative and count denotations quantized,
-and disagree on whether the distinction is a property of nouns or of the spine.
+## Main definitions
+
+* `Division` — a reticule over cumulative stuff: finitely many cells, none
+  required to be a canonical unit.
+* `Division.merge`, `Division.counts` — the sum of two divisions; the number
+  of complete cells a counter selects for.
+* `DeterminerClass`, with `much`, `every`, `indefArticle`, `cardinal`,
+  `allDet`, `hungarianCardinal` — the typology's two features and its rows.
+* `status`, `Countable` — the spine's bottom-up typing and count structure.
+
+## Main results
+
+* `sumFrom_mem` — divided stuff is still stuff: apples plus apples gives
+  apples, the cumulativity bare plurals share with mass nouns.
+* `exists_division_without_units`, `exists_unit_of_counts_pos` — plural
+  marking presupposes no singulars, while a positively counted division
+  yields individuals: individuals emerge at ⟨e⟩#, not at ⟨e⟩div.
+* `counters_reject_bare_stems`, `dividers_take_bare_stems`, `all_pattern`,
+  `hungarian_no_plural` — the determiner distribution derived from the two
+  features.
+* `q_below_num`, `quantified_mass` — dividing feeds counting and nothing
+  divides a quantity, while the quantity head alone over undivided stuff is
+  quantified mass.
 
 ## References
 
-* [borer-2005]
-* [chierchia-1998]
+* [borer-2005] — the book.
+* [krifka-1998] — the cumulative and quantized notions the book measures its
+  proposal against.
+* [chierchia-1998] — the lexical rival.
 -/
 
 namespace Borer2005
 
 open Mereology Minimalist
 
-variable {α : Type*} [SemilatticeSup α] (P : α → Prop)
+variable {α : Type*} {P : α → Prop}
 
-/-! ### Individuation and counting -/
+/-! ### Dividing without individuating
 
-/-- Borer's individuating head (CL#, the `Q` head) restricts a root predicate to its
-atoms — the singular-number restriction `Number.atomsOf`. -/
-abbrev Div : α → Prop := Number.atomsOf P
+Assigning range to ⟨e⟩div superimposes divisions on a mass denotation. A
+division carves cells; it does not choose among reticules, and its cells need
+not be canonical units — the book's apple portions, and the reticules with no
+complete cells that ground *zero apples* and *0.5 apples*. -/
 
-/-- Individuated predicates are quantized: the count reading of any root is `QUA`. -/
-theorem div_qua : QUA (Div P) := qua_of_atom fun _ h => h.2
+/-- A division of cumulative stuff — the book's reticule: finitely many cells
+carved from the `P`-stuff, possibly none of them a canonical unit. -/
+structure Division (P : α → Prop) where
+  /-- The cells the reticule carves. -/
+  cells : List α
+  /-- Every cell is carved from the stuff. -/
+  stuff : ∀ x ∈ cells, P x
 
-/-- Sums of individuated units of a cumulative root stay in the root's denotation:
-pluralities of beer-units are beer. -/
-theorem algClosure_div_sub (hCum : CUM P) : ∀ x, AlgClosure (Div P) x → P x :=
-  fun x hx => (algClosure_of_cum hCum).1 (algClosure_mono (fun _ h => h.1) x hx)
+/-- Merging two divisions divides the same stuff. -/
+def Division.merge (d₁ d₂ : Division P) : Division P :=
+  ⟨d₁.cells ++ d₂.cells, fun x hx =>
+    (List.mem_append.mp hx).elim (d₁.stuff x) (d₂.stuff x)⟩
 
-/-- The number head counts individuated units: *three beers* is the quantizing
-modification of `Div √BEER` to measure `3`. -/
-def count {M : Type*} (μ : α → M) (n : M) : α → Prop := QMOD (Div P) μ n
+section Sums
 
-theorem count_qua {M : Type*} (μ : α → M) (n : M) : QUA (count P μ n) :=
-  (div_qua P).subset fun _ h => h.1
+variable [SemilatticeSup α]
 
-/-- In a classifier language the classifier fills the individuating head and restricts
-which atoms count as units (Mandarin *zhī* to small animals); non-classifier languages
-individuate covertly, with the trivial classifier (`divCL_true`). -/
-abbrev DivCL (cl : α → Prop) : α → Prop := Div fun x => P x ∧ cl x
+/-- The sum of a list of cells, accumulated from a first cell. -/
+def sumFrom (a : α) (l : List α) : α := l.foldl (· ⊔ ·) a
 
-theorem divCL_qua (cl : α → Prop) : QUA (DivCL P cl) := div_qua _
+/-- Divided stuff is still stuff: the sum of cells of the cumulative root
+satisfies the root — apples plus apples gives apples, the cumulativity bare
+plurals share with mass nouns against singulars. -/
+theorem sumFrom_mem (hCum : CUM P) {a : α} (ha : P a) {l : List α}
+    (hl : ∀ x ∈ l, P x) : P (sumFrom a l) := by
+  induction l generalizing a with
+  | nil => exact ha
+  | cons b l ih =>
+    exact ih (hCum ha (hl b (by simp))) fun x hx => hl x (by simp [hx])
 
-theorem divCL_sub_div {cl : α → Prop} {x : α} (h : DivCL P cl x) : Div P x := ⟨h.1.1, h.2⟩
+end Sums
 
-theorem divCL_true : DivCL P (fun _ => True) = Div P := by
-  funext x; simp [DivCL, Div, Number.atomsOf]
+section Units
+
+variable (unit : α → Prop)
+
+/-- Plural marking presupposes no singulars: whenever the stuff has a
+noncanonical portion, some cell-nonempty division contains no unit at all —
+the divisions behind *zero apples*, *0.5 apples*, and the apple-portion
+readings of bare plurals. -/
+theorem exists_division_without_units (h : ∃ x, P x ∧ ¬ unit x) :
+    ∃ d : Division P, d.cells ≠ [] ∧ ∀ x ∈ d.cells, ¬ unit x :=
+  let ⟨x, hP, hu⟩ := h
+  ⟨⟨[x], by simpa using hP⟩, by simp, by simpa using hu⟩
+
+variable [DecidablePred unit]
+
+/-- The counting function: a counter assigning range to ⟨e⟩# selects a
+division by its number of complete cells — cells that are canonical units. -/
+def Division.counts (d : Division P) : ℕ :=
+  (d.cells.filter fun x => decide (unit x)).length
+
+/-- Individuals emerge at ⟨e⟩#: a division counted positively contains a
+canonical unit of the stuff — *more than three circles* cannot be true
+without individual circles, though bare *circles* can. -/
+theorem exists_unit_of_counts_pos {d : Division P} (h : 0 < d.counts unit) :
+    ∃ x, unit x ∧ P x := by
+  obtain ⟨x, hx⟩ := List.exists_mem_of_length_pos h
+  exact ⟨x, by simpa using List.of_mem_filter hx, d.stuff x (List.mem_of_mem_filter hx)⟩
+
+end Units
+
+/-! ### The determiner typology
+
+The typology sorts determiners by two features — counting, the assignment of
+range to ⟨e⟩#, and dividing, the assignment of range to ⟨e⟩div — and the
+distribution over bare stems, plurals, and mass follows from the features. -/
+
+/-- A determiner class: whether it counts (`none` for the unspecified
+determiners) and whether it divides. -/
+structure DeterminerClass where
+  /-- Assigns range to ⟨e⟩#; `none` when unspecified. -/
+  counts : Option Bool
+  /-- Assigns range to ⟨e⟩div. -/
+  divides : Bool
+  deriving DecidableEq, Repr
+
+/-- *much*, *little*: quantity over undivided mass; no classifier phrase. -/
+def much : DeterminerClass := ⟨some false, false⟩
+
+/-- *every*, *each*: portmanteau divider-counters over bare stems. -/
+def every : DeterminerClass := ⟨some true, true⟩
+
+/-- *a*, *one*: the singular as simultaneous division and counting — the
+dividing and counting functions can never be separated for singulars. -/
+def indefArticle : DeterminerClass := ⟨some true, true⟩
+
+/-- Cardinals and the plural-selecting quantifiers (*three*, *several*,
+*many*): pure counters over previously introduced divisions. -/
+def cardinal : DeterminerClass := ⟨some true, false⟩
+
+/-- *all*, *a lot of*, *most*: unspecified for counting, never dividing. -/
+def allDet : DeterminerClass := ⟨none, false⟩
+
+/-- Hungarian, Turkish, and Armenian cardinals: dividing counters, on a par
+with *every* and *each*. -/
+def hungarianCardinal : DeterminerClass := ⟨some true, true⟩
+
+/-- Combination with a bare stem: the stem is undivided stuff, so the
+determiner must either divide it or tolerate mass — pure counters cannot. -/
+abbrev takesBareStem (c : DeterminerClass) : Prop :=
+  c.divides = true ∨ c.counts ≠ some true
+
+/-- Combination with plural marking: the plural assigns range to ⟨e⟩div, so a
+divider clashes with it, and a pure mass quantity has nothing to count. -/
+abbrev takesPlural (c : DeterminerClass) : Prop :=
+  c.divides = false ∧ c.counts ≠ some false
+
+/-- Pure counters reject bare stems — mass cannot be counted: *two boy*,
+*two meat* — while taking plurals: *two boys*. -/
+theorem counters_reject_bare_stems :
+    ¬ takesBareStem cardinal ∧ takesPlural cardinal := by decide
+
+/-- The divider-counters take bare stems of either sort — *a boy*, *one
+meat*, *every boy*, *each meat* — and reject plurals: *every boys*. -/
+theorem dividers_take_bare_stems :
+    (takesBareStem indefArticle ∧ ¬ takesPlural indefArticle) ∧
+      takesBareStem every ∧ ¬ takesPlural every := by decide
+
+/-- *all* takes mass and plurals but, not dividing, yields no count reading
+on a bare stem: *all meat*, *all boys*, not *all boy*. -/
+theorem all_pattern :
+    takesBareStem allDet ∧ takesPlural allDet ∧ allDet.divides = false := by decide
+
+/-- Dividing cardinals take bare stems and never co-occur with plural
+marking — the Hungarian, Turkish, and Armenian pattern. -/
+theorem hungarian_no_plural :
+    takesBareStem hungarianCardinal ∧ ¬ takesPlural hungarianCardinal := by decide
 
 /-! ### The nominal spine -/
 
-/-- A nominal spine is count when it projects the individuating head. -/
+/-- A nominal spine is count when it projects the dividing head. -/
 abbrev Countable (spine : List Cat) : Prop := Cat.Q ∈ spine
 
 example : Countable [.N, .n, .Q, .Num, .D] := by decide
 example : ¬ Countable [.N, .n, .D] := by decide
 
-/-- The mereological type of a nominal denotation along the spine: cumulative (a root),
-quantized (individuated), or measured (counted). -/
+/-- The mereological type of a nominal denotation along the spine: cumulative
+stuff, divided stuff, or quantity. -/
 inductive Status where
-  | cum
-  | qua
-  | measured
+  | stuff
+  | divided
+  | quantity
   deriving DecidableEq, Repr
 
-/-- The typing of the semantically active heads: individuation takes cumulative to
-quantized (`div_qua`) and counting takes quantized to measured (`count_qua`); the other
-heads are transparent. -/
-def typing : Cat → Option (Status × Status)
-  | .Q => some (.cum, .qua)
-  | .Num => some (.qua, .measured)
-  | _ => none
+/-- The semantically active heads: ⟨e⟩div divides stuff, and ⟨e⟩# counts
+divisions or measures undivided stuff — *three cats* against *much salt*;
+the other heads are transparent. Nothing divides a quantity. -/
+def steps : Cat → Status → Option Status
+  | .Q, .stuff => some .divided
+  | .Q, _ => none
+  | .Num, .quantity => none
+  | .Num, _ => some .quantity
+  | _, s => some s
 
-/-- The type of a spine's denotation, composed bottom-up from a cumulative root; `none`
-when some head receives input of the wrong type. -/
+/-- The type of a spine's denotation, composed bottom-up from cumulative
+stuff; `none` when a head has no well-typed input. -/
 def status (spine : List Cat) : Option Status :=
-  spine.foldl (fun s c => s.bind fun s => match typing c with
-    | some (i, o) => if s = i then some o else none
-    | none => some s) (some .cum)
+  spine.foldl (fun s c => s.bind (steps c)) (some .stuff)
 
-/-- Individuation below counting is the only well-typed order of the two heads. -/
+/-- Dividing feeds counting and nothing divides a quantity: the only
+well-typed order puts the dividing head below the quantity head — the order
+the extended projection's F-values encode. -/
 theorem q_below_num :
-    status [.N, .n, .Q, .Num] = some .measured ∧ status [.N, .n, .Num, .Q] = none := by
-  decide
+    status [.N, .n, .Q, .Num] = some .quantity ∧
+      status [.N, .n, .Num, .Q] = none := by decide
 
-/-- Every truncation of the spine is well-typed — the bare root is mass, the individuated
-root a single unit, the counted root a measured plurality — except counting without
-individuation. -/
+/-- The quantity head alone, over undivided stuff, is quantified mass —
+*much salt* projects no classifier phrase. -/
+theorem quantified_mass : status [.N, .n, .Num] = some .quantity := by decide
+
+/-- The truncations: the bare stem is mass, the divided stem a bare plural. -/
 theorem status_truncations :
-    status [.N, .n] = some .cum ∧ status [.N, .n, .Q] = some .qua ∧
-      status [.N, .n, .Num] = none := by
-  decide
+    status [.N, .n] = some .stuff ∧ status [.N, .n, .Q] = some .divided := by decide
 
-/-- The extended projection's F-values place the individuating head below the counting
-head. -/
+/-- The extended projection's F-values place the dividing head below the
+quantity head. -/
 theorem fValue_Q_lt_Num : fValue .Q < fValue .Num := by decide
 
 end Borer2005

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Studies.Borer2005
+import Linglib.Features.Number.Interp
 import Linglib.Studies.Filip2012
 import Mathlib.Topology.Connected.Basic
 import Mathlib.Tactic.FinCases
@@ -167,10 +167,10 @@ theorem mixedDrink_not_atom {recipe : Recipe α K (n + 2)} {x : α}
   rw [h0, h1] at hDisj
   exact hDisj (Overlap.refl hAtom.not_isBot)
 
-/-- [borer-2005]'s individuation operator, which restricts to atoms, excludes mixed drinks:
-their unit of individuation is not atomicity but the measured part. -/
-theorem div_excludes_mixed_drinks {recipe : Recipe α K (n + 2)} (DRINK : α → Prop) {x : α}
-    (hx : mixedDrinkDen recipe μ phase x) : ¬ Borer2005.Div DRINK x :=
+/-- The atoms-restriction — individuation as atom-based count theories construe it — excludes
+mixed drinks: their unit of individuation is not atomicity but the measured part. -/
+theorem atomsOf_excludes_mixed_drinks {recipe : Recipe α K (n + 2)} (DRINK : α → Prop) {x : α}
+    (hx : mixedDrinkDen recipe μ phase x) : ¬ Number.atomsOf DRINK x :=
   fun ⟨_, hAtom⟩ => mixedDrink_not_atom hx hAtom
 
 /-- Half a margarita with its ratios and connectivity preserved is a margarita, so the

--- a/Linglib/Studies/WangSun2026.lean
+++ b/Linglib/Studies/WangSun2026.lean
@@ -1,6 +1,5 @@
 import Linglib.Syntax.Mereological.Interpretation
 import Linglib.Fragments.Mandarin.Classifiers
-import Linglib.Studies.Borer2005
 import Linglib.Studies.Chierchia1998
 
 /-!

--- a/Linglib/Syntax/Mereological/Interpretation.lean
+++ b/Linglib/Syntax/Mereological/Interpretation.lean
@@ -1,25 +1,26 @@
 import Linglib.Syntax.Mereological.Basic
-import Linglib.Studies.Borer2005
+import Linglib.Features.Number.Interp
 
 /-!
 # Mereological Syntax → Semantics Bridge
 [adger-2025] [borer-2005] [wang-sun-2026]
 
 Connects the syntactic visibility predicate (`labelInOnePartChain`) from
-mereological syntax to the semantic individuation operator (`Div`) from
-[borer-2005]'s nominal theory, closing the gap between two
-independent uses of mereology in the library:
+mereological syntax to the atoms-restriction `Number.atomsOf` — the
+individuating operation [wang-sun-2026] and [adger-2025] assume for the
+classifier head of a [borer-2005]-style nominal spine — closing the gap
+between two independent uses of mereology in the library:
 
 1. **Semantic mereology** (`Semantics/Mereology.lean`): part-whole over entities.
-   CUM (cumulative), QUA (quantized), Div (individuation to atoms).
+   CUM (cumulative), QUA (quantized), `Number.atomsOf` (restriction to atoms).
 2. **Syntactic mereology** (`Mereological/`): part-of over syntactic
    objects. SynObj, subjoin, Dimensionality.
 
 The syntactic parthood structure *determines* which semantic operations
 compose into the denotation. Whether Cl is in D's 1-part chain determines
-whether individuation (`Div`) applies:
+whether individuation (`Number.atomsOf`) applies:
 
-- **Cl visible** (in 1-part chain) → `Div` applies → QUA → sortal
+- **Cl visible** (in 1-part chain) → atoms-restriction applies → QUA → sortal
 - **Cl invisible** (cross-dimensional) → root passes through → CUM → mensural
 
 This is the formal content of [wang-sun-2026]'s 的-contrast.
@@ -44,24 +45,23 @@ def individuates (d : SynObj) : Bool :=
 section Semantics
 
 open _root_.Mereology
-open Borer2005
 
 variable {α : Type*} [SemilatticeSup α]
 
 /-- The nominal denotation at a syntactic node, given a root predicate P.
 
-    When Cl is visible (in the node's 1-part chain), `Div` applies:
+    When Cl is visible (in the node's 1-part chain), `Number.atomsOf` applies:
     the denotation picks out atomic instances of P (sortal/count).
     When Cl is invisible, P passes through unmodified (mensural/mass). -/
 noncomputable def nominalDenotation (d : SynObj) (P : α → Prop) : α → Prop :=
-  if individuates d then Div P else P
+  if individuates d then Number.atomsOf P else P
 
-/-- Classifier-parametric variant: uses `DivCL` to further restrict
-    which atoms qualify, based on the classifier's semantic content
+/-- Classifier-parametric variant: further restricts which atoms qualify,
+    based on the classifier's semantic content
     (e.g., 张 *zhāng* restricts to flat-surface atoms). -/
 noncomputable def nominalDenotationCL (d : SynObj) (P : α → Prop)
     (cl : α → Prop) : α → Prop :=
-  if individuates d then DivCL P cl else P
+  if individuates d then Number.atomsOf (fun x => P x ∧ cl x) else P
 
 -- ════════════════════════════════════════════════════
 -- § 3. Core Bridge Theorems
@@ -72,7 +72,7 @@ noncomputable def nominalDenotationCL (d : SynObj) (P : α → Prop)
 theorem visible_cl_gives_qua (d : SynObj) (P : α → Prop)
     (hv : individuates d = true) :
     QUA (nominalDenotation d P) := by
-  unfold nominalDenotation; rw [hv]; exact div_qua P
+  unfold nominalDenotation; rw [hv]; exact qua_of_atom fun _ h => h.2
 
 /-- When Cl is invisible, the denotation equals the root predicate. -/
 theorem invisible_cl_preserves_root (d : SynObj) (P : α → Prop)
@@ -85,7 +85,7 @@ theorem invisible_cl_preserves_root (d : SynObj) (P : α → Prop)
 theorem visible_cl_gives_qua_CL (d : SynObj) (P : α → Prop)
     (cl : α → Prop) (hv : individuates d = true) :
     QUA (nominalDenotationCL d P cl) := by
-  unfold nominalDenotationCL; rw [hv]; exact divCL_qua P cl
+  unfold nominalDenotationCL; rw [hv]; exact qua_of_atom fun _ h => h.2
 
 /-- When Cl is invisible and the root is cumulative, the denotation
     is cumulative — the mass/mensural reading. -/


### PR DESCRIPTION
The study modeled Borer's dividing head as restriction-to-atoms with a quantized-output theorem — the opposite of the book's §4.4 thesis (individuals are created at the quantity head, not by division; bare plurals stay cumulative; plural marking presupposes no singulars) — and typed #-over-undivided-stuff as ill-formed, contradicting the book's much-salt structure. Recut: Division (reticule) model with cumulativity, no-units, and units-at-count theorems; the determiner typology derived from its two features (counters reject bare stems, divider-counters take them and reject plurals, Hungarian dividing cardinals); spine typing corrected with quantified mass well-typed; q_below_num kept. Consumers repointed to Number.atomsOf directly, removing the Studies import from theory-layer Syntax/Mereological/Interpretation.lean (layering bug).