### PR TITLE
refactor(Studies/Jardine2017): grammars (21)/(22) as AR.Free lists over AR.ofWords

### DIFF
--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -52,6 +52,16 @@ def Free (B : List {F : TieredAR ι τ // Finite F.obj.V}) : Prop :=
 
 variable {F X} {o : ι → ℕ}
 
+instance (G : {F : TieredAR ι τ // Finite F.obj.V}) : Finite G.val.obj.V := G.property
+
+@[simp] theorem free_nil : X.Free [] := fun _ h => (List.not_mem_nil h).elim
+
+/-- A grammar tests its forbidden factors one by one. -/
+theorem free_cons {F : {F : TieredAR ι τ // Finite F.obj.V}}
+    {B : List {F : TieredAR ι τ // Finite F.obj.V}} :
+    X.Free (F :: B) ↔ ¬ F.val.FactorEmbeds X ∧ X.Free B :=
+  List.forall_mem_cons
+
 /-- On a tier where the factor is nonempty, the window equations force the offset
     in bounds. -/
 theorem IsFactorAt.offset_le (h : F.IsFactorAt X o) {i : ι} (hi : F.tierLength i ≠ 0) :

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -308,6 +308,54 @@ theorem AR.factorEmbeds_ofData_iff
         · exact (AR.link_ofData false true _ _).mpr
             ⟨by decide, hbf p hp, hbt q hq, Or.inl hres⟩
 
+/-! #### Two-tier representations from words -/
+
+namespace TwoTier
+
+/-- The tier words of a melody word and a timing word. -/
+def words (as : List α) (bs : List β) : ∀ b : Bool, List (TwoTier α β b)
+  | true => (as : List (TwoTier α β true))
+  | false => (bs : List (TwoTier α β false))
+
+/-- Association lines from melody position `p` to timing position `q` under `L`. -/
+def links (L : ℕ → ℕ → Prop) (i j : Bool) (p q : ℕ) : Prop := i = true ∧ j = false ∧ L p q
+
+instance (L : ℕ → ℕ → Prop) [DecidableRel L] (i j : Bool) (p q : ℕ) :
+    Decidable (links L i j p q) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
+
+end TwoTier
+
+/-- The representation of a melody `as` over a timing word `bs`, associated by `L` on
+positions: the general two-tier form, of which `junction` is the complete case. -/
+def AR.ofWords (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) :
+    AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool) :=
+  AR.ofData (TwoTier.words as bs) (TwoTier.links L)
+
+instance (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) : Finite (AR.ofWords as bs L).obj.V :=
+  inferInstanceAs (Finite ((_ : Bool) × Fin _))
+
+@[simp] theorem AR.tierWord_ofWords_true (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) :
+    (AR.ofWords as bs L).tierWord true = as :=
+  AR.tierWord_ofData true
+
+@[simp] theorem AR.tierWord_ofWords_false (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) :
+    (AR.ofWords as bs L).tierWord false = bs :=
+  AR.tierWord_ofData false
+
+/-- Embedding between representations of words is the data-level check, hence decidable. -/
+theorem AR.factorEmbeds_ofWords_iff (as as' : List α) (bs bs' : List β)
+    (L L' : ℕ → ℕ → Prop) :
+    (AR.ofWords as bs L).FactorEmbeds (AR.ofWords as' bs' L') ↔
+      dataEmbeds (TwoTier.words as bs) (TwoTier.words as' bs') (TwoTier.links L)
+        (TwoTier.links L') :=
+  AR.factorEmbeds_ofData_iff
+
+instance [DecidableEq α] [DecidableEq β] (as as' : List α) (bs bs' : List β)
+    (L L' : ℕ → ℕ → Prop) [DecidableRel L] [DecidableRel L'] :
+    Decidable ((AR.ofWords as bs L).FactorEmbeds (AR.ofWords as' bs' L')) :=
+  decidable_of_iff _ (AR.factorEmbeds_ofWords_iff as as' bs bs' L L').symm
+
 /-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
     node links to it. -/
 def AR.surfacesWith

--- a/Linglib/Studies/Jardine2017.lean
+++ b/Linglib/Studies/Jardine2017.lean
@@ -4,309 +4,150 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Junction
+import Linglib.Phonology.Tone.Basic
 
 /-!
 # Jardine (2017): tone-association patterns as forbidden subgraphs
-[jardine-2017]
 
-[jardine-2017] argues that tone-association patterns over
-autosegmental representations are *computationally local* in a
-well-defined sense: each pattern's well-formedness can be specified
-by a finite set of forbidden connected subgraphs. An AR is
-well-formed under a grammar `{¬ F₁, ..., ¬ Fₙ}` iff none of the
-`Fᵢ` embeds into it.
+[jardine-2017] argues that tone-association patterns are *local*: each is specified by a
+finite grammar `¬r₁ ∧ … ∧ ¬rₙ` of forbidden connected subgraphs of autosegmental
+representations (§2, §4), so that well-formedness is checked, and learned, by scanning a
+bounded window. The directional patterns of §3.1 are the test case: Mende (Leben 1973)
+allows plateaus and contours only at the right word edge, (4)–(5), and Hausa (Newman
+1986) only at the left, (6)–(7). The grammars of §5.1 forbid non-final spreading and
+contours, (21), and non-initial ones, (22) — mirror images, differing only in the edge.
 
-This gives a restrictive theory of tonal well-formedness that:
-* makes clear typological predictions (the paper covers Mende,
-  Hausa, Northern Karanga Shona, Kukuya, Hirosaki Japanese);
-* contrasts with derivational/global accounts (`*VαCVβ` constraints,
-  directionality parameters) which can overgenerate;
-* admits a learning algorithm based on "scanning window" inspection.
-
-## Coverage
-
-This file formalises §3.1 + §5.1 of [jardine-2017]: the Mende
-right-edge multiple-association pattern and the contrasting Hausa
-left-edge pattern. Hirosaki Japanese (§5.3), Northern Karanga Shona
-(§5.1's second half), and Kukuya (§5.2) are sketched in the
-docstring as future extensions — each follows the same `Graph`-
-based forbidden-subgraph schema.
-
-Second consumer of `Autosegmental.Graph` after
-`Studies/LaoideKemp2026.lean`. Exercises the `SubgraphEmbeds`
-predicate (precedence-preserving translation embedding), which
-Laoide-Kemp doesn't touch.
+Forbidden subgraphs are factors (`AR.FactorEmbeds`). The contour subgraph (19) leaves its
+two tones unordered so as to match rising as well as falling contours; a factor's tier word
+is ordered, so (19) is rendered as the pair of orders.
 
 ## Main definitions
 
-* `Tone`, `TBU` — label types for the tonal and timing tiers.
-* `AR` — `Graph Tone TBU`, an autosegmental representation in
-  Jardine's sense.
-* `Mende.attested` — three worked Mende ARs from
-  [jardine-2017] eq. (5): `mbû` ('owl', HL contour on 1σ),
-  `ngìlà` ('dog', H L on 2σ), `félàmà` ('junction', HLL with
-  L-spread on 3σ).
-* `Mende.forbidden_*` — three forbidden subgraphs from eq. (21):
-  non-final H spreading, non-final L spreading, non-final contour.
-* `Hausa.attested` — Hausa ARs with left-edge multiple association
-  (eq. 7).
-* `Hausa.forbidden_*` — non-initial spreading + non-initial contour
-  (eq. 22).
-* Per-attested-form theorems: each attested AR does NOT contain any
-  forbidden subgraph.
+* `ar` — a representation drawn as the paper does: a melody, a syllable string, and the
+  association lines as position pairs.
+* `Mende.forms`, `Hausa.forms` — the words of (4) and (6) as representations.
+* `Mende.grammar`, `Hausa.grammar` — the grammars (21) and (22).
 
-## Convention
+## Main results
 
-Jardine 2017 draws forbidden subgraphs with explicit `H→L`
-precedence arrows on the tone tier and `σ→σ` arrows on the TBU tier.
-In `Graph Tone TBU`, precedence is implicit in list order: the upper
-tier is `List Tone`, the lower is `List TBU`. The `SubgraphEmbeds`
-predicate captures the paper's connected-subgraph embedding by
-requiring a *translation* mapping (consecutive positions in F map
-to consecutive positions in G).
+* `Mende.free`, `Hausa.free` — every word of (4) is free of (21), every word of (6) free
+  of (22).
+* `Mende.not_free_hántúnàa`, `Hausa.not_free_félàmà` — the diagnostic forms fail the
+  other language's grammar: left-edge spreading is exactly what (21) forbids, right-edge
+  spreading exactly what (22) forbids ((18), (16)).
+
+Northern Karanga Shona (23)–(28), Kukuya (29)–(33) and Hirosaki Japanese (34)–(38) follow
+the same schema.
 -/
 
 namespace Jardine2017
 
-open Autosegmental
+open Autosegmental Tone Tone.TRN
 
-/-! ## §1 Label types
+/-- The syllable, the paper's tone-bearing unit. -/
+abbrev σ : TBUKind := .syllable
 
-Jardine 2017 uses `H` and `L` for tones and `σ` (syllable) or `μ`
-(mora) for tone-bearing units, plus `#` for tier boundaries.
-Boundaries (`#`) appear in some grammars (e.g., Northern Karanga
-Shona eq. (24)) but not in the Mende/Hausa grammars formalised here;
-we include the constructor for future extensions.
--/
+/-- A representation drawn as the paper does: a melody over a syllable string, with the
+association lines given as pairs of positions. -/
+abbrev ar (tones : List TRN) (tbus : List TBUKind) (lines : List (ℕ × ℕ)) :=
+  AR.ofWords tones tbus fun p q => (p, q) ∈ lines
 
-/-- Tonal-tier label. -/
-inductive Tone
-  | H
-  | L
-  /-- Word/tier boundary marker (#). Used by some grammars (e.g.,
-      Northern Karanga Shona in [jardine-2017] eq. 24); not used
-      in the Mende/Hausa formalisations below. -/
-  | bdry
-  deriving DecidableEq, Repr
+/-- The grammar of forbidden subgraphs `¬r₁ ∧ … ∧ ¬rₙ` of (3a), as the list of factors. -/
+abbrev Grammar := List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V}
 
-/-- Tone-bearing unit label. Most patterns in [jardine-2017]
-    use the syllable σ; Hirosaki Japanese (§5.3) uses the mora μ. -/
-inductive TBU
-  | σ
-  | μ
-  /-- TBU-tier boundary marker. -/
-  | bdry
-  deriving DecidableEq, Repr
-
-/-- An autosegmental representation in Jardine 2017's sense, on the graph
-    foundation: tones over TBUs (with implicit precedence by position),
-    links as association lines. -/
-abbrev ARep := Autosegmental.AR
-  (Sigma.fst : ((b : Bool) × Autosegmental.TwoTier Tone TBU b) → Bool)
-
-/-- Link presentations from finite pair lists (melody position, TBU position). -/
-def mkL (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) : Prop :=
-  i = true ∧ j = false ∧ (p, q) ∈ links
-
-instance (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) :
-    Decidable (mkL links i j p q) :=
-  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
-
-/-- Build a representation from a tone melody, a TBU string, and links. -/
-abbrev mk (tones : List Tone) (tbus : List TBU) (links : List (ℕ × ℕ)) : ARep :=
-  Autosegmental.AR.ofData
-    (fun b => match b with
-      | true => (tones : List (Autosegmental.TwoTier Tone TBU true))
-      | false => tbus)
-    (mkL links)
-
-open Autosegmental in
-/-- Non-embedding verdicts compute: the spec plus kernel evaluation. -/
-theorem mk_embeds_iff {tF tX : List Tone} {bF bX : List TBU}
-    {lF lX : List (ℕ × ℕ)} :
-    (mk tF bF lF).FactorEmbeds (mk tX bX lX) ↔
-      dataEmbeds
-        (fun b => match b with
-          | true => (tF : List (Autosegmental.TwoTier Tone TBU true))
-          | false => bF)
-        (fun b => match b with
-          | true => (tX : List (Autosegmental.TwoTier Tone TBU true))
-          | false => bX)
-        (mkL lF) (mkL lX) :=
-  AR.factorEmbeds_ofData_iff
-
-/-! ## §2 Mende: right-edge multiple association
-[jardine-2017] §3.1, eq. (5)
-
-In Mende, tonal *plateaus* (a single tone associated to multiple
-syllables) and contour tones (multiple tones on one syllable) are
-restricted to the right word edge. -/
+/-! ### Mende: multiple association at the right edge -/
 
 namespace Mende
 
-/-- `mbû` 'owl' (1σ, HL contour). -/
-abbrev mbû : ARep := mk [Tone.H, Tone.L] [TBU.σ] [(0, 0), (1, 0)]
+/-- The words of (4), drawn as in (5): `mbû` 'owl', `ngílà` 'dog', `félàmà` 'junction',
+`mbâ` 'companion', `nyàhâ` 'woman', `nìkílì` 'groundnut' — melody, syllables, lines. -/
+def forms : List (List TRN × List TBUKind × List (ℕ × ℕ)) :=
+  [([H, L], [σ], [(0, 0), (1, 0)]),
+   ([H, L], [σ, σ], [(0, 0), (1, 1)]),
+   ([H, L], [σ, σ, σ], [(0, 0), (1, 1), (1, 2)]),
+   ([L, H, L], [σ], [(0, 0), (1, 0), (2, 0)]),
+   ([L, H, L], [σ, σ], [(0, 0), (1, 1), (2, 1)]),
+   ([L, H, L], [σ, σ, σ], [(0, 0), (1, 1), (2, 2)])]
 
-/-- `ngìlà` 'dog' (2σ, HL melody, one tone per syllable). -/
-abbrev ngìlà : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 1)]
+/-- (17): a non-final H, and a non-final L, associated to two syllables. -/
+abbrev nonfinalH := ar [H, L] [σ, σ] [(0, 0), (0, 1)]
+abbrev nonfinalL := ar [L, H] [σ, σ] [(0, 0), (0, 1)]
 
-/-- `félàmà` 'junction' (3σ, HL melody with L-spread to the right two
-    syllables: HLL surface). The diagnostic case for Mende. -/
-abbrev félàmà : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ, TBU.σ] [(0, 0), (1, 1), (1, 2)]
+/-- (19): a contour on a non-final syllable, in both tone orders. -/
+abbrev nonfinalHL := ar [H, L] [σ, σ] [(0, 0), (1, 0)]
+abbrev nonfinalLH := ar [L, H] [σ, σ] [(0, 0), (1, 0)]
 
-/-- **(21a) non-final H spreading**: an H linked to two consecutive σs with an
-    L following on the tonal tier. -/
-abbrev forbidden_nonfinal_H : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (0, 1)]
+/-- The Mende grammar (21). -/
+def grammar : Grammar :=
+  [⟨nonfinalH, inferInstance⟩, ⟨nonfinalL, inferInstance⟩, ⟨nonfinalHL, inferInstance⟩,
+    ⟨nonfinalLH, inferInstance⟩]
 
-/-- **(21b) non-final L spreading** (mirror). -/
-abbrev forbidden_nonfinal_L : ARep := mk [Tone.L, Tone.H] [TBU.σ, TBU.σ] [(0, 0), (0, 1)]
+theorem free_grammar_iff (X : TieredAR Bool (TwoTier TRN TBUKind)) [Finite X.obj.V] :
+    X.Free grammar ↔ ¬ nonfinalH.FactorEmbeds X ∧ ¬ nonfinalL.FactorEmbeds X ∧
+      ¬ nonfinalHL.FactorEmbeds X ∧ ¬ nonfinalLH.FactorEmbeds X := by
+  simp only [grammar, AR.free_cons, AR.free_nil, and_true]
 
-/-- **(21c) non-final contour**: an HL contour on a σ with another σ
-    following. -/
-abbrev forbidden_nonfinal_contour : ARep :=
-  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 0)]
+instance (tones : List TRN) (tbus : List TBUKind) (lines : List (ℕ × ℕ)) :
+    Decidable ((ar tones tbus lines).Free grammar) :=
+  decidable_of_iff _ (free_grammar_iff _).symm
 
-/-! ### §2.2 Attested forms satisfy the Mende grammar ([jardine-2017] §5.1) -/
-
-theorem mbû_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds mbû := by
-  rw [mk_embeds_iff]; decide
-
-theorem mbû_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds mbû := by
-  rw [mk_embeds_iff]; decide
-
-theorem mbû_no_nonfinal_contour : ¬ forbidden_nonfinal_contour.FactorEmbeds mbû := by
-  rw [mk_embeds_iff]; decide
-
-theorem ngìlà_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds ngìlà := by
-  rw [mk_embeds_iff]; decide
-
-theorem ngìlà_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds ngìlà := by
-  rw [mk_embeds_iff]; decide
-
-theorem ngìlà_no_nonfinal_contour :
-    ¬ forbidden_nonfinal_contour.FactorEmbeds ngìlà := by
-  rw [mk_embeds_iff]; decide
-
-theorem félàmà_no_nonfinal_H : ¬ forbidden_nonfinal_H.FactorEmbeds félàmà := by
-  rw [mk_embeds_iff]; decide
-
-theorem félàmà_no_nonfinal_L : ¬ forbidden_nonfinal_L.FactorEmbeds félàmà := by
-  rw [mk_embeds_iff]; decide
-
-theorem félàmà_no_nonfinal_contour :
-    ¬ forbidden_nonfinal_contour.FactorEmbeds félàmà := by
-  rw [mk_embeds_iff]; decide
+/-- Every word of (4) is well-formed under (21). -/
+theorem free : ∀ f ∈ forms, (ar f.1 f.2.1 f.2.2).Free grammar := by decide
 
 end Mende
 
-/-! ## §3 Hausa: left-edge multiple association ([jardine-2017] eq. (7), (22)) -/
+/-! ### Hausa: multiple association at the left edge -/
 
 namespace Hausa
 
-/-- `fáadi` 'fall' (2σ, HL melody one-to-one). -/
-abbrev fáadi : ARep := mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 0), (1, 1)]
+/-- The words of (6), drawn as in (7): `fáadì` 'fall', `hántúnàa` 'noses', `búhúnhúnàa`
+'sacks', `mántá` 'forget', `káràntá` 'read', `kákkáràntá` 'reread' — melody, syllables,
+lines. -/
+def forms : List (List TRN × List TBUKind × List (ℕ × ℕ)) :=
+  [([H, L], [σ, σ], [(0, 0), (1, 1)]),
+   ([H, L], [σ, σ, σ], [(0, 0), (0, 1), (1, 2)]),
+   ([H, L], [σ, σ, σ, σ], [(0, 0), (0, 1), (0, 2), (1, 3)]),
+   ([H, L, H], [σ, σ], [(0, 0), (1, 0), (2, 1)]),
+   ([H, L, H], [σ, σ, σ], [(0, 0), (1, 1), (2, 2)]),
+   ([H, L, H], [σ, σ, σ, σ], [(0, 0), (0, 1), (1, 2), (2, 3)])]
 
-/-- `háantúnàa` 'noses' (3σ, HHL — H spreads at the *left* edge). -/
-abbrev háantúnàa : ARep :=
-  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ, TBU.σ] [(0, 0), (0, 1), (1, 2)]
+/-- (22): a non-initial H, and a non-initial L, associated to two syllables. -/
+abbrev noninitialH := ar [L, H] [σ, σ] [(1, 0), (1, 1)]
+abbrev noninitialL := ar [H, L] [σ, σ] [(1, 0), (1, 1)]
 
-/-- **(22a) non-initial H spreading**: an L preceding an H linked to two σs. -/
-abbrev forbidden_noninitial_H : ARep :=
-  mk [Tone.L, Tone.H] [TBU.σ, TBU.σ] [(1, 0), (1, 1)]
+/-- (22): a contour on a non-initial syllable, in both tone orders. -/
+abbrev noninitialHL := ar [H, L] [σ, σ] [(0, 1), (1, 1)]
+abbrev noninitialLH := ar [L, H] [σ, σ] [(0, 1), (1, 1)]
 
-/-- **(22b) non-initial L spreading** (mirror). -/
-abbrev forbidden_noninitial_L : ARep :=
-  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(1, 0), (1, 1)]
+/-- The Hausa grammar (22). -/
+def grammar : Grammar :=
+  [⟨noninitialH, inferInstance⟩, ⟨noninitialL, inferInstance⟩,
+    ⟨noninitialHL, inferInstance⟩, ⟨noninitialLH, inferInstance⟩]
 
-/-- **(22c) non-initial contour**: a σ preceded by another σ, bearing an HL
-    contour. -/
-abbrev forbidden_noninitial_contour : ARep :=
-  mk [Tone.H, Tone.L] [TBU.σ, TBU.σ] [(0, 1), (1, 1)]
+theorem free_grammar_iff (X : TieredAR Bool (TwoTier TRN TBUKind)) [Finite X.obj.V] :
+    X.Free grammar ↔ ¬ noninitialH.FactorEmbeds X ∧ ¬ noninitialL.FactorEmbeds X ∧
+      ¬ noninitialHL.FactorEmbeds X ∧ ¬ noninitialLH.FactorEmbeds X := by
+  simp only [grammar, AR.free_cons, AR.free_nil, and_true]
 
-/-! ### §3.2 Attested Hausa forms satisfy the Hausa grammar -/
+instance (tones : List TRN) (tbus : List TBUKind) (lines : List (ℕ × ℕ)) :
+    Decidable ((ar tones tbus lines).Free grammar) :=
+  decidable_of_iff _ (free_grammar_iff _).symm
 
-theorem fáadi_no_noninitial_H : ¬ forbidden_noninitial_H.FactorEmbeds fáadi := by
-  rw [mk_embeds_iff]; decide
-
-theorem fáadi_no_noninitial_L : ¬ forbidden_noninitial_L.FactorEmbeds fáadi := by
-  rw [mk_embeds_iff]; decide
-
-theorem fáadi_no_noninitial_contour :
-    ¬ forbidden_noninitial_contour.FactorEmbeds fáadi := by
-  rw [mk_embeds_iff]; decide
-
-theorem háantúnàa_no_noninitial_H :
-    ¬ forbidden_noninitial_H.FactorEmbeds háantúnàa := by
-  rw [mk_embeds_iff]; decide
-
-theorem háantúnàa_no_noninitial_L :
-    ¬ forbidden_noninitial_L.FactorEmbeds háantúnàa := by
-  rw [mk_embeds_iff]; decide
-
-theorem háantúnàa_no_noninitial_contour :
-    ¬ forbidden_noninitial_contour.FactorEmbeds háantúnàa := by
-  rw [mk_embeds_iff]; decide
+/-- Every word of (6) is well-formed under (22). -/
+theorem free : ∀ f ∈ forms, (ar f.1 f.2.1 f.2.2).Free grammar := by decide
 
 end Hausa
 
-/-! ## §4 The Mende/Hausa contrast: same shape, opposite edges
-[jardine-2017] §3.1 and §5.1
+/-! ### The contrast: the same subgraphs at opposite edges -/
 
-Mende's `félàmà` (HLL on 3σ, L-spread at *right* edge) is exactly
-the kind of pattern Hausa's grammar would forbid (its mirror is a
-non-initial L spread). Conversely, Hausa's `háantúnàa` (HHL on 3σ,
-H-spread at *left* edge) is exactly what Mende's grammar forbids.
+/-- Hausa's `hántúnàa` (HHL, H spread at the left edge) contains (21)'s non-final H spread
+((18a) is a valid Hausa representation). -/
+theorem Mende.not_free_hántúnàa :
+    ¬ (ar [H, L] [σ, σ, σ] [(0, 0), (0, 1), (1, 2)]).Free Mende.grammar := by decide
 
-This pair makes Jardine's locality thesis concrete: each language's
-grammar is a finite set of forbidden subgraphs, and the difference
-between Mende and Hausa is the *side* of the word edge to which the
-prohibition applies.
--/
-
-/-- The Hausa attested form `háantúnàa` (HHL = H-spread to first 2σ)
-    contains exactly the structural pattern that Mende's grammar
-    forbids: non-final H spreading. This makes Mende and Hausa
-    mutually exclusive on their diagnostic forms. -/
-theorem hausa_haantunaa_violates_mende :
-    Mende.forbidden_nonfinal_H.FactorEmbeds Hausa.háantúnàa := by
-  rw [mk_embeds_iff]; decide
-
-/-- Symmetrically, Mende's `félàmà` (HLL = L-spread to last 2σ)
-    contains Hausa's forbidden non-initial-L pattern. -/
-theorem mende_felama_violates_hausa :
-    Hausa.forbidden_noninitial_L.FactorEmbeds Mende.félàmà := by
-  rw [mk_embeds_iff]; decide
-
-/-! ## §5 Future extensions
-
-The paper covers three further patterns not formalised here. Each
-extends the same `Graph`-based forbidden-subgraph schema and would
-be a natural addition to this file.
-
-* **Northern Karanga Shona** (§5.1 second half, eq. 23-28): a
-  *positional* pattern where the leftmost H of a verb stem spreads
-  maximally as far as the third syllable; medial L blocks
-  multiple-H association. Grammar (24) uses boundary symbols (`#`)
-  on both tiers; the `Tone.bdry` and `TBU.bdry` constructors are in
-  place for this extension.
-
-* **Kukuya** (§5.2, eq. 30-33): a *quality-sensitive* pattern where
-  H tones cannot multiply associate in the presence of L, while L
-  can spread freely. Encoded as the conjunction of Mende-grammar
-  forbidden subgraphs (for non-final H association) and
-  Hausa-grammar forbidden subgraphs (for non-initial H association),
-  plus a non-final-contour ban.
-
-* **Hirosaki Japanese** (§5.3, eq. 35-38): a *culminativity*
-  constraint: at most one H per word, F (falling) only word-finally,
-  H never spreads to multiple TBUs (here moras `μ`, not syllables).
-  Demonstrates that the `Graph` substrate handles arbitrary TBU
-  types (the `TBU.μ` constructor is already in place).
-
-The deferred items are all `≤ 100 LOC` each in the same shape as
-the Mende/Hausa above: enumerate attested forms, enumerate forbidden
-subgraphs, prove non-embedding by `decide`. They can be added
-incrementally as needed.
--/
+/-- Mende's `félàmà` (HLL, L spread at the right edge) contains (22)'s non-initial L
+spread ((16a) is ill-formed in Hausa). -/
+theorem Hausa.not_free_félàmà :
+    ¬ (ar [H, L] [σ, σ, σ] [(0, 0), (1, 1), (1, 2)]).Free Hausa.grammar := by decide
 
 end Jardine2017


### PR DESCRIPTION
Deep cleanse of `Studies/Jardine2017.lean` against the paper.

- `Junction`: `AR.ofWords as bs L` (a melody over a timing word, associated by `L` — the general two-tier form of which `junction` is the complete case) with `TwoTier.words`/`links`, tier-word simp lemmas and a decidable `FactorEmbeds` between such representations; `Factors`: subtype `Finite` instance, `free_nil`, `free_cons`. This generalises the study's local `mk`/`mkL`/`mk_embeds_iff` (and `Jardine2019`'s copy, left for a follow-up).
- Study: alphabet is `Tone.TRN`/`Tone.TBUKind` (no local `Tone`/`TBU` with dead `bdry`/`μ` constructors); all twelve words of (4)/(6) as (melody, syllables, lines) data; grammars (21)/(22) as `AR.Free` lists, each `∀ f ∈ forms, … := by decide`; the two diagnostic cross-violations kept. Fidelity: `ngílà`, `fáadì`, `hántúnàa` corrected from the text, and (19)'s deliberately unordered contour subgraph rendered as both tone orders (an ordered tier word alone misses rising contours). Docstring reduced to the mathlib register (no bare key, no `§N` headers, no coverage/LOC essays).