### PR TITLE
feat(Morphology/Paradigm): proportional analogy and the DLM realization

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1322,6 +1322,7 @@ import Linglib.Morphology.Morphotactics.MirrorPrinciple
 import Linglib.Morphology.Morphotactics.RelevanceHierarchy
 import Linglib.Morphology.Morphotactics.Template
 import Linglib.Morphology.Nanosyntax.TreeSpellout
+import Linglib.Morphology.Paradigm.Analogy
 import Linglib.Morphology.Paradigm.Basic
 import Linglib.Morphology.Paradigm.Case
 import Linglib.Morphology.Paradigm.Complexity
@@ -1478,6 +1479,7 @@ import Linglib.Processing.DiscriminativeLexicon.Coding
 import Linglib.Processing.DiscriminativeLexicon.Defs
 import Linglib.Processing.DiscriminativeLexicon.Measures
 import Linglib.Processing.DiscriminativeLexicon.Normed
+import Linglib.Processing.DiscriminativeLexicon.Realization
 import Linglib.Processing.DiscriminativeLexicon.Training
 import Linglib.Processing.Expectation.Defs
 import Linglib.Processing.Expectation.InformationValue

--- a/Linglib/Morphology/Paradigm/Analogy.lean
+++ b/Linglib/Morphology/Paradigm/Analogy.lean
@@ -1,0 +1,61 @@
+import Linglib.Morphology.Paradigm.Basic
+import Mathlib.Algebra.Group.Hom.Defs
+import Mathlib.Tactic.Abel
+
+/-!
+# Proportional analogy
+
+Word-and-paradigm morphology relates the forms of one lexeme to those of another by
+**proportional analogy**, *cat : cats :: dog : dogs* ([blevins-2016]): the contrast between two
+cells is the same for both lexemes. For forms in an additive group the contrast is a difference,
+so a lexeme-indexed family of paradigms `p : L → Cell → F` is analogically regular when every
+cell contrast is lexeme-independent; equivalently it decomposes as a lexeme part plus a cell part
+(`isAnalogicallyRegular_iff_exists_add`), and the property is preserved by additive maps of the
+form space (`IsAnalogicallyRegular.map`). Which families are regular is what a theory of
+realization predicts: over imputed additive semantics a discriminative lexicon realises exactly
+the regular ones (`Studies/HeitmeierChuangBaayen2026`).
+
+## Main declarations
+
+* `Morphology.IsAnalogicallyRegular` — every cell contrast of the family is lexeme-independent.
+* `Morphology.isAnalogicallyRegular_iff_exists_add` — regular iff a lexeme part plus a cell
+  part.
+
+## References
+
+* [J. P. Blevins, *Word and Paradigm Morphology* (2016)][blevins-2016]
+-/
+
+namespace Morphology
+
+variable {L Cell F G : Type*} [AddCommGroup F] [AddCommGroup G]
+
+/-- A lexeme-indexed family of paradigms is **analogically regular** when the form contrast
+between any two cells is the same for every lexeme. -/
+def IsAnalogicallyRegular (p : L → Cell → F) : Prop :=
+  ∀ l l' c c', p l c - p l c' = p l' c - p l' c'
+
+/-- A lexeme part plus a cell part is analogically regular. -/
+theorem isAnalogicallyRegular_add (a : L → F) (b : Cell → F) :
+    IsAnalogicallyRegular fun l c => a l + b c := fun _ _ _ _ => by dsimp only; abel
+
+/-- Analogy is preserved by additive maps of the form space. -/
+theorem IsAnalogicallyRegular.map {p : L → Cell → F} (h : IsAnalogicallyRegular p) (f : F →+ G) :
+    IsAnalogicallyRegular fun l c => f (p l c) := fun l l' c c' => by
+  rw [← map_sub, ← map_sub, h l l' c c']
+
+/-- Analogy is additivity: a regular family is a lexeme part plus a cell part. -/
+theorem isAnalogicallyRegular_iff_exists_add [Nonempty L] [Nonempty Cell] {p : L → Cell → F} :
+    IsAnalogicallyRegular p ↔ ∃ (a : L → F) (b : Cell → F), ∀ l c, p l c = a l + b c := by
+  refine ⟨fun h => ?_, fun ⟨a, b, hab⟩ => ?_⟩
+  · obtain ⟨l₀⟩ := ‹Nonempty L›
+    obtain ⟨c₀⟩ := ‹Nonempty Cell›
+    refine ⟨fun l => p l c₀, fun c => p l₀ c - p l₀ c₀, fun l c => ?_⟩
+    dsimp only
+    rw [← h l l₀ c c₀]
+    abel
+  · have : p = fun l c => a l + b c := funext fun l => funext fun c => hab l c
+    rw [this]
+    exact isAnalogicallyRegular_add a b
+
+end Morphology

--- a/Linglib/Processing/DiscriminativeLexicon/Coding.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Coding.lean
@@ -23,7 +23,8 @@ proportional analogy (`Studies/HeitmeierChuangBaayen2026`).
 - `cues k w`: the `k`-gram cues of the string `w`.
 - `multiHot inv p`: the indicator row of the units satisfying `p` over an inventory `inv`.
 - `cueVector k inv w`: the row of `C` for `w`.
-- `conceptualize emb`: the additive map from primitive multisets to meaning vectors.
+- `conceptualize emb`: the additive map from primitive multisets to meaning vectors;
+  `conceptualize_pair` is the imputed semantics of a paradigm cell.
 
 ## References
 
@@ -63,5 +64,11 @@ def conceptualize (emb : Prim → V) : Multiset Prim →+ V :=
 
 @[simp] theorem conceptualize_apply (emb : Prim → V) (ps : Multiset Prim) :
     conceptualize emb ps = (ps.map emb).sum := rfl
+
+/-- Conceptualizing a lexeme with one inflectional function is the sum of their vectors — the
+imputed additive semantics of a paradigm cell (eq. 5.3). -/
+@[simp] theorem conceptualize_pair {A B : Type*} (σ : A → V) (ε : B → V) (a : A) (b : B) :
+    conceptualize (Sum.elim σ ε) {Sum.inl a, Sum.inr b} = σ a + ε b := by
+  simp
 
 end DiscriminativeLexicon

--- a/Linglib/Processing/DiscriminativeLexicon/Realization.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Realization.lean
@@ -1,0 +1,69 @@
+import Linglib.Morphology.Realization
+import Linglib.Morphology.Paradigm.Analogy
+import Linglib.Processing.DiscriminativeLexicon.Coding
+
+/-!
+# The discriminative lexicon as a realization
+
+A linear DLM with imputed lexeme and cell vectors realises a lexeme at a paradigm cell as the
+form its production map predicts from the conceptualized meaning: the constructed meaning-to-form
+route of [heitmeier-chuang-baayen-2026] (Table 12.7), where the meaning of *walked* is the meaning
+of *walk* plus a past-tense vector and `G` maps it to the form. On the shared
+`Morphology.Realization` interface this is a total, univalent realization, which puts the model
+beside Distributed Morphology, Paradigm Function Morphology and nanosyntax on the same paradigm
+data. The model itself posits no stems or exponents (Box 1.3), so the interface is linglib's
+comparison device, not the theory's ontology. Its form table is analogically regular by
+construction (`Morphology.IsAnalogicallyRegular`), which `Studies/HeitmeierChuangBaayen2026`
+turns into an iff.
+
+## Main declarations
+
+* `DiscriminativeLexicon.Linear.paradigm D σ ε` — the model's form table over imputed vectors.
+* `DiscriminativeLexicon.Linear.realization D σ ε` — the same as a `Morphology.Realization`,
+  total and univalent.
+* `DiscriminativeLexicon.Linear.isAnalogicallyRegular_paradigm` — the table is analogically
+  regular.
+
+## References
+
+* [M. Heitmeier, Y.-Y. Chuang and R. H. Baayen, *The Discriminative Lexicon*
+  (2026)][heitmeier-chuang-baayen-2026]
+-/
+
+namespace DiscriminativeLexicon.Linear
+
+open Morphology
+
+variable {n d : ℕ} {L Cell : Type*} (D : Linear ℝ (FormVec n) (MeaningVec d))
+  (σ : L → MeaningVec d) (ε : Cell → MeaningVec d)
+
+/-- The form table of a linear DLM over imputed lexeme and cell vectors: the production map at the
+conceptualized meaning of each cell. -/
+def paradigm (l : L) (c : Cell) : FormVec n :=
+  D.production (conceptualize (Sum.elim σ ε) {Sum.inl l, Sum.inr c})
+
+@[simp] theorem paradigm_apply (l : L) (c : Cell) :
+    D.paradigm σ ε l c = D.production (σ l + ε c) := by
+  simp [paradigm]
+
+/-- A linear DLM as a `Morphology.Realization`: a lexeme at a cell is realised by the one form the
+production map predicts. -/
+def realization : Realization L Cell (FormVec n) := ⟨fun l c => {D.paradigm σ ε l c}⟩
+
+@[simp] theorem realization_realize (l : L) (c : Cell) :
+    (D.realization σ ε).realize l c = {D.paradigm σ ε l c} := rfl
+
+theorem realization_isTotal : (D.realization σ ε).IsTotal := fun _ _ => Finset.singleton_nonempty _
+
+theorem realization_isUnivalent : (D.realization σ ε).IsUnivalent := fun _ _ =>
+  (Finset.card_singleton _).le
+
+/-- The form table of a linear DLM over additive semantics is analogically regular: the form shift
+of a cell is lexeme-independent. -/
+theorem isAnalogicallyRegular_paradigm : IsAnalogicallyRegular (D.paradigm σ ε) := by
+  have : D.paradigm σ ε = fun l c => D.production.toAddMonoidHom (σ l + ε c) :=
+    funext fun l => funext fun c => by simp
+  rw [this]
+  exact (isAnalogicallyRegular_add σ ε).map _
+
+end DiscriminativeLexicon.Linear

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Processing.DiscriminativeLexicon.Coding
+import Linglib.Processing.DiscriminativeLexicon.Realization
 import Linglib.Processing.DiscriminativeLexicon.Training
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 
@@ -12,21 +12,22 @@ as the meaning of *walk* plus a past-tense vector (Table 12.7; conceptualization
 addition, eq. 5.3, §16.3), which regularizes a system into "a reasonable approximation of a truly
 regular system, and for such a system, linear mappings appear to work quite well" (§16.6,
 Table 16.2); but with the meanings of held-out verbs reconstructed this way, "none of the
-irregular verbs was produced correctly" (§12.9). This file states why. Over additive semantics a
-linear map's form table satisfies proportional analogy by construction, so a table violating
-analogy has no linear interpolant and forces positive training loss, and when stem and exponent
-vectors are jointly independent linear realisability is exactly analogy. Over word-specific
-embeddings, by contrast, any table is linearly realisable as soon as the embeddings are linearly
-independent, which fills the irregular-linear cell of Table 16.2. The English past tense at the
-book's letter-trigram coding (§12.9, `cueVector`) is the irregular table: *walk, walked* against
-*go, went*.
+irregular verbs was produced correctly" (§12.9). This file states why, in word-and-paradigm
+terms (`Morphology.IsAnalogicallyRegular`). Over additive semantics a linear map's form table
+satisfies proportional analogy by construction, so a table violating analogy has no linear
+interpolant and forces positive training loss, and when stem and exponent vectors are jointly
+independent a table is the paradigm of some linear DLM iff it is analogically regular. Over
+word-specific embeddings, by contrast, any table is linearly realisable as soon as the
+embeddings are linearly independent, which fills the irregular-linear cell of Table 16.2. The
+English past tense at the book's letter-trigram coding (§12.9, `cueVector`) is the irregular
+table: *walk, walked* against *go, went*.
 
 ## Main results
 
 * `not_exists_linear_of_not_regular`, `pos_weightedLoss_of_not_regular`: an irregular table has
   no linear interpolant over additive semantics and forces positive loss.
-* `exists_linear_iff_isAnalogicallyRegular`: over jointly independent stem and exponent vectors,
-  linear realisability is analogy.
+* `exists_linear_iff_isAnalogicallyRegular`, `exists_paradigm_eq_iff`: over jointly independent
+  stem and exponent vectors, a table is realised by a linear DLM iff it is analogically regular.
 * `exists_linear_of_linearIndependent_words`: over independent word-specific embeddings every
   table is linearly realisable.
 * `pastTense_not_regular`: *walk, walked, go, went* violates analogy.
@@ -39,31 +40,13 @@ book's letter-trigram coding (§12.9, `cueVector`) is the irregular table: *walk
 
 namespace HeitmeierChuangBaayen2026
 
-open DiscriminativeLexicon
+open DiscriminativeLexicon Morphology
 
 variable {d n : ℕ} {Stem Cell : Type*}
-
-/-- A paradigm's form table satisfies **proportional analogy** if the form contrast between two
-cells is the same for every stem (*cat : cats :: dog : dogs*). -/
-def IsAnalogicallyRegular (f : Stem → Cell → FormVec n) : Prop :=
-  ∀ st st' c c', f st c - f st c' = f st' c - f st' c'
 
 /-! ### Additive semantics -/
 
 variable (σ : Stem → MeaningVec d) (ε : Cell → MeaningVec d)
-
-/-- Conceptualizing a paradigm cell from its stem and cell primitives is the imputed additive
-semantics (eq. 5.3, Table 12.7). -/
-@[simp] theorem conceptualize_pair (st : Stem) (c : Cell) :
-    conceptualize (Sum.elim σ ε) {Sum.inl st, Sum.inr c} = σ st + ε c := by
-  simp
-
-/-- Every linear map's paradigm table over additive semantics is analogically regular: the form
-shift of an exponent is stem-independent. -/
-theorem isAnalogicallyRegular_comp (G : MeaningVec d →ₗ[ℝ] FormVec n) :
-    IsAnalogicallyRegular fun st c => G (σ st + ε c) := fun st st' c c' => by
-  simp only [map_add]
-  abel
 
 /-- A table violating proportional analogy has no linear interpolant over additive semantics:
 irregular forms cannot be produced from constructed meanings (§12.9). -/
@@ -71,7 +54,7 @@ theorem not_exists_linear_of_not_regular {f : Stem → Cell → FormVec n}
     (hf : ¬ IsAnalogicallyRegular f) :
     ¬ ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c := by
   rintro ⟨G, hG⟩
-  exact hf (by simpa only [hG] using isAnalogicallyRegular_comp σ ε G)
+  exact hf (by simpa [hG] using (isAnalogicallyRegular_add σ ε).map G.toAddMonoidHom)
 
 /-! ### Interpolation -/
 
@@ -101,17 +84,24 @@ theorem exists_linear_iff_isAnalogicallyRegular [Nonempty Stem] [Nonempty Cell]
     (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Stem → Cell → FormVec n) :
     (∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c) ↔
       IsAnalogicallyRegular f := by
-  refine ⟨fun ⟨G, hG⟩ => by simpa only [hG] using isAnalogicallyRegular_comp σ ε G,
-    fun hreg => ?_⟩
-  obtain ⟨st₀⟩ := ‹Nonempty Stem›
-  obtain ⟨c₀⟩ := ‹Nonempty Cell›
-  obtain ⟨G, hG⟩ := exists_linear_of_linearIndependent hind
-    (Sum.elim (fun st => f st c₀) fun c => f st₀ c - f st₀ c₀)
+  refine ⟨fun ⟨G, hG⟩ => by
+    simpa [hG] using (isAnalogicallyRegular_add σ ε).map G.toAddMonoidHom, fun hreg => ?_⟩
+  obtain ⟨a, b, hab⟩ := isAnalogicallyRegular_iff_exists_add.1 hreg
+  obtain ⟨G, hG⟩ := exists_linear_of_linearIndependent hind (Sum.elim a b)
   refine ⟨G, fun st c => ?_⟩
-  have hσ : G (σ st) = f st c₀ := hG (Sum.inl st)
-  have hε : G (ε c) = f st₀ c - f st₀ c₀ := hG (Sum.inr c)
-  rw [map_add, hσ, hε, ← hreg st st₀ c c₀]
-  abel
+  have hσ : G (σ st) = a st := hG (Sum.inl st)
+  have hε : G (ε c) = b c := hG (Sum.inr c)
+  rw [map_add, hσ, hε, hab]
+
+/-- On the `Morphology.Realization` interface: a table is the paradigm of some linear DLM over
+jointly independent imputed vectors iff it is analogically regular. -/
+theorem exists_paradigm_eq_iff [Nonempty Stem] [Nonempty Cell]
+    (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Stem → Cell → FormVec n) :
+    (∃ D : Linear ℝ (FormVec n) (MeaningVec d), D.paradigm σ ε = f) ↔
+      IsAnalogicallyRegular f := by
+  rw [← exists_linear_iff_isAnalogicallyRegular σ ε hind]
+  refine ⟨fun ⟨D, hD⟩ => ⟨D.production, fun st c => by simpa using congrFun (congrFun hD st) c⟩,
+    fun ⟨G, hG⟩ => ⟨⟨0, G⟩, funext fun st => funext fun c => by simpa using hG st c⟩⟩
 
 /-! ### The English past tense -/
 

--- a/references.bib
+++ b/references.bib
@@ -27531,7 +27531,7 @@
   doi       = {10.1017/9781009634564},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Studies/ChuangEtAl2026.lean;Studies/LuChuangBaayen2026.lean;Processing/DiscriminativeLexicon/Defs.lean;Processing/DiscriminativeLexicon/Normed.lean;Processing/DiscriminativeLexicon/Coding.lean;Processing/DiscriminativeLexicon/Training.lean;Studies/HeitmeierChuangBaayen2026.lean}
+  sources   = {Processing/DiscriminativeLexicon/Realization.lean;Studies/ChuangEtAl2026.lean;Studies/LuChuangBaayen2026.lean;Processing/DiscriminativeLexicon/Defs.lean;Processing/DiscriminativeLexicon/Normed.lean;Processing/DiscriminativeLexicon/Coding.lean;Processing/DiscriminativeLexicon/Training.lean;Studies/HeitmeierChuangBaayen2026.lean}
 }
 
 @unpublished{lu-chuang-baayen-2024,
@@ -31075,7 +31075,7 @@
   isbn      = {978-0-19-959354-5},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Sister.lean}
+  sources   = {Morphology/Paradigm/Analogy.lean;Morphology/Construction/Sister.lean}
 }
 
 @article{evans-gazdar-1996,


### PR DESCRIPTION
Integrates the DLM substrate with the Morphology API at the paradigm level.

- `Morphology/Paradigm/Analogy.lean`: word-and-paradigm proportional analogy for lexeme-indexed families of paradigms valued in an additive group (`IsAnalogicallyRegular`), with the characterization as a lexeme part plus a cell part and preservation under additive maps. This was a local definition in the Heitmeier study; it is the object-API notion.
- `Processing/DiscriminativeLexicon/Realization.lean`: a linear DLM over imputed lexeme and cell vectors as a `Morphology.Realization` (the book's constructed meaning-to-form route, Table 12.7), total and univalent, on PFM's `paradigmRealization` pattern, with the theorem that its form table is analogically regular. Documented as linglib's comparison device, since the book posits no stems or exponents.
- `HeitmeierChuangBaayen2026` re-based on both: the linear-realisability iff now goes through the additive decomposition, and `exists_paradigm_eq_iff` states it on the shared interface. `conceptualize_pair` generalised into `Coding.lean`.