### PR TITLE
refactor(Logic/ComparativeProbability): le-primitive orders on Boolean algebras

### DIFF
--- a/Linglib/Logic/ComparativeProbability/Cancellation.lean
+++ b/Linglib/Logic/ComparativeProbability/Cancellation.lean
@@ -189,7 +189,7 @@ theorem representable_implies_cancellation {n : ℕ}
     The ↔ (rather than →) is essential: the forward direction ensures the
     measure respects the ordering, while the backward direction ensures
     strictness is preserved (no spurious ties). -/
-def feasibleWeights (n : ℕ) (sys : QualitativeProbability (Fin n)) : Set (Fin n → ℚ) :=
+def feasibleWeights (n : ℕ) (sys : QualitativeProbability (Set (Fin n))) : Set (Fin n → ℚ) :=
   { p | (∀ i, 0 ≤ p i) ∧
         Finset.univ.sum p = 1 ∧
         ∀ (A B : Finset (Fin n)), Disjoint A B →
@@ -212,7 +212,7 @@ private theorem atomMu_eq_finset_sum {n : ℕ} (p : Fin n → ℚ) (S : Finset (
     from a pointwise membership case split. Representation (ge ↔ μ(A) ≥ μ(B))
     reduces to disjoint pairs via `reduce_to_disjoint` (using FA's Axiom A),
     then applies the ↔ condition from `feasibleWeights`. -/
-private theorem feasible_to_measure {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem feasible_to_measure {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     {p : Fin n → ℚ} (hp : p ∈ feasibleWeights n sys) :
     Representable sys := by
   obtain ⟨hnn, hsum, hcompat⟩ := hp
@@ -241,7 +241,7 @@ private theorem feasible_to_measure {n : ℕ} (sys : QualitativeProbability (Fin
     simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx1 hx2
     exact Set.disjoint_left.mp hdisj hx1 hx2
   -- hcompat on filter-finsets, transported to Sets via coercion identity
-  have key := hcompat _ _ hfinDisj
+  have key := hcompat _ _ hfinDisj.symm
   rw [hCeq, hDeq] at key
   -- Bridge atomMu on Sets to Finset.sum (conv_lhs avoids rewriting RHS)
   have hmuC : atomMu p C = (Finset.univ.filter (· ∈ C)).sum p := by
@@ -250,14 +250,14 @@ private theorem feasible_to_measure {n : ℕ} (sys : QualitativeProbability (Fin
   have hmuD : atomMu p D = (Finset.univ.filter (· ∈ D)).sum p := by
     conv_lhs => rw [show D = ↑(Finset.univ.filter (· ∈ D)) from hDeq.symm]
     exact atomMu_eq_finset_sum p _
-  -- Unfold inducedGe (a def, not auto-reduced) and rewrite atomMu to finset sums
-  change sys.ge C D ↔ atomMu p C ≥ atomMu p D
+  -- Unfold `le`/`≤` to the ≿-form of `key` and rewrite atomMu to finset sums
+  change sys.ge D C ↔ atomMu p D ≥ atomMu p C
   rw [hmuC, hmuD]; exact key
 
 -- ── Step 4a. Not all singletons null ─────────────
 
 /-- If all singletons are null, then ∅ ≿ S for any finset S (by FA induction). -/
-private lemma ge_empty_of_all_null {n : ℕ} (sys : QualitativeProbability (Fin n))
+private lemma ge_empty_of_all_null {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (hall : ∀ i, sys.ge ∅ {i}) (S : Finset (Fin n)) : sys.ge ∅ ↑S := by
   induction S using Finset.induction_on with
   | empty => simp only [Finset.coe_empty]; exact sys.refl ∅
@@ -272,15 +272,17 @@ private lemma ge_empty_of_all_null {n : ℕ} (sys : QualitativeProbability (Fin 
       · rintro ⟨hx | hx, hnx⟩ <;> [exact hx; exact absurd hx hnx]
       · rintro rfl; exact ⟨Or.inl rfl, fun h => haS' (Finset.mem_coe.mp h)⟩
     rw [Finset.coe_insert, Set.insert_eq]
-    exact sys.trans (B := ↑S') ih
-      (by rw [sys.additive ↑S' ({a} ∪ ↑S'), h1, h2]; exact hall a)
+    exact sys.trans (b := ↑S')
+      (by rw [sys.additive ({a} ∪ ↑S') ↑S', h2, h1]; exact hall a) ih
 
 /-- Not all singletons can be null: ∃ i, ¬sys.ge ∅ {i}. If all were null,
     FA induction gives sys.ge ∅ Set.univ, contradicting nonTrivial. -/
-theorem not_all_null {n : ℕ} (sys : QualitativeProbability (Fin n)) :
+theorem not_all_null {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
     ∃ i : Fin n, ¬sys.ge ∅ {i} := by
   by_contra hall; push Not at hall
-  exact sys.nonTrivial (by rw [← Finset.coe_univ]; exact ge_empty_of_all_null sys hall _)
+  exact sys.nonTrivial (by
+    rw [Set.top_eq_univ, Set.bot_eq_empty, ← Finset.coe_univ]
+    exact ge_empty_of_all_null sys hall _)
 
 -- ── Step 4b. Farkas alternative (→ version) ─────
 
@@ -303,24 +305,24 @@ private lemma compVec_as_sum_diff {n : ℕ} (A B : Finset (Fin n)) (x : Fin n �
     simp_all [Finset.disjoint_left.mp hdisj]
 
 /-- All disjoint `ge`-pairs: disjoint (A, B) where `sys.ge ↑A ↑B`. -/
-private noncomputable def gePairsOf {n : ℕ} (sys : QualitativeProbability (Fin n)) :
+private noncomputable def gePairsOf {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
     List (Finset (Fin n) × Finset (Fin n)) :=
   ((Finset.univ ×ˢ Finset.univ : Finset _).filter
     (fun ab => Disjoint ab.1 ab.2 ∧ sys.ge ↑ab.1 ↑ab.2)).toList
 
-private theorem gePairs_mem {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem gePairs_mem {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (A B : Finset (Fin n)) (hd : Disjoint A B) (hge : sys.ge ↑A ↑B) :
     (A, B) ∈ gePairsOf sys := by
   simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
     Finset.mem_univ, true_and]; exact ⟨hd, hge⟩
 
-private theorem gePairs_disj {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem gePairs_disj {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (m : Fin (gePairsOf sys).length) :
     Disjoint ((gePairsOf sys).get m).1 ((gePairsOf sys).get m).2 := by
   have := List.get_mem (gePairsOf sys) m
   simp only [gePairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.1
 
-private theorem gePairs_ge {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem gePairs_ge {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (m : Fin (gePairsOf sys).length) :
     sys.ge ↑((gePairsOf sys).get m).1 ↑((gePairsOf sys).get m).2 := by
   have := List.get_mem (gePairsOf sys) m
@@ -375,37 +377,37 @@ private lemma filterMap_weightedSum {n k' : ℕ}
       simp [this]
 
 /-- Strict pairs: disjoint (A, B) where sys.ge ↑A ↑B strictly (¬sys.ge ↑B ↑A). -/
-private noncomputable def strictPairsOf {n : ℕ} (sys : QualitativeProbability (Fin n)) :
+private noncomputable def strictPairsOf {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
     List (Finset (Fin n) × Finset (Fin n)) :=
   ((Finset.univ ×ˢ Finset.univ : Finset _).filter
     (fun ab => Disjoint ab.1 ab.2 ∧ sys.ge ↑ab.1 ↑ab.2 ∧ ¬sys.ge ↑ab.2 ↑ab.1)).toList
 
-private theorem strictPairs_mem {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem strictPairs_mem {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (A B : Finset (Fin n)) (hd : Disjoint A B) (hge : sys.ge ↑A ↑B) (hng : ¬sys.ge ↑B ↑A) :
     (A, B) ∈ strictPairsOf sys := by
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter, Finset.mem_product,
     Finset.mem_univ, true_and]; exact ⟨hd, hge, hng⟩
 
-private theorem strictPairs_disj {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem strictPairs_disj {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (m : Fin (strictPairsOf sys).length) :
     Disjoint ((strictPairsOf sys).get m).1 ((strictPairsOf sys).get m).2 := by
   have := List.get_mem (strictPairsOf sys) m
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.1
 
-private theorem strictPairs_ge {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem strictPairs_ge {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (m : Fin (strictPairsOf sys).length) :
     sys.ge ↑((strictPairsOf sys).get m).1 ↑((strictPairsOf sys).get m).2 := by
   have := List.get_mem (strictPairsOf sys) m
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.2.1
 
-private theorem strictPairs_strict {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem strictPairs_strict {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (m : Fin (strictPairsOf sys).length) :
     ¬sys.ge ↑((strictPairsOf sys).get m).2 ↑((strictPairsOf sys).get m).1 := by
   have := List.get_mem (strictPairsOf sys) m
   simp only [strictPairsOf, Finset.mem_toList, Finset.mem_filter] at this; exact this.2.2.2
 
 /-- `(univ, ∅)` is always a strict pair, so the strict list is nonempty. -/
-private theorem strictPairs_length_pos {n : ℕ} (sys : QualitativeProbability (Fin n)) :
+private theorem strictPairs_length_pos {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
     0 < (strictPairsOf sys).length :=
   List.length_pos_of_mem (strictPairs_mem sys Finset.univ ∅ (Finset.disjoint_empty_right _)
     (by rw [Finset.coe_univ, Finset.coe_empty]; exact sys.mono (Set.empty_subset _))
@@ -416,7 +418,7 @@ private theorem strictPairs_length_pos {n : ℕ} (sys : QualitativeProbability (
     compVec·p ≥ 1 per strict pair}: a feasible point normalizes to a member of
     `feasibleWeights`; an infeasibility certificate assembles a valid neutral
     portfolio with a strict member, contradicting cancellation. -/
-private theorem cancellation_nonempty {n : ℕ} (sys : QualitativeProbability (Fin n))
+private theorem cancellation_nonempty {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     (hcancel : Cancellation n sys.ge) :
     ∃ p, p ∈ feasibleWeights n sys := by
   let gePairs : List (Finset (Fin n) × Finset (Fin n)) := gePairsOf sys
@@ -501,7 +503,7 @@ private theorem cancellation_nonempty {n : ℕ} (sys : QualitativeProbability (F
         exact div_le_div_of_nonneg_right (hx_ord A B hdisj hge) (le_of_lt hσ_pos)
       · -- ← direction (contrapositive)
         by_contra hng
-        have hBA : sys.ge ↑B ↑A := (sys.total ↑A ↑B).resolve_left hng
+        have hBA : sys.ge ↑B ↑A := (sys.total ↑A ↑B).resolve_right hng
         have hmem := strictPairs_mem sys B A hdisj.symm hBA hng
         obtain ⟨⟨s, hs⟩, hgets⟩ := List.mem_iff_get.mp hmem
         have hgap := hx_strict ⟨s, hs⟩
@@ -695,7 +697,7 @@ private theorem cancellation_nonempty {n : ℕ} (sys : QualitativeProbability (F
     2. `feasible_to_measure`: a feasible weight vector constructs a
        representing `FinAddMeasure`. -/
 theorem cancellation_implies_representable {n : ℕ}
-    (sys : QualitativeProbability (Fin n))
+    (sys : QualitativeProbability (Set (Fin n)))
     (hcancel : Cancellation n sys.ge) :
     Representable sys := by
   obtain ⟨p, hp⟩ := cancellation_nonempty sys hcancel
@@ -703,26 +705,26 @@ theorem cancellation_implies_representable {n : ℕ}
 
 /-- **Scott's theorem**: an FA system is representable by a finitely additive
     measure iff it satisfies the cancellation property. -/
-theorem representable_iff_cancellation {n : ℕ} (sys : QualitativeProbability (Fin n)) :
+theorem representable_iff_cancellation {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
     Representable sys ↔ Cancellation n sys.ge :=
-  ⟨fun ⟨m, hm⟩ => representable_implies_cancellation m hm,
+  ⟨fun ⟨m, hm⟩ => representable_implies_cancellation m fun A B => hm B A,
    cancellation_implies_representable sys⟩
 
 /-- A null atom plus a representability oracle one cardinality down yields
     cancellation: swap the null atom to position 0 and apply `null_elem_reduce`. -/
-theorem cancellation_of_null_atom {n : ℕ} (sys : QualitativeProbability (Fin (n + 2)))
+theorem cancellation_of_null_atom {n : ℕ} (sys : QualitativeProbability (Set (Fin (n + 2))))
     {j : Fin (n + 2)} (hj : sys.ge ∅ {j})
-    (sub : ∀ sys' : QualitativeProbability (Fin (n + 1)), Representable sys') :
+    (sub : ∀ sys' : QualitativeProbability (Set (Fin (n + 1))), Representable sys') :
     Cancellation (n + 2) sys.ge := by
   set σ := Equiv.swap (0 : Fin (n + 2)) j with hσ
-  have h0 : (sys.transport σ).ge ∅ {0} := by
+  have h0 : (sys.transport σ).le {0} ∅ := by
     rw [perm_null_iff, show σ.symm 0 = j by simp [hσ]]; exact hj
-  have hnn : ∃ i : Fin (n + 1), ¬(sys.transport σ).ge ∅ {Fin.succ i} := by
+  have hnn : ∃ i : Fin (n + 1), ¬(sys.transport σ).le {Fin.succ i} ∅ := by
     obtain ⟨k, hk⟩ := not_all_null (sys.transport σ)
     obtain ⟨i, rfl⟩ : ∃ i, Fin.succ i = k :=
       Fin.exists_succ_eq.mpr fun h => hk (h ▸ h0)
     exact ⟨i, hk⟩
   obtain ⟨m, hm⟩ := perm_repr σ sys (null_elem_reduce _ h0 hnn sub)
-  exact representable_implies_cancellation m hm
+  exact representable_implies_cancellation m fun A B => hm B A
 
 end ComparativeProbability

--- a/Linglib/Logic/ComparativeProbability/CancellationFin4.lean
+++ b/Linglib/Logic/ComparativeProbability/CancellationFin4.lean
@@ -56,23 +56,23 @@ private lemma cmpVec_mergeCmp {n : ℕ} (c d : Finset (Fin n) × Finset (Fin n))
   simp only [cmpVec, mergeCmp, Finset.mem_sdiff, Finset.mem_union]; split_ifs <;> simp_all
 
 /-- `mergeCmp` of two valid comparisons is valid, given the disjointness conditions.
-    Uses `ge_generalized_merge` then Axiom A to reach disjoint normal form. -/
-private lemma mergeCmp_valid {n : ℕ} (sys : QualitativeProbability (Fin n))
+    Uses `QualitativeProbability.sup_le_sup` then Axiom A to reach disjoint normal form. -/
+private lemma mergeCmp_valid {n : ℕ} (sys : QualitativeProbability (Set (Fin n)))
     {c d : Finset (Fin n) × Finset (Fin n)}
     (hc : sys.ge ↑c.1 ↑c.2) (hd : sys.ge ↑d.1 ↑d.2)
     (hpos : Disjoint c.1 d.1) (hneg : Disjoint c.2 d.2) :
     sys.ge ↑(mergeCmp c d).1 ↑(mergeCmp c d).2 := by
-  have hmerge : sys.ge (↑c.1 ∪ ↑d.1) (↑c.2 ∪ ↑d.2) :=
-    ge_generalized_merge sys hc hd
-      (by rwa [← Finset.disjoint_coe] at hpos)
+  have hmerge : sys.le (↑c.2 ∪ ↑d.2) (↑c.1 ∪ ↑d.1) :=
+    sys.sup_le_sup hc hd
       (by rwa [← Finset.disjoint_coe] at hneg)
+      (by rwa [← Finset.disjoint_coe] at hpos)
   -- reduce to disjoint form via Axiom A
-  rw [sys.additive (↑c.1 ∪ ↑d.1) (↑c.2 ∪ ↑d.2)] at hmerge
+  rw [sys.additive (↑c.2 ∪ ↑d.2) (↑c.1 ∪ ↑d.1)] at hmerge
   have e1 : (↑c.1 ∪ ↑d.1 : Set (Fin n)) \ (↑c.2 ∪ ↑d.2) = ↑(mergeCmp c d).1 := by
     simp only [mergeCmp, Finset.coe_sdiff, Finset.coe_union]
   have e2 : (↑c.2 ∪ ↑d.2 : Set (Fin n)) \ (↑c.1 ∪ ↑d.1) = ↑(mergeCmp c d).2 := by
     simp only [mergeCmp, Finset.coe_sdiff, Finset.coe_union]
-  rwa [e1, e2] at hmerge
+  rwa [e2, e1] at hmerge
 
 /-- Pointwise integer vector-sum of a list of comparisons. -/
 private def cvSumList {n : ℕ} (L : List (Finset (Fin n) × Finset (Fin n))) (i : Fin n) : ℤ :=
@@ -91,7 +91,7 @@ private lemma cvSumList_perm {n : ℕ} {L L' : List (Finset (Fin n) × Finset (F
     everywhere with a strict negative coordinate, some atom is null (`ge ∅ {i}`).
     Disjointness forces `A ⊆ D` and `C ⊆ B`, giving `ge C A → ge C B → (Axiom A) ge ∅ (B\C)`
     and symmetrically `ge ∅ (D\A)`; the strict coordinate lies in one of them. -/
-private lemma null_from_pair (sys : QualitativeProbability (Fin 4))
+private lemma null_from_pair (sys : QualitativeProbability (Set (Fin 4)))
     {A B C D : Finset (Fin 4)}
     (hAB : sys.ge ↑A ↑B) (hCD : sys.ge ↑C ↑D)
     (hABd : Disjoint A B) (hCDd : Disjoint C D)
@@ -112,27 +112,27 @@ private lemma null_from_pair (sys : QualitativeProbability (Fin 4))
       sub_zero] at this
     split_ifs at this <;> omega
   -- ge C A, ge C B
-  have hCA : sys.ge ↑C ↑A := sys.trans hCD (sys.mono (Finset.coe_subset.mpr hAD))
-  have hCB_ge : sys.ge ↑C ↑B := sys.trans hCA hAB
+  have hCA : sys.ge ↑C ↑A := sys.trans (sys.mono (Finset.coe_subset.mpr hAD)) hCD
+  have hCB_ge : sys.ge ↑C ↑B := sys.trans hAB hCA
   -- Axiom A: ge ∅ (B \ C)
   have hBC : sys.ge (∅ : Set (Fin 4)) ↑(B \ C) := by
-    have hax := (sys.additive ↑C ↑B).mp hCB_ge
+    have hax := (sys.additive ↑B ↑C).mp hCB_ge
     rwa [← Finset.coe_sdiff, ← Finset.coe_sdiff,
       Finset.sdiff_eq_empty_iff_subset.mpr hCB, Finset.coe_empty] at hax
   -- symmetric: ge A D, ge A C, ge A D? -> ge ∅ (D \ A)
-  have hAC : sys.ge ↑A ↑C := sys.trans hAB (sys.mono (Finset.coe_subset.mpr hCB))
+  have hAC : sys.ge ↑A ↑C := sys.trans (sys.mono (Finset.coe_subset.mpr hCB)) hAB
   have hDA : sys.ge (∅ : Set (Fin 4)) ↑(D \ A) := by
-    have hax := (sys.additive ↑A ↑D).mp (sys.trans hAC hCD)
+    have hax := (sys.additive ↑D ↑A).mp (sys.trans hCD hAC)
     rwa [← Finset.coe_sdiff, ← Finset.coe_sdiff,
       Finset.sdiff_eq_empty_iff_subset.mpr hAD, Finset.coe_empty] at hax
   -- strict coordinate i₀ ∈ (B \ C) ∪ (D \ A)
   have hmem : i₀ ∈ B \ C ∨ i₀ ∈ D \ A := by
     simp only [cmpVec, Finset.mem_sdiff] at hlt ⊢; split_ifs at hlt <;> simp_all
   rcases hmem with hm | hm
-  · exact ⟨i₀, sys.trans hBC (sys.mono
-      (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
-  · exact ⟨i₀, sys.trans hDA (sys.mono
-      (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm))⟩
+  · exact ⟨i₀, sys.trans (sys.mono
+      (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm)) hBC⟩
+  · exact ⟨i₀, sys.trans (sys.mono
+      (by rw [Set.singleton_subset_iff]; exact Finset.mem_coe.mpr hm)) hDA⟩
 
 /-! ### Bridging comparisons to ℚ sign vectors -/
 
@@ -348,7 +348,7 @@ private lemma v1_tailored
     `(p, q)` with `p = (vpos \ c.1) ∪ (c.2 \ vneg)`, `q = (vneg \ c.2) ∪ (c.1 \ vpos)`
     — is provable (`ge p q`, the IH), then `ge vpos vneg`. Proved by merging `(p,q)`
     with `c` via `mergeCmp_valid`; the disjoint-normal-form is exactly `(vpos, vneg)`. -/
-private lemma recombine (sys : QualitativeProbability (Fin 4))
+private lemma recombine (sys : QualitativeProbability (Set (Fin 4)))
     (vpos vneg : Finset (Fin 4)) (c : Finset (Fin 4) × Finset (Fin 4))
     (hcd : Disjoint c.1 c.2) (hvv : Disjoint vpos vneg)
     (hrc1 : Disjoint vneg c.1) (hrc2 : Disjoint vpos c.2)
@@ -384,7 +384,7 @@ private lemma recombine (sys : QualitativeProbability (Fin 4))
     mono-domination, merge a generalizable pair and recurse, or (no g-merge pair)
     `v1_tailored` gives a null pair (→ contradiction via `hnull`) or a member merged
     by the reversed target (→ peel it, recurse, `recombine`). -/
-private theorem merge_to_single (sys : QualitativeProbability (Fin 4))
+private theorem merge_to_single (sys : QualitativeProbability (Set (Fin 4)))
     (hnull : ∀ i : Fin 4, ¬ sys.ge ∅ {i})
     (L : List (Finset (Fin 4) × Finset (Fin 4)))
     (hdisj : ∀ c ∈ L, Disjoint c.1 c.2)
@@ -397,8 +397,8 @@ private theorem merge_to_single (sys : QualitativeProbability (Fin 4))
   · by_cases hdom : ∃ c ∈ L, c.1 ⊆ vpos ∧ vneg ⊆ c.2
     · -- mono-domination discharge
       obtain ⟨c, hcL, hc1, hc2⟩ := hdom
-      exact ge_mono_dominated sys (hvalid c hcL)
-        (Finset.coe_subset.mpr hc1) (Finset.coe_subset.mpr hc2)
+      exact sys.trans (sys.mono (Finset.coe_subset.mpr hc2))
+        (sys.trans (hvalid c hcL) (sys.mono (Finset.coe_subset.mpr hc1)))
     · -- no mono-dominating member: either a gmerge pair (merge & recurse) or, failing
       -- that, a forced null atom contradicting `hnull`.
       push Not at hdom
@@ -462,7 +462,7 @@ private theorem merge_to_single (sys : QualitativeProbability (Fin 4))
   · -- trivial-target discharge: vneg = ∅
     rw [Finset.not_nonempty_iff_eq_empty] at hne
     subst hne
-    simpa using ge_empty_target sys (↑vpos)
+    simpa using sys.bot_le (↑vpos)
 termination_by L.length
 decreasing_by
   all_goals
@@ -526,7 +526,7 @@ private lemma cleared_sum_eq (P : Portfolio 4) (i : Fin 4) (D : ℕ)
     clearing denominators yields a unit-weight list `R` of valid disjoint comparisons
     with `cvSumList R = cmpVec (s.right, s.left)` — the denominator-cleared balanced
     multiset with one copy of `s` removed. -/
-private theorem exists_balanced_list (sys : QualitativeProbability (Fin 4))
+private theorem exists_balanced_list (sys : QualitativeProbability (Set (Fin 4)))
     (P : Portfolio 4) (hvalid : P.isValid sys.ge) (hneutral : P.isNeutral)
     (s : WComparison 4) (hsmem : List.Mem s P) :
     ∃ R : List (Finset (Fin 4) × Finset (Fin 4)),
@@ -596,7 +596,7 @@ private theorem exists_balanced_list (sys : QualitativeProbability (Fin 4))
 
 /-- **No-null case** of Theorem 8a (Fin 4): when no atom is null, every valid neutral
     portfolio is non-strict, via the merge reduction `merge_to_single`. -/
-theorem no_null_cancellation (sys : QualitativeProbability (Fin 4))
+theorem no_null_cancellation (sys : QualitativeProbability (Set (Fin 4)))
     (hnull : ∀ i : Fin 4, ¬ sys.ge ∅ {i}) :
     Cancellation 4 sys.ge := by
   intro P hvalid hneutral hstrict
@@ -621,10 +621,10 @@ private def restrict3 (A : Set (Fin 4)) : Set (Fin 3) := {i | Fin.castSucc i ∈
 
 /-- Lexicographic extension: the new world `Fin.last 3` dominates; ties break
     by the restriction. -/
-def QualitativeProbability.extendLex (sys : QualitativeProbability (Fin 3)) :
-    QualitativeProbability (Fin 4) where
-  ge A B := (Fin.last 3 ∈ A ∧ Fin.last 3 ∉ B) ∨
-    ((Fin.last 3 ∈ A ↔ Fin.last 3 ∈ B) ∧ sys.ge (restrict3 A) (restrict3 B))
+def QualitativeProbability.extendLex (sys : QualitativeProbability (Set (Fin 3))) :
+    QualitativeProbability (Set (Fin 4)) where
+  le A B := (Fin.last 3 ∈ B ∧ Fin.last 3 ∉ A) ∨
+    ((Fin.last 3 ∈ B ↔ Fin.last 3 ∈ A) ∧ sys.le (restrict3 A) (restrict3 B))
   mono' A B hAB := by
     by_cases hb : Fin.last 3 ∈ B
     · by_cases ha : Fin.last 3 ∈ A
@@ -638,54 +638,54 @@ def QualitativeProbability.extendLex (sys : QualitativeProbability (Fin 3)) :
   total A B := by
     by_cases ha : Fin.last 3 ∈ A <;> by_cases hb : Fin.last 3 ∈ B
     · rcases sys.total (restrict3 A) (restrict3 B) with h | h
-      · exact Or.inl (Or.inr ⟨iff_of_true ha hb, h⟩)
-      · exact Or.inr (Or.inr ⟨iff_of_true hb ha, h⟩)
-    · exact Or.inl (Or.inl ⟨ha, hb⟩)
-    · exact Or.inr (Or.inl ⟨hb, ha⟩)
+      · exact Or.inl (Or.inr ⟨iff_of_true hb ha, h⟩)
+      · exact Or.inr (Or.inr ⟨iff_of_true ha hb, h⟩)
+    · exact Or.inr (Or.inl ⟨ha, hb⟩)
+    · exact Or.inl (Or.inl ⟨hb, ha⟩)
     · rcases sys.total (restrict3 A) (restrict3 B) with h | h
-      · exact Or.inl (Or.inr ⟨iff_of_false ha hb, h⟩)
-      · exact Or.inr (Or.inr ⟨iff_of_false hb ha, h⟩)
+      · exact Or.inl (Or.inr ⟨iff_of_false hb ha, h⟩)
+      · exact Or.inr (Or.inr ⟨iff_of_false ha hb, h⟩)
   trans' A B C := by
-    rintro (⟨ha, hnb⟩ | ⟨hab, hge1⟩) (⟨hb, hnc⟩ | ⟨hbc, hge2⟩)
+    rintro (⟨hb, hna⟩ | ⟨hba, hle1⟩) (⟨hc, hnb⟩ | ⟨hcb, hle2⟩)
     · exact absurd hb hnb
-    · exact Or.inl ⟨ha, fun hc => hnb (hbc.mpr hc)⟩
-    · exact Or.inl ⟨hab.mpr hb, hnc⟩
-    · exact Or.inr ⟨hab.trans hbc, sys.trans hge1 hge2⟩
+    · exact Or.inl ⟨hcb.mpr hb, hna⟩
+    · exact Or.inl ⟨hc, fun ha => hnb (hba.mpr ha)⟩
+    · exact Or.inr ⟨hcb.trans hba, sys.trans hle1 hle2⟩
   additive A B := by
     by_cases ha : Fin.last 3 ∈ A <;> by_cases hb : Fin.last 3 ∈ B
     · -- tie on both sides; restriction additivity carries it
       have hab : Fin.last 3 ∉ A \ B := fun h => h.2 hb
       have hba : Fin.last 3 ∉ B \ A := fun h => h.2 ha
       constructor
-      · rintro (⟨-, hnb⟩ | ⟨-, hge⟩)
-        · exact absurd hb hnb
-        · exact Or.inr ⟨iff_of_false hab hba, (sys.additive _ _).mp hge⟩
-      · rintro (⟨h3, -⟩ | ⟨-, hge⟩)
-        · exact absurd h3 hab
-        · exact Or.inr ⟨iff_of_true ha hb, (sys.additive _ _).mpr hge⟩
-    · -- the new world sits in `A \ B`: both sides true by dominance
-      exact iff_of_true (Or.inl ⟨ha, hb⟩) (Or.inl ⟨⟨ha, hb⟩, fun h => hb h.1⟩)
-    · -- the new world sits in `B \ A`: both sides false
+      · rintro (⟨-, hna⟩ | ⟨-, hle⟩)
+        · exact absurd ha hna
+        · exact Or.inr ⟨iff_of_false hba hab, (sys.additive _ _).mp hle⟩
+      · rintro (⟨h3, -⟩ | ⟨-, hle⟩)
+        · exact absurd h3 hba
+        · exact Or.inr ⟨iff_of_true hb ha, (sys.additive _ _).mpr hle⟩
+    · -- the new world sits in `A \ B`: both sides false
       refine iff_of_false ?_ ?_
       · rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
-        · exact ha h3
-        · exact ha (hiff.mpr hb)
+        · exact hb h3
+        · exact hb (hiff.mpr ha)
       · rintro (⟨h3, -⟩ | ⟨hiff, -⟩)
-        · exact ha h3.1
-        · exact ha (hiff.mpr ⟨hb, ha⟩).1
+        · exact hb h3.1
+        · exact hb (hiff.mpr ⟨ha, hb⟩).1
+    · -- the new world sits in `B \ A`: both sides true by dominance
+      exact iff_of_true (Or.inl ⟨hb, ha⟩) (Or.inl ⟨⟨hb, ha⟩, fun h => ha h.1⟩)
     · -- the new world is absent everywhere; restriction additivity again
       have hab : Fin.last 3 ∉ A \ B := fun h => ha h.1
       have hba : Fin.last 3 ∉ B \ A := fun h => hb h.1
       constructor
-      · rintro (⟨h3, -⟩ | ⟨-, hge⟩)
-        · exact absurd h3 ha
-        · exact Or.inr ⟨iff_of_false hab hba, (sys.additive _ _).mp hge⟩
-      · rintro (⟨h3, -⟩ | ⟨-, hge⟩)
-        · exact absurd h3 hab
-        · exact Or.inr ⟨iff_of_false ha hb, (sys.additive _ _).mpr hge⟩
+      · rintro (⟨h3, -⟩ | ⟨-, hle⟩)
+        · exact absurd h3 hb
+        · exact Or.inr ⟨iff_of_false hba hab, (sys.additive _ _).mp hle⟩
+      · rintro (⟨h3, -⟩ | ⟨-, hle⟩)
+        · exact absurd h3 hba
+        · exact Or.inr ⟨iff_of_false hb ha, (sys.additive _ _).mpr hle⟩
 
 /-- The extension preserves the absence of null atoms. -/
-private lemma extendLex_no_null (sys : QualitativeProbability (Fin 3))
+private lemma extendLex_no_null (sys : QualitativeProbability (Set (Fin 3)))
     (hnull : ∀ i : Fin 3, ¬sys.ge ∅ {i}) :
     ∀ j : Fin 4, ¬(QualitativeProbability.extendLex sys).ge ∅ {j} := by
   refine Fin.lastCases ?_ ?_
@@ -734,7 +734,7 @@ private lemma comparisonVec_map_castSucc (A B : Finset (Fin 3)) (i : Fin 3) :
   simp only [Finset.mem_map']; rfl
 
 /-- Cancellation transfers back along the lexicographic extension. -/
-private theorem cancellation_extendLex (sys : QualitativeProbability (Fin 3))
+private theorem cancellation_extendLex (sys : QualitativeProbability (Set (Fin 3)))
     (h : Cancellation 4 (QualitativeProbability.extendLex sys).ge) : Cancellation 3 sys.ge := by
   intro P hvalid hneutral hstrict
   refine h (P.map embedComparison) ?_ ?_ ?_
@@ -786,7 +786,7 @@ private theorem cancellation_extendLex (sys : QualitativeProbability (Fin 3))
 /-- **Cancellation for Fin 3**, structurally: a null atom reduces to `Fin 2`
     representability; the no-null case extends lexicographically into `Fin 4`
     and pulls back through `no_null_cancellation`. -/
-theorem fa_cancellation_fin3 (sys : QualitativeProbability (Fin 3)) :
+theorem fa_cancellation_fin3 (sys : QualitativeProbability (Set (Fin 3))) :
     Cancellation 3 sys.ge := by
   by_cases h : ∃ j, sys.ge ∅ {j}
   · obtain ⟨j, hj⟩ := h
@@ -798,13 +798,13 @@ theorem fa_cancellation_fin3 (sys : QualitativeProbability (Fin 3)) :
 /-- **Theorem 8a for Fin 3**: every FA system on three elements is representable —
     now *derived from* Scott cancellation, replacing the former measure-by-measure
     case analysis. -/
-theorem representable_fin3 (sys : QualitativeProbability (Fin 3)) : Representable sys :=
+theorem representable_fin3 (sys : QualitativeProbability (Set (Fin 3))) : Representable sys :=
   cancellation_implies_representable sys (fa_cancellation_fin3 sys)
 
 /-- **Theorem 8a (Fin 4), structural**: every FA system on `Fin 4` satisfies
     cancellation. A null atom reduces to `Fin 3`; the no-null case is the merge
     reduction `no_null_cancellation`. -/
-theorem fa_cancellation_fin4 (sys : QualitativeProbability (Fin 4)) :
+theorem fa_cancellation_fin4 (sys : QualitativeProbability (Set (Fin 4))) :
     Cancellation 4 sys.ge := by
   by_cases h : ∃ j, sys.ge ∅ {j}
   · obtain ⟨j, hj⟩ := h
@@ -814,7 +814,7 @@ theorem fa_cancellation_fin4 (sys : QualitativeProbability (Fin 4)) :
 
 /-- **Theorem 8a for Fin 4**: every FA system on 4 elements is representable.
     Via Scott cancellation — see `Cancellation.lean` for the framework. -/
-theorem representable_fin4 (sys : QualitativeProbability (Fin 4)) : Representable sys :=
+theorem representable_fin4 (sys : QualitativeProbability (Set (Fin 4))) : Representable sys :=
   cancellation_implies_representable sys (fa_cancellation_fin4 sys)
 
 end ComparativeProbability

--- a/Linglib/Logic/ComparativeProbability/Completeness.lean
+++ b/Linglib/Logic/ComparativeProbability/Completeness.lean
@@ -29,7 +29,7 @@ namespace ComparativeProbability
     Theorem 8): below five worlds every FA system is representable —
     FA and FP∞ coincide. -/
 theorem representable_of_card_lt_five {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) (hcard : Fintype.card W < 5) :
+    (sys : QualitativeProbability (Set W)) (hcard : Fintype.card W < 5) :
     Representable sys := by
   have : DecidableEq W := Classical.typeDecidableEq W
   let e := Fintype.equivFin W
@@ -46,7 +46,7 @@ theorem representable_of_card_lt_five {W : Type*} [Fintype W]
     weaker than FP∞. -/
 theorem exists_nonrepresentable_of_five_le_card {W : Type*} [Fintype W]
     (hcard : 5 ≤ Fintype.card W) :
-    ∃ sys : QualitativeProbability W, ¬Representable sys := by
+    ∃ sys : QualitativeProbability (Set W), ¬Representable sys := by
   have : DecidableEq W := Classical.typeDecidableEq W
   obtain ⟨sysF, hsysF⟩ := exists_nonrepresentable_fin hcard
   exact ⟨sysF.transport (Fintype.equivFin W).symm,
@@ -56,74 +56,72 @@ theorem exists_nonrepresentable_of_five_le_card {W : Type*} [Fintype W]
 
 attribute [local instance] Classical.propDecidable
 
-/-- Count of finsets dominated by A under the ge ordering. -/
+/-- Count of finsets at most as likely as `A`. -/
 private noncomputable def belowCount {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) (A : Set W) : ℕ :=
-  (Finset.univ.filter (fun S : Finset W => sys.ge A ↑S)).card
+    (sys : QualitativeProbability (Set W)) (A : Set W) : ℕ :=
+  (Finset.univ.filter (fun S : Finset W => sys.le ↑S A)).card
 
 private theorem belowCount_univ {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) :
+    (sys : QualitativeProbability (Set W)) :
     belowCount sys Set.univ = Fintype.card (Finset W) := by
   unfold belowCount
   rw [Finset.filter_true_of_mem fun S _ => sys.mono (Set.subset_univ _)]
   exact Finset.card_univ
 
 private theorem belowCount_mono {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) (A B : Set W)
-    (h : sys.ge A B) : belowCount sys A ≥ belowCount sys B := by
+    (sys : QualitativeProbability (Set W)) (A B : Set W)
+    (h : sys.le A B) : belowCount sys A ≤ belowCount sys B := by
   refine Finset.card_le_card fun S hS => ?_
   rw [Finset.mem_filter] at hS ⊢
-  exact ⟨hS.1, sys.trans h hS.2⟩
+  exact ⟨hS.1, sys.trans hS.2 h⟩
 
 private theorem belowCount_strict {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) (A B : Set W)
-    (h : ¬sys.ge A B) : belowCount sys A < belowCount sys B := by
+    (sys : QualitativeProbability (Set W)) (A B : Set W)
+    (h : ¬sys.le A B) : belowCount sys B < belowCount sys A := by
   refine Finset.card_lt_card ⟨fun S hS => ?_, fun hsub => ?_⟩
   · rw [Finset.mem_filter] at hS ⊢
-    exact ⟨hS.1, sys.trans ((sys.total A B).resolve_left h) hS.2⟩
-  · have : B.toFinset ∈ Finset.univ.filter (fun S : Finset W => sys.ge A ↑S) :=
-      hsub (Finset.mem_filter.mpr ⟨Finset.mem_univ _, by rw [Set.coe_toFinset]; exact sys.refl B⟩)
+    exact ⟨hS.1, sys.trans hS.2 ((sys.total A B).resolve_left h)⟩
+  · have : A.toFinset ∈ Finset.univ.filter (fun S : Finset W => sys.le ↑S B) :=
+      hsub (Finset.mem_filter.mpr ⟨Finset.mem_univ _, by rw [Set.coe_toFinset]; exact sys.refl A⟩)
     rw [Finset.mem_filter, Set.coe_toFinset] at this
     exact h this.2
 
 private theorem belowCount_iff {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) (A B : Set W) :
-    belowCount sys A ≥ belowCount sys B ↔ sys.ge A B := by
+    (sys : QualitativeProbability (Set W)) (A B : Set W) :
+    belowCount sys A ≤ belowCount sys B ↔ sys.le A B := by
   refine ⟨fun hcount => by_contra fun hng => ?_, belowCount_mono sys A B⟩
   have := belowCount_strict sys A B hng
   omega
 
-private theorem ge_div_iff {a b d : ℚ} (hd : 0 < d) :
-    a / d ≥ b / d ↔ a ≥ b := by
-  rw [ge_iff_le, ge_iff_le, div_le_div_iff_of_pos_right hd]
-
 /-- **Theorem 6 completeness** ([holliday-icard-2013], Theorem 6; [van-der-hoek-1996]):
-    every FA system is representable by a qualitatively additive measure —
-    the dominated-set count, affinely renormalised so μ(∅) = 0 and μ(Ω) = 1. -/
+    every qualitative probability order on a finite carrier is representable by a
+    qualitatively additive measure — the dominated-set count, affinely
+    renormalised so μ(∅) = 0 and μ(Ω) = 1. -/
 theorem exists_qualAddMeasure_repr {W : Type*} [Fintype W]
-    (sys : QualitativeProbability W) :
-    ∃ (m : QualAddMeasure ℚ W), ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+    (sys : QualitativeProbability (Set W)) :
+    ∃ (m : QualAddMeasure ℚ W), ∀ A B, sys.le A B ↔ m A ≤ m B := by
   classical
   set E : ℚ := (belowCount sys ∅ : ℚ) with hE
   set N : ℚ := (Fintype.card (Finset W) : ℚ) with hN
   have hd : (0 : ℚ) < N - E := by
-    have := belowCount_strict sys ∅ Set.univ sys.nonTrivial
+    have := belowCount_strict sys Set.univ ∅ (by simpa using sys.nonTrivial)
     rw [belowCount_univ] at this
     exact sub_pos.mpr (by rw [hN, hE]; exact_mod_cast this)
   -- the affine map t ↦ (t − E)/(N − E) is an order isomorphism
   have key : ∀ A B : Set W,
-      ((belowCount sys A : ℚ) - E) / (N - E) ≥ ((belowCount sys B : ℚ) - E) / (N - E) ↔
-      sys.ge A B := fun A B => by
-    rw [ge_div_iff hd, ge_iff_le, sub_le_sub_iff_right, Nat.cast_le]; exact belowCount_iff sys A B
+      ((belowCount sys A : ℚ) - E) / (N - E) ≤ ((belowCount sys B : ℚ) - E) / (N - E) ↔
+      sys.le A B := fun A B => by
+    rw [div_le_div_iff_of_pos_right hd, sub_le_sub_iff_right, Nat.cast_le]
+    exact belowCount_iff sys A B
   have hAle : ∀ A : Set W, E ≤ (belowCount sys A : ℚ) := fun A => by
-    rw [hE, Nat.cast_le]; exact belowCount_mono sys A ∅ (sys.mono (Set.empty_subset A))
+    rw [hE, Nat.cast_le]; exact belowCount_mono sys ∅ A (sys.mono (Set.empty_subset A))
   refine ⟨⟨fun A => ((belowCount sys A : ℚ) - E) / (N - E),
     fun A => div_nonneg (sub_nonneg.mpr (hAle A)) hd.le,
     by simp only [← hE, sub_self, zero_div], ?_, ?_⟩, fun A B => (key A B).symm⟩
   · show ((belowCount sys Set.univ : ℚ) - E) / (N - E) = 1
     rw [belowCount_univ, ← hN]; exact div_self hd.ne'
   · intro A B
-    show _ ≥ _ ↔ _ ≥ _
+    show _ ≤ _ ↔ _ ≤ _
     rw [key A B, key (A \ B) (B \ A)]; exact sys.additive A B
 
 /-- Helper: if ge A {b} for every b ∈ B, then ge A B, given monotonicity (T)

--- a/Linglib/Logic/ComparativeProbability/Entailments.lean
+++ b/Linglib/Logic/ComparativeProbability/Entailments.lean
@@ -113,17 +113,17 @@ section QualitativeAdditivity
 
 /-- I1 is invalid for FA: every finitely additive measure induces an FA system
     via `toQualitativeProbability`, so the measure counterexample transfers. -/
-theorem fa_not_I1 : ∃ (W : Type) (sys : QualitativeProbability W), ¬patternI1 sys.ge :=
+theorem fa_not_I1 : ∃ (W : Type) (sys : QualitativeProbability (Set W)), ¬patternI1 sys.ge :=
   let ⟨m, hm⟩ := measure_not_I1
   ⟨Fin 3, m.toQualitativeProbability, hm⟩
 
 /-- I2 is invalid for FA. -/
-theorem fa_not_I2 : ∃ (W : Type) (sys : QualitativeProbability W), ¬patternI2 sys.ge :=
+theorem fa_not_I2 : ∃ (W : Type) (sys : QualitativeProbability (Set W)), ¬patternI2 sys.ge :=
   let ⟨m, hm⟩ := measure_not_I2
   ⟨Fin 3, m.toQualitativeProbability, hm⟩
 
 /-- I3 is invalid for FA. -/
-theorem fa_not_I3 : ∃ (W : Type) (sys : QualitativeProbability W), ¬patternI3 sys.ge :=
+theorem fa_not_I3 : ∃ (W : Type) (sys : QualitativeProbability (Set W)), ¬patternI3 sys.ge :=
   let ⟨m, hm⟩ := measure_not_I3
   ⟨Fin 3, m.toQualitativeProbability, hm⟩
 

--- a/Linglib/Logic/ComparativeProbability/Representability.lean
+++ b/Linglib/Logic/ComparativeProbability/Representability.lean
@@ -38,10 +38,10 @@ from mathlib (see the note in `Systems.lean`).
 
 namespace ComparativeProbability
 
-/-- An FA system is **representable** when some finitely additive probability
-    measure induces exactly its comparison relation. -/
-def Representable {W : Type*} (sys : QualitativeProbability W) : Prop :=
-  ∃ m : FinAddMeasure ℚ W, ∀ A B, sys.ge A B ↔ m.inducedGe A B
+/-- A qualitative probability order is **representable** when some finitely
+    additive probability measure induces exactly its comparison relation. -/
+def Representable {W : Type*} (sys : QualitativeProbability (Set W)) : Prop :=
+  ∃ m : FinAddMeasure ℚ W, ∀ A B, sys.le A B ↔ m A ≤ m B
 
 -- ── KPS Counterexample Infrastructure ──────────────
 
@@ -84,17 +84,18 @@ section KPSSystem
 attribute [local instance] Classical.propDecidable
 
 private noncomputable def kpsRankSet (A : Set (Fin 5)) : ℕ := kpsRank A.toFinset
-private noncomputable def kpsGe (A B : Set (Fin 5)) : Prop := kpsRankSet A ≥ kpsRankSet B
+private noncomputable def kpsLe (A B : Set (Fin 5)) : Prop := kpsRankSet A ≤ kpsRankSet B
 
-noncomputable def kpsSystem : QualitativeProbability (Fin 5) where
-  ge := kpsGe
+noncomputable def kpsSystem : QualitativeProbability (Set (Fin 5)) where
+  le := kpsLe
   mono' := λ {A B} hAB => kps_mono_finset _ _ (Set.toFinset_subset_toFinset.mpr hAB)
   nonTrivial := by
-    simp only [kpsGe, kpsRankSet, Set.toFinset_univ, Set.toFinset_empty]; decide
-  total := λ A B => le_total (kpsRankSet B) (kpsRankSet A)
-  trans' := λ {_ _ _} hab hbc => le_trans hbc hab
+    simp only [kpsLe, kpsRankSet, Set.top_eq_univ, Set.bot_eq_empty, Set.toFinset_univ,
+      Set.toFinset_empty]; decide
+  total := λ A B => le_total (kpsRankSet A) (kpsRankSet B)
+  trans' := λ {_ _ _} hab hbc => le_trans hab hbc
   additive A B := by
-    unfold kpsGe kpsRankSet
+    unfold kpsLe kpsRankSet
     rw [Set.toFinset_sdiff, Set.toFinset_sdiff]
     exact kps_additive_finset _ _
 
@@ -120,18 +121,18 @@ theorem kps_not_representable : ¬Representable kpsSystem := by
   set R := m ({(2 : Fin 5)} : Set (Fin 5))
   set S := m ({(3 : Fin 5)} : Set (Fin 5))
   set T := m ({(4 : Fin 5)} : Set (Fin 5))
-  -- Ordering facts: three strict (rank <), one weak (rank ≥)
-  have hord1 : ¬ kpsGe ({1, 3} : Set (Fin 5)) {0} := by
-    unfold kpsGe kpsRankSet
+  -- Ordering facts: three strict (rank <), one weak (rank ≤)
+  have hord1 : ¬ kpsLe {0} ({1, 3} : Set (Fin 5)) := by
+    unfold kpsLe kpsRankSet
     simp only [Set.toFinset_insert, Set.toFinset_singleton]; decide
-  have hord2 : ¬ kpsGe ({0, 1} : Set (Fin 5)) {2, 3} := by
-    unfold kpsGe kpsRankSet
+  have hord2 : ¬ kpsLe {2, 3} ({0, 1} : Set (Fin 5)) := by
+    unfold kpsLe kpsRankSet
     simp only [Set.toFinset_insert, Set.toFinset_singleton]; decide
-  have hord3 : ¬ kpsGe ({0, 3} : Set (Fin 5)) {1, 4} := by
-    unfold kpsGe kpsRankSet
+  have hord3 : ¬ kpsLe {1, 4} ({0, 3} : Set (Fin 5)) := by
+    unfold kpsLe kpsRankSet
     simp only [Set.toFinset_insert, Set.toFinset_singleton]; decide
-  have hord4 : kpsGe ({0, 1, 3} : Set (Fin 5)) {2, 4} := by
-    unfold kpsGe kpsRankSet
+  have hord4 : kpsLe {2, 4} ({0, 1, 3} : Set (Fin 5)) := by
+    unfold kpsLe kpsRankSet
     simp only [Set.toFinset_insert, Set.toFinset_singleton]; decide
   -- Convert to measure inequalities via the representation isomorphism
   have hmeas1 : m ({1, 3} : Set _) < m ({(0 : Fin 5)} : Set _) :=
@@ -167,38 +168,38 @@ attribute [local instance] Classical.propDecidable
 
 /-- Agreement on disjoint pairs suffices for full representability (Axiom A
     reduces every comparison to a disjoint one). -/
-theorem reduce_to_disjoint {W : Type*} (sys : QualitativeProbability W)
+theorem reduce_to_disjoint {W : Type*} (sys : QualitativeProbability (Set W))
     (m : FinAddMeasure ℚ W)
-    (h : ∀ C D : Set W, Disjoint C D → (sys.ge C D ↔ m.inducedGe C D)) :
-    ∀ A B, sys.ge A B ↔ m.inducedGe A B := by
+    (h : ∀ C D : Set W, Disjoint C D → (sys.le C D ↔ m C ≤ m D)) :
+    ∀ A B, sys.le A B ↔ m A ≤ m B := by
   intro A B
   rw [sys.additive A B]
   exact (h _ _ disjoint_sdiff_sdiff).trans (m.mu_qadd A B).symm
 
 -- ── Null element reduction ────────────────────────────
 
-/-- Removing a null element (`sys.ge ∅ {j}`) from both sides of a disjoint
-    comparison preserves `ge`. -/
-theorem null_removal_disjoint {W : Type*} (sys : QualitativeProbability W)
-    (j : W) (hj : sys.ge ∅ {j})
+/-- Removing a null element (`sys.le {j} ∅`) from both sides of a disjoint
+    comparison preserves `le`. -/
+theorem null_removal_disjoint {W : Type*} (sys : QualitativeProbability (Set W))
+    (j : W) (hj : sys.le {j} ∅)
     (C D : Set W) (hdisj : Disjoint C D) :
-    sys.ge C D ↔ sys.ge (C \ {j}) (D \ {j}) := by
-  have null_sub : ∀ S : Set W, sys.ge (S \ {j}) S := by
+    sys.le C D ↔ sys.le (C \ {j}) (D \ {j}) := by
+  have null_sub : ∀ S : Set W, sys.le S (S \ {j}) := by
     intro S
     by_cases hj_in : j ∈ S
-    · rw [sys.additive (S \ {j}) S, Set.sdiff_eq_empty.mpr Set.sdiff_subset,
+    · rw [sys.additive S (S \ {j}), Set.sdiff_eq_empty.mpr Set.sdiff_subset,
         Set.sdiff_sdiff_cancel_left (Set.singleton_subset_iff.mpr hj_in)]
       exact hj
     · rw [Set.sdiff_singleton_eq_self hj_in]; exact sys.refl S
   by_cases hjC : j ∈ C
   · have hjnD : j ∉ D := Set.disjoint_left.mp hdisj hjC
     rw [Set.sdiff_singleton_eq_self hjnD]
-    exact ⟨fun h => sys.trans (null_sub C) h,
-           fun h => sys.trans (sys.mono Set.sdiff_subset) h⟩
+    exact ⟨fun h => sys.trans (sys.mono Set.sdiff_subset) h,
+           fun h => sys.trans (null_sub C) h⟩
   · rw [Set.sdiff_singleton_eq_self hjC]
     by_cases hjD : j ∈ D
-    · exact ⟨fun h => sys.trans h (sys.mono Set.sdiff_subset),
-             fun h => sys.trans h (null_sub D)⟩
+    · exact ⟨fun h => sys.trans h (null_sub D),
+             fun h => sys.trans h (sys.mono Set.sdiff_subset)⟩
     · rw [Set.sdiff_singleton_eq_self hjD]
 
 /-- `Fin.succ '' (Fin.succ ⁻¹' S) = S \ {0}` for `S : Set (Fin (n+1))`. -/
@@ -208,33 +209,33 @@ private theorem succ_image_preimage {n : ℕ} (S : Set (Fin (n + 1))) :
   ext x; simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_singleton_iff,
     Set.mem_sdiff]; exact And.comm
 
-/-- Pull back an FA system along an injection: `α`-propositions compare via their
-    images. Non-triviality requires a witness and must be supplied. -/
+/-- Pull back a qualitative probability order along an injection: `α`-sets
+    compare via their images. Non-triviality requires a witness and must be
+    supplied. -/
 def QualitativeProbability.comap {α W : Type*} (f : α → W) (hf : Function.Injective f)
-    (sys : QualitativeProbability W) (hnt : ¬sys.ge ∅ (Set.range f)) :
-    QualitativeProbability α where
-  ge A B := sys.ge (f '' A) (f '' B)
+    (sys : QualitativeProbability (Set W)) (hnt : ¬sys.le (Set.range f) ∅) :
+    QualitativeProbability (Set α) where
+  le A B := sys.le (f '' A) (f '' B)
   mono' _ _ hAB := sys.mono (Set.image_mono hAB)
   nonTrivial := by
-    show ¬sys.ge (f '' ∅) (f '' Set.univ)
+    show ¬sys.le (f '' Set.univ) (f '' ∅)
     rwa [Set.image_empty, Set.image_univ]
   total _ _ := sys.total _ _
   trans' _ _ _ h1 h2 := sys.trans h1 h2
   additive A B := by
-    show sys.ge (f '' A) (f '' B) ↔ sys.ge (f '' (A \ B)) (f '' (B \ A))
+    show sys.le (f '' A) (f '' B) ↔ sys.le (f '' (A \ B)) (f '' (B \ A))
     rw [Set.image_sdiff hf, Set.image_sdiff hf]; exact sys.additive _ _
 
-/-- Null element reduction: if atom 0 is null in an FA system on `Fin (n+2)` and
+/-- Null element reduction: if atom 0 is null in an order on `Fin (n+2)` and
     some atom is not, representability reduces along `Fin.succ` to `Fin (n+1)`. -/
-theorem null_elem_reduce {n : ℕ} (sys : QualitativeProbability (Fin (n + 2)))
-    (hn0 : sys.ge ∅ {(0 : Fin (n + 2))})
-    (hnn : ∃ i : Fin (n + 1), ¬sys.ge ∅ {Fin.succ i})
-    (sub_repr : ∀ sys' : QualitativeProbability (Fin (n + 1)), Representable sys') :
+theorem null_elem_reduce {n : ℕ} (sys : QualitativeProbability (Set (Fin (n + 2))))
+    (hn0 : sys.le {(0 : Fin (n + 2))} ∅)
+    (hnn : ∃ i : Fin (n + 1), ¬sys.le {Fin.succ i} ∅)
+    (sub_repr : ∀ sys' : QualitativeProbability (Set (Fin (n + 1))), Representable sys') :
     Representable sys := by
-  have hnt : ¬sys.ge ∅ (Set.range (Fin.succ : Fin (n + 1) → Fin (n + 2))) := by
+  have hnt : ¬sys.le (Set.range (Fin.succ : Fin (n + 1) → Fin (n + 2))) ∅ := by
     obtain ⟨i, hi⟩ := hnn
-    exact fun h => hi (sys.trans h
-      (sys.mono (Set.singleton_subset_iff.mpr ⟨i, rfl⟩)))
+    exact fun h => hi (sys.trans (sys.mono (Set.singleton_subset_iff.mpr (Set.mem_range_self i))) h)
   obtain ⟨m_r, hm_r⟩ := sub_repr (sys.comap Fin.succ (Fin.succ_injective _) hnt)
   -- lift the sub-measure (the null element gets weight 0)
   refine ⟨m_r.map Fin.succ, reduce_to_disjoint sys _ (fun C D hdisj => ?_)⟩
@@ -246,9 +247,12 @@ theorem null_elem_reduce {n : ℕ} (sys : QualitativeProbability (Fin (n + 2)))
 
 /-- There is no qualitative probability order on an empty carrier: `∅ = Ω`
     contradicts non-triviality. Mirrors `Fin.elim0`. -/
-def QualitativeProbability.elim0 {C : Sort*} (sys : QualitativeProbability (Fin 0)) : C := by
+def QualitativeProbability.elim0 {C : Sort*} (sys : QualitativeProbability (Set (Fin 0))) :
+    C := by
   have : (∅ : Set (Fin 0)) = Set.univ := by ext x; exact Fin.elim0 x
-  exact absurd (this ▸ sys.refl ∅) sys.nonTrivial
+  have h : sys.le ⊤ ⊥ := by
+    rw [Set.top_eq_univ, Set.bot_eq_empty, ← this]; exact sys.refl ∅
+  exact absurd h sys.nonTrivial
 
 -- ── Card 1 ─────────────────────────────────────────
 
@@ -260,16 +264,14 @@ private theorem set_fin1_eq (A : Set (Fin 1)) : A = ∅ ∨ A = Set.univ := by
 private noncomputable def measure_fin1 : FinAddMeasure ℚ (Fin 1) :=
   .ofFintype ![1] (by intro i; fin_cases i; norm_num) (by simp)
 
-theorem representable_fin1 (sys : QualitativeProbability (Fin 1)) : Representable sys := by
+theorem representable_fin1 (sys : QualitativeProbability (Set (Fin 1))) : Representable sys := by
   refine ⟨measure_fin1, fun A B => ?_⟩
   have hme := measure_fin1.mu_empty
   have hu := measure_fin1.total
   rcases set_fin1_eq A with rfl | rfl <;> rcases set_fin1_eq B with rfl | rfl
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
-  · exact ⟨fun h => absurd h sys.nonTrivial,
-          fun h => by simp only [FinAddMeasure.inducedGe] at h; linarith⟩
-  · exact ⟨fun _ => by simp only [FinAddMeasure.inducedGe]; rw [hme, hu]; norm_num,
-          fun _ => sys.mono (Set.empty_subset _)⟩
+  · exact ⟨fun _ => by rw [hme, hu]; norm_num, fun _ => sys.mono (Set.empty_subset _)⟩
+  · exact ⟨fun h => absurd h sys.nonTrivial, fun h => by rw [hme, hu] at h; linarith⟩
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
 
 -- ── Card 2: Infrastructure ──────────────────────────
@@ -295,15 +297,14 @@ private theorem set_fin2_eq (A : Set (Fin 2)) :
   · right; right; left; ext x; fin_cases x <;> simp_all
   · left; ext x; fin_cases x <;> simp_all
 
-private theorem not_both_null_fin2 (sys : QualitativeProbability (Fin 2)) :
-    ¬(sys.ge ∅ {0} ∧ sys.ge ∅ {1}) := by
+private theorem not_both_null_fin2 (sys : QualitativeProbability (Set (Fin 2))) :
+    ¬(sys.le {0} ∅ ∧ sys.le {1} ∅) := by
   intro ⟨h0, h1⟩
   have hd1 : ({(0 : Fin 2)} : Set _) \ Set.univ = ∅ := by ext x; simp
   have hd2 : Set.univ \ ({(0 : Fin 2)} : Set _) = {(1 : Fin 2)} := by
     ext x; simp only [Set.mem_sdiff, Set.mem_univ, Set.mem_singleton_iff, true_and, Fin.ext_iff]
     omega
-  exact sys.nonTrivial (sys.trans h0
-    ((sys.additive {0} Set.univ).mpr (hd1 ▸ hd2 ▸ h1)))
+  exact sys.nonTrivial (sys.trans ((sys.additive Set.univ {0}).mpr (hd1 ▸ hd2 ▸ h1)) h0)
 
 -- ── Card 2: Helper for disjoint-pair dispatch ────────
 
@@ -311,14 +312,14 @@ private theorem not_both_null_fin2 (sys : QualitativeProbability (Fin 2)) :
     The 7 non-disjoint pairs close by exfalso.
     The 5 uniform pairs (∅/∅, X/∅, ∅/univ) are independent of the ordering.
     The 4 critical pairs (∅/{0}, ∅/{1}, {0}/{1}, {1}/{0}) use the hypotheses. -/
-private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
+private theorem fin2_dispatch (sys : QualitativeProbability (Set (Fin 2)))
     (a : ℚ) (ha : 0 ≤ a) (ha1 : a ≤ 1)
-    (he0 : sys.ge ∅ {(0 : Fin 2)} ↔ a ≤ 0)
-    (he1 : sys.ge ∅ {(1 : Fin 2)} ↔ 1 - a ≤ 0)
-    (h01 : sys.ge {(0 : Fin 2)} {1} ↔ a ≥ 1 - a)
-    (h10 : sys.ge {(1 : Fin 2)} {0} ↔ 1 - a ≥ a) :
+    (he0 : sys.le {(0 : Fin 2)} ∅ ↔ a ≤ 0)
+    (he1 : sys.le {(1 : Fin 2)} ∅ ↔ 1 - a ≤ 0)
+    (h01 : sys.le {(0 : Fin 2)} {1} ↔ a ≤ 1 - a)
+    (h10 : sys.le {(1 : Fin 2)} {0} ↔ 1 - a ≤ a) :
     ∀ C D : Set (Fin 2), Disjoint C D →
-      (sys.ge C D ↔ (measure_fin2 a ha ha1).inducedGe C D) := by
+      (sys.le C D ↔ measure_fin2 a ha ha1 C ≤ measure_fin2 a ha ha1 D) := by
   intro C D hCD
   have hme := (measure_fin2 a ha ha1).mu_empty
   have hm0 := mf2_zero a ha ha1
@@ -330,34 +331,29 @@ private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
   -- ∅ vs ∅
   · exact ⟨fun _ => le_refl _, fun _ => sys.refl _⟩
   -- ∅ vs {0}
-  · show sys.ge ∅ {0} ↔ _ ≥ _; rw [hme, hm0]; exact he0
+  · rw [hme, hm0]; exact ⟨fun _ => ha, fun _ => sys.mono (Set.empty_subset _)⟩
   -- ∅ vs {1}
-  · show sys.ge ∅ {1} ↔ _ ≥ _; rw [hme, hm1]
-    exact ⟨fun h => by linarith [he1.mp h], fun h => he1.mpr (by linarith)⟩
+  · rw [hme, hm1]; exact ⟨fun _ => by linarith, fun _ => sys.mono (Set.empty_subset _)⟩
   -- ∅ vs univ
-  · show sys.ge ∅ Set.univ ↔ _ ≥ _; rw [hme, hmu]
-    exact ⟨fun h => absurd h sys.nonTrivial, fun h => by linarith⟩
+  · rw [hme, hmu]; exact ⟨fun _ => by norm_num, fun _ => sys.mono (Set.empty_subset _)⟩
   -- {0} vs ∅
-  · show sys.ge {0} ∅ ↔ _ ≥ _; rw [hm0, hme]
-    exact ⟨fun _ => ha, fun _ => sys.mono (Set.empty_subset _)⟩
+  · rw [hm0, hme]; exact he0
   -- {0} vs {0}: not disjoint
   · exact (hdisj 0 rfl rfl).elim
   -- {0} vs {1}
-  · show sys.ge {0} {1} ↔ _ ≥ _; rw [hm0, hm1]; exact h01
+  · rw [hm0, hm1]; exact h01
   -- {0} vs univ: not disjoint
   · exact (hdisj 0 rfl (Set.mem_univ _)).elim
   -- {1} vs ∅
-  · show sys.ge {1} ∅ ↔ _ ≥ _; rw [hm1, hme]
-    exact ⟨fun _ => by linarith, fun _ => sys.mono (Set.empty_subset _)⟩
+  · rw [hm1, hme]; exact he1
   -- {1} vs {0}
-  · show sys.ge {1} {0} ↔ _ ≥ _; rw [hm1, hm0]; exact h10
+  · rw [hm1, hm0]; exact h10
   -- {1} vs {1}: not disjoint
   · exact (hdisj 1 rfl rfl).elim
   -- {1} vs univ: not disjoint
   · exact (hdisj 1 rfl (Set.mem_univ _)).elim
   -- univ vs ∅
-  · show sys.ge Set.univ ∅ ↔ _ ≥ _; rw [hmu, hme]
-    exact ⟨fun _ => by linarith, fun _ => sys.mono (Set.empty_subset _)⟩
+  · rw [hmu, hme]; exact ⟨fun h => absurd h sys.nonTrivial, fun h => by linarith⟩
   -- univ vs {0}: not disjoint
   · exact (hdisj 0 (Set.mem_univ _) rfl).elim
   -- univ vs {1}: not disjoint
@@ -367,125 +363,125 @@ private theorem fin2_dispatch (sys : QualitativeProbability (Fin 2))
 
 -- ── Card 2: Main theorem ───────────────────────────
 
-theorem representable_fin2 (sys : QualitativeProbability (Fin 2)) : Representable sys := by
-  by_cases h_null0 : sys.ge ∅ {(0 : Fin 2)}
-  · -- Case 1: ge ∅ {0} → a = 0
-    have h_nnull1 : ¬sys.ge ∅ {(1 : Fin 2)} := fun h => not_both_null_fin2 sys ⟨h_null0, h⟩
-    have h_nge01 : ¬sys.ge {(0 : Fin 2)} {1} :=
-      fun h => not_both_null_fin2 sys ⟨h_null0, sys.trans h_null0 h⟩
-    have h_ge10 : sys.ge {(1 : Fin 2)} {0} :=
-      (sys.total {(1 : Fin 2)} {0}).resolve_right h_nge01
+theorem representable_fin2 (sys : QualitativeProbability (Set (Fin 2))) : Representable sys := by
+  by_cases h_null0 : sys.le {(0 : Fin 2)} ∅
+  · -- Case 1: atom 0 null → a = 0
+    have h_nnull1 : ¬sys.le {(1 : Fin 2)} ∅ := fun h => not_both_null_fin2 sys ⟨h_null0, h⟩
+    have h_n10 : ¬sys.le {(1 : Fin 2)} {0} :=
+      fun h => not_both_null_fin2 sys ⟨h_null0, sys.trans h h_null0⟩
+    have h_01 : sys.le {(0 : Fin 2)} {1} :=
+      (sys.total {(0 : Fin 2)} {1}).resolve_right h_n10
     refine ⟨measure_fin2 0 le_rfl zero_le_one,
       reduce_to_disjoint sys _ (fin2_dispatch sys 0 le_rfl zero_le_one
-                ⟨fun _ => le_refl _, fun _ => h_null0⟩
+        ⟨fun _ => le_refl _, fun _ => h_null0⟩
         ⟨fun h => absurd h h_nnull1, fun h => by linarith⟩
-        ⟨fun h => absurd h h_nge01, fun h => by linarith⟩
-        ⟨fun _ => by linarith, fun _ => h_ge10⟩)⟩
-  · by_cases h_null1 : sys.ge ∅ {(1 : Fin 2)}
-    · -- Case 2: ge ∅ {1} → a = 1
-      have h_nge10 : ¬sys.ge {(1 : Fin 2)} {0} :=
-        fun h => not_both_null_fin2 sys ⟨sys.trans h_null1 h, h_null1⟩
-      have h_ge01 : sys.ge {(0 : Fin 2)} {1} :=
-        (sys.total {(0 : Fin 2)} {1}).resolve_right h_nge10
+        ⟨fun _ => by linarith, fun _ => h_01⟩
+        ⟨fun h => absurd h h_n10, fun h => by linarith⟩)⟩
+  · by_cases h_null1 : sys.le {(1 : Fin 2)} ∅
+    · -- Case 2: atom 1 null → a = 1
+      have h_n01 : ¬sys.le {(0 : Fin 2)} {1} :=
+        fun h => not_both_null_fin2 sys ⟨sys.trans h h_null1, h_null1⟩
+      have h_10 : sys.le {(1 : Fin 2)} {0} :=
+        (sys.total {(1 : Fin 2)} {0}).resolve_right h_n01
       refine ⟨measure_fin2 1 zero_le_one le_rfl,
         reduce_to_disjoint sys _ (fin2_dispatch sys 1 zero_le_one le_rfl
-                    ⟨fun h => absurd h h_null0, fun h => by linarith⟩
+          ⟨fun h => absurd h h_null0, fun h => by linarith⟩
           ⟨fun _ => by linarith, fun _ => h_null1⟩
-          ⟨fun _ => by linarith, fun _ => h_ge01⟩
-          ⟨fun h => absurd h h_nge10, fun h => by linarith⟩)⟩
+          ⟨fun h => absurd h h_n01, fun h => by linarith⟩
+          ⟨fun _ => by linarith, fun _ => h_10⟩)⟩
     · -- Neither null: both singletons are "positive"
-      by_cases h01 : sys.ge {(0 : Fin 2)} {1}
-      · by_cases h10 : sys.ge {(1 : Fin 2)} {0}
-        · -- Case 3c: ge {0} {1} ∧ ge {1} {0} → a = 1/2
+      by_cases h01 : sys.le {(0 : Fin 2)} {1}
+      · by_cases h10 : sys.le {(1 : Fin 2)} {0}
+        · -- Case 3c: {0} ≈ {1} → a = 1/2
           refine ⟨measure_fin2 (1/2) (by linarith) (by linarith),
             reduce_to_disjoint sys _ (fin2_dispatch sys (1/2) (by linarith) (by linarith)
-                            ⟨fun h => absurd h h_null0, fun h => by linarith⟩
+              ⟨fun h => absurd h h_null0, fun h => by linarith⟩
               ⟨fun h => absurd h h_null1, fun h => by linarith⟩
               ⟨fun _ => by linarith, fun _ => h01⟩
               ⟨fun _ => by linarith, fun _ => h10⟩)⟩
-        · -- Case 3a: ge {0} {1} ∧ ¬ge {1} {0} → a = 2/3
-          refine ⟨measure_fin2 (2/3) (by linarith) (by linarith),
-            reduce_to_disjoint sys _ (fin2_dispatch sys (2/3) (by linarith) (by linarith)
-                            ⟨fun h => absurd h h_null0, fun h => by linarith⟩
+        · -- Case 3a: {0} ≺ {1} → a = 1/3
+          refine ⟨measure_fin2 (1/3) (by linarith) (by linarith),
+            reduce_to_disjoint sys _ (fin2_dispatch sys (1/3) (by linarith) (by linarith)
+              ⟨fun h => absurd h h_null0, fun h => by linarith⟩
               ⟨fun h => absurd h h_null1, fun h => by linarith⟩
               ⟨fun _ => by linarith, fun _ => h01⟩
               ⟨fun h => absurd h h10, fun h => by linarith⟩)⟩
-      · -- Case 3b: ¬ge {0} {1} → ge {1} {0} (totality), a = 1/3
-        have h10 : sys.ge {(1 : Fin 2)} {0} :=
+      · -- Case 3b: ¬({0} ≼ {1}) → {1} ≺ {0} (totality), a = 2/3
+        have h10 : sys.le {(1 : Fin 2)} {0} :=
           (sys.total {(1 : Fin 2)} {0}).resolve_right h01
-        refine ⟨measure_fin2 (1/3) (by linarith) (by linarith),
-          reduce_to_disjoint sys _ (fin2_dispatch sys (1/3) (by linarith) (by linarith)
-                        ⟨fun h => absurd h h_null0, fun h => by linarith⟩
+        refine ⟨measure_fin2 (2/3) (by linarith) (by linarith),
+          reduce_to_disjoint sys _ (fin2_dispatch sys (2/3) (by linarith) (by linarith)
+            ⟨fun h => absurd h h_null0, fun h => by linarith⟩
             ⟨fun h => absurd h h_null1, fun h => by linarith⟩
             ⟨fun h => absurd h h01, fun h => by linarith⟩
             ⟨fun _ => by linarith, fun _ => h10⟩)⟩
 
 -- ── Transport + Permutation infrastructure ────────────
 
-/-- Transport an FA system along an equivalence of carriers. -/
+/-- Transport a qualitative probability order along an equivalence of carriers. -/
 def QualitativeProbability.transport {W α : Type*} (e : W ≃ α)
-    (sys : QualitativeProbability W) : QualitativeProbability α :=
+    (sys : QualitativeProbability (Set W)) : QualitativeProbability (Set α) :=
   sys.comap e.symm e.symm.injective
-    (by rw [Equiv.range_eq_univ]; exact sys.nonTrivial)
+    (by rw [Equiv.range_eq_univ, ← Set.top_eq_univ, ← Set.bot_eq_empty]; exact sys.nonTrivial)
 
 theorem transfer_repr {W α : Type*}
-    (e : W ≃ α) (sys : QualitativeProbability W) (m : FinAddMeasure ℚ α)
-    (hm : ∀ A B : Set α, (sys.transport e).ge A B ↔ m.inducedGe A B) :
-    ∀ A B : Set W, sys.ge A B ↔ (m.map e.symm).inducedGe A B := by
+    (e : W ≃ α) (sys : QualitativeProbability (Set W)) (m : FinAddMeasure ℚ α)
+    (hm : ∀ A B : Set α, (sys.transport e).le A B ↔ m A ≤ m B) :
+    ∀ A B : Set W, sys.le A B ↔ m.map e.symm A ≤ m.map e.symm B := by
   intro A B
   have h := hm (e '' A) (e '' B)
   simp only [QualitativeProbability.transport, QualitativeProbability.comap,
     Equiv.symm_image_image] at h
-  simpa only [FinAddMeasure.inducedGe, FinAddMeasure.map_apply,
-    ← Equiv.image_eq_preimage_symm] using h
+  simpa only [FinAddMeasure.map_apply, ← Equiv.image_eq_preimage_symm] using h
 
 /-- Null pattern transport: `j` is null in `sys.transport σ` iff `σ.symm j` is
     null in `sys`. -/
 theorem perm_null_iff {n : ℕ} (σ : Fin n ≃ Fin n)
-    (sys : QualitativeProbability (Fin n)) (j : Fin n) :
-    (sys.transport σ).ge ∅ {j} ↔ sys.ge ∅ {σ.symm j} := by
-  show sys.ge (σ.symm '' ∅) (σ.symm '' {j}) ↔ sys.ge ∅ {σ.symm j}
+    (sys : QualitativeProbability (Set (Fin n))) (j : Fin n) :
+    (sys.transport σ).le {j} ∅ ↔ sys.le {σ.symm j} ∅ := by
+  show sys.le (σ.symm '' {j}) (σ.symm '' ∅) ↔ sys.le {σ.symm j} ∅
   simp only [Set.image_empty, Set.image_singleton]
 
 /-- Representability transports backward along any equivalence. -/
-theorem perm_repr {W α : Type*} (σ : W ≃ α) (sys : QualitativeProbability W)
+theorem perm_repr {W α : Type*} (σ : W ≃ α) (sys : QualitativeProbability (Set W))
     (h : Representable (sys.transport σ)) : Representable sys := by
   obtain ⟨m, hm⟩ := h
   exact ⟨m.map σ.symm, transfer_repr σ sys m hm⟩
 
 -- ── Null-atom padding: Theorem 8b at every cardinality ≥ 5 ──
 
-/-- Pad an FA system with one null atom: comparisons on `Fin (n + 1)` are decided
+/-- Pad an order with one null atom: comparisons on `Fin (n + 1)` are decided
     by the preimage restriction to the first `n` atoms. -/
-def QualitativeProbability.pad {n : ℕ} (sys : QualitativeProbability (Fin n)) :
-    QualitativeProbability (Fin (n + 1)) where
-  ge A B := sys.ge (Fin.castSucc ⁻¹' A) (Fin.castSucc ⁻¹' B)
+def QualitativeProbability.pad {n : ℕ} (sys : QualitativeProbability (Set (Fin n))) :
+    QualitativeProbability (Set (Fin (n + 1))) where
+  le A B := sys.le (Fin.castSucc ⁻¹' A) (Fin.castSucc ⁻¹' B)
   mono' _ _ hAB := sys.mono (Set.preimage_mono hAB)
   nonTrivial := by
-    show ¬sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' Set.univ)
-    rw [Set.preimage_univ, Set.preimage_empty]; exact sys.nonTrivial
+    show ¬sys.le (Fin.castSucc ⁻¹' Set.univ) (Fin.castSucc ⁻¹' ∅)
+    rw [Set.preimage_univ, Set.preimage_empty, ← Set.top_eq_univ, ← Set.bot_eq_empty]
+    exact sys.nonTrivial
   total _ _ := sys.total _ _
   trans' _ _ _ h1 h2 := sys.trans h1 h2
   additive A B := by
-    show sys.ge _ _ ↔ sys.ge _ _
+    show sys.le _ _ ↔ sys.le _ _
     rw [Set.preimage_sdiff, Set.preimage_sdiff]; exact sys.additive _ _
 
 /-- The padded atom is null. -/
-theorem QualitativeProbability.pad_last_null {n : ℕ} (sys : QualitativeProbability (Fin n)) :
-    sys.pad.ge ∅ {Fin.last n} := by
-  show sys.ge (Fin.castSucc ⁻¹' ∅) (Fin.castSucc ⁻¹' {Fin.last n})
+theorem QualitativeProbability.pad_last_null {n : ℕ}
+    (sys : QualitativeProbability (Set (Fin n))) : sys.pad.le {Fin.last n} ∅ := by
+  show sys.le (Fin.castSucc ⁻¹' {Fin.last n}) (Fin.castSucc ⁻¹' ∅)
   rw [Set.preimage_empty, show Fin.castSucc ⁻¹' {Fin.last n} = (∅ : Set (Fin n)) from
     Set.eq_empty_of_forall_notMem fun i hi => (Fin.castSucc_lt_last i).ne hi]; exact sys.refl ∅
 
 /-- Padding reflects representability: a measure for `sys.pad` assigns the
     padded atom measure zero, so its `Fin.castSucc`-image restriction represents
     `sys`. -/
-theorem representable_of_pad {n : ℕ} {sys : QualitativeProbability (Fin n)}
+theorem representable_of_pad {n : ℕ} {sys : QualitativeProbability (Set (Fin n))}
     (h : Representable sys.pad) : Representable sys := by
   obtain ⟨m, hm⟩ := h
   have hinj := Fin.castSucc_injective n
   have hlast : m {Fin.last n} = 0 := by
-    have h0 : m ∅ ≥ m {Fin.last n} := (hm _ _).mp sys.pad_last_null
+    have h0 : m {Fin.last n} ≤ m ∅ := (hm _ _).mp sys.pad_last_null
     rw [m.mu_empty] at h0; linarith [m.nonneg {Fin.last n}]
   have hcover : Fin.castSucc '' (Set.univ : Set (Fin n)) ∪ {Fin.last n} = Set.univ := by
     rw [Set.image_univ]
@@ -507,14 +503,14 @@ theorem representable_of_pad {n : ℕ} {sys : QualitativeProbability (Fin n)}
     total' := htotal
   }, fun A B => ?_⟩
   have key := hm (Fin.castSucc '' A) (Fin.castSucc '' B)
-  rwa [show sys.pad.ge (Fin.castSucc '' A) (Fin.castSucc '' B) ↔ sys.ge A B from by
-    show sys.ge (Fin.castSucc ⁻¹' (Fin.castSucc '' A)) _ ↔ _
+  rwa [show sys.pad.le (Fin.castSucc '' A) (Fin.castSucc '' B) ↔ sys.le A B from by
+    show sys.le (Fin.castSucc ⁻¹' (Fin.castSucc '' A)) _ ↔ _
     rw [Set.preimage_image_eq A hinj, Set.preimage_image_eq B hinj]] at key
 
 /-- **Theorem 8b at every cardinality**: for `n ≥ 5` there is a non-representable
     FA system on `Fin n` — the KPS counterexample, padded with null atoms. -/
 theorem exists_nonrepresentable_fin {n : ℕ} (h : 5 ≤ n) :
-    ∃ sys : QualitativeProbability (Fin n), ¬Representable sys := by
+    ∃ sys : QualitativeProbability (Set (Fin n)), ¬Representable sys := by
   induction n, h using Nat.le_induction with
   | base => exact ⟨kpsSystem, kps_not_representable⟩
   | succ n _ ih =>

--- a/Linglib/Logic/ComparativeProbability/Systems.lean
+++ b/Linglib/Logic/ComparativeProbability/Systems.lean
@@ -15,7 +15,8 @@ qualitatively-additive measure semantics, and the two world-ordering lifts.
 
 * `RightUnion`, `DeterminedBySingletons` — the two likelihood axioms with no
   mathlib/`Defs` analog (the rest are the `Defs.lean` mixins).
-* `QualitativeProbability` — the bundled qualitative probability order,
+* `QualitativeProbability` — the bundled qualitative probability order on a
+  Boolean algebra (`le`-primitive; `ge` is the paper-facing `≿`), on `Set W`
   [holliday-icard-2013]'s logic FA.
 * `FinAddMeasure`/`QualAddMeasure` — finitely- and qualitatively-additive
   probability measures over an ordered field, with their induced orders.
@@ -31,10 +32,13 @@ qualitatively-additive measure semantics, and the two world-ordering lifts.
 
 ## Implementation notes
 
-Reflexivity and `Ω ≿ ∅` are consequences of monotonicity, not fields
-(`QualitativeProbability.refl`/`univ_ge_empty`). Sub-FA hypotheses (the
-completeness theorems for weaker logics) are stated on a bare relation with
-explicit monotonicity/transitivity hypotheses, not on a weaker bundle.
+The order is stored as `le` and stated in `≤`-vocabulary, mathlib's
+convention; the literature's `≿` is the derived `ge`, and it is `ge` that
+carries the pattern-layer mixin instances (the `Defs.lean` classes are
+`≿`-calibrated, as are the papers). Reflexivity and `⊥ ≼ a` are consequences
+of monotonicity, not fields. Sub-FA hypotheses (the completeness theorems for
+weaker logics) are stated on a bare relation with explicit
+monotonicity/transitivity hypotheses, not on a weaker bundle.
 
 The measures are generic over an ordered field `K`: `ℝ` gives the paper's literal
 `[0,1]`-valued measures, `ℚ` the computable theory. On a finite state space the
@@ -82,118 +86,111 @@ end Axioms
 
 /-! ### Qualitative probability orders
 
-Fields hold the bare propositions; the matching `Defs.lean` mixin instances
-are below. -/
+The relation is stored as `le` (`a ≼ b`: `a` is at most as likely as `b`),
+mathlib's convention; the paper-facing converse `≿` is `ge`, mathlib's `GE.ge`
+pattern, and it is `ge` that carries the `Defs.lean` mixin instances. -/
 
-/-- A **qualitative probability** order on `Set W`: total, transitive, monotone,
-non-trivial, and qualitatively additive — the standard base system for
-comparative probability since de Finetti, and [holliday-icard-2013]'s logic FA.
-Sound and complete for qualitatively additive measure semantics (Theorem 6;
-[van-der-hoek-1996]), and strictly weaker than finite additivity for `|W| ≥ 5`
-(Theorem 8, after [kraft-pratt-seidenberg-1959]). Reflexivity and `Ω ≿ ∅` are
-consequences of monotonicity (`refl`, `univ_ge_empty`), not fields. -/
-structure QualitativeProbability (W : Type*) where
-  /-- The "at least as likely as" relation on propositions. -/
-  ge : Set W → Set W → Prop
-  /-- Monotonicity: supersets are at least as likely. Use the lemma `mono`. -/
-  mono' : ∀ A B : Set W, A ⊆ B → ge B A
-  /-- Non-triviality: excludes the degenerate all-equivalent order. -/
-  nonTrivial : ¬ ge ∅ Set.univ
-  /-- Totality: any two propositions are comparable. -/
-  total : ∀ A B : Set W, ge A B ∨ ge B A
+/-- A **qualitative probability** order on a Boolean algebra `α`: total,
+transitive, monotone, non-trivial, and qualitatively additive — the standard
+base system for comparative probability since de Finetti, and, on `Set W`,
+[holliday-icard-2013]'s logic FA. Sound and complete for qualitatively additive
+measure semantics (Theorem 6; [van-der-hoek-1996]), and strictly weaker than
+finite additivity for `|W| ≥ 5` (Theorem 8, after [kraft-pratt-seidenberg-1959]).
+Reflexivity and `⊥ ≼ a` are consequences of monotonicity (`refl`, `bot_le`), not
+fields. -/
+structure QualitativeProbability (α : Type*) [BooleanAlgebra α] where
+  /-- The "at most as likely as" relation. -/
+  le : α → α → Prop
+  /-- Monotonicity: `a ≤ b → a ≼ b`. Use the lemma `mono`. -/
+  mono' : ∀ a b : α, a ≤ b → le a b
+  /-- Non-triviality: `⊤` is not at most as likely as `⊥`. -/
+  nonTrivial : ¬ le ⊤ ⊥
+  /-- Totality: any two elements are comparable. -/
+  total : ∀ a b : α, le a b ∨ le b a
   /-- Transitivity. Use the lemma `trans`. -/
-  trans' : ∀ A B C : Set W, ge A B → ge B C → ge A C
-  /-- Qualitative additivity: `A ≿ B ↔ (A \ B) ≿ (B \ A)`. -/
-  additive : ∀ A B : Set W, ge A B ↔ ge (A \ B) (B \ A)
+  trans' : ∀ a b c : α, le a b → le b c → le a c
+  /-- Qualitative additivity: `a ≼ b ↔ a \ b ≼ b \ a`. -/
+  additive : ∀ a b : α, le a b ↔ le (a \ b) (b \ a)
 
 namespace QualitativeProbability
 
-variable {W : Type*} (sys : QualitativeProbability W)
+variable {α : Type*} [BooleanAlgebra α] (sys : QualitativeProbability α)
 
-/-- Monotonicity: supersets are at least as likely. -/
-theorem mono {A B : Set W} (h : A ⊆ B) : sys.ge B A := sys.mono' A B h
+/-- `sys.ge a b` (`a ≿ b`): `a` is at least as likely as `b` — the converse of
+`le`, mathlib's `GE.ge` pattern. This is the relation the `Defs.lean` mixins,
+the pattern layer, and the paper-facing studies consume. -/
+def ge (a b : α) : Prop := sys.le b a
+
+@[inherit_doc le] scoped notation:50 a:51 " ≼[" sys "] " b:51 => QualitativeProbability.le sys a b
+@[inherit_doc ge] scoped notation:50 a:51 " ≿[" sys "] " b:51 => QualitativeProbability.ge sys a b
+
+@[simp] theorem ge_iff_le {a b : α} : sys.ge a b ↔ sys.le b a := Iff.rfl
+
+/-- Monotonicity. -/
+theorem mono {a b : α} (h : a ≤ b) : sys.le a b := sys.mono' a b h
 
 /-- Transitivity. -/
-theorem trans {A B C : Set W} (hab : sys.ge A B) (hbc : sys.ge B C) : sys.ge A C :=
-  sys.trans' A B C hab hbc
+theorem trans {a b c : α} (hab : sys.le a b) (hbc : sys.le b c) : sys.le a c :=
+  sys.trans' a b c hab hbc
 
 /-- Reflexivity, from monotonicity. -/
-theorem refl (A : Set W) : sys.ge A A := sys.mono subset_rfl
+theorem refl (a : α) : sys.le a a := sys.mono le_rfl
 
-/-- The tautology is at least as likely as the contradiction. -/
-theorem univ_ge_empty : sys.ge Set.univ ∅ := sys.mono (Set.empty_subset _)
+protected theorem bot_le (a : α) : sys.le ⊥ a := sys.mono bot_le
+
+protected theorem le_top (a : α) : sys.le a ⊤ := sys.mono le_top
+
+/-! #### Consequences of the axioms -/
+
+/-- Disjoint common context cancels: `a ⊔ c ≼ b ⊔ c ↔ a ≼ b` for `c` disjoint
+    from both. -/
+theorem sup_le_sup_iff_right {a b c : α} (hca : Disjoint c a) (hcb : Disjoint c b) :
+    sys.le (a ⊔ c) (b ⊔ c) ↔ sys.le a b := by
+  rw [sys.additive a b, sys.additive (a ⊔ c) (b ⊔ c), sup_comm b c, ← sdiff_sdiff_left,
+    sup_sdiff_right_self, sdiff_eq_left.mpr hca.symm, sup_comm a c, ← sdiff_sdiff_left,
+    sup_sdiff_left_self, sdiff_eq_left.mpr hcb.symm]
+
+theorem sup_le_sup_right {a b c : α} (h : sys.le a b) (hca : Disjoint c a)
+    (hcb : Disjoint c b) : sys.le (a ⊔ c) (b ⊔ c) :=
+  (sys.sup_le_sup_iff_right hca hcb).mpr h
+
+/-- Two comparisons with disjoint left parts and disjoint right parts merge
+    into their joins, even with cross overlaps: add context to each side,
+    transit through `b₁ ⊔ a₂`, then restore the pivot `a₂ ⊓ b₁` by additivity. -/
+theorem sup_le_sup {a₁ b₁ a₂ b₂ : α} (h₁ : sys.le a₁ b₁) (h₂ : sys.le a₂ b₂)
+    (ha : Disjoint a₁ a₂) (hb : Disjoint b₁ b₂) : sys.le (a₁ ⊔ a₂) (b₁ ⊔ b₂) := by
+  have e₁ : (a₂ ⊔ a₁ \ b₂) ⊔ a₁ ⊓ b₂ = a₁ ⊔ a₂ := by
+    rw [sup_assoc, sup_comm (a₁ \ b₂), sup_inf_sdiff, sup_comm]
+  have e₂ : (b₁ ⊔ b₂ \ a₁) ⊔ a₁ ⊓ b₂ = b₁ ⊔ b₂ := by
+    rw [sup_assoc, inf_comm a₁, sup_comm (b₂ \ a₁), sup_inf_sdiff]
+  rw [← e₁, ← e₂]
+  refine sys.sup_le_sup_right (sys.trans (b := b₂ ⊔ a₁) ?_ ?_)
+    ((ha.mono_left inf_le_left).sup_right (disjoint_sdiff_self_right.mono_left inf_le_right))
+    ((hb.symm.mono_left inf_le_right).sup_right (disjoint_sdiff_self_right.mono_left inf_le_left))
+  · have h := sys.sup_le_sup_right h₂ (ha.mono_left sdiff_le) disjoint_sdiff_self_left
+    rwa [sup_sdiff_self_right] at h
+  · have h := sys.sup_le_sup_right h₁ disjoint_sdiff_self_left (hb.symm.mono_left sdiff_le)
+    rwa [sup_sdiff_self_right, sup_comm a₁ b₂] at h
 
 end QualitativeProbability
 
-/-! ### FA systems carry the comparative-probability mixins
+/-! ### The mixin instances
 
-An FA system's fields are defeq the `Defs.lean` mixin classes (`a ≤ b` is `a ⊆ b`
-on `Set W`), so the instances below register its relation as a comparative-
-probability order, and the validity patterns V1–V13 transfer from
-`ComparativeProbability.Patterns` by instance resolution. -/
-
-section
-
-variable {W : Type*} (sys : QualitativeProbability W)
-
-instance : ComparativeProbability.IsLikelihoodMono sys.ge := ⟨sys.mono'⟩
-
-instance : IsTrans (Set W) sys.ge := ⟨sys.trans'⟩
-
-instance : ComparativeProbability.IsQualitativeAdditive sys.ge := ⟨sys.additive⟩
-
-instance : ComparativeProbability.IsNontrivial sys.ge := ⟨sys.nonTrivial⟩
-
-end
-
-/-! ### Consequences of the FA axioms -/
+`ge` is defeq the `Defs.lean` mixin classes' relation, so the instances below
+register it as a comparative-probability order, and the validity patterns
+V1–V13 transfer from `ComparativeProbability.Patterns` by instance resolution. -/
 
 section
-variable {W : Type*} (sys : QualitativeProbability W)
 
-/-- **Add common context**: for `C` disjoint from both `X` and `Y`,
-    `X ≿ Y ↔ (X ∪ C) ≿ (Y ∪ C)`. -/
-lemma ge_union_context (X Y C : Set W)
-    (hCX : Disjoint C X := by grind) (hCY : Disjoint C Y := by grind) :
-    sys.ge X Y ↔ sys.ge (X ∪ C) (Y ∪ C) := by
-  rw [sys.additive X Y, sys.additive (X ∪ C) (Y ∪ C)]
-  congr! 1 <;> grind
+variable {α : Type*} [BooleanAlgebra α] (sys : QualitativeProbability α)
 
-/-- Forward form of `ge_union_context`: context `C` disjoint from both sides
-    preserves `≿`. -/
-lemma ge_add_context {X Y C : Set W} (h : sys.ge X Y)
-    (hCX : Disjoint C X := by grind) (hCY : Disjoint C Y := by grind) :
-    sys.ge (X ∪ C) (Y ∪ C) :=
-  (ge_union_context sys X Y C hCX hCY).mp h
+instance : IsLikelihoodMono sys.ge := ⟨sys.mono'⟩
 
-/-- **Generalized merge**: two valid comparisons with disjoint left parts and
-    disjoint right parts merge into their union, even with pivot overlaps.
-    Derivation: add context to each side, transit through `X₂ ∪ Y₁`, then
-    restore the pivot `X₂ ∩ Y₁` via Axiom A. -/
-lemma ge_generalized_merge {X₁ Y₁ X₂ Y₂ : Set W}
-    (h1 : sys.ge X₁ Y₁) (h2 : sys.ge X₂ Y₂)
-    (hX : Disjoint X₁ X₂) (hY : Disjoint Y₁ Y₂) :
-    sys.ge (X₁ ∪ X₂) (Y₁ ∪ Y₂) := by
-  -- split each side around the pivot `X₂ ∩ Y₁`
-  rw [show X₁ ∪ X₂ = (X₁ ∪ (X₂ \ Y₁)) ∪ (X₂ ∩ Y₁) by grind,
-    show Y₁ ∪ Y₂ = (Y₂ ∪ (Y₁ \ X₂)) ∪ (X₂ ∩ Y₁) by grind]
-  -- the pivot is common context; strip it, then transit through `X₂ ∪ Y₁`
-  refine ge_add_context sys ?_
-  refine sys.trans (B := X₂ ∪ Y₁) ?_ ?_
-  · rw [show X₂ ∪ Y₁ = Y₁ ∪ (X₂ \ Y₁) by grind]
-    exact ge_add_context sys h1
-  · rw [show X₂ ∪ Y₁ = X₂ ∪ (Y₁ \ X₂) by grind]
-    exact ge_add_context sys h2
+instance : IsTrans α sys.ge := ⟨fun _ _ _ hab hbc => sys.trans hbc hab⟩
 
-/-- **Mono-domination**: a valid comparison `X ≿ Y` with `X ⊆ P` and `Q ⊆ Y`
-    proves `P ≿ Q`. -/
-lemma ge_mono_dominated {X Y P Q : Set W} (h : sys.ge X Y) (hXP : X ⊆ P) (hQY : Q ⊆ Y) :
-    sys.ge P Q :=
-  sys.trans (sys.mono hXP) (sys.trans h (sys.mono hQY))
+instance : IsQualitativeAdditive sys.ge := ⟨fun a b => sys.additive b a⟩
 
-/-- `P ≿ ∅` always (monotonicity). -/
-lemma ge_empty_target (P : Set W) : sys.ge P ∅ :=
-  sys.mono (Set.empty_subset P)
+instance : IsNontrivial sys.ge := ⟨sys.nonTrivial⟩
 
 end
 
@@ -239,7 +236,9 @@ theorem additive (m : FinAddMeasure K W) {A B : Set W} (h : Disjoint A B) :
 
 @[simp] theorem total (m : FinAddMeasure K W) : m Set.univ = 1 := m.total'
 
-/-- Measure-induced comparative likelihood: A ≿ B ↔ μ(A) ≥ μ(B). -/
+/-- Measure-induced comparative likelihood `A ≿ B ↔ μ(A) ≥ μ(B)` — the
+    paper-facing converse relation (`QualitativeProbability.ge`) that the pattern
+    layer consumes; the order itself is `toQualitativeProbability`. -/
 def inducedGe (m : FinAddMeasure K W) (A B : Set W) : Prop := m A ≥ m B
 
 /-- μ(∅) = 0 for any finitely additive measure.
@@ -263,7 +262,7 @@ theorem mu_compl (m : FinAddMeasure K W) (A : Set W) :
 /-- Qualitative additivity for a finitely additive measure: splitting `A` and `B`
     into the shared part `A ∩ B` and the private parts cancels the shared part. -/
 theorem mu_qadd (m : FinAddMeasure K W) (A B : Set W) :
-    m A ≥ m B ↔ m (A \ B) ≥ m (B \ A) := by
+    m A ≤ m B ↔ m (A \ B) ≤ m (B \ A) := by
   have key : ∀ X Y : Set W, m X = m (X \ Y) + m (X ∩ Y) := fun X Y => by
     conv_lhs => rw [(Set.sdiff_union_inter X Y).symm]
     exact m.additive (Set.disjoint_left.mpr fun _ hx hy => hx.2 hy.2)
@@ -335,7 +334,7 @@ structure QualAddMeasure (K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedR
   /-- Normalization. Use the lemma `total`. -/
   total' : toFun Set.univ = 1
   /-- Qualitative additivity. Use the lemma `qualAdd`. -/
-  qualAdd' : ∀ A B, toFun A ≥ toFun B ↔ toFun (A \ B) ≥ toFun (B \ A)
+  qualAdd' : ∀ A B, toFun A ≤ toFun B ↔ toFun (A \ B) ≤ toFun (B \ A)
 
 namespace QualAddMeasure
 
@@ -354,29 +353,28 @@ theorem nonneg (m : QualAddMeasure K W) (A : Set W) : 0 ≤ m A := m.nonneg' A
 
 @[simp] theorem total (m : QualAddMeasure K W) : m Set.univ = 1 := m.total'
 
-/-- Qualitative additivity: `μ(A) ≥ μ(B) ↔ μ(A ∖ B) ≥ μ(B ∖ A)`. -/
+/-- Qualitative additivity: `μ(A) ≤ μ(B) ↔ μ(A ∖ B) ≤ μ(B ∖ A)`. -/
 theorem qualAdd (m : QualAddMeasure K W) (A B : Set W) :
-    m A ≥ m B ↔ m (A \ B) ≥ m (B \ A) := m.qualAdd' A B
+    m A ≤ m B ↔ m (A \ B) ≤ m (B \ A) := m.qualAdd' A B
 
-/-- Measure-induced comparative likelihood: A ≿ B ↔ μ(A) ≥ μ(B). -/
+/-- Measure-induced comparative likelihood `A ≿ B ↔ μ(A) ≥ μ(B)` (the
+    paper-facing converse; see `FinAddMeasure.inducedGe`). -/
 def inducedGe (m : QualAddMeasure K W) (A B : Set W) : Prop := m A ≥ m B
 
 /-- Subset monotonicity: `A ⊆ B → μ(A) ≤ μ(B)`. From qualAdd + μ(∅) = 0 + nonneg. -/
 theorem mu_mono (m : QualAddMeasure K W) {A B : Set W} (h : A ⊆ B) :
     m A ≤ m B := by
-  show m B ≥ m A
-  rw [m.qualAdd B A, Set.sdiff_eq_empty.mpr h, m.mu_empty]; exact m.nonneg (B \ A)
+  rw [m.qualAdd A B, Set.sdiff_eq_empty.mpr h, m.mu_empty]; exact m.nonneg (B \ A)
 
-/-- A qualitatively additive measure induces System FA.
-    Soundness direction of [holliday-icard-2013] Theorem 6:
-    every qualitatively additive measure model satisfies the FA axioms. -/
+/-- A qualitatively additive measure induces a qualitative probability order —
+    the soundness direction of [holliday-icard-2013] Theorem 6. -/
 def toQualitativeProbability (m : QualAddMeasure K W) :
-    QualitativeProbability W where
-  ge := m.inducedGe
+    QualitativeProbability (Set W) where
+  le A B := m A ≤ m B
   mono' := fun _ _ h => m.mu_mono h
-  nonTrivial := by simp only [inducedGe, m.mu_empty, m.total, not_le]; exact one_pos
-  total := fun A B => le_total (m B) (m A)
-  trans' := fun _ _ _ hab hbc => le_trans hbc hab
+  nonTrivial := by simp
+  total := fun A B => le_total (m A) (m B)
+  trans' := fun _ _ _ hab hbc => le_trans hab hbc
   additive := m.qualAdd
 
 end QualAddMeasure
@@ -398,7 +396,8 @@ def FinAddMeasure.toQualAdd (m : FinAddMeasure K W) : QualAddMeasure K W where
 /-- Every finitely additive measure satisfies the FA axioms, through
     `toQualAdd`. A fortiori from [holliday-icard-2013] Theorem 6 soundness,
     since every finitely additive measure is qualitatively additive. -/
-def FinAddMeasure.toQualitativeProbability (m : FinAddMeasure K W) : QualitativeProbability W :=
+def FinAddMeasure.toQualitativeProbability (m : FinAddMeasure K W) :
+    QualitativeProbability (Set W) :=
   m.toQualAdd.toQualitativeProbability
 
 end
@@ -469,10 +468,11 @@ variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {W : Type
 instance : ComparativeProbability.IsLikelihoodMono m.inducedGe :=
   ⟨m.toQualitativeProbability.mono'⟩
 
-instance : IsTrans (Set W) m.inducedGe := ⟨m.toQualitativeProbability.trans'⟩
+instance : IsTrans (Set W) m.inducedGe :=
+  ⟨fun _ _ _ hab hbc => m.toQualitativeProbability.trans hbc hab⟩
 
 instance : ComparativeProbability.IsQualitativeAdditive m.inducedGe :=
-  ⟨m.toQualitativeProbability.additive⟩
+  ⟨fun A B => m.toQualitativeProbability.additive B A⟩
 
 instance : ComparativeProbability.IsNontrivial m.inducedGe :=
   ⟨m.toQualitativeProbability.nonTrivial⟩

--- a/Linglib/Studies/HollidayIcard2013.lean
+++ b/Linglib/Studies/HollidayIcard2013.lean
@@ -37,7 +37,8 @@ See also [yalcin-2010] for the inference-pattern inventory V1–V13/I1–I3 and
 
 namespace HollidayIcard2013
 
-open ComparativeProbability ComparativeProbability
+open ComparativeProbability
+open scoped ComparativeProbability.QualitativeProbability
 
 /-! ### Fact 1: the disjunction problem -/
 
@@ -91,16 +92,17 @@ theorem mLift_refutes_I_patterns :
 
 /-- **Theorem 6** ([van-der-hoek-1996]): every FA system is represented by a
     qualitatively additive measure. -/
-theorem fa_qualAdd_complete {W : Type*} [Fintype W] (sys : QualitativeProbability W) :
-    ∃ m : QualAddMeasure ℚ W, ∀ A B, sys.ge A B ↔ m.inducedGe A B :=
-  exists_qualAddMeasure_repr sys
+theorem fa_qualAdd_complete {W : Type*} [Fintype W] (sys : QualitativeProbability (Set W)) :
+    ∃ m : QualAddMeasure ℚ W, ∀ A B, A ≿[sys] B ↔ m.inducedGe A B :=
+  let ⟨m, hm⟩ := exists_qualAddMeasure_repr sys
+  ⟨m, fun A B => hm B A⟩
 
 /-! ### Theorem 8: FA = FP∞ exactly below five worlds -/
 
 /-- **Theorem 8** ([kraft-pratt-seidenberg-1959]): every FA system on `Fin n`
     is representable by a finitely additive measure iff `n < 5`. -/
 theorem fa_representable_iff_card_lt_five (n : ℕ) :
-    (∀ sys : QualitativeProbability (Fin n), Representable sys) ↔ n < 5 :=
+    (∀ sys : QualitativeProbability (Set (Fin n)), Representable sys) ↔ n < 5 :=
   ⟨fun h => by_contra fun hge =>
       let ⟨sys, hsys⟩ := exists_nonrepresentable_fin (n := n) (by omega); hsys (h sys),
     fun h sys => representable_of_card_lt_five sys (by simpa using h)⟩


### PR DESCRIPTION
Fourth and final elegance arc for the comparative-probability substrate (after #2573, #2574, #2575): the two divergences from mathlib orthodoxy a referee would still flag.

- `QualitativeProbability` is now stated on an arbitrary `[BooleanAlgebra α]` (de Finetti/Scott generality; `Set W` is the instance the H&I logic FA lives on) with the relation stored as `le` and every substrate lemma in `≤`-vocabulary — monotonicity is now covariant (`a ≤ b → a ≼ b`), and the context-cancellation / merge lemmas (`sup_le_sup_iff_right`, `sup_le_sup_right`, `sup_le_sup`) are proved by explicit lattice lemmas instead of `Set`-only `grind`
- the paper-facing `≿` survives as `QualitativeProbability.ge` — mathlib's `GE.ge` pattern — carrying the `Defs.lean` mixin instances and the pattern layer, with scoped notation `a ≼[sys] b` / `a ≿[sys] b` (used in the H&I study to state Theorem 6 as the paper writes it)
- `Representable`, the KPS/Scott representation files and the dominated-set-count completeness construction restated in `le`; `Cancellation.lean`'s portfolio framework keeps its ≿-native comparison vocabulary through `ge`; `univ_ge_empty`/`ge_empty_target` dissolve into `QualitativeProbability.bot_le`/`le_top`