### PR TITLE
refactor(Logic/ComparativeProbability): FunLike measures, implicit binders

### DIFF
--- a/Linglib/Logic/BeliefRevision.lean
+++ b/Linglib/Logic/BeliefRevision.lean
@@ -177,9 +177,9 @@ open ComparativeProbability in
 /-- In finite W, if every singleton in A has measure 0, then μ(A) = 0. -/
 private theorem mu_eq_zero_of_singletons {W : Type*} [Fintype W] [DecidableEq W]
     (m : FinAddMeasure ℚ W) (A : Set W)
-    (h : ∀ w ∈ A, m.mu {w} = 0) : m.mu A = 0 := by
+    (h : ∀ w ∈ A, m {w} = 0) : m A = 0 := by
   classical
-  suffices key : ∀ (s : Finset W), (∀ w ∈ s, m.mu {w} = 0) → m.mu ↑s = 0 by
+  suffices key : ∀ (s : Finset W), (∀ w ∈ s, m {w} = 0) → m ↑s = 0 by
     have hA : A = ↑(Finset.univ.filter (· ∈ A)) := by ext x; simp
     rw [hA]
     exact key _ (fun w hw => by simp [Finset.mem_filter] at hw; exact h w hw)
@@ -191,7 +191,7 @@ private theorem mu_eq_zero_of_singletons {W : Type*} [Fintype W] [DecidableEq W]
     rw [Finset.coe_cons, Set.insert_eq a ↑t]
     have hdisj : Disjoint ({a} : Set W) ↑t :=
       Set.disjoint_singleton_left.mpr fun hxt => ha (Finset.mem_coe.mp hxt)
-    rw [m.additive {a} ↑t hdisj,
+    rw [m.additive hdisj,
         hall a (Finset.mem_cons_self a t),
         ih (fun w hw => hall w (Finset.mem_cons.mpr (Or.inr hw))),
         zero_add]
@@ -225,7 +225,7 @@ open ComparativeProbability in
 private theorem mu_diff_eq_zero_of_condMu {W : Type*}
     (m : CondMeasure W) (ψ φ : Set W)
     (hreg : m.condMu φ φ ≠ 0) (hcond : m.condMu ψ φ = m.condMu Set.univ φ) :
-    m.mu (φ \ ψ) = 0 := by
+    m (φ \ ψ) = 0 := by
   have hnorm := m.cond_norm φ hreg
   have htop := (condMu_self_eq_univ m φ hreg).symm
   rw [hnorm] at htop
@@ -246,9 +246,9 @@ open ComparativeProbability in
     Worlds with positive measure satisfy all probability-1 beliefs. -/
 private theorem mem_of_mu_singleton_pos {W : Type*}
     (m : FinAddMeasure ℚ W) (w : W) (A : Set W)
-    (hw : 0 < m.mu {w}) (hA : m.mu A = 1) : w ∈ A := by
+    (hw : 0 < m {w}) (hA : m A = 1) : w ∈ A := by
   by_contra hw_not
-  have hAc : m.mu Aᶜ = 0 := by have := m.mu_compl A; linarith
+  have hAc : m Aᶜ = 0 := by have := m.mu_compl A; linarith
   have hsub : ({w} : Set W) ⊆ Aᶜ := fun v hv => by
     rw [Set.mem_singleton_iff.mp hv]; exact hw_not
   linarith [m.mu_mono hsub]
@@ -263,19 +263,23 @@ open ComparativeProbability in
     is equivalent to: every singleton has positive measure.
 
     [halpern-2003]'s regularity condition. -/
-structure ComparativeProbability.RegularCondMeasure (W : Type*) extends ComparativeProbability.CondMeasure W where
+structure RegularCondMeasure (W : Type*) extends ComparativeProbability.CondMeasure W where
   regular : ∀ (φ : Set W), (∃ w, w ∈ φ) → condMu φ φ ≠ 0
-  muPositive : ∀ (φ : Set W), (∃ w, w ∈ φ) → 0 < mu φ
+  muPositive : ∀ (φ : Set W), (∃ w, w ∈ φ) → 0 < toFun φ
+
+/-- A regular conditional measure applies as its underlying measure. -/
+instance {W : Type*} : CoeFun (RegularCondMeasure W) (fun _ => Set W → ℚ) :=
+  ⟨fun m => ⇑m.toCondMeasure⟩
 
 open ComparativeProbability in
 /-- The core inclusion argument, factored as a helper for reuse by K*5.
     If P(ψ|φ) = P(⊤|φ) and w satisfies all probability-1 beliefs and φ,
     then w satisfies ψ. -/
 private theorem revised_entails {W : Type*}
-    (m : ComparativeProbability.RegularCondMeasure W) (ψ φ : Set W)
+    (m : RegularCondMeasure W) (ψ φ : Set W)
     (hrev : m.condMu (fun w => ψ w : Set W) (fun w => φ w : Set W) =
             m.condMu Set.univ (fun w => φ w : Set W))
-    (w : W) (hbeliefs : ∀ (χ : Set W), m.mu (fun w => χ w : Set W) = 1 → χ w)
+    (w : W) (hbeliefs : ∀ (χ : Set W), m (fun w => χ w : Set W) = 1 → χ w)
     (hφ : φ w) : ψ w := by
   by_contra hnψ
   have hsat : ∃ v, φ v := ⟨w, hφ⟩
@@ -284,10 +288,10 @@ private theorem revised_entails {W : Type*}
   -- w ∈ φ \ ψ, so {w} ⊆ φ \ ψ, so μ({w}) ≤ μ(φ \ ψ) = 0
   have hsub : ({w} : Set W) ⊆ (fun w => φ w : Set W) \ (fun w => ψ w : Set W) :=
     fun v hv => by rw [Set.mem_singleton_iff.mp hv]; exact ⟨hφ, hnψ⟩
-  have hw_zero : m.mu ({w} : Set W) = 0 :=
+  have hw_zero : m ({w} : Set W) = 0 :=
     le_antisymm (by linarith [m.toFinAddMeasure.mu_mono hsub]) (m.nonneg _)
   -- μ({w}ᶜ) = 1, so by hbeliefs, w ∈ {w}ᶜ — contradiction
-  have hcompl : m.mu ({w} : Set W)ᶜ = 1 := by
+  have hcompl : m ({w} : Set W)ᶜ = 1 := by
     have := m.toFinAddMeasure.mu_compl ({w} : Set W); linarith
   exact absurd (hbeliefs (fun v => v ≠ w) hcompl) (not_not.mpr rfl)
 
@@ -309,10 +313,10 @@ open ComparativeProbability in
       measure 0, so μ(φ \ ψ) = 0)
     - K*5 (consistency): finite W has a positive-measure φ-world satisfying
       all beliefs, which satisfies all of K*φ by K*3 -/
-noncomputable def ComparativeProbability.RegularCondMeasure.toAGM {W : Type*}
+noncomputable def RegularCondMeasure.toAGM {W : Type*}
     [Fintype W] [DecidableEq W]
-    (m : ComparativeProbability.RegularCondMeasure W) : AGMRevision W where
-  beliefs := { ψ | m.mu (fun w => ψ w : Set W) = 1 }
+    (m : RegularCondMeasure W) : AGMRevision W where
+  beliefs := { ψ | m (fun w => ψ w : Set W) = 1 }
   revise := fun φ =>
     { ψ | m.condMu (fun w => ψ w : Set W) (fun w => φ w : Set W) =
            m.condMu Set.univ (fun w => φ w : Set W) }
@@ -325,11 +329,11 @@ noncomputable def ComparativeProbability.RegularCondMeasure.toAGM {W : Type*}
   vacuity := fun φ ψ hnot_neg hent => by
     show m.condMu (fun w => ψ w) (fun w => φ w) = m.condMu Set.univ (fun w => φ w)
     -- ¬φ ∉ beliefs ↔ μ(φᶜ) ≠ 1 ↔ μ(φ) > 0
-    have hmu_phi_pos : 0 < m.mu (fun w => φ w : Set W) := by
+    have hmu_phi_pos : 0 < m (fun w => φ w : Set W) := by
       have hcompl := m.toFinAddMeasure.mu_compl (fun w => φ w : Set W)
       by_contra h; push Not at h
       have h0 := le_antisymm h (m.nonneg _)
-      have hone : m.mu (fun w => φ w : Set W)ᶜ = 1 := by linarith
+      have hone : m (fun w => φ w : Set W)ᶜ = 1 := by linarith
       exact hnot_neg hone
     have hsat : ∃ w, φ w := by
       by_contra hall; push Not at hall
@@ -349,15 +353,16 @@ noncomputable def ComparativeProbability.RegularCondMeasure.toAGM {W : Type*}
     simp only [Set.inter_univ] at hchain
     rw [m.toCondMeasure.cond_univ, m.toCondMeasure.cond_univ] at hchain
     -- Show μ(ψᶜ ∩ φ) = 0: every w ∈ ψᶜ ∩ φ has μ({w}) = 0
-    have hdiff_zero : m.mu ((fun w => ψ w : Set W)ᶜ ∩ (fun w => φ w : Set W)) = 0 := by
+    have hdiff_zero : m ((fun w => ψ w : Set W)ᶜ ∩ (fun w => φ w : Set W)) = 0 := by
       apply mu_eq_zero_of_singletons m.toFinAddMeasure
       intro w ⟨hnψ, hφ⟩
       by_contra h_pos; push Not at h_pos
-      have h_pos' : 0 < m.mu ({w} : Set W) :=
+      have h_pos' : 0 < m ({w} : Set W) :=
         lt_of_le_of_ne (m.nonneg _) (Ne.symm h_pos)
-      have hbeliefs : ∀ (χ : Set W), m.mu (fun w => χ w : Set W) = 1 → χ w :=
+      have hbeliefs : ∀ (χ : Set W), m (fun w => χ w : Set W) = 1 → χ w :=
         fun χ hχ => mem_of_mu_singleton_pos m.toFinAddMeasure w _ h_pos' hχ
       exact hnψ (hent w hbeliefs hφ)
+    simp only [FinAddMeasure.toFun_eq_coe] at hchain
     rw [hdiff_zero] at hchain
     rcases mul_eq_zero.mp hchain.symm with h | h
     · exact h
@@ -365,15 +370,16 @@ noncomputable def ComparativeProbability.RegularCondMeasure.toAGM {W : Type*}
   consistency := fun φ hsat => by
     -- Find w ∈ φ with μ({w}) > 0, then w satisfies all of K*φ.
     have hmu_pos := m.muPositive _ hsat
+    simp only [FinAddMeasure.toFun_eq_coe] at hmu_pos
     -- If all singletons in φ had measure 0, μ(φ) = 0, contradiction.
     by_contra hall; push Not at hall
     -- hall : ∀ w, ∃ ψ ∈ revise φ, ¬ψ w
-    have hzero : ∀ w, φ w → m.mu ({w} : Set W) = 0 := by
+    have hzero : ∀ w, φ w → m ({w} : Set W) = 0 := by
       intro w hw
       by_contra h_pos; push Not at h_pos
-      have h_pos' : 0 < m.mu ({w} : Set W) :=
+      have h_pos' : 0 < m ({w} : Set W) :=
         lt_of_le_of_ne (m.nonneg _) (Ne.symm h_pos)
-      have hbeliefs : ∀ (χ : Set W), m.mu (fun w => χ w : Set W) = 1 → χ w :=
+      have hbeliefs : ∀ (χ : Set W), m (fun w => χ w : Set W) = 1 → χ w :=
         fun χ hχ => mem_of_mu_singleton_pos m.toFinAddMeasure w _ h_pos' hχ
       obtain ⟨ψ, hψ, hnψ⟩ := hall w
       exact hnψ (revised_entails m ψ φ hψ w hbeliefs hw)

--- a/Linglib/Logic/ComparativeProbability/Cancellation.lean
+++ b/Linglib/Logic/ComparativeProbability/Cancellation.lean
@@ -115,9 +115,9 @@ private lemma finset_sum_as_univ {n : ℕ} (S : Finset (Fin n)) (f : Fin n → �
 
 private lemma single_comp_sum {n : ℕ} (m : FinAddMeasure ℚ (Fin n))
     (L R : Finset (Fin n)) (hd : Disjoint L R) :
-    m.mu ↑L - m.mu ↑R =
+    m ↑L - m ↑R =
     Finset.univ.sum (fun i : Fin n =>
-      m.mu {i} * ((comparisonVec n L R i : ℤ) : ℚ)) := by
+      m {i} * ((comparisonVec n L R i : ℤ) : ℚ)) := by
   rw [← m.sum_mu_singleton L, ← m.sum_mu_singleton R, finset_sum_as_univ L, finset_sum_as_univ R,
       ← Finset.sum_sub_distrib]
   refine Finset.sum_congr rfl fun i _ => ?_
@@ -126,8 +126,8 @@ private lemma single_comp_sum {n : ℕ} (m : FinAddMeasure ℚ (Fin n))
 
 private lemma portfolio_interchange {n : ℕ} (m : FinAddMeasure ℚ (Fin n))
     (P : Portfolio n) :
-    (P.map (fun wc => wc.weight * (m.mu ↑wc.left - m.mu ↑wc.right))).sum =
-    Finset.univ.sum (fun i => m.mu {i} * Portfolio.weightedSum P i) := by
+    (P.map (fun wc => wc.weight * (m ↑wc.left - m ↑wc.right))).sum =
+    Finset.univ.sum (fun i => m {i} * Portfolio.weightedSum P i) := by
   induction P with
   | nil =>
     simp only [List.map_nil, List.sum_nil]
@@ -157,7 +157,7 @@ theorem representable_implies_cancellation {n : ℕ}
     Cancellation n ge := by
   intro P hValid hNeutral ⟨wc, hwc_mem, hwc_strict⟩
   -- Define the portfolio valuation function
-  let f : WComparison n → ℚ := fun wc => wc.weight * (m.mu ↑wc.left - m.mu ↑wc.right)
+  let f : WComparison n → ℚ := fun wc => wc.weight * (m ↑wc.left - m ↑wc.right)
   -- Each term is nonneg
   have hnn : ∀ x ∈ P.map f, (0 : ℚ) ≤ x := by
     intro x hx
@@ -165,7 +165,7 @@ theorem representable_implies_cancellation {n : ℕ}
     exact mul_nonneg wc'.weight_pos.le
       (sub_nonneg.mpr ((hm _ _).mp (hValid wc' hwc'_mem)))
   -- The strict term is strictly positive
-  have hlt : m.mu ↑wc.left > m.mu ↑wc.right := by
+  have hlt : m ↑wc.left > m ↑wc.right := by
     by_contra h; push Not at h
     exact hwc_strict ((hm _ _).mpr h)
   have hp : ∃ x ∈ P.map f, (0 : ℚ) < x :=
@@ -175,7 +175,7 @@ theorem representable_implies_cancellation {n : ℕ}
   have hpos := list_sum_pos hnn hp
   -- But by interchange, portfolio value = Σ_i mu_i * weightedSum_i = 0
   rw [portfolio_interchange m P] at hpos
-  have hzero : Finset.univ.sum (fun i => m.mu {i} * P.weightedSum i) = 0 :=
+  have hzero : Finset.univ.sum (fun i => m {i} * P.weightedSum i) = 0 :=
     Finset.sum_eq_zero (fun i _ => by rw [hNeutral i, mul_zero])
   linarith
 
@@ -272,7 +272,7 @@ private lemma ge_empty_of_all_null {n : ℕ} (sys : QualitativeProbability (Fin 
       · rintro ⟨hx | hx, hnx⟩ <;> [exact hx; exact absurd hx hnx]
       · rintro rfl; exact ⟨Or.inl rfl, fun h => haS' (Finset.mem_coe.mp h)⟩
     rw [Finset.coe_insert, Set.insert_eq]
-    exact sys.trans ∅ ↑S' ({a} ∪ ↑S') ih
+    exact sys.trans (B := ↑S') ih
       (by rw [sys.additive ↑S' ({a} ∪ ↑S'), h1, h2]; exact hall a)
 
 /-- Not all singletons can be null: ∃ i, ¬sys.ge ∅ {i}. If all were null,
@@ -408,7 +408,7 @@ private theorem strictPairs_strict {n : ℕ} (sys : QualitativeProbability (Fin 
 private theorem strictPairs_length_pos {n : ℕ} (sys : QualitativeProbability (Fin n)) :
     0 < (strictPairsOf sys).length :=
   List.length_pos_of_mem (strictPairs_mem sys Finset.univ ∅ (Finset.disjoint_empty_right _)
-    (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.mono _ _ (Set.empty_subset _))
+    (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.mono (Set.empty_subset _))
     (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.nonTrivial))
 
 /-- The core LP step: cancellation implies the feasibility polytope is nonempty.
@@ -656,7 +656,7 @@ private theorem cancellation_nonempty {n : ℕ} (sys : QualitativeProbability (F
         split_ifs at hj with hpos
         cases hj
         simp only [Finset.coe_singleton, Finset.coe_empty]
-        exact sys.mono ∅ {j} (Set.empty_subset _)
+        exact sys.mono (Set.empty_subset _)
     have hQ_neutral : Q.isNeutral := by
       intro j
       show Portfolio.weightedSum (Q_ord ++ Q_strict ++ Q_sing) j = 0

--- a/Linglib/Logic/ComparativeProbability/CancellationFin4.lean
+++ b/Linglib/Logic/ComparativeProbability/CancellationFin4.lean
@@ -112,26 +112,26 @@ private lemma null_from_pair (sys : QualitativeProbability (Fin 4))
       sub_zero] at this
     split_ifs at this <;> omega
   -- ge C A, ge C B
-  have hCA : sys.ge ↑C ↑A := sys.trans _ _ _ hCD (sys.mono ↑A ↑D (Finset.coe_subset.mpr hAD))
-  have hCB_ge : sys.ge ↑C ↑B := sys.trans _ _ _ hCA hAB
+  have hCA : sys.ge ↑C ↑A := sys.trans hCD (sys.mono (Finset.coe_subset.mpr hAD))
+  have hCB_ge : sys.ge ↑C ↑B := sys.trans hCA hAB
   -- Axiom A: ge ∅ (B \ C)
   have hBC : sys.ge (∅ : Set (Fin 4)) ↑(B \ C) := by
     have hax := (sys.additive ↑C ↑B).mp hCB_ge
     rwa [← Finset.coe_sdiff, ← Finset.coe_sdiff,
       Finset.sdiff_eq_empty_iff_subset.mpr hCB, Finset.coe_empty] at hax
   -- symmetric: ge A D, ge A C, ge A D? -> ge ∅ (D \ A)
-  have hAC : sys.ge ↑A ↑C := sys.trans _ _ _ hAB (sys.mono ↑C ↑B (Finset.coe_subset.mpr hCB))
+  have hAC : sys.ge ↑A ↑C := sys.trans hAB (sys.mono (Finset.coe_subset.mpr hCB))
   have hDA : sys.ge (∅ : Set (Fin 4)) ↑(D \ A) := by
-    have hax := (sys.additive ↑A ↑D).mp (sys.trans _ _ _ hAC hCD)
+    have hax := (sys.additive ↑A ↑D).mp (sys.trans hAC hCD)
     rwa [← Finset.coe_sdiff, ← Finset.coe_sdiff,
       Finset.sdiff_eq_empty_iff_subset.mpr hAD, Finset.coe_empty] at hax
   -- strict coordinate i₀ ∈ (B \ C) ∪ (D \ A)
   have hmem : i₀ ∈ B \ C ∨ i₀ ∈ D \ A := by
     simp only [cmpVec, Finset.mem_sdiff] at hlt ⊢; split_ifs at hlt <;> simp_all
   rcases hmem with hm | hm
-  · exact ⟨i₀, sys.trans _ _ _ hBC (sys.mono {i₀} ↑(B \ C)
+  · exact ⟨i₀, sys.trans hBC (sys.mono
       (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
-  · exact ⟨i₀, sys.trans _ _ _ hDA (sys.mono {i₀} ↑(D \ A)
+  · exact ⟨i₀, sys.trans hDA (sys.mono
       (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
 
 /-! ### Bridging comparisons to ℚ sign vectors -/
@@ -621,15 +621,16 @@ private def restrict3 (A : Set (Fin 4)) : Set (Fin 3) := {i | Fin.castSucc i ∈
 
 /-- Lexicographic extension: the new world `Fin.last 3` dominates; ties break
     by the restriction. -/
-def QualitativeProbability.extendLex (sys : QualitativeProbability (Fin 3)) : QualitativeProbability (Fin 4) where
+def QualitativeProbability.extendLex (sys : QualitativeProbability (Fin 3)) :
+    QualitativeProbability (Fin 4) where
   ge A B := (Fin.last 3 ∈ A ∧ Fin.last 3 ∉ B) ∨
     ((Fin.last 3 ∈ A ↔ Fin.last 3 ∈ B) ∧ sys.ge (restrict3 A) (restrict3 B))
-  mono A B hAB := by
+  mono' A B hAB := by
     by_cases hb : Fin.last 3 ∈ B
     · by_cases ha : Fin.last 3 ∈ A
-      · exact Or.inr ⟨iff_of_true hb ha, sys.mono _ _ fun i hi => hAB hi⟩
+      · exact Or.inr ⟨iff_of_true hb ha, sys.mono fun i hi => hAB hi⟩
       · exact Or.inl ⟨hb, ha⟩
-    · exact Or.inr ⟨iff_of_false hb fun h => hb (hAB h), sys.mono _ _ fun i hi => hAB hi⟩
+    · exact Or.inr ⟨iff_of_false hb fun h => hb (hAB h), sys.mono fun i hi => hAB hi⟩
   nonTrivial := by
     rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
     · exact h3
@@ -644,12 +645,12 @@ def QualitativeProbability.extendLex (sys : QualitativeProbability (Fin 3)) : Qu
     · rcases sys.total (restrict3 A) (restrict3 B) with h | h
       · exact Or.inl (Or.inr ⟨iff_of_false ha hb, h⟩)
       · exact Or.inr (Or.inr ⟨iff_of_false hb ha, h⟩)
-  trans A B C := by
+  trans' A B C := by
     rintro (⟨ha, hnb⟩ | ⟨hab, hge1⟩) (⟨hb, hnc⟩ | ⟨hbc, hge2⟩)
     · exact absurd hb hnb
     · exact Or.inl ⟨ha, fun hc => hnb (hbc.mpr hc)⟩
     · exact Or.inl ⟨hab.mpr hb, hnc⟩
-    · exact Or.inr ⟨hab.trans hbc, sys.trans _ _ _ hge1 hge2⟩
+    · exact Or.inr ⟨hab.trans hbc, sys.trans hge1 hge2⟩
   additive A B := by
     by_cases ha : Fin.last 3 ∈ A <;> by_cases hb : Fin.last 3 ∈ B
     · -- tie on both sides; restriction additivity carries it

--- a/Linglib/Logic/ComparativeProbability/Completeness.lean
+++ b/Linglib/Logic/ComparativeProbability/Completeness.lean
@@ -16,6 +16,8 @@ The top-level results of [holliday-icard-2013] / [kraft-pratt-seidenberg-1959]:
   ([van-der-hoek-1996]; [halpern-2003] Thm. 7.5.1a).
 * `ComparativeProbability.axiomA_iff_fa` — Axiom A is equivalent to disjoint-union
   invariance (finite additivity).
+
+`[UPSTREAM]` candidate (see the note in `Systems.lean`).
 -/
 
 namespace ComparativeProbability
@@ -63,7 +65,7 @@ private theorem belowCount_univ {W : Type*} [Fintype W]
     (sys : QualitativeProbability W) :
     belowCount sys Set.univ = Fintype.card (Finset W) := by
   unfold belowCount
-  rw [Finset.filter_true_of_mem fun S _ => sys.mono _ _ (Set.subset_univ _)]
+  rw [Finset.filter_true_of_mem fun S _ => sys.mono (Set.subset_univ _)]
   exact Finset.card_univ
 
 private theorem belowCount_mono {W : Type*} [Fintype W]
@@ -71,14 +73,14 @@ private theorem belowCount_mono {W : Type*} [Fintype W]
     (h : sys.ge A B) : belowCount sys A ≥ belowCount sys B := by
   refine Finset.card_le_card fun S hS => ?_
   rw [Finset.mem_filter] at hS ⊢
-  exact ⟨hS.1, sys.trans _ _ _ h hS.2⟩
+  exact ⟨hS.1, sys.trans h hS.2⟩
 
 private theorem belowCount_strict {W : Type*} [Fintype W]
     (sys : QualitativeProbability W) (A B : Set W)
     (h : ¬sys.ge A B) : belowCount sys A < belowCount sys B := by
   refine Finset.card_lt_card ⟨fun S hS => ?_, fun hsub => ?_⟩
   · rw [Finset.mem_filter] at hS ⊢
-    exact ⟨hS.1, sys.trans _ _ _ ((sys.total A B).resolve_left h) hS.2⟩
+    exact ⟨hS.1, sys.trans ((sys.total A B).resolve_left h) hS.2⟩
   · have : B.toFinset ∈ Finset.univ.filter (fun S : Finset W => sys.ge A ↑S) :=
       hsub (Finset.mem_filter.mpr ⟨Finset.mem_univ _, by rw [Set.coe_toFinset]; exact sys.refl B⟩)
     rw [Finset.mem_filter, Set.coe_toFinset] at this
@@ -114,7 +116,7 @@ theorem exists_qualAddMeasure_repr {W : Type*} [Fintype W]
       sys.ge A B := fun A B => by
     rw [ge_div_iff hd, ge_iff_le, sub_le_sub_iff_right, Nat.cast_le]; exact belowCount_iff sys A B
   have hAle : ∀ A : Set W, E ≤ (belowCount sys A : ℚ) := fun A => by
-    rw [hE, Nat.cast_le]; exact belowCount_mono sys A ∅ (sys.mono ∅ A (Set.empty_subset A))
+    rw [hE, Nat.cast_le]; exact belowCount_mono sys A ∅ (sys.mono (Set.empty_subset A))
   refine ⟨⟨fun A => ((belowCount sys A : ℚ) - E) / (N - E),
     fun A => div_nonneg (sub_nonneg.mpr (hAle A)) hd.le,
     by simp only [← hE, sub_self, zero_div], ?_, ?_⟩, fun A B => (key A B).symm⟩

--- a/Linglib/Logic/ComparativeProbability/Conditional.lean
+++ b/Linglib/Logic/ComparativeProbability/Conditional.lean
@@ -51,11 +51,17 @@ structure CondMeasure (W : Type*) extends FinAddMeasure ℚ W where
   /-- Conditioning sees only the part inside the evidence: P(A|B) = P(A ∩ B|B) -/
   cond_inter : ∀ A B, condMu A B = condMu (A ∩ B) B
   /-- Unconditional connection: P(A | Ω) = μ(A) -/
-  cond_univ : ∀ A, condMu A Set.univ = mu A
+  cond_univ : ∀ A, condMu A Set.univ = toFun A
 
 namespace CondMeasure
 
 variable {W : Type*}
+
+/-- A conditional measure applies as its underlying unconditional measure
+    (`CoeFun`, not `FunLike`: the conditional component is not determined by
+    the unconditional values). -/
+instance : CoeFun (CondMeasure W) (fun _ => Set W → ℚ) :=
+  ⟨fun m => ⇑m.toFinAddMeasure⟩
 
 /-- Conditional comparison: A ≿_B C iff P(A|B) ≥ P(C|B). -/
 def condGe (m : CondMeasure W) (A C B : Set W) : Prop :=
@@ -97,22 +103,22 @@ end CondMeasure
 noncomputable def FinAddMeasure.toCondMeasure {W : Type*}
     (m : FinAddMeasure ℚ W) : CondMeasure W where
   toFinAddMeasure := m
-  condMu := fun A B => m.mu (A ∩ B) / m.mu B
+  condMu := fun A B => m (A ∩ B) / m B
   cond_nonneg := fun A B => div_nonneg (m.nonneg _) (m.nonneg _)
   cond_norm := fun B hne => by
     simp only [Set.inter_self] at hne ⊢
     exact div_self fun h => hne (by rw [h, div_zero])
   cond_additive := fun A₁ A₂ B hdisj => by
-    rw [Set.union_inter_distrib_right, m.additive (A₁ ∩ B) (A₂ ∩ B)
-      (hdisj.mono Set.inter_subset_left Set.inter_subset_left), add_div]
+    rw [Set.union_inter_distrib_right,
+      m.additive (hdisj.mono Set.inter_subset_left Set.inter_subset_left), add_div]
   cond_chain := fun A B C => by
     -- Ratio algebra a/c = (a/b)·(b/c): when μ(B∩C)=0 both sides vanish, else cancel.
     rw [Set.inter_assoc]
-    by_cases hBC : m.mu (B ∩ C) = 0
-    · have hABC : m.mu (A ∩ (B ∩ C)) = 0 :=
+    by_cases hBC : m (B ∩ C) = 0
+    · have hABC : m (A ∩ (B ∩ C)) = 0 :=
         le_antisymm (hBC ▸ m.mu_mono Set.inter_subset_right) (m.nonneg _)
       simp [hABC, hBC]
-    · rw [div_mul_div_comm, mul_comm (m.mu (A ∩ (B ∩ C))), mul_div_mul_left _ _ hBC]
+    · rw [div_mul_div_comm, mul_comm (m (A ∩ (B ∩ C))), mul_div_mul_left _ _ hBC]
   cond_inter := fun A B => by rw [Set.inter_assoc, Set.inter_self]
   cond_univ := fun A => by simp [Set.inter_univ, m.total, div_one]
 
@@ -170,10 +176,10 @@ theorem jeffreyUpdate_total {W : Type*} (m : CondMeasure W)
     Jeffrey update is a finitely additive probability measure. -/
 def jeffreyMeasure {W : Type*} (m : CondMeasure W) (ev : EvidencePartition W)
     (hnorm : ∀ E ∈ ev.cells, m.condMu E E ≠ 0) : FinAddMeasure ℚ W where
-  mu := jeffreyUpdate m ev
-  nonneg := jeffreyUpdate_nonneg m ev
-  additive := jeffreyUpdate_additive m ev
-  total := jeffreyUpdate_total m ev hnorm
+  toFun := jeffreyUpdate m ev
+  nonneg' := jeffreyUpdate_nonneg m ev
+  additive' := jeffreyUpdate_additive m ev
+  total' := jeffreyUpdate_total m ev hnorm
 
 /-- Bayesian conditioning is Jeffrey conditioning with the partition `{B, Bᶜ}`
     and weights `1, 0`. -/

--- a/Linglib/Logic/ComparativeProbability/Entailments.lean
+++ b/Linglib/Logic/ComparativeProbability/Entailments.lean
@@ -54,20 +54,20 @@ private noncomputable def uf3 : FinAddMeasure ℚ (Fin 3) :=
   .ofFintype (fun _ => 1/3) (fun _ => by norm_num)
     (by simp [Finset.sum_const, Fintype.card_fin, nsmul_eq_mul])
 
-private theorem uf3_mu_0 : uf3.mu {(0 : Fin 3)} = 1/3 := by simp [uf3]
+private theorem uf3_mu_0 : uf3 {(0 : Fin 3)} = 1/3 := by simp [uf3]
 
-private theorem uf3_mu_1 : uf3.mu {(1 : Fin 3)} = 1/3 := by simp [uf3]
+private theorem uf3_mu_1 : uf3 {(1 : Fin 3)} = 1/3 := by simp [uf3]
 
-private theorem uf3_mu_2 : uf3.mu {(2 : Fin 3)} = 1/3 := by simp [uf3]
+private theorem uf3_mu_2 : uf3 {(2 : Fin 3)} = 1/3 := by simp [uf3]
 
-private theorem uf3_mu_union_12 : uf3.mu ({(1 : Fin 3)} ∪ {2}) = 2/3 := by
-  rw [uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega)), uf3_mu_1, uf3_mu_2]; norm_num
+private theorem uf3_mu_union_12 : uf3 ({(1 : Fin 3)} ∪ {2}) = 2/3 := by
+  rw [uf3.additive (Set.disjoint_singleton.mpr (by omega)), uf3_mu_1, uf3_mu_2]; norm_num
 
-private theorem uf3_mu_pair_01 : uf3.mu ({0, 1} : Set (Fin 3)) = 2/3 := by
+private theorem uf3_mu_pair_01 : uf3 ({0, 1} : Set (Fin 3)) = 2/3 := by
   rw [show ({0, 1} : Set (Fin 3)) = {0} ∪ {1} from Set.insert_eq 0 {1},
-    uf3.additive _ _ (Set.disjoint_singleton.mpr (by omega)), uf3_mu_0, uf3_mu_1]; norm_num
+    uf3.additive (Set.disjoint_singleton.mpr (by omega)), uf3_mu_0, uf3_mu_1]; norm_num
 
-private theorem uf3_mu_compl' (A : Set (Fin 3)) : uf3.mu Aᶜ = 1 - uf3.mu A := by
+private theorem uf3_mu_compl' (A : Set (Fin 3)) : uf3 Aᶜ = 1 - uf3 A := by
   have := uf3.mu_compl A; linarith
 
 /-- I1 is invalid for measure semantics: with uniform measure on Fin 3,

--- a/Linglib/Logic/ComparativeProbability/Representability.lean
+++ b/Linglib/Logic/ComparativeProbability/Representability.lean
@@ -17,6 +17,9 @@ finitely additive probability measures (**Theorem 8a**,
 counterexample with null atoms gives a non-representable order at each
 cardinality (**Theorem 8b**).
 
+`[UPSTREAM]` candidate: KPS representability is measurement theory absent
+from mathlib (see the note in `Systems.lean`).
+
 ## Contents
 
 1. **`Representable`**: the representability predicate.
@@ -85,24 +88,24 @@ private noncomputable def kpsGe (A B : Set (Fin 5)) : Prop := kpsRankSet A ≥ k
 
 noncomputable def kpsSystem : QualitativeProbability (Fin 5) where
   ge := kpsGe
-  mono := λ {A B} hAB => kps_mono_finset _ _ (Set.toFinset_subset_toFinset.mpr hAB)
+  mono' := λ {A B} hAB => kps_mono_finset _ _ (Set.toFinset_subset_toFinset.mpr hAB)
   nonTrivial := by
     simp only [kpsGe, kpsRankSet, Set.toFinset_univ, Set.toFinset_empty]; decide
   total := λ A B => le_total (kpsRankSet B) (kpsRankSet A)
-  trans := λ {_ _ _} hab hbc => le_trans hbc hab
+  trans' := λ {_ _ _} hab hbc => le_trans hbc hab
   additive A B := by
     unfold kpsGe kpsRankSet
     rw [Set.toFinset_sdiff, Set.toFinset_sdiff]
     exact kps_additive_finset _ _
 
 private theorem mu_pair (m : FinAddMeasure ℚ (Fin 5)) (a b : Fin 5) (hab : a ≠ b) :
-    m.mu ({a, b} : Set (Fin 5)) = m.mu {a} + m.mu {b} := by
-  rw [Set.insert_eq a {b}, m.additive {a} {b} (Set.disjoint_singleton.mpr hab)]
+    m ({a, b} : Set (Fin 5)) = m {a} + m {b} := by
+  rw [Set.insert_eq a {b}, m.additive (Set.disjoint_singleton.mpr hab)]
 
 private theorem mu_triple (m : FinAddMeasure ℚ (Fin 5)) (a b c : Fin 5)
     (hab : a ≠ b) (hac : a ≠ c) (hbc : b ≠ c) :
-    m.mu ({a, b, c} : Set (Fin 5)) = m.mu {a} + m.mu {b} + m.mu {c} := by
-  rw [Set.insert_eq a ({b, c} : Set (Fin 5)), m.additive {a} {b, c}
+    m ({a, b, c} : Set (Fin 5)) = m {a} + m {b} + m {c} := by
+  rw [Set.insert_eq a ({b, c} : Set (Fin 5)), m.additive (A := {a}) (B := {b, c})
     (Set.disjoint_left.mpr fun x hx hxbc => by
       rw [Set.mem_singleton_iff] at hx
       simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hxbc
@@ -112,11 +115,11 @@ private theorem mu_triple (m : FinAddMeasure ℚ (Fin 5)) (a b c : Fin 5)
 
 theorem kps_not_representable : ¬Representable kpsSystem := by
   intro ⟨m, hm⟩
-  set P := m.mu ({(0 : Fin 5)} : Set (Fin 5))
-  set Q := m.mu ({(1 : Fin 5)} : Set (Fin 5))
-  set R := m.mu ({(2 : Fin 5)} : Set (Fin 5))
-  set S := m.mu ({(3 : Fin 5)} : Set (Fin 5))
-  set T := m.mu ({(4 : Fin 5)} : Set (Fin 5))
+  set P := m ({(0 : Fin 5)} : Set (Fin 5))
+  set Q := m ({(1 : Fin 5)} : Set (Fin 5))
+  set R := m ({(2 : Fin 5)} : Set (Fin 5))
+  set S := m ({(3 : Fin 5)} : Set (Fin 5))
+  set T := m ({(4 : Fin 5)} : Set (Fin 5))
   -- Ordering facts: three strict (rank <), one weak (rank ≥)
   have hord1 : ¬ kpsGe ({1, 3} : Set (Fin 5)) {0} := by
     unfold kpsGe kpsRankSet
@@ -131,13 +134,13 @@ theorem kps_not_representable : ¬Representable kpsSystem := by
     unfold kpsGe kpsRankSet
     simp only [Set.toFinset_insert, Set.toFinset_singleton]; decide
   -- Convert to measure inequalities via the representation isomorphism
-  have hmeas1 : m.mu ({1, 3} : Set _) < m.mu ({(0 : Fin 5)} : Set _) :=
+  have hmeas1 : m ({1, 3} : Set _) < m ({(0 : Fin 5)} : Set _) :=
     not_le.mp (λ h => hord1 ((hm _ _).mpr h))
-  have hmeas2 : m.mu ({0, 1} : Set _) < m.mu ({2, 3} : Set _) :=
+  have hmeas2 : m ({0, 1} : Set _) < m ({2, 3} : Set _) :=
     not_le.mp (λ h => hord2 ((hm _ _).mpr h))
-  have hmeas3 : m.mu ({0, 3} : Set _) < m.mu ({1, 4} : Set _) :=
+  have hmeas3 : m ({0, 3} : Set _) < m ({1, 4} : Set _) :=
     not_le.mp (λ h => hord3 ((hm _ _).mpr h))
-  have hmeas4 : m.mu ({0, 1, 3} : Set _) ≥ m.mu ({2, 4} : Set _) :=
+  have hmeas4 : m ({0, 1, 3} : Set _) ≥ m ({2, 4} : Set _) :=
     (hm _ _).mp hord4
   -- Decompose pairs/triples using finite additivity
   rw [mu_pair m 1 3 (by decide)] at hmeas1
@@ -190,12 +193,12 @@ theorem null_removal_disjoint {W : Type*} (sys : QualitativeProbability W)
   by_cases hjC : j ∈ C
   · have hjnD : j ∉ D := Set.disjoint_left.mp hdisj hjC
     rw [Set.sdiff_singleton_eq_self hjnD]
-    exact ⟨fun h => sys.trans _ _ _ (null_sub C) h,
-           fun h => sys.trans _ _ _ (sys.mono _ _ Set.sdiff_subset) h⟩
+    exact ⟨fun h => sys.trans (null_sub C) h,
+           fun h => sys.trans (sys.mono Set.sdiff_subset) h⟩
   · rw [Set.sdiff_singleton_eq_self hjC]
     by_cases hjD : j ∈ D
-    · exact ⟨fun h => sys.trans _ _ _ h (sys.mono _ _ Set.sdiff_subset),
-             fun h => sys.trans _ _ _ h (null_sub D)⟩
+    · exact ⟨fun h => sys.trans h (sys.mono Set.sdiff_subset),
+             fun h => sys.trans h (null_sub D)⟩
     · rw [Set.sdiff_singleton_eq_self hjD]
 
 /-- `Fin.succ '' (Fin.succ ⁻¹' S) = S \ {0}` for `S : Set (Fin (n+1))`. -/
@@ -211,12 +214,12 @@ def QualitativeProbability.comap {α W : Type*} (f : α → W) (hf : Function.In
     (sys : QualitativeProbability W) (hnt : ¬sys.ge ∅ (Set.range f)) :
     QualitativeProbability α where
   ge A B := sys.ge (f '' A) (f '' B)
-  mono _ _ hAB := sys.mono _ _ (Set.image_mono hAB)
+  mono' _ _ hAB := sys.mono (Set.image_mono hAB)
   nonTrivial := by
     show ¬sys.ge (f '' ∅) (f '' Set.univ)
     rwa [Set.image_empty, Set.image_univ]
   total _ _ := sys.total _ _
-  trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
+  trans' _ _ _ h1 h2 := sys.trans h1 h2
   additive A B := by
     show sys.ge (f '' A) (f '' B) ↔ sys.ge (f '' (A \ B)) (f '' (B \ A))
     rw [Set.image_sdiff hf, Set.image_sdiff hf]; exact sys.additive _ _
@@ -230,8 +233,8 @@ theorem null_elem_reduce {n : ℕ} (sys : QualitativeProbability (Fin (n + 2)))
     Representable sys := by
   have hnt : ¬sys.ge ∅ (Set.range (Fin.succ : Fin (n + 1) → Fin (n + 2))) := by
     obtain ⟨i, hi⟩ := hnn
-    exact fun h => hi (sys.trans _ _ _ h
-      (sys.mono _ _ (Set.singleton_subset_iff.mpr ⟨i, rfl⟩)))
+    exact fun h => hi (sys.trans h
+      (sys.mono (Set.singleton_subset_iff.mpr ⟨i, rfl⟩)))
   obtain ⟨m_r, hm_r⟩ := sub_repr (sys.comap Fin.succ (Fin.succ_injective _) hnt)
   -- lift the sub-measure (the null element gets weight 0)
   refine ⟨m_r.map Fin.succ, reduce_to_disjoint sys _ (fun C D hdisj => ?_)⟩
@@ -266,7 +269,7 @@ theorem representable_fin1 (sys : QualitativeProbability (Fin 1)) : Representabl
   · exact ⟨fun h => absurd h sys.nonTrivial,
           fun h => by simp only [FinAddMeasure.inducedGe] at h; linarith⟩
   · exact ⟨fun _ => by simp only [FinAddMeasure.inducedGe]; rw [hme, hu]; norm_num,
-          fun _ => sys.mono _ _ (Set.empty_subset _)⟩
+          fun _ => sys.mono (Set.empty_subset _)⟩
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
 
 -- ── Card 2: Infrastructure ──────────────────────────
@@ -277,11 +280,11 @@ private noncomputable def measure_fin2 (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) 
     (by simp [Fin.sum_univ_two])
 
 private theorem mf2_zero (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
-    (measure_fin2 a ha ha1).mu {(0 : Fin 2)} = a := by
+    (measure_fin2 a ha ha1) {(0 : Fin 2)} = a := by
   simp [measure_fin2]
 
 private theorem mf2_one (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1) :
-    (measure_fin2 a ha ha1).mu {(1 : Fin 2)} = 1 - a := by
+    (measure_fin2 a ha ha1) {(1 : Fin 2)} = 1 - a := by
   simp [measure_fin2]
 
 private theorem set_fin2_eq (A : Set (Fin 2)) :
@@ -299,7 +302,7 @@ private theorem not_both_null_fin2 (sys : QualitativeProbability (Fin 2)) :
   have hd2 : Set.univ \ ({(0 : Fin 2)} : Set _) = {(1 : Fin 2)} := by
     ext x; simp only [Set.mem_sdiff, Set.mem_univ, Set.mem_singleton_iff, true_and, Fin.ext_iff]
     omega
-  exact sys.nonTrivial (sys.trans _ _ _ h0
+  exact sys.nonTrivial (sys.trans h0
     ((sys.additive {0} Set.univ).mpr (hd1 ▸ hd2 ▸ h1)))
 
 -- ── Card 2: Helper for disjoint-pair dispatch ────────
@@ -336,7 +339,7 @@ private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
     exact ⟨fun h => absurd h sys.nonTrivial, fun h => by linarith⟩
   -- {0} vs ∅
   · show sys.ge {0} ∅ ↔ _ ≥ _; rw [hm0, hme]
-    exact ⟨fun _ => ha, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
+    exact ⟨fun _ => ha, fun _ => sys.mono (Set.empty_subset _)⟩
   -- {0} vs {0}: not disjoint
   · exact (hdisj 0 rfl rfl).elim
   -- {0} vs {1}
@@ -345,7 +348,7 @@ private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
   · exact (hdisj 0 rfl (Set.mem_univ _)).elim
   -- {1} vs ∅
   · show sys.ge {1} ∅ ↔ _ ≥ _; rw [hm1, hme]
-    exact ⟨fun _ => by linarith, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
+    exact ⟨fun _ => by linarith, fun _ => sys.mono (Set.empty_subset _)⟩
   -- {1} vs {0}
   · show sys.ge {1} {0} ↔ _ ≥ _; rw [hm1, hm0]; exact h10
   -- {1} vs {1}: not disjoint
@@ -354,7 +357,7 @@ private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
   · exact (hdisj 1 rfl (Set.mem_univ _)).elim
   -- univ vs ∅
   · show sys.ge Set.univ ∅ ↔ _ ≥ _; rw [hmu, hme]
-    exact ⟨fun _ => by linarith, fun _ => sys.mono _ _ (Set.empty_subset _)⟩
+    exact ⟨fun _ => by linarith, fun _ => sys.mono (Set.empty_subset _)⟩
   -- univ vs {0}: not disjoint
   · exact (hdisj 0 (Set.mem_univ _) rfl).elim
   -- univ vs {1}: not disjoint
@@ -369,7 +372,7 @@ theorem representable_fin2 (sys : QualitativeProbability (Fin 2)) : Representabl
   · -- Case 1: ge ∅ {0} → a = 0
     have h_nnull1 : ¬sys.ge ∅ {(1 : Fin 2)} := fun h => not_both_null_fin2 sys ⟨h_null0, h⟩
     have h_nge01 : ¬sys.ge {(0 : Fin 2)} {1} :=
-      fun h => not_both_null_fin2 sys ⟨h_null0, sys.trans _ _ _ h_null0 h⟩
+      fun h => not_both_null_fin2 sys ⟨h_null0, sys.trans h_null0 h⟩
     have h_ge10 : sys.ge {(1 : Fin 2)} {0} :=
       (sys.total {(1 : Fin 2)} {0}).resolve_right h_nge01
     refine ⟨measure_fin2 0 le_rfl zero_le_one,
@@ -381,7 +384,7 @@ theorem representable_fin2 (sys : QualitativeProbability (Fin 2)) : Representabl
   · by_cases h_null1 : sys.ge ∅ {(1 : Fin 2)}
     · -- Case 2: ge ∅ {1} → a = 1
       have h_nge10 : ¬sys.ge {(1 : Fin 2)} {0} :=
-        fun h => not_both_null_fin2 sys ⟨sys.trans _ _ _ h_null1 h, h_null1⟩
+        fun h => not_both_null_fin2 sys ⟨sys.trans h_null1 h, h_null1⟩
       have h_ge01 : sys.ge {(0 : Fin 2)} {1} :=
         (sys.total {(0 : Fin 2)} {1}).resolve_right h_nge10
       refine ⟨measure_fin2 1 zero_le_one le_rfl,
@@ -433,7 +436,7 @@ theorem transfer_repr {W α : Type*}
   have h := hm (e '' A) (e '' B)
   simp only [QualitativeProbability.transport, QualitativeProbability.comap,
     Equiv.symm_image_image] at h
-  simpa only [FinAddMeasure.inducedGe, FinAddMeasure.map_mu,
+  simpa only [FinAddMeasure.inducedGe, FinAddMeasure.map_apply,
     ← Equiv.image_eq_preimage_symm] using h
 
 /-- Null pattern transport: `j` is null in `sys.transport σ` iff `σ.symm j` is
@@ -457,12 +460,12 @@ theorem perm_repr {W α : Type*} (σ : W ≃ α) (sys : QualitativeProbability W
 def QualitativeProbability.pad {n : ℕ} (sys : QualitativeProbability (Fin n)) :
     QualitativeProbability (Fin (n + 1)) where
   ge A B := sys.ge (Fin.castSucc ⁻¹' A) (Fin.castSucc ⁻¹' B)
-  mono _ _ hAB := sys.mono _ _ (Set.preimage_mono hAB)
+  mono' _ _ hAB := sys.mono (Set.preimage_mono hAB)
   nonTrivial := by
     show ¬sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' Set.univ)
     rw [Set.preimage_univ, Set.preimage_empty]; exact sys.nonTrivial
   total _ _ := sys.total _ _
-  trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
+  trans' _ _ _ h1 h2 := sys.trans h1 h2
   additive A B := by
     show sys.ge _ _ ↔ sys.ge _ _
     rw [Set.preimage_sdiff, Set.preimage_sdiff]; exact sys.additive _ _
@@ -481,8 +484,8 @@ theorem representable_of_pad {n : ℕ} {sys : QualitativeProbability (Fin n)}
     (h : Representable sys.pad) : Representable sys := by
   obtain ⟨m, hm⟩ := h
   have hinj := Fin.castSucc_injective n
-  have hlast : m.mu {Fin.last n} = 0 := by
-    have h0 : m.mu ∅ ≥ m.mu {Fin.last n} := (hm _ _).mp sys.pad_last_null
+  have hlast : m {Fin.last n} = 0 := by
+    have h0 : m ∅ ≥ m {Fin.last n} := (hm _ _).mp sys.pad_last_null
     rw [m.mu_empty] at h0; linarith [m.nonneg {Fin.last n}]
   have hcover : Fin.castSucc '' (Set.univ : Set (Fin n)) ∪ {Fin.last n} = Set.univ := by
     rw [Set.image_univ]
@@ -493,15 +496,15 @@ theorem representable_of_pad {n : ℕ} {sys : QualitativeProbability (Fin n)}
     · exact Or.inr rfl
   have hdisj : Disjoint (Fin.castSucc '' (Set.univ : Set (Fin n))) {Fin.last n} :=
     Set.disjoint_singleton_right.mpr fun ⟨i, _, hi⟩ => (Fin.castSucc_lt_last i).ne hi
-  have htotal : m.mu (Fin.castSucc '' (Set.univ : Set (Fin n))) = 1 := by
-    have := m.additive _ _ hdisj
+  have htotal : m (Fin.castSucc '' (Set.univ : Set (Fin n))) = 1 := by
+    have := m.additive hdisj
     rw [hcover, m.total, hlast, add_zero] at this; linarith
   refine ⟨{
-    mu := fun A => m.mu (Fin.castSucc '' A)
-    nonneg := fun A => m.nonneg _
-    additive := fun A B hd => by
-      rw [Set.image_union]; exact m.additive _ _ ((Set.disjoint_image_iff hinj).mpr hd)
-    total := htotal
+    toFun := fun A => m (Fin.castSucc '' A)
+    nonneg' := fun A => m.nonneg _
+    additive' := fun A B hd => by
+      rw [Set.image_union]; exact m.additive ((Set.disjoint_image_iff hinj).mpr hd)
+    total' := htotal
   }, fun A B => ?_⟩
   have key := hm (Fin.castSucc '' A) (Fin.castSucc '' B)
   rwa [show sys.pad.ge (Fin.castSucc '' A) (Fin.castSucc '' B) ↔ sys.ge A B from by

--- a/Linglib/Logic/ComparativeProbability/Systems.lean
+++ b/Linglib/Logic/ComparativeProbability/Systems.lean
@@ -41,8 +41,17 @@ The measures are generic over an ordered field `K`: `ℝ` gives the paper's lite
 two agree (rational and real linear feasibility coincide), and only `ℚ` supports
 the constructive Farkas (`FourierMotzkin.lean`) and `decide`-checked models
 (`Representability.lean`) behind the representation theorems. `FinAddMeasure`
-overlaps mathlib's `MeasureTheory.AddContent` and could be re-founded on it;
-`FinAddMeasure.inducedGe` is `Order.Preimage m.mu (· ≥ ·)`.
+mirrors mathlib's `MeasureTheory.AddContent` interface (`FunLike` application
+`m A`, primed axiom fields with unprimed lemmas); re-founding on `AddContent`
+itself would trade the ordered-field axioms for monoid-valued contents over a
+set system with `sUnion` side conditions, so the structure stays local.
+`FinAddMeasure.inducedGe` is `Order.Preimage ⇑m (· ≥ ·)`.
+
+`[UPSTREAM]` candidate: `QualitativeProbability`, the measures, and the
+KPS/Scott representation theory (`Representability.lean`, `Cancellation.lean`,
+`CancellationFin4.lean`, `Completeness.lean`) are measurement-theoretic
+mathematics with no mathlib counterpart; the world-ordering lifts and the
+pattern layer are program content and stay here.
 
 ## References
 
@@ -86,14 +95,14 @@ consequences of monotonicity (`refl`, `univ_ge_empty`), not fields. -/
 structure QualitativeProbability (W : Type*) where
   /-- The "at least as likely as" relation on propositions. -/
   ge : Set W → Set W → Prop
-  /-- Monotonicity: supersets are at least as likely. -/
-  mono : ∀ A B : Set W, A ⊆ B → ge B A
+  /-- Monotonicity: supersets are at least as likely. Use the lemma `mono`. -/
+  mono' : ∀ A B : Set W, A ⊆ B → ge B A
   /-- Non-triviality: excludes the degenerate all-equivalent order. -/
   nonTrivial : ¬ ge ∅ Set.univ
   /-- Totality: any two propositions are comparable. -/
   total : ∀ A B : Set W, ge A B ∨ ge B A
-  /-- Transitivity. -/
-  trans : ∀ A B C : Set W, ge A B → ge B C → ge A C
+  /-- Transitivity. Use the lemma `trans`. -/
+  trans' : ∀ A B C : Set W, ge A B → ge B C → ge A C
   /-- Qualitative additivity: `A ≿ B ↔ (A \ B) ≿ (B \ A)`. -/
   additive : ∀ A B : Set W, ge A B ↔ ge (A \ B) (B \ A)
 
@@ -101,11 +110,18 @@ namespace QualitativeProbability
 
 variable {W : Type*} (sys : QualitativeProbability W)
 
+/-- Monotonicity: supersets are at least as likely. -/
+theorem mono {A B : Set W} (h : A ⊆ B) : sys.ge B A := sys.mono' A B h
+
+/-- Transitivity. -/
+theorem trans {A B C : Set W} (hab : sys.ge A B) (hbc : sys.ge B C) : sys.ge A C :=
+  sys.trans' A B C hab hbc
+
 /-- Reflexivity, from monotonicity. -/
-theorem refl (A : Set W) : sys.ge A A := sys.mono A A subset_rfl
+theorem refl (A : Set W) : sys.ge A A := sys.mono subset_rfl
 
 /-- The tautology is at least as likely as the contradiction. -/
-theorem univ_ge_empty : sys.ge Set.univ ∅ := sys.mono ∅ Set.univ (Set.empty_subset _)
+theorem univ_ge_empty : sys.ge Set.univ ∅ := sys.mono (Set.empty_subset _)
 
 end QualitativeProbability
 
@@ -120,9 +136,9 @@ section
 
 variable {W : Type*} (sys : QualitativeProbability W)
 
-instance : ComparativeProbability.IsLikelihoodMono sys.ge := ⟨sys.mono⟩
+instance : ComparativeProbability.IsLikelihoodMono sys.ge := ⟨sys.mono'⟩
 
-instance : IsTrans (Set W) sys.ge := ⟨sys.trans⟩
+instance : IsTrans (Set W) sys.ge := ⟨sys.trans'⟩
 
 instance : ComparativeProbability.IsQualitativeAdditive sys.ge := ⟨sys.additive⟩
 
@@ -163,7 +179,7 @@ lemma ge_generalized_merge {X₁ Y₁ X₂ Y₂ : Set W}
     show Y₁ ∪ Y₂ = (Y₂ ∪ (Y₁ \ X₂)) ∪ (X₂ ∩ Y₁) by grind]
   -- the pivot is common context; strip it, then transit through `X₂ ∪ Y₁`
   refine ge_add_context sys ?_
-  refine sys.trans _ (X₂ ∪ Y₁) _ ?_ ?_
+  refine sys.trans (B := X₂ ∪ Y₁) ?_ ?_
   · rw [show X₂ ∪ Y₁ = Y₁ ∪ (X₂ \ Y₁) by grind]
     exact ge_add_context sys h1
   · rw [show X₂ ∪ Y₁ = X₂ ∪ (Y₁ \ X₂) by grind]
@@ -173,11 +189,11 @@ lemma ge_generalized_merge {X₁ Y₁ X₂ Y₂ : Set W}
     proves `P ≿ Q`. -/
 lemma ge_mono_dominated {X Y P Q : Set W} (h : sys.ge X Y) (hXP : X ⊆ P) (hQY : Q ⊆ Y) :
     sys.ge P Q :=
-  sys.trans _ _ _ (sys.mono X P hXP) (sys.trans _ _ _ h (sys.mono Q Y hQY))
+  sys.trans (sys.mono hXP) (sys.trans h (sys.mono hQY))
 
 /-- `P ≿ ∅` always (monotonicity). -/
 lemma ge_empty_target (P : Set W) : sys.ge P ∅ :=
-  sys.mono ∅ P (Set.empty_subset P)
+  sys.mono (Set.empty_subset P)
 
 end
 
@@ -186,94 +202,116 @@ end
 /-- A finitely additive probability measure on subsets of `W`, valued in an
     ordered field `K`. The value type is left generic: instantiate at `ℚ` for the
     constructive, `decide`-able representation theory and at `ℝ` for the paper's
-    literal `[0,1]`-valued measures (see the module docstring). -/
+    literal `[0,1]`-valued measures (see the module docstring).
+
+    The measure applies as a function: `m A`, via `FunLike`. -/
 structure FinAddMeasure (K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedRing K]
     (W : Type*) where
-  /-- The measure function -/
-  mu : Set W → K
-  /-- Non-negativity -/
-  nonneg : ∀ A, 0 ≤ mu A
-  /-- Finite additivity: μ(A ∪ B) = μ(A) + μ(B) for disjoint A, B -/
-  additive : ∀ A B, Disjoint A B → mu (A ∪ B) = mu A + mu B
-  /-- Normalization -/
-  total : mu Set.univ = 1
+  /-- The measure function. Apply the measure itself: `m A`. -/
+  toFun : Set W → K
+  /-- Non-negativity. Use the lemma `nonneg`. -/
+  nonneg' : ∀ A, 0 ≤ toFun A
+  /-- Finite additivity on disjoint sets. Use the lemma `additive`. -/
+  additive' : ∀ A B, Disjoint A B → toFun (A ∪ B) = toFun A + toFun B
+  /-- Normalization. Use the lemma `total`. -/
+  total' : toFun Set.univ = 1
 
-section
+namespace FinAddMeasure
 
 variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {W : Type*}
 
+instance : FunLike (FinAddMeasure K W) (Set W) K where
+  coe := toFun
+  coe_injective m m' _ := by cases m; cases m'; congr
+
+@[simp] theorem coe_mk (f : Set W → K) (h₁ h₂ h₃) :
+    ⇑(⟨f, h₁, h₂, h₃⟩ : FinAddMeasure K W) = f := rfl
+
+@[simp] theorem toFun_eq_coe (m : FinAddMeasure K W) : m.toFun = ⇑m := rfl
+
+@[ext] theorem ext {m m' : FinAddMeasure K W} (h : ∀ A, m A = m' A) : m = m' :=
+  DFunLike.ext m m' h
+
+theorem nonneg (m : FinAddMeasure K W) (A : Set W) : 0 ≤ m A := m.nonneg' A
+
+theorem additive (m : FinAddMeasure K W) {A B : Set W} (h : Disjoint A B) :
+    m (A ∪ B) = m A + m B := m.additive' A B h
+
+@[simp] theorem total (m : FinAddMeasure K W) : m Set.univ = 1 := m.total'
+
 /-- Measure-induced comparative likelihood: A ≿ B ↔ μ(A) ≥ μ(B). -/
-def FinAddMeasure.inducedGe (m : FinAddMeasure K W) (A B : Set W) : Prop := m.mu A ≥ m.mu B
+def inducedGe (m : FinAddMeasure K W) (A B : Set W) : Prop := m A ≥ m B
 
 /-- μ(∅) = 0 for any finitely additive measure.
     Follows from additivity: μ(∅ ∪ ∅) = μ(∅) + μ(∅), but ∅ ∪ ∅ = ∅. -/
-@[simp] theorem FinAddMeasure.mu_empty (m : FinAddMeasure K W) : m.mu ∅ = 0 := by
-  have h := m.additive ∅ ∅ disjoint_bot_left; rw [Set.empty_union] at h; linarith
+@[simp] theorem mu_empty (m : FinAddMeasure K W) : m ∅ = 0 := by
+  have h := m.additive (A := ∅) (B := ∅) disjoint_bot_left
+  rw [Set.empty_union] at h; linarith
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. -/
-theorem FinAddMeasure.mu_mono (m : FinAddMeasure K W) {A B : Set W} (h : A ⊆ B) :
-    m.mu A ≤ m.mu B := by
-  have hunion := m.additive A (B \ A) disjoint_sdiff_self_right
+theorem mu_mono (m : FinAddMeasure K W) {A B : Set W} (h : A ⊆ B) :
+    m A ≤ m B := by
+  have hunion := m.additive (A := A) (B := B \ A) disjoint_sdiff_self_right
   rw [Set.union_sdiff_cancel h] at hunion; linarith [m.nonneg (B \ A)]
 
 /-- Complement measure: `μ(A) + μ(Aᶜ) = 1`. -/
-theorem FinAddMeasure.mu_compl (m : FinAddMeasure K W) (A : Set W) :
-    m.mu A + m.mu Aᶜ = 1 := by
-  have hunion := m.additive A Aᶜ disjoint_compl_right
+theorem mu_compl (m : FinAddMeasure K W) (A : Set W) :
+    m A + m Aᶜ = 1 := by
+  have hunion := m.additive (A := A) (B := Aᶜ) disjoint_compl_right
   rw [Set.union_compl_self] at hunion; linarith [m.total]
 
 /-- Qualitative additivity for a finitely additive measure: splitting `A` and `B`
     into the shared part `A ∩ B` and the private parts cancels the shared part. -/
-theorem FinAddMeasure.mu_qadd (m : FinAddMeasure K W) (A B : Set W) :
-    m.mu A ≥ m.mu B ↔ m.mu (A \ B) ≥ m.mu (B \ A) := by
-  have key : ∀ X Y : Set W, m.mu X = m.mu (X \ Y) + m.mu (X ∩ Y) := fun X Y => by
+theorem mu_qadd (m : FinAddMeasure K W) (A B : Set W) :
+    m A ≥ m B ↔ m (A \ B) ≥ m (B \ A) := by
+  have key : ∀ X Y : Set W, m X = m (X \ Y) + m (X ∩ Y) := fun X Y => by
     conv_lhs => rw [(Set.sdiff_union_inter X Y).symm]
-    exact m.additive _ _ (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.2)
-  rw [key A B, key B A, Set.inter_comm B A]; exact add_le_add_iff_right (m.mu (A ∩ B))
+    exact m.additive (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.2)
+  rw [key A B, key B A, Set.inter_comm B A]; exact add_le_add_iff_right (m (A ∩ B))
 
 /-- The measure of a finite set is the sum of its singleton measures. -/
-@[simp] theorem FinAddMeasure.sum_mu_singleton (m : FinAddMeasure K W) (S : Finset W) :
-    ∑ i ∈ S, m.mu {i} = m.mu ↑S := by
+@[simp] theorem sum_mu_singleton (m : FinAddMeasure K W) (S : Finset W) :
+    ∑ i ∈ S, m {i} = m ↑S := by
   classical
   induction S using Finset.induction_on with
   | empty => simp
   | @insert a S ha ih =>
     have hdisj : Disjoint ({a} : Set W) ↑S :=
       Set.disjoint_singleton_left.mpr fun h => ha (Finset.mem_coe.mp h)
-    rw [Finset.sum_insert ha, ih, Finset.coe_insert, Set.insert_eq, m.additive _ _ hdisj]
+    rw [Finset.sum_insert ha, ih, Finset.coe_insert, Set.insert_eq, m.additive hdisj]
 
 /-- Pushforward of a finitely additive measure along a map. -/
-def FinAddMeasure.map {α : Type*} (f : W → α) (m : FinAddMeasure K W) : FinAddMeasure K α where
-  mu A := m.mu (f ⁻¹' A)
-  nonneg _ := m.nonneg _
-  additive A B h := by rw [Set.preimage_union]; exact m.additive _ _ (h.preimage f)
-  total := by rw [Set.preimage_univ]; exact m.total
+def map {α : Type*} (f : W → α) (m : FinAddMeasure K W) : FinAddMeasure K α where
+  toFun A := m (f ⁻¹' A)
+  nonneg' _ := m.nonneg _
+  additive' A B h := by rw [Set.preimage_union]; exact m.additive (h.preimage f)
+  total' := by rw [Set.preimage_univ]; exact m.total
 
-@[simp] theorem FinAddMeasure.map_mu {α : Type*} (f : W → α) (m : FinAddMeasure K W)
-    (A : Set α) : (m.map f).mu A = m.mu (f ⁻¹' A) := rfl
+@[simp] theorem map_apply {α : Type*} (f : W → α) (m : FinAddMeasure K W)
+    (A : Set α) : m.map f A = m (f ⁻¹' A) := rfl
 
 open scoped Classical in
 /-- The discrete measure with weight `w i` on the atom `i` (the `PMF.ofFintype`
     pattern). -/
-noncomputable def FinAddMeasure.ofFintype [Fintype W] (w : W → K) (hw : ∀ i, 0 ≤ w i)
+noncomputable def ofFintype [Fintype W] (w : W → K) (hw : ∀ i, 0 ≤ w i)
     (hw1 : ∑ i, w i = 1) : FinAddMeasure K W where
-  mu A := ∑ i, if i ∈ A then w i else 0
-  nonneg A := Finset.sum_nonneg fun i _ => by split <;> simp [hw i]
-  additive A B h := by
+  toFun A := ∑ i, if i ∈ A then w i else 0
+  nonneg' A := Finset.sum_nonneg fun i _ => by split <;> simp [hw i]
+  additive' A B h := by
     rw [← Finset.sum_add_distrib]
     refine Finset.sum_congr rfl fun i _ => ?_
     by_cases hA : i ∈ A
     · simp [Set.mem_union, hA, Set.disjoint_left.mp h hA]
     · by_cases hB : i ∈ B <;> simp [Set.mem_union, hA, hB]
-  total := by simpa using hw1
+  total' := by simpa using hw1
 
-@[simp] theorem FinAddMeasure.ofFintype_singleton [Fintype W] (w : W → K)
+@[simp] theorem ofFintype_singleton [Fintype W] (w : W → K)
     (hw : ∀ i, 0 ≤ w i) (hw1 : ∑ i, w i = 1) (i : W) :
-    (ofFintype w hw hw1).mu {i} = w i := by
+    ofFintype w hw hw1 {i} = w i := by
   classical
   simp [ofFintype, Set.mem_singleton_iff, Finset.sum_ite_eq' Finset.univ i w]
 
-end
+end FinAddMeasure
 
 /-! ### Qualitatively additive measures -/
 
@@ -288,51 +326,74 @@ end
     affine renormalisation of the dominated-set count. -/
 structure QualAddMeasure (K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedRing K]
     (W : Type*) where
-  /-- The measure function -/
-  mu : Set W → K
-  /-- Non-negativity -/
-  nonneg : ∀ A, 0 ≤ mu A
-  /-- The impossible proposition has measure zero -/
-  mu_empty : mu ∅ = 0
-  /-- Normalization -/
-  total : mu Set.univ = 1
-  /-- Qualitative additivity: μ(A) ≥ μ(B) ↔ μ(A \ B) ≥ μ(B \ A) -/
-  qualAdd : ∀ A B, mu A ≥ mu B ↔ mu (A \ B) ≥ mu (B \ A)
+  /-- The measure function. Apply the measure itself: `m A`. -/
+  toFun : Set W → K
+  /-- Non-negativity. Use the lemma `nonneg`. -/
+  nonneg' : ∀ A, 0 ≤ toFun A
+  /-- The impossible proposition has measure zero. Use the lemma `mu_empty`. -/
+  empty' : toFun ∅ = 0
+  /-- Normalization. Use the lemma `total`. -/
+  total' : toFun Set.univ = 1
+  /-- Qualitative additivity. Use the lemma `qualAdd`. -/
+  qualAdd' : ∀ A B, toFun A ≥ toFun B ↔ toFun (A \ B) ≥ toFun (B \ A)
 
-section
+namespace QualAddMeasure
 
 variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {W : Type*}
 
+instance : FunLike (QualAddMeasure K W) (Set W) K where
+  coe := toFun
+  coe_injective m m' _ := by cases m; cases m'; congr
+
+@[ext] theorem ext {m m' : QualAddMeasure K W} (h : ∀ A, m A = m' A) : m = m' :=
+  DFunLike.ext m m' h
+
+theorem nonneg (m : QualAddMeasure K W) (A : Set W) : 0 ≤ m A := m.nonneg' A
+
+@[simp] theorem mu_empty (m : QualAddMeasure K W) : m ∅ = 0 := m.empty'
+
+@[simp] theorem total (m : QualAddMeasure K W) : m Set.univ = 1 := m.total'
+
+/-- Qualitative additivity: `μ(A) ≥ μ(B) ↔ μ(A ∖ B) ≥ μ(B ∖ A)`. -/
+theorem qualAdd (m : QualAddMeasure K W) (A B : Set W) :
+    m A ≥ m B ↔ m (A \ B) ≥ m (B \ A) := m.qualAdd' A B
+
 /-- Measure-induced comparative likelihood: A ≿ B ↔ μ(A) ≥ μ(B). -/
-def QualAddMeasure.inducedGe (m : QualAddMeasure K W) (A B : Set W) : Prop := m.mu A ≥ m.mu B
+def inducedGe (m : QualAddMeasure K W) (A B : Set W) : Prop := m A ≥ m B
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. From qualAdd + μ(∅) = 0 + nonneg. -/
-theorem QualAddMeasure.mu_mono (m : QualAddMeasure K W) {A B : Set W} (h : A ⊆ B) :
-    m.mu A ≤ m.mu B := by
-  show m.mu B ≥ m.mu A
+theorem mu_mono (m : QualAddMeasure K W) {A B : Set W} (h : A ⊆ B) :
+    m A ≤ m B := by
+  show m B ≥ m A
   rw [m.qualAdd B A, Set.sdiff_eq_empty.mpr h, m.mu_empty]; exact m.nonneg (B \ A)
 
 /-- A qualitatively additive measure induces System FA.
     Soundness direction of [holliday-icard-2013] Theorem 6:
     every qualitatively additive measure model satisfies the FA axioms. -/
-def QualAddMeasure.toQualitativeProbability (m : QualAddMeasure K W) :
+def toQualitativeProbability (m : QualAddMeasure K W) :
     QualitativeProbability W where
   ge := m.inducedGe
-  mono := fun _ _ h => m.mu_mono h
+  mono' := fun _ _ h => m.mu_mono h
   nonTrivial := by simp only [inducedGe, m.mu_empty, m.total, not_le]; exact one_pos
-  total := fun A B => le_total (m.mu B) (m.mu A)
-  trans := fun _ _ _ hab hbc => le_trans hbc hab
+  total := fun A B => le_total (m B) (m A)
+  trans' := fun _ _ _ hab hbc => le_trans hbc hab
   additive := m.qualAdd
+
+end QualAddMeasure
+
+section
+
+variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {W : Type*}
 
 /-- Every finitely additive measure is qualitatively additive.
     Proof: μ(A) = μ(A \ B) + μ(A ∩ B) and μ(B) = μ(B \ A) + μ(A ∩ B),
     so μ(A) ≥ μ(B) ↔ μ(A \ B) ≥ μ(B \ A). -/
 def FinAddMeasure.toQualAdd (m : FinAddMeasure K W) : QualAddMeasure K W where
-  mu := m.mu
-  nonneg := m.nonneg
-  mu_empty := m.mu_empty
-  total := m.total
-  qualAdd := m.mu_qadd
+  toFun := m.toFun
+  nonneg' := m.nonneg'
+  empty' := m.mu_empty
+  total' := m.total'
+  qualAdd' := m.mu_qadd
 
 /-- Every finitely additive measure satisfies the FA axioms, through
     `toQualAdd`. A fortiori from [holliday-icard-2013] Theorem 6 soundness,
@@ -405,9 +466,10 @@ section
 variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {W : Type*}
   (m : FinAddMeasure K W)
 
-instance : ComparativeProbability.IsLikelihoodMono m.inducedGe := ⟨m.toQualitativeProbability.mono⟩
+instance : ComparativeProbability.IsLikelihoodMono m.inducedGe :=
+  ⟨m.toQualitativeProbability.mono'⟩
 
-instance : IsTrans (Set W) m.inducedGe := ⟨m.toQualitativeProbability.trans⟩
+instance : IsTrans (Set W) m.inducedGe := ⟨m.toQualitativeProbability.trans'⟩
 
 instance : ComparativeProbability.IsQualitativeAdditive m.inducedGe :=
   ⟨m.toQualitativeProbability.additive⟩

--- a/Linglib/Studies/HarrisonTrainorHollidayIcard2016.lean
+++ b/Linglib/Studies/HarrisonTrainorHollidayIcard2016.lean
@@ -149,16 +149,16 @@ variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
 
 open scoped Classical in
 private lemma mu_eq_sum_ite (E : Set W) :
-    m.mu E = ∑ s, if s ∈ E then m.mu {s} else 0 := by
+    m E = ∑ s, if s ∈ E then m {s} else 0 := by
   classical
-  have h : m.mu E = ∑ i ∈ E.toFinset, m.mu {i} := by
+  have h : m E = ∑ i ∈ E.toFinset, m {i} := by
     rw [m.sum_mu_singleton, Set.coe_toFinset]
   rw [h, ← Finset.sum_filter]
   refine Finset.sum_congr ?_ (fun _ _ => rfl)
   ext s; simp [Set.mem_toFinset]
 
 private lemma mu_listSum (L : List (Set W)) :
-    (L.map m.mu).sum = ∑ s, m.mu {s} * (seqCount s L : K) := by
+    (L.map m).sum = ∑ s, m {s} * (seqCount s L : K) := by
   classical
   induction L with
   | nil => simp [seqCount]
@@ -173,14 +173,14 @@ private lemma mu_listSum (L : List (Set W)) :
     · simp [hs]
 
 private lemma mu_listSum_eq_of_balanced {L₁ L₂ : List (Set W)} (h : Balanced L₁ L₂) :
-    (L₁.map m.mu).sum = (L₂.map m.mu).sum := by
+    (L₁.map m).sum = (L₂.map m).sum := by
   rw [mu_listSum m L₁, mu_listSum m L₂]
   exact Finset.sum_congr rfl (fun s _ => by rw [h s])
 
 omit [Fintype W] in
 private lemma mu_sum_mono {prem : List (Set W × Set W)}
     (hprem : ∀ p ∈ prem, m.inducedGe p.1 p.2) :
-    ((prem.map Prod.snd).map m.mu).sum ≤ ((prem.map Prod.fst).map m.mu).sum := by
+    ((prem.map Prod.snd).map m).sum ≤ ((prem.map Prod.fst).map m).sum := by
   induction prem with
   | nil => simp
   | cons p ps ih =>
@@ -204,8 +204,8 @@ def GFCOrder.ofMeasure : GFCOrder W where
     simp only [List.map_append, List.sum_append, List.map_replicate, List.sum_replicate,
       nsmul_eq_mul] at hsum
     have hr0 : (0 : K) < r := by exact_mod_cast Nat.lt_of_lt_of_le Nat.one_pos hr
-    show m.mu X ≤ m.mu Y
-    have hkey : (r : K) * m.mu X ≤ (r : K) * m.mu Y := by nlinarith [mu_sum_mono m hprem]
+    show m X ≤ m Y
+    have hkey : (r : K) * m X ≤ (r : K) * m Y := by nlinarith [mu_sum_mono m hprem]
     exact le_of_mul_le_mul_left hkey hr0
 
 end


### PR DESCRIPTION
Third elegance arc for the comparative-probability substrate (after #2573, #2574): the mathlib-ergonomics pass.

- `FinAddMeasure`/`QualAddMeasure` get the `AddContent` interface: `FunLike` application (`m A`, no more `.mu`), `@[ext]`, `coe_mk`/`toFun_eq_coe`, primed axiom fields with unprimed lemmas (`additive` now takes just the `Disjoint` proof); `map_mu` → `map_apply`; `CondMeasure`/`RegularCondMeasure` get delegating `CoeFun` (deliberately not `FunLike` — the conditional component is not determined by the unconditional values)
- `QualitativeProbability.mono`/`trans` become implicit-binder lemmas over primed fields (the mathlib `Preorder.le_trans`-field vs `le_trans`-lemma pattern), killing the `sys.trans _ _ _` noise dir-wide
- `RegularCondMeasure` was accidentally declared inside `namespace BeliefRevision` as `ComparativeProbability.RegularCondMeasure`, creating a phantom nested namespace and the ambiguous-open warnings — now honestly `BeliefRevision.RegularCondMeasure`
- `[UPSTREAM]` marks on the qualitative-probability core and the KPS/Scott representation files