### PR TITLE
refactor(DiscriminativeLexicon): training as columnwise least squares

### DIFF
--- a/Linglib/Core/Analysis/LeastSquares.lean
+++ b/Linglib/Core/Analysis/LeastSquares.lean
@@ -21,7 +21,8 @@ fitted values, and the solution coset.
 * `isLeastSquares_iff_adjoint_eq_zero`, `isLeastSquares_iff_inner_eq_zero`: the **normal
   equations** — the adjoint kills the residual, equivalently the residual is orthogonal to the
   range of `A`.
-* `exists_isLeastSquares`: solutions exist.
+* `exists_isLeastSquares`, `isLeastSquares_of_map_eq`: solutions exist, and an interpolating
+  point is one.
 * `IsLeastSquares.map_eq`, `IsLeastSquares.iff_map_eq`: fitted values are unique, and the
   solutions are exactly the preimages of the fitted value.
 -/
@@ -37,7 +38,13 @@ variable {E F : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
 `‖b − A y‖`. -/
 def IsLeastSquares (x : E) : Prop := IsMinOn (fun y => ‖b - A y‖) Set.univ x
 
-variable {A b} [FiniteDimensional ℝ E] [FiniteDimensional ℝ F] {x x' : E}
+variable {A b} {x x' : E}
+
+/-- An interpolating point is a least-squares solution. -/
+theorem isLeastSquares_of_map_eq (h : A x = b) : IsLeastSquares A b x :=
+  isMinOn_univ_iff.mpr fun y => by simp [h]
+
+variable [FiniteDimensional ℝ E] [FiniteDimensional ℝ F]
 
 /-- The normal equations in adjoint form: `x` solves iff the adjoint kills the residual. -/
 theorem isLeastSquares_iff_adjoint_eq_zero :

--- a/Linglib/Processing/DiscriminativeLexicon/Training.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Training.lean
@@ -1,35 +1,36 @@
 import Linglib.Core.Analysis.LeastSquares
 import Linglib.Processing.DiscriminativeLexicon.Measures
+import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.LinearAlgebra.Matrix.DotProduct
-import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.ToLin
 
 /-!
 # DLM training: endstate and frequency-informed learning
 
-The trained production map of a DLM minimises a frequency-weighted quadratic loss over the
-training experience. The choice of weights is the cognitive commitment — uniform weights are
-endstate learning (EL), token counts are frequency-informed learning (FIL,
-[heitmeier-chuang-axen-baayen-2024]) — and the optimisation is fixed. Through the `√q`-scaled
-design map the loss is a Euclidean least-squares residual, so `Core.IsLeastSquares` supplies the
-theory: the normal equations `SᵀQ(SG − C) = 0` of [gahl-baayen-2024]'s appendix, existence of
-solutions, uniqueness of fitted values (hence of `semSup` at experienced meanings), the
-solution coset, and the identification of FIL under `q` with EL on the `√q`-premultiplied
-experience ([heitmeier-2024]).
+A DLM is trained by solving `SG = C` in the least-squares sense: the mapping matrix `G` minimises
+the frequency-weighted loss `∑ᵢ qᵢ ‖(SG − C)ᵢ‖²` over the semantic matrix `S` and form matrix `C`
+of the training experience. The weights are the cognitive commitment, uniform for endstate
+learning (EL) and token counts for frequency-informed learning (FIL,
+[heitmeier-chuang-axen-baayen-2024]); the optimisation is fixed. The loss separates over form
+coordinates, so each column of `G` is a vector least-squares problem for the `√Q`-scaled design
+`√Q S`, where Mathlib characterises the minimisers by the adjoint (`Core.IsLeastSquares`). That
+gives the normal equations `SᵀQ(SG − C) = 0` of [gahl-baayen-2024]'s appendix and their closed
+form `(SᵀQS)⁻¹SᵀQC`, existence, uniqueness of the fitted values `SG` (hence of `semSup` at
+experienced meanings), the solution coset, and the identification of FIL under `q` with EL on the
+`√Q`-premultiplied experience ([heitmeier-2024]).
 
 ## Main declarations
 
-* `TrainingExperience`, `FrequencyVector`, `weightedLoss`, `IsERMSolution`, `IsELSolution`.
-* `isERMSolution_iff_isLeastSquares`, `exists_isERMSolution`.
-* `isERMSolution_iff_inner_eq_zero`, `isERMSolution_iff_forall_coord`,
-  `IsERMSolution.sum_smul_sub_eq_zero`: the normal equations, against every direction, in
-  coordinates, and in vector form.
-* `IsERMSolution.apply_meanings_eq`, `apply_eq_of_mem_span`, `exists_apply_ne`,
-  `existsUnique_isERMSolution_iff`: fitted values are unique exactly on the span of experience.
-* `isERMSolution_toLin'_transpose_iff`, `isERMSolution_closedForm`: the normal equations as
-  `SᵀQ(SG − C) = 0` and their closed form `(SᵀQS)⁻¹SᵀQC`.
-* `isELSolution_sqrtScale_iff`: FIL under `q` is EL on `TrainingExperience.sqrtScale`.
+* `TrainingExperience`, `FrequencyVector`, `weightedLoss`, `IsTrained`, `IsELTrained`.
+* `isTrained_iff_forall_isLeastSquares`, `exists_isTrained`: training is columnwise least
+  squares, and solutions exist.
+* `isTrained_iff`, `isTrained_closedForm`: the normal equations `SᵀQ(SG − C) = 0` and their
+  closed form.
+* `IsTrained.mul_eq`, `IsTrained.vecMul_eq_of_mem_span`, `IsTrained.exists_vecMul_ne`,
+  `existsUnique_isTrained_iff`: fitted values are unique exactly on the span of experience.
+* `isELTrained_sqrtScale_iff`: FIL under `q` is EL on `TrainingExperience.sqrtScale`.
 * `Linear.IsTrainedOn` and the `semSup` transfer theorems.
 
 ## References
@@ -46,447 +47,402 @@ namespace DiscriminativeLexicon
 
 noncomputable section
 
-open Matrix NNReal RealInnerProductSpace
+open Matrix NNReal
 
 variable {m n d : ℕ}
 
 /-! ### The training problem -/
 
-/-- A **training experience**: a finite indexed family of (meaning, form) observation pairs, the
-rows of the papers' `S` and `C` matrices. -/
+/-- A **training experience**: the papers' semantic matrix `S` and form matrix `C`, one usage
+event per row. -/
 structure TrainingExperience (numEvents formDim meaningDim : ℕ) where
-  meanings : Fin numEvents → MeaningVec meaningDim
-  forms : Fin numEvents → FormVec formDim
+  /-- The semantic matrix: the experienced meanings as rows. -/
+  S : Matrix (Fin numEvents) (Fin meaningDim) ℝ
+  /-- The form matrix: the observed forms as rows. -/
+  C : Matrix (Fin numEvents) (Fin formDim) ℝ
 
-/-- A **frequency vector** weights each usage event — the diagonal of the papers' `Q`. Uniform
+/-- A **frequency vector** weights each usage event, the diagonal of the papers' `Q`. Uniform
 weights give EL, token counts FIL ([gahl-baayen-2024]'s appendix, which warns against
 log-transforming them). -/
 abbrev FrequencyVector (numEvents : ℕ) : Type := Fin numEvents → ℝ≥0
 
-variable (data : TrainingExperience m n d) (q : FrequencyVector m)
-  (G : MeaningVec d →ₗ[ℝ] FormVec n)
+variable (data : TrainingExperience m n d) (q : FrequencyVector m) (G : Matrix (Fin d) (Fin n) ℝ)
 
-/-- The **frequency-weighted training loss** `∑ᵢ qᵢ ‖G sᵢ − cᵢ‖²`. -/
+/-- The weight matrix `Q`. -/
+def FrequencyVector.Q : Matrix (Fin m) (Fin m) ℝ := diagonal fun i => (q i : ℝ)
+
+/-- Its square root, the `√Q` of the papers' appendix. -/
+def FrequencyVector.sqrtQ : Matrix (Fin m) (Fin m) ℝ := diagonal fun i => √(q i : ℝ)
+
+@[simp] theorem FrequencyVector.Q_one : (1 : FrequencyVector m).Q = 1 := by
+  simp [FrequencyVector.Q]
+
+@[simp] theorem FrequencyVector.sqrtQ_one : (1 : FrequencyVector m).sqrtQ = 1 := by
+  simp [FrequencyVector.sqrtQ]
+
+@[simp] theorem FrequencyVector.sqrtQ_transpose : q.sqrtQᵀ = q.sqrtQ := diagonal_transpose _
+
+theorem FrequencyVector.sqrtQ_mul_sqrtQ : q.sqrtQ * q.sqrtQ = q.Q := by
+  simp [FrequencyVector.sqrtQ, FrequencyVector.Q, diagonal_mul_diagonal, Real.mul_self_sqrt]
+
+/-- The `√Q`-premultiplied experience `(√Q S, √Q C)` of the papers' appendix. -/
+def TrainingExperience.sqrtScale : TrainingExperience m n d := ⟨q.sqrtQ * data.S, q.sqrtQ * data.C⟩
+
+@[simp] theorem TrainingExperience.sqrtScale_S (i : Fin m) :
+    (data.sqrtScale q).S i = √(q i : ℝ) • data.S i := by
+  funext k; simp [TrainingExperience.sqrtScale, FrequencyVector.sqrtQ, diagonal_mul]
+
+@[simp] theorem TrainingExperience.sqrtScale_C (i : Fin m) :
+    (data.sqrtScale q).C i = √(q i : ℝ) • data.C i := by
+  funext j; simp [TrainingExperience.sqrtScale, FrequencyVector.sqrtQ, diagonal_mul]
+
+/-- The **frequency-weighted training loss** `∑ᵢ qᵢ ‖(SG − C)ᵢ‖²`. -/
 def weightedLoss : ℝ :=
-  ∑ i, q i * ((G (data.meanings i) - data.forms i) ⬝ᵥ (G (data.meanings i) - data.forms i))
+  ∑ i, q i * ((data.S * G - data.C) i ⬝ᵥ (data.S * G - data.C) i)
 
 theorem weightedLoss_nonneg : 0 ≤ weightedLoss data q G :=
   Finset.sum_nonneg fun i _ => mul_nonneg (q i).2 (Finset.sum_nonneg fun _ _ => mul_self_nonneg _)
 
 /-- Under positive weights the loss vanishes exactly on interpolating maps. -/
 theorem weightedLoss_eq_zero_iff (hq : ∀ i, 0 < q i) :
-    weightedLoss data q G = 0 ↔ ∀ i, G (data.meanings i) = data.forms i := by
+    weightedLoss data q G = 0 ↔ data.S * G = data.C := by
   constructor
-  · intro h0 i
+  · intro h0
+    ext i j
     have hterm := (Finset.sum_eq_zero_iff_of_nonneg fun k _ =>
       mul_nonneg (q k).2 (Finset.sum_nonneg fun _ _ => mul_self_nonneg _)).1 h0 i
       (Finset.mem_univ i)
-    exact sub_eq_zero.1 <| dotProduct_self_eq_zero.1 <|
-      (mul_eq_zero.1 hterm).resolve_left (NNReal.coe_pos.2 (hq i)).ne'
+    have hrow := dotProduct_self_eq_zero.1
+      ((mul_eq_zero.1 hterm).resolve_left (NNReal.coe_pos.2 (hq i)).ne')
+    simpa [sub_eq_zero] using congrFun hrow j
   · intro h
-    simp [weightedLoss, h]
+    simp [weightedLoss, h, dotProduct]
 
-/-- `G` is an **empirical risk minimiser** (ERM) for `data` under `q`: no linear map achieves
-a smaller weighted loss. -/
-def IsERMSolution : Prop := IsMinOn (weightedLoss data q) Set.univ G
+/-- `G` is **trained** on `data` under `q` when it minimises the weighted loss over all mapping
+matrices: `SG = C` solved by least squares. -/
+def IsTrained : Prop := IsMinOn (weightedLoss data q) Set.univ G
 
-/-- An **endstate-learning** (EL) solution is an ERM solution under uniform weights
-([gahl-baayen-2024] appendix). -/
-abbrev IsELSolution : Prop := IsERMSolution data 1 G
+/-- **Endstate learning**: training under uniform weights ([gahl-baayen-2024] appendix). -/
+abbrev IsELTrained : Prop := IsTrained data 1 G
 
-/-- The weighted loss is linear in the frequency vector. -/
-theorem weightedLoss_smul_frequency (c : ℝ≥0) :
+theorem weightedLoss_smul (c : ℝ≥0) :
     weightedLoss data (c • q) G = c * weightedLoss data q G := by
   simp [weightedLoss, Finset.mul_sum, mul_assoc]
 
-/-- ERM solutions are invariant under positive rescaling of the frequency vector — only
-relative frequencies matter. -/
-theorem isERMSolution_iff_rescaled {c : ℝ≥0} (hc : 0 < c) :
-    IsERMSolution data (c • q) G ↔ IsERMSolution data q G := by
-  simp only [IsERMSolution, isMinOn_univ_iff, weightedLoss_smul_frequency,
+/-- Only relative frequencies matter. -/
+theorem isTrained_smul_iff {c : ℝ≥0} (hc : 0 < c) :
+    IsTrained data (c • q) G ↔ IsTrained data q G := by
+  simp only [IsTrained, isMinOn_univ_iff, weightedLoss_smul,
     mul_le_mul_iff_right₀ (NNReal.coe_pos.2 hc)]
 
-/-! ### Training as Euclidean least squares
+/-- The uniform-weight loss on the `√Q`-premultiplied experience is the `q`-weighted loss. -/
+theorem weightedLoss_sqrtScale :
+    weightedLoss (data.sqrtScale q) 1 G = weightedLoss data q G := by
+  unfold weightedLoss
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hrow : ((data.sqrtScale q).S * G - (data.sqrtScale q).C) i =
+      √(q i : ℝ) • (data.S * G - data.C) i := by
+    show (data.sqrtScale q).S i ᵥ* G - (data.sqrtScale q).C i =
+      √(q i : ℝ) • (data.S i ᵥ* G - data.C i)
+    rw [TrainingExperience.sqrtScale_S, TrainingExperience.sqrtScale_C, smul_vecMul, smul_sub]
+  rw [hrow, smul_dotProduct, dotProduct_smul, smul_eq_mul, smul_eq_mul]
+  simp [← mul_assoc, Real.mul_self_sqrt (q i).coe_nonneg]
 
-The `√q`-scaled predictions of a production map are a point of Euclidean event-coordinate
-space, and the weighted loss is the squared distance to the scaled observations; production
-maps enter through their matrices. -/
+/-- FIL under `q` is exactly EL on the `√Q`-premultiplied experience: [heitmeier-2024]'s FIL–EL
+equivalence, invertibility-free. -/
+theorem isELTrained_sqrtScale_iff : IsELTrained (data.sqrtScale q) G ↔ IsTrained data q G := by
+  have h : weightedLoss (data.sqrtScale q) 1 = weightedLoss data q :=
+    funext fun G => weightedLoss_sqrtScale data q G
+  simp only [IsELTrained, IsTrained, h]
 
-/-- Production maps as points of Euclidean space, via their matrices. -/
-def toEuclidean : (MeaningVec d →ₗ[ℝ] FormVec n) ≃ₗ[ℝ] EuclideanSpace ℝ (Fin n × Fin d) :=
-  LinearMap.toMatrix' ≪≫ₗ (LinearEquiv.curry ℝ ℝ (Fin n) (Fin d)).symm ≪≫ₗ
-    (WithLp.linearEquiv 2 ℝ _).symm
+/-! ### Training as columnwise least squares
 
-@[simp] theorem toEuclidean_apply (p : Fin n × Fin d) :
-    (toEuclidean G).ofLp p = G (Pi.single p.2 1) p.1 := rfl
+The loss separates over form coordinates: column `j` of `G` is a least-squares solution of the
+`√Q`-scaled regression of column `j` of `C` on `S`, a vector problem in Euclidean space. -/
 
-/-- The `√q`-scaled **design map**: the scaled predictions `√qᵢ (G sᵢ)ⱼ` of the production map
-with the given matrix. -/
-def designMap : EuclideanSpace ℝ (Fin n × Fin d) →ₗ[ℝ] EuclideanSpace ℝ (Fin m × Fin n) :=
-  ((WithLp.linearEquiv 2 ℝ _).symm.toLinearMap ∘ₗ
-    LinearMap.pi fun p => (Real.sqrt (q p.1) : ℝ) •
-      (LinearMap.proj p.2 ∘ₗ LinearMap.applyₗ (data.meanings p.1))) ∘ₗ
-    toEuclidean.symm.toLinearMap
+private theorem col_mul {l : ℕ} (A : Matrix (Fin m) (Fin l) ℝ) (B : Matrix (Fin l) (Fin n) ℝ)
+    (j : Fin n) : (A * B)ᵀ j = A *ᵥ Bᵀ j := by
+  funext i; simp [mul_apply, mulVec, dotProduct]
 
-@[simp] theorem designMap_toEuclidean (p : Fin m × Fin n) :
-    (designMap data q (toEuclidean G)).ofLp p = Real.sqrt (q p.1) * G (data.meanings p.1) p.2 := by
-  simp [designMap]
+private theorem col_sub (A B : Matrix (Fin m) (Fin n) ℝ) (j : Fin n) :
+    (A - B)ᵀ j = Aᵀ j - Bᵀ j := rfl
 
-/-- The `√q`-scaled observed forms. -/
-def scaledTarget : EuclideanSpace ℝ (Fin m × Fin n) :=
-  WithLp.toLp 2 fun p => Real.sqrt (q p.1) * data.forms p.1 p.2
-
-/-- The weighted loss is the squared least-squares residual of the design map. -/
-theorem weightedLoss_eq_norm_sq :
-    weightedLoss data q G = ‖scaledTarget data q - designMap data q (toEuclidean G)‖ ^ 2 := by
-  rw [EuclideanSpace.norm_sq_eq, Fintype.sum_prod_type]
+/-- The weighted loss is the sum over form coordinates of the columns' squared residuals. -/
+theorem weightedLoss_eq_sum_norm_sq :
+    weightedLoss data q G = ∑ j, ‖WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j) -
+      toEuclideanLin (q.sqrtQ * data.S) (WithLp.toLp 2 (Gᵀ j))‖ ^ 2 := by
+  simp only [toLpLin_toLp, toLin'_apply, ← WithLp.toLp_sub, EuclideanSpace.norm_sq_eq,
+    Pi.sub_apply, Real.norm_eq_abs, sq_abs, ← col_mul, transpose_apply, Matrix.mul_assoc,
+    FrequencyVector.sqrtQ, diagonal_mul]
+  rw [Finset.sum_comm]
   unfold weightedLoss dotProduct
-  simp_rw [Finset.mul_sum]
-  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-  simp only [PiLp.sub_apply, designMap_toEuclidean, scaledTarget, Real.norm_eq_abs, sq_abs,
-    Pi.sub_apply]
-  linear_combination
-    -(G (data.meanings i) j - data.forms i j) ^ 2 * Real.mul_self_sqrt (q i).coe_nonneg
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  rw [Matrix.sub_apply]
+  linear_combination -(data.C i j - (data.S * G) i j) ^ 2 * Real.mul_self_sqrt (q i).coe_nonneg
 
-/-- ERM solutions are exactly the least-squares solutions of the design map: DLM training,
-seen through `√q`-scaling, is weighted linear regression. -/
-theorem isERMSolution_iff_isLeastSquares :
-    IsERMSolution data q G ↔
-      Core.IsLeastSquares (designMap data q) (scaledTarget data q) (toEuclidean G) := by
-  simp only [IsERMSolution, Core.IsLeastSquares, isMinOn_univ_iff, weightedLoss_eq_norm_sq]
-  refine ⟨fun h z => ?_, fun h G' => ?_⟩
-  · have := h (toEuclidean.symm z)
-    rw [LinearEquiv.apply_symm_apply] at this
-    exact (sq_le_sq₀ (norm_nonneg _) (norm_nonneg _)).1 this
-  · exact pow_le_pow_left₀ (norm_nonneg _) (h (toEuclidean G')) 2
+/-- Minimising a separable finite sum over a product is minimising each term. -/
+private theorem sum_min_iff {ι : Type*} [Fintype ι] [DecidableEq ι] {β : ι → Type*}
+    (g : ∀ i, β i → ℝ) (x : ∀ i, β i) :
+    (∀ y : ∀ i, β i, ∑ i, g i (x i) ≤ ∑ i, g i (y i)) ↔ ∀ i, ∀ b : β i, g i (x i) ≤ g i b := by
+  refine ⟨fun h i b => ?_, fun h y => Finset.sum_le_sum fun i _ => h i (y i)⟩
+  have hy := h (Function.update x i b)
+  simp_rw [Function.apply_update (fun j => g j) x i b] at hy
+  rw [Finset.sum_update_of_mem (Finset.mem_univ i),
+    ← Finset.add_sum_erase Finset.univ _ (Finset.mem_univ i), Finset.erase_eq] at hy
+  linarith
 
-/-- ERM solutions exist. -/
-theorem exists_isERMSolution : ∃ G, IsERMSolution data q G :=
-  let ⟨z, hz⟩ := Core.exists_isLeastSquares (A := designMap data q) (b := scaledTarget data q)
-  ⟨toEuclidean.symm z, by rwa [isERMSolution_iff_isLeastSquares, LinearEquiv.apply_symm_apply]⟩
+/-- Training is columnwise least squares: each column of `G` minimises the residual of the
+corresponding scaled regression. -/
+theorem isTrained_iff_forall_isLeastSquares :
+    IsTrained data q G ↔ ∀ j, Core.IsLeastSquares (toEuclideanLin (q.sqrtQ * data.S))
+      (WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j)) (WithLp.toLp 2 (Gᵀ j)) := by
+  have key := sum_min_iff (fun j v => ‖WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j) -
+    toEuclideanLin (q.sqrtQ * data.S) (WithLp.toLp 2 v)‖ ^ 2) Gᵀ
+  simp only [IsTrained, Core.IsLeastSquares, isMinOn_univ_iff, weightedLoss_eq_sum_norm_sq]
+  refine ⟨fun h j z => ?_,
+    fun h G' => key.2 (fun j v => pow_le_pow_left₀ (norm_nonneg _) (h j _) 2) G'ᵀ⟩
+  have := key.1 (fun y => h yᵀ) j z.ofLp
+  simpa using (sq_le_sq₀ (norm_nonneg _) (norm_nonneg _)).1 this
+
+/-- Trained mapping matrices exist. -/
+theorem exists_isTrained : ∃ G, IsTrained data q G := by
+  choose x hx using fun j => Core.exists_isLeastSquares (A := toEuclideanLin (q.sqrtQ * data.S))
+    (b := WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j))
+  exact ⟨Matrix.of fun k j => (x j).ofLp k, (isTrained_iff_forall_isLeastSquares _ _ _).2 hx⟩
 
 /-! ### The normal equations -/
 
-variable {data q G}
+/-- **Normal equations**: `G` is trained iff `SᵀQ(SG − C) = 0` ([gahl-baayen-2024] (A2), (A4)),
+from Mathlib's adjoint characterisation of least squares, column by column. -/
+theorem isTrained_iff : IsTrained data q G ↔ data.Sᵀ * q.Q * (data.S * G - data.C) = 0 := by
+  have hcol : ∀ j, Core.IsLeastSquares (toEuclideanLin (q.sqrtQ * data.S))
+      (WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j)) (WithLp.toLp 2 (Gᵀ j)) ↔
+      ((q.sqrtQ * data.S)ᵀ * (q.sqrtQ * data.C - q.sqrtQ * data.S * G))ᵀ j = 0 := fun j => by
+    rw [Core.isLeastSquares_iff_adjoint_eq_zero, ← toEuclideanLin_conjTranspose_eq_adjoint,
+      conjTranspose_eq_transpose_of_trivial]
+    simp only [toLpLin_toLp, toLin'_apply, ← WithLp.toLp_sub, WithLp.toLp_eq_zero, ← col_mul,
+      ← col_sub]
+  have hX : (q.sqrtQ * data.S)ᵀ * (q.sqrtQ * data.C - q.sqrtQ * data.S * G) =
+      -(data.Sᵀ * q.Q * (data.S * G - data.C)) := by
+    rw [transpose_mul, FrequencyVector.sqrtQ_transpose, Matrix.mul_assoc q.sqrtQ,
+      ← Matrix.mul_sub, Matrix.mul_assoc, ← Matrix.mul_assoc q.sqrtQ,
+      FrequencyVector.sqrtQ_mul_sqrtQ, ← Matrix.mul_assoc, ← neg_sub (data.S * G) data.C,
+      Matrix.mul_neg]
+  rw [isTrained_iff_forall_isLeastSquares]
+  simp only [hcol]
+  rw [hX, ← neg_eq_zero (a := data.Sᵀ * q.Q * (data.S * G - data.C)), ← transpose_eq_zero]
+  exact ⟨funext, fun h j => congrFun h j⟩
 
-private theorem inner_residual_designMap (H : MeaningVec d →ₗ[ℝ] FormVec n) :
-    ⟪scaledTarget data q - designMap data q (toEuclidean G), designMap data q (toEuclidean H)⟫ =
-      -∑ i, q i * ((G (data.meanings i) - data.forms i) ⬝ᵥ H (data.meanings i)) := by
-  rw [PiLp.inner_apply, Fintype.sum_prod_type, ← Finset.sum_neg_distrib]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  unfold dotProduct
-  rw [Finset.mul_sum, ← Finset.sum_neg_distrib]
-  refine Finset.sum_congr rfl fun j _ => ?_
-  simp only [PiLp.sub_apply, designMap_toEuclidean, scaledTarget, Pi.sub_apply, RCLike.inner_apply,
-    conj_trivial]
-  linear_combination (data.forms i j - G (data.meanings i) j) * H (data.meanings i) j *
-    Real.mul_self_sqrt (q i).coe_nonneg
-
-/-- **Normal equations**: `G` is an ERM solution iff its `q`-weighted residuals are orthogonal
-to the predictions of every linear map — `SᵀQ(SG − C) = 0` with `Sᵀ`'s rows generalised to all
-directions. -/
-theorem isERMSolution_iff_inner_eq_zero :
-    IsERMSolution data q G ↔ ∀ H : MeaningVec d →ₗ[ℝ] FormVec n,
-      ∑ i, q i * ((G (data.meanings i) - data.forms i) ⬝ᵥ H (data.meanings i)) = 0 := by
-  rw [isERMSolution_iff_isLeastSquares, Core.isLeastSquares_iff_inner_eq_zero]
-  refine ⟨fun h H => ?_, fun h y => ?_⟩
-  · simpa [inner_residual_designMap] using h (toEuclidean H)
-  · obtain ⟨H, rfl⟩ := toEuclidean.surjective y
-    rw [inner_residual_designMap, h H, neg_zero]
-
-/-- The normal equations in coordinates, `SᵀQ(SG − C) = 0` entrywise: at every form coordinate
-`j` the `q`-weighted residual column is orthogonal to every meaning coordinate `k`. -/
-theorem isERMSolution_iff_forall_coord :
-    IsERMSolution data q G ↔ ∀ (j : Fin n) (k : Fin d),
-      ∑ i, q i * ((G (data.meanings i) j - data.forms i j) * data.meanings i k) = 0 := by
-  rw [isERMSolution_iff_inner_eq_zero]
-  constructor
-  · intro h j k
-    simpa [dotProduct_single, mul_comm, mul_left_comm] using
-      h ((LinearMap.proj k).smulRight (Pi.single j 1))
-  · intro h H
-    have hH : ∀ i, q i * ((G (data.meanings i) - data.forms i) ⬝ᵥ H (data.meanings i)) =
-        ∑ j, ∑ k, q i * ((G (data.meanings i) j - data.forms i j) * data.meanings i k) *
-          H (fun j => if k = j then 1 else 0) j := fun i => by
-      have hx : H (data.meanings i) =
-          ∑ k, data.meanings i k • H (fun j => if k = j then 1 else 0) :=
-        H.pi_apply_eq_sum_univ _
-      unfold dotProduct
-      rw [hx, Finset.mul_sum]
-      refine Finset.sum_congr rfl fun j _ => ?_
-      rw [Finset.sum_apply, Finset.mul_sum, Finset.mul_sum]
-      exact Finset.sum_congr rfl fun k _ => by
-        simp only [Pi.smul_apply, smul_eq_mul, Pi.sub_apply]; ring
-    simp_rw [hH]
-    rw [Finset.sum_comm]
-    refine Finset.sum_eq_zero fun j _ => ?_
-    rw [Finset.sum_comm]
-    refine Finset.sum_eq_zero fun k _ => ?_
-    rw [← Finset.sum_mul, h j k, zero_mul]
-
-/-- The normal equations in vector form: the `q`-weighted residuals, weighted further by any
-linear functional of the meanings, sum to zero. -/
-theorem IsERMSolution.sum_smul_sub_eq_zero (hG : IsERMSolution data q G)
-    (w : MeaningVec d →ₗ[ℝ] ℝ) :
-    ∑ i, (q i * w (data.meanings i)) • (G (data.meanings i) - data.forms i) = 0 := by
-  funext j
-  have h := isERMSolution_iff_inner_eq_zero.1 hG (w.smulRight (Pi.single j 1))
-  simpa [dotProduct_smul, dotProduct_single, Finset.sum_apply, mul_assoc, mul_comm,
-    mul_left_comm] using h
-
-/-! ### Fitted values -/
-
-/-- All ERM solutions under positive weights produce the same predicted form at every
-experienced meaning — fitted values are unique even when the ERM map is not. -/
-theorem IsERMSolution.apply_meanings_eq (hq : ∀ i, 0 < q i)
-    {G' : MeaningVec d →ₗ[ℝ] FormVec n}
-    (hG : IsERMSolution data q G) (hG' : IsERMSolution data q G') (i : Fin m) :
-    G (data.meanings i) = G' (data.meanings i) := by
-  rw [isERMSolution_iff_isLeastSquares] at hG hG'
-  funext j
-  have h := congrArg (fun v : EuclideanSpace ℝ (Fin m × Fin n) => v.ofLp (i, j)) (hG.map_eq hG')
-  simp only [designMap_toEuclidean] at h
-  exact mul_left_cancel₀ (Real.sqrt_pos.2 (NNReal.coe_pos.2 (hq i))).ne' h
-
-/-- ERM solutions agree at every meaning in the span of the experienced ones. -/
-theorem IsERMSolution.apply_eq_of_mem_span (hq : ∀ i, 0 < q i)
-    {G' : MeaningVec d →ₗ[ℝ] FormVec n}
-    (hG : IsERMSolution data q G) (hG' : IsERMSolution data q G')
-    {s : MeaningVec d} (hs : s ∈ Submodule.span ℝ (Set.range data.meanings)) :
-    G s = G' s := by
-  have hker : Submodule.span ℝ (Set.range data.meanings) ≤ LinearMap.ker (G' - G) :=
-    Submodule.span_le.mpr <| Set.range_subset_iff.mpr fun i => by
-      simp [LinearMap.mem_ker, (IsERMSolution.apply_meanings_eq hq hG hG' i).symm]
-  have h0 := hker hs
-  rw [LinearMap.mem_ker, LinearMap.sub_apply, sub_eq_zero] at h0
-  exact h0.symm
-
-/-- Adding a map that vanishes on every training meaning preserves ERM. -/
-theorem IsERMSolution.add_of_forall_eq_zero (hG : IsERMSolution data q G)
-    {H : MeaningVec d →ₗ[ℝ] FormVec n} (hH : ∀ i, H (data.meanings i) = 0) :
-    IsERMSolution data q (G + H) := by
-  rw [isERMSolution_iff_isLeastSquares] at hG ⊢
-  refine hG.iff_map_eq.mpr ?_
-  rw [map_add, map_add, add_eq_left]
-  exact (WithLp.ofLp_eq_zero 2).1 (funext fun p => by simp [hH])
-
-/-- Off the span of experienced meanings, ERM solutions are underdetermined: any ERM solution
-can be modified into another with a different prediction at an unexperienced meaning. -/
-theorem IsERMSolution.exists_apply_ne [NeZero n] (hG : IsERMSolution data q G)
-    {s : MeaningVec d} (hs : s ∉ Submodule.span ℝ (Set.range data.meanings)) :
-    ∃ G' : MeaningVec d →ₗ[ℝ] FormVec n, IsERMSolution data q G' ∧ G s ≠ G' s := by
-  obtain ⟨φ, hφ, hφs⟩ : ∃ φ ∈ (Submodule.span ℝ (Set.range data.meanings)).dualAnnihilator,
-      φ s ≠ 0 := by
-    have h := mt (Subspace.forall_mem_dualAnnihilator_apply_eq_zero_iff _ s).mp hs
-    push Not at h
-    exact h
-  refine ⟨G + φ.smulRight (Pi.single 0 1), hG.add_of_forall_eq_zero fun i => by
-    simp [(Submodule.mem_dualAnnihilator φ).mp hφ _
-      (Submodule.subset_span (Set.mem_range_self i))], fun h => ?_⟩
-  have h0 := congrFun h (0 : Fin n)
-  simp only [LinearMap.add_apply, LinearMap.smulRight_apply, Pi.add_apply, Pi.smul_apply,
-    Pi.single_eq_same, smul_eq_mul, mul_one] at h0
-  exact hφs (by linarith)
-
-/-- The trained map is uniquely determined exactly when the experienced meanings span the
-meaning space — the coordinate-free form of the papers' full-column-rank condition on the
-closed-form solution ([gahl-baayen-2024] appendix; [heitmeier-2024]). -/
-theorem existsUnique_isERMSolution_iff [NeZero n] (hq : ∀ i, 0 < q i) :
-    (∃! G : MeaningVec d →ₗ[ℝ] FormVec n, IsERMSolution data q G) ↔
-      Submodule.span ℝ (Set.range data.meanings) = ⊤ := by
-  constructor
-  · rintro ⟨G, hG, huniq⟩
-    by_contra hne
-    obtain ⟨s, hs⟩ : ∃ s, s ∉ Submodule.span ℝ (Set.range data.meanings) := by
-      by_contra hall
-      push Not at hall
-      exact hne (Submodule.eq_top_iff'.mpr hall)
-    obtain ⟨G', hG', hne'⟩ := hG.exists_apply_ne hs
-    exact hne' (by rw [huniq G' hG'])
-  · intro htop
-    obtain ⟨G, hG⟩ := exists_isERMSolution data q
-    exact ⟨G, hG, fun G' hG' => LinearMap.ext fun s =>
-      IsERMSolution.apply_eq_of_mem_span hq hG' hG (Submodule.eq_top_iff'.mp htop s)⟩
-
-/-- If some linear functional of the meanings reproduces coordinate `j₀` of the observed forms
-exactly, so does every ERM solution under positive weights, on every training event. -/
-theorem IsERMSolution.coord_eq_of_decodable (hq : ∀ i, 0 < q i) (hG : IsERMSolution data q G)
-    {j₀ : Fin n} {w : MeaningVec d →ₗ[ℝ] ℝ}
-    (hw : ∀ i, w (data.meanings i) = data.forms i j₀) (i : Fin m) :
-    G (data.meanings i) j₀ = data.forms i j₀ := by
-  have h := (isERMSolution_iff_inner_eq_zero.1 hG)
-    ((w - LinearMap.proj j₀ ∘ₗ G).smulRight (Pi.single j₀ 1))
-  simp only [LinearMap.smulRight_apply, LinearMap.sub_apply, LinearMap.comp_apply,
-    LinearMap.proj_apply, dotProduct_smul, dotProduct_single, Pi.sub_apply, hw, smul_eq_mul,
-    mul_one] at h
-  have hterm : ∀ k ∈ Finset.univ, (q k : ℝ) * ((data.forms k j₀ - G (data.meanings k) j₀) *
-      (G (data.meanings k) j₀ - data.forms k j₀)) ≤ 0 := fun k _ =>
-    mul_nonpos_of_nonneg_of_nonpos (q k).2
-      (by nlinarith [sq_nonneg (G (data.meanings k) j₀ - data.forms k j₀)])
-  have hi := (Finset.sum_eq_zero_iff_of_nonpos hterm).1 h i (Finset.mem_univ i)
-  rcases mul_eq_zero.1 hi with h0 | h0
-  · exact absurd h0 (NNReal.coe_pos.2 (hq i)).ne'
-  · rcases mul_eq_zero.1 h0 with h1 | h1
-    · exact (sub_eq_zero.1 h1).symm
-    · exact sub_eq_zero.1 h1
-
-/-! ### The normal equations in matrix form
-
-The papers state the training problem on matrices: the semantic matrix `S` and form matrix `C`
-have the experienced meanings and forms as rows, the frequency vector is the diagonal of `Q`, and
-a mapping matrix `G` acts on row vectors, `ĉ = sG`. The normal equations read `SᵀQ(SG − C) = 0`,
-solved in closed form as `G = (SᵀQS)⁻¹SᵀQC` whenever `SᵀQS` is invertible ([gahl-baayen-2024]
-(A2), (A4); [heitmeier-chuang-baayen-2026] §6.1, §6.3). -/
-
-variable (data q)
-
-/-- The semantic matrix `S`: the experienced meanings as rows. -/
-def TrainingExperience.S : Matrix (Fin m) (Fin d) ℝ := Matrix.of fun i k => data.meanings i k
-
-/-- The form matrix `C`: the observed forms as rows. -/
-def TrainingExperience.C : Matrix (Fin m) (Fin n) ℝ := Matrix.of fun i j => data.forms i j
-
-/-- The weight matrix `Q`: the frequency vector on the diagonal. -/
-def FrequencyVector.Q : Matrix (Fin m) (Fin m) ℝ := Matrix.diagonal fun i => (q i : ℝ)
-
-@[simp] theorem TrainingExperience.S_apply (i : Fin m) (k : Fin d) :
-    data.S i k = data.meanings i k := rfl
-
-@[simp] theorem TrainingExperience.C_apply (i : Fin m) (j : Fin n) : data.C i j = data.forms i j :=
-  rfl
-
-@[simp] theorem FrequencyVector.Q_one : (1 : FrequencyVector m).Q = 1 := by
-  simp [FrequencyVector.Q]
-
-/-- The normal equations as a matrix identity: a mapping matrix `G`, acting on row vectors, is
-an ERM solution iff `SᵀQ(SG − C) = 0`. -/
-theorem isERMSolution_toLin'_transpose_iff (G : Matrix (Fin d) (Fin n) ℝ) :
-    IsERMSolution data q (Matrix.toLin' Gᵀ) ↔ data.Sᵀ * q.Q * (data.S * G - data.C) = 0 := by
-  rw [isERMSolution_iff_forall_coord]
-  have key : ∀ (j : Fin n) (k : Fin d), (data.Sᵀ * q.Q * (data.S * G - data.C)) k j =
-      ∑ i, q i * ((Matrix.toLin' Gᵀ (data.meanings i) j - data.forms i j) * data.meanings i k) := by
-    intro j k
-    have hsum : ∀ i, Matrix.toLin' Gᵀ (data.meanings i) j = ∑ l, data.meanings i l * G l j :=
-      fun i => by simp [Matrix.toLin'_apply, Matrix.mulVec, dotProduct, mul_comm]
-    rw [Matrix.mul_apply]
-    simp only [FrequencyVector.Q, Matrix.mul_diagonal, Matrix.transpose_apply,
-      TrainingExperience.S_apply]
-    simp only [Matrix.sub_apply, Matrix.mul_apply, TrainingExperience.S_apply,
-      TrainingExperience.C_apply, hsum]
-    exact Finset.sum_congr rfl fun i _ => by ring
-  constructor
-  · intro h
-    ext k j
-    rw [key, h, Matrix.zero_apply]
-  · intro h j k
-    rw [← key, h, Matrix.zero_apply]
-
-/-- **Closed form**: when `SᵀQS` is invertible, `G = (SᵀQS)⁻¹SᵀQC` solves the normal
-equations ([gahl-baayen-2024] (A2), (A4)). -/
-theorem isERMSolution_closedForm (hS : IsUnit (data.Sᵀ * q.Q * data.S)) :
-    IsERMSolution data q
-      (Matrix.toLin' ((data.Sᵀ * q.Q * data.S)⁻¹ * (data.Sᵀ * q.Q * data.C))ᵀ) := by
-  rw [isERMSolution_toLin'_transpose_iff, Matrix.mul_sub, ← Matrix.mul_assoc,
+/-- **Closed form**: when `SᵀQS` is invertible, `G = (SᵀQS)⁻¹SᵀQC` is trained
+([gahl-baayen-2024] (A2), (A4)). -/
+theorem isTrained_closedForm (hS : IsUnit (data.Sᵀ * q.Q * data.S)) :
+    IsTrained data q ((data.Sᵀ * q.Q * data.S)⁻¹ * (data.Sᵀ * q.Q * data.C)) := by
+  rw [isTrained_iff, Matrix.mul_sub, ← Matrix.mul_assoc,
     Matrix.mul_nonsing_inv_cancel_left _ _ ((Matrix.isUnit_iff_isUnit_det _).1 hS), sub_self]
 
 /-- The endstate closed form `G = (SᵀS)⁻¹SᵀC` ([gahl-baayen-2024] (A2)). -/
-theorem isELSolution_closedForm (hS : IsUnit (data.Sᵀ * data.S)) :
-    IsELSolution data (Matrix.toLin' ((data.Sᵀ * data.S)⁻¹ * (data.Sᵀ * data.C))ᵀ) := by
-  have := isERMSolution_closedForm data 1 (by simpa using hS)
-  simpa [IsELSolution] using this
+theorem isELTrained_closedForm (hS : IsUnit (data.Sᵀ * data.S)) :
+    IsELTrained data ((data.Sᵀ * data.S)⁻¹ * (data.Sᵀ * data.C)) := by
+  simpa only [FrequencyVector.Q_one, Matrix.mul_one] using
+    isTrained_closedForm data 1 (by simpa using hS)
 
-/-! ### √Q transport
+variable {data q G}
 
-[gahl-baayen-2024]'s appendix computes FIL by solving the EL problem on `√Q`-premultiplied `S`
-and `C`; [heitmeier-2024] proves the equivalence with frequency-replicated data under
-invertibility. Here it holds at the level of ERM solution sets. -/
+/-- The normal equations in vector form: the `q`-weighted residual rows, weighted further by any
+linear functional of the meanings, sum to zero. -/
+theorem IsTrained.sum_smul_sub_eq_zero (hG : IsTrained data q G) (w : MeaningVec d →ₗ[ℝ] ℝ) :
+    ∑ i, (q i * w (data.S i)) • ((data.S * G) i - data.C i) = 0 := by
+  rw [isTrained_iff] at hG
+  funext j
+  have hw : ∀ i, w (data.S i) = ∑ k, data.S i k * w (fun j => if k = j then 1 else 0) :=
+    fun i => by rw [w.pi_apply_eq_sum_univ]; simp only [smul_eq_mul]
+  have hk : ∀ k, ∑ i, (q i : ℝ) * (data.S i k * ((data.S * G) i j - data.C i j)) = 0 :=
+    fun k => by
+    have := congrFun (congrFun hG k) j
+    rw [mul_apply] at this
+    simp only [FrequencyVector.Q, mul_diagonal, transpose_apply, Matrix.zero_apply,
+      Matrix.sub_apply] at this
+    exact (Finset.sum_congr rfl fun i _ => by ring).trans this
+  simp only [Finset.sum_apply, Pi.smul_apply, Pi.sub_apply, smul_eq_mul, hw, Finset.sum_mul,
+    Finset.mul_sum, Pi.zero_apply]
+  rw [Finset.sum_comm]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  calc _ = (∑ i, (q i : ℝ) * (data.S i k * ((data.S * G) i j - data.C i j))) *
+          w (fun j => if k = j then 1 else 0) := by
+        rw [Finset.sum_mul]; exact Finset.sum_congr rfl fun i _ => by ring
+    _ = 0 := by rw [hk k, zero_mul]
 
-/-- The `√q`-premultiplied training experience. -/
-def TrainingExperience.sqrtScale : TrainingExperience m n d where
-  meanings i := Real.sqrt (q i) • data.meanings i
-  forms i := Real.sqrt (q i) • data.forms i
+/-! ### Fitted values -/
 
-/-- The uniform-weight loss on the `√q`-premultiplied experience is the `q`-weighted loss. -/
-theorem weightedLoss_sqrtScale :
-    weightedLoss (data.sqrtScale q) 1 G = weightedLoss data q G := by
-  unfold weightedLoss dotProduct
-  refine Finset.sum_congr rfl fun i _ => ?_
-  simp only [TrainingExperience.sqrtScale, map_smul, ← smul_sub, Pi.smul_apply, smul_eq_mul,
-    Pi.one_apply, NNReal.coe_one, one_mul, Finset.mul_sum]
-  exact Finset.sum_congr rfl fun j _ => by
-    linear_combination
-      ((G (data.meanings i) - data.forms i) j) ^ 2 * Real.mul_self_sqrt (q i).coe_nonneg
+/-- All trained matrices under positive weights produce the same predicted forms `SG` on the
+training events: fitted values are unique even when `G` is not. -/
+theorem IsTrained.mul_eq (hq : ∀ i, 0 < q i) {G' : Matrix (Fin d) (Fin n) ℝ}
+    (hG : IsTrained data q G) (hG' : IsTrained data q G') : data.S * G = data.S * G' := by
+  rw [isTrained_iff_forall_isLeastSquares] at hG hG'
+  ext i j
+  have h := congrArg (fun v : EuclideanSpace ℝ (Fin m) => v.ofLp i) ((hG j).map_eq (hG' j))
+  simp only [toLpLin_toLp, toLin'_apply, WithLp.ofLp_toLp, ← col_mul, transpose_apply,
+    Matrix.mul_assoc, FrequencyVector.sqrtQ, diagonal_mul] at h
+  exact mul_left_cancel₀ (Real.sqrt_pos.2 (NNReal.coe_pos.2 (hq i))).ne' h
 
-/-- FIL under `q` is exactly EL on the `√q`-premultiplied experience — [heitmeier-2024]'s
-FIL–EL equivalence, invertibility-free. -/
-theorem isELSolution_sqrtScale_iff :
-    IsELSolution (data.sqrtScale q) G ↔ IsERMSolution data q G := by
-  have h : weightedLoss (data.sqrtScale q) 1 = weightedLoss data q :=
-    funext fun G => weightedLoss_sqrtScale data q (G := G)
-  simp only [IsELSolution, IsERMSolution, h]
+/-- Trained matrices agree at every meaning in the span of the experienced ones. -/
+theorem IsTrained.vecMul_eq_of_mem_span (hq : ∀ i, 0 < q i) {G' : Matrix (Fin d) (Fin n) ℝ}
+    (hG : IsTrained data q G) (hG' : IsTrained data q G') {s : MeaningVec d}
+    (hs : s ∈ Submodule.span ℝ (Set.range data.S)) : s ᵥ* G = s ᵥ* G' := by
+  have hker : Submodule.span ℝ (Set.range data.S) ≤ LinearMap.ker (toLin' (G - G')ᵀ) :=
+    Submodule.span_le.mpr <| Set.range_subset_iff.mpr fun i => by
+      simp only [SetLike.mem_coe, LinearMap.mem_ker, toLin'_apply, mulVec_transpose,
+        Matrix.vecMul_sub, sub_eq_zero]
+      exact congrFun (hG.mul_eq hq hG') i
+  have h0 := hker hs
+  rw [LinearMap.mem_ker, toLin'_apply, mulVec_transpose, Matrix.vecMul_sub, sub_eq_zero] at h0
+  exact h0
 
-end
+/-- Adding a matrix that annihilates every training meaning preserves training. -/
+theorem IsTrained.add_of_mul_eq_zero (hG : IsTrained data q G) {H : Matrix (Fin d) (Fin n) ℝ}
+    (hH : data.S * H = 0) : IsTrained data q (G + H) := by
+  have : weightedLoss data q (G + H) = weightedLoss data q G := by
+    simp [weightedLoss, Matrix.mul_add, hH]
+  simpa only [IsTrained, isMinOn_univ_iff, this] using hG
+
+/-- Off the span of experienced meanings, training is underdetermined: any trained matrix can be
+modified into another with a different prediction at an unexperienced meaning. -/
+theorem IsTrained.exists_vecMul_ne [NeZero n] (hG : IsTrained data q G) {s : MeaningVec d}
+    (hs : s ∉ Submodule.span ℝ (Set.range data.S)) :
+    ∃ G' : Matrix (Fin d) (Fin n) ℝ, IsTrained data q G' ∧ s ᵥ* G ≠ s ᵥ* G' := by
+  obtain ⟨φ, hφ, hφs⟩ : ∃ φ ∈ (Submodule.span ℝ (Set.range data.S)).dualAnnihilator, φ s ≠ 0 := by
+    have h := mt (Subspace.forall_mem_dualAnnihilator_apply_eq_zero_iff _ s).mp hs
+    push Not at h
+    exact h
+  set H : Matrix (Fin d) (Fin n) ℝ :=
+    vecMulVec (fun k => φ fun j => if k = j then 1 else 0) (Pi.single 0 1) with hH
+  have hvec (v : MeaningVec d) : v ᵥ* H = φ v • Pi.single 0 1 := by
+    rw [hH, vecMul_vecMulVec, φ.pi_apply_eq_sum_univ v]; rfl
+  have hSH : data.S * H = 0 := funext fun i => by
+    show data.S i ᵥ* H = 0
+    rw [hvec, (Submodule.mem_dualAnnihilator φ).1 hφ _ (Submodule.subset_span ⟨i, rfl⟩),
+      zero_smul]
+  exact ⟨G + H, hG.add_of_mul_eq_zero hSH,
+    fun h => hφs (by simpa [Matrix.vecMul_add, hvec] using h.symm)⟩
+
+/-- The trained matrix is uniquely determined exactly when the experienced meanings span the
+meaning space: the coordinate-free form of the papers' full-column-rank condition on the
+closed-form solution ([gahl-baayen-2024] appendix; [heitmeier-2024]). -/
+theorem existsUnique_isTrained_iff [NeZero n] (hq : ∀ i, 0 < q i) :
+    (∃! G : Matrix (Fin d) (Fin n) ℝ, IsTrained data q G) ↔
+      Submodule.span ℝ (Set.range data.S) = ⊤ := by
+  constructor
+  · rintro ⟨G, hG, huniq⟩
+    by_contra hne
+    obtain ⟨s, hs⟩ : ∃ s, s ∉ Submodule.span ℝ (Set.range data.S) := by
+      by_contra hall
+      push Not at hall
+      exact hne (Submodule.eq_top_iff'.mpr hall)
+    obtain ⟨G', hG', hne'⟩ := hG.exists_vecMul_ne hs
+    exact hne' (by rw [huniq G' hG'])
+  · intro htop
+    obtain ⟨G, hG⟩ := exists_isTrained data q
+    refine ⟨G, hG, fun G' hG' => ?_⟩
+    ext k j
+    have := congrFun (hG'.vecMul_eq_of_mem_span hq hG (Submodule.eq_top_iff'.mp htop
+      (Pi.single k 1))) j
+    simpa [Matrix.single_one_vecMul] using this
+
+/-- If some linear functional of the meanings reproduces column `j₀` of the observed forms
+exactly, so does every trained matrix under positive weights, on every training event. -/
+theorem IsTrained.mul_apply_eq_of_decodable (hq : ∀ i, 0 < q i) (hG : IsTrained data q G)
+    {j₀ : Fin n} {w : MeaningVec d →ₗ[ℝ] ℝ} (hw : ∀ i, w (data.S i) = data.C i j₀) (i : Fin m) :
+    (data.S * G) i j₀ = data.C i j₀ := by
+  set v : Fin d → ℝ := fun k => w (fun j => if k = j then 1 else 0)
+  have hSv : data.S *ᵥ v = data.Cᵀ j₀ := by
+    funext i'
+    rw [transpose_apply, ← hw i', w.pi_apply_eq_sum_univ]
+    simp [mulVec, dotProduct, v]
+  have hls : Core.IsLeastSquares (toEuclideanLin (q.sqrtQ * data.S))
+      (WithLp.toLp 2 ((q.sqrtQ * data.C)ᵀ j₀)) (WithLp.toLp 2 v) :=
+    Core.isLeastSquares_of_map_eq (by
+      rw [toLpLin_toLp, toLin'_apply, ← mulVec_mulVec, hSv, ← col_mul])
+  have h := congrArg (fun u : EuclideanSpace ℝ (Fin m) => u.ofLp i)
+    (((isTrained_iff_forall_isLeastSquares data q G).1 hG j₀).map_eq hls)
+  simp only [toLpLin_toLp, toLin'_apply, WithLp.ofLp_toLp] at h
+  rw [← mulVec_mulVec, ← mulVec_mulVec, hSv, FrequencyVector.sqrtQ, mulVec_diagonal,
+    mulVec_diagonal, ← col_mul, transpose_apply, transpose_apply] at h
+  exact mul_left_cancel₀ (Real.sqrt_pos.2 (NNReal.coe_pos.2 (hq i))).ne' h
 
 /-! ### Trained lexicons -/
 
 namespace Linear
 
-variable {m n d : ℕ} (D : Linear ℝ (FormVec n) (MeaningVec d))
-  (data : TrainingExperience m n d) (q : FrequencyVector m)
+variable (D : Linear ℝ (FormVec n) (MeaningVec d)) (data) (q)
 
-/-- `D` is **trained on** `data` under weights `q` if its production map is an ERM solution.
-Only the production side is constrained, as in the papers' production models. -/
-def IsTrainedOn : Prop := IsERMSolution data q D.production
+/-- The mapping matrix of the production map, acting on row vectors: `ĉ = sG`. -/
+def productionMatrix : Matrix (Fin d) (Fin n) ℝ := (LinearMap.toMatrix' D.production)ᵀ
 
-/-- A DLM is **EL-trained** on `data` iff its production map is the uniform-weight ERM solution. -/
+theorem production_eq_vecMul (s : MeaningVec d) : D.production s = s ᵥ* D.productionMatrix := by
+  rw [productionMatrix, vecMul_transpose, ← toLin'_apply, toLin'_toMatrix']
+
+/-- Row `i` of the fitted forms is the production map at the `i`-th experienced meaning. -/
+theorem mul_productionMatrix_apply (i : Fin m) :
+    (data.S * D.productionMatrix) i = D.production (data.S i) :=
+  (D.production_eq_vecMul _).symm
+
+@[simp] theorem productionMatrix_mk (F : FormVec n →ₗ[ℝ] MeaningVec d)
+    (G : Matrix (Fin d) (Fin n) ℝ) : (Linear.mk F (toLin' Gᵀ)).productionMatrix = G := by
+  simp [productionMatrix]
+
+/-- `D` is **trained on** `data` under weights `q` if its production matrix is. Only the
+production side is constrained, as in the papers' production models. -/
+def IsTrainedOn : Prop := IsTrained data q D.productionMatrix
+
+/-- A DLM is **EL-trained** on `data` iff its production matrix is trained under uniform weights. -/
 abbrev IsELTrainedOn : Prop := D.IsTrainedOn data 1
-
-/-- A DLM is **FIL-trained** on `data` with weights `q` iff its production map is the
-corresponding ERM solution. -/
-abbrev IsFILTrainedOn : Prop := D.IsTrainedOn data q
 
 variable {D data q}
 
 /-- A trained DLM's semantic support at a linearly decodable form coordinate equals the observed
 form value on every training event. -/
 theorem IsTrainedOn.semSup_eq_of_decodable (hD : D.IsTrainedOn data q) (hq : ∀ i, 0 < q i)
-    {j₀ : Fin n} {w : MeaningVec d →ₗ[ℝ] ℝ}
-    (hw : ∀ i, w (data.meanings i) = data.forms i j₀) (i : Fin m) :
-    semSup D (data.meanings i) j₀ = data.forms i j₀ :=
-  IsERMSolution.coord_eq_of_decodable hq hD hw i
+    {j₀ : Fin n} {w : MeaningVec d →ₗ[ℝ] ℝ} (hw : ∀ i, w (data.S i) = data.C i j₀) (i : Fin m) :
+    semSup D (data.S i) j₀ = data.C i j₀ := by
+  rw [semSup, ← mul_productionMatrix_apply]
+  exact IsTrained.mul_apply_eq_of_decodable hq hD hw i
 
-/-- Two DLMs trained on the same experience and weights have identical semantic support at
-every experienced meaning: `semSup` is a property of the training experience, not of the
-particular ERM solution. -/
+/-- Two DLMs trained on the same experience and weights have identical semantic support at every
+experienced meaning: `semSup` is a property of the training experience, not of the particular
+trained matrix. -/
 theorem IsTrainedOn.semSup_eq {D' : Linear ℝ (FormVec n) (MeaningVec d)}
     (hD : D.IsTrainedOn data q) (hD' : D'.IsTrainedOn data q) (hq : ∀ i, 0 < q i) (i : Fin m)
-    (j : Fin n) : semSup D (data.meanings i) j = semSup D' (data.meanings i) j :=
-  congrFun (IsERMSolution.apply_meanings_eq hq hD hD' i) j
+    (j : Fin n) : semSup D (data.S i) j = semSup D' (data.S i) j := by
+  rw [semSup, semSup, ← mul_productionMatrix_apply, ← mul_productionMatrix_apply,
+    IsTrained.mul_eq hq hD hD']
 
 /-- `semSup` is well-defined at novel meanings in the span of experienced ones. -/
-theorem IsTrainedOn.semSup_eq_of_mem_span
-    {D' : Linear ℝ (FormVec n) (MeaningVec d)}
+theorem IsTrainedOn.semSup_eq_of_mem_span {D' : Linear ℝ (FormVec n) (MeaningVec d)}
     (hD : D.IsTrainedOn data q) (hD' : D'.IsTrainedOn data q) (hq : ∀ i, 0 < q i)
-    {s : MeaningVec d} (hs : s ∈ Submodule.span ℝ (Set.range data.meanings)) (j : Fin n) :
-    semSup D s j = semSup D' s j :=
-  congrFun (IsERMSolution.apply_eq_of_mem_span hq hD hD' hs) j
+    {s : MeaningVec d} (hs : s ∈ Submodule.span ℝ (Set.range data.S)) (j : Fin n) :
+    semSup D s j = semSup D' s j := by
+  rw [semSup, semSup, production_eq_vecMul, production_eq_vecMul,
+    IsTrained.vecMul_eq_of_mem_span hq hD hD' hs]
 
 /-- *Semantic Support for Form* ([gahl-baayen-2024] appendix) at a form vector equals the
 observed form's own support whenever each coordinate the form vector touches is linearly
 decodable from the meanings. -/
 theorem IsTrainedOn.semSupWord_eq_of_decodable (hD : D.IsTrainedOn data q) (hq : ∀ i, 0 < q i)
     {c : FormVec n}
-    (hw : ∀ j, c j ≠ 0 → ∃ w : MeaningVec d →ₗ[ℝ] ℝ, ∀ i, w (data.meanings i) = data.forms i j)
-    (i : Fin m) :
-    semSupWord D (data.meanings i) c = data.forms i ⬝ᵥ c := by
+    (hw : ∀ j, c j ≠ 0 → ∃ w : MeaningVec d →ₗ[ℝ] ℝ, ∀ i, w (data.S i) = data.C i j)
+    (i : Fin m) : semSupWord D (data.S i) c = data.C i ⬝ᵥ c := by
   unfold semSupWord dotProduct
   refine Finset.sum_congr rfl fun j _ => ?_
   by_cases hc : c j = 0
   · simp [hc]
   · obtain ⟨w, hwj⟩ := hw j hc
-    rw [show D.production (data.meanings i) j = semSup D (data.meanings i) j from rfl,
+    rw [show D.production (data.S i) j = semSup D (data.S i) j from rfl,
       hD.semSup_eq_of_decodable hq hwj i]
 
 end Linear
+
+end
 
 end DiscriminativeLexicon

--- a/Linglib/Studies/GahlBaayen2024.lean
+++ b/Linglib/Studies/GahlBaayen2024.lean
@@ -12,8 +12,8 @@ The paper reanalyses the Switchboard durations of the 409 English homophones of 
 (*time* ~ *thyme*) from a discriminative lexicon (`DiscriminativeLexicon.Linear`, [baayen-2019]):
 linear maps between triphone and embedding vectors, with no stored words and so no word to bear
 a frequency. Frequency is treated as composite. *Practice* is frequency-informed learning of the
-production map `G` (`IsFILTrainedOn`, [heitmeier-chuang-axen-baayen-2024]); *contextual
-independence* is the diagonal `d` of a word-to-word map `W` with `UW = U` over an
+production map `G` (`IsTrainedOn` under token frequencies, [heitmeier-chuang-axen-baayen-2024]);
+*contextual independence* is the diagonal `d` of a word-to-word map `W` with `UW = U` over an
 utterance-by-word matrix `U`, transformed to `Cind` by (9); *semantic support for form* is the
 support a word's own triphones receive from its meaning, the diagonal of `T = ĈCᵀ` (A5),
 `semSupWord` at a word's meaning and form. In Gaussian location-scale GAMs the predictors
@@ -25,18 +25,18 @@ scope, and the paper derives nothing formal from its Pearson-correlation homopho
 What is stated is the paper's own toy lexicon *time, lime, thyme* (§2.3), worked through the
 substrate's training theory. The endstate map (4) and the frequency-informed map for token
 frequencies 100, 10, 1 (A3) are the closed forms `(SᵀS)⁻¹SᵀC` and `(SᵀQS)⁻¹SᵀQC` of the normal
-equations (A2), (A4), hence `IsELTrainedOn` and `IsFILTrainedOn`; the support matrix of (A6)
-and both columns of Table 1 come out exactly, the frequency-informed column being `√frequency`
-times the support the learned map alone gives, as it is the fitted value of the `√Q`-scaled
-regression; the homophones get distinct predicted forms from identical triphones (Fig. A2); and
-the word-to-word map of (6) is the pseudoinverse solution `Uᵀ(UUᵀ)⁻¹U` of `UW = U`, an
-orthogonal projector, whose diagonal therefore lies in `[0, 1]` and dominates its rows as the
-paper observes.
+equations (A2), (A4), hence `IsELTrainedOn` and `IsTrainedOn` under `freq`; the support matrix
+of (A6) and both columns of Table 1 come out exactly, the frequency-informed column being
+`√frequency` times the support the learned map alone gives, as it is the fitted value of the
+`√Q`-scaled regression; the homophones get distinct predicted forms from identical triphones
+(Fig. A2); and the word-to-word map of (6) is the pseudoinverse solution `Uᵀ(UUᵀ)⁻¹U` of
+`UW = U`, an orthogonal projector, whose diagonal therefore lies in `[0, 1]` and dominates its
+rows as the paper observes.
 
 ## Main results
 
-* `endstate_isELTrainedOn`, `frequencyInformed_isFILTrainedOn`: the paper's mappings are the
-  substrate's ERM solutions.
+* `endstate_isELTrainedOn`, `frequencyInformed_isTrainedOn`: the paper's mappings are trained
+  in the substrate's sense, by the closed forms of the normal equations.
 * `supportMatrix_endstate`, `semanticSupport_endstate`, `semanticSupportFIL_eq`: (A6) and
   Table 1 exactly; practice reverses the order of *time* and *thyme*
   (`semanticSupport_endstate_time_lt_thyme`, `semanticSupportFIL_thyme_lt_time`).
@@ -93,8 +93,8 @@ theorem toyForms_eq :
 two arbitrary semantic dimensions (`0.1 0.3; 0.6 0.2; 1.1 0.6`), and the triphone matrix `C`
 of (2). *time* and *thyme* share a form row. -/
 def toy : TrainingExperience 3 6 2 where
-  meanings := ![![1 / 10, 3 / 10], ![6 / 10, 2 / 10], ![11 / 10, 6 / 10]]
-  forms := toyForms
+  S := !![1 / 10, 3 / 10; 6 / 10, 2 / 10; 11 / 10, 6 / 10]
+  C := Matrix.of toyForms
 
 /-- *time*, the first row of the toy lexicon. -/
 abbrev time : Fin 3 := 0
@@ -123,8 +123,7 @@ theorem endstateG_eq :
   ext i j
   fin_cases i <;> fin_cases j <;>
     norm_num [endstateG, Matrix.inv_def, Ring.inverse_eq_inv', Matrix.adjugate_fin_two,
-      Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, toyForms_eq,
-      TrainingExperience.S, TrainingExperience.C]
+      Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, toyForms_eq]
 
 /-- The DLM at the endstate of learning. -/
 def endstate : Linear ℝ (FormVec 6) (MeaningVec 2) where
@@ -144,27 +143,29 @@ theorem frequencyInformedG_eq :
   fin_cases i <;> fin_cases j <;>
     norm_num [frequencyInformedG, Matrix.inv_def, Ring.inverse_eq_inv', Matrix.adjugate_fin_two,
       Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, toyForms_eq, freq,
-      TrainingExperience.S, TrainingExperience.C, FrequencyVector.Q, Matrix.diagonal]
+      FrequencyVector.Q, Matrix.diagonal]
 
 /-- The DLM after frequency-informed learning. -/
 def frequencyInformed : Linear ℝ (FormVec 6) (MeaningVec 2) where
   comprehension := 0
   production := Matrix.toLin' frequencyInformedGᵀ
 
-/-- The endstate mapping is the uniform-weight ERM solution, by the closed form of the normal
+/-- The endstate mapping is trained under uniform weights, by the closed form of the normal
 equations (A2): `SᵀS` is invertible. -/
-theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy :=
-  isELSolution_closedForm toy <| by
-    rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
-    norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, TrainingExperience.S]
+theorem endstate_isELTrainedOn : endstate.IsELTrainedOn toy := by
+  rw [Linear.IsELTrainedOn, Linear.IsTrainedOn, endstate, Linear.productionMatrix_mk]
+  refine isELTrained_closedForm toy ?_
+  rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
+  norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy]
 
-/-- The frequency-informed mapping is the ERM solution under `freq`, by the closed form of the
+/-- The frequency-informed mapping is trained under `freq`, by the closed form of the
 `√Q`-scaled normal equations (A4): `SᵀQS` is invertible. -/
-theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy freq :=
-  isERMSolution_closedForm toy freq <| by
-    rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
-    norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, freq,
-      TrainingExperience.S, FrequencyVector.Q, Matrix.diagonal]
+theorem frequencyInformed_isTrainedOn : frequencyInformed.IsTrainedOn toy freq := by
+  rw [Linear.IsTrainedOn, frequencyInformed, Linear.productionMatrix_mk]
+  refine isTrained_closedForm toy freq ?_
+  rw [Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero]
+  norm_num [Matrix.det_fin_two, Matrix.mul_apply, Fin.sum_univ_succ, toy, freq,
+    FrequencyVector.Q, Matrix.diagonal]
 
 /-! ### Semantic support for form -/
 
@@ -172,7 +173,7 @@ theorem frequencyInformed_isFILTrainedOn : frequencyInformed.IsFILTrainedOn toy 
 each word's meaning (row). -/
 def supportMatrix {m n d : ℕ} (D : Linear ℝ (FormVec n) (MeaningVec d))
     (data : TrainingExperience m n d) : Matrix (Fin m) (Fin m) ℝ :=
-  Matrix.of fun i k => semSupWord D (data.meanings i) (data.forms k)
+  Matrix.of fun i k => semSupWord D (data.S i) (data.C k)
 
 /-- *Semantic support for form*: the diagonal of `T`, a word's support for its own form. -/
 def semanticSupport {m n d : ℕ} (D : Linear ℝ (FormVec n) (MeaningVec d))
@@ -206,13 +207,13 @@ theorem semanticSupport_endstate_time_lt_thyme :
 the toy lexicon (Table 1, (A7)): the predicted forms are the fitted values `√Q S G` of the
 `√Q`-scaled regression, paired with the words' own unscaled triphone vectors. -/
 def semanticSupportFIL (i : Fin 3) : ℝ :=
-  semSupWord frequencyInformed ((toy.sqrtScale freq).meanings i) (toy.forms i)
+  semSupWord frequencyInformed ((toy.sqrtScale freq).S i) (toy.C i)
 
 /-- The `√frequency` factor made explicit: the paper's frequency-informed support is
 `√(freq i)` times the support the learned map alone gives. -/
 theorem semanticSupportFIL_eq_sqrt_mul (i : Fin 3) :
     semanticSupportFIL i = Real.sqrt (freq i) * semanticSupport frequencyInformed toy i := by
-  simp [semanticSupportFIL, semanticSupport, supportMatrix, TrainingExperience.sqrtScale]
+  simp [semanticSupportFIL, semanticSupport, supportMatrix]
 
 /-- The learned frequency-informed map alone still supports *thyme* most:
 `3.981, 3.151, 6.225`. -/
@@ -243,7 +244,7 @@ their meaning difference lies outside the production kernel, the neutralization 
 (`LinearMap.sub_mem_ker_iff`), so their triphones receive different support
 ((A3), Fig. A2; §6.2). -/
 theorem time_sub_thyme_notMem_ker :
-    toy.meanings time - toy.meanings thyme ∉ LinearMap.ker endstate.production := fun h => by
+    toy.S time - toy.S thyme ∉ LinearMap.ker endstate.production := fun h => by
   have := congrFun (LinearMap.sub_mem_ker_iff.mp h) 0
   norm_num [toy, toyForms_eq, endstate, endstateG_eq, time, thyme, Matrix.cons_val_two,
     Matrix.toLin'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_succ] at this

--- a/Linglib/Studies/HeitmeierChuangBaayen2026.lean
+++ b/Linglib/Studies/HeitmeierChuangBaayen2026.lean
@@ -139,25 +139,28 @@ theorem pastTense_not_regular : ¬ IsAnalogicallyRegular pastTense := fun h => b
 
 variable [Fintype Lexeme] [Fintype Cell]
 
-/-- The paradigm as a training experience: imputed semantics as the meanings, the form table as
-the targets. -/
+/-- The paradigm as a training experience: imputed semantics as the semantic matrix, the form
+table as the form matrix. -/
 noncomputable def paradigmExperience (f : Lexeme → Cell → FormVec n) :
     TrainingExperience (Fintype.card (Lexeme × Cell)) n d where
-  meanings i := imputed σ ε ((Fintype.equivFin (Lexeme × Cell)).symm i).1
+  S := Matrix.of fun i => imputed σ ε ((Fintype.equivFin (Lexeme × Cell)).symm i).1
     ((Fintype.equivFin (Lexeme × Cell)).symm i).2
-  forms i := f ((Fintype.equivFin (Lexeme × Cell)).symm i).1
+  C := Matrix.of fun i => f ((Fintype.equivFin (Lexeme × Cell)).symm i).1
     ((Fintype.equivFin (Lexeme × Cell)).symm i).2
 
-/-- Irregularity forces positive training loss: no linear map fits a suppletive paradigm exactly,
-so every ERM solution carries residual error. -/
+open Matrix in
+/-- Irregularity forces positive training loss: no mapping matrix fits a suppletive paradigm
+exactly, so every trained matrix carries residual error. -/
 theorem pos_weightedLoss_of_not_regular {f : Lexeme → Cell → FormVec n}
     (hf : ¬ IsAnalogicallyRegular f) {q : FrequencyVector (Fintype.card (Lexeme × Cell))}
-    (hq : ∀ i, 0 < q i) (G : MeaningVec d →ₗ[ℝ] FormVec n) :
+    (hq : ∀ i, 0 < q i) (G : Matrix (Fin d) (Fin n) ℝ) :
     0 < weightedLoss (paradigmExperience σ ε f) q G := by
   refine lt_of_le_of_ne (weightedLoss_nonneg _ _ _) (Ne.symm fun h0 => ?_)
   have hint := (weightedLoss_eq_zero_iff _ _ _ hq).1 h0
-  refine not_exists_paradigm_eq_of_not_regular σ ε hf ⟨⟨0, G⟩, funext fun l => funext fun c => ?_⟩
-  have h := hint ((Fintype.equivFin (Lexeme × Cell)) (l, c))
-  simpa [paradigmExperience] using h
+  refine not_exists_paradigm_eq_of_not_regular σ ε hf
+    ⟨⟨0, Matrix.toLin' Gᵀ⟩, funext fun l => funext fun c => funext fun j => ?_⟩
+  have h := congrFun (congrFun hint ((Fintype.equivFin (Lexeme × Cell)) (l, c))) j
+  simpa [paradigmExperience, Linear.paradigm, Matrix.toLin'_apply, Matrix.mulVec_transpose,
+    Matrix.mul_apply, Matrix.vecMul, dotProduct] using h
 
 end HeitmeierChuangBaayen2026

--- a/Linglib/Studies/LuChuangBaayen2026.lean
+++ b/Linglib/Studies/LuChuangBaayen2026.lean
@@ -83,11 +83,12 @@ the centroid of `P`'s embeddings exactly to the centroid of `P`'s target contour
 theorem production_centroid_eq_of_decodable {m : ℕ} {D : TaiwanMandarinDLM}
     {data : TrainingExperience m PitchSampleCount CKIPGPT2HiddenDim} (hD : D.IsELTrainedOn data)
     {P : Finset (Fin m)} {w : ContextualEmbedding →ₗ[ℝ] ℝ}
-    (hw : ∀ i, w (data.meanings i) = if i ∈ P then 1 else 0) :
-    D.production (centroid P data.meanings) = centroid P data.forms := by
-  have h := IsERMSolution.sum_smul_sub_eq_zero hD w
+    (hw : ∀ i, w (data.S i) = if i ∈ P then 1 else 0) :
+    D.production (centroid P data.S) = centroid P data.C := by
+  have h := IsTrained.sum_smul_sub_eq_zero hD w
   simp only [Pi.one_apply, NNReal.coe_one, one_mul, hw, ite_smul, one_smul, zero_smul,
-    Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_sub_distrib, sub_eq_zero] at h
+    Finset.sum_ite_mem, Finset.univ_inter, Linear.mul_productionMatrix_apply,
+    Finset.sum_sub_distrib, sub_eq_zero] at h
   simp [centroid, map_sum, h]
 
 end LuChuangBaayen2026

--- a/Linglib/Studies/Saito2025.lean
+++ b/Linglib/Studies/Saito2025.lean
@@ -82,9 +82,9 @@ theorem semSup_lt_of_forms_lt
     {q : FrequencyVector m}
     (hD : D.IsTrainedOn data q) (hq : ∀ i, 0 < q i)
     {suffixIdx : Fin TriphoneCount} {w : GermanWord2VecVec →ₗ[ℝ] ℝ}
-    (hw : ∀ i, w (data.meanings i) = data.forms i suffixIdx)
-    {i k : Fin m} (hik : data.forms i suffixIdx < data.forms k suffixIdx) :
-    semSup D (data.meanings i) suffixIdx < semSup D (data.meanings k) suffixIdx := by
+    (hw : ∀ i, w (data.S i) = data.C i suffixIdx)
+    {i k : Fin m} (hik : data.C i suffixIdx < data.C k suffixIdx) :
+    semSup D (data.S i) suffixIdx < semSup D (data.S k) suffixIdx := by
   rw [hD.semSup_eq_of_decodable hq hw i, hD.semSup_eq_of_decodable hq hw k]
   exact hik
 


### PR DESCRIPTION
Recut \`Training.lean\` onto one carrier, the mapping matrix \`G\` over the semantic and form matrices \`S\`, \`C\`: \`IsTrained\` is the weighted-loss minimiser, characterised column by column through \`Core.IsLeastSquares\` and mathlib's adjoint theorem, which yields the normal equations and closed form.

- Drops \`toEuclidean\`, \`designMap\`, the \`IsFILTrainedOn\` alias and the ERM vocabulary; \`Linear.IsTrainedOn\` goes through \`productionMatrix\`.
- Adds \`Core.isLeastSquares_of_map_eq\`; the four consumer studies read rows as \`S i\`, \`C i\`.