### PR TITLE
refactor(Semantics/ArgumentStructure/Root): profile regions as Finsets

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -135,9 +135,8 @@ def run : VerbEntry where
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion
   root := { profile := {
-    forceMag := some [.moderate]
-    agentVolition := some [.volitional]
-    agentControl := some [.compatible]
+    forceMag := {.moderate}
+    agentControl := {.compatible}
   } }
 
 /-- "arrive" — unaccusative intransitive -/
@@ -178,9 +177,8 @@ def eat : VerbEntry where
   verbIncClass := some .sinc
   levinClass := some .eat
   root := { profile := {
-    forceMag := some [.low, .moderate]
-    agentVolition := some [.volitional]
-    agentControl := some [.compatible]
+    forceMag := {.low, .moderate}
+    agentControl := {.compatible}
   } }
 
 /-- "kick" — transitive -/
@@ -192,10 +190,9 @@ def kick : VerbEntry := .mkRegular {
   vendlerClass := some .activity
   levinClass := some .hit
   root := { profile := {
-    forceMag := some [.moderate, .high]
-    forceDir := some [.unidirectional]
-    agentVolition := some [.neutral, .volitional]
-    agentControl := some [.neutral, .compatible]
+    forceMag := {.moderate, .high}
+    forceDir := {.unidirectional}
+    agentControl := {.neutral, .compatible}
   } } }
 
 /-- "give" — ditransitive, alternates DOC/PP.
@@ -814,9 +811,8 @@ def kill : VerbEntry := .mkRegular {
   causative := some .make
   levinClass := some .murder
   root := { profile := {
-    resultType := some [.totalDestruction]
-    agentVolition := some [.neutral, .volitional]
-    agentControl := some [.neutral, .compatible]
+    resultType := {.totalDestruction}
+    agentControl := {.neutral, .compatible}
   } } }
 
 /-- "break" — thick lexical causative (Levin 45.1 Break Verbs; [embick-2009] break-class).
@@ -834,12 +830,12 @@ def break_ : VerbEntry where
   causative := some .make
   levinClass := some .break_
   root := { profile := {
-    forceMag := some [.moderate, .high]
+    forceMag := {.moderate, .high}
     -- forceDir unconstrained: *break* covers snapping (bidirectional),
     -- hammering (omnidirectional), and directed blows (unidirectional)
-    patientRob := some [.moderate, .robust]
-    resultType := some [.fracture]
-    agentControl := some [.incompatible, .neutral]
+    patientRob := {.moderate, .robust}
+    resultType := {.fracture}
+    agentControl := {.incompatible, .neutral}
     -- break is unspecified for instrument and object dimensionality
     -- ([majid-boster-bowerman-2008]: Dim 1 low predictability)
   } }
@@ -864,13 +860,13 @@ def tear_ : VerbEntry where
   causative := some .make
   levinClass := some .break_
   root := { profile := {
-    forceMag := some [.moderate, .high]
-    forceDir := some [.bidirectional, .unidirectional]
-    patientRob := some [.flimsy, .moderate, .robust]
-    resultType := some [.separation]
-    agentControl := some [.neutral, .compatible]
-    instrumentType := some [.hands]
-    patientDim := some [.twoD]
+    forceMag := {.moderate, .high}
+    forceDir := {.bidirectional, .unidirectional}
+    patientRob := {.flimsy, .moderate, .robust}
+    resultType := {.separation}
+    agentControl := {.neutral, .compatible}
+    instrumentType := {.hands}
+    patientDim := {.twoD}
   } }
 
 -- ════════════════════════════════════════════════════
@@ -944,11 +940,10 @@ def burn : VerbEntry := .mkRegular {
   causative := some .make
   levinClass := some .otherCoS
   root := { profile := {
-    forceMag := some [.moderate, .high]
-    patientRob := some [.flimsy, .moderate, .robust]
-    resultType := some [.totalDestruction, .deformation]
-    agentVolition := some [.neutral, .volitional]
-    agentControl := some [.neutral, .compatible]
+    forceMag := {.moderate, .high}
+    patientRob := {.flimsy, .moderate, .robust}
+    resultType := {.totalDestruction, .deformation}
+    agentControl := {.neutral, .compatible}
   } } }
 
 /-- "destroy" — thin lexical causative (result-only, no manner). -/
@@ -959,9 +954,8 @@ def destroy : VerbEntry := .mkRegular {
   causative := some .make
   levinClass := some .destroy
   root := { profile := {
-    resultType := some [.totalDestruction]
-    agentVolition := some [.neutral, .volitional]
-    agentControl := some [.neutral, .compatible]
+    resultType := {.totalDestruction}
+    agentControl := {.neutral, .compatible}
   } } }
 
 /-- "melt" — thick lexical causative (manner = by heat).
@@ -976,11 +970,10 @@ def melt : VerbEntry := .mkRegular {
   causative := some .make
   levinClass := some .otherCoS
   root := { profile := {
-    forceMag := some [.low, .moderate]
-    patientRob := some [.moderate, .robust]
-    resultType := some [.deformation]
-    agentVolition := some [.neutral, .volitional]
-    agentControl := some [.compatible]
+    forceMag := {.low, .moderate}
+    patientRob := {.moderate, .robust}
+    resultType := {.deformation}
+    agentControl := {.compatible}
   } } }
 
 -- ════════════════════════════════════════════════════
@@ -1127,9 +1120,8 @@ def devour : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   levinClass := some .devour
   root := { profile := {
-    forceMag := some [.moderate, .high]
-    agentVolition := some [.volitional]
-    agentControl := some [.neutral]
+    forceMag := {.moderate, .high}
+    agentControl := {.neutral}
   } } }
 
 /-- "read" — transitive, no presupposition -/
@@ -1187,10 +1179,9 @@ def sweep : VerbEntry where
   passivizable := true
   levinClass := some .wipe
   root := { profile := {
-    forceMag := some [.low, .moderate]
-    forceDir := some [.unidirectional]
-    agentVolition := some [.volitional]
-    agentControl := some [.compatible]
+    forceMag := {.low, .moderate}
+    forceDir := {.unidirectional}
+    agentControl := {.compatible}
   } }
 
 /-- "sweep" instrument sense — obligatorily agentive, broom lexicalized. -/
@@ -1207,10 +1198,9 @@ def sweep_instr : VerbEntry where
   senseTag := .instrumental
   levinClass := some .wipe
   root := { profile := {
-    forceMag := some [.low, .moderate]
-    forceDir := some [.unidirectional]
-    agentVolition := some [.volitional]
-    agentControl := some [.compatible]
+    forceMag := {.low, .moderate}
+    forceDir := {.unidirectional}
+    agentControl := {.compatible}
   } }
 
 -- ════════════════════════════════════════════════════
@@ -2371,8 +2361,8 @@ def cut : VerbEntry where
   verbIncClass := some .sinc
   levinClass := some .cut
   root := { profile := {
-    resultType := some [.surfaceBreach]
-    instrumentType := some [.sharpBlade]
+    resultType := {.surfaceBreach}
+    instrumentType := {.sharpBlade}
   } }
 
 /-- "chop" — Levin 21.2 Carve verbs. -/

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -200,11 +200,11 @@ def rasgar : SpanishVerbEntry :=
     licensesStylLE := true,
     levinClass := some .break_,
     root := { profile := {
-      forceMag := some [.low, .moderate]
-      forceDir := some [.unidirectional]
-      patientRob := some [.insubstantial, .flimsy]
-      resultType := some [.separation, .surfaceBreach]
-      agentControl := some [.incompatible, .neutral]
+      forceMag := {.low, .moderate}
+      forceDir := {.unidirectional}
+      patientRob := {.insubstantial, .flimsy}
+      resultType := {.separation, .surfaceBreach}
+      agentControl := {.incompatible, .neutral}
     } } }
 
 /-- *asesinar* "assassinate" — AGENT causer required. No anticausative.

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -51,6 +51,14 @@ of feature-set inclusion.
 
 namespace ArgumentStructure
 
+/-- Three-valued volitional involvement of a participant, `neutral` where a form
+leaves it open. -/
+inductive Volitionality where
+  | nonvolitional
+  | neutral
+  | volitional
+  deriving DecidableEq, Repr
+
 /-- The ten entailments defining the proto-roles ([dowty-1991] pp.572–573):
 the first five are Proto-Agent, the last five Proto-Patient. Fields default
 to `false`, so a profile lists only the entailments it imposes. -/

--- a/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Defs.lean
@@ -84,10 +84,9 @@ structure Root where
   profile : Verb.Root.Profile := {}
   deriving DecidableEq
 
-/-- A `Repr` showing the name, atom count, position, and profile, since `Finset` has
-only an `unsafe` one. -/
-instance : Repr Root :=
-  ⟨λ r _ => repr (r.name, r.entailments.card, r.position, r.profile)⟩
+/-- A `Repr` showing the name, atom count, and position, since `Finset` has only an
+`unsafe` one. -/
+instance : Repr Root := ⟨λ r _ => repr (r.name, r.entailments.card, r.position)⟩
 
 namespace Root
 

--- a/Linglib/Semantics/ArgumentStructure/Root/Profile.lean
+++ b/Linglib/Semantics/ArgumentStructure/Root/Profile.lean
@@ -1,231 +1,145 @@
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Root Quality Dimensions
+# Root quality profiles
 
-Within-class root content profiles: ranges over quality dimensions —
-force, robustness, instrument, dimensionality, agent properties. A
-multi-paper synthesis ([talmy-1988], [talmy-2000], [dowty-1991],
-[majid-boster-bowerman-2008], [spalek-mcnally-2026]); no single paper
-carries this profile. Structural entailments (state, manner, result,
-cause) are the separate `Root.Kinds` (`Root/Kinds.lean`).
+The dimensions along which verbs of one class differ in root content, each a
+region of a finite scale rather than a point, since a verb is compatible with a
+range of force levels, patient materials, or result geometries.
+[spalek-mcnally-2026] separate English *tear* from Spanish *rasgar* by patient
+robustness, force direction, and compatibility with careful action;
+[majid-boster-bowerman-2008] sort cutting and breaking events by instrument,
+object dimensionality, and the geometry of the result. `Root.Profile` bundles
+one region per dimension, `univ` where a root says nothing.
 
 ## Main declarations
 
-* `Root.Profile.Range` — within-class variation along a dimension
-* the dimension enums (`ForceLevel`, `Robustness`, `InstrumentType`, …)
-* `Root.Profile` — the bundled profile
+* `Root.Profile.ForceLevel`, `ForceDirection`, `Robustness`, `ResultType`,
+  `InstrumentType`, `ObjectDimensionality`, `AgentControl` — the dimensions
+* `Root.Profile` — a region per dimension
+* `Root.Profile.Overlaps` — the regions meet on every dimension
+
+## References
+
+* [spalek-mcnally-2026]: The anatomy of a verb.
+* [majid-boster-bowerman-2008]: The cross-linguistic categorization of everyday
+  events.
+* [talmy-1988]: Force dynamics in language and cognition.
+* [levin-1993]: English Verb Classes and Alternations.
 -/
 
-namespace Verb
+namespace Verb.Root.Profile
 
-namespace Root.Profile
+/-! ### Dimensions -/
 
-/-! ### Range mechanism -/
-
-/-- Acceptable values along a quality dimension.
-
-    - `none`: the root is unconstrained on this dimension (says nothing)
-    - `some [v₁, v₂, …]`: the root is compatible with exactly these values
-
-    Roots are **regions**, not points: a verb like *tear* is compatible with
-    a range of force levels, not a single one. -/
-abbrev Range (α : Type*) := Option (List α)
-
-namespace Range
-
-variable {α : Type*}
-
-def unconstrained : Range α := none
-
-def only (vs : List α) : Range α := some vs
-
-def isCompatible [BEq α] : Range α → α → Bool
-  | none, _ => true
-  | some vs, v => vs.contains v
-
-def isConstrained : Range α → Bool
-  | none => false
-  | some _ => true
-
-/-- Two ranges overlap if they share at least one value. -/
-def overlaps [BEq α] : Range α → Range α → Bool
-  | none, _ => true
-  | _, none => true
-  | some vs₁, some vs₂ => vs₁.any (vs₂.contains ·)
-
-end Range
-
-end Root.Profile
-
-/-! ### Quality dimensions -/
-
-/-- Magnitude of force involved in the event.
-
-    [talmy-1988] identifies force magnitude as a core parameter of
-    force-dynamic schemas. [spalek-mcnally-2026]: *tear* implies considerable
-    force; *rasgar* implies less (enough to damage something flimsy). -/
+/-- Magnitude of the force involved ([talmy-1988]). -/
 inductive ForceLevel where
-  | none      -- no force component (states)
-  | low       -- gentle / minimal force
-  | moderate  -- typical force
-  | high      -- considerable / violent force
-  deriving DecidableEq, Repr
+  /-- No force component, as in states. -/
+  | zero
+  | low
+  | moderate
+  | high
+  deriving DecidableEq, Fintype, Repr
 
-/-- Spatial pattern of force application.
-
-    [talmy-2000]: force vectors have directional parameters.
-    [spalek-mcnally-2026]: *tear* implies contrary-direction force (pulling
-    apart); *rasgar* implies unidirectional force (gash-like). -/
+/-- Spatial pattern of the force applied ([talmy-2000]), contrary directions for
+*tear* and a single direction for *rasgar* ([spalek-mcnally-2026]). -/
 inductive ForceDirection where
-  | none             -- no directional force component
-  | unidirectional   -- linear / single-direction force (rasgar: gash)
-  | bidirectional    -- contrary directions (tear: pulling apart)
-  | omnidirectional  -- multi-directional (shatter: radiating fracture)
-  deriving DecidableEq, Repr
+  | undirected
+  | unidirectional
+  | bidirectional
+  | omnidirectional
+  deriving DecidableEq, Fintype, Repr
 
-/-- Material substantiality of the affected entity (patient).
-
-    [spalek-mcnally-2026]: the primary dimension distinguishing
-    *tear* (unrestricted) from *rasgar* (flimsy patients only). -/
+/-- Material substantiality of the patient, on which *rasgar* is restricted to
+flimsy patients and *tear* is not ([spalek-mcnally-2026]). -/
 inductive Robustness where
-  | insubstantial  -- states, abstractions (silence, darkness)
-  | flimsy         -- thin solids: fabric, paper, thin plastic
-  | moderate       -- standard solids: rope, muscle, tendons
-  | robust         -- thick solids: bread, cement, bone
-  deriving DecidableEq, Repr
+  | insubstantial
+  | flimsy
+  | moderate
+  | robust
+  deriving DecidableEq, Fintype, Repr
 
-/-- Nature of the physical change produced by the event.
-
-    Grounded in [levin-1993]'s class descriptions and [hale-keyser-1987] notion of "separation in material integrity":
-    - 45.1 Break: loss of material integrity (break, crack, shatter, tear)
-    - 45.2 Bend: change in shape without loss of integrity
-    - 44 Destroy: total destruction (no specific resulting state)
-    - 21 Cut: separation via instrument contact
-    Refined by [beavers-koontz-garboden-2020] on CoS root types.
-    UNVERIFIED: Levin chapter numbers cited from memory. -/
+/-- The physical change produced, after the class descriptions of [levin-1993]
+(§45.1 break, §45.2 bend, §44 destroy, §21.1 cut) and [hale-keyser-1987]'s
+separation in material integrity. -/
 inductive ResultType where
-  | separation      -- loss of integrity via pulling apart (tear)
-  | surfaceBreach   -- gash-like damage to surface (rasgar)
-  | fracture        -- breakage along stress lines (crack, break)
-  | fragmentation   -- complete structural failure (shatter, smash)
-  | deformation     -- shape change, integrity preserved (bend, fold)
-  | totalDestruction -- entity ceases to exist as such (destroy, ruin)
-  deriving DecidableEq, Repr
+  /-- Loss of integrity by pulling apart (*tear*). -/
+  | separation
+  /-- Damage to a surface (*rasgar*, *cut*). -/
+  | surfaceBreach
+  /-- Breakage along stress lines (*crack*, *break*). -/
+  | fracture
+  /-- Complete structural failure (*shatter*, *smash*). -/
+  | fragmentation
+  /-- Change of shape with integrity preserved (*bend*, *fold*). -/
+  | deformation
+  /-- The entity ceases to exist as such (*destroy*). -/
+  | totalDestruction
+  deriving DecidableEq, Fintype, Repr
 
-/-- Type of instrument used in the event.
-
-    [majid-boster-bowerman-2008]: instrument type interacts with object
-    properties to determine the predictability of separation locus (their
-    Dimension 1). Sharp instruments yield predictable separations; blunt
-    instruments and hands yield unpredictable separations.
-
-    [levin-1993]: *cut* verbs specify their instrument
-    (`instrumentSpec = true`); *break* verbs do not.
-    UNVERIFIED: Levin chapter (§21 vs §45.1) cited from memory. -/
+/-- The instrument effecting a separation, which together with the object's
+properties fixes how predictable the locus of separation is
+([majid-boster-bowerman-2008]). -/
 inductive InstrumentType where
-  | sharpBlade    -- knife, scissors, saw, chisel (predictable separation)
-  | bluntImpact   -- hammer, mallet, rock (unpredictable separation)
-  | hands         -- bare hands (tearing, snapping, pulling apart)
-  | none          -- no instrument / unspecified
-  deriving DecidableEq, Repr
+  | sharpBlade
+  | bluntImpact
+  | hands
+  | other
+  deriving DecidableEq, Fintype, Repr
 
-/-- Dimensionality of the affected object (patient).
-
-    [majid-boster-bowerman-2008]: object dimensionality interacts
-    with instrument type and manner of action to determine event
-    categorization cross-linguistically. 1D objects (rope, stick) can
-    be snapped; 2D objects (cloth, paper) can be torn; 3D objects
-    (melon, pot) can be smashed. -/
+/-- Dimensionality of the patient, the rope that snaps, the cloth that tears, or the
+pot that smashes ([majid-boster-bowerman-2008]). -/
 inductive ObjectDimensionality where
-  | oneD          -- elongated: rope, stick, twig, carrot, yarn
-  | twoD          -- flat/flexible: cloth, paper, plate
-  | threeD        -- solid/volumetric: melon, pot, box, orange
-  deriving DecidableEq, Repr
+  | oneD
+  | twoD
+  | threeD
+  deriving DecidableEq, Fintype, Repr
 
-/-- Whether the agent acts with volitional intent.
-
-    [dowty-1991]: Proto-Agent entailment P1 = "volitional involvement
-    in the event or state." [ausensi-yu-smith-2021]: killing verb roots impose
-    specific intentionality requirements on the agent (*murder* requires
-    intentional agent; *kill* does not).
-    [levin-1993]: some *break* verbs "allow unintentional, action
-    interpretations with body-part objects." -/
-inductive Volitionality where
-  | nonvolitional  -- unintentional / accidental
-  | neutral        -- underspecified for volition
-  | volitional     -- intentional / deliberate
-  deriving DecidableEq, Repr
-
-/-- Whether the action can be performed with care and control.
-
-    [dowty-1991]: Proto-Agent entailment P2 = "sentience
-    (and/or perception)," enabling controlled action.
-    [spalek-mcnally-2026]: *tear* is compatible with careful action
-    ("carefully tore the tin foil"); *rasgar* is not
-    ("??rasgaron con cuidado el papel"). -/
+/-- Compatibility with careful, controlled action, which *tear* has and *rasgar*
+lacks ([spalek-mcnally-2026]). -/
 inductive AgentControl where
-  | incompatible  -- incompatible with careful/controlled action
-  | neutral       -- underspecified for control
-  | compatible    -- compatible with careful/controlled action
-  deriving DecidableEq, Repr
+  | incompatible
+  | neutral
+  | compatible
+  deriving DecidableEq, Fintype, Repr
 
-namespace Root
+end Verb.Root.Profile
 
-open Profile (Range)
+namespace Verb.Root
 
-/-- Within-class root content profile.
+open Profile Finset
 
-    Captures **quality** dimensions of root content — force, robustness,
-    agent properties — as opposed to `Root.Kinds`, which captures
-    **structural** entailments (state, manner, result, cause).
-
-    Each dimension is a `Range` of acceptable values; `none` means the
-    root says nothing about that dimension (unconstrained). -/
+/-- A root's quality profile, a region of each dimension, `univ` where the root says
+nothing. -/
 structure Profile where
-  /-- Force magnitude: [talmy-1988]. -/
-  forceMag : Range ForceLevel := none
-  /-- Force directionality: [talmy-2000], [spalek-mcnally-2026]. -/
-  forceDir : Range ForceDirection := none
-  /-- Patient material robustness: [spalek-mcnally-2026]. -/
-  patientRob : Range Robustness := none
-  /-- Type of physical change: [levin-1993], [beavers-koontz-garboden-2020]. -/
-  resultType : Range ResultType := none
-  /-- Agent volitionality: [dowty-1991] P1, [ausensi-yu-smith-2021]. -/
-  agentVolition : Range Volitionality := none
-  /-- Agent control: [dowty-1991] P2, [spalek-mcnally-2026]. -/
-  agentControl : Range AgentControl := none
-  /-- Instrument type the root selects for: [majid-boster-bowerman-2008].
-      *cut* selects for sharp blades; *break* is unspecified. -/
-  instrumentType : Range InstrumentType := none
-  /-- Patient dimensionality: [majid-boster-bowerman-2008].
-      *tear* selects for 2D objects (cloth, paper); *snap* for 1D (stick, twig). -/
-  patientDim : Range ObjectDimensionality := none
-  deriving DecidableEq, BEq, Repr, Inhabited
+  /-- Force magnitude. -/
+  forceMag : Finset ForceLevel := univ
+  /-- Force direction. -/
+  forceDir : Finset ForceDirection := univ
+  /-- Patient robustness. -/
+  patientRob : Finset Robustness := univ
+  /-- The physical change produced. -/
+  resultType : Finset ResultType := univ
+  /-- Compatibility with careful action. -/
+  agentControl : Finset AgentControl := univ
+  /-- The instrument selected for. -/
+  instrumentType : Finset InstrumentType := univ
+  /-- Patient dimensionality. -/
+  patientDim : Finset ObjectDimensionality := univ
+  deriving DecidableEq
 
 namespace Profile
 
-/-- Does a root profile constrain patient properties? -/
-def constrainsPatient (rp : Profile) : Prop :=
-  rp.patientRob.isConstrained = true
+/-- Two profiles overlap when their regions meet on every dimension. -/
+def Overlaps (p q : Profile) : Prop :=
+  ¬ Disjoint p.forceMag q.forceMag ∧ ¬ Disjoint p.forceDir q.forceDir ∧
+    ¬ Disjoint p.patientRob q.patientRob ∧ ¬ Disjoint p.resultType q.resultType ∧
+    ¬ Disjoint p.agentControl q.agentControl ∧
+    ¬ Disjoint p.instrumentType q.instrumentType ∧ ¬ Disjoint p.patientDim q.patientDim
 
-instance (rp : Profile) : Decidable rp.constrainsPatient :=
-  inferInstanceAs (Decidable (_ = true))
-
-/-- Do two root profiles overlap (share at least one compatible event)? -/
-def overlaps (rp₁ rp₂ : Profile) : Prop :=
-  rp₁.forceMag.overlaps rp₂.forceMag = true ∧
-  rp₁.forceDir.overlaps rp₂.forceDir = true ∧
-  rp₁.patientRob.overlaps rp₂.patientRob = true ∧
-  rp₁.resultType.overlaps rp₂.resultType = true ∧
-  rp₁.agentVolition.overlaps rp₂.agentVolition = true ∧
-  rp₁.agentControl.overlaps rp₂.agentControl = true
-
-instance (rp₁ rp₂ : Profile) : Decidable (rp₁.overlaps rp₂) :=
-  inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _ ∧ _ ∧ _))
+instance (p q : Profile) : Decidable (p.Overlaps q) := by unfold Overlaps; infer_instance
 
 end Profile
 
-end Root
-
-end Verb
+end Verb.Root

--- a/Linglib/Semantics/Causation/Morphological.lean
+++ b/Linglib/Semantics/Causation/Morphological.lean
@@ -2,7 +2,7 @@ import Mathlib.Order.Nat
 import Linglib.Semantics.Causation.Psych
 import Linglib.Semantics.Causation.CoerciveImplication
 import Linglib.Semantics.ArgumentStructure.Agentivity
-import Linglib.Semantics.ArgumentStructure.Root.Profile
+import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 
 /-!
 # Morphological Causation: Causative Construction Typology
@@ -48,7 +48,7 @@ Agentivity decomposes into **intentionality × control** (following
 
 - `CauserType.toCausalSource` → `CausalSource` (psych causation)
 - `CauserType.toAgentivity` → `Agentivity` (agentivity lattice)
-- `CauserType.volitionality` → `Volitionality` (root dimensions)
+- `CauserType.volitionality` → `Volitionality` (proto-agent volition)
 - `CauserType.agentivityDegree` → `AgentivityDegree`
 - `CausativeConstruction` bundles complexity + mediation + causer/causee
   restrictions for cross-linguistic comparison
@@ -73,9 +73,8 @@ the external cause entirely, yielding monoeventive structure.
 
 namespace Causation.Morphological
 
-open Verb
 open Causation.Psych (CausalSource)
-open ArgumentStructure (Agentivity)
+open ArgumentStructure (Agentivity Volitionality)
 
 /-! ### Causer Type ([hafeez-2025], [comrie-1989]) -/
 

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -65,8 +65,10 @@ namespace MajidBosterBowerman2008
 open Verb
 open ArgumentStructure
 open Features
-open InstrumentType ObjectDimensionality Robustness ResultType
-     ForceLevel ForceDirection
+open Verb.Root.Profile
+open Verb.Root.Profile.InstrumentType Verb.Root.Profile.ObjectDimensionality
+  Verb.Root.Profile.Robustness Verb.Root.Profile.ResultType Verb.Root.Profile.ForceLevel
+  Verb.Root.Profile.ForceDirection
 
 -- ════════════════════════════════════════════════════
 -- § 1. Separation Events (stimulus level)
@@ -163,7 +165,7 @@ def clip53_breakStick : SeparationEvent :=
     a sharp blade — it breaches the material through puncture, not clean
     cutting. -/
 def clip45_pokeHole : SeparationEvent :=
-  ⟨.none, .twoD, .flimsy, .surfaceBreach, .low, .unidirectional, false⟩
+  ⟨.other, .twoD, .flimsy, .surfaceBreach, .low, .unidirectional, false⟩
 
 /-- Clip 7: Push chair back from table (reversible separation). -/
 def clip07_pushChair : SeparationEvent :=
@@ -212,8 +214,8 @@ def SeparationEvent.predictability (e : SeparationEvent) : Predictability :=
     | .bidirectional => .low     -- tearing/snapping: unpredictable
     | .omnidirectional => .low   -- smashing by hand: unpredictable
     | .unidirectional => .intermediate  -- karate chop: partly predictable
-    | .none => .low
-  | .none => .low
+    | .undirected => .low
+  | .other => .low
 
 /-- Break subtypes within the low-predictability cluster (Dimension 3).
 
@@ -253,7 +255,7 @@ def SeparationEvent.isMaterialDestruction (e : SeparationEvent) : Bool :=
     Poking a hole in a flat flexible object — distinguished from
     cutting and breaking because the object is not separated into
     pieces. The paper notes this emerged as a distinct cluster in 5/28
-    languages. Our encoding uses `.none` instrument for the twig since
+    languages. Our encoding uses `.other` for the twig since
     `InstrumentType` lacks a `.pointed` variant; the diagnostic feature
     is the combination of surface breach + 2D flexible object. -/
 def SeparationEvent.isPokingHole (e : SeparationEvent) : Bool :=
@@ -263,18 +265,14 @@ def SeparationEvent.isPokingHole (e : SeparationEvent) : Bool :=
 -- § 4. Compatibility with Root.Profile
 -- ════════════════════════════════════════════════════
 
-/-- Is a separation event compatible with a verb root's profile?
+/-- A separation event is compatible with a root's profile when each of its feature
+    values lies in the root's region for that dimension. -/
+def SeparationEvent.CompatibleWith (e : SeparationEvent) (r : Root.Profile) : Prop :=
+  e.force ∈ r.forceMag ∧ e.forceDir ∈ r.forceDir ∧ e.objectRob ∈ r.patientRob ∧
+    e.result ∈ r.resultType ∧ e.instrument ∈ r.instrumentType ∧ e.objectDim ∈ r.patientDim
 
-    An event is compatible iff each of its feature values falls within
-    the root's range for that dimension. Unconstrained dimensions
-    (range = none) accept any value. -/
-def SeparationEvent.compatibleWith (e : SeparationEvent) (r : Root.Profile) : Bool :=
-  r.forceMag.isCompatible e.force &&
-  r.forceDir.isCompatible e.forceDir &&
-  r.patientRob.isCompatible e.objectRob &&
-  r.resultType.isCompatible e.result &&
-  r.instrumentType.isCompatible e.instrument &&
-  r.patientDim.isCompatible e.objectDim
+instance (e : SeparationEvent) (r : Root.Profile) : Decidable (e.CompatibleWith r) := by
+  unfold SeparationEvent.CompatibleWith; infer_instance
 
 -- ════════════════════════════════════════════════════
 -- § 5. Dimension Verification
@@ -514,31 +512,31 @@ open English.Predicates.Verbal
 
 /-- The tear cloth event is compatible with the Fragment *tear* entry. -/
 theorem tearCloth_compatible_tear :
-    clip01_tearCloth.compatibleWith (fragmentProfile tear_) = true := rfl
+    clip01_tearCloth.CompatibleWith (fragmentProfile tear_) := by decide
 
 /-- A cutting event is NOT compatible with the *tear* profile
     (wrong instrument type). -/
 theorem sliceCarrot_incompatible_tear :
-    clip09_sliceCarrot.compatibleWith (fragmentProfile tear_) = false := rfl
+    ¬ clip09_sliceCarrot.CompatibleWith (fragmentProfile tear_) := by decide
 
 /-- Smashing a pot is NOT compatible with the *break* profile
     (fragmentation ≠ fracture — English *smash* covers fragmentation). -/
 theorem smashPot_incompatible_break :
-    clip39_smashPot.compatibleWith (fragmentProfile break_) = false := rfl
+    ¬ clip39_smashPot.CompatibleWith (fragmentProfile break_) := by decide
 
 /-- A snapping event IS compatible with *break* (fracture result, moderate
     force) — English *break* can cover snapping events, though *snap*
     is more specific. -/
 theorem snapTwig_compatible_break :
-    clip19_snapTwig.compatibleWith (fragmentProfile break_) = true := rfl
+    clip19_snapTwig.CompatibleWith (fragmentProfile break_) := by decide
 
 /-- Slicing a carrot is compatible with the *cut* entry. -/
 theorem sliceCarrot_compatible_cut :
-    clip09_sliceCarrot.compatibleWith (fragmentProfile cut) = true := rfl
+    clip09_sliceCarrot.CompatibleWith (fragmentProfile cut) := by decide
 
 /-- Tearing cloth is NOT compatible with the *cut* profile (wrong instrument). -/
 theorem tearCloth_incompatible_cut :
-    clip01_tearCloth.compatibleWith (fragmentProfile cut) = false := rfl
+    ¬ clip01_tearCloth.CompatibleWith (fragmentProfile cut) := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 10. Key Finding: Dimensional Constraint

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -94,7 +94,7 @@ theorem agent_control_differs :
     where both verbs are applicable. This overlap zone is where they
     function as translation equivalents (§4.2, Table 1). -/
 theorem roots_overlap :
-    tear_.rootProfile.overlaps rasgar.rootProfile := by
+    tear_.rootProfile.Overlaps rasgar.rootProfile := by
   decide
 
 -- ════════════════════════════════════════════════════


### PR DESCRIPTION
`Root.Profile`'s dimensions are `Finset` regions with `univ` for "says nothing", replacing the `Option (List α)` carrier and its `BEq` helpers; `Overlaps` is disjointness-free on every dimension (the old `overlaps` skipped two), and `constrainsPatient` goes.

- `agentVolition` dropped: no theorem read it and `EntailmentProfile.volition` already carries Dowty's P1; the `Volitionality` scale moves to `EntailmentProfile.lean` for its two remaining consumers (Causation/Morphological, Indonesian *ter-*)
- dimension enums move under `Root.Profile`; `none` constructors renamed (`ForceLevel.zero`, `ForceDirection.undirected`, `InstrumentType.other`); Levin's class numbers verified against the PDF so the two UNVERIFIED flags go
- English/Spanish fragments store `{.a, .b}` literals; Majid's `CompatibleWith` is a Prop