### PR TITLE
feat(Morphology/Morphotactics): position-class systems for Turkish

### DIFF
--- a/Linglib/Fragments/Turkish/Morphotactics.lean
+++ b/Linglib/Fragments/Turkish/Morphotactics.lean
@@ -1,4 +1,6 @@
 import Linglib.Morphology.Morphotactics.Template
+import Linglib.Syntax.Agreement.Paradigm
+import Linglib.Fragments.Turkish.VowelHarmony
 
 /-!
 # Turkish morphotactics
@@ -11,32 +13,43 @@ positions (§8.2.3): the possibility suffix -(y)A (1), which precedes the negati
 (§8.2.3.1), the bound auxiliaries (2), the markers of tense, aspect and modality proper
 (3), the copular markers (4) and -DIr (5). Markers of one position cannot co-occur, and
 every finite verb but the imperative and the third-person optative carries one of
-position 3. The inflectional suffixes of a nominal appear in the order number -
-possession - case (§8.1). Both templates are `Morphology.AffixTemplate`s: the voice slot
-is a position class, filled by up to four stacked voice suffixes (§8.2 (7)), and the
-clitics mI and dA, which can interrupt the inflectional string (§6.3 (5)), are Chapter 11
-material outside them. The markers' meanings are the matter of Chapter 21 and Appendix 2:
--DI marks past tense, perfective aspect and direct knowledge, -mIş relative past tense,
-perfective aspect and indirect knowledge (evidential modality, §21.4.3), the copular
--(y)mIş evidential modality alone; -mIş followed by a copular marker or -DIr is
-perfective only (§8.2.3.3). Negation of the aorist is irregular, -mAz for -(A/I)r
-(§8.2.2; see `Turkish.Negation`). The grammar's examples are checked against the
-templates in `Studies/GokselKerslake2005.lean`.
+position 3; the voice slot alone admits a sequence of suffixes, up to four (§8.2 (7),
+§8.2.1.1). The inflectional suffixes of a nominal appear in the order number -
+possession - case (§8.1). The finite verb and the nominal are each a
+`Morphology.PositionClassSystem`: a slot inventory, its template, and the exponents of
+each slot, with the person markers (§8.4) and the possessives (§8.1.2) as
+`Agreement.Paradigm`s. The clitics mI and dA, which can interrupt the inflectional string
+(§6.3 (5)), are Chapter 11 material outside both systems. The markers' meanings are the
+matter of Chapter 21 and Appendix 2: -DI marks past tense, perfective aspect and direct
+knowledge, -mIş relative past tense, perfective aspect and indirect knowledge (evidential
+modality, §21.4.3), the copular -(y)mIş evidential modality alone; -mIş followed by a
+copular marker or -DIr is perfective only (§8.2.3.3). Negation of the aorist is
+irregular, -mAz for -(A/I)r (§8.2.2; see `Turkish.Negation`). The grammar's examples are
+checked against both systems in `Studies/GokselKerslake2005.lean`.
 
 ## Main definitions
 
-* `VerbSlot`, `NounSlot`, `verbTemplate`, `nounTemplate` — the slot inventories and templates.
-* `Marker`, `Marker.slot` — the tense/aspect/modality markers by position.
+* `Turkish.Verb.Slot`, `Turkish.Verb.Exponent`, `Turkish.Verb.system` — the finite verb.
+* `Turkish.Nominal.Slot`, `Turkish.Nominal.Exponent`, `Turkish.Nominal.system` — the nominal.
+* `Exponent.form` — each exponent's form after a consonant-final stem, as segments.
 
 ## References
 
 * [A. Göksel and C. Kerslake, *Turkish: A Comprehensive Grammar* (2005)][goksel-kerslake-2005]
 -/
 
-namespace Turkish.Morphotactics
+open Phonology (Segment)
+
+namespace Turkish
+
+open Turkish.Phonology
+
+/-! ### The finite verb -/
+
+namespace Verb
 
 /-- The suffix slots of a finite verb (§8.2, §8.2.3). -/
-inductive VerbSlot where
+inductive Slot where
   /-- Causative, passive, reflexive and reciprocal (§8.2.1). -/
   | voice
   /-- The possibility suffix -(y)A of negative forms, position 1 (§8.2.3.1). -/
@@ -57,70 +70,181 @@ inductive VerbSlot where
   | generalizing
   deriving DecidableEq, Repr
 
-/-- The suffix slots of a nominal (§6.3, §8.1). -/
-inductive NounSlot where
-  | derivational
+/-- The person-marker groups of §8.4: group 1 after -DI, -sA and the copular markers -(y)DI
+and -(y)sA; group 2 after the other position-3 markers, the copular -(y)mIş and nominal
+predicates. The optative and imperative groups 3 and 4 are not represented. -/
+inductive PersonGroup where
+  | one
+  | two
+  deriving DecidableEq, Repr
+
+/-- The person markers of group 1 (§8.4); the second-person plural is also the formal
+singular, and the third-person singular is zero. -/
+def PersonGroup.one.paradigm : Agreement.Paradigm (List Segment) :=
+  [(.pn .first .Sing, [m]), (.pn .second .Sing, [n]), (.pn .third .Sing, []),
+   (.pn .first .Plur, [k]), (.pn .second .Plur, [n, I, z]), (.pn .third .Plur, [l, A, r])]
+
+/-- The person markers of group 2 (§8.4). -/
+def PersonGroup.two.paradigm : Agreement.Paradigm (List Segment) :=
+  [(.pn .first .Sing, [I, m]), (.pn .second .Sing, [s, I, n]), (.pn .third .Sing, []),
+   (.pn .first .Plur, [I, z]), (.pn .second .Plur, [s, I, n, I, z]),
+   (.pn .third .Plur, [l, A, r])]
+
+/-- The paradigm of a person-marker group. -/
+def PersonGroup.paradigm : PersonGroup → Agreement.Paradigm (List Segment)
+  | .one => PersonGroup.one.paradigm
+  | .two => PersonGroup.two.paradigm
+
+/-- The exponents of each slot (§8.2.1 to §8.4). -/
+inductive Exponent : Slot → Type where
+  /-- -(I)ş (§8.2.1.4). -/
+  | reciprocal : Exponent .voice
+  /-- -(I)n (§8.2.1.3). -/
+  | reflexive : Exponent .voice
+  /-- -DIr, with the stem-conditioned allomorphs -t, -It, -Ir, -Ar and -Art (§8.2.1.1). -/
+  | causative : Exponent .voice
+  /-- -Il, with -In after `l` and -n after a vowel (§8.2.1.2). -/
+  | passive : Exponent .voice
+  /-- -(y)A, possibility; negative forms only (§8.2.3.1). -/
+  | possibility : Exponent .possibility
+  /-- -mA (§8.2.2). -/
+  | negative : Exponent .negation
+  /-- -(y)Abil, possibility (§8.2.3.2). -/
+  | abil : Exponent .auxiliary
+  /-- -(y)Iver, non-premeditative. -/
+  | iver : Exponent .auxiliary
+  | agel : Exponent .auxiliary
+  | ayaz : Exponent .auxiliary
+  | akal : Exponent .auxiliary
+  | adur : Exponent .auxiliary
+  /-- -DI, perfective (§8.2.3.3). -/
+  | di : Exponent .tam
+  /-- -mIş, perfective/evidential. -/
+  | miş : Exponent .tam
+  /-- -sA, conditional. -/
+  | sa : Exponent .tam
+  /-- -(A/I)r, negative -z. -/
+  | aorist : Exponent .tam
+  /-- -(y)AcAK, future. -/
+  | acak : Exponent .tam
+  /-- -(I)yor, imperfective. -/
+  | iyor : Exponent .tam
+  /-- -mAlI, obligative. -/
+  | mali : Exponent .tam
+  /-- -mAktA, imperfective. -/
+  | makta : Exponent .tam
+  /-- -(y)A, optative. -/
+  | optative : Exponent .tam
+  /-- -(y)DI, past copula (§8.3.2). -/
+  | pastCopula : Exponent .copula
+  /-- -(y)mIş, evidential copula. -/
+  | evidentialCopula : Exponent .copula
+  /-- -(y)sA, conditional copula. -/
+  | conditionalCopula : Exponent .copula
+  /-- A person marker: the cell of a group's paradigm (§8.4). -/
+  | person (group : PersonGroup) (cell : Agreement.Cell) : Exponent .person
+  /-- -DIr, generalizing modality (§8.3.3). -/
+  | dir : Exponent .generalizing
+  deriving DecidableEq
+
+variable {σ : Slot}
+
+/-- The form of an exponent after a consonant-final stem; the deletable vowels and buffer
+`y` of §6.1.3 and the stem-conditioned allomorphs of §8.2.1 are not represented, and a
+person cell outside its group's paradigm has no form. -/
+def Exponent.form : Exponent σ → List Segment
+  | .reciprocal => [I, ş]
+  | .reflexive => [I, n]
+  | .causative => [D, I, r]
+  | .passive => [I, l]
+  | .possibility => [A]
+  | .negative => [m, A]
+  | .abil => [A, b, i, l]
+  | .iver => [I, v, e, r]
+  | .agel => [A, g, e, l]
+  | .ayaz => [A, y, a, z]
+  | .akal => [A, k, a, l]
+  | .adur => [A, d, u, r]
+  | .di => [D, I]
+  | .miş => [m, I, ş]
+  | .sa => [s, A]
+  | .aorist => [I, r]
+  | .acak => [A, c, A, K]
+  | .iyor => [I, y, o, r]
+  | .mali => [m, A, l, I]
+  | .makta => [m, A, k, t, A]
+  | .optative => [A]
+  | .pastCopula => [D, I]
+  | .evidentialCopula => [m, I, ş]
+  | .conditionalCopula => [s, A]
+  | .person g c => (g.paradigm.realize c).getD []
+  | .dir => [D, I, r]
+
+/-- The finite verb: its slots in the order of §8.2, the voice slot iterable. -/
+def system : Morphology.PositionClassSystem where
+  Slot := Slot
+  template :=
+    { suffixSlots :=
+        [.voice, .possibility, .negation, .auxiliary, .tam, .copula, .person, .generalizing] }
+  Exponent := Exponent
+  Iterable := (· = .voice)
+
+end Verb
+
+/-! ### The nominal -/
+
+namespace Nominal
+
+/-- The inflectional suffix slots of a nominal (§8.1). -/
+inductive Slot where
   | number
   | possession
   | case
   deriving DecidableEq, Repr
 
-/-- The finite-verb template, stem-outward (§8.2). -/
-def verbTemplate : Morphology.AffixTemplate VerbSlot where
-  suffixSlots :=
-    [.voice, .possibility, .negation, .auxiliary, .tam, .copula, .person, .generalizing]
+/-- The possessive suffixes (§8.1.2); the second-person plural is also the formal singular,
+and the third-person forms lose their final `n` word-finally. -/
+def possessives : Agreement.Paradigm (List Segment) :=
+  [(.pn .first .Sing, [I, m]), (.pn .second .Sing, [I, n]), (.pn .third .Sing, [I]),
+   (.pn .first .Plur, [I, m, I, z]), (.pn .second .Plur, [I, n, I, z]),
+   (.pn .third .Plur, [l, A, r, I])]
 
-/-- The nominal template, stem-outward (§8.1). -/
-def nounTemplate : Morphology.AffixTemplate NounSlot where
-  suffixSlots := [.derivational, .number, .possession, .case]
+/-- The exponents of each slot (§8.1.1 to §8.1.3). -/
+inductive Exponent : Slot → Type where
+  /-- -lAr (§8.1.1). -/
+  | plural : Exponent .number
+  /-- A possessive suffix: a cell of `possessives` (§8.1.2). -/
+  | possessive (cell : Agreement.Cell) : Exponent .possession
+  /-- -(y)I. -/
+  | accusative : Exponent .case
+  /-- -(y)A. -/
+  | dative : Exponent .case
+  /-- -DA. -/
+  | locative : Exponent .case
+  /-- -DAn. -/
+  | ablative : Exponent .case
+  /-- -(n)In. -/
+  | genitive : Exponent .case
+  deriving DecidableEq
 
-/-- The tense/aspect/modality markers of §8.2.3, by position. -/
-inductive Marker where
-  /-- -(y)A, possibility; position 1, negative forms only. -/
-  | possibility
-  /-- -(y)Abil, possibility; position 2. -/
-  | abil
-  /-- -(y)Iver, non-premeditative. -/
-  | iver
-  | agel
-  | ayaz
-  | akal
-  | adur
-  /-- -DI, perfective; position 3. -/
-  | di
-  /-- -mIş, perfective/evidential. -/
-  | miş
-  /-- -sA, conditional. -/
-  | sa
-  /-- -(A/I)r, negative -z. -/
-  | aorist
-  /-- -(y)AcAK, future. -/
-  | acak
-  /-- -(I)yor, imperfective. -/
-  | iyor
-  /-- -mAlI, obligative. -/
-  | mali
-  /-- -mAktA, imperfective. -/
-  | makta
-  /-- -(y)A, optative. -/
-  | optative
-  /-- -(y)DI, past copula; position 4. -/
-  | pastCopula
-  /-- -(y)mIş, evidential copula. -/
-  | evidentialCopula
-  /-- -(y)sA, conditional copula. -/
-  | conditionalCopula
-  /-- -DIr, generalizing modality; position 5. -/
-  | dir
-  deriving DecidableEq, Repr
+variable {σ : Slot}
 
-/-- The template slot of a marker: positions 1 to 5 are the slots `possibility`,
-`auxiliary`, `tam`, `copula` and `generalizing`. -/
-def Marker.slot : Marker → VerbSlot
-  | .possibility => .possibility
-  | .abil | .iver | .agel | .ayaz | .akal | .adur => .auxiliary
-  | .di | .miş | .sa | .aorist | .acak | .iyor | .mali | .makta | .optative => .tam
-  | .pastCopula | .evidentialCopula | .conditionalCopula => .copula
-  | .dir => .generalizing
+/-- The form of an exponent after a consonant-final stem (§6.1.3 as for the verb). -/
+def Exponent.form : Exponent σ → List Segment
+  | .plural => [l, A, r]
+  | .possessive c => (possessives.realize c).getD []
+  | .accusative => [I]
+  | .dative => [A]
+  | .locative => [D, A]
+  | .ablative => [D, A, n]
+  | .genitive => [I, n]
 
-end Turkish.Morphotactics
+/-- The nominal: number - possession - case (§8.1). -/
+def system : Morphology.PositionClassSystem where
+  Slot := Slot
+  template := { suffixSlots := [.number, .possession, .case] }
+  Exponent := Exponent
+
+end Nominal
+
+end Turkish

--- a/Linglib/Fragments/Turkish/VowelHarmony.lean
+++ b/Linglib/Fragments/Turkish/VowelHarmony.lean
@@ -23,7 +23,8 @@ are derived in `Studies/GokselKerslake2005.lean`.
 
 * `a`, `e`, `ı`, `i`, `o`, `ö`, `u`, `ü` — the vowels; `A`, `I` — the suffix archiphonemes.
 * `fronting`, `rounding`, `voicing` — the two vowel harmonies and D-voicing.
-* `surface` — the three alternations applied to a word.
+* `surface` — the three alternations applied to a word; the suffixes it applies to are the
+  exponent forms of `Turkish.Morphotactics`.
 
 ## References
 
@@ -84,6 +85,11 @@ def k : Segment := consonant [(.consonantal, true), (.sonorant, false), (.contin
   (.dorsal, true), (.voice, false)]
 def g : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
   (.dorsal, true), (.voice, true)]
+/-- The final K of -(y)AcAK: `k`, or `ğ` before a vowel (Chapter 2). -/
+def K : Segment := consonant [(.consonantal, true), (.sonorant, false), (.dorsal, true),
+  (.voice, false)]
+def c : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, false),
+  (.delayedRelease, true), (.coronal, true), (.anterior, false), (.voice, true)]
 def s : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
   (.strident, true), (.coronal, true), (.anterior, true), (.voice, false)]
 def z : Segment := consonant [(.consonantal, true), (.sonorant, false), (.continuant, true),
@@ -108,42 +114,6 @@ def r : Segment := consonant [(.consonantal, true), (.sonorant, true), (.tap, tr
   (.coronal, true), (.voice, true)]
 def y : Segment := consonant [(.consonantal, false), (.sonorant, true), (.approximant, true),
   (.continuant, true), (.voice, true)]
-
-/-! ### Suffixes
-
-Citation forms after a consonant-final stem; the deletable vowels and buffer `y` of
-§6.1.3 are not represented. -/
-
-/-- -lAr, plural (§8.1.1). -/
-def plural : List Segment := [l, A, r]
-/-- -(I)m, first-person singular possessive (§8.1.2). -/
-def possessive1sg : List Segment := [I, m]
-/-- -(I)n, second-person singular possessive (§8.1.2). -/
-def possessive2sg : List Segment := [I, n]
-/-- -(I)mIz, first-person plural possessive (§8.1.2). -/
-def possessive1pl : List Segment := [I, m, I, z]
-/-- -(s)I, third-person singular possessive (§8.1.2). -/
-def possessive3sg : List Segment := [I]
-/-- -DA, locative (§8.1.3). -/
-def locative : List Segment := [D, A]
-/-- -Il, passive (§8.2.1.2). -/
-def passive : List Segment := [I, l]
-/-- -mA, negative (§8.2.2); before -(I)yor its vowel is raised to I (§8.2.2). -/
-def negative : List Segment := [m, A]
-/-- -DI, perfective (§8.2.3.3). -/
-def perfective : List Segment := [D, I]
-/-- -mIş, perfective/evidential (§8.2.3.3). -/
-def evidential : List Segment := [m, I, ş]
-/-- -(I)yor, imperfective; its `o` does not harmonize (§3.4 (vi)). -/
-def imperfective : List Segment := [I, y, o, r]
-/-- -(y)mIş, the evidential copula (§8.3.2). -/
-def evidentialCopula : List Segment := [y, m, I, ş]
-/-- -(y)ken, converb; invariable (§3.4 (vi)). -/
-def ken : List Segment := [k, e, n]
-/-- -(I)m, first-person singular of the group 2 person markers (§8.4). -/
-def person1sg : List Segment := [I, m]
-/-- -nIz, second-person plural of the group 1 person markers (§8.4). -/
-def person2pl : List Segment := [n, I, z]
 
 /-! ### Alternations -/
 

--- a/Linglib/Morphology/Morphotactics/Template.lean
+++ b/Linglib/Morphology/Morphotactics/Template.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.List.Chain
 import Mathlib.Tactic.TypeStar
 
 /-!
@@ -27,7 +28,9 @@ prefix/suffix split encoding a morpheme's position relative to the verb stem.
 ## Main definitions
 
 * `Morphology.AffixTemplate` — a word's prefix/suffix slots over an arbitrary slot type.
-* `Morphology.AffixTemplate.Licenses` — the affix strings a template admits.
+* `Morphology.PositionClassSystem` — a template with the exponents of each slot, and the
+  slots that may be filled more than once; `PositionClassSystem.Licenses` is the affix
+  strings it admits.
 -/
 
 namespace Morphology
@@ -43,20 +46,61 @@ structure AffixTemplate (Slot : Type*) where
   suffixSlots : List Slot := []
   deriving Repr, DecidableEq
 
-namespace AffixTemplate
+/-! ### Position-class systems -/
 
-variable {Slot : Type*} [DecidableEq Slot] (t : AffixTemplate Slot)
+universe u
 
-open List in
-/-- A word's affixes are licensed by the template when its prefix and suffix slot
-sequences are sublists of the template's: each slot filled at most once, in template
-order. -/
-def Licenses (pre suf : List Slot) : Prop :=
-  pre <+ t.prefixSlots ∧ suf <+ t.suffixSlots
+/-- A position-class system: a slot inventory ordered by an affix template, the exponents of
+each slot, and the slots that may be filled by several exponents in sequence. The exponents
+are abstract symbols, as the symbols of a `FirstOrder.Language` are; their forms are an
+interpretation supplied by the citing grammar. -/
+structure PositionClassSystem where
+  /-- The position classes. -/
+  Slot : Type u
+  [decEq : DecidableEq Slot]
+  /-- Their order. -/
+  template : AffixTemplate Slot
+  /-- The exponents of each slot. -/
+  Exponent : Slot → Type u
+  /-- The slots admitting more than one exponent in sequence. -/
+  Iterable : Slot → Prop := fun _ => False
+  [decIterable : DecidablePred Iterable]
 
-instance (pre suf : List Slot) : Decidable (t.Licenses pre suf) :=
+namespace PositionClassSystem
+
+attribute [instance] decEq decIterable
+
+variable (P : PositionClassSystem)
+
+/-- In the slot order `slots`, `b` may follow `a`: a later slot, or the same iterable slot. -/
+def Precedes (slots : List P.Slot) (a b : P.Slot) : Prop :=
+  slots.idxOf a < slots.idxOf b ∨ a = b ∧ P.Iterable a
+
+instance (slots : List P.Slot) : DecidableRel (P.Precedes slots) := fun _ _ =>
+  inferInstanceAs (Decidable (_ ∨ _ ∧ _))
+
+/-- The affix strings admitted in the slot order `slots`: every exponent in one of its slots,
+consecutive exponents in later or iterable slots. -/
+def LicensesIn (slots : List P.Slot) (w : List (Σ s, P.Exponent s)) : Prop :=
+  (∀ x ∈ w, x.1 ∈ slots) ∧ (w.map Sigma.fst).IsChain (P.Precedes slots)
+
+instance (slots : List P.Slot) (w : List (Σ s, P.Exponent s)) :
+    Decidable (P.LicensesIn slots w) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-end AffixTemplate
+/-- The words the system admits: the prefixes licensed in the prefix order and the suffixes
+in the suffix order. -/
+def Licenses (pre suf : List (Σ s, P.Exponent s)) : Prop :=
+  P.LicensesIn P.template.prefixSlots pre ∧ P.LicensesIn P.template.suffixSlots suf
+
+instance (pre suf : List (Σ s, P.Exponent s)) : Decidable (P.Licenses pre suf) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Two exponents of one slot cannot be adjacent unless the slot is iterable. -/
+theorem not_licensesIn_pair {s : P.Slot} (h : ¬ P.Iterable s) (slots : List P.Slot)
+    (e₁ e₂ : P.Exponent s) : ¬ P.LicensesIn slots [⟨s, e₁⟩, ⟨s, e₂⟩] := by
+  simp [LicensesIn, Precedes, h]
+
+end PositionClassSystem
 
 end Morphology

--- a/Linglib/Studies/GokselKerslake2005.lean
+++ b/Linglib/Studies/GokselKerslake2005.lean
@@ -1,25 +1,25 @@
 import Linglib.Fragments.Turkish.Morphotactics
-import Linglib.Fragments.Turkish.VowelHarmony
 
 /-!
 # Göksel and Kerslake (2005): Turkish suffixation
 
 The reference grammar's account of the form and order of Turkish suffixes, checked
 against the Turkish Fragment. Chapter 3's vowel harmony is derived by the alternations
-of `Turkish.Phonology` from archiphonemic suffixes: the permissible vowel sequences
-of §3.1 are the A-type and I-type resolutions, the last vowel of a disharmonic loan
-decides (*otobüs-ler*), an invariant suffix vowel is skipped and re-triggers
-(*görüyorum*, §3.4), and the palatal l of *gol* fronts its suffix (§3.4). Chapter 8's
-suffix order is licensing by the templates of `Turkish.Morphotactics`: the grammar's
-example verbs and nominals are licensed, reversed orders are not, and its rule that
-markers of one position cannot co-occur (§8.2.3) is the template's having no repeated
-slot.
+of `Turkish.Phonology` from the exponent forms of `Turkish.Morphotactics`: the
+permissible vowel sequences of §3.1 are the A-type and I-type resolutions, the last vowel
+of a disharmonic loan decides (*otobüs-ler*), an invariant suffix vowel is skipped and
+re-triggers (*görüyorum*, §3.4), and the palatal l of *gol* fronts its suffix (§3.4).
+Chapter 8's suffix order is licensing by the finite-verb and nominal position-class
+systems: the grammar's example words are licensed with their stacked voice suffixes,
+reversed orders are not, and its rule that markers of one position cannot co-occur
+(§8.2.3) is the position's not being iterable.
 
 ## Main results
 
 * `followers_table`: the §3.1 table of permissible vowel sequences.
 * `retriggering`, `palatal_l`: the §3.4 exceptions to harmony, derived rather than listed.
-* `same_position_excluded`: §8.2.3 (i) from `List.nodup_iff_sublist`.
+* `finite_verb`: §8.2 (7), every slot of the finite verb.
+* `same_position_excluded`: §8.2.3 (i) from `PositionClassSystem.not_licensesIn_pair`.
 
 ## References
 
@@ -28,7 +28,7 @@ slot.
 
 namespace GokselKerslake2005
 
-open Turkish Phonology Morphotactics
+open Turkish Phonology
 
 /-! ### Vowel harmony (Chapter 3) -/
 
@@ -44,43 +44,53 @@ theorem followers_table :
 
 /-- §3.2.1: the second-person possessive -(I)n on *kız*, *el*, *kol* and *göz*. -/
 theorem iType :
-    surface ([k, ı, z] ++ possessive2sg) = [k, ı, z, ı, n] ∧
-    surface ([e, l] ++ possessive2sg) = [e, l, i, n] ∧
-    surface ([k, o, l] ++ possessive2sg) = [k, o, l, u, n] ∧
-    surface ([g, ö, z] ++ possessive2sg) = [g, ö, z, ü, n] := by
+    surface ([k, ı, z] ++ (Nominal.Exponent.possessive (.pn .second .Sing)).form) =
+        [k, ı, z, ı, n] ∧
+    surface ([e, l] ++ (Nominal.Exponent.possessive (.pn .second .Sing)).form) =
+        [e, l, i, n] ∧
+    surface ([k, o, l] ++ (Nominal.Exponent.possessive (.pn .second .Sing)).form) =
+        [k, o, l, u, n] ∧
+    surface ([g, ö, z] ++ (Nominal.Exponent.possessive (.pn .second .Sing)).form) =
+        [g, ö, z, ü, n] := by
   decide
 
 /-- Chapter 3: the last vowel of a stem decides, so the disharmonic loan *otobüs* takes
 *-ler*. -/
 theorem last_vowel_decides :
-    surface ([o, t, o, b, ü, s] ++ plural) = [o, t, o, b, ü, s, l, e, r] := by
+    surface ([o, t, o, b, ü, s] ++ Nominal.Exponent.plural.form) =
+      [o, t, o, b, ü, s, l, e, r] := by
   decide
 
 /-- §3.2: *üz-ül-dü-nüz* 'you became sad' — rounding copied through three suffixes, and
 the `D` of -DI voiced after `l`. -/
 theorem iterated :
-    surface ([ü, z] ++ passive ++ perfective ++ person2pl) = [ü, z, ü, l, d, ü, n, ü, z] := by
+    surface ([ü, z] ++ Verb.Exponent.passive.form ++ Verb.Exponent.di.form ++
+        (Verb.Exponent.person .one (.pn .second .Plur)).form) =
+      [ü, z, ü, l, d, ü, n, ü, z] := by
   decide
 
 /-- §3.4 (vi): the `o` of -(I)yor does not harmonize and triggers the person marker,
-*gör-üyor-um*; the invariable -(y)ken, *bak-mış-ken*. -/
+*gör-üyor-um*; the invariable converb -(y)ken, *bak-mış-ken*. -/
 theorem retriggering :
-    surface ([g, ö, r] ++ imperfective ++ person1sg) = [g, ö, r, ü, y, o, r, u, m] ∧
-    surface ([b, a, k] ++ evidential ++ ken) = [b, a, k, m, ı, ş, k, e, n] := by
+    surface ([g, ö, r] ++ Verb.Exponent.iyor.form ++
+        (Verb.Exponent.person .two (.pn .first .Sing)).form) = [g, ö, r, ü, y, o, r, u, m] ∧
+    surface ([b, a, k] ++ Verb.Exponent.miş.form ++ [k, e, n]) = [b, a, k, m, ı, ş, k, e, n] := by
   decide
 
 /-- §3.4 (iv): the palatal l of *gol* and *hal* fronts the suffix, *gol-ü* and *hal-im*,
 while rounding still comes from the vowel. -/
 theorem palatal_l :
-    surface ([g, o, l'] ++ possessive3sg) = [g, o, l', ü] ∧
-    surface ([h, a, l'] ++ possessive1sg) = [h, a, l', i, m] := by
+    surface ([g, o, l'] ++ (Nominal.Exponent.possessive (.pn .third .Sing)).form) =
+      [g, o, l', ü] ∧
+    surface ([h, a, l'] ++ (Nominal.Exponent.possessive (.pn .first .Sing)).form) =
+      [h, a, l', i, m] := by
   decide
 
 /-- §6.1.2: the `D` of -DI is `d` after a voiced segment and `t` after a voiceless one,
 *kal-dı* and *düş-tü*. -/
 theorem voicing_of_D :
-    surface ([k, a, l] ++ perfective) = [k, a, l, d, ı] ∧
-    surface ([d, ü, ş] ++ perfective) = [d, ü, ş, t, ü] := by
+    surface ([k, a, l] ++ Verb.Exponent.di.form) = [k, a, l, d, ı] ∧
+    surface ([d, ü, ş] ++ Verb.Exponent.di.form) = [d, ü, ş, t, ü] := by
   decide
 
 /-- §8.2.2: before -(I)yor the negative's vowel is raised and harmonizes as an I-type
@@ -91,50 +101,52 @@ theorem negative_raised :
   decide
 
 /-- §8.1 (2) *Ev-ler-imiz-de-ymiş-ler* 'apparently they are at our homes': the nominal
-string with the evidential copula and a person marker. -/
+string, the evidential copula with its buffer `y`, and a group-2 person marker. -/
 theorem nominal_predicate :
-    surface ([e, v] ++ plural ++ possessive1pl ++ locative ++ evidentialCopula ++ plural) =
+    surface ([e, v] ++ Nominal.Exponent.plural.form ++
+        (Nominal.Exponent.possessive (.pn .first .Plur)).form ++ Nominal.Exponent.locative.form ++
+        [y] ++ Verb.Exponent.evidentialCopula.form ++
+        (Verb.Exponent.person .two (.pn .third .Plur)).form) =
       [e, v, l, e, r, i, m, i, z, d, e, y, m, i, ş, l, e, r] := by
   decide
 
-/-! ### The order of suffixes (Chapters 6 and 8) -/
+/-! ### The order of suffixes (Chapter 8) -/
 
-/-- §8.1 (1) *çocuk-lar-ın-a* 'to your children' and §6.3 (2) *diz-ge-ler-im-de* 'on my
-lists': number - possession - case, after a derivational suffix. -/
+/-- §8.1 (1) *çocuk-lar-ın-a* 'to your children': number - possession - case. -/
 theorem nominal :
-    nounTemplate.Licenses [] [.number, .possession, .case] ∧
-    nounTemplate.Licenses [] [.derivational, .number, .possession, .case] := by
+    Nominal.system.Licenses []
+      [⟨_, .plural⟩, ⟨_, .possessive (.pn .second .Sing)⟩, ⟨_, .dative⟩] := by
   decide
 
 /-- §8.2 (7) *Döğ-üş-tür-t-ül-me-yebil-iyor-muş-sunuz-dur*: every slot of the finite verb,
-the voice slot filled by four stacked voice suffixes. -/
+the voice slot filled by four stacked suffixes. -/
 theorem finite_verb :
-    verbTemplate.Licenses []
-      [.voice, .negation, Marker.abil.slot, Marker.iyor.slot, Marker.evidentialCopula.slot,
-        .person, .generalizing] := by
+    Verb.system.Licenses []
+      [⟨_, .reciprocal⟩, ⟨_, .causative⟩, ⟨_, .causative⟩, ⟨_, .passive⟩, ⟨_, .negative⟩,
+        ⟨_, .abil⟩, ⟨_, .iyor⟩, ⟨_, .evidentialCopula⟩, ⟨_, .person .two (.pn .second .Plur)⟩,
+        ⟨_, .dir⟩] := by
   decide
 
 /-- §8.2.3 (11) *Bitir-e-me-miş-tir*, (12) *Oku-yabil-ecek-miş* and §8.2.3.3 *git-ti-ydi-n*:
-positions 1-3-5, 2-3-4 and 3-4 with a person marker. -/
+positions 1-3-5, 2-3-4 and 3-4 with a group-1 person marker. -/
 theorem tam_positions :
-    verbTemplate.Licenses []
-      [Marker.possibility.slot, .negation, Marker.miş.slot, Marker.dir.slot] ∧
-    verbTemplate.Licenses [] [Marker.abil.slot, Marker.acak.slot, Marker.evidentialCopula.slot] ∧
-    verbTemplate.Licenses [] [Marker.di.slot, Marker.pastCopula.slot, .person] := by
+    Verb.system.Licenses [] [⟨_, .possibility⟩, ⟨_, .negative⟩, ⟨_, .miş⟩, ⟨_, .dir⟩] ∧
+    Verb.system.Licenses [] [⟨_, .abil⟩, ⟨_, .acak⟩, ⟨_, .evidentialCopula⟩] ∧
+    Verb.system.Licenses []
+      [⟨_, .di⟩, ⟨_, .pastCopula⟩, ⟨_, .person .one (.pn .second .Sing)⟩] := by
   decide
 
 /-- The negative follows voice and precedes the tense/aspect/modality marker (§8.2.2), and
 the copular markers follow it (§8.2.3): the reversed orders are unlicensed. -/
 theorem reversed_orders :
-    ¬ verbTemplate.Licenses [] [.negation, .voice] ∧
-    ¬ verbTemplate.Licenses [] [.tam, .negation] ∧
-    ¬ verbTemplate.Licenses [] [.copula, .tam] := by
+    ¬ Verb.system.Licenses [] [⟨_, .negative⟩, ⟨_, .causative⟩] ∧
+    ¬ Verb.system.Licenses [] [⟨_, .di⟩, ⟨_, .negative⟩] ∧
+    ¬ Verb.system.Licenses [] [⟨_, .pastCopula⟩, ⟨_, .di⟩] := by
   decide
 
-/-- §8.2.3 (i): markers of one position cannot co-occur — the template has no repeated
-slot. -/
-theorem same_position_excluded (m₁ m₂ : Marker) (h : m₁.slot = m₂.slot) :
-    ¬ verbTemplate.Licenses [] [m₁.slot, m₂.slot] :=
-  fun ⟨_, hs⟩ => List.nodup_iff_sublist.1 (by decide) _ (h ▸ hs)
+/-- §8.2.3 (i): markers of one position cannot co-occur — position 3 is not iterable. -/
+theorem same_position_excluded (m₁ m₂ : Verb.Exponent .tam) :
+    ¬ Verb.system.Licenses [] [⟨_, m₁⟩, ⟨_, m₂⟩] :=
+  fun h => Verb.system.not_licensesIn_pair (by decide : Verb.Slot.tam ≠ .voice) _ m₁ m₂ h.2
 
 end GokselKerslake2005


### PR DESCRIPTION
Follow-up to #2661: the Turkish verb and nominal become `Morphology.PositionClassSystem`s, on the `FirstOrder.Language` pattern.

- `PositionClassSystem` bundles a slot type, its `AffixTemplate`, a slot-indexed exponent family and the iterable slots; `Licenses` is `IsChain` on the slot sequence, and `not_licensesIn_pair` gives same-position exclusion for non-iterable slots.
- `Turkish.Verb.Exponent : Slot → Type` and `Turkish.Nominal.Exponent` replace the marker enum and its `slot` projection; person markers and possessives are `Agreement.Paradigm` tables; `Exponent.form` is the interpretation `surface` consumes.
- The study's example words are now sigma lists of filled slots, with the four stacked voice suffixes of §8.2 (7) visible.