### PR TITLE
refactor(Semantics/ArgumentStructure/Root): kind order as an inductive LE

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/Affectedness.lean
+++ b/Linglib/Semantics/ArgumentStructure/Affectedness.lean
@@ -48,7 +48,7 @@ three `EntailmentProfile` projections
 (`Agentivity` P-Agent, this file P-Patient strength → MAP
 (`Studies/Beavers2010.lean`), `PersistenceLevel` → case regions); distinct
 from the surface (`MeaningComponents.changeOfState`) and root
-(`LexKind.result`) change-of-state notions ([beavers-koontz-garboden-2020]).
+(`Root.Kind.result`) change-of-state notions ([beavers-koontz-garboden-2020]).
 -/
 
 namespace ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -505,24 +505,24 @@ cross-linguistically (validated across 88 languages).
 /-- PC roots entail state but NOT result — they name properties
     without inherent change. "Flat" is a simple state. -/
 theorem pc_no_result :
-    LexKind.state ∈ propertyConcept ∧
-    LexKind.result ∉ propertyConcept := by decide
+    Root.Kind.state ∈ propertyConcept ∧
+    Root.Kind.result ∉ propertyConcept := by decide
 
 /-- Result roots entail both state AND result — the state is
     inseparable from prior change. "Cracked" entails having
     been cracked. -/
 theorem result_has_change :
-    LexKind.state ∈ pureResult ∧
-    LexKind.result ∈ pureResult ∧
-    LexKind.cause ∉ pureResult := by decide
+    Root.Kind.state ∈ pureResult ∧
+    Root.Kind.result ∈ pureResult ∧
+    Root.Kind.cause ∉ pureResult := by decide
 
 /-- Caused-result roots entail state + result + cause — the
     change must have been externally caused. "Break" entails
     external causation. -/
 theorem caused_result_full :
-    LexKind.state ∈ causativeResult ∧
-    LexKind.result ∈ causativeResult ∧
-    LexKind.cause ∈ causativeResult := by decide
+    Root.Kind.state ∈ causativeResult ∧
+    Root.Kind.result ∈ causativeResult ∧
+    Root.Kind.cause ∈ causativeResult := by decide
 
 /-- The root typology forms an implicational hierarchy:
     cause → result → state. For well-formed signatures this is a
@@ -530,7 +530,8 @@ theorem caused_result_full :
     not a per-signature stipulation. -/
 theorem root_typology_hierarchy :
     ∀ s : Root.Kinds, s.WellFormed →
-      (.cause ∈ s → .result ∈ s) ∧ (.result ∈ s → .state ∈ s) := by decide
+      (.cause ∈ s → .result ∈ s) ∧ (.result ∈ s → .state ∈ s) :=
+  fun _ h => ⟨h Root.Kind.LE.result_cause, h Root.Kind.LE.state_result⟩
 
 /-- PC and result roots differ in licensing predictions:
     PC roots can fill stative templates (simple statives exist);
@@ -541,8 +542,8 @@ theorem pc_result_stative_difference :
     RootLicensesTemplate propertyConcept .state ∧
     RootLicensesTemplate pureResult .state ∧
     -- But result roots entail change (root-level, not template-level)
-    LexKind.result ∉ propertyConcept ∧
-    LexKind.result ∈ pureResult := by decide
+    Root.Kind.result ∉ propertyConcept ∧
+    Root.Kind.result ∈ pureResult := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 8. Summary: Where the Pipeline is Informative
@@ -566,7 +567,7 @@ theorem pc_result_stative_difference :
 The enriched pipeline covers hit, break, cut, mannerOfMotion classes
 exactly — `deriveEnriched` matches `LevinClass.roleList` with no
 override needed. Only amuse, build/create, eat/devour, perception,
-directedMotion, and minimal-rootEntailments classes need overrides.
+directedMotion, and empty-signature classes need overrides.
 
 The full derivational chain:
 

--- a/Linglib/Semantics/ArgumentStructure/EventStructure.lean
+++ b/Linglib/Semantics/ArgumentStructure/EventStructure.lean
@@ -129,18 +129,18 @@ denotational result entailment and `cause_implies_resultState` are one fact seen
 through the signature. -/
 
 section Signature
-open Verb (LexKind Root)
+open Verb (Root)
 
 /-- The event-structure template determined by a root's (closed) kind signature. -/
 def Template.ofKinds (σ : Root.Kinds) : Template :=
-  if LexKind.cause ∈ σ then .accomplishment
-  else if LexKind.result ∈ σ then .achievement
-  else if LexKind.manner ∈ σ then .activity
+  if Root.Kind.cause ∈ σ then .accomplishment
+  else if Root.Kind.result ∈ σ then .achievement
+  else if Root.Kind.manner ∈ σ then .activity
   else .state
 
 /-- `HasCause` reduces to carrying the `cause` kind. -/
 theorem ofKinds_hasCause_iff (σ : Root.Kinds) :
-    (Template.ofKinds σ).HasCause ↔ LexKind.cause ∈ σ := by
+    (Template.ofKinds σ).HasCause ↔ Root.Kind.cause ∈ σ := by
   unfold Template.ofKinds
   split_ifs <;> simp_all [Template.HasCause]
 
@@ -148,14 +148,8 @@ theorem ofKinds_hasCause_iff (σ : Root.Kinds) :
     reduces to carrying the `result` kind — via `cause` ⟹ `result`. -/
 theorem ofKinds_hasResultState_iff {σ : Root.Kinds}
     (h : σ.WellFormed) :
-    (Template.ofKinds σ).HasResultState ↔ LexKind.result ∈ σ := by
-  have hcr : LexKind.cause ∈ σ → LexKind.result ∈ σ := by
-    intro hc
-    have hr : LexKind.result ∈ Root.Kinds.close σ :=
-      (Root.Kinds.mem_close_iff σ LexKind.result).mpr
-        ⟨LexKind.cause, hc, by decide⟩
-    have he : Root.Kinds.close σ = σ := h
-    rwa [he] at hr
+    (Template.ofKinds σ).HasResultState ↔ Root.Kind.result ∈ σ := by
+  have hcr : Root.Kind.cause ∈ σ → Root.Kind.result ∈ σ := h Root.Kind.LE.result_cause
   unfold Template.ofKinds
   split_ifs with hc hr hm <;> simp_all [Template.HasResultState]
 
@@ -167,7 +161,7 @@ def _root_.Verb.Root.template (r : Root) : Template :=
     the [beavers-koontz-garboden-2020] result entailment, bridged to the
     `EventStructure` template diagnostic. -/
 theorem _root_.Verb.Root.template_hasResultState_iff (r : Root) :
-    r.template.HasResultState ↔ LexKind.result ∈ r.closedKinds :=
+    r.template.HasResultState ↔ Root.Kind.result ∈ r.closedKinds :=
   ofKinds_hasResultState_iff r.closedKinds_wellFormed
 
 end Signature

--- a/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
@@ -45,7 +45,7 @@ namespace ArgumentStructure
 
 /-- Root kind signature for each Levin class.
 
-    Assignments marked (B&KG) are directly from [beavers-koontz-garboden-2020] Table 12 and Chapters 2–5. Others are inferred from class
+    Assignments marked (B&KG) are directly from [beavers-koontz-garboden-2020] (12) and chapters 2–5. Others are inferred from class
     semantics following B&KG's framework:
     - Externally caused CoS → `causativeResult` (√CRACK pattern)
     - Internally caused CoS → `pureResult` (√BLOSSOM pattern)
@@ -53,33 +53,33 @@ namespace ArgumentStructure
     - MRC violators → `fullSpec` (√HAND/√DROWN pattern)
     - Stative/psychological → `propertyConcept` (√FLAT pattern)
 
-    Classes marked (default) use `minimal` as a conservative placeholder
+    Classes marked (default) use `∅` as a conservative placeholder
     pending detailed study under B&KG's framework. -/
 def LevinClass.rootEntailments : LevinClass → Root.Kinds
   -- §9 Putting: template provides CAUSE+BECOME; root content varies
-  | .put => minimal                -- (default)
+  | .put => ∅                -- (default)
   | .funnel => pureManner          -- manner of channeling
   | .pour => pureManner            -- manner of pouring
   | .coil => pureManner            -- manner of arranging
-  | .sprayLoad => minimal          -- (default)
+  | .sprayLoad => ∅          -- (default)
   -- §10 Removing
-  | .remove => minimal             -- (default)
+  | .remove => ∅             -- (default)
   | .clear => causativeResult      -- externally caused cleared state
   | .wipe => pureManner            -- manner of surface action
-  | .steal => minimal              -- (default)
+  | .steal => ∅              -- (default)
   -- §11 Sending and Carrying
-  | .send => minimal               -- (default)
+  | .send => ∅               -- (default)
   | .carry => pureManner           -- manner of transport
   | .drive => pureManner           -- manner via vehicle
   -- §12 Exerting Force
   | .pushPull => pureManner        -- manner of force application
   -- §13 Change of Possession
   | .give => fullSpec              -- (B&KG Ch.3) √HAND: manner + caused possession change
-  | .contribute => minimal         -- (default) less specified than give
-  | .getObtain => minimal          -- (default)
-  | .exchange => minimal           -- (default)
+  | .contribute => ∅         -- (default) less specified than give
+  | .getObtain => ∅          -- (default)
+  | .exchange => ∅           -- (default)
   -- §14–16
-  | .learn => minimal              -- (default)
+  | .learn => ∅              -- (default)
   | .hold => propertyConcept       -- state of holding
   | .conceal => causativeResult    -- externally caused hidden state
   -- §17 Throwing
@@ -90,7 +90,7 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   -- §19 Poking
   | .poke => pureManner            -- manner of contact
   -- §20 Contact: Touch
-  | .touch => minimal              -- (B&KG) no structural entailments
+  | .touch => ∅              -- (B&KG) no structural entailments
   -- §21 Cutting
   | .cut => fullSpec               -- (B&KG Ch.4) cutting manner + caused separation
   | .carve => fullSpec             -- like cut
@@ -116,26 +116,26 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   | .calve => pureResult           -- internally caused biological process
   -- §29 Predicative Complements
   | .appoint => causativeResult    -- externally caused status change
-  | .characterize => minimal       -- (default)
+  | .characterize => ∅       -- (default)
   | .declare => causativeResult    -- externally caused status change
   -- §30 Perception
-  | .see => minimal                -- (default)
-  | .sight => minimal              -- (default)
+  | .see => ∅                -- (default)
+  | .sight => ∅              -- (default)
   -- §31 Psych-Verbs
   | .amuse => causativeResult      -- stimulus causes psychological CoS
   | .admire => propertyConcept     -- psychological state
   | .marvel => propertyConcept     -- psychological state
   -- §32–34
   | .want => propertyConcept       -- desiderative state
-  | .judgment => minimal           -- (default)
-  | .assessment => minimal         -- (default)
+  | .judgment => ∅           -- (default)
+  | .assessment => ∅         -- (default)
   -- §35 Searching
   | .search => pureManner          -- searching manner
   -- §36 Social Interaction
-  | .socialInteraction => minimal  -- (default)
+  | .socialInteraction => ∅  -- (default)
   -- §37 Communication
-  | .say => minimal                -- (default)
-  | .tell => minimal               -- (default)
+  | .say => ∅                -- (default)
+  | .tell => ∅               -- (default)
   | .mannerOfSpeaking => pureManner -- manner of speaking
   -- §38 Animal Sounds
   | .animalSound => pureManner     -- specific sound manner
@@ -144,8 +144,8 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   | .devour => fullSpec            -- vigorous manner + caused consumption
   | .dine => pureManner            -- social activity manner
   -- §40 Body
-  | .bodyProcess => minimal        -- (default)
-  | .flinch => minimal             -- (default)
+  | .bodyProcess => ∅        -- (default)
+  | .flinch => ∅             -- (default)
   -- §41 Grooming
   | .dress => causativeResult      -- externally caused dressed state
   -- §42 Killing
@@ -165,9 +165,9 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   | .entitySpecificCoS => pureResult -- √BLOSSOM/√RUST: internally caused
   | .calibratableCoS => pureResult -- internally driven scalar change
   -- §46 Lodge
-  | .lodge => minimal              -- (default)
+  | .lodge => ∅              -- (default)
   -- §47 Existence
-  | .exist => minimal              -- (B&KG) pure stative, no root content
+  | .exist => ∅              -- (B&KG) pure stative, no root content
   -- §48 Appearance, Disappearance
   | .appear => pureResult          -- internally caused appearance
   | .disappearance => pureResult   -- internally caused going out of existence
@@ -182,16 +182,16 @@ def LevinClass.rootEntailments : LevinClass → Root.Kinds
   | .vehicleMotion => pureManner   -- vehicle manner
   | .chase => pureManner           -- chasing manner
   -- §52 Avoid
-  | .avoid => minimal              -- (default)
+  | .avoid => ∅              -- (default)
   -- §53 Lingering and Rushing
   | .linger => pureManner          -- temporal manner
   | .rush => pureManner            -- temporal manner
   -- §54 Measure
   | .measure => propertyConcept    -- measurement state
   -- §55 Aspectual
-  | .aspectual => minimal          -- (default) template-level
+  | .aspectual => ∅          -- (default) template-level
   -- §57 Weather
-  | .weather => minimal            -- (default)
+  | .weather => ∅            -- (default)
 
 /-! ### Table soundness (universal)
 

--- a/Linglib/Semantics/ArgumentStructure/Root/Classification.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Classification.lean
@@ -86,7 +86,7 @@ def ChangeType.allowsRestitutiveAgain : ChangeType → Bool
     projection is manner-blind — see `Classification.salienceClass_ofKinds`
     for what survives it. -/
 def ChangeType.ofKinds (s : Root.Kinds) : ChangeType :=
-  if LexKind.result ∈ s then .result else .propertyConcept
+  if Root.Kind.result ∈ s then .result else .propertyConcept
 
 /-- Property concept root subclasses ([dixon-1982]; [beavers-etal-2021]
     ex. 5). [beavers-etal-2021] exclude human propensity from their sample
@@ -160,7 +160,7 @@ def Classification.salienceClass (c : Classification) : Option SalienceClass :=
     necessary: a manner root maps to `.propertyConcept` under
     `ChangeType.ofKinds`, where the annotation coordinates return `none`
     but the signature classifier sees agent salience. -/
-theorem Classification.salienceClass_ofKinds (h : LexKind.manner ∉ s) :
+theorem Classification.salienceClass_ofKinds (h : Root.Kind.manner ∉ s) :
     ({ valency := v, changeType := .ofKinds s,
        licensesTransitiveVoice := decide (.internal ∈ v) } :
       Classification).salienceClass = SalienceClass.ofKinds s v := by

--- a/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
@@ -5,15 +5,12 @@ import Linglib.Semantics.ArgumentStructure.Root.Kinds
 # Verbal roots
 
 A verbal root of [beavers-koontz-garboden-2020] is a bundle of lexical
-entailments (§5.2.1, after [dowty-1991]): idiosyncratic atoms, each of one of
-the four kinds the book's root typology tracks (§5.4.1, (11)) — a state, a
-manner, a change into a state, or causation. `Root` carries a finite set of
-such atoms and the root's within-class quality profile. Its kind signature
-`Root.kinds` is *derived*, the image of the atoms under `Entailment.kind`, and
-`Root.closedKinds` adds the kinds the book's collocational restrictions force
-(`Root.Kinds.close`); that closure is where the templatic content a root's own
-entailments carry with them (a cracked state entails a change, §5.2.1) enters
-the signature.
+entailments (§5.2.1), each of one of the four kinds of `Root.Kind`. `Root`
+carries a finite set of such atoms and a within-class quality profile. Its
+kind signature `Root.kinds` is the image of the atoms under `Entailment.kind`,
+and `Root.closedKinds` completes it under the collocational restrictions
+(`Root.Kinds.close`). Participant entailments are the separate linking layer
+`ArgumentStructure.EntailmentProfile`.
 
 ## Main declarations
 
@@ -24,8 +21,6 @@ the signature.
 ## References
 
 * [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
-* [dowty-1991]: Thematic proto-roles and argument selection.
-* [bohnemeyer-2004]: Split intransitivity, linking, and lexical representation.
 * [spalek-mcnally-2026], [majid-boster-bowerman-2008]: the quality dimensions of
   `Root.Profile`.
 -/
@@ -34,13 +29,8 @@ namespace Verb
 
 /-! ### Atoms -/
 
-/-- A lexical entailment a root carries, of one of the four kinds of the root
-typology of [beavers-koontz-garboden-2020] (§5.4.1, (11)). The label names the
-particular state, manner, or result; causation is unlabelled because the
-typology records only that there is a cause (the internal vs external cause
-distinction of [bohnemeyer-2004] is `EventStructure.InternalExternalCause`).
-Participant entailments (volition, sentience, …) are the separate linking layer
-`ArgumentStructure.EntailmentProfile`. -/
+/-- A lexical entailment of a verbal root, labelled by the state, manner, or result
+it names ([beavers-koontz-garboden-2020] §5.4.1). -/
 inductive Root.Entailment where
   /-- The root describes the labelled state. -/
   | state (label : String)
@@ -52,8 +42,8 @@ inductive Root.Entailment where
   | cause
   deriving DecidableEq, Repr
 
-/-- The kind of an atom: forget its label. -/
-def Root.Entailment.kind : Root.Entailment → LexKind
+/-- The kind of an atom, forgetting its label. -/
+def Root.Entailment.kind : Root.Entailment → Root.Kind
   | .state _ => .state
   | .manner _ => .manner
   | .result _ => .result
@@ -61,8 +51,7 @@ def Root.Entailment.kind : Root.Entailment → LexKind
 
 /-! ### Roots -/
 
-/-- A verbal root: its form, the lexical entailments it carries, and its
-within-class quality profile. -/
+/-- A verbal root, with its lexical entailments and quality profile. -/
 structure Root where
   /-- The root form, `""` when the root is carried anonymously by a verb whose
   citation form names it. -/
@@ -74,26 +63,26 @@ structure Root where
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- `Finset` has only an `unsafe` `Repr`, so `Root` cannot derive one; this shows
-the name, the number of atoms, and the profile. -/
+/-- A `Repr` showing the name, atom count, and profile, since `Finset` has only an
+`unsafe` one. -/
 instance : Repr Root := ⟨λ r _ => repr (r.name, r.entailments.card, r.profile)⟩
 
 namespace Root
 
 variable (r : Root)
 
-/-- The kind signature of a root: the kinds of its atoms. -/
+/-- The kind signature of a root, the kinds of its atoms. -/
 def kinds : Kinds := r.entailments.image Entailment.kind
 
 variable {r} in
-@[simp] theorem mem_kinds {k : LexKind} : k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = k :=
+@[simp] theorem mem_kinds {k : Kind} : k ∈ r.kinds ↔ ∃ a ∈ r.entailments, a.kind = k :=
   Finset.mem_image
 
-/-- The closed signature: `kinds` completed under the collocational restrictions
-of [beavers-koontz-garboden-2020] (`Root.Kinds.close`). -/
+/-- The kind signature completed under the collocational restrictions
+(`Root.Kinds.close`). -/
 def closedKinds : Kinds := r.kinds.close
 
-theorem kinds_le_closedKinds : r.kinds ≤ r.closedKinds := Kinds.le_close _
+theorem kinds_subset_closedKinds : r.kinds ⊆ r.closedKinds := Kinds.subset_close _
 
 theorem closedKinds_wellFormed : r.closedKinds.WellFormed := Kinds.close_wellFormed _
 

--- a/Linglib/Semantics/ArgumentStructure/Root/Kinds.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Kinds.lean
@@ -1,190 +1,123 @@
-import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Powerset
-import Mathlib.Order.UpperLower.Basic
-import Mathlib.Order.Closure
+import Mathlib.Order.UpperLower.Closure
 import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Root kind signatures
 
-The four-feature vocabulary of [beavers-koontz-garboden-2020]'s root
-typology (ch. 5): `LexKind` with the book's collocational order
-(`state < result < cause`, `manner` isolated), and a root's **kind
-signature** — the kinds of lexical entailment it carries — as a
-`Finset LexKind`, so signatures inherit the Boolean lattice of finite
-sets (`≤` is "carries at most these kinds"). Well-formedness is
-downward-closedness in the collocational order, and `close` — the
-induced lower closure, packaged as a mathlib `ClosureOperator` —
-repairs any signature to a well-formed one.
-
-This file is `Root`-free: consumers that map other objects to signatures
-(e.g. Levin classes, the salience classifier) can import it without the
-root substrate.
+The root typology of [beavers-koontz-garboden-2020] (§5.4.1) records which of
+four kinds of lexical entailment a root carries — state, manner, result, cause —
+under two collocational restrictions, that a change entails a state and a cause
+entails a change. The restrictions are the partial order `state ≤ result ≤ cause`
+on `Root.Kind`, with `manner` isolated. A root's kind signature is a
+`Finset Root.Kind`; it is well-formed when it is a lower set of that order, and
+`close` sends any signature to its lower closure. The named signatures are the
+attested rows of the typology's display (12).
 
 ## Main declarations
 
-* `LexKind`, with its collocational `PartialOrder`
-* `Root.Kinds := Finset LexKind`
-* `Root.Kinds.close`, `Root.Kinds.closeOp`, `Root.Kinds.WellFormed`
-* canonical signatures (`propertyConcept`, `pureResult`,
-  `causativeResult`, `pureManner`, `mannerResult`, `fullSpec`,
-  `minimal`)
+* `Root.Kind`, with the collocational `PartialOrder`
+* `Root.Kinds`, `Root.Kinds.close`, `Root.Kinds.WellFormed`
+* `Root.Kinds.propertyConcept`, `pureResult`, `causativeResult`, `pureManner`,
+  `fullSpec`
+
+## References
+
+* [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
 -/
 
 namespace Verb
 
-/-! ### Lexical entailment kinds -/
+/-! ### Kinds -/
 
-/-- The four kinds of lexical entailment of
-    [beavers-koontz-garboden-2020]'s root typology. -/
-inductive LexKind where
+/-- The kinds of lexical entailment in the root typology of
+[beavers-koontz-garboden-2020]. -/
+inductive Root.Kind where
   | state
   | manner
   | result
   | cause
   deriving DecidableEq, Fintype, Repr
 
-namespace LexKind
+namespace Root.Kind
 
-/-- Boolean table for the collocational order. -/
-private def leB : LexKind → LexKind → Bool
-  | .state,  .state  => true
-  | .state,  .result => true
-  | .state,  .cause  => true
-  | .result, .result => true
-  | .result, .cause  => true
-  | .cause,  .cause  => true
-  | .manner, .manner => true
-  | _,       _       => false
+/-- The collocational order, `state ≤ result ≤ cause` with `manner` isolated, since a
+change entails a state and a cause entails a change. -/
+protected inductive LE : Kind → Kind → Prop
+  | refl (a) : Kind.LE a a
+  | state_result : Kind.LE state result
+  | state_cause : Kind.LE state cause
+  | result_cause : Kind.LE result cause
 
-/-- The collocational order of [beavers-koontz-garboden-2020]:
-    `state < result < cause` (a cause presupposes a result, a result
-    presupposes a state), with `manner` incomparable to the chain. -/
-instance : PartialOrder LexKind where
-  le a b := leB a b = true
-  le_refl a := by cases a <;> rfl
-  le_trans a b c := by revert a b c; decide
-  le_antisymm a b := by revert a b; decide
+instance : LE Kind := ⟨Kind.LE⟩
 
-instance : DecidableLE LexKind := fun _ _ => inferInstanceAs (Decidable (_ = true))
+instance : DecidableLE Kind := fun a b => by
+  cases a <;> cases b <;> first | exact isTrue (by constructor) | exact isFalse (by rintro ⟨_⟩)
 
-end LexKind
+instance : PartialOrder Kind where
+  le_refl := .refl
+  le_trans := by decide
+  le_antisymm := by decide
 
-/-! ### Kind signatures -/
+end Root.Kind
 
-/-- A root kind signature: the set of entailment kinds carried.
-    `≤` (= `⊆`) and the lattice operations come from `Finset`. -/
-abbrev Root.Kinds := Finset LexKind
+/-! ### Signatures -/
+
+/-- A root kind signature, the set of kinds a root carries. -/
+abbrev Root.Kinds := Finset Root.Kind
 
 namespace Root.Kinds
 
-/-- The collocational closure: a signature carrying `cause` is
-    completed with `result` and `state`; one carrying `result` is
-    completed with `state`. This is the lower closure under the
-    `LexKind` order (`mem_close_iff`). -/
-def close (s : Root.Kinds) : Root.Kinds :=
-  s ∪ (if .cause ∈ s then {.result, .state} else ∅)
-    ∪ (if .result ∈ s then {.state} else ∅)
+open Finset
 
-theorem le_close : ∀ s : Root.Kinds, s ≤ close s := by decide
+variable {s t : Kinds}
 
-theorem close_idem : ∀ s : Root.Kinds, close (close s) = close s := by
-  decide
+/-- The collocational closure of a signature, its lower closure in the kind order. -/
+def close (s : Kinds) : Kinds := univ.filter (∃ j ∈ s, · ≤ j)
 
-theorem close_mono : ∀ {s t : Root.Kinds}, s ≤ t → close s ≤ close t := by
-  decide
+@[simp] theorem mem_close {k : Kind} : k ∈ close s ↔ ∃ j ∈ s, k ≤ j := by simp [close]
 
-/-- `close` is the lower closure under the collocational order:
-    `k` is in the closure iff some kind in `s` dominates it. -/
-theorem mem_close_iff : ∀ (s : Root.Kinds) (k : LexKind),
-    k ∈ close s ↔ ∃ j ∈ s, k ≤ j := by decide
+@[simp] theorem coe_close (s : Kinds) : (close s : Set Kind) = lowerClosure (s : Set Kind) := by
+  ext; simp
 
-/-- The collocational closure as a mathlib `ClosureOperator`. -/
-def closeOp : ClosureOperator Root.Kinds where
-  toFun := close
-  monotone' _ _ := close_mono
-  le_closure' := le_close
-  idempotent' := close_idem
+theorem subset_close (s : Kinds) : s ⊆ close s := fun k hk => mem_close.2 ⟨k, hk, le_rfl⟩
 
-/-- A signature is well-formed iff it already satisfies the
-    collocational constraints (it is a fixed point of `close`). -/
-def WellFormed (s : Root.Kinds) : Prop := close s = s
+theorem close_mono (h : s ⊆ t) : close s ⊆ close t := by
+  simp only [subset_iff, mem_close] at h ⊢
+  exact fun k ⟨j, hj, hkj⟩ => ⟨j, h hj, hkj⟩
 
-instance (s : Root.Kinds) : Decidable s.WellFormed :=
-  inferInstanceAs (Decidable (_ = _))
+theorem close_close (s : Kinds) : close (close s) = close s :=
+  coe_injective <| by simp
 
-/-- Well-formedness is downward-closedness in the `LexKind` order. -/
-theorem wellFormed_iff_isLowerSet (s : Root.Kinds) :
-    s.WellFormed ↔ IsLowerSet (↑s : Set LexKind) := by
-  constructor
-  · intro hwf a b hba ha
-    have hb : b ∈ close s := (mem_close_iff s b).mpr ⟨a, Finset.mem_coe.mp ha, hba⟩
-    rw [hwf] at hb
-    exact Finset.mem_coe.mpr hb
-  · intro h
-    refine le_antisymm (fun k hk => ?_) (le_close s)
-    obtain ⟨j, hj, hkj⟩ := (mem_close_iff s k).mp hk
-    exact Finset.mem_coe.mp (h hkj (Finset.mem_coe.mpr hj))
+/-- A signature is well-formed if it respects the collocational restrictions, that is,
+if it is a lower set of the kind order. -/
+def WellFormed (s : Kinds) : Prop := IsLowerSet (s : Set Kind)
 
-/-- Closure output is always well-formed — the collocational
-    constraints hold of closed signatures *by construction*. -/
-theorem close_wellFormed : ∀ s : Root.Kinds, (close s).WellFormed :=
-  close_idem
+instance : DecidablePred WellFormed := fun s =>
+  inferInstanceAs (Decidable (∀ a b : Kind, b ≤ a → a ∈ s → b ∈ s))
 
-/-! ### Canonical signatures
+theorem wellFormed_iff_close_eq : s.WellFormed ↔ close s = s := by
+  rw [WellFormed, ← lowerClosure_eq, ← coe_close, coe_inj]
 
-The attested rows of the root typology of [beavers-koontz-garboden-2020]
-ch. 5 (their example display (12), §5.4). -/
+theorem close_wellFormed (s : Kinds) : (close s).WellFormed := by
+  rw [WellFormed, coe_close]; exact (lowerClosure _).lower
 
-/-- +S −M −R −C: property concept roots (√FLAT, √DRY).
-    Deadjectival COS verbs — the root names the result state.
-    Complement position. -/
-def propertyConcept : Root.Kinds := {.state}
+/-! ### The attested rows of the typology -/
 
-/-- +S −M +R −C: internally caused result roots (√BLOSSOM, √RUST).
-    Root entails both a state and a change to that state, but not
-    external causation. Complement position. -/
-def pureResult : Root.Kinds := {.state, .result}
+/-- The signature of property-concept roots (√flat). -/
+def propertyConcept : Kinds := {.state}
 
-/-- +S −M +R +C: externally caused result roots (√CRACK, √BREAK).
-    Root entails a state, change, AND causation. If roots subdivide by
-    entailed causation, this may underlie Levin & Rappaport Hovav's
-    (1995) externally vs internally caused change-of-state distinction
-    ([beavers-koontz-garboden-2020], hedged as a possibility).
-    Complement position. -/
-def causativeResult : Root.Kinds := {.state, .result, .cause}
+/-- The signature of result roots without causation (√blossom). -/
+def pureResult : Kinds := {.state, .result}
 
-/-- −S +M −R −C: pure manner roots (√JOG, √RUN, √SWIM).
-    Root specifies action manner without entailing any state.
-    Adjoined position. -/
-def pureManner : Root.Kinds := {.manner}
+/-- The signature of caused-result roots (√crack). -/
+def causativeResult : Kinds := {.state, .result, .cause}
 
-/-- +S +M +R −C: manner + result without cause. Well-formed per the
-    constraints; [beavers-koontz-garboden-2020] leave its attestation
-    an open question ("whether a change and a manner can exist together
-    in a single meaning without causation"), with candidate witnesses
-    *slide* and motion-in-sound-emission *buzz*. -/
-def mannerResult : Root.Kinds := {.state, .manner, .result}
+/-- The signature of pure manner roots (√jog). -/
+def pureManner : Kinds := {.manner}
 
-/-- +S +M +R +C: fully specified roots (√HAND adjoined, √DROWN and the
-    other manner-of-killing roots in complement position;
-    [beavers-koontz-garboden-2020] chs. 3–4). These are the attested
-    MRC violators. The adjoined/complement contrast is carried by
-    `Root.Position`, not by the signature. -/
-def fullSpec : Root.Kinds := {.state, .manner, .result, .cause}
-
-/-- −S −M −R −C: minimal roots — no structural entailments.
-    Conservative default for classes not yet studied under B&KG's
-    framework. Not a row in B&KG's typology (which only lists roots
-    with at least one positive feature). -/
-def minimal : Root.Kinds := ∅
-
-/-- Every canonical signature is well-formed. -/
-theorem canonical_wellFormed :
-    propertyConcept.WellFormed ∧ pureResult.WellFormed ∧
-    causativeResult.WellFormed ∧ pureManner.WellFormed ∧
-    mannerResult.WellFormed ∧ fullSpec.WellFormed ∧ minimal.WellFormed := by
-  decide
+/-- The signature of roots carrying every kind (√hand, √drown). -/
+def fullSpec : Kinds := univ
 
 end Root.Kinds
 

--- a/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
@@ -76,7 +76,7 @@ def SalienceClass.ofKinds : Option SalienceClass :=
 /-- Collocational closure does not move the transitiviser cut on
     cause-free signatures: the only available closure edge is
     result→state, which no arm of the classifier consults. -/
-theorem SalienceClass.ofKinds_close (h : LexKind.cause ∉ s) :
+theorem SalienceClass.ofKinds_close (h : Root.Kind.cause ∉ s) :
     ofKinds s.close v = ofKinds s v := by
   revert s v; decide
 

--- a/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
+++ b/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
@@ -131,8 +131,8 @@ theorem causative_entails_resultState (M : CosModel Entity State T)
     kinds *select the event template* — the denotational payoff of the signature. -/
 def denote (M : CosModel Entity State T) (v : Verb) (y x : Entity) :
     Event T → Prop :=
-  if LexKind.cause ∈ v.closedKinds then M.causative v y x
-  else if LexKind.result ∈ v.closedKinds then M.inchoative v x
+  if Root.Kind.cause ∈ v.closedKinds then M.causative v y x
+  else if Root.Kind.result ∈ v.closedKinds then M.inchoative v x
   else M.manner v
 
 /-- The denotational payoff of a `.result` root: any verb whose root signature
@@ -143,10 +143,10 @@ def denote (M : CosModel Entity State T) (v : Verb) (y x : Entity) :
     `denote` is the manner core). -/
 theorem denote_result_entails_resultState (M : CosModel Entity State T)
     (v : Verb) (y x : Entity) (e : Event T)
-    (hres : LexKind.result ∈ v.closedKinds)
+    (hres : Root.Kind.result ∈ v.closedKinds)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   unfold denote at h
-  by_cases hc : LexKind.cause ∈ v.closedKinds
+  by_cases hc : Root.Kind.cause ∈ v.closedKinds
   · rw [if_pos hc] at h
     exact M.causative_entails_resultState v y x e h
   · rw [if_neg hc, if_pos hres] at h
@@ -161,7 +161,7 @@ theorem denote_result_from_template (M : CosModel Entity State T)
     (v : Verb) (ht : v.root.template.HasResultState) (y x : Entity) (e : Event T)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   refine M.denote_result_entails_resultState v y x e ?_ h
-  show LexKind.result ∈ v.root.closedKinds
+  show Root.Kind.result ∈ v.root.closedKinds
   exact (Verb.Root.template_hasResultState_iff v.root).mp ht
 
 end Verb.CosModel

--- a/Linglib/Studies/BeaversEtAl2021.lean
+++ b/Linglib/Studies/BeaversEtAl2021.lean
@@ -297,17 +297,17 @@ theorem pc_roots_consistent_with_bifurcation :
 entail change, causation, and manner simultaneously (√GUILLOTINE, √HAND) —
 witnessed by `Root.Kinds.fullSpec`. -/
 theorem bkg_bifurcation_fails_all_dimensions :
-    LexKind.result ∈ Root.Kinds.fullSpec ∧
-    LexKind.cause ∈ Root.Kinds.fullSpec ∧
-    LexKind.manner ∈ Root.Kinds.fullSpec ∧
-    LexKind.state ∈ Root.Kinds.fullSpec := by decide
+    Root.Kind.result ∈ Root.Kinds.fullSpec ∧
+    Root.Kind.cause ∈ Root.Kinds.fullSpec ∧
+    Root.Kind.manner ∈ Root.Kinds.fullSpec ∧
+    Root.Kind.state ∈ Root.Kinds.fullSpec := by decide
 
 /-- Multiple Levin classes witness the stronger bifurcation failure. -/
 theorem bkg_bifurcation_multiple_witnesses :
-    LexKind.result ∈ LevinClass.rootEntailments .cut ∧
-    LexKind.manner ∈ LevinClass.rootEntailments .cut ∧
-    LexKind.cause ∈ LevinClass.rootEntailments .give ∧
-    LexKind.manner ∈ LevinClass.rootEntailments .give := by decide
+    Root.Kind.result ∈ LevinClass.rootEntailments .cut ∧
+    Root.Kind.manner ∈ LevinClass.rootEntailments .cut ∧
+    Root.Kind.cause ∈ LevinClass.rootEntailments .give ∧
+    Root.Kind.manner ∈ LevinClass.rootEntailments .give := by decide
 
 /-! ### Default realization ((44), §8) -/
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -38,6 +38,8 @@ which root types are attested.
 * `flat`, `jog`, `blossom`, `crack`, `hand`, `drown`
 * `exists_violatesBifurcation`, `bifurcation_thesis_false`
 * `exists_hasMannerAndResult`, `manner_result_complementarity_false`
+* `Root.Kinds.typology`, `wellFormed_iff_mem_typology` — the rows of (12) and
+  their exhaustiveness
 * `Verb.CosModel.again` and the (25)–(27) reading hierarchy
 
 The thesis predicates and the sublexical *again* operator are carried
@@ -85,7 +87,7 @@ theorem violatesBifurcation_mono :
     Manner/Result Complementarity ([rappaport-hovav-levin-2010])
     claims no root realizes. -/
 def HasMannerAndResult (s : Root.Kinds) : Prop :=
-  {LexKind.manner, LexKind.result} ≤ s
+  {Root.Kind.manner, Root.Kind.result} ≤ s
 
 instance (s : Root.Kinds) : Decidable s.HasMannerAndResult :=
   inferInstanceAs (Decidable (_ ≤ _))
@@ -105,6 +107,18 @@ theorem hasMannerAndResult_close_iff :
     ∀ s : Root.Kinds,
       (close s).HasMannerAndResult ↔
         s.HasMannerAndResult ∨ (.manner ∈ s ∧ .cause ∈ s) := by decide
+
+/-! ### The typology -/
+
+/-- The seven rows of the typology (12). -/
+def typology : Finset Root.Kinds :=
+  {propertyConcept, pureResult, causativeResult, pureManner, {.state, .manner},
+   {.state, .manner, .result}, fullSpec}
+
+/-- The typology (12) is exhaustive, since the signatures respecting the collocational
+    restrictions are its seven rows and `∅`. -/
+theorem wellFormed_iff_mem_typology :
+    ∀ s : Root.Kinds, s.WellFormed ↔ s = ∅ ∨ s ∈ typology := by decide
 
 end Verb.Root.Kinds
 

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -205,7 +205,7 @@ Her (37) puts CAUSE in the simple forms of *eat* and *dress*; the substrate's
 of contact is the *presence* of CAUSE, not its source — for [krejci-2012] the
 causer is the coidentified agent itself, and she argues explicitly against
 deriving the causative by adding an external causer ((93) vs. (96)–(97)).
-`learn`'s root is still the substrate's conservative `minimal` placeholder, so
+`learn`'s root is still the substrate's conservative `∅` placeholder, so
 the bridge is stated for *eat* and *dress* only.
 
 The accomplishment template licenses an intransitive (achievement) variant,
@@ -225,7 +225,7 @@ theorem dress_is_causativeResult :
 /-- causativeResult roots carry the `cause` kind — CAUSE is in the simple
     form, as her (37) requires. -/
 theorem causativeResult_entails_cause :
-    LexKind.cause ∈ causativeResult := by decide
+    Root.Kind.cause ∈ causativeResult := by decide
 
 /-- eat roots license the accomplishment template. -/
 theorem eat_licenses_accomplishment :

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -407,7 +407,7 @@ theorem positional_crosscuts_transitiviser_classes :
 
 /-- For cause-free roots — every root in this sample — collocational
     closure does not change the predicted class. -/
-theorem predictedClass_closure_invariant (r : Root) (h : LexKind.cause ∉ r.kinds) :
+theorem predictedClass_closure_invariant (r : Root) (h : Root.Kind.cause ∉ r.kinds) :
     SalienceClass.ofKinds r.closedKinds (valency r) = predictedClass r :=
   SalienceClass.ofKinds_close r.kinds (valency r) h
 

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -852,7 +852,7 @@ theorem largeVase_score_le_one :
     state inheritance from root to deverbal adjective is refuted at
     substrate level. -/
 theorem cracked_adj_refutes_bkg_crack_root_inheritance :
-    Verb.LexKind.result ∈ BeaversKoontzGarboden2020.crack.kinds ∧
+    Verb.Root.Kind.result ∈ BeaversKoontzGarboden2020.crack.kinds ∧
     crack.adjEntailsPrecedingChange = false :=
   ⟨by decide, rfl⟩
 


### PR DESCRIPTION
`Root.Kind`'s collocational order is a `protected inductive LE` whose constructors are the book's two restrictions (mathlib's `SignType` shape), replacing the Boolean table; `close` is the lower closure (`coe_close` bridges to `lowerClosure`) and `WellFormed` is `IsLowerSet`, so the closure lemmas and the cause→result→state hierarchy are structural rather than `decide`d.

- `LexKind` → `Root.Kind` (owner-relative, matching `Root.Entailment`); `closeOp`, `minimal` (now `∅`), `mannerResult`, `canonical_wellFormed` dissolved
- `Studies/BeaversKoontzGarboden2020`: display (12) as `Root.Kinds.typology` with its exhaustiveness theorem
- `Root/Defs.lean` docstrings cut to mathlib register