### PR TITLE
refactor(Studies/BejarRezac2003): derive DNC repair from EPP parameter

### DIFF
--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -1,201 +1,177 @@
 import Linglib.Syntax.Minimalist.Probe.Phi
 
 /-!
-# Béjar & Rezac 2003 — Person Licensing and the Derivation of PCC Effects
-[bejar-rezac-2003]
+# Béjar and Rezac 2003: person licensing and the Person Case Constraint
 
-[bejar-rezac-2003]: the Person Case Constraint ([bonet-1991]: in
-combinations of a phonologically weak direct and indirect object, the
-direct object may not be 1st/2nd person) derives from two ingredients
-in a [chomsky-2000] probe-goal system:
+This file formalizes Béjar and Rezac's derivation of the Person Case Constraint — in a
+combination of two phonologically weak objects the direct object may not be 1st or 2nd
+person — from a probe–goal system with separate person and number probes and a Person
+Licensing Condition: an interpretable 1st/2nd person feature must enter an Agree relation
+with a functional category. The person probe of a Case-licensing head matches the closest
+nominal; a dative already Case-licensed by its own functional category is inactive and
+absorbs the probe, so a 1st/2nd person theme below it is never licensed. Obviation supplies
+a further person probe: embedding the theme's competitor under a preposition, or, in a
+dative–nominative construction whose dative cannot satisfy the EPP, raising the nominative
+over the dative so that the projection of T probes again.
 
-- **Split probes** (§3): [π] and [#] are separate probes on a single
-  head F (v⁰ in double-object constructions, T⁰ in
-  dative-nominative ones), probing in that order. The [π]-probe
-  matches the *closest* goal — every NP bears a person value, the
-  dative's included (their (8): dative π=3 matches) — but the dative
-  is inactive (its Case already valued), so [π] is absorbed without
-  Agree: it "never enters into an Agree relationship with the
-  accusative; remaining unvalued, it gets a default value".
-- **The PLC** (§3): "An interpretable 1st/2nd person feature must be
-  licensed by entering into an Agree relation with a functional
-  category." Datives, PP-embedded themes, and strong pronouns are
-  licensed by their own φ-bearing F (§4: the applicative P, dative
-  marker, or focus F — inherent Case reduces to structural Case from
-  F); a weak 1st/2nd accusative has only the [π]-probe, which the
-  dative absorbs — the PCC.
+## Main definitions
 
-Through `Probe/Basic.lean`, the [π]-probe is the **off-diagonal**
-licensing shape: visibility is total (`pi.vis = ⊤` — closest goal),
-neediness is bearing [participant] — the same shape as Mam's Voice_TR
-(visible, halting, non-valuing intervener; `Studies/Scott2023.lean`)
-and Zulu's L⁰ (`Studies/Halpert2012.lean`). [preminger-2014] Ch. 4's
-Kichean application moves this very system onto the diagonal by
-feature-relativizing the probes.
+* `Argument`: a weak nominal, with its person and whether a functional category of its own
+  licenses it.
+* `pi`: the person probe, a `Probe` with total visibility whose active goals are the
+  nominals not already licensed.
+* `PLCOk`: the Person Licensing Condition over the person-Agree cycles of a derivation.
+* `dncCycles`: the cycles of a dative–nominative construction, determined by whether the
+  dative satisfies the EPP.
 
-**Repairs** (§4–6): embed the theme under P (their (3)); or — the
-French/Spanish dative-nominative repair (their (16)–(17)) — raise the
-nominative over the dative, whereupon the projection of T introduces
-a fresh [π]-probe and a *second Agree cycle* finds the nominative
-first. Icelandic, where the dative itself satisfies the EPP and stays
-highest, keeps the PCC in dative-nominative constructions (their
-(12)). Modeled here as a list of probe cycles, each an ordered goal
-sequence. The second-cycle mechanism prefigures [bejar-rezac-2009]'s
-cyclic Agree (see `CyclicAgree.lean`), but the two are formally
-distinct: 2003 varies the goal *order* under one probe; 2009 varies
-the *relativization* (per-segment) over one order.
+## Main results
+
+* `pi_agree_eq_some_iff`: the person probe Agrees with the closest nominal, and only if it
+  is not already licensed.
+* `plcOk_iff`: a participant satisfies the condition iff its own functional category
+  licenses it or it heads some cycle.
+* `strong_pcc`: over a dative and an accusative the condition holds iff the accusative is
+  3rd person.
+* `dnc_pcc_iff`: in a dative–nominative construction the constraint applies iff the dative
+  satisfies the EPP.
+* `plcOk_singleCycle_iff_allLicensed`: one cycle over the base order is
+  `Probe.AllLicensed` for the indiscriminate probe.
+
+## References
+
+* [bejar-rezac-2003]
+* [bonet-1991]: the constraint.
+* [chomsky-2000]: Agree, the Active Goal Hypothesis, and closest c-command.
+* [anagnostopoulou-2003]: checking of the person feature by the dative and the
+  cliticization loophole.
+* [harley-ritter-2002]: the person geometry behind `Argument.IsParticipant`.
+* [zaenen-maling-thrainsson-1985], [taraldsen-1995], [sigurdsson-1996]: the Icelandic
+  dative subject and its person restriction.
 -/
 
 namespace BejarRezac2003
 
 open Minimalist
 
-/-- A weak (X⁰) nominal in a single Case-licensing domain: its person
-    value, and whether it sits under a φ-bearing functional category F
-    (applicative P, dative marker, focus F). F assigns the nominal's
-    Case — deactivating it for outside Agree — and licenses its [π]
-    itself (§4). -/
+/-- A weak nominal in a Case-licensing domain: its person, and whether a φ-bearing
+functional category of its own — applicative P, dative marker, focus — assigns its Case and
+licenses its person feature (§4). -/
 structure Argument where
   person : Person
   fLicensed : Bool
   deriving DecidableEq, Repr
 
-/-- Bears an interpretable 1st/2nd person feature (the PLC's domain),
-    via [harley-ritter-2002] decomposition. -/
+/-- `a` bears an interpretable 1st/2nd person feature, the domain of the Person Licensing
+Condition. -/
 def Argument.IsParticipant (a : Argument) : Prop :=
   (decomposePerson a.person).hasParticipant = true
 
 instance : DecidablePred Argument.IsParticipant := fun a =>
   inferInstanceAs (Decidable ((decomposePerson a.person).hasParticipant = true))
 
-/-- One cycle of [π]-Agree over an ordered goal sequence: the probe
-    matches the closest goal (every NP bears [π], per their (8), so
-    visibility is total) and Agrees with it only if it is active —
-    not licensed by its own φ-bearing F. An inactive match absorbs
-    the probe without valuing it (their (9)). (The paper glosses
-    activity as Caselessness but leaves open why same-projection
-    Case valuation does not deactivate the French nominative for the
-    second cycle; ¬F gives the right extension.) -/
+theorem Argument.ne_of_fLicensed {a b : Argument} (ha : a.fLicensed = true)
+    (hb : b.fLicensed = false) : a ≠ b :=
+  fun h => by subst h; simp [hb] at ha
+
+/-- The person probe of a Case-licensing head: every nominal bears a person value (8), and
+a nominal already licensed by its own functional category is inactive (§2, §4). -/
 def pi : Probe Argument :=
   { vis := fun _ => true, act := fun a => !a.fLicensed }
 
-/-- One cycle of [π]-Agree: `pi.agree` over the ordered goals. -/
-def piAgree (goals : List Argument) : Option Argument :=
-  pi.agree goals
+theorem pi_search (goals : List Argument) : pi.search goals = goals.head? := by
+  cases goals <;> rfl
 
-/-- The PLC over a derivation's [π]-Agree cycles: every interpretable
-    1st/2nd person feature enters an Agree relation with a functional
-    category — its own F, or some cycle's [π]-probe. Intended
-    invariant (not enforced): each cycle is a reordering of `args`
-    (the French repair re-probes the *same* two arguments in reversed
-    order). Differs from the substrate `Minimalist.PLC` — Preminger's
-    single-cycle, search-only, probe-relativized rendering — by the
-    paper's F-licensing disjunct and the multiplicity of cycles; the
-    single-cycle case collapses onto the substrate shape
-    (`plcOk_singleCycle_iff_allLicensed`). -/
+/-- The person probe Agrees with the closest nominal, and only if that nominal is not
+already licensed ((9), (10)). -/
+theorem pi_agree_eq_some_iff {goals : List Argument} {a : Argument} :
+    pi.agree goals = some a ↔ goals.head? = some a ∧ a.fLicensed = false := by
+  rw [Probe.agree_eq_some_iff, pi_search]
+  simp [pi]
+
+/-- An inactive closest nominal absorbs the probe: match without Agree (9). -/
+theorem pi_agree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
+    pi.agree [dat, acc] = none :=
+  Probe.agree_eq_none_of_inactive rfl (by simp [pi, hd])
+
+/-- The Person Licensing Condition over the person-Agree cycles of a derivation: every
+participant among `args` is licensed by its own functional category or Agrees with the person
+probe of some cycle (§3). -/
 def PLCOk (cycles : List (List Argument)) (args : List Argument) : Prop :=
   ∀ a ∈ args, a.IsParticipant →
-    (a.fLicensed = true ∨ ∃ goals ∈ cycles, piAgree goals = some a)
+    (a.fLicensed = true ∨ ∃ goals ∈ cycles, pi.agree goals = some a)
 
 instance (cycles : List (List Argument)) (args : List Argument) :
     Decidable (PLCOk cycles args) :=
   inferInstanceAs (Decidable (∀ a ∈ args, a.IsParticipant →
-    (a.fLicensed = true ∨ ∃ goals ∈ cycles, piAgree goals = some a)))
+    (a.fLicensed = true ∨ ∃ goals ∈ cycles, pi.agree goals = some a)))
 
-/-! ### The strong PCC, derived -/
+/-- A participant satisfies the condition iff its own functional category licenses it or it
+is the highest nominal of some cycle (§6). -/
+theorem plcOk_iff (cycles : List (List Argument)) (args : List Argument) :
+    PLCOk cycles args ↔ ∀ a ∈ args, a.IsParticipant →
+      (a.fLicensed = true ∨ ∃ goals ∈ cycles, goals.head? = some a) := by
+  unfold PLCOk
+  refine forall₃_congr fun a _ _ => ?_
+  simp only [pi_agree_eq_some_iff]
+  cases a.fLicensed <;> simp
 
-/-- A dative absorbs the [π]-probe without valuing it: the closest
-    goal matches but is inactive, so the cycle Agrees with nothing —
-    "remaining unvalued, it gets a default value". The default is not
-    a crash (a `Probe.outcome` of `unvalued`, tolerated per [preminger-2014]
-    Ch. 5); ungrammaticality comes only from the PLC. -/
-theorem piAgree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
-    piAgree [dat, acc] = none :=
-  Probe.agree_eq_none_of_inactive rfl (by simp [pi, hd])
-
-/-- Single-cycle collapse onto the substrate's `(needs, vis)`
-    licensing shape: one [π]-cycle over the base order satisfies the
-    PLC iff `AllLicensed` holds with neediness "participant and not
-    F-licensed" and total visibility. The recoding is lossy by
-    design: it folds the F-licensing route into ¬needy, whereas the
-    paper counts F-licensing as itself an Agree relation; and the
-    multi-cycle repairs ((16)–(17)) escape this signature entirely. -/
+/-- One cycle over the base order is `Probe.AllLicensed` for the indiscriminate probe, with
+the needy goals the participants not licensed by a functional category of their own. -/
 theorem plcOk_singleCycle_iff_allLicensed (goals : List Argument) :
     PLCOk [goals] goals ↔
       (Probe.indiscriminate (α := Argument)).AllLicensed
         (fun a => decide a.IsParticipant && !a.fLicensed) goals := by
-  unfold PLCOk Probe.AllLicensed
-  constructor
-  · intro h a ha hneeds
-    simp only [Bool.and_eq_true, decide_eq_true_eq, Bool.not_eq_true'] at hneeds
-    rcases h a ha hneeds.1 with hF' | ⟨gs, hgs, hag⟩
-    · exact nomatch hneeds.2.symm.trans hF'
-    · rw [List.mem_singleton.mp hgs] at hag
-      exact (Probe.agree_eq_some_iff.mp hag).1
-  · intro h a ha hpart
-    cases hF : a.fLicensed with
-    | true => exact Or.inl rfl
-    | false =>
-      refine Or.inr ⟨goals, List.mem_singleton_self _, ?_⟩
-      exact (Probe.agree_eq_some_iff (p := pi)).mpr
-        ⟨h a ha (by simp [hpart, hF]), by simp [pi, hF]⟩
+  rw [plcOk_iff, Probe.indiscriminate_allLicensed_iff]
+  refine forall₂_congr fun a _ => ?_
+  cases a.fLicensed <;> simp
 
-/-- **The PCC** (their (1)/(7), generalized): in a double-object
-    configuration — dative over accusative, one [π]-Agree cycle on
-    v⁰ — the PLC holds iff the accusative is 3rd person. Left-to-right
-    is Bonet's strong PCC; right-to-left says 3rd-person accusatives
-    and F-licensed datives of any person are unconstrained. -/
+/-! ### The constraint -/
+
+/-- Over a dative and an accusative in one person-Agree cycle, the condition holds iff the
+accusative is 3rd person ((1), (7)). -/
 theorem strong_pcc (dat acc : Argument)
     (hd : dat.fLicensed = true) (ha : acc.fLicensed = false) :
     PLCOk [[dat, acc]] [dat, acc] ↔ ¬ acc.IsParticipant := by
-  constructor
-  · intro h hacc
-    rcases h acc (List.mem_pair.mpr (Or.inr rfl)) hacc with hF | ⟨gs, hgs, hag⟩
-    · exact nomatch ha.symm.trans hF
-    · rw [List.mem_singleton.mp hgs, piAgree_absorbed dat acc hd] at hag
-      exact nomatch hag
-  · intro hacc a ha' hpart
-    rcases List.mem_pair.mp ha' with rfl | rfl
-    · exact Or.inl hd
-    · exact absurd hpart hacc
+  rw [plcOk_iff]
+  simp [hd, ha, Argument.ne_of_fLicensed hd ha]
 
-/-- The French clitic cluster (their (1)): *le lui* licit, **te lui*
-    a PCC violation. -/
-theorem french_cluster :
-    PLCOk [[⟨.third, true⟩, ⟨.third, false⟩]]
-      [⟨.third, true⟩, ⟨.third, false⟩] ∧
-    ¬ PLCOk [[⟨.third, true⟩, ⟨.second, false⟩]]
-      [⟨.third, true⟩, ⟨.second, false⟩] := by
+-- (1): *le lui* licit, *te lui* excluded.
+example :
+    PLCOk [[⟨.third, true⟩, ⟨.third, false⟩]] [⟨.third, true⟩, ⟨.third, false⟩] ∧
+    ¬ PLCOk [[⟨.third, true⟩, ⟨.second, false⟩]] [⟨.third, true⟩, ⟨.second, false⟩] := by
   decide
 
-/-! ### Repairs -/
+/-! ### Obviation -/
 
-/-- Repair by P-embedding (their (3), *je te ai présenté à lui*): in
-    the prepositional construction the theme is the highest goal and
-    the dative sits in a low PP — the [π]-probe finds the active theme
-    and Agrees, and the PP-internal goal is licensed by P itself. -/
-theorem pp_repair :
-    PLCOk [[⟨.second, false⟩, ⟨.third, true⟩]]
-      [⟨.second, false⟩, ⟨.third, true⟩] := by
-  decide
+/-- In the prepositional construction the theme is the highest nominal and the goal sits
+under P, so the person probe Agrees with the theme and P licenses the goal ((3), (11a)). -/
+theorem pp_repair (theme goal : Argument) (hg : goal.fLicensed = true) :
+    PLCOk [[theme, goal]] [theme, goal] := by
+  rw [plcOk_iff]
+  simp [hg]
 
-/-- The dative-nominative split (their (12) vs. (13)/(16)–(17)):
-    Icelandic datives satisfy the EPP and stay highest, so the
-    [π]-cycle is absorbed and a 1st/2nd nominative violates the PLC
-    (*þið*, their (12)). (Modeled as a single cycle; per their (25c)
-    Icelandic also projects a second one, but the dative still
-    intervenes — extensionally the same.) In French the nominative
-    raises over the dative and T's projection opens a second
-    [π]-cycle over the reversed order, which finds the now-highest
-    active nominative — PCC obviated (their (13)). -/
-theorem dnc_split :
-    -- Icelandic: one cycle, dative highest — 2nd-person nominative out
-    ¬ PLCOk [[⟨.third, true⟩, ⟨.second, false⟩]]
-      [⟨.third, true⟩, ⟨.second, false⟩] ∧
-    -- French: second cycle over the reversed order — 1st-person nominative in
-    PLCOk [[⟨.third, true⟩, ⟨.first, false⟩],
-           [⟨.first, false⟩, ⟨.third, true⟩]]
-      [⟨.third, true⟩, ⟨.first, false⟩] := by
+/-- The person-Agree cycles of a dative–nominative construction: T probes the base order,
+and once the EPP is satisfied the projection of T probes again — over the same order if the
+dative can satisfy the EPP, over the reversed order if the nominative has raised past it
+((16), (17), (25)). -/
+def dncCycles (dativeEPP : Bool) (dat nom : Argument) : List (List Argument) :=
+  [[dat, nom], if dativeEPP then [dat, nom] else [nom, dat]]
+
+/-- The Person Case Constraint applies in a dative–nominative construction iff the dative
+satisfies the EPP (§5). -/
+theorem dnc_pcc_iff (dativeEPP : Bool) (dat nom : Argument)
+    (hd : dat.fLicensed = true) (hn : nom.fLicensed = false) :
+    PLCOk (dncCycles dativeEPP dat nom) [dat, nom] ↔
+      (dativeEPP = true → ¬ nom.IsParticipant) := by
+  rw [plcOk_iff]
+  cases dativeEPP <;> simp [dncCycles, hd, hn, Argument.ne_of_fLicensed hd hn]
+
+-- (12) Icelandic *þið* excluded; (13) French *je lui fus présenté* licit.
+example :
+    ¬ PLCOk (dncCycles true ⟨.third, true⟩ ⟨.second, false⟩)
+        [⟨.third, true⟩, ⟨.second, false⟩] ∧
+    PLCOk (dncCycles false ⟨.third, true⟩ ⟨.first, false⟩)
+        [⟨.third, true⟩, ⟨.first, false⟩] := by
   decide
 
 end BejarRezac2003

--- a/references.bib
+++ b/references.bib
@@ -19674,9 +19674,45 @@
   pages     = {49--62},
   note      = {Selected papers from the 32nd Linguistic Symposium on Romance Languages (LSRL 32). Current Issues in Linguistic Theory series, vol. 244.},
   subfield  = {syntax},
-  role      = {cited},
+  role      = {formalized},
   validated = {true},
   sources   = {Studies/Preminger2014.lean;Studies/BejarRezac2003.lean}
+}
+@book{anagnostopoulou-2003,
+  author    = {Anagnostopoulou, Elena},
+  year      = {2003},
+  title     = {The Syntax of Ditransitives: Evidence from Clitics},
+  publisher = {Mouton de Gruyter},
+  address   = {Berlin},
+  series    = {Studies in Generative Grammar},
+  number    = {54},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/BejarRezac2003.lean}
+}
+@incollection{taraldsen-1995,
+  author    = {Taraldsen, Knut Tarald},
+  year      = {1995},
+  title     = {On Agreement and Nominative Objects in {Icelandic}},
+  booktitle = {Studies in Comparative Germanic Syntax},
+  editor    = {Haider, Hubert and Olsen, Susan and Vikner, Sten},
+  publisher = {Kluwer},
+  address   = {Dordrecht},
+  pages     = {307--327},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/BejarRezac2003.lean}
+}
+@article{sigurdsson-1996,
+  author    = {Sigur{\dh}sson, Halld{\'o}r {\'A}rmann},
+  year      = {1996},
+  title     = {{Icelandic} Finite Verb Agreement},
+  journal   = {Working Papers in Scandinavian Syntax},
+  volume    = {57},
+  pages     = {1--46},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/BejarRezac2003.lean}
 }% REF: Béjar, S. & M. Rezac (2009). Cyclic Agree. Linguistic Inquiry 40(1): 35–73.
 @article{bejar-rezac-2009,
   author    = {Béjar, Susana and Rezac, Milan},


### PR DESCRIPTION
Derive the dative–nominative repair cycles from whether the dative satisfies the EPP (`dncCycles`, `dnc_pcc_iff`: the PCC applies in a DNC iff the dative is the subject) instead of hand-supplied goal orders; add the `pi_agree_eq_some_iff`/`plcOk_iff` characterizations, generalize `pp_repair`, and strip forward references to 2009–2023 work. Verified against the LSRL 32 chapter.

- bib: `bejar-rezac-2003` role → formalized; `anagnostopoulou-2003`, `taraldsen-1995`, `sigurdsson-1996` added.