### PR TITLE
refactor(Studies/ChuangEtAl2026): word centroids under least squares

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -139,6 +139,7 @@ import Linglib.Core.InformationTheory.KullbackLeibler.Finite
 import Linglib.Core.Learning.Luce
 import Linglib.Core.Learning.RescorlaWagner
 import Linglib.Core.Learning.WidrowHoff
+import Linglib.Core.LinearAlgebra.AffineSpace.Centroid
 import Linglib.Core.LinearAlgebra.Matrix.Symmetric
 import Linglib.Core.LinearAlgebra.SymmetricAlgebra.Derivation
 import Linglib.Core.LinearAlgebra.SymmetricPower.Lift

--- a/Linglib/Core/LinearAlgebra/AffineSpace/Centroid.lean
+++ b/Linglib/Core/LinearAlgebra/AffineSpace/Centroid.lean
@@ -1,0 +1,43 @@
+import Mathlib.LinearAlgebra.AffineSpace.Centroid
+
+/-!
+# Centroids under affine and linear maps
+
+`[UPSTREAM]` Affine maps commute with the centroids of nonempty finite families of points, the
+centroid case of `Finset.map_affineCombination`; so do linear maps, a module being an affine space
+over itself; and in a module the centroid is the average of the points.
+-/
+
+open Affine
+
+namespace Finset
+
+variable {k V P V₂ P₂ ι : Type*} [DivisionRing k] [AddCommGroup V] [Module k V] [AffineSpace V P]
+  [AddCommGroup V₂] [Module k V₂] [AffineSpace V₂ P₂] (s : Finset ι)
+
+/-- Affine maps commute with centroids, if the number of points, converted to `k`, is not zero. -/
+theorem map_centroid_of_cast_card_ne_zero (p : ι → P) (f : P →ᵃ[k] P₂) (h : (#s : k) ≠ 0) :
+    f (s.centroid k p) = s.centroid k (f ∘ p) := by
+  rw [centroid_def, centroid_def,
+    s.map_affineCombination p _ (s.sum_centroidWeights_eq_one_of_cast_card_ne_zero h)]
+
+/-- In the characteristic zero case, affine maps commute with centroids of nonempty sets. -/
+theorem map_centroid_of_nonempty [CharZero k] (p : ι → P) (f : P →ᵃ[k] P₂) (h : s.Nonempty) :
+    f (s.centroid k p) = s.centroid k (f ∘ p) :=
+  s.map_centroid_of_cast_card_ne_zero p f (Nat.cast_ne_zero.2 (card_pos.2 h).ne')
+
+/-- The centroid of points of a module is their average, if the number of points, converted to
+`k`, is not zero. -/
+theorem centroid_eq_smul_sum (p : ι → V) (h : (#s : k) ≠ 0) :
+    s.centroid k p = (#s : k)⁻¹ • ∑ i ∈ s, p i := by
+  rw [centroid_def, s.affineCombination_eq_linear_combination p _
+    (s.sum_centroidWeights_eq_one_of_cast_card_ne_zero h), smul_sum]
+  simp only [centroidWeights_apply]
+
+end Finset
+
+/-- In the characteristic zero case, linear maps commute with centroids of nonempty sets. -/
+theorem LinearMap.map_centroid {k V V₂ ι : Type*} [DivisionRing k] [CharZero k] [AddCommGroup V]
+    [Module k V] [AddCommGroup V₂] [Module k V₂] (f : V →ₗ[k] V₂) {s : Finset ι} (h : s.Nonempty)
+    (p : ι → V) : f (s.centroid k p) = s.centroid k (f ∘ p) :=
+  s.map_centroid_of_nonempty p f.toAffineMap h

--- a/Linglib/Processing/DiscriminativeLexicon/Training.lean
+++ b/Linglib/Processing/DiscriminativeLexicon/Training.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Analysis.LeastSquares
+import Linglib.Core.LinearAlgebra.AffineSpace.Centroid
 import Linglib.Processing.DiscriminativeLexicon.Measures
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.PiL2
@@ -32,15 +33,23 @@ experienced meanings), the solution coset, and the identification of FIL under `
   `existsUnique_isTrained_iff`: fitted values are unique exactly on the span of experience.
 * `isELTrained_sqrtScale_iff`: FIL under `q` is EL on `TrainingExperience.sqrtScale`.
 * `Linear.IsTrainedOn` and the `semSup` transfer theorems.
+* `IsTrained.sum_smul_mul_eq_of_decodable`,
+  `Linear.IsELTrainedOn.production_centroid_eq_of_decodable`: fitted and observed forms agree on
+  every linearly decodable average, so a trained DLM sends the centroid of a linearly decodable
+  set of meanings to the centroid of its forms.
 
 ## References
 
+* [Y.-Y. Chuang, M. J. Bell, Y.-H. Tseng and R. H. Baayen, *Word-specific tonal realizations
+  in Mandarin* (2026)][chuang-bell-tseng-baayen-2026]
 * [S. Gahl and R. H. Baayen, *Time and thyme again* (2024)][gahl-baayen-2024]
 * [M. Heitmeier, *Mappings in the Discriminative Lexicon Model* (2024)][heitmeier-2024]
 * [M. Heitmeier, Y.-Y. Chuang, S. D. Axen and R. H. Baayen, *Frequency effects in linear
   discriminative learning* (2024)][heitmeier-chuang-axen-baayen-2024]
 * [M. Heitmeier, Y.-Y. Chuang and R. H. Baayen, *The Discriminative Lexicon*
   (2026)][heitmeier-chuang-baayen-2026]
+* [Y. Lu, Y.-Y. Chuang and R. H. Baayen, *The realization of tones in spontaneous spoken
+  Taiwan Mandarin* (2026)][lu-chuang-baayen-2026]
 -/
 
 namespace DiscriminativeLexicon
@@ -274,6 +283,15 @@ theorem IsTrained.sum_smul_sub_eq_zero (hG : IsTrained data q G) (w : MeaningVec
         rw [Finset.sum_mul]; exact Finset.sum_congr rfl fun i _ => by ring
     _ = 0 := by rw [hk k, zero_mul]
 
+/-- Whenever membership in a set `P` of usage events is a linear functional of the meanings, the
+`q`-weighted sums of the fitted and of the observed forms over `P` agree. -/
+theorem IsTrained.sum_smul_mul_eq_of_decodable (hG : IsTrained data q G) {P : Finset (Fin m)}
+    {w : MeaningVec d →ₗ[ℝ] ℝ} (hw : ∀ i, w (data.S i) = if i ∈ P then 1 else 0) :
+    ∑ i ∈ P, (q i : ℝ) • (data.S * G) i = ∑ i ∈ P, (q i : ℝ) • data.C i := by
+  simpa only [hw, mul_ite, mul_one, mul_zero, ite_smul, zero_smul, Finset.sum_ite_mem,
+    Finset.univ_inter, smul_sub, Finset.sum_sub_distrib, sub_eq_zero] using
+    hG.sum_smul_sub_eq_zero w
+
 /-! ### Fitted values -/
 
 /-- All trained matrices under positive weights produce the same predicted forms `SG` on the
@@ -440,6 +458,22 @@ theorem IsTrainedOn.semSupWord_eq_of_decodable (hD : D.IsTrainedOn data q) (hq :
   · obtain ⟨w, hwj⟩ := hw j hc
     rw [show D.production (data.S i) j = semSup D (data.S i) j from rfl,
       hD.semSup_eq_of_decodable hq hwj i]
+
+/-! ### Centroids -/
+
+/-- **Centroids under training** ([chuang-bell-tseng-baayen-2026] §3.4, [lu-chuang-baayen-2026]
+§4.4): whenever membership in a nonempty set `P` of usage events is a linear functional of the
+meanings, an EL-trained DLM sends the centroid of `P`'s meanings exactly to the centroid of `P`'s
+observed forms. Linearity alone sends it to the centroid of the predicted forms
+(`LinearMap.map_centroid`); training makes those coincide with the observed ones. -/
+theorem IsELTrainedOn.production_centroid_eq_of_decodable (hD : D.IsELTrainedOn data)
+    {P : Finset (Fin m)} (hP : P.Nonempty) {w : MeaningVec d →ₗ[ℝ] ℝ}
+    (hw : ∀ i, w (data.S i) = if i ∈ P then 1 else 0) :
+    D.production (P.centroid ℝ data.S) = P.centroid ℝ data.C := by
+  have hc : (P.card : ℝ) ≠ 0 := Nat.cast_ne_zero.2 hP.card_pos.ne'
+  have h := IsTrained.sum_smul_mul_eq_of_decodable hD hw
+  simp only [Pi.one_apply, NNReal.coe_one, one_smul, mul_productionMatrix_apply] at h
+  rw [P.centroid_eq_smul_sum data.S hc, P.centroid_eq_smul_sum data.C hc, map_smul, map_sum, h]
 
 end Linear
 

--- a/Linglib/Studies/ChuangEtAl2026.lean
+++ b/Linglib/Studies/ChuangEtAl2026.lean
@@ -1,5 +1,4 @@
-import Linglib.Processing.DiscriminativeLexicon.Defs
-import Linglib.Processing.DiscriminativeLexicon.Normed
+import Linglib.Processing.DiscriminativeLexicon.Training
 
 /-!
 # Chuang, Bell, Tseng & Baayen 2026: Word-specific tonal realizations in Mandarin
@@ -43,25 +42,42 @@ on continuous f0 vectors, not the discrete-tone substrate (`Phonology/Tone/`,
 `Autosegmental.FloatingForm`): bridging the two would presuppose the
 discretization of tonal categories that §4 contests.
 
-Per the Processing scope discipline, the GAM/DLM fit results above are empirical
-findings recorded in prose, not Lean theorems. The Lean content instantiates the
-DLM substrate (`Processing/DiscriminativeLexicon/`, [baayen-2019]
-[heitmeier-chuang-baayen-2026]) at the paper's carriers and proves the one
-structural claim the paper itself states (fn. 29,
-`comprehension_not_surjective`). The substrate supplies the rest:
-`Linear.norm_production_sub_le` (the production map's Lipschitz
-bound — similar embeddings surface as similar contours) and
-`LinearMap.sub_mem_ker_iff` (homophones like *cheng2shi4*
-'city' ~ 'computer program' (§2.1) surface distinctly iff their embedding
-difference avoids the production kernel).
+The GAM and DLM fit results above are empirical findings, recorded in prose per
+the Processing scope. The Lean content instantiates the DLM substrate
+(`Processing/DiscriminativeLexicon/`, [baayen-2019]
+[heitmeier-chuang-baayen-2026]) at the paper's carriers and derives the two
+structural claims the paper makes about its linear networks. Fn. 29's dimension
+argument: a linear comprehension map from fifty-sample contours reaches at most a
+fifty-dimensional subspace of the embedding space (`comprehension_not_surjective`),
+so no comprehension network undoes the production network
+(`comprehension_comp_production_ne_id`). Fig. 18's word-centroid contours: the
+paper reports the LDL contour produced from a word's centroid embedding as
+remarkably similar to the average of that word's training contours, and reads the
+match as form–meaning isomorphy; least squares makes it exact whenever word-type
+membership is a linear functional of the embeddings — the idealization of Fig. 14's
+distinct word-type regions — because the normal equations force fitted and observed
+forms to agree on every linearly decodable average
+(`production_centroid_eq_of_decodable`, over the substrate's
+`Linear.IsELTrainedOn.production_centroid_eq_of_decodable`). The grand centroid of
+all tokens, which the paper reads as the meaning of the unmodulated rise–fall
+contour, maps to the grand-mean training contour under the same hypothesis for the
+whole data set (`production_centroid_univ_eq`). The substrate's
+`Linear.norm_production_sub_le` is the quantitative form of §4's isomorphy claim:
+embeddings within `ε` of each other produce contours within `‖production‖ * ε`.
 
 ## Main results
 
 * `PitchContour` / `ContextualEmbedding` / `TaiwanMandarinRFDLM` — the paper's
   carriers: 50-sample min–max-normalized pitch shapes (§3.2) and 768-dim CKIP
   GPT-2 contextualized embeddings (§3.1)
-* `comprehension_not_surjective` — fn. 29: a linear map from 50-dimensional
-  pitch space cannot reach all of the 768-dimensional embedding space
+* `comprehension_not_surjective`, `comprehension_comp_production_ne_id` — fn. 29:
+  a linear map from 50-dimensional pitch space cannot reach all of the
+  768-dimensional embedding space, so no comprehension map inverts production
+* `production_centroid_eq_of_decodable` — Fig. 18: a trained LDL production net
+  sends a word type's centroid embedding to the average of its training contours
+  whenever word-type membership is linearly decodable from the embeddings
+* `production_centroid_univ_eq` — §3.4.2: the grand centroid of all tokens maps
+  to the grand-mean contour
 
 ## References
 
@@ -76,7 +92,7 @@ difference avoids the production kernel).
 
 namespace ChuangEtAl2026
 
-open DiscriminativeLexicon
+open DiscriminativeLexicon Finset
 
 /-- The paper samples 50 evenly-spaced f0 values per token from the GAM-smoothed
 contour (§3.2). -/
@@ -101,14 +117,54 @@ abbrev ContextualEmbedding : Type := MeaningVec CKIPGPT2HiddenDim
 abbrev TaiwanMandarinRFDLM : Type :=
   Linear ℝ PitchContour ContextualEmbedding
 
+variable (D : TaiwanMandarinRFDLM)
+
+/-! ### Comprehension from fifty dimensions (§3.3) -/
+
 /-- **Fn. 29** (§3.3): "it is impossible to map a lower-dimensional space into a
 higher-dimensional space with a linear mapping without losing information" — any
 linear comprehension map from 50-sample pitch contours reaches at most a
 50-dimensional subspace of the 768-dimensional embedding space, the paper's
 ground for finding ResLDL's comprehension advantage over LDL "unsurprising". -/
-theorem comprehension_not_surjective (D : TaiwanMandarinRFDLM) :
-    ¬ Function.Surjective D.comprehension := fun h => by
+theorem comprehension_not_surjective : ¬ Function.Surjective D.comprehension := fun h => by
   simpa [CKIPGPT2HiddenDim, TaiwanMandarinPitchSampleCount] using
     LinearMap.finrank_le_finrank_of_surjective (f := D.comprehension) h
+
+/-- Fn. 29's picture: points of a cube projected onto a plane cannot be recovered
+from the projection. No comprehension network undoes the production network — the
+round trip through pitch space is never the identity on embeddings. -/
+theorem comprehension_comp_production_ne_id :
+    D.comprehension ∘ₗ D.production ≠ LinearMap.id := fun h =>
+  comprehension_not_surjective D <| Function.Surjective.of_comp (g := D.production) <| by
+    rw [← LinearMap.coe_comp, h]; exact Function.surjective_id
+
+/-! ### Word-centroid contours (§3.4) -/
+
+variable {D} {m : ℕ} {W : Type*} [DecidableEq W]
+  {data : TrainingExperience m TaiwanMandarinPitchSampleCount CKIPGPT2HiddenDim}
+
+/-- **Fig. 18** (§3.4): a word type is the set of tokens carrying the corpus's word
+label (§1, §2.2); the paper maps the centroid of a word's contextualized
+embeddings through the LDL production network and finds the result remarkably
+similar to the average of the word's training contours. Least squares makes the
+match exact whenever membership in the word type is a linear functional of the
+embeddings — the idealization of Fig. 14's distinct word-type regions. -/
+theorem production_centroid_eq_of_decodable (hD : D.IsELTrainedOn data) (word : Fin m → W)
+    {w : W} (hw : ∃ i, word i = w) {ℓ : ContextualEmbedding →ₗ[ℝ] ℝ}
+    (hℓ : ∀ i, ℓ (data.S i) = if word i = w then 1 else 0) :
+    D.production ((univ.filter (word · = w)).centroid ℝ data.S) =
+      (univ.filter (word · = w)).centroid ℝ data.C :=
+  hD.production_centroid_eq_of_decodable (by simpa [filter_nonempty_iff] using hw)
+    (by simpa using hℓ)
+
+/-- **The grand centroid** (§3.4.2): the contour produced from the centroid of all
+tokens' embeddings resembles the unmodulated rise–fall contour (Fig. 1), so the
+paper reads that centroid as the contour's "meaning". If some linear functional
+is constant on every training embedding, the produced contour is exactly the
+grand-mean training contour. -/
+theorem production_centroid_univ_eq [NeZero m] (hD : D.IsELTrainedOn data)
+    {ℓ : ContextualEmbedding →ₗ[ℝ] ℝ} (hℓ : ∀ i, ℓ (data.S i) = 1) :
+    D.production (univ.centroid ℝ data.S) = univ.centroid ℝ data.C :=
+  hD.production_centroid_eq_of_decodable ⟨0, mem_univ 0⟩ (by simpa using hℓ)
 
 end ChuangEtAl2026

--- a/Linglib/Studies/LuChuangBaayen2026.lean
+++ b/Linglib/Studies/LuChuangBaayen2026.lean
@@ -19,21 +19,22 @@ simply be reclassified, and theoretically: the model predicts forms from meaning
 from forms, and the tone-pattern contours emerge without the model being told the patterns.
 The lab-speech contours of [xu-1997] match the predicted ones for several patterns (Fig. 11).
 
-This file instantiates the DLM at the paper's carriers and derives the model-side half of the
-centroid claim. Linearity alone sends a centroid to the mean of the predicted contours
-(`production_centroid`); training does better: whenever membership in a set of training tokens
-is a linear functional of the embeddings, the least-squares map sends that set's centroid
-exactly to the mean of its target contours (`production_centroid_eq_of_decodable`). The
-paper's centroids weight word types equally rather than tokens (§4.4) and Fig. 9 compares
-against GAMM contours, so the match it reports is approximate; the theorem states what least
-squares guarantees when a tone pattern is linearly recoverable from meaning. The GAMM fits
-and the nearest-neighbour accuracies are outside the Processing scope.
+This file instantiates the DLM at the paper's carriers and states the model-side half of the
+centroid claim at them. Linearity alone sends a centroid to the mean of the predicted contours
+(`LinearMap.map_centroid`); training does better: whenever membership in a set of training
+tokens is a linear functional of the embeddings, the least-squares map sends that set's
+centroid exactly to the mean of its target contours (`production_centroid_eq_of_decodable`,
+the substrate's `Linear.IsELTrainedOn.production_centroid_eq_of_decodable`, shared with
+[chuang-bell-tseng-baayen-2026]'s Fig. 18). The paper's centroids weight word types equally
+rather than tokens (§4.4) and Fig. 9 compares against GAMM contours, so the match it reports
+is approximate; the theorem states what least squares guarantees when a tone pattern is
+linearly recoverable from meaning. The GAMM fits and the nearest-neighbour accuracies are
+outside the Processing scope.
 
 ## Main results
 
-* `production_centroid`: a production map sends a centroid to the mean of the predictions.
 * `production_centroid_eq_of_decodable`: a least-squares-trained map sends the centroid of a
-  linearly decodable set of tokens exactly to the mean of their target contours.
+  linearly decodable tone pattern's tokens exactly to the mean of their target contours.
 
 ## References
 
@@ -65,30 +66,14 @@ abbrev PitchVector : Type := FormVec PitchSampleCount
 contextualized embeddings of [chuang-bell-tseng-baayen-2026] (§4.2). -/
 abbrev TaiwanMandarinDLM : Type := Linear ℝ PitchVector ContextualEmbedding
 
-variable {ι V : Type*} [AddCommGroup V] [Module ℝ V]
-
-/-- The centroid of a finite family of vectors: their mean (§4.4). -/
-noncomputable def centroid (P : Finset ι) (v : ι → V) : V := (P.card : ℝ)⁻¹ • ∑ i ∈ P, v i
-
-/-- A production map sends a centroid of embeddings to the centroid of the predicted contours:
-average contours correspond to average embeddings (§4.5). -/
-theorem production_centroid (D : TaiwanMandarinDLM) (P : Finset ι)
-    (s : ι → ContextualEmbedding) :
-    D.production (centroid P s) = centroid P fun i => D.production (s i) := by
-  simp [centroid, map_sum]
-
-/-- **Centroids under least squares** (§4.4, Fig. 9): if membership in a set `P` of training
-tokens is a linear functional of their embeddings, a least-squares-trained production map sends
-the centroid of `P`'s embeddings exactly to the centroid of `P`'s target contours. -/
+/-- **Centroids under least squares** (§4.4, Fig. 9): if membership in a tone pattern's set `P`
+of training tokens is a linear functional of their embeddings, a least-squares-trained production
+map sends the centroid of `P`'s embeddings exactly to the centroid of `P`'s target contours. -/
 theorem production_centroid_eq_of_decodable {m : ℕ} {D : TaiwanMandarinDLM}
     {data : TrainingExperience m PitchSampleCount CKIPGPT2HiddenDim} (hD : D.IsELTrainedOn data)
-    {P : Finset (Fin m)} {w : ContextualEmbedding →ₗ[ℝ] ℝ}
+    {P : Finset (Fin m)} (hP : P.Nonempty) {w : ContextualEmbedding →ₗ[ℝ] ℝ}
     (hw : ∀ i, w (data.S i) = if i ∈ P then 1 else 0) :
-    D.production (centroid P data.S) = centroid P data.C := by
-  have h := IsTrained.sum_smul_sub_eq_zero hD w
-  simp only [Pi.one_apply, NNReal.coe_one, one_mul, hw, ite_smul, one_smul, zero_smul,
-    Finset.sum_ite_mem, Finset.univ_inter, Linear.mul_productionMatrix_apply,
-    Finset.sum_sub_distrib, sub_eq_zero] at h
-  simp [centroid, map_sum, h]
+    D.production (P.centroid ℝ data.S) = P.centroid ℝ data.C :=
+  hD.production_centroid_eq_of_decodable hP hw
 
 end LuChuangBaayen2026

--- a/references.bib
+++ b/references.bib
@@ -27579,7 +27579,7 @@
   doi       = {10.1017/S0097850725000001},
   subfield  = {phonology},
   role      = {formalized},
-  sources   = {Studies/ChuangEtAl2026.lean;Processing/DiscriminativeLexicon/Defs.lean;Processing/DiscriminativeLexicon/Normed.lean}
+  sources   = {Studies/ChuangEtAl2026.lean;Processing/DiscriminativeLexicon/Defs.lean;Processing/DiscriminativeLexicon/Normed.lean;Processing/DiscriminativeLexicon/Training.lean;Studies/LuChuangBaayen2026.lean}
 }
 
 @article{baayen-2019,
@@ -27684,7 +27684,7 @@
   doi       = {10.1515/cllt-2025-0028},
   subfield  = {phonology},
   role      = {formalized},
-  sources   = {Studies/LuChuangBaayen2026.lean;Processing/DiscriminativeLexicon/Normed.lean}
+  sources   = {Studies/LuChuangBaayen2026.lean;Processing/DiscriminativeLexicon/Normed.lean;Processing/DiscriminativeLexicon/Training.lean}
 }
 
 @unpublished{saito-tomaschek-baayen-2025,


### PR DESCRIPTION
Graduates the centroid-under-training theorem shared by Chuang et al. 2026 (Fig. 18) and Lu et al. 2026 (Fig. 9) into the DLM substrate, on an `[UPSTREAM]` Core file (`Finset.map_centroid_of_nonempty`, `LinearMap.map_centroid`, `Finset.centroid_eq_smul_sum`), and restates the study in the paper's terms.

- fn. 29: `comprehension_not_surjective` gains its round-trip corollary `comprehension_comp_production_ne_id`
- Fig. 18 and the grand centroid (§3.4.2) as `production_centroid_eq_of_decodable` / `production_centroid_univ_eq` over the corpus's word labels
- the Lu study drops its local `centroid` for mathlib's `Finset.centroid`