### PR TITLE
refactor(Studies/CarianiSantorio2018): fix the Hajek reading, drop the prediction table

### DIFF
--- a/Linglib/Studies/CarianiSantorio2018.lean
+++ b/Linglib/Studies/CarianiSantorio2018.lean
@@ -7,99 +7,74 @@ import Linglib.Semantics.Modality.Selectional
 import Linglib.Semantics.Conditionals.WillConditional
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Core.Probability.Finite
-import Linglib.Fragments.English.Auxiliaries
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# [cariani-santorio-2018] — *Will* done Better
+# Cariani and Santorio 2018: will done better
 
-Cariani, F. & Santorio, P. (2018). Will done Better: Selection Semantics,
-Future Credence, and Indeterminacy. *Mind* 127(505): 129–165.
+This file formalizes the selectional analysis of the future modal in [cariani-santorio-2018].
+*Will* is a modal — it embeds, scopes and interacts with negation — but not a quantifier over
+worlds: `will A` is true at `w` when `A` holds at the single world a [stalnaker-1968] selection
+function picks out of the historical alternatives. Quantificational accounts fail two further
+desiderata that this one meets by construction. *Will* is scopeless, `¬ will A` and `will ¬A`
+being equivalent, which universal quantification over a non-trivial modal base cannot deliver;
+and sincere assertion of `will A` requires only non-extreme credence, whereas a universal reading
+makes any open future-claim false and so demands credence 0.
 
-## Core Claim
+The Sports Fan scenario is the worked model: Cynthia wears a Warriors cap, a Giants cap, or no
+cap tomorrow according to a fair three-way process, and an agent gives each option credence 1/3.
+The selectional content of *Cynthia will wear a Warriors cap* is just the Warriors-cap worlds, so
+it inherits credence 1/3, while the universal reading is false throughout and gets credence 0.
+The same model shows the account's limit: no proposition over it has probability 1/2, so the
+selectional content of *if Cynthia wears a cap, she will wear a Warriors cap* cannot take the
+value the corresponding conditional probability does — an instance of [hajek-1989]'s observation
+that conditional probability values outnumber unconditional ones.
 
-The future modal *will* is best analyzed as a **selectional** operator:
-`will A` is true at `w` iff `A` holds at the unique world picked out by
-a selection function from a set of historical alternatives. This rejects
-both the pure-tense view (*will A* = *A* holds at a future time) and the
-universal view (*will A* = *A* at every historical alternative).
+## Main definitions
 
-## Three Constraints (the desiderata)
+* `W`, `histAlt`, `cynthiaSel`, `cynthiaPMF` — the Sports Fan worlds, alternatives, selection
+  function and credences
 
-[cariani-santorio-2018] argue that an adequate theory must satisfy:
+## Main results
 
-1. **Modal character** — *will* embeds, takes scope, and interacts with
-   negation/quantifiers. Pure tense fails.
-2. **Scopelessness** — `¬ will A ↔ will ¬ A` in matrix uses.
-   Universal quantification over a non-trivial modal base fails (the
-   asymmetry between `¬∀` and `∀¬`).
-3. **Cognitive role** — sincere assertion of `will A` requires
-   non-extreme credence, not credence 1. Universal-base accounts make
-   the assertion conditions too strong.
+* `cynthia_credence_one_third`, `universal_will_credence_zero` — the cognitive-role contrast
+* `cap_will_conditional_cem`, `universal_will_conditional_cem_fails` — will-conditionals validate
+  Compositional CEM on the selectional reading and refute it on the universal one
+* `no_unconditional_one_half`, `cap_warriors_credence_one_half` — no proposition over the model
+  has the probability the conditional does
 
-The selectional analysis satisfies all three by construction.
+## References
 
-## The Sports Fan model (paper §2.3, §3 figure 2)
-
-Cynthia is wondering what hat Robin will wear tomorrow to the game.
-She considers three open historical alternatives — Robin will wear a
-*Warriors* cap (`cw`), a *Giants* cap (`cg`), or *no* cap (`cn`) —
-and assigns each credence 1/3. The example is designed to make every
-predicate of interest land on a probability in `{0, 1/3, 2/3, 1}`,
-which is what blocks [hajek-1989]'s triviality argument from
-applying (paper §8.2 footnote 32).
-
-## Verified predictions
-
-| # | Prediction | Theorem |
-|---|-----------|---------|
-| 1 | Sports Fan: Cynthia thinks Robin will wear a Warriors cap | `cynthia_will_warriors_cap` |
-| 2 | Will Excluded Middle holds at every world | `will_em_at_cw` |
-| 3 | Negation Swap: ¬will A ↔ will ¬A | `swap_at_cw` |
-| 4 | Speaker w/o w in modal base ≠ collapse | `nonmember_no_collapse` |
-| 5 | Speaker with w in modal base ⇒ collapse | `member_collapses` |
-| 6 | Selectional `will`: μ(‖will Warriors-cap‖) = 1/3 | `cynthia_credence_one_third` |
-| 7 | Universal `will`: μ(‖∀Warriors-cap‖) = 0 (collapse) | `universal_will_credence_zero` |
-| 8 | "If Robin wears a cap, Robin'll wear a Warriors cap" — *conditional* credence 1/2 (paper ex. (31)/eq. (32), §8)| `cap_warriors_credence_one_half` |
-| 9 | Hájek triviality fails: no proposition has probability 1/2 unconditionally (§8.2 fn 32) | `no_unconditional_one_half` |
-| 10| `cynthiaSel` is coherent (§5.1: selection induces a well-ordering) | `cynthiaSel_coherent` |
-| 11| Selectional will-conditional validates Compositional CEM (§7) | `cap_will_conditional_cem` |
-| 12| Universal-base will-conditional refutes CEM (the Lewis side) | `universal_will_conditional_cem_fails` |
+* [cariani-santorio-2018]
+* [stalnaker-1968]
+* [hajek-1989]
 -/
 
 namespace CarianiSantorio2018
 
 open _root_.Conditionals (SelectionFunction)
 open Modality.Selectional
-open Conditionals.WillConditional
-  (wouldConditional willConditional universalWillConditional compositional_CEM)
+open Conditionals.WillConditional (willConditional universalWillConditional compositional_CEM)
 open scoped ENNReal
 
--- ============================================================================
--- §1. The Sports Fan model
--- ============================================================================
+/-! ### The Sports Fan model -/
 
-/-- Three worlds — Robin's cap choices for tomorrow's game
-    [cariani-santorio-2018] §2.3 + §3 figure 2:
-- `cw`: Robin wears a Warriors cap.
-- `cg`: Robin wears a Giants cap.
-- `cn`: Robin wears no cap. -/
+/-- The three worlds of the Sports Fan scenario (§2.3), the modal base of *Cynthia will wear a
+Warriors cap*: she wears a Warriors cap, a Giants cap, or no cap. -/
 inductive W where
   | cw | cg | cn
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- Cynthia's modal parameter: every cap-choice is historically open.
-    [cariani-santorio-2018] treat the Sports Fan as a case where
-    *all three* alternatives are live; nothing is settled at the time
-    Cynthia forms her credences. -/
+/-- The modal parameter: every cap-choice is historically open, nothing being settled at the time
+of utterance. -/
 def histAlt : Set W := { .cw, .cg, .cn }
 
-/-- Proposition: "Robin wears a Warriors cap." -/
+/-- Proposition: "Cynthia wears a Warriors cap." -/
 def warriorsCap : Set W := {.cw}
 
 instance : DecidablePred (· ∈ warriorsCap) := fun w => decEq w .cw
 
-/-- Proposition: "Robin wears *some* cap" (Warriors or Giants). -/
+/-- Proposition: "Cynthia wears *some* cap" (Warriors or Giants). -/
 def wearsCap : Set W := {.cw, .cg}
 
 instance : DecidablePred (· ∈ wearsCap) := fun w =>
@@ -139,13 +114,10 @@ noncomputable def cynthiaSel : SelectionFunction W where
   inclusion := selFn_inclusion
   centering := selFn_centering
 
-/-- **Coherence** [cariani-santorio-2018] §5.1: `cynthiaSel`
-    induces a well-ordering on `{cw, cg, cn}` — its pairwise preference
-    is transitive. The order, by construction of `selFn`, is
-    `cw < cg < cn` from any centre that is not itself in the candidate
-    pair (Centering forces the centre to win when it is present).
-
-    Proved by exhaustive enumeration over 3⁴ = 81 quadruples. -/
+/-- The preference `selFn` induces on the three worlds is transitive. [cariani-santorio-2018]
+impose only Inclusion and Centering, leaving [stalnaker-1968]'s further constraints open (§5.2
+fn. 17); this witness satisfies them anyway, ordering the worlds `cw < cg < cn` from any centre
+not itself among the candidates. -/
 theorem cynthiaSel_coherent : cynthiaSel.isCoherent := by
   intro w₀ w₁ w₂ w₃ h12 h23
   unfold _root_.Conditionals.selectionPrefers cynthiaSel selFn at *
@@ -153,80 +125,46 @@ theorem cynthiaSel_coherent : cynthiaSel.isCoherent := by
   cases w₀ <;> cases w₁ <;> cases w₂ <;> cases w₃ <;>
     simp_all (config := { decide := true })
 
--- ============================================================================
--- §2. Sports Fan predictions
--- ============================================================================
+/-! ### Modal subordination -/
 
-/-- **Prediction 1**: From the Warriors-cap world `cw`,
-    Cynthia's assertion *Robin will wear a Warriors cap* is true.
-
-    `willSem cynthiaSel warriorsCap histAlt cw` reduces by Centering
-    (since `cw ∈ histAlt`) to `warriorsCap cw = True`. -/
+/-- At the Warriors-cap world, *Cynthia will wear a Warriors cap* is true: Centering makes the
+selected world the world of evaluation, so the claim reduces to its prejacent. -/
 theorem cynthia_will_warriors_cap :
     willSem cynthiaSel warriorsCap histAlt .cw := by
   rw [unembedded_collapse cynthiaSel warriorsCap histAlt .cw
       (by simp [histAlt])]
   trivial
 
-/-- **Prediction 2** (Will Excluded Middle): at every world,
-    `will warriorsCap ∨ will ¬warriorsCap` holds. -/
-theorem will_em_at_cw :
-    willSem cynthiaSel warriorsCap histAlt .cw ∨
-    willSem cynthiaSel (fun w => ¬ warriorsCap w) histAlt .cw :=
-  will_excluded_middle cynthiaSel warriorsCap histAlt .cw
 
-/-- **Prediction 3** (Negation Swap): under selectional semantics,
-    `¬ will A ↔ will ¬ A`. This is what makes *will* "scopeless"
-    in matrix uses — failing under universal quantification. -/
-theorem swap_at_cw :
-    willSem cynthiaSel (fun w => ¬ warriorsCap w) histAlt .cw ↔
-    ¬ willSem cynthiaSel warriorsCap histAlt .cw :=
-  negation_swap cynthiaSel warriorsCap histAlt .cw
-
--- ============================================================================
--- §3. Modal subordination — collapse only with membership
--- ============================================================================
 
 /-- A modal parameter that *excludes* the actual world `cw` (here taken
     as the world from which Cynthia evaluates): the speaker is reasoning
-    about a counterfactual continuation in which Robin wears no cap. -/
+    about a counterfactual continuation in which Cynthia wears no cap. -/
 def counterfactualAlt : Set W := { .cn }
 
-/-- **Prediction 4**: when the evaluation world `cw` is *not* in the
-    modal parameter, *no* collapse — `will A` may diverge from `A w`.
-
-    Here `will warriorsCap` evaluated at `cw` against `counterfactualAlt`
-    selects `cn` (by Inclusion + the construction of `cynthiaSel`),
-    where `warriorsCap` is False. So the assertion is False even
-    though `warriorsCap cw = True`. -/
+/-- Where the world of evaluation is outside the modal parameter the collapse fails: the
+selection function must leave it, and the claim can diverge from its prejacent. -/
 theorem nonmember_no_collapse :
     ¬ willSem cynthiaSel warriorsCap counterfactualAlt .cw := by
   show selFn .cw counterfactualAlt ∉ warriorsCap
   unfold selFn counterfactualAlt
   simp [warriorsCap]
 
-/-- **Prediction 5** (= [cariani-santorio-2018] eq. (18) collapse):
-    when `w` is in the modal parameter, `will A` collapses to `A w`. -/
+/-- Where the world of evaluation is in the modal parameter, Centering collapses `will A` to its
+prejacent — which is what makes an unembedded will-claim inherit its prejacent's credence. -/
 theorem member_collapses (A : W → Prop) (w : W) (hw : w ∈ histAlt) :
     willSem cynthiaSel A histAlt w ↔ A w :=
   unembedded_collapse cynthiaSel A histAlt w hw
 
--- ============================================================================
--- §4. Cognitive role: μ(‖will A‖) vs μ(‖∀A‖)
--- ============================================================================
+/-! ### The cognitive role of a will-claim -/
 
 /-- The universe of `W` enumerated as a 3-element `Finset` —
     used to reduce `∑ w : W, f w` to `f cw + f cg + f cn`. -/
 private lemma univ_W_eq : (Finset.univ : Finset W) = {.cw, .cg, .cn} := by
   ext w; cases w <;> decide
 
-/-- **Cynthia's credence** over the historical alternatives. Uniform
-    on `histAlt = {cw, cg, cn}` — each cap choice gets 1/3.
-
-    The uniform-over-three structure is what blocks the [hajek-1989]
-    triviality argument: no proposition lands on probability 1/2
-    unconditionally, so the selectional account survives Hájek's
-    objection by construction (paper §8.2 footnote 32). -/
+/-- The agent's credences over the historical alternatives: uniform, each cap choice getting
+1/3. -/
 noncomputable def cynthiaPMF : PMF W :=
   PMF.ofFintype (fun _ => (1 : ℝ≥0∞) / 3) (by
     rw [univ_W_eq, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
@@ -241,12 +179,8 @@ theorem cynthiaPMF_support_in_histAlt : cynthiaPMF.support ⊆ histAlt := by
   intro w _
   cases w <;> simp [histAlt]
 
-/-- **Prediction 6** (selectional cognitive role, paper §8.1):
-    Cynthia's credence in *Robin will wear a Warriors cap* equals her
-    credence in *Robin wears a Warriors cap*. Both are 1/3 — non-extreme
-    credence licenses the *will*-assertion.
-
-    Direct application of `Selectional.cognitive_role`. -/
+/-- Transparency (§8.1): the credence in *Cynthia will wear a Warriors cap* is the credence in
+its prejacent, so a will-claim about an open future carries non-extreme credence. -/
 theorem cynthia_credence_one_third :
     cynthiaPMF.probOfSet {w | cynthiaSel.sel w histAlt ∈ warriorsCap} = 1/3 := by
   rw [cognitive_role cynthiaSel warriorsCap histAlt cynthiaPMF
@@ -268,15 +202,9 @@ theorem universalWill_warriorsCap_const_false (w : W) :
   have hcg : W.cg ∈ warriorsCap := h .cg (by simp [histAlt])
   simp [warriorsCap] at hcg
 
-/-- **Prediction 7** (universal-base credence collapse, paper §8.1):
-    under the universal-quantifier reading, Cynthia's credence in
-    *will Warriors-cap* is **0**, because the universal is false at
-    every world (the Giants-cap world `cg` is in `histAlt`).
-
-    Contrast with the selectional reading (`cynthia_credence_one_third`),
-    which gives 1/3 — the empirically attested value. The
-    selectional/universal split here is the substantive cognitive-role
-    argument from [cariani-santorio-2018] §8.1. -/
+/-- The universal reading gets credence 0, since the universal is false wherever the future is
+open. This is the cognitive-role argument: a rational agent's non-extreme credence in a
+will-claim is unavailable on a quantificational semantics. -/
 theorem universal_will_credence_zero :
     cynthiaPMF.probOfSet {w | universalWill warriorsCap histAlt w} = 0 := by
   have hempty : {w | universalWill warriorsCap histAlt w} = (∅ : Set W) := by
@@ -285,30 +213,14 @@ theorem universal_will_credence_zero :
     exact universalWill_warriorsCap_const_false w
   rw [hempty, PMF.probOfSet_empty]
 
--- ============================================================================
--- §5. The cap-conditional (paper ex. (31)/eq. (32), §8)
--- ============================================================================
+/-! ### The cap-conditional -/
 
-/-- **Prediction 8** (will-conditional, paper ex. (31)/eq. (32) §8):
-    *If Robin wears a cap, Robin'll wear a Warriors cap*. The Kratzer
-    restriction (`willConditional`) sends the modal parameter from
-    `histAlt = {cw, cg, cn}` to `histAlt ∩ ‖cap‖ = {cw, cg}` — the
-    cap-wearing alternatives.
-
-    The theorem records the **conditional** (Bayesian) credence
-    `P(Warriors-cap | cap) = 1/2`: of the cap-wearing worlds (mass 2/3),
-    the Warriors-cap world has mass 1/3, so `1/3 ÷ 2/3 = 1/2`. This is
-    the intuitive Adams-thesis value.
-
-    Note [cariani-santorio-2018] §8 are explicit that the selectional
-    will-conditional *proposition* itself does **not** reach 1/2 in this
-    3-world model — it gets 1/3 or 2/3, since "no proposition can have
-    probability 1/2" when every world has probability 1/3. Standard
-    conditional semantics "fails to vindicate the intuitive assignments
-    of probabilities to conditional sentences"; recovering 1/2 for the
-    proposition needs the §8 refinement to a finer world-algebra. The
-    theorem here captures the Bayesian conditional ratio (the value that
-    refinement targets), not the selectional proposition's probability. -/
+/-- The value a degree of belief in *if Cynthia wears a cap, she will wear a Warriors cap*
+naturally takes: of the cap-wearing worlds, which carry mass 2/3, the Warriors-cap world carries
+1/3. No proposition over this model has that probability (`no_unconditional_one_half`), so the
+selectional content of the conditional cannot take it — it is 1/3 or 2/3 depending on which world
+the selection function returns at the no-cap world. [cariani-santorio-2018] recover the value by
+refining the algebra to world-and-selection-function pairs. -/
 theorem cap_warriors_credence_one_half :
     cynthiaPMF.probOfSet wearsCap ≠ 0 ∧
     cynthiaPMF.condProbSet wearsCap warriorsCap = 1/2 := by
@@ -335,32 +247,11 @@ theorem cap_warriors_credence_one_half :
     -- (1/3) / (2/3) = 1/2 in ENNReal — `ennreal_arith` lifts to ℝ
     ennreal_arith
 
-/-- **The morphological identity in action**: the would-conditional
-    *if Robin had worn a cap, Robin would have worn a Warriors cap*
-    is the same proposition as the corresponding will-conditional.
-    [cariani-santorio-2018] §5.3.2's claim that *would* = past-
-    tense *will* lifts to conditionals: `wouldConditional` and
-    `willConditional` agree definitionally. -/
-theorem cap_would_eq_will (w : W) :
-    wouldConditional cynthiaSel wearsCap warriorsCap histAlt w =
-    willConditional cynthiaSel wearsCap warriorsCap histAlt w :=
-  rfl
+/-! ### Conditional excluded middle
 
--- ============================================================================
--- §5b. Conditional Excluded Middle: selectional validates, universal refutes
--- ============================================================================
-
-/-! ## The Stalnaker/Lewis CEM fault line, lifted to will-conditionals
-
-[cariani-santorio-2018] §7 derive Compositional CEM —
-`(if A, will B) ∨ (if A, will ¬B)` — from selection single-valuedness.
-The Lewis-style universal-base reading (`universalWillConditional`)
-refutes it, exactly as Lewis's universal counterfactual refutes
-Conditional Excluded Middle for counterfactuals (cf.
-`Stalnaker1981.bizet_cem_fails_universal`). The contrast below exhibits
-that fault line at the future-modal layer, on the Sports Fan model: the
-restricted parameter `histAlt ∩ ‖cap‖ = {cw, cg}` contains both a
-Warriors-cap world (`cw`) and a non-Warriors-cap world (`cg`). -/
+Compositional CEM — `(if A, will B) ∨ (if A, will ¬B)` — follows from the single-valuedness of
+selection (§7). The universal-base reading refutes it on the same restricted parameter
+`histAlt ∩ ‖cap‖ = {cw, cg}`, which holds both a Warriors-cap world and a Giants-cap one. -/
 
 /-- **Selectional will-conditionals validate Compositional CEM**
     (paper §7): for the cap-conditional on the Sports Fan model,
@@ -392,37 +283,13 @@ theorem universal_will_conditional_cem_fails :
       h .cw ⟨by simp [histAlt], show (W.cw) ∈ wearsCap by decide⟩
     exact absurd (show (W.cw) ∈ warriorsCap by decide) hcw
 
-/-- **The CEM split at the future-modal layer**: the selectional
-    will-conditional validates Compositional CEM while the universal-base
-    reading refutes it. This is the future-tense image of the Stalnaker /
-    Lewis dispute that `Stalnaker1981` records for counterfactuals — one
-    structural divergence, surfaced at both the counterfactual and the
-    will-conditional layer. -/
-theorem will_conditional_cem_split :
-    (willConditional cynthiaSel wearsCap warriorsCap histAlt .cw ∨
-     willConditional cynthiaSel wearsCap (fun w => ¬ warriorsCap w) histAlt .cw) ∧
-    (¬ universalWillConditional wearsCap warriorsCap histAlt .cw ∧
-     ¬ universalWillConditional wearsCap (fun w => ¬ warriorsCap w) histAlt .cw) :=
-  ⟨cap_will_conditional_cem, universal_will_conditional_cem_fails⟩
+/-! ### The limit of the account -/
 
--- ============================================================================
--- §6. Hájek triviality fails (paper §8.2 footnote 32)
--- ============================================================================
-
-/-- **Prediction 9** (paper §8.2 footnote 32): on the 3-cap Sports Fan
-    model with uniform credence 1/3, *no* predicate `B : W → Bool` has
-    `cynthiaPMF`-probability `1/2`. The probabilities all land in
-    `{0, 1/3, 2/3, 1}`.
-
-    [hajek-1989]'s triviality argument requires a proposition with
-    probability 1/2 to construct its problematic conditional. Cariani &
-    Santorio observe that the Sports Fan deliberately avoids any such
-    predicate — no proposition gets probability 1/2 here, so Hájek's
-    argument cannot get off the ground in this model. The selectional
-    account is therefore not undermined by the triviality result on
-    this paradigm.
-
-    Proved by exhaustive enumeration over `2³ = 8` decidable subsets. -/
+/-- No proposition over the Sports Fan model has probability 1/2: with three worlds at 1/3 each,
+every probability lands in `{0, 1/3, 2/3, 1}`. This is [hajek-1989]'s point in miniature —
+conditional probability values outnumber unconditional ones, so some conditional probability has
+no proposition to match it, and a semantics that gives a conditional a proposition as its content
+cannot always give it the value it intuitively takes. -/
 theorem no_unconditional_one_half (S : Set W) [DecidablePred (· ∈ S)] :
     cynthiaPMF.probOfSet S ≠ 1/2 := by
   rw [PMF.probOfSet_apply, univ_W_eq, Finset.sum_insert (by decide),
@@ -437,67 +304,5 @@ theorem no_unconditional_one_half (S : Set W) [DecidablePred (· ∈ S)] :
     (simp [hcw, hcg, hcn, ENNReal.toReal_add,
            ENNReal.toReal_ofNat, ENNReal.add_eq_top] at h
      try norm_num at h)
-
--- ============================================================================
--- §11. Morphological preconditions of the C&S analysis (Fragment binding)
--- ============================================================================
-
-/-! ## Fragment binding
-
-C&S analyse the English auxiliaries `English.Auxiliaries.will`
-and `English.Auxiliaries.would`. The Fragment is the source
-of truth for those entries' morphology; this section records the
-morphological facts the C&S analysis depends on, as per-entry `rfl`
-preconditions. If anyone later changes the morphological classification
-of *will* or *would* in the Fragment (e.g., flips the `tense` field
-on `would` away from `some .Past`), the corresponding precondition
-theorem here breaks — making the cascading consequence for C&S visible
-at compile time.
-
-The Auxiliaries Fragment is a hub: other studies that analyse the
-same entries ([condoravdi-2002], [kratzer-1981], etc.) record
-their own morphological preconditions parallel to these. To enumerate
-every analysis that touches a given entry, grep for
-`English.Auxiliaries.<entry>` across the library.
-
-This section records *morphological* preconditions only. The C&S
-semantic clauses (`willSem`, `wouldSem`) and their downstream theorems
-live in the rest of this file and in
-`Semantics/Modality/Selectional.lean`. The signature mismatch
-between C&S's atemporal-propositional `willSem` and Condoravdi's
-time-indexed-eventive `woll` means their predictions cannot be
-compared by direct equation; a divergence-witness theorem against
-[condoravdi-2002] is left for follow-up. -/
-
-/-- **C&S precondition**: the Fragment classifies *will* as a modal
-    auxiliary. C&S's selectional analysis presupposes modal status —
-    constraint #1 (modal character) requires *will* to embed, scope,
-    and interact with negation/quantifiers. -/
-theorem cs_assumes_will_is_modal_aux :
-    English.Auxiliaries.will ∈ English.Auxiliaries.modals := by decide
-
-/-- **C&S precondition**: the Fragment marks *will* as morphologically
-    non-past (`tense = none`). C&S analyse *will* as the present-tense
-    member of the future-modal pair; the `wouldSem`-as-past-shifted-
-    `willSem` argument (§5.3.2) presumes this. -/
-theorem cs_assumes_will_no_past_morph :
-    English.Auxiliaries.will.tense = none := rfl
-
-/-- **C&S precondition**: the Fragment marks *would* as morphologically
-    past (`tense = some .Past`). C&S §5.3.2 derives the *would* clause
-    by past-shifting the modal parameter on *will*; if the Fragment
-    later reclassified *would* as non-past, the §5.3.2 argument would
-    no longer apply at the surface-form level. -/
-theorem cs_assumes_would_past_morph :
-    English.Auxiliaries.would.tense =
-      some UD.Tense.Past := rfl
-
-/-- **C&S precondition**: *will* and *would* are morphologically
-    distinguished by their `tense` fields. The selectional analysis
-    would collapse vacuously if the Fragment treated them as
-    morphologically identical. -/
-theorem cs_will_would_morph_distinct :
-    English.Auxiliaries.will.tense ≠
-      English.Auxiliaries.would.tense := by decide
 
 end CarianiSantorio2018

--- a/references.bib
+++ b/references.bib
@@ -10946,6 +10946,20 @@
   role      = {referenced},
   sources   = {Studies/CaoWhiteLassiter2025.lean}
 }
+@article{hajek-1989,
+  author    = {H{\'a}jek, Alan},
+  year      = {1989},
+  title     = {Probabilities of Conditionals --- Revisited},
+  journal   = {Journal of Philosophical Logic},
+  volume    = {18},
+  number    = {4},
+  pages     = {423--428},
+  doi       = {10.1007/BF00262944},
+  subfield  = {semantics/conditionals},
+  validated = {true},
+  role      = {cited},
+  sources   = {Studies/CarianiSantorio2018.lean}
+}
 @inproceedings{halpern-kleiman-weiner-2018,
   author    = {Halpern, Joseph Y. and Kleiman-Weiner, Max},
   year      = {2018},


### PR DESCRIPTION
The file had Hájek backwards. It said the Sports Fan model "blocks [hajek-1989]'s triviality argument from applying" and that "the selectional account is therefore not undermined by the triviality result", under a section headed "Hájek triviality fails". The paper says the opposite: no proposition over the model has probability 1/2, which is *why* the selectional content of the cap-conditional cannot take the value the conditional probability does, and Hájek is cited to show the mismatch is general. `no_unconditional_one_half` proves exactly that, and now says so.

- The subject of the Sports Fan example is Cynthia, not Robin; the docstrings had invented a second character while the declaration names kept the paper's.
- `cynthiaSel_coherent` was attributed to "§5.1: selection induces a well-ordering". §5.1 is Setup, and §5.2 says Inclusion and Centering "are the only constraints we impose", leaving Stalnaker's further ones open in fn. 17.
- Cut the 12-row prediction table from the module docstring, four Fragment-field `rfl` read-backs under a docstring explaining their maintenance value, `cap_would_eq_will` (`rfl` between two substrate defs, one of which is defined as the other), `will_conditional_cem_split` (the conjunction of the two theorems above it), and two theorems that were substrate lemmas applied at `.cw`.
- `cap_warriors_credence_one_half` is kept and reframed as the value the account misses, which is what its own docstring already said and what the table's "Verified prediction" row denied.
- Adds `hajek-1989` (JPL 18(4):423–428, DOI verified), which was cited but absent from the bibliography.

Paper read in full from the White Rose accepted manuscript; §2.3, §5.2, §5.3.2, §7, §8.1, §8.2 and fn. 32 verified.