### PR TITLE
refactor(Phonology/Tone): Tone.Plateauing → Tone; Jardine2016a cleanse

### DIFF
--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -426,6 +426,17 @@ theorem isRightSubsequential_iff_left_reverse :
       ↔ IsLeftSubsequential (fun xs => (f xs.reverse).reverse) :=
   Iff.rfl
 
+/-- A finite Mealy machine computes a left-subsequential function. -/
+theorem Mealy.isLeftSubsequential_run {σ : Type*} [Fintype σ] (T : Mealy σ α β) :
+    IsLeftSubsequential T.run :=
+  T.isMealyComputable.isLeftSubsequential
+
+/-- A finite Mealy machine run right-to-left computes a right-subsequential function. -/
+theorem Mealy.isRightSubsequential_runRight {σ : Type*} [Fintype σ] (T : Mealy σ α β) :
+    IsRightSubsequential T.runRight := by
+  rw [isRightSubsequential_iff_left_reverse]
+  simpa using T.isLeftSubsequential_run
+
 /-- A left-subsequential function withholds at most the longest state-final output:
 `f u` and `f (u ++ v)` share a prefix covering all but boundedly many symbols of `f u`.
 Much weaker than [choffrut-1977]'s bounded-variation characterization — this compares

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -24,7 +24,7 @@ surfacing predicate, the two-sided window `H ∈ w.take (i + 1) ∧ H ∈ w.drop
 before `i` and one at or after it. The map is `utp.map`, the surfacing set `plateau`.
 
 What surfaces is the representation. The string reads back into two-tier autosegmental
-representations by `toAR`, and the output representation `plateauAR w` is the OCP-merged
+representations by `TBU.toAR`, and the output representation `plateauAR w` is the OCP-merged
 input, hull-closed — fusion then spreading. Timing slot `i` surfaces with H in `plateauAR w`
 exactly when `utp.Surfaces w i` (`utp.surfaces_iff_surfacesWith_plateauAR`).
 
@@ -37,19 +37,19 @@ exclusion theorems of `Studies/Jardine2016a` (bimachine rendering) and `Studies/
 
 ## Main definitions
 
-* `Tone.Plateauing.TBU` — the H/Ø string alphabet (association states; distinct from
-  `Tone.TBUKind`, the phonological typology of timing units).
-* `Tone.Plateauing.toAR`, `Tone.Plateauing.plateauAR` — the translation of a TBU into a
-  one-slot representation, and the output representation (OCP-merged input, hull-closed).
-* `Tone.Plateauing.utp` — plateauing as a `Tone.Surfacing` process; `utp.map` the map.
-* `Tone.Plateauing.plateau` — the set of surfacing positions.
+* `Tone.TBU` — the H/Ø string alphabet (association states; distinct from `Tone.TBUKind`,
+  the phonological typology of timing units).
+* `Tone.TBU.toAR`, `Tone.plateauAR` — the translation of a TBU into a one-slot
+  representation, and the output representation (OCP-merged input, hull-closed).
+* `Tone.utp` — plateauing as a `Tone.Surfacing` process; `utp.map` the map.
+* `Tone.plateau` — the set of surfacing positions.
 
 ## Main results
 
 * `utp.surfaces_iff_surfacesWith_plateauAR` — surfacing is H-linkedness in the output
   representation.
 * `utp.map_getElem?_H_iff` / `utp.map_getElem?_O_iff` — pointwise characterization of the map.
-* `utp_eq_plateau_indicator`, `plateau_eq_Icc` — the output is the indicator word of an
+* `utp.map_eq_plateau_indicator`, `plateau_eq_Icc` — the output is the indicator word of an
   interval, from the first trigger to the last.
 * `utp.map_toneless`, `utp.map_single`, `utp.map_plateau` — the rule schemata: toneless words
   and lone Hs are unchanged; everything between the outermost Hs surfaces H.
@@ -59,7 +59,7 @@ exclusion theorems of `Studies/Jardine2016a` (bimachine rendering) and `Studies/
   every distance.
 -/
 
-namespace Tone.Plateauing
+namespace Tone
 
 /-! ### The tone-bearing-unit alphabet -/
 
@@ -75,6 +75,8 @@ OCP-fusion followed by hull-closure of the association lines ([hyman-katamba-201
 as an operation on structures). -/
 
 open Autosegmental
+
+namespace TBU
 
 /-- The melody a TBU contributes: its H tone if H-toned, nothing otherwise. -/
 def melody : TBU → List TRN
@@ -144,8 +146,7 @@ theorem link_realize_toAR (w : List TBU) (p j : ℕ) :
   have hoff : AR.tierOffset toAR true w j = (w.take j).count .H := by
     simp only [AR.tierOffset, AR.tierLength_realize, tierLength_toAR_true, sum_length_melody]
   rw [AR.link_realize_of_tierLength_eq_one toAR fun _ => tierLength_toAR_false _]
-  simp only [link_toAR, hoff, and_true, length_melody,
-    List.getElem?_eq_some_iff]
+  simp only [link_toAR, hoff, and_true, length_melody, List.getElem?_eq_some_iff]
   constructor
   · rintro ⟨hj, hle, hlt⟩
     split_ifs at hlt with h
@@ -156,7 +157,7 @@ theorem link_realize_toAR (w : List TBU) (p j : ℕ) :
 
 /-- Links of the OCP-merged realization: the single fused `H` node (index `0`) links
 exactly to the H-toned slots. -/
-theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
+theorem link_collapse_realize_toAR (w : List TBU) (k j : ℕ) :
     ((AR.realize toAR w).collapse true).link true false k j ↔ k = 0 ∧ w[j]? = some .H := by
   rw [AR.link_collapse]
   simp only [AR.collapseIdx_self, AR.collapseIdx_of_ne _ true (by decide : false ≠ true),
@@ -167,13 +168,15 @@ theorem link_realizeMerged (w : List TBU) (k j : ℕ) :
   · rintro ⟨rfl, h⟩
     exact ⟨_, j, ⟨rfl, h⟩, rfl, rfl⟩
 
+end TBU
+
 /-- The output representation in coordinates: OCP-merge then hull, both at the melody
 tier. -/
 noncomputable def plateauAR (w : List TBU) : TieredAR Bool (TwoTier TRN Unit) :=
-  ((AR.realize toAR w).collapse true).hull true
+  ((AR.realize TBU.toAR w).collapse true).hull true
 
 instance (w : List TBU) : Finite (plateauAR w).obj.V :=
-  inferInstanceAs (Finite (((AR.realize toAR w).collapse true).hull true).obj.V)
+  inferInstanceAs (Finite (((AR.realize TBU.toAR w).collapse true).hull true).obj.V)
 
 /-- Links of the output representation: the fused `H` links to slot `j` iff some H-toned
 TBU lies at or before `j` and some at or after it — fusion then spreading, read back as
@@ -183,9 +186,9 @@ theorem link_plateauAR (w : List TBU) (k j : ℕ) :
   by_cases hj : j < w.length
   · unfold plateauAR
     rw [AR.link_hull_left true _ (by decide)
-      (by simpa using hj : j < ((AR.realize toAR w).collapse true).tierLength false)]
-    simp only [link_realizeMerged, List.mem_take_iff_getElem?, List.mem_drop_iff_getElem?,
-      Nat.lt_succ_iff]
+      (by simpa using hj : j < ((AR.realize TBU.toAR w).collapse true).tierLength false)]
+    simp only [TBU.link_collapse_realize_toAR, List.mem_take_iff_getElem?,
+      List.mem_drop_iff_getElem?, Nat.lt_succ_iff]
     constructor
     · rintro ⟨q₁, q₂, ⟨rfl, h₁⟩, ⟨-, h₂⟩, hle₁, hle₂⟩
       exact ⟨rfl, ⟨q₁, hle₁, h₁⟩, q₂, hle₂, h₂⟩
@@ -300,7 +303,7 @@ def plateau (w : List TBU) : Finset ℕ := utp.support w
     ⟨i, mem_plateau.mpr (utp.surfaces_of_hi hi)⟩⟩
 
 /-- `utp.map` writes the indicator word of its plateau. -/
-theorem utp_eq_plateau_indicator :
+theorem utp.map_eq_plateau_indicator :
     utp.map w
       = (List.range w.length).map fun i => if i ∈ plateau w then TBU.H else TBU.O :=
   utp.map_eq_indicator
@@ -370,14 +373,14 @@ theorem utp.surfaces_map : utp.Surfaces (utp.map w) i ↔ utp.Surfaces w i := by
   · exact fun h => utp.surfaces_iff.mpr ⟨⟨i, le_rfl, utp.map_getElem?_H_iff.mpr h⟩,
       i, le_rfl, utp.map_getElem?_H_iff.mpr h⟩
 
-@[simp] theorem plateau_utp : plateau (utp.map w) = plateau w := by
+@[simp] theorem plateau_map : plateau (utp.map w) = plateau w := by
   ext j
   rw [mem_plateau, mem_plateau, utp.surfaces_map]
 
 /-- Idempotence: a plateau is already closed. -/
 @[simp] theorem utp.map_map : utp.map (utp.map w) = utp.map w := by
-  rw [utp_eq_plateau_indicator (w := utp.map w), plateau_utp, Surfacing.map_length,
-    ← utp_eq_plateau_indicator]
+  rw [utp.map_eq_plateau_indicator (w := utp.map w), plateau_map, Surfacing.map_length,
+    ← utp.map_eq_plateau_indicator]
 
 /-! ### The plateauing rule
 
@@ -387,7 +390,7 @@ The rule schemata as theorems about `utp` rather than clauses of its definition.
 theorem utp.map_toneless (n : ℕ) : utp.map (List.replicate n .O) = List.replicate n .O := by
   have h : plateau (List.replicate n TBU.O) = ∅ :=
     Finset.not_nonempty_iff_eq_empty.mp (by simp)
-  simp [utp_eq_plateau_indicator, h, List.map_const']
+  simp [utp.map_eq_plateau_indicator, h, List.map_const']
 
 /-- A word with a single H is unchanged — one H cannot trigger a plateau. -/
 theorem utp.map_single (m n : ℕ) :
@@ -398,7 +401,7 @@ theorem utp.map_single (m n : ℕ) :
     simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
       List.length_replicate]
     split_ifs <;> simp_all <;> omega
-  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of ((hH m).mpr rfl) ((hH m).mpr rfl)
+  rw [utp.map_eq_plateau_indicator, plateau_eq_Icc_of ((hH m).mpr rfl) ((hH m).mpr rfl)
     fun j hj => by rw [hH j] at hj; omega]
   refine List.ext_getElem (by simp) fun i h₁ h₂ => ?_
   simp only [List.getElem_map, List.getElem_range, List.getElem_append, List.getElem_cons,
@@ -415,7 +418,7 @@ theorem utp.map_plateau (m p : ℕ) (w : List TBU) :
     simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
       List.length_replicate] at hj
     split_ifs at hj <;> first | omega | simp_all
-  rw [utp_eq_plateau_indicator, plateau_eq_Icc_of (by simp) (by
+  rw [utp.map_eq_plateau_indicator, plateau_eq_Icc_of (by simp) (by
       simp only [List.getElem?_append, List.getElem?_cons, List.getElem?_replicate,
         List.length_replicate]
       split_ifs <;> first | rfl | omega) hb]
@@ -444,4 +447,4 @@ position changes depends on unboundedly distant material on both sides. -/
 theorem utp.twoSidedUnboundedDependence : TwoSidedUnboundedDependence utp.map :=
   utp.requiresBothSides.twoSidedUnboundedDependence
 
-end Tone.Plateauing
+end Tone

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -15,7 +15,7 @@ marked tone value, and a context predicate `Surfaces w i` saying position `i` of
 surfaces with it. The induced rewrite `Surfacing.map` writes the marked tone exactly at
 the surfacing positions and the default elsewhere; `Surfacing.support` is the surfacing
 set. Owning the context predicate on the process is what lets rival processes coexist:
-unbounded tonal plateauing (`Tone.Plateauing.utp`) and Copperbelt Bemba high-tone
+unbounded tonal plateauing (`Tone.utp`) and Copperbelt Bemba high-tone
 spreading (`Studies/Yolyan2025`) instantiate the same structure with very different
 predicates — plateauing's is convex and its map a closure operator, spreading's is
 neither — so only the genuinely shared API lives here.

--- a/Linglib/Studies/Jardine2016a.lean
+++ b/Linglib/Studies/Jardine2016a.lean
@@ -3,84 +3,68 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.Subsequential
-import Linglib.Phonology.Subregular.Dependence
-import Linglib.Core.Computability.Mealy
-import Linglib.Core.Computability.Bimachine
 import Linglib.Core.Computability.ElgotMezei
-import Linglib.Phonology.Autosegmental.OCP
-import Linglib.Phonology.Autosegmental.Junction
-import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Plateauing
 
 /-!
 # Jardine (2016): Computationally, tone is different
 
-[jardine-2016a] (Phonology 33) characterises a typological asymmetry computationally:
-*unbounded circumambient* processes — application depends on unboundedly distant material
-on both sides of the target — are common in tone but rare in segmental phonology, and
-they are exactly the attested maps exceeding weak determinism. The flagship witness is
-**unbounded tonal plateauing** (UTP; [hyman-katamba-2010]): every TBU between two H-toned
-TBUs surfaces H. This file formalizes the paper's formal skeleton over its string
-representation (§4.1: `H` a H-toned TBU, `O` the paper's Ø).
-
-The map itself and its plateau/circumambience API live in `Phonology/Tone/Plateauing`
-(the rule set (36) as `utp.map_toneless`/`utp.map_single`/`utp.map_plateau`; definition (2) as
-`utp.twoSidedUnboundedDependence`); this file keeps the paper's theorems about it.
-
-## Main definitions
-
-* `markLeft`, `resolve` — the (43) two-pass decomposition over the `?`-enlarged alphabet.
+[jardine-2016a] characterises a typological asymmetry computationally: *unbounded
+circumambient* processes — application depends on unboundedly distant material on both sides
+of the target, (2) — are common in tone but rare in segmental phonology, and they are exactly
+the attested maps exceeding weak determinism. The flagship witness is **unbounded tonal
+plateauing** (UTP; [hyman-katamba-2010]): every TBU between two H-toned TBUs surfaces H. The
+map itself, over the paper's string representation (§4.1: `H` a H-toned TBU, `O` its Ø; the
+three cases of (36) are `utp.map_toneless`, `utp.map_single`, `utp.map_plateau`), is
+`Tone.utp`; this file proves the paper's theorems about it.
 
 ## Main results
 
-* `utp_not_isSubsequential` — the central theorem (§4.2, online appendix): no
-  deterministic FST computes UTP in either direction, via
-  `not_isLeftSubsequential_of_diverging` and the reversal symmetry `utp.map_reverse`.
-* `utp_not_weaklyDeterministic` — §5.2, via `RequiresBothSides`: no union of
-  one-sided rules expresses UTP's conjunctive trigger.
-* `utp_markup_decomposition` — (43): with the mark `?`, UTP is right-subsequential after
-  left-subsequential; weak determinism forbids exactly this enlargement.
-* `utp_isBimachineComputable` — §4.2: UTP is regular, the (43) decomposition read through
-  Elgot–Mezei composition.
-* `link_realizeMerged_map` — the OCP-merged realization of the UTP output is a single H
-  linked exactly to the surfacing positions ([hyman-katamba-2010] (7)).
-* `utp_fullyRegular` — §7: UTP is regular but neither subsequential nor weakly
-  deterministic.
+* `utp_not_isSubsequential` — §4.2 (proof in the online appendix): no deterministic
+  transducer computes UTP in either direction, by bounded delay and the reversal symmetry
+  `utp.map_reverse`.
+* `utp_not_weaklyDeterministic` — §5.2: UTP requires both sides, which no union of one-sided
+  rules expresses.
+* `utp_eq_resolve_mark`, `utp_isBimachineComputable` — (43): over the `?`-enlarged alphabet,
+  UTP is a right-to-left Mealy pass after a left-to-right one, hence regular — a bimachine,
+  [elgot-mezei-1965]. What fails is one-directional determinism, not finite-state
+  computability.
+* `utp_fullyRegular` — §5.3: UTP is *fully regular*, regular but not weakly deterministic —
+  the class the paper places tone in and bars segmental phonology from.
+* `link_collapse_realize_toAR_map` — §4.4: read back into autosegmental representations
+  ((40)), the OCP-merged output is one H linked exactly to the plateau
+  ([hyman-katamba-2010]'s rule as given in (7)).
 -/
 
 namespace Jardine2016a
 
-open Tone.Plateauing
+open Tone
 
-variable {w : List TBU} {i j k : ℕ}
+variable {w : List TBU} {j k : ℕ}
 
 /-! ### UTP is not subsequential
 
-The paper's central theorem (§4.2, online appendix), by bounded delay: a left machine
-reading `H Øⁿ` has emitted at most one symbol (`utp.map (H Øⁿ) = H Øⁿ` and
-`utp.map (H Øⁿ H) = H^(n+2)` diverge at position 1), so it withholds `n` symbols. -/
+By bounded delay: a left machine reading `H Øⁿ⁺¹` has emitted at most one symbol, since
+`utp.map (H Øⁿ⁺¹) = H Øⁿ⁺¹` and `utp.map (H Øⁿ⁺¹ H) = Hⁿ⁺³` already differ at position `1`;
+so it withholds `n + 1` symbols. -/
 
 /-- UTP is not left-subsequential (§4.2, online appendix). -/
-theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp.map := by
-  refine not_isLeftSubsequential_of_diverging fun N =>
-    ⟨.H :: List.replicate (N + 1) .O, [.H], 1, ?_, ?_⟩
-  · simp only [Tone.Surfacing.map_length, List.length_cons, List.length_replicate]; omega
-  · -- the images disagree at position 1: toneless there without the second H, plateau with it
-    have h1 : (utp.map (TBU.H :: List.replicate (N + 1) TBU.O))[1]? = some TBU.O :=
-      utp.map_getElem?_O_iff.mpr ⟨by simp, fun hs => by simpa using (utp.surfaces_def.mp hs).2⟩
-    have h2 : (utp.map ((TBU.H :: List.replicate (N + 1) TBU.O) ++ [TBU.H]))[1]? = some TBU.H :=
-      utp.map_getElem?_H_iff.mpr (utp.surfaces_def.mpr ⟨by simp, by simp⟩)
-    rw [h1, h2]; simp
+theorem utp_not_isLeftSubsequential : ¬ IsLeftSubsequential utp.map :=
+  not_isLeftSubsequential_of_diverging fun N =>
+    ⟨.H :: List.replicate (N + 1) .O, [.H], 1,
+      by simp only [Surfacing.map_length, List.length_cons, List.length_replicate]; omega, by
+      rw [show utp.map (.H :: List.replicate (N + 1) .O) = .H :: List.replicate (N + 1) .O from
+          by simpa using utp.map_single 0 (N + 1),
+        show utp.map (.H :: List.replicate (N + 1) .O ++ [.H])
+            = List.replicate (N + 1 + 2) .H from
+          by simpa using utp.map_plateau 0 0 (List.replicate (N + 1) .O)]
+      simp [show (1 : ℕ) < N + 1 + 2 by omega]⟩
 
 /-- UTP is not right-subsequential: by the reversal symmetry, a right machine faces the
 mirror-image unbounded look-ahead. -/
 theorem utp_not_isRightSubsequential : ¬ IsRightSubsequential utp.map := by
-  intro hf
-  rw [isRightSubsequential_iff_left_reverse] at hf
-  have heq : (fun xs : List TBU => (utp.map xs.reverse).reverse) = utp.map := by
-    funext xs; rw [utp.map_reverse, List.reverse_reverse]
-  exact utp_not_isLeftSubsequential (heq ▸ hf)
+  rw [isRightSubsequential_iff_left_reverse]
+  simpa [utp.map_reverse] using utp_not_isLeftSubsequential
 
 /-- UTP is subsequential in neither direction. -/
 theorem utp_not_isSubsequential : ∀ d, ¬ IsSubsequential d utp.map
@@ -89,9 +73,8 @@ theorem utp_not_isSubsequential : ∀ d, ¬ IsSubsequential d utp.map
 
 /-! ### UTP is not weakly deterministic
 
-Under the non-interacting-bimachine rendering of [heinz-lai-2013]'s weak determinism,
-§5.2's claim is a theorem: UTP `RequiresBothSides`, which no union of one-sided rules
-expresses. -/
+Under the non-interacting-bimachine rendering of [heinz-lai-2013]'s weak determinism, §5.2's
+claim is a theorem: UTP `RequiresBothSides`, which no union of one-sided rules expresses. -/
 
 /-- UTP is not weakly deterministic (§5.2). -/
 theorem utp_not_weaklyDeterministic : ¬ IsNonInteractingBimachineComputable utp.map :=
@@ -99,10 +82,10 @@ theorem utp_not_weaklyDeterministic : ¬ IsNonInteractingBimachineComputable utp
 
 /-! ### The (43) mark-up decomposition
 
-With one extra symbol the two-pass decomposition exists: a left pass marks every
-toneless TBU after a H with `?`; a right pass resolves `?` by whether a H follows. The
-mark is exactly the alphabet enlargement weak determinism disallows, so with the
-impossibility theorem this locates UTP precisely. -/
+With one extra symbol the two-pass decomposition exists: a left pass marks every toneless
+TBU after a H with `?`; a right pass resolves `?` by whether a H follows. The mark is
+exactly the alphabet enlargement weak determinism disallows, so with the impossibility
+theorem this locates UTP precisely. -/
 
 /-- The mark-up alphabet of (43): `Q` is the paper's `?`. -/
 inductive Mark | H | O | Q
@@ -112,27 +95,29 @@ inductive Mark | H | O | Q
 def markLeft : Mealy Bool TBU Mark :=
   .ofFlag (· == .H) fun l a => match a with | .H => .H | .O => if l then .Q else .O
 
-/-- Right pass of (43): resolve `?` to H when a H follows, else to Ø. -/
+/-- Right pass of (43), run right-to-left: resolve `?` to H when a H follows, else to Ø. -/
 def resolveRight : Mealy Bool Mark TBU :=
   .ofFlag (· == .H) fun r a =>
     match a with | .H => .H | .O => .O | .Q => if r then .H else .O
 
-/-- The right pass as a right-to-left string function (`Mealy.runRight`). -/
-def resolve (x : List Mark) : List TBU := resolveRight.runRight x
-
-private theorem markLeft_run_H_iff (w : List TBU) (j : ℕ) :
+/-- The left pass writes `H` exactly where the input has `H`. -/
+theorem markLeft_run_getElem?_H_iff :
     (markLeft.run w)[j]? = some Mark.H ↔ w[j]? = some TBU.H := by
   rw [markLeft, Mealy.getElem?_ofFlag_run]
   cases hv : w[j]? with
   | none => simp
   | some a => cases a <;> simp [ite_eq_iff]
 
-/-- The (43) decomposition computes UTP. -/
-theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w) := by
-  have hmark : ∀ i : ℕ, Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) :=
-    fun i => by simp only [List.mem_iff_getElem?, List.getElem?_drop, markLeft_run_H_iff]
+/-- The (43) decomposition computes UTP: mark left-to-right, then resolve right-to-left.
+Both passes run finite Mealy machines, so this exhibits UTP as a right-subsequential map
+after a left-subsequential one (`Mealy.isLeftSubsequential_run`,
+`Mealy.isRightSubsequential_runRight`). -/
+theorem utp_eq_resolve_mark (w : List TBU) :
+    utp.map w = resolveRight.runRight (markLeft.run w) := by
+  have hmark (i : ℕ) : Mark.H ∈ (markLeft.run w).drop (i + 1) ↔ TBU.H ∈ w.drop (i + 1) := by
+    simp only [List.mem_iff_getElem?, List.getElem?_drop, markLeft_run_getElem?_H_iff]
   refine List.ext_getElem? fun i => ?_
-  rw [utp.map_getElem?, resolve, resolveRight, Mealy.getElem?_ofFlag_runRight]
+  rw [utp.map_getElem?, resolveRight, Mealy.getElem?_ofFlag_runRight]
   simp only [List.any_beq', List.contains_eq_mem, decide_eq_decide.mpr (hmark i)]
   rw [markLeft, Mealy.getElem?_ofFlag_run, Option.map_map]
   simp only [List.any_beq', List.contains_eq_mem]
@@ -147,68 +132,39 @@ theorem utp_eq_resolve_mark (w : List TBU) : utp.map w = resolve (markLeft.run w
       by_cases hL : TBU.H ∈ w.take i <;> by_cases hR : TBU.H ∈ w.drop (i + 1) <;>
         simp [utp.surfaces_split ha, hL, hR]
 
-/-- The (43) mark-up decomposition (§5.2): over the `?`-enlarged alphabet, UTP is a
-right-subsequential map after a left-subsequential map. -/
-theorem utp_markup_decomposition :
-    IsLeftSubsequential markLeft.run ∧ IsRightSubsequential resolve
-      ∧ utp.map = resolve ∘ markLeft.run := by
-  refine ⟨markLeft.isMealyComputable.isLeftSubsequential, ?_,
-    funext utp_eq_resolve_mark⟩
-  rw [isRightSubsequential_iff_left_reverse]
-  have heq : (fun xs : List Mark => (resolve xs.reverse).reverse) = resolveRight.run := by
-    funext xs; simp [resolve]
-  exact heq ▸ resolveRight.isMealyComputable.isLeftSubsequential
+/-- UTP is regular (§4.2): the (43) decomposition is a right-to-left Mealy pass after a
+left-to-right one, and such a composite is computed by a bimachine — one deterministic
+pass per direction ([elgot-mezei-1965]). So what fails above is one-directional
+determinism, not finite-state computability. -/
+theorem utp_isBimachineComputable : IsBimachineComputable utp.map := by
+  rw [show utp.map = resolveRight.runRight ∘ markLeft.run from funext utp_eq_resolve_mark]
+  exact resolveRight.isRightSubsequential_runRight.isBimachineComputable_comp
+    markLeft.isLeftSubsequential_run rfl
 
-/-- UTP is regular (§4.2): the (43) decomposition is a right-subsequential pass after a
-left-subsequential one, and such a composite is computed by a bimachine — one
-deterministic pass per direction ([elgot-mezei-1965]). So what fails above is
-one-directional determinism, not finite-state computability. -/
-theorem utp_isBimachineComputable : IsBimachineComputable utp.map :=
-  have ⟨hL, hR, heq⟩ := utp_markup_decomposition
-  heq ▸ hR.isBimachineComputable_comp hL rfl
-
-/-! ### The autosegmental grounding ((40), §4.4)
-
-The string representation reads back from the autosegmental one; the
-grounding claims are stated on the graph foundation below. -/
-
-section AutosegmentalGrounding
-
-open Autosegmental
-
-/-! #### The autosegmental grounding in coordinates
-
-The same claims on the graph foundation: the output representation's melody
-fuses to one `H`, linked exactly to the surfacing slots. -/
-
-/-- (7) in coordinates: the merged output's links are the fused `H` node over
-    the surfacing positions. -/
-theorem link_realizeMerged_map {w : List TBU} {k j : ℕ} :
-    ((Autosegmental.AR.realize Tone.Plateauing.toAR (utp.map w)).collapse true).link
-        true false k j ↔ k = 0 ∧ utp.Surfaces w j := by
-  rw [Tone.Plateauing.link_realizeMerged, utp.map_getElem?_H_iff]
-
-/-- (7) concretely: `HØØH` fuses to one H linked to all four TBUs. -/
-example : ∀ j < 4,
-    ((Autosegmental.AR.realize Tone.Plateauing.toAR
-      (utp.map [.H, .O, .O, .H])).collapse true).link true false 0 j := by
-  intro j hj
-  rw [link_realizeMerged_map]
-  refine ⟨rfl, ?_⟩
-  match j, hj with
-  | 0, _ => decide
-  | 1, _ => decide
-  | 2, _ => decide
-  | 3, _ => decide
-
-end AutosegmentalGrounding
-
-/-- Computationally, tone is different (§7): UTP is fully regular — regular but neither
-subsequential in either direction nor weakly deterministic, the bound segmental
-phonology respects. -/
+/-- UTP is *fully regular* (§5.3): regular but not weakly deterministic — the class the
+paper places tone in and bars segmental phonology from. -/
 theorem utp_fullyRegular :
-    IsBimachineComputable utp.map ∧ (∀ d, ¬ IsSubsequential d utp.map)
-      ∧ ¬ IsNonInteractingBimachineComputable utp.map :=
-  ⟨utp_isBimachineComputable, utp_not_isSubsequential, utp_not_weaklyDeterministic⟩
+    IsBimachineComputable utp.map ∧ ¬ IsNonInteractingBimachineComputable utp.map :=
+  ⟨utp_isBimachineComputable, utp_not_weaklyDeterministic⟩
+
+/-! ### The autosegmental reading (§4.4)
+
+The string representation reads back into autosegmental representations by `TBU.toAR`
+((40)); the OCP-merged representation of the output has one `H`, linked exactly to the
+plateau — [hyman-katamba-2010]'s rule as given in (7). -/
+
+open Autosegmental in
+/-- The merged output's links are the fused `H` over the surfacing positions. -/
+theorem link_collapse_realize_toAR_map :
+    ((AR.realize TBU.toAR (utp.map w)).collapse true).link true false k j ↔
+      k = 0 ∧ utp.Surfaces w j := by
+  rw [TBU.link_collapse_realize_toAR, utp.map_getElem?_H_iff]
+
+/-- `HØØH` fuses to one H linked to all four TBUs. -/
+example : ∀ j < 4,
+    ((Autosegmental.AR.realize TBU.toAR (utp.map [.H, .O, .O, .H])).collapse true).link
+      true false 0 j := by
+  simp only [link_collapse_realize_toAR_map, true_and]
+  decide
 
 end Jardine2016a

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -246,9 +246,9 @@ theorem tutrugbu_not_bmrsWeaklyDeterministic :
 flagship pattern (the class of the paper's Prop. 5.4 Bemba case), through
 `Phonology/Tone/Plateauing`'s witness. -/
 theorem utp_not_bmrsWeaklyDeterministic :
-    ¬ IsBmrsWeaklyDeterministic Tone.Plateauing.utp.map :=
+    ¬ IsBmrsWeaklyDeterministic Tone.utp.map :=
   not_isBmrsWeaklyDeterministic_of_requiresBothSides
-    Tone.Plateauing.utp.requiresBothSides
+    Tone.utp.requiresBothSides
 
 /-! ### Bemba high-tone spreading is not weakly deterministic (Prop. 5.4)
 


### PR DESCRIPTION
Deep cleanse of `Studies/Jardine2016a.lean` with the substrate it sits on.

- `Tone.Plateauing` was a file-named sub-namespace doing no disambiguation work; dissolved into `Tone` (`Tone.TBU` with `TBU.toAR`/`TBU.melody` as its dot-API, `Tone.utp`, `Tone.plateau`, `Tone.plateauAR`).
- `Jardine2016a`: two imports, `resolve` alias and the `∧`-packaged `utp_markup_decomposition` gone, non-subsequentiality proved from the (36) schemata `utp.map_single`/`utp.map_plateau` as the paper does, locators re-verified against the text (`utp_fullyRegular` is the paper's §5.3 term: regular but not weakly deterministic).
- `Mealy.isLeftSubsequential_run` / `Mealy.isRightSubsequential_runRight`: a Mealy run is subsequential in its scan direction (was re-derived inline).