### PR TITLE
refactor(Tense): move ReichenbachFrame from namespace Time to Tense

### DIFF
--- a/Linglib/Fragments/English/Tense.lean
+++ b/Linglib/Fragments/English/Tense.lean
@@ -22,7 +22,7 @@ constraints via `EPCondition` and `UPCondition` enums.
 
 -/
 
-open Time
+open Tense
 open Tense
 
 namespace English.Tense

--- a/Linglib/Fragments/German/Tense.lean
+++ b/Linglib/Fragments/German/Tense.lean
@@ -24,7 +24,7 @@ has a PRESENT tense head (indexical-compatible).
 
 -/
 
-open Time
+open Tense
 open Tense
 
 namespace German.Tense

--- a/Linglib/Fragments/Italian/Tense.lean
+++ b/Linglib/Fragments/Italian/Tense.lean
@@ -29,7 +29,7 @@ PRESENT tense + PERFECT aspect. The auxiliary *avere*/*essere* makes the
 PERF head morphologically transparent.
 -/
 
-open Time
+open Tense
 open Tense
 
 namespace Italian.Tense

--- a/Linglib/Semantics/Reference/Context/Basic.lean
+++ b/Linglib/Semantics/Reference/Context/Basic.lean
@@ -14,7 +14,7 @@ projection; `KContext` is the full Kaplanian structure.
 
 -/
 
-open Time
+open Tense
 
 namespace Semantics.Context
 

--- a/Linglib/Semantics/Tense/Decomposition.lean
+++ b/Linglib/Semantics/Tense/Decomposition.lean
@@ -21,7 +21,7 @@ divergence from [ogihara-1996] live in `Studies/Kratzer1998.lean`.
 
 namespace Tense.Decomposition
 
-open Time Tense
+open Tense
 open Intensional (Overtness)
 
 /-! ### SOT deletion -/

--- a/Linglib/Semantics/Tense/Embedding.lean
+++ b/Linglib/Semantics/Tense/Embedding.lean
@@ -17,7 +17,7 @@ shifted/simultaneous split by a language's `SOTParameter`, and
 presuppositional construal.
 -/
 
-open Time
+open Tense
 
 namespace Tense
 

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -55,7 +55,7 @@ classification in `Evidential`. `EPCondition.IsNonfuture` and
 
 -/
 
-open Time
+open Tense
 
 namespace Tense.Evidential
 

--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -26,7 +26,7 @@ against π — PAST `Tense.past`, PRES `Tense.present`, and ⌈then⌉
 ⌈then⌉-present clash is disjointness of comparison categories.
 -/
 
-open Time
+open Tense
 
 namespace Tense.Perspective
 

--- a/Linglib/Semantics/Tense/Reichenbach.lean
+++ b/Linglib/Semantics/Tense/Reichenbach.lean
@@ -17,7 +17,7 @@ Tense relates R to P; Aspect relates E to R.
 
 -/
 
-namespace Time
+namespace Tense
 
 /--
 Reichenbach's temporal parameters for tense/aspect analysis,
@@ -173,4 +173,4 @@ instance (f : ReichenbachFrame T) : Decidable f.isProspective :=
 
 end ReichenbachFrame
 
-end Time
+end Tense

--- a/Linglib/Studies/Arka2013.lean
+++ b/Linglib/Studies/Arka2013.lean
@@ -45,7 +45,7 @@ structures are equational.
 
 namespace Arka2013
 
-open Time Indonesian Data.Examples
+open Tense Indonesian Data.Examples
 
 /-! ### Tense theory and the status of Indonesian TAM (§2) -/
 

--- a/Linglib/Studies/Declerck1991.lean
+++ b/Linglib/Studies/Declerck1991.lean
@@ -29,7 +29,7 @@ companion volume, [declerck-1991-grammar].
 - `putiDefault`: Declerck's principle of unmarked temporal interpretation
 -/
 
-open Time
+open Tense
 
 namespace Declerck1991
 

--- a/Linglib/Studies/Egressy2026.lean
+++ b/Linglib/Studies/Egressy2026.lean
@@ -116,17 +116,17 @@ the three named readings are exactly `ReichenbachFrame.isPast/isPresent/isFuture
 
 variable {T : Type*} [LinearOrder T]
 
-theorem isPast_iff_atom (f : Time.ReichenbachFrame T) :
+theorem isPast_iff_atom (f : Tense.ReichenbachFrame T) :
     f.isPast ↔ compare f.referenceTime f.perspectiveTime = Ordering.lt := by
-  simp [Time.ReichenbachFrame.isPast, Tense.past]
+  simp [Tense.ReichenbachFrame.isPast, Tense.past]
 
-theorem isPresent_iff_atom (f : Time.ReichenbachFrame T) :
+theorem isPresent_iff_atom (f : Tense.ReichenbachFrame T) :
     f.isPresent ↔ compare f.referenceTime f.perspectiveTime = Ordering.eq := by
-  simp [Time.ReichenbachFrame.isPresent]
+  simp [Tense.ReichenbachFrame.isPresent]
 
-theorem isFuture_iff_atom (f : Time.ReichenbachFrame T) :
+theorem isFuture_iff_atom (f : Tense.ReichenbachFrame T) :
     f.isFuture ↔ compare f.referenceTime f.perspectiveTime = Ordering.gt := by
-  simp [Time.ReichenbachFrame.isFuture, Tense.future]
+  simp [Tense.ReichenbachFrame.isFuture, Tense.future]
 
 end Realization
 

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -57,7 +57,7 @@ files consume it). Verified against the Kiparsky 2002 PDF: the
 
 -/
 
-open Time
+open Tense
 
 namespace Kiparsky2002
 

--- a/Linglib/Studies/Klecha2016.lean
+++ b/Linglib/Studies/Klecha2016.lean
@@ -54,7 +54,7 @@ can be future-oriented:
 
 -/
 
-open Time
+open Tense
 open Tense
 
 namespace Klecha2016

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -51,7 +51,7 @@ judgment.
 
 -/
 
-open Time
+open Tense
 
 namespace Kratzer1998
 

--- a/Linglib/Studies/Ogihara1996.lean
+++ b/Linglib/Studies/Ogihara1996.lean
@@ -40,7 +40,7 @@ puzzle (where they actually diverge).
 
 -/
 
-open Time
+open Tense
 
 namespace Ogihara1996
 

--- a/Linglib/Studies/Percus2000.lean
+++ b/Linglib/Studies/Percus2000.lean
@@ -44,7 +44,7 @@ Fragments/English/Predicates/Verbal.lean
 
 -/
 
-open Time
+open Tense
 open Tense
 
 namespace Percus2000

--- a/Linglib/Studies/Schlenker2004.lean
+++ b/Linglib/Studies/Schlenker2004.lean
@@ -65,7 +65,7 @@ This file: tower operations produce the Reichenbach frames of the SOT diagnostic
 
 -/
 
-open Tense Time
+open Tense
 
 namespace Schlenker2004
 

--- a/Linglib/Studies/Sharvit2003.lean
+++ b/Linglib/Studies/Sharvit2003.lean
@@ -43,7 +43,7 @@ contrast as separate Lean defs would be vacuous.
 
 -/
 
-open Time
+open Tense
 
 namespace Sharvit2003
 

--- a/Linglib/Studies/TsiliaZhao2026.lean
+++ b/Linglib/Studies/TsiliaZhao2026.lean
@@ -36,7 +36,7 @@ tolerates present-under-future.
 
 namespace TsiliaZhao2026
 
-open Time Tense Tense.Perspective
+open Tense Tense.Perspective
 open Semantics.Context (KContext)
 
 /-! ### Shift together -/

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -47,7 +47,7 @@ embedded tense to the matrix event time in sequence of tense.
 
 -/
 
-open Time
+open Tense
 
 namespace VonStechow2009
 

--- a/Linglib/Studies/Wurmbrand2014.lean
+++ b/Linglib/Studies/Wurmbrand2014.lean
@@ -198,7 +198,7 @@ theorem restructuring_dependent :
     embedded perspective time is the matrix event time (`embeddedFrame`). -/
 theorem propositional_uses_attitude_eval_time :
     classOrientation .propositional = .simultaneous ∧
-    ∀ (f : Time.ReichenbachFrame ℕ) (embR embE : ℕ),
+    ∀ (f : Tense.ReichenbachFrame ℕ) (embR embE : ℕ),
       (Tense.embeddedFrame f embR embE).perspectiveTime = f.eventTime :=
   ⟨rfl, fun _ _ _ => rfl⟩
 

--- a/Linglib/Studies/Zeijlstra2012.lean
+++ b/Linglib/Studies/Zeijlstra2012.lean
@@ -49,7 +49,7 @@ reversing its c-command direction.
 * Temporal de re, counterfactual tense, and relative-clause tense are not addressed.
 -/
 
-open Time
+open Tense
 
 namespace Zeijlstra2012
 

--- a/Linglib/Studies/Zhao2025.lean
+++ b/Linglib/Studies/Zhao2025.lean
@@ -81,7 +81,7 @@ theorem guo_compatible_with_all :
 
 /-! ### The ⌈then⌉-present puzzle -/
 
-open Time Tense.Perspective
+open Tense Tense.Perspective
 
 /-- The ⌈then⌉ adverbs of [zhao-2025]'s language sample, from the Fragment
     lexicons. -/


### PR DESCRIPTION
`namespace Time` in `Semantics/Tense/Reichenbach.lean` was a one-file island holding only `ReichenbachFrame` and its dot-API, named after the old binder retired in #2599; every other module in the directory is `namespace Tense`. Consumers' `open Time Tense` collapses to `open Tense`; the 7 `Time.ReichenbachFrame` qualifiers follow.