### PR TITLE
refactor(Semantics/ArgumentStructure/Root): kinds as image of atoms

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/EventStructure.lean
+++ b/Linglib/Semantics/ArgumentStructure/EventStructure.lean
@@ -167,11 +167,8 @@ def _root_.Verb.Root.template (r : Root) : Template :=
     the [beavers-koontz-garboden-2020] result entailment, bridged to the
     `EventStructure` template diagnostic. -/
 theorem _root_.Verb.Root.template_hasResultState_iff (r : Root) :
-    r.template.HasResultState ↔ LexKind.result ∈ r.closedKinds := by
-  apply ofKinds_hasResultState_iff
-  show Root.Kinds.close r.closedKinds = r.closedKinds
-  unfold Verb.Root.closedKinds
-  exact Root.Kinds.close_idem _
+    r.template.HasResultState ↔ LexKind.result ∈ r.closedKinds :=
+  ofKinds_hasResultState_iff r.closedKinds_wellFormed
 
 end Signature
 

--- a/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
@@ -199,10 +199,9 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
 earns its place via a theorem that holds for *every* class and breaks if a
 row is changed: every assigned signature is well-formed (collocationally
 closed). Invert any row to an unclosed signature and this fails — the
-grounding is not decorative. Manner/result complementarity of these
-signatures is covered by the canonical kinds-layer theory
-(`Roots/Closure.lean`, `closed_violatesBifurcation_iff`), which quantifies
-over all `Root.Kinds`, so no per-class MRC spot-check is restated here. -/
+grounding is not decorative. Manner/result complementarity is a claim about
+roots, prosecuted over all `Root.Kinds` in `Studies/BeaversKoontzGarboden2020.lean`,
+so no per-class spot-check is restated here. -/
 
 /-- Every Levin class is assigned a well-formed (closed) root signature. -/
 theorem rootEntailments_wellFormed (c : LevinClass) :

--- a/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
@@ -2,144 +2,100 @@ import Linglib.Semantics.ArgumentStructure.Root.Profile
 import Linglib.Semantics.ArgumentStructure.Root.Kinds
 
 /-!
-# Atomic Lexical Entailments and Roots
+# Verbal roots
 
-Lexical entailments are the atomic claims a verbal root makes about
-the events it describes and the participants in those events.
-Following [beavers-koontz-garboden-2020], we treat these as
-*structured atoms* rather than as a fixed feature vector: a **root**
-is a finite collection of such atoms, and its kind signature
-(`Root.Kinds`) is the *derived* set of kinds its atoms realize —
-exposing the Bifurcation Thesis of Roots and Manner/Result
-Complementarity as testable conjectures rather than architectural
-commitments.
+A verbal root of [beavers-koontz-garboden-2020] is a bundle of lexical
+entailments (§5.2.1, after [dowty-1991]): idiosyncratic atoms, each of one of
+the four kinds the book's root typology tracks (§5.4.1, (11)) — a state, a
+manner, a change into a state, or causation. `Root` carries a finite set of
+such atoms and the root's within-class quality profile. Its kind signature
+`Root.kinds` is *derived*, the image of the atoms under `Entailment.kind`, and
+`Root.closedKinds` adds the kinds the book's collocational restrictions force
+(`Root.Kinds.close`); that closure is where the templatic content a root's own
+entailments carry with them (a cracked state entails a change, §5.2.1) enters
+the signature.
 
 ## Main declarations
 
-* `LexEntailment` — labeled atoms; `LexEntailment.kind` projects its
-  B&K-G kind
-* `Root` — a named list of atoms
-* `Root.kinds` — the derived signature; `Root.closedKinds` its
-  collocational closure
-* `Root.HasState`/`HasManner`/`HasResult`/`HasCause` — kind membership
+* `Root.Entailment` — a labelled atom; `Root.Entailment.kind` forgets the label
+* `Root` — name, atoms, quality profile
+* `Root.kinds`, `Root.closedKinds` — the derived and the closed signature
+
+## References
+
+* [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
+* [dowty-1991]: Thematic proto-roles and argument selection.
+* [bohnemeyer-2004]: Split intransitivity, linking, and lexical representation.
+* [spalek-mcnally-2026], [majid-boster-bowerman-2008]: the quality dimensions of
+  `Root.Profile`.
 -/
 
 namespace Verb
 
-/-! ### Atomic entailments -/
+/-! ### Atoms -/
 
-/-- An atomic structural claim a verbal root makes — one of the four
-    B&K-G entailment kinds (state, manner, result, cause). The three
-    contentful kinds carry a label; `hasCause` is nullary.
-    `LexEntailment.kind` projects the kind each realizes.
-
-    Participant/proto-role entailments (volition, sentience, movement,
-    affectedness, …) are deliberately *not* modeled here: they are an
-    orthogonal, linking-relevant layer carried by
-    `ArgumentStructure.EntailmentProfile`. -/
-inductive LexEntailment where
-  /-- Attributes a static property (state-kind atom). -/
-  | hasState     (label : String)
-  /-- Specifies the manner in which the action is performed. -/
-  | hasManner    (label : String)
-  /-- Entails change of state to the labelled result. -/
-  | becomesState (label : String)
-  /-- Entails a causing event. Nullary because B&K-G's typology is
-      neutral about *what* causes — only that there is a cause.
-      The cause-type distinction (internal vs external,
-      [bohnemeyer-2004]) is carried separately by
-      `ArgumentStructure.EventStructure.InternalExternalCause`. -/
-  | hasCause
+/-- A lexical entailment a root carries, of one of the four kinds of the root
+typology of [beavers-koontz-garboden-2020] (§5.4.1, (11)). The label names the
+particular state, manner, or result; causation is unlabelled because the
+typology records only that there is a cause (the internal vs external cause
+distinction of [bohnemeyer-2004] is `EventStructure.InternalExternalCause`).
+Participant entailments (volition, sentience, …) are the separate linking layer
+`ArgumentStructure.EntailmentProfile`. -/
+inductive Root.Entailment where
+  /-- The root describes the labelled state. -/
+  | state (label : String)
+  /-- The root describes an action of the labelled manner. -/
+  | manner (label : String)
+  /-- The root entails a change into the labelled state. -/
+  | result (label : String)
+  /-- The root entails causation. -/
+  | cause
   deriving DecidableEq, Repr
 
-namespace LexEntailment
-
-/-- The B&K-G kind an atom realizes. Total — every atom has a kind —
-    but kept `Option`-valued for the closure API (`Closure.lean`),
-    which quantifies over `a.kind = some k`. -/
-def kind : LexEntailment → Option LexKind
-  | hasState _     => some .state
-  | hasManner _    => some .manner
-  | becomesState _ => some .result
-  | hasCause       => some .cause
-
-end LexEntailment
+/-- The kind of an atom: forget its label. -/
+def Root.Entailment.kind : Root.Entailment → LexKind
+  | .state _ => .state
+  | .manner _ => .manner
+  | .result _ => .result
+  | .cause => .cause
 
 /-! ### Roots -/
 
-/-- A verbal root: a name and a finite set of atomic entailments it
-    imposes.
-
-    The set is the root's *base* entailment set — the atoms asserted
-    directly. A closure operation (B&K-G's networks of entailments
-    where one atom may entail another) is layered on top in
-    `Closure.lean`. -/
+/-- A verbal root: its form, the lexical entailments it carries, and its
+within-class quality profile. -/
 structure Root where
-  /-- The root form; `""` for an unnamed annotation (e.g. a quality-profile-only
-      root carried by a verb whose root form is its citation form). -/
+  /-- The root form, `""` when the root is carried anonymously by a verb whose
+  citation form names it. -/
   name : String := ""
-  /-- The B&KG structural-entailment atoms; `∅` where the root's structural
-      content has not been annotated (its `kinds` is then uninformative). -/
-  entailments : Finset LexEntailment := ∅
+  /-- The root's atoms, `∅` where its structural content is unannotated. -/
+  entailments : Finset Verb.Root.Entailment := ∅
   /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
-      [majid-boster-bowerman-2008]); `{}` (all unconstrained) by default. -/
+  [majid-boster-bowerman-2008]); `{}` leaves every dimension unconstrained. -/
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- `Finset` carries no `Repr`, so `Root` cannot `deriving Repr`; we supply
-    one by hand so `Verb` can `deriving Repr` over its `root` field. It shows
-    `name` and `profile` in full plus the `entailments`
-    cardinality — the entailment *set* itself has no computable `Repr`
-    (`Finset`/`Multiset` would need a `LinearOrder` on the elements to render),
-    but this already distinguishes roots that differ in profile, which
-    the old name-only `Repr` collapsed.
-
-    `BEq`/`LawfulBEq` need no hand-rolled instance: both come from the derived
-    `DecidableEq` (line above) via the global `instBEqOfDecidableEq`. -/
-instance : Repr Root :=
-  ⟨fun r _ => repr (r.name, r.entailments.card, r.profile)⟩
+/-- `Finset` has only an `unsafe` `Repr`, so `Root` cannot derive one; this shows
+the name, the number of atoms, and the profile. -/
+instance : Repr Root := ⟨λ r _ => repr (r.name, r.entailments.card, r.profile)⟩
 
 namespace Root
 
-/-- The derived kind signature of a root: the set of kinds its
-    atoms realize. -/
-def kinds (r : Root) : Root.Kinds :=
-  Finset.univ.filter (fun k => ∃ a ∈ r.entailments, a.kind = some k)
+variable (r : Root)
 
-theorem mem_kinds {r : Root} {k : LexKind} :
-    k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = some k := by
-  simp only [kinds, Finset.mem_filter, Finset.mem_univ, true_and]
+/-- The kind signature of a root: the kinds of its atoms. -/
+def kinds : Kinds := r.entailments.image Entailment.kind
 
-/-- The root entails attribution of some state.
-    `abbrev` (not `def`) so `Decidable`/`simp`/`decide` see through to the
-    underlying `Finset` membership without per-predicate boilerplate. -/
-abbrev HasState (r : Root) : Prop := .state ∈ r.kinds
+variable {r} in
+@[simp] theorem mem_kinds {k : LexKind} : k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = k :=
+  Finset.mem_image
 
-/-- The root specifies some manner. -/
-abbrev HasManner (r : Root) : Prop := .manner ∈ r.kinds
+/-- The closed signature: `kinds` completed under the collocational restrictions
+of [beavers-koontz-garboden-2020] (`Root.Kinds.close`). -/
+def closedKinds : Kinds := r.kinds.close
 
-/-- The root entails some change of state (B&K-G "result"). -/
-abbrev HasResult (r : Root) : Prop := .result ∈ r.kinds
+theorem kinds_le_closedKinds : r.kinds ≤ r.closedKinds := Kinds.le_close _
 
-/-- The root entails causation. -/
-abbrev HasCause (r : Root) : Prop := .cause ∈ r.kinds
-
-/-! ### The closed signature -/
-
-/-- The closed kind signature: the collocational closure
-    (`Root.Kinds.close`) of the derived signature. Both
-    [beavers-koontz-garboden-2020] restrictions (result→state and
-    cause→result) hold of closed signatures by construction. -/
-def closedKinds (r : Root) : Root.Kinds :=
-  r.kinds.close
-
-theorem closedKinds_wellFormed (r : Root) :
-    r.closedKinds.WellFormed :=
-  Root.Kinds.close_wellFormed _
-
-theorem kinds_le_closed (r : Root) :
-    r.kinds ≤ r.closedKinds :=
-  Root.Kinds.le_close _
+theorem closedKinds_wellFormed : r.closedKinds.WellFormed := Kinds.close_wellFormed _
 
 end Root
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -259,32 +259,32 @@ open Verb
 /-! ### The six representative roots -/
 
 /-- √flat — pure state. -/
-def flat : Root := ⟨"flat", {.hasState "flat"}, {}⟩
+def flat : Root := ⟨"flat", {.state "flat"}, {}⟩
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", {.hasManner "jogging-gait"}, {}⟩
+def jog : Root := ⟨"jog", {.manner "jogging-gait"}, {}⟩
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/
-def blossom : Root := ⟨"blossom", {.becomesState "flowering"}, {}⟩
+def blossom : Root := ⟨"blossom", {.result "flowering"}, {}⟩
 
 /-- √crack — caused result without specified manner. -/
-def crack : Root := ⟨"crack", {.becomesState "fissured", .hasCause}, {}⟩
+def crack : Root := ⟨"crack", {.result "fissured", .cause}, {}⟩
 
 /-- √hand — manner + cause + result, adjoined position. The
     possession result is non-cancelable ("Mary handed John the book,
     #but it never came to be on his person", ch. 3 (48)), so it is
     root-entailed rather than implicated. -/
 def hand : Root := ⟨"hand",
-  {.hasManner "by-hand-transfer",
-   .becomesState "in-recipient-possession",
-   .hasCause}, {}⟩
+  {.manner "by-hand-transfer",
+   .result "in-recipient-possession",
+   .cause}, {}⟩
 
 /-- √drown — manner of killing (Levin 1993's *crucify, drown, hang,
     electrocute* class; [beavers-koontz-garboden-2020] ch. 4):
     manner + cause + result, complement position. -/
 def drown : Root := ⟨"drown",
-  {.hasManner "submersion-in-liquid", .becomesState "dead", .hasCause}, {}⟩
+  {.manner "submersion-in-liquid", .result "dead", .cause}, {}⟩
 
 /-! ### Kind signatures
 

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -70,19 +70,19 @@ open Verb ArgumentStructure Morphology
 /-! ### Agent-salient roots (p. 629, ex. (1a)) -/
 
 /-- síit' 'jump' (ex. (1a)). -/
-def siit : Root := ⟨"síit'", {.hasManner "jumping"}, {}⟩
+def siit : Root := ⟨"síit'", {.manner "jumping"}, {}⟩
 
 /-- ¢'iib' 'write' (p. 629). -/
-def tziib : Root := ⟨"¢'iib'", {.hasManner "writing"}, {}⟩
+def tziib : Root := ⟨"¢'iib'", {.manner "writing"}, {}⟩
 
 /-- mìis 'sweep' (p. 629); denominal from 'broom'. -/
-def miis : Root := ⟨"mìis", {.hasManner "sweeping"}, {}⟩
+def miis : Root := ⟨"mìis", {.manner "sweeping"}, {}⟩
 
 /-- čé'eh 'smile' (p. 629). -/
-def cheh : Root := ⟨"čé'eh", {.hasManner "smiling"}, {}⟩
+def cheh : Root := ⟨"čé'eh", {.manner "smiling"}, {}⟩
 
 /-- páak 'weed' (p. 629). -/
-def paak : Root := ⟨"páak", {.hasManner "weeding"}, {}⟩
+def paak : Root := ⟨"páak", {.manner "weeding"}, {}⟩
 
 /-! ### Agent-patient salient roots (p. 629, ex. (1b))
 
@@ -91,20 +91,20 @@ Root transitives. They carry no uniform signature: *kuč*, *p'is*, *ha¢*,
 *hit* type), while *k'os* 'cut' is manner+result (their *cut* type). -/
 
 /-- kuč 'carry' (ex. (1b)). -/
-def kuc : Root := ⟨"kuč", {.hasManner "carrying"}, {}⟩
+def kuc : Root := ⟨"kuč", {.manner "carrying"}, {}⟩
 
 /-- k'os 'cut' (p. 629); manner+result. -/
 def kos : Root :=
-  ⟨"k'os", {.hasManner "cutting", .becomesState "cut"}, {}⟩
+  ⟨"k'os", {.manner "cutting", .result "cut"}, {}⟩
 
 /-- p'is 'measure' (p. 629); no entailed change of state. -/
-def pis : Root := ⟨"p'is", {.hasManner "measuring"}, {}⟩
+def pis : Root := ⟨"p'is", {.manner "measuring"}, {}⟩
 
 /-- ha¢ 'whip' (p. 629). -/
-def hats : Root := ⟨"ha¢", {.hasManner "whipping"}, {}⟩
+def hats : Root := ⟨"ha¢", {.manner "whipping"}, {}⟩
 
 /-- loš 'punch' (p. 629); surface contact without entailed result. -/
-def los : Root := ⟨"loš", {.hasManner "striking"}, {}⟩
+def los : Root := ⟨"loš", {.manner "striking"}, {}⟩
 
 /-! ### Patient-salient roots (ex. (2), pp. 629–630)
 
@@ -113,41 +113,41 @@ adjacency" (fn. 7): 'ah ~ wen, siih ~ kíim, tú'ub' ~ k'a'ah, ču'un ~
 č'en, hó'op' ~ háaw. The order below is the list's. -/
 
 /-- 'ah '(a)wake(n)' ('ah=s 'wake (someone)'). -/
-def ah : Root := ⟨"'ah", {.becomesState "awake"}, {}⟩
+def ah : Root := ⟨"'ah", {.result "awake"}, {}⟩
 
 /-- wen '(fall a)sleep' (ween=s 'put to sleep'); fn. 7 flags it as also
     denoting continuation in the state. -/
-def wen : Root := ⟨"wen", {.becomesState "asleep"}, {}⟩
+def wen : Root := ⟨"wen", {.result "asleep"}, {}⟩
 
 /-- siih 'be born' (siih=s 'give birth, bear'). -/
-def siih : Root := ⟨"siih", {.becomesState "born"}, {}⟩
+def siih : Root := ⟨"siih", {.result "born"}, {}⟩
 
 /-- kíim 'die' (ex. (1c); kíim=s 'kill'). -/
-def kiim : Root := ⟨"kíim", {.becomesState "dead"}, {}⟩
+def kiim : Root := ⟨"kíim", {.result "dead"}, {}⟩
 
 /-- tú'ub' 'forget' (tú'ub'=s 'distract, cause to forget'). -/
-def tuub : Root := ⟨"tú'ub'", {.becomesState "forgotten"}, {}⟩
+def tuub : Root := ⟨"tú'ub'", {.result "forgotten"}, {}⟩
 
 /-- k'a'ah 'remember' (k'á'ah=s 'remind, mention, invoke'). -/
-def kaah : Root := ⟨"k'a'ah", {.becomesState "remembered"}, {}⟩
+def kaah : Root := ⟨"k'a'ah", {.result "remembered"}, {}⟩
 
 /-- ču'un 'begin activity' (ču'un=s 'cause to begin'). -/
-def chuun : Root := ⟨"ču'un", {.becomesState "begun"}, {}⟩
+def chuun : Root := ⟨"ču'un", {.result "begun"}, {}⟩
 
 /-- č'en 'stop, cease' (č'en=s 'cause to stop, suspend'). -/
-def chen : Root := ⟨"č'en", {.becomesState "ceased"}, {}⟩
+def chen : Root := ⟨"č'en", {.result "ceased"}, {}⟩
 
 /-- hó'op' 'begin, start' (hó'op'=s 'cause to begin'). -/
-def hoop : Root := ⟨"hó'op'", {.becomesState "started"}, {}⟩
+def hoop : Root := ⟨"hó'op'", {.result "started"}, {}⟩
 
 /-- háaw 'stop, cease, heal' (háaw=s 'stop, revoke, medicate'). -/
-def haaw : Root := ⟨"háaw", {.becomesState "stopped"}, {}⟩
+def haaw : Root := ⟨"háaw", {.result "stopped"}, {}⟩
 
 /-- hé'el 'rest, stop at' (hé'e(l)=s 'rest'). -/
-def heel : Root := ⟨"hé'el", {.becomesState "rested"}, {}⟩
+def heel : Root := ⟨"hé'el", {.result "rested"}, {}⟩
 
 /-- p'át 'remain' (p'át=s 'abandon'). -/
-def paat : Root := ⟨"p'át", {.becomesState "remaining"}, {}⟩
+def paat : Root := ⟨"p'át", {.result "remaining"}, {}⟩
 
 /-! ### Motion roots (ex. (4), p. 640)
 
@@ -158,41 +158,41 @@ adds that *péek* and *'ú'ul* are also irregular in their agent-focused
 perfective forms, "where they pattern like agent-salient roots". -/
 
 /-- máan 'pass by' (`#`; máan=s 'pass, transfer, transport'). -/
-def maan : Root := ⟨"máan", {.becomesState "past"}, {}⟩
+def maan : Root := ⟨"máan", {.result "past"}, {}⟩
 
 /-- péek 'move, vibrate' (`#`; pek=s 'cause to move, vibrate'). -/
-def peek : Root := ⟨"péek", {.becomesState "in-motion"}, {}⟩
+def peek : Root := ⟨"péek", {.result "in-motion"}, {}⟩
 
 /-- b'in 'go' (`#`; bi(n)=s 'take'). -/
-def bin : Root := ⟨"b'in", {.becomesState "gone"}, {}⟩
+def bin : Root := ⟨"b'in", {.result "gone"}, {}⟩
 
 /-- tàal 'come (here)' (`#`; tàa(l)=s 'bring'). -/
-def taal : Root := ⟨"tàal", {.becomesState "come"}, {}⟩
+def taal : Root := ⟨"tàal", {.result "come"}, {}⟩
 
 /-- 'ú'ul 'arrive (here)' (`#`; 'ú'uh=s 'bring it to here'). -/
-def uul : Root := ⟨"'ú'ul", {.becomesState "arrived"}, {}⟩
+def uul : Root := ⟨"'ú'ul", {.result "arrived"}, {}⟩
 
 /-- 'ok 'enter, intrude' ('òok=s 'move it in(to)'). -/
-def ok : Root := ⟨"'ok", {.becomesState "inside"}, {}⟩
+def ok : Root := ⟨"'ok", {.result "inside"}, {}⟩
 
 /-- lúub' 'fall' (lúub'=s 'fell'). -/
-def luub : Root := ⟨"lúub'", {.becomesState "fallen"}, {}⟩
+def luub : Root := ⟨"lúub'", {.result "fallen"}, {}⟩
 
 /-- líik' '(a)rise, ascend' (lii(k)'=s 'raise, lift, put away'). -/
-def liik : Root := ⟨"líik'", {.becomesState "risen"}, {}⟩
+def liik : Root := ⟨"líik'", {.result "risen"}, {}⟩
 
 /-- ná'ak '(a)rise, ascend' (ná'ak=s 'raise'); distinct from náak
     'arrive, reach, hit', not sampled here. -/
-def naak : Root := ⟨"ná'ak", {.becomesState "ascended"}, {}⟩
+def naak : Root := ⟨"ná'ak", {.result "ascended"}, {}⟩
 
 /-! ### Positional roots (ex. (7), p. 643) -/
 
 /-- čin 'bow, bend down, bend over' (ex. (5)–(7)); zero-derives a
     transitive, ex. (6) 'I bent it'. -/
-def cin : Root := ⟨"čin", {.hasState "bent"}, {}⟩
+def cin : Root := ⟨"čin", {.state "bent"}, {}⟩
 
 /-- kul 'sit' (p. 645, fn. 24: relational 'x is-seated [on y]'). -/
-def kul : Root := ⟨"kul", {.hasState "seated"}, {}⟩
+def kul : Root := ⟨"kul", {.state "seated"}, {}⟩
 
 /-! ### Valency and class lists -/
 
@@ -407,7 +407,7 @@ theorem positional_crosscuts_transitiviser_classes :
 
 /-- For cause-free roots — every root in this sample — collocational
     closure does not change the predicted class. -/
-theorem predictedClass_closure_invariant (r : Root) (h : ¬ r.HasCause) :
+theorem predictedClass_closure_invariant (r : Root) (h : LexKind.cause ∉ r.kinds) :
     SalienceClass.ofKinds r.closedKinds (valency r) = predictedClass r :=
   SalienceClass.ofKinds_close r.kinds (valency r) h
 

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -60,7 +60,7 @@ verb allows only conceptual access (§4.2).
 - §14 Cross-paper engagement: Beavers & Koontz-Garboden 2020 root
      eventivity (Tham §5.1 refutes strict root → deverbal-adjective
      result-state inheritance, against B&KG's `crack : Root :=
-     ⟨"crack", [.becomesState "fissured", .hasCause]⟩`)
+     ⟨"crack", {.result "fissured", .cause}⟩`)
 - §15 Cross-paper engagement: Waldon et al. 2023 normalization contrast
      (substrate-level: shared numerator, divergent denominator)
 - §16 Cross-paper engagement: Solt 2018 SuB reciprocal bridge
@@ -831,8 +831,8 @@ theorem largeVase_score_le_one :
 
 /-! [beavers-koontz-garboden-2020] formalize verbal roots as
     bundles of lexical entailments
-    (`Semantics/Lexical/Roots/Basic.lean`). Their classification
-    of √crack is `[.becomesState "fissured", .hasCause]` — the
+    (`Semantics/ArgumentStructure/Root/Defs.lean`). Their classification
+    of √crack is `{.result "fissured", .cause}` — the
     "result + cause, no manner" base feature signature
     `{.result, .cause}` (`BeaversKoontzGarboden2020.crack`).
 
@@ -841,18 +841,18 @@ theorem largeVase_score_le_one :
     INHERITANCE from this root signature to the deverbal adjective:
     the adjective applies to surfaces that have not undergone the
     CoS event. The substrate-level contrast: B&KG's *crack* root
-    asserts `becomesState` (the verbal entry derived from this root
+    asserts `result` (the verbal entry derived from this root
     inherits it via `Verbal.crack.toVerb.degreeAchievementScale`),
     yet the adjectival side `Tham2025.crack.adjEntailsPrecedingChange`
     is false. -/
 
-/-- B&KG's `crack` root has a result entailment (the `becomesState
+/-- B&KG's `crack` root has a result entailment (the `result
     "fissured"` atom provides it), but Tham's deverbal adjective
     *cracked* does NOT entail a preceding CoS event. Strict result-
     state inheritance from root to deverbal adjective is refuted at
     substrate level. -/
 theorem cracked_adj_refutes_bkg_crack_root_inheritance :
-    BeaversKoontzGarboden2020.crack.HasResult ∧
+    Verb.LexKind.result ∈ BeaversKoontzGarboden2020.crack.kinds ∧
     crack.adjEntailsPrecedingChange = false :=
   ⟨by decide, rfl⟩
 


### PR DESCRIPTION
`Root.kinds` is the `Finset.image` of a total `Root.Entailment.kind`; the `Option`-valued kind justified by a nonexistent `Closure.lean`, and the four `Has*` abbrevs, go.

- `LexEntailment` → `Root.Entailment`, constructors named for the book's (11) features (`state`, `manner`, `result`, `cause`)
- `template_hasResultState_iff` uses `closedKinds_wellFormed` instead of re-proving it; stale `Roots/Closure.lean` and `Semantics/Lexical` pointers in LevinTheory and Tham2025 fixed