### PR TITLE
refactor(Studies/BhattDayal2020): kya: in alternative questions, ForceP selection

### DIFF
--- a/Linglib/Semantics/Questions/Singleton.lean
+++ b/Linglib/Semantics/Questions/Singleton.lean
@@ -13,8 +13,8 @@ several cross-linguistic question-particle analyses:
   the polar question particle presupposes that its sister denotes a
   question whose alternative set is a singleton (the "highlighted"
   cell, in the sense of [roelofsen-farkas-2015]).
-- the parallel analysis of Mandarin *nandao* that
-  [bhatt-dayal-2020] fn. 11 cites as the model for kya:.
+- the parallel analysis of Mandarin *nandao* ([xu-2017]) that
+  [bhatt-dayal-2020] draws on for kya:.
 
 Declarative contents are exactly the singleton ones (under finiteness
 of `props`); the standard two-cell polar `polar p` (with both `p` and
@@ -129,8 +129,8 @@ presupposition satisfied". Used by particle-specific study files
 /-- The **subtype of singleton issues** — issues whose alternative set
     is a singleton. Used as the well-typed sister-content for
     singleton-presuppositional Q-particles
-    ([bhatt-dayal-2020], kya: eq. 23 and parallel nandao analysis
-    cited in fn. 11). The mathlib pattern for "predicate + partial
+    ([bhatt-dayal-2020], kya: eq. 23, and the parallel nandao
+    analysis of [xu-2017]). The mathlib pattern for "predicate + partial
     function" pairs: rather than `Option`-valued partial interpretation,
     use a subtype. -/
 def SingletonQuestion (W : Type u) : Type u :=

--- a/Linglib/Studies/BhattDayal2020.lean
+++ b/Linglib/Studies/BhattDayal2020.lean
@@ -3,52 +3,60 @@ import Linglib.Semantics.Questions.Hamblin
 import Linglib.Fragments.HindiUrdu.Particles
 
 /-!
-# Bhatt & Dayal (2020): the polar question particle *kya:*
-[bhatt-dayal-2020]
+# Bhatt and Dayal 2020: the polar question particle kya:
 
-Hindi-Urdu polar *kya:* is a **polar question particle** (PQP) — a class
-distinct from clause-typing Q-morphemes like Japanese *ka*: it occurs only in
-polar questions (not in wh-questions), sits in a projection above CP the
-paper labels ForceP, and embeds only in the quasi-subordinated configuration
-of [dayal-grimshaw-2009] (complements of rogatives), not in ordinary
-subordination. Semantically kya: presupposes that its sister question has a
-**singleton** alternative set (eq. 23) and is otherwise the identity; a polar
-question denotes the singleton `{p}` (eq. 22b). The same singleton
-restriction models the (bias-introducing) Mandarin particle *nandao* in
-[xu-2012] (cross-linguistic picture in [xu-2017]), which the paper draws on.
+This file formalizes Bhatt and Dayal's analysis of Hindi-Urdu polar *kya:*. The particle is
+not a clause-typing Q-morpheme of the Japanese *-ka* kind: it occurs in polar and
+alternative questions but not in constituent questions, and it embeds under rogative
+predicates and modified responsives but not under plain responsives — the quasi-subordinated
+configuration, which the authors place in a projection above CP, ForceP, that only some
+predicates select. Semantically *kya:* is the identity on its sister question, defined only
+when that question's alternative set is a singleton; a polar question denotes the singleton
+of its nucleus proposition, a constituent question a plural set. An alternative question is
+the disjunction of two polar questions and so has two alternatives; *kya:* is licensed in it
+by applying inside a disjunct, and fails when it scopes over the disjunction — which is why
+clause-final *kya:*, whose sister is the whole clause, is excluded there.
+
+## Main definitions
+
+* `altQ`: the alternative question *p or q* as the disjunction of two singleton polar
+  questions.
+* `selectsForceP`: the embedding contexts whose selecting predicate takes a ForceP
+  complement.
+
+## Main results
+
+* `kya_polar`, `kya_not_wh`: the presupposition holds of a polar question and fails on a
+  constituent question with two answer cells.
+* `altQ_not_singleton`, `kya_in_disjunct`: *kya:* over an alternative question fails, while
+  *kya:* inside a disjunct leaves the alternative question intact.
+* `kya_licensed_iff_selectsForceP`, `kya_clause_types`: the fragment's embedding and
+  clause-type distributions are ForceP selection and singleton-satisfiability.
+
+## References
+
+* [bhatt-dayal-2020]
+* [dayal-grimshaw-2009]: quasi-subordination.
+* [roelofsen-farkas-2015]: the highlighted proposition of a polar question.
+* [xu-2012], [xu-2017]: the Mandarin *nandao* analysis the account draws on.
 -/
 
 namespace BhattDayal2020
 
-open Question (IsSingleton SingletonQuestion ofSet polar which
-  isSingleton_ofSet not_isSingleton_polar_of_nontrivial
-  not_isSingleton_of_two_alternatives alt_which_of_antichain)
-open HindiUrdu.Particles (kya)
+open Question HindiUrdu.Particles Clause
 
 variable {W : Type*}
 
-/-! ### The singleton-alternative presupposition (eq. 23)
+/-! ### The singleton presupposition -/
 
-`⟦kya:⟧ = λQ⟨st⟩t : ∃p ∈ Q[∀q[q ∈ Q → q = p]].Q` — defined only when the
-sister question `Q` has a singleton alternative set, and then the identity
-on `Q`. The presupposition is `Question.IsSingleton`; the felicitous sister
-is the subtype `SingletonQuestion W`. In the paper a polar question denotes
-a singleton (eq. 22b: ⟦did John leave⟧ = {John left}) — the substrate's
-one-cell `ofSet p`, not its two-cell Hamblin `polar`. -/
-
-/-- Felicitous case: a polar question in the paper's sense is a singleton. -/
-theorem kya_felicitous_singleton_polar (p : Set W) :
-    IsSingleton (ofSet (W := W) p) :=
+/-- A polar question denotes the singleton of its nucleus proposition (22b), so *kya:* is
+defined on it and returns it (23). -/
+theorem kya_polar (p : Set W) : IsSingleton (ofSet p) :=
   isSingleton_ofSet p
 
-/-- Defined case: on a felicitous sister, kya: is the identity. -/
-theorem kya_interp (p : Set W) :
-    (SingletonQuestion.ofSet (W := W) p).issue = ofSet p :=
-  SingletonQuestion.ofSet_issue p
-
-/-- The headline restriction (ex. 4): a wh-question with two distinct answer
-cells is non-singleton, so kya: rejects it. -/
-theorem kya_infelicitous_wh {E : Type*} {D : Set E} {P : E → Set W}
+/-- A constituent question with two distinct answer cells is not a singleton (22a), so
+*kya:* is undefined on it (4). -/
+theorem kya_not_wh {E : Type*} {D : Set E} {P : E → Set W}
     (hD : D.Nonempty) (hne : ∀ e ∈ D, (P e).Nonempty)
     (hA : IsAntichain (· ⊆ ·) (P '' D))
     {e₁ e₂ : E} (h₁ : e₁ ∈ D) (h₂ : e₂ ∈ D) (hPne : P e₁ ≠ P e₂) :
@@ -57,22 +65,62 @@ theorem kya_infelicitous_wh {E : Type*} {D : Set E} {P : E → Set W}
     rw [alt_which_of_antichain hD hne hA]
   exacts [⟨e₁, h₁, rfl⟩, ⟨e₂, h₂, rfl⟩]
 
-/-- A two-cell Hamblin polar likewise fails the presupposition. -/
-theorem kya_infelicitous_two_cell_polar {p : Set W}
-    (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
+/-- The two-cell Hamblin polar question fails the presupposition as well; the paper's polar
+question is the one-cell `ofSet p`. -/
+theorem kya_not_two_cell {p : Set W} (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     ¬ IsSingleton (polar (W := W) p) :=
   not_isSingleton_polar_of_nontrivial hne hnu
 
-/-! ### Embedding: quasi-subordination only
+/-! ### Alternative questions -/
 
-kya: appears in matrix polar questions and in the quasi-subordinated
-configuration of [dayal-grimshaw-2009] (complements of rogatives, ex. 9)
-but not in ordinary subordination (complements of responsives, ex. 8) —
-read off the fragment's embedding facet. -/
+/-- The alternative question *p or q*: the disjunction of the two polar questions ((44),
+(52)). -/
+def altQ (p q : Set W) : Question W := ofSet p ⊔ ofSet q
 
-theorem kya_embedding_profile :
-    kya.LicensedInEmbed .matrix ∧ kya.LicensedInEmbed .quasiSubordinated ∧
-      ¬ kya.LicensedInEmbed .subordinated := by
+theorem mem_alt_altQ_left {p q : Set W} (h : ¬ p ⊆ q) : p ∈ alt (altQ p q) :=
+  mem_alt_sup_of_alt_left (by simp) fun _ hr hpr => absurd (hpr.trans hr) h
+
+theorem mem_alt_altQ_right {p q : Set W} (h : ¬ q ⊆ p) : q ∈ alt (altQ p q) :=
+  mem_alt_sup_of_alt_right (by simp) fun _ hr hqr => absurd (hqr.trans hr) h
+
+/-- An alternative question has two alternatives, so *kya:* scoping over it fails the
+presupposition ((43), (51)) — the exclusion of clause-final *kya:* on *p or q* (48b). -/
+theorem altQ_not_singleton {p q : Set W} (hpq : ¬ p ⊆ q) (hqp : ¬ q ⊆ p) :
+    ¬ IsSingleton (altQ p q) :=
+  not_isSingleton_of_two_alternatives _ (mem_alt_altQ_left hpq) (mem_alt_altQ_right hqp)
+    fun h => hpq h.le
+
+/-- *kya:* applied inside a disjunct meets its presupposition on `{p}` and returns it, and
+the disjunction of the two polar questions is the alternative question ((44), (47), (52)). -/
+theorem kya_in_disjunct (p q : Set W) :
+    (SingletonQuestion.ofSet p).issue ⊔ ofSet q = altQ p q :=
+  rfl
+
+/-- Disjunction inside a polar question keeps a singleton: the yes/no reading of *p or q*
+(45). -/
+theorem kya_polar_disjunction (p q : Set W) : IsSingleton (ofSet (p ∪ q)) :=
+  isSingleton_ofSet _
+
+/-! ### Distribution -/
+
+/-- The embedding contexts whose selecting predicate takes a ForceP complement (21): the
+matrix clause and quasi-subordination, not ordinary subordination. -/
+def selectsForceP (e : EmbeddingContext) : Prop :=
+  e = .matrix ∨ e = .quasiSubordinated
+
+instance (e : EmbeddingContext) : Decidable (selectsForceP e) :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+/-- Over the contexts the paper records, *kya:* is licensed exactly where ForceP is selected
+((8), (9), (21)). -/
+theorem kya_licensed_iff_selectsForceP :
+    ∀ e, e ≠ EmbeddingContext.quotation → (kya.LicensedInEmbed e ↔ selectsForceP e) := by
+  decide
+
+/-- *kya:* is licensed in exactly the clause types whose denotation can be a singleton: polar
+and alternative questions, not constituent questions ((4), (5)). -/
+theorem kya_clause_types :
+    ∀ c, kya.LicensedIn c ↔ c = Particle.ClauseType.polar ∨ c = .alternative := by
   decide
 
 end BhattDayal2020


### PR DESCRIPTION
Add the paper's §5 result on the `Question` lattice — an alternative question is the disjunction of two singleton polar questions, so *kya:* fails when scoping over it (clause-final *kya:*, (48b)) and is licensed inside a disjunct — and derive the fragment's embedding distribution from ForceP selection ((21)) rather than restating it. Corrects a locator in `Questions/Singleton.lean`: the *nandao* model is drawn from Xu 2012/2017 in §3.2, not footnote 11 (a thanks note).