### PR TITLE
refactor(Studies/CaoWhiteLassiter2025): state what the simplified INT loses

### DIFF
--- a/Linglib/Studies/CaoWhiteLassiter2025.lean
+++ b/Linglib/Studies/CaoWhiteLassiter2025.lean
@@ -7,30 +7,48 @@ import Linglib.Semantics.Causation.Interpretation
 import Linglib.Semantics.Causation.SEM.Counterfactual
 
 /-!
-# Cao, White & Lassiter 2025: graded causative verb semantics
+# Cao, White and Lassiter 2025: graded causative verb semantics
 
-This file formalizes the graded-causative analysis of English *cause*,
-*make*, and *force* from [cao-white-lassiter-2025]. On that account,
-acceptability tracks three measures defined in one structural causal
-model: Pearl's probability of sufficiency ([pearl-2019],
-`Causation.SEM.probSufficiency`), a simplified
-[halpern-kleiman-weiner-2018] degree of intention (`intentionDegree`),
-and the number of alternative actions available to the causee
-(`altCount`). The models are time-indexed (`CausalGraph.TimeIndex`),
-and their agents play a soft-optimality policy (`softOptimalPolicy`).
-The model apparatus is shared with
-[cao-geiger-kreiss-icard-gerstenberg-2023].
+This file formalizes the graded-causative analysis of English *cause*, *make*, and *force* in
+[cao-white-lassiter-2025]. Where [nadathur-lauer-2020] give *make* and *force* a single
+categorical truth condition, this account measures three quantities in one structural causal
+model of tic-tac-toe — Pearl's probability of sufficiency ([pearl-2019],
+`Causation.SEM.probSufficiency`), a simplified [halpern-kleiman-weiner-2018] degree of intention,
+and the number of alternative actions open to the causee — and finds that no one of them
+determines which verb speakers accept, each verb instead having its own set of reliable
+interactions. The model apparatus is shared with [cao-geiger-kreiss-icard-gerstenberg-2023]:
+models are time-indexed (`CausalGraph.TimeIndex`) and their agents play a soft-optimality policy.
 
-The paper's in-text judgments (its examples (3)–(11)) are stored as rows
-in `Data/Examples/CaoWhiteLassiter2025.json`. Regression estimates
-remain in prose; no single measure reliably determines verb choice, and
-each verb's per-verb model has a distinct set of reliable interaction
-terms.
+The paper's in-text judgments, its examples (3)–(11), are rows in
+`Data/Examples/CaoWhiteLassiter2025.json`; the regression estimates stay in prose.
+
+## Main definitions
+
+* `softOptimalPolicy` — the move distribution of a player of skill `ρ`
+* `altCount`, `intentionDegree`, `modelIntention` — the ALT and INT measures
+* `deterministicSuf` — the {0,1} collapse of SUF in the deterministic limit
+
+## Main results
+
+* `softOptimalPolicy_zero`, `softOptimalPolicy_one` — the infant and the professional
+* `intentionDegree_eq_one_of_altCount_eq_zero` — an action with no alternative comes out
+  maximally intentional, so the simplified INT drops the alternative-possibilities condition
+  ([frankfurt-1969], [halpern-kleiman-weiner-2018]) and ALT carries it instead
+* `probSufficiency_empty_eq_deterministicSuf` — at the vacuous context Pearl's SUF is
+  [nadathur-lauer-2020]'s categorical causal sufficiency
+* `probSufficiency_empty_eq_one_of_make` — the categorical *make* semantics is strictly stronger
+  than maximal graded SUF
+* `make_semantics_eq_force`, `judgment_differs_make_force` — the force-dynamic semantics does not
+  distinguish the two verbs the paper's (8) separates
 
 ## References
 
-* [A. Cao, A. S. White, D. Lassiter,
-  *Cause, make, and force as graded causatives*][cao-white-lassiter-2025]
+* [cao-white-lassiter-2025]
+* [pearl-2019]
+* [halpern-kleiman-weiner-2018]
+* [frankfurt-1969]
+* [nadathur-lauer-2020]
+* [cao-geiger-kreiss-icard-gerstenberg-2023]
 -/
 
 namespace CaoWhiteLassiter2025
@@ -40,16 +58,12 @@ open scoped ENNReal NNReal
 
 /-! ### Soft-optimality policy
 
-The paper's mechanism for agent moves (§2.1.1): the highest-utility
-move — minimax over the game tree, with terminal utility
-`Winner × (EmptySpace + 1)` — is taken with probability `ρ + (1−ρ)/n`,
-every other available move with `(1−ρ)/n` (`softOptimalPolicy_apply_best`,
-`softOptimalPolicy_apply_of_ne`).
-The skill parameter `ρ` interpolates between a uniformly random player
-("assume that the players are infants", `softOptimalPolicy_zero`) — the
-limiting case under which the paper's worked SUF contrast between
-contexts collapses — and a deterministic professional
-(`softOptimalPolicy_one`). -/
+The paper's mechanism for agent moves (§2.1.1). The highest-utility move — minimax over the game
+tree, with terminal utility `Winner × (EmptySpace + 1)` — is taken with probability `ρ + (1−ρ)/n`
+and every other available move with `(1−ρ)/n`, for `n` the number of empty spaces. The skill
+parameter interpolates between a uniformly random player ("assume that the players are infants"),
+under which the paper's worked SUF contrast between two board states collapses, and a
+deterministic professional. -/
 
 section
 variable {A : Type*} [Fintype A] [Nonempty A] (best : A) (ρ : ℝ≥0) (hρ : ρ ≤ 1)
@@ -77,11 +91,9 @@ end
 
 /-! ### The ALT measure
 
-ALT (§2.2 of [cao-white-lassiter-2025]) counts the alternative actions
-available to the causee, excluding the action actually taken —
-`ALT(Y₁) = 5` at the paper's fig. 2a board state. `ALT = 0` is the
-Frankfurt-style could-not-have-done-otherwise configuration
-(`altCount_eq_zero_iff`). -/
+ALT (§2.2) counts the alternative actions available to the causee, excluding the one actually
+taken — `ALT(Y₁) = 5` at the paper's fig. 2a board state. `ALT = 0` is the Frankfurt-style
+could-not-have-done-otherwise configuration. -/
 
 section
 variable {A : Type*} [Fintype A] (p : PMF A) (taken : A)
@@ -91,6 +103,7 @@ variable {A : Type*} [Fintype A] (p : PMF A) (taken : A)
 noncomputable def altCount : ℕ :=
   (p.support \ {taken}).ncard
 
+/-- The causee had no alternative exactly when every other action had probability zero. -/
 theorem altCount_eq_zero_iff : altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0 := by
   rw [altCount, Set.ncard_eq_zero (Set.toFinite _), Set.sdiff_eq_empty,
     Set.subset_singleton_iff]
@@ -98,26 +111,23 @@ theorem altCount_eq_zero_iff : altCount p taken = 0 ↔ ∀ a ≠ taken, p a = 0
 
 /-! ### The INT measure
 
-The paper's §2.3 displayed equation, a simplified
-[halpern-kleiman-weiner-2018] degree of intention:
+The paper's §2.3 displayed equation, a simplified [halpern-kleiman-weiner-2018] degree of
+intention:
 
 `INT(a) = Pr(A = a ∧ G) · u′(a) / Σ_{a′} Pr(A = a′ ∧ G) · u′(a′)`
 
-"the probability that an action performed in a state will result in the
-desired outcome, normalized by the probability of all alternative
-actions that would have resulted in the same outcome", with each term
-weighted by exponentiated utility `u′ = e^u` — the exponential serving
-only to make the weights strictly positive. Here `pr a′` is the joint
-probability that the agent takes `a′` and the goal results, and the
-weight is abstracted to any `w : A → ℝ≥0` (the paper's instantiation is
-`w = e^u`); `modelIntention` below instantiates `pr` over a `SEM`. INT
-is the normalized goal-weighted action distribution evaluated at the
-taken action (`intentionDegree_eq_normalize`), and an action without
-alternatives is trivially intentional
-(`intentionDegree_eq_one_of_altCount_eq_zero`) — the
-alternative-possibilities principle of [frankfurt-1969], via
-[halpern-kleiman-weiner-2018], behind the paper's *made*/*forced*
-contrast in its example (8). -/
+"the probability that an action performed in a state will result in the desired outcome,
+normalized by the probability of all alternative actions that would have resulted in the same
+outcome", each term weighted by exponentiated utility `u′ = eᵘ`, the exponential serving only to
+make the weights strictly positive. Here `pr a′` is the joint probability that the agent takes
+`a′` and the goal results, and the weight is abstracted to any `w : A → ℝ≥0`; `modelIntention`
+instantiates `pr` over a `SEM`.
+
+The simplification costs the principle it is motivated by: [halpern-kleiman-weiner-2018] hold,
+after [frankfurt-1969], that an action an agent could not have avoided is never intentional,
+while under this measure such an action is maximally intentional, its sole goal-conducive
+alternative being itself. It is ALT rather than INT that registers the paper's *made*/*forced*
+contrast in (8). -/
 
 variable (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A)
 
@@ -126,6 +136,7 @@ variable (pr : A → ℝ≥0∞) (w : A → ℝ≥0) (a : A)
 noncomputable def intentionDegree : ℝ≥0∞ :=
   (pr a * w a) / ∑ a', pr a' * w a'
 
+/-- INT is a share, so it never exceeds 1. -/
 theorem intentionDegree_le_one : intentionDegree pr w a ≤ 1 :=
   ENNReal.div_le_of_le_mul <| by
     simpa using Finset.single_le_sum (f := fun a' => pr a' * w a') (fun _ _ => zero_le)
@@ -139,6 +150,7 @@ theorem intentionDegree_eq_normalize (h0 : (∑' a', pr a' * w a') ≠ 0)
     intentionDegree pr w a = PMF.normalize (fun a' => pr a' * w a') h0 htop a := by
   rw [intentionDegree, PMF.normalize_apply, div_eq_mul_inv, tsum_fintype]
 
+/-- An action that is the only goal-conducive one carries the whole normalized weight. -/
 theorem intentionDegree_eq_one_of_no_alternatives
     (h : ∀ a ≠ taken, pr a = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0)
     (htop : pr taken ≠ ∞) :
@@ -148,6 +160,9 @@ theorem intentionDegree_eq_one_of_no_alternatives
   exact ENNReal.div_self (mul_ne_zero h0 (ENNReal.coe_ne_zero.mpr hw))
     (ENNReal.mul_ne_top htop ENNReal.coe_ne_top)
 
+/-- An agent who could not have done otherwise comes out maximally intentional: the simplified
+INT does not carry the alternative-possibilities condition, and ALT is what separates *made* from
+*forced*. -/
 theorem intentionDegree_eq_one_of_altCount_eq_zero
     (hle : pr ≤ ⇑p) (h : altCount p taken = 0) (h0 : pr taken ≠ 0) (hw : w taken ≠ 0) :
     intentionDegree pr w taken = 1 :=
@@ -171,14 +186,10 @@ noncomputable def modelIntention {V : Type*} {α : V → Type*}
 
 /-! ### Deterministic limit
 
-In the deterministic limit, SUF collapses to a {0,1} indicator
-(`Causation.SEM.probSufficiency_eq_indicator_of_deterministic`). At the
-vacuous (empty) context this is exactly [nadathur-lauer-2020]'s causal
-sufficiency (their definition (23)): with nothing observed, Pearl's
-counterfactual degenerates to the bare interventional development of
-`cause := true`, and "interventional = counterfactual at a vacuous
-context" is a theorem (`probSufficiency_empty_eq_deterministicSuf`)
-rather than a conflation. -/
+In the deterministic limit SUF collapses to a {0,1} indicator
+(`Causation.SEM.probSufficiency_eq_indicator_of_deterministic`). At the vacuous context this is
+[nadathur-lauer-2020]'s categorical causal sufficiency: with nothing observed, Pearl's
+counterfactual degenerates to the bare interventional development of `cause := true`. -/
 
 section
 variable {V : Type*} [Fintype V] [DecidableEq V] (M : BoolSEM V) [CausalGraph.IsDAG M.graph]
@@ -217,33 +228,37 @@ end
 
 /-! ### The paper's judgment data
 
-The paper's in-text acceptability contrasts are typed rows in
-`Data.Examples.CaoWhiteLassiter2025` (examples (3)–(11)): the
-non-interchangeability triplets, the gym gradability triplets, the
-could-have-done-otherwise pair, the intent-denial continuations, and the
-*make*/*let* sufficiency pair. Regression results stay in the module
-docstring: analysis outputs are not Lean content. -/
+The in-text contrasts are rows in `Data.Examples.CaoWhiteLassiter2025`: the
+non-interchangeability triplets (3)–(4), the gym gradability triplets (5)–(7), the
+could-have-done-otherwise pair (8), the intent-denial continuations (9)–(10), and the
+*make*/*let* sufficiency pair (11). -/
 
-/-- The force-dynamic dispatch of [nadathur-lauer-2020] gives *make* and
-    *force* identical truth conditions, but the paper's minimal pair (8)
-    — same frame, a could-have-done-otherwise continuation — pulls them
-    apart; *made* tolerates the continuation, *forced* resists it. The
-    ALT/INT measures register the difference
-    (`intentionDegree_eq_one_of_altCount_eq_zero`). -/
-theorem make_force_same_semantics_different_judgments
+/-- The force-dynamic dispatch gives *make* and *force* the same truth conditions, since both
+assert causal sufficiency ([nadathur-lauer-2020]). -/
+theorem make_semantics_eq_force
     {V : Type*} {α : V → Type*} [Fintype V] [DecidableEq V] [DecidableValuation α]
-    [∀ v, Fintype (α v)] (M : SEM V α) [CausalGraph.IsDAG M.graph]
-    [IsDeterministic M] :
-    Causative.toSemantics M .make = Causative.toSemantics M .force ∧
-    Examples.cwl2025_ex8a.judgment = .acceptable ∧
-    Examples.cwl2025_ex8b.judgment = .questionable :=
-  ⟨rfl, rfl, rfl⟩
+    [∀ v, Fintype (α v)] (M : SEM V α) [CausalGraph.IsDAG M.graph] [IsDeterministic M] :
+    Causative.toSemantics M .make = Causative.toSemantics M .force := rfl
 
-/-! ### A probabilistic example
+/-- The paper's (8) separates them anyway: in one frame with a could-have-done-otherwise
+continuation, *made* tolerates the continuation and *forced* resists it. What the shared
+semantics misses is the causee's alternatives, which ALT measures. -/
+theorem judgment_differs_make_force :
+    Examples.cwl2025_ex8a.judgment ≠ Examples.cwl2025_ex8b.judgment := by decide
 
-A 2-vertex SEM whose `effect` mechanism is a `p`-weighted coin —
-genuinely probabilistic, not Dirac. Demonstrates that `probSufficiency`
-accepts non-deterministic SEMs (no `IsDeterministic` constraint). -/
+/-- The gym triplets (5)–(7) grade the stronger verbs against a constant *cause*: the same three
+causing events leave *caused* acceptable throughout while *forced* switches, which is why the
+account measures the causal relation rather than classifying it. -/
+theorem gym_grades_stronger_verbs :
+    Examples.cwl2025_ex5a.judgment = Examples.cwl2025_ex6a.judgment ∧
+      Examples.cwl2025_ex6a.judgment = Examples.cwl2025_ex7a.judgment ∧
+      Examples.cwl2025_ex5c.judgment ≠ Examples.cwl2025_ex7c.judgment := by decide
+
+/-! ### A probabilistic model
+
+A 2-vertex SEM whose `effect` mechanism is a `p`-weighted coin. `probSufficiency` is defined for
+it with no determinism hypothesis, which is what makes SUF the graded measure the paper needs
+rather than the indicator of the previous section. -/
 
 namespace ProbabilisticExample
 
@@ -257,22 +272,20 @@ def graph : CausalGraph V := ⟨fun | .cause => ∅ | .effect => {.cause}⟩
 
 variable (p : ℝ≥0) (h : p ≤ 1)
 
-/-- The probabilistic mechanism for `effect`, ignoring its parent and
-    returning `true` with probability `p` — genuinely non-Dirac when
-    `p ∉ {0, 1}`. -/
+/-- The mechanism for `effect`: ignore the parent and return `true` with probability `p`. -/
 noncomputable def effectMech :
     Mechanism graph (fun _ => Bool) .effect :=
   ⟨fun _ => PMF.mix p h (PMF.pure false) (PMF.pure true)⟩
 
-/-- A genuinely probabilistic SEM (not `IsDeterministic` for `p ∉ {0,1}`). -/
+/-- The model: a `cause` vertex fixed to `false` and an `effect` vertex given by the coin. -/
 noncomputable def model : BoolSEM V :=
   { graph := graph
     mech := fun
       | .cause => const (G := graph) false
       | .effect => effectMech p h }
 
-/-- The 2-vertex graph is time-indexed in the sense of the paper's
-    definition 1, with `cause` at step 0 and `effect` at step 1. -/
+/-- The graph is time-indexed in the sense of the paper's definition 1, with `cause` at step 0
+and `effect` at step 1. -/
 def timeIndex : CausalGraph.TimeIndex graph where
   time := fun | .cause => 0 | .effect => 1
   parent_succ := by
@@ -286,11 +299,17 @@ instance : CausalGraph.IsDAG graph := timeIndex.isDAG
 instance : CausalGraph.IsDAG (model p h).graph :=
   inferInstanceAs (CausalGraph.IsDAG graph)
 
-/-- `probSufficiency` accepts this SEM despite it NOT being
-    `IsDeterministic` — exactly the [cao-white-lassiter-2025]
-    requirement that SUF be a real probability. -/
-noncomputable example : ENNReal :=
-  BoolSEM.probSufficiency (model p h) Valuation.empty .cause .effect
+/-- The model is not deterministic for `p` strictly between 0 and 1, so `probSufficiency` takes
+it outside the deterministic limit — as the paper's SUF, a genuine probability, requires. -/
+theorem isEmpty_isDeterministic (h0 : p ≠ 0) (h1 : p ≠ 1) :
+    IsEmpty (SEM.IsDeterministic (model p h)) := by
+  refine ⟨fun hd => ?_⟩
+  obtain ⟨hdet⟩ := hd
+  obtain ⟨f, hf⟩ := hdet .effect
+  have hb := hf fun _ => false
+  cases hfv : f (fun _ => false) <;> rw [hfv] at hb
+  · exact h0 (by simpa [model, effectMech] using DFunLike.congr_fun hb true)
+  · exact h1 (by simpa [model, effectMech] using DFunLike.congr_fun hb true)
 
 end ProbabilisticExample
 


### PR DESCRIPTION
The paper cites Frankfurt and Halpern & Kleiman-Weiner for "an action an agent could not have avoided is never intentional", but its simplified INT makes such an action *maximally* intentional — which is what `intentionDegree_eq_one_of_altCount_eq_zero` proves. The docstring had it the other way round, as the principle itself; it now says ALT carries the condition.

- `make_force_same_semantics_different_judgments` bundled the substrate fact that the force-dynamic dispatch identifies the two verbs with two `rfl` read-backs of stored judgments. Split into `make_semantics_eq_force` and two contrasts over the rows (`judgment_differs_make_force`, `gym_grades_stronger_verbs`).
- The probabilistic section ended in a `noncomputable example : ENNReal` under a docstring claiming the model is not `IsDeterministic` — now `isEmpty_isDeterministic` proves it.
- Module docstring recut to mathlib register; the References list was a single markdown reference-link and omitted every cited key but one.

Locators verified against the paper (ELM 3: 88–103): §2.1.1's policy and `Winner × (EmptySpace + 1)`, §2.2's `ALT(Y₁) = 5` at fig. 2a, §2.3's INT equation and its prose gloss, the "players are infants" ρ = 0 collapse, and §4's finding that no single measure determines verb choice.