### PR TITLE
refactor(Semantics/ArgumentStructure): dissolve Affectedness sub-namespace

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/Affectedness.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness.lean
@@ -51,7 +51,7 @@ from the surface (`MeaningComponents.changeOfState`) and root
 (`LexKind.result`) change-of-state notions ([beavers-koontz-garboden-2020]).
 -/
 
-namespace ArgumentStructure.Affectedness
+namespace ArgumentStructure
 
 variable {α β δ : Type*}
 
@@ -312,4 +312,4 @@ per-verb substrate binding a fragment verb's profile to its θ; until that
 lands, consumers declare the strongest mixin the verb's scalar witnesses
 support. -/
 
-end ArgumentStructure.Affectedness
+end ArgumentStructure

--- a/Linglib/Semantics/Aspect/Incremental.lean
+++ b/Linglib/Semantics/Aspect/Incremental.lean
@@ -276,7 +276,7 @@ def IsSincVerb.mk' {θ : α → β → Prop}
     final degree is verb-specific lexical content that cannot be
     derived from SINC alone. -/
 
-open _root_.ArgumentStructure.Affectedness
+open _root_.ArgumentStructure
 
 /-- Bridge: a K98 SINC verb θ with an explicit final-degree witness
     becomes a Beavers `IsQuantizedAffected` instance (the weaker

--- a/Linglib/Semantics/Degree/Measure/Temporal.lean
+++ b/Linglib/Semantics/Degree/Measure/Temporal.lean
@@ -61,7 +61,7 @@ quantify over the scale's maximum (or its absence).
 
 namespace Degree
 
-open ArgumentStructure.Affectedness
+open ArgumentStructure
 
 /-! ### TemporalMeasure ([hay-kennedy-levin-1999] eq. 11) -/
 

--- a/Linglib/Studies/Beavers2010.lean
+++ b/Linglib/Studies/Beavers2010.lean
@@ -46,7 +46,7 @@ stairs* (85), prospective possession for the dative (90).
 namespace Beavers2010
 
 open ArgumentStructure
-open ArgumentStructure.Affectedness (AffectednessDegree profileToDegree)
+open ArgumentStructure (AffectednessDegree profileToDegree)
 open ArgumentStructure (DiathesisAlternation)
 
 /-! ### L-thematic roles as entailment sets ((65)–(67)) -/

--- a/Linglib/Studies/BeaversUdayana2022.lean
+++ b/Linglib/Studies/BeaversUdayana2022.lean
@@ -53,7 +53,7 @@ open ArgumentStructure
 open Indonesian.VoiceSystem
 open Minimalist.Voice (Params)
 open Beavers2010
-open ArgumentStructure.Affectedness (AffectednessDegree)
+open ArgumentStructure (AffectednessDegree)
 open Voice
 open ArgumentStructure.VoiceSemantics
 open Intensional

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -56,7 +56,7 @@ carriers for distinct objects.
 
 namespace Bhadra2024
 
-open ArgumentStructure ArgumentStructure.Affectedness
+open ArgumentStructure
 
 /-! ### Outcome cardinality -/
 

--- a/Linglib/Studies/KennedyLevin2008.lean
+++ b/Linglib/Studies/KennedyLevin2008.lean
@@ -331,7 +331,7 @@ with the Quantized witness `g_φ = ⊤`,
 feeding [beavers-2011]'s affectedness hierarchy. Here it is instantiated at the
 dimensions the K&L verbs measure. -/
 
-open ArgumentStructure.Affectedness
+open ArgumentStructure
 open Features (ScalarDimension)
 open Degree
 

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -60,9 +60,7 @@ open Intensional (Index)
 open Presupposition
 open French.Predicates
 open ArgumentStructure
-open ArgumentStructure.Affectedness
 open Features
-open ArgumentStructure
 open Minimalist Minimalist.Voice
 
 -- ============================================================================


### PR DESCRIPTION
`Semantics/ArgumentStructure/` is one namespace; `Affectedness.lean` declared `ArgumentStructure.Affectedness`, which is what produced `open ArgumentStructure ArgumentStructure.Affectedness` in Bhadra2024. Dissolved into `ArgumentStructure` (clash-free); the seven consumers' `open` lines updated. `EventStructure`, `VoiceSemantics`, and `Linking` sub-namespaces remain for the same treatment.