### PR TITLE
refactor(Studies/Jardine2019): ASL^{gT} on realizeMerged, verdicts decided on the words

### DIFF
--- a/Linglib/Phonology/Autosegmental/Factors.lean
+++ b/Linglib/Phonology/Autosegmental/Factors.lean
@@ -62,6 +62,51 @@ theorem free_cons {F : {F : TieredAR ι τ // Finite F.obj.V}}
     X.Free (F :: B) ↔ ¬ F.val.FactorEmbeds X ∧ X.Free B :=
   List.forall_mem_cons
 
+/-- Embedding reads only the tier words and links of the two representations. -/
+theorem factorEmbeds_congr {F' X' : TieredAR ι τ} [Finite F'.obj.V] [Finite X'.obj.V]
+    (hwF : ∀ i, F.tierWord i = F'.tierWord i)
+    (hlF : ∀ i j p q, F.link i j p q ↔ F'.link i j p q)
+    (hwX : ∀ i, X.tierWord i = X'.tierWord i)
+    (hlX : ∀ i j p q, X.link i j p q ↔ X'.link i j p q) :
+    F.FactorEmbeds X ↔ F'.FactorEmbeds X' := by
+  have hlen : ∀ i, F.tierLength i = F'.tierLength i := fun i => by
+    rw [← length_tierWord, hwF, length_tierWord]
+  refine exists_congr fun o => ⟨fun h => ⟨fun i p hp => ?_, fun i j p q hl => ?_⟩,
+    fun h => ⟨fun i p hp => ?_, fun i j p q hl => ?_⟩⟩
+  · rw [← hwX, ← hwF]; exact h.window i p (by rwa [hlen])
+  · exact (hlX ..).mp (h.link_map i j p q ((hlF ..).mpr hl))
+  · rw [hwX, hwF]; exact h.window i p (by rwa [← hlen])
+  · exact (hlX ..).mpr (h.link_map i j p q ((hlF ..).mp hl))
+
+/-- Freeness reads only the tier words and links. -/
+theorem free_congr {Y : TieredAR ι τ} [Finite Y.obj.V]
+    (hw : ∀ i, X.tierWord i = Y.tierWord i) (hl : ∀ i j p q, X.link i j p q ↔ Y.link i j p q)
+    (B : List {F : TieredAR ι τ // Finite F.obj.V}) : X.Free B ↔ Y.Free B :=
+  forall₂_congr fun _ _ =>
+    not_congr (factorEmbeds_congr (fun _ => rfl) (fun _ _ _ _ => Iff.rfl) hw hl)
+
+/-- Factor occurrences compose, offsets adding. -/
+theorem IsFactorAt.trans {Y : TieredAR ι τ} [Finite Y.obj.V] {o' : ι → ℕ}
+    (h : F.IsFactorAt X o) (h' : X.IsFactorAt Y o') :
+    F.IsFactorAt Y fun i => o i + o' i where
+  window i p hp := by
+    have hlt : p + o i < X.tierLength i := by
+      have hF : p < (F.tierWord i).length := by simpa using hp
+      have h1 : (X.tierWord i)[p + o i]? = some (F.tierWord i)[p] :=
+        (h.window i p hp).trans (List.getElem?_eq_getElem hF)
+      simpa using (List.getElem?_eq_some_iff.mp h1).1
+    rw [← Nat.add_assoc, h'.window i (p + o i) hlt]
+    exact h.window i p hp
+  link_map i j p q hl := by
+    simpa [Nat.add_assoc] using h'.link_map i j _ _ (h.link_map i j p q hl)
+
+/-- Factor embedding is transitive. -/
+theorem FactorEmbeds.trans {Y : TieredAR ι τ} [Finite Y.obj.V]
+    (h : F.FactorEmbeds X) (h' : X.FactorEmbeds Y) : F.FactorEmbeds Y :=
+  have ⟨_, h⟩ := h
+  have ⟨_, h'⟩ := h'
+  ⟨_, h.trans h'⟩
+
 /-- On a tier where the factor is nonempty, the window equations force the offset
     in bounds. -/
 theorem IsFactorAt.offset_le (h : F.IsFactorAt X o) {i : ι} (hi : F.tierLength i ≠ 0) :

--- a/Linglib/Phonology/Autosegmental/Junction.lean
+++ b/Linglib/Phonology/Autosegmental/Junction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Autosegmental.Factors
+import Linglib.Phonology.Autosegmental.Realization
 
 /-!
 # Local autosegmental configurations
@@ -317,6 +318,10 @@ def words (as : List α) (bs : List β) : ∀ b : Bool, List (TwoTier α β b)
   | true => (as : List (TwoTier α β true))
   | false => (bs : List (TwoTier α β false))
 
+@[simp] theorem words_true (as : List α) (bs : List β) : words as bs true = as := rfl
+
+@[simp] theorem words_false (as : List α) (bs : List β) : words as bs false = bs := rfl
+
 /-- Association lines from melody position `p` to timing position `q` under `L`. -/
 def links (L : ℕ → ℕ → Prop) (i j : Bool) (p q : ℕ) : Prop := i = true ∧ j = false ∧ L p q
 
@@ -355,6 +360,127 @@ instance [DecidableEq α] [DecidableEq β] (as as' : List α) (bs bs' : List β)
     (L L' : ℕ → ℕ → Prop) [DecidableRel L] [DecidableRel L'] :
     Decidable ((AR.ofWords as bs L).FactorEmbeds (AR.ofWords as' bs' L')) :=
   decidable_of_iff _ (AR.factorEmbeds_ofWords_iff as as' bs bs' L L').symm
+
+@[simp] theorem AR.tierLength_ofWords_true (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) :
+    (AR.ofWords as bs L).tierLength true = as.length :=
+  AR.tierLength_ofData true
+
+@[simp] theorem AR.tierLength_ofWords_false (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) :
+    (AR.ofWords as bs L).tierLength false = bs.length :=
+  AR.tierLength_ofData false
+
+/-- The lines of a representation of words: in bounds, and related by `L`. -/
+theorem AR.link_ofWords (as : List α) (bs : List β) (L : ℕ → ℕ → Prop) (p q : ℕ) :
+    (AR.ofWords as bs L).link true false p q ↔ p < as.length ∧ q < bs.length ∧ L p q := by
+  simp [AR.ofWords, AR.link_ofData, TwoTier.words, TwoTier.links]
+
+/-- A representation of words with no lines. -/
+theorem AR.not_link_ofWords_false (as : List α) (bs : List β) (i j : Bool) (p q : ℕ) :
+    ¬ (AR.ofWords as bs fun _ _ => False).link i j p q := fun hl => by
+  rcases (AR.link_ofData i j p q).mp hl with ⟨-, -, -, ⟨-, -, h⟩ | ⟨-, -, h⟩⟩ <;> exact h
+
+/-- Two-tier links are determined by the melody-to-timing case. -/
+theorem AR.link_iff_of_true_false {X Y : AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)}
+    [Finite X.obj.V] [Finite Y.obj.V]
+    (h : ∀ p q, X.link true false p q ↔ Y.link true false p q) (i j : Bool) (p q : ℕ) :
+    X.link i j p q ↔ Y.link i j p q := by
+  cases i <;> cases j
+  · exact iff_of_false (X.not_link_self_tier _ _ _) (Y.not_link_self_tier _ _ _)
+  · exact ⟨fun hl => Y.link_symm ((h q p).mp (X.link_symm hl)),
+      fun hl => X.link_symm ((h q p).mpr (Y.link_symm hl))⟩
+  · exact h p q
+  · exact iff_of_false (X.not_link_self_tier _ _ _) (Y.not_link_self_tier _ _ _)
+
+/-! #### Realizations of word primitives
+
+The realization of a string whose primitives are representations of words has the readers
+of one representation of words: the tier words concatenate, and a line lives inside one
+symbol's primitive, at that symbol's offsets. -/
+
+section RealizeOfWords
+
+variable {S : Type*} (as : S → List α) (bs : S → List β) (L : S → ℕ → ℕ → Prop)
+
+/-- The offset of the `k`-th symbol's word in the concatenation. -/
+def wordOffset {γ : Type*} (f : S → List γ) (w : List S) (k : ℕ) : ℕ :=
+  ((w.take k).map fun s => (f s).length).sum
+
+theorem wordOffset_add_length_le {γ : Type*} (f : S → List γ) {w : List S} {k : ℕ}
+    (hk : k < w.length) : wordOffset f w k + (f w[k]).length ≤ (w.map f).flatten.length := by
+  have h := List.sum_take_add_sum_drop (w.map fun s => (f s).length) k
+  rw [List.drop_eq_getElem_cons (by simpa using hk), List.sum_cons] at h
+  simp only [wordOffset, List.length_flatten, List.map_map, List.map_take, List.getElem_map,
+    Function.comp_def] at h ⊢
+  omega
+
+/-- The lines of a concatenation of word primitives: inside one symbol's primitive, at its
+offsets. -/
+def blockLinks (w : List S) (p q : ℕ) : Prop :=
+  ∃ k, ∃ hk : k < w.length, wordOffset as w k ≤ p ∧ wordOffset bs w k ≤ q ∧
+    p - wordOffset as w k < (as w[k]).length ∧ q - wordOffset bs w k < (bs w[k]).length ∧
+    L w[k] (p - wordOffset as w k) (q - wordOffset bs w k)
+
+instance [∀ s, DecidableRel (L s)] (w : List S) : DecidableRel (blockLinks as bs L w) :=
+  fun _ _ => by unfold blockLinks; infer_instance
+
+theorem blockLinks_lt {w : List S} {p q : ℕ} (h : blockLinks as bs L w p q) :
+    p < (w.map as).flatten.length ∧ q < (w.map bs).flatten.length := by
+  obtain ⟨k, hk, hp, hq, hp', hq', -⟩ := h
+  have := wordOffset_add_length_le as hk
+  have := wordOffset_add_length_le bs hk
+  omega
+
+variable (g₀ : S → AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)) [∀ s, Finite (g₀ s).obj.V]
+  (hg : ∀ s, g₀ s = AR.ofWords (as s) (bs s) (L s))
+include hg
+
+theorem AR.tierWord_realize_true_of_eq_ofWords (w : List S) :
+    (AR.realize g₀ w).tierWord true = (w.map as).flatten := by
+  simp [AR.tierWord_realize, hg]
+
+theorem AR.tierWord_realize_false_of_eq_ofWords (w : List S) :
+    (AR.realize g₀ w).tierWord false = (w.map bs).flatten := by
+  simp [AR.tierWord_realize, hg]
+
+theorem AR.tierOffset_true_of_eq_ofWords (w : List S) (k : ℕ) :
+    AR.tierOffset g₀ true w k = wordOffset as w k := by
+  simp [AR.tierOffset, hg, wordOffset]
+
+theorem AR.tierOffset_false_of_eq_ofWords (w : List S) (k : ℕ) :
+    AR.tierOffset g₀ false w k = wordOffset bs w k := by
+  simp [AR.tierOffset, hg, wordOffset]
+
+theorem AR.link_realize_of_eq_ofWords (w : List S) (p q : ℕ) :
+    (AR.realize g₀ w).link true false p q ↔ blockLinks as bs L w p q := by
+  rw [AR.link_realize]
+  simp only [AR.tierOffset_true_of_eq_ofWords as bs L g₀ hg,
+    AR.tierOffset_false_of_eq_ofWords as bs L g₀ hg, hg, AR.link_ofWords, blockLinks]
+
+/-- The realization of word primitives has the readers of one representation of words. -/
+theorem AR.factorEmbeds_realize_iff_of_eq_ofWords
+    (F : AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool)) [Finite F.obj.V] (w : List S) :
+    F.FactorEmbeds (AR.realize g₀ w) ↔
+      F.FactorEmbeds (AR.ofWords (w.map as).flatten (w.map bs).flatten (blockLinks as bs L w)) :=
+  AR.factorEmbeds_congr (fun _ => rfl) (fun _ _ _ _ => Iff.rfl)
+    (fun i => by
+      cases i
+      · exact (AR.tierWord_realize_false_of_eq_ofWords as bs L g₀ hg w).trans
+          (AR.tierWord_ofWords_false _ _ _).symm
+      · exact (AR.tierWord_realize_true_of_eq_ofWords as bs L g₀ hg w).trans
+          (AR.tierWord_ofWords_true _ _ _).symm)
+    (AR.link_iff_of_true_false fun p q => by
+      rw [AR.link_realize_of_eq_ofWords as bs L g₀ hg, AR.link_ofWords]
+      exact ⟨fun h => ⟨(blockLinks_lt as bs L h).1, (blockLinks_lt as bs L h).2, h⟩,
+        fun h => h.2.2⟩)
+
+theorem AR.free_realize_iff_of_eq_ofWords
+    (B : List {F : AR (Sigma.fst : ((b : Bool) × TwoTier α β b) → Bool) // Finite F.obj.V})
+    (w : List S) :
+    (AR.realize g₀ w).Free B ↔
+      (AR.ofWords (w.map as).flatten (w.map bs).flatten (blockLinks as bs L w)).Free B :=
+  forall₂_congr fun _ _ => not_congr (AR.factorEmbeds_realize_iff_of_eq_ofWords as bs L g₀ hg _ w)
+
+end RealizeOfWords
 
 /-- A timing slot **surfaces with** melody label `a`: some `a`-labelled melody
     node links to it. -/

--- a/Linglib/Phonology/Autosegmental/OCP.lean
+++ b/Linglib/Phonology/Autosegmental/OCP.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.FreeMonoid.Destutter
 import Linglib.Phonology.OCP
 import Linglib.Phonology.Autosegmental.Realization
+import Linglib.Phonology.Autosegmental.Junction
 
 /-!
 # OCP-merging collapse of autosegmental representations
@@ -356,7 +357,110 @@ noncomputable def realizeMerged (g₀ : S → TieredAR ι τ)
     TieredAR ι τ :=
   (AR.realize g₀ w).collapse m
 
+instance (g₀ : S → TieredAR ι τ) [∀ s, Finite (g₀ s).obj.V] (w : List S) :
+    Finite (realizeMerged m g₀ w).obj.V :=
+  inferInstanceAs (Finite ((AR.realize g₀ w).collapse m).obj.V)
+
 end RealizeMerged
+
+/-! ### The merged realization of word primitives
+
+Two-tier case, melody over `true`: the merged realization of a string of word primitives
+has the readers of one representation of words — the melody destuttered, the lines
+repointed through the run index. -/
+
+section MergedOfWords
+
+universe u
+variable {α β : Type u} [DecidableEq α] {S : Type*}
+
+/-- The lines of an OCP-merged realization: a line of the realization with its melody
+position repointed through the run index of the melody. -/
+def mergedLinks (melody : List α) (Lk : ℕ → ℕ → Prop) (r s : ℕ) : Prop :=
+  ∃ p < melody.length, Lk p s ∧ runIdx melody p = r
+
+instance (melody : List α) (Lk : ℕ → ℕ → Prop) [DecidableRel Lk] :
+    DecidableRel (mergedLinks melody Lk) :=
+  fun _ _ => by unfold mergedLinks; infer_instance
+
+/-- Melody-to-timing lines of a two-tier collapse at the melody tier. -/
+theorem AR.link_collapse_true_false (X : TieredAR Bool (TwoTier α β)) [Finite X.obj.V]
+    (r s : ℕ) :
+    (X.collapse true).link true false r s ↔
+      ∃ p < X.tierLength true, X.link true false p s ∧ runIdx (X.tierWord true) p = r := by
+  rw [AR.link_collapse]
+  simp only [AR.collapseIdx_self, AR.collapseIdx_of_ne _ true (by decide : false ≠ true)]
+  constructor
+  · rintro ⟨p, q, hl, rfl, rfl⟩
+    obtain ⟨hp, -, -⟩ := id hl
+    exact ⟨p, hp, hl, rfl⟩
+  · rintro ⟨p, hp, hl, rfl⟩
+    exact ⟨p, s, hl, rfl, rfl⟩
+
+variable (as : S → List α) (bs : S → List β) (L : S → ℕ → ℕ → Prop)
+  (g₀ : S → TieredAR Bool (TwoTier α β)) [∀ s, Finite (g₀ s).obj.V]
+  (hg : ∀ s, g₀ s = AR.ofWords (as s) (bs s) (L s))
+include hg
+
+theorem AR.tierWord_realizeMerged_true_of_eq_ofWords (w : List S) :
+    (realizeMerged true g₀ w).tierWord true = OCP.collapse (w.map as).flatten := by
+  simp [realizeMerged, AR.tierWord_realize_true_of_eq_ofWords as bs L g₀ hg]
+
+theorem AR.tierWord_realizeMerged_false_of_eq_ofWords (w : List S) :
+    (realizeMerged true g₀ w).tierWord false = (w.map bs).flatten := by
+  simp [realizeMerged, AR.tierWord_realize_false_of_eq_ofWords as bs L g₀ hg]
+
+theorem AR.link_realizeMerged_of_eq_ofWords (w : List S) (r s : ℕ) :
+    (realizeMerged true g₀ w).link true false r s ↔
+      mergedLinks (w.map as).flatten (blockLinks as bs L w) r s := by
+  show ((AR.realize g₀ w).collapse true).link true false r s ↔ _
+  rw [AR.link_collapse_true_false]
+  simp only [AR.link_realize_of_eq_ofWords as bs L g₀ hg,
+    AR.tierWord_realize_true_of_eq_ofWords as bs L g₀ hg, mergedLinks, AR.tierLength_realize,
+    hg, AR.tierLength_ofWords_true, List.length_flatten, List.map_map, Function.comp_def]
+
+/-- The tier words of the merged realization are those of its representation of words. -/
+theorem AR.tierWord_realizeMerged_eq_tierWord_ofWords (w : List S) (i : Bool) :
+    (realizeMerged true g₀ w).tierWord i =
+      (AR.ofWords (OCP.collapse (w.map as).flatten) (w.map bs).flatten
+        (mergedLinks (w.map as).flatten (blockLinks as bs L w))).tierWord i := by
+  cases i
+  · exact (AR.tierWord_realizeMerged_false_of_eq_ofWords as bs L g₀ hg w).trans
+      (AR.tierWord_ofWords_false _ _ _).symm
+  · exact (AR.tierWord_realizeMerged_true_of_eq_ofWords as bs L g₀ hg w).trans
+      (AR.tierWord_ofWords_true _ _ _).symm
+
+/-- The lines of the merged realization are those of its representation of words. -/
+theorem AR.link_realizeMerged_iff_link_ofWords (w : List S) (i j : Bool) (p q : ℕ) :
+    (realizeMerged true g₀ w).link i j p q ↔
+      (AR.ofWords (OCP.collapse (w.map as).flatten) (w.map bs).flatten
+        (mergedLinks (w.map as).flatten (blockLinks as bs L w))).link i j p q :=
+  AR.link_iff_of_true_false (fun r s => by
+    rw [AR.link_realizeMerged_of_eq_ofWords as bs L g₀ hg, AR.link_ofWords]
+    constructor
+    · rintro ⟨p, hp, hl, rfl⟩
+      exact ⟨runIdx_lt_collapse_length _ hp, (blockLinks_lt as bs L hl).2, p, hp, hl, rfl⟩
+    · exact fun h => h.2.2) i j p q
+
+/-- Embedding into the merged realization of word primitives computes on the words. -/
+theorem AR.factorEmbeds_realizeMerged_iff_of_eq_ofWords
+    (F : TieredAR Bool (TwoTier α β)) [Finite F.obj.V] (w : List S) :
+    F.FactorEmbeds (realizeMerged true g₀ w) ↔
+      F.FactorEmbeds (AR.ofWords (OCP.collapse (w.map as).flatten) (w.map bs).flatten
+        (mergedLinks (w.map as).flatten (blockLinks as bs L w))) :=
+  AR.factorEmbeds_congr (fun _ => rfl) (fun _ _ _ _ => Iff.rfl)
+    (AR.tierWord_realizeMerged_eq_tierWord_ofWords as bs L g₀ hg w)
+    (AR.link_realizeMerged_iff_link_ofWords as bs L g₀ hg w)
+
+theorem AR.free_realizeMerged_iff_of_eq_ofWords
+    (B : List {F : TieredAR Bool (TwoTier α β) // Finite F.obj.V}) (w : List S) :
+    (realizeMerged true g₀ w).Free B ↔
+      (AR.ofWords (OCP.collapse (w.map as).flatten) (w.map bs).flatten
+        (mergedLinks (w.map as).flatten (blockLinks as bs L w))).Free B :=
+  AR.free_congr (AR.tierWord_realizeMerged_eq_tierWord_ofWords as bs L g₀ hg w)
+    (AR.link_realizeMerged_iff_link_ofWords as bs L g₀ hg w) B
+
+end MergedOfWords
 
 section Axiom6Bridge
 

--- a/Linglib/Studies/Jardine2019.lean
+++ b/Linglib/Studies/Jardine2019.lean
@@ -4,263 +4,243 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Computability.Language
-import Linglib.Phonology.Autosegmental.Factors
-import Linglib.Phonology.Autosegmental.Realization
 import Linglib.Phonology.Autosegmental.OCP
-import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Subregular.ContainsFactor
+import Linglib.Phonology.Tone.Basic
 
 /-!
 # Jardine (2019): the expressivity of autosegmental grammars
 
-[jardine-2019] defines `ASL^g` — stringsets given by forbidden-subgraph grammars over
-autosegmental representations interpreted through a realization `g` — and places the
-tone class `ASL^{gT}` in the subregular hierarchy. This file defines the class on
-the graph foundation, instantiates it with the tone realization `gT`, and checks
-banned-subgraph constraints over its realizations.
+[jardine-2019] defines, for a map `g` from symbols to autosegmental graph primitives
+(Definition 1) extended to strings by merging concatenation (Definition 2), the stringset
+`L(B^g)` of a finite set `B` of forbidden connected subgraphs — the strings whose graph
+contains none of them — and the class `ASL^g` of such sets (§5.3). The tone class `ASL^{gT}`
+uses `gT` of (23): `H` and `L` are a tone over a mora, `F` a falling `H L` contour over one;
+merging fuses `gT(Hⁿ)` into a single `H` over `n` morae (Fig. 10). Theorem 2 places the
+class strictly inside the star-free sets; Theorems 3 and 4 make it incomparable with SL,
+TSL and SP.
 
-## Scope
+`gT` on strings is `realizeMerged`, the tensor realization with its melody runs fused. Its
+tier words and lines compute from the words (`AR.free_realizeMerged_iff_of_eq_ofWords`), so
+membership in `L(B^{gT})` decides for concrete grammars. The unmerged `AR.realize` is the
+project's bridge-only realization, kept for the contrast merging makes.
 
-Two realizations are checked, against the same forbidden tone melody `*HLH`:
+## Main definitions
 
-* `Autosegmental.AR.realize` uses the project's *bridge-only* `concat` (the coproduct), so
-  an `H`-plateau `Hⁿ` stays `n` separate `H` nodes. Banning `*HLH` over `AR.realize` then
-  catches only a *local* `H-L-H` (three adjacent tonal nodes) — `hlh_excluded`.
-* `Autosegmental.AR.realizeMerged` (`OCP.lean`) is [jardine-2019]'s OCP-*merging*
-  `g_T`: `g_T(Hⁿ)` is a *single* `H` node multiply associated. Banning `*HLH` over
-  `AR.realizeMerged` becomes genuinely **non-local** — it forbids `H⁺ L⁺ H⁺` for *any*
-  plateau widths, because the plateaus collapse to single nodes before the melody is
-  read (`hlhTier_merged_excludes_plateau` vs `hlhTier_unmerged_admits_plateau`).
+* `Sym`, `gT` — Σ_T = {H, L, F} and (23).
+* `ASL` — `L(B^{gT})`; the grammars `spreadGrammar` (26) and `utpGrammar` (33).
 
-## Subregular placement
+## Main results
 
-[jardine-2019] places the bridge-only class `ASL` strictly inside the star-free
-languages. We prove the **link-free fragment**: when no forbidden subgraph carries
-association lines, `ASL g₀ B` is star-free (`AR.ASL.isStarFree_of_link_free`)
-— over any alphabet, no `[Finite S]` needed — because such a grammar is a Boolean
-combination of per-tier factor constraints, each the inverse image of a star-free
-contains-factor language ([schutzenberger-1965] [mcnaughton-papert-1971]) along a tier
-projection. The `*HLH` tonal-tier melody `hlhTier` is one such constraint
-(`hlhTier_isStarFree`).
-
-The genuinely autosegmental case — links coupling the two tiers — is deeper: a forbidden
-subgraph can match with an unlinked run-end arbitrarily far from its linked core, so a
-bounded sliding-window scanner over the realization is unsound; a two-tape synchronising
-aperiodic recognizer is needed, and is left to future work.
-
-The relation-level `L = ASL^{gT}` equivalences ([jardine-2019]) remain future work.
+* (27): `HH` and `HF` are out of `L({(26)})`, the listed strings up to length three in.
+* (32): the listed strings of `L_UTP` are in `L(B_UTP)`; `HLH`, `LHHLH` and the unbounded
+  plateau `HHLLHH` are out — while `HHLLHH` is free of `B_UTP` under the unmerged
+  realization (`HHLLHH_free_realize`): the non-local reach that merging buys.
+* Theorem 3's observation: `gT(HL)` is a subgraph of `gT(HF)` (`realizeMerged_HL_embeds_HF`),
+  so no forbidden-subgraph grammar excludes `HL` without excluding `HF`
+  (`not_mem_ASL_HF_of_not_mem_ASL_HL`).
+* The link-free fragment of the unmerged class is star-free
+  (`isStarFree_free_realize_of_link_free`): a grammar without association lines is a Boolean
+  combination of per-tier factor constraints, each the inverse image of a star-free
+  contains-factor language ([schutzenberger-1965], [mcnaughton-papert-1971]) along a tier
+  projection; `utpGrammar`'s melody constraint is one (`isStarFree_free_realize_hlh`).
+  Theorem 2 for the merged class, via FO-definability, is not formalized.
 -/
 
-namespace Autosegmental
+namespace Jardine2019
 
-variable {S : Type*}
+open Autosegmental Tone Tone.TRN
 
-/-! #### The star-free placement in coordinates -/
+/-- The string alphabet Σ_T = {H, L, F} (§5.2.2): a high, low or falling-toned mora. -/
+inductive Sym | H | L | F
+  deriving DecidableEq, Repr
 
-section Coordinate
+/-- The melody of a symbol's primitive: `F` is the falling contour `H L`. -/
+def Sym.melody : Sym → List TRN
+  | .H => [TRN.H]
+  | .L => [TRN.L]
+  | .F => [TRN.H, TRN.L]
 
-variable {ι : Type*} [Finite ι] {τ : ι → Type*}
+/-- The mora, the paper's tone-bearing unit. -/
+abbrev μ : TBUKind := .mora
 
-/-- The Autosegmental Strictly Local stringset `ASL^g`: strings whose realization
-    avoids every forbidden factor. It is the same construction as the tier-based
-    strictly local sets — a preimage of a local condition along a free-monoid
-    homomorphism (`TSL = tierProject ⁻¹' SL`); the association structure `AR.realize`
-    keeps is why [jardine-2019] finds the two classes incomparable. -/
-def AR.ASL (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
-    [∀ s, Finite (g₀ s).obj.V]
-    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}) :
-    Language S :=
-  { w | (AR.realize g₀ w).Free B }
+/-- `gT` (23): a symbol's melody over one mora, fully associated. -/
+def gT (s : Sym) : TieredAR Bool (TwoTier TRN TBUKind) :=
+  AR.ofWords s.melody [μ] fun _ _ => True
 
-omit [Finite ι] in
-@[simp] theorem AR.mem_ASL
-    {g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι)}
-    [∀ s, Finite (g₀ s).obj.V]
-    {B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V}}
-    {w : List S} : w ∈ AR.ASL g₀ B ↔ (AR.realize g₀ w).Free B := Iff.rfl
+instance (s : Sym) : Finite (gT s).obj.V :=
+  inferInstanceAs (Finite (AR.ofWords s.melody [μ] fun _ _ => True).obj.V)
 
-/-- For a single link-free forbidden factor, the strings whose realization
-    contains it form a star-free language: the finite intersection of per-tier
-    factor constraints, each the inverse image of a star-free contains-factor
-    language along a tier projection. -/
-theorem AR.isStarFree_occur_of_link_free
-    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
-    [∀ s, Finite (g₀ s).obj.V]
-    (F : AR (Sigma.fst : ((i : ι) × τ i) → ι)) [Finite F.obj.V]
+theorem gT_eq (s : Sym) : gT s = AR.ofWords s.melody [μ] fun _ _ => True := rfl
+
+/-- The merged realization of a string, read as a representation of words. -/
+abbrev merged (w : List Sym) :=
+  AR.ofWords (OCP.collapse (w.map Sym.melody).flatten) (w.map fun _ => [μ]).flatten
+    (mergedLinks (w.map Sym.melody).flatten
+      (blockLinks Sym.melody (fun _ => [μ]) (fun _ _ _ => True) w))
+
+/-- The unmerged realization of a string, read as a representation of words. -/
+abbrev unmerged (w : List Sym) :=
+  AR.ofWords (w.map Sym.melody).flatten (w.map fun _ => [μ]).flatten
+    (blockLinks Sym.melody (fun _ => [μ]) (fun _ _ _ => True) w)
+
+/-- `L(B^{gT})` (§5.3): the strings whose merged realization is free of the grammar. -/
+def ASL (B : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V}) :
+    Language Sym :=
+  {w | (realizeMerged true gT w).Free B}
+
+theorem mem_ASL_iff {B : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V}}
+    {w : List Sym} : w ∈ ASL B ↔ (merged w).Free B :=
+  AR.free_realizeMerged_iff_of_eq_ofWords _ _ _ gT gT_eq B w
+
+theorem free_realize_iff (B : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V})
+    (w : List Sym) : (AR.realize gT w).Free B ↔ (unmerged w).Free B :=
+  AR.free_realize_iff_of_eq_ofWords _ _ _ gT gT_eq B w
+
+/-! ### The grammars of (26) and (33) -/
+
+/-- (26): a tone over two morae. -/
+abbrev spread := AR.ofWords [H] [μ, μ] fun _ _ => True
+
+/-- (3), the melody `H L H`. -/
+abbrev hlh := AR.ofWords [H, L, H] ([] : List TBUKind) fun _ _ => False
+
+/-- The falling contour: `H L` over one mora. -/
+abbrev fall := AR.ofWords [H, L] [μ] fun _ _ => True
+
+/-- The grammar of (26): no tone over two morae. -/
+def spreadGrammar : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V} :=
+  [⟨spread, inferInstance⟩]
+
+/-- `B_UTP` (33): no `H L H` melody, no contour. -/
+def utpGrammar : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V} :=
+  [⟨hlh, inferInstance⟩, ⟨fall, inferInstance⟩]
+
+theorem mem_ASL_spreadGrammar_iff (w : List Sym) :
+    w ∈ ASL spreadGrammar ↔ ¬ spread.FactorEmbeds (merged w) := by
+  simp only [mem_ASL_iff, spreadGrammar, AR.free_cons, AR.free_nil, and_true]
+
+theorem mem_ASL_utpGrammar_iff (w : List Sym) :
+    w ∈ ASL utpGrammar ↔ ¬ hlh.FactorEmbeds (merged w) ∧ ¬ fall.FactorEmbeds (merged w) := by
+  simp only [mem_ASL_iff, utpGrammar, AR.free_cons, AR.free_nil, and_true]
+
+instance (w : List Sym) : Decidable (w ∈ ASL spreadGrammar) :=
+  decidable_of_iff _ (mem_ASL_spreadGrammar_iff w).symm
+
+instance (w : List Sym) : Decidable (w ∈ ASL utpGrammar) :=
+  decidable_of_iff _ (mem_ASL_utpGrammar_iff w).symm
+
+/-! ### The data of (27) and (32) -/
+
+/-- (27): `HH` and `HF` are out — their fused `H` spans two morae. -/
+theorem HH_not_mem_ASL_spread : [.H, .H] ∉ ASL spreadGrammar := by decide
+
+theorem HF_not_mem_ASL_spread : [.H, .F] ∉ ASL spreadGrammar := by decide
+
+/-- (27): the listed strings up to length three are in. -/
+theorem mem_ASL_spread :
+    ∀ w ∈ [[], [.L], [.H], [.F], [.L, .L], [.L, .H], [.L, .F], [.H, .L], [.F, .H], [.F, .F],
+      [.L, .L, .L], [.L, .L, .H], [.L, .L, .F], [.L, .H, .L], [.L, .F, .L], [.L, .F, .F],
+      [.H, .L, .L], [.H, .L, .H], [.H, .L, .F]], w ∈ ASL spreadGrammar := by
+  decide
+
+/-- (32): the listed strings of `L_UTP` are in. -/
+theorem mem_ASL_utp :
+    ∀ w ∈ [[], [.L], [.H], [.L, .L], [.L, .H], [.H, .L], [.H, .H], [.L, .L, .L], [.L, .L, .H],
+      [.L, .H, .L], [.L, .H, .H], [.H, .L, .L], [.H, .H, .L], [.H, .H, .H], [.L, .L, .L, .L],
+      [.L, .L, .L, .H], [.L, .L, .H, .L], [.L, .L, .H, .H], [.L, .H, .L, .L], [.L, .H, .H, .L],
+      [.L, .H, .H, .H], [.H, .L, .L, .L], [.H, .H, .L, .L], [.H, .H, .H, .L], [.H, .H, .H, .H]],
+      w ∈ ASL utpGrammar := by
+  decide
+
+/-- `HLH` is out: its melody is `H L H`. -/
+theorem HLH_not_mem_ASL_utp : [.H, .L, .H] ∉ ASL utpGrammar := by decide
+
+/-- `LHHLH` is out: the `HH` plateau fuses and the melody reads `L H L H`. -/
+theorem LHHLH_not_mem_ASL_utp : [.L, .H, .H, .L, .H] ∉ ASL utpGrammar := by decide
+
+/-- The unbounded plateau `HHLLHH` is out: both plateaus fuse and the melody reads `H L H`,
+at any widths. -/
+theorem HHLLHH_not_mem_ASL_utp : [.H, .H, .L, .L, .H, .H] ∉ ASL utpGrammar := by decide
+
+/-- The same string is free of `B_UTP` under the unmerged realization: its melody reads
+`H H L L H H`, and no three adjacent nodes spell `H L H` — the reach merging buys. -/
+theorem HHLLHH_free_realize : (AR.realize gT [.H, .H, .L, .L, .H, .H]).Free utpGrammar := by
+  rw [free_realize_iff]
+  simp only [utpGrammar, AR.free_cons, AR.free_nil, and_true]
+  decide
+
+/-! ### Theorem 3: contours contain their pure counterparts -/
+
+/-- `gT(HL)` is a subgraph of `gT(HF)`: the falling contour on the second mora contains
+the `L` on it. -/
+theorem realizeMerged_HL_embeds_HF :
+    (realizeMerged true gT [.H, .L]).FactorEmbeds (realizeMerged true gT [.H, .F]) :=
+  (AR.factorEmbeds_congr
+    (AR.tierWord_realizeMerged_eq_tierWord_ofWords _ _ _ gT gT_eq _)
+    (AR.link_realizeMerged_iff_link_ofWords _ _ _ gT gT_eq _)
+    (AR.tierWord_realizeMerged_eq_tierWord_ofWords _ _ _ gT gT_eq _)
+    (AR.link_realizeMerged_iff_link_ofWords _ _ _ gT gT_eq _)).mpr (by decide)
+
+/-- Hence no forbidden-subgraph grammar excludes `HL` without excluding `HF` (Theorem 3):
+a subgraph of `gT(HL)` is a subgraph of `gT(HF)`. -/
+theorem not_mem_ASL_HF_of_not_mem_ASL_HL
+    (B : List {F : TieredAR Bool (TwoTier TRN TBUKind) // Finite F.obj.V})
+    (h : [.H, .L] ∉ ASL B) : [.H, .F] ∉ ASL B :=
+  fun hHF => h fun F hF hemb => hHF F hF (hemb.trans realizeMerged_HL_embeds_HF)
+
+/-! ### The link-free fragment of the unmerged class is star-free -/
+
+section StarFree
+
+variable {S : Type*} {ι : Type*} [Finite ι] {τ : ι → Type*}
+  (g₀ : S → TieredAR ι τ) [∀ s, Finite (g₀ s).obj.V]
+
+/-- For a link-free forbidden factor, the strings whose unmerged realization contains it
+form a star-free language: the intersection of per-tier factor constraints, each the
+inverse image of a star-free contains-factor language along a tier projection. -/
+theorem isStarFree_factorEmbeds_realize_of_link_free (F : TieredAR ι τ) [Finite F.obj.V]
     (hF : ∀ i j p q, ¬ F.link i j p q) :
-    Language.IsStarFree {w : List S | F.FactorEmbeds (Autosegmental.AR.realize g₀ w)} := by
-  have hset : {w : List S | F.FactorEmbeds (Autosegmental.AR.realize g₀ w)}
+    Language.IsStarFree {w : List S | F.FactorEmbeds (AR.realize g₀ w)} := by
+  have hset : {w : List S | F.FactorEmbeds (AR.realize g₀ w)}
       = ⋂ i, {w : List S | F.tierWord i <:+: AR.tierProj g₀ i (FreeMonoid.ofList w)} := by
     ext w
-    haveI := Autosegmental.AR.realize.instFinite g₀ w
-    simp only [Set.mem_ofPred_eq, Set.mem_iInter,
-      AR.factorEmbeds_iff_infix_of_link_free hF, AR.tierProj_ofList]
+    simp only [Set.mem_ofPred_eq, Set.mem_iInter, AR.factorEmbeds_iff_infix_of_link_free hF,
+      AR.tierProj_ofList]
     exact Iff.rfl
   rw [hset]
   exact Language.IsStarFree.iInter fun i =>
     (Language.isStarFree_containsFactor (F.tierWord i)).comap (AR.tierProj g₀ i)
 
-/-- **Link-free autosegmental SL sets are star-free**, on the graph foundation:
-    when no forbidden factor carries association lines, `AR.ASL` is
-    a Boolean combination of per-tier factor constraints. -/
-theorem AR.ASL.isStarFree_of_link_free
-    (g₀ : S → AR (Sigma.fst : ((i : ι) × τ i) → ι))
-    [∀ s, Finite (g₀ s).obj.V]
-    (B : List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
-    (hB : ∀ F ∈ B, haveI := F.property; ∀ i j p q, ¬ F.val.link i j p q) :
-    (AR.ASL g₀ B).IsStarFree := by
+/-- A grammar without association lines specifies a star-free set of strings under the
+unmerged realization. -/
+theorem isStarFree_free_realize_of_link_free
+    (B : List {F : TieredAR ι τ // Finite F.obj.V})
+    (hB : ∀ F ∈ B, ∀ i j p q, ¬ F.val.link i j p q) :
+    Language.IsStarFree {w : List S | (AR.realize g₀ w).Free B} := by
   induction B with
   | nil =>
-    have : AR.ASL g₀ ([] :
-        List {F : AR (Sigma.fst : ((i : ι) × τ i) → ι) // Finite F.obj.V})
-        = Set.univ :=
-      Set.eq_univ_of_forall fun w F hF => absurd hF (List.not_mem_nil)
-    rw [this]
-    exact Language.isStarFree_univ
-  | cons F B' ih =>
-    have hFl := hB F (List.mem_cons_self ..)
-    have ih' := ih fun F' hF' => hB F' (List.mem_cons_of_mem _ hF')
-    have hset : AR.ASL g₀ (F :: B') =
-        {w : List S | haveI := F.property
-          F.val.FactorEmbeds (Autosegmental.AR.realize g₀ w)}ᶜ ∩ AR.ASL g₀ B' := by
+    simpa [AR.free_nil] using Language.isStarFree_univ (α := S)
+  | cons F B ih =>
+    have hset : {w : List S | (AR.realize g₀ w).Free (F :: B)} =
+        {w : List S | F.val.FactorEmbeds (AR.realize g₀ w)}ᶜ ∩
+          {w : List S | (AR.realize g₀ w).Free B} := by
       ext w
-      show (∀ G ∈ F :: B', _) ↔ _
-      rw [List.forall_mem_cons]
-      exact Iff.rfl
+      simp [AR.free_cons]
     rw [hset]
-    haveI := F.property
-    exact (AR.isStarFree_occur_of_link_free g₀ F.val hFl).compl.inter ih'
+    exact (isStarFree_factorEmbeds_realize_of_link_free g₀ F.val
+      (hB F (List.mem_cons_self ..))).compl.inter
+      (ih fun F' hF' => hB F' (List.mem_cons_of_mem _ hF'))
 
-end Coordinate
+end StarFree
 
-end Autosegmental
-
-namespace Jardine2019
-
-open Autosegmental
-
-/-- The tone alphabet ([jardine-2019] §2): high, low, falling. -/
-inductive ToneSym | H | L | F
-  deriving DecidableEq, Repr
-
-/-- The tone-bearing unit (a mora). -/
-inductive Mora | μ
-  deriving DecidableEq, Repr
-
-/-- Two-tier tone representations (melody over `true`, morae over `false`). -/
-abbrev TRep := AR
-  (Sigma.fst : ((b : Bool) × TwoTier ToneSym Mora b) → Bool)
-
-/-- Link presentations from finite pair lists. -/
-def mkL (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) : Prop :=
-  i = true ∧ j = false ∧ (p, q) ∈ links
-
-instance (links : List (ℕ × ℕ)) (i j : Bool) (p q : ℕ) :
-    Decidable (mkL links i j p q) :=
-  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
-
-/-- Build a representation from a tone melody, morae, and links. -/
-abbrev mk (tones : List ToneSym) (moras : List Mora) (links : List (ℕ × ℕ)) : TRep :=
-  AR.ofData
-    (fun b => match b with
-      | true => (tones : List (TwoTier ToneSym Mora true))
-      | false => moras)
-    (mkL links)
-
-theorem mk_embeds_iff {tF tX : List ToneSym} {bF bX : List Mora}
-    {lF lX : List (ℕ × ℕ)} :
-    (mk tF bF lF).FactorEmbeds (mk tX bX lX) ↔
-      dataEmbeds
-        (fun b => match b with
-          | true => (tF : List (TwoTier ToneSym Mora true))
-          | false => bF)
-        (fun b => match b with
-          | true => (tX : List (TwoTier ToneSym Mora true))
-          | false => bX)
-        (mkL lF) (mkL lX) :=
-  AR.factorEmbeds_ofData_iff
-
-/-- The forbidden subgraph `*HLH` ([jardine-2019] (3)): an `H-L-H` tone
-    sequence, three tones each on their own mora. -/
-abbrev hlh : TRep := mk [.H, .L, .H] [.μ, .μ, .μ] [(0, 0), (1, 1), (2, 2)]
-
-/-! ### The bridge-only realization: local `*HLH`
-
-The realization of a tone string under the bridge-only tensor is, in flattened
-presentation, the diagonal literal — one tone per mora (`gT` (23), with `F` an
-`H-L` contour). The `*HLH` verdicts compute through the data-level checker. -/
-
-/-- `HLH` is excluded: its realization contains the `*HLH` subgraph. -/
-theorem hlh_excluded :
-    hlh.FactorEmbeds (mk [.H, .L, .H] [.μ, .μ, .μ] [(0, 0), (1, 1), (2, 2)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- `HL` is admitted (no `H-L-H`). -/
-theorem hl_included :
-    ¬ hlh.FactorEmbeds (mk [.H, .L] [.μ, .μ] [(0, 0), (1, 1)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- `LHL` is admitted (no `H-L-H`). -/
-theorem lhl_included :
-    ¬ hlh.FactorEmbeds (mk [.L, .H, .L] [.μ, .μ, .μ] [(0, 0), (1, 1), (2, 2)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- The constraint reaches inside longer strings: `HHLH` is excluded (the
-    medial `H-L-H` realizes the forbidden subgraph). -/
-theorem hhlh_excluded :
-    hlh.FactorEmbeds
-      (mk [.H, .H, .L, .H] [.μ, .μ, .μ, .μ] [(0, 0), (1, 1), (2, 2), (3, 3)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-! ### The OCP-merging realization: non-local tone plateauing
-
-[jardine-2019]'s `g_T` is OCP-*merging*: an `H`-plateau `Hⁿ` fuses to a single
-`H` node (`AR.collapse`). Against the merged forms we ban the
-**tonal-tier melody** `*HLH` — adjacent tonal nodes, morae unconstrained —
-which is where merging buys non-local power: `H⁺ L⁺ H⁺` is excluded for *any*
-plateau widths, because the plateaus collapse first. -/
-
-/-- The forbidden tonal-tier melody `*HLH`: no morae pinned, no links. -/
-abbrev hlhTier : TRep := mk [.H, .L, .H] [] []
-
-/-- `LHHLH` is excluded under merging: the `HH`-plateau fuses, the tone tier
-    reads `L-H-L-H`, and the medial `H-L-H` melody appears. -/
-theorem lhhlh_merged_excluded :
-    hlhTier.FactorEmbeds
-      (mk [.L, .H, .L, .H] [.μ, .μ, .μ, .μ, .μ]
-        [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- A single `H`-plateau is admitted under merging: `HHH` fuses to one `H`. -/
-theorem hhh_merged_included :
-    ¬ hlhTier.FactorEmbeds (mk [.H] [.μ, .μ, .μ] [(0, 0), (0, 1), (0, 2)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- **The non-local power merging buys**: the unbounded plateau `HH-LL-HH`
-    fuses to tone tier `H-L-H`, so the melody appears — at any widths. -/
-theorem hlhTier_merged_excludes_plateau :
-    hlhTier.FactorEmbeds
-      (mk [.H, .L, .H] [.μ, .μ, .μ, .μ, .μ, .μ]
-        [(0, 0), (0, 1), (1, 2), (1, 3), (2, 4), (2, 5)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- The same string **unmerged** is admitted: the plateaus stay apart, the tone
-    tier reads `H-H-L-L-H-H`, and no three adjacent nodes spell `H-L-H`. The
-    contrast with `hlhTier_merged_excludes_plateau` is exactly the non-local
-    expressivity OCP merging adds. -/
-theorem hlhTier_unmerged_admits_plateau :
-    ¬ hlhTier.FactorEmbeds
-      (mk [.H, .H, .L, .L, .H, .H] [.μ, .μ, .μ, .μ, .μ, .μ]
-        [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]) := by
-  rw [mk_embeds_iff]; decide
-
-/-- **The `*HLH` tonal-tier melody set is star-free**: `hlhTier` carries no
-    links, so any grammar built from it falls in the link-free fragment
-    (`AR.ASL.isStarFree_of_link_free`) — a concrete instance of
-    [jardine-2019]'s `ASL ⊊ SF` placement. -/
-theorem hlhTier_link_free : ∀ i j p q, ¬ hlhTier.link i j p q := by
-  intro i j p q hl
-  rcases (AR.link_ofData i j p q).mp hl with
-    ⟨-, -, -, ⟨-, -, h⟩ | ⟨-, -, h⟩⟩ <;> exact absurd h (List.not_mem_nil)
+/-- The melody constraint of `B_UTP` is link-free, so under the unmerged realization it
+specifies a star-free set. -/
+theorem isStarFree_free_realize_hlh :
+    Language.IsStarFree {w : List Sym | (AR.realize gT w).Free [⟨hlh, inferInstance⟩]} :=
+  isStarFree_free_realize_of_link_free gT _ fun F hF => by
+    rw [List.mem_singleton] at hF
+    subst hF
+    exact AR.not_link_ofWords_false _ _
 
 end Jardine2019


### PR DESCRIPTION
Deep cleanse of `Studies/Jardine2019.lean` against the paper.

- The file's verdicts were about hand-written `mk` literals standing in for realizations, with the connection to `AR.realize`/`realizeMerged` asserted in prose; its `hlh` "each on its own mora, (3)" mis-cited (3), which is the melody-only subgraph. Now `ASL` is the paper's `L(B^{gT})` on `realizeMerged` (Definition 2's merging `g`), the grammars are (26) and `B_UTP` (33), and every membership verdict — the (27) and (32) data, `HLH`/`LHHLH`/`HHLLHH` out under merging while `HHLLHH` is free unmerged — is `decide`. Theorem 3's observation `gT(HL) ⊑ gT(HF)` is decided too and yields the general theorem that no grammar excludes `HL` without excluding `HF`. The link-free star-free fragment (unmerged) is kept and applied to `B_UTP`'s melody constraint.
- Substrate that makes this compute: `Factors` — `factorEmbeds_congr`/`free_congr` (embedding reads only tier words and links), `IsFactorAt.trans`/`FactorEmbeds.trans`; `Junction` — `link_ofWords`, `link_iff_of_true_false`, and the readers of a realization of word primitives (`wordOffset`, `blockLinks`, `link_realize_of_eq_ofWords`, `factorEmbeds_realize_iff_of_eq_ofWords`); `OCP` — the merged readers (`mergedLinks`, `link_collapse_true_false`, `factorEmbeds_realizeMerged_iff_of_eq_ofWords`, `free_realizeMerged_iff_of_eq_ofWords`) and the missing `Finite` instance on `realizeMerged`.