### PR TITLE
refactor(Studies): replace the String type tag, register the Chatzikyriakidis docstrings

### DIFF
--- a/Linglib/Studies/ChatzikyriakidisEtAl2025.lean
+++ b/Linglib/Studies/ChatzikyriakidisEtAl2025.lean
@@ -1,36 +1,41 @@
 import Linglib.Data.Examples.Schema
 import Mathlib.Logic.Equiv.Defs
-import Linglib.Data.Examples.ChatzikyriakidisEtAl2025
 
 /-!
-# Chatzikyriakidis–Cooper–Gregoromichelaki–Sutton 2025: TTR intentional identity
+# Chatzikyriakidis, Cooper, Gregoromichelaki and Sutton 2025: intentional identity in TTR
 
-[chatzikyriakidis-etal-2025] §2.3.2 treats [geach-1967]'s Hob–Nob puzzle —
-"Hob thinks a witch has blighted Bob's mare, and Nob wonders whether she (the
-same witch) killed Cob's sow" — following [ranta-1994]'s belief-context
-analysis, recast by [cooper-2023] with record types in place of contexts: Hob's
-and Nob's belief contexts overlap with respect to a shared witch component,
-which need not be witnessed. Types, unlike sets of worlds, are individuated
-intensionally (`extEquiv_not_intEq` below), so two
-agents' attitudes can concern the same possibly-empty type.
+This file formalizes the treatment of [geach-1967]'s Hob–Nob sentence — *Hob thinks a witch has
+blighted Bob's mare, and Nob wonders whether she (the same witch) killed Cob's sow* — in
+[chatzikyriakidis-etal-2025] §2.3.2, following [ranta-1994]'s belief contexts as recast by
+[cooper-2023] with record types. The discourse is acceptable although no witch need exist and
+neither attitude holder need know of the other, so what the two attitudes share cannot be an
+individual. On this account it is a type: Hob's and Nob's contents both have the witch type as a
+component, and types are individuated intensionally, so the two contents can share it while
+remaining distinct and while the type is empty. The datum is
+`Data/Examples/ChatzikyriakidisEtAl2025.json`.
 
-This file formalizes the shared-component core of the account: Hob's and Nob's
-contents both have `witchType` as a meet component while that type is empty.
-The full analysis additionally aligns *labels* across the agents' belief
-contexts ("indexed by the same variable in their respective belief contexts"),
-giving sameness of discourse referent rather than merely of type; that
-refinement awaits dependent record substrate, and without it component-sharing
-alone cannot distinguish "the same witch" from "a witch of the same kind" —
-the distinction [edelberg-1986]'s asymmetry data make empirically load-bearing.
+The full analysis also aligns labels across the two belief contexts, giving sameness of discourse
+referent rather than merely of type; that needs dependent record substrate.
 
-## Main declarations
+## Main definitions
 
-- `Examples.hobNob`: Geach's sentence as a `LinguisticExample`
-- `witchType`, `hobContent`, `nobContent`: the Hob–Nob model
-- `SharesComponent`: a content has `T` as its left meet component
-- `intentional_identity`: the contents share the empty witch type yet
-  are intensionally distinct
-- `validates_hobNob`: the model validates the empirical datum
+* `Tag`, `IType` — a carrier with an identity beyond its extension
+* `IType.extEquiv`, `IType.intEq`, `IType.meet` — extensional equivalence, intensional identity,
+  and the meet that preserves it
+* `witchType`, `hobContent`, `nobContent`, `SharesComponent` — the model and component sharing
+
+## Main results
+
+* `extEquiv_not_intEq` — the two contents are extensionally equivalent and intensionally distinct,
+  which a possible-worlds content cannot manage
+* `intentional_identity` — they share the witch type, remain distinct, and the type is empty
+
+## References
+
+* [chatzikyriakidis-etal-2025]
+* [geach-1967]
+* [ranta-1994]
+* [cooper-2023]
 -/
 
 namespace ChatzikyriakidisEtAl2025
@@ -40,13 +45,25 @@ namespace ChatzikyriakidisEtAl2025
 [cooper-2023] §1.3: types are individuated beyond their extensions — a
 name-tagged wrapper over a Lean carrier suffices for the Hob–Nob model. -/
 
+/-- The atoms of the model, and their meets: what individuates a type beyond its extension. -/
+inductive Tag where
+  /-- The witch. -/
+  | witch
+  /-- Blighting Bob's mare. -/
+  | blightBobsMare
+  /-- Killing Cob's sow. -/
+  | killCobsSow
+  /-- The meet of two tags. -/
+  | meet (a b : Tag)
+  deriving DecidableEq, Repr
+
 /-- An intensional type: a carrier tagged with an identity beyond its
 extension ([cooper-2023] §1.3). -/
 structure IType where
   /-- The underlying Lean type (extension carrier) -/
   carrier : Type
   /-- Intensional identity tag -/
-  name : String
+  name : Tag
 
 /-- Extensional equivalence: equivalent carriers. -/
 def IType.extEquiv (T₁ T₂ : IType) : Prop := Nonempty (T₁.carrier ≃ T₂.carrier)
@@ -57,19 +74,19 @@ def IType.intEq (T₁ T₂ : IType) : Prop := T₁ = T₂
 /-- Meet: pair the carriers, compose the names — intensional identity is
 preserved through meet. -/
 def IType.meet (T₁ T₂ : IType) : IType :=
-  ⟨T₁.carrier × T₂.carrier, T₁.name ++ " ∧ " ++ T₂.name⟩
+  ⟨T₁.carrier × T₂.carrier, .meet T₁.name T₂.name⟩
 
 /-! ### TTR model of the Hob–Nob puzzle -/
 
 /-- The shared witch type: empty carrier (no witch exists), individuated
 intensionally by its name. -/
-def witchType : IType := ⟨Empty, "witch"⟩
+def witchType : IType := ⟨Empty, .witch⟩
 
 /-- "blighted Bob's mare" as a predicate type. -/
-def blightBobsMare : IType := ⟨Unit, "blighted_bobs_mare"⟩
+def blightBobsMare : IType := ⟨Unit, .blightBobsMare⟩
 
 /-- "killed Cob's sow" as a predicate type. -/
-def killCobsSow : IType := ⟨Unit, "killed_cobs_sow"⟩
+def killCobsSow : IType := ⟨Unit, .killCobsSow⟩
 
 /-- Hob's belief content: a witch who blighted Bob's mare. -/
 def hobContent : IType := witchType.meet blightBobsMare
@@ -116,15 +133,5 @@ theorem intentional_identity :
     IsEmpty witchType.carrier :=
   ⟨sharesComponent_hobContent, sharesComponent_nobContent,
    hobContent_ne_nobContent, isFalse_witchType⟩
-
-/-- The model validates `Examples.hobNob`'s key judgment: the discourse is
-acceptable although no witch need exist, and the model supplies shared
-cross-attitude content built on an empty type. -/
-theorem validates_hobNob :
-    Examples.hobNob.judgment = .acceptable ∧
-    SharesComponent witchType hobContent ∧
-    SharesComponent witchType nobContent ∧
-    IsEmpty witchType.carrier :=
-  ⟨rfl, sharesComponent_hobContent, sharesComponent_nobContent, isFalse_witchType⟩
 
 end ChatzikyriakidisEtAl2025

--- a/Linglib/Studies/ChatzikyriakidisLuo2017.lean
+++ b/Linglib/Studies/ChatzikyriakidisLuo2017.lean
@@ -33,6 +33,27 @@ chapter's grade axioms are `LinearOrder` plus `DenselyOrdered`).
 - `man_and_not_man` … `not_human_not_man`: the chapter's §4 Coq examples
 - `no_aspect_map`, `copredication`: the §2.2 copredication argument
 - `Idiot`, `small_idiot_contradictory`: the §5 gradable-noun treatment
+
+## Main definitions
+
+* `CN`, `Sub` — a common noun as a type, and a coercion between two of them
+* `p`, `NegOperator`, `NegOperator.bigP` — the predicational forms of judgemental interpretations
+* `Idiot` — a gradable noun as a Σ-type indexed by degree
+
+## Main results
+
+* `man_and_not_man`, `not_not_man`, `not_human_not_man`, `some_man_walks` — the chapter's Coq
+  experiments, replayed against the same law set
+* `standardNeg` — a model of the negation laws, which the chapter axiomatizes without exhibiting
+* `no_aspect_map`, `copredication` — copredication needs common nouns as types
+* `small_idiot_contradictory` — *small idiot* asks for a degree both above and below the standard
+
+## References
+
+* [chatzikyriakidis-luo-2017]
+* [montague-1973]
+* [ranta-1994]
+* [asher-2011]
 -/
 
 namespace ChatzikyriakidisLuo2017

--- a/Linglib/Studies/ChatzikyriakidisLuo2020.lean
+++ b/Linglib/Studies/ChatzikyriakidisLuo2020.lean
@@ -1,6 +1,5 @@
 /-!
-# Chatzikyriakidis & Luo (2020): MTT semantics via coercive subtyping
-[chatzikyriakidis-luo-2020]
+# Chatzikyriakidis and Luo 2020: MTT semantics via coercive subtyping
 
 Modern Type Theory (MTT) analysis where common nouns denote *types*,
 not predicates, and subtyping is *coercive* — `A ≤_c B` whenever
@@ -32,11 +31,14 @@ Props below.
   from `A` to `B` agree (paper coherence requirement, not enforced
   by Lean — proved per-instance).
 
+## Main results
+
+* `read_johnMan_wpHeavy_expanded` — the coerced reading is the reading of the underlying entities
+* the `CoherentCoercion` instances — the paper's coherence requirement, discharged per instance
+
 ## References
 
-* [chatzikyriakidis-luo-2020] §2.4 (coercive subtyping),
-  §3.2.1 (CNs as types), §3.2.2 (subtyping in MTT-semantics,
-  esp. eq. 3.30-3.33 and projective subtyping at eq. 3.33).
+* [chatzikyriakidis-luo-2020]
 -/
 
 namespace ChatzikyriakidisLuo2020


### PR DESCRIPTION
`IType` in the 2025 file carried its intensional identity as a `String`, and the distinctness proof decided string inequality — `String` in proof-relevant code, against the project's conventions. A four-constructor `Tag` inductive with a `meet` case does the same work and decides structurally.

- `validates_hobNob` was `intentional_identity` minus a conjunct, plus a `rfl` read-back of the JSON row's judgment; the row is named in the docstring as the datum instead, and its import goes with the theorem.
- The 2017 and 2020 docstrings gain `## Main definitions` / `## Main results` / a `## References` list; 2020 loses the bare `[key]` under its title, and its reference entry stops carrying the section and equation numbers as a citation body.

Nothing else needed changing: all three files are substantive (predicational forms replayed against the chapter's law set, copredication, coercive subtyping through Lean's `Coe`) with no stipulated tables or `rfl` bridges.