### PR TITLE
refactor(Phonology/Tone): TRN as structure + bundle Equiv; Register split out

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1419,6 +1419,7 @@ import Linglib.Phonology.Tone.Basic
 import Linglib.Phonology.Tone.Constraints
 import Linglib.Phonology.Tone.Grammatical
 import Linglib.Phonology.Tone.Plateauing
+import Linglib.Phonology.Tone.Register
 import Linglib.Phonology.Tone.Surfacing
 import Linglib.Pragmatics.AsymmetricCommunication
 import Linglib.Pragmatics.BToM

--- a/Linglib/Fragments/Drubea/Prosody.lean
+++ b/Linglib/Fragments/Drubea/Prosody.lean
@@ -170,8 +170,9 @@ def applyBoundary (specs : List TRN)
 -- § 5: Language Properties
 -- ============================================================================
 
-/-- Drubea is a register-based tone system ([lionnet-2025] §6.2). -/
-def wordProsodicType : WordProsodicType := .registerBased
+/-- Drubea is tonal by [hyman-2006]'s definition (3) — register enters lexical
+realization — and has no stress accent ([lionnet-2025] §6.2). -/
+def wordProsody : WordProsody := ⟨true, false⟩
 
 /-- The register-bearing unit in Drubea is the mora ([lionnet-2025] §4.2). -/
 def tbuKind : TBUKind := .mora

--- a/Linglib/Fragments/Mwaghavul/Basic.lean
+++ b/Linglib/Fragments/Mwaghavul/Basic.lean
@@ -24,8 +24,7 @@ namespace Mwaghavul
 
 open Tone (TRN TBU Spec)
 
-/-- Mwaghavul is a tone language with syllable TBUs. -/
-def wordProsodicType : Tone.WordProsodicType := .toneBased
+/-- Mwaghavul's tone-bearing unit is the syllable. -/
 def tbuKind : Tone.TBUKind := .syllable
 
 /-! ### Verbalisers -/

--- a/Linglib/Phonology/Tone/Basic.lean
+++ b/Linglib/Phonology/Tone/Basic.lean
@@ -3,585 +3,143 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Mathlib.Data.List.Forall2
-import Mathlib.Data.List.Count
-import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Logic.Equiv.Defs
 import Linglib.Features.Basic
 
 /-!
-# Tonal Root Nodes and Subtonal Features
+# Tonal root nodes and subtonal features
 
-Tone is paradigmatic. A **Tonal Root Node** (TRN) is a bundle of
-**subtonal features** `[±upper]` and `[±raised]` ([yip-1980]
-[pulleyblank-1986]), each of which links to a TBU (mora, syllable).
-This file follows [lionnet-2022]'s reformulation of register-tier
-geometry: the four tier organisation (subtonal features → TRN → TBU)
-is shared with [snider-1999], but the features themselves are
-*paradigmatic* targets, not *syntagmatic* shifts.
+Tone is paradigmatic: a **tonal root node** (TRN) bundles the two subtonal features
+`[±upper]` (which register half) and `[±raised]` (which target within it) of [yip-1980] and
+[pulleyblank-1986], each possibly unspecified, and links to a tone-bearing unit. Following
+[lionnet-2022], the features are paradigmatic targets, not [snider-1999]'s syntagmatic
+shifts; the terracing reading of `[raised]` is `Tone.Register`.
 
 ## Main definitions
 
-* `Subtonal` — the two paradigmatic subtonal feature dimensions
-  `[±upper]` and `[±raised]`.
-* `TRN` — Tonal Root Node, a bundle of `Option Bool` values for the two
-  subtonal features. Linked to its `Subtonal → Option Bool` view by
-  `TRN.toBundle` / `TRN.ofBundle`.
-* `TRN.empty`, `TRN.downstep`, `TRN.upstep` — register-only TRNs for
-  Drubea/Numèè-style systems.
-* `TRN.H`, `TRN.M`, `TRN.L`, `TRN.superHigh` — the four `[±u, ±r]`
-  combinations underlying the Laal-style 3-tone system.
-* `realizePitch`, `pitchDeltas`, `realizePitchUtterance` — terracing
-  realisation (cumulative register shifts).
-* `TRN.absolutePitch` — paradigmatic Laal-style realisation.
-* `ThreeToneGap` — the four typological classes of 3-tone systems.
-* `TBUKind`, `WordProsodicType`, `DownstepProperties`,
-  `AnalysisInventory` — prosodic typology primitives.
-* `IsCulminative` — at most one `[-raised]` TRN per stem.
-* `hEpenthesis`, `hEpenthesisSpread` — postlexical operations.
-* `subtonalAssimilate`, `mergeTRN`, `dockFloating` —
-  subtonal feature operations via the bundle view.
-
-## Implementation notes
-
-### Why paradigmatic, not syntagmatic
-
-[snider-1999]'s `h`/`l` features are defined both paradigmatically
-(specifying register half) **and** syntagmatically ("higher / lower than
-the preceding register"). [lionnet-2022] argues this dual
-definition is overloaded: the same feature does double duty as a
-representational primitive and as a phonological process trigger.
-Switching to purely paradigmatic `[±upper]`/`[±raised]` separates the
-two roles — the features are the representation, the operations
-(spreading, OCP merger, deletion) are the processes.
-
-### Geometry
-
-```
-    [±upper]    Register-half subtonal feature tier
-    [±raised]   Within-register subtonal feature tier
-       ○        Tonal Root Node (TRN) — bundles both features
-       |
-      TBU       Tone-bearing unit (mora / syllable)
-```
-
-A TRN is the structural node that gathers a `[±upper]` value and a
-`[±raised]` value and links them to a TBU. Either or both features may
-be **underspecified** (`none`), with surface values filled in by default.
+* `Subtonal`, `TRN` — the two feature dimensions and the root node; `TRN.bundleEquiv`
+  identifies a root node with its feature bundle `Subtonal → Option Bool`
+  (`Features.Bundle`).
+* `TRN.H`, `TRN.M`, `TRN.L`, `TRN.superHigh` — the four full specifications;
+  `TRN.empty`, `TRN.downstep`, `TRN.upstep` — the register-only nodes.
+* `TRN.assimilate`, `TRN.merge`, `TRN.dock` — the feature operations, through the bundle.
+* `TBUKind`, `WordProsody`, `IsRegisterOnly` — the tone-bearing unit, [hyman-2006]'s two
+  word-prosodic dimensions, and [lionnet-2025]'s register-only inventories.
 -/
 
 namespace Tone
 
-/-! ### Subtonal features -/
-
-/-- The two paradigmatic subtonal feature dimensions
-    ([lionnet-2022] ex. 51, after [yip-1980],
-    [pulleyblank-1986]).
-
-    - `upper`: which register half (upper / lower)
-    - `raised`: which target within the register (higher / lower)
-
-    Each takes a value in `Bool`: `true ≡ +`, `false ≡ -`. A subtonal
-    feature is `none` (underspecified), `some true` (`+`), or
-    `some false` (`-`). -/
+/-- The two subtonal feature dimensions ([lionnet-2022] ex. 51, after [yip-1980],
+[pulleyblank-1986]): `upper`, which register half; `raised`, which target within it. A
+value is `some true` (`+`), `some false` (`-`), or `none` (unspecified). -/
 inductive Subtonal where
   | upper
   | raised
   deriving DecidableEq, Repr, Inhabited
 
-/-! ### Tonal root node -/
-
-/-- A **Tonal Root Node**: a structural node that bundles a `[±upper]`
-    and a `[±raised]` subtonal-feature value and links them to a TBU.
-
-    Either or both fields may be `none` (underspecified). For the
-    register-only Drubea/Numèè system the `upper` field is uniformly
-    `none`; for full 3-tone Laal both fields are usually specified.
-
-    Implemented as a structure rather than `Subtonal → Option Bool`
-    so that `DecidableEq` and `Repr` derive automatically (and `BEq`
-    follows from `DecidableEq`, below) and so that `decide`-based proofs
-    over concrete TRN literals reduce cleanly. The bundle view is
-    recovered by `TRN.toBundle`. -/
+/-- A **tonal root node**: a `[±upper]` and a `[±raised]` value, each possibly unspecified.
+A structure rather than the bundle `Subtonal → Option Bool`, so that `DecidableEq` derives
+and literals reduce; `TRN.bundleEquiv` is the bundle view. -/
 structure TRN where
-  upper  : Option Bool
+  upper : Option Bool
   raised : Option Bool
   deriving DecidableEq, Repr, Inhabited
 
 namespace TRN
 
-/-- Boolean equality on TRN as decidable equality, so that `LawfulBEq`
-    holds. Required for `simp`-based reasoning over `(t == t)`. -/
-instance : BEq TRN := ⟨fun a b => decide (a = b)⟩
-
-instance : LawfulBEq TRN where
-  eq_of_beq h := of_decide_eq_true h
-  rfl := decide_eq_true rfl
-
-/-- The empty / fully underspecified TRN. In the Drubea/Numèè register-
-    only system, this is the **registerless** mora. -/
+/-- The fully unspecified node: the registerless mora of Drubea and Numèè
+([lionnet-2025]). -/
 @[match_pattern] def empty : TRN := ⟨none, none⟩
 
-/-- A floating `[-raised]` subtonal feature, no `[upper]` value.
-    In the register-only system this is the **downstep** TRN: it lowers
-    the running register baseline. -/
+/-- A floating `[-raised]`: the downstep node of a register-only system. -/
 @[match_pattern] def downstep : TRN := ⟨none, some false⟩
 
-/-- A floating `[+raised]` subtonal feature, no `[upper]` value.
-    In the register-only system this is the **upstep** TRN — used by
-    pre-downstep h-epenthesis ([lionnet-2025]). -/
+/-- A floating `[+raised]`: the upstep node. -/
 @[match_pattern] def upstep : TRN := ⟨none, some true⟩
 
-/-- The **High** tone of Laal-style 3-tone systems: `[+upper, -raised]`
-    ([lionnet-2022] ex. 51). Highest pitch. -/
-def H : TRN := ⟨some true, some false⟩
+/-- High, `[+upper, -raised]` ([lionnet-2022] ex. 51). -/
+@[match_pattern] def H : TRN := ⟨some true, some false⟩
 
-/-- The **Mid** tone of Laal-style 3-tone systems: `[-upper, +raised]`
-    ([lionnet-2022] ex. 51). M is one of the four `[±u, ±r]`
-    combinations, derived from the binary subtonal features — not a
-    primitive enum constructor. -/
-def M : TRN := ⟨some false, some true⟩
+/-- Mid, `[-upper, +raised]` ([lionnet-2022] ex. 51). -/
+@[match_pattern] def M : TRN := ⟨some false, some true⟩
 
-/-- The **Low** tone of Laal-style 3-tone systems: `[-upper, -raised]`
-    ([lionnet-2022] ex. 51). Lowest pitch. -/
-def L : TRN := ⟨some false, some false⟩
+/-- Low, `[-upper, -raised]` ([lionnet-2022] ex. 51). -/
+@[match_pattern] def L : TRN := ⟨some false, some false⟩
 
-/-- The fourth combination `[+upper, +raised]` — *unattested* in Laal,
-    where it is the gap of the subtonal system ([lionnet-2022] ex. 51:
-    "Missing from this system is the subtonal specification
-    `[+upper, +raised]`"). Provided for completeness; an attested 4-tone
-    language or a different 3-tone gap would use this. -/
-def superHigh : TRN := ⟨some true, some true⟩
+/-- The fourth specification `[+upper, +raised]`: the gap of Laal's three-tone system
+([lionnet-2022] ex. 51). -/
+@[match_pattern] def superHigh : TRN := ⟨some true, some true⟩
 
-/-- View a TRN as a `Subtonal → Option Bool` (the parametric
-    foundation in `Features.Bundle`). The bundle algebra
-    (merge, assimilate, delete, set, refines) is then directly available
-    via this view. -/
+/-- The feature bundle of a node. -/
 def toBundle (t : TRN) : Subtonal → Option Bool
-  | .upper  => t.upper
+  | .upper => t.upper
   | .raised => t.raised
 
-/-- Recover a TRN from a generic subtonal-feature bundle. Inverse of
-    `toBundle`. -/
-def ofBundle (b : Subtonal → Option Bool) : TRN :=
-  ⟨b .upper, b .raised⟩
+/-- The node of a feature bundle. -/
+def ofBundle (b : Subtonal → Option Bool) : TRN := ⟨b .upper, b .raised⟩
 
-@[simp] theorem toBundle_upper  (t : TRN) : t.toBundle .upper  = t.upper  := rfl
+@[simp] theorem toBundle_upper (t : TRN) : t.toBundle .upper = t.upper := rfl
+
 @[simp] theorem toBundle_raised (t : TRN) : t.toBundle .raised = t.raised := rfl
 
-@[simp] theorem ofBundle_toBundle (t : TRN) : ofBundle t.toBundle = t := by
-  cases t; rfl
+@[simp] theorem ofBundle_toBundle (t : TRN) : ofBundle t.toBundle = t := rfl
+
+@[simp] theorem toBundle_ofBundle (b : Subtonal → Option Bool) : (ofBundle b).toBundle = b := by
+  funext f; cases f <;> rfl
+
+/-- A root node is its feature bundle. -/
+def bundleEquiv : TRN ≃ (Subtonal → Option Bool) where
+  toFun := toBundle
+  invFun := ofBundle
+  left_inv := ofBundle_toBundle
+  right_inv := toBundle_ofBundle
+
+/-- **Subtonal assimilation** at `f`: the target takes its value at `f` from the source,
+its other feature untouched. Laal M-lowering ([lionnet-2022] §5.2) is `assimilate .raised`:
+a `[-raised]` value spreads onto M, `[-upper, +raised]`, giving L. -/
+def assimilate (f : Subtonal) (src tgt : TRN) : TRN :=
+  ofBundle (Features.Bundle.assimilate f src.toBundle tgt.toBundle)
+
+/-- **Merger** of two nodes ([lionnet-2022] ex. 53–54): each feature from the left node
+where it is specified, else from the right (`Features.Bundle.merge`) — the fusion of two
+associated tones ([goldsmith-1976]); the tier-level merger of a run of identical tones is
+`OCP.collapse`. -/
+def merge (t₁ t₂ : TRN) : TRN := ofBundle (Features.Bundle.merge t₁.toBundle t₂.toBundle)
+
+@[simp] theorem merge_self (t : TRN) : merge t t = t := by
+  simp only [merge, Features.Bundle.merge_self, ofBundle_toBundle]
+
+/-- **Docking** of a floating feature ([lionnet-2022] §5.3): a free `[±f]` lands on a node,
+overwriting its value at `f`. -/
+def dock (f : Subtonal) (v : Bool) (t : TRN) : TRN :=
+  ofBundle (Features.Bundle.set f v t.toBundle)
 
 end TRN
 
-/-! ### Pitch realisation -/
+/-! ### Tone-bearing units and word-prosodic types -/
 
-/-- Syntagmatic register shift contributed by a TRN, used by the
-    terracing realisation `realizePitch`. Reads only the `[raised]`
-    subtonal feature: `[-raised]` lowers, `[+raised]` raises,
-    underspecified is inert.
-
-    This is *not* the paradigmatic interpretation of `[raised]`
-    ([lionnet-2022] §5.1). It is the realisation pattern attested in
-    register-only systems like Drubea and Numèè ([lionnet-2025]),
-    where each `[-raised]` triggers a downstep operation that resets
-    the register baseline. -/
-def TRN.pitchEffect (t : TRN) : Int :=
-  match t.raised with
-  | none       => 0
-  | some false => -1
-  | some true  => 1
-
-/-- **Terracing realisation**: realise a TRN sequence as a sequence of
-    pitch levels, where each `[-raised]` cumulatively lowers the
-    baseline ([snider-1999] [lionnet-2025]).
-
-    Used for register-only systems (Drubea, Numèè) and for catathesis
-    in Japanese / English intonation ([beckman-pierrehumbert-1986]).
-    For the paradigmatic Laal-style realisation see `TRN.absolutePitch`.
-
-    Defined by direct case-split on the `[raised]` value so that
-    `realizePitch n [TRN.empty, …]` reduces to `n :: …` definitionally
-    (the alternative `level + t.pitchEffect` form does not reduce for
-    opaque `n : Int`, since `n + 0 = n` is not definitional). -/
-def realizePitch : Int → List TRN → List Int
-  | _,     []                              => []
-  | level, ⟨_, none⟩       :: rest         => level       :: realizePitch level       rest
-  | level, ⟨_, some false⟩ :: rest         => (level - 1) :: realizePitch (level - 1) rest
-  | level, ⟨_, some true⟩  :: rest         => (level + 1) :: realizePitch (level + 1) rest
-
-/-- A uniform `cons` rewrite for `realizePitch` in terms of `pitchEffect`. -/
-@[simp] theorem realizePitch_cons (level : Int) (t : TRN)
-    (rest : List TRN) :
-    realizePitch level (t :: rest) =
-      (level + t.pitchEffect) :: realizePitch (level + t.pitchEffect) rest := by
-  obtain ⟨u, r⟩ := t
-  cases r with
-  | none => simp [realizePitch, TRN.pitchEffect]
-  | some b =>
-    cases b with
-    | false => simp [realizePitch, TRN.pitchEffect, Int.sub_eq_add_neg]
-    | true  => simp [realizePitch, TRN.pitchEffect]
-
-/-- **Pitch deltas** — the theory-primary view ([snider-1999]
-    [lionnet-2025]). Cumulative register shifts produced by a TRN
-    sequence, expressed as integer offsets from the start. There is no
-    privileged "zero" pitch; only the differences are meaningful. -/
-def pitchDeltas (ts : List TRN) : List Int := realizePitch 0 ts
-
-private theorem realizePitch_shift (n d : Int) (ts : List TRN) :
-    realizePitch (n + d) ts = (realizePitch n ts).map (· + d) := by
-  induction ts generalizing n with
-  | nil => rfl
-  | cons t rest ih =>
-    simp only [realizePitch_cons, List.map_cons]
-    have h : n + d + t.pitchEffect = (n + t.pitchEffect) + d := by omega
-    rw [h, ih]
-
-/-- `realizePitch n ts` is `pitchDeltas ts` shifted by the offset `n`. -/
-theorem realizePitch_eq_pitchDeltas_shift (n : Int) (ts : List TRN) :
-    realizePitch n ts = (pitchDeltas ts).map (· + n) := by
-  have := realizePitch_shift 0 n ts
-  rwa [Int.zero_add] at this
-
-/-- **Utterance-initial phonetic neutralisation**: an utterance-initial
-    `[-raised]` TRN is realised at the starting pitch (no preceding
-    register to contrast with — [lionnet-2025] §3.5, §4.5). The
-    feature is **not** removed from the underlying form: it remains
-    phonologically active for blocking pre-downstep h-epenthesis on
-    itself and for feeding raising on a following registerless TRN. -/
-def realizePitchUtterance (level : Int) : List TRN → List Int
-  | []          => []
-  | t :: rest   =>
-      if t.raised = some false ∧ t.upper = none then
-        level :: realizePitch level rest
-      else
-        realizePitch level (t :: rest)
-
-/-- **Paradigmatic Laal-style pitch realisation** ([lionnet-2022]
-    §4). Pitch is computed from `[upper]` (×2) plus `[raised]` (×1),
-    *independently* per TRN — no terracing, no register-baseline state.
-
-    Unspecified features contribute 0. The four combinations give:
-    `H = 2`, `M = 1`, `L = 0`, `superHigh = 3` (Laal's gap). -/
-def TRN.absolutePitch (t : TRN) : Int :=
-  let u : Int := if t.upper  = some true then 2 else 0
-  let r : Int := if t.raised = some true then 1 else 0
-  u + r
-
-/-! ### Lionnet's 3-tone typology -/
-
-/-- The four classes of 3-tone system definable over the binary subtonal
-    features `[±upper]`/`[±raised]` ([lionnet-2022] ex. 51): with four
-    full specifications available, a 3-tone system realises three of them,
-    and the unselected combination is the *gap*. The four-way classification
-    by gap is a systematisation of Lionnet's binary-feature account (Laal
-    itself has the `[+upper, +raised]` gap), not a typology the paper
-    surveys. -/
-inductive ThreeToneGap where
-  /-- Gap = `[+upper, +raised]` (Laal pattern). -/
-  | upperRaised
-  /-- Gap = `[+upper, -raised]`. -/
-  | upperLowered
-  /-- Gap = `[-upper, +raised]`. -/
-  | lowerRaised
-  /-- Gap = `[-upper, -raised]`. -/
-  | lowerLowered
-  deriving DecidableEq, Repr
-
-/-- Which TRN combination is the gap for a given 3-tone language type. -/
-def ThreeToneGap.gap : ThreeToneGap → TRN
-  | .upperRaised  => TRN.superHigh        -- ⟨+u, +r⟩
-  | .upperLowered => TRN.H                -- ⟨+u, -r⟩
-  | .lowerRaised  => TRN.M                -- ⟨-u, +r⟩
-  | .lowerLowered => TRN.L                -- ⟨-u, -r⟩
-
-/-- Laal's gap is `[+upper, +raised]` ([lionnet-2022] ex. 51). -/
-theorem laal_gap_eq_superHigh : ThreeToneGap.upperRaised.gap = TRN.superHigh := rfl
-
-/-! ### TBU and word-prosodic typology -/
-
-/-- The prosodic domain that carries TRN specifications. In most tone
-    languages this is the syllable; in Drubea and Numèè it is the mora
-    ([lionnet-2025]). -/
+/-- The prosodic unit that carries a node: the syllable in most tone languages, the mora in
+Drubea and Numèè ([lionnet-2025]). -/
 inductive TBUKind where
   | mora
   | syllable
   deriving DecidableEq, Repr
 
-/-- Word-prosodic system types ([hyman-2006], enriched by
-    [lionnet-2025]).
-
-    Tone systems split into **tone-based** (paradigmatic — full TRN
-    contrasts) and **register-based** (only `[raised]` varies, with
-    cumulative terracing realisation). -/
-inductive WordProsodicType where
-  /-- Paradigmatic H/L contrast (e.g., Yoruba, Mandarin). -/
-  | toneBased
-  /-- Syntagmatic downstep contrast (e.g., Drubea, Numèè). -/
-  | registerBased
-  /-- Prominence-based (e.g., English, Russian). -/
-  | stressAccent
-  /-- Both tone and register (e.g., Paicî, Baga Pukur). -/
-  | mixed
+/-- A language's word prosody: [hyman-2006]'s two independent dimensions — whether pitch
+enters the lexical realization of morphemes (his definition (3) of tone) and whether words
+carry an obligatory metrical head (his definition (5) of stress accent). -/
+structure WordProsody where
+  tone : Bool
+  stressAccent : Bool
   deriving DecidableEq, Repr
 
-/-- Core definitional properties of downstep, following [leben-2018]
-    as refined by [lionnet-2025].
+/-- A **register-only** inventory ([lionnet-2025]): no node specifies `[upper]`, so only the
+syntagmatic `[raised]` is contrastive. Lionnet's split of [hyman-2006]'s tone prototype —
+register-based systems (Drubea, Numèè) against tone-based ones with paradigmatic `[upper]`
+contrasts (Yoruba, Mandarin) and mixed ones (Paicî, Baga Pukur) — is read off the lexical
+inventory rather than recorded. -/
+def IsRegisterOnly (ts : List TRN) : Prop := ∀ t ∈ ts, t.upper = none
 
-    Properties (a)–(c) are definitional; (d)–(f) are cross-linguistic
-    tendencies that need not hold in every system. -/
-structure DownstepProperties where
-  /-- (a) Affects the entire prosodic domain, not just a single tone. -/
-  affectsDomain : Bool
-  /-- (b) Changes the register for what follows. -/
-  changesRegister : Bool
-  /-- (c) Cumulative: multiple downsteps stack (unlimited in principle). -/
-  isCumulative : Bool
-  /-- (d) Utterance-initially, no phonetic contrast with undownstepped. -/
-  uttInitialNeutral : Bool
-  /-- (e) Characteristically affects H tones. -/
-  characteristicallyAffectsH : Bool
-  /-- (f) Functions contrastively (phonological, syntactic,
-      morphophonological, or lexical). -/
-  functionsContrastively : Bool
-  deriving Repr
-
-/-- Inventory of primitives in a phonological analysis ([lionnet-2025]). -/
-structure AnalysisInventory where
-  underlyingPrimitives : Nat
-  postlexicalProcesses : Nat
-  deriving Repr, DecidableEq
-
-/-! ### Culminativity -/
-
-/-- **Register culminativity**: at most one `[-raised]` TRN per stem.
-
-    Holds for all native Drubea and Numèè stems
-    ([lionnet-2025] §3.10). The Lionnet 2022 framing: a stem
-    contains at most one bundle whose `[raised]` value is `some false`. -/
-abbrev IsCulminative (ts : List TRN) : Prop :=
-  (ts.countP (fun t => t.raised == some false)) ≤ 1
-
-/-! ### Postlexical operations -/
-
-/-- **Pre-downstep h-epenthesis** ([lionnet-2025]): insert an
-    upstep TRN immediately before a downstep, on a registerless host.
-
-    The rule fires when an empty (`⟨none, none⟩`) TRN is immediately
-    followed by a downstep TRN (`⟨none, some false⟩`); the empty TRN
-    is replaced by an upstep (`⟨none, some true⟩`). An *underlying*
-    downstep blocks the rule on itself — that is the diagnostic that
-    survives utterance-initial phonetic neutralisation. -/
-def hEpenthesis : List TRN → List TRN
-  | []                                => []
-  | [t]                               => [t]
-  | TRN.empty :: TRN.downstep :: rest =>
-      TRN.upstep :: TRN.downstep :: hEpenthesis rest
-  | t :: rest                         => t :: hEpenthesis rest
-
-/-- **Spreading h-epenthesis**: raise *all* registerless TRNs in the
-    sequence preceding a downstep, not just the immediately preceding
-    one ([lionnet-2025] §3.2). Models the **abrupt-spreading**
-    variant. -/
-def hEpenthesisSpread : List TRN → List TRN
-  | []                       => []
-  | TRN.downstep :: rest     => TRN.downstep :: hEpenthesisSpread rest
-  | TRN.upstep   :: rest     => TRN.upstep   :: hEpenthesisSpread rest
-  | TRN.empty    :: rest     =>
-      let rest' := hEpenthesisSpread rest
-      match rest' with
-      | TRN.downstep :: _ | TRN.upstep :: _ => TRN.upstep :: rest'
-      | _                                   => TRN.empty  :: rest'
-  | t :: rest                => t :: hEpenthesisSpread rest
-
-/-! ### Subtonal feature operations -/
-
-/-- **Subtonal assimilation** at feature `f`: the target TRN takes its
-    value at `f` from the source TRN, leaving its other feature
-    untouched. The Laal **M-lowering** rule ([lionnet-2022] §5.2)
-    is `subtonalAssimilate Subtonal.raised src tgt`: a `[-raised]`
-    value spreads from `src` to `tgt`, so a target M (`⟨-u, +r⟩`)
-    becomes L (`⟨-u, -r⟩`) without altering its `[upper]` value. -/
-def subtonalAssimilate (f : Subtonal) (src tgt : TRN) : TRN :=
-  TRN.ofBundle (Features.Bundle.assimilate f src.toBundle tgt.toBundle)
-
-/-- **Binary TRN merger** ([lionnet-2022] ex. 53–54): merge two TRNs' subtonal
-    features into one, taking each feature from the left TRN where it is specified and
-    falling back to the right (`Features.Bundle.merge`). Models the autosegmental fusion
-    of two associated tones ([goldsmith-1976]); the tier-level OCP merger that
-    collapses a run of identical tones is `OCP.collapse`. -/
-def mergeTRN (t₁ t₂ : TRN) : TRN :=
-  TRN.ofBundle (Features.Bundle.merge t₁.toBundle t₂.toBundle)
-
-/-- Merging a TRN with itself is the identity: `mergeTRN` is idempotent on equal
-    tones. -/
-@[simp] theorem mergeTRN_self (t : TRN) : mergeTRN t t = t := by
-  simp only [mergeTRN, Features.Bundle.merge_self, TRN.ofBundle_toBundle]
-
-/-- **Floating-feature docking** ([lionnet-2022] §5.3): a free
-    `[±f]` subtonal feature docks onto a target TRN, overwriting
-    whatever value it had at `f`. Used for the morphosyntactic
-    `[-raised]` suffix in Laal that triggers M-lowering. -/
-def dockFloating (f : Subtonal) (v : Bool) (t : TRN) : TRN :=
-  TRN.ofBundle (Features.Bundle.set f v t.toBundle)
-
-/-! ### Verification: Laal subtonal identities -/
-
-/-- The Laal H/M/L tones are exactly three of the four binary
-    `[±u, ±r]` combinations — the gap is `superHigh`. -/
-theorem laal_three_tones :
-    TRN.H ≠ TRN.M ∧ TRN.M ≠ TRN.L ∧ TRN.H ≠ TRN.L ∧
-    TRN.H ≠ TRN.superHigh ∧ TRN.M ≠ TRN.superHigh ∧
-    TRN.L ≠ TRN.superHigh := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
-
-/-- Paradigmatic pitch ordering: `L < M < H < superHigh`. -/
-theorem laal_paradigmatic_pitch :
-    TRN.L.absolutePitch = 0 ∧
-    TRN.M.absolutePitch = 1 ∧
-    TRN.H.absolutePitch = 2 ∧
-    TRN.superHigh.absolutePitch = 3 := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
-
-/-- **M-lowering as `[-raised]` assimilation** ([lionnet-2022]
-    §5.2). When a `[-raised]` source assimilates onto an M target, the
-    result is L: M's `[+raised]` is overwritten to `[-raised]`, and its
-    `[-upper]` is preserved.
-
-    Critically, the `[upper]` feature is *not* changed — this is what
-    makes the operation subtonal-level rather than full-tone replacement. -/
-theorem m_lowering_via_assimilation :
-    subtonalAssimilate Subtonal.raised TRN.L TRN.M = TRN.L := by decide
-
-/-- The same operation has no effect when the source itself is M:
-    assimilating `[+raised]` onto M leaves M unchanged. -/
-theorem m_lowering_vacuous_on_m :
-    subtonalAssimilate Subtonal.raised TRN.M TRN.M = TRN.M := by decide
-
-/-- **Floating `[-raised]` docking onto M produces L**
-    ([lionnet-2022] §5.3): the morphosyntactic suffix is a free
-    floating feature that overwrites the target's `[raised]` value. -/
-theorem floating_minus_raised_lowers_m :
-    dockFloating Subtonal.raised false TRN.M = TRN.L := by decide
-
-/-! ### Verification: Drubea/Numèè register-only realisation -/
-
-/-- Registerless sequences have uniform pitch. -/
-theorem registerless_uniform (n : Int) :
-    realizePitch n [TRN.empty, TRN.empty, TRN.empty] = [n, n, n] := rfl
-
-/-- A single downstep lowers pitch by one step. -/
-theorem downstep_lowers (n : Int) :
-    realizePitch n [TRN.empty, TRN.downstep] = [n, n - 1] := rfl
-
-/-- Multiple downsteps produce cumulative terracing. -/
-theorem terracing (n : Int) :
-    realizePitch n [TRN.downstep, TRN.downstep, TRN.downstep] =
-      [n - 1, n - 1 - 1, n - 1 - 1 - 1] := rfl
-
-/-- Deltas-only view of three downsteps: pitch falls by 1, 2, 3 register
-    steps from the start. No anchor required. -/
-theorem terracing_deltas :
-    pitchDeltas [TRN.downstep, TRN.downstep, TRN.downstep] = [-1, -2, -3] := by
-  decide
-
-/-- Concrete terracing from offset 4 (mid-high on the 1–5 scale). -/
-theorem terracing_from_4 :
-    realizePitch 4 [TRN.downstep, TRN.downstep, TRN.downstep] = [3, 2, 1] := by
-  decide
-
-/-- h-epenthesis raises the registerless TRN before a downstep. -/
-theorem h_epenthesis_before_downstep :
-    hEpenthesis [TRN.empty, TRN.downstep, TRN.empty] =
-      [TRN.upstep, TRN.downstep, TRN.empty] := rfl
-
-/-- h-epenthesis + realisation: the raised TRN is higher than baseline. -/
-theorem h_epenthesis_raises_pitch :
-    realizePitch 4 (hEpenthesis [TRN.empty, TRN.downstep, TRN.empty]) =
-      [5, 4, 4] := by decide
-
-/-- An underlying downstep blocks h-epenthesis on itself: the rule only
-    targets *registerless* TRNs immediately preceding a downstep. This
-    is what the underlying initial downstep (preserved by
-    `realizePitchUtterance`) buys us — the contrast `/X ⁺Y/` (raises X)
-    vs `/⁺X ⁺Y/` (no raising on ⁺X) survives even when the initial X
-    is utterance-initial and phonetically flat. -/
-theorem l_blocks_own_h_epenthesis :
-    hEpenthesis [TRN.downstep, TRN.downstep] =
-      [TRN.downstep, TRN.downstep] := rfl
-
-/-- Phonetic suppression of an utterance-initial downstep: the realized
-    pitch sequence starts flat, indistinguishable from a registerless
-    initial. -/
-theorem utt_initial_phonetic_suppression :
-    realizePitchUtterance 4 [TRN.downstep, TRN.empty, TRN.empty] =
-      [4, 4, 4] := by decide
-
-/-- The phonetic neutralisation is *only* utterance-initial: a
-    non-initial downstep still drops pitch, even after the suppression
-    rule fires. -/
-theorem utt_initial_only_first :
-    realizePitchUtterance 4 [TRN.downstep, TRN.downstep, TRN.empty] =
-      [4, 3, 3] := by decide
-
-/-- Underlying culminativity is preserved under utterance-initial
-    suppression: an initial downstep still counts toward the stem-level
-    `[-raised]` budget. The phonetic interface does not delete it. -/
-theorem utt_initial_l_underlyingly_present :
-    IsCulminative [TRN.downstep, TRN.empty] ∧
-      realizePitchUtterance 4 [TRN.downstep, TRN.empty] =
-        realizePitch 4 [TRN.empty, TRN.empty] := by
-  refine ⟨by decide, by decide⟩
-
-/-- Culminativity: a single `[-raised]` is culminative. -/
-theorem single_l_culminative :
-    IsCulminative [TRN.empty, TRN.downstep, TRN.empty] := by decide
-
-/-- Non-culminativity: two `[-raised]` TRNs violate culminativity. -/
-theorem double_l_not_culminative :
-    ¬ IsCulminative [TRN.downstep, TRN.downstep] := by decide
-
-/-! ### Monotonicity (catathesis-blocking) -/
-
-/-- TRN order by syntagmatic pitch effect: `t₁ ≤ t₂` iff `t₁` is at least
-    as lowering as `t₂`. Lifted from the `Int` order along `TRN.pitchEffect`
-    (`Preorder.lift`) — a `Preorder`, not a `PartialOrder`, since TRNs
-    sharing a `[raised]` value share a pitch effect. -/
-instance : Preorder TRN := Preorder.lift TRN.pitchEffect
-
-instance : DecidableRel ((· ≤ ·) : TRN → TRN → Prop) := fun _ _ => Int.decLe _ _
-
-/-- **Monotonicity of `realizePitch` in the baseline**: a higher starting
-    pitch produces pointwise higher output for any fixed TRN sequence.
-
-    Structural basis for catathesis blocking
-    ([beckman-pierrehumbert-1986]): when an ip boundary resets the
-    register, subsequent pitches are higher than if catathesis had
-    continued from a compressed baseline. -/
-theorem realizePitch_baseline_mono (ts : List TRN)
-    {n m : Int} (h : n ≤ m) :
-    List.Forall₂ (· ≤ ·) (realizePitch n ts) (realizePitch m ts) := by
-  induction ts generalizing n m with
-  | nil => exact .nil
-  | cons t rest ih =>
-    have hstep : n + t.pitchEffect ≤ m + t.pitchEffect := Int.add_le_add_right h _
-    simp only [realizePitch_cons]
-    exact .cons hstep (ih hstep)
-
-/-- **Full monotonicity of `realizePitch`**: pointwise lowering features
-    plus a lower baseline give pointwise lower output. Subsumes
-    `realizePitch_baseline_mono`. -/
-theorem realizePitch_mono
-    {ts₁ ts₂ : List TRN}
-    (hts : List.Forall₂ (· ≤ ·) ts₁ ts₂)
-    {n m : Int} (hnm : n ≤ m) :
-    List.Forall₂ (· ≤ ·) (realizePitch n ts₁) (realizePitch m ts₂) := by
-  induction hts generalizing n m with
-  | nil => exact .nil
-  | @cons t₁ t₂ rest1 rest2 hhead _ ih =>
-    have hstep : n + t₁.pitchEffect ≤ m + t₂.pitchEffect :=
-      Int.add_le_add hnm hhead
-    simp only [realizePitch_cons]
-    exact .cons hstep (ih hstep)
+instance (ts : List TRN) : Decidable (IsRegisterOnly ts) := List.decidableBAll _ _
 
 end Tone

--- a/Linglib/Phonology/Tone/Register.lean
+++ b/Linglib/Phonology/Tone/Register.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Forall2
+import Mathlib.Logic.Function.Defs
+import Linglib.Phonology.Tone.Basic
+
+/-!
+# Register: the terracing realization of `[raised]`
+
+The syntagmatic reading of `[raised]` ([snider-1999], [lionnet-2025]): each `[-raised]`
+node lowers the register for everything that follows and each `[+raised]` node raises it,
+so a node sequence is realized as the running sum of its shifts from a baseline —
+terracing, as in the register-only systems of Drubea and Numèè and in the catathesis of
+Japanese and English intonation ([beckman-pierrehumbert-1986]).
+
+## Main definitions
+
+* `TRN.pitchEffect` — the shift a node contributes.
+* `realizePitch` — the pitch levels of a sequence from a baseline, the running sums
+  (`List.scanl`); `pitchDeltas`, the same from `0`.
+
+## Main results
+
+* `realizePitch_eq_pitchDeltas_shift` — a baseline only shifts the deltas.
+* `realizePitch_mono` — realization is monotone in the baseline and, pointwise, in the
+  shifts: the basis of catathesis blocking.
+-/
+
+namespace Tone
+
+open Function
+
+/-- The register shift a node contributes: `[-raised]` lowers, `[+raised]` raises, an
+unspecified `[raised]` is inert. -/
+def TRN.pitchEffect (t : TRN) : Int :=
+  match t.raised with
+  | none => 0
+  | some false => -1
+  | some true => 1
+
+/-- **Terracing**: the pitch levels of a node sequence from a baseline, each shift
+cumulative — the running sums of the shifts. -/
+def realizePitch (level : Int) (ts : List TRN) : List Int :=
+  ((ts.map TRN.pitchEffect).scanl (· + ·) level).tail
+
+@[simp] theorem realizePitch_nil (level : Int) : realizePitch level [] = [] := rfl
+
+@[simp] theorem realizePitch_cons (level : Int) (t : TRN) (rest : List TRN) :
+    realizePitch level (t :: rest) =
+      (level + t.pitchEffect) :: realizePitch (level + t.pitchEffect) rest := by
+  cases rest <;> simp [realizePitch, List.scanl]
+
+@[simp] theorem length_realizePitch (level : Int) (ts : List TRN) :
+    (realizePitch level ts).length = ts.length := by
+  simp [realizePitch]
+
+/-- The register shifts from the start: no privileged pitch, only the differences. -/
+def pitchDeltas (ts : List TRN) : List Int := realizePitch 0 ts
+
+/-- A baseline only shifts the deltas. -/
+theorem realizePitch_eq_pitchDeltas_shift (level : Int) (ts : List TRN) :
+    realizePitch level ts = (pitchDeltas ts).map (· + level) := by
+  suffices h : ∀ n d : Int, realizePitch (n + d) ts = (realizePitch n ts).map (· + d) by
+    simpa [pitchDeltas] using h 0 level
+  intro n d
+  induction ts generalizing n with
+  | nil => rfl
+  | cons t rest ih =>
+    simp only [realizePitch_cons, List.map_cons]
+    rw [show n + d + t.pitchEffect = n + t.pitchEffect + d by omega, ih]
+
+/-- **Monotonicity**: pointwise lower shifts and a lower baseline give pointwise lower
+pitch. Structural basis of catathesis blocking ([beckman-pierrehumbert-1986]): a register
+reset at a phrase boundary leaves everything after it higher than continued compression
+would. -/
+theorem realizePitch_mono {ts₁ ts₂ : List TRN}
+    (hts : List.Forall₂ ((· ≤ ·) on TRN.pitchEffect) ts₁ ts₂) {n m : Int} (hnm : n ≤ m) :
+    List.Forall₂ (· ≤ ·) (realizePitch n ts₁) (realizePitch m ts₂) := by
+  induction hts generalizing n m with
+  | nil => exact .nil
+  | cons hhead _ ih =>
+    have hstep := Int.add_le_add hnm hhead
+    simp only [realizePitch_cons]
+    exact .cons hstep (ih hstep)
+
+/-- A higher baseline gives pointwise higher pitch for a fixed sequence. -/
+theorem realizePitch_baseline_mono (ts : List TRN) {n m : Int} (h : n ≤ m) :
+    List.Forall₂ (· ≤ ·) (realizePitch n ts) (realizePitch m ts) :=
+  realizePitch_mono (List.forall₂_same.mpr fun _ _ => le_rfl) h
+
+end Tone

--- a/Linglib/Studies/BeckmanPierrehumbert1986.lean
+++ b/Linglib/Studies/BeckmanPierrehumbert1986.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Prosody
-import Linglib.Phonology.Tone.Basic
+import Linglib.Phonology.Tone.Register
 import Linglib.Fragments.Japanese.Prosody
 import Linglib.Data.Examples.BeckmanPierrehumbert1986
 

--- a/Linglib/Studies/FaustLampitelli2026.lean
+++ b/Linglib/Studies/FaustLampitelli2026.lean
@@ -478,7 +478,7 @@ theorem identicalVowel_synersis_overshoots_walker_rose :
     adjacent |A| elements collapse to one.
 
     This makes structurally explicit that F&L's "fusion" mechanism
-    is the same operation as [lionnet-2022]'s `mergeTRN` for
+    is the same operation as [lionnet-2022]'s `TRN.merge` for
     Laal tones, just instantiated over a different value space
     (privative `Element` vs binary-feature `TRN`). -/
 theorem fusion_is_collapse_instance :

--- a/Linglib/Studies/Hyman2006.lean
+++ b/Linglib/Studies/Hyman2006.lean
@@ -1,521 +1,223 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Phonology.Tone.Basic
 
-
 /-!
-# Hyman 2006: Word-prosodic typology
-[hyman-2006]
+# Hyman (2006): word-prosodic typology
 
-Hyman, L. M. (2006). Word-prosodic typology. *Phonology* 23, 225--257.
-
-## Core claims formalized
-
-1. **Two prototypes, not three**: The highest-level typological cut distinguishes
-   two prototypical word-prosodic systems — **tone** (T) and **stress accent** (SA) —
-   not three. Pitch accent (PA) is not a coherent third type but a "pick and
-   choose" combination of properties from both prototypes.
-
-2. **Definition of tone** (def. 3): "A language with tone is one in which an
-   indication of pitch enters into the lexical realisation of at least some
-   morphemes." Tone is featural and paradigmatic.
-
-3. **Definition of stress accent** (def. 5): "A language with stress accent is one
-   in which there is an indication of word-level metrical structure" meeting two
-   criteria: (a) OBLIGATORINESS — every lexical word has at least one primary
-   stress; (b) CULMINATIVITY — every lexical word has at most one primary stress.
-   OBLHEAD is the more important criterion.
-
-4. **2×2 typology** (Table I): Since T and SA are independent properties, languages
-   may have both (+T+SA), either (+T−SA, −T+SA), or neither (−T−SA).
-
-5. **Non-definitional properties**: Additional properties cluster with but do not
-   define the SA prototype: privativity, subordination, demarcation, rhythmicity.
-
-6. **Table II**: Restricted H-tone systems independently attest all four
-   combinations of obligatoriness × culminativity, showing these are orthogonal.
-
-7. **OBLHEAD as the deepest cut**: The most significant typological cut is between
-   systems satisfying OBLHEAD and those that do not.
-
-## Connection to [lionnet-2025]
-
-Hyman's tone prototype encompasses all systems where pitch enters lexical
-realization. [lionnet-2025] shows this category splits further into
-**tone-based** (paradigmatic H/L: Yoruba, Mandarin) and **register-based**
-(syntagmatic downstep: Drubea, Numèè). This enrichment is orthogonal to
-Hyman's SA dimension.
+[hyman-2006] cuts word-prosodic systems along two independent properties rather than into
+three types: **tone** — pitch enters the lexical realization of some morphemes (definition
+(3)) — and **stress accent** — words carry an obligatory, culminative metrical head
+(definition (5)); "pitch accent" is no third prototype but a pick-and-choose of properties
+from the two, and its classic cases are reclassified as tonal. Since the two properties are
+independent, all four combinations occur (Table I); restricted-H systems attest all four
+combinations of obligatoriness and culminativity (Table II), and the deepest typological cut
+is OBLHEAD, obligatoriness of the metrical head (§7). The profile `Tone.WordProsody`
+records the two dimensions.
 -/
 
 namespace Hyman2006
 
-
 open Tone
 
--- ============================================================================
--- § 1: Two Prototypes
--- ============================================================================
-
-/-- Hyman's two independent binary word-prosodic properties.
-
-    A language's word-prosodic profile is characterized by two
-    independent Boolean dimensions, not a single categorical type.
-    This is the key insight: T and SA can freely co-occur (Table I). -/
-structure WordProsodicProfile where
-  hasTone         : Bool  -- (3): pitch enters lexical realization
-  hasStressAccent : Bool  -- (5): obligatory metrical head structure
-  deriving DecidableEq, Repr
+/-! ### The two prototypes -/
 
 /-- The four cells of Table I. -/
 inductive ProsodicQuadrant where
-  | toneAndStress    -- +T, +SA (e.g., Ma'ya, Serbo-Croatian, Swedish)
-  | toneOnly         -- +T, −SA (e.g., Yoruba, Igbo, Skou)
-  | stressOnly       -- −T, +SA (e.g., English, Russian, Turkish)
-  | neither          -- −T, −SA (e.g., Bella Coola, French)
+  | toneAndStress
+  | toneOnly
+  | stressOnly
+  | neither
   deriving DecidableEq, Repr
 
-def WordProsodicProfile.quadrant (p : WordProsodicProfile) : ProsodicQuadrant :=
-  match p.hasTone, p.hasStressAccent with
-  | true,  true  => .toneAndStress
-  | true,  false => .toneOnly
-  | false, true  => .stressOnly
+/-- The cell of Table I a profile falls in. -/
+def quadrant (p : WordProsody) : ProsodicQuadrant :=
+  match p.tone, p.stressAccent with
+  | true, true => .toneAndStress
+  | true, false => .toneOnly
+  | false, true => .stressOnly
   | false, false => .neither
 
--- ============================================================================
--- § 2: Definitional Properties of Stress Accent
--- ============================================================================
-
-/-- The two central definitional criteria for stress accent (def. 5).
-
-    OBLIGATORINESS is more important: it is "an absolute universal —
-    definitional — of a SA system" (p. 232). Culminativity may be
-    violated in some alleged PA systems. -/
+/-- The two definitional criteria of stress accent (definition (5)): obligatoriness — every
+lexical word has a primary stress — and culminativity — at most one. Obligatoriness is the
+definitional one (p. 232); culminativity fails in some alleged pitch-accent systems. -/
 structure StressAccentCriteria where
-  /-- (5a) Every lexical word has at least one syllable with primary stress. -/
-  obligatoriness  : Bool
-  /-- (5b) Every lexical word has at most one syllable with primary stress. -/
-  culminativity   : Bool
+  obligatoriness : Bool
+  culminativity : Bool
   deriving DecidableEq, Repr
 
-/-- A system satisfying both criteria is a prototypical SA system. -/
+/-- A prototypical stress-accent system meets both criteria. -/
 def StressAccentCriteria.isPrototypicalSA (c : StressAccentCriteria) : Bool :=
   c.obligatoriness && c.culminativity
 
-/-- OBLHEAD requires both obligatoriness and syllable-targeting. -/
-def StressAccentCriteria.satisfiesOblHead (c : StressAccentCriteria) : Bool :=
-  c.obligatoriness
-
--- ============================================================================
--- § 3: Non-Definitional Properties (Clustering)
--- ============================================================================
-
-/-- Additional properties that cluster with the SA and T prototypes
-    but are not definitional.
-
-    SA-clustering properties include privativity, subordination,
-    demarcation, and rhythmicity. T-clustering properties include
-    being paradigmatic and identifying TBU tones. -/
+/-- Properties that cluster with the stress-accent prototype without defining it (p. 234):
+privativity, subordination, demarcation, rhythmicity. -/
 structure ClusteringProperties where
-  /-- Privativity: stress is present vs. absent, not graded (p. 234). -/
-  privativity    : Bool
-  /-- Subordination: one stress may be subordinated to another (p. 234). -/
-  subordination  : Bool
-  /-- Demarcation: stress fixed on initial/final/etc. signals word boundary (p. 234). -/
-  demarcation    : Bool
-  /-- Rhythmicity: echo-stresses occur on every other syllable (p. 234). -/
-  rhythmicity    : Bool
+  privativity : Bool
+  subordination : Bool
+  demarcation : Bool
+  rhythmicity : Bool
   deriving DecidableEq, Repr
 
-/-- Prototypical SA systems exhibit all four clustering properties. -/
+/-- The prototype shows all four. -/
 def prototypicalSACluster : ClusteringProperties :=
-  { privativity := true, subordination := true
-  , demarcation := true, rhythmicity := true }
+  { privativity := true, subordination := true, demarcation := true, rhythmicity := true }
 
--- ============================================================================
--- § 4: Table I — Language Classification
--- ============================================================================
+/-! ### Table I -/
 
-/-- Language entry for the 2×2 typology (Table I, p. 237). -/
+/-- A language of Table I (p. 237) with its profile. -/
 structure TypologyEntry where
-  name    : String
-  profile : WordProsodicProfile
+  name : String
+  profile : WordProsody
   deriving Repr
 
-/-- Table I entries: representative languages for each quadrant. -/
+/-- Table I. -/
 def tableI : List TypologyEntry :=
-  -- +tone, +stress accent
-  [ ⟨"Ma'ya",            ⟨true,  true⟩⟩
-  , ⟨"Usarufa",          ⟨true,  true⟩⟩
-  , ⟨"Fasu",             ⟨true,  true⟩⟩
-  , ⟨"Serbo-Croatian",   ⟨true,  true⟩⟩
-  , ⟨"Swedish-Norwegian", ⟨true, true⟩⟩
-  , ⟨"Ayutla Mixtec",    ⟨true,  true⟩⟩
-  -- +tone, −stress accent
-  , ⟨"Yoruba",           ⟨true,  false⟩⟩
-  , ⟨"Igbo",             ⟨true,  false⟩⟩
-  , ⟨"Kuki-Thaadow",     ⟨true,  false⟩⟩
-  , ⟨"Skou",             ⟨true,  false⟩⟩
-  -- −tone, +stress accent
-  , ⟨"English",          ⟨false, true⟩⟩
-  , ⟨"Russian",          ⟨false, true⟩⟩
-  , ⟨"Turkish",          ⟨false, true⟩⟩
-  , ⟨"Finnish",          ⟨false, true⟩⟩
-  -- −tone, −stress accent
-  , ⟨"Bella Coola",      ⟨false, false⟩⟩
-  , ⟨"French",           ⟨false, false⟩⟩
-  , ⟨"Tamazight",        ⟨false, false⟩⟩
-  , ⟨"Bengali",          ⟨false, false⟩⟩
-  ]
+  [ ⟨"Ma'ya", ⟨true, true⟩⟩, ⟨"Usarufa", ⟨true, true⟩⟩, ⟨"Fasu", ⟨true, true⟩⟩,
+    ⟨"Serbo-Croatian", ⟨true, true⟩⟩, ⟨"Swedish-Norwegian", ⟨true, true⟩⟩,
+    ⟨"Ayutla Mixtec", ⟨true, true⟩⟩,
+    ⟨"Yoruba", ⟨true, false⟩⟩, ⟨"Igbo", ⟨true, false⟩⟩, ⟨"Kuki-Thaadow", ⟨true, false⟩⟩,
+    ⟨"Skou", ⟨true, false⟩⟩,
+    ⟨"English", ⟨false, true⟩⟩, ⟨"Russian", ⟨false, true⟩⟩, ⟨"Turkish", ⟨false, true⟩⟩,
+    ⟨"Finnish", ⟨false, true⟩⟩,
+    ⟨"Bella Coola", ⟨false, false⟩⟩, ⟨"French", ⟨false, false⟩⟩, ⟨"Tamazight", ⟨false, false⟩⟩,
+    ⟨"Bengali", ⟨false, false⟩⟩ ]
 
-/-- All four quadrants are attested in Table I. -/
+/-- All four cells are attested. -/
 theorem all_quadrants_attested :
-    tableI.any (fun e => e.profile.quadrant == .toneAndStress) = true ∧
-    tableI.any (fun e => e.profile.quadrant == .toneOnly) = true ∧
-    tableI.any (fun e => e.profile.quadrant == .stressOnly) = true ∧
-    tableI.any (fun e => e.profile.quadrant == .neither) = true := by
-  exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
+    ∀ q ∈ [ProsodicQuadrant.toneAndStress, .toneOnly, .stressOnly, .neither],
+      ∃ e ∈ tableI, quadrant e.profile = q := by
+  decide
 
--- ============================================================================
--- § 5: Table II — Obligatoriness × Culminativity
--- ============================================================================
+/-! ### Table II -/
 
-/-- Table II (p. 245): restricted H-tone systems attest all four
-    combinations of obligatoriness and culminativity. -/
+/-- A restricted-H system of Table II (p. 245) with its criteria. -/
 structure RestrictedHToneEntry where
-  name           : String
-  criteria       : StressAccentCriteria
+  name : String
+  criteria : StressAccentCriteria
   deriving Repr
 
-/-- Table II entries. -/
+/-- Table II. -/
 def tableII : List RestrictedHToneEntry :=
-  [ ⟨"Kinga",  ⟨true,  true⟩⟩   -- +obligatory, +culminative
-  , ⟨"Creek",  ⟨true,  false⟩⟩  -- +obligatory, −culminative
-  , ⟨"Somali", ⟨false, true⟩⟩   -- −obligatory, +culminative
-  , ⟨"Seneca", ⟨false, false⟩⟩  -- −obligatory, −culminative
-  ]
+  [ ⟨"Kinga", ⟨true, true⟩⟩, ⟨"Creek", ⟨true, false⟩⟩, ⟨"Somali", ⟨false, true⟩⟩,
+    ⟨"Seneca", ⟨false, false⟩⟩ ]
 
-/-- All four combinations of obligatoriness × culminativity are attested. -/
+/-- Obligatoriness and culminativity are independent: all four combinations occur. -/
 theorem all_oblig_culm_combos :
-    tableII.any (fun e => e.criteria.obligatoriness && e.criteria.culminativity) = true ∧
-    tableII.any (fun e => e.criteria.obligatoriness && !e.criteria.culminativity) = true ∧
-    tableII.any (fun e => !e.criteria.obligatoriness && e.criteria.culminativity) = true ∧
-    tableII.any (fun e => !e.criteria.obligatoriness && !e.criteria.culminativity) = true := by
-  exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
+    ∀ c ∈ [(⟨true, true⟩ : StressAccentCriteria), ⟨true, false⟩, ⟨false, true⟩, ⟨false, false⟩],
+      ∃ e ∈ tableII, e.criteria = c := by
+  decide
 
-/-- Only Kinga satisfies both definitional criteria for SA. -/
+/-- Only Kinga meets both criteria. -/
 theorem only_kinga_prototypical_sa :
-    (tableII.filter (fun e => e.criteria.isPrototypicalSA)).length = 1 := by
-  native_decide
+    ∀ e ∈ tableII, e.criteria.isPrototypicalSA = true ↔ e.name = "Kinga" := by
+  decide
 
--- ============================================================================
--- § 6: Pitch Accent as Non-Type
--- ============================================================================
+/-! ### Pitch accent is not a type -/
 
-/-- "PA-like" properties (13): three distinct things that have been
-    called pitch accent. These do not cohere into a single prototype. -/
+/-- The three properties that have been called pitch accent, (13): none defines a prototype
+parallel to (3) and (5). -/
 inductive PALikeProperty where
-  /-- (13a) Underlying prosody abstractly different from surface realisations. -/
+  /-- (13a) An underlying prosody abstractly different from its surface realizations. -/
   | abstractDifferent
-  /-- (13b) System combines tone and stress. -/
+  /-- (13b) A system combining tone and stress. -/
   | combinesToneAndStress
-  /-- (13c) Restricted, sparse, or privative tone (e.g., /H/ vs. ∅). -/
+  /-- (13c) Restricted, sparse or privative tone. -/
   | restrictedTone
   deriving DecidableEq, Repr
 
-/-- Hyman's key argument: languages called "PA" freely pick and choose
-    between these properties. No single definition of PA can be given
-    that parallels the definitions for T (3) and SA (5).
+/-- The classic pitch-accent languages, reclassified: pitch enters lexical realization, so
+they are tonal, and without stress accent. -/
+def tokyoJapanese : WordProsody := ⟨true, false⟩
+def somali : WordProsody := ⟨true, false⟩
+def westernBasque : WordProsody := ⟨true, false⟩
 
-    The claim is that PA reduces to T (since pitch enters lexical
-    realization), with additional SA-like properties possibly co-occurring.
-    Hyman reclassifies Tokyo Japanese, Somali, and Western Basque as
-    [+T, −SA] — i.e., tonal. -/
-def tokyoJapanese : WordProsodicProfile := ⟨true, false⟩
-def somali : WordProsodicProfile := ⟨true, false⟩
-def westernBasque : WordProsodicProfile := ⟨true, false⟩
-
-/-- All three classic "PA" languages are reclassified as +T, −SA. -/
 theorem pa_languages_are_tonal :
-    tokyoJapanese.quadrant = .toneOnly ∧
-    somali.quadrant = .toneOnly ∧
-    westernBasque.quadrant = .toneOnly := ⟨rfl, rfl, rfl⟩
+    quadrant tokyoJapanese = .toneOnly ∧ quadrant somali = .toneOnly ∧
+      quadrant westernBasque = .toneOnly := ⟨rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 7: Connection to WALS
--- ============================================================================
+/-! ### The two dimensions read off WALS
 
-/-- WALS Ch 13 tone system ([maddieson-2013]). **Theory-laden**: WALS defines
-    tone by level-inventory size, exactly the partition Hyman challenges with
-    his functional definition. Mapped to Hyman's binary +T/−T by
-    `wals13AToHasTone`; kept here with the critique that consumes it. -/
-inductive ToneSystem where
+WALS 13A ([maddieson-2013]) codes tone by the size of the level inventory — the partition
+Hyman's functional definition replaces — and WALS 14A ([goedemans-van-der-hulst-2013])
+codes fixed stress location, presupposing an obligatory head. Both map onto the two
+dimensions, with a known loss on the stress side. -/
+
+/-- WALS 13A. -/
+inductive WalsToneSystem where
   | none | simple | complex
   deriving DecidableEq, Repr
 
-/-- WALS Ch 14 fixed stress location ([goedemans-van-der-hulst-2013]).
-    StressTyp framework: presupposes obligatory metrical heads — the
-    commitment Hyman's −SA systems (Bella Coola, French) violate. -/
+/-- WALS 14A. -/
 inductive StressLocation where
   | noFixed | initial | second | third | antepenultimate | penultimate | ultimate
   deriving DecidableEq, Repr
 
-/-- WALS F13A maps onto Hyman's binary tone dimension:
-    `noTones` → −T; `simpleToneSystem`/`complexToneSystem` → +T. -/
-def wals13AToHasTone (t : ToneSystem) : Bool :=
-  match t with
-  | .none    => false
-  | .simple  => true
-  | .complex => true
+/-- The profile of a WALS coding: any tone system is tone; any 14A value — fixed or free
+stress — is stress accent, and absence from 14A is read as no stress accent. -/
+def ofWals (t : WalsToneSystem) (s : Option StressLocation) : WordProsody :=
+  ⟨t ≠ .none, s.isSome⟩
 
-/-- WALS F14A maps onto Hyman's binary stress dimension:
-    `noFixed` (free stress) → +SA; fixed locations → +SA;
-    absence from WALS survey → indeterminate.
+def english : WordProsody := ofWals .none (some .noFixed)
+def german : WordProsody := ofWals .none (some .noFixed)
+def finnish : WordProsody := ofWals .none (some .initial)
+def turkish : WordProsody := ofWals .none (some .ultimate)
+def russian : WordProsody := ofWals .none (some .noFixed)
+def french : WordProsody := ofWals .none (some .noFixed)
+def spanish : WordProsody := ofWals .none (some .penultimate)
+def japanese : WordProsody := ofWals .simple none
+def mandarin : WordProsody := ofWals .complex (some .noFixed)
+def hindi : WordProsody := ofWals .none (some .noFixed)
+def georgian : WordProsody := ofWals .none (some .initial)
+def hungarian : WordProsody := ofWals .none (some .initial)
+def swahili : WordProsody := ofWals .none (some .penultimate)
+def yoruba : WordProsody := ofWals .complex none
+def maori : WordProsody := ofWals .none (some .initial)
+def zulu : WordProsody := ofWals .simple (some .penultimate)
 
-    Note: WALS F14A only classifies *fixed* stress location.
-    Free stress languages (English, Russian) appear as `noFixed`,
-    which still indicates +SA. The −SA case (Bella Coola, French)
-    is not directly captured by WALS F14A. -/
-def wals14AToHasStress (_ : StressLocation) : Bool :=
-  true  -- All values in F14A indicate the language *has* stress
+theorem english_stress_only : quadrant english = .stressOnly := by decide
+theorem finnish_stress_only : quadrant finnish = .stressOnly := by decide
+theorem yoruba_tone_only : quadrant yoruba = .toneOnly := by decide
+theorem japanese_tone_only : quadrant japanese = .toneOnly := by decide
+theorem mandarin_tone_and_stress : quadrant mandarin = .toneAndStress := by decide
+theorem zulu_tone_and_stress : quadrant zulu = .toneAndStress := by decide
 
-/-- Construct a `WordProsodicProfile` directly from WALS F13A tone + optional
-    F14A stress coding. Replaces a former `PhonProfile → WordProsodicProfile`
-    indirection where `PhonProfile` carried 14 fields Hyman2006 never read.
-    The 16 language defs below construct their `WordProsodicProfile` values
-    via this helper, keeping the WALS-encoding visible at the call site. -/
-def wpProfile (t : ToneSystem) (s : Option StressLocation) : WordProsodicProfile :=
-  { hasTone := wals13AToHasTone t
-  , hasStressAccent := match s with
-      | some sloc => wals14AToHasStress sloc
-      | none      => false }
-
-/-! Per-language sample (16 languages from a former
-    `Phenomena/Phonology/Typology.lean` `PhonProfile` block). Each
-    `wpProfile` argument pair is the language's WALS F13A coding (Hyman's
-    +T/−T) and WALS F14A coding (Hyman's +SA/−SA). The `none` stress
-    cases correspond to "WALS F14A does not survey this language" —
-    NOT "language has no stress" — see `french_wals_mismatch` for an
-    example of why this distinction matters. -/
-
-def english   : WordProsodicProfile := wpProfile .none    (some .noFixed)
-def german    : WordProsodicProfile := wpProfile .none    (some .noFixed)
-def finnish   : WordProsodicProfile := wpProfile .none    (some .initial)
-def turkish   : WordProsodicProfile := wpProfile .none    (some .ultimate)
-def russian   : WordProsodicProfile := wpProfile .none    (some .noFixed)
-def french    : WordProsodicProfile := wpProfile .none    (some .noFixed)  -- WALS: fixed-stress; Hyman: −SA (Table I) — `french_wals_mismatch`
-def spanish   : WordProsodicProfile := wpProfile .none    (some .penultimate)
-def japanese  : WordProsodicProfile := wpProfile .simple  none
-def mandarin  : WordProsodicProfile := wpProfile .complex (some .noFixed)
-def hindi     : WordProsodicProfile := wpProfile .none    (some .noFixed)
-def georgian  : WordProsodicProfile := wpProfile .none    (some .initial)
-def hungarian : WordProsodicProfile := wpProfile .none    (some .initial)
-def swahili   : WordProsodicProfile := wpProfile .none    (some .penultimate)
-def yoruba    : WordProsodicProfile := wpProfile .complex none
-def maori     : WordProsodicProfile := wpProfile .none    (some .initial)
-def zulu      : WordProsodicProfile := wpProfile .simple  (some .penultimate)
-
-/-- English: −tone (WALS none), +stress (WALS noFixed = free stress). -/
-theorem english_stress_only :
-    (english).quadrant = .stressOnly := rfl
-
-/-- Finnish: −tone, +stress (WALS initial = fixed stress). -/
-theorem finnish_stress_only :
-    (finnish).quadrant = .stressOnly := rfl
-
-/-- Yoruba: +tone (WALS complex), −stress (absent from WALS F14A). -/
-theorem yoruba_tone_only :
-    (yoruba).quadrant = .toneOnly := rfl
-
-/-- Japanese: +tone (WALS simple), −stress (absent from WALS F14A). -/
-theorem japanese_tone_only :
-    (japanese).quadrant = .toneOnly := rfl
-
-/-- Mandarin: +tone (WALS complex), +stress (WALS noFixed). -/
-theorem mandarin_tone_and_stress :
-    (mandarin).quadrant = .toneAndStress := rfl
-
-/-- Zulu: +tone (WALS simple), +stress (WALS penultimate). -/
-theorem zulu_tone_and_stress :
-    (zulu).quadrant = .toneAndStress := rfl
-
-/-- Three of the four quadrants are attested among the 16 PhonProfile
-    languages. The −T−SA quadrant is NOT attested because WALS F14A
-    encodes stress *location* but not stress *absence*: languages
-    like French appear as `noFixed` (= free stress = +SA), even though
-    Hyman classifies French as −SA.
-
-    This demonstrates the inherent limitation of deriving Hyman's
-    framework from WALS data alone. -/
+/-- WALS reaches three cells: 14A codes stress location, not its absence, so the −T−SA
+cell never appears from WALS alone. -/
 theorem wals_covers_three_quadrants :
-    let profiles := [english, german, finnish, turkish, russian, french,
-                     spanish, japanese, mandarin, hindi, georgian,
-                     hungarian, swahili, yoruba, maori, zulu]
-    profiles.any (fun p => (p).quadrant == .toneAndStress) = true ∧
-    profiles.any (fun p => (p).quadrant == .toneOnly) = true ∧
-    profiles.any (fun p => (p).quadrant == .stressOnly) = true := by
-  exact ⟨by native_decide, by native_decide, by native_decide⟩
-
-/-- French is classified as −T−SA in Hyman's Table I, but WALS F14A
-    records it with `noFixed` stress (= free stress), which our
-    `profileFromWPSample` maps to +SA. This mismatch arises because
-    WALS F14A does not distinguish "free word stress" (English) from
-    "no word stress" (French — stress is phrase-final, not word-level).
-
-    This is not a bug in the formalization but a documented limitation
-    of the WALS→Hyman bridge. The −SA classification requires
-    language-specific analysis beyond WALS data. -/
-theorem french_wals_mismatch :
-    (french).quadrant = .stressOnly ∧
-    (tableI.filter (fun e => e.name == "French")).all
-      (fun e => e.profile.quadrant == .neither) = true := by
-  exact ⟨rfl, by native_decide⟩
-
--- ============================================================================
--- § 8: Connection to Lionnet 2025 (Register Enrichment)
--- ============================================================================
-
-/-- Whether a `WordProsodicType` counts as tonal under Hyman's
-    definition (3): "an indication of pitch enters into the lexical
-    realisation of at least some morphemes."
-
-    [lionnet-2025] enriches Hyman's tone prototype by splitting it
-    into tone-based (paradigmatic H/L) and register-based (syntagmatic
-    h/l). Both sub-types satisfy definition (3). -/
-def isTonalUnderHyman (wpt : WordProsodicType) : Bool :=
-  match wpt with
-  | .toneBased     => true   -- paradigmatic: H/L (Yoruba, Mandarin)
-  | .registerBased => true   -- syntagmatic: h/l (Drubea, Numèè)
-  | .mixed         => true   -- both register and tone (Paicî)
-  | .stressAccent  => false  -- no pitch in lexical realization
-
-/-- Both tone-based and register-based systems count as +tone
-    under Hyman's definition (3). -/
-theorem register_based_is_tonal :
-    isTonalUnderHyman .registerBased = true := rfl
-
-/-- Stress accent systems are −tone under Hyman's definition. -/
-theorem stress_accent_is_not_tonal :
-    isTonalUnderHyman .stressAccent = false := rfl
-
-/-- All four `WordProsodicType` values from [lionnet-2025] map
-    consistently to Hyman's binary +/−tone. -/
-theorem all_wpt_classified (wpt : WordProsodicType) :
-    isTonalUnderHyman wpt = true ∨ isTonalUnderHyman wpt = false := by
-  cases wpt <;> simp [isTonalUnderHyman]
-
-/-- The WALS 3-way tone classification (F13A) does not capture the
-    tone-based vs. register-based distinction. Both Yoruba (tone-based)
-    and Drubea (register-based) would be classified as "simple" or
-    "complex" in WALS, losing the syntagmatic vs. paradigmatic
-    distinction that [lionnet-2025] identifies. -/
-theorem wals_coarser_than_lionnet :
-    wals13AToHasTone .simple = true ∧
-    wals13AToHasTone .complex = true ∧
-    wals13AToHasTone .none = false := ⟨rfl, rfl, rfl⟩
-
--- ============================================================================
--- § 9: Drubea in the 2×2 Typology
--- ============================================================================
-
-/-- Drubea's word-prosodic profile under Hyman's framework: +T, −SA.
-
-    +T: register features (downstep) enter lexical realization — the
-    minimal pairs in [lionnet-2025] ex. 4 demonstrate this directly.
-    −SA: no obligatory metrical head; the prosodic system is purely
-    register-based with no stress accent.
-
-    This places Drubea in the same quadrant as Yoruba, Igbo, and the
-    reclassified "PA" languages (Tokyo Japanese, Somali). -/
-def drubea : WordProsodicProfile := ⟨true, false⟩
-
-/-- Drubea is in the +T−SA quadrant (tone only). -/
-theorem drubea_tone_only :
-    drubea.quadrant = .toneOnly := rfl
-
-/-- Drubea's profile is consistent with Yoruba's
-    (both +T, −SA from different sub-types of tone). -/
-theorem drubea_same_quadrant_as_yoruba :
-    drubea.quadrant = (yoruba).quadrant := rfl
-
-/-- Drubea lacks stress accent — it is not an OBLHEAD system. -/
-theorem drubea_no_stress :
-    drubea.hasStressAccent = false := rfl
-
--- ============================================================================
--- § 10: Culminativity — Two Distinct Uses
--- ============================================================================
-
-/-- Hyman's stress culminativity (5b) and Drubea's register culminativity
-    ([lionnet-2025]) share the name but apply to different domains:
-
-    - **Stress culminativity** (Hyman): at most one primary stress per word.
-      Definitional for SA systems. Violated in some alleged PA systems
-      (Creek, Seneca — Table II).
-    - **Register culminativity** (Lionnet): at most one `l` feature per
-      native stem. A distributional constraint on register features,
-      not a metrical property.
-
-    Both are "at most one X per domain" constraints, but the X differs
-    (metrical prominence vs. register feature) and the domain differs
-    (word vs. stem). -/
-inductive CulminativityDomain where
-  | stressPerWord      -- Hyman (5b): at most one primary stress per word
-  | registerPerStem    -- Lionnet: at most one `l` feature per native stem
-  deriving DecidableEq, Repr
-
-/-- The two culminativity constraints are formally parallel but
-    apply to different phonological objects. -/
-theorem culminativity_parallel_but_distinct :
-    CulminativityDomain.stressPerWord ≠ CulminativityDomain.registerPerStem := by
+    ∀ q ∈ [ProsodicQuadrant.toneAndStress, .toneOnly, .stressOnly],
+      ∃ p ∈ [english, german, finnish, turkish, russian, french, spanish, japanese, mandarin,
+        hindi, georgian, hungarian, swahili, yoruba, maori, zulu], quadrant p = q := by
   decide
 
-/-- Culminativity (distributional: at most one X per domain) is orthogonal
-    to prosodic dominance (`Features.Prosody.ProsodicDominance`, interactional:
-    does a morpheme override the prosodic specification of its base?).
+/-- French is −T−SA in Table I but has free stress in WALS 14A, which reads as +SA: 14A
+does not distinguish free word stress from no word stress (French's is phrase-final). The
+−SA classification needs language-specific analysis beyond WALS. -/
+theorem french_wals_mismatch :
+    quadrant french = .stressOnly ∧
+      ∀ e ∈ tableI, e.name = "French" → quadrant e.profile = .neither := by
+  decide
 
-    A system can be culminative — at most one accent per prosodic word —
-    while having both dominant and recessive morphemes. Japanese exemplifies
-    this: pitch accent is culminative (one accent per AP), yet deaccenting
-    suffixes like *-teki* are dominant while *-si* 'Mr.' is recessive
-    ([kawahara-2015]). -/
-theorem culminativity_orthogonal_to_dominance :
-    CulminativityDomain.stressPerWord ≠ CulminativityDomain.registerPerStem →
-    True := λ _ => trivial
+/-! ### OBLHEAD as the deepest cut -/
 
--- ============================================================================
--- § 11: OBLHEAD as the Deepest Cut
--- ============================================================================
+/-- The most significant cut (§7): whether every word obligatorily carries a metrical head.
+Stress-accent systems, with or without tone, are OBLHEAD systems; tone-only and −T−SA
+systems (Bella Coola, which lacks syllables) are not. -/
+def IsOblHeadSystem (p : WordProsody) : Prop := p.stressAccent = true
 
-/-- Hyman's final proposal (§7): the most significant typological cut
-    is OBLHEAD — whether every word obligatorily has a metrical head.
+instance (p : WordProsody) : Decidable (IsOblHeadSystem p) := inferInstanceAs (Decidable (_ = _))
 
-    OBLHEAD = OBLIGATORINESS: every lexical word has at least one
-    syllable marked for the highest degree of metrical prominence.
-    This is the unique defining property of SA systems.
+/-- OBLHEAD separates stress accent, with or without tone, from its absence. -/
+theorem isOblHeadSystem_iff (p : WordProsody) : IsOblHeadSystem p ↔ p.stressAccent = true :=
+  Iff.rfl
 
-    Systems satisfying OBLHEAD are SA (possibly with co-occurring T).
-    Systems not satisfying OBLHEAD include tone-only systems and
-    −T−SA systems (e.g., Bella Coola, which lacks syllables and
-    therefore cannot have OBLHEAD). -/
-def isOblHeadSystem (p : WordProsodicProfile) : Bool :=
-  p.hasStressAccent
-
-/-- OBLHEAD separates SA (±T) from non-SA systems. -/
-theorem oblhead_separates :
-    isOblHeadSystem ⟨true, true⟩ = true ∧
-    isOblHeadSystem ⟨false, true⟩ = true ∧
-    isOblHeadSystem ⟨true, false⟩ = false ∧
-    isOblHeadSystem ⟨false, false⟩ = false := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- OBLHEAD partitions Table I: languages with +SA are OBLHEAD systems,
-    regardless of whether they also have tone. -/
+/-- OBLHEAD partitions Table I along the stress-accent dimension alone. -/
 theorem oblhead_partitions_tableI :
-    (tableI.filter (fun e => isOblHeadSystem e.profile)).length = 10 ∧
-    (tableI.filter (fun e => !isOblHeadSystem e.profile)).length = 8 := by
-  native_decide
-
-/-- Every Table I language with −SA also has −OBLHEAD. -/
-theorem no_stress_implies_no_oblhead :
-    tableI.all (fun e =>
-      e.profile.hasStressAccent || !isOblHeadSystem e.profile) = true := by
-  native_decide
+    ∀ e ∈ tableI, IsOblHeadSystem e.profile ↔
+      quadrant e.profile = .toneAndStress ∨ quadrant e.profile = .stressOnly := by
+  decide
 
 end Hyman2006

--- a/Linglib/Studies/Lionnet2022Laal.lean
+++ b/Linglib/Studies/Lionnet2022Laal.lean
@@ -11,9 +11,7 @@ import Linglib.Fragments.Laal.Prosody
 /-!
 # Lionnet (2022): The features and geometry of tone in Laal
 
-[lionnet-2022]
-
-Laal (isolate, southern Chad) has three contrastive tone heights H/M/L. Lionnet
+Laal (isolate, southern Chad) has three contrastive tone heights H/M/L. [lionnet-2022]
 argues for a subtonal analysis à la [yip-1980]/[pulleyblank-1986] (two register
 features `[±upper]`, `[±raised]`) linked to a Tonal Root Node ([snider-2020]):
 H = `[+upper, −raised]`, M = `[−upper, +raised]`, L = `[−upper, −raised]`, with
@@ -25,10 +23,10 @@ exclusivity (`*MX/XM`) and its instability (M-lowering).
 
 * §5.1 the featural analysis — the substrate `TRN.H/M/L` encode Lionnet's (51).
 * §3 M-exclusivity (`*MX/XM`) over the attested stem melodies.
-* §5.2 M-lowering as `[−raised]` assimilation (`subtonalAssimilate`): a `[−raised]`
+* §5.2 M-lowering as `[−raised]` assimilation (`TRN.assimilate`): a `[−raised]`
   trigger (H or L) turns the only `[+raised]` tone, M, into L.
 * §5.5 the ventive suffix as a floating `[−raised]` with `[upper]` from the root
-  (`dockFloating`).
+  (`TRN.dock`).
 * §5.6 the `[+upper, +raised]` gap (Table-4 type-A system).
 * §5.2 (ex. 53–55, 58) the **optional** OCP-`[raised]` merger — consuming the
   `OCP` fusion repair.
@@ -74,6 +72,17 @@ theorem featural_analysis :
 theorem tones_distinct_as_TRN :
     (([Tone.H, Tone.M, Tone.L]).map toneToTRN).Nodup := by decide
 
+/-- Paradigmatic pitch (§4): `[upper]` counts two and `[raised]` one, independently per
+node — no register state. -/
+def absolutePitch (t : TRN) : Int :=
+  (if t.upper = some true then 2 else 0) + if t.raised = some true then 1 else 0
+
+/-- `L < M < H`, with the gap above `H`. -/
+theorem absolutePitch_ordered :
+    absolutePitch TRN.L = 0 ∧ absolutePitch TRN.M = 1 ∧ absolutePitch TRN.H = 2 ∧
+      absolutePitch TRN.superHigh = 3 := by
+  decide
+
 /-- The minimal triplet (ex. 8) contrasts in tone alone: pairwise-distinct
 melodies on one segmental frame. -/
 theorem minimalTriplet_distinct_tones :
@@ -90,27 +99,27 @@ theorem M_exclusive :
 
 /-- M-lowering is `[−raised]` assimilation: an L trigger (`[−raised]`) spreads its
 `[raised]` value onto M (the only `[+raised]` tone), turning it into L. -/
-theorem mLowering_from_L : subtonalAssimilate .raised TRN.L TRN.M = TRN.L := by decide
+theorem mLowering_from_L : TRN.assimilate .raised TRN.L TRN.M = TRN.L := by decide
 
 /-- M-lowering from a `[−raised]` H trigger likewise turns M into L. -/
-theorem mLowering_from_H : subtonalAssimilate .raised TRN.H TRN.M = TRN.L := by decide
+theorem mLowering_from_H : TRN.assimilate .raised TRN.H TRN.M = TRN.L := by decide
 
 /-- Only M is targeted: H is inert under `[−raised]` assimilation (already
 `[−raised]`), explaining why H- and L-toned roots never lower. -/
-theorem H_stable : subtonalAssimilate .raised TRN.L TRN.H = TRN.H := by decide
+theorem H_stable : TRN.assimilate .raised TRN.L TRN.H = TRN.H := by decide
 
 /-- L is likewise inert under `[−raised]` assimilation. -/
-theorem L_stable : subtonalAssimilate .raised TRN.H TRN.L = TRN.L := by decide
+theorem L_stable : TRN.assimilate .raised TRN.H TRN.L = TRN.L := by decide
 
 /-! ### The ventive suffix (§5.5) -/
 
 /-- The ventive suffix (ex. 60) is a floating `[−raised]` feature with `[upper]`
-inherited from the root: `dockFloating .raised false`. It surfaces as H after a
+inherited from the root: `TRN.dock .raised false`. It surfaces as H after a
 `[+upper]` (H) root and as L after `[−upper]` (M or L) roots — the M-lowering
 realisation `kárá`/`dàgà`/`jàrà`. -/
-theorem ventive_after_H : dockFloating .raised false TRN.H = TRN.H := by decide
-theorem ventive_after_M : dockFloating .raised false TRN.M = TRN.L := by decide
-theorem ventive_after_L : dockFloating .raised false TRN.L = TRN.L := by decide
+theorem ventive_after_H : TRN.dock .raised false TRN.H = TRN.H := by decide
+theorem ventive_after_M : TRN.dock .raised false TRN.M = TRN.L := by decide
+theorem ventive_after_L : TRN.dock .raised false TRN.L = TRN.L := by decide
 
 /-! ### The `[+upper, +raised]` gap (§5.6) -/
 

--- a/Linglib/Studies/Lionnet2025.lean
+++ b/Linglib/Studies/Lionnet2025.lean
@@ -1,75 +1,94 @@
-import Linglib.Phonology.Tone.Basic
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Phonology.Tone.Register
 import Linglib.Fragments.Drubea.Prosody
 import Linglib.Fragments.Numee.Prosody
 import Linglib.Studies.Hyman2006
 
-
 /-!
-# Lionnet (2025): Tonal Languages Without Tone
-[lionnet-2025]
+# Lionnet (2025): tonal languages without tone
 
-Tonal languages without tone: downstep in Drubea and Numèè
-(Oceanic, New Caledonia). *Phonology* 42, e23, 1–43.
+[lionnet-2025] analyses the word prosody of Drubea and Numèè (Oceanic, New Caledonia) as
+consisting entirely of register features — an underlying downstep `l` and a postlexical
+upstep `h` — with no tone features: the register-bearing unit is the mora, as the CV⁺V
+three-way contrast shows; each native stem carries at most one downstep (culminativity);
+the downstep meets [leben-2018]'s definitional properties; and the analysis is more
+parsimonious than a tonal one (§5). Tone systems thereby split into tone-based and
+register-based, enriching [hyman-2006]'s word-prosodic typology.
 
-## Key claims formalized
-
-1. The word-prosodic system of Drubea and Numèè consists entirely of
-   register features — underlying downstep (`l`) and postlexical
-   upstep (`h`) — with **no tone features**.
-
-2. The register-bearing unit (RBU) is the **mora**, not the syllable,
-   evidenced by the CV⁺V three-way contrast.
-
-3. **Culminativity**: each native stem contains at most one downstep.
-
-4. Drubea/Numèè downstep satisfies the core definitional properties
-   of downstep cross-linguistically ([leben-2018]).
-
-5. Tonal systems split into **tone-based** (paradigmatic) and
-   **register-based** (syntagmatic), enriching [hyman-2006]'s
-   word-prosodic typology.
-
-6. The register analysis is more parsimonious than the tonal
-   alternative: 1 underlying primitive + 1 postlexical process
-   vs. 3 + 2 ([lionnet-2025] §5).
+The register-only apparatus — culminativity, pre-downstep h-epenthesis in its abrupt and
+spreading variants, and utterance-initial neutralisation — is the paper's; the terracing
+realization it rides on is `Tone.Register`.
 -/
 
 namespace Lionnet2025
 
-open Tone
-open Drubea.Prosody
+open Tone Drubea.Prosody
 
--- ============================================================================
--- § 1: Segmental Identity of Minimal Pairs
--- ============================================================================
+/-! ### The register-only apparatus -/
 
-/-- Every monosyllabic minimal pair shares the same segmental form.
-    The contrast is **purely prosodic** — the register feature `l` is
-    the only difference between the two members of each pair
-    ([lionnet-2025]). -/
+/-- **Register culminativity** (§3.10): at most one `[-raised]` node per stem. -/
+abbrev IsCulminative (ts : List TRN) : Prop :=
+  ts.countP (fun t => t.raised == some false) ≤ 1
+
+/-- **Pre-downstep h-epenthesis** (§3.2, §4.4): an upstep replaces the registerless node
+immediately before a downstep. An underlying downstep blocks the rule on itself — the
+diagnostic that survives utterance-initial neutralisation. -/
+def hEpenthesis : List TRN → List TRN
+  | [] => []
+  | [t] => [t]
+  | TRN.empty :: TRN.downstep :: rest => TRN.upstep :: TRN.downstep :: hEpenthesis rest
+  | t :: rest => t :: hEpenthesis rest
+
+/-- **Spreading h-epenthesis** (§3.2): every registerless node before a downstep is
+raised. -/
+def hEpenthesisSpread : List TRN → List TRN
+  | [] => []
+  | TRN.downstep :: rest => TRN.downstep :: hEpenthesisSpread rest
+  | TRN.upstep :: rest => TRN.upstep :: hEpenthesisSpread rest
+  | TRN.empty :: rest =>
+      let rest' := hEpenthesisSpread rest
+      match rest' with
+      | TRN.downstep :: _ | TRN.upstep :: _ => TRN.upstep :: rest'
+      | _ => TRN.empty :: rest'
+  | t :: rest => t :: hEpenthesisSpread rest
+
+/-- **Utterance-initial neutralisation** (§3.5, §4.5): an initial `[-raised]` node is
+realized at the baseline, there being no preceding register to contrast with. The feature
+stays in the underlying form, blocking h-epenthesis on itself. -/
+def realizePitchUtterance (level : Int) : List TRN → List Int
+  | [] => []
+  | t :: rest =>
+      if t.raised = some false ∧ t.upper = none then level :: realizePitch level rest
+      else realizePitch level (t :: rest)
+
+/-! ### Segmental identity of minimal pairs -/
+
+/-- Every monosyllabic minimal pair shares its segmental form: the contrast is the register
+feature `l` alone. -/
 theorem minimal_pairs_same_segments :
     monoMinimalPairs.all (fun (a, b) => a.form == b.form) = true := by
   decide
 
-/-- The contrast in each minimal pair IS the register specification:
-    one member is registerless, the other is σ1-downstepped. -/
+/-- The contrast in each minimal pair is the register specification: one member is
+registerless, the other σ1-downstepped. -/
 theorem minimal_pairs_register_contrast :
     monoMinimalPairs.all (fun (a, b) =>
       a.pattern == .registerless && b.pattern == .σ1_downstepped) = true := by
   decide
 
--- ============================================================================
--- § 2: Culminativity
--- ============================================================================
+/-! ### Culminativity -/
 
-/-- Every stem in the Drubea fragment satisfies culminativity:
-    at most one `l` feature per stem ([lionnet-2025] §3.10). -/
+/-- Every stem in the Drubea fragment is culminative: at most one `l` per stem (§3.10). -/
 theorem all_stems_culminative :
     ∀ e ∈ allStems, IsCulminative e.specs := by
   decide
 
-/-- Culminativity holds structurally for all three patterns at any
-    mora count: each pattern places at most one `l`. -/
+/-- Culminativity holds structurally for all three patterns at any mora count: each
+pattern places at most one `l`. -/
 theorem pattern_culminative_0 (p : StemPattern) :
     IsCulminative (p.toSpecs 0) := by cases p <;> decide
 theorem pattern_culminative_1 (p : StemPattern) :
@@ -81,172 +100,148 @@ theorem pattern_culminative_3 (p : StemPattern) :
 theorem pattern_culminative_4 (p : StemPattern) :
     IsCulminative (p.toSpecs 4) := by cases p <;> decide
 
--- ============================================================================
--- § 3: CV⁺V Three-Way Contrast (mora as RBU)
--- ============================================================================
+/-! ### The CV⁺V three-way contrast: the mora as register-bearing unit -/
 
-/-- The three register patterns produce distinct mora-level specifications
-    on bimoraic stems, confirming the mora as the RBU
-    ([lionnet-2025] §3.7, §4.2). -/
+/-- The three register patterns give distinct mora-level specifications on bimoraic stems
+(§3.7, §4.2). -/
 theorem cvPlusV_three_way_distinct :
     StemPattern.registerless.toSpecs 2 ≠ StemPattern.σ1_downstepped.toSpecs 2 ∧
     StemPattern.registerless.toSpecs 2 ≠ StemPattern.σ2_downstepped.toSpecs 2 ∧
     StemPattern.σ1_downstepped.toSpecs 2 ≠ StemPattern.σ2_downstepped.toSpecs 2 := by
   refine ⟨by decide, by decide, by decide⟩
 
-/-- CVV registerless: both morae unspecified [∅, ∅]. -/
+/-- CVV registerless: both morae unspecified. -/
 theorem cvv_registerless :
     StemPattern.registerless.toSpecs 2 = [TRN.empty, TRN.empty] := by rfl
 
-/-- ⁺CVV: downstep on first mora [l, ∅]. -/
+/-- ⁺CVV: downstep on the first mora. -/
 theorem cvv_σ1_downstepped :
     StemPattern.σ1_downstepped.toSpecs 2 = [TRN.downstep, TRN.empty] := by rfl
 
-/-- CV⁺V: downstep on second mora [∅, l]. -/
+/-- CV⁺V: downstep on the second mora. -/
 theorem cvPlusV_σ2_downstepped :
     StemPattern.σ2_downstepped.toSpecs 2 = [TRN.empty, TRN.downstep] := by rfl
 
-/-- With only 1 mora (monomoraic CV), only two patterns are distinct:
-    registerless and σ1-downstepped. The σ2 pattern collapses to
-    registerless (no second mora to host the `l`). -/
+/-- On a monomoraic stem only two patterns are distinct: the σ2 pattern collapses to
+registerless, there being no second mora to host the `l`. -/
 theorem monomoraic_two_way :
     StemPattern.σ2_downstepped.toSpecs 1 = StemPattern.registerless.toSpecs 1 := by rfl
 
--- ============================================================================
--- § 4: Terracing (Register Realization)
--- ============================================================================
+/-! ### Terracing -/
 
-/-- Four consecutive downstepped monosyllables produce terracing:
-    each is realized one step lower than the preceding
-    (cf. ex. 11: /⁺ɲi ⁺mwa ⁺ŋii ⁺me/ 'They said that…';
-    ex. 12: /⁺mwa ⁺ŋii ⁺yoo ⁺ne/ in Figure 7).
-
-    The theory-primary content is the delta sequence `[-1, -2, -3, -4]`:
-    each downstep adds another step of cumulative descent. The offset-4
-    realization below is just an arbitrary anchoring of those deltas. -/
+/-- Four consecutive downstepped monosyllables terrace, each one step lower than the last
+(ex. 11, ex. 12): the deltas `[-1, -2, -3, -4]`; a baseline only anchors them. -/
 theorem four_downsteps_deltas :
     pitchDeltas [TRN.downstep, TRN.downstep, TRN.downstep, TRN.downstep] = [-1, -2, -3, -4] := by
   decide
 
 theorem four_downsteps_terrace :
-    realizePitch 4
-      [TRN.downstep, TRN.downstep, TRN.downstep, TRN.downstep] = [3, 2, 1, 0] := by
+    realizePitch 4 [TRN.downstep, TRN.downstep, TRN.downstep, TRN.downstep] = [3, 2, 1, 0] := by
   decide
 
-/-- Registerless syllables following a downstep maintain the lowered
-    register — they are realized at the same pitch as the downstepped
-    syllable. -/
+/-- Registerless syllables after a downstep keep the lowered register. -/
 theorem registerless_maintains_lowered :
-    realizePitch 4
-      [TRN.downstep, TRN.empty, TRN.empty] = [3, 3, 3] := by
+    realizePitch 4 [TRN.downstep, TRN.empty, TRN.empty] = [3, 3, 3] := by
   decide
 
-/-- A mixed sequence of downstepped and registerless syllables:
-    each downstep creates a new lower plateau, registerless RBUs
-    inherit the current register. -/
+/-- Each downstep opens a new lower plateau; registerless morae inherit the current one. -/
 theorem mixed_terracing :
     realizePitch 4
       [TRN.downstep, TRN.downstep, TRN.empty, TRN.downstep, TRN.empty, TRN.empty, TRN.downstep] =
       [3, 2, 2, 1, 1, 1, 0] := by
   decide
 
--- ============================================================================
--- § 5: Pre-Downstep Raising (h-Epenthesis)
--- ============================================================================
+/-! ### Pre-downstep raising -/
 
-/-- Abrupt h-epenthesis: insert `h` on the registerless RBU immediately
-    preceding a downstep (cf. ex. 13b; [lionnet-2025] §3.2, §4.4). -/
+/-- Abrupt h-epenthesis: `h` on the registerless mora immediately before a downstep
+(ex. 13b). -/
 theorem h_epenthesis_abrupt :
     hEpenthesis [TRN.empty, TRN.downstep, TRN.empty] =
       [TRN.upstep, TRN.downstep, TRN.empty] := by rfl
 
-/-- Spreading h-epenthesis: raising extends over the entire sequence
-    of registerless syllables before a downstep
-    ([lionnet-2025] §3.2). -/
+/-- The raised mora is realized above the baseline. -/
+theorem h_epenthesis_raises_pitch :
+    realizePitch 4 (hEpenthesis [TRN.empty, TRN.downstep, TRN.empty]) = [5, 4, 4] := by
+  decide
+
+/-- Spreading h-epenthesis: raising extends over the whole registerless stretch before a
+downstep (§3.2). -/
 theorem h_epenthesis_spreads :
     hEpenthesisSpread [TRN.empty, TRN.empty, TRN.empty, TRN.downstep, TRN.empty] =
       [TRN.upstep, TRN.upstep, TRN.upstep, TRN.downstep, TRN.empty] := by rfl
 
--- ============================================================================
--- § 6: Utterance-Initial Neutralization
--- ============================================================================
+/-! ### Utterance-initial neutralisation -/
 
-/-- Utterance-initial downstep is not phonetically realized: there is
-    no preceding register to contrast with ([lionnet-2025] §3.5,
-    §4.5). The realized pitch sequence is indistinguishable from a
-    registerless initial. -/
+/-- An utterance-initial downstep is not realized: the pitch sequence is that of a
+registerless initial (§3.5, §4.5). -/
 theorem utt_initial_no_contrast :
     realizePitchUtterance 4 [TRN.downstep, TRN.empty] =
     realizePitch 4 [TRN.empty, TRN.empty] := by
   decide
 
-/-- The contrast between registerless and downstepped IS maintained
-    when a downstepped syllable follows: the initial registerless
-    syllable undergoes pre-downstep raising, the initial downstepped
-    one does not ([lionnet-2025] §3.5, §4.5). The minimal pair
-    `/goo ⁺mie/` 'wet Hibbertia' (registerless initial → h-epenthesis)
-    vs `/⁺goo ⁺mie/` 'wet tree' (downstepped initial → no h-epenthesis)
-    is the diagnostic. -/
+/-- Only the first node is neutralised: a later downstep still drops the pitch. -/
+theorem utt_initial_only_first :
+    realizePitchUtterance 4 [TRN.downstep, TRN.downstep, TRN.empty] = [4, 3, 3] := by
+  decide
+
+/-- The contrast survives when a downstep follows: a registerless initial undergoes
+pre-downstep raising, a downstepped one does not — `/goo ⁺mie/` 'wet Hibbertia' vs
+`/⁺goo ⁺mie/` 'wet tree' (§3.5, §4.5). -/
 theorem utt_initial_contrast_with_following_downstep :
     hEpenthesis [TRN.empty, TRN.downstep] = [TRN.upstep, TRN.downstep] ∧
     hEpenthesis [TRN.downstep, TRN.downstep] = [TRN.downstep, TRN.downstep] := ⟨rfl, rfl⟩
 
-/-- The reason the contrast survives utterance-initial neutralization:
-    `realizePitchUtterance` only suppresses the *phonetic* drop, leaving
-    the underlying `l` in place to block h-epenthesis on itself. The
-    underlying form is still culminative-sensitive
-    ([lionnet-2025] §3.5). -/
+/-- Why it survives: neutralisation suppresses only the phonetic drop, and the underlying
+`l` still blocks h-epenthesis on itself (§3.5). -/
 theorem utt_initial_l_underlyingly_active :
-    -- Phonetically flat utterance-initially…
-    realizePitchUtterance 4 [TRN.downstep, TRN.downstep] = realizePitch 4 [TRN.empty, TRN.downstep] ∧
-    -- …but the underlying `l` blocks h-epenthesis on itself.
+    realizePitchUtterance 4 [TRN.downstep, TRN.downstep] =
+        realizePitch 4 [TRN.empty, TRN.downstep] ∧
     hEpenthesis [TRN.downstep, TRN.downstep] = [TRN.downstep, TRN.downstep] := by
   refine ⟨by decide, rfl⟩
 
--- ============================================================================
--- § 7: Drubea Utterance-Final Raising (h%)
--- ============================================================================
+/-! ### Drubea utterance-final raising -/
 
-/-- Drubea utterance-final raising: `h%` docks onto the final
-    registerless syllable ([lionnet-2025] §3.3, §4.8). The
-    Numèè utterance-final downstep `⁺%` is formalized separately
-    in §13 because its eligibility conditions (light CV + registerless
-    penult) require explicit syllable structure. -/
+/-- Drubea's `h%` docks onto the final registerless syllable (§3.3, §4.8); Numèè's
+utterance-final downstep `⁺%` is below, its conditions needing syllable structure. -/
 theorem drubea_final_raising :
     applyBoundary [TRN.downstep, TRN.empty, TRN.empty] .h_pct =
       [TRN.downstep, TRN.empty, TRN.upstep] := by decide
 
--- ============================================================================
--- § 8: Downstep Properties (Leben 2018)
--- ============================================================================
+/-! ### Downstep properties -/
 
-/-- Drubea/Numèè downstep satisfies all three core definitional
-    properties of downstep ([leben-2018]: 2;
-    [lionnet-2025] §6.1):
+/-- [leben-2018]'s properties of downstep, as refined in §6.1: (a)–(c) definitional,
+(d)–(f) cross-linguistic tendencies. -/
+structure DownstepProperties where
+  /-- (a) Affects the whole prosodic domain, not a single tone. -/
+  affectsDomain : Bool
+  /-- (b) Changes the register for what follows. -/
+  changesRegister : Bool
+  /-- (c) Cumulative: downsteps stack. -/
+  isCumulative : Bool
+  /-- (d) Utterance-initially, no phonetic contrast with the undownstepped. -/
+  uttInitialNeutral : Bool
+  /-- (e) Characteristically affects H tones. -/
+  characteristicallyAffectsH : Bool
+  /-- (f) Functions contrastively. -/
+  functionsContrastively : Bool
+  deriving Repr
 
-    (a) affects the entire prosodic domain (not just one tone)
-    (b) changes the register for what follows
-    (c) cumulative: multiple downsteps stack -/
+/-- Drubea/Numèè downstep meets the three definitional properties ([leben-2018]: 2; §6.1).
+Property (e) does not apply: the system has no H tones. -/
 def drubeaDownstep : DownstepProperties where
-  affectsDomain          := true
-  changesRegister        := true
-  isCumulative           := true
-  uttInitialNeutral      := true   -- tendency (d)
-  characteristicallyAffectsH := false  -- N/A: no H tones in the system
-  functionsContrastively := true   -- tendency (f): lexical contrast
+  affectsDomain := true
+  changesRegister := true
+  isCumulative := true
+  uttInitialNeutral := true
+  characteristicallyAffectsH := false
+  functionsContrastively := true
 
 theorem drubea_core_properties :
-    drubeaDownstep.affectsDomain ∧
-    drubeaDownstep.changesRegister ∧
-    drubeaDownstep.isCumulative := ⟨rfl, rfl, rfl⟩
+    drubeaDownstep.affectsDomain ∧ drubeaDownstep.changesRegister ∧
+      drubeaDownstep.isCumulative := ⟨rfl, rfl, rfl⟩
 
-/-- The `functionsContrastively` annotation on `drubeaDownstep` is not a
-    free stipulation: it is *witnessed* by `monoMinimalPairs`. A pair of
-    segmentally identical stems differing only in register (the form
-    equality of `minimal_pairs_same_segments` plus the register
-    contrast of `minimal_pairs_register_contrast`) is exactly what
-    `functionsContrastively` claims for the lexical case
-    ([lionnet-2025] §3.10). -/
+/-- `functionsContrastively` is witnessed by `monoMinimalPairs`: two stems with the same
+segments and different register specifications (§3.10). -/
 theorem drubea_contrastively_witnessed :
     drubeaDownstep.functionsContrastively = true ∧
     ∃ a b : StemEntry, a.form = b.form ∧ a.specs ≠ b.specs := by
@@ -255,29 +250,27 @@ theorem drubea_contrastively_witnessed :
           ⟨"be", "niaouli tree", .σ1_downstepped, 1⟩, rfl, ?_⟩
   decide
 
--- ============================================================================
--- § 9: Register vs Tonal Analysis
--- ============================================================================
+/-! ### Register versus tonal analysis -/
 
-/-- The register analysis of Drubea/Numèè ([lionnet-2025] §4):
-    1 underlying primitive (the `l` feature) and
-    1 postlexical process (h-epenthesis). -/
+/-- The primitives of an analysis (§4–§5): underlying primitives and postlexical
+processes. -/
+structure AnalysisInventory where
+  underlyingPrimitives : Nat
+  postlexicalProcesses : Nat
+  deriving Repr, DecidableEq
+
+/-- The register analysis (§4): one underlying primitive, `l`, and one postlexical
+process, h-epenthesis. -/
 def registerAnalysis : AnalysisInventory where
-  underlyingPrimitives := 1  -- just `l`
-  postlexicalProcesses := 1  -- h-epenthesis
+  underlyingPrimitives := 1
+  postlexicalProcesses := 1
 
-/-- The competing tonal analysis ([lionnet-2025] §5):
-    3 representational primitives (underlying L + epenthetic H +
-    epenthetic downstep ⁺) and 2 postlexical processes (OCP-driven
-    downstep insertion + H-spreading for pre-downstep raising).
-
-    Additionally, the tonal analysis suffers from a duplication problem
-    (both L and downstep encode the same pitch drop) and a conspiracy
-    problem (raising of H before L and of L before ⁺L are analysed as
-    unrelated despite the same phonetic effect). -/
+/-- The tonal alternative (§5): underlying L, epenthetic H and epenthetic downstep, with
+OCP-driven downstep insertion and H-spreading — and a duplication (L and downstep both
+encode the drop) and a conspiracy (two unrelated raisings with one phonetic effect). -/
 def tonalAnalysis : AnalysisInventory where
-  underlyingPrimitives := 3  -- underlying L + epenthetic H + epenthetic ⁺
-  postlexicalProcesses := 2  -- OCP downstep insertion + H-spreading
+  underlyingPrimitives := 3
+  postlexicalProcesses := 2
 
 /-- The register analysis is strictly more parsimonious. -/
 theorem register_more_parsimonious :
@@ -285,127 +278,74 @@ theorem register_more_parsimonious :
     registerAnalysis.postlexicalProcesses < tonalAnalysis.postlexicalProcesses :=
   ⟨by decide, by decide⟩
 
--- ============================================================================
--- § 10: Typological Classification
--- ============================================================================
+/-! ### Typology
 
-/-- Drubea is the first attested **register-only** word-prosodic system:
-    tonal contrasts defined entirely syntagmatically, with no paradigmatic
-    tone features ([lionnet-2025] §6.2, Conclusion). -/
-theorem drubea_is_register_based :
-    wordProsodicType = .registerBased := rfl
+Drubea is tonal by [hyman-2006]'s definition (3) — register enters lexical realization, as
+the minimal pairs show — yet register-based rather than tone-based: a sub-distinction
+within Hyman's tone prototype that he did not draw (§6.2). Its culminativity is register
+culminativity, at most one `l` per stem, not Hyman's stress culminativity (definition (5b)),
+which it lacks along with stress accent. -/
 
--- ============================================================================
--- § 11: Connection to Hyman 2006
--- ============================================================================
+/-- Drubea is the first attested register-only word-prosodic system (§6.2): no stem
+specifies `[upper]`. -/
+theorem drubea_register_only : ∀ e ∈ allStems, IsRegisterOnly e.specs := by decide
 
-/-- Drubea is +tone under [hyman-2006]'s definition (3): pitch
-    (via register features) enters into the lexical realization of
-    morphemes. The minimal pairs in §1 demonstrate this directly. -/
-theorem drubea_is_tonal_hyman :
-    Hyman2006.isTonalUnderHyman wordProsodicType = true := rfl
+/-- Tonal by definition (3), without stress accent: +T, −SA, the cell of Yoruba. -/
+theorem drubea_tone_only :
+    wordProsody.tone = true ∧ Hyman2006.quadrant wordProsody = .toneOnly ∧
+      Hyman2006.quadrant wordProsody = Hyman2006.quadrant Hyman2006.yoruba := ⟨rfl, rfl, rfl⟩
 
-/-- Drubea enriches Hyman's typology: it is a tonal system (by def. 3)
-    that is register-based rather than tone-based — a sub-distinction
-    within Hyman's tone prototype that he did not draw. -/
-theorem drubea_enriches_hyman :
-    Hyman2006.isTonalUnderHyman .registerBased = true ∧
-    wordProsodicType = .registerBased := ⟨rfl, rfl⟩
-
-/-- Drubea is +T, −SA under [hyman-2006]'s 2×2 typology
-    (same quadrant as Yoruba). -/
-theorem drubea_quadrant :
-    Hyman2006.drubea.quadrant = .toneOnly := rfl
-
--- ============================================================================
--- § 12: Culminativity — Register vs Stress
--- ============================================================================
-
-/-- Drubea satisfies register culminativity: every stem in the fragment
-    has at most one `l` feature. This is `IsCulminative` from
-    RegisterTier, applied to all stems in §2.
-
-    This is NOT [hyman-2006]'s stress culminativity (def. 5b),
-    which concerns primary stress per word. Drubea has no stress
-    accent system — OBLHEAD does not apply. The two uses of
-    "culminativity" are formally parallel but phonologically distinct
-    (see `Hyman2006.CulminativityDomain`). -/
+/-- Register culminativity holds while stress accent, hence Hyman's culminativity, is
+absent. -/
 theorem drubea_register_culminative_not_stress :
-    -- Register culminativity holds (Lionnet)
-    (∀ e ∈ allStems, IsCulminative e.specs) ∧
-    -- Stress accent is absent (Hyman)
-    Hyman2006.drubea.hasStressAccent = false :=
+    (∀ e ∈ allStems, IsCulminative e.specs) ∧ wordProsody.stressAccent = false :=
   ⟨all_stems_culminative, rfl⟩
 
--- ============================================================================
--- § 13: Numèè Boundary Downstep ⁺% ([lionnet-2025] §3.4)
--- ============================================================================
+/-! ### Numèè boundary downstep
 
-/-! Numèè shares Drubea's underlying register inventory (registerless vs
-    downstepped morae, no tone features) but diverges at the
-    utterance-final boundary. The phenomenon, formalized in
-    `Fragments/Numee/Prosody.lean`, has three properties worth pinning
-    down here: it applies only to **light CV** finals, only when the
-    **preceding syllable is registerless**, and produces a *stacked*
-    double downstep when the final is itself underlyingly downstepped
-    — preserving the registerless/downstepped contrast utterance-finally. -/
+Numèè shares Drubea's register inventory but diverges at the utterance-final boundary
+(§3.4): the boundary downstep `⁺%` applies only to a light CV final after a registerless
+syllable, and stacks a second downstep on a final that is itself downstepped, preserving
+the contrast utterance-finally. The process is `Fragments/Numee/Prosody`. -/
 
 open Numee.Prosody
 
-/-- Boundary `⁺%` downsteps a registerless light CV final preceded by
-    a registerless syllable ([lionnet-2025] ex. 24). -/
+/-- `⁺%` downsteps a registerless light CV final after a registerless syllable (ex. 24). -/
 theorem numee_registerless_final_single :
     numeeBoundaryEffect [jaa, niCoconut] = .single := by decide
 
-/-- An *already-downstepped* light CV final receives a *second* downstep
-    at the boundary — the stacked `⁺⁺` that preserves the underlying
-    contrast in final position ([lionnet-2025] ex. 25). The minimal
-    pair `nĩ` 'coconut' (registerless) vs `⁺nĩ` 'breast' (downstepped)
-    is realised utterance-finally as a one-step vs two-step pitch drop
-    on the same surface segments. -/
+/-- A downstepped light CV final receives a second downstep — the stacked `⁺⁺` (ex. 25):
+`nĩ` 'coconut' vs `⁺nĩ` 'breast' surface as a one-step vs two-step drop. -/
 theorem numee_downstepped_final_double :
     numeeBoundaryEffect [jaa, niBreast] = .double := by decide
 
-/-- The boundary distinguishes the minimal pair: `niCoconut` triggers
-    `single`, `niBreast` triggers `double`. This is the empirical
-    signature that the underlying registerless/downstepped contrast
-    survives the boundary process. -/
+/-- The boundary distinguishes the minimal pair. -/
 theorem numee_minimal_pair_distinguished :
     numeeBoundaryEffect [jaa, niCoconut] ≠ numeeBoundaryEffect [jaa, niBreast] := by
   decide
 
-/-- A **heavy CVV** final blocks the boundary downstep — eligibility
-    requires a light (monomoraic) final ([lionnet-2025] ex. 26). -/
+/-- A heavy CVV final blocks the boundary downstep (ex. 26). -/
 theorem numee_heavy_final_blocks :
     numeeBoundaryEffect [regCV, mii] = .none := by decide
 
-/-- A **downstepped preceding syllable** blocks the boundary, even
-    when the final is light CV and registerless
-    ([lionnet-2025] ex. 28: `⁺tĩĩ ku` 'three yams'). -/
+/-- A downstepped preceding syllable blocks it, even before a light registerless final
+(ex. 28, `⁺tĩĩ ku` 'three yams'). -/
 theorem numee_after_downstepped_blocks :
     numeeBoundaryEffect [regCVV, beTii, ku] = .none := by decide
 
-/-- Same blocking pattern with a different downstepped penult and
-    different light CV final ([lionnet-2025] ex. 29: `⁺paa kwɛ̃`
-    'down sand'). -/
+/-- The same, with another downstepped penult (ex. 29, `⁺paa kwɛ̃` 'down sand'). -/
 theorem numee_after_downstepped_blocks' :
     numeeBoundaryEffect [niCoconut, paa, kwe] = .none := by decide
 
-/-- A bare light CV final with no preceding syllable does not trigger
-    the boundary — the rule's structural description requires *two*
-    syllables. -/
+/-- A lone light CV final does not trigger the boundary: its structural description needs
+two syllables. -/
 theorem numee_singleton_no_boundary :
     numeeBoundaryEffect [niCoconut] = .none := by decide
 
-/-- Numèè syllables inherit the same register inventory as Drubea
-    morphemes — the per-mora `TRN` list `niBreast` carries is
-    `IsCulminative`, just like Drubea stems. The boundary process is
-    *postlexical* and does not feed culminativity, which is a property
-    of underlying lexical specifications. -/
+/-- Numèè syllables carry the same culminative register inventory as Drubea stems; the
+boundary process is postlexical and does not feed culminativity. -/
 theorem numee_lexical_culminative :
-    IsCulminative niBreast.specs ∧
-    IsCulminative beTii.specs ∧
-    IsCulminative paa.specs := by
+    IsCulminative niBreast.specs ∧ IsCulminative beTii.specs ∧ IsCulminative paa.specs := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 end Lionnet2025


### PR DESCRIPTION
Recut of `Tone/Basic.lean` (587-line grab-bag) on mathlib lines.

- `Basic`: `TRN` keeps its two-`Option Bool` structure with `TRN.bundleEquiv : TRN ≃ (Subtonal → Option Bool)` (the `Complex`/`equivRealProd` pattern); all named tones `@[match_pattern]`; the hand `BEq`/`LawfulBEq` instances (duplicating `instBEqOfDecidableEq`) removed; feature operations `TRN.assimilate`/`merge`/`dock` (were `subtonalAssimilate`/`mergeTRN`/`dockFloating`); `TBUKind`; Hyman's two-dimension `WordProsody` and Lionnet's `IsRegisterOnly` (a predicate on inventories, not a stored label) replace the framework-mixing `WordProsodicType`.
- New `Register`: `realizePitch` is `List.scanl` of `pitchEffect`; monotonicity stated with `(· ≤ ·) on TRN.pitchEffect` instead of a global `Preorder TRN`.
- Single-paper apparatus to its studies: `Lionnet2025` gets culminativity, h-epenthesis, utterance-initial neutralisation, the Leben checklist and the analysis inventory (plus §8–§10 of `Hyman2006`, a 2006 study citing 2025 data); `Lionnet2022Laal` gets `absolutePitch`. `ThreeToneGap` (formaliser's synthesis, no consumer) and the duplicate Laal/Drubea verification theorems deleted. `Hyman2006` restated on `WordProsody` with `decide` throughout (no `native_decide`), minus a vacuous `→ True` theorem.