### PR TITLE
refactor(Studies/Ciardelli2022): InqML modalities and Fig. 8.1

### DIFF
--- a/Linglib/Logic/Team/Inquisitive.lean
+++ b/Linglib/Logic/Team/Inquisitive.lean
@@ -29,27 +29,21 @@ places InqML with dependence logic in the downward-closed, empty-team cell of
 
 ## Main definitions
 
-* `InquisitiveModalModel`, `KripkeModel.toInquisitive`, `Formula`, `support`.
-* `Formula.neg`, `Formula.disj`, `Formula.polarQ`, `Formula.IsClassical`.
-* `truthSet`, `TruthConditional`, `proposition`.
+* `InquisitiveModalModel`: a valuation and a map from worlds to sets of information states, with
+  the induced accessibility `access`; `KripkeModel.toInquisitive` embeds Kripke models.
+* `Formula` and `support`: the language with `□` and `⊞`, and support of a formula by a state.
+* `TruthConditional`: the statements, the formulas whose support is truth at every world.
+* `proposition`: the inquisitive proposition `[φ]_M`, the support set as a `Question`.
 
 ## Main results
 
-* `isLowerSet_support`, `support_empty` — Proposition 3.3.1.
-* `support_singleton_impl`, `support_singleton_neg`, `support_singleton_disj` — Proposition
-  3.1.7.
-* `truthConditional_of_isClassical`, `TruthConditional.conj`, `TruthConditional.impl`,
-  `truthConditional_neg`, `truthConditional_nec`, `truthConditional_ent` — Propositions 3.1.8,
-  3.4.7 and 3.4.8 and their modal cases.
-* `support_neg_neg`, `truthConditional_iff_neg_neg` — Propositions 3.4.9 and 3.4.10.
-* `support_impl_iff_of_truthConditional` — the Ramsey test, Proposition 2.5.2.
-* `mem_proposition`, `proposition_conj`, `proposition_inqDisj`, `proposition_impl`,
-  `proposition_bot`, `info_proposition`, `truthConditional_iff_proposition_eq`,
-  `proposition_neg_neg` — the algebra of propositions, Proposition 3.3.5 and Definition 3.4.1.
-* `support_nec_conj`, `support_nec_impl_nec`, `support_nec_inqDisj`, `support_ent_of_nec`,
-  `support_ent_iff_nec_of_truthConditional`, `support_ent_toInquisitive` — §8.2 and §8.3.
-* `not_supClosed_inqDisj_of_witness`, `soundFor_downwardClosed_inter_empty` — the closure
-  cell.
+* `isLowerSet_support` and `support_empty`: support is persistent and holds at the empty state,
+  so the support set is a proposition on which the connectives are the Heyting operations.
+* `truthConditional_of_isClassical`, `truthConditional_nec` and `truthConditional_ent`: classical
+  and modal formulas are statements, and `truthConditional_iff_neg_neg`: the double negation law
+  holds exactly for statements.
+* `support_nec_inqDisj` and `support_ent_iff_nec_of_truthConditional`: `□` distributes over
+  inquisitive disjunction, and `⊞` agrees with `□` on statements.
 
 ## References
 

--- a/Linglib/Logic/Team/Inquisitive.lean
+++ b/Linglib/Logic/Team/Inquisitive.lean
@@ -1,303 +1,523 @@
 import Linglib.Logic.Team.Kripke
-import Linglib.Logic.Team.Closure
 import Linglib.Logic.Team.Definability
+import Linglib.Semantics.Questions.Basic
 
 /-!
-# Inquisitive Modal Logic (InqML)
+# Inquisitive modal logic
 
-[ciardelli-2022] [ciardelli-2014]
-[ciardelli-groenendijk-roelofsen-2018]
+Inquisitive logic evaluates formulas at information states, sets of possible worlds, by a
+relation of support in place of truth ([ciardelli-2022]). The propositional system InqB
+extends the classical connectives `⊥`, `∧`, `→` with the inquisitive disjunction `\\/`,
+supported by a state that supports either disjunct (Definitions 3.1.3 and 3.2.3); negation and
+classical disjunction are defined (Definition 3.1.2) and `?φ := φ \\/ ¬φ` is the polar question
+(Definition 3.2.2). Inquisitive modal logic adds two modalities over an inquisitive modal
+model, which relates each world `w` to a set `Σ(w)` of states with the induced accessibility
+`σ(w) = ⋃ Σ(w)` (Chapter 8; [ciardelli-2014], [ciardelli-roelofsen-2015]): `□φ` is supported
+when `σ(w)` supports `φ` at every world `w` of the state (§8.2), `⊞φ` when every state in
+`Σ(w)` does (§8.3). Support is persistent and holds at the empty state (Proposition 3.3.1), so
+the support set of a formula is an inquisitive proposition `[φ]_M`, a `Question` (Definition
+2.4.2), on which the connectives act as the operations of the Heyting algebra of propositions
+([ciardelli-groenendijk-roelofsen-2018]). Truth at a world is support at its singleton
+(Proposition 3.1.7), and a formula is truth-conditional, a statement rather than a question,
+when support is truth at every world of the state (Definitions 2.6.3 and 3.4.1): classical
+formulas are (Proposition 3.1.8), `∧` and `→` preserve truth-conditionality (Proposition
+3.4.7), `¬¬φ` is the statement with `φ`'s truth set (Proposition 3.4.9), and every modal
+formula is a statement (§8.2, §8.3), so that the two modalities agree on statements while `□`,
+but not `⊞`, distributes over `\\/`. Inquisitive disjunction breaks union closure, which
+places InqML with dependence logic in the downward-closed, empty-team cell of
+[anttila-2025]'s definability programme.
 
-Inquisitive modal logic extends classical modal logic with a treatment
-of questions alongside statements, following the
-Ciardelli-Groenendijk-Roelofsen tradition. The originating modal paper
-is [ciardelli-2014] (Advances in Modal Logic), with the
-propositional inquisitive system InqB developed in
-[ciardelli-groenendijk-roelofsen-2018] (Oxford University Press)
-and the modal preview in [ciardelli-2022] Chapter 8.
+## Main definitions
 
-Formulas are evaluated at **information states** (teams of worlds),
-with two crucial novelties relative to BSML / MDL / MIL:
+* `InquisitiveModalModel`, `KripkeModel.toInquisitive`, `Formula`, `support`.
+* `Formula.neg`, `Formula.disj`, `Formula.polarQ`, `Formula.IsClassical`.
+* `truthSet`, `TruthConditional`, `proposition`.
 
-* The **inquisitive disjunction** `φ \\/ ψ` (written `inqDisj` here),
-  which is supported by a team `s` iff `s ⊨ φ` *or* `s ⊨ ψ` (global
-  disjunction, not the team-split `∨` of BSML).
-* The **implication** `φ → ψ`, which is supported by `s` iff every
-  subteam `t ⊆ s` satisfies `t ⊨ φ → t ⊨ ψ` (universal subteam
-  quantification).
-* The **Kripke modality** `□φ`, supported by `s` iff every `w ∈ s`
-  has `M, R[w] ⊨ φ` (per-world full image of the accessibility
-  relation, distinct from BSML's per-world *sub-witness* or MDL's
-  single-witness or MIL's lax form).
+## Main results
 
-Reference: [ciardelli-2022] Chapter 8 (modal preview), with the
-propositional InqB base from Chapter 3.
+* `isLowerSet_support`, `support_empty` — Proposition 3.3.1.
+* `support_singleton_impl`, `support_singleton_neg`, `support_singleton_disj` — Proposition
+  3.1.7.
+* `truthConditional_of_isClassical`, `TruthConditional.conj`, `TruthConditional.impl`,
+  `truthConditional_neg`, `truthConditional_nec`, `truthConditional_ent` — Propositions 3.1.8,
+  3.4.7 and 3.4.8 and their modal cases.
+* `support_neg_neg`, `truthConditional_iff_neg_neg` — Propositions 3.4.9 and 3.4.10.
+* `support_impl_iff_of_truthConditional` — the Ramsey test, Proposition 2.5.2.
+* `mem_proposition`, `proposition_conj`, `proposition_inqDisj`, `proposition_impl`,
+  `proposition_bot`, `info_proposition`, `truthConditional_iff_proposition_eq`,
+  `proposition_neg_neg` — the algebra of propositions, Proposition 3.3.5 and Definition 3.4.1.
+* `support_nec_conj`, `support_nec_impl_nec`, `support_nec_inqDisj`, `support_ent_of_nec`,
+  `support_ent_iff_nec_of_truthConditional`, `support_ent_toInquisitive` — §8.2 and §8.3.
+* `not_supClosed_inqDisj_of_witness`, `soundFor_downwardClosed_inter_empty` — the closure
+  cell.
 
-## Closure profile
+## References
 
-| Property            | InqML formula     |
-|---------------------|-------------------|
-| `IsLowerSet`        | ✓ (persistence)   |
-| `SupClosed`         | ✗ broken by `\\/` |
-| `∅ ∈ support`       | ✓                 |
-
-InqML inhabits the same closure cell as MDL (downward-closed + empty,
-sup-closure broken) — but via a different syntactic mechanism: the
-*inquisitive disjunction* `\\/` breaks union closure where MDL's
-*dependence atom* does. This is the second inhabitant of this cell in
-linglib, demonstrating that the architectural pattern "team-semantic
-logic with non-classical disjunction-like connective fails union
-closure" applies regardless of whether the connective is question-
-flavored (InqML) or dependence-flavored (MDL).
-
-## Main declarations
-
-* `Formula` — InqML syntax (Ciardelli §8.2 modal + §3 propositional base).
-* `eval` — single-relation team-semantic evaluation (only support,
-  no anti-support). Negation derived as `φ → ⊥`, matching
-  [ciardelli-2022].
-* `Formula.neg`, `Formula.polarQ` — standard inquisitive abbreviations
-  (`¬φ := φ → ⊥`, `?φ := φ \\/ ¬φ`).
-* `Formula.modalDepth` — depth of nested `□`.
-* `isLowerSet_support` — persistence property (Ciardelli §3 Lemma).
-* `support_empty` — every formula supported on the empty team.
-* `not_supClosed_inqDisj_of_witness` — constructive witness that
-  inquisitive disjunction `\\/` breaks union closure.
-
-## Implementation notes
-
-The standard inquisitive connective set is `{⊥, ∧, →, \\/}` with
-`¬φ := φ → ⊥`, `!φ := ¬¬φ` (non-inquisitive projection), and `?φ := φ \\/ ¬φ`
-(polar question) as standard abbreviations. We include `\\/` and `→`
-as primitives; `¬`, `!`, `?` can be added as helpers later when a
-consumer needs them.
-
-The modal extension adds only `□` per [ciardelli-2022] §8.2.
-Section 8.3 introduces a second modality `⊞` (properly inquisitive,
-using a relation `R : W × ℘(W)` instead of `R : W × W`) — deferred to
-a follow-up file/PR because it requires a different model carrier
-than `KripkeModel`.
-
-The KripkeModel carrier from `Logic/Team/Kripke.lean` is reused.
-Per-world `□` semantics naturally fits the `R : W → Finset W` shape.
-
-## Sibling logics in `Logic/Modal/`
-
-* `Modal/Kripke.lean` — the carrier type.
-* `Modal/Dependence.lean` — MDL (Väänänen 2008), bilateral, dep atoms.
-* `Modal/Inclusion.lean` — MIL (AHY 2024), unilateral, inclusion atoms.
-* `Modal/Inquisitive.lean` (this file) — InqML, unilateral, inquisitive
-  disjunction.
-
-## Todo
-
-* `⊞` modality (Ciardelli §8.3) — needs a `InquisitiveModalModel` with
-  `R : W → Finset (Finset W)`. Add when a downstream consumer needs it.
-* Declarative `!φ := ¬¬φ` and polar question `?φ := φ \\/ ¬φ`
-  abbreviations + their closure-property lemmas.
-* First-order inquisitive modal logic (InqBQ + modality) — Ciardelli
-  §8 mentions but full development in subsequent literature.
-* Bisim invariance — Ciardelli & Otto (2020) "Inquisitive bisimulation".
+* [I. Ciardelli, *Inquisitive Logic: Consequence and Inference in the Realm of Questions*
+  (2022)][ciardelli-2022]
+* [I. Ciardelli, *Modalities in the realm of questions: Axiomatizing inquisitive epistemic
+  logic* (2014)][ciardelli-2014]
+* [I. Ciardelli and F. Roelofsen, *Inquisitive dynamic epistemic logic*
+  (2015)][ciardelli-roelofsen-2015]
+* [I. Ciardelli, J. Groenendijk and F. Roelofsen, *Inquisitive Semantics*
+  (2018)][ciardelli-groenendijk-roelofsen-2018]
+* [A. Anttila, *Expressive completeness in team semantics* (2025)][anttila-2025]
 -/
 
 namespace ModalLogic.Inquisitive
 
-variable {W : Type*} {Atom : Type*}
+variable {W Atom : Type*}
 
-open ModalLogic (KripkeModel)
+/-! ### Models (§8.3) -/
 
-/-! ### Syntax (Ciardelli §3 + §8) -/
+/-- An **inquisitive modal model**: a valuation and, at each world `w`, the set `Σ(w)` of
+information states related to it — under the epistemic reading, the states in which the
+agent's issues are settled. -/
+structure InquisitiveModalModel (W Atom : Type*) where
+  /-- `Σ(w)`, the states related to `w`. -/
+  inq : W → Finset (Finset W)
+  /-- The valuation. -/
+  val : Atom → W → Bool
 
-/-- InqML syntax: classical propositional base (atoms, `⊥`, `∧`, `→`)
-    extended with inquisitive disjunction `\\/` and Kripke modality `□`. -/
+namespace InquisitiveModalModel
+
+variable [DecidableEq W] (M : InquisitiveModalModel W Atom)
+
+/-- The induced accessibility `σ(w) = ⋃ Σ(w)`, the agent's epistemic state at `w`. -/
+def access (w : W) : Finset W := (M.inq w).sup id
+
+@[simp] theorem mem_access {w v : W} : v ∈ M.access w ↔ ∃ t ∈ M.inq w, v ∈ t := by
+  simp [access]
+
+theorem subset_access {w : W} {t : Finset W} (ht : t ∈ M.inq w) : t ⊆ M.access w :=
+  Finset.le_sup (f := id) ht
+
+end InquisitiveModalModel
+
+/-- A Kripke model as the inquisitive modal model relating each world to its single successor
+state `R[w]` (§8.2). -/
+def _root_.ModalLogic.KripkeModel.toInquisitive (M : KripkeModel W Atom) :
+    InquisitiveModalModel W Atom :=
+  ⟨fun w => {M.access w}, M.val⟩
+
+@[simp] theorem _root_.ModalLogic.KripkeModel.access_toInquisitive [DecidableEq W]
+    (M : KripkeModel W Atom) (w : W) : M.toInquisitive.access w = M.access w :=
+  Finset.sup_singleton
+
+/-! ### Syntax (Definition 3.2.1; §8.2, §8.3) -/
+
+/-- Formulas of InqML: the classical base `⊥`, `∧`, `→` over atoms, inquisitive disjunction
+`\\/` and the two modalities. -/
 inductive Formula (Atom : Type*) where
-  /-- Atomic proposition. -/
   | atom (p : Atom)
-  /-- Weak contradiction `⊥`. -/
   | bot
-  /-- Conjunction. -/
   | conj (φ ψ : Formula Atom)
-  /-- Implication. -/
   | impl (φ ψ : Formula Atom)
   /-- Inquisitive disjunction `φ \\/ ψ`. -/
   | inqDisj (φ ψ : Formula Atom)
-  /-- Kripke modality `□φ`. -/
+  /-- The Kripke modality `□φ` (§8.2). -/
   | nec (φ : Formula Atom)
-  deriving Repr
+  /-- The properly inquisitive modality `⊞φ` (§8.3), the entertain modality of
+  [ciardelli-roelofsen-2015]. -/
+  | ent (φ : Formula Atom)
+  deriving Repr, DecidableEq
 
-/-! ### Semantics (Ciardelli §3.1 + §8.2) -/
+namespace Formula
 
-/-- Inquisitive team-semantic evaluation. Single-relation semantics
-    (only support, no anti-support); negation is derived as
-    `impl φ bot`. -/
-def eval (M : KripkeModel W Atom) : Formula Atom → Finset W → Prop
-  | .atom p,        s => ∀ w ∈ s, M.val p w = true
-  | .bot,           s => s = ∅
-  | .conj φ ψ,      s => eval M φ s ∧ eval M ψ s
-  | .impl φ ψ,      s => ∀ t : Finset W, t ⊆ s → eval M φ t → eval M ψ t
-  | .inqDisj φ ψ,   s => eval M φ s ∨ eval M ψ s
-  | .nec φ,        s => ∀ w ∈ s, eval M φ (M.access w)
+variable (φ ψ : Formula Atom)
 
-/-- Support: alias for `eval`. InqML has a single support relation
-    (no anti-support). -/
-abbrev support (M : KripkeModel W Atom) (φ : Formula Atom) (s : Finset W) : Prop :=
-  eval M φ s
+/-- `¬φ := φ → ⊥` (Definition 3.1.2). -/
+abbrev neg : Formula Atom := impl φ bot
 
-@[simp] lemma support_atom (M : KripkeModel W Atom) (p : Atom) (s : Finset W) :
+/-- Classical disjunction `φ ∨ ψ := ¬(¬φ ∧ ¬ψ)` (Definition 3.1.2). -/
+abbrev disj : Formula Atom := (conj φ.neg ψ.neg).neg
+
+/-- The polar question `?φ := φ \\/ ¬φ` (Definition 3.2.2). -/
+abbrev polarQ : Formula Atom := inqDisj φ φ.neg
+
+/-- The classical formulas, those without inquisitive disjunction (§3.1, §8.2). -/
+def IsClassical : Formula Atom → Prop
+  | atom _ => True
+  | bot => True
+  | conj φ ψ => φ.IsClassical ∧ ψ.IsClassical
+  | impl φ ψ => φ.IsClassical ∧ ψ.IsClassical
+  | inqDisj _ _ => False
+  | nec φ => φ.IsClassical
+  | ent φ => φ.IsClassical
+
+end Formula
+
+private theorem isLowerSet_image_coe [Fintype W] {S : Set (Finset W)} (hS : IsLowerSet S) :
+    IsLowerSet ((fun t : Finset W => (↑t : Set W)) '' S) := by
+  rintro a b hba ⟨t, ht, rfl⟩
+  exact ⟨(Set.toFinite b).toFinset,
+    hS (fun w hw => hba ((Set.Finite.mem_toFinset _).1 hw)) ht, by simp⟩
+
+/-! ### Support (Definitions 3.1.3 and 3.2.3; §8.2, §8.3) -/
+
+variable [DecidableEq W]
+
+/-- `support M φ s`: the information state `s` settles `φ` in `M`. -/
+def support (M : InquisitiveModalModel W Atom) : Formula Atom → Finset W → Prop
+  | .atom p, s => ∀ w ∈ s, M.val p w = true
+  | .bot, s => s = ∅
+  | .conj φ ψ, s => support M φ s ∧ support M ψ s
+  | .impl φ ψ, s => ∀ t ⊆ s, support M φ t → support M ψ t
+  | .inqDisj φ ψ, s => support M φ s ∨ support M ψ s
+  | .nec φ, s => ∀ w ∈ s, support M φ (M.access w)
+  | .ent φ, s => ∀ w ∈ s, ∀ t ∈ M.inq w, support M φ t
+
+variable (M : InquisitiveModalModel W Atom) (φ ψ : Formula Atom) (s : Finset W) (w : W)
+
+@[simp] theorem support_atom (p : Atom) :
     support M (.atom p) s ↔ ∀ w ∈ s, M.val p w = true := Iff.rfl
 
-@[simp] lemma support_bot (M : KripkeModel W Atom) (s : Finset W) :
-    support M (.bot : Formula Atom) s ↔ s = ∅ := Iff.rfl
+@[simp] theorem support_bot : support M (.bot : Formula Atom) s ↔ s = ∅ := Iff.rfl
 
-@[simp] lemma support_conj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (s : Finset W) :
+@[simp] theorem support_conj :
     support M (.conj φ ψ) s ↔ support M φ s ∧ support M ψ s := Iff.rfl
 
-@[simp] lemma support_impl (M : KripkeModel W Atom) (φ ψ : Formula Atom) (s : Finset W) :
-    support M (.impl φ ψ) s ↔
-      ∀ t : Finset W, t ⊆ s → support M φ t → support M ψ t := Iff.rfl
+@[simp] theorem support_impl :
+    support M (.impl φ ψ) s ↔ ∀ t ⊆ s, support M φ t → support M ψ t := Iff.rfl
 
-@[simp] lemma support_inqDisj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (s : Finset W) :
+@[simp] theorem support_inqDisj :
     support M (.inqDisj φ ψ) s ↔ support M φ s ∨ support M ψ s := Iff.rfl
 
-@[simp] lemma support_nec (M : KripkeModel W Atom) (φ : Formula Atom) (s : Finset W) :
+@[simp] theorem support_nec :
     support M (.nec φ) s ↔ ∀ w ∈ s, support M φ (M.access w) := Iff.rfl
 
-/-! ### Derived connectives -/
+@[simp] theorem support_ent :
+    support M (.ent φ) s ↔ ∀ w ∈ s, ∀ t ∈ M.inq w, support M φ t := Iff.rfl
 
-/-- Negation: `¬φ := φ → ⊥` (Ciardelli §3, Def 3.2.2). -/
-abbrev Formula.neg (φ : Formula Atom) : Formula Atom := .impl φ .bot
+/-- Support is decidable over a finite set of worlds, by structural recursion. -/
+instance decidableSupport [Fintype W] :
+    (φ : Formula Atom) → (s : Finset W) → Decidable (support M φ s)
+  | .atom _, _ => by unfold support; infer_instance
+  | .bot, _ => by unfold support; infer_instance
+  | .conj φ ψ, s => by
+    unfold support; exact @instDecidableAnd _ _ (decidableSupport φ s) (decidableSupport ψ s)
+  | .impl φ ψ, s => by
+    unfold support; have := decidableSupport φ; have := decidableSupport ψ; infer_instance
+  | .inqDisj φ ψ, s => by
+    unfold support; exact @instDecidableOr _ _ (decidableSupport φ s) (decidableSupport ψ s)
+  | .nec φ, s => by unfold support; have := decidableSupport φ; infer_instance
+  | .ent φ, s => by unfold support; have := decidableSupport φ; infer_instance
 
-/-- Polar question: `?φ := φ \\/ ¬φ` (Ciardelli §3, Def 3.2.2). The
-    canonical inquisitive abbreviation for "whether φ". -/
-abbrev Formula.polarQ (φ : Formula Atom) : Formula Atom :=
-  .inqDisj φ φ.neg
+/-! ### Persistence and the empty state (Proposition 3.3.1) -/
 
-/-! ### Modal depth -/
-
-/-- Modal depth of an InqML formula. -/
-def Formula.modalDepth : Formula Atom → ℕ
-  | .atom _ => 0
-  | .bot => 0
-  | .conj φ ψ => max φ.modalDepth ψ.modalDepth
-  | .impl φ ψ => max φ.modalDepth ψ.modalDepth
-  | .inqDisj φ ψ => max φ.modalDepth ψ.modalDepth
-  | .nec φ => φ.modalDepth + 1
-
-/-! ### Persistence (Ciardelli §3 — downward closure) -/
-
-/-- **Persistence**: every InqML formula's support is downward-closed
-    under `⊆`. Ciardelli §3 (propositional case) + §8.2 (modal
-    extension); the key structural property of inquisitive semantics. -/
-theorem isLowerSet_support (M : KripkeModel W Atom) (φ : Formula Atom) :
-    IsLowerSet { s : Finset W | support M φ s } := by
+/-- **Persistence**: the support set of a formula is downward closed. -/
+theorem isLowerSet_support : IsLowerSet {s : Finset W | support M φ s} := by
   induction φ with
-  | atom p =>
-    intro s t hts hs w hw
-    exact hs w (hts hw)
-  | bot =>
-    intro s t hts hs
-    show t = ∅
-    rw [hs] at hts
-    exact Finset.subset_empty.mp hts
-  | conj φ ψ ihφ ihψ =>
-    intro s t hts ⟨hsφ, hsψ⟩
-    exact ⟨ihφ hts hsφ, ihψ hts hsψ⟩
-  | impl φ ψ _ihφ _ihψ =>
-    -- s ⊨ φ → ψ means ∀u ⊆ s, u ⊨ φ → u ⊨ ψ.
-    -- For t ⊆ s, any u ⊆ t is also ⊆ s, so same property.
-    intro s t hts hs u hut huφ
-    exact hs u (hut.trans hts) huφ
-  | inqDisj φ ψ ihφ ihψ =>
-    intro s t hts hs
-    rcases hs with hsφ | hsψ
-    · exact Or.inl (ihφ hts hsφ)
-    · exact Or.inr (ihψ hts hsψ)
-  | nec φ ihφ =>
-    intro s t hts hs w hw
-    exact hs w (hts hw)
+  | atom p => exact fun s t hts hs w hw => hs w (hts hw)
+  | bot => exact fun s t hts hs => Finset.subset_empty.1 (hs ▸ hts)
+  | conj φ ψ ihφ ihψ => exact fun s t hts hs => ⟨ihφ hts hs.1, ihψ hts hs.2⟩
+  | impl φ ψ _ _ => exact fun s t hts hs u hut => hs u (hut.trans hts)
+  | inqDisj φ ψ ihφ ihψ => exact fun s t hts hs => hs.imp (ihφ hts) (ihψ hts)
+  | nec φ _ => exact fun s t hts hs w hw => hs w (hts hw)
+  | ent φ _ => exact fun s t hts hs w hw => hs w (hts hw)
 
-/-! ### Empty-team property (Ciardelli §3) -/
-
-/-- Every InqML formula is supported on the empty team. -/
-theorem support_empty (M : KripkeModel W Atom) (φ : Formula Atom) :
-    support M φ ∅ := by
+/-- **The empty state property**: the inconsistent state supports every formula. -/
+theorem support_empty : support M φ ∅ := by
   induction φ with
-  | atom p => intro w hw; exact absurd hw (Finset.notMem_empty w)
+  | atom p => simp
   | bot => rfl
   | conj φ ψ ihφ ihψ => exact ⟨ihφ, ihψ⟩
-  | impl φ ψ _ihφ ihψ =>
-    -- ∀t ⊆ ∅, t ⊨ φ → t ⊨ ψ. Only t = ∅; conclude from ihψ.
-    intro t hts _hφ
-    have ht : t = ∅ := Finset.subset_empty.mp hts
-    rw [ht]; exact ihψ
-  | inqDisj φ ψ ihφ _ihψ => exact Or.inl ihφ
-  | nec φ _ihφ => intro w hw; exact absurd hw (Finset.notMem_empty w)
+  | impl φ ψ _ ihψ => exact fun t ht _ => by obtain rfl := Finset.subset_empty.1 ht; exact ihψ
+  | inqDisj φ ψ ihφ _ => exact Or.inl ihφ
+  | nec φ _ => simp
+  | ent φ _ => simp
 
-/-! ### Inquisitive disjunction breaks union closure -/
+/-! ### Truth (Proposition 3.1.7) -/
 
-/-- **Inquisitive disjunction breaks union closure**: a constructive
-    counterexample. With two worlds `w₁, w₂` where `p` is true at `w₁`
-    only and `q` is true at `w₂` only, the singletons `{w₁}` and `{w₂}`
-    each support `p \\/ q` (the first supports `p`, the second supports
-    `q`), but `{w₁, w₂}` supports neither. This is the canonical
-    inquisitive UC-failure pattern. -/
-theorem not_supClosed_inqDisj_of_witness [DecidableEq W] {p q : Atom}
-    {w₁ w₂ : W} {M : KripkeModel W Atom}
+theorem support_neg : support M φ.neg s ↔ ∀ t ⊆ s, support M φ t → t = ∅ := Iff.rfl
+
+theorem support_singleton_impl :
+    support M (.impl φ ψ) {w} ↔ (support M φ {w} → support M ψ {w}) := by
+  refine ⟨fun h => h _ subset_rfl, fun h t ht hφ => ?_⟩
+  rcases Finset.subset_singleton_iff.1 ht with rfl | rfl
+  · exact support_empty M ψ
+  · exact h hφ
+
+theorem support_singleton_neg : support M φ.neg {w} ↔ ¬ support M φ {w} := by
+  simp only [Formula.neg, support_singleton_impl, support_bot, Finset.singleton_ne_empty,
+    imp_false]
+
+theorem support_singleton_disj :
+    support M (φ.disj ψ) {w} ↔ support M φ {w} ∨ support M ψ {w} := by
+  simp only [Formula.disj, support_singleton_neg, support_conj, not_and_or, not_not]
+
+/-! ### Truth-conditional formulas (§3.4) -/
+
+/-- The truth set `|φ|_M` (§3.1): the worlds at which `φ` is true, truth being support at the
+singleton state. -/
+def truthSet : Set W := {w | support M φ {w}}
+
+/-- `φ` is **truth-conditional** in `M` (Definitions 2.6.3 and 3.4.1) when a state supports it
+iff it is true at each of its worlds: a statement rather than a question. -/
+def TruthConditional : Prop := ∀ s : Finset W, support M φ s ↔ ∀ w ∈ s, support M φ {w}
+
+theorem truthConditional_atom (p : Atom) : TruthConditional M (.atom p) := fun s => by simp
+
+theorem truthConditional_bot : TruthConditional M (.bot : Formula Atom) := fun s => by
+  simp [Finset.eq_empty_iff_forall_notMem]
+
+theorem truthConditional_nec : TruthConditional M (.nec φ) := fun s => by simp
+
+theorem truthConditional_ent : TruthConditional M (.ent φ) := fun s => by simp
+
+variable {M φ ψ}
+
+theorem TruthConditional.support_iff (h : TruthConditional M φ) :
+    support M φ s ↔ (↑s : Set W) ⊆ truthSet M φ :=
+  h s
+
+theorem TruthConditional.conj (hφ : TruthConditional M φ) (hψ : TruthConditional M ψ) :
+    TruthConditional M (.conj φ ψ) := fun s => by
+  rw [support_conj, hφ s, hψ s]
+  exact ⟨fun h w hw => ⟨h.1 w hw, h.2 w hw⟩,
+    fun h => ⟨fun w hw => (h w hw).1, fun w hw => (h w hw).2⟩⟩
+
+/-- Proposition 3.4.7: an implication with a truth-conditional consequent is truth-conditional,
+whatever its antecedent. -/
+theorem TruthConditional.impl (hψ : TruthConditional M ψ) (φ : Formula Atom) :
+    TruthConditional M (.impl φ ψ) := fun s => by
+  refine ⟨fun h w hw => isLowerSet_support M (.impl φ ψ) (Finset.singleton_subset_iff.2 hw) h,
+    fun h t hts hφ => (hψ t).2 fun w hw => ?_⟩
+  exact (support_singleton_impl M φ ψ w).1 (h w (hts hw))
+    (isLowerSet_support M φ (Finset.singleton_subset_iff.2 hw) hφ)
+
+variable (M φ ψ)
+
+/-- Proposition 3.4.8: every negation is truth-conditional. -/
+theorem truthConditional_neg : TruthConditional M φ.neg := (truthConditional_bot M).impl φ
+
+theorem truthConditional_disj : TruthConditional M (φ.disj ψ) := truthConditional_neg M _
+
+/-- Proposition 3.1.8: classical formulas are truth-conditional. -/
+theorem truthConditional_of_isClassical (h : φ.IsClassical) : TruthConditional M φ := by
+  induction φ with
+  | atom p => exact truthConditional_atom M p
+  | bot => exact truthConditional_bot M
+  | conj φ ψ ihφ ihψ => exact (ihφ h.1).conj (ihψ h.2)
+  | impl φ ψ _ ihψ => exact (ihψ h.2).impl φ
+  | inqDisj φ ψ _ _ => exact h.elim
+  | nec φ _ => exact truthConditional_nec M φ
+  | ent φ _ => exact truthConditional_ent M φ
+
+/-- Proposition 3.4.9: `¬¬φ` is supported exactly where `φ` is true at every world. -/
+theorem support_neg_neg : support M φ.neg.neg s ↔ ∀ w ∈ s, support M φ {w} := by
+  simp only [Formula.neg, support_impl, support_bot]
+  constructor
+  · intro h w hw
+    by_contra hφ
+    refine Finset.singleton_ne_empty w (h {w} (Finset.singleton_subset_iff.2 hw) fun u hu hφu => ?_)
+    rcases Finset.subset_singleton_iff.1 hu with rfl | rfl
+    · rfl
+    · exact absurd hφu hφ
+  · intro h t hts ht
+    by_contra hne
+    obtain ⟨w, hw⟩ := Finset.nonempty_iff_ne_empty.2 hne
+    exact Finset.singleton_ne_empty w (ht {w} (Finset.singleton_subset_iff.2 hw) (h w (hts hw)))
+
+theorem truthSet_neg_neg : truthSet M φ.neg.neg = truthSet M φ :=
+  Set.ext fun w => (support_neg_neg M φ {w}).trans (by simp [truthSet])
+
+/-- Proposition 3.4.10: the double negation law holds exactly for statements. -/
+theorem truthConditional_iff_neg_neg :
+    TruthConditional M φ ↔ ∀ s, (support M φ.neg.neg s ↔ support M φ s) := by
+  simp only [TruthConditional, support_neg_neg]
+  exact forall_congr' fun s => Iff.comm
+
+/-- Proposition 2.5.2, the Ramsey test: for a statement `α`, `α → ψ` is supported at `s` iff
+`ψ` is supported at the `α`-worlds of `s`. -/
+theorem support_impl_iff_of_truthConditional [Fintype W] {α : Formula Atom}
+    (hα : TruthConditional M α) :
+    support M (.impl α ψ) s ↔ support M ψ (s.filter fun w => support M α {w}) :=
+  ⟨fun h => h _ (Finset.filter_subset _ _) ((hα _).2 fun _ hw => (Finset.mem_filter.1 hw).2),
+    fun h t hts hαt => isLowerSet_support M ψ
+      (fun w hw => Finset.mem_filter.2 ⟨hts hw, (hα t).1 hαt w hw⟩) h⟩
+
+/-! ### The proposition expressed (Proposition 3.3.1, §3.5) -/
+
+section Proposition
+
+variable [Fintype W]
+
+/-- The inquisitive proposition `[φ]_M` expressed by `φ`: its support set, a `Question` by
+persistence and the empty state property. -/
+def proposition : Question W :=
+  Question.ofLowerSet ((fun t : Finset W => (↑t : Set W)) '' {t | support M φ t})
+    ⟨∅, support_empty M φ, by simp⟩ (isLowerSet_image_coe (isLowerSet_support M φ))
+
+@[simp] theorem mem_proposition {s : Set W} :
+    s ∈ proposition M φ ↔ ∃ t : Finset W, ↑t = s ∧ support M φ t := by
+  simp only [proposition, Question.mem_ofLowerSet, Set.mem_image, Set.mem_ofPred_eq, and_comm]
+
+@[simp] theorem coe_mem_proposition : (↑s : Set W) ∈ proposition M φ ↔ support M φ s := by
+  simp
+
+/-- Conjunction is the meet of propositions. -/
+theorem proposition_conj : proposition M (.conj φ ψ) = proposition M φ ⊓ proposition M ψ := by
+  ext s
+  simp only [mem_proposition, support_conj, Question.mem_inf]
+  constructor
+  · rintro ⟨t, hts, hφ, hψ⟩
+    exact ⟨⟨t, hts, hφ⟩, ⟨t, hts, hψ⟩⟩
+  · rintro ⟨⟨t, hts, hφ⟩, ⟨u, hus, hψ⟩⟩
+    obtain rfl := Finset.coe_injective (hts.trans hus.symm)
+    exact ⟨t, hts, hφ, hψ⟩
+
+/-- Inquisitive disjunction is the join. -/
+theorem proposition_inqDisj :
+    proposition M (.inqDisj φ ψ) = proposition M φ ⊔ proposition M ψ := by
+  ext s
+  simp only [mem_proposition, support_inqDisj, Question.mem_sup]
+  constructor
+  · rintro ⟨t, hts, hφ | hψ⟩
+    · exact Or.inl ⟨t, hts, hφ⟩
+    · exact Or.inr ⟨t, hts, hψ⟩
+  · rintro (⟨t, hts, hφ⟩ | ⟨t, hts, hψ⟩)
+    · exact ⟨t, hts, Or.inl hφ⟩
+    · exact ⟨t, hts, Or.inr hψ⟩
+
+/-- Implication is the Heyting arrow. -/
+theorem proposition_impl : proposition M (.impl φ ψ) = proposition M φ ⇨ proposition M ψ := by
+  ext s
+  rw [Question.mem_himp]
+  simp only [mem_proposition, support_impl]
+  constructor
+  · rintro ⟨t, rfl, hsupp⟩ r hrs ⟨a, ha, haφ⟩
+    exact ⟨a, ha, hsupp a (Finset.coe_subset.1 (ha.le.trans hrs)) haφ⟩
+  · intro h
+    refine ⟨(Set.toFinite s).toFinset, by simp, fun u hu hφu => ?_⟩
+    have hus : (↑u : Set W) ⊆ s := by
+      rw [← (Set.toFinite s).coe_toFinset]; exact Finset.coe_subset.2 hu
+    obtain ⟨b, hb, hψb⟩ := h ↑u hus ⟨u, rfl, hφu⟩
+    rwa [← Finset.coe_injective hb]
+
+/-- `⊥` is the bottom. -/
+theorem proposition_bot : proposition M (.bot : Formula Atom) = ⊥ := by
+  ext s
+  simp only [mem_proposition, support_bot, Question.mem_bot]
+  constructor
+  · rintro ⟨t, rfl, rfl⟩; simp
+  · rintro rfl; exact ⟨∅, by simp, rfl⟩
+
+/-- Proposition 3.3.5: the truth set is the union of the proposition. -/
+theorem info_proposition : (proposition M φ).info = truthSet M φ := by
+  ext w
+  simp only [Question.info, Set.mem_sUnion]
+  constructor
+  · rintro ⟨_, ⟨t, ht, rfl⟩, hw⟩
+    exact isLowerSet_support M φ (Finset.singleton_subset_iff.2 (Finset.mem_coe.1 hw)) ht
+  · exact fun h => ⟨_, ⟨{w}, h, rfl⟩, by simp⟩
+
+/-- Definition 3.4.1 on propositions: `φ` is a statement iff it expresses the declarative
+proposition of its truth set. -/
+theorem truthConditional_iff_proposition_eq :
+    TruthConditional M φ ↔ proposition M φ = Question.ofSet (truthSet M φ) := by
+  constructor
+  · intro h
+    ext s
+    rw [mem_proposition, Question.mem_ofSet]
+    constructor
+    · rintro ⟨t, rfl, ht⟩
+      exact fun w hw => (h t).1 ht w (Finset.mem_coe.1 hw)
+    · intro hs
+      exact ⟨(Set.toFinite s).toFinset, by simp, (h _).2 fun w hw => hs (by simpa using hw)⟩
+  · intro h s
+    rw [← coe_mem_proposition, h, Question.mem_ofSet]
+    exact Iff.rfl
+
+/-- Proposition 3.4.9 on propositions: `¬¬φ` expresses the non-inquisitive projection of
+`[φ]_M`. -/
+theorem proposition_neg_neg : proposition M φ.neg.neg = (proposition M φ).proj := by
+  rw [Question.proj, info_proposition, ← truthSet_neg_neg,
+    ← (truthConditional_iff_proposition_eq M _).1 (truthConditional_neg M φ.neg)]
+
+end Proposition
+
+/-! ### Modalities (§8.2, §8.3) -/
+
+variable {M φ ψ}
+
+/-- Two statements that agree at every world agree at every state. -/
+theorem TruthConditional.iff_of_singleton (hφ : TruthConditional M φ) (hψ : TruthConditional M ψ)
+    (h : ∀ w, support M φ {w} ↔ support M ψ {w}) : support M φ s ↔ support M ψ s := by
+  rw [hφ s, hψ s]
+  exact forall₂_congr fun w _ => h w
+
+variable (M φ ψ)
+
+/-- `□` commutes with `∧` (§8.2). -/
+theorem support_nec_conj :
+    support M (.nec (.conj φ ψ)) s ↔ support M (.conj (.nec φ) (.nec ψ)) s := by
+  simp [imp_and, forall_and]
+
+/-- The K axiom for `□` (§8.2). -/
+theorem support_nec_impl_nec :
+    support M (.impl (.nec (.impl φ ψ)) (.impl (.nec φ) (.nec ψ))) s :=
+  fun _ _ ht _ hut hu w hw => ht w (hut hw) _ subset_rfl (hu w hw)
+
+/-- Necessitation for `□` (§8.2). -/
+theorem support_nec_of_forall (h : ∀ s, support M φ s) (s : Finset W) : support M (.nec φ) s :=
+  fun _ _ => h _
+
+/-- `□` distributes over inquisitive disjunction (§8.2): `□(φ \\/ ψ) ≡ □φ ∨ □ψ`. -/
+theorem support_nec_inqDisj :
+    support M (.nec (.inqDisj φ ψ)) s ↔ support M ((Formula.nec φ).disj (.nec ψ)) s :=
+  (truthConditional_nec M _).iff_of_singleton s (truthConditional_disj M _ _) fun w => by
+    rw [support_singleton_disj]; simp
+
+/-- `⊞` commutes with `∧` (§8.3). -/
+theorem support_ent_conj :
+    support M (.ent (.conj φ ψ)) s ↔ support M (.conj (.ent φ) (.ent ψ)) s := by
+  simp [imp_and, forall_and]
+
+/-- The K axiom for `⊞` (§8.3). -/
+theorem support_ent_impl_ent :
+    support M (.impl (.ent (.impl φ ψ)) (.impl (.ent φ) (.ent ψ))) s :=
+  fun _ _ ht _ hut hu w hw v hv => ht w (hut hw) v hv _ subset_rfl (hu w hw v hv)
+
+/-- Necessitation for `⊞` (§8.3). -/
+theorem support_ent_of_forall (h : ∀ s, support M φ s) (s : Finset W) : support M (.ent φ) s :=
+  fun _ _ _ _ => h _
+
+/-- `□φ` entails `⊞φ`: each related state lies in the epistemic state, and support is
+persistent (§8.3). -/
+theorem support_ent_of_nec (h : support M (.nec φ) s) : support M (.ent φ) s :=
+  fun w hw _ ht => isLowerSet_support M φ (M.subset_access ht) (h w hw)
+
+/-- On statements the two modalities coincide (§8.3). -/
+theorem support_ent_iff_nec_of_truthConditional (h : TruthConditional M φ) :
+    support M (.ent φ) s ↔ support M (.nec φ) s :=
+  ⟨fun hent w hw => (h _).2 fun v hv => by
+      obtain ⟨t, ht, hvt⟩ := M.mem_access.1 hv
+      exact (h t).1 (hent w hw t ht) v hvt,
+    support_ent_of_nec M φ s⟩
+
+/-- On a Kripke model `⊞` is `□`, the only related state being `R[w]` (§8.2). -/
+theorem support_ent_toInquisitive (M : KripkeModel W Atom) :
+    support M.toInquisitive (.ent φ) s ↔ support M.toInquisitive (.nec φ) s := by
+  simp [KripkeModel.toInquisitive, InquisitiveModalModel.access]
+
+/-! ### The closure cell -/
+
+/-- Inquisitive disjunction breaks union closure: with `p` true only at `w₁` and `q` only at
+`w₂`, the singletons support `p \\/ q` but their union supports neither disjunct. -/
+theorem not_supClosed_inqDisj_of_witness {p q : Atom} {w₁ w₂ : W}
     (hp₁ : M.val p w₁ = true) (hq₁ : M.val q w₁ = false)
     (hp₂ : M.val p w₂ = false) (hq₂ : M.val q w₂ = true) :
-    ¬ SupClosed { s : Finset W | support M (.inqDisj (.atom p) (.atom q)) s } := by
-  intro hSC
-  -- {w₁} supports p \/ q because {w₁} ⊨ p (only world is w₁, p true there)
-  have h₁ : support M (.inqDisj (.atom p) (.atom q)) ({w₁} : Finset W) := by
-    refine Or.inl ?_
-    intro w hw; rw [Finset.mem_singleton] at hw; subst hw; exact hp₁
-  -- {w₂} supports p \/ q because {w₂} ⊨ q
-  have h₂ : support M (.inqDisj (.atom p) (.atom q)) ({w₂} : Finset W) := by
-    refine Or.inr ?_
-    intro w hw; rw [Finset.mem_singleton] at hw; subst hw; exact hq₂
-  -- By SupClosed, {w₁} ∪ {w₂} supports p \/ q
-  have hunion : support M (.inqDisj (.atom p) (.atom q))
-      (({w₁} : Finset W) ∪ {w₂}) :=
-    hSC h₁ h₂
-  -- But {w₁, w₂} supports neither p nor q
-  rcases hunion with hp | hq
-  · -- Suppose support p {w₁, w₂}: needs p true at w₂. But hp₂ says false.
-    have : M.val p w₂ = true := hp w₂ (by
-      rw [Finset.mem_union, Finset.mem_singleton, Finset.mem_singleton]
-      exact Or.inr rfl)
-    rw [hp₂] at this; exact Bool.noConfusion this
-  · -- Suppose support q {w₁, w₂}: needs q true at w₁. But hq₁ says false.
-    have : M.val q w₁ = true := hq w₁ (by
-      rw [Finset.mem_union, Finset.mem_singleton, Finset.mem_singleton]
-      exact Or.inl rfl)
-    rw [hq₁] at this; exact Bool.noConfusion this
-
-/-! ### Soundness for the closure cell (Definability bridge) -/
+    ¬ SupClosed {s : Finset W | support M (.inqDisj (.atom p) (.atom q)) s} := fun h => by
+  have := h (a := {w₁}) (b := {w₂}) (by simp [hp₁]) (by simp [hq₂])
+  simp [hp₂, hq₁] at this
 
 open Team in
-/-- **InqML is sound for its closure cell**: every InqML-definable team property
-    is downward-closed (persistent) and has the empty-team property. InqML shares
-    the downward-closed, empty-team cell with dependence logic ([ciardelli-2022];
-    [anttila-2025]) — but breaks union closure via inquisitive disjunction
-    `\\/` (see `not_supClosed_inqDisj_of_witness`) rather than via a dependence
-    atom.
-
-    Composes `isLowerSet_support` (persistence) and `support_empty` through the
-    `Team/Definability.lean` bridge. The converse (every such property is
-    InqML-definable) is the open half. -/
-theorem soundFor_downwardClosed_inter_empty (M : KripkeModel W Atom) :
-    SoundFor (support M) (downwardClosedProperties ∩ emptyTeamProperties) := by
-  unfold SoundFor
-  apply Set.subset_inter
-  · intro P hP
-    simp only [mem_definableClass] at hP
-    obtain ⟨φ, rfl⟩ := hP
-    show IsLowerSet (definedBy (support M) φ)
-    exact isLowerSet_support M φ
-  · intro P hP
-    simp only [mem_definableClass] at hP
-    obtain ⟨φ, rfl⟩ := hP
-    show ∅ ∈ definedBy (support M) φ
-    exact support_empty M φ
+/-- InqML is sound for the downward-closed, empty-team cell of [anttila-2025]'s programme,
+which it shares with dependence logic. -/
+theorem soundFor_downwardClosed_inter_empty :
+    SoundFor (support M) (downwardClosedProperties ∩ emptyTeamProperties) :=
+  Set.subset_inter (definableClass_subset (isLowerSet_support M))
+    (definableClass_subset (support_empty M))
 
 end ModalLogic.Inquisitive

--- a/Linglib/Studies/Ciardelli2022.lean
+++ b/Linglib/Studies/Ciardelli2022.lean
@@ -1,122 +1,113 @@
-import Linglib.Semantics.Questions.Basic
 import Linglib.Logic.Team.Inquisitive
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Ciardelli 2022 — InqML denotation into `Question`
+# Ciardelli 2022: Inquisitive Logic — questions under modalities
 
-[ciardelli-2022] [ciardelli-groenendijk-roelofsen-2018]
+[ciardelli-2022] builds inquisitive logic on support at information states: questions join
+statements in one language through the inquisitive disjunction `\\/`, entailment among
+questions is dependency, and the proposition a formula expresses is a downward-closed set of
+states (Chapters 2–3). Chapter 8 previews the modal extension. The Kripke modality `□` applied
+to a question is a statement whose truth at `w` is the support of the question by the successor
+state `R[w]`, so that under the epistemic reading `□?p` says the agent knows whether `p`, and
+knowing whether `p` amounts to knowing that `p` or knowing that `¬p`: `□?p ≡ □p ∨ □¬p`, an
+instance of the pseudo-commutation `□(φ \\/ ψ) ≡ □φ ∨ □ψ` (§8.2). The properly inquisitive
+modality `⊞`, interpreted over a relation from worlds to states `Σ(w)`, is supported when every
+state in `Σ(w)` supports its argument; on statements it collapses onto `□`, but on questions it
+expresses issue-directed attitudes: `¬□μ ∧ ⊞μ`, [ciardelli-roelofsen-2015]'s wondering about
+`μ`, holds when the agent's information does not settle `μ` while every state settling the
+agent's issues does. Fig. 8.1 exhibits three inquisitive states of an agent over the four
+worlds for `p` and `q`: in (a) the agent knows that `p` and has no open issue, in (b) knows
+nothing and is interested in whether `p`, in (c) knows nothing and is interested in whether
+`q`; the agent knows whether `p` in (a), wonders whether `p` in (b), and neither in (c). The
+same state (b) shows that `⊞` does not pseudo-commute: `⊞?p` holds there while `⊞p ∨ ⊞¬p`
+fails (§8.3).
 
-Formulas of inquisitive modal logic ([ciardelli-2022] Ch. 8) denote
-inquisitive contents. `Question.ofInqML M φ` packages the supporting
-teams of `φ` — viewed as information states via the canonical
-`Finset W → Set W` coercion — into a `Question W`; the downward-closure
-and empty-state obligations discharge directly from InqML's persistence
-(`isLowerSet_support`) and empty-team (`support_empty`) lemmas.
+The substrate `Logic/Team/Inquisitive.lean` carries the logic — support, persistence,
+truth-conditionality, the proposition expressed and the modal validities. This file states
+the chapter's illustrations at it: `nec_polarQ` is the knowing-whether equation, `fig81a`,
+`fig81b` and `fig81c` are the three models of Fig. 8.1 with `wonders` the formula of wondering,
+and the three classifications and the failure of pseudo-commutation for `⊞` are decided on
+them.
 
-The denotation is a lattice/Heyting homomorphism: it carries InqML's
-`conj`/`inqDisj`/`impl`/`bot` to the `Question` algebra's
-`⊓`/`⊔`/`⇨`/`⊥` (`ofInqML_conj` … `ofInqML_bot`), through the injective
-`Finset → Set` coercion and the pointwise `mem_himp` characterization of
-the Heyting arrow.
+## References
 
-## Main declarations
-
-* `Question.ofInqML` — the InqML denotation map.
-* `Question.mem_ofInqML` — its membership characterization.
-* `Question.ofInqML_conj` / `_inqDisj` / `_impl` / `_bot` — the
-  lattice/Heyting homomorphism laws.
+* [I. Ciardelli, *Inquisitive Logic: Consequence and Inference in the Realm of Questions*
+  (2022)][ciardelli-2022]
+* [I. Ciardelli and F. Roelofsen, *Inquisitive dynamic epistemic logic*
+  (2015)][ciardelli-roelofsen-2015]
 -/
 
-namespace Question
+namespace Ciardelli2022
 
-open ModalLogic (KripkeModel)
 open ModalLogic.Inquisitive
 
-variable {W : Type*} [Fintype W] {Atom : Type*}
+/-! ### Knowing whether (§8.2) -/
 
-/-- The image of a lower family of teams under the `Finset W → Set W`
-    coercion is again lower (`Fintype W`: every state is the coercion of
-    its `toFinset`). The reusable bridge any downward-closed team logic
-    needs to denote its support into `Question`. -/
-private theorem isLowerSet_image_coe {s : Set (Finset W)} (hs : IsLowerSet s) :
-    IsLowerSet ((fun t : Finset W => (↑t : Set W)) '' s) := by
-  rintro a b hba ⟨t, ht, rfl⟩
-  exact ⟨(Set.toFinite b).toFinset,
-    hs (fun w hw => hba ((Set.Finite.mem_toFinset _).mp hw)) ht, by simp⟩
+variable {W A : Type*} [DecidableEq W] (M : InquisitiveModalModel W A) (φ : Formula A)
+  (s : Finset W)
 
-/-- The inquisitive content denoted by an InqML formula at a Kripke
-    model. A state `s : Set W` lies in the denotation iff some supporting
-    team `t : Finset W` coerces to `s`.
+/-- (3b): knowing whether `φ` is knowing that `φ` or knowing that `¬φ`, the polar instance of
+`support_nec_inqDisj`. -/
+theorem nec_polarQ :
+    support M (.nec φ.polarQ) s ↔ support M ((Formula.nec φ).disj (.nec φ.neg)) s :=
+  support_nec_inqDisj M φ φ.neg s
 
-    Built via `Question.ofLowerSet`: the two `Question` obligations are
-    exactly InqML's empty-team property (`support_empty`) and persistence
-    (`isLowerSet_support`), bridged across the `Finset → Set` coercion. -/
-def ofInqML (M : KripkeModel W Atom) (φ : Formula Atom) : Question W :=
-  ofLowerSet ((fun t : Finset W => (↑t : Set W)) '' { t : Finset W | support M φ t })
-    ⟨∅, support_empty M φ, by simp⟩ (isLowerSet_image_coe (isLowerSet_support M φ))
+/-- `¬□μ ∧ ⊞μ`: the agent wonders about `μ` ([ciardelli-roelofsen-2015]; §8.3). -/
+abbrev wonders (μ : Formula A) : Formula A := (Formula.nec μ).neg.conj (.ent μ)
 
-/-- Membership in the InqML denotation: a state `s : Set W` lies in the
-    `Question` iff some supporting team `t : Finset W` coerces to `s`. -/
-@[simp] theorem mem_ofInqML (M : KripkeModel W Atom) (φ : Formula Atom) (s : Set W) :
-    s ∈ ofInqML M φ ↔ ∃ t : Finset W, ↑t = s ∧ support M φ t := by
-  simp only [ofInqML, mem_ofLowerSet, Set.mem_image, Set.mem_ofPred_eq, and_comm]
+/-! ### Fig. 8.1: knowing, wondering and neither (§8.3) -/
 
-/-- `ofInqML` carries InqML conjunction to the lattice meet `⊓`.
-    `support (.conj φ ψ)` is the pointwise `And`, so the supporting-team
-    set is an intersection, and the injective `Finset → Set` coercion
-    preserves it. -/
-theorem ofInqML_conj (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
-    ofInqML M (.conj φ ψ) = ofInqML M φ ⊓ ofInqML M ψ := by
-  ext s
-  simp only [mem_ofInqML, support_conj, mem_inf]
-  constructor
-  · rintro ⟨t, hts, hφ, hψ⟩
-    exact ⟨⟨t, hts, hφ⟩, ⟨t, hts, hψ⟩⟩
-  · rintro ⟨⟨t, hts, hφ⟩, ⟨u, hus, hψ⟩⟩
-    have htu : t = u := Finset.coe_injective (hts.trans hus.symm)
-    subst htu
-    exact ⟨t, hts, hφ, hψ⟩
+/-- The four worlds `w_pq`, `w_p¬q`, `w_¬pq`, `w_¬p¬q` of Fig. 8.1. -/
+inductive World
+  | pq | pnq | npq | npnq
+  deriving DecidableEq, Fintype
 
-/-- `ofInqML` carries InqML disjunction to the lattice join `⊔`.
-    `support (.inqDisj φ ψ)` is the pointwise `Or`, and `Set.image`
-    distributes over union unconditionally. -/
-theorem ofInqML_inqDisj (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
-    ofInqML M (.inqDisj φ ψ) = ofInqML M φ ⊔ ofInqML M ψ := by
-  ext s
-  simp only [mem_ofInqML, support_inqDisj, mem_sup]
-  constructor
-  · rintro ⟨t, hts, hφ | hψ⟩
-    · exact Or.inl ⟨t, hts, hφ⟩
-    · exact Or.inr ⟨t, hts, hψ⟩
-  · rintro (⟨t, hts, hφ⟩ | ⟨t, hts, hψ⟩)
-    · exact ⟨t, hts, Or.inl hφ⟩
-    · exact ⟨t, hts, Or.inr hψ⟩
+inductive Atom
+  | p | q
+  deriving DecidableEq
 
-/-- `ofInqML` carries InqML implication to the Heyting arrow `⇨`.
-    `support (.impl φ ψ) t` is `∀ u ⊆ t, support φ u → support ψ u`. -/
-theorem ofInqML_impl (M : KripkeModel W Atom) (φ ψ : Formula Atom) :
-    ofInqML M (.impl φ ψ) = ofInqML M φ ⇨ ofInqML M ψ := by
-  ext s
-  rw [mem_himp]
-  simp only [mem_ofInqML, support_impl]
-  constructor
-  · rintro ⟨t, rfl, hsupp⟩ r hrs ⟨a, ha, haφ⟩
-    exact ⟨a, ha, hsupp a (Finset.coe_subset.mp (ha.le.trans hrs)) haφ⟩
-  · intro h
-    refine ⟨(Set.toFinite s).toFinset, by simp, fun u hu hφu => ?_⟩
-    have hus : (↑u : Set W) ⊆ s := by
-      rw [← (Set.toFinite s).coe_toFinset]; exact Finset.coe_subset.mpr hu
-    obtain ⟨b, hb, hψb⟩ := h ↑u hus ⟨u, rfl, hφu⟩
-    rwa [← Finset.coe_injective hb]
+/-- The valuation of Fig. 8.1. -/
+def val : Atom → World → Bool
+  | .p, .pq | .p, .pnq | .q, .pq | .q, .npq => true
+  | _, _ => false
 
-/-- `ofInqML` carries InqML `⊥` to the lattice bottom `⊥`.
-    `support .bot t` holds iff `t = ∅`, so the denotation is `{∅}`. -/
-theorem ofInqML_bot (M : KripkeModel W Atom) :
-    ofInqML M (Atom := Atom) .bot = ⊥ := by
-  ext s
-  simp only [mem_ofInqML, support_bot, mem_bot]
-  constructor
-  · rintro ⟨t, rfl, rfl⟩; simp
-  · rintro rfl; exact ⟨∅, by simp, rfl⟩
+/-- `p` as a formula. -/
+abbrev p : Formula Atom := .atom .p
 
-end Question
+/-- Fig. 8.1a: `Σ(w) = {{w_pq, w_p¬q}}↓`, the agent knows that `p` and has no open issue. -/
+def fig81a : InquisitiveModalModel World Atom :=
+  ⟨fun _ => ({.pq, .pnq} : Finset World).powerset, val⟩
+
+/-- Fig. 8.1b: `Σ(w) = {{w_pq, w_p¬q}, {w_¬pq, w_¬p¬q}}↓`, the agent knows nothing and is
+interested in whether `p`. -/
+def fig81b : InquisitiveModalModel World Atom :=
+  ⟨fun _ => ({.pq, .pnq} : Finset World).powerset ∪ ({.npq, .npnq} : Finset World).powerset,
+    val⟩
+
+/-- Fig. 8.1c: `Σ(w) = {{w_pq, w_¬pq}, {w_p¬q, w_¬p¬q}}↓`, the agent knows nothing and is
+interested in whether `q`. -/
+def fig81c : InquisitiveModalModel World Atom :=
+  ⟨fun _ => ({.pq, .npq} : Finset World).powerset ∪ ({.pnq, .npnq} : Finset World).powerset,
+    val⟩
+
+/-- In (a) the agent knows that `p`, hence knows whether `p`. -/
+theorem fig81a_knows : ∀ w, support fig81a (.nec p) {w} ∧ support fig81a (.nec p.polarQ) {w} := by
+  decide
+
+/-- In (b) the agent wonders whether `p`. -/
+theorem fig81b_wonders : ∀ w, support fig81b (wonders p.polarQ) {w} := by decide
+
+/-- In (c) the agent neither knows whether `p` nor wonders about it. -/
+theorem fig81c_neither :
+    ∀ w, support fig81c ((Formula.nec p.polarQ).neg.conj (Formula.ent p.polarQ).neg) {w} := by
+  decide
+
+/-- `⊞` does not pseudo-commute: in (b) the agent entertains whether `p` without entertaining
+`p` or entertaining `¬p`. -/
+theorem fig81b_ent_polarQ_not_disj :
+    ∀ w, support fig81b (.ent p.polarQ) {w} ∧
+      ¬ support fig81b ((Formula.ent p).disj (.ent p.neg)) {w} := by
+  decide
+
+end Ciardelli2022

--- a/references.bib
+++ b/references.bib
@@ -29049,7 +29049,22 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {referenced}
+  sources   = {Logic/Team/Inquisitive.lean}
 }
+@article{ciardelli-roelofsen-2015,
+  author    = {Ciardelli, Ivano and Roelofsen, Floris},
+  year      = {2015},
+  title     = {Inquisitive dynamic epistemic logic},
+  journal   = {Synthese},
+  volume    = {192},
+  number    = {6},
+  pages     = {1643--1687},
+  doi       = {10.1007/s11229-014-0404-7},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Logic/Team/Inquisitive.lean;Studies/Ciardelli2022.lean}
+}
+
 @book{ciardelli-2022,
   author    = {Ciardelli, Ivano},
   year      = {2022},
@@ -29063,6 +29078,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized}
+  sources   = {Logic/Team/Inquisitive.lean;Studies/Ciardelli2022.lean}
 }
 @article{anttila-haggblom-yang-2024,
   author    = {Anttila, Aleksi and H{\"a}ggblom, Matilda and Yang, Fan},


### PR DESCRIPTION
Rebuilds the InqML substrate on the book's inquisitive modal models (§8.3): `⊞` alongside `□`, decidable support, truth-conditionality (§3.4) with the Ramsey test, the proposition expressed as a `Question` with its Heyting laws (Propositions 3.3.1 and 3.3.5), and the §8.2–8.3 modal facts (K, necessitation, `□` pseudo-commutation, `⊞` = `□` on statements). The study states Chapter 8's illustrations: knowing whether as knowing that or knowing that not, and Fig. 8.1's three models decided (knows, wonders, neither; `⊞` fails pseudo-commutation).

- bib: `ciardelli-roelofsen-2015` from the book's reference list