### PR TITLE
refactor(Studies/BillEtAl2025): desiderata over complexity measures, drop fit tables

### DIFF
--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -1,609 +1,145 @@
-import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Conjunction
 import Linglib.Semantics.Plurality.Distributivity
-import Linglib.Morphology.Morph
-import Linglib.Syntax.Category.Coordinator
 import Linglib.Syntax.Coordination
 import Linglib.Studies.Haspelmath2007
 import Linglib.Studies.MitrovicSauerland2016
 
 /-!
-# [bill-etal-2025] — DP Conjunction Complexity
+# Bill, Gonzalez, Driemel, Makharoblidze and Pintér 2025: is DP conjunction always complex?
 
-"Is DP conjunction always complex? The view from child Georgian and Hungarian"
-Semantics & Pragmatics 18, Article 5, 1-20.
+This file formalizes the argument of Bill and colleagues' comprehension study of conjunctive
+expressions in Georgian and Hungarian. Both languages express DP conjunction with a *j*
+particle alone, with a *mu* particle on each conjunct, or with both. Under Mitrović and
+Sauerland's decomposition every strategy realizes the same three-piece structure — *j* as
+intersection and two *mu*s as subset operators over singleton-shifted conjuncts — and, with
+the Transparency Principle that children comprehend one-to-one form–meaning mappings more
+easily, the fully overt *j-mu* expressions are predicted to be the easiest. Georgian
+children replayed *j-mu* sentences more often than *j* or *mu* sentences, with no difference
+between the latter two, and Hungarian children showed no difference at all; so the
+prediction fails, as does the ordering of the accounts on which *j* is structurally simplest
+and *mu* and *j-mu* share one structure. The paper concludes that an adequate account must
+make *j-mu* more complex than *j* and *mu*, make *j* and *mu* equally complex, and make
+Hungarian *mu* less complex than Georgian *mu*.
 
-## Main Question
+## Main definitions
 
-[mitrovic-sauerland-2014] claim DP conjunction universally decomposes
-into J (set intersection) + MU (subset) + ☉ (type-shifter). Combined with the
-Transparency Principle — children prefer 1-to-1 form-meaning
-mappings — this predicts J-MU expressions (where all pieces are overt) should
-be easier for children to comprehend than J-only or MU-only.
+* `covertPieces`: the pieces of the decomposition a strategy leaves unpronounced, the
+  Transparency Principle's measure of difficulty.
+* `structuralPieces`: the pieces of the rival structures, one for *j* and three for *mu*
+  and *j-mu*.
+* `georgianHarder`: the significant comprehension contrasts among Georgian children.
+* `Desiderata`: the paper's conditions on a complexity measure.
 
-## Experiment
+## Main results
 
-Act-out task: children and adults hear conjunctive sentences and manipulate
-objects to match. Two DVs: accuracy and sentence-played-n (replay count).
+* `transparency_prediction`: the decomposition with the Transparency Principle predicts
+  *j-mu* easiest.
+* `georgian_contradicts_transparency`, `georgian_contradicts_structural`: the observed
+  contrasts reverse the first prediction and split the strategies the rival equates.
+* `covertPieces_not_desiderata`, `structuralPieces_not_desiderata`: neither measure meets
+  the desiderata.
+* `ms_decomposition_eq_coord`, `mu_is_distributive_check`: the decomposition computes
+  ordinary distributive conjunction.
 
-## Key Findings
+## References
 
-- Georgian children: J-MU sentences required significantly more replays than
-  J or MU sentences (opposite of prediction). No difference between J and MU.
-- Hungarian: no significant sentence-type effects detected on either measure.
-  (Null result — could reflect ceiling effects or insufficient power.)
-- Adults: near-ceiling in both languages.
-
-## Theoretical Significance
-
-Results challenge both Mitrović & Sauerland's universal decomposition and
-alternative accounts.
-
-## Semantic Connection
-
-The M&S decomposition maps directly onto Montague/Conjunction.lean:
-- J = `genConj` (Partee & Rooth's generalized conjunction / set intersection)
-- MU = `individual` (INCL on singletons = type-raising; structural `abbrev`)
-- ☉ = `msShift` (individual → singleton set)
-
-`coordEntities` is defined AS `genConj(individual e₁, individual e₂)`,
-so the M&S derivation is the definition itself, not a theorem.
-`mu_is_distributive_check` proves this equals Link's `distMaximal` on pairs.
-
+* [bill-etal-2025]
+* [mitrovic-sauerland-2014], [mitrovic-sauerland-2016]: the decomposition.
+* [van-hout-1998]: the Transparency Principle.
+* [szabolcsi-2015], [haslinger-etal-2019]: the rival structures.
+* [clark-2017]: bound versus free morphemes in acquisition.
 -/
 
 namespace BillEtAl2025
 
-open Syntax.Coordination
-
--- Conjunction Particle Typology
-
--- Georgian and Hungarian Conjunction Particles
-
-/-- A conjunction particle in a specific language. -/
-structure ConjParticle where
-  language : String
-  form : String
-  gloss : String
-  role : Coordinator.Role
-  boundMorpheme : Bool  -- clitic/suffix vs free morpheme
-  deriving Repr
-
-/-- Georgian J particle -/
-def georgian_da : ConjParticle :=
-  { language := "Georgian", form := "da", gloss := "and"
-  , role := .j, boundMorpheme := false }
-
-/-- Georgian MU particle (clitic) -/
-def georgian_c : ConjParticle :=
-  { language := "Georgian", form := "-c", gloss := "MU/also"
-  , role := .mu, boundMorpheme := true }
-
-/-- Hungarian J particle -/
-def hungarian_es : ConjParticle :=
-  { language := "Hungarian", form := "és", gloss := "and"
-  , role := .j, boundMorpheme := false }
-
-/-- Hungarian MU particle -/
-def hungarian_is : ConjParticle :=
-  { language := "Hungarian", form := "is", gloss := "MU/also"
-  , role := .mu, boundMorpheme := false }
-
-/--
-Both Georgian and Hungarian allow all three strategies.
-This is typologically rare — most languages have only one or two.
--/
-def georgianStrategies : List ConjunctionStrategy := [.jOnly, .muOnly, .jMu]
-def hungarianStrategies : List ConjunctionStrategy := [.jOnly, .muOnly, .jMu]
-
-/--
-Key morphological difference: Georgian MU (-c) is a bound clitic,
-Hungarian MU (is) is a free morpheme.
-This may be relevant to the cross-linguistic difference in results
-([clark-2017]: free morphemes may be acquired more readily than bound).
--/
-theorem georgian_mu_bound : georgian_c.boundMorpheme = true := rfl
-theorem hungarian_mu_free : hungarian_is.boundMorpheme = false := rfl
-
--- Experimental Design
-
-inductive Group where
-  | adult | child
-  deriving DecidableEq, Repr
-
-/-- Age range for a participant group, in months. -/
-structure AgeRange where
-  minMonths : Nat
-  maxMonths : Nat
-  meanMonths : Nat
-  deriving Repr
-
-/-- Participant group with demographics. -/
-structure ParticipantGroup where
-  language : String
-  group : Group
-  n : Nat
-  ageRange : Option AgeRange  -- None for adults
-  deriving Repr
-
-def georgianChildren : ParticipantGroup :=
-  { language := "Georgian", group := .child, n := 31
-  , ageRange := some { minMonths := 45, maxMonths := 70, meanMonths := 57 } }  -- 3;9-5;10, M=4;9
-
-def georgianAdults : ParticipantGroup :=
-  { language := "Georgian", group := .adult, n := 41, ageRange := none }
-
-def hungarianChildren : ParticipantGroup :=
-  { language := "Hungarian", group := .child, n := 25
-  , ageRange := some { minMonths := 36, maxMonths := 60, meanMonths := 50 } }  -- 3;0-5;0, M=4;2
-
-def hungarianAdults : ParticipantGroup :=
-  { language := "Hungarian", group := .adult, n := 30, ageRange := none }
-
--- Correlations
-
-/--
-Age-accuracy correlation in Georgian children: medium positive.
-r(525) = 0.31, p < 0.001 (footnote 8).
--/
-def georgianAgeAccuracyCorrelation : Float := 0.31
-
-/--
-Age-sentencePlayedN correlation in Georgian children: small negative.
-r(497) = -0.18, p < 0.001 (footnote 9). Older children needed fewer replays.
--/
-def georgianAgeSentencePlayedCorrelation : Float := -0.18
-
-/--
-Age-accuracy correlation in Hungarian children: small positive.
-r(423) = 0.19, p < 0.001 (footnote 11).
--/
-def hungarianAgeAccuracyCorrelation : Float := 0.19
-
-/--
-Age-sentencePlayedN correlation in Hungarian children: small negative.
-r(405) = -0.28, p < 0.001 (footnote 11). Older children needed fewer replays.
--/
-def hungarianAgeSentencePlayedCorrelation : Float := -0.28
-
-/-- A single cell in the Group × SentenceType design. -/
-structure ConditionResult where
-  language : String
-  group : Group
-  sentenceType : ConjunctionStrategy
-  /-- Accuracy (percentage 0-100, approximate from Figure 4/6) -/
-  accuracyPct : Nat
-  /-- Number of participants -/
-  nParticipants : Nat
-  deriving Repr
-
--- Georgian Data (Section 3.1)
-
-/--
-Georgian accuracy data (approximate from Figure 4).
-Adults near ceiling across all conditions.
-Children lower but no significant sentence-type effect on accuracy.
--/
-def georgianAccuracy : List ConditionResult :=
-  [ -- Adults (near ceiling)
-    { language := "Georgian", group := .adult, sentenceType := .jOnly,  accuracyPct := 97, nParticipants := georgianAdults.n }
-  , { language := "Georgian", group := .adult, sentenceType := .jMu,   accuracyPct := 97, nParticipants := georgianAdults.n }
-  , { language := "Georgian", group := .adult, sentenceType := .muOnly, accuracyPct := 97, nParticipants := georgianAdults.n }
-    -- Children
-  , { language := "Georgian", group := .child, sentenceType := .jOnly,  accuracyPct := 78, nParticipants := georgianChildren.n }
-  , { language := "Georgian", group := .child, sentenceType := .jMu,   accuracyPct := 78, nParticipants := georgianChildren.n }
-  , { language := "Georgian", group := .child, sentenceType := .muOnly, accuracyPct := 80, nParticipants := georgianChildren.n }
-  ]
-
--- Error Type Breakdown (Section 3.1, footnote 12)
-
-/--
-Error categories for Georgian children (footnote 12).
-Of 103 total errors:
-- 73% placed unmentioned objects (possible ad-hoc implicature failure:
-  children may not derive "nothing else is on the table")
-- 20% placed only one of the mentioned objects
-- 7% placed neither mentioned object
--/
-structure ErrorBreakdown where
-  totalErrors : Nat
-  /-- Placed unmentioned objects on the table -/
-  unmentionedObjectsPct : Nat
-  /-- Placed only one of two mentioned objects -/
-  oneConjunctOnlyPct : Nat
-  /-- Placed neither mentioned object -/
-  neitherConjunctPct : Nat
-  deriving Repr
-
-def georgianChildErrors : ErrorBreakdown :=
-  { totalErrors := 103
-  , unmentionedObjectsPct := 73
-  , oneConjunctOnlyPct := 20
-  , neitherConjunctPct := 7 }
-
-/-- Error percentages sum to 100. -/
-theorem error_pcts_sum :
-    georgianChildErrors.unmentionedObjectsPct +
-    georgianChildErrors.oneConjunctOnlyPct +
-    georgianChildErrors.neitherConjunctPct = 100 := by native_decide
-
--- Statistical Results
-
-/--
-Result of a Likelihood Ratio Test comparing nested models.
-
-We encode statistical test results as data, not as theorems about
-the underlying population. A non-significant result means the test
-did not detect an effect — not that no effect exists.
--/
-structure LRTResult where
-  effect : String
-  df : Nat
-  chiSquared : Float
-  pValue : Float
-  /-- Whether p < .05 (conventional threshold) -/
-  significant : Bool
-  deriving Repr
-
-/--
-Table 1: LRT results for Georgian accuracy.
-
-Only group is significant — sentence-type effect NOT detected.
-NOTE: This is a null result. The act-out task allowed unlimited replays,
-which may have washed out accuracy differences (see Section 3.1.2).
--/
-def georgianAccuracyLRT : List LRTResult :=
-  [ { effect := "group",            df := 1, chiSquared := 12.27, pValue := 0.001, significant := true }
-  , { effect := "sentence",         df := 2, chiSquared := 2.24,  pValue := 0.327, significant := false }
-  , { effect := "group:sentence",   df := 2, chiSquared := 1.95,  pValue := 0.377, significant := false }
-  ]
-
-/--
-Table 2: LRT results for Georgian sentence-played-n.
-
-All effects significant — this is where the key finding emerges.
--/
-def georgianSentencePlayedLRT : List LRTResult :=
-  [ { effect := "group",            df := 1, chiSquared := 35.88, pValue := 0.001, significant := true }
-  , { effect := "sentence",         df := 2, chiSquared := 14.95, pValue := 0.001, significant := true }
-  , { effect := "group:sentence",   df := 2, chiSquared := 23.89, pValue := 0.001, significant := true }
-  ]
-
-/--
-Pairwise comparison for sentence-played-n (Table 3).
-Tukey-adjusted p-values. Values on log scale, encoded as thousandths
-(e.g., -176 = -0.176) so that comparisons are decidable.
--/
-structure PairwiseComparison where
-  group : Group
-  contrast : String
-  /-- Estimate on log scale, in thousandths (-176 = -0.176) -/
-  estimate_thou : Int
-  /-- Standard error in thousandths -/
-  se_thou : Nat
-  df : Nat
-  /-- t-ratio in thousandths -/
-  tRatio_thou : Int
-  /-- p-value in ten-thousandths (1 = 0.0001, 670 = 0.067) -/
-  pValue_tenThou : Nat
-  significant : Bool
-  deriving Repr
-
-/-- Georgian children: J vs J-MU (p < .0001). Negative = J-MU harder. -/
-def georgianChild_j_vs_jmu : PairwiseComparison :=
-  { group := .child, contrast := "J vs J-MU"
-  , estimate_thou := -176, se_thou := 31, df := 1121, tRatio_thou := -5681
-  , pValue_tenThou := 1, significant := true }
-
-/-- Georgian children: J vs MU (p = .067, marginal). -/
-def georgianChild_j_vs_mu : PairwiseComparison :=
-  { group := .child, contrast := "J vs MU"
-  , estimate_thou := -69, se_thou := 31, df := 1121, tRatio_thou := -2230
-  , pValue_tenThou := 670, significant := false }
-
-/-- Georgian children: J-MU vs MU (p < .01). Positive = J-MU harder. -/
-def georgianChild_jmu_vs_mu : PairwiseComparison :=
-  { group := .child, contrast := "J-MU vs MU"
-  , estimate_thou := 106, se_thou := 30, df := 1121, tRatio_thou := 3555
-  , pValue_tenThou := 100, significant := true }
-
-def georgianChildPairwise : List PairwiseComparison :=
-  [georgianChild_j_vs_jmu, georgianChild_j_vs_mu, georgianChild_jmu_vs_mu]
-
-/-- Adults show no pairwise differences (all p > .6). -/
-def georgianAdultPairwise : List PairwiseComparison :=
-  [ { group := .adult, contrast := "J vs J-MU"
-    , estimate_thou := 19, se_thou := 26, df := 1120, tRatio_thou := 708
-    , pValue_tenThou := 7590, significant := false }
-  , { group := .adult, contrast := "J vs MU"
-    , estimate_thou := -3, se_thou := 27, df := 1120, tRatio_thou := -102
-    , pValue_tenThou := 9940, significant := false }
-  , { group := .adult, contrast := "J-MU vs MU"
-    , estimate_thou := -21, se_thou := 25, df := 1120, tRatio_thou := -850
-    , pValue_tenThou := 6720, significant := false }
-  ]
-
--- Hungarian Data (Section 3.2)
-
-/--
-Table 4: LRT results for Hungarian accuracy.
-
-No significant effects detected.
-NOTE: Null result — Hungarian children were somewhat older-behaving
-than Georgian children despite being younger (see fn. 4).
--/
-def hungarianAccuracyLRT : List LRTResult :=
-  [ { effect := "group",            df := 1, chiSquared := 0.75,  pValue := 0.385, significant := false }
-  , { effect := "sentence",         df := 2, chiSquared := 2.93,  pValue := 0.231, significant := false }
-  , { effect := "group:sentence",   df := 2, chiSquared := 1.82,  pValue := 0.402, significant := false }
-  ]
-
-/--
-Table 5: LRT results for Hungarian sentence-played-n.
-
-Only group significant — sentence-type effect NOT detected.
-NOTE: Null result for sentence-type. Could reflect: (a) no actual difference,
-(b) insufficient power (n=25 children), (c) Hungarian MU (free morpheme "is")
-being easier than Georgian MU (bound clitic "-c"), washing out complexity effects.
--/
-def hungarianSentencePlayedLRT : List LRTResult :=
-  [ { effect := "group",            df := 1, chiSquared := 6.54,  pValue := 0.05,  significant := true }
-  , { effect := "sentence",         df := 2, chiSquared := 2.19,  pValue := 0.334, significant := false }
-  , { effect := "group:sentence",   df := 2, chiSquared := 0.55,  pValue := 0.761, significant := false }
-  ]
-
--- Verified Findings (significant results only)
-
-/--
-Georgian children replayed J-MU sentences significantly more than J sentences.
-
-This is the OPPOSITE of what [mitrovic-sauerland-2016] + Transparency Principle predicts.
-The prediction was that J-MU (most transparent) should be EASIEST.
-
-Negative estimate means J < J-MU in replay count (J-MU harder).
--/
-theorem georgian_child_jmu_harder_than_j :
-    georgianChild_j_vs_jmu.significant = true ∧ georgianChild_j_vs_jmu.estimate_thou < 0 := by
-  native_decide
-
-/--
-Georgian children replayed J-MU sentences significantly more than MU sentences.
-
-Positive estimate means J-MU > MU in replay count (J-MU harder).
--/
-theorem georgian_child_jmu_harder_than_mu :
-    georgianChild_jmu_vs_mu.significant = true ∧ georgianChild_jmu_vs_mu.estimate_thou > 0 := by
-  native_decide
-
-/--
-No significant difference between J and MU for Georgian children.
-
-NOTE: This is a null result (p = .067, marginal). We record the
-non-significance but do NOT assert that J and MU are equally difficult.
--/
-theorem georgian_child_j_vs_mu_not_significant :
-    georgianChild_j_vs_mu.significant = false := by
-  native_decide
-
--- The Prediction and Its Failure
-
-/--
-The Transparency Principle:
-Learning is easier for overt and unambiguous (1-to-1) form-meaning mappings
-than for covert and/or conflated (many-to-1) mappings.
--/
-def transparencyPredicts (s1 s2 : ConjunctionStrategy) : Bool :=
-  s1.overtMorphemeCount > s2.overtMorphemeCount
-
-/--
-[mitrovic-sauerland-2016] + Transparency Principle predicts J-MU is more transparent
-than both J-only and MU-only.
--/
-theorem jmu_predicted_most_transparent :
-    transparencyPredicts .jMu .jOnly = true ∧
-    transparencyPredicts .jMu .muOnly = true := by
-  native_decide
-
-/--
-The Georgian sentence-played-n data contradicts this prediction:
-J-MU was HARDER (more replays), not easier.
-The significant pairwise comparisons go in the wrong direction.
--/
-theorem georgian_contradicts_transparency :
-    -- The prediction says J-MU should be easier (fewer replays)
-    transparencyPredicts .jMu .jOnly = true ∧
-    -- But the data shows J-MU required MORE replays (negative estimate = J < J-MU)
-    georgianChild_j_vs_jmu.estimate_thou < 0 := by
-  native_decide
-
--- Connection to Form-Meaning Correspondences
-
-/-!
-## Link to form-meaning correspondences (`Studies/Haslinger2025.lean`)
-
-The Transparency Principle is the acquisition-side counterpart of
-the No Needless Manner Violations principle formalized in
-`Studies/Haslinger2025.lean`.
-
-Both principles relate form complexity to meaning:
-- NNMV: More complex form → more precise meaning
-- Transparency: More overt form-meaning mapping → easier acquisition
-
-The `andBoth` datum in `Studies/Haslinger2025.lean` is particularly relevant:
-"Ann and Bert" (J-only) vs "both Ann and Bert" (≈ J+MU).
-"Both" adds precision (removes homogeneity gap) — it's arguably an
-overt realization of MU/distributivity, paralleling the J-MU strategy.
-
-Bill et al.'s finding complicates this picture: in Georgian, adding
-overt MU+J (maximum transparency) made comprehension HARDER, suggesting
-that morphological complexity can outweigh transparency benefits.
--/
-
--- Connection to Additive Particles
-
-/-!
-## Link to additive particles
-
-Japanese "mo", the additive particle ("also, too", attached to NP),
-is the canonical MU particle in Mitrović & Sauerland's framework.
-In conjunction, "mo...mo" = MU-only strategy:
-
-  Taroo-mo Hanako-mo neta
-  Taro-MU Hanako-MU slept
-  "Both Taro and Hanako slept"
-
-Similarly, Hungarian "is" and Georgian "-c" serve as both additive
-particles and conjunction MU particles — unifying two phenomena
-under a single morpheme.
--/
-
--- ============================================================================
--- § Montague Conjunction Grounding
--- ============================================================================
-
-/-!
-## Semantic Decomposition ([mitrovic-sauerland-2016])
-
-The M&S decomposition maps onto operations in Montague/Conjunction.lean:
-
-| M&S piece | Semantic operation | Conjunction.lean |
-|-----------|-------------------|-----------------|
-| ☉         | {x} formation     | `msShift` (= Partee's `ident`) |
-| MU        | INCL (subset)     | `individual` (structural `abbrev`) |
-| J         | Set intersection  | `genConj` at GQ type |
-
-MU IS `individual` — the identity is structural (an `abbrev`), not a
-theorem. `coordEntities` is defined AS `genConj(individual e₁, individual e₂)`,
-so the M&S derivation is the definition itself. The result
-P(e₁) ∧ P(e₂) equals Link's `distMaximal P {e₁, e₂}`
-(`mu_is_distributive_check`).
--/
+open Syntax.Coordination Haspelmath2007 MitrovicSauerland2016
+
+/-- Both test languages attest all three strategies, the precondition of the test ((1),
+(2)). -/
+theorem both_have_all_three :
+    hasAllThreeStrategies georgian ∧ hasAllThreeStrategies hungarian := by
+  decide
+
+/-! ### The prediction -/
+
+/-- The pieces of the three-piece decomposition a strategy leaves unpronounced: the
+Transparency Principle's measure of comprehension difficulty (3). -/
+def covertPieces (s : ConjunctionStrategy) : ℕ :=
+  ConjunctionStrategy.semanticPieceCount - s.overtMorphemeCount
+
+/-- The decomposition with the Transparency Principle predicts the fully overt *j-mu*
+expressions easiest (4). -/
+theorem transparency_prediction :
+    covertPieces .jMu < covertPieces .jOnly ∧ covertPieces .jMu < covertPieces .muOnly := by
+  decide
+
+/-- The pieces of the rival structures: a lone *j* for *j* expressions, a *j* with two
+*mu*s for *mu* and *j-mu* expressions (Figure 1). -/
+def structuralPieces : ConjunctionStrategy → ℕ
+  | .jOnly => 1
+  | .muOnly => 3
+  | .jMu => 3
+
+/-! ### The finding -/
+
+/-- The significant contrasts in Georgian children's replay counts (Table 3): *j-mu*
+sentences were harder than *j* and than *mu* sentences, and *j* and *mu* did not differ. -/
+def georgianHarder : ConjunctionStrategy → ConjunctionStrategy → Prop
+  | .jMu, .jOnly => True
+  | .jMu, .muOnly => True
+  | _, _ => False
+
+/-- The harder expressions were the more transparent ones: the prediction is reversed. -/
+theorem georgian_contradicts_transparency (s t : ConjunctionStrategy) (h : georgianHarder s t) :
+    covertPieces s < covertPieces t := by
+  cases s <;> cases t <;> simp [georgianHarder] at h <;> decide
+
+/-- The rival structures equate *mu* and *j-mu*, which the Georgian children split. -/
+theorem georgian_contradicts_structural :
+    ∃ s t, georgianHarder s t ∧ structuralPieces s = structuralPieces t :=
+  ⟨.jMu, .muOnly, trivial, rfl⟩
+
+/-! ### The desiderata -/
+
+/-- The paper's conditions on a complexity measure: *j-mu* more complex than *j* and than
+*mu*, and *j* and *mu* equally complex. -/
+def Desiderata (c : ConjunctionStrategy → ℕ) : Prop :=
+  c .jOnly < c .jMu ∧ c .muOnly < c .jMu ∧ c .jOnly = c .muOnly
+
+instance (c : ConjunctionStrategy → ℕ) : Decidable (Desiderata c) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
+
+theorem covertPieces_not_desiderata : ¬ Desiderata covertPieces := by decide
+
+theorem structuralPieces_not_desiderata : ¬ Desiderata structuralPieces := by decide
+
+/-- The third desideratum's morphological route: Georgian *mu* is a bound clitic where
+Hungarian *mu* is free, the difference the paper suggests may make Hungarian *mu* the less
+complex. -/
+theorem mu_kind_differs :
+    georgian.muKind = some (.bound .after .clitic) ∧ hungarian.muKind = some .free := by
+  decide
+
+/-! ### The decomposition -/
 
 open Intensional.Conjunction in
 open Quantification (individual) in
-/--
-Type-raising an entity and checking subset inclusion of its singleton
-is equivalent to applying the predicate directly.
-
-This is the core of the M&S decomposition: the roundtrip through
-☉ + MU + J recovers ordinary conjunction semantics.
--/
-theorem individual_incl_reduces {E : Type} (e : E) (p : E → Prop) :
-    individual (α := E) e p = p e := rfl
-
-open Intensional.Conjunction in
-open Quantification (individual) in
-/--
-Full M&S derivation: "DP₁ and DP₂ VP" via ☉ + MU + J
-yields the same result as Partee & Rooth's `coordEntities`.
--/
-theorem ms_decomposition_eq_coord {E W : Type} (e1 e2 : E)
-    (p : E → Prop) :
+/-- The decomposition — singleton shift, subset, intersection — is the substrate's
+`coordEntities`, so *DP₁ and DP₂ VP* comes out as `VP(DP₁) ∧ VP(DP₂)` (Figure 2). -/
+theorem ms_decomposition_eq_coord {E W : Type} (e1 e2 : E) (p : E → Prop) :
     (individual (α := E) e1 p ∧ individual (α := E) e2 p) =
-      coordEntities (E := E) (W := W) e1 e2 p := rfl
+      coordEntities (E := E) (W := W) e1 e2 p :=
+  rfl
 
--- ============================================================================
--- § MU ↔ Distributivity: The Root Explanation
--- ============================================================================
-
-/-!
-## MU IS Distributive Predication
-
-The M&S decomposition and Link's distributive inference are the same
-operation. Both reduce to: check a predicate against each entity
-individually and conjoin.
-
-| Framework | Operation | Result |
-|-----------|-----------|--------|
-| M&S       | J(individual(e₁), individual(e₂))(P) | P(e₁) ∧ P(e₂) |
-| Link      | distMaximal P {e₁, e₂} w | P(e₁) ∧ P(e₂) |
-
-The M&S side is structural: `coordEntities` IS `genConj(individual e₁,
-individual e₂)` by definition, and MU IS `individual` by `abbrev`.
-The Link side is independently structural: `distMaximal` IS
-`decide (∀ a ∈ x, P a w)`.
-
-The theorem below bridges the two type systems (Montague `Frame.Entity`
-vs `Finset Atom`). This bridge can't be made structural — the types
-are different — but it proves the same operation is being computed.
-
-This explains WHY MU particles are universally additive particles
-(`mu_additive_generalization`): additive "also/too" IS the distributive
-check on a single atom (`individual e P = P e = distMaximal P {e}`).
-Conjunction is the two-atom case. Link's `distr_atom_part` is the
-general case for arbitrary pluralities.
--/
-
-section MUDistributivity
-
-open Intensional.Conjunction
-open Quantification (individual)
-open Semantics.Plurality
-open Semantics.Plurality.Distributivity
-
-/--
-M&S conjunction = Link's distributive predication for pairs.
-
-`coordEntities e₁ e₂ P = distMaximal (fun a _ => P a) {e₁, e₂} ()`
-
-Both sides compute `P(e₁) ∧ P(e₂)`:
-- LHS by definition (`coordEntities` = `genConj(individual e₁, individual e₂)`)
-- RHS by `distMaximal_pair`
-
-This can't be an `abbrev` — the types are different (Montague
-`Frame.Entity` vs `Finset Atom`). The theorem is the right tool
-for cross-theory unification.
--/
+open Intensional.Conjunction in
+open Quantification (individual) in
+open Semantics.Plurality in
+open Semantics.Plurality.Distributivity in
+/-- The decomposition is distributive predication over the pair of conjuncts. -/
 theorem mu_is_distributive_check {E W : Type} [DecidableEq E]
     (e1 e2 : E) (P : E → Unit → Prop) [∀ a u, Decidable (P a u)] :
     coordEntities (E := E) (W := W) e1 e2 (fun a => P a ()) ↔
     distMaximal P {e1, e2} () := by
   simp [coordEntities_both_satisfy, distMaximal_pair]
-
-end MUDistributivity
-
--- ============================================================================
--- § Typological Challenges
--- ============================================================================
-
-open Haspelmath2007 (georgian hungarian) in
-open MitrovicSauerland2016 (hasAllThreeStrategies) in
-/--
-**M&S universality challenged.**
-
-Georgian has all three strategies (J-only, MU-only, J-MU).
-M&S + Transparency predicts J-MU should be easiest (most transparent).
-But Georgian children found J-MU significantly harder (more replays).
--/
-theorem ms_universality_challenged :
-    hasAllThreeStrategies georgian ∧
-    transparencyPredicts .jMu .jOnly = true ∧
-    georgianChild_j_vs_jmu.significant = true ∧
-    georgianChild_j_vs_jmu.estimate_thou < 0 := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
-
-open Haspelmath2007 (georgian hungarian) in
-open Syntax.Coordination (ConjunctionSystem.muKind) in
-/--
-**The bound-status confound.**
-
-Georgian MU (-c) is bound; Hungarian MU (is) is free. Hungarian children
-showed no significant sentence-type effect on either accuracy or replays.
-This raises the possibility that morphological bound status — not the M&S
-decomposition itself — drives the Georgian difficulty.
-
-If bound status is the real factor, then M&S categories (J, MU, J-MU) are
-not the right level of analysis for acquisition predictions.
--/
-theorem bound_status_confound :
-    -- Georgian MU is a bound enclitic, Hungarian MU is free
-    georgian.muKind = some (.bound .after .clitic) ∧
-    hungarian.muKind = some .free ∧
-    -- Georgian children found J-MU significantly harder
-    georgianChild_j_vs_jmu.significant = true ∧
-    -- Hungarian: no significant sentence-type effect on replays
-    (hungarianSentencePlayedLRT.filter
-      (·.effect == "sentence")).all (·.significant == false) = true := by
-  native_decide
 
 end BillEtAl2025

--- a/references.bib
+++ b/references.bib
@@ -3832,6 +3832,20 @@
   doi       = {10.3765/sp.18.5},
   subfield  = {semantics/compositional},
   validated = {true},
+  role      = {formalized},
+  sources   = {Studies/BillEtAl2025.lean}
+}
+@inproceedings{van-hout-1998,
+  author    = {van Hout, Angeliek},
+  year      = {1998},
+  title     = {On the Role of Direct Objects and Particles in Learning Telicity in {Dutch} and {English}},
+  booktitle = {Proceedings of the 22nd Annual Boston University Conference on Language Development},
+  editor    = {Greenhill, Annabel and Hughes, Mary and Littlefield, Heather and Walsh, Hugh},
+  volume    = {2},
+  pages     = {397--408},
+  publisher = {Cascadilla Press},
+  address   = {Somerville, MA},
+  subfield  = {acquisition},
   role      = {cited},
   sources   = {Studies/BillEtAl2025.lean}
 }% ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Recut against the S&P article. Deletes the `Float` correlations, hand-typed LRT/pairwise/accuracy tables (some "approximate from Figure 4") with their `native_decide` readers, and `String`-field particle records duplicating the Georgian/Hungarian fragments. What remains is the paper's argument: the transparency measure derived from the substrate's piece counts predicts *j-mu* easiest, the rival structural measure equates *mu* and *j-mu*, the Georgian contrasts (Table 3) reverse the first and split the second, and §4's desiderata are a predicate both measures provably fail. 609 → 145 lines.

- bib: `bill-etal-2025` role → formalized; `van-hout-1998` (Transparency Principle) added from the paper's reference list.