### PR TITLE
docs(Studies): Ciardelli studies in the mathlib register

### DIFF
--- a/Linglib/Studies/CiardelliGroenendijkRoelofsen2018.lean
+++ b/Linglib/Studies/CiardelliGroenendijkRoelofsen2018.lean
@@ -1,103 +1,32 @@
 import Linglib.Semantics.Questions.Basic
-import Linglib.Semantics.Questions.Hamblin
-import Linglib.Semantics.Questions.Resolution
 
 /-!
-# Ciardelli, Groenendijk & Roelofsen 2018: Inquisitive Semantics
+# Ciardelli, Groenendijk and Roelofsen 2018: Inquisitive Semantics
 
-The substrate of `Semantics/Questions/` is the formalisation of
-[ciardelli-groenendijk-roelofsen-2018] (*Inquisitive Semantics*, Oxford Surveys
-in Semantics and Pragmatics 6): every Chapter 2–3 definition has a direct
-substrate counterpart. This file records the correspondence — the table below
-maps each definition and fact to its substrate identifier — and proves the one
-chapter-2 fact stated over two contents at once, `update_nonInquisitive`
-(Fact 2.36, the book's "update without inquisitiveness yields standard
-results").
+An information state is a set of possible worlds, an issue over it a non-empty downward-closed
+set of its enhancements, and a proposition an issue over some state (Chapter 2): the states in it
+settle it, it is true at a world when the singleton settles it, informative when its union, the
+informative content, excludes a world, and inquisitive when that union does not itself settle
+it, so that its alternatives, the maximal states in it, are several (Facts 2.14–2.19).
+Entailment is inclusion, with the tautology and the contradiction as its extremes, and a context
+is updated with a proposition by intersection, which reduces to standard update on
+non-inquisitive inputs (Fact 2.36). Propositions form a Heyting algebra under meet, join and
+relative pseudo-complement, and each is the meet of its non-inquisitive projection `!P` and its
+non-informative projection `?P` (Chapter 3, Facts 3.1–3.15); polar, alternative, open
+disjunctive and wh-questions, and their conjunctions, disjunctions and conditionalizations, are
+these operations applied to declarative contents (Chapter 5).
 
-## Substrate identification table
-
-### Chapter 2 — Basic notions
-
-| [ciardelli-groenendijk-roelofsen-2018]    | substrate                        |
-|-----|-----|
-| Def 2.1 Information state `s ⊆ W`              | `Set W` (mathlib)                |
-| Def 2.2 Enhancement `t ⊆ s`                    | set inclusion                    |
-| Def 2.3 Issue (non-empty downward-closed set of states) | `Question W`        |
-| Def 2.4 Resolution `s ∈ I`                     | `s ∈ I.props` ≡ `Support.supports s I` |
-| Def 2.5 Issues over a state `⋃I = s`           | `info I = s`                     |
-| Def 2.6 Refinement `I ⊆ J`                     | `(I : Question W) ≤ J`           |
-| Def 2.7 Alternatives in an issue (max elts)    | `Question.alt`              |
-| Fact 2.8 Multi-alts iff proper (finite case)   | `isInquisitive_of_two_alternatives` (one direction; full equivalence under `Q.props.Finite`) |
-| Def 2.9 Proposition (non-empty downward-closed)| `Question W` (same as Issue) |
-| Def 2.10 Informative content `info(P) := ⋃P`   | `Question.info`             |
-| Def 2.11 Issue embodied by P                   | `P` itself                       |
-| Def 2.12 Truth `w ∈ info(P)`                   | `w ∈ info P`                     |
-| Def 2.13 Support `s ∈ P`                       | `Support.supports s P`           |
-| Fact 2.14 Truth = singleton support            | `mem_info_iff_singleton_mem`     |
-| Def 2.15 Informative / Inquisitive             | `isInformative` / `isInquisitive` |
-| Def 2.16 Alternatives in a proposition         | `Question.alt`              |
-| Fact 2.17 Inquisitive iff multi-alts (finite)  | (specialisation of Fact 2.8)     |
-| Fact 2.18 (i) Non-inquisitive ↔ `info(P) ∈ P`  | `info_mem_iff_not_isInquisitive` |
-| Fact 2.18 (ii) Non-informative ↔ `info(P) = W` | `not_not` on `isInformative`'s definition |
-| Fact 2.18 (iii) Tautology ↔ `W ∈ P`            | `eq_top_iff_univ_mem`            |
-| Fact 2.19 Non-inquisitive characterizations    | (1↔2) `info_mem_iff_eq_ofSet_info`; (4) `mem_iff_subset_info` |
-| Def 2.20–2.22 Entailment `P ⊨ Q ↔ P ⊆ Q`       | substrate's `≤` (`le_def`)       |
-| Fact 2.23 Entailment as support preservation   | by `le_def`                      |
-| Def 2.24 Tautology `⊤ := ℘(W)`, contradiction `⊥ := {∅}` | `top` / `bot`           |
-| Fact 2.25 Partial order on propositions        | `inferInstance : CompleteLattice` |
-| Def 2.26 Context (= proposition)               | `Question W`                |
-| Def 2.27 `info(C) := ⋃C`                       | `Question.info`             |
-| Def 2.28-2.32 Informed/inquisitive contexts    | `isInformative` / `isInquisitive` |
-| Def 2.30 Initial / absurd contexts             | `⊤` / `⊥`                       |
-| Def 2.35 Update `C[P] := C ∩ P`                | `C ⊓ P` (substrate's `inf`, `rfl` on `props`) |
-| Fact 2.36 Update reduces to standard on non-inquisitive | `update_nonInquisitive` (this file) |
-
-### Chapter 3 — Basic operations
-
-| [ciardelli-groenendijk-roelofsen-2018]    | substrate                        |
-|-----|-----|
-| Fact 3.1 Meet `⋂Σ = {s \| s ∈ P ∀ P ∈ Σ}`      | `sInf` / `mem_sInf`              |
-| Fact 3.2 Join `⋃Σ = {s \| s ∈ P ∃ P ∈ Σ}`      | `sSup` / `mem_sSup`              |
-| Fact 3.3 Relative pseudo-complement `P ⇒ Q`    | substrate's Heyting `⇨` (`mem_himp`) |
-| Fact 3.4 Absolute pseudo-complement `P*`       | substrate's `Pᶜ`                 |
-| Fact 3.5 `P* = ℘(¬info(P))`                    | `compl_eq`                       |
-| Def 3.8-3.9 Decision set `D(P) := P ∪ P*`      | derived from `inqDisj P Pᶜ`      |
-| Def 3.13 Projection `!P := ℘(info(P))`         | `proj` (`rfl`)                   |
-| Def 3.13 Projection `?P := P ∪ P*`             | `nonInfo` (`nonInfo_eq_sup_compl`) |
-| Fact 3.14 Division `P = !P ⊓ ?P`               | `proj_inf_nonInfo`               |
-| Fact 3.15 `!P = P**`                           | `proj_eq_compl_compl`            |
-
-### Chapter 5 — Questions
-
-| [ciardelli-groenendijk-roelofsen-2018]    | substrate                        |
-|-----|-----|
-| §5.1 Polar `?Mab := Mab ∨ ¬Mab`                | `Question.polar` (`polar_eq_sup`) |
-| §5.2 Alternative `Mab ∨ Mac`                   | `declarative Mab ⊔ declarative Mac` |
-| §5.3 Open disjunctive `?(Mab ∨ Mac)`           | `nonInfo (ofSet Mab ⊔ declarative Mac)` |
-| §5.4.1 Mention-all wh `∀x?Pax`                 | (substrate's [karttunen-1977] `which` modulo `?`) |
-| §5.4.2 Mention-some wh `∃xLax`                 | `Question.which` (`mem_which`)   |
-| §5.5.1 Conjoined `Q ∧ Q'`                      | `Q ⊓ Q'` (`inf_eq_conj`)         |
-| §5.5.2 Disjoined `Q ∨ Q'`                      | `Q ⊔ Q'` (`sup_eq_inqDisj`)      |
-| §5.5.3 Conditional `if A, Q ↦ A → Q`           | substrate's Heyting `A ⇨ Q`      |
-
-## What this file does NOT cover
-
-* **Ch 4** First-order syntax (the `InqB` logical language): the substrate
-  is at the meaning side (`Question W`); the syntactic translation
-  layer is not formalised here.
-* **Ch 6** Disjunction, clause typing, intonation: partial coverage in
-  `Semantics/Mood/` and the focus studies (`Studies/Rooth1992.lean`).
-* **Ch 7** Conditionals: the substrate exposes `⇨` via the
-  `HeytingAlgebra` instance; the chapter's empirical analysis lives in
-  `Semantics/Conditionals/` and study files there.
-* **Ch 8** Inquisitive epistemic logic / `know` and `wonder`: see
-  `Semantics/Attitudes/` and `Studies/TheilerRoelofsenAloni2018.lean`.
-* **Ch 9** Comparison with alternative and partition semantics: see
-  `Studies/GroenendijkStokhof1984.lean` and `Semantics/Questions/`.
+The substrate `Semantics/Questions/` is this theory: `Question W` is the proposition, `info`,
+`alt`, `isInformative` and `isInquisitive` its attributes, the lattice order its entailment with
+`⊤`, `⊥`, `⊓`, `⊔` and `⇨` the operations, `proj` and `nonInfo` the two projections with
+`proj_inf_nonInfo` the division law, and `polar` and `which` the polar and mention-some forms.
+This file proves the one Chapter 2 fact stated over two contents at once,
+`update_nonInquisitive` (Fact 2.36). The logical language of Chapter 4 is the propositional
+fragment of `Logic/Team/Inquisitive.lean`; Chapters 6–9 are not represented.
 
 ## References
 
-* [I. Ciardelli, J. Groenendijk, F. Roelofsen, *Inquisitive Semantics*
+* [I. Ciardelli, J. Groenendijk and F. Roelofsen, *Inquisitive Semantics*
   (2018)][ciardelli-groenendijk-roelofsen-2018]
 -/
 
@@ -107,14 +36,9 @@ variable {W : Type*}
 
 open Question
 
-/-- [ciardelli-groenendijk-roelofsen-2018] Fact 2.36 (Update without
-    inquisitiveness yields standard results): when context and proposition
-    are both non-inquisitive, the inquisitive update `C ⊓ P` is again
-    non-inquisitive and its informative content is the standard
-    intersection of the inputs' informative contents. (The informative
-    half holds without the non-inquisitiveness assumptions — substrate
-    `info_inf`; the CGR-specific content is declarativity
-    preservation.) -/
+/-- Fact 2.36: updating a non-inquisitive context with a non-inquisitive proposition is again
+non-inquisitive, with the intersection of the two informative contents as its own. The
+informative half needs no non-inquisitiveness (`info_inf`). -/
 theorem update_nonInquisitive (C P : Question W) (hC : C.info ∈ C)
     (hP : P.info ∈ P) :
     (C ⊓ P).info ∈ C ⊓ P ∧ (C ⊓ P).info = C.info ∩ P.info := by

--- a/Linglib/Studies/CiardelliGuerrini2026.lean
+++ b/Linglib/Studies/CiardelliGuerrini2026.lean
@@ -5,109 +5,81 @@ import Mathlib.Data.Set.Basic
 import Linglib.Logic.Modal.Basic
 
 /-!
-# Ciardelli & Guerrini 2026: Against wide scope free choice
+# Ciardelli and Guerrini 2026: Against wide scope free choice
 
-The **reductionist thesis** ([ciardelli-guerrini-2026]): the free-choice
-reading of "you may A or you may B" does not arise from the wide-scope LF
-`◇A ∨ ◇B`, but from the narrow-scope LF `◇(A ∨ B)`. For possibility over
-disjunction the two LFs are truth-conditionally equivalent
-(`scope_equivalence`), so the ambiguity is invisible there; the paper's §2
-evidence comes from the configurations where it is visible — must-or-must (5),
-where the narrow LF is a strictly weaker disjunctive obligation, and
-may-and-may (7), where the narrow LF is a strictly stronger conjunctive
-permission. The free-choice reading tracks the narrow LF (only `◇(A ∨ B)`
-feeds the exhaustification that derives `◇A ∧ ◇B`); the wide-scope LF yields
-the ignorance reading ([fusco-2019]'s sluicing argument) and does not entail
-free choice (`wideScope_underdetermines_fc`).
+The free-choice reading of *you may A or you may B* is not the wide-scope LF `◇A ∨ ◇B` but the
+narrow-scope `◇(A ∨ B)`, from which exhaustification derives `◇A ∧ ◇B` as for *you may A or B*,
+the wide LF yielding the ignorance reading ([fusco-2019]). For possibility over disjunction the
+two LFs have the same truth conditions, so the ambiguity shows where they differ: *you must A
+or you must B* has a reading as one disjunctive obligation `□(A ∨ B)`, weaker than `□A ∨ □B`
+(5), and *you may A and you may B* one as a conjunctive permission `◇(A ∧ B)`, stronger than
+`◇A ∧ ◇B` (7) (§2). The narrow LF arises by modal concord ([zeijlstra-2007]): each auxiliary
+carries an uninterpretable modal feature and one silent interpretable operator above the
+coordination checks both (§3). Non-auxiliary modals carry interpretable features and cannot be
+checked, hence no free choice in [meyer-sauerland-2017]'s (19) (§4.1); concord across negation
+needs dual forces, (24)–(27) after [grosz-2010] and [anand-brasoveanu-2010], so *I need not
+cook and I need not clean* conveys `◇(¬cook ∧ ¬clean)` but not `□(¬cook ∧ ¬clean)` (§4.2);
+*may* and *can* share their feature, answering [alonso-ovalle-2006]'s mixed-form case (fn. 4);
+*it is possible that A or it is possible that B* is left open (§4.3).
 
-The narrow-scope LF is derived by modal concord ([zeijlstra-2007], §3): modal
-auxiliaries carry uninterpretable features `[u∃/∀-MOD]`; a single silent
-interpretable operator c-commanding the coordination checks both, so only it is
-interpreted, yielding `Δ(A ∘ B)` rather than `ΔA ∘ ΔB`.
-
-`MOD A COORD MOD B` is scope-ambiguous across the board (the (2)/(5)/(7)
-stimuli live in `Data.Examples.CiardelliGuerrini2026`):
-
-| surface form     | wide-scope LF | narrow-scope LF |
-|------------------|---------------|-----------------|
-| may A or may B   | `◇A ∨ ◇B`     | `◇(A ∨ B)`      |
-| must A or must B | `□A ∨ □B`     | `□(A ∨ B)`      |
-| may A and may B  | `◇A ∧ ◇B`     | `◇(A ∧ B)`      |
-
-The modal operators are `ModalLogic.poss`/`nec` (the flat
-S5 modals shared with the whole free-choice stack), so the scope theorems consume
-the substrate's distribution lemmas directly.
-
-## Main declarations
-
-* `scope_equivalence` — the two disjunction LFs are truth-conditionally equal.
-* `disjunctive_obligation_narrow_weaker` / `_not_wide` — must-or-must: under
-  necessity the narrow LF `□(A ∪ B)` is strictly *weaker* than the wide `□A ∨ □B`.
-* `conjunctive_narrow_stronger` — may-and-may: `◇(A ∩ B)` strictly stronger.
-* `ConcordDerivation` — two `[u-MOD]` auxiliaries checked by one silent operator;
-  instantiated as `mayMayConcord`, `mustMustConcord`, and fn. 4's mixed-form
-  `mayCanConcord`.
-* `narrowScope_yields_fc` / `wideScope_underdetermines_fc` — free choice from the
-  narrow LF; non-entailment of free choice from the wide LF.
-* `reductionist_thesis` — the two packaged together.
-* `negation_concord_pattern` — cross-negation concord succeeds iff forces are duals.
+`scope_equivalence`, `disjunctive_obligation_narrow_weaker` with `_not_wide`, and
+`conjunctive_narrow_stronger` are the three cells of §2 on the flat modals `ModalLogic.poss`
+and `nec`. A `ConcordDerivation` is two uninterpretable features of one concord class with the
+silent checker derived from them, built from the Fragment's auxiliaries as `mayMayConcord`,
+`mustMustConcord` and fn. 4's `mayCanConcord`; `interpreted_unchecked` is the §4.1 mechanism
+and `negation_concord_pattern` the §4.2 one, with (24)–(29) as instances. `doublyExhaustified`
+is [fox-2007]'s exhaustification of the narrow LF, `narrowScope_yields_fc` derives free choice
+from it, `wideScope_underdetermines_fc` shows the wide LF does not entail it, and
+`reductionist_thesis` packages the two. The stimuli (2), (5) and (7) are in
+`Data.Examples.CiardelliGuerrini2026`; the argument against across-the-board movement
+([simons-2005]) from *everyone sang or everyone danced* (3) has no movement substrate here.
 
 ## References
 
-* [I. Ciardelli, J. Guerrini, *Against wide scope free choice*
+* [I. Ciardelli and J. Guerrini, *Against Wide Scope Free Choice*
   (2026)][ciardelli-guerrini-2026]
-* [H. Zeijlstra, *Modal concord* (2007)][zeijlstra-2007]
-* [M.-C. Meyer, U. Sauerland, *Covert across-the-board movement revisited*
-  (2017)][meyer-sauerland-2017]
+* [H. Zeijlstra, *Modal Concord* (2007)][zeijlstra-2007]
+* [M.-C. Meyer and U. Sauerland, *Covert Across-the-Board Movement Revisited: Free Choice and
+  the Scope of Modals* (2017)][meyer-sauerland-2017]
+* [M. Fusco, *Sluicing on free choice* (2019)][fusco-2019]
+* [D. Fox, *Free Choice and the Theory of Scalar Implicatures* (2007)][fox-2007]
+* [M. Simons, *Dividing Things Up: The Semantics of Or and the Modal/Or Interaction*
+  (2005)][simons-2005]
+* [P. Grosz, *Grading Modality: A New Approach to Modal Concord and its Relatives*
+  (2010)][grosz-2010]
+* [P. Anand and A. Brasoveanu, *Modal Concord as Modal Modification*
+  (2010)][anand-brasoveanu-2010]
+* [L. Alonso-Ovalle, *Disjunction in Alternative Semantics* (2006)][alonso-ovalle-2006]
 -/
 
 namespace CiardelliGuerrini2026
 
-open Modality
+open Modality English.Auxiliaries
+
 /-- Possibility of a proposition, the flat S5 `ModalLogic.poss`. -/
 abbrev poss {World : Type*} (p : Set World) : Prop := ModalLogic.poss p
 
 /-- Necessity of a proposition, the flat S5 `ModalLogic.nec`. -/
 abbrev nec {World : Type*} (p : Set World) : Prop := ModalLogic.nec p
-open English.Auxiliaries
 
-/-! ### Truth-conditional equivalence
+/-! ### Scope and truth conditions (§2) -/
 
-For possibility over disjunction the two LFs collapse: `◇(A ∨ B) ↔ ◇A ∨ ◇B` in
-standard modal logic. This is why the scope ambiguity is truth-conditionally
-undetectable exactly in the classic free-choice configuration — the readings
-differ only pragmatically there — while must-or-must and may-and-may (below)
-make it visible. -/
-
-/-- The two disjunction LFs are truth-conditionally equivalent:
-`◇(A ∨ B) ↔ ◇A ∨ ◇B` — possibility distributes over disjunction, so
-may-or-may is the one cell of [ciardelli-guerrini-2026]'s paradigm where the
-scope ambiguity is invisible to truth conditions. -/
+/-- Possibility distributes over disjunction, so may-or-may is the one cell of the paradigm
+where the scope ambiguity is invisible to truth conditions. -/
 theorem scope_equivalence {World : Type*} (A B : Set World) :
     poss (A ∪ B) ↔ poss A ∨ poss B :=
   ⟨λ ⟨w, h⟩ => h.elim (λ h => Or.inl ⟨w, h⟩) (λ h => Or.inr ⟨w, h⟩),
     λ h => h.elim (λ ⟨w, h⟩ => ⟨w, Or.inl h⟩) (λ ⟨w, h⟩ => ⟨w, Or.inr h⟩)⟩
 
-/-! ### Must-or-must: disjunctive obligation (§2)
-
-Under *necessity*, the scope distinction is **not** truth-conditionally vacuous.
-`poss`/`nec` here are `ModalLogic.poss`/`nec`, so these theorems consume
-the substrate's flat distribution directly. For disjunction the narrow LF
-`□(A ∪ B)` is strictly *weaker* than the wide LF `□A ∨ □B` — exactly C&G's
-must-or-must contrast: "(either) you must A or you must B" on its salient reading
-is a single disjunctive obligation `□(A ∨ B)`, not two obligations. -/
-
-/-- Wide ⟹ narrow: `□A ∨ □B → □(A ∪ B)`. The narrow disjunctive-obligation LF is
-the weaker reading (monotonicity of `ModalLogic.nec`). -/
+/-- Must-or-must (5): the narrow-scope disjunctive obligation `□(A ∪ B)` follows from the wide
+`□A ∨ □B`. -/
 theorem disjunctive_obligation_narrow_weaker {World : Type*} (A B : Set World) :
     nec A ∨ nec B → nec (A ∪ B) := by
   rintro (h | h)
   · exact ModalLogic.nec_mono (fun _ ha => Or.inl ha) h
   · exact ModalLogic.nec_mono (fun _ hb => Or.inr hb) h
 
-/-- …but **not** conversely: `□(A ∪ B)` does not entail `□A ∨ □B`. A disjunctive
-obligation leaves which disjunct is met open, so neither `□A` nor `□B` follows.
-This is why must-or-must has a genuine narrow reading the wide LF lacks. -/
+/-- But not conversely: a disjunctive obligation leaves open which disjunct is met. -/
 theorem disjunctive_obligation_not_wide :
     ∃ (A B : Set Bool), nec (A ∪ B) ∧ ¬ (nec A ∨ nec B) := by
   refine ⟨{true}, {false}, ?_, ?_⟩
@@ -118,46 +90,39 @@ theorem disjunctive_obligation_not_wide :
     · exact absurd (show false = true from h false) (by decide)
     · exact absurd (show true = false from h true) (by decide)
 
-/-! ### Modal concord derivation (§3)
+/-- May-and-may (7): the narrow-scope conjunctive permission `◇(A ∩ B)` entails the wide
+`◇A ∧ ◇B`, but not conversely. -/
+theorem conjunctive_narrow_stronger {World : Type*}
+    (p q : Set World)
+    (h : poss (p ∩ q)) : poss p ∧ poss q := by
+  obtain ⟨w, hp, hq⟩ := h
+  exact ⟨⟨w, hp⟩, ⟨w, hq⟩⟩
 
-[zeijlstra-2007]'s feature system explains how the narrow-scope LF `◇(A ∨ B)`
-arises compositionally for "may A or may B":
+/-! ### Modal concord (§3) -/
 
-1. each "may" carries `[u∃-MOD]` (uninterpretable existential feature);
-2. a silent `◇` operator `[i∃-MOD]` is projected above the coordination;
-3. the silent operator checks both `[u∃-MOD]` features in the conjuncts;
-4. only the silent operator is semantically interpreted, giving `◇(A ∨ B)`.
--/
-
-/-- The modal feature carried by English "may" — derived from the Fragment entry's
-force and interpretability. -/
+/-- The modal feature of *may*, from the Fragment. -/
 def mayFeature : ModalFeature := may.modalFeature.get!
 
-/-- The modal feature carried by English "must" — derived from the Fragment. -/
+/-- The modal feature of *must*, from the Fragment. -/
 def mustFeature : ModalFeature := must.modalFeature.get!
 
-/-- "May" carries `[u∃-MOD]`: possibility force, uninterpretable. -/
+/-- *May* carries `[u∃-MOD]`. -/
 theorem may_feature_eq :
     may.modalFeature = some ⟨.possibility, .uninterpretable⟩ := rfl
 
-/-- "Must" carries `[u∀-MOD]`: necessity force, uninterpretable. -/
+/-- *Must* carries `[u∀-MOD]`. -/
 theorem must_feature_eq :
     must.modalFeature = some ⟨.necessity, .uninterpretable⟩ := rfl
 
-/-- The silent operator that checks a given u-feature: same force, but
-interpretable. This is the operator [ciardelli-guerrini-2026] posit above the
-coordination. -/
+/-- The silent operator checking a feature: the same force, interpretable. -/
 def silentChecker (f : ModalFeature) : ModalFeature := ⟨f.force, .interpretable⟩
 
-/-- **Core derivation**: the matching silent operator checks any u-feature. This is
-the general form of the concord mechanism — not just "may" or "must", but *any*
-auxiliary carrying a u-feature. -/
+/-- The matching silent operator checks any uninterpretable feature. -/
 theorem silent_checker_works (f : ModalFeature) (h : f.interp = .uninterpretable) :
     (silentChecker f).checks f = true := by
   simp only [silentChecker, ModalFeature.checks, h]
   cases f.force <;> decide
 
-/-- A silent `[i-MOD]` with force `g₁` checks any `[u-MOD]` of matching concord class. -/
 private theorem silent_checks_matching (g₁ g₂ : ModalFeature)
     (hI : g₂.interp = .uninterpretable)
     (hF : ConcordType.fromModalForce g₁.force = ConcordType.fromModalForce g₂.force) :
@@ -167,51 +132,37 @@ private theorem silent_checks_matching (g₁ g₂ : ModalFeature)
   rw [hforce]
   exact silent_checker_works g₂ hI
 
-/-! #### ConcordDerivation: packaging the full derivation chain -/
-
-/-- A concord derivation witnesses that two modal features can be checked by a
-single silent operator. This is the formal content of [ciardelli-guerrini-2026]'s
-compositional mechanism.
-
-A `ConcordDerivation` exists iff both features are uninterpretable (u-MOD) and
-belong to the same concord class (both ∃-type or both ∀-type). The silent
-operator, the checking proofs, and the resulting narrow-scope interpretation are
-all derived from these two conditions. -/
+/-- A concord derivation: two uninterpretable modal features of one concord class, checked by a
+single silent operator. -/
 structure ConcordDerivation where
-  /-- The feature of the first modal auxiliary. -/
+  /-- The feature of the first auxiliary. -/
   f₁ : ModalFeature
-  /-- The feature of the second modal auxiliary. -/
+  /-- The feature of the second auxiliary. -/
   f₂ : ModalFeature
-  /-- Both are uninterpretable. -/
   uInterp₁ : f₁.interp = .uninterpretable
   uInterp₂ : f₂.interp = .uninterpretable
-  /-- Same concord class. -/
   sameClass : ConcordType.fromModalForce f₁.force = ConcordType.fromModalForce f₂.force
 
 namespace ConcordDerivation
 
-/-- The silent interpretable operator — derived, not stipulated. -/
+/-- The silent interpretable operator. -/
 def checker (cd : ConcordDerivation) : ModalFeature :=
   silentChecker cd.f₁
 
-/-- The checker is interpretable (semantically active). -/
 theorem checker_interpretable (cd : ConcordDerivation) :
     cd.checker.interp = .interpretable := rfl
 
-/-- The checker checks the first feature. -/
 theorem checks_first (cd : ConcordDerivation) :
     cd.checker.checks cd.f₁ = true :=
   silent_checker_works cd.f₁ cd.uInterp₁
 
-/-- The checker checks the second feature. -/
 theorem checks_second (cd : ConcordDerivation) :
     cd.checker.checks cd.f₂ = true :=
   silent_checks_matching cd.f₁ cd.f₂ cd.uInterp₂ cd.sameClass
 
 end ConcordDerivation
 
-/-- Construct a `ConcordDerivation` from two `Auxiliary`s. The derivation is built
-entirely from Fragment data — no stipulation. -/
+/-- A concord derivation from two Fragment auxiliaries. -/
 def ConcordDerivation.fromAux (a₁ a₂ : Auxiliary)
     {f₁ f₂ : ModalFeature}
     (_h₁ : a₁.modalFeature = some f₁) (_h₂ : a₂.modalFeature = some f₂)
@@ -220,63 +171,40 @@ def ConcordDerivation.fromAux (a₁ a₂ : Auxiliary)
     ConcordDerivation :=
   ⟨f₁, f₂, hI₁, hI₂, hF⟩
 
-/-! #### Universal modal properties -/
-
-/-- Fragment modals with a modal feature — those that can form
-`ConcordDerivation`s. Excludes `dare`, whose meaning the fragment leaves
-unspecified. -/
+/-- The Fragment's modals with a modal feature; *dare*'s is unspecified. -/
 def concordCapableModals : List Auxiliary :=
   modals.filter (λ a => a.modalFeature.isSome)
 
-/-- [zeijlstra-2007]'s generalization over the whole Fragment inventory:
-every English modal auxiliary carries its modal feature *uninterpretable* —
-so any of them can be checked by a silent operator. -/
+/-- [zeijlstra-2007]'s generalization over the Fragment: every modal auxiliary carries its
+feature uninterpretable. -/
 theorem concordCapable_uninterpretable :
     ∀ a ∈ concordCapableModals,
       a.interpretability = some .uninterpretable := by decide
 
-/-- Non-modal auxiliaries have no modal feature — they cannot participate in
-concord at all. -/
+/-- Non-modal auxiliaries have no modal feature. -/
 theorem nonmodal_no_feature :
     ∀ a ∈ [do_, am, have_], a.modalFeature = none := by decide
 
-/-! #### Instantiations -/
-
-/-- "May A or may B" concord derivation — fully derived from the Fragment. -/
+/-- *May A or may B*. -/
 def mayMayConcord : ConcordDerivation :=
   .fromAux may may may_feature_eq may_feature_eq rfl rfl rfl
 
-/-- "Must A or must B" concord derivation — fully derived from the Fragment. -/
+/-- *Must A or must B*. -/
 def mustMustConcord : ConcordDerivation :=
   .fromAux must must must_feature_eq must_feature_eq rfl rfl rfl
 
-/-- Cross-force checking fails: a silent `□` cannot check "may" `[u∃]`. -/
+/-- A silent `□` cannot check *may*'s `[u∃]`. -/
 theorem cross_force_blocked :
     (silentChecker mustFeature).checks mayFeature = false := by decide
 
-/-! ### The FC pipeline: concord → narrow scope → free choice (§3)
-
-The pipeline has three stages:
-
-1. **feature matching** → `ConcordDerivation` (above);
-2. **narrow scope** → a single modal operator over the coordination;
-3. **exhaustification** → the free-choice inference.
-
-The key point: the narrow/wide scope distinction is truth-conditionally vacuous
-*for disjunction* (`scope_equivalence`) but pragmatically active. Only the
-narrow-scope LF, exhaustified, yields free choice; the wide-scope LF
-underdetermines it (and yields an ignorance reading instead). -/
+/-! ### From the narrow LF to free choice (§3) -/
 
 /-- The narrow-scope `◇(A ∨ B)` doubly exhaustified over its disjunct and conjunctive
-alternatives ([fox-2007]): the conjunctive alternative and the exhaustified disjunct
-alternatives are denied. -/
+alternatives ([fox-2007]). -/
 def doublyExhaustified {World : Type*} (A B : Set World) : Prop :=
   poss (A ∪ B) ∧ ¬ poss (A ∩ B) ∧ ¬ (poss A ∧ ¬ poss B) ∧ ¬ (poss B ∧ ¬ poss A)
 
-/-- The **free-choice pipeline**: the narrow-scope `◇(A ∨ B)`, doubly exhaustified,
-yields free choice `◇A ∧ ◇B`. This is the reductionist thesis in action — FC
-arises from the narrow-scope LF (derived via concord) fed to the standard
-exhaustification mechanism. -/
+/-- The exhaustified narrow LF yields free choice. -/
 theorem narrowScope_yields_fc {World : Type*} {A B : Set World}
     (hExh : doublyExhaustified A B) : poss A ∧ poss B := by
   obtain ⟨⟨w, hw⟩, -, h₁, h₂⟩ := hExh
@@ -284,138 +212,70 @@ theorem narrowScope_yields_fc {World : Type*} {A B : Set World}
   · exact ⟨hA, not_not.1 λ hB => h₁ ⟨hA, hB⟩⟩
   · exact absurd ⟨hw.elim (λ h => absurd ⟨w, h⟩ hA) (λ h => ⟨w, h⟩), hA⟩ h₂
 
-/-- The wide-scope LF `◇A ∨ ◇B` does **not** entail free choice `◇A ∧ ◇B`: a
-disjunction of possibilities holds even when only one disjunct is possible. This
-is why [ciardelli-guerrini-2026] locate the free-choice reading exclusively in the
-narrow-scope LF — the wide-scope LF yields the *ignorance* reading (the speaker is
-unsure which disjunct holds), not free choice. -/
+/-- The wide-scope LF does not entail free choice: one possible disjunct suffices for it. -/
 theorem wideScope_underdetermines_fc :
     ∃ (A B : Set Unit), (poss A ∨ poss B) ∧ ¬ (poss A ∧ poss B) := by
   refine ⟨Set.univ, ∅, Or.inl ⟨(), trivial⟩, ?_⟩
   rintro ⟨-, w, hw⟩
   exact Set.notMem_empty w hw
 
-/-- **The reductionist thesis** ([ciardelli-guerrini-2026], formalized).
-
-Despite truth-conditional equivalence (`scope_equivalence`), the FC reading arises
-only from the narrow-scope LF: (1) the two disjunction LFs are equivalent, and
-(2) the narrow-scope LF, exhaustified, yields free choice. The wide-scope LF does
-not (`wideScope_underdetermines_fc`), so there is no separate problem of
-"wide-scope free choice". -/
+/-- The reductionist thesis: the two disjunction LFs are equivalent, and free choice comes from
+the exhaustified narrow one. -/
 theorem reductionist_thesis {World : Type*} (A B : Set World) :
     (poss (A ∪ B) ↔ poss A ∨ poss B) ∧
     (doublyExhaustified A B → poss A ∧ poss B) :=
   ⟨scope_equivalence A B, narrowScope_yields_fc⟩
 
-/-! ### Auxiliary vs non-auxiliary modals (§4.1)
+/-! ### Auxiliary and non-auxiliary modals (§4.1) -/
 
-[meyer-sauerland-2017] observed that (19a-b) lack FC readings:
-
-  (19a) It's ok for John to sing or it's ok for John to dance.  (*FC)
-  (19b) John is allowed to sing or he is allowed to dance.      (*FC)
-
-[ciardelli-guerrini-2026] explain this: "it's ok" and "be allowed" carry
-**interpretable** features, so they are already interpreted and cannot be checked
-by a higher silent operator — no narrow-scope LF, no FC. Modal auxiliaries ("may",
-"must", "can") carry **uninterpretable** features and *can* be checked → FC
-available. The auxiliary status of "may", "must", "can", "need" is derived from
-`English.FunctionWords` — they are all `.modal` entries.
-
-Caveat: in §4.3 the authors flag (31) "it is possible that A or it is possible
-that B", a *non-auxiliary* modal that nevertheless seems to allow FC, as an
-outstanding problem. The prediction below is therefore about the concord
-*mechanism* (interpreted features cannot be checked), not an exceptionless surface
-generalization. -/
-
-/-- Fragment-derived: the English modals used by [ciardelli-guerrini-2026] are
-modal auxiliaries, all carrying uninterpretable features. -/
+/-- The paper's modals are Fragment auxiliaries with uninterpretable features. -/
 theorem paper_modals_uninterpretable :
     ∀ a ∈ [may, must, can, need],
       a ∈ modals ∧ a.interpretability = some .uninterpretable := by decide
 
-/-- **The mechanism behind the auxiliary/non-auxiliary contrast**: an *interpreted*
-feature can never be checked. Non-auxiliary modal constructions ("it's ok that",
-"be allowed/required to") carry interpretable features, so no silent operator can
-check them — hence no narrow-scope LF and no FC in coordination. This is derived
-from `ModalFeature.checks` (which requires the checked feature to be
-uninterpretable), not stipulated. -/
+/-- An interpreted feature is never checked, so non-auxiliary modals such as *be allowed* admit
+no narrow-scope LF and no free choice in coordination ((19), [meyer-sauerland-2017]). -/
 theorem interpreted_unchecked (checker f : ModalFeature)
     (h : f.interp = .interpretable) : checker.checks f = false := by
   have hb : (f.interp == .uninterpretable) = false := by rw [h]; decide
   simp only [ModalFeature.checks, hb, Bool.and_false, Bool.false_and]
 
-/-- Corollary: an interpreted feature cannot be the checked conjunct of a
-`ConcordDerivation` — that would contradict `uInterp₂`. -/
 theorem interpreted_not_concord_checked (cd : ConcordDerivation) :
     cd.f₂.interp ≠ .interpretable := by
   rw [cd.uInterp₂]; decide
 
-/-! ### Against ATB movement (§1, ex. 3)
+/-! ### Concord across negation (§4.2) -/
 
-[simons-2005] proposed that the narrow-scope LF `◇(A ∨ B)` arises from
-across-the-board (ATB) movement of the modal at LF. [ciardelli-guerrini-2026] note
-evidence *against* this: ATB movement is independently blocked for nominal
-quantifiers.
-
-  (3a) Everyone sang or everyone danced.
-  (3b) Everyone sang or danced.
-
-(3a) cannot be interpreted as (3b). If ATB movement of "everyone" were possible at
-LF, (3a) should receive the (3b) reading — but it does not. This undermines ATB as
-the mechanism for deriving narrow-scope modal LFs. The modal concord account avoids
-the problem: the narrow-scope LF is derived by feature checking (specific to
-modals), not movement (which would overgeneralize to quantifiers).
-
-Formalizing the contrast faithfully needs a movement/quantifier substrate this
-study does not import, so the argument is recorded here as prose. -/
-
-/-! ### Concord across negation (§4.2)
-
-Modal concord across negation requires **opposite** forces. The checking uses
-`ModalForce.dual` — negation over a modal operator yields its dual:
-
-  (24) ALLOW[i∃](¬NEED[u∀]) ✓  — dual(∀) = ∃, matches the checker
-  (26) *DEMAND[i∀](¬NEED[u∀]) ✗  — dual(∀) = ∃ ≠ ∀
-  (25) DEMAND[i∀](¬MAY[u∃]) ✓  — dual(∃) = ∀, matches the checker
-  (27) *ALLOW[i∃](¬MAY[u∃]) ✗  — dual(∃) = ∀ ≠ ∃
-
-The pattern: checking across negation succeeds iff the checker's force equals the
-dual of the checked item's force. This follows from
-`ModalFeature.checksAcrossNegation`, which uses `ModalForce.dual`. The
-generalization is from [grosz-2010] and [anand-brasoveanu-2010]. -/
-
-/-- (24) ALLOW[i∃] checks ¬NEED[u∀]: well-formed (dual(∀) = ∃). -/
+/-- (24): ALLOW`[i∃]` checks ¬NEED`[u∀]`. -/
 theorem allow_neg_need_ok :
     (ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       ⟨.necessity, .uninterpretable⟩)
     = true := by decide
 
-/-- (26) *DEMAND[i∀] checks ¬NEED[u∀]: ill-formed (dual(∀) = ∃ ≠ ∀). -/
+/-- (26): DEMAND`[i∀]` does not check ¬NEED`[u∀]`. -/
 theorem demand_neg_need_bad :
     (ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       ⟨.necessity, .uninterpretable⟩)
     = false := by decide
 
-/-- (25) DEMAND[i∀] checks ¬MAY[u∃]: well-formed (dual(∃) = ∀). -/
+/-- (25): DEMAND`[i∀]` checks ¬MAY`[u∃]`. -/
 theorem demand_neg_may_ok :
     (ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       ⟨.possibility, .uninterpretable⟩)
     = true := by decide
 
-/-- (27) *ALLOW[i∃] checks ¬MAY[u∃]: ill-formed (dual(∃) = ∀ ≠ ∃). -/
+/-- (27): ALLOW`[i∃]` does not check ¬MAY`[u∃]`. -/
 theorem allow_neg_may_bad :
     (ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       ⟨.possibility, .uninterpretable⟩)
     = false := by decide
 
-/-- General pattern: cross-negation concord succeeds iff the forces are duals.
-This is the content of the negation-concord generalization from [grosz-2010] and
-[anand-brasoveanu-2010], formalized as a consequence of `checksAcrossNegation`
-using `ModalForce.dual`. -/
+/-- Concord across negation succeeds iff the checker's force is the dual of the checked one
+([grosz-2010], [anand-brasoveanu-2010]). -/
 theorem negation_concord_pattern (checkerForce checkedForce : ModalForce)
     (hNec : checkerForce = .necessity ∨ checkerForce = .possibility)
     (hChk : checkedForce = .necessity ∨ checkedForce = .possibility) :
@@ -425,68 +285,37 @@ theorem negation_concord_pattern (checkerForce checkedForce : ModalForce)
     ↔ checkerForce = checkedForce.dual := by
   rcases hNec with rfl | rfl <;> rcases hChk with rfl | rfl <;> decide
 
-/-! ### "I need not cook and I need not clean" (§4.2, ex. 28-29)
-
-"I need not cook and I need not clean" can convey `◇(¬Cook ∧ ¬Clean)` —
-permission to do neither — but not `□(¬Cook ∧ ¬Clean)` — obligation to do neither.
-This follows from the concord-across-negation generalization; the "need" u-feature
-force (necessity) comes from the Fragment. -/
-
-/-- "Need" carries `[u∀-MOD]` in the Fragment. -/
+/-- *Need* carries `[u∀-MOD]`. -/
 theorem need_feature_eq :
     need.modalFeature = some ⟨.necessity, .uninterpretable⟩ := rfl
 
-/-- The existential reading is available: `◇[i∃]` checks `¬NEED[u∀]`. -/
+/-- (28): *I need not cook and I need not clean* has the reading `◇(¬cook ∧ ¬clean)`, the silent
+`◇[i∃]` checking ¬NEED`[u∀]`. -/
 theorem need_not_existential_ok :
     ModalFeature.checksAcrossNegation
       ⟨.possibility, .interpretable⟩
       need.modalFeature.get!
     = true := by decide
 
-/-- The universal reading is blocked: `□[i∀]` cannot check `¬NEED[u∀]`. -/
+/-- (29): it lacks the reading `□(¬cook ∧ ¬clean)`. -/
 theorem need_not_universal_blocked :
     ModalFeature.checksAcrossNegation
       ⟨.necessity, .interpretable⟩
       need.modalFeature.get!
     = false := by decide
 
-/-! ### Conjunctive permission, may-and-may (§2, ex. 7-8)
+/-! ### Mixed forms (fn. 4) -/
 
-"You may go to Bob's party and you may go to Charlie's party" has a reading where
-Alice is allowed to go to both parties: `◇(Bob ∧ Charlie)`. Unlike disjunction,
-`◇(A ∧ B)` is strictly *stronger* than `◇A ∧ ◇B`, so for conjunction the scope
-distinction has truth-conditional consequences. -/
-
-/-- For conjunction, narrow scope is strictly stronger than wide scope:
-`◇(A ∧ B) → ◇A ∧ ◇B` (but not conversely). -/
-theorem conjunctive_narrow_stronger {World : Type*}
-    (p q : Set World)
-    (h : poss (p ∩ q)) : poss p ∧ poss q := by
-  obtain ⟨w, hp, hq⟩ := h
-  exact ⟨⟨w, hp⟩, ⟨w, hq⟩⟩
-
-/-! ### Mixed surface forms: may/can (fn. 4)
-
-[alonso-ovalle-2006] objected to narrow-scope-disjunction accounts that free
-choice arises even when the modal takes a different surface form in each
-disjunct: "You may email us or you can reach the Business License office …".
-[ciardelli-guerrini-2026] fn. 4: *may* and *can* carry the same
-uninterpretable feature, so the disjunction inherits it and a single silent
-operator checks both, yielding `◇(email ∨ call)`. The Fragment exhibits the
-precondition. -/
-
-/-- "Can" carries `[u∃-MOD]`: possibility force, uninterpretable — the same
-feature as "may". -/
+/-- *Can* carries `[u∃-MOD]`, the feature of *may*. -/
 theorem can_feature_eq :
     can.modalFeature = some ⟨.possibility, .uninterpretable⟩ := rfl
 
-/-- Fn. 4's mixed-form concord as a `ConcordDerivation`, derived from the
-Fragment: "may … or can …" is checked by one silent `[i∃]` operator. -/
+/-- *You may email us or you can reach the office*, [alonso-ovalle-2006]'s mixed-form case:
+one silent `[i∃]` checks both. -/
 def mayCanConcord : ConcordDerivation :=
   .fromAux may can may_feature_eq can_feature_eq rfl rfl rfl
 
-/-- Cross-force concord fails: "must" `[u∀]` cannot be checked by a silent `[i∃-MOD]`
-operator. This predicts no concord between necessity and possibility modals. -/
+/-- No concord between *may* and *must*: a silent `[i∃]` cannot check `[u∀]`. -/
 theorem must_may_no_concord :
     (ModalFeature.checks
       ⟨may.modalFeature.get!.force, .interpretable⟩

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -3,100 +3,34 @@ import Mathlib.Tactic.NormNum
 import Mathlib.Data.Rat.Defs
 
 /-!
-# Ciardelli, Zhang & Champollion 2018: Two switches
+# Ciardelli, Zhang and Champollion 2018: Two switches in the theory of counterfactuals
 
-## Headline finding
+Two switches at the ends of a hallway control a light, on iff they are in the same position;
+both are up and the light is on (Fig. 1). Participants judged *if switch A were down, the light
+would be off* and its B counterpart true by a majority, and *if switch A or switch B were down*
+likewise, but not *if switches A and B were not both up, the light would be off*, though its
+antecedent is the De Morgan equivalent of the disjunction (Table 3). The contrast falsifies
+every minimal-change semantics, not one choice of similarity: whenever the two simple
+counterfactuals are true, any counterfactual quantifying over the closest antecedent worlds
+makes the not-both-up one true as well, a closest not-both-up world in which A is down being a
+closest A-down world (§1.2), and the argument extends to [kratzer-1981]'s premise semantics
+(§6.3). The paper's positive proposal, a background semantics with the inquisitive lifting of
+disjunction (§3.2, §4), is not represented.
 
-Two truth-conditionally equivalent clauses (`A̅ ∨ B̅` and `¬(A ∧ B)`,
-related by De Morgan) make different semantic contributions when
-embedded as counterfactual antecedents
-([ciardelli-zhang-champollion-2018]). This challenges the textbook
-truth-conditional view of meaning AND falsifies any minimal-change
-semantics of counterfactuals — including Lewis-Stalnaker similarity
-semantics and Kratzer-style premise semantics.
-
-## The switches scenario (p. 578, Fig. 1)
-
-Two switches A, B at opposite ends of a hallway. The light is on iff
-both switches are in the same position. Currently both are up, light is
-on. The crowdsourced main experiment elicited truth judgments for five
-counterfactuals; the discriminating contrast (Table 3, "True" counts):
-
-- **`A̅ > OFF`** ("If A were down, light would be off"): 169/256 ≈ 66% true
-- **`B̅ > OFF`**:                                         153/235 ≈ 65% true
-- **`A̅ ∨ B̅ > OFF`**:                                    251/362 ≈ 69% true
-- **`¬(A ∧ B) > OFF`**:                                   82/372 ≈ 22% true
-
-`A̅ ∨ B̅` and `¬(A ∧ B)` are de-Morgan equivalent yet diverge sharply
-(the paper's dashed-line block structure: within-block differences are
-not significant, across-block differences are; the same pattern holds
-in both presentation orders, Tables 7–8).
-
-## What this file proves
-
-1. **De Morgan equivalence**: `(A̅ ∨ B̅) = ¬(A ∧ B)` as sets of worlds.
-2. **Concrete predictions across three operators**: instantiating a
-   Hamming-distance similarity ordering at the actual world `uu`, all
-   three closest-worlds operators in linglib —
-   `universalCounterfactual` (Lewis/Stalnaker), `selectionalCounterfactual`
-   (Stalnaker + supervaluation, returns `Trivalent.true`), and
-   `homogeneityCounterfactual` (von Fintel/Križ, returns `assertion =
-   some true` with satisfied presupposition) — all predict `¬(A ∧ B) >
-   OFF` true. This is the empirically falsified prediction (22% true,
-   Table 3).
-3. **Generic structural argument** (CZC §1.2 argument, p. 582):
-   the operator-agnostic core
-   (`closestWorlds_predicate_forces_notBothUp`) shows that for ANY
-   similarity ordering and ANY consequent `B`, joint truth of "every
-   closest aDn-world is B" and "every closest bDn-world is B" entails
-   "every closest notBothUp-world is B". Three corollaries instantiate
-   this for `universalCounterfactual`,  `selectionalCounterfactual`,
-   and `homogeneityCounterfactual` — closing CZC's claim that *all*
-   minimal-change theories fail.
-
-## Connection to linglib's Kratzer infrastructure
-
-[ciardelli-zhang-champollion-2018] §6.3 extends the argument to
-*standard premise semantics* as formulated in [kratzer-1981] (CZC
-cite both Kratzer 1981a and 1981b — only the 1981 "Notional Category"
-paper is in the linglib bib): "regardless of the particular ordering
-source that
-we consider, standard premise semantics still predicts that ... `¬(A ∧ B)
-> OFF` is true as well, contrary to our experimental findings." Per
-Lewis 1981, standard premise semantics is equivalent to ordering
-semantics with a weak partial order, which puts it in scope of the §1.2
-argument formalized above.
-
-**Whether the argument extends to [kratzer-2012]'s lumping-based
-revision (§5.4.4) is open and not addressed by CZC.** The lumping CF
-truth condition (§5.4.4) is a quantifier alternation — "for every set
-in F_{w,p} there is a superset that implies q" — *not* the
-maximization-of-consistency pattern that the §1.2 argument falsifies.
-Lumping constrains *which* propositions can accompany an antecedent
-into a Crucial Set (the lumping-closure condition); it doesn't relax
-the for-all-supersets quantifier. Whether this rescues the analysis on
-the switches scenario requires building a properly situation-semantic
-switches model and instantiating
-`Conditionals.PremiseSemantic.wouldCF`; we leave this as
-future work.
-
-For the first concrete `wouldCF` instantiation on a situation-semantic
-scenario, see
-`Kratzer2012Lumping` — which
-formalizes Kratzer's own apple-buying example (§5.4.1–§5.4.3). That
-file establishes the template for an eventual situation-semantic
-switches model that would settle the question raised here.
-
-The CZC positive proposal — a foreground/background distinction
-(§4, background semantics) combined with the inquisitive lifting of
-§3.2 — and §6.4's SNCA derivation (Proposition 2 + Lemma 1) are also
-left as future formalization.
+The four worlds, the wiring law and the five clauses are `World`, `lightOn` and the predicates
+`aDn` to `lightOff`, with `aOrBdn_eq_notBothUp` the De Morgan identity; under the Hamming
+similarity `hammingSim` the substrate's `universalCounterfactual` makes all four counterfactuals
+true at the actual world, and `selectionalCounterfactual` and `homogeneityCounterfactual` make
+the falsified one true as well. `closestWorlds_predicate_forces_notBothUp` is the §1.2 argument
+for any similarity ordering and consequent, with the three operators' versions as corollaries.
+The Table 3 counts are the rationals `trueRate_*`, `table3_pattern` the majority pattern the
+paper reads off them and `deMorgan_antecedents_diverge` the divergence of the equivalent pair.
 
 ## References
 
-* [I. Ciardelli, L. Zhang, L. Champollion, *Two switches in the theory of
-  counterfactuals* (2018)][ciardelli-zhang-champollion-2018]
-* [A. Kratzer, *The notional category of modality* (1981)][kratzer-1981]
+* [I. Ciardelli, L. Zhang and L. Champollion, *Two switches in the theory of counterfactuals: A
+  study of truth conditionality and minimal change* (2018)][ciardelli-zhang-champollion-2018]
+* [A. Kratzer, *The Notional Category of Modality* (1981)][kratzer-1981]
 -/
 
 namespace CiardelliZhangChampollion2018
@@ -106,44 +40,30 @@ open Conditionals.Counterfactual
   (universalCounterfactual selectionalCounterfactual homogeneityCounterfactual
    PresupStatus PresupResult)
 
-/-! ## The switches scenario -/
+/-! ### The switches scenario (Fig. 1) -/
 
-/-- The four worlds, indexed by (A-position, B-position).
-    Naming: `u` = up, `d` = down. So `uu` = both up, etc. -/
+/-- The four worlds, by the positions of A and B: `u` up, `d` down. -/
 inductive World where
-  /-- A up, B up — the actual world; light is ON. -/
-  | uu
-  /-- A up, B down — light is OFF. -/
-  | ud
-  /-- A down, B up — light is OFF. -/
-  | du
-  /-- A down, B down — light is ON. -/
-  | dd
+  | uu | ud | du | dd
   deriving Repr, DecidableEq, Fintype
 
-/-- Atomic propositions: switch positions and the light. -/
+/-- Switch A is up. -/
 def aUp : World → Prop | .uu | .ud => True | .du | .dd => False
+/-- Switch B is up. -/
 def bUp : World → Prop | .uu | .du => True | .ud | .dd => False
 
-/-- The wiring law ([ciardelli-zhang-champollion-2018], p. 578):
-    light is on iff both switches are in the same position. -/
+/-- The wiring: the light is on iff the switches are in the same position. -/
 def lightOn : World → Prop | .uu | .dd => True | .ud | .du => False
 
-/-! ### Antecedents and consequents
-
-We follow the paper's notation: `A̅` (`aDn`) means "switch A is down"
-and so on. The two key antecedents — `A̅ ∨ B̅` (`aOrBdn`) and
-`¬(A ∧ B)` (`notBothUp`) — are de-Morgan equivalent. -/
-
-/-- "Switch A is down." -/
+/-- *Switch A is down.* -/
 def aDn (w : World) : Prop := ¬ aUp w
-/-- "Switch B is down." -/
+/-- *Switch B is down.* -/
 def bDn (w : World) : Prop := ¬ bUp w
-/-- "Switch A is down or switch B is down." -/
+/-- *Switch A is down or switch B is down.* -/
 def aOrBdn (w : World) : Prop := aDn w ∨ bDn w
-/-- "Switches A and B are not both up" (= `¬(A ∧ B)`). -/
+/-- *Switches A and B are not both up.* -/
 def notBothUp (w : World) : Prop := ¬ (aUp w ∧ bUp w)
-/-- "The light is off." -/
+/-- *The light is off.* -/
 def lightOff (w : World) : Prop := ¬ lightOn w
 
 instance : DecidablePred aUp := fun w => by cases w <;> simp only [aUp] <;> infer_instance
@@ -155,23 +75,19 @@ instance : DecidablePred aOrBdn := fun _ => inferInstanceAs (Decidable (_ ∨ _)
 instance : DecidablePred notBothUp := fun _ => inferInstanceAs (Decidable (¬ _))
 instance : DecidablePred lightOff := fun _ => inferInstanceAs (Decidable (¬ _))
 
-/-! ## De Morgan equivalence -/
+/-! ### De Morgan equivalence -/
 
-/-- `A̅ ∨ B̅` and `¬(A ∧ B)` are pointwise-equivalent: the two antecedents
-    have identical truth conditions across the four worlds. -/
 theorem aOrBdn_iff_notBothUp (w : World) : aOrBdn w ↔ notBothUp w := by
   cases w <;> decide
 
-/-- The same equivalence as set equality (the truth-conditional content
-    of the two antecedents coincides). -/
+/-- The two antecedents have the same truth conditions. -/
 theorem aOrBdn_eq_notBothUp : aOrBdn = notBothUp := by
   funext w
   exact propext (aOrBdn_iff_notBothUp w)
 
-/-! ## Concrete similarity ordering: Hamming distance -/
+/-! ### Predictions under Hamming similarity -/
 
-/-- Hamming distance between two worlds: the number of switch positions
-    on which they disagree. -/
+/-- The number of switches on which two worlds differ. -/
 def hamming : World → World → Nat
   | .uu, .uu | .ud, .ud | .du, .du | .dd, .dd => 0
   | .uu, .ud | .ud, .uu | .du, .dd | .dd, .du => 1
@@ -179,94 +95,51 @@ def hamming : World → World → Nat
   | .uu, .dd | .dd, .uu => 2
   | .ud, .du | .du, .ud => 2
 
-/-- Standard "edit distance" similarity ordering: `w₁` is at least as
-    close to `w₀` as `w₂` is iff `hamming w₀ w₁ ≤ hamming w₀ w₂`. This
-    is one natural ordering on this scenario; the abstract theorem
-    below shows the falsification doesn't depend on this choice. -/
+/-- Similarity by Hamming distance, one natural ordering on the scenario. -/
 def hammingSim : SimilarityOrdering World where
   closer w₀ w₁ w₂ := hamming w₀ w₁ ≤ hamming w₀ w₂
   closer_refl _ _ := Nat.le_refl _
   closer_trans _ _ _ _ h₁ h₂ := h₁.trans h₂
   decClose _ _ _ := Nat.decLe _ _
 
-/-! ## Predictions of the universal/Lewis-Stalnaker counterfactual -/
-
-/-- **Prediction 1**: `A̅ > OFF` is true at `uu`. (The closest A̅-world
-    to `uu` is `du` — Hamming distance 1 — and the light is off there.)
-    Empirically: 66% true (Table 3). -/
+/-- *If A were down, the light would be off* is true at the actual world: the closest A-down
+world is `du`. -/
 theorem aDn_off_at_uu :
     universalCounterfactual hammingSim aDn lightOff .uu := by decide
 
-/-- **Prediction 2**: `B̅ > OFF` is true at `uu`. By the symmetric
-    argument. Empirically: 65% true (Table 3). -/
+/-- *If B were down, the light would be off* is true at the actual world. -/
 theorem bDn_off_at_uu :
     universalCounterfactual hammingSim bDn lightOff .uu := by decide
 
-/-- **Prediction 3**: `A̅ ∨ B̅ > OFF` is true at `uu`. The closest
-    A̅ ∨ B̅-worlds are `{ud, du}` (both at Hamming distance 1), and the
-    light is off in both. Empirically: 69% true (Table 3). -/
+/-- *If A or B were down, the light would be off* is true at the actual world: the closest
+worlds are `ud` and `du`. -/
 theorem aOrBdn_off_at_uu :
     universalCounterfactual hammingSim aOrBdn lightOff .uu := by decide
 
-/-- **Prediction 4 (the falsified one)**: `¬(A ∧ B) > OFF` is *also*
-    predicted true at `uu`, since `¬(A ∧ B)` and `A̅ ∨ B̅` are
-    de-Morgan equivalent. **Empirically: only 22% true (Table 3).**
-
-    This is the central empirical contrast of
-    [ciardelli-zhang-champollion-2018]: a truth-conditional
-    semantics combined with minimal change cannot reproduce the sharp
-    divergence between the two predictions, since the two antecedents
-    are forced to behave identically. -/
+/-- *If A and B were not both up, the light would be off* is predicted true at the actual world,
+the antecedent being equivalent to the disjunction; participants judged it true only by a
+minority (Table 3). -/
 theorem notBothUp_off_at_uu :
     universalCounterfactual hammingSim notBothUp lightOff .uu := by decide
 
-/-! ### Same falsified prediction under selectional and homogeneity
-
-[ciardelli-zhang-champollion-2018]'s argument targets *any*
-minimal-change semantics. Both `selectionalCounterfactual` (Stalnaker
-+ supervaluation) and `homogeneityCounterfactual` (von Fintel/Križ)
-share the same closest-worlds substrate as `universalCounterfactual`,
-and so make the same falsified prediction on the switches scenario. -/
-
-/-- **Selectional CF** also predicts `¬(A ∧ B) > OFF` true at `uu`. -/
+/-- The selectional counterfactual makes the same prediction. -/
 theorem selectional_notBothUp_off_at_uu :
     selectionalCounterfactual hammingSim notBothUp lightOff .uu = .true := by
   decide
 
-/-- **Homogeneity CF** also predicts `¬(A ∧ B) > OFF` true at `uu`,
-    with satisfied presupposition (the closest worlds are not mixed
-    on `lightOff`). -/
+/-- The homogeneity counterfactual makes the same prediction, with its presupposition satisfied.
+-/
 theorem homogeneity_notBothUp_off_at_uu :
     homogeneityCounterfactual hammingSim notBothUp lightOff .uu =
       { presupposition := .satisfied, assertion := some true } := by
   decide
 
-/-! ## Abstract minimal-change forcing ([ciardelli-zhang-champollion-2018] §1.2, p. 582)
+/-! ### Minimal change forces the equivalence (§1.2) -/
 
-The concrete predictions above used a specific similarity ordering. The
-following theorem strengthens the argument: for *any* similarity
-ordering whatsoever, if both `A̅ > OFF` and `B̅ > OFF` are true at a
-world, then `¬(A ∧ B) > OFF` is forced true at that world. So there is
-no choice of similarity that vindicates the empirical pattern — the
-fault lies with the minimal-change architecture itself. -/
-
-/-! ### The generic structural argument
-
-CZC's §1.2 proof actually targets *any* operator definable as
-"every closest A-world satisfies B". We expose the generic version
-first; the universal/selectional/homogeneity instantiations below all
-collapse to it. -/
-
-/-- **Generic minimal-change forcing**: for any similarity ordering and
-    any consequent predicate `B`, joint truth of "every closest aDn-world
-    is B" and "every closest bDn-world is B" entails "every closest
-    notBothUp-world is B".
-
-    This is the operator-agnostic core of CZC §1.2 p. 582. The structural
-    fact is `SimilarityOrdering.mem_closestWorlds_of_subset`: a closest
-    `notBothUp`-world that happens to be `aDn` is also a closest
-    `aDn`-world (since `aDn ⊆ notBothUp` as Finsets), so `h_a` applies;
-    symmetric for `bDn`. -/
+/-- For any similarity ordering and consequent `B`, if every closest A-down world and every
+closest B-down world is `B`, so is every closest not-both-up world: such a world is A-down or
+B-down, and then a closest world of that antecedent
+(`SimilarityOrdering.mem_closestWorlds_of_subset`). -/
 theorem closestWorlds_predicate_forces_notBothUp
     (sim : SimilarityOrdering World) (w₀ : World)
     (B : World → Prop) [DecidablePred B]
@@ -292,17 +165,7 @@ theorem closestWorlds_predicate_forces_notBothUp
     exact h_b w (sim.mem_closestWorlds_of_subset h_bDn_sub hw
       (Finset.mem_filter.mpr ⟨Finset.mem_univ _, hwB⟩))
 
-/-! ### Operator-specific corollaries
-
-All three of `universalCounterfactual`, `selectionalCounterfactual`,
-and `homogeneityCounterfactual` reduce their "true" verdict to the
-same `∀ w' ∈ closestWorlds, B w'` condition (the first `if` branch in
-each definition). The structural lemma above therefore applies
-verbatim, only differing in how each operator packages its truth value. -/
-
-/-- **Universal CF version** (Lewis/Stalnaker). Direct corollary of the
-    generic lemma since `universalCounterfactual` *is* the universal
-    quantifier over closest worlds. -/
+/-- The universal counterfactual is the quantifier over closest worlds. -/
 theorem minimal_change_forces_notBothUp_off
     (sim : SimilarityOrdering World) (w₀ : World)
     (h_a : universalCounterfactual sim aDn lightOff w₀)
@@ -310,9 +173,6 @@ theorem minimal_change_forces_notBothUp_off
     universalCounterfactual sim notBothUp lightOff w₀ :=
   closestWorlds_predicate_forces_notBothUp sim w₀ lightOff h_a h_b
 
-/-- The "true"-verdict condition for `selectionalCounterfactual` is
-    exactly the closest-worlds universal quantifier (the first `if`
-    branch in its definition). -/
 private theorem selectional_eq_true_iff
     (sim : SimilarityOrdering World) (A B : World → Prop)
     [DecidablePred A] [DecidablePred B] (w : World) :
@@ -327,8 +187,6 @@ private theorem selectional_eq_true_iff
   · intro h
     rw [if_pos h]
 
-/-- The "true"-verdict condition for `homogeneityCounterfactual` is
-    likewise the closest-worlds universal quantifier. -/
 private theorem homogeneity_eq_true_iff
     (sim : SimilarityOrdering World) (A B : World → Prop)
     [DecidablePred A] [DecidablePred B] (w : World) :
@@ -344,9 +202,7 @@ private theorem homogeneity_eq_true_iff
   · intro h
     rw [if_pos h]
 
-/-- **Selectional CF version** (Stalnaker + supervaluation). When both
-    simple counterfactuals return `.true` (every closest world is OFF),
-    so does the disjunctive-antecedent counterfactual. -/
+/-- The selectional counterfactual's true verdict is the same quantifier. -/
 theorem selectional_minimal_change_forces_notBothUp_off
     (sim : SimilarityOrdering World) (w₀ : World)
     (h_a : selectionalCounterfactual sim aDn lightOff w₀ = .true)
@@ -357,10 +213,8 @@ theorem selectional_minimal_change_forces_notBothUp_off
       ((selectional_eq_true_iff sim aDn lightOff w₀).mp h_a)
       ((selectional_eq_true_iff sim bDn lightOff w₀).mp h_b))
 
-/-- **Homogeneity CF version** (von Fintel/Križ). When both simple
-    counterfactuals satisfy their presupposition with `assertion = some
-    true` (every closest world is OFF), so does the disjunctive-
-    antecedent version. -/
+/-- The homogeneity counterfactual's true verdict, with its presupposition satisfied, is the
+same quantifier. -/
 theorem homogeneity_minimal_change_forces_notBothUp_off
     (sim : SimilarityOrdering World) (w₀ : World)
     (h_a : homogeneityCounterfactual sim aDn lightOff w₀ =
@@ -374,29 +228,21 @@ theorem homogeneity_minimal_change_forces_notBothUp_off
       ((homogeneity_eq_true_iff sim aDn lightOff w₀).mp h_a)
       ((homogeneity_eq_true_iff sim bDn lightOff w₀).mp h_b))
 
-/-! ## Empirical results (Table 3, main experiment)
+/-! ### The main experiment (Table 3) -/
 
-The exact "True" proportions of Table 3 (count judged true over responses).
-The paper's block structure: `A̅ > OFF`, `B̅ > OFF`, and `A̅ ∨ B̅ > OFF` were
-judged true by a wide majority; `¬(A ∧ B) > OFF` and `¬(A ∧ B) > ON` were
-not (within-block differences not significant, across-block differences
-highly significant). -/
-
-/-- Table 3 "True" proportion for `A̅ > OFF`. -/
+/-- The proportion judged true of *if A were down, the light would be off*. -/
 def trueRate_aDn_off : ℚ := 169 / 256
-/-- Table 3 "True" proportion for `B̅ > OFF`. -/
+/-- The proportion judged true of *if B were down, the light would be off*. -/
 def trueRate_bDn_off : ℚ := 153 / 235
-/-- Table 3 "True" proportion for `A̅ ∨ B̅ > OFF`. -/
+/-- The proportion judged true of *if A or B were down, the light would be off*. -/
 def trueRate_aOrBdn_off : ℚ := 251 / 362
-/-- Table 3 "True" proportion for `¬(A ∧ B) > OFF`. -/
+/-- The proportion judged true of *if A and B were not both up, the light would be off*. -/
 def trueRate_notBothUp_off : ℚ := 82 / 372
-/-- Table 3 "True" proportion for `¬(A ∧ B) > ON`. -/
+/-- The proportion judged true of *if A and B were not both up, the light would be on*. -/
 def trueRate_notBothUp_on : ℚ := 43 / 200
 
-/-- Table 3's block pattern: each first-block sentence carries a true-majority,
-    neither `¬(A ∧ B)` sentence does — "while both `A̅ > OFF` and `B̅ > OFF` were
-    judged true by a majority of participants, `¬(A ∧ B) > OFF` was not,
-    contrary to the predictions of the minimal change requirement". -/
+/-- The first three sentences were judged true by a majority and the two not-both-up sentences
+were not. -/
 theorem table3_pattern :
     (1 / 2 < trueRate_aDn_off ∧ 1 / 2 < trueRate_bDn_off ∧
       1 / 2 < trueRate_aOrBdn_off) ∧
@@ -405,10 +251,8 @@ theorem table3_pattern :
     norm_num [trueRate_aDn_off, trueRate_bDn_off, trueRate_aOrBdn_off,
       trueRate_notBothUp_off, trueRate_notBothUp_on]
 
-/-- The de-Morgan pair diverges: `A̅ ∨ B̅ > OFF` was judged true more often
-    than the truth-conditionally equivalent `¬(A ∧ B) > OFF` (the difference
-    the paper reports as highly significant) — the two antecedents have
-    different truth conditions. -/
+/-- The De Morgan pair diverges: the disjunctive antecedent was judged true more often than its
+equivalent. -/
 theorem deMorgan_antecedents_diverge :
     trueRate_notBothUp_off < trueRate_aOrBdn_off := by
   norm_num [trueRate_aOrBdn_off, trueRate_notBothUp_off]


### PR DESCRIPTION
Module docstrings of CiardelliGroenendijkRoelofsen2018, CiardelliGuerrini2026 and CiardelliZhangChampollion2018 cut to two prose paragraphs plus references, per the study register; section headers to one line, declaration docstrings to at most two sentences; the CGR substrate table folded into prose and its unused imports dropped. Follow-up to #2614–#2616.