### PR TITLE
refactor(Morphology/Paradigm): analogy under operations, lexemes not stems

### DIFF
--- a/Linglib/Morphology/Paradigm/Analogy.lean
+++ b/Linglib/Morphology/Paradigm/Analogy.lean
@@ -6,18 +6,26 @@ import Mathlib.Tactic.Abel
 # Proportional analogy
 
 Word-and-paradigm morphology relates the forms of one lexeme to those of another by
-**proportional analogy**, *cat : cats :: dog : dogs* ([blevins-2016]): the contrast between two
-cells is the same for both lexemes. For forms in an additive group the contrast is a difference,
-so a lexeme-indexed family of paradigms `p : L → Cell → F` is analogically regular when every
-cell contrast is lexeme-independent; equivalently it decomposes as a lexeme part plus a cell part
+**proportional analogy**, *cat : cats :: dog : dogs* ([blevins-2016]): the operation taking the
+form at one cell to the form at another is the same for every lexeme. Which operations count is a
+parameter, affixation on strings or translation on vectors, so a lexeme-indexed family of
+paradigms `p : L → Cell → F` is **analogical** under a class of operations when every pair of
+cells is related by one operation of the class shared across lexemes (`IsAnalogical`). Analogy
+under any class makes each cell's form identify the lexeme's whole paradigm, Ackerman and
+Malouf's vocabular clarity (`ParadigmSystem.isVocabularClear_of_isAnalogical` in
+`Complexity.lean`). For forms in an additive group and translations as the operations, the cell
+contrast is a difference and the family is **analogically regular** (`IsAnalogicallyRegular`):
+every contrast is lexeme-independent, equivalently the family is a lexeme part plus a cell part
 (`isAnalogicallyRegular_iff_exists_add`), and the property is preserved by additive maps of the
-form space (`IsAnalogicallyRegular.map`). Which families are regular is what a theory of
-realization predicts: over imputed additive semantics a discriminative lexicon realises exactly
-the regular ones (`Studies/HeitmeierChuangBaayen2026`).
+form space (`IsAnalogicallyRegular.map`). This is the case a discriminative lexicon realises
+exactly (`Studies/HeitmeierChuangBaayen2026`).
 
 ## Main declarations
 
-* `Morphology.IsAnalogicallyRegular` — every cell contrast of the family is lexeme-independent.
+* `Morphology.IsAnalogical ops p` — every pair of cells is related by one operation of `ops`,
+  the same for every lexeme.
+* `Morphology.IsAnalogicallyRegular p` — analogy under the translations of an additive group;
+  `isAnalogicallyRegular_iff` is its difference form.
 * `Morphology.isAnalogicallyRegular_iff_exists_add` — regular iff a lexeme part plus a cell
   part.
 
@@ -28,23 +36,51 @@ the regular ones (`Studies/HeitmeierChuangBaayen2026`).
 
 namespace Morphology
 
-variable {L Cell F G : Type*} [AddCommGroup F] [AddCommGroup G]
+variable {L Cell F G : Type*}
 
-/-- A lexeme-indexed family of paradigms is **analogically regular** when the form contrast
-between any two cells is the same for every lexeme. -/
+/-- A lexeme-indexed family of paradigms is **analogical** under a class of operations on forms
+when every pair of cells is related by one operation of the class, the same for every lexeme. -/
+def IsAnalogical (ops : Set (F → F)) (p : L → Cell → F) : Prop :=
+  ∀ c c', ∃ g ∈ ops, ∀ l, p l c' = g (p l c)
+
+section AddCommGroup
+
+variable [AddCommGroup F] [AddCommGroup G]
+
+/-- Analogy under translations: the form contrast between any two cells is the same for every
+lexeme. -/
 def IsAnalogicallyRegular (p : L → Cell → F) : Prop :=
-  ∀ l l' c c', p l c - p l c' = p l' c - p l' c'
+  IsAnalogical (Set.range fun v : F => (· + v)) p
+
+/-- The difference form of analogical regularity. -/
+theorem isAnalogicallyRegular_iff {p : L → Cell → F} :
+    IsAnalogicallyRegular p ↔ ∀ l l' c c', p l c - p l c' = p l' c - p l' c' := by
+  constructor
+  · intro h l l' c c'
+    obtain ⟨_, ⟨v, rfl⟩, hv⟩ := h c c'
+    dsimp only at hv
+    rw [hv l, hv l']
+    abel
+  · intro h c c'
+    rcases isEmpty_or_nonempty L with hL | ⟨⟨l₀⟩⟩
+    · exact ⟨_, ⟨0, rfl⟩, fun l => (hL.false l).elim⟩
+    · refine ⟨_, ⟨p l₀ c' - p l₀ c, rfl⟩, fun l => ?_⟩
+      show p l c' = p l c + (p l₀ c' - p l₀ c)
+      rw [← h l l₀ c' c]
+      abel
 
 /-- A lexeme part plus a cell part is analogically regular. -/
 theorem isAnalogicallyRegular_add (a : L → F) (b : Cell → F) :
-    IsAnalogicallyRegular fun l c => a l + b c := fun _ _ _ _ => by dsimp only; abel
+    IsAnalogicallyRegular fun l c => a l + b c :=
+  isAnalogicallyRegular_iff.2 fun _ _ _ _ => by abel
 
-/-- Analogy is preserved by additive maps of the form space. -/
+/-- Analogical regularity is preserved by additive maps of the form space. -/
 theorem IsAnalogicallyRegular.map {p : L → Cell → F} (h : IsAnalogicallyRegular p) (f : F →+ G) :
-    IsAnalogicallyRegular fun l c => f (p l c) := fun l l' c c' => by
-  rw [← map_sub, ← map_sub, h l l' c c']
+    IsAnalogicallyRegular fun l c => f (p l c) :=
+  isAnalogicallyRegular_iff.2 fun l l' c c' => by
+    rw [← map_sub, ← map_sub, isAnalogicallyRegular_iff.1 h l l' c c']
 
-/-- Analogy is additivity: a regular family is a lexeme part plus a cell part. -/
+/-- Analogical regularity is additivity: a regular family is a lexeme part plus a cell part. -/
 theorem isAnalogicallyRegular_iff_exists_add [Nonempty L] [Nonempty Cell] {p : L → Cell → F} :
     IsAnalogicallyRegular p ↔ ∃ (a : L → F) (b : Cell → F), ∀ l c, p l c = a l + b c := by
   refine ⟨fun h => ?_, fun ⟨a, b, hab⟩ => ?_⟩
@@ -52,10 +88,12 @@ theorem isAnalogicallyRegular_iff_exists_add [Nonempty L] [Nonempty Cell] {p : L
     obtain ⟨c₀⟩ := ‹Nonempty Cell›
     refine ⟨fun l => p l c₀, fun c => p l₀ c - p l₀ c₀, fun l c => ?_⟩
     dsimp only
-    rw [← h l l₀ c c₀]
+    rw [← isAnalogicallyRegular_iff.1 h l l₀ c c₀]
     abel
   · have : p = fun l c => a l + b c := funext fun l => funext fun c => hab l c
     rw [this]
     exact isAnalogicallyRegular_add a b
+
+end AddCommGroup
 
 end Morphology

--- a/Linglib/Morphology/Paradigm/Complexity.lean
+++ b/Linglib/Morphology/Paradigm/Complexity.lean
@@ -1,3 +1,4 @@
+import Linglib.Morphology.Paradigm.Analogy
 import Linglib.Morphology.Paradigm.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
 import Mathlib.Data.Fintype.Pi
@@ -31,6 +32,8 @@ classes.
 
 * `ParadigmSystem.conditionalCellEntropy_eq_zero_of_predicts`,
   `ParadigmSystem.isTransparent_of_isVocabularClear`: prediction is zero conditional entropy.
+* `ParadigmSystem.isVocabularClear_of_isAnalogical`: classes related by proportional analogy
+  (`Morphology.IsAnalogical`) are vocabularly clear.
 * `ParadigmSystem.cellEntropy_eq_zero_of_card_le_one`: a cell with one realization has zero
   entropy.
 * `ParadigmSystem.card_paradigms_le_prod_card_realizations`: classes are bounded by the product
@@ -189,6 +192,21 @@ theorem conditionalCellEntropy_eq_zero_of_predicts {ci cj : Fin n} (h : ps.Predi
 /-- A vocabularly clear system is transparent. -/
 theorem isTransparent_of_isVocabularClear (h : ps.IsVocabularClear) : ps.IsTransparent :=
   fun ci cj _ => ps.conditionalCellEntropy_eq_zero_of_predicts (h cj ci)
+
+omit [DecidableEq Form] in
+/-- A system whose classes are the paradigms of a family related by proportional analogy under
+any operations is vocabularly clear: a cell's form fixes the lexeme's whole paradigm
+([blevins-2016]'s analogy as implicative structure). -/
+theorem isVocabularClear_of_isAnalogical {L : Type*} {ops : Set (Form → Form)}
+    {p : L → Fin n → Form} (h : IsAnalogical ops p) (hps : ∀ e ∈ ps.entries, ∃ l, e.1 = p l) :
+    ps.IsVocabularClear := by
+  intro c j q hq q' hq' hcq
+  obtain ⟨l, hl⟩ := hps q hq
+  obtain ⟨l', hl'⟩ := hps q' hq'
+  obtain ⟨g, -, hg⟩ := h c j
+  have hc := hcq c (Finset.mem_singleton_self c)
+  rw [hl, hl'] at hc ⊢
+  rw [hg l, hg l', hc]
 
 end ParadigmSystem
 

--- a/Linglib/Processing/DiscriminativeLexicon/Coding.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Coding.lean
@@ -24,7 +24,7 @@ proportional analogy (`Studies/HeitmeierChuangBaayen2026`).
 - `multiHot inv p`: the indicator row of the units satisfying `p` over an inventory `inv`.
 - `cueVector k inv w`: the row of `C` for `w`.
 - `conceptualize emb`: the additive map from primitive multisets to meaning vectors;
-  `conceptualize_pair` is the imputed semantics of a paradigm cell.
+  `imputed σ ε` is the resulting semantics of a lexeme at a cell.
 
 ## References
 
@@ -70,5 +70,15 @@ imputed additive semantics of a paradigm cell (eq. 5.3). -/
 @[simp] theorem conceptualize_pair {A B : Type*} (σ : A → V) (ε : B → V) (a : A) (b : B) :
     conceptualize (Sum.elim σ ε) {Sum.inl a, Sum.inr b} = σ a + ε b := by
   simp
+
+/-- **Imputed semantics**: the meaning of a lexeme at a cell conceptualized from the lexeme's
+vector and the inflectional function's vector (eq. 5.3; the constructed meaning-to-form route of
+Table 12.7, which §16.6 calls imputed embeddings for stems and exponents). -/
+def imputed {A B : Type*} (σ : A → V) (ε : B → V) (a : A) (b : B) : V :=
+  conceptualize (Sum.elim σ ε) {Sum.inl a, Sum.inr b}
+
+@[simp] theorem imputed_apply {A B : Type*} (σ : A → V) (ε : B → V) (a : A) (b : B) :
+    imputed σ ε a b = σ a + ε b :=
+  conceptualize_pair σ ε a b
 
 end DiscriminativeLexicon

--- a/Linglib/Processing/DiscriminativeLexicon/Realization.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Realization.lean
@@ -5,24 +5,27 @@ import Linglib.Processing.DiscriminativeLexicon.Coding
 /-!
 # The discriminative lexicon as a realization
 
-A linear DLM with imputed lexeme and cell vectors realises a lexeme at a paradigm cell as the
-form its production map predicts from the conceptualized meaning: the constructed meaning-to-form
-route of [heitmeier-chuang-baayen-2026] (Table 12.7), where the meaning of *walked* is the meaning
-of *walk* plus a past-tense vector and `G` maps it to the form. On the shared
-`Morphology.Realization` interface this is a total, univalent realization, which puts the model
-beside Distributed Morphology, Paradigm Function Morphology and nanosyntax on the same paradigm
-data. The model itself posits no stems or exponents (Box 1.3), so the interface is linglib's
-comparison device, not the theory's ontology. Its form table is analogically regular by
-construction (`Morphology.IsAnalogicallyRegular`), which `Studies/HeitmeierChuangBaayen2026`
-turns into an iff.
+A linear DLM realises a lexeme at a paradigm cell as the form its production map predicts from
+the cell's meaning. Which meaning is the speaker's choice ([heitmeier-chuang-baayen-2026]
+Table 12.7): an empirical embedding of the word, or a meaning constructed from the lexeme's vector
+and the inflectional function's vector (`imputed`), the meaning of *walked* as the meaning of
+*walk* plus a past-tense vector. Either way, on the shared `Morphology.Realization` interface this
+is a total, univalent realization, which puts the model beside Distributed Morphology, Paradigm
+Function Morphology and nanosyntax on the same paradigm data. The model itself posits no stems or
+exponents (Box 1.3); its lexeme and inflectional function are semantic primitives (ch. 5), and the
+interface is linglib's comparison device, not the theory's ontology. Over imputed semantics the
+form table is analogically regular by construction (`Morphology.IsAnalogicallyRegular`), which
+`Studies/HeitmeierChuangBaayen2026` turns into an iff; over word-specific embeddings it need not
+be.
 
 ## Main declarations
 
-* `DiscriminativeLexicon.Linear.paradigm D σ ε` — the model's form table over imputed vectors.
-* `DiscriminativeLexicon.Linear.realization D σ ε` — the same as a `Morphology.Realization`,
+* `DiscriminativeLexicon.Linear.paradigm D s` — the model's form table over a meaning
+  assignment `s` to lexemes at cells.
+* `DiscriminativeLexicon.Linear.realization D s` — the same as a `Morphology.Realization`,
   total and univalent.
-* `DiscriminativeLexicon.Linear.isAnalogicallyRegular_paradigm` — the table is analogically
-  regular.
+* `DiscriminativeLexicon.Linear.isAnalogicallyRegular_paradigm_imputed` — over imputed
+  semantics the table is analogically regular.
 
 ## References
 
@@ -35,33 +38,31 @@ namespace DiscriminativeLexicon.Linear
 open Morphology
 
 variable {n d : ℕ} {L Cell : Type*} (D : Linear ℝ (FormVec n) (MeaningVec d))
-  (σ : L → MeaningVec d) (ε : Cell → MeaningVec d)
+  (s : L → Cell → MeaningVec d)
 
-/-- The form table of a linear DLM over imputed lexeme and cell vectors: the production map at the
-conceptualized meaning of each cell. -/
-def paradigm (l : L) (c : Cell) : FormVec n :=
-  D.production (conceptualize (Sum.elim σ ε) {Sum.inl l, Sum.inr c})
+/-- The form table of a linear DLM over a meaning assignment: the production map at the meaning
+of each lexeme at each cell. -/
+def paradigm (l : L) (c : Cell) : FormVec n := D.production (s l c)
 
-@[simp] theorem paradigm_apply (l : L) (c : Cell) :
-    D.paradigm σ ε l c = D.production (σ l + ε c) := by
-  simp [paradigm]
+@[simp] theorem paradigm_apply (l : L) (c : Cell) : D.paradigm s l c = D.production (s l c) := rfl
 
 /-- A linear DLM as a `Morphology.Realization`: a lexeme at a cell is realised by the one form the
 production map predicts. -/
-def realization : Realization L Cell (FormVec n) := ⟨fun l c => {D.paradigm σ ε l c}⟩
+def realization : Realization L Cell (FormVec n) := ⟨fun l c => {D.paradigm s l c}⟩
 
 @[simp] theorem realization_realize (l : L) (c : Cell) :
-    (D.realization σ ε).realize l c = {D.paradigm σ ε l c} := rfl
+    (D.realization s).realize l c = {D.paradigm s l c} := rfl
 
-theorem realization_isTotal : (D.realization σ ε).IsTotal := fun _ _ => Finset.singleton_nonempty _
+theorem realization_isTotal : (D.realization s).IsTotal := fun _ _ => Finset.singleton_nonempty _
 
-theorem realization_isUnivalent : (D.realization σ ε).IsUnivalent := fun _ _ =>
+theorem realization_isUnivalent : (D.realization s).IsUnivalent := fun _ _ =>
   (Finset.card_singleton _).le
 
-/-- The form table of a linear DLM over additive semantics is analogically regular: the form shift
-of a cell is lexeme-independent. -/
-theorem isAnalogicallyRegular_paradigm : IsAnalogicallyRegular (D.paradigm σ ε) := by
-  have : D.paradigm σ ε = fun l c => D.production.toAddMonoidHom (σ l + ε c) :=
+/-- Over imputed semantics the form table is analogically regular: the form shift of a cell is
+lexeme-independent. -/
+theorem isAnalogicallyRegular_paradigm_imputed (σ : L → MeaningVec d) (ε : Cell → MeaningVec d) :
+    IsAnalogicallyRegular (D.paradigm (imputed σ ε)) := by
+  have : D.paradigm (imputed σ ε) = fun l c => D.production.toAddMonoidHom (σ l + ε c) :=
     funext fun l => funext fun c => by simp
   rw [this]
   exact (isAnalogicallyRegular_add σ ε).map _

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -13,23 +13,25 @@ addition, eq. 5.3, §16.3), which regularizes a system into "a reasonable approx
 regular system, and for such a system, linear mappings appear to work quite well" (§16.6,
 Table 16.2); but with the meanings of held-out verbs reconstructed this way, "none of the
 irregular verbs was produced correctly" (§12.9). This file states why, in word-and-paradigm
-terms (`Morphology.IsAnalogicallyRegular`). Over additive semantics a linear map's form table
-satisfies proportional analogy by construction, so a table violating analogy has no linear
-interpolant and forces positive training loss, and when stem and exponent vectors are jointly
-independent a table is the paradigm of some linear DLM iff it is analogically regular. Over
-word-specific embeddings, by contrast, any table is linearly realisable as soon as the
-embeddings are linearly independent, which fills the irregular-linear cell of Table 16.2. The
-English past tense at the book's letter-trigram coding (§12.9, `cueVector`) is the irregular
-table: *walk, walked* against *go, went*.
+terms (`Morphology.IsAnalogicallyRegular`), on the `Morphology.Realization` interface
+(`DiscriminativeLexicon.Linear.paradigm`). Over imputed semantics, a lexeme vector plus an
+inflectional-function vector (`imputed`; §16.6 says "imputed embeddings for stems and exponents"),
+a linear map's form table satisfies proportional analogy by construction, so a table violating
+analogy is the paradigm of no linear DLM and forces positive training loss, and when the lexeme
+and function vectors are jointly independent a table is the paradigm of some linear DLM iff it is
+analogically regular. Over word-specific embeddings, by contrast, any table is the paradigm of
+some linear DLM as soon as the embeddings are linearly independent, which fills the
+irregular-linear cell of Table 16.2. The English past tense at the book's letter-trigram coding
+(§12.9, `cueVector`) is the irregular table: *walk, walked* against *go, went*.
 
 ## Main results
 
-* `not_exists_linear_of_not_regular`, `pos_weightedLoss_of_not_regular`: an irregular table has
-  no linear interpolant over additive semantics and forces positive loss.
-* `exists_linear_iff_isAnalogicallyRegular`, `exists_paradigm_eq_iff`: over jointly independent
-  stem and exponent vectors, a table is realised by a linear DLM iff it is analogically regular.
-* `exists_linear_of_linearIndependent_words`: over independent word-specific embeddings every
-  table is linearly realisable.
+* `not_exists_paradigm_eq_of_not_regular`, `pos_weightedLoss_of_not_regular`: an irregular
+  table is the paradigm of no linear DLM over imputed semantics and forces positive loss.
+* `exists_paradigm_imputed_eq_iff`: over jointly independent lexeme and function vectors, a
+  table is the paradigm of some linear DLM iff it is analogically regular.
+* `exists_paradigm_eq_of_linearIndependent`: over independent word-specific embeddings every
+  table is the paradigm of some linear DLM.
 * `pastTense_not_regular`: *walk, walked, go, went* violates analogy.
 
 ## References
@@ -42,19 +44,19 @@ namespace HeitmeierChuangBaayen2026
 
 open DiscriminativeLexicon Morphology
 
-variable {d n : ℕ} {Stem Cell : Type*}
+variable {d n : ℕ} {Lexeme Cell : Type*}
 
-/-! ### Additive semantics -/
+/-! ### Imputed semantics -/
 
-variable (σ : Stem → MeaningVec d) (ε : Cell → MeaningVec d)
+variable (σ : Lexeme → MeaningVec d) (ε : Cell → MeaningVec d)
 
-/-- A table violating proportional analogy has no linear interpolant over additive semantics:
-irregular forms cannot be produced from constructed meanings (§12.9). -/
-theorem not_exists_linear_of_not_regular {f : Stem → Cell → FormVec n}
+/-- A table violating proportional analogy is the paradigm of no linear DLM over imputed
+semantics: irregular forms cannot be produced from constructed meanings (§12.9). -/
+theorem not_exists_paradigm_eq_of_not_regular {f : Lexeme → Cell → FormVec n}
     (hf : ¬ IsAnalogicallyRegular f) :
-    ¬ ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c := by
-  rintro ⟨G, hG⟩
-  exact hf (by simpa [hG] using (isAnalogicallyRegular_add σ ε).map G.toAddMonoidHom)
+    ¬ ∃ D : Linear ℝ (FormVec n) (MeaningVec d), D.paradigm (imputed σ ε) = f := by
+  rintro ⟨D, rfl⟩
+  exact hf (D.isAnalogicallyRegular_paradigm_imputed σ ε)
 
 /-! ### Interpolation -/
 
@@ -68,40 +70,29 @@ theorem exists_linear_of_linearIndependent {ι : Type*} {v : ι → MeaningVec d
   rwa [LinearMap.comp_apply, Submodule.subtype_apply, Module.Basis.constr_basis,
     Module.Basis.span_apply] at h
 
-/-- Over word-specific, linearly independent embeddings any form table is linearly realisable,
-irregulars included: the irregular-linear cell of Table 16.2, the English past tense on empirical
-embeddings (§12.9). -/
-theorem exists_linear_of_linearIndependent_words {s : Stem → Cell → MeaningVec d}
-    (hs : LinearIndependent ℝ (Function.uncurry s)) (f : Stem → Cell → FormVec n) :
-    ∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (s st c) = f st c :=
+/-- Over word-specific, linearly independent embeddings any form table is the paradigm of some
+linear DLM, irregulars included: the irregular-linear cell of Table 16.2, the English past tense
+on empirical embeddings (§12.9). -/
+theorem exists_paradigm_eq_of_linearIndependent {s : Lexeme → Cell → MeaningVec d}
+    (hs : LinearIndependent ℝ (Function.uncurry s)) (f : Lexeme → Cell → FormVec n) :
+    ∃ D : Linear ℝ (FormVec n) (MeaningVec d), D.paradigm s = f :=
   let ⟨G, hG⟩ := exists_linear_of_linearIndependent hs (Function.uncurry f)
-  ⟨G, fun st c => hG (st, c)⟩
+  ⟨⟨0, G⟩, funext fun l => funext fun c => hG (l, c)⟩
 
-/-- When stem and exponent vectors are jointly linearly independent, a paradigm table is linearly
-realisable over additive semantics **iff** it is analogically regular: for a regularized system,
-linearity and regularity are the same constraint (§16.6). -/
-theorem exists_linear_iff_isAnalogicallyRegular [Nonempty Stem] [Nonempty Cell]
-    (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Stem → Cell → FormVec n) :
-    (∃ G : MeaningVec d →ₗ[ℝ] FormVec n, ∀ st c, G (σ st + ε c) = f st c) ↔
+/-- When the lexeme and inflectional-function vectors are jointly linearly independent, a table
+is the paradigm of some linear DLM over imputed semantics **iff** it is analogically regular: for
+a regularized system, linearity and regularity are the same constraint (§16.6). -/
+theorem exists_paradigm_imputed_eq_iff [Nonempty Lexeme] [Nonempty Cell]
+    (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Lexeme → Cell → FormVec n) :
+    (∃ D : Linear ℝ (FormVec n) (MeaningVec d), D.paradigm (imputed σ ε) = f) ↔
       IsAnalogicallyRegular f := by
-  refine ⟨fun ⟨G, hG⟩ => by
-    simpa [hG] using (isAnalogicallyRegular_add σ ε).map G.toAddMonoidHom, fun hreg => ?_⟩
+  refine ⟨fun ⟨D, hD⟩ => hD ▸ D.isAnalogicallyRegular_paradigm_imputed σ ε, fun hreg => ?_⟩
   obtain ⟨a, b, hab⟩ := isAnalogicallyRegular_iff_exists_add.1 hreg
   obtain ⟨G, hG⟩ := exists_linear_of_linearIndependent hind (Sum.elim a b)
-  refine ⟨G, fun st c => ?_⟩
-  have hσ : G (σ st) = a st := hG (Sum.inl st)
+  refine ⟨⟨0, G⟩, funext fun l => funext fun c => ?_⟩
+  have hσ : G (σ l) = a l := hG (Sum.inl l)
   have hε : G (ε c) = b c := hG (Sum.inr c)
-  rw [map_add, hσ, hε, hab]
-
-/-- On the `Morphology.Realization` interface: a table is the paradigm of some linear DLM over
-jointly independent imputed vectors iff it is analogically regular. -/
-theorem exists_paradigm_eq_iff [Nonempty Stem] [Nonempty Cell]
-    (hind : LinearIndependent ℝ (Sum.elim σ ε)) (f : Stem → Cell → FormVec n) :
-    (∃ D : Linear ℝ (FormVec n) (MeaningVec d), D.paradigm σ ε = f) ↔
-      IsAnalogicallyRegular f := by
-  rw [← exists_linear_iff_isAnalogicallyRegular σ ε hind]
-  refine ⟨fun ⟨D, hD⟩ => ⟨D.production, fun st c => by simpa using congrFun (congrFun hD st) c⟩,
-    fun ⟨G, hG⟩ => ⟨⟨0, G⟩, funext fun st => funext fun c => by simpa using hG st c⟩⟩
+  simp [hσ, hε, hab]
 
 /-! ### The English past tense -/
 
@@ -137,37 +128,36 @@ def trigram : Fin 13 → Augmented Letter :=
 def pastTense (v : Verb) (t : Tense) : FormVec 13 := cueVector 3 trigram (form v t)
 
 /-- The English past tense violates proportional analogy: *walked* adds the cue `ed#` to *walk*,
-*went* adds nothing to *go*. So no linear map produces it from constructed meanings
-(`not_exists_linear_of_not_regular`), while independent embeddings realise it
-(`exists_linear_of_linearIndependent_words`), as in §12.9. -/
+*went* adds nothing to *go*. So no linear DLM produces it from constructed meanings
+(`not_exists_paradigm_eq_of_not_regular`), while independent embeddings realise it
+(`exists_paradigm_eq_of_linearIndependent`), as in §12.9. -/
 theorem pastTense_not_regular : ¬ IsAnalogicallyRegular pastTense := fun h => by
-  have := congrFun (h .walk .go .past .base) 6
+  have := congrFun (isAnalogicallyRegular_iff.1 h .walk .go .past .base) 6
   simp +decide [pastTense, cueVector, multiHot] at this
 
 /-! ### Training on a paradigm -/
 
-variable [Fintype Stem] [Fintype Cell]
+variable [Fintype Lexeme] [Fintype Cell]
 
-/-- The paradigm as a training experience: conceptualized additive semantics as the meanings,
-the form table as the targets. -/
-noncomputable def paradigmExperience (f : Stem → Cell → FormVec n) :
-    TrainingExperience (Fintype.card (Stem × Cell)) n d where
-  meanings i := conceptualize (Sum.elim σ ε)
-    {Sum.inl ((Fintype.equivFin (Stem × Cell)).symm i).1,
-      Sum.inr ((Fintype.equivFin (Stem × Cell)).symm i).2}
-  forms i := f ((Fintype.equivFin (Stem × Cell)).symm i).1
-    ((Fintype.equivFin (Stem × Cell)).symm i).2
+/-- The paradigm as a training experience: imputed semantics as the meanings, the form table as
+the targets. -/
+noncomputable def paradigmExperience (f : Lexeme → Cell → FormVec n) :
+    TrainingExperience (Fintype.card (Lexeme × Cell)) n d where
+  meanings i := imputed σ ε ((Fintype.equivFin (Lexeme × Cell)).symm i).1
+    ((Fintype.equivFin (Lexeme × Cell)).symm i).2
+  forms i := f ((Fintype.equivFin (Lexeme × Cell)).symm i).1
+    ((Fintype.equivFin (Lexeme × Cell)).symm i).2
 
 /-- Irregularity forces positive training loss: no linear map fits a suppletive paradigm exactly,
 so every ERM solution carries residual error. -/
-theorem pos_weightedLoss_of_not_regular {f : Stem → Cell → FormVec n}
-    (hf : ¬ IsAnalogicallyRegular f) {q : FrequencyVector (Fintype.card (Stem × Cell))}
+theorem pos_weightedLoss_of_not_regular {f : Lexeme → Cell → FormVec n}
+    (hf : ¬ IsAnalogicallyRegular f) {q : FrequencyVector (Fintype.card (Lexeme × Cell))}
     (hq : ∀ i, 0 < q i) (G : MeaningVec d →ₗ[ℝ] FormVec n) :
     0 < weightedLoss (paradigmExperience σ ε f) q G := by
   refine lt_of_le_of_ne (weightedLoss_nonneg _ _ _) (Ne.symm fun h0 => ?_)
   have hint := (weightedLoss_eq_zero_iff _ _ _ hq).1 h0
-  refine not_exists_linear_of_not_regular σ ε hf ⟨G, fun st c => ?_⟩
-  have h := hint ((Fintype.equivFin (Stem × Cell)) (st, c))
+  refine not_exists_paradigm_eq_of_not_regular σ ε hf ⟨⟨0, G⟩, funext fun l => funext fun c => ?_⟩
+  have h := hint ((Fintype.equivFin (Lexeme × Cell)) (l, c))
   simpa [paradigmExperience] using h
 
 end HeitmeierChuangBaayen2026


### PR DESCRIPTION
Follow-up to #2633 on two points: the analogy notion was the DLM's vector rendering rather than a general paradigm notion, and the DLM hom baked in additive semantics.

- `Morphology/Paradigm/Analogy.lean`: `IsAnalogical ops p` is the neutral word-and-paradigm notion, every pair of cells related by one operation of a class shared across lexemes, over any form type; `IsAnalogicallyRegular` is its translation instance for group-valued forms, with the difference form, additive decomposition, and map lemmas derived from it.
- `Complexity.lean`: analogy under any operations makes a paradigm system vocabularly clear (`isVocabularClear_of_isAnalogical`), which the existing theorem chains to zero conditional entropy; Blevins's analogy meets Ackerman and Malouf's implicative structure.
- `DiscriminativeLexicon.Linear.paradigm` and `realization` now take any meaning assignment, covering the book's empirical-embedding route; `imputed σ ε` in `Coding.lean` is the constructed route (Table 12.7), and regularity is proved for it alone. The Heitmeier study says lexeme and inflectional function, not stem and exponent (Box 1.3, ch. 5), and states all three results on the interface.