### PR TITLE
refactor(Studies): Levy2008 and GoodmanStuhlmuller2013 on measure-level klDiv

### DIFF
--- a/Linglib/Core/Probability/Entropy.lean
+++ b/Linglib/Core/Probability/Entropy.lean
@@ -299,16 +299,6 @@ theorem klDiv_eq_sum_klFun {α : Type*} [Fintype α] [MeasurableSpace α]
   refine Finset.sum_congr rfl (fun y _ => ?_)
   rw [PMF.toMeasure_apply_singleton _ _ (measurableSet_singleton y), mul_comm]
 
-open scoped ProbabilityTheory in
-/-- The Kullback-Leibler divergence of `p` conditioned on an event `s` from
-`p` itself is the negative log-mass of the event ([levy-2008]'s eq. (4) at
-its most general). -/
-theorem klDiv_filter_self {α : Type*} [MeasurableSpace α] (p : PMF α) {s : Set α}
-    (hs : MeasurableSet s) (h : ∃ a ∈ s, a ∈ p.support) :
-    (p.filter s h).klDiv p = ENNReal.ofReal (-Real.log (p.toMeasure s).toReal) := by
-  rw [klDiv_eq_toMeasure_klDiv, PMF.toMeasure_filter p hs h]
-  exact InformationTheory.klDiv_cond_self p.toMeasure hs (p.toMeasure_ne_zero hs h)
-
 -- ============================================================================
 -- §7: Jensen-Shannon divergence — KL-symmetrized form (mathlib-style)
 -- ============================================================================

--- a/Linglib/Studies/GoodmanStuhlmuller2013.lean
+++ b/Linglib/Studies/GoodmanStuhlmuller2013.lean
@@ -1,9 +1,8 @@
-import Linglib.Core.Probability.DataProcessing
-import Linglib.Core.Probability.Entropy
 import Linglib.Core.Probability.Hypergeometric
 import Linglib.Core.Probability.Posterior
 import Linglib.Pragmatics.RSA.Operators
 import Linglib.Pragmatics.RSA.Silence
+import Mathlib.InformationTheory.KullbackLeibler.DataProcessing
 import Mathlib.Probability.ProbabilityMassFunction.Monad
 import Mathlib.Probability.Distributions.Uniform
 
@@ -986,9 +985,9 @@ The paper's **cancellation principle** (informal): as the speaker's
 observation kernel becomes noisier, the listener's posterior moves closer to
 the prior. The universally provable structural content is observation-level:
 if the noisy kernel post-processes the informative one
-(`κ_n s = (κ_i s).bind noise`), the state–observation mutual information
-decreases — a per-state corollary of the data processing inequality
-(`PMF.klDiv_bind_le`).
+(`noise ∘ₖ κ_i`), the state–observation mutual information decreases — a
+per-state corollary of the data processing inequality
+(`InformationTheory.klDiv_comp_right_le`).
 
 The utterance-level form `MI(state; utt_n) ≤ MI(state; utt_i)` is NOT a
 clean DPI corollary: the noisy and informative utterances share the
@@ -999,32 +998,28 @@ theorem. -/
 
 section Cancellation
 
-variable {W Obs : Type*} [Fintype W] [Fintype Obs]
-  [MeasurableSpace W] [MeasurableSingletonClass W]
-  [MeasurableSpace Obs] [MeasurableSingletonClass Obs]
+open InformationTheory MeasureTheory ProbabilityTheory
+open scoped ProbabilityTheory
+
+variable {W Obs : Type*} [Fintype W] [MeasurableSpace W] [MeasurableSpace Obs]
 
 /-- Per-state-decomposed mutual information between state and observation:
-`MI(state; obs) = ∑ s, prior s · KL(κ s ‖ prior.bind κ)` — the
+`MI(state; obs) = ∑ s, prior {s} · KL(κ s ‖ κ ∘ₘ prior)` — the
 conditional-relative-entropy form, which is what makes the per-state DPI
 argument applicable. -/
-noncomputable def mutualInfoStateObs (prior : PMF W) (κ : W → PMF Obs) : ℝ≥0∞ :=
-  ∑ s, prior s * (κ s).klDiv (prior.bind κ)
+noncomputable def mutualInfoStateObs (prior : Measure W) (κ : Kernel W Obs) : ℝ≥0∞ :=
+  ∑ s, prior {s} * klDiv (κ s) (κ ∘ₘ prior)
 
 /-- **Observation-level cancellation (DPI form)**: post-processing the
 observation kernel through a noise channel decreases the mutual information
-between state and observation. `h_ac` is per-state absolute continuity of
-`κ_i s` w.r.t. the informative observation marginal. -/
-theorem mutualInfoStateObs_bind_noise_le
-    (prior : PMF W) (κ_i : W → PMF Obs) (noise : Obs → PMF Obs)
-    (h_ac : ∀ s, MeasureTheory.Measure.AbsolutelyContinuous
-              (κ_i s).toMeasure (prior.bind κ_i).toMeasure) :
-    mutualInfoStateObs prior (fun s => (κ_i s).bind noise)
-      ≤ mutualInfoStateObs prior κ_i := by
+between state and observation. -/
+theorem mutualInfoStateObs_comp_le (prior : Measure W) [IsFiniteMeasure prior]
+    (κ_i : Kernel W Obs) [IsMarkovKernel κ_i] (noise : Kernel Obs Obs) [IsMarkovKernel noise] :
+    mutualInfoStateObs prior (noise ∘ₖ κ_i) ≤ mutualInfoStateObs prior κ_i := by
   unfold mutualInfoStateObs
-  rw [← PMF.bind_bind prior κ_i noise]
-  exact Finset.sum_le_sum fun s _ =>
-    mul_le_mul' (le_refl _)
-      (PMF.klDiv_bind_le (κ_i s) (prior.bind κ_i) noise (h_ac s))
+  simp_rw [← Measure.comp_assoc, Kernel.comp_apply]
+  gcongr with s
+  exact klDiv_comp_right_le _ _ noise
 
 end Cancellation
 
@@ -1040,7 +1035,7 @@ prior). Where the fitted model predicts only a marginal implicature
 (access 2), directions can differ from the plotted predictions.
 
 **They are NOT corollaries of a single information-theoretic cancellation
-theorem.** The provable structural content is `mutualInfoStateObs_bind_noise_le`
+theorem.** The provable structural content is `mutualInfoStateObs_comp_le`
 above; the per-(world-pair) orderings these cells encode are utterance-level
 claims that depend on the specific lex shape, not just on kernel
 informativity. -/

--- a/Linglib/Studies/Levy2008.lean
+++ b/Linglib/Studies/Levy2008.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Probability.Entropy
+import Linglib.Core.InformationTheory.KullbackLeibler.Cond
 import Linglib.Processing.Expectation.LanguageModel
 import Linglib.Processing.Expectation.PrefixProbability
 
@@ -29,9 +29,9 @@ conditional word probabilities they determine.
 ## Main results
 
 * `posterior_incremental` — incremental update equals direct conditioning
-  (eqs. (5)–(8)), via `PMF.filter_filter`.
+  (eqs. (5)–(8)).
 * `klDiv_posterior_eq_surprisal` — eq. (4): the relative entropy of the update
-  equals the surprisal of the word, via `PMF.klDiv_filter_self`.
+  equals the surprisal of the word, via `InformationTheory.klDiv_cond_self`.
 * `klDiv_posterior_eq_lm_surprisal` — the difficulty read through any
   `LangModel` matching the process's conditional word probabilities.
 * `bottleneck` — §2.3: processes agreeing on conditional word probabilities
@@ -39,70 +39,71 @@ conditional word probabilities they determine.
 
 ## Implementation notes
 
-Structures live in an arbitrary discrete measurable space — `PMF` handles the
-paper's "normally infinite" 𝒯 (the theorem is measure-level via
-`ProbabilityTheory.klDiv_cond_self` and the `PMF.filter`–`Measure.cond`
-bridge). The prior `P` is fixed throughout, matching the paper's caveat that
-the equivalence holds only when extra-sentential context does not change while
-the word is processed.
+Structures live in an arbitrary discrete measurable space, covering the
+paper's "normally infinite" 𝒯; the generative process is the prefix
+substrate's `PMF`, conditioned as a measure. The prior `P` is fixed
+throughout, matching the paper's caveat that the equivalence holds only when
+extra-sentential context does not change while the word is processed.
 -/
 
 namespace Levy2008
 
-open Processing.LanguageModel
-open Processing.Expectation
-open scoped ENNReal
+open InformationTheory MeasureTheory ProbabilityTheory
+open Processing.LanguageModel Processing.Expectation
+open scoped ENNReal ProbabilityTheory
 
-variable {T W : Type*}
+variable {T W : Type*} [MeasurableSpace T] [DiscreteMeasurableSpace T]
 
 /-- `Pᵢ` (eq. (3)): the comprehender's distribution over complete structures
     given the prefix — the prior conditioned on consistency. -/
-noncomputable def posterior (P : PMF T) (str : T → List W) (ws : List W)
-    (h : ∃ t ∈ consistent str ws, t ∈ P.support) : PMF T :=
-  P.filter (consistent str ws) h
+noncomputable def posterior (P : PMF T) (str : T → List W) (ws : List W) : Measure T :=
+  P.toMeasure[|consistent str ws]
 
 variable (P : PMF T) (str : T → List W) (ws : List W) (w : W)
 
-/-- Incremental update equals direct conditioning (eqs. (5)–(8)): filtering the
-    current posterior by consistency with the extended prefix is conditioning
-    the prior on the extended prefix directly. -/
-theorem posterior_incremental
-    (hws : ∃ t ∈ consistent str ws, t ∈ P.support)
-    (hnext : ∃ t ∈ consistent str (ws ++ [w]), t ∈ P.support) :
-    (posterior P str ws hws).filter (consistent str (ws ++ [w]))
-      (hnext.imp fun _ ht =>
-        ⟨ht.1, (PMF.mem_support_filter_iff hws).mpr
-          ⟨consistent_anti str (List.prefix_append ws [w]) ht.1, ht.2⟩⟩) =
-    posterior P str (ws ++ [w]) hnext :=
-  PMF.filter_filter P (consistent_anti str (List.prefix_append ws [w])) hws hnext _
+/-- The prior's mass on the structures consistent with a prefix is the prefix
+    probability. -/
+theorem toMeasure_consistent : P.toMeasure (consistent str ws) = prefixMass P str ws :=
+  P.toMeasure_apply .of_discrete
 
-variable [MeasurableSpace T] [DiscreteMeasurableSpace T]
+/-- Incremental update equals direct conditioning (eqs. (5)–(8)): conditioning
+    the current posterior on consistency with the extended prefix is
+    conditioning the prior on the extended prefix directly. -/
+theorem posterior_incremental :
+    (posterior P str ws)[|consistent str (ws ++ [w])] = posterior P str (ws ++ [w]) := by
+  rw [posterior, posterior, cond_cond_eq_cond_inter .of_discrete .of_discrete,
+    Set.inter_eq_right.mpr (consistent_anti str (List.prefix_append ws [w]))]
+
+/-- The posterior's mass on the structures consistent with the next word is
+    the induced conditional word probability. -/
+theorem posterior_consistent_append :
+    posterior P str ws (consistent str (ws ++ [w])) = nextProb P str ws w := by
+  rw [posterior, cond_apply .of_discrete,
+    Set.inter_eq_right.mpr (consistent_anti str (List.prefix_append ws [w])),
+    toMeasure_consistent, toMeasure_consistent, nextProb, div_eq_mul_inv, mul_comm]
 
 /-- **Eq. (4)**: the relative entropy of the updated distribution over
     structures with respect to the pre-update distribution is the surprisal of
     the word that triggered the update. -/
-theorem klDiv_posterior_eq_surprisal
-    (hws : ∃ t ∈ consistent str ws, t ∈ P.support)
-    (hnext : ∃ t ∈ consistent str (ws ++ [w]), t ∈ P.support) :
-    (posterior P str (ws ++ [w]) hnext).klDiv (posterior P str ws hws)
+theorem klDiv_posterior_eq_surprisal (h : prefixMass P str (ws ++ [w]) ≠ 0) :
+    klDiv (posterior P str (ws ++ [w])) (posterior P str ws)
       = ENNReal.ofReal (-Real.log (nextProb P str ws w).toReal) := by
-  rw [← posterior_incremental P str ws w hws hnext,
-    PMF.klDiv_filter_self _ MeasurableSet.of_discrete, PMF.toMeasure_apply]
-  · simp only [posterior]
-    rw [PMF.tsum_indicator_filter_of_subset P
-      (consistent_anti str (List.prefix_append ws [w])) hws]
-    rfl
-  · exact MeasurableSet.of_discrete
+  have hws : prefixMass P str ws ≠ 0 := fun h0 =>
+    h (le_zero_iff.mp ((prefixMass_anti P str (List.prefix_append ws [w])).trans_eq h0))
+  have : IsProbabilityMeasure (posterior P str ws) :=
+    cond_isProbabilityMeasure ((toMeasure_consistent P str ws).trans_ne hws)
+  rw [← posterior_incremental, klDiv_cond_self _ .of_discrete, posterior_consistent_append]
+  rw [posterior_consistent_append, nextProb]
+  exact ENNReal.div_ne_zero.mpr ⟨h, ne_top_of_le_ne_top ENNReal.one_ne_top
+    ((prefixMass_anti P str (List.nil_prefix)).trans_eq (prefixMass_nil P str))⟩
 
 /-- The update difficulty read through any language model that matches the
     process's conditional word probabilities is that model's surprisal. -/
 theorem klDiv_posterior_eq_lm_surprisal (lm : LangModel W)
-    (hlm : lm.nextProb ws w = nextProb P str ws w)
-    (hws : ∃ t ∈ consistent str ws, t ∈ P.support)
-    (hnext : ∃ t ∈ consistent str (ws ++ [w]), t ∈ P.support) :
-    (posterior P str (ws ++ [w]) hnext).klDiv (posterior P str ws hws)
+    (hlm : lm.nextProb ws w = nextProb P str ws w) (h : prefixMass P str (ws ++ [w]) ≠ 0) :
+    klDiv (posterior P str (ws ++ [w])) (posterior P str ws)
       = ENNReal.ofReal (lm.surprisal ws w) := by
-  rw [klDiv_posterior_eq_surprisal, LangModel.surprisal, hlm]
+  rw [klDiv_posterior_eq_surprisal P str ws w h, LangModel.surprisal, hlm]
 
 /-- **Causal bottleneck** (§2.3, Fig. 1b): two generative processes assigning
     the same conditional word probability incur the same update difficulty,
@@ -110,12 +111,10 @@ theorem klDiv_posterior_eq_lm_surprisal (lm : LangModel W)
 theorem bottleneck {T' : Type*} [MeasurableSpace T'] [DiscreteMeasurableSpace T']
     (P' : PMF T') (str' : T' → List W)
     (hagree : nextProb P str ws w = nextProb P' str' ws w)
-    (hws : ∃ t ∈ consistent str ws, t ∈ P.support)
-    (hnext : ∃ t ∈ consistent str (ws ++ [w]), t ∈ P.support)
-    (hws' : ∃ t ∈ consistent str' ws, t ∈ P'.support)
-    (hnext' : ∃ t ∈ consistent str' (ws ++ [w]), t ∈ P'.support) :
-    (posterior P str (ws ++ [w]) hnext).klDiv (posterior P str ws hws)
-      = (posterior P' str' (ws ++ [w]) hnext').klDiv (posterior P' str' ws hws') := by
-  rw [klDiv_posterior_eq_surprisal, klDiv_posterior_eq_surprisal, hagree]
+    (h : prefixMass P str (ws ++ [w]) ≠ 0) (h' : prefixMass P' str' (ws ++ [w]) ≠ 0) :
+    klDiv (posterior P str (ws ++ [w])) (posterior P str ws)
+      = klDiv (posterior P' str' (ws ++ [w])) (posterior P' str' ws) := by
+  rw [klDiv_posterior_eq_surprisal P str ws w h, klDiv_posterior_eq_surprisal P' str' ws w h',
+    hagree]
 
 end Levy2008


### PR DESCRIPTION
Levy2008's posterior is now the prior conditioned as a measure (`P.toMeasure[|consistent str ws]`), so the incremental-update identity is `cond_cond_eq_cond_inter` and eq. (4) is `klDiv_cond_self`, with nonzero prefix mass replacing the support-witness hypotheses. GoodmanStuhlmuller2013's observation-level cancellation is stated on a `Kernel` and proved from mathlib's `klDiv_comp_right_le`, which needs no absolute-continuity hypothesis.

- `PMF.klDiv_filter_self` loses its last consumer and is removed.