### PR TITLE
fix(Semantics/Focus): Büring's revised Weak Restriction, not the preliminary one

### DIFF
--- a/Linglib/Semantics/Focus/Unalternatives.lean
+++ b/Linglib/Semantics/Focus/Unalternatives.lean
@@ -91,12 +91,14 @@ open Alternatives
 
 variable {W α β : Type*}
 
-/-- Weak Restriction ([buring-2015]): under the default weak–strong
+/-- Weak Restriction ([buring-2015] (4)): under the default weak–strong
 pattern, the banned focal targets vary the weak (function) daughter
-over its alternative domain while the strong daughter stays at its
-ordinary value. -/
+*non-trivially* while the strong daughter stays at its ordinary value.
+The weak daughter's own ordinary value is subtracted, so a node never
+excludes its literal meaning — the revision [buring-2015] makes to the
+preliminary rule (1), which lacked the subtraction. -/
 def weakBanned (dw : AltMeaning (α → β)) (ds : AltMeaning α) : Set β :=
-  dw.aSet.seq {ds.oValue}
+  (dw.aSet \ {dw.oValue}).seq {ds.oValue}
 
 /-- Strong Restriction ([buring-2015]): under prosodic reversal, the
 allowed focal targets vary the accented (function) daughter
@@ -106,10 +108,10 @@ def strongAllowed (dm : AltMeaning (α → β)) (ds : AltMeaning α) :
     Set β :=
   (dm.aSet \ {dm.oValue}).seq {ds.oValue}
 
-/-- Reversal allows only targets that the default bans. -/
-theorem strongAllowed_subset_weakBanned (dm : AltMeaning (α → β))
-    (ds : AltMeaning α) : strongAllowed dm ds ⊆ weakBanned dm ds :=
-  Set.seq_mono Set.sdiff_subset subset_rfl
+/-- Reversal allows exactly the targets the default bans: the two metrical patterns of a branching
+node divide its focal targets between them. -/
+theorem strongAllowed_eq_weakBanned (dm : AltMeaning (α → β))
+    (ds : AltMeaning α) : strongAllowed dm ds = weakBanned dm ds := rfl
 
 /-- The focal targets a metrical configuration licenses: everything
 the daughters compose to, minus the banned targets. At `β := Set W`

--- a/Linglib/Studies/Buring2015.lean
+++ b/Linglib/Studies/Buring2015.lean
@@ -10,16 +10,18 @@ import Linglib.Semantics.Focus.Unalternatives
 
 Formalises [buring-2015]: calculating focus alternatives without
 F-markers, from metrical structure alone. A branching node's stress
-pattern restricts its focal targets — under the default weak–strong
-pattern the Weak Restriction (his (1)) bans targets that vary the
-weak daughter while the strong stays at its ordinary value; under
-prosodic reversal the Strong Restriction (his (9)) allows only
-targets varying the accented daughter non-trivially.
+pattern restricts its focal targets. Under the default weak–strong
+pattern the Weak Restriction ((4), the revision of the preliminary
+(1) that keeps a node's literal meaning out of the banned set) bans
+targets varying the weak daughter non-trivially while the strong stays
+at its ordinary value; under prosodic reversal the Strong Restriction
+((9)) allows exactly those same targets, so the two patterns divide a
+node's focal targets between them.
 
 The worked example is his *ordered BREAKfast* vs *ORDERED breakfast*:
-default stress bans exactly the verb-focus targets ('R breakfast')
-and permits object and VP focus; reversal permits exactly the
-non-trivial verb-focus targets. The rules live in
+default stress bans exactly *paid for breakfast*, licensing "all VP
+meanings, except those that are relations to breakfast other than
+ordering breakfast"; reversal licenses exactly what the default bans. The rules live in
 `Semantics/Focus/Unalternatives.lean`, shared with the
 morphosyntactic extension of [assmann-etal-2023].
 -/
@@ -53,86 +55,80 @@ private theorem vt_ne : vt .paidFor ≠ vt .ordered := fun h => by
   have := congrFun h .breakfast
   exact absurd (congrArg Prod.fst this) (by decide)
 
-/-- Default *ordered BREAKfast* bans the verb-focus target 'paid for
-breakfast': it varies the weak daughter over given *breakfast*. -/
-theorem default_bans_verb_focus :
-    (Rel.paidFor, Obj.breakfast) ∈ weakBanned orderedM breakfastM :=
-  ⟨vt .paidFor, List.Mem.tail _ (List.Mem.head _), .breakfast, rfl, rfl⟩
+/-- Under default stress the banned targets are exactly the verb-focus ones: *paid for breakfast*
+and nothing else. The subtraction of the weak daughter's ordinary value in (4) is what keeps
+*ordered breakfast* itself out of the banned set. -/
+theorem weakBanned_eq :
+    weakBanned orderedM breakfastM = {(Rel.paidFor, Obj.breakfast)} := by
+  ext ⟨r, o⟩
+  simp only [weakBanned, Set.mem_seq_iff, Set.mem_sdiff, Set.mem_singleton_iff,
+    AltMeaning.mem_aSet, orderedM, breakfastM]
+  constructor
+  · rintro ⟨f, ⟨hf, hne⟩, a, rfl, heq⟩
+    rcases List.mem_cons.mp hf with rfl | hf'
+    · exact absurd rfl hne
+    rcases List.mem_cons.mp hf' with rfl | hf''
+    · exact heq.symm
+    · exact nomatch hf''
+  · intro h
+    refine ⟨vt .paidFor, ⟨List.mem_cons_of_mem _ (List.mem_cons_self ..), vt_ne⟩,
+      .breakfast, rfl, ?_⟩
+    rw [h]; rfl
 
-/-- Default *ordered BREAKfast* permits the object-focus target
-'ordered lunch': no way to compose it holding *breakfast* fixed. -/
+/-- Default *ordered BREAKfast* bans the verb-focus target *paid for breakfast*: it varies the weak
+daughter over given *breakfast*. -/
+theorem default_bans_verb_focus :
+    (Rel.paidFor, Obj.breakfast) ∈ weakBanned orderedM breakfastM := by
+  rw [weakBanned_eq]; rfl
+
+/-- It permits the object-focus target *ordered lunch*: no composition holds *breakfast* fixed. -/
 theorem default_permits_object_focus :
     (Rel.ordered, Obj.lunch) ∉ weakBanned orderedM breakfastM := by
-  rintro ⟨f, hf, a, rfl, heq⟩
-  rcases List.mem_cons.mp hf with rfl | hf'
-  · exact absurd (congrArg Prod.snd heq) (by decide)
-  rcases List.mem_cons.mp hf' with rfl | hf''
-  · exact absurd (congrArg Prod.snd heq) (by decide)
-  · exact nomatch hf''
+  rw [weakBanned_eq]; decide
 
-/-- Reversed *ORDERED breakfast* allows the non-trivial verb-focus
-target 'paid for breakfast'. -/
-theorem reversal_allows_verb_focus :
-    (Rel.paidFor, Obj.breakfast) ∈ strongAllowed orderedM breakfastM :=
-  ⟨vt .paidFor, ⟨List.Mem.tail _ (List.Mem.head _), vt_ne⟩,
-    .breakfast, rfl, rfl⟩
+/-- And it permits the node's own literal meaning. This is what rule (4) secures over the
+preliminary (1), which banned it: "we should never, at the lower (VP) level, exclude the literal
+meaning of a neutral node". -/
+theorem default_permits_ordinary_value :
+    (Rel.ordered, Obj.breakfast) ∉ weakBanned orderedM breakfastM := by
+  rw [weakBanned_eq]; decide
 
-/-- Reversed *ORDERED breakfast* excludes the trivial target 'ordered
-breakfast' itself: the accented daughter must vary. -/
-theorem reversal_excludes_trivial :
-    (Rel.ordered, Obj.breakfast) ∉ strongAllowed orderedM breakfastM := by
-  rintro ⟨f, ⟨hf, hne⟩, a, rfl, heq⟩
-  rcases List.mem_cons.mp hf with rfl | hf'
-  · exact hne rfl
-  rcases List.mem_cons.mp hf' with rfl | hf''
-  · exact absurd (congrArg Prod.fst heq) (by decide)
-  · exact nomatch hf''
+/-- Reversed *ORDERED breakfast* allows exactly what the default bans — an instance of
+`Focus.strongAllowed_eq_weakBanned`, so the two metrical patterns of the node divide its focal
+targets between them. -/
+theorem reversal_allows_exactly_default_bans :
+    strongAllowed orderedM breakfastM = weakBanned orderedM breakfastM :=
+  Focus.strongAllowed_eq_weakBanned _ _
 
-/-- Reversal also excludes object-focus targets: only the accented
-verb may vary. -/
-theorem reversal_excludes_object_focus :
-    (Rel.ordered, Obj.lunch) ∉ strongAllowed orderedM breakfastM := by
-  rintro ⟨f, ⟨hf, _⟩, a, rfl, heq⟩
-  rcases List.mem_cons.mp hf with rfl | hf'
-  · exact absurd (congrArg Prod.snd heq) (by decide)
-  rcases List.mem_cons.mp hf' with rfl | hf''
-  · exact absurd (congrArg Prod.snd heq) (by decide)
-  · exact nomatch hf''
+/-- In particular reversal allows the non-trivial verb-focus target and nothing else: neither the
+ordinary value nor an object-focus target. -/
+theorem reversal_allows_only_verb_focus :
+    (Rel.paidFor, Obj.breakfast) ∈ strongAllowed orderedM breakfastM ∧
+      (Rel.ordered, Obj.breakfast) ∉ strongAllowed orderedM breakfastM ∧
+      (Rel.ordered, Obj.lunch) ∉ strongAllowed orderedM breakfastM := by
+  rw [reversal_allows_exactly_default_bans, weakBanned_eq]
+  refine ⟨rfl, by decide, by decide⟩
 
-/-- The licensed focal targets of default *ordered BREAKfast*
-compute to exactly the *breakfast*-free compositions: object focus
-with a new object survives; everything about *breakfast* is banned.
-The licensed set is the focus value the prosody derives — the
-pipeline the squiggle consumes at propositional type. -/
+/-- The licensed focal targets of default *ordered BREAKfast* are all the VP meanings the daughters
+compose except the banned one — "all VP meanings, except those that are relations to breakfast
+other than ordering breakfast". The licensed set is the focus value the prosody derives, which the
+squiggle consumes at propositional type. -/
 theorem licensed_eq :
     licensedFocusValue orderedM breakfastM =
-      {p : Rel × Obj | p.2 = Obj.lunch} := by
+      {p : Rel × Obj | p ≠ (Rel.paidFor, Obj.breakfast)} := by
   ext ⟨r, o⟩
+  rw [licensedFocusValue, weakBanned_eq]
+  simp only [Set.mem_sdiff, Set.mem_singleton_iff, Set.mem_ofPred_eq, Set.mem_seq_iff,
+    AltMeaning.mem_aSet, orderedM, breakfastM]
   constructor
-  · rintro ⟨⟨f, hf, a, ha, heq⟩, hban⟩
-    rcases List.mem_cons.mp ha with rfl | ha'
-    · exact absurd ⟨f, hf, .breakfast, rfl, heq⟩ hban
-    rcases List.mem_cons.mp ha' with rfl | ha''
-    · rcases List.mem_cons.mp hf with rfl | hf'
-      · exact (congrArg Prod.snd heq).symm
-      rcases List.mem_cons.mp hf' with rfl | hf''
-      · exact (congrArg Prod.snd heq).symm
-      · exact nomatch hf''
-    · exact nomatch ha''
-  · intro ho
-    have ho' : o = Obj.lunch := ho
-    subst ho'
-    refine ⟨⟨vt r, ?_, .lunch,
-      List.mem_cons_of_mem _ (List.mem_cons_self ..), rfl⟩, ?_⟩
+  · rintro ⟨-, hne⟩; exact hne
+  · intro hne
+    refine ⟨⟨vt r, ?_, o, ?_, rfl⟩, hne⟩
     · cases r
       · exact List.mem_cons_self ..
       · exact List.mem_cons_of_mem _ (List.mem_cons_self ..)
-    · rintro ⟨g, hg, a, ha, heq⟩
-      rcases Set.eq_of_mem_singleton ha with rfl
-      rcases List.mem_cons.mp hg with rfl | hg'
-      · exact absurd (congrArg Prod.snd heq) nofun
-      rcases List.mem_cons.mp hg' with rfl | hg''
-      · exact absurd (congrArg Prod.snd heq) nofun
-      · exact nomatch hg''
+    · cases o
+      · exact List.mem_cons_self ..
+      · exact List.mem_cons_of_mem _ (List.mem_cons_self ..)
 
 end Buring2015


### PR DESCRIPTION
`weakBanned` implemented Büring's rule **(1)**, which the paper labels "preliminary" and then revises. His (4) subtracts the weak daughter's ordinary value — `(alt.dom(Dw) \ {[[Dw]]O}) ⊗ {[[Ds]]O}` — for a stated reason: "we should never, at the lower (VP) level, exclude the literal meaning of a neutral node." Without that subtraction the rule bans a node's own denotation, and `Studies/Buring2015.licensed_eq` recorded exactly that consequence: the licensed set for *ordered BREAKfast* came out as the *breakfast*-free compositions, where Büring's own gloss is "all VP meanings, except those that are relations to breakfast other than ordering breakfast".

Fixing it sharpens the neighbouring result. `strongAllowed` already implemented (9) correctly, and (4)'s banned set is (9)'s allowed set, so `strongAllowed_subset_weakBanned` becomes `strongAllowed_eq_weakBanned`, provable by `rfl`: the two metrical patterns of a branching node divide its focal targets between them, rather than one merely refining the other.

Study side: `weakBanned_eq` pins the banned set to the single verb-focus target, `default_permits_ordinary_value` states the property (4) was introduced to secure, `licensed_eq` now matches Büring's gloss, and `reversal_allows_exactly_default_bans` instantiates the equality. `AssmannEtAl2023` and `Phonology/Prosody/Phrase`, the other consumers, are unaffected.

Follow-up, not in this PR: `Semantics/Alternatives/AltMeaning` stores the alternative set as `List α` — the docstring calls it a set, `aSet` converts it back, and Roothian alternative sets are in general infinite — and its stated invariant, that the ordinary value is among the alternatives, is a comment rather than a field, though both rules above subtract it.