### PR TITLE
refactor(Tense): rename the time-axis type parameter Time to T

### DIFF
--- a/Linglib/Core/Order/AllenRelation.lean
+++ b/Linglib/Core/Order/AllenRelation.lean
@@ -132,14 +132,14 @@ end AllenRelation
 -- § Holds Predicate
 -- ════════════════════════════════════════════════════
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 namespace AllenRelation
 
 /-- `r.holds i j` is true iff atomic Allen relation `r` is the one that
     holds between intervals `i` and `j`. The defining inequalities follow
     [allen-1983]. -/
-def holds : AllenRelation → NonemptyInterval Time → NonemptyInterval Time → Prop
+def holds : AllenRelation → NonemptyInterval T → NonemptyInterval T → Prop
   | .precedes,     i, j => i.snd < j.fst
   | .meets,        i, j => i.snd = j.fst
   | .overlaps,     i, j => i.fst < j.fst ∧ j.fst < i.snd ∧ i.snd < j.snd
@@ -156,7 +156,7 @@ def holds : AllenRelation → NonemptyInterval Time → NonemptyInterval Time �
 
 /-- Holds is symmetric under inversion: r holds of (i, j) iff r⁻¹ holds of
     (j, i). This is the central algebraic property of the inverse operation. -/
-theorem holds_inverse (r : AllenRelation) (i j : NonemptyInterval Time) :
+theorem holds_inverse (r : AllenRelation) (i j : NonemptyInterval T) :
     r.holds i j ↔ r.inverse.holds j i := by
   cases r <;> simp [holds, inverse, and_comm, and_left_comm, eq_comm]
 
@@ -166,7 +166,7 @@ theorem holds_inverse (r : AllenRelation) (i j : NonemptyInterval Time) :
     `i.snd vs j.fst`, then `i.fst vs j.snd`, then refinement on
     `i.fst vs j.fst` and `i.snd vs j.snd`. Used to derive the
     constructive `NonemptyInterval.allenRel` projection. -/
-def witness (i j : NonemptyInterval Time) : { r : AllenRelation // r.holds i j } :=
+def witness (i j : NonemptyInterval T) : { r : AllenRelation // r.holds i j } :=
   if h₁ : i.snd < j.fst then ⟨.precedes, h₁⟩
   else if h₁' : i.snd = j.fst then ⟨.meets, h₁'⟩
   else
@@ -197,7 +197,7 @@ def witness (i j : NonemptyInterval Time) : { r : AllenRelation // r.holds i j }
 
 /-- **Exhaustiveness** (existence half): every interval pair satisfies at
     least one atomic Allen relation. Existential projection of `witness`. -/
-theorem holds_exists (i j : NonemptyInterval Time) : ∃ r : AllenRelation, r.holds i j :=
+theorem holds_exists (i j : NonemptyInterval T) : ∃ r : AllenRelation, r.holds i j :=
   ⟨_, (witness i j).2⟩
 
 -- ════════════════════════════════════════════════════
@@ -214,21 +214,21 @@ theorem holds_exists (i j : NonemptyInterval Time) : ∃ r : AllenRelation, r.ho
     heartbeat budget) into two 13-case lemmas. -/
 
 /-- Three-way sign of `a vs b` on a linear order. -/
-def sgn (a b : Time) : Ordering :=
+def sgn (a b : T) : Ordering :=
   if a < b then .lt else if a = b then .eq else .gt
 
-theorem sgn_lt {a b : Time} (h : a < b) : sgn a b = .lt := if_pos h
+theorem sgn_lt {a b : T} (h : a < b) : sgn a b = .lt := if_pos h
 
-theorem sgn_eq {a b : Time} (h : a = b) : sgn a b = .eq := by
+theorem sgn_eq {a b : T} (h : a = b) : sgn a b = .eq := by
   subst h; simp [sgn]
 
-theorem sgn_gt {a b : Time} (h : b < a) : sgn a b = .gt := by
+theorem sgn_gt {a b : T} (h : b < a) : sgn a b = .gt := by
   unfold sgn; rw [if_neg (lt_asymm h), if_neg (ne_of_gt h)]
 
 /-- The 4-tuple signature of an interval pair: pairwise comparisons of
     `(i.fst vs j.fst, i.fst vs j.snd, i.snd vs j.fst,
     i.snd vs j.snd)`. -/
-def signature (i j : NonemptyInterval Time) : Ordering × Ordering × Ordering × Ordering :=
+def signature (i j : NonemptyInterval T) : Ordering × Ordering × Ordering × Ordering :=
   (sgn i.fst j.fst, sgn i.fst j.snd, sgn i.snd j.fst, sgn i.snd j.snd)
 
 /-- The expected signature of each Allen atom — the unique 4-tuple of
@@ -260,7 +260,7 @@ theorem expectedSig_injective (r₁ r₂ : AllenRelation)
     signature is exactly `r.expectedSig`. (13 cases, each computing
     four `sgn` components via `Prod.ext` + the appropriate `sgn_*`
     lemma + `order`.) -/
-theorem signature_of_holds (r : AllenRelation) (i j : NonemptyInterval Time)
+theorem signature_of_holds (r : AllenRelation) (i j : NonemptyInterval T)
     (hi : i.fst < i.snd) (hj : j.fst < j.snd) (h : r.holds i j) :
     signature i j = r.expectedSig := by
   cases r <;> simp only [holds] at h
@@ -290,7 +290,7 @@ theorem signature_of_holds (r : AllenRelation) (i j : NonemptyInterval Time)
     Proof: factor through the 4-tuple `signature`. Both `r₁` and `r₂`
     force the same signature (`signature_of_holds`), and distinct atoms
     have distinct signatures (`expectedSig_injective`). -/
-theorem holds_unique (i j : NonemptyInterval Time)
+theorem holds_unique (i j : NonemptyInterval T)
     (hi : i.fst < i.snd) (hj : j.fst < j.snd)
     (r₁ r₂ : AllenRelation)
     (h₁ : r₁.holds i j) (h₂ : r₂.holds i j) : r₁ = r₂ :=
@@ -324,23 +324,23 @@ namespace AllenRelation
 /-- "`holdsIn S i j`" iff some atom in the list `S` is the relation
     holding between `i` and `j`. Singleton lists yield exact-atom
     predicates; longer lists yield union predicates. -/
-def holdsIn (S : List AllenRelation) (i j : NonemptyInterval Time) : Prop :=
+def holdsIn (S : List AllenRelation) (i j : NonemptyInterval T) : Prop :=
   ∃ r ∈ S, r.holds i j
 
-@[simp] theorem holdsIn_nil (i j : NonemptyInterval Time) :
+@[simp] theorem holdsIn_nil (i j : NonemptyInterval T) :
     holdsIn [] i j ↔ False := by simp [holdsIn]
 
-@[simp] theorem holdsIn_singleton (r : AllenRelation) (i j : NonemptyInterval Time) :
+@[simp] theorem holdsIn_singleton (r : AllenRelation) (i j : NonemptyInterval T) :
     holdsIn [r] i j ↔ r.holds i j := by simp [holdsIn]
 
 theorem holdsIn_cons (r : AllenRelation) (S : List AllenRelation)
-    (i j : NonemptyInterval Time) :
+    (i j : NonemptyInterval T) :
     holdsIn (r :: S) i j ↔ r.holds i j ∨ holdsIn S i j := by
   simp [holdsIn, or_and_right, exists_or]
 
 /-- Subset monotonicity: enlarging the atom set weakens the predicate. -/
 theorem holdsIn_mono {S₁ S₂ : List AllenRelation} (h : ∀ r ∈ S₁, r ∈ S₂)
-    (i j : NonemptyInterval Time) : holdsIn S₁ i j → holdsIn S₂ i j := by
+    (i j : NonemptyInterval T) : holdsIn S₁ i j → holdsIn S₂ i j := by
   rintro ⟨r, hr, hrij⟩; exact ⟨r, h r hr, hrij⟩
 
 -- ──── Named atom-sets corresponding to existing `NonemptyInterval` predicates ────
@@ -402,7 +402,7 @@ end AllenRelation
 
 namespace NonemptyInterval
 
-variable (i j : NonemptyInterval Time)
+variable (i j : NonemptyInterval T)
 
 /-- `NonemptyInterval.precedes` is exactly the Allen `precedes` atom. -/
 theorem precedes_iff_allen : i.precedes j ↔ AllenRelation.holdsIn AllenRelation.precedesSet i j := by
@@ -501,8 +501,8 @@ end NonemptyInterval
 namespace AllenRelation
 
 /-- `holds` is decidable on a linear order (provided `<` and `=` are). -/
-instance holds_decidable [DecidableEq Time] [DecidableRel (α := Time) (· < ·)]
-    (r : AllenRelation) (i j : NonemptyInterval Time) : Decidable (r.holds i j) := by
+instance holds_decidable [DecidableEq T] [DecidableRel (α := T) (· < ·)]
+    (r : AllenRelation) (i j : NonemptyInterval T) : Decidable (r.holds i j) := by
   cases r <;> unfold holds <;> infer_instance
 
 end AllenRelation
@@ -521,7 +521,7 @@ end AllenRelation
 
 namespace AllenRelation
 
-variable {i j k : NonemptyInterval Time}
+variable {i j k : NonemptyInterval T}
 
 /-- `equal` is a left identity: if i = j and j r k, then i r k. -/
 theorem holds_equal_left (r : AllenRelation)
@@ -578,18 +578,18 @@ namespace NonemptyInterval
     extracted from the constructive `AllenRelation.witness`. For
     non-degenerate intervals this is well-defined: `allenRel_unique`
     proves every witness equals the projection. -/
-def allenRel (i j : NonemptyInterval Time) : AllenRelation :=
+def allenRel (i j : NonemptyInterval T) : AllenRelation :=
   (AllenRelation.witness i j).1
 
 /-- The projected atom does hold between the intervals. -/
-theorem allenRel_holds (i j : NonemptyInterval Time) : (allenRel i j).holds i j :=
+theorem allenRel_holds (i j : NonemptyInterval T) : (allenRel i j).holds i j :=
   (AllenRelation.witness i j).2
 
 /-- For non-degenerate intervals, the projection is **unique**: every
     atom that holds equals `allenRel i j`. This is the core "well-
     definedness" theorem for the projection — it justifies treating
     `allenRel i j` as **the** Allen relation between the two intervals. -/
-theorem allenRel_unique (i j : NonemptyInterval Time)
+theorem allenRel_unique (i j : NonemptyInterval T)
     (hi : i.fst < i.snd) (hj : j.fst < j.snd)
     {r : AllenRelation} (h : r.holds i j) : r = allenRel i j :=
   AllenRelation.holds_unique i j hi hj r (allenRel i j) h (allenRel_holds i j)
@@ -597,7 +597,7 @@ theorem allenRel_unique (i j : NonemptyInterval Time)
 /-- The projection lands in the named atom-set iff the corresponding
     `holdsIn` predicate holds. (For non-degenerate intervals; uses
     uniqueness to convert membership to existence.) -/
-theorem allenRel_mem_iff_holdsIn (i j : NonemptyInterval Time)
+theorem allenRel_mem_iff_holdsIn (i j : NonemptyInterval T)
     (hi : i.fst < i.snd) (hj : j.fst < j.snd)
     (S : List AllenRelation) :
     allenRel i j ∈ S ↔ AllenRelation.holdsIn S i j := by

--- a/Linglib/Logic/Temporal/Basic.lean
+++ b/Linglib/Logic/Temporal/Basic.lean
@@ -29,50 +29,50 @@ re-proved — `N` is S5 because `∼ₜ` is an equivalence, `box` because the un
 
 namespace Temporal.TWFrame
 
-variable {Time : Type*} {World : Type*} {Atom : Type*} [LinearOrder Time]
-  (F : TWFrame Time World) (V : Atom → Time → World → Prop)
+variable {T : Type*} {World : Type*} {Atom : Type*} [LinearOrder T]
+  (F : TWFrame T World) (V : Atom → T → World → Prop)
 
 open ModalLogic (box_T box_four box_restrict box_isIndicial IsIndicial)
 
 /-! ### Satisfaction clauses -/
 
-@[simp] theorem sat_atom (p : Atom) (t : Time) (w : World) :
+@[simp] theorem sat_atom (p : Atom) (t : T) (w : World) :
     F.sat V (.atom p) t w ↔ V p t w := Iff.rfl
 
-@[simp] theorem sat_neg (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_neg (a : OForm Atom) (t : T) (w : World) :
     F.sat V (.neg a) t w ↔ ¬ F.sat V a t w := Iff.rfl
 
-@[simp] theorem sat_and (a b : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_and (a b : OForm Atom) (t : T) (w : World) :
     F.sat V (.and a b) t w ↔ F.sat V a t w ∧ F.sat V b t w := Iff.rfl
 
-@[simp] theorem sat_G (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_G (a : OForm Atom) (t : T) (w : World) :
     F.sat V (.G a) t w ↔ ∀ t', t < t' → F.sat V a t' w := Iff.rfl
 
-@[simp] theorem sat_H (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_H (a : OForm Atom) (t : T) (w : World) :
     F.sat V (.H a) t w ↔ ∀ t', t' < t → F.sat V a t' w := Iff.rfl
 
-@[simp] theorem sat_N (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_N (a : OForm Atom) (t : T) (w : World) :
     F.sat V (.N a) t w ↔ ∀ w', F.sim t w w' → F.sat V a t w' := Iff.rfl
 
-@[simp] theorem sat_box (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_box (a : OForm Atom) (t : T) (w : World) :
     F.sat V (.box a) t w ↔ ∀ w', F.sat V a t w' :=
   ⟨fun h w' => h w' trivial, fun h w' _ => h w'⟩
 
 /-! ### Dual operators -/
 
-@[simp] theorem sat_M (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_M (a : OForm Atom) (t : T) (w : World) :
     F.sat V a.M t w ↔ ∃ w', F.sim t w w' ∧ F.sat V a t w' := by
   simp only [OForm.M, sat_neg, sat_N, not_forall, not_not, exists_prop]
 
-@[simp] theorem sat_dia (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_dia (a : OForm Atom) (t : T) (w : World) :
     F.sat V a.dia t w ↔ ∃ w', F.sat V a t w' := by
   simp only [OForm.dia, sat_neg, sat_box, not_forall, not_not]
 
-@[simp] theorem sat_Fut (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_Fut (a : OForm Atom) (t : T) (w : World) :
     F.sat V a.Fut t w ↔ ∃ t', t < t' ∧ F.sat V a t' w := by
   simp only [OForm.Fut, sat_neg, sat_G, not_forall, not_not, exists_prop]
 
-@[simp] theorem sat_Pst (a : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_Pst (a : OForm Atom) (t : T) (w : World) :
     F.sat V a.Pst t w ↔ ∃ t', t' < t ∧ F.sat V a t' w := by
   simp only [OForm.Pst, sat_neg, sat_H, not_forall, not_not, exists_prop]
 
@@ -83,36 +83,36 @@ correspondence theory: `box ⊃ N` from `box_restrict` (the universal relation c
 axioms from reflexivity (`box_T`); the `4` axioms from transitivity (`box_four`); the `5` axioms from
 euclideanness of `∼ₜ`. -/
 
-theorem sat_box_imp_N {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_box_imp_N {a : OForm Atom} {t : T} {w : World} :
     F.sat V (.box a) t w → F.sat V (.N a) t w :=
   fun h => box_restrict _ (fun _ _ _ => trivial) _ h
 
-theorem sat_N_imp_self {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_N_imp_self {a : OForm Atom} {t : T} {w : World} :
     F.sat V (.N a) t w → F.sat V a t w := by
   haveI : Std.Refl (F.sim t) := ⟨(F.sim_equiv t).refl⟩
   exact fun h => box_T h
 
-theorem sat_box_imp_self {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_box_imp_self {a : OForm Atom} {t : T} {w : World} :
     F.sat V (.box a) t w → F.sat V a t w :=
   fun h => box_T h
 
-theorem sat_N_imp_N_N {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_N_imp_N_N {a : OForm Atom} {t : T} {w : World} :
     F.sat V (.N a) t w → F.sat V (.N (.N a)) t w := by
   haveI : IsTrans World (F.sim t) := ⟨fun _ _ _ => (F.sim_equiv t).trans⟩
   exact fun h => box_four h
 
-theorem sat_box_imp_box_box {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_box_imp_box_box {a : OForm Atom} {t : T} {w : World} :
     F.sat V (.box a) t w → F.sat V (.box (.box a)) t w :=
   fun h => box_four h
 
-theorem sat_M_imp_N_M {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_M_imp_N_M {a : OForm Atom} {t : T} {w : World} :
     F.sat V a.M t w → F.sat V a.M.N t w := by
   intro h w' hww'
   rw [sat_M] at h ⊢
   obtain ⟨w₀, hww₀, ha⟩ := h
   exact ⟨w₀, (F.sim_equiv t).trans ((F.sim_equiv t).symm hww') hww₀, ha⟩
 
-theorem sat_dia_imp_box_dia {a : OForm Atom} {t : Time} {w : World} :
+theorem sat_dia_imp_box_dia {a : OForm Atom} {t : T} {w : World} :
     F.sat V a.dia t w → F.sat V a.dia.box t w := by
   intro h w' _
   rw [sat_dia] at h ⊢
@@ -122,7 +122,7 @@ theorem sat_dia_imp_box_dia {a : OForm Atom} {t : Time} {w : World} :
 /-- Historical necessity `N` is a Kripke (indicial) modality — `ModalLogic.box` over `∼ₜ`,
     [gallin-1975]'s indicial necessity. (`G`/`H` are tense over the time order, not world-PropOps,
     so they fall outside this world-indexed classification.) -/
-theorem N_isIndicial (t : Time) : IsIndicial (ModalLogic.box (F.sim t)) :=
+theorem N_isIndicial (t : T) : IsIndicial (ModalLogic.box (F.sim t)) :=
   box_isIndicial (F.sim t)
 
 /-! ### The temporal adjunctions `Fut ⊣ H`, `Pst ⊣ G`

--- a/Linglib/Logic/Temporal/Defs.lean
+++ b/Linglib/Logic/Temporal/Defs.lean
@@ -28,13 +28,13 @@ universe u v
 
 /-- A **T × W frame** ([thomason-1984], [von-kutschera-1997]): linear time, worlds, and a per-time
     historical-equivalence `sim` that is an equivalence and backward-closed. -/
-structure TWFrame (Time : Type u) (World : Type v) [LinearOrder Time] where
+structure TWFrame (T : Type u) (World : Type v) [LinearOrder T] where
   /-- Historical equivalence `∼ₜ`: `sim t w w'` holds iff `w`, `w'` share their history up to `t`. -/
-  sim : Time → World → World → Prop
+  sim : T → World → World → Prop
   /-- Each `∼ₜ` is an equivalence relation. -/
   sim_equiv : ∀ t, Equivalence (sim t)
   /-- **Backward closure**: agreement up to `t` implies agreement up to any earlier `t'`. -/
-  sim_backward : ∀ {t t' : Time} (w w' : World), t' ≤ t → sim t w w' → sim t' w w'
+  sim_backward : ∀ {t t' : T} (w w' : World), t' ≤ t → sim t w w' → sim t' w w'
 
 /-- The object language `L` of T × W logic ([von-kutschera-1997] §1). -/
 inductive OForm (Atom : Type*) where
@@ -56,15 +56,15 @@ inductive OForm (Atom : Type*) where
 
 namespace TWFrame
 
-variable {Time : Type u} {World : Type v} {Atom : Type*} [LinearOrder Time]
+variable {T : Type u} {World : Type v} {Atom : Type*} [LinearOrder T]
 
 open ModalLogic (box) in
 /-- Satisfaction `V_{t,w}(A)` ([von-kutschera-1997]) relative to an atomic valuation `V`.
     `G`/`H`/`N`/`box` are `ModalLogic.box` Kripke modalities over, respectively, future
     precedence `<`, past precedence `>`, historical equivalence `sim t`, and the universal
     relation — making the object logic a multimodal Kripke logic by construction. -/
-def sat (F : TWFrame Time World) (V : Atom → Time → World → Prop) :
-    OForm Atom → Time → World → Prop
+def sat (F : TWFrame T World) (V : Atom → T → World → Prop) :
+    OForm Atom → T → World → Prop
   | .atom p,  t, w => V p t w
   | .neg a,   t, w => ¬ F.sat V a t w
   | .and a b, t, w => F.sat V a t w ∧ F.sat V b t w
@@ -74,7 +74,7 @@ def sat (F : TWFrame Time World) (V : Atom → Time → World → Prop) :
   | .box a,   t, w => box ⊤ (fun w' => F.sat V a t w') w
 
 /-- Local entailment in a model: `a` entails `b` iff `b` holds wherever `a` does. -/
-def entails (F : TWFrame Time World) (V : Atom → Time → World → Prop) (a b : OForm Atom) : Prop :=
+def entails (F : TWFrame T World) (V : Atom → T → World → Prop) (a b : OForm Atom) : Prop :=
   ∀ t w, F.sat V a t w → F.sat V b t w
 
 end TWFrame

--- a/Linglib/Logic/Temporal/Soundness.lean
+++ b/Linglib/Logic/Temporal/Soundness.lean
@@ -50,15 +50,15 @@ def OForm.mentions : OForm Atom → Atom → Prop
 
 namespace TWFrame
 
-variable {Time : Type*} {World : Type*} [LinearOrder Time]
+variable {T : Type*} {World : Type*} [LinearOrder T]
 
-@[simp] theorem sat_imp (F : TWFrame Time World) (V : Atom → Time → World → Prop)
-    (a b : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_imp (F : TWFrame T World) (V : Atom → T → World → Prop)
+    (a b : OForm Atom) (t : T) (w : World) :
     F.sat V (a.imp b) t w ↔ (F.sat V a t w → F.sat V b t w) := by
   simp only [OForm.imp, sat_neg, sat_and, not_and, not_not]
 
-@[simp] theorem sat_or (F : TWFrame Time World) (V : Atom → Time → World → Prop)
-    (a b : OForm Atom) (t : Time) (w : World) :
+@[simp] theorem sat_or (F : TWFrame T World) (V : Atom → T → World → Prop)
+    (a b : OForm Atom) (t : T) (w : World) :
     F.sat V (a.or b) t w ↔ (F.sat V a t w ∨ F.sat V b t w) := by
   simp only [OForm.or, sat_neg, sat_and, not_and_or, not_not]
 
@@ -66,7 +66,7 @@ variable {Time : Type*} {World : Type*} [LinearOrder Time]
 
 A formula's truth at a point depends only on the valuation of the atoms it mentions. -/
 
-theorem sat_iff_of_agree (F : TWFrame Time World) (V₁ V₂ : Atom → Time → World → Prop) :
+theorem sat_iff_of_agree (F : TWFrame T World) (V₁ V₂ : Atom → T → World → Prop) :
     ∀ (a : OForm Atom), (∀ p, a.mentions p → ∀ t w, V₁ p t w ↔ V₂ p t w) →
       ∀ t w, (F.sat V₁ a t w ↔ F.sat V₂ a t w)
   | .atom p,  h, t, w => h p rfl t w
@@ -95,8 +95,8 @@ end TWFrame
 
 /-- A formula is **valid** when it is true at every point of every T × W model. -/
 def Valid (a : OForm Atom) : Prop :=
-  ∀ {Time : Type u} {World : Type v} [LinearOrder Time]
-    (F : TWFrame Time World) (V : Atom → Time → World → Prop) (t : Time) (w : World),
+  ∀ {T : Type u} {World : Type v} [LinearOrder T]
+    (F : TWFrame T World) (V : Atom → T → World → Prop) (t : T) (w : World),
     F.sat V a t w
 
 /-! ### The `TW` calculus -/
@@ -171,7 +171,7 @@ open ModalLogic (box_four self_imp_box_flip_diamond)
 
 /-- **Soundness of `TW`** ([von-kutschera-1997]): every `TW`-provable formula is T × W-valid. -/
 theorem soundness {a : OForm Atom} (h : Provable a) : Valid.{u, v} a := by
-  intro Time World _ F V t w
+  intro T World _ F V t w
   induction h generalizing V t w with
   | impK _ _ => simp only [sat_imp]; exact fun p _ => p
   | impS _ _ _ => simp only [sat_imp]; exact fun f g p => f p (g p)
@@ -216,7 +216,7 @@ theorem soundness {a : OForm Atom} (h : Provable a) : Valid.{u, v} a := by
   | necBox _ ih => exact fun w' _ => ih V t w'
   | @ir a q _ hq ih =>
       classical
-      let V' : Atom → Time → World → Prop := fun p t'' w'' => if p = q then t < t'' else V p t'' w''
+      let V' : Atom → T → World → Prop := fun p t'' w'' => if p = q then t < t'' else V p t'' w''
       have hbox : F.sat V' (OForm.and (.neg (.atom q)) (.G (.atom q))).box t w := by
         intro w' _; refine ⟨?_, fun t' ht' => ?_⟩ <;> simp only [sat_neg, sat_atom, V']
         exacts [lt_irrefl t, ht']

--- a/Linglib/Semantics/ArgumentStructure/ArgumentIntroduction.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgumentIntroduction.lean
@@ -7,10 +7,10 @@ import Linglib.Semantics.ArgumentStructure.Thematic.Defs
 [parsons-1990] [moltmann-2025] [hopperdietzel-2024]
 
 Neo-Davidsonian substrate for argument-introducing heads (Voice, applicative,
-Cause), built on the canonical `ThematicRel` (`Entity → Event Time → Prop`,
+Cause), built on the canonical `ThematicRel` (`Entity → Event T → Prop`,
 [moltmann-2025]: "the preferred version of event semantics for
 syntacticians"). A verb/VP denotation is a predicate of events
-`Event Time → Prop` (this is `Set (Event Time)`; used predicatively).
+`Event T → Prop` (this is `Set (Event T)`; used predicatively).
 
 The central new object is `VerbDenot`: a verb denotation classified by the
 structure argument introduction is sensitive to (its valency; the finite
@@ -35,25 +35,25 @@ contextually-interpreted single argument-introducer is its `IntroMode` reading.
 
 namespace ArgumentStructure
 
-variable {Entity : Type*} {Time : Type*} [LinearOrder Time]
+variable {Entity : Type*} {T : Type*} [LinearOrder T]
 
 /-! ### Event Identification and thematic uniqueness -/
 
 /-- Event Identification ([kratzer-1996]): combine an argument-introducer
 `f` (a thematic relation, awaiting its participant) with a VP predicate `g`,
 conjoining at the event. The result still awaits the introduced participant. -/
-def eventIdentification (f : ThematicRel Entity Time) (g : Event Time → Prop) :
-    ThematicRel Entity Time :=
+def eventIdentification (f : ThematicRel Entity T) (g : Event T → Prop) :
+    ThematicRel Entity T :=
   fun x e => f x e ∧ g e
 
-theorem eventIdentification_apply (f : ThematicRel Entity Time)
-    (g : Event Time → Prop) (x : Entity) (e : Event Time) :
+theorem eventIdentification_apply (f : ThematicRel Entity T)
+    (g : Event T → Prop) (x : Entity) (e : Event T) :
     eventIdentification f g x e ↔ f x e ∧ g e := Iff.rfl
 
 /-- Two thematic relations are role-exclusive when no participant bears both to
 the same event (thematic uniqueness). This is the principle behind
 [pylkkanen-2008]'s eq. 103: a participant cannot be both agent and theme. -/
-def RolesExclusive (r₁ r₂ : ThematicRel Entity Time) : Prop :=
+def RolesExclusive (r₁ r₂ : ThematicRel Entity T) : Prop :=
   ∀ x e, r₁ x e → ¬ r₂ x e
 
 /-! ### Verb denotations classified by valence -/
@@ -69,9 +69,9 @@ rather than a stipulation.
   (e.g. *send a letter*).
 * `kimianStative` — a relation over individuals with *no* event argument
   (Kimian state, [moltmann-2025] §1.4.1; e.g. *own*, *owe*). [Diagnostic 2] -/
-inductive VerbDenot (Entity : Type*) (Time : Type*) [LinearOrder Time] where
-  | unergative (body : Event Time → Prop)
-  | transitive (theme : ThematicRel Entity Time) (body : ThematicRel Entity Time)
+inductive VerbDenot (Entity : Type*) (T : Type*) [LinearOrder T] where
+  | unergative (body : Event T → Prop)
+  | transitive (theme : ThematicRel Entity T) (body : ThematicRel Entity T)
   | kimianStative (rel : Entity → Entity → Prop)
 
 namespace VerbDenot
@@ -79,11 +79,11 @@ namespace VerbDenot
 /-- Does this denotation supply an event-internal theme (Davidsonian transitive)?
 `unergative` (no participant slot) and `kimianStative` (no event argument) lack
 one, for two distinct structural reasons. -/
-def IsTransitive : VerbDenot Entity Time → Prop
+def IsTransitive : VerbDenot Entity T → Prop
   | .transitive _ _ => True
   | _ => False
 
-instance : DecidablePred (IsTransitive (Entity := Entity) (Time := Time)) := fun vd =>
+instance : DecidablePred (IsTransitive (Entity := Entity) (T := T)) := fun vd =>
   match vd with
   | .transitive _ _ => .isTrue trivial
   | .unergative _ => .isFalse id
@@ -107,12 +107,12 @@ inductive IntroMode where
 /-- Which verb denotations an introducer of this mode can compose with, derived
 from the denotation's valence: an event-relating introducer composes with
 anything; a theme-relating one needs an event-internal theme. -/
-def IntroMode.Licenses : IntroMode → VerbDenot Entity Time → Prop
+def IntroMode.Licenses : IntroMode → VerbDenot Entity T → Prop
   | .toEvent, _  => True
   | .toTheme, vd => vd.IsTransitive
 
 instance (m : IntroMode) :
-    DecidablePred (IntroMode.Licenses m (Entity := Entity) (Time := Time)) := fun vd => by
+    DecidablePred (IntroMode.Licenses m (Entity := Entity) (T := T)) := fun vd => by
   cases m <;> unfold IntroMode.Licenses <;> infer_instance
 
 /-! ### Applicative denotations -/
@@ -120,24 +120,24 @@ instance (m : IntroMode) :
 /-- High applicative / Voice denotation: introduce a participant related to the
 EVENT, via Event Identification. Total over any VP predicate — so it composes
 with unergatives. -/
-def applToEvent (rel : ThematicRel Entity Time) (vp : Event Time → Prop) :
-    ThematicRel Entity Time :=
+def applToEvent (rel : ThematicRel Entity T) (vp : Event T → Prop) :
+    ThematicRel Entity T :=
   eventIdentification rel vp
 
 /-- Low applicative denotation: relate the applied argument to the THEME of a
 transitive verb via a transfer relation. Requires the verb's internal theme
-function `ThematicRel Entity Time` (type ⟨e,⟨s,t⟩⟩) — an unergative or Kimian
+function `ThematicRel Entity T` (type ⟨e,⟨s,t⟩⟩) — an unergative or Kimian
 state cannot supply it. -/
-def applToTheme (themeRel : ThematicRel Entity Time)
-    (transfer : Entity → Entity → Prop) (verb : ThematicRel Entity Time)
-    (theme applied : Entity) : Event Time → Prop :=
+def applToTheme (themeRel : ThematicRel Entity T)
+    (transfer : Entity → Entity → Prop) (verb : ThematicRel Entity T)
+    (theme applied : Entity) : Event T → Prop :=
   fun e => verb theme e ∧ themeRel theme e ∧ transfer theme applied
 
 /-- Any low-applicative denotation entails the theme bears the theme relation —
 the theme conjunct is present by construction. -/
-theorem applToTheme_entails_theme (themeRel : ThematicRel Entity Time)
-    (transfer : Entity → Entity → Prop) (verb : ThematicRel Entity Time)
-    (theme applied : Entity) (e : Event Time)
+theorem applToTheme_entails_theme (themeRel : ThematicRel Entity T)
+    (transfer : Entity → Entity → Prop) (verb : ThematicRel Entity T)
+    (theme applied : Entity) (e : Event T)
     (h : applToTheme themeRel transfer verb theme applied e) : themeRel theme e :=
   h.2.1
 
@@ -145,25 +145,25 @@ theorem applToTheme_entails_theme (themeRel : ThematicRel Entity Time)
 
 /-- High introduction licenses any verb, including unergatives (Luganda/Venda/
 Albanian high applicatives over unergatives, [pylkkanen-2008] §2.1.2). -/
-theorem toEvent_licenses_all (vd : VerbDenot Entity Time) :
+theorem toEvent_licenses_all (vd : VerbDenot Entity T) :
     IntroMode.toEvent.Licenses vd := trivial
 
 /-- Diagnostic 1: low (theme-relating) introduction is blocked over an
 unergative — it has no event-internal theme. Derived from the valence type,
 not stipulated. -/
-theorem toTheme_blocks_unergative (body : Event Time → Prop) :
+theorem toTheme_blocks_unergative (body : Event T → Prop) :
     ¬ IntroMode.toTheme.Licenses (VerbDenot.unergative (Entity := Entity) body) :=
   id
 
 /-- Diagnostic 2: low introduction is blocked over a Kimian stative — distinct
 reason from Diagnostic 1: no event argument at all ([moltmann-2025]). -/
 theorem toTheme_blocks_kimian (rel : Entity → Entity → Prop) :
-    ¬ IntroMode.toTheme.Licenses (VerbDenot.kimianStative (Time := Time) rel) :=
+    ¬ IntroMode.toTheme.Licenses (VerbDenot.kimianStative (T := T) rel) :=
   id
 
 /-- Low introduction is licensed over a Davidsonian transitive (English DOC,
 Hebrew possessor datives). -/
-theorem toTheme_licenses_transitive (themeRel body : ThematicRel Entity Time) :
+theorem toTheme_licenses_transitive (themeRel body : ThematicRel Entity T) :
     IntroMode.toTheme.Licenses (VerbDenot.transitive themeRel body) := trivial
 
 /-- [pylkkanen-2008]'s eq. 103, as a theorem about the denotations:
@@ -172,9 +172,9 @@ argument's theme relation to the external argument, yielding `agentRel x e ∧
 themeRel x e` for one participant — contradictory under thematic uniqueness.
 The transitivity restriction is thus *derived*, not stipulated. -/
 theorem low_external_arg_clash
-    (agentRel themeRel : ThematicRel Entity Time)
+    (agentRel themeRel : ThematicRel Entity T)
     (excl : RolesExclusive agentRel themeRel)
-    (x : Entity) (e : Event Time)
+    (x : Entity) (e : Event T)
     (hAgent : agentRel x e) (hTheme : themeRel x e) : False :=
   excl x e hAgent hTheme
 
@@ -182,22 +182,22 @@ theorem low_external_arg_clash
 
 /-- Bieventive Cause: the causative head relates the described event to a
 causing event, introducing NO individual. `λf.λe. ∃e'. f e' ∧ cause e e'`. -/
-def causeBieventive (cause : Event Time → Event Time → Prop) (caused : Event Time → Prop) :
-    Event Time → Prop :=
+def causeBieventive (cause : Event T → Event T → Prop) (caused : Event T → Prop) :
+    Event T → Prop :=
   fun e => ∃ e', caused e' ∧ cause e e'
 
 /-- The θ-role analysis [pylkkanen-2008] argues against: Cause introduces a
 causer individual. `λx.λe. causer x e ∧ ∃e'. f e' ∧ cause e e'`. -/
-def causeThetaRole (cause : Event Time → Event Time → Prop)
-    (causer : ThematicRel Entity Time) (caused : Event Time → Prop) :
-    ThematicRel Entity Time :=
+def causeThetaRole (cause : Event T → Event T → Prop)
+    (causer : ThematicRel Entity T) (caused : Event T → Prop) :
+    ThematicRel Entity T :=
   fun x e => causer x e ∧ ∃ e', caused e' ∧ cause e e'
 
 /-- The θ-role analysis forces an external (causer) participant: its denotation
 entails `causer x e`. -/
-theorem causeThetaRole_forces_causer (cause : Event Time → Event Time → Prop)
-    (causer : ThematicRel Entity Time) (caused : Event Time → Prop)
-    (x : Entity) (e : Event Time)
+theorem causeThetaRole_forces_causer (cause : Event T → Event T → Prop)
+    (causer : ThematicRel Entity T) (caused : Event T → Prop)
+    (x : Entity) (e : Event T)
     (h : causeThetaRole cause causer caused x e) : causer x e :=
   h.1
 
@@ -206,8 +206,8 @@ participant: given only a causing relation to some caused event,
 `causeBieventive` holds without any causer. This is the Japanese adversity
 causative ([pylkkanen-2008] §3.2.2) the θ-role analysis cannot model. -/
 theorem causeBieventive_no_external_arg
-    (cause : Event Time → Event Time → Prop) (caused : Event Time → Prop)
-    (e e' : Event Time) (hc : caused e') (hcause : cause e e') :
+    (cause : Event T → Event T → Prop) (caused : Event T → Prop)
+    (e e' : Event T) (hc : caused e') (hcause : cause e e') :
     causeBieventive cause caused e :=
   ⟨e', hc, hcause⟩
 

--- a/Linglib/Semantics/ArgumentStructure/Thematic/Basic.lean
+++ b/Linglib/Semantics/ArgumentStructure/Thematic/Basic.lean
@@ -37,26 +37,26 @@ open Modifier (intersective intersective_apply)
     - `holder_selects_state`: holders only participate in states
     - `agent_unique`: each event has at most one agent
     - `patient_unique`: each event has at most one patient -/
-class ThematicAxioms (Entity Time : Type*) [LinearOrder Time]
-    (frame : ThematicFrame Entity Time) where
+class ThematicAxioms (Entity T : Type*) [LinearOrder T]
+    (frame : ThematicFrame Entity T) where
   /-- Agents only participate in actions (dynamic events). -/
-  agent_selects_action : ∀ (x : Entity) (e : Event Time),
+  agent_selects_action : ∀ (x : Entity) (e : Event T),
     frame.agent x e → e.sort = .dynamic
   /-- Holders only participate in states. -/
-  holder_selects_state : ∀ (x : Entity) (e : Event Time),
+  holder_selects_state : ∀ (x : Entity) (e : Event T),
     frame.holder x e → e.sort = .stative
   /-- Each event has at most one agent. -/
-  agent_unique : ∀ (x y : Entity) (e : Event Time),
+  agent_unique : ∀ (x y : Entity) (e : Event T),
     frame.agent x e → frame.agent y e → x = y
   /-- Each event has at most one patient. -/
-  patient_unique : ∀ (x y : Entity) (e : Event Time),
+  patient_unique : ∀ (x y : Entity) (e : Event T),
     frame.patient x e → frame.patient y e → x = y
 
 /-- Agent and holder cannot both hold of the same entity and event,
     since agents require actions and holders require states. -/
-theorem agent_holder_disjoint {Entity Time : Type*} [LinearOrder Time]
-    {frame : ThematicFrame Entity Time} [ax : ThematicAxioms Entity Time frame]
-    (x : Entity) (e : Event Time) :
+theorem agent_holder_disjoint {Entity T : Type*} [LinearOrder T]
+    {frame : ThematicFrame Entity T} [ax : ThematicAxioms Entity T frame]
+    (x : Entity) (e : Event T) :
     frame.agent x e → frame.holder x e → False := by
   intro hAgent hHolder
   have hAction := ax.agent_selects_action x e hAgent
@@ -67,7 +67,7 @@ theorem agent_holder_disjoint {Entity Time : Type*} [LinearOrder Time]
 /-! ### Adverbial modification (Davidson's key payoff) -/
 
 /-- An event modifier: a predicate on events (e.g., "quickly", "in the park"). -/
-abbrev EventModifier (Time : Type*) [LinearOrder Time] := Event Time → Prop
+abbrev EventModifier (T : Type*) [LinearOrder T] := Event T → Prop
 
 /-- Apply a modifier to an event predicate via conjunction.
     [davidson-1967]: adverbial modification is conjunction of event
@@ -76,13 +76,13 @@ abbrev EventModifier (Time : Type*) [LinearOrder Time] := Event Time → Prop
 
     Davidson's adverbial modification is the intersective modifier
     (`Semantics.Modification.intersective`) at event-predicate type. -/
-def modify {Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (M : EventModifier Time) : Event Time → Prop :=
+def modify {T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (M : EventModifier T) : Event T → Prop :=
   intersective P M
 
 /-- Modification is commutative: "quickly and loudly" = "loudly and quickly". -/
-theorem modify_comm {Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (M₁ M₂ : EventModifier Time) :
+theorem modify_comm {T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (M₁ M₂ : EventModifier T) :
     modify (modify P M₁) M₂ = modify (modify P M₂) M₁ := by
   funext e
   simp only [modify, intersective_apply]
@@ -90,8 +90,8 @@ theorem modify_comm {Time : Type*} [LinearOrder Time]
                 λ ⟨⟨hp, hm2⟩, hm1⟩ => ⟨⟨hp, hm1⟩, hm2⟩⟩
 
 /-- Modification is associative. -/
-theorem modify_assoc {Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (M₁ M₂ : EventModifier Time) :
+theorem modify_assoc {T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (M₁ M₂ : EventModifier T) :
     modify (modify P M₁) M₂ = modify P (λ e => M₁ e ∧ M₂ e) := by
   funext e
   simp only [modify, intersective_apply]
@@ -103,24 +103,24 @@ theorem modify_assoc {Time : Type*} [LinearOrder Time]
 /-- "x is happy" ↦ ∃s. P(s) ∧ Holder(x, s). Parallel to
     `intransitiveLogicalForm` but using `holder` instead of `agent`,
     reflecting that states select for holders. -/
-def stativeLogicalForm {Entity Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (frame : ThematicFrame Entity Time)
+def stativeLogicalForm {Entity T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (frame : ThematicFrame Entity T)
     (x : Entity) : Prop :=
-  ∃ s : Event Time, P s ∧ frame.holder x s
+  ∃ s : Event T, P s ∧ frame.holder x s
 
 /-- "x is happy in the morning" ↦ ∃s. P(s) ∧ Holder(x, s) ∧ M(s).
     State modification = event modification applied to states. -/
-def modifiedStativeLogicalForm {Entity Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (frame : ThematicFrame Entity Time)
-    (x : Entity) (M : EventModifier Time) : Prop :=
-  ∃ s : Event Time, P s ∧ frame.holder x s ∧ M s
+def modifiedStativeLogicalForm {Entity T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (frame : ThematicFrame Entity T)
+    (x : Entity) (M : EventModifier T) : Prop :=
+  ∃ s : Event T, P s ∧ frame.holder x s ∧ M s
 
 /-- Modified stative = stative of modified predicate (Predicate Modification):
     state modification is an instance of Davidson's conjunction-based
     event modification. -/
-theorem modified_stative_is_pm {Entity Time : Type*} [LinearOrder Time]
-    (P : Event Time → Prop) (frame : ThematicFrame Entity Time)
-    (x : Entity) (M : EventModifier Time) :
+theorem modified_stative_is_pm {Entity T : Type*} [LinearOrder T]
+    (P : Event T → Prop) (frame : ThematicFrame Entity T)
+    (x : Entity) (M : EventModifier T) :
     modifiedStativeLogicalForm P frame x M ↔
       stativeLogicalForm (modify P M) frame x := by
   simp only [modifiedStativeLogicalForm, stativeLogicalForm, modify, intersective_apply]

--- a/Linglib/Semantics/ArgumentStructure/Thematic/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Thematic/Defs.lean
@@ -10,7 +10,7 @@ types.
 
 ## Main definitions
 
-* `ThematicRel` — the core relation type `Entity → Event Time → Prop`
+* `ThematicRel` — the core relation type `Entity → Event T → Prop`
 * `EventRel` — event-first generalization to non-entity arguments ([rudin-2025b])
 * `ThematicFrame` — a model's assignment of the role relations
 
@@ -25,8 +25,8 @@ namespace ArgumentStructure
 /-- A thematic relation: a two-place predicate relating an entity to an event.
     The core neo-Davidsonian type.
     Agent(j, e) means "j is the agent of event e". -/
-abbrev ThematicRel (Entity Time : Type*) [LinearOrder Time] :=
-  Entity → Event Time → Prop
+abbrev ThematicRel (Entity T : Type*) [LinearOrder T] :=
+  Entity → Event T → Prop
 
 /-- A relation between an event and an argument of arbitrary sort.
     Generalizes `ThematicRel` past the entity-first restriction:
@@ -36,7 +36,7 @@ abbrev ThematicRel (Entity Time : Type*) [LinearOrder Time] :=
     the neo-Davidsonian convention for thematic roles vs. the more
     general event-relation pattern used by content/reenactment relations
     ([rudin-2025b], §4.4–4.7). -/
-abbrev EventRel (Time α : Type*) [LinearOrder Time] := Event Time → α → Prop
+abbrev EventRel (T α : Type*) [LinearOrder T] := Event T → α → Prop
 
 /-- A thematic frame bundles thematic relations for a given model.
 
@@ -44,25 +44,25 @@ abbrev EventRel (Time α : Type*) [LinearOrder Time] := Event Time → α → Pr
     selects for states, not actions. The Fragment-layer `ThetaRole`
     enum does not include `holder` since `VendlerClass` already
     encodes dynamicity. -/
-structure ThematicFrame (Entity Time : Type*) [LinearOrder Time] where
+structure ThematicFrame (Entity T : Type*) [LinearOrder T] where
   /-- Agent: volitional causer -/
-  agent : ThematicRel Entity Time
+  agent : ThematicRel Entity T
   /-- Patient: affected entity -/
-  patient : ThematicRel Entity Time
+  patient : ThematicRel Entity T
   /-- Theme: entity in a state/location -/
-  theme : ThematicRel Entity Time
+  theme : ThematicRel Entity T
   /-- Experiencer: perceiver/cognizer -/
-  experiencer : ThematicRel Entity Time
+  experiencer : ThematicRel Entity T
   /-- Goal: recipient/target -/
-  goal : ThematicRel Entity Time
+  goal : ThematicRel Entity T
   /-- Source: origin -/
-  source : ThematicRel Entity Time
+  source : ThematicRel Entity T
   /-- Instrument: means -/
-  instrument : ThematicRel Entity Time
+  instrument : ThematicRel Entity T
   /-- Stimulus: cause of experience -/
-  stimulus : ThematicRel Entity Time
+  stimulus : ThematicRel Entity T
   /-- Holder: entity in a state. Distinct from Agent: selects for
       states, not actions. -/
-  holder : ThematicRel Entity Time
+  holder : ThematicRel Entity T
 
 end ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
+++ b/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
@@ -67,44 +67,44 @@ of the root's kinds. -/
     templatic primitives a COS verb's denotation is built from. `become`/`cause`/
     `effector` are model primitives here (BKG refine their truth conditions in
     their §1.6); a Study instantiates them. -/
-structure Verb.CosModel (Entity State Time : Type*) [LinearOrder Time] where
+structure Verb.CosModel (Entity State T : Type*) [LinearOrder T] where
   /-- `⟦√V⟧(x,s)` (BKG (22a)): a state `s` of the root's lexical property holds of
       `x` (e.g. `flat'(x,s)`). The root denotes a state predicate. -/
   rootState : Verb → Entity → State → Prop
   /-- `become'(s,e)` (BKG (22b)): event `e` gives rise to state `s`. -/
-  become : State → Event Time → Prop
+  become : State → Event T → Prop
   /-- `cause'(v,e)` (BKG (22c)): event `v` causes event `e`. -/
-  cause : Event Time → Event Time → Prop
+  cause : Event T → Event T → Prop
   /-- `effector'(y,v)` (BKG (22c)): `y` is the effector of event `v`. -/
-  effector : Entity → Event Time → Prop
+  effector : Entity → Event T → Prop
   /-- The bare manner/activity core `⟦√V⟧(e)` of a pure-manner root (no change),
       e.g. `jog`/`run`'s action specification. -/
-  manner : Verb → Event Time → Prop
+  manner : Verb → Event T → Prop
 
 namespace Verb.CosModel
 
-variable {Entity State Time : Type*} [LinearOrder Time]
+variable {Entity State T : Type*} [LinearOrder T]
 
 /-- The inchoative denotation ([beavers-koontz-garboden-2020] (23c)):
     `λxλe. ∃s. become'(s,e) ∧ ⟦√V⟧(x,s)` — an event of change giving rise to a
     state of the root's property holding of the patient `x`. -/
-def inchoative (M : CosModel Entity State Time) (v : Verb) (x : Entity) :
-    Event Time → Prop :=
+def inchoative (M : CosModel Entity State T) (v : Verb) (x : Entity) :
+    Event T → Prop :=
   fun e => ∃ s, M.become s e ∧ M.rootState v x s
 
 /-- The causative denotation ([beavers-koontz-garboden-2020] (24c)): the
     inchoative embedded under an effector and a causing event —
     `λyλxλw. ∃e. effector'(y,w) ∧ cause'(w,e) ∧ inchoative(x)(e)`. -/
-def causative (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
-    Event Time → Prop :=
+def causative (M : CosModel Entity State T) (v : Verb) (y x : Entity) :
+    Event T → Prop :=
   fun w => ∃ e, M.effector y w ∧ M.cause w e ∧ M.inchoative v x e
 
 /-- BKG's first prediction ([beavers-koontz-garboden-2020] p. 16): the causative
     **entails** the inchoative — there is an event satisfying the inchoative,
     "by simple virtue of" the embedding (∃-projection over the caused event).
     Holds by construction, not stipulation. -/
-theorem causative_entails_inchoative (M : CosModel Entity State Time)
-    (v : Verb) (y x : Entity) (w : Event Time) (h : M.causative v y x w) :
+theorem causative_entails_inchoative (M : CosModel Entity State T)
+    (v : Verb) (y x : Entity) (w : Event T) (h : M.causative v y x w) :
     ∃ e, M.inchoative v x e := by
   obtain ⟨e, _, _, hinch⟩ := h
   exact ⟨e, hinch⟩
@@ -113,14 +113,14 @@ theorem causative_entails_inchoative (M : CosModel Entity State Time)
     state of the root's property — `∃s. become'(s,e) ∧ ⟦√V⟧(x,s)`. The
     non-cancelable result of a change-of-state root (the *break* vs *hit*
     contrast, [beavers-koontz-garboden-2020] (6)); definitional, hence immediate. -/
-theorem inchoative_entails_resultState (M : CosModel Entity State Time)
-    (v : Verb) (x : Entity) (e : Event Time) (h : M.inchoative v x e) :
+theorem inchoative_entails_resultState (M : CosModel Entity State T)
+    (v : Verb) (x : Entity) (e : Event T) (h : M.inchoative v x e) :
     ∃ s, M.become s e ∧ M.rootState v x s := h
 
 /-- Composing the two predictions: a caused change reaches the root state —
     the causative entails the full result-state condition. -/
-theorem causative_entails_resultState (M : CosModel Entity State Time)
-    (v : Verb) (y x : Entity) (w : Event Time) (h : M.causative v y x w) :
+theorem causative_entails_resultState (M : CosModel Entity State T)
+    (v : Verb) (y x : Entity) (w : Event T) (h : M.causative v y x w) :
     ∃ e s, M.become s e ∧ M.rootState v x s := by
   obtain ⟨e, hinch⟩ := M.causative_entails_inchoative v y x w h
   exact ⟨e, hinch⟩
@@ -129,8 +129,8 @@ theorem causative_entails_resultState (M : CosModel Entity State Time)
     `kinds` (cf. [beavers-koontz-garboden-2020] (18)–(19)): `.cause` →
     causative, else `.result` → inchoative, else the bare manner core. The root's
     kinds *select the event template* — the denotational payoff of the signature. -/
-def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
-    Event Time → Prop :=
+def denote (M : CosModel Entity State T) (v : Verb) (y x : Entity) :
+    Event T → Prop :=
   if LexKind.cause ∈ v.closedKinds then M.causative v y x
   else if LexKind.result ∈ v.closedKinds then M.inchoative v x
   else M.manner v
@@ -141,8 +141,8 @@ def denote (M : CosModel Entity State Time) (v : Verb) (y x : Entity) :
     [beavers-koontz-garboden-2020] non-cancelable result, *derived from the
     signature* rather than stipulated (and absent for a pure-manner root, whose
     `denote` is the manner core). -/
-theorem denote_result_entails_resultState (M : CosModel Entity State Time)
-    (v : Verb) (y x : Entity) (e : Event Time)
+theorem denote_result_entails_resultState (M : CosModel Entity State T)
+    (v : Verb) (y x : Entity) (e : Event T)
     (hres : LexKind.result ∈ v.closedKinds)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   unfold denote at h
@@ -157,8 +157,8 @@ theorem denote_result_entails_resultState (M : CosModel Entity State Time)
     entailing that result state — `denote_result_entails_resultState` and
     `Template.HasResultState` are one fact, through the closed kind signature
     ([beavers-koontz-garboden-2020]; [rappaport-hovav-levin-1998]). -/
-theorem denote_result_from_template (M : CosModel Entity State Time)
-    (v : Verb) (ht : v.root.template.HasResultState) (y x : Entity) (e : Event Time)
+theorem denote_result_from_template (M : CosModel Entity State T)
+    (v : Verb) (ht : v.root.template.HasResultState) (y x : Entity) (e : Event T)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   refine M.denote_result_entails_resultState v y x e ?_ h
   show LexKind.result ∈ v.root.closedKinds

--- a/Linglib/Semantics/Aspect/Basic.lean
+++ b/Linglib/Semantics/Aspect/Basic.lean
@@ -17,7 +17,7 @@ following [knick-sharf-2026].
 ## Compositional Architecture
 
 ```
-Event Time → Prop ──[IMPF/PRFV]──▷ IntervalPred ──[PERF]──▷ PointPred ──[TENSE]──▷ Prop
+Event T → Prop ──[IMPF/PRFV]──▷ IntervalPred ──[PERF]──▷ PointPred ──[TENSE]──▷ Prop
 ```
 
 Equations (verified against the [knick-sharf-2026] proceedings PDF):
@@ -66,18 +66,18 @@ open Features
 
 /-! Event predicates and the `Event` type are imported from
     `Semantics/Events/Basic.lean` — the unified event ontology.
-    Tense-aspect code uses `Event Time` and `W → Event Time → Prop` without
+    Tense-aspect code uses `Event T` and `W → Event T → Prop` without
     referencing `.sort` (the field exists for Krifka-style consumers but
     is irrelevant for Klein-style tense composition). -/
 
 /-- Predicate over time intervals (output of IMPF/PRFV). -/
-abbrev IntervalPred (W Time : Type*) [LinearOrder Time] := W → NonemptyInterval Time → Prop
+abbrev IntervalPred (W T : Type*) [LinearOrder T] := W → NonemptyInterval T → Prop
 
 /-- Predicate over time points (output of PERF, input to TENSE).
-    Defined as `Index W Time → Prop` to make the situation structure
+    Defined as `Index W T → Prop` to make the situation structure
     explicit in the tense-aspect pipeline, connecting directly to
     situation semantics (Elbourne, Percus, Kratzer). -/
-abbrev PointPred (W Time : Type*) := Index W Time → Prop
+abbrev PointPred (W T : Type*) := Index W T → Prop
 
 -- ════════════════════════════════════════════════════
 -- § Klein's Viewpoint Classification
@@ -95,7 +95,7 @@ inductive ViewpointType where
   deriving DecidableEq, Repr, Inhabited
 
 /-- The perfective / imperfective opposition — viewpoint aspect at its
-    coarsest, without the interval-based `Event Time → Prop`/`IntervalPred`
+    coarsest, without the interval-based `Event T → Prop`/`IntervalPred`
     machinery of Klein's full classification (`ViewpointType`). The right
     granularity where the key fact is simply "perfective requires
     actualization, imperfective doesn't", or where the opposition is
@@ -122,8 +122,8 @@ theorem toPerfectivity_toKleinViewpoint (a : Perfectivity) :
     a.toKleinViewpoint.toPerfectivity = some a := by cases a <;> rfl
 
 /-- The TT↔TSit interval relation for each viewpoint ([klein-1994]: 108). -/
-def ViewpointType.ttTSitRelation {Time : Type*} [LinearOrder Time]
-    (v : ViewpointType) (tt tsit : NonemptyInterval Time) : Prop :=
+def ViewpointType.ttTSitRelation {T : Type*} [LinearOrder T]
+    (v : ViewpointType) (tt tsit : NonemptyInterval T) : Prop :=
   match v with
   | .imperfective => tt < tsit
   | .perfective   => tsit ≤ tt
@@ -131,7 +131,7 @@ def ViewpointType.ttTSitRelation {Time : Type*} [LinearOrder Time]
   | .prospective  => tt.isBefore tsit
   | .neutral      => tt.initialOverlap tsit
 
-instance {Time : Type*} [LinearOrder Time] (v : ViewpointType) (tt tsit : NonemptyInterval Time) :
+instance {T : Type*} [LinearOrder T] (v : ViewpointType) (tt tsit : NonemptyInterval T) :
     Decidable (v.ttTSitRelation tt tsit) := by
   cases v <;> unfold ViewpointType.ttTSitRelation <;> infer_instance
 
@@ -149,25 +149,25 @@ iff theorems, not as a stipulated lookup. -/
 /-- The viewpoint asserts the situation's initial point: every licensed
     (`tt`, `tsit`) pair has `tt` containing `tsit.fst`. -/
 def ViewpointType.ShowsInitialPoint (v : ViewpointType) : Prop :=
-  ∀ {Time : Type} [LinearOrder Time] {tt tsit : NonemptyInterval Time},
+  ∀ {T : Type} [LinearOrder T] {tt tsit : NonemptyInterval T},
     v.ttTSitRelation tt tsit → tsit.fst ∈ tt
 
 /-- The viewpoint asserts the situation's final point. -/
 def ViewpointType.ShowsFinalPoint (v : ViewpointType) : Prop :=
-  ∀ {Time : Type} [LinearOrder Time] {tt tsit : NonemptyInterval Time},
+  ∀ {T : Type} [LinearOrder T] {tt tsit : NonemptyInterval T},
     v.ttTSitRelation tt tsit → tsit.snd ∈ tt
 
 /-- The viewpoint presents the situation as informationally closed: the
     topic time reaches at least the situation time's right endpoint. -/
 def ViewpointType.IsClosed (v : ViewpointType) : Prop :=
-  ∀ {Time : Type} [LinearOrder Time] {tt tsit : NonemptyInterval Time},
+  ∀ {T : Type} [LinearOrder T] {tt tsit : NonemptyInterval T},
     v.ttTSitRelation tt tsit → tsit.snd ≤ tt.snd
 
 /-- The viewpoint focuses a topic time strictly inside the situation, the
     structural source of the imperfective's "preliminary stages" reading
     for punctual events ([smith-1997] §4.2.2). -/
 def ViewpointType.FocusesPreliminaryStages (v : ViewpointType) : Prop :=
-  ∀ {Time : Type} [LinearOrder Time] {tt tsit : NonemptyInterval Time},
+  ∀ {T : Type} [LinearOrder T] {tt tsit : NonemptyInterval T},
     v.ttTSitRelation tt tsit → tt < tsit
 
 namespace ViewpointType
@@ -317,23 +317,23 @@ end ViewpointType
 -- § Aspect Operators
 -- ════════════════════════════════════════════════════
 
-variable {Time : Type*} [LinearOrder Time] {W : Type*}
+variable {T : Type*} [LinearOrder T] {W : Type*}
 
 /-- **IMPERFECTIVE**: reference time properly contained in event runtime.
     [klein-1994]: TT INCL TSit. [knick-sharf-2026] eq. 25. -/
-def IMPF (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, t < e.τ ∧ P w e
+def IMPF (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, t < e.τ ∧ P w e
 
 /-- **PERFECTIVE**: event runtime contained in reference time.
     [klein-1994]: TT AT TSit (simplified to TSit ⊆ TT, following [smith-1997]).
     [knick-sharf-2026] eq. 28. -/
-def PRFV (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, e.τ ≤ t ∧ P w e
+def PRFV (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, e.τ ≤ t ∧ P w e
 
 /-- **PROSPECTIVE**: reference time before situation time.
     [klein-1994]: TT BEFORE TSit. -/
-def PROSP (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, t.isBefore e.τ ∧ P w e
+def PROSP (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, t.isBefore e.τ ∧ P w e
 
 /-- **INIT_OVERLAP**: initial overlap between reference time and event runtime.
     [pancheva-2003] eq. 7b: ⟦NEUTRAL⟧ = λP.λi.∃e[i ∂τ(e) & P(e)]
@@ -344,8 +344,8 @@ def PROSP (P : W → Event Time → Prop) : IntervalPred W Time :=
     neutral viewpoint (`ViewpointType.neutral`), which is a different concept.
     Pancheva's operator is an inner Asp₂ head; Smith's neutral viewpoint is
     a default viewpoint type. -/
-def INIT_OVERLAP (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, t.initialOverlap e.τ ∧ P w e
+def INIT_OVERLAP (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, t.initialOverlap e.τ ∧ P w e
 
 
 -- ════════════════════════════════════════════════════
@@ -353,10 +353,10 @@ def INIT_OVERLAP (P : W → Event Time → Prop) : IntervalPred W Time :=
 -- ════════════════════════════════════════════════════
 
 /-- Right Boundary: PTS finishes at reference time point t. -/
-def RB (pts : NonemptyInterval Time) (t : Time) : Prop := pts.snd = t
+def RB (pts : NonemptyInterval T) (t : T) : Prop := pts.snd = t
 
 /-- Left Boundary: PTS starts at time tLB. -/
-def LB (tLB : Time) (pts : NonemptyInterval Time) : Prop := pts.fst = tLB
+def LB (tLB : T) (pts : NonemptyInterval T) : Prop := pts.fst = tLB
 
 /-- **PERFECT**: introduces Perfect Time Span.
     [knick-sharf-2026] eq. 22b — the standard XN-theoretic entry
@@ -368,8 +368,8 @@ def LB (tLB : Time) (pts : NonemptyInterval Time) : Prop := pts.fst = tLB
     below PERF (paper §4.2.1, sentence after eq. 25). The implementation
     here applies p to `pts` directly (the post-composition meaning), which
     matches K&S's worked composition in their (26). -/
-def PERF (p : IntervalPred W Time) : PointPred W Time :=
-  λ s => ∃ pts : NonemptyInterval Time, RB pts s.time ∧ p s.world pts
+def PERF (p : IntervalPred W T) : PointPred W T :=
+  λ s => ∃ pts : NonemptyInterval T, RB pts s.time ∧ p s.world pts
 
 /-- **PERFECT with Extended Now** (K&S's revision: domain-restricted left
     boundary). [knick-sharf-2026] eq. 23b. Verified against the
@@ -387,13 +387,13 @@ def PERF (p : IntervalPred W Time) : PointPred W Time :=
 
     Type-level simplification: K&S's `t_LB` is an *initial subinterval* of
     t_PTS (per their 23a), and `t_LB ⊆ t_r` compares two interval-sets.
-    The implementation here uses `tLB : Time` (a single point) with
+    The implementation here uses `tLB : T` (a single point) with
     `∃ tLB ∈ tᵣ` (membership), simplifying K&S's set-theoretic LB to a
     single time witness inside the domain-restriction set. The simpler
     typing is sufficient for the empirical predictions K&S draw and
     avoids carrying intervals at every level. -/
-def PERF_XN (p : IntervalPred W Time) (tᵣ : Set Time) : PointPred W Time :=
-  λ s => ∃ pts : NonemptyInterval Time, ∃ tLB ∈ tᵣ,
+def PERF_XN (p : IntervalPred W T) (tᵣ : Set T) : PointPred W T :=
+  λ s => ∃ pts : NonemptyInterval T, ∃ tLB ∈ tᵣ,
     LB tLB pts ∧ RB pts s.time ∧ p s.world pts
 
 -- ════════════════════════════════════════════════════
@@ -401,12 +401,12 @@ def PERF_XN (p : IntervalPred W Time) (tᵣ : Set Time) : PointPred W Time :=
 -- ════════════════════════════════════════════════════
 
 /-- IMPF matches Klein's IMPERFECTIVE: ∃e where TT ⊂ TSit. -/
-theorem impf_is_klein_imperfective (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem impf_is_klein_imperfective (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     IMPF P w t ↔ ∃ e, ViewpointType.ttTSitRelation .imperfective t e.τ ∧ P w e := by
   simp only [IMPF, ViewpointType.ttTSitRelation, Event.τ]
 
 /-- PRFV matches Klein's PERFECTIVE: ∃e where TSit ⊆ TT. -/
-theorem prfv_is_klein_perfective (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem prfv_is_klein_perfective (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     PRFV P w t ↔ ∃ e, ViewpointType.ttTSitRelation .perfective t e.τ ∧ P w e := by
   simp only [PRFV, ViewpointType.ttTSitRelation, Event.τ]
 
@@ -415,18 +415,18 @@ theorem prfv_is_klein_perfective (P : W → Event Time → Prop) (w : W) (t : No
 -- ════════════════════════════════════════════════════
 
 /-- "has been V-ing" = PERF(IMPF(V)). -/
-abbrev perfProg (P : W → Event Time → Prop) : PointPred W Time :=
+abbrev perfProg (P : W → Event T → Prop) : PointPred W T :=
   PERF (IMPF P)
 
 /-- "has V-ed" = PERF(PRFV(V)). -/
-abbrev perfSimple (P : W → Event Time → Prop) : PointPred W Time :=
+abbrev perfSimple (P : W → Event T → Prop) : PointPred W T :=
   PERF (PRFV P)
 
 /-- PERF(IMPF(P)) unfolds: ∃ PTS and event, with PTS right-bounded at t,
     the PTS properly inside the event, and P holds of the event. -/
-theorem perf_impf_unfold (P : W → Event Time → Prop) (w : W) (t : Time) :
+theorem perf_impf_unfold (P : W → Event T → Prop) (w : W) (t : T) :
     perfProg P ⟨w, t⟩ ↔
-    ∃ pts : NonemptyInterval Time, ∃ e : Event Time,
+    ∃ pts : NonemptyInterval T, ∃ e : Event T,
       RB pts t ∧ pts < e.τ ∧ P w e := by
   constructor
   · intro ⟨pts, hRB, e, hSub, hP⟩
@@ -436,9 +436,9 @@ theorem perf_impf_unfold (P : W → Event Time → Prop) (w : W) (t : Time) :
 
 /-- PERF(PRFV(P)) unfolds: ∃ PTS and event, with PTS right-bounded at t,
     the event inside the PTS, and P holds of the event. -/
-theorem perf_prfv_unfold (P : W → Event Time → Prop) (w : W) (t : Time) :
+theorem perf_prfv_unfold (P : W → Event T → Prop) (w : W) (t : T) :
     perfSimple P ⟨w, t⟩ ↔
-    ∃ pts : NonemptyInterval Time, ∃ e : Event Time,
+    ∃ pts : NonemptyInterval T, ∃ e : Event T,
       RB pts t ∧ e.τ ≤ pts ∧ P w e := by
   constructor
   · intro ⟨pts, hRB, e, hSub, hP⟩
@@ -451,14 +451,14 @@ theorem perf_prfv_unfold (P : W → Event Time → Prop) (w : W) (t : Time) :
 -- ════════════════════════════════════════════════════
 
 /-- Extended Now entails basic perfect (PERF_XN is stronger). -/
-theorem perf_xn_entails_perf (p : IntervalPred W Time) (tᵣ : Set Time)
-    (w : W) (t : Time) :
+theorem perf_xn_entails_perf (p : IntervalPred W T) (tᵣ : Set T)
+    (w : W) (t : T) :
     PERF_XN p tᵣ ⟨w, t⟩ → PERF p ⟨w, t⟩ := by
   intro ⟨pts, _tLB, _hmem, _hLB, hRB, hp⟩
   exact ⟨pts, hRB, hp⟩
 
 /-- With maximal domain (Set.univ), PERF_XN collapses to PERF. -/
-theorem perf_xn_univ_iff_perf (p : IntervalPred W Time) (w : W) (t : Time) :
+theorem perf_xn_univ_iff_perf (p : IntervalPred W T) (w : W) (t : T) :
     PERF_XN p Set.univ ⟨w, t⟩ ↔ PERF p ⟨w, t⟩ := by
   constructor
   · exact perf_xn_entails_perf p Set.univ w t
@@ -466,8 +466,8 @@ theorem perf_xn_univ_iff_perf (p : IntervalPred W Time) (w : W) (t : Time) :
     exact ⟨pts, pts.fst, Set.mem_univ _, rfl, hRB, hp⟩
 
 /-- Narrower domain restriction is stronger (monotone in tᵣ). -/
-theorem perf_xn_monotone (p : IntervalPred W Time) (tᵣ₁ tᵣ₂ : Set Time)
-    (hSub : tᵣ₁ ⊆ tᵣ₂) (w : W) (t : Time) :
+theorem perf_xn_monotone (p : IntervalPred W T) (tᵣ₁ tᵣ₂ : Set T)
+    (hSub : tᵣ₁ ⊆ tᵣ₂) (w : W) (t : T) :
     PERF_XN p tᵣ₁ ⟨w, t⟩ → PERF_XN p tᵣ₂ ⟨w, t⟩ := by
   intro ⟨pts, tLB, hmem, hLB, hRB, hp⟩
   exact ⟨pts, tLB, hSub hmem, hLB, hRB, hp⟩
@@ -477,24 +477,24 @@ theorem perf_xn_monotone (p : IntervalPred W Time) (tᵣ₁ tᵣ₂ : Set Time)
 -- ════════════════════════════════════════════════════
 
 /-- IMPF entails an event exists. -/
-theorem impf_entails_event (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem impf_entails_event (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     IMPF P w t → ∃ e, P w e :=
   λ ⟨e, _, hP⟩ => ⟨e, hP⟩
 
 /-- PRFV entails an event exists. -/
-theorem prfv_entails_event (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem prfv_entails_event (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     PRFV P w t → ∃ e, P w e :=
   λ ⟨e, _, hP⟩ => ⟨e, hP⟩
 
 /-- PERF is monotone: p ⊆ q → PERF(p) ⊆ PERF(q). -/
-theorem perf_monotone (p q : IntervalPred W Time)
-    (h : ∀ w t, p w t → q w t) (w : W) (t : Time) :
+theorem perf_monotone (p q : IntervalPred W T)
+    (h : ∀ w t, p w t → q w t) (w : W) (t : T) :
     PERF p ⟨w, t⟩ → PERF q ⟨w, t⟩ :=
   λ ⟨pts, hRB, hp⟩ => ⟨pts, hRB, h w pts hp⟩
 
 /-- IMPF and PRFV impose opposite containment directions.
     IMPF: reference ⊂ event runtime. PRFV: event runtime ⊆ reference. -/
-theorem impf_prfv_opposite_containment (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem impf_prfv_opposite_containment (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     (IMPF P w t → ∃ e, P w e ∧ t < e.τ) ∧
     (PRFV P w t → ∃ e, P w e ∧ e.τ ≤ t) :=
   ⟨λ ⟨e, hSub, hP⟩ => ⟨e, hP, hSub⟩,
@@ -513,34 +513,34 @@ theorem impf_prfv_opposite_containment (P : W → Event Time → Prop) (w : W) (
 /-- Pancheva's UNBOUNDED (Asp₂): non-strict ⊆ variant of IMPF.
     ⟦UNBOUNDED⟧ = λP.λi.∃e[i ⊆ τ(e) & P(e)] ([pancheva-2003]: 282, eq. 7b).
     Differs from IMPF in using non-strict ⊆ rather than strict ⊂. -/
-def UNBOUNDED (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, t ≤ e.τ ∧ P w e
+def UNBOUNDED (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, t ≤ e.τ ∧ P w e
 
 /-- Pancheva's BOUNDED (Asp₂): strict ⊂ variant of PRFV.
     ⟦BOUNDED⟧ = λP.λi.∃e[τ(e) ⊂ i & P(e)] ([pancheva-2003]: 282, eq. 7b).
     Differs from PRFV in using strict ⊂ rather than non-strict ⊆. -/
-def BOUNDED (P : W → Event Time → Prop) : IntervalPred W Time :=
-  λ w t => ∃ e : Event Time, e.τ < t ∧ P w e
+def BOUNDED (P : W → Event T → Prop) : IntervalPred W T :=
+  λ w t => ∃ e : Event T, e.τ < t ∧ P w e
 
 /-- IMPF (strict ⊂) entails UNBOUNDED (non-strict ⊆). -/
-theorem impf_entails_unbounded (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem impf_entails_unbounded (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     IMPF P w t → UNBOUNDED P w t :=
   λ ⟨e, hSub, hP⟩ => ⟨e, hSub.1, hP⟩
 
 /-- BOUNDED (strict ⊂) entails PRFV (non-strict ⊆). -/
-theorem bounded_entails_prfv (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+theorem bounded_entails_prfv (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     BOUNDED P w t → PRFV P w t :=
   λ ⟨e, hSub, hP⟩ => ⟨e, hSub.1, hP⟩
 
 /-- Pancheva-style interval-level PERFECT (Asp₁).
     ⟦PERFECT⟧ = λp.λi.∃i'[PTS(i', i) & p(i')] ([pancheva-2003]: 284, eq. 9b).
     PTS(i', i) iff i is a final subinterval of i': i ⊆ i' ∧ i.snd = i'.snd. -/
-def PERF_P (p : IntervalPred W Time) : IntervalPred W Time :=
-  λ w i => ∃ pts : NonemptyInterval Time, i.finalSubinterval pts ∧ p w pts
+def PERF_P (p : IntervalPred W T) : IntervalPred W T :=
+  λ w i => ∃ pts : NonemptyInterval T, i.finalSubinterval pts ∧ p w pts
 
 /-- Point-based PERF is the special case of interval-based PERF_P
     where the reference interval degenerates to a point [t, t]. -/
-theorem perf_p_at_point_iff_perf (p : IntervalPred W Time) (w : W) (t : Time) :
+theorem perf_p_at_point_iff_perf (p : IntervalPred W T) (w : W) (t : T) :
     PERF_P p w (NonemptyInterval.pure t) ↔ PERF p ⟨w, t⟩ := by
   constructor
   · intro ⟨pts, hFin, hp⟩
@@ -549,8 +549,8 @@ theorem perf_p_at_point_iff_perf (p : IntervalPred W Time) (w : W) (t : Time) :
     exact ⟨pts, ⟨⟨le_trans pts.fst_le_snd (le_of_eq hRB), le_of_eq hRB.symm⟩, hRB.symm⟩, hp⟩
 
 /-- PERF_P is monotone: if p entails q, then PERF_P(p) entails PERF_P(q). -/
-theorem perf_p_monotone (p q : IntervalPred W Time)
-    (h : ∀ w t, p w t → q w t) (w : W) (i : NonemptyInterval Time) :
+theorem perf_p_monotone (p q : IntervalPred W T)
+    (h : ∀ w t, p w t → q w t) (w : W) (i : NonemptyInterval T) :
     PERF_P p w i → PERF_P q w i :=
   λ ⟨pts, hFin, hp⟩ => ⟨pts, hFin, h w pts hp⟩
 
@@ -570,25 +570,25 @@ inductive PerfectType where
 /-- Universal perfect: PERF_P(UNBOUNDED(V)).
     "has been running" — event ongoing throughout PTS.
     [pancheva-2003]: explains why universal reading requires imperfective. -/
-abbrev universalPerfect (P : W → Event Time → Prop) : IntervalPred W Time :=
+abbrev universalPerfect (P : W → Event T → Prop) : IntervalPred W T :=
   PERF_P (UNBOUNDED P)
 
 /-- Experiential perfect: PERF_P(INIT_OVERLAP(V)).
     "has visited Paris" — event began within PTS.
     [pancheva-2003]: initial-overlap aspect allows event to extend beyond PTS. -/
-abbrev experientialPerfect (P : W → Event Time → Prop) : IntervalPred W Time :=
+abbrev experientialPerfect (P : W → Event T → Prop) : IntervalPred W T :=
   PERF_P (INIT_OVERLAP P)
 
 /-- Resultative perfect: PERF_P(BOUNDED(V)).
     "has broken the vase" — event completed within PTS.
     Simplified: properly involves result state ([pancheva-2003]: 288). -/
-abbrev resultativePerfect (P : W → Event Time → Prop) : IntervalPred W Time :=
+abbrev resultativePerfect (P : W → Event T → Prop) : IntervalPred W T :=
   PERF_P (BOUNDED P)
 
 /-- perfProg at a point entails universalPerfect at that point.
     Since IMPF (strict ⊂) entails UNBOUNDED (non-strict ⊆),
     PERF(IMPF(V)) entails PERF(UNBOUNDED(V)) = universalPerfect. -/
-theorem perf_prog_entails_universal_at_point (P : W → Event Time → Prop) (w : W) (t : Time) :
+theorem perf_prog_entails_universal_at_point (P : W → Event T → Prop) (w : W) (t : T) :
     perfProg P ⟨w, t⟩ → universalPerfect P w (NonemptyInterval.pure t) :=
   λ h => (perf_p_at_point_iff_perf (UNBOUNDED P) w t).mpr
     (perf_monotone (IMPF P) (UNBOUNDED P) (impf_entails_unbounded P) w t h)
@@ -599,7 +599,7 @@ theorem perf_prog_entails_universal_at_point (P : W → Event Time → Prop) (w 
 
 /-- Evaluate an interval predicate at a point (trivial interval [t, t]).
     Bridge for non-perfect forms. -/
-def IntervalPred.atPoint (p : IntervalPred W Time) : PointPred W Time :=
+def IntervalPred.atPoint (p : IntervalPred W T) : PointPred W T :=
   λ s => p s.world (NonemptyInterval.pure s.time)
 
 end Aspect

--- a/Linglib/Semantics/Aspect/Stratified.lean
+++ b/Linglib/Semantics/Aspect/Stratified.lean
@@ -130,9 +130,9 @@ def ReferenceUniv {α β : Type*} [SemilatticeSup α]
     partial-order instance via the entity lattice).
 
     For dimensions without a `PartialOrder` instance — notably the
-    runtime dimension (`NonemptyInterval Time`) used by stativity — atomicity
+    runtime dimension (`NonemptyInterval T`) used by stativity — atomicity
     is expressed dimension-natively (e.g., `NonemptyInterval.IsPoint` for
-    `NonemptyInterval Time`). The unification is at the `Reference`
+    `NonemptyInterval T`). The unification is at the `Reference`
     parameter-space level: both express "γ = inner is atomic in the
     dimension's natural sense" at different concrete instantiations. -/
 def AtomicGranularity {β : Type*} [PartialOrder β] : β → β → Prop :=
@@ -210,8 +210,8 @@ theorem relationalDistributiveReference_graph {Entity α : Type*}
 
 /-- Proper-subinterval granularity: inner runtime is a proper subinterval
     of outer runtime. The binary `γ` for subinterval reference. -/
-def SubintervalGranularity {Time : Type*} [LinearOrder Time]
-    (inner outer : NonemptyInterval Time) : Prop :=
+def SubintervalGranularity {T : Type*} [LinearOrder T]
+    (inner outer : NonemptyInterval T) : Prop :=
   inner < outer
 
 /-- Stratified Subinterval Reference: dimension is τ (runtime),
@@ -224,15 +224,15 @@ def SubintervalGranularity {Time : Type*} [LinearOrder Time]
 
     Genuine instance of `Reference` with `d := τ` and
     `γ := SubintervalGranularity`. -/
-def SubintervalReference {Time : Type*} [LinearOrder Time]
-    [SemilatticeSup (Event Time)]
-    (P : Event Time → Prop) (e : Event Time) : Prop :=
-  Reference (λ e' : Event Time => e'.runtime) SubintervalGranularity P e
+def SubintervalReference {T : Type*} [LinearOrder T]
+    [SemilatticeSup (Event T)]
+    (P : Event T → Prop) (e : Event T) : Prop :=
+  Reference (λ e' : Event T => e'.runtime) SubintervalGranularity P e
 
 /-- Universal subinterval reference: every P-event has it. -/
-def SubintervalReferenceUniv {Time : Type*} [LinearOrder Time]
-    [SemilatticeSup (Event Time)]
-    (P : Event Time → Prop) : Prop :=
+def SubintervalReferenceUniv {T : Type*} [LinearOrder T]
+    [SemilatticeSup (Event T)]
+    (P : Event T → Prop) : Prop :=
   ∀ e, P e → SubintervalReference P e
 
 /-! ### Stratified Measurement Reference -/
@@ -290,8 +290,8 @@ abbrev eachConstr {α β : Type*} [SemilatticeSup α] [PartialOrder β]
 /-- "for"-adverbials require subinterval reference: the predicate must
     have stratified subinterval reference (atelicity).
     Map = τ, granularity = proper subinterval. -/
-abbrev forConstr {Time : Type*} [LinearOrder Time] [SemilatticeSup (Event Time)]
-    (Share : Event Time → Prop) (e : Event Time) : Prop :=
+abbrev forConstr {T : Type*} [LinearOrder T] [SemilatticeSup (Event T)]
+    (Share : Event T → Prop) (e : Event T) : Prop :=
   SubintervalReference Share e
 
 /-! ### Key Theorems -/
@@ -379,8 +379,8 @@ theorem reference_join {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
     "John ran for an hour" is felicitous because "run" has it.
     "* John arrived for an hour" is infelicitous because "arrive" lacks it. -/
 theorem forAdverbial_requires_subintervalReference
-    {Time : Type*} [LinearOrder Time] [SemilatticeSup (Event Time)]
-    {P : Event Time → Prop}
+    {T : Type*} [LinearOrder T] [SemilatticeSup (Event T)]
+    {P : Event T → Prop}
     (h_for_ok : SubintervalReferenceUniv P) :
     ∀ e, P e → SubintervalReference P e :=
   h_for_ok
@@ -398,10 +398,10 @@ theorem forAdverbial_requires_subintervalReference
     `P := λe. e.runtime.length ≤ 1` over dense time). See module docstring
     "Relation to Krifka's CUM/QUA". -/
 theorem qua_incompatible_with_subintervalReference
-    {Time : Type*} [LinearOrder Time] [SemilatticeSup (Event Time)]
-    {P : Event Time → Prop}
+    {T : Type*} [LinearOrder T] [SemilatticeSup (Event T)]
+    {P : Event T → Prop}
     (hQua : QUA P)
-    {e : Event Time} (he : P e) (hSub : SubintervalReference P e) :
+    {e : Event T} (he : P e) (hSub : SubintervalReference P e) :
     False := by
   obtain ⟨a, ⟨hPa, hGran⟩, hle⟩ := algClosure_has_base hSub
   have hne : a ≠ e := by
@@ -416,9 +416,9 @@ theorem qua_incompatible_with_subintervalReference
     ([champollion-2017]'s for-adverbial entry, eq. (72), restated for
     *for an hour* as eq. (21); eq. (39) is the constraint on its Share).
     "V for δ" = λe. V(e) ∧ τ(e) = δ ∧ SubintervalReference V e. -/
-def forAdverbialMeaning {Time : Type*} [LinearOrder Time]
-    [SemilatticeSup (Event Time)]
-    (V : Event Time → Prop) (duration : NonemptyInterval Time) (e : Event Time) : Prop :=
+def forAdverbialMeaning {T : Type*} [LinearOrder T]
+    [SemilatticeSup (Event T)]
+    (V : Event T → Prop) (duration : NonemptyInterval T) (e : Event T) : Prop :=
   V e ∧ e.runtime = duration ∧ SubintervalReference V e
 
 /-- "in"-adverbials are incompatible with subinterval reference (they
@@ -426,10 +426,10 @@ def forAdverbialMeaning {Time : Type*} [LinearOrder Time]
     subinterval reference. Any P-event with subinterval reference has a
     strict P-part, contradicting QUA. -/
 theorem in_adverbial_incompatible_with_subintervalReference
-    {Time : Type*} [LinearOrder Time] [SemilatticeSup (Event Time)]
-    {P : Event Time → Prop}
+    {T : Type*} [LinearOrder T] [SemilatticeSup (Event T)]
+    {P : Event T → Prop}
     (hQua : QUA P)
-    {e₁ e₂ : Event Time} (he₁ : P e₁) (_he₂ : P e₂) (_hne : e₁ ≠ e₂) :
+    {e₁ e₂ : Event T} (he₁ : P e₁) (_he₂ : P e₂) (_hne : e₁ ≠ e₂) :
     ¬ SubintervalReferenceUniv P := by
   intro hSub
   exact qua_incompatible_with_subintervalReference hQua he₁ (hSub e₁ he₁)

--- a/Linglib/Semantics/Aspect/SubeventStructure.lean
+++ b/Linglib/Semantics/Aspect/SubeventStructure.lean
@@ -29,7 +29,7 @@ temporally simple. This module makes that structure explicit via
 
 ## ViewpointAspect Bridge (§ 6–7)
 
-`phasePred` converts temporal phases into `Unit → Event Time → Prop`, making them
+`phasePred` converts temporal phases into `Unit → Event T → Prop`, making them
 consumable by IMPF/PRFV/PERF. Key results:
 
 - `impf_phasePred` / `prfv_phasePred`: reduce operator applications to
@@ -52,11 +52,11 @@ open Features
 /-- The two temporal phases of a complex event (accomplishment/achievement):
     an activity trace (the process) and a result trace (the outcome state).
     The activity phase must precede or meet the result phase. -/
-structure SubeventPhases (Time : Type*) [LinearOrder Time] where
+structure SubeventPhases (T : Type*) [LinearOrder T] where
   /-- Temporal extent of the activity/process phase -/
-  activityTrace : NonemptyInterval Time
+  activityTrace : NonemptyInterval T
   /-- Temporal extent of the result state phase -/
-  resultTrace : NonemptyInterval Time
+  resultTrace : NonemptyInterval T
   /-- Activity precedes or meets result: activity ends ≤ result starts -/
   activity_precedes_result : activityTrace.snd ≤ resultTrace.fst
 
@@ -67,42 +67,42 @@ structure SubeventPhases (Time : Type*) [LinearOrder Time] where
     - States and activities are `.simple`: one homogeneous interval.
     - Accomplishments and achievements are `.complex`: the overall runtime
       decomposes into an activity phase and a result phase. -/
-inductive TemporalDecomposition (Time : Type*) [LinearOrder Time] where
+inductive TemporalDecomposition (T : Type*) [LinearOrder T] where
   /-- Simple event: a single runtime interval with no internal structure. -/
-  | simple (runtime : NonemptyInterval Time)
+  | simple (runtime : NonemptyInterval T)
   /-- Complex event: overall runtime with activity and result subphases.
       Both subphases are contained within the overall runtime. -/
   | complex
-    (runtime : NonemptyInterval Time)
-    (phases : SubeventPhases Time)
+    (runtime : NonemptyInterval T)
+    (phases : SubeventPhases T)
     (activity_in_runtime : phases.activityTrace ≤ runtime)
     (result_in_runtime : phases.resultTrace ≤ runtime)
 
 namespace TemporalDecomposition
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- Extract the overall runtime from any decomposition. -/
-def runtime : TemporalDecomposition Time → NonemptyInterval Time
+def runtime : TemporalDecomposition T → NonemptyInterval T
   | .simple r => r
   | .complex r _ _ _ => r
 
 /-- Extract the activity phase (only available for complex events). -/
-def activityPhase : TemporalDecomposition Time → Option (NonemptyInterval Time)
+def activityPhase : TemporalDecomposition T → Option (NonemptyInterval T)
   | .simple _ => none
   | .complex _ phases _ _ => some phases.activityTrace
 
 /-- Extract the result phase (only available for complex events). -/
-def resultPhase : TemporalDecomposition Time → Option (NonemptyInterval Time)
+def resultPhase : TemporalDecomposition T → Option (NonemptyInterval T)
   | .simple _ => none
   | .complex _ phases _ _ => some phases.resultTrace
 
 /-- Is this a complex (phased) decomposition? -/
-def isComplex : TemporalDecomposition Time → Prop
+def isComplex : TemporalDecomposition T → Prop
   | .simple _ => False
   | .complex _ _ _ _ => True
 
-instance : DecidablePred (@isComplex Time _) :=
+instance : DecidablePred (@isComplex T _) :=
   fun d => by unfold isComplex; cases d <;> infer_instance
 
 end TemporalDecomposition
@@ -131,26 +131,26 @@ theorem hasComplexDecomposition_iff_telic (c : VendlerClass) :
 
 /-- An event enriched with temporal decomposition information.
     Extends `Event` (which has runtime + sort) with subevent phase structure. -/
-structure DecomposedEv (Time : Type*) [LinearOrder Time] where
+structure DecomposedEv (T : Type*) [LinearOrder T] where
   /-- The underlying event -/
-  event : Event Time
+  event : Event T
   /-- Temporal decomposition of the event -/
-  decomposition : TemporalDecomposition Time
+  decomposition : TemporalDecomposition T
   /-- The decomposition's runtime matches the event's runtime -/
   runtime_consistent : decomposition.runtime = event.runtime
 
 /-- Attach a simple decomposition to an event (for states/activities). -/
-def _root_.Event.withSimpleDecomposition {Time : Type*} [LinearOrder Time]
-    (e : Event Time) : DecomposedEv Time where
+def _root_.Event.withSimpleDecomposition {T : Type*} [LinearOrder T]
+    (e : Event T) : DecomposedEv T where
   event := e
   decomposition := .simple e.runtime
   runtime_consistent := rfl
 
 /-- Attach a complex decomposition to an event (for accomplishments/achievements). -/
-def _root_.Event.withComplexDecomposition {Time : Type*} [LinearOrder Time]
-    (e : Event Time) (phases : SubeventPhases Time)
+def _root_.Event.withComplexDecomposition {T : Type*} [LinearOrder T]
+    (e : Event T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ e.runtime)
-    (h_res : phases.resultTrace ≤ e.runtime) : DecomposedEv Time where
+    (h_res : phases.resultTrace ≤ e.runtime) : DecomposedEv T where
   event := e
   decomposition := .complex e.runtime phases h_act h_res
   runtime_consistent := rfl
@@ -158,14 +158,14 @@ def _root_.Event.withComplexDecomposition {Time : Type*} [LinearOrder Time]
 /-! ### Structural Theorems -/
 
 /-- Activity precedes result in any SubeventPhases (direct accessor). -/
-theorem SubeventPhases.ordering {Time : Type*} [LinearOrder Time]
-    (p : SubeventPhases Time) : p.activityTrace.snd ≤ p.resultTrace.fst :=
+theorem SubeventPhases.ordering {T : Type*} [LinearOrder T]
+    (p : SubeventPhases T) : p.activityTrace.snd ≤ p.resultTrace.fst :=
   p.activity_precedes_result
 
 /-- Both subevent phases are contained in the overall runtime of a complex
     decomposition (by construction). -/
-theorem complex_phases_in_runtime {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem complex_phases_in_runtime {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ rt)
     (h_res : phases.resultTrace ≤ rt) :
     phases.activityTrace ≤ rt ∧
@@ -173,13 +173,13 @@ theorem complex_phases_in_runtime {Time : Type*} [LinearOrder Time]
   ⟨h_act, h_res⟩
 
 /-- A simple decomposition has no result phase. -/
-theorem simple_no_result {Time : Type*} [LinearOrder Time]
-    (r : NonemptyInterval Time) :
+theorem simple_no_result {T : Type*} [LinearOrder T]
+    (r : NonemptyInterval T) :
     (TemporalDecomposition.simple r).resultPhase = none := rfl
 
 /-- A simple decomposition has no activity phase. -/
-theorem simple_no_activity {Time : Type*} [LinearOrder Time]
-    (r : NonemptyInterval Time) :
+theorem simple_no_activity {T : Type*} [LinearOrder T]
+    (r : NonemptyInterval T) :
     (TemporalDecomposition.simple r).activityPhase = none := rfl
 
 /-! ### Phase Event Predicates -/
@@ -194,14 +194,14 @@ open _root_.Aspect
     The world parameter is fixed to `Unit` since temporal decomposition
     is world-independent (following the same convention as
     `Giannakidou.lean`). -/
-def phasePred {Time : Type*} [LinearOrder Time]
-    (phase : NonemptyInterval Time) : Unit → Event Time → Prop :=
+def phasePred {T : Type*} [LinearOrder T]
+    (phase : NonemptyInterval T) : Unit → Event T → Prop :=
   λ _ ev => ev.runtime = phase
 
 /-- IMPF applied to a phase predicate reduces to the reference time being
     properly inside that phase interval. -/
-theorem impf_phasePred {Time : Type*} [LinearOrder Time]
-    (phase t : NonemptyInterval Time) :
+theorem impf_phasePred {T : Type*} [LinearOrder T]
+    (phase t : NonemptyInterval T) :
     IMPF (phasePred phase) () t ↔ t < phase := by
   simp only [IMPF, phasePred, Event.τ]
   constructor
@@ -210,8 +210,8 @@ theorem impf_phasePred {Time : Type*} [LinearOrder Time]
 
 /-- PRFV applied to a phase predicate reduces to the phase interval being
     contained in the reference time. -/
-theorem prfv_phasePred {Time : Type*} [LinearOrder Time]
-    (phase t : NonemptyInterval Time) :
+theorem prfv_phasePred {T : Type*} [LinearOrder T]
+    (phase t : NonemptyInterval T) :
     PRFV (phasePred phase) () t ↔ phase ≤ t := by
   simp only [PRFV, phasePred, Event.τ]
   constructor
@@ -248,10 +248,10 @@ theorem progressive_before_result :
 
     Proof: result ⊆ runtime (by `h_res`) and runtime ⊆ ref (by PRFV),
     so result ⊆ ref by transitivity. -/
-theorem perfective_full_entails_result {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem perfective_full_entails_result {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_res : phases.resultTrace ≤ rt)
-    (t : NonemptyInterval Time)
+    (t : NonemptyInterval T)
     (h_prfv : PRFV (phasePred rt) () t) :
     phases.resultTrace ≤ t := by
   rw [prfv_phasePred] at h_prfv
@@ -259,10 +259,10 @@ theorem perfective_full_entails_result {Time : Type*} [LinearOrder Time]
 
 /-- PRFV on the full event entails the activity trace is within the
     reference time. The process phase is also covered. -/
-theorem perfective_full_entails_activity {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem perfective_full_entails_activity {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ rt)
-    (t : NonemptyInterval Time)
+    (t : NonemptyInterval T)
     (h_prfv : PRFV (phasePred rt) () t) :
     phases.activityTrace ≤ t := by
   rw [prfv_phasePred] at h_prfv
@@ -271,11 +271,11 @@ theorem perfective_full_entails_activity {Time : Type*} [LinearOrder Time]
 /-- For complex events, PRFV on the full event entails both subevent phases
     are within the reference time. This is the compositional account of why
     perfective aspect entails completion for accomplishments. -/
-theorem perfective_full_covers_phases {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem perfective_full_covers_phases {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ rt)
     (h_res : phases.resultTrace ≤ rt)
-    (t : NonemptyInterval Time)
+    (t : NonemptyInterval T)
     (h_prfv : PRFV (phasePred rt) () t) :
     phases.activityTrace ≤ t ∧ phases.resultTrace ≤ t :=
   ⟨perfective_full_entails_activity rt phases h_act t h_prfv,
@@ -289,10 +289,10 @@ theorem perfective_full_covers_phases {Time : Type*} [LinearOrder Time]
     runtime ⊆ ref. Since activity ⊆ runtime (by `h_act`), we get
     activity ⊆ ref. Combined with ref ⊆ activity (from IMPF), this forces
     ref = activity, contradicting the strict inequality in properSubinterval. -/
-theorem impf_activity_prfv_full_incompatible {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem impf_activity_prfv_full_incompatible {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ rt)
-    (t : NonemptyInterval Time) :
+    (t : NonemptyInterval T) :
     IMPF (phasePred phases.activityTrace) () t →
     ¬ PRFV (phasePred rt) () t := by
   rw [impf_phasePred, prfv_phasePred]
@@ -428,13 +428,13 @@ theorem MoensSteedmanClass.when_needs_coercion_iff (c : MoensSteedmanClass) :
                              explicit culmination
     ```
     [moens-steedman-1988] -/
-structure Nucleus (Time : Type*) [LinearOrder Time] where
+structure Nucleus (T : Type*) [LinearOrder T] where
   /-- Preparatory process leading to culmination -/
-  prepProcess : Option (NonemptyInterval Time)
+  prepProcess : Option (NonemptyInterval T)
   /-- The culmination point: instantaneous transition -/
-  culmination : Time
+  culmination : T
   /-- Consequent state persisting after culmination -/
-  consState : Option (NonemptyInterval Time)
+  consState : Option (NonemptyInterval T)
   /-- Prep process ends at or before culmination -/
   prep_le_culm : ∀ i, prepProcess = some i → i.snd ≤ culmination
   /-- Consequent state starts at or after culmination -/
@@ -442,10 +442,10 @@ structure Nucleus (Time : Type*) [LinearOrder Time] where
 
 namespace Nucleus
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- The M&S event type determined by which components are present. -/
-def eventType (n : Nucleus Time) : MoensSteedmanClass :=
+def eventType (n : Nucleus T) : MoensSteedmanClass :=
   match n.prepProcess, n.consState with
   | some _, some _ => .culminatedProcess
   | none,   some _ => .culmination
@@ -453,26 +453,26 @@ def eventType (n : Nucleus Time) : MoensSteedmanClass :=
 
 /-- A full nucleus (both prep and cons present) yields SubeventPhases.
     The ordering proof follows from transitivity through the culmination. -/
-def toSubeventPhases (n : Nucleus Time)
-    (prep cons : NonemptyInterval Time)
+def toSubeventPhases (n : Nucleus T)
+    (prep cons : NonemptyInterval T)
     (h_prep : n.prepProcess = some prep)
     (h_cons : n.consState = some cons) :
-    SubeventPhases Time where
+    SubeventPhases T where
   activityTrace := prep
   resultTrace := cons
   activity_precedes_result :=
     le_trans (n.prep_le_culm prep h_prep) (n.culm_le_cons cons h_cons)
 
 /-- A full nucleus has event type culminatedProcess. -/
-theorem full_is_culminatedProcess (n : Nucleus Time)
-    {p c : NonemptyInterval Time}
+theorem full_is_culminatedProcess (n : Nucleus T)
+    {p c : NonemptyInterval T}
     (hp : n.prepProcess = some p) (hc : n.consState = some c) :
     n.eventType = .culminatedProcess := by
   simp [eventType, hp, hc]
 
 /-- A nucleus with consequent state has M&S's consequent state feature. -/
-theorem hasConsState_of_consState (n : Nucleus Time)
-    {c : NonemptyInterval Time} (hc : n.consState = some c) :
+theorem hasConsState_of_consState (n : Nucleus T)
+    {c : NonemptyInterval T} (hc : n.consState = some c) :
     n.eventType.toProfile.hasConsequentState = true := by
   simp only [eventType]
   split <;> simp_all [MoensSteedmanClass.toProfile]

--- a/Linglib/Semantics/Aspect/SubintervalProperty.lean
+++ b/Linglib/Semantics/Aspect/SubintervalProperty.lean
@@ -38,7 +38,7 @@ namespace Aspect.SubintervalProperty
 
 open _root_.Aspect
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- **Subinterval property for event predicates** (mereological version).
     SUB(P) iff every subinterval of a P-event's runtime that is also
@@ -64,18 +64,18 @@ variable {W Time : Type*} [LinearOrder Time]
     ([zhao-2025] ATOM-DIST_t) lives in `Semantics/Aspect/AtomDist.lean`. The
     three formulations are NOT directly interderivable; bridging requires
     explicit witness-existence assumptions. -/
-def HasSubintervalProp (P : W → Event Time → Prop) : Prop :=
-  ∀ (e₁ : Event Time) (w : W),
+def HasSubintervalProp (P : W → Event T → Prop) : Prop :=
+  ∀ (e₁ : Event T) (w : W),
     P w e₁ →
-    ∀ (t : NonemptyInterval Time), t ≤ e₁.τ →
-    ∀ (e₂ : Event Time), e₂.τ = t →
+    ∀ (t : NonemptyInterval T), t ≤ e₁.τ →
+    ∀ (e₂ : Event T), e₂.τ = t →
     P w e₂
 
 /-- **Closed subinterval property** (CSUB): `P`'s run-times form a *lower set*.
 
     This is the contentful homogeneity property — `eventDenotation (P w ·)`
     (the run-time image, `Semantics/Events/Basic.lean`) is downward-closed in
-    `NonemptyInterval Time` at every world. Equivalently, for any subinterval
+    `NonemptyInterval T` at every world. Equivalently, for any subinterval
     `t` of a P-event's runtime there *exists* a P-event whose runtime is `t`
     (the witness form — see `hasClosedSubintervalProp_iff_witnesses`).
 
@@ -91,18 +91,18 @@ def HasSubintervalProp (P : W → Event Time → Prop) : Prop :=
     that already exist and is vacuous under a sparse event ontology; CSUB
     *produces* a witness at every subinterval, which is what every
     operator-level theorem below consumes. -/
-def HasClosedSubintervalProp (P : W → Event Time → Prop) : Prop :=
+def HasClosedSubintervalProp (P : W → Event T → Prop) : Prop :=
   ∀ w, IsLowerSet (eventDenotation (fun e => P w e))
 
 /-- **CSUB ⟺ the witness form.** Unfolds the lower-set definition to the
     classic Bennett-Partee/Dowty statement: every subinterval of a P-event's
     runtime is itself the runtime of some P-event. Operator-level theorems
     consume CSUB through this characterization. -/
-theorem hasClosedSubintervalProp_iff_witnesses {P : W → Event Time → Prop} :
+theorem hasClosedSubintervalProp_iff_witnesses {P : W → Event T → Prop} :
     HasClosedSubintervalProp P ↔
-      ∀ (e₁ : Event Time) (w : W), P w e₁ →
-        ∀ (t : NonemptyInterval Time), t ≤ e₁.τ →
-        ∃ (e₂ : Event Time), e₂.τ = t ∧ P w e₂ := by
+      ∀ (e₁ : Event T) (w : W), P w e₁ →
+        ∀ (t : NonemptyInterval T), t ≤ e₁.τ →
+        ∃ (e₂ : Event T), e₂.τ = t ∧ P w e₂ := by
   constructor
   · intro h e₁ w hP t ht
     obtain ⟨e₂, hPe₂, he₂⟩ := h w ht (mem_eventDenotation_of hP)
@@ -159,10 +159,10 @@ open Features
     subinterval. It is the witness form of CSUB
     (`hasClosedSubintervalProp_iff_witnesses`). -/
 theorem activity_entailment
-    (P : W → Event Time → Prop) (hSub : HasClosedSubintervalProp P)
-    (w : W) (e₁ : Event Time) (hP : P w e₁)
-    (t : NonemptyInterval Time) (hSub' : t ≤ e₁.τ) :
-    ∃ (e₂ : Event Time), e₂.τ = t ∧ P w e₂ :=
+    (P : W → Event T → Prop) (hSub : HasClosedSubintervalProp P)
+    (w : W) (e₁ : Event T) (hP : P w e₁)
+    (t : NonemptyInterval T) (hSub' : t ≤ e₁.τ) :
+    ∃ (e₂ : Event T), e₂.τ = t ∧ P w e₂ :=
   hasClosedSubintervalProp_iff_witnesses.mp hSub e₁ w hP t hSub'
 
 /-- **Telic non-homogeneity** (the extensional core of the imperfective
@@ -174,28 +174,28 @@ theorem activity_entailment
     intensional and modeled elsewhere; see the section caveat above. This
     theorem only exhibits a non-subinterval-closed predicate.)
 
-    The hypothesis `t₁ < t₂` ensures Time is nontrivial — in a singleton
-    Time there is only one interval and SUB holds vacuously for all P.
+    The hypothesis `t₁ < t₂` ensures `T` is nontrivial — in a singleton
+    `T` there is only one interval and SUB holds vacuously for all P.
     With two distinct time points, we construct a "telic" predicate
     P that holds only for events finishing at t₂ and fails for proper
     subintervals like [t₁, t₁]. -/
 theorem imperfective_paradox_possible
-    (w : W) (t₁ t₂ : Time) (hlt : t₁ < t₂) :
-    ¬ (∀ (P : W → Event Time → Prop), HasSubintervalProp P) := by
+    (w : W) (t₁ t₂ : T) (hlt : t₁ < t₂) :
+    ¬ (∀ (P : W → Event T → Prop), HasSubintervalProp P) := by
   intro hall
   -- Define a "telic" predicate: P holds iff the event's runtime ends at t₂
-  let P : W → Event Time → Prop := λ _ e => e.τ.snd = t₂
+  let P : W → Event T → Prop := λ _ e => e.τ.snd = t₂
   have hSub := hall P
   -- Construct an event e₁ with runtime [t₁, t₂]; P holds (finish = t₂)
   -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
-  let e₁ : Event Time := ⟨⟨⟨t₁, t₂⟩, le_of_lt hlt⟩, .dynamic⟩
+  let e₁ : Event T := ⟨⟨⟨t₁, t₂⟩, le_of_lt hlt⟩, .dynamic⟩
   have hPe₁ : P w e₁ := rfl
   -- [t₁, t₁] is a subinterval of [t₁, t₂]
-  let sub : NonemptyInterval Time := ⟨⟨t₁, t₁⟩, le_refl t₁⟩
+  let sub : NonemptyInterval T := ⟨⟨t₁, t₁⟩, le_refl t₁⟩
   have hSI : sub ≤ e₁.τ := NonemptyInterval.le_def.mpr ⟨le_refl t₁, le_of_lt hlt⟩
   -- SIP says P must hold for any event with runtime [t₁, t₁]
   -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
-  let e₂ : Event Time := ⟨sub, .dynamic⟩
+  let e₂ : Event T := ⟨sub, .dynamic⟩
   have hPe₂ := hSub e₁ w hPe₁ sub hSI e₂ rfl
   -- But P w e₂ means t₁ = t₂, contradicting t₁ < t₂
   exact absurd hPe₂ (ne_of_lt hlt)
@@ -238,8 +238,8 @@ theorem imperfective_paradox_possible
     running has CSUB, there exists a running event whose runtime
     IS exactly t, which satisfies the PRFV containment requirement. -/
 theorem impf_entails_prfv_of_csub
-    (P : W → Event Time → Prop) (hCSUB : HasClosedSubintervalProp P)
-    (w : W) (t : NonemptyInterval Time) :
+    (P : W → Event T → Prop) (hCSUB : HasClosedSubintervalProp P)
+    (w : W) (t : NonemptyInterval T) :
     IMPF P w t → PRFV P w t := by
   intro ⟨e, hPSub, hP⟩
   -- hPSub : t < e.τ — reference time properly inside event
@@ -265,9 +265,9 @@ theorem impf_entails_prfv_of_csub
     - Q gives t ⊆ τ(e₂) (from the predicate's second conjunct)
     - Mutual containment gives τ(e₂) = t (closing the ⊆ → = gap) -/
 theorem csub_necessary_for_impf_prfv :
-    (∀ (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time),
+    (∀ (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T),
       IMPF P w t → PRFV P w t) →
-    ∀ (P : W → Event Time → Prop), HasClosedSubintervalProp P := by
+    ∀ (P : W → Event T → Prop), HasClosedSubintervalProp P := by
   intro hall P
   rw [hasClosedSubintervalProp_iff_witnesses]
   intro e w hP t hSub
@@ -278,7 +278,7 @@ theorem csub_necessary_for_impf_prfv :
   · -- τ(e) ≠ t: t is strictly contained in τ(e)
     have hProper : t < e.τ := lt_of_le_of_ne hSub (fun h => heq (h ▸ rfl))
     -- Step 2: refined predicate Q carries reverse containment
-    let Q : W → Event Time → Prop := fun w' e' => P w' e' ∧ t ≤ e'.τ
+    let Q : W → Event T → Prop := fun w' e' => P w' e' ∧ t ≤ e'.τ
     -- IMPF(Q)(w)(t): witnessed by e (proper subinterval + P holds + t ⊆ τ(e))
     obtain ⟨e₂, hSub₂, hPe₂, hSubRev⟩ := hall Q w t ⟨e, hProper, hP, hSub⟩
     -- hSub₂ : τ(e₂) ⊆ t (from PRFV), hSubRev : t ⊆ τ(e₂) (from Q)

--- a/Linglib/Semantics/Causation/Progressive.lean
+++ b/Linglib/Semantics/Causation/Progressive.lean
@@ -263,7 +263,7 @@ theorem typeLevelHolds_is_develop {V : Type*} [Fintype V] [DecidableEq V]
     variable. The causal model explains WHY the activity leads to the
     result: the initiator is type-level sufficient. -/
 structure CausallyGroundedEvent (V : Type*) [Fintype V] [DecidableEq V]
-    (Time : Type*) [LinearOrder Time] where
+    (T : Type*) [LinearOrder T] where
   /-- The causal process underlying the event -/
   process : CausalProcess V
   /-- IsDAG instance for process.M.graph (carried explicitly). -/
@@ -271,7 +271,7 @@ structure CausallyGroundedEvent (V : Type*) [Fintype V] [DecidableEq V]
   /-- IsDeterministic instance for proc.M (carried explicitly). -/
   detInst : SEM.IsDeterministic process.M
   /-- The temporal phases: activity and result with ordering -/
-  phases : Aspect.SubeventStructure.SubeventPhases Time
+  phases : Aspect.SubeventStructure.SubeventPhases T
   /-- The causal trajectory is viable: initiator is type-level sufficient. -/
   causallyViable : @CausalProcess.typeLevelHolds V _ _ process dagInst detInst
 

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -47,7 +47,7 @@ open Conditionals.Counterfactual (universalCounterfactual)
     Bundles event-structural and temporal properties that distinguish
     eventive causation (percept → state change) from maintenance
     causation (representation → state persistence). -/
-structure PsychCausalLink (Time : Type*) [LinearOrder Time] where
+structure PsychCausalLink (T : Type*) [LinearOrder T] where
   /-- Ontological sort of the causing eventuality -/
   causeSort : Features.Dynamicity
   /-- Ontological sort of the caused eventuality -/
@@ -57,7 +57,7 @@ structure PsychCausalLink (Time : Type*) [LinearOrder Time] where
       Maintenance: [CAUSE [STATE]] — no. -/
   involvesTransition : Bool
   /-- Temporal constraint on the runtimes of cause and effect -/
-  temporalConstraint : NonemptyInterval Time → NonemptyInterval Time → Prop
+  temporalConstraint : NonemptyInterval T → NonemptyInterval T → Prop
 
 /-! ### Eventive and Maintenance Links -/
 
@@ -67,7 +67,7 @@ structure PsychCausalLink (Time : Type*) [LinearOrder Time] where
     Event structure: [[percept ACT] CAUSE [BECOME [experiencer STATE]]]
     Example: "The noise frightened John" — the noise event happens,
     THEN John enters the frightened state. -/
-def eventiveLink (Time : Type*) [LinearOrder Time] : PsychCausalLink Time :=
+def eventiveLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
   { causeSort := .dynamic
     effectSort := .dynamic
     involvesTransition := true
@@ -85,7 +85,7 @@ def eventiveLink (Time : Type*) [LinearOrder Time] : PsychCausalLink Time :=
     (a) Relates two eventualities (both states)
     (b) Temporal contemporaneity (τ(cause) overlaps τ(effect))
     (c) Counterfactual dependence (effect ceases when cause ceases) -/
-def maintenanceLink (Time : Type*) [LinearOrder Time] : PsychCausalLink Time :=
+def maintenanceLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
   { causeSort := .stative
     effectSort := .stative
     involvesTransition := false
@@ -96,26 +96,26 @@ def maintenanceLink (Time : Type*) [LinearOrder Time] : PsychCausalLink Time :=
 /-- Ground `CausalSource` (a two-constructor enum) in the richer
     `PsychCausalLink` structure. External source = eventive causation;
     internal source = maintenance causation. -/
-def CausalSource.toLink (Time : Type*) [LinearOrder Time] :
-    CausalSource → PsychCausalLink Time
-  | .external => eventiveLink Time
-  | .internal => maintenanceLink Time
+def CausalSource.toLink (T : Type*) [LinearOrder T] :
+    CausalSource → PsychCausalLink T
+  | .external => eventiveLink T
+  | .internal => maintenanceLink T
 
 /-! ### Temporal Theorems -/
 
 /-- Maintenance is temporally symmetric: if cause overlaps effect,
     effect overlaps cause. Delegates to `NonemptyInterval.overlaps_symm`. -/
-theorem maintenance_temporal_symmetric {Time : Type*} [LinearOrder Time]
-    (i₁ i₂ : NonemptyInterval Time)
-    (h : (maintenanceLink Time).temporalConstraint i₁ i₂) :
-    (maintenanceLink Time).temporalConstraint i₂ i₁ :=
+theorem maintenance_temporal_symmetric {T : Type*} [LinearOrder T]
+    (i₁ i₂ : NonemptyInterval T)
+    (h : (maintenanceLink T).temporalConstraint i₁ i₂) :
+    (maintenanceLink T).temporalConstraint i₂ i₁ :=
   NonemptyInterval.overlaps_symm h
 
 /-- Eventive causation is temporally irreflexive: no eventuality
     can precede itself. Delegates to `NonemptyInterval.precedes_irrefl`. -/
-theorem eventive_temporal_irrefl {Time : Type*} [LinearOrder Time]
-    (i : NonemptyInterval Time) :
-    ¬ (eventiveLink Time).temporalConstraint i i :=
+theorem eventive_temporal_irrefl {T : Type*} [LinearOrder T]
+    (i : NonemptyInterval T) :
+    ¬ (eventiveLink T).temporalConstraint i i :=
   NonemptyInterval.precedes_irrefl i
 
 /-- Precedence and overlap are mutually exclusive: if cause precedes
@@ -123,38 +123,38 @@ theorem eventive_temporal_irrefl {Time : Type*} [LinearOrder Time]
     eventive/stative dichotomy — the two temporal configurations are
     incompatible for any given pair of eventualities.
     Delegates to `NonemptyInterval.precedes_not_overlaps`. -/
-theorem precedes_excludes_overlap {Time : Type*} [LinearOrder Time]
-    (i₁ i₂ : NonemptyInterval Time)
-    (h : (eventiveLink Time).temporalConstraint i₁ i₂) :
-    ¬ (maintenanceLink Time).temporalConstraint i₁ i₂ :=
+theorem precedes_excludes_overlap {T : Type*} [LinearOrder T]
+    (i₁ i₂ : NonemptyInterval T)
+    (h : (eventiveLink T).temporalConstraint i₁ i₂) :
+    ¬ (maintenanceLink T).temporalConstraint i₁ i₂ :=
   NonemptyInterval.precedes_not_overlaps h
 
 /-! ### Event Sort Properties -/
 
 /-- Maintenance relates two states ([kim-2024] property (a)). -/
-theorem maintenance_both_states {Time : Type*} [LinearOrder Time] :
-    (maintenanceLink Time).causeSort = .stative ∧
-    (maintenanceLink Time).effectSort = .stative := ⟨rfl, rfl⟩
+theorem maintenance_both_states {T : Type*} [LinearOrder T] :
+    (maintenanceLink T).causeSort = .stative ∧
+    (maintenanceLink T).effectSort = .stative := ⟨rfl, rfl⟩
 
 /-- Eventive causation relates two dynamic eventualities. -/
-theorem eventive_both_dynamic {Time : Type*} [LinearOrder Time] :
-    (eventiveLink Time).causeSort = .dynamic ∧
-    (eventiveLink Time).effectSort = .dynamic := ⟨rfl, rfl⟩
+theorem eventive_both_dynamic {T : Type*} [LinearOrder T] :
+    (eventiveLink T).causeSort = .dynamic ∧
+    (eventiveLink T).effectSort = .dynamic := ⟨rfl, rfl⟩
 
 /-- Maintenance involves no transition (no BECOME). -/
-theorem maintenance_no_transition {Time : Type*} [LinearOrder Time] :
-    (maintenanceLink Time).involvesTransition = false := rfl
+theorem maintenance_no_transition {T : Type*} [LinearOrder T] :
+    (maintenanceLink T).involvesTransition = false := rfl
 
 /-- Eventive causation involves a transition (BECOME). -/
-theorem eventive_has_transition {Time : Type*} [LinearOrder Time] :
-    (eventiveLink Time).involvesTransition = true := rfl
+theorem eventive_has_transition {T : Type*} [LinearOrder T] :
+    (eventiveLink T).involvesTransition = true := rfl
 
 /-- The two causal flavors assign opposite values on every dimension. -/
-theorem flavors_differ_on_all_dimensions {Time : Type*} [LinearOrder Time] :
-    (eventiveLink Time).causeSort = .dynamic ∧
-    (maintenanceLink Time).causeSort = .stative ∧
-    (eventiveLink Time).involvesTransition = true ∧
-    (maintenanceLink Time).involvesTransition = false :=
+theorem flavors_differ_on_all_dimensions {T : Type*} [LinearOrder T] :
+    (eventiveLink T).causeSort = .dynamic ∧
+    (maintenanceLink T).causeSort = .stative ∧
+    (eventiveLink T).involvesTransition = true ∧
+    (maintenanceLink T).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ### Counterfactual Predicates -/
@@ -241,14 +241,14 @@ theorem dependent_excludes_persistent {W : Type*} [DecidableEq W] [Fintype W]
     and similarity ordering. The structural version — no BECOME means
     no independent grounding for the effect — is the deeper explanation
     for WHY maintenance-caused states are counterfactually dependent. -/
-theorem maintenance_three_properties {Time : Type*} [LinearOrder Time] :
+theorem maintenance_three_properties {T : Type*} [LinearOrder T] :
     -- (a) Both eventualities are states
-    (maintenanceLink Time).causeSort = .stative ∧
-    (maintenanceLink Time).effectSort = .stative ∧
+    (maintenanceLink T).causeSort = .stative ∧
+    (maintenanceLink T).effectSort = .stative ∧
     -- (b) Temporal contemporaneity (overlaps, not precedes)
-    (maintenanceLink Time).temporalConstraint = NonemptyInterval.overlaps ∧
+    (maintenanceLink T).temporalConstraint = NonemptyInterval.overlaps ∧
     -- (c) No transition (no BECOME)
-    (maintenanceLink Time).involvesTransition = false :=
+    (maintenanceLink T).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 end Causation.PsychLink

--- a/Linglib/Semantics/Degree/Measure/Temporal.lean
+++ b/Linglib/Semantics/Degree/Measure/Temporal.lean
@@ -19,7 +19,7 @@ the DA semantics (K&L eq. 25).
 
 | K&L primitive                                | This file                       |
 |----------------------------------------------|---------------------------------|
-| Measure function `m : e × t → d` (HKL eq. 11; K&L p. 167) | `TemporalMeasure α δ Time` |
+| Measure function `m : e × t → d` (HKL eq. 11; K&L p. 167) | `TemporalMeasure α δ T` |
 | Scale `⟨S, R, δ⟩` (K&L fn 8)                 | `[LinearOrder δ]`               |
 | Difference function `m_d^↑` (K&L eq. 23)     | `differenceFunction`            |
 | Measure of change `m_Δ` (K&L eq. 25)         | `measureOfChange`               |
@@ -65,7 +65,7 @@ open ArgumentStructure
 
 /-! ### TemporalMeasure ([hay-kennedy-levin-1999] eq. 11) -/
 
-/-- A **time-indexed measure function** `m : α → Time → δ`
+/-- A **time-indexed measure function** `m : α → T → δ`
     ([hay-kennedy-levin-1999] eq. 11; restated in
     [kennedy-levin-2008] §7.3.1 main text p. 167): a function
     from objects and times to degrees on a scale.
@@ -83,7 +83,7 @@ open ArgumentStructure
 
     For typeclass-resolution participation (so `HasScalarResult` and
     `HasLatentScale` instances synthesise automatically), use the
-    `HasTemporalMeasure α δ Time` typeclass below — the mathlib pattern
+    `HasTemporalMeasure α δ T` typeclass below — the mathlib pattern
     of pairing a function abbrev with a typeclass wrapper, analogous to
     `Set α := α → Prop` (abbrev) plus the various `[Membership]` /
     `[SetLike]` (typeclass) interfaces.
@@ -93,18 +93,18 @@ open ArgumentStructure
     here — same pattern as mathlib's `Function` files. The `set_option
     linter.dupNamespace false in` immediately above silences the
     namespace-duplication warning for this single declaration. -/
-abbrev TemporalMeasure (α : Type*) (δ : Type*) (Time : Type*) :=
-  α → Time → δ
+abbrev TemporalMeasure (α : Type*) (δ : Type*) (T : Type*) :=
+  α → T → δ
 
 /-- The typeclass form of `TemporalMeasure`: a verb commits to a
     canonical time-indexed measure on dimension `δ`. Per-verb instance
-    (one per (α, δ, Time) triple a verb's lexical content addresses).
+    (one per (α, δ, T) triple a verb's lexical content addresses).
 
     Mathlib pattern: cf. `MetricSpace α` (typeclass providing `dist`),
     `MeasurableSpace α` (typeclass providing `MeasurableSet`). The
     typeclass enables instance synthesis — any verb declaring a
-    `[HasTemporalMeasure α δ Time]` instance automatically gets
-    `[HasScalarResult α δ (Event Time)]` and `[HasLatentScale α (Event Time)]`
+    `[HasTemporalMeasure α δ T]` instance automatically gets
+    `[HasScalarResult α δ (Event T)]` and `[HasLatentScale α (Event T)]`
     via the auto-synthesis instances in §5 below, opening Beavers'
     affectedness typeclass chain to the verb without explicit smart
     constructor calls.
@@ -112,9 +112,9 @@ abbrev TemporalMeasure (α : Type*) (δ : Type*) (Time : Type*) :=
     The auto-synthesis is what makes the K&L → Beavers bridge
     "structural" rather than "smart-constructor": consumers who
     declare HasTemporalMeasure get Beavers' typeclasses for free. -/
-class HasTemporalMeasure (α : Type*) (δ : Type*) (Time : Type*) where
+class HasTemporalMeasure (α : Type*) (δ : Type*) (T : Type*) where
   /-- The verb's canonical time-indexed measure function. -/
-  measure : α → Time → δ
+  measure : α → T → δ
 
 /-! ### Difference Function (K&L 2008 eq. 23) -/
 
@@ -129,22 +129,22 @@ class HasTemporalMeasure (α : Type*) (δ : Type*) (Time : Type*) where
 
     Used in the comparative semantics of `wider than the carpet`
     (K&L eq. 24): `wide_{wide(c)}^↑(x)(t) ≥ stnd(wide_{wide(c)}^↑)`. -/
-def differenceFunction {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (d : δ) :
-    TemporalMeasure α δ Time :=
+def differenceFunction {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (d : δ) :
+    TemporalMeasure α δ T :=
   fun x t => max d (m x t)
 
 /-- The difference function's value is always at least the clamping
     minimum. Direct from `le_max_left`. -/
-theorem differenceFunction_ge_clamp {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (d : δ) (x : α) (t : Time) :
+theorem differenceFunction_ge_clamp {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (d : δ) (x : α) (t : T) :
     d ≤ differenceFunction m d x t :=
   le_max_left d (m x t)
 
 /-- When the underlying measure already exceeds the clamp, the
     difference function returns the underlying measure unchanged. -/
-theorem differenceFunction_eq_measure {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (d : δ) (x : α) (t : Time)
+theorem differenceFunction_eq_measure {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (d : δ) (x : α) (t : T)
     (h : d ≤ m x t) :
     differenceFunction m d x t = m x t := by
   simp [differenceFunction, max_eq_right h]
@@ -168,45 +168,45 @@ theorem differenceFunction_eq_measure {α δ Time : Type*} [LinearOrder δ]
     The Lean signature takes the initial and final times explicitly
     rather than an event, keeping the substrate event-type-agnostic.
     The convenience overload `measureOfChangeOnEvent` specialises to
-    `Event Time` events with the runtime-interval projections. -/
-def measureOfChange {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (x : α) (initT finT : Time) : δ :=
+    `Event T` events with the runtime-interval projections. -/
+def measureOfChange {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (x : α) (initT finT : T) : δ :=
   differenceFunction m (m x initT) x finT
 
 /-- Identity theorem: when initial and final times coincide, the
     measure of change is the initial degree (no change). -/
-theorem measureOfChange_self {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (x : α) (t : Time) :
+theorem measureOfChange_self {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (x : α) (t : T) :
     measureOfChange m x t t = m x t := by
   simp [measureOfChange, differenceFunction]
 
 /-- The measure of change is always at least the initial degree
     (clamped from below). Direct from `differenceFunction_ge_clamp`. -/
-theorem measureOfChange_ge_init {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (x : α) (initT finT : Time) :
+theorem measureOfChange_ge_init {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (x : α) (initT finT : T) :
     m x initT ≤ measureOfChange m x initT finT :=
   differenceFunction_ge_clamp m (m x initT) x finT
 
 /-- When the patient's degree increases over the event, the measure
     of change equals the final degree. -/
-theorem measureOfChange_eq_final {α δ Time : Type*} [LinearOrder δ]
-    (m : TemporalMeasure α δ Time) (x : α) (initT finT : Time)
+theorem measureOfChange_eq_final {α δ T : Type*} [LinearOrder δ]
+    (m : TemporalMeasure α δ T) (x : α) (initT finT : T)
     (h : m x initT ≤ m x finT) :
     measureOfChange m x initT finT = m x finT :=
   differenceFunction_eq_measure m (m x initT) x finT h
 
 /-! ### Event-specialised Measure of Change -/
 
-/-- Specialisation of `measureOfChange` to `Event Time` events: extract
+/-- Specialisation of `measureOfChange` to `Event T` events: extract
     init/fin times from the event's runtime interval. -/
-def measureOfChangeOnEvent {α δ Time : Type*} [LinearOrder δ] [LinearOrder Time]
-    (m : TemporalMeasure α δ Time) (x : α) (e : Event Time) : δ :=
+def measureOfChangeOnEvent {α δ T : Type*} [LinearOrder δ] [LinearOrder T]
+    (m : TemporalMeasure α δ T) (x : α) (e : Event T) : δ :=
   measureOfChange m x e.runtime.fst e.runtime.snd
 
 /-! ### Auto-synthesis bridges to Beavers' substrate -/
 
 /-- **Auto-synthesis instance**: a verb with a canonical measure
-    function (`[HasTemporalMeasure α δ Time]`) automatically has a
+    function (`[HasTemporalMeasure α δ T]`) automatically has a
     Beavers `HasScalarResult` instance.
 
     `HasScalarResult.resultAt x g e := measure x e.runtime.snd = g`
@@ -224,14 +224,14 @@ def measureOfChangeOnEvent {α δ Time : Type*} [LinearOrder δ] [LinearOrder Ti
     (instance synthesising the general framework's typeclass from
     a specific framework's typeclass). -/
 instance HasScalarResult.ofHasMeasureFunction
-    {α δ Time : Type*} [LinearOrder Time] [HasTemporalMeasure α δ Time] :
-    HasScalarResult α δ (Event Time) where
+    {α δ T : Type*} [LinearOrder T] [HasTemporalMeasure α δ T] :
+    HasScalarResult α δ (Event T) where
   resultAt x g e := HasTemporalMeasure.measure x e.runtime.snd = g
 
 /-- Companion smart constructor: `HasTemporalMeasure`-backed verbs
     can also be given a Beavers `HasLatentScale` instance via this
     function. NOT an `instance` because `δ` doesn't appear in the
-    `HasLatentScale α (Event Time)` conclusion — Lean's typeclass
+    `HasLatentScale α (Event T)` conclusion — Lean's typeclass
     synthesiser cannot infer which dimension's measure function to
     use, so the instance arrow can't fire automatically.
 
@@ -258,8 +258,8 @@ instance HasScalarResult.ofHasMeasureFunction
     a typeclass-elaboration hygiene marker. -/
 @[reducible]
 def HasLatentScale.ofHasMeasureFunction
-    {α δ Time : Type*} [LinearOrder Time] [HasTemporalMeasure α δ Time] :
-    HasLatentScale α (Event Time) where
+    {α δ T : Type*} [LinearOrder T] [HasTemporalMeasure α δ T] :
+    HasLatentScale α (Event T) where
   latentScale _ _ := True
 
 end Degree

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -279,8 +279,8 @@ end DynamicSemantics
 `Mood/Dynamic.lean`): a `Possibility` whose world coordinate is the
 current evaluation index and whose `ℕ`-registered drefs are also
 world-time indices. Contexts are plain level-0 states
-(`Set (Intensional.Index.Possibility W Time)`), so the update
+(`Set (Intensional.Index.Possibility W T)`), so the update
 spine of `Semantics/Dynamic/Update.lean` applies directly. -/
-abbrev Intensional.Index.Possibility (W Time : Type*) :=
-  DynamicSemantics.Possibility (Intensional.Index W Time) ℕ
-    (Intensional.Index W Time)
+abbrev Intensional.Index.Possibility (W T : Type*) :=
+  DynamicSemantics.Possibility (Intensional.Index W T) ℕ
+    (Intensional.Index W T)

--- a/Linglib/Semantics/Events/Adjacency.lean
+++ b/Linglib/Semantics/Events/Adjacency.lean
@@ -21,21 +21,21 @@ are consumed by:
 /-- Two events are temporally adjacent (`∞_E` in [krifka-1998]'s
     notation) if their runtime intervals meet: one's finish equals
     the other's start. The natural concrete instance of K98's
-    abstract event-adjacency primitive (eq. 14) on the `Event Time`
-    structure where events have `runtime : Interval Time`. -/
-def Event.adjacent {Time : Type*} [LinearOrder Time]
-    (e1 e2 : Event Time) : Prop :=
+    abstract event-adjacency primitive (eq. 14) on the `Event T`
+    structure where events have `runtime : Interval T`. -/
+def Event.adjacent {T : Type*} [LinearOrder T]
+    (e1 e2 : Event T) : Prop :=
   e1.runtime.snd = e2.runtime.fst ∨ e2.runtime.snd = e1.runtime.fst
 
 /-- Event temporal precedence (`«_E` in K98 §2.5): one event's runtime
     is entirely before the other's. Defined via `Interval.isBefore`
-    from `Core/Time/Interval/Basic.lean`. -/
-def Event.precedes {Time : Type*} [LinearOrder Time]
-    (e1 e2 : Event Time) : Prop :=
+    from `Core/T/Interval/Basic.lean`. -/
+def Event.precedes {T : Type*} [LinearOrder T]
+    (e1 e2 : Event T) : Prop :=
   e1.runtime.isBefore e2.runtime
 
 /-- Event adjacency is symmetric. -/
-theorem Event.adjacent_comm {Time : Type*} [LinearOrder Time]
-    {e1 e2 : Event Time} :
+theorem Event.adjacent_comm {T : Type*} [LinearOrder T]
+    {e1 e2 : Event T} :
     e1.adjacent e2 ↔ e2.adjacent e1 :=
   or_comm

--- a/Linglib/Semantics/Events/Basic.lean
+++ b/Linglib/Semantics/Events/Basic.lean
@@ -46,9 +46,9 @@ sortless construction sites default to `.dynamic`.
 open Features
 
 /-- An event: a temporal individual with ontological sort. -/
-structure Event (Time : Type*) [LinearOrder Time] where
+structure Event (T : Type*) [LinearOrder T] where
   /-- The temporal extent of this event -/
-  runtime : NonemptyInterval Time
+  runtime : NonemptyInterval T
   /-- Ontological sort (aktionsart): `dynamic` or `stative` ([bach-1986]).
       This is the `Features.Dynamicity` feature — the action/state distinction
       at the event-token level. -/
@@ -56,39 +56,39 @@ structure Event (Time : Type*) [LinearOrder Time] where
 
 namespace Event
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-! ### Temporal trace -/
 
 /-- Temporal trace function τ(e) = the runtime interval of event e. -/
 @[simp]
-def τ (e : Event Time) : NonemptyInterval Time :=
+def τ (e : Event T) : NonemptyInterval T :=
   e.runtime
 
 /-! ### Sort predicates -/
 
 /-- Is this event an action (dynamic event)? -/
-def isAction (e : Event Time) : Prop :=
+def isAction (e : Event T) : Prop :=
   e.sort = .dynamic
 
 /-- Is this event a state (stative event)? -/
-def isState (e : Event Time) : Prop :=
+def isState (e : Event T) : Prop :=
   e.sort = .stative
 
-instance : DecidablePred (isAction (Time := Time)) :=
+instance : DecidablePred (isAction (T := T)) :=
   fun e => decEq e.sort .dynamic
 
-instance : DecidablePred (isState (Time := Time)) :=
+instance : DecidablePred (isState (T := T)) :=
   fun e => decEq e.sort .stative
 
 /-- `isAction` and `isState` are complementary. -/
-theorem isAction_iff_not_isState (e : Event Time) :
+theorem isAction_iff_not_isState (e : Event T) :
     e.isAction ↔ ¬ e.isState := by
   simp only [Event.isAction, Event.isState]
   cases e.sort <;> decide
 
 /-- `isState` and `isAction` are complementary. -/
-theorem isState_iff_not_isAction (e : Event Time) :
+theorem isState_iff_not_isAction (e : Event T) :
     e.isState ↔ ¬ e.isAction := by
   simp only [Event.isAction, Event.isState]
   cases e.sort <;> decide
@@ -98,37 +98,37 @@ theorem isState_iff_not_isAction (e : Event Time) :
 /-- Is this event punctual (instantaneous)? Its runtime is a single point.
     The temporal-extent counterpart of the dynamicity sort; derived from the
     runtime via `NonemptyInterval.IsPoint`. -/
-def isPunctual (e : Event Time) : Prop :=
+def isPunctual (e : Event T) : Prop :=
   e.τ.IsPoint
 
 /-- Is this event durative (temporally extended)? -/
-def isDurative (e : Event Time) : Prop :=
+def isDurative (e : Event T) : Prop :=
   ¬ e.isPunctual
 
-instance : DecidablePred (isPunctual (Time := Time)) :=
+instance : DecidablePred (isPunctual (T := T)) :=
   fun e => by unfold Event.isPunctual NonemptyInterval.IsPoint; infer_instance
 
-instance : DecidablePred (isDurative (Time := Time)) :=
+instance : DecidablePred (isDurative (T := T)) :=
   fun e => by unfold Event.isDurative; infer_instance
 
 /-- `isDurative` and `isPunctual` are complementary. -/
-theorem isDurative_iff_not_isPunctual (e : Event Time) :
+theorem isDurative_iff_not_isPunctual (e : Event T) :
     e.isDurative ↔ ¬ e.isPunctual := Iff.rfl
 
 /-! ### Existential closure -/
 
 /-- Existential closure: ∃e. P(e). The fundamental step from event
     semantics to truth conditions. -/
-def existsClosure (P : Event Time → Prop) : Prop :=
-  ∃ e : Event Time, P e
+def existsClosure (P : Event T → Prop) : Prop :=
+  ∃ e : Event T, P e
 
 /-! ### Mereology -/
 
 /-- Axioms for event part-of structure. Part-of is a partial order on
     events with temporal and sort constraints. -/
-class Mereology (Time : Type*) [LinearOrder Time] where
+class Mereology (T : Type*) [LinearOrder T] where
   /-- e₁ is a part of e₂ -/
-  partOf : Event Time → Event Time → Prop
+  partOf : Event T → Event T → Prop
   /-- Part-of is reflexive -/
   refl : ∀ e, partOf e e
   /-- Part-of is antisymmetric -/
@@ -144,8 +144,8 @@ class Mereology (Time : Type*) [LinearOrder Time] where
 
 /-- Event mereology induces a `PartialOrder`: parthood is reflexive,
     transitive, and antisymmetric. -/
-instance partialOrder (Time : Type*) [LinearOrder Time]
-    [m : Mereology Time] : PartialOrder (Event Time) where
+instance partialOrder (T : Type*) [LinearOrder T]
+    [m : Mereology T] : PartialOrder (Event T) where
   le := m.partOf
   le_refl := m.refl
   le_trans := m.trans
@@ -156,17 +156,17 @@ instance partialOrder (Time : Type*) [LinearOrder Time]
 /-- A manner: the "how" of an event, individuated as an equivalence class
     of events under a similarity relation ([liefke-2024] §4.3).
     Manners are to events what properties are to individuals. -/
-structure Manner (Time : Type*) [LinearOrder Time] where
+structure Manner (T : Type*) [LinearOrder T] where
   /-- The characteristic predicate: which events exhibit this manner -/
-  exhibits : Event Time → Prop
+  exhibits : Event T → Prop
 
 /-- The manner of an event under a similarity criterion.
     `e.manner sim` gives the manner class of `e` under `sim`. -/
-def manner (e : Event Time) (sim : Event Time → Event Time → Prop) : Manner Time :=
+def manner (e : Event T) (sim : Event T → Event T → Prop) : Manner T :=
   ⟨sim e⟩
 
 /-- Two events share a manner iff both satisfy the manner predicate. -/
-def Manner.sharedBy (m : Manner Time) (e₁ e₂ : Event Time) : Prop :=
+def Manner.sharedBy (m : Manner T) (e₁ e₂ : Event T) : Prop :=
   m.exhibits e₁ ∧ m.exhibits e₂
 
 end Event
@@ -185,27 +185,27 @@ stated as order-theoretic facts about it (see
 
 section Denotation
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- The event→interval projection: the set of run-time intervals of events
     satisfying `P`, i.e. the image of `P` under the temporal trace τ. Every
     event-level temporal theory projects to the interval level through this map. -/
-def eventDenotation (P : Event Time → Prop) : Set (NonemptyInterval Time) :=
+def eventDenotation (P : Event T → Prop) : Set (NonemptyInterval T) :=
   Event.τ '' { e | P e }
 
 /-- Membership in `eventDenotation`: an interval is a run-time of some `P`-event. -/
 @[simp]
-theorem mem_eventDenotation {P : Event Time → Prop} {i : NonemptyInterval Time} :
+theorem mem_eventDenotation {P : Event T → Prop} {i : NonemptyInterval T} :
     i ∈ eventDenotation P ↔ ∃ e, P e ∧ e.τ = i := Iff.rfl
 
 /-- No events satisfy `P` ↔ the denotation is empty. -/
-theorem eventDenotation_eq_empty {P : Event Time → Prop} :
+theorem eventDenotation_eq_empty {P : Event T → Prop} :
     eventDenotation P = ∅ ↔ ∀ e, ¬ P e := by
   rw [eventDenotation, Set.image_eq_empty]
   exact Set.eq_empty_iff_forall_notMem
 
 /-- The run-time of any `P`-event is in the denotation. -/
-theorem mem_eventDenotation_of {P : Event Time → Prop} {e : Event Time} (he : P e) :
+theorem mem_eventDenotation_of {P : Event T → Prop} {e : Event T} (he : P e) :
     e.τ ∈ eventDenotation P :=
   Set.mem_image_of_mem _ he
 

--- a/Linglib/Semantics/Events/CEM.lean
+++ b/Linglib/Semantics/Events/CEM.lean
@@ -16,12 +16,12 @@ There is deliberately no single bundled event-mereology class. An event theory's
 two assumptions — that events form a classical mereology, and (separately) that a
 trace function such as the temporal trace `Event.runtime` preserves sums (a
 `SupHom`) — are logically independent, so callers state the standard mixins
-directly: `[ClassicalMereology (Event Time)]` and, where τ-pullback is needed, a
+directly: `[ClassicalMereology (Event T)]` and, where τ-pullback is needed, a
 `map_sup` hypothesis on the trace ([champollion-2017] §2.5; [bach-1986] for the
 underlying event algebra).
 
 Lexical cumulativity of a verb predicate is just `Mereology.CUM` over
-`Event Time` — [champollion-2017] takes it as a working hypothesis, *universal*
+`Event T` — [champollion-2017] takes it as a working hypothesis, *universal*
 over verbal predicates (telic ones included) — so it is used directly with no
 event-specific re-spelling.
 
@@ -42,16 +42,16 @@ open _root_.Mereology
 /-- The binary sum `⊔` on events, derived from the classical-mereology fusion
     axioms: `e₁ ⊔ e₂` is the unique type-2 fusion of `{e₁, e₂}`. Noncomputable
     because the fusion is extracted by choice from `Fusion2E`. -/
-noncomputable instance instSemilatticeSupEvent (Time : Type*) [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)] :
-    SemilatticeSup (Event Time) :=
+noncomputable instance instSemilatticeSupEvent (T : Type*) [LinearOrder T]
+    [Event.Mereology T] [ClassicalMereology (Event T)] :
+    SemilatticeSup (Event T) :=
   ClassicalMereology.toSemilatticeSup
 
 /-- The event sum `e₁ ⊔ e₂` is the least upper bound of `{e₁, e₂}` under
     parthood — i.e. the mereological fusion, not a stipulated operation. -/
-theorem sup_isLUB {Time : Type*} [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    (e₁ e₂ : Event Time) : IsLUB {e₁, e₂} (e₁ ⊔ e₂) :=
+theorem sup_isLUB {T : Type*} [LinearOrder T]
+    [Event.Mereology T] [ClassicalMereology (Event T)]
+    (e₁ e₂ : Event T) : IsLUB {e₁, e₂} (e₁ ⊔ e₂) :=
   Classical.choose_spec (ClassicalMereology.exists_isLUB_pair e₁ e₂)
 
 end Events.CEM

--- a/Linglib/Semantics/Events/SpatialTrace.lean
+++ b/Linglib/Semantics/Events/SpatialTrace.lean
@@ -31,17 +31,17 @@ namespace Spatial
     use sites, per `Semantics/Events/CEM.lean`: sum preservation as a
     `map_sup` hypothesis, `Function.Injective st.σ` where QUA pullback needs
     it. -/
-class Trace (Loc Time : Type*) [LinearOrder Time] where
+class Trace (Loc T : Type*) [LinearOrder T] where
   /-- The path traversed in an event. -/
-  σ : Event Time → Path Loc
+  σ : Event T → Path Loc
 
 namespace Trace
 
 /-! ### Telicity transfer through σ -/
 
-variable {Loc Time : Type*} [LinearOrder Time] [Event.Mereology Time]
-  [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
-  [st : Trace Loc Time] {P : Path Loc → Prop}
+variable {Loc T : Type*} [LinearOrder T] [Event.Mereology T]
+  [ClassicalMereology (Event T)] [SemilatticeSup (Path Loc)]
+  [st : Trace Loc T] {P : Path Loc → Prop}
 
 /-- QUA path predicates pull back through an injective sum-homomorphic σ to
     QUA (telic) VP predicates — [krifka-1998]'s quantization route to

--- a/Linglib/Semantics/Intensional/Index.lean
+++ b/Linglib/Semantics/Intensional/Index.lean
@@ -19,11 +19,11 @@ namespace Intensional
     This is the Lewis/Kaplan "index" — a coordinate tuple as point of
     evaluation, abstracting from the spatial/parthood structure of true
     Kratzer situations (see `Intensional.Situations`). -/
-structure Index (W Time : Type*) where
+structure Index (W T : Type*) where
   /-- The world coordinate -/
   world : W
   /-- The temporal coordinate -/
-  time : Time
+  time : T
   deriving Repr
 
 end Intensional

--- a/Linglib/Semantics/Modality/HistoricalAlternatives.lean
+++ b/Linglib/Semantics/Modality/HistoricalAlternatives.lean
@@ -41,11 +41,11 @@ open Intensional (Index)
 /-- Historical-alternatives relation: given a ⟨world, time⟩ index, returns the
     worlds that agree with that world up to that time. This is the basis for the
     "historical" or "open future" modal base used in future-oriented modality. -/
-def HistoricalAlternatives (W Time : Type*) := Index W Time → Set W
+def HistoricalAlternatives (W T : Type*) := Index W T → Set W
 
 namespace HistoricalAlternatives
 
-variable {W Time : Type*}
+variable {W T : Type*}
 
 /-! ## Partial History Taxonomy
 
@@ -55,69 +55,69 @@ all five as predicates on time pairs. Only actual and future drive the core
 DOX/CIR mechanism, but the full taxonomy is needed for extensions (prospective
 is the temporal component of `historicalBase` below).
 
-These are framework-neutral interval predicates over `LE Time` / `LT Time`; the
+These are framework-neutral interval predicates over `LE T` / `LT T`; the
 [klecha-2016] citation is for the terminology, not the mathematical content
 (which is just `≤`, `<`, `>`, `≥`). -/
 
 /-- Maximal history: unrestricted temporal extent (Ω_t = all histories). -/
-def isMaximalHistory (_evalTime _historyTime : Time) : Prop :=
+def isMaximalHistory (_evalTime _historyTime : T) : Prop :=
   True
 
 /-- Actual history: temporal component ends at or before `t` (𝒜_t). -/
-def isActualHistory [LE Time] (evalTime historyTime : Time) : Prop :=
+def isActualHistory [LE T] (evalTime historyTime : T) : Prop :=
   historyTime ≤ evalTime
 
 /-- Past history: temporal component ends strictly before `t` (𝒫_t).
     Distinct from actual: past excludes `t` itself. -/
-def isPastHistory [LT Time] (evalTime historyTime : Time) : Prop :=
+def isPastHistory [LT T] (evalTime historyTime : T) : Prop :=
   historyTime < evalTime
 
 /-- Future history: temporal component starts strictly after `t` (ℱ_t). -/
-def isFutureHistory [LT Time] (evalTime historyTime : Time) : Prop :=
+def isFutureHistory [LT T] (evalTime historyTime : T) : Prop :=
   historyTime > evalTime
 
 /-- Prospective history: temporal component starts at or after `t` (ℙ_t).
     This is exactly the temporal component of `historicalBase`. -/
-def isProspectiveHistory [LE Time] (evalTime historyTime : Time) : Prop :=
+def isProspectiveHistory [LE T] (evalTime historyTime : T) : Prop :=
   historyTime ≥ evalTime
 
 /-- Actual and future histories are complementary: every time is
     either ≤ t (actual) or > t (future). -/
-theorem actual_future_complementary [LinearOrder Time]
-    (evalTime historyTime : Time) :
+theorem actual_future_complementary [LinearOrder T]
+    (evalTime historyTime : T) :
     isActualHistory evalTime historyTime ∨ isFutureHistory evalTime historyTime :=
   (lt_or_ge evalTime historyTime).elim Or.inr Or.inl
 
 /-- Past and prospective histories are complementary: every time is
     either < t (past) or ≥ t (prospective). -/
-theorem past_prospective_complementary [LinearOrder Time]
-    (evalTime historyTime : Time) :
+theorem past_prospective_complementary [LinearOrder T]
+    (evalTime historyTime : T) :
     isPastHistory evalTime historyTime ∨ isProspectiveHistory evalTime historyTime :=
   (lt_or_ge historyTime evalTime).elim Or.inl Or.inr
 
 /-- Past ⊂ actual: strict past implies actual. -/
-theorem past_implies_actual [Preorder Time]
-    (evalTime historyTime : Time) (h : isPastHistory evalTime historyTime) :
+theorem past_implies_actual [Preorder T]
+    (evalTime historyTime : T) (h : isPastHistory evalTime historyTime) :
     isActualHistory evalTime historyTime :=
   le_of_lt h
 
 /-- Future ⊂ prospective: strict future implies prospective. -/
-theorem future_implies_prospective [Preorder Time]
-    (evalTime historyTime : Time) (h : isFutureHistory evalTime historyTime) :
+theorem future_implies_prospective [Preorder T]
+    (evalTime historyTime : T) (h : isFutureHistory evalTime historyTime) :
     isProspectiveHistory evalTime historyTime :=
   le_of_lt h
 
 /-- Actual ∩ prospective = simultaneous: a time that is both actual
     and prospective is exactly the evaluation time. -/
-theorem actual_and_prospective_iff_simultaneous [PartialOrder Time]
-    (evalTime historyTime : Time) :
+theorem actual_and_prospective_iff_simultaneous [PartialOrder T]
+    (evalTime historyTime : T) :
     isActualHistory evalTime historyTime ∧ isProspectiveHistory evalTime historyTime ↔
     historyTime = evalTime :=
   ⟨λ ⟨hle, hge⟩ => le_antisymm hle hge, λ h => ⟨le_of_eq h, ge_of_eq h⟩⟩
 
 /-- Past and future are disjoint: no time is both < t and > t. -/
-theorem past_future_disjoint [Preorder Time]
-    (evalTime historyTime : Time) :
+theorem past_future_disjoint [Preorder T]
+    (evalTime historyTime : T) :
     ¬(isPastHistory evalTime historyTime ∧ isFutureHistory evalTime historyTime) := by
   intro ⟨h1, h2⟩
   exact lt_asymm h1 h2
@@ -127,53 +127,53 @@ theorem past_future_disjoint [Preorder Time]
 /-- Historical modal base: situations whose worlds agree with `s` up to τ(s),
     and whose times are at or after τ(s). Past is fixed, the future branches
     ([thomason-1984], [condoravdi-2002]). -/
-def historicalBase [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (s : Index W Time) : Set (Index W Time) :=
+def historicalBase [LE T]
+    (history : HistoricalAlternatives W T)
+    (s : Index W T) : Set (Index W T) :=
   { s' | s'.world ∈ history s ∧ isProspectiveHistory s.time s'.time }
 
 /-- Actual history base ([klecha-2016] DOX): situations whose worlds agree
     with `s` and whose times are at or before τ(s) — the temporal mirror of
     `historicalBase`. -/
-def actualHistoryBase [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (s : Index W Time) : Set (Index W Time) :=
+def actualHistoryBase [LE T]
+    (history : HistoricalAlternatives W T)
+    (s : Index W T) : Set (Index W T) :=
   { s' | s'.world ∈ history s ∧ isActualHistory s.time s'.time }
 
 /-- Future history base ([klecha-2016] CIR): situations whose worlds agree
     with `s` and whose times are strictly after τ(s). -/
-def futureHistoryBase [LT Time]
-    (history : HistoricalAlternatives W Time)
-    (s : Index W Time) : Set (Index W Time) :=
+def futureHistoryBase [LT T]
+    (history : HistoricalAlternatives W T)
+    (s : Index W T) : Set (Index W T) :=
   { s' | s'.world ∈ history s ∧ isFutureHistory s.time s'.time }
 
 /-- A historical-alternatives relation is reflexive if every world agrees with
     itself. -/
-def reflexive (h : HistoricalAlternatives W Time) : Prop :=
-  ∀ s : Index W Time, s.world ∈ h s
+def reflexive (h : HistoricalAlternatives W T) : Prop :=
+  ∀ s : Index W T, s.world ∈ h s
 
 /-- A historical-alternatives relation is symmetric: if `w'` agrees with `w` up
     to `t`, then `w` agrees with `w'` up to `t`. Part of `≃_t` being an
     equivalence relation ([condoravdi-2002]). -/
-def symmetric (h : HistoricalAlternatives W Time) : Prop :=
-  ∀ (w w' : W) (t : Time), w' ∈ h ⟨w, t⟩ → w ∈ h ⟨w', t⟩
+def symmetric (h : HistoricalAlternatives W T) : Prop :=
+  ∀ (w w' : W) (t : T), w' ∈ h ⟨w, t⟩ → w ∈ h ⟨w', t⟩
 
 /-- A historical-alternatives relation is transitive: if `w'` agrees with `w` up
     to `t` and `w''` agrees with `w'` up to `t`, then `w''` agrees with `w` up
     to `t`. -/
-def transitive (h : HistoricalAlternatives W Time) : Prop :=
-  ∀ (w w' w'' : W) (t : Time), w' ∈ h ⟨w, t⟩ → w'' ∈ h ⟨w', t⟩ → w'' ∈ h ⟨w, t⟩
+def transitive (h : HistoricalAlternatives W T) : Prop :=
+  ∀ (w w' w'' : W) (t : T), w' ∈ h ⟨w, t⟩ → w'' ∈ h ⟨w', t⟩ → w'' ∈ h ⟨w, t⟩
 
 /-- A historical-alternatives relation is backwards-closed: if `w'` agrees with
     `w` up to `t` and `t' ≤ t`, then `w'` agrees with `w` up to `t'`
     ([condoravdi-2002]). -/
-def backwardsClosed [LE Time] (h : HistoricalAlternatives W Time) : Prop :=
-  ∀ (w w' : W) (t t' : Time), t' ≤ t → w' ∈ h ⟨w, t⟩ → w' ∈ h ⟨w, t'⟩
+def backwardsClosed [LE T] (h : HistoricalAlternatives W T) : Prop :=
+  ∀ (w w' : W) (t t' : T), t' ≤ t → w' ∈ h ⟨w, t⟩ → w' ∈ h ⟨w, t'⟩
 
 /-- Standard historical modal base properties: `≃_t` is an equivalence relation
     that is monotone in time ([condoravdi-2002]). -/
-structure HistoricalProperties [LE Time]
-    (h : HistoricalAlternatives W Time) : Prop where
+structure HistoricalProperties [LE T]
+    (h : HistoricalAlternatives W T) : Prop where
   /-- Every world agrees with itself -/
   refl : h.reflexive
   /-- Historical agreement is symmetric -/
@@ -185,15 +185,15 @@ structure HistoricalProperties [LE Time]
 
 /-- A temporal proposition: true or false at each situation. The
     situation-semantic analog of `Prop' W`. -/
-abbrev TProp (W Time : Type*) := Index W Time → Prop
+abbrev TProp (W T : Type*) := Index W T → Prop
 
 /-- Lift a world proposition to a temporal proposition, true at situation `s`
     iff the original holds at `s.world`. -/
-def liftProp (p : W → Prop) : TProp W Time :=
+def liftProp (p : W → Prop) : TProp W T :=
   λ s => p s.world
 
 /-- A proposition holds at time `t` in world `w`. -/
-def holdsAt (p : TProp W Time) (w : W) (t : Time) : Prop :=
+def holdsAt (p : TProp W T) (w : W) (t : T) : Prop :=
   p ⟨w, t⟩
 
 /-! ## Klecha 2016: ULC derived from history structure
@@ -218,15 +218,15 @@ by `HistoricalAlternatives` membership; the value-level projection
 `s'.time ≤ s.time` recovers Abusch's bare-`≤` form. -/
 
 /-- A situation in `historicalBase` has prospective time. -/
-theorem historicalBase_time_prospective [LE Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem historicalBase_time_prospective [LE T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (h : s' ∈ historicalBase history s) :
     isProspectiveHistory s.time s'.time :=
   h.2
 
 /-- A situation in `actualHistoryBase` has actual time. -/
-theorem actualHistoryBase_time_actual [LE Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem actualHistoryBase_time_actual [LE T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (h : s' ∈ actualHistoryBase history s) :
     isActualHistory s.time s'.time :=
   h.2
@@ -235,40 +235,40 @@ theorem actualHistoryBase_time_actual [LE Time]
     relative to a matrix situation `s` and doxastic accessibility `history` iff
     `s'` lies in `s`'s actual-history base. See the section note for how this
     recovers [abusch-1997]'s alternative-quantifying formulation. -/
-def upperLimitConstraintModal [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (matrixSituation embeddedSituation : Index W Time) : Prop :=
+def upperLimitConstraintModal [LE T]
+    (history : HistoricalAlternatives W T)
+    (matrixSituation embeddedSituation : Index W T) : Prop :=
   embeddedSituation ∈ actualHistoryBase history matrixSituation
 
 /-- The modal-layer Upper Limit Constraint implies the value-level one
     (`embeddedSituation.time ≤ matrixSituation.time`), by `.2` projection
     through `actualHistoryBase`. -/
-theorem upperLimitConstraintModal_implies_value [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (s s' : Index W Time)
+theorem upperLimitConstraintModal_implies_value [LE T]
+    (history : HistoricalAlternatives W T)
+    (s s' : Index W T)
     (h : upperLimitConstraintModal history s s') :
     s'.time ≤ s.time :=
   h.2
 
 /-- A situation in `futureHistoryBase` has future time. -/
-theorem futureHistoryBase_time_future [LT Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem futureHistoryBase_time_future [LT T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (h : s' ∈ futureHistoryBase history s) :
     isFutureHistory s.time s'.time :=
   h.2
 
 /-- `futureHistoryBase ⊆ historicalBase`: future situations are prospective.
     The situation-semantic instantiation of `future_implies_prospective`. -/
-theorem futureHistoryBase_subset_historicalBase [Preorder Time]
-    (history : HistoricalAlternatives W Time) (s : Index W Time) :
+theorem futureHistoryBase_subset_historicalBase [Preorder T]
+    (history : HistoricalAlternatives W T) (s : Index W T) :
     futureHistoryBase history s ⊆ historicalBase history s :=
   λ _ ⟨hw, ht⟩ => ⟨hw, le_of_lt ht⟩
 
 /-- `actualHistoryBase ∩ historicalBase` contains only simultaneous situations.
     The situation-semantic instantiation of
     `actual_and_prospective_iff_simultaneous`. -/
-theorem actualBase_inter_historicalBase_simultaneous [PartialOrder Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem actualBase_inter_historicalBase_simultaneous [PartialOrder T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (hActual : s' ∈ actualHistoryBase history s)
     (hHist : s' ∈ historicalBase history s) :
     s'.time = s.time :=
@@ -276,8 +276,8 @@ theorem actualBase_inter_historicalBase_simultaneous [PartialOrder Time]
 
 /-- Actual and future history bases are disjoint on the time component.
     The situation-semantic instantiation of `past_future_disjoint`. -/
-theorem actualBase_futureBase_disjoint [Preorder Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time) :
+theorem actualBase_futureBase_disjoint [Preorder T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T) :
     ¬(s' ∈ actualHistoryBase history s ∧ s' ∈ futureHistoryBase history s) := by
   intro ⟨⟨_, hle⟩, ⟨_, hgt⟩⟩
   exact lt_irrefl _ (lt_of_lt_of_le hgt hle)
@@ -285,8 +285,8 @@ theorem actualBase_futureBase_disjoint [Preorder Time]
 /-- Every situation is in `actualHistoryBase ∪ futureHistoryBase` on the time
     component. The situation-semantic instantiation of
     `actual_future_complementary`. -/
-theorem actualBase_futureBase_complementary [LinearOrder Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem actualBase_futureBase_complementary [LinearOrder T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (hw : s'.world ∈ history s) :
     s' ∈ actualHistoryBase history s ∨ s' ∈ futureHistoryBase history s :=
   (le_or_gt s'.time s.time).elim
@@ -295,8 +295,8 @@ theorem actualBase_futureBase_complementary [LinearOrder Time]
 
 /-- Converse: prospective time + world agreement → membership in
     `historicalBase`. -/
-theorem prospective_time_mem_historicalBase [LE Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem prospective_time_mem_historicalBase [LE T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (hw : s'.world ∈ history s)
     (ht : isProspectiveHistory s.time s'.time) :
     s' ∈ historicalBase history s :=
@@ -304,8 +304,8 @@ theorem prospective_time_mem_historicalBase [LE Time]
 
 /-- Converse: actual time + world agreement → membership in
     `actualHistoryBase`. -/
-theorem actual_time_mem_actualHistoryBase [LE Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem actual_time_mem_actualHistoryBase [LE T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (hw : s'.world ∈ history s)
     (ht : isActualHistory s.time s'.time) :
     s' ∈ actualHistoryBase history s :=
@@ -313,8 +313,8 @@ theorem actual_time_mem_actualHistoryBase [LE Time]
 
 /-- Converse: future time + world agreement → membership in
     `futureHistoryBase`. -/
-theorem future_time_mem_futureHistoryBase [LT Time]
-    (history : HistoricalAlternatives W Time) (s s' : Index W Time)
+theorem future_time_mem_futureHistoryBase [LT T]
+    (history : HistoricalAlternatives W T) (s s' : Index W T)
     (hw : s'.world ∈ history s)
     (ht : isFutureHistory s.time s'.time) :
     s' ∈ futureHistoryBase history s :=
@@ -328,73 +328,73 @@ might have gone" — worlds that agree on the past but may diverge in the future
 
 /-- Historical equivalence: `w'` agrees with `w` up to time `t`.
     `w ≃_t w'` iff `w' ∈ history(w, t)`. -/
-def histEquiv (history : HistoricalAlternatives W Time) (t : Time)
+def histEquiv (history : HistoricalAlternatives W T) (t : T)
     (w w' : W) : Prop :=
   w' ∈ history ⟨w, t⟩
 
 /-- `histEquiv history t` is an equivalence relation when `history` satisfies the
     standard properties ([condoravdi-2002]). -/
-def histEquiv_equivalence {history : HistoricalAlternatives W Time}
+def histEquiv_equivalence {history : HistoricalAlternatives W T}
     (hRefl : history.reflexive) (hSymm : history.symmetric)
-    (hTrans : history.transitive) (t : Time) :
+    (hTrans : history.transitive) (t : T) :
     Equivalence (histEquiv history t) where
   refl w := hRefl ⟨w, t⟩
   symm h := hSymm _ _ t h
   trans h₁ h₂ := hTrans _ _ _ t h₁ h₂
 
 /-- The `Setoid` induced by historical equivalence at time `t`. -/
-def histSetoid {history : HistoricalAlternatives W Time}
+def histSetoid {history : HistoricalAlternatives W T}
     (hRefl : history.reflexive) (hSymm : history.symmetric)
-    (hTrans : history.transitive) (t : Time) : Setoid W where
+    (hTrans : history.transitive) (t : T) : Setoid W where
   r := histEquiv history t
   iseqv := histEquiv_equivalence hRefl hSymm hTrans t
 
 /-- `histEquiv_equivalence` from bundled `HistoricalProperties`. -/
-def histEquiv_equivalence' {history : HistoricalAlternatives W Time} [LE Time]
-    (hp : HistoricalProperties history) (t : Time) :
+def histEquiv_equivalence' {history : HistoricalAlternatives W T} [LE T]
+    (hp : HistoricalProperties history) (t : T) :
     Equivalence (histEquiv history t) :=
   histEquiv_equivalence hp.refl hp.symm hp.trans t
 
 /-- `histSetoid` from bundled `HistoricalProperties`. -/
-def histSetoid' {history : HistoricalAlternatives W Time} [LE Time]
-    (hp : HistoricalProperties history) (t : Time) : Setoid W :=
+def histSetoid' {history : HistoricalAlternatives W T} [LE T]
+    (hp : HistoricalProperties history) (t : T) : Setoid W :=
   histSetoid hp.refl hp.symm hp.trans t
 
 /-- Historical equivalence is reflexive (from `reflexive`). -/
-theorem histEquiv_refl {history : HistoricalAlternatives W Time}
-    (hRefl : history.reflexive) (t : Time) (w : W) :
+theorem histEquiv_refl {history : HistoricalAlternatives W T}
+    (hRefl : history.reflexive) (t : T) (w : W) :
     histEquiv history t w w :=
   hRefl ⟨w, t⟩
 
 /-- Historical equivalence is symmetric (from `symmetric`). -/
-theorem histEquiv_symm {history : HistoricalAlternatives W Time}
-    (hSymm : history.symmetric) (t : Time) {w w' : W}
+theorem histEquiv_symm {history : HistoricalAlternatives W T}
+    (hSymm : history.symmetric) (t : T) {w w' : W}
     (h : histEquiv history t w w') :
     histEquiv history t w' w :=
   hSymm w w' t h
 
 /-- Historical equivalence is transitive (from `transitive`). -/
-theorem histEquiv_trans {history : HistoricalAlternatives W Time}
-    (hTrans : history.transitive) (t : Time) {w w' w'' : W}
+theorem histEquiv_trans {history : HistoricalAlternatives W T}
+    (hTrans : history.transitive) (t : T) {w w' w'' : W}
     (h₁ : histEquiv history t w w')
     (h₂ : histEquiv history t w' w'') :
     histEquiv history t w w'' :=
   hTrans w w' w'' t h₁ h₂
 
-variable [LE Time] in
+variable [LE T] in
 /-- Historical equivalence is monotone in time: agreement up to a later time
     implies agreement up to an earlier time (from `backwardsClosed`). -/
-theorem histEquiv_mono {history : HistoricalAlternatives W Time}
-    (hBC : history.backwardsClosed) {t t' : Time} (w w' : W)
+theorem histEquiv_mono {history : HistoricalAlternatives W T}
+    (hBC : history.backwardsClosed) {t t' : T} (w w' : W)
     (hle : t' ≤ t) (h : histEquiv history t w w') :
     histEquiv history t' w w' :=
   hBC w w' t t' hle h
 
-variable [LE Time] in
+variable [LE T] in
 /-- The set of metaphysical alternatives shrinks as time advances
     ([condoravdi-2002]): `t ↦ { w' | w ≃_t w' }` is antitone. -/
-theorem alternatives_antitone {history : HistoricalAlternatives W Time}
-    (hBC : history.backwardsClosed) (w : W) {t t' : Time}
+theorem alternatives_antitone {history : HistoricalAlternatives W T}
+    (hBC : history.backwardsClosed) (w : W) {t t' : T}
     (hle : t ≤ t') :
     { w' | histEquiv history t' w w' } ⊆
     { w' | histEquiv history t w w' } :=
@@ -408,15 +408,15 @@ maximal modal base compatible with the world's history up to `t`. -/
 
 /-- The metaphysical modal base: at world `w` and time `t`, the set of all worlds
     sharing `w`'s history up to `t`. -/
-def metaphysicalBase (history : HistoricalAlternatives W Time) :
-    W → Time → Set W :=
+def metaphysicalBase (history : HistoricalAlternatives W T) :
+    W → T → Set W :=
   λ w t => { w' | histEquiv history t w w' }
 
-variable [LE Time] in
+variable [LE T] in
 /-- The metaphysical modal base is antitone in time: later times yield smaller
     accessible sets. -/
-theorem metaphysicalBase_antitone {history : HistoricalAlternatives W Time}
-    (hBC : history.backwardsClosed) (w : W) {t t' : Time}
+theorem metaphysicalBase_antitone {history : HistoricalAlternatives W T}
+    (hBC : history.backwardsClosed) (w : W) {t t' : T}
     (hle : t ≤ t') :
     metaphysicalBase history w t' ⊆ metaphysicalBase history w t :=
   alternatives_antitone hBC w hle
@@ -431,15 +431,15 @@ base must contain worlds that disagree on the property. -/
 
 /-- Settledness: within each common-ground equivalence class, the property `P` is
     resolved uniformly — all historically equivalent worlds agree on `P`. -/
-def settled (history : HistoricalAlternatives W Time) (cg : Set W)
-    (t₀ : Time) (P : W → Prop) : Prop :=
+def settled (history : HistoricalAlternatives W T) (cg : Set W)
+    (t₀ : T) (P : W → Prop) : Prop :=
   ∀ w ∈ cg, ∀ w', histEquiv history t₀ w w' → (P w ↔ P w')
 
 /-- Diversity condition: there is a common-ground world whose modal base contains
     worlds disagreeing on `P`. The felicity condition for pairing a metaphysical
     modal base with a possibility modal ([condoravdi-2002]). -/
-def diverse (MB : W → Time → Set W) (cg : Set W)
-    (t : Time) (P : W → Prop) : Prop :=
+def diverse (MB : W → T → Set W) (cg : Set W)
+    (t : T) (P : W → Prop) : Prop :=
   ∃ w ∈ cg, ∃ w' ∈ MB w t, ∃ w'' ∈ MB w t, P w' ∧ ¬ P w''
 
 /-- When `MB(w,t) ⊆ {w' | w ≃_t w'}` (the metaphysical case) and `P` is settled,
@@ -447,8 +447,8 @@ def diverse (MB : W → Time → Set W) (cg : Set W)
     witness disagreement. The key theorem blocking metaphysical readings for
     settled properties. -/
 theorem settled_not_diverse
-    (history : HistoricalAlternatives W Time) (MB : W → Time → Set W)
-    (cg : Set W) (t : Time) (P : W → Prop)
+    (history : HistoricalAlternatives W T) (MB : W → T → Set W)
+    (cg : Set W) (t : T) (P : W → Prop)
     (hMB : ∀ w ∈ cg, ∀ w' ∈ MB w t, histEquiv history t w w')
     (hSettled : settled history cg t P) :
     ¬ diverse MB cg t P := by
@@ -461,7 +461,7 @@ theorem settled_not_diverse
     `cg` and fails for another, both accessible from some `w` via `MB`, then
     diversity holds. -/
 theorem diverse_of_witnesses
-    (MB : W → Time → Set W) (cg : Set W) (t : Time) (P : W → Prop)
+    (MB : W → T → Set W) (cg : Set W) (t : T) (P : W → Prop)
     (w : W) (hwcg : w ∈ cg)
     (w' w'' : W) (hw' : w' ∈ MB w t) (hw'' : w'' ∈ MB w t)
     (hP : P w') (hnP : ¬ P w'') :
@@ -480,41 +480,41 @@ the same operator ([thomason-1984], [von-kutschera-1997]). -/
 section TWFrame
 open Temporal
 
-variable [LinearOrder Time] {Atom : Type*}
-  (history : HistoricalAlternatives W Time) (hp : HistoricalProperties history)
+variable [LinearOrder T] {Atom : Type*}
+  (history : HistoricalAlternatives W T) (hp : HistoricalProperties history)
 
 /-- A historical-alternatives relation with `HistoricalProperties`, viewed as a
     `TWFrame`: `sim` is `histEquiv`, reusing `histEquiv_equivalence'` for the
     equivalence axiom and `backwards` for backward closure. -/
-def toTWFrame : TWFrame Time W where
+def toTWFrame : TWFrame T W where
   sim := histEquiv history
   sim_equiv t := histEquiv_equivalence' hp t
   sim_backward w w' hle h := hp.backwards w w' _ _ hle h
 
-@[simp] theorem toTWFrame_sim (t : Time) (w w' : W) :
+@[simp] theorem toTWFrame_sim (t : T) (w w' : W) :
     (toTWFrame history hp).sim t w w' ↔ w' ∈ metaphysicalBase history w t := Iff.rfl
 
 /-- Historical necessity `N` in the object logic = truth throughout the
     metaphysical base. -/
-theorem toTWFrame_sat_N_atom (V : Atom → Time → W → Prop) (p : Atom) (t : Time) (w : W) :
+theorem toTWFrame_sat_N_atom (V : Atom → T → W → Prop) (p : Atom) (t : T) (w : W) :
     (toTWFrame history hp).sat V (.N (.atom p)) t w ↔
       ∀ w' ∈ metaphysicalBase history w t, V p t w' := by
   simp only [TWFrame.sat_N, TWFrame.sat_atom, toTWFrame_sim]
 
 /-- The all-worlds modality `box` = truth in every world (the unrestricted base). -/
-theorem toTWFrame_sat_box_atom (V : Atom → Time → W → Prop) (p : Atom) (t : Time) (w : W) :
+theorem toTWFrame_sat_box_atom (V : Atom → T → W → Prop) (p : Atom) (t : T) (w : W) :
     (toTWFrame history hp).sat V (.box (.atom p)) t w ↔ ∀ w', V p t w' := by
   simp only [TWFrame.sat_box, TWFrame.sat_atom]
 
 include hp in
 /-- The evaluation world is always a metaphysical alternative to itself. -/
-theorem mem_metaphysicalBase_self (t : Time) (w : W) :
+theorem mem_metaphysicalBase_self (t : T) (w : W) :
     w ∈ metaphysicalBase history w t := hp.refl ⟨w, t⟩
 
 /-- A formula is **historically determined** at `(t, w)` — the object logic decides it,
     `N a ∨ N ¬a` — iff it is constant across the metaphysical base. The single-world,
     formula-general core of settledness. -/
-theorem toTWFrame_N_or_N_neg_iff (V : Atom → Time → W → Prop) (a : OForm Atom) (t : Time) (w : W) :
+theorem toTWFrame_N_or_N_neg_iff (V : Atom → T → W → Prop) (a : OForm Atom) (t : T) (w : W) :
     ((toTWFrame history hp).sat V a.N t w ∨ (toTWFrame history hp).sat V a.neg.N t w) ↔
       ∀ w' ∈ metaphysicalBase history w t,
         ((toTWFrame history hp).sat V a t w' ↔ (toTWFrame history hp).sat V a t w) := by
@@ -534,7 +534,7 @@ theorem toTWFrame_N_or_N_neg_iff (V : Atom → Time → W → Prop) (a : OForm A
     `IsInevitable`). `P` is the already-forward-instantiated world proposition (Condoravdi's
     `AT([t₀,_), ·, P)`; the AT-wrapper is discharged by the caller). Cf. [klecha-2016]'s
     `futureHistoryBase` — the slice on which determinacy can fail. -/
-theorem settled_iff_determined (cg : Set W) (P : W → Prop) (t : Time) :
+theorem settled_iff_determined (cg : Set W) (P : W → Prop) (t : T) :
     settled history cg t P ↔
       ∀ w ∈ cg,
         ((toTWFrame history hp).sat (fun _ _ w' => P w') (.N (.atom ())) t w ∨

--- a/Linglib/Semantics/Modality/Selectional.lean
+++ b/Linglib/Semantics/Modality/Selectional.lean
@@ -288,18 +288,18 @@ Selectional `will` parameterized by the metaphysical modal base of
 /-- **Selectional `will` over historical alternatives.** Evaluates
     the prejacent at the world selected from the metaphysical modal
     base at ⟨w, t⟩. -/
-def willHistorical {Time : Type*} (s : SelectionFunction W)
-    (history : HistoricalAlternatives W Time) (A : W → Prop)
-    (w : W) (t : Time) : Prop :=
+def willHistorical {T : Type*} (s : SelectionFunction W)
+    (history : HistoricalAlternatives W T) (A : W → Prop)
+    (w : W) (t : T) : Prop :=
   willSem s A (metaphysicalBase history w t) w
 
 /-- When the world-history relation is reflexive (the standard
     assumption that a world is among its own historical alternatives,
     [condoravdi-2002]), `willHistorical` collapses to its prejacent:
     `will_t A` at `w` reduces to `A w`. -/
-theorem willHistorical_reflexive_collapse {Time : Type*}
-    (s : SelectionFunction W) {history : HistoricalAlternatives W Time}
-    (hRefl : history.reflexive) (A : W → Prop) (w : W) (t : Time) :
+theorem willHistorical_reflexive_collapse {T : Type*}
+    (s : SelectionFunction W) {history : HistoricalAlternatives W T}
+    (hRefl : history.reflexive) (A : W → Prop) (w : W) (t : T) :
     willHistorical s history A w t ↔ A w := by
   unfold willHistorical
   apply unembedded_collapse

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -58,7 +58,7 @@ open HistoricalAlternatives DynamicSemantics
 open DynamicSemantics.CCP (IsEliminative)
 open DynamicSemantics.Update (test closure)
 
-variable {W Time : Type*}
+variable {W T : Type*}
 
 /-- The generative update behind `dynSUBJ`: for each entry with
 assignment `g` and current index `s`, produce the entries
@@ -66,12 +66,12 @@ assignment `g` and current index `s`, produce the entries
 assignment at `v` *and* move the evaluation index to the introduced
 situation. Unlike a test filter, this is *not* eliminative: it can
 produce entries that did not appear in the input context. -/
-def dynIntroduce (gen : Index W Time → Set (Index W Time))
-    (v : ℕ) (c : Set (Index.Possibility W Time)) :
-    Set (Index.Possibility W Time) :=
+def dynIntroduce (gen : Index W T → Set (Index W T))
+    (v : ℕ) (c : Set (Index.Possibility W T)) :
+    Set (Index.Possibility W T) :=
   { p' |
     ∃ g s s',
-      (⟨s, g⟩ : Index.Possibility W Time) ∈ c ∧
+      (⟨s, g⟩ : Index.Possibility W T) ∈ c ∧
       s' ∈ gen s ∧
       p'.assignment = Function.update g v s' ∧
       p'.world = s' }
@@ -80,9 +80,9 @@ def dynIntroduce (gen : Index W Time → Set (Index W Time))
 returns the new current index — the structural property that makes a
 same-variable filter (`dynIND v ∘ dynIntroduce gen v`) vacuous. -/
 theorem dynIntroduce_binds_current
-    (gen : Index W Time → Set (Index W Time))
-    {v : ℕ} {c : Set (Index.Possibility W Time)}
-    {p : Index.Possibility W Time}
+    (gen : Index W T → Set (Index W T))
+    {v : ℕ} {c : Set (Index.Possibility W T)}
+    {p : Index.Possibility W T}
     (h : p ∈ dynIntroduce gen v c) :
     p.assignment v = p.world := by
   obtain ⟨g, _, s', _, _, h_upd, h_eq⟩ := h
@@ -91,11 +91,11 @@ theorem dynIntroduce_binds_current
 /-- Every output entry of `dynIntroduce` has its current index drawn
 from `gen` applied to some input index. -/
 theorem dynIntroduce_current_in_gen
-    (gen : Index W Time → Set (Index W Time))
-    {v : ℕ} {c : Set (Index.Possibility W Time)}
-    {p : Index.Possibility W Time}
+    (gen : Index W T → Set (Index W T))
+    {v : ℕ} {c : Set (Index.Possibility W T)}
+    {p : Index.Possibility W T}
     (h : p ∈ dynIntroduce gen v c) :
-    ∃ s, (∃ g, (⟨s, g⟩ : Index.Possibility W Time) ∈ c) ∧
+    ∃ s, (∃ g, (⟨s, g⟩ : Index.Possibility W T) ∈ c) ∧
       p.world ∈ gen s := by
   obtain ⟨g, s, s', hc, h_gen, _, h_eq⟩ := h
   exact ⟨s, ⟨g, hc⟩, h_eq ▸ h_gen⟩
@@ -103,41 +103,41 @@ theorem dynIntroduce_current_in_gen
 /-- Dynamic IND: the eliminative update filtering entries whose current
 index shares its world with the situation bound to `v` — the spine's
 test filter at `sameWorld`. -/
-def dynIND (v : ℕ) : Set (Index.Possibility W Time) →
-    Set (Index.Possibility W Time) :=
+def dynIND (v : ℕ) : Set (Index.Possibility W T) →
+    Set (Index.Possibility W T) :=
   lift (test fun p => sameWorld p.world (p.assignment v))
 
 /-! ### The eliminative side -/
 
 /-- `dynIND` is a context filter. -/
 theorem dynIND_isEliminative (v : ℕ) :
-    IsEliminative (dynIND (W := W) (Time := Time) v) :=
+    IsEliminative (dynIND (W := W) (T := T) v) :=
   lift_test_isEliminative _
 
 /-- Surviving `dynIND` means the current and bound situations share a
 world. -/
 theorem dynIND_same_world {v : ℕ}
-    {c : Set (Index.Possibility W Time)}
-    {p : Index.Possibility W Time} (h : p ∈ dynIND v c) :
+    {c : Set (Index.Possibility W T)}
+    {p : Index.Possibility W T} (h : p ∈ dynIND v c) :
     p.world.world = (p.assignment v).world :=
   (mem_lift_test.mp h).2
 
 /-- `dynIND` is idempotent. -/
 theorem dynIND_idempotent (v : ℕ)
-    (c : Set (Index.Possibility W Time)) :
+    (c : Set (Index.Possibility W T)) :
     dynIND v (dynIND v c) = dynIND v c :=
   lift_test_idem _ c
 
 section Subjunctive
 
-variable [LE Time] (history : HistoricalAlternatives W Time) (v : ℕ)
-  (c : Set (Index.Possibility W Time))
-  (p : Index.Possibility W Time)
+variable [LE T] (history : HistoricalAlternatives W T) (v : ℕ)
+  (c : Set (Index.Possibility W T))
+  (p : Index.Possibility W T)
 
 /-- Dynamic SUBJ: the generative update sending each entry to its
 extensions at every historically accessible situation. -/
-def dynSUBJ : Set (Index.Possibility W Time) →
-    Set (Index.Possibility W Time) :=
+def dynSUBJ : Set (Index.Possibility W T) →
+    Set (Index.Possibility W T) :=
   dynIntroduce (historicalBase history) v
 
 /-! ### The generative side -/
@@ -145,7 +145,7 @@ def dynSUBJ : Set (Index.Possibility W Time) →
 /-- Every `dynSUBJ` output situation is drawn from the historical base
 of some input situation. -/
 theorem dynSUBJ_existential (h : p ∈ dynSUBJ history v c) :
-    ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W Time) ∈ c) ∧
+    ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W T) ∈ c) ∧
       p.world ∈ historicalBase history s₀ :=
   dynIntroduce_current_in_gen _ h
 
@@ -158,10 +158,10 @@ theorem dynSUBJ_binds_current (h : p ∈ dynSUBJ history v c) :
 
 /-- The exact output of `dynSUBJ` on a singleton context:
 `⟨s₁, g[v↦s₁]⟩` for each `s₁` in the historical base of `s₀`. -/
-theorem dynSUBJ_singleton_eq (g : ℕ → Index W Time)
-    (s₀ : Index W Time) :
+theorem dynSUBJ_singleton_eq (g : ℕ → Index W T)
+    (s₀ : Index W T) :
     dynSUBJ history v
-      ({⟨s₀, g⟩} : Set (Index.Possibility W Time)) =
+      ({⟨s₀, g⟩} : Set (Index.Possibility W T)) =
     { p | ∃ s₁ ∈ historicalBase history s₀,
         p = ⟨s₁, Function.update g v s₁⟩ } := by
   apply Set.ext; intro p
@@ -177,10 +177,10 @@ theorem dynSUBJ_singleton_eq (g : ℕ → Index W Time)
 
 /-- `dynSUBJ` realizes the static `SUBJ`: on a singleton context, some
 output satisfies `P` at the bound variable iff `SUBJ` holds. -/
-theorem dynSUBJ_realizes_SUBJ (g : ℕ → Index W Time)
-    (s₀ : Index W Time) (P : SitPred W Time) :
+theorem dynSUBJ_realizes_SUBJ (g : ℕ → Index W T)
+    (s₀ : Index W T) (P : SitPred W T) :
     (∃ p ∈ dynSUBJ history v
-        ({⟨s₀, g⟩} : Set (Index.Possibility W Time)),
+        ({⟨s₀, g⟩} : Set (Index.Possibility W T)),
       P (p.assignment v) s₀) ↔
     SUBJ history P s₀ := by
   rw [dynSUBJ_singleton_eq]
@@ -209,8 +209,8 @@ theorem dynIND_after_dynSUBJ_same_var :
 /-- The dynamic operator each grammatical mood denotes: indicative the
 eliminative `dynIND`, subjunctive the generative `dynSUBJ`. -/
 def Grammatical.dynOp :
-    Grammatical → ℕ → Set (Index.Possibility W Time) →
-      Set (Index.Possibility W Time)
+    Grammatical → ℕ → Set (Index.Possibility W T) →
+      Set (Index.Possibility W T)
   | .indicative  => dynIND
   | .subjunctive => dynSUBJ history
 
@@ -224,7 +224,7 @@ carries a freshly introduced situation, bound to `v`. -/
 theorem dynOp_subjunctive_introduces
     (h : p ∈ Grammatical.subjunctive.dynOp history v c) :
     p.assignment v = p.world ∧
-      ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W Time) ∈ c) ∧
+      ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W T) ∈ c) ∧
         p.world ∈ historicalBase history s₀ :=
   ⟨dynSUBJ_binds_current history v c p h,
    dynSUBJ_existential history v c p h⟩

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -33,46 +33,46 @@ open Intensional (Index)
 open HistoricalAlternatives
 
 /-- A situation predicate, relating a described situation to its anchor. -/
-abbrev SitPred (W Time : Type*) := Index W Time → Index W Time → Prop
+abbrev SitPred (W T : Type*) := Index W T → Index W T → Prop
 
 /-- The modal kernel: two situations share their world coordinate.
 `abbrev` so `decide`/`rw` see through it. -/
-abbrev sameWorld {W Time : Type*}
-    (s₁ s₂ : Index W Time) : Prop :=
+abbrev sameWorld {W T : Type*}
+    (s₁ s₂ : Index W T) : Prop :=
   s₁.world = s₂.world
 
-variable {W Time : Type*} (history : HistoricalAlternatives W Time)
-  (P : SitPred W Time) (s₀ : Index W Time)
+variable {W T : Type*} (history : HistoricalAlternatives W T)
+  (P : SitPred W T) (s₀ : Index W T)
 
 /-- The subjunctive introduces a new situation dref from the historical
 alternatives of the anchor — an indefinite for situations
 ([mendes-2025], Definition on p.29). -/
-def SUBJ [LE Time] : Prop :=
-  ∃ s₁ : Index W Time,
+def SUBJ [LE T] : Prop :=
+  ∃ s₁ : Index W T,
     s₁ ∈ historicalBase history s₀ ∧ P s₁ s₀
 
 /-- The indicative retrieves existing situations and tests that they
 share a world — a definite for situations ([mendes-2025], Definition
 on p.29). -/
-def IND (s₁ s₂ : Index W Time) : Prop :=
+def IND (s₁ s₂ : Index W T) : Prop :=
   sameWorld s₂ s₁ ∧ P s₂ s₁
 
 /-- A conditional with an SF antecedent: `SUBJ` introduces the *if*
 situation, and the consequent is temporally anchored to it — why SF
 enables future reference ([mendes-2025]). -/
-def conditionalSF [LE Time]
-    (antecedent : Index W Time → Prop)
-    (consequent : Index W Time → Index W Time → Prop)
-    (s₀ : Index W Time) : Prop :=
+def conditionalSF [LE T]
+    (antecedent : Index W T → Prop)
+    (consequent : Index W T → Index W T → Prop)
+    (s₀ : Index W T) : Prop :=
   SUBJ history (λ s₁ s₀' => antecedent s₁ → consequent s₁ s₀') s₀
 
 /-- Surviving `IND` means the two situations share a world. -/
-theorem ind_same_world (s₁ s₂ : Index W Time)
+theorem ind_same_world (s₁ s₂ : Index W T)
     (h : IND P s₁ s₂) : s₂.world = s₁.world :=
   h.1
 
 /-- With a reflexive history, the anchor itself is always an option. -/
-theorem subj_current_option [Preorder Time]
+theorem subj_current_option [Preorder T]
     (h_refl : history.reflexive) (h_P : P s₀ s₀) :
     SUBJ history P s₀ :=
   ⟨s₀, ⟨h_refl s₀, le_refl s₀.time⟩, h_P⟩
@@ -81,7 +81,7 @@ theorem subj_current_option [Preorder Time]
 situation's time — the mechanism SF exploits for future reference, and
 the parallel to attitude verbs shifting embedded evaluation to matrix
 event time (`Studies/VonStechow2009.lean`). -/
-theorem subj_temporal_anchor [LE Time]
+theorem subj_temporal_anchor [LE T]
     (h : SUBJ history P s₀) :
     ∃ s₁, s₁ ∈ historicalBase history s₀ ∧ s₁.time ≥ s₀.time ∧ P s₁ s₀ := by
   obtain ⟨s₁, h_hist, h_P⟩ := h
@@ -92,14 +92,14 @@ theorem subj_temporal_anchor [LE Time]
 /-- A propositional operator is non-veridical iff `F p` can hold
 without `p` ([giannakidou-1998]). -/
 def nonVeridical
-    (F : (Index W Time → Prop) → Index W Time → Prop) : Prop :=
-  ∃ (P : Index W Time → Prop) (s : Index W Time),
+    (F : (Index W T → Prop) → Index W T → Prop) : Prop :=
+  ∃ (P : Index W T → Prop) (s : Index W T),
     F P s ∧ ¬P s
 
 /-- `SUBJ` is non-veridical whenever the history branches: the
 introduced situation may differ from the actual one. -/
-theorem subj_nonveridical [LE Time]
-    (h_branching : ∃ s₀ s₁ : Index W Time,
+theorem subj_nonveridical [LE T]
+    (h_branching : ∃ s₀ s₁ : Index W T,
       s₁ ∈ historicalBase history s₀ ∧ s₀ ≠ s₁) :
     nonVeridical (λ P s₀ => SUBJ history (λ s₁ _ => P s₁) s₀) := by
   obtain ⟨s₀, s₁, h₁, hne⟩ := h_branching
@@ -115,8 +115,8 @@ tense indexing). -/
 
 /-- The mood-labeled context shift to the introduced situation's world
 and time. -/
-def subjShift {E P : Type*} (newWorld : W) (newTime : Time) :
-    Semantics.Context.ContextShift (Semantics.Context.KContext W E P Time) where
+def subjShift {E P : Type*} (newWorld : W) (newTime : T) :
+    Semantics.Context.ContextShift (Semantics.Context.KContext W E P T) where
   apply := λ c => { c with world := newWorld, time := newTime }
   label := .mood
 

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -18,43 +18,43 @@ namespace Tense
 
 open Intensional (Index)
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- The tense cell `s`, applied compositionally ([mendes-2025]):
     ⟦s⟧ = λP.λsit.λsit'. `compare τ(sit) τ(sit') ∈ s` ∧ P(sit) — the cell
     constrains the event–evaluation comparison and the payload is
     evaluated at the event situation. -/
-def constrain (s : Finset Ordering) (P : (Index W Time → Prop))
-    (sit sit' : Index W Time) : Prop :=
+def constrain (s : Finset Ordering) (P : (Index W T → Prop))
+    (sit sit' : Index W T) : Prop :=
   compare sit.time sit'.time ∈ s ∧ P sit
 
 /-- ⟦PAST⟧ = `constrain past`: the event situation precedes the
     evaluation situation. -/
-abbrev PAST : (Index W Time → Prop) → Index W Time →
-    Index W Time → Prop := constrain past
+abbrev PAST : (Index W T → Prop) → Index W T →
+    Index W T → Prop := constrain past
 
 /-- ⟦PRES⟧ = `constrain present`: the event situation is contemporaneous
     with the evaluation situation. -/
-abbrev PRES : (Index W Time → Prop) → Index W Time →
-    Index W Time → Prop := constrain present
+abbrev PRES : (Index W T → Prop) → Index W T →
+    Index W T → Prop := constrain present
 
 /-- ⟦FUT⟧ = `constrain future`: the event situation follows the
     evaluation situation. -/
-abbrev FUT : (Index W Time → Prop) → Index W Time →
-    Index W Time → Prop := constrain future
+abbrev FUT : (Index W T → Prop) → Index W T →
+    Index W T → Prop := constrain future
 
-@[simp] theorem constrain_past_iff (P : (Index W Time → Prop))
-    (sit sit' : Index W Time) :
+@[simp] theorem constrain_past_iff (P : (Index W T → Prop))
+    (sit sit' : Index W T) :
     constrain past P sit sit' ↔ sit.time < sit'.time ∧ P sit := by
   simp [constrain]
 
-@[simp] theorem constrain_present_iff (P : (Index W Time → Prop))
-    (sit sit' : Index W Time) :
+@[simp] theorem constrain_present_iff (P : (Index W T → Prop))
+    (sit sit' : Index W T) :
     constrain present P sit sit' ↔ sit.time = sit'.time ∧ P sit := by
   simp [constrain]
 
-@[simp] theorem constrain_future_iff (P : (Index W Time → Prop))
-    (sit sit' : Index W Time) :
+@[simp] theorem constrain_future_iff (P : (Index W T → Prop))
+    (sit sit' : Index W T) :
     constrain future P sit sit' ↔ sit'.time < sit.time ∧ P sit := by
   simp [constrain]
 

--- a/Linglib/Semantics/Tense/Decomposition.lean
+++ b/Linglib/Semantics/Tense/Decomposition.lean
@@ -45,8 +45,8 @@ theorem present_past_no_deletion :
 /-- The embedded frame after SOT deletion: the embedded reference time
     becomes the matrix event time (the embedded clause inherits the matrix
     temporal coordinates). -/
-def applyDeletion {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) : ReichenbachFrame Time where
+def applyDeletion {T : Type*}
+    (matrixFrame : ReichenbachFrame T) : ReichenbachFrame T where
   speechTime := matrixFrame.speechTime
   perspectiveTime := matrixFrame.eventTime
   referenceTime := matrixFrame.eventTime
@@ -56,15 +56,15 @@ def applyDeletion {Time : Type*}
     the embedded tense yields exactly the simultaneous-reading frame whose
     embedded event time is the matrix event time — the formal core of the
     Kratzer/Ogihara "same predictions" agreement. -/
-theorem applyDeletion_eq_simultaneousFrame {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) :
+theorem applyDeletion_eq_simultaneousFrame {T : Type*}
+    (matrixFrame : ReichenbachFrame T) :
     applyDeletion matrixFrame = simultaneousFrame matrixFrame matrixFrame.eventTime :=
   rfl
 
 /-- Deletion derives the simultaneous reading: after deletion the embedded
     reference time is the matrix event time, the PRESENT relation. -/
-theorem applyDeletion_isPresent {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) :
+theorem applyDeletion_isPresent {T : Type*}
+    (matrixFrame : ReichenbachFrame T) :
     (applyDeletion matrixFrame).isPresent := rfl
 
 /-! ### Surface tense -/

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -52,33 +52,33 @@ open _root_.Intensional (Index)
 open DynamicSemantics
 open DynamicSemantics.Update (test closure)
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- Dynamic PAST: the spine's test filter at the `past` cell. A context
     entry survives iff its event-variable index precedes its
     reference-variable index in time. -/
 def dynPAST (eventVar refVar : ℕ) :
-    Set (Index.Possibility W Time) →
-      Set (Index.Possibility W Time) :=
+    Set (Index.Possibility W T) →
+      Set (Index.Possibility W T) :=
   lift (test fun p =>
     compare (p.assignment eventVar).time (p.assignment refVar).time ∈ past)
 
 /-- Dynamic PRES: the test filter at the `present` cell. -/
 def dynPRES (eventVar refVar : ℕ) :
-    Set (Index.Possibility W Time) →
-      Set (Index.Possibility W Time) :=
+    Set (Index.Possibility W T) →
+      Set (Index.Possibility W T) :=
   lift (test fun p =>
     compare (p.assignment eventVar).time (p.assignment refVar).time ∈ present)
 
 /-- Dynamic FUT: the test filter at the `future` cell. -/
 def dynFUT (eventVar refVar : ℕ) :
-    Set (Index.Possibility W Time) →
-      Set (Index.Possibility W Time) :=
+    Set (Index.Possibility W T) →
+      Set (Index.Possibility W T) :=
   lift (test fun p =>
     compare (p.assignment eventVar).time (p.assignment refVar).time ∈ future)
 
-variable (e r : ℕ) (c : Set (Index.Possibility W Time))
-  (p : Index.Possibility W Time)
+variable (e r : ℕ) (c : Set (Index.Possibility W T))
+  (p : Index.Possibility W T)
 
 /-! ### Membership characterizations -/
 

--- a/Linglib/Semantics/Tense/Embedding.lean
+++ b/Linglib/Semantics/Tense/Embedding.lean
@@ -21,7 +21,7 @@ open Time
 
 namespace Tense
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-! ### Embedded frames -/
 
@@ -30,8 +30,8 @@ variable {Time : Type*}
     tense locates its R′ relative to the attitude holder's now, not
     speech time. `embeddedR` and `embeddedE` are the embedded clause's
     reference and event times, determined by its tense and aspect. -/
-def embeddedFrame (matrixFrame : ReichenbachFrame Time)
-    (embeddedR embeddedE : Time) : ReichenbachFrame Time where
+def embeddedFrame (matrixFrame : ReichenbachFrame T)
+    (embeddedR embeddedE : T) : ReichenbachFrame T where
   speechTime := matrixFrame.speechTime
   perspectiveTime := matrixFrame.eventTime
   referenceTime := embeddedR
@@ -41,14 +41,14 @@ def embeddedFrame (matrixFrame : ReichenbachFrame Time)
     Mary was sick" — sick at the saying time), so embedded tense is
     PRESENT relative to the embedded perspective
     (`simultaneousFrame_isPresent`). -/
-def simultaneousFrame (matrixFrame : ReichenbachFrame Time)
-    (embeddedE : Time) : ReichenbachFrame Time :=
+def simultaneousFrame (matrixFrame : ReichenbachFrame T)
+    (embeddedE : T) : ReichenbachFrame T :=
   embeddedFrame matrixFrame matrixFrame.eventTime embeddedE
 
 /-- The simultaneous frame satisfies PRESENT (R = P) relative to the
     embedded perspective. -/
-theorem simultaneousFrame_isPresent (matrixFrame : ReichenbachFrame Time)
-    (embeddedE : Time) :
+theorem simultaneousFrame_isPresent (matrixFrame : ReichenbachFrame T)
+    (embeddedE : T) :
     (simultaneousFrame matrixFrame embeddedE).isPresent := rfl
 
 /-! ### Embedded tense readings -/
@@ -97,16 +97,16 @@ modal-layer formulation would be more faithful. -/
 /-- The Upper Limit Constraint ([abusch-1997] §7, presuppositional
     construal per [heim-1994-comments]): the embedded reference time may
     not exceed the matrix event time (= the embedded perspective). -/
-abbrev upperLimitConstraint [LE Time] (embeddedR matrixE : Time) : Prop :=
+abbrev upperLimitConstraint [LE T] (embeddedR matrixE : T) : Prop :=
   embeddedR ≤ matrixE
 
 /-- The shifted reading satisfies the ULC. -/
-theorem shifted_satisfies_ulc [Preorder Time] (embeddedR matrixE : Time)
+theorem shifted_satisfies_ulc [Preorder T] (embeddedR matrixE : T)
     (h : embeddedR < matrixE) : upperLimitConstraint embeddedR matrixE :=
   le_of_lt h
 
 /-- The simultaneous reading satisfies the ULC. -/
-theorem simultaneous_satisfies_ulc [Preorder Time] (embeddedR matrixE : Time)
+theorem simultaneous_satisfies_ulc [Preorder T] (embeddedR matrixE : T)
     (h : embeddedR = matrixE) : upperLimitConstraint embeddedR matrixE :=
   le_of_eq h
 
@@ -116,9 +116,9 @@ theorem simultaneous_satisfies_ulc [Preorder Time] (embeddedR matrixE : Time)
     R = the pronoun's referent under `g`, with perspective, speech, and
     event times supplied by the embedding context. -/
 def TensePronoun.toFrame (tp : TensePronoun)
-    (g : TemporalAssignment Time)
-    (speechTime perspectiveTime eventTime : Time) :
-    ReichenbachFrame Time where
+    (g : TemporalAssignment T)
+    (speechTime perspectiveTime eventTime : T) :
+    ReichenbachFrame T where
   speechTime := speechTime
   perspectiveTime := perspectiveTime
   referenceTime := tp.resolve g
@@ -128,8 +128,8 @@ def TensePronoun.toFrame (tp : TensePronoun)
     simultaneous reading as pronoun resolution: binding the variable to
     the perspective time yields a PRESENT frame. -/
 theorem TensePronoun.bound_present_simultaneous
-    (tp : TensePronoun) (g : TemporalAssignment Time)
-    (speechTime perspTime eventTime : Time)
+    (tp : TensePronoun) (g : TemporalAssignment T)
+    (speechTime perspTime eventTime : T)
     (hBind : tp.resolve g = perspTime)
     (_hPres : tp.constraint = present) :
     (tp.toFrame g speechTime perspTime eventTime).isPresent := by
@@ -139,7 +139,7 @@ theorem TensePronoun.bound_present_simultaneous
 /-- The double access reading of a present tense under a past attitude: the denotation of the
 present tense overlaps both the believing time and the utterance time. A condition on the
 tense's reference, not on the truth of the complement at either time. -/
-def DoubleAccess (I : Set Time) (believing utterance : Time) : Prop :=
+def DoubleAccess (I : Set T) (believing utterance : T) : Prop :=
   believing ∈ I ∧ utterance ∈ I
 
 end Tense

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -69,10 +69,10 @@ open Presupposition
 /-- Cumming's (S, A, T) frame. Extends Reichenbach with an evidence-acquisition
     time A. S = speechTime, T = eventTime, A = acquisitionTime. The existing
     referenceTime (R) stays — it governs utterance perspective independently. -/
-structure EvidentialFrame (Time : Type*) extends ReichenbachFrame Time where
+structure EvidentialFrame (T : Type*) extends ReichenbachFrame T where
   /-- Evidence-acquisition time (A): when the speaker acquires the evidence
       grounding the assertion. -/
-  acquisitionTime : Time
+  acquisitionTime : T
 
 /-! ### EP Constraint Enum -/
 

--- a/Linglib/Semantics/Tense/Licensing.lean
+++ b/Linglib/Semantics/Tense/Licensing.lean
@@ -38,7 +38,7 @@ every temporal argument by its local evaluation time.
 
 namespace Tense
 
-variable {ι Time : Type*}
+variable {ι T : Type*}
 
 /-- A temporal argument: its relation variable, the index of its time, and the index of its local
 evaluation time. -/
@@ -51,43 +51,43 @@ structure TemporalArgument (ι : Type*) where
   evalIndex : ℕ
 
 /-- An assignment of temporal relations to relation variables. -/
-abbrev RelationAssignment (ι Time : Type*) := ι → Time → Time → Prop
+abbrev RelationAssignment (ι T : Type*) := ι → T → T → Prop
 
 namespace TemporalArgument
 
-variable (a : TemporalArgument ι) (ρ : RelationAssignment ι Time) (g : ℕ → Time)
+variable (a : TemporalArgument ι) (ρ : RelationAssignment ι T) (g : ℕ → T)
 
 /-- The constraint `con`: the argument's relation holds between its time and its local
 evaluation time. -/
 def Con : Prop := ρ a.rel (g a.index) (g a.evalIndex)
 
 /-- The upper limit constraint: the argument's time does not follow its local evaluation time. -/
-def UpperLimit [LE Time] : Prop := upperLimitConstraint (g a.index) (g a.evalIndex)
+def UpperLimit [LE T] : Prop := upperLimitConstraint (g a.index) (g a.evalIndex)
 
 /-- Locally licensed: the argument's own relation is temporal precedence. -/
-def LocallyLicensed [LT Time] : Prop := ρ a.rel = (· < ·)
+def LocallyLicensed [LT T] : Prop := ρ a.rel = (· < ·)
 
 /-- Non-locally licensed: a transmitted relation other than the argument's own is precedence. -/
-def NonLocallyLicensed [LT Time] (acc : Finset ι) : Prop :=
+def NonLocallyLicensed [LT T] (acc : Finset ι) : Prop :=
   ∃ r ∈ acc, r ≠ a.rel ∧ ρ r = (· < ·)
 
 end TemporalArgument
 
 /-- The past tense constraint on the relations a tense has access to: at least one is temporal
 precedence. -/
-def PastConstraint [LT Time] (ρ : RelationAssignment ι Time) (acc : Finset ι) : Prop :=
+def PastConstraint [LT T] (ρ : RelationAssignment ι T) (acc : Finset ι) : Prop :=
   ∃ r ∈ acc, ρ r = (· < ·)
 
 /-- The present tense constraint: every accessible relation entails the negation of temporal
 precedence. -/
-def PresentConstraint [LT Time] (ρ : RelationAssignment ι Time) (acc : Finset ι) : Prop :=
+def PresentConstraint [LT T] (ρ : RelationAssignment ι T) (acc : Finset ι) : Prop :=
   ∀ r ∈ acc, ∀ a b, ρ r a b → ¬ a < b
 
-variable {ρ : RelationAssignment ι Time} {acc : Finset ι} {r : ι}
+variable {ρ : RelationAssignment ι T} {acc : Finset ι} {r : ι}
 
 section LT
 
-variable [LT Time]
+variable [LT T]
 
 theorem pastConstraint_singleton : PastConstraint ρ {r} ↔ ρ r = (· < ·) := by
   simp [PastConstraint]
@@ -96,21 +96,21 @@ theorem PastConstraint.of_mem (hr : r ∈ acc) (h : ρ r = (· < ·)) : PastCons
   ⟨r, hr, h⟩
 
 /-- A present-constrained relation that holds somewhere is not temporal precedence. -/
-theorem PresentConstraint.ne_lt (hq : PresentConstraint ρ acc) (hr : r ∈ acc) {a b : Time}
+theorem PresentConstraint.ne_lt (hq : PresentConstraint ρ acc) (hr : r ∈ acc) {a b : T}
     (hab : ρ r a b) : ρ r ≠ (· < ·) := fun h =>
   hq r hr a b hab ((congrFun (congrFun h a) b).mp hab)
 
 /-- No relation both licenses a past tense and satisfies a present constraint at an instantiated
 argument. -/
 theorem PastConstraint.false_of_presentConstraint (hp : PastConstraint ρ {r}) {acc : Finset ι}
-    (hq : PresentConstraint ρ acc) (hr : r ∈ acc) {a b : Time} (hab : ρ r a b) : False :=
+    (hq : PresentConstraint ρ acc) (hr : r ∈ acc) {a b : T} (hab : ρ r a b) : False :=
   hq.ne_lt hr hab (pastConstraint_singleton.1 hp)
 
 end LT
 
 section Preorder
 
-variable [Preorder Time] {a : TemporalArgument ι} {g : ℕ → Time}
+variable [Preorder T] {a : TemporalArgument ι} {g : ℕ → T}
 
 theorem TemporalArgument.not_locallyLicensed_of_coindexed (hcon : a.Con ρ g)
     (h : a.index = a.evalIndex) : ¬ a.LocallyLicensed ρ := fun hl => by

--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -41,11 +41,11 @@ open Tense
     tense; the clash with PRES arises because the temporal assertion
     ("during then") forces the PRES reference inside the ⌈then⌉
     reference. -/
-def thenPresup {Time : Type*} [LinearOrder Time] (thenRef perspective : Time) : Prop :=
+def thenPresup {T : Type*} [LinearOrder T] (thenRef perspective : T) : Prop :=
   compare thenRef perspective ∈ Tense.presentᶜ
 
-@[simp] theorem thenPresup_def {Time : Type*} [LinearOrder Time]
-    (thenRef perspective : Time) :
+@[simp] theorem thenPresup_def {T : Type*} [LinearOrder T]
+    (thenRef perspective : T) :
     thenPresup thenRef perspective ↔ thenRef ≠ perspective := by
   simp [thenPresup]
 
@@ -64,13 +64,13 @@ structure ThenAdverb where
 
 /-- OP_π shifts the perspective time to a new value.
     ⟦OP_π φ⟧^{c,π,g} = λi_κ. ⟦φ⟧^{c,i_t,g}(i) -/
-def opPi {Time : Type*} (f : ReichenbachFrame Time) (newPi : Time) :
-    ReichenbachFrame Time :=
+def opPi {T : Type*} (f : ReichenbachFrame T) (newPi : T) :
+    ReichenbachFrame T :=
   { f with perspectiveTime := newPi }
 
 /-- OP_π corresponds to `embeddedFrame` when shifting to the matrix event time. -/
-theorem opPi_eq_embeddedFrame {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) (embeddedR embeddedE : Time) :
+theorem opPi_eq_embeddedFrame {T : Type*}
+    (matrixFrame : ReichenbachFrame T) (embeddedR embeddedE : T) :
     opPi { speechTime := matrixFrame.speechTime
            perspectiveTime := matrixFrame.speechTime
            referenceTime := embeddedR
@@ -85,9 +85,9 @@ theorem opPi_eq_embeddedFrame {Time : Type*}
     PRES presupposes R = π (`isPresent`), the temporal assertion requires the
     ⌈then⌉ reference to contain — in the point approximation, equal — R
     ("during then"), and ⌈then⌉ presupposes its reference disjoint from π. -/
-theorem then_present_clash {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time)
-    {thenRef : Time} (hPres : f.isPresent) (hDuring : f.referenceTime = thenRef)
+theorem then_present_clash {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T)
+    {thenRef : T} (hPres : f.isPresent) (hDuring : f.referenceTime = thenRef)
     (hThen : thenPresup thenRef f.perspectiveTime) : False :=
   (thenPresup_def _ _).mp hThen (hDuring.symm.trans hPres)
 
@@ -96,8 +96,8 @@ theorem then_present_clash {Time : Type*} [LinearOrder Time]
     ([tsilia-zhao-2026]): a deleted tense contributes no perspectival
     presupposition, leaving only `thenPresup`, which any reference off the
     perspective witnesses. -/
-theorem thenPresup_satisfiable {Time : Type*} [LinearOrder Time] [Nontrivial Time]
-    (perspective : Time) : ∃ thenRef, thenPresup thenRef perspective := by
+theorem thenPresup_satisfiable {T : Type*} [LinearOrder T] [Nontrivial T]
+    (perspective : T) : ∃ thenRef, thenPresup thenRef perspective := by
   simpa using exists_ne perspective
 
 end Tense.Perspective

--- a/Linglib/Semantics/Tense/Pronoun.lean
+++ b/Linglib/Semantics/Tense/Pronoun.lean
@@ -27,15 +27,15 @@ namespace Tense
 
 /-- Temporal assignment function: maps variable indices to times.
     The temporal analogue of H&K's `Assignment` (`ℕ → Entity`). -/
-abbrev TemporalAssignment (Time : Type*) := Assignment Time
+abbrev TemporalAssignment (T : Type*) := Assignment T
 
 /-- Modified temporal assignment `g[n ↦ t]`. Specializes `Function.update`. -/
-abbrev updateTemporal {Time : Type*} (g : TemporalAssignment Time)
-    (n : ℕ) (t : Time) : TemporalAssignment Time :=
+abbrev updateTemporal {T : Type*} (g : TemporalAssignment T)
+    (n : ℕ) (t : T) : TemporalAssignment T :=
   Function.update g n t
 
 /-- Temporal variable denotation: ⟦tₙ⟧^g = g(n). -/
-abbrev interpTense {Time : Type*} (n : ℕ) (g : TemporalAssignment Time) : Time :=
+abbrev interpTense {T : Type*} (n : ℕ) (g : TemporalAssignment T) : T :=
   g n
 
 /-- Temporal lambda abstraction: bind a time variable.
@@ -43,29 +43,29 @@ abbrev interpTense {Time : Type*} (n : ℕ) (g : TemporalAssignment Time) : Time
     Partee's bound tense: "Whenever Mary phones, Sam *is* asleep" —
     present tense bound by "whenever", just as "Every farmer beats
     *his* donkey" has "his" bound by "every farmer". -/
-abbrev temporalLambdaAbs {Time α : Type*} (n : ℕ)
-    (body : TemporalAssignment Time → α) :
-    TemporalAssignment Time → Time → α :=
+abbrev temporalLambdaAbs {T α : Type*} (n : ℕ)
+    (body : TemporalAssignment T → α) :
+    TemporalAssignment T → T → α :=
   λ g t => body (Function.update g n t)
 
 /-- Project a situation assignment to a temporal assignment: the temporal
     coordinate of each situation is extracted. -/
-def situationToTemporal {W Time : Type*}
-    (g : ℕ → Index W Time) : TemporalAssignment Time :=
+def situationToTemporal {W T : Type*}
+    (g : ℕ → Index W T) : TemporalAssignment T :=
   λ n => (g n).time
 
 /-- Temporal interpretation via situation assignment commutes with
     time projection: `interpTense n (π g) = (g n).time`. -/
-theorem situation_temporal_commutes {W Time : Type*}
-    (g : ℕ → Index W Time) (n : ℕ) :
+theorem situation_temporal_commutes {W T : Type*}
+    (g : ℕ → Index W T) (n : ℕ) :
     interpTense n (situationToTemporal g) = (g n).time := rfl
 
 /-- Zero tense: a bound tense variable contributes no independent
     temporal constraint. When an attitude verb binds it, the variable receives
     the matrix event time. This is the SOT mechanism: the "past" morphology on
     the embedded verb is agreement, not a semantic tense. -/
-theorem zeroTense_receives_binder_time {Time : Type*}
-    (g : TemporalAssignment Time) (n : ℕ) (binderTime : Time) :
+theorem zeroTense_receives_binder_time {T : Type*}
+    (g : TemporalAssignment T) (n : ℕ) (binderTime : T) :
     interpTense n (updateTemporal g n binderTime) = binderTime :=
   Function.update_self n binderTime g
 
@@ -88,29 +88,29 @@ structure TensePronoun where
 
 namespace TensePronoun
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-- Resolve: look up the temporal variable. -/
-def resolve (tp : TensePronoun) (g : TemporalAssignment Time) : Time :=
+def resolve (tp : TensePronoun) (g : TemporalAssignment T) : T :=
   interpTense tp.varIndex g
 
 /-- Presupposition: the constraint applied to the resolved time. -/
-def presupposition [LinearOrder Time]
-    (tp : TensePronoun) (resolvedTime perspectiveTime : Time) : Prop :=
+def presupposition [LinearOrder T]
+    (tp : TensePronoun) (resolvedTime perspectiveTime : T) : Prop :=
   compare resolvedTime perspectiveTime ∈ tp.constraint
 
 /-- Resolve the evaluation time from the assignment.
     In root clauses (evalTimeIndex = 0, g(0) = speech time), this is speech time.
     Under embedding, the attitude verb updates the assignment so that
     g(evalTimeIndex) = matrix event time. -/
-def evalTime (tp : TensePronoun) (g : TemporalAssignment Time) : Time :=
+def evalTime (tp : TensePronoun) (g : TemporalAssignment T) : T :=
   interpTense tp.evalTimeIndex g
 
 /-- Full presupposition: the tense constraint checked against the resolved
     evaluation time (not just a bare perspective time parameter).
     This makes the eval time compositionally determined rather than stipulated. -/
-def fullPresupposition [LinearOrder Time]
-    (tp : TensePronoun) (g : TemporalAssignment Time) : Prop :=
+def fullPresupposition [LinearOrder T]
+    (tp : TensePronoun) (g : TemporalAssignment T) : Prop :=
   compare (tp.resolve g) (tp.evalTime g) ∈ tp.constraint
 
 def isIndexical (tp : TensePronoun) : Prop := tp.mode = .indexical
@@ -124,7 +124,7 @@ instance (tp : TensePronoun) : Decidable tp.isBound :=
 /-- When evalTimeIndex = 0 and g(0) = speechTime, the evaluation time is speech time.
     This is the root-clause default: tense is checked against speech time. -/
 theorem evalTime_root_is_speech (tp : TensePronoun)
-    (g : TemporalAssignment Time) (speechTime : Time)
+    (g : TemporalAssignment T) (speechTime : T)
     (hEval : tp.evalTimeIndex = 0) (hRoot : g 0 = speechTime) :
     tp.evalTime g = speechTime := by
   simp [evalTime, interpTense, hEval, hRoot]
@@ -133,19 +133,19 @@ theorem evalTime_root_is_speech (tp : TensePronoun)
     the embedded tense is now checked against a different time (the matrix
     event time). This is how attitude verbs "transmit" their event time. -/
 theorem evalTime_shifts_under_embedding (tp : TensePronoun)
-    (g : TemporalAssignment Time) (matrixEventTime : Time) :
+    (g : TemporalAssignment T) (matrixEventTime : T) :
     tp.evalTime (updateTemporal g tp.evalTimeIndex matrixEventTime) = matrixEventTime :=
   zeroTense_receives_binder_time g tp.evalTimeIndex matrixEventTime
 
 /-- Resolving a bound tense under binding yields the binder time. -/
 theorem bound_resolve_eq_binder (tp : TensePronoun)
-    (g : TemporalAssignment Time) (binderTime : Time) :
+    (g : TemporalAssignment T) (binderTime : T) :
     tp.resolve (updateTemporal g tp.varIndex binderTime) = binderTime :=
   zeroTense_receives_binder_time g tp.varIndex binderTime
 
 /-- An indexical present tense presupposes resolution to speech time. -/
-theorem indexical_present_at_speech [LinearOrder Time]
-    (tp : TensePronoun) (resolvedTime speechTime : Time)
+theorem indexical_present_at_speech [LinearOrder T]
+    (tp : TensePronoun) (resolvedTime speechTime : T)
     (hPres : tp.constraint = present)
     (hPresup : tp.presupposition resolvedTime speechTime) :
     resolvedTime = speechTime := by

--- a/Linglib/Semantics/Tense/RunTimes.lean
+++ b/Linglib/Semantics/Tense/RunTimes.lean
@@ -24,34 +24,34 @@ BeaverCondoravdi2003, Rett2020, …).
 namespace Tense
 
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- A sentence denotes a set of temporal intervals — its "run-times". -/
-abbrev RunTimes (Time : Type*) [LinearOrder Time] := Set (NonemptyInterval Time)
+abbrev RunTimes (T : Type*) [LinearOrder T] := Set (NonemptyInterval T)
 
 /-- The time points contained in some interval of a denotation. -/
-def timeTrace (p : RunTimes Time) : Set Time :=
+def timeTrace (p : RunTimes T) : Set T :=
   { t | ∃ i ∈ p, t ∈ i }
 
-@[simp] theorem mem_timeTrace {p : RunTimes Time} {t : Time} :
+@[simp] theorem mem_timeTrace {p : RunTimes T} {t : T} :
     t ∈ timeTrace p ↔ ∃ i ∈ p, t ∈ i := Iff.rfl
 
-theorem timeTrace_image {α : Type*} (f : α → NonemptyInterval Time) (s : Set α) :
+theorem timeTrace_image {α : Type*} (f : α → NonemptyInterval T) (s : Set α) :
     timeTrace (f '' s) = { t | ∃ a ∈ s, t ∈ f a } := by
   ext t; simp
 
-@[simp] theorem timeTrace_empty : timeTrace (∅ : RunTimes Time) = ∅ := by
+@[simp] theorem timeTrace_empty : timeTrace (∅ : RunTimes T) = ∅ := by
   ext; simp [timeTrace]
 
-@[simp] theorem timeTrace_singleton (i : NonemptyInterval Time) :
-    timeTrace {i} = (i : Set Time) := by
+@[simp] theorem timeTrace_singleton (i : NonemptyInterval T) :
+    timeTrace {i} = (i : Set T) := by
   ext; simp [timeTrace]
 
-@[simp] theorem timeTrace_insert (i : NonemptyInterval Time) (p : RunTimes Time) :
-    timeTrace (insert i p) = (i : Set Time) ∪ timeTrace p := by
+@[simp] theorem timeTrace_insert (i : NonemptyInterval T) (p : RunTimes T) :
+    timeTrace (insert i p) = (i : Set T) ∪ timeTrace p := by
   ext; simp [timeTrace]
 
-theorem mem_timeTrace_pure {a t : Time} :
+theorem mem_timeTrace_pure {a t : T} :
     t ∈ timeTrace {NonemptyInterval.pure a} ↔ t = a := by
   simp
 
@@ -60,42 +60,42 @@ theorem mem_timeTrace_pure {a t : Time} :
     subinterval-closure property. The *activity* case (a minimal-parts floor:
     a single step is not "running") is the stratified reference of
     `Aspect/Stratified` ([champollion-2017]), not this lower set. -/
-def stativeDenotation (i : NonemptyInterval Time) : RunTimes Time :=
+def stativeDenotation (i : NonemptyInterval T) : RunTimes T :=
   Set.Iic i
 
 /-- Accomplishment denotation: exactly the singleton `{i}` — quantization. -/
-def accomplishmentDenotation (i : NonemptyInterval Time) : RunTimes Time :=
+def accomplishmentDenotation (i : NonemptyInterval T) : RunTimes T :=
   {i}
 
-theorem stativeDenotation_self (i : NonemptyInterval Time) :
+theorem stativeDenotation_self (i : NonemptyInterval T) :
     i ∈ stativeDenotation i :=
   Set.mem_Iic.mpr le_rfl
 
-theorem timeTrace_stativeDenotation (i : NonemptyInterval Time) :
+theorem timeTrace_stativeDenotation (i : NonemptyInterval T) :
     timeTrace (stativeDenotation i) = { t | t ∈ i } := by
   ext t
   simp only [mem_timeTrace, stativeDenotation, Set.mem_Iic, Set.mem_ofPred_eq,
     NonemptyInterval.mem_def, NonemptyInterval.le_def]
   grind
 
-theorem mem_timeTrace_stativeDenotation {i : NonemptyInterval Time} {t : Time} :
+theorem mem_timeTrace_stativeDenotation {i : NonemptyInterval T} {t : T} :
     t ∈ timeTrace (stativeDenotation i) ↔ t ∈ i := by
   rw [timeTrace_stativeDenotation]; rfl
 
-theorem timeTrace_accomplishmentDenotation (i : NonemptyInterval Time) :
+theorem timeTrace_accomplishmentDenotation (i : NonemptyInterval T) :
     timeTrace (accomplishmentDenotation i) = { t | t ∈ i } := by
   ext t; simp [timeTrace, accomplishmentDenotation]
 
 
-theorem timeTrace_eventDenotation (P : Event Time → Prop) :
+theorem timeTrace_eventDenotation (P : Event T → Prop) :
     timeTrace (eventDenotation P) = { t | ∃ e, P e ∧ t ∈ e.τ } :=
   timeTrace_image Event.τ { e | P e }
 
-theorem eventDenotation_singleton (e₀ : Event Time) :
+theorem eventDenotation_singleton (e₀ : Event T) :
     eventDenotation (fun e => e = e₀) = accomplishmentDenotation e₀.τ := by
   simp [eventDenotation, accomplishmentDenotation]
 
-theorem eventDenotation_sub_stative (i : NonemptyInterval Time) (P : Event Time → Prop)
+theorem eventDenotation_sub_stative (i : NonemptyInterval T) (P : Event T → Prop)
     (hP : ∀ e, P e → e.τ ≤ i) :
     eventDenotation P ⊆ stativeDenotation i := by
   rintro j ⟨e, he, rfl⟩; exact hP e he

--- a/Linglib/Semantics/Tense/TemporalAdverbials.lean
+++ b/Linglib/Semantics/Tense/TemporalAdverbials.lean
@@ -18,7 +18,7 @@ free, yielding only existential readings.
 ## Architecture
 
 ```
-PTSConstraint ──[toLBDomain]──▷ Set Time ──▷ PERF_XN
+PTSConstraint ──[toLBDomain]──▷ Set T ──▷ PERF_XN
 ```
 
 Adverbials are modeled as `PTSConstraint`s on the PTS interval. The
@@ -35,13 +35,13 @@ open Tense
 open Aspect
 open Tense.TenseAspectComposition
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-! ### PTS Constraints -/
 
 /-- A constraint on the Perfect Time Span.
     Adverbials restrict which PTS intervals are admissible. -/
-abbrev PTSConstraint (Time : Type*) [LinearOrder Time] := NonemptyInterval Time → Prop
+abbrev PTSConstraint (T : Type*) [LinearOrder T] := NonemptyInterval T → Prop
 
 /-- [iatridou-anagnostopoulou-izvorski-2001] adverbial type classification.
     - `durative`: specifies the left boundary (e.g., "since Monday")
@@ -55,22 +55,22 @@ inductive AdverbialType where
 
 /-- "ever since t₀": PTS must start at t₀.
     E.g., "has been running since Monday" → PTS.fst = Monday. -/
-def everSince (t₀ : Time) : PTSConstraint Time :=
+def everSince (t₀ : T) : PTSConstraint T :=
   λ pts => pts.fst = t₀
 
 /-- "for (duration) from tStart": PTS must start at tStart.
     Simplified duration adverbial — the duration is implicit in the
     interval length [tStart, RB]. -/
-def forDurationFrom (tStart : Time) : PTSConstraint Time :=
+def forDurationFrom (tStart : T) : PTSConstraint T :=
   λ pts => pts.fst = tStart
 
 /-- "always" / no temporal adverbial: no constraint on PTS. -/
-def always : PTSConstraint Time :=
+def always : PTSConstraint T :=
   λ _ => True
 
 /-- "before t" (inclusive adverbial): no constraint on PTS start.
     The adverbial constrains the event location, not the PTS boundary. -/
-def before : PTSConstraint Time :=
+def before : PTSConstraint T :=
   λ _ => True
 
 /-! ### LB Domain Extraction -/
@@ -80,7 +80,7 @@ def before : PTSConstraint Time :=
 
     For a constraint C, the compatible LBs are those tLB ≤ tc such that
     C holds of the interval [tLB, tc]. -/
-def PTSConstraint.toLBDomain (adv : PTSConstraint Time) (tc : Time) : Set Time :=
+def PTSConstraint.toLBDomain (adv : PTSConstraint T) (tc : T) : Set T :=
   { tLB | tLB ≤ tc ∧ ∀ (h : tLB ≤ tc), adv ⟨⟨tLB, tc⟩, h⟩ }
 
 /-! ### PERF with Adverbial -/
@@ -88,8 +88,8 @@ def PTSConstraint.toLBDomain (adv : PTSConstraint Time) (tc : Time) : Set Time :
 /-- Perfect with adverbial constraint: PERF_ADV(p, adv).
     Combines PERF with an adverbial constraint on the PTS.
     Equivalent to PERF_XN with the adverbial's derived LB domain. -/
-def PERF_ADV (p : IntervalPred W Time) (adv : PTSConstraint Time) : PointPred W Time :=
-  λ s => ∃ pts : NonemptyInterval Time, RB pts s.time ∧ adv pts ∧ p s.world pts
+def PERF_ADV (p : IntervalPred W T) (adv : PTSConstraint T) : PointPred W T :=
+  λ s => ∃ pts : NonemptyInterval T, RB pts s.time ∧ adv pts ∧ p s.world pts
 
 /-! ### Adverbial Type Properties -/
 
@@ -107,8 +107,8 @@ def AdverbialType.specifiesLB : AdverbialType → Bool
     PERF_ADV requires adv(PTS); PERF_XN requires LB(tLB, PTS) with
     tLB ∈ toLBDomain(adv, tc). These are equivalent by definition of
     toLBDomain: tLB ∈ toLBDomain ↔ tLB ≤ tc ∧ adv([tLB, tc]). -/
-theorem perf_adv_eq_perf_xn (p : IntervalPred W Time) (adv : PTSConstraint Time)
-    (tc : Time) (w : W) :
+theorem perf_adv_eq_perf_xn (p : IntervalPred W T) (adv : PTSConstraint T)
+    (tc : T) (w : W) :
     PERF_ADV p adv ⟨w, tc⟩ ↔ PERF_XN p (adv.toLBDomain tc) ⟨w, tc⟩ := by
   constructor
   · intro ⟨pts, hRB, hadv, hp⟩
@@ -131,8 +131,8 @@ theorem perf_adv_eq_perf_xn (p : IntervalPred W Time) (adv : PTSConstraint Time)
 
     Proof sketch: toLBDomain(everSince t₀, tc) = {tLB | tLB ≤ tc ∧ tLB = t₀}
     = {t₀} when t₀ ≤ tc. -/
-theorem everSince_specifies_lb (t₀ tc : Time) (h : t₀ ≤ tc) :
-    (everSince t₀ : PTSConstraint Time).toLBDomain tc = {t₀} := by
+theorem everSince_specifies_lb (t₀ tc : T) (h : t₀ ≤ tc) :
+    (everSince t₀ : PTSConstraint T).toLBDomain tc = {t₀} := by
   ext x
   simp only [PTSConstraint.toLBDomain, everSince, Set.mem_ofPred_eq]
   constructor
@@ -145,8 +145,8 @@ theorem everSince_specifies_lb (t₀ tc : Time) (h : t₀ ≤ tc) :
 
     Proof sketch: toLBDomain(before, tc) = {tLB | tLB ≤ tc ∧ True}
     = {tLB | tLB ≤ tc}. -/
-theorem before_no_lb_constraint (tc : Time) :
-    (before : PTSConstraint Time).toLBDomain tc = {tLB | tLB ≤ tc} := by
+theorem before_no_lb_constraint (tc : T) :
+    (before : PTSConstraint T).toLBDomain tc = {tLB | tLB ≤ tc} := by
   ext x
   simp only [PTSConstraint.toLBDomain, before, Set.mem_ofPred_eq]
   exact ⟨fun ⟨h, _⟩ => h, fun h => ⟨h, fun _ => trivial⟩⟩
@@ -155,7 +155,7 @@ theorem before_no_lb_constraint (tc : Time) :
 
     When the LB is pinned (durative adverbial), the U-perf reading
     entails the simple present via `u_perf_entails_simple_present`. -/
-theorem durative_licenses_u_perfect (V : W → Event Time → Prop) (t₀ tc : Time) (w : W)
+theorem durative_licenses_u_perfect (V : W → Event T → Prop) (t₀ tc : T) (w : W)
     (_h : t₀ ≤ tc) :
     presPerfProgXN V {t₀} tc w → simplePresent V tc w :=
   u_perf_entails_simple_present V {t₀} tc w
@@ -166,7 +166,7 @@ theorem durative_licenses_u_perfect (V : W → Event Time → Prop) (t₀ tc : T
     With no LB constraint, the domain is {tLB | tLB ≤ tc}. Under IMPF
     (subinterval property), this is close to Set.univ for the relevant
     range, so U-perf ↔ simple present by `broad_focus_equiv`'s argument. -/
-theorem inclusive_no_u_license (V : W → Event Time → Prop) (tc : Time) (w : W) :
+theorem inclusive_no_u_license (V : W → Event T → Prop) (tc : T) (w : W) :
     presPerfProgXN V Set.univ tc w ↔ simplePresent V tc w :=
   broad_focus_equiv V tc w
 

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -7,10 +7,10 @@ evaluation, following [knick-sharf-2026].
 ## The Pipeline
 
 ```
-Event Time → Prop ──[IMPF/PRFV]──▷ IntervalPred ──[PERF]──▷ PointPred ──[eval*]──▷ Prop
+Event T → Prop ──[IMPF/PRFV]──▷ IntervalPred ──[PERF]──▷ PointPred ──[eval*]──▷ Prop
 ```
 
-The aspect chain produces `PointPred W Time = Index W Time → Prop`.
+The aspect chain produces `PointPred W T = Index W T → Prop`.
 The eval* operators instantiate the situation (fixing world and time).
 
 ## Composed Forms
@@ -42,34 +42,34 @@ open Intensional (Index)
 
 open Aspect
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-! ### Tense Evaluation Operators -/
 
 /-- Evaluate a point predicate at speech time (PRESENT).
     PRES: p holds at tc in world w. -/
-def evalPres (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
+def evalPres (p : PointPred W T) (tc : T) (w : W) : Prop :=
   p ⟨w, tc⟩
 
 /-- Existential tense evaluation: the GQ `some` (`Quantification.some_sem`)
     over times `rel`-related to the evaluation time `tc`, scope `p` at `⟨w, ·⟩`.
     `evalPast`/`evalFut` are the `<`/`>` instances. -/
-def evalRel (rel : Time → Time → Prop) (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
+def evalRel (rel : T → T → Prop) (p : PointPred W T) (tc : T) (w : W) : Prop :=
   Quantification.some_sem (fun t => rel t tc) (fun t => p ⟨w, t⟩)
 
-omit [LinearOrder Time] in
+omit [LinearOrder T] in
 /-- Monotone in the body predicate — inherited from `some_scope_up`, not reproved. -/
-theorem evalRel_mono {rel : Time → Time → Prop} {p q : PointPred W Time}
-    (h : ∀ x, p x → q x) {tc : Time} {w : W} :
+theorem evalRel_mono {rel : T → T → Prop} {p q : PointPred W T}
+    (h : ∀ x, p x → q x) {tc : T} {w : W} :
     evalRel rel p tc w → evalRel rel q tc w :=
   Quantification.some_scope_up _ _ _ fun _ hp => h _ hp
 
 /-- Evaluate a point predicate with existential past (PAST): `∃ t < tc, p(w)(t)`. -/
-def evalPast (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
+def evalPast (p : PointPred W T) (tc : T) (w : W) : Prop :=
   evalRel (· < ·) p tc w
 
 /-- Evaluate a point predicate with existential future (FUTURE): `∃ t > tc, p(w)(t)`. -/
-def evalFut (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
+def evalFut (p : PointPred W T) (tc : T) (w : W) : Prop :=
   evalRel (· > ·) p tc w
 
 /-! ### Composed Tense–Aspect Forms -/
@@ -78,49 +78,49 @@ def evalFut (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
     "John runs" = at speech time, ∃e with tc ⊂ τ(e) and V(e).
     Since atPoint evaluates at [tc, tc], this gives:
     ∃e, [tc,tc] ⊂ τ(e) ∧ V(e). -/
-def simplePresent (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
+def simplePresent (V : W → Event T → Prop) (tc : T) (w : W) : Prop :=
   evalPres (IntervalPred.atPoint (IMPF V)) tc w
 
 /-- **Simple past**: PAST(PRFV(V).atPoint).
     "John ran" = ∃t < tc, ∃e with τ(e) ⊆ [t,t] and V(e). -/
-def simplePast (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
+def simplePast (V : W → Event T → Prop) (tc : T) (w : W) : Prop :=
   evalPast (IntervalPred.atPoint (PRFV V)) tc w
 
 /-- **Present perfect progressive**: PRES(PERF(IMPF(V))).
     "John has been running" = at tc, ∃PTS with RB(PTS, tc) and IMPF(V)(PTS). -/
-def presPerfProg (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
+def presPerfProg (V : W → Event T → Prop) (tc : T) (w : W) : Prop :=
   evalPres (PERF (IMPF V)) tc w
 
 /-- **Present perfect simple**: PRES(PERF(PRFV(V))).
     "John has run" = at tc, ∃PTS with RB(PTS, tc) and PRFV(V)(PTS). -/
-def presPerfSimple (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
+def presPerfSimple (V : W → Event T → Prop) (tc : T) (w : W) : Prop :=
   evalPres (PERF (PRFV V)) tc w
 
 /-- **Present perfect progressive with Extended Now**: PRES(PERF_XN(IMPF(V), tᵣ)).
     [knick-sharf-2026] eq. 39b: the U-perf reading.
     "John has been running (since Monday)" with domain restriction tᵣ on LB. -/
-def presPerfProgXN (V : W → Event Time → Prop) (tᵣ : Set Time) (tc : Time) (w : W) : Prop :=
+def presPerfProgXN (V : W → Event T → Prop) (tᵣ : Set T) (tc : T) (w : W) : Prop :=
   evalPres (PERF_XN (IMPF V) tᵣ) tc w
 
 /-- **Past perfect progressive**: PAST(PERF(IMPF(V))).
     "John had been running" = ∃t < tc, PERF(IMPF(V))(w)(t). -/
-def pastPerfProg (V : W → Event Time → Prop) (tc : Time) (w : W) : Prop :=
+def pastPerfProg (V : W → Event T → Prop) (tc : T) (w : W) : Prop :=
   evalPast (PERF (IMPF V)) tc w
 
 /-! ### Unfold Theorems -/
 
 /-- Simple present unfolds to: ∃e, [tc,tc] ⊂ τ(e) ∧ V(w)(e). -/
-theorem simplePresent_unfold (V : W → Event Time → Prop) (tc : Time) (w : W) :
+theorem simplePresent_unfold (V : W → Event T → Prop) (tc : T) (w : W) :
     simplePresent V tc w ↔
-    ∃ e : Event Time, NonemptyInterval.pure tc < e.τ ∧ V w e := by
+    ∃ e : Event T, NonemptyInterval.pure tc < e.τ ∧ V w e := by
   rfl
 
 /-- Present perfect progressive with XN unfolds to K&S eq. 39b:
     ∃PTS, ∃tLB ∈ tᵣ, LB(tLB, PTS) ∧ RB(PTS, tc) ∧ IMPF(V)(w)(PTS). -/
-theorem presPerfProgXN_unfold (V : W → Event Time → Prop) (tᵣ : Set Time)
-    (tc : Time) (w : W) :
+theorem presPerfProgXN_unfold (V : W → Event T → Prop) (tᵣ : Set T)
+    (tc : T) (w : W) :
     presPerfProgXN V tᵣ tc w ↔
-    ∃ pts : NonemptyInterval Time, ∃ tLB ∈ tᵣ,
+    ∃ pts : NonemptyInterval T, ∃ tLB ∈ tᵣ,
       LB tLB pts ∧ RB pts tc ∧ IMPF V w pts := by
   rfl
 
@@ -136,8 +136,8 @@ theorem presPerfProgXN_unfold (V : W → Event Time → Prop) (tᵣ : Set Time)
     Proof sketch: Given PERF_XN(IMPF(V), tᵣ)(w)(tc), we have PTS with
     RB(PTS, tc) and ∃e with PTS ⊂ τ(e). Since [tc,tc] ⊆ PTS (because
     tc = PTS.snd) and PTS ⊂ τ(e), we get [tc,tc] ⊂ τ(e). -/
-theorem u_perf_entails_simple_present (V : W → Event Time → Prop)
-    (tᵣ : Set Time) (tc : Time) (w : W) :
+theorem u_perf_entails_simple_present (V : W → Event T → Prop)
+    (tᵣ : Set T) (tc : T) (w : W) :
     presPerfProgXN V tᵣ tc w → simplePresent V tc w := by
   intro ⟨pts, _, _, _, hRB, e, hlt, hV⟩
   obtain ⟨hsub, hOr⟩ := NonemptyInterval.lt_def.mp hlt
@@ -160,7 +160,7 @@ theorem u_perf_entails_simple_present (V : W → Event Time → Prop)
     ∃e with [tc,tc] ⊂ τ(e). Construct PTS = [e.τ.fst, tc]. Then
     LB(e.τ.fst, PTS) ∈ Set.univ, RB(PTS, tc), and PTS ⊆ τ(e) with
     PTS ⊂ τ(e) (since tc < e.τ.snd by properSubinterval). -/
-theorem broad_focus_equiv (V : W → Event Time → Prop) (tc : Time) (w : W) :
+theorem broad_focus_equiv (V : W → Event T → Prop) (tc : T) (w : W) :
     presPerfProgXN V Set.univ tc w ↔ simplePresent V tc w := by
   constructor
   · exact u_perf_entails_simple_present V Set.univ tc w
@@ -180,8 +180,8 @@ theorem broad_focus_equiv (V : W → Event Time → Prop) (tc : Time) (w : W) :
     Proof sketch: Given PTS₁ = [tLB₁, tc] with e.τ ⊃ PTS₁ and V(e),
     construct PTS₂ = [tLB₂, tc]. Since tLB₁ < tLB₂ ≤ tc, PTS₂ is valid.
     PTS₂ ⊆ PTS₁ ⊆ τ(e), and PTS₂ ⊂ τ(e) follows from PTS₁ ⊂ τ(e). -/
-theorem earlier_lb_stronger_impf (V : W → Event Time → Prop)
-    (tLB₁ tLB₂ : Time) (tc : Time) (w : W) (h : tLB₁ < tLB₂) (htc : tLB₂ ≤ tc) :
+theorem earlier_lb_stronger_impf (V : W → Event T → Prop)
+    (tLB₁ tLB₂ : T) (tc : T) (w : W) (h : tLB₁ < tLB₂) (htc : tLB₂ ≤ tc) :
     PERF_XN (IMPF V) {tLB₁} ⟨w, tc⟩ → PERF_XN (IMPF V) {tLB₂} ⟨w, tc⟩ := by
   intro ⟨pts, tLB, htLB, hLB, hRB, e, hlt, hV⟩
   obtain ⟨hsub, _hOr⟩ := NonemptyInterval.lt_def.mp hlt
@@ -213,8 +213,8 @@ theorem earlier_lb_stronger_impf (V : W → Event Time → Prop)
     Proof sketch: Given PTS₂ = [tLB₂, tc] with τ(e) ⊆ PTS₂,
     construct PTS₁ = [tLB₁, tc]. Since tLB₁ < tLB₂, PTS₂ ⊆ PTS₁,
     so τ(e) ⊆ PTS₁. -/
-theorem later_lb_stronger_prfv (V : W → Event Time → Prop)
-    (tLB₁ tLB₂ : Time) (tc : Time) (w : W) (h : tLB₁ < tLB₂) :
+theorem later_lb_stronger_prfv (V : W → Event T → Prop)
+    (tLB₁ tLB₂ : T) (tc : T) (w : W) (h : tLB₁ < tLB₂) :
     PERF_XN (PRFV V) {tLB₂} ⟨w, tc⟩ → PERF_XN (PRFV V) {tLB₁} ⟨w, tc⟩ := by
   intro ⟨pts, tLB, htLB, hLB, hRB, e, hle, hV⟩
   obtain ⟨hS1, hS2⟩ := NonemptyInterval.le_def.mp hle

--- a/Linglib/Studies/Abusch1997.lean
+++ b/Linglib/Studies/Abusch1997.lean
@@ -43,14 +43,14 @@ namespace Abusch1997
 
 open Tense Acquaintance
 
-variable {E W Time : Type*}
+variable {E W T : Type*}
 
 /-! ### De re interpretation across attitude contexts -/
 
 /-- The simultaneous reading of *Mary believed it was raining*: the embedded past is anaphoric
 to the matrix past, hence de re, with identity to the now as acquaintance relation; the believed
 centered proposition is rain at the believer's now. -/
-theorem simultaneous_deRe (rain : Time → W → Prop) :
+theorem simultaneous_deRe (rain : T → W → Prop) :
     deRe (identity (E := E)) (fun t _ w => rain t w) = fun _ t w => rain t w :=
   deRe_identity _
 
@@ -66,12 +66,12 @@ def matrixPast : TemporalArgument ℕ := ⟨1, 1, 0⟩
 `R²(t₂, t₂)`. -/
 def embeddedPast : TemporalArgument ℕ := ⟨2, 2, 2⟩
 
-variable {ρ : RelationAssignment ℕ Time} {g : ℕ → Time}
+variable {ρ : RelationAssignment ℕ T} {g : ℕ → T}
 
 /-- The simultaneous reading is licensed non-locally: the embedded relation is reflexive at the
 now, so the matrix relation must be precedence — the believing precedes the utterance time and
 the raining is at the believer's now. -/
-theorem simultaneous_nonLocal [Preorder Time] (h₁ : matrixPast.Con ρ g)
+theorem simultaneous_nonLocal [Preorder T] (h₁ : matrixPast.Con ρ g)
     (h₂ : embeddedPast.Con ρ g) (hp₁ : PastConstraint ρ {1}) (hp₂ : PastConstraint ρ {1, 2}) :
     g 1 < g 0 ∧ embeddedPast.NonLocallyLicensed ρ {1, 2} :=
   ⟨by simpa [matrixPast, TemporalArgument.Con, pastConstraint_singleton.1 hp₁] using h₁,
@@ -92,7 +92,7 @@ theorem narrowScope_forward (k : ℕ) (hk : k ≠ 1) :
 
 /-- The wide-scope LF: the relative clause is outside the attitude, so its past has access only
 to its own relation, evaluated at the utterance time — the interest precedes the utterance. -/
-theorem wideScope_precedes [Preorder Time] {k i : ℕ}
+theorem wideScope_precedes [Preorder T] {k i : ℕ}
     (hcon : (⟨k, i, 0⟩ : TemporalArgument ℕ).Con ρ g) (hp : PastConstraint ρ {k}) : g i < g 0 := by
   simpa [TemporalArgument.Con, pastConstraint_singleton.1 hp] using hcon
 
@@ -101,7 +101,7 @@ def matrixPresent : TemporalArgument ℕ := ⟨1, 1, 0⟩
 
 /-- A present matrix forces local licensing: the past of *a man she met recently* must itself be
 precedence, so the meeting precedes the marrying. -/
-theorem expects_local [Preorder Time] (h₁ : matrixPresent.Con ρ g)
+theorem expects_local [Preorder T] (h₁ : matrixPresent.Con ρ g)
     (hq : PresentConstraint ρ {1}) (hp : PastConstraint ρ {1, 3})
     (h₃ : (⟨3, 3, 2⟩ : TemporalArgument ℕ).Con ρ g) : g 3 < g 2 := by
   obtain ⟨r, hr, hρ⟩ := hp
@@ -112,7 +112,7 @@ theorem expects_local [Preorder Time] (h₁ : matrixPresent.Con ρ g)
 
 /-- *Sue expects to marry a man she loved* has no simultaneous reading: coindexing the embedded
 past with the marrying time leaves no relation to license it. -/
-theorem expects_no_simultaneous [Preorder Time] (h₁ : matrixPresent.Con ρ g)
+theorem expects_no_simultaneous [Preorder T] (h₁ : matrixPresent.Con ρ g)
     (hq : PresentConstraint ρ {1}) (hp : PastConstraint ρ {1, 3})
     (h₃ : (⟨3, 2, 2⟩ : TemporalArgument ℕ).Con ρ g) : False := by
   obtain ⟨r, hr, hρ⟩ := hp
@@ -124,15 +124,15 @@ theorem expects_no_simultaneous [Preorder Time] (h₁ : matrixPresent.Con ρ g)
 /-- The two LFs of the simultaneous reading — de re with the identity relation, and non-locally
 licensed with the embedded past coindexed with the now — ascribe the same centered
 proposition. -/
-theorem deRe_eq_nonLocal (rain : Time → W → Prop) :
-    deRe (identity (E := E)) (fun t _ w => rain t w) = fun (_ : E) (t : Time) w => rain t w :=
+theorem deRe_eq_nonLocal (rain : T → W → Prop) :
+    deRe (identity (E := E)) (fun t _ w => rain t w) = fun (_ : E) (t : T) w => rain t w :=
   simultaneous_deRe rain
 
 /-! ### The upper limit constraint -/
 
 /-- The forward-shifted reading of *he thought that a burglar attacked him*: an embedded past
 anaphoric to the later opening violates the upper limit constraint at the thinking time. -/
-theorem forwardShifted_not_upperLimit [LinearOrder Time] {a : TemporalArgument ℕ}
+theorem forwardShifted_not_upperLimit [LinearOrder T] {a : TemporalArgument ℕ}
     (h : g a.evalIndex < g a.index) : ¬ a.UpperLimit g :=
   not_le.2 h
 
@@ -144,7 +144,7 @@ def embeddedPresent : TemporalArgument ℕ := ⟨3, 3, 2⟩
 
 /-- The non-de-re LF is contradictory: the matrix past makes `R¹` precedence, the embedded
 present requires it to exclude precedence. -/
-theorem presentUnderPast_false [Preorder Time] (h₁ : matrixPast.Con ρ g)
+theorem presentUnderPast_false [Preorder T] (h₁ : matrixPast.Con ρ g)
     (hp : PastConstraint ρ {1}) (hq : PresentConstraint ρ {1, 3}) : False :=
   hp.false_of_presentConstraint hq (by simp) h₁
 
@@ -153,8 +153,8 @@ utterance time; its trace denotes `J` in the belief world, bounded by the upper 
 at the believer's now; and the counterpart correspondence — `I` follows the believing time iff `J`
 follows the now, `I` overlaps it iff `J` overlaps the now — leaves only the reading where `I`
 overlaps the believing time as well. -/
-theorem doubleAccess_of_counterpart [LinearOrder Time] {I J : Set Time} (hI : I.OrdConnected)
-    {believing utterance now : Time} (hlt : believing < utterance) (hU : utterance ∈ I)
+theorem doubleAccess_of_counterpart [LinearOrder T] {I J : Set T} (hI : I.OrdConnected)
+    {believing utterance now : T} (hlt : believing < utterance) (hU : utterance ∈ I)
     (hulc : ∃ s ∈ J, s ≤ now)
     (hafter : (∀ s ∈ I, believing < s) ↔ ∀ s ∈ J, now < s)
     (hoverlap : believing ∈ I ↔ now ∈ J) :

--- a/Linglib/Studies/AlstottAravind2026.lean
+++ b/Linglib/Studies/AlstottAravind2026.lean
@@ -50,22 +50,22 @@ open Core.Order
 
 /-! ### The two theories (§2.1) -/
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- The under-specification entry for *before* (7a): some run-time of the main clause is
 partly preceded by every run-time of the embedded clause — Anscombe's entry with *some*
 subinterval following in place of *every*, the weakening accomplishments require. -/
-def weakBefore (A B : RunTimes Time) : Prop := ∃ i ∈ A, ∀ j ∈ B, i.snd < j.snd
+def weakBefore (A B : RunTimes T) : Prop := ∃ i ∈ A, ∀ j ∈ B, i.snd < j.snd
 
 /-- The under-specification entry for *after* (7b): some run-time of the main clause fully
 follows some run-time of the embedded clause. -/
-def weakAfter (A B : RunTimes Time) : Prop := ∃ i ∈ A, ∃ j ∈ B, j.snd < i.fst
+def weakAfter (A B : RunTimes T) : Prop := ∃ i ∈ A, ∃ j ∈ B, j.snd < i.fst
 
 /-- Temporal overlap — the *while* reading a competition-based implicature negates (§8.1). -/
-def Overlap (A B : RunTimes Time) : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
+def Overlap (A B : RunTimes T) : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
 
 /-- A stative is weakly *before* an accomplishment iff its onset precedes the telos. -/
-theorem weakBefore_stative_accomplishment_iff (a b : NonemptyInterval Time) :
+theorem weakBefore_stative_accomplishment_iff (a b : NonemptyInterval T) :
     weakBefore (stativeDenotation a) (accomplishmentDenotation b) ↔ a.fst < b.snd := by
   constructor
   · rintro ⟨i, hi, h⟩
@@ -75,7 +75,7 @@ theorem weakBefore_stative_accomplishment_iff (a b : NonemptyInterval Time) :
       fun j hj => hj ▸ h⟩
 
 /-- A stative is weakly *after* a stative iff its end follows the other's onset. -/
-theorem weakAfter_stative_stative_iff (a b : NonemptyInterval Time) :
+theorem weakAfter_stative_stative_iff (a b : NonemptyInterval T) :
     weakAfter (stativeDenotation a) (stativeDenotation b) ↔ b.fst < a.snd := by
   constructor
   · rintro ⟨i, hi, j, hj, h⟩
@@ -86,7 +86,7 @@ theorem weakAfter_stative_stative_iff (a b : NonemptyInterval Time) :
       NonemptyInterval.pure b.fst, Set.mem_Iic.mpr ⟨le_rfl, b.fst_le_snd⟩, h⟩
 
 /-- A stative and an accomplishment overlap iff neither ends before the other starts. -/
-theorem overlap_stative_accomplishment_iff (a b : NonemptyInterval Time) :
+theorem overlap_stative_accomplishment_iff (a b : NonemptyInterval T) :
     Overlap (stativeDenotation a) (accomplishmentDenotation b) ↔ a.fst ≤ b.snd ∧ b.fst ≤ a.snd := by
   simp only [Overlap, timeTrace_stative_closedInterval, timeTrace_accomplishment_closedInterval,
     Set.mem_ofPred_eq]

--- a/Linglib/Studies/Anscombe1964.lean
+++ b/Linglib/Studies/Anscombe1964.lean
@@ -26,29 +26,29 @@ namespace Anscombe1964
 
 open Tense NonemptyInterval
 
-variable {Time : Type*} [LinearOrder Time] {A B C : RunTimes Time}
+variable {T : Type*} [LinearOrder T] {A B C : RunTimes T}
 
 /-! ### Definitions -/
 
 /-- *p before q*: *p and not q, and then q* (§II). -/
-def Anscombe.before (A B : RunTimes Time) : Prop :=
+def Anscombe.before (A B : RunTimes T) : Prop :=
   ∃ t ∈ timeTrace A \ timeTrace B, ∃ t' ∈ timeTrace B, t < t'
 
 /-- *p after q*: *q, and then p* — a time of *p* after a time of *q* (§II, §IV). -/
-def Anscombe.after (A B : RunTimes Time) : Prop :=
+def Anscombe.after (A B : RunTimes T) : Prop :=
   ∃ t ∈ timeTrace A, ∃ t' ∈ timeTrace B, t' < t
 
 /-- The §IV rendering of *p before q*, a time of *p* before every time of *q*, which §V
 finds right for *p before ever q*. -/
-def Anscombe.beforeEver (A B : RunTimes Time) : Prop :=
+def Anscombe.beforeEver (A B : RunTimes T) : Prop :=
   ∃ t ∈ timeTrace A, ∀ t' ∈ timeTrace B, t < t'
 
 /-- Repetition: *p, and then not p, and then p* (§II). -/
-def Repetition (A : RunTimes Time) : Prop :=
+def Repetition (A : RunTimes T) : Prop :=
   ∃ t₁ ∈ timeTrace A, ∃ t₂ ∉ timeTrace A, ∃ t₃ ∈ timeTrace A, t₁ < t₂ ∧ t₂ < t₃
 
 /-- A clause reports an instantaneous event when it holds at a single time (§VIII). -/
-def Instantaneous (A : RunTimes Time) : Prop := ∃ t, timeTrace A = {t}
+def Instantaneous (A : RunTimes T) : Prop := ∃ t, timeTrace A = {t}
 
 /-! ### The logical properties (§II) -/
 
@@ -134,7 +134,7 @@ theorem before_not_beforeEver :
     fun ⟨t, ht, h⟩ => absurd (h 1 (by simp)) (by simp at ht; subst ht; decide)⟩
 
 /-- *Before ever*, when *q* has a first time: a time of *p* precedes it. -/
-theorem beforeEver_iff_lt_least {lb : Time} (hlb : IsLeast (timeTrace B) lb) :
+theorem beforeEver_iff_lt_least {lb : T} (hlb : IsLeast (timeTrace B) lb) :
     Anscombe.beforeEver A B ↔ ∃ t ∈ timeTrace A, t < lb :=
   ⟨fun ⟨a, ha, h⟩ => ⟨a, ha, h lb hlb.1⟩,
     fun ⟨a, ha, h⟩ => ⟨a, ha, fun _ ht' => h.trans_le (hlb.2 ht')⟩⟩
@@ -174,19 +174,19 @@ theorem nonempty_of_before : Anscombe.before A B → (timeTrace B).Nonempty :=
   fun ⟨_, _, b, hb, _⟩ => ⟨b, hb⟩
 
 /-- For a non-repeating *q* with a first time, *p before q* is *p before q began*. -/
-theorem before_iff_lt_least {lb : Time} (hB : (timeTrace B).OrdConnected)
+theorem before_iff_lt_least {lb : T} (hB : (timeTrace B).OrdConnected)
     (hlb : IsLeast (timeTrace B) lb) : Anscombe.before A B ↔ ∃ t ∈ timeTrace A, t < lb := by
   rw [before_iff_beforeEver hB, beforeEver_iff_lt_least hlb, and_iff_left ⟨lb, hlb.1⟩]
 
 /-- *p after q* is *p after q began* (§III (3), §X case 3a); *q before p* gives it too
 (`after_of_before`, case 3b). -/
-theorem after_iff_least_lt {lb : Time} (hlb : IsLeast (timeTrace B) lb) :
+theorem after_iff_least_lt {lb : T} (hlb : IsLeast (timeTrace B) lb) :
     Anscombe.after A B ↔ ∃ t ∈ timeTrace A, lb < t :=
   ⟨fun ⟨a, ha, _, ht', h⟩ => ⟨a, ha, (hlb.2 ht').trans_lt h⟩,
     fun ⟨a, ha, h⟩ => ⟨a, ha, lb, hlb.1, h⟩⟩
 
 /-- *p after q stopped* gives *p after q* (§III (4) to (3), §X case 3c). -/
-theorem after_of_greatest_lt {ub : Time} (hub : IsGreatest (timeTrace B) ub) :
+theorem after_of_greatest_lt {ub : T} (hub : IsGreatest (timeTrace B) ub) :
     (∃ t ∈ timeTrace A, ub < t) → Anscombe.after A B :=
   fun ⟨a, ha, h⟩ => ⟨a, ha, ub, hub.1, h⟩
 

--- a/Linglib/Studies/ArreguiKusumoto1998.lean
+++ b/Linglib/Studies/ArreguiKusumoto1998.lean
@@ -48,15 +48,15 @@ namespace ArreguiKusumoto1998
 open Data.Examples English.TemporalExpressions Japanese.TemporalConnectives
 open Tense (SOTParameter EmbeddedTenseReading availableReadings)
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-! ### Tensed clauses and their types -/
 
 /-- A tensed clause: a past-tense operator yields a set of times, a present-tense variable a
     proposition open in that variable. -/
-inductive TP (Time : Type*)
-  | times (X : Time → Prop)
-  | free (P : Time → Prop)
+inductive TP (T : Type*)
+  | times (X : T → Prop)
+  | free (P : T → Prop)
 
 /-- The semantic type of a tensed clause. -/
 inductive Shape
@@ -65,7 +65,7 @@ inductive Shape
   deriving DecidableEq
 
 /-- The type of a tensed clause. -/
-def TP.shape : TP Time → Shape
+def TP.shape : TP T → Shape
   | .times _ => .times
   | .free _ => .free
 
@@ -81,7 +81,7 @@ def Tense.shape : Tense → Shape
   | .present => .free
 
 /-- The speech time in C saturates a set of times; an unbound present variable is indexical. -/
-def TP.atSpeech : TP Time → Time → Prop
+def TP.atSpeech : TP T → T → Prop
   | .times X, s => X s
   | .free P, s => P s
 
@@ -93,62 +93,62 @@ def Shape.selected (binder : Bool) : Shape → Bool
 /-- A connective selecting TP: with a binder index it abstracts over the present variable,
     without one it takes the set of times a past operator yields. The other two combinations
     are uninterpretable — vacuous binding, or a truth value where a set of times is needed. -/
-def selectTP : Bool → TP Time → Option (Time → Prop)
+def selectTP : Bool → TP T → Option (T → Prop)
   | true, .free P => some P
   | false, .times X => some X
   | _, _ => none
 
-theorem selectTP_isSome (binder : Bool) (tp : TP Time) :
+theorem selectTP_isSome (binder : Bool) (tp : TP T) :
     (selectTP binder tp).isSome = tp.shape.selected binder := by
   cases binder <;> cases tp <;> rfl
 
-variable [LinearOrder Time]
+variable [LinearOrder T]
 
 /-! ### Tense as operator or variable -/
 
 /-- The Priorian past operator closes the clause into the set of times some `P`-time precedes;
     the present tense leaves `P` open in its variable. -/
-def Tense.tp : Tense → (Time → Prop) → TP Time
+def Tense.tp : Tense → (T → Prop) → TP T
   | .past, P => .times λ t => ∃ t' < t, P t'
   | .present, P => .free P
 
-@[simp] theorem Tense.shape_tp (τ : Tense) (P : Time → Prop) : (τ.tp P).shape = τ.shape := by
+@[simp] theorem Tense.shape_tp (τ : Tense) (P : T → Prop) : (τ.tp P).shape = τ.shape := by
   cases τ <;> rfl
 
 /-- A root present-tense sentence holds at the speech time. -/
-theorem root_present (P : Time → Prop) (s : Time) : (Tense.present.tp P).atSpeech s ↔ P s :=
+theorem root_present (P : T → Prop) (s : T) : (Tense.present.tp P).atSpeech s ↔ P s :=
   Iff.rfl
 
 /-- A root past-tense sentence holds at some time before the speech time. -/
-theorem root_past (P : Time → Prop) (s : Time) :
+theorem root_past (P : T → Prop) (s : T) :
     (Tense.past.tp P).atSpeech s ↔ ∃ t < s, P t :=
   Iff.rfl
 
 /-! ### Before and after -/
 
 /-- *before*: the times preceding every `X`-time. -/
-def before (X : Time → Prop) (t : Time) : Prop := ∀ t', X t' → t < t'
+def before (X : T → Prop) (t : T) : Prop := ∀ t', X t' → t < t'
 
 /-- *after*: the times some `X`-time precedes. -/
-def after (X : Time → Prop) (t : Time) : Prop := ∃ t', t' < t ∧ X t'
+def after (X : T → Prop) (t : T) : Prop := ∃ t', t' < t ∧ X t'
 
 /-- A connective is veridical when its clause holds only if the complement has a time. -/
-def Veridical (C : (Time → Prop) → Time → Prop) : Prop := ∀ X t, C X t → ∃ t', X t'
+def Veridical (C : (T → Prop) → T → Prop) : Prop := ∀ X t, C X t → ∃ t', X t'
 
-theorem veridical_after : Veridical (after (Time := Time)) := λ _ _ ⟨t', _, h⟩ => ⟨t', h⟩
+theorem veridical_after : Veridical (after (T := T)) := λ _ _ ⟨t', _, h⟩ => ⟨t', h⟩
 
-theorem not_veridical_before (t : Time) : ¬ Veridical (before (Time := Time)) :=
+theorem not_veridical_before (t : T) : ¬ Veridical (before (T := T)) :=
   λ h => (h (λ _ => False) t λ _ h => h.elim).elim λ _ h => h
 
 /-- The connective denotation of a fragment entry's order, where the paper gives one. -/
-def denotation : TemporalOrder → Option ((Time → Prop) → Time → Prop)
+def denotation : TemporalOrder → Option ((T → Prop) → T → Prop)
   | .before => some before
   | .after => some after
   | _ => none
 
 /-- The fragments' veridicality field is the veridicality of the denotation. -/
-theorem complementVeridical_iff (t : Time) :
-    ∀ e ∈ [before_, after_, mae, ato], ∀ C ∈ denotation (Time := Time) e.order,
+theorem complementVeridical_iff (t : T) :
+    ∀ e ∈ [before_, after_, mae, ato], ∀ C ∈ denotation (T := T) e.order,
       (e.complementVeridical = true ↔ Veridical C) := by
   simp [before_, after_, mae, ato, denotation, veridical_after, not_veridical_before t]
 
@@ -156,53 +156,53 @@ theorem complementVeridical_iff (t : Time) :
 
 /-- A relative-clause adjunct: the relative pronoun abstracts over a trace in the clause's
     time argument, and the speech time in C saturates the tensed clause. -/
-def relativeClause (τ : Tense) (P : Time → Prop) (s tj : Time) : Prop :=
+def relativeClause (τ : Tense) (P : T → Prop) (s tj : T) : Prop :=
   (τ.tp λ t => P t ∧ t = tj).atSpeech s
 
 /-- A past-tensed relative clause denotes the past `P`-times, ordered against the speech time
     alone. -/
-theorem relativeClause_past (P : Time → Prop) (s t : Time) :
+theorem relativeClause_past (P : T → Prop) (s t : T) :
     relativeClause .past P s t ↔ t < s ∧ P t := by
   simp [relativeClause, Tense.tp, TP.atSpeech]
 
 /-- An indexical present in a relative clause denotes the speech time, if `P` holds there. -/
-theorem relativeClause_present (P : Time → Prop) (s t : Time) :
+theorem relativeClause_present (P : T → Prop) (s t : T) :
     relativeClause .present P s t ↔ P s ∧ s = t :=
   Iff.rfl
 
 /-- A past-tensed matrix clause `Q` modified by an adjunct `X`: the adjunct intersects the VP
     and the matrix past locates the result before the speech time `s`. -/
-def modified (Q X : Time → Prop) (s : Time) : Prop := ∃ t < s, Q t ∧ X t
+def modified (Q X : T → Prop) (s : T) : Prop := ∃ t < s, Q t ∧ X t
 
 /-- *Satoshi left after Junko came*: both events are past, and the connective alone orders
     them. -/
-theorem after_relativeClause (Q P : Time → Prop) (s : Time) :
+theorem after_relativeClause (Q P : T → Prop) (s : T) :
     modified Q (after (relativeClause .past P s)) s ↔
       ∃ t < s, Q t ∧ ∃ t', t' < t ∧ t' < s ∧ P t' := by
   simp [modified, after, relativeClause_past]
 
 /-- *Satoshi left before Junko came*: the leaving precedes every past coming. -/
-theorem before_relativeClause (Q P : Time → Prop) (s : Time) :
+theorem before_relativeClause (Q P : T → Prop) (s : T) :
     modified Q (before (relativeClause .past P s)) s ↔
       ∃ t < s, Q t ∧ ∀ t', t' < s → P t' → t < t' := by
   simp [modified, before, relativeClause_past]
 
 /-- *Junko was in her room when Satoshi came*, past tense: an episode at a past time. -/
-theorem when_past (Q P : Time → Prop) (s : Time) :
+theorem when_past (Q P : T → Prop) (s : T) :
     modified Q (relativeClause .past P s) s ↔ ∃ t < s, Q t ∧ t < s ∧ P t := by
   simp [modified, relativeClause_past]
 
 /-- An indexical present in a when-clause contradicts a past matrix: the adjunct time is the
     speech time, which the matrix event precedes. -/
-theorem when_present_indexical (Q P : Time → Prop) (s : Time) :
+theorem when_present_indexical (Q P : T → Prop) (s : T) :
     ¬ modified Q (relativeClause .present P s) s := by
   rintro ⟨t, ht, -, -, rfl⟩
   exact lt_irrefl _ ht
 
 /-- The present variable bound by a covert adverb of quantification: over some past interval,
     every `P`-time is a `Q`-time. -/
-def whenever (P Q : Time → Prop) (s : Time) : Prop :=
-  ∃ I : Set Time, (∀ t ∈ I, t < s) ∧ ∀ t ∈ I, P t → Q t
+def whenever (P Q : T → Prop) (s : T) : Prop :=
+  ∃ I : Set T, (∀ t ∈ I, t < s) ∧ ∀ t ∈ I, P t → Q t
 
 /-- The readings of a when-clause. -/
 inductive WhenReading
@@ -218,14 +218,14 @@ def WhenReading.of : Shape → WhenReading
   | .free => .habitual
 
 /-- The truth conditions of each reading, for a when-clause `P` modifying a past `Q`. -/
-def WhenReading.denotation : WhenReading → (Time → Prop) → (Time → Prop) → Time → Prop
+def WhenReading.denotation : WhenReading → (T → Prop) → (T → Prop) → T → Prop
   | .episodic, P, Q, s => modified Q (relativeClause .past P s) s
   | .habitual, P, Q, s => whenever P Q s
 
 /-! ### Connectives selecting TP -/
 
 /-- The past operator inside an after-clause is absorbed by *after*. -/
-theorem after_past [DenselyOrdered Time] (P : Time → Prop) (t : Time) :
+theorem after_past [DenselyOrdered T] (P : T → Prop) (t : T) :
     after (λ t => ∃ t' < t, P t') t ↔ after P t := by
   constructor
   · rintro ⟨t', ht', t'', ht'', h⟩
@@ -236,25 +236,25 @@ theorem after_past [DenselyOrdered Time] (P : Time → Prop) (t : Time) :
 
 /-- *ato* takes the set of times its past-tensed complement denotes, and *after* absorbs the
     past operator. -/
-theorem after_selectTP [DenselyOrdered Time] (P : Time → Prop) :
+theorem after_selectTP [DenselyOrdered T] (P : T → Prop) :
     ∀ X ∈ selectTP false (Tense.past.tp P), after X = after P := by
   simp only [selectTP, Tense.tp, Option.mem_def, Option.some.injEq, forall_eq']
   exact funext λ t => propext (after_past P t)
 
 /-- *Satoshi left after Junko came* in Japanese: the coming precedes the leaving, with no
     relation to the speech time. -/
-theorem modified_after (Q P : Time → Prop) (s : Time) :
+theorem modified_after (Q P : T → Prop) (s : T) :
     modified Q (after P) s ↔ ∃ t < s, Q t ∧ ∃ t', t' < t ∧ P t' :=
   Iff.rfl
 
 /-- *mae* binds the present variable of its complement. -/
-theorem before_selectTP (P : Time → Prop) :
+theorem before_selectTP (P : T → Prop) :
     ∀ X ∈ selectTP true (Tense.present.tp P), X = P := by
   simp [selectTP, Tense.tp]
 
 /-- *Satoshi left before Junko came* in Japanese: the leaving precedes every coming, past or
     not. -/
-theorem modified_before (Q P : Time → Prop) (s : Time) :
+theorem modified_before (Q P : T → Prop) (s : T) :
     modified Q (before P) s ↔ ∃ t < s, Q t ∧ ∀ t', P t' → t < t' :=
   Iff.rfl
 

--- a/Linglib/Studies/BeaverCondoravdi2003.lean
+++ b/Linglib/Studies/BeaverCondoravdi2003.lean
@@ -181,7 +181,7 @@ section Classical
 
 open Anscombe1964
 
-variable {Time : Type*} [LinearOrder Time] (A B B' : RunTimes Time)
+variable {T : Type*} [LinearOrder T] (A B B' : RunTimes T)
 
 /-- The complement of [anscombe-1964]'s quantificational *before* is downward entailing: the
 universal over `B` reverses inclusion — the NPI-licensing environment. -/

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -169,7 +169,7 @@ The reading hierarchy `(25c) ⊨ (25b) ⊨ (25a)` and the result-root collapse
 (§2.4, exs (43)/(45)) fall out of the change-of-state entailments of
 `Verb.CosModel`. -/
 
-variable {Entity State Time : Type*} [LinearOrder Time]
+variable {Entity State T : Type*} [LinearOrder T]
 
 /-- (26): the sublexical modifier *again*. Given a precedence `≪` (`lt`) on an
     eventuality type `ι` and a predicate `P`, *again* asserts `P e` and
@@ -189,30 +189,30 @@ theorem again_iff {ι : Type*} (lt : ι → ι → Prop) (P : ι → Prop) (e : 
 
 /-- (27a): *again* attached low, to the root `√V`. The asserted/presupposed
     predicate is the root **state** — the restitutive reading. -/
-def againRestitutive (M : CosModel Entity State Time)
+def againRestitutive (M : CosModel Entity State T)
     (ltS : State → State → Prop) (v : Verb) (x : Entity) (s : State) : Prop :=
   again ltS (M.rootState v x) s
 
 /-- (27b): *again* attached to `vbecomeP` — the repetitive-over-change
     reading. -/
-def againRepetitiveBecome (M : CosModel Entity State Time)
-    (ltE : Event Time → Event Time → Prop) (v : Verb) (x : Entity)
-    (e : Event Time) : Prop :=
+def againRepetitiveBecome (M : CosModel Entity State T)
+    (ltE : Event T → Event T → Prop) (v : Verb) (x : Entity)
+    (e : Event T) : Prop :=
   again ltE (M.inchoative v x) e
 
 /-- (27c): *again* attached high, to `vcauseP` — the
     repetitive-over-causation reading. -/
-def againRepetitiveCause (M : CosModel Entity State Time)
-    (ltE : Event Time → Event Time → Prop) (v : Verb) (y x : Entity)
-    (w : Event Time) : Prop :=
+def againRepetitiveCause (M : CosModel Entity State T)
+    (ltE : Event T → Event T → Prop) (v : Verb) (y x : Entity)
+    (w : Event T) : Prop :=
   again ltE (M.causative v y x) w
 
 /-- (25) hierarchy, upper step: the repetitive-causation presupposition (25c)
     entails the repetitive-change presupposition (25b) — the earlier causing
     event *is* an earlier change, by `causative_entails_inchoative`. -/
-theorem againPresup_cause_entails_become (M : CosModel Entity State Time)
-    (lt : Event Time → Event Time → Prop) (v : Verb) (y x : Entity)
-    (w : Event Time) (h : againPresup lt (M.causative v y x) w) :
+theorem againPresup_cause_entails_become (M : CosModel Entity State T)
+    (lt : Event T → Event T → Prop) (v : Verb) (y x : Entity)
+    (w : Event T) (h : againPresup lt (M.causative v y x) w) :
     ∃ w', lt w' w ∧ ∃ e, M.inchoative v x e := by
   obtain ⟨w', hlt, hcaus⟩ := h
   exact ⟨w', hlt, M.causative_entails_inchoative v y x w' hcaus⟩
@@ -220,9 +220,9 @@ theorem againPresup_cause_entails_become (M : CosModel Entity State Time)
 /-- (25) hierarchy, lower step: the repetitive-change presupposition (25b)
     entails the restitutive presupposition (25a) — the earlier change gives
     rise to an earlier root state, by `inchoative_entails_resultState`. -/
-theorem againPresup_become_entails_state (M : CosModel Entity State Time)
-    (lt : Event Time → Event Time → Prop) (v : Verb) (x : Entity)
-    (e : Event Time) (h : againPresup lt (M.inchoative v x) e) :
+theorem againPresup_become_entails_state (M : CosModel Entity State T)
+    (lt : Event T → Event T → Prop) (v : Verb) (x : Entity)
+    (e : Event T) (h : againPresup lt (M.inchoative v x) e) :
     ∃ e', lt e' e ∧ ∃ s, M.become s e' ∧ M.rootState v x s := by
   obtain ⟨e', hlt, hinch⟩ := h
   exact ⟨e', hlt, M.inchoative_entails_resultState v x e' hinch⟩
@@ -230,9 +230,9 @@ theorem againPresup_become_entails_state (M : CosModel Entity State Time)
 /-- (25) hierarchy, end to end: "Mary had flattened it before" ⊨ "it had
     been flat before", composed through the change-of-state decomposition
     (`causative_entails_resultState`). -/
-theorem againPresup_cause_entails_state (M : CosModel Entity State Time)
-    (lt : Event Time → Event Time → Prop) (v : Verb) (y x : Entity)
-    (w : Event Time) (h : againPresup lt (M.causative v y x) w) :
+theorem againPresup_cause_entails_state (M : CosModel Entity State T)
+    (lt : Event T → Event T → Prop) (v : Verb) (y x : Entity)
+    (w : Event T) (h : againPresup lt (M.causative v y x) w) :
     ∃ w', lt w' w ∧ ∃ e s, M.become s e ∧ M.rootState v x s := by
   obtain ⟨w', hlt, hcaus⟩ := h
   exact ⟨w', hlt, M.causative_entails_resultState v y x w' hcaus⟩
@@ -241,7 +241,7 @@ theorem againPresup_cause_entails_state (M : CosModel Entity State Time)
     change, so even the low/restitutive attachment of *again* carries a change
     entailment — the restitutive reading collapses into the repetitive one
     ("result roots never admit truly restitutive readings"). -/
-theorem result_restitution_entails_change (M : CosModel Entity State Time)
+theorem result_restitution_entails_change (M : CosModel Entity State T)
     (ltS : State → State → Prop) (v : Verb) (x : Entity) (s : State)
     (hres : ∀ s, M.rootState v x s → ∃ e, M.become s e)
     (h : againPresup ltS (M.rootState v x) s) :
@@ -406,16 +406,16 @@ def jogV : Verb := { form := "jog", frames := [], root := jog }
 /-- √crack carries `.result`, so in **any** model its denotation entails the
     result state — the non-cancelable result of [beavers-koontz-garboden-2020]
     (6), derived from crack's signature rather than stipulated. -/
-theorem crack_denote_entails_result {Entity State Time : Type*} [LinearOrder Time]
-    (M : Verb.CosModel Entity State Time) (y x : Entity) (e : Event Time)
+theorem crack_denote_entails_result {Entity State T : Type*} [LinearOrder T]
+    (M : Verb.CosModel Entity State T) (y x : Entity) (e : Event T)
     (h : M.denote crackV y x e) : ∃ e' s, M.become s e' ∧ M.rootState crackV x s :=
   M.denote_result_entails_resultState crackV y x e (by decide) h
 
 /-- √jog has no `.result` (nor `.cause`), so its denotation is the bare manner
     core — no `become`, no result state. Only the change-of-state root entails a
     result. -/
-theorem jog_denote_eq_manner {Entity State Time : Type*} [LinearOrder Time]
-    (M : Verb.CosModel Entity State Time) (y x : Entity) :
+theorem jog_denote_eq_manner {Entity State T : Type*} [LinearOrder T]
+    (M : Verb.CosModel Entity State T) (y x : Entity) :
     M.denote jogV y x = M.manner jogV := by
   unfold Verb.CosModel.denote
   rw [if_neg (by decide), if_neg (by decide)]
@@ -443,9 +443,9 @@ theorem jog_template_no_resultState : ¬ jog.template.HasResultState := by decid
 /-- √crack's template embeds a result state, so by `denote_result_from_template`
     its denotation entails the result state in any model — the template diagnostic
     and the denotational entailment are *one* fact through `crack`'s `kinds`. -/
-theorem crack_template_forces_denote_result {Entity State Time : Type*}
-    [LinearOrder Time] (M : Verb.CosModel Entity State Time) (y x : Entity)
-    (e : Event Time) (h : M.denote crackV y x e) :
+theorem crack_template_forces_denote_result {Entity State T : Type*}
+    [LinearOrder T] (M : Verb.CosModel Entity State T) (y x : Entity)
+    (e : Event T) (h : M.denote crackV y x e) :
     ∃ e' s, M.become s e' ∧ M.rootState crackV x s :=
   M.denote_result_from_template crackV crack_template_hasResultState y x e h
 

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -139,31 +139,31 @@ theorem tier_eq_multi_iff (c : OutcomeClass) :
 /-! ### States, boundaries, and roots -/
 
 /-- An object's state over time: a lifespan point for each time (53). -/
-abbrev StateFunction (Entity State Time : Type*) := Time → Entity → State
+abbrev StateFunction (Entity State T : Type*) := T → Entity → State
 
-variable {Entity State Time : Type*} [LinearOrder Time]
+variable {Entity State T : Type*} [LinearOrder T]
 
 /-- `res(e)(x)`, the object's state at the right boundary of `e` (64). -/
-def resState (k : StateFunction Entity State Time) (e : Event Time) (x : Entity) : State :=
+def resState (k : StateFunction Entity State T) (e : Event T) (x : Entity) : State :=
   k (Event.τ e).snd x
 
 /-- `pre(e)(x)`, the object's state at the left boundary of `e` (65). -/
-def preState (k : StateFunction Entity State Time) (e : Event Time) (x : Entity) : State :=
+def preState (k : StateFunction Entity State T) (e : Event T) (x : Entity) : State :=
   k (Event.τ e).fst x
 
 /-- A verb root as the prefixes see it: its base predicate with the lexical outcome set of
 states at the right boundary and the contextual threshold set of states at the left
 boundary ((56), (60)). -/
-structure VerbOutcomes (Entity State Time : Type*) [LinearOrder Time] where
+structure VerbOutcomes (Entity State T : Type*) [LinearOrder T] where
   /-- The base predicate `P(e)(x)`. -/
-  verb : EventRel Time Entity
+  verb : EventRel T Entity
   /-- The outcome set `O`. -/
   outcomes : Set State
   /-- The threshold set `T`. -/
   thresholds : Set State
 
 /-- The cardinality tier of a root's outcome set. -/
-noncomputable def VerbOutcomes.cardinality (vro : VerbOutcomes Entity State Time) :
+noncomputable def VerbOutcomes.cardinality (vro : VerbOutcomes Entity State T) :
     OutcomeCardinality :=
   OutcomeCardinality.ofSet vro.outcomes
 
@@ -173,9 +173,9 @@ noncomputable def VerbOutcomes.cardinality (vro : VerbOutcomes Entity State Time
 event starts from, a multi-membered outcome set, and the *un-* event returning the object
 to the base event's initial state. The vacuous `∃ Q. Q(e)(x)` of the assertion is
 dropped. -/
-def unSem (k : StateFunction Entity State Time) (vro : VerbOutcomes Entity State Time)
-    (e : Event Time) (x : Entity) : Prop :=
-  ∃ e' : Event Time,
+def unSem (k : StateFunction Entity State T) (vro : VerbOutcomes Entity State T)
+    (e : Event T) (x : Entity) : Prop :=
+  ∃ e' : Event T,
     vro.verb e' x ∧
     (Event.τ e').precedes (Event.τ e) ∧
     resState k e' x = preState k e x ∧
@@ -186,9 +186,9 @@ def unSem (k : StateFunction Entity State Time) (vro : VerbOutcomes Entity State
 result state is an admissible start state — the base action does not leave the object where
 its result cannot be restored — and the base predicate holding of the *re-* event. No
 cardinality demand is placed on the outcome set. -/
-def reSem (k : StateFunction Entity State Time) (vro : VerbOutcomes Entity State Time)
-    (e : Event Time) (x : Entity) : Prop :=
-  (∃ e' : Event Time,
+def reSem (k : StateFunction Entity State T) (vro : VerbOutcomes Entity State T)
+    (e : Event T) (x : Entity) : Prop :=
+  (∃ e' : Event T,
     vro.verb e' x ∧
     (Event.τ e').precedes (Event.τ e) ∧
     resState k e x = resState k e' x ∧
@@ -196,34 +196,34 @@ def reSem (k : StateFunction Entity State Time) (vro : VerbOutcomes Entity State
   vro.verb e x
 
 /-- A root whose outcome set is not multi-membered cannot host *un-* (67). -/
-theorem subsingleton_blocks_un (k : StateFunction Entity State Time)
-    (vro : VerbOutcomes Entity State Time) (h : ¬ vro.outcomes.Nontrivial)
-    (e : Event Time) (x : Entity) : ¬ unSem k vro e x :=
+theorem subsingleton_blocks_un (k : StateFunction Entity State T)
+    (vro : VerbOutcomes Entity State T) (h : ¬ vro.outcomes.Nontrivial)
+    (e : Event T) (x : Entity) : ¬ unSem k vro e x :=
   fun ⟨_, _, _, _, hnt, _⟩ => h hnt
 
-theorem singleton_blocks_un (k : StateFunction Entity State Time)
-    (vro : VerbOutcomes Entity State Time) (s : State) (hs : vro.outcomes = {s})
-    (e : Event Time) (x : Entity) : ¬ unSem k vro e x :=
+theorem singleton_blocks_un (k : StateFunction Entity State T)
+    (vro : VerbOutcomes Entity State T) (s : State) (hs : vro.outcomes = {s})
+    (e : Event T) (x : Entity) : ¬ unSem k vro e x :=
   subsingleton_blocks_un k vro
     (by rw [Set.not_nontrivial_iff, hs]; exact Set.subsingleton_singleton) e x
 
-theorem empty_blocks_un (k : StateFunction Entity State Time)
-    (vro : VerbOutcomes Entity State Time) (hs : vro.outcomes = ∅)
-    (e : Event Time) (x : Entity) : ¬ unSem k vro e x :=
+theorem empty_blocks_un (k : StateFunction Entity State T)
+    (vro : VerbOutcomes Entity State T) (hs : vro.outcomes = ∅)
+    (e : Event T) (x : Entity) : ¬ unSem k vro e x :=
   subsingleton_blocks_un k vro
     (by rw [Set.not_nontrivial_iff, hs]; exact Set.subsingleton_empty) e x
 
 /-- Hosting *un-* forces a root's outcome set into the multi-membered tier. -/
-theorem un_requires_multi (k : StateFunction Entity State Time)
-    (vro : VerbOutcomes Entity State Time) (e : Event Time) (x : Entity)
+theorem un_requires_multi (k : StateFunction Entity State T)
+    (vro : VerbOutcomes Entity State T) (e : Event T) (x : Entity)
     (h : unSem k vro e x) : vro.cardinality = .multi :=
   let ⟨_, _, _, _, hnt, _⟩ := h
   OutcomeCardinality.ofSet_eq_multi hnt
 
 /-- A base action whose result is never an admissible start state blocks *re-* (72). -/
-theorem not_reSem_of_outcome_not_threshold (k : StateFunction Entity State Time)
-    (vro : VerbOutcomes Entity State Time) (x : Entity)
-    (h : ∀ e', vro.verb e' x → resState k e' x ∉ vro.thresholds) (e : Event Time) :
+theorem not_reSem_of_outcome_not_threshold (k : StateFunction Entity State T)
+    (vro : VerbOutcomes Entity State T) (x : Entity)
+    (h : ∀ e', vro.verb e' x → resState k e' x ∉ vro.thresholds) (e : Event T) :
     ¬ reSem k vro e x :=
   fun ⟨⟨e', hv, _, _, hT⟩, _⟩ => h e' hv hT
 

--- a/Linglib/Studies/BonehDoron2013.lean
+++ b/Linglib/Studies/BonehDoron2013.lean
@@ -142,26 +142,26 @@ construction. -/
 
 /-- (19b): the retrospective — some reference interval satisfying the
 description lies wholly before the perspective interval. -/
-def retro {W Time : Type*} [LinearOrder Time] (A : IntervalPred W Time) :
-    IntervalPred W Time :=
+def retro {W T : Type*} [LinearOrder T] (A : IntervalPred W T) :
+    IntervalPred W T :=
   fun w p => ∃ i, A w i ∧ i.isBefore p
 
 /-- (18): *used to* — the retrospective over the imperfective. -/
-def usedToOp {W Time : Type*} [LinearOrder Time] (P : W → Event Time → Prop) :
-    IntervalPred W Time :=
+def usedToOp {W T : Type*} [LinearOrder T] (P : W → Event T → Prop) :
+    IntervalPred W T :=
   retro (IMPF P)
 
 /-- (34a): the perfect — the perspective is a final subinterval of the
 reference interval ([pancheva-2003]'s PTS, from the substrate). -/
-def perfectOp {W Time : Type*} [LinearOrder Time] (A : IntervalPred W Time) :
-    IntervalPred W Time :=
+def perfectOp {W T : Type*} [LinearOrder T] (A : IntervalPred W T) :
+    IntervalPred W T :=
   fun w p => ∃ i, A w i ∧ p.finalSubinterval i
 
 /-- (32)–(34): one reference interval serves the retrospective and the
 perfect at once only for a degenerate instantaneous perspective. The two
 form the Horn scale behind the retrospectivity implicature (31)–(33). -/
-theorem retro_perfect_forces_point {Time : Type*} [LinearOrder Time]
-    {i p : NonemptyInterval Time} (hb : i.isBefore p) (hf : p.finalSubinterval i) :
+theorem retro_perfect_forces_point {T : Type*} [LinearOrder T]
+    {i p : NonemptyInterval T} (hb : i.isBefore p) (hf : p.finalSubinterval i) :
     p.IsPoint :=
   le_antisymm p.fst_le_snd (hf.2.trans_le hb)
 
@@ -169,9 +169,9 @@ theorem retro_perfect_forces_point {Time : Type*} [LinearOrder Time]
 Still do."): (19a) bounds only the reference interval, so a state whose
 runtime strictly contains a pre-perspective reference interval satisfies
 *used to* however far the state runs — through the perspective included. -/
-theorem usedTo_of_persisting_state {W Time : Type*} [LinearOrder Time]
-    {P : W → Event Time → Prop} {w : W} {e : Event Time} (hP : P w e)
-    {i p : NonemptyInterval Time} (hie : i < e.τ) (hip : i.isBefore p) :
+theorem usedTo_of_persisting_state {W T : Type*} [LinearOrder T]
+    {P : W → Event T → Prop} {w : W} {e : Event T} (hP : P w e)
+    {i p : NonemptyInterval T} (hie : i < e.τ) (hip : i.isBefore p) :
     usedToOp P w p :=
   ⟨i, ⟨e, hie, hP⟩, hip⟩
 

--- a/Linglib/Studies/CarianiSantorioWellwood2024.lean
+++ b/Linglib/Studies/CarianiSantorioWellwood2024.lean
@@ -82,11 +82,11 @@ comparison of the two states' measures whenever each holder has a unique state o
 kind — the compositional half of the claim that nominal *confidence* and adjectival *confident*
 are interchangeable in the comparative. -/
 theorem confidence_comparative_reduces
-    {E : Type*} {Time : Type*} [LinearOrder Time]
-    {frame : ArgumentStructure.ThematicFrame E Time}
-    {P : Event Time → Prop}
-    {μ : Event Time → ℚ}
-    {a b : E} {sa sb : Event Time}
+    {E : Type*} {T : Type*} [LinearOrder T]
+    {frame : ArgumentStructure.ThematicFrame E T}
+    {P : Event T → Prop}
+    {μ : Event T → ℚ}
+    {a b : E} {sa sb : Event T}
     (ha : frame.holder a sa ∧ P sa)
     (ha_unique : ∀ s, frame.holder a s → P s → s = sa)
     (hb : frame.holder b sb ∧ P sb)

--- a/Linglib/Studies/Champollion2017.lean
+++ b/Linglib/Studies/Champollion2017.lean
@@ -49,15 +49,15 @@ open Aspect.Stratified
 Whether a verb distributes over the atomic fillers of a thematic role is a property of its event
 denotation, not a feature it carries. -/
 
-variable {Entity State Time : Type*} [LinearOrder Time] [PartialOrder Entity]
-  [SemilatticeSup (Event Time)]
+variable {Entity State T : Type*} [LinearOrder T] [PartialOrder Entity]
+  [SemilatticeSup (Event T)]
 
 /-- A verb **stratifies over** the atomic fillers of role `R`: for every
     argument assignment `(y, x)`, the verb's `CosModel` denotation has
     relational Stratified Distributive Reference along `R`
     (`RelationalDistributiveReference`). -/
-def StratifiesOver (v : Verb) (M : CosModel Entity State Time)
-    (R : Entity → Event Time → Prop) : Prop :=
+def StratifiesOver (v : Verb) (M : CosModel Entity State T)
+    (R : Entity → Event T → Prop) : Prop :=
   ∀ y x, RelationalDistributiveReferenceUniv R (M.denote v y x)
 
 end Verb
@@ -92,14 +92,14 @@ The book's per-verb distributivity facts are lexical meaning postulates in Hoeks
 theorems; they are stated here over the Fragment verbs' denotations. -/
 
 section Distributivity
-variable {Entity State Time : Type*} [LinearOrder Time] [PartialOrder Entity]
-  [SemilatticeSup (Event Time)]
+variable {Entity State T : Type*} [LinearOrder T] [PartialOrder Entity]
+  [SemilatticeSup (Event T)]
 
 /-- The verb-distributivity postulates of [champollion-2017] Ch 4, over the Fragment verbs'
 `CosModel` denotations and the model's agent and theme roles: *see* distributes on both, *kill*
 on its theme only — a member of the posse need not have killed anyone — and *meet* on neither. -/
-structure ChampollionPostulates (M : Verb.CosModel Entity State Time)
-    (agentRole themeRole : Entity → Event Time → Prop) : Prop where
+structure ChampollionPostulates (M : Verb.CosModel Entity State T)
+    (agentRole themeRole : Entity → Event T → Prop) : Prop where
   see_distributes_agent : see.toVerb.StratifiesOver M agentRole
   see_distributes_theme : see.toVerb.StratifiesOver M themeRole
   kill_distributes_theme : kill.toVerb.StratifiesOver M themeRole
@@ -116,11 +116,11 @@ end Distributivity
     *is* the existence of such a cover — his Theorem 14
     (`Cover.algClosure_iff_exists_finCover`) at the runtime dimension. The
     genuine consumer of `Semantics/Plurality/Cover.lean`. -/
-theorem subintervalReference_iff_cover {Time : Type*} [LinearOrder Time]
-    [SemilatticeSup (Event Time)] [DecidableEq (Event Time)]
-    {P : Event Time → Prop} {e : Event Time} :
+theorem subintervalReference_iff_cover {T : Type*} [LinearOrder T]
+    [SemilatticeSup (Event T)] [DecidableEq (Event T)]
+    {P : Event T → Prop} {e : Event T} :
     SubintervalReference P e ↔
-      ∃ (parts : Finset (Event Time)) (hne : parts.Nonempty),
+      ∃ (parts : Finset (Event T)) (hne : parts.Nonempty),
         IsFinCover parts hne e ∧ ∀ p ∈ parts, P p ∧ p.runtime < e.runtime := by
   unfold SubintervalReference Reference SubintervalGranularity
   exact algClosure_iff_exists_finCover

--- a/Linglib/Studies/Condoravdi2002.lean
+++ b/Linglib/Studies/Condoravdi2002.lean
@@ -57,22 +57,22 @@ the forward-expansion variants are Condoravdi's modal apparatus (evaluation
 expanded to the half-open `[t, _)`), consumed by the modal operators below. -/
 
 section AtRelation
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- Eventive AT, `AT(t, w, P)` for eventive `P`: an event of `P` whose runtime
     is included in `t`. Definitionally Klein's perfective `Aspect.PRFV`;
     Condoravdi writes the conjuncts predicate-first, `PRFV` relation-first. -/
-def atEvent (P : W → Event Time → Prop) : IntervalPred W Time := PRFV P
+def atEvent (P : W → Event T → Prop) : IntervalPred W T := PRFV P
 
 /-- Stative AT, `AT(t, w, P)` for stative `P`: an event of `P` whose runtime
     merely overlaps `t`. Weaker than `Aspect.IMPF` (proper inclusion), so it
     has no Aspect counterpart and stays a local definition. -/
-def atState (P : W → Event Time → Prop) : IntervalPred W Time :=
-  fun w t => ∃ e : Event Time, e.τ.overlaps t ∧ P w e
+def atState (P : W → Event T → Prop) : IntervalPred W T :=
+  fun w t => ∃ e : Event T, e.τ.overlaps t ∧ P w e
 
 /-- The AT relation, dispatching on eventuality sort. The paper's third case
     (properties of times) is vacuous here: the event predicate is eventuality-valued. -/
-def at' (sort : Dynamicity) (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+def at' (sort : Dynamicity) (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     Prop :=
   match sort with
   | .dynamic => atEvent P w t
@@ -80,20 +80,20 @@ def at' (sort : Dynamicity) (P : W → Event Time → Prop) (w : W) (t : Nonempt
 
 /-- Eventive instantiation is stronger than stative: an event included in the
     interval certainly overlaps it. -/
-theorem atState_of_atEvent (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time)
+theorem atState_of_atEvent (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T)
     (h : atEvent P w t) : atState P w t :=
   let ⟨e, hSub, hP⟩ := h
   ⟨e, NonemptyInterval.overlaps_of_le hSub, hP⟩
 
 /-- `atEvent` is monotone in the reference interval. -/
-theorem atEvent_mono {t₁ t₂ : NonemptyInterval Time} (P : W → Event Time → Prop) (w : W)
+theorem atEvent_mono {t₁ t₂ : NonemptyInterval T} (P : W → Event T → Prop) (w : W)
     (hSub : t₁ ≤ t₂) (h : atEvent P w t₁) : atEvent P w t₂ :=
   let ⟨e, heSub, hP⟩ := h
   ⟨e, le_trans heSub hSub, hP⟩
 
 /-- `atState` is monotone in the reference interval: overlap with a subinterval
     entails overlap with the containing interval. -/
-theorem atState_mono {t₁ t₂ : NonemptyInterval Time} (P : W → Event Time → Prop) (w : W)
+theorem atState_mono {t₁ t₂ : NonemptyInterval T} (P : W → Event T → Prop) (w : W)
     (hSub : t₁ ≤ t₂) (h : atState P w t₁) : atState P w t₂ :=
   let ⟨e, hOv, hP⟩ := h
   ⟨e, ⟨le_trans hOv.1 (NonemptyInterval.le_def.mp hSub).2,
@@ -108,16 +108,16 @@ constraints are expressed directly: for events the runtime starts at or after
 
 /-- Event instantiated in the future of `t` — `AT([t, _), w, P)` for eventive
     `P`: the event starts at or after `t`. -/
-def atEventForward (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
-  ∃ e : Event Time, t ≤ e.τ.fst ∧ P w e
+def atEventForward (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
+  ∃ e : Event T, t ≤ e.τ.fst ∧ P w e
 
 /-- State instantiated through `t` — `AT([t, _), w, P)` for stative `P`: the
     state persists at or past `t`. -/
-def atStateForward (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
-  ∃ e : Event Time, t ≤ e.τ.snd ∧ P w e
+def atStateForward (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
+  ∃ e : Event T, t ≤ e.τ.snd ∧ P w e
 
 /-- Forward AT, dispatching on eventuality sort. -/
-def atForward (sort : Dynamicity) (P : W → Event Time → Prop) (w : W) (t : Time) :
+def atForward (sort : Dynamicity) (P : W → Event T → Prop) (w : W) (t : T) :
     Prop :=
   match sort with
   | .dynamic => atEventForward P w t
@@ -125,19 +125,19 @@ def atForward (sort : Dynamicity) (P : W → Event Time → Prop) (w : W) (t : T
 
 /-- Forward stative is weaker than forward eventive: if the event starts at or
     after `t`, its finish is also at or after `t`. -/
-theorem atStateForward_of_atEventForward (P : W → Event Time → Prop) (w : W)
-    (t : Time) (h : atEventForward P w t) : atStateForward P w t :=
+theorem atStateForward_of_atEventForward (P : W → Event T → Prop) (w : W)
+    (t : T) (h : atEventForward P w t) : atStateForward P w t :=
   let ⟨e, hStart, hP⟩ := h
   ⟨e, le_trans hStart e.τ.fst_le_snd, hP⟩
 
 /-- `atEvent` at a point `[t, t]` implies `atEventForward` at `t`. -/
-theorem atEventForward_of_atEvent_point (P : W → Event Time → Prop) (w : W) (t : Time)
+theorem atEventForward_of_atEvent_point (P : W → Event T → Prop) (w : W) (t : T)
     (h : atEvent P w (NonemptyInterval.pure t)) : atEventForward P w t :=
   let ⟨e, hSub, hP⟩ := h
   ⟨e, hSub.1, hP⟩
 
 /-- `atState` at a point `[t, t]` implies `atStateForward` at `t`. -/
-theorem atStateForward_of_atState_point (P : W → Event Time → Prop) (w : W) (t : Time)
+theorem atStateForward_of_atState_point (P : W → Event T → Prop) (w : W) (t : T)
     (h : atState P w (NonemptyInterval.pure t)) : atStateForward P w t :=
   let ⟨e, hOv, hP⟩ := h
   ⟨e, hOv.2, hP⟩
@@ -147,19 +147,19 @@ end AtRelation
 /-! ## Operators -/
 
 section Operators
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- Present tense: instantiates a property at the utterance time. The
     temporal anchor is a single point. -/
-def pres (sort : Dynamicity) (P : W → Event Time → Prop) (t : Time)
+def pres (sort : Dynamicity) (P : W → Event T → Prop) (t : T)
     (w : W) : Prop :=
   at' sort P w (NonemptyInterval.pure t)
 
 /-- Perfect: shifts evaluation to a prior time. There is some `t' < t` at
     which the property holds. -/
-def perf (sort : Dynamicity) (P : W → Event Time → Prop) (w : W)
-    (t : Time) : Prop :=
-  ∃ t' : Time, t' < t ∧ at' sort P w (NonemptyInterval.pure t')
+def perf (sort : Dynamicity) (P : W → Event T → Prop) (w : W)
+    (t : T) : Prop :=
+  ∃ t' : T, t' < t ∧ at' sort P w (NonemptyInterval.pure t')
 
 /-! ### Modal cores vs. prospective modals
 
@@ -173,35 +173,35 @@ prospective operator; `may_of_mayCore_dynamic` relates the two. -/
 
 /-- Modal possibility core: ∃ w' ∈ MB(w,t), the prejacent holds at
     the point `t` in `w'`. No forward expansion. -/
-def mayCore (MB : W → Time → Set W) (sort : Dynamicity)
-    (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
+def mayCore (MB : W → T → Set W) (sort : Dynamicity)
+    (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
   ∃ w' ∈ MB w t, at' sort P w' (NonemptyInterval.pure t)
 
 /-- MAY/MIGHT: existential quantification over the modal base, with
     forward temporal expansion. The English modal lexicalizes the
     prospective choice ([condoravdi-2002]). -/
-def may (MB : W → Time → Set W) (sort : Dynamicity)
-    (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
+def may (MB : W → T → Set W) (sort : Dynamicity)
+    (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
   ∃ w' ∈ MB w t, atForward sort P w' t
 
 /-- Modal necessity core: ∀ w' ∈ MB(w,t), the prejacent holds at
     the point `t` in `w'`. No forward expansion. -/
-def wollCore (MB : W → Time → Set W) (sort : Dynamicity)
-    (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
+def wollCore (MB : W → T → Set W) (sort : Dynamicity)
+    (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
   ∀ w' ∈ MB w t, at' sort P w' (NonemptyInterval.pure t)
 
 /-- WOLL: universal quantification over the modal base, with forward
     temporal expansion. The untensed modal underlying *will* / *would*. -/
-def woll (MB : W → Time → Set W) (sort : Dynamicity)
-    (P : W → Event Time → Prop) (w : W) (t : Time) : Prop :=
+def woll (MB : W → T → Set W) (sort : Dynamicity)
+    (P : W → Event T → Prop) (w : W) (t : T) : Prop :=
   ∀ w' ∈ MB w t, atForward sort P w' t
 
 /-- For dynamic predicates, `mayCore` implies `may`: forward expansion
     is a weakening when the prejacent is checked at a point. The
     pointwise instantiation gives an event whose start lies at or
     after `t`, which is exactly what `atEventForward` requires. -/
-theorem may_of_mayCore_dynamic (MB : W → Time → Set W)
-    (P : W → Event Time → Prop) (w : W) (t : Time)
+theorem may_of_mayCore_dynamic (MB : W → T → Set W)
+    (P : W → Event T → Prop) (w : W) (t : T)
     (h : mayCore MB .dynamic P w t) : may MB .dynamic P w t := by
   obtain ⟨w', hMem, hAt⟩ := h
   refine ⟨w', hMem, ?_⟩
@@ -209,8 +209,8 @@ theorem may_of_mayCore_dynamic (MB : W → Time → Set W)
 
 /-- For stative predicates, `mayCore` implies `may`: pointwise state
     overlap entails forward state persistence at the point. -/
-theorem may_of_mayCore_stative (MB : W → Time → Set W)
-    (P : W → Event Time → Prop) (w : W) (t : Time)
+theorem may_of_mayCore_stative (MB : W → T → Set W)
+    (P : W → Event T → Prop) (w : W) (t : T)
     (h : mayCore MB .stative P w t) : may MB .stative P w t := by
   obtain ⟨w', hMem, hAt⟩ := h
   refine ⟨w', hMem, ?_⟩
@@ -226,8 +226,8 @@ counterfactual modality. The trivial single-operator examples
 /-- "He may have won" — *epistemic* reading. The modal scopes over the
     perfect (PRES > MAY > PERF). Modal base evaluated at `t`; the
     perfect back-shifts inside the modal's scope. -/
-def mayEpistemic (MB : W → Time → Set W) (P : W → Event Time → Prop)
-    (t : Time) (w : W) : Prop :=
+def mayEpistemic (MB : W → T → Set W) (P : W → Event T → Prop)
+    (t : T) (w : W) : Prop :=
   ∃ w' ∈ MB w t, perf .dynamic P w' t
 
 /-- "He might have won" — *counterfactual* reading. The perfect scopes
@@ -235,9 +235,9 @@ def mayEpistemic (MB : W → Time → Set W) (P : W → Event Time → Prop)
     base's evaluation point to a past `t'`; the modal then quantifies
     over worlds compatible with the past, with the property in
     `[t', _)`. -/
-def mightCounterfactual (MB : W → Time → Set W) (P : W → Event Time → Prop)
-    (t : Time) (w : W) : Prop :=
-  ∃ t' : Time, t' < t ∧ may MB .dynamic P w t'
+def mightCounterfactual (MB : W → T → Set W) (P : W → Event T → Prop)
+    (t : T) (w : W) : Prop :=
+  ∃ t' : T, t' < t ∧ may MB .dynamic P w t'
 
 end Operators
 
@@ -277,13 +277,13 @@ def ModalReading.orientation : ModalReading → TemporalOrientation
 /-! ## Bridge to Klein's viewpoint operators -/
 
 section KleinBridge
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- Condoravdi's eventive `perf` entails Klein's `perfSimple`: a prior
     point of instantiation gives a degenerate PTS `[t', t']`
     right-bounded at `t`. -/
 theorem perf_eventive_implies_perfSimple
-    (P : W → Event Time → Prop) (w : W) (t : Time)
+    (P : W → Event T → Prop) (w : W) (t : T)
     (h : perf .dynamic P w t) : perfSimple P ⟨w, t⟩ := by
   obtain ⟨t', hlt, e, hSub, hP⟩ := h
   exact ⟨⟨⟨t', t⟩, le_of_lt hlt⟩, rfl, e,
@@ -292,7 +292,7 @@ theorem perf_eventive_implies_perfSimple
 
 /-- [klein-1994]'s imperfective entails Condoravdi's stative AT: proper
     inclusion of the reference interval in the event runtime implies overlap. -/
-theorem atState_of_impf (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time)
+theorem atState_of_impf (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T)
     (h : IMPF P w t) : atState P w t :=
   let ⟨e, hPSub, hP⟩ := h
   have hOv : e.τ.overlaps t :=
@@ -315,17 +315,17 @@ modality expressed:
   not settled, so a metaphysical base is available. -/
 
 section ScopeCorrelation
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 /-- When MAY scopes over PERF, the property under the modal is *back-
     shifted past*. If this property is settled in the common ground (as
     past properties are), then a metaphysical modal base cannot satisfy
     diversity — restricting MODAL > PERF to epistemic modality. -/
 theorem modal_over_perf_blocks_metaphysical
-    (history : HistoricalAlternatives W Time)
-    (MB : W → Time → Set W)
-    (cg : Set W) (now : Time)
-    (P : W → Event Time → Prop)
+    (history : HistoricalAlternatives W T)
+    (MB : W → T → Set W)
+    (cg : Set W) (now : T)
+    (P : W → Event T → Prop)
     (hMB : ∀ w ∈ cg, ∀ w' ∈ MB w now, histEquiv history now w w')
     (hSettled : settled history cg now (λ w => perf .dynamic P w now)) :
     ¬ diverse MB cg now (λ w => perf .dynamic P w now) :=
@@ -337,9 +337,9 @@ theorem modal_over_perf_blocks_metaphysical
     base wider. This is the structural source of the counterfactual
     reading's "could have been otherwise" force. -/
 theorem counterfactual_widens_domain
-    (history : HistoricalAlternatives W Time)
+    (history : HistoricalAlternatives W T)
     (hBC : history.backwardsClosed) (w : W)
-    {t' now : Time} (hle : t' ≤ now) :
+    {t' now : T} (hle : t' ≤ now) :
     metaphysicalBase history w now ⊆ metaphysicalBase history w t' :=
   metaphysicalBase_antitone hBC w hle
 
@@ -355,16 +355,16 @@ period intersects the temporal region the modal projects. The eight
 `le_refl` rather than a lookup table. -/
 
 section Adverbs
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- "Yesterday": strictly before the reference time. -/
-def yesterday (now : Time) : Set Time := {t | t < now}
+def yesterday (now : T) : Set T := {t | t < now}
 
 /-- "Now": the reference time itself. -/
-def nowAdv (now : Time) : Set Time := {now}
+def nowAdv (now : T) : Set T := {now}
 
 /-- "Tomorrow": strictly after the reference time. -/
-def tomorrow (now : Time) : Set Time := {t | now < t}
+def tomorrow (now : T) : Set T := {t | now < t}
 
 /-- The temporal region in which a modal evaluates its scope, read off
     the AT relation:
@@ -382,7 +382,7 @@ def tomorrow (now : Time) : Set Time := {t | now < t}
     table-style "now is incompatible with eventive future" prediction
     of the original paper is a pragmatic event-duration fact that
     `compatible` does not formally exclude. -/
-def projectedRegion (orient : TemporalOrientation) (now : Time) : Set Time :=
+def projectedRegion (orient : TemporalOrientation) (now : T) : Set T :=
   match orient with
   | .future  => {t | now ≤ t}
   | .present => {now}
@@ -390,24 +390,24 @@ def projectedRegion (orient : TemporalOrientation) (now : Time) : Set Time :=
 
 /-- Compatibility: the adverb's selected period overlaps the modal's
     projected region. -/
-def compatible (period : Time → Set Time) (reading : ModalReading)
-    (now : Time) : Prop :=
+def compatible (period : T → Set T) (reading : ModalReading)
+    (now : T) : Prop :=
   ∃ t, t ∈ period now ∧ t ∈ projectedRegion reading.orientation now
 
 -- ── Modals for the present (future orientation) ──
 
 /-- "He may get sick tomorrow." Future-oriented modal accepts a future
     adverb (witnessed via `NoMaxOrder`). -/
-theorem tomorrow_present_compat [NoMaxOrder Time] (now : Time) :
-    compatible (tomorrow (Time := Time)) .present now := by
+theorem tomorrow_present_compat [NoMaxOrder T] (now : T) :
+    compatible (tomorrow (T := T)) .present now := by
   obtain ⟨t, ht⟩ := exists_gt now
   exact ⟨t, ht, le_of_lt ht⟩
 
 /-- "*He may get sick yesterday." Future-oriented modal rejects a past
     adverb: any witness would satisfy `t < now ∧ now ≤ t`,
     contradicting `lt_irrefl`. -/
-theorem yesterday_present_incompat (now : Time) :
-    ¬ compatible (yesterday (Time := Time)) .present now := by
+theorem yesterday_present_incompat (now : T) :
+    ¬ compatible (yesterday (T := T)) .present now := by
   rintro ⟨t, ht1, ht2⟩
   exact absurd (lt_of_lt_of_le ht1 ht2) (lt_irrefl _)
 
@@ -415,24 +415,24 @@ theorem yesterday_present_incompat (now : Time) :
     with `[now, ∞)` via `le_refl`. The eventive variant ("??He may get
     sick now") is marginal in the paper for pragmatic event-duration
     reasons; see the `projectedRegion` docstring. -/
-theorem now_present_compat (now : Time) :
-    compatible (nowAdv (Time := Time)) .present now :=
+theorem now_present_compat (now : T) :
+    compatible (nowAdv (T := T)) .present now :=
   ⟨now, rfl, le_refl now⟩
 
 -- ── Modals for the past (past orientation, epistemic reading) ──
 
 /-- "He may have gotten sick yesterday." Past-oriented modal accepts a
     past adverb (witnessed via `NoMinOrder`). -/
-theorem yesterday_epistemic_compat [NoMinOrder Time] (now : Time) :
-    compatible (yesterday (Time := Time)) .epistemic now := by
+theorem yesterday_epistemic_compat [NoMinOrder T] (now : T) :
+    compatible (yesterday (T := T)) .epistemic now := by
   obtain ⟨t, ht⟩ := exists_lt now
   exact ⟨t, ht, ht⟩
 
 /-- "*He may have gotten sick tomorrow." Past-oriented modal rejects a
     future adverb: `now < t ∧ t < now` contradicts `lt_irrefl` via
     `lt_trans`. -/
-theorem tomorrow_epistemic_incompat (now : Time) :
-    ¬ compatible (tomorrow (Time := Time)) .epistemic now := by
+theorem tomorrow_epistemic_incompat (now : T) :
+    ¬ compatible (tomorrow (T := T)) .epistemic now := by
   rintro ⟨t, ht1, ht2⟩
   exact absurd (lt_trans ht2 ht1) (lt_irrefl _)
 

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -77,15 +77,15 @@ inductive AgentivityFeature where
     entity–event pairs for each of Cruse's four sub-features.
 
     Each field `hasF x e` means "entity x exhibits feature F in event e". -/
-structure AgentivityProfile (Entity Time : Type*) [LinearOrder Time] where
+structure AgentivityProfile (Entity T : Type*) [LinearOrder T] where
   /-- Does x exhibit an act of will in e? -/
-  hasVolitive : Entity → Event Time → Prop
+  hasVolitive : Entity → Event T → Prop
   /-- Does x exert force (from position/motion/energy) in e? -/
-  hasEffective : Entity → Event Time → Prop
+  hasEffective : Entity → Event T → Prop
   /-- Does x initiate action by command/instruction in e? -/
-  hasInitiative : Entity → Event Time → Prop
+  hasInitiative : Entity → Event T → Prop
   /-- Does x use own body's internal energy in e? -/
-  hasAgentive : Entity → Event Time → Prop
+  hasAgentive : Entity → Event T → Prop
 
 -- ════════════════════════════════════════════════════
 -- § 2. The Do-Test ([cruse-1973] pp.13–14)
@@ -95,15 +95,15 @@ structure AgentivityProfile (Entity Time : Type*) [LinearOrder Time] where
     iff at least one agentivity sub-feature is present.
 
     This is the disjunction of all four features. -/
-def passesDoTest {Entity Time : Type*} [LinearOrder Time]
-    (x : Entity) (e : Event Time)
-    (profile : AgentivityProfile Entity Time) : Prop :=
+def passesDoTest {Entity T : Type*} [LinearOrder T]
+    (x : Entity) (e : Event T)
+    (profile : AgentivityProfile Entity T) : Prop :=
   profile.hasVolitive x e ∨ profile.hasEffective x e ∨
   profile.hasInitiative x e ∨ profile.hasAgentive x e
 
 /-- The do-test is equivalent to the 4-way disjunction (definitional). -/
-theorem passesDo_iff_or {Entity Time : Type*} [LinearOrder Time]
-    (x : Entity) (e : Event Time) (p : AgentivityProfile Entity Time) :
+theorem passesDo_iff_or {Entity T : Type*} [LinearOrder T]
+    (x : Entity) (e : Event T) (p : AgentivityProfile Entity T) :
     passesDoTest x e p ↔
     (p.hasVolitive x e ∨ p.hasEffective x e ∨
      p.hasInitiative x e ∨ p.hasAgentive x e) :=
@@ -124,23 +124,23 @@ theorem passesDo_iff_or {Entity Time : Type*} [LinearOrder Time]
       (command present, prisoners do the marching)
     - `agentive_without_initiative`: "John ran"
       (own energy, no command to another) -/
-class CruseIndependence (Entity Time : Type*) [LinearOrder Time]
-    (profile : AgentivityProfile Entity Time) where
+class CruseIndependence (Entity T : Type*) [LinearOrder T]
+    (profile : AgentivityProfile Entity T) where
   /-- Volitive without agentive: "John deliberately drifted downstream" -/
   volitive_without_agentive :
-    ∃ (x : Entity) (e : Event Time),
+    ∃ (x : Entity) (e : Event T),
       profile.hasVolitive x e ∧ ¬ profile.hasAgentive x e
   /-- Effective without volitive: "The bullet smashed the collar-bone" -/
   effective_without_volitive :
-    ∃ (x : Entity) (e : Event Time),
+    ∃ (x : Entity) (e : Event T),
       profile.hasEffective x e ∧ ¬ profile.hasVolitive x e
   /-- Initiative without agentive: "The warder marched the prisoners" -/
   initiative_without_agentive_ :
-    ∃ (x : Entity) (e : Event Time),
+    ∃ (x : Entity) (e : Event T),
       profile.hasInitiative x e ∧ ¬ profile.hasAgentive x e
   /-- Agentive without initiative: "John ran" -/
   agentive_without_initiative :
-    ∃ (x : Entity) (e : Event Time),
+    ∃ (x : Entity) (e : Event T),
       profile.hasAgentive x e ∧ ¬ profile.hasInitiative x e
 
 -- ════════════════════════════════════════════════════
@@ -152,11 +152,11 @@ class CruseIndependence (Entity Time : Type*) [LinearOrder Time]
     The Parsonian `agent(x,e)` captures specifically the own-energy
     sub-feature: an agent uses its own body's internal energy source.
     This is strictly narrower than the full do-test. -/
-class AgentAgentiveLink (Entity Time : Type*) [LinearOrder Time]
-    (frame : ThematicFrame Entity Time)
-    (profile : AgentivityProfile Entity Time) where
+class AgentAgentiveLink (Entity T : Type*) [LinearOrder T]
+    (frame : ThematicFrame Entity T)
+    (profile : AgentivityProfile Entity T) where
   /-- Parsons' agent implies Cruse's agentive_ feature. -/
-  agent_implies_agentive : ∀ (x : Entity) (e : Event Time),
+  agent_implies_agentive : ∀ (x : Entity) (e : Event T),
     frame.agent x e → profile.hasAgentive x e
 
 /-- Parsons' agent(x,e) entails passesDoTest(x,e), since agentive_ is
@@ -164,11 +164,11 @@ class AgentAgentiveLink (Entity Time : Type*) [LinearOrder Time]
 
     In any model where agent → hasAgentive, the result follows
     immediately from the fact that agentive_ is the fourth disjunct. -/
-theorem agent_implies_passesDo {Entity Time : Type*} [LinearOrder Time]
-    {frame : ThematicFrame Entity Time}
-    {profile : AgentivityProfile Entity Time}
-    [link : AgentAgentiveLink Entity Time frame profile]
-    (x : Entity) (e : Event Time)
+theorem agent_implies_passesDo {Entity T : Type*} [LinearOrder T]
+    {frame : ThematicFrame Entity T}
+    {profile : AgentivityProfile Entity T}
+    [link : AgentAgentiveLink Entity T frame profile]
+    (x : Entity) (e : Event T)
     (h : frame.agent x e) :
     passesDoTest x e profile := by
   exact Or.inr (Or.inr (Or.inr (link.agent_implies_agentive x e h)))
@@ -180,12 +180,12 @@ theorem agent_implies_passesDo {Entity Time : Type*} [LinearOrder Time]
     `ThematicAxioms` has agent entail agentive_ (from the link) and
     agent entail action (from the axioms). Together these characterize
     the prototypical "own-energy + dynamic" combination. -/
-theorem agent_is_agentive_subfeature {Entity Time : Type*} [LinearOrder Time]
-    {frame : ThematicFrame Entity Time}
-    {profile : AgentivityProfile Entity Time}
-    [link : AgentAgentiveLink Entity Time frame profile]
-    [ax : ThematicAxioms Entity Time frame]
-    (x : Entity) (e : Event Time)
+theorem agent_is_agentive_subfeature {Entity T : Type*} [LinearOrder T]
+    {frame : ThematicFrame Entity T}
+    {profile : AgentivityProfile Entity T}
+    [link : AgentAgentiveLink Entity T frame profile]
+    [ax : ThematicAxioms Entity T frame]
+    (x : Entity) (e : Event T)
     (h : frame.agent x e) :
     profile.hasAgentive x e ∧ e.sort = .dynamic :=
   ⟨link.agent_implies_agentive x e h, ax.agent_selects_action x e h⟩
@@ -251,10 +251,10 @@ theorem coercion_requires_volitive :
 
     The bridge: initiative ↔ {make, force} builders, where the causer
     has initiative and the causee has agentive_. -/
-structure InitiativeCausativeLink (Entity Time : Type*) [LinearOrder Time]
-    (profile : AgentivityProfile Entity Time) where
+structure InitiativeCausativeLink (Entity T : Type*) [LinearOrder T]
+    (profile : AgentivityProfile Entity T) where
   /-- In a causative construction, the causer has initiative. -/
-  causer_has_initiative : ∀ (causer causee : Entity) (e : Event Time),
+  causer_has_initiative : ∀ (causer causee : Entity) (e : Event T),
     profile.hasInitiative causer e → ¬ profile.hasAgentive causer e →
     -- The causee is the one with agentive_ (doing the action)
     profile.hasAgentive causee e
@@ -294,10 +294,10 @@ theorem stative_can_pass_doTest :
     entity is agent of a stative event we get a contradiction — so
     no stative event has a Parsonian agent. The do-test still passes
     for statives via other features (volitive, effective). -/
-theorem agent_selects_action_consistent {Entity Time : Type*} [LinearOrder Time]
-    {frame : ThematicFrame Entity Time}
-    [ax : ThematicAxioms Entity Time frame]
-    (x : Entity) (e : Event Time)
+theorem agent_selects_action_consistent {Entity T : Type*} [LinearOrder T]
+    {frame : ThematicFrame Entity T}
+    [ax : ThematicAxioms Entity T frame]
+    (x : Entity) (e : Event T)
     (hState : e.sort = .stative)
     (hAgent : frame.agent x e) :
     False := by

--- a/Linglib/Studies/Declerck1991.lean
+++ b/Linglib/Studies/Declerck1991.lean
@@ -66,41 +66,41 @@ inductive Orientation where
 /-- A **time of orientation** (TO): a temporal anchor, realized as a
     `NonemptyInterval` so point times (degenerate intervals) and extended
     times-of-situation share one type. -/
-abbrev TO (Time : Type*) [LinearOrder Time] := NonemptyInterval Time
+abbrev TO (T : Type*) [LinearOrder T] := NonemptyInterval T
 
 /-- Construct a point TO from a single time. -/
-abbrev TO.pure {Time : Type*} [LinearOrder Time] (t : Time) : TO Time :=
+abbrev TO.pure {T : Type*} [LinearOrder T] (t : T) : TO T :=
   NonemptyInterval.pure t
 
 /-- A TO with an identifying role label. -/
-structure NamedTO (Time : Type*) [LinearOrder Time] where
+structure NamedTO (T : Type*) [LinearOrder T] where
   /-- The role label. -/
   name : Orientation
   /-- The TO itself. -/
-  span : TO Time
+  span : TO T
 
 /-- Build a point NamedTO from a label and a single time. -/
-def NamedTO.ofPoint {Time : Type*} [LinearOrder Time]
-    (name : Orientation) (t : Time) : NamedTO Time where
+def NamedTO.ofPoint {T : Type*} [LinearOrder T]
+    (name : Orientation) (t : T) : NamedTO T where
   name := name
   span := TO.pure t
 
 /-- A **temporal domain**: a central (binding) TO together with its
     sub-TOs. Allen relations between TOs are computed on demand from the
     `LinearOrder`; no relation table is stored. -/
-structure Domain (Time : Type*) [LinearOrder Time] where
+structure Domain (T : Type*) [LinearOrder T] where
   /-- The central TO — the binding TO of the domain. -/
-  central : NamedTO Time
+  central : NamedTO T
   /-- The other TOs in the domain. -/
-  subTOs : List (NamedTO Time)
+  subTOs : List (NamedTO T)
 
 /-- All TOs in the domain (central first). -/
-def Domain.all {Time : Type*} [LinearOrder Time] (d : Domain Time) :
-    List (NamedTO Time) :=
+def Domain.all {T : Type*} [LinearOrder T] (d : Domain T) :
+    List (NamedTO T) :=
   d.central :: d.subTOs
 
 /-- The role label of every TO in the domain. -/
-def Domain.labels {Time : Type*} [LinearOrder Time] (d : Domain Time) :
+def Domain.labels {T : Type*} [LinearOrder T] (d : Domain T) :
     List Orientation :=
   d.all.map (·.name)
 
@@ -133,7 +133,7 @@ the link for TO₂ is `⟨.sub 0, .lt, t₂⟩` — meaning TO₂ (= `.sub 0`,
 one step out from the binding TO₁ = `.perspective`) stands in the
 `before` relation to the next TO outward. The `.situation` role
 labels TO_sit. -/
-structure TOLink (Time : Type*) where
+structure TOLink (T : Type*) where
   /-- The orientation-time role of this link (`.situation` for TO_sit;
       `.sub n` for an intermediate TO). -/
   name : Orientation
@@ -142,7 +142,7 @@ structure TOLink (Time : Type*) where
       it (after); `.eq` = simultaneous (overlapping). -/
   relation : Ordering
   /-- The resolved time value. -/
-  time : Time
+  time : T
 
 /-- Declerck's tense schema: a chain of TOs from TO₁ outward to TO_sit,
 with a time-sphere classification.
@@ -156,28 +156,28 @@ E and R in the Reichenbach projection are derived from TO_sit.
 The chain captures only adjacent relations. Non-adjacent TOs (e.g.,
 TO_sit and TO₁ in the conditional tense) have no asserted relation —
 this is Declerck's account of temporal vagueness. -/
-structure DeclercianSchema (Time : Type*) where
+structure DeclercianSchema (T : Type*) where
   /-- Temporal zero-point (usually = speech time) -/
-  t0 : Time
+  t0 : T
   /-- Basic TO (TO₁): the starting point for temporal relations.
       Usually = t₀, but can be a future or past time in embedded contexts. -/
-  to1 : Time
+  to1 : T
   /-- Chain of TOs from TO₁ outward. Each link's `relation` connects it
       to the previous link (or to TO₁ for the first link). The last element
       is TO_sit, which TS is simultaneous with. -/
-  chain : List (TOLink Time)
+  chain : List (TOLink T)
   /-- Which time-sphere the tense belongs to -/
   timeSphere : TimeSphere
 
 /-- The situation-TO (= TS): the TO with which the situation time coincides.
 This is the last element of the chain, or TO₁ if the chain is empty. -/
-def DeclercianSchema.toSit {Time : Type*} (s : DeclercianSchema Time) : Time :=
+def DeclercianSchema.toSit {T : Type*} (s : DeclercianSchema T) : T :=
   match s.chain.getLast? with
   | some link => link.time
   | none => s.to1
 
 /-- Number of TOs in the schema (including TO₁). -/
-def DeclercianSchema.depth {Time : Type*} (s : DeclercianSchema Time) : ℕ :=
+def DeclercianSchema.depth {T : Type*} (s : DeclercianSchema T) : ℕ :=
   s.chain.length + 1
 
 /-! ### Projection to ReichenbachFrame -/
@@ -189,16 +189,16 @@ Since R = E always, no Declercian frame satisfies `isPerfect` (E < R) —
 see `toFrame_not_isPerfect`. The "perfect" in Declerck's system is a chain
 property (TO_sit before TO₂), not an E/R relation. The projection is lossy:
 intermediate TOs and temporal vagueness are collapsed. -/
-def DeclercianSchema.toFrame {Time : Type*}
-    (s : DeclercianSchema Time) : ReichenbachFrame Time where
+def DeclercianSchema.toFrame {T : Type*}
+    (s : DeclercianSchema T) : ReichenbachFrame T where
   speechTime := s.t0
   perspectiveTime := s.to1
   referenceTime := s.toSit
   eventTime := s.toSit
 
 /-- Every Declercian frame has E = R (Declerck's TS = TO_sit principle). -/
-theorem DeclercianSchema.eventTime_eq_referenceTime {Time : Type*}
-    (s : DeclercianSchema Time) :
+theorem DeclercianSchema.eventTime_eq_referenceTime {T : Type*}
+    (s : DeclercianSchema T) :
     s.toFrame.eventTime = s.toFrame.referenceTime := rfl
 
 /-! ### The eight English tense schemata
@@ -208,13 +208,13 @@ theorems can verify the structural relations. -/
 
 section Schemata
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-- **Preterit**: TS simul TO_sit, TO_sit before TO₁. Past time-sphere.
 
 Example: "John was ill yesterday." — TO₁ = t₀ (absolute use),
 TO_sit before TO₁, TS = TO_sit. -/
-def preterit (t0 toSit : Time) : DeclercianSchema Time where
+def preterit (t0 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.situation, .lt, toSit⟩]
@@ -228,7 +228,7 @@ equality (captured by `.eq`); interval-level inclusion is
 handled by `NonemptyInterval.le_def`.
 
 Example: "John is in London." -/
-def present (t0 toSit : Time) : DeclercianSchema Time where
+def present (t0 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.situation, .eq, toSit⟩]
@@ -247,7 +247,7 @@ Example: "I have visited Paris."
 Scope note: the schema represents the **predicated** situation's TO_sit;
 the continuative reading ("I have lived here for ten years"), where the
 full situation extends through t₀, is not representable here. -/
-def presentPerfect (t0 toSit : Time) : DeclercianSchema Time where
+def presentPerfect (t0 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.situation, .lt, toSit⟩]
@@ -259,7 +259,7 @@ perfect": TO₂ lies in the past time-sphere relative to TO₁, and TO_sit
 is anterior to TO₂.
 
 Example: "John had left before we arrived." -/
-def pastPerfect (t0 to2 toSit : Time) : DeclercianSchema Time where
+def pastPerfect (t0 to2 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.sub 0, .lt, to2⟩, ⟨.situation, .lt, toSit⟩]
@@ -269,7 +269,7 @@ def pastPerfect (t0 to2 toSit : Time) : DeclercianSchema Time where
 TO_sit lies in the post-present sector.
 
 Example: "I will do it next week." -/
-def future (t0 toSit : Time) : DeclercianSchema Time where
+def future (t0 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.situation, .gt, toSit⟩]
@@ -283,7 +283,7 @@ John may have already left, may be leaving now, or may leave later.
 The chain captures this by NOT asserting a TO_sit–TO₁ relation.
 
 Example: "John will have left when we arrive." -/
-def futurePerfect (t0 to2 toSit : Time) : DeclercianSchema Time where
+def futurePerfect (t0 to2 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.sub 0, .gt, to2⟩, ⟨.situation, .lt, toSit⟩]
@@ -296,7 +296,7 @@ relation to TO₁ — the situation may or may not have occurred by speech time.
 
 Example (from [declerck-1991]): "The faded red brick of the house had
 weathered many London storms and would weather many more." -/
-def conditional (t0 to2 toSit : Time) : DeclercianSchema Time where
+def conditional (t0 to2 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.sub 0, .lt, to2⟩, ⟨.situation, .gt, toSit⟩]
@@ -307,7 +307,7 @@ TO₃ after TO₂, TO₂ before TO₁. Past time-sphere. The most intricate
 English tense: "past in the future in the past".
 
 Example: "He would have left by then." -/
-def conditionalPerfect (t0 to2 to3 toSit : Time) : DeclercianSchema Time where
+def conditionalPerfect (t0 to2 to3 toSit : T) : DeclercianSchema T where
   t0 := t0
   to1 := t0
   chain := [⟨.sub 0, .lt, to2⟩, ⟨.sub 1, .gt, to3⟩, ⟨.situation, .lt, toSit⟩]
@@ -325,52 +325,52 @@ infrastructure used by the other tense theories in linglib. -/
 
 section Bridge
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- No Declercian frame is `isPerfect` (E < R): the TS = TO_sit principle
 forces E = R. The perfect lives in the chain, not in the E/R relation. -/
-theorem DeclercianSchema.toFrame_not_isPerfect (s : DeclercianSchema Time) :
+theorem DeclercianSchema.toFrame_not_isPerfect (s : DeclercianSchema T) :
     ¬ s.toFrame.isPerfect :=
   λ h => lt_irrefl _ h
 
 /-- Preterit projects to a frame satisfying PAST (R < P). -/
-theorem preterit_isPast (t0 toSit : Time) (h : toSit < t0) :
+theorem preterit_isPast (t0 toSit : T) (h : toSit < t0) :
     (preterit t0 toSit).toFrame.isPast := (ReichenbachFrame.isPast_def _).mpr h
 
-omit [LinearOrder Time] in
+omit [LinearOrder T] in
 /-- Present projects to a frame satisfying PRESENT (R = P) for point times. -/
-theorem present_isPresent (t0 : Time) :
+theorem present_isPresent (t0 : T) :
     (present t0 t0).toFrame.isPresent := rfl
 
 /-- Present perfect projects to PAST (R < P) — because TO_sit (= R) < TO₁
 (= P). The present-sphere membership is tracked by `timeSphere`, not by
 the Reichenbach R/P relation. -/
-theorem presentPerfect_frame_isPast (t0 toSit : Time) (h : toSit < t0) :
+theorem presentPerfect_frame_isPast (t0 toSit : T) (h : toSit < t0) :
     (presentPerfect t0 toSit).toFrame.isPast := (ReichenbachFrame.isPast_def _).mpr h
 
-omit [LinearOrder Time] in
+omit [LinearOrder T] in
 /-- Preterit and present perfect produce identical Reichenbach frames for
 the same times — they differ ONLY in time-sphere. This is Declerck's
 central thesis about the perfect/preterit distinction: the contrast
 is sphere membership, not R/P configuration. -/
-theorem preterit_presentPerfect_same_frame (t0 toSit : Time) :
+theorem preterit_presentPerfect_same_frame (t0 toSit : T) :
     (preterit t0 toSit).toFrame = (presentPerfect t0 toSit).toFrame := rfl
 
-omit [LinearOrder Time] in
+omit [LinearOrder T] in
 /-- … but they differ in time-sphere. -/
-theorem preterit_presentPerfect_differ_sphere (t0 toSit : Time) :
+theorem preterit_presentPerfect_differ_sphere (t0 toSit : T) :
     (preterit t0 toSit).timeSphere ≠ (presentPerfect t0 toSit).timeSphere :=
   nofun
 
 /-- Past perfect projects to PAST (R < P): the chain gives
 TO_sit < TO₂ < TO₁, so R (= TO_sit) < P (= TO₁). -/
-theorem pastPerfect_isPast (t0 to2 toSit : Time)
+theorem pastPerfect_isPast (t0 to2 toSit : T)
     (h₁ : toSit < to2) (h₂ : to2 < t0) :
     (pastPerfect t0 to2 toSit).toFrame.isPast :=
   (ReichenbachFrame.isPast_def _).mpr (lt_trans h₁ h₂)
 
 /-- Future projects to FUTURE (P < R). -/
-theorem future_isFuture (t0 toSit : Time) (h : t0 < toSit) :
+theorem future_isFuture (t0 toSit : T) (h : t0 < toSit) :
     (future t0 toSit).toFrame.isFuture := (ReichenbachFrame.isFuture_def _).mpr h
 
 end Bridge
@@ -422,7 +422,7 @@ TO₁, while the tower counts shifts, so `schema.depth = tower.depth + 1`. -/
 
 section TowerBridge
 
-variable {Time : Type*}
+variable {T : Type*}
 
 open Semantics.Context (ContextTower ContextShift KContext)
 
@@ -430,8 +430,8 @@ open Semantics.Context (ContextTower ContextShift KContext)
 Each `TOLink` becomes a temporal shift with `.temporal` label.
 The relation in the link is not encoded in the shift itself —
 it is a constraint on the times, not a transformation. -/
-def declercianToShifts {E P : Type*} (chain : List (TOLink Time)) :
-    List (ContextShift (KContext Time E P Time)) :=
+def declercianToShifts {E P : Type*} (chain : List (TOLink T)) :
+    List (ContextShift (KContext T E P T)) :=
   chain.map λ link => {
     apply := λ c => { c with time := link.time }
     label := .temporal
@@ -440,8 +440,8 @@ def declercianToShifts {E P : Type*} (chain : List (TOLink Time)) :
 /-- Convert a Declercian schema to a context tower: the origin context has
 `time := to1` (the basic TO), and each chain link becomes a temporal shift. -/
 def declercianToTower {E P : Type*}
-    (s : DeclercianSchema Time) (agent addressee : E) (world : Time) (pos : P) :
-    ContextTower (KContext Time E P Time) where
+    (s : DeclercianSchema T) (agent addressee : E) (world : T) (pos : P) :
+    ContextTower (KContext T E P T) where
   origin := {
     agent := agent
     addressee := addressee
@@ -453,35 +453,35 @@ def declercianToTower {E P : Type*}
 
 /-- The tower depth equals the chain length. -/
 theorem declercianToTower_depth {E P : Type*}
-    (s : DeclercianSchema Time) (agent addr : E) (world : Time) (pos : P) :
+    (s : DeclercianSchema T) (agent addr : E) (world : T) (pos : P) :
     (declercianToTower (E := E) (P := P) s agent addr world pos).depth = s.chain.length := by
   simp only [declercianToTower, ContextTower.depth, declercianToShifts, List.length_map]
 
 /-- Declerck's depth = tower depth + 1: Declerck counts TO₁ as part of the
 depth (number of TOs), while the tower counts only shifts (pushes). -/
 theorem declerck_depth_is_tower_depth_plus_one {E P : Type*}
-    (s : DeclercianSchema Time) (agent addr : E) (world : Time) (pos : P) :
+    (s : DeclercianSchema T) (agent addr : E) (world : T) (pos : P) :
     s.depth = (declercianToTower (E := E) (P := P) s agent addr world pos).depth + 1 := by
   simp only [DeclercianSchema.depth, declercianToTower_depth]
 
 /-- For simple tenses (chain length 1), the tower has depth 1. -/
-theorem preterit_tower_depth (t0 toSit : Time) {E P : Type*}
-    (agent addr : E) (world : Time) (pos : P) :
+theorem preterit_tower_depth (t0 toSit : T) {E P : Type*}
+    (agent addr : E) (world : T) (pos : P) :
     (declercianToTower (E := E) (P := P) (preterit t0 toSit) agent addr world pos).depth = 1 := by
   simp only [declercianToTower, ContextTower.depth, declercianToShifts,
              preterit, List.length_map, List.length_cons, List.length_nil]
 
 /-- For compound tenses (chain length 2), the tower has depth 2. -/
-theorem pastPerfect_tower_depth (t0 to2 toSit : Time) {E P : Type*}
-    (agent addr : E) (world : Time) (pos : P) :
+theorem pastPerfect_tower_depth (t0 to2 toSit : T) {E P : Type*}
+    (agent addr : E) (world : T) (pos : P) :
     (declercianToTower (E := E) (P := P) (pastPerfect t0 to2 toSit)
       agent addr world pos).depth = 2 := by
   simp only [declercianToTower, ContextTower.depth, declercianToShifts,
              pastPerfect, List.length_map, List.length_cons, List.length_nil]
 
 /-- For the conditional perfect (chain length 3), the tower has depth 3. -/
-theorem conditionalPerfect_tower_depth (t0 to2 to3 toSit : Time) {E P : Type*}
-    (agent addr : E) (world : Time) (pos : P) :
+theorem conditionalPerfect_tower_depth (t0 to2 to3 toSit : T) {E P : Type*}
+    (agent addr : E) (world : T) (pos : P) :
     (declercianToTower (E := E) (P := P) (conditionalPerfect t0 to2 to3 toSit)
       agent addr world pos).depth = 3 := by
   simp only [declercianToTower, ContextTower.depth, declercianToShifts,
@@ -499,33 +499,33 @@ stay unchanged; Reichenbach-projecting code continues to use
 
 section DomainBridge
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- The schema as a temporal `Domain` over the `Orientation` role
 vocabulary: central = `.utterance` (t₀), sub-TOs =
 `.perspective` (TO₁) followed by every chain link as a point interval.
 
 The Allen relations between any pair of TOs are **computed** from the
-underlying `LinearOrder Time` via `NonemptyInterval.allenRel`; nothing
+underlying `LinearOrder T` via `NonemptyInterval.allenRel`; nothing
 is stored. The chain's `relation` field encodes the *intended* Declercian
 temporal relation but is not consulted here — its job is to constrain
 admissible time assignments at the call site. -/
-def DeclercianSchema.toDomain (s : DeclercianSchema Time) :
-    Domain Time where
+def DeclercianSchema.toDomain (s : DeclercianSchema T) :
+    Domain T where
   central := NamedTO.ofPoint .utterance s.t0
   subTOs := NamedTO.ofPoint .perspective s.to1 ::
             s.chain.map (λ link => NamedTO.ofPoint link.name link.time)
 
-@[simp] theorem DeclercianSchema.toDomain_central (s : DeclercianSchema Time) :
+@[simp] theorem DeclercianSchema.toDomain_central (s : DeclercianSchema T) :
     s.toDomain.central = NamedTO.ofPoint .utterance s.t0 := rfl
 
-@[simp] theorem DeclercianSchema.toDomain_subTOs (s : DeclercianSchema Time) :
+@[simp] theorem DeclercianSchema.toDomain_subTOs (s : DeclercianSchema T) :
     s.toDomain.subTOs = NamedTO.ofPoint .perspective s.to1 ::
       s.chain.map (λ link => NamedTO.ofPoint link.name link.time) := rfl
 
 /-- The schema's domain labels: utterance first, then perspective, then
 every chain link's role. Useful for stating role-set invariants. -/
-theorem DeclercianSchema.toDomain_labels (s : DeclercianSchema Time) :
+theorem DeclercianSchema.toDomain_labels (s : DeclercianSchema T) :
     s.toDomain.labels =
       Orientation.utterance :: .perspective :: s.chain.map TOLink.name := by
   simp only [Domain.labels, Domain.all, DeclercianSchema.toDomain_central,
@@ -565,14 +565,14 @@ inductive Zone where
 
 namespace DeclercianSchema
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-- Classify a schema's TO_sit by zone, based on `(timeSphere, chain
 length, last chain link's relation)`. Simple past-sphere tenses
 (chain length 1) classify as `past`; deeper past-sphere chains land in
 the domain-internal `prePast`/`postPast` positions. Defaults to the
 sphere's center for empty chains and non-strict relations. -/
-def zoneOf (s : DeclercianSchema Time) : Zone :=
+def zoneOf (s : DeclercianSchema T) : Zone :=
   match s.timeSphere, s.chain.length, (s.chain.getLast?).map TOLink.relation with
   | .past,    1, some .lt => .past         -- preterit
   | .past,    _, some .lt => .prePast      -- past perfect, conditional perfect
@@ -586,40 +586,40 @@ end DeclercianSchema
 
 section ZoneClassification
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-! Each named English tense classifies to its expected zone; these
 exercise the `zoneOf` match against all eight constructors. -/
 
-theorem preterit_zone (t0 toSit : Time) :
+theorem preterit_zone (t0 toSit : T) :
     (preterit t0 toSit).zoneOf = .past := rfl
 
-theorem present_zone (t0 toSit : Time) :
+theorem present_zone (t0 toSit : T) :
     (present t0 toSit).zoneOf = .present := rfl
 
-theorem presentPerfect_zone (t0 toSit : Time) :
+theorem presentPerfect_zone (t0 toSit : T) :
     (presentPerfect t0 toSit).zoneOf = .prePresent := rfl
 
-theorem future_zone (t0 toSit : Time) :
+theorem future_zone (t0 toSit : T) :
     (future t0 toSit).zoneOf = .postPresent := rfl
 
-theorem pastPerfect_zone (t0 to2 toSit : Time) :
+theorem pastPerfect_zone (t0 to2 toSit : T) :
     (pastPerfect t0 to2 toSit).zoneOf = .prePast := rfl
 
-theorem conditional_zone (t0 to2 toSit : Time) :
+theorem conditional_zone (t0 to2 toSit : T) :
     (conditional t0 to2 toSit).zoneOf = .postPast := rfl
 
-theorem futurePerfect_zone (t0 to2 toSit : Time) :
+theorem futurePerfect_zone (t0 to2 toSit : T) :
     (futurePerfect t0 to2 toSit).zoneOf = .prePresent := rfl
 
-theorem conditionalPerfect_zone (t0 to2 to3 toSit : Time) :
+theorem conditionalPerfect_zone (t0 to2 to3 toSit : T) :
     (conditionalPerfect t0 to2 to3 toSit).zoneOf = .prePast := rfl
 
 /-- Preterit and present perfect classify to **different zones** (`past`
 vs `prePresent`) despite projecting to identical Reichenbach frames
 (`preterit_presentPerfect_same_frame`). The Zone classifier surfaces
 what `toFrame` flattens. -/
-theorem preterit_presentPerfect_differ_zone (t0 toSit : Time) :
+theorem preterit_presentPerfect_differ_zone (t0 toSit : T) :
     (preterit t0 toSit).zoneOf ≠ (presentPerfect t0 toSit).zoneOf :=
   nofun
 

--- a/Linglib/Studies/FuscoSgrizzi2026.lean
+++ b/Linglib/Studies/FuscoSgrizzi2026.lean
@@ -173,50 +173,50 @@ verb, two complement sizes. -/
 /-- A causative attitude verb: the agent causes the experiencer to
     enter a rational attitude state whose content is the complement
     predicate. -/
-structure CausativeAttitude (E Time : Type*) [LinearOrder Time] where
+structure CausativeAttitude (E T : Type*) [LinearOrder T] where
   /-- The verb's descriptive predicate (Convince). -/
-  verbPred : Event Time → Prop
+  verbPred : Event T → Prop
   /-- The agent of the matrix event. -/
   agent : E
   /-- The patient of the matrix event and experiencer of the attitude. -/
   experiencer : E
   /-- Agent thematic role. -/
-  isAgent : Event Time → E → Prop
+  isAgent : Event T → E → Prop
   /-- Patient thematic role. -/
-  isPatient : Event Time → E → Prop
+  isPatient : Event T → E → Prop
   /-- Experiencer thematic role, on the attitude event. -/
-  isExperiencer : Event Time → E → Prop
+  isExperiencer : Event T → E → Prop
   /-- The matrix event causally brings about the attitude state. -/
-  cause : Event Time → Event Time → Prop
+  cause : Event T → Event T → Prop
 
-variable {E Time : Type*} [LinearOrder Time]
+variable {E T : Type*} [LinearOrder T]
 
 /-- The verb applied to a complement predicate `P`: some matrix event
     causes a stative rational-attitude event satisfying `P`. -/
-def CausativeAttitude.denote (v : CausativeAttitude E Time)
-    (P : Event Time → Prop) : Prop :=
-  ∃ e e' : Event Time,
+def CausativeAttitude.denote (v : CausativeAttitude E T)
+    (P : Event T → Prop) : Prop :=
+  ∃ e e' : Event T,
     v.verbPred e ∧ v.isAgent e v.agent ∧ v.isPatient e v.experiencer ∧
     v.cause e e' ∧ e'.sort = .stative ∧
     v.isExperiencer e' v.experiencer ∧ P e'
 
 /-- Belief reading: the CP complement is existentially closed into a
     proposition, evaluated against doxastic content. -/
-def CausativeAttitude.beliefReading (v : CausativeAttitude E Time)
-    (embeddedVP : Event Time → Prop) : Prop :=
-  v.denote (fun _ => ∃ e : Event Time, embeddedVP e)
+def CausativeAttitude.beliefReading (v : CausativeAttitude E T)
+    (embeddedVP : Event T → Prop) : Prop :=
+  v.denote (fun _ => ∃ e : Event T, embeddedVP e)
 
 /-- Intention reading: the sub-CP complement is applied directly as an
     event predicate, evaluated against inertial continuation. -/
-def CausativeAttitude.intentionReading (v : CausativeAttitude E Time)
-    (embeddedVP : Event Time → Prop) : Prop :=
+def CausativeAttitude.intentionReading (v : CausativeAttitude E T)
+    (embeddedVP : Event T → Prop) : Prop :=
   v.denote embeddedVP
 
 /-- The paper's central claim (ex. 24): both readings are the one
     `denote` applied to different complement predicates — the
     belief/intention split is compositional, not lexical. -/
 theorem CausativeAttitude.readings_from_single_denote
-    (v : CausativeAttitude E Time) (VP : Event Time → Prop) :
+    (v : CausativeAttitude E T) (VP : Event T → Prop) :
     v.beliefReading VP = v.denote (fun _ => ∃ e, VP e) ∧
     v.intentionReading VP = v.denote VP :=
   ⟨rfl, rfl⟩

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -43,7 +43,7 @@ Uses `Aspect.Core.UNBOUNDED` (= non-strict IMPF, [pancheva-2003]) projected
 to `RunTimes` for the imperfective denotation:
 
 ```
-Unit → Event Time → Prop ──[UNBOUNDED]──▷ IntervalPred ──[fix w=()]──▷ RunTimes
+Unit → Event T → Prop ──[UNBOUNDED]──▷ IntervalPred ──[fix w=()]──▷ RunTimes
 ```
 
 The key property — subinterval-closure — holds for both `UNBOUNDED` (⊆) and
@@ -72,7 +72,7 @@ open NonemptyInterval
 open Aspect
 open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 -- ============================================================================
 -- § 1: Aspect.Core → RunTimes Projection
@@ -84,14 +84,14 @@ variable {Time : Type*} [LinearOrder Time]
     rather than `IMPF` (which requires strict ⊂) because the homogeneity
     argument is identical and the non-strict version connects cleanly to
     `stativeDenotation`. -/
-abbrev impfDen (P : Unit → Event Time → Prop) : RunTimes Time :=
+abbrev impfDen (P : Unit → Event T → Prop) : RunTimes T :=
   { i | UNBOUNDED P () i }
 
 /-- PRFV denotation: the set of exact event runtimes — the `eventDenotation`
     τ-image (`Projection.lean`) of `P ()`. Unlike the `Aspect.Core.PRFV` operator
     (whose intervals CONTAIN the runtime: TSit ⊆ TT), this gives the runtime itself,
     directly characterizing the event's temporal extent. -/
-def prfvDen (P : Unit → Event Time → Prop) : RunTimes Time :=
+def prfvDen (P : Unit → Event T → Prop) : RunTimes T :=
   eventDenotation (P ())
 
 -- ============================================================================
@@ -109,16 +109,16 @@ def prfvDen (P : Unit → Event Time → Prop) : RunTimes Time :=
     of the main clause of durative *until*. The imperfective viewpoint
     provides this automatically: since the event extends beyond any reference
     interval, every sub-window into the event is equally valid. -/
-theorem impfDen_subinterval_closed (P : Unit → Event Time → Prop)
-    (t : NonemptyInterval Time) (ht : t ∈ impfDen P)
-    (t' : NonemptyInterval Time) (ht' : t' ≤ t) :
+theorem impfDen_subinterval_closed (P : Unit → Event T → Prop)
+    (t : NonemptyInterval T) (ht : t ∈ impfDen P)
+    (t' : NonemptyInterval T) (ht' : t' ≤ t) :
     t' ∈ impfDen P := by
   obtain ⟨e, hSub, hP⟩ := ht
   exact ⟨e, ⟨le_trans hSub.1 ht'.1, le_trans ht'.2 hSub.2⟩, hP⟩
 
 /-- IMPF denotation contains the event runtime itself (the maximal interval). -/
-theorem impfDen_contains_runtime (P : Unit → Event Time → Prop)
-    (e : Event Time) (hP : P () e) :
+theorem impfDen_contains_runtime (P : Unit → Event T → Prop)
+    (e : Event T) (hP : P () e) :
     e.τ ∈ impfDen P :=
   ⟨e, le_refl _, hP⟩
 
@@ -156,7 +156,7 @@ theorem prfvDen_not_subinterval_closed :
 
 /-- IMPF denotation is homogeneous (a lower set / subinterval-closed) — wide scope
     is available. -/
-theorem impfDen_homogeneous (P : Unit → Event Time → Prop) :
+theorem impfDen_homogeneous (P : Unit → Event T → Prop) :
     IsLowerSet (impfDen P) := by
   intro a b hba ha
   exact impfDen_subinterval_closed P a ha b hba
@@ -175,7 +175,7 @@ theorem prfvDen_not_always_homogeneous :
     PRFV's failure of subinterval-closure, not from a stipulated constraint. -/
 theorem scope_pattern_derived :
     -- IMPF always permits wide scope (homogeneous)
-    (∀ (P : Unit → Event Time → Prop), IsLowerSet (impfDen P)) ∧
+    (∀ (P : Unit → Event T → Prop), IsLowerSet (impfDen P)) ∧
     -- PRFV does not always permit wide scope (not always homogeneous)
     ¬ (∀ (P : Unit → Event ℤ → Prop), IsLowerSet (prfvDen P)) :=
   ⟨impfDen_homogeneous, prfvDen_not_always_homogeneous⟩
@@ -189,8 +189,8 @@ theorem scope_pattern_derived :
     aspect bridge to the existing temporal connective infrastructure
     in `Basic.lean`. -/
 theorem impfDen_singleton_eq_stativeDenotation
-    (i : NonemptyInterval Time) :
-    impfDen (fun () (e : Event Time) => e.τ = i) =
+    (i : NonemptyInterval T) :
+    impfDen (fun () (e : Event T) => e.τ = i) =
     stativeDenotation i := by
   ext j
   simp only [UNBOUNDED, stativeDenotation, Set.mem_Iic, Set.mem_ofPred_eq, Event.τ]
@@ -202,8 +202,8 @@ theorem impfDen_singleton_eq_stativeDenotation
 /-- For a single event, the PRFV denotation is exactly the accomplishment
     denotation (singleton containing just the runtime). -/
 theorem prfvDen_singleton_eq_accomplishmentDenotation
-    (i : NonemptyInterval Time) :
-    prfvDen (fun () (e : Event Time) => e.τ = i) =
+    (i : NonemptyInterval T) :
+    prfvDen (fun () (e : Event T) => e.τ = i) =
     accomplishmentDenotation i := by
   ext j
   simp only [prfvDen, mem_eventDenotation, accomplishmentDenotation, Event.τ]
@@ -222,7 +222,7 @@ theorem prfvDen_singleton_eq_accomplishmentDenotation
     This is why Karttunen's Level 1 (point-set) definitions cannot distinguish
     imperfective from perfective clauses — the difference is only visible
     at Level 2 (interval sets). -/
-theorem timeTrace_impf_eq_prfv (P : Unit → Event Time → Prop) :
+theorem timeTrace_impf_eq_prfv (P : Unit → Event T → Prop) :
     timeTrace (impfDen P) = timeTrace (prfvDen P) := by
   ext t
   simp only [timeTrace, prfvDen, UNBOUNDED, Set.mem_ofPred_eq, Event.τ]
@@ -247,7 +247,7 @@ theorem timeTrace_impf_eq_prfv (P : Unit → Event Time → Prop) :
     Available when A is imperfective: the main clause denotes a homogeneous
     interval set via IMPF, so *until* can take it as an argument.
     Negation scopes over the entire *until*-clause. -/
-def wideScopeNotUntil (A : Unit → Event Time → Prop) (B : RunTimes Time) : Prop :=
+def wideScopeNotUntil (A : Unit → Event T → Prop) (B : RunTimes T) : Prop :=
   ¬ when_ (impfDen A) B
 
 /-- **Narrow-scope negation** under *until* (= Karttunen's ¬*before*):
@@ -259,13 +259,13 @@ def wideScopeNotUntil (A : Unit → Event Time → Prop) (B : RunTimes Time) : P
     This is the only reading available with perfective main clauses:
     since PRFV gives a bounded event, *until* reduces to temporal ordering
     and negation gives Karttunen's notUntil = ¬before. -/
-def narrowScopeNotUntil (A : Unit → Event Time → Prop) (B : RunTimes Time) : Prop :=
+def narrowScopeNotUntil (A : Unit → Event T → Prop) (B : RunTimes T) : Prop :=
   notUntil (prfvDen A) B
 
 /-- Narrow-scope ¬*until* is exactly ¬*before* (by definition).
     This is [karttunen-1974]'s identity, now made explicit in the
     aspectual decomposition. -/
-theorem narrowScope_eq_not_before (A : Unit → Event Time → Prop) (B : RunTimes Time) :
+theorem narrowScope_eq_not_before (A : Unit → Event T → Prop) (B : RunTimes T) :
     narrowScopeNotUntil A B ↔ ¬ Anscombe.beforeEver (prfvDen A) B :=
   Iff.rfl
 
@@ -349,7 +349,7 @@ theorem scope_readings_independent :
     `¬∃t'∃e' [t'∈C ∧ t'<t ∧ P(e',t')]`. The scalar/contextual component
     is abstracted away here; the core truth-conditional difference (overlap +
     lateness vs. lateness alone) is preserved. -/
-def eventiveUntil (A B : RunTimes Time) : Prop :=
+def eventiveUntil (A B : RunTimes T) : Prop :=
   (∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B) ∧ ¬ Anscombe.beforeEver A B
 
 -- ============================================================================
@@ -360,22 +360,22 @@ def eventiveUntil (A B : RunTimes Time) : Prop :=
     This is the **actualization entailment** that [giannakidou-2002]
     identifies as the hallmark of NPI-*until* (para monon), absent from
     durative *until* (mexri) and before (prin). -/
-theorem eventiveUntil_entails_actualization (A B : RunTimes Time) :
+theorem eventiveUntil_entails_actualization (A B : RunTimes T) :
     eventiveUntil A B → ∃ t, t ∈ timeTrace A := by
   rintro ⟨⟨t, ht, _⟩, _⟩; exact ⟨t, ht⟩
 
 /-- Eventive UNTIL entails complement actualization: B must have occurred. -/
-theorem eventiveUntil_entails_complement (A B : RunTimes Time) :
+theorem eventiveUntil_entails_complement (A B : RunTimes T) :
     eventiveUntil A B → ∃ t, t ∈ timeTrace B := by
   rintro ⟨⟨t, _, ht⟩, _⟩; exact ⟨t, ht⟩
 
 /-- Eventive UNTIL entails ¬*before*: A didn't happen prior to B. -/
-theorem eventiveUntil_entails_notBefore (A B : RunTimes Time) :
+theorem eventiveUntil_entails_notBefore (A B : RunTimes T) :
     eventiveUntil A B → notUntil A B :=
   And.right
 
 /-- Eventive UNTIL entails temporal coincidence (*when*): A and B overlap. -/
-theorem eventiveUntil_entails_when (A B : RunTimes Time) :
+theorem eventiveUntil_entails_when (A B : RunTimes T) :
     eventiveUntil A B → when_ A B := by
   rintro ⟨⟨t, htA, htB⟩, _⟩; exact ⟨t, htA, htB⟩
 
@@ -746,7 +746,7 @@ theorem negBefore_lacks_actualization :
     common to both *prin/before* and *until/para monon*. -/
 theorem before_not_equiv_eventiveUntil :
     -- eventiveUntil entails main-clause actualization
-    (∀ (A B : RunTimes Time), eventiveUntil A B → ∃ t, t ∈ timeTrace A) ∧
+    (∀ (A B : RunTimes T), eventiveUntil A B → ∃ t, t ∈ timeTrace A) ∧
     -- ¬before is compatible with main-clause non-actualization
     (∃ (A B : RunTimes ℤ), notUntil A B ∧ ¬ ∃ t, t ∈ timeTrace A) :=
   ⟨eventiveUntil_entails_actualization, negBefore_lacks_actualization⟩

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -205,19 +205,19 @@ not carry out her intention). -/
     some stative intention state held by the agent, each of whose
     content pairs ⟨w', x⟩ supports an event that the state brings
     about in the right way and that satisfies the complement. The
-    complement type `E → W → Event Time → Prop` keeps the event
+    complement type `E → W → Event T → Prop` keeps the event
     argument open — the formal correlate of Premise 3: indicative
     would existentially close it to `W → Prop`, which cannot compose
     with the causal self-reference relation. -/
-def intentionHolds {E W Time : Type*} [LinearOrder Time]
-    (isIntention : Event Time → W → Prop)
-    (holder : E → Event Time → W → Prop)
-    (content : Event Time → Set (W × E))
-    (causeStar : Event Time → Event Time → W → Prop)
-    (agent : E) (P : E → W → Event Time → Prop) (w : W) : Prop :=
-  ∃ s : Event Time,
+def intentionHolds {E W T : Type*} [LinearOrder T]
+    (isIntention : Event T → W → Prop)
+    (holder : E → Event T → W → Prop)
+    (content : Event T → Set (W × E))
+    (causeStar : Event T → Event T → W → Prop)
+    (agent : E) (P : E → W → Event T → Prop) (w : W) : Prop :=
+  ∃ s : Event T,
     s.sort = .stative ∧ isIntention s w ∧ holder agent s w ∧
-    ∀ p ∈ content s, ∃ e : Event Time, causeStar s e p.1 ∧ P p.2 p.1 e
+    ∀ p ∈ content s, ∃ e : Event T, causeStar s e p.1 ∧ P p.2 p.1 e
 
 /-- Plain belief reports need no causal self-reference: the complement
     is a closed proposition evaluated over doxastic alternatives —
@@ -250,7 +250,7 @@ theorem subj_enables_eventuality_abstraction {E : Type*} (P : E → Prop) :
     Grammatical.subjunctive.eventDenotation P = .abstracted P := rfl
 
 /-- The three-premise argument chain:
-    1. `intentionHolds` requires P : E → W → Event Time → Prop (open event arg)
+    1. `intentionHolds` requires P : E → W → Event T → Prop (open event arg)
     2. IND closes the event argument (`eventDenotation` lands in `closed`)
     3. SBJV leaves it open (`eventDenotation` lands in `abstracted`)
     → intention reports require SBJV, reject IND -/

--- a/Linglib/Studies/HartshorneEtAl2016.lean
+++ b/Linglib/Studies/HartshorneEtAl2016.lean
@@ -371,18 +371,18 @@ theorem profile_agreement (t : SemanticType) :
 -- ════════════════════════════════════════════════════
 
 /-- External source predicts transition (BECOME). -/
-theorem external_predicts_transition (Time : Type*) [LinearOrder Time] :
-    (CausalSource.toLink Time .external).involvesTransition = true := rfl
+theorem external_predicts_transition (T : Type*) [LinearOrder T] :
+    (CausalSource.toLink T .external).involvesTransition = true := rfl
 
 /-- Internal source predicts no transition. -/
-theorem internal_predicts_no_transition (Time : Type*) [LinearOrder Time] :
-    (CausalSource.toLink Time .internal).involvesTransition = false := rfl
+theorem internal_predicts_no_transition (T : Type*) [LinearOrder T] :
+    (CausalSource.toLink T .internal).involvesTransition = false := rfl
 
 /-- Consistency: PsychCausalLink's transition prediction agrees with the
     empirical profile derived from SemanticType.
     Both are derived independently — the agreement is a genuine check. -/
-theorem transition_prediction_consistent (t : SemanticType) (Time : Type*) [LinearOrder Time] :
-    (CausalSource.toLink Time (semanticTypeToCausalSource t)).involvesTransition =
+theorem transition_prediction_consistent (t : SemanticType) (T : Type*) [LinearOrder T] :
+    (CausalSource.toLink T (semanticTypeToCausalSource t)).involvesTransition =
       (causalSourceToProfile (semanticTypeToCausalSource t)).involvesBecome := by
   cases t <;> rfl
 

--- a/Linglib/Studies/HayKennedyLevin1999.lean
+++ b/Linglib/Studies/HayKennedyLevin1999.lean
@@ -65,9 +65,9 @@ open English.Predicates.Verbal
 
 /-- HKL eq 11: `[long(x)(t)] = the degree to which x is long at time t`.
     A gradable adjective denotes a time-indexed measure function — the
-    same shape as K&L 2008's `TemporalMeasure α δ Time` in
+    same shape as K&L 2008's `TemporalMeasure α δ T` in
     `Semantics/Degree/Measure/Temporal.lean`. -/
-abbrev TimedAdjective (α δ Time : Type*) := α → Time → δ
+abbrev TimedAdjective (α δ T : Type*) := α → T → δ
 
 /-- HKL eq 16, the INCREASE function:
     `INCREASE(φ)(x)(d)(e) = 1 iff φ(x)(SPO(e)) + d = φ(x)(EPO(e))`.
@@ -82,22 +82,22 @@ abbrev TimedAdjective (α δ Time : Type*) := α → Time → δ
     The two coincide on monotone-increase events with `d ≥ 0`; HKL's
     `Prop`-valued INCREASE is sufficient for the §3 data and avoids
     the clamping bookkeeping. -/
-def INCREASE {α δ Time : Type*} [Add δ]
-    (φ : TimedAdjective α δ Time) (x : α) (d : δ)
-    (startT finT : Time) : Prop :=
+def INCREASE {α δ T : Type*} [Add δ]
+    (φ : TimedAdjective α δ T) (x : α) (d : δ)
+    (startT finT : T) : Prop :=
   φ x startT + d = φ x finT
 
 /-- Zero-duration events (start = end) carry zero difference value. -/
-theorem increase_self {α δ Time : Type*} [AddZeroClass δ]
-    (φ : TimedAdjective α δ Time) (x : α) (t : Time) :
+theorem increase_self {α δ T : Type*} [AddZeroClass δ]
+    (φ : TimedAdjective α δ T) (x : α) (t : T) :
     INCREASE φ x 0 t t := by
   simp [INCREASE]
 
 /-- HKL §3 thesis at the type level: when the difference value `d` is
     given, the end degree is **uniquely determined** by the start degree
     — the structural source of telic interpretations. -/
-theorem increase_unique_end {α δ Time : Type*} [Add δ]
-    (φ : TimedAdjective α δ Time) (x : α) (d : δ) (startT finT₁ finT₂ : Time)
+theorem increase_unique_end {α δ T : Type*} [Add δ]
+    (φ : TimedAdjective α δ T) (x : α) (d : δ) (startT finT₁ finT₂ : T)
     (h₁ : INCREASE φ x d startT finT₁) (h₂ : INCREASE φ x d startT finT₂) :
     φ x finT₁ = φ x finT₂ :=
   h₁.symm.trans h₂

--- a/Linglib/Studies/HeimComments1994.lean
+++ b/Linglib/Studies/HeimComments1994.lean
@@ -21,7 +21,7 @@ contributions:
    - **ULC as presupposition** (eq 16, p. 149): "If α_i is a tense,
      then [[α_i]]^g,c is only defined if `g(i)` does-not-follow `g(0)`."
      The substrate's `Tense.upperLimitConstraint` (in `Tense/Embedding.lean`)
-     IS this presupposition, already typed at `[LE Time]` and credited
+     IS this presupposition, already typed at `[LE T]` and credited
      to [heim-1994-comments] in its docstring; this study file
      proves the felicity-to-ULC bridge through the substrate primitive.
    - **Time-concept** (p. 155): "By a 'time-concept' I mean a function
@@ -182,7 +182,7 @@ theorem toSubstrate_factors_iff_agent_blind {W E P T : Type*}
     [[α_i]]^g,c is only defined if `g(i)` does-not-follow `g(0)`."
     Heim's presuppositional construal of [abusch-1997]'s Upper
     Limit Constraint is already encoded in the substrate as
-    `Tense.upperLimitConstraint` (typed `[LE Time]`,
+    `Tense.upperLimitConstraint` (typed `[LE T]`,
     anchored to [heim-1994-comments] in its docstring). This
     bridge theorem projects the substrate's `TemporalDeReReading`
     `IsFelicitousWith .past` (strict `<`) onto the substrate's ULC

--- a/Linglib/Studies/Heinamaki1974.lean
+++ b/Linglib/Studies/Heinamaki1974.lean
@@ -21,7 +21,7 @@ namespace Heinamaki1974
 
 open Tense Anscombe1964 NonemptyInterval
 
-variable {Time : Type*} [LinearOrder Time] (A B : RunTimes Time)
+variable {T : Type*} [LinearOrder T] (A B : RunTimes T)
 
 /-- *A when B*: `A` and `B` hold at a common time. -/
 def when_ : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
@@ -66,18 +66,18 @@ theorem before_by : Anscombe.beforeEver A B → by_ A B :=
   fun ⟨t, ht, h⟩ => ⟨t, ht, fun t' ht' => (h t' ht').le⟩
 
 /-- *A before B* by the reference point: some time of `A` precedes `B`'s first time `lb`. -/
-def before (A : RunTimes Time) (lb : Time) : Prop := ∃ t ∈ timeTrace A, t < lb
+def before (A : RunTimes T) (lb : T) : Prop := ∃ t ∈ timeTrace A, t < lb
 
 /-- *A after B* by the reference point: some time of `A` follows `B`'s first time `lb`. -/
-def after (A : RunTimes Time) (lb : Time) : Prop := ∃ t ∈ timeTrace A, lb < t
+def after (A : RunTimes T) (lb : T) : Prop := ∃ t ∈ timeTrace A, lb < t
 
 /-- When `B` has a first time, the reference-point *before* is [anscombe-1964]'s
 quantificational one. -/
-theorem before_iff_anscombe {lb : Time} (hlb : IsLeast (timeTrace B) lb) :
+theorem before_iff_anscombe {lb : T} (hlb : IsLeast (timeTrace B) lb) :
     before A lb ↔ Anscombe.beforeEver A B := (beforeEver_iff_lt_least hlb).symm
 
 /-- When `B` has a first time, the reference-point *after* is [anscombe-1964]'s. -/
-theorem after_iff_anscombe {lb : Time} (hlb : IsLeast (timeTrace B) lb) :
+theorem after_iff_anscombe {lb : T} (hlb : IsLeast (timeTrace B) lb) :
     after A lb ↔ Anscombe.after A B := (after_iff_least_lt hlb).symm
 
 /-- *While* is not symmetric: a moment inside a stretch. -/

--- a/Linglib/Studies/Huijsmans2025.lean
+++ b/Linglib/Studies/Huijsmans2025.lean
@@ -53,16 +53,16 @@ open Tense.Evidential (EPCondition EvidentialFrame)
     state both Huijsmans's MBT predictions and the EAT predictions she
     is contrasted against. The MBT/EAT split lives in *which* pair of
     anchors a profile reads. -/
-structure Stimulus (Time : Type) where
+structure Stimulus (T : Type) where
   /-- ⌜MBT⌝ — the maximum over `q ∈ MB` of `EARLIEST(SHIFT q)`, i.e.
       the latest "earliest moment" required by the modal base. -/
-  earliestMBT   : Time
+  earliestMBT   : T
   /-- ⌜PrejT⌝ — `EARLIEST(p)` for the prejacent `p`. -/
-  earliestPrejT : Time
+  earliestPrejT : T
   /-- The (Cumming/Hirayama-Matthewson) evidence-acquisition time. -/
-  eat           : Time
+  eat           : T
   /-- The event time of the prejacent. -/
-  et            : Time
+  et            : T
   deriving Repr
 
 -- ════════════════════════════════════════════════════
@@ -95,12 +95,12 @@ def MBTProfile.toRelation : MBTProfile → Finset Ordering
   | .unrestricted   => ⊤
 
 /-- The MBT-licensing predicate, derived from the abstract partition. -/
-def MBTProfile.licenses {Time : Type} [LinearOrder Time]
-    (c : MBTProfile) (s : Stimulus Time) : Prop :=
+def MBTProfile.licenses {T : Type} [LinearOrder T]
+    (c : MBTProfile) (s : Stimulus T) : Prop :=
   compare s.earliestMBT s.earliestPrejT ∈ c.toRelation
 
-instance {Time : Type} [LinearOrder Time] [DecidableEq Time] (c : MBTProfile)
-    (s : Stimulus Time) : Decidable (c.licenses s) := by
+instance {T : Type} [LinearOrder T] [DecidableEq T] (c : MBTProfile)
+    (s : Stimulus T) : Decidable (c.licenses s) := by
   unfold MBTProfile.licenses; infer_instance
 
 -- ════════════════════════════════════════════════════
@@ -186,14 +186,14 @@ theorem smell_table :
     partition shape to `(eat, et)` instead of `(earliestMBT, earliestPrejT)`.
     Defined inline rather than imported from a (not-yet-existent)
     Hirayama-Matthewson study file. -/
-def MBTProfile.eatLicenses {Time : Type} [LinearOrder Time] :
-    MBTProfile → Stimulus Time → Prop
+def MBTProfile.eatLicenses {T : Type} [LinearOrder T] :
+    MBTProfile → Stimulus T → Prop
   | .strictPrior,    s => s.eat < s.et
   | .nonProspective, s => s.et ≤ s.eat
   | .unrestricted,   _ => True
 
-instance {Time : Type} [LinearOrder Time] [DecidableEq Time] (c : MBTProfile)
-    (s : Stimulus Time) : Decidable (c.eatLicenses s) := by
+instance {T : Type} [LinearOrder T] [DecidableEq T] (c : MBTProfile)
+    (s : Stimulus T) : Decidable (c.eatLicenses s) := by
   cases c <;> simp [MBTProfile.eatLicenses] <;> infer_instance
 
 /-- **The empirical wedge** (Huijsmans (46)–(49)).

--- a/Linglib/Studies/IatridouZeijlstra2021.lean
+++ b/Linglib/Studies/IatridouZeijlstra2021.lean
@@ -57,7 +57,7 @@ open Tense.TemporalAdverbials (PTSConstraint AdverbialType)
 open IatridouEtAl2001 (BoundaryKind)
 open Kiparsky2002 (PerfectReading)
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 
 
 -- ════════════════════════════════════════════════════
@@ -70,8 +70,8 @@ variable {W Time : Type*} [LinearOrder Time]
     - `pts`: the Perfect Time Span (LB set by adverbial or context, RB by Tense)
     - `uts`: the Until Time Span (LB contextually set, RB by *until*'s argument) -/
 inductive TimeSpanKind where
-  | pts  -- Perfect Time Span
-  | uts  -- Until Time Span
+  | pts  -- Perfect T Span
+  | uts  -- Until T Span
   deriving DecidableEq, Repr
 
 /-- The boundary set by Tense (not by the adverbial).
@@ -234,17 +234,17 @@ theorem nonNPI_no_domainAlts :
     These subdomain alternatives are logically stronger than the assertion
     (entailed by it), because if a culminated event took place in a
     subinterval of τ, it also took place in τ. -/
-def SubdomainAlternatives (τ : NonemptyInterval Time) : Set (NonemptyInterval Time) :=
+def SubdomainAlternatives (τ : NonemptyInterval T) : Set (NonemptyInterval T) :=
   Set.Iic τ
 
 /-- Subdomain alternatives of τ include τ itself. -/
-theorem self_in_subdomain (τ : NonemptyInterval Time) :
+theorem self_in_subdomain (τ : NonemptyInterval T) :
     τ ∈ SubdomainAlternatives τ :=
   ⟨le_refl _, le_refl _⟩
 
 /-- Subdomain alternatives of a subinterval are a subset of subdomain
     alternatives of the superinterval. -/
-theorem subdomain_monotone (τ₁ τ₂ : NonemptyInterval Time)
+theorem subdomain_monotone (τ₁ τ₂ : NonemptyInterval T)
     (h : τ₁ ≤ τ₂) :
     SubdomainAlternatives τ₁ ⊆ SubdomainAlternatives τ₂ := by
   intro τ' ⟨hs, hf⟩
@@ -257,18 +257,18 @@ theorem subdomain_monotone (τ₁ τ₂ : NonemptyInterval Time)
 /-- An event of type P has its runtime inside time span τ.
     This is the assertion form for both PTS and UTS:
     ∃e.[P(e) ∧ Run(e) ⊆ τ] -/
-def eventInSpan (P : W → Event Time → Prop) (w : W) (τ : NonemptyInterval Time) : Prop :=
-  ∃ e : Event Time, e.τ ≤ τ ∧ P w e
+def eventInSpan (P : W → Event T → Prop) (w : W) (τ : NonemptyInterval T) : Prop :=
+  ∃ e : Event T, e.τ ≤ τ ∧ P w e
 
 /-- Negated form: no P-event has runtime inside τ.
     ¬∃e.[P(e) ∧ Run(e) ⊆ τ] -/
-def noEventInSpan (P : W → Event Time → Prop) (w : W) (τ : NonemptyInterval Time) : Prop :=
+def noEventInSpan (P : W → Event T → Prop) (w : W) (τ : NonemptyInterval T) : Prop :=
   ¬ eventInSpan P w τ
 
 /-- If a culminated event occurs in a subinterval, it occurs in the
     superinterval. Entailment from subinterval to superinterval. -/
-theorem eventInSpan_monotone (P : W → Event Time → Prop) (w : W)
-    (τ₁ τ₂ : NonemptyInterval Time) (h : τ₁ ≤ τ₂) :
+theorem eventInSpan_monotone (P : W → Event T → Prop) (w : W)
+    (τ₁ τ₂ : NonemptyInterval T) (h : τ₁ ≤ τ₂) :
     eventInSpan P w τ₁ → eventInSpan P w τ₂ := by
   intro ⟨e, hsub, hP⟩
   exact ⟨e, ⟨le_trans h.1 hsub.1, le_trans hsub.2 h.2⟩, hP⟩
@@ -276,8 +276,8 @@ theorem eventInSpan_monotone (P : W → Event Time → Prop) (w : W)
 /-- Subdomain alternatives for culminated events are all nonweaker:
     every subdomain alternative entails the assertion.
     This is because eventInSpan is monotone in the time span. -/
-theorem subdomain_alts_nonweaker (P : W → Event Time → Prop) (w : W)
-    (τ : NonemptyInterval Time) (τ' : NonemptyInterval Time) (h : τ' ∈ SubdomainAlternatives τ) :
+theorem subdomain_alts_nonweaker (P : W → Event T → Prop) (w : W)
+    (τ : NonemptyInterval T) (τ' : NonemptyInterval T) (h : τ' ∈ SubdomainAlternatives τ) :
     eventInSpan P w τ' → eventInSpan P w τ :=
   eventInSpan_monotone P w τ' τ h
 
@@ -294,13 +294,13 @@ theorem subdomain_alts_nonweaker (P : W → Event Time → Prop) (w : W)
     This explains why *in years* is an NPI:
     "*Joe has met Mary in weeks" is ungrammatical because exhaustification
     of the domain alternatives in a positive context yields contradiction. -/
-theorem positive_exhaustification_contradicts (P : W → Event Time → Prop) (w : W)
-    (τ : NonemptyInterval Time)
+theorem positive_exhaustification_contradicts (P : W → Event T → Prop) (w : W)
+    (τ : NonemptyInterval T)
     (_hassert : eventInSpan P w τ)
     -- The exhaustifier requires negating all stronger alternatives
     (hexh : ∀ τ' ∈ SubdomainAlternatives τ, τ' ≠ τ → noEventInSpan P w τ') :
     -- If any proper subinterval exists, we have a contradiction
-    ∀ (τ_sub : NonemptyInterval Time),
+    ∀ (τ_sub : NonemptyInterval T),
       τ_sub ≤ τ → τ_sub ≠ τ →
       -- The assertion entails the subdomain alternative
       eventInSpan P w τ_sub → False := by
@@ -312,8 +312,8 @@ theorem positive_exhaustification_contradicts (P : W → Event Time → Prop) (w
     WEAKER than the assertion ¬∃e.[P(e) ∧ Run(e) ⊆ τ] (for τ' ⊆ τ).
     Since no subdomain alternative is stronger, there is nothing to exclude,
     and exhaustification applies vacuously. No contradiction arises. -/
-theorem negated_subdomain_weaker (P : W → Event Time → Prop) (w : W)
-    (τ τ' : NonemptyInterval Time) (h : τ' ≤ τ) :
+theorem negated_subdomain_weaker (P : W → Event T → Prop) (w : W)
+    (τ τ' : NonemptyInterval T) (h : τ' ≤ τ) :
     noEventInSpan P w τ → noEventInSpan P w τ' := by
   intro hneg hev
   exact hneg (eventInSpan_monotone P w τ' τ h hev)
@@ -333,14 +333,14 @@ theorem negated_subdomain_weaker (P : W → Event Time → Prop) (w : W)
     that stretches as far as possible, the LB must be at the most recent
     occurrence of the event. This makes the event's occurrence a
     presupposition, not just an implicature — hence noncancelable. -/
-def actualityInference (P : W → Event Time → Prop) (w : W)
-    (τ : NonemptyInterval Time) : Prop :=
+def actualityInference (P : W → Event T → Prop) (w : W)
+    (τ : NonemptyInterval T) : Prop :=
   eventInSpan P w τ
 
 /-- The AI with *in years* is at the LB: the event occurs at the LB point. -/
-def aiAtBoundary (P : W → Event Time → Prop) (w : W)
-    (τ : NonemptyInterval Time) : Prop :=
-  ∃ e : Event Time, e.τ.snd = τ.fst ∧ P w e
+def aiAtBoundary (P : W → Event T → Prop) (w : W)
+    (τ : NonemptyInterval T) : Prop :=
+  ∃ e : Event T, e.τ.snd = τ.fst ∧ P w e
 
 -- ════════════════════════════════════════════════════
 -- § 9. The Beyond Expectation Inference
@@ -355,9 +355,9 @@ def aiAtBoundary (P : W → Event Time → Prop) (w : W)
     any contextual alternative, so the event occurred earlier than expected. -/
 structure BeyondExpectationInference where
   /-- The actual time span -/
-  actualSpan : NonemptyInterval Time
+  actualSpan : NonemptyInterval T
   /-- The contextually expected upper bound on the time span -/
-  expectedBound : NonemptyInterval Time
+  expectedBound : NonemptyInterval T
   /-- The actual span is larger (the event is earlier than expected) -/
   beyondExpectation : expectedBound ≤ actualSpan
   /-- The spans are not equal (the actual is strictly larger) -/
@@ -370,14 +370,14 @@ structure BeyondExpectationInference where
 /-- Perfective contributes ST ⊆ TT: the event is contained in the time span.
     [iatridou-zeijlstra-2021] §1 (eq. 17a), following [klein-1994].
     Equivalently, the E-perfect: the event is contained in the PTS. -/
-def perfectiveContainment (e : Event Time) (τ : NonemptyInterval Time) : Prop :=
+def perfectiveContainment (e : Event T) (τ : NonemptyInterval T) : Prop :=
   e.τ ≤ τ
 
 /-- Imperfective contributes TT ⊆ ST: the time span is contained in the event.
     [iatridou-zeijlstra-2021] §1 (eq. 17b).
     With the subinterval property, every subinterval of a P-event is also
     a P-event. This is the key to *until*-d (affirmative imperfective). -/
-def imperfectiveContainment (e : Event Time) (τ : NonemptyInterval Time) : Prop :=
+def imperfectiveContainment (e : Event T) (τ : NonemptyInterval T) : Prop :=
   τ ≤ e.τ
 
 /-- Under IMPF + subinterval property, all subdomain alternatives of the
@@ -385,11 +385,11 @@ def imperfectiveContainment (e : Event Time) (τ : NonemptyInterval Time) : Prop
     is vacuous for affirmative imperfectives — explaining why *until*-d
     (affirmative imperfective + *until*) is fine without negation.
     [iatridou-zeijlstra-2021] §7.2 -/
-theorem impf_subdomain_entailed (P : W → Event Time → Prop)
+theorem impf_subdomain_entailed (P : W → Event T → Prop)
     (hSub : HasSubintervalProp P) (w : W)
-    (e : Event Time) (τ : NonemptyInterval Time)
+    (e : Event T) (τ : NonemptyInterval T)
     (hP : P w e) (hImpf : τ ≤ e.τ)
-    (τ' : NonemptyInterval Time) (hτ' : τ' ≤ τ) :
+    (τ' : NonemptyInterval T) (hτ' : τ' ≤ τ) :
     eventInSpan P w τ' := by
   -- τ' ⊆ τ ⊆ τ(e), so τ' ⊆ τ(e)
   have h_sub_e : τ' ≤ e.τ :=

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -866,16 +866,16 @@ open Anscombe1964 Karttunen1974
 
 /-- BEFORE entails a temporal witness for p (the main clause event
     occurs at some time). This is the positive inference. -/
-theorem before_positive_inference {Time : Type*} [LinearOrder Time]
-    (A B : RunTimes Time) (h : Anscombe.beforeEver A B) :
+theorem before_positive_inference {T : Type*} [LinearOrder T]
+    (A B : RunTimes T) (h : Anscombe.beforeEver A B) :
     ∃ t, t ∈ timeTrace A := by
   obtain ⟨t, ht, _⟩ := h; exact ⟨t, ht⟩
 
 /-- BEFORE entails temporal separation: the main-clause time strictly
     precedes all complement-clause times. When B is nonempty,
     p (at t) and ¬p (at any t' ∈ B) coexist — the dual inference. -/
-theorem before_temporal_separation {Time : Type*} [LinearOrder Time]
-    (A B : RunTimes Time) (h : Anscombe.beforeEver A B) :
+theorem before_temporal_separation {T : Type*} [LinearOrder T]
+    (A B : RunTimes T) (h : Anscombe.beforeEver A B) :
     ∃ t ∈ timeTrace A, ∀ t' ∈ timeTrace B, t < t' := h
 
 /-- BEFORE licenses EN because it maps to the temporal operator
@@ -885,8 +885,8 @@ theorem before_licensing :
 
 /-- Punctual UNTIL = ¬BEFORE (Karttunen): the negation of BEFORE
     surfaces as the complement-clause negator, which is exactly EN. -/
-theorem until_en_from_before_negation {Time : Type*} [LinearOrder Time]
-    (A B : RunTimes Time) :
+theorem until_en_from_before_negation {T : Type*} [LinearOrder T]
+    (A B : RunTimes T) :
     notUntil A B ↔ ¬ Anscombe.beforeEver A B := Iff.rfl
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Karttunen1974.lean
+++ b/Linglib/Studies/Karttunen1974.lean
@@ -31,7 +31,7 @@ namespace Karttunen1974
 
 open Tense Anscombe1964 Heinamaki1974
 
-variable {Time : Type*} [LinearOrder Time] (A B : RunTimes Time)
+variable {T : Type*} [LinearOrder T] (A B : RunTimes T)
 
 /-- Durative *A until B*: some run-time of `A` reaches a time of `B`. -/
 def until_ : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
@@ -53,7 +53,7 @@ theorem notUntil_iff : notUntil A B ↔ ∀ t ∈ timeTrace A, ∃ t' ∈ timeTr
 theorem not_notUntil_iff : ¬ notUntil A B ↔ Anscombe.beforeEver A B := not_not
 
 /-- The logical form holds of a clause that never happens. -/
-theorem notUntil_empty : notUntil (∅ : RunTimes Time) B :=
+theorem notUntil_empty : notUntil (∅ : RunTimes T) B :=
   fun ⟨_, ⟨_, hi, _⟩, _⟩ => hi
 
 /-- Disjunctive syllogism, (36): assertion and presupposition together yield *A when B*. -/
@@ -62,7 +62,7 @@ theorem notUntil_when (h : notUntil A B) (hp : presupposition A B) : when_ A B :
 
 /-- For point events under the presupposition, *A not until B* and *A when B* — the logical
 forms of Finnish *ennenkuin* and *vasta*, (39) — say the same. -/
-theorem notUntil_iff_when_of_presupposition (a b : Time)
+theorem notUntil_iff_when_of_presupposition (a b : T)
     (hp : presupposition {NonemptyInterval.pure a} {NonemptyInterval.pure b}) :
     notUntil {NonemptyInterval.pure a} {NonemptyInterval.pure b} ↔
       when_ {NonemptyInterval.pure a} {NonemptyInterval.pure b} := by

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -217,25 +217,25 @@ theorem worry_uniform_projection :
 -- § 4. Temporal Prediction from CausalSource
 -- ════════════════════════════════════════════════════
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- **Temporal derivation (external)**: any verb with external causal source
     predicts temporal precedence and a state transition (BECOME).
     The temporal behavior FOLLOWS from the causal source, not from
     per-verb stipulation. -/
 theorem external_predicts_precedence :
-    (CausalSource.toLink Time .external).temporalConstraint =
+    (CausalSource.toLink T .external).temporalConstraint =
       NonemptyInterval.precedes ∧
-    (CausalSource.toLink Time .external).involvesTransition = true :=
+    (CausalSource.toLink T .external).involvesTransition = true :=
   ⟨rfl, rfl⟩
 
 /-- **Temporal derivation (internal)**: any verb with internal causal source
     predicts temporal overlap and no state transition.
     Cause and effect coexist (maintenance relation). -/
 theorem internal_predicts_overlap :
-    (CausalSource.toLink Time .internal).temporalConstraint =
+    (CausalSource.toLink T .internal).temporalConstraint =
       NonemptyInterval.overlaps ∧
-    (CausalSource.toLink Time .internal).involvesTransition = false :=
+    (CausalSource.toLink T .internal).involvesTransition = false :=
   ⟨rfl, rfl⟩
 
 /-- **Per-verb temporal grounding**: frighten's fragment datum (external source)
@@ -243,18 +243,18 @@ theorem internal_predicts_overlap :
     would change the predictions. -/
 theorem frighten_temporal :
     frighten.causalSource = some .external ∧
-    (CausalSource.toLink Time .external).temporalConstraint =
+    (CausalSource.toLink T .external).temporalConstraint =
       NonemptyInterval.precedes ∧
-    (CausalSource.toLink Time .external).involvesTransition = true :=
+    (CausalSource.toLink T .external).involvesTransition = true :=
   ⟨rfl, rfl, rfl⟩
 
 /-- **Per-verb temporal grounding**: concern's internal source determines
     temporal overlap and no transition. -/
 theorem concern_temporal :
     concern.causalSource = some .internal ∧
-    (CausalSource.toLink Time .internal).temporalConstraint =
+    (CausalSource.toLink T .internal).temporalConstraint =
       NonemptyInterval.overlaps ∧
-    (CausalSource.toLink Time .internal).involvesTransition = false :=
+    (CausalSource.toLink T .internal).involvesTransition = false :=
   ⟨rfl, rfl, rfl⟩
 
 /-- **UPH at the causal link level**: eventive and stative Class II verbs
@@ -263,13 +263,13 @@ theorem concern_temporal :
     to argument structure. -/
 theorem uph_causal_link_level :
     -- Different temporal behavior
-    (CausalSource.toLink Time .external).temporalConstraint =
+    (CausalSource.toLink T .external).temporalConstraint =
       NonemptyInterval.precedes ∧
-    (CausalSource.toLink Time .internal).temporalConstraint =
+    (CausalSource.toLink T .internal).temporalConstraint =
       NonemptyInterval.overlaps ∧
     -- Different event structure
-    (CausalSource.toLink Time .external).involvesTransition = true ∧
-    (CausalSource.toLink Time .internal).involvesTransition = false :=
+    (CausalSource.toLink T .external).involvesTransition = true ∧
+    (CausalSource.toLink T .internal).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -89,24 +89,24 @@ inductive PerfectReading where
 /-- Existential reading: the PTS is right-bounded at R, and the event
     runtime is contained within the PTS.
     "I have visited Paris" — ∃ visiting event inside the PTS. -/
-def existentialReading {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (pts : NonemptyInterval Time)
-    (R : Time) : Prop :=
+def existentialReading {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (pts : NonemptyInterval T)
+    (R : T) : Prop :=
   pts.snd = R ∧ d.runtime ≤ pts
 
 /-- Universal reading: the PTS is right-bounded at R, and the PTS is
     contained within the event runtime (event ongoing throughout PTS).
     "I have lived here since 2010" — PTS ⊆ event runtime. -/
-def universalReading {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (pts : NonemptyInterval Time)
-    (R : Time) : Prop :=
+def universalReading {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (pts : NonemptyInterval T)
+    (R : T) : Prop :=
   pts.snd = R ∧ pts ≤ d.runtime
 
 /-- Resultative reading: the result phase contains R. Requires a complex
     decomposition (telic predicate with activity + result phases).
     "I have broken the vase" — result state holds at R. -/
-def resultativeReading {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (R : Time) : Prop :=
+def resultativeReading {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (R : T) : Prop :=
   match d with
   | .complex _ phases _ _ => R ∈ phases.resultTrace
   | .simple _ => False
@@ -114,8 +114,8 @@ def resultativeReading {Time : Type*} [LinearOrder Time]
 /-- Present-state reading: result phase contains R, activity is implicit
     (presupposed rather than asserted). Requires complex decomposition.
     "The road has widened" — result state observable at R. -/
-def presentStateReading {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (R : Time) : Prop :=
+def presentStateReading {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (R : T) : Prop :=
   match d with
   | .complex _ phases _ _ => R ∈ phases.resultTrace
   | .simple _ => False
@@ -151,8 +151,8 @@ theorem atelic_no_presentState (c : VendlerClass) (h : c.telicity = .atelic) :
 
 /-- The resultative reading requires a complex (telic) decomposition:
     simple decompositions make it trivially False. -/
-theorem resultative_requires_complex {Time : Type*} [LinearOrder Time]
-    (r : NonemptyInterval Time) (R : Time) :
+theorem resultative_requires_complex {T : Type*} [LinearOrder T]
+    (r : NonemptyInterval T) (R : T) :
     ¬ resultativeReading (.simple r) R := by
   simp [resultativeReading]
 
@@ -175,8 +175,8 @@ TODO: Full formalization requires formalizing P_sub anchoring rules (Kiparsky's
 /-- In the resultative reading of a present perfect, R includes P (= S for root).
     Since P is within the result phase, the embedded perspective is not past-shifted,
     and SOT does not apply. -/
-theorem resultative_no_sot_shift {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time) (d : TemporalDecomposition Time)
+theorem resultative_no_sot_shift {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T) (d : TemporalDecomposition T)
     (h_present : f.isPresent) (h_result : resultativeReading d f.referenceTime) :
     -- The result phase contains R (= P by h_present), so the embedded
     -- temporal perspective is anchored to "now", not to a past time.
@@ -196,8 +196,8 @@ and two readings (existential vs resultative) explain the ambiguity. -/
 
 /-- Present perfect with a past-time adverb: if R = P and the adverb forces
     R < P, we get a contradiction. -/
-theorem present_perfect_puzzle {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time)
+theorem present_perfect_puzzle {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T)
     (h_present : f.isPresent)
     (h_past_adverb : f.referenceTime < f.perspectiveTime) :
     False := by
@@ -205,8 +205,8 @@ theorem present_perfect_puzzle {Time : Type*} [LinearOrder Time]
   exact absurd (h_present ▸ h_past_adverb) (lt_irrefl _)
 
 /-- Past perfect allows past-time adverbs: R < P is consistent with isPast. -/
-theorem past_perfect_allows_adverbs {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time)
+theorem past_perfect_allows_adverbs {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T)
     (h_past : f.isPast)
     (h_perfect : f.isPerfect) :
     f.referenceTime < f.perspectiveTime ∧ f.eventTime < f.referenceTime :=
@@ -253,8 +253,8 @@ same compositional pipeline used by ViewpointAspect.lean. -/
     The PTS is right-bounded at R, and the full event runtime is
     contained within the PTS — exactly PRFV (runtime ⊆ PTS)
     composed with PERF (PTS ends at R). -/
-theorem existential_eq_perf_prfv {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (R : Time) :
+theorem existential_eq_perf_prfv {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (R : T) :
     (∃ pts, existentialReading d pts R) ↔
     PERF (PRFV (phasePred d.runtime)) ⟨(), R⟩ := by
   simp only [existentialReading, PERF, RB, PRFV, phasePred, Event.τ]
@@ -269,8 +269,8 @@ theorem existential_eq_perf_prfv {Time : Type*} [LinearOrder Time]
     The PTS is right-bounded at R, and the PTS is contained within
     the event runtime — exactly UNBOUNDED (PTS ⊆ runtime)
     composed with PERF (PTS ends at R). -/
-theorem universal_eq_perf_unbounded {Time : Type*} [LinearOrder Time]
-    (d : TemporalDecomposition Time) (R : Time) :
+theorem universal_eq_perf_unbounded {T : Type*} [LinearOrder T]
+    (d : TemporalDecomposition T) (R : T) :
     (∃ pts, universalReading d pts R) ↔
     PERF (UNBOUNDED (phasePred d.runtime)) ⟨(), R⟩ := by
   simp only [universalReading, PERF, RB, UNBOUNDED, phasePred, Event.τ]
@@ -286,11 +286,11 @@ theorem universal_eq_perf_unbounded {Time : Type*} [LinearOrder Time]
     event guarantees the result trace is within the reference time (by
     `perfective_full_entails_result`), but the reading itself depends
     only on R's position relative to the result phase. -/
-theorem resultative_from_result_contains {Time : Type*} [LinearOrder Time]
-    (rt : NonemptyInterval Time) (phases : SubeventPhases Time)
+theorem resultative_from_result_contains {T : Type*} [LinearOrder T]
+    (rt : NonemptyInterval T) (phases : SubeventPhases T)
     (h_act : phases.activityTrace ≤ rt)
     (h_res : phases.resultTrace ≤ rt)
-    (R : Time)
+    (R : T)
     (h_R_in_result : R ∈ phases.resultTrace) :
     resultativeReading (.complex rt phases h_act h_res) R :=
   h_R_in_result

--- a/Linglib/Studies/Klecha2016.lean
+++ b/Linglib/Studies/Klecha2016.lean
@@ -82,8 +82,8 @@ stipulated ULC. -/
 /-- Temporal constraint imposed by the modal base pronoun: DOX confines
 the embedded reference time to the actual history (RT ≤ EvalT, the Upper
 Limit Constraint), CIR to the future histories (RT > EvalT). -/
-def attitudeTemporalConstraint {Time : Type*} [LinearOrder Time]
-    (kind : ModalBaseKind) (evalTime refTime : Time) : Prop :=
+def attitudeTemporalConstraint {T : Type*} [LinearOrder T]
+    (kind : ModalBaseKind) (evalTime refTime : T) : Prop :=
   match kind with
   | .doxastic => isActualHistory evalTime refTime
   | .circumstantial => isFutureHistory evalTime refTime
@@ -91,37 +91,37 @@ def attitudeTemporalConstraint {Time : Type*} [LinearOrder Time]
 /-- Membership in `actualHistoryBase` derives the DOX constraint (35a):
 the ULC follows from the situation base rather than being stipulated. -/
 theorem attitudeTemporalConstraint_derived_doxastic
-    {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
-    (s s' : Intensional.Index W Time)
+    {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
+    (s s' : Intensional.Index W T)
     (h : s' ∈ actualHistoryBase history s) :
     attitudeTemporalConstraint .doxastic s.time s'.time :=
   actualHistoryBase_time_actual history s s' h
 
 /-- Membership in `futureHistoryBase` derives the CIR constraint (35b). -/
 theorem attitudeTemporalConstraint_derived_circumstantial
-    {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
-    (s s' : Intensional.Index W Time)
+    {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
+    (s s' : Intensional.Index W T)
     (h : s' ∈ futureHistoryBase history s) :
     attitudeTemporalConstraint .circumstantial s.time s'.time :=
   futureHistoryBase_time_future history s s' h
 
 /-- Past reference satisfies the DOX constraint. -/
-theorem dox_compatible_with_past {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) (hPast : refTime < evalTime) :
+theorem dox_compatible_with_past {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) (hPast : refTime < evalTime) :
     attitudeTemporalConstraint .doxastic evalTime refTime :=
   le_of_lt hPast
 
 /-- Future reference violates the DOX constraint. -/
-theorem dox_incompatible_with_future {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) (hFut : refTime > evalTime) :
+theorem dox_incompatible_with_future {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) (hFut : refTime > evalTime) :
     ¬ attitudeTemporalConstraint .doxastic evalTime refTime :=
   not_le.mpr hFut
 
 /-- Future reference satisfies the CIR constraint. -/
-theorem cir_compatible_with_future {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) (hFut : refTime > evalTime) :
+theorem cir_compatible_with_future {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) (hFut : refTime > evalTime) :
     attitudeTemporalConstraint .circumstantial evalTime refTime :=
   hFut
 
@@ -187,8 +187,8 @@ above. -/
     tense, the embedded reference time is strictly before the evaluation
     time. Both constraints are satisfiable, and their conjunction is just
     PAST (since RT < t implies RT ≤ t). -/
-theorem dox_past_iff {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) :
+theorem dox_past_iff {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) :
     attitudeTemporalConstraint .doxastic evalTime refTime ∧
     compare refTime evalTime ∈ Tense.past ↔
     refTime < evalTime := by
@@ -200,8 +200,8 @@ theorem dox_past_iff {Time : Type*} [LinearOrder Time]
     surface "past" morphology in "Martina hoped Carissa got pregnant"
     under the future-oriented (CIR) reading is SOT agreement over
     semantic NPST per [klecha-2016] §3.3, not semantic PAST. -/
-theorem cir_past_iff_false {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) :
+theorem cir_past_iff_false {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) :
     attitudeTemporalConstraint .circumstantial evalTime refTime ∧
     compare refTime evalTime ∈ Tense.past ↔ False := by
   simp only [Tense.compare_mem_past]
@@ -211,8 +211,8 @@ theorem cir_past_iff_false {Time : Type*} [LinearOrder Time]
     and non-past tense requires RT ≥ t. The conjunction forces RT = t.
     This is why "Martina thought Carissa was pregnant" with non-past
     (SOT-agreed) gives a simultaneous reading. -/
-theorem dox_npst_iff {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) :
+theorem dox_npst_iff {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) :
     attitudeTemporalConstraint .doxastic evalTime refTime ∧
     compare refTime evalTime ∈ Tense.nonpast ↔
     refTime = evalTime := by
@@ -224,8 +224,8 @@ theorem dox_npst_iff {Time : Type*} [LinearOrder Time]
     and non-past tense requires RT ≥ t. The conjunction is RT > t.
     This is why "Martina hoped Carissa got pregnant" with non-past
     (SOT-agreed) gives a future-oriented reading under CIR. -/
-theorem cir_npst_iff {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) :
+theorem cir_npst_iff {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) :
     attitudeTemporalConstraint .circumstantial evalTime refTime ∧
     compare refTime evalTime ∈ Tense.nonpast ↔
     refTime > evalTime := by
@@ -409,7 +409,7 @@ proposition:
   via `actualHistoryBase_time_actual : s' ∈ actualHistoryBase history s
   → s'.time ≤ s.time`, a `.2`-projection through the situation-base
   definition. The doxastic-alternative quantification is carried by
-  `HistoricalAlternatives W Time` membership.
+  `HistoricalAlternatives W T` membership.
 
 - **Abusch route** (in `Semantics/Tense/Embedding.lean`): the
   predicate is stated directly as `abbrev upperLimitConstraint
@@ -422,7 +422,7 @@ proposition:
 So the equivalence is strict at the value level. **It is *not* strict
 at the modal-layer level**: Klecha's substrate carries doxastic
 alternatives via `HistoricalAlternatives`; Abusch's bare-`≤` form has dropped
-them. A modal-layer `upperLimitConstraint` over `HistoricalAlternatives W Time`
+them. A modal-layer `upperLimitConstraint` over `HistoricalAlternatives W T`
 matching Abusch's original "now of an epistemic alternative" is
 deferred. -/
 
@@ -435,8 +435,8 @@ deferred. -/
     the implementation-level equality kernel-checked. The substantive
     spirit-level difference (derivation vs. stipulation) is recorded
     in §5b above and in the docstring. -/
-theorem klecha_dox_iff_abusch_ulc {Time : Type*} [LinearOrder Time]
-    (evalTime refTime : Time) :
+theorem klecha_dox_iff_abusch_ulc {T : Type*} [LinearOrder T]
+    (evalTime refTime : T) :
     attitudeTemporalConstraint .doxastic evalTime refTime ↔
     upperLimitConstraint refTime evalTime :=
   Iff.rfl

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -25,8 +25,8 @@ committed to the proposition (non-modal analysis, contra
 
 ## TODO
 
-* **Location field on `Event Time`**: △ is parameterized over an external
-  `loc : Event Time → L` because `Event Time` lacks a built-in location.
+* **Location field on `Event T`**: △ is parameterized over an external
+  `loc : Event T → L` because `Event T` lacks a built-in location.
   Extending the core event type would affect ~20 files. Until then,
   spatial-distance reasoning takes `loc` as a parameter at use sites.
 * **Learning event `e_l` ontology**: Koev's deepest contribution (74b) is
@@ -195,28 +195,28 @@ open Bulgarian.Evidentials
     they occur at different locations (smoke-from-chimney scenario).
     Inlined from former `Semantics/Events/SpatiotemporalDistance.lean`
     — single-consumer (this file) substrate, paper-anchored entirely on
-    Koev 2017. Architectural note: `Event Time` lacks a built-in location
-    field, so △ is parameterized by an external `loc : Event Time → L`. -/
+    Koev 2017. Architectural note: `Event T` lacks a built-in location
+    field, so △ is parameterized by an external `loc : Event T → L`. -/
 
 /-- Two events are temporally disjoint when their temporal traces do not
     overlap (Koev 2017, first disjunct of Def. 24). -/
-def temporallyDisjoint {Time : Type*} [LinearOrder Time]
-    (e₁ e₂ : Event Time) : Prop :=
+def temporallyDisjoint {T : Type*} [LinearOrder T]
+    (e₁ e₂ : Event T) : Prop :=
   ¬ (e₁.τ.overlaps e₂.τ)
 
 /-- Spatiotemporal distance △ (Koev 2017, Def. 24). Two events are
     spatiotemporally distant if either their temporal traces don't
     overlap or they occur at different locations. -/
-def spatiotemporallyDistant {Time : Type*} [LinearOrder Time]
+def spatiotemporallyDistant {T : Type*} [LinearOrder T]
     {L : Type*} [DecidableEq L]
-    (loc : Event Time → L) (e₁ e₂ : Event Time) : Prop :=
+    (loc : Event T → L) (e₁ e₂ : Event T) : Prop :=
   temporallyDisjoint e₁ e₂ ∨ loc e₁ ≠ loc e₂
 
 /-- If e₁ temporally precedes e₂, they are temporally disjoint
     (standard indirect evidence: described event finished before
     learning event started). -/
-theorem temporallyDisjoint_of_precedes {Time : Type*} [LinearOrder Time]
-    (e₁ e₂ : Event Time)
+theorem temporallyDisjoint_of_precedes {T : Type*} [LinearOrder T]
+    (e₁ e₂ : Event T)
     (h : e₁.τ.precedes e₂.τ) : temporallyDisjoint e₁ e₂ := by
   unfold temporallyDisjoint NonemptyInterval.overlaps NonemptyInterval.precedes at *
   simp only [Event.τ] at *
@@ -225,8 +225,8 @@ theorem temporallyDisjoint_of_precedes {Time : Type*} [LinearOrder Time]
 /-- If two events are temporally disjoint and the first starts no later
     than the second, then the first is temporally before the second:
     bridges Koev's event-based △ to Cumming's point-based T ≤ A. -/
-theorem disjoint_earlier_implies_isBefore {Time : Type*} [LinearOrder Time]
-    (e₁ e₂ : Event Time)
+theorem disjoint_earlier_implies_isBefore {T : Type*} [LinearOrder T]
+    (e₁ e₂ : Event T)
     (hd : temporallyDisjoint e₁ e₂)
     (hearlier : e₁.τ.fst ≤ e₂.τ.fst) : e₁.τ.isBefore e₂.τ := by
   unfold temporallyDisjoint NonemptyInterval.overlaps at hd
@@ -237,22 +237,22 @@ theorem disjoint_earlier_implies_isBefore {Time : Type*} [LinearOrder Time]
   exact hd ⟨le_trans hearlier e₂.runtime.fst_le_snd, le_of_lt h⟩
 
 /-- Overlapping runtimes are incompatible with temporal distance. -/
-theorem overlapping_not_disjoint {Time : Type*} [LinearOrder Time]
-    (e₁ e₂ : Event Time)
+theorem overlapping_not_disjoint {T : Type*} [LinearOrder T]
+    (e₁ e₂ : Event T)
     (h : e₁.τ.overlaps e₂.τ) : ¬ temporallyDisjoint e₁ e₂ :=
   fun hd => hd h
 
 /-- Spatial distance alone suffices for △ (Koev 2017, ex. 25b). -/
 theorem spatiotemporallyDistant_of_different_location
-    {Time : Type*} [LinearOrder Time] {L : Type*} [DecidableEq L]
-    (loc : Event Time → L) (e₁ e₂ : Event Time)
+    {T : Type*} [LinearOrder T] {L : Type*} [DecidableEq L]
+    (loc : Event T → L) (e₁ e₂ : Event T)
     (h : loc e₁ ≠ loc e₂) : spatiotemporallyDistant loc e₁ e₂ :=
   Or.inr h
 
 /-- Temporal disjointness alone suffices for △. -/
 theorem spatiotemporallyDistant_of_temporallyDisjoint
-    {Time : Type*} [LinearOrder Time] {L : Type*} [DecidableEq L]
-    (loc : Event Time → L) (e₁ e₂ : Event Time)
+    {T : Type*} [LinearOrder T] {L : Type*} [DecidableEq L]
+    (loc : Event T → L) (e₁ e₂ : Event T)
     (h : temporallyDisjoint e₁ e₂) : spatiotemporallyDistant loc e₁ e₂ :=
   Or.inl h
 
@@ -302,23 +302,23 @@ theorem spatiotemporallyDistant_of_temporallyDisjoint
     - **Evidence source typology**: The paper distinguishes reportative,
       inferential, and assumptive evidence (§5) via different learn
       predicates. We collapse these into a single △ constraint. -/
-structure LearningScenario (Time : Type*) [LinearOrder Time] where
+structure LearningScenario (T : Type*) [LinearOrder T] where
   /-- The described event (what happened: e.g., Ivan kissing Maria) -/
-  described : Event Time
+  described : Event T
   /-- The learning event (how the speaker found out: e.g., hearing a report) -/
-  learning : Event Time
+  learning : Event T
 
 /-- △ holds for this scenario (temporal component): the described and
     learning events have non-overlapping temporal traces. -/
-def LearningScenario.isTemporallyDisjoint {Time : Type*} [LinearOrder Time]
-    (s : LearningScenario Time) : Prop :=
+def LearningScenario.isTemporallyDisjoint {T : Type*} [LinearOrder T]
+    (s : LearningScenario T) : Prop :=
   temporallyDisjoint s.described s.learning
 
 /-- △ holds for this scenario (full spatiotemporal version): temporal
     disjointness OR spatial distance. -/
-def LearningScenario.isSpatiotemporallyDistant {Time : Type*} [LinearOrder Time]
-    {L : Type*} [DecidableEq L] (loc : Event Time → L)
-    (s : LearningScenario Time) : Prop :=
+def LearningScenario.isSpatiotemporallyDistant {T : Type*} [LinearOrder T]
+    {L : Type*} [DecidableEq L] (loc : Event T → L)
+    (s : LearningScenario T) : Prop :=
   spatiotemporallyDistant loc s.described s.learning
 
 /-- Computable temporal △ for ℤ events: ¬(τ(e) overlaps τ(e_l)).

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -151,8 +151,8 @@ end KratzerChain
     they differ in mechanism (deletion of a genuine PAST vs a bound zero
     PRESENT — see `Ogihara1996.PastReading` for the typed
     mechanism-level divergence). -/
-theorem deletion_agrees_with_zero_tense_binding {Time : Type*}
-    (m : ReichenbachFrame Time) :
+theorem deletion_agrees_with_zero_tense_binding {T : Type*}
+    (m : ReichenbachFrame T) :
     applyDeletion m = Tense.simultaneousFrame m m.eventTime ∧
     (applyDeletion m).isPresent :=
   ⟨applyDeletion_eq_simultaneousFrame m, applyDeletion_isPresent m⟩

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -22,7 +22,7 @@ This file inlines the §4 movement-relation predicates (formerly in
 * `IsInitialPart` / `IsFinalPart` / `IsTelic` — K98 §2.5 telicity, with
   `isTelic_of_qua` the `QUA → TEL` direction.
 * `EXP` / `SEINC` / `ADJ` / `SMR` / `MovementClosure` / `MR` — K98 §4 movement
-  substrate (TANG_H-free), with `mr_of_smr` and the `Event Time` instantiations
+  substrate (TANG_H-free), with `mr_of_smr` and the `Event T` instantiations
   `expEv` / `seincEv` / `smrPath` / `mrPath`.
 
 ## Main statements
@@ -257,9 +257,9 @@ section SpatialTracePullback
 
 open Spatial
 
-variable {Loc Time : Type*} [LinearOrder Time]
-variable [Event.Mereology Time] [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
-variable [st : Trace Loc Time]
+variable {Loc T : Type*} [LinearOrder T]
+variable [Event.Mereology T] [ClassicalMereology (Event T)] [SemilatticeSup (Path Loc)]
+variable [st : Trace Loc T]
 
 /-- Bounded path (QUA) ↦ telic VP via the σ-pullback (K98 §4.5 *walked from X to Y*). -/
 theorem walked_from_to_telic_propositional
@@ -320,41 +320,41 @@ theorem pathType_telicity_matches_motionData :
 
 end MotionData
 
-/-! ### EXP / SEINC instances on `Event Time` (K98 §4.1) -/
+/-! ### EXP / SEINC instances on `Event T` (K98 §4.1) -/
 
 section Expansiveness
 
-variable [SemilatticeSup α] {Time : Type*} [LinearOrder Time]
+variable [SemilatticeSup α] {T : Type*} [LinearOrder T]
 
-/-- EXP-as-property of any θ : α → Event Time → Prop using `Event.precedes`. -/
-abbrev expEv (θ : α → Event Time → Prop) : Prop :=
-  EXP (Event.precedes (Time := Time)) θ
+/-- EXP-as-property of any θ : α → Event T → Prop using `Event.precedes`. -/
+abbrev expEv (θ : α → Event T → Prop) : Prop :=
+  EXP (Event.precedes (T := T)) θ
 
-/-- SEINC-as-property of θ over `Event Time` using `Event.precedes`. -/
-abbrev seincEv [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    (θ : α → Event Time → Prop) : Prop :=
-  SEINC (Event.precedes (Time := Time)) θ
+/-- SEINC-as-property of θ over `Event T` using `Event.precedes`. -/
+abbrev seincEv [Event.Mereology T] [ClassicalMereology (Event T)]
+    (θ : α → Event T → Prop) : Prop :=
+  SEINC (Event.precedes (T := T)) θ
 
 end Expansiveness
 
-/-! ### SMR / MR instances on `Path Loc → Event Time → Prop` (K98 §4.2-4.3) -/
+/-! ### SMR / MR instances on `Path Loc → Event T → Prop` (K98 §4.2-4.3) -/
 
 section MovementInstances
 
 open Spatial
 
-variable {Loc Time : Type*} [LinearOrder Time]
-variable [Event.Mereology Time] [ClassicalMereology (Event Time)]
+variable {Loc T : Type*} [LinearOrder T]
+variable [Event.Mereology T] [ClassicalMereology (Event T)]
 variable [SemilatticeSup (Path Loc)]
 
 /-- SMR specialized to paths and events with concrete adjacency. -/
-abbrev smrPath (θ : Path Loc → Event Time → Prop) : Prop :=
-  SMR Path.adjacent (Event.adjacent (Time := Time))
+abbrev smrPath (θ : Path Loc → Event T → Prop) : Prop :=
+  SMR Path.adjacent (Event.adjacent (T := T))
     (fun _ : Path Loc => True) θ
 
 /-- MR specialized to paths and events with concrete adjacency + precedence. -/
-abbrev mrPath (θ : Path Loc → Event Time → Prop) : Prop :=
-  MR Path.adjacent (Event.adjacent (Time := Time)) (Event.precedes (Time := Time))
+abbrev mrPath (θ : Path Loc → Event T → Prop) : Prop :=
+  MR Path.adjacent (Event.adjacent (T := T)) (Event.precedes (T := T))
     (fun _ : Path Loc => True) θ
 
 end MovementInstances

--- a/Linglib/Studies/Lakoff1970.lean
+++ b/Linglib/Studies/Lakoff1970.lean
@@ -223,13 +223,13 @@ open Tense
     orthogonal to the evidential constraint: "false past" arises
     even when evidence is downstream (the chipmunk is still there, so
     T ≤ A holds) because the event has lost psychological salience. -/
-structure TensePerspective (Time : Type*) extends EvidentialFrame Time where
+structure TensePerspective (T : Type*) extends EvidentialFrame T where
   /-- Is the event psychologically salient to the speaker at S? -/
   speakerSalience : Bool
   /-- Is the propositional content new to the hearer? -/
   hearerNovelty : Bool
 
-variable {Time : Type*}
+variable {T : Type*}
 
 /-- **False tense** (Lakoff §1): past (or future) morphology applied to a
     present-time event because the speaker does not find it salient.
@@ -238,25 +238,25 @@ variable {Time : Type*}
     Future example: "That thing WILL be a chipmunk" (it already IS one).
     The licensing condition is the same for both; the surface-form
     divergence is recorded in the perspective entries (`formType`). -/
-def falsePast (f : TensePerspective Time) : Prop :=
+def falsePast (f : TensePerspective T) : Prop :=
   f.eventTime = f.speechTime ∧ ¬(f.speakerSalience = true)
 
 /-- **Novel-information present** (Lakoff §2): present tense survives under
     a past-tense matrix verb because the embedded content is new to the
     hearer ("He discovered that the boy HAS blue eyes"). -/
-def novelInfoPresent (f : TensePerspective Time) : Prop :=
+def novelInfoPresent (f : TensePerspective T) : Prop :=
   f.hearerNovelty = true ∧ f.eventTime = f.speechTime
 
 /-- **Perfect requires salience** (Lakoff §4): the present perfect is
     infelicitous when the event lacks current relevance to the speaker
     (*"Shakespeare has quarreled with Bacon"). -/
-def perfectRequiresSalience (f : TensePerspective Time) : Prop :=
+def perfectRequiresSalience (f : TensePerspective T) : Prop :=
   f.speakerSalience = true
 
 /-- **Will-deletion** (Lakoff §5): future-time events can appear in present
     tense (deleting *will*) when the speaker treats them as salient and
     scheduled ("The meeting starts at 3"). -/
-def willDeletion [LT Time] (f : TensePerspective Time) : Prop :=
+def willDeletion [LT T] (f : TensePerspective T) : Prop :=
   f.speechTime < f.eventTime ∧ f.speakerSalience = true
 
 /-- Classify a tense use as true (grammatical tense matches the temporal
@@ -268,8 +268,8 @@ def willDeletion [LT Time] (f : TensePerspective Time) : Prop :=
     (`compare f.eventTime f.speechTime ∈ gramTense`), reproducing the four-way
     past/present/future/nonpast table (`past`: `E < S`; `present`: `E = S`;
     `future`: `S < E`; `nonpast`: `S ≤ E`). -/
-def classifyUse [LinearOrder Time] (gramTense : Finset Ordering)
-    (f : TensePerspective Time) : TenseUseType :=
+def classifyUse [LinearOrder T] (gramTense : Finset Ordering)
+    (f : TensePerspective T) : TenseUseType :=
   if compare f.eventTime f.speechTime ∈ gramTense then .trueTense else .falseTense
 
 /-- **Periphrastic forms block false tense** (Lakoff §1, ex. 8a vs 9a):
@@ -368,7 +368,7 @@ theorem simplePast_entry_allows_false :
 
 /-- A false past is temporally present — the mismatch is purely
     psychological (salience), not temporal. -/
-theorem false_past_is_temporally_present (f : TensePerspective Time)
+theorem false_past_is_temporally_present (f : TensePerspective T)
     (h : falsePast f) :
     f.eventTime = f.speechTime :=
   h.1
@@ -380,8 +380,8 @@ theorem false_past_satisfies_up_present (f : TensePerspective ℤ)
     UPCondition.present.toConstraint f.toEvidentialFrame :=
   h.1
 
-theorem false_past_classified_correctly [LinearOrder Time]
-    (f : TensePerspective Time) (h : falsePast f) :
+theorem false_past_classified_correctly [LinearOrder T]
+    (f : TensePerspective T) (h : falsePast f) :
     classifyUse Tense.past f = .falseTense := by
   simp only [classifyUse, Tense.compare_mem_past]
   exact if_neg (by rw [h.1]; exact lt_irrefl _)

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -65,11 +65,11 @@ Structure ([mendes-2025] §3.2):
 This is the compositional derivation:
 ⟦SF⟧ = ⟦SUBJ⟧ ∘ ⟦FUT⟧
 -/
-def subordinateFuture {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+def subordinateFuture {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (newSitVar : ℕ)   -- Fresh variable for introduced situation
     (refSitVar : ℕ)   -- Variable for reference situation
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   -- First apply SUBJ to introduce s₁
   let c' := dynSUBJ history newSitVar c
   -- Then constrain τ(s₁) > τ(s₀)
@@ -84,13 +84,13 @@ Conditional with SF antecedent (dynamic version).
 2. Antecedent predicate evaluated at s₁
 3. Consequent: temporally anchored to s₁ (future relative to s₀)
 -/
-def conditionalWithSF {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+def conditionalWithSF {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (antecedentVar : ℕ)  -- Situation introduced by SF
     (speechVar : ℕ)      -- Speech time situation
-    (antecedent : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))  -- "Maria is home"
-    (consequent : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))  -- "she answers"
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (antecedent : Set (Index.Possibility W T) → Set (Index.Possibility W T))  -- "Maria is home"
+    (consequent : Set (Index.Possibility W T) → Set (Index.Possibility W T))  -- "she answers"
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   -- Apply SF to introduce antecedent situation
   let c₁ := subordinateFuture history antecedentVar speechVar c
   -- Filter by antecedent
@@ -109,11 +109,11 @@ Structure:
 2. Restrictor (boy ∧ awake) evaluated at s₁
 3. Nuclear scope (get cookie) evaluated with temporal anchor from s₁
 -/
-def relativeClauseSF {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+def relativeClauseSF {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (rcVar : ℕ)           -- Situation variable for relative clause
     (speechVar : ℕ)       -- Speech time situation
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   subordinateFuture history rcVar speechVar c
 
 /--
@@ -127,12 +127,12 @@ The SF in the restrictor:
 2. Quantification over books is relativized to s₁
 3. Nuclear scope inherits temporal anchor from s₁
 -/
-def everyWithSFRestrictor {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+def everyWithSFRestrictor {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (rcVar speechVar : ℕ)
-    (restrictor : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))  -- "book that M reads"
-    (nuclear : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))     -- "is interesting"
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (restrictor : Set (Index.Possibility W T) → Set (Index.Possibility W T))  -- "book that M reads"
+    (nuclear : Set (Index.Possibility W T) → Set (Index.Possibility W T))     -- "is interesting"
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   -- First: SF introduces situation for restrictor
   let c₁ := subordinateFuture history rcVar speechVar c
   -- Then: Filter by restrictor content
@@ -150,11 +150,11 @@ SF introduces a future situation.
 
 The subordinate future always introduces a situation with time ≥ current.
 -/
-theorem sf_introduces_future {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+theorem sf_introduces_future {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (newVar refVar : ℕ)
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ subordinateFuture history newVar refVar c) :
     (gs.assignment newVar).time ≥ (gs.assignment refVar).time := by
   -- The subordinateFuture composes SUBJ and FUT
@@ -178,17 +178,17 @@ The temporal shift is *derived* from the modal semantics, not stipulated.
 Modal donkey anaphora explains
 why subjunctive mood enables future reference in subordinate clauses.
 -/
-theorem temporal_shift_parasitic_on_modal {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+theorem temporal_shift_parasitic_on_modal {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time))
+    (c : Set (Index.Possibility W T))
     -- For any situation in the output of SF application...
-    (gs : Index.Possibility W Time)
+    (gs : Index.Possibility W T)
     (h : gs ∈ subordinateFuture history sfVar speechVar c)
     -- ...there exists an original speech situation...
-    : ∃ (g₀ : Assignment (Index W Time)) (s₀ : Index W Time),
+    : ∃ (g₀ : Assignment (Index W T)) (s₀ : Index W T),
         -- ...that was in the input context...
-        (⟨s₀, g₀⟩ : Index.Possibility W Time) ∈ c ∧
+        (⟨s₀, g₀⟩ : Index.Possibility W T) ∈ c ∧
         -- ...and the temporal shift comes from SUBJ's modal component:
         -- 1. The bound situation s₁ is in the historical base of s₀
         (gs.assignment sfVar) ∈ historicalBase history s₀ ∧
@@ -227,12 +227,12 @@ With SF in the relative clause, "every" can quantify over future entities.
 Restrictor and nuclear must be context filters (`IsEliminative`).
 Linguistically, predicates filter contexts without modifying assignments.
 -/
-theorem sf_restrictor_future_reference {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+theorem sf_restrictor_future_reference {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     (rcVar speechVar : ℕ)
-    (restrictor nuclear : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (restrictor nuclear : Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ everyWithSFRestrictor history rcVar speechVar restrictor nuclear c)
     (hR : IsEliminative restrictor) (hN : IsEliminative nuclear) :
     -- The restrictor situation can be future relative to speech time
@@ -250,16 +250,16 @@ theorem sf_restrictor_future_reference {W Time : Type*} [LinearOrder Time]
 -- § 3. Compositional CDRT Derivations (§4.3.1)
 -- ════════════════════════════════════════════════════════════════
 
-variable {W Time E : Type*} [LinearOrder Time]
-variable (history : HistoricalAlternatives W Time)
+variable {W T E : Type*} [LinearOrder T]
+variable (history : HistoricalAlternatives W T)
 
 /--
 Maria — proper name.
 `⟦Maria⟧ = λP.P(maria)`
 -/
 def lexMaria (maria : E)
-    (P : E → Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (P : E → Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   P maria c
 
 /--
@@ -267,10 +267,10 @@ estar em casa — "be at home".
 `⟦estar em casa⟧ = λxλsλc. [| at-home(x)(s)]; c`
 -/
 def lexAtHome
-    (atHomeRel : E → Index W Time → Prop)
+    (atHomeRel : E → Index W T → Prop)
     (x : E)
     (sitVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   { gs ∈ c | atHomeRel x (gs.assignment sitVar) }
 
 /--
@@ -278,25 +278,25 @@ atender — "answer (the door)".
 `⟦atender⟧ = λxλsλc. [| answer(x)(s)]; c`
 -/
 def lexAnswer
-    (answerRel : E → Index W Time → Prop)
+    (answerRel : E → Index W T → Prop)
     (x : E)
     (sitVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   { gs ∈ c | answerRel x (gs.assignment sitVar) }
 
 /--
 SF (Subordinate Future).
 `⟦SF⟧ = SUBJ ∘ FUT`
 -/
-def lexSF := @subordinateFuture W Time _
+def lexSF := @subordinateFuture W T _
 
 /--
 ela — "she" (pronoun bound to Maria).
 `⟦ela⟧ = λP.P(maria)`
 -/
 def lexShe (maria : E)
-    (P : E → Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (P : E → Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   P maria c
 
 /--
@@ -305,9 +305,9 @@ vai — future auxiliary "will".
 via modal anaphora.
 -/
 def lexWill
-    (VP : ℕ → Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
+    (VP : ℕ → Set (Index.Possibility W T) → Set (Index.Possibility W T))
     (sitVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   VP sitVar c
 
 /--
@@ -321,8 +321,8 @@ force comes from SUBJ's quantification over historical alternatives, not
 from the conditional operator itself.
 -/
 def seqUpdate
-    (antecedent consequent : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (antecedent consequent : Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   consequent (antecedent c)
 
 
@@ -334,9 +334,9 @@ Introduces s₁ ∈ hist(s₀), constrains τ(s₁) > τ(s₀), asserts Maria at
 -/
 def deriveAntecedent
     (maria : E)
-    (atHomeRel : E → Index W Time → Prop)
+    (atHomeRel : E → Index W T → Prop)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   let c₁ := lexSF history sfVar speechVar c
   lexAtHome atHomeRel maria sfVar c₁
 
@@ -346,9 +346,9 @@ Consequent derivation:
 -/
 def deriveConsequent
     (maria : E)
-    (answerRel : E → Index W Time → Prop)
+    (answerRel : E → Index W T → Prop)
     (sfVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   let c₁ := dynIND sfVar c
   lexAnswer answerRel maria sfVar c₁
 
@@ -358,9 +358,9 @@ Full sentence derivation:
 -/
 def deriveFullSentence
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   let antecedent := deriveAntecedent history maria atHomeRel sfVar speechVar
   let consequent := deriveConsequent maria answerRel sfVar
   seqUpdate antecedent consequent c
@@ -371,12 +371,12 @@ The situation introduced by SF is in the historical alternatives.
 -/
 theorem derivation_in_historical_base
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ deriveFullSentence history maria atHomeRel answerRel sfVar speechVar c) :
-    ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W Time) ∈ c) ∧
+    ∃ s₀, (∃ g₀, (⟨s₀, g₀⟩ : Index.Possibility W T) ∈ c) ∧
           (gs.assignment sfVar) ∈ historicalBase history s₀ := by
   unfold deriveFullSentence seqUpdate at h
   unfold deriveConsequent lexAnswer at h
@@ -403,10 +403,10 @@ The derivation enforces future ordering: τ(s₁) > τ(s₀).
 -/
 theorem derivation_future_ordering
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ deriveFullSentence history maria atHomeRel answerRel sfVar speechVar c) :
     (gs.assignment sfVar).time > (gs.assignment speechVar).time := by
   unfold deriveFullSentence seqUpdate at h
@@ -425,10 +425,10 @@ If Maria is at home at s₁, she answers at s₁.
 -/
 theorem derivation_conditional_holds
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (sfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ deriveFullSentence history maria atHomeRel answerRel sfVar speechVar c) :
     atHomeRel maria (gs.assignment sfVar) → answerRel maria (gs.assignment sfVar) := by
   intro _
@@ -445,9 +445,9 @@ Uses SUBJ without FUT — allows past/present alternatives.
 -/
 def deriveCounterfactual
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (cfVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   let c₁ := dynSUBJ history cfVar c
   let c₂ := lexAtHome atHomeRel maria cfVar c₁
   let c₃ := dynIND cfVar c₂
@@ -456,13 +456,13 @@ def deriveCounterfactual
 /--
 SF constrains to future; counterfactual allows past/present.
 -/
-theorem sf_vs_counterfactual_temporal {W Time : Type*} [LinearOrder Time]
-    (history : HistoricalAlternatives W Time)
+theorem sf_vs_counterfactual_temporal {W T : Type*} [LinearOrder T]
+    (history : HistoricalAlternatives W T)
     {E : Type*}
     (maria : E)
-    (atHomeRel answerRel : E → Index W Time → Prop)
+    (atHomeRel answerRel : E → Index W T → Prop)
     (sitVar speechVar : ℕ)
-    (c : Set (Index.Possibility W Time)) :
+    (c : Set (Index.Possibility W T)) :
     ∀ gs ∈ deriveFullSentence history maria atHomeRel answerRel sitVar speechVar c,
       (gs.assignment sitVar).time > (gs.assignment speechVar).time :=
   derivation_future_ordering history maria atHomeRel answerRel sitVar speechVar c
@@ -495,26 +495,26 @@ def existentialPresup {W E : Type*}
 Indicative restrictor: evaluates at the actual world.
 "Every book that Maria reads.IND..." → presupposes books exist that Maria reads.
 -/
-def indicativeRestrictor {W Time E : Type*}
-    (restrictor : E → Index W Time → Prop)
-    (s : Index W Time) : E → Prop :=
+def indicativeRestrictor {W T E : Type*}
+    (restrictor : E → Index W T → Prop)
+    (s : Index W T) : E → Prop :=
   λ x => restrictor x s
 
 /--
 SF restrictor: quantifies over historical alternatives.
 "Every book that Maria reads.SF..." → no categorical existence presupposition.
 -/
-def sfRestrictor {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor : E → Index W Time → Prop)
-    (s₀ : Index W Time) : E → Prop :=
+def sfRestrictor {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor : E → Index W T → Prop)
+    (s₀ : Index W T) : E → Prop :=
   λ x => ∃ s₁ ∈ historicalBase history s₀, restrictor x s₁
 
 
 /-- Indicative preserves existential presupposition. -/
-theorem indicative_preserves_presup {W Time E : Type*}
-    (restrictor : E → Index W Time → Prop)
-    (s : Index W Time)
+theorem indicative_preserves_presup {W T E : Type*}
+    (restrictor : E → Index W T → Prop)
+    (s : Index W T)
     (h_presup : ∃ x, indicativeRestrictor restrictor s x) :
     ∃ x, restrictor x s := by
   obtain ⟨x, hx⟩ := h_presup
@@ -524,10 +524,10 @@ theorem indicative_preserves_presup {W Time E : Type*}
 SF weakens existential presupposition: even without actual existence at s₀,
 the SF restrictor can be satisfied in alternative situations.
 -/
-theorem sf_weakens_presup {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor : E → Index W Time → Prop)
-    (s₀ : Index W Time)
+theorem sf_weakens_presup {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor : E → Index W T → Prop)
+    (s₀ : Index W T)
     (h_no_actual : ¬∃ x, restrictor x s₀)
     (h_possible : ∃ s₁ ∈ historicalBase history s₀, ∃ x, restrictor x s₁) :
     ∃ x, sfRestrictor history restrictor s₀ x := by
@@ -539,10 +539,10 @@ theorem sf_weakens_presup {W Time E : Type*} [LE Time]
 /--
 SF makes strong quantifiers felicitous under uncertainty.
 -/
-theorem sf_felicitous_under_uncertainty {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor : E → Index W Time → Prop)
-    (s₀ : Index W Time)
+theorem sf_felicitous_under_uncertainty {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor : E → Index W T → Prop)
+    (s₀ : Index W T)
     (h_uncertainty : (∃ s₁ ∈ historicalBase history s₀, ∃ x, restrictor x s₁) ∧
                      (∃ s₂ ∈ historicalBase history s₀, ¬∃ x, restrictor x s₂)) :
     (∃ x, sfRestrictor history restrictor s₀ x) ∧
@@ -559,17 +559,17 @@ theorem sf_felicitous_under_uncertainty {W Time E : Type*} [LE Time]
 Relative clause with SF weakens strong quantifier presupposition.
 This is the formal version of the indicative-vs-SF contrast in restrictors.
 -/
-def relClauseSF {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (noun : E → Index W Time → Prop)
-    (relClause : E → Index W Time → Prop)
-    (s₀ : Index W Time) : E → Prop :=
+def relClauseSF {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (noun : E → Index W T → Prop)
+    (relClause : E → Index W T → Prop)
+    (s₀ : Index W T) : E → Prop :=
   λ x => ∃ s₁ ∈ historicalBase history s₀, noun x s₁ ∧ relClause x s₁
 
-theorem relClause_sf_weakens_quantifier {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (noun relClause : E → Index W Time → Prop)
-    (s₀ : Index W Time)
+theorem relClause_sf_weakens_quantifier {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (noun relClause : E → Index W T → Prop)
+    (s₀ : Index W T)
     (h_none_actual : ¬∃ x, noun x s₀ ∧ relClause x s₀)
     (h_some_possible : ∃ s₁ ∈ historicalBase history s₀, ∃ x, noun x s₁ ∧ relClause x s₁) :
     ∃ x, relClauseSF history noun relClause s₀ x := by
@@ -582,10 +582,10 @@ theorem relClause_sf_weakens_quantifier {W Time E : Type*} [LE Time]
 Modal displacement: SF introduces quantification over situations,
 "displacing" the existential presupposition to be local within each situation.
 -/
-def modalDisplacement {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor nuclear : E → Index W Time → Prop)
-    (s₀ : Index W Time) : Prop :=
+def modalDisplacement {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor nuclear : E → Index W T → Prop)
+    (s₀ : Index W T) : Prop :=
   ∀ s₁ ∈ historicalBase history s₀,
     (∃ x, restrictor x s₁) →
     ∀ x, restrictor x s₁ → nuclear x s₁
@@ -593,10 +593,10 @@ def modalDisplacement {W Time E : Type*} [LE Time]
 /--
 SF semantics is equivalent to modal displacement.
 -/
-theorem sf_is_modal_displacement {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor nuclear : E → Index W Time → Prop)
-    (s₀ : Index W Time) :
+theorem sf_is_modal_displacement {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor nuclear : E → Index W T → Prop)
+    (s₀ : Index W T) :
     modalDisplacement history restrictor nuclear s₀ ↔
     ∀ s₁ ∈ historicalBase history s₀,
       ∀ x, restrictor x s₁ → nuclear x s₁ := by
@@ -612,10 +612,10 @@ theorem sf_is_modal_displacement {W Time E : Type*} [LE Time]
 /--
 Modal displacement is weaker than global accommodation.
 -/
-theorem modal_displacement_weaker_than_accommodation {W Time E : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
-    (restrictor : E → Index W Time → Prop)
-    (s₀ : Index W Time)
+theorem modal_displacement_weaker_than_accommodation {W T E : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
+    (restrictor : E → Index W T → Prop)
+    (s₀ : Index W T)
     (h_global : ∀ s₁ ∈ historicalBase history s₀, ∃ x, restrictor x s₁)
     (h_nonempty : ∃ s, s ∈ historicalBase history s₀) :
     ∃ s₁ ∈ historicalBase history s₀, ∃ x, restrictor x s₁ := by
@@ -656,10 +656,10 @@ Example:
   "Se Maria estiver em casa, ela vai atender."
        ↑ SUBJ introduces s₁ ↑ IND retrieves s₁
 -/
-def crossClausalBinding {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+def crossClausalBinding {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (antecedentVar _consequentVar : ℕ)
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   dynIND antecedentVar (dynSUBJ history antecedentVar c)
 
 /--
@@ -667,11 +667,11 @@ Cross-clausal binding preserves world identity: when a situation is
 introduced in the antecedent and retrieved in the consequent, the two
 clauses are evaluated at the same world.
 -/
-theorem cross_clausal_same_world {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+theorem cross_clausal_same_world {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ crossClausalBinding history v v c) :
     gs.world.world = (gs.assignment v).world := by
   unfold crossClausalBinding at h
@@ -682,12 +682,12 @@ The SUBJ-IND anaphoric chain: SUBJ introduces `s₁`, the antecedent
 predicate filters at `s₁`, IND retrieves `s₁` (same-world check), and
 the consequent inherits the temporal anchor from `s₁`.
 -/
-def subjIndChain {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+def subjIndChain {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (antecedentPred : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (consequentPred : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time)) : Set (Index.Possibility W Time) :=
+    (antecedentPred : Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (consequentPred : Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T)) : Set (Index.Possibility W T) :=
   consequentPred (dynIND v (antecedentPred (dynSUBJ history v c)))
 
 /--
@@ -697,12 +697,12 @@ is evaluated at a world that agrees with the bound situation's world.
 `Q` must be a context filter — predicates filter contexts without
 modifying assignments.
 -/
-theorem subj_ind_chain_modal_donkey {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+theorem subj_ind_chain_modal_donkey {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (P Q : Set (Index.Possibility W Time) → Set (Index.Possibility W Time))
-    (c : Set (Index.Possibility W Time))
-    (gs : Index.Possibility W Time)
+    (P Q : Set (Index.Possibility W T) → Set (Index.Possibility W T))
+    (c : Set (Index.Possibility W T))
+    (gs : Index.Possibility W T)
     (h : gs ∈ subjIndChain history v P Q c)
     (hQ : IsEliminative Q) :
     gs.world.world = (gs.assignment v).world := by
@@ -716,11 +716,11 @@ situation in a conditional antecedent, the conditional quantifies
 universally over situations satisfying the antecedent — the modal
 analog of donkey universals.
 -/
-theorem unselective_universal_force {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+theorem unselective_universal_force {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (antecedent consequent : Index W Time → Prop)
-    (c : Set (Index.Possibility W Time)) :
+    (antecedent consequent : Index W T → Prop)
+    (c : Set (Index.Possibility W T)) :
     ∀ gs ∈ subjIndChain history v
       (λ c' => { gs' ∈ c' | antecedent gs'.world })
       (λ c' => { gs' ∈ c' | consequent gs'.world })
@@ -747,16 +747,16 @@ The SUBJ-IND chain with predication filters on a singleton context
 characterizes the static existential conjunction
 `∃ s₁ ∈ historicalBase(s₀), P(s₁) ∧ Q(s₁)`.
 -/
-theorem subjIndChain_singleton {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+theorem subjIndChain_singleton {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (g : Assignment (Index W Time))
-    (s₀ : Index W Time)
-    (P Q : Index W Time → Prop) :
+    (g : Assignment (Index W T))
+    (s₀ : Index W T)
+    (P Q : Index W T → Prop) :
     (∃ gs, gs ∈ subjIndChain history v
       (fun c => { gs ∈ c | P gs.world })
       (fun c => { gs ∈ c | Q gs.world })
-      ({⟨s₀, g⟩} : Set (Index.Possibility W Time))) ↔
+      ({⟨s₀, g⟩} : Set (Index.Possibility W T))) ↔
     (∃ s₁ ∈ historicalBase history s₀, P s₁ ∧ Q s₁) := by
   unfold subjIndChain
   constructor
@@ -781,17 +781,17 @@ The dynamic pipeline entails the static conditional (`conditionalSF`).
 Conjunction is stronger than implication: if the dynamic pipeline finds
 an `s₁` satisfying both `P` and `Q`, then `P(s₁) → Q(s₁)` holds trivially.
 -/
-theorem subjIndChain_entails_conditionalSF {W Time : Type*} [LE Time]
-    (history : HistoricalAlternatives W Time)
+theorem subjIndChain_entails_conditionalSF {W T : Type*} [LE T]
+    (history : HistoricalAlternatives W T)
     (v : ℕ)
-    (g : Assignment (Index W Time))
-    (s₀ : Index W Time)
-    (P : Index W Time → Prop)
-    (Q : Index W Time → Index W Time → Prop)
+    (g : Assignment (Index W T))
+    (s₀ : Index W T)
+    (P : Index W T → Prop)
+    (Q : Index W T → Index W T → Prop)
     (h : ∃ gs, gs ∈ subjIndChain history v
       (fun c => { gs ∈ c | P gs.world })
       (fun c => { gs ∈ c | Q gs.world gs.world })
-      ({⟨s₀, g⟩} : Set (Index.Possibility W Time))) :
+      ({⟨s₀, g⟩} : Set (Index.Possibility W T))) :
     conditionalSF history P (fun s₁ _ => Q s₁ s₁) s₀ := by
   unfold conditionalSF SUBJ
   obtain ⟨s₁, h_hist, hP, hQ⟩ :=

--- a/Linglib/Studies/Ogihara1989.lean
+++ b/Linglib/Studies/Ogihara1989.lean
@@ -23,9 +23,9 @@ open Intensional (Index)
     time precedes the speech situation and (2) the predicate holds at the
     referential time: the referential analysis picks the time, the
     operator imposes the constraint. -/
-theorem referential_past_decomposition {W Time : Type*} [LinearOrder Time]
-    (P : (Index W Time → Prop)) (g : TemporalAssignment Time) (n : ℕ)
-    (w : W) (speechTime : Time) :
+theorem referential_past_decomposition {W T : Type*} [LinearOrder T]
+    (P : (Index W T → Prop)) (g : TemporalAssignment T) (n : ℕ)
+    (w : W) (speechTime : T) :
     PAST P ⟨w, interpTense n g⟩ ⟨w, speechTime⟩ ↔
     (g n < speechTime ∧ P ⟨w, g n⟩) := by
   simp [Tense.constrain]

--- a/Linglib/Studies/Ogihara1996.lean
+++ b/Linglib/Studies/Ogihara1996.lean
@@ -81,8 +81,8 @@ theorem ogihara_ambiguity_vs_deletion :
     tense reading of past: the bound variable receives `E_matrix`. The
     derivation chain is `zeroTense_receives_binder_time` (substrate) →
     `embeddedR = matrixFrame.eventTime` → `embeddedFrame.isPresent`. -/
-theorem ogihara_derives_simultaneous {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) (g : TemporalAssignment Time) (n : ℕ) :
+theorem ogihara_derives_simultaneous {T : Type*}
+    (matrixFrame : ReichenbachFrame T) (g : TemporalAssignment T) (n : ℕ) :
     let embeddedR := interpTense n (updateTemporal g n matrixFrame.eventTime)
     (embeddedFrame matrixFrame embeddedR embeddedR).isPresent := by
   simp only [zeroTense_receives_binder_time, embeddedFrame,
@@ -91,8 +91,8 @@ theorem ogihara_derives_simultaneous {Time : Type*}
 /-- [ogihara-1996] derives the shifted reading via the
     genuine-past reading: the past tense contributes temporal
     precedence. -/
-theorem ogihara_derives_shifted {Time : Type*} [LinearOrder Time]
-    (matrixFrame : ReichenbachFrame Time) (embeddedR embeddedE : Time)
+theorem ogihara_derives_shifted {T : Type*} [LinearOrder T]
+    (matrixFrame : ReichenbachFrame T) (embeddedR embeddedE : T)
     (hPast : embeddedR < matrixFrame.eventTime) :
     (embeddedFrame matrixFrame embeddedR embeddedE).isPast := by
   simp only [embeddedFrame, ReichenbachFrame.isPast_def]

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -329,29 +329,29 @@ exist and the complement's run-time wholly precedes the main event's — while *
 existential over the main clause and universal over the complement, so it is vacuously
 satisfied when no complement event exists. The precedence is Allen's `precedes` atom. -/
 
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 /-- *P after Q*: some `P`-event whose run-time some `Q`-event's run-time wholly precedes. -/
-def eventAfter (P Q : Event Time → Prop) : Prop :=
-  ∃ e₁ e₂ : Event Time, P e₁ ∧ Q e₂ ∧ e₂.τ.precedes e₁.τ
+def eventAfter (P Q : Event T → Prop) : Prop :=
+  ∃ e₁ e₂ : Event T, P e₁ ∧ Q e₂ ∧ e₂.τ.precedes e₁.τ
 
 /-- *P before Q*: some `P`-event whose run-time wholly precedes every `Q`-event's. -/
-def eventBefore (P Q : Event Time → Prop) : Prop :=
-  ∃ e₁ : Event Time, P e₁ ∧ ∀ e₂ : Event Time, Q e₂ → e₁.τ.precedes e₂.τ
+def eventBefore (P Q : Event T → Prop) : Prop :=
+  ∃ e₁ : Event T, P e₁ ∧ ∀ e₂ : Event T, Q e₂ → e₁.τ.precedes e₂.τ
 
-theorem eventAfter_iff_allen (P Q : Event Time → Prop) :
-    eventAfter P Q ↔ ∃ e₁ e₂ : Event Time, P e₁ ∧ Q e₂ ∧
+theorem eventAfter_iff_allen (P Q : Event T → Prop) :
+    eventAfter P Q ↔ ∃ e₁ e₂ : Event T, P e₁ ∧ Q e₂ ∧
       AllenRelation.holdsIn AllenRelation.precedesSet e₂.τ e₁.τ := by
   simp only [eventAfter, NonemptyInterval.precedes_iff_allen]
 
-theorem eventBefore_iff_allen (P Q : Event Time → Prop) :
-    eventBefore P Q ↔ ∃ e₁ : Event Time, P e₁ ∧ ∀ e₂ : Event Time, Q e₂ →
+theorem eventBefore_iff_allen (P Q : Event T → Prop) :
+    eventBefore P Q ↔ ∃ e₁ : Event T, P e₁ ∧ ∀ e₂ : Event T, Q e₂ →
       AllenRelation.holdsIn AllenRelation.precedesSet e₁.τ e₂.τ := by
   simp only [eventBefore, NonemptyInterval.precedes_iff_allen]
 
 /-- *After*'s veridicality follows from its double existential. -/
-theorem after_veridicality_derived {P Q : Event Time → Prop} (h : eventAfter P Q) :
-    ∃ e : Event Time, Q e :=
+theorem after_veridicality_derived {P Q : Event T → Prop} (h : eventAfter P Q) :
+    ∃ e : Event T, Q e :=
   let ⟨_, e₂, _, hq, _⟩ := h; ⟨e₂, hq⟩
 
 /-- *Before*'s non-veridicality follows from its universal: any `P`-event with an empty `Q`
@@ -362,12 +362,12 @@ theorem before_nonveridicality_derived :
     ⟨⟨⟨⟨0, 1⟩, by decide⟩, .dynamic⟩, rfl, fun _ h => h.elim⟩, fun ⟨_, h⟩ => h⟩
 
 /-- Both connectives commit to the main clause. -/
-theorem eventBefore_veridical_main {P Q : Event Time → Prop} (h : eventBefore P Q) :
-    ∃ e : Event Time, P e :=
+theorem eventBefore_veridical_main {P Q : Event T → Prop} (h : eventBefore P Q) :
+    ∃ e : Event T, P e :=
   let ⟨e₁, hp, _⟩ := h; ⟨e₁, hp⟩
 
 /-- The event-level *after* projects to [anscombe-1964]'s on run-time denotations. -/
-theorem anscombe_after_of_eventAfter {P Q : Event Time → Prop} (h : eventAfter P Q) :
+theorem anscombe_after_of_eventAfter {P Q : Event T → Prop} (h : eventAfter P Q) :
     Anscombe.after (eventDenotation P) (eventDenotation Q) := by
   obtain ⟨e₁, e₂, hp, hq, hprec⟩ := h
   refine ⟨e₁.τ.fst, ?_, e₂.τ.snd, ?_, hprec⟩
@@ -375,7 +375,7 @@ theorem anscombe_after_of_eventAfter {P Q : Event Time → Prop} (h : eventAfter
   · rw [timeTrace_eventDenotation]; exact ⟨e₂, hq, e₂.τ.fst_le_snd, le_rfl⟩
 
 /-- The event-level *before* projects to [anscombe-1964]'s quantificational one. -/
-theorem anscombe_before_of_eventBefore {P Q : Event Time → Prop} (h : eventBefore P Q) :
+theorem anscombe_before_of_eventBefore {P Q : Event T → Prop} (h : eventBefore P Q) :
     Anscombe.beforeEver (eventDenotation P) (eventDenotation Q) := by
   obtain ⟨e₁, hp, hall⟩ := h
   refine ⟨e₁.τ.snd, ?_, fun t' ht' => ?_⟩
@@ -536,9 +536,9 @@ The following theorems make this structural parallel precise. -/
     Formally: CSIP(P) → IMPF(P)(w)(t) → PRFV(P)(w)(t). This is
     `impf_entails_prfv_of_csub` from SubintervalProperty.lean. -/
 theorem csip_entails_completion
-    {W Time : Type*} [LinearOrder Time]
-    (P : W → Event Time → Prop) (hCSIP : HasClosedSubintervalProp P)
-    (w : W) (t : NonemptyInterval Time) :
+    {W T : Type*} [LinearOrder T]
+    (P : W → Event T → Prop) (hCSIP : HasClosedSubintervalProp P)
+    (w : W) (t : NonemptyInterval T) :
     IMPF P w t → PRFV P w t :=
   fun h => impf_entails_prfv_of_csub P hCSIP w t h
 
@@ -566,10 +566,10 @@ theorem non_csip_lacks_completion
     events to worlds where a target Q is reached, there exists an ongoing
     event whose continuation satisfies Q in accessible worlds. -/
 theorem progressive_before_modal_resolution
-    {W Time : Type*} [LinearOrder Time]
-    (P Q : W → Event Time → Prop)
-    (alternatives : Event Time → Set W)
-    (w : W) (t : NonemptyInterval Time)
+    {W T : Type*} [LinearOrder T]
+    (P Q : W → Event T → Prop)
+    (alternatives : Event T → Set W)
+    (w : W) (t : NonemptyInterval T)
     (hIMPF : IMPF P w t)
     (hContinuation : ∀ e, P w e → t < e.τ →
       ∀ w' ∈ alternatives e, ∃ e', Q w' e') :
@@ -589,11 +589,11 @@ theorem progressive_before_modal_resolution
     directly entails its complement). Predicates WITHOUT CSIP require modal
     resolution (the progressive / anti-veridical *before*). -/
 theorem csip_determines_modal_need
-    {W Time : Type*} [LinearOrder Time]
-    (P : W → Event Time → Prop) (w : W) (t : NonemptyInterval Time) :
+    {W T : Type*} [LinearOrder T]
+    (P : W → Event T → Prop) (w : W) (t : NonemptyInterval T) :
     (HasClosedSubintervalProp P → IMPF P w t → PRFV P w t) ∧
     (IMPF P w t → ¬HasClosedSubintervalProp P →
-      ¬(∀ (t' : NonemptyInterval Time), t' ≤ t →
+      ¬(∀ (t' : NonemptyInterval T), t' ≤ t →
         ∃ e, e.τ = t' ∧ P w e) →
       -- Modal resolution needed: must appeal to alternative worlds
       ∃ e, t < e.τ ∧ P w e) := by

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -44,8 +44,8 @@ open Intensional (Index)
     Past tense introduces a temporal variable resolved to a specific
     contextually salient time. The negation scopes over the temporal
     reference, giving ¬P(t_i) rather than Prior's ∃t < now. ¬P(t). -/
-def parteeStoveExample {Time : Type*} (turnedOff : Time → Bool)
-    (g : TemporalAssignment Time) (n : ℕ) : Bool :=
+def parteeStoveExample {T : Type*} (turnedOff : T → Bool)
+    (g : TemporalAssignment T) (n : ℕ) : Bool :=
   !turnedOff (interpTense n g)
 
 /-- [partee-1973]'s argument against [prior-1967], as a countermodel: in a
@@ -66,8 +66,8 @@ theorem stove_refutes_prior :
     anaphora. Under the referential analysis both clauses evaluate at
     g(n) for the same discourse-salient temporal variable n, just as
     anaphoric pronouns corefer with an established individual. -/
-def narrativeAnaphora {Time : Type*} (P Q : Time → Bool)
-    (g : TemporalAssignment Time) (n : ℕ) : Bool :=
+def narrativeAnaphora {T : Type*} (P Q : T → Bool)
+    (g : TemporalAssignment T) (n : ℕ) : Bool :=
   P (interpTense n g) && Q (interpTense n g)
 
 end Partee1973

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -42,21 +42,21 @@ open ArgumentStructure (ThematicFrame)
 
 /-- A mental-state verb: its predicate on eventualities and its intensity measure `μ_int`;
 thematic roles are assigned by a `ThematicFrame` at use sites. -/
-structure MentalStateVerb (Time D : Type*) [LinearOrder Time] where
+structure MentalStateVerb (T D : Type*) [LinearOrder T] where
   /-- The verb's predicate on eventualities. -/
-  predicate : Event Time → Prop
+  predicate : Event T → Prop
   /-- The intensity measure. -/
-  μint : Event Time → D
+  μint : Event T → D
 
-variable {Entity Time D : Type*} [LinearOrder Time] [Preorder D] (v : MentalStateVerb Time D)
-  (frame : ThematicFrame Entity Time)
+variable {Entity T D : Type*} [LinearOrder T] [Preorder D] (v : MentalStateVerb T D)
+  (frame : ThematicFrame Entity T)
 
 /-- Eventualities of the verb with experiencer `α` and theme `x`. -/
-def themed (α x : Entity) (e : Event Time) : Prop :=
+def themed (α x : Entity) (e : Event T) : Prop :=
   frame.experiencer α e ∧ v.predicate e ∧ frame.theme x e
 
 /-- *α V x at degree d*: a themed eventuality of the verb with intensity at least `d`. -/
-def MentalStateVerb.holdsAtDegree (α x : Entity) (d : D) (e : Event Time) : Prop :=
+def MentalStateVerb.holdsAtDegree (α x : Entity) (d : D) (e : Event T) : Prop :=
   themed v frame α x e ∧ d ≤ v.μint e
 
 /-- The than-clause degrees of *β V y* are the degrees at which *β V y* holds. -/
@@ -77,7 +77,7 @@ theorem intensityComparative.exists_matrix (h : intensityComparative v frame α 
   let ⟨_, _, e, he, _⟩ := h; ⟨e, he⟩
 
 /-- With unique witnesses on both sides the comparative compares the two intensities. -/
-theorem intensityComparative_unique {ea eb : Event Time} (ha : themed v frame α x ea)
+theorem intensityComparative_unique {ea eb : Event T} (ha : themed v frame α x ea)
     (ha' : ∀ e, themed v frame α x e → e = ea) (hb : themed v frame β y eb)
     (hb' : ∀ e, themed v frame β y e → e = eb) :
     intensityComparative v frame α β x y ↔ v.μint eb < v.μint ea :=
@@ -100,7 +100,7 @@ variable {v frame}
 
 /-- With the zero degree, the comparative is consistent with there being no `β`-eventuality
 at all: *Jack admires the chairman more than Jill does; in fact, Jill doesn't admire him*. -/
-theorem intensityComparativeZero_of_none {e : Event Time} (he : themed v frame α x e)
+theorem intensityComparativeZero_of_none {e : Event T} (he : themed v frame α x e)
     (hpos : 0 < v.μint e) (hβ : ∀ e', themed v frame β y e' → v.μint e' ≤ 0) :
     intensityComparativeZero v frame α β x y :=
   ⟨e, he, 0, ⟨Set.mem_insert _ _, fun _ hd => (Set.mem_insert_iff.1 hd).elim le_of_eq

--- a/Linglib/Studies/Percus2000.lean
+++ b/Linglib/Studies/Percus2000.lean
@@ -24,8 +24,8 @@ bind which variable.
 
 ## Situation Assignment Infrastructure
 
-Situation assignments specialize `Assignment` from `D = Time`
-(Partee's temporal variables) to `D = Index W Time` (Percus's
+Situation assignments specialize `Assignment` from `D = T`
+(Partee's temporal variables) to `D = Index W T` (Percus's
 situation variables).
 
 ## Empirical Chain
@@ -59,22 +59,22 @@ open Features (Attitude)
 -- ════════════════════════════════════════════════════════════════
 
 /-- Situation assignment function: maps variable indices to situations. -/
-abbrev SituationAssignment (W Time : Type*) := Assignment (Index W Time)
+abbrev SituationAssignment (W T : Type*) := Assignment (Index W T)
 
 /-- Situation variable denotation: s_n^g = g(n). -/
-abbrev interpSitVar {W Time : Type*} (n : ℕ) (g : SituationAssignment W Time) :
-    Index W Time :=
+abbrev interpSitVar {W T : Type*} (n : ℕ) (g : SituationAssignment W T) :
+    Index W T :=
   g n
 
 /-- Modified situation assignment g[n -> s]. -/
-abbrev updateSitVar {W Time : Type*} (g : SituationAssignment W Time)
-    (n : ℕ) (s : Index W Time) : SituationAssignment W Time :=
+abbrev updateSitVar {W T : Type*} (g : SituationAssignment W T)
+    (n : ℕ) (s : Index W T) : SituationAssignment W T :=
   Function.update g n s
 
 /-- Situation lambda abstraction: bind a situation variable. -/
-abbrev sitLambdaAbs {W Time α : Type*} (n : ℕ)
-    (body : SituationAssignment W Time → α) :
-    SituationAssignment W Time → Index W Time → α :=
+abbrev sitLambdaAbs {W T α : Type*} (n : ℕ)
+    (body : SituationAssignment W T → α) :
+    SituationAssignment W T → Index W T → α :=
   λ g s => body (Function.update g n s)
 
 
@@ -126,33 +126,33 @@ theorem genX_bridge_compliant :
 -- § Attitude Semantics with Situation Binding
 -- ════════════════════════════════════════════════════════════════
 
-abbrev DoxSit (W Time E : Type*) := E → Index W Time → List (Index W Time)
+abbrev DoxSit (W T E : Type*) := E → Index W T → List (Index W T)
 
-def believeSit {W Time E : Type*}
-    (dox : DoxSit W Time E) (agent : E) (n : ℕ)
-    (complement : SituationAssignment W Time → Prop)
-    (g : SituationAssignment W Time) (s : Index W Time) : Prop :=
+def believeSit {W T E : Type*}
+    (dox : DoxSit W T E) (agent : E) (n : ℕ)
+    (complement : SituationAssignment W T → Prop)
+    (g : SituationAssignment W T) (s : Index W T) : Prop :=
   ∀ s' ∈ dox agent s, complement (updateSitVar g n s')
 
-instance {W Time E : Type*}
-    (dox : DoxSit W Time E) (agent : E) (n : ℕ)
-    (complement : SituationAssignment W Time → Prop) [DecidablePred complement]
-    (g : SituationAssignment W Time) (s : Index W Time) :
+instance {W T E : Type*}
+    (dox : DoxSit W T E) (agent : E) (n : ℕ)
+    (complement : SituationAssignment W T → Prop) [DecidablePred complement]
+    (g : SituationAssignment W T) (s : Index W T) :
     Decidable (believeSit dox agent n complement g s) := by
   unfold believeSit; infer_instance
 
-def alwaysAt {W Time : Type*}
-    (domain : Index W Time → List (Index W Time))
-    (ssh : Index W Time) (n : ℕ)
-    (scope : SituationAssignment W Time → Prop)
-    (g : SituationAssignment W Time) : Prop :=
+def alwaysAt {W T : Type*}
+    (domain : Index W T → List (Index W T))
+    (ssh : Index W T) (n : ℕ)
+    (scope : SituationAssignment W T → Prop)
+    (g : SituationAssignment W T) : Prop :=
   ∀ s' ∈ domain ssh, scope (updateSitVar g n s')
 
-instance {W Time : Type*}
-    (domain : Index W Time → List (Index W Time))
-    (ssh : Index W Time) (n : ℕ)
-    (scope : SituationAssignment W Time → Prop) [DecidablePred scope]
-    (g : SituationAssignment W Time) :
+instance {W T : Type*}
+    (domain : Index W T → List (Index W T))
+    (ssh : Index W T) (n : ℕ)
+    (scope : SituationAssignment W T → Prop) [DecidablePred scope]
+    (g : SituationAssignment W T) :
     Decidable (alwaysAt domain ssh n scope g) := by
   unfold alwaysAt; infer_instance
 
@@ -161,13 +161,13 @@ instance {W Time : Type*}
 -- § Key Properties
 -- ════════════════════════════════════════════════════════════════
 
-theorem sitVar_receives_binder_value {W Time : Type*}
-    (g : SituationAssignment W Time) (n : ℕ) (s : Index W Time) :
+theorem sitVar_receives_binder_value {W T : Type*}
+    (g : SituationAssignment W T) (n : ℕ) (s : Index W T) :
     interpSitVar n (updateSitVar g n s) = s :=
   Function.update_self n s g
 
-theorem sitVar_other_unaffected {W Time : Type*}
-    (g : SituationAssignment W Time) (n i : ℕ) (s : Index W Time)
+theorem sitVar_other_unaffected {W T : Type*}
+    (g : SituationAssignment W T) (n i : ℕ) (s : Index W T)
     (h : i ≠ n) :
     interpSitVar i (updateSitVar g n s) = interpSitVar i g :=
   Function.update_of_ne h s g
@@ -177,12 +177,12 @@ theorem sitVar_other_unaffected {W Time : Type*}
 -- § Bridge: Temporal <-> Situational
 -- ════════════════════════════════════════════════════════════════
 
-def toTemporalAssignment {W Time : Type*}
-    (g : SituationAssignment W Time) : TemporalAssignment Time :=
+def toTemporalAssignment {W T : Type*}
+    (g : SituationAssignment W T) : TemporalAssignment T :=
   λ n => (g n).time
 
-theorem temporal_projection_commutes {W Time : Type*}
-    (g : SituationAssignment W Time) (n : ℕ) :
+theorem temporal_projection_commutes {W T : Type*}
+    (g : SituationAssignment W T) (n : ℕ) :
     Tense.interpTense n (toTemporalAssignment g) = (interpSitVar n g).time :=
   rfl
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -728,9 +728,9 @@ open ArgumentStructure in
     event with no external argument — is admitted by the bieventive Cause
     denotation, which the θ-role analysis (forcing a causer) cannot model. -/
 theorem cause_bieventive_admits_adversity_causative
-    {Time : Type*} [LinearOrder Time]
-    (cause : Event Time → Event Time → Prop) (caused : Event Time → Prop)
-    (e e' : Event Time) (hc : caused e') (hcause : cause e e') :
+    {T : Type*} [LinearOrder T]
+    (cause : Event T → Event T → Prop) (caused : Event T → Prop)
+    (e e' : Event T) (hc : caused e') (hcause : cause e e') :
     causeBieventive cause caused e :=
   causeBieventive_no_external_arg cause caused e e' hc hcause
 
@@ -1227,8 +1227,8 @@ def applIntroMode : ApplType → IntroMode
     This is `low_applicative_blocks_unergative` re-grounded in the
     `ArgumentIntroduction` substrate rather than the `IsLow` alias. -/
 theorem low_appl_blocks_unergative_denotational
-    {Entity Time : Type*} [LinearOrder Time] (a : ApplType) (hLow : a.IsLow)
-    (body : Event Time → Prop) :
+    {Entity T : Type*} [LinearOrder T] (a : ApplType) (hLow : a.IsLow)
+    (body : Event T → Prop) :
     ¬ (applIntroMode a).Licenses (VerbDenot.unergative (Entity := Entity) body) := by
   have h : applIntroMode a = .toTheme := by
     cases a <;> first | rfl | exact absurd hLow (by decide)
@@ -1237,8 +1237,8 @@ theorem low_appl_blocks_unergative_denotational
 /-- High applicatives license unergatives, derived denotationally
     (Luganda/Venda/Albanian, PDF eq. 23a/24a/25a). -/
 theorem high_appl_licenses_unergative_denotational
-    {Entity Time : Type*} [LinearOrder Time]
-    (body : Event Time → Prop) :
+    {Entity T : Type*} [LinearOrder T]
+    (body : Event T → Prop) :
     (applIntroMode .high).Licenses (VerbDenot.unergative (Entity := Entity) body) :=
   toEvent_licenses_all _
 

--- a/Linglib/Studies/Rett2020.lean
+++ b/Linglib/Studies/Rett2020.lean
@@ -52,7 +52,7 @@ open Features
 open Features.ChangeOfState
 open Degree (maxOnScale isAmbidirectional maxOnScale_singleton maxOnScale_lt_closedInterval
   maxOnScale_gt_closedInterval)
-variable {Time : Type*} [LinearOrder Time]
+variable {T : Type*} [LinearOrder T]
 
 -- ============================================================================
 -- § 1: Rett's Truth Conditions
@@ -60,12 +60,12 @@ variable {Time : Type*} [LinearOrder Time]
 
 /-- Rett's *before* (eq. 22a): ∃t ∈ times(A) [t ≺ MAX(times(B)_≺)].
     Some time in A precedes the maximal (on the ≺ scale) time of B. -/
-def Rett.before (A B : RunTimes Time) : Prop :=
+def Rett.before (A B : RunTimes T) : Prop :=
   ∃ t ∈ timeTrace A, ∃ m ∈ maxOnScale .lt (timeTrace B), t < m
 
 /-- Rett's *after* (eq. 22b): ∃t ∈ times(A) [t ≻ MAX(times(B)_≻)].
     Some time in A succeeds the maximal (on the ≻ scale) time of B. -/
-def Rett.after (A B : RunTimes Time) : Prop :=
+def Rett.after (A B : RunTimes T) : Prop :=
   ∃ t ∈ timeTrace A, ∃ m ∈ maxOnScale .gt (timeTrace B), t > m
 
 -- ============================================================================
@@ -79,8 +79,8 @@ def Rett.after (A B : RunTimes Time) : Prop :=
     Linguistically: "Amy was surprised" → "the start of Amy being surprised".
     Cross-linguistically realized as inchoative morphology (Russian *-sja*,
     Tagalog PFV.NEUT). -/
-def INCHOAT (p : RunTimes Time) : RunTimes Time :=
-  { i | ∃ onset : Time,
+def INCHOAT (p : RunTimes T) : RunTimes T :=
+  { i | ∃ onset : T,
     (∀ j ∈ p, onset ≤ j.fst) ∧
     (∀ t, (∀ j ∈ p, t ≤ j.fst) → t ≤ onset) ∧
     i = NonemptyInterval.pure onset }
@@ -92,8 +92,8 @@ def INCHOAT (p : RunTimes Time) : RunTimes Time :=
     Linguistically: "Jane climbed the mountain" → "the moment Jane reached
     the top". Cross-linguistically realized as completive morphology
     (Tagalog AIA). -/
-def COMPLET (p : RunTimes Time) : RunTimes Time :=
-  { i | ∃ telos : Time,
+def COMPLET (p : RunTimes T) : RunTimes T :=
+  { i | ∃ telos : T,
     (∀ j ∈ p, j.snd ≤ telos) ∧
     (∀ t, (∀ j ∈ p, j.snd ≤ t) → telos ≤ t) ∧
     i = NonemptyInterval.pure telos }
@@ -103,7 +103,7 @@ def COMPLET (p : RunTimes Time) : RunTimes Time :=
 -- ============================================================================
 
 /-- INCHOAT extracts the start point of a stative denotation. -/
-theorem inchoat_bridges_inception (i : NonemptyInterval Time) :
+theorem inchoat_bridges_inception (i : NonemptyInterval T) :
     INCHOAT (stativeDenotation i) = { j | j = NonemptyInterval.pure i.fst } := by
   ext k
   simp only [INCHOAT, stativeDenotation, Set.mem_ofPred_eq, NonemptyInterval.le_def]
@@ -116,7 +116,7 @@ theorem inchoat_bridges_inception (i : NonemptyInterval Time) :
     exact ⟨i.fst, λ j ⟨hjs, _⟩ => hjs, λ t ht => ht i ⟨le_refl _, le_refl _⟩, rfl⟩
 
 /-- COMPLET extracts the finish point of an accomplishment denotation. -/
-theorem complet_bridges_cessation (i : NonemptyInterval Time) :
+theorem complet_bridges_cessation (i : NonemptyInterval T) :
     COMPLET (accomplishmentDenotation i) = { j | j = NonemptyInterval.pure i.snd } := by
   ext k
   simp only [COMPLET, accomplishmentDenotation, Set.mem_ofPred_eq]
@@ -140,7 +140,7 @@ theorem complet_bridges_cessation (i : NonemptyInterval Time) :
     - Rett: ∃ t ∈ A, t < MAX(B_≺). For statives, MAX on ≺ picks B.fst
       (the GLB), and t < B.fst ↔ t < all times in B. -/
 theorem anscombe_rett_agree_stative_before_start
-    (A : RunTimes Time) (i_B : NonemptyInterval Time) :
+    (A : RunTimes T) (i_B : NonemptyInterval T) :
     (Anscombe.beforeEver A (stativeDenotation i_B) ↔
      Rett.before A (stativeDenotation i_B)) := by
   constructor
@@ -165,7 +165,7 @@ theorem anscombe_rett_agree_stative_before_start
     A to follow B's *finish* (t > MAX₍>₎(B) = i_B.snd). These differ
     when A overlaps B without extending past B's endpoint. -/
 theorem rett_implies_anscombe_telic_after_finish
-    (A : RunTimes Time) (i_B : NonemptyInterval Time) :
+    (A : RunTimes T) (i_B : NonemptyInterval T) :
     Rett.after A (accomplishmentDenotation i_B) →
     Anscombe.after A (accomplishmentDenotation i_B) := by
   rintro ⟨t, ht_A, m, ⟨hm_mem, _⟩, htm⟩
@@ -181,7 +181,7 @@ theorem rett_implies_anscombe_telic_after_finish
     From Rett: t < m where m = min(timeTrace B). Since m < all other
     points in timeTrace B (by maxOnScale), t < every point in timeTrace B.
     This gives Anscombe's ∀-quantified conclusion. -/
-theorem rett_before_implies_anscombe (A B : RunTimes Time) :
+theorem rett_before_implies_anscombe (A B : RunTimes T) :
     Rett.before A B → Anscombe.beforeEver A B := by
   rintro ⟨t, ht, m, ⟨hm_mem, hm_min⟩, htm⟩
   exact ⟨t, ht, fun t' ht' => by
@@ -193,7 +193,7 @@ theorem rett_before_implies_anscombe (A B : RunTimes Time) :
 
     Immediate: m ∈ maxOnScale(timeTrace B) implies m ∈ timeTrace B,
     and t > m gives the existential witness for Anscombe.after. -/
-theorem rett_after_implies_anscombe (A B : RunTimes Time) :
+theorem rett_after_implies_anscombe (A B : RunTimes T) :
     Rett.after A B → Anscombe.after A B := by
   rintro ⟨t, ht, m, ⟨hm_mem, _⟩, htm⟩
   exact ⟨t, ht, m, hm_mem, htm⟩
@@ -218,14 +218,14 @@ to this bound, so negating B is truth-conditionally vacuous.
 *While* requires total temporal overlap; ¬B fails when A overlaps B. -/
 
 /-- *Before* truth conditions depend only on MAX₍<₎ of B's time trace. -/
-theorem before_determined_by_max (A B₁ B₂ : RunTimes Time)
+theorem before_determined_by_max (A B₁ B₂ : RunTimes T)
     (h : maxOnScale .lt (timeTrace B₁) = maxOnScale .lt (timeTrace B₂)) :
     Rett.before A B₁ ↔ Rett.before A B₂ := by
   constructor <;> rintro ⟨t, ht, m, hm, htm⟩ <;> exact ⟨t, ht, m, h ▸ hm, htm⟩
 
 /-- When B's time trace is a closed interval [s, f], Rett.before reduces to
     "∃ t ∈ A, t < s". -/
-theorem rett_before_closedTrace_eq (A B : RunTimes Time) (s f : Time) (hsf : s ≤ f)
+theorem rett_before_closedTrace_eq (A B : RunTimes T) (s f : T) (hsf : s ≤ f)
     (htrace : timeTrace B = { t | s ≤ t ∧ t ≤ f }) :
     Rett.before A B ↔ ∃ t ∈ timeTrace A, t < s := by
   unfold Rett.before
@@ -235,7 +235,7 @@ theorem rett_before_closedTrace_eq (A B : RunTimes Time) (s f : Time) (hsf : s �
   · rintro ⟨t, ht, htm⟩; exact ⟨t, ht, s, rfl, htm⟩
 
 /-- COMPLET on a stative denotation extracts the finish point. -/
-theorem complet_stative (i : NonemptyInterval Time) :
+theorem complet_stative (i : NonemptyInterval T) :
     COMPLET (stativeDenotation i) = { j | j = NonemptyInterval.pure i.snd } := by
   ext k
   simp only [COMPLET, stativeDenotation, Set.mem_ofPred_eq, NonemptyInterval.le_def]
@@ -248,92 +248,92 @@ theorem complet_stative (i : NonemptyInterval Time) :
     exact ⟨i.snd, fun j ⟨_, hjf⟩ => hjf, fun t ht => ht i ⟨le_refl _, le_refl _⟩, rfl⟩
 
 /-- The pre-event complement of an event interval [s, f]. -/
-def preEventDenotation (bot : Time) (i : NonemptyInterval Time) (hbot : bot ≤ i.fst) :
-    RunTimes Time :=
+def preEventDenotation (bot : T) (i : NonemptyInterval T) (hbot : bot ≤ i.fst) :
+    RunTimes T :=
   stativeDenotation ⟨⟨bot, i.fst⟩, hbot⟩
 
 /-- The time trace of a stative denotation is the closed interval [start, finish]. -/
-theorem timeTrace_stative_closedInterval (i : NonemptyInterval Time) :
+theorem timeTrace_stative_closedInterval (i : NonemptyInterval T) :
     timeTrace (stativeDenotation i) = { t | i.fst ≤ t ∧ t ≤ i.snd } := by
   rw [timeTrace_stativeDenotation]; ext; simp [NonemptyInterval.mem_def]
 
 /-- MAX₍<₎ of a stative denotation's time trace is {start}. -/
-theorem maxOnScale_lt_stative (i : NonemptyInterval Time) :
+theorem maxOnScale_lt_stative (i : NonemptyInterval T) :
     maxOnScale .lt (timeTrace (stativeDenotation i)) = {i.fst} := by
   rw [timeTrace_stative_closedInterval, maxOnScale_lt_closedInterval _ _ i.fst_le_snd]
 
 /-- The time trace of an accomplishment denotation is its run-time's closed interval. -/
-theorem timeTrace_accomplishment_closedInterval (i : NonemptyInterval Time) :
+theorem timeTrace_accomplishment_closedInterval (i : NonemptyInterval T) :
     timeTrace (accomplishmentDenotation i) = { t | i.fst ≤ t ∧ t ≤ i.snd } := by
   rw [timeTrace_accomplishmentDenotation]; ext; simp [NonemptyInterval.mem_def]
 
 /-- MAX₍<₎ of an accomplishment denotation's time trace is {start}. -/
-theorem maxOnScale_lt_accomplishment (i : NonemptyInterval Time) :
+theorem maxOnScale_lt_accomplishment (i : NonemptyInterval T) :
     maxOnScale .lt (timeTrace (accomplishmentDenotation i)) = {i.fst} := by
   rw [timeTrace_accomplishment_closedInterval, maxOnScale_lt_closedInterval _ _ i.fst_le_snd]
 
 /-- MAX₍>₎ of a stative denotation's time trace is {finish}. -/
-theorem maxOnScale_gt_stative (i : NonemptyInterval Time) :
+theorem maxOnScale_gt_stative (i : NonemptyInterval T) :
     maxOnScale .gt (timeTrace (stativeDenotation i)) = {i.snd} := by
   rw [timeTrace_stative_closedInterval, maxOnScale_gt_closedInterval _ _ i.fst_le_snd]
 
 /-- The time trace of the inchoative coercion of a stative is its onset. -/
-theorem timeTrace_inchoat_stative (i : NonemptyInterval Time) :
+theorem timeTrace_inchoat_stative (i : NonemptyInterval T) :
     timeTrace (INCHOAT (stativeDenotation i)) = {i.fst} := by
   rw [inchoat_bridges_inception]
   ext; simp [timeTrace, NonemptyInterval.mem_pure]
 
 /-- The time trace of the completive coercion of an accomplishment is its telos. -/
-theorem timeTrace_complet_accomplishment (i : NonemptyInterval Time) :
+theorem timeTrace_complet_accomplishment (i : NonemptyInterval T) :
     timeTrace (COMPLET (accomplishmentDenotation i)) = {i.snd} := by
   rw [complet_bridges_cessation]
   ext; simp [timeTrace, NonemptyInterval.mem_pure]
 
 /-- *Before* against a denotation with earliest time `m`: some time of `A` precedes `m`. -/
-theorem Rett.before_iff_of_maxOnScale_eq {A B : RunTimes Time} {m : Time}
+theorem Rett.before_iff_of_maxOnScale_eq {A B : RunTimes T} {m : T}
     (h : maxOnScale .lt (timeTrace B) = {m}) : Rett.before A B ↔ ∃ t ∈ timeTrace A, t < m := by
   simp [Rett.before, h]
 
 /-- *After* against a denotation with latest time `m`: some time of `A` follows `m`. -/
-theorem Rett.after_iff_of_maxOnScale_eq {A B : RunTimes Time} {m : Time}
+theorem Rett.after_iff_of_maxOnScale_eq {A B : RunTimes T} {m : T}
     (h : maxOnScale .gt (timeTrace B) = {m}) : Rett.after A B ↔ ∃ t ∈ timeTrace A, m < t := by
   simp [Rett.after, h]
 
 /-- A stative main clause is *before* `B` iff its onset precedes `B`'s earliest time. -/
-theorem Rett.before_stative_iff (a : NonemptyInterval Time) {B : RunTimes Time} {m : Time}
+theorem Rett.before_stative_iff (a : NonemptyInterval T) {B : RunTimes T} {m : T}
     (h : maxOnScale .lt (timeTrace B) = {m}) : Rett.before (stativeDenotation a) B ↔ a.fst < m := by
   rw [Rett.before_iff_of_maxOnScale_eq h, timeTrace_stative_closedInterval]
   exact ⟨fun ⟨_, ⟨h1, _⟩, h3⟩ => lt_of_le_of_lt h1 h3, fun h => ⟨a.fst, ⟨le_rfl, a.fst_le_snd⟩, h⟩⟩
 
 /-- A stative main clause is *after* `B` iff its end follows `B`'s latest time. -/
-theorem Rett.after_stative_iff (a : NonemptyInterval Time) {B : RunTimes Time} {m : Time}
+theorem Rett.after_stative_iff (a : NonemptyInterval T) {B : RunTimes T} {m : T}
     (h : maxOnScale .gt (timeTrace B) = {m}) : Rett.after (stativeDenotation a) B ↔ m < a.snd := by
   rw [Rett.after_iff_of_maxOnScale_eq h, timeTrace_stative_closedInterval]
   exact ⟨fun ⟨_, ⟨_, h2⟩, h3⟩ => lt_of_lt_of_le h3 h2, fun h => ⟨a.snd, ⟨a.fst_le_snd, le_rfl⟩, h⟩⟩
 
 /-- Before-start: a stative before an accomplishment compares onset to start. -/
-theorem Rett.before_stative_accomplishment_iff (a b : NonemptyInterval Time) :
+theorem Rett.before_stative_accomplishment_iff (a b : NonemptyInterval T) :
     Rett.before (stativeDenotation a) (accomplishmentDenotation b) ↔ a.fst < b.fst :=
   Rett.before_stative_iff a (maxOnScale_lt_accomplishment b)
 
 /-- Before-finish under `COMPLET`: onset to telos. -/
-theorem Rett.before_stative_complet_iff (a b : NonemptyInterval Time) :
+theorem Rett.before_stative_complet_iff (a b : NonemptyInterval T) :
     Rett.before (stativeDenotation a) (COMPLET (accomplishmentDenotation b)) ↔ a.fst < b.snd :=
   Rett.before_stative_iff a (by rw [timeTrace_complet_accomplishment, maxOnScale_singleton])
 
 /-- After-finish: a stative after a stative compares end to end. -/
-theorem Rett.after_stative_stative_iff (a b : NonemptyInterval Time) :
+theorem Rett.after_stative_stative_iff (a b : NonemptyInterval T) :
     Rett.after (stativeDenotation a) (stativeDenotation b) ↔ b.snd < a.snd :=
   Rett.after_stative_iff a (maxOnScale_gt_stative b)
 
 /-- After-start under `INCHOAT`: end to onset. -/
-theorem Rett.after_stative_inchoat_iff (a b : NonemptyInterval Time) :
+theorem Rett.after_stative_inchoat_iff (a b : NonemptyInterval T) :
     Rett.after (stativeDenotation a) (INCHOAT (stativeDenotation b)) ↔ b.fst < a.snd :=
   Rett.after_stative_iff a (by rw [timeTrace_inchoat_stative, maxOnScale_singleton])
 
 /-- The time trace of `COMPLET(preEventDenotation bot i)` is the degenerate
     interval `{i.fst}`. -/
-theorem timeTrace_complet_preEvent (bot : Time) (i : NonemptyInterval Time) (hbot : bot ≤ i.fst) :
+theorem timeTrace_complet_preEvent (bot : T) (i : NonemptyInterval T) (hbot : bot ≤ i.fst) :
     timeTrace (COMPLET (preEventDenotation bot i hbot)) =
     { t | i.fst ≤ t ∧ t ≤ i.fst } := by
   unfold preEventDenotation
@@ -343,7 +343,7 @@ theorem timeTrace_complet_preEvent (bot : Time) (i : NonemptyInterval Time) (hbo
   ext; simp [NonemptyInterval.mem_def, NonemptyInterval.mem_pure]
 
 /-- MAX₍<₎ of the COMPLET of a pre-event denotation is {start}. -/
-theorem maxOnScale_lt_complet_preEvent (bot : Time) (i : NonemptyInterval Time) (hbot : bot ≤ i.fst) :
+theorem maxOnScale_lt_complet_preEvent (bot : T) (i : NonemptyInterval T) (hbot : bot ≤ i.fst) :
     maxOnScale .lt (timeTrace (COMPLET (preEventDenotation bot i hbot))) =
     {i.fst} := by
   rw [timeTrace_complet_preEvent, maxOnScale_lt_closedInterval _ _ (le_refl _)]
@@ -354,8 +354,8 @@ theorem maxOnScale_lt_complet_preEvent (bot : Time) (i : NonemptyInterval Time) 
     the original uses the default *before*-start reading (MAX₍<₎),
     while the negated version requires COMPLET coercion to extract the
     end of the pre-event interval. -/
-theorem before_preEvent_ambidirectional (A : RunTimes Time) (i_B : NonemptyInterval Time)
-    (bot : Time) (hbot : bot ≤ i_B.fst) :
+theorem before_preEvent_ambidirectional (A : RunTimes T) (i_B : NonemptyInterval T)
+    (bot : T) (hbot : bot ≤ i_B.fst) :
     Rett.before A (stativeDenotation i_B) ↔
     Rett.before A (COMPLET (preEventDenotation bot i_B hbot)) := by
   apply before_determined_by_max
@@ -363,14 +363,14 @@ theorem before_preEvent_ambidirectional (A : RunTimes Time) (i_B : NonemptyInter
 
 /-- *After* is NOT ambidirectional: negating B changes
     truth conditions because MAX₍>₎(B) ≠ MAX₍>₎(¬B). -/
-theorem after_not_ambidirectional (hab : ∃ (a b : Time), a < b) :
-    ¬ ∀ (A : RunTimes Time) (B : Set Time),
+theorem after_not_ambidirectional (hab : ∃ (a b : T), a < b) :
+    ¬ ∀ (A : RunTimes T) (B : Set T),
       isAmbidirectional (λ X => ∃ t ∈ timeTrace A, ∃ m ∈ maxOnScale .gt X, t > m) B := by
   obtain ⟨a, b, hab⟩ := hab
   intro h
   have h_amb := h {NonemptyInterval.pure b} {a}
-  have h_fB : ∃ t ∈ timeTrace ({NonemptyInterval.pure b} : RunTimes Time),
-      ∃ m ∈ maxOnScale .gt ({a} : Set Time), t > m :=
+  have h_fB : ∃ t ∈ timeTrace ({NonemptyInterval.pure b} : RunTimes T),
+      ∃ m ∈ maxOnScale .gt ({a} : Set T), t > m :=
     ⟨b, ⟨NonemptyInterval.pure b, rfl, le_refl _, le_refl _⟩,
      a, ⟨rfl, fun _ hx' hne => absurd hx' hne⟩, hab⟩
   obtain ⟨t, ht_A, m, ⟨hm_mem, hm_dom⟩, htm⟩ := h_amb.mp h_fB
@@ -379,22 +379,22 @@ theorem after_not_ambidirectional (hab : ∃ (a b : Time), a < b) :
   subst hj_mem
   simp only [NonemptyInterval.pure] at hj_s hj_f
   have ht_eq : t = b := le_antisymm hj_f hj_s
-  have hb_compl : b ∈ ({a} : Set Time)ᶜ := by
+  have hb_compl : b ∈ ({a} : Set T)ᶜ := by
     simp only [Set.mem_compl_iff, Set.mem_singleton_iff]; exact ne_of_gt hab
   by_cases hmb : m = b
   · rw [ht_eq, hmb] at htm; exact absurd htm (lt_irrefl _)
   · rw [ht_eq] at htm; exact absurd htm (not_lt.mpr (le_of_lt (hm_dom b hb_compl (Ne.symm hmb))))
 
-omit [LinearOrder Time] in
+omit [LinearOrder T] in
 /-- *While* is not ambidirectional. -/
-theorem while_not_ambidirectional [Inhabited Time] :
-    ¬ ∀ (A B : Set Time),
+theorem while_not_ambidirectional [Inhabited T] :
+    ¬ ∀ (A B : Set T),
       isAmbidirectional (λ X => ∀ t ∈ A, t ∈ X) B := by
   intro h
   have := h {default} {default}
   simp only [isAmbidirectional] at this
-  have lhs : ∀ t ∈ ({default} : Set Time), t ∈ ({default} : Set Time) := fun _ h => h
-  have rhs := this.mp lhs (default : Time) rfl
+  have lhs : ∀ t ∈ ({default} : Set T), t ∈ ({default} : Set T) := fun _ h => h
+  have rhs := this.mp lhs (default : T) rfl
   exact absurd rfl rhs
 
 end Rett2020

--- a/Linglib/Studies/Rouillard2026.lean
+++ b/Linglib/Studies/Rouillard2026.lean
@@ -87,36 +87,36 @@ open Core.Order
 open Degree
 open English.TemporalExpressions
 
-variable {W Time : Type*} [LinearOrder Time]
+variable {W T : Type*} [LinearOrder T]
 variable {α : Type*} [AddCommMonoid α] [LinearOrder α]
 
 /-! ### Time measure -/
 
 /-- A temporal measure: an `IsIntervalContent` (additivity, [rouillard-2026]
     eq. 6; positivity, eq. 7) together with two saturation axioms — richness
-    of `Time` lets any interval be trimmed or right-anchored-extended to any
+    of `T` lets any interval be trimmed or right-anchored-extended to any
     target measure (PTSs are anchored at speech time). Instantiate `α := ℕ`
     for the discrete integer-numeral reading or `α := ℚ≥0` over dense time
     for the reading that drives the G-TIA collapse (`ratLength` below). -/
-class TimeMeasure (Time : Type*) [LinearOrder Time] {α : Type*}
+class TimeMeasure (T : Type*) [LinearOrder T] {α : Type*}
     [AddCommMonoid α] [LinearOrder α]
-    (μ : NonemptyInterval Time → α) : Prop extends IsIntervalContent μ where
+    (μ : NonemptyInterval T → α) : Prop extends IsIntervalContent μ where
   /-- Any interval can be subdivided to a subinterval with a given smaller
       measure. -/
-  subdivisible : ∀ (i : NonemptyInterval Time) (m : α), m ≤ μ i →
-    ∃ j : NonemptyInterval Time, j ≤ i ∧ μ j = m
+  subdivisible : ∀ (i : NonemptyInterval T) (m : α), m ≤ μ i →
+    ∃ j : NonemptyInterval T, j ≤ i ∧ μ j = m
   /-- Right-anchored left-extension: any interval can be extended to a
       given larger measure keeping its right endpoint fixed. -/
-  extensibleLeft : ∀ (i : NonemptyInterval Time) (m : α), μ i ≤ m →
-    ∃ j : NonemptyInterval Time, i ≤ j ∧ j.snd = i.snd ∧ μ j = m
+  extensibleLeft : ∀ (i : NonemptyInterval T) (m : α), μ i ≤ m →
+    ∃ j : NonemptyInterval T, i ≤ j ∧ j.snd = i.snd ∧ μ j = m
 
 namespace TimeMeasure
 
 /-- Any interval can be extended to a superinterval with a given larger
     measure: weakening of `extensibleLeft` (forget the right anchor). -/
-theorem extensible {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (i : NonemptyInterval Time) (m : α) (h : μ i ≤ m) :
-    ∃ j : NonemptyInterval Time, i ≤ j ∧ μ j = m :=
+theorem extensible {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (i : NonemptyInterval T) (m : α) (h : μ i ≤ m) :
+    ∃ j : NonemptyInterval T, i ≤ j ∧ μ j = m :=
   let ⟨j, hij, _, hjμ⟩ := TimeMeasure.extensibleLeft i m h
   ⟨j, hij, hjμ⟩
 
@@ -127,11 +127,11 @@ end TimeMeasure
 /-- A generalized interval with specified boundary types.
     Extends the basic `NonemptyInterval` with open/closed annotations on each end.
     [rouillard-2026] eq. (14a–b), (99a–b). -/
-structure GInterval (Time : Type*) [LinearOrder Time] where
+structure GInterval (T : Type*) [LinearOrder T] where
   /-- Left endpoint -/
-  left : Time
+  left : T
   /-- Right endpoint -/
-  right : Time
+  right : T
   /-- Left boundary type: closed [m or open]m -/
   leftType : BoundaryType
   /-- Right boundary type: closed m] or open m[ -/
@@ -143,7 +143,7 @@ namespace GInterval
 
 /-- A closed interval [m₁, m₂]: both endpoints included.
     [rouillard-2026] eq. (14a): C := {t | min(t) ⊑ᵢ t ∧ max(t) ⊑ᵢ t}. -/
-def closed (i : NonemptyInterval Time) : GInterval Time where
+def closed (i : NonemptyInterval T) : GInterval T where
   left := i.fst
   right := i.snd
   leftType := .closed
@@ -152,7 +152,7 @@ def closed (i : NonemptyInterval Time) : GInterval Time where
 
 /-- An open interval]m₁, m₂[: both endpoints excluded.
     [rouillard-2026] eq. (14b): O := {t | min(t) ⊄ᵢ t ∨ max(t) ⊄ᵢ t}. -/
-def open_ (i : NonemptyInterval Time) : GInterval Time where
+def open_ (i : NonemptyInterval T) : GInterval T where
   left := i.fst
   right := i.snd
   leftType := .open_
@@ -162,26 +162,26 @@ def open_ (i : NonemptyInterval Time) : GInterval Time where
 /-- The o(t) operation: open counterpart of a time.
     [rouillard-2026] eq. (99a): if t is open, o(t) = t; if t is closed,
     o(t) is the open interval with the same endpoints. -/
-def toOpen (gi : GInterval Time) : GInterval Time :=
+def toOpen (gi : GInterval T) : GInterval T :=
   { gi with leftType := .open_, rightType := .open_ }
 
 /-- The c(t) operation: closed counterpart of a time.
     [rouillard-2026] eq. (99b): if t is closed, c(t) = t; if t is open,
     c(t) adds the endpoints. -/
-def toClosed (gi : GInterval Time) : GInterval Time :=
+def toClosed (gi : GInterval T) : GInterval T :=
   { gi with leftType := .closed, rightType := .closed }
 
 /-- Is this interval closed (both boundaries included)? -/
-def isClosed (gi : GInterval Time) : Prop :=
+def isClosed (gi : GInterval T) : Prop :=
   gi.leftType = .closed ∧ gi.rightType = .closed
 
 /-- Is this interval open (both boundaries excluded)? -/
-def isOpen (gi : GInterval Time) : Prop :=
+def isOpen (gi : GInterval T) : Prop :=
   gi.leftType = .open_ ∧ gi.rightType = .open_
 
 /-- Containment for generalized intervals: m is in gi.
     For closed endpoints, ≤ is used; for open endpoints, <. -/
-def gcontains (gi : GInterval Time) (m : Time) : Prop :=
+def gcontains (gi : GInterval T) (m : T) : Prop :=
   (match gi.leftType with
    | .closed => gi.left ≤ m
    | .open_ => gi.left < m) ∧
@@ -190,41 +190,41 @@ def gcontains (gi : GInterval Time) (m : Time) : Prop :=
    | .open_ => m < gi.right)
 
 /-- Generalized subinterval: gi₁ ⊆ gi₂ (every moment in gi₁ is in gi₂). -/
-def gsubinterval (gi₁ gi₂ : GInterval Time) : Prop :=
-  ∀ m : Time, gi₁.gcontains m → gi₂.gcontains m
+def gsubinterval (gi₁ gi₂ : GInterval T) : Prop :=
+  ∀ m : T, gi₁.gcontains m → gi₂.gcontains m
 
 /-- Convert a closed GInterval back to the basic NonemptyInterval type. -/
-def toInterval (gi : GInterval Time) : NonemptyInterval Time :=
+def toInterval (gi : GInterval T) : NonemptyInterval T :=
   ⟨⟨gi.left, gi.right⟩, gi.valid⟩
 
 /-- The closed counterpart of an open interval is always closed. -/
-@[simp] theorem toClosed_isClosed (gi : GInterval Time) : gi.toClosed.isClosed :=
+@[simp] theorem toClosed_isClosed (gi : GInterval T) : gi.toClosed.isClosed :=
   ⟨rfl, rfl⟩
 
 /-- The open counterpart is always open. -/
-@[simp] theorem toOpen_isOpen (gi : GInterval Time) : gi.toOpen.isOpen :=
+@[simp] theorem toOpen_isOpen (gi : GInterval T) : gi.toOpen.isOpen :=
   ⟨rfl, rfl⟩
 
 /-- toClosed is idempotent. -/
-@[simp] theorem toClosed_idempotent (gi : GInterval Time) :
+@[simp] theorem toClosed_idempotent (gi : GInterval T) :
     gi.toClosed.toClosed = gi.toClosed := rfl
 
 /-- toOpen is idempotent. -/
-@[simp] theorem toOpen_idempotent (gi : GInterval Time) :
+@[simp] theorem toOpen_idempotent (gi : GInterval T) :
     gi.toOpen.toOpen = gi.toOpen := rfl
 
 /-- The closed counterpart of an interval contains its endpoints (definitional). -/
-@[simp] theorem closed_gcontains_start (i : NonemptyInterval Time) :
+@[simp] theorem closed_gcontains_start (i : NonemptyInterval T) :
     (closed i).gcontains i.fst := ⟨le_refl _, i.fst_le_snd⟩
 
-@[simp] theorem closed_gcontains_finish (i : NonemptyInterval Time) :
+@[simp] theorem closed_gcontains_finish (i : NonemptyInterval T) :
     (closed i).gcontains i.snd := ⟨i.fst_le_snd, le_refl _⟩
 
 /-- A closed interval contained in an open generalized interval forces strict
     inequalities at both endpoints: instantiate `gsubinterval` at the closed
     endpoints and unfold `gcontains`. -/
 theorem gsubinterval_closed_open_strict
-    (rt : NonemptyInterval Time) (gi : GInterval Time)
+    (rt : NonemptyInterval T) (gi : GInterval T)
     (h_open : gi.isOpen) (h_sub : (closed rt).gsubinterval gi) :
     gi.left < rt.fst ∧ rt.snd < gi.right := by
   have h_start := h_sub rt.fst (closed_gcontains_start rt)
@@ -247,8 +247,8 @@ end GInterval
 /-- Prior time span: the maximal interval right-bounded by `s` with
     measure `n`, over `GInterval` so open-vs-closed boundary tags are
     carried structurally. [rouillard-2026] eq. (50). -/
-def pts (n : α) (μ : NonemptyInterval Time → α) [TimeMeasure Time μ] (s : Time)
-    (gi : GInterval Time) : Prop :=
+def pts (n : α) (μ : NonemptyInterval T → α) [TimeMeasure T μ] (s : T)
+    (gi : GInterval T) : Prop :=
   gi.right = s ∧ μ gi.toInterval = n
 
 /-! ### E-TIA semantics -/
@@ -256,16 +256,16 @@ def pts (n : α) (μ : NonemptyInterval Time → α) [TimeMeasure Time μ] (s : 
 /-- The preposition *in* as an event-level adverbial (E-TIA reading).
     The event's runtime is included in the measure-phrase's bound.
     [rouillard-2026] eq. (62) instantiated at M = τ. -/
-def inETIA (e : Event Time) (bound : NonemptyInterval Time) : Prop :=
+def inETIA (e : Event T) (bound : NonemptyInterval T) : Prop :=
   e.τ ≤ bound
 
 /-- E-TIA derived property: at world `w`, value `n` is true iff there is
     a P-event whose runtime is included in some `n`-unit time, and that
     `n`-unit time falls within `g1`. [rouillard-2026] eq. (77). -/
-def eTIAProperty (P : W → Event Time → Prop) (μ : NonemptyInterval Time → α)
-    [TimeMeasure Time μ] (g1 : NonemptyInterval Time) : α → W → Prop :=
-  fun n w => ∃ t : NonemptyInterval Time, μ t = n ∧
-    ∃ e : Event Time, P w e ∧ e.τ ≤ g1 ∧ e.τ ≤ t
+def eTIAProperty (P : W → Event T → Prop) (μ : NonemptyInterval T → α)
+    [TimeMeasure T μ] (g1 : NonemptyInterval T) : α → W → Prop :=
+  fun n w => ∃ t : NonemptyInterval T, μ t = n ∧
+    ∃ e : Event T, P w e ∧ e.τ ≤ g1 ∧ e.τ ≤ t
 
 /-! ### G-TIA semantics over open generalized intervals -/
 
@@ -273,26 +273,26 @@ def eTIAProperty (P : W → Event Time → Prop) (μ : NonemptyInterval Time →
     an OPEN PTS of measure `n` ending at `s` containing the closed runtime
     of a P-event. The openness of the PTS is carried structurally by
     `GInterval`. [rouillard-2026] eq. (94) revised with eq. (101). -/
-def gTIAPropertyOpen (P : W → Event Time → Prop) (μ : NonemptyInterval Time → α)
-    [TimeMeasure Time μ] (s : Time) : α → W → Prop :=
-  fun n w => ∃ ptsGI : GInterval Time,
+def gTIAPropertyOpen (P : W → Event T → Prop) (μ : NonemptyInterval T → α)
+    [TimeMeasure T μ] (s : T) : α → W → Prop :=
+  fun n w => ∃ ptsGI : GInterval T,
     ptsGI.isOpen ∧
     ptsGI.right = s ∧
     μ ptsGI.toInterval = n ∧
-    ∃ e : Event Time, P w e ∧ (GInterval.closed e.τ).gsubinterval ptsGI
+    ∃ e : Event T, P w e ∧ (GInterval.closed e.τ).gsubinterval ptsGI
 
 /-- The negation of `gTIAPropertyOpen`, used for G-TIAs in negative
     contexts (where the property "no event in the n-unit open PTS" holds
     iff `gTIAPropertyOpen` is false). -/
-def gTIAPropertyOpenNeg (P : W → Event Time → Prop) (μ : NonemptyInterval Time → α)
-    [TimeMeasure Time μ] (s : Time) : α → W → Prop :=
+def gTIAPropertyOpenNeg (P : W → Event T → Prop) (μ : NonemptyInterval T → α)
+    [TimeMeasure T μ] (s : T) : α → W → Prop :=
   fun n w => ¬ gTIAPropertyOpen P μ s n w
 
 /-- The positive G-TIA property is upward monotone: a wider gap window with
     the same right anchor still contains the event runtime, via
     `TimeMeasure.extensibleLeft`. -/
-theorem gTIAPropertyOpen_upwardMonotone {μ : NonemptyInterval Time → α}
-    [TimeMeasure Time μ] (P : W → Event Time → Prop) (s : Time) :
+theorem gTIAPropertyOpen_upwardMonotone {μ : NonemptyInterval T → α}
+    [TimeMeasure T μ] (P : W → Event T → Prop) (s : T) :
     Monotone (gTIAPropertyOpen P μ s) := by
   rintro n m hnm w ⟨ptsGI, hOpen, hRight, hμ, e, hP, hSub⟩
   obtain ⟨j, hij, hjsnd, hjμ⟩ :=
@@ -314,8 +314,8 @@ theorem gTIAPropertyOpen_upwardMonotone {μ : NonemptyInterval Time → α}
 /-- The negated G-TIA property is downward monotone: if no event sits in
     the `n`-unit gap window, none sits in any narrower one. Discharges the
     monotonicity that `gTIANeg_hasIsGreatest` needs. -/
-theorem gTIAPropertyOpenNeg_downwardMonotone {μ : NonemptyInterval Time → α}
-    [TimeMeasure Time μ] (P : W → Event Time → Prop) (s : Time) :
+theorem gTIAPropertyOpenNeg_downwardMonotone {μ : NonemptyInterval T → α}
+    [TimeMeasure T μ] (P : W → Event T → Prop) (s : T) :
     Antitone (gTIAPropertyOpenNeg P μ s) :=
   fun x y hxy w hy hx =>
     hy (gTIAPropertyOpen_upwardMonotone P s hxy w hx)
@@ -334,8 +334,8 @@ def IsMIPLicensed (P : α → W → Prop) : Prop :=
     subinterval property, the E-TIA derived property is constant: every
     numeral yields a true proposition at any world where any does, so no
     numeral is more informative than another. [rouillard-2026] §4.1.1. -/
-theorem eTIA_atelic_collapse {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (g1 : NonemptyInterval Time)
+theorem eTIA_atelic_collapse {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (g1 : NonemptyInterval T)
     (hSub : HasSubintervalProp P) :
     IsConstant (α := α) (eTIAProperty P μ g1) := by
   suffices h : ∀ n m w, eTIAProperty P μ g1 n w → eTIAProperty P μ g1 m w from
@@ -351,15 +351,15 @@ theorem eTIA_atelic_collapse {μ : NonemptyInterval Time → α} [TimeMeasure Ti
     exact ⟨j, hj_μ, e, hP, hg1, hj_sup⟩
 
 /-- Atelic E-TIA fails the `AdmitsOptimum` half of MIP licensing. -/
-theorem eTIA_atelic_no_optimum {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (g1 : NonemptyInterval Time)
+theorem eTIA_atelic_no_optimum {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (g1 : NonemptyInterval T)
     (hSub : HasSubintervalProp P) :
     ¬ AdmitsOptimum (eTIAProperty P μ g1) :=
   fun h => h (eTIA_atelic_collapse P g1 hSub)
 
 /-- Atelic E-TIA is not MIP-licensed. -/
-theorem eTIA_atelic_not_licensed {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (g1 : NonemptyInterval Time)
+theorem eTIA_atelic_not_licensed {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (g1 : NonemptyInterval T)
     (hSub : HasSubintervalProp P) :
     ¬ IsMIPLicensed (eTIAProperty P μ g1) :=
   fun ⟨hAdm, _⟩ => eTIA_atelic_no_optimum P g1 hSub hAdm
@@ -370,8 +370,8 @@ theorem eTIA_atelic_not_licensed {μ : NonemptyInterval Time → α} [TimeMeasur
     [rouillard-2026] §4.1.1: when P is telic, the derived E-TIA
     property is upward monotone — the same event witnesses larger
     measures via `TimeMeasure.extensible`. -/
-theorem eTIA_telic_upwardMonotone {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (g1 : NonemptyInterval Time) :
+theorem eTIA_telic_upwardMonotone {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (g1 : NonemptyInterval T) :
     Monotone (eTIAProperty P μ g1) := by
   intro n m hnm w ⟨t, hμ, e, hP, hg1, hsub⟩
   have h_le : μ t ≤ m := by rw [hμ]; exact hnm
@@ -397,7 +397,7 @@ theorem upwardMonotone_hasIsLeast_of_witness {W : Type*}
 /-! ### G-TIA geometric density: no smallest open PTS -/
 
 /-- **No smallest open PTS includes a closed runtime** (geometric witness).
-    [rouillard-2026] §4.2.2: under density on `Time`, an open PTS containing
+    [rouillard-2026] §4.2.2: under density on `T`, an open PTS containing
     a closed runtime always has a strictly smaller open PTS still containing
     it — pick a moment between the open boundary and the closed start.
 
@@ -405,13 +405,13 @@ theorem upwardMonotone_hasIsLeast_of_witness {W : Type*}
     additivity and positivity; `gTIAOpen_not_MIP_licensed` is the end-to-end
     blocking result. (For `α := ℕ` over dense time the `TimeMeasure` axioms
     are unsatisfiable — positivity forces an infinite descending ℕ-chain —
-    so the discrete reading lives on discrete `Time` only, where E-TIA
+    so the discrete reading lives on discrete `T` only, where E-TIA
     results apply but the density argument does not.) -/
-theorem no_smallest_open_PTS_geometric [DenselyOrdered Time]
-    (rt : NonemptyInterval Time) (ptsGI : GInterval Time)
+theorem no_smallest_open_PTS_geometric [DenselyOrdered T]
+    (rt : NonemptyInterval T) (ptsGI : GInterval T)
     (h_open : ptsGI.isOpen)
     (h_sub : (GInterval.closed rt).gsubinterval ptsGI) :
-    ∃ ptsGI' : GInterval Time,
+    ∃ ptsGI' : GInterval T,
       ptsGI'.isOpen ∧
       (GInterval.closed rt).gsubinterval ptsGI' ∧
       ptsGI'.right = ptsGI.right ∧
@@ -422,7 +422,7 @@ theorem no_smallest_open_PTS_geometric [DenselyOrdered Time]
   -- m sits strictly between ptsGI.left and rt.fst.
   have hm_valid : m ≤ ptsGI.right :=
     le_of_lt (lt_of_lt_of_le hm_right (le_trans rt.fst_le_snd (le_of_lt h_strict_right)))
-  let ptsGI' : GInterval Time :=
+  let ptsGI' : GInterval T :=
     { left := m, right := ptsGI.right
     , leftType := .open_, rightType := .open_
     , valid := hm_valid }
@@ -439,13 +439,13 @@ theorem no_smallest_open_PTS_geometric [DenselyOrdered Time]
     show p < ptsGI.right
     exact lt_of_le_of_lt hp2 h_strict_right
 
-/-- **Positive G-TIA: no least true value**. Under dense `Time`, additivity
+/-- **Positive G-TIA: no least true value**. Under dense `T`, additivity
     and positivity let every witnessing open PTS shrink to a strictly
     smaller-measure open PTS still containing the runtime, so the per-world
     true set has no least element. [rouillard-2026] §4.2.2. -/
-theorem gTIAOpen_no_isLeast [DenselyOrdered Time] [AddRightStrictMono α]
-    {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (s : Time) (w : W) (x : α) :
+theorem gTIAOpen_no_isLeast [DenselyOrdered T] [AddRightStrictMono α]
+    {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (s : T) (w : W) (x : α) :
     ¬ IsLeast {y | gTIAPropertyOpen P μ s y w} x := by
   rintro ⟨⟨ptsGI, hOpen, hRight, hμ, e, hP, hSub⟩, hLB⟩
   obtain ⟨ptsGI', hOpen', hSub', hRight', hLeft'⟩ :=
@@ -464,15 +464,15 @@ theorem gTIAOpen_no_isLeast [DenselyOrdered Time] [AddRightStrictMono α]
     least-true-numeral leg of `IsMIPLicensed` fails at every world. The
     end-to-end discharge of the information-collapse argument
     ([rouillard-2026] §4.2.2) that the ℕ-valued measure could not provide. -/
-theorem gTIAOpen_not_MIP_licensed [DenselyOrdered Time] [AddRightStrictMono α]
-    {μ : NonemptyInterval Time → α} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (s : Time) :
+theorem gTIAOpen_not_MIP_licensed [DenselyOrdered T] [AddRightStrictMono α]
+    {μ : NonemptyInterval T → α} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (s : T) :
     ¬ IsMIPLicensed (gTIAPropertyOpen P μ s) :=
   fun ⟨_, w, x, hLeast⟩ => gTIAOpen_no_isLeast P s w x hLeast
 
 /-! ### The rational length model
 
-Non-vacuity witness: over `Time := ℚ`, interval length valued in `ℚ≥0` is
+Non-vacuity witness: over `T := ℚ`, interval length valued in `ℚ≥0` is
 a `TimeMeasure`, so the hypotheses of `gTIAOpen_not_MIP_licensed` are
 jointly satisfiable at a concrete dense model. -/
 
@@ -547,8 +547,8 @@ theorem downwardMonotone_hasIsGreatest_of_bound {W : Type*}
     *excluding* a closed time, though never a smallest one including it.
     Downward monotonicity is supplied by
     `gTIAPropertyOpenNeg_downwardMonotone` (no longer hypothesis-gated). -/
-theorem gTIANeg_hasIsGreatest {μ : NonemptyInterval Time → ℕ} [TimeMeasure Time μ]
-    (P : W → Event Time → Prop) (s : Time) (w : W)
+theorem gTIANeg_hasIsGreatest {μ : NonemptyInterval T → ℕ} [TimeMeasure T μ]
+    (P : W → Event T → Prop) (s : T) (w : W)
     [DecidablePred (fun n => gTIAPropertyOpenNeg P μ s n w)]
     (h_witness : ∃ n, gTIAPropertyOpenNeg P μ s n w)
     (h_bound : ∃ n, ¬ gTIAPropertyOpenNeg P μ s n w) :

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -80,7 +80,7 @@ We split the formalization in two layers:
 1. **`PerformanceOntology Perf`** — properties of utterance-events
    (LINGMAT, Loud, Whispered, RisingDecl, Commits, RaisesIssue) and
    the cross-property axioms that drive verb-class postulates.
-2. **`SpeechVerbs Time SemObj Perf [Ω]`** — verb predicates (SAY, ASK,
+2. **`SpeechVerbs T SemObj Perf [Ω]`** — verb predicates (SAY, ASK,
    ASSERT, YELL, WHISPER), event relations (CONTENT, REENACT), and
    meaning postulates that connect verbs to performances via the
    ontology.
@@ -127,7 +127,7 @@ each verb). The SAY and ASK postulates are explicit in the paper.
 
 Performances are *events* in their own right — utterance-events
 paratactically associated with the speech-event. We model `Performance`
-as a type synonym `Event Time`, following [rudin-2025b]'s remark that
+as a type synonym `Event T`, following [rudin-2025b]'s remark that
 performances are special-purpose events. But the `SpeechVerbs` structure
 is parameterized over an arbitrary `Perf` type, so alternative
 ontologies (e.g., a Farkas-Bruce-derived discourse adapter) can supply
@@ -142,12 +142,12 @@ open _root_.ArgumentStructure (EventRel)
 -- § 1. Performance Ontology
 -- ════════════════════════════════════════════════════
 
-/-- Default performance type: an `Event Time`, since performances have
+/-- Default performance type: an `Event T`, since performances have
     temporal extent and ontological status as events
     (per [rudin-2025b], fn 21). The `SpeechVerbs` structure is
     parameterized over `Perf`, so users may instantiate `Perf` with
     other types (e.g., a discourse-state-derived performance type). -/
-abbrev Performance (Time : Type*) [LinearOrder Time] := Event Time
+abbrev Performance (T : Type*) [LinearOrder T] := Event T
 
 /-- The ontology of performance properties.
 
@@ -223,22 +223,22 @@ end PerformanceOntology
     Each meaning postulate carries an annotation indicating whether it
     is *explicit* in [rudin-2025b] or an *extrapolation* (formal
     rendering of an informal generalization in the paper). -/
-structure SpeechVerbs (Time SemObj Perf : Type*) [LinearOrder Time]
+structure SpeechVerbs (T SemObj Perf : Type*) [LinearOrder T]
     (Ω : PerformanceOntology Perf) where
   /-- *say*: linguistic-material producing event -/
-  SAY : Event Time → Prop
+  SAY : Event T → Prop
   /-- *assert*: SAY + commitment -/
-  ASSERT : Event Time → Prop
+  ASSERT : Event T → Prop
   /-- *ask*: REENACT pole forces RESP performances -/
-  ASK : Event Time → Prop
+  ASK : Event T → Prop
   /-- *yell*: SAY + loud performance -/
-  YELL : Event Time → Prop
+  YELL : Event T → Prop
   /-- *whisper*: SAY + whispered performance -/
-  WHISPER : Event Time → Prop
+  WHISPER : Event T → Prop
   /-- CONTENT: event-to-content (proposition or question denotation) -/
-  CONTENT : EventRel Time SemObj
+  CONTENT : EventRel T SemObj
   /-- REENACT: event-to-performance ([rudin-2025b] §3.2). -/
-  REENACT : EventRel Time Perf
+  REENACT : EventRel T Perf
   /-- The semantic object is a proposition. -/
   isProposition : SemObj → Prop
   /-- The semantic object is a question denotation. -/
@@ -284,7 +284,7 @@ structure SpeechVerbs (Time SemObj Perf : Type*) [LinearOrder Time]
 
 namespace SpeechVerbs
 
-variable {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceOntology Perf}
+variable {T SemObj Perf : Type*} [LinearOrder T] {Ω : PerformanceOntology Perf}
 
 -- ════════════════════════════════════════════════════
 -- § 3. Composition: Quotative vs Propositional Complements
@@ -292,15 +292,15 @@ variable {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceOntology
 
 /-- *Propositional* complement composition: *V that p* asserts a CONTENT
     relation between the verb-event and the propositional denotation. -/
-def thatComp (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop)
-    (p : SemObj) (e : Event Time) : Prop :=
+def thatComp (M : SpeechVerbs T SemObj Perf Ω) (V : Event T → Prop)
+    (p : SemObj) (e : Event T) : Prop :=
   V e ∧ M.CONTENT e p
 
 /-- *Quotative* complement composition: *V "u"* asserts a REENACT relation
     between the verb-event and the cotemporaneous performance *u*
     (the referent of covert *pthat*; [rudin-2025b] §3). -/
-def quoteComp (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop)
-    (u : Perf) (e : Event Time) : Prop :=
+def quoteComp (M : SpeechVerbs T SemObj Perf Ω) (V : Event T → Prop)
+    (u : Perf) (e : Event T) : Prop :=
   V e ∧ M.REENACT e u
 
 /-- Quotative composition existentially closed over the performance.
@@ -309,8 +309,8 @@ def quoteComp (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop)
     attaches, then constrained by descriptive content (a proposition
     over performances, e.g., "this rising-declarative tokening of
     *Aaron likes apples?*"). -/
-def quoteCompEx (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop)
-    (P : Perf → Prop) (e : Event Time) : Prop :=
+def quoteCompEx (M : SpeechVerbs T SemObj Perf Ω) (V : Event T → Prop)
+    (P : Perf → Prop) (e : Event T) : Prop :=
   V e ∧ ∃ u, M.REENACT e u ∧ P u
 
 -- ════════════════════════════════════════════════════
@@ -320,8 +320,8 @@ def quoteCompEx (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop)
 /-- Prediction: a *say* event with REENACT to *u* requires *u* to be
     linguistic material. (Rules out *#Sara said {grunt}* in the absence
     of LINGMAT.) -/
-theorem say_quote_lingmat (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem say_quote_lingmat (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     quoteComp M M.SAY u e → Ω.LINGMAT u := by
   rintro ⟨hsay, hreen⟩
   exact (M.say_iff_lingmat e).mp hsay u hreen
@@ -329,8 +329,8 @@ theorem say_quote_lingmat (M : SpeechVerbs Time SemObj Perf Ω)
 /-- Prediction: an *assert* event with a rising-declarative performance
     is impossible ([rudin-2025b] §4.5: *#Sara asserted "Aaron
     likes apples?"* with rising intonation). -/
-theorem assert_quote_rd_empty (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem assert_quote_rd_empty (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     Ω.RisingDecl u → ¬ quoteComp M M.ASSERT u e := by
   intro hrd ⟨hass, hreen⟩
   obtain ⟨_, hcom⟩ := (M.assert_iff_say_and_commits e).mp hass
@@ -341,8 +341,8 @@ theorem assert_quote_rd_empty (M : SpeechVerbs Time SemObj Perf Ω)
     raise an issue and don't commit), satisfying ASK's postulate.
     ([rudin-2025b] §4.4.1: derives the felicity of *Sara asked
     "Aaron likes apples?"*.) -/
-theorem ask_quote_rd_consistent (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem ask_quote_rd_consistent (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     M.ASK e → M.REENACT e u → Ω.RisingDecl u → Ω.RESP u := by
   intro hask hreen _
   exact (M.ask_iff_resp e).mp hask u hreen
@@ -352,15 +352,15 @@ theorem ask_quote_rd_consistent (M : SpeechVerbs Time SemObj Perf Ω)
     `RaisesIssue`. (Rules out e.g. *#Sara asked "Aaron likes apples"*
     with falling, declarative intonation that commits the original
     speaker rather than raising an open question.) -/
-theorem ask_quote_no_issue_empty (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem ask_quote_no_issue_empty (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     ¬ Ω.RaisesIssue u → ¬ quoteComp M M.ASK u e := by
   intro hni ⟨hask, hreen⟩
   exact hni ((M.ask_iff_resp e).mp hask u hreen).1
 
 /-- Prediction: a *yell* event with REENACT to *u* makes *u* loud. -/
-theorem yell_quote_loud (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem yell_quote_loud (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     quoteComp M M.YELL u e → Ω.Loud u := by
   rintro ⟨hyell, hreen⟩
   exact ((M.yell_iff_say_and_loud e).mp hyell).2 u hreen
@@ -368,8 +368,8 @@ theorem yell_quote_loud (M : SpeechVerbs Time SemObj Perf Ω)
 /-- Prediction: a *whisper* event with a loud performance is impossible.
     Loud and whispered are mutually exclusive, but `whisper` requires
     whispered performances. -/
-theorem whisper_quote_loud_empty (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (u : Perf) :
+theorem whisper_quote_loud_empty (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (u : Perf) :
     Ω.Loud u → ¬ quoteComp M M.WHISPER u e := by
   intro hloud ⟨hwhis, hreen⟩
   obtain ⟨_, hwh⟩ := (M.whisper_iff_say_and_whispered e).mp hwhis
@@ -379,8 +379,8 @@ theorem whisper_quote_loud_empty (M : SpeechVerbs Time SemObj Perf Ω)
     that CONTENT be a question. Combined with disjointness of
     `isProposition` and `isQuestion` in concrete models, this rules out
     *#ask that p* with declarative *p*. -/
-theorem ask_that_question (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) (δ : SemObj) :
+theorem ask_that_question (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) (δ : SemObj) :
     thatComp M M.ASK δ e → M.isQuestion δ := by
   rintro ⟨hask, hcont⟩
   exact M.content_ask_question e δ hask hcont
@@ -390,18 +390,18 @@ theorem ask_that_question (M : SpeechVerbs Time SemObj Perf Ω)
 -- ════════════════════════════════════════════════════
 
 /-- ASSERT ⊆ SAY: an assertion is a saying. Direct from the postulate. -/
-theorem assert_implies_say (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) : M.ASSERT e → M.SAY e := fun h =>
+theorem assert_implies_say (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) : M.ASSERT e → M.SAY e := fun h =>
   ((M.assert_iff_say_and_commits e).mp h).1
 
 /-- YELL ⊆ SAY: yelling is a manner-of-saying. -/
-theorem yell_implies_say (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) : M.YELL e → M.SAY e := fun h =>
+theorem yell_implies_say (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) : M.YELL e → M.SAY e := fun h =>
   ((M.yell_iff_say_and_loud e).mp h).1
 
 /-- WHISPER ⊆ SAY: whispering is a manner-of-saying. -/
-theorem whisper_implies_say (M : SpeechVerbs Time SemObj Perf Ω)
-    (e : Event Time) : M.WHISPER e → M.SAY e := fun h =>
+theorem whisper_implies_say (M : SpeechVerbs T SemObj Perf Ω)
+    (e : Event T) : M.WHISPER e → M.SAY e := fun h =>
   ((M.whisper_iff_say_and_whispered e).mp h).1
 
 /-- ASSERT and ASK are incompatible at a single performance: ASSERT
@@ -410,7 +410,7 @@ theorem whisper_implies_say (M : SpeechVerbs Time SemObj Perf Ω)
     asked "p?"* via different performances, but a single performance
     can satisfy at most one.) -/
 theorem assert_ask_incompatible_at_perf
-    (M : SpeechVerbs Time SemObj Perf Ω) (e e' : Event Time) (u : Perf) :
+    (M : SpeechVerbs T SemObj Perf Ω) (e e' : Event T) (u : Perf) :
     M.ASSERT e → M.REENACT e u → M.ASK e' → M.REENACT e' u → False := by
   intro hass hreen hask hreen'
   obtain ⟨_, hcom⟩ := (M.assert_iff_say_and_commits e).mp hass
@@ -422,7 +422,7 @@ theorem assert_ask_incompatible_at_perf
     not linguistic material is impossible. The postulate enforces
     LINGMAT, so a non-LINGMAT witness gives an immediate contradiction. -/
 theorem say_non_lingmat_impossible
-    (M : SpeechVerbs Time SemObj Perf Ω) (e : Event Time) (u : Perf) :
+    (M : SpeechVerbs T SemObj Perf Ω) (e : Event T) (u : Perf) :
     M.SAY e → M.REENACT e u → ¬ Ω.LINGMAT u → False := fun hsay hreen hnl =>
   hnl ((M.say_iff_lingmat e).mp hsay u hreen)
 
@@ -689,8 +689,8 @@ inductive Complement
   deriving DecidableEq, Repr, Inhabited
 
 /-- Selector: map a `Verb` enum to the corresponding model predicate. -/
-def Verb.toPred {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceOntology Perf}
-    (M : SpeechVerbs Time SemObj Perf Ω) : Verb → (Event Time → Prop)
+def Verb.toPred {T SemObj Perf : Type*} [LinearOrder T] {Ω : PerformanceOntology Perf}
+    (M : SpeechVerbs T SemObj Perf Ω) : Verb → (Event T → Prop)
   | .say => M.SAY
   | .assert => M.ASSERT
   | .yell => M.YELL
@@ -720,8 +720,8 @@ def Verb.toPred {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceO
     constraints on REENACTed performances (or CONTENT denotations);
     if those constraints conflict with the complement's, no witness
     exists and the cell is infelicitous. -/
-def Felicitous {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceOntology Perf}
-    (M : SpeechVerbs Time SemObj Perf Ω) (V : Event Time → Prop) :
+def Felicitous {T SemObj Perf : Type*} [LinearOrder T] {Ω : PerformanceOntology Perf}
+    (M : SpeechVerbs T SemObj Perf Ω) (V : Event T → Prop) :
     Complement → Prop
   | .quoteDecl =>
       ∃ e u, V e ∧ M.REENACT e u ∧ Ω.LINGMAT u ∧ Ω.Commits u
@@ -747,8 +747,8 @@ def Felicitous {Time SemObj Perf : Type*} [LinearOrder Time] {Ω : PerformanceOn
     This class IS the empirical claim. There is no separate `empirical`
     function whose values must be reconciled with model predictions —
     a model satisfies these facts or it does not. -/
-class IsRudinModel {Time SemObj Perf : Type*} [LinearOrder Time]
-    {Ω : PerformanceOntology Perf} (M : SpeechVerbs Time SemObj Perf Ω) :
+class IsRudinModel {T SemObj Perf : Type*} [LinearOrder T]
+    {Ω : PerformanceOntology Perf} (M : SpeechVerbs T SemObj Perf Ω) :
     Prop where
   -- say (5 felicitous, 1 infelicitous)
   say_quoteDecl       : Felicitous M M.SAY .quoteDecl

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -43,13 +43,13 @@ open Aspect (PointPred)
 /-- The `EARLIEST` definedness presupposition of `before^{B&C}`: `EARLIEST_C` is defined for
     body `p` iff the set of `C`-times where `p` holds has a least element (mathlib's
     `IsLeast`). -/
-def hasEarliest {Time : Type*} [LinearOrder Time] (C : Set Time) (p : Time → Prop) : Prop :=
+def hasEarliest {T : Type*} [LinearOrder T] (C : Set T) (p : T → Prop) : Prop :=
   ∃ t, IsLeast {t' | t' ∈ C ∧ p t'} t
 
 /-- [beaver-condoravdi-2003]'s `earliest` is defined exactly when the `EARLIEST`
     presupposition holds of the instantiation times, with trivial restrictor. -/
-theorem earliestAlt_nonempty_iff_hasEarliest {W Time : Type*} [LinearOrder Time]
-    (alt : HistoricalAlternatives W Time) (B : Set (W × Time)) (w : W) (t : Time) :
+theorem earliestAlt_nonempty_iff_hasEarliest {W T : Type*} [LinearOrder T]
+    (alt : HistoricalAlternatives W T) (B : Set (W × T)) (w : W) (t : T) :
     (BeaverCondoravdi2003.earliestAlt alt B w t).Nonempty ↔
       hasEarliest Set.univ (· ∈ BeaverCondoravdi2003.instTimes (alt ⟨w, t⟩) B) := by
   unfold hasEarliest
@@ -72,8 +72,8 @@ inductive LexicalType
     `some` (`Quantification.some_sem`) over the contextual restrictor `K`, with
     scope "precedes `t` and satisfies `p`". Definitionally
     `∃ t' ∈ K, t' < t ∧ p t'`. -/
-def quantificationalPast {Time : Type*} [LT Time]
-    (K : Set Time) (p : Time → Prop) (t : Time) : Prop :=
+def quantificationalPast {T : Type*} [LT T]
+    (K : Set T) (p : T → Prop) (t : T) : Prop :=
   Quantification.some_sem (· ∈ K) (fun t' => t' < t ∧ p t')
 
 /-- The pipeline's existential past is the quantificational past with trivial
@@ -81,8 +81,8 @@ def quantificationalPast {Time : Type*} [LT Time]
     with `pronominalLookup_eq_some_iff_tensePronoun` below, this places both
     of Sharvit's tense lexical types over operators the rest of the codebase
     already uses. -/
-theorem evalPast_iff_quantificationalPast {W Time : Type*} [LinearOrder Time]
-    (p : PointPred W Time) (tc : Time) (w : W) :
+theorem evalPast_iff_quantificationalPast {W T : Type*} [LinearOrder T]
+    (p : PointPred W T) (tc : T) (w : W) :
     evalPast p tc w ↔ quantificationalPast Set.univ (λ t => p ⟨w, t⟩) tc := by
   simp [evalPast, evalRel, quantificationalPast, Quantification.some_sem]
 
@@ -93,11 +93,11 @@ theorem evalPast_iff_quantificationalPast {W Time : Type*} [LinearOrder Time]
     via density to a strictly smaller body-witness. The technical core of the
     thesis that only languages with pronominal tenses license past-under-past
     in `before`-clauses. -/
-theorem ipf_quantificationalPast {Time : Type*} [LinearOrder Time]
-    {C K : Set Time}
+theorem ipf_quantificationalPast {T : Type*} [LinearOrder T]
+    {C K : Set T}
     (hK : K ⊆ C)
     (hC_dense : ∀ a b, a ∈ C → b ∈ C → a < b → ∃ c ∈ C, a < c ∧ c < b)
-    (q : Time → Prop) :
+    (q : T → Prop) :
     ¬ hasEarliest C (quantificationalPast K q) := by
   rintro ⟨t_min, ⟨ht_min_C, t_q, ht_q_K, ht_q_lt, hq_t_q⟩, hmin⟩
   obtain ⟨t_mid, ht_mid_C, ht_q_lt_mid, ht_mid_lt_min⟩ :=
@@ -129,21 +129,21 @@ past-constraint `TensePronoun`, so [sharvit-2014]'s (30a) and
 /-- [sharvit-2014] (30a): pronominal-past lookup `[[past_{j,k}]]^g`. Indices `j`
     (evaluation), `k` (referential); defined iff `g k < g j`, then `g k`. Uses
     `Option` (not `Part`/`PFun`) as the domain is decidable. -/
-def pronominalLookup {Time : Type*} [LT Time] [DecidableLT Time]
-    (g : ℕ → Time) (j k : ℕ) : Option Time :=
+def pronominalLookup {T : Type*} [LT T] [DecidableLT T]
+    (g : ℕ → T) (j k : ℕ) : Option T :=
   if g k < g j then some (g k) else none
 
 /-- The pronominal past denotes the referential index when defined. -/
 @[simp]
-theorem pronominalLookup_eq_some_iff {Time : Type*} [LT Time]
-    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) (t : Time) :
+theorem pronominalLookup_eq_some_iff {T : Type*} [LT T]
+    [DecidableLT T] (g : ℕ → T) (j k : ℕ) (t : T) :
     pronominalLookup g j k = some t ↔ g k < g j ∧ g k = t := by
   unfold pronominalLookup; split <;> simp_all
 
 /-- The pronominal past is undefined exactly when the constraint fails. -/
 @[simp]
-theorem pronominalLookup_eq_none_iff {Time : Type*} [LT Time]
-    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) :
+theorem pronominalLookup_eq_none_iff {T : Type*} [LT T]
+    [DecidableLT T] (g : ℕ → T) (j k : ℕ) :
     pronominalLookup g j k = none ↔ ¬ g k < g j := by
   unfold pronominalLookup; split <;> simp_all
 
@@ -151,8 +151,8 @@ theorem pronominalLookup_eq_none_iff {Time : Type*} [LT Time]
     defined with value `t` iff the past-constraint `TensePronoun` with
     referential index `k` and evaluation index `j` satisfies its presupposition
     and resolves to `t` — for any binding `mode`. -/
-theorem pronominalLookup_eq_some_iff_tensePronoun {Time : Type*} [LinearOrder Time]
-    (g : Tense.TemporalAssignment Time) (j k : ℕ) (t : Time)
+theorem pronominalLookup_eq_some_iff_tensePronoun {T : Type*} [LinearOrder T]
+    (g : Tense.TemporalAssignment T) (j k : ℕ) (t : T)
     (mode : Intensional.ReferentialMode) :
     pronominalLookup g j k = some t ↔
       (Tense.TensePronoun.mk k Tense.past mode j).fullPresupposition g ∧

--- a/Linglib/Studies/TsiliaZhao2026.lean
+++ b/Linglib/Studies/TsiliaZhao2026.lean
@@ -45,8 +45,8 @@ open Semantics.Context (KContext)
     the shifted PRES (R = π') and a clausemate ⌈then⌉ (reference disjoint
     from π') read the same π' — no reference satisfies both the "during
     then" containment and disjointness. *Nate said Erica is angry (*then)*. -/
-theorem shifted_present_blocks_then {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time) (attitudeTime : Time)
+theorem shifted_present_blocks_then {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T) (attitudeTime : T)
     (hPres : (opPi f attitudeTime).isPresent) :
     ¬∃ thenRef, (opPi f attitudeTime).referenceTime = thenRef ∧
       thenPresup thenRef (opPi f attitudeTime).perspectiveTime :=

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -61,8 +61,8 @@ open Tense
 /-- [von-stechow-2009] derives the shifted reading: [PAST] feature
     checked against matrix E. The embedded reference time is before
     the matrix event time. -/
-theorem vonStechow_derives_shifted {Time : Type*} [LinearOrder Time]
-    (matrixFrame : ReichenbachFrame Time) (embeddedR embeddedE : Time)
+theorem vonStechow_derives_shifted {T : Type*} [LinearOrder T]
+    (matrixFrame : ReichenbachFrame T) (embeddedR embeddedE : T)
     (hPast : compare embeddedR matrixFrame.eventTime ∈ Tense.past) :
     (embeddedFrame matrixFrame embeddedR embeddedE).isPast := by
   simp only [embeddedFrame, ReichenbachFrame.isPast]
@@ -71,17 +71,17 @@ theorem vonStechow_derives_shifted {Time : Type*} [LinearOrder Time]
 /-- [von-stechow-2009] derives the simultaneous reading: [PRES]
     feature checked against matrix E. The embedded reference time
     equals the matrix event time — no deletion rule needed. -/
-theorem vonStechow_derives_simultaneous {Time : Type*} [LinearOrder Time]
-    (matrixFrame : ReichenbachFrame Time) (embeddedE : Time) :
+theorem vonStechow_derives_simultaneous {T : Type*} [LinearOrder T]
+    (matrixFrame : ReichenbachFrame T) (embeddedE : T) :
     (embeddedFrame matrixFrame matrixFrame.eventTime embeddedE).isPresent := by
   simp only [embeddedFrame, ReichenbachFrame.isPresent]
 
 /-- [von-stechow-2009] derives double-access: [PRES] feature under
     past attitude verb. The present tense is checked against matrix E,
     but its indexical nature also requires truth at speech time. -/
-theorem vonStechow_derives_double_access {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time)
-    (p : Time → Prop)
+theorem vonStechow_derives_double_access {T : Type*}
+    (matrixFrame : ReichenbachFrame T)
+    (p : T → Prop)
     (h_matrix : p matrixFrame.eventTime)
     (h_speech : p matrixFrame.speechTime) :
     p matrixFrame.eventTime ∧ p matrixFrame.speechTime :=
@@ -96,8 +96,8 @@ theorem vonStechow_derives_double_access {Time : Type*}
     This is where von Stechow has an advantage over [abusch-1997]:
     feature checking does not require attitude semantics or res
     movement — any eval time source works. -/
-theorem vonStechow_derives_relative_clause {Time : Type*} [LinearOrder Time]
-    (rcPerspective : Time) (rcRefTime : Time)
+theorem vonStechow_derives_relative_clause {T : Type*} [LinearOrder T]
+    (rcPerspective : T) (rcRefTime : T)
     (hPast : compare rcRefTime rcPerspective ∈ Tense.past) :
     rcRefTime < rcPerspective :=
   (Tense.compare_mem_past _ _).mp hPast
@@ -110,8 +110,8 @@ theorem vonStechow_derives_relative_clause {Time : Type*} [LinearOrder Time]
 /-- [von-stechow-2009]'s feature checking is
     `TensePronoun.fullPresupposition` when the eval time resolves to
     the same value. -/
-theorem feature_checking_is_fullPresupposition {Time : Type*} [LinearOrder Time]
-    (tp : TensePronoun) (g : TemporalAssignment Time) :
+theorem feature_checking_is_fullPresupposition {T : Type*} [LinearOrder T]
+    (tp : TensePronoun) (g : TemporalAssignment T) :
     compare (tp.resolve g) (tp.evalTime g) ∈ tp.constraint ↔
     tp.fullPresupposition g :=
   Iff.rfl
@@ -120,44 +120,44 @@ theorem feature_checking_is_fullPresupposition {Time : Type*} [LinearOrder Time]
 /-! ### Situation-indexed attitudes
 
 The complement type of *believe* shifts from `W → Prop` to
-predicates over `Index W Time`, and doxastic alternatives become world–time pairs:
+predicates over `Index W T`, and doxastic alternatives become world–time pairs:
 ⟦x believes p⟧(w,t) = ∀(w',t') ∈ Dox_x(w,t). p(w',t'). -/
 
 open Intensional (Index)
 open Doxastic (Veridicality DoxasticPredicate BoxAt VeridicalityHolds)
 
-variable {W Time E : Type*}
+variable {W T E : Type*}
 
 /-- Universal modal over situations: `p` holds at every accessible
     world–time pair. -/
-def sitBoxAt (R : E → Index W Time → Index W Time → Prop)
-    (agent : E) (s : Index W Time)
-    (situations : List (Index W Time)) (p : (Index W Time → Prop)) : Prop :=
+def sitBoxAt (R : E → Index W T → Index W T → Prop)
+    (agent : E) (s : Index W T)
+    (situations : List (Index W T)) (p : (Index W T → Prop)) : Prop :=
   ∀ s' ∈ situations, R agent s s' → p s'
 
-instance (R : E → Index W Time → Index W Time → Prop)
-    [∀ a s s', Decidable (R a s s')] (agent : E) (s : Index W Time)
-    (situations : List (Index W Time)) (p : (Index W Time → Prop))
+instance (R : E → Index W T → Index W T → Prop)
+    [∀ a s s', Decidable (R a s s')] (agent : E) (s : Index W T)
+    (situations : List (Index W T)) (p : (Index W T → Prop))
     [DecidablePred p] : Decidable (sitBoxAt R agent s situations p) :=
   inferInstanceAs (Decidable (∀ s' ∈ situations, _))
 
 /-- A world-proposition as a situation-proposition ignoring the
     temporal coordinate. -/
-def liftProp (p : W → Prop) : (Index W Time → Prop) :=
+def liftProp (p : W → Prop) : (Index W T → Prop) :=
   fun s => p s.world
 
 /-- A world-accessibility relation as a situation-accessibility
     relation ignoring temporal coordinates — classic Hintikka
     behavior, where doxastic alternatives differ only in world. -/
 def liftAccess (R : E → W → W → Prop) :
-    E → Index W Time → Index W Time → Prop :=
+    E → Index W T → Index W T → Prop :=
   fun agent s₁ s₂ => R agent s₁.world s₂.world
 
 /-- Hintikka semantics is the time-invariant special case: on lifted
     relations and propositions, the situation modal is `BoxAt` over
     the world projections. -/
 theorem sitBoxAt_lift_eq_BoxAt (R : E → W → W → Prop) (agent : E)
-    (s : Index W Time) (sits : List (Index W Time))
+    (s : Index W T) (sits : List (Index W T))
     (p : W → Prop) :
     sitBoxAt (liftAccess R) agent s sits (liftProp p) ↔
     BoxAt R agent s.world (sits.map (·.world)) p := by
@@ -170,43 +170,43 @@ theorem sitBoxAt_lift_eq_BoxAt (R : E → W → W → Prop) (agent : E)
 
 /-- The veridicality check at a situation: veridical predicates
     require the complement at the evaluation situation. -/
-def sitVeridicalityHolds (v : Veridicality) (p : (Index W Time → Prop))
-    (s : Index W Time) : Prop :=
+def sitVeridicalityHolds (v : Veridicality) (p : (Index W T → Prop))
+    (s : Index W T) : Prop :=
   match v with
   | .veridical => p s
   | .nonVeridical => True
 
-instance (v : Veridicality) (p : (Index W Time → Prop)) [DecidablePred p]
-    (s : Index W Time) :
+instance (v : Veridicality) (p : (Index W T → Prop)) [DecidablePred p]
+    (s : Index W T) :
     Decidable (sitVeridicalityHolds v p s) := by
   cases v <;> simp [sitVeridicalityHolds] <;> infer_instance
 
 /-- Lifted veridicality is world-level veridicality. -/
 theorem sitVeridicalityHolds_lift (v : Veridicality) (p : W → Prop)
-    (s : Index W Time) :
+    (s : Index W T) :
     sitVeridicalityHolds v (liftProp p) s ↔ VeridicalityHolds v p s.world := by
   cases v <;> simp [sitVeridicalityHolds, VeridicalityHolds, liftProp]
 
 /-- A doxastic predicate with situation-indexed accessibility:
     `Dox_y(w,t)` is a set of world–time pairs. -/
-structure SitDoxasticPredicate (W Time E : Type*) where
+structure SitDoxasticPredicate (W T E : Type*) where
   /-- Situation-indexed accessibility relation. -/
-  access : E → Index W Time → Index W Time → Prop
+  access : E → Index W T → Index W T → Prop
   /-- Veridicality (veridical or not). -/
   veridicality : Veridicality
 
 /-- ⟦x V that p⟧(s): the veridicality check at `s` plus the universal
     modal over accessible situations. -/
-def SitDoxasticPredicate.HoldsAt (V : SitDoxasticPredicate W Time E)
-    (agent : E) (p : (Index W Time → Prop)) (s : Index W Time)
-    (situations : List (Index W Time)) : Prop :=
+def SitDoxasticPredicate.HoldsAt (V : SitDoxasticPredicate W T E)
+    (agent : E) (p : (Index W T → Prop)) (s : Index W T)
+    (situations : List (Index W T)) : Prop :=
   sitVeridicalityHolds V.veridicality p s ∧ sitBoxAt V.access agent s situations p
 
 /-- Veridical situation-indexed predicates entail their complement at
     the evaluation situation. -/
-theorem sit_veridical_entails_complement (V : SitDoxasticPredicate W Time E)
-    (hV : V.veridicality = .veridical) (agent : E) (p : (Index W Time → Prop))
-    (s : Index W Time) (sits : List (Index W Time))
+theorem sit_veridical_entails_complement (V : SitDoxasticPredicate W T E)
+    (hV : V.veridicality = .veridical) (agent : E) (p : (Index W T → Prop))
+    (s : Index W T) (sits : List (Index W T))
     (holds : V.HoldsAt agent p s sits) : p s := by
   unfold SitDoxasticPredicate.HoldsAt at holds
   rw [hV] at holds
@@ -214,8 +214,8 @@ theorem sit_veridical_entails_complement (V : SitDoxasticPredicate W Time E)
 
 /-- A world-level `DoxasticPredicate` as a situation-indexed one, with
     time-invariant accessibility. -/
-def liftDoxastic (V : DoxasticPredicate W E) (Time : Type*) :
-    SitDoxasticPredicate W Time E where
+def liftDoxastic (V : DoxasticPredicate W E) (T : Type*) :
+    SitDoxasticPredicate W T E where
   access := liftAccess V.access
   veridicality := V.veridicality
 
@@ -223,9 +223,9 @@ def liftDoxastic (V : DoxasticPredicate W E) (Time : Type*) :
     `DoxasticPredicate` analysis replays unchanged in the
     situation-indexed framework. -/
 theorem liftDoxastic_holdsAt_iff (V : DoxasticPredicate W E) (agent : E)
-    (p : W → Prop) (s : Index W Time)
-    (sits : List (Index W Time)) :
-    (liftDoxastic V Time).HoldsAt agent (liftProp p) s sits ↔
+    (p : W → Prop) (s : Index W T)
+    (sits : List (Index W T)) :
+    (liftDoxastic V T).HoldsAt agent (liftProp p) s sits ↔
     V.HoldsAt agent p s.world (sits.map (·.world)) := by
   simp only [SitDoxasticPredicate.HoldsAt, DoxasticPredicate.HoldsAt,
     liftDoxastic, sitVeridicalityHolds_lift, sitBoxAt_lift_eq_BoxAt]
@@ -239,23 +239,23 @@ clause's temporal interpretation to the matrix event time. -/
 /-- Accessible situations share the evaluation time — the
     simultaneous reading in sequence of tense. -/
 def temporallyBound (R : E → W → W → Prop) :
-    E → Index W Time → Index W Time → Prop :=
+    E → Index W T → Index W T → Prop :=
   fun agent s₁ s₂ => R agent s₁.world s₂.world ∧ s₂.time = s₁.time
 
-instance [DecidableEq Time] (R : E → W → W → Prop)
+instance [DecidableEq T] (R : E → W → W → Prop)
     [∀ a w w', Decidable (R a w w')] :
-    ∀ a s₁ s₂, Decidable (temporallyBound (Time := Time) R a s₁ s₂) := by
+    ∀ a s₁ s₂, Decidable (temporallyBound (T := T) R a s₁ s₂) := by
   intro a s₁ s₂; unfold temporallyBound; infer_instance
 
 /-- Accessible situations are at or after the evaluation time —
     forward-looking attitudes like *expect* and *intend*. -/
-def futureOriented [LE Time] (R : E → W → W → Prop) :
-    E → Index W Time → Index W Time → Prop :=
+def futureOriented [LE T] (R : E → W → W → Prop) :
+    E → Index W T → Index W T → Prop :=
   fun agent s₁ s₂ => R agent s₁.world s₂.world ∧ s₁.time ≤ s₂.time
 
-instance [LE Time] [DecidableRel (α := Time) (· ≤ ·)]
+instance [LE T] [DecidableRel (α := T) (· ≤ ·)]
     (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')] :
-    ∀ a s₁ s₂, Decidable (futureOriented (Time := Time) R a s₁ s₂) := by
+    ∀ a s₁ s₂, Decidable (futureOriented (T := T) R a s₁ s₂) := by
   intro a s₁ s₂; unfold futureOriented; infer_instance
 
 /-! ### Temporal tower bridge ([abusch-1997] ↔ `ContextTower`)

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -247,24 +247,24 @@ end TypeDriven
 /-! ### Three domain instantiations -/
 
 section Domains
-variable {Entity Time : Type*} [LinearOrder Time]
+variable {Entity T : Type*} [LinearOrder T]
 
 /-- Nominal comparative (§2.1, eq. 42): Agent role, entities measured via
     `themeOf`. -/
-def nominalComparative (frame : ThematicFrame Entity Time)
-    (P : Event Time → Prop) (themeOf : Event Time → Entity)
+def nominalComparative (frame : ThematicFrame Entity T)
+    (P : Event T → Prop) (themeOf : Event T → Entity)
     (μ : Entity → ℚ) (a b : Entity) : Prop :=
   comparativeTruth frame.agent P themeOf μ a b
 
 /-- Verbal comparative (§2.2, eq. 48): Agent role, events measured directly. -/
-def verbalComparative (frame : ThematicFrame Entity Time)
-    (P : Event Time → Prop) (μ : Event Time → ℚ) (a b : Entity) : Prop :=
+def verbalComparative (frame : ThematicFrame Entity T)
+    (P : Event T → Prop) (μ : Event T → ℚ) (a b : Entity) : Prop :=
   comparativeTruth frame.agent P id μ a b
 
 /-- Adjectival comparative (§3.2, eq. 65): Holder role, states measured
     directly. -/
-def adjectivalComparative (frame : ThematicFrame Entity Time)
-    (P : Event Time → Prop) (μ : Event Time → ℚ) (a b : Entity) : Prop :=
+def adjectivalComparative (frame : ThematicFrame Entity T)
+    (P : Event T → Prop) (μ : Event T → ℚ) (a b : Entity) : Prop :=
   comparativeTruth frame.holder P id μ a b
 
 end Domains

--- a/Linglib/Studies/Zeijlstra2012.lean
+++ b/Linglib/Studies/Zeijlstra2012.lean
@@ -135,8 +135,8 @@ theorem sotConfig_only_matrix_active (cfg : SOTAgreeConfig) :
     clause has no independent past — it is interpreted at the matrix event
     time, giving `simultaneousFrame` (R' = P' = matrix E). See the module notes
     on the fn. 9 non-future refinement. -/
-theorem zeijlstra_derives_simultaneous {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) (embeddedE : Time)
+theorem zeijlstra_derives_simultaneous {T : Type*}
+    (matrixFrame : ReichenbachFrame T) (embeddedE : T)
     (embeddedT : TenseHead)
     (h_u : embeddedT.status = .uninterpretable) :
     ¬ embeddedT.IsSemanticallyActive ∧
@@ -148,9 +148,9 @@ theorem zeijlstra_derives_simultaneous {Time : Type*}
 /-- The back-shifted reading: when embedded `T` bears an independent `[iPAST]`
     (no Agree), it contributes genuine past semantics: the embedded frame
     is past (R' < P'). -/
-theorem zeijlstra_derives_shifted {Time : Type*} [LinearOrder Time]
-    (matrixFrame : ReichenbachFrame Time)
-    (embeddedR embeddedE : Time)
+theorem zeijlstra_derives_shifted {T : Type*} [LinearOrder T]
+    (matrixFrame : ReichenbachFrame T)
+    (embeddedR embeddedE : T)
     (embeddedT : TenseHead)
     (h_i : embeddedT.status = .interpretable)
     (h_shifted : embeddedR < matrixFrame.eventTime) :

--- a/Linglib/Studies/Zhao2025.lean
+++ b/Linglib/Studies/Zhao2025.lean
@@ -30,7 +30,7 @@ dynamicity projection in Aktionsart), not a single theorem.
 
 `le.requiresAntiAtomDist = true` is the Fragment-level encoding of
 [zhao-2025] Def. 5.36 (p. 165) ATOM-DIST_t at the verb-quantifier
-level. The substrate-side treatment lives in `Core/Time/AtomDist.lean`
+level. The substrate-side treatment lives in `Core/T/AtomDist.lean`
 (`AtomDist τ V`, with `EvQuant.ofPred` bridging from event predicates
 to event quantifiers); for the witness-universal subinterval form on
 event predicates, see `HasSubintervalProp` in
@@ -95,8 +95,8 @@ def thenAdverbs : List ThenAdverb :=
 /-- Root clause ("Mary is feeling sick (*then)"): π = S, so a present-tensed
     clause admits no ⌈then⌉ restriction — no reference satisfies both the
     "during then" containment and ⌈then⌉'s disjointness from π. -/
-theorem then_present_root_clash {Time : Type*} [LinearOrder Time]
-    (f : ReichenbachFrame Time)
+theorem then_present_root_clash {T : Type*} [LinearOrder T]
+    (f : ReichenbachFrame T)
     (hSimple : f.isSimpleCase) (hPres : f.isPresent) :
     ¬∃ thenRef, f.referenceTime = thenRef ∧ thenPresup thenRef f.speechTime :=
   λ ⟨_, hDuring, hThen⟩ =>


### PR DESCRIPTION
The time axis is bound as `Time` in 83 files and as `T` in the rest (`KContext W E P T`, `ReichenbachFrame T`); this consolidates on `T`, pairing with `W` for worlds and matching the temporal frame ⟨T, <⟩. Pure identifier rename: the `Time` namespace (`open Time`, `Time.ReichenbachFrame`) and English prose ("Perfect Time Span", "Time-Spheres") are untouched.