### PR TITLE
refactor(Core/Probability): cleanse SoftmaxTheory onto the measure face

### DIFF
--- a/Linglib/Core/Analysis/SpecialFunctions/Softmax.lean
+++ b/Linglib/Core/Analysis/SpecialFunctions/Softmax.lean
@@ -32,6 +32,8 @@ log-sum-exp as `cgf` — is `Core.Probability.SoftmaxTheory`.
   in the scores.
 * `Real.softmax_add_const` — translation invariance.
 * `Real.softmax_fin_two` — two alternatives give `Real.sigmoid`.
+* `Real.tendsto_softmax_atTop` — as the inverse temperature grows, softmax
+  concentrates on a strict maximizer.
 * `Real.softmax_sum_apply`, `Real.sum_softmax_eval_eq` — a separable score on a
   product type gives a product distribution, with coordinate marginals.
 * `Real.rpow_div_sum_rpow` — Luce's power rule is softmax of log-scores.
@@ -132,6 +134,35 @@ theorem softmax_lt_softmax_of_single_lt {s s' : ι → ℝ} {i : ι} (hlt : s i 
   exact softmax_update_strictMono s i hlt
 
 end Update
+
+/-! ### Limits in the inverse temperature -/
+
+section Limit
+
+open Filter Topology
+
+variable (s : ι → ℝ) (i : ι)
+
+theorem softmax_eq_inv_sum_exp_sub : softmax s i = (∑ j, exp (s j - s i))⁻¹ := by
+  simp only [softmax_def, exp_sub, ← sum_div, inv_div]
+
+variable {s i}
+
+/-- As the inverse temperature grows, softmax concentrates on a strict maximizer. -/
+theorem tendsto_softmax_atTop (h : ∀ j ≠ i, s j < s i) :
+    Tendsto (fun α : ℝ => softmax (α • s) i) atTop (𝓝 1) := by
+  classical
+  simp only [softmax_eq_inv_sum_exp_sub, Pi.smul_apply, smul_eq_mul, ← mul_sub]
+  have : Tendsto (fun α : ℝ => ∑ j, exp (α * (s j - s i))) atTop
+      (𝓝 (∑ j, if j = i then 1 else 0)) := by
+    refine tendsto_finsetSum _ fun j _ => ?_
+    split_ifs with hj
+    · simp [hj]
+    · simpa [Function.comp_def] using
+        tendsto_exp_atBot.comp (tendsto_id.atTop_mul_const_of_neg (sub_neg.2 (h j hj)))
+  simpa using this.inv₀ (by simp)
+
+end Limit
 
 /-! ### Two alternatives and the logit -/
 

--- a/Linglib/Core/Optimization/Decoder.lean
+++ b/Linglib/Core/Optimization/Decoder.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Probability.SoftmaxTheory
+import Linglib.Core.Analysis.SpecialFunctions.Softmax
 
 /-!
 # Decoders — from scored candidates to probability distributions
@@ -26,8 +26,7 @@ Noise-kernel-based decoders live in `NoiseKernel.lean`.
 
 `softmaxDecoder α` interpolates between soft and hard optimization: as
 `α → ∞`, the softmax distribution concentrates on the unique maximizer
-(when one exists), recovering `argmaxDecoder` — `softmax_argmax_limit` in
-`Core.Probability.Choice.RationalAction`.
+(when one exists), recovering `argmaxDecoder` — `Real.tendsto_softmax_atTop`.
 
 ## Semiring connection
 
@@ -108,7 +107,7 @@ open scoped Classical in
     `score` on `cands`. Deterministic (Dirac on the unique maximizer)
     when the maximum is achieved by exactly one candidate.
 
-    The `α → ∞` limit of `softmaxDecoder` (see `softmax_argmax_limit`). -/
+    The `α → ∞` limit of `softmaxDecoder` (see `Real.tendsto_softmax_atTop`). -/
 noncomputable def argmaxDecoder {Cand : Type*} {Score : Type*} [LinearOrder Score] :
     Decoder Cand Score where
   decode cands score := fun c =>

--- a/Linglib/Core/Probability/GibbsVariational.lean
+++ b/Linglib/Core/Probability/GibbsVariational.lean
@@ -26,6 +26,7 @@ by the module docstring of `Mathlib/MeasureTheory/Measure/Tilted.lean`.
 * `InformationTheory.freeEnergy_le_cgf` — the **variational inequality**:
   `freeEnergy μ f q ≤ cgf f μ 1` for every probability measure `q ≪ μ`.
 * `InformationTheory.freeEnergy_tilted` — the bound is **attained** at `μ.tilted f`.
+* `InformationTheory.eq_tilted_of_freeEnergy_eq_cgf` — and only there.
 * `InformationTheory.isGreatest_cgf` — the **variational principle**: `cgf f μ 1` is
   the greatest value of `freeEnergy μ f` over admissible `q`.
 
@@ -106,6 +107,24 @@ theorem freeEnergy_tilted (μ : Measure α) [IsProbabilityMeasure μ] {f : α �
   rw [klDiv_self, ENNReal.toReal_zero] at h
   rw [Measure.freeEnergy]
   linarith
+
+/-- The variational bound is attained only at the Gibbs measure: a probability
+measure `q ≪ μ` with `freeEnergy μ f q = cgf f μ 1` is `μ.tilted f`. From the
+decomposition identity, `KL(q ‖ μ.tilted f) = 0`. -/
+theorem eq_tilted_of_freeEnergy_eq_cgf (μ q : Measure α) [IsProbabilityMeasure μ]
+    [IsProbabilityMeasure q] {f : α → ℝ} (hqμ : q ≪ μ)
+    (h_int_llr : Integrable (llr q μ) q) (h_int_f : Integrable f q)
+    (h_exp : Integrable (fun x => Real.exp (f x)) μ)
+    (h : μ.freeEnergy f q = cgf f μ 1) : q = μ.tilted f := by
+  have : IsProbabilityMeasure (μ.tilted f) := isProbabilityMeasure_tilted h_exp
+  have hkl : (klDiv q (μ.tilted f)).toReal = 0 := by
+    rw [toReal_klDiv_tilted_right μ q hqμ h_int_llr h_int_f h_exp]
+    rw [Measure.freeEnergy] at h
+    linarith
+  have hne : klDiv q (μ.tilted f) ≠ ⊤ := klDiv_ne_top_iff.2
+    ⟨hqμ.trans (absolutelyContinuous_tilted h_exp),
+      integrable_llr_tilted_right hqμ h_int_f h_int_llr h_exp⟩
+  exact klDiv_eq_zero_iff.1 (((ENNReal.toReal_eq_zero_iff _).1 hkl).resolve_right hne)
 
 /-- **Gibbs / Donsker–Varadhan variational principle**: the cumulant generating
 function `cgf f μ 1` is the *greatest* value of the free-energy functional

--- a/Linglib/Core/Probability/SoftmaxTheory.lean
+++ b/Linglib/Core/Probability/SoftmaxTheory.lean
@@ -1,651 +1,106 @@
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
-import Mathlib.Analysis.SpecialFunctions.Sigmoid
-import Mathlib.InformationTheory.KullbackLeibler.KLFun
-import Mathlib.Data.Fintype.BigOperators
-import Mathlib.Algebra.BigOperators.Field
+import Mathlib.Analysis.SpecialFunctions.Log.Deriv
 import Mathlib.Analysis.MeanInequalities
+import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.Topology.Instances.RealVectorSpace
 import Mathlib.Probability.Moments.Basic
+import Mathlib.Probability.UniformOn
 import Mathlib.MeasureTheory.Measure.Tilted
 import Mathlib.MeasureTheory.Measure.Count
 import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
 import Linglib.Core.Analysis.SpecialFunctions.Softmax
 
 /-!
-# Softmax: variational, information-theoretic, and limiting characterizations
+# Softmax: characterization, log-partition function, exponential tilting
 
-The deep theory of `Real.softmax` (`Core.Analysis.SpecialFunctions.Softmax`): why it
-takes the exponential form, what it optimizes, how it concentrates, and its link
-to exponential tilting; elementary properties are surveyed in [franke-degen-2023].
+Three faces of `Real.softmax` beyond its elementary algebra.
+
+* **Fechnerian characterization** ([adams-messick-1958]): a strictly monotone
+  solution of Cauchy's multiplicative equation `g (s + t) = g s * g t` is an
+  exponential, so a ratio scale expressed through differences of an interval
+  scale is the exponential of that scale — the exponential parameterization is
+  forced, not chosen.
+* **Log-partition function**: `α ↦ log ∑ᵢ exp (α sᵢ + rᵢ)` is convex, so the
+  log-likelihood `α ↦ log (softmax (α • s + r) y)` is concave, with derivative
+  the observed minus the expected feature.
+* **Exponential tilting**: the partition function, log-sum-exp, and softmax are
+  the counting-measure `mgf`, `cgf`, and `Measure.tilted`, and tilting the
+  uniform measure by the scores gives the softmax measure — the input to the
+  Gibbs variational principle of `Core.Probability.GibbsVariational`.
+
+`[UPSTREAM]`: pure-math characterizations of softmax; no linguistics.
 
 ## Main results
 
-* `cauchy_mul_exp`, `luce_fechnerian_exp` — the Fechnerian bridge: the exponential
-  form is forced by a Cauchy functional equation (ratio scale → interval scale).
-* `gibbs_variational` — softmax uniquely maximizes `H(p) + α·⟨p, s⟩` on the simplex.
-* `softmax_maximizes_entropyReg`, `softmax_unique_maximizer`,
-  `softmax_minimizes_freeEnergy`, `max_entropy_duality`, `entropy_le_log_card` —
-  the maximum-entropy / minimum-free-energy characterization.
-* `softmax_argmax_limit`, `softmax_nonmax_limit` — concentration on the argmax as
-  rationality → ∞.
-* `bayesian_maximizes` — the Bayesian posterior maximizes expected log-likelihood.
-* `convexOn_log_sum_exp`, `concaveOn_log_softmax`, `hasDerivAt_log_softmax` — the
-  log-partition function is convex, so the log-likelihood is concave with
-  derivative observed minus expected feature.
+* `cauchy_mul_exp`, `luce_fechnerian_exp` — the Fechnerian characterization.
+* `convexOn_log_sum_exp`, `hasDerivAt_log_sum_exp`, `concaveOn_log_softmax`,
+  `hasDerivAt_log_softmax` — convexity and derivative of the log-partition
+  function and of the log-likelihood.
 * `ProbabilityTheory.mgf_count`, `ProbabilityTheory.cgf_count`,
-  `MeasureTheory.tilted_count` — the partition function, log-sum-exp, and softmax
-  as the counting-measure `mgf`, `cgf`, and exponential tilting.
-
-`[UPSTREAM]`: pure-math characterizations of softmax; no linguistics. Quality-and-role
-marker — sits above `Real.softmax`, below the rational-agent framing.
+  `ProbabilityTheory.hasDerivAt_cgf_count`, `MeasureTheory.tilted_count`,
+  `ProbabilityTheory.tilted_uniformOn_univ` — the counting-measure face.
 -/
 
 open Real Finset
 
-/-! ### Why softmax? The Fechnerian characterization
+/-! ### The Fechnerian characterization
 
-The exponential parameterization `score = exp(α · utility)` is not a design
-choice — it is the **unique** transformation connecting Luce's ratio scale to
-a utility (interval) scale ([adams-messick-1958]).
+A ratio scale `v` and an interval scale `u` for one ordering are related by
+`v x / v y = g (u x - u y)` for a strictly monotone `g`; transitivity of ratios
+forces Cauchy's multiplicative equation, whose strictly monotone solutions are
+exponentials ([adams-messick-1958]). -/
 
-**Ratio vs interval scales.** Luce's Axiom 1 (IIA) yields a **ratio scale**
-`v`: only ratios `v(a)/v(b)` are meaningful. Fechner's
-psychophysics requires an **interval scale** `u`: only differences
-`u(a) - u(b)` are meaningful. The question: how are `v` and `u` related?
+/-- A strictly monotone solution of Cauchy's multiplicative functional equation
+`g (s + t) = g s * g t` is an exponential `exp (k * s)` with `k > 0`. -/
+theorem cauchy_mul_exp (g : ℝ → ℝ) (hg_mul : ∀ s t, g (s + t) = g s * g t)
+    (hg_mono : StrictMono g) : ∃ k : ℝ, 0 < k ∧ g 0 = 1 ∧ ∀ s, g s = exp (k * s) := by
+  have h1 := hg_mono (show (-1 : ℝ) < 0 by norm_num)
+  have h2 := hg_mono (show (0 : ℝ) < 1 by norm_num)
+  have hne : g 0 ≠ 0 := fun h => by
+    have := hg_mul (-1) 1
+    rw [neg_add_cancel, h] at this
+    rw [h] at h1 h2
+    nlinarith
+  have h0 : g 0 = 1 := mul_left_cancel₀ hne (by simpa using (hg_mul 0 0).symm)
+  have hpos (x : ℝ) : 0 < g x := by
+    have hsq : g x = g (x / 2) * g (x / 2) := by rw [← hg_mul, add_halves]
+    refine lt_of_le_of_ne (by rw [hsq]; exact mul_self_nonneg _) fun hx => ?_
+    have := hg_mul x (-x)
+    rw [add_neg_cancel, h0, ← hx, zero_mul] at this
+    exact one_ne_zero this
+  let h : ℝ →+ ℝ :=
+    { toFun := fun x => log (g x)
+      map_zero' := by simp [h0]
+      map_add' := fun s t => by simp only [hg_mul, log_mul (hpos s).ne' (hpos t).ne'] }
+  have hmono : StrictMono h := fun a b hab => log_lt_log (hpos a) (hg_mono hab)
+  have hcont : Continuous h :=
+    h.continuous_of_isBounded_nhds_zero (Icc_mem_nhds (by norm_num : (-1 : ℝ) < 0) one_pos)
+      ((Metric.isBounded_Icc (h (-1)) (h 1)).subset hmono.monotone.image_Icc_subset)
+  refine ⟨h 1, by simpa using hmono one_pos, h0, fun s => ?_⟩
+  have hs : h s = s * h 1 := by simpa using map_real_smul h hcont s 1
+  rw [← exp_log (hpos s), mul_comm]
+  exact congrArg exp hs
 
-**Derivation.** From `P(a,b) = v(a)/(v(a)+v(b))`, the odds ratio is
-`v(a)/v(b) = g(u(a) - u(b))` for some function `g`. Transitivity of ratios
-(`v(a)/v(c) = [v(a)/v(b)] · [v(b)/v(c)]`) forces Cauchy's multiplicative
-functional equation: `g(s + t) = g(s) · g(t)`. The unique monotone increasing
-solution is `g(s) = exp(k · s)` (`cauchy_mul_exp`), giving:
-
-- `v(a) = C · exp(k · u(a))` — the ratio scale IS the exponential of utility
-- `P(a,b) = 1/(1 + exp(-k · (u(a) - u(b))))` — the logistic function
-- For n alternatives: `P(a|S) = exp(k · u(a)) / Σ exp(k · u(b))` — softmax
-
-The parameter `k > 0` is the rationality parameter `α` in RSA.
-
--/
-
-private theorem cauchy_g0_eq_one (g : ℝ → ℝ)
-    (hg_mul : ∀ s t, g (s + t) = g s * g t)
-    (hg_mono : StrictMono g) : g 0 = 1 := by
-  have h0 : g 0 = g 0 * g 0 := by
-    have := hg_mul 0 0; simp at this; exact this
-  have : g 0 * (g 0 - 1) = 0 := by ring_nf; linarith
-  rcases mul_eq_zero.mp this with h | h
-  · exfalso
-    have h1 : g (-1) < g 0 := hg_mono (by linarith : (-1 : ℝ) < 0)
-    have h2 : g 0 < g 1 := hg_mono (by linarith : (0 : ℝ) < 1)
-    have h3 : g (-1) * g 1 = g 0 := by
-      have := hg_mul (-1) 1; simp at this; exact this.symm
-    rw [h] at h1 h2 h3
-    linarith [mul_neg_of_neg_of_pos h1 h2]
-  · linarith
-
-private theorem cauchy_g_pos (g : ℝ → ℝ)
-    (hg_mul : ∀ s t, g (s + t) = g s * g t)
-    (hg_mono : StrictMono g) (x : ℝ) : 0 < g x := by
-  have hg0 := cauchy_g0_eq_one g hg_mul hg_mono
-  have hsq : g x = g (x / 2) * g (x / 2) := by
-    have := hg_mul (x / 2) (x / 2); rw [add_halves] at this; exact this
-  by_contra h; push Not at h
-  have hgx_zero : g x = 0 := le_antisymm h (by rw [hsq]; exact mul_self_nonneg _)
-  have hx2_zero : g (x / 2) = 0 := by rwa [hsq, mul_self_eq_zero] at hgx_zero
-  have hg0' : g 0 = g x * g (-x) := by
-    have := hg_mul x (-x); simp at this; exact this
-  rw [hgx_zero, zero_mul] at hg0'; linarith
-
-private theorem cauchy_additive_zero (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) : h 0 = 0 := by
-  have := hadd 0 0; simp at this; linarith
-
-private theorem cauchy_additive_neg (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) (x : ℝ) : h (-x) = -h x := by
-  have : h (x + (-x)) = h x + h (-x) := hadd x (-x)
-  simp [cauchy_additive_zero h hadd] at this; linarith
-
-private theorem cauchy_additive_nat (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) (n : ℕ) : h n = n * h 1 := by
-  induction n with
-  | zero => simp [cauchy_additive_zero h hadd]
-  | succ k ih => rw [Nat.cast_succ, hadd, ih]; ring
-
-private theorem cauchy_additive_int (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) (n : ℤ) : h n = n * h 1 := by
-  cases n with
-  | ofNat k => simp [cauchy_additive_nat h hadd k]
-  | negSucc k =>
-    simp only [Int.cast_negSucc]
-    rw [cauchy_additive_neg h hadd, cauchy_additive_nat h hadd (k + 1)]
-    push_cast; ring
-
-private theorem cauchy_additive_rat (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) (q : ℚ) : h q = q * h 1 := by
-  have hden_pos : (0 : ℝ) < q.den := Nat.cast_pos.mpr q.pos
-  have hden_ne : (q.den : ℝ) ≠ 0 := ne_of_gt hden_pos
-  have hmul_nat : ∀ (n : ℕ) (x : ℝ), h (n * x) = n * h x := by
-    intro n x; induction n with
-    | zero => simp [cauchy_additive_zero h hadd]
-    | succ k ih => rw [Nat.cast_succ, add_mul, one_mul, hadd, ih]; ring
-  have step1 : (q.den : ℝ) * h q = h (q.num : ℤ) := by
-    rw [← hmul_nat q.den q]; congr 1; rw [Rat.cast_def]; field_simp
-  rw [cauchy_additive_int h hadd] at step1
-  have : h q = (q.num : ℝ) * h 1 / q.den := by field_simp at step1 ⊢; linarith
-  rw [this, Rat.cast_def]; field_simp
-
-private theorem cauchy_monotone_additive_linear (h : ℝ → ℝ)
-    (hadd : ∀ s t, h (s + t) = h s + h t) (hmono : StrictMono h) :
-    ∀ x, h x = x * h 1 := by
-  have h0 : h 0 = 0 := cauchy_additive_zero h hadd
-  have h1_pos : 0 < h 1 := by linarith [hmono (show (0 : ℝ) < 1 by norm_num), h0]
-  intro x
-  by_contra hne
-  rcases ne_iff_lt_or_gt.mp hne with hlt | hgt
-  · obtain ⟨q, hq1, hq2⟩ := exists_rat_btwn (show h x / h 1 < x by
-      rw [div_lt_iff₀ h1_pos]; linarith)
-    have : h x < h q := by
-      rw [cauchy_additive_rat h hadd q]
-      have := (div_lt_iff₀ h1_pos).mp hq1; linarith
-    linarith [hmono hq2]
-  · obtain ⟨q, hq1, hq2⟩ := exists_rat_btwn (show x < h x / h 1 by
-      rw [lt_div_iff₀ h1_pos]; linarith)
-    have : h q < h x := by
-      rw [cauchy_additive_rat h hadd q]
-      have := (lt_div_iff₀ h1_pos).mp hq2; linarith
-    linarith [hmono hq1]
-
-/-- **Cauchy's multiplicative functional equation** (classical): if `g : ℝ → ℝ`
-    satisfies `g(s + t) = g(s) · g(t)` and is strictly monotone increasing, then
-    `g(s) = exp(k · s)` for some `k > 0`. -/
-theorem cauchy_mul_exp (g : ℝ → ℝ)
-    (hg_mul : ∀ s t, g (s + t) = g s * g t)
-    (hg_mono : StrictMono g) :
-    ∃ k : ℝ, 0 < k ∧ g 0 = 1 ∧ ∀ s, g s = Real.exp (k * s) := by
-  have hg0 := cauchy_g0_eq_one g hg_mul hg_mono
-  have hg_pos := cauchy_g_pos g hg_mul hg_mono
-  set h := fun x => log (g x) with hh_def
-  have hadd : ∀ s t, h (s + t) = h s + h t := fun s t => by
-    simp only [h]; rw [hg_mul s t, log_mul (ne_of_gt (hg_pos s)) (ne_of_gt (hg_pos t))]
-  have hmono : StrictMono h := fun a b hab => by
-    simp only [h]; exact log_lt_log (hg_pos a) (hg_mono hab)
-  have hlinear := cauchy_monotone_additive_linear h hadd hmono
-  have hk_pos : 0 < h 1 := by
-    have := hmono (show (0 : ℝ) < 1 by norm_num)
-    simp only [h] at this; rw [hg0, log_one] at this; exact this
-  refine ⟨h 1, hk_pos, hg0, fun s => ?_⟩
-  have := hlinear s
-  simp only [h] at this
-  rw [← exp_log (hg_pos s), this, mul_comm]
-
-/-- **Fechnerian uniqueness** ([adams-messick-1958]): if a ratio scale `v`
-    and interval scale `u` represent the same ordering via
-    `v(x)/v(y) = g(u(x) - u(y))` for a strictly monotone multiplicative `g`, then
-    `v` is the exponential of `u`. -/
+/-- **Fechnerian uniqueness** ([adams-messick-1958]): if a ratio scale `v` and an
+interval scale `u` represent the same ordering via `v x / v y = g (u x - u y)` for
+a strictly monotone multiplicative `g`, then `v` is the exponential of `u`. -/
 theorem luce_fechnerian_exp {X : Type*} (v u : X → ℝ) (g : ℝ → ℝ)
     (hv_pos : ∀ x, 0 < v x)
     (h_ratio : ∀ x y, v x / v y = g (u x - u y))
     (hg_mul : ∀ s t, g (s + t) = g s * g t)
     (hg_mono : StrictMono g) :
-    ∃ k : ℝ, 0 < k ∧ ∀ x₀ x, v x = v x₀ * Real.exp (k * (u x - u x₀)) := by
+    ∃ k : ℝ, 0 < k ∧ ∀ x₀ x, v x = v x₀ * exp (k * (u x - u x₀)) := by
   obtain ⟨k, hk, _, hg_exp⟩ := cauchy_mul_exp g hg_mul hg_mono
   exact ⟨k, hk, fun x₀ x => by
     have h := h_ratio x x₀
     rw [hg_exp (u x - u x₀)] at h
     rwa [div_eq_iff (ne_of_gt (hv_pos x₀)), mul_comm] at h⟩
 
-/-! ### Gibbs variational principle
+/-! ### The log-partition function -/
 
-The softmax distribution uniquely maximizes entropy plus expected score on the
-probability simplex — the mathematical foundation for RSA convergence
-([zaslavsky-hu-levy-2020]).
-
-The KL machinery used here — `klFinite`, `kl_eq_sum_klFun`, `kl_nonneg` — is
-inlined as private `ι → ℝ` helpers; the measure-level form is
-`InformationTheory.toReal_klDiv_eq_sum_log_div`.
--/
-
-/-- Private `ι → ℝ` discrete KL divergence for the Gibbs proofs in this section. -/
-private noncomputable def klFinite {ι : Type*} [Fintype ι] (p q : ι → ℝ) : ℝ :=
-  ∑ i, if p i = 0 then 0 else p i * Real.log (p i / q i)
-
-/-- Per-element identity: `q · klFun(p/q) = if p=0 then 0 else p log(p/q) + (q − p)`. -/
-private theorem kl_term_eq_klFun {p_i q_i : ℝ} (hq : 0 < q_i) (_hp : 0 ≤ p_i) :
-    (if p_i = 0 then (0 : ℝ) else p_i * Real.log (p_i / q_i)) =
-    q_i * _root_.InformationTheory.klFun (p_i / q_i) + (p_i - q_i) := by
-  by_cases hp0 : p_i = 0
-  · simp only [hp0, ↓reduceIte, zero_div, _root_.InformationTheory.klFun_zero, mul_one,
-               zero_sub, add_neg_cancel]
-  · simp only [hp0, ↓reduceIte]
-    unfold _root_.InformationTheory.klFun
-    have hq_ne : q_i ≠ 0 := ne_of_gt hq
-    field_simp
-    ring
-
-/-- `klFinite = ∑ q · klFun(p/q)` when sums match. -/
-private theorem kl_eq_sum_klFun {ι : Type*} [Fintype ι]
-    (p q : ι → ℝ) (hq : ∀ i, 0 < q i) (hp : ∀ i, 0 ≤ p i)
-    (hsum : ∑ i, p i = ∑ i, q i) :
-    klFinite p q = ∑ i, q i * _root_.InformationTheory.klFun (p i / q i) := by
-  unfold klFinite
-  have hterm : ∀ i, (if p i = 0 then (0 : ℝ) else p i * Real.log (p i / q i)) =
-      q i * _root_.InformationTheory.klFun (p i / q i) + (p i - q i) :=
-    λ i => kl_term_eq_klFun (hq i) (hp i)
-  simp_rw [hterm]
-  rw [Finset.sum_add_distrib]
-  have hcancel : ∑ i, (p i - q i) = 0 := by
-    rw [Finset.sum_sub_distrib, hsum, sub_self]
-  linarith
-
-/-- KL non-negativity (Gibbs' inequality). -/
-private theorem kl_nonneg {ι : Type*} [Fintype ι]
-    (p q : ι → ℝ) (hq : ∀ i, 0 < q i) (hp : ∀ i, 0 ≤ p i)
-    (hsum : ∑ i, p i = ∑ i, q i) :
-    0 ≤ klFinite p q := by
-  rw [kl_eq_sum_klFun p q hq hp hsum]
-  apply Finset.sum_nonneg
-  intro i _
-  exact mul_nonneg (le_of_lt (hq i))
-    (_root_.InformationTheory.klFun_nonneg (div_nonneg (hp i) (le_of_lt (hq i))))
-
-/-- KL non-negativity, distribution form. -/
-private theorem kl_nonneg' {ι : Type*} [Fintype ι] [Nonempty ι] {p q : ι → ℝ}
-    (hp_nonneg : ∀ i, 0 ≤ p i) (hq_pos : ∀ i, 0 < q i)
-    (hp_sum : ∑ i, p i = 1) (hq_sum : ∑ i, q i = 1) :
-    0 ≤ klFinite p q :=
-  kl_nonneg p q hq_pos hp_nonneg (by rw [hp_sum, hq_sum])
-
-/-- Private `ι → ℝ` Shannon entropy for the Gibbs proofs in this section. -/
-private noncomputable def entropy {α : Type*} (s : Finset α) (p : α → ℝ) : ℝ :=
-  ∑ a ∈ s, Real.negMulLog (p a)
-
-section GibbsVariational
-
-variable {ι : Type*} [Fintype ι]
-
-/-- The per-meaning speaker objective: f(s) = Σᵤ [negMulLog(sᵤ) + α · sᵤ · vᵤ].
-
-This is the function that the speaker maximizes for each meaning m,
-where vᵤ = log L(m|u) is the listener utility of utterance u. -/
-noncomputable def speakerObj (v : ι → ℝ) (α : ℝ) (s : ι → ℝ) : ℝ :=
-  ∑ u, (Real.negMulLog (s u) + α * s u * v u)
-
-/-- The softmax achieves the log-partition function `log ∑ exp (α vᵤ)`. -/
-theorem speakerObj_at_softmax [Nonempty ι] (v : ι → ℝ) (α : ℝ) :
-    speakerObj v α (softmax (α • v)) = log (∑ u, exp (α * v u)) := by
-  unfold speakerObj
-  have hlog_softmax (u : ι) : log (softmax (α • v) u) = α * v u - log (∑ u, exp (α * v u)) :=
-    log_softmax (α • v) u
-  have hterm (u : ι) : Real.negMulLog (softmax (α • v) u) + α * softmax (α • v) u * v u =
-      softmax (α • v) u * log (∑ u, exp (α * v u)) := by
-    unfold Real.negMulLog; rw [hlog_softmax]; ring
-  simp_rw [hterm]
-  rw [← Finset.sum_mul, sum_softmax, one_mul]
-
-/-- Key identity: speakerObj(s) + KL(s ‖ s*) = log-partition (= speakerObj(s*)). -/
-private theorem speakerObj_plus_kl [Nonempty ι] (v : ι → ℝ) (α : ℝ)
-    (s : ι → ℝ) (_hs_nonneg : ∀ i, 0 ≤ s i) (hs_sum : ∑ i, s i = 1) :
-    speakerObj v α s + klFinite s (softmax (α • v)) = log (∑ j, exp (α * v j)) := by
-  unfold speakerObj klFinite
-  rw [← Finset.sum_add_distrib]
-  have hterm : ∀ u, (Real.negMulLog (s u) + α * s u * v u) +
-      (if s u = 0 then (0 : ℝ) else s u * log (s u / softmax (α • v) u)) =
-      s u * log (∑ j : ι, exp (α * v j)) := by
-    intro u
-    by_cases hs0 : s u = 0
-    · simp [hs0, Real.negMulLog]
-    · simp only [hs0, ↓reduceIte]
-      have hs_pos : 0 < softmax (α • v) u := softmax_pos (α • v) u
-      rw [log_div hs0 (ne_of_gt hs_pos)]
-      have hlog_sm : log (softmax (α • v) u) = α * v u - log (∑ j : ι, exp (α * v j)) := by
-        simp only [softmax, Pi.smul_apply, smul_eq_mul]
-        rw [log_div (ne_of_gt (exp_pos _)) (ne_of_gt (Finset.sum_pos
-          (fun j _ => exp_pos _) Finset.univ_nonempty)), log_exp]
-      rw [hlog_sm]; unfold Real.negMulLog; ring
-  simp_rw [hterm, ← Finset.sum_mul, hs_sum, one_mul]
-
-/-- **Gibbs Variational Principle**: softmax maximizes entropy + expected score.
-
-For any distribution p on ι and scores s : ι → ℝ:
-  H(p) + α·⟨p, s⟩ ≤ H(q) + α·⟨q, s⟩
-where q = softmax(s, α) and H(p) = Σ negMulLog(pᵢ). -/
-theorem gibbs_variational [Nonempty ι] (s : ι → ℝ) (α : ℝ) (p : ι → ℝ)
-    (hp_nonneg : ∀ i, 0 ≤ p i) (hp_sum : ∑ i, p i = 1) :
-    (∑ i, Real.negMulLog (p i)) + α * ∑ i, p i * s i ≤
-    (∑ i, Real.negMulLog (softmax (α • s) i)) + α * ∑ i, softmax (α • s) i * s i := by
-  set q := softmax (α • s)
-  have hq_pos : ∀ i, 0 < q i := fun i => softmax_pos (α • s) i
-  have hq_sum : ∑ i, q i = 1 := sum_softmax (α • s)
-  have hkl := kl_nonneg' hp_nonneg hq_pos hp_sum hq_sum
-  have h_logq : ∀ i, Real.log (q i) = α * s i - log (∑ j, exp (α * s j)) := fun i => log_softmax (α • s) i
-  have h_combine : ∀ i,
-      Real.negMulLog (p i) +
-        (if p i = 0 then (0 : ℝ) else p i * Real.log (p i / q i)) =
-      -(p i * Real.log (q i)) := by
-    intro i
-    by_cases hpi : p i = 0
-    · simp [hpi, Real.negMulLog]
-    · simp only [hpi, ↓reduceIte, Real.negMulLog]
-      have hpi_pos : 0 < p i := lt_of_le_of_ne (hp_nonneg i) (Ne.symm hpi)
-      rw [Real.log_div (ne_of_gt hpi_pos) (ne_of_gt (hq_pos i))]
-      ring
-  have h1 : (∑ i, Real.negMulLog (p i)) + klFinite p q =
-      -(∑ i, p i * Real.log (q i)) := by
-    unfold klFinite
-    rw [← Finset.sum_add_distrib]
-    simp_rw [h_combine, Finset.sum_neg_distrib]
-  have h2 : -(∑ i, p i * Real.log (q i)) = -(α * ∑ i, p i * s i) + log (∑ j, exp (α * s j)) := by
-    have : ∑ i, p i * Real.log (q i) = α * ∑ i, p i * s i - log (∑ j, exp (α * s j)) := by
-      simp_rw [h_logq]
-      rw [show ∑ i : ι, p i * (α * s i - log (∑ j, exp (α * s j))) =
-          ∑ i, (α * (p i * s i) - log (∑ j, exp (α * s j)) * p i) from
-        Finset.sum_congr rfl fun i _ => by ring]
-      rw [Finset.sum_sub_distrib, ← Finset.mul_sum, ← Finset.mul_sum, hp_sum, mul_one]
-    linarith
-  have h3 : (∑ i, Real.negMulLog (q i)) + α * ∑ i, q i * s i = log (∑ j, exp (α * s j)) := by
-    rw [Finset.mul_sum, ← Finset.sum_add_distrib]
-    rw [show ∑ i : ι, (Real.negMulLog (q i) + α * (q i * s i)) = ∑ i, log (∑ j, exp (α * s j)) * q i from
-      Finset.sum_congr rfl fun i _ => by simp only [Real.negMulLog, h_logq i]; ring]
-    rw [← Finset.mul_sum, hq_sum, mul_one]
-  linarith
-
-end GibbsVariational
-
-/-! ### Softmax concentration at high rationality
-
-As the rationality parameter α → ∞, softmax concentrates all probability mass
-on the action with highest utility — i.e., softmax converges to argmax. This
-connects:
-
-- **MaxEnt phonology ↔ OT**: a MaxEnt grammar with weights `w` becomes
-  categorical (OT-like) as temperature → 0 (equivalently α → ∞).
-- **RSA ↔ neo-Gricean pragmatics**: a soft-rational RSA speaker becomes a
-  hard-rational Gricean reasoner in the α → ∞ limit.
--/
-
-section SoftmaxLimit
-
-variable {ι : Type*} [Fintype ι] [Nonempty ι] [DecidableEq ι]
-
-omit [Nonempty ι] [DecidableEq ι] in
-/-- Each softmax component is bounded by `exp(α(sⱼ - s_{i_max}))`, obtained
-    by dropping all but the `i_max` term from the partition function. -/
-private theorem softmax_le_exp_diff (s : ι → ℝ) (α : ℝ) (j i_max : ι) :
-    softmax (α • s) j ≤ exp (α * (s j - s i_max)) := by
-  simp only [softmax, Pi.smul_apply, smul_eq_mul]
-  rw [show α * (s j - s i_max) = α * s j - α * s i_max from by ring, exp_sub]
-  exact div_le_div_of_nonneg_left (exp_pos _).le (exp_pos _)
-    (single_le_sum (f := fun k => exp (α * s k)) (fun k _ => (exp_pos _).le) (mem_univ i_max))
-
-omit [Nonempty ι] [DecidableEq ι] in
-/-- When `x < 0`, `exp(α · x) < ε` for all sufficiently large `α`. -/
-private theorem exp_mul_neg_lt (x : ℝ) (hx : x < 0) (ε : ℝ) (hε : 0 < ε)
-    (α : ℝ) (hα : α > log ε / x) : exp (α * x) < ε := by
-  calc exp (α * x) < exp (log ε) := by
-        apply exp_lt_exp.mpr
-        have := mul_lt_mul_of_neg_right hα hx
-        rwa [div_mul_cancel₀ (log ε) (ne_of_lt hx)] at this
-    _ = ε := exp_log hε
-
-open Filter Topology in
-/-- **Softmax → argmax limit**: as α → ∞, softmax concentrates on the unique
-    maximizer. For any `i_max` with `s i_max` strictly greater than all other
-    scores, `softmax(s, α)_{i_max} → 1`.
-
-    This is the formal connection between MaxEnt (soft optimization) and OT
-    (hard optimization): OT is the α → ∞ limit of MaxEnt. -/
-theorem softmax_argmax_limit (s : ι → ℝ) (i_max : ι)
-    (h_max : ∀ j, j ≠ i_max → s j < s i_max) :
-    Tendsto (fun α : ℝ => softmax (α • s) i_max) atTop (𝓝 1) := by
-  rw [Metric.tendsto_atTop]
-  intro ε hε
-  set n := Fintype.card ι
-  have hn_pos : (0 : ℝ) < n := Nat.cast_pos.mpr Fintype.card_pos
-  set εn := ε / n
-  have hεn : 0 < εn := div_pos hε hn_pos
-  let threshFn : ι → ℝ := fun j =>
-    if j = i_max then (0 : ℝ) else log εn / (s j - s i_max)
-  refine ⟨univ.sup' ⟨i_max, mem_univ _⟩ threshFn + 1, fun α hα => ?_⟩
-  have hbound : ∀ j ≠ i_max, softmax (α • s) j < εn := by
-    intro j hj
-    apply lt_of_le_of_lt (softmax_le_exp_diff s α j i_max)
-    apply exp_mul_neg_lt _ (sub_neg.mpr (h_max j hj)) εn hεn
-    have h1 : threshFn j ≤ univ.sup' ⟨i_max, mem_univ _⟩ threshFn :=
-      le_sup' _ (mem_univ j)
-    simp only [threshFn, hj, ↓reduceIte] at h1
-    linarith
-  have htail : 1 - softmax (α • s) i_max = ∑ j ∈ univ.erase i_max, softmax (α • s) j := by
-    rw [← sum_softmax (α • s), ← add_sum_erase _ _ (mem_univ i_max)]; ring
-  have htail_nonneg : 0 ≤ 1 - softmax (α • s) i_max := by
-    rw [htail]; exact sum_nonneg fun j _ => le_of_lt (softmax_pos (α • s) j)
-  have htail_strict : 1 - softmax (α • s) i_max < ε := by
-    rw [htail]
-    rcases (univ.erase i_max : Finset ι).eq_empty_or_nonempty with hempty | ⟨j, hj⟩
-    · simp [hempty]; exact hε
-    · calc ∑ k ∈ univ.erase i_max, softmax (α • s) k
-          < ∑ _ ∈ univ.erase i_max, εn :=
-            sum_lt_sum (fun k hk => le_of_lt (hbound k (mem_erase.mp hk).1))
-              ⟨j, hj, hbound j (mem_erase.mp hj).1⟩
-        _ ≤ ∑ (_ : ι), εn :=
-            sum_le_sum_of_subset_of_nonneg (erase_subset _ _) (fun _ _ _ => hεn.le)
-        _ = ↑n * εn := by rw [sum_const, card_univ, nsmul_eq_mul]
-        _ = ε := mul_div_cancel₀ _ (ne_of_gt hn_pos)
-  rw [Real.dist_eq, abs_sub_lt_iff]; constructor <;> linarith
-
-omit [Nonempty ι] [DecidableEq ι] in
-open Filter Topology in
-/-- Complement of the limit: non-maximal actions get probability → 0. -/
-theorem softmax_nonmax_limit (s : ι → ℝ) (i_max : ι)
-    (h_max : ∀ j, j ≠ i_max → s j < s i_max) (j : ι) (hj : j ≠ i_max) :
-    Tendsto (fun α : ℝ => softmax (α • s) j) atTop (𝓝 0) := by
-  have : Nonempty ι := ⟨j⟩
-  rw [Metric.tendsto_atTop]
-  intro ε hε
-  refine ⟨log ε / (s j - s i_max) + 1, fun α hα => ?_⟩
-  rw [Real.dist_eq, sub_zero, abs_of_pos (softmax_pos _ _)]
-  exact lt_of_le_of_lt (softmax_le_exp_diff s α j i_max)
-    (exp_mul_neg_lt _ (sub_neg.mpr (h_max j hj)) ε hε α (by linarith))
-
-end SoftmaxLimit
-
-section Entropy
-
-/-! ### Shannon entropy and maximum entropy
-
-This section uses the private `ι → ℝ` Shannon entropy (`entropy`, above), since
-softmax is a real-arithmetic construction; the measure-level form is
-`InformationTheory.measureEntropy`. -/
+section LogPartition
 
 variable {ι : Type*} [Fintype ι] [Nonempty ι]
-
-
-/-- Maximum entropy is achieved by the uniform distribution. -/
-theorem entropy_le_log_card (p : ι → ℝ)
-    (hp_nonneg : ∀ i, 0 ≤ p i) (hp_sum : ∑ i : ι, p i = 1) :
-    entropy Finset.univ p ≤ log (Fintype.card ι) := by
-  set n := (Fintype.card ι : ℝ) with hn_def
-  have hn_pos : 0 < n := Nat.cast_pos.mpr Fintype.card_pos
-  have hn_ne : n ≠ 0 := ne_of_gt hn_pos
-  set q : ι → ℝ := λ _ => 1 / n with hq_def
-  have hq_pos : ∀ i, 0 < q i := fun _ => by simp [hq_def]; positivity
-  have hq_sum : ∑ i, q i = 1 := by
-    simp only [hq_def, Finset.sum_const, Finset.card_univ, nsmul_eq_mul, hn_def]
-    field_simp
-  have hkl := kl_nonneg' hp_nonneg hq_pos hp_sum hq_sum
-  -- KL(p ‖ q) = log n - H(p): rearrange to H(p) ≤ log n
-  suffices h : klFinite p q = -entropy Finset.univ p + log n by linarith
-  simp only [klFinite, entropy, Real.negMulLog]
-  -- Each term: if p=0 then 0 else p*log(p/q) = -(-(p)*log(p)) + p*log n
-  have hterm : ∀ i, (if p i = 0 then (0 : ℝ) else p i * log (p i / q i)) =
-      -(-(p i) * log (p i)) + p i * log n := by
-    intro i
-    by_cases hp0 : p i = 0
-    · simp [hp0]
-    · simp only [hp0, ↓reduceIte]
-      have hq_ne : q i ≠ 0 := ne_of_gt (hq_pos i)
-      rw [log_div hp0 hq_ne]
-      have hlogq : log (q i) = -log n := by
-        simp only [hq_def, log_div one_ne_zero hn_ne, log_one, zero_sub]
-      rw [hlogq]; ring
-  simp_rw [hterm]
-  rw [Finset.sum_add_distrib, ← Finset.sum_mul, hp_sum, one_mul,
-      Finset.sum_neg_distrib]
-
-
-/-- Entropy of softmax: H(softmax(s, α)) = log Z - α · 𝔼[s]. -/
-theorem entropy_softmax (s : ι → ℝ) (α : ℝ) :
-    entropy Finset.univ (softmax (α • s)) =
-    log (∑ j, exp (α * s j)) - α * ∑ i : ι, softmax (α • s) i * s i := by
-  simp only [entropy, softmax, Real.negMulLog, Pi.smul_apply, smul_eq_mul]
-  have hne : (∑ j : ι, exp (α * s j)) ≠ 0 :=
-    ne_of_gt (Finset.sum_pos (fun j _ => exp_pos _) Finset.univ_nonempty)
-  have hlog : ∀ i, log (exp (α * s i) / ∑ j : ι, exp (α * s j)) =
-                   α * s i - log (∑ j : ι, exp (α * s j)) := by
-    intro i; rw [log_div (ne_of_gt (exp_pos _)) hne, log_exp]
-  simp_rw [hlog]
-  have hsum1 : ∑ i : ι, exp (α * s i) / ∑ j : ι, exp (α * s j) = 1 := by
-    rw [← Finset.sum_div, div_self hne]
-  -- Move negation outside: ∑ -(x · y) = -∑ x · y
-  simp_rw [neg_mul]
-  rw [Finset.sum_neg_distrib]
-  calc -∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) *
-        (α * s i - log (∑ j : ι, exp (α * s j)))
-      = -∑ i : ι, ((exp (α * s i) / ∑ j : ι, exp (α * s j)) * (α * s i) -
-                   (exp (α * s i) / ∑ j : ι, exp (α * s j)) * log (∑ j : ι, exp (α * s j))) := by
-        congr 1; apply Finset.sum_congr rfl; intros; ring
-    _ = -(∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * (α * s i) -
-          ∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * log (∑ j : ι, exp (α * s j))) := by
-        rw [Finset.sum_sub_distrib]
-    _ = -(∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * (α * s i) -
-          (∑ i : ι, exp (α * s i) / ∑ j : ι, exp (α * s j)) * log (∑ j : ι, exp (α * s j))) := by
-        rw [← Finset.sum_mul]
-    _ = -(∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * (α * s i) - 1 * log (∑ j : ι, exp (α * s j))) := by
-        rw [hsum1]
-    _ = log (∑ j : ι, exp (α * s j)) - ∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * (α * s i) := by ring
-    _ = log (∑ j : ι, exp (α * s j)) - ∑ i : ι, α * ((exp (α * s i) / ∑ j : ι, exp (α * s j)) * s i) := by
-        congr 1; apply Finset.sum_congr rfl; intros; ring
-    _ = log (∑ j : ι, exp (α * s j)) - α * ∑ i : ι, (exp (α * s i) / ∑ j : ι, exp (α * s j)) * s i := by
-        rw [← Finset.mul_sum]
-
-/-- Entropy-regularized objective: G_α(p, s) = ⟨s, p⟩ + (1/α) H(p). -/
-noncomputable def entropyRegObjective (s : ι → ℝ) (α : ℝ) (p : ι → ℝ) : ℝ :=
-  ∑ i : ι, p i * s i + (1 / α) * entropy Finset.univ p
-
-/-- The maximum value of the entropy-regularized objective. -/
-theorem entropyRegObjective_softmax (s : ι → ℝ) (α : ℝ) (hα : 0 < α) :
-    entropyRegObjective s α (softmax (α • s)) = (1 / α) * log (∑ j, exp (α * s j)) := by
-  simp only [entropyRegObjective, entropy_softmax]
-  have hne : α ≠ 0 := ne_of_gt hα
-  field_simp
-  ring
-
-/-- Softmax maximizes the entropy-regularized objective. -/
-theorem softmax_maximizes_entropyReg (s : ι → ℝ) (α : ℝ) (hα : 0 < α)
-    (p : ι → ℝ) (hp_nonneg : ∀ i, 0 ≤ p i) (hp_sum : ∑ i : ι, p i = 1) :
-    entropyRegObjective s α p ≤ entropyRegObjective s α (softmax (α • s)) := by
-  -- entropyRegObjective unfolds to ∑ pᵢsᵢ + (1/α) · entropy Finset.univ p
-  -- and entropy Finset.univ p = ∑ negMulLog (p i), exactly what gibbs_variational uses
-  simp only [entropyRegObjective, entropy]
-  have hgibbs := gibbs_variational s α p hp_nonneg hp_sum
-  have hα_ne : α ≠ 0 := ne_of_gt hα
-  have h := div_le_div_of_nonneg_right hgibbs (le_of_lt hα)
-  simp only [add_div, mul_div_cancel_left₀ _ hα_ne] at h
-  simp only [div_eq_inv_mul] at h
-  rw [show (α⁻¹ : ℝ) = 1 / α from by ring] at h
-  linarith
-
-omit [Nonempty ι] in
-/-- KL divergence zero implies distributions are equal (when q > 0 and sums match). -/
-private theorem kl_eq_zero_imp_eq (p q : ι → ℝ) (hq_pos : ∀ i, 0 < q i)
-    (hp_nonneg : ∀ i, 0 ≤ p i) (hsum : ∑ i, p i = ∑ i, q i)
-    (hkl : klFinite p q = 0) :
-    p = q := by
-  rw [kl_eq_sum_klFun p q hq_pos hp_nonneg hsum] at hkl
-  funext i
-  have hpi_div_qi_nonneg : 0 ≤ p i / q i := div_nonneg (hp_nonneg i) (le_of_lt (hq_pos i))
-  have hqi_pos : 0 < q i := hq_pos i
-  have hqi_nonneg : 0 ≤ q i := le_of_lt hqi_pos
-  -- Each term q_i * klFun(p_i/q_i) ≥ 0 and their sum = 0
-  have hterm_nonneg : ∀ j, 0 ≤ q j * InformationTheory.klFun (p j / q j) := by
-    intro j; exact mul_nonneg (le_of_lt (hq_pos j))
-      (InformationTheory.klFun_nonneg (div_nonneg (hp_nonneg j) (le_of_lt (hq_pos j))))
-  have hterm_zero : q i * InformationTheory.klFun (p i / q i) = 0 := by
-    have hsz := Finset.sum_eq_zero_iff_of_nonneg (fun j _ => hterm_nonneg j) |>.mp hkl
-    exact hsz i (Finset.mem_univ i)
-  -- q_i > 0 so klFun(p_i/q_i) = 0, hence p_i/q_i = 1
-  rcases mul_eq_zero.mp hterm_zero with hq0 | hkl0
-  · exact absurd hq0 (ne_of_gt hqi_pos)
-  · rw [InformationTheory.klFun_eq_zero_iff hpi_div_qi_nonneg] at hkl0
-    exact div_eq_one_iff_eq (ne_of_gt hqi_pos) |>.mp hkl0
-
-/-- Softmax is the unique maximizer of the entropy-regularized objective. -/
-theorem softmax_unique_maximizer (s : ι → ℝ) (α : ℝ) (hα : 0 < α)
-    (p : ι → ℝ) (hp_nonneg : ∀ i, 0 ≤ p i) (hp_sum : ∑ i : ι, p i = 1)
-    (h_max : entropyRegObjective s α p = entropyRegObjective s α (softmax (α • s))) :
-    p = softmax (α • s) := by
-  set q := softmax (α • s) with hq_def
-  have hq_pos : ∀ i, 0 < q i := fun i => softmax_pos (α • s) i
-  have hq_sum : ∑ i, q i = 1 := sum_softmax (α • s)
-  -- From speakerObj_plus_kl: speakerObj(p) + KL(p ‖ q) = log-partition = speakerObj(q) + 0
-  have h_p := speakerObj_plus_kl s α p hp_nonneg hp_sum
-  have h_q := speakerObj_plus_kl s α q (fun i => le_of_lt (hq_pos i)) hq_sum
-  -- KL(q ‖ q) = 0
-  have hkl_self : klFinite q q = 0 := by
-    simp only [klFinite]
-    apply Finset.sum_eq_zero
-    intro i _
-    have hne : q i ≠ 0 := ne_of_gt (hq_pos i)
-    simp [hne]
-  rw [hkl_self, add_zero] at h_q
-  -- So KL(p ‖ q) = log-partition - speakerObj(p) = speakerObj(q) - speakerObj(p)
-  have hkl_val : klFinite p q = speakerObj s α q - speakerObj s α p := by linarith
-  -- entropyRegObjective equality means speakerObj equality (up to rescaling)
-  -- entropyRegObjective = Σ p*s + (1/α) * H(p)
-  -- speakerObj = Σ negMulLog(p) + α * Σ p*s  (i.e. H(p) + α⟨p,s⟩ but per-element)
-  -- We showed: entropyRegObj(p) = (1/α) * speakerObj(p)
-  have hobj_eq : speakerObj s α p = speakerObj s α q := by
-    -- entropyRegObjective = Σ p*s + (1/α)*H(p) = (1/α)(H(p) + α Σ p*s) = (1/α)*speakerObj
-    have hα_ne' : α ≠ 0 := ne_of_gt hα
-    have hconv : ∀ r : ι → ℝ, (∀ i, 0 ≤ r i) →
-        entropyRegObjective s α r = (1 / α) * speakerObj s α r := by
-      intro r hr_nn
-      simp only [entropyRegObjective, speakerObj]
-      simp only [entropy]
-      rw [Finset.mul_sum, ← Finset.sum_add_distrib, Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro i _
-      field_simp
-      ring
-    have h1 := hconv p hp_nonneg
-    have h2 := hconv q (fun i => le_of_lt (hq_pos i))
-    have hα_ne : (1 : ℝ) / α ≠ 0 := by positivity
-    rw [h1, h2] at h_max
-    exact mul_left_cancel₀ hα_ne h_max
-  -- Therefore KL(p ‖ q) = 0
-  have hkl_zero : klFinite p q = 0 := by linarith
-  exact kl_eq_zero_imp_eq p q hq_pos hp_nonneg (by rw [hp_sum, hq_sum]) hkl_zero
-
-/-- Free energy (from statistical mechanics). -/
-noncomputable def freeEnergy (s : ι → ℝ) (α : ℝ) (p : ι → ℝ) : ℝ :=
-  -∑ i : ι, p i * s i - (1 / α) * entropy Finset.univ p
-
-/-- Softmax is the Boltzmann distribution: minimizes free energy. -/
-theorem softmax_minimizes_freeEnergy (s : ι → ℝ) (α : ℝ) (hα : 0 < α)
-    (p : ι → ℝ) (hp_nonneg : ∀ i, 0 ≤ p i) (hp_sum : ∑ i : ι, p i = 1) :
-    freeEnergy s α (softmax (α • s)) ≤ freeEnergy s α p := by
-  simp only [freeEnergy]
-  have h := softmax_maximizes_entropyReg s α hα p hp_nonneg hp_sum
-  simp only [entropyRegObjective] at h
-  linarith
-
-/-! ### The log-partition function
-
-With one weight `α` varying and the other constraints' contributions `r` fixed,
-the log-partition function `α ↦ log ∑ᵢ exp (α sᵢ + rᵢ)` is convex, so the
-log-likelihood `α ↦ log (softmax (α • s + r) y)` of an observation `y` is
-concave, with derivative the observed feature `s y` minus its expectation under
-the model. -/
 
 /-- The log-partition function is convex in the weight. -/
 theorem convexOn_log_sum_exp (s r : ι → ℝ) :
@@ -658,9 +113,8 @@ theorem convexOn_log_sum_exp (s r : ι → ℝ) :
     · simp [show b = 1 from by linarith]
     rcases eq_or_lt_of_le hb with rfl | hb_pos
     · simp [show a = 1 from by linarith]
-    have hexp_split : ∀ i, exp ((a * x + b * y) * s i + r i) =
+    have hexp_split (i : ι) : exp ((a * x + b * y) * s i + r i) =
         (exp (x * s i + r i)) ^ a * (exp (y * s i + r i)) ^ b := by
-      intro i
       rw [← exp_mul, ← exp_mul, ← exp_add]
       congr 1
       linear_combination -(r i) * hab
@@ -668,28 +122,20 @@ theorem convexOn_log_sum_exp (s r : ι → ℝ) :
     have holder := Real.inner_le_Lp_mul_Lq_of_nonneg (s := Finset.univ (α := ι)) hpq
       (f := fun i => (exp (x * s i + r i)) ^ a)
       (g := fun i => (exp (y * s i + r i)) ^ b)
-      (fun i _ => rpow_nonneg (le_of_lt (exp_pos _)) a)
-      (fun i _ => rpow_nonneg (le_of_lt (exp_pos _)) b)
+      (fun i _ => rpow_nonneg (exp_pos _).le a) (fun i _ => rpow_nonneg (exp_pos _).le b)
     conv at holder => lhs; arg 2; ext i; rw [← hexp_split]
-    have ha_ne : a ≠ 0 := ne_of_gt ha_pos
-    have hb_ne : b ≠ 0 := ne_of_gt hb_pos
-    have hsimp_f : ∀ i, ((exp (x * s i + r i)) ^ a) ^ a⁻¹ = exp (x * s i + r i) := by
-      intro i
-      rw [← rpow_mul (le_of_lt (exp_pos _)), mul_inv_cancel₀ ha_ne, rpow_one]
-    have hsimp_g : ∀ i, ((exp (y * s i + r i)) ^ b) ^ b⁻¹ = exp (y * s i + r i) := by
-      intro i
-      rw [← rpow_mul (le_of_lt (exp_pos _)), mul_inv_cancel₀ hb_ne, rpow_one]
+    have hsimp_f (i : ι) : ((exp (x * s i + r i)) ^ a) ^ a⁻¹ = exp (x * s i + r i) := by
+      rw [← rpow_mul (exp_pos _).le, mul_inv_cancel₀ ha_pos.ne', rpow_one]
+    have hsimp_g (i : ι) : ((exp (y * s i + r i)) ^ b) ^ b⁻¹ = exp (y * s i + r i) := by
+      rw [← rpow_mul (exp_pos _).le, mul_inv_cancel₀ hb_pos.ne', rpow_one]
     simp_rw [hsimp_f, hsimp_g] at holder
     simp only [one_div, inv_inv] at holder
-    have hZ_x : (0 : ℝ) < ∑ i : ι, exp (x * s i + r i) :=
-      Finset.sum_pos (fun _ _ => exp_pos _) Finset.univ_nonempty
-    have hZ_y : (0 : ℝ) < ∑ i : ι, exp (y * s i + r i) :=
-      Finset.sum_pos (fun _ _ => exp_pos _) Finset.univ_nonempty
-    have hZ_mid : 0 < ∑ j : ι, exp ((a * x + b * y) * s j + r j) :=
-      Finset.sum_pos (fun _ _ => exp_pos _) Finset.univ_nonempty
+    have hZ_x : (0 : ℝ) < ∑ i : ι, exp (x * s i + r i) := sum_exp_pos _
+    have hZ_y : (0 : ℝ) < ∑ i : ι, exp (y * s i + r i) := sum_exp_pos _
+    have hZ_mid : (0 : ℝ) < ∑ j : ι, exp ((a * x + b * y) * s j + r j) := sum_exp_pos _
     have hlog_le := log_le_log hZ_mid holder
-    rw [log_mul (ne_of_gt (rpow_pos_of_pos hZ_x a)) (ne_of_gt (rpow_pos_of_pos hZ_y b)),
-        log_rpow hZ_x, log_rpow hZ_y] at hlog_le
+    rw [log_mul (rpow_pos_of_pos hZ_x a).ne' (rpow_pos_of_pos hZ_y b).ne', log_rpow hZ_x,
+      log_rpow hZ_y] at hlog_le
     linarith
 
 /-- The derivative of the log-partition function is the expected feature value. -/
@@ -697,23 +143,14 @@ theorem hasDerivAt_log_sum_exp (s r : ι → ℝ) (α : ℝ) :
     HasDerivAt (fun α => log (∑ i, exp (α * s i + r i)))
       (∑ i, softmax (α • s + r) i * s i) α := by
   simp only [softmax_def, Pi.add_apply, Pi.smul_apply, smul_eq_mul]
-  have hZ_ne : (∑ j : ι, exp (α * s j + r j)) ≠ 0 :=
-    ne_of_gt (Finset.sum_pos (fun _ _ => exp_pos _) Finset.univ_nonempty)
-  have hexp : ∀ j : ι, HasDerivAt (fun a => exp (a * s j + r j))
-      (exp (α * s j + r j) * s j) α := by
-    intro j
-    have h1 : HasDerivAt (fun a => a * s j + r j) (s j) α := by
-      have := ((hasDerivAt_id α).mul_const (s j)).add_const (r j)
-      simpa using this
-    exact (Real.hasDerivAt_exp (α * s j + r j)).comp α h1
+  have hexp (j : ι) : HasDerivAt (fun a => exp (a * s j + r j)) (exp (α * s j + r j) * s j) α :=
+    (hasDerivAt_exp _).comp α (by simpa using ((hasDerivAt_id α).mul_const (s j)).add_const (r j))
   have hsum : HasDerivAt (fun a => ∑ j : ι, exp (a * s j + r j))
       (∑ j : ι, exp (α * s j + r j) * s j) α :=
     HasDerivAt.fun_sum fun j _ => hexp j
-  convert hsum.log hZ_ne using 1
-  rw [Finset.sum_div]
-  apply Finset.sum_congr rfl
-  intro i _
-  ring
+  convert hsum.log (sum_exp_pos _).ne' using 1
+  rw [sum_div]
+  exact sum_congr rfl fun i _ => by ring
 
 /-- The log-likelihood `α ↦ log (softmax (α • s + r) y)` is concave: affine minus
 convex. -/
@@ -734,53 +171,8 @@ theorem hasDerivAt_log_softmax (s r : ι → ℝ) (y : ι) (α : ℝ) :
     simpa using ((hasDerivAt_id α).mul_const (s y)).add_const (r y)
   exact h_affine.sub (hasDerivAt_log_sum_exp s r α)
 
-/-- Strong duality: max entropy = min free energy. -/
-theorem max_entropy_duality (s : ι → ℝ) (c : ℝ)
-    (α : ℝ) (_hα : 0 < α) (h_constraint : ∑ i : ι, softmax (α • s) i * s i = c) :
-    entropy Finset.univ (softmax (α • s)) =
-    log (∑ j, exp (α * s j)) - α * c := by
-  rw [entropy_softmax, h_constraint]
+end LogPartition
 
-end Entropy
-
-/-! ### Bayesian optimality -/
-
-section BayesianOptimality
-
-variable {ι : Type*} [Fintype ι]
-
-/-- **Bayesian optimality**: the normalized posterior maximizes weighted
-log-likelihood on the probability simplex. For weights `wᵢ ≥ 0` with
-`C = Σ wᵢ > 0` and any distribution `L` on the simplex, the normalized posterior
-`p*ᵢ = wᵢ / C` satisfies `Σᵢ wᵢ · log Lᵢ ≤ Σᵢ wᵢ · log p*ᵢ`. -/
-theorem bayesian_maximizes (w : ι → ℝ) (hw_nonneg : ∀ i, 0 ≤ w i)
-    (hC_pos : 0 < ∑ i, w i)
-    (L : ι → ℝ) (hL_pos : ∀ i, 0 < L i) (hL_sum : ∑ i, L i = 1) :
-    ∑ i, w i * log (L i) ≤ ∑ i, w i * log (w i / ∑ j, w j) := by
-  set C := ∑ i, w i with hC_def
-  have hC_ne : C ≠ 0 := ne_of_gt hC_pos
-  have hp_nonneg : ∀ i, 0 ≤ w i / C := λ i => div_nonneg (hw_nonneg i) (le_of_lt hC_pos)
-  have hp_sum : ∑ i, w i / C = 1 := by rw [← Finset.sum_div, div_self hC_ne]
-  have hkl : 0 ≤ klFinite (λ i => w i / C) L :=
-    kl_nonneg _ L hL_pos hp_nonneg (by rw [hp_sum, hL_sum])
-  suffices h : (∑ i, w i * log (w i / C)) - (∑ i, w i * log (L i)) =
-      C * klFinite (fun i => w i / C) L by
-    linarith [mul_nonneg (le_of_lt hC_pos) hkl]
-  unfold klFinite
-  rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
-  apply Finset.sum_congr rfl
-  intro i _
-  by_cases hwi : w i = 0
-  · simp [hwi]
-  · have hwC_ne : w i / C ≠ 0 := div_ne_zero hwi hC_ne
-    simp only [hwC_ne, ↓reduceIte]
-    have hwi_pos : 0 < w i := lt_of_le_of_ne (hw_nonneg i) (Ne.symm hwi)
-    rw [show C * (w i / C * log (w i / C / L i)) = w i * log (w i / C / L i) from by
-      rw [← mul_assoc]; congr 1; field_simp]
-    rw [log_div (ne_of_gt (div_pos hwi_pos hC_pos)) (ne_of_gt (hL_pos i))]
-    ring
-
-end BayesianOptimality
 /-! ### Exponential tilting and the cumulant generating function
 
 Softmax is the finite, counting-measure case of mathlib's exponential-family
@@ -812,5 +204,16 @@ theorem ProbabilityTheory.hasDerivAt_cgf_count [Nonempty ι] (s : ι → ℝ) (�
 theorem MeasureTheory.tilted_count (s : ι → ℝ) :
     Measure.count.tilted s = Measure.count.withDensity fun i => ENNReal.ofReal (softmax s i) := by
   simp [Measure.tilted, softmax_def]
+
+omit [Fintype ι] [MeasurableSingletonClass ι] in
+/-- The uniform measure is the counting measure tilted by zero. -/
+theorem ProbabilityTheory.uniformOn_univ_eq_tilted_zero :
+    uniformOn (Set.univ : Set ι) = Measure.count.tilted 0 := by
+  rw [tilted_zero', uniformOn, cond, Measure.restrict_univ]
+
+/-- Tilting the uniform measure by the scores gives the softmax measure. -/
+theorem ProbabilityTheory.tilted_uniformOn_univ (s : ι → ℝ) :
+    (uniformOn (Set.univ : Set ι)).tilted s = Measure.count.tilted s := by
+  rw [uniformOn_univ_eq_tilted_zero, tilted_tilted (Integrable.of_finite), zero_add]
 
 end Tilting

--- a/Linglib/Phonology/HarmonicGrammar/Expressivity.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Expressivity.lean
@@ -3,7 +3,7 @@ import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Tableau
 import Linglib.Core.Optimization.Evaluation
-import Linglib.Core.Probability.SoftmaxTheory
+import Linglib.Core.Analysis.SpecialFunctions.Softmax
 import Linglib.Core.Optimization.Semiring
 import Linglib.Core.Optimization.Dequantization.LogSumExp.Softmax
 
@@ -293,7 +293,7 @@ theorem ot_lex_imp_higher_harmony {C : Type*}
 /-- **MaxEnt concentration on HG winner**: as α → ∞, MaxEnt probability
     concentrates on the candidate with the highest harmony score.
 
-    This is `softmax_argmax_limit` instantiated with harmony scores.
+    This is `Real.tendsto_softmax_atTop` instantiated with harmony scores.
     The interesting content is in the *hypotheses*: showing that the
     HG winner equals the OT winner (§4). -/
 theorem maxent_concentrates_on_hg_winner {C : Type*} [Fintype C] [Nonempty C]
@@ -302,7 +302,7 @@ theorem maxent_concentrates_on_hg_winner {C : Type*} [Fintype C] [Nonempty C]
     (h_opt : ∀ c, c ≠ c_opt →
       harmonyScore con w c < harmonyScore con w c_opt) :
     Tendsto (fun α : ℝ => softmax (α • harmonyScore con w) c_opt) atTop (𝓝 1) :=
-  softmax_argmax_limit (harmonyScore con w) c_opt h_opt
+  tendsto_softmax_atTop h_opt
 
 /-- **MaxEnt → OT limit** ([smolensky-legendre-2006]): as α → ∞,
     MaxEnt probability concentrates on the OT winner.
@@ -313,7 +313,7 @@ theorem maxent_concentrates_on_hg_winner {C : Type*} [Fintype C] [Nonempty C]
 
     The proof combines:
     1. `ot_lex_imp_higher_harmony`: lex-better ⟹ higher harmony (HG–OT agreement)
-    2. `softmax_argmax_limit`: MaxEnt concentrates on harmony maximizer -/
+    2. `Real.tendsto_softmax_atTop`: MaxEnt concentrates on harmony maximizer -/
 theorem maxent_ot_limit {C : Type*} [Fintype C] [Nonempty C] [DecidableEq C]
     (ranking : List (Constraint C)) (M : Nat) (hM : 0 < M)
     (c_opt : C)
@@ -324,11 +324,8 @@ theorem maxent_ot_limit {C : Type*} [Fintype C] [Nonempty C] [DecidableEq C]
     Tendsto (fun α : ℝ =>
       softmax (α • harmonyScore ranking.get (expWeights ranking.length M)) c_opt)
       atTop (𝓝 1) := by
-  apply softmax_argmax_limit
-  intro c hc
-  exact ot_lex_imp_higher_harmony ranking M hM c_opt c
-    (fun con hcon => ⟨hbound c_opt con hcon, hbound c con hcon⟩)
-    (hlex c hc)
+  exact tendsto_softmax_atTop fun c hc => ot_lex_imp_higher_harmony ranking M hM c_opt c
+    (fun con hcon => ⟨hbound c_opt con hcon, hbound c con hcon⟩) (hlex c hc)
 
 /-! ### The warped-semiring view of the limit -/
 

--- a/Linglib/Pragmatics/SoftmaxOptimality.lean
+++ b/Linglib/Pragmatics/SoftmaxOptimality.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Probability.Choice.RationalAction
 import Linglib.Core.Probability.SoftmaxTheory
+import Linglib.Core.Probability.GibbsVariational
 import Linglib.Core.Probability.Decision.Basic
 import Linglib.Core.Probability.SoftmaxLimits
 import Mathlib.Data.Rat.Cast.Defs
@@ -19,8 +20,9 @@ explicit by bridging `DecisionProblem` (ℚ) from `DecisionTheory.lean` with
 
 2. **Monotonicity** (§2): Higher EU ⟹ higher choice probability (α > 0).
 
-3. **Entropy-regularized optimality** (§3): The softmax agent uniquely maximizes
-   `∑ p(a)·EU(a) + (1/α)·H(p)` — the Gibbs Variational Principle in
+3. **Entropy-regularized optimality** (§3): The softmax policy is the Gibbs
+   measure of the uniform prior tilted by `α • EU`, hence the unique greatest
+   free-energy distribution — the Gibbs variational principle in
    decision-theoretic language.
 
 4. **Hard-max convergence** (§4): As α → ∞, the softmax agent converges to
@@ -98,39 +100,49 @@ theorem fromDP_policy_strict_mono {W A : Type*} [Fintype W] [Fintype A] [Nonempt
 -- §3. Entropy-Regularized EU Maximality
 -- ============================================================================
 
-/-- The softmax agent uniquely maximizes entropy-regularized expected utility:
-    p* = argmax_p [∑ p(a)·EU(a) + (1/α)·H(p)].
+section Gibbs
 
-This is the decision-theoretic content of the Gibbs Variational Principle.
-The objective `entropyRegObjective` from `RationalAction.lean` is exactly
-`∑ p(a)·s(a) + (1/α)·H(p)` — we just instantiate `s = EU`. -/
-theorem softmax_maximizes_EU_plus_entropy {W A : Type*}
-    [Fintype W] [Fintype A] [Nonempty A]
-    (dp : DecisionTheory.DecisionProblem ℚ W A) {α : ℝ} (hα : 0 < α)
-    (p : A → ℝ) (hp_nn : ∀ a, 0 ≤ p a) (hp_sum : ∑ a, p a = 1) :
-    entropyRegObjective (fun a => expectedUtilityR dp a) α p ≤
-    entropyRegObjective (fun a => expectedUtilityR dp a) α
-      ((RationalAction.fromDecisionProblem dp α).policy () ·) := by
-  -- The policy of fromDecisionProblem equals softmax over EU
-  have hpol : ∀ a, (RationalAction.fromDecisionProblem dp α).policy () a =
-      softmax (α • fun a => expectedUtilityR dp a) a := by
-    intro a
-    exact RationalAction.fromSoftmax_policy_eq _ α () a
-  simp_rw [show (fun a => (RationalAction.fromDecisionProblem dp α).policy () a) =
-    softmax (α • fun a => expectedUtilityR dp a) from funext hpol]
-  exact softmax_maximizes_entropyReg _ α hα p hp_nn hp_sum
+open MeasureTheory ProbabilityTheory InformationTheory
 
-/-- The softmax agent is the UNIQUE maximizer: any distribution achieving
-the same objective value must equal the softmax policy. -/
-theorem softmax_unique_EU_maximizer {W A : Type*}
-    [Fintype W] [Fintype A] [Nonempty A]
-    (dp : DecisionTheory.DecisionProblem ℚ W A) {α : ℝ} (hα : 0 < α)
-    (p : A → ℝ) (hp_nn : ∀ a, 0 ≤ p a) (hp_sum : ∑ a, p a = 1)
-    (h_max : entropyRegObjective (fun a => expectedUtilityR dp a) α p =
-             entropyRegObjective (fun a => expectedUtilityR dp a) α
-               (softmax (α • fun a => expectedUtilityR dp a))) :
-    p = softmax (α • fun a => expectedUtilityR dp a) :=
-  softmax_unique_maximizer _ α hα p hp_nn hp_sum h_max
+variable {W A : Type*} [Fintype W] [Fintype A] [Nonempty A] [MeasurableSpace A]
+  [MeasurableSingletonClass A] (dp : DecisionTheory.DecisionProblem ℚ W A) (α : ℝ)
+
+/-- The softmax policy, as a measure, is the uniform prior tilted by the scaled
+expected utility — the Gibbs measure of `α • EU`. -/
+theorem fromDP_policy_eq_tilted :
+    Measure.count.withDensity
+        (fun a => ENNReal.ofReal ((RationalAction.fromDecisionProblem dp α).policy () a)) =
+      (uniformOn Set.univ).tilted (α • fun a => expectedUtilityR dp a) := by
+  rw [tilted_uniformOn_univ, tilted_count]
+  congr; funext a; exact congrArg ENNReal.ofReal (RationalAction.fromSoftmax_policy_eq _ α () a)
+
+/-- **Gibbs variational principle for the softmax agent**: the softmax policy is
+the greatest free-energy distribution `𝔼_q[α • EU] − KL(q ‖ uniform)` over the
+uniform prior, the greatest value being the cumulant generating function
+(`isGreatest_cgf`, with the integrability conditions automatic on a finite type). -/
+theorem fromDP_isGreatest_freeEnergy :
+    IsGreatest ((uniformOn (Set.univ : Set A)).freeEnergy (α • fun a => expectedUtilityR dp a) ''
+        {q | IsProbabilityMeasure q ∧ q ≪ uniformOn Set.univ})
+      (cgf (α • fun a => expectedUtilityR dp a) (uniformOn Set.univ) 1) := by
+  have := isProbabilityMeasure_uniformOn' (s := (Set.univ : Set A)) Set.finite_univ Set.univ_nonempty
+  have : IsProbabilityMeasure ((uniformOn (Set.univ : Set A)).tilted
+      (α • fun a => expectedUtilityR dp a)) := isProbabilityMeasure_tilted Integrable.of_finite
+  refine ⟨⟨_, ⟨this, tilted_absolutelyContinuous _ _⟩,
+    freeEnergy_tilted _ Integrable.of_finite Integrable.of_finite Integrable.of_finite⟩, ?_⟩
+  rintro x ⟨q, ⟨hq, hqμ⟩, rfl⟩
+  exact freeEnergy_le_cgf _ q hqμ Integrable.of_finite Integrable.of_finite Integrable.of_finite
+
+/-- The greatest free energy is attained only by the softmax policy. -/
+theorem fromDP_eq_tilted_of_freeEnergy_eq (q : Measure A) [IsProbabilityMeasure q]
+    (hq : q ≪ uniformOn Set.univ)
+    (h : (uniformOn (Set.univ : Set A)).freeEnergy (α • fun a => expectedUtilityR dp a) q =
+      cgf (α • fun a => expectedUtilityR dp a) (uniformOn Set.univ) 1) :
+    q = (uniformOn Set.univ).tilted (α • fun a => expectedUtilityR dp a) :=
+  have := isProbabilityMeasure_uniformOn' (s := (Set.univ : Set A)) Set.finite_univ Set.univ_nonempty
+  eq_tilted_of_freeEnergy_eq_cgf _ q hq Integrable.of_finite Integrable.of_finite
+    Integrable.of_finite h
+
+end Gibbs
 
 -- ============================================================================
 -- §4. Hard-Max Convergence

--- a/Linglib/Processing/Psychophysics/Psychophysics.lean
+++ b/Linglib/Processing/Psychophysics/Psychophysics.lean
@@ -12,7 +12,7 @@ and its extension to multi-dimensional stimulus continua.
 Stevens' magnitude estimation experiments yield ψ(s) = k · sⁿ — a power function
 relating physical stimulus intensity to psychological magnitude. Luce shows this
 is not an independent discovery but a **corollary** of the Fechnerian framework
-(`luce_fechnerian_exp` in `RationalAction.lean`) under a change of variables.
+(`luce_fechnerian_exp` in `Core.Probability.SoftmaxTheory`) under a change of variables.
 
 The key insight: if we work with log-intensity `u = log s` rather than raw
 intensity `s`, then the ratio scale `v(s) = C · sⁿ = C · exp(n · log s)`

--- a/references.bib
+++ b/references.bib
@@ -1325,8 +1325,7 @@
   publisher = {Center for Open Science},
   subfield  = {pragmatics/rsa},
   validated = {true},
-  role      = {cited},
-  sources   = {Core/Probability/SoftmaxTheory.lean}
+  role      = {cited}
 }
 @article{hawkins-etal-2025,
   author    = {Hawkins, Robert D. and Tsvilodub, Polina and Bergey, Claire A. and Goodman, Noah D. and Franke, Michael},
@@ -1429,7 +1428,7 @@
   url       = {https://arxiv.org/abs/2005.06641},
   subfield  = {pragmatics/rsa},
   role      = {formalized},
-  sources   = {Core/Probability/SoftmaxTheory.lean;Processing/Memory/SurprisalTradeoff.lean;Core/Probability/Choice/RationalAction.lean}
+  sources   = {Processing/Memory/SurprisalTradeoff.lean;Core/Probability/Choice/RationalAction.lean}
 }
 @article{beltrama-2025,
   author    = {Beltrama, Andrea},


### PR DESCRIPTION
`SoftmaxTheory.lean` goes from 817 to 219 lines. Its finite-sum Gibbs half (private KL and entropy helpers, `gibbs_variational`, `entropyRegObjective`, the root `freeEnergy`, uniqueness by hand) was a second implementation of the measure-face principle in `GibbsVariational.lean`; it is gone, and `GibbsVariational` gains the missing uniqueness lemma `eq_tilted_of_freeEnergy_eq_cgf`. `SoftmaxOptimality` §3 now states the softmax agent's optimality as `isGreatest_cgf` for the uniform prior tilted by `α • EU`, with the policy identified as that Gibbs measure.

- `cauchy_mul_exp` proved through mathlib (`AddMonoidHom.continuous_of_isBounded_nhds_zero`, `map_real_smul`) instead of 75 lines of ℕ→ℤ→ℚ→ℝ Cauchy lemmas.
- The argmax limit moves to the mirror file as `Real.tendsto_softmax_atTop` (sibling of `tendsto_sigmoid_atTop`); `Expressivity` and `Decoder` import only that file now. Orphans `bayesian_maximizes` and `entropy_le_log_card` deleted.
- New counting-measure lemmas `uniformOn_univ_eq_tilted_zero`, `tilted_uniformOn_univ`.