### PR TITLE
refactor(Syntax/Minimalist/Merge): gradings via HahnSeries.single

### DIFF
--- a/Linglib/Core/Algebra/RotaBaxterLaurent.lean
+++ b/Linglib/Core/Algebra/RotaBaxterLaurent.lean
@@ -30,10 +30,11 @@ polar parts and kills products of non-polar parts, because `support (x * y) ⊆ 
 
 The lemmas are stated at the *coefficient function* level (`polarHahn`, not a packaged `LinearMap`)
 and the `op` field of `rotaBaxterPolar` is constructed **inline**, so its module is the expected
-`Algebra.toModule` rather than `HahnSeries.instModule`. This avoids the `Module`-instance diamond on
-`LaurentSeries A` (the two modules are defeq but distinct *terms*, and reconciling them runs `isDefEq`
-through the noncomputable Laurent multiplication) — the same way mathlib proves the `HahnSeries` ring
-axioms directly at the coefficient level rather than by transporting packaged maps.
+`Algebra.toModule` rather than `HahnSeries.instModule`. This avoids the `Module`-instance diamond
+on `LaurentSeries A` (the two modules are defeq but distinct *terms*, and reconciling them runs
+`isDefEq` through the noncomputable Laurent multiplication) — the same way mathlib proves the
+`HahnSeries` ring axioms directly at the coefficient level rather than by transporting packaged
+maps.
 
 ## Main definitions
 
@@ -110,6 +111,45 @@ theorem polarHahn_eq_zero (s : LaurentSeries A) (h : ∀ i : ℤ, i < 0 → s.co
 /-- `1 = t⁰` is nonpolar. -/
 @[simp] theorem polarHahn_one : polarHahn (1 : LaurentSeries A) = 0 :=
   polarHahn_eq_zero _ fun i hi => by rw [HahnSeries.coeff_one, if_neg (by omega)]
+
+/-! ### Monomials -/
+
+/-- The monomial `single d r` is fixed by `R` when `d < 0` and killed otherwise. -/
+@[simp] theorem polarHahn_single (d : ℤ) (r : A) :
+    polarHahn (HahnSeries.single d r) = if d < 0 then HahnSeries.single d r else 0 := by
+  split_ifs with hd
+  · exact polarHahn_eq_self _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
+  · exact polarHahn_eq_zero _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
+
+/-- A nonzero monomial is nonpolar iff its exponent is nonnegative. -/
+theorem polarHahn_single_eq_zero_iff {d : ℤ} {r : A} (hr : r ≠ 0) :
+    polarHahn (HahnSeries.single d r) = 0 ↔ 0 ≤ d := by
+  rw [polarHahn_single]
+  split_ifs with hd
+  · simp [HahnSeries.single_eq_zero_iff, hr, hd.not_ge]
+  · simp [not_lt.mp hd]
+
+/-- The polar part of a sum of monomials is the sum over the negative exponents. -/
+theorem polarHahn_sum_map_single (d : Multiset ℤ) (r : A) :
+    polarHahn (d.map (HahnSeries.single · r)).sum
+      = ((d.filter (· < 0)).map (HahnSeries.single · r)).sum := by
+  induction d using Multiset.induction with
+  | empty => simp
+  | cons i d ih =>
+    rw [Multiset.map_cons, Multiset.sum_cons, polarHahn_add, ih, polarHahn_single]
+    by_cases h : i < 0 <;> simp [h]
+
+/-- The nonpolar projection `1 − R` of a sum of monomials keeps the nonnegative exponents. -/
+theorem sum_map_single_sub_polarHahn (d : Multiset ℤ) (r : A) :
+    (d.map (HahnSeries.single · r)).sum - polarHahn (d.map (HahnSeries.single · r)).sum
+      = ((d.filter (0 ≤ ·)).map (HahnSeries.single · r)).sum := by
+  rw [polarHahn_sum_map_single, sub_eq_iff_eq_add', ← Multiset.sum_add, ← Multiset.map_add]
+  simp only [← not_lt, Multiset.filter_add_not]
+
+/-- A sum of monomials with nonnegative exponents is nonpolar. -/
+theorem polarHahn_sum_map_single_of_nonneg {d : Multiset ℤ} (h : ∀ i ∈ d, 0 ≤ i) (r : A) :
+    polarHahn (d.map (HahnSeries.single · r)).sum = 0 := by
+  simp [polarHahn_sum_map_single, Multiset.filter_eq_nil.mpr fun i hi => not_lt.mpr (h i hi)]
 
 /-- A nonpolar series (`R s = 0`) is supported on non-negative degrees. -/
 theorem support_subset_nonneg (s : LaurentSeries A) (hs : polarHahn s = 0) :
@@ -201,7 +241,8 @@ private theorem coeff_algebraMap_mul (c : k) (y : LaurentSeries A) (i : ℤ) :
 /-- **The polar projection is a Rota–Baxter operator of weight `-1`** on `LaurentSeries A`
     ([marcolli-chomsky-berwick-2025] Prop. 3.5.2): the prototype minimal-subtraction operator. The
     `op` linear map is built inline with `letI := Algebra.toModule` to pin the expected module (see
-    the implementation note); `map_smul'` is then over the algebra action `c • x = algebraMap c * x`. -/
+    the implementation note); `map_smul'` is then over the algebra action
+    `c • x = algebraMap c * x`. -/
 noncomputable def rotaBaxterPolar : RotaBaxter k (LaurentSeries A) (-1) where
   op := by
     letI : Module k (LaurentSeries A) := Algebra.toModule
@@ -214,7 +255,7 @@ noncomputable def rotaBaxterPolar : RotaBaxter k (LaurentSeries A) (-1) where
           coeff_algebraMap_mul, coeff_algebraMap_mul, coeff_polarHahn]
         split_ifs <;> ring }
   rotaBaxter a b := by
-    letI : Module k (LaurentSeries A) := Algebra.toModule
+    let _ : Module k (LaurentSeries A) := Algebra.toModule
     simp only [LinearMap.coe_mk, AddHom.coe_mk]
     rw [neg_one_smul, ← sub_eq_add_neg]
     exact polarHahn_rotaBaxter a b

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -80,14 +80,14 @@ theorem em_pair_satisfiesMinimalYield (lbl : α) (S S' : Nonplanar (α ⊕ β)) 
   have hnode : (Nonplanar.node (Sum.inl lbl) {S, S'}).accCount
       = S.accCount + S'.accCount + 2 := Nonplanar.accCount_node_pair (Sum.inl lbl) S S'
   refine ⟨⟨?_, ?_⟩, ?_⟩
-  · simp only [Forest.b₀_singleton, Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_zero]
+  · simp only [Forest.b₀_singleton, Multiset.insert_eq_cons, Forest.b₀_cons]
     omega
   · rw [Forest.alpha_singleton, hnode]
     simp only [Multiset.insert_eq_cons, Forest.alpha_cons, Forest.alpha_singleton]
     omega
   · simp only [Forest.sigma, Forest.b₀_singleton, Forest.alpha_singleton]
     rw [hnode]
-    simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton, Forest.b₀_zero,
+    simp only [Multiset.insert_eq_cons, Forest.b₀_cons, Forest.b₀_singleton,
       Forest.alpha_cons, Forest.alpha_singleton]
     omega
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
@@ -20,8 +20,8 @@ canonical construction `L(F) → F` is exactly `α(F) = Forest.alpha F` (the lea
 
 Since `α(F) ≥ 0`, `ϕt` lands entirely in the **nonpolar** subring `DM[[t]] = (1 − R)·DM[t⁻¹][[t]]`
 (**MCB Lemma 3.5.5**): `R·ϕt(F) = 0` for every forest `F`. This is exactly why `ϕt` alone cannot
-detect Sideward Merge — the intermediate-derivation character `ψt` (Cor. 3.5.4) and the full Birkhoff
-factorization (Prop. 3.5.6) are needed to separate Internal/External from Sideward Merge.
+detect Sideward Merge — the intermediate-derivation character `ψt` (Cor. 3.5.4) and the full
+Birkhoff factorization (Prop. 3.5.6) are needed to separate Internal/External from Sideward Merge.
 
 ## Main definitions
 
@@ -38,20 +38,11 @@ open RoseTree RoseTree.Nonplanar ConnesKreimer LaurentSeries
 
 variable {α : Type*} {R : Type*} [CommRing R]
 
-/-! ### `gradeMonomial` is a multiplicative grading -/
-
-@[simp] theorem gradeMonomial_zero : gradeMonomial (A := R) 0 = 1 := rfl
-
-/-- `tᵃ · tᵇ = tᵃ⁺ᵇ`: the grading monomials multiply by adding exponents. -/
-theorem gradeMonomial_mul (a b : ℤ) :
-    gradeMonomial (A := R) a * gradeMonomial b = gradeMonomial (a + b) := by
-  rw [gradeMonomial, gradeMonomial, gradeMonomial, HahnSeries.single_mul_single, one_mul]
-
 /-! ### The character ϕt (MCB Prop. 3.5.3, `δα` grading) -/
 
 /-- The per-tree value of `ϕt`: `t^{α(T)} = t^{accCount T}` (the `δα` grading of `L(T) → T`). -/
 noncomputable def gradingMonomialTree (T : Nonplanar α) : LaurentSeries R :=
-  gradeMonomial (T.accCount : ℤ)
+  HahnSeries.single (T.accCount : ℤ) 1
 
 /-- `ϕt` extended multiplicatively to forests (`ϕt(F ⊔ F') = ϕt(F)·ϕt(F')`); mirrors
     `antipodeMonoidHomN`. -/
@@ -79,20 +70,20 @@ noncomputable def gradingChar : ConnesKreimer R (Nonplanar α) →ₐ[R] Laurent
 /-- `ϕt(F) = t^{α(F)}`: the forest value is the single grading monomial at the accessible-term
     count (the product of per-tree monomials collapses since `α` is additive). -/
 theorem prod_gradingMonomialTree (F : Forest (Nonplanar α)) :
-    (F.map (gradingMonomialTree (R := R))).prod = gradeMonomial (Forest.alpha F : ℤ) := by
+    (F.map (gradingMonomialTree (R := R))).prod = HahnSeries.single (Forest.alpha F : ℤ) 1 := by
   induction F using Multiset.induction with
   | empty => rw [Multiset.map_zero, Multiset.prod_zero, Forest.alpha_zero]; rfl
   | cons T F ih =>
-    rw [Multiset.map_cons, Multiset.prod_cons, ih, gradingMonomialTree, gradeMonomial_mul,
-      Forest.alpha_cons]
+    rw [Multiset.map_cons, Multiset.prod_cons, ih, gradingMonomialTree,
+      HahnSeries.single_mul_single, one_mul, Forest.alpha_cons]
     push_cast; rfl
 
 theorem gradingChar_apply_of'_eq (F : Forest (Nonplanar α)) :
-    gradingChar (R := R) (of' F) = gradeMonomial (Forest.alpha F : ℤ) := by
+    gradingChar (R := R) (of' F) = HahnSeries.single (Forest.alpha F : ℤ) 1 := by
   rw [gradingChar_apply_of', prod_gradingMonomialTree]
 
 @[simp] theorem gradingChar_apply_ofTree (T : Nonplanar α) :
-    gradingChar (R := R) (ofTree T) = gradeMonomial (T.accCount : ℤ) := by
+    gradingChar (R := R) (ofTree T) = HahnSeries.single (T.accCount : ℤ) 1 := by
   unfold ofTree
   rw [gradingChar_apply_of', Multiset.map_singleton, Multiset.prod_singleton]
   rfl
@@ -104,13 +95,13 @@ theorem gradingChar_apply_of'_eq (F : Forest (Nonplanar α)) :
     operations build `F`), motivating the intermediate-derivation character `ψt`. -/
 theorem polarHahn_gradingChar_of' (F : Forest (Nonplanar α)) :
     polarHahn (gradingChar (R := R) (of' F)) = 0 := by
-  rw [gradingChar_apply_of'_eq, polarHahn_gradeMonomial,
+  rw [gradingChar_apply_of'_eq, polarHahn_single,
     if_neg (by omega : ¬ ((Forest.alpha F : ℤ) < 0))]
 
 /-- Lemma 3.5.5 on a single tree: `R·ϕt(T) = 0`. -/
 theorem polarHahn_gradingChar_ofTree (T : Nonplanar α) :
     polarHahn (gradingChar (R := R) (ofTree T)) = 0 := by
-  rw [gradingChar_apply_ofTree, polarHahn_gradeMonomial,
+  rw [gradingChar_apply_ofTree, polarHahn_single,
     if_neg (by omega : ¬ ((T.accCount : ℤ) < 0))]
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
@@ -7,172 +7,78 @@ import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Core.Algebra.RotaBaxterLaurent
 
 /-!
-# The δ-grading of Minimal Yield and the polar part
+# The gradings of Minimal Yield and the polar part
 
-MCB's §3.5.2 recasts Minimal Yield (Def. 1.6.1) as a Birkhoff factorization in a ring of **Laurent
-series** `DM[t⁻¹][[t]]` with coefficients in the algebra of free Merge derivations, weighting each
-derivation `F → F'` by `tᵟ` for a **grading** `δ ∈ {δb₀, δα, δσ}`. This file is the grading layer
-between `MinimalYield.lean`'s size measures `b₀/α/σ` and the polar-part Rota–Baxter operator
-`LaurentSeries.polarHahn` of `RotaBaxterLaurent.lean` (MCB Prop. 3.5.2).
+Minimal Yield can be restated as a Birkhoff factorization in the ring of Laurent series
+`DM[t⁻¹][[t]]` over the algebra of free Merge derivations, weighting a transformation `F → F'` of
+workspaces by `tᵟ` for a grading `δ` read off the size measures of `MinimalYield.lean`. In this file
+we define the three gradings
 
-The signed deltas (MCB §3.5.2.1) of a transformation `F → F'`:
+  `δb₀ F F' = b₀ F − b₀ F'`,  `δα F F' = α F' − α F`,  `δσ F F' = σ F' − σ F`,
 
-  `δb₀ = b₀ F − b₀ F'`,  `δα = α F' − α F`,  `δσ = σ F' − σ F`,
+with `δσ = δα − δb₀` since `σ = b₀ + α`, and show that Minimal Yield is exactly
+`0 ≤ δb₀ ∧ 0 ≤ δα ∧ δσ = 1` (no divergence, no information loss, minimality of yield).
 
-with `σ = b₀ + α` giving `δσ = δα − δb₀`. Minimal Yield (Def. 1.6.1) is exactly
-`δb₀ ≥ 0 ∧ δα ≥ 0 ∧ δσ = 1` (no divergence / no information loss / minimality of yield).
-
-The bridge to the polar projection: a derivation graded `tᵟ` lands in the **polar** part (`δ < 0`,
-fixed by `R = polarHahn`, the divergent part Birkhoff factorization removes) iff its grading is
-negative. Minimal-Yield-respecting steps (External/Internal Merge) have `δ ≥ 0`, hence **nonpolar**
-(the per-merge shadow of MCB Lemma 3.5.5); the divergent Sideward Merge steps 3(a)/3(b) have
-`δb₀ = −1 < 0`, hence **polar** — the derivations MCB Prop. 3.5.6's factorization eliminates.
-
-The intermediate-derivation character `ψt` (Cor. 3.5.4, eq. 3.5.7) sums `tᵟ` over all pairs
-`(F, F')` of intermediate derivations of a target, and since `δ` depends only on the endpoints,
-each pair contributes one grading monomial. For such sums the polar part is the sum over the
-divergent gradings alone (`polarHahn_sum_map_gradeMonomial`), and `1 − R` keeps the rest — the
-sum-level reason `ψt` sees a Sideward Merge that `ϕt` (Lemma 3.5.5) cannot.
+The grading meets the polar-part operator `R = LaurentSeries.polarHahn` through the monomial `tᵟ`,
+which is nonpolar iff `0 ≤ δ` (`LaurentSeries.polarHahn_single_eq_zero_iff`). Hence a
+transformation satisfies weak Minimal Yield iff its `δb₀`- and `δα`-monomials are both nonpolar
+(`minimalYieldWeak_iff_polarHahn`): External and Internal Merge are nonpolar, while the divergent
+forms of Sideward Merge, which raise `b₀`, are polar — the terms Birkhoff factorization removes.
+Summing monomials over a family of transformations, as the intermediate-derivation character `ψt`
+does, the polar part is the sum over the divergent ones (`LaurentSeries.polarHahn_sum_map_single`).
 
 ## Main definitions
 
-- `Minimalist.Merge.δb₀ / δα / δσ`: the signed `ℤ`-valued gradings.
-- `Minimalist.Merge.gradeMonomial`: the Laurent monomial `tᵈ` whose polarity tracks `d`.
+* `Minimalist.Merge.δb₀`, `Minimalist.Merge.δα`, `Minimalist.Merge.δσ`: the signed gradings.
+
+## Main results
+
+* `Minimalist.Merge.minimalYield_iff`: Minimal Yield as sign conditions on the gradings.
+* `Minimalist.Merge.minimalYieldWeak_iff_polarHahn`: weak Minimal Yield as nonpolarity.
 
 ## References
 
-* [marcolli-chomsky-berwick-2025], §3.5.2 (Prop. 3.5.2, Cor. 3.5.4, Lemma 3.5.5, Prop. 3.5.6)
+* [marcolli-chomsky-berwick-2025], §3.5.2.1–3.5.2.2
 -/
 
 namespace Minimalist.Merge
 
 open RoseTree RoseTree.Nonplanar LaurentSeries
 
-variable {α β : Type*}
+variable {α β A : Type*} [CommRing A] (F F' : Forest (Nonplanar (α ⊕ β)))
 
-/-! ### The δ-grading (MCB §3.5.2.1) -/
+/-! ### The gradings -/
 
-/-- `δb₀ = b₀ F − b₀ F'` (MCB §3.5.2.1): divergence; `≥ 0` is "no divergence". -/
-def δb₀ (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.b₀ F : ℤ) - Forest.b₀ F'
+/-- `δb₀ F F' = b₀ F − b₀ F'`, nonnegative iff `F → F'` does not diverge. -/
+def δb₀ : ℤ := (Forest.b₀ F : ℤ) - Forest.b₀ F'
 
-/-- `δα = α F' − α F` (MCB §3.5.2.1): information gain; `≥ 0` is "no information loss". -/
-def δα (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.alpha F' : ℤ) - Forest.alpha F
+/-- `δα F F' = α F' − α F`, nonnegative iff `F → F'` loses no information. -/
+def δα : ℤ := (Forest.alpha F' : ℤ) - Forest.alpha F
 
-/-- `δσ = σ F' − σ F` (MCB §3.5.2.1): yield; `= 1` is "minimality of yield". -/
-def δσ (F F' : Forest (Nonplanar (α ⊕ β))) : ℤ := (Forest.sigma F' : ℤ) - Forest.sigma F
+/-- `δσ F F' = σ F' − σ F`, equal to `1` iff `F → F'` has minimal yield. -/
+def δσ : ℤ := (Forest.sigma F' : ℤ) - Forest.sigma F
 
-/-- The grading consistency relation `δσ = δα − δb₀`, from `σ = b₀ + α`. -/
-theorem δσ_eq (F F' : Forest (Nonplanar (α ⊕ β))) : δσ F F' = δα F F' - δb₀ F F' := by
-  simp only [δσ, δα, δb₀, Forest.sigma]; push_cast; ring
+theorem δσ_eq : δσ F F' = δα F F' - δb₀ F F' := by
+  simp only [δσ, δα, δb₀, Forest.sigma]; omega
 
-/-! ### Minimal Yield as the grading conditions (MCB §3.5.2.1) -/
+/-! ### Minimal Yield as sign conditions -/
 
-/-- Weak Minimal Yield is exactly `δb₀ ≥ 0 ∧ δα ≥ 0` (MCB §3.5.2.1, "no divergence / no
-    information loss"). -/
-theorem minimalYieldWeak_iff (F F' : Forest (Nonplanar (α ⊕ β))) :
-    MinimalYieldWeak F F' ↔ 0 ≤ δb₀ F F' ∧ 0 ≤ δα F F' := by
-  simp only [δb₀, δα]
-  constructor
-  · rintro ⟨hb, ha⟩; exact ⟨by omega, by omega⟩
-  · rintro ⟨hb, ha⟩; exact ⟨by omega, by omega⟩
+theorem minimalYieldWeak_iff : MinimalYieldWeak F F' ↔ 0 ≤ δb₀ F F' ∧ 0 ≤ δα F F' := by
+  simp only [δb₀, δα, sub_nonneg, Nat.cast_le]
+  exact ⟨fun h => ⟨h.1, h.2⟩, fun h => ⟨h.1, h.2⟩⟩
 
-/-- Minimal Yield is exactly `δb₀ ≥ 0 ∧ δα ≥ 0 ∧ δσ = 1` (MCB §3.5.2.1). -/
-theorem minimalYield_iff (F F' : Forest (Nonplanar (α ⊕ β))) :
+theorem minimalYield_iff :
     MinimalYield F F' ↔ 0 ≤ δb₀ F F' ∧ 0 ≤ δα F F' ∧ δσ F F' = 1 := by
-  constructor
-  · intro h
-    obtain ⟨hb, ha⟩ := (minimalYieldWeak_iff F F').mp h.toMinimalYieldWeak
-    have hs := h.minimalYield
-    exact ⟨hb, ha, by simp only [δσ]; omega⟩
-  · rintro ⟨hb, ha, hs⟩
-    refine ⟨(minimalYieldWeak_iff F F').mpr ⟨hb, ha⟩, ?_⟩
-    simp only [δσ] at hs; omega
+  rw [← and_assoc, ← minimalYieldWeak_iff, δσ, sub_eq_iff_eq_add']
+  exact ⟨fun h => ⟨h.1, by exact_mod_cast h.2⟩, fun h => ⟨h.1, by exact_mod_cast h.2⟩⟩
 
-/-! ### The grading monomial and the polar part (bridge to MCB Prop. 3.5.2) -/
+/-! ### Nonpolarity -/
 
-variable {A : Type*} [CommRing A]
-
-/-- The Laurent grading monomial `tᵈ` (MCB eq. 3.5.6, coefficient `1`): a derivation graded by `d`
-    contributes `tᵈ` to the Laurent-series character. -/
-noncomputable def gradeMonomial (d : ℤ) : LaurentSeries A := HahnSeries.single d 1
-
-/-- A graded monomial is **polar** (fixed by `R = polarHahn`) iff its grading is negative, and is
-    annihilated by `R` otherwise — the divergent/convergent split of MCB Prop. 3.5.2. -/
-theorem polarHahn_gradeMonomial (d : ℤ) :
-    polarHahn (gradeMonomial (A := A) d) = if d < 0 then gradeMonomial d else 0 := by
-  unfold gradeMonomial
-  split_ifs with hd
-  · exact polarHahn_eq_self _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
-  · exact polarHahn_eq_zero _ fun i hi => HahnSeries.coeff_single_of_ne (by omega)
-
-/-! ### Sums of grading monomials -/
-
-/-- The polar part of a sum of grading monomials is the sum over the negative gradings. -/
-theorem polarHahn_sum_map_gradeMonomial (d : Multiset ℤ) :
-    polarHahn (d.map (gradeMonomial (A := A))).sum
-      = ((d.filter (· < 0)).map gradeMonomial).sum := by
-  induction d using Multiset.induction with
-  | empty => simp
-  | cons i d ih =>
-    rw [Multiset.map_cons, Multiset.sum_cons, polarHahn_add, ih, polarHahn_gradeMonomial]
-    by_cases h : i < 0 <;> simp [h]
-
-/-- The nonpolar projection `1 − R` of a sum of grading monomials keeps the nonnegative
-    gradings. -/
-theorem sum_map_gradeMonomial_sub_polarHahn (d : Multiset ℤ) :
-    (d.map (gradeMonomial (A := A))).sum - polarHahn (d.map gradeMonomial).sum
-      = ((d.filter (0 ≤ ·)).map gradeMonomial).sum := by
-  rw [polarHahn_sum_map_gradeMonomial, sub_eq_iff_eq_add', ← Multiset.sum_add,
-    ← Multiset.map_add]
-  simp only [← not_lt, Multiset.filter_add_not]
-
-/-- A sum of grading monomials with nonnegative gradings is nonpolar. -/
-theorem polarHahn_sum_map_gradeMonomial_of_nonneg {d : Multiset ℤ} (h : ∀ i ∈ d, 0 ≤ i) :
-    polarHahn (d.map (gradeMonomial (A := A))).sum = 0 := by
-  simp [polarHahn_sum_map_gradeMonomial, Multiset.filter_eq_nil.mpr fun i hi => not_lt.mpr (h i hi)]
-
-/-! ### Per-merge polarity: Minimal Yield is nonpolar, divergent Sideward is polar -/
-
-/-- A weak-Minimal-Yield step is **nonpolar** in the `δb₀` grading: `R` annihilates its monomial
-    (`δb₀ ≥ 0`). The External/Internal-Merge shadow of MCB Lemma 3.5.5. -/
-theorem polarHahn_gradeMonomial_of_minimalYieldWeak
-    (F F' : Forest (Nonplanar (α ⊕ β))) (h : MinimalYieldWeak F F') :
-    polarHahn (gradeMonomial (A := A) (δb₀ F F')) = 0 := by
-  rw [polarHahn_gradeMonomial, if_neg]
-  obtain ⟨hb, _⟩ := (minimalYieldWeak_iff F F').mp h
-  omega
-
-/-- External Merge is nonpolar (MCB Lemma 3.5.5): `δb₀ = +1 ≥ 0`, so `R` annihilates its
-    monomial. -/
-theorem polarHahn_gradeMonomial_em (lbl : α) (S S' : Nonplanar (α ⊕ β)) :
-    polarHahn (gradeMonomial (A := A)
-        (δb₀ ({S, S'} : Forest (Nonplanar (α ⊕ β))) {Nonplanar.node (Sum.inl lbl) {S, S'}})) = 0 :=
-  polarHahn_gradeMonomial_of_minimalYieldWeak _ _
-    (em_pair_satisfiesMinimalYield lbl S S').toMinimalYieldWeak
-
-/-- Sideward Merge 3(a) has divergent grading `δb₀ = −1` (`b₀` increases by one). -/
-theorem δb₀_sideward_3a (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
-    δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq} = -1 := by
-  simp only [δb₀, sideward_3a_b₀_increases T_i Tnode T_iq]; push_cast; ring
-
-/-- Sideward Merge 3(b) has divergent grading `δb₀ = −1` (`b₀` increases by one). -/
-theorem δb₀_sideward_3b (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
-    δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq} = -1 := by
-  simp only [δb₀, sideward_3b_b₀_increases T_i T_j Tnode T_iq T_jq]; push_cast; ring
-
-/-- Sideward Merge 3(a) is **polar** in the `δb₀` grading: `R` fixes its monomial (`δb₀ = −1 < 0`) —
-    the divergent derivation MCB Prop. 3.5.6's Birkhoff factorization eliminates. -/
-theorem polarHahn_gradeMonomial_sideward_3a (T_i Tnode T_iq : Nonplanar (α ⊕ β)) :
-    polarHahn (gradeMonomial (A := A)
-        (δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq}))
-      = gradeMonomial (δb₀ ({T_i} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq}) := by
-  rw [polarHahn_gradeMonomial, δb₀_sideward_3a, if_pos (by norm_num : (-1 : ℤ) < 0)]
-
-/-- Sideward Merge 3(b) is **polar** in the `δb₀` grading (`δb₀ = −1 < 0`). -/
-theorem polarHahn_gradeMonomial_sideward_3b (T_i T_j Tnode T_iq T_jq : Nonplanar (α ⊕ β)) :
-    polarHahn (gradeMonomial (A := A)
-        (δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq}))
-      = gradeMonomial (δb₀ ({T_i, T_j} : Forest (Nonplanar (α ⊕ β))) {Tnode, T_iq, T_jq}) := by
-  rw [polarHahn_gradeMonomial, δb₀_sideward_3b, if_pos (by norm_num : (-1 : ℤ) < 0)]
+/-- Weak Minimal Yield holds iff the `δb₀`- and `δα`-monomials of `F → F'` are both nonpolar. -/
+theorem minimalYieldWeak_iff_polarHahn [Nontrivial A] :
+    MinimalYieldWeak F F' ↔
+      polarHahn (HahnSeries.single (δb₀ F F') (1 : A)) = 0 ∧
+        polarHahn (HahnSeries.single (δα F F') (1 : A)) = 0 := by
+  simp only [minimalYieldWeak_iff, polarHahn_single_eq_zero_iff one_ne_zero]
 
 end Minimalist.Merge


### PR DESCRIPTION
Audit of `MinimalYieldGrading.lean`: `gradeMonomial` was an alias of `HahnSeries.single d 1`, and its five per-merge polarity lemmas (zero consumers) were instances of one iff.

- `polarHahn_single`, `polarHahn_single_eq_zero_iff`, and the monomial-sum lemmas move to `RotaBaxterLaurent.lean`, general in the coefficient.
- `minimalYieldWeak_iff_polarHahn` states weak Minimal Yield as nonpolarity of the `δb₀` and `δα` monomials; `MinimalYieldCharacter.lean` uses `single` directly.