### PR TITLE
refactor(Studies/CobrerosEtAl2012): rebuild the study from the paper

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2403,7 +2403,7 @@ import Linglib.Studies.LaoideKemp2026
 import Linglib.Studies.Larson1988
 import Linglib.Studies.Lassiter2017
 import Linglib.Studies.Lassiter2025
-import Linglib.Studies.LassiterGoodman2017PMF
+import Linglib.Studies.LassiterGoodman2017
 import Linglib.Studies.LeBruynDeSwart2022
 import Linglib.Studies.Lechner2004
 import Linglib.Studies.Levin1993

--- a/Linglib/Core/Probability/Posterior.lean
+++ b/Linglib/Core/Probability/Posterior.lean
@@ -740,7 +740,7 @@ at most one `i ∈ s` has `x ∈ f i`, so `∑ i ∈ s, (f i).indicator p x ≤ 
 Summing pointwise: `∑' x, (...) ≤ ∑' x, p x = 1` (`PMF.tsum_coe`).
 
 Used by interval-additive sorites bounds in
-`Studies/LassiterGoodman2017PMF.lean` (Eq. 37).
+`Studies/LassiterGoodman2017.lean` (Eq. 37).
 General enough that any disjoint-events probability bound consumer
 can use it. -/
 theorem toOuterMeasure_finset_sum_disjoint_le_one

--- a/Linglib/Logic/Bilateral/Classical.lean
+++ b/Linglib/Logic/Bilateral/Classical.lean
@@ -51,15 +51,14 @@ variable {Model Formula Mode : Type*}
 /-- Satisfaction duality: a negation operation on formulas and a
     dual operation on modes such that:
     - `dual` is an involution (d(d(m)) = m)
-    - `neg` is an involution (¬¬φ = φ)
     - Negation swaps modes: `M ⊨ᵐ ¬φ ↔ M ⊭^{d(m)} φ`
 
-    In TCS, d(t) = s, d(s) = t, d(c) = c, and negation is formula
-    negation. -/
+    Nothing is assumed of `neg` itself, so syntactic negation (where
+    `¬¬φ` and `φ` are distinct formulas) qualifies. In TCS, d(t) = s,
+    d(s) = t, d(c) = c, and negation is formula negation. -/
 structure SatDuality (sat : Model → Mode → Formula → Prop)
     (neg : Formula → Formula) (dual : Mode → Mode) : Prop where
   dual_invol : ∀ m : Mode, dual (dual m) = m
-  neg_invol : ∀ φ : Formula, neg (neg φ) = φ
   neg_swap : ∀ (M : Model) (m : Mode) (φ : Formula),
     sat M m (neg φ) ↔ ¬sat M (dual m) φ
 

--- a/Linglib/Logic/Trivalent/Propositional.lean
+++ b/Linglib/Logic/Trivalent/Propositional.lean
@@ -36,8 +36,7 @@ namespace Trivalent
 
 open Consequence (MixedConsequence)
 
-/-- Propositional formulas over an atom type
-(`Semantics.Supervaluation.TCSFormula` instantiates it). -/
+/-- Propositional formulas over an atom type (`CobrerosEtAl2012.Formula` instantiates it). -/
 inductive Formula (Atom : Type*) where
   | atom : Atom → Formula Atom
   | neg : Formula Atom → Formula Atom
@@ -86,6 +85,22 @@ def Realize (M : Model Atom) (d : Trivalent.Designation) (φ : Formula Atom) : P
     (φ ψ : Formula Atom) :
     (M ⊨[d] Formula.conj φ ψ) ↔ (M ⊨[d] φ) ∧ (M ⊨[d] ψ) :=
   Trivalent.designated_inf d (eval M φ) (eval M ψ)
+
+/-- Disjunction, defined classically from negation and conjunction. -/
+def disj (φ ψ : Formula Atom) : Formula Atom := .neg (.conj (.neg φ) (.neg ψ))
+
+/-- The material conditional `¬(φ ∧ ¬ψ)`. -/
+def imp (φ ψ : Formula Atom) : Formula Atom := .neg (.conj φ (.neg ψ))
+
+@[simp] theorem realize_disj (M : Model Atom) (d : Trivalent.Designation) (φ ψ : Formula Atom) :
+    (M ⊨[d] φ.disj ψ) ↔ (M ⊨[d] φ) ∨ (M ⊨[d] ψ) := by
+  simp [disj, or_iff_not_imp_left]
+
+/-- A conditional is realized at `d` iff its consequent is whenever its antecedent is realized
+at the dual standard. -/
+@[simp] theorem realize_imp (M : Model Atom) (d : Trivalent.Designation) (φ ψ : Formula Atom) :
+    (M ⊨[d] φ.imp ψ) ↔ ((M ⊨[d.dual] φ) → (M ⊨[d] ψ)) := by
+  simp [imp]
 
 end Formula
 

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -1,1486 +1,751 @@
-import Linglib.Semantics.Supervaluation
-import Linglib.Core.Data.Trivalent
-import Linglib.Logic.Consequence
-import Linglib.Logic.Trivalent.Propositional
 import Linglib.Logic.Modal.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Logic.Function.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Tactic.Linarith
+import Linglib.Logic.Trivalent.Propositional
 
 /-!
-# Cobreros, Egré, Ripley & van Rooij 2012: 4-Element Sorites Model
+# Cobreros, Égré, Ripley and van Rooij 2012: Tolerant, classical, strict
 
-[cobreros-etal-2012]
+A T-model is a classical model whose predicates each carry an indifference relation `∼_P`,
+reflexive and symmetric but possibly non-transitive (Definition 4), the vague predicate's
+"looks the same with respect to `P`". Besides classical truth a T-model supports two further
+notions defined by simultaneous induction (Definition 9): `Pa` is strictly true when every
+`∼_P`-neighbour of `a` is classically `P` and tolerantly true when some neighbour is, negation
+swapping the two, so that the strict extension sharpens and the tolerant extension coarsens
+the classical one (Lemma 1) and the tolerance principle `Pa ∧ a I_P b → Pb` is tolerantly
+valid (Fact 2) up to two similarity steps (Fact 3). Borderline cases are the tolerantly-but-
+not-strictly `P` individuals (Definition 10), the ones tolerantly both `P` and `¬P`. On the
+similarity-free vocabulary tolerant validity is classical validity while nothing is strictly
+valid (Theorems 1 and 2), and tolerant and strict consequence are Priest's LP and strong Kleene
+K3 (Theorem 3), via the model correspondences of Lemmas 4 and 5. Mixing the three notions gives
+nine consequence relations `⊨ᵐⁿ` (Definition 17), ordered by Lemma 7, dualised by Lemma 6,
+collapsing to four on the restricted vocabulary (Lemmas 8 and 9) but distinct once similarity
+statements are expressible (§3.4), where the deduction theorem singles out the self-dual `st`,
+`cc` and `ts` (Lemma 10). The paper's choice is `st`, strict premises to tolerant conclusions:
+it validates tolerance and modus ponens and is non-transitive, so it validates every step of a
+sorites while invalidating the chain (§3.6, Version 1), and it makes the tolerance-premise
+sorites valid but unsound, its tolerance premise not being strictly true (Version 2).
 
-The paper's TCS apparatus together with its worked 4-element example
-(described in the body text on p. 354, immediately above footnote 4).
+The language is the paper's propositional fragment over a set of constants `C`: negation and
+conjunction over predications `Pa` and similarity statements `a I_P b`, with disjunction and
+the conditional defined classically. The universally quantified principles appear as their
+instances, which the paper notes changes nothing (§3.6). Identity, which the paper adds in
+§2.3.1, is not represented. Consequence quantifies over T-models of every domain in the
+universe of `C` (`TModels`), as the paper's does; the atomic strict and tolerant clauses are
+`ModalLogic.box` and `ModalLogic.diamond` along `∼_P`, so Lemma 1's atomic case is the T axiom.
 
-## The model
+## Main definitions
 
-Four individuals `a, b, c, d` arranged in a similarity chain
-`a ~ b ~ c ~ d` (with reflexivity and symmetry, no other pairs).
-The classical extension of `tall` is `{a, b}`. The paper uses this
-model to illustrate:
+* `TModel`, `TModel.Realize`, `Mode` — T-models and their three notions of truth, the modes
+  ordered by strength `strict < classical < tolerant`.
+* `TModel.Borderline` — Definition 10.
+* `Valid`, `Consequence` — Definitions 11 and 17.
+* `IsRestricted`, `TModel.identity`, `allBorderline`, `toMV`, `ofMV` — the restricted
+  vocabulary and the models of Lemmas 2, 3, 4 and 5.
+* `series` — the sorites series of §3.4.1 and §3.6, whose instances are the four-element model
+  of p. 354 and the five-men model of §4.2.3.
 
-- The **extension hierarchy**: `{a} ⊆ {a,b} ⊆ {a,b,c}` (strict ⊆ classical ⊆ tolerant)
-- **Borderline cases**: `b` and `c` are tolerantly tall AND tolerantly not-tall
-- **Two-step tolerance limit**: `d` is NOT tolerantly tall (three steps from `a` exceeds Fact 3)
-- **Sorites resolution**: each one-step inference `Pa, aIb ⊨ˢᵗ Pb` is
-  valid; each two-step `Pa, aIb, bIc ⊨ˢᵗ Pc` is valid; but the
-  three-step `Pa, aIb, bIc, cId ⊨ˢᵗ Pd` is **invalid**.
+## Main results
 
-  Attribution: paper §3.4.1 (p. 372) demonstrates non-transitivity for
-  `⊨ᶜᵗ` (the chain `Pa_1, a_1I_Pa_2, a_2I_Pa_3 ⊭ᶜᵗ Pa_3`); the `⊨ˢᵗ`
-  version of the sorites is stated in §3.6 (Version 1, p. 376). The
-  structural pattern — each step valid, chain fails — is §3.4.1's
-  contribution; the `st`-instantiation here applies that pattern to
-  the relation the paper ultimately advocates (paper p. 373).
+* `TModel.realize_mono` (Lemma 1), `satDuality` (Remark 1), `tolerance_valid` (Fact 2),
+  `st_two_step` (Fact 3).
+* `TModel.Borderline.exists_ne` — a model with a borderline case has two (footnote 4);
+  `TModel.eq_tolerant_of_realize_conj_neg` — a contradiction can only be tolerantly true.
+* `valid_tolerant_iff`, `unsat_strict_iff` (Theorem 1); `not_valid_strict`,
+  `exists_realize_tolerant` (Theorem 2); `consequence_tolerant_iff_lp`,
+  `consequence_strict_iff_k3` (Theorem 3).
+* `Consequence.dual` (Lemma 6), `Consequence.mono` (Lemma 7), `Consequence.restricted_iff`
+  (Lemma 8), `not_consequence_tolerant_strict` (Lemma 9), `Consequence.imp_iff` (Lemma 10).
+* `not_cc_one_step`, `not_valid_classical_tolerance`, `not_sc_two_step`, `not_ct_two_step` —
+  the §3.4 distinctness of `cc`, `sc`, `ct` and `st`, on the four-element model.
+* `not_st_version1`, `st_version2`, `not_series_realize_strict_tolerance` — the sorites of
+  §3.6.
+* `alxatibPelletier_median_borderline` — the median man of [alxatib-pelletier-2011]'s stimulus
+  is borderline however he is classified (§4.2.3).
 
-## Cross-framework note
+## Comparisons the paper draws
 
-`tcs_supervaluation_disagree_concrete` instantiates the existence
-theorem `tcs_vs_supervaluation_borderline_contradiction` at
-`(soritesModel, .tall, .b)`. Comparator caveat: the paper's headline
-borderline-contradiction contrast (p. 356) is actually with **Hyde 1997
-subvaluationism**, not with Fine 1975 supervaluation. Subvaluationism
-*agrees* with TCS that `P ∧ ¬P` holds at borderline cases — they
-disagree on framework foundations. The Lean theorem here formalises the
-*formal-validity-side* contrast (p. 359) where TCS at `t` mode says ✓
-and supervaluation says ✗. Subvaluationism is not formalised in linglib;
-a proper "borderline-verdict comparator" theorem awaits its formalisation.
+* Tolerant and strict truth are not sub- and supervaluationist truth ([fine-1975]): those keep
+  classical validity, whereas strict validity is empty and borderline cases are tolerantly
+  both `P` and `¬P` (§2.1, §2.4).
+* Tolerant and strict consequence coincide with LP and K3 ([kleene-1952]) on the restricted
+  vocabulary, from distinct motivations: three notions of truth, none many-valued (§2.4).
+* [kamp-1981]'s atomic and negation clauses are similar; his conditionals and quantifiers
+  differ (footnote 3).
+* Non-transitivity of indifference is shared with [williamson-1994]'s epistemicism without its
+  commitment to the classical extensions being the objective meanings (§5).
+* [van-rooij-2011a]'s delineation between the tallest and the shortest, leaving a gap, is what
+  the five-men model of §4.2.3 represents.
 
-The asymmetric-engagement reciprocation: `LassiterGoodman2017PMF.lean::lg_literal_borderline_bounded`
-proves L&G's literal-meaning rule predicts ≤ 25% acceptance for
-borderline `tall ∧ ¬ tall`, well below the [alxatib-pelletier-2011]
-empirical 44.7%. That paper's docstring cites TCS as the alternative
-that handles the data; this file's `b_tolerant_contradiction` shows the
-TCS prediction direction matches the data.
+## References
 
-## Architecture
-
-This file is anchored on the Cobreros-Egré-Ripley-van Rooij 2012 paper
-itself and contains both the paper's TCS apparatus (the sections
-immediately below) and its worked example. General supervaluation
-substrate remains in `Semantics/Supervaluation.lean`.
+* [P. Cobreros, P. Égré, D. Ripley and R. van Rooij, *Tolerant, Classical, Strict*
+  (2012)][cobreros-etal-2012]
+* [S. Alxatib and F. J. Pelletier, *The Psychology of Vagueness: Borderline Cases and
+  Contradictions* (2011)][alxatib-pelletier-2011]
+* [K. Fine, *Vagueness, truth and logic* (1975)][fine-1975]
+* [S. C. Kleene, *Introduction to Metamathematics* (1952)][kleene-1952]
+* [H. Kamp, *The paradox of the heap* (1981)][kamp-1981]
+* [T. Williamson, *Vagueness* (1994)][williamson-1994]
+* [R. van Rooij, *Implicit versus Explicit Comparatives* (2011)][van-rooij-2011a]
 -/
 
-/-!
-## The TCS apparatus
+universe u
 
-[cobreros-etal-2012]
+namespace CobrerosEtAl2012
 
-[cobreros-etal-2012] "Tolerant, Classical, Strict",
-*Journal of Philosophical Logic* 41:347–385.
+open ModalLogic (IsKTBFrame box diamond box_T)
+open scoped ModalLogic Trivalent.Formula
+open Consequence (MixedConsequence mnValid mnValid_iff_emptyPremise IsSelfDual mixed_monotone
+  consequence_dual)
 
-A similarity-based three-valued semantics for vague predicates that
-derives three notions of truth from a single model:
+/-! ### T-models -/
 
-- **Classical (c)**: standard satisfaction `M ⊨ᶜ P(a) iff a ∈ I(P)` (Def 9)
-- **Tolerant (t)**: `M ⊨ᵗ P(a) iff ∃d ~_P a, d ∈ I(P)` (Def 9)
-- **Strict (s)**: `M ⊨ˢ P(a) iff ∀d ~_P a, d ∈ I(P)` (Def 9)
-
-The indifference relation `~_P` is reflexive and symmetric — but, crucially,
-not necessarily transitive — capturing "looks the same for predicate P."
-
-## Paper-anchored mathematical foundation
-
-The paper formulates TCS in terms of indifference relations derived from
-**semi-orders** (paper p. 350 fn 1, citing Luce 1956). The same atom-level
-operators are equivalently described as the **lower / upper approximation
-operators** of a tolerance approximation space in the rough-set tradition.
-The paper flags this analogy in **footnote 5 (p. 355)**, citing
-[pawlak-1982] (paper's reference [19]) for the equivalence-relation
-case; borderline cases are exactly the boundary `upper \ lower`.
-
-## Re-reading TCS through a modal-logic lens (formaliser's framing)
-
-The paper itself does NOT use modal-logic vocabulary. The framing in this
-section is the formaliser's lens, used to integrate with the modal-logic
-substrate (`Logic/Modal`); it is not paper-anchored.
-
-Structurally, TCS is a propositional modal logic in which each predicate
-`P` carries its own reflexive-symmetric (KTB) Kripke accessibility
-relation `~_P`. The strict and tolerant satisfaction operators are
-exactly the modal `□` and `◇` over `~_P`, applied to the classical
-extension of `P`:
-
-- `strict P at a` ≡ `box (~_P) I(P) a` (Definition 9)
-- `tolerant P at a` ≡ `diamond (~_P) I(P) a` (Definition 9)
-
-The s ⊆ c ⊆ t hierarchy is the **T axiom** instantiated at `box`
-(`ModalLogic.box_T`); the t/s duality is the standard
-modal de Morgan `box R ¬p ↔ ¬diamond R p`. T-models are KTB frames by
-construction (Definition 4 of [cobreros-etal-2012]): each `~_P`
-carries an `IsKTBFrame` instance. The Brouwersche axiom B / symmetric-frame correspondence is
-a standard Sahlqvist result; for systematic treatment see
-[blackburn-derijke-venema-2001] §3.5–3.6 and the model-theoretic
-overview [goranko-otto-2007]. The non-equivalence-relation
-generalisation of Pawlak's rough sets to tolerance approximation spaces
-(which the paper implicitly uses in footnote 5) is due to
-[skowron-stepaniuk-1996]; this attribution is supplied by the
-formaliser, not the paper.
-
-## Key Results (paper-section-tagged)
-
-- **Definition 9** (p. 353): t/s atomic clauses + their compositional lift
-- **Lemma 1** (p. 357): extension hierarchy s ⊆ c ⊆ t
-- **Facts 2-3** (p. 354): one-step + two-step tolerance principle
-- **Definition 10** (p. 355): borderline = `upper \ lower`
-- **Lemma 2** (p. 357): identity-model collapse of all three modes
-- **Definition 17** (p. 366): nine mixed consequence relations ⊨ᵐⁿ
-- **Lemma 7** (p. 368): strength ordering ⊨ᵗᵐ ⊆ ⊨ᶜᵐ ⊆ ⊨ˢᵐ
-- **Lemma 8** (p. 369): collapse cc = sc = ct = st on restricted vocabulary
-- **Remark 1** (p. 353), **Lemma 10** (p. 371): t/s duality + self-duality
-  of st and cc → deduction theorem
-- **Lemma 4** (p. 361) + **Theorem 3** (p. 362): formula-level then
-  consequence-level correspondence with LP and K3. Note: paper Lemma 4 is
-  stated only for the restricted vocabulary (no `I_P`); the formalisation
-  in §15 extends it to handle similarity atoms by treating them as
-  classical Bool-valued (always in `{0, 1} ⊂ {0, 1/2, 1}`), which is a
-  faithful extension of the paper's construction.
-
-## Cross-framework comparators (paper p. 356, p. 359)
-
-The paper draws TWO distinct contrasts on the borderline-contradictions
-question, with two different opponents:
-
-- **Borderline-verdict contrast (p. 356)** — TCS vs **subvaluationism**
-  (Hyde 1997). Both make `P ∧ ¬P` true at borderline cases; the contrast
-  is over the underlying framework foundations (TCS via similarity-based
-  modal semantics; subvaluationism via dual super-truth). Subvaluationism
-  is not formalised in linglib; this is the closer comparator on the
-  *verdict* but cannot be checked at the Lean level here.
-- **Formal-validity contrast (p. 359)** — TCS vs **supervaluationism**
-  (Fine 1975). Supervaluationism makes `P ∧ ¬P` super-FALSE even at
-  borderline cases (penumbral connection); this is the comparator
-  formalised here, and it is realised as the §17 cross-framework theorem
-  `tcs_vs_supervaluation_borderline_contradiction`. The Lean theorem
-  combines the TCS half (`IsBorderline` definition unfolding through
-  `SatMode.dual`) with the supervaluation half (`nonContradiction_superFalse`
-  from `Supervaluation/Basic.lean`).
-
-Strict truth for an atomic predicate at individual `a` IS supervaluation
-over the tolerance neighborhood of `a`: `superTrue I(P) {d | d ~_P a}`.
-Tolerant truth is its existential dual. This makes TCS a **localized**
-supervaluation — each individual gets its own specification space
-determined by its similarity neighborhood.
-
-## Architecture
-
-This file provides the **propositional restricted-vocabulary** fragment
-of TCS — atoms cover both predicate atoms `P(a)` and similarity atoms
-`a I_P b` (paper Definition 8), but no quantifiers. All §2 (restricted
-vocabulary) results apply; phenomena requiring first-order quantifiers
-(paper §2.3) are out of scope.
-
-The 4-element worked example from p. 354 of the paper (in the body text
-immediately above footnote 4) lives in the study sections below. The
-asymmetric reciprocation point with
-`LassiterGoodman2017PMF.lean::lg_literal_borderline_bounded`
-is addressed in §8–§9 below.
--/
-
-namespace Semantics.Supervaluation.TCS
-
-open ModalLogic
-  (IsKTBFrame IsSerial box diamond box_T)
-open Consequence (MixedConsequence SatImplies IsSelfDual
-  premise_monotone conclusion_monotone mixed_monotone)
-open Semantics.Supervaluation (SpecSpace superTrue
-  superTrue_true_iff superTrue_false_iff superTrue_indet_iff
-  nonContradiction_superFalse)
-
--- ════════════════════════════════════════════════════
--- § 1. T-Models (Definition 4, p. 351)
--- ════════════════════════════════════════════════════
-
-/-- A T-model: a classical model equipped with per-predicate tolerance
-    relations. Each `~_P` is reflexive and symmetric — but possibly
-    non-transitive — capturing "looks the same for predicate P."
-
-    Definition 4 of [cobreros-etal-2012]. The non-transitivity of
-    `~_P` is what makes vagueness possible: a can look like b and b can
-    look like c, but a need not look like c.
-
-    Following the modal-logic tradition, the similarity relation is
-    `Prop`-valued so that it integrates directly with `box`/`diamond`.
-    Decidability is added per-model where computation is needed. -/
-structure TModel (D Pred : Type*) where
-  /-- Classical interpretation `I : Pred → D → Prop`. -/
+/-- A T-model (Definition 4): a classical model of the constants `C` and predicates `Pred` over
+the domain `D`, with for each predicate a reflexive and symmetric, possibly non-transitive,
+indifference relation `∼_P`. -/
+structure TModel (Pred C : Type*) (D : Type*) where
+  /-- The interpretation of the constants. -/
+  const : C → D
+  /-- The classical extension of each predicate. -/
   interp : Pred → D → Prop
-  /-- Decidability of the interpretation (per predicate, per individual).
-      Bundled so each `TModel` instance carries its own decision procedure. -/
-  decInterp : ∀ P d, Decidable (interp P d)
-  /-- Tolerance (indifference) relation `~_P` per predicate. -/
+  /-- The indifference relation `∼_P` of each predicate. -/
   sim : Pred → D → D → Prop
-  /-- Each `~_P` is reflexive + symmetric (KTB frame). -/
   sim_ktb : ∀ P, IsKTBFrame (sim P)
 
-/-- Per-`TModel` decidability instance for the classical interpretation,
-    extracted from the bundled `decInterp` field. -/
-instance TModel.instDecidablePredInterp {D Pred : Type*}
-    (M : TModel D Pred) (P : Pred) : DecidablePred (M.interp P) :=
-  M.decInterp P
+variable {Pred : Type*} {C : Type u} {D : Type*}
+
+instance (M : TModel Pred C D) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
+
+/-- The three notions of truth, ordered by strength: `strict < classical < tolerant`. -/
+inductive Mode
+  | strict
+  | classical
+  | tolerant
+  deriving DecidableEq, Fintype
+
+namespace Mode
+
+/-- The duality of Definition 20: `d(t) = s`, `d(s) = t`, `d(c) = c`. -/
+def dual : Mode → Mode
+  | strict => tolerant
+  | classical => classical
+  | tolerant => strict
+
+theorem dual_involutive : Function.Involutive dual := λ m => by cases m <;> rfl
+
+@[simp] theorem dual_dual (m : Mode) : m.dual.dual = m := dual_involutive m
+
+@[simp] theorem dual_strict : strict.dual = tolerant := rfl
+@[simp] theorem dual_classical : classical.dual = classical := rfl
+@[simp] theorem dual_tolerant : tolerant.dual = strict := rfl
+
+private def rank : Mode → Fin 3
+  | strict => 0
+  | classical => 1
+  | tolerant => 2
+
+instance : LinearOrder Mode := LinearOrder.lift' rank (by decide)
+
+theorem strict_le (m : Mode) : strict ≤ m := by cases m <;> decide
+
+theorem le_tolerant (m : Mode) : m ≤ tolerant := by cases m <;> decide
+
+end Mode
+
+/-- Atomic sentences: predications `Pa` and similarity statements `a I_P b` (Definition 8). -/
+inductive Atom (Pred C : Type*)
+  | pred : Pred → C → Atom Pred C
+  | sim : Pred → C → C → Atom Pred C
+
+/-- The propositional fragment of the language (Definition 2). -/
+abbrev Formula (Pred C : Type*) := Trivalent.Formula (Atom Pred C)
+
+/-- The instance `Pa ∧ a I_P b → Pb` of the tolerance principle (1). -/
+def tolerance (P : Pred) (a b : C) : Formula Pred C :=
+  Trivalent.Formula.imp (.conj (.atom (.pred P a)) (.atom (.sim P a b))) (.atom (.pred P b))
 
 namespace TModel
 
-variable {D Pred : Type*}
+/-- Definition 9, with Definition 5 for the classical mode: a predication is strictly true when
+`P` holds throughout the `∼_P`-neighbourhood of the individual, `□`, and tolerantly true when it
+holds somewhere in it, `◇`; negation swaps to the dual mode; similarity statements are classical
+in every mode (Remark 2). -/
+def Realize (M : TModel Pred C D) : Mode → Formula Pred C → Prop
+  | _, .atom (.sim P a b) => M.sim P (M.const a) (M.const b)
+  | .classical, .atom (.pred P a) => M.interp P (M.const a)
+  | .strict, .atom (.pred P a) => □[M.sim P] (M.interp P) (M.const a)
+  | .tolerant, .atom (.pred P a) => ◇[M.sim P] (M.interp P) (M.const a)
+  | m, .neg φ => ¬ M.Realize m.dual φ
+  | m, .conj φ ψ => M.Realize m φ ∧ M.Realize m ψ
 
-/-- The similarity relation as a Kripke accessibility relation — the frame
-    associated with each predicate. By construction this frame is
-    reflexive + symmetric, i.e., a **KTB frame** (`ModalLogic.IsKTBFrame`). -/
-@[reducible] def simAccess (M : TModel D Pred) (P : Pred) : D → D → Prop := M.sim P
+variable (M : TModel Pred C D)
 
-/-- Per-`(M, P)` KTB-frame instance: lets typeclass search reach
-    `Std.Refl` and `Std.Symm` on `M.sim P` from any call site. -/
-instance (M : TModel D Pred) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
+@[simp] theorem realize_sim (m : Mode) (P : Pred) (a b : C) :
+    M.Realize m (.atom (.sim P a b)) ↔ M.sim P (M.const a) (M.const b) := by cases m <;> rfl
+
+@[simp] theorem realize_classical_pred (P : Pred) (a : C) :
+    M.Realize .classical (.atom (.pred P a)) ↔ M.interp P (M.const a) := Iff.rfl
+
+@[simp] theorem realize_strict_pred (P : Pred) (a : C) :
+    M.Realize .strict (.atom (.pred P a)) ↔ □[M.sim P] (M.interp P) (M.const a) := Iff.rfl
+
+@[simp] theorem realize_tolerant_pred (P : Pred) (a : C) :
+    M.Realize .tolerant (.atom (.pred P a)) ↔ ◇[M.sim P] (M.interp P) (M.const a) := Iff.rfl
+
+@[simp] theorem realize_neg (m : Mode) (φ : Formula Pred C) :
+    M.Realize m (.neg φ) ↔ ¬ M.Realize m.dual φ := Iff.rfl
+
+@[simp] theorem realize_conj (m : Mode) (φ ψ : Formula Pred C) :
+    M.Realize m (.conj φ ψ) ↔ M.Realize m φ ∧ M.Realize m ψ := Iff.rfl
+
+@[simp] theorem realize_disj (m : Mode) (φ ψ : Formula Pred C) :
+    M.Realize m (φ.disj ψ) ↔ M.Realize m φ ∨ M.Realize m ψ := by
+  simp [Trivalent.Formula.disj, or_iff_not_imp_left]
+
+/-- `M ⊨ᵐ φ → ψ` iff `M ⊨ⁿ ψ` whenever `M ⊨^{d(m)} φ` (the proof of Fact 3). -/
+@[simp] theorem realize_imp (m : Mode) (φ ψ : Formula Pred C) :
+    M.Realize m (φ.imp ψ) ↔ (M.Realize m.dual φ → M.Realize m ψ) := by
+  simp [Trivalent.Formula.imp]
+
+instance decidableRealize [Fintype D] [∀ P, DecidableRel (M.sim P)]
+    [∀ P, DecidablePred (M.interp P)] : ∀ (m : Mode) (φ : Formula Pred C), Decidable (M.Realize m φ)
+  | _, .atom (.sim P a b) => inferInstanceAs (Decidable (M.sim P (M.const a) (M.const b)))
+  | .classical, .atom (.pred P a) => inferInstanceAs (Decidable (M.interp P (M.const a)))
+  | .strict, .atom (.pred P a) =>
+    inferInstanceAs (Decidable (□[M.sim P] (M.interp P) (M.const a)))
+  | .tolerant, .atom (.pred P a) =>
+    inferInstanceAs (Decidable (◇[M.sim P] (M.interp P) (M.const a)))
+  | m, .neg φ => @instDecidableNot _ (decidableRealize m.dual φ)
+  | m, .conj φ ψ => @instDecidableAnd _ _ (decidableRealize m φ) (decidableRealize m ψ)
+
+/-- **Lemma 1**: strict truth implies classical truth, which implies tolerant truth. -/
+theorem realize_mono (φ : Formula Pred C) : Monotone (M.Realize · φ) := by
+  have h : ∀ φ : Formula Pred C,
+      (M.Realize .strict φ → M.Realize .classical φ) ∧
+      (M.Realize .classical φ → M.Realize .tolerant φ) := by
+    intro φ
+    induction φ with
+    | atom α =>
+      cases α with
+      | pred P a => exact ⟨box_T, λ h => ⟨M.const a, Std.Refl.refl _, h⟩⟩
+      | sim => exact ⟨id, id⟩
+    | neg ψ ih => exact ⟨λ h hc => h (ih.2 hc), λ h hs => h (ih.1 hs)⟩
+    | conj ψ χ ihψ ihχ =>
+      exact ⟨λ h => ⟨ihψ.1 h.1, ihχ.1 h.2⟩, λ h => ⟨ihψ.2 h.1, ihχ.2 h.2⟩⟩
+  intro m m' hm x
+  cases m <;> cases m' <;> first
+    | exact x
+    | exact absurd hm (by decide)
+    | exact (h φ).1 x
+    | exact (h φ).2 x
+    | exact (h φ).2 ((h φ).1 x)
+
+/-- A contradiction is true only tolerantly (§4.1). -/
+theorem eq_tolerant_of_realize_conj_neg {m : Mode} {φ : Formula Pred C}
+    (h : M.Realize m (.conj φ (.neg φ))) : m = .tolerant := by
+  cases m with
+  | tolerant => rfl
+  | classical => exact absurd h.1 h.2
+  | strict => exact absurd (M.realize_mono φ (by decide : Mode.strict ≤ .tolerant) h.1) h.2
+
+/-- Excluded middle fails only strictly (§2.4). -/
+theorem realize_disj_neg {m : Mode} (hm : m ≠ .strict) (φ : Formula Pred C) :
+    M.Realize m (φ.disj (.neg φ)) := by
+  rw [realize_disj, realize_neg]
+  cases m with
+  | strict => exact absurd rfl hm
+  | classical => exact em _
+  | tolerant => exact (em _).imp_left (M.realize_mono φ (by decide))
+
+/-! ### Borderline cases -/
+
+/-- Definition 10: `d` is a borderline case of `P` iff it is tolerantly but not strictly `P`. -/
+def Borderline (P : Pred) (d : D) : Prop :=
+  ◇[M.sim P] (M.interp P) d ∧ ¬ □[M.sim P] (M.interp P) d
+
+instance [Fintype D] [∀ P, DecidableRel (M.sim P)] [∀ P, DecidablePred (M.interp P)]
+    (P : Pred) (d : D) : Decidable (M.Borderline P d) :=
+  inferInstanceAs (Decidable (_ ∧ ¬ _))
+
+/-- A borderline case is one indifferent both from a `P` and from a non-`P` individual (p. 365). -/
+theorem borderline_iff (P : Pred) (d : D) :
+    M.Borderline P d ↔ (∃ e, M.sim P d e ∧ M.interp P e) ∧ ∃ e, M.sim P d e ∧ ¬ M.interp P e := by
+  simp [Borderline, box, diamond]
+
+/-- A borderline case is tolerantly both `P` and `¬P` (Definition 10). -/
+theorem borderline_iff_realize_conj_neg (P : Pred) (a : C) :
+    M.Borderline P (M.const a) ↔
+      M.Realize .tolerant (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a)))) := Iff.rfl
+
+/-- A borderline case is neither strictly `P` nor strictly `¬P` (Definition 10). -/
+theorem borderline_iff_not_realize_strict (P : Pred) (a : C) :
+    M.Borderline P (M.const a) ↔
+      ¬ M.Realize .strict (.atom (.pred P a)) ∧ ¬ M.Realize .strict (.neg (.atom (.pred P a))) := by
+  simp [Borderline, and_comm]
+
+/-- Excluded middle fails strictly at a borderline case (§2.4). -/
+theorem Borderline.not_realize_strict_disj {P : Pred} {a : C} (h : M.Borderline P (M.const a)) :
+    ¬ M.Realize .strict ((Trivalent.Formula.atom (.pred P a)).disj (.neg (.atom (.pred P a)))) := by
+  rw [realize_disj, realize_neg]
+  exact λ hd => hd.elim h.2 (λ hn => hn h.1)
+
+/-- By symmetry, a model with a borderline case has at least two (footnote 4). -/
+theorem Borderline.exists_ne {P : Pred} {d : D} (h : M.Borderline P d) :
+    ∃ e ≠ d, M.Borderline P e := by
+  obtain ⟨⟨e₁, h₁, hP₁⟩, e₂, h₂, hP₂⟩ := (M.borderline_iff P d).1 h
+  by_cases hd : M.interp P d
+  · exact ⟨e₂, λ he => hP₂ (he ▸ hd),
+      (M.borderline_iff P e₂).2 ⟨⟨d, Std.Symm.symm _ _ h₂, hd⟩, e₂, Std.Refl.refl _, hP₂⟩⟩
+  · exact ⟨e₁, λ he => hd (he ▸ hP₁),
+      (M.borderline_iff P e₁).2 ⟨⟨e₁, Std.Refl.refl _, hP₁⟩, d, Std.Symm.symm _ _ h₁, hd⟩⟩
 
 end TModel
 
--- ════════════════════════════════════════════════════
--- § 2. Atoms and Formulas
--- ════════════════════════════════════════════════════
-
-/-- Atoms of the propositional restricted vocabulary of TCS. Two
-    constructors per Definitions 8-9 of [cobreros-etal-2012]:
-
-    - `pred P a` ≡ `P(a)` — predicate application; t/c/s satisfaction
-      clauses depend on the mode (Definition 9).
-    - `sim P a b` ≡ `a I_P b` — similarity predicate; **classically
-      interpreted in all modes** (Definition 8, p. 353 + Remark 2,
-      p. 354 reiterating the assumption for s/t modes). -/
-inductive TCSAtom (Pred D : Type*) where
-  | pred : Pred → D → TCSAtom Pred D
-  | sim : Pred → D → D → TCSAtom Pred D
-
-/-- TCS formulas: propositional combinations (¬, ∧) of TCS atoms.
-    Reuses the canonical `Trivalent.Formula` rather than introducing a duplicate
-    inductive — `Trivalent.Formula.eval` and the `Trivalent.Formula.Realize` lemmas apply directly. -/
-abbrev TCSFormula (Pred D : Type*) := Trivalent.Formula (TCSAtom Pred D)
-
--- ════════════════════════════════════════════════════
--- § 3. Atomic Satisfaction (Definition 9 atomic clauses, p. 353)
--- ════════════════════════════════════════════════════
-
-variable {D Pred : Type*}
-
-/-- **Strict** atomic satisfaction: `P` holds at every `~_P`-neighbour
-    of `a`. Definition 9, atomic clause for `⊨ˢ`. Modal-logic-wise,
-    this is `box (M.simAccess P)` over the classical extension. -/
-def StrictAt (M : TModel D Pred) (P : Pred) (a : D) : Prop :=
-  ∀ d, M.sim P a d → M.interp P d
-
-/-- **Tolerant** atomic satisfaction: `P` holds at some `~_P`-neighbour
-    of `a`. Definition 9, atomic clause for `⊨ᵗ`. Modal-logic-wise,
-    this is `diamond (M.simAccess P)` over the classical extension. -/
-def TolerantAt (M : TModel D Pred) (P : Pred) (a : D) : Prop :=
-  ∃ d, M.sim P a d ∧ M.interp P d
-
-/-- **Strict atom = `box` over the similarity frame.** This is
-    definitionally true; the lemma exists to expose the modal-logic
-    framing and to let downstream proofs invoke `box_T`/`box_B`
-    directly. -/
-theorem strictAt_eq_box (M : TModel D Pred) (P : Pred) (a : D) :
-    StrictAt M P a = box (M.simAccess P) (λ d => M.interp P d) a := rfl
-
-/-- **Tolerant atom = `diamond` over the similarity frame.** Definitional. -/
-theorem tolerantAt_eq_diamond (M : TModel D Pred) (P : Pred) (a : D) :
-    TolerantAt M P a = diamond (M.simAccess P) (λ d => M.interp P d) a := rfl
-
--- ════════════════════════════════════════════════════
--- § 4. Lemma 1 atomic (extension hierarchy, p. 357)
--- ════════════════════════════════════════════════════
-
-/-- **Strict ⟹ classical** at the atomic level: if `P` holds for every
-    `~_P`-neighbour of `a`, it holds for `a` itself by reflexivity of
-    `~_P`. This is the **T axiom** instantiated. -/
-theorem StrictAt.imp_classical (M : TModel D Pred) (P : Pred) (a : D)
-    (hs : StrictAt M P a) : M.interp P a :=
-  box_T hs
-
-/-- **Classical ⟹ tolerant** at the atomic level: `a` itself
-    witnesses the existential by reflexivity of `~_P`. -/
-theorem TolerantAt.of_classical (M : TModel D Pred) (P : Pred) (a : D)
-    (hc : M.interp P a) : TolerantAt M P a :=
-  ⟨a, Std.Refl.refl (r := M.sim P) a, hc⟩
-
-/-- **Strict ⟹ tolerant** (transitive from above). -/
-theorem StrictAt.imp_tolerant (M : TModel D Pred) (P : Pred) (a : D)
-    (hs : StrictAt M P a) : TolerantAt M P a :=
-  TolerantAt.of_classical M P a (StrictAt.imp_classical M P a hs)
-
--- ════════════════════════════════════════════════════
--- § 5. Tolerance Principle (Facts 2-3, p. 354)
--- ════════════════════════════════════════════════════
-
-/-- **One-step tolerance** (Fact 2 of [cobreros-etal-2012], p. 354):
-    if `a` is strictly `P` and `a ~_P b`, then `b` is tolerantly `P`.
-    The tolerance principle `∀x∀y(P(x) ∧ x~_Py → P(y))` is t-valid.
-
-    Proof structure: strict-at-a + sim(a,b) gives classical-at-b
-    (via the strict clause); classical implies tolerant. -/
-theorem tolerance_one_step (M : TModel D Pred) (P : Pred) (a b : D)
-    (hs : StrictAt M P a) (hsim : M.sim P a b) :
-    TolerantAt M P b :=
-  TolerantAt.of_classical M P b (hs b hsim)
-
-/-- **Two-step tolerance** (Fact 3 of [cobreros-etal-2012], p. 354):
-    tolerance propagates across two similarity steps. The third step
-    can fail because `~_P` is non-transitive — paper footnote 4
-    illustrates this on the 4-element model with `Pa, a~b, b~c, c~d`
-    where `Pd` is NOT tolerantly true.
-
-    Proof: strict(a) + sim(a,b) gives classical(b); then b witnesses
-    tolerant(c) via sim(c,b) (by symmetry). -/
-theorem tolerance_two_step (M : TModel D Pred) (P : Pred) (a b c : D)
-    (hs : StrictAt M P a) (hab : M.sim P a b) (hbc : M.sim P b c) :
-    TolerantAt M P c :=
-  ⟨b, Std.Symm.symm (r := M.sim P) b c hbc, hs b hab⟩
-
--- ════════════════════════════════════════════════════
--- § 6. Borderline (Definition 10, p. 355)
--- ════════════════════════════════════════════════════
-
-/-- **Borderline**: in the tolerant extension but not the strict.
-
-    Definition 10 (p. 355): `b(P)^M := ⟦P⟧ᵗ \ ⟦P⟧ˢ`. We adopt this
-    set-difference form as canonical; the equivalent paraconsistent
-    characterisation `tolerant P ∧ tolerant ¬P` follows from Definition
-    9's negation clause (`tolerant ¬P ↔ ¬strict P`) and is recorded as
-    `IsBorderline.iff_tolerant_pair` below. -/
-def IsBorderline (M : TModel D Pred) (P : Pred) (a : D) : Prop :=
-  TolerantAt M P a ∧ ¬ StrictAt M P a
-
-/-- **Borderline iff witnesses on both sides** of the classical extension
-    in the similarity neighbourhood. This is the structural reading
-    underlying paper p. 355's discussion of borderline-as-disagreement. -/
-theorem IsBorderline.iff_both_witnesses (M : TModel D Pred) (P : Pred) (a : D) :
-    IsBorderline M P a ↔
-      (∃ d, M.sim P a d ∧ M.interp P d) ∧
-      (∃ d, M.sim P a d ∧ ¬ M.interp P d) := by
-  refine ⟨?_, ?_⟩
-  · rintro ⟨⟨d, hsd, hpd⟩, hns⟩
-    refine ⟨⟨d, hsd, hpd⟩, ?_⟩
-    by_contra hc
-    apply hns
-    intro e hse
-    by_contra hne
-    exact hc ⟨e, hse, hne⟩
-  · rintro ⟨⟨d, hsd, hpd⟩, ⟨e, hse, hne⟩⟩
-    refine ⟨⟨d, hsd, hpd⟩, ?_⟩
-    intro hs
-    exact hne (hs e hse)
-
--- ════════════════════════════════════════════════════
--- § 7. Bridge: TCS atoms ↔ Supervaluation (paper p. 355 footnote 5)
--- ════════════════════════════════════════════════════
-
-section Bridge
-
-variable [Fintype D]
-
-/-- The tolerance neighborhood of `a` under `P` as a `SpecSpace`.
-    Reflexivity of `~_P` ensures `a` is in its own neighbourhood, so the
-    admissible Finset is non-empty.
-
-    This makes TCS a **localized supervaluation**: each individual gets
-    its own specification space (the rough-set / tolerance-approximation
-    "granule" around it). -/
-def toleranceSpace (M : TModel D Pred) (P : Pred) (a : D)
-    [DecidablePred (M.sim P a)] : SpecSpace D where
-  admissible := Finset.univ.filter (M.sim P a)
-  nonempty := ⟨a, Finset.mem_filter.mpr ⟨Finset.mem_univ a,
-    Std.Refl.refl (r := M.sim P) a⟩⟩
-
-/-- **Strict truth = super-truth** over the tolerance neighborhood.
-    `P` is strict at `a` iff `P` is super-true (true at every spec point)
-    over `a`'s tolerance space. The central architectural connection to
-    `Supervaluation/Basic.lean`. -/
-theorem StrictAt.iff_superTrue (M : TModel D Pred) (P : Pred) (a : D)
-    [DecidablePred (M.sim P a)] :
-    StrictAt M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.true := by
-  rw [superTrue_true_iff]
-  refine ⟨λ h d hd => h d (Finset.mem_filter.mp hd).2,
-          λ h d hd => h d (Finset.mem_filter.mpr ⟨Finset.mem_univ d, hd⟩)⟩
-
-/-- **¬Tolerant = super-false** over the tolerance neighborhood. -/
-theorem TolerantAt.not_iff_superFalse (M : TModel D Pred) (P : Pred) (a : D)
-    [DecidablePred (M.sim P a)] :
-    ¬ TolerantAt M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.false := by
-  rw [superTrue_false_iff]
-  refine ⟨?_, ?_⟩
-  · intro h d hd hpd
-    have hsim := (Finset.mem_filter.mp hd).2
-    exact h ⟨d, hsim, hpd⟩
-  · rintro h ⟨d, hsim, hpd⟩
-    have hd : d ∈ Finset.univ.filter (M.sim P a) :=
-      Finset.mem_filter.mpr ⟨Finset.mem_univ d, hsim⟩
-    exact h d hd hpd
-
-/-- **Borderline = supervaluationally indeterminate** over the tolerance
-    neighborhood. Connects TCS to [fine-1975]: borderline cases are
-    exactly where the tolerance neighborhood disagrees on `P`. -/
-theorem IsBorderline.iff_superTrue_indet (M : TModel D Pred) (P : Pred) (a : D)
-    [DecidablePred (M.sim P a)] :
-    IsBorderline M P a ↔
-      superTrue (M.interp P) (toleranceSpace M P a) = Trivalent.indet := by
-  rw [IsBorderline.iff_both_witnesses, superTrue_indet_iff]
-  refine ⟨?_, ?_⟩
-  · rintro ⟨⟨d, hsd, hpd⟩, ⟨e, hse, hne⟩⟩
-    exact ⟨⟨d, Finset.mem_filter.mpr ⟨Finset.mem_univ d, hsd⟩, hpd⟩,
-           ⟨e, Finset.mem_filter.mpr ⟨Finset.mem_univ e, hse⟩, hne⟩⟩
-  · rintro ⟨⟨d, hd, hpd⟩, ⟨e, he, hne⟩⟩
-    exact ⟨⟨d, (Finset.mem_filter.mp hd).2, hpd⟩,
-           ⟨e, (Finset.mem_filter.mp he).2, hne⟩⟩
-
-end Bridge
-
--- ════════════════════════════════════════════════════
--- § 8. SatMode and Compositional Satisfaction (Definition 9 full)
--- ════════════════════════════════════════════════════
-
-/-- The three satisfaction modes of [cobreros-etal-2012]. -/
-inductive SatMode | tolerant | classical | strict
-  deriving DecidableEq, Repr, Inhabited
-
-namespace SatMode
-
-/-- The dual operation on modes: tolerant ↔ strict, classical fixed.
-    Encodes the mutual recursion of Definition 9: `M ⊨ᵗ ¬φ iff M ⊭ˢ φ`. -/
-def dual : SatMode → SatMode
-  | .tolerant => .strict
-  | .strict => .tolerant
-  | .classical => .classical
-
-/-- `dual` is an involution. Packaged as `Function.Involutive` so
-    downstream consumers can use mathlib's involution machinery. -/
-theorem dual_involutive : Function.Involutive dual := λ m => by cases m <;> rfl
-
-@[simp] theorem dual_dual (m : SatMode) : m.dual.dual = m := dual_involutive m
-
-end SatMode
-
-/-- **Three-valued satisfaction (Definition 9 full).** The propositional
-    fragment of Definition 9, dispatching on mode at atoms and threading
-    `SatMode.dual` through negation. Similarity atoms `a I_P b` are
-    classically interpreted regardless of mode (Definition 8 +
-    standing assumption above Definition 9). -/
-def Sat (M : TModel D Pred) : SatMode → TCSFormula Pred D → Prop
-  | _, .atom (.sim P a b) => M.sim P a b
-  | .classical, .atom (.pred P a) => M.interp P a
-  | .tolerant, .atom (.pred P a) => TolerantAt M P a
-  | .strict, .atom (.pred P a) => StrictAt M P a
-  | m, .neg φ => ¬ Sat M m.dual φ
-  | m, .conj φ ψ => Sat M m φ ∧ Sat M m ψ
-
-@[simp] theorem Sat.atom_classical_pred (M : TModel D Pred) (P : Pred) (a : D) :
-    Sat M .classical (.atom (.pred P a)) = (M.interp P a) := rfl
-
-@[simp] theorem Sat.atom_tolerant_pred (M : TModel D Pred) (P : Pred) (a : D) :
-    Sat M .tolerant (.atom (.pred P a)) = TolerantAt M P a := rfl
-
-@[simp] theorem Sat.atom_strict_pred (M : TModel D Pred) (P : Pred) (a : D) :
-    Sat M .strict (.atom (.pred P a)) = StrictAt M P a := rfl
-
-@[simp] theorem Sat.atom_sim (M : TModel D Pred) (m : SatMode)
-    (P : Pred) (a b : D) :
-    Sat M m (.atom (.sim P a b)) = M.sim P a b := by
-  cases m <;> rfl
-
-@[simp] theorem Sat.neg_eq (M : TModel D Pred) (m : SatMode) (φ : TCSFormula Pred D) :
-    Sat M m (.neg φ) = ¬ Sat M m.dual φ := rfl
-
-@[simp] theorem Sat.conj_eq (M : TModel D Pred) (m : SatMode) (φ ψ : TCSFormula Pred D) :
-    Sat M m (.conj φ ψ) = (Sat M m φ ∧ Sat M m ψ) := rfl
-
--- ════════════════════════════════════════════════════
--- § 9. Lemma 1 full (formula-level hierarchy, p. 357)
--- ════════════════════════════════════════════════════
-
-/-- **Lemma 1** (paper p. 357, formula level): for any TCS formula φ,
-    strict satisfaction implies classical, and classical implies
-    tolerant. Both directions must be proved together because the
-    negation case for one direction needs the contrapositive of the
-    other.
-
-    For predicate atoms this is the atomic Lemma 1 (`StrictAt.imp_classical`,
-    `TolerantAt.of_classical`). For similarity atoms all three modes
-    agree (similarity predicates are uniformly classical). The negation
-    case turns into a `dual`-swap; conjunction is pointwise. -/
-theorem Sat.hierarchy (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    (Sat M .strict φ → Sat M .classical φ) ∧
-    (Sat M .classical φ → Sat M .tolerant φ) := by
-  induction φ with
-  | atom α =>
-    cases α with
-    | pred P a =>
-      exact ⟨StrictAt.imp_classical M P a, TolerantAt.of_classical M P a⟩
-    | sim P a b => exact ⟨id, id⟩
-  | neg ψ ih =>
-    -- The neg case reduces both directions to contrapositives of `ih`.
-    -- `Sat M .strict (.neg ψ) = ¬ Sat M .tolerant ψ` and
-    -- `Sat M .classical (.neg ψ) = ¬ Sat M .classical ψ` definitionally,
-    -- so each direction is `(¬ q) → (¬ p)` which is `mt p_imp_q`.
-    exact ⟨λ h hc => h (ih.2 hc), λ h hs => h (ih.1 hs)⟩
-  | conj ψ χ ihψ ihχ =>
-    exact ⟨λ ⟨h1, h2⟩ => ⟨ihψ.1 h1, ihχ.1 h2⟩,
-           λ ⟨h1, h2⟩ => ⟨ihψ.2 h1, ihχ.2 h2⟩⟩
-
-theorem Sat.strict_imp_classical (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    Sat M .strict φ → Sat M .classical φ := (Sat.hierarchy M φ).1
-
-theorem Sat.classical_imp_tolerant (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    Sat M .classical φ → Sat M .tolerant φ := (Sat.hierarchy M φ).2
-
-theorem Sat.strict_imp_tolerant (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    Sat M .strict φ → Sat M .tolerant φ :=
-  λ h => Sat.classical_imp_tolerant M φ (Sat.strict_imp_classical M φ h)
-
--- ════════════════════════════════════════════════════
--- § 10. Identity Models and Lemma 2 (p. 357)
--- ════════════════════════════════════════════════════
-
-/-- An **identity T-model**: similarity is propositional equality.
-    Paper Lemma 2 (p. 357): every C-model can be expanded to a T-model
-    where t/c/s satisfaction coincide.
-
-    The construction is parameterised by an `interp` and produces the
-    T-model whose similarity relation is `(· = ·)`. -/
-def identityModel (interp : Pred → D → Prop) [∀ P d, Decidable (interp P d)] :
-    TModel D Pred where
-  interp := interp
-  decInterp := inferInstance
-  sim _ d₁ d₂ := d₁ = d₂
-  sim_ktb _ := { refl := fun _ => rfl, symm := fun _ _ h => h.symm }
-
-/-- In an identity model, tolerant atomic = classical. -/
-theorem identityModel.tolerantAt_iff (interp : Pred → D → Prop)
-    [∀ P d, Decidable (interp P d)] (P : Pred) (a : D) :
-    TolerantAt (identityModel interp) P a ↔ interp P a :=
-  ⟨λ ⟨_, hsim, hp⟩ => by cases hsim; exact hp,
-   λ h => ⟨a, rfl, h⟩⟩
-
-/-- In an identity model, strict atomic = classical. -/
-theorem identityModel.strictAt_iff (interp : Pred → D → Prop)
-    [∀ P d, Decidable (interp P d)] (P : Pred) (a : D) :
-    StrictAt (identityModel interp) P a ↔ interp P a :=
-  ⟨λ h => h a rfl, λ h _ hsim => by cases hsim; exact h⟩
-
-/-- **Lemma 2** (formula level): all three modes agree in an identity
-    model, for every formula. -/
-theorem identityModel.modes_agree (interp : Pred → D → Prop)
-    [∀ P d, Decidable (interp P d)]
-    (mode : SatMode) (φ : TCSFormula Pred D) :
-    Sat (identityModel interp) mode φ ↔ Sat (identityModel interp) .classical φ := by
-  induction φ generalizing mode with
-  | atom α =>
-    cases α with
-    | pred P a =>
-      cases mode with
-      | classical => exact Iff.rfl
-      | tolerant =>
-        simp only [Sat.atom_tolerant_pred, Sat.atom_classical_pred]
-        exact identityModel.tolerantAt_iff interp P a
-      | strict =>
-        simp only [Sat.atom_strict_pred, Sat.atom_classical_pred]
-        exact identityModel.strictAt_iff interp P a
-    | sim P a b => simp only [Sat.atom_sim]
-  | neg ψ ih =>
-    simp only [Sat.neg_eq]
-    exact not_congr (ih mode.dual)
-  | conj ψ χ ihψ ihχ =>
-    simp only [Sat.conj_eq]
-    exact and_congr (ihψ mode) (ihχ mode)
-
--- ════════════════════════════════════════════════════
--- § 11. Mixed Consequence (Definition 17, p. 366)
--- ════════════════════════════════════════════════════
-
-/-- **Mixed TCS-consequence** (Definition 17 of [cobreros-etal-2012]):
-    `Γ ⊨ᵐⁿ φ` iff every T-model that m-satisfies all premises also
-    n-satisfies the conclusion. The nine combinations (m, n ∈ {t, c, s})
-    yield the nine consequence relations.
-
-    Specialisation of `Consequence.MixedConsequence`. As an
-    `abbrev` so the substrate API surface (`mixed_monotone`, etc.) is
-    reachable without `unfold`. -/
-abbrev tcsConsequence
-    (m n : SatMode) (Γ : List (TCSFormula Pred D)) (φ : TCSFormula Pred D) : Prop :=
-  MixedConsequence (Sat (D := D) (Pred := Pred)) m n Γ φ
-
--- ════════════════════════════════════════════════════
--- § 12. Lemma 7 strength ordering (consequence level, p. 368)
--- ════════════════════════════════════════════════════
-
-/-- The atomic-level **`Sat`Implies** witnesses for the three pairwise
-    implications among satisfaction modes. These lift the formula-level
-    Lemma 1 (`Sat.strict_imp_classical` etc.) into the abstract
-    `SatImplies` shape that `MixedConsequence`'s monotonicity API
-    consumes. -/
-theorem satImplies_strict_classical :
-    SatImplies (Sat (D := D) (Pred := Pred)) .strict .classical :=
-  λ M φ h => Sat.strict_imp_classical M φ h
-
-theorem satImplies_classical_tolerant :
-    SatImplies (Sat (D := D) (Pred := Pred)) .classical .tolerant :=
-  λ M φ h => Sat.classical_imp_tolerant M φ h
-
-theorem satImplies_strict_tolerant :
-    SatImplies (Sat (D := D) (Pred := Pred)) .strict .tolerant :=
-  SatImplies.trans satImplies_strict_classical satImplies_classical_tolerant
-
-/-- **Lemma 7, premise-mode clause** (p. 368): premise-mode strengthening
-    coarsens consequence: `⊨ᵗᵐ ⊆ ⊨ᶜᵐ ⊆ ⊨ˢᵐ` for any conclusion mode `m`.
-    The "first/second part" decomposition is the formaliser's exposition;
-    the paper states both clauses as a single result. -/
-theorem tcsConsequence.from_tolerant_premise
-    {m : SatMode} {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (h : tcsConsequence .tolerant m Γ φ) :
-    tcsConsequence .classical m Γ φ :=
-  premise_monotone satImplies_classical_tolerant h
-
-theorem tcsConsequence.from_classical_premise
-    {m : SatMode} {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (h : tcsConsequence .classical m Γ φ) :
-    tcsConsequence .strict m Γ φ :=
-  premise_monotone satImplies_strict_classical h
-
-/-- **Lemma 7, conclusion-mode clause** (p. 368): conclusion-mode weakening
-    coarsens consequence: `⊨ᵐˢ ⊆ ⊨ᵐᶜ ⊆ ⊨ᵐᵗ` for any premise mode `m`. -/
-theorem tcsConsequence.to_classical_conclusion
-    {m : SatMode} {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (h : tcsConsequence m .strict Γ φ) :
-    tcsConsequence m .classical Γ φ :=
-  conclusion_monotone satImplies_strict_classical h
-
-theorem tcsConsequence.to_tolerant_conclusion
-    {m : SatMode} {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (h : tcsConsequence m .classical Γ φ) :
-    tcsConsequence m .tolerant Γ φ :=
-  conclusion_monotone satImplies_classical_tolerant h
-
--- ════════════════════════════════════════════════════
--- § 13. Lemma 8 collapse cc = sc = ct = st (p. 369, restricted vocabulary)
--- ════════════════════════════════════════════════════
-
-/-- A TCS formula is **restricted** if it uses only predicate atoms.
-    Paper §2 (p. 356) defines the restricted vocabulary as formulas
-    free of BOTH `I_P` (similarity) atoms AND `=` (identity) atoms;
-    this Lean substrate has no `=` constructor on `TCSAtom`, so this
-    predicate captures only the no-`I_P` half of the paper's restriction.
-    For the propositional fragment under consideration here, the two
-    coincide.
-
-    On this fragment the **Lemma 8** collapse holds (paper §3.3.1, p. 369,
-    states `⊨ˢᵗ ⇒ ⊨ᶜᶜ`, and combined with Lemma 7 monotonicity gives
-    cc = sc = ct = st). With similarity (or identity) atoms in the
-    language, ALL NINE consequence relations of Definition 17 become
-    genuinely distinct (paper §3.4 full-vocabulary diagram, p. 371);
-    the four strongest (cc, sc, ct, st) are demonstrated distinct in
-    paper §3.4 via the one-step tolerance inference `{Pa, aI_Pb} ⊨ Pb`. -/
-def IsRestricted : TCSFormula Pred D → Prop
+/-! ### Consequence -/
+
+/-- The T-models of the language over every domain, which validity and consequence quantify
+over (Definitions 11 and 17). -/
+abbrev TModels (Pred : Type*) (C : Type u) := (D : Type u) × TModel Pred C D
+
+/-- Truth in a bundled model. -/
+abbrev TModels.Realize (M : TModels Pred C) : Mode → Formula Pred C → Prop := M.2.Realize
+
+/-- Definition 11: `φ` is `n`-valid iff every T-model `n`-satisfies it. -/
+abbrev Valid (n : Mode) (φ : Formula Pred C) : Prop :=
+  mnValid (TModels.Realize (Pred := Pred) (C := C)) n φ
+
+/-- Definition 12: `φ` is `n`-unsatisfiable iff no T-model `n`-satisfies it. -/
+abbrev Unsat (n : Mode) (φ : Formula Pred C) : Prop := ∀ M : TModels Pred C, ¬ M.Realize n φ
+
+/-- Definition 17: `Γ ⊨ᵐⁿ φ` iff every T-model that `m`-satisfies `Γ` `n`-satisfies `φ`. -/
+abbrev Consequence (m n : Mode) (Γ : List (Formula Pred C)) (φ : Formula Pred C) : Prop :=
+  MixedConsequence (TModels.Realize (Pred := Pred) (C := C)) m n Γ φ
+
+variable {m n : Mode} {Γ : List (Formula Pred C)} {φ ψ : Formula Pred C}
+
+/-- `mn`-validity is `n`-validity (Definition 18). -/
+theorem consequence_nil (m n : Mode) (φ : Formula Pred C) : Consequence m n [] φ ↔ Valid n φ :=
+  mnValid_iff_emptyPremise _ _ _ _
+
+/-- **Remark 1**, for unsatisfiability: `φ` is `n`-unsatisfiable iff `¬φ` is `d(n)`-valid. -/
+theorem unsat_iff_valid_neg (n : Mode) (φ : Formula Pred C) :
+    Unsat n φ ↔ Valid n.dual (.neg φ) := by
+  simp [Valid, mnValid]
+
+/-- **Lemma 7**: consequence grows as premises are held to a stronger standard and conclusions
+to a weaker one. -/
+theorem Consequence.mono {m' n' : Mode} (hm : m' ≤ m) (hn : n ≤ n') (h : Consequence m n Γ φ) :
+    Consequence m' n' Γ φ :=
+  mixed_monotone (λ M φ => M.2.realize_mono φ hm) (λ M φ => M.2.realize_mono φ hn) h
+
+/-- **Remark 1**: negation swaps tolerant and strict truth and fixes classical truth. -/
+theorem satDuality :
+    Bilateral.SatDuality (TModels.Realize (Pred := Pred) (C := C)) .neg Mode.dual where
+  dual_invol := Mode.dual_dual
+  neg_swap _ _ _ := Iff.rfl
+
+/-- **Lemma 6**: `⊨ᵐⁿ` is the dual of `⊨^{d(n)d(m)}`. -/
+theorem Consequence.dual (h : Consequence m n [φ] ψ) :
+    Consequence n.dual m.dual [.neg ψ] (.neg φ) :=
+  consequence_dual satDuality h
+
+/-- The self-dual relations are `st`, `cc` and `ts` (§3.1). -/
+theorem isSelfDual_iff (m n : Mode) :
+    IsSelfDual Mode.dual m n ↔
+      (m = .strict ∧ n = .tolerant) ∨ (m = .classical ∧ n = .classical) ∨
+        (m = .tolerant ∧ n = .strict) := by
+  cases m <;> cases n <;> simp [IsSelfDual]
+
+/-- **Lemma 10**, the deduction theorem for self-dual consequence relations. Its converse rests
+on the nine relations being distinct (§3.4). -/
+theorem Consequence.imp_iff (h : IsSelfDual Mode.dual m n) :
+    Consequence m n [φ] ψ ↔ Valid n (φ.imp ψ) := by
+  obtain rfl : m = n.dual := h.symm
+  simp [Consequence, MixedConsequence, Valid, mnValid]
+
+/-! ### Tolerance -/
+
+/-- **Fact 2**: the tolerance principle is tolerantly valid. -/
+theorem tolerance_valid (P : Pred) (a b : C) : Valid .tolerant (tolerance P a b) := by
+  rintro ⟨D, M⟩
+  simp only [TModels.Realize, tolerance, TModel.realize_imp, TModel.realize_conj,
+    TModel.realize_sim, Mode.dual_tolerant, TModel.realize_strict_pred,
+    TModel.realize_tolerant_pred]
+  exact λ ⟨hs, hab⟩ => ⟨M.const b, Std.Refl.refl _, hs _ hab⟩
+
+/-- `{Pa, a I_P b} ⊨ˢᶜ Pb` (§3.4). -/
+theorem sc_one_step (P : Pred) (a b : C) :
+    Consequence .strict .classical [.atom (.pred P a), .atom (.sim P a b)] (.atom (.pred P b)) := by
+  rintro ⟨D, M⟩ h
+  simp only [TModels.Realize, List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp,
+    forall_eq,
+    TModel.realize_strict_pred, TModel.realize_sim] at h
+  exact h.1 _ h.2
+
+/-- `{Pa, a I_P b} ⊨ᶜᵗ Pb` (§3.4). -/
+theorem ct_one_step (P : Pred) (a b : C) :
+    Consequence .classical .tolerant [.atom (.pred P a), .atom (.sim P a b)]
+      (.atom (.pred P b)) := by
+  rintro ⟨D, M⟩ h
+  simp only [TModels.Realize, List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp,
+    forall_eq,
+    TModel.realize_classical_pred, TModel.realize_sim] at h
+  exact ⟨M.const a, Std.Symm.symm _ _ h.2, h.1⟩
+
+/-- Each step of a sorites is `st`-valid (§3.6). -/
+theorem st_one_step (P : Pred) (a b : C) :
+    Consequence .strict .tolerant [.atom (.pred P a), .atom (.sim P a b)] (.atom (.pred P b)) :=
+  (sc_one_step P a b).mono le_rfl (by decide)
+
+/-- **Fact 3**: tolerance holds up to two similarity steps. -/
+theorem st_two_step (P : Pred) (a b c : C) :
+    Consequence .strict .tolerant
+      [.atom (.pred P a), .atom (.sim P a b), .atom (.sim P b c)] (.atom (.pred P c)) := by
+  rintro ⟨D, M⟩ h
+  simp only [TModels.Realize, List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp,
+    forall_eq,
+    TModel.realize_strict_pred, TModel.realize_sim] at h
+  exact ⟨M.const b, Std.Symm.symm _ _ h.2.2, h.1 _ h.2.1⟩
+
+/-! ### The restricted vocabulary -/
+
+/-- Membership in the restricted vocabulary (§2): no similarity statements. -/
+def IsRestricted : Formula Pred C → Prop
   | .atom (.pred _ _) => True
   | .atom (.sim _ _ _) => False
   | .neg φ => IsRestricted φ
   | .conj φ ψ => IsRestricted φ ∧ IsRestricted ψ
 
-/-- **Identity-model construction for Lemma 8.** On the restricted
-    vocabulary (no sim atoms), the identity model built from `M`'s
-    classical interpretation classically satisfies the same formulas
-    as `M`. Combined with `identityModel.modes_agree` (where t = c = s
-    in the identity model), this drives the cc=st collapse. -/
-private theorem identityModel.classical_eq (M : TModel D Pred)
-    (φ : TCSFormula Pred D) (hr : IsRestricted φ) :
-    Sat (identityModel M.interp) .classical φ ↔ Sat M .classical φ := by
+namespace TModel
+
+variable (M : TModel Pred C D)
+
+/-- The T-model of Lemma 2: `M` with identity as every indifference relation. -/
+def identity : TModel Pred C D :=
+  { M with sim := λ _ => Eq, sim_ktb := λ _ => { refl := λ _ => rfl, symm := λ _ _ => Eq.symm } }
+
+/-- **Lemma 2**: in an identity model every mode agrees with classical truth. -/
+theorem identity_realize (m : Mode) (φ : Formula Pred C) :
+    M.identity.Realize m φ ↔ M.identity.Realize .classical φ := by
+  induction φ generalizing m with
+  | atom α =>
+    cases α with
+    | pred P a => cases m <;> simp [identity, box, diamond]
+    | sim P a b => simp
+  | neg ψ ih => simp [ih]
+  | conj ψ χ ihψ ihχ => simp [ihψ, ihχ]
+
+/-- The identity model agrees classically with `M` on the restricted vocabulary. -/
+theorem identity_realize_classical {φ : Formula Pred C} (hφ : IsRestricted φ) :
+    M.identity.Realize .classical φ ↔ M.Realize .classical φ := by
   induction φ with
   | atom α =>
     cases α with
     | pred P a => exact Iff.rfl
-    | sim P a b => exact hr.elim
-  | neg ψ ih =>
-    simp only [Sat.neg_eq, SatMode.dual]
-    exact not_congr (ih hr)
-  | conj ψ χ ihψ ihχ =>
-    simp only [Sat.conj_eq]
-    exact and_congr (ihψ hr.1) (ihχ hr.2)
+    | sim P a b => exact hφ.elim
+  | neg ψ ih => simp [ih hφ]
+  | conj ψ χ ihψ ihχ => simp [ihψ hφ.1, ihχ hφ.2]
 
-/-- **Lemma 8, st ⟹ cc** on restricted formulas (paper p. 369): the
-    heart of the collapse. An st-counterexample to a cc-claim survives
-    in the identity model where all modes agree.
+end TModel
 
-    The restriction to `IsRestricted` formulas is essential — paper §3.4
-    (p. 371) shows all nine consequence relations are distinct in the
-    full vocabulary. -/
-theorem tcsConsequence.st_imp_cc_restricted
-    {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (hΓ : ∀ ψ ∈ Γ, IsRestricted ψ) (hφ : IsRestricted φ)
-    (hst : tcsConsequence (D := D) (Pred := Pred) .strict .tolerant Γ φ) :
-    tcsConsequence .classical .classical Γ φ := by
-  intro M hprem
-  let M' := identityModel (D := D) (Pred := Pred) M.interp
-  have hprem' : ∀ γ ∈ Γ, Sat M' .strict γ := by
-    intro γ hγ
-    rw [identityModel.modes_agree, identityModel.classical_eq _ _ (hΓ γ hγ)]
-    exact hprem γ hγ
-  have hconc' := hst M' hprem'
-  rw [identityModel.modes_agree, identityModel.classical_eq _ _ hφ] at hconc'
-  exact hconc'
+/-- **Theorem 1**: on the restricted vocabulary, tolerant validity is classical validity. -/
+theorem valid_tolerant_iff (hφ : IsRestricted φ) : Valid .tolerant φ ↔ Valid .classical φ :=
+  ⟨λ h ⟨D, M⟩ => (M.identity_realize_classical hφ).1
+      ((M.identity_realize _ φ).1 (h ⟨D, M.identity⟩)),
+    λ h M => M.2.realize_mono φ (by decide) (h M)⟩
 
-/-- **cc ⟹ st** by monotonicity (Lemma 7, twice). Holds unrestricted. -/
-theorem tcsConsequence.cc_imp_st
-    {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (hcc : tcsConsequence (D := D) (Pred := Pred) .classical .classical Γ φ) :
-    tcsConsequence .strict .tolerant Γ φ :=
-  mixed_monotone satImplies_strict_classical satImplies_classical_tolerant hcc
+/-- **Theorem 1**: on the restricted vocabulary, strict unsatisfiability is classical
+unsatisfiability. -/
+theorem unsat_strict_iff (hφ : IsRestricted φ) : Unsat .strict φ ↔ Unsat .classical φ := by
+  rw [unsat_iff_valid_neg, unsat_iff_valid_neg, Mode.dual_strict, Mode.dual_classical]
+  exact valid_tolerant_iff hφ
 
-/-- **Lemma 8 cc ↔ st** on restricted formulas: classical consequence
-    collapses with strict-to-tolerant. -/
-theorem tcsConsequence.cc_iff_st_restricted
-    {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (hΓ : ∀ ψ ∈ Γ, IsRestricted ψ) (hφ : IsRestricted φ) :
-    tcsConsequence (D := D) (Pred := Pred) .classical .classical Γ φ ↔
-      tcsConsequence .strict .tolerant Γ φ :=
-  ⟨tcsConsequence.cc_imp_st, tcsConsequence.st_imp_cc_restricted hΓ hφ⟩
+/-- The model of Lemma 3: an individual for each constant plus one more, all indifferent, the
+extra one alone falling outside every predicate, so that every predication is borderline. -/
+def allBorderline (Pred C : Type*) : TModel Pred C (Option C) where
+  const := some
+  interp _ d := d.isSome
+  sim _ _ _ := True
+  sim_ktb _ := { refl := λ _ => trivial, symm := λ _ _ _ => trivial }
 
-/-- **Lemma 8 cc ↔ sc** on restricted formulas: sandwiching via Lemma 7. -/
-theorem tcsConsequence.cc_iff_sc_restricted
-    {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (hΓ : ∀ ψ ∈ Γ, IsRestricted ψ) (hφ : IsRestricted φ) :
-    tcsConsequence (D := D) (Pred := Pred) .classical .classical Γ φ ↔
-      tcsConsequence .strict .classical Γ φ := by
-  refine ⟨premise_monotone satImplies_strict_classical, ?_⟩
-  intro h
-  apply tcsConsequence.st_imp_cc_restricted hΓ hφ
-  exact conclusion_monotone satImplies_classical_tolerant h
+/-- **Lemma 3**: in `allBorderline` nothing restricted is strictly true and everything restricted
+is tolerantly true. -/
+theorem allBorderline_realize (hφ : IsRestricted φ) :
+    ¬ (allBorderline Pred C).Realize .strict φ ∧ (allBorderline Pred C).Realize .tolerant φ := by
+  induction φ with
+  | atom α =>
+    cases α with
+    | pred P a => exact ⟨λ h => by simpa [allBorderline] using h none trivial, some a, trivial, rfl⟩
+    | sim P a b => exact hφ.elim
+  | neg ψ ih => exact ⟨λ h => h (ih hφ).2, (ih hφ).1⟩
+  | conj ψ χ ihψ ihχ => exact ⟨λ h => (ihψ hφ.1).1 h.1, (ihψ hφ.1).2, (ihχ hφ.2).2⟩
 
-/-- **Lemma 8 cc ↔ ct** on restricted formulas: the dual sandwich. -/
-theorem tcsConsequence.cc_iff_ct_restricted
-    {Γ : List (TCSFormula Pred D)} {φ : TCSFormula Pred D}
-    (hΓ : ∀ ψ ∈ Γ, IsRestricted ψ) (hφ : IsRestricted φ) :
-    tcsConsequence (D := D) (Pred := Pred) .classical .classical Γ φ ↔
-      tcsConsequence .classical .tolerant Γ φ := by
-  refine ⟨conclusion_monotone satImplies_classical_tolerant, ?_⟩
-  intro h
-  apply tcsConsequence.st_imp_cc_restricted hΓ hφ
-  exact premise_monotone satImplies_strict_classical h
+/-- **Theorem 2**: no restricted formula is strictly valid. -/
+theorem not_valid_strict (hφ : IsRestricted φ) : ¬ Valid .strict φ :=
+  λ h => (allBorderline_realize hφ).1 (h ⟨_, allBorderline Pred C⟩)
 
--- ════════════════════════════════════════════════════
--- § 14. Duality (Remark 1 + Lemma 10, pp. 353+371)
--- ════════════════════════════════════════════════════
+/-- **Theorem 2**: every restricted formula is tolerantly satisfiable. -/
+theorem exists_realize_tolerant (hφ : IsRestricted φ) :
+    ∃ M : TModels Pred C, M.Realize .tolerant φ :=
+  ⟨⟨_, allBorderline Pred C⟩, (allBorderline_realize hφ).2⟩
 
-/-- **Remark 1** (p. 353): satisfaction-level duality. Negation swaps
-    the satisfaction mode via `dual`: `M ⊨ᵐ ¬φ ↔ ¬ M ⊨^{dual m} φ`.
-    Definitionally true from `Sat.neg_eq`.
+/-- **Lemma 8**: on the restricted vocabulary `st`-consequence is classical consequence. -/
+theorem Consequence.classical_of_st (hΓ : ∀ γ ∈ Γ, IsRestricted γ) (hφ : IsRestricted φ)
+    (h : Consequence .strict .tolerant Γ φ) : Consequence .classical .classical Γ φ := by
+  rintro ⟨D, M⟩ hM
+  exact (M.identity_realize_classical hφ).1 ((M.identity_realize _ φ).1
+    (h ⟨D, M.identity⟩ λ γ hγ =>
+      (M.identity_realize _ γ).2 ((M.identity_realize_classical (hΓ γ hγ)).2 (hM γ hγ))))
 
-    Note: the abstract `Bilateral.SatDuality` structure
-    requires `neg` to be a syntactic involution (`¬¬φ = φ`). TCSFormula
-    negation is NOT syntactically involutive (we have `.neg (.neg φ)`,
-    not `φ`), so the abstract structure does not literally apply. The
-    semantic-level swap is what's needed downstream and is proved here
-    directly. -/
-theorem Sat.neg_swap (M : TModel D Pred) (m : SatMode) (φ : TCSFormula Pred D) :
-    Sat M m (.neg φ) ↔ ¬ Sat M m.dual φ := Iff.rfl
+/-- **Lemma 8**: on the restricted vocabulary `cc`, `sc`, `ct` and `st` coincide. -/
+theorem Consequence.restricted_iff (hΓ : ∀ γ ∈ Γ, IsRestricted γ) (hφ : IsRestricted φ)
+    (hm : m ≤ .classical) (hn : .classical ≤ n) :
+    Consequence m n Γ φ ↔ Consequence .classical .classical Γ φ :=
+  ⟨λ h => classical_of_st hΓ hφ (h.mono (Mode.strict_le _) (Mode.le_tolerant _)),
+    λ h => h.mono hm hn⟩
 
-/-- **Lemma 10** self-dual witnesses: the consequence relations satisfying
-    `m = dual n` (equivalently `n = dual m`) are exactly the self-dual ones,
-    and these are exactly the ones for which the deduction theorem holds.
-    For TCS this gives `st`, `ts`, and `cc`. -/
-theorem st_self_dual : IsSelfDual SatMode.dual .strict .tolerant := rfl
+/-- **Lemma 9**: on the restricted vocabulary `ts`-consequence is empty. -/
+theorem not_consequence_tolerant_strict (hΓ : ∀ γ ∈ Γ, IsRestricted γ) (hφ : IsRestricted φ) :
+    ¬ Consequence .tolerant .strict Γ φ :=
+  λ h => (allBorderline_realize hφ).1
+    (h ⟨_, allBorderline Pred C⟩ λ γ hγ => (allBorderline_realize (hΓ γ hγ)).2)
 
-theorem ts_self_dual : IsSelfDual SatMode.dual .tolerant .strict := rfl
+/-! ### LP and K3 -/
 
-theorem cc_self_dual : IsSelfDual SatMode.dual .classical .classical := rfl
-
--- ════════════════════════════════════════════════════
--- § 15. Lemma 4 + Theorem 3 (LP/K3 correspondence, pp. 361-362)
--- ════════════════════════════════════════════════════
-
-section LpK3
-
-attribute [local instance] Classical.propDecidable
-
-/-- The MV-model construction of Lemma 4 (p. 361). Each TCS atom is
-    classified into Strong Kleene's `{true, false, indet}`:
-
-    - `pred P a` → `.true` if `StrictAt M P a`, `.false` if `¬TolerantAt M P a`,
-      `.indet` otherwise (borderline).
-    - `sim P a b` → classical: `.true` if similar, `.false` otherwise.
-
-    Definition is `noncomputable` because strictness/tolerance are not
-    decidable in general (only when `D` is finite and `sim` is decidable).
-    The local `Classical.propDecidable` instance makes the `if-then-else`
-    well-typed; every theorem about `toMV` remains constructive. -/
-noncomputable def toMV (M : TModel D Pred) : Trivalent.Model (TCSAtom Pred D) := λ α =>
-  match α with
+open Classical in
+/-- The MV-model of Lemma 4: a predication is `true` when strictly true, `false` when not
+tolerantly true and `indet` when borderline; similarity statements are two-valued. -/
+noncomputable def toMV (M : TModel Pred C D) : Trivalent.Model (Atom Pred C)
   | .pred P a =>
-    if StrictAt M P a then Trivalent.true
-    else if TolerantAt M P a then Trivalent.indet
-    else Trivalent.false
-  | .sim P a b => if M.sim P a b then Trivalent.true else Trivalent.false
+    if □[M.sim P] (M.interp P) (M.const a) then .true
+    else if ◇[M.sim P] (M.interp P) (M.const a) then .indet else .false
+  | .sim P a b => if M.sim P (M.const a) (M.const b) then .true else .false
 
-theorem toMV_pred_true_iff (M : TModel D Pred) (P : Pred) (a : D) :
-    toMV M (.pred P a) = Trivalent.true ↔ StrictAt M P a := by
-  unfold toMV
-  by_cases hs : StrictAt M P a
-  · simp [hs]
-  · simp only [if_neg hs]
-    refine ⟨λ h => absurd ?_ hs, λ h => absurd h hs⟩
-    by_cases ht : TolerantAt M P a
-    · rw [if_pos ht] at h; exact Trivalent.noConfusion h
-    · rw [if_neg ht] at h; exact Trivalent.noConfusion h
-
-theorem toMV_pred_false_iff (M : TModel D Pred) (P : Pred) (a : D) :
-    toMV M (.pred P a) = Trivalent.false ↔ ¬ TolerantAt M P a := by
-  unfold toMV
-  by_cases hs : StrictAt M P a
-  · simp only [if_pos hs]
-    exact ⟨λ h => Trivalent.noConfusion h,
-           λ h => absurd (StrictAt.imp_tolerant M P a hs) h⟩
-  · simp only [if_neg hs]
-    by_cases ht : TolerantAt M P a
-    · simp only [if_pos ht]
-      exact ⟨λ h => Trivalent.noConfusion h, λ h => absurd ht h⟩
-    · simp only [if_neg ht]
-      refine Iff.intro (λ _ => ht) (λ _ => ?_)
-      trivial
-
-theorem toMV_sim_true_iff (M : TModel D Pred) (P : Pred) (a b : D) :
-    toMV M (.sim P a b) = Trivalent.true ↔ M.sim P a b := by
-  unfold toMV
-  by_cases h : M.sim P a b
-  · simp [h]
-  · simp only [if_neg h]
-    exact ⟨λ heq => Trivalent.noConfusion heq, λ hh => absurd hh h⟩
-
-theorem toMV_sim_false_iff (M : TModel D Pred) (P : Pred) (a b : D) :
-    toMV M (.sim P a b) = Trivalent.false ↔ ¬ M.sim P a b := by
-  unfold toMV
-  by_cases h : M.sim P a b
-  · simp only [if_pos h]
-    exact ⟨λ heq => Trivalent.noConfusion heq, λ hn => absurd h hn⟩
-  · simp [h]
-
-/-- **Lemma 4** (p. 361, formula-level): for every T-model `M` and TCS
-    formula `φ`,
-
-    - `M ⊨ᵗ φ ↔ Trivalent.Formula.eval (toMV M) φ` is LP-designated (non-false)
-    - `M ⊨ˢ φ ↔ Trivalent.Formula.eval (toMV M) φ` is K3-designated (= true)
-
-    The two halves are proved by mutual induction. The negation case
-    uses `lpSat_neg_iff`/`k3Sat_neg_iff` from the substrate; the
-    conjunction case uses `lpSat_conj`/`k3Sat_conj`. -/
-theorem tcs_lp_k3_correspondence (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    (Sat M .tolerant φ ↔ Trivalent.Formula.Realize (toMV M) .lp φ) ∧
-    (Sat M .strict φ ↔ Trivalent.Formula.Realize (toMV M) .k3 φ) := by
+/-- **Lemma 4**: tolerant truth is LP-truth and strict truth K3-truth in `toMV M`. -/
+theorem TModel.realize_toMV (M : TModel Pred C D) (φ : Formula Pred C) :
+    (M.Realize .tolerant φ ↔ toMV M ⊨[.lp] φ) ∧ (M.Realize .strict φ ↔ toMV M ⊨[.k3] φ) := by
   induction φ with
   | atom α =>
     cases α with
     | pred P a =>
-      refine ⟨?_, ?_⟩
-      · -- tolerant ↔ LP-designated
-        simp only [Sat.atom_tolerant_pred, Trivalent.Formula.Realize, Trivalent.designated_lp_iff, Trivalent.Formula.eval]
-        constructor
-        · intro h heq
-          have := (toMV_pred_false_iff M P a).mp heq
-          exact this h
-        · intro h
-          by_contra hnot
-          exact h ((toMV_pred_false_iff M P a).mpr hnot)
-      · -- strict ↔ K3-designated
-        simp only [Sat.atom_strict_pred, Trivalent.Formula.Realize, Trivalent.designated_k3_iff, Trivalent.Formula.eval]
-        exact (toMV_pred_true_iff M P a).symm
+      simp only [TModel.realize_tolerant_pred, TModel.realize_strict_pred,
+        Trivalent.Formula.realize_atom, Trivalent.designated_lp_iff, Trivalent.designated_k3_iff,
+        toMV]
+      split_ifs with hs ht
+      · exact ⟨iff_of_true ⟨_, Std.Refl.refl _, box_T hs⟩ (by decide), iff_of_true hs rfl⟩
+      · exact ⟨iff_of_true ht (by decide), iff_of_false hs (by decide)⟩
+      · exact ⟨iff_of_false ht (λ h => h rfl), iff_of_false hs (by decide)⟩
     | sim P a b =>
-      refine ⟨?_, ?_⟩
-      · -- For sim atoms: Sat M m (sim) = M.sim P a b regardless of m.
-        -- LP-sat: Trivalent.Formula.eval = sim ? .true : .false; LP-designated iff true iff sim.
-        simp only [Sat.atom_sim, Trivalent.Formula.Realize, Trivalent.designated_lp_iff, Trivalent.Formula.eval, toMV]
-        by_cases hsim : M.sim P a b
-        · simp only [if_pos hsim]
-          exact ⟨λ _ h => Trivalent.noConfusion h, λ _ => hsim⟩
-        · simp only [if_neg hsim]
-          exact ⟨λ h => absurd h hsim, λ h => absurd rfl h⟩
-      · simp only [Sat.atom_sim, Trivalent.Formula.Realize, Trivalent.designated_k3_iff, Trivalent.Formula.eval, toMV]
-        by_cases hsim : M.sim P a b
-        · simp only [if_pos hsim]
-          refine Iff.intro (λ _ => ?_) (λ _ => hsim)
-          trivial
-        · simp only [if_neg hsim]
-          exact ⟨λ h => absurd h hsim, λ h => Trivalent.noConfusion h⟩
+      simp only [TModel.realize_sim, Trivalent.Formula.realize_atom, Trivalent.designated_lp_iff,
+        Trivalent.designated_k3_iff, toMV]
+      split_ifs with h <;> simp [h]
   | neg ψ ih =>
-    obtain ⟨iht, ihs⟩ := ih
-    refine ⟨?_, ?_⟩
-    · -- tolerant (¬ψ) ↔ LP-designated of neg
-      simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
-      exact not_congr ihs
-    · simp only [Sat.neg_eq, SatMode.dual, Trivalent.Formula.realize_neg, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
-      exact not_congr iht
+    simp only [TModel.realize_neg, Trivalent.Formula.realize_neg, Mode.dual_tolerant,
+      Mode.dual_strict, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
+    exact ⟨not_congr ih.2, not_congr ih.1⟩
   | conj ψ χ ihψ ihχ =>
-    obtain ⟨ihtψ, ihsψ⟩ := ihψ
-    obtain ⟨ihtχ, ihsχ⟩ := ihχ
-    refine ⟨?_, ?_⟩
-    · simp only [Sat.conj_eq, Trivalent.Formula.realize_conj]
-      exact and_congr ihtψ ihtχ
-    · simp only [Sat.conj_eq, Trivalent.Formula.realize_conj]
-      exact and_congr ihsψ ihsχ
-
-/-- **Lemma 4, t-direction**: tolerant satisfaction = LP-satisfaction
-    via `toMV`. -/
-theorem tolerant_iff_lp (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    Sat M .tolerant φ ↔ Trivalent.Formula.Realize (toMV M) .lp φ :=
-  (tcs_lp_k3_correspondence M φ).1
-
-/-- **Lemma 4, s-direction**: strict satisfaction = K3-satisfaction
-    via `toMV`. -/
-theorem strict_iff_k3 (M : TModel D Pred) (φ : TCSFormula Pred D) :
-    Sat M .strict φ ↔ Trivalent.Formula.Realize (toMV M) .k3 φ :=
-  (tcs_lp_k3_correspondence M φ).2
-
-/-- **Theorem 3** (paper p. 362, consequence-level): on the restricted
-    propositional vocabulary, t-consequence equals LP-consequence and
-    s-consequence equals K3-consequence (modulo the `toMV` translation
-    on premise/conclusion). The forward direction lifts Lemma 4
-    pointwise; the reverse direction uses the same `toMV`. -/
-theorem tcs_lp_consequence_correspondence
-    (Γ : List (TCSFormula Pred D)) (φ : TCSFormula Pred D) :
-    tcsConsequence .tolerant .tolerant Γ φ ↔
-      ∀ M : TModel D Pred,
-        (∀ γ ∈ Γ, Trivalent.Formula.Realize (toMV M) .lp γ) → Trivalent.Formula.Realize (toMV M) .lp φ := by
-  refine ⟨?_, ?_⟩
-  · intro h M hprem
-    rw [← tolerant_iff_lp]
-    exact h M (λ γ hγ => (tolerant_iff_lp M γ).mpr (hprem γ hγ))
-  · intro h M hprem
-    rw [tolerant_iff_lp]
-    exact h M (λ γ hγ => (tolerant_iff_lp M γ).mp (hprem γ hγ))
-
-theorem tcs_k3_consequence_correspondence
-    (Γ : List (TCSFormula Pred D)) (φ : TCSFormula Pred D) :
-    tcsConsequence .strict .strict Γ φ ↔
-      ∀ M : TModel D Pred,
-        (∀ γ ∈ Γ, Trivalent.Formula.Realize (toMV M) .k3 γ) → Trivalent.Formula.Realize (toMV M) .k3 φ := by
-  refine ⟨?_, ?_⟩
-  · intro h M hprem
-    rw [← strict_iff_k3]
-    exact h M (λ γ hγ => (strict_iff_k3 M γ).mpr (hprem γ hγ))
-  · intro h M hprem
-    rw [strict_iff_k3]
-    exact h M (λ γ hγ => (strict_iff_k3 M γ).mp (hprem γ hγ))
-
-end LpK3
-
--- ════════════════════════════════════════════════════
--- § 16. Non-transitivity schema via similarity atoms
--- ════════════════════════════════════════════════════
-
-/-! Schema theorems for the non-transitivity demonstration. With
-    similarity atoms in the formula language, we can now state and prove
-    the structural pattern of paper §3.4.1: each one-step / two-step
-    sorites inference is individually valid in mixed consequence, but
-    chaining past Fact 3's two-step limit fails.
-
-    Attribution caveat: the paper's §3.4.1 demonstration of
-    non-transitivity is for `⊨ᶜᵗ` (the corresponding chain `Pa, aI_Pb,
-    bI_Pc ⊭ᶜᵗ Pc`). The `⊨ˢᵗ` version of the sorites is stated separately
-    in paper §3.6 (Version 1 of the sorites, p. 376). The structural
-    pattern — each step valid in isolation, chain fails — is what §3.4.1
-    contributes; the `st`-instantiation here applies the same pattern to
-    the relation the paper ultimately advocates (paper p. 373: "st" is
-    the best-motivated choice).
-
-    Each one-step inference `[Pa, a I_P b] ⊨ˢᵗ Pb` is st-valid (Fact 2 of
-    the paper, p. 354). Two such inferences chain to give
-    `[Pa, a I_P b, b I_P c] ⊨ˢᵗ Pc` via Fact 3 (two-step tolerance,
-    p. 354). But three steps cannot be chained: on a model where `~_P`
-    exhausts at two steps, `[Pa, a I_P b, b I_P c, c I_P d] ⊭ˢᵗ Pd`. The
-    Studies file instantiates this on the 4-element model from p. 354. -/
-
-/-- Convenience: `Pa, a I_P b ⊨ˢᵗ Pb` is st-valid for every T-model
-    (one-step tolerance, schema form). Consumes paper Fact 2. -/
-theorem st_one_step_valid (P : Pred) (a b : D) :
-    tcsConsequence (D := D) (Pred := Pred) .strict .tolerant
-      [.atom (.pred P a), .atom (.sim P a b)]
-      (.atom (.pred P b)) := by
-  intro M hprem
-  have hPa : StrictAt M P a := hprem (.atom (.pred P a)) (by simp)
-  have hsim : M.sim P a b := hprem (.atom (.sim P a b)) (by simp)
-  exact tolerance_one_step M P a b hPa hsim
-
-/-- Two-step tolerance is st-valid in schema form. Consumes paper Fact 3. -/
-theorem st_two_step_valid (P : Pred) (a b c : D) :
-    tcsConsequence (D := D) (Pred := Pred) .strict .tolerant
-      [.atom (.pred P a), .atom (.sim P a b), .atom (.sim P b c)]
-      (.atom (.pred P c)) := by
-  intro M hprem
-  have hPa : StrictAt M P a := hprem (.atom (.pred P a)) (by simp)
-  have hab : M.sim P a b := hprem (.atom (.sim P a b)) (by simp)
-  have hbc : M.sim P b c := hprem (.atom (.sim P b c)) (by simp)
-  exact tolerance_two_step M P a b c hPa hab hbc
-
--- ════════════════════════════════════════════════════
--- § 17. Cross-framework divergence: TCS vs Supervaluation
--- ════════════════════════════════════════════════════
-
-/-! Cross-framework divergence between TCS and Fine 1975 supervaluationism
-    on borderline contradictions: TCS makes `P ∧ ¬P` tolerantly true while
-    supervaluation makes it super-FALSE on the same neighbourhood. Both
-    ingredients exist in the substrate (`TolerantAt`,
-    `nonContradiction_superFalse`); this section combines them into a
-    Lean-checkable existential divergence claim.
-
-    Comparator caveat: the paper's headline borderline-contradiction
-    contrast (p. 356) is actually with **Hyde 1997 subvaluationism**, NOT
-    with Fine 1975 supervaluationism. Subvaluation and TCS *agree* that
-    `P ∧ ¬P` holds at borderline cases; they disagree on the underlying
-    framework. The contrast formalised here — TCS vs supervaluation —
-    is the *formal-validity-side* contrast (paper p. 359, where TCS's
-    *t*/*s*-validity diverge from supervaluationist validity in the
-    quantifier-pattern sense). Subvaluationism is not formalised in
-    linglib; if it were, a NEW divergence theorem on the
-    framework-foundations axis would be the right comparator on the
-    *verdict* question.
-
-    A concrete instantiation on the paper's 4-element model is provided
-    in `Studies/CobrerosEtAl2012.lean`. -/
-
-/-- **TCS-vs-Supervaluation borderline-contradiction divergence (schema
-    form)**: for any T-model `M`, predicate `P`, and individual `a` that
-    is borderline-`P`, the conjunction `P(a) ∧ ¬P(a)` is **tolerantly**
-    true at `a` in TCS while the supervaluation of the same conjunction
-    over the tolerance neighborhood is **super-FALSE**.
-
-    The two frameworks DISAGREE on the formal-validity-side verdict of
-    borderline contradictions: TCS at `t` mode says ✓, supervaluation
-    says ✗ everywhere. (Note: on the *verdict* question, the paper's
-    headline contrast is with subvaluationism; see the section docstring.) -/
-theorem tcs_vs_supervaluation_borderline_contradiction
-    [Fintype D] [DecidableEq D]
-    (M : TModel D Pred) (P : Pred) (a : D) [DecidablePred (M.sim P a)]
-    (hb : IsBorderline M P a) :
-    Sat M .tolerant (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a)))) ∧
-    superTrue (fun d => M.interp P d ∧ ¬ M.interp P d) (toleranceSpace M P a)
-      = Trivalent.false := by
-  refine ⟨?_, nonContradiction_superFalse _ _⟩
-  -- TCS side: tolerant(P) ∧ tolerant(¬P)
-  -- tolerant(¬P) = ¬strict(P), which holds because borderline.
-  refine ⟨hb.1, ?_⟩
-  -- Sat M .tolerant (.neg (.atom (.pred P a))) = ¬ Sat M .strict (.atom (.pred P a)) = ¬ StrictAt M P a
-  simp only [Sat.neg_eq, SatMode.dual, Sat.atom_strict_pred]
-  exact hb.2
-
-/-- **Paracomplete dual** (schema form): on the same borderline cases,
-    `¬(P ∧ ¬P)` (i.e., excluded middle in dual form) fails strictly.
-
-    Note that strict satisfaction is the **paracomplete** dual of
-    tolerant: in TCS, borderline cases satisfy `P ∧ ¬P` tolerantly
-    AND fail to satisfy classical principles strictly. -/
-theorem tcs_borderline_excluded_middle_strict_fails
-    (M : TModel D Pred) (P : Pred) (a : D) (hb : IsBorderline M P a) :
-    ¬ Sat M .strict (.neg (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a))))) := by
-  -- Sat M .strict (.neg φ) = ¬ Sat M .tolerant φ. The conjunction is
-  -- tolerantly true at borderline cases (`tcs_vs_supervaluation_borderline_contradiction`),
-  -- so its strict negation fails. simp collapses ¬¬ to give the IsBorderline
-  -- shape directly.
-  simp only [Sat.neg_eq, SatMode.dual, Sat.conj_eq, Sat.atom_tolerant_pred,
-    Sat.atom_strict_pred, not_not]
-  exact hb
-
-end Semantics.Supervaluation.TCS
-
-namespace CobrerosEtAl2012
-
-open Semantics.Supervaluation.TCS
-open Semantics.Supervaluation (SpecSpace superTrue)
-
--- ════════════════════════════════════════════════════
--- § 1. The 4-element domain (paper footnote 4, p. 354)
--- ════════════════════════════════════════════════════
-
-/-- Four individuals — the elements of the paper's chain. -/
-inductive Elt | a | b | c | d
-  deriving Repr, DecidableEq
-
-instance : Fintype Elt where
-  elems := {.a, .b, .c, .d}
-  complete x := by cases x <;> decide
-
-/-- One vague predicate — "tall". -/
-inductive VPred | tall
-  deriving Repr, DecidableEq
-
-instance : Fintype VPred where
-  elems := {.tall}
-  complete x := by cases x; decide
-
--- ════════════════════════════════════════════════════
--- § 2. Similarity relation (paper footnote 4, p. 354)
--- ════════════════════════════════════════════════════
-
-/-- The similarity chain `a ~ b ~ c ~ d` with reflexivity + symmetry,
-    nothing else. Implemented via a Bool-valued helper so the `Decidable`
-    instance reduces through Bool equality, keeping the model fully
-    computable for `decide`-based extension proofs. -/
-def soritesSimBool : Elt → Elt → Bool
-  | .a, .a => true | .a, .b => true
-  | .b, .a => true | .b, .b => true | .b, .c => true
-  | .c, .b => true | .c, .c => true | .c, .d => true
-  | .d, .c => true | .d, .d => true
-  | _, _ => false
-
-/-- The similarity relation as a `Prop`, for direct integration with
-    the modal-logic substrate's `box`/`diamond`. -/
-def soritesSim (x y : Elt) : Prop := soritesSimBool x y = true
-
-instance : DecidableRel soritesSim := λ x y =>
-  inferInstanceAs (Decidable (soritesSimBool x y = true))
-
--- ════════════════════════════════════════════════════
--- § 3. The T-model itself (paper footnote 4, p. 354)
--- ════════════════════════════════════════════════════
-
-/-- The paper's running 4-element model: `I(tall) = {a, b}`, similarity
-    chain `a ~ b ~ c ~ d`. -/
-def soritesModel : TModel Elt VPred where
-  interp
-    | .tall, .a => True
-    | .tall, .b => True
-    | .tall, .c => False
-    | .tall, .d => False
-  decInterp P x := by cases P; cases x <;> simp only [] <;> infer_instance
-  sim _ := soritesSim
-  sim_ktb _ := { refl := fun x => by cases x <;> decide
-                 symm := fun x y h => by cases x <;> cases y <;> first | decide | exact h }
-
-/-- Per-pair decidability of the model's sim relation. Needed for
-    `decide`-style proofs of the extension theorems below. Since
-    `soritesModel.sim P` ignores `P` (definitionally `soritesSim`),
-    the instance reduces to `soritesSim`'s `DecidableRel`. The
-    `DecidablePred (soritesModel.sim P x)` shape needed by `toleranceSpace`
-    is auto-derived from this per-pair instance. -/
-instance soritesModel_sim_dec (P : VPred) (x y : Elt) :
-    Decidable (soritesModel.sim P x y) :=
-  inferInstanceAs (Decidable (soritesSim x y))
-
--- ════════════════════════════════════════════════════
--- § 4. Atomic-level decidability (so `decide` works)
--- ════════════════════════════════════════════════════
-
-/-- `StrictAt` is decidable on the sorites model: it's a finite
-    universal over the 4 elements. -/
-instance soritesModel_strict_dec (P : VPred) (x : Elt) :
-    Decidable (StrictAt soritesModel P x) :=
-  Fintype.decidableForallFintype
-
-/-- `TolerantAt` is decidable on the sorites model: it's a finite
-    existential. -/
-instance soritesModel_tolerant_dec (P : VPred) (x : Elt) :
-    Decidable (TolerantAt soritesModel P x) :=
-  Fintype.decidableExistsFintype
-
-instance soritesModel_borderline_dec (P : VPred) (x : Elt) :
-    Decidable (IsBorderline soritesModel P x) :=
-  inferInstanceAs (Decidable (TolerantAt soritesModel P x ∧ _))
-
--- ════════════════════════════════════════════════════
--- § 5. Extension verification
--- ════════════════════════════════════════════════════
-
-/-- **Strict extension** of `tall`: `{a}` only. Other elements have
-    similar individuals that aren't classically tall. -/
-theorem strict_extension :
-    StrictAt soritesModel .tall .a ∧
-    ¬ StrictAt soritesModel .tall .b ∧
-    ¬ StrictAt soritesModel .tall .c ∧
-    ¬ StrictAt soritesModel .tall .d := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
-
-/-- **Classical extension** of `tall`: `{a, b}` directly from `I(tall)`. -/
-theorem classical_extension :
-    soritesModel.interp .tall .a ∧
-    soritesModel.interp .tall .b ∧
-    ¬ soritesModel.interp .tall .c ∧
-    ¬ soritesModel.interp .tall .d := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> simp [soritesModel]
-
-/-- **Tolerant extension** of `tall`: `{a, b, c}`. `d` is too far from
-    the classical extension to count as tolerantly tall (three steps
-    from `a`, exceeding Fact 3's two-step limit). -/
-theorem tolerant_extension :
-    TolerantAt soritesModel .tall .a ∧
-    TolerantAt soritesModel .tall .b ∧
-    TolerantAt soritesModel .tall .c ∧
-    ¬ TolerantAt soritesModel .tall .d := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
-
--- ════════════════════════════════════════════════════
--- § 6. Borderline classification
--- ════════════════════════════════════════════════════
-
-/-- `b` is borderline-tall: tolerantly tall (witness: `a`), but not
-    strictly tall (counter-witness: `c`, which is similar to `b` but
-    not classically tall). -/
-theorem b_is_borderline : IsBorderline soritesModel .tall .b := by decide
-
-/-- `c` is borderline-tall: tolerantly tall (witness: `b`), but not
-    strictly tall (counter-witness: `d`). -/
-theorem c_is_borderline : IsBorderline soritesModel .tall .c := by decide
-
-/-- `a` is NOT borderline: strictly tall, hence not in `tolerant \ strict`. -/
-theorem a_not_borderline : ¬ IsBorderline soritesModel .tall .a := by decide
-
-/-- `d` is NOT borderline: not even tolerantly tall, hence not in `tolerant \ strict`. -/
-theorem d_not_borderline : ¬ IsBorderline soritesModel .tall .d := by decide
-
--- ════════════════════════════════════════════════════
--- § 7. Tolerant contradictions at borderline cases (paraconsistent half)
--- ════════════════════════════════════════════════════
-
-/-- At the borderline individual `b`, `tall ∧ ¬ tall` is **tolerantly true**
-    in TCS — the paraconsistent feature. Compare with the same conjunction
-    being super-FALSE in supervaluation: see §8 below. -/
-theorem b_tolerant_contradiction :
-    Sat soritesModel .tolerant
-      (.conj (.atom (.pred .tall .b)) (.neg (.atom (.pred .tall .b)))) := by
-  exact (tcs_vs_supervaluation_borderline_contradiction
-    soritesModel .tall .b b_is_borderline).1
-
-/-- Same for `c`. -/
-theorem c_tolerant_contradiction :
-    Sat soritesModel .tolerant
-      (.conj (.atom (.pred .tall .c)) (.neg (.atom (.pred .tall .c)))) :=
-  (tcs_vs_supervaluation_borderline_contradiction
-    soritesModel .tall .c c_is_borderline).1
-
-/-- At the **non-borderline** individual `a` (strictly tall), the
-    contradiction `tall ∧ ¬ tall` is NOT tolerantly true. -/
-theorem a_no_tolerant_contradiction :
-    ¬ Sat soritesModel .tolerant
-      (.conj (.atom (.pred .tall .a)) (.neg (.atom (.pred .tall .a)))) := by
-  rintro ⟨_, hneg⟩
-  -- hneg : ¬ Sat soritesModel .strict (.atom (.pred .tall .a))
-  -- But a IS strictly tall — contradiction.
-  exact hneg strict_extension.1
-
-/-- Dually for `d` (not even tolerantly tall). -/
-theorem d_no_tolerant_contradiction :
-    ¬ Sat soritesModel .tolerant
-      (.conj (.atom (.pred .tall .d)) (.neg (.atom (.pred .tall .d)))) := by
-  rintro ⟨htol, _⟩
-  exact tolerant_extension.2.2.2 htol
-
--- ════════════════════════════════════════════════════
--- § 8. Cross-framework divergence (TCS vs Fine 1975 supervaluation)
--- ════════════════════════════════════════════════════
-
-/-- **Cross-framework divergence theorem**, instantiated at
-    `(soritesModel, .tall, .b)`.
-
-    On the same tolerance neighborhood `{d | b ~ d}`:
-    - **TCS** says `tall(b) ∧ ¬ tall(b)` is **tolerantly true**
-    - **Fine 1975 supervaluation** says it is **super-FALSE** (= `Trivalent.false`)
-
-    The frameworks disagree on the *formal-validity-side* verdict.
-    Caveat (per the file docstring): the paper's headline contrast on
-    borderline contradictions (p. 356) is with **Hyde 1997
-    subvaluationism**, which agrees with TCS on the verdict. Fine 1975
-    supervaluation is the comparator we can formalise here because it's
-    the only one of the two with a substrate in linglib. -/
-theorem tcs_supervaluation_disagree_concrete :
-    Sat soritesModel .tolerant
-      (.conj (.atom (.pred .tall .b)) (.neg (.atom (.pred .tall .b)))) ∧
-    superTrue (λ e => soritesModel.interp .tall e && !soritesModel.interp .tall e)
-      (toleranceSpace soritesModel .tall .b)
-      = Trivalent.false :=
-  tcs_vs_supervaluation_borderline_contradiction
-    soritesModel .tall .b b_is_borderline
-
--- ════════════════════════════════════════════════════
--- § 9. Genuine non-transitivity demonstration via similarity atoms
--- ════════════════════════════════════════════════════
-
-/-- Named atoms used in the non-transitivity demonstration. Extracting
-    them as private definitions avoids dotted-identifier elaboration
-    issues in conjunctions and lists where the expected element type
-    isn't propagated through the syntactic constructors. -/
-private abbrev fmlPa : TCSFormula VPred Elt := .atom (.pred .tall .a)
-private abbrev fmlPb : TCSFormula VPred Elt := .atom (.pred .tall .b)
-private abbrev fmlPc : TCSFormula VPred Elt := .atom (.pred .tall .c)
-private abbrev fmlPd : TCSFormula VPred Elt := .atom (.pred .tall .d)
-private abbrev fmlIab : TCSFormula VPred Elt := .atom (.sim .tall .a .b)
-private abbrev fmlIbc : TCSFormula VPred Elt := .atom (.sim .tall .b .c)
-private abbrev fmlIcd : TCSFormula VPred Elt := .atom (.sim .tall .c .d)
-
-/-! Non-transitivity in the full vocabulary with similarity predicates
-    `Iₚ`. Each one-step `Pa, aIb ⊨ˢᵗ Pb` is valid (Fact 2, p. 354); each
-    two-step `Pa, aIb, bIc ⊨ˢᵗ Pc` is valid (Fact 3, p. 354); but
-    three-step `Pa, aIb, bIc, cId ⊨ˢᵗ Pd` is **invalid** because `d`
-    requires three similarity steps from the classical extension `{a, b}`,
-    exceeding Fact 3's two-step limit.
-
-    Attribution: paper §3.4.1 (p. 372) demonstrates non-transitivity for
-    `⊨ᶜᵗ` (the chain `Pa_1, a_1I_Pa_2, a_2I_Pa_3 ⊭ᶜᵗ Pa_3`), and
-    footnote 14 formalises the simple-transitivity statement. The `⊨ˢᵗ`
-    sorites version is in §3.6 (Version 1, p. 376). The structural
-    pattern (each step valid, chain fails) is §3.4.1's contribution; the
-    `st`-instantiation here transfers it to the relation the paper
-    advocates. -/
-
-/-- **One-step st-validity**, instantiated to the model: `tall(a), aIb ⊨ˢᵗ tall(b)`.
-    The schema theorem `Semantics.Supervaluation.TCS.st_one_step_valid` instantiates here. -/
-theorem st_one_step_a_to_b :
-    tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-      [fmlPa, fmlIab] fmlPb :=
-  st_one_step_valid (P := VPred.tall) (a := Elt.a) (b := Elt.b)
-
-/-- **Two-step st-validity**: `tall(a), aIb, bIc ⊨ˢᵗ tall(c)`. -/
-theorem st_two_step_a_to_c :
-    tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-      [fmlPa, fmlIab, fmlIbc] fmlPc :=
-  st_two_step_valid (P := VPred.tall) (a := Elt.a) (b := Elt.b) (c := Elt.c)
-
-/-- **Three-step st-INVALIDITY**: `tall(a), aIb, bIc, cId ⊭ˢᵗ tall(d)`.
-
-    Each step is individually st-valid (above), but the chain of three
-    exhausts the two-step tolerance limit (Fact 3, p. 354), so the
-    conclusion fails to hold even tolerantly at `d`. Structural pattern
-    of paper §3.4.1; paper itself states the `⊨ᶜᵗ` version there and
-    the `⊨ˢᵗ` sorites Version 1 in §3.6 (p. 376). -/
-theorem st_three_step_invalid :
-    ¬ tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-      [fmlPa, fmlIab, fmlIbc, fmlIcd] fmlPd := by
+    simp only [TModel.realize_conj, Trivalent.Formula.realize_conj]
+    exact ⟨and_congr ihψ.1 ihχ.1, and_congr ihψ.2 ihχ.2⟩
+
+/-- The T-model of Lemma 5 over the doubled domain: `(a, false)` is `a` and `(a, true)` its
+double `a'`, indifferent from each other and from nothing else; `a` is `P` when `v` makes `Pa`
+true and `a'` when `v` makes it non-false. -/
+def ofMV (v : Trivalent.Model (Atom Pred C)) : TModel Pred C (C × Bool) where
+  const a := (a, false)
+  interp P
+    | (a, false) => v (.pred P a) = .true
+    | (a, true) => v (.pred P a) ≠ .false
+  sim _ x y := x.1 = y.1
+  sim_ktb _ := { refl := λ _ => rfl, symm := λ _ _ => Eq.symm }
+
+/-- **Lemma 5**: on the restricted vocabulary, LP-truth in `v` is tolerant truth and K3-truth
+strict truth in `ofMV v`. -/
+theorem ofMV_realize (v : Trivalent.Model (Atom Pred C)) (hφ : IsRestricted φ) :
+    ((ofMV v).Realize .tolerant φ ↔ v ⊨[.lp] φ) ∧ ((ofMV v).Realize .strict φ ↔ v ⊨[.k3] φ) := by
+  induction φ with
+  | atom α =>
+    cases α with
+    | pred P a =>
+      simp only [TModel.realize_tolerant_pred, TModel.realize_strict_pred,
+        Trivalent.Formula.realize_atom, Trivalent.designated_lp_iff, Trivalent.designated_k3_iff,
+        ofMV, box, diamond]
+      refine ⟨⟨?_, λ h => ⟨(a, true), rfl, h⟩⟩, ⟨λ h => h (a, false) rfl, ?_⟩⟩
+      · rintro ⟨⟨b, i⟩, rfl, h⟩
+        cases i <;> simp_all
+      · rintro h ⟨b, i⟩ rfl
+        cases i <;> simp [h]
+    | sim P a b => exact hφ.elim
+  | neg ψ ih =>
+    simp only [TModel.realize_neg, Trivalent.Formula.realize_neg, Mode.dual_tolerant,
+      Mode.dual_strict, Trivalent.Designation.dual_lp, Trivalent.Designation.dual_k3]
+    exact ⟨not_congr (ih hφ).2, not_congr (ih hφ).1⟩
+  | conj ψ χ ihψ ihχ =>
+    simp only [TModel.realize_conj, Trivalent.Formula.realize_conj]
+    exact ⟨and_congr (ihψ hφ.1).1 (ihχ hφ.2).1, and_congr (ihψ hφ.1).2 (ihχ hφ.2).2⟩
+
+/-- **Theorem 3**: on the restricted vocabulary, tolerant consequence is LP-consequence. -/
+theorem consequence_tolerant_iff_lp (hΓ : ∀ γ ∈ Γ, IsRestricted γ) (hφ : IsRestricted φ) :
+    Consequence .tolerant .tolerant Γ φ ↔ Trivalent.Consequence .lp .lp Γ φ :=
+  ⟨λ h v hv => (ofMV_realize v hφ).1.1
+      (h ⟨_, ofMV v⟩ λ γ hγ => (ofMV_realize v (hΓ γ hγ)).1.2 (hv γ hγ)),
+    λ h ⟨_, M⟩ hM => (M.realize_toMV φ).1.2 (h (toMV M) λ γ hγ => (M.realize_toMV γ).1.1 (hM γ hγ))⟩
+
+/-- **Theorem 3**: on the restricted vocabulary, strict consequence is K3-consequence. -/
+theorem consequence_strict_iff_k3 (hΓ : ∀ γ ∈ Γ, IsRestricted γ) (hφ : IsRestricted φ) :
+    Consequence .strict .strict Γ φ ↔ Trivalent.Consequence .k3 .k3 Γ φ :=
+  ⟨λ h v hv => (ofMV_realize v hφ).2.1
+      (h ⟨_, ofMV v⟩ λ γ hγ => (ofMV_realize v (hΓ γ hγ)).2.2 (hv γ hγ)),
+    λ h ⟨_, M⟩ hM => (M.realize_toMV φ).2.2 (h (toMV M) λ γ hγ => (M.realize_toMV γ).2.1 (hM γ hγ))⟩
+
+/-! ### Sorites series -/
+
+/-- The sorites series of §3.4.1 and §3.6: `n` individuals in a line, each indifferent from its
+neighbours, the first `i` classically `P`. `series 4 2` is the four-element model of p. 354,
+`a, b, c, d` being `0, 1, 2, 3` and the classical extension `{a, b}`. -/
+def series (n i : ℕ) : TModel Unit (Fin n) (Fin n) where
+  const := id
+  interp _ x := x.val < i
+  sim _ x y := x.val ≤ y.val + 1 ∧ y.val ≤ x.val + 1
+  sim_ktb _ := { refl := λ _ => ⟨Nat.le_succ _, Nat.le_succ _⟩, symm := λ _ _ => And.symm }
+
+instance (n i : ℕ) (P : Unit) : DecidableRel ((series n i).sim P) :=
+  λ x y => inferInstanceAs (Decidable (x.val ≤ y.val + 1 ∧ y.val ≤ x.val + 1))
+
+instance (n i : ℕ) (P : Unit) : DecidablePred ((series n i).interp P) :=
+  λ x => inferInstanceAs (Decidable (x.val < i))
+
+variable {n i : ℕ}
+
+theorem series_realize_tolerant (hi : 0 < i) (x : Fin n) :
+    (series n i).Realize .tolerant (.atom (.pred () x)) ↔ x.val ≤ i := by
+  simp only [TModel.realize_tolerant_pred, diamond, series, id]
+  refine ⟨λ ⟨y, ⟨h₁, _⟩, h₃⟩ => by omega, λ h => ?_⟩
+  rcases Nat.lt_or_ge x.val i with hx | hx
+  · exact ⟨x, ⟨Nat.le_succ _, Nat.le_succ _⟩, hx⟩
+  · exact ⟨⟨x.val - 1, by omega⟩, by simp; omega, by simp; omega⟩
+
+theorem series_realize_strict (hin : i < n) (x : Fin n) :
+    (series n i).Realize .strict (.atom (.pred () x)) ↔ x.val + 1 < i := by
+  simp only [TModel.realize_strict_pred, box, series, id]
+  refine ⟨λ h => ?_, λ h y ⟨_, h₂⟩ => by omega⟩
+  by_cases hx : x.val + 1 < n
+  · simpa using h ⟨x.val + 1, hx⟩ ⟨Nat.le_succ_of_le (Nat.le_succ _), le_rfl⟩
+  · have := h x ⟨Nat.le_succ _, Nat.le_succ _⟩
+    omega
+
+/-- In a series with a cut the borderline cases are the two individuals either side of it. -/
+theorem series_borderline (hi : 0 < i) (hin : i < n) (x : Fin n) :
+    (series n i).Borderline () x ↔ x.val + 1 = i ∨ x.val = i := by
+  rw [TModel.Borderline, show ◇[(series n i).sim ()] ((series n i).interp ()) x ↔ x.val ≤ i from
+    series_realize_tolerant hi x, show □[(series n i).sim ()] ((series n i).interp ()) x ↔
+    x.val + 1 < i from series_realize_strict hin x]
+  omega
+
+/-- In the four-element model of p. 354 the strict, classical and tolerant extensions of `P`
+are `{a}`, `{a, b}` and `{a, b, c}`, so `b` and `c` are borderline. -/
+theorem series_four_two (x : Fin 4) :
+    ((series 4 2).Realize .strict (.atom (.pred () x)) ↔ x = 0) ∧
+    ((series 4 2).Realize .classical (.atom (.pred () x)) ↔ x = 0 ∨ x = 1) ∧
+    ((series 4 2).Realize .tolerant (.atom (.pred () x)) ↔ x ≠ 3) ∧
+    ((series 4 2).Borderline () x ↔ x = 1 ∨ x = 2) := by
+  revert x; decide
+
+/-- `b` is tolerantly both `P` and `¬P` in the four-element model (p. 356). -/
+theorem series_four_two_realize_conj_neg :
+    (series 4 2).Realize .tolerant
+      (.conj (.atom (.pred () 1)) (.neg (.atom (.pred () (1 : Fin 4))))) := by
+  decide
+
+/-- `{Pa, a I_P b} ⊨ Pb` is not `cc`-valid (§3.4): `b, c` of the four-element model. -/
+theorem not_cc_one_step :
+    ¬ Consequence .classical .classical
+      [.atom (.pred () 1), .atom (.sim () 1 2)] (.atom (.pred () (2 : Fin 4))) :=
+  λ h => absurd (h ⟨_, series 4 2⟩ (by decide)) (by decide)
+
+/-- Tolerance is not classically valid, hence neither `cc`- nor `sc`-valid (§3.4). -/
+theorem not_valid_classical_tolerance : ¬ Valid .classical (tolerance () (1 : Fin 4) 2) :=
+  λ h => absurd (h ⟨_, series 4 2⟩) (by decide)
+
+/-- `{Pa, a I_P b, b I_P c} ⊨ Pc` is not `sc`-valid (§3.4): `a, b, c` of the four-element
+model. -/
+theorem not_sc_two_step :
+    ¬ Consequence .strict .classical
+      [.atom (.pred () 0), .atom (.sim () 0 1), .atom (.sim () 1 2)]
+      (.atom (.pred () (2 : Fin 4))) :=
+  λ h => absurd (h ⟨_, series 4 2⟩ (by decide)) (by decide)
+
+/-- `{Pa, a I_P b, b I_P c} ⊨ Pc` is not `ct`-valid (§3.4): `b, c, d` of the four-element
+model. -/
+theorem not_ct_two_step :
+    ¬ Consequence .classical .tolerant
+      [.atom (.pred () 1), .atom (.sim () 1 2), .atom (.sim () 2 3)]
+      (.atom (.pred () (3 : Fin 4))) :=
+  λ h => absurd (h ⟨_, series 4 2⟩ (by decide)) (by decide)
+
+/-- The similarity premises `a₁ I_P a₂, …, aₙ I_P aₙ₊₁` of the sorites (§3.6). -/
+def steps (n : ℕ) : List (Formula Unit (Fin (n + 1))) :=
+  (List.finRange n).map λ k => .atom (.sim () k.castSucc k.succ)
+
+/-- The tolerance premises `Pa₁ ∧ a₁ I_P a₂ → Pa₂, …` of the sorites, Version 2 (§3.6). -/
+def tolerances (n : ℕ) : List (Formula Unit (Fin (n + 1))) :=
+  (List.finRange n).map λ k => tolerance () k.castSucc k.succ
+
+/-- **The sorites, Version 1**, is `st`-invalid for every series of at least four members, the
+four-element model being a countermodel, although each of its steps is `st`-valid
+(`st_one_step`). Below four members it is valid by Facts 2 and 3. -/
+theorem not_st_version1 (hn : 3 ≤ n) :
+    ¬ Consequence .strict .tolerant (.atom (.pred () 0) :: steps n)
+      (.atom (.pred () (Fin.last n))) := by
   intro h
-  have hprem : ∀ γ ∈ [fmlPa, fmlIab, fmlIbc, fmlIcd],
-      Sat soritesModel .strict γ := by
-    intro γ hγ
-    simp only [List.mem_cons, List.not_mem_nil, or_false] at hγ
-    rcases hγ with rfl | rfl | rfl | rfl
-    · exact strict_extension.1
-    all_goals (simp only [Sat.atom_sim]; decide)
-  exact tolerant_extension.2.2.2 (h soritesModel hprem)
+  have := (series_realize_tolerant (by omega) _).1 (h ⟨_, series (n + 1) 2⟩ ?_)
+  · simp at this
+    omega
+  intro γ hγ
+  simp only [List.mem_cons, steps, List.mem_map, List.mem_finRange, true_and] at hγ
+  rcases hγ with rfl | ⟨k, rfl⟩
+  · exact (series_realize_strict (by omega) _).2 (by simp)
+  · exact ⟨by simp [series]; omega, by simp [series]⟩
 
-/-- Convenience packaging: the chain of one-step + two-step st-valid
-    inferences cannot be extended to three steps, even though each
-    constituent step is valid. -/
-theorem st_chain_breaks_at_step_three :
-    tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-        [fmlPa, fmlIab] fmlPb ∧
-    tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-        [fmlPa, fmlIab, fmlIbc] fmlPc ∧
-    ¬ tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-        [fmlPa, fmlIab, fmlIbc, fmlIcd] fmlPd :=
-  ⟨st_one_step_a_to_b, st_two_step_a_to_c, st_three_step_invalid⟩
+/-- **The sorites, Version 2**, with tolerance as a premise, is `st`-valid: it is classically
+valid and `st` extends classical consequence. -/
+theorem st_version2 (n : ℕ) :
+    Consequence .strict .tolerant (.atom (.pred () 0) :: steps n ++ tolerances n)
+      (.atom (.pred () (Fin.last n))) := by
+  refine Consequence.mono (by decide) (by decide)
+    (?_ : Consequence .classical .classical _ _)
+  rintro ⟨D, M⟩ h
+  have hstep : ∀ k : Fin n, M.Realize .classical (.atom (.pred () k.castSucc)) →
+      M.Realize .classical (.atom (.pred () k.succ)) := by
+    intro k hk
+    have ht : M.Realize .classical (tolerance () k.castSucc k.succ) :=
+      h _ (List.mem_cons_of_mem _
+        (List.mem_append_right _ (List.mem_map_of_mem (List.mem_finRange k))))
+    have hs : M.Realize .classical (.atom (.sim () k.castSucc k.succ)) :=
+      h _ (List.mem_cons_of_mem _
+        (List.mem_append_left _ (List.mem_map_of_mem (List.mem_finRange k))))
+    rw [tolerance, M.realize_imp, Mode.dual_classical] at ht
+    exact ht ⟨hk, hs⟩
+  suffices ∀ k (hk : k ≤ n), M.Realize .classical (.atom (.pred () ⟨k, by omega⟩)) from
+    this n le_rfl
+  intro k
+  induction k with
+  | zero => exact λ _ => h _ (List.mem_cons_self ..)
+  | succ k ih => exact λ hk => hstep ⟨k, by omega⟩ (ih (by omega))
 
--- ════════════════════════════════════════════════════
--- § 10. Cross-framework reciprocations (Lean-checkable)
--- ════════════════════════════════════════════════════
+/-- Version 2 is unsound: across the cut of any series, the tolerance premise is not strictly
+true (§3.6). -/
+theorem not_series_realize_strict_tolerance (hi : 0 < i) (hin : i < n) :
+    ¬ (series n i).Realize .strict (tolerance () ⟨i - 1, by omega⟩ ⟨i, hin⟩) := by
+  simp only [tolerance, TModel.realize_imp, TModel.realize_conj, TModel.realize_sim,
+    Mode.dual_strict, series_realize_tolerant hi, series_realize_strict hin]
+  simp [series]
+  omega
 
-/-! Two Lean-checkable cross-framework theorems that close gaps flagged
-    by the cross-framework reconciler:
-
-    1. **TCS-vs-product-rule expressivity gap**: TCS predicts borderline
-       contradictions *categorically* (the conjunction is true, not
-       fractional); any framework that predicts them as a product of
-       complementary probabilities is *fractionally bounded* by 1/4
-       (AM-GM). The architectural divergence between TCS and L&G's
-       literal rule is structural, not parametric.
-    2. **Klein-delineation tension**: in `soritesModel`, two adjacent
-       individuals are tolerantly similar AND both borderline, yet
-       classically separated — exactly the configuration where any
-       sound Klein delineation would over-impose a scalar relation. -/
-
-/-- **TCS predicts borderline contradictions categorically.** Helper:
-    for any T-model `M`, predicate `P`, and individual `a` that is
-    borderline-`P`, the conjunction `P(a) ∧ ¬P(a)` is tolerantly true.
-    Extracted from the TCS half of
-    `tcs_vs_supervaluation_borderline_contradiction`. -/
-theorem tcs_borderline_contradiction_categorical
-    {D' Pred' : Type*} (M : TModel D' Pred') (P : Pred') (a : D')
-    (hb : IsBorderline M P a) :
-    Sat M .tolerant (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a)))) := by
-  refine ⟨hb.1, ?_⟩
-  simp only [Sat.neg_eq, SatMode.dual, Sat.atom_strict_pred]
-  exact hb.2
-
-/-- **TCS-vs-product-rule framework expressivity gap.** A framework-level
-    contrast theorem with two simultaneous halves, witnessing that TCS
-    and any "literal rule = product of complementary probabilities"
-    framework (paradigmatically L&G:
-    `Studies/LassiterGoodman2017PMF.lean::lg_literal_borderline_bounded`)
-    diverge structurally on borderline contradictions:
-
-    - **TCS half**: the conjunction `P(a) ∧ ¬P(a)` is tolerantly TRUE
-      (not fractional) at every borderline `a`. This is a categorical
-      framework prediction — independent of any parameter.
-    - **Product-rule half**: any product `q · (1 - q)` for `q ∈ [0, 1]`
-      is bounded above by `1/4` (AM-GM). This is the framework-level
-      ceiling on any literal-meaning rule that multiplies a probability
-      by its complement. L&G's `lg_literal_borderline_bounded` is the
-      `PMF`-typed instance of this generic bound.
-
-    The empirical Alxatib-Pelletier 2011 acceptance rate (44.7% — see
-    the [alxatib-pelletier-2011] contrast section of
-    `Studies/LassiterGoodman2017PMF.lean`)
-    exceeds the product-rule's 25% ceiling, refuting the literal-rule
-    framework empirically. TCS's categorical prediction is consistent
-    with the empirical direction without committing to any specific
-    fractional value. The structural divergence is what's interesting:
-    L&G's framework architecture *cannot represent* the empirical
-    direction (any literal-rule PMF is bounded ≤ 25%); TCS's framework
-    architecture predicts it categorically. -/
-theorem tcs_categorical_vs_product_bounded
-    {D' Pred' : Type*} (M : TModel D' Pred') (P : Pred') (a : D')
-    (hb : IsBorderline M P a) (q : ℝ) :
-    Sat M .tolerant (.conj (.atom (.pred P a)) (.neg (.atom (.pred P a)))) ∧
-    q * (1 - q) ≤ (1 / 4 : ℝ) := by
-  refine ⟨tcs_borderline_contradiction_categorical M P a hb, ?_⟩
-  -- (q - 1/2)² ≥ 0 expands to q² - q + 1/4 ≥ 0 ⟹ q(1-q) ≤ 1/4 for ALL real q
-  -- (no [0, 1] constraint needed — the bound is universal).
-  nlinarith [sq_nonneg (q - 1/2)]
-
-/-- **Klein-delineation tension witness**: in `soritesModel`, the
-    individuals `b` and `c` are both borderline-tall AND tolerantly
-    similar (`b ~_tall c`), yet classically separated (b is classically
-    tall, c is classically not-tall). Any Klein-style sound delineation
-    derived from `M.interp .tall` would impose a scalar relation
-    `R b c` on this pair (per
-    `Semantics/Degree/Delineation.lean::IsSoundDelineation`),
-    over-generating where TCS says `b` and `c` are *both equally
-    borderline* and the scalar relation should be unwarranted.
-
-    This is the Lean-checkable witness for the prose tension flagged at
-    `Comparison/Delineation.lean` lines 566-571. -/
-theorem klein_delineation_tension_concrete :
-    -- Both are borderline:
-    IsBorderline soritesModel .tall .b ∧
-    IsBorderline soritesModel .tall .c ∧
-    -- They are tolerantly similar:
-    soritesModel.sim .tall .b .c ∧
-    -- Yet classically separated:
-    soritesModel.interp .tall .b ∧
-    ¬ soritesModel.interp .tall .c :=
-  ⟨b_is_borderline, c_is_borderline, by decide, by simp [soritesModel], by simp [soritesModel]⟩
-
--- ════════════════════════════════════════════════════
--- § 11. Single-premise sorites unsoundness
--- ════════════════════════════════════════════════════
-
-/-- Single-premise sorites unsoundness (the previous formalization's
-    `sorites_chain_invalid`). Subsumed by `st_three_step_invalid` above
-    but kept under the historical name. -/
-theorem sorites_chain_invalid :
-    ¬ tcsConsequence (D := Elt) (Pred := VPred) .strict .tolerant
-      [.atom (.pred .tall .a)] (.atom (.pred .tall .d)) := by
-  intro h
-  have hprem : ∀ γ ∈ [(.atom (.pred .tall .a) : TCSFormula VPred Elt)],
-      Sat soritesModel .strict γ := by
-    intro γ hγ
-    simp at hγ
-    subst hγ
-    exact strict_extension.1
-  have hconc := h soritesModel hprem
-  exact tolerant_extension.2.2.2 hconc
+/-- §4.2.3: [alxatib-pelletier-2011]'s five men ranked by height, `#1 < #4 < #2 < #5 < #3`
+as ranks `0` to `4`, with `#1` and `#4` tall and `#5` and `#3` not. Whichever way the median
+man `#2`, rank `2`, is classified, `series 5 2` or `series 5 3`, he is borderline: tolerantly
+tall and tolerantly not tall. -/
+theorem alxatibPelletier_median_borderline (hi : i = 2 ∨ i = 3) :
+    (series 5 i).Borderline () 2 :=
+  (series_borderline (by omega) (by omega) 2).2 (by show 2 + 1 = i ∨ 2 = i; omega)
 
 end CobrerosEtAl2012

--- a/Linglib/Studies/HerbstrittFranke2019.lean
+++ b/Linglib/Studies/HerbstrittFranke2019.lean
@@ -10,7 +10,7 @@ import Mathlib.Probability.Distributions.Uniform
 
 Compositional threshold semantics plus an RSA model over an urn scenario
 (`N = 10` balls), formalised on mathlib's `PMF` in the same key as
-`Studies/LassiterGoodman2017PMF.lean`. Cognition 186 (2019) 50–71.
+`Studies/LassiterGoodman2017.lean`. Cognition 186 (2019) 50–71.
 
 The architectural novelty is a Hellinger-distance speaker utility (Eq. 16) in
 place of KL divergence. The literal listener `P_LL(s|m) ∝ ⟦m⟧(s) · P_prior(s)`

--- a/Linglib/Studies/LassiterGoodman2017.lean
+++ b/Linglib/Studies/LassiterGoodman2017.lean
@@ -1,15 +1,12 @@
 import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Core.Probability.JointPosterior
-import Linglib.Studies.CobrerosEtAl2012
 import Mathlib.Probability.Distributions.Uniform
 
 /-!
-# [lassiter-goodman-2017] on mathlib `PMF` — structural shell
-[lassiter-goodman-2017]
+# Lassiter and Goodman 2017: Adjectival vagueness in a Bayesian model of interpretation
 
-L&G 2017 ("Adjectival vagueness in a Bayesian model of interpretation",
-*Synthese* 194:3801-3836) gives a Bayesian/RSA account of vague gradable
+[lassiter-goodman-2017] gives a Bayesian/RSA account of vague gradable
 adjectives. This file formalises the **structural skeleton** of that
 account on mathlib's `PMF`, with explicit acknowledgment of what the
 file does and does not capture.
@@ -60,23 +57,6 @@ posterior.
 - Adams's bound (`adams_uncertainty_bound`, deferred — verbose generic
   probability theorem, not RSA-specific; cf. § Note on Adams below).
 
-## Connection to the bundled formalisation
-
-The bundled-config formalisation in `LassiterGoodman2017.lean`
-(sibling file, in this directory) handles the empirical-fit reproduction
-via interval reflection. Its `defaultCfg.L1 : Utterance → Height →
-ℝ` returns unnormalised real values via the bundled API; it is not
-PMF-shaped.
-
-The two files are **deliberately complementary**, not bridged: this one
-for the structural skeleton + cross-framework positioning, the bundled
-one for numeric simulations of Figs. 5-10. A formal bridge would
-require a PMF-shaped projection of `defaultCfg.L1` (currently absent
-from the bundled API) and isn't load-bearing for either file's
-contribution. The structural bounds proved here apply to *any* PMF over
-thresholds, so any future PMF projection of `defaultCfg.L1` would
-inherit them by construction.
-
 ## Geometry of the sorites bound
 
 L&G 2017 Eq. 37 defines premise probability as an **integral over an
@@ -101,9 +81,9 @@ borderline cases are *one* of several formalised positions in linglib:
 * `Studies/Fine1975.lean` — supervaluation,
   borderline mapped to `Trivalent.indet`, sorites resolved by super-falsity
   of the inductive premise.
-* `Linglib/Semantics/Supervaluation/TCS.lean` —
-  Cobreros-Égré-Ripley-van-Rooij Tolerant/Strict/Classical, sorites
-  resolved by non-transitivity of st-consequence.
+* `Studies/CobrerosEtAl2012.lean` — tolerant, classical and strict truth
+  ([cobreros-etal-2012]), sorites resolved by the non-transitivity of
+  strict-to-tolerant consequence.
 * `Studies/Klein1980.lean` — comparison-class
   delineation.
 * `Studies/Kennedy2007.lean` —
@@ -130,7 +110,7 @@ Equation": `P(if A then B) = P(B|A)`), used for PC-sorites premise
 strengths — neither captured.
 -/
 
-namespace LassiterGoodman2017.PMF
+namespace LassiterGoodman2017
 
 open scoped ENNReal
 
@@ -451,8 +431,8 @@ acceptance** for "X is tall and not tall" applied to the median
 
 `44.7% > 25%`, so a literal-meaning probabilistic account cannot
 reproduce the data. This is the formal expression of the empirical
-challenge that motivated TCS (`Linglib/Semantics/Supervaluation/TCS.lean`,
-[cobreros-etal-2012]), where borderline cases tolerantly satisfy
+challenge that motivated TCS ([cobreros-etal-2012],
+`Studies/CobrerosEtAl2012.lean`), where borderline cases tolerantly satisfy
 `P ∧ ¬P` *as a tolerantly-true proposition* — not via probability
 multiplication.
 
@@ -468,8 +448,8 @@ threshold posterior or the height being judged.
 
 Empirical contrast: [alxatib-pelletier-2011] report 44.7% — well
 above 25% — so the literal-rule prediction is empirically refuted.
-TCS (`[cobreros-etal-2012]`, formalised in
-`Semantics/Supervaluation/TCS.lean`) accommodates the data via
+TCS ([cobreros-etal-2012], `Studies/CobrerosEtAl2012.lean`)
+accommodates the data via
 non-probabilistic tolerant satisfaction. -/
 theorem lg_literal_borderline_bounded {S : Type*} (L1_latent : PMF S) (s : Set S) :
     L1_latent.toOuterMeasure s * (1 - L1_latent.toOuterMeasure s) ≤ (1/4 : ℝ≥0∞) := by
@@ -500,50 +480,4 @@ theorem lg_literal_borderline_bounded {S : Type*} (L1_latent : PMF S) (s : Set S
   -- Now: q * (1 - q) ≤ 1/4 on ℝ via (2q - 1)² ≥ 0
   nlinarith [sq_nonneg (2 * q - 1)]
 
-/-! ## §8. L&G-vs-TCS framework expressivity gap (Lean-checkable reciprocation)
-
-The previous version of this engagement was docstring-prose-only: §7
-above mentions TCS as the framework that handles the data direction
-the literal rule misses, and `Studies/CobrerosEtAl2012.lean`
-docstring mentions L&G's `lg_literal_borderline_bounded` as the empirical
-challenge that motivated TCS — but no Lean theorem connected the two.
-
-The theorem below closes that gap with a **concrete PMF-typed**
-witness of the expressivity divergence: simultaneously, L&G's
-literal-rule prediction is bounded (`≤ 1/4`) AND TCS's
-borderline-contradiction prediction is categorical (true, not
-fractional). The abstract real-arithmetic version of the same gap is
-`CobrerosEtAl2012.tcs_categorical_vs_product_bounded`. Together the two
-make the framework architecture difference visible at theorem level
-from both sides. -/
-
-open CobrerosEtAl2012 (
-  tcs_borderline_contradiction_categorical)
-open Semantics.Supervaluation.TCS (
-  TModel IsBorderline Sat SatMode TCSAtom)
-
-/-- **L&G-vs-TCS framework gap, PMF-typed**: L&G's literal-rule
-    prediction `P(P) · P(¬P)` is bounded above by `1/4` for any PMF
-    (`lg_literal_borderline_bounded`), while TCS's borderline-contradiction
-    prediction is **categorical** — the conjunction is tolerantly true,
-    not a fractional value to be matched.
-
-    The empirical Alxatib-Pelletier 2011 acceptance rate (44.7%) exceeds
-    the L&G literal upper bound (25%), refuting the literal-rule's
-    expressivity at this dataset. TCS's categorical prediction is
-    consistent with the empirical direction. The Lean theorem records
-    both halves of the framework gap simultaneously. -/
-theorem lg_literal_vs_tcs_categorical
-    {S : Type*} (L1_latent : PMF S) (s : Set S)
-    {D Pred : Type*} (M : TModel D Pred) (P : Pred) (a : D)
-    (hb : IsBorderline M P a) :
-    -- L&G literal-rule's framework-level upper bound:
-    L1_latent.toOuterMeasure s * (1 - L1_latent.toOuterMeasure s)
-      ≤ (1/4 : ℝ≥0∞) ∧
-    -- TCS's framework-level categorical prediction:
-    Sat M SatMode.tolerant
-      (.conj (.atom (TCSAtom.pred P a)) (.neg (.atom (TCSAtom.pred P a)))) :=
-  ⟨lg_literal_borderline_bounded L1_latent s,
-   tcs_borderline_contradiction_categorical M P a hb⟩
-
-end LassiterGoodman2017.PMF
+end LassiterGoodman2017

--- a/Linglib/Studies/Nouwen2024.lean
+++ b/Linglib/Studies/Nouwen2024.lean
@@ -962,7 +962,7 @@ of Nouwen's actual contribution:
 - **Positive-valence half** (Figure 8): `seq_pleasantly_prefers_moderate`
   — a support fact (`μ_pleasant (deg 6) = 0` licenses no threshold).
 
-## Connection to `LassiterGoodman2017PMF.lean`
+## Connection to `LassiterGoodman2017.lean`
 
 [nouwen-2024] §4 explicitly adopts the [lassiter-goodman-2017]
 RSA framework and modifies it to sequential two-update inference (vs L&G's

--- a/Linglib/Studies/TesslerGoodman2022.lean
+++ b/Linglib/Studies/TesslerGoodman2022.lean
@@ -1450,7 +1450,7 @@ question. The cross-paper compatibility was previously enforced via
 `personWeight_eq_lassiterGoodman` / `basketballWeight_eq_lassiterGoodman`
 bridge theorems referencing `RSA.LassiterGoodman2017.heightPrior`; those
 were removed when L&G's old bundled-config formalisation was retired.
-The PMF formalisation (`LassiterGoodman2017PMF.lean`) does not duplicate
+The PMF formalisation (`LassiterGoodman2017.lean`) does not duplicate
 the empirical priors. -/
 
 -- ============================================================================

--- a/references.bib
+++ b/references.bib
@@ -597,7 +597,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/LassiterGoodman2017PMF.lean}
+  sources   = {Studies/LassiterGoodman2017.lean}
 }% REF: Takahashi, S. & Hulsey, S. (2009). Wholesale Late Merger.
 @inproceedings{takahashi-fox-2005,
   author    = {Takahashi, Shoichi and Fox, Danny},
@@ -23281,7 +23281,7 @@
   doi       = {10.1007/s10992-010-9165-z},
   subfield  = {philosophical logic},
   role      = {primary},
-  sources   = {Semantics/Supervaluation/TCS.lean;Core/Logic/Consequence.lean;Core/Logic/ThreeValuedLogic.lean;Studies/CobrerosEtAl2012.lean},
+  sources   = {Studies/CobrerosEtAl2012.lean;Logic/Consequence.lean;Logic/Bilateral/Classical.lean;Logic/Trivalent/Propositional.lean;Core/Data/Trivalent.lean},
 }
 @article{alxatib-pelletier-2011,
   author    = {Alxatib, Sam and Pelletier, Francis Jeffry},


### PR DESCRIPTION
Rebuild the study on T-models over every domain (constants separate from the domain, consequence quantifying over \`TModels\`), stating the paper's own results in one \`namespace CobrerosEtAl2012\`: Theorems 1–3 (both directions of the LP/K3 correspondence via Lemmas 4 and 5), Lemmas 6, 9 and 10, the §3.4 distinctness facts, the §3.6 sorites Versions 1 and 2 on a general \`series\`, and the §4.2.3 five-men model; the supervaluation bridge, the "modal lens" prose and the reconciler theorems are gone.

- \`Bilateral.SatDuality\` drops its unused \`neg_invol\` field; \`Trivalent.Formula\` gains \`imp\`/\`disj\`.
- \`LassiterGoodman2017PMF.lean\` becomes the single \`LassiterGoodman2017.lean\` (namespace \`LassiterGoodman2017\`), its §8 conjunction and stale "bundled formalisation" section removed.