### PR TITLE
feat(Syntax/Minimalist/Probe): PhiGoal, ofAct; BejarRezac2003 on them

### DIFF
--- a/Linglib/Studies/BejarRezac2003.lean
+++ b/Linglib/Studies/BejarRezac2003.lean
@@ -14,12 +14,13 @@ a further person probe: embedding the theme's competitor under a preposition, or
 dative–nominative construction whose dative cannot satisfy the EPP, raising the nominative
 over the dative so that the projection of T probes again.
 
+Goals are `Minimalist.PhiGoal`s — a Case-licensing state with a φ-cell — and the person
+probe is `Probe.ofAct`, the probe gated only by the Active Goal Hypothesis.
+
 ## Main definitions
 
-* `Argument`: a weak nominal, with its person and whether a functional category of its own
-  licenses it.
-* `pi`: the person probe, a `Probe` with total visibility whose active goals are the
-  nominals not already licensed.
+* `dat`: a dative, Case-valued by its own functional category.
+* `pi`: the person probe.
 * `PLCOk`: the Person Licensing Condition over the person-Agree cycles of a derivation.
 * `dncCycles`: the cycles of a dative–nominative construction, determined by whether the
   dative satisfies the EPP.
@@ -27,11 +28,11 @@ over the dative so that the projection of T probes again.
 ## Main results
 
 * `pi_agree_eq_some_iff`: the person probe Agrees with the closest nominal, and only if it
-  is not already licensed.
-* `plcOk_iff`: a participant satisfies the condition iff its own functional category
-  licenses it or it heads some cycle.
-* `strong_pcc`: over a dative and an accusative the condition holds iff the accusative is
-  3rd person.
+  is active.
+* `plcOk_iff`: a participant satisfies the condition iff its Case is already valued or it
+  heads some cycle.
+* `strong_pcc`: over a dative and an unvalued nominal the condition holds iff the lower
+  nominal is 3rd person.
 * `dnc_pcc_iff`: in a dative–nominative construction the constraint applies iff the dative
   satisfies the EPP.
 * `plcOk_singleCycle_iff_allLicensed`: one cycle over the base order is
@@ -44,134 +45,113 @@ over the dative so that the projection of T probes again.
 * [chomsky-2000]: Agree, the Active Goal Hypothesis, and closest c-command.
 * [anagnostopoulou-2003]: checking of the person feature by the dative and the
   cliticization loophole.
-* [harley-ritter-2002]: the person geometry behind `Argument.IsParticipant`.
+* [harley-ritter-2002]: the person geometry behind `Agreement.Cell.IsParticipant`.
 * [zaenen-maling-thrainsson-1985], [taraldsen-1995], [sigurdsson-1996]: the Icelandic
   dative subject and its person restriction.
 -/
 
 namespace BejarRezac2003
 
-open Minimalist
+open Minimalist Agreement
 
-/-- A weak nominal in a Case-licensing domain: its person, and whether a φ-bearing
-functional category of its own — applicative P, dative marker, focus — assigns its Case and
-licenses its person feature (§4). -/
-structure Argument where
-  person : Person
-  fLicensed : Bool
-  deriving DecidableEq, Repr
-
-/-- `a` bears an interpretable 1st/2nd person feature, the domain of the Person Licensing
-Condition. -/
-def Argument.IsParticipant (a : Argument) : Prop :=
-  (decomposePerson a.person).hasParticipant = true
-
-instance : DecidablePred Argument.IsParticipant := fun a =>
-  inferInstanceAs (Decidable ((decomposePerson a.person).hasParticipant = true))
-
-theorem Argument.ne_of_fLicensed {a b : Argument} (ha : a.fLicensed = true)
-    (hb : b.fLicensed = false) : a ≠ b :=
-  fun h => by subst h; simp [hb] at ha
+/-- A dative: Case valued by its own φ-bearing functional category — applicative P or
+dative marker — and so inactive for outside Agree (§4). -/
+def dat (c : Cell) : PhiGoal := .valued .dat c
 
 /-- The person probe of a Case-licensing head: every nominal bears a person value (8), and
-a nominal already licensed by its own functional category is inactive (§2, §4). -/
-def pi : Probe Argument :=
-  { vis := fun _ => true, act := fun a => !a.fLicensed }
+a nominal whose Case is already valued is inactive (§2, §4). -/
+def pi : Probe PhiGoal := .ofAct (·.isActive)
 
-theorem pi_search (goals : List Argument) : pi.search goals = goals.head? := by
-  cases goals <;> rfl
-
-/-- The person probe Agrees with the closest nominal, and only if that nominal is not
-already licensed ((9), (10)). -/
-theorem pi_agree_eq_some_iff {goals : List Argument} {a : Argument} :
-    pi.agree goals = some a ↔ goals.head? = some a ∧ a.fLicensed = false := by
-  rw [Probe.agree_eq_some_iff, pi_search]
-  simp [pi]
+/-- The person probe Agrees with the closest nominal, and only if that nominal is active
+((9), (10)). -/
+theorem pi_agree_eq_some_iff {goals : List PhiGoal} {g : PhiGoal} :
+    pi.agree goals = some g ↔ goals.head? = some g ∧ g.isActive = true :=
+  Probe.ofAct_agree_eq_some_iff
 
 /-- An inactive closest nominal absorbs the probe: match without Agree (9). -/
-theorem pi_agree_absorbed (dat acc : Argument) (hd : dat.fLicensed = true) :
-    pi.agree [dat, acc] = none :=
-  Probe.agree_eq_none_of_inactive rfl (by simp [pi, hd])
+theorem pi_agree_absorbed (d g : PhiGoal) (hd : d.isActive = false) :
+    pi.agree [d, g] = none :=
+  Probe.agree_eq_none_of_inactive rfl hd
 
 /-- The Person Licensing Condition over the person-Agree cycles of a derivation: every
-participant among `args` is licensed by its own functional category or Agrees with the person
-probe of some cycle (§3). -/
-def PLCOk (cycles : List (List Argument)) (args : List Argument) : Prop :=
-  ∀ a ∈ args, a.IsParticipant →
-    (a.fLicensed = true ∨ ∃ goals ∈ cycles, pi.agree goals = some a)
+participant among `args` has its Case valued by a functional category of its own or Agrees
+with the person probe of some cycle (§3). -/
+def PLCOk (cycles : List (List PhiGoal)) (args : List PhiGoal) : Prop :=
+  ∀ g ∈ args, g.cell.IsParticipant →
+    (g.isActive = false ∨ ∃ goals ∈ cycles, pi.agree goals = some g)
 
-instance (cycles : List (List Argument)) (args : List Argument) :
+instance (cycles : List (List PhiGoal)) (args : List PhiGoal) :
     Decidable (PLCOk cycles args) :=
-  inferInstanceAs (Decidable (∀ a ∈ args, a.IsParticipant →
-    (a.fLicensed = true ∨ ∃ goals ∈ cycles, pi.agree goals = some a)))
+  inferInstanceAs (Decidable (∀ g ∈ args, g.cell.IsParticipant →
+    (g.isActive = false ∨ ∃ goals ∈ cycles, pi.agree goals = some g)))
 
-/-- A participant satisfies the condition iff its own functional category licenses it or it
-is the highest nominal of some cycle (§6). -/
-theorem plcOk_iff (cycles : List (List Argument)) (args : List Argument) :
-    PLCOk cycles args ↔ ∀ a ∈ args, a.IsParticipant →
-      (a.fLicensed = true ∨ ∃ goals ∈ cycles, goals.head? = some a) := by
+/-- A participant satisfies the condition iff its Case is already valued or it is the
+highest nominal of some cycle (§6). -/
+theorem plcOk_iff (cycles : List (List PhiGoal)) (args : List PhiGoal) :
+    PLCOk cycles args ↔ ∀ g ∈ args, g.cell.IsParticipant →
+      (g.isActive = false ∨ ∃ goals ∈ cycles, goals.head? = some g) := by
   unfold PLCOk
-  refine forall₃_congr fun a _ _ => ?_
+  refine forall₃_congr fun g _ _ => ?_
   simp only [pi_agree_eq_some_iff]
-  cases a.fLicensed <;> simp
+  cases g.isActive <;> simp
 
 /-- One cycle over the base order is `Probe.AllLicensed` for the indiscriminate probe, with
-the needy goals the participants not licensed by a functional category of their own. -/
-theorem plcOk_singleCycle_iff_allLicensed (goals : List Argument) :
+the needy goals the active participants. -/
+theorem plcOk_singleCycle_iff_allLicensed (goals : List PhiGoal) :
     PLCOk [goals] goals ↔
-      (Probe.indiscriminate (α := Argument)).AllLicensed
-        (fun a => decide a.IsParticipant && !a.fLicensed) goals := by
+      (Probe.indiscriminate (α := PhiGoal)).AllLicensed
+        (fun g => decide g.cell.IsParticipant && g.isActive) goals := by
   rw [plcOk_iff, Probe.indiscriminate_allLicensed_iff]
-  refine forall₂_congr fun a _ => ?_
-  cases a.fLicensed <;> simp
+  refine forall₂_congr fun g _ => ?_
+  cases g.isActive <;> simp
 
 /-! ### The constraint -/
 
-/-- Over a dative and an accusative in one person-Agree cycle, the condition holds iff the
-accusative is 3rd person ((1), (7)). -/
-theorem strong_pcc (dat acc : Argument)
-    (hd : dat.fLicensed = true) (ha : acc.fLicensed = false) :
-    PLCOk [[dat, acc]] [dat, acc] ↔ ¬ acc.IsParticipant := by
+/-- Over a dative and an unvalued nominal in one person-Agree cycle, the condition holds iff
+the lower nominal is 3rd person ((1), (7)). -/
+theorem strong_pcc (cd ca : Cell) :
+    PLCOk [[dat cd, .unvalued ca]] [dat cd, .unvalued ca] ↔ ¬ ca.IsParticipant := by
   rw [plcOk_iff]
-  simp [hd, ha, Argument.ne_of_fLicensed hd ha]
+  simp [dat]
 
 -- (1): *le lui* licit, *te lui* excluded.
 example :
-    PLCOk [[⟨.third, true⟩, ⟨.third, false⟩]] [⟨.third, true⟩, ⟨.third, false⟩] ∧
-    ¬ PLCOk [[⟨.third, true⟩, ⟨.second, false⟩]] [⟨.third, true⟩, ⟨.second, false⟩] := by
+    PLCOk [[dat (.pn .third .Sing), .unvalued (.pn .third .Sing)]]
+      [dat (.pn .third .Sing), .unvalued (.pn .third .Sing)] ∧
+    ¬ PLCOk [[dat (.pn .third .Sing), .unvalued (.pn .second .Sing)]]
+      [dat (.pn .third .Sing), .unvalued (.pn .second .Sing)] := by
   decide
 
 /-! ### Obviation -/
 
 /-- In the prepositional construction the theme is the highest nominal and the goal sits
 under P, so the person probe Agrees with the theme and P licenses the goal ((3), (11a)). -/
-theorem pp_repair (theme goal : Argument) (hg : goal.fLicensed = true) :
-    PLCOk [[theme, goal]] [theme, goal] := by
+theorem pp_repair (ct cg : Cell) :
+    PLCOk [[.unvalued ct, dat cg]] [.unvalued ct, dat cg] := by
   rw [plcOk_iff]
-  simp [hg]
+  simp [dat]
 
 /-- The person-Agree cycles of a dative–nominative construction: T probes the base order,
 and once the EPP is satisfied the projection of T probes again — over the same order if the
 dative can satisfy the EPP, over the reversed order if the nominative has raised past it
 ((16), (17), (25)). -/
-def dncCycles (dativeEPP : Bool) (dat nom : Argument) : List (List Argument) :=
-  [[dat, nom], if dativeEPP then [dat, nom] else [nom, dat]]
+def dncCycles (dativeEPP : Bool) (d n : PhiGoal) : List (List PhiGoal) :=
+  [[d, n], if dativeEPP then [d, n] else [n, d]]
 
 /-- The Person Case Constraint applies in a dative–nominative construction iff the dative
 satisfies the EPP (§5). -/
-theorem dnc_pcc_iff (dativeEPP : Bool) (dat nom : Argument)
-    (hd : dat.fLicensed = true) (hn : nom.fLicensed = false) :
-    PLCOk (dncCycles dativeEPP dat nom) [dat, nom] ↔
-      (dativeEPP = true → ¬ nom.IsParticipant) := by
+theorem dnc_pcc_iff (dativeEPP : Bool) (cd cn : Cell) :
+    PLCOk (dncCycles dativeEPP (dat cd) (.unvalued cn)) [dat cd, .unvalued cn] ↔
+      (dativeEPP = true → ¬ cn.IsParticipant) := by
   rw [plcOk_iff]
-  cases dativeEPP <;> simp [dncCycles, hd, hn, Argument.ne_of_fLicensed hd hn]
+  cases dativeEPP <;> simp [dncCycles, dat]
 
 -- (12) Icelandic *þið* excluded; (13) French *je lui fus présenté* licit.
 example :
-    ¬ PLCOk (dncCycles true ⟨.third, true⟩ ⟨.second, false⟩)
-        [⟨.third, true⟩, ⟨.second, false⟩] ∧
-    PLCOk (dncCycles false ⟨.third, true⟩ ⟨.first, false⟩)
-        [⟨.third, true⟩, ⟨.first, false⟩] := by
+    ¬ PLCOk (dncCycles true (dat (.pn .third .Sing)) (.unvalued (.pn .second .Sing)))
+        [dat (.pn .third .Sing), .unvalued (.pn .second .Sing)] ∧
+    PLCOk (dncCycles false (dat (.pn .third .Sing)) (.unvalued (.pn .first .Sing)))
+        [dat (.pn .third .Sing), .unvalued (.pn .first .Sing)] := by
   decide
 
 end BejarRezac2003

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -600,7 +600,7 @@ theorem Probe.Articulated.ban_part_part (P : Probe.Articulated)
     needs or the probe.) -/
 theorem probeless_divergence_from_plc :
     ¬ Gluttonous [] [dp .first, dp .second] ∧
-    ¬ BejarRezac2003.PLCOk [] [⟨.first, false⟩] := by
+    ¬ BejarRezac2003.PLCOk [] [Minimalist.PhiGoal.unvalued (.pn .first .Sing)] := by
   decide
 
 open PCC in

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -130,15 +130,6 @@ open Agreement
 
 /-! ### Feature decomposition (grounded in `Phi/Geometry.lean`) -/
 
-/-- Bears [+participant]? Visibility to π⁰ under relativized probing
-    ([bejar-rezac-2003] via `Agreement.Cell.visibleTo`); derives from
-    [harley-ritter-2002]'s feature geometry through `decomposePerson`. -/
-def IsParticipant (c : Agreement.Cell) : Prop :=
-  c.visibleTo .participant = true
-
-instance : DecidablePred IsParticipant := fun c =>
-  inferInstanceAs (Decidable (c.visibleTo .participant = true))
-
 /-- Bears [+author]? -/
 def IsAuthor (c : Agreement.Cell) : Prop :=
   (decomposePerson c.toPerson).hasAuthor = true
@@ -149,8 +140,8 @@ instance : DecidablePred IsAuthor := fun c =>
 /-- [author] entails [participant]: the [harley-ritter-2002] geometric
     containment, inherited from `decomposePerson`. -/
 theorem isParticipant_of_isAuthor (c : Agreement.Cell) :
-    IsAuthor c → IsParticipant c := by
-  unfold IsAuthor IsParticipant Agreement.Cell.visibleTo
+    IsAuthor c → c.IsParticipant := by
+  unfold IsAuthor Agreement.Cell.IsParticipant Agreement.Cell.visibleTo
   simp only [probeVisible]
   cases c.toPerson <;> decide
 
@@ -205,10 +196,10 @@ def afRank (c : Agreement.Cell) : Nat :=
     `personRestrictionOk_iff_plc`. This is the syntactic licensing
     story, not the morphological clitic-slot competition. -/
 def PersonRestrictionOk (subj obj : Agreement.Cell) : Prop :=
-  ¬(IsParticipant subj ∧ IsParticipant obj)
+  ¬(subj.IsParticipant ∧ obj.IsParticipant)
 
 instance : DecidableRel PersonRestrictionOk := fun subj obj =>
-  inferInstanceAs (Decidable ¬(IsParticipant subj ∧ IsParticipant obj))
+  inferInstanceAs (Decidable ¬(subj.IsParticipant ∧ obj.IsParticipant))
 
 /-- The person restriction derives from the PLC ([bejar-rezac-2003];
     [preminger-2014] §4.4 (75)): with the AF clause's agent and
@@ -242,8 +233,9 @@ theorem personRestrictionOk_iff_plc (s o : Agreement.Cell) :
     Relativization to exactly the licensing-needy class is what
     converts absorption into omnivorous licensing. -/
 theorem ch4_relativization_contrast :
-    ¬ BejarRezac2003.PLCOk [[⟨.third, true⟩, ⟨.first, false⟩]]
-        [⟨.third, true⟩, ⟨.first, false⟩] ∧
+    ¬ BejarRezac2003.PLCOk
+        [[BejarRezac2003.dat (.pn .third .Sing), Minimalist.PhiGoal.unvalued (.pn .first .Sing)]]
+        [BejarRezac2003.dat (.pn .third .Sing), Minimalist.PhiGoal.unvalued (.pn .first .Sing)] ∧
     PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :
         List (ArgumentRole × Agreement.Cell)) := by
   decide
@@ -300,10 +292,10 @@ theorem afAgreementTarget_eq_rank :
     expectations — [+participant] → rank 2, [+plural, −participant]
     → rank 1, 3SG → rank 0. -/
 theorem feature_decomposition_cells :
-    IsParticipant (.pn .first .Sing) ∧
-    IsParticipant (.pn .second .Sing) ∧
-    ¬IsParticipant (.pn .third .Sing) ∧
-    ¬IsParticipant (.pn .third .Plur) ∧
+    (Cell.pn .first .Sing).IsParticipant ∧
+    (Cell.pn .second .Sing).IsParticipant ∧
+    ¬(Cell.pn .third .Sing).IsParticipant ∧
+    ¬(Cell.pn .third .Plur).IsParticipant ∧
     afRank (.pn .first .Sing) = 2 ∧ afRank (.pn .second .Sing) = 2 ∧
     afRank (.pn .third .Plur) = 1 ∧ afRank (.pn .third .Sing) = 0 := by
   decide

--- a/Linglib/Syntax/Minimalist/Probe/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Basic.lean
@@ -22,7 +22,7 @@ a separate concern (`Agree.applyAgree`). This is the general core: the
 
 ## Main declarations
 
-- `Probe`, `Probe.ofVis`, `Probe.indiscriminate` — the bundle and constructors.
+- `Probe`, `Probe.ofVis`, `Probe.ofAct`, `Probe.indiscriminate` — the bundle and constructors.
 - `Probe.search` / `Probe.agree` — first visible goal / that goal if active.
 - `Probe.outcome`, `Probe.Outcome` — valued vs. unvalued.
 - `Probe.Licensed`, `Probe.AllLicensed`, `allLicensed_iff` — one search
@@ -82,6 +82,11 @@ def ofVis (vis : α → Bool) : Probe α := { vis := vis }
     delivers the closest one ([halpert-2012]'s L⁰). -/
 def indiscriminate : Probe α := ofVis fun _ => true
 
+/-- A probe with no visibility condition, gated only by activity: it finds the closest
+goal and Agrees with it iff that goal is active — the Active Goal Hypothesis of
+[chomsky-2000]. -/
+def ofAct (act : α → Bool) : Probe α := { vis := fun _ => true, act := act }
+
 /-! ### Search -/
 
 /-- The goal a probe finds in an ordered goal sequence: the first
@@ -138,6 +143,15 @@ theorem agree_eq_some_iff {a : α} :
       exact ⟨rfl, hb⟩
     · rintro ⟨hb, ha⟩
       exact ⟨hb ▸ ha, hb.symm ▸ rfl⟩
+
+/-- An activity-gated probe finds the closest goal. -/
+@[simp] theorem ofAct_search (act : α → Bool) : (ofAct act).search goals = goals.head? := by
+  cases goals <;> rfl
+
+/-- An activity-gated probe Agrees with the closest goal iff that goal is active. -/
+theorem ofAct_agree_eq_some_iff {act : α → Bool} {a : α} :
+    (ofAct act).agree goals = some a ↔ goals.head? = some a ∧ act a := by
+  rw [agree_eq_some_iff, ofAct_search]; rfl
 
 /-- An inactive closest goal absorbs the probe: match without Agree. -/
 theorem agree_eq_none_of_inactive {a : α}

--- a/Linglib/Syntax/Minimalist/Probe/Phi.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Phi.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Minimalist.Probe.Basic
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Minimalist.Phi.Geometry
+import Linglib.Syntax.Case.Licensing
 
 /-!
 # φ-probes: the φ-feature specialization of `Probe`
@@ -15,7 +16,9 @@ Condition built on it.
 ## Main declarations
 
 - `Agreement.Cell.visibleTo` — a cell bears the feature a target seeks.
+- `Agreement.Cell.IsParticipant` — a cell bears an interpretable 1st/2nd person feature.
 - `Probe.Target.toProbe` — a target's denotation as a `Probe` over φ-cells.
+- `PhiGoal` — a nominal as a φ-goal: its Case-licensing state with its φ-cell.
 - `PLC` — the Person Licensing Condition over φ-bearing goal tokens.
 -/
 
@@ -26,10 +29,65 @@ namespace Minimalist
 def _root_.Agreement.Cell.visibleTo (c : Agreement.Cell) (t : Probe.Target) : Bool :=
   probeVisible t c.toPerson c.isPlural
 
+/-- A cell bears an interpretable 1st/2nd person feature: it is visible to the
+participant probe, by the person geometry of [harley-ritter-2002]. -/
+def _root_.Agreement.Cell.IsParticipant (c : Agreement.Cell) : Prop :=
+  c.visibleTo .participant = true
+
+instance : DecidablePred Agreement.Cell.IsParticipant := fun c =>
+  inferInstanceAs (Decidable (c.visibleTo .participant = true))
+
 /-- The `Probe` a `Probe.Target` denotes: relativized to the sought
     feature, over φ-cells (π⁰ = `Probe.Target.participant.toProbe`). -/
 def Probe.Target.toProbe (t : Probe.Target) : Probe Agreement.Cell :=
   .ofVis (·.visibleTo t)
+
+/-- A nominal as the goal of a φ-probe: its Case-licensing state (`LicensedNP`) together
+with its φ-cell. A relativized probe reads the cell for visibility; Agree reads the Case
+state for activity (`LicensedNP.isActive`, the Active Goal Hypothesis of [chomsky-2000]). -/
+structure PhiGoal extends Syntax.Case.Licensing.LicensedNP where
+  cell : Agreement.Cell
+  deriving DecidableEq, Repr
+
+/-- A nominal whose Case `c` a head of its own has already valued: inactive for Agree. -/
+def PhiGoal.valued (c : Case) (cell : Agreement.Cell) : PhiGoal :=
+  { label := "", lexicalCase := some c, needsLicensing := true, cell := cell }
+
+/-- A nominal with unvalued Case: active for Agree. -/
+def PhiGoal.unvalued (cell : Agreement.Cell) : PhiGoal :=
+  { label := "", lexicalCase := none, needsLicensing := true, cell := cell }
+
+@[simp] theorem PhiGoal.cell_valued (c : Case) (cell : Agreement.Cell) :
+    (PhiGoal.valued c cell).cell = cell := rfl
+
+@[simp] theorem PhiGoal.lexicalCase_valued (c : Case) (cell : Agreement.Cell) :
+    (PhiGoal.valued c cell).lexicalCase = some c := rfl
+
+@[simp] theorem PhiGoal.needsLicensing_valued (c : Case) (cell : Agreement.Cell) :
+    (PhiGoal.valued c cell).needsLicensing = true := rfl
+
+@[simp] theorem PhiGoal.cell_unvalued (cell : Agreement.Cell) :
+    (PhiGoal.unvalued cell).cell = cell := rfl
+
+@[simp] theorem PhiGoal.lexicalCase_unvalued (cell : Agreement.Cell) :
+    (PhiGoal.unvalued cell).lexicalCase = none := rfl
+
+@[simp] theorem PhiGoal.needsLicensing_unvalued (cell : Agreement.Cell) :
+    (PhiGoal.unvalued cell).needsLicensing = true := rfl
+
+theorem PhiGoal.isActive_valued (c : Case) (cell : Agreement.Cell) :
+    (PhiGoal.valued c cell).isActive = false := rfl
+
+theorem PhiGoal.isActive_unvalued (cell : Agreement.Cell) :
+    (PhiGoal.unvalued cell).isActive = true := rfl
+
+@[simp] theorem PhiGoal.valued_ne_unvalued (c : Case) (cell cell' : Agreement.Cell) :
+    PhiGoal.valued c cell ≠ PhiGoal.unvalued cell' := by
+  simp [PhiGoal.valued, PhiGoal.unvalued]
+
+@[simp] theorem PhiGoal.unvalued_ne_valued (c : Case) (cell cell' : Agreement.Cell) :
+    PhiGoal.unvalued cell' ≠ PhiGoal.valued c cell :=
+  (PhiGoal.valued_ne_unvalued c cell cell').symm
 
 /-- The Person Licensing Condition ([bejar-rezac-2003], [preminger-2014]):
     every [participant]-bearing goal is licensed by the person probe's


### PR DESCRIPTION
Replace BejarRezac2003's study-local `Argument {person, fLicensed : Bool}` with substrate objects: `Minimalist.PhiGoal` (a nominal as φ-goal — Kalin's `LicensedNP` Case state with an `Agreement.Cell`), `Agreement.Cell.IsParticipant`, and `Probe.ofAct` (the activity-gated probe of the Active Goal Hypothesis, dual of `ofVis`). Preminger2014 drops its local `IsParticipant` copy for the substrate one; both consumers use `PhiGoal` literals.