### PR TITLE
refactor(Semantics/Degree): move scale boundedness out of Core/Order

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -228,7 +228,6 @@ import Linglib.Core.Optimization.System
 import Linglib.Core.Order.AllenRelation
 import Linglib.Core.Order.Antichain
 import Linglib.Core.Order.Argmax
-import Linglib.Core.Order.Boundedness
 import Linglib.Core.Order.Branching
 import Linglib.Core.Order.Caratheodory
 import Linglib.Core.Order.Command
@@ -1621,6 +1620,7 @@ import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Aggregation
 import Linglib.Semantics.Degree.Antonymy
 import Linglib.Semantics.Degree.Basic
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Semantics.Degree.Comparison
 import Linglib.Semantics.Degree.Defs
 import Linglib.Semantics.Degree.Delineation

--- a/Linglib/Discourse/QUD/AtIssueness.lean
+++ b/Linglib/Discourse/QUD/AtIssueness.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Semantics.Degree.Comparison
 import Mathlib.Algebra.Order.Interval.Set.Instances
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
@@ -14,7 +14,7 @@ with projectivity. Mirrors the gradable-adjective pattern (degree > θ →
 positive meaning).
 -/
 namespace Discourse.AtIssueness
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 /-! ### Degree Types -/
 /-- A degree of at-issueness ∈ [0, 1].
     0 = fully backgrounded (not at-issue), 1 = fully at-issue. -/

--- a/Linglib/Features/ScalarDimension.lean
+++ b/Linglib/Features/ScalarDimension.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Features.Aktionsart
 import Linglib.Features.PropertyDomain
 import Linglib.Semantics.Degree.Measure.Dimension
@@ -28,7 +28,7 @@ telicity defaults, endpoint licensing) is in
 
 namespace Features
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 
 /-- The scalar dimension a gradable predicate measures along — the union
     of the perceptual adjective dimensions and the scalar-change verb
@@ -102,7 +102,7 @@ Absorbed from the retired `Degree/Gradability/Dimension.lean`: the degree
 carrier transports from `Boundedness.degreeShape`, and the Kennedy–Levin
 telicity defaults are theorems about it. -/
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 
 /-- Each dimension's degree type — inherited from its boundedness, so the grounding
     transports rather than re-casing per dimension. -/

--- a/Linglib/Fragments/English/Modifiers/Adjectives.lean
+++ b/Linglib/Fragments/English/Modifiers/Adjectives.lean
@@ -30,7 +30,7 @@ namespace English.Modifiers.Adjectives
 
 
 open Degree (AntonymRelation)
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Features (NegationType)
 
 -- ============================================================================

--- a/Linglib/Fragments/English/Predicates/Adjectival.lean
+++ b/Linglib/Fragments/English/Predicates/Adjectival.lean
@@ -15,7 +15,7 @@ Kennedy classification is exercised at the end of this file.
 namespace English.Predicates.Adjectival
 
 open Degree (AntonymRelation GradableAdjective)
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Features (EvaluativeValence)
 open Features (NegationType)
 

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -27,7 +27,7 @@ export Features (Preferential Attitude)
 open Features
 open ArgumentStructure
 open Features.DegreeAchievement (DegreeAchievementScale)
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Aspect.Incremental (VerbIncClass)
 open ArgumentStructure
 open ArgumentStructure

--- a/Linglib/Semantics/Aspect/DegreeAchievement.lean
+++ b/Linglib/Semantics/Aspect/DegreeAchievement.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Features.ScalarDimension
 import Linglib.Features.Aktionsart
 
@@ -23,7 +23,7 @@ This module derives `VendlerClass` from `Boundedness`.
 
 namespace Features.DegreeAchievement
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Features
 open Features
 

--- a/Linglib/Semantics/Degree/Adjective.lean
+++ b/Linglib/Semantics/Degree/Adjective.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Features.ScalarDimension
 import Linglib.Features.Antonymy
 import Linglib.Features.Valence
@@ -29,7 +29,6 @@ The intersective/subsective/privative classification lives in
 
 namespace Degree
 
-open Core.Order (Boundedness)
 open Features (NegationType ScalarDimension)
 
 /-! ## Standards and Interpretive Economy ([kennedy-2007])

--- a/Linglib/Semantics/Degree/Basic.lean
+++ b/Linglib/Semantics/Degree/Basic.lean
@@ -2,7 +2,7 @@ import Mathlib.Order.Interval.Set.LinearOrder
 import Mathlib.Order.Bounds.Basic
 import Linglib.Semantics.Degree.Comparison
 import Linglib.Semantics.Degree.Defs
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 
 /-!
 # Degree comparison: the point-standard core
@@ -45,7 +45,6 @@ consumers in `Studies/Hoeksema1983.lean`.
 
 namespace Degree
 
-open Core.Order (ScalePolarity)
 
 /-! ### Comparative and equative semantics -/
 

--- a/Linglib/Semantics/Degree/Boundedness.lean
+++ b/Linglib/Semantics/Degree/Boundedness.lean
@@ -22,7 +22,7 @@ pair an adjective is.
 * `ScalePolarity`
 -/
 
-namespace Core.Order
+namespace Degree
 
 /-! ### Scale boundedness -/
 
@@ -110,4 +110,4 @@ inductive ScalePolarity where
   | negative
   deriving DecidableEq, Repr
 
-end Core.Order
+end Degree

--- a/Linglib/Semantics/Degree/Hom.lean
+++ b/Linglib/Semantics/Degree/Hom.lean
@@ -417,13 +417,13 @@ variable {Entity D D' : Type*} [LinearOrder D] [Preorder D']
 
 /-- Comparatives are invariant under change of scale representation. -/
 theorem comparativeSem_comp (hf : StrictMono f) (a b : Entity)
-    (dir : Core.Order.ScalePolarity) :
+    (dir : Degree.ScalePolarity) :
     comparativeSem (f ∘ μ) a b dir ↔ comparativeSem μ a b dir := by
   cases dir <;> exact hf.lt_iff_lt
 
 /-- Equatives are invariant under change of scale representation. -/
 theorem equativeSem_comp (hf : StrictMono f) (a b : Entity)
-    (dir : Core.Order.ScalePolarity) :
+    (dir : Degree.ScalePolarity) :
     equativeSem (f ∘ μ) a b dir ↔ equativeSem μ a b dir := by
   cases dir <;> exact hf.le_iff_le
 

--- a/Linglib/Semantics/Degree/Predicate.lean
+++ b/Linglib/Semantics/Degree/Predicate.lean
@@ -2,7 +2,7 @@ import Mathlib.Order.Basic
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Order.Max
 import Mathlib.Tactic.NormNum
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Semantics.Degree.Comparison
 
 /-!
@@ -27,7 +27,6 @@ relation per case.
 
 namespace Degree
 
-open Core.Order
 
 /-! ### Informativity on Scales -/
 

--- a/Linglib/Semantics/Events/Path.lean
+++ b/Linglib/Semantics/Events/Path.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Mathlib.Data.List.Infix
 
 /-!

--- a/Linglib/Studies/AlstottAravind2026.lean
+++ b/Linglib/Studies/AlstottAravind2026.lean
@@ -46,7 +46,6 @@ to pragmatic as against semantic coercion.
 namespace AlstottAravind2026
 
 open Tense Rett2020 Data.Examples
-open Core.Order
 
 /-! ### The two theories (§2.1) -/
 

--- a/Linglib/Studies/BeckOdaSugisaki2004.lean
+++ b/Linglib/Studies/BeckOdaSugisaki2004.lean
@@ -58,7 +58,7 @@ Example numbers follow the journal article; the examples are typed in
 
 namespace BeckOdaSugisaki2004
 
-open Core.Order Degree Definiteness
+open Degree Definiteness
 
 variable {Entity D : Type*} [LinearOrder D]
 

--- a/Linglib/Studies/Beltrama2025.lean
+++ b/Linglib/Studies/Beltrama2025.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Basic
 import Linglib.Semantics.Degree.Intensification
 import Linglib.Fragments.English.Predicates.Adjectival
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Data.Examples.Beltrama2025
 
 /-!
@@ -48,7 +48,7 @@ standard function assign functional standards.
 
 namespace Beltrama2025
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Degree (PositiveStandard interpretiveEconomy positiveMeaning)
 open Degree (AdjectiveClass)
 

--- a/Linglib/Studies/Bresnan1973.lean
+++ b/Linglib/Studies/Bresnan1973.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Syntax.Category.Degree.Basic
 
 /-!
@@ -44,7 +44,7 @@ structural fact about the head and the deleted constituent.
 namespace Bresnan1973
 
 open Degree (Head)
-open Core.Order (ScalePolarity)
+open Degree (ScalePolarity)
 
 /-- The two syntactic forms of than-clauses: phrasal "than Bill" vs
     clausal "than Bill is tall". -/

--- a/Linglib/Studies/Buring2007.lean
+++ b/Linglib/Studies/Buring2007.lean
@@ -54,7 +54,8 @@ the accessible worlds agree on the standard's degree.
 
 namespace Buring2007
 
-open Core.Order ModalLogic
+open ModalLogic
+open Degree (ScalePolarity)
 
 /-! ### The comparative and the degree negation -/
 

--- a/Linglib/Studies/HayKennedyLevin1999.lean
+++ b/Linglib/Studies/HayKennedyLevin1999.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Degree.Measure.Temporal
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Fragments.English.Predicates.Verbal
 
 /-!
@@ -56,7 +56,7 @@ rather than docstring prose.
 
 namespace HayKennedyLevin1999
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open English.Predicates.Verbal
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Basic
 import Linglib.Fragments.English.Predicates.Adjectival
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Features.PropertyDomain
 import Linglib.Features.Antonymy
 
@@ -297,7 +297,7 @@ structure AdjectiveTypologyDatum where
   scale : String
   /-- Scale structure (Kennedy 2007's 4-way typology), the canonical
       `Boundedness` enum rather than a `Bool`-pair re-encoding. -/
-  scaleType : Core.Order.Boundedness
+  scaleType : Degree.Boundedness
   /-- Natural with "slightly X"? -/
   naturalWithSlightly : Bool
   /-- Natural with "completely X"? -/
@@ -519,13 +519,13 @@ Per the matrix:
   considerations).
 - **Measure phrases** (*6 feet tall*) work on all dimensional scales
   ([hay-kennedy-levin-1999]). -/
-def Licenses : DegreeModifierType → Core.Order.Boundedness → Prop
+def Licenses : DegreeModifierType → Degree.Boundedness → Prop
   | .proportional, b => b.HasMax
   | .diminisher, b => b.HasMin
   | .intensifier, _ => True
   | .measurePhrase, _ => True
 
-instance : ∀ (m : DegreeModifierType) (b : Core.Order.Boundedness),
+instance : ∀ (m : DegreeModifierType) (b : Degree.Boundedness),
     Decidable (Licenses m b)
   | .proportional, b => inferInstanceAs (Decidable b.HasMax)
   | .diminisher, b => inferInstanceAs (Decidable b.HasMin)
@@ -538,7 +538,6 @@ section Bridge
 
 open Degree
 open English.Predicates.Adjectival
-open Core.Order
 
 /-! #### Scale structure → comparison-class sensitivity
 

--- a/Linglib/Studies/Rett2015.lean
+++ b/Linglib/Studies/Rett2015.lean
@@ -34,7 +34,7 @@ members of their pairs ([bierwisch-1989], [kennedy-2007]).
 
 namespace Rett2015
 
-open Core.Order (ScalePolarity)
+open Degree (ScalePolarity)
 open Degree
 open English.Predicates.Adjectival (tall short)
 

--- a/Linglib/Studies/Rett2020.lean
+++ b/Linglib/Studies/Rett2020.lean
@@ -46,7 +46,6 @@ namespace Rett2020
 
 open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
-open Core.Order
 open NonemptyInterval
 open Features
 open Features.ChangeOfState
@@ -437,7 +436,6 @@ namespace Rett2020.Examples
 
 open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
-open Core.Order
 open NonemptyInterval
 open Tense
 

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -39,7 +39,7 @@ Two types of EN with different syntactic positions and licensing:
 
 namespace Rett2026
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Degree (isAmbidirectional)
 open English.Modifiers.Adjectives (AdjModifierEntry)
 

--- a/Linglib/Studies/Sassoon2013.lean
+++ b/Linglib/Studies/Sassoon2013.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Discrete
 import Linglib.Semantics.Degree.Adjective
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 
 /-!
 # [sassoon-2013]
@@ -65,7 +65,7 @@ open Degree (DimensionBindingType conjunctiveBinding
   disjunctiveBinding deMorgan_conjunctive_disjunctive
   deMorgan_disjunctive_conjunctive predictedBinding)
 open Degree (interpretiveEconomy)
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 -- ════════════════════════════════════════════════════
 -- § 1. Multidimensional Adjective Data
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -1715,7 +1715,7 @@ The chain connects three independent modules:
 open Degree (interpretiveEconomy PositiveStandard IsClassA)
 
 /-- Height is an open-scale dimension: "tall" is relative (Class A). -/
-theorem height_is_classA : IsClassA Core.Order.Boundedness.open_ := trivial
+theorem height_is_classA : IsClassA Degree.Boundedness.open_ := trivial
 
 /-- Open scale → contextual domain inference applies (the full chain).
     This is a three-step argument:

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -6,7 +6,7 @@ import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Studies.Sassoon2013
 import Linglib.Studies.Solt2018Multidim
 import Linglib.Studies.BeaversKoontzGarboden2020
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Semantics.Degree.Adjective
 
 /-!
@@ -85,7 +85,7 @@ the paper's argument is that disturbance predicates are a uniform class.
 
 namespace Tham2025
 
-open Core.Order (Boundedness)
+open Degree (Boundedness)
 open Degree (DimensionBindingType GradableAdjective conjunctiveBinding disjunctiveBinding)
 open Degree.Aggregation (weightedScore boolMeasures
   spatialNormalizedScore spatialNormalizedBinding)

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Mereology
 import Linglib.Semantics.ArgumentStructure.Thematic.Defs
 import Linglib.Semantics.Genericity.MeaningPreservation
 import Linglib.Features.Aktionsart
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Fragments.English.Nouns
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Data.Examples.Wellwood2015

--- a/Linglib/Syntax/Category/Adjective/Basic.lean
+++ b/Linglib/Syntax/Category/Adjective/Basic.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Boundedness
+import Linglib.Semantics.Degree.Boundedness
 import Linglib.Features.ScalarDimension
 import Linglib.Morphology.Paradigm.Degree
 
@@ -87,7 +87,7 @@ structure Adjective where
   isLowerEndpoint : Bool := false
   /-- The direction of the ordering the adjective imposes on its `dimension`: antonyms share a
       dimension and reverse the ordering (*tall* positive, *short* negative). -/
-  polarity : Option Core.Order.ScalePolarity := none
+  polarity : Option Degree.ScalePolarity := none
   /-- Comparative/superlative morphology. -/
   comparison : Adjective.ComparisonFacet := .regular
   /-- Lexical antonym's surface form, when it has a stable one. -/

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -388,7 +388,7 @@ The aspectual chain: `HasMax → bounded RP → telic resultative`. -/
 /-- Map [kennedy-2007]'s scale boundedness to [goldberg-jackendoff-2004]'s
 RP boundedness. Scales with a maximum endpoint yield bounded RPs (the RP denotes
 a delimited endstate). Scales without a maximum yield unbounded RPs. -/
-def adjScaleToRPBoundedness (b : Core.Order.Boundedness) : Boundedness :=
+def adjScaleToRPBoundedness (b : Degree.Boundedness) : Boundedness :=
   if b.HasMax then .bounded else .unbounded
 
 /-- Closed scales yield bounded RPs. -/
@@ -409,10 +409,10 @@ theorem lower_bounded_scale_unbounded :
 
 /-- The full aspectual chain: a closed-scale adjective as RP yields a telic
     resultative. `HasMax → bounded → telic → accomplishment`. -/
-theorem closed_scale_telic_resultative (b : Core.Order.Boundedness) (hMax : b.HasMax) :
+theorem closed_scale_telic_resultative (b : Degree.Boundedness) (hMax : b.HasMax) :
     resultativeVendlerClass (adjScaleToRPBoundedness b) = .accomplishment := by
-  cases b <;> simp [Core.Order.Boundedness.HasMax] at hMax <;>
-    simp [adjScaleToRPBoundedness, Core.Order.Boundedness.HasMax,
+  cases b <;> simp [Degree.Boundedness.HasMax] at hMax <;>
+    simp [adjScaleToRPBoundedness, Degree.Boundedness.HasMax,
       resultativeVendlerClass, resultativeAspect, AspectualProfile.toVendlerClass]
 
 /-- The dry/wet contrast: dry is productive (bounded → telic),
@@ -732,7 +732,7 @@ subconstruction satisfying the hypotheses, not just the attested entries. -/
 
 /-- **Aspect chain**: any adjective with a scale maximum, used as an RP
     in a resultative, produces a telic accomplishment. -/
-theorem aspect_chain (b : Core.Order.Boundedness) (hMax : b.HasMax) :
+theorem aspect_chain (b : Degree.Boundedness) (hMax : b.HasMax) :
     let rpB := adjScaleToRPBoundedness b
     rpB = .bounded ∧
     resultativeVendlerClass rpB = .accomplishment ∧


### PR DESCRIPTION
`Core/Order/Boundedness.lean` held [kennedy-mcnally-2005]'s scale-structure typology, its dual, a degree carrier per shape and scale polarity — degree-semantics vocabulary anchored on linguistics papers, not order theory mathlib would take. It moves to `Semantics/Degree/Boundedness.lean` under `namespace Degree` (`Degree.Boundedness`, `Degree.ScalePolarity`), so the degree modules open the namespace they work in; 16 imports, 27 qualified references and 21 `open` lines follow. The bare `open Core.Order` lines that only resolved through this file (Rett2020, AlstottAravind2026, Kennedy2007, BeckOdaSugisaki2004, Buring2007, Degree/Predicate) are dropped or retargeted.