### PR TITLE
refactor(Processing/Discriminative): cue coding as the book pads it

### DIFF
--- a/Linglib/Processing/Lexical/Discriminative/Coding.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Coding.lean
@@ -1,94 +1,67 @@
 import Linglib.Processing.Lexical.Discriminative.Defs
 import Linglib.Phonology.Subregular.Boundary
 import Linglib.Core.Data.List.Factors
+import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 
 /-!
 # Form and meaning coding for the DLM
-[heitmeier-chuang-baayen-2026]
 
-The interfaces by which linguistic objects feed the discriminative lexicon
-([heitmeier-chuang-baayen-2026] ch. 4-5). A `Linearizable` type yields a
-symbol string; its cues are the `k`-factors of the boundary-augmented
-string — the same windowing as subregular locality (`StrictlyLocalGrammar`)
-— and its form vector is the binary cue indicator (Box 4.2: the `C` matrix
-holds only 1s and 0s, not counts; the count refinement is where strict
-locality's unit margin lives, `StrictlyLocalGrammar`). A `SemanticPrimitives`
-type yields a multiset of atomic semantic primitives — a lexeme plus
-inflectional-function tags (the book's term, ch. 5) — and `conceptualize`
-builds its meaning vector as the sum of primitive embeddings: the book's
-additive decomposition (eq. 5.3) and its verb for the operation (§16.3).
+How linguistic objects feed the discriminative lexicon ([heitmeier-chuang-baayen-2026] ch. 4
+and 5). A form is a symbol string; its **cues** are the `n`-grams of the string padded with one
+boundary symbol on each side (`#a aa ap p#`, `#aa aap ap#`), and its row of the form matrix `C`
+is the multiple-hot indicator of those cues over the cue inventory (Box 4.2: `C` holds only 1s
+and 0s). The padding is one boundary symbol whatever the width, unlike the `k − 1` of strictly
+local grammars (`boundary`), so DLM trigrams are not the 3-factors of subregular phonology. A
+meaning is a multiset of atomic **semantic primitives**, a lexeme and its inflectional functions,
+and **conceptualization** builds its vector as the sum of the primitives' vectors (eq. 5.3): a
+novel inflected word is conceptualized from known primitives (eq. 5.5, §16.3). Conceptualization
+is additive in the multiset by construction, which is what makes a linear mapping respect
+proportional analogy (`Studies/HeitmeierChuangBaayen2026`).
 
-`conceptualize_analogy` is the general form of proportional analogy: a
-linear map respects every multiset-level relation among primitive
-decompositions. The stem-exponent fourth proportional of
-`Studies/HeitmeierChuangBaayen2026` is the two-primitive case.
+## Main declarations
+
+- `cues k w`: the `k`-gram cues of the string `w`.
+- `multiHot inv p`: the indicator row of the units satisfying `p` over an inventory `inv`.
+- `cueVector k inv w`: the row of `C` for `w`.
+- `conceptualize emb`: the additive map from primitive multisets to meaning vectors.
+
+## References
+
+* [M. Heitmeier, Y.-Y. Chuang and R. H. Baayen, *The Discriminative Lexicon*
+  (2026)][heitmeier-chuang-baayen-2026]
 -/
 
 namespace Processing.Lexical.Discriminative
 
-
+variable {Sym : Type*}
 
 /-! ### Form side -/
 
-/-- A form type that linearizes to a symbol string — the domain of the
-    DLM's cue coding. -/
-class Linearizable (W : Type*) (Sym : outParam Type*) where
-  symbols : W → List Sym
+/-- The `k`-gram cues of a form: the `k`-factors of the string padded with one boundary symbol
+on each side, JudiLing's `make_cue_matrix` with `grams = k`. -/
+def cues (k : ℕ) (w : List Sym) : List (Augmented Sym) := (boundary 2 w).kFactors k
 
-instance {α : Type*} : Linearizable (List α) α := ⟨id⟩
+/-- The multiple-hot row over an inventory `inv` of the units satisfying `p`. -/
+def multiHot {N : ℕ} {α : Type*} (inv : Fin N → α) (p : α → Prop) [DecidablePred p] :
+    Fin N → ℝ :=
+  fun j => if p (inv j) then 1 else 0
 
-variable {W Sym : Type*} [Linearizable W Sym]
-
-/-- The `k`-gram cues of a form: `k`-factors of the boundary-augmented
-    symbol string. -/
-def cues (k : ℕ) (w : W) : List (Augmented Sym) :=
-  List.kFactors k (boundary k (Linearizable.symbols w))
-
-/-- The binary cue-indicator vector over a fixed cue inventory. -/
-def cueVector [DecidableEq Sym] (k : ℕ) {N : ℕ} (inv : Fin N → Augmented Sym)
-    (w : W) : FormVec N :=
-  fun j => if inv j ∈ cues k w then 1 else 0
-
-/-- A lexicon is **discriminable** at width `k` when cue coding separates
-    its forms; failures are homographs
-    ([heitmeier-chuang-baayen-2026] ch. 7). -/
-def Discriminable (k : ℕ) (lexicon : Set W) : Prop :=
-  Set.InjOn (cues (Sym := Sym) k) lexicon
+/-- The row of the form matrix `C` for the form `w`: the indicator of its cues over the cue
+inventory. -/
+def cueVector [DecidableEq Sym] (k : ℕ) {N : ℕ} (inv : Fin N → Augmented Sym) (w : List Sym) :
+    FormVec N :=
+  multiHot inv (· ∈ cues k w)
 
 /-! ### Meaning side -/
 
-/-- A meaning type with atomic semantic primitives — a lexeme and
-    inflectional-function tags. -/
-class SemanticPrimitives (M : Type*) (Prim : outParam Type*) where
-  primitives : M → Multiset Prim
+variable {Prim V : Type*} [AddCommMonoid V]
 
-export SemanticPrimitives (primitives)
+/-- **Conceptualization**: the meaning vector of a multiset of semantic primitives is the sum of
+the primitives' vectors, additive in the multiset. -/
+def conceptualize (emb : Prim → V) : Multiset Prim →+ V :=
+  Multiset.sumAddMonoidHom.comp (Multiset.mapAddMonoidHom emb)
 
-variable {M Prim : Type*} [SemanticPrimitives M Prim] {d n : ℕ}
-
-/-- **Conceptualization**: the meaning vector of an object is the sum of its
-    primitives' vectors. -/
-def conceptualize (emb : Prim → MeaningVec d) (m : M) : MeaningVec d :=
-  ((primitives m).map emb).sum
-
-theorem conceptualize_add_of_primitives_add (emb : Prim → MeaningVec d)
-    {m₁ m₂ m₃ m₄ : M}
-    (h : primitives m₁ + primitives m₂ = primitives m₃ + primitives m₄) :
-    conceptualize emb m₁ + conceptualize emb m₂
-      = conceptualize emb m₃ + conceptualize emb m₄ := by
-  unfold conceptualize
-  rw [← Multiset.sum_add, ← Multiset.map_add, h, Multiset.map_add,
-      Multiset.sum_add]
-
-/-- **Generic proportional analogy**: any linear map respects every
-    multiset-level relation among primitive decompositions. The
-    stem-exponent fourth proportional is the case
-    `{lex, PL} + {lex', SG} = {lex, SG} + {lex', PL}`. -/
-theorem conceptualize_analogy (emb : Prim → MeaningVec d)
-    (G : MeaningVec d →ₗ[ℝ] FormVec n) {m₁ m₂ m₃ m₄ : M}
-    (h : primitives m₁ + primitives m₂ = primitives m₃ + primitives m₄) :
-    G (conceptualize emb m₁) + G (conceptualize emb m₂)
-      = G (conceptualize emb m₃) + G (conceptualize emb m₄) := by
-  rw [← map_add, conceptualize_add_of_primitives_add emb h, map_add]
+@[simp] theorem conceptualize_apply (emb : Prim → V) (ps : Multiset Prim) :
+    conceptualize emb ps = (ps.map emb).sum := rfl
 
 end Processing.Lexical.Discriminative

--- a/Linglib/Studies/GahlBaayen2024.lean
+++ b/Linglib/Studies/GahlBaayen2024.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.LinearAlgebra.Matrix.Symmetric
+import Linglib.Processing.Lexical.Discriminative.Coding
 import Linglib.Processing.Lexical.Discriminative.Training
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.LinearAlgebra.Matrix.Notation
@@ -62,12 +63,37 @@ noncomputable section
 
 /-! ### The toy lexicon -/
 
+/-- The phones of the toy lexicon, `i` standing for the paper's `ɪ`; the diphthong is written as
+the two phones `a ɪ` (§2.3). -/
+inductive Phone
+  | t | l | a | i | m
+  deriving DecidableEq
+
+/-- The toy words as phone strings, *time*, *lime*, *thyme*; the homophones share a string. -/
+def word : Fin 3 → List Phone := ![[.t, .a, .i, .m], [.l, .a, .i, .m], [.t, .a, .i, .m]]
+
+/-- The six triphones of (2) in the paper's column order `#ta taɪ aɪm ɪm# #la laɪ`. -/
+def triphone : Fin 6 → Augmented Phone :=
+  ![[none, some .t, some .a], [some .t, some .a, some .i], [some .a, some .i, some .m],
+    [some .i, some .m, none], [none, some .l, some .a], [some .l, some .a, some .i]]
+
+/-- The rows of the form matrix `C` of (2): each word's triphone indicator, the DLM's cue coding
+at width 3 (`cueVector`). -/
+def toyForms (i : Fin 3) : FormVec 6 := cueVector 3 triphone (word i)
+
+/-- The form matrix as the paper prints it. -/
+theorem toyForms_eq :
+    toyForms = ![![1, 1, 1, 1, 0, 0], ![0, 0, 1, 1, 1, 1], ![1, 1, 1, 1, 0, 0]] := by
+  funext i j
+  fin_cases i <;> fin_cases j <;>
+    simp +decide [toyForms, cueVector, multiHot, Matrix.cons_val_two]
+
 /-- The toy lexicon of §2.3: the semantic matrix `S` of (1), rows *time*, *lime*, *thyme* over
-two arbitrary semantic dimensions (`0.1 0.3; 0.6 0.2; 1.1 0.6`), and the binary triphone matrix
-`C` of (2), columns `#ta taɪ aɪm ɪm# #la laɪ`. *time* and *thyme* share a form row. -/
+two arbitrary semantic dimensions (`0.1 0.3; 0.6 0.2; 1.1 0.6`), and the triphone matrix `C`
+of (2). *time* and *thyme* share a form row. -/
 def toy : TrainingExperience 3 6 2 where
   meanings := ![![1 / 10, 3 / 10], ![6 / 10, 2 / 10], ![11 / 10, 6 / 10]]
-  forms := ![![1, 1, 1, 1, 0, 0], ![0, 0, 1, 1, 1, 1], ![1, 1, 1, 1, 0, 0]]
+  forms := toyForms
 
 /-- *time*, the first row of the toy lexicon. -/
 abbrev time : Fin 3 := 0
@@ -112,7 +138,7 @@ equations (A2) hold. -/
 theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy := by
   refine isERMSolution_iff_forall_coord.mpr fun j k => ?_
   fin_cases j <;> fin_cases k <;>
-    norm_num [toy, endstate, endstateG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct,
+    norm_num [toy, toyForms_eq, endstate, endstateG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct,
       Fin.sum_univ_succ]
 
 /-- The frequency-informed mapping is the substrate's ERM solution under `freq`: the
@@ -120,7 +146,7 @@ theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy := by
 theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy freq := by
   refine isERMSolution_iff_forall_coord.mpr fun j k => ?_
   fin_cases j <;> fin_cases k <;>
-    norm_num [toy, freq, frequencyInformed, frequencyInformedG, Matrix.toLin'_apply,
+    norm_num [toy, toyForms_eq, freq, frequencyInformed, frequencyInformedG, Matrix.toLin'_apply,
       Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
 /-! ### Semantic support for form -/
@@ -144,7 +170,7 @@ theorem supportMatrix_endstate :
       (1181 : ℝ)⁻¹ • !![4080, 906, 4080; 1120, 1916, 1120; 5460, 4026, 5460] := by
   ext i k
   fin_cases i <;> fin_cases k <;>
-    norm_num [supportMatrix, semSupWord, toy, endstate, endstateG, Matrix.toLin'_apply,
+    norm_num [supportMatrix, semSupWord, toy, toyForms_eq, endstate, endstateG, Matrix.toLin'_apply,
       Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
 /-- Table 1, endstate column: `3.455, 1.622, 4.623`. -/
@@ -177,7 +203,7 @@ theorem semanticSupport_frequencyInformed :
     semanticSupport frequencyInformed toy = (16543 : ℝ)⁻¹ • ![65850, 52132, 102972] := by
   ext i
   fin_cases i <;>
-    norm_num [semanticSupport, supportMatrix, semSupWord, toy, frequencyInformed,
+    norm_num [semanticSupport, supportMatrix, semSupWord, toy, toyForms_eq, frequencyInformed,
       frequencyInformedG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
 /-- Table 1, frequency-informed column: `39.805, 9.965, 6.225`. -/
@@ -202,7 +228,8 @@ their meaning difference lies outside the production kernel, the neutralization 
 theorem time_sub_thyme_notMem_ker :
     toy.meanings time - toy.meanings thyme ∉ LinearMap.ker endstate.production := fun h => by
   have := congrFun (LinearMap.sub_mem_ker_iff.mp h) 0
-  norm_num [toy, endstate, endstateG, time, thyme, Matrix.cons_val_two, Matrix.toLin'_apply,
+  norm_num [toy, toyForms_eq, endstate, endstateG, time, thyme, Matrix.cons_val_two,
+    Matrix.toLin'_apply,
     Matrix.mulVec, dotProduct, Fin.sum_univ_succ] at this
 
 /-! ### Contextual independence

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -112,21 +112,16 @@ theorem not_isAnalogicallyRegular_of_xor {f : Bool → Bool → FormVec n}
 
 /-! ### The coding interface
 
-The stem-exponent setting is the two-primitive case of the DLM coding
-interface: a paradigm cell's semantic primitives are its stem and cell
-tags, and conceptualization over `Sum.elim σ ε` is the imputed additive
-semantics. The fourth proportional above is `conceptualize_analogy` at the
-multiset relation `{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
+The stem-exponent setting is the two-primitive case of the DLM coding interface: a paradigm
+cell's semantic primitives are its stem and cell tags, and conceptualization over
+`Sum.elim σ ε` is the imputed additive semantics. Proportional analogy is the additivity of
+`conceptualize` at the multiset relation `{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
 
-instance : SemanticPrimitives (Stem × Cell) (Stem ⊕ Cell) :=
-  ⟨fun p => {Sum.inl p.1, Sum.inr p.2}⟩
-
-@[simp] theorem primitives_pair (st : Stem) (c : Cell) :
-    primitives (Prim := Stem ⊕ Cell) (st, c) = {Sum.inl st, Sum.inr c} := rfl
-
-theorem conceptualize_sumElim (st : Stem) (c : Cell) :
-    conceptualize (Sum.elim σ ε) (st, c) = σ st + ε c := by
-  simp [conceptualize]
+/-- Conceptualizing a paradigm cell from its stem and cell primitives is the imputed additive
+semantics. -/
+@[simp] theorem conceptualize_pair (st : Stem) (c : Cell) :
+    conceptualize (Sum.elim σ ε) {Sum.inl st, Sum.inr c} = σ st + ε c := by
+  simp
 
 variable [Fintype Stem] [Fintype Cell]
 
@@ -134,8 +129,9 @@ variable [Fintype Stem] [Fintype Cell]
     meanings, the form table as the targets. -/
 noncomputable def paradigmExperience (f : Stem → Cell → FormVec n) :
     TrainingExperience (Fintype.card (Stem × Cell)) n d where
-  meanings i := σ ((Fintype.equivFin (Stem × Cell)).symm i).1
-      + ε ((Fintype.equivFin (Stem × Cell)).symm i).2
+  meanings i := conceptualize (Sum.elim σ ε)
+    {Sum.inl ((Fintype.equivFin (Stem × Cell)).symm i).1,
+      Sum.inr ((Fintype.equivFin (Stem × Cell)).symm i).2}
   forms i := f ((Fintype.equivFin (Stem × Cell)).symm i).1
       ((Fintype.equivFin (Stem × Cell)).symm i).2
 

--- a/references.bib
+++ b/references.bib
@@ -27531,7 +27531,7 @@
   doi       = {10.1017/9781009634564},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Studies/ChuangEtAl2026.lean;Studies/LuChuangBaayen2026.lean;Processing/Lexical/Discriminative/Defs.lean;Processing/Lexical/Discriminative/Normed.lean}
+  sources   = {Studies/ChuangEtAl2026.lean;Studies/LuChuangBaayen2026.lean;Processing/Lexical/Discriminative/Defs.lean;Processing/Lexical/Discriminative/Normed.lean;Processing/Lexical/Discriminative/Coding.lean;Processing/Lexical/Discriminative/Training.lean;Studies/HeitmeierChuangBaayen2026.lean}
 }
 
 @unpublished{lu-chuang-baayen-2024,


### PR DESCRIPTION
`Coding.lean` against Heitmeier, Chuang and Baayen's book (ch. 4, 5, 7, 16; all its locators check out). One bug: `cues` used the subregular `boundary k`, which pads `k − 1` boundary symbols, while JudiLing pads a single `#` per side at every n-gram width (`#aa aap ap#`), so DLM triphones were emitting `##a`-style cues that neither the book nor the Gahl–Baayen toy has. Fixed, and the docstring now says DLM trigrams are not strictly-local 3-factors.

- Cut the consumer-less `Linearizable` and `SemanticPrimitives` classes and `Discriminable`; `conceptualize emb` is the bundled additive map `Multiset Prim →+ V`, so proportional analogy is `map_add`; `multiHot` is the Box 4.2 indicator row.
- Consumers: the Gahl–Baayen toy's form matrix is now computed from its phone strings by `cueVector` (the paper's own recipe) and shown equal to the printed matrix; the Heitmeier paradigm experience conceptualizes its cells.