### PR TITLE
refactor(Phonology/Tone): Plateauing on an AR link kit; Jardine2016 a/b

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2340,8 +2340,8 @@ import Linglib.Studies.JackendoffAudring2020
 import Linglib.Studies.Jaeger2007
 import Linglib.Studies.Jaeger2014
 import Linglib.Studies.JansenPollmann2001
-import Linglib.Studies.Jardine2016
-import Linglib.Studies.Jardine2016Tone
+import Linglib.Studies.Jardine2016a
+import Linglib.Studies.Jardine2016b
 import Linglib.Studies.Jardine2017
 import Linglib.Studies.Jardine2019
 import Linglib.Studies.Jenks2018

--- a/Linglib/Core/Data/List/TakeDrop.lean
+++ b/Linglib/Core/Data/List/TakeDrop.lean
@@ -6,22 +6,31 @@ Authors: Robert Hawkins
 import Mathlib.Data.List.TakeDrop
 
 /-!
-# Membership in `take` and `drop`, positionally
+# Membership in `take` and `drop` by index
 
-`getElem?`-indexed characterizations of membership in a prefix or suffix. Candidates
-for `Mathlib/Data/List/TakeDrop.lean`.
+The `getElem?` forms of `List.mem_take_iff_getElem` and `List.mem_drop_iff_getElem`: an
+element of a prefix or suffix is an entry of the original list at an index on that side of
+the cut. [UPSTREAM] candidates for `Init/Data/List/Nat/TakeDrop.lean`, beside their `getElem`
+counterparts.
 -/
 
 namespace List
 
-variable {α : Type*} {a : α} {w : List α} {k : ℕ}
+variable {α : Type*} {l : List α} {a : α} {n : ℕ}
 
-theorem mem_take_iff : a ∈ w.take k ↔ ∃ j < k, w[j]? = some a := by
-  simp [List.mem_iff_getElem?, List.getElem?_take]
+/-- An element of `l.take n` is an entry of `l` at an index below `n`. -/
+theorem mem_take_iff_getElem? : a ∈ l.take n ↔ ∃ i < n, l[i]? = some a := by
+  simp [mem_iff_getElem?, getElem?_take]
 
-theorem mem_drop_iff : a ∈ w.drop k ↔ ∃ j ≥ k, w[j]? = some a := by
-  simp only [List.mem_iff_getElem?, List.getElem?_drop]
-  exact ⟨fun ⟨t, ht⟩ => ⟨k + t, Nat.le_add_right k t, ht⟩,
-    fun ⟨j, hkj, hj⟩ => ⟨j - k, by rwa [Nat.add_sub_cancel' hkj]⟩⟩
+/-- An element of `l.drop n` is an entry of `l` at an index at least `n`. Unlike
+`List.mem_drop_iff_getElem`, the index is into `l`, not into the suffix. -/
+theorem mem_drop_iff_getElem? : a ∈ l.drop n ↔ ∃ i ≥ n, l[i]? = some a := by
+  simp only [mem_iff_getElem?, getElem?_drop]
+  exact ⟨fun ⟨i, h⟩ ↦ ⟨n + i, Nat.le_add_right n i, h⟩,
+    fun ⟨i, hn, h⟩ ↦ ⟨i - n, by rwa [Nat.add_sub_cancel' hn]⟩⟩
+
+/-- A nonempty suffix starts inside the list. -/
+theorem lt_length_of_mem_drop (h : a ∈ l.drop n) : n < l.length :=
+  Nat.not_le.mp (drop_eq_nil_iff.not.mp (ne_nil_of_mem h))
 
 end List

--- a/Linglib/Phonology/Autosegmental/AR.lean
+++ b/Linglib/Phonology/Autosegmental/AR.lean
@@ -11,7 +11,7 @@ import Linglib.Phonology.Autosegmental.Graph
 /-!
 # Autosegmental representations: the §4.2 axioms and their category
 
-The well-formedness axioms of [jardine-2016-diss] §4.2, each stated on exactly the
+The well-formedness axioms of [jardine-2016b] §4.2, each stated on exactly the
 components it reads (`Digraph` arcs, `SimpleGraph` edges, a coloring `c : V → ι`) and
 read on a labeled mixed graph at the tier coloring `X.tier t`. `AR t` is the full
 subcategory of `Graph S` they carve out, monoidal under `Graph.concat`.
@@ -19,7 +19,7 @@ subcategory of `Graph S` they carve out, monoidal under `Graph.concat`.
 ## Main definitions
 
 * `IsTierOrdered`, `NoInternalAssoc`, `IsSaturated`, `IsPlanar`, `IsOCPClean`: the six
-  well-formedness axioms of [jardine-2016-diss] §4.2.
+  well-formedness axioms of [jardine-2016b] §4.2.
 * `AR t`: the category of autosegmental representations — the full subcategory on
   Axioms 1–3, monoidal under `concat`.
 
@@ -138,7 +138,7 @@ end Graph
 open CategoryTheory
 
 /-- The category of autosegmental representations over a tier assignment, given by the
-    full subcategory on Axioms 1–3 of [jardine-2016-diss] §4.2. These are the formal
+    full subcategory on Axioms 1–3 of [jardine-2016b] §4.2. These are the formal
     literature's ARs ([jardine-2019], [chandlee-jardine-2019]). -/
 abbrev AR (t : S → ι) :=
   ObjectProperty.FullSubcategory

--- a/Linglib/Phonology/Autosegmental/Correspondence.lean
+++ b/Linglib/Phonology/Autosegmental/Correspondence.lean
@@ -8,7 +8,7 @@ import Linglib.Phonology.Autosegmental.Junction
 /-!
 # Phonological transformations as correspondence-graph relations
 
-[jardine-2016-diss] (Ch. 7) models a phonological *process* not as a function but as a
+[jardine-2016b] (Ch. 7) models a phonological *process* not as a function but as a
 **relation** between input and output, presented by a set of **correspondence graphs**
 and carved out of GEN by **banned-subgraph constraints** (markedness + faithfulness) —
 which is what makes the relation *local*.
@@ -18,7 +18,7 @@ upper tier is the input string, the lower tier the output string, and the associ
 links are the input↔output **correspondence arcs**. (Precedence is carried by the tier
 order; Jardine's separate precedence/correspondence arc-labeling `ℓ_A` is here the
 structural split between tier-order and links.) The banned-subgraph grammar is
-`Graph.Free` ([jardine-2016-diss] Ch. 5's `L^NL_G`).
+`Graph.Free` ([jardine-2016b] Ch. 5's `L^NL_G`).
 
 This is the *process* layer of the substrate's three-layer spec (objects `AR`,
 precedence-morphisms `PrecAR`, processes here). The autosegmental case — correspondence
@@ -35,7 +35,7 @@ arc-labelled-subgraph refinement he flags in Ch. 7 fn. 7; that is deferred.
 
 * `Correspondence.input`/`output` — the two strings a correspondence graph relates.
 * `Correspondence.rel` — `R(CG)`, the string relation of a set of correspondence graphs
-  ([jardine-2016-diss] Def. 25).
+  ([jardine-2016b] Def. 25).
 * `Correspondence.specifiedBy` — `CG(φ)`, a process presented by a banned-subgraph grammar.
 * `Correspondence.IsLocal` — a relation presented by a finite banned-subgraph grammar.
 -/
@@ -70,7 +70,7 @@ noncomputable def Rep.output (G : Rep S T) : List T :=
   haveI := G.property
   G.val.tierWord false
 
-/-- **R(CG)** ([jardine-2016-diss] Def. 25) on the foundation: the string
+/-- **R(CG)** ([jardine-2016b] Def. 25) on the foundation: the string
     relation realized by a set of correspondence representations. -/
 def relRep (CG : Rep S T → Prop) (w : List S) (v : List T) : Prop :=
   ∃ G, CG G ∧ G.input = w ∧ G.output = v

--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -11,7 +11,7 @@ import Linglib.Phonology.Autosegmental.NormalForm
 
 [jardine-2017]'s connected-subgraph embedding in position coordinates: a factor
 occurs at per-tier offsets when its tier words are windows of the host's and its
-links transport shifted. Banned-subgraph grammars ([jardine-2016-diss] Ch. 5)
+links transport shifted. Banned-subgraph grammars ([jardine-2016b] Ch. 5)
 are lists of forbidden factors.
 
 ## Main definitions
@@ -46,7 +46,7 @@ structure IsFactorAt (o : ι → ℕ) : Prop where
 def FactorEmbeds : Prop := ∃ o : ι → ℕ, F.IsFactorAt X o
 
 /-- `X` avoids every forbidden factor of a banned-subgraph grammar
-    ([jardine-2016-diss] Ch. 5's `L^NL_G`). -/
+    ([jardine-2016b] Ch. 5's `L^NL_G`). -/
 def Free (B : List {F : TieredAR ι τ // Finite F.obj.V}) : Prop :=
   ∀ F ∈ B, haveI := F.property; ¬ F.val.FactorEmbeds X
 

--- a/Linglib/Phonology/Autosegmental/Hull.lean
+++ b/Linglib/Phonology/Autosegmental/Hull.lean
@@ -52,6 +52,9 @@ instance : Finite (X.hull m).obj.V :=
     (X.hull m).tierWord i = X.tierWord i :=
   AR.tierWord_ofData i
 
+@[simp] theorem AR.tierLength_hull (i : ι) : (X.hull m).tierLength i = X.tierLength i := by
+  rw [← AR.length_tierWord, AR.tierWord_hull, AR.length_tierWord]
+
 /-- Hull membership at the melody tier: `q` lies between two of `p`'s links. -/
 theorem AR.link_hull_left {j : ι} (hj : m ≠ j) {p q : ℕ}
     (hq : q < X.tierLength j) :

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -12,7 +12,7 @@ The named building blocks of autosegmental representations. `AR.junction as bs` 
 every melody node of `as` to every timing slot of `bs`; its planar specializations —
 `single`, `bare`, `float`, `contour`, `spread` — are the local configurations of
 autosegmental tonology, and `concat`-products of them build every representation in the
-current tone studies (`Studies/Jardine2016Tone`, `Studies/Jardine2017`,
+current tone studies (`Studies/Jardine2016a`, `Studies/Jardine2017`,
 `Studies/Jardine2019`). Building through them (rather than raw structure literals)
 carries the in-bounds proof at arbitrary alphabets, where the studies' `by decide`
 cannot go, and gives every configuration a simp kit.
@@ -43,10 +43,9 @@ becomes primary and the five kits derive from its (the
 
 * `AR.isPlanar_junction_iff` — NCC-planarity of a junction: one side is at most a
   singleton.
-* `AR.linearize_junction` — every slot of a junction carries the whole melody.
-* Per-builder simp kits: tier projections (at the `LabeledTuple` level, so `.len`,
-  `.toList`, `.get?` follow from the `ofList` kit), reduced link sets, linearization,
-  planarity, and OCP-cleanliness.
+* The junction simp kit — tier words and lengths (`AR.tierWord_junction_true`,
+  `AR.tierLength_junction_true`, …) and links (`AR.link_junction`) — which the builders
+  inherit as transparent aliases; per-builder planarity (`AR.isPlanar_single`, …).
 -/
 
 namespace Autosegmental
@@ -70,6 +69,10 @@ variable {α β : Type u}
     `false`. -/
 abbrev TwoTier (α β : Type u) : Bool → Type u := fun b => bif b then α else β
 
+instance [DecidableEq α] : DecidableEq (TwoTier α β true) := inferInstanceAs (DecidableEq α)
+
+instance [DecidableEq β] : DecidableEq (TwoTier α β false) := inferInstanceAs (DecidableEq β)
+
 /-- Complete many-to-many association of a melody onto a slot sequence, in
     coordinates. -/
 def AR.junction (as : List α) (bs : List β) :
@@ -92,8 +95,16 @@ instance (as : List α) (bs : List β) :
     (AR.junction as bs).tierWord false = bs :=
   AR.tierWord_ofData false
 
+@[simp] theorem AR.tierLength_junction_true (as : List α) (bs : List β) :
+    (AR.junction as bs).tierLength true = as.length :=
+  AR.tierLength_ofData true
+
+@[simp] theorem AR.tierLength_junction_false (as : List α) (bs : List β) :
+    (AR.junction as bs).tierLength false = bs.length :=
+  AR.tierLength_ofData false
+
 /-- Junction links are complete: every in-bounds melody–timing pair. -/
-theorem AR.link_junction (as : List α) (bs : List β) {b b' : Bool}
+@[simp] theorem AR.link_junction (as : List α) (bs : List β) {b b' : Bool}
     {p q : ℕ} : (AR.junction as bs).link b b' p q ↔
       b = true ∧ b' = false ∧ p < as.length ∧ q < bs.length ∨
         b = false ∧ b' = true ∧ p < bs.length ∧ q < as.length := by
@@ -160,19 +171,19 @@ theorem AR.isPlanar_junction_iff (as : List α) (bs : List β) :
 /-! #### The planar local configurations -/
 
 /-- One-to-one association. -/
-def AR.single (a : α) (b : β) := AR.junction [a] [b]
+abbrev AR.single (a : α) (b : β) := AR.junction [a] [b]
 
 /-- A bare (unassociated) timing slot. -/
-def AR.bare (b : β) := AR.junction ([] : List α) [b]
+abbrev AR.bare (b : β) := AR.junction ([] : List α) [b]
 
 /-- A floating autosegment ([leben-1973]). -/
-def AR.float (a : α) := AR.junction [a] ([] : List β)
+abbrev AR.float (a : α) := AR.junction [a] ([] : List β)
 
 /-- Several melody nodes on one slot. -/
-def AR.contour (as : List α) (b : β) := AR.junction as [b]
+abbrev AR.contour (as : List α) (b : β) := AR.junction as [b]
 
 /-- One melody node over several slots. -/
-def AR.spread (a : α) (bs : List β) := AR.junction [a] bs
+abbrev AR.spread (a : α) (bs : List β) := AR.junction [a] bs
 
 theorem AR.isPlanar_single (a : α) (b : β) :
     IsPlanar (AR.single a b).obj.edges (AR.single a b).obj.arcs :=
@@ -229,8 +240,6 @@ instance {wsF wsX : ∀ b : Bool, List (TwoTier α β b)}
     [∀ i j p q, Decidable (LF i j p q)] [∀ i j p q, Decidable (LX i j p q)] :
     Decidable (dataEmbeds wsF wsX LF LX) := by
   unfold dataEmbeds
-  haveI : DecidableEq (TwoTier α β true) := inferInstanceAs (DecidableEq α)
-  haveI : DecidableEq (TwoTier α β false) := inferInstanceAs (DecidableEq β)
   infer_instance
 
 /-- **The spec**: on `ofData`-presented two-tier forms, factor embedding is the

--- a/Linglib/Phonology/Autosegmental/NormalForm.lean
+++ b/Linglib/Phonology/Autosegmental/NormalForm.lean
@@ -345,6 +345,9 @@ instance : Finite ((𝟙_ (TieredAR ι τ)).obj.V) :=
   rw [tierWord_eq_ofFn (OrderIso.ofIsEmpty (Fin 0) _)]
   exact List.ofFn_zero
 
+@[simp] theorem tierLength_unit (i : ι) : (𝟙_ (TieredAR ι τ)).tierLength i = 0 := by
+  rw [← length_tierWord, tierWord_unit, List.length_nil]
+
 end TierWordTensor
 
 /-! ### Readers in ℕ coordinates
@@ -362,6 +365,10 @@ variable (X : TieredAR ι τ)
     (out-of-bounds positions link to nothing). -/
 def link [Finite X.obj.V] (i j : ι) (p q : ℕ) : Prop :=
   ∃ (hp : p < X.tierLength i) (hq : q < X.tierLength j), X.linkRel i j ⟨p, hp⟩ ⟨q, hq⟩
+
+open scoped MonoidalCategory in
+@[simp] theorem not_link_unit (i j : ι) (p q : ℕ) : ¬ (𝟙_ (TieredAR ι τ)).link i j p q :=
+  fun ⟨hp, _, _⟩ => by simp at hp
 
 open scoped Classical in
 /-- The two-tier reading of tiers `i` over `j`: each tier-`j` position's label
@@ -589,7 +596,7 @@ noncomputable def ofDataFiberEnum (i : ι) :
   obtain rfl : j = i := hp
   exact ⟨q, rfl⟩
 
-theorem tierLength_ofData (i : ι) :
+@[simp] theorem tierLength_ofData (i : ι) :
     (ofData ws L).tierLength i = (ws i).length := by
   rw [← length_tierWord,
     tierWord_eq_ofFn (ofDataFiberEnum i), List.length_ofFn]

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -83,15 +83,31 @@ variable (m : ι) [DecidableEq (τ m)]
 noncomputable def AR.collapsedWord [Finite X.obj.V] : ∀ i, List (τ i) :=
   Function.update (fun i => X.tierWord i) m (OCP.collapse (X.tierWord m))
 
+@[simp] theorem AR.collapsedWord_self [Finite X.obj.V] :
+    X.collapsedWord m m = OCP.collapse (X.tierWord m) :=
+  Function.update_self ..
+
+@[simp] theorem AR.collapsedWord_of_ne [Finite X.obj.V] {i : ι} (h : i ≠ m) :
+    X.collapsedWord m i = X.tierWord i :=
+  Function.update_of_ne h ..
+
 theorem AR.collapsedWord_length_le [Finite X.obj.V] (i : ι) :
     (X.collapsedWord m i).length ≤ X.tierLength i := by
   rcases eq_or_ne i m with rfl | h
-  · simpa [AR.collapsedWord] using OCP.collapse_length_le (X.tierWord i)
-  · simp [AR.collapsedWord, Function.update_of_ne h]
+  · simpa using OCP.collapse_length_le (X.tierWord i)
+  · simp [h]
 
 /-- Position repointing: `runIdx` on the melody tier, identity elsewhere. -/
 noncomputable def AR.collapseIdx [Finite X.obj.V] (i : ι) (p : ℕ) : ℕ :=
   if i = m then runIdx (X.tierWord m) p else p
+
+@[simp] theorem AR.collapseIdx_self [Finite X.obj.V] (p : ℕ) :
+    X.collapseIdx m m p = runIdx (X.tierWord m) p :=
+  if_pos rfl
+
+@[simp] theorem AR.collapseIdx_of_ne [Finite X.obj.V] {i : ι} (h : i ≠ m) (p : ℕ) :
+    X.collapseIdx m i p = p :=
+  if_neg h
 
 /-- **The OCP-merging collapse**: melody tier `m` destuttered, links repointed
     through `runIdx`, other tiers untouched. -/
@@ -225,7 +241,7 @@ theorem AR.link_collapse [Finite X.obj.V] (i j : ι) (r s : ℕ) :
     subst hij
     exact X.not_link_self_tier i p q hpq
 
-theorem AR.tierLength_collapse [Finite X.obj.V] (i : ι) :
+@[simp] theorem AR.tierLength_collapse [Finite X.obj.V] (i : ι) :
     (X.collapse m).tierLength i = (X.collapsedWord m i).length := by
   rw [← AR.length_tierWord, AR.tierWord_collapse]
 
@@ -388,7 +404,7 @@ private theorem AR.label_normalize_succ [Finite X.obj.V]
   exact ⟨fun h => eq_of_heq (Sigma.mk.inj_iff.mp h).2, fun h => congrArg (Sigma.mk m) h⟩
 
 /-- **The OCP bridge**: tier-word cleanliness is Axiom 6 on the normal form —
-    the coordinate OCP and [jardine-2016-diss]'s §4.2 axiom agree. -/
+    the coordinate OCP and [jardine-2016b]'s §4.2 axiom agree. -/
 theorem AR.isCleanAt_iff_isOCPClean [Finite X.obj.V] :
     X.IsCleanAt m ↔
       IsOCPClean (X.normalize).obj.arcs (X.normalize).obj.label Sigma.fst m := by

--- a/Linglib/Phonology/Autosegmental/Realization.lean
+++ b/Linglib/Phonology/Autosegmental/Realization.lean
@@ -26,7 +26,9 @@ arcs and is too coarse to preserve tier words.
 ## Main results
 
 * `AR.cls_normalize`: normal forms represent their class.
-* `AR.tierWord_realize`: tier content of a realization is compositional.
+* `AR.tierWord_realize`, `AR.link_realize`: tier content and links of a realization are
+  compositional — each link lives inside one symbol's primitive at that symbol's tier
+  offsets (`AR.tierOffset`).
 -/
 
 namespace Autosegmental
@@ -94,17 +96,79 @@ theorem tierWord_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
   | nil => simp
   | cons a w ih => simp [ih]
 
+@[simp] theorem tierLength_realize [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+    (realize g₀ w).tierLength i = (w.map fun s => (g₀ s).tierLength i).sum := by
+  rw [← length_tierWord, tierWord_realize, List.length_flatten, List.map_map]
+  simp [Function.comp_def]
+
+/-! ### Links of realizations -/
+
+variable [∀ s, Finite (g₀ s).obj.V]
+
+/-- The tier-`i` offset of the `k`-th symbol of `w` in its realization: the tier-`i` content
+of the prefix before it. -/
+noncomputable def tierOffset (i : ι) (w : List S) (k : ℕ) : ℕ :=
+  (realize g₀ (w.take k)).tierLength i
+
+@[simp] theorem tierOffset_zero (i : ι) (w : List S) : tierOffset g₀ i w 0 = 0 := by
+  simp [tierOffset]
+
+@[simp] theorem tierOffset_cons_succ (i : ι) (a : S) (w : List S) (k : ℕ) :
+    tierOffset g₀ i (a :: w) (k + 1) = (g₀ a).tierLength i + tierOffset g₀ i w k := by
+  simp [tierOffset, List.take_succ_cons]
+
+/-- Links of a realization are blockwise: a link lives inside one symbol's primitive, at
+that symbol's tier offsets — the link half of `tierWord_realize`. -/
+theorem link_realize (i j : ι) (w : List S) (p q : ℕ) :
+    (realize g₀ w).link i j p q ↔
+      ∃ k, ∃ hk : k < w.length, tierOffset g₀ i w k ≤ p ∧ tierOffset g₀ j w k ≤ q ∧
+        (g₀ w[k]).link i j (p - tierOffset g₀ i w k) (q - tierOffset g₀ j w k) := by
+  induction w generalizing p q with
+  | nil => simp
+  | cons a w ih =>
+    rw [show (realize g₀ (a :: w)).link i j p q ↔ (g₀ a ⊗ realize g₀ w).link i j p q from
+      Iff.rfl, link_tensor, ih]
+    constructor
+    · rintro (h | ⟨hp, hq, k, hk, hpk, hqk, h⟩)
+      · exact ⟨0, by simp, by simp, by simp, by simpa using h⟩
+      · exact ⟨k + 1, by simpa using hk, by simp; omega, by simp; omega,
+          by simpa [Nat.sub_sub] using h⟩
+    · rintro ⟨_ | k, hk, hpk, hqk, h⟩
+      · exact Or.inl (by simpa using h)
+      · simp only [tierOffset_cons_succ, List.getElem_cons_succ] at hpk hqk h
+        exact Or.inr ⟨by omega, by omega, k, by simpa using hk, by omega, by omega,
+          by simpa [Nat.sub_sub] using h⟩
+
+/-- With one tier-`j` position per symbol, tier-`j` positions of the realization are the
+string's positions: a link at position `q` is a link inside the `q`-th symbol's primitive. -/
+theorem link_realize_of_tierLength_eq_one {j : ι} (hj : ∀ s, (g₀ s).tierLength j = 1)
+    (i : ι) (w : List S) (p q : ℕ) :
+    (realize g₀ w).link i j p q ↔
+      ∃ hq : q < w.length, tierOffset g₀ i w q ≤ p ∧
+        (g₀ w[q]).link i j (p - tierOffset g₀ i w q) 0 := by
+  have hoff : ∀ k ≤ w.length, tierOffset g₀ j w k = k := fun k hk => by
+    simp [tierOffset, hj, hk]
+  rw [link_realize]
+  constructor
+  · rintro ⟨k, hk, hpk, hqk, h⟩
+    rw [hoff k hk.le] at hqk h
+    obtain ⟨-, hlt, -⟩ := id h
+    rw [hj] at hlt
+    obtain rfl : k = q := by omega
+    exact ⟨hk, hpk, by simpa using h⟩
+  · rintro ⟨hq, hpq, h⟩
+    exact ⟨q, hq, hpq, by rw [hoff q hq.le], by simpa [hoff q hq.le] using h⟩
+
 /-- The tier-`i` projection of a realization, as a free-monoid homomorphism:
     each symbol contributes its primitive's tier word. -/
-noncomputable def tierProj [∀ s, Finite (g₀ s).obj.V] (i : ι) :
-    FreeMonoid S →* FreeMonoid (τ i) :=
+noncomputable def tierProj (i : ι) : FreeMonoid S →* FreeMonoid (τ i) :=
   FreeMonoid.lift fun s => FreeMonoid.ofList ((g₀ s).tierWord i)
 
-@[simp] theorem tierProj_of [∀ s, Finite (g₀ s).obj.V] (i : ι) (a : S) :
+@[simp] theorem tierProj_of (i : ι) (a : S) :
     tierProj g₀ i (FreeMonoid.of a) = FreeMonoid.ofList ((g₀ a).tierWord i) := rfl
 
 /-- `tierProj` packages `tierWord`: on a word it is the realized tier word. -/
-theorem tierProj_ofList [∀ s, Finite (g₀ s).obj.V] (i : ι) (w : List S) :
+theorem tierProj_ofList (i : ι) (w : List S) :
     tierProj g₀ i (FreeMonoid.ofList w) = FreeMonoid.ofList ((realize g₀ w).tierWord i) := by
   induction w with
   | nil => simp

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -17,357 +17,237 @@ import Linglib.Phonology.Tone.Surfacing
 # Unbounded tonal plateauing
 
 [hyman-katamba-2010]'s plateauing rule for Luganda: every tone-bearing unit between two
-H-toned units surfaces H. Formalized over the string rendering of [jardine-2016]: a word
+H-toned units surfaces H. Formalized over the string rendering of [jardine-2016a]: a word
 over `TBU` records each timing unit's association state (`H` associated to a H tone, `O`
 unassociated), and `utp` — a `Tone.Surfacing` process — rewrites it pointwise by its
-surfacing predicate. What surfaces is the *representation*: `utp.Surfaces w i` is by
-definition H-linkedness of timing node `i` in the output representation `plateauAR w`
-(the OCP-merged input, hull-closed — fusion then spreading); the string reading is the
-derived `utp.surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
+surfacing predicate, the two-sided window `H ∈ w.take (i + 1) ∧ H ∈ w.drop i`: a H at or
+before `i` and one at or after it. The map is `utp.map`, the surfacing set `plateau`.
+
+What surfaces is the representation. The string reads back into two-tier autosegmental
+representations by `toAR`, and the output representation `plateauAR w` is the OCP-merged
+input, hull-closed — fusion then spreading. Timing slot `i` surfaces with H in `plateauAR w`
+exactly when `utp.Surfaces w i` (`utp.surfaces_iff_surfacesWith_plateauAR`).
 
 The map is the flagship *unbounded circumambient* process: whether a position changes
 depends on unboundedly distant material on **both** sides, in the strong witness form
-`utp.requiresBothSides` — perturbing either far side alone reverts the change — with
-the weaker `utp.twoSidedUnboundedDependence` as a corollary, which
-feeds the weak-determinism exclusion theorems of `Studies/Jardine2016Tone` (bimachine
-rendering) and `Studies/Yolyan2025` (BMRS rendering).
+`utp.requiresBothSides` — perturbing either far side alone reverts the change — with the
+weaker `utp.twoSidedUnboundedDependence` as a corollary, which feeds the weak-determinism
+exclusion theorems of `Studies/Jardine2016a` (bimachine rendering) and `Studies/Yolyan2025`
+(BMRS rendering).
 
 ## Main definitions
 
 * `Tone.Plateauing.TBU` — the H/Ø string alphabet (association states; distinct from
   `Tone.TBUKind`, the phonological typology of timing units).
-* `Tone.Plateauing.plateauAR` — the output representation (OCP-merged input,
-  hull-closed); `utp.Surfaces` is H-linkedness in it, via `Graph.SurfacesWith` and
-  `Graph.hull` (`Phonology/Autosegmental/Hull.lean`).
+* `Tone.Plateauing.toAR`, `Tone.Plateauing.plateauAR` — the translation of a TBU into a
+  one-slot representation, and the output representation (OCP-merged input, hull-closed).
 * `Tone.Plateauing.utp` — plateauing as a `Tone.Surfacing` process; `utp.map` the map.
 * `Tone.Plateauing.plateau` — the set of surfacing positions.
 
 ## Main results
 
+* `utp.surfaces_iff_surfacesWith_plateauAR` — surfacing is H-linkedness in the output
+  representation.
 * `utp.map_getElem?_H_iff` / `utp.map_getElem?_O_iff` — pointwise characterization of the map.
 * `utp_eq_plateau_indicator`, `plateau_eq_Icc` — the output is the indicator word of an
   interval, from the first trigger to the last.
-* `utp.map_toneless`, `utp.map_single`, `utp.map_plateau` — the rule schemata: toneless words and
-  lone Hs are unchanged; everything between the outermost Hs surfaces H.
+* `utp.map_toneless`, `utp.map_single`, `utp.map_plateau` — the rule schemata: toneless words
+  and lone Hs are unchanged; everything between the outermost Hs surfaces H.
 * `utp.map_getElem?_H_of_getElem?_H`, `utp.map_mono`, `utp.map_map` — plateauing is a closure
   operator in the pointwise H-order: extensive, monotone, idempotent.
 * `utp.requiresBothSides` — deleting either flanking H reverts the plateau target, at
   every distance.
-* `realizeMerged_toAR_map` — the commuting square: the merged representation of the
-  output string is the output representation `plateauAR`.
 -/
 
 namespace Tone.Plateauing
 
-
-
 /-! ### The tone-bearing-unit alphabet -/
 
 /-- A tone-bearing unit's association state: `H` is a TBU associated to a H tone, `O` an
-unspecified TBU ([jardine-2016]'s Ø). -/
+unspecified TBU ([jardine-2016a]'s Ø). -/
 inductive TBU | H | O
   deriving DecidableEq, Repr
 
 /-! ### The output representation
 
-The string rendering embeds into autosegmental representations, and plateauing on
-representations is OCP-fusion followed by hull-closure of the association lines
-([hyman-katamba-2010]'s rule as an operation on structures). What surfaces is the
-representation: `utp.Surfaces` is *by definition* H-linkedness in the output
-representation `plateauAR w`; the string-level `take`/`drop` reading is the derived
-characterization `utp.surfaces_def`. -/
+The string reads back into two-tier representations, and plateauing on representations is
+OCP-fusion followed by hull-closure of the association lines ([hyman-katamba-2010]'s rule
+as an operation on structures). -/
 
 open Autosegmental
 
-/-- `toAR` in coordinates: the two-tier representation of one association
-    state (melody over `true`, timing over `false`). -/
-noncomputable def toRep (a : TBU) :
-    Autosegmental.AR
-      (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
-  match a with
-  | .H => Autosegmental.AR.single _root_.Tone.TRN.H ()
-  | .O => Autosegmental.AR.bare ()
+/-- The melody a TBU contributes: its H tone if H-toned, nothing otherwise. -/
+def melody : TBU → List TRN
+  | .H => [.H]
+  | .O => []
 
-instance (a : TBU) : Finite (toRep a).obj.V := by
-  cases a <;> exact inferInstanceAs (Finite ((_ : Bool) × Fin _))
+@[simp] theorem melody_H : melody .H = [.H] := rfl
 
-instance : DecidableEq (Autosegmental.TwoTier _root_.Tone.TRN Unit true) :=
-  inferInstanceAs (DecidableEq _root_.Tone.TRN)
+@[simp] theorem melody_O : melody .O = [] := rfl
 
-/-- The output representation in coordinates: OCP-merge then hull, both at the
-    melody tier. -/
-noncomputable def plateauRep (w : List TBU) :
-    Autosegmental.AR
-      (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier _root_.Tone.TRN Unit b) → Bool) :=
-  ((Autosegmental.AR.realize toRep w).collapse true).hull true
+theorem length_melody (a : TBU) : (melody a).length = if a = .H then 1 else 0 := by
+  cases a <;> rfl
 
-instance (w : List TBU) : Finite (plateauRep w).obj.V :=
-  inferInstanceAs (Finite ((_ : Bool) × Fin _))
-
-section TierWords
-open CategoryTheory
-open scoped MonoidalCategory
-
-/-- The melody word of a realized string: one `H` node per H-toned TBU. -/
-theorem tierWord_realize_toRep_true (w : List TBU) :
-    (Autosegmental.AR.realize toRep w).tierWord true
-      = List.replicate (w.count .H) _root_.Tone.TRN.H := by
+theorem sum_length_melody (w : List TBU) :
+    (w.map fun a => (melody a).length).sum = w.count .H := by
   induction w with
-  | nil => simp [Autosegmental.AR.tierWord_unit]
-  | cons a w ih =>
-    calc (Autosegmental.AR.realize toRep (a :: w)).tierWord true
-        = (toRep a ⊗ Autosegmental.AR.realize toRep w).tierWord true := rfl
-      _ = (toRep a).tierWord true ++ (Autosegmental.AR.realize toRep w).tierWord true :=
-          Autosegmental.AR.tierWord_tensor true
-      _ = List.replicate ((a :: w).count .H) _root_.Tone.TRN.H := by
-          rw [ih]
-          cases a
-          · rw [show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
-              Autosegmental.AR.tierWord_ofData true,
-              List.count_cons_self, List.replicate_succ]
-            rfl
-          · rw [show (toRep TBU.O).tierWord true = [] from
-              Autosegmental.AR.tierWord_ofData true,
-              List.count_cons_of_ne (by decide)]
-            rfl
+  | nil => rfl
+  | cons a w ih => cases a <;> simp [ih, Nat.add_comm]
 
-/-- The timing word of a realized string: one slot per TBU. -/
-theorem tierWord_realize_toRep_false (w : List TBU) :
-    (Autosegmental.AR.realize toRep w).tierWord false = List.replicate w.length () := by
+/-- The translation of a TBU into a representation, in coordinates: one timing slot
+carrying the TBU's melody ([jardine-2016a]'s reading of the string as a representation). -/
+def toAR (a : TBU) : TieredAR Bool (TwoTier TRN Unit) := AR.junction (melody a) [()]
+
+theorem toAR_H : toAR .H = AR.single TRN.H () := rfl
+
+theorem toAR_O : toAR .O = AR.bare () := rfl
+
+instance (a : TBU) : Finite (toAR a).obj.V :=
+  inferInstanceAs (Finite (AR.junction (melody a) [()]).obj.V)
+
+@[simp] theorem tierWord_toAR_true (a : TBU) : (toAR a).tierWord true = melody a :=
+  AR.tierWord_junction_true _ _
+
+@[simp] theorem tierWord_toAR_false (a : TBU) : (toAR a).tierWord false = [()] :=
+  AR.tierWord_junction_false _ _
+
+@[simp] theorem tierLength_toAR_true (a : TBU) :
+    (toAR a).tierLength true = (melody a).length :=
+  AR.tierLength_junction_true _ _
+
+@[simp] theorem tierLength_toAR_false (a : TBU) : (toAR a).tierLength false = 1 :=
+  AR.tierLength_junction_false _ _
+
+@[simp] theorem link_toAR (a : TBU) (p q : ℕ) :
+    (toAR a).link true false p q ↔ p < (melody a).length ∧ q = 0 := by
+  simp [toAR]
+
+/-- The melody of a realized string: one `H` node per H-toned TBU. -/
+@[simp] theorem tierWord_realize_toAR_true (w : List TBU) :
+    (AR.realize toAR w).tierWord true = List.replicate (w.count .H) TRN.H := by
   induction w with
-  | nil => simp [Autosegmental.AR.tierWord_unit]
-  | cons a w ih =>
-    calc (Autosegmental.AR.realize toRep (a :: w)).tierWord false
-        = (toRep a ⊗ Autosegmental.AR.realize toRep w).tierWord false := rfl
-      _ = (toRep a).tierWord false ++ (Autosegmental.AR.realize toRep w).tierWord false :=
-          Autosegmental.AR.tierWord_tensor false
-      _ = List.replicate (a :: w).length () := by
-          rw [ih, List.length_cons, List.replicate_succ]
-          cases a
-          · rw [show (toRep TBU.H).tierWord false = [()] from
-              Autosegmental.AR.tierWord_ofData false]
-            rfl
-          · rw [show (toRep TBU.O).tierWord false = [()] from
-              Autosegmental.AR.tierWord_ofData false]
-            rfl
+  | nil => simp
+  | cons a w ih => cases a <;> simp [ih, List.replicate_succ]
 
-/-- Links of a realized string: slot `j` links to melody node `p` exactly when
-    TBU `j` is H-toned and `p` is its accumulated melody position. -/
-theorem link_realize_toRep (w : List TBU) (p j : ℕ) :
-    (Autosegmental.AR.realize toRep w).link true false p j ↔
+/-- The timing tier of a realized string: one slot per TBU. -/
+@[simp] theorem tierWord_realize_toAR_false (w : List TBU) :
+    (AR.realize toAR w).tierWord false = List.replicate w.length () := by
+  induction w with
+  | nil => simp
+  | cons a w ih => simp [ih, List.replicate_succ]
+
+/-- Links of a realized string: slot `j` links to melody node `p` exactly when TBU `j` is
+H-toned and `p` is its accumulated melody position. -/
+theorem link_realize_toAR (w : List TBU) (p j : ℕ) :
+    (AR.realize toAR w).link true false p j ↔
       p = (w.take j).count .H ∧ w[j]? = some .H := by
-  induction w generalizing p j with
-  | nil =>
-    have h0 : (Autosegmental.AR.realize toRep []).tierLength true = 0 := by
-      rw [← Autosegmental.AR.length_tierWord,
-        show (Autosegmental.AR.realize toRep []).tierWord true = _ from
-          Autosegmental.AR.tierWord_unit true, List.length_nil]
-    constructor
-    · rintro ⟨hp, -, -⟩
-      omega
-    · rintro ⟨-, h⟩
-      simp at h
-  | cons a w ih =>
-    haveI := Autosegmental.AR.realize.instFinite toRep w
-    rw [show (Autosegmental.AR.realize toRep (a :: w)).link true false p j
-          = (toRep a ⊗ Autosegmental.AR.realize toRep w).link true false p j from rfl,
-      Autosegmental.AR.link_tensor (X := toRep a)
-        (Y := Autosegmental.AR.realize toRep w) true false p j]
-    cases a
-    · have hta : (toRep TBU.H).tierLength true = 1 := by
-        rw [← Autosegmental.AR.length_tierWord,
-          show (toRep TBU.H).tierWord true = [_root_.Tone.TRN.H] from
-            Autosegmental.AR.tierWord_ofData true]
-        rfl
-      have hfa : (toRep TBU.H).tierLength false = 1 := by
-        rw [← Autosegmental.AR.length_tierWord,
-          show (toRep TBU.H).tierWord false = [()] from
-            Autosegmental.AR.tierWord_ofData false]
-        rfl
-      have hj : (toRep TBU.H).link true false p j ↔ p = 0 ∧ j = 0 := by
-        refine (Autosegmental.AR.link_junction
-          [_root_.Tone.TRN.H] [()]).trans ?_
-        constructor
-        · rintro (⟨-, -, h1, h2⟩ | ⟨h, -⟩)
-          · exact ⟨by simpa using h1, by simpa using h2⟩
-          · exact absurd h (by decide)
-        · rintro ⟨rfl, rfl⟩
-          exact Or.inl ⟨rfl, rfl, by simp, by simp⟩
-      rw [hj, hta, hfa, ih]
-      rcases j with _ | j
-      · simp
-      · constructor
-        · rintro (⟨-, h⟩ | ⟨hp1, -, hrec, hj1⟩)
-          · exact absurd h (by omega)
-          · rw [show j + 1 - 1 = j from rfl] at hrec
-            refine ⟨?_, by simpa using hj1⟩
-            rw [List.take_succ_cons, List.count_cons_self]
-            omega
-        · rintro ⟨hp, hj1⟩
-          rw [List.take_succ_cons, List.count_cons_self] at hp
-          refine Or.inr ⟨by omega, by omega, ?_, by simpa using hj1⟩
-          have : j + 1 - 1 = j := by omega
-          rw [this]
-          omega
-    · have hta : (toRep TBU.O).tierLength true = 0 := by
-        rw [← Autosegmental.AR.length_tierWord,
-          show (toRep TBU.O).tierWord true = [] from
-            Autosegmental.AR.tierWord_ofData true]
-        rfl
-      have hfa : (toRep TBU.O).tierLength false = 1 := by
-        rw [← Autosegmental.AR.length_tierWord,
-          show (toRep TBU.O).tierWord false = [()] from
-            Autosegmental.AR.tierWord_ofData false]
-        rfl
-      have hj : ¬ (toRep TBU.O).link true false p j := by
-        intro h
-        rcases (Autosegmental.AR.link_junction
-          ([] : List _root_.Tone.TRN) [()]).mp h with ⟨-, -, h1, -⟩ | ⟨h1, -⟩
-        · simp at h1
-        · exact absurd h1 (by decide)
-      rw [hta, hfa, ih]
-      rcases j with _ | j
-      · constructor
-        · rintro (h | ⟨-, h, -⟩)
-          · exact absurd h hj
-          · omega
-        · rintro ⟨-, h⟩
-          simp at h
-      · constructor
-        · rintro (h | ⟨-, -, hrec, hj1⟩)
-          · exact absurd h hj
-          · rw [show j + 1 - 1 = j from rfl] at hrec
-            refine ⟨?_, by simpa using hj1⟩
-            rw [List.take_succ_cons, List.count_cons_of_ne (by decide)]
-            omega
-        · rintro ⟨hp, hj1⟩
-          rw [List.take_succ_cons, List.count_cons_of_ne (by decide)] at hp
-          refine Or.inr ⟨by omega, by omega, ?_, by simpa using hj1⟩
-          have : j + 1 - 1 = j := by omega
-          rw [this]
-          omega
+  have hoff : AR.tierOffset toAR true w j = (w.take j).count .H := by
+    simp only [AR.tierOffset, AR.tierLength_realize, tierLength_toAR_true, sum_length_melody]
+  rw [AR.link_realize_of_tierLength_eq_one toAR fun _ => tierLength_toAR_false _]
+  simp only [link_toAR, hoff, and_true, length_melody,
+    List.getElem?_eq_some_iff]
+  constructor
+  · rintro ⟨hj, hle, hlt⟩
+    split_ifs at hlt with h
+    · exact ⟨by omega, hj, h⟩
+    · omega
+  · rintro ⟨rfl, hj, h⟩
+    exact ⟨hj, le_rfl, by simp [h]⟩
 
-/-- Links of the OCP-merged realization: the single fused `H` node (index `0`)
-    links exactly to the H-toned slots. -/
+/-- Links of the OCP-merged realization: the single fused `H` node (index `0`) links
+exactly to the H-toned slots. -/
 theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
-    ((Autosegmental.AR.realize toRep w).collapse true).link true false k j ↔
-      k = 0 ∧ w[j]? = some .H := by
-  haveI := Autosegmental.AR.realize.instFinite toRep w
-  rw [Autosegmental.AR.link_collapse]
+    ((AR.realize toAR w).collapse true).link true false k j ↔ k = 0 ∧ w[j]? = some .H := by
+  rw [AR.link_collapse]
+  simp only [AR.collapseIdx_self, AR.collapseIdx_of_ne _ true (by decide : false ≠ true),
+    link_realize_toAR, tierWord_realize_toAR_true, OCP.runIdx_replicate]
   constructor
-  · rintro ⟨p, q, hl, hk, hjq⟩
-    obtain ⟨hp, hq⟩ := (link_realize_toRep w p q).mp hl
-    refine ⟨?_, ?_⟩
-    · rw [← hk]
-      unfold Autosegmental.AR.collapseIdx
-      rw [if_pos rfl, tierWord_realize_toRep_true]
-      exact OCP.runIdx_replicate _ _ _
-    · rw [← hjq]
-      unfold Autosegmental.AR.collapseIdx
-      rw [if_neg (by decide)]
-      exact hq
-  · rintro ⟨rfl, hj⟩
-    refine ⟨(w.take j).count .H, j, (link_realize_toRep w _ j).mpr ⟨rfl, hj⟩, ?_, ?_⟩
-    · unfold Autosegmental.AR.collapseIdx
-      rw [if_pos rfl, tierWord_realize_toRep_true]
-      exact OCP.runIdx_replicate _ _ _
-    · unfold Autosegmental.AR.collapseIdx
-      rw [if_neg (by decide)]
+  · rintro ⟨p, q, ⟨-, h⟩, rfl, rfl⟩
+    exact ⟨rfl, h⟩
+  · rintro ⟨rfl, h⟩
+    exact ⟨_, j, ⟨rfl, h⟩, rfl, rfl⟩
 
-/-- **What surfaces is the representation**: slot `j` is H-linked in
-    `plateauRep w` iff some H-toned TBU lies at or before `j` and some at or
-    after it — fusion then spreading, read back as the string window. -/
-theorem link_plateauRep (w : List TBU) (j : ℕ) :
-    (∃ k, (plateauRep w).link true false k j) ↔
-      .H ∈ w.take (j + 1) ∧ .H ∈ w.drop j := by
-  haveI := Autosegmental.AR.realize.instFinite toRep w
-  have hlen : ((Autosegmental.AR.realize toRep w).collapse true).tierLength false
-      = w.length := by
-    rw [← Autosegmental.AR.length_tierWord,
-      Autosegmental.AR.tierWord_collapse,
-      show (Autosegmental.AR.realize toRep w).collapsedWord true false
-        = (Autosegmental.AR.realize toRep w).tierWord false from
-        Function.update_of_ne (by decide) _ _,
-      tierWord_realize_toRep_false]
-    exact List.length_replicate
-  rw [List.mem_take_iff, List.mem_drop_iff]
-  constructor
-  · rintro ⟨k, hk⟩
-    obtain ⟨-, hjb, -⟩ := id hk
-    have hlenh : (plateauRep w).tierLength false = w.length := by
-      rw [← Autosegmental.AR.length_tierWord,
-        show (plateauRep w).tierWord false
-          = ((Autosegmental.AR.realize toRep w).collapse true).tierWord false from
-          Autosegmental.AR.tierWord_hull true _ false,
-        Autosegmental.AR.length_tierWord, hlen]
-    have hjw : j < w.length := hlenh ▸ hjb
-    obtain ⟨q₁, q₂, h₁, h₂, hle₁, hle₂⟩ :=
-      (Autosegmental.AR.link_hull_left true _ (by decide)
-        (by omega : j < ((Autosegmental.AR.realize toRep w).collapse true).tierLength false)).mp hk
-    obtain ⟨-, hq₁⟩ := (link_realizeMerged w k q₁).mp h₁
-    obtain ⟨-, hq₂⟩ := (link_realizeMerged w k q₂).mp h₂
-    exact ⟨⟨q₁, by omega, hq₁⟩, q₂, hle₂, hq₂⟩
-  · rintro ⟨⟨q₁, hq₁b, hq₁⟩, q₂, hq₂b, hq₂⟩
-    have hq₂w : q₂ < w.length := by
-      rcases List.getElem?_eq_some_iff.mp hq₂ with ⟨h, -⟩
-      exact h
-    have hl₁ := (link_realizeMerged w 0 q₁).mpr ⟨rfl, hq₁⟩
-    have hl₂ := (link_realizeMerged w 0 q₂).mpr ⟨rfl, hq₂⟩
-    exact ⟨0, (Autosegmental.AR.link_hull_left true _ (by decide)
-      (by omega : j < ((Autosegmental.AR.realize toRep w).collapse true).tierLength false)).mpr
-      ⟨q₁, q₂, hl₁, hl₂, by omega, hq₂b⟩⟩
+/-- The output representation in coordinates: OCP-merge then hull, both at the melody
+tier. -/
+noncomputable def plateauAR (w : List TBU) : TieredAR Bool (TwoTier TRN Unit) :=
+  ((AR.realize toAR w).collapse true).hull true
 
-end TierWords
+instance (w : List TBU) : Finite (plateauAR w).obj.V :=
+  inferInstanceAs (Finite (((AR.realize toAR w).collapse true).hull true).obj.V)
+
+/-- Links of the output representation: the fused `H` links to slot `j` iff some H-toned
+TBU lies at or before `j` and some at or after it — fusion then spreading, read back as
+the string window. -/
+theorem link_plateauAR (w : List TBU) (k j : ℕ) :
+    (plateauAR w).link true false k j ↔ k = 0 ∧ .H ∈ w.take (j + 1) ∧ .H ∈ w.drop j := by
+  by_cases hj : j < w.length
+  · unfold plateauAR
+    rw [AR.link_hull_left true _ (by decide)
+      (by simpa using hj : j < ((AR.realize toAR w).collapse true).tierLength false)]
+    simp only [link_realizeMerged, List.mem_take_iff_getElem?, List.mem_drop_iff_getElem?,
+      Nat.lt_succ_iff]
+    constructor
+    · rintro ⟨q₁, q₂, ⟨rfl, h₁⟩, ⟨-, h₂⟩, hle₁, hle₂⟩
+      exact ⟨rfl, ⟨q₁, hle₁, h₁⟩, q₂, hle₂, h₂⟩
+    · rintro ⟨rfl, ⟨q₁, hle₁, h₁⟩, q₂, hle₂, h₂⟩
+      exact ⟨q₁, q₂, ⟨rfl, h₁⟩, ⟨rfl, h₂⟩, hle₁, hle₂⟩
+  · refine iff_of_false (fun h => hj ?_) fun ⟨_, _, h⟩ => hj (List.lt_length_of_mem_drop h)
+    obtain ⟨-, hq, -⟩ := id h
+    simpa [plateauAR] using hq
+
+/-- Slot `j` surfaces with H in the output representation iff the string window holds. -/
+theorem surfacesWith_plateauAR (w : List TBU) (j : ℕ) :
+    (plateauAR w).surfacesWith TRN.H j ↔ .H ∈ w.take (j + 1) ∧ .H ∈ w.drop j := by
+  simp only [AR.surfacesWith, link_plateauAR, and_assoc, exists_eq_left]
+  refine and_congr_right fun hA => and_iff_left_of_imp fun _ => ?_
+  obtain ⟨n, hn⟩ := Nat.exists_eq_succ_of_ne_zero
+    (List.count_pos_iff.mpr (List.take_subset _ _ hA)).ne'
+  simp [plateauAR, hn]
+  rfl
 
 /-! ### The plateauing process -/
 
-/-- Unbounded tonal plateauing as a surfacing process: a TBU surfaces the marked tone
-`H` iff its timing node is H-linked in the output representation. -/
+/-- Unbounded tonal plateauing as a surfacing process: TBU `i` surfaces H iff some H-toned
+TBU lies at or before it and some at or after it. -/
+@[simps hi lo]
 def utp : Surfacing TBU where
   hi := .H
   lo := .O
   Surfaces w i := .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i
   hi_ne_lo := by decide
-  lt_length h := by
-    have h₂ := List.length_pos_of_mem h.2
-    rw [List.length_drop] at h₂
-    omega
+  lt_length h := List.lt_length_of_mem_drop h.2
   surfaces_of_hi h :=
-    ⟨List.mem_take_iff.mpr ⟨_, Nat.lt_succ_self _, h⟩, List.mem_drop_iff.mpr ⟨_, le_rfl, h⟩⟩
+    ⟨List.mem_take_iff_getElem?.mpr ⟨_, Nat.lt_succ_self _, h⟩,
+      List.mem_drop_iff_getElem?.mpr ⟨_, le_rfl, h⟩⟩
   decSurfaces w i := inferInstanceAs (Decidable (_ ∧ _))
 
-/-- **What surfaces is the representation**: `utp.Surfaces w i` is H-linkedness
-    of timing slot `i` in the coordinate output representation `plateauRep w` —
-    the OCP-merged, hull-closed realization. -/
-theorem utp.surfaces_iff_link_plateauRep {w : List TBU} {i : ℕ} :
-    utp.Surfaces w i ↔ ∃ k, (plateauRep w).link true false k i :=
-  (link_plateauRep w i).symm
-
-@[simp] theorem utp.hi_def : utp.hi = .H := rfl
-
-@[simp] theorem utp.lo_def : utp.lo = .O := rfl
+variable {w : List TBU} {i j k : ℕ}
 
 /-- The string-level reading of surfacing: the windowed form, definitional. -/
-theorem utp.surfaces_def {w : List TBU} {i : ℕ} :
-    utp.Surfaces w i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i :=
+theorem utp.surfaces_def : utp.Surfaces w i ↔ .H ∈ w.take (i + 1) ∧ .H ∈ w.drop i :=
   Iff.rfl
 
-variable {w : List TBU} {i j k : ℕ}
+/-- **What surfaces is the representation**: `utp.Surfaces w i` is H-linkedness of timing
+slot `i` in the output representation `plateauAR w` — the OCP-merged, hull-closed
+realization. -/
+theorem utp.surfaces_iff_surfacesWith_plateauAR :
+    utp.Surfaces w i ↔ (plateauAR w).surfacesWith TRN.H i :=
+  (surfacesWith_plateauAR w i).symm
 
 /-- Positionwise reading of surfacing: a H at some `j ≤ i` and a H at some `j ≥ i`. -/
 theorem utp.surfaces_iff :
     utp.Surfaces w i ↔ (∃ j ≤ i, w[j]? = some .H) ∧ ∃ j ≥ i, w[j]? = some .H := by
-  rw [utp.surfaces_def, List.mem_take_iff, List.mem_drop_iff]
+  rw [utp.surfaces_def, List.mem_take_iff_getElem?, List.mem_drop_iff_getElem?]
   simp
 
 /-- The surfacing set is convex: the windows only widen. -/
-theorem _root_.Tone.Surfacing.Surfaces.of_le_of_le (hi : utp.Surfaces w i)
-    (hk : utp.Surfaces w k) (hij : i ≤ j) (hjk : j ≤ k) : utp.Surfaces w j :=
+theorem utp.surfaces_of_le_of_le (hi : utp.Surfaces w i) (hk : utp.Surfaces w k)
+    (hij : i ≤ j) (hjk : j ≤ k) : utp.Surfaces w j :=
   utp.surfaces_def.mpr
     ⟨w.take_subset_take_left (by omega) (utp.surfaces_def.mp hi).1,
       w.drop_subset_drop_left (by omega) (utp.surfaces_def.mp hk).2⟩
 
-theorem _root_.Tone.Surfacing.Surfaces.H_mem (h : utp.Surfaces w i) : .H ∈ w :=
+theorem utp.H_mem_of_surfaces (h : utp.Surfaces w i) : .H ∈ w :=
   List.take_subset _ _ (utp.surfaces_def.mp h).1
 
 /-- Reversal symmetry: under `reverse` the two windows swap. -/
@@ -415,7 +295,7 @@ def plateau (w : List TBU) : Finset ℕ := utp.support w
 @[simp] theorem mem_plateau : j ∈ plateau w ↔ utp.Surfaces w j := utp.mem_support
 
 @[simp] theorem plateau_nonempty : (plateau w).Nonempty ↔ .H ∈ w :=
-  ⟨fun ⟨_, hj⟩ => (mem_plateau.mp hj).H_mem, fun hw =>
+  ⟨fun ⟨_, hj⟩ => utp.H_mem_of_surfaces (mem_plateau.mp hj), fun hw =>
     have ⟨i, hi⟩ := List.mem_iff_getElem?.mp hw
     ⟨i, mem_plateau.mpr (utp.surfaces_of_hi hi)⟩⟩
 
@@ -442,7 +322,7 @@ theorem plateau_eq_Icc (hne : (plateau w).Nonempty) :
   ext j
   rw [Finset.mem_Icc]
   refine ⟨fun hj => ⟨(plateau w).min'_le j hj, (plateau w).le_max' j hj⟩, fun ⟨h₁, h₂⟩ =>
-    mem_plateau.mpr ((mem_plateau.mp ((plateau w).min'_mem hne)).of_le_of_le
+    mem_plateau.mpr (utp.surfaces_of_le_of_le (mem_plateau.mp ((plateau w).min'_mem hne))
       (mem_plateau.mp ((plateau w).max'_mem hne)) h₁ h₂)⟩
 
 /-! ### Closure laws
@@ -458,7 +338,7 @@ theorem utp.map_getElem?_H_of_getElem?_H (h : w[i]? = some .H) :
   utp.map_getElem?_hi_of_getElem?_hi h
 
 /-- Surfacing is monotone in the word's H-set. -/
-theorem _root_.Tone.Surfacing.Surfaces.mono {w' : List TBU}
+theorem utp.surfaces_mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (h : utp.Surfaces w i) :
     utp.Surfaces w' i := by
   obtain ⟨⟨l, hl, hlH⟩, r, hr, hrH⟩ := utp.surfaces_iff.mp h
@@ -468,12 +348,12 @@ theorem _root_.Tone.Surfacing.Surfaces.mono {w' : List TBU}
 theorem utp.map_mono {w' : List TBU}
     (hw : ∀ j : ℕ, w[j]? = some TBU.H → w'[j]? = some TBU.H) (j : ℕ)
     (h : (utp.map w)[j]? = some TBU.H) : (utp.map w')[j]? = some TBU.H :=
-  utp.map_getElem?_H_iff.mpr ((utp.map_getElem?_H_iff.mp h).mono hw)
+  utp.map_getElem?_H_iff.mpr (utp.surfaces_mono hw (utp.map_getElem?_H_iff.mp h))
 
 /-- Plateauing preserves the presence of a trigger in both directions. -/
 theorem utp.H_mem_map : .H ∈ utp.map w ↔ .H ∈ w :=
   ⟨fun h => have ⟨_, hi⟩ := List.mem_iff_getElem?.mp h
-    (utp.map_getElem?_H_iff.mp hi).H_mem,
+    utp.H_mem_of_surfaces (utp.map_getElem?_H_iff.mp hi),
    fun h => have ⟨i, hi⟩ := List.mem_iff_getElem?.mp h
     List.mem_iff_getElem?.mpr ⟨i, utp.map_getElem?_H_of_getElem?_H hi⟩⟩
 
@@ -554,7 +434,7 @@ example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 Whether the target surfaces is controlled by unboundedly distant flanks: instantiate
 the flank-witness template with `2d+2` toneless TBUs between the flanks. -/
 
-/-- UTP requires both sides ([jardine-2016]): its trigger is the two-sided window
+/-- UTP requires both sides ([jardine-2016a]): its trigger is the two-sided window
 conjunction, so deleting either flanking H reverts the plateau target. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map :=
   utp.requiresBothSides_of_surfaces_iff fun _ _ => utp.surfaces_def

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -10,7 +10,7 @@ import Linglib.Phonology.Subregular.Dependence
 /-!
 # Tonal surfacing processes
 
-A **surfacing process** bundles the analysis [jardine-2016] gives tone-string maps: a
+A **surfacing process** bundles the analysis [jardine-2016a] gives tone-string maps: a
 marked tone value, and a context predicate `Surfaces w i` saying position `i` of `w`
 surfaces with it. The induced rewrite `Surfacing.map` writes the marked tone exactly at
 the surfacing positions and the default elsewhere; `Surfacing.support` is the surfacing

--- a/Linglib/Studies/Jardine2016a.lean
+++ b/Linglib/Studies/Jardine2016a.lean
@@ -16,7 +16,7 @@ import Linglib.Phonology.Tone.Plateauing
 /-!
 # Jardine (2016): Computationally, tone is different
 
-[jardine-2016] (Phonology 33) characterises a typological asymmetry computationally:
+[jardine-2016a] (Phonology 33) characterises a typological asymmetry computationally:
 *unbounded circumambient* processes — application depends on unboundedly distant material
 on both sides of the target — are common in tone but rare in segmental phonology, and
 they are exactly the attested maps exceeding weak determinism. The flagship witness is
@@ -31,30 +31,25 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 ## Main definitions
 
 * `markLeft`, `resolve` — the (43) two-pass decomposition over the `?`-enlarged alphabet.
-* `toAR` — the (40) translation into autosegmental representations.
 
 ## Main results
 
 * `utp_not_isSubsequential` — the central theorem (§4.2, online appendix): no
   deterministic FST computes UTP in either direction, via
-  `IsLeftSubsequential.bounded_delay` and the reversal symmetry `utp.map_reverse`.
+  `not_isLeftSubsequential_of_diverging` and the reversal symmetry `utp.map_reverse`.
 * `utp_not_weaklyDeterministic` — §5.2, via `RequiresBothSides`: no union of
   one-sided rules expresses UTP's conjunctive trigger.
 * `utp_markup_decomposition` — (43): with the mark `?`, UTP is right-subsequential after
   left-subsequential; weak determinism forbids exactly this enlargement.
 * `utp_isBimachineComputable` — §4.2: UTP is regular, the (43) decomposition read through
   Elgot–Mezei composition.
-* `readTBU_linearize_realize` — §4.4: the TBU string is the linearization of the realized
-  AR ((37a)), so string look-ahead is timing-tier look-ahead.
-* `links_realizeMerged_utp`, `upper_realizeMerged_utp` — the OCP-merged realization of
-  the UTP output is a single H multiply linked to the `plateau`
-  ([hyman-katamba-2010] (7)).
+* `link_realizeMerged_map` — the OCP-merged realization of the UTP output is a single H
+  linked exactly to the surfacing positions ([hyman-katamba-2010] (7)).
 * `utp_fullyRegular` — §7: UTP is regular but neither subsequential nor weakly
   deterministic.
-
 -/
 
-namespace Jardine2016Tone
+namespace Jardine2016a
 
 open Tone.Plateauing
 
@@ -135,7 +130,7 @@ private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
 /-- The (43) decomposition computes UTP. -/
 theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w) := by
   have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
-    fun i => by simp only [List.mem_drop_iff, markLeft_run_H_iff]
+    fun i => by simp only [List.mem_drop_iff_getElem?, markLeft_run_H_iff]
   refine List.ext_getElem? fun i => ?_
   rw [utp.map_getElem?, resolve, resolveRight, Mealy.getElem?_ofFlag_runRight]
   simp only [List.any_beq', List.contains_eq_mem, decide_eq_decide.mpr (hmark i)]
@@ -189,13 +184,13 @@ fuses to one `H`, linked exactly to the surfacing slots. -/
 /-- (7) in coordinates: the merged output's links are the fused `H` node over
     the surfacing positions. -/
 theorem link_realizeMerged_map {w : List TBU} {k j : ℕ} :
-    ((Autosegmental.AR.realize Tone.Plateauing.toRep (utp.map w)).collapse true).link
+    ((Autosegmental.AR.realize Tone.Plateauing.toAR (utp.map w)).collapse true).link
         true false k j ↔ k = 0 ∧ utp.Surfaces w j := by
   rw [Tone.Plateauing.link_realizeMerged, utp.map_getElem?_H_iff]
 
 /-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
 example : ∀ j < 4,
-    ((Autosegmental.AR.realize Tone.Plateauing.toRep
+    ((Autosegmental.AR.realize Tone.Plateauing.toAR
       (utp.map [.H, .O, .O, .H])).collapse true).link true false 0 j := by
   intro j hj
   rw [link_realizeMerged_map]
@@ -216,4 +211,4 @@ theorem utp_fullyRegular :
       ∧ ¬ IsNonInteractingBimachineComputable utp.map :=
   ⟨utp_isBimachineComputable, utp_not_isSubsequential, utp_not_weaklyDeterministic⟩
 
-end Jardine2016Tone
+end Jardine2016a

--- a/Linglib/Studies/Jardine2016b.lean
+++ b/Linglib/Studies/Jardine2016b.lean
@@ -8,7 +8,7 @@ import Linglib.Phonology.Autosegmental.Correspondence
 /-!
 # Jardine (2016): transformations as correspondence-graph relations
 
-[jardine-2016] (Ch. 7) presents a phonological process as a **relation** between input
+[jardine-2016b] (Ch. 7) presents a phonological process as a **relation** between input
 and output, given by correspondence graphs carved out of GEN by banned-subgraph
 constraints. This file exercises the `Autosegmental.Correspondence` substrate on the
 intervocalic-voicing schema (Jardine's running example): a faithfulness constraint
@@ -24,7 +24,7 @@ and Jardine's *output-only* markedness `*VTV` needs the arc-labelled-subgraph re
 (Ch. 7 fn. 7). Both are deferred — see `Autosegmental/Correspondence.lean`.
 -/
 
-namespace Jardine2016
+namespace Jardine2016b
 
 open Autosegmental Correspondence
 
@@ -160,9 +160,9 @@ theorem gVoice_specified : specifiedByRep [noPP] gVoice := by
   · exact absurd h1 (by decide)
 
 /-- Hence `apa ↔ aba` lies in the relation presented by the local grammar
-    `*[p↔p]`, witnessed by `gVoice` ([jardine-2016] Def. 25). -/
+    `*[p↔p]`, witnessed by `gVoice` ([jardine-2016b] Def. 25). -/
 theorem voicing_local :
     relRep (specifiedByRep [noPP]) [Seg.a, .p, .a] [Seg.a, .b, .a] :=
   ⟨gVoice, gVoice_specified, gVoice_io.1, gVoice_io.2⟩
 
-end Jardine2016
+end Jardine2016b

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -38,7 +38,7 @@ false, [lamont-ohara-smith-2019] Thm. 3.1 — via [padgett-1995]/[wilson-2003]'s
 pathology), and — through the shared
 witnesses already in the library — Tutrugbu ATR harmony (Prop. 5.5,
 [mccollum-bakovic-mai-meinhardt-2020]), Luganda unbounded tonal plateauing
-([jardine-2016]), and Copperbelt Bemba high-tone spreading (Prop. 5.4), the latter
+([jardine-2016a]), and Copperbelt Bemba high-tone spreading (Prop. 5.4), the latter
 formalized here as a second `Tone.Surfacing` instance. The positive
 side: with no underlying stress the input predicate is constantly `⊥` and ⊙ collapses
 to disjunction — (5.15), recovering [koser-jardine-2020]'s LHOL program as the
@@ -242,7 +242,7 @@ theorem tutrugbu_not_bmrsWeaklyDeterministic :
   not_isBmrsWeaklyDeterministic_of_requiresBothSides
     McCollumEtAl2020.tutrugbu_requiresBothSides
 
-/-- Luganda unbounded tonal plateauing is not weakly deterministic: [jardine-2016]'s
+/-- Luganda unbounded tonal plateauing is not weakly deterministic: [jardine-2016a]'s
 flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
 `Phonology/Tone/Plateauing`'s witness. -/
 theorem utp_not_bmrsWeaklyDeterministic :
@@ -252,7 +252,7 @@ theorem utp_not_bmrsWeaklyDeterministic :
 
 /-! ### Bemba high-tone spreading is not weakly deterministic (Prop. 5.4)
 
-Copperbelt Bemba ([jardine-2016]; the paper's bounded/unbounded spreading data): a high
+Copperbelt Bemba ([jardine-2016a]; the paper's bounded/unbounded spreading data): a high
 tone spreads to the end of the word when no high follows it, and only onto the next two
 TBUs when one does. A second `Tone.Surfacing` instance — and a cautionary one: unlike
 plateauing, the surface set is not convex and the map is neither monotone nor

--- a/references.bib
+++ b/references.bib
@@ -32781,7 +32781,7 @@
   sources   = {Phonology/Autosegmental/MixedGraph.lean}
 }
 
-@phdthesis{jardine-2016-diss,
+@phdthesis{jardine-2016b,
   author    = {Jardine, Adam},
   year      = {2016},
   title     = {Locality and Non-linear Representations in Tonal Phonology},
@@ -32789,10 +32789,10 @@
   subfield  = {phonology/autosegmental},
   validated = {true},
   role      = {cited},
-  sources   = {Phonology/Autosegmental/Correspondence.lean; Phonology/Autosegmental/ASL.lean; Phonology/Autosegmental/MixedGraph.lean}
+  sources   = {Phonology/Autosegmental/Correspondence.lean; Phonology/Autosegmental/ASL.lean; Phonology/Autosegmental/MixedGraph.lean; Studies/Jardine2016b.lean}
 }
 
-@article{jardine-2016,
+@article{jardine-2016a,
   author    = {Jardine, Adam},
   year      = {2016},
   title     = {Computationally, tone is different},
@@ -32804,7 +32804,7 @@
   subfield  = {phonology/subregular},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/Jardine2016Tone.lean; Phonology/Tone/Plateauing.lean}
+  sources   = {Studies/Jardine2016a.lean; Phonology/Tone/Plateauing.lean}
 }
 
 % REF: Aksënova, Rawski, Graf & Heinz (2020). The Computational Power of


### PR DESCRIPTION
Random-file audit of `Core/Data/List/TakeDrop.lean`, grown into the cleanse of the file it feeds.

- `mem_take_iff`/`mem_drop_iff` → `mem_take_iff_getElem?`/`mem_drop_iff_getElem?` (core's naming), plus `lt_length_of_mem_drop`.
- `Jardine2016Tone`/`Jardine2016` → `Jardine2016a` (article) / `Jardine2016b` (dissertation; it was citing the article key for Ch. 7 content); bib keys `jardine-2016a`/`jardine-2016b`.
- `Autosegmental`: the link half of realization compositionality (`AR.tierOffset`, `AR.link_realize`, `AR.link_realize_of_tierLength_eq_one`) and a builder/collapse simp kit; `Plateauing` rederives its representation-level theorems from them (`link_realize_toRep` 95 → 14 lines), `toRep`/`plateauRep` → `toAR`/`plateauAR`, utp-specific lemmas out of the `Surfacing.Surfaces` namespace.