### PR TITLE
refactor(Studies/GokselKerslake2005): derive harmony and templates

### DIFF
--- a/Linglib/Fragments/Turkish/SuffixTemplate.lean
+++ b/Linglib/Fragments/Turkish/SuffixTemplate.lean
@@ -1,47 +1,65 @@
 import Linglib.Morphology.Morphotactics.Template
 
 /-!
-# Turkish Suffix Templates
-[goksel-kerslake-2005]
+# Turkish suffix templates
 
-Turkish is strictly suffixing ([goksel-kerslake-2005] Ch 6): suffixes
-attach in a fixed order determined by a positional template. The verbal
-(Ch 6, 8, 13) and nominal (Ch 6, 8, 14) templates live here as Fragment
-data over `Morphology.AffixTemplate`; ordering predictions are checked in
-`Studies/GokselKerslake2005.lean`.
+Turkish is suffixing: derivational suffixes precede inflectional ones and clitics
+follow both ([goksel-kerslake-2005] §6.3). The inflectional suffixes of a finite verb
+appear in the order root - voice - negation - tense/aspect/modality - copular marker -
+person marker - -DIr (§8.2), the tense/aspect/modality markers themselves falling
+into five positions of which the fourth is the copular markers and the fifth -DIr
+(§8.2.3), the possibility suffix -(y)A of position 1 preceding the negative
+(§8.2.3.1). The inflectional suffixes of a nominal appear in the order number -
+possession - case (§8.1). Both are `Morphology.AffixTemplate`s: the voice slot is a
+position class, filled by up to four stacked voice suffixes (§8.2 (7)), and the
+clitics mI and dA, which can interrupt the inflectional string (§6.3 (5)), are
+Chapter 11 material outside them. The grammar's examples are checked against the
+templates in `Studies/GokselKerslake2005.lean`.
 
-Voice suffixes can stack within their slot (*yap-tır-ıl-* 'be made to
-do' = CAUS + PASS); slots are position classes, not token counts.
+## References
+
+* [A. Göksel and C. Kerslake, *Turkish: A Comprehensive Grammar* (2005)][goksel-kerslake-2005]
 -/
 
 namespace Turkish.SuffixTemplate
 
-/-- Verbal suffix slots. [goksel-kerslake-2005] Ch 6, 8, 13. -/
+/-- The suffix slots of a finite verb (§8.2, §8.2.3). -/
 inductive VerbSlot where
-  | voice         -- causative -DIr, passive -(I)l, reflexive -(I)n, reciprocal -(I)ş
-  | negation      -- -mA
-  | tam           -- -DI, -mIş, -(I)r, -Iyor, -(y)AcAK, -sA, -(y)A, -mAlI
-  | copula        -- compound tense: -DI, -mIş, -(y)sA
-  | agreement     -- person/number
-  | question      -- mI
+  /-- Causative, passive, reflexive and reciprocal (§8.2.1). -/
+  | voice
+  /-- The possibility suffix -(y)A of negative forms, position 1 (§8.2.3.1). -/
+  | possibility
+  /-- -mA (§8.2.2). -/
+  | negation
+  /-- The bound auxiliaries -(y)Abil, -(y)Iver, -(y)Agel, -(y)Ayaz, -(y)Akal and
+  -(y)Adur, position 2 (§8.2.3.2). -/
+  | auxiliary
+  /-- Position 3: -DI, -mIş, -sA, the aorist, -(y)AcAK, -(I)yor, -mAlI, -mAktA and the
+  optative -(y)A (§8.2.3.3). -/
+  | tam
+  /-- The copular markers -(y)DI, -(y)mIş and -(y)sA, position 4 (§8.3.2). -/
+  | copula
+  /-- Person markers (§8.4). -/
+  | person
+  /-- The generalizing-modality marker -DIr, position 5 (§8.3.3). -/
+  | generalizing
   deriving DecidableEq, Repr
 
-/-- Nominal suffix slots. [goksel-kerslake-2005] Ch 6, 8, 14. -/
+/-- The suffix slots of a nominal (§6.3, §8.1). -/
 inductive NounSlot where
-  | derivational  -- denominal/deadjectival suffixes
-  | plural        -- -lAr
-  | possessive    -- -(I)m, -(I)n, -(s)I, etc.
-  | case          -- -(y)I, -(y)A, -DA, -DAn, -(n)In, zero
+  | derivational
+  | number
+  | possession
+  | case
   deriving DecidableEq, Repr
 
-/-- The verbal template, stem-outward:
-`Root - Voice - Negation - TAM - Copula - Agreement - Question`. -/
+/-- The finite-verb template, stem-outward (§8.2). -/
 def verbTemplate : Morphology.AffixTemplate VerbSlot where
-  suffixSlots := [.voice, .negation, .tam, .copula, .agreement, .question]
+  suffixSlots :=
+    [.voice, .possibility, .negation, .auxiliary, .tam, .copula, .person, .generalizing]
 
-/-- The nominal template, stem-outward:
-`Root - Derivational - Plural - Possessive - Case`. -/
+/-- The nominal template, stem-outward (§8.1). -/
 def nounTemplate : Morphology.AffixTemplate NounSlot where
-  suffixSlots := [.derivational, .plural, .possessive, .case]
+  suffixSlots := [.derivational, .number, .possession, .case]
 
 end Turkish.SuffixTemplate

--- a/Linglib/Fragments/Turkish/TAM.lean
+++ b/Linglib/Fragments/Turkish/TAM.lean
@@ -1,95 +1,76 @@
-import Linglib.Fragments.Turkish.Negation
+import Linglib.Fragments.Turkish.SuffixTemplate
 
 /-!
-# Turkish Tense-Aspect-Modality System
-[goksel-kerslake-2005]
+# Turkish tense, aspect and modality markers
 
-The TAM system is the core of the Turkish verbal paradigm
-([goksel-kerslake-2005] Ch 21, Appendix 2). There are five **basic** TAM
-categories and three **modal** categories, occupying a single paradigmatic slot.
+The tense/aspect/modality markers of a finite verb occupy five positions
+([goksel-kerslake-2005] §8.2.3): the possibility suffix -(y)A (1), the bound
+auxiliaries (2), the markers of tense, aspect and modality proper (3), the copular
+markers (4) and -DIr (5). Markers of one position cannot co-occur, and every finite
+verb but the imperative and the third-person optative carries one of position 3. Their
+meanings are the matter of Chapter 21 and Appendix 2: -DI marks past tense, perfective
+aspect and direct knowledge, -mIş relative past tense, perfective aspect and indirect
+knowledge (evidential modality, §21.4.3), the copular -(y)mIş evidential modality
+alone; -mIş followed by a copular marker or -DIr is perfective only (§8.2.3.3).
+Negation of the aorist is irregular, -mAz for -(A/I)r (§8.2.2; see
+`Turkish.Negation`).
 
-## Key properties
+## References
 
-1. **Evidential -mIş is a TAM marker**, not a separate evidential morpheme.
-   It fills the same paradigmatic slot as -DI (past definite) and cannot
-   co-occur with it.
-
-2. **Aorist negation is asymmetric**: affirmative -(I)r becomes negative -mAz
-   rather than the expected *-mA-(I)r. All other categories use regular
-   -mA- negation (see also `Turkish.Negation`).
-
-3. **Compound tenses** are formed by adding a copular suffix (-DI, -mIş,
-   -(y)sA) to the basic form: *geliyordu* (progressive + past copula).
-
-## Suffix notation
-
-Capital letters indicate vowel harmony alternation
-(see `Turkish.VowelHarmony`):
-- **A** = a/e (twofold), **I** = ı/i/u/ü (fourfold)
-- **D** = d/t (voicing assimilation)
+* [A. Göksel and C. Kerslake, *Turkish: A Comprehensive Grammar* (2005)][goksel-kerslake-2005]
 -/
 
 namespace Turkish.TAM
 
-/-- The eight TAM categories of Turkish. -/
-inductive TAMCategory where
-  | pastDef        -- witnessed/definite past: -DI
-  | evidential     -- indirect/reportative: -(y)mIş
-  | aorist         -- habitual/dispositional: -(I)r
-  | progressive    -- ongoing: -Iyor
-  | future         -- prospective: -(y)AcAK
-  | conditional    -- hypothesis: -(y)sA
-  | optative       -- wish/mild imperative: -(y)A
-  | necessitative  -- obligation: -mAlI
-  deriving DecidableEq, Repr, Inhabited
+open Turkish.SuffixTemplate (VerbSlot)
 
-/-- TAM suffix entry with positive and negative forms. -/
-structure TAMEntry where
-  category : TAMCategory
-  affSuffix : String
-  negSuffix : String
-  /-- Is negation symmetric (neg = stem + -mA- + TAM)? -/
-  isNegSymmetric : Bool
-  deriving Repr, BEq, Inhabited
-
-def entries : List TAMEntry :=
-  [ { category := .pastDef,      affSuffix := "-DI",
-      negSuffix := "-mA-DI",     isNegSymmetric := true }
-  , { category := .evidential,   affSuffix := "-mIş",
-      negSuffix := "-mA-mIş",    isNegSymmetric := true }
-  , { category := .aorist,       affSuffix := "-(I)r",
-      negSuffix := "-mAz",       isNegSymmetric := false }
-  , { category := .progressive,  affSuffix := "-Iyor",
-      negSuffix := "-m-Iyor",    isNegSymmetric := true }
-  , { category := .future,       affSuffix := "-(y)AcAK",
-      negSuffix := "-mA-yAcAK",  isNegSymmetric := true }
-  , { category := .conditional,  affSuffix := "-(y)sA",
-      negSuffix := "-mA-sA",     isNegSymmetric := true }
-  , { category := .optative,     affSuffix := "-(y)A",
-      negSuffix := "-mA-yA",     isNegSymmetric := true }
-  , { category := .necessitative, affSuffix := "-mAlI",
-      negSuffix := "-mA-mAlI",   isNegSymmetric := true }
-  ]
-
--- ============================================================================
--- § Compound tenses
--- ============================================================================
-
-/-- Copular suffixes that combine with basic TAM for compound tenses. -/
-inductive CopulaSuffix where
-  | pastCop         -- -DI: geliyordu 'was coming'
-  | evidentialCop   -- -(y)mIş: geliyormuş 'was apparently coming'
-  | conditionalCop  -- -(y)sA: geliyorsa 'if s/he is coming'
+/-- The tense/aspect/modality markers of §8.2.3, by position. -/
+inductive Marker where
+  /-- -(y)A, possibility; position 1, negative forms only. -/
+  | possibility
+  /-- -(y)Abil, possibility; position 2. -/
+  | abil
+  /-- -(y)Iver, non-premeditative. -/
+  | iver
+  | agel
+  | ayaz
+  | akal
+  | adur
+  /-- -DI, perfective; position 3. -/
+  | di
+  /-- -mIş, perfective/evidential. -/
+  | miş
+  /-- -sA, conditional. -/
+  | sa
+  /-- -(A/I)r, negative -z. -/
+  | aorist
+  /-- -(y)AcAK, future. -/
+  | acak
+  /-- -(I)yor, imperfective. -/
+  | iyor
+  /-- -mAlI, obligative. -/
+  | mali
+  /-- -mAktA, imperfective. -/
+  | makta
+  /-- -(y)A, optative. -/
+  | optative
+  /-- -(y)DI, past copula; position 4. -/
+  | pastCopula
+  /-- -(y)mIş, evidential copula. -/
+  | evidentialCopula
+  /-- -(y)sA, conditional copula. -/
+  | conditionalCopula
+  /-- -DIr, generalizing modality; position 5. -/
+  | dir
   deriving DecidableEq, Repr
 
--- ============================================================================
--- § Verification
--- ============================================================================
-
-/-- The aorist is the only TAM category with asymmetric negation;
-    all others use regular `-mA-` insertion (cf. `Negation.aorist_asymmetric`
-    for the surface-form counterpart). -/
-theorem asymmetric_is_aorist :
-    (entries.filter (! ·.isNegSymmetric)).map (·.category) = [.aorist] := rfl
+/-- The template slot of a marker: positions 1 to 5 are the slots `possibility`,
+`auxiliary`, `tam`, `copula` and `generalizing`. -/
+def Marker.slot : Marker → VerbSlot
+  | .possibility => .possibility
+  | .abil | .iver | .agel | .ayaz | .akal | .adur => .auxiliary
+  | .di | .miş | .sa | .aorist | .acak | .iyor | .mali | .makta | .optative => .tam
+  | .pastCopula | .evidentialCopula | .conditionalCopula => .copula
+  | .dir => .generalizing
 
 end Turkish.TAM

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -1,202 +1,180 @@
-import Linglib.Phonology.Segmental.Basic
-import Linglib.Phonology.Segmental.Geometry
-import Linglib.Phonology.Subregular.LocalRewrite
-import Linglib.Phonology.Autosegmental.Sharing
 import Linglib.Phonology.Subregular.Harmony
 
 /-!
-# Turkish Vowel Harmony
-[goksel-kerslake-2005] [rose-walker-2011]
+# Turkish vowel harmony
 
-Turkish has a perfectly symmetric 2x2x2 vowel inventory and a
-**two-dimensional** vowel harmony system ([goksel-kerslake-2005] Ch 3).
+Turkish has one vowel for each combination of [back], [round] and [high], and two
+harmonies over them ([goksel-kerslake-2005] Chapter 3): fronting harmony copies
+[back] from the preceding vowel to a suffix vowel, rounding harmony copies [round]
+to a high suffix vowel. Suffix vowels are archiphonemes: the A of A-type suffixes is
+non-high and unrounded but unspecified for [back] (§3.2.2), the I of I-type suffixes
+is high and unspecified for both (§3.2.1). So the targets of each harmony are the
+vowels lacking its feature, and a suffix vowel specified for it, such as the `o` of
+-(I)yor, is skipped and triggers what follows (§3.4). Consonants are off both tiers,
+except that the palatal l of loans such as *gol* carries [−back] and fronts the
+suffix (§3.4, [clements-sezer-1982]). The suffix-initial D of -DI and -DA copies
+[voice] from the preceding segment (§6.1.2).
 
-## Vowel inventory
+The alternations are `Subregular.Harmony.System`s over `Phonology.Segment`; a
+suffixed word's surface form is their `System.transduceWord`. The grammar's examples
+are derived in `Studies/GokselKerslake2005.lean`.
 
-|          | Front       |             | Back        |             |
-|----------|-------------|-------------|-------------|-------------|
-|          | Unrounded   | Rounded     | Unrounded   | Rounded     |
-| **High** | i           | ü           | ı           | u           |
-| **Non-high** | e       | ö           | a           | o           |
+## Main definitions
 
-## Two harmony dimensions
+* `a`, `e`, `ı`, `i`, `o`, `ö`, `u`, `ü` — the vowels; `A`, `I` — the suffix archiphonemes.
+* `fronting`, `rounding`, `voicing` — the two vowel harmonies and D-voicing.
+* `surface` — the three alternations applied to a word.
 
-1. **Palatal harmony** ([±back]): the last vowel's [back] value spreads to
-   *all* suffix vowels. Determines the **twofold** alternation A -> a/e.
+## References
 
-2. **Labial harmony** ([±round]): the last vowel's [round] value spreads
-   to **[+high] suffix vowels only**. Combined with palatal harmony, this
-   yields the **fourfold** alternation I -> ı/i/u/ü.
-
-## Archiphonemic suffix vowels
-
-Turkish grammars use capital letters for harmonizing suffix vowels:
-- **A** alternates a/e (twofold: [back] only)
-- **I** alternates ı/i/u/ü (fourfold: [back] + [round])
-
-Examples with *ev* 'house' [front, unrounded]:
-  Plural ev-ler (A -> e), Accusative ev-i (I -> i)
-Examples with *göz* 'eye' [front, rounded]:
-  Plural göz-ler (A -> e), Accusative göz-ü (I -> ü)
-Examples with *kol* 'arm' [back, rounded]:
-  Plural kol-lar (A -> a), Accusative kol-u (I -> u)
-
-## Harmony systems ([rose-walker-2011])
-
-Turkish VH decomposes into two `System` instances:
-- `palatalHarmony`: [back] spreads to all suffix vowels (twofold A)
-- `labialHarmony`: [round] spreads to high suffix vowels only (fourfold I)
+* [A. Göksel and C. Kerslake, *Turkish: A Comprehensive Grammar* (2005)][goksel-kerslake-2005]
+* [G. N. Clements and E. Sezer, *Vowel and consonant disharmony in Turkish*][clements-sezer-1982]
 -/
 
 namespace Turkish.VowelHarmony
 
-open Phonology (Segment Feature)
-open Autosegmental (agreeAt)
-open Subregular.Harmony (System triggerValue)
+open Phonology (Segment)
+open Subregular.Harmony (System)
 
--- ============================================================================
--- § 1: Turkish Vowel Inventory (8 vowels)
--- ============================================================================
+/-! ### Segments -/
 
-def i_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, true),
-   (.back, false), (.round, false), (.low, false)]
+/-- The vowel of the given [back], [round] and [high] values. -/
+private def vowel (back round high : Bool) : Segment :=
+  Segment.ofSpecs [(.syllabic, true), (.dorsal, true), (.voice, true),
+    (.back, back), (.round, round), (.high, high)]
 
-def ü_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, true),
-   (.back, false), (.round, true), (.low, false)]
+def a : Segment := vowel true false false
+def e : Segment := vowel false false false
+def ı : Segment := vowel true false true
+def i : Segment := vowel false false true
+def o : Segment := vowel true true false
+def ö : Segment := vowel false true false
+def u : Segment := vowel true true true
+def ü : Segment := vowel false true true
 
-def ı_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, true),
-   (.back, true), (.round, false), (.low, false)]
+/-- The eight vowels. -/
+def vowels : List Segment := [a, e, ı, i, o, ö, u, ü]
 
-def u_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, true),
-   (.back, true), (.round, true), (.low, false)]
+/-- The vowel of A-type suffixes such as -lAr and -mA: unrounded and non-high, its
+backness supplied by fronting harmony (§3.2.2). -/
+def A : Segment :=
+  Segment.ofSpecs [(.syllabic, true), (.dorsal, true), (.voice, true),
+    (.high, false), (.round, false)]
 
-def e_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, false),
-   (.back, false), (.round, false), (.low, false)]
+/-- The vowel of I-type suffixes such as -(I)m and -mIş: high, its backness and rounding
+supplied by the two harmonies (§3.2.1). -/
+def I : Segment :=
+  Segment.ofSpecs [(.syllabic, true), (.dorsal, true), (.voice, true), (.high, true)]
 
-def ö_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, false),
-   (.back, false), (.round, true), (.low, false)]
+/-- A consonant of the given specifications. -/
+private def consonant (specs : List (Phonology.Feature × Bool)) : Segment :=
+  Segment.ofSpecs ((.syllabic, false) :: specs)
 
-def a_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, false),
-   (.back, true), (.round, false), (.low, true)]
+def b : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.labial, true), (.voice, true)]
+def t : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.coronal, true), (.anterior, true), (.voice, false)]
+def d : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.coronal, true), (.anterior, true), (.voice, true)]
+/-- The suffix-initial D of -DI and -DA: `t` after a voiceless consonant, `d` otherwise
+(§6.1.2). -/
+def D : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.coronal, true), (.anterior, true)]
+def k : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.dorsal, true), (.voice, false)]
+def g : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.dorsal, true), (.voice, true)]
+def s : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
+  (.strident, true), (.coronal, true), (.anterior, true), (.voice, false)]
+def z : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
+  (.strident, true), (.coronal, true), (.anterior, true), (.voice, true)]
+def ş : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
+  (.strident, true), (.coronal, true), (.anterior, false), (.voice, false)]
+def v : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
+  (.labial, true), (.voice, true)]
+def h : Segment := consonant [(.consonantal, false), (.sonorant, false), (.continuant, true),
+  (.spreadGlottis, true), (.voice, false)]
+def m : Segment := consonant [(.consonantal, true), (.sonorant, true), (.nasal, true),
+  (.labial, true), (.voice, true)]
+def n : Segment := consonant [(.consonantal, true), (.sonorant, true), (.nasal, true),
+  (.coronal, true), (.voice, true)]
+def l : Segment := consonant [(.consonantal, true), (.sonorant, true), (.lateral, true),
+  (.coronal, true), (.voice, true)]
+/-- The palatal l of loans such as *gol* and *hal*: [−back], so a trigger of fronting
+harmony (§3.4 (iv), [clements-sezer-1982]). -/
+def l' : Segment := consonant [(.consonantal, true), (.sonorant, true), (.lateral, true),
+  (.coronal, true), (.voice, true), (.back, false)]
+def r : Segment := consonant [(.consonantal, true), (.sonorant, true), (.tap, true),
+  (.coronal, true), (.voice, true)]
+def y : Segment := consonant [(.consonantal, false), (.sonorant, true), (.approximant, true),
+  (.continuant, true), (.voice, true)]
 
-def o_vowel : Segment := Segment.ofSpecs
-  [(.syllabic, true), (.dorsal, true), (.high, false),
-   (.back, true), (.round, true), (.low, false)]
+/-! ### Suffixes
 
--- ============================================================================
--- § 2: Harmony System Instances
--- ============================================================================
+Citation forms after a consonant-final stem; the deletable vowels and buffer `y` of
+§6.1.3 are not represented. -/
 
-/-- Palatal harmony: [back] spreads from the last stem vowel to all suffix
-    vowels. Every vowel is both trigger and target; no transparency. -/
-def palatalHarmony : System Segment :=
+/-- -lAr, plural (§8.1.1). -/
+def plural : List Segment := [l, A, r]
+/-- -(I)m, first-person singular possessive (§8.1.2). -/
+def possessive1sg : List Segment := [I, m]
+/-- -(I)n, second-person singular possessive (§8.1.2). -/
+def possessive2sg : List Segment := [I, n]
+/-- -(I)mIz, first-person plural possessive (§8.1.2). -/
+def possessive1pl : List Segment := [I, m, I, z]
+/-- -(s)I, third-person singular possessive (§8.1.2). -/
+def possessive3sg : List Segment := [I]
+/-- -DA, locative (§8.1.3). -/
+def locative : List Segment := [D, A]
+/-- -Il, passive (§8.2.1.2). -/
+def passive : List Segment := [I, l]
+/-- -mA, negative (§8.2.2); before -(I)yor its vowel is raised to I (§8.2.2). -/
+def negative : List Segment := [m, A]
+/-- -DI, perfective (§8.2.3.3). -/
+def perfective : List Segment := [D, I]
+/-- -mIş, perfective/evidential (§8.2.3.3). -/
+def evidential : List Segment := [m, I, ş]
+/-- -(I)yor, imperfective; its `o` does not harmonize (§3.4 (vi)). -/
+def imperfective : List Segment := [I, y, o, r]
+/-- -(y)mIş, the evidential copula (§8.3.2). -/
+def evidentialCopula : List Segment := [y, m, I, ş]
+/-- -(y)ken, converb; invariable (§3.4 (vi)). -/
+def ken : List Segment := [k, e, n]
+/-- -(I)m, first-person singular of the group 2 person markers (§8.4). -/
+def person1sg : List Segment := [I, m]
+/-- -nIz, second-person plural of the group 1 person markers (§8.4). -/
+def person2pl : List Segment := [n, I, z]
+
+/-! ### Alternations -/
+
+/-- Fronting harmony: a suffix vowel unspecified for [back] takes the value of the
+preceding segment specified for it — a vowel, or a palatal `l'`; all other consonants are
+off the tier (§3.1, §3.2). -/
+def fronting : System Segment :=
   System.mk' (feature := .back)
-    (isTrigger     := (·.HasValue .syllabic true))
-    (isTarget      := (·.HasValue .syllabic true))
-    (isTransparent := (λ _ => false))
-    (direction     := .rightward)
+    (isTrigger     := fun s => (s .back).isSome)
+    (isTarget      := fun s => s.HasValue .syllabic true && (s .back).isNone)
+    (isTransparent := fun s => (s .back).isNone && !s.HasValue .syllabic true)
 
-/-- Labial harmony: [round] spreads from the last stem vowel to high suffix
-    vowels only. Every vowel triggers; only [+high] vowels are targets. -/
-def labialHarmony : System Segment :=
+/-- Rounding harmony: a high suffix vowel unspecified for [round] takes the value of the
+preceding vowel; consonants are off the tier (§3.1, §3.2.1). -/
+def rounding : System Segment :=
   System.mk' (feature := .round)
-    (isTrigger     := (·.HasValue .syllabic true))
-    (isTarget      := (λ s => s.HasValue .syllabic true && s.HasValue .high true))
-    (isTransparent := (λ _ => false))
-    (direction     := .rightward)
+    (isTrigger     := fun s => (s .round).isSome)
+    (isTarget      := fun s => s.HasValue .syllabic true && s.HasValue .high true
+                                 && (s .round).isNone)
+    (isTransparent := fun s => !s.HasValue .syllabic true)
 
--- ============================================================================
--- § 3: Archiphoneme Resolution
--- ============================================================================
+/-- Voicing of a suffix-initial `D`: it takes the [voice] of the preceding segment
+(§6.1.2). -/
+def voicing : System Segment :=
+  System.mk' (feature := .voice)
+    (isTrigger     := fun s => (s .voice).isSome)
+    (isTarget      := fun s => (s .voice).isNone)
+    (isTransparent := fun _ => false)
 
-/-- Resolve archiphonemic **A**: twofold alternation a/e controlled by [back].
-    Used for plural -lAr, past -DI, future -(y)AcAK, etc. -/
-def resolveA (back : Bool) : Segment :=
-  if back then a_vowel else e_vowel
-
-/-- Resolve archiphonemic **I**: fourfold alternation ı/i/u/ü
-    controlled by [back] and [round].
-    Used for accusative -(y)I, progressive -Iyor, possessive -(I)m, etc. -/
-def resolveI : Bool → Bool → Segment
-  | true,  false => ı_vowel
-  | false, false => i_vowel
-  | true,  true  => u_vowel
-  | false, true  => ü_vowel
-
--- ============================================================================
--- § 4: Verification
--- ============================================================================
-
--- Back/front classification
-theorem a_is_back : a_vowel.HasValue .back true = true := by decide
-theorem e_is_front : e_vowel.HasValue .back false = true := by decide
-theorem ö_is_front : ö_vowel.HasValue .back false = true := by decide
-theorem u_is_back : u_vowel.HasValue .back true = true := by decide
-
--- Rounding
-theorem ü_is_round : ü_vowel.HasValue .round true = true := by decide
-theorem ı_is_unround : ı_vowel.HasValue .round false = true := by decide
-
--- Height
-theorem i_is_high : i_vowel.HasValue .high true = true := by decide
-theorem a_is_low : a_vowel.HasValue .low true = true := by decide
-
--- Archiphoneme resolution
-theorem resolveA_back : resolveA true = a_vowel := rfl
-theorem resolveA_front : resolveA false = e_vowel := rfl
-theorem resolveI_back_unround : resolveI true false = ı_vowel := rfl
-theorem resolveI_front_round : resolveI false true = ü_vowel := rfl
-theorem resolveI_back_round : resolveI true true = u_vowel := rfl
-theorem resolveI_front_unround : resolveI false false = i_vowel := rfl
-
--- ============================================================================
--- § 5: Harmony System Verification
--- ============================================================================
-
-/-- Palatal harmony extracts [back] from a back-vowel stem. -/
-theorem palatal_back_stem :
-    triggerValue palatalHarmony [a_vowel] = some true := by decide
-
-/-- Palatal harmony extracts [−back] from a front-vowel stem. -/
-theorem palatal_front_stem :
-    triggerValue palatalHarmony [e_vowel] = some false := by decide
-
-/-- Labial harmony extracts [round] from a rounded stem. -/
-theorem labial_round_stem :
-    triggerValue labialHarmony [o_vowel] = some true := by decide
-
-/-- Labial harmony extracts [−round] from an unrounded stem. -/
-theorem labial_unround_stem :
-    triggerValue labialHarmony [ı_vowel] = some false := by decide
-
--- 2D harmony: göz (front, rounded) determines both dimensions
-theorem göz_palatal : triggerValue palatalHarmony [ö_vowel] = some false := by
-  decide
-theorem göz_labial : triggerValue labialHarmony [ö_vowel] = some true := by
-  decide
-
-/-- **OSL transduction harmonizes the suffix** (`System.transduce`, the proved
-    2-OSL function `palatalHarmony.transduce_isLeftOSL`): a [−back] target after
-    a [+back] stem surfaces [+back] — the value propagated from the preceding
-    output segment, the genuine subregular semantics. -/
-theorem palatal_transduce_spreads_back :
-    ((palatalHarmony.transduce [a_vowel, e_vowel])[1]?).bind (fun s => s .back)
-      = some true := by decide
-
--- Cross-backness: a and e disagree on dorsal features
-theorem a_e_dorsal_disagree :
-    agreeAt a_vowel e_vowel .dorsal = false := by decide
-
--- Same-backness: a and o agree on [back]
-theorem a_o_same_back :
-    a_vowel.HasValue .back true = true ∧
-    o_vowel.HasValue .back true = true := ⟨by decide, by decide⟩
+/-- The surface form of a suffixed word: the three alternations applied in turn. -/
+def surface (w : List Segment) : List Segment :=
+  voicing.transduceWord (rounding.transduceWord (fronting.transduceWord w))
 
 end Turkish.VowelHarmony

--- a/Linglib/Morphology/Morphotactics/Template.lean
+++ b/Linglib/Morphology/Morphotactics/Template.lean
@@ -27,6 +27,7 @@ prefix/suffix split encoding a morpheme's position relative to the verb stem.
 ## Main definitions
 
 * `Morphology.AffixTemplate` — a word's prefix/suffix slots over an arbitrary slot type.
+* `Morphology.AffixTemplate.Licenses` — the affix strings a template admits.
 -/
 
 namespace Morphology
@@ -41,5 +42,21 @@ structure AffixTemplate (Slot : Type*) where
   /-- Suffix slots, ordered stem-outward (innermost suffix first). -/
   suffixSlots : List Slot := []
   deriving Repr, DecidableEq
+
+namespace AffixTemplate
+
+variable {Slot : Type*} [DecidableEq Slot] (t : AffixTemplate Slot)
+
+open List in
+/-- A word's affixes are licensed by the template when its prefix and suffix slot
+sequences are sublists of the template's: each slot filled at most once, in template
+order. -/
+def Licenses (pre suf : List Slot) : Prop :=
+  pre <+ t.prefixSlots ∧ suf <+ t.suffixSlots
+
+instance (pre suf : List Slot) : Decidable (t.Licenses pre suf) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+end AffixTemplate
 
 end Morphology

--- a/Linglib/Phonology/Subregular/Harmony.lean
+++ b/Linglib/Phonology/Subregular/Harmony.lean
@@ -213,6 +213,23 @@ theorem System.transduce_isLeftOSL :
     IsLeftOutputStrictlyLocal 2 sys.transduce :=
   sys.spreadRule.isLeftOutputStrictlyLocal_apply
 
+/-- The harmonized word: `transduce` run over the pattern's tier (`Pattern.OnTier`), with
+off-tier segments copied through — the tier-based strictly local function of
+[burness-mcmullin-2020] whose restriction to the tier is the 2-OSL `transduce`
+(`System.tier_transduceWord`). -/
+def System.transduceWord : List α → List α :=
+  sys.spreadRule.applyOnTier sys.pattern.OnTier
+
+/-- On the tier, `transduceWord` is `transduce`, provided the write keeps a segment on the
+tier. -/
+theorem System.tier_transduceWord
+    (hw : ∀ v s, sys.pattern.OnTier s → sys.pattern.OnTier (sys.write v s)) (w : List α) :
+    sys.pattern.tier (sys.transduceWord w) = sys.transduce (sys.pattern.tier w) :=
+  sys.spreadRule.filter_applyOnTier (fun _ s hs y hy => by
+    simp only [System.spreadRule] at hy
+    split_ifs at hy <;> (try split at hy) <;> (try split at hy) <;>
+      simp only [List.mem_singleton] at hy <;> subst hy <;> first | exact hs | exact hw _ _ hs) w
+
 /-! ### Properties -/
 
 variable {sys val}

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -103,6 +103,68 @@ def apply (r : OSLRule k α β) (input : List α) : List β :=
   show r.windowOutput [] x ++ r.applyAux _ [] = r.windowOutput [] x
   exact List.append_nil _
 
+/-! ### Application over a tier -/
+
+/-- Auxiliary for `applyOnTier`: thread the output window through the tier only. -/
+def applyOnTierAux (r : OSLRule k α α) (p : α → Prop) [DecidablePred p] :
+    (outputWindow : List α) → (rest : List α) → List α
+  | _, [] => []
+  | outputWindow, x :: xs =>
+    if p x then
+      r.windowOutput outputWindow x
+        ++ applyOnTierAux r p ((outputWindow ++ r.windowOutput outputWindow x).rtake (k - 1)) xs
+    else x :: applyOnTierAux r p outputWindow xs
+
+/-- Apply the rule over the tier `p`: symbols off the tier are copied through and never
+enter the output window, so each on-tier output block depends on the last `k - 1`
+on-tier output symbols — the single-tier case of the tier-based strictly local functions
+of [burness-mcmullin-2020]. Over the total tier this is `apply` (`applyOnTier_true`). -/
+def applyOnTier (r : OSLRule k α α) (p : α → Prop) [DecidablePred p] (input : List α) :
+    List α :=
+  r.applyOnTierAux p [] input
+
+section Tier
+
+variable {p : α → Prop} [DecidablePred p] (r : OSLRule k α α)
+
+@[simp] lemma applyOnTierAux_nil (outputWindow : List α) :
+    r.applyOnTierAux p outputWindow [] = [] := rfl
+
+lemma applyOnTierAux_cons (outputWindow : List α) (x : α) (xs : List α) :
+    r.applyOnTierAux p outputWindow (x :: xs) =
+      if p x then
+        r.windowOutput outputWindow x
+          ++ r.applyOnTierAux p ((outputWindow ++ r.windowOutput outputWindow x).rtake (k - 1)) xs
+      else x :: r.applyOnTierAux p outputWindow xs := rfl
+
+@[simp] lemma applyOnTier_nil : r.applyOnTier p [] = [] := rfl
+
+/-- Over the total tier, `applyOnTier` is `apply`. -/
+theorem applyOnTier_true : r.applyOnTier (fun _ => True) = r.apply := by
+  funext l
+  suffices ∀ w, r.applyOnTierAux (fun _ => True) w l = r.applyAux w l from this []
+  induction l with
+  | nil => exact fun _ => rfl
+  | cons x xs ih => exact fun w => by simp [applyOnTierAux_cons, ih]
+
+/-- Restricted to the tier, `applyOnTier` is `apply` on the tier's projection, provided the
+rule keeps on-tier input on the tier. -/
+theorem filter_applyOnTier (hr : ∀ w x, p x → ∀ y ∈ r.windowOutput w x, p y) (l : List α) :
+    (r.applyOnTier p l).filter (decide <| p ·) = r.apply (l.filter (decide <| p ·)) := by
+  suffices ∀ w, (r.applyOnTierAux p w l).filter (decide <| p ·) =
+      r.applyAux w (l.filter (decide <| p ·)) from this []
+  induction l with
+  | nil => exact fun _ => rfl
+  | cons x xs ih =>
+    intro w
+    by_cases hx : p x
+    · have h : (r.windowOutput w x).filter (decide <| p ·) = r.windowOutput w x :=
+        List.filter_eq_self.2 fun y hy => decide_eq_true (hr w x hx y hy)
+      simp [applyOnTierAux_cons, hx, List.filter_append, h, ih]
+    · simp [applyOnTierAux_cons, hx, ih]
+
+end Tier
+
 end OSLRule
 
 /-- A function `f : List α → List β` is **k-Left-Output-Strictly-Local**

--- a/Linglib/Studies/GokselKerslake2005.lean
+++ b/Linglib/Studies/GokselKerslake2005.lean
@@ -1,123 +1,141 @@
-import Linglib.Semantics.Tense.Evidential
 import Linglib.Fragments.Turkish.TAM
-import Linglib.Fragments.Turkish.SuffixTemplate
 import Linglib.Fragments.Turkish.VowelHarmony
 
 /-!
-# Göksel & Kerslake 2005: Turkish Evidential TAM
-[goksel-kerslake-2005] [cumming-2026]
+# Göksel and Kerslake (2005): Turkish suffixation
 
-Bridge between Turkish TAM data and [cumming-2026]'s (S, A, T) evidential
-framework. The key prediction: Turkish -DI and -mIş differ in their
-**evidential perspective constraint** (EPCondition), not primarily in their
-temporal (UPCondition) constraint.
+The reference grammar's account of the form and order of Turkish suffixes, checked
+against the Turkish Fragment. Chapter 3's vowel harmony is derived by the alternations
+of `Turkish.VowelHarmony` from archiphonemic suffixes: the permissible vowel sequences
+of §3.1 are the A-type and I-type resolutions, the last vowel of a disharmonic loan
+decides (*otobüs-ler*), an invariant suffix vowel is skipped and re-triggers
+(*görüyorum*, §3.4), and the palatal l of *gol* fronts its suffix (§3.4). Chapter 8's
+suffix order is licensing by the templates of `Turkish.SuffixTemplate`: the grammar's
+example verbs and nominals are licensed, reversed orders are not, and its rule that
+markers of one position cannot co-occur (§8.2.3) is the template's having no repeated
+slot.
 
-## The -DI / -mIş contrast
+## Main results
 
-- **-DI** (past definite): speaker directly witnessed the event. Evidence
-  was acquired contemporaneously with the event (A overlaps T).
-  EPCondition: `contemporaneous`.
+* `followers_table`: the §3.1 table of permissible vowel sequences.
+* `retriggering`, `palatal_l`: the §3.4 exceptions to harmony, derived rather than listed.
+* `same_position_excluded`: §8.2.3 (i) from `List.nodup_iff_sublist`.
 
-- **-mIş** (evidential): speaker did not witness the event. Evidence
-  was acquired strictly after the event (A > T).
-  EPCondition: `strictDownstream`.
+## References
 
-Both share the same utterance perspective: past (T < S). The evidential
-dimension is what distinguishes them — a prediction from the (S, A, T)
-framework applied to Turkish.
+* [A. Göksel and C. Kerslake, *Turkish: A Comprehensive Grammar* (2005)][goksel-kerslake-2005]
 -/
 
 namespace GokselKerslake2005
 
-open Tense.Evidential
-open Turkish.TAM
+open Turkish.VowelHarmony Turkish.SuffixTemplate Turkish.TAM
+open Phonology (Segment)
 
--- ============================================================================
--- § 1: EP/UP assignments for Turkish TAM
--- ============================================================================
+/-! ### Vowel harmony (Chapter 3) -/
 
-/-- Turkish -DI (witnessed past): contemporaneous evidence acquisition.
-    The speaker was present at the time of the event. -/
-def diEP : EPCondition := .contemporaneous
+/-- The vowels that may follow `v` in a suffix: its A-type and I-type resolutions. -/
+def followers (v : Segment) : List Segment :=
+  [A, I].map fun x => (surface [v, x]).getLastD x
 
-/-- Turkish -mIş (indirect/reportative): strictly downstream evidence.
-    The speaker learned about the event after it occurred. -/
-def mişEP : EPCondition := .strictDownstream
-
-/-- Both -DI and -mIş are past tense: T < S. -/
-def diUP : UPCondition := .past
-def mişUP : UPCondition := .past
-
--- ============================================================================
--- § 2: Predictions
--- ============================================================================
-
-/-- -DI and -mIş share temporal constraint but differ in evidential perspective. -/
-theorem same_tense_different_evidence :
-    diUP = mişUP ∧ diEP ≠ mişEP := by
-  exact ⟨rfl, by decide⟩
-
-/-- -DI is the only category with contemporaneous EP (direct witness). -/
-theorem di_unique_direct : diEP = .contemporaneous := rfl
-
-/-- -mIş EP is strictly downstream — evidence comes after the event. -/
-theorem miş_indirect : mişEP = .strictDownstream := rfl
-
--- ============================================================================
--- § 3: The suffix template (Ch 6, 8, 13-14)
--- ============================================================================
-
-/-! Ordering predictions derived from the Fragment templates
-(`Turkish.SuffixTemplate.verbTemplate`/`nounTemplate`), checked as
-slot-position facts rather than re-typed rank tables. -/
-
-open Turkish.SuffixTemplate
-
-/-- The verbal template has a single TAM slot, so -DI and -mIş — both
-TAM-category suffixes — are in complementary distribution: a simplex
-verb form cannot carry both. -/
-theorem tam_slot_unique :
-    verbTemplate.suffixSlots.count .tam = 1 := by decide
-
-/-- Negation strictly precedes TAM in the template, matching the surface
-order stem-NEG-TAM: every symmetric negative in the TAM inventory spells
-NEG before the TAM suffix (gel-**me**-**di** 'come-NEG-PST'). -/
-theorem negation_precedes_tam :
-    verbTemplate.suffixSlots.idxOf .negation < verbTemplate.suffixSlots.idxOf .tam ∧
-    ∀ e ∈ entries, e.isNegSymmetric → e.negSuffix.data.take 2 = ['-', 'm'] := by decide
-
-/-- The question particle mI fills the outermost verbal slot, following
-agreement: gel-di-**m** **mi**? (come-PST-1SG Q). -/
-theorem question_is_outermost :
-    ∀ s ∈ verbTemplate.suffixSlots,
-      verbTemplate.suffixSlots.idxOf s ≤ verbTemplate.suffixSlots.idxOf .question := by
+/-- §3.1: the permissible vowel sequences, as the grammar tabulates them. -/
+theorem followers_table :
+    followers a = [a, ı] ∧ followers ı = [a, ı] ∧ followers o = [a, u] ∧ followers u = [a, u] ∧
+    followers e = [e, i] ∧ followers i = [e, i] ∧ followers ö = [e, ü] ∧ followers ü = [e, ü] := by
   decide
 
-/-- Nominal ordering: plural before possessive before case
-(ev-**ler**-**im**-**de** 'house-PL-1SG.POSS-LOC'). -/
-theorem noun_slot_order :
-    nounTemplate.suffixSlots.idxOf .plural < nounTemplate.suffixSlots.idxOf .possessive ∧
-    nounTemplate.suffixSlots.idxOf .possessive < nounTemplate.suffixSlots.idxOf .case := by
+/-- §3.2.1: the second-person possessive -(I)n on *kız*, *el*, *kol* and *göz*. -/
+theorem iType :
+    surface ([k, ı, z] ++ possessive2sg) = [k, ı, z, ı, n] ∧
+    surface ([e, l] ++ possessive2sg) = [e, l, i, n] ∧
+    surface ([k, o, l] ++ possessive2sg) = [k, o, l, u, n] ∧
+    surface ([g, ö, z] ++ possessive2sg) = [g, ö, z, ü, n] := by
   decide
 
--- ============================================================================
--- § 4: Vowel harmony resolves TAM suffix vowels
--- ============================================================================
+/-- Chapter 3: the last vowel of a stem decides, so the disharmonic loan *otobüs* takes
+*-ler*. -/
+theorem last_vowel_decides :
+    surface ([o, t, o, b, ü, s] ++ plural) = [o, t, o, b, ü, s, l, e, r] := by
+  decide
 
-open Turkish.VowelHarmony
+/-- §3.2: *üz-ül-dü-nüz* 'you became sad' — rounding copied through three suffixes, and
+the `D` of -DI voiced after `l`. -/
+theorem iterated :
+    surface ([ü, z] ++ passive ++ perfective ++ person2pl) = [ü, z, ü, l, d, ü, n, ü, z] := by
+  decide
 
-/-- The archiphonemic I in progressive -Iyor resolves to 4 surface vowels
-by stem harmony: kol → -ıyor, gel → -iyor, kork → -uyor, göz → -üyor. -/
-theorem progressive_I_resolution :
-    resolveI true  false = ı_vowel ∧
-    resolveI false false = i_vowel ∧
-    resolveI true  true  = u_vowel ∧
-    resolveI false true  = ü_vowel := ⟨rfl, rfl, rfl, rfl⟩
+/-- §3.4 (vi): the `o` of -(I)yor does not harmonize and triggers the person marker,
+*gör-üyor-um*; the invariable -(y)ken, *bak-mış-ken*. -/
+theorem retriggering :
+    surface ([g, ö, r] ++ imperfective ++ person1sg) = [g, ö, r, ü, y, o, r, u, m] ∧
+    surface ([b, a, k] ++ evidential ++ ken) = [b, a, k, m, ı, ş, k, e, n] := by
+  decide
 
-/-- The archiphonemic A in future -(y)AcAK resolves to a/e by palatal
-harmony: kol → -(y)acak, gel → -(y)ecek. -/
-theorem future_A_resolution :
-    resolveA true  = a_vowel ∧
-    resolveA false = e_vowel := ⟨rfl, rfl⟩
+/-- §3.4 (iv): the palatal l of *gol* and *hal* fronts the suffix, *gol-ü* and *hal-im*,
+while rounding still comes from the vowel. -/
+theorem palatal_l :
+    surface ([g, o, l'] ++ possessive3sg) = [g, o, l', ü] ∧
+    surface ([h, a, l'] ++ possessive1sg) = [h, a, l', i, m] := by
+  decide
+
+/-- §6.1.2: the `D` of -DI is `d` after a voiced segment and `t` after a voiceless one,
+*kal-dı* and *düş-tü*. -/
+theorem voicing_of_D :
+    surface ([k, a, l] ++ perfective) = [k, a, l, d, ı] ∧
+    surface ([d, ü, ş] ++ perfective) = [d, ü, ş, t, ü] := by
+  decide
+
+/-- §8.2.2: before -(I)yor the negative's vowel is raised and harmonizes as an I-type
+suffix, *anla-m-ıyor* and *gör-m-üyor*. -/
+theorem negative_raised :
+    surface ([a, n, l, a] ++ [m, I] ++ [y, o, r]) = [a, n, l, a, m, ı, y, o, r] ∧
+    surface ([g, ö, r] ++ [m, I] ++ [y, o, r]) = [g, ö, r, m, ü, y, o, r] := by
+  decide
+
+/-- §8.1 (2) *Ev-ler-imiz-de-ymiş-ler* 'apparently they are at our homes': the nominal
+string with the evidential copula and a person marker. -/
+theorem nominal_predicate :
+    surface ([e, v] ++ plural ++ possessive1pl ++ locative ++ evidentialCopula ++ plural) =
+      [e, v, l, e, r, i, m, i, z, d, e, y, m, i, ş, l, e, r] := by
+  decide
+
+/-! ### The order of suffixes (Chapters 6 and 8) -/
+
+/-- §8.1 (1) *çocuk-lar-ın-a* 'to your children' and §6.3 (2) *diz-ge-ler-im-de* 'on my
+lists': number - possession - case, after a derivational suffix. -/
+theorem nominal :
+    nounTemplate.Licenses [] [.number, .possession, .case] ∧
+    nounTemplate.Licenses [] [.derivational, .number, .possession, .case] := by
+  decide
+
+/-- §8.2 (7) *Döğ-üş-tür-t-ül-me-yebil-iyor-muş-sunuz-dur*: every slot of the finite verb,
+the voice slot filled by four stacked voice suffixes. -/
+theorem finite_verb :
+    verbTemplate.Licenses []
+      [.voice, .negation, Marker.abil.slot, Marker.iyor.slot, Marker.evidentialCopula.slot,
+        .person, .generalizing] := by
+  decide
+
+/-- §8.2.3 (11) *Bitir-e-me-miş-tir*, (12) *Oku-yabil-ecek-miş* and §8.2.3.3 *git-ti-ydi-n*:
+positions 1-3-5, 2-3-4 and 3-4 with a person marker. -/
+theorem tam_positions :
+    verbTemplate.Licenses []
+      [Marker.possibility.slot, .negation, Marker.miş.slot, Marker.dir.slot] ∧
+    verbTemplate.Licenses [] [Marker.abil.slot, Marker.acak.slot, Marker.evidentialCopula.slot] ∧
+    verbTemplate.Licenses [] [Marker.di.slot, Marker.pastCopula.slot, .person] := by
+  decide
+
+/-- The negative follows voice and precedes the tense/aspect/modality marker (§8.2.2), and
+the copular markers follow it (§8.2.3): the reversed orders are unlicensed. -/
+theorem reversed_orders :
+    ¬ verbTemplate.Licenses [] [.negation, .voice] ∧
+    ¬ verbTemplate.Licenses [] [.tam, .negation] ∧
+    ¬ verbTemplate.Licenses [] [.copula, .tam] := by
+  decide
+
+/-- §8.2.3 (i): markers of one position cannot co-occur — the template has no repeated
+slot. -/
+theorem same_position_excluded (m₁ m₂ : Marker) (h : m₁.slot = m₂.slot) :
+    ¬ verbTemplate.Licenses [] [m₁.slot, m₂.slot] :=
+  fun ⟨_, hs⟩ => List.nodup_iff_sublist.1 (by decide) _ (h ▸ hs)
 
 end GokselKerslake2005

--- a/references.bib
+++ b/references.bib
@@ -22802,7 +22802,7 @@
   doi       = {10.1515/9783112423325-007},
   subfield  = {phonology},
   role      = {background},
-  sources   = {Studies/SandeClemDabkowski2026.lean}
+  sources   = {Studies/SandeClemDabkowski2026.lean;Fragments/Turkish/VowelHarmony.lean}
 }
 
 @article{clements-1985,
@@ -36806,7 +36806,7 @@
   url       = {https://aclanthology.org/2020.sigmorphon-1.29/},
   subfield  = {phonology/autosegmental},
   role      = {cited},
-  sources   = {}
+  sources   = {Phonology/Subregular/OSL.lean;Phonology/Subregular/Harmony.lean}
 }
 
 % REF: Bhaskar, Chandlee, Jardine, Oakden (2020). Boolean monadic


### PR DESCRIPTION
Rebuild the Göksel and Kerslake 2005 study on the grammar's own content, verified against the book.

- Drop the Cumming 2026 (S, A, T) bridge (a 2005 study cannot cite 2026, and its -DI/-mIş EP constants contradicted `Turkish.Evidentiality`) and the `rfl`/`decide` restatements of Fragment data.
- Turkish vowel harmony now derives the grammar's forms: archiphonemic suffix vowels, targets are the vowels lacking the feature, invariant vowels re-trigger, palatal l fronts, D-voicing. Substrate: `OSLRule.applyOnTier` and `System.transduceWord` (tier-restricted 2-OSL, with `tier_transduceWord`).
- `AffixTemplate.Licenses` (sublist licensing); the Turkish verb template recut to §8.2's slots; TAM markers as the §8.2.3 position table with a `slot` hom.