### PR TITLE
refactor(Semantics): dissolve umbrella namespace prefixes

### DIFF
--- a/Linglib/Discourse/Commitment/SourceMarked.lean
+++ b/Linglib/Discourse/Commitment/SourceMarked.lean
@@ -39,7 +39,7 @@ namespace Discourse.Gunlogson
 
 open Discourse.Commitment
 open Discourse (DiscourseRole)
-open Semantics.Questions.Bias (ContextualEvidence)
+open Questions.Bias (ContextualEvidence)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Gunlogson State

--- a/Linglib/Fragments/English/Conditionals.lean
+++ b/Linglib/Fragments/English/Conditionals.lean
@@ -16,7 +16,7 @@ language's X-marking exponent ([iatridou-2000], [von-fintel-iatridou-2023]).
 
 namespace English.Conditionals
 
-open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
+open _root_.Conditionals (ConditionalMarker ConditionalMarkerType)
 open Modality.Exclusion (XMarkingExponent)
 
 /-- English if: HC and PC conditional marker.

--- a/Linglib/Fragments/English/Distributives.lean
+++ b/Linglib/Fragments/English/Distributives.lean
@@ -27,9 +27,9 @@ contrast that blocks *each ten minutes* while allowing *every ten minutes*
 
 namespace English.Distributives
 
-open Semantics.Plurality
-open Semantics.Plurality.Distributivity
-open Semantics.Plurality.Trivalent
+open Plurality
+open Plurality.Distributivity
+open Plurality.Trivalent
 
 variable {Atom W : Type*} [DecidableEq Atom]
 

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -28,7 +28,7 @@ open Features
 open ArgumentStructure
 open Features.DegreeAchievement (DegreeAchievementScale)
 open Core.Order (Boundedness)
-open Semantics.Aspect.Incremental (VerbIncClass)
+open Aspect.Incremental (VerbIncClass)
 open ArgumentStructure
 open ArgumentStructure
 

--- a/Linglib/Fragments/German/Conditionals.lean
+++ b/Linglib/Fragments/German/Conditionals.lean
@@ -15,7 +15,7 @@ Conditional connectives in German and their HC/PC restrictions.
 
 namespace German.Conditionals
 
-open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
+open _root_.Conditionals (ConditionalMarker ConditionalMarkerType)
 
 /-- German falls: HC-only conditional marker.
 

--- a/Linglib/Fragments/German/Distributives.lean
+++ b/Linglib/Fragments/German/Distributives.lean
@@ -29,9 +29,9 @@ Theory definitions, never stipulating their own meaning functions.
 
 namespace German.Distributives
 
-open Semantics.Plurality
-open Semantics.Plurality.Distributivity
-open Semantics.Plurality.Trivalent
+open Plurality
+open Plurality.Distributivity
+open Plurality.Trivalent
 
 variable {Atom W : Type*} [DecidableEq Atom]
 

--- a/Linglib/Fragments/German/PolarityMarking.lean
+++ b/Linglib/Fragments/German/PolarityMarking.lean
@@ -18,7 +18,7 @@ German's strategy is non-particulate.
 
 ## Cross-Module Connections
 
-- `Semantics.Questions.VerumFocus`: VERUM in questions — a
+- `Questions.VerumFocus`: VERUM in questions — a
   different phenomenon from the declarative Verum focus encoded here
 - `German.Particles`: German *denn* (question-flavoring)
 

--- a/Linglib/Fragments/Hungarian/Reciprocals.lean
+++ b/Linglib/Fragments/Hungarian/Reciprocals.lean
@@ -45,8 +45,8 @@ construction types, while reflexives require morphosyntactic plurality
 namespace Hungarian.Reciprocals
 
 open Pronoun
-open Semantics.Reference.Reciprocals
-open Semantics.Reference.PluralityLicensing
+open Reference.Reciprocals
+open Reference.PluralityLicensing
 
 /-- *egymás* — reciprocal pronoun 'each other'.
     Morphologically invariable: no φ-feature inflection.

--- a/Linglib/Fragments/Japanese/Conditionals.lean
+++ b/Linglib/Fragments/Japanese/Conditionals.lean
@@ -19,7 +19,7 @@ Conditional morphemes in Japanese and their HC/PC restrictions.
 
 namespace Japanese.Conditionals
 
-open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
+open _root_.Conditionals (ConditionalMarker ConditionalMarkerType)
 open Modality.Exclusion (XMarkingExponent)
 
 /-- Japanese -ra / -tara: HC-only conditional marker.

--- a/Linglib/Fragments/Mandarin/AspectComparison.lean
+++ b/Linglib/Fragments/Mandarin/AspectComparison.lean
@@ -18,14 +18,14 @@ guo has no such presupposition.
 
 ## Cross-Module Connections
 
-- `Semantics.Aspect`: ATOM-DIST and antiAtomDistLicensed
+- `Aspect`: ATOM-DIST and antiAtomDistLicensed
 - `Mandarin.Particles`: existing Mandarin particle pattern
 
 -/
 
 namespace Mandarin.AspectComparison
 
-open Semantics.Aspect
+open Aspect
 
 -- ════════════════════════════════════════════════════
 -- § 1. Cross-Domain Particle Entries

--- a/Linglib/Fragments/Mandarin/Conditionals.lean
+++ b/Linglib/Fragments/Mandarin/Conditionals.lean
@@ -18,7 +18,7 @@ Conditional morphemes in Mandarin and their properties.
 
 namespace Mandarin.Conditionals
 
-open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
+open _root_.Conditionals (ConditionalMarker ConditionalMarkerType)
 
 /-- Mandarin ruguo (如果): general-purpose conditional marker.
 

--- a/Linglib/Fragments/Mandarin/Resultatives.lean
+++ b/Linglib/Fragments/Mandarin/Resultatives.lean
@@ -22,7 +22,7 @@ dǎo 倒, wán 完, hǎo 好, diào 掉, zhù 住.
 
 - `Causation.Resultatives`: `ResultativeRealization`,
   `ResultOrientation`
-- `Semantics.Aspect.ChangeOfState`: `CoSType`
+- `Aspect.ChangeOfState`: `CoSType`
 - `Tay2024`: thesis-specific theorems and analysis that import this Fragment
 
 `PhaseComplement` (the closed-class V2 morpheme enum) lives here rather

--- a/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/VerbClasses.lean
@@ -49,7 +49,7 @@ Status marking encodes both viewpoint aspect and modal assertiveness
 
 namespace Yukatek
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open ArgumentStructure.EventStructure (EventType InternalExternalCause)
 open Mayan (MarkerSet)
 

--- a/Linglib/Fragments/Slavic/Serbian/TemporalConnectives.lean
+++ b/Linglib/Fragments/Slavic/Serbian/TemporalConnectives.lean
@@ -26,7 +26,7 @@ PFV/IMPF opposition rather than Tagalog's finer-grained system.
 
 namespace Serbian.TemporalConnectives
 
-open Semantics.Aspect
+open Aspect
 open English.TemporalExpressions (Reading TemporalExprEntry ComplementType)
 
 -- ============================================================================

--- a/Linglib/Fragments/Tagalog/TemporalConnectives.lean
+++ b/Linglib/Fragments/Tagalog/TemporalConnectives.lean
@@ -22,7 +22,7 @@ overt aspect markers in Tagalog.
 
 namespace Tagalog.TemporalConnectives
 
-open Semantics.Aspect
+open Aspect
 open English.TemporalExpressions (Reading TemporalExprEntry ComplementType)
 
 -- ============================================================================

--- a/Linglib/Pragmatics/Emotion.lean
+++ b/Linglib/Pragmatics/Emotion.lean
@@ -251,7 +251,7 @@ inferred preferences and updated beliefs. This connects counterfactual
 *appraisal* (utility comparison) to counterfactual *reasoning* (how
 likely was the alternative?) — bridging `counterfactualAppraisal` here
 with the counterfactual conditional semantics in
-`Semantics.Conditionals.Counterfactual`. -/
+`Conditionals.Counterfactual`. -/
 def weightedCounterfactualAppraisal (utility : W → A → F)
     (altProb : F) (actualAction altAction : A) (world : W) : F :=
   altProb * (utility world altAction - utility world actualAction)

--- a/Linglib/Semantics/Aspect/AtomDist.lean
+++ b/Linglib/Semantics/Aspect/AtomDist.lean
@@ -26,7 +26,7 @@ The `antiAtomDistLicensed` predicate is the licensing condition for
 Mandarin perfective particles in [zhao-2025] (le, méi-yǒu).
 -/
 
-namespace Semantics.Aspect
+namespace Aspect
 
 
 /-- An event quantifier: a predicate on event predicates.
@@ -77,4 +77,4 @@ def ofPred {Event : Type*} (P : Event → Prop) : EvQuant Event :=
 
 end EvQuant
 
-end Semantics.Aspect
+end Aspect

--- a/Linglib/Semantics/Aspect/Basic.lean
+++ b/Linglib/Semantics/Aspect/Basic.lean
@@ -55,7 +55,7 @@ import Linglib.Semantics.Events.Basic
 -- § Main Module
 -- ════════════════════════════════════════════════════
 
-namespace Semantics.Aspect
+namespace Aspect
 
 open _root_.Intensional (Index)
 open Features
@@ -602,4 +602,4 @@ theorem perf_prog_entails_universal_at_point (P : W → Event Time → Prop) (w 
 def IntervalPred.atPoint (p : IntervalPred W Time) : PointPred W Time :=
   λ s => p s.world (NonemptyInterval.pure s.time)
 
-end Semantics.Aspect
+end Aspect

--- a/Linglib/Semantics/Aspect/Boundedness.lean
+++ b/Linglib/Semantics/Aspect/Boundedness.lean
@@ -15,7 +15,7 @@ cumulative) lets the licensing pipeline classify boundedness uniformly
 with other scale-style properties.
 -/
 
-namespace Semantics.Aspect
+namespace Aspect
 
 /-- Aspectual boundedness of a situation.
 
@@ -48,4 +48,4 @@ theorem bounded_licensed :
 theorem unbounded_blocked :
     ¬ Core.Order.LicensingPipeline.IsLicensed SituationBoundedness.unbounded := id
 
-end Semantics.Aspect
+end Aspect

--- a/Linglib/Semantics/Aspect/Composition.lean
+++ b/Linglib/Semantics/Aspect/Composition.lean
@@ -31,7 +31,7 @@ temporal feature clashes with the verb constellation's, the adverbial wins.
 
 -/
 
-namespace Semantics.Aspect.Composition
+namespace Aspect.Composition
 
 open Features
 open _root_ (MassCount)
@@ -204,4 +204,4 @@ theorem override_agrees_with_shift :
 theorem achievement_durative_is_accomplishment :
     (overrideDuration achievementProfile .durative).toVendlerClass = .accomplishment := rfl
 
-end Semantics.Aspect.Composition
+end Aspect.Composition

--- a/Linglib/Semantics/Aspect/Cumulativity.lean
+++ b/Linglib/Semantics/Aspect/Cumulativity.lean
@@ -25,11 +25,11 @@ The explicit-witness variants (`cum_propagation_of_cumTheta`,
 proof-factoring helpers, not part of the public API — mathlib pattern.
 -/
 
-namespace Semantics.Aspect.Cumulativity
+namespace Aspect.Cumulativity
 
 open _root_.Mereology
 open _root_.ArgumentStructure
-open Semantics.Aspect.Incremental
+open _root_.Aspect.Incremental
 
 variable {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
 
@@ -134,4 +134,4 @@ theorem qua_propagation {θ : α → β → Prop} [IsSincVerb θ]
     QUA (VP θ OBJ) :=
   qua_propagation_of_sinc IsSincVerb.up IsSincVerb.sinc hQua
 
-end Semantics.Aspect.Cumulativity
+end Aspect.Cumulativity

--- a/Linglib/Semantics/Aspect/Incremental.lean
+++ b/Linglib/Semantics/Aspect/Incremental.lean
@@ -39,7 +39,7 @@ and any modern incremental-theme account.
 * [dowty-1991] (proto-roles)
 -/
 
-namespace Semantics.Aspect.Incremental
+namespace Aspect.Incremental
 
 open _root_.ArgumentStructure
 
@@ -131,10 +131,10 @@ theorem mo_of_sinc {θ : α → β → Prop} (h : SINC θ) : MO θ :=
     strictly incremental reading-parts that can overlap in their
     object coverage.
 
-    Specialization of `Semantics.Aspect.PrecedenceClosure` with the
+    Specialization of `Aspect.PrecedenceClosure` with the
     trivial precedence condition: arbitrary sums are admitted. -/
 abbrev IncClosure (θ' : α → β → Prop) : α → β → Prop :=
-  Semantics.Aspect.PrecedenceClosure (fun _ _ ↦ True) θ'
+  Aspect.PrecedenceClosure (fun _ _ ↦ True) θ'
 
 /-- General Incrementality: θ is the IncClosure of some SINC θ'. -/
 def INC (θ : α → β → Prop) : Prop :=
@@ -144,8 +144,8 @@ def INC (θ : α → β → Prop) : Prop :=
     cumulative is trivially its own closure. CumTheta ensures the
     reverse direction: `IncClosure θ ⊆ θ`. -/
 theorem inc_of_sinc {θ : α → β → Prop} (h : SINC θ) (hCum : CumTheta θ) : INC θ :=
-  ⟨θ, h, fun x e => ⟨fun hθ => Semantics.Aspect.PrecedenceClosure.base hθ,
-    fun hcl => Semantics.Aspect.PrecedenceClosure.closure_subset
+  ⟨θ, h, fun x e => ⟨fun hθ => Aspect.PrecedenceClosure.base hθ,
+    fun hcl => Aspect.PrecedenceClosure.closure_subset
       (fun _ _ h => h) (fun x₁ x₂ e₁ e₂ h₁ h₂ _ => hCum _ _ _ _ h₁ h₂) hcl⟩⟩
 
 /-! ### VerbIncClass — Verb Incrementality Classification (K98 §3.6) -/
@@ -299,4 +299,4 @@ def IsQuantizedAffected.ofIsSincVerb {α β δ : Type*}
     IsQuantizedAffected (δ := δ) θ :=
   ⟨g_φ, h_quantized⟩
 
-end Semantics.Aspect.Incremental
+end Aspect.Incremental

--- a/Linglib/Semantics/Aspect/PrecedenceClosure.lean
+++ b/Linglib/Semantics/Aspect/PrecedenceClosure.lean
@@ -31,7 +31,7 @@ inter-event constraint `cond : β → β → Prop`. Two specializations:
 * [krifka-1998] §4.3 eq. 71 (movement-relation closure, modulo TANG_H)
 -/
 
-namespace Semantics.Aspect
+namespace Aspect
 
 /-- Smallest `α → β → Prop` relation containing `θ'` and closed under
     componentwise sum, when the summed events satisfy `cond`. Taking
@@ -64,4 +64,4 @@ theorem PrecedenceClosure.closure_subset {α β : Type*}
   | base h => exact hBase _ _ h
   | sum _ _ hC ih₁ ih₂ => exact hClosed _ _ _ _ ih₁ ih₂ hC
 
-end Semantics.Aspect
+end Aspect

--- a/Linglib/Semantics/Aspect/Stratified.lean
+++ b/Linglib/Semantics/Aspect/Stratified.lean
@@ -87,7 +87,7 @@ property.
   builds on)
 -/
 
-namespace Semantics.Aspect.Stratified
+namespace Aspect.Stratified
 
 open _root_.Mereology
 open Features
@@ -434,4 +434,4 @@ theorem in_adverbial_incompatible_with_subintervalReference
   intro hSub
   exact qua_incompatible_with_subintervalReference hQua he₁ (hSub e₁ he₁)
 
-end Semantics.Aspect.Stratified
+end Aspect.Stratified

--- a/Linglib/Semantics/Aspect/SubeventStructure.lean
+++ b/Linglib/Semantics/Aspect/SubeventStructure.lean
@@ -43,7 +43,7 @@ consumable by IMPF/PRFV/PERF. Key results:
 
 -/
 
-namespace Semantics.Aspect.SubeventStructure
+namespace Aspect.SubeventStructure
 
 open Features
 
@@ -184,7 +184,7 @@ theorem simple_no_activity {Time : Type*} [LinearOrder Time]
 
 /-! ### Phase Event Predicates -/
 
-open Semantics.Aspect
+open _root_.Aspect
 
 /-- Event predicate localized to an interval: holds of eventualities whose
     runtime equals the given interval. Converts temporal phases of a
@@ -479,4 +479,4 @@ theorem hasConsState_of_consState (n : Nucleus Time)
 
 end Nucleus
 
-end Semantics.Aspect.SubeventStructure
+end Aspect.SubeventStructure

--- a/Linglib/Semantics/Aspect/SubintervalProperty.lean
+++ b/Linglib/Semantics/Aspect/SubintervalProperty.lean
@@ -34,9 +34,9 @@ analysis — consumed by `Studies/Rouillard2026.lean`,
 `Semantics/Tense/SentDenotation.lean`.
 -/
 
-namespace Semantics.Aspect.SubintervalProperty
+namespace Aspect.SubintervalProperty
 
-open Semantics.Aspect
+open _root_.Aspect
 
 variable {W Time : Type*} [LinearOrder Time]
 
@@ -285,4 +285,4 @@ theorem csub_necessary_for_impf_prfv :
     -- Mutual containment → equality (antisymmetry of the containment order)
     exact ⟨e₂, le_antisymm hSub₂ hSubRev, hPe₂⟩
 
-end Semantics.Aspect.SubintervalProperty
+end Aspect.SubintervalProperty

--- a/Linglib/Semantics/Attitudes/Desire/Conditional.lean
+++ b/Linglib/Semantics/Attitudes/Desire/Conditional.lean
@@ -22,7 +22,7 @@ desirability relation cannot make both `p` and `¬p` wanted (`Want.not_compl`).
 
 namespace Desire.Conditional
 
-open Semantics.Conditionals (SimilarityOrdering)
+open Conditionals (SimilarityOrdering)
 
 variable {W : Type*}
 

--- a/Linglib/Semantics/Attitudes/NegRaising.lean
+++ b/Linglib/Semantics/Attitudes/NegRaising.lean
@@ -111,7 +111,7 @@ theorem forall_opinionated_iff_subsingleton {W E : Type*} (R : E → W → W →
     (agent : E) (worlds : List W) (w : W) :
     (∀ p : W → Prop, Opinionated R agent worlds p w) ↔
       (accessibleSet R agent worlds w).Subsingleton := by
-  rw [← Semantics.Homogeneity.excludedMiddle_iff_subsingleton (accessibleSet R agent worlds w)]
+  rw [← Homogeneity.excludedMiddle_iff_subsingleton (accessibleSet R agent worlds w)]
   simp only [Opinionated, boxAt_iff_forall_accessibleSet]
 
 /-- Neg-raising is available exactly when the predicate admits a gap

--- a/Linglib/Semantics/Causation/Progressive.lean
+++ b/Linglib/Semantics/Causation/Progressive.lean
@@ -271,7 +271,7 @@ structure CausallyGroundedEvent (V : Type*) [Fintype V] [DecidableEq V]
   /-- IsDeterministic instance for proc.M (carried explicitly). -/
   detInst : SEM.IsDeterministic process.M
   /-- The temporal phases: activity and result with ordering -/
-  phases : Semantics.Aspect.SubeventStructure.SubeventPhases Time
+  phases : Aspect.SubeventStructure.SubeventPhases Time
   /-- The causal trajectory is viable: initiator is type-level sufficient. -/
   causallyViable : @CausalProcess.typeLevelHolds V _ _ process dagInst detInst
 

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -37,8 +37,8 @@ The fourth uses `universalCounterfactual` from `Counterfactual.lean`.
 namespace Causation.PsychLink
 
 open Causation.Psych (CausalSource)
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual (universalCounterfactual)
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual (universalCounterfactual)
 
 /-! ### PsychCausalLink -/
 

--- a/Linglib/Semantics/Classifier.lean
+++ b/Linglib/Semantics/Classifier.lean
@@ -9,7 +9,7 @@ import Linglib.Semantics.Plurality.Algebra
 Unified compositional semantics for classifier constructions, connecting
 the typological vocabulary in `Syntax/Category/Classifier` to the
 mereological infrastructure in `Mereology` and the materialization
-homomorphism in `Semantics.Plurality.Algebra`.
+homomorphism in `Plurality.Algebra`.
 
 ## Two Semantic Strategies
 
@@ -117,14 +117,14 @@ theorem clfForNum_qua {α M : Type*} [SemilatticeSup α] [AddCommMonoid M]
     We use `Atom x` instead of `μ(x) = 1` since atomicity is the
     mereological content of "counting as one group." -/
 def groupClf {E D : Type*} [SemilatticeSup E] [SemilatticeSup D]
-    (mat : Semantics.Plurality.Algebra.Materialization E D)
+    (mat : Plurality.Algebra.Materialization E D)
     (P : E → Prop) (x : E) : Prop :=
   Atom x ∧ ∃ y, P y ∧ mat y = mat x
 
 /-- Group classifier output is quantized: no proper part of a group
     is itself a group (since groups are atoms). -/
 theorem groupClf_qua {E D : Type*} [SemilatticeSup E] [SemilatticeSup D]
-    (mat : Semantics.Plurality.Algebra.Materialization E D)
+    (mat : Plurality.Algebra.Materialization E D)
     {P : E → Prop} : QUA (groupClf mat P) :=
   Mereology.qua_of_atom fun _ h => h.1
 

--- a/Linglib/Semantics/Conditionals/Basic.lean
+++ b/Linglib/Semantics/Conditionals/Basic.lean
@@ -44,9 +44,9 @@ conversational background) lives in `Conditionals/Restrictor.lean`, which
 bridges to `strictImp` via `conditionalNecessity_iff_mem_strictImp`.
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
-open Semantics.Conditionals (SimilarityOrdering)
+open _root_.Conditionals (SimilarityOrdering)
 
 variable {I W : Type*} {access : I → Set W} {p p' q q' : Set W} {i : I} {w : W}
 
@@ -125,7 +125,7 @@ theorem strict_implies_material {R : W → Set W} (h_refl : w ∈ R w)
 vacuously true if the domain has no antecedent worlds; otherwise true iff
 some antecedent world settles the consequent throughout all antecedent
 worlds at least as close. (`SimilarityOrdering` and its constructors live in
-`Semantics.Conditionals.SimilarityOrdering`.) -/
+`Conditionals.SimilarityOrdering`.) -/
 def variablyStrictImp (sim : SimilarityOrdering W) (allWorlds p q : Set W) :
     Set W :=
   {w | allWorlds ∩ p = ∅ ∨
@@ -182,4 +182,4 @@ theorem perfection_not_entailed_variablyStrict :
     Or.inr ⟨true, ⟨Set.mem_univ _, rfl⟩, λ _ _ _ => trivial⟩,
     λ h => h Bool.false_ne_true trivial⟩
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/ConditionalType.lean
+++ b/Linglib/Semantics/Conditionals/ConditionalType.lean
@@ -31,7 +31,7 @@ PPI licensing requires established status (PC).
 This explains why PCs block NPIs despite being semantically DE!
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 open Discourse.Commitment.Table
 
 -- Conditional Type: HC vs PC
@@ -342,4 +342,4 @@ This explains the apparent paradox that PCs block NPIs despite being
 semantically DE: NPI licensing requires BOTH DE + uncertain status.
 -/
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -38,15 +38,15 @@ in mixed scenarios:
 - Universal: all individual CFs false → strength-independent
 -/
 
-namespace Semantics.Conditionals.Counterfactual
+namespace Conditionals.Counterfactual
 
 open Intensional (Index)
 
-open Semantics.Conditionals
+open _root_.Conditionals
 open Trivalent (ProjectionType dist)
 
 
-open Semantics.Conditionals (SimilarityOrdering)
+open _root_.Conditionals (SimilarityOrdering)
 
 
 /-!
@@ -584,7 +584,7 @@ theorem distribution_fails_universal :
 
 Stalnaker's original counterfactual analysis used a single Stalnakerian
 selection function — picking THE closest A-world — without supervaluation
-over ties. This is the same `Semantics.Conditionals.SelectionFunction` infrastructure that
+over ties. This is the same `Conditionals.SelectionFunction` infrastructure that
 [cariani-santorio-2018] reuse for *will* (see
 `Semantics/Modality/Selectional.lean`); the mechanism is identical,
 only the temporal/modal target differs.
@@ -598,15 +598,15 @@ single-function analysis (`Bool`) under `Trivalent.ofBool`. -/
 
 /-- **Stalnaker's single-selection-function counterfactual** [stalnaker-1968].
     `A □→ B` is true at `w` iff `B` holds at `s(w, ‖A‖)`. The counterfactual
-    reading is the `Semantics.Conditionals.selectionConditional` clause
+    reading is the `Conditionals.selectionConditional` clause
     (shared substrate) supplied with a similarity-induced selection function;
     it is the *same* truth-condition as the indicative
     `Stalnaker.moodedConditional`, differing only in admissible `s`. -/
-def stalnakerCounterfactual {W : Type*} (s : Semantics.Conditionals.SelectionFunction W)
+def stalnakerCounterfactual {W : Type*} (s : Conditionals.SelectionFunction W)
     (A B : W → Prop) (w : W) : Prop :=
-  Semantics.Conditionals.selectionConditional s A B w
+  Conditionals.selectionConditional s A B w
 
-instance stalnakerCounterfactual_decidable {W : Type*} (s : Semantics.Conditionals.SelectionFunction W)
+instance stalnakerCounterfactual_decidable {W : Type*} (s : Conditionals.SelectionFunction W)
     (A B : W → Prop) [DecidablePred B] (w : W) :
     Decidable (stalnakerCounterfactual s A B w) :=
   inferInstanceAs (Decidable (B _))
@@ -619,14 +619,14 @@ instance stalnakerCounterfactual_decidable {W : Type*} (s : Semantics.Conditiona
     `Trivalent.ofBool`. The supervaluation gap arises only with ties; once
     ties are resolved by the selection function, both analyses coincide. -/
 theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype W]
-    (s : Semantics.Conditionals.SelectionFunction W) (sim : SimilarityOrdering W)
+    (s : Conditionals.SelectionFunction W) (sim : SimilarityOrdering W)
     (A B : W → Prop) [DecidablePred A] [DecidablePred B] (w : W)
     (h_singleton : sim.closestWorlds w (Finset.univ.filter A)
                    = {s.sel w {w' | A w'}}) :
     selectionalCounterfactual sim A B w =
     Trivalent.ofBool (decide (stalnakerCounterfactual s A B w)) := by
   unfold selectionalCounterfactual stalnakerCounterfactual
-    Semantics.Conditionals.selectionConditional
+    Conditionals.selectionConditional
   rw [h_singleton]
   by_cases hB : B (s.sel w {w' | A w'})
   · -- Both sides equal .true
@@ -646,7 +646,7 @@ theorem stalnaker_eq_selectional_singleton {W : Type*} [DecidableEq W] [Fintype 
 
 [cariani-santorio-2018] §5.3.2 + §5.3.1 unify *will*, *would*,
 will-conditionals, and Stalnaker counterfactuals under a single
-`Semantics.Conditionals.SelectionFunction` substrate. Each operator differs only in its
+`Conditionals.SelectionFunction` substrate. Each operator differs only in its
 modal parameter `f`:
 
 - `willSem s A f w` — bare *will* with parameter `f`
@@ -670,17 +670,17 @@ truth-conditions thus coincide (`↔`).
 This is the formal payoff of the unification: bare *will* (`willSem`),
 will-conditionals (`willConditional`), Stalnaker counterfactuals, and
 *would*-conditionals (`wouldConditional`) all derive from one
-`Semantics.Conditionals.SelectionFunction` mechanism, differing only in which modal
+`Conditionals.SelectionFunction` mechanism, differing only in which modal
 parameter the tense morphology supplies. -/
 theorem stalnakerCounterfactual_eq_willConditional_universe
-    {W : Type*} (s : Semantics.Conditionals.SelectionFunction W) (A B : W → Prop) (w : W) :
+    {W : Type*} (s : Conditionals.SelectionFunction W) (A B : W → Prop) (w : W) :
     stalnakerCounterfactual s A B w ↔
-    Semantics.Conditionals.WillConditional.willConditional
+    Conditionals.WillConditional.willConditional
       s A B Set.univ w := by
   unfold stalnakerCounterfactual
-    Semantics.Conditionals.selectionConditional
-    Semantics.Conditionals.WillConditional.willConditional
-    Semantics.Conditionals.WillConditional.restrict
+    Conditionals.selectionConditional
+    Conditionals.WillConditional.willConditional
+    Conditionals.WillConditional.restrict
     Modality.Selectional.willSem
   rw [Set.univ_inter]
 
@@ -691,9 +691,9 @@ the morphological identity `wouldConditional = willConditional`. The
 counterfactual is, on the C&S analysis, a past-tense (would-) form,
 so the would-conditional reading is the more natural surface gloss. -/
 theorem stalnakerCounterfactual_eq_wouldConditional_universe
-    {W : Type*} (s : Semantics.Conditionals.SelectionFunction W) (A B : W → Prop) (w : W) :
+    {W : Type*} (s : Conditionals.SelectionFunction W) (A B : W → Prop) (w : W) :
     stalnakerCounterfactual s A B w ↔
-    Semantics.Conditionals.WillConditional.wouldConditional
+    Conditionals.WillConditional.wouldConditional
       s A B Set.univ w :=
   stalnakerCounterfactual_eq_willConditional_universe s A B w
 
@@ -712,12 +712,12 @@ theorem stalnakerCounterfactual_eq_wouldConditional_universe
     selection-function over `Set` — collapse to the same content. -/
 theorem selectional_eq_wouldConditional_singleton_universe
     {W : Type*} [DecidableEq W] [Fintype W]
-    (s : Semantics.Conditionals.SelectionFunction W) (sim : SimilarityOrdering W)
+    (s : Conditionals.SelectionFunction W) (sim : SimilarityOrdering W)
     (A B : W → Prop) [DecidablePred A] [DecidablePred B] (w : W)
     (h_singleton : sim.closestWorlds w (Finset.univ.filter A)
                    = {s.sel w {w' | A w'}}) :
     selectionalCounterfactual sim A B w = .true ↔
-    Semantics.Conditionals.WillConditional.wouldConditional
+    Conditionals.WillConditional.wouldConditional
       s A B Set.univ w := by
   rw [stalnaker_eq_selectional_singleton s sim A B w h_singleton]
   rw [← stalnakerCounterfactual_eq_wouldConditional_universe s A B w]
@@ -731,7 +731,7 @@ theorem selectional_eq_wouldConditional_singleton_universe
 
     `selFn w S` returns `w` if `w ∈ S` (Centering); otherwise returns
     `1` if `1 ∈ S`; otherwise picks the unique non-`w` element. -/
-private noncomputable def divergeSel : Semantics.Conditionals.SelectionFunction (Fin 3) :=
+private noncomputable def divergeSel : Conditionals.SelectionFunction (Fin 3) :=
   open Classical in
   { sel := fun w S => if w ∈ S then w
                       else if (1 : Fin 3) ∈ S then 1
@@ -787,10 +787,10 @@ theorem stalnaker_lewis_would_diverge :
       decide
     have hsel : divergeSel.sel 0 {w : Fin 3 | w = 1 ∨ w = 2} = 1 := by
       unfold divergeSel
-      simp [Semantics.Conditionals.SelectionFunction.sel, h0, h1]
+      simp [Conditionals.SelectionFunction.sel, h0, h1]
     show (fun w : Fin 3 => w = 1) (divergeSel.sel 0 _)
     rw [hsel]
   · -- Universal closestWorlds = {1, 2}; the universal fails at w=2.
     decide
 
-end Semantics.Conditionals.Counterfactual
+end Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/Counterfactual/Alternatives.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Alternatives.lean
@@ -17,7 +17,7 @@ otherwise — the presupposition of `DIST_π` and the trivalent conditional of
 [cariani-goldstein-2020].
 -/
 
-namespace Semantics.Conditionals.Counterfactual
+namespace Conditionals.Counterfactual
 
 variable {W : Type*} [DecidableEq W] [Fintype W] (sim : SimilarityOrdering W)
   (S : List (Finset W)) (C : W → Prop) [DecidablePred C] (w : W)
@@ -77,4 +77,4 @@ theorem universalCounterfactual_mem_filter (A : W → Prop) [DecidablePred A] :
       universalCounterfactual sim A C w := by
   simp [universalCounterfactual]
 
-end Semantics.Conditionals.Counterfactual
+end Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Implicature.lean
@@ -40,7 +40,7 @@ that can be cited (in the contrastive direction) by the
 [ramotowska-marty-romoli-santorio-2025] study file.
 -/
 
-namespace Semantics.Conditionals.Counterfactual
+namespace Conditionals.Counterfactual
 
 
 /-- Under the implicature approach with all-true individual results,
@@ -66,4 +66,4 @@ theorem implicature_wrong_for_notEvery :
       ([Trivalent.true, Trivalent.true].map Trivalent.neg) = .false := by
   decide
 
-end Semantics.Conditionals.Counterfactual
+end Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/Counterfactual/Lumping.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Lumping.lean
@@ -48,7 +48,7 @@ formal definitions in §5.4.4 — is out of scope here.
   shows how to recover Kratzer's worlds-only reading.
 -/
 
-namespace Semantics.Conditionals.Counterfactual
+namespace Conditionals.Counterfactual
 
 open Set
 open Intensional
@@ -242,4 +242,4 @@ theorem Lumps.discrete_iff (p q : Set G) (w : G) :
 
 end DiscreteCorollary
 
-end Semantics.Conditionals.Counterfactual
+end Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/QuantifierEmbedding.lean
@@ -58,7 +58,7 @@ but DISAGREE on "some" and "no" — the discriminating contrast tested
 in [ramotowska-marty-romoli-santorio-2025].
 -/
 
-namespace Semantics.Conditionals.Counterfactual
+namespace Conditionals.Counterfactual
 
 open Trivalent (ProjectionType)
 
@@ -225,4 +225,4 @@ theorem universal_all_false (n : Nat) (hn : n > 0) :
       | succ k ih => simp only [List.replicate_succ, List.foldl_cons, sup_idem, ih]
     exact this n
 
-end Semantics.Conditionals.Counterfactual
+end Conditionals.Counterfactual

--- a/Linglib/Semantics/Conditionals/LeftNested.lean
+++ b/Linglib/Semantics/Conditionals/LeftNested.lean
@@ -40,7 +40,7 @@ CAN be interpreted as HCs, because these provide "object-level" content
 that can be genuinely supposed without prior discourse.
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 open Discourse.Commitment.Table
 
@@ -88,14 +88,14 @@ def semantics (lnc : LNC W) : Set W :=
 Full LNC semantics using Kratzer-style conditionals.
 
 The outer conditional uses the canonical
-`Semantics.Conditionals.Restrictor.conditionalNecessity` (Kratzer's
+`Conditionals.Restrictor.conditionalNecessity` (Kratzer's
 restrictor analysis: if-clauses restrict the modal base, then necessity
 quantifies over best worlds), with the inner conditional as the
 restrictor. -/
 def kratzerSemantics (f : Modality.Kratzer.ModalBase W)
     (g : Modality.Kratzer.OrderingSource W) (lnc : LNC W) :
     Set W :=
-  fun w => Semantics.Conditionals.Restrictor.conditionalNecessity f g
+  fun w => Conditionals.Restrictor.conditionalNecessity f g
     lnc.innerConditional lnc.outerConsequent w
 
 end LNC
@@ -214,7 +214,7 @@ theorem lnc_grounded {W : Type*}
     (f : Modality.Kratzer.ModalBase W)
     (g : Modality.Kratzer.OrderingSource W) (lnc : LNC W) :
     lnc.kratzerSemantics f g =
-    fun w => Semantics.Conditionals.Restrictor.conditionalNecessity f g
+    fun w => Conditionals.Restrictor.conditionalNecessity f g
       lnc.innerConditional lnc.outerConsequent w := rfl
 
 -- Extended LNC with Metadata
@@ -393,4 +393,4 @@ object) inherently requires discourse anchoring to be supposed. This explains:
 4. Why modal/generic LNCs allow HC readings
 -/
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/Marker.lean
+++ b/Linglib/Semantics/Conditionals/Marker.lean
@@ -12,7 +12,7 @@ per-language marker entries live in `Fragments/{Language}/Conditionals.lean`.
 Extracted from `Conditionals/ConditionalType.lean` (was lines 372–396).
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 /-- Cross-linguistic conditional markers and their type restrictions.
 
@@ -42,4 +42,4 @@ structure ConditionalMarker where
   notes : String
   deriving Repr
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/PremiseSemantic.lean
+++ b/Linglib/Semantics/Conditionals/PremiseSemantic.lean
@@ -73,10 +73,10 @@ three, the lumping CF does NOT use `SimilarityOrdering` /
   from minimal-change semantics) is documented separately.
 -/
 
-namespace Semantics.Conditionals.PremiseSemantic
+namespace Conditionals.PremiseSemantic
 
 open Intensional
-open Semantics.Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
+open _root_.Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
 
 variable {F : SituationFrame}
 
@@ -170,4 +170,4 @@ theorem mightCF_iff_not_wouldCF_compl {Fw : Set (Set F.Index)} {w : F.Index}
     mightCF Fw w p q ↔ ¬ wouldCF Fw w p qᶜ := by
   sorry  -- TODO: requires upward-directedness of CrucialSet; see docstring
 
-end Semantics.Conditionals.PremiseSemantic
+end Conditionals.PremiseSemantic

--- a/Linglib/Semantics/Conditionals/Presupposition.lean
+++ b/Linglib/Semantics/Conditionals/Presupposition.lean
@@ -40,10 +40,10 @@ in `Counterfactual.closestWorlds`.
 
 -/
 
-namespace Semantics.Conditionals.Presupposition
+namespace Conditionals.Presupposition
 
-open Semantics.Conditionals
-open Semantics.Conditionals (SimilarityOrdering)
+open _root_.Conditionals
+open _root_.Conditionals (SimilarityOrdering)
 open _root_.Presupposition
 
 variable {W : Type*}
@@ -285,4 +285,4 @@ theorem kp_presup_does_not_imply_kpstar :
     have := hall true (by simp [closB, trivialCloser, List.filter])
     exact this
 
-end Semantics.Conditionals.Presupposition
+end Conditionals.Presupposition

--- a/Linglib/Semantics/Conditionals/Probabilistic.lean
+++ b/Linglib/Semantics/Conditionals/Probabilistic.lean
@@ -43,7 +43,7 @@ research question ([schulz-2011],
 [ciardelli-zhang-champollion-2018]).
 -/
 
-namespace Semantics.Conditionals.Probabilistic
+namespace Conditionals.Probabilistic
 
 open PMF
 open scoped ENNReal
@@ -61,4 +61,4 @@ theorem condIf_propositional (p : PMF W) (φ ψ : Set W) :
     condIf p φ (ψ.indicator (fun _ => 1)) = p.condProbSet φ ψ :=
   p.condExpect_indicator φ ψ
 
-end Semantics.Conditionals.Probabilistic
+end Conditionals.Probabilistic

--- a/Linglib/Semantics/Conditionals/Restrictor.lean
+++ b/Linglib/Semantics/Conditionals/Restrictor.lean
@@ -28,7 +28,7 @@ necessity (∀w' ∈ Best(f+α, ∅, w). β(w')) equals the strict conditional
 
 -/
 
-namespace Semantics.Conditionals.Restrictor
+namespace Conditionals.Restrictor
 
 open Modality.Kratzer
 
@@ -173,4 +173,4 @@ theorem conditionalNecessity_iff_mem_strictImp
     w ∈ strictImp (accessibleWorlds f) {w' | α w'} {w' | β w'} :=
   (restrictor_eq_strict f α β w).trans mem_strictImp_forall.symm
 
-end Semantics.Conditionals.Restrictor
+end Conditionals.Restrictor

--- a/Linglib/Semantics/Conditionals/SelectionFunction.lean
+++ b/Linglib/Semantics/Conditionals/SelectionFunction.lean
@@ -24,7 +24,7 @@ Behavior on empty `A` is left unspecified: the axioms are vacuous
 there, and concrete instances may pick any default.
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 /-- A **selection function** on `W`: maps a world and a proposition to
     a "selected" world, satisfying [stalnaker-1968]'s Inclusion
@@ -114,4 +114,4 @@ def SelectionFunction.isCoherent {W : Type*} (s : SelectionFunction W) : Prop :=
     selectionPrefers s w₀ w₁ w₂ → selectionPrefers s w₀ w₂ w₃ →
     selectionPrefers s w₀ w₁ w₃
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/SimilarityOrdering.lean
+++ b/Linglib/Semantics/Conditionals/SimilarityOrdering.lean
@@ -16,7 +16,7 @@ maximally similar to `w₀` — the minimal elements of `s` under `closer w₀` 
 centering, and `w₁ ≤[sim, w₀] w₂` is notation for `sim.closer w₀ w₁ w₂`.
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 /-! ## Structure -/
 
@@ -167,4 +167,4 @@ def candidateSelections {W : Type*} (sim : SimilarityOrdering W)
 notation:50 w₁ " ≤[" sim "," w₀ "] " w₂ =>
   SimilarityOrdering.closer sim w₀ w₁ w₂
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -39,7 +39,7 @@ A selection function `s` determines a pairwise preference:
 `success`) and total (by definition); transitivity requires
 `s.isCoherent` — rationalizability by a total preorder. The
 `coherentSelectionToSimilarity` constructor turns a coherent `s` into
-a `Semantics.Conditionals.SimilarityOrdering`.
+a `Conditionals.SimilarityOrdering`.
 
 ## Stalnakerian indicative/subjunctive split ([stalnaker-1975])
 
@@ -56,11 +56,11 @@ equivalence within an appropriate context (the
 `*_eq_material_within_context` theorems below) rather than stipulate it.
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 open Mood (Grammatical)
-open _root_.Semantics.Conditionals (SelectionFunction selectionPrefers)
-open Semantics.Conditionals (SimilarityOrdering)
+open _root_.Conditionals (SelectionFunction selectionPrefers)
+open _root_.Conditionals (SimilarityOrdering)
 
 /-! ## Coherent selection ⇒ similarity ordering -/
 
@@ -208,4 +208,4 @@ theorem moodedConditional_indicative_eq_material_within_context {W : Type*}
   selectionConditional_eq_material_within_context s C p q w hC_w h_open_p
     h_admissible h_C_imp
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/Sweetser.lean
+++ b/Linglib/Semantics/Conditionals/Sweetser.lean
@@ -19,7 +19,7 @@ semantics to the causal-model infrastructure in `Causation/`.
 Extracted from `Conditionals/ConditionalType.lean` (was lines 309–368).
 -/
 
-namespace Semantics.Conditionals
+namespace Conditionals
 
 /-- [sweetser-1990]'s three domains of conditional meaning. -/
 inductive SweetserDomain where
@@ -67,4 +67,4 @@ theorem epistemic_not_causal :
 theorem speechAct_not_causal :
     SweetserDomain.speechAct.triggersCausalInference = false := rfl
 
-end Semantics.Conditionals
+end Conditionals

--- a/Linglib/Semantics/Conditionals/WillConditional.lean
+++ b/Linglib/Semantics/Conditionals/WillConditional.lean
@@ -39,9 +39,9 @@ single-valuedness.
   collapses to its consequent: `will B` reduces to `B w`.
 -/
 
-namespace Semantics.Conditionals.WillConditional
+namespace Conditionals.WillConditional
 
-open _root_.Semantics.Conditionals (SelectionFunction)
+open _root_.Conditionals (SelectionFunction)
 open Modality.Selectional
 
 variable {W : Type*}
@@ -70,7 +70,7 @@ def willConditional (s : SelectionFunction W) (A B : W → Prop)
     selectional `will`-conditional, the disjunction `(if A, will B) ∨
     (if A, will ¬B)` holds at every point.
 
-    Derived from `Semantics.Conditionals.SelectionFunction.sel_em` applied at the
+    Derived from `Conditionals.SelectionFunction.sel_em` applied at the
     restricted parameter `f ∩ ‖A‖`. Will Excluded Middle and
     Compositional CEM share this single structural origin: the
     selected world is single-valued no matter which proposition
@@ -92,7 +92,7 @@ theorem valid2_compositional_CEM (A B : W → Prop) :
 /-- **Narrow Negation Swap in Conditionals** [cariani-santorio-2018]
     §7: under the *narrow* reading where negation scopes under the
     if-clause, `¬ (if A, will B) ↔ (if A, will ¬B)`. Derived from
-    `Semantics.Conditionals.SelectionFunction.sel_neg_swap` at the restricted parameter
+    `Conditionals.SelectionFunction.sel_neg_swap` at the restricted parameter
     `f ∩ ‖A‖`; the conditional analogue of the matrix Negation Swap,
     lifted by restrictor-style restriction of the modal parameter. -/
 theorem narrow_negation_swap (s : SelectionFunction W) (A B : W → Prop)
@@ -266,4 +266,4 @@ theorem subordinated_eq_unrestricted_of_no_shift (s : SelectionFunction W)
   unfold subordinatedWillDiscourse willConditional willSem
   rw [h_no_shift]
 
-end Semantics.Conditionals.WillConditional
+end Conditionals.WillConditional

--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -59,7 +59,7 @@ individual denotation — it has no `NominalDenot`) remains deferred.
 
 namespace Definiteness
 
-open Semantics.Reference (NominalDenot)
+open Reference (NominalDenot)
 open Intensional.Variables
 
 variable {E W : Type}

--- a/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
+++ b/Linglib/Semantics/Dynamic/PPCDRT/Cumulativity.lean
@@ -22,7 +22,7 @@ docstring asserted as prose.
 
 namespace PPCDRT
 
-open Semantics.Plurality.Cumulativity
+open Plurality.Cumulativity
 
 variable {E : Type*}
 

--- a/Linglib/Semantics/Events/CEM.lean
+++ b/Linglib/Semantics/Events/CEM.lean
@@ -35,7 +35,7 @@ Generic mereological vocabulary (`CUM`, `QUA`, `Overlap`, `IsFusion`,
 `ClassicalMereology`, …) lives in `Mereology`; consumers `open Mereology`.
 -/
 
-namespace Semantics.Events.CEM
+namespace Events.CEM
 
 open _root_.Mereology
 
@@ -54,4 +54,4 @@ theorem sup_isLUB {Time : Type*} [LinearOrder Time]
     (e₁ e₂ : Event Time) : IsLUB {e₁, e₂} (e₁ ⊔ e₂) :=
   Classical.choose_spec (ClassicalMereology.exists_isLUB_pair e₁ e₂)
 
-end Semantics.Events.CEM
+end Events.CEM

--- a/Linglib/Semantics/Events/Phase.lean
+++ b/Linglib/Semantics/Events/Phase.lean
@@ -11,7 +11,7 @@ project (`Presupposition.Aboutness`).
 
 Complementary decompositions elsewhere in the event API: `Event` (a
 temporal *token* with runtime and sort), and
-`Semantics.Aspect.SubeventStructure.TemporalDecomposition` (interval-valued
+`Aspect.SubeventStructure.TemporalDecomposition` (interval-valued
 activity/result phases of a token). `EventPhase` is type-level and modal —
 phases as predicates over worlds, not intervals. For change-of-state verbs
 its precondition/consequence coincide with `Features.ChangeOfState`'s

--- a/Linglib/Semantics/Genericity/Basic.lean
+++ b/Linglib/Semantics/Genericity/Basic.lean
@@ -57,7 +57,7 @@ See `Studies/TesslerGoodman2019.lean` for the RSA account.
 
 -/
 
-namespace Semantics.Genericity
+namespace Genericity
 
 -- Core Types
 
@@ -295,4 +295,4 @@ theorem homogeneity_no
     genHomogeneityPresup situations restrictor scope :=
   Or.inr h
 
-end Semantics.Genericity
+end Genericity

--- a/Linglib/Semantics/Genericity/Dynamic.lean
+++ b/Linglib/Semantics/Genericity/Dynamic.lean
@@ -44,7 +44,7 @@ worlds. The single-world simplification suffices for all the paper's
 examples about Sobel sequences.
 -/
 
-namespace Semantics.Genericity.Dynamic
+namespace Genericity.Dynamic
 
 -- ═══ Computable Model ═══
 
@@ -653,4 +653,4 @@ def GenericSentence.fromOrder
     decide (∀ e' ∈ restricted, le e' e → le e e')
   ⟨restrictor, scope, normals⟩
 
-end Semantics.Genericity.Dynamic
+end Genericity.Dynamic

--- a/Linglib/Semantics/Homogeneity/Collective.lean
+++ b/Linglib/Semantics/Homogeneity/Collective.lean
@@ -21,7 +21,7 @@ distributive predicates this reduces to supervaluation over atoms
 * [M. Križ, *Homogeneity, Non-Maximality, and All*][kriz-2016]
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 open Semantics.Supervaluation (superTrue)
 
@@ -90,4 +90,4 @@ theorem generalisedTruthValue_distributive_reduction
       rw [if_pos hWitness, if_neg]
       intro hf; exact hf x hxa hpx
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Homogeneity/Conditional.lean
+++ b/Linglib/Semantics/Homogeneity/Conditional.lean
@@ -10,7 +10,7 @@ plural quantifies over atoms, conditional excluded middle is the
 homogeneity gap, and *necessarily* is the gap remover, as *all* is for
 plurals (`Homogeneity.Plural`). `bareConditional` computes the same
 three-valued truth value as `selectionalCounterfactual` in
-`Semantics.Conditionals.Counterfactual` (see
+`Conditionals.Counterfactual` (see
 `selectional_as_supervaluation`); the two differ only in input
 representation.
 
@@ -27,7 +27,7 @@ representation.
   Conditionals*][von-fintel-1999]
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 open Trivalent (Prop3)
 open Semantics.Supervaluation (superTrue superTrue_true_iff)
@@ -74,4 +74,4 @@ theorem necessarily_prevents_nonmax (q : QUD W) (w : W)
   simp only [bareConditional, dif_pos hne] at hCondTrue
   exact (superTrue_true_iff Q ⟨closestPWorlds w, hne⟩).mp hCondTrue
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Homogeneity/Decided.lean
+++ b/Linglib/Semantics/Homogeneity/Decided.lean
@@ -31,7 +31,7 @@ The lemmas are stated over an arbitrary `Set W`, so all three are instances.
 * `negRaising_iff_forceCollapse` — the two faces coincide.
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 variable {W : Type*}
 
@@ -102,4 +102,4 @@ example {α : Type*} (cookies : Set α) (hne : cookies.Nonempty) :
       cookies.Subsingleton :=
   forceCollapse_iff_subsingleton hne
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Homogeneity/Defs.lean
+++ b/Linglib/Semantics/Homogeneity/Defs.lean
@@ -21,7 +21,7 @@ gap into the negative extension; the pragmatics of the gap lives in
 * [M. Križ, *Aspects of Homogeneity in the Semantics of Natural Language*][kriz-2015]
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 open Trivalent (Prop3)
 
@@ -48,4 +48,4 @@ theorem not_isHomogeneous_metaAssert (p : Prop3 W) :
     ¬isHomogeneous p.metaAssert := by
   simp [isHomogeneous, Prop3.gapExt_metaAssert]
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Homogeneity/Plural.lean
+++ b/Linglib/Semantics/Homogeneity/Plural.lean
@@ -30,11 +30,11 @@ Originates with [kriz-2016]; consumed by `Studies/Kriz2016.lean`,
 * [M. Križ, *Homogeneity, Non-Maximality, and All*][kriz-2016]
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 open Trivalent (Prop3)
-open Semantics.Plurality
-open Semantics.Plurality.Trivalent
+open Plurality
+open Plurality.Trivalent
 
 variable {Atom W : Type*} (P : Atom → W → Prop) [∀ a w, Decidable (P a w)]
   (x : Finset Atom)
@@ -128,4 +128,4 @@ theorem barePlural_eq_superTrue (hne : x.Nonempty) (w : W) :
 theorem allPlural_ne_indet (w : W) : allPlural P x w ≠ .indet := by
   rcases isBivalent_allPlural P x w with h | h <;> simp [h]
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Homogeneity/Usable.lean
+++ b/Linglib/Semantics/Homogeneity/Usable.lean
@@ -28,7 +28,7 @@ of Addressing.
 * [M. Križ and B. Spector, *Interpreting Plural Predication*][kriz-spector-2021]
 -/
 
-namespace Semantics.Homogeneity
+namespace Homogeneity
 
 open Trivalent (Prop3)
 
@@ -197,4 +197,4 @@ theorem exact_stronglyRelevantSet_eq [BEq W] [LawfulBEq W]
 def bivalentPred (p : Prop3 W) : W → Bool :=
   λ w => p w == .true
 
-end Semantics.Homogeneity
+end Homogeneity

--- a/Linglib/Semantics/Intensional/Rigidity.lean
+++ b/Linglib/Semantics/Intensional/Rigidity.lean
@@ -11,7 +11,7 @@ from indices (possible worlds) to extensions, rigid designators, evaluation,
 and referential interpretation modes.
 
 These primitives are shared by `Intensional.Defs`,
-`Semantics.Reference/`, `Semantics.Attitudes/`, and `RSA/` — any module
+`Reference/`, `Semantics.Attitudes/`, and `RSA/` — any module
 that needs world-parameterized meanings.
 
 ## Relationship to `Denot`

--- a/Linglib/Semantics/Modality/ActualityEntailments.lean
+++ b/Linglib/Semantics/Modality/ActualityEntailments.lean
@@ -49,7 +49,7 @@ from the aspect-scope licensing here would tie the two accounts together.
 
 namespace Modality
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/Modality/Selectional.lean
+++ b/Linglib/Semantics/Modality/Selectional.lean
@@ -66,7 +66,7 @@ must satisfy three constraints:
 
 namespace Modality.Selectional
 
-open _root_.Semantics.Conditionals (SelectionFunction)
+open _root_.Conditionals (SelectionFunction)
 open HistoricalAlternatives
 open scoped ENNReal
 
@@ -100,7 +100,7 @@ instance willSem_decidable (s : SelectionFunction W) (A : W → Prop)
 /-- **Negation Swap** [cariani-santorio-2018]: under selectional
     semantics, *will* commutes with negation. `will ¬A ↔ ¬ will A`.
 
-    Derived from `Semantics.Conditionals.SelectionFunction.sel_neg_swap` — the structural
+    Derived from `Conditionals.SelectionFunction.sel_neg_swap` — the structural
     origin is single-valuedness of selection: the selected world either
     satisfies `A` or it doesn't. -/
 theorem negation_swap (s : SelectionFunction W) (A : W → Prop)
@@ -111,7 +111,7 @@ theorem negation_swap (s : SelectionFunction W) (A : W → Prop)
 /-- **Will Excluded Middle** [cariani-santorio-2018]: `will A ∨
     will ¬A` holds at every point of evaluation.
 
-    Derived from `Semantics.Conditionals.SelectionFunction.sel_em` — the disjunction
+    Derived from `Conditionals.SelectionFunction.sel_em` — the disjunction
     holds because `s.sel w f` is a single world, on which `A` is
     either true or false. This is the selectional analogue of
     Conditional Excluded Middle for Stalnaker counterfactuals; both

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -48,7 +48,7 @@ mathlib's `SupHom` and could be folded into it (Todo).
   requires aligning `Finset Atom` with `Type*`-lattice carriers.
 -/
 
-namespace Semantics.Plurality.Algebra
+namespace Plurality.Algebra
 
 open _root_.Mereology
 
@@ -355,4 +355,4 @@ theorem distr_star_iff_all_atoms {P : E → Prop} (hDistr : IsDistr P)
     star P x → ∀ {y : E}, Atom y → y ≤ x → P y :=
   distr_atom_part hDistr hJP
 
-end Semantics.Plurality.Algebra
+end Plurality.Algebra

--- a/Linglib/Semantics/Plurality/Basic.lean
+++ b/Linglib/Semantics/Plurality/Basic.lean
@@ -27,14 +27,14 @@ files.
 
 ## Implementation notes
 
-This file sits under `namespace Semantics.Plurality` (the directory
-umbrella) rather than `Semantics.Plurality.Basic` (filename pattern).
-Consumers `open Semantics.Plurality` for substrate access; specific
+This file sits under `namespace Plurality` (the directory
+umbrella) rather than `Plurality.Basic` (filename pattern).
+Consumers `open Plurality` for substrate access; specific
 theoretical accounts (`Distributivity`, `Trivalent`, `Implicature`,
 `Cumulativity`, …) live under sub-namespaces and are opened separately.
 -/
 
-namespace Semantics.Plurality
+namespace Plurality
 
 variable {Atom W : Type*}
 
@@ -125,4 +125,4 @@ instance noneSatisfy.instDecidable (P : Atom → W → Prop)
     [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
     Decidable (noneSatisfy P x w) := by unfold noneSatisfy; infer_instance
 
-end Semantics.Plurality
+end Plurality

--- a/Linglib/Semantics/Plurality/Cover.lean
+++ b/Linglib/Semantics/Plurality/Cover.lean
@@ -54,7 +54,7 @@ many orders — which is why the forward bridge yields *some* cover
 (`∃`), not a canonical one.
 -/
 
-namespace Semantics.Plurality.Cover
+namespace Plurality.Cover
 
 open _root_.Mereology
 
@@ -173,4 +173,4 @@ theorem algClosure_iff_exists_finCover {α : Type*} [SemilatticeSup α] [Decidab
   ⟨exists_finCover_of_algClosure,
    λ ⟨_, _, hCover, hP⟩ => algClosure_of_finCover hCover hP⟩
 
-end Semantics.Plurality.Cover
+end Plurality.Cover

--- a/Linglib/Semantics/Plurality/Cumulativity.lean
+++ b/Linglib/Semantics/Plurality/Cumulativity.lean
@@ -42,7 +42,7 @@ cumulative.
   of cumulativity — is not yet formalised.
 -/
 
-namespace Semantics.Plurality.Cumulativity
+namespace Plurality.Cumulativity
 
 variable {A B : Type*}
 
@@ -133,4 +133,4 @@ theorem singleton_right_cumulative (R : A → B → Prop) (x : Finset A) (y : B)
   obtain ⟨a, ha⟩ := hne
   exact ⟨a, ha, h a ha⟩
 
-end Semantics.Plurality.Cumulativity
+end Plurality.Cumulativity

--- a/Linglib/Semantics/Plurality/Distributivity.lean
+++ b/Linglib/Semantics/Plurality/Distributivity.lean
@@ -35,9 +35,9 @@ A tolerance relation induces a partition on pluralities: identity tolerance
 
 -/
 
-namespace Semantics.Plurality.Distributivity
+namespace Plurality.Distributivity
 
-open Semantics.Plurality
+open _root_.Plurality
 
 variable {Atom W : Type*} [DecidableEq Atom]
 
@@ -285,4 +285,4 @@ theorem distMaximal_iff_star_atoms (P : Atom → W → Prop)
       · exact ih₁ a hau
       · exact ih₂ a hav
 
-end Semantics.Plurality.Distributivity
+end Plurality.Distributivity

--- a/Linglib/Semantics/Plurality/Groups.lean
+++ b/Linglib/Semantics/Plurality/Groups.lean
@@ -20,7 +20,7 @@ directional sub-events ([siloni-2012] §4.1).
 * `GroupStructure.up_injective` — distinct sums form distinct groups.
 -/
 
-namespace Semantics.Plurality
+namespace Plurality
 
 /-- Landman's group structure: `up` packs a sum into a group atom, `down`
     recovers the underlying sum. The two laws are the operative core of
@@ -105,4 +105,4 @@ noncomputable def finsetModel (β : Type*) [DecidableEq β] [Encodable β] :
 
 end GroupStructure
 
-end Semantics.Plurality
+end Plurality

--- a/Linglib/Semantics/Plurality/Implicature.lean
+++ b/Linglib/Semantics/Plurality/Implicature.lean
@@ -47,7 +47,7 @@ bridge if needed.
   `Mereology.AlgClosure` for unification with Link's `*P` family.
 -/
 
-namespace Semantics.Plurality.Implicature
+namespace Plurality.Implicature
 
 variable {Atom W : Type*}
 
@@ -91,4 +91,4 @@ theorem existPL_singleton [DecidableEq Atom] (a : Atom) (P : Atom → W → Prop
     rwa [Finset.mem_singleton.mp hb_mem] at hP
   · intro hP; exact ⟨a, hx, Finset.mem_singleton_self a, hP⟩
 
-end Semantics.Plurality.Implicature
+end Plurality.Implicature

--- a/Linglib/Semantics/Plurality/Reciprocal.lean
+++ b/Linglib/Semantics/Plurality/Reciprocal.lean
@@ -60,10 +60,10 @@ uses `Finset (Finset α)` for the partition witness.
   among schemes given context.
 -/
 
-namespace Semantics.Plurality.Reciprocal
+namespace Plurality.Reciprocal
 
-open Semantics.Plurality
-open Semantics.Plurality.Cumulativity
+open _root_.Plurality
+open _root_.Plurality.Cumulativity
 
 variable {A : Type*}
 
@@ -530,4 +530,4 @@ theorem PairwiseConfig.partitionedStrong {R : A → A → Prop} {X : Finset A}
   exact ⟨P, fun Y hY => (hcells Y hY).2, hcover,
     fun Y hY x hx y hy hne => (hiff x y).mpr ⟨Y, hY, hx, hy, hne.symm⟩⟩
 
-end Semantics.Plurality.Reciprocal
+end Plurality.Reciprocal

--- a/Linglib/Semantics/Plurality/Trivalent.lean
+++ b/Linglib/Semantics/Plurality/Trivalent.lean
@@ -45,7 +45,7 @@ made kernel-checked in `malamud_strictly_weaker_when_mixed`.
 
 Strong relevance (constancy on QUD cells) is defined at the substrate level
 in `Semantics/Homogeneity/Usable.lean` as
-`Semantics.Homogeneity.isStronglyRelevantProp` and re-exported here.
+`Homogeneity.isStronglyRelevantProp` and re-exported here.
 The bivalent bridge to [kriz-2016]'s `addressesIssue` is proved in
 `Studies/KrizSpector2021.lean`.
 
@@ -65,12 +65,12 @@ The bivalent bridge to [kriz-2016]'s `addressesIssue` is proved in
   account.
 -/
 
-namespace Semantics.Plurality.Trivalent
+namespace Plurality.Trivalent
 
-open Semantics.Homogeneity (isStronglyRelevantProp stronglyRelevantSet
+open Homogeneity (isStronglyRelevantProp stronglyRelevantSet
   exact_all_relevant)
-open Semantics.Plurality
-open Semantics.Plurality.Implicature (existPL)
+open _root_.Plurality
+open _root_.Plurality.Implicature (existPL)
 
 variable {Atom W : Type*}
 
@@ -327,7 +327,7 @@ theorem pluralTruthValue_eq_candidateSemantics (P : Atom → W → Prop)
 
 /-! ### QUD relevance for K&S candidates
 
-`isStronglyRelevantProp` lives in `Semantics.Homogeneity` (substrate);
+`isStronglyRelevantProp` lives in `Homogeneity` (substrate);
 these are the K&S-specific specialisations applied to `candidateProp`. -/
 
 /-- The maximal candidate is always strongly relevant to the exact QUD. -/
@@ -533,13 +533,13 @@ in `fullCandidateSet`. -/
 theorem mem_fullCandidateSet_of_cover_cell [DecidableEq Atom]
     (P : Atom → W → Prop) [∀ a w, Decidable (P a w)]
     (x : Finset Atom) {parts : Finset (Finset Atom)} {hne : parts.Nonempty}
-    (hCover : Semantics.Plurality.Cover.IsFinCover parts hne x)
+    (hCover : Plurality.Cover.IsFinCover parts hne x)
     {z : Finset Atom} (hz : z ∈ parts) (hzNe : z.Nonempty) :
     candidateProp P z ∈ fullCandidateSet P x := by
   refine ⟨z, Finset.mem_powerset.mpr ?_, hzNe, rfl⟩
   have h_le : z ≤ parts.sup' hne id := Finset.le_sup' id hz
-  unfold Semantics.Plurality.Cover.IsFinCover at hCover
+  unfold Plurality.Cover.IsFinCover at hCover
   rw [hCover] at h_le
   exact h_le
 
-end Semantics.Plurality.Trivalent
+end Plurality.Trivalent

--- a/Linglib/Semantics/Polarity/CzechNegation.lean
+++ b/Linglib/Semantics/Polarity/CzechNegation.lean
@@ -15,7 +15,7 @@ without importing them. NCI licensing by Agree follows [zeijlstra-2004].
 
 namespace Czech.Negation
 
-open Semantics.Questions.Bias (EvidentialBiasStrength)
+open Questions.Bias (EvidentialBiasStrength)
 
 /-- The three LF positions for negation in Czech PQs ([stankova-2026], her (16)).
 

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -34,7 +34,7 @@ relation), inheriting the possessor's intrinsic presupposition. So:
 
 namespace Possessive
 
-open Semantics.Reference (NominalDenot)
+open Reference (NominalDenot)
 open Definiteness
 
 variable {Ctx : Type*} {W E : Type}

--- a/Linglib/Semantics/Possessive/PronounMixing.lean
+++ b/Linglib/Semantics/Possessive/PronounMixing.lean
@@ -28,7 +28,7 @@ i.e. *derived*, not stipulated.
 
 namespace Possessive
 
-open Semantics.Reference (NominalDenot)
+open Reference (NominalDenot)
 open Definiteness
 open Intensional.Variables (interpPronoun)
 

--- a/Linglib/Semantics/Probabilistic/BayesianSemantics.lean
+++ b/Linglib/Semantics/Probabilistic/BayesianSemantics.lean
@@ -40,7 +40,7 @@ probability layer.
 
 namespace Semantics.Montague.BayesianSemantics
 
-open Semantics.Probabilistic
+open Probabilistic
 open scoped ENNReal
 
 -- Example: Threshold Predicates (Lassiter & Goodman Style)

--- a/Linglib/Semantics/Probabilistic/Composition.lean
+++ b/Linglib/Semantics/Probabilistic/Composition.lean
@@ -21,7 +21,7 @@ The normalized counterpart on `PMF` is the Product of Experts
 [erk-herbelot-2024]'s situation description systems.
 -/
 
-namespace Semantics.Probabilistic
+namespace Probabilistic
 
 variable {U W R : Type*}
 
@@ -61,4 +61,4 @@ theorem prodMeaning_nonneg [PosMulMono R] {lex : U → W → R}
 
 end Order
 
-end Semantics.Probabilistic
+end Probabilistic

--- a/Linglib/Semantics/Probabilistic/ConditionalAssertability.lean
+++ b/Linglib/Semantics/Probabilistic/ConditionalAssertability.lean
@@ -19,7 +19,7 @@ This probabilistic semantics:
 import Linglib.Semantics.Causation.BayesNet
 import Mathlib.Data.Rat.Defs
 
-namespace Semantics.Probabilistic.ConditionalAssertability
+namespace Probabilistic.ConditionalAssertability
 
 open Causation.BayesNet
 
@@ -316,4 +316,4 @@ theorem correlation_strength_zero_iff_independent (ws : WorldState) (hA : 0 < ws
     -- h : ws.pAC = ws.pA * ws.pC
     rw [h, mul_comm, mul_div_assoc, div_self hA_ne, mul_one]
 
-end Semantics.Probabilistic.ConditionalAssertability
+end Probabilistic.ConditionalAssertability

--- a/Linglib/Semantics/Probabilistic/ParamPred.lean
+++ b/Linglib/Semantics/Probabilistic/ParamPred.lean
@@ -20,7 +20,7 @@ uncertainty) recovers Boolean truth — gradience is not stipulated but
 emerges from parameter uncertainty.
 -/
 
-namespace Semantics.Probabilistic
+namespace Probabilistic
 
 open scoped ENNReal
 
@@ -62,4 +62,4 @@ theorem gradedTruth_pure (sem : Θ → E → Bool) (θ₀ : Θ) (x : E) :
 
 end ParamPred
 
-end Semantics.Probabilistic
+end Probabilistic

--- a/Linglib/Semantics/Probabilistic/PrototypeTheory.lean
+++ b/Linglib/Semantics/Probabilistic/PrototypeTheory.lean
@@ -19,7 +19,7 @@ This is the parametric theory consumed by paper-specific PT models
 which provide their own prototype/spread parameter values.
 -/
 
-namespace Semantics.Probabilistic.PrototypeTheory
+namespace Probabilistic.PrototypeTheory
 
 /-- Tent kernel: `max 0 (1 - |x|)`. Non-negative, monotone-decreasing
 in `|x|`, continuous, peak `1` at `x = 0`, vanishes for `|x| ≥ 1`.
@@ -52,4 +52,4 @@ theorem ptMeaning_nonneg (n : Nat) (p : Nat) (d : ℚ) (t : Fin (n + 1)) :
     0 ≤ ptMeaning n p d t :=
   bumpKernel_nonneg _
 
-end Semantics.Probabilistic.PrototypeTheory
+end Probabilistic.PrototypeTheory

--- a/Linglib/Semantics/Probabilistic/SDS/ConceptNode.lean
+++ b/Linglib/Semantics/Probabilistic/SDS/ConceptNode.lean
@@ -48,10 +48,10 @@ signatures clean. Lifting to `Kernel` is only needed if downstream work
 requires disintegration/Radon-Nikodym lemmas.
 -/
 
-namespace Semantics.Probabilistic.SDS.ConceptNode
+namespace Probabilistic.SDS.ConceptNode
 
 open scoped ENNReal
-open Semantics.Probabilistic.SDS
+open _root_.Probabilistic.SDS
 
 variable {Scenario Concept Role : Type}
 
@@ -152,4 +152,4 @@ theorem conditionalAt_perScenario_uniform [Fintype Concept] [Nonempty Concept]
   rw [mul_comm ((Fintype.card Concept : ℝ≥0∞)⁻¹) (sel r c), mul_assoc,
       ENNReal.mul_inv_cancel hNinv_pos hNinv_fin, mul_one]
 
-end Semantics.Probabilistic.SDS.ConceptNode
+end Probabilistic.SDS.ConceptNode

--- a/Linglib/Semantics/Probabilistic/SDS/GraphicalModel.lean
+++ b/Linglib/Semantics/Probabilistic/SDS/GraphicalModel.lean
@@ -52,7 +52,7 @@ Normalizing over all assignments consistent with observations gives the
 joint posterior (in `SDS/JointPosterior.lean`, Phase 2 part B).
 -/
 
-namespace Semantics.Probabilistic.SDS
+namespace Probabilistic.SDS
 
 open scoped ENNReal
 open ProbabilityTheory
@@ -166,4 +166,4 @@ theorem jointFactorObs_eq_zero_of_inconsistent
 
 end GraphicalModel
 
-end Semantics.Probabilistic.SDS
+end Probabilistic.SDS

--- a/Linglib/Semantics/Probabilistic/SDS/JointPosterior.lean
+++ b/Linglib/Semantics/Probabilistic/SDS/JointPosterior.lean
@@ -50,7 +50,7 @@ machinery handles the abstraction; concrete computation would need
 either MCMC (out of scope) or aggressive structural simplification.
 -/
 
-namespace Semantics.Probabilistic.SDS
+namespace Probabilistic.SDS
 
 open scoped ENNReal
 open ProbabilityTheory GraphicalModel
@@ -161,4 +161,4 @@ theorem conceptPosteriorAt_eq_of_support
 
 end GraphicalModel
 
-end Semantics.Probabilistic.SDS
+end Probabilistic.SDS

--- a/Linglib/Semantics/Probabilistic/SDS/ScenarioMix.lean
+++ b/Linglib/Semantics/Probabilistic/SDS/ScenarioMix.lean
@@ -63,7 +63,7 @@ naming aliases over those primitives.
   `Core/Probability/PolyaUrn.lean`.
 -/
 
-namespace Semantics.Probabilistic.SDS.ScenarioMix
+namespace Probabilistic.SDS.ScenarioMix
 
 open scoped ENNReal
 open ProbabilityTheory
@@ -99,4 +99,4 @@ noncomputable def scenarioCountPosterior (α : ℝ) (hα : 0 < α)
       pseudo_pos := fun s => by positivity }
     newDraws
 
-end Semantics.Probabilistic.SDS.ScenarioMix
+end Probabilistic.SDS.ScenarioMix

--- a/Linglib/Semantics/Questions/Bias.lean
+++ b/Linglib/Semantics/Questions/Bias.lean
@@ -21,7 +21,7 @@ frames lives study-side (`Studies/RomeroHan2004.lean`).
 * `originalBiasOK`, `evidenceBiasOK` — Romero's compatibility tables.
 -/
 
-namespace Semantics.Questions.Bias
+namespace Questions.Bias
 
 /-- The three polar question forms ([romero-2024] §1).
 
@@ -131,4 +131,4 @@ theorem hiNQ_evidence_against_ok :
 theorem hiNQ_evidence_neutral_ok :
     evidenceBiasOK .HiNQ .neutral = true := rfl
 
-end Semantics.Questions.Bias
+end Questions.Bias

--- a/Linglib/Semantics/Questions/Exhaustivity.lean
+++ b/Linglib/Semantics/Questions/Exhaustivity.lean
@@ -41,7 +41,7 @@ Given `Q : Question W` and a world `w : W`:
   by applying the exhaustification operator Exh to alternatives. Stub.
 -/
 
-namespace Semantics.Questions.Exhaustivity
+namespace Questions.Exhaustivity
 
 universe u
 variable {W : Type u}
@@ -481,4 +481,4 @@ def IsExhaustivelyResolvable.decidable_polar {p : Set W}
     Decidable (IsExhaustivelyResolvable (polar p) w) :=
   isTrue (isExhaustivelyResolvable_polar_of_nontrivial hne hnu w)
 
-end Semantics.Questions.Exhaustivity
+end Questions.Exhaustivity

--- a/Linglib/Semantics/Questions/Probabilistic.lean
+++ b/Linglib/Semantics/Questions/Probabilistic.lean
@@ -43,7 +43,7 @@ that introduced them) since their only consumer is the IKW 2025
 discourse-*only* study file.
 -/
 
-namespace Semantics.Questions.Probabilistic
+namespace Questions.Probabilistic
 
 open Question PMF
 
@@ -346,4 +346,4 @@ theorem IsResolutionEvidencedBy.isRelevantPropOf
   push Not at hcon
   exact absurd (hindep hcon) (ne_of_gt hRes.raises_prob)
 
-end Semantics.Questions.Probabilistic
+end Questions.Probabilistic

--- a/Linglib/Semantics/Reference/Acquaintance.lean
+++ b/Linglib/Semantics/Reference/Acquaintance.lean
@@ -29,7 +29,7 @@ parallel `Concept` type is introduced. The acquaintance predicate is
 mathlib idioms — the only genuinely new content here is naming.
 -/
 
-namespace Semantics.Reference.Acquaintance
+namespace Reference.Acquaintance
 
 open Intensional (Intension)
 
@@ -87,4 +87,4 @@ theorem nameCover_isAcquaintedWith_of_mem {Idx Res : Type*} (dom : Set Res)
     isAcquaintedWith r (nameCover (Idx := Idx) dom) p := by
   refine ⟨Intension.rigid (W := Idx) r, ⟨r, hr, rfl⟩, rfl⟩
 
-end Semantics.Reference.Acquaintance
+end Reference.Acquaintance

--- a/Linglib/Semantics/Reference/Almog2014.lean
+++ b/Linglib/Semantics/Reference/Almog2014.lean
@@ -52,14 +52,14 @@ The central chain from [almog-2014] Ch 1–2:
 
 -/
 
-namespace Semantics.Reference.Almog2014
+namespace Reference.Almog2014
 
-open Semantics.Reference.Basic (ReferentialProfile ReferringExpression properName
+open _root_.Reference.Basic (ReferentialProfile ReferringExpression properName
   isDirectlyReferential)
-open Semantics.Reference.Kaplan (SingularProposition indexical)
-open Semantics.Reference.Donnellan (UseMode referentialExpression)
-open Semantics.Reference.KaplanLD (dthatW dthatW_isRigid)
-open Semantics.Reference.Kripke (rigid_iff_scope_invariant deRe deDicto)
+open _root_.Reference.Kaplan (SingularProposition indexical)
+open _root_.Reference.Donnellan (UseMode referentialExpression)
+open _root_.Reference.KaplanLD (dthatW dthatW_isRigid)
+open _root_.Reference.Kripke (rigid_iff_scope_invariant deRe deDicto)
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid evalAt rigid_section
   rigid_evalAt_lossy)
@@ -178,7 +178,7 @@ def dthatExpression {C W E : Type*} (desc : Intension W E) (cW : W) :
 /-- dthat-expressions are de jure rigid: their character produces rigid
 content and their profile records the designation mechanism. -/
 theorem dthat_deJureRigid {C W E : Type*} (desc : Intension W E) (cW : W) :
-    Semantics.Reference.Basic.IsDeJureRigid
+    Reference.Basic.IsDeJureRigid
       (dthatExpression (C := C) desc cW) :=
   ⟨rfl, λ _ => dthatW_isRigid desc cW⟩
 
@@ -376,7 +376,7 @@ distinction between designation and referential use
 as independent sources of world-invariance. -/
 theorem kdthat_deFactoRigid {C W E : Type*} (loaded : E) (guide : E → W → Prop)
     (c : C) :
-    Semantics.Reference.Basic.IsDeFactoRigid
+    Reference.Basic.IsDeFactoRigid
       (kdthatExpression (C := C) loaded guide) c :=
   ⟨rigid_isRigid loaded, rfl⟩
 
@@ -741,4 +741,4 @@ this for each pair; lifting to a quantifier-over-pairs statement
 requires choosing a canonical `Mechanism` enum and an `exprs` registry.
 Previously stubbed in the deleted `Core/Conjectures.lean`. -/
 
-end Semantics.Reference.Almog2014
+end Reference.Almog2014

--- a/Linglib/Semantics/Reference/Basic.lean
+++ b/Linglib/Semantics/Reference/Basic.lean
@@ -21,7 +21,7 @@ These mechanisms are independent: a term can exhibit any subset.
 import Linglib.Semantics.Intensional.Rigidity
 import Linglib.Semantics.Reference.Context.Basic
 
-namespace Semantics.Reference.Basic
+namespace Reference.Basic
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid evalAt CoRefer CoExtensional
@@ -167,4 +167,4 @@ def Context.toKContext {W E P T : Type*} (c : Context W E) (addr : E) (p : P) (t
     Semantics.Context.KContext W E P T :=
   ⟨c.agent, addr, c.world, t, p⟩
 
-end Semantics.Reference.Basic
+end Reference.Basic

--- a/Linglib/Semantics/Reference/Binding.lean
+++ b/Linglib/Semantics/Reference/Binding.lean
@@ -19,7 +19,7 @@ import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Variables
 import Linglib.Semantics.Quantification.Quantifier
 
-namespace Semantics.Reference.Binding
+namespace Reference.Binding
 
 open Intensional
 open Intensional.Variables
@@ -116,4 +116,4 @@ theorem binding_establishes_diagonal {E : Type} (κ l : Nat)
 
 end CylindricAlgebra
 
-end Semantics.Reference.Binding
+end Reference.Binding

--- a/Linglib/Semantics/Reference/Demonstratives.lean
+++ b/Linglib/Semantics/Reference/Demonstratives.lean
@@ -25,12 +25,12 @@ import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.KaplanLD
 import Linglib.Semantics.Reference.Nominal
 
-namespace Semantics.Reference.Demonstratives
+namespace Reference.Demonstratives
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid)
 open Semantics.Context (KContext)
-open Semantics.Reference.Basic (ReferringExpression isDirectlyReferential)
+open _root_.Reference.Basic (ReferringExpression isDirectlyReferential)
 
 /-! ## Demonstrations -/
 
@@ -200,4 +200,4 @@ Demonstrations connect to RSA reference games:
 See `RSA.FrankGoodman2012` for a reference game implementation.
 -/
 
-end Semantics.Reference.Demonstratives
+end Reference.Demonstratives

--- a/Linglib/Semantics/Reference/Donnellan.lean
+++ b/Linglib/Semantics/Reference/Donnellan.lean
@@ -42,13 +42,13 @@ import Linglib.Semantics.Reference.Nominal
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Definiteness.Maximality
 
-namespace Semantics.Reference.Donnellan
+namespace Reference.Donnellan
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid)
 open Presupposition
 open Presupposition.PartialProp
-open Semantics.Reference.Basic
+open _root_.Reference.Basic
 open Definiteness
 
 /-! ## Use Modes -/
@@ -182,4 +182,4 @@ theorem attributive_is_pointwise_iota {W E : Type*} (domain : List E)
     attributiveContent domain restrictor w =
     russellIotaList domain (fun e => restrictor e w) := rfl
 
-end Semantics.Reference.Donnellan
+end Reference.Donnellan

--- a/Linglib/Semantics/Reference/FreeIndirectDiscourse.lean
+++ b/Linglib/Semantics/Reference/FreeIndirectDiscourse.lean
@@ -28,7 +28,7 @@ coordinates read from origin vs local.
 
 -/
 
-namespace Semantics.Reference.FreeIndirectDiscourse
+namespace Reference.FreeIndirectDiscourse
 
 open Semantics.Context
 
@@ -186,4 +186,4 @@ theorem fid_vs_direct_agent {W E P T : Type*}
     List.take, List.foldl, perspectiveShift]
   exact hDiff
 
-end Semantics.Reference.FreeIndirectDiscourse
+end Reference.FreeIndirectDiscourse

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -19,11 +19,11 @@ import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.Context.Tower
 import Linglib.Semantics.Reference.Context.Shifts
 
-namespace Semantics.Reference.Kaplan
+namespace Reference.Kaplan
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid)
-open Semantics.Reference.Basic
+open _root_.Reference.Basic
 open Semantics.Context (KContext)
 
 /-! ## Indexicals -/
@@ -313,4 +313,4 @@ theorem opActually_root (c : KContext W' E' P' T') :
 
 end TowerIndexicals
 
-end Semantics.Reference.Kaplan
+end Reference.Kaplan

--- a/Linglib/Semantics/Reference/KaplanLD.lean
+++ b/Linglib/Semantics/Reference/KaplanLD.lean
@@ -24,12 +24,12 @@ import Linglib.Semantics.Reference.Context.Basic
 import Linglib.Semantics.Intensional.Rigidity
 import Linglib.Semantics.Reference.Basic
 
-namespace Semantics.Reference.KaplanLD
+namespace Reference.KaplanLD
 
 open Intensional (Intension)
 open Intensional.Intension (rigid IsRigid rigid_isRigid StableCharacter)
 open Semantics.Context (KContext ProperContext LocatedContext)
-open Semantics.Reference.Basic (Context Character Content)
+open _root_.Reference.Basic (Context Character Content)
 
 /-! ## LD Structure -/
 
@@ -185,4 +185,4 @@ theorem actually_stable {W T : Type*} (cW : W) (φ : W → T → Prop) (t : T) :
     ∀ w₁ w₂ : W, opActually cW φ w₁ t = opActually cW φ w₂ t :=
   λ _ _ => rfl
 
-end Semantics.Reference.KaplanLD
+end Reference.KaplanLD

--- a/Linglib/Semantics/Reference/Kripke.lean
+++ b/Linglib/Semantics/Reference/Kripke.lean
@@ -29,13 +29,13 @@ import Linglib.Semantics.Intensional.Rigidity
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.KaplanLD
 
-namespace Semantics.Reference.Kripke
+namespace Reference.Kripke
 
 open Intensional (Intension)
 open Intensional.Intension (IsRigid rigid rigid_isRigid CoRefer CoExtensional
   rigid_identity_necessary varying_not_rigid rigid_neq_nonrigid)
-open Semantics.Reference.Basic (properName isDirectlyReferential)
-open Semantics.Reference.KaplanLD (dthatW dthatW_isRigid)
+open _root_.Reference.Basic (properName isDirectlyReferential)
+open _root_.Reference.KaplanLD (dthatW dthatW_isRigid)
 
 /-! ## De Re and De Dicto
 
@@ -223,4 +223,4 @@ theorem rigid_stronglyRigid {W E : Type*} {exists_ : E → W → Prop}
     IsStronglyRigid exists_ (rigid (W := W) e) :=
   ⟨rigid_isRigid e, hExists⟩
 
-end Semantics.Reference.Kripke
+end Reference.Kripke

--- a/Linglib/Semantics/Reference/Monsters.lean
+++ b/Linglib/Semantics/Reference/Monsters.lean
@@ -31,7 +31,7 @@ monster *predicate* and Kaplan's thesis, not the operator.
 
 -/
 
-namespace Semantics.Reference.Monsters
+namespace Reference.Monsters
 
 open Semantics.Context
 
@@ -112,4 +112,4 @@ theorem kaplansThesisAsTower {W : Type*} {E : Type*} {P : Type*} {T : Type*} :
   rw [hMem]
   exact identityShift_not_monster
 
-end Semantics.Reference.Monsters
+end Reference.Monsters

--- a/Linglib/Semantics/Reference/Nominal.lean
+++ b/Linglib/Semantics/Reference/Nominal.lean
@@ -21,7 +21,7 @@ generalisation of this signature, to be added when a dynamic study needs it.
   selector.
 * `NominalDenot.resolve` — resolve a nominal against a scope, as
   `PartialProp.presupOfReferent` applied to the selector at a context. Existing
-  definite denotations *are* this, by `rfl` (see `Semantics.Reference.Donnellan`).
+  definite denotations *are* this, by `rfl` (see `Reference.Donnellan`).
 * `NominalDenot.toPartialProp` — the full denotation: `resolve` conjoined with the
   intrinsic presupposition, so a pronoun's φ-features project.
 
@@ -41,7 +41,7 @@ The unification this core was built toward is realized by the seam lemma
 partiality layer this signature adds. Static reference and dynamic
 (`Set`/`PMF`) anaphora therefore meet at one lookup interface on the static
 fiber, and bound pronouns share that selector with binding supplied externally
-(`Semantics.Reference.Binding`).
+(`Reference.Binding`).
 
 Carrying the effect functor `M` *in this structure* (so `selector` is
 `Ctx → W → M (Option E)` and literally `iLookup`) is deliberately **not** done
@@ -52,7 +52,7 @@ belongs with the first dynamic consumer that requires it. Until then the seam
 lemma carries the connection.
 -/
 
-namespace Semantics.Reference
+namespace Reference
 
 open Presupposition
 
@@ -166,4 +166,4 @@ theorem bind_assoc (nd : NominalDenot Ctx W α) (k : α → NominalDenot Ctx W �
 
 end NominalDenot
 
-end Semantics.Reference
+end Reference

--- a/Linglib/Semantics/Reference/PersonFeatures.lean
+++ b/Linglib/Semantics/Reference/PersonFeatures.lean
@@ -31,7 +31,7 @@ the referent is the agent of an embedded context but NOT the actual speaker.
   condition
 -/
 
-namespace Semantics.Reference.PersonFeatures
+namespace Reference.PersonFeatures
 
 open Semantics.Context
 
@@ -158,4 +158,4 @@ theorem speaker_not_logophoric [BEq E] [LawfulBEq E]
     DepthSpec.origin_resolve, ContextTower.contextAt_zero,
     beq_self_eq_true, Bool.not_true, Bool.and_false]
 
-end Semantics.Reference.PersonFeatures
+end Reference.PersonFeatures

--- a/Linglib/Semantics/Reference/PluralityLicensing.lean
+++ b/Linglib/Semantics/Reference/PluralityLicensing.lean
@@ -36,7 +36,7 @@ substrate that defines `bindingCond`, `reciprocityCond`,
 `groupIdentityCond`.
 -/
 
-namespace Semantics.Reference.PluralityLicensing
+namespace Reference.PluralityLicensing
 
 open PPCDRT
 
@@ -155,4 +155,4 @@ theorem binding_compatible_with_singleton (e : E) (uAnaph uAnt : Nat) :
   · subst h; rfl
   · simp [PartialAssign.update_at, h]
 
-end Semantics.Reference.PluralityLicensing
+end Reference.PluralityLicensing

--- a/Linglib/Semantics/Reference/PronounDenotation.lean
+++ b/Linglib/Semantics/Reference/PronounDenotation.lean
@@ -21,7 +21,7 @@ This follows [buring-2012]'s survey: the assignment lookup (his (14)), the
 feature presuppositions (his (49)/(50)), and the absence-of-features treatment
 of unmarked values. The same `interpPronoun` selector serves bound, anaphoric,
 and deictic uses (his §2.1.1); binding is the external β-operator
-(`Semantics.Reference.Binding`).
+(`Reference.Binding`).
 
 ## Main definitions
 
@@ -39,7 +39,7 @@ bridges plus `ContainmentPairLike.toPair`, deferred until a study needs them.
 
 open Presupposition
 open Presupposition.PhiFeatures
-open Semantics.Reference (NominalDenot)
+open Reference (NominalDenot)
 open Intensional.Variables (interpPronoun DenotGS SitAssignment)
 
 /-- The conjoined φ-feature presupposition of a pronoun entry, over an entity

--- a/Linglib/Semantics/Reference/Reciprocals.lean
+++ b/Linglib/Semantics/Reference/Reciprocals.lean
@@ -63,7 +63,7 @@ distributive operators (§5) and logophoric antecedents (§6) — see
 [dalrymple-haug-2024] for the empirical contrast.
 -/
 
-namespace Semantics.Reference.Reciprocals
+namespace Reference.Reciprocals
 
 open PPCDRT
 
@@ -285,4 +285,4 @@ theorem readings_pairwise_distinct :
     crossedReading ≠ wideScopeReading := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
-end Semantics.Reference.Reciprocals
+end Reference.Reciprocals

--- a/Linglib/Semantics/Reference/ShiftedIndexicals.lean
+++ b/Linglib/Semantics/Reference/ShiftedIndexicals.lean
@@ -20,10 +20,10 @@ person shifts but time does not.
 
 -/
 
-namespace Semantics.Reference.ShiftedIndexicals
+namespace Reference.ShiftedIndexicals
 
 open Semantics.Context
-open Semantics.Reference.Kaplan
+open _root_.Reference.Kaplan
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
@@ -182,4 +182,4 @@ def englishMixed : MixedShiftLexicon :=
 theorem english_not_mixed :
     englishMixed.personDepth = englishMixed.temporalDepth := rfl
 
-end Semantics.Reference.ShiftedIndexicals
+end Reference.ShiftedIndexicals

--- a/Linglib/Semantics/Tense/TemporalAdverbials.lean
+++ b/Linglib/Semantics/Tense/TemporalAdverbials.lean
@@ -32,7 +32,7 @@ import Linglib.Semantics.Tense.TenseAspectComposition
 namespace Tense.TemporalAdverbials
 
 open Core.Order Tense
-open Semantics.Aspect
+open Aspect
 open Tense.TenseAspectComposition
 
 variable {W Time : Type*} [LinearOrder Time]

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -41,7 +41,7 @@ namespace Tense.TenseAspectComposition
 open Intensional (Index)
 
 open Core.Order
-open Semantics.Aspect
+open Aspect
 
 variable {W Time : Type*} [LinearOrder Time]
 

--- a/Linglib/Semantics/Truthmaker/Basic.lean
+++ b/Linglib/Semantics/Truthmaker/Basic.lean
@@ -80,7 +80,7 @@ the verification/falsification level:
 
 -/
 
-namespace Semantics.Truthmaker
+namespace Truthmaker
 
 
 -- ════════════════════════════════════════════════════
@@ -562,4 +562,4 @@ theorem subjectMatter_distinguishes_classically_equivalent :
     · exact ht
   exact hb_not_in_lhs (h ▸ hb_in_rhs)
 
-end Semantics.Truthmaker
+end Truthmaker

--- a/Linglib/Semantics/Truthmaker/Closure.lean
+++ b/Linglib/Semantics/Truthmaker/Closure.lean
@@ -34,7 +34,7 @@ witnesses; for infinitary closure use `LowerSet`-style packaging.
 
 -/
 
-namespace Semantics.Truthmaker
+namespace Truthmaker
 
 open _root_.Mereology
 
@@ -109,4 +109,4 @@ theorem isConvex_regularClose (p : TMProp S) :
 
 end Regular
 
-end Semantics.Truthmaker
+end Truthmaker

--- a/Linglib/Semantics/Truthmaker/Entailment.lean
+++ b/Linglib/Semantics/Truthmaker/Entailment.lean
@@ -46,7 +46,7 @@ which `BoxAt` cannot.
 
 -/
 
-namespace Semantics.Truthmaker
+namespace Truthmaker
 
 
 -- ════════════════════════════════════════════════════
@@ -155,4 +155,4 @@ theorem not_isSubsumedBy_tmOr_intro_general :
   cases ht
   exact absurd hle (by decide)
 
-end Semantics.Truthmaker
+end Truthmaker

--- a/Linglib/Semantics/Truthmaker/Inexact.lean
+++ b/Linglib/Semantics/Truthmaker/Inexact.lean
@@ -30,7 +30,7 @@ inside linglib.
 
 -/
 
-namespace Semantics.Truthmaker
+namespace Truthmaker
 
 
 -- ════════════════════════════════════════════════════
@@ -168,4 +168,4 @@ theorem InexactEntails.of_exact {p q : TMProp S} (h : p ⊨ₑ q) : p ⊨ᵢ q :
 
 end Entailment
 
-end Semantics.Truthmaker
+end Truthmaker

--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -54,7 +54,7 @@ namespace AghaJeretic2022
 
 open Trivalent (Prop3 dist dist_eq_true_iff dist_eq_false_iff dist_eq_indet_iff
   dist_not_of_nonempty)
-open Semantics.Homogeneity Quantification Data.Examples
+open Homogeneity Quantification Data.Examples
 open Generalizations.HomogeneityGap (GapDatum GapScenario fromExample)
 open Features (Polarity)
 

--- a/Linglib/Studies/AghaJeretic2026.lean
+++ b/Linglib/Studies/AghaJeretic2026.lean
@@ -52,7 +52,7 @@ without a formal counterpart here.
 namespace AghaJeretic2026
 
 open Modality.Kratzer Modality.Directive Data.Examples
-open Semantics.Homogeneity (negRaising_iff_subsingleton)
+open Homogeneity (negRaising_iff_subsingleton)
 open Exhaustification
 
 /-! ### Weak and strong necessity -/

--- a/Linglib/Studies/AlonsoOvalle2009.lean
+++ b/Linglib/Studies/AlonsoOvalle2009.lean
@@ -45,7 +45,7 @@ The paper's verdicts are checked in `rows_agree`.
 
 namespace AlonsoOvalle2009
 
-open Semantics.Conditionals Semantics.Conditionals.Counterfactual McKayVanInwagen1977
+open Conditionals Conditionals.Counterfactual McKayVanInwagen1977
   Data.Examples
 
 variable {W : Type*} [DecidableEq W] [Fintype W] (sim : SimilarityOrdering W)

--- a/Linglib/Studies/BarLev2021.lean
+++ b/Linglib/Studies/BarLev2021.lean
@@ -41,7 +41,7 @@ non-distributive extension of §8 is not formalized.
 
 namespace BarLev2021
 
-open Exhaustification Semantics.Plurality.Implicature
+open Exhaustification Plurality.Implicature
 
 variable {Atom W : Type*} {D x : Finset Atom} {P : Atom → W → Prop}
 

--- a/Linglib/Studies/BarLevFox2020.lean
+++ b/Linglib/Studies/BarLevFox2020.lean
@@ -144,7 +144,7 @@ theorem only_presup {R : W → W → Prop} {a b : Set W} (h₁ : ∃ w ∈ poss 
 
 section Simplification
 
-open Semantics.Conditionals Semantics.Conditionals.Counterfactual
+open Conditionals Conditionals.Counterfactual
 
 variable [DecidableEq W] [Fintype W] (sim : SimilarityOrdering W) (p q r : W → Prop)
   [DecidablePred p] [DecidablePred q] [DecidablePred r]
@@ -271,7 +271,7 @@ structure Switch where
 
 namespace Switch
 
-open Semantics.Conditionals
+open Conditionals
 
 /-- Worlds with a different wiring are farther than any with the same; among the latter,
 distance is the number of switches in another position. -/
@@ -301,7 +301,7 @@ instance : DecidablePred off := λ _ => inferInstanceAs (Decidable (_ = _))
 /-- Both switches up, and the light on exactly when the switches agree. -/
 def actual : Switch := ⟨true, true, λ x y => x == y⟩
 
-open Semantics.Conditionals.Counterfactual
+open Conditionals.Counterfactual
 
 /-- *If switch A or switch B were down, the light would be off* (76) is true in the scenario:
 its strengthening asserts both simplifications and denies the conjunctive one. -/

--- a/Linglib/Studies/Beck2001.lean
+++ b/Linglib/Studies/Beck2001.lean
@@ -51,7 +51,7 @@ comparison); the trivalent divergence from [sternefeld-1998] in
 
 namespace Beck2001
 
-open Semantics.Plurality.Reciprocal
+open Plurality.Reciprocal
 
 variable {α : Type*}
 

--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -133,8 +133,8 @@ theorem ms_decomposition_eq_coord {E W : Type} (e1 e2 : E) (p : E → Prop) :
 
 open Intensional.Conjunction in
 open Quantification (individual) in
-open Semantics.Plurality in
-open Semantics.Plurality.Distributivity in
+open Plurality in
+open Plurality.Distributivity in
 /-- The decomposition is distributive predication over the pair of conjuncts. -/
 theorem mu_is_distributive_check {E W : Type} [DecidableEq E]
     (e1 e2 : E) (P : E → Unit → Prop) [∀ a u, Decidable (P a u)] :

--- a/Linglib/Studies/Bohnemeyer2004.lean
+++ b/Linglib/Studies/Bohnemeyer2004.lean
@@ -46,7 +46,7 @@ linking-relevant property. Two classes of counterevidence:
 namespace Bohnemeyer2004
 
 open ArgumentStructure.EventStructure (EventType InternalExternalCause Template)
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open Mayan (MarkerSet)
 open Yukatek
 

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -275,7 +275,7 @@ theorem transparentSSMapping_diagonal :
 
 /-! ### The Comp head -/
 
-open Semantics.Truthmaker in
+open Truthmaker in
 /-- The Comp head (§2.3 ex. 151): `x` is part of the evaluation situation
 and exactly verifies `p`, `compHead p x s ↔ x ≤ s ∧ p x`. -/
 def compHead [Preorder S] (p : S → Prop) (x s : S) : Prop :=
@@ -283,7 +283,7 @@ def compHead [Preorder S] (p : S → Prop) (x s : S) : Prop :=
 
 /-- Exact exemplification by a part is inexact verification. -/
 theorem inexactVer_of_compHead [Preorder S] {p : S → Prop} {x s : S}
-    (h : compHead p x s) : Semantics.Truthmaker.inexactVer p s :=
+    (h : compHead p x s) : Truthmaker.inexactVer p s :=
   ⟨x, h.1, h.2⟩
 
 /-! ### Cont exponence -/

--- a/Linglib/Studies/BondarenkoElliott2026.lean
+++ b/Linglib/Studies/BondarenkoElliott2026.lean
@@ -26,7 +26,7 @@ under conjunction needs two further principles, that the content of a sum is the
 intersection of the contents and that one holder's believings are closed under sum
 (`believes_inter`); without them belief need not close (`not_believes_inter`). Finally, the
 paper's refinement of informational parthood to Fine's conjunctive parthood on alternative
-sets is `Semantics.Truthmaker.IsContentPart`, and its witness that disjunction introduction
+sets is `Truthmaker.IsContentPart`, and its witness that disjunction introduction
 fails — *Jessica married an American linguist* does not make *Jessica married a linguist or
 a philosopher* a conjunctive part — is `not_isContentPart_disjunction`.
 
@@ -240,7 +240,7 @@ theorem not_believes_inter :
 
 /-! ### Conjunctive parthood -/
 
-open Semantics.Truthmaker (IsContentPart)
+open Truthmaker (IsContentPart)
 
 /-- A singleton `{q}` is a content part of `p` only if `q` lies below every `p`-element. -/
 theorem not_isContentPart_singleton {α : Type*} [Preorder α] {q q' : α} {p : α → Prop}

--- a/Linglib/Studies/BonehDoron2013.lean
+++ b/Linglib/Studies/BonehDoron2013.lean
@@ -55,8 +55,8 @@ and [pancheva-2003]'s final-subinterval perfect.
 namespace BonehDoron2013
 
 open Quantification
-open Semantics.Genericity (Situation traditionalGEN)
-open Semantics.Aspect (Perfectivity IntervalPred IMPF)
+open Genericity (Situation traditionalGEN)
+open Aspect (Perfectivity IntervalPred IMPF)
 open Modality.Kratzer (ModalBase accessibleWorlds)
 
 /-! ### Hab against Gen ((4)–(8), (13)–(15))

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -75,7 +75,7 @@ open Semantics.Composition
 open Semantics.Composition.Tree
 open Pragmatics.Expressives
 open Quantification
-open Semantics.Reference.Binding
+open Reference.Binding
 open Intensional
 open Intensional.Variables
 open Semantics.Montague

--- a/Linglib/Studies/Buring2012.lean
+++ b/Linglib/Studies/Buring2012.lean
@@ -20,7 +20,7 @@ theorems are about.
   not assertion).
 * A *bound* pronoun has the *same* denotation as a free one — binding is
   supplied externally by an assignment update, not by a distinct lexical entry
-  (Büring's §3 thesis; the continuation rendering is `Semantics.Reference.Binding`).
+  (Büring's §3 thesis; the continuation rendering is `Reference.Binding`).
 
 A fourth theorem records the [arnold-2026] contrast that motivates the
 English `epicene` paradigm: *they* carries no gender presupposition, so it is

--- a/Linglib/Studies/BuringGunlogson2000.lean
+++ b/Linglib/Studies/BuringGunlogson2000.lean
@@ -38,7 +38,7 @@ inner-negation NPQ, `HiNQ` its outer-negation NPQ.
 
 namespace BuringGunlogson2000
 
-open Semantics.Questions.Bias
+open Questions.Bias
 
 /-! ### Compelling contextual evidence -/
 

--- a/Linglib/Studies/CarianiGoldstein2020.lean
+++ b/Linglib/Studies/CarianiGoldstein2020.lean
@@ -36,8 +36,8 @@ not yet present in linglib and are left as future work.
 
 namespace CarianiGoldstein2020
 
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual (homogeneity)
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual (homogeneity)
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/CarianiSantorio2018.lean
+++ b/Linglib/Studies/CarianiSantorio2018.lean
@@ -69,9 +69,9 @@ applying (paper §8.2 footnote 32).
 
 namespace CarianiSantorio2018
 
-open _root_.Semantics.Conditionals (SelectionFunction)
+open _root_.Conditionals (SelectionFunction)
 open Modality.Selectional
-open Semantics.Conditionals.WillConditional
+open Conditionals.WillConditional
   (wouldConditional willConditional universalWillConditional compositional_CEM)
 open scoped ENNReal
 
@@ -148,7 +148,7 @@ noncomputable def cynthiaSel : SelectionFunction W where
     Proved by exhaustive enumeration over 3⁴ = 81 quadruples. -/
 theorem cynthiaSel_coherent : cynthiaSel.isCoherent := by
   intro w₀ w₁ w₂ w₃ h12 h23
-  unfold _root_.Semantics.Conditionals.selectionPrefers cynthiaSel selFn at *
+  unfold _root_.Conditionals.selectionPrefers cynthiaSel selFn at *
   revert h12 h23
   cases w₀ <;> cases w₁ <;> cases w₂ <;> cases w₃ <;>
     simp_all (config := { decide := true })
@@ -383,7 +383,7 @@ theorem universal_will_conditional_cem_fails :
     ¬ universalWillConditional wearsCap warriorsCap histAlt .cw ∧
     ¬ universalWillConditional wearsCap (fun w => ¬ warriorsCap w) histAlt .cw := by
   unfold universalWillConditional _root_.Modality.Selectional.universalWill
-    _root_.Semantics.Conditionals.WillConditional.restrict
+    _root_.Conditionals.WillConditional.restrict
   refine ⟨fun h => ?_, fun h => ?_⟩
   · have hcg : (W.cg) ∈ warriorsCap :=
       h .cg ⟨by simp [histAlt], show (W.cg) ∈ wearsCap by decide⟩

--- a/Linglib/Studies/Champollion2016.lean
+++ b/Linglib/Studies/Champollion2016.lean
@@ -45,7 +45,7 @@ namespace Champollion2016
 open Intensional
 open Intensional.Conjunction
 open Quantification (individual)
-open Semantics.Plurality.Algebra
+open Plurality.Algebra
 
 /-! ### The type-shift `⊔ ↦ ⊓` is guarded to distributive predicates
 

--- a/Linglib/Studies/Champollion2017.lean
+++ b/Linglib/Studies/Champollion2017.lean
@@ -38,7 +38,7 @@ verbs.
 
 namespace Verb
 
-open Semantics.Aspect.Stratified
+open Aspect.Stratified
 
 /-! ### Verb distributivity — derived from `Verb.denote`
 
@@ -70,9 +70,9 @@ namespace Champollion2017
 open English.Predicates.Verbal
 open Features (forXPrediction inXPrediction)
 open _root_.Mereology
-open Semantics.Plurality.Algebra (Materialization)
-open Semantics.Aspect.Stratified
-open Semantics.Plurality.Cover (IsFinCover algClosure_iff_exists_finCover)
+open Plurality.Algebra (Materialization)
+open Aspect.Stratified
+open Plurality.Cover (IsFinCover algClosure_iff_exists_finCover)
 
 /-! ### §2.7.2 algebraic substrate -/
 

--- a/Linglib/Studies/Charlow2018.lean
+++ b/Linglib/Studies/Charlow2018.lean
@@ -503,25 +503,25 @@ The paper's operations are instantiations of the Reader monad from
 
 section ReaderBridge
 
-open Semantics.Reference.Binding
+open Reference.Binding
 
 variable {E W : Type}
 
 /-- `constDenot` is the Reader monad's `pure`. -/
 theorem constDenot_is_reader_pure {σ : Ty} (d : Denot E W σ) :
     constDenot d =
-    @Pure.pure (Semantics.Reference.Binding.Reader (Assignment E)) _ _ d := rfl
+    @Pure.pure (Reference.Binding.Reader (Assignment E)) _ _ d := rfl
 
 /-- VF `readerPure` is also the Reader monad's `pure`. -/
 theorem readerPure_is_reader_monad_pure {A : Type} (x : A) :
     readerPure (E := E) x =
-    @Pure.pure (Semantics.Reference.Binding.Reader E) _ A x := rfl
+    @Pure.pure (Reference.Binding.Reader E) _ A x := rfl
 
 /-- `denotGJoin` (the paper's μ, eq. 19) is the `W` (duplicator)
 combinator from `Binding.lean`. -/
 theorem denotGJoin_is_W {A : Type}
     (f : Assignment E → Assignment E → A) :
-    denotGJoin f = Semantics.Reference.Binding.W f := rfl
+    denotGJoin f = Reference.Binding.W f := rfl
 
 end ReaderBridge
 

--- a/Linglib/Studies/ChungMascarenhas2024.lean
+++ b/Linglib/Studies/ChungMascarenhas2024.lean
@@ -243,7 +243,7 @@ transparent compositional form of English *must*:
 
 1. the evaluative predicate `toy` 'EVAL' as the measure function `μ_R`
 2. the conditional `if φ, EVAL` as `E_w[μ_R ∣ φ]` (their eq. 44, our
-   `Semantics.Conditionals.Probabilistic.condIf`)
+   `Conditionals.Probabilistic.condIf`)
 3. the exhaustifier `-(e)ya` 'only-if' adding the alternative
    negation: `∀ψ ∈ Alt(φ). E_w[μ_R ∣ ψ] ≤ θ`
 

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -77,7 +77,7 @@ into a Crucial Set (the lumping-closure condition); it doesn't relax
 the for-all-supersets quantifier. Whether this rescues the analysis on
 the switches scenario requires building a properly situation-semantic
 switches model and instantiating
-`Semantics.Conditionals.PremiseSemantic.wouldCF`; we leave this as
+`Conditionals.PremiseSemantic.wouldCF`; we leave this as
 future work.
 
 For the first concrete `wouldCF` instantiation on a situation-semantic
@@ -94,8 +94,8 @@ combined with inquisitive lifting (§4) — and §6.4's SNCA derivation
 
 namespace CiardelliZhangChampollion2018
 
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual
   (universalCounterfactual selectionalCounterfactual homogeneityCounterfactual
    PresupStatus PresupResult)
 

--- a/Linglib/Studies/CiardelliZhangChampollion2018Lumping.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018Lumping.lean
@@ -85,8 +85,8 @@ The empty Base Set keeps the proofs direct.
 namespace CiardelliZhangChampollion2018Lumping
 
 open Intensional
-open Semantics.Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
-open Semantics.Conditionals.PremiseSemantic
+open Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
+open Conditionals.PremiseSemantic
   (CrucialSet IsCrucialSet wouldCF)
 
 /-! ## The switches model -/

--- a/Linglib/Studies/Cohen1999.lean
+++ b/Linglib/Studies/Cohen1999.lean
@@ -56,7 +56,7 @@ divergence as a theorem against `cohenGEN`.
 
 namespace Cohen1999
 
-open Semantics.Genericity (Situation)
+open Genericity (Situation)
 open Quantification (prevalenceOn countOn everyOn thresholdGtOn thresholdGtOn_iff_prevalenceOn
   mostOn thresholdGtOn_one_two_iff_mostOn Proportional mostOn_univ_proportional
   count count_decompose)

--- a/Linglib/Studies/Condoravdi2002.lean
+++ b/Linglib/Studies/Condoravdi2002.lean
@@ -42,7 +42,7 @@ Present and for the Past. In D. Beaver, S. Kaufmann, B. Clark, & L. Casillas
 namespace Condoravdi2002
 
 open Features (Dynamicity)
-open Semantics.Aspect
+open Aspect
 open HistoricalAlternatives
 open Modality (TemporalPerspective TemporalOrientation)
 

--- a/Linglib/Studies/CondoravdiLauer2016.lean
+++ b/Linglib/Studies/CondoravdiLauer2016.lean
@@ -60,7 +60,7 @@ namespace CondoravdiLauer2016
 
 open Desire
 open Modality.Kratzer
-open Semantics.Conditionals.Restrictor
+open Conditionals.Restrictor
 
 universe u
 

--- a/Linglib/Studies/DalrympleHaug2024.lean
+++ b/Linglib/Studies/DalrympleHaug2024.lean
@@ -47,7 +47,7 @@ cases, while the quantificational analysis fails for distributive operators
 
 namespace DalrympleHaug2024
 
-open Semantics.Reference.Reciprocals
+open Reference.Reciprocals
 open PPCDRT
 open Core
 

--- a/Linglib/Studies/Dayal2016.lean
+++ b/Linglib/Studies/Dayal2016.lean
@@ -61,7 +61,7 @@ holds (`IsExhaustivelyResolvable`).
 namespace Dayal2016
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Declerck1991.lean
+++ b/Linglib/Studies/Declerck1991.lean
@@ -782,7 +782,7 @@ Boundedness is sentence-level and distinct from telicity: *Bill ran five
 miles* is bounded but *Bill was running five miles* is unbounded, with
 the same telic VP. These are pragmatic defaults, not entailments. -/
 
-open Semantics.Aspect (SituationBoundedness)
+open Aspect (SituationBoundedness)
 
 /-- The three default temporal arrangements of Declerck's principle of
 unmarked temporal interpretation. -/

--- a/Linglib/Studies/DelPrete2013.lean
+++ b/Linglib/Studies/DelPrete2013.lean
@@ -61,7 +61,7 @@ the SOE conflicting with common knowledge (§8.7).
 
 namespace DelPrete2013
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 
 -- ═══ Reading Types ═══
 

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -67,7 +67,7 @@ open Definiteness
 open Definiteness
 open Intensional (SitVarStatus ReferentialMode)
 open Definiteness
-open Semantics.Reference.Donnellan (UseMode definiteNominal)
+open Reference.Donnellan (UseMode definiteNominal)
 
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/ErkHerbelot2024.lean
+++ b/Linglib/Studies/ErkHerbelot2024.lean
@@ -112,7 +112,7 @@ back-solve, don't intervals").
 namespace ErkHerbelot2024
 
 open scoped ENNReal
-open Semantics.Probabilistic.SDS
+open Probabilistic.SDS
 
 -- ════════════════════════════════════════════════════
 -- §1. Concept, scenario, role types (paper §5.1, p. 569)

--- a/Linglib/Studies/EvcenBaleBarner2026.lean
+++ b/Linglib/Studies/EvcenBaleBarner2026.lean
@@ -35,7 +35,7 @@ competent about, `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}` — is
 the same derivation [bale-etal-2025]'s scalar-implicature paradigm uses,
 so conditional perfection and scalar implicature share the competence
 gate by construction. Perfection is not a semantic entailment
-(`Semantics.Conditionals.perfection_not_entailed_variablyStrict`), and
+(`Conditionals.perfection_not_entailed_variablyStrict`), and
 coverage without exclusion does not suffice
 (`VonFintel2001.coverage_without_exclusion_insufficient`).
 
@@ -54,7 +54,7 @@ coverage without exclusion does not suffice
 
 namespace EvcenBaleBarner2026
 
-open VonFintel2001 Semantics.Conditionals Exhaustification NeoGricean
+open VonFintel2001 Conditionals Exhaustification NeoGricean
 open BaleEtAl2025 (speakerState all competent_iff_looked)
 open GoodmanStuhlmuller2013 (Access WorldState)
 

--- a/Linglib/Studies/Filip2012.lean
+++ b/Linglib/Studies/Filip2012.lean
@@ -51,8 +51,8 @@ namespace Filip2012
 
 open _root_.Mereology
 open ArgumentStructure
-open Semantics.Aspect.Incremental
-open Semantics.Aspect.Cumulativity
+open Aspect.Incremental
+open Aspect.Cumulativity
 
 /-! ### Three-way exhaustiveness (Filip's distinctive observation) -/
 

--- a/Linglib/Studies/Fox2018.lean
+++ b/Linglib/Studies/Fox2018.lean
@@ -67,7 +67,7 @@ informative true Hamblin alternative.
 namespace Fox2018
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/GartnerGyuris2017.lean
+++ b/Linglib/Studies/GartnerGyuris2017.lean
@@ -31,7 +31,7 @@ and verified against the delimiting principles.
 
 namespace GartnerGyuris2017
 
-open Semantics.Questions.Bias (PQForm OriginalBias ContextualEvidence)
+open Questions.Bias (PQForm OriginalBias ContextualEvidence)
 
 -- ============================================================================
 -- §1: Core Types

--- a/Linglib/Studies/George2011.lean
+++ b/Linglib/Studies/George2011.lean
@@ -78,7 +78,7 @@ of all alternatives true at `w`.
 namespace George2011
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -69,7 +69,7 @@ namespace Giannakidou2002
 
 open Core.Order
 open NonemptyInterval
-open Semantics.Aspect
+open Aspect
 open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
 variable {Time : Type*} [LinearOrder Time]

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -88,7 +88,7 @@ the specific empirical regularity the world-knowledge component is fit to.
 namespace GroveWhite2025
 
 open Factivity
-open Semantics.Probabilistic
+open Probabilistic
 open DegenTonhauser2021
 open DegenTonhauser2022
 open scoped ENNReal NNReal

--- a/Linglib/Studies/GrusdtLassiterFranke2022.lean
+++ b/Linglib/Studies/GrusdtLassiterFranke2022.lean
@@ -48,7 +48,7 @@ to exact `PMF` evaluation.
 ## Grounding
 
 The assertability truth values are grounded in the probabilistic assertability
-condition from `Semantics.Probabilistic.ConditionalAssertability`: a conditional
+condition from `Probabilistic.ConditionalAssertability`: a conditional
 "if A then C" is assertable when P(A) > 0 and P(C|A) ≥ θ.
 
 ## Experiments
@@ -66,7 +66,7 @@ namespace GrusdtLassiterFranke2022
 
 open Causation
 open Causation.BayesNet
-open Semantics.Probabilistic.ConditionalAssertability
+open Probabilistic.ConditionalAssertability
 open Causation.Sufficiency
 open Causation.Necessity
 open scoped ENNReal

--- a/Linglib/Studies/Guerrini2026.lean
+++ b/Linglib/Studies/Guerrini2026.lean
@@ -35,7 +35,7 @@ stimuli are typed rows in `Data/Examples/Guerrini2026.json` (`Examples.all`).
 namespace Guerrini2026
 
 open Semantics.Kinds.NMP (NominalMapping NominalDenotation CanDenoteKind downDefinedFor)
-open Semantics.Plurality (distMaximal allSatisfy noneSatisfy)
+open Plurality (distMaximal allSatisfy noneSatisfy)
 open Data.Examples (LinguisticExample)
 
 /-! ### The four LF parses -/
@@ -85,7 +85,7 @@ abbrev distributiveKindPred {Atom W : Type} (kindExt : W → Finset Atom)
     extension to a set of locations (§4, structure (62)). -/
 abbrev cumulativeKindPred {Atom Loc : Type} (R : Atom → Loc → Prop)
     (kindExt : Finset Atom) (locations : Finset Loc) : Prop :=
-  Semantics.Plurality.Cumulativity.Cumulative R kindExt locations
+  Plurality.Cumulativity.Cumulative R kindExt locations
 
 /-! ### Nominal Mapping and denotation (diagram (145), §5.3) -/
 

--- a/Linglib/Studies/Hacquard2006.lean
+++ b/Linglib/Studies/Hacquard2006.lean
@@ -39,7 +39,7 @@ Substrate note: the event-relative machinery (`EventBinder`,
 namespace Hacquard2006
 
 open Modality Modality.Kratzer
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open Data.Examples (LinguisticExample)
 
 /-! ### Position → temporal perspective

--- a/Linglib/Studies/HaslingerEtAl2025.lean
+++ b/Linglib/Studies/HaslingerEtAl2025.lean
@@ -37,9 +37,9 @@ import Linglib.Fragments.German.Distributives
 
 namespace HaslingerEtAl2025
 
-open Semantics.Plurality
-open Semantics.Plurality.Distributivity
-open Semantics.Plurality.Trivalent
+open Plurality
+open Plurality.Distributivity
+open Plurality.Trivalent
 
 -- German Distributive Lexical Items
 

--- a/Linglib/Studies/HaslingerHienEtAl2025.lean
+++ b/Linglib/Studies/HaslingerHienEtAl2025.lean
@@ -54,9 +54,9 @@ namespace HaslingerHienEtAl2025
 
 open Quantification.UnifiedUniversal
 open Quantification.ONEModifiers
-open Semantics.Plurality
-open Semantics.Plurality.Distributivity
-open Semantics.Plurality.Trivalent
+open Plurality
+open Plurality.Distributivity
+open Plurality.Trivalent
 open _root_.Mereology
 
 /-! ### Cross-linguistic typology

--- a/Linglib/Studies/HaugDalrymple2020.lean
+++ b/Linglib/Studies/HaugDalrymple2020.lean
@@ -65,10 +65,10 @@ docstrings here follow that attribution.
 
 namespace HaugDalrymple2020
 
-open Semantics.Reference.Reciprocals
+open Reference.Reciprocals
 open PPCDRT
 open Trivalent (dist metaAssert)
-open Semantics.Plurality.Cumulativity
+open Plurality.Cumulativity
 
 -- ════════════════════════════════════════════════════════════════
 -- § 0: Toy domain — Tracy / Chris / Matty
@@ -544,7 +544,7 @@ theorem quantifiedReciprocalTV_iff_supervaluation
     simp [hdEval, hdSpec, hm, hr]
 
 /-! **Sibling parallel — Križ 2016 plural homogeneity.**
-    `Semantics.Homogeneity.barePlural_eq_superTrue` reduces plural
+    `Homogeneity.barePlural_eq_superTrue` reduces plural
     homogeneity to `superTrue` over **atoms in the plurality** as
     specification points; the bridge above reduces the H&D §5 reciprocal
     gap to `superTrue` over **precisifications of the reciprocal's

--- a/Linglib/Studies/Heim1992.lean
+++ b/Linglib/Studies/Heim1992.lean
@@ -168,8 +168,8 @@ false under the belief state `sick`, since `w2` is believed and not recovered. -
 theorem not_sick_subset_recovered : ¬ sick ⊆ recovered := λ h => @h .w2 trivial
 
 /-- Every world is equally similar to every other. -/
-def trivialSim : Semantics.Conditionals.SimilarityOrdering HealthWorld := by
-  refine Semantics.Conditionals.SimilarityOrdering.ofBool (λ _ _ _ => true) ?_ ?_
+def trivialSim : Conditionals.SimilarityOrdering HealthWorld := by
+  refine Conditionals.SimilarityOrdering.ofBool (λ _ _ _ => true) ?_ ?_
   · intros; rfl
   · intros; rfl
 

--- a/Linglib/Studies/Heim1994.lean
+++ b/Linglib/Studies/Heim1994.lean
@@ -67,7 +67,7 @@ contexts).
 namespace Heim1994
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/HeimComments1994.lean
+++ b/Linglib/Studies/HeimComments1994.lean
@@ -212,12 +212,12 @@ theorem isFelicitousWith_past_imp_upperLimitConstraint
     Lewis."
 
     Heim's "suitable" set of time-concepts IS the substrate's
-    `Semantics.Reference.Acquaintance.Cover` at the appropriate
+    `Reference.Acquaintance.Cover` at the appropriate
     instantiation `Idx := Index W T`, `Res := T`. Membership
     `c ∈ cov` is the suitability predicate directly — no separate
     `IsSuitable` wrapper is needed. -/
 abbrev SuitableTimeCover (W T : Type*) :=
-  Semantics.Reference.Acquaintance.Cover (Index W T) T
+  Reference.Acquaintance.Cover (Index W T) T
 
 /-- **Pullback preserves cover exhaustiveness**: if `cov` is a
     suitability cover for Heim time-concepts that exhaustively
@@ -232,7 +232,7 @@ abbrev SuitableTimeCover (W T : Type*) :=
 theorem toSubstrate_image_isExhaustiveOn {W E P T : Type*}
     {cov : SuitableTimeCover W T} {dom : Set T}
     (h : cov.isExhaustiveOn dom) :
-    Semantics.Reference.Acquaintance.Cover.isExhaustiveOn
+    Reference.Acquaintance.Cover.isExhaustiveOn
       ((fun c : TimeConcept W T =>
         toSubstrate (E := E) (P := P) c) '' cov) dom := by
   intro k r hr

--- a/Linglib/Studies/HeimLasnikMay1991.lean
+++ b/Linglib/Studies/HeimLasnikMay1991.lean
@@ -64,7 +64,7 @@ because distributors are undefined on atoms and cannot iterate.
 
 namespace HeimLasnikMay1991
 
-open Semantics.Plurality.Reciprocal
+open Plurality.Reciprocal
 
 variable {A : Type*} [DecidableEq A]
 
@@ -74,7 +74,7 @@ HLM's model is `⟨D, A, Π⟩`: a domain with mereological structure, atoms
 `A`, and proper-part-of `Π`; `·Π` is the proper-*atomic*-part relation.
 Pluralities are encoded here as `Finset A` (sums of atoms) with `·Π` as
 membership, matching the `(R, X)` signature of
-`Semantics.Plurality.Reciprocal`. -/
+`Plurality.Reciprocal`. -/
 
 /-- (16): *other* as a 3-place relation — referent `z` is an atomic part
     of the range `y` distinct from the contrast `x`. In reciprocals both
@@ -110,7 +110,7 @@ def eachOtherLF (np : Finset A) (R : A → A → Prop) : Prop :=
 /-- The compositional each∘other analysis derives Strong Reciprocity:
     HLM's truth conditions "coincide with those of the standard semantic
     analyses". Through the entailment lattice of
-    `Semantics.Plurality.Reciprocal`, the weaker schemes follow
+    `Plurality.Reciprocal`, the weaker schemes follow
     (`strong_imp_weak`, …). -/
 theorem eachOtherLF_iff_strongReciprocity (np : Finset A) (R : A → A → Prop) :
     eachOtherLF np R ↔ StrongReciprocity R np := by

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -173,7 +173,7 @@ def usesImperfectiveInCF : CFLanguage → Bool
 -- Fragment-level lexical fact (cf. Mizuno's use of Japanese `eba` / Mandarin `ruguo`);
 -- the CF-type morphology classification below is [iatridou-2000]'s analysis (this study).
 #guard English.Conditionals.if_.markerType ==
-  Semantics.Conditionals.ConditionalMarkerType.both
+  Conditionals.ConditionalMarkerType.both
 
 /-! ### Subjunctive-requirement data ([iatridou-2000], §6.1) -/
 

--- a/Linglib/Studies/IatridouZeijlstra2021.lean
+++ b/Linglib/Studies/IatridouZeijlstra2021.lean
@@ -51,8 +51,8 @@ framework but has not been line-by-line cross-checked against IZ
 namespace IatridouZeijlstra2021
 
 open Core.Order Tense
-open Semantics.Aspect
-open Semantics.Aspect.SubintervalProperty
+open Aspect
+open Aspect.SubintervalProperty
 open Tense.TemporalAdverbials (PTSConstraint AdverbialType)
 open IatridouEtAl2001 (BoundaryKind)
 open Kiparsky2002 (PerfectReading)

--- a/Linglib/Studies/IoninMatushansky2006.lean
+++ b/Linglib/Studies/IoninMatushansky2006.lean
@@ -47,7 +47,7 @@ singular nouns; the syntax here is his grammar
 ## Main definitions
 
 - `IsPart`: their (6) partition (Finset counterpart of
-  `Semantics.Plurality.Cover.IsPartition`, chosen for cardinality
+  `Plurality.Cover.IsPartition`, chosen for cardinality
   counting)
 - `cardMod`: their (5) cardinal-as-modifier
 - `Equicardinal`: their (23) countability presupposition
@@ -72,7 +72,7 @@ variable {α : Type*} [DecidableEq α]
 
 /-- Their (6): `S` is a partition of `x` — nonempty, pairwise-disjoint
 cells whose union is `x`. Finset counterpart of
-`Semantics.Plurality.Cover.IsPartition`. -/
+`Plurality.Cover.IsPartition`. -/
 def IsPart (S : Finset (Finset α)) (x : Finset α) : Prop :=
   (∀ s ∈ S, s ≠ ∅) ∧ (S : Set (Finset α)).PairwiseDisjoint id ∧
     S.sup id = x

--- a/Linglib/Studies/IppolitoKissWilliams2022.lean
+++ b/Linglib/Studies/IppolitoKissWilliams2022.lean
@@ -45,7 +45,7 @@ agreement. Both relations are symmetric in their `S`/`S'` arguments.
 
 namespace IppolitoKissWilliams2022
 
-open Question Semantics.Questions.Probabilistic
+open Question Questions.Probabilistic
 
 variable {W : Type*}
 

--- a/Linglib/Studies/IppolitoKissWilliams2025.lean
+++ b/Linglib/Studies/IppolitoKissWilliams2025.lean
@@ -106,7 +106,7 @@ answer whose existence the definedness condition requires.
 
 namespace IppolitoKissWilliams2025
 
-open Question Semantics.Questions.Probabilistic
+open Question Questions.Probabilistic
 open Question (isRelevantTo_polar_iff)
 open IppolitoKissWilliams2022
 

--- a/Linglib/Studies/Istratkova2004.lean
+++ b/Linglib/Studies/Istratkova2004.lean
@@ -43,7 +43,7 @@ glosses stacked *po-* as DLMT, the analyses here follow her own labels
 
 namespace Istratkova2004
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open Verb (Stem)
 open Svenonius2004 (Analysis WellStacked)
 open Bulgarian.Verbs

--- a/Linglib/Studies/Jablonska2004.lean
+++ b/Linglib/Studies/Jablonska2004.lean
@@ -29,7 +29,7 @@ common semantic denominator across the readings. Her fn. 2 notes that
 
 namespace Jablonska2004
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open Svenonius2004 (Analysis WellStacked)
 open Polish.Verbs
 

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -993,7 +993,7 @@ meaning, satisfying the logical operator licensing condition (§6.3.3).
 More precisely: "q UNLESS p" entails that ¬p is true in all
 *suppositive worlds* (worlds where q holds). -/
 
-open Semantics.Conditionals (materialImp)
+open Conditionals (materialImp)
 
 /-- UNLESS q p is definable as material implication with negated
     antecedent: if ¬p then q. The negation is structural. -/

--- a/Linglib/Studies/Karttunen1977.lean
+++ b/Linglib/Studies/Karttunen1977.lean
@@ -56,7 +56,7 @@ substrate is in place.
 namespace Karttunen1977
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -63,8 +63,8 @@ namespace Kiparsky2002
 
 open Core.Order
 open Features
-open Semantics.Aspect
-open Semantics.Aspect.SubeventStructure
+open Aspect
+open Aspect.SubeventStructure
 
 -- ════════════════════════════════════════════════════
 -- § 1. Perfect Readings ([kiparsky-2002])
@@ -219,7 +219,7 @@ asserted. Wh-extraction from presupposed content is blocked. This explains why *
 (the eating is presupposed, so "what" cannot extract from it).
 
 TODO: Full formalization requires bridging to presupposition semantics
-(Presupposition) and question semantics (Semantics.Questions). -/
+(Presupposition) and question semantics (Questions). -/
 
 /-- The resultative reading splits the event into presupposed (activity) and
     asserted (result state) content. -/

--- a/Linglib/Studies/KirkGiannini2024.lean
+++ b/Linglib/Studies/KirkGiannini2024.lean
@@ -1003,13 +1003,13 @@ explains c-monstrous behavior WITHOUT touching the
 worlds-as-evaluation-points architecture or introducing context shifts.
 -/
 theorem diagonalize_no_kaplan_monster {W E P T : Type*} :
-    Semantics.Reference.Monsters.KaplansThesisHolds
+    Reference.Monsters.KaplansThesisHolds
       (kgEmbeddingShifts (W := W) (E := E) (P := P) (T := T)) := by
   intro σ hMem
   -- All entries in kgEmbeddingShifts are identityShift, never a monster.
   simp [kgEmbeddingShifts] at hMem
   rcases hMem with rfl | rfl | rfl | rfl
-  all_goals exact Semantics.Reference.Monsters.identityShift_not_monster
+  all_goals exact Reference.Monsters.identityShift_not_monster
 
 /--
 **K-G refutes KJR's convention-shift architecture.** KJR

--- a/Linglib/Studies/Kirkpatrick2024.lean
+++ b/Linglib/Studies/Kirkpatrick2024.lean
@@ -41,7 +41,7 @@ makes exceptional individuals salient before the general claim is assessed.
 
 namespace Kirkpatrick2024
 
-open Semantics.Genericity.Dynamic
+open Genericity.Dynamic
 
 
 -- ═══ Toy Model: Ravens ═══

--- a/Linglib/Studies/KonukEtAl2026.lean
+++ b/Linglib/Studies/KonukEtAl2026.lean
@@ -252,7 +252,7 @@ theorem loss_gap_iff_pluralGap :
     (lossClassical (f 0) (f 1) (f 2) (f 3) = true ∧
      lossStrong (f 0) (f 1) (f 2) (f 3) = false) ↔
     (lossClassical (f 0) (f 1) (f 2) (f 3) = true ∧
-     Semantics.Plurality.someSatisfy
+     Plurality.someSatisfy
        (fun (i : Fin 4) (_ : Unit) => f i) Finset.univ () = true) := by
   decide
 
@@ -342,7 +342,7 @@ theorem lossStrong_iff_allFalse (f : Fin 4 → Bool) :
 theorem lossStrong_eq_noneSatisfy :
     ∀ f : Fin 4 → Bool,
     lossStrong (f 0) (f 1) (f 2) (f 3) =
-    Semantics.Plurality.noneSatisfy
+    Plurality.noneSatisfy
       (fun (i : Fin 4) (_ : Unit) => f i) Finset.univ () := by
   decide
 

--- a/Linglib/Studies/Kratzer2012Lumping.lean
+++ b/Linglib/Studies/Kratzer2012Lumping.lean
@@ -138,8 +138,8 @@ still-life painting variant from §5.2.
 namespace Kratzer2012Lumping
 
 open Intensional
-open Semantics.Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
-open Semantics.Conditionals.PremiseSemantic
+open Conditionals.Counterfactual (Lumps IsConsistent IsCompatible Follows)
+open Conditionals.PremiseSemantic
 
 /-! ## The minimal Paula scenario -/
 

--- a/Linglib/Studies/Krifka1989.lean
+++ b/Linglib/Studies/Krifka1989.lean
@@ -70,10 +70,10 @@ on abstract domains.
 namespace Krifka1989
 
 open _root_.Mereology
-open Semantics.Plurality.Algebra (Materialization)
+open Plurality.Algebra (Materialization)
 open ArgumentStructure (UP)
-open Semantics.Aspect.Incremental (SINC VerbIncClass IsSincVerb)
-open Semantics.Aspect.Cumulativity (VP qua_propagation)
+open Aspect.Incremental (SINC VerbIncClass IsSincVerb)
+open Aspect.Cumulativity (VP qua_propagation)
 open Core.Order (MereoTag)
 open Features
   (forXPrediction inXPrediction DiagnosticResult)

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -51,8 +51,8 @@ namespace Krifka1998
 open Features
 open _root_.Mereology
 open ArgumentStructure (IsCumThetaVerb)
-open Semantics.Aspect.Incremental (SINC IsSincVerb)
-open Semantics.Aspect.Cumulativity (VP cum_propagation qua_propagation)
+open Aspect.Incremental (SINC IsSincVerb)
+open Aspect.Cumulativity (VP cum_propagation qua_propagation)
 open Spatial (Trace)
 
 variable {α β : Type*}
@@ -227,7 +227,7 @@ def SMR [SemilatticeSup α] [SemilatticeSup β]
 /-- K98 §4.3 eq. 71: smallest θ-extension closed under precedence-respecting sums. -/
 abbrev MovementClosure [SemilatticeSup α] [SemilatticeSup β]
     (precedes : β → β → Prop) (θ' : α → β → Prop) : α → β → Prop :=
-  Semantics.Aspect.PrecedenceClosure precedes θ'
+  Aspect.PrecedenceClosure precedes θ'
 
 /-- K98 §4.3 eq. 71 MR (TANG_H-free): θ is the `MovementClosure` of some SMR θ'. -/
 def MR [SemilatticeSup α] [SemilatticeSup β]
@@ -245,8 +245,8 @@ theorem mr_of_smr [SemilatticeSup α] [SemilatticeSup β]
     (hClosed : ∀ x1 x2 e1 e2, θ x1 e1 → θ x2 e2 → precedes e1 e2 →
                θ (x1 ⊔ x2) (e1 ⊔ e2)) :
     MR adjα adjβ precedes isPath θ :=
-  ⟨θ, h, fun x e => ⟨Semantics.Aspect.PrecedenceClosure.base,
-    fun hcl => Semantics.Aspect.PrecedenceClosure.closure_subset
+  ⟨θ, h, fun x e => ⟨Aspect.PrecedenceClosure.base,
+    fun hcl => Aspect.PrecedenceClosure.closure_subset
       (fun _ _ h => h) hClosed hcl⟩⟩
 
 end K98PropositionalSubstrate

--- a/Linglib/Studies/Krifka2015.lean
+++ b/Linglib/Studies/Krifka2015.lean
@@ -56,7 +56,7 @@ namespace Krifka2015
 open Discourse.Krifka
 open Discourse (DiscourseRole)
 open Discourse.Commitment (IndexedCommitment CommitmentSlate)
-open Semantics.Questions.Bias (ContextualEvidence)
+open Questions.Bias (ContextualEvidence)
 open Features (Acceptability)
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Kriz2016.lean
+++ b/Linglib/Studies/Kriz2016.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Homogeneity.Plural
 # Križ (2016): homogeneity, non-maximality, and *all*
 
 This file verifies [kriz-2016]'s predictions against a finite model, using
-the homogeneity substrate in `Semantics.Homogeneity` and its plural
+the homogeneity substrate in `Homogeneity` and its plural
 instantiation (`barePlural`, `allPlural` — both originating with this
 paper). A five-world model checks the predictions end-to-end, including the
 §4.2 sensitivity to what an exception does instead and the §4.1
@@ -34,7 +34,7 @@ unaddressed, as in the paper.
 
 namespace Kriz2016
 
-open Semantics.Homogeneity
+open Homogeneity
 
 /-! ### Finite model
 

--- a/Linglib/Studies/KrizSpector2021.lean
+++ b/Linglib/Studies/KrizSpector2021.lean
@@ -29,17 +29,17 @@ This file proves the correspondence between the two accounts:
    Addressing the QUD ↔ `allSatisfy` is strongly relevant.
 
 These theorems connect two independently formalized mechanisms:
-- `Semantics.Homogeneity.addressesIssue` (from Križ 2016)
-- `Semantics.Homogeneity.isStronglyRelevantProp` (substrate, originating with K&S 2021)
+- `Homogeneity.addressesIssue` (from Križ 2016)
+- `Homogeneity.isStronglyRelevantProp` (substrate, originating with K&S 2021)
 
 showing they agree on the bivalent fragment.
 -/
 
 namespace KrizSpector2021
 
-open Semantics.Plurality
-open Semantics.Plurality.Trivalent
-open Semantics.Homogeneity
+open Plurality
+open Plurality.Trivalent
+open Homogeneity
 open _root_.Trivalent (Prop3)
 
 variable {Atom W : Type*}
@@ -299,7 +299,7 @@ The existing `generalisedTruthValue` in `Homogeneity/Collective.lean` captures t
 `overlaps` relation. Here we prove the connection: when an overlapping
 super-plurality satisfies P, the sentence about x is gapped, not false. -/
 
-open Semantics.Homogeneity (generalisedTruthValue generalisedTruthValue_eq_true)
+open Homogeneity (generalisedTruthValue generalisedTruthValue_eq_true)
 
 /-- Upward homogeneity: if P is false of x but true of some overlapping
     super-plurality in the domain, then the generalised truth value is GAP,
@@ -314,10 +314,10 @@ theorem upward_homogeneity_gap [DecidableEq Atom]
     (x : Finset Atom)
     (hPx : ¬ P x)
     (b : Finset Atom) (hb : b ∈ domain)
-    (hov : Semantics.Homogeneity.overlaps x b)
+    (hov : Homogeneity.overlaps x b)
     (hPb : P b) :
     generalisedTruthValue P domain x = .indet := by
-  have hex : ∃ b ∈ domain, Semantics.Homogeneity.overlaps x b ∧ P b :=
+  have hex : ∃ b ∈ domain, Homogeneity.overlaps x b ∧ P b :=
     ⟨b, hb, hov, hPb⟩
   simp [generalisedTruthValue, if_neg hPx, if_pos hex]
 

--- a/Linglib/Studies/Lassiter2025.lean
+++ b/Linglib/Studies/Lassiter2025.lean
@@ -22,7 +22,7 @@ typology in `Fragments/{Language}/Conditionals.lean`.
 namespace Lassiter2025
 
 open Data.Examples
-open Semantics.Conditionals (ConditionalMarker ConditionalMarkerType)
+open Conditionals (ConditionalMarker ConditionalMarkerType)
 
 /-- Marker adapter: the Fragment entry for the row's conditional marker. -/
 def markerOf (row : LinguisticExample) : Option ConditionalMarker :=

--- a/Linglib/Studies/Longobardi2005.lean
+++ b/Linglib/Studies/Longobardi2005.lean
@@ -334,7 +334,7 @@ instance : DecidablePred ExpletiveBlocksKindReading := fun a => by
 -- § 7: Bridge to Reference/Basic — Proper Names as Directly Referential
 -- ============================================================================
 
-open Semantics.Reference.Basic (properName isDirectlyReferential
+open Reference.Basic (properName isDirectlyReferential
   constantCharacter)
 
 /-- Proper names in D are directly referential.
@@ -348,8 +348,8 @@ theorem proper_name_in_d_is_constant
     {C W E : Type*} (e : E) :
     isDirectlyReferential (properName (C := C) (W := W) e).character ∧
     constantCharacter (properName (C := C) (W := W) e).character :=
-  ⟨Semantics.Reference.Basic.properName_isDirectlyReferential e,
-   Semantics.Reference.Basic.properName_constantCharacter e⟩
+  ⟨Reference.Basic.properName_isDirectlyReferential e,
+   Reference.Basic.properName_constantCharacter e⟩
 
 -- ============================================================================
 -- § 8: N-to-D Raising as Head-to-Head Movement

--- a/Linglib/Studies/Magri2014.lean
+++ b/Linglib/Studies/Magri2014.lean
@@ -228,7 +228,7 @@ atoms of `x` satisfy `P` at `w`. -/
 
 section ImplicatureBridge
 
-open Semantics.Plurality.Implicature (existPL existPL_full)
+open Plurality.Implicature (existPL existPL_full)
 
 variable {Atom W : Type*} [DecidableEq Atom]
 

--- a/Linglib/Studies/McKayVanInwagen1977.lean
+++ b/Linglib/Studies/McKayVanInwagen1977.lean
@@ -43,8 +43,8 @@ instances are auto-derived from `DecidableEq` on the world enums.
 
 namespace McKayVanInwagen1977
 
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual (universalCounterfactual)
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual (universalCounterfactual)
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Mizuno2024.lean
+++ b/Linglib/Studies/Mizuno2024.lean
@@ -24,7 +24,7 @@ O-marking as a Historical-Present shift ([schlenker-2004], [anand-toosarvandani-
 
 Stimuli: `Data/Examples/Mizuno2024.json` (module `Mizuno2024.Examples`); `#guard`s
 check observed directions on the named examples, row theorems quantify over
-`Examples.all`. Semantics: `Semantics.Conditionals.strictImp` over a
+`Examples.all`. Semantics: `Conditionals.strictImp` over a
 `HistoricalAlternatives` base; `Modality.Exclusion` supplies the X/O
 typology and exponent inventory.
 
@@ -45,7 +45,7 @@ typology and exponent inventory.
 namespace Mizuno2024
 
 open Modality.Exclusion (MarkingStrategy XMarkingExponent)
-open Semantics.Conditionals (strictImp mem_strictImp_of_subset not_subset_of_mem_strictImp)
+open Conditionals (strictImp mem_strictImp_of_subset not_subset_of_mem_strictImp)
 open HistoricalAlternatives (histEquiv_mono)
 open Intensional (Index)
 open Data.Examples (LinguisticExample Glottocode)
@@ -267,10 +267,10 @@ theorem expanded_anderson_informative (antecedent : Set Bool)
 
 -- Japanese Anderson conditionals use -(e)ba (both HC and PC, unlike HC-only -ra).
 #guard Japanese.Conditionals.eba.markerType ==
-  Semantics.Conditionals.ConditionalMarkerType.both
+  Conditionals.ConditionalMarkerType.both
 
 -- Mandarin uses general-purpose ruguo; X/O is carried by consequent-final le.
 #guard Mandarin.Conditionals.ruguo.markerType ==
-  Semantics.Conditionals.ConditionalMarkerType.both
+  Conditionals.ConditionalMarkerType.both
 
 end Mizuno2024

--- a/Linglib/Studies/Montague1973Attitudes.lean
+++ b/Linglib/Studies/Montague1973Attitudes.lean
@@ -156,7 +156,7 @@ theorem up_down_identity {E W : Type} {τ : Ty} (x : Denot E W τ) (w : W) :
 
 The `morningStar`/`eveningStar` individual concepts defined above are
 *Fregean concepts* (world-dependent). In contrast, proper names in
-`Semantics.Reference.Basic` are *Kripkean rigid designators*.
+`Reference.Basic` are *Kripkean rigid designators*.
 
 This section makes the distinction explicit, connecting the existing
 Hesperus/Phosphorus examples to the direct reference framework. -/

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -45,8 +45,8 @@ portions, and measured parts.
 namespace Moon2026
 
 open Mereology
-open Semantics.Aspect.Incremental (IsSincVerb)
-open Semantics.Aspect.Cumulativity (VP)
+open Aspect.Incremental (IsSincVerb)
+open Aspect.Cumulativity (VP)
 
 /-! ### Mereotopology -/
 

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -138,7 +138,7 @@ the §5 conclusion proposes the broader "insinuative speech" terminology.
 
 namespace Ney2026
 
-open Semantics.Reference.Basic
+open Reference.Basic
 
 /-! ## §1. Metasemantic apparatus -/
 

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -46,7 +46,7 @@ the derived values against the external WALS rows.
 - Siloni's discontinuity prediction checked against attested judgments (§3.3)
 - WALS Ch 106 grounding for the *derived* reflexive relation (via `lookupISO`)
 - `ReciprocityType` semantic 6-way classification (§4), realized as the
-  relation shapes of `Semantics.Plurality.Reciprocal`
+  relation shapes of `Plurality.Reciprocal`
 - Polysemous markers beyond the profile sample (§4.2)
 - Fragment grounding for English reciprocals
 -/
@@ -360,7 +360,7 @@ inductive ReciprocityType where
 
 /-- The relation shape each configurational label denotes over a
     participant plurality — [majid-et-al-2011]'s extensional schemas as
-    the exact-extension conditions of `Semantics.Plurality.Reciprocal`.
+    the exact-extension conditions of `Plurality.Reciprocal`.
     Symmetry and participant-exhaustiveness are theorems there
     (`ChainConfig.not_pairSymmetricOn`,
     `RadialConfig.inclusiveAlternativeOrdering`, melee failing
@@ -368,12 +368,12 @@ inductive ReciprocityType where
     features of the labels. -/
 def ReciprocityType.Realizes {A : Type*} :
     ReciprocityType → (A → A → Prop) → Finset A → Prop
-  | .strong,   R, X => Semantics.Plurality.Reciprocal.StrongReciprocity R X
-  | .pairwise, R, X => Semantics.Plurality.Reciprocal.PairwiseConfig R X
-  | .chain,    R, X => Semantics.Plurality.Reciprocal.ChainConfig R X
-  | .radial,   R, X => Semantics.Plurality.Reciprocal.RadialConfig R X
-  | .melee,    R, X => Semantics.Plurality.Reciprocal.MeleeConfig R X
-  | .ring,     R, X => Semantics.Plurality.Reciprocal.RingConfig R X
+  | .strong,   R, X => Plurality.Reciprocal.StrongReciprocity R X
+  | .pairwise, R, X => Plurality.Reciprocal.PairwiseConfig R X
+  | .chain,    R, X => Plurality.Reciprocal.ChainConfig R X
+  | .radial,   R, X => Plurality.Reciprocal.RadialConfig R X
+  | .melee,    R, X => Plurality.Reciprocal.MeleeConfig R X
+  | .ring,     R, X => Plurality.Reciprocal.RingConfig R X
 
 /-- The six reciprocity types English *each other* can express
     ([evans-et-al-2011b], p. 8; [nordlinger-2023] ex. 44). -/

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -506,8 +506,8 @@ theorem japanese_ato_matches_datum :
     sits inside the event's runtime in the actual world, while alternatives
     contain worlds where the continuation reaches a target. -/
 
-open Semantics.Aspect
-open Semantics.Aspect.SubintervalProperty
+open Aspect
+open Aspect.SubintervalProperty
 
 /-! **Imperfective paradox ↔ before non-veridicality: shared vacuous-∀ structure.**
 

--- a/Linglib/Studies/Pancheva2003.lean
+++ b/Linglib/Studies/Pancheva2003.lean
@@ -55,7 +55,7 @@ analysis uses.
 namespace Pancheva2003
 
 open Data.Examples (LinguisticExample)
-open Semantics.Aspect (PerfectType)
+open Aspect (PerfectType)
 open Kiparsky2002 (PerfectReading)
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/Pearson2015.lean
+++ b/Linglib/Studies/Pearson2015.lean
@@ -53,7 +53,7 @@ minimal pronoun, so — unlike *yè* — it takes no long-distance antecedent).
 namespace Pearson2015
 
 open Intensional (Intension)
-open Semantics.Reference.Acquaintance (Cover)
+open Reference.Acquaintance (Cover)
 open Features.Logophoricity (LogophoricRole Logophoric)
 
 /-! ### Concept generators ([percus-sauerland-2003], [charlow-sharvit-2014]) -/

--- a/Linglib/Studies/Rakosi2019.lean
+++ b/Linglib/Studies/Rakosi2019.lean
@@ -51,8 +51,8 @@ a morphosyntactic mechanism.
 
 namespace Rakosi2019
 
-open Semantics.Reference.Reciprocals
-open Semantics.Reference.PluralityLicensing
+open Reference.Reciprocals
+open Reference.PluralityLicensing
 open PPCDRT
 open Core
 open Hungarian.Reciprocals

--- a/Linglib/Studies/RamotowskaEtAl2025.lean
+++ b/Linglib/Studies/RamotowskaEtAl2025.lean
@@ -379,7 +379,7 @@ def experiment2PluralDefiniteResults : List PluralDefiniteDatum :=
 -- Grounding: Study Predictions ↔ Formal Selectional Semantics
 -- ════════════════════════════════════════════════════════════════
 
-open Semantics.Conditionals.Counterfactual
+open Conditionals.Counterfactual
   (embeddedSelectional noSelectional notEverySelectional QStrength
    all_four_quantifiers_mixed)
 
@@ -415,7 +415,7 @@ theorem selectional_prediction_grounded (q : Quantifier) (bs : List Bool)
 
 open Trivalent (aggregate ProjectionType
   aggregate_replicate_indet aggregate_map_ofBool_mixed aggregate_map_ofBool_ne_indet)
-open Semantics.Conditionals.Counterfactual (projectTruthValues_eq_aggregate)
+open Conditionals.Counterfactual (projectTruthValues_eq_aggregate)
 
 /-!
 ### Why Strength Matters: Local vs Global Aggregation

--- a/Linglib/Studies/RobertsSimons2024.lean
+++ b/Linglib/Studies/RobertsSimons2024.lean
@@ -31,7 +31,7 @@ non-anaphoric presupposition. *Linguistics and Philosophy* 47(4):703–748.
 ## Connection to Existing Theory
 
 This study file imports and bridges:
-- `Semantics.Events.Phase` / `Presupposition.Aboutness` (EventPhase, entailment classification)
+- `Events.Phase` / `Presupposition.Aboutness` (EventPhase, entailment classification)
 - `ChangeOfState.Theory` (CoS presuppositions)
 - `Features.Aktionsart` (Vendler classes, telicity)
 - `ProjectiveContent` (Tonhauser taxonomy: all three verb classes are Class C)

--- a/Linglib/Studies/Romero2024.lean
+++ b/Linglib/Studies/Romero2024.lean
@@ -30,7 +30,7 @@ predicate-level bridge below is the right granularity.
 namespace Romero2024
 
 open Pragmatics.Bias
-open Semantics.Questions.Bias
+open Questions.Bias
 
 /-- HiNQ's original-bias filter requires speaker bias for p. The
     licensed bias profile's `contradictsPriorBelief` axis is the

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -81,8 +81,8 @@ end NonemptyInterval
 namespace Rouillard2026
 
 open NonemptyInterval
-open Semantics.Aspect
-open Semantics.Aspect.SubintervalProperty
+open Aspect
+open Aspect.SubintervalProperty
 open Features
 open Core.Order
 open Degree

--- a/Linglib/Studies/Rubinstein2014.lean
+++ b/Linglib/Studies/Rubinstein2014.lean
@@ -58,7 +58,7 @@ abbrev World := Fin 4
 open Modality.Kratzer
 open Modality.Directive
 open Modality (ModalForce)
-open Semantics.Homogeneity (negRaising_iff_subsingleton)
+open Homogeneity (negRaising_iff_subsingleton)
 open Data.Examples
 
 /-- Named worlds for the concrete `Fin 4` evaluation frame used in the

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -33,8 +33,8 @@ receive different distributive verdicts (`substitution_fails`).
 
 namespace Santorio2018
 
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual
 
 variable {W : Type*} [DecidableEq W] [Fintype W]
 

--- a/Linglib/Studies/Sauerland2003.lean
+++ b/Linglib/Studies/Sauerland2003.lean
@@ -39,7 +39,7 @@ the unmarked values, plural and third person (`politeness_unmarked`).
 namespace Sauerland2003
 
 open Mereology (Atom AlgClosure cum_maximal_unique algClosure_cum not_atom_sup_of_ne)
-open Semantics.Plurality.Algebra (D)
+open Plurality.Algebra (D)
 open Features (ContainmentPair ContainmentPairLike)
 open Presupposition
 open Constraints OptimalityTheory

--- a/Linglib/Studies/Schlenker2003.lean
+++ b/Linglib/Studies/Schlenker2003.lean
@@ -149,7 +149,7 @@ theorem fixity_world_only (p : W → Prop) :
 
 /-! ### Shifted indexicals -/
 
-open Semantics.Reference.Kaplan (pronI_access pronI_shift_invariant)
+open Reference.Kaplan (pronI_access pronI_shift_invariant)
 
 /-- English *I* is invariant under the attitude shift used by
     `ContextBox` — it resolves to the origin agent (the actual
@@ -161,8 +161,8 @@ theorem english_I_invariant
   pronI_shift_invariant t (attitudeShift holder w')
 
 
-open Semantics.Reference.ShiftedIndexicals (amharic_pronI)
-open Semantics.Reference.Kaplan (pronI_access)
+open Reference.ShiftedIndexicals (amharic_pronI)
+open Reference.Kaplan (pronI_access)
 
 -- ════════════════════════════════════════════════════════════════
 -- § Concrete Setup
@@ -294,7 +294,7 @@ theorem bridge_english_invariant :
 -- § Person Features: Logophoric Pronouns
 -- ════════════════════════════════════════════════════════════════
 
-open Semantics.Reference.PersonFeatures
+open Reference.PersonFeatures
 
 /-- Bob is logophoric under the attitude shift: he is +author(local)
     (agent of the embedded context) but −author* (not the actual

--- a/Linglib/Studies/SchlenkerEtAl2026.lean
+++ b/Linglib/Studies/SchlenkerEtAl2026.lean
@@ -44,7 +44,7 @@ is on a 7-point scale (7 = best, 1 = worst). Classifier direction
 namespace SchlenkerEtAl2026
 
 open Semantics.Iconic
-open Semantics.Reference.Monsters (IsTowerMonster attitudeShift_is_monster isTowerMonster_congr)
+open Reference.Monsters (IsTowerMonster attitudeShift_is_monster isTowerMonster_congr)
 open Semantics.Context
 open ASL (SigningSpace)
 

--- a/Linglib/Studies/SchlotterbeckWang2023.lean
+++ b/Linglib/Studies/SchlotterbeckWang2023.lean
@@ -22,7 +22,7 @@ reported simulations, matching the exponent-free chain here.
 ## Main results
 
 * Order-independence of the prefix meaning — the paper's listener-level
-  sanity check — is the substrate lemma `Semantics.Probabilistic.prodMeaning_perm`.
+  sanity check — is the substrate lemma `Probabilistic.prodMeaning_perm`.
 * `size_first_when_size_discriminates` / `color_first_when_color_reliable`:
   the trajectory preference tracks discriminatory power (Scene A) and
   flips to the more reliable dimension under equal discrimination
@@ -37,7 +37,7 @@ reported simulations, matching the exponent-free chain here.
 The chain is exact ℚ≥0: `lex` is the Bernoulli-channel form of
 [degen-etal-2020]'s continuous semantics (reliability if the word truly
 applies, the complementary noise floor otherwise), prefix meanings are
-`Semantics.Probabilistic.prodMeaning` products, `l0Score`/`s1Score`
+`Probabilistic.prodMeaning` products, `l0Score`/`s1Score`
 normalize via `PMF.normalizeScores`, and the PMF speaker is `PMF.ofScores`. Trajectories are `Fin`-indexed
 products of speaker values, so ordering predictions close by
 `PMF.prod_ofScores_lt` with one kernel certificate each.
@@ -47,7 +47,7 @@ open scoped ENNReal NNRat
 
 namespace SchlotterbeckWang2023
 
-open Semantics.Probabilistic
+open Probabilistic
 
 /-- Referents in the reference game. -/
 inductive Referent where

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -95,7 +95,6 @@ with low negation). Supports fronted-negation + *väl* marking NRQs.
 
 namespace SeeligerRepp2018
 
-open Semantics
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Bias values ([sudo-2013], extended by [seeliger-repp-2018])
@@ -211,7 +210,7 @@ def DeclQuestionType.declPolarity : DeclQuestionType → Features.Polarity
     evidential version of VERUM may appear.
 
     These correspond to the operators defined in
-    `Semantics.Questions.Bias` (`verum`, `mkFalsum`). -/
+    `Questions.Bias` (`verum`, `mkFalsum`). -/
 inductive IllocutionaryModifier where
   /-- FALSUM: zero commitment to q (non-propositional negation).
       [repp-2013]: speaker is not committed to q at issue. -/
@@ -493,14 +492,14 @@ theorem val_creates_questions :
     particle's bias requirement is the analysis, so it lives here):
     felicitous only in contexts with contextual evidence for the
     proposition, matching the evidential bias of PDQs and NRQs. -/
-def valContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+def valContextualEvidence : Option Questions.Bias.ContextualEvidence :=
   some .forP
 
 /-- S&R's classification, epistemic dimension: *väl* signals epistemic
     *uncertainty* — the speaker suspects p but is not certain,
     corresponding to the [-positive] epistemic bias of PDQs — so it
     imposes no original-bias requirement (contrast `dochWohlOriginalBias`). -/
-def valOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
+def valOriginalBias : Option Questions.Bias.OriginalBias := none
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10. German *doch wohl* marks RQs via REJECTQ
@@ -512,11 +511,11 @@ def valOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
     and epistemic presuppositions in the REJECTQ definition (eq. 40).
     Shares its evidential value with `valContextualEvidence`; the
     epistemic dimension is where German is stricter than Swedish. -/
-def dochWohlContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+def dochWohlContextualEvidence : Option Questions.Bias.ContextualEvidence :=
   some .forP
 
 /-- See `dochWohlContextualEvidence`: prior speaker bias against p. -/
-def dochWohlOriginalBias : Option Semantics.Questions.Bias.OriginalBias :=
+def dochWohlOriginalBias : Option Questions.Bias.OriginalBias :=
   some .againstP
 
 /-- *doch wohl* is not usable in assertions — it marks questions.

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -38,7 +38,7 @@ namespace Sharvit2014
 
 open Tense.Decomposition (sotDeletionApplicable)
 open Tense.TenseAspectComposition (evalPast evalRel)
-open Semantics.Aspect (PointPred)
+open Aspect (PointPred)
 
 /-- The `EARLIEST` definedness presupposition of `before^{B&C}`: `EARLIEST_C` is defined for
     body `p` iff the set of `C`-times where `p` holds has a least element (mathlib's

--- a/Linglib/Studies/Sharvit2025.lean
+++ b/Linglib/Studies/Sharvit2025.lean
@@ -124,7 +124,7 @@ theorem orPositive_defined_at_proud :
 -- Part II: K/P and K/P* Analysis
 -- ============================================================================
 
-open Semantics.Conditionals.Presupposition
+open Conditionals.Presupposition
 
 -- Decidable instances for compound PartialProp assertions
 

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -71,7 +71,7 @@ arguments and entailing the crossed directional events
 
 namespace Siloni2012
 
-open Reciprocal ArgumentStructure Semantics.Plurality
+open Reciprocal ArgumentStructure Plurality
 
 /-! ### Three-way reciprocal classification (§2.4) -/
 

--- a/Linglib/Studies/Simik2024.lean
+++ b/Linglib/Studies/Simik2024.lean
@@ -56,12 +56,12 @@ def razveFamily : List Particle :=
 for the prejacent (§4.2.4), extended here to the kin the chapter reports
 as similar in meaning. -/
 def evidentialRequirement (p : Particle) :
-    Option Semantics.Questions.Bias.ContextualEvidence :=
+    Option Questions.Bias.ContextualEvidence :=
   if p ∈ razveFamily then some .forP else none
 
 /-- *Razve*'s prior epistemic bias runs against the prejacent — the
 'I thought that ¬p' component of exx. 39 and 42. -/
-def razveOriginalBias : Option Semantics.Questions.Bias.OriginalBias :=
+def razveOriginalBias : Option Questions.Bias.OriginalBias :=
   some .againstP
 
 /-- *Razve* is a root phenomenon while *li* is obligatory in subordinated

--- a/Linglib/Studies/Smith1997.lean
+++ b/Linglib/Studies/Smith1997.lean
@@ -44,8 +44,8 @@ re-packages those into the row-wise groupings Smith uses prose-side.
 -/
 
 open Features
-open Semantics.Aspect (ViewpointType)
-open Semantics.Aspect.Composition
+open Aspect (ViewpointType)
+open Aspect.Composition
 open Features (DiagnosticResult)
 
 namespace Smith1997

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -62,7 +62,7 @@ the substrate section above.
 
 * `Studies/CarianiSantorio2018.lean` — extends the
   Stalnaker selection-function mechanism from conditionals to bare
-  *will*. C&S's `Semantics.Conditionals.SelectionFunction` infrastructure is exactly the
+  *will*. C&S's `Conditionals.SelectionFunction` infrastructure is exactly the
   one used here for `selectionConditional`; the `would`-conditional /
   Stalnaker-counterfactual identification in C&S §5.3.2 reuses this
   paper's selection-function semantics under universe parameter.
@@ -181,8 +181,8 @@ end Discourse.ReasonableInference
 namespace Stalnaker1975
 
 open Mood (Grammatical)
-open _root_.Semantics.Conditionals (SelectionFunction)
-open Semantics.Conditionals
+open _root_.Conditionals (SelectionFunction)
+open Conditionals
 open Discourse.ReasonableInference
 
 -- § 1. The direct argument is REASONABLE (abstract version)
@@ -452,7 +452,7 @@ presupposed false. For indicatives — which obey `pragmaticConstraint` —
 both inference forms come out reasonable in the Appendix's sense.
 
 The semantic-failure side already exists as
-`Semantics.Conditionals.perfection_not_entailed_variablyStrict` and can be
+`Conditionals.perfection_not_entailed_variablyStrict` and can be
 adapted directly to selection-based conditionals. The pragmatic-success
 side is a clean extension of `direct_argument_reasonable` and is left for
 follow-up. -/

--- a/Linglib/Studies/Stalnaker1981.lean
+++ b/Linglib/Studies/Stalnaker1981.lean
@@ -31,8 +31,8 @@ A Defense of Conditional Excluded Middle. In Harper, Stalnaker & Pearce
 
 namespace Stalnaker1981
 
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual
 
 -- ════════════════════════════════════════════════════
 -- § 1. The Bizet–Verdi Example: Indeterminacy from Ties

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -177,7 +177,7 @@ end Stankova2026
 
 namespace Czech.Negation
 
-open Semantics.Questions.Bias
+open Questions.Bias
 open Stankova2026 (CzechPQForm)
 open StankovaSimik2025 (VerbPosition)
 
@@ -210,7 +210,7 @@ end Czech.Negation
 namespace Stankova2026
 
 open Czech.Negation
-open Semantics.Questions.Bias
+open Questions.Bias
 open StankovaSimik2025 (VerbPosition)
 
 /-- [romero-2024] PQ form of each [simik-2024] grid cell: InterNPQ is

--- a/Linglib/Studies/StankovaSimik2025.lean
+++ b/Linglib/Studies/StankovaSimik2025.lean
@@ -28,7 +28,7 @@ namespace StankovaSimik2025
 open Czech.Particles (nahodou snad copak)
 open Czech.Determiners (zadny nejaky)
 open Czech.Negation
-open Semantics.Questions.Bias (ContextualEvidence evidenceBiasOK)
+open Questions.Bias (ContextualEvidence evidenceBiasOK)
 open Features (Judgment)
 
 /-! ### The main experiment (§5)

--- a/Linglib/Studies/Sternefeld1998.lean
+++ b/Linglib/Studies/Sternefeld1998.lean
@@ -97,8 +97,8 @@ eq 120 ↔ H&D's group identity all factor through
 
 namespace Sternefeld1998
 
-open Semantics.Plurality.Cumulativity
-open Semantics.Plurality.Reciprocal
+open Plurality.Cumulativity
+open Plurality.Reciprocal
 
 variable {α : Type*} [DecidableEq α]
 

--- a/Linglib/Studies/Svenonius2004.lean
+++ b/Linglib/Studies/Svenonius2004.lean
@@ -59,7 +59,7 @@ namespace Svenonius2004
 open Data.Examples (LinguisticExample)
 open Morphology (Morph)
 open Morphology.Word (Tree)
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 open Verb (Stem)
 
 /-- Aspectual subtypes of the superlexical class — the labels recurring

--- a/Linglib/Studies/Theiler2021.lean
+++ b/Linglib/Studies/Theiler2021.lean
@@ -45,7 +45,7 @@ theorem denn_is_PerspP :
     (whose classification lives in `Zheng2025`), and the point on which
     Bayer/Obenauer-style evidence-sensitive analyses of *denn* would
     disagree. -/
-def dennBias : Option Semantics.Questions.Bias.ContextualEvidence := none
+def dennBias : Option Questions.Bias.ContextualEvidence := none
 
 /-- Unlike Mandarin *nandao*, *denn* is licensed in constituent
     questions. Both are PerspP-layer particles, but *denn* lacks

--- a/Linglib/Studies/Thomas2026.lean
+++ b/Linglib/Studies/Thomas2026.lean
@@ -52,7 +52,7 @@ do); see the per-field docstrings of `IsTooFelicitous`.
 
 namespace Thomas2026
 
-open Question Semantics.Questions.Probabilistic
+open Question Questions.Probabilistic
 
 variable {W : Type*} {μ : PMF W}
   {prejacent antecedent : Set W} {rq : Question W}
@@ -161,7 +161,7 @@ caller to exhibit. -/
 
 namespace Thomas2026.Witness
 
-open Question Semantics.Questions.Probabilistic
+open Question Questions.Probabilistic
 open scoped ENNReal
 
 abbrev W := Fin 3

--- a/Linglib/Studies/VanTielEtAl2021.lean
+++ b/Linglib/Studies/VanTielEtAl2021.lean
@@ -370,9 +370,9 @@ def spread : ModelQuantityWord → ℚ
   | .all   => 1
 
 /-- PT meaning via the parametric operator from
-    `Semantics.Probabilistic.PrototypeTheory`. -/
+    `Probabilistic.PrototypeTheory`. -/
 def ptMeaning (m : ModelQuantityWord) (t : WorldState) : ℚ :=
-  Semantics.Probabilistic.PrototypeTheory.ptMeaning
+  Probabilistic.PrototypeTheory.ptMeaning
     domainSize (prototype m) (spread m) t
 
 -- Salience: Lexical Accessibility

--- a/Linglib/Studies/VonFintel2001.lean
+++ b/Linglib/Studies/VonFintel2001.lean
@@ -31,7 +31,7 @@ it is the project-canonical innocent-exclusion operator `exhIE`
 
 namespace VonFintel2001
 
-open Semantics.Conditionals Exhaustification
+open Conditionals Exhaustification
 
 variable {ι W : Type*}
 

--- a/Linglib/Studies/WaldonDegen2021.lean
+++ b/Linglib/Studies/WaldonDegen2021.lean
@@ -54,13 +54,13 @@ different (language × scene) configurations of the same chain.
 - **Incremental RSA**: Extends [cohn-gordon-goodman-potts-2019] with
   continuous semantics and cross-linguistic word order variation.
 - **Graded composition**: `uttContinuousQ` is defined via
-  `Semantics.Probabilistic.prodMeaning`, sharing the multiplicative
+  `Probabilistic.prodMeaning`, sharing the multiplicative
   composition with [schlotterbeck-wang-2023] by construction.
 -/
 
 namespace WaldonDegen2021
 
-open RSA Semantics.Probabilistic
+open RSA Probabilistic
 
 /-! ### Domain Types -/
 

--- a/Linglib/Studies/Winter2018.lean
+++ b/Linglib/Studies/Winter2018.lean
@@ -29,7 +29,7 @@ contact and communication verbs), beyond the event-free logical core
 formalized here.
 
 Sums of two distinct atoms are encoded as pair `Finset`s `{x, y}`,
-matching the `(R, X)` signature of `Semantics.Plurality.Reciprocal`.
+matching the `(R, X)` signature of `Plurality.Reciprocal`.
 
 ## Main declarations
 

--- a/Linglib/Studies/Xiang2022.lean
+++ b/Linglib/Studies/Xiang2022.lean
@@ -67,7 +67,7 @@ defer that lift and work with the propositional projection here.
 namespace Xiang2022
 
 open Question
-open Semantics.Questions.Exhaustivity
+open Questions.Exhaustivity
 
 variable {W : Type*}
 

--- a/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
+++ b/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
@@ -53,9 +53,9 @@ The DCR→SDA trajectory supports homogeneity-based accounts
 namespace ZaniCiardelliSanfelici2026
 
 open Trivalent (ProjectionType)
-open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual (universalCounterfactual)
-open Semantics.Conditionals.Counterfactual (Distributive homogeneity)
+open Conditionals (SimilarityOrdering)
+open Conditionals.Counterfactual (universalCounterfactual)
+open Conditionals.Counterfactual (Distributive homogeneity)
 
 
 -- ============================================================

--- a/Linglib/Studies/Zhao2025.lean
+++ b/Linglib/Studies/Zhao2025.lean
@@ -64,7 +64,7 @@ namespace Zhao2025
 
 open Features
 open Mandarin.AspectComparison
-open Semantics.Aspect
+open Aspect
 
 /-! ### Mandarin particle licensing -/
 

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -194,13 +194,13 @@ open Mandarin.QuestionParticles (nandao)
 
 /-- *Nandao* requires contextual evidence for p — Zheng's evidential
 classification, the lexical face of `evidential_bias_necessary`. -/
-def nandaoContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
+def nandaoContextualEvidence : Option Questions.Bias.ContextualEvidence :=
   some .forP
 
 /-- *Nandao* does not require epistemic bias — it is compatible with a
 neutral epistemic state (pure inquiry use, ex. 3); the lexical face of
 `epistemic_bias_not_necessary`. -/
-def nandaoOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
+def nandaoOriginalBias : Option Questions.Bias.OriginalBias := none
 
 /-- `nandaoFelicitous` entails `evidenceSupports`, connecting the felicity
 predicate to `nandaoContextualEvidence` and the empirical generalization

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -17,7 +17,7 @@ open NaturalLogic (Signature)
 open Causation.Psych (CausalSource)
 open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
-open Semantics.Aspect.Incremental (VerbIncClass)
+open Aspect.Incremental (VerbIncClass)
 open ArgumentStructure
 
 /-- Derive unaccusativity from voice type when present, falling back

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -56,7 +56,7 @@ open NaturalLogic (Signature)
 open Causation.Psych (CausalSource)
 open ArgumentStructure (EntailmentProfile)
 open Features.DegreeAchievement (DegreeAchievementScale)
-open Semantics.Aspect.Incremental (VerbIncClass)
+open Aspect.Incremental (VerbIncClass)
 open ArgumentStructure
 
 /-! ### Selectional and inflectional enums -/

--- a/Linglib/Syntax/Category/Verb/Stem.lean
+++ b/Linglib/Syntax/Category/Verb/Stem.lean
@@ -19,7 +19,7 @@ semantics beyond its gloss.
 
 namespace Verb
 
-open Semantics.Aspect (Perfectivity)
+open Aspect (Perfectivity)
 
 /-- A verb-stem lexical entry: citation form, lexically encoded
     perfectivity (the dictionary-consensus value), and gloss. -/

--- a/Linglib/Syntax/Category/Verb/Symmetric.lean
+++ b/Linglib/Syntax/Category/Verb/Symmetric.lean
@@ -18,7 +18,7 @@ Formation-locus classification of reciprocal verbs lives in
 (`Studies/Siloni2012.lean`).
 -/
 
-open Semantics.Plurality
+open Plurality
 
 /-- A symmetric verb entry: an intransitive verb whose lexical meaning
     codes symmetry; `base` is the transitive alternate when the vocabulary


### PR DESCRIPTION
Ten directories under `Semantics/` declared their namespace with a `Semantics.` prefix while the rest — `ArgumentStructure`, `Causation`, `Definiteness`, `Focus`, `Mood`, `Quantification`, `Tense`, `Presupposition`, `Intensional`, `Degree` — do not. This drops the prefix from the stragglers: Aspect, Conditionals, Events, Genericity, Homogeneity, Plurality, Probabilistic, Questions, Reference, Truthmaker. Module paths are untouched; only namespaces and the references to them change.

Two things the rename surfaced:

- Language fragments sit inside `namespace German.Conditionals` and the like, so a bare `open Conditionals` there now resolves to the enclosing namespace rather than the root. Those opens (23 files, mostly Conditionals/Reference/Plurality/Aspect) are now `_root_`-qualified.
- `Studies/SeeligerRepp2018` had a bare `open Semantics`, which no longer names anything; it qualified everything as `Questions.Bias.*` anyway, so the open is gone.

No bare namespace of any of the ten names existed beforehand, so nothing collides. Every changed module builds locally.

Touches `Studies/Bohnemeyer2004.lean`, which #2524 also edits — merge that first and this rebases trivially (one `open` line).