### PR TITLE
refactor(Semantics): move the root ontology to Semantics/Root

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1495,10 +1495,10 @@ import Linglib.Semantics.ArgumentStructure.ParticipantType
 import Linglib.Semantics.ArgumentStructure.PersistenceLevel
 import Linglib.Semantics.ArgumentStructure.Projection
 import Linglib.Semantics.ArgumentStructure.RoleList
-import Linglib.Semantics.ArgumentStructure.Root.Classification
-import Linglib.Semantics.ArgumentStructure.Root.Defs
-import Linglib.Semantics.ArgumentStructure.Root.Kinds
-import Linglib.Semantics.ArgumentStructure.Root.Profile
+import Linglib.Semantics.Root.Classification
+import Linglib.Semantics.Root.Defs
+import Linglib.Semantics.Root.Kinds
+import Linglib.Semantics.Root.Profile
 import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Semantics.ArgumentStructure.Thematic.Basic
 import Linglib.Semantics.ArgumentStructure.Thematic.Defs

--- a/Linglib/Fragments/Dargwa/ComplexPredicates.lean
+++ b/Linglib/Fragments/Dargwa/ComplexPredicates.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Voice.Alternation
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 
 /-!
 # Dargwa (Tanti / Muira) Complex Predicates [sumbatova-2021]
@@ -39,7 +39,7 @@ Under vVPE, the light verb (v head) survives while the nominal root
 
 namespace Dargwa.ComplexPredicates
 
-open Verb
+open Semantics
 
 -- ============================================================================
 -- § 1: Light Verb Inventory

--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Category.Verb.Basic
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 
 /-!
 # German Predicate Lexicon Fragment
@@ -38,7 +38,7 @@ structure GermanVerbEntry extends Verb where
   formPastPart : String
   /-- Root type ([beavers-etal-2021]): result vs property concept.
       Only set for change-of-state verbs where the distinction is applicable. -/
-  rootType : Option Verb.Root.ChangeType := none
+  rootType : Option Semantics.Root.ChangeType := none
   deriving Repr, BEq
 
 -- ============================================================================

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -3,7 +3,7 @@ import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.Realization
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
 /-!
@@ -183,13 +183,13 @@ def Verbalizer.vocabulary : List (VocabularyItem Feature Verbalizer.Alloseme) :=
 /-- Root change-type conditions v alloseme selection: result roots,
     which entail a prior change, demand the event variable; property
     concept roots do not — the root typology feeding v allosemy. -/
-def Verbalizer.Alloseme.fromRootType : Verb.Root.ChangeType → Verbalizer.Alloseme
+def Verbalizer.Alloseme.fromRootType : Semantics.Root.ChangeType → Verbalizer.Alloseme
   | .result          => .eventive
   | .propertyConcept => .zero
 
 /-- The bridge preserves the change entailment: eventive v iff the root
 entails change. -/
-theorem Verbalizer.fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
+theorem Verbalizer.fromRootType_iff_entailsChange (rt : Semantics.Root.ChangeType) :
     (Verbalizer.Alloseme.fromRootType rt).introducesEvent = true ↔ rt.EntailsChange := by
   cases rt <;> decide
 

--- a/Linglib/Morphology/Root/Consonantal.lean
+++ b/Linglib/Morphology/Root/Consonantal.lean
@@ -27,8 +27,8 @@ Owner-relative roots coexist: the top-level root is a contentful morph
 are explicitly *not* roots); `Morphology.ConsonantalRoot` (this file) is the
 *consonantal melody*; `DistributedMorphology.Root` is the abstract acategorial
 terminal; `Panagiotidis2015.RootFamily` records a category-neutral lexical
-root with its category-stamped derivatives; `Verb.Root`
-(`Semantics/ArgumentStructure/Root/`) is the *lexical-semantic* root. No identification
+root with its category-stamped derivatives; `Semantics.Root`
+(`Semantics/Root/`) is the *lexical-semantic* root. No identification
 between them is substrate — homs live in the studies that assert them.
 -/
 

--- a/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
+++ b/Linglib/Semantics/ArgumentStructure/ArgDerivation.lean
@@ -48,7 +48,7 @@ adds information beyond what root entailments + template predict:
 
 namespace ArgumentStructure.ArgDerivation
 
-open Verb
+open Semantics
 open ArgumentStructure
 open ArgumentStructure.EventStructure (Template)
 open ArgumentStructure

--- a/Linglib/Semantics/ArgumentStructure/EventStructure.lean
+++ b/Linglib/Semantics/ArgumentStructure/EventStructure.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 
 /-!
 # Event Structure Templates
@@ -129,7 +129,7 @@ denotational result entailment and `cause_implies_resultState` are one fact seen
 through the signature. -/
 
 section Signature
-open Verb (Root)
+open Semantics
 
 /-- The event-structure template determined by a root's (closed) kind signature. -/
 def Template.ofKinds (σ : Root.Kinds) : Template :=
@@ -154,13 +154,13 @@ theorem ofKinds_hasResultState_iff {σ : Root.Kinds}
   split_ifs with hc hr hm <;> simp_all [Template.HasResultState]
 
 /-- A root's event-structure template, read off its collocational closure. -/
-def _root_.Verb.Root.template (r : Root) : Template :=
+def _root_.Semantics.Root.template (r : Root) : Template :=
   Template.ofKinds r.closedKinds
 
 /-- A root entails a result state (template-level) iff it carries `result` —
     the [beavers-koontz-garboden-2020] result entailment, bridged to the
     `EventStructure` template diagnostic. -/
-theorem _root_.Verb.Root.template_hasResultState_iff (r : Root) :
+theorem _root_.Semantics.Root.template_hasResultState_iff (r : Root) :
     r.template.HasResultState ↔ Root.Kind.result ∈ r.closedKinds :=
   ofKinds_hasResultState_iff r.closedKinds_wellFormed
 

--- a/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
@@ -3,7 +3,7 @@ import Linglib.Features.Attitudes
 import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
-import Linglib.Semantics.ArgumentStructure.Root.Kinds
+import Linglib.Semantics.Root.Kinds
 import Linglib.Semantics.ArgumentStructure.EventStructure
 
 /-!
@@ -18,7 +18,7 @@ The `LevinClass` enum and its classification data (`meaningComponents`,
 This file provides the theoretical content that depends on `Root.Kinds`:
 the root signature label, the root–MC comparison enums, and the universal
 consistency/divergence theorems that ground them. `LevinClass` is a *lossy
-realization label*, not a source of truth (that is `Verb.Root.kinds`); the
+realization label*, not a source of truth (that is `Semantics.Root.kinds`); the
 theorems below are the non-decorative grounding — each holds for every class
 and breaks if a table row changes, so per-class `rfl` spot-checks are not
 restated.
@@ -39,8 +39,8 @@ components, plus the universal consistency theorems and divergence witnesses.
 -- ════════════════════════════════════════════════════
 
 section LevinClassMethods
-open Verb
-open Root.Kinds
+open Semantics
+open Semantics.Root.Kinds
 namespace ArgumentStructure
 
 /-- Root kind signature for each Levin class.
@@ -307,7 +307,7 @@ event template and break under a genuine table change. -/
 
 /-- Root structural contribution to meaning components.
     Maps result → changeOfState and manner → mannerSpec. -/
-def _root_.Verb.Root.Kinds.structuralMC (re : Root.Kinds) : MeaningComponents :=
+def _root_.Semantics.Root.Kinds.structuralMC (re : Root.Kinds) : MeaningComponents :=
   { changeOfState := decide (.result ∈ re)
   , contact := false
   , motion := false
@@ -361,7 +361,7 @@ theorem template_resultState_not_iff_resultKind_stateChange :
     `meaningComponents` is not just `structuralMC ∘ rootEntailments`. -/
 theorem structuralMC_diverges_from_meaningComponents :
     ∃ c : LevinClass,
-      (Verb.Root.Kinds.structuralMC c.rootEntailments).changeOfState = true ∧
+      (Semantics.Root.Kinds.structuralMC c.rootEntailments).changeOfState = true ∧
       c.meaningComponents.changeOfState = false :=
   ⟨.give, by decide⟩
 

--- a/Linglib/Semantics/ArgumentStructure/MeaningComponents.lean
+++ b/Linglib/Semantics/ArgumentStructure/MeaningComponents.lean
@@ -21,7 +21,7 @@ substrate.
 The 4-feature decomposition is [levin-1993]'s diagnostic apparatus.
 [beavers-koontz-garboden-2020] argue these are SURFACE behaviors,
 not root-level entailments — root-level structural features live in
-`Semantics/ArgumentStructure/Root/Kinds.lean::Root.Kinds`
+`Semantics/Root/Kinds.lean::Root.Kinds`
 (state/manner/result/cause). The two carve-ups are NOT equivalent:
 e.g., `causation` here is what diathesis alternations diagnose, while
 B&KG's `cause` is a root entailment.
@@ -63,7 +63,7 @@ namespace ArgumentStructure
     These describe **surface** verb behavior, not root-level entailments.
     [beavers-koontz-garboden-2020] argue that surface CoS and causation
     can come from either the template or the root; see `Root.Kinds`
-    in `Semantics/ArgumentStructure/Root/Kinds.lean` for the
+    in `Semantics/Root/Kinds.lean` for the
     root-level decomposition.
 
     Diagnosed by participation in diathesis alternations:

--- a/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Kinds
+import Linglib.Semantics.Root.Kinds
 import Linglib.Semantics.ArgumentStructure.Valency
 
 /-!
@@ -31,7 +31,7 @@ the Chuj root classes.
 
 namespace ArgumentStructure
 
-open Verb
+open Semantics
 
 /-- Lucy's "three large predicate root classes", named for the
     argument(s) the underived root makes salient. Positional roots are

--- a/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
+++ b/Linglib/Semantics/ArgumentStructure/VerbDenotation.lean
@@ -41,6 +41,7 @@ anchoring study, `Studies/BeaversKoontzGarboden2020.lean`.
 -/
 
 open ArgumentStructure
+open Semantics
 
 /-! ### The theta-grid (derived from the proto-role profiles) -/
 
@@ -162,6 +163,6 @@ theorem denote_result_from_template (M : CosModel Entity State T)
     (h : M.denote v y x e) : ∃ e' s, M.become s e' ∧ M.rootState v x s := by
   refine M.denote_result_entails_resultState v y x e ?_ h
   show Root.Kind.result ∈ v.root.closedKinds
-  exact (Verb.Root.template_hasResultState_iff v.root).mp ht
+  exact (Semantics.Root.template_hasResultState_iff v.root).mp ht
 
 end Verb.CosModel

--- a/Linglib/Semantics/Root/Classification.lean
+++ b/Linglib/Semantics/Root/Classification.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Kinds
+import Linglib.Semantics.Root.Kinds
 import Linglib.Semantics.ArgumentStructure.Valency
 import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Semantics.Composition.Ty
@@ -31,7 +31,7 @@ manner-free signatures.
 
 open ArgumentStructure
 
-namespace Verb.Root
+namespace Semantics.Root
 
 /-! ### Change type -/
 
@@ -120,4 +120,4 @@ theorem salienceClass_ofKinds {s : Kinds} (v : Valency) (h : Kind.manner ∉ s) 
 
 end Classification
 
-end Verb.Root
+end Semantics.Root

--- a/Linglib/Semantics/Root/Defs.lean
+++ b/Linglib/Semantics/Root/Defs.lean
@@ -1,5 +1,5 @@
-import Linglib.Semantics.ArgumentStructure.Root.Profile
-import Linglib.Semantics.ArgumentStructure.Root.Kinds
+import Linglib.Semantics.Root.Profile
+import Linglib.Semantics.Root.Kinds
 
 /-!
 # Verbal roots
@@ -34,7 +34,7 @@ restitutive *again* (§4.5.4) and the deletion site of verbal VP ellipsis
   `Root.Profile`.
 -/
 
-namespace Verb
+namespace Semantics
 
 /-! ### Atoms -/
 
@@ -76,12 +76,12 @@ structure Root where
   citation form names it. -/
   name : String := ""
   /-- The root's atoms, `∅` where its structural content is unannotated. -/
-  entailments : Finset Verb.Root.Entailment := ∅
+  entailments : Finset Semantics.Root.Entailment := ∅
   /-- The position in which the root composes with `v`, where annotated. -/
-  position : Option Verb.Root.Position := none
+  position : Option Semantics.Root.Position := none
   /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
   [majid-boster-bowerman-2008]); `{}` leaves every dimension unconstrained. -/
-  profile : Verb.Root.Profile := {}
+  profile : Semantics.Root.Profile := {}
   deriving DecidableEq
 
 /-- A `Repr` showing the name, atom count, and position, since `Finset` has only an
@@ -109,4 +109,4 @@ theorem closedKinds_wellFormed : r.closedKinds.WellFormed := Kinds.close_wellFor
 
 end Root
 
-end Verb
+end Semantics

--- a/Linglib/Semantics/Root/Kinds.lean
+++ b/Linglib/Semantics/Root/Kinds.lean
@@ -26,7 +26,7 @@ attested rows of the typology's display (12).
 * [beavers-koontz-garboden-2020]: The Roots of Verbal Meaning.
 -/
 
-namespace Verb
+namespace Semantics
 
 /-! ### Kinds -/
 
@@ -121,4 +121,4 @@ def fullSpec : Kinds := univ
 
 end Root.Kinds
 
-end Verb
+end Semantics

--- a/Linglib/Semantics/Root/Profile.lean
+++ b/Linglib/Semantics/Root/Profile.lean
@@ -29,7 +29,7 @@ one region per dimension, `univ` where a root says nothing.
 * [levin-1993]: English Verb Classes and Alternations.
 -/
 
-namespace Verb.Root.Profile
+namespace Semantics.Root.Profile
 
 /-! ### Dimensions -/
 
@@ -104,9 +104,9 @@ inductive AgentControl where
   | compatible
   deriving DecidableEq, Fintype, Repr
 
-end Verb.Root.Profile
+end Semantics.Root.Profile
 
-namespace Verb.Root
+namespace Semantics.Root
 
 open Profile Finset
 
@@ -142,4 +142,4 @@ instance (p q : Profile) : Decidable (p.Overlaps q) := by unfold Overlaps; infer
 
 end Profile
 
-end Verb.Root
+end Semantics.Root

--- a/Linglib/Studies/BeaversEtAl2021.lean
+++ b/Linglib/Studies/BeaversEtAl2021.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.Rat.Defs
 import Mathlib.Tactic.NormNum
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 import Linglib.Semantics.ArgumentStructure.LevinTheory
 import Linglib.Semantics.ArgumentStructure.EventStructure
 import Linglib.Semantics.ArgumentStructure.RoleList
@@ -24,7 +24,7 @@ and the three attested language types.
 ## Main statements
 
 * `bifurcation_fails`: result roots entail change
-  (`Verb.Root.ChangeType.EntailsChange`), violating the bifurcation
+  (`Semantics.Root.ChangeType.EntailsChange`), violating the bifurcation
   thesis (2).
 * `grand_unification`: the root's change entailment alone determines the
   full package of morphosyntactic correlates ((44), §§3, 6–9).
@@ -47,7 +47,7 @@ and the three attested language types.
 
 namespace BeaversEtAl2021
 
-open Verb Verb.Root ArgumentStructure ArgumentStructure.EventStructure Features
+open Semantics Semantics.Root ArgumentStructure ArgumentStructure.EventStructure Features
 
 /-! ### Root meanings and subclasses ((5)–(6)) -/
 

--- a/Linglib/Studies/BeaversKoontzGarboden2020.lean
+++ b/Linglib/Studies/BeaversKoontzGarboden2020.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 import Linglib.Semantics.ArgumentStructure.VerbDenotation
 import Linglib.Semantics.ArgumentStructure.EventStructure
 import Linglib.Data.Examples.BeaversKoontzGarboden2020
@@ -57,7 +57,7 @@ they graduate back to the theory layer when a second study lands.
 * [von-stechow-1996]: The different readings of wieder.
 -/
 
-namespace Verb.Root.Kinds
+namespace Semantics.Root.Kinds
 
 /-! ### The two theses, at signature level -/
 
@@ -126,9 +126,9 @@ def attestedCells : Finset (Root.Kinds × Root.Position) :=
   {(propertyConcept, .complement), (pureResult, .complement), (causativeResult, .complement),
    (pureManner, .adjoined), (fullSpec, .adjoined), (fullSpec, .complement)}
 
-end Verb.Root.Kinds
+end Semantics.Root.Kinds
 
-namespace Verb.Root
+namespace Semantics.Root
 
 /-! ### The two theses, at root level -/
 
@@ -172,7 +172,7 @@ def RespectsMannerResultComplementarity (r : Root) : Prop :=
 instance (r : Root) : Decidable r.RespectsMannerResultComplementarity :=
   inferInstanceAs (Decidable (¬ _))
 
-end Verb.Root
+end Semantics.Root
 
 namespace Verb.CosModel
 
@@ -275,6 +275,7 @@ end Verb.CosModel
 namespace BeaversKoontzGarboden2020
 
 open Verb
+open Semantics
 
 /-! ### The six representative roots -/
 
@@ -456,9 +457,9 @@ theorem jog_denote_eq_manner {Entity State T : Type*} [LinearOrder T]
 
 /-! ### The same contrast at the template level ([rappaport-hovav-levin-1998])
 
-`Verb.Root.template` reads the event-structure template off a root's
+`Semantics.Root.template` reads the event-structure template off a root's
 collocational closure; the kinds proven above fix it, and `HasResultState`
-reduces to carrying `result` (`Verb.Root.template_hasResultState_iff`). So the
+reduces to carrying `result` (`Semantics.Root.template_hasResultState_iff`). So the
 denotational result entailment (√crack) and the template result diagnostic are
 *one fact* seen through `kinds`. -/
 

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -168,7 +168,7 @@ open Morphology.Exponence in
 winner: the more specified eventive entry beats vacuous v exactly when the
 root entails an event, so `Verbalizer.Alloseme.fromRootType` is derived, not
 stipulated. -/
-theorem fromRootType_is_selectBy_winner (rt : Verb.Root.ChangeType) :
+theorem fromRootType_is_selectBy_winner (rt : Semantics.Root.ChangeType) :
     (winner? Verbalizer.vocabulary (vContext (decide rt.EntailsChange))).map (·.exponent) =
       some (Verbalizer.Alloseme.fromRootType rt) := by
   cases rt <;> rfl

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.Paradigm.Morphome
@@ -31,7 +31,7 @@ arguments. The root lexicon lives in
 namespace Coon2019
 
 open Chuj
-open Verb.Root
+open Semantics.Root
 
 /-! ### Root-class coordinates -/
 

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 import Linglib.Studies.KoontzGarboden2009
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Semantics.Possession.Relationalizer
@@ -63,7 +63,7 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
 
 namespace HaninkKoontzGarboden2025
 
-open Verb Verb.Root
+open Verb Semantics.Root
 open KoontzGarboden2009.Monotonicity
 open DistributedMorphology (Categorizer)
 open Possession (π)

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -1,5 +1,5 @@
 import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
-import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Semantics.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Applicative
 import Linglib.Syntax.Minimalist.Agree.Checking
 import Linglib.Syntax.Minimalist.Verbal.Voice
@@ -284,7 +284,7 @@ structure VerbalizedRoot where
   /-- The acategorial root. -/
   root : DistributedMorphology.Root
   /-- The root's c-selection content (arity, change-type). -/
-  classification : Verb.Root.Classification
+  classification : Semantics.Root.Classification
   /-- The Semitic template (functional head bundle). -/
   template : SemiticTemplate
   /-- The root label for l-selection lookup. -/
@@ -302,7 +302,7 @@ def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : Flavor :=
 /-- Valency is template-invariant (root-level), unlike l-selection: c-selection
     and l-selection factor differently in the grammar. -/
 theorem valency_template_invariant (rt : DistributedMorphology.Root)
-    (cls : Verb.Root.Classification) (rl : RootLabel)
+    (cls : Semantics.Root.Classification) (rl : RootLabel)
     (t1 t2 : SemiticTemplate) :
     (VerbalizedRoot.mk rt cls t1 rl).classification.valency =
       (VerbalizedRoot.mk rt cls t2 rl).classification.valency := rfl
@@ -337,7 +337,7 @@ theorem voice_distinguishes_templates :
 /-- [kratzer-1996]'s severing instantiated for Semitic: root-level valency is
     template-invariant while the Voice contribution varies by template. -/
 theorem severing_instantiated (rt : DistributedMorphology.Root)
-    (cls : Verb.Root.Classification) (rl : RootLabel) :
+    (cls : Semantics.Root.Classification) (rl : RootLabel) :
     (VerbalizedRoot.mk rt cls .XaYaZ rl).classification.valency =
       (VerbalizedRoot.mk rt cls .XaYYaZ rl).classification.valency ∧
     SemiticTemplate.toVoiceFlavor .XaYaZ ≠ SemiticTemplate.toVoiceFlavor .XaYYaZ :=

--- a/Linglib/Studies/Krejci2012.lean
+++ b/Linglib/Studies/Krejci2012.lean
@@ -50,9 +50,9 @@ Middle and Ingestive Verbs*. Master's Report, University of Texas at Austin.
 
 namespace Krejci2012
 
-open Verb
+open Semantics
 open ArgumentStructure
-open Root.Kinds
+open Semantics.Root.Kinds
 open Causation.Morphological
 open ArgumentStructure.EventStructure
 open ArgumentStructure.ArgDerivation

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -64,6 +64,7 @@ does not directly accommodate. This file formalizes the specific case.
 namespace Levin2026
 
 open Verb
+open Semantics
 open Semantics.Context (Index)
 
 open ArgumentStructure

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Morphology.Exponence.Select
 
@@ -65,7 +65,7 @@ Yucatec roots, diagnostic operators, and attested derivations.
 
 namespace Lucy1994
 
-open Verb ArgumentStructure Morphology
+open Semantics ArgumentStructure Morphology
 
 /-! ### Agent-salient roots (p. 629, ex. (1a)) -/
 

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -63,12 +63,13 @@ varies across languages.
 namespace MajidBosterBowerman2008
 
 open Verb
+open Semantics
 open ArgumentStructure
 open Features
-open Verb.Root.Profile
-open Verb.Root.Profile.InstrumentType Verb.Root.Profile.ObjectDimensionality
-  Verb.Root.Profile.Robustness Verb.Root.Profile.ResultType Verb.Root.Profile.ForceLevel
-  Verb.Root.Profile.ForceDirection
+open Semantics.Root.Profile
+open Semantics.Root.Profile.InstrumentType Semantics.Root.Profile.ObjectDimensionality
+  Semantics.Root.Profile.Robustness Semantics.Root.Profile.ResultType Semantics.Root.Profile.ForceLevel
+  Semantics.Root.Profile.ForceDirection
 
 -- ════════════════════════════════════════════════════
 -- § 1. Separation Events (stimulus level)

--- a/Linglib/Studies/Tham2025.lean
+++ b/Linglib/Studies/Tham2025.lean
@@ -831,7 +831,7 @@ theorem largeVase_score_le_one :
 
 /-! [beavers-koontz-garboden-2020] formalize verbal roots as
     bundles of lexical entailments
-    (`Semantics/ArgumentStructure/Root/Defs.lean`). Their classification
+    (`Semantics/Root/Defs.lean`). Their classification
     of √crack is `{.result "fissured", .cause}` — the
     "result + cause, no manner" base feature signature
     `{.result, .cause}` (`BeaversKoontzGarboden2020.crack`).
@@ -852,7 +852,7 @@ theorem largeVase_score_le_one :
     state inheritance from root to deverbal adjective is refuted at
     substrate level. -/
 theorem cracked_adj_refutes_bkg_crack_root_inheritance :
-    Verb.Root.Kind.result ∈ BeaversKoontzGarboden2020.crack.kinds ∧
+    Semantics.Root.Kind.result ∈ BeaversKoontzGarboden2020.crack.kinds ∧
     crack.adjEntailsPrecedingChange = false :=
   ⟨by decide, rfl⟩
 

--- a/Linglib/Syntax/Category/Adjective/Basic.lean
+++ b/Linglib/Syntax/Category/Adjective/Basic.lean
@@ -25,7 +25,7 @@ This file deliberately does not depend on the Degree/Kennedy semantics.
 * Agreement φ-features + `toWord` realization — added when an agreeing-language fragment
   sets them (φ with no setter would be dead fields).
 * Dixon `PCClass` view (`ScalarDimension.pcClass`) — waits on wiring to
-  `Verb.Root.PCClass` (in `Semantics/ArgumentStructure/Root/Classification.lean`).
+  `Semantics.Root.PCClass` (in `Semantics/Root/Classification.lean`).
 * The `Modifier`/`Gradable` capability classes — built at the second-carrier trigger
   (an `Adverb`/degree-word struct), exactly as `Pronoun` defers its deictic axis.
 

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Category.Verb.Defs
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 
 /-! # Verb entry — derived API
 
@@ -35,20 +35,20 @@ def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
 
 /-- The verb's within-class quality profile ([spalek-mcnally-2026]), read off its
     `root` (where the profile is carried). -/
-def Verb.rootProfile (v : Verb) : Verb.Root.Profile :=
+def Verb.rootProfile (v : Verb) : Semantics.Root.Profile :=
   v.root.profile
 
 /-- The verb's raw kind signature ([beavers-koontz-garboden-2020]): the
     un-closed atom-kinds of its root, the source of truth for what the verb
     structurally entails. `Verb.closedKinds` is its collocational closure and
     the root the sole provenance of the kind signature. -/
-def Verb.kinds (v : Verb) : Verb.Root.Kinds :=
+def Verb.kinds (v : Verb) : Semantics.Root.Kinds :=
   v.root.kinds
 
 /-- The verb's closed kind signature ([beavers-koontz-garboden-2020]): the
     collocational closure of `Verb.kinds` (`cause ⟹ result ⟹ state`), which the
-    event-structure spine (`Verb.Root.template`, `CosModel.denote`) runs on. -/
-def Verb.closedKinds (v : Verb) : Verb.Root.Kinds :=
+    event-structure spine (`Semantics.Root.template`, `CosModel.denote`) runs on. -/
+def Verb.closedKinds (v : Verb) : Semantics.Root.Kinds :=
   v.root.closedKinds
 
 /-- Effective subject entailment profile: verb-level override if present,

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -14,8 +14,8 @@ import Linglib.Semantics.Causation.Psych
 import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.ArgumentStructure.RoleList
-import Linglib.Semantics.ArgumentStructure.Root.Defs
-import Linglib.Semantics.ArgumentStructure.Root.Profile
+import Linglib.Semantics.Root.Defs
+import Linglib.Semantics.Root.Profile
 
 /-! # Verb entry — core type
 
@@ -277,10 +277,6 @@ structure Attitude where
 end Verb
 
 section
--- Open the `Verb` namespace so the `root` field below resolves `Root` as
--- `Verb.Root`: inside the `structure Verb` body the `Verb` *type* shadows the
--- `Verb` *namespace*, so a bare `Verb.Root` mis-parses as a field projection.
-open _root_.Verb
 /--
 Cross-linguistic verb core: all semantic fields shared across languages.
 
@@ -297,7 +293,7 @@ structure Verb extends
   /-- The verb's lexical root, from which its kind signature and change type are
       read rather than from the `levinClass` table. The default `{}` is the
       unannotated root. -/
-  root : Root := {}
+  root : Semantics.Root := {}
   /-- Citation form (cross-linguistic) -/
   form : String
   /-- Does the verb denote the performance of an illocutionary act?

--- a/Linglib/Syntax/Category/Verb/Stem.lean
+++ b/Linglib/Syntax/Category/Verb/Stem.lean
@@ -12,7 +12,7 @@ field records the dictionary-consensus value; analytical
 reclassifications (e.g. [istratkova-2004]'s aspectless homogeneous
 class) are study-level, never entry data.
 
-Contrast `Verb.Root` (the lexical-semantic root) and the full semantic
+Contrast `Semantics.Root` (the lexical-semantic root) and the full semantic
 `Verb` entry of `Syntax/Category/Verb/Defs.lean`; `Verb.Stem` carries no
 semantics beyond its gloss.
 -/

--- a/Linglib/Syntax/Minimalist/Ellipsis.lean
+++ b/Linglib/Syntax/Minimalist/Ellipsis.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Verbal.Voice
-import Linglib.Semantics.ArgumentStructure.Root.Defs
+import Linglib.Semantics.Root.Defs
 import Linglib.Syntax.Anaphora.Basic
 
 /-!
@@ -42,7 +42,7 @@ generically for all `DeletionSpine` instances.
 
 namespace Minimalist.Ellipsis
 
-open Verb
+open Semantics
 
 -- ════════════════════════════════════════════════════
 -- § 0. Generic Deletion Spine


### PR DESCRIPTION
The lexical-semantic root is category-neutral in every account formalized here (BKG's √flat underlies *flat* and *flatten*; Coon's √NOM and √POS; Hanink's PC roots that surface as verbs, nouns, or adjectives), so it is neither the verb's nor argument structure's. `ArgumentStructure/Root/` becomes the domain dir `Semantics/Root/` and `Verb.Root` becomes `Semantics.Root`; `ArgumentStructure/` now consumes the root rather than housing it. Mechanical move and rename only; the Classification dissolution and `PCClass` rehoming follow separately.