### PR TITLE
refactor(Semantics/Root): Profile is Content, fields named by what they describe

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1497,7 +1497,7 @@ import Linglib.Semantics.ArgumentStructure.Projection
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Semantics.Root.Defs
 import Linglib.Semantics.Root.Kinds
-import Linglib.Semantics.Root.Profile
+import Linglib.Semantics.Root.Content
 import Linglib.Semantics.Root.PropertyConcept
 import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Semantics.ArgumentStructure.Thematic.Basic

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -134,8 +134,8 @@ def run : VerbEntry where
   passivizable := false
   vendlerClass := some .activity
   levinClass := some .mannerOfMotion
-  root := { profile := {
-    forceMag := {.moderate}
+  root := { content := {
+    force := {.moderate}
     agentControl := {.compatible}
   } }
 
@@ -176,8 +176,8 @@ def eat : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .eat
-  root := { profile := {
-    forceMag := {.low, .moderate}
+  root := { content := {
+    force := {.low, .moderate}
     agentControl := {.compatible}
   } }
 
@@ -189,9 +189,9 @@ def kick : VerbEntry := .mkRegular {
   objectEntailments := some contactObject
   vendlerClass := some .activity
   levinClass := some .hit
-  root := { profile := {
-    forceMag := {.moderate, .high}
-    forceDir := {.unidirectional}
+  root := { content := {
+    force := {.moderate, .high}
+    direction := {.unidirectional}
     agentControl := {.neutral, .compatible}
   } } }
 
@@ -810,8 +810,8 @@ def kill : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .murder
-  root := { profile := {
-    resultType := {.totalDestruction}
+  root := { content := {
+    resultGeometry := {.totalDestruction}
     agentControl := {.neutral, .compatible}
   } } }
 
@@ -829,12 +829,12 @@ def break_ : VerbEntry where
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .break_
-  root := { profile := {
-    forceMag := {.moderate, .high}
-    -- forceDir unconstrained: *break* covers snapping (bidirectional),
+  root := { content := {
+    force := {.moderate, .high}
+    -- direction unconstrained: *break* covers snapping (bidirectional),
     -- hammering (omnidirectional), and directed blows (unidirectional)
-    patientRob := {.moderate, .robust}
-    resultType := {.fracture}
+    patientRobustness := {.moderate, .robust}
+    resultGeometry := {.fracture}
     agentControl := {.incompatible, .neutral}
     -- break is unspecified for instrument and object dimensionality
     -- ([majid-boster-bowerman-2008]: Dim 1 low predictability)
@@ -859,14 +859,14 @@ def tear_ : VerbEntry where
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .break_
-  root := { profile := {
-    forceMag := {.moderate, .high}
-    forceDir := {.bidirectional, .unidirectional}
-    patientRob := {.flimsy, .moderate, .robust}
-    resultType := {.separation}
+  root := { content := {
+    force := {.moderate, .high}
+    direction := {.bidirectional, .unidirectional}
+    patientRobustness := {.flimsy, .moderate, .robust}
+    resultGeometry := {.separation}
     agentControl := {.neutral, .compatible}
-    instrumentType := {.hands}
-    patientDim := {.twoD}
+    instrument := {.hands}
+    patientDimensionality := {.twoD}
   } }
 
 -- ════════════════════════════════════════════════════
@@ -939,10 +939,10 @@ def burn : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  root := { profile := {
-    forceMag := {.moderate, .high}
-    patientRob := {.flimsy, .moderate, .robust}
-    resultType := {.totalDestruction, .deformation}
+  root := { content := {
+    force := {.moderate, .high}
+    patientRobustness := {.flimsy, .moderate, .robust}
+    resultGeometry := {.totalDestruction, .deformation}
     agentControl := {.neutral, .compatible}
   } } }
 
@@ -953,8 +953,8 @@ def destroy : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   causative := some .make
   levinClass := some .destroy
-  root := { profile := {
-    resultType := {.totalDestruction}
+  root := { content := {
+    resultGeometry := {.totalDestruction}
     agentControl := {.neutral, .compatible}
   } } }
 
@@ -969,10 +969,10 @@ def melt : VerbEntry := .mkRegular {
   verbIncClass := some .sinc
   causative := some .make
   levinClass := some .otherCoS
-  root := { profile := {
-    forceMag := {.low, .moderate}
-    patientRob := {.moderate, .robust}
-    resultType := {.deformation}
+  root := { content := {
+    force := {.low, .moderate}
+    patientRobustness := {.moderate, .robust}
+    resultGeometry := {.deformation}
     agentControl := {.compatible}
   } } }
 
@@ -1119,8 +1119,8 @@ def devour : VerbEntry := .mkRegular {
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .devour
-  root := { profile := {
-    forceMag := {.moderate, .high}
+  root := { content := {
+    force := {.moderate, .high}
     agentControl := {.neutral}
   } } }
 
@@ -1178,9 +1178,9 @@ def sweep : VerbEntry where
   subjectEntailments := some wipeManner.subjectProfile
   passivizable := true
   levinClass := some .wipe
-  root := { profile := {
-    forceMag := {.low, .moderate}
-    forceDir := {.unidirectional}
+  root := { content := {
+    force := {.low, .moderate}
+    direction := {.unidirectional}
     agentControl := {.compatible}
   } }
 
@@ -1197,9 +1197,9 @@ def sweep_instr : VerbEntry where
   passivizable := true
   senseTag := .instrumental
   levinClass := some .wipe
-  root := { profile := {
-    forceMag := {.low, .moderate}
-    forceDir := {.unidirectional}
+  root := { content := {
+    force := {.low, .moderate}
+    direction := {.unidirectional}
     agentControl := {.compatible}
   } }
 
@@ -2360,9 +2360,9 @@ def cut : VerbEntry where
   vendlerClass := some .accomplishment
   verbIncClass := some .sinc
   levinClass := some .cut
-  root := { profile := {
-    resultType := {.surfaceBreach}
-    instrumentType := {.sharpBlade}
+  root := { content := {
+    resultGeometry := {.surfaceBreach}
+    instrument := {.sharpBlade}
   } }
 
 /-- "chop" — Levin 21.2 Carve verbs. -/

--- a/Linglib/Fragments/Spanish/Predicates.lean
+++ b/Linglib/Fragments/Spanish/Predicates.lean
@@ -199,11 +199,11 @@ def rasgar : SpanishVerbEntry :=
     causativeAlternation := true, verbHead := [.vCAUSE, .vGO, .vBE],
     licensesStylLE := true,
     levinClass := some .break_,
-    root := { profile := {
-      forceMag := {.low, .moderate}
-      forceDir := {.unidirectional}
-      patientRob := {.insubstantial, .flimsy}
-      resultType := {.separation, .surfaceBreach}
+    root := { content := {
+      force := {.low, .moderate}
+      direction := {.unidirectional}
+      patientRobustness := {.insubstantial, .flimsy}
+      resultGeometry := {.separation, .surfaceBreach}
       agentControl := {.incompatible, .neutral}
     } } }
 

--- a/Linglib/Semantics/Root/Content.lean
+++ b/Linglib/Semantics/Root/Content.lean
@@ -2,23 +2,26 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Root quality profiles
+# Root content
 
-The dimensions along which verbs of one class differ in root content, each a
-region of a finite scale rather than a point, since a verb is compatible with a
-range of force levels, patient materials, or result geometries.
-[spalek-mcnally-2026] separate English *tear* from Spanish *rasgar* by patient
+What a root says about the action, its result, and the patient, the fine,
+within-class half of a root's meaning; the coarse half, which templatic
+components it entails, is `Root.Kinds`. Each dimension is a region of a finite
+scale rather than a point, since a verb is compatible with a range of force
+levels, patient materials, or result geometries. [spalek-mcnally-2026] separate
+English *tear* from Spanish *rasgar*, two roots of one kind, by patient
 robustness, force direction, and compatibility with careful action;
 [majid-boster-bowerman-2008] sort cutting and breaking events by instrument,
-object dimensionality, and the geometry of the result. `Root.Profile` bundles
+object dimensionality, and the geometry of the result. `Root.Content` bundles
 one region per dimension, `univ` where a root says nothing.
 
 ## Main declarations
 
-* `Root.Profile.ForceLevel`, `ForceDirection`, `Robustness`, `ResultType`,
-  `InstrumentType`, `ObjectDimensionality`, `AgentControl` — the dimensions
-* `Root.Profile` — a region per dimension
-* `Root.Profile.Overlaps` — the regions meet on every dimension
+* `Root.Content.ForceLevel`, `ForceDirection`, `InstrumentType`, `AgentControl` —
+  dimensions of the action; `ResultGeometry` of the result; `Robustness`,
+  `ObjectDimensionality` of the patient
+* `Root.Content` — a region per dimension
+* `Root.Content.Overlaps` — the regions meet on every dimension
 
 ## References
 
@@ -29,7 +32,7 @@ one region per dimension, `univ` where a root says nothing.
 * [levin-1993]: English Verb Classes and Alternations.
 -/
 
-namespace Semantics.Root.Profile
+namespace Semantics.Root.Content
 
 /-! ### Dimensions -/
 
@@ -63,7 +66,7 @@ inductive Robustness where
 /-- The physical change produced, after the class descriptions of [levin-1993]
 (§45.1 break, §45.2 bend, §44 destroy, §21.1 cut) and [hale-keyser-1987]'s
 separation in material integrity. -/
-inductive ResultType where
+inductive ResultGeometry where
   /-- Loss of integrity by pulling apart (*tear*). -/
   | separation
   /-- Damage to a surface (*rasgar*, *cut*). -/
@@ -104,42 +107,42 @@ inductive AgentControl where
   | compatible
   deriving DecidableEq, Fintype, Repr
 
-end Semantics.Root.Profile
+end Semantics.Root.Content
 
 namespace Semantics.Root
 
-open Profile Finset
+open Content Finset
 
-/-- A root's quality profile, a region of each dimension, `univ` where the root says
-nothing. -/
-structure Profile where
-  /-- Force magnitude. -/
-  forceMag : Finset ForceLevel := univ
-  /-- Force direction. -/
-  forceDir : Finset ForceDirection := univ
-  /-- Patient robustness. -/
-  patientRob : Finset Robustness := univ
-  /-- The physical change produced. -/
-  resultType : Finset ResultType := univ
+/-- A root's content, a region of each dimension, `univ` where the root says nothing. -/
+structure Content where
+  /-- Magnitude of the force applied. -/
+  force : Finset ForceLevel := univ
+  /-- Direction of the force applied. -/
+  direction : Finset ForceDirection := univ
+  /-- The instrument selected for. -/
+  instrument : Finset InstrumentType := univ
   /-- Compatibility with careful action. -/
   agentControl : Finset AgentControl := univ
-  /-- The instrument selected for. -/
-  instrumentType : Finset InstrumentType := univ
-  /-- Patient dimensionality. -/
-  patientDim : Finset ObjectDimensionality := univ
+  /-- The physical change produced. -/
+  resultGeometry : Finset ResultGeometry := univ
+  /-- Robustness of the patient. -/
+  patientRobustness : Finset Robustness := univ
+  /-- Dimensionality of the patient. -/
+  patientDimensionality : Finset ObjectDimensionality := univ
   deriving DecidableEq
 
-namespace Profile
+namespace Content
 
-/-- Two profiles overlap when their regions meet on every dimension. -/
-def Overlaps (p q : Profile) : Prop :=
-  ¬ Disjoint p.forceMag q.forceMag ∧ ¬ Disjoint p.forceDir q.forceDir ∧
-    ¬ Disjoint p.patientRob q.patientRob ∧ ¬ Disjoint p.resultType q.resultType ∧
-    ¬ Disjoint p.agentControl q.agentControl ∧
-    ¬ Disjoint p.instrumentType q.instrumentType ∧ ¬ Disjoint p.patientDim q.patientDim
+/-- Two contents overlap when their regions meet on every dimension. -/
+def Overlaps (p q : Content) : Prop :=
+  ¬ Disjoint p.force q.force ∧ ¬ Disjoint p.direction q.direction ∧
+    ¬ Disjoint p.instrument q.instrument ∧ ¬ Disjoint p.agentControl q.agentControl ∧
+    ¬ Disjoint p.resultGeometry q.resultGeometry ∧
+    ¬ Disjoint p.patientRobustness q.patientRobustness ∧
+    ¬ Disjoint p.patientDimensionality q.patientDimensionality
 
-instance (p q : Profile) : Decidable (p.Overlaps q) := by unfold Overlaps; infer_instance
+instance (p q : Content) : Decidable (p.Overlaps q) := by unfold Overlaps; infer_instance
 
-end Profile
+end Content
 
 end Semantics.Root

--- a/Linglib/Semantics/Root/Defs.lean
+++ b/Linglib/Semantics/Root/Defs.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Root.Profile
+import Linglib.Semantics.Root.Content
 import Linglib.Semantics.Root.Kinds
 import Linglib.Semantics.ArgumentStructure.Valency
 import Linglib.Semantics.Composition.Ty
@@ -9,7 +9,7 @@ import Linglib.Semantics.Composition.Ty
 A verbal root of [beavers-koontz-garboden-2020] is a bundle of lexical
 entailments (§5.2.1), each of one of the four kinds of `Root.Kind`. `Root`
 carries a finite set of such atoms, its position with respect to the verbalizing
-head `v`, and a within-class quality profile. Its kind signature `Root.kinds` is
+head `v`, and its within-class content. Its kind signature `Root.kinds` is
 the image of the atoms under `Entailment.kind`, and `Root.closedKinds` completes
 it under the collocational restrictions (`Root.Kinds.close`). A root composes
 with `v` either as its complement, the result position of change-of-state roots
@@ -26,7 +26,7 @@ and whether it combines with transitive Voice.
 
 * `Root.Entailment` — a labelled state, manner, or result atom, or causation
 * `Root.Position` — complement of `v` or adjoined to it
-* `Root` — a root's name, atoms, position, quality profile, and annotated
+* `Root` — a root's name, atoms, position, content, and annotated
   valency, semantic type, and transitive-Voice licensing
 * `Root.kinds` — the kinds of a root's atoms; `Root.closedKinds` closes them
 * `Root.changeType` — property-concept or result root, off the closed signature
@@ -38,8 +38,8 @@ and whether it combines with transitive Voice.
 * [beavers-etal-2021]: States and changes of state.
 * [kalyakin-2026]: VP ellipsis and argument structure alternations: Evidence from
   Muira Dargwa complex predicates.
-* [spalek-mcnally-2026], [majid-boster-bowerman-2008]: the quality dimensions of
-  `Root.Profile`.
+* [spalek-mcnally-2026], [majid-boster-bowerman-2008]: the dimensions of
+  `Root.Content`.
 -/
 
 namespace Semantics
@@ -78,7 +78,7 @@ inductive Root.Position where
 
 /-! ### Roots -/
 
-/-- A verbal root, with its lexical entailments, position, and quality profile. -/
+/-- A verbal root, with its lexical entailments, position, and content. -/
 structure Root where
   /-- The root form, `""` when the root is carried anonymously by a verb whose
   citation form names it. -/
@@ -87,9 +87,9 @@ structure Root where
   entailments : Finset Semantics.Root.Entailment := ∅
   /-- The position in which the root composes with `v`, where annotated. -/
   position : Option Semantics.Root.Position := none
-  /-- Within-class graded quality dimensions ([spalek-mcnally-2026],
-  [majid-boster-bowerman-2008]); `{}` leaves every dimension unconstrained. -/
-  profile : Semantics.Root.Profile := {}
+  /-- Within-class content ([spalek-mcnally-2026], [majid-boster-bowerman-2008]); `{}`
+  leaves every dimension unconstrained. -/
+  content : Semantics.Root.Content := {}
   /-- The core-argument positions the root introduces, where annotated ([coon-2019]). -/
   valency : Option ArgumentStructure.Valency := none
   /-- The root's semantic type, where annotated ([coon-2019] (3)). -/

--- a/Linglib/Semantics/Root/Kinds.lean
+++ b/Linglib/Semantics/Root/Kinds.lean
@@ -5,8 +5,10 @@ import Mathlib.Tactic.DeriveFintype
 /-!
 # Root kind signatures
 
-The root typology of [beavers-koontz-garboden-2020] (§5.4.1) records which of
-four kinds of lexical entailment a root carries — state, manner, result, cause —
+Which templatic components a root entails, the coarse, between-class half of a
+root's meaning; the fine, within-class half is `Root.Content`. The root typology
+of [beavers-koontz-garboden-2020] (§5.4.1) records which of four kinds of
+lexical entailment a root carries — state, manner, result, cause —
 under two collocational restrictions, that a change entails a state and a cause
 entails a change. The restrictions are the partial order `state ≤ result ≤ cause`
 on `Root.Kind`, with `manner` isolated. A root's kind signature is a

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -36,13 +36,13 @@ they carve and where they place boundaries.
 
 ## Integration with linglib
 
-The 4 dimensions project onto existing `Root.Profile` features:
+The 4 dimensions project onto existing `Root.Content` features:
 
 | Dimension | Projects onto |
 |-----------|--------------|
-| Dim 1 (predictability) | `instrumentType` × `patientRob` (derived) |
-| Dim 2 (tearing) | `resultType == .separation` ∧ `instrumentType == .hands` |
-| Dim 3 (snap/smash) | `forceDir` (bidirectional vs omnidirectional) |
+| Dim 1 (predictability) | `instrument` × `patientRobustness` (derived) |
+| Dim 2 (tearing) | `resultGeometry == .separation` ∧ `instrument == .hands` |
+| Dim 3 (snap/smash) | `direction` (bidirectional vs omnidirectional) |
 | Dim 4 (poke hole) | specific event type |
 
 Bridge theorems connect to `LevinClass` and `MeaningComponents`:
@@ -54,7 +54,7 @@ Bridge theorems connect to `LevinClass` and `MeaningComponents`:
 ## Design
 
 `SeparationEvent` is a **point** in the same feature space that
-`Root.Profile` defines **regions** over. A verb is compatible with an
+`Root.Content` defines **regions** over. A verb is compatible with an
 event iff the event's feature values fall within the verb root's ranges.
 This captures the many-to-many mapping between events and verbs that
 varies across languages.
@@ -66,10 +66,10 @@ open Verb
 open Semantics
 open ArgumentStructure
 open Features
-open Semantics.Root.Profile
-open Semantics.Root.Profile.InstrumentType Semantics.Root.Profile.ObjectDimensionality
-  Semantics.Root.Profile.Robustness Semantics.Root.Profile.ResultType Semantics.Root.Profile.ForceLevel
-  Semantics.Root.Profile.ForceDirection
+open Semantics.Root.Content
+open Semantics.Root.Content.InstrumentType Semantics.Root.Content.ObjectDimensionality
+  Semantics.Root.Content.Robustness Semantics.Root.Content.ResultGeometry Semantics.Root.Content.ForceLevel
+  Semantics.Root.Content.ForceDirection
 
 -- ════════════════════════════════════════════════════
 -- § 1. Separation Events (stimulus level)
@@ -81,7 +81,7 @@ open Semantics.Root.Profile.InstrumentType Semantics.Root.Profile.ObjectDimensio
     This is the **stimulus level**: each value is a specific point,
     not a range. Corresponds to a single video clip in the experiment.
     Verb roots select *ranges* over these same dimensions
-    (via `Root.Profile`). -/
+    (via `Root.Content`). -/
 structure SeparationEvent where
   /-- Instrument used to effect separation. -/
   instrument : InstrumentType
@@ -90,7 +90,7 @@ structure SeparationEvent where
   /-- Material robustness of the affected object. -/
   objectRob : Robustness
   /-- Physical result type. -/
-  result : ResultType
+  result : ResultGeometry
   /-- Force magnitude. -/
   force : ForceLevel
   /-- Force directionality. -/
@@ -263,16 +263,17 @@ def SeparationEvent.isPokingHole (e : SeparationEvent) : Bool :=
   e.result == .surfaceBreach && e.objectDim == .twoD && e.objectRob == .flimsy
 
 -- ════════════════════════════════════════════════════
--- § 4. Compatibility with Root.Profile
+-- § 4. Compatibility with Root.Content
 -- ════════════════════════════════════════════════════
 
 /-- A separation event is compatible with a root's profile when each of its feature
     values lies in the root's region for that dimension. -/
-def SeparationEvent.CompatibleWith (e : SeparationEvent) (r : Root.Profile) : Prop :=
-  e.force ∈ r.forceMag ∧ e.forceDir ∈ r.forceDir ∧ e.objectRob ∈ r.patientRob ∧
-    e.result ∈ r.resultType ∧ e.instrument ∈ r.instrumentType ∧ e.objectDim ∈ r.patientDim
+def SeparationEvent.CompatibleWith (e : SeparationEvent) (r : Root.Content) : Prop :=
+  e.force ∈ r.force ∧ e.forceDir ∈ r.direction ∧ e.objectRob ∈ r.patientRobustness ∧
+    e.result ∈ r.resultGeometry ∧ e.instrument ∈ r.instrument ∧
+    e.objectDim ∈ r.patientDimensionality
 
-instance (e : SeparationEvent) (r : Root.Profile) : Decidable (e.CompatibleWith r) := by
+instance (e : SeparationEvent) (r : Root.Content) : Decidable (e.CompatibleWith r) := by
   unfold SeparationEvent.CompatibleWith; infer_instance
 
 -- ════════════════════════════════════════════════════
@@ -506,38 +507,38 @@ theorem cut_break_same_template :
 
 open English.Predicates.Verbal in
 /-- Extract the root profile from a Fragment verb entry. -/
-private def fragmentProfile (v : VerbEntry) : Root.Profile :=
-  v.rootProfile
+private def fragmentContent (v : VerbEntry) : Root.Content :=
+  v.rootContent
 
 open English.Predicates.Verbal
 
 /-- The tear cloth event is compatible with the Fragment *tear* entry. -/
 theorem tearCloth_compatible_tear :
-    clip01_tearCloth.CompatibleWith (fragmentProfile tear_) := by decide
+    clip01_tearCloth.CompatibleWith (fragmentContent tear_) := by decide
 
 /-- A cutting event is NOT compatible with the *tear* profile
     (wrong instrument type). -/
 theorem sliceCarrot_incompatible_tear :
-    ¬ clip09_sliceCarrot.CompatibleWith (fragmentProfile tear_) := by decide
+    ¬ clip09_sliceCarrot.CompatibleWith (fragmentContent tear_) := by decide
 
 /-- Smashing a pot is NOT compatible with the *break* profile
     (fragmentation ≠ fracture — English *smash* covers fragmentation). -/
 theorem smashPot_incompatible_break :
-    ¬ clip39_smashPot.CompatibleWith (fragmentProfile break_) := by decide
+    ¬ clip39_smashPot.CompatibleWith (fragmentContent break_) := by decide
 
 /-- A snapping event IS compatible with *break* (fracture result, moderate
     force) — English *break* can cover snapping events, though *snap*
     is more specific. -/
 theorem snapTwig_compatible_break :
-    clip19_snapTwig.CompatibleWith (fragmentProfile break_) := by decide
+    clip19_snapTwig.CompatibleWith (fragmentContent break_) := by decide
 
 /-- Slicing a carrot is compatible with the *cut* entry. -/
 theorem sliceCarrot_compatible_cut :
-    clip09_sliceCarrot.CompatibleWith (fragmentProfile cut) := by decide
+    clip09_sliceCarrot.CompatibleWith (fragmentContent cut) := by decide
 
 /-- Tearing cloth is NOT compatible with the *cut* profile (wrong instrument). -/
 theorem tearCloth_incompatible_cut :
-    ¬ clip01_tearCloth.CompatibleWith (fragmentProfile cut) := by decide
+    ¬ clip01_tearCloth.CompatibleWith (fragmentContent cut) := by decide
 
 -- ════════════════════════════════════════════════════
 -- § 10. Key Finding: Dimensional Constraint

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -67,22 +67,22 @@ theorem both_causative :
     [spalek-mcnally-2026] ex. (14): "she tore a chunk off her slice of bread" ✓
     vs. "??rasgó un trozo de pan" (§3.2). -/
 theorem patient_restriction_differs :
-    tear_.rootProfile ≠ rasgar.rootProfile := by
+    tear_.rootContent ≠ rasgar.rootContent := by
   decide
 
 /-- *tear* implies bidirectional (contrary-direction) force;
     *rasgar* implies unidirectional (linear/gash-like) force. -/
 theorem force_direction_differs :
-    tear_.rootProfile.forceDir ≠
-    rasgar.rootProfile.forceDir := by
+    tear_.rootContent.direction ≠
+    rasgar.rootContent.direction := by
   decide
 
 /-- *tear* is compatible with controlled action; *rasgar* is not.
     [spalek-mcnally-2026] ex. (17): "carefully tore the tin foil" ✓
     vs. "??rasgaron con cuidado el papel de aluminio" (§3.2). -/
 theorem agent_control_differs :
-    tear_.rootProfile.agentControl ≠
-    rasgar.rootProfile.agentControl := by
+    tear_.rootContent.agentControl ≠
+    rasgar.rootContent.agentControl := by
   decide
 
 -- ════════════════════════════════════════════════════
@@ -94,7 +94,7 @@ theorem agent_control_differs :
     where both verbs are applicable. This overlap zone is where they
     function as translation equivalents (§4.2, Table 1). -/
 theorem roots_overlap :
-    tear_.rootProfile.Overlaps rasgar.rootProfile := by
+    tear_.rootContent.Overlaps rasgar.rootContent := by
   decide
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -33,10 +33,9 @@ def Verb.derivedUnaccusative (v : Verb) : Bool :=
 def Verb.derivedVendlerClass (v : Verb) : Option VendlerClass :=
   v.vendlerClass <|> v.degreeAchievementScale.map (·.defaultVendlerClass)
 
-/-- The verb's within-class quality profile ([spalek-mcnally-2026]), read off its
-    `root` (where the profile is carried). -/
-def Verb.rootProfile (v : Verb) : Semantics.Root.Profile :=
-  v.root.profile
+/-- The verb's within-class root content ([spalek-mcnally-2026]), read off its `root`. -/
+def Verb.rootContent (v : Verb) : Semantics.Root.Content :=
+  v.root.content
 
 /-- The verb's raw kind signature ([beavers-koontz-garboden-2020]): the
     un-closed atom-kinds of its root, the source of truth for what the verb

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -15,7 +15,6 @@ import Linglib.Semantics.Aspect.DegreeAchievement
 import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Semantics.Root.Defs
-import Linglib.Semantics.Root.Profile
 
 /-! # Verb entry — core type
 


### PR DESCRIPTION
`Root.Profile` becomes `Root.Content`, the term both source papers use, ending the collision with `ArgumentStructure.EntailmentProfile`; fields say what each dimension describes (`force`, `direction`, `instrument`, `agentControl` for the action; `resultGeometry` for the result, ending the `resultType`/`ChangeType`/`denotationType` overlap; `patientRobustness`, `patientDimensionality` for the patient), and the `Kinds` and `Content` module docstrings each open with the coarse-versus-fine contrast between them. `Verb.rootProfile` becomes `Verb.rootContent`.