### PR TITLE
refactor(Studies): derive the DLM mappings from the closed-form normal equations

### DIFF
--- a/Linglib/Processing/Lexical/Discriminative/Training.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Training.lean
@@ -3,6 +3,7 @@ import Linglib.Processing.Lexical.Discriminative.Measures
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.LinearAlgebra.Matrix.DotProduct
 import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 
 /-!
 # DLM training: endstate and frequency-informed learning
@@ -26,6 +27,8 @@ experience ([heitmeier-2024]).
   coordinates, and in vector form.
 * `IsERMSolution.apply_meanings_eq`, `apply_eq_of_mem_span`, `exists_apply_ne`,
   `existsUnique_isERMSolution_iff`: fitted values are unique exactly on the span of experience.
+* `isERMSolution_toLin'_transpose_iff`, `isERMSolution_closedForm`: the normal equations as
+  `SᵀQ(SG − C) = 0` and their closed form `(SᵀQS)⁻¹SᵀQC`.
 * `isELSolution_sqrtScale_iff`: FIL under `q` is EL on `TrainingExperience.sqrtScale`.
 * `LinearDiscriminativeLexicon.IsTrainedOn` and the `semSup` transfer theorems.
 
@@ -43,7 +46,7 @@ namespace Processing.Lexical.Discriminative
 
 noncomputable section
 
-open NNReal RealInnerProductSpace
+open Matrix NNReal RealInnerProductSpace
 
 variable {m n d : ℕ}
 
@@ -327,13 +330,76 @@ theorem IsERMSolution.coord_eq_of_decodable (hq : ∀ i, 0 < q i) (hG : IsERMSol
     · exact (sub_eq_zero.1 h1).symm
     · exact sub_eq_zero.1 h1
 
+/-! ### The normal equations in matrix form
+
+The papers state the training problem on matrices: the semantic matrix `S` and form matrix `C`
+have the experienced meanings and forms as rows, the frequency vector is the diagonal of `Q`, and
+a mapping matrix `G` acts on row vectors, `ĉ = sG`. The normal equations read `SᵀQ(SG − C) = 0`,
+solved in closed form as `G = (SᵀQS)⁻¹SᵀQC` whenever `SᵀQS` is invertible ([gahl-baayen-2024]
+(A2), (A4); [heitmeier-chuang-baayen-2026] §6.1, §6.3). -/
+
+variable (data q)
+
+/-- The semantic matrix `S`: the experienced meanings as rows. -/
+def TrainingExperience.S : Matrix (Fin m) (Fin d) ℝ := Matrix.of fun i k => data.meanings i k
+
+/-- The form matrix `C`: the observed forms as rows. -/
+def TrainingExperience.C : Matrix (Fin m) (Fin n) ℝ := Matrix.of fun i j => data.forms i j
+
+/-- The weight matrix `Q`: the frequency vector on the diagonal. -/
+def FrequencyVector.Q : Matrix (Fin m) (Fin m) ℝ := Matrix.diagonal fun i => (q i : ℝ)
+
+@[simp] theorem TrainingExperience.S_apply (i : Fin m) (k : Fin d) :
+    data.S i k = data.meanings i k := rfl
+
+@[simp] theorem TrainingExperience.C_apply (i : Fin m) (j : Fin n) : data.C i j = data.forms i j :=
+  rfl
+
+@[simp] theorem FrequencyVector.Q_one : (1 : FrequencyVector m).Q = 1 := by
+  simp [FrequencyVector.Q]
+
+/-- The normal equations as a matrix identity: a mapping matrix `G`, acting on row vectors, is
+an ERM solution iff `SᵀQ(SG − C) = 0`. -/
+theorem isERMSolution_toLin'_transpose_iff (G : Matrix (Fin d) (Fin n) ℝ) :
+    IsERMSolution data q (Matrix.toLin' Gᵀ) ↔ data.Sᵀ * q.Q * (data.S * G - data.C) = 0 := by
+  rw [isERMSolution_iff_forall_coord]
+  have key : ∀ (j : Fin n) (k : Fin d), (data.Sᵀ * q.Q * (data.S * G - data.C)) k j =
+      ∑ i, q i * ((Matrix.toLin' Gᵀ (data.meanings i) j - data.forms i j) * data.meanings i k) := by
+    intro j k
+    have hsum : ∀ i, Matrix.toLin' Gᵀ (data.meanings i) j = ∑ l, data.meanings i l * G l j :=
+      fun i => by simp [Matrix.toLin'_apply, Matrix.mulVec, dotProduct, mul_comm]
+    rw [Matrix.mul_apply]
+    simp only [FrequencyVector.Q, Matrix.mul_diagonal, Matrix.transpose_apply,
+      TrainingExperience.S_apply]
+    simp only [Matrix.sub_apply, Matrix.mul_apply, TrainingExperience.S_apply,
+      TrainingExperience.C_apply, hsum]
+    exact Finset.sum_congr rfl fun i _ => by ring
+  constructor
+  · intro h
+    ext k j
+    rw [key, h, Matrix.zero_apply]
+  · intro h j k
+    rw [← key, h, Matrix.zero_apply]
+
+/-- **Closed form**: when `SᵀQS` is invertible, `G = (SᵀQS)⁻¹SᵀQC` solves the normal
+equations ([gahl-baayen-2024] (A2), (A4)). -/
+theorem isERMSolution_closedForm (hS : IsUnit (data.Sᵀ * q.Q * data.S)) :
+    IsERMSolution data q
+      (Matrix.toLin' ((data.Sᵀ * q.Q * data.S)⁻¹ * (data.Sᵀ * q.Q * data.C))ᵀ) := by
+  rw [isERMSolution_toLin'_transpose_iff, Matrix.mul_sub, ← Matrix.mul_assoc,
+    Matrix.mul_nonsing_inv_cancel_left _ _ ((Matrix.isUnit_iff_isUnit_det _).1 hS), sub_self]
+
+/-- The endstate closed form `G = (SᵀS)⁻¹SᵀC` ([gahl-baayen-2024] (A2)). -/
+theorem isELSolution_closedForm (hS : IsUnit (data.Sᵀ * data.S)) :
+    IsELSolution data (Matrix.toLin' ((data.Sᵀ * data.S)⁻¹ * (data.Sᵀ * data.C))ᵀ) := by
+  have := isERMSolution_closedForm data 1 (by simpa using hS)
+  simpa [IsELSolution] using this
+
 /-! ### √Q transport
 
 [gahl-baayen-2024]'s appendix computes FIL by solving the EL problem on `√Q`-premultiplied `S`
 and `C`; [heitmeier-2024] proves the equivalence with frequency-replicated data under
 invertibility. Here it holds at the level of ERM solution sets. -/
-
-variable (data q)
 
 /-- The `√q`-premultiplied training experience. -/
 def TrainingExperience.sqrtScale : TrainingExperience m n d where

--- a/Linglib/Studies/GahlBaayen2024.lean
+++ b/Linglib/Studies/GahlBaayen2024.lean
@@ -24,13 +24,14 @@ scope, and the paper derives nothing formal from its Pearson-correlation homopho
 
 What is stated is the paper's own toy lexicon *time, lime, thyme* (§2.3), worked through the
 substrate's training theory. The endstate map (4) and the frequency-informed map for token
-frequencies 100, 10, 1 (A3) are certified `IsELTrainedOn` and `IsFILTrainedOn` by the
-coordinate normal equations; the support matrix of (A6) and both columns of Table 1 come out
-exactly, the frequency-informed column being `√frequency` times the support the learned map
-alone gives, as it is the fitted value of the `√Q`-scaled regression; the homophones get
-distinct predicted forms from identical triphones (Fig. A2); and the word-to-word map of (6) is,
-exactly, the orthogonal projector onto the row space of `U`, whose diagonal therefore lies in
-`[0, 1]` and dominates its rows and columns as the paper observes.
+frequencies 100, 10, 1 (A3) are the closed forms `(SᵀS)⁻¹SᵀC` and `(SᵀQS)⁻¹SᵀQC` of the normal
+equations (A2), (A4), hence `IsELTrainedOn` and `IsFILTrainedOn`; the support matrix of (A6)
+and both columns of Table 1 come out exactly, the frequency-informed column being `√frequency`
+times the support the learned map alone gives, as it is the fitted value of the `√Q`-scaled
+regression; the homophones get distinct predicted forms from identical triphones (Fig. A2); and
+the word-to-word map of (6) is the pseudoinverse solution `Uᵀ(UUᵀ)⁻¹U` of `UW = U`, an
+orthogonal projector, whose diagonal therefore lies in `[0, 1]` and dominates its rows as the
+paper observes.
 
 ## Main results
 
@@ -112,42 +113,58 @@ def freq : FrequencyVector 3 := ![100, 10, 1]
 The paper fits only the production side of the model, so the comprehension maps below are left
 zero. Mapping matrices act on row vectors, `ĉ = sG` (10), so a production map is `toLin' Gᵀ`. -/
 
-/-- The endstate mapping `G` of (4), exactly: `(SᵀS)⁻¹SᵀC` of (A2), with
-`1181 = 10⁴ · det(SᵀS)`; the paper prints it to two decimals. -/
-def endstateG : Matrix (Fin 2) (Fin 6) ℝ :=
-  (1181 : ℝ)⁻¹ • !![-1410, -1410, -90, -90, 1320, 1320; 4500, 4500, 2800, 2800, -1700, -1700]
+/-- The endstate mapping `G` of (4): the closed form `(SᵀS)⁻¹SᵀC` of (A2). -/
+def endstateG : Matrix (Fin 2) (Fin 6) ℝ := (toy.Sᵀ * toy.S)⁻¹ * (toy.Sᵀ * toy.C)
+
+/-- (4) exactly, with `1181 = 10⁴ · det(SᵀS)`; the paper prints it to two decimals. -/
+theorem endstateG_eq :
+    endstateG = (1181 : ℝ)⁻¹ • !![-1410, -1410, -90, -90, 1320, 1320;
+      4500, 4500, 2800, 2800, -1700, -1700] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [endstateG, Matrix.inv_def, Ring.inverse_eq_inv', Matrix.adjugate_fin_two,
+      Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, toyForms_eq,
+      TrainingExperience.S, TrainingExperience.C]
 
 /-- The DLM at the endstate of learning. -/
 def endstate : LinearDiscriminativeLexicon ℝ (FormVec 6) (MeaningVec 2) where
   comprehension := 0
   production := Matrix.toLin' endstateGᵀ
 
-/-- The frequency-informed mapping, exactly: the solution of the `√Q`-scaled normal equations
-(A4) for the frequencies `freq`, with `16543 = 500 · det(SᵀQS)`. -/
+/-- The frequency-informed mapping: the closed form `(SᵀQS)⁻¹SᵀQC` of (A4) for the
+frequencies `freq`. -/
 def frequencyInformedG : Matrix (Fin 2) (Fin 6) ℝ :=
-  (16543 : ℝ)⁻¹ • !![-20190, -20190, 4230, 4230, 24420, 24420;
-    61920, 61920, 53150, 53150, -8770, -8770]
+  (toy.Sᵀ * freq.Q * toy.S)⁻¹ * (toy.Sᵀ * freq.Q * toy.C)
+
+/-- The frequency-informed mapping exactly, with `16543 = 500 · det(SᵀQS)`. -/
+theorem frequencyInformedG_eq :
+    frequencyInformedG = (16543 : ℝ)⁻¹ • !![-20190, -20190, 4230, 4230, 24420, 24420;
+      61920, 61920, 53150, 53150, -8770, -8770] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [frequencyInformedG, Matrix.inv_def, Ring.inverse_eq_inv', Matrix.adjugate_fin_two,
+      Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, toyForms_eq, freq,
+      TrainingExperience.S, TrainingExperience.C, FrequencyVector.Q, Matrix.diagonal]
 
 /-- The DLM after frequency-informed learning. -/
 def frequencyInformed : LinearDiscriminativeLexicon ℝ (FormVec 6) (MeaningVec 2) where
   comprehension := 0
   production := Matrix.toLin' frequencyInformedGᵀ
 
-/-- The endstate mapping is the substrate's uniform-weight ERM solution: the coordinate normal
-equations (A2) hold. -/
-theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy := by
-  refine isERMSolution_iff_forall_coord.mpr fun j k => ?_
-  fin_cases j <;> fin_cases k <;>
-    norm_num [toy, toyForms_eq, endstate, endstateG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct,
-      Fin.sum_univ_succ]
+/-- The endstate mapping is the uniform-weight ERM solution, by the closed form of the normal
+equations (A2): `SᵀS` is invertible. -/
+theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy :=
+  isELSolution_closedForm toy <| by
+    rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
+    norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, TrainingExperience.S]
 
-/-- The frequency-informed mapping is the substrate's ERM solution under `freq`: the
-`√Q`-scaled normal equations (A4) hold. -/
-theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy freq := by
-  refine isERMSolution_iff_forall_coord.mpr fun j k => ?_
-  fin_cases j <;> fin_cases k <;>
-    norm_num [toy, toyForms_eq, freq, frequencyInformed, frequencyInformedG, Matrix.toLin'_apply,
-      Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+/-- The frequency-informed mapping is the ERM solution under `freq`, by the closed form of the
+`√Q`-scaled normal equations (A4): `SᵀQS` is invertible. -/
+theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy freq :=
+  isERMSolution_closedForm toy freq <| by
+    rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
+    norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, freq,
+      TrainingExperience.S, FrequencyVector.Q, Matrix.diagonal]
 
 /-! ### Semantic support for form -/
 
@@ -170,8 +187,8 @@ theorem supportMatrix_endstate :
       (1181 : ℝ)⁻¹ • !![4080, 906, 4080; 1120, 1916, 1120; 5460, 4026, 5460] := by
   ext i k
   fin_cases i <;> fin_cases k <;>
-    norm_num [supportMatrix, semSupWord, toy, toyForms_eq, endstate, endstateG, Matrix.toLin'_apply,
-      Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+    norm_num [supportMatrix, semSupWord, toy, toyForms_eq, endstate, endstateG_eq,
+      Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
 /-- Table 1, endstate column: `3.455, 1.622, 4.623`. -/
 theorem semanticSupport_endstate :
@@ -204,7 +221,7 @@ theorem semanticSupport_frequencyInformed :
   ext i
   fin_cases i <;>
     norm_num [semanticSupport, supportMatrix, semSupWord, toy, toyForms_eq, frequencyInformed,
-      frequencyInformedG, Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
+      frequencyInformedG_eq, Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ]
 
 /-- Table 1, frequency-informed column: `39.805, 9.965, 6.225`. -/
 theorem semanticSupportFIL_eq :
@@ -228,9 +245,8 @@ their meaning difference lies outside the production kernel, the neutralization 
 theorem time_sub_thyme_notMem_ker :
     toy.meanings time - toy.meanings thyme ∉ LinearMap.ker endstate.production := fun h => by
   have := congrFun (LinearMap.sub_mem_ker_iff.mp h) 0
-  norm_num [toy, toyForms_eq, endstate, endstateG, time, thyme, Matrix.cons_val_two,
-    Matrix.toLin'_apply,
-    Matrix.mulVec, dotProduct, Fin.sum_univ_succ] at this
+  norm_num [toy, toyForms_eq, endstate, endstateG_eq, time, thyme, Matrix.cons_val_two,
+    Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ] at this
 
 /-! ### Contextual independence
 
@@ -253,8 +269,22 @@ def U : Matrix (Fin 5) (Fin 9) ℚ :=
      1, 0, 1, 0, 0, 0, 0, 1, 1;
      1, 0, 1, 0, 1, 0, 0, 1, 0]
 
-/-- The word-to-word map `W` of (6), exactly; the paper prints it to two decimals. -/
-def W : Matrix (Fin 9) (Fin 9) ℚ := (71 : ℚ)⁻¹ •
+/-- The word-to-word map `W` of (6): the pseudoinverse solution `Uᵀ(UUᵀ)⁻¹U` of `UW = U`
+((A8), (A9)), the orthogonal projector onto the row space of `U`. -/
+def W : Matrix (Fin 9) (Fin 9) ℚ := Uᵀ * (U * Uᵀ)⁻¹ * U
+
+/-- The inverse of the Gram matrix `UUᵀ`. -/
+private def gramInv : Matrix (Fin 5) (Fin 5) ℚ := (71 : ℚ)⁻¹ •
+  !![33, -20, -1, -15, 5;
+     -20, 53, -8, 22, -31;
+     -1, -8, 28, -6, 2;
+     -15, 22, -6, 52, -41;
+     5, -31, 2, -41, 61]
+
+private theorem inv_gram : (U * Uᵀ)⁻¹ = gramInv := Matrix.inv_eq_right_inv (by decide +kernel)
+
+/-- (6) exactly; the paper prints it to two decimals. -/
+theorem W_eq : W = (71 : ℚ)⁻¹ •
   !![41, 18, 10, 2, 12, 15, 15, 8, 12;
      18, 46, -6, 13, 7, -9, -9, -19, 7;
      10, -6, 44, 23, -4, -5, -5, 21, -4;
@@ -263,21 +293,22 @@ def W : Matrix (Fin 9) (Fin 9) ℚ := (71 : ℚ)⁻¹ •
      15, -9, -5, -1, -6, 28, 28, -4, -6;
      15, -9, -5, -1, -6, 28, 28, -4, -6;
      8, -19, 21, -10, 11, -4, -4, 31, 11;
-     12, 7, -4, -15, -19, -6, -6, 11, 52]
+     12, 7, -4, -15, -19, -6, -6, 11, 52] := by
+  rw [W, inv_gram]; decide +kernel
 
 /-- `W` solves the paper's equation `UW = U` (A8), exactly where the paper reports agreement
 "up to fifteen decimal digits". -/
-theorem U_mul_W : U * W = U := by decide +kernel
+theorem U_mul_W : U * W = U := by rw [W_eq]; decide +kernel
 
 /-- `W` is symmetric. -/
-theorem isSymm_W : W.IsSymm := by decide +kernel
+theorem isSymm_W : W.IsSymm := by rw [W_eq]; decide +kernel
 
 /-- `W` is idempotent: with symmetry, an orthogonal projector. -/
 theorem isIdempotentElem_W : IsIdempotentElem W := by
-  unfold IsIdempotentElem; decide +kernel
+  unfold IsIdempotentElem; rw [W_eq]; decide +kernel
 
 /-- The diagonal of `W` dominates its rows, as the paper observes of (6). -/
-theorem le_diag_W : ∀ i j, W i j ≤ W i i := by decide +kernel
+theorem le_diag_W : ∀ i j, W i j ≤ W i i := by rw [W_eq]; decide +kernel
 
 /-- The diagonal of `W` lies in `[0, 1]`, the "proportions" of §3.2, because `W` is an
 orthogonal projector. -/

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -3,27 +3,38 @@ import Linglib.Processing.Lexical.Discriminative.Training
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
-# Heitmeier, Chuang & Baayen (2026): linearity and regularity
-[heitmeier-chuang-baayen-2026]
+# Heitmeier, Chuang and Baayen 2026: linearity and regularity
 
-The relation between morphological regularity and linearity of the
-form-meaning mapping (§16.6, Table 16.2), for paradigms with **imputed
-additive semantics** — word meaning as stem vector plus exponent vector, the
-book's regularisation of embeddings for "truly regular" systems.
+The book's linear production maps handle inflectional systems with irregular forms: trained on
+empirical embeddings, its English past-tense model produces 94% of the regular and 74% of the
+irregular training verbs (§12.9). Meanings can instead be *constructed*, the meaning of *walked*
+as the meaning of *walk* plus a past-tense vector (Table 12.7; conceptualization is vector
+addition, eq. 5.3, §16.3), which regularizes a system into "a reasonable approximation of a truly
+regular system, and for such a system, linear mappings appear to work quite well" (§16.6,
+Table 16.2); but with the meanings of held-out verbs reconstructed this way, "none of the
+irregular verbs was produced correctly" (§12.9). This file states why. Over additive semantics a
+linear map's form table satisfies proportional analogy by construction, so a table violating
+analogy has no linear interpolant and forces positive training loss, and when stem and exponent
+vectors are jointly independent linear realisability is exactly analogy. Over word-specific
+embeddings, by contrast, any table is linearly realisable as soon as the embeddings are linearly
+independent, which fills the irregular-linear cell of Table 16.2. The English past tense at the
+book's letter-trigram coding (§12.9, `cueVector`) is the irregular table: *walk, walked* against
+*go, went*.
 
-* Linear maps satisfy **proportional analogy** by construction
-  (`isAnalogicallyRegular_comp`): an exponent's form shift is
-  stem-independent. Hence a table violating analogy (suppletion) has no
-  linear interpolant over additive semantics
-  (`not_exists_linear_of_not_regular`) — irregulars survive in a linear
-  system only through word-specific, non-additive semantic vectors, which is
-  how the book's linear models fit English past tense and Maltese plurals.
-* When stem and exponent vectors are jointly independent the converse holds
-  (`exists_linear_iff_isAnalogicallyRegular`): linear realisability *is*
-  analogical regularity.
-* Under ERM training on the paradigm (`paradigmExperience`), an irregular
-  table forces positive loss for every linear map
-  (`pos_weightedLoss_of_not_regular`).
+## Main results
+
+* `not_exists_linear_of_not_regular`, `pos_weightedLoss_of_not_regular`: an irregular table has
+  no linear interpolant over additive semantics and forces positive loss.
+* `exists_linear_iff_isAnalogicallyRegular`: over jointly independent stem and exponent vectors,
+  linear realisability is analogy.
+* `exists_linear_of_linearIndependent_words`: over independent word-specific embeddings every
+  table is linearly realisable.
+* `pastTense_not_regular`: *walk, walked, go, went* violates analogy.
+
+## References
+
+* [M. Heitmeier, Y.-Y. Chuang and R. H. Baayen, *The Discriminative Lexicon*
+  (2026)][heitmeier-chuang-baayen-2026]
 -/
 
 namespace HeitmeierChuangBaayen2026
@@ -32,120 +43,138 @@ open Processing.Lexical.Discriminative
 
 variable {d n : ℕ} {Stem Cell : Type*}
 
-/-- A paradigm's form table satisfies **proportional analogy** if the form
-    contrast between two cells is the same for every stem
-    (*cat : cats :: dog : dogs*). -/
+/-- A paradigm's form table satisfies **proportional analogy** if the form contrast between two
+cells is the same for every stem (*cat : cats :: dog : dogs*). -/
 def IsAnalogicallyRegular (f : Stem → Cell → FormVec n) : Prop :=
   ∀ st st' c c', f st c - f st c' = f st' c - f st' c'
 
+/-! ### Additive semantics -/
+
 variable (σ : Stem → MeaningVec d) (ε : Cell → MeaningVec d)
 
-/-- Under additive semantics, the form shift a linear map assigns to an
-    exponent is stem-independent. -/
-theorem map_add_sub_map (G : MeaningVec d →ₗ[ℝ] FormVec n) (st : Stem)
-    (c : Cell) : G (σ st + ε c) - G (σ st) = G (ε c) := by
-  rw [map_add]
-  abel
+/-- Conceptualizing a paradigm cell from its stem and cell primitives is the imputed additive
+semantics (eq. 5.3, Table 12.7). -/
+@[simp] theorem conceptualize_pair (st : Stem) (c : Cell) :
+    conceptualize (Sum.elim σ ε) {Sum.inl st, Sum.inr c} = σ st + ε c := by
+  simp
 
-/-- Every linear map's paradigm table over additive semantics is
-    analogically regular. -/
+/-- Every linear map's paradigm table over additive semantics is analogically regular: the form
+shift of an exponent is stem-independent. -/
 theorem isAnalogicallyRegular_comp (G : MeaningVec d →ₗ[ℝ] FormVec n) :
     IsAnalogicallyRegular fun st c => G (σ st + ε c) := fun st st' c c' => by
   simp only [map_add]
   abel
 
-/-- A table violating proportional analogy has no linear interpolant over
-    additive semantics. -/
+/-- A table violating proportional analogy has no linear interpolant over additive semantics:
+irregular forms cannot be produced from constructed meanings (§12.9). -/
 theorem not_exists_linear_of_not_regular {f : Stem → Cell → FormVec n}
     (hf : ¬ IsAnalogicallyRegular f) :
     ¬ ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c := by
   rintro ⟨G, hG⟩
   exact hf (by simpa only [hG] using isAnalogicallyRegular_comp σ ε G)
 
-/-- When stem and exponent vectors are jointly linearly independent, a
-    paradigm table is linearly realisable **iff** it is analogically
-    regular — over imputed additive semantics, linearity and regularity are
-    the same constraint. -/
-theorem exists_linear_iff_isAnalogicallyRegular [Nonempty Stem]
-    [Nonempty Cell] (hind : LinearIndependent ℝ (Sum.elim σ ε))
-    (f : Stem → Cell → FormVec n) :
-    (∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c)
-      ↔ IsAnalogicallyRegular f := by
-  constructor
-  · rintro ⟨G, hG⟩
-    simpa only [hG] using isAnalogicallyRegular_comp σ ε G
-  · intro hreg
-    obtain ⟨st₀⟩ := ‹Nonempty Stem›
-    obtain ⟨c₀⟩ := ‹Nonempty Cell›
-    obtain ⟨G, hG⟩ := LinearMap.exists_extend ((Module.Basis.span hind).constr ℝ
-      (Sum.elim (fun st => f st c₀) fun c => f st₀ c - f st₀ c₀))
-    have hb : ∀ x : Stem ⊕ Cell, G (Sum.elim σ ε x)
-        = Sum.elim (fun st => f st c₀) (fun c => f st₀ c - f st₀ c₀) x := by
-      intro x
-      have h1 := LinearMap.congr_fun hG (Module.Basis.span hind x)
-      rwa [LinearMap.comp_apply, Submodule.subtype_apply, Module.Basis.constr_basis,
-           Module.Basis.span_apply] at h1
-    refine ⟨G, fun st c => ?_⟩
-    have hσ : G (σ st) = f st c₀ := hb (Sum.inl st)
-    have hε : G (ε c) = f st₀ c - f st₀ c₀ := hb (Sum.inr c)
-    rw [map_add, hσ, hε, ← hreg st st₀ c c₀]
-    abel
+/-! ### Interpolation -/
 
-/-- Proportional analogy is the vanishing of second differences — the same
-    equation as the XOR obstruction of linear separability (§16.6's
-    hub-and-neighbour classification example): a table realising XOR on a
-    coordinate, `f ⊤ ⊤ = f ⊥ ⊥ ≠ f ⊤ ⊥ = f ⊥ ⊤`, violates analogy, so no
-    linear map over additive semantics produces it. Analogy, linear
-    separability, and absence of interaction terms are one constraint. -/
-theorem not_isAnalogicallyRegular_of_xor {f : Bool → Bool → FormVec n}
-    (hxor : f true true = f false false ∧ f true false = f false true)
-    (hne : f true true ≠ f true false) :
-    ¬ IsAnalogicallyRegular f := fun hreg => by
-  have h := hreg true false true false
-  rw [hxor.1, hxor.2] at h
-  have h0 : f false false = f false true := by
-    funext j
-    have hj := congrFun h j
-    simp only [Pi.sub_apply] at hj
-    linarith
-  exact hne ((hxor.1.trans h0).trans hxor.2.symm)
+/-- A linearly independent family of meanings can be sent anywhere by a linear map. -/
+theorem exists_linear_of_linearIndependent {ι : Type*} {v : ι → MeaningVec d}
+    (hv : LinearIndependent ℝ v) (w : ι → FormVec n) :
+    ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ i, G (v i) = w i := by
+  obtain ⟨G, hG⟩ := LinearMap.exists_extend ((Module.Basis.span hv).constr ℝ w)
+  refine ⟨G, fun i => ?_⟩
+  have h := LinearMap.congr_fun hG (Module.Basis.span hv i)
+  rwa [LinearMap.comp_apply, Submodule.subtype_apply, Module.Basis.constr_basis,
+    Module.Basis.span_apply] at h
 
-/-! ### The coding interface
+/-- Over word-specific, linearly independent embeddings any form table is linearly realisable,
+irregulars included: the irregular-linear cell of Table 16.2, the English past tense on empirical
+embeddings (§12.9). -/
+theorem exists_linear_of_linearIndependent_words {s : Stem → Cell → MeaningVec d}
+    (hs : LinearIndependent ℝ (Function.uncurry s)) (f : Stem → Cell → FormVec n) :
+    ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (s st c) = f st c :=
+  let ⟨G, hG⟩ := exists_linear_of_linearIndependent hs (Function.uncurry f)
+  ⟨G, fun st c => hG (st, c)⟩
 
-The stem-exponent setting is the two-primitive case of the DLM coding interface: a paradigm
-cell's semantic primitives are its stem and cell tags, and conceptualization over
-`Sum.elim σ ε` is the imputed additive semantics. Proportional analogy is the additivity of
-`conceptualize` at the multiset relation `{st, c} + {st', c'} = {st, c'} + {st', c}`. -/
+/-- When stem and exponent vectors are jointly linearly independent, a paradigm table is linearly
+realisable over additive semantics **iff** it is analogically regular: for a regularized system,
+linearity and regularity are the same constraint (§16.6). -/
+theorem exists_linear_iff_isAnalogicallyRegular [Nonempty Stem] [Nonempty Cell]
+    (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Stem → Cell → FormVec n) :
+    (∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c) ↔
+      IsAnalogicallyRegular f := by
+  refine ⟨fun ⟨G, hG⟩ => by simpa only [hG] using isAnalogicallyRegular_comp σ ε G,
+    fun hreg => ?_⟩
+  obtain ⟨st₀⟩ := ‹Nonempty Stem›
+  obtain ⟨c₀⟩ := ‹Nonempty Cell›
+  obtain ⟨G, hG⟩ := exists_linear_of_linearIndependent hind
+    (Sum.elim (fun st => f st c₀) fun c => f st₀ c - f st₀ c₀)
+  refine ⟨G, fun st c => ?_⟩
+  have hσ : G (σ st) = f st c₀ := hG (Sum.inl st)
+  have hε : G (ε c) = f st₀ c - f st₀ c₀ := hG (Sum.inr c)
+  rw [map_add, hσ, hε, ← hreg st st₀ c c₀]
+  abel
 
-/-- Conceptualizing a paradigm cell from its stem and cell primitives is the imputed additive
-semantics. -/
-@[simp] theorem conceptualize_pair (st : Stem) (c : Cell) :
-    conceptualize (Sum.elim σ ε) {Sum.inl st, Sum.inr c} = σ st + ε c := by
-  simp
+/-! ### The English past tense -/
+
+/-- The letters of *walk, walked, go, went*. -/
+inductive Letter
+  | w | a | l | k | e | d | g | o | n | t
+  deriving DecidableEq
+
+/-- A regular and a suppletive verb. -/
+inductive Verb
+  | walk | go
+
+/-- The base and past cells. -/
+inductive Tense
+  | base | past
+
+/-- The orthographic forms. -/
+def form : Verb → Tense → List Letter
+  | .walk, .base => [.w, .a, .l, .k]
+  | .walk, .past => [.w, .a, .l, .k, .e, .d]
+  | .go, .base => [.g, .o]
+  | .go, .past => [.w, .e, .n, .t]
+
+/-- The letter-trigram cue inventory of the four forms (§12.9 codes forms as letter trigrams). -/
+def trigram : Fin 13 → Augmented Letter :=
+  ![[none, some .w, some .a], [some .w, some .a, some .l], [some .a, some .l, some .k],
+    [some .l, some .k, none], [some .l, some .k, some .e], [some .k, some .e, some .d],
+    [some .e, some .d, none], [none, some .g, some .o], [some .g, some .o, none],
+    [none, some .w, some .e], [some .w, some .e, some .n], [some .e, some .n, some .t],
+    [some .n, some .t, none]]
+
+/-- The past-tense form table at the trigram coding. -/
+def pastTense (v : Verb) (t : Tense) : FormVec 13 := cueVector 3 trigram (form v t)
+
+/-- The English past tense violates proportional analogy: *walked* adds the cue `ed#` to *walk*,
+*went* adds nothing to *go*. So no linear map produces it from constructed meanings
+(`not_exists_linear_of_not_regular`), while independent embeddings realise it
+(`exists_linear_of_linearIndependent_words`), as in §12.9. -/
+theorem pastTense_not_regular : ¬ IsAnalogicallyRegular pastTense := fun h => by
+  have := congrFun (h .walk .go .past .base) 6
+  simp +decide [pastTense, cueVector, multiHot] at this
+
+/-! ### Training on a paradigm -/
 
 variable [Fintype Stem] [Fintype Cell]
 
-/-- The paradigm as a training experience: imputed additive semantics as the
-    meanings, the form table as the targets. -/
+/-- The paradigm as a training experience: conceptualized additive semantics as the meanings,
+the form table as the targets. -/
 noncomputable def paradigmExperience (f : Stem → Cell → FormVec n) :
     TrainingExperience (Fintype.card (Stem × Cell)) n d where
   meanings i := conceptualize (Sum.elim σ ε)
     {Sum.inl ((Fintype.equivFin (Stem × Cell)).symm i).1,
       Sum.inr ((Fintype.equivFin (Stem × Cell)).symm i).2}
   forms i := f ((Fintype.equivFin (Stem × Cell)).symm i).1
-      ((Fintype.equivFin (Stem × Cell)).symm i).2
+    ((Fintype.equivFin (Stem × Cell)).symm i).2
 
-/-- Irregularity forces positive training loss: no linear map fits a
-    suppletive paradigm exactly, so every ERM solution carries residual
-    error — Table 16.2's irregular-linear cell runs on word-specific
-    semantics, not on additive imputation. -/
+/-- Irregularity forces positive training loss: no linear map fits a suppletive paradigm exactly,
+so every ERM solution carries residual error. -/
 theorem pos_weightedLoss_of_not_regular {f : Stem → Cell → FormVec n}
-    (hf : ¬ IsAnalogicallyRegular f)
-    {q : FrequencyVector (Fintype.card (Stem × Cell))} (hq : ∀ i, 0 < q i)
-    (G : MeaningVec d →ₗ[ℝ] FormVec n) :
+    (hf : ¬ IsAnalogicallyRegular f) {q : FrequencyVector (Fintype.card (Stem × Cell))}
+    (hq : ∀ i, 0 < q i) (G : MeaningVec d →ₗ[ℝ] FormVec n) :
     0 < weightedLoss (paradigmExperience σ ε f) q G := by
-  refine lt_of_le_of_ne
-    (weightedLoss_nonneg _ _ _) (Ne.symm fun h0 => ?_)
+  refine lt_of_le_of_ne (weightedLoss_nonneg _ _ _) (Ne.symm fun h0 => ?_)
   have hint := (weightedLoss_eq_zero_iff _ _ _ hq).1 h0
   refine not_exists_linear_of_not_regular σ ε hf ⟨G, fun st c => ?_⟩
   have h := hint ((Fintype.equivFin (Stem × Cell)) (st, c))


### PR DESCRIPTION
Deep cleanse of `HeitmeierChuangBaayen2026` and a second pass on `GahlBaayen2024`, both against the book and the paper.

- `Training.lean`: the normal equations as a matrix identity, `IsERMSolution data q (toLin' Gᵀ) ↔ SᵀQ(SG − C) = 0`, and their closed form `(SᵀQS)⁻¹SᵀQC` (Gahl and Baayen's (A2), (A4)) as ERM solutions when `SᵀQS` is invertible.
- `GahlBaayen2024`: the endstate and frequency-informed mappings are now computed by that closed form and the printed matrices are theorems; certification is a determinant check. The Cind map `W` is `Uᵀ(UUᵀ)⁻¹U`, with the printed (6) a theorem.
- `HeitmeierChuangBaayen2026`: verified against §12.9 (74% of irregulars from empirical embeddings; none from reconstructed base + PAST meanings), Table 12.7, §16.3 and §16.6. Adds the interpolation theorem that independent word-specific embeddings realise any table, the irregular-linear cell of Table 16.2, and the concrete irregular table *walk, walked, go, went* at the book's trigram coding. The XOR theorem, whose §16.6 attribution was wrong, and an unused helper are cut.