### PR TITLE
refactor(Semantics/ArgumentStructure/Root): position as a Root coordinate

### DIFF
--- a/Linglib/Fragments/Dargwa/ComplexPredicates.lean
+++ b/Linglib/Fragments/Dargwa/ComplexPredicates.lean
@@ -267,14 +267,9 @@ theorem some_lvs_bound :
 -- § 7: NV Root Position ([kalyakin-2026] §2.2)
 -- ============================================================================
 
-/-- A complex predicate annotated with its NV root position, following
-    Marantz (2009a;b, 2013) as applied to Dargwa by [kalyakin-2026] §2.2.
-
-    Uses `Root.Position` (`Semantics/Lexical/Roots/Template.lean`):
-    - `.complement`: change-of-state roots — *wana* 'warm', *hark* 'open'
-    - `.adjoined`: manner/activity roots — *duc'* 'run', *taˤh* 'jump'
-
-    The vVPE eligibility implications are derived in the study file. -/
+/-- A complex predicate annotated with the position of its non-verbal root
+    ([kalyakin-2026] §2.2), where change-of-state roots such as *wana* 'warm' are
+    complements and manner roots such as *duc'* 'run' are adjoined. -/
 structure AnnotatedCPr where
   lexicalStem : String
   stemGloss : String

--- a/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
@@ -1,12 +1,14 @@
 import Linglib.Semantics.ArgumentStructure.Root.Profile
 import Linglib.Semantics.ArgumentStructure.Root.Kinds
+import Linglib.Semantics.ArgumentStructure.Root.Position
 
 /-!
 # Verbal roots
 
 A verbal root of [beavers-koontz-garboden-2020] is a bundle of lexical
 entailments (§5.2.1), each of one of the four kinds of `Root.Kind`. `Root`
-carries a finite set of such atoms and a within-class quality profile. Its
+carries a finite set of such atoms, its position with respect to `v`, and a
+within-class quality profile. Its
 kind signature `Root.kinds` is the image of the atoms under `Entailment.kind`,
 and `Root.closedKinds` completes it under the collocational restrictions
 (`Root.Kinds.close`). Participant entailments are the separate linking layer
@@ -15,7 +17,7 @@ and `Root.closedKinds` completes it under the collocational restrictions
 ## Main declarations
 
 * `Root.Entailment` — a labelled atom; `Root.Entailment.kind` forgets the label
-* `Root` — name, atoms, quality profile
+* `Root` — name, atoms, position, quality profile
 * `Root.kinds`, `Root.closedKinds` — the derived and the closed signature
 
 ## References
@@ -51,21 +53,24 @@ def Root.Entailment.kind : Root.Entailment → Root.Kind
 
 /-! ### Roots -/
 
-/-- A verbal root, with its lexical entailments and quality profile. -/
+/-- A verbal root, with its lexical entailments, position, and quality profile. -/
 structure Root where
   /-- The root form, `""` when the root is carried anonymously by a verb whose
   citation form names it. -/
   name : String := ""
   /-- The root's atoms, `∅` where its structural content is unannotated. -/
   entailments : Finset Verb.Root.Entailment := ∅
+  /-- The position in which the root composes with `v`, where annotated. -/
+  position : Option Verb.Root.Position := none
   /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
   [majid-boster-bowerman-2008]); `{}` leaves every dimension unconstrained. -/
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- A `Repr` showing the name, atom count, and profile, since `Finset` has only an
-`unsafe` one. -/
-instance : Repr Root := ⟨λ r _ => repr (r.name, r.entailments.card, r.profile)⟩
+/-- A `Repr` showing the name, atom count, position, and profile, since `Finset` has
+only an `unsafe` one. -/
+instance : Repr Root :=
+  ⟨λ r _ => repr (r.name, r.entailments.card, r.position, r.profile)⟩
 
 namespace Root
 

--- a/Linglib/Semantics/ArgumentStructure/Root/Position.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Position.lean
@@ -1,39 +1,34 @@
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Root attachment position
+# Root position
 
-A verb root attaches in one of two structural positions
-([beavers-koontz-garboden-2020] ch. 1; the Distributed-Morphology tradition,
-Marantz): adjoined to a head, or as a head's complement. The distinction
-conditions vVPE eligibility ([kalyakin-2026]), result-state modifier scope, and
-the restitutive/repetitive *again* ambiguity ([merchant-2013]).
+A verbal root composes with the verbalizing head `v` either as its complement, the
+result position of change-of-state roots such as √flat and √drown, or adjoined to it
+as a modifier, the manner position of √jog and √hand ([beavers-koontz-garboden-2020]
+§4.5.3–4.5.4). Position is the second coordinate of the book's root typology (§5.4.1,
+(12)), and an adjoined root escapes both the scope of restitutive *again* (§4.5.4) and
+the deletion site of verbal VP ellipsis ([kalyakin-2026] §2.2).
 
 ## Main declarations
 
-* `Root.Position` — complement vs adjoined attachment
+* `Root.Position`
+
+## References
+
+* [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
+* [kalyakin-2026]: VP ellipsis and argument structure alternations: Evidence from
+  Muira Dargwa complex predicates.
 -/
 
 namespace Verb
 
-/-! ### Root position -/
-
-/-- Structural attachment position of a verb root, following the
-    Distributed-Morphology tradition (Marantz; systematized by
-    [beavers-koontz-garboden-2020]):
-
-    - **complement**: root merges as complement of v (inside VP),
-      filling the result/state slot (√flat, √crack, √blossom, √drown);
-    - **adjoined**: root merges as adjunct to v (outside VP), modifying
-      the event (√jog, √toss, √hand).
-
-    The distinction matters beyond root typology: it conditions vVPE
-    eligibility ([kalyakin-2026]), result-state modifier scope, and the
-    restitutive/repetitive *again* ambiguity
-    ([beavers-koontz-garboden-2020], [merchant-2013]). -/
+/-- The position in which a verbal root composes with `v`. -/
 inductive Root.Position where
+  /-- The complement of `v`, the result position. -/
   | complement
+  /-- Adjoined to `v` as a modifier, the manner position. -/
   | adjoined
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Fintype, Repr
 
 end Verb

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -40,6 +40,7 @@ which root types are attested.
 * `exists_hasMannerAndResult`, `manner_result_complementarity_false`
 * `Root.Kinds.typology`, `wellFormed_iff_mem_typology` — the rows of (12) and
   their exhaustiveness
+* `Root.Kinds.attestedCells`, `cells_attested` — the filled cells of (12)
 * `Verb.CosModel.again` and the (25)–(27) reading hierarchy
 
 The thesis predicates and the sublexical *again* operator are carried
@@ -119,6 +120,11 @@ def typology : Finset Root.Kinds :=
     restrictions are its seven rows and `∅`. -/
 theorem wellFormed_iff_mem_typology :
     ∀ s : Root.Kinds, s.WellFormed ↔ s = ∅ ∨ s ∈ typology := by decide
+
+/-- The filled cells of (12), pairs of a closed signature and a position. -/
+def attestedCells : Finset (Root.Kinds × Root.Position) :=
+  {(propertyConcept, .complement), (pureResult, .complement), (causativeResult, .complement),
+   (pureManner, .adjoined), (fullSpec, .adjoined), (fullSpec, .complement)}
 
 end Verb.Root.Kinds
 
@@ -273,32 +279,37 @@ open Verb
 /-! ### The six representative roots -/
 
 /-- √flat — pure state. -/
-def flat : Root := ⟨"flat", {.state "flat"}, {}⟩
+def flat : Root := { name := "flat", entailments := {.state "flat"}, position := some .complement }
 
 /-- √jog — pure manner of motion. -/
-def jog : Root := ⟨"jog", {.manner "jogging-gait"}, {}⟩
+def jog : Root :=
+  { name := "jog", entailments := {.manner "jogging-gait"}, position := some .adjoined }
 
 /-- √blossom — result with no specified manner or cause (an
     internally caused change of state). -/
-def blossom : Root := ⟨"blossom", {.result "flowering"}, {}⟩
+def blossom : Root :=
+  { name := "blossom", entailments := {.result "flowering"}, position := some .complement }
 
 /-- √crack — caused result without specified manner. -/
-def crack : Root := ⟨"crack", {.result "fissured", .cause}, {}⟩
+def crack : Root :=
+  { name := "crack", entailments := {.result "fissured", .cause}, position := some .complement }
 
 /-- √hand — manner + cause + result, adjoined position. The
     possession result is non-cancelable ("Mary handed John the book,
     #but it never came to be on his person", ch. 3 (48)), so it is
     root-entailed rather than implicated. -/
-def hand : Root := ⟨"hand",
-  {.manner "by-hand-transfer",
-   .result "in-recipient-possession",
-   .cause}, {}⟩
+def hand : Root :=
+  { name := "hand",
+    entailments := {.manner "by-hand-transfer", .result "in-recipient-possession", .cause},
+    position := some .adjoined }
 
 /-- √drown — manner of killing (Levin 1993's *crucify, drown, hang,
     electrocute* class; [beavers-koontz-garboden-2020] ch. 4):
     manner + cause + result, complement position. -/
-def drown : Root := ⟨"drown",
-  {.manner "submersion-in-liquid", .result "dead", .cause}, {}⟩
+def drown : Root :=
+  { name := "drown",
+    entailments := {.manner "submersion-in-liquid", .result "dead", .cause},
+    position := some .complement }
 
 /-! ### Kind signatures
 
@@ -344,6 +355,15 @@ theorem hand_closedKinds :
 
 theorem drown_closedKinds :
     drown.closedKinds = Root.Kinds.fullSpec := by decide
+
+/-- Each of the six roots fills a cell of (12). -/
+theorem cells_attested :
+    ∀ r ∈ [flat, jog, blossom, crack, hand, drown],
+      ∃ p, r.position = some p ∧ (r.closedKinds, p) ∈ Root.Kinds.attestedCells := by decide
+
+/-- √hand and √drown share a signature and differ only in position. -/
+theorem hand_drown_differ_in_position :
+    hand.closedKinds = drown.closedKinds ∧ hand.position ≠ drown.position := by decide
 
 /-! ### Falsifying the Bifurcation Thesis -/
 

--- a/Linglib/Studies/Kalyakin2026.lean
+++ b/Linglib/Studies/Kalyakin2026.lean
@@ -274,10 +274,8 @@ theorem again_distinguishes_vVPE_from_englishVPE :
 
 open Dargwa.ComplexPredicates in
 
-/-- Is a CPr's NV inside vVPE's deletion domain?
-    The fragment's `AnnotatedCPr` stores `Root.Position` (from
-    `Semantics/Lexical/Roots/Template.lean`); this function bridges to the
-    Minimalist `rootInVVPEDomain` from `DeletionDomain.lean`. -/
+/-- Whether a CPr's non-verbal root lies in vVPE's deletion domain, `rootInVVPEDomain`
+    at the position the fragment annotates. -/
 def cprInVVPEDomain (cpr : Dargwa.ComplexPredicates.AnnotatedCPr) : Prop :=
   rootInVVPEDomain cpr.rootPosition
 

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -70,19 +70,19 @@ open Verb ArgumentStructure Morphology
 /-! ### Agent-salient roots (p. 629, ex. (1a)) -/
 
 /-- síit' 'jump' (ex. (1a)). -/
-def siit : Root := ⟨"síit'", {.manner "jumping"}, {}⟩
+def siit : Root := { name := "síit'", entailments := {.manner "jumping"} }
 
 /-- ¢'iib' 'write' (p. 629). -/
-def tziib : Root := ⟨"¢'iib'", {.manner "writing"}, {}⟩
+def tziib : Root := { name := "¢'iib'", entailments := {.manner "writing"} }
 
 /-- mìis 'sweep' (p. 629); denominal from 'broom'. -/
-def miis : Root := ⟨"mìis", {.manner "sweeping"}, {}⟩
+def miis : Root := { name := "mìis", entailments := {.manner "sweeping"} }
 
 /-- čé'eh 'smile' (p. 629). -/
-def cheh : Root := ⟨"čé'eh", {.manner "smiling"}, {}⟩
+def cheh : Root := { name := "čé'eh", entailments := {.manner "smiling"} }
 
 /-- páak 'weed' (p. 629). -/
-def paak : Root := ⟨"páak", {.manner "weeding"}, {}⟩
+def paak : Root := { name := "páak", entailments := {.manner "weeding"} }
 
 /-! ### Agent-patient salient roots (p. 629, ex. (1b))
 
@@ -91,20 +91,20 @@ Root transitives. They carry no uniform signature: *kuč*, *p'is*, *ha¢*,
 *hit* type), while *k'os* 'cut' is manner+result (their *cut* type). -/
 
 /-- kuč 'carry' (ex. (1b)). -/
-def kuc : Root := ⟨"kuč", {.manner "carrying"}, {}⟩
+def kuc : Root := { name := "kuč", entailments := {.manner "carrying"} }
 
 /-- k'os 'cut' (p. 629); manner+result. -/
 def kos : Root :=
-  ⟨"k'os", {.manner "cutting", .result "cut"}, {}⟩
+  { name := "k'os", entailments := {.manner "cutting", .result "cut"} }
 
 /-- p'is 'measure' (p. 629); no entailed change of state. -/
-def pis : Root := ⟨"p'is", {.manner "measuring"}, {}⟩
+def pis : Root := { name := "p'is", entailments := {.manner "measuring"} }
 
 /-- ha¢ 'whip' (p. 629). -/
-def hats : Root := ⟨"ha¢", {.manner "whipping"}, {}⟩
+def hats : Root := { name := "ha¢", entailments := {.manner "whipping"} }
 
 /-- loš 'punch' (p. 629); surface contact without entailed result. -/
-def los : Root := ⟨"loš", {.manner "striking"}, {}⟩
+def los : Root := { name := "loš", entailments := {.manner "striking"} }
 
 /-! ### Patient-salient roots (ex. (2), pp. 629–630)
 
@@ -113,41 +113,41 @@ adjacency" (fn. 7): 'ah ~ wen, siih ~ kíim, tú'ub' ~ k'a'ah, ču'un ~
 č'en, hó'op' ~ háaw. The order below is the list's. -/
 
 /-- 'ah '(a)wake(n)' ('ah=s 'wake (someone)'). -/
-def ah : Root := ⟨"'ah", {.result "awake"}, {}⟩
+def ah : Root := { name := "'ah", entailments := {.result "awake"} }
 
 /-- wen '(fall a)sleep' (ween=s 'put to sleep'); fn. 7 flags it as also
     denoting continuation in the state. -/
-def wen : Root := ⟨"wen", {.result "asleep"}, {}⟩
+def wen : Root := { name := "wen", entailments := {.result "asleep"} }
 
 /-- siih 'be born' (siih=s 'give birth, bear'). -/
-def siih : Root := ⟨"siih", {.result "born"}, {}⟩
+def siih : Root := { name := "siih", entailments := {.result "born"} }
 
 /-- kíim 'die' (ex. (1c); kíim=s 'kill'). -/
-def kiim : Root := ⟨"kíim", {.result "dead"}, {}⟩
+def kiim : Root := { name := "kíim", entailments := {.result "dead"} }
 
 /-- tú'ub' 'forget' (tú'ub'=s 'distract, cause to forget'). -/
-def tuub : Root := ⟨"tú'ub'", {.result "forgotten"}, {}⟩
+def tuub : Root := { name := "tú'ub'", entailments := {.result "forgotten"} }
 
 /-- k'a'ah 'remember' (k'á'ah=s 'remind, mention, invoke'). -/
-def kaah : Root := ⟨"k'a'ah", {.result "remembered"}, {}⟩
+def kaah : Root := { name := "k'a'ah", entailments := {.result "remembered"} }
 
 /-- ču'un 'begin activity' (ču'un=s 'cause to begin'). -/
-def chuun : Root := ⟨"ču'un", {.result "begun"}, {}⟩
+def chuun : Root := { name := "ču'un", entailments := {.result "begun"} }
 
 /-- č'en 'stop, cease' (č'en=s 'cause to stop, suspend'). -/
-def chen : Root := ⟨"č'en", {.result "ceased"}, {}⟩
+def chen : Root := { name := "č'en", entailments := {.result "ceased"} }
 
 /-- hó'op' 'begin, start' (hó'op'=s 'cause to begin'). -/
-def hoop : Root := ⟨"hó'op'", {.result "started"}, {}⟩
+def hoop : Root := { name := "hó'op'", entailments := {.result "started"} }
 
 /-- háaw 'stop, cease, heal' (háaw=s 'stop, revoke, medicate'). -/
-def haaw : Root := ⟨"háaw", {.result "stopped"}, {}⟩
+def haaw : Root := { name := "háaw", entailments := {.result "stopped"} }
 
 /-- hé'el 'rest, stop at' (hé'e(l)=s 'rest'). -/
-def heel : Root := ⟨"hé'el", {.result "rested"}, {}⟩
+def heel : Root := { name := "hé'el", entailments := {.result "rested"} }
 
 /-- p'át 'remain' (p'át=s 'abandon'). -/
-def paat : Root := ⟨"p'át", {.result "remaining"}, {}⟩
+def paat : Root := { name := "p'át", entailments := {.result "remaining"} }
 
 /-! ### Motion roots (ex. (4), p. 640)
 
@@ -158,41 +158,41 @@ adds that *péek* and *'ú'ul* are also irregular in their agent-focused
 perfective forms, "where they pattern like agent-salient roots". -/
 
 /-- máan 'pass by' (`#`; máan=s 'pass, transfer, transport'). -/
-def maan : Root := ⟨"máan", {.result "past"}, {}⟩
+def maan : Root := { name := "máan", entailments := {.result "past"} }
 
 /-- péek 'move, vibrate' (`#`; pek=s 'cause to move, vibrate'). -/
-def peek : Root := ⟨"péek", {.result "in-motion"}, {}⟩
+def peek : Root := { name := "péek", entailments := {.result "in-motion"} }
 
 /-- b'in 'go' (`#`; bi(n)=s 'take'). -/
-def bin : Root := ⟨"b'in", {.result "gone"}, {}⟩
+def bin : Root := { name := "b'in", entailments := {.result "gone"} }
 
 /-- tàal 'come (here)' (`#`; tàa(l)=s 'bring'). -/
-def taal : Root := ⟨"tàal", {.result "come"}, {}⟩
+def taal : Root := { name := "tàal", entailments := {.result "come"} }
 
 /-- 'ú'ul 'arrive (here)' (`#`; 'ú'uh=s 'bring it to here'). -/
-def uul : Root := ⟨"'ú'ul", {.result "arrived"}, {}⟩
+def uul : Root := { name := "'ú'ul", entailments := {.result "arrived"} }
 
 /-- 'ok 'enter, intrude' ('òok=s 'move it in(to)'). -/
-def ok : Root := ⟨"'ok", {.result "inside"}, {}⟩
+def ok : Root := { name := "'ok", entailments := {.result "inside"} }
 
 /-- lúub' 'fall' (lúub'=s 'fell'). -/
-def luub : Root := ⟨"lúub'", {.result "fallen"}, {}⟩
+def luub : Root := { name := "lúub'", entailments := {.result "fallen"} }
 
 /-- líik' '(a)rise, ascend' (lii(k)'=s 'raise, lift, put away'). -/
-def liik : Root := ⟨"líik'", {.result "risen"}, {}⟩
+def liik : Root := { name := "líik'", entailments := {.result "risen"} }
 
 /-- ná'ak '(a)rise, ascend' (ná'ak=s 'raise'); distinct from náak
     'arrive, reach, hit', not sampled here. -/
-def naak : Root := ⟨"ná'ak", {.result "ascended"}, {}⟩
+def naak : Root := { name := "ná'ak", entailments := {.result "ascended"} }
 
 /-! ### Positional roots (ex. (7), p. 643) -/
 
 /-- čin 'bow, bend down, bend over' (ex. (5)–(7)); zero-derives a
     transitive, ex. (6) 'I bent it'. -/
-def cin : Root := ⟨"čin", {.state "bent"}, {}⟩
+def cin : Root := { name := "čin", entailments := {.state "bent"} }
 
 /-- kul 'sit' (p. 645, fn. 24: relational 'x is-seated [on y]'). -/
-def kul : Root := ⟨"kul", {.state "seated"}, {}⟩
+def kul : Root := { name := "kul", entailments := {.state "seated"} }
 
 /-! ### Valency and class lists -/
 

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -60,7 +60,7 @@ verb allows only conceptual access (§4.2).
 - §14 Cross-paper engagement: Beavers & Koontz-Garboden 2020 root
      eventivity (Tham §5.1 refutes strict root → deverbal-adjective
      result-state inheritance, against B&KG's `crack : Root :=
-     ⟨"crack", {.result "fissured", .cause}⟩`)
+     { name := "crack", entailments := {.result "fissured", .cause} }`)
 - §15 Cross-paper engagement: Waldon et al. 2023 normalization contrast
      (substrate-level: shared numerator, divergent denominator)
 - §16 Cross-paper engagement: Solt 2018 SuB reciprocal bridge

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -294,11 +294,9 @@ structure Verb extends
     Verb.Causation, Verb.Attitude where
   /-- [levin-1993] verb class (§§ 9–57). -/
   levinClass : Option LevinClass := none
-  /-- The verb's lexical root — its entailment atoms, derived B&KG kind
-      signature. The content carrier the Verb
-      API integrates around (P-HUB): the verb's signature / change-type
-      are read off *this* root rather than the `levinClass` table. Total, with
-      the trivial root `{}` (no annotation) as the `⊥`. -/
+  /-- The verb's lexical root, from which its kind signature and change type are
+      read rather than from the `levinClass` table. The default `{}` is the
+      unannotated root. -/
   root : Root := {}
   /-- Citation form (cross-linguistic) -/
   form : String

--- a/Linglib/Syntax/Minimalist/Ellipsis.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis.lean
@@ -329,10 +329,9 @@ theorem mismatch_monotone (d : MismatchDimension) (e₁ e₂ : EllipsisType)
 -- § 6. Root Attachment Position
 -- ════════════════════════════════════════════════════
 
-/-- Spine position of a root by its attachment (`Root.Position`,
-    `Semantics/Lexical/Roots/Template.lean`; Marantz, [beavers-koontz-garboden-2020]):
-    change-of-state `.complement` roots sit at `V` (in v's complement),
-    manner/activity `.adjoined` roots at `VP_adj` (outside it). -/
+/-- Spine position of a root by its `Root.Position` ([beavers-koontz-garboden-2020]
+    §4.5), where change-of-state `.complement` roots sit at `V` in v's complement and
+    manner `.adjoined` roots at `VP_adj` outside it. -/
 def rootSpinePos : Root.Position → SpinePos
   | .complement => .V
   | .adjoined => .VP_adj


### PR DESCRIPTION
`Root.Position` gets constructor docstrings and a docstring sourced to the book (§4.5.3–4.5.4: result vs manner position; the restitutive *again* scope fact is the book's, not [merchant-2013]'s), and `Root` gains `position : Option Root.Position` so the typology's second coordinate is expressible.

- `Studies/BeaversKoontzGarboden2020`: the six roots carry their (12) positions; `Root.Kinds.attestedCells`, `cells_attested`, and `hand_drown_differ_in_position` state the filled cells
- stale `Semantics/Lexical/Roots/Template.lean` pointers and bare "Marantz" citations in Dargwa/ComplexPredicates, Minimalist/Ellipsis, Kalyakin2026 fixed; `Verb.root` docstring loses its "(P-HUB)" shorthand
- Lucy1994's roots use structure-instance notation