### PR TITLE
refactor(Studies/LuChuangBaayen2026): centroids under least squares

### DIFF
--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -21,8 +21,9 @@ experience ([heitmeier-2024]).
 
 * `TrainingExperience`, `FrequencyVector`, `weightedLoss`, `IsERMSolution`, `IsELSolution`.
 * `isERMSolution_iff_isLeastSquares`, `exists_isERMSolution`.
-* `isERMSolution_iff_inner_eq_zero`, `isERMSolution_iff_forall_coord`: the normal equations,
-  against every direction and in coordinates.
+* `isERMSolution_iff_inner_eq_zero`, `isERMSolution_iff_forall_coord`,
+  `IsERMSolution.sum_smul_sub_eq_zero`: the normal equations, against every direction, in
+  coordinates, and in vector form.
 * `IsERMSolution.apply_meanings_eq`, `apply_eq_of_mem_span`, `exists_apply_ne`,
   `existsUnique_isERMSolution_iff`: fitted values are unique exactly on the span of experience.
 * `isELSolution_sqrtScale_iff`: FIL under `q` is EL on `TrainingExperience.sqrtScale`.
@@ -219,6 +220,16 @@ theorem isERMSolution_iff_forall_coord :
     rw [Finset.sum_comm]
     refine Finset.sum_eq_zero fun k _ => ?_
     rw [← Finset.sum_mul, h j k, zero_mul]
+
+/-- The normal equations in vector form: the `q`-weighted residuals, weighted further by any
+linear functional of the meanings, sum to zero. -/
+theorem IsERMSolution.sum_smul_sub_eq_zero (hG : IsERMSolution data q G)
+    (w : MeaningVec d →ₗ[ℝ] ℝ) :
+    ∑ i, (q i * w (data.meanings i)) • (G (data.meanings i) - data.forms i) = 0 := by
+  funext j
+  have h := isERMSolution_iff_inner_eq_zero.1 hG (w.smulRight (Pi.single j 1))
+  simpa [dotProduct_smul, dotProduct_single, Finset.sum_apply, mul_assoc, mul_comm,
+    mul_left_comm] using h
 
 /-! ### Fitted values -/
 

--- a/Linglib/Studies/LuChuangBaayen2026.lean
+++ b/Linglib/Studies/LuChuangBaayen2026.lean
@@ -1,307 +1,93 @@
-import Linglib.Processing.Lexical.Discriminative.Defs
-import Linglib.Processing.Lexical.Discriminative.Normed
+import Linglib.Processing.Lexical.Discriminative.Training
 import Linglib.Studies.ChuangEtAl2026
-import Mathlib.LinearAlgebra.Pi
 
 /-!
-# Lu, Chuang & Baayen (2026): Realization of tones in spontaneous Taiwan Mandarin
-[lu-chuang-baayen-2026] [chuang-bell-tseng-baayen-2026]
-[baayen-2019] [heitmeier-chuang-baayen-2026]
+# Lu, Chuang and Baayen 2026: tonal realization in spontaneous Taiwan Mandarin
 
-Lu, Y., Chuang, Y.-Y., & Baayen, R. H. (2026). The realization of tones
-in spontaneous spoken Taiwan Mandarin: a corpus-based survey and
-theory-driven computational modeling. *Corpus Linguistics and
-Linguistic Theory*. DOI 10.1515/cllt-2025-0028.
+[lu-chuang-baayen-2026] survey the f0 contours of disyllabic words across all 20 tone patterns
+of Taiwan Mandarin, a lexical tone followed by a lexical or neutral tone (Table 1), in
+[fon-2004]'s corpus of spontaneous speech. In generalized additive mixed models, word and sense
+outweigh tone pattern as predictors of the contour (§3.4). Following
+[chuang-bell-tseng-baayen-2026], a linear mapping from 768-dimensional GPT-2 contextualized
+embeddings to 100-sample normalized pitch contours, fitted by least squares on the training
+tokens (§4.3, the method of [gahl-baayen-2024]), predicts held-out tokens' contours above
+chance, and the centroid embedding of each tone pattern maps to a contour close to the GAMM
+contour of that pattern (§4.4, Fig. 9): the average pitch contours correspond to average
+embeddings (§4.5). The discussion (§5) meets the tone-sandhi objection empirically, T3-T3 and
+T2-T3 being neutralized in Taiwan Mandarin ([lu-chuang-baayen-2024]) so that T3-T3 words can
+simply be reclassified, and theoretically: the model predicts forms from meanings, never forms
+from forms, and the tone-pattern contours emerge without the model being told the patterns.
+The lab-speech contours of [xu-1997] match the predicted ones for several patterns (Fig. 11).
 
-## Empirical claims
+This file instantiates the DLM at the paper's carriers and derives the model-side half of the
+centroid claim. Linearity alone sends a centroid to the mean of the predicted contours
+(`production_centroid`); training does better: whenever membership in a set of training tokens
+is a linear functional of the embeddings, the least-squares map sends that set's centroid
+exactly to the mean of its target contours (`production_centroid_eq_of_decodable`). The
+paper's centroids weight word types equally rather than tokens (§4.4) and Fig. 9 compares
+against GAMM contours, so the match it reports is approximate; the theorem states what least
+squares guarantees when a tone pattern is linearly recoverable from meaning. The GAMM fits
+and the nearest-neighbour accuracies are outside the Processing scope.
 
-This study **generalises** [chuang-bell-tseng-baayen-2026] from a
-single tone pattern (T2-T4 rise-fall) to **all 20 disyllabic tone
-patterns** of Taiwan Mandarin, in a 4,283-token / 313-word-type subset
-of the Corpus of Spontaneous Taiwan Mandarin (Fon 2004), restricted to
-the four most frequent tonal contexts (4.4, 3.4, 4.1, 4.0).
+## Main results
 
-1. **Word effect generalises across all 20 tone patterns.** Withholding
-   `word` from the GAMM raises AIC by 7,269.27 to 12,345.54 across the
-   four tonal contexts (paper §3.4.1, Fig. 2), far exceeding any other
-   predictor. When `word` is included, withholding `tone_pattern`
-   raises AIC by only single- or low-double-digit units, reflecting
-   near-total subsumption of `tone_pattern` by `word`.
-2. **Sense > word.** Replacing the `word` factor smooth with a `sense_type`
-   factor smooth further reduces AIC (paper §3.4.2, Table 4),
-   replicating [chuang-bell-tseng-baayen-2026] on the broader
-   20-pattern dataset.
-3. **Form–meaning isomorphism for all 20 tone patterns.** A linear
-   meaning→form mapping from CE centroids to fixed-length pitch vectors
-   recovers the GAMM-derived gold-standard contours of all 20 tone
-   patterns with high cosine similarity (paper §4.4, Fig. 9).
-4. **T3 tone sandhi as DLM kernel-neutralization.** The classically
-   stipulated "T3 → T2 / __ T3" sandhi rule **does not appear in the
-   model**: T3-T3 and T2-T3 word-token CE centroids in Taiwan Mandarin
-   differ only by elements that lie in the **kernel of the trained
-   production map**, so their surface pitch contours are identical
-   ("complete neutralization for Taiwan Mandarin", paper §5; consistent
-   with [lu-chuang-baayen-2025]'s corpus measurement showing T3-T3 ≡
-   T2-T3 surface in spontaneous Taiwan Mandarin).
+* `production_centroid`: a production map sends a centroid to the mean of the predictions.
+* `production_centroid_eq_of_decodable`: a least-squares-trained map sends the centroid of a
+  linearly decodable set of tokens exactly to the mean of their target contours.
 
-The substantive theoretical claim is that **a word-and-paradigm DLM
-suffices to predict every disyllabic tone pattern's surface realisation
-without any explicit phonological tone-sandhi rule**. The architecture
-predicts neutralization where the meaning-space evidence supports it
-(Taiwan Mandarin, complete) and underdetermines it where evidence does
-not (Standard Chinese, where T3-T2 / T3-T3 distinction "is hardly
-visible to the eye" but reportedly incomplete; [lu-chuang-baayen-2026]
-§5).
+## References
 
-## Substrate
-
-This file specialises the `LinearDiscriminativeLexicon` substrate
-(`Processing/Lexical/Discriminative/Defs.lean`) to:
-
-- **100-dimensional** pitch vectors (vs. Chuang's 50-dim) — paper §4.1;
-- the **same 768-dimensional** CKIP GPT-2 embedding space
-  (`CKIPGPT2HiddenDim`, reused from `ChuangEtAl2026`);
-- a **20-element** `TonePattern20` enum covering all disyllabic
-  combinations of T1/T2/T3/T4/T0.
-
-## Cross-framework note: vs. autosegmental T3 sandhi
-
-The classical autosegmental account of Mandarin T3 sandhi
-([chen-2000], [duanmu-2007], and the surrounding literature)
-posits a structural rule: an underlying `/T3 T3/` sequence undergoes
-spreading or delinking, surfacing as `[T2 T3]`. Linglib's existing
-discrete-tone substrate (`Phonology/Tone/Constraints.lean`,
-`Phonology/Autosegmental/Floating.lean`) is set up to express
-such rule-based accounts, although no Mandarin-specific T3-sandhi
-fragment has been formalised in linglib to date.
-
-The DLM-side account differs both **architecturally** and
-**predictively**:
-
-- **Architecturally**, no rule is invoked. The neutralisation falls out
-  of the kernel of the trained meaning→form map. `t3_sandhi_via_kernel`
-  below states this as a direct application of the kernel
-  characterisation `LinearMap.sub_mem_ker_iff`.
-- **Predictively**, the DLM accommodates **dialect variation** in
-  sandhi completeness without re-stipulating the rule: Taiwan Mandarin's
-  complete neutralisation = the kernel-difference holds; Standard
-  Chinese's incomplete neutralisation = the difference is small but
-  non-zero. The autosegmental account requires either a derivational
-  optionality or a different rule per dialect.
-
-The two formalisations are not in head-on conflict; they generate
-different predictions on the same data. A formal cross-framework
-discrimination experiment would require the discrete-tone substrate
-to commit to a Mandarin T3-sandhi fragment, which it currently does
-not. Until then, this comparison lives in prose.
-
-## Sections
-
-- Substrate import and paper-specific dimensional instantiation
-- The 20 disyllabic tone patterns of Mandarin
-- Tone sandhi neutralization as DLM kernel application
-- DLM dialect flexibility: same architecture, different kernels
-- Empirical content (AIC, accuracies, isomorphism metrics)
+* [Y. Lu, Y.-Y. Chuang and R. H. Baayen, *The realization of tones in spontaneous spoken Taiwan
+  Mandarin: a corpus-based survey and theory-driven computational modeling*
+  (2026)][lu-chuang-baayen-2026]
+* [Y. Lu, Y.-Y. Chuang and R. H. Baayen, *Form and meaning co-determine the realization of tone
+  in Taiwan Mandarin spontaneous speech* (2024)][lu-chuang-baayen-2024]
+* [Y.-Y. Chuang, M. J. Bell, Y.-H. Tseng and R. H. Baayen, *Word-specific tonal realizations
+  in Mandarin* (2026)][chuang-bell-tseng-baayen-2026]
+* [S. Gahl and R. H. Baayen, *Time and thyme again* (2024)][gahl-baayen-2024]
+* [J. Fon, *A preliminary construction of Taiwan Southern Min spontaneous speech corpus*
+  (2004)][fon-2004]
+* [Y. Xu, *Contextual tonal variations in Mandarin* (1997)][xu-1997]
 -/
 
 namespace LuChuangBaayen2026
 
-open Processing.Lexical.Discriminative
-open ChuangEtAl2026
+open Processing.Lexical.Discriminative ChuangEtAl2026
 
-/-! ### Substrate import + paper-specific instantiation -/
+/-- The paper samples 100 f0 values per token in normalized time, centered and scaled per
+token (§4.1). -/
+abbrev PitchSampleCount : ℕ := 100
 
-/-- The paper uses 100 evenly-spaced f0 samples per token (paper §4.1).
-    Distinct from [chuang-bell-tseng-baayen-2026]'s 50; the
-    `FormVec` substrate is dimension-polymorphic so both fit. -/
-abbrev LuPitchSampleCount : ℕ := 100
+/-- A pitch contour at the paper's resolution. -/
+abbrev PitchVector : Type := FormVec PitchSampleCount
 
-/-- Pitch contour at the paper's chosen sampling resolution. -/
-abbrev LuPitchContour : Type := FormVec LuPitchSampleCount
+/-- The paper's DLM: 100-sample pitch vectors from the 768-dimensional CKIP GPT-2
+contextualized embeddings of [chuang-bell-tseng-baayen-2026] (§4.2). -/
+abbrev TaiwanMandarinDLM : Type := LinearDiscriminativeLexicon ℝ PitchVector ContextualEmbedding
 
-/-- The paper's specific DLM instantiation: 100-dim pitch vectors,
-    768-dim contextualised embeddings (`CKIPGPT2HiddenDim` reused from
-    `ChuangEtAl2026`). The substrate type
-    `LinearDiscriminativeLexicon` is in
-    `Processing/Lexical/Discriminative/Defs.lean`. -/
-abbrev LuTaiwanMandarinDLM : Type :=
-  LinearDiscriminativeLexicon ℝ LuPitchContour ContextualEmbedding
+variable {ι V : Type*} [AddCommGroup V] [Module ℝ V]
 
-/-! ### The 20 disyllabic tone patterns -/
+/-- The centroid of a finite family of vectors: their mean (§4.4). -/
+noncomputable def centroid (P : Finset ι) (v : ι → V) : V := (P.card : ℝ)⁻¹ • ∑ i ∈ P, v i
 
-/-- The 20 disyllabic tone patterns of Mandarin (paper Table 1).
-    Enumerated as the row-major Cartesian-product list of
-    {T1, T2, T3, T4} (full lexical tones) on the first syllable with
-    {T1, T2, T3, T4, T0} (full + neutral) on the second.
+/-- A production map sends a centroid of embeddings to the centroid of the predicted contours:
+average contours correspond to average embeddings (§4.5). -/
+theorem production_centroid (D : TaiwanMandarinDLM) (P : Finset ι)
+    (s : ι → ContextualEmbedding) :
+    D.production (centroid P s) = centroid P fun i => D.production (s i) := by
+  simp [centroid, map_sum]
 
-    The neutral tone (T0) appears only on the second syllable in this
-    paradigm; mono-T0 disyllables are not analysed. The structural fact
-    20 = 4 × 5 is by enumeration here, not by a typeclass. -/
-inductive TonePattern20 where
-  | T1_T1 | T1_T2 | T1_T3 | T1_T4 | T1_T0
-  | T2_T1 | T2_T2 | T2_T3 | T2_T4 | T2_T0
-  | T3_T1 | T3_T2 | T3_T3 | T3_T4 | T3_T0
-  | T4_T1 | T4_T2 | T4_T3 | T4_T4 | T4_T0
-  deriving DecidableEq, Repr
-
-/-! ### Tone sandhi neutralization as DLM kernel application -/
-
-/-- **T3 tone sandhi neutralization via DLM kernel**.
-
-    The classical phonological rule "T3 → T2 / __ T3" stipulates that
-    underlying `/T3 T3/` surfaces as `[T2 T3]`. Within the DLM, this
-    surface coincidence is **derived**, not stipulated: if the CE
-    centroids of T3-T3 and T2-T3 word tokens differ by an element of
-    the production map's kernel, then their predicted pitch contours
-    coincide.
-
-    The paper (§5) reports that for Taiwan Mandarin this kernel
-    condition holds empirically — complete neutralization. For
-    Standard Chinese the kernel condition holds only approximately,
-    consistent with the literature's report that T3 sandhi
-    neutralization is incomplete in Standard Chinese.
-
-    The specific patterns `T3_T3` and `T2_T3` are **load-bearing in
-    the type signature**: the theorem witnesses the paper's specific
-    empirical claim, not a generic two-pattern claim. The body is the
-    kernel characterisation `LinearMap.sub_mem_ker_iff`. -/
-theorem t3_sandhi_via_kernel
-    (D : LuTaiwanMandarinDLM)
-    (centroidOf : TonePattern20 → ContextualEmbedding)
-    (h_kernel :
-      centroidOf .T3_T3 - centroidOf .T2_T3 ∈ LinearMap.ker D.production) :
-    D.production (centroidOf .T3_T3) = D.production (centroidOf .T2_T3) :=
-  LinearMap.sub_mem_ker_iff.mp h_kernel
-
-/-- **Quantitative refinement of `t3_sandhi_via_kernel`.** The exact-
-    kernel hypothesis is the limiting case; in real data the centroid
-    difference is *small but non-zero*. Lipschitz continuity bounds
-    the resulting contour difference by `‖production‖ * ε` whenever
-    the centroid difference is within ε.
-
-    The empirical content of [lu-chuang-baayen-2026] §5 is that
-    for Taiwan Mandarin the trained `‖production‖` and the centroid
-    distance are both small enough that the contour bound is
-    consistent with the reported "essentially identical" surface
-    realizations. For Standard Chinese the bound permits visible
-    contour difference, matching the reported incomplete neutralization.
-
-    Lipschitz application of `LinearDiscriminativeLexicon.norm_production_sub_le`. -/
-theorem t3_sandhi_quantitative
-    (D : LuTaiwanMandarinDLM)
-    (centroidOf : TonePattern20 → ContextualEmbedding) {ε : ℝ}
-    (h : ‖centroidOf .T3_T3 - centroidOf .T2_T3‖ ≤ ε) :
-    ‖D.production (centroidOf .T3_T3) - D.production (centroidOf .T2_T3)‖ ≤
-      ‖D.production.toContinuousLinearMap‖ * ε :=
-  D.norm_production_sub_le h
-
-/-! ### Dialect flexibility via different production maps -/
-
-/-- The "broadcast coordinate `i`" linear map `e ↦ fun _ => e i`, a non-degenerate witness. -/
-def broadcast {n d : ℕ} (i : Fin d) : MeaningVec d →ₗ[ℝ] FormVec n :=
-  LinearMap.pi fun _ => LinearMap.proj i
-
-@[simp] theorem broadcast_apply {n d : ℕ} (i : Fin d) (e : MeaningVec d) (j : Fin n) :
-    broadcast i e j = e i := rfl
-
-/-- **DLMs accommodate dialect variation in neutralization without
-    rule modification.** The same `LinearDiscriminativeLexicon`
-    architecture supports both complete neutralization (Taiwan Mandarin:
-    T3-T3 surface = T2-T3 surface) and incomplete neutralization
-    (Standard Chinese: T3-T3 differs subtly from T2-T3) by varying *the
-    production map's kernel*, not by introducing a separate sandhi
-    rule.
-
-    Witness: the all-zero DLM has every `MeaningVec` mapping to the
-    zero contour — every meaning pair is "neutralized" (degenerate
-    Taiwan-Mandarin extreme); a DLM with the non-degenerate `broadcast`
-    production map distinguishes the same pair (Standard-Chinese-like
-    extreme). The architectural point survives the witness's simplicity:
-    a SINGLE `LinearDiscriminativeLexicon` type accommodates both
-    regimes; only the trained weights differ.
-
-    Cross-framework significance: a rule-based account requires
-    dialect-specific rule modification (or stochastic optionality) to
-    handle this variation. The DLM accommodates it without any
-    framework-level move. -/
-theorem dlm_dialect_flexibility :
-    ∃ (D₁ D₂ : LuTaiwanMandarinDLM) (e₁ e₂ : ContextualEmbedding),
-      D₁.production e₁ = D₁.production e₂ ∧
-      D₂.production e₁ ≠ D₂.production e₂ := by
-  refine ⟨⟨0, 0⟩, ⟨0, broadcast 0⟩, 0, Pi.single 0 1, rfl, fun h => ?_⟩
-  have h0 := congrFun h 0
-  simp only [broadcast_apply, Pi.zero_apply, Pi.single_eq_same] at h0
-  exact zero_ne_one h0
-
-/-! ### Empirical content (prose) -/
-
-/-! ### Methods + accuracies as paper-supplied empirical facts
-
-Per `CLAUDE.md` (Processing-scope guidance), specific numerical fits
-(R² values, AIC reductions, cross-validation accuracies) are out of
-scope as Lean theorems. They are recorded here as documented empirical
-findings with paper-section pointers.
-
-**Word emerges as crucial across all 20 tone patterns** (paper §3.4.1,
-Fig. 2, Table 4). Withholding the `word` factor smooth from the GAMM
-raises AIC by 7,269.27 to 12,345.54 across the four tonal contexts,
-substantially exceeding the AIC change for any other predictor
-including `tone_pattern`. When `word` is included, withholding
-`tone_pattern` raises AIC by only single- or low-double-digit units
-per context (paper §3.4.1) — `word` essentially subsumes `tone_pattern`.
-
-**Sense > word** (paper §3.4.2, Table 4). Adding `sense_type` on top
-of `tone_pattern` produces a substantial AIC reduction
-(−16,077.20 at 4.4, −10,541.88 at 3.4, −9,171.19 at 4.1, −7,895.57
-at 4.0; values from Table 4), exceeding the contribution of
-`word` alone. Replicates the headline sense-effect of
-[chuang-bell-tseng-baayen-2026] on the broader 20-pattern dataset.
-
-**DLM accuracy across three preprocessing methods** (paper §4.4):
-- Method I (per-token GAMMs): training 2.8% / test 1.4%
-- Method II (per-word-type GAMMs): training 23.5% / test 15.1% (**best**)
-- Method III (per-tonal-context GAMMs): training 12.0% / test 6.9%
-- Permutation baseline ≈ 0.4%; majority baseline ≈ 1.3%.
-
-**Form–meaning isomorphism across all 20 tone patterns** (paper §4.4,
-Fig. 9, Fig. 10). Cosine similarity / Pearson correlation /
-Euclidean distance between GAMM-derived gold-standard contours and
-DLM-predicted contours, respectively for methods I, II, III:
-- Method I:   cosine 0.73 / corr 0.85 / dist 1.24
-- Method II:  cosine 0.93 / corr 0.98 / dist 1.50
-- Method III: cosine 0.82 / corr 0.96 / dist 1.09
-
-Method II wins on cosine and correlation; loses (slightly) on
-Euclidean distance. Boxplot of the three measures across methods:
-paper Fig. 10.
-
-**Comparison to lab speech** (paper §5, Fig. 11). The DLM-derived
-contours from spontaneous Taiwan Mandarin closely match [xu-1997]'s
-lab-speech contours for most tone patterns (T4-T4, T2-T3, T2-T4 nearly
-identical); some patterns (T1-T1, T1-T2) differ visibly, attributed
-to dialect (Beijing vs. Taiwan Mandarin) and register (lab vs.
-spontaneous) effects.
-
-### Implications recorded in the paper's discussion
-
-- **Word-and-paradigm sufficiency** (paper §5): the DLM does not need
-  abstract phonological units (syllable, segment, tone) to predict
-  pitch realisation — meaning vectors → pitch vectors directly. This
-  aligns with [heitmeier-chuang-baayen-2026]'s W&P framing of
-  the DLM and challenges item-and-arrangement architectures that
-  presuppose stored sub-word inventories.
-- **Anti-arbitrariness of the sign** (paper §5): the linear meaning→form
-  mapping generalises to held-out data, falsifying the axiom that
-  the form–meaning relation is fundamentally arbitrary.
-- **Anti-dual-articulation** (paper §5, also [chuang-bell-tseng-baayen-2026]):
-  the same DLM architecture exhibits isomorphism between phonetic
-  form-space and contextualised meaning-space, undermining the
-  assumption that form and meaning are orthogonal grammar modules.
-- **Tone sandhi as kernel-emergence**: see §3 (`t3_sandhi_via_kernel`).
-- **Dialect variation as kernel variation**: see §4 (`dlm_dialect_flexibility`).
-- **Beyond Mandarin**: paper §5 cites preliminary results
-  ([chuang-bell-tseng-baayen-2026] discussion) that English
-  two-syllable words also exhibit word-specific pitch components,
-  suggesting form-meaning isomorphism is not a tone-language quirk. -/
+/-- **Centroids under least squares** (§4.4, Fig. 9): if membership in a set `P` of training
+tokens is a linear functional of their embeddings, a least-squares-trained production map sends
+the centroid of `P`'s embeddings exactly to the centroid of `P`'s target contours. -/
+theorem production_centroid_eq_of_decodable {m : ℕ} {D : TaiwanMandarinDLM}
+    {data : TrainingExperience m PitchSampleCount CKIPGPT2HiddenDim} (hD : D.IsELTrainedOn data)
+    {P : Finset (Fin m)} {w : ContextualEmbedding →ₗ[ℝ] ℝ}
+    (hw : ∀ i, w (data.meanings i) = if i ∈ P then 1 else 0) :
+    D.production (centroid P data.meanings) = centroid P data.forms := by
+  have h := IsERMSolution.sum_smul_sub_eq_zero hD w
+  simp only [Pi.one_apply, NNReal.coe_one, one_mul, hw, ite_smul, one_smul, zero_smul,
+    Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_sub_distrib, sub_eq_zero] at h
+  simp [centroid, map_sum, h]
 
 end LuChuangBaayen2026

--- a/references.bib
+++ b/references.bib
@@ -27534,9 +27534,9 @@
   sources   = {Studies/ChuangEtAl2026.lean;Studies/LuChuangBaayen2026.lean;Processing/Lexical/Discriminative/Defs.lean;Processing/Lexical/Discriminative/Normed.lean}
 }
 
-@unpublished{lu-chuang-baayen-2025,
+@unpublished{lu-chuang-baayen-2024,
   author    = {Lu, Yuxin and Chuang, Yu-Ying and Baayen, R. Harald},
-  year      = {2025},
+  year      = {2024},
   title     = {Form and meaning co-determine the realization of tone in {T}aiwan {M}andarin spontaneous speech: the case of tone 3 sandhi},
   note      = {arXiv:2408.15747},
   doi       = {10.48550/arXiv.2408.15747},
@@ -27544,6 +27544,19 @@
   role      = {cited},
   sources   = {Studies/LuChuangBaayen2026.lean}
 }
+
+@techreport{fon-2004,
+  author      = {Fon, Janice},
+  year        = {2004},
+  title       = {A preliminary construction of {Taiwan Southern Min} spontaneous speech corpus},
+  number      = {NSC-92-2411-H-003-050},
+  institution = {National Science Council},
+  address     = {Taiwan},
+  subfield    = {phonology},
+  role        = {cited},
+  sources     = {Studies/LuChuangBaayen2026.lean}
+}
+
 
 @article{lu-chuang-baayen-2026,
   author    = {Lu, Yuxin and Chuang, Yu-Ying and Baayen, R. Harald},
@@ -27646,29 +27659,6 @@
   subfield  = {processing},
   role      = {cited},
   sources   = {Studies/Saito2025.lean}
-}
-
-@book{chen-2000,
-  author    = {Chen, Matthew Y.},
-  year      = {2000},
-  title     = {Tone Sandhi: Patterns Across {C}hinese Dialects},
-  publisher = {Cambridge University Press},
-  address   = {Cambridge},
-  subfield  = {phonology},
-  role      = {cited},
-  sources   = {Studies/LuChuangBaayen2026.lean}
-}
-
-@book{duanmu-2007,
-  author    = {Duanmu, San},
-  year      = {2007},
-  title     = {The Phonology of Standard {C}hinese},
-  edition   = {2nd},
-  publisher = {Oxford University Press},
-  address   = {Oxford},
-  subfield  = {phonology},
-  role      = {cited},
-  sources   = {Studies/LuChuangBaayen2026.lean}
 }
 
 @article{xu-1997,


### PR DESCRIPTION
The old file's Lean content was not in the paper: a "T3 sandhi via kernel" tautology (hypothesis and conclusion related by an iff), a Lipschitz re-export with a Standard-Chinese story, a zero-map-versus-broadcast "dialect flexibility" witness, and an autosegmental contrast citing Chen 2000 and Duanmu 2007, none of which the paper mentions. What the paper derives is that a tone pattern's centroid embedding maps to a contour close to its GAMM contour (§4.4, Fig. 9). Rewritten around that: `production_centroid` (linearity) and `production_centroid_eq_of_decodable`, which shows a least-squares-trained map sends the centroid of any linearly decodable set of training tokens exactly to the mean of their target contours, via the new vector form of the normal equations `IsERMSolution.sum_smul_sub_eq_zero`.

- Bib: `lu-chuang-baayen-2025` → `lu-chuang-baayen-2024` (arXiv 2408.15747 was posted in 2024, as the paper cites it); `fon-2004` added; the uncited `chen-2000` and `duanmu-2007` removed.