### PR TITLE
feat(Core/InformationTheory): entropy of a measure, finite KL sum

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -130,8 +130,10 @@ import Linglib.Core.Data.RoseTree.FilterMap
 import Linglib.Core.Data.RoseTree.Traversable
 import Linglib.Core.Data.Setoid.Basic
 import Linglib.Core.GroupTheory.Congruence.Hom
+import Linglib.Core.InformationTheory.Entropy
 import Linglib.Core.InformationTheory.KullbackLeibler.Basic
 import Linglib.Core.InformationTheory.KullbackLeibler.Cond
+import Linglib.Core.InformationTheory.KullbackLeibler.Finite
 import Linglib.Core.InformationTheory.MutualInformation
 import Linglib.Core.Learning.Luce
 import Linglib.Core.Learning.RescorlaWagner
@@ -163,6 +165,9 @@ import Linglib.Logic.Consequence
 import Linglib.Logic.CylindricAlgebra
 import Linglib.Logic.Duality
 import Linglib.Core.Relation.FactorsThroughOn
+import Linglib.Core.MeasureTheory.Measure.AbsolutelyContinuous
+import Linglib.Core.MeasureTheory.Measure.Decomposition.RadonNikodym
+import Linglib.Core.MeasureTheory.Measure.Prod
 import Linglib.Core.ModelTheory.Binders
 import Linglib.Core.ModelTheory.StructureFamily
 import Linglib.Core.ModelTheory.EhrenfeuchtFraisse

--- a/Linglib/Core/InformationTheory/Entropy.lean
+++ b/Linglib/Core/InformationTheory/Entropy.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.InformationTheory.KullbackLeibler.Finite
+import Linglib.Core.InformationTheory.MutualInformation
+import Linglib.Core.MeasureTheory.Measure.Prod
+import Linglib.Core.Probability.UniformOn
+import Mathlib.Analysis.Convex.Jensen
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+
+/-!
+# Entropy of a measure
+
+The Shannon entropy of a measure on a measurable space, following the PFR project's
+`ForMathlib` entropy: `Hm[μ] = ∑' s, negMulLog (((μ univ)⁻¹ • μ).real {s})`, normalized so
+that a finite measure has the entropy of its probability normalization. Mutual information is
+the entropy difference `Im[μ] = Hm[μ.fst] + Hm[μ.snd] - Hm[μ]`; on a finite type it is the
+real part of the Kullback–Leibler form `mutualInfo`, hence nonnegative.
+
+## Main definitions
+
+* `measureEntropy`, notation `Hm[μ]`
+* `measureMutualInfo`, notation `Im[μ]`
+
+## Main results
+
+* `measureEntropy_le_log_card`: entropy is at most the log of the cardinality;
+  `measureEntropy_uniformOn`: the uniform measure attains it.
+* `measureMutualInfo_eq_toReal_mutualInfo`, `measureMutualInfo_nonneg`.
+
+## References
+
+* [cover-thomas-2006], chapter 2.
+* The PFR project, `PFR/ForMathlib/Entropy/Measure.lean`.
+-/
+
+open MeasureTheory ProbabilityTheory Real
+open scoped ENNReal
+
+namespace InformationTheory
+
+variable {S T : Type*} [MeasurableSpace S] [MeasurableSpace T]
+
+section measureEntropy
+
+variable {μ : Measure S}
+
+/-- Entropy of a measure. The measure is normalized by `(μ Set.univ)⁻¹`, so that a finite
+measure has the entropy of its probability normalization and every other measure has entropy
+`0`; on a probability measure `simp` removes the normalization. -/
+noncomputable def measureEntropy (μ : Measure S) : ℝ :=
+  ∑' s, negMulLog (((μ Set.univ)⁻¹ • μ).real {s})
+
+@[inherit_doc measureEntropy] scoped notation:100 "Hm[" μ "]" => measureEntropy μ
+
+@[simp] theorem measureEntropy_zero : Hm[(0 : Measure S)] = 0 := by simp [measureEntropy]
+
+theorem measureEntropy_of_not_isFiniteMeasure (h : ¬ IsFiniteMeasure μ) : Hm[μ] = 0 := by
+  simp [measureEntropy, not_isFiniteMeasure_iff.mp h]
+
+theorem measureEntropy_of_isProbabilityMeasure (μ : Measure S) [IsZeroOrProbabilityMeasure μ] :
+    Hm[μ] = ∑' s, negMulLog (μ.real {s}) := by
+  rcases eq_zero_or_isProbabilityMeasure μ with rfl | _ <;> simp [measureEntropy]
+
+theorem measureEntropy_eq_sum [Fintype S] (μ : Measure S) [IsZeroOrProbabilityMeasure μ] :
+    Hm[μ] = ∑ s, negMulLog (μ.real {s}) := by
+  rw [measureEntropy_of_isProbabilityMeasure, tsum_fintype]
+
+theorem measureEntropy_univ_smul : Hm[(μ Set.univ)⁻¹ • μ] = Hm[μ] := by
+  by_cases hμ : IsFiniteMeasure μ
+  · rcases eq_zero_or_neZero μ with rfl | _
+    · simp
+    · simp [measureEntropy]
+  · rw [measureEntropy_of_not_isFiniteMeasure hμ]
+    rw [not_isFiniteMeasure_iff] at hμ
+    simp [hμ]
+
+theorem measureEntropy_nonneg (μ : Measure S) : 0 ≤ Hm[μ] := by
+  by_cases hμ : IsFiniteMeasure μ
+  · refine tsum_nonneg fun s => negMulLog_nonneg (by positivity) ?_
+    rcases eq_zero_or_neZero μ with rfl | _
+    · simp
+    · exact measureReal_le_one
+  · rw [measureEntropy_of_not_isFiniteMeasure hμ]
+
+variable [MeasurableSingletonClass S]
+
+@[simp] theorem measureEntropy_dirac (x : S) : Hm[Measure.dirac x] = 0 := by
+  rw [measureEntropy_of_isProbabilityMeasure, tsum_eq_single x]
+  · simp [measureReal_def]
+  · intro y hy
+    simp [measureReal_def, hy.symm]
+
+private theorem measureEntropy_le_log_card_of_isProbabilityMeasure [Fintype S] (μ : Measure S)
+    [IsProbabilityMeasure μ] : Hm[μ] ≤ log (Fintype.card S) := by
+  have : Nonempty S := μ.nonempty_of_neZero
+  set N := Fintype.card S
+  have hN : (N : ℝ) ≠ 0 := by positivity
+  rw [measureEntropy_eq_sum]
+  calc ∑ s, negMulLog (μ.real {s}) = N * ∑ s, (N : ℝ)⁻¹ * negMulLog (μ.real {s}) := by
+        rw [Finset.mul_sum]
+        congr with s
+        rw [← mul_assoc, mul_inv_cancel₀ hN, one_mul]
+    _ ≤ N * negMulLog (∑ s, (N : ℝ)⁻¹ * μ.real {s}) := by
+        gcongr
+        exact concaveOn_negMulLog.le_map_sum (by simp) (by simp [N]) (by simp)
+    _ = N * negMulLog (N : ℝ)⁻¹ := by
+        rw [← Finset.mul_sum, sum_measureReal_singleton, Finset.coe_univ, probReal_univ, mul_one]
+    _ = log N := by simp [negMulLog, ← mul_assoc, mul_inv_cancel₀ hN]
+
+/-- Entropy is at most the logarithm of the cardinality of the type. -/
+theorem measureEntropy_le_log_card [Fintype S] (μ : Measure S) :
+    Hm[μ] ≤ log (Fintype.card S) := by
+  by_cases hμ : IsFiniteMeasure μ
+  · rcases eq_zero_or_neZero μ with rfl | _
+    · simpa using log_natCast_nonneg (Fintype.card S)
+    · rw [← measureEntropy_univ_smul]
+      exact measureEntropy_le_log_card_of_isProbabilityMeasure _
+  · rw [measureEntropy_of_not_isFiniteMeasure hμ]
+    exact log_natCast_nonneg _
+
+/-- The entropy of the uniform measure on a finite set is the logarithm of its cardinality. -/
+theorem measureEntropy_uniformOn [Fintype S] [DecidableEq S] {A : Finset S} (hA : A.Nonempty) :
+    Hm[uniformOn (A : Set S)] = log A.card := by
+  have := isProbabilityMeasure_uniformOn A.finite_toSet (by simpa using hA)
+  have hcard : (A.card : ℝ) ≠ 0 := by exact_mod_cast hA.card_pos.ne'
+  rw [measureEntropy_eq_sum]
+  simp_rw [measureReal_def, uniformOn_finset_apply_singleton, apply_ite ENNReal.toReal,
+    apply_ite negMulLog, ENNReal.toReal_zero, negMulLog_zero, Finset.sum_ite_mem,
+    Finset.univ_inter, Finset.sum_const, nsmul_eq_mul, ENNReal.toReal_inv, ENNReal.toReal_natCast,
+    negMulLog, log_inv]
+  field_simp
+
+end measureEntropy
+
+section measureMutualInfo
+
+/-- Mutual information of a measure on a product: the entropies of the marginals less the
+entropy of the joint. -/
+noncomputable def measureMutualInfo (μ : Measure (S × T)) : ℝ :=
+  Hm[μ.fst] + Hm[μ.snd] - Hm[μ]
+
+@[inherit_doc measureMutualInfo] scoped notation:100 "Im[" μ "]" => measureMutualInfo μ
+
+variable [Fintype S] [Fintype T] [MeasurableSingletonClass S] [MeasurableSingletonClass T]
+  (μ : Measure (S × T)) [IsProbabilityMeasure μ]
+
+/-- On a finite product, the entropy form of mutual information is the real part of the
+Kullback–Leibler form. -/
+theorem measureMutualInfo_eq_toReal_mutualInfo : Im[μ] = (mutualInfo μ).toReal := by
+  have h (a : S) (b : T) :
+      μ.real {(a, b)} * log (μ.real {(a, b)} / (μ.fst.prod μ.snd).real {(a, b)})
+        = -negMulLog (μ.real {(a, b)}) - μ.real {(a, b)} * log (μ.fst.real {a})
+          - μ.real {(a, b)} * log (μ.snd.real {b}) := by
+    rw [Measure.prod_real_singleton]
+    obtain hp | hp := eq_or_ne (μ.real {(a, b)}) 0
+    · simp [hp]
+    · have hpos : 0 < μ.real {(a, b)} := lt_of_le_of_ne measureReal_nonneg hp.symm
+      have ha : μ.real {(a, b)} ≤ μ.fst.real {a} := by
+        rw [Measure.fst_real_singleton_eq_sum]
+        exact Finset.single_le_sum (f := fun b => μ.real {(a, b)}) (fun _ _ => measureReal_nonneg)
+          (Finset.mem_univ b)
+      have hb : μ.real {(a, b)} ≤ μ.snd.real {b} := by
+        rw [Measure.snd_real_singleton_eq_sum]
+        exact Finset.single_le_sum (f := fun a => μ.real {(a, b)}) (fun _ _ => measureReal_nonneg)
+          (Finset.mem_univ a)
+      rw [log_div hp (mul_ne_zero (hpos.trans_le ha).ne' (hpos.trans_le hb).ne'),
+        log_mul (hpos.trans_le ha).ne' (hpos.trans_le hb).ne', negMulLog]
+      ring
+  have h1 : ∑ a, ∑ b, μ.real {(a, b)} * log (μ.fst.real {a})
+      = ∑ a, μ.fst.real {a} * log (μ.fst.real {a}) := by
+    simp_rw [← Finset.sum_mul, ← Measure.fst_real_singleton_eq_sum]
+  have h2 : ∑ a, ∑ b, μ.real {(a, b)} * log (μ.snd.real {b})
+      = ∑ b, μ.snd.real {b} * log (μ.snd.real {b}) := by
+    rw [Finset.sum_comm]
+    simp_rw [← Finset.sum_mul, ← Measure.snd_real_singleton_eq_sum]
+  rw [mutualInfo, toReal_klDiv_eq_sum_log_div μ.absolutelyContinuous_fst_prod_snd,
+    measureMutualInfo, measureEntropy_eq_sum, measureEntropy_eq_sum, measureEntropy_eq_sum]
+  simp_rw [Fintype.sum_prod_type, h, Finset.sum_sub_distrib, Finset.sum_neg_distrib, h1, h2,
+    negMulLog, neg_mul, Finset.sum_neg_distrib]
+  ring
+
+theorem measureMutualInfo_nonneg : 0 ≤ Im[μ] := by
+  rw [measureMutualInfo_eq_toReal_mutualInfo]
+  exact ENNReal.toReal_nonneg
+
+end measureMutualInfo
+
+end InformationTheory

--- a/Linglib/Core/InformationTheory/KullbackLeibler/Finite.lean
+++ b/Linglib/Core/InformationTheory/KullbackLeibler/Finite.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.MeasureTheory.Measure.Decomposition.RadonNikodym
+import Mathlib.InformationTheory.KullbackLeibler.Basic
+import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
+import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
+
+/-!
+# Kullback–Leibler divergence on a finite type
+
+On a finite type with measurable singletons the Radon–Nikodym derivative is the ratio of atom
+masses, so `klDiv` is a finite sum, and for probability measures its real part is the textbook
+relative entropy `∑ a, μ {a} * log (μ {a} / ν {a})` ([cover-thomas-2006], chapter 2).
+`[UPSTREAM]` candidate for `Mathlib/InformationTheory/KullbackLeibler/`.
+-/
+
+open MeasureTheory Real
+open scoped ENNReal
+
+namespace InformationTheory
+
+variable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α] [Fintype α]
+  {μ ν : Measure α}
+
+theorem klDiv_eq_sum_klFun [IsFiniteMeasure μ] [IsFiniteMeasure ν] (hμν : μ ≪ ν) :
+    klDiv μ ν = ∑ a, ν {a} * ENNReal.ofReal (klFun (μ {a} / ν {a}).toReal) := by
+  have h : (fun a => ENNReal.ofReal (klFun (μ.rnDeriv ν a).toReal))
+      =ᵐ[ν] fun a => ENNReal.ofReal (klFun (μ {a} / ν {a}).toReal) := by
+    filter_upwards [Measure.rnDeriv_eq_div_singleton hμν] with a ha
+    rw [ha]
+  rw [klDiv_eq_lintegral_klFun_of_ac hμν, lintegral_congr_ae h, lintegral_fintype]
+  simp_rw [mul_comm]
+
+theorem toReal_klDiv_eq_sum_log_div [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+    (hμν : μ ≪ ν) :
+    (klDiv μ ν).toReal = ∑ a, μ.real {a} * log (μ.real {a} / ν.real {a}) := by
+  have key (a : α) : ν.real {a} * klFun (μ.real {a} / ν.real {a})
+      = μ.real {a} * log (μ.real {a} / ν.real {a}) + (ν.real {a} - μ.real {a}) := by
+    obtain hq | hq := eq_or_ne (ν.real {a}) 0
+    · have hp : μ.real {a} = 0 := by
+        rw [measureReal_eq_zero_iff (measure_ne_top _ _)] at hq ⊢
+        exact hμν hq
+      simp [hp, hq]
+    · unfold klFun; field_simp; ring
+  have h : (fun a => klFun (μ.rnDeriv ν a).toReal)
+      =ᵐ[ν] fun a => klFun (μ {a} / ν {a}).toReal := by
+    filter_upwards [Measure.rnDeriv_eq_div_singleton hμν] with a ha
+    rw [ha]
+  rw [toReal_klDiv_eq_integral_klFun hμν, integral_congr_ae h, integral_fintype .of_finite]
+  simp_rw [smul_eq_mul, ENNReal.toReal_div, ← measureReal_def, key,
+    Finset.sum_add_distrib, Finset.sum_sub_distrib, sum_measureReal_singleton,
+    Finset.coe_univ, probReal_univ, sub_self, add_zero]
+
+end InformationTheory

--- a/Linglib/Core/MeasureTheory/Measure/AbsolutelyContinuous.lean
+++ b/Linglib/Core/MeasureTheory/Measure/AbsolutelyContinuous.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.MeasureTheory.Measure.AbsolutelyContinuous
+
+/-!
+# Absolute continuity on a countable type
+
+On a countable type with measurable singletons, absolute continuity is checked on atoms.
+`[UPSTREAM]` candidate for `Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean`.
+-/
+
+namespace MeasureTheory.Measure
+
+variable {α : Type*} [MeasurableSpace α] [Countable α] {μ ν : Measure α}
+
+theorem absolutelyContinuous_of_forall_singleton (h : ∀ a, ν {a} = 0 → μ {a} = 0) : μ ≪ ν := by
+  refine AbsolutelyContinuous.mk fun s _ hs => ?_
+  rw [← Set.biUnion_of_singleton s, measure_biUnion_null_iff s.to_countable] at hs ⊢
+  exact fun a ha => h a (hs a ha)
+
+theorem absolutelyContinuous_iff_forall_singleton : μ ≪ ν ↔ ∀ a, ν {a} = 0 → μ {a} = 0 :=
+  ⟨fun h _ ha => h ha, absolutelyContinuous_of_forall_singleton⟩
+
+end MeasureTheory.Measure

--- a/Linglib/Core/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Linglib/Core/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+
+/-!
+# The Radon–Nikodym derivative on a countable type
+
+On a countable type with measurable singletons, a measure absolutely continuous with respect
+to a finite measure `ν` has density `a ↦ μ {a} / ν {a}`, so its Radon–Nikodym derivative is
+the ratio of atom masses `ν`-almost everywhere. `[UPSTREAM]` candidate for
+`Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean`.
+-/
+
+open scoped ENNReal
+
+namespace MeasureTheory.Measure
+
+variable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α] [Countable α]
+  {μ ν : Measure α} [IsFiniteMeasure ν]
+
+theorem withDensity_div_singleton (hμν : μ ≪ ν) :
+    ν.withDensity (fun a => μ {a} / ν {a}) = μ := by
+  refine ext_of_singleton fun a => ?_
+  rw [withDensity_apply _ (measurableSet_singleton a), lintegral_singleton]
+  exact ENNReal.div_mul_cancel' (fun h => hμν h) fun h => absurd h (measure_ne_top ν _)
+
+theorem rnDeriv_eq_div_singleton (hμν : μ ≪ ν) :
+    μ.rnDeriv ν =ᵐ[ν] fun a => μ {a} / ν {a} := by
+  conv_lhs => rw [← withDensity_div_singleton hμν]
+  exact rnDeriv_withDensity ν (measurable_of_countable _)
+
+end MeasureTheory.Measure

--- a/Linglib/Core/MeasureTheory/Measure/Prod.lean
+++ b/Linglib/Core/MeasureTheory/Measure/Prod.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.MeasureTheory.Measure.AbsolutelyContinuous
+import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.MeasureTheory.Measure.Real
+
+/-!
+# Measures on a product at atoms
+
+The marginals `Measure.fst` and `Measure.snd` at a singleton, as sums over the other
+coordinate when it ranges over a finite type, in `ℝ≥0∞` and on reals; the product measure at
+a rectangle on reals; and absolute continuity of a joint with respect to the product of its
+marginals. `[UPSTREAM]` candidate for `Mathlib/MeasureTheory/Measure/Prod.lean`.
+-/
+
+open scoped ENNReal
+
+namespace MeasureTheory.Measure
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+
+theorem measureReal_prod_prod (μ : Measure α) (ν : Measure β) [SFinite ν] (s : Set α)
+    (t : Set β) : (μ.prod ν).real (s ×ˢ t) = μ.real s * ν.real t := by
+  simp [measureReal_def, prod_prod]
+
+theorem prod_real_singleton (μ : Measure α) (ν : Measure β) [SFinite ν] (a : α) (b : β) :
+    (μ.prod ν).real {(a, b)} = μ.real {a} * ν.real {b} := by
+  rw [← Set.singleton_prod_singleton, measureReal_prod_prod]
+
+variable [MeasurableSingletonClass α] [MeasurableSingletonClass β]
+
+theorem fst_apply_singleton [Fintype β] (ρ : Measure (α × β)) (a : α) :
+    ρ.fst {a} = ∑ b, ρ {(a, b)} := by
+  rw [fst_apply (.singleton a),
+    show Prod.fst ⁻¹' ({a} : Set α) = ↑(({a} : Finset α) ×ˢ (Finset.univ : Finset β)) from by
+      ext ⟨_, _⟩; simp [eq_comm],
+    ← sum_measure_singleton, Finset.sum_product, Finset.sum_singleton]
+
+theorem snd_apply_singleton [Fintype α] (ρ : Measure (α × β)) (b : β) :
+    ρ.snd {b} = ∑ a, ρ {(a, b)} := by
+  rw [snd_apply (.singleton b),
+    show Prod.snd ⁻¹' ({b} : Set β) = ↑((Finset.univ : Finset α) ×ˢ ({b} : Finset β)) from by
+      ext ⟨_, _⟩; simp [eq_comm],
+    ← sum_measure_singleton, Finset.sum_product]
+  exact Finset.sum_congr rfl fun _ _ => Finset.sum_singleton _ _
+
+/-- The first marginal at a singleton is the mass of the corresponding product event. -/
+theorem fst_real_singleton [Fintype β] (ρ : Measure (α × β)) (a : α) :
+    ρ.fst.real {a} = ρ.real ↑(({a} : Finset α) ×ˢ (Finset.univ : Finset β)) := by
+  rw [measureReal_def, measureReal_def, fst_apply_singleton, ← sum_measure_singleton,
+    Finset.sum_product, Finset.sum_singleton]
+
+/-- The second marginal at a singleton is the mass of the corresponding product event. -/
+theorem snd_real_singleton [Fintype α] (ρ : Measure (α × β)) (b : β) :
+    ρ.snd.real {b} = ρ.real ↑((Finset.univ : Finset α) ×ˢ ({b} : Finset β)) := by
+  rw [measureReal_def, measureReal_def, snd_apply_singleton, ← sum_measure_singleton,
+    Finset.sum_product]
+  exact congrArg _ (Finset.sum_congr rfl fun _ _ => (Finset.sum_singleton _ _).symm)
+
+theorem fst_real_singleton_eq_sum [Fintype β] (ρ : Measure (α × β)) [IsFiniteMeasure ρ]
+    (a : α) : ρ.fst.real {a} = ∑ b, ρ.real {(a, b)} := by
+  simp [measureReal_def, fst_apply_singleton, ENNReal.toReal_sum, measure_ne_top]
+
+theorem snd_real_singleton_eq_sum [Fintype α] (ρ : Measure (α × β)) [IsFiniteMeasure ρ]
+    (b : β) : ρ.snd.real {b} = ∑ a, ρ.real {(a, b)} := by
+  simp [measureReal_def, snd_apply_singleton, ENNReal.toReal_sum, measure_ne_top]
+
+/-- A joint on a countable product is absolutely continuous with respect to the product of
+its marginals. -/
+theorem absolutelyContinuous_fst_prod_snd [Countable α] [Countable β] (ρ : Measure (α × β))
+    [SFinite ρ] : ρ ≪ ρ.fst.prod ρ.snd := by
+  refine absolutelyContinuous_of_forall_singleton fun ⟨a, b⟩ h => ?_
+  rw [← Set.singleton_prod_singleton, prod_prod, mul_eq_zero, fst_apply (.singleton a),
+    snd_apply (.singleton b)] at h
+  exact h.elim (measure_mono_null (Set.singleton_subset_iff.mpr rfl))
+    (measure_mono_null (Set.singleton_subset_iff.mpr rfl))
+
+end MeasureTheory.Measure

--- a/Linglib/Core/Probability/Kernel/Posterior.lean
+++ b/Linglib/Core/Probability/Kernel/Posterior.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.MeasureTheory.Measure.Prod
 import Mathlib.Probability.Kernel.Posterior
 import Mathlib.MeasureTheory.Measure.Real
 
@@ -149,34 +150,6 @@ theorem compProd_apply_singleton (μ : Measure Ω) [SFinite μ] (κ : Kernel Ω 
     [IsSFiniteKernel κ] (ω : Ω) (θ : Θ) : (μ ⊗ₘ κ) {(ω, θ)} = μ {ω} * κ ω {θ} := by
   rw [← Set.singleton_prod_singleton, compProd_apply_prod (.singleton ω) (.singleton θ),
     lintegral_singleton, mul_comm]
-
-theorem fst_apply_singleton [Fintype Θ] (m : Measure (Ω × Θ)) (ω : Ω) :
-    m.fst {ω} = ∑ θ : Θ, m {(ω, θ)} := by
-  rw [Measure.fst_apply (.singleton ω),
-    show Prod.fst ⁻¹' ({ω} : Set Ω) = ↑(({ω} : Finset Ω) ×ˢ (Finset.univ : Finset Θ)) from by
-      ext ⟨a, θ⟩; simp [eq_comm],
-    ← sum_measure_singleton, Finset.sum_product, Finset.sum_singleton]
-
-theorem snd_apply_singleton [Fintype Ω] (m : Measure (Ω × Θ)) (θ : Θ) :
-    m.snd {θ} = ∑ ω : Ω, m {(ω, θ)} := by
-  rw [Measure.snd_apply (.singleton θ),
-    show Prod.snd ⁻¹' ({θ} : Set Θ) = ↑((Finset.univ : Finset Ω) ×ˢ ({θ} : Finset Θ)) from by
-      ext ⟨a, b⟩; simp [eq_comm],
-    ← sum_measure_singleton, Finset.sum_product]
-  exact Finset.sum_congr rfl fun ω _ => Finset.sum_singleton _ _
-
-/-- The state marginal at a singleton is the mass of the corresponding product event. -/
-theorem fst_real_singleton [Fintype Θ] (m : Measure (Ω × Θ)) (ω : Ω) :
-    m.fst.real {ω} = m.real ↑(({ω} : Finset Ω) ×ˢ (Finset.univ : Finset Θ)) := by
-  rw [measureReal_def, measureReal_def, fst_apply_singleton, ← sum_measure_singleton,
-    Finset.sum_product, Finset.sum_singleton]
-
-/-- The latent marginal at a singleton is the mass of the corresponding product event. -/
-theorem snd_real_singleton [Fintype Ω] (m : Measure (Ω × Θ)) (θ : Θ) :
-    m.snd.real {θ} = m.real ↑((Finset.univ : Finset Ω) ×ˢ ({θ} : Finset Θ)) := by
-  rw [measureReal_def, measureReal_def, snd_apply_singleton, ← sum_measure_singleton,
-    Finset.sum_product]
-  exact congrArg _ (Finset.sum_congr rfl fun ω _ => (Finset.sum_singleton _ _).symm)
 
 end MeasureTheory.Measure
 


### PR DESCRIPTION
Measure-face Shannon entropy following the PFR project's `measureEntropy`: `Hm[μ]`, `Im[μ]`, entropy at most `log card` with the uniform measure attaining it, and `Im[μ] = (mutualInfo μ).toReal` through a finite-type reduction of `klDiv` to the textbook sum. No consumer changes; first step of moving `Core/Probability/Entropy.lean` off `PMF`.

- `Core/MeasureTheory/Measure/{AbsolutelyContinuous,Prod,Decomposition/RadonNikodym}.lean`: absolute continuity checked on atoms, marginals at atoms (moved out of `Kernel/Posterior.lean`), and the Radon–Nikodym derivative on a countable type.