### PR TITLE
refactor(Syntax/Minimalist/Merge): recut the operator files, no bridges

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2874,6 +2874,7 @@ import Linglib.Syntax.Minimalist.Merge.MinimalYieldCharacter
 import Linglib.Syntax.Minimalist.Merge.MinimalYieldGrading
 import Linglib.Syntax.Minimalist.Merge.NoComplexityLoss
 import Linglib.Syntax.Minimalist.Merge.Sideward
+import Linglib.Syntax.Minimalist.Merge.SyntacticObject
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Minimalist.Movement.DegreeMovement
 import Linglib.Syntax.Minimalist.Movement.InverseVoice

--- a/Linglib/Syntax/Minimalist/Merge/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Basic.lean
@@ -1,10 +1,10 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
+import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.Maps
 
 /-!
 # Merge operator on the Connes–Kreimer bialgebra of nonplanar forests
-[marcolli-chomsky-berwick-2025]
 
 Per [marcolli-chomsky-berwick-2025] §1.3 (Definitions 1.3.1, 1.3.2, 1.3.4),
 the linguistic **Merge operator** `M_{S,S'}` for a pair `(S, S') : Nonplanar α`
@@ -25,8 +25,10 @@ on the canonical carrier `ConnesKreimer R (Nonplanar α)`, where:
   union, the algebra structure).
 
 This file builds the building blocks (`gammaMatch`, `deltaMatch`, `graftBinaryAt`)
-and assembles `mergeOp`. Bridges to linguistic `Step.apply` live in
-`Merge.External` (EM) and `Merge.Internal` (IM).
+and assembles `mergeOp`, together with the generic operator `mergeOpG` over an
+arbitrary cut enumeration and its Δ^c instance `mergeOpC`. The three cases of
+Merge are realized in `Merge/External.lean`, `Merge/Internal.lean`, and
+`Merge/Sideward.lean`; the Minimal-Search weighting in `Merge/MinimalSearch.lean`.
 
 ## Merge coproduct: Δ^ρ, not Δ^d
 
@@ -37,9 +39,9 @@ only in the remainder, which `mergePost` discards when grafting the pair — so
 merge correctness is unaffected. Δ^ρ is the n-ary-faithful deletion (MCB's
 binary Δ^d `+2` is a rebinarization artifact).
 
-The **cost-weighted** Merge `M^ε` (eq. 1.5.1) is deferred: it needs an
-ε-weighted Δ^ρ (a `cutTotalDepth` analogue on `cutSummandsN`), not yet in the
-substrate.
+## References
+
+* [marcolli-chomsky-berwick-2025], §1.3 (Definitions 1.3.1, 1.3.2, 1.3.4)
 -/
 
 namespace Minimalist.Merge
@@ -400,5 +402,28 @@ theorem mergeOpUnit_one (β : Nonplanar α) :
       rw [h]
     simp only [Multiset.card_zero, Multiset.card_singleton] at this
     omega)]
+
+/-! ### The generic operator over a cut enumeration -/
+
+/-- The generic Merge operator `M_{S,S'}^{cuts}` over a cut enumeration `cuts`:
+    `mergePost lbl S S' ∘ comulAlgHomNG cuts`. Only the coproduct varies with `cuts`; the
+    post-chain of graft, δ-projection, and multiplication is shared. -/
+noncomputable def mergeOpG (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (lbl : α) (S S' : Nonplanar α) :
+    ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
+  mergePost (R := R) (α := α) lbl S S' ∘ₗ (comulAlgHomNG cuts).toLinearMap
+
+/-- The Δ^ρ operator `mergeOp` is the generic operator at `cuts := cutSummandsN`. -/
+theorem mergeOp_eq_G (lbl : α) (S S' : Nonplanar α) :
+    mergeOp (R := R) lbl S S' = mergeOpG (R := R) cutSummandsN lbl S S' := rfl
+
+omit [DecidableEq (Nonplanar α)] in
+/-- The Δ^c (trace) Merge operator, the generic operator at `cuts := cutSummandsCN τ`. Its
+    quotients carry a trace leaf at each cut site at the cut depth, so the Minimal-Search cost
+    `Cut.depthC` is recoverable from them. -/
+noncomputable def mergeOpC {β : Type*} [DecidableEq (Nonplanar (α ⊕ β))]
+    (τ : Nonplanar (α ⊕ β) → β) (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
+    ConnesKreimer R (Nonplanar (α ⊕ β)) →ₗ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
+  mergeOpG (R := R) (cutSummandsCN τ) lbl S S'
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -1,54 +1,35 @@
 import Linglib.Syntax.Minimalist.Merge.Basic
-import Linglib.Syntax.Minimalist.Defs
 import Linglib.Syntax.Minimalist.Workspace.DeletionConservation
 import Linglib.Core.Combinatorics.RootedTree.CutAvoiding
 import Linglib.Core.Algebra.RootedTree.HopfAlgebra
-import Linglib.Core.Data.RoseTree.DecEq
 
 /-!
-# External Merge bridge: algebraic ↔ linguistic
-[marcolli-chomsky-berwick-2025]
+# External Merge on the algebraic carrier
 
-Realizes M-C-B §1.4 Lemma 1.4.1 (External Merge) at the algebraic level on the
-canonical carrier `ConnesKreimer R (Nonplanar α)` and bridges to linguistic
-`Step.emR`/`Step.emL`.
+External Merge (Lemma 1.4.1) on the canonical carrier `ConnesKreimer R (Nonplanar α)`: for a pair
+`(S, S') : Nonplanar α` and a root label `lbl`, `mergeOp lbl S S'` sends the workspace
+`of' {S, S'}` to `of' {Nonplanar.node lbl {S, S'}}` (`mergeOp_pair`), and on a workspace with a
+residual part `F̂` avoiding the cuts that extract `S` or `S'`, it factors through the spectator
+components (`mergeOp_factor_out_singleton`, `mergeOp_pair_residual`). The carrier-level form on
+`SyntacticObject` is `SyntacticObject.merge_toForest` in `Merge/SyntacticObject.lean`.
 
-## Contents
-
-**Lemma 1.4.1, F̂ = ∅ subcase** (`mergeOp_pair`). For any pair
-`(S, S') : Nonplanar α` and any root label `lbl`, `mergeOp lbl S S'` applied to
-`of' {S, S'}` yields `of' {Nonplanar.node lbl {S, S'}}`. Proof: expand the merge
-coproduct `Δ^ρ({S, S'}) = comulTreeN S * comulTreeN S'` (`comulForestN_cons`),
-distribute the prim/cut split of each factor, and evaluate the 4 cross-terms via
-`mergePost_basis_tensor`. Only the `prim × prim` cross-term survives; the other
-three vanish because no proper cut extracts a whole tree as its crown
-(`cutSummandsN_crown_ne_singleton`) and vertex conservation
-(`cutSummandsN_numNodes`) forbids two crowns from reassembling `{S, S'}`.
-
-**Lemma 1.4.1 with residual workspace F̂** (`mergeOp_factor_out_singleton`,
-`mergeOp_pair_residual`, MCB "Case 1"). Under `CutAvoidingForest ({S, S'}) F̂`
-(the `cutSummandsN`-based disjointness predicate: each
-`T ∈ F̂` differs from `S, S'` and no Δ^ρ cut of `T` extracts either as a crown),
-Merge factors through multiplication by the spectator components `of' {T}`; an
-induction on F̂ assembles the full Case-1 result. `mergeOp_factor_out_singleton`
-is the inductive step: `mergeOp lbl S S' (of' {T} * w) = of' {T} * mergeOp lbl S S'
-w`, isolating the surviving empty-cut summand of `comulTreeN T` via
+The proof of `mergeOp_pair` expands the merge coproduct
+`Δ^ρ({S, S'}) = comulTreeN S * comulTreeN S'`, distributes the primitive-plus-cut split of each
+factor, and evaluates the four cross-terms via `mergePost_basis_tensor`; only the primitive ×
+primitive term survives, the others vanishing because no proper cut extracts a whole tree as its
+crown (`cutSummandsN_crown_ne_singleton`) and vertex conservation (`cutSummandsN_numNodes`)
+forbids two crowns from reassembling `{S, S'}`. The residual case is an induction on `F̂` under
+`CutAvoidingForest`, isolating the surviving empty-cut summand of `comulTreeN T` via
 `cutSummandsN_filter_card_zero`.
 
-The Minimalism-specific bridges (`mergeOp_emR/emL_matches_Step`) specialize to
-`R = ℤ`, `α = LIToken ⊕ Unit`. They take the **head label** `L` of the merged
-node and a coherence hypothesis `h_coh` factoring `(current * item).toNonplanar` as
-`Nonplanar.node (Sum.inl L) {current.toNonplanar, item.toNonplanar}` — the labeling convention
-fixed in `Merge.Defs`'s `planarToNonplanar` (each internal node decorated with its head
-leaf). This is the coupling point that validates the carrier bridge's design.
+## Main results
 
-## Deferred (substrate gap)
+* `Minimalist.Merge.mergeOp_pair`: External Merge on a two-object workspace.
+* `Minimalist.Merge.mergeOp_pair_residual`: External Merge with a cut-avoiding residual workspace.
 
-- **§3-4: cost-weighted Merge `M^ε` and the ε → 0 Sideward-elimination chain**
-  (`mergeOp_eps_zero_*`, `em_only_chain_eps_zero`). Needs an ε-weighted Δ^ρ
-  (a `cutTotalDepth` analogue on `cutSummandsN`), not yet in the substrate.
-  Once it lands, the EM-only chain can ride either `mergeOp` (unweighted) or the
-  cost-weighted operator.
+## References
+
+* [marcolli-chomsky-berwick-2025], §1.4 (Lemma 1.4.1)
 -/
 
 namespace Minimalist.Merge
@@ -275,8 +256,8 @@ theorem mergeOp_factor_out_singleton {R : Type*} [CommSemiring R] {α : Type*}
 
     Induction on `Fhat` via `mergeOp_factor_out_singleton`. Without the
     disjointness, `mergeOp` produces the full sum-over-matchings (including
-    Sideward contributions); MCB eliminate those via Minimal-Search cost weighting
-    in the ε → 0 limit (the deferred `M^ε` arc). -/
+    Sideward contributions); the Minimal-Search weighting `mergeOpCEps` eliminates those in
+    the ε → 0 limit. -/
 theorem mergeOp_pair_residual {R : Type*} [CommSemiring R] {α : Type*}
     [DecidableEq (Nonplanar α)] (lbl : α) {S S' : Nonplanar α}
     {Fhat : Forest (Nonplanar α)}
@@ -309,11 +290,5 @@ theorem mergeOp_pair_residual {R : Type*} [CommSemiring R] {α : Type*}
           (({Nonplanar.node lbl {S, S'}} : Forest (Nonplanar α)) + Fhat'),
         mergeOp_factor_out_singleton lbl hT_S hT_S']
     exact congrArg (of' (R := R) ({T} : Forest (Nonplanar α)) * ·) ih'
-
-/-! The linguistic External-Merge bridges `mergeOp_emR/emL_matches_Step` (which
-related `mergeOp (Sum.inl L)` on the head-decorated `toNonplanar` projection to the
-legacy `Step.emR/emL`) have been retired by the single-carrier migration. On the
-bare `SyntacticObject` carrier the bridge is `Workspace.lean`'s `SyntacticObject.merge_toForest`
-(`mergeOp_pair` with the bare `Sum.inr ()` label). -/
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/Internal.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Internal.lean
@@ -1,41 +1,30 @@
 import Linglib.Syntax.Minimalist.Merge.External
 
 /-!
-# Internal Merge bridge: algebraic ↔ linguistic
-[marcolli-chomsky-berwick-2025]
+# Internal Merge as a composition of Merges
 
-Realizes M-C-B Proposition 1.4.2 (book p. 50): Internal Merge as a
-**composition of two algebraic Merges** on the canonical carrier
-`ConnesKreimer R (Nonplanar α)` —
+Internal Merge (Proposition 1.4.2) on the canonical carrier `ConnesKreimer R (Nonplanar α)` is a
+composition of two algebraic Merges,
 
-  IM(mover, T) = mergeOp lbl mover (T/mover) ∘ mergeOpUnit mover
+  IM(mover, T) = mergeOp lbl mover (T/mover) ∘ mergeOpUnit mover,
 
-where the first stage `mergeOpUnit mover` selects the Δ^ρ cut on `T` whose crown
-forest equals `{mover}` (yielding `mover ⊗ (T/mover)`), and the second stage
-performs External Merge between mover and the deletion-quotient.
+where the first stage `mergeOpUnit mover` selects the Δ^ρ cut on `T` whose crown forest is
+`{mover}`, yielding `mover ⊗ (T/mover)`, and the second stage is External Merge of the mover with
+the deletion quotient. The unit stage `M_{β,1}` is a bookkeeping device that factors Internal
+Merge as a composition, not a stand-alone Merge. The carrier-level form on `SyntacticObject` is
+`SyntacticObject.intMerge_toForest` in `Merge/SyntacticObject.lean`.
 
-## Contents
+## Main results
 
-- `mergeOpUnit_apply_singleton{,_unique}`: per-cut decomposition of the unit-mover
-  stage `mergeOpUnit β`. Surviving contributions are exactly the `cutSummandsN T`
-  summands `p` with `p.1 = {β}`. Under uniqueness (the filtered sub-multiset is the
-  singleton `{p0}`), the sum collapses.
-- `mergeOp_im_composition`, `mergeOp_im_composition_moverLeft`: the IM composition
-  theorem. Under the unique-cut hypothesis, the two-stage pipeline reduces to EM
-  Case 1 (`mergeOp_pair`).
-- `mergeOp_im_matches_Step`: bridge to linguistic `Step.im` via
-  `((Step.im mover traceId).apply current).toNonplanar`.
+* `Minimalist.Merge.mergeOpUnit_apply_singleton`, `mergeOpUnit_apply_singleton_unique`: the
+  per-cut decomposition of the unit stage; only cuts with crown `{β}` contribute, and when that
+  cut is unique the sum collapses.
+* `Minimalist.Merge.mergeOp_im_composition`, `mergeOp_im_composition_moverLeft`: under the
+  unique-cut hypothesis the two-stage pipeline reduces to `mergeOp_pair`.
 
-## Deferred (substrate gap)
+## References
 
-§4 — IM cost-survival at ε = 0 (`mergeOp_eps_zero_im_*`, MCB Prop 1.5.1 bullet 3)
-— rides the same ε-weighted Δ^ρ gap as `External`'s ε arc (no `cutTotalDepth` on
-`cutSummandsN`). Queued behind that substrate.
-
-**Caveat (M-C-B p. 52 "virtual particles"):** the `mergeOpUnit` stage M_{β,1} is
-virtual — not a stand-alone Merge in M-C-B's formalism. It is introduced as a
-bookkeeping device to factor IM as composition; the linguistic Merge is the full
-IM, not the unit stage on its own.
+* [marcolli-chomsky-berwick-2025], §1.4 (Proposition 1.4.2)
 -/
 
 namespace Minimalist.Merge
@@ -155,12 +144,5 @@ theorem mergeOp_im_composition
       show ({β} : Forest (Nonplanar α)) + {Q} = ({Q, β} : Forest (Nonplanar α))
         from add_comm _ _]
   exact mergeOp_pair lbl Q β
-
-/-! The linguistic Internal-Merge bridge `mergeOp_im_matches_Step` (which related the
-`mergeOp ∘ mergeOpUnit` composition on the head-decorated `toNonplanar` projection to
-the legacy `Step.im` + `⊕ Nat` trace index) has been retired by the single-carrier
-migration. On the bare `SyntacticObject` carrier the bridge is `Workspace.lean`'s
-`SyntacticObject.intMerge_toForest` (`mergeOp_im_composition` with the bare `Sum.inr ()` label and
-the index-free `SyntacticObject.traceLeaf`). -/
 
 end Minimalist.Merge

--- a/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
@@ -1,35 +1,31 @@
 import Linglib.Syntax.Minimalist.Merge.Basic
-import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Linglib.Syntax.Minimalist.Workspace.Conservation
 
 /-!
-# Minimal Search: the generic (cut-policy-parameterized) Merge operator
-[marcolli-chomsky-berwick-2025]
+# Minimal Search as a weighting of Merge
 
-MCB's Merge variants and the three coproducts (Δ^ρ/Δ^c/Δ^d) share one operator
-shape `M = ⊔ ∘ (B ⊗ id) ∘ δ_{S,S'} ∘ Δ`, differing only in the coproduct `Δ`.
-`mergeOpG cuts` parameterizes the operator over the cut enumeration (via
-`comulAlgHomNG`), recovering the Δ^ρ `mergeOp` as the instance
-`cuts := cutSummandsN` (definitional) and defining the Δ^c Merge `mergeOpC τ` as
-`cuts := cutSummandsCN τ`. This is the operator-level companion to the
-already-generic cut layer (`cutSummandsG`).
-
-The Δ^c instance is the home of the **Minimal-Search ε arc** (MCB §1.5,
-Prop 1.5.1): the trace coproduct is where extraction depth is recoverable
-(`Nonplanar.Cut.depthC`), so the ε-weighted graft and the ε → 0
-Sideward-elimination belong on `mergeOpC`, not the Δ^ρ `mergeOp`.
+The ε-weighted Merge `M^ε = ⊔ ∘ (Bᵉ ⊗ id) ∘ δ ∘ Δ` scales the graft by `ε^c`, where `c` is the
+Minimal-Search cost of the merge. Since `mergePost` is linear and the graft is its only creation,
+this is the Δ^c Merge `mergeOpC` scaled by `epsWeight ε c`. The net cost is the signed sum of the
+operands' depth-costs (`Cut.extractionCost`, `Cut.quotientCost`): External Merge costs `0`;
+Internal Merge's extraction `+d` and its own quotient's `−d` cancel; Sideward Merge's extraction
+is uncancelled, so `c = d > 0`. At `ε = 0` External and Internal Merge survive and Sideward Merge
+is annihilated.
 
 ## Main definitions
 
-* `mergeOpG cuts lbl S S'` — the generic Merge operator.
-* `mergeOp_eq_G` — the Δ^ρ `mergeOp` is `mergeOpG cutSummandsN` (definitional).
-* `mergeOpC τ lbl S S'` — the Δ^c Merge operator.
-* `epsWeight`, `emNetCost`/`imNetCost`/`swNetCost` — the Minimal-Search ε-weight
-  and the per-merge net costs (EM/IM = 0, Sideward > 0).
-* `mergeOpCEps τ ε c` — the ε-weighted Δ^c Merge (`ε^c • mergeOpC`).
-* `mergeOpCEps_zero_em`, `mergeOpCEps_zero_im`, `mergeOpCEps_zero_sideward` —
-  **MCB Proposition 1.5.1**: at ε → 0, External and Internal Merge survive
-  (`1 • M = M`), Sideward Merge vanishes (`0 • M = 0`).
+* `Minimalist.Merge.epsWeight`: the weight `ε^c`.
+* `Minimalist.Merge.emNetCost`, `imNetCost`, `swNetCost`: the per-case net costs.
+* `Minimalist.Merge.mergeOpCEps`: the ε-weighted Δ^c Merge.
+
+## Main results
+
+* `Minimalist.Merge.mergeOpCEps_zero_em`, `mergeOpCEps_zero_im`, `mergeOpCEps_zero_sideward`: the
+  ε → 0 limit keeps External and Internal Merge and kills Sideward Merge.
+
+## References
+
+* [marcolli-chomsky-berwick-2025], §1.5 (Proposition 1.5.1)
 -/
 
 namespace Minimalist.Merge
@@ -37,51 +33,9 @@ namespace Minimalist.Merge
 open scoped TensorProduct
 open RoseTree RoseTree.Nonplanar ConnesKreimer
 
-variable {R : Type*} [CommSemiring R] {α : Type*}
+variable {R : Type*} [CommSemiring R] {α β : Type*}
 
-/-- The **generic Merge operator** `M_{S,S'}^{cuts}`, parameterized by the cut
-    enumeration `cuts`: `mergePost lbl S S' ∘ comulAlgHomNG cuts`. The
-    coproduct-agnostic post-chain `mergePost` (graft `B`, δ-projection, and
-    multiplication `⊔`) is shared; only the coproduct `comulAlgHomNG cuts`
-    varies. -/
-noncomputable def mergeOpG [DecidableEq (Nonplanar α)]
-    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
-    (lbl : α) (S S' : Nonplanar α) :
-    ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  mergePost (R := R) (α := α) lbl S S' ∘ₗ (comulAlgHomNG cuts).toLinearMap
-
-/-- The Δ^ρ Merge operator `mergeOp` is the generic operator at
-    `cuts := cutSummandsN` — definitional, since `comulAlgHomN = comulAlgHomNG
-    cutSummandsN`. -/
-theorem mergeOp_eq_G [DecidableEq (Nonplanar α)] (lbl : α) (S S' : Nonplanar α) :
-    mergeOp (R := R) lbl S S' = mergeOpG (R := R) cutSummandsN lbl S S' := rfl
-
-/-- The **Δ^c (trace) Merge operator** `mergeOpC τ`, the generic operator at
-    `cuts := cutSummandsCN τ`. Unlike the Δ^ρ `mergeOp`, this coproduct's
-    quotients carry a trace leaf at each cut site at exactly the cut depth, so
-    the Minimal-Search cost `Cut.depthC` is recoverable — making `mergeOpC` the
-    faithful home of MCB's ε-weighted Merge (§1.5). -/
-noncomputable def mergeOpC {β : Type*} [DecidableEq (Nonplanar (α ⊕ β))]
-    (τ : Nonplanar (α ⊕ β) → β) (lbl : α ⊕ β) (S S' : Nonplanar (α ⊕ β)) :
-    ConnesKreimer R (Nonplanar (α ⊕ β)) →ₗ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  mergeOpG (R := R) (cutSummandsCN τ) lbl S S'
-
-/-! ## The Minimal-Search ε arc (MCB §1.5, Prop 1.5.1)
-
-The ε-weighted Merge `M^ε = ⊔ ∘ (Bᵉ ⊗ id) ∘ δ ∘ Δ` (eq 1.5.1) scales the graft
-`Bᵉ(α⊔β) = ε^{c(𝔐(α,β))} B(α⊔β)` (eq 1.5.2) by the Minimal-Search cost `ε^c`.
-Since `mergePost` is linear and the graft is its only creation, scaling the
-graft by `ε^c` equals scaling the whole operator: `mergeOpCEps = ε^c • mergeOpC`.
-The net cost `c` is the sum of the two operands' signed depth-costs (MCB rules
-1–2, `Nonplanar.Cut.extractionCost`/`quotientCost`):
-
-* **EM** `𝔐(T_i, T_j)`: both whole, `c = 0`.
-* **IM** `𝔐(T_v, T_i/T_v)`: extracted crown `+d` and its own quotient `−d`
-  cancel, `c = 0`.
-* **Sideward** `𝔐(T_v, T')`: the crown's `+d` is uncancelled (no quotient
-  operand), `c = d > 0`.
-
-At ε → 0, `ε^0 = 1` keeps EM/IM, `ε^{d>0} = 0` drops Sideward. -/
+/-! ### The weight -/
 
 /-- The **Minimal-Search ε-weight** of a merge with net cost `c`: `ε^c`
     (MCB eq 1.5.2). -/
@@ -94,14 +48,7 @@ theorem epsWeight_zero_of_pos {c : ℕ} (hc : 0 < c) : epsWeight (0 : R) c = 0 :
 
 @[simp] theorem epsWeight_one (c : ℕ) : epsWeight (1 : R) c = 1 := one_pow c
 
-end Minimalist.Merge
-
-namespace Minimalist.Merge
-
-open scoped TensorProduct
-open RoseTree RoseTree.Nonplanar ConnesKreimer
-
-variable {R : Type*} [CommSemiring R] {α β : Type*}
+/-! ### Net costs and the weighted operator -/
 
 /-- **External Merge net cost** (MCB rule 4, whole operands): `0`. -/
 def emNetCost : ℕ := 0

--- a/Linglib/Syntax/Minimalist/Merge/Sideward.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Sideward.lean
@@ -1,8 +1,7 @@
 import Linglib.Syntax.Minimalist.Merge.External
 
 /-!
-# Sideward Merge: realization on the canonical carrier
-[marcolli-chomsky-berwick-2025]
+# Sideward Merge on the algebraic carrier
 
 Realizes M-C-B Lemmas 1.4.4 + 1.4.5 (book pp. 54-55) for the three
 Sideward-flavored cases of §1.4.1 on the canonical carrier
@@ -32,13 +31,9 @@ For each case 2b, 3a, 3b:
   `Fhat` via `mergeOp_factor_out_singleton` (from `Merge.External`),
   under `CutAvoidingForest`.
 
-## Deferred (substrate gap)
+## References
 
-The §1.5 cost-suppression theorems (`mergeOp_eps_zero_for_sideward_*`,
-showing Sideward configurations vanish in the ε → 0 Minimal-Search limit)
-ride the same ε-weighted Δ^ρ gap as `External`/`Internal`'s ε arc: there
-is no `cutTotalDepth` analogue on `cutSummandsN` yet. They are queued
-behind that substrate and omitted here.
+* [marcolli-chomsky-berwick-2025], §1.4 (Lemmas 1.4.4, 1.4.5)
 -/
 
 namespace Minimalist.Merge
@@ -49,15 +44,13 @@ open RoseTree RoseTree.Nonplanar ConnesKreimer
 /-! ### Matching-cut multisets -/
 
 /-- Cut summands of `T` whose crown forest is the singleton `{β}` (single
-    accessible-term extraction). The `cutSummandsN` analogue of legacy
-    `matchingSingleEdgeCuts`. -/
+    accessible-term extraction). -/
 noncomputable def matchingSingleEdgeCutsN {α : Type*} [DecidableEq (Nonplanar α)]
     (T β : Nonplanar α) : Multiset (Forest (Nonplanar α) × Nonplanar α) :=
   (cutSummandsN T).filter (fun p => p.1 = ({β} : Forest (Nonplanar α)))
 
 /-- Cut summands of `T` whose crown forest is `{α_t, β}` (two accessible
-    terms, case 3(a)). The `cutSummandsN` analogue of legacy
-    `matchingTwoEdgeCuts`. -/
+    terms, case 3(a)). -/
 noncomputable def matchingTwoEdgeCutsN {α : Type*} [DecidableEq (Nonplanar α)]
     (T α_t β : Nonplanar α) : Multiset (Forest (Nonplanar α) × Nonplanar α) :=
   (cutSummandsN T).filter (fun p => p.1 = ({α_t, β} : Forest (Nonplanar α)))
@@ -522,9 +515,10 @@ theorem mergeOp_sideward_3b {R : Type*} [CommSemiring R]
                   = ({T} : Forest (Nonplanar α))
                     + (({T_i, T_j} : Forest (Nonplanar α)) + Fhat') := by
       rw [show T ::ₘ Fhat' = ({T} : Forest (Nonplanar α)) + Fhat' from rfl]; abel
-    have h_rhs_eq : ({Nonplanar.node lbl {α_t, β}, T_i_q, T_j_q} : Forest (Nonplanar α)) + T ::ₘ Fhat'
-                  = ({T} : Forest (Nonplanar α))
-                    + (({Nonplanar.node lbl {α_t, β}, T_i_q, T_j_q} : Forest (Nonplanar α)) + Fhat') := by
+    have h_rhs_eq :
+        ({Nonplanar.node lbl {α_t, β}, T_i_q, T_j_q} : Forest (Nonplanar α)) + T ::ₘ Fhat'
+          = ({T} : Forest (Nonplanar α))
+            + (({Nonplanar.node lbl {α_t, β}, T_i_q, T_j_q} : Forest (Nonplanar α)) + Fhat') := by
       rw [show T ::ₘ Fhat' = ({T} : Forest (Nonplanar α)) + Fhat' from rfl]; abel
     rw [h_lhs_eq, h_rhs_eq, of'_add (R := R) ({T} : Forest (Nonplanar α)) _,
         of'_add (R := R) ({T} : Forest (Nonplanar α)) _,

--- a/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
+++ b/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Merge.Internal
+import Linglib.Syntax.Minimalist.Workspace.Basic
+
+/-!
+# Merge on the syntactic-object carrier
+
+The carrier operations `SyntacticObject.merge` and `SyntacticObject.intMerge` of
+`SyntacticObject/Build.lean` build a bare binary node with root label `Sum.inr ()`. This file
+identifies them with the algebraic Merge operator of `Merge/Basic.lean` on workspaces lifted along
+`of'`: External Merge of two objects is `mergeOp_pair`, and Internal Merge is the two-stage
+composition `mergeOp_im_composition`, given the unique Δ^ρ cut extracting the mover.
+
+## Main results
+
+* `Minimalist.SyntacticObject.merge_toForest`: External Merge on the carrier is `mergeOp`.
+* `Minimalist.SyntacticObject.intMerge_toForest`: Internal Merge on the carrier is
+  `mergeOp ∘ mergeOpUnit`.
+
+## References
+
+* [marcolli-chomsky-berwick-2025], §1.4 (Lemma 1.4.1, Proposition 1.4.2)
+-/
+
+namespace Minimalist.SyntacticObject
+
+open RoseTree RoseTree.Nonplanar ConnesKreimer
+
+/-- External Merge on the carrier is the algebraic Merge with the bare root label on the
+    two-object workspace. -/
+theorem merge_toForest (S S' : SyntacticObject) :
+    Merge.mergeOp (R := ℤ) (Sum.inr ()) S.val S'.val
+        (of' ({S.val, S'.val} : Forest (Nonplanar SOLabel)))
+      = of' (R := ℤ) ({(merge S S').val} : Forest (Nonplanar SOLabel)) := by
+  rw [Merge.mergeOp_pair, merge_val]
+
+/-- Internal Merge on the carrier is the two-stage algebraic Merge, given the unique Δ^ρ cut `p0`
+    of `T` extracting `mover` with remainder `remainder`. -/
+theorem intMerge_toForest (mover remainder T : SyntacticObject)
+    (p0 : Forest (Nonplanar SOLabel) × Nonplanar SOLabel)
+    (h_filter : (cutSummandsN T.val).filter
+        (fun p => p.1 = ({mover.val} : Forest (Nonplanar SOLabel))) = {p0})
+    (h_remainder : p0.2 = remainder.val)
+    (hT : T.val ≠ mover.val) :
+    Merge.mergeOp (R := ℤ) (Sum.inr ()) remainder.val mover.val
+        (Merge.mergeOpUnit (R := ℤ) mover.val
+          (of' ({T.val} : Forest (Nonplanar SOLabel))))
+      = of' (R := ℤ)
+          ({(intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
+  rw [Merge.mergeOp_im_composition (Sum.inr ()) mover.val T.val remainder.val
+        p0 h_filter h_remainder hT, intMerge_val]
+
+end Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -180,5 +180,17 @@ example : (lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by de
 example : demoVP.leafCount = 2 ∧ demoVP.nodeCount = 1 := by decide
 /-- The trace leaf is recognized; a lexical leaf is not a trace. -/
 example : isTrace traceLeaf ∧ ¬ isTrace (lexLeaf (mkTraceToken 0)) := by decide
+/-- A bare binary node over a lexical leaf and a bare trace, the shape of an Internal-Merge
+    result, is a syntactic object. -/
+example :
+    IsSO (Nonplanar.mk (.node (Sum.inr ())
+      [.leaf (Sum.inl (mkTraceToken 0)), .leaf (Sum.inr ())])) := by decide
+/-- A lexical item with children is rejected: lexical items are leaves. -/
+example :
+    ¬ IsSO (Nonplanar.mk (.node (Sum.inl (mkTraceToken 0)) [.leaf (Sum.inr ())])) := by decide
+/-- A ternary bare node is rejected: syntactic objects are binary. -/
+example :
+    ¬ IsSO (Nonplanar.mk (.node (Sum.inr ())
+      [.leaf (Sum.inr ()), .leaf (Sum.inr ()), .leaf (Sum.inr ())])) := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Workspace/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Basic.lean
@@ -3,145 +3,40 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Syntax.Minimalist.SyntacticObject.Build
-import Linglib.Syntax.Minimalist.Merge.Internal
 
 /-!
-# Workspaces and Merge over syntactic objects
+# Workspaces
 
-[marcolli-chomsky-berwick-2025] §1.2–1.4. The single-carrier program's P1b: the
-**Merge and workspace layer over the `SyntacticObject` syntactic objects** (`SyntacticObject.lean`).
-This is additive — it does *not* touch the legacy `SyntacticObject`/`Step`/`Derivation`
-(`FreeCommMagma (LIToken ⊕ Nat)`); completing the `SyntacticObject` flip and retiring
-the `⊕ Nat` index is P2.
+A workspace is a forest, a finite multiset, of syntactic objects. The forest product is disjoint
+union with unit the empty forest, so a workspace is exactly what `of'` lifts into the Hopf algebra
+`ConnesKreimer ℤ (Nonplanar SOLabel)`. A moved element occupies repeated isomorphic components,
+and the number of copies is the chain's multiplicity (`Workspace.chainMultiplicity`): chain
+identity lives at the workspace level, with no index on the trace leaf. Merge on workspaces and
+its identity with the algebraic Merge operator are in `Merge/SyntacticObject.lean`.
 
-## What this file connects
+## Main definitions
 
-The Merge **algebra** already lives on `ConnesKreimer ℤ (Nonplanar α)` (the #424
-work, `Merge/External.lean` + `Merge/Internal.lean`): `mergeOp_pair` realizes
-External Merge (Lemma 1.4.1) and `mergeOp_im_composition` realizes Internal Merge
-as a two-stage composition (Prop 1.4.2). This file gives the **syntactic surface**
-on the carrier — workspaces, the bare-binary-node Merge primitive, the index-free
-trace leaf — and relates each to the algebra by theorem.
+* `Minimalist.Workspace`: forests of syntactic objects.
+* `Minimalist.Workspace.chainMultiplicity`: the multiplicity of a syntactic object in a workspace.
 
-## Bare internals, index-free traces (§1.1.3.1, §1.15, Def 1.2.1)
+## References
 
-The carrier puts **bare `Sum.inr ()`** on internal nodes (the head comes from the
-separate §1.15 head function, not the object) and on **trace leaves** (a moved
-element leaves a bare vertex; chain identity is read at the workspace level, MCB
-Def 1.2.1, not from a per-leaf index). So External and Internal Merge here both
-build a bare binary node — distinct from the legacy head-decorated `toNonplanar`
-bridges (`mergeOp_emR_matches_Step`, which graft `Sum.inl L`); those are the head
-function *applied*, and P3/P4 retire them.
-
-## Computability discipline
-
-`Nonplanar.node`, `mergeOp`, and the coproduct are `noncomputable` (the Hopf
-machinery round-trips through `Quotient.out`). So `SyntacticObject.merge`/`SyntacticObject.intMerge`
-are
-`noncomputable`, and studies must **state result trees directly** (built computably
-via `Nonplanar.mk ∘ RoseTree.node`, then `decide` on `IsSO`) and relate them to Merge
-by theorem — never compute Merge under `decide`. `merge_mk` is the construction
-bridge; the `#eval`-free `decide` examples at the end confirm the discipline holds
-on this carrier (the P1 spike, now as carrier tests).
+* [marcolli-chomsky-berwick-2025], §1.2 (Definition 1.2.1)
 -/
 
 namespace Minimalist
 
-open RoseTree RoseTree.Nonplanar ConnesKreimer SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
-/-! ### Workspaces (MCB Def 1.2.1)
-
-The carrier Merge operators `SyntacticObject.merge` (Lemma 1.4.1) and `SyntacticObject.intMerge`
-(Prop 1.4.2) are
-defined in `SyntacticObject/Build.lean` (they need only the bare binary node); this file
-adds their **coproduct identity** on the workspace Hopf algebra. -/
-
-/-- A **workspace** is a forest (finite multiset) of syntactic objects
-    ([marcolli-chomsky-berwick-2025] Def 1.2.1). The forest **product is disjoint
-    union** (`+` on `Multiset`), with unit the empty forest (`0`); a *well-formed*
-    workspace is nonempty. `Forest` is the algebra's forest type, so a workspace is
-    exactly what `of'` lifts into `ConnesKreimer ℤ (Nonplanar SOLabel)`. -/
+/-- A workspace is a forest of syntactic objects. -/
 abbrev Workspace : Type := Forest SyntacticObject
 
-/-- A moved element occupies **repeated isomorphic components** of the workspace; the
-    number of copies is their multiplicity ([marcolli-chomsky-berwick-2025]
-    Def 1.2.1: "those isomorphism classes are the chain"). Decidable now that the
-    carrier has `DecidableEq SyntacticObject` (#792) — this is the workspace-level chain identity
-    that **replaces the legacy `⊕ Nat` trace index**. -/
+/-- `chainMultiplicity S W = W.count S`, the number of isomorphic copies of `S` in `W`. -/
 def Workspace.chainMultiplicity (S : SyntacticObject) (W : Workspace) : Nat := W.count S
 
-namespace SyntacticObject
-
-/-! ### External Merge: bridge to the algebra (Lemma 1.4.1) -/
-
-/-- **External Merge ↔ algebra** ([marcolli-chomsky-berwick-2025] Lemma 1.4.1,
-    F̂ = ∅). The algebraic Merge `mergeOp (Sum.inr ())` on the 2-object workspace
-    `{S, S'}` yields the singleton workspace of the carrier Merge `SyntacticObject.merge S S'`.
-    The root label is the **bare** `Sum.inr ()` — the faithful departure from the
-    head-decorated legacy bridge. -/
-theorem merge_toForest (S S' : SyntacticObject) :
-    Merge.mergeOp (R := ℤ) (Sum.inr ()) S.val S'.val
-        (of' ({S.val, S'.val} : Forest (Nonplanar SOLabel)))
-      = of' (R := ℤ) ({(merge S S').val} : Forest (Nonplanar SOLabel)) := by
-  rw [Merge.mergeOp_pair, merge_val]
-
-/-! ### Internal Merge as composition (MCB Prop 1.4.2) -/
-
-/-- **Internal Merge ↔ algebra** ([marcolli-chomsky-berwick-2025] Prop 1.4.2). Given
-    the Δ^ρ cut data on `T` extracting `mover` with remainder `remainder` (the unique
-    crown-`{mover}` summand `p0`, `p0.2 = remainder.val`, `T ≠ mover`), the two-stage
-    composition `mergeOp (inr ()) ∘ mergeOpUnit mover` over `{T}` yields the singleton
-    workspace of `SyntacticObject.intMerge mover remainder`. This is `mergeOp_im_composition`
-    transported to the carrier with the `IsSO`-carrying result. -/
-theorem intMerge_toForest (mover remainder T : SyntacticObject)
-    (p0 : Forest (Nonplanar SOLabel) × Nonplanar SOLabel)
-    (h_filter : (cutSummandsN T.val).filter
-        (fun p => p.1 = ({mover.val} : Forest (Nonplanar SOLabel))) = {p0})
-    (h_remainder : p0.2 = remainder.val)
-    (hT : T.val ≠ mover.val) :
-    Merge.mergeOp (R := ℤ) (Sum.inr ()) remainder.val mover.val
-        (Merge.mergeOpUnit (R := ℤ) mover.val
-          (of' ({T.val} : Forest (Nonplanar SOLabel))))
-      = of' (R := ℤ)
-          ({(intMerge mover remainder).val} : Forest (Nonplanar SOLabel)) := by
-  rw [Merge.mergeOp_im_composition (Sum.inr ()) mover.val T.val remainder.val
-        p0 h_filter h_remainder hT, intMerge_val]
-
-end SyntacticObject
-
-/-! ### `decide` demonstrations (the P1 computability spike, as carrier tests)
-
-Confirms: trace/lexical leaves are well-formed; an IM-result-shaped tree — a bare
-binary node over a lexical leaf and a bare trace leaf — built directly via planar
-`.node` is `IsSO` and `decide`-able even though the Merge *operator* is
-noncomputable; ill-formed shapes are rejected. -/
-
-private def demoTok : LIToken := mkTraceToken 0
-
-/-- A lexical leaf is well-formed. -/
-example : IsSO (lexLeaf demoTok).val := by decide
-
-/-- The bare trace leaf is well-formed. -/
-example : IsSO traceLeaf.val := by decide
-
-/-- An IM-result-shaped tree — bare binary node over a lexical leaf and a bare
-    trace — is well-formed (built directly, no Merge operator). -/
-example :
-    IsSO (Nonplanar.mk (.node (Sum.inr ())
-      [.leaf (Sum.inl demoTok), .leaf (Sum.inr ())])) := by decide
-
-/-- A lexical item with children is **rejected** (lexical items are leaves). -/
-example :
-    ¬ IsSO (Nonplanar.mk (.node (Sum.inl demoTok)
-      [.leaf (Sum.inr ())])) := by decide
-
-/-- A ternary bare node is **rejected** (syntactic objects are binary). -/
-example :
-    ¬ IsSO (Nonplanar.mk (.node (Sum.inr ())
-      [.leaf (Sum.inr ()), .leaf (Sum.inr ()), .leaf (Sum.inr ())])) := by decide
-
-/-- Workspace chain identity is decidable: two isomorphic components ⇒ chain of 2. -/
+/-- Two isomorphic components form a chain of two. -/
 example : Workspace.chainMultiplicity SyntacticObject.traceLeaf
     {SyntacticObject.traceLeaf, SyntacticObject.traceLeaf} = 2 := by decide
 


### PR DESCRIPTION
First of three cuts toward `Workspace < Merge < Economy`.

- The generic operator `mergeOpG` and its Δ^c instance join `Merge/Basic.lean`; `MinimalSearch.lean` keeps only the ε-weighting.
- Merge over the syntactic-object carrier moves from `Workspace/Basic.lean` to `Merge/SyntacticObject.lean`, so `Workspace/` no longer imports `Merge/`; the carrier `decide` tests join `SyntacticObject/Build.lean`.
- `External`, `Internal`, `Sideward` retitled as the cases they are; roadmap narration and references to retired theorems removed.