### PR TITLE
refactor(Semantics/Intensional): slim Variables to the Reader API

### DIFF
--- a/Linglib/Semantics/Intensional/Variables.lean
+++ b/Linglib/Semantics/Intensional/Variables.lean
@@ -1,24 +1,27 @@
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Logic.Assignment
-import Linglib.Logic.CylindricAlgebra
 
 /-!
-# Variable Binding and Assignment Functions
+# Assignment-relative denotations
 
-[heim-kratzer-1998] [charlow-2018]
-
-Framework-neutral infrastructure for interpreting expressions with free variables,
-built on `Intensional.Denot`.
+Denotations of expressions with free variables, relative to an assignment `g : ℕ → E` of
+entities to indices ([heim-kratzer-1998]): a pronoun with index `n` denotes `g n`, a binder
+at `n` abstracts over the value of `n` by updating `g`, and composition threads the assignment
+through — the Reader applicative of [charlow-2018], whose laws hold definitionally. Situation
+pronouns are the same construction at an assignment of indices, and `DenotGS` carries both.
 
 ## Main definitions
 
-- `Assignment` (from `Logic/Assignment.lean`) instantiated at
-  `E` for entity pronouns and `W` for situation pronouns;
-  the `g[n ↦ x]` notation for `Function.update` is declared here
-- `DenotG` — assignment-relative denotations
-- `applyG`, `lambdaAbsG`, `constDenot` — composition with assignments
-- Applicative functor laws ([charlow-2018])
-- Cylindric algebra bridge ([henkin-monk-tarski-1971])
+* `DenotG E W ty`: denotations relative to an entity assignment; `constDenot`, `applyG`,
+  `lambdaAbsG`, `interpPronoun`, `denotGJoin`.
+* `DenotGS E W ty`: denotations relative to an entity and a situation assignment;
+  `interpSitPronoun`, `DenotGS.const`.
+* `g[n ↦ x]`: [heim-kratzer-1998]'s assignment update, `Function.update g n x`.
+
+## References
+
+* [I. Heim, A. Kratzer, *Semantics in Generative Grammar* (1998)][heim-kratzer-1998]
+* [S. Charlow, *A modular theory of pronouns and binding* (2018)][charlow-2018]
 -/
 
 namespace Intensional.Variables
@@ -31,8 +34,8 @@ open Intensional
 update laws. -/
 scoped notation:max g "[" n " ↦ " x "]" => Function.update g n x
 
-/-- Denotation depending on assignment function. -/
-def DenotG (E W : Type) (ty : Ty) := Assignment E → Denot E W ty
+/-- A denotation relative to an entity assignment. -/
+abbrev DenotG (E W : Type) (ty : Ty) := Assignment E → Denot E W ty
 
 /-- Pronoun/variable denotation: ⟦xₙ⟧^g = g(n). -/
 def interpPronoun {E W : Type} (n : ℕ) : DenotG E W .e :=
@@ -41,9 +44,6 @@ def interpPronoun {E W : Type} (n : ℕ) : DenotG E W .e :=
 /-- Lift constant denotation to assignment-relative form. -/
 def constDenot {E W : Type} {ty : Ty} (d : Denot E W ty) : DenotG E W ty :=
   λ _ => d
-
-theorem constDenot_independent {E W : Type} {ty : Ty} (d : Denot E W ty)
-    (g₁ g₂ : Assignment E) : constDenot d g₁ = constDenot d g₂ := rfl
 
 /-- Function application with assignments. -/
 def applyG {E W : Type} {σ τ : Ty}
@@ -58,18 +58,6 @@ def lambdaAbsG {E W : Type} {τ : Ty} (n : ℕ) (body : DenotG E W τ)
 theorem lambdaAbsG_apply {E W : Type} {τ : Ty} (n : ℕ) (body : DenotG E W τ)
     (arg : E) (g : Assignment E)
     : (lambdaAbsG n body g) arg = body (g[n ↦ arg]) := rfl
-
-theorem lambdaAbsG_alpha {E W : Type} {τ : Ty} (n₁ n₂ : ℕ) (body : DenotG E W τ)
-    (g : Assignment E)
-    (h_fresh : ∀ g' : Assignment E, ∀ x : E,
-      body (g'[n₁ ↦ x]) = body (g'[n₂ ↦ x]))
-    : lambdaAbsG n₁ body g = lambdaAbsG n₂ body g := by
-  funext x
-  exact h_fresh g x
-
--- ════════════════════════════════════════════════════════════════
--- § Applicative Functor Structure
--- ════════════════════════════════════════════════════════════════
 
 /-! ### Assignment-sensitive composition as an applicative functor
 
@@ -106,9 +94,7 @@ theorem applyG_composition
 
 end ApplicativeFunctor
 
--- ════════════════════════════════════════════════════════════════
--- § Monadic Join for Higher-Order Variables
--- ════════════════════════════════════════════════════════════════
+/-! ### Monadic join for higher-order variables -/
 
 section MonadicJoin
 
@@ -141,85 +127,6 @@ theorem denotGJoin_assoc {A : Type}
 
 end MonadicJoin
 
--- ════════════════════════════════════════════════════════════════
--- § Cylindric Algebra Structure
--- ════════════════════════════════════════════════════════════════
-
-/-! ### Assignments as a cylindric set algebra
-
-[heim-kratzer-1998] assignment functions satisfy the same algebraic axioms
-as DRT's dynamic assignments: predicates on assignments form a cylindric
-set algebra ([henkin-monk-tarski-1971]). -/
-
-section CylindricStructure
-
-variable {E W : Type}
-
-/-- Existential closure at variable `n`:
-    `(∃n.φ)(g) = ∃x. φ(g[n↦x])`. -/
-def existsClosure (n : Nat) (φ : Assignment E → Prop) : Assignment E → Prop :=
-  fun g => ∃ x : E, φ (g[n ↦ x])
-
-/-- Diagonal element: assignments where variables n and k agree. -/
-def diag (n k : Nat) : Assignment E → Prop :=
-  fun g => g n = g k
-
-/-- **C₁**: Existential closure of False is False. -/
-theorem existsClosure_bot (n : Nat) :
-    existsClosure n (fun _ : Assignment E => False) = fun _ => False := by
-  ext g; simp [existsClosure]
-
-/-- **C₂**: φ implies its existential closure. -/
-theorem le_existsClosure (n : Nat) (φ : Assignment E → Prop) (g : Assignment E) :
-    φ g → existsClosure n φ g :=
-  fun h => ⟨g n, by rw [Function.update_eq_self]; exact h⟩
-
-/-- **C₅**: `Dnn = ⊤` (reflexivity of equality). -/
-theorem diag_refl (n : Nat) :
-    @diag E n n = (fun _ => True) := by
-  ext; simp [diag]
-
-/-- Pronoun resolution: setting variable κ to read from variable l. -/
-def resolve (κ l : Nat) (φ : Assignment E → Prop) : Assignment E → Prop :=
-  fun g => φ (g[κ ↦ g l])
-
-/-- **Substitution = resolution.** -/
-theorem resolve_eq_existsClosure_diag (κ l : Nat) (φ : Assignment E → Prop)
-    (h : κ ≠ l) (g : Assignment E) :
-    resolve κ l φ g ↔ existsClosure κ (fun g' => diag κ l g' ∧ φ g') g := by
-  simp only [resolve, existsClosure, diag]; constructor
-  · intro hφ
-    exact ⟨g l, by simp [Function.update_of_ne (Ne.symm h) (g l) g], hφ⟩
-  · rintro ⟨x, hd, hφ⟩
-    have : x = g l := by
-      rw [Function.update_self, Function.update_of_ne (Ne.symm h) x g] at hd; exact hd
-    subst this; exact hφ
-
-/-- Lambda abstraction at n is the "integrand" of existential closure. -/
-theorem existsClosure_eq_exists_lambda (n : Nat) (body : DenotG E W .t) (g : Assignment E) :
-    existsClosure n (fun g' => body g') g ↔
-    ∃ x : E, lambdaAbsG n body g x := by
-  simp [existsClosure, lambdaAbsG]
-
--- Bridge to CylindricAlgebra
-
-open CylindricAlgebra
-
-theorem existsClosure_eq_cylindrify (n : Nat) (φ : Assignment E → Prop) :
-    existsClosure n φ = cylindrify n φ := rfl
-
-theorem diag_eq_diagonal (n k : Nat) :
-    @diag E n k = @diagonal E n k := rfl
-
-theorem resolve_eq_directSubst (κ l : Nat) (φ : Assignment E → Prop) :
-    resolve κ l φ = @directSubst E κ l φ := rfl
-
-end CylindricStructure
-
--- ════════════════════════════════════════════════════════════════
--- § Situation Assignment (Hanink-style situation-pronoun binding)
--- ════════════════════════════════════════════════════════════════
-
 /-! ### Situation pronouns as the type-level dual of entity pronouns
 
 Hanink (2018, 2021), Bondarenko (2022, 2023) and the broader post-Schwarz
@@ -241,26 +148,14 @@ abbrev SitAssignment (W : Type) := Assignment W
 def interpSitPronoun {W : Type} (n : Nat) : SitAssignment W → W :=
   fun gs => gs n
 
-/-- Bi-assignment-relative denotation: depends on both an entity assignment
-    and a situation assignment. Used by any module that interprets expressions
-    containing both entity pronouns and situation pronouns (definites,
-    attitude reports, modal scope, world-variable binding). -/
-def DenotGS (E W : Type) (ty : Ty) :=
+/-- A denotation relative to an entity assignment and a situation assignment, for
+expressions containing both entity and situation pronouns (definites, attitude reports,
+world-variable binding). -/
+abbrev DenotGS (E W : Type) (ty : Ty) :=
   Assignment E → SitAssignment W → Denot E W ty
 
-/-- Lift a pure entity-assignment-relative denotation to bi-assignment form
-    (ignores the situation assignment). -/
-def DenotGS.ofDenotG {E W : Type} {ty : Ty} (d : DenotG E W ty) : DenotGS E W ty :=
-  fun g _ => d g
-
-/-- Lift a constant denotation to bi-assignment form (ignores both
-    assignments). -/
+/-- A constant denotation as a bi-assignment-relative one. -/
 def DenotGS.const {E W : Type} {ty : Ty} (d : Denot E W ty) : DenotGS E W ty :=
   fun _ _ => d
-
-/-- Bi-assignment lift of a pure constant is the same as DenotG-lift of a
-    constant — the two `const` paths agree. -/
-theorem DenotGS.ofDenotG_const {E W : Type} {ty : Ty} (d : Denot E W ty) :
-    DenotGS.ofDenotG (constDenot d) = DenotGS.const d := rfl
 
 end Intensional.Variables

--- a/Linglib/Semantics/Reference/Binding.lean
+++ b/Linglib/Semantics/Reference/Binding.lean
@@ -17,12 +17,14 @@ view of the assignment update.
 
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Variables
+import Linglib.Logic.CylindricAlgebra
 import Linglib.Semantics.Quantification.Quantifier
 
 namespace Reference.Binding
 
 open Intensional
 open Intensional.Variables
+open CylindricAlgebra
 
 
 section Continuations
@@ -102,17 +104,17 @@ section CylindricAlgebra
 After binding, `g(κ) = g(l)`, which is the diagonal element `Dκl`.
 The semantic effect on a predicate φ is `φ(g[κ↦g(l)])`, which is
 cylindric substitution `σ^κ_l(φ)`. -/
-theorem binding_eq_resolve {E : Type} (κ l : Nat)
+theorem binding_eq_directSubst {E : Type} (κ l : Nat)
     (φ : Assignment E → Prop) (g : Assignment E) :
-    φ (g[κ ↦ g l]) = resolve κ l φ g := rfl
+    φ (g[κ ↦ g l]) = directSubst κ l φ g := rfl
 
 /-- After binding, the bound pronoun and its binder agree:
 `(g[κ↦g(l)])(κ) = (g[κ↦g(l)])(l)`. This is the diagonal condition
 `Dκl` that cylindric substitution enforces. -/
 theorem binding_establishes_diagonal {E : Type} (κ l : Nat)
     (g : Assignment E) (h : κ ≠ l) :
-    diag κ l (g[κ ↦ g l]) := by
-  simp [diag, Function.update_of_ne (Ne.symm h) (g l) g]
+    diagonal κ l (g[κ ↦ g l]) := by
+  simp [diagonal, Function.update_of_ne (Ne.symm h) (g l) g]
 
 end CylindricAlgebra
 


### PR DESCRIPTION
Arc 5 of the Intensional/ cleanse.

- `DenotG` and `DenotGS` are reducible, so assignment-relative denotations are the function types they abbreviate.
- The cylindric section (`existsClosure`, `diag`, `resolve` and their `rfl` bridges to `CylindricAlgebra`) is deleted; `Reference/Binding.lean` states binding resolution against `CylindricAlgebra.directSubst` and `diagonal` directly. Zero-consumer lemmas and `DenotGS.ofDenotG` go with it.