### PR TITLE
refactor(Semantics/Degree): type scales by polarity and dual, retire isLowerEndpoint

### DIFF
--- a/Linglib/Features/ScalarDimension.lean
+++ b/Linglib/Features/ScalarDimension.lean
@@ -65,20 +65,23 @@ def ScalarDimension.domain : ScalarDimension → PropertyDomain
   | .curvature | .boiling | .corrosion | .unspecified => .state
   | .color => .color
 
-/-- The dimension's canonical scale shape. Polarity/standard-type are not
-    here — they live on the adjective entry (`min`/`max`-standard
-    adjectives select a pole of a closed scale). Reducible so the degree
-    fiber's `OrderTop`/`NoMaxOrder` instances synthesise through it. -/
+/-- The dimension's scale shape in its increasing direction ([kennedy-mcnally-2005]
+    (24)–(27), [kennedy-2007] (33), (60)): *??completely wet* but *completely dry* makes
+    wetness lower closed, *fully straight* but *??fully bent* makes straightness upper
+    closed, *100% full/empty* makes fullness closed. The negative member of an antonym
+    pair measures on the dual (`Boundedness.ofPolarity`). Reducible so the degree fiber's
+    `OrderTop`/`NoMaxOrder` instances synthesise through it. -/
 abbrev ScalarDimension.boundedness : ScalarDimension → Boundedness
-  | .straightness | .flatness | .openness | .cleanliness | .curvature
-  | .cracking | .denting | .scratching | .boiling
-  | .alive | .freedom | .fullness | .purity | .shattering | .smoothness
-  | .tightness | .wetness | .pregnancy => .closed
+  | .openness | .curvature | .cracking | .denting | .scratching | .boiling
+  | .alive | .freedom | .fullness | .shattering | .tightness | .pregnancy => .closed
+  | .straightness | .flatness | .cleanliness | .purity | .smoothness | .safety
+  | .confidence => .upperBounded
+  | .wetness => .lowerBounded
   | .height | .width | .length | .weight | .thickness | .depth | .speed
   | .strength | .age | .generalSize | .temperature | .brightness | .volume
   | .happiness | .cost | .price | .quality | .value | .danger | .beauty
-  | .importance | .safety | .intelligence | .expectation | .possibility
-  | .confidence | .hardness | .color | .corrosion | .quantity
+  | .importance | .intelligence | .expectation | .possibility
+  | .hardness | .color | .corrosion | .quantity
   | .unspecified => .open_
 
 /-! ### Bridges to the physical quantity algebra -/

--- a/Linglib/Fragments/English/Predicates/Adjectival.lean
+++ b/Linglib/Fragments/English/Predicates/Adjectival.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Degree.Adjective
 Gradable adjective entries following [kennedy-2007], typed with
 `Degree.GradableAdjective` (the syntactic `Syntax/Category/Adjective` lexeme
 refined with the degree-semantic layer). Each entry stores its surface form, scalar
-`dimension`, lexicalized pole (`isLowerEndpoint`) or `standardOverride`, and antonym
+`dimension`, `polarity` or `standardOverride`, and antonym
 data; the scale shape (`scaleType`), positive `standard`, and Kennedy `adjectiveClass`
 are *derived* views, not stored — the fix for the old `scaleType` field that conflated
 scale shape with pole (`wet`/`dry` share one closed `.wetness` scale). The derived
@@ -86,12 +86,12 @@ def full : AdjectivalPredicateEntry where
   antonymForm := some "empty"
   antonymRelation := some .contradictory  -- Closed scales often contradictory
 
-/-- "empty" — closed fullness scale, lower pole ⇒ minimum standard,
+/-- "empty" — negative pole of the closed fullness scale ⇒ maximum standard (no contents),
     contradictory to "full". -/
 def empty : AdjectivalPredicateEntry where
   form := "empty"
+  polarity := some .negative
   dimension := some .fullness
-  isLowerEndpoint := true
   antonymForm := some "full"
   antonymRelation := some .contradictory
 
@@ -125,20 +125,20 @@ def cheap : AdjectivalPredicateEntry where
   antonymForm := some "expensive"
   antonymRelation := some .contrary
 
-/-- "wet" — closed wetness scale, lower pole ⇒ minimum standard (true with any
+/-- "wet" — lower-closed wetness scale ⇒ minimum standard (true with any
     non-zero wetness). Shares the closed `.wetness` scale with "dry"; the two
     differ only in pole. -/
 def wet : AdjectivalPredicateEntry where
   form := "wet"
   dimension := some .wetness
-  isLowerEndpoint := true
   antonymForm := some "dry"
   antonymRelation := some .contradictory
 
-/-- "dry" — closed wetness scale, upper pole ⇒ maximum standard (true only at
+/-- "dry" — negative pole of the wetness scale ⇒ maximum standard (true only at
     complete dryness). -/
 def dry : AdjectivalPredicateEntry where
   form := "dry"
+  polarity := some .negative
   dimension := some .wetness
   antonymForm := some "wet"
   antonymRelation := some .contradictory
@@ -154,7 +154,7 @@ def clean : AdjectivalPredicateEntry where
 /-- "dirty" — closed scale (maximally dirty), contradictory to "clean" -/
 def dirty : AdjectivalPredicateEntry where
   form := "dirty"
-  isLowerEndpoint := true
+  polarity := some .negative
   dimension := some .cleanliness
   antonymForm := some "clean"
   antonymRelation := some .contradictory
@@ -186,6 +186,7 @@ def open_ : AdjectivalPredicateEntry where
 /-- "closed" — closed scale, contradictory to "open" -/
 def closed_ : AdjectivalPredicateEntry where
   form := "closed"
+  polarity := some .negative
   dimension := some .openness
   antonymForm := some "open"
   antonymRelation := some .contradictory
@@ -194,6 +195,7 @@ def closed_ : AdjectivalPredicateEntry where
 /-- "shut" — closed scale, contradictory to "open" (near-synonym of "closed") -/
 def shut : AdjectivalPredicateEntry where
   form := "shut"
+  polarity := some .negative
   dimension := some .openness
   antonymForm := some "open"
   antonymRelation := some .contradictory
@@ -210,6 +212,7 @@ def free_ : AdjectivalPredicateEntry where
 /-- "loose" — closed scale (maximally loose), contradictory to "tight" -/
 def loose : AdjectivalPredicateEntry where
   form := "loose"
+  polarity := some .negative
   dimension := some .tightness
   antonymForm := some "tight"
   antonymRelation := some .contradictory
@@ -222,12 +225,12 @@ def tight : AdjectivalPredicateEntry where
   antonymForm := some "loose"
   antonymRelation := some .contradictory
 
-/-- "bent" — closed straightness scale, lower pole ⇒ minimum standard (true with
+/-- "bent" — negative pole of the upper-closed straightness scale ⇒ minimum standard (true with
     any non-zero bend). Shares the closed `.straightness` scale with "straight". -/
 def bent : AdjectivalPredicateEntry where
   form := "bent"
+  polarity := some .negative
   dimension := some .straightness
-  isLowerEndpoint := true
   antonymForm := some "straight"
   antonymRelation := some .contradictory
 
@@ -241,6 +244,7 @@ def smooth : AdjectivalPredicateEntry where
 /-- "rough" — closed scale, contradictory to "smooth" -/
 def rough : AdjectivalPredicateEntry where
   form := "rough"
+  polarity := some .negative
   dimension := some .smoothness
   antonymForm := some "smooth"
   antonymRelation := some .contradictory
@@ -319,7 +323,7 @@ def pristine : AdjectivalPredicateEntry where
 /-- "filthy" — closed scale, contrary to "pristine" (extreme absolute: gap exists) -/
 def filthy : AdjectivalPredicateEntry where
   form := "filthy"
-  isLowerEndpoint := true
+  polarity := some .negative
   dimension := some .cleanliness
   antonymForm := some "pristine"
   antonymRelation := some .contrary
@@ -810,46 +814,5 @@ def allEntries : List (AdjectivalPredicateEntry) := [
 /-- Look up an entry by form -/
 def lookup (form : String) : Option (AdjectivalPredicateEntry) :=
   allEntries.find? (·.form == form)
-
-/-! ### Derived Kennedy classification
-
-The scale shape, positive standard, and Kennedy class are `GradableAdjective`
-views derived from each entry's `dimension` + pole/override — nothing here is a
-stored field ([kennedy-2007], [kennedy-mcnally-2005]). Everything closes by
-`rfl`/`decide`, so the migration off the old stored `scaleType` is checked. -/
-
--- scale *shape* is the dimension's; `wet`/`dry` no longer disagree on it:
-theorem tall_open : tall.scaleType = .open_ := rfl
-theorem wet_closed : wet.scaleType = .closed := rfl
-theorem dry_closed : dry.scaleType = .closed := rfl
-
--- the pole the old `scaleType` conflated, now recovered from `isLowerEndpoint`:
-theorem wet_min : wet.standard = .minEndpoint := rfl
-theorem dry_max : dry.standard = .maxEndpoint := rfl
-
--- every Kennedy class, derived from (dimension, pole, override):
-theorem tall_relative     : tall.adjectiveClass = .relativeGradable := rfl
-theorem good_relative     : good.adjectiveClass = .relativeGradable := rfl
-theorem full_absMax       : full.adjectiveClass = .absoluteMaximum := rfl
-theorem straight_absMax   : straight.adjectiveClass = .absoluteMaximum := rfl
-theorem dry_absMax        : dry.adjectiveClass = .absoluteMaximum := rfl
-theorem empty_absMin      : empty.adjectiveClass = .absoluteMinimum := rfl
-theorem wet_absMin        : wet.adjectiveClass = .absoluteMinimum := rfl
-theorem bent_absMin       : bent.adjectiveClass = .absoluteMinimum := rfl
-theorem decent_mildlyPos  : decent.adjectiveClass = .mildlyPositive := rfl
-theorem acceptable_mildlyPos : acceptable.adjectiveClass = .mildlyPositive := rfl
-theorem adequate_mildlyPos   : adequate.adjectiveClass = .mildlyPositive := rfl
-
--- comparison-class dependence: only the open-scale relatives require one:
-theorem tall_requires_cc  : tall.IsRelative := by decide
-theorem good_requires_cc  : good.IsRelative := by decide
-theorem wet_no_cc         : ¬ wet.IsRelative := by decide
-theorem full_no_cc        : ¬ full.IsRelative := by decide
-theorem decent_no_cc      : ¬ decent.IsRelative := by decide
-
-/-- Every entry above carries a scalar dimension, so all are gradable. -/
-theorem all_gradable :
-    tall.IsGradable ∧ full.IsGradable ∧ wet.IsGradable ∧ good.IsGradable ∧
-      decent.IsGradable := by decide
 
 end English.Predicates.Adjectival

--- a/Linglib/Semantics/Degree/Adjective.lean
+++ b/Linglib/Semantics/Degree/Adjective.lean
@@ -38,8 +38,8 @@ gradable adjectives by scale structure and the derivation of standard
 type from boundedness. Interpretive Economy ([kennedy-2007] eq. (66))
 maximises the contribution of conventional meaning: a scale with an
 endpoint rules out the contextual standard; a totally closed scale
-admits *both* endpoint standards (`ieAdmits`) with the maximum as the
-pragmatically preferred default (`interpretiveEconomy`). -/
+admits *both* endpoint standards (`Boundedness.Admits`) with the maximum as the
+pragmatically preferred default (`Boundedness.defaultStandard`). -/
 
 /-! ### Classification carriers -/
 
@@ -111,68 +111,44 @@ instance : DecidablePred AdjectiveClass.IsRelative :=
 one with a minimum, so an endpoint standard is available exactly where the scale has that
 endpoint; the contextual standard, which context must supply, survives IE (66) only on a
 totally open scale. A totally closed scale therefore admits both endpoints ((67)–(68)). -/
-def ieAdmits (b : Boundedness) : PositiveStandard → Prop
+def Boundedness.Admits (b : Boundedness) : PositiveStandard → Prop
   | .contextual  => b = .open_
   | .minEndpoint => b.HasMin
   | .maxEndpoint => b.HasMax
   | .functional  => False
 
-instance (b : Boundedness) (s : PositiveStandard) : Decidable (ieAdmits b s) := by
-  cases s <;> simp only [ieAdmits] <;> infer_instance
+instance (b : Boundedness) (s : PositiveStandard) : Decidable (b.Admits s) := by
+  cases s <;> simp only [Boundedness.Admits] <;> infer_instance
 
-/-- The out-of-context *default* positive standard. Where Interpretive Economy
-admits a unique standard (open / one-sided closed scales) this is forced; for a
-totally closed scale IE admits both endpoints (`ieAdmits`) and the default is
-the **maximum** on pragmatic grounds — a maximum standard entails a minimum one
-and stronger meanings are preferred ([kennedy-2007] eq. (66) discussion). So
-this is Interpretive Economy *plus* a strengthening default for closed scales,
-not IE alone; the genuine (variable) IE claim is `ieAdmits`. -/
-def interpretiveEconomy : Boundedness → PositiveStandard
+/-- The out-of-context default standard, Interpretive Economy plus a strengthening
+preference: where one standard is admitted it is forced, and a totally closed scale takes the
+maximum (a maximum standard entails a minimum one). -/
+def Boundedness.defaultStandard : Boundedness → PositiveStandard
   | .open_        => .contextual
   | .lowerBounded => .minEndpoint
   | .upperBounded => .maxEndpoint
   | .closed       => .maxEndpoint
 
-theorem interpretiveEconomy_open : interpretiveEconomy .open_ = .contextual := rfl
-theorem interpretiveEconomy_lowerBounded :
-    interpretiveEconomy .lowerBounded = .minEndpoint := rfl
-theorem interpretiveEconomy_upperBounded :
-    interpretiveEconomy .upperBounded = .maxEndpoint := rfl
-
-/-- The default standard for a totally closed scale is the maximum — a
-*pragmatic* preference (stronger meaning), not an Interpretive-Economy
-determination; the minimum is equally admitted (`ieAdmits_closed_minEndpoint`). -/
-theorem interpretiveEconomy_closed : interpretiveEconomy .closed = .maxEndpoint := rfl
-
-/-- The default standard is always among those Interpretive Economy admits. -/
-theorem ieAdmits_interpretiveEconomy (b : Boundedness) :
-    ieAdmits b (interpretiveEconomy b) := by
+/-- The default standard is always admitted. -/
+theorem Boundedness.admits_defaultStandard (b : Boundedness) : b.Admits b.defaultStandard := by
   cases b <;> decide
 
-/-- Interpretive variability of totally closed scales: IE admits the **minimum**
-standard, so the `interpretiveEconomy` maximum default is a pragmatic preference,
-not a semantic determination ([kennedy-2007] eq. (67)–(68): *opaque/transparent*,
-*open/exposed*). -/
-theorem ieAdmits_closed_minEndpoint : ieAdmits .closed .minEndpoint := trivial
+/-- A totally closed scale admits the minimum standard as well as the default maximum
+([kennedy-2007] (67)–(68)). -/
+theorem Boundedness.closed_admits_minEndpoint : Boundedness.closed.Admits .minEndpoint := trivial
 
-/-- A totally closed scale also admits the maximum standard. -/
-theorem ieAdmits_closed_maxEndpoint : ieAdmits .closed .maxEndpoint := trivial
+theorem Boundedness.closed_admits_maxEndpoint : Boundedness.closed.Admits .maxEndpoint := trivial
 
+/-- Interpretive Economy rules out the contextual standard whenever the scale has an endpoint. -/
+theorem Boundedness.not_admits_contextual_of_ne_open {b : Boundedness} (h : b ≠ .open_) :
+    ¬ b.Admits .contextual := h
 
-/-- Interpretive Economy rules out the relative (contextual) standard whenever the scale has
-an endpoint. -/
-theorem not_ieAdmits_contextual_of_ne_open {b : Boundedness} (h : b ≠ .open_) :
-    ¬ ieAdmits b .contextual := h
+/-- A scale is relative iff its default standard needs a comparison class, i.e. iff it is open
+(*tall*, *expensive*, *big*). -/
+def Boundedness.IsRelative (b : Boundedness) : Prop := b.defaultStandard.RequiresComparisonClass
 
-/-- A boundedness is *Class A* (relative) iff its default standard requires a
-comparison class — i.e. iff the scale is open. Kennedy's *tall*, *expensive*,
-*big*. -/
-def IsClassA (b : Boundedness) : Prop :=
-  (interpretiveEconomy b).RequiresComparisonClass
-
-instance : DecidablePred IsClassA :=
-  fun b => inferInstanceAs (Decidable (interpretiveEconomy b).RequiresComparisonClass)
-
+instance : DecidablePred Boundedness.IsRelative :=
+  fun b => inferInstanceAs (Decidable b.defaultStandard.RequiresComparisonClass)
 
 /-! ### Two-threshold model for contrary antonyms -/
 
@@ -283,39 +259,19 @@ structure GradableAdjective extends Adjective where
 
 namespace GradableAdjective
 
-/-- The scale's intrinsic shape — read off the `dimension` key, not stored
-    (`.open_` for a non-gradable, which has no scale). -/
+/-- The scale the adjective measures on: its dimension's, dualized for the negative member of
+an antonym pair (`.open_` for a non-gradable, which has no scale). -/
 def scaleType (g : GradableAdjective) : Boundedness :=
-  (g.dimension.map ScalarDimension.boundedness).getD .open_
+  (g.dimension.map fun d => d.boundedness.ofPolarity (g.polarity.getD .positive)).getD .open_
 
-/-- The effective positive standard: the default from (scale shape, pole),
-    overridable by `standardOverride`. This is the quantity the old `scaleType` field
-    conflated — it separates `wet` (closed + lower ⇒ min) from `dry` (closed + upper ⇒
-    max), and lets `good` (open shape) take a contextual standard rather than a bogus
-    bound. ([kennedy-2007]'s Interpretive Economy on the open/singly-bounded cases.) -/
+/-- The positive standard: the scale's default, unless overridden (the *good*/MPA residual). -/
 def standard (g : GradableAdjective) : PositiveStandard :=
-  g.standardOverride.getD <|
-    match g.dimension.map ScalarDimension.boundedness, g.isLowerEndpoint with
-    | some .closed, true  => .minEndpoint
-    | some .closed, false => .maxEndpoint
-    | some b,       _     => interpretiveEconomy b
-    | none,         _     => .contextual
+  g.standardOverride.getD g.scaleType.defaultStandard
 
-/-- The entry-level selection implements the type-level theory: an
-    override-free entry's derived `standard` is always among the standards
-    Interpretive Economy admits for its scale shape. The closed-scale
-    pole dispatch (min for lower-endpoint, max otherwise) picks within
-    IE's admitted pair rather than beyond it. -/
-theorem standard_ieAdmits (g : GradableAdjective)
-    (h : g.standardOverride = none) :
-    ieAdmits g.scaleType g.standard := by
-  unfold standard scaleType
-  rw [h]
-  cases hd : g.dimension with
-  | none => trivial
-  | some d =>
-    cases hb : d.boundedness <;> cases hl : g.isLowerEndpoint <;>
-      simp [ieAdmits, interpretiveEconomy, hb, Boundedness.HasMin, Boundedness.HasMax]
+/-- An override-free entry's standard is one its scale admits. -/
+theorem admits_standard (g : GradableAdjective) (h : g.standardOverride = none) :
+    g.scaleType.Admits g.standard := by
+  simp [standard, h, Boundedness.admits_defaultStandard]
 
 /-- Kennedy's adjective class — derived from `standard`, not stored; `.nonGradable`
     exactly when there is no `dimension` ([kennedy-2007], [kennedy-mcnally-2005]). -/

--- a/Linglib/Semantics/Degree/Boundedness.lean
+++ b/Linglib/Semantics/Degree/Boundedness.lean
@@ -17,7 +17,8 @@ pair an adjective is.
 
 ## Main declarations
 
-* `Boundedness`, `Boundedness.HasMax`, `Boundedness.HasMin`, `Boundedness.dual`
+* `Boundedness`, `Boundedness.HasMax`, `Boundedness.HasMin`, `Boundedness.dual`,
+  `Boundedness.ofPolarity`
 * `Boundedness.degreeShape`, `Boundedness.hasGreatest_degreeShape_iff`
 * `ScalePolarity`
 -/
@@ -109,5 +110,17 @@ inductive ScalePolarity where
   | positive
   | negative
   deriving DecidableEq, Repr
+
+/-- The scale an adjective measures on: its dimension's scale for the positive member of an
+antonym pair, the same scale with the ends exchanged for the negative member. -/
+def Boundedness.ofPolarity (b : Boundedness) : ScalePolarity → Boundedness
+  | .positive => b
+  | .negative => b.dual
+
+@[simp] theorem Boundedness.ofPolarity_positive (b : Boundedness) :
+    b.ofPolarity .positive = b := rfl
+
+@[simp] theorem Boundedness.ofPolarity_negative (b : Boundedness) :
+    b.ofPolarity .negative = b.dual := rfl
 
 end Degree

--- a/Linglib/Studies/Beltrama2025.lean
+++ b/Linglib/Studies/Beltrama2025.lean
@@ -49,7 +49,7 @@ standard function assign functional standards.
 namespace Beltrama2025
 
 open Degree (Boundedness)
-open Degree (PositiveStandard interpretiveEconomy positiveMeaning)
+open Degree (PositiveStandard positiveMeaning)
 open Degree (AdjectiveClass)
 
 /-! ### Empirical Profile (Table 1) -/
@@ -116,7 +116,7 @@ def valueScaleBoundedness : Boundedness := .lowerBounded
     a contextual standard) and MPAs (which get a functional standard).
     This shows IE must be generalized for evaluative predicates. -/
 theorem ie_underpredicts_for_value_scale :
-    interpretiveEconomy valueScaleBoundedness = .minEndpoint := rfl
+    valueScaleBoundedness.defaultStandard = .minEndpoint := rfl
 
 /-! ### Standard Types: MPA vs Good vs MinSAA -/
 
@@ -402,7 +402,7 @@ def enoughParallel : Head := .sufficiency
     can assign functional standards when the adjective's lexical semantics
     introduces practical commitments ([beltrama-2025] §5.4, p. 195). -/
 theorem ie_divergence_on_value_scale :
-    interpretiveEconomy valueScaleBoundedness = .minEndpoint ∧
+    valueScaleBoundedness.defaultStandard = .minEndpoint ∧
     goodStandard = .contextual ∧
     mpaStandard = .functional ∧
     minsaaStandard = .minEndpoint ∧

--- a/Linglib/Studies/HayKennedyLevin1999.lean
+++ b/Linglib/Studies/HayKennedyLevin1999.lean
@@ -128,12 +128,11 @@ theorem increase_unique_end {α δ T : Type*} [Add δ]
     structurally; this file checks HKL's specific predictions on the
     central exemplars. -/
 
-/-- HKL eq 26 (closed-range default): "straighten" — closed scale,
+/-- HKL eq 26 (closed-range default): "straighten" — a scale with a maximum,
     accomplishment (telic). -/
 theorem straighten_closed_accomplishment :
-    straighten.toVerb.degreeAchievementScale.map (·.scaleBoundedness) =
-      some Boundedness.closed ∧
-    straighten.toVerb.vendlerClass = some .accomplishment := ⟨rfl, rfl⟩
+    (straighten.toVerb.degreeAchievementScale.get!).scaleBoundedness.HasMax ∧
+    straighten.toVerb.vendlerClass = some .accomplishment := ⟨trivial, rfl⟩
 
 /-- HKL eq 27 (open-range default): "lengthen" — open scale, activity
     (atelic). -/

--- a/Linglib/Studies/Kennedy2007.lean
+++ b/Linglib/Studies/Kennedy2007.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Basic
+import Linglib.Fragments.English.Predicates.Adjectival
 
 /-!
 # Kennedy 2007: relative and absolute gradable adjectives
@@ -94,12 +95,6 @@ inductive DegreeModifier
   | minimizer
   deriving DecidableEq
 
-/-- The scale an adjective measures on: its dimension's scale for the positive member of an
-antonym pair, the same scale with the ends exchanged for the negative member ((60)). -/
-def scaleOf (b : Boundedness) : ScalePolarity → Boundedness
-  | .positive => b
-  | .negative => b.dual
-
 /-- A modifier is licensed on a scale that has the endpoint it picks out. -/
 def Licenses : DegreeModifier → Boundedness → Prop
   | .maximizer, b => b.HasMax
@@ -127,21 +122,34 @@ def table61 : ScalePolarity → Boundedness → DegreeModifier → Bool
 
 /-- Every cell of (61) is the endpoint structure of the adjective's own scale. -/
 theorem table61_iff_licenses (p : ScalePolarity) (b : Boundedness) (m : DegreeModifier) :
-    table61 p b m = true ↔ Licenses m (scaleOf b p) := by
+    table61 p b m = true ↔ Licenses m (b.ofPolarity p) := by
   cases p <;> cases b <;> cases m <;> decide
+
+open English.Predicates.Adjectival in
+/-- The Fragment's antonym pairs fill (61): *completely full/empty*, *slightly wet* but
+*??completely wet*, *completely dry* but *??slightly dry*, *slightly bent* but *??fully bent*,
+*fully straight*, and nothing on the open height scale. -/
+theorem fragment_pairs_table61 :
+    Licenses .maximizer full.scaleType ∧ Licenses .maximizer empty.scaleType ∧
+    Licenses .minimizer wet.scaleType ∧ ¬ Licenses .maximizer wet.scaleType ∧
+    Licenses .maximizer dry.scaleType ∧ ¬ Licenses .minimizer dry.scaleType ∧
+    Licenses .minimizer bent.scaleType ∧ ¬ Licenses .maximizer bent.scaleType ∧
+    Licenses .maximizer straight.scaleType ∧
+    ¬ Licenses .maximizer tall.scaleType ∧ ¬ Licenses .minimizer short.scaleType := by
+  decide
 
 /-! ### Interpretive Economy (§4.2–§4.3) -/
 
 /-- An open scale offers no endpoint, so its standard is contextual and the adjective needs a
 comparison class. -/
 theorem open_requires_comparison_class :
-    (interpretiveEconomy .open_).RequiresComparisonClass :=
+    Boundedness.IsRelative .open_ :=
   trivial
 
 /-- A totally closed scale is interpretively variable: both endpoint standards are admitted
 ((67)–(68), *opaque/transparent*, *open/exposed*); the maximum is only the default. -/
 theorem closed_admits_both_endpoints :
-    ieAdmits .closed .minEndpoint ∧ ieAdmits .closed .maxEndpoint :=
+    Boundedness.closed.Admits .minEndpoint ∧ Boundedness.closed.Admits .maxEndpoint :=
   ⟨trivial, trivial⟩
 
 end Kennedy2007

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -285,12 +285,12 @@ theorem all_attested_adjs_spatial :
       (·.spatialConfigType |>.isSome) = true := by
   decide
 
-/-- All attested adjectives are closed-scale (absolute) in
-    [kennedy-2007]'s terms. Spatially instantiated states have
-    crisp endpoints (fully open vs. fully closed). -/
+/-- All attested adjectives are absolute with a maximal endpoint in
+    [kennedy-2007]'s terms: spatially instantiated states have a crisp
+    endpoint (fully open, fully closed, fully flat). -/
 theorem all_attested_adjs_closed_scale :
     [open_, closed_, shut, free_, loose, flat].all
-      (·.scaleType == .closed) = true := by
+      (fun a => decide a.scaleType.HasMax) = true := by
   decide
 
 /-! Adjectives in senses that are NOT spatially instantiated do not

--- a/Linglib/Studies/Sassoon2013.lean
+++ b/Linglib/Studies/Sassoon2013.lean
@@ -64,7 +64,6 @@ namespace Sassoon2013
 open Degree (DimensionBindingType conjunctiveBinding
   disjunctiveBinding deMorgan_conjunctive_disjunctive
   deMorgan_disjunctive_conjunctive predictedBinding)
-open Degree (interpretiveEconomy)
 open Degree (Boundedness)
 -- ════════════════════════════════════════════════════
 -- § 1. Multidimensional Adjective Data
@@ -76,7 +75,7 @@ structure MultidimAdj where
   /-- Evaluative polarity: positive adjectives denote membership under a
       generalization across ALL dimensional properties; negative adjectives
       denote the existence of a counterexample to SOME dimensional standard.
-      Distinct from scale-endpoint polarity (`AdjModifierEntry.isLowerEndpoint`):
+      Distinct from scale polarity (`AdjModifierEntry.isLowerEndpoint`):
       *empty* is lower-endpoint but evaluatively positive. -/
   isPositive : Bool
   /-- Scale structure classification ([kennedy-mcnally-2005]). -/
@@ -290,7 +289,7 @@ theorem hypothesis2_all : allAdjs.all hypothesis2Holds = true := by native_decid
     Max-endpoint standard → conjunctive, min-endpoint → disjunctive,
     contextual → mixed. -/
 def predictedFromStandard (b : Boundedness) : DimensionBindingType :=
-  predictedBinding (interpretiveEconomy b)
+  predictedBinding b.defaultStandard
 
 theorem standard_closed_conjunctive :
     predictedFromStandard .closed = .conjunctive := rfl

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -1708,14 +1708,14 @@ the CC is pragmatic/contextual, not a constituent of the logical form.
     bounded scale → endpoint standard → s fixed by scale → nothing to infer
 
 The chain connects three independent modules:
-1. `Degree.interpretiveEconomy` (Theory: scale → standard type)
+1. `Degree.Boundedness.defaultStandard` (Theory: scale → standard type)
 2. `Degree.PositiveStandard.RequiresComparisonClass` (Theory: standard → domain-dependent?)
 3. `listenerK` with latent `ComparisonClass` (this file: infer CC) -/
 
-open Degree (interpretiveEconomy PositiveStandard IsClassA)
+open Degree (Boundedness PositiveStandard)
 
 /-- Height is an open-scale dimension: "tall" is relative (Class A). -/
-theorem height_is_classA : IsClassA Degree.Boundedness.open_ := trivial
+theorem height_is_relative : Boundedness.IsRelative .open_ := trivial
 
 /-- Open scale → contextual domain inference applies (the full chain).
     This is a three-step argument:
@@ -1727,13 +1727,13 @@ theorem height_is_classA : IsClassA Degree.Boundedness.open_ := trivial
     This is compatible with Kennedy's view: the CC is pragmatic/contextual
     (inferred by L1), not a semantic argument of *pos*. -/
 theorem open_scale_requires_cc_inference :
-    (interpretiveEconomy .open_).RequiresComparisonClass := trivial
+    (Boundedness.defaultStandard .open_).RequiresComparisonClass := trivial
 
 /-- Closed scale → contextual domain inference is irrelevant.
     "Full" has an endpoint standard via Interpretive Economy; the threshold
     is the scale maximum regardless of context. No domain to infer. -/
 theorem closed_scale_no_cc_inference :
-    ¬ (interpretiveEconomy .closed).RequiresComparisonClass := id
+    ¬ (Boundedness.defaultStandard .closed).RequiresComparisonClass := id
 
 -- ============================================================================
 -- § 13. Connection to Generic Language ([tessler-goodman-2019])

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -91,7 +91,6 @@ open Degree.Aggregation (weightedScore boolMeasures
   spatialNormalizedScore spatialNormalizedBinding)
 open Features.DegreeAchievement (DegreeAchievementScale)
 open ArgumentStructure
-open Degree (interpretiveEconomy)
 open English.Predicates
 
 -- ════════════════════════════════════════════════════
@@ -491,7 +490,7 @@ theorem scratch_adj_verb_scale_agree :
     the lower bound determines the threshold for being on the scale at
     all. -/
 theorem cracked_standard_maxEndpoint :
-    interpretiveEconomy Adjectival.cracked.scaleType = .maxEndpoint := rfl
+    Adjectival.cracked.scaleType.defaultStandard = .maxEndpoint := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 9. Cross-paper engagement: Kennedy-Levin pipeline
@@ -941,7 +940,7 @@ theorem solt_tham_share_substrate_bounded_by_one :
     only the lower bound. The wedge is at the level of WHICH endpoint
     of the closed scale is load-bearing for which prediction. -/
 theorem cracked_ie_max_vs_tham_lower_bound :
-    interpretiveEconomy Adjectival.cracked.scaleType =
+    Adjectival.cracked.scaleType.defaultStandard =
       Degree.PositiveStandard.maxEndpoint ∧
     crack.simplePredicationObjective = true ∧
     -- The two endpoints of a closed scale are distinct standards,

--- a/Linglib/Syntax/Category/Adjective/Basic.lean
+++ b/Linglib/Syntax/Category/Adjective/Basic.lean
@@ -82,11 +82,9 @@ structure Adjective where
       `none` for classifying/relational adjectives (*wooden*, *former*, *medical*)
       and other non-gradables. -/
   dimension : Option ScalarDimension := none
-  /-- Which pole of the scale the adjective lexicalizes (*short*, *empty*, *wet*):
-      the only thing distinguishing polar scale-mates that share one `dimension`. -/
-  isLowerEndpoint : Bool := false
   /-- The direction of the ordering the adjective imposes on its `dimension`: antonyms share a
-      dimension and reverse the ordering (*tall* positive, *short* negative). -/
+      dimension and reverse the ordering (*tall* positive, *short* negative), so the negative
+      member measures on the dual scale. `none` reads as positive. -/
   polarity : Option Degree.ScalePolarity := none
   /-- Comparative/superlative morphology. -/
   comparison : Adjective.ComparisonFacet := .regular


### PR DESCRIPTION
An adjective's scale is its dimension's, dualized for the negative member of an antonym pair (`Boundedness.ofPolarity`, [kennedy-2007] (60)); the positive standard is that scale's default. This retires the `isLowerEndpoint` flag and fixes the dimension table by [kennedy-mcnally-2005] (24)–(27) and [kennedy-2007] (33): wetness lower closed (*??completely wet*, *completely dry*), straightness, flatness, cleanliness, purity, smoothness, safety and confidence upper closed (*fully straight*, *??fully bent*, *100% pure*, *completely safe*), fullness and openness closed. *Empty* thereby becomes a maximum-standard absolute (no contents), as in the paper, where the old pole flag had made it minimum-standard.

- `Degree.ieAdmits`/`interpretiveEconomy`/`IsClassA` → `Boundedness.Admits`/`defaultStandard`/`IsRelative` (owner-relative, no abbreviations).
- The Fragment's migration tripwires (`wet_closed := rfl` etc.) go; Kennedy2007 instantiates table (61) on the Fragment's pairs (*full/empty*, *wet/dry*, *bent/straight*, *tall/short*).
- HayKennedyLevin1999's *straighten* and Levin2026's spatial adjectives are restated as `HasMax`, which is what those papers claim; `danger` stays open per Nouwen 2024 fn. 3.