### PR TITLE
refactor(Studies/GahlBaayen2024): work the toy lexicon through training

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -137,6 +137,7 @@ import Linglib.Core.InformationTheory.MutualInformation
 import Linglib.Core.Learning.Luce
 import Linglib.Core.Learning.RescorlaWagner
 import Linglib.Core.Learning.WidrowHoff
+import Linglib.Core.LinearAlgebra.Matrix.Symmetric
 import Linglib.Core.LinearAlgebra.SymmetricAlgebra.Derivation
 import Linglib.Core.LinearAlgebra.SymmetricPower.Lift
 import Linglib.Core.LinearAlgebra.SymmetricPower.ToSymmetricAlgebra

--- a/Linglib/Core/LinearAlgebra/Matrix/Symmetric.lean
+++ b/Linglib/Core/LinearAlgebra/Matrix/Symmetric.lean
@@ -1,0 +1,39 @@
+import Mathlib.LinearAlgebra.Matrix.Symmetric
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Tactic.Linarith
+
+/-!
+# Diagonals of symmetric idempotent matrices
+
+A symmetric idempotent matrix `P` — an orthogonal projector — satisfies `P = PᵀP`, so each
+diagonal entry is a sum of squares, `P i i = ∑ j, P i j ^ 2`, and over an ordered ring lies in
+`[0, 1]`.
+
+`[UPSTREAM]` candidate.
+-/
+
+namespace Matrix
+
+variable {n R : Type*} [Fintype n]
+
+theorem diag_eq_sum_sq_of_isSymm_of_isIdempotentElem [CommSemiring R] {P : Matrix n n R}
+    (hs : P.IsSymm) (hp : IsIdempotentElem P) (i : n) : P i i = ∑ j, P i j ^ 2 := by
+  conv_lhs => rw [← hp.eq]
+  simp only [mul_apply, sq]
+  exact Finset.sum_congr rfl fun j _ => by rw [hs.apply i j]
+
+variable [CommRing R] [LinearOrder R] [IsStrictOrderedRing R] {P : Matrix n n R}
+
+theorem diag_nonneg_of_isSymm_of_isIdempotentElem (hs : P.IsSymm) (hp : IsIdempotentElem P)
+    (i : n) : 0 ≤ P i i := by
+  rw [diag_eq_sum_sq_of_isSymm_of_isIdempotentElem hs hp i]
+  exact Finset.sum_nonneg fun j _ => sq_nonneg _
+
+theorem diag_le_one_of_isSymm_of_isIdempotentElem (hs : P.IsSymm) (hp : IsIdempotentElem P)
+    (i : n) : P i i ≤ 1 := by
+  have h : P i i ^ 2 ≤ P i i := by
+    conv_rhs => rw [diag_eq_sum_sq_of_isSymm_of_isIdempotentElem hs hp i]
+    exact Finset.single_le_sum (fun j _ => sq_nonneg (P i j)) (Finset.mem_univ i)
+  nlinarith [sq_nonneg (P i i - 1)]
+
+end Matrix

--- a/Linglib/Processing/Lexical/Discriminative/Measures.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Measures.lean
@@ -1,90 +1,93 @@
 import Linglib.Processing.Lexical.Discriminative.Defs
+import Mathlib.Data.Matrix.Mul
 
 /-!
 # DLM-derived semantic-support measures
-[baayen-2019] [gahl-baayen-2024] [saito-tomaschek-baayen-2025]
-[heitmeier-chuang-baayen-2026]
 
-The *semantic support* measures projected from a
-`LinearDiscriminativeLexicon`'s production map, specialised to the
-`FormVec`/`MeaningVec` carriers.
+The *semantic support* measures read off a `LinearDiscriminativeLexicon`'s production map at
+the `FormVec`/`MeaningVec` carriers. The support a form receives from a meaning is the dot
+product of the predicted form with the target form, `ĉ ⬝ᵥ c` for `ĉ = sG`: the entries of
+[gahl-baayen-2024]'s support matrix `T = ĈCᵀ`, whose diagonal is their *semantic support for
+form*, and at a single triphone [saito-tomaschek-baayen-2025]'s `SemSupSuffix`.
 
 ## Main declarations
 
-- `semSup D s j`: semantic support for form coordinate `j` from meaning `s`.
-- `semSupWord D s js`: sum of `semSup` over a word's form coordinates —
-  [gahl-baayen-2024]'s *Semantic Support for Form*,
-  [saito-tomaschek-baayen-2025]'s `SemSupWord`.
-- `semSup_add` / `semSup_smul` / `semSup_zero`: `@[simp]` linearity lemmas
-  in the meaning argument.
+- `semSup D s j`: support for form coordinate `j` from meaning `s`, the predicted value
+  `D.production s j`.
+- `semSupWord D s c`: support for the form vector `c` from meaning `s`, `D.production s ⬝ᵥ c`;
+  `semSup` is its value at a coordinate indicator (`semSupWord_single`).
+- `semSup_add`, `semSup_smul`, `semSupWord_add_left`, `semSupWord_smul_right`, …: `@[simp]`
+  linearity in each argument.
+
+## References
+
+* [R. H. Baayen, Y.-Y. Chuang, E. Shafaei-Bajestan and J. P. Blevins, *The discriminative
+  lexicon* (2019)][baayen-2019]
+* [S. Gahl and R. H. Baayen, *Time and thyme again* (2024)][gahl-baayen-2024]
+* [M. Saito, F. Tomaschek and R. H. Baayen, *Interaction of frequency and inflectional status*
+  (2025)][saito-tomaschek-baayen-2025]
+* [M. Heitmeier, Y.-Y. Chuang and R. H. Baayen, *The Discriminative Lexicon*
+  (2026)][heitmeier-chuang-baayen-2026]
 -/
 
 namespace Processing.Lexical.Discriminative
 
-noncomputable section SemSupMeasures
+noncomputable section
 
-variable {n d : ℕ}
+variable {n d : ℕ} (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
 
-/-! ### Semantic support — coordinate projection of production -/
+/-! ### Semantic support -/
 
-/-- **Semantic support** for form coordinate `j` from meaning vector `s`:
-    the named binding for `D.production s j` ([saito-tomaschek-baayen-2025];
-    [gahl-baayen-2024]'s per-triphone support). -/
-def semSup (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (s : MeaningVec d) (j : Fin n) : ℝ :=
-  D.production s j
+/-- **Semantic support** for form coordinate `j` from meaning `s`: the predicted value
+`D.production s j` ([saito-tomaschek-baayen-2025]; [gahl-baayen-2024]'s per-triphone support). -/
+def semSup (s : MeaningVec d) (j : Fin n) : ℝ := D.production s j
 
-/-- **Word-level semantic support** — the sum of `semSup` over a word's
-    component form coordinates ([gahl-baayen-2024]'s *Semantic Support for
-    Form*; [saito-tomaschek-baayen-2025]'s `SemSupWord`). -/
-def semSupWord (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (s : MeaningVec d) (js : List (Fin n)) : ℝ :=
-  (js.map (semSup D s)).sum
+/-- **Semantic support** for the form vector `c` from meaning `s`: the dot product of the
+predicted form with `c`. At a word's own binary triphone vector this is [gahl-baayen-2024]'s
+*semantic support for form*, the diagonal of `T = ĈCᵀ`. -/
+def semSupWord (s : MeaningVec d) (c : FormVec n) : ℝ := D.production s ⬝ᵥ c
 
-/-! ### `semSup` is linear in the meaning vector
+variable {D}
 
-Since `D.production` is a `LinearMap`, `semSup D · j` is a linear
-functional on the meaning space. -/
+@[simp] theorem semSupWord_single (s : MeaningVec d) (j : Fin n) :
+    semSupWord D s (Pi.single j 1) = semSup D s j := by
+  simp [semSupWord, semSup]
 
-@[simp] theorem semSup_add
-    (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (s₁ s₂ : MeaningVec d) (j : Fin n) :
+/-! ### Linearity -/
+
+@[simp] theorem semSup_add (s₁ s₂ : MeaningVec d) (j : Fin n) :
     semSup D (s₁ + s₂) j = semSup D s₁ j + semSup D s₂ j := by
-  unfold semSup
-  rw [map_add]
-  rfl
+  simp [semSup]
 
-@[simp] theorem semSup_smul
-    (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (c : ℝ) (s : MeaningVec d) (j : Fin n) :
-    semSup D (c • s) j = c * semSup D s j := by
-  unfold semSup
-  rw [map_smul]
-  rfl
+@[simp] theorem semSup_smul (a : ℝ) (s : MeaningVec d) (j : Fin n) :
+    semSup D (a • s) j = a * semSup D s j := by
+  simp [semSup]
 
-@[simp] theorem semSup_zero
-    (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (j : Fin n) :
-    semSup D 0 j = 0 := by
-  unfold semSup
-  rw [map_zero]
-  rfl
+@[simp] theorem semSup_zero (j : Fin n) : semSup D 0 j = 0 := by
+  simp [semSup]
 
-/-! ### `semSupWord` zero case
+@[simp] theorem semSupWord_add_left (s₁ s₂ : MeaningVec d) (c : FormVec n) :
+    semSupWord D (s₁ + s₂) c = semSupWord D s₁ c + semSupWord D s₂ c := by
+  simp [semSupWord, add_dotProduct]
 
-The general `semSupWord_add` / `semSupWord_smul` linearity is deferred
-until a consumer needs it. -/
+@[simp] theorem semSupWord_smul_left (a : ℝ) (s : MeaningVec d) (c : FormVec n) :
+    semSupWord D (a • s) c = a * semSupWord D s c := by
+  simp [semSupWord, smul_dotProduct]
 
-@[simp] theorem semSupWord_zero
-    (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
-    (js : List (Fin n)) :
-    semSupWord D 0 js = 0 := by
-  induction js with
-  | nil => rfl
-  | cons j js ih =>
-    show semSup D 0 j + semSupWord D 0 js = 0
-    rw [semSup_zero, ih, zero_add]
+@[simp] theorem semSupWord_zero_left (c : FormVec n) : semSupWord D 0 c = 0 := by
+  simp [semSupWord]
 
-end SemSupMeasures
+@[simp] theorem semSupWord_add_right (s : MeaningVec d) (c₁ c₂ : FormVec n) :
+    semSupWord D s (c₁ + c₂) = semSupWord D s c₁ + semSupWord D s c₂ := by
+  simp [semSupWord, dotProduct_add]
+
+@[simp] theorem semSupWord_smul_right (a : ℝ) (s : MeaningVec d) (c : FormVec n) :
+    semSupWord D s (a • c) = a * semSupWord D s c := by
+  simp [semSupWord, dotProduct_smul]
+
+@[simp] theorem semSupWord_zero_right (s : MeaningVec d) : semSupWord D s 0 = 0 := by
+  simp [semSupWord]
+
+end
 
 end Processing.Lexical.Discriminative

--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -32,7 +32,8 @@ frequency-informed learning); the optimisation is fixed across theories.
   experience ([heitmeier-2024]'s FIL-EL equivalence, also
   [heitmeier-chuang-axen-baayen-2024]; invertibility-free).
 * `isERMSolution_iff_residualPairing_eq_zero`: the normal equations
-  `SᵀQ(SG − C) = 0` as an invertibility-free iff.
+  `SᵀQ(SG − C) = 0` as an invertibility-free iff; `isERMSolution_iff_forall_coord`
+  is their coordinate form, the finite check that certifies an explicit mapping.
 * `IsERMSolution.apply_eq_of_mem_span` / `exists_apply_ne`: fitted values are
   unique exactly on the span of experienced meanings.
 
@@ -420,6 +421,28 @@ theorem isERMSolution_iff_forall_column (hq : ∀ i, 0 ≤ q i) :
     refine Finset.sum_eq_zero fun j _ => ?_
     simpa using h j ((LinearMap.proj j).comp H)
 
+/-- Coordinate form of the normal equations `SᵀQ(SG − C) = 0`: `G` is an ERM solution iff at
+    every form coordinate `j` the `q`-weighted residual column is orthogonal to every meaning
+    coordinate `k`. -/
+theorem isERMSolution_iff_forall_coord (hq : ∀ i, 0 ≤ q i) :
+    IsERMSolution data q G ↔
+      ∀ (j : Fin n) (k : Fin d),
+        ∑ i, q i * ((G (data.meanings i) j - data.forms i j) * data.meanings i k) = 0 := by
+  rw [isERMSolution_iff_forall_column hq]
+  refine ⟨fun h j k => h j (LinearMap.proj k), fun h j w => ?_⟩
+  have hw : ∀ i, w (data.meanings i) =
+      ∑ k, data.meanings i k * w (fun j => if k = j then 1 else 0) :=
+    fun i => by rw [w.pi_apply_eq_sum_univ]; simp only [smul_eq_mul]
+  simp_rw [hw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  calc ∑ i, q i * ((G (data.meanings i) j - data.forms i j) *
+          (data.meanings i k * w (fun j => if k = j then 1 else 0)))
+      = (∑ i, q i * ((G (data.meanings i) j - data.forms i j) * data.meanings i k)) *
+          w (fun j => if k = j then 1 else 0) := by
+        rw [Finset.sum_mul]; exact Finset.sum_congr rfl fun i _ => by ring
+    _ = 0 := by rw [h j k, zero_mul]
+
 /-- Under positive weights the prediction energy is definite: it vanishes iff
     the predictions vanish on every training meaning. -/
 theorem predictionEnergy_eq_zero_iff (hq : ∀ i, 0 < q i)
@@ -597,21 +620,22 @@ theorem IsTrainedOn.semSup_eq_of_mem_span
   congrFun (IsERMSolution.apply_eq_of_mem_span hq hD hD' hs) j
 
 /-- *Semantic Support for Form* ([gahl-baayen-2024] appendix;
-    [heitmeier-chuang-baayen-2026]) — `semSupWord` over a word's cue
-    coordinates — equals the sum of the observed form values whenever each
-    coordinate is linearly decodable from the meanings. -/
+    [heitmeier-chuang-baayen-2026]) — `semSupWord` at a form vector — equals the observed
+    form's own support whenever each coordinate the form vector touches is linearly decodable
+    from the meanings. -/
 theorem IsTrainedOn.semSupWord_eq_of_decodable
-    (hD : D.IsTrainedOn data q) (hq : ∀ i, 0 < q i)
-    {js : List (Fin n)}
-    (hw : ∀ j ∈ js, ∃ w : MeaningVec d →ₗ[ℝ] ℝ,
+    (hD : D.IsTrainedOn data q) (hq : ∀ i, 0 < q i) {c : FormVec n}
+    (hw : ∀ j, c j ≠ 0 → ∃ w : MeaningVec d →ₗ[ℝ] ℝ,
       ∀ i, w (data.meanings i) = data.forms i j)
     (i : Fin m) :
-    semSupWord D (data.meanings i) js = (js.map fun j => data.forms i j).sum := by
-  unfold semSupWord
-  congr 1
-  refine List.map_congr_left fun j hj => ?_
-  obtain ⟨w, hwj⟩ := hw j hj
-  exact hD.semSup_eq_of_decodable hq hwj i
+    semSupWord D (data.meanings i) c = data.forms i ⬝ᵥ c := by
+  unfold semSupWord dotProduct
+  refine Finset.sum_congr rfl fun j _ => ?_
+  by_cases hc : c j = 0
+  · simp [hc]
+  · obtain ⟨w, hwj⟩ := hw j hc
+    rw [show D.production (data.meanings i) j = semSup D (data.meanings i) j from rfl,
+      hD.semSup_eq_of_decodable hq hwj i]
 
 end LinearDiscriminativeLexicon
 

--- a/Linglib/Studies/GahlBaayen2024.lean
+++ b/Linglib/Studies/GahlBaayen2024.lean
@@ -1,252 +1,277 @@
-import Linglib.Processing.Lexical.Discriminative.Defs
-import Linglib.Processing.Lexical.Discriminative.Measures
-import Linglib.Processing.Lexical.Discriminative.Normed
+import Linglib.Core.LinearAlgebra.Matrix.Symmetric
+import Linglib.Processing.Lexical.Discriminative.Training
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.LinearAlgebra.Matrix.Notation
+import Mathlib.LinearAlgebra.Matrix.ToLin
 
 /-!
-# Gahl & Baayen (2024): English homophone duration via DLM
-[gahl-baayen-2024] [baayen-2019]
-[heitmeier-chuang-baayen-2026]
+# Gahl and Baayen 2024: homophone duration without a stored lexicon
 
-Gahl, S., & Baayen, R. H. (2024). Time and thyme again: Connecting
-English spoken word duration to models of the mental lexicon.
-*Language* 100(4), 623–670.
+The paper reanalyses the Switchboard durations of the 409 English homophones of [gahl-2008]
+(*time* ~ *thyme*) from a discriminative lexicon (`LinearDiscriminativeLexicon`, [baayen-2019]):
+linear maps between triphone and embedding vectors, with no stored words and so no word to bear
+a frequency. Frequency is treated as composite. *Practice* is frequency-informed learning of the
+production map `G` (`IsFILTrainedOn`, [heitmeier-chuang-axen-baayen-2024]); *contextual
+independence* is the diagonal `d` of a word-to-word map `W` with `UW = U` over an
+utterance-by-word matrix `U`, transformed to `Cind` by (9); *semantic support for form* is the
+support a word's own triphones receive from its meaning, the diagonal of `T = ĈCᵀ` (A5),
+`semSupWord` at a word's meaning and form. In Gaussian location-scale GAMs the predictors
+grounded in the model beat the localist ones (Table 5), homophone twins differ in duration, and
+semantically similar twins are closer in duration. The GAM fits are outside the Processing
+scope, and the paper derives nothing formal from its Pearson-correlation homophone similarity
+(§3.4), so neither is stated here.
 
-## Empirical claims
+What is stated is the paper's own toy lexicon *time, lime, thyme* (§2.3), worked through the
+substrate's training theory. The endstate map (4) and the frequency-informed map for token
+frequencies 100, 10, 1 (A3) are certified `IsELTrainedOn` and `IsFILTrainedOn` by the
+coordinate normal equations; the support matrix of (A6) and both columns of Table 1 come out
+exactly, the frequency-informed column being `√frequency` times the support the learned map
+alone gives, as it is the fitted value of the `√Q`-scaled regression; the homophones get
+distinct predicted forms from identical triphones (Fig. A2); and the word-to-word map of (6) is,
+exactly, the orthogonal projector onto the row space of `U`, whose diagonal therefore lies in
+`[0, 1]` and dominates its rows and columns as the paper observes.
 
-The paper reanalyses the Switchboard-corpus homophone-duration data
-of Gahl 2008 (409 English homophone pairs such as *time* / *thyme*,
-*side* / *sighed*) and asks whether a discriminative-lexicon (DL) model
-without stored words can recover the homophone duration effect — long
-attributed to lexical *frequency*. The headline findings:
+## Main results
 
-1. **Form-meaning isomorphism predicts homophone duration differences.**
-   The duration of a homophone correlates with how strongly its
-   meaning supports its form (paper §5.2 Table 4). The semantic
-   support measure outperforms lexical frequency in a Gaussian
-   location-scale GAMM (DL-based AIC −239.13 vs. localist AIC −231.69;
-   evidence ratio 41.26 in paper Table 5).
-2. **Homophone semantic similarity predicts duration similarity.**
-   Pearson correlation of homophone-pair semantic vectors is a
-   significant predictor of how close their durations are (paper §5.2
-   Table 4). Semantically similar homophones are produced more
-   similarly, consistent with the DL prediction that meaning →
-   form mappings vary continuously with the meaning input.
-3. **Contextual independence (CIND) outperforms frequency.**
-   A novel measure derived from a word-to-word matrix `W` (satisfying
-   `UW = U` for utterance multi-hot matrix `U`) captures how much a
-   word's meaning can be inferred independently of its utterance
-   context. Replacing lemma frequency with CIND consistently improves
-   model fit (paper §5.3 Table 5).
+* `endstate_isELTrainedOn`, `frequencyInformed_isFILTrainedOn`: the paper's mappings are the
+  substrate's ERM solutions.
+* `supportMatrix_endstate`, `semanticSupport_endstate`, `semanticSupportFIL_eq`: (A6) and
+  Table 1 exactly; practice reverses the order of *time* and *thyme*
+  (`semanticSupport_endstate_time_lt_thyme`, `semanticSupportFIL_thyme_lt_time`).
+* `time_sub_thyme_notMem_ker`: the homophones leave the neutralization locus.
+* `U_mul_W`, `isSymm_W`, `isIdempotentElem_W`, `le_diag_W`, `diag_W_mem_Icc`: the toy `W`
+  and its diagonal; `strictAntiOn_cind`: the transform (9) reverses its order.
 
-The substantive theoretical move: **lexical frequency is composite,
-not primitive**. The "frequency effect" on duration decomposes into
-(a) `practice`/learning (operationalised via Frequency-Informed
-Learning of the mapping `G`), (b) `contextual independence` (CIND),
-and (c) `semantic support for form` (SemSupForm). A model **without
-stored lexical entries** can recover the duration patterns previously
-attributed to frequency.
+## References
 
-## Substrate (this file)
-
-Built on the `LinearDiscriminativeLexicon` substrate
-(`Processing/Lexical/Discriminative/Defs.lean`) and the `semSup` family
-(`Measures.lean`).
-
-Carrier instantiation: 5,600-dim binary triphone vectors × 200-dim
-fastText English embeddings (paper §3.4, appendix §A2). The substrate
-is dimension-polymorphic; only the dimensions and the empirical
-training data differ from Saito's German setup.
-
-## Substrate generality validated (cumulative table)
-
-| Axis              | Chuang 2026   | Lu 2026       | Saito 2025      | **Gahl-B 2024**          |
-|-------------------|---------------|---------------|-----------------|--------------------------|
-| Language          | Mandarin      | Mandarin      | German          | **English**              |
-| Modality          | f0 pitch      | f0 pitch      | EMA tongue pos. | **acoustic duration**    |
-| Form rep          | 50-dim ℝ      | 100-dim ℝ     | 14,404-dim binary| **5,600-dim binary**    |
-| Meaning rep       | 768-dim CKIP  | 768-dim CKIP  | 300-dim word2vec| **200-dim fastText**     |
-| Phenomenon        | tonal realiz. | tone sandhi   | morpho-phonetics| **homophone duration**   |
-| Headline measure  | word smooth   | sense smooth  | semSupSuffix    | **semSupForm + CIND**    |
-
-Same `LinearDiscriminativeLexicon ℝ FormVec MeaningVec` accommodates
-all four with carrier-type instantiation only — no specialisation.
-
-## Cross-paper convergence
-
-The four DLM Studies share a common architectural commitment that
-this file makes especially explicit: **the seemingly pretheoretical
-construct "lexical frequency" decomposes into separable distributional
-facts** (paper §1.1, §6.4). Three of the four (Chuang, Lu, Saito) make
-this point implicitly by demonstrating word-or-meaning predictors
-that subsume frequency effects; Gahl & Baayen 2024 makes it the
-explicit headline. Lu's tone sandhi and Saito's morphological-boundary
-effects are both special cases of this composite-frequency story.
-
-## Cross-framework note: localist (WEAVER, Dell) vs DL
-
-The paper directly compares DL-based GAMMs to GAMMs grounded in
-**localist** lexical models (Dell 1986, Levelt-Roelofs-Meyer 1999)
-where frequency is a property of stored lexical entries. linglib does
-not currently formalize WEAVER or Dell-style spreading-activation
-substrates; the cross-framework discrimination lives in this file's
-prose (§5 below). When a `Processing/Lexical/WEAVER/` sibling
-lands, the localist–DL comparison can become a Lean-stateable
-contrast theorem.
-
-## Sections
-
-- §1 Substrate instantiation (English DLM at 5600/200 dimensions)
-- §2 Paper-specific alias for word-level semantic support
-- §3 Lipschitz application: similar homophone meanings ⇒ similar predicted forms
-- §4 Empirical content (prose; includes CIND and HomophoneSemSim)
+* [S. Gahl and R. H. Baayen, *Time and thyme again: Connecting English spoken word duration to
+  models of the mental lexicon* (2024)][gahl-baayen-2024]
+* [S. Gahl, *Time and thyme are not homophones: The effect of lemma frequency on word durations
+  in spontaneous speech* (2008)][gahl-2008]
+* [R. H. Baayen, Y.-Y. Chuang, E. Shafaei-Bajestan and J. P. Blevins, *The discriminative
+  lexicon* (2019)][baayen-2019]
+* [M. Heitmeier, Y.-Y. Chuang, S. D. Axen and R. H. Baayen, *Frequency effects in linear
+  discriminative learning* (2024)][heitmeier-chuang-axen-baayen-2024]
 -/
 
 namespace GahlBaayen2024
 
-open Processing.Lexical.Discriminative
+open Processing.Lexical.Discriminative Matrix
 
--- ============================================================================
--- §1: Substrate instantiation — English DLM
--- ============================================================================
+noncomputable section
 
-/-- Number of triphones in the paper's CELEX-derived word-by-triphone
-    matrix `C` (paper appendix §A2: matrix `C` of shape `10,636 × 5,600`).
-    Form vectors are zero/one binary indicators of triphone presence. -/
-abbrev EnglishTriphoneCount : ℕ := 5600
+/-! ### The toy lexicon -/
 
-/-- Dimensionality of the pretrained fastText English embeddings
-    (paper appendix §A2: matrix `S` of shape `10,636 × 200`; the
-    embeddings are the tweet-based fastText vectors cited in the
-    paper). -/
-abbrev FastTextEnglishDim : ℕ := 200
+/-- The toy lexicon of §2.3: the semantic matrix `S` of (1), rows *time*, *lime*, *thyme* over
+two arbitrary semantic dimensions (`0.1 0.3; 0.6 0.2; 1.1 0.6`), and the binary triphone matrix
+`C` of (2), columns `#ta taɪ aɪm ɪm# #la laɪ`. *time* and *thyme* share a form row. -/
+def toy : TrainingExperience 3 6 2 where
+  meanings := ![![1 / 10, 3 / 10], ![6 / 10, 2 / 10], ![11 / 10, 6 / 10]]
+  forms := ![![1, 1, 1, 1, 0, 0], ![0, 0, 1, 1, 1, 1], ![1, 1, 1, 1, 0, 0]]
 
-/-- A form vector for the English DLM. The "binary" structure is data,
-    not type — `FormVec` is `Fin n → ℝ`. -/
-abbrev EnglishTriphoneVec : Type := FormVec EnglishTriphoneCount
+/-- *time*, the first row of the toy lexicon. -/
+abbrev time : Fin 3 := 0
 
-/-- A semantic vector: 200-dim fastText embedding of word meaning. -/
-abbrev EnglishFastTextVec : Type := MeaningVec FastTextEnglishDim
+/-- *lime*, the second row of the toy lexicon. -/
+abbrev lime : Fin 3 := 1
 
-/-- The paper's specific DLM instantiation. -/
-abbrev EnglishHomophoneDLM : Type :=
-  LinearDiscriminativeLexicon ℝ EnglishTriphoneVec EnglishFastTextVec
+/-- *thyme*, the third row of the toy lexicon. -/
+abbrev thyme : Fin 3 := 2
 
--- ============================================================================
--- §2: Paper-specific alias for word-level semantic support
--- ============================================================================
+/-- The token frequencies 100, 10, 1 of *time*, *lime*, *thyme* (A3). -/
+def freq : FrequencyVector 3 := ![100, 10, 1]
 
-/-- **Semantic Support for Form** (paper §3.4 eq. 10): the total
-    support a word's meaning provides to its constituent triphones,
-    `Σ_{j ∈ word} (D.production s) j`. The paper's name for the
-    `semSupWord` measure (now in
-    `Processing/Lexical/Discriminative/Measures.lean`); here
-    as an `abbrev` re-exporting under the paper-specific name.
+/-! ### Endstate and frequency-informed learning
 
-    Two other paper-specific measures (`CIND` for contextual
-    independence, `HomophoneSemSim` for Pearson correlation of
-    homophone-pair semantic vectors) are defined in the paper but
-    not formalised as Lean defs in this file. CIND requires
-    formalising the word-to-word matrix `W` satisfying `UW = U`
-    (paper §3.2 eq. 9 — substantial substrate work). HomophoneSemSim
-    requires inner-product / Pearson machinery on `MeaningVec`
-    (deferred to a future `Measures/InnerProduct.lean` sibling).
-    Both measures are recorded in §4 prose. -/
-noncomputable abbrev semSupForm (D : EnglishHomophoneDLM)
-    (s : EnglishFastTextVec) (triphones : List (Fin EnglishTriphoneCount)) : ℝ :=
-  semSupWord D s triphones
+The paper fits only the production side of the model, so the comprehension maps below are left
+zero. Mapping matrices act on row vectors, `ĉ = sG` (10), so a production map is `toLin' Gᵀ`. -/
 
--- ============================================================================
--- §3: Lipschitz application — similar homophones ⇒ similar form vectors
--- ============================================================================
+/-- The endstate mapping `G` of (4), exactly: `(SᵀS)⁻¹SᵀC` of (A2), with
+`1181 = 10⁴ · det(SᵀS)`; the paper prints it to two decimals. -/
+def endstateG : Matrix (Fin 2) (Fin 6) ℝ :=
+  (1181 : ℝ)⁻¹ • !![-1410, -1410, -90, -90, 1320, 1320; 4500, 4500, 2800, 2800, -1700, -1700]
 
-/-- **Quantitative form of the homophone-similarity → duration-similarity
-    prediction** (paper §3.4, §5.2). The paper reports that homophone
-    pairs with high `homophoneSemSim` (semantically similar meanings)
-    have more similar durations.
+/-- The DLM at the endstate of learning. -/
+def endstate : LinearDiscriminativeLexicon ℝ (FormVec 6) (MeaningVec 2) where
+  comprehension := 0
+  production := Matrix.toLin' endstateGᵀ
 
-    Structurally, this follows from the Lipschitz continuity of the
-    production map: if two semantic vectors are close, their predicted
-    form vectors are close, which (given that triphone presences feed
-    duration estimation) implies close predicted durations.
+/-- The frequency-informed mapping, exactly: the solution of the `√Q`-scaled normal equations
+(A4) for the frequencies `freq`, with `16543 = 500 · det(SᵀQS)`. -/
+def frequencyInformedG : Matrix (Fin 2) (Fin 6) ℝ :=
+  (16543 : ℝ)⁻¹ • !![-20190, -20190, 4230, 4230, 24420, 24420;
+    61920, 61920, 53150, 53150, -8770, -8770]
 
-    Direct application of `dlm_neighbor_centroids_imply_neighbor_contours`
-    to the English homophone DLM. -/
-theorem homophone_similarity_implies_form_similarity
-    (D : EnglishHomophoneDLM) (s₁ s₂ : EnglishFastTextVec) {ε : ℝ}
-    (h : ‖s₁ - s₂‖ ≤ ε) :
-    ‖D.production s₁ - D.production s₂‖ ≤
-      ‖D.production.toContinuousLinearMap‖ * ε :=
-  dlm_neighbor_centroids_imply_neighbor_contours D h
+/-- The DLM after frequency-informed learning. -/
+def frequencyInformed : LinearDiscriminativeLexicon ℝ (FormVec 6) (MeaningVec 2) where
+  comprehension := 0
+  production := Matrix.toLin' frequencyInformedGᵀ
 
--- ============================================================================
--- §4: Empirical content (prose)
--- ============================================================================
+/-- The endstate mapping is the substrate's uniform-weight ERM solution: the coordinate normal
+equations (A2) hold. -/
+theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy := by
+  refine (isERMSolution_iff_forall_coord ?_).mpr fun j k => ?_
+  · exact fun _ => zero_le_one
+  · fin_cases j <;> fin_cases k <;>
+      norm_num [toy, endstate, endstateG, uniformFrequency, Matrix.toLin'_apply, Matrix.mulVec,
+        dotProduct, Fin.sum_univ_succ]
 
-/-! ### Findings as paper-supplied empirical facts
+/-- The frequency-informed mapping is the substrate's ERM solution under `freq`: the
+`√Q`-scaled normal equations (A4) hold. -/
+theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy freq := by
+  refine (isERMSolution_iff_forall_coord ?_).mpr fun j k => ?_
+  · intro i; fin_cases i <;> norm_num [freq]
+  · fin_cases j <;> fin_cases k <;>
+      norm_num [toy, freq, frequencyInformed, frequencyInformedG, Matrix.toLin'_apply,
+        Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
-Per `CLAUDE.md` (Processing-scope guidance), specific GAMM fits, AIC
-deltas, and random forest variable-importance scores are out of scope
-as Lean theorems. They are recorded here as documented findings.
+/-! ### Semantic support for form -/
 
-**DL-based GAMM outperforms localist GAMM** (paper §5.2 / §5.3,
-Tables 3-5). Three Gaussian-location-scale GAMMs fitted to log-duration
-of 409 Switchboard homophones:
+/-- The support matrix `T = ĈCᵀ` of (A5): the support each word's form (column) receives from
+each word's meaning (row). -/
+def supportMatrix {m n d : ℕ} (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
+    (data : TrainingExperience m n d) : Matrix (Fin m) (Fin m) ℝ :=
+  Matrix.of fun i k => semSupWord D (data.meanings i) (data.forms k)
 
-- Localist (predictors: lemma frequency, relative frequency,
-  phonological neighbourhood density, +controls): AIC = −231.69.
-- DL with frequency-informed-learning (FIL) semSupForm + CIND
-  +HomophoneSemSim +controls: AIC = −239.13. **Best DL model**:
-  endstate-learning semSupForm + CIND + ortho consistency → AIC =
-  −244.77 (evidence ratio 692.29 vs. localist baseline; paper Table 5).
+/-- *Semantic support for form*: the diagonal of `T`, a word's support for its own form. -/
+def semanticSupport {m n d : ℕ} (D : LinearDiscriminativeLexicon ℝ (FormVec n) (MeaningVec d))
+    (data : TrainingExperience m n d) : Fin m → ℝ :=
+  (supportMatrix D data).diag
 
-**SemSupForm with endstate learning is the strongest predictor**
-(paper §5.4, Fig. 5). Random Forest variable importance ranks
-`LogSemanticSupportFormEOL` highest, ahead of phonological neighbourhood
-density, orthographic regularity, lemma frequency, and CIND. The
-endstate-learning variant is preferred for variable-importance
-analysis because it is uncorrelated with frequency (r ≈ −0.38, vs
-r = +0.61 for the FIL variant).
+/-- (A6): the endstate support matrix, which the paper prints as
+`3.455 0.767 3.455; 0.948 1.622 0.948; 4.623 3.409 4.623`. Its columns for *time* and *thyme*
+coincide, as their triphones do. -/
+theorem supportMatrix_endstate :
+    supportMatrix endstate toy =
+      (1181 : ℝ)⁻¹ • !![4080, 906, 4080; 1120, 1916, 1120; 5460, 4026, 5460] := by
+  ext i k
+  fin_cases i <;> fin_cases k <;>
+    norm_num [supportMatrix, semSupWord, toy, endstate, endstateG, Matrix.toLin'_apply,
+      Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
-**Homophones do NOT sound identical** (paper §6.1, §1.3 — confirmed
-contra prior reanalyses claiming the effect is artefactual).
-Confirmed: the duration of *time* differs from the duration of
-*thyme* even when speaker, phonetic-segment baseline, prosodic
-position, and noun-bias are controlled for. The DL model explains
-this *via* meaning: identical triphone vectors but different semantic
-vectors → different predicted form vectors via `D.production` →
-different duration estimates.
+/-- Table 1, endstate column: `3.455, 1.622, 4.623`. -/
+theorem semanticSupport_endstate :
+    semanticSupport endstate toy = (1181 : ℝ)⁻¹ • ![4080, 1916, 5460] := by
+  ext i
+  fin_cases i <;> simp [semanticSupport, supportMatrix_endstate, Matrix.cons_val_two]
 
-**Frequency is composite** (paper §1.1, §6.4 — the headline
-theoretical claim). The DL predictors `practice` (FIL),
-`contextual independence` (CIND), and `semantic support for form`
-(SemSupForm) jointly capture what was previously bundled under
-"frequency". The "frequency effect" decomposes; no stored lexical
-entry need carry a frequency property.
+/-- At the endstate, *thyme*'s meaning supports its form more strongly than *time*'s does
+(A6). -/
+theorem semanticSupport_endstate_time_lt_thyme :
+    semanticSupport endstate toy time < semanticSupport endstate toy thyme := by
+  rw [semanticSupport_endstate]; norm_num [time, thyme, Matrix.cons_val_two]
 
-### Implications recorded in the paper's discussion
+/-- Semantic support for form under frequency-informed learning as the paper computes it for
+the toy lexicon (Table 1, (A7)): the predicted forms are the fitted values `√Q S G` of the
+`√Q`-scaled regression, paired with the words' own unscaled triphone vectors. -/
+def semanticSupportFIL (i : Fin 3) : ℝ :=
+  semSupWord frequencyInformed ((toy.sqrtScale freq).meanings i) (toy.forms i)
 
-- **Anti-lexical-storage** (paper §6.1, §6.2 contra
-  [levelt-roelofs-meyer-1999] and the Dell-style spreading-
-  activation lineage): frequency effects on duration emerge from a
-  model *without* stored words. The DL model has only the matrices
-  `C`, `S`, and the trained mappings `G`, `F`, `W` — no lexical
-  entries bearing frequency annotations.
-- **Form-meaning isomorphism** (paper §6.3, §6.4): the linear mapping
-  `G : S → C` predicts considerable structural alignment between the
-  semantic and form spaces — a generalisation of sound-symbolism /
-  iconicity beyond onomatopoeia and ideophones. Quantitatively
-  validated by the homophone-similarity → duration-similarity
-  prediction (§3 above).
-- **Contextual independence as cognitive measure** (paper §3.2,
-  §6.4): CIND captures how much a word's meaning can be learned
-  *without* its co-occurring contexts, and is correlated with
-  visual lexical decision times (paper appendix §A5.1, validated
-  against the British Lexicon Project).
-- **Convergence with [saito-tomaschek-baayen-2025]**: both
-  papers find that DL-derived semantic-support measures replace
-  categorical morphological / lexical predictors with smaller AIC
-  values and (in Saito) fewer effective degrees of freedom. The
-  composite-frequency thesis of paper §6.4 receives independent
-  support from the German morpho-phonetics data of Saito 2025. -/
+/-- The `√frequency` factor made explicit: the paper's frequency-informed support is
+`√(freq i)` times the support the learned map alone gives. -/
+theorem semanticSupportFIL_eq_sqrt_mul (i : Fin 3) :
+    semanticSupportFIL i = Real.sqrt (freq i) * semanticSupport frequencyInformed toy i := by
+  simp [semanticSupportFIL, semanticSupport, supportMatrix, TrainingExperience.sqrtScale]
+
+/-- The learned frequency-informed map alone still supports *thyme* most:
+`3.981, 3.151, 6.225`. -/
+theorem semanticSupport_frequencyInformed :
+    semanticSupport frequencyInformed toy = (16543 : ℝ)⁻¹ • ![65850, 52132, 102972] := by
+  ext i
+  fin_cases i <;>
+    norm_num [semanticSupport, supportMatrix, semSupWord, toy, frequencyInformed,
+      frequencyInformedG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+
+/-- Table 1, frequency-informed column: `39.805, 9.965, 6.225`. -/
+theorem semanticSupportFIL_eq :
+    semanticSupportFIL = ![658500 / 16543, Real.sqrt 10 * (52132 / 16543), 102972 / 16543] := by
+  have h100 : Real.sqrt 100 = 10 := by
+    rw [show (100 : ℝ) = 10 ^ 2 by norm_num, Real.sqrt_sq (by norm_num)]
+  ext i
+  rw [semanticSupportFIL_eq_sqrt_mul, semanticSupport_frequencyInformed]
+  fin_cases i <;> norm_num [freq, h100, Matrix.cons_val_two]
+
+/-- Under practice *time* overtakes *thyme* ((A7): 39.805 against 6.225), reversing the
+endstate order. -/
+theorem semanticSupportFIL_thyme_lt_time :
+    semanticSupportFIL thyme < semanticSupportFIL time := by
+  rw [semanticSupportFIL_eq]; norm_num [time, thyme, Matrix.cons_val_two]
+
+/-- Identical triphones, distinct predicted forms: *time* and *thyme* share a form row, but
+their meaning difference lies outside the production kernel, the neutralization locus of
+`LinearDiscriminativeLexicon.sub_mem_ker_iff`, so their triphones receive different support
+((A3), Fig. A2; §6.2). -/
+theorem time_sub_thyme_notMem_ker :
+    toy.meanings time - toy.meanings thyme ∉ LinearMap.ker endstate.production := fun h => by
+  have := congrFun (endstate.sub_mem_ker_iff.mp h) 0
+  norm_num [toy, endstate, endstateG, time, thyme, Matrix.cons_val_two, Matrix.toLin'_apply,
+    Matrix.mulVec, dotProduct, Fin.sum_univ_succ] at this
+
+/-! ### Contextual independence
+
+The paper's second component of frequency is estimated at the utterance level: a word-to-word
+map `W` with `UW = U` (A8) predicts every word of an utterance from all the words in it, and
+the diagonal of `W` is the share of a word's prediction strength that it owes to itself
+((7), (8)). For the toy utterances of (5) the paper solves the equation by regression; the
+printed `W` of (6) is the minimum-norm solution `U⁺U = Uᵀ(UUᵀ)⁻¹U`, the orthogonal projector
+onto the row space of `U`, reproduced here exactly. (A5.2) folds the measure back into the
+model by scaling a word's semantic vector, which scales its semantic support for form by the
+same factor (`semSupWord_smul_left`). -/
+
+/-- The utterance-by-word matrix `U` of (5): rows *my time is short*, *my good time*,
+*my fragrant thyme*, *my lime is bad*, *my lime is good*; columns *my, time, is, short, good,
+fragrant, thyme, lime, bad*. -/
+def U : Matrix (Fin 5) (Fin 9) ℚ :=
+  !![1, 1, 1, 1, 0, 0, 0, 0, 0;
+     1, 1, 0, 0, 1, 0, 0, 0, 0;
+     1, 0, 0, 0, 0, 1, 1, 0, 0;
+     1, 0, 1, 0, 0, 0, 0, 1, 1;
+     1, 0, 1, 0, 1, 0, 0, 1, 0]
+
+/-- The word-to-word map `W` of (6), exactly; the paper prints it to two decimals. -/
+def W : Matrix (Fin 9) (Fin 9) ℚ := (71 : ℚ)⁻¹ •
+  !![41, 18, 10, 2, 12, 15, 15, 8, 12;
+     18, 46, -6, 13, 7, -9, -9, -19, 7;
+     10, -6, 44, 23, -4, -5, -5, 21, -4;
+     2, 13, 23, 33, -15, -1, -1, -10, -15;
+     12, 7, -4, -15, 52, -6, -6, 11, -19;
+     15, -9, -5, -1, -6, 28, 28, -4, -6;
+     15, -9, -5, -1, -6, 28, 28, -4, -6;
+     8, -19, 21, -10, 11, -4, -4, 31, 11;
+     12, 7, -4, -15, -19, -6, -6, 11, 52]
+
+/-- `W` solves the paper's equation `UW = U` (A8), exactly where the paper reports agreement
+"up to fifteen decimal digits". -/
+theorem U_mul_W : U * W = U := by decide +kernel
+
+/-- `W` is symmetric. -/
+theorem isSymm_W : W.IsSymm := by decide +kernel
+
+/-- `W` is idempotent: with symmetry, an orthogonal projector. -/
+theorem isIdempotentElem_W : IsIdempotentElem W := by
+  unfold IsIdempotentElem; decide +kernel
+
+/-- The diagonal of `W` dominates its rows, as the paper observes of (6). -/
+theorem le_diag_W : ∀ i j, W i j ≤ W i i := by decide +kernel
+
+/-- The diagonal of `W` lies in `[0, 1]`, the "proportions" of §3.2, because `W` is an
+orthogonal projector. -/
+theorem diag_W_mem_Icc (i : Fin 9) : W i i ∈ Set.Icc (0 : ℚ) 1 :=
+  ⟨Matrix.diag_nonneg_of_isSymm_of_isIdempotentElem isSymm_W isIdempotentElem_W i,
+    Matrix.diag_le_one_of_isSymm_of_isIdempotentElem isSymm_W isIdempotentElem_W i⟩
+
+/-- The contextual-independence measure of (9): `Cind = (log(1/d))^{1/4}`, a log against the
+right skew of the diagonal values and a power to finish it. -/
+def cind (d : ℝ) : ℝ := Real.log (1 / d) ^ (1 / 4 : ℝ)
+
+/-- `Cind` reverses the order of the diagonal values on `(0, 1)`: the more a word predicts
+itself, the lower its `Cind` — the sign of its correlation with frequency in Fig. 2. -/
+theorem strictAntiOn_cind : StrictAntiOn cind (Set.Ioo 0 1) := fun a ha b hb hab => by
+  unfold cind
+  refine Real.rpow_lt_rpow (Real.log_nonneg ?_)
+    (Real.log_lt_log (one_div_pos.mpr hb.1) (one_div_lt_one_div_of_lt ha.1 hab)) (by norm_num)
+  rw [le_div_iff₀ hb.1]; linarith [hb.2]
+
+end
 
 end GahlBaayen2024

--- a/references.bib
+++ b/references.bib
@@ -27474,7 +27474,7 @@
   doi       = {10.1155/2019/4895891},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Studies/ChuangEtAl2026.lean;Processing/Lexical/Discriminative/Defs.lean;Processing/Lexical/Discriminative/Normed.lean}
+  sources   = {Studies/GahlBaayen2024.lean;Studies/ChuangEtAl2026.lean;Processing/Lexical/Discriminative/Defs.lean;Processing/Lexical/Discriminative/Normed.lean}
 }
 
 @article{heitmeier-schmidt-lensch-baayen-2025,
@@ -27498,7 +27498,7 @@
   doi       = {10.3389/fnhum.2023.1242720},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Processing/Lexical/Discriminative/Training.lean}
+  sources   = {Studies/GahlBaayen2024.lean;Processing/Lexical/Discriminative/Training.lean}
 }
 
 @unpublished{widrow-hoff-1960,
@@ -27588,9 +27588,24 @@
   volume    = {100},
   number    = {4},
   pages     = {623--670},
+  doi       = {10.1353/lan.2024.a947037},
   subfield  = {phonology},
   role      = {formalized},
-  sources   = {Studies/Saito2025.lean;Studies/GahlBaayen2024.lean;Processing/Lexical/Discriminative/Measures.lean;Processing/Lexical/Discriminative/Training.lean}
+  sources   = {Studies/Saito2025.lean;Studies/GahlBaayen2024.lean;Processing/Lexical/Discriminative/Measures.lean;Processing/Lexical/Discriminative/Training.lean;Processing/Lexical/Discriminative/Regression.lean}
+}
+
+@article{gahl-2008,
+  author    = {Gahl, Susanne},
+  year      = {2008},
+  title     = {Time and thyme are not homophones: The effect of lemma frequency on word durations in spontaneous speech},
+  journal   = {Language},
+  volume    = {84},
+  number    = {3},
+  pages     = {474--496},
+  doi       = {10.1353/lan.0.0035},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Studies/GahlBaayen2024.lean}
 }
 
 @article{levelt-roelofs-meyer-1999,


### PR DESCRIPTION
Rewrites the study on the paper's own toy lexicon *time, lime, thyme*: the endstate and frequency-informed mappings are certified ERM solutions by the coordinate normal equations, the support matrix (A6) and both columns of Table 1 come out exactly (the FIL column carries a `√frequency` factor, being the fitted value of the `√Q`-scaled regression), the homophones leave the production kernel, and the toy word-to-word map `W` of (6) is verified exactly as an orthogonal projector with `UW = U`. Drops the fabricated locators and numbers of the old prose (409 "pairs", `LogSemanticSupportFormEOL`, *side/sighed*, the mislabelled best model) and the Lipschitz re-export.

- `semSupWord` is now the dot product of the predicted form with a form vector, the paper's `T = ĈCᵀ`, with bilinearity lemmas; `isERMSolution_iff_forall_coord` is the coordinate normal equations.
- New `Core/LinearAlgebra/Matrix/Symmetric.lean`: diagonal of a symmetric idempotent matrix is a sum of squares in `[0, 1]`.
- Bib: adds `gahl-2008`, the 2024 DOI.