### PR TITLE
refactor(Studies/BonamiStump2016): name the chapter's predictions, drop vacuous cores bridge

### DIFF
--- a/Linglib/Studies/BonamiStump2016.lean
+++ b/Linglib/Studies/BonamiStump2016.lean
@@ -1,78 +1,94 @@
 import Linglib.Morphology.Paradigm.Function
-import Linglib.Morphology.Root.Certificates
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# PFM1 worked fragments: Icelandic verbs and Sanskrit nominals
-[bonami-stump-2016] [stump-2001] [kiparsky-1973]
+# Bonami and Stump 2016: Paradigm Function Morphology
 
-Worked fragments for the PFM1 engine of `Morphology/Paradigm/Function.lean`,
-transcribing [bonami-stump-2016]'s own examples.
+This file formalizes the worked PFM1 fragments of [bonami-stump-2016] on the engine of
+`Morphology/Paradigm/Function.lean`: the finite paradigm of four Icelandic verbs (rules of basic
+stem choice, three blocks of rules of exponence, the Identity Function Default), the Sanskrit
+ninth-conjugation portmanteau with the Function Composition Default, and the Sanskrit vocative
+rule of referral.
 
-* **Icelandic verbs** (their Table 17.1/17.3): the paradigm function derives
-  `PF(⟨KALLA, {ind pst 2sg}⟩) = kallaðir` by pure suffixation `-a`, `-ði`, `-r`
-  through Blocks I–III. Basic stem choice resolves the `greip`/`grip`/`gríp`
-  conflict for `GRÍPA` by narrowness (the three-cell rule beats the twelve- and
-  twenty-seven-cell rules); a strong verb's Block I falls through to the
-  Identity Function Default. Umlaut (`kall` ~ `köll`) and the other
-  morphophonological metageneralizations are phonological substance and are not
-  modelled here, so only umlaut-free cells are decided.
-* **Sanskrit** (their Table 17.5, (17)): the portmanteau `-āna` of a
-  consonant-final ninth-conjugation root overrides the `-nī`/`-hi` sequence,
-  while a vowel-final root defaults to their composition (the Function
-  Composition Default); the vocative refers to the nominative's Block-i
-  exponent (block-confined syncretism), a schematic case fragment.
+Morphophonological metageneralizations (umlaut, vowel loss, coalescence) are phonological
+substance outside the engine, so only cells they leave untouched are decided; the strong verbs'
+ablaut alternants enter as basic stems, as in the chapter.
 
-All predictions are `decide`-checked realized values; payload equality is never
-decided (payloads are form operations).
+## Main definitions
+
+* `iceStems`, `blockI`, `blockII`, `blockIII`, `pf` — the Icelandic rules of basic stem choice,
+  rules of exponence, and paradigm function
+* `blockNi`, `blockHi`, `blockAna` — the Sanskrit `-nī`, `-hi` and portmanteau `-āna` blocks
+* `caseBlock` — a Sanskrit case block with the vocative rule of referral
+
+## Main results
+
+* `pf_kalla`, `pf_gripa_imp`, `pf_fljuga`, `pf_gripa_pst` — the chapter's flagship realizations
+* `stem_gripa_pst` — narrowness resolves the `greip`/`grip`/`gríp` stem conflict
+* `blockIII_narrowness` — the three competing second-singular rules are strictly ordered
+* `as_portmanteau`, `kri_composition` — `-āna` overrides `-nī-hi`; a vowel-final root defaults
+  to the composition of Blocks ii and i
+* `voc_refers_to_nom` — the vocative dual takes the nominative dual's exponent
+
+## References
+
+* [bonami-stump-2016]
+* [stump-2001]
 -/
 
 namespace BonamiStump2016
 
 open Morphology Morphology.Exponence Morphology.PFM
 
-/-! ### Icelandic verbs (Table 17.1, Table 17.3) -/
+/-! ### Icelandic verbs -/
 
 section Icelandic
 
-/-- The four verbs of the fragment: `KALLA` weak.4.a, `ÆTLA` weak.4.b, `GRÍPA`
-strong.1.a, `FLJÚGA` strong.2.b. -/
+/-- The four verbs of Table 17.1: KALLA (weak.4.a), ÆTLA (weak.4.b), GRÍPA (strong.1.a),
+FLJÚGA (strong.2.b). -/
 inductive Verb | kalla | aetla | gripa | fljuga
   deriving DecidableEq, Fintype
 
-/-- Morphosyntactic features (decomposed: person and number separate). -/
+/-- Morphosyntactic properties; person and number are separate properties, as in the chapter's
+`{pst sg}`. -/
 inductive Feat | ind | sbjv | imp | prs | pst | p1 | p2 | p3 | sg | pl
   deriving DecidableEq, Fintype
 
 open Verb Feat
 
-/-- Weak conjugation 4 (here all weak verbs of the fragment). -/
+local notation "ExpoRule" => PFM.Rule Verb (Finset Feat) (Action String (Finset Feat))
+local notation "IFD" => (identityDefault : ExpoRule)
+
+/-- Weak conjugation 4. -/
 def weak : Finset Verb := {kalla, aetla}
 /-- Weak conjugation 4.b. -/
 def weak4b : Finset Verb := {aetla}
-/-- Strong conjugation. -/
+/-- The strong conjugations. -/
 def strong : Finset Verb := {gripa, fljuga}
 
-local notation "IFD" => (identityDefault : PFM.Rule Verb (Finset Feat) (Action String (Finset Feat)))
-
-/-- Block I: theme-vowel exponence ([bonami-stump-2016]'s Table 17.3). -/
+/-- Block I of Table 17.3: theme vowels. -/
 def blockI : Block Verb String (Finset Feat) :=
   [ ⟨weak, {pst, pl}, .const (· ++ "u")⟩,
     ⟨Finset.univ, {sbjv, prs}, .const (· ++ "i")⟩,
     ⟨weak, {}, .const (· ++ "a")⟩,
     IFD ]
 
-/-- Block II: past-tense exponence. -/
+/-- Block II of Table 17.3: past-tense exponence. -/
 def blockII : Block Verb String (Finset Feat) :=
   [ ⟨weak, {pst, sg}, .const (· ++ "ði")⟩,
     ⟨weak, {pst, pl}, .const (· ++ "ðu")⟩,
     IFD ]
 
-/-- Block III: agreement exponence. -/
+/-- The weak.4.b imperative `-ðu`. -/
+def weak4bImp : ExpoRule := ⟨weak4b, {imp, p2, sg}, .const (· ++ "ðu")⟩
+/-- The zero exponent of the second-singular imperative. -/
+def zeroImp : ExpoRule := ⟨Finset.univ, {imp, p2, sg}, .const id⟩
+/-- The general second-singular `-r`. -/
+def rSg2 : ExpoRule := ⟨Finset.univ, {p2, sg}, .const (· ++ "r")⟩
+
+/-- Block III of Table 17.3: agreement and mood exponence. -/
 def blockIII : Block Verb String (Finset Feat) :=
-  [ ⟨weak4b, {imp, p2, sg}, .const (· ++ "ðu")⟩,
-    ⟨Finset.univ, {imp, p2, sg}, .const id⟩,
-    ⟨Finset.univ, {p2, sg}, .const (· ++ "r")⟩,
+  [ weak4bImp, zeroImp, rSg2,
     ⟨Finset.univ, {ind, prs, p3, sg}, .const (· ++ "r")⟩,
     ⟨Finset.univ, {p1, pl}, .const (· ++ "um")⟩,
     ⟨Finset.univ, {p2, pl}, .const (· ++ "ið")⟩,
@@ -80,9 +96,7 @@ def blockIII : Block Verb String (Finset Feat) :=
     ⟨strong, {ind, pst, p2, sg}, .const (· ++ "st")⟩,
     IFD ]
 
-/-- Rules of basic stem choice ([bonami-stump-2016]'s (7)); the `GRÍPA` and
-`FLJÚGA` alternants list the umlaut/ablaut stems as data, not string
-operations. -/
+/-- Rules of basic stem choice (7); the strong verbs' ablaut alternants are listed as stems. -/
 def iceStems : List (PFM.Rule Verb (Finset Feat) String) :=
   [ ⟨{kalla}, {}, "kall"⟩,
     ⟨{aetla}, {}, "ætl"⟩,
@@ -95,115 +109,129 @@ def iceStems : List (PFM.Rule Verb (Finset Feat) String) :=
     ⟨{fljuga}, {ind, prs, sg}, "flýg"⟩,
     ⟨{fljuga}, {}, "fljúg"⟩ ]
 
-/-- Within one lexeme's paradigm the covert lexemic index is constant. -/
-def iceStem : Finset Feat → Verb := fun _ => kalla
+/-- The covert lexemic index (11): every stem in `v`'s paradigm is indexed `v`. -/
+def lindex (v : Verb) : String → Verb := fun _ => v
 
-/-- **Flagship** ([bonami-stump-2016]'s (4a), derived through (6)): the second
-person singular indicative past of `KALLA` is `kallaðir`, `kall` + `-a` + `-ði`
-+ `-r` through Blocks I–III. -/
-example :
-    paradigmFunction (fun _ => kalla) (stemChoiceOf iceStems (fun _ => ""))
-      [blockI, blockII, blockIII] (kalla, {ind, pst, p2, sg})
-      = ("kallaðir", {ind, pst, p2, sg}) := by decide
+/-- The Icelandic paradigm function (13): basic stem choice, then Blocks I–III. -/
+def pf (v : Verb) (σ : Finset Feat) : String × Finset Feat :=
+  paradigmFunction (lindex v) (stemChoiceOf iceStems (fun _ => "")) [blockI, blockII, blockIII]
+    (v, σ)
 
-/-- **Stem-choice narrowness** ([bonami-stump-2016]'s discussion of (7)): at
-`⟨GRÍPA, {ind pst 1sg}⟩` the three-cell rule for `greip` overrides the
-twelve-cell `grip` and twenty-seven-cell `gríp` rules. -/
-example : stemChoiceOf iceStems (fun _ => "") (gripa, {ind, pst, p1, sg}) = "greip" := by decide
+/-- (4a): `kallaðir`, derived by (6) as `kall` + `-a` + `-ði` + `-r`. -/
+theorem pf_kalla : pf kalla {ind, pst, p2, sg} = ("kallaðir", {ind, pst, p2, sg}) := by decide
 
-/-- **Identity Function Default fires**: a strong verb's Block I has no
-applicable exponence rule, so the IFD leaves the stem unchanged
-(`gríp`, first singular present indicative of `GRÍPA`). -/
-example : evalBlock (fun _ => gripa) blockI ("gríp", {ind, prs, p1, sg})
+/-- (4c): the bare imperative `gríp` — the IFD fires in Blocks I and II, and the zero imperative
+exponent preempts `-r` in Block III. -/
+theorem pf_gripa_imp : pf gripa {imp, p2, sg} = ("gríp", {imp, p2, sg}) := by decide
+
+/-- (4d): `flaug`, the narrowest stem-choice rule for FLJÚGA followed by the IFD in every block. -/
+theorem pf_fljuga : pf fljuga {ind, pst, p1, sg} = ("flaug", {ind, pst, p1, sg}) := by decide
+
+/-- Table 17.1: the strong second-singular past `greipst`, the strong-verb rule preempting `-r`. -/
+theorem pf_gripa_pst : pf gripa {ind, pst, p2, sg} = ("greipst", {ind, pst, p2, sg}) := by decide
+
+/-- The conflict among (7c)–(7e) at `⟨GRÍPA, {ind pst 1sg}⟩` resolves to the three-cell rule. -/
+theorem stem_gripa_pst :
+    stemChoiceOf iceStems (fun _ => "") (gripa, {ind, pst, p1, sg}) = "greip" := by decide
+
+/-- A strong verb's Block I has no applicable rule of exponence, so the IFD leaves the stem. -/
+theorem blockI_gripa : evalBlock (lindex gripa) blockI ("gríp", {ind, prs, p1, sg})
     = ("gríp", {ind, prs, p1, sg}) := by decide
 
-/-- **The Icelandic PFM inventory is atomic-total**: as a `Realization`, the
-paradigm function realizes every cell (`paradigmRealization_isTotal`) with a
-single form (`_isUnivalent`), and under the stem projection every cell exposes
-a nonempty core — the lexeme-index stratum certified by
-`Morphology.Root.HasNonemptyCores`. -/
-theorem iceParadigm_hasNonemptyCores :
-    Morphology.Root.HasNonemptyCores
-      (paradigmRealization (fun _ => kalla) (stemChoiceOf iceStems (fun _ => ""))
-        [blockI, blockII, blockIII])
-      (fun w => {w.1}) :=
-  Morphology.Root.hasNonemptyCores_of_extract_nonempty _ _
-    (fun _ => Finset.singleton_nonempty _)
+/-- The example of (14): `[iii : ⟨ætla, {imp 2sg}⟩] = ⟨ætlaðu, σ⟩`. -/
+theorem nar_aetla_imp : evalBlock (lindex aetla) blockIII ("ætla", {imp, p2, sg})
+    = ("ætlaðu", {imp, p2, sg}) := by decide
+
+/-- The example of (15): the weak.4.b `-ðu` is narrower than the zero imperative, which is
+narrower than `-r`. -/
+theorem blockIII_narrowness : weak4bImp < zeroImp ∧ zeroImp < rSg2 := by decide
 
 end Icelandic
 
-/-! ### Sanskrit portmanteau and Function Composition Default (Table 17.5) -/
+/-! ### Sanskrit portmanteau and the Function Composition Default -/
 
-section SanskritPortmanteau
+section Portmanteau
 
-/-- Two ninth-conjugation roots: `AŚ` (consonant-final), `KRĪ` (vowel-final). -/
-inductive Root | as | kri
+/-- Two ninth-conjugation verbs: consonant-final AŚ 'eat' and vowel-final KRĪ 'buy'. -/
+inductive NinthVerb | as | kri
   deriving DecidableEq, Fintype
 
-/-- Features of the second-person singular imperative active. -/
+/-- Properties of the second-person singular imperative active. -/
 inductive SF | p2 | sg | imp | act
   deriving DecidableEq, Fintype
 
-open Root SF
+open NinthVerb SF
 
-/-- Block i: ninth-conjugation `-nī` ([bonami-stump-2016]'s (20a)). -/
-def blockNi : Block Root String (Finset SF) :=
+/-- Block i, (20a): ninth-conjugation `-nī`. -/
+def blockNi : Block NinthVerb String (Finset SF) :=
   [ ⟨Finset.univ, {}, .const (· ++ "nī")⟩ ]
 
-/-- Block ii: subject-agreement `-hi` ([bonami-stump-2016]'s (20b)). -/
-def blockHi : Block Root String (Finset SF) :=
+/-- Block ii, (20b): second-singular imperative active `-hi`. -/
+def blockHi : Block NinthVerb String (Finset SF) :=
   [ ⟨Finset.univ, {p2, sg, imp, act}, .const (· ++ "hi")⟩ ]
 
-/-- Portmanteau Block [ii,i]: consonant-final `-āna` ([bonami-stump-2016]'s
-(20c)); consonant-finality is carried by the singleton class `{AŚ}`. -/
-def blockAna : Block Root String (Finset SF) :=
+/-- Block [ii,i], (20c): `-āna` after a consonant-final root, consonant-finality carried by the
+class `{AŚ}`. -/
+def blockAna : Block NinthVerb String (Finset SF) :=
   [ ⟨{as}, {p2, sg, imp, act}, .const (· ++ "āna")⟩ ]
 
-/-- The consonant-final root `AŚ` takes the portmanteau `-āna`, overriding the
-`-nī`/`-hi` sequence ([bonami-stump-2016]'s (22)). -/
-example : evalPortmanteau (fun _ => as) blockAna blockHi blockNi ("aś", {p2, sg, imp, act})
-    = ("aśāna", {p2, sg, imp, act}) := by decide
+/-- (21) at (22): AŚ takes the portmanteau `-āna` (Table 17.5). -/
+theorem as_portmanteau :
+    evalPortmanteau (fun _ => as) blockAna blockHi blockNi ("aś", {p2, sg, imp, act})
+      = ("aśāna", {p2, sg, imp, act}) := by decide
 
-/-- The vowel-final root `KRĪ` has no portmanteau rule, so Block [ii,i] defaults
-to the composition of Blocks ii and i (the Function Composition Default),
-yielding `krīnīhi` ([bonami-stump-2016]'s (23)). -/
-example : evalPortmanteau (fun _ => kri) blockAna blockHi blockNi ("krī", {p2, sg, imp, act})
-    = ("krīnīhi", {p2, sg, imp, act}) := by decide
+/-- No portmanteau rule applies at (23). -/
+theorem kri_no_portmanteau : applicable blockAna (kri, ({p2, sg, imp, act} : Finset SF)) = [] :=
+  rfl
 
-end SanskritPortmanteau
+/-- (23): Block [ii,i] defaults to the composition of Blocks ii and i, the Function Composition
+Default (24). -/
+theorem kri_fcd :
+    evalPortmanteau (fun _ => kri) blockAna blockHi blockNi ("krī", {p2, sg, imp, act})
+      = evalBlock (fun _ => kri) blockHi
+          (evalBlock (fun _ => kri) blockNi ("krī", {p2, sg, imp, act})) :=
+  evalPortmanteau_eq_comp_of_not_applies _ _ _ _ _ kri_no_portmanteau
 
-/-! ### Sanskrit vocative referral (schematic, (17)) -/
+/-- Table 17.5: `krīnīhi`. -/
+theorem kri_composition :
+    evalPortmanteau (fun _ => kri) blockAna blockHi blockNi ("krī", {p2, sg, imp, act})
+      = ("krīnīhi", {p2, sg, imp, act}) := by decide
 
-section SanskritReferral
+end Portmanteau
 
-/-- A schematic nominal declension. -/
+/-! ### Sanskrit vocative referral -/
+
+section Referral
+
+/-- The neuter a-stem DĀNA 'gift' of Table 17.2. -/
 inductive Noun | dana
   deriving DecidableEq, Fintype
 
-/-- Case and number features. -/
+/-- Case and number properties. -/
 inductive NF | nom | voc | du
   deriving DecidableEq, Fintype
 
 open Noun NF
 
-/-- Retarget a vocative property set to the corresponding nominative. -/
-def vocToNom (σ : Finset NF) : Finset NF := insert nom (σ.erase voc)
+/-- `σ/{nom}` of (17): the property set like `σ` but nominative. -/
+def toNom (σ : Finset NF) : Finset NF := insert nom (σ.erase voc)
 
-/-- The case block: a nominative exponence rule and a vocative rule of referral
-([bonami-stump-2016]'s (17)), the referral re-consulting the block at the
-nominative cell. -/
+/-- Block i: a nominative exponent and the vocative rule of referral (17), which re-consults the
+block at the nominative cell. -/
 def caseBlock : Block Noun String (Finset NF) :=
   [ ⟨Finset.univ, {nom}, .const (· ++ "e")⟩,
-    ⟨Finset.univ, {voc}, .referral vocToNom⟩ ]
+    ⟨Finset.univ, {voc}, .referral toNom⟩ ]
 
-/-- The vocative dual takes the nominative dual's Block-i exponent: a
-block-confined syncretism (`dāne`), distinct from a whole-word paradigm-function
-clause. -/
-example : evalBlock (fun _ => dana) caseBlock ("dān", {voc, du}) = ("dāne", {voc, du}) := by decide
+/-- The vocative dual takes the nominative dual's exponent: a syncretism confined to Block i,
+unlike the whole-word clause (5). -/
+theorem voc_refers_to_nom :
+    (evalBlock (fun _ => dana) caseBlock ("dān", {voc, du})).1
+      = (evalBlock (fun _ => dana) caseBlock ("dān", {nom, du})).1 := by decide
 
-/-- The nominative dual it refers to. -/
-example : evalBlock (fun _ => dana) caseBlock ("dān", {nom, du}) = ("dāne", {nom, du}) := by decide
+/-- Table 17.2: the vocative dual `dāne`. -/
+theorem voc_du : evalBlock (fun _ => dana) caseBlock ("dān", {voc, du}) = ("dāne", {voc, du}) := by
+  decide
 
-end SanskritReferral
+end Referral
 
 end BonamiStump2016

--- a/references.bib
+++ b/references.bib
@@ -28455,7 +28455,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Morphology/TheorySpace.lean;Studies/KalinBjorkmanEtAl2026.lean;Morphology/Containment/Vocabulary.lean}
+  sources   = {Morphology/TheorySpace.lean;Studies/KalinBjorkmanEtAl2026.lean;Morphology/Containment/Vocabulary.lean;Studies/BonamiStump2016.lean}
 }
 @incollection{stump-2012-mmm8,
   author    = {Stump, Gregory T.},


### PR DESCRIPTION
Verified against the handbook chapter (Tables 17.1/17.3/17.5, (4)–(24)); all rules and locators matched. Turns the anonymous `example`s into named theorems — (4a/c/d) plus the strong 2sg past, the (7) stem conflict, the (14) Nar example, and the (15) narrowness chain as a `<`-chain on the three Block III rules — and derives the KRĪ case from `evalPortmanteau_eq_comp_of_not_applies` rather than only deciding its string. Deletes the dead `iceStem` and the `HasNonemptyCores` certificate, which held for any singleton stem projection and said nothing about Icelandic. Module docstring in mathlib register.