### PR TITLE
refactor(Studies/CitkoGracaninYuksek2025): PF reduction on planar objects

### DIFF
--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -1,1010 +1,313 @@
-import Linglib.Syntax.Minimalist.SyntacticObject.Build
-import Linglib.Syntax.Minimalist.Economy.Basic
-import Linglib.Syntax.Question
+import Linglib.Syntax.Minimalist.Linearization.Chain
+
 /-!
-# Economy in PF Reduction
-[citko-gracanin-yuksek-2025]
+# Citko and Gračanin-Yuksek (2025): Economy in PF reduction
 
-Coordinated wh-questions (CWHs) and coordinated sluices (CSs) are two
-PF-reduced constructions with wh-phrase remnants. Despite superficial
-similarity, they differ in structure, derivational cost, and empirical
-properties. Economy governs the choice between ellipsis and
-multidominance as the PF reduction mechanism.
+[citko-gracanin-yuksek-2025] argue that economy chooses between the two mechanisms of PF
+reduction, multidominance and ellipsis: among the derivations that yield the same string and the
+same interpretation and violate no independent principle, the one with the fewest lexical
+resources and operations wins. A coordinated wh-question (*What and when should you teach?*)
+keeps each wh-phrase in its own conjunct, the conjuncts sharing their heads but not their
+phrases. Building two clauses and eliding one costs more lexical items and an ellipsis; sharing
+the whole C′ is cheaper still, but sends both wh-phrases through one vP edge, which the ban on
+multiple wh-fronting excludes in English. A coordinated sluice (*I forgot what and when*) does
+share the C′: both conjuncts must be reduced, so an ellipsis is unavoidable, and one [E] on the
+shared C elides the shared TP once, at the price of a vP edge with two wh-specifiers. The ban on
+multiple wh-fronting is therefore restated at PF as an asterisk on a phase edge with several
+wh-specifiers, parameterised by edge: the elided vP edge is harmless, and multiple sluicing
+divides speakers by whether the surviving CP edge counts.
 
-## Key Claims
+Pronunciation Economy bans ellipsis with no effect on pronunciation. It excludes the sluice with
+the coordinated-question shape, where one shared [E] complementizer has two TP complements and
+the second deletion silences nothing new, and it forces the nonpaired sluice to carry two
+complementizers, only one bearing [E]. In right node raising the same economy prefers sharing
+the pivot to building it twice and, when the verbs match, sharing the verb phrase to eliding it.
 
-1. CWHs use **non-bulk-sharing MD**: each conjunct CP contains one
-   wh-phrase; functional heads (C, T) are multiply dominated.
-   No ellipsis is involved.
+Each candidate is a planar object of `Linearization/Chain.lean`: a token at two positions is
+shared, a moved wh-phrase leaves indexed traces at the vP edge and its base position, and the
+coordinator is left out, so a string is its conjuncts' words. The predictions decide: the
+pronounced strings, the unbound traces that carry the paired reading, the asterisks, and the
+costs the winners beat.
 
-2. CSs use **bulk-sharing MD + ellipsis**: the entire C' is shared
-   between conjuncts; both wh-phrases originate inside the shared vP.
-   The E-feature on C triggers TP deletion (cf. `FeatureVal.ellipsis`
-   in `Core/Features.lean`, which models this E-feature).
+## References
 
-3. **Economy selects the structure**: MD is preferred over ellipsis
-   (fewer operations, fewer lexical items). Bulk-sharing MD is more
-   economical than non-bulk-sharing, but is blocked for CWHs by the
-   MWF parameter. CSs can't have the CWH structure because of
-   Pronunciation Economy.
-
-## Empirical Contrasts
-
-- CWHs ban coordination of obligatory wh-arguments;
-  CSs allow it.
-- CWHs ban wh-object + wh-adjunct with obligatorily transitive verbs;
-  CSs allow it.
-- CWHs only allow nonpaired readings;
-  CSs allow paired readings (with obligatorily transitive verbs)
-  and nonpaired readings (with optionally transitive verbs).
-
-## Substrate engagement
-
-- MD primitives (`PFReductionMechanism`, `MDSharing`, `SharedNode`,
-  `PFReducedCoordination`) are imported from
-  `Syntax/Minimalist/Multidominance.lean` (anchored on Citko
-  2014). They were briefly inlined here while the substrate file was
-  absent; restored to substrate for cross-paper reuse.
-- MWF parameter substrate (`MWFParameter`, `PhaseEdge`, `EdgeAsterisk`,
-  `MWFViolation`, `EllipsisRepairsMWF`) lives in
-  `Typology/Question.lean`. Cross-linguistic data (Bulgarian, German,
-  Greek) and the intra-English variety A/B split — paper-specific to
-  [citko-gracanin-yuksek-2025] — live in §2 over that substrate.
-- Pronunciation Economy is the **per-operation** primitive
-  `pronunciationEconomy : List PFOperation → Prop` from
-  `Syntax/Minimalist/Economy/Basic.lean`. Paper p. 32 ex (45c) needs
-  per-op vacuity (a derivation with one real deletion + one vacuous
-  deletion violates), which a whole-derivation `pfBefore ≠ pfAfter`
-  check could not express.
-
-## Integration
-
-- CSs are coordinated sluices — each conjunct of a CS is a sluice.
-  §1b decomposes CS examples into standalone component sluices.
-- The MWF parameter (`Typology/Question.lean`) classifies languages:
-  non-MWF languages (English) ban multiple wh-fronting in questions.
-- RNR (§9) demonstrates that economy can force BOTH ellipsis and MD
-  in a single derivation ([belk-neeleman-philip-2023],
-  [barros-vicente-2011]).
+* [B. Citko and M. Gračanin-Yuksek, *Economy in PF reduction* (2025)][citko-gracanin-yuksek-2025]
+* [J. Merchant, *The Syntax of Silence* (2001)][merchant-2001]
+* [Z. Belk, A. Neeleman and J. Philip, *What divides, and what unites, right-node raising*
+  (2023)][belk-neeleman-philip-2023]
 -/
 
 namespace CitkoGracaninYuksek2025
 
-open Minimalist SyntacticObject
-open Syntax.Question
+open Minimalist RoseTree RoseTree.Pathed
+open Syntax.Question (MWFParameter)
 
-/-! ### Multidominance (relocated from Minimalist/Multidominance.lean)
+/-! ### The lexicon -/
 
-A multidominance (MD) structure is a syntactic object built once that is
-structurally accessible from two (or more) dominating nodes. At PF, it
-linearizes once. MD is one of the two main mechanisms for producing
-PF-reduced representations (representations where some material is
-interpreted but not pronounced); the other is ellipsis. [citko-2014] [wilder-2008]
+/-- A token: a category, its selection, its form, and the wh and [E] features. -/
+def tok (id : ℕ) (cat : Cat) (sel : SelStack := []) (phon : String := "") (wh : Bool := false)
+    (ellipsis : Bool := false) : LIToken :=
+  ⟨LexicalItem.simple cat sel phon wh ellipsis, id⟩
 
-The MD primitives any MD-using analysis needs:
+def what := tok 1 .D (phon := "what") (wh := true)
+def when := tok 2 .P (phon := "when") (wh := true)
+def who := tok 3 .D (phon := "who") (wh := true)
+def you := tok 4 .D (phon := "you")
+def T := tok 5 .T [.v]
+def v := tok 6 .v [.V]
+def teach := tok 7 .V [.D] "teach"
+def should := tok 8 .C [.T] "should"
+def will := tok 9 .C [.T] "will"
+/-- The null complementizer, and a second one. -/
+def c := tok 10 .C [.T]
+def c' := tok 11 .C [.T]
+/-- The null complementizer bearing [E], and a second one. -/
+def cE := tok 12 .C [.T] (ellipsis := true)
+def cE' := tok 13 .C [.T] (ellipsis := true)
+/-- The tokens a second, separately built clause draws. -/
+def you' := tok 14 .D (phon := "you")
+def T' := tok 15 .T [.v]
+def v' := tok 16 .v [.V]
+def teach' := tok 17 .V [.D] "teach"
+/-- The auxiliary in T. -/
+def shouldT := tok 18 .T [.v] "should"
+def it := tok 19 .D (phon := "it")
+def saw := tok 20 .V [.D] "saw"
 
-- `PFReductionMechanism` — the two PF-reduction mechanisms (ellipsis vs
-  multidominance);
-- `MDSharing` — bulk vs non-bulk sharing in coordination;
-- `SharedNode` — a multiply-dominated node + its category + whether it
-  is pronounced;
-- `PFReducedCoordination` — a coordinate &P with PF reduction.
+/-! ### The candidate objects -/
 
-Anchored on [citko-2014] (textbook treatment of parallel-Merge MD)
-and [wilder-2008] (constituent-sharing flavor).
+/-- `[CP wh [C′ c [TP subj [T′ T [vP wh [v′ v VP]]]]]]`: the wh-phrase moved through the edge of
+vP. -/
+def clause (wh c subj T v : LIToken) (VP : RoseTree ChainLabel) : RoseTree ChainLabel :=
+  nodeC (leafC wh) (nodeC (leafC c)
+    (nodeC (leafC subj) (nodeC (leafC T) (nodeC (traceC wh) (nodeC (leafC v) VP)))))
 
-## Convention notes
+/-- Non-bulk sharing under the complementizers `c₁` and `c₂`: each wh-phrase in its own
+conjunct, the subject, T, v and verb shared ((10b), (14), (16b), (38d), (45b), (46b)). -/
+def nonBulk (c₁ c₂ : LIToken) : RoseTree ChainLabel :=
+  nodeC (clause what c₁ you T v (nodeC (leafC teach) (traceC what)))
+    (clause when c₂ you T v (nodeC (leafC teach) (traceC when)))
 
-- This does **not** commit to a particular MD flavor (parallel-Merge
-  vs constituent-sharing vs 3-D phrase structure). `SharedNode` records
-  the multiply-dominated node abstractly; specific MD theories
-  instantiate the dominance/sharing relation via their own apparatus.
-- `MDSharing` was renamed from `SharingType` to avoid a bare-name
-  collision with a since-dissolved DG module's `SharingType` (which
-  classified *extraction symmetry*, not constituent sharing); the
-  clearer name stays.
-- `UsesMD` / `UsesEllipsis` / `UsesBoth` are `Prop` with decidability
-  instances (per `feedback_no_intrinsic_bool` discipline); decide-checked
-  consumers continue to work.
--/
+/-- Bulk sharing: one C′ under both wh-phrases, both of which moved through its vP edge ((12b),
+(20b)). -/
+def bulk (c : LIToken) : RoseTree ChainLabel :=
+  let c' := nodeC (leafC c) (nodeC (leafC you) (nodeC (leafC T) (nodeC (traceC what)
+    (nodeC (traceC when)
+      (nodeC (leafC v) (nodeC (nodeC (leafC teach) (traceC what)) (traceC when)))))))
+  nodeC (nodeC (leafC what) c') (nodeC (leafC when) c')
 
-/-- The two mechanisms of PF reduction.
+/-- Footnote 21's alternative to `bulk`: a shared TP under two complementizers. -/
+def bulkTP (c₁ c₂ : LIToken) : RoseTree ChainLabel :=
+  let tp := nodeC (leafC you) (nodeC (leafC T) (nodeC (traceC what)
+    (nodeC (traceC when)
+      (nodeC (leafC v) (nodeC (nodeC (leafC teach) (traceC what)) (traceC when))))))
+  nodeC (nodeC (leafC what) (nodeC (leafC c₁) tp)) (nodeC (leafC when) (nodeC (leafC c₂) tp))
 
-    Both produce representations where material is interpreted but not
-    pronounced. Economy (`Syntax/Minimalist/Economy/Basic.lean`)
-    governs the choice between them. -/
-inductive PFReductionMechanism where
-  /-- E-feature on a functional head triggers deletion of its complement
-      at PF. The deleted material is built in full during the derivation. -/
-  | ellipsis
-  /-- A syntactic object is built once and shared between two dominating
-      nodes. Pronounced at one position only. -/
-  | multidominance
-  deriving Repr, DecidableEq
+/-- Two clauses from separate tokens, the first elided under its [E] complementizer with its
+auxiliary in T, as the Sluicing-COMP generalization requires of a sluice: the ellipsis analysis
+of the coordinated wh-question (11b). -/
+def cwhEllipsis : RoseTree ChainLabel :=
+  nodeC (nodeC (leafC what) (nodeC (leafC cE) (nodeC (leafC you) (nodeC (leafC shouldT)
+      (nodeC (traceC what) (nodeC (leafC v) (nodeC (leafC teach) (traceC what))))))))
+    (clause when should you' T' v' (nodeC (leafC teach') (traceC when)))
 
-/-- How material is shared between conjuncts in an MD coordination.
+/-- Two clauses from separate tokens, both elided, the second's object the pronoun of vehicle
+change: the double-ellipsis analysis of the coordinated sluice (19b). -/
+def csEllipsis : RoseTree ChainLabel :=
+  nodeC (clause what cE you T v (nodeC (leafC teach) (traceC what)))
+    (clause when cE' you' T' v' (nodeC (nodeC (leafC teach') (leafC it)) (traceC when)))
 
-    The empirical motivation is [citko-gracanin-yuksek-2025]:
-    coordinated wh-questions use non-bulk-sharing (individual heads
-    shared), while coordinated sluices use bulk-sharing (entire C'
-    shared). The two sharing modes derive different syntactic and
-    interpretive properties.
+/-- A multiple question, both wh-phrases fronted through the vP edge: (28b), and the multiple
+sluice (29b) under an [E] complementizer. -/
+def multipleQuestion (c : LIToken) : RoseTree ChainLabel :=
+  nodeC (leafC who) (nodeC (leafC what) (nodeC (leafC c) (nodeC (traceC who) (nodeC (leafC T)
+    (nodeC (traceC who)
+      (nodeC (traceC what) (nodeC (leafC v) (nodeC (leafC saw) (traceC what)))))))))
 
-    Named `MDSharing` (not `SharingType`) for constituent sharing, as
-    against extraction symmetry. -/
-inductive MDSharing where
-  /-- Individual functional heads shared between conjuncts. Each conjunct
-      remains a separate full phrase; only specific heads (e.g., C, T)
-      are multiply dominated. -/
-  | nonBulk
-  /-- An entire constituent is shared between conjuncts. Both conjuncts
-      dominate the same subtree, so they share all material inside it
-      (C, TP, vP, VP, ...). -/
-  | bulk
-  deriving Repr, DecidableEq
+/-- The coordinated wh-question (10b), its complementizer shared. -/
+abbrev cwh := nonBulk should should
+/-- Its bulk-sharing rival (12b). -/
+abbrev cwhBulk := bulk should
+/-- Its rival with a null complementizer in the first conjunct (14). -/
+abbrev cwhNullC := nonBulk c should
+/-- Footnote 15: the null complementizer in the second conjunct instead. -/
+abbrev cwhNullCSecond := nonBulk should c
+/-- The embedded coordinated wh-question (15a) with its null complementizer shared, and with two
+(15b). -/
+abbrev cwhEmbedded := nonBulk c c
+abbrev cwhEmbeddedTwoC := nonBulk c c'
+/-- Two pronounced complementizers (16b). -/
+abbrev cwhTwoAux := nonBulk should will
+/-- The coordinated sluice (20b), (26b), (38b). -/
+abbrev cs := bulk cE
+/-- Its rival with two [E] complementizers over a shared TP (footnote 21). -/
+abbrev csTwoC := bulkTP cE cE'
+/-- The coordinated sluice with the shape of the coordinated wh-question, one shared [E]
+complementizer over two TPs ((38d), (45c)). -/
+abbrev csSharedC := nonBulk cE cE
+/-- Two [E] complementizers (45b). -/
+abbrev csnrTwoE := nonBulk cE cE'
+/-- The nonpaired coordinated sluice (46b): two complementizers, one bearing [E]. -/
+abbrev csnr := nonBulk cE c
 
-/-- A node shared between two conjuncts in a coordination structure.
+/-- The paired reading: the second conjunct holds an unbound trace of the first conjunct's
+wh-phrase, the copy that vehicle change reads as an E-type pronoun (footnote 20). -/
+def Paired (t : RoseTree ChainLabel) : Prop :=
+  ∃ x ∈ unboundTraces t, x.2 = what ∧ x.1.head? = some 1
 
-    The shared node is built once but is structurally accessible from
-    both `parent1` and `parent2`. At PF, it is linearized once. -/
-structure SharedNode where
-  /-- The multiply dominated node. -/
-  node : SyntacticObject
-  /-- Category of the shared node, when labelled. -/
-  category : Option Cat
-  /-- The shared node has PF content (vs. is silent). -/
-  pronounced : Bool
-  deriving Repr, DecidableEq
+instance : DecidablePred Paired := λ _ => inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-/-- A coordination structure with PF reduction.
+/-! ### The multiple-wh-fronting parameter (27) by language -/
 
-    Models a coordinate &P where material is either multiply dominated
-    (shared between conjuncts) or elided by an E-feature.
+/-- English variety A: the asterisk lands on both phase edges, so multiple sluicing crashes. -/
+def englishA : MWFParameter := .nonFrontsBothEdges
+/-- English variety B: the asterisk lands on the vP edge only, so multiple sluicing converges. -/
+def englishB : MWFParameter := .nonFrontsVPOnly
+/-- German and Greek: no multiple wh-fronting (30), multiple sluicing (31). -/
+def german : MWFParameter := .nonFrontsVPOnly
+def greek : MWFParameter := .nonFrontsVPOnly
+def bulgarian : MWFParameter := .fronts
+def romanian : MWFParameter := .fronts
 
-    **Substrate note (post-MCB Phase 1.0).** The `conjunct1` / `conjunct2`
-    field names are **stipulated planar labels** at the coord-structure
-    *meta*-level, NOT inherited from the SyntacticObject substrate (which is nonplanar
-    via FreeCommMagma — see `Minimalist.merge_comm`). The first-vs-second
-    conjunct distinction tracked by these fields is a *coordination-
-    specific stipulation* about which conjunct hosts the shared / deleted
-    material, on the asymmetric coordinate structure both accounts of category mismatch assume.
-    Phase 2+: harmonize with [citko-2011]'s symmetric-merge
-    multidominance framework, where conjunct ordering is genuinely
-    a multiset operation. -/
-structure PFReducedCoordination where
-  /-- First conjunct. Planar label is stipulated at coord-structure level
-      (not inherited from substrate). -/
-  conjunct1 : SyntacticObject
-  /-- Second conjunct. -/
-  conjunct2 : SyntacticObject
-  /-- PF reduction mechanism(s) used. -/
-  mechanisms : List PFReductionMechanism
-  /-- Mode of sharing (for MD structures). -/
-  sharing : Option MDSharing
-  /-- Nodes that are shared or deleted. -/
-  sharedNodes : List SharedNode
-  /-- PF output after reduction. -/
-  pfOutput : List String
-  deriving Repr, DecidableEq
+/-! ### Coordinated wh-questions (§3.1) -/
 
-namespace PFReducedCoordination
-
-/-- Does this coordination use multidominance? -/
-def UsesMD (c : PFReducedCoordination) : Prop :=
-  PFReductionMechanism.multidominance ∈ c.mechanisms
-
-instance (c : PFReducedCoordination) : Decidable c.UsesMD := by
-  unfold UsesMD; infer_instance
-
-/-- Does this coordination use ellipsis? -/
-def UsesEllipsis (c : PFReducedCoordination) : Prop :=
-  PFReductionMechanism.ellipsis ∈ c.mechanisms
-
-instance (c : PFReducedCoordination) : Decidable c.UsesEllipsis := by
-  unfold UsesEllipsis; infer_instance
-
-/-- Does this coordination use both MD and ellipsis? -/
-def UsesBoth (c : PFReducedCoordination) : Prop :=
-  c.UsesMD ∧ c.UsesEllipsis
-
-instance (c : PFReducedCoordination) : Decidable c.UsesBoth := by
-  unfold UsesBoth; infer_instance
-
-end PFReducedCoordination
-
--- ============================================================================
--- § 1: Construction Types and Empirical Data
--- ============================================================================
-
-/-- The two PF-reduced wh-coordination constructions. -/
-inductive WHCoordType where
-  /-- Coordinated wh-question: "What and when did John teach?" -/
-  | CWH
-  /-- Coordinated sluice: "I forgot what and when." -/
-  | CS
-  deriving Repr, DecidableEq
-
-/-- An empirical datum contrasting CWHs and CSs. -/
-structure WHCoordDatum where
-  sentence : String
-  construction : WHCoordType
-  whPhrases : List String
-  grammatical : Bool
-  notes : String := ""
-  deriving Repr
-
--- CWH examples
-
-def cwh_basic : WHCoordDatum :=
-  { sentence := "What and when did John teach?"
-  , construction := .CWH
-  , whPhrases := ["what", "when"]
-  , grammatical := true }
-
-/-- CWHs ban coordination of obligatory wh-arguments (ex 5a). -/
-def cwh_obligatory_args_banned : WHCoordDatum :=
-  { sentence := "*What and to whom did John give?"
-  , construction := .CWH
-  , whPhrases := ["what", "to whom"]
-  , grammatical := false
-  , notes := "Both are obligatory arguments of 'give'; banned in CWHs" }
-
-/-- CWHs ban wh-object + wh-adjunct with obligatorily transitive verbs (ex 6a).
-    Distinct from (5a): here only one wh-phrase is an obligatory argument;
-    the other is an adjunct. The ban persists because the verb ('buy')
-    is obligatorily transitive. -/
-def cwh_obj_adjunct_banned : WHCoordDatum :=
-  { sentence := "*What and when did John buy?"
-  , construction := .CWH
-  , whPhrases := ["what", "when"]
-  , grammatical := false
-  , notes := "Wh-object + wh-adjunct; 'buy' is obligatorily transitive" }
-
--- CS examples
-
-def cs_basic : WHCoordDatum :=
-  { sentence := "John taught something, but I forgot what and when."
-  , construction := .CS
-  , whPhrases := ["what", "when"]
-  , grammatical := true }
-
-/-- CSs allow coordination of obligatory wh-arguments (ex 5b). -/
-def cs_obligatory_args_allowed : WHCoordDatum :=
-  { sentence := "John gave something to someone, but I forgot what and to whom."
-  , construction := .CS
-  , whPhrases := ["what", "to whom"]
-  , grammatical := true
-  , notes := "Both obligatory args; allowed in CSs" }
-
-/-- CSs allow wh-object + wh-adjunct coordination (ex 6b). -/
-def cs_obj_adjunct_allowed : WHCoordDatum :=
-  { sentence := "John bought something at some point, but I forgot what and when."
-  , construction := .CS
-  , whPhrases := ["what", "when"]
-  , grammatical := true
-  , notes := "Wh-object + wh-adjunct; allowed in CSs even with 'buy'" }
-
-/-- All CWH/CS empirical contrasts as a single drift-sentry table. Replaces
-    seven trivial `rfl` readouts (`cwh_bans_obligatory_args` etc.) with one
-    decide-checked aggregate that catches drift in any row. -/
-def whCoordContrastTable : List (WHCoordDatum × Bool) :=
-  [ (cwh_basic, true)
-  , (cwh_obligatory_args_banned, false)
-  , (cwh_obj_adjunct_banned, false)
-  , (cs_basic, true)
-  , (cs_obligatory_args_allowed, true)
-  , (cs_obj_adjunct_allowed, true) ]
-
-theorem whCoordContrastTable_consistent :
-    whCoordContrastTable.all (fun ⟨d, expected⟩ => d.grammatical == expected) = true := by
+theorem cwh_pf : pfPhon cwh = ["what", "when", "should", "you", "teach"] := by decide
+theorem cwhEllipsis_pf : pfPhon cwhEllipsis = pfPhon cwh := by decide
+theorem cwhBulk_pf : pfPhon cwhBulk = pfPhon cwh := by decide
+theorem cwhNullC_pf : pfPhon cwhNullC = pfPhon cwh := by decide
+/-- Footnote 15: a pronounced complementizer in the first conjunct only precedes the second
+wh-phrase. -/
+theorem cwhNullCSecond_pf : pfPhon cwhNullCSecond = ["what", "should", "when", "you", "teach"] := by
+  decide
+theorem cwhTwoAux_pf : pfPhon cwhTwoAux = ["what", "should", "when", "will", "you", "teach"] := by
   decide
 
--- ============================================================================
--- § 1a: Reading Typology
--- ============================================================================
-
-/-- Reading type for wh-coordination. -/
-inductive ReadingType where
-  /-- Each wh-phrase ranges over a single value (n-tuple as the answer). -/
-  | paired
-  /-- Each wh-phrase ranges over multiple values (cross-product answer). -/
-  | nonpaired
-  deriving Repr, DecidableEq
-
-/-- Reading availability datum. -/
-structure ReadingDatum where
-  construction : WHCoordType
-  reading : ReadingType
-  available : Bool
-  notes : String := ""
-  deriving Repr
-
-/-- CWHs: only nonpaired reading available (ex 8a). -/
-def cwh_nonpaired : ReadingDatum :=
-  { construction := .CWH
-  , reading := .nonpaired
-  , available := true
-  , notes := "Each wh-phrase ranges over multiple values" }
-
-/-- CWHs: paired reading unavailable (ex 8a). -/
-def cwh_no_paired : ReadingDatum :=
-  { construction := .CWH
-  , reading := .paired
-  , available := false
-  , notes := "Single-pair reading is unavailable for CWHs" }
-
-/-- CSs: paired reading available with obligatorily transitive verbs (ex 8b).
-    The bulk-sharing CS structure puts both wh-phrases inside a single vP. -/
-def cs_paired : ReadingDatum :=
-  { construction := .CS
-  , reading := .paired
-  , available := true
-  , notes := "Both wh-phrases share scope inside the bulk-shared vP" }
-
-/-- CSs: nonpaired reading available with optionally transitive verbs (§6.1, ex 43).
-    With optionally transitive verbs, the CWH-style structure becomes
-    available, yielding a nonpaired reading. -/
-def cs_nonpaired : ReadingDatum :=
-  { construction := .CS
-  , reading := .nonpaired
-  , available := true
-  , notes := "Available with optionally transitive verbs (CWH-style structure)" }
-
-/-- Reading availability drift sentry. Replaces three rfl-readouts. -/
-def readingTable : List ReadingDatum :=
-  [cwh_nonpaired, cwh_no_paired, cs_paired, cs_nonpaired]
-
-/-- Drift sentry: the four reading datums encode the paper's central
-    paired/nonpaired contrast — CWH bans paired, CS allows both. -/
-theorem readingTable_consistent :
-    cwh_nonpaired.available = true ∧
-    cwh_no_paired.available = false ∧
-    cs_paired.available = true ∧
-    cs_nonpaired.available = true := by decide
-
--- ============================================================================
--- § 1b: Sluicing Decomposition (CSs ≈ coordinated sluices)
--- ============================================================================
-
-/-- One conjunct of a coordinated sluice, recast as a standalone sluice. -/
-structure ComponentSluice where
-  sentence : String
-  whPhrase : String
-  grammatical : Bool := true
-  deriving Repr, DecidableEq
-
-/-- The "what" conjunct of `cs_basic` as a standalone sluice
-    (antecedent "John taught something", correlate "something",
-    elided "John taught"). -/
-def cs_basic_sluice_what : ComponentSluice :=
-  { sentence := "John taught something, but I forgot what."
-  , whPhrase := "what" }
-
-/-- The "when" conjunct of `cs_basic` as a standalone sluice
-    (antecedent "John taught (then)", correlate "(then)",
-    elided "John taught"). -/
-def cs_basic_sluice_when : ComponentSluice :=
-  { sentence := "John taught (then), but I forgot when."
-  , whPhrase := "when" }
-
-/-- Each CS decomposes into sluices: the wh-phrases in a CS are
-    each sluice remnants. -/
-theorem cs_basic_decomposes_into_sluices :
-    cs_basic.whPhrases =
-      [cs_basic_sluice_what.whPhrase, cs_basic_sluice_when.whPhrase] := rfl
-
-/-- Both component sluices are grammatical. -/
-theorem cs_components_grammatical :
-    cs_basic_sluice_what.grammatical = true ∧
-    cs_basic_sluice_when.grammatical = true := ⟨rfl, rfl⟩
-
-/-- The "what" conjunct of `cs_obligatory_args_allowed` (correlate
-    "something", elided "John gave (to someone)"). -/
-def cs_oblig_sluice_what : ComponentSluice :=
-  { sentence := "John gave something to someone, but I forgot what."
-  , whPhrase := "what" }
-
-/-- The "to whom" conjunct of `cs_obligatory_args_allowed` (correlate
-    "to someone", elided "John gave (something)"). -/
-def cs_oblig_sluice_toWhom : ComponentSluice :=
-  { sentence := "John gave something to someone, but I forgot to whom."
-  , whPhrase := "to whom" }
-
-/-- Obligatory-argument CS also decomposes into sluices. -/
-theorem cs_obligatory_decomposes :
-    cs_obligatory_args_allowed.whPhrases =
-      [cs_oblig_sluice_what.whPhrase, cs_oblig_sluice_toWhom.whPhrase] := rfl
-
--- ============================================================================
--- § 2: Cross-linguistic MWF data and the English variety A/B split
--- ============================================================================
-
-/-! Languages vary in whether multiple wh-specifiers at a phase edge are
-tolerable at PF ([rudin-1988], [citko-gracanin-yuksek-2025]). The
-substrate primitives (`MWFParameter`, `PhaseEdge`, `EdgeAsterisk`,
-`MWFViolation`, `EllipsisRepairsMWF`) are in `Typology/Question.lean`;
-this section holds the per-language data and theorems consuming them.
-
-The intra-English variety A/B split is paper-specific to
-[citko-gracanin-yuksek-2025] (p. 19): both varieties are non-MWF in
-matrix questions, but they diverge on multiple sluicing — variety A bans
-it, variety B allows it. The paper *derives* this asymmetry from where
-the PF asterisk lands (vP only vs both vP and CP edges), not as a free
-parameter: variety B is `.nonFrontsVPOnly`, variety A is
-`.nonFrontsBothEdges`. -/
-
-/-- Cross-linguistic MWF datum. Records the parameter setting and an
-    example question. `AllowsMultipleSluicing` is **derived** from the
-    parameter via `EllipsisRepairsMWF`. -/
-structure MWFLanguageDatum where
-  language : String
-  mwfParam : MWFParameter
-  /-- Example multiple wh-question. -/
-  exampleQuestion : String
-  /-- Is the bare multiple-wh question grammatical? -/
-  grammatical : Bool
-  notes : String := ""
-  deriving Repr, DecidableEq
-
-/-- Multiple sluicing is licensed iff vP-edge ellipsis repairs the MWF
-    violation for `n = 2` wh-specifiers. **Derived, not stipulated.** -/
-def MWFLanguageDatum.AllowsMultipleSluicing (d : MWFLanguageDatum) : Prop :=
-  EllipsisRepairsMWF d.mwfParam 2 (vpEdgeDeleted := true)
-
-instance (d : MWFLanguageDatum) : Decidable d.AllowsMultipleSluicing := by
-  unfold MWFLanguageDatum.AllowsMultipleSluicing; infer_instance
-
-/-- Bulgarian: MWF language ([rudin-1988] canonical case). -/
-def bulgarian : MWFLanguageDatum :=
-  { language := "Bulgarian"
-  , mwfParam := .fronts
-  , exampleQuestion := "Koj kakvo e kupil?"
-  , grammatical := true
-  , notes := "All wh-phrases front; [rudin-1988] canonical MWF language" }
-
-/-- German: non-MWF; vP-only asterisk; multiple sluicing repairs.
-    [citko-gracanin-yuksek-2025] ex 31a. -/
-def german : MWFLanguageDatum :=
-  { language := "German"
-  , mwfParam := .nonFrontsVPOnly
-  , exampleQuestion := "*Wer was hat gesehen?"
-  , grammatical := false
-  , notes := "Non-MWF; bans multiple wh-fronting in questions; "
-           ++ "allows multiple sluicing ([citko-gracanin-yuksek-2025] ex 31a)" }
-
-/-- Greek: non-MWF; vP-only asterisk; multiple sluicing repairs.
-    [citko-gracanin-yuksek-2025] ex 31b. -/
-def greek : MWFLanguageDatum :=
-  { language := "Greek"
-  , mwfParam := .nonFrontsVPOnly
-  , exampleQuestion := "*Pços ti efere?"
-  , grammatical := false
-  , notes := "Non-MWF; bans multiple wh-fronting in questions; "
-           ++ "allows multiple sluicing ([citko-gracanin-yuksek-2025] ex 31b)" }
-
-/-- Cross-linguistic MWF table (textbook-consensus subset). -/
-def mwfLanguageTable : List MWFLanguageDatum := [bulgarian, german, greek]
-
-/-- Bulgarian: MWF language → no violations on bare multiple wh. -/
-theorem bulgarian_no_violation : ¬ MWFViolation bulgarian.mwfParam 2 := by decide
-
-/-- German question with two wh-phrases is starred. -/
-theorem german_violates_in_questions : MWFViolation german.mwfParam 2 := by decide
-
-/-- Sluicing repairs in German and Greek (vP-only asterisk eliminated). -/
-theorem german_greek_sluicing_repairs :
-    german.AllowsMultipleSluicing ∧ greek.AllowsMultipleSluicing := by decide
-
-/-- English (default): variety A — both vP and CP asterisks; no sluicing
-    repair. -/
-def english : MWFParameter := .nonFrontsBothEdges
-
-/-- English bans multiple wh-specifiers at a phase edge. -/
-theorem english_bans_multiple_wh : MWFViolation english 2 := by decide
-
-/-- A single wh-specifier is fine in English. -/
-theorem english_allows_single_wh : ¬ MWFViolation english 1 := by decide
-
-/-- English variety A: non-MWF, bans multiple sluicing. The CP-edge
-    asterisk survives ellipsis (vP-edge deletion is not enough). -/
-def english_varietyA : MWFLanguageDatum :=
-  { language := "English (variety A)"
-  , mwfParam := .nonFrontsBothEdges
-  , exampleQuestion := "*Who what saw?"
-  , grammatical := false
-  , notes := "MWF asterisks at BOTH vP and CP edges; ellipsis cannot repair" }
-
-/-- English variety B: non-MWF, allows multiple sluicing. Only the vP
-    edge has the asterisk; vP-edge deletion repairs it. -/
-def english_varietyB : MWFLanguageDatum :=
-  { language := "English (variety B)"
-  , mwfParam := .nonFrontsVPOnly
-  , exampleQuestion := "*Who what saw?"
-  , grammatical := false
-  , notes := "MWF asterisk only at vP edge; sluicing repairs by deleting vP" }
-
-/-- Variety A bans multiple sluicing, variety B allows it. **Derived** from
-    the parameter via `EllipsisRepairsMWF`, not stipulated as an
-    independent Bool. -/
-theorem english_variety_split :
-    ¬ english_varietyA.AllowsMultipleSluicing ∧
-    english_varietyB.AllowsMultipleSluicing := by decide
-
--- ============================================================================
--- § 3: Derivation Cost Functions
--- ============================================================================
-
-/-! Cost defs unchanged in shape from earlier revisions. The 4-Nat
-parameterization (sm/sl/nsm/nsl coarse, hm/hl/pm/pl/wm/wl fine) is
-ergonomically cryptic but matches the paper's argument granularity:
-
-**Coarse** (MD vs ellipsis): parameterized by total shared/non-shared cost.
-Used for Theorems 1–2.
-
-- `sm`/`sl`: Merge/lexical cost of shared material (built once with MD,
-  twice with ellipsis)
-- `nsm`/`nsl`: cost of non-shared parts (wh-movement, coordination)
-
-**Fine** (non-bulk vs bulk sharing): decomposes shared material into
-heads vs phrasal structure. Used for Theorem 3.
-
-- `hm`/`hl`: cost of shared heads (C, T — built once either way)
-- `pm`/`pl`: cost of per-conjunct phrasal structure (C', TP, vP assembly)
-- `wm`/`wl`: cost of wh-phrases + coordination (non-shared)
--/
-
-/-- Cost of CWH via non-bulk-sharing MD (adopted structure, paper's (10b)).
-    Shared material built once; no ellipsis. -/
-def cwhMDCost (sm sl nsm nsl : Nat) : DerivationCost where
-  mergeOps := sm + nsm
-  lexicalItems := sl + nsl
-  agreeOps := 0
-  ellipsisOps := 0
-
-/-- Cost of CWH via ellipsis (biclausal alternative, paper's (11b)).
-    Shared material duplicated; one E-feature deletion. -/
-def cwhEllipsisCost (sm sl nsm nsl : Nat) : DerivationCost where
-  mergeOps := 2 * sm + nsm
-  lexicalItems := 2 * sl + nsl
-  agreeOps := 0
-  ellipsisOps := 1
-
-/-- Cost of CWH via non-bulk-sharing MD — fine-grained (paper's (10b)).
-    Individual heads (C, T) shared; per-conjunct phrasal structure
-    (assembling C', TP, vP around shared heads) built in each conjunct. -/
-def cwhNonBulkCost (hm hl pm pl wm wl : Nat) : DerivationCost where
-  mergeOps := hm + 2 * pm + wm
-  lexicalItems := hl + 2 * pl + wl
-  agreeOps := 0
-  ellipsisOps := 0
-
-/-- Cost of CWH via bulk-sharing MD (excluded, paper's (12b)).
-    Entire C' shared — phrasal structure built only once.
-    More economical than non-bulk-sharing, but blocked by MWF. -/
-def cwhBulkMDCost (hm hl pm pl wm wl : Nat) : DerivationCost where
-  mergeOps := hm + pm + wm
-  lexicalItems := hl + pl + wl
-  agreeOps := 0
-  ellipsisOps := 0
-
-/-- Cost of CS via bulk-sharing MD + single ellipsis (adopted, paper's (20b)).
-    C' shared; E-feature on C deletes TP once. -/
-def csBulkCost (sm sl nsm nsl : Nat) : DerivationCost where
-  mergeOps := sm + nsm
-  lexicalItems := sl + nsl
-  agreeOps := 0
-  ellipsisOps := 1
-
-/-- Cost of CS via double ellipsis, no MD (excluded, paper's (19b)).
-    Both conjuncts built in full; E-feature in each. -/
-def csDoubleEllipsisCost (sm sl nsm nsl : Nat) : DerivationCost where
-  mergeOps := 2 * sm + nsm
-  lexicalItems := 2 * sl + nsl
-  agreeOps := 0
-  ellipsisOps := 2
-
--- ============================================================================
--- § 4: Economy Theorems
--- ============================================================================
-
-/-- **Theorem 1**: For CWHs, the MD derivation is strictly more economical
-    than the ellipsis alternative (paper's (10b) vs (11b)).
-
-    The MD derivation saves `sm` Merge ops and `sl` lexical items, and
-    avoids the ellipsis op entirely. This holds for ANY shared material —
-    even `sm = sl = 0`, the ellipsis op alone makes the alternative
-    costlier. -/
-theorem cwh_md_beats_ellipsis (sm sl nsm nsl : Nat) :
-    strictlyMoreEconomical (cwhMDCost sm sl nsm nsl) (cwhEllipsisCost sm sl nsm nsl) := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩
-  all_goals simp only [cwhMDCost, cwhEllipsisCost]
-  all_goals omega
-
-/-- **Theorem 2**: For CSs, the bulk-sharing derivation is strictly more
-    economical than the double-ellipsis alternative (paper's (20b) vs (19b)).
-
-    The bulk-sharing derivation saves `sm` Merge operations and `sl`
-    lexical items, and uses one fewer ellipsis operation. -/
-theorem cs_bulk_beats_double_ellipsis (sm sl nsm nsl : Nat) :
-    strictlyMoreEconomical (csBulkCost sm sl nsm nsl) (csDoubleEllipsisCost sm sl nsm nsl) := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩
-  all_goals simp only [csBulkCost, csDoubleEllipsisCost]
-  all_goals omega
-
-/-- **Theorem 3**: Bulk-sharing is strictly more economical than
-    non-bulk-sharing for CWHs (paper's (12b) vs (10b)).
-
-    The paper's crucial insight: the MOST economical derivation for CWHs
-    (bulk-sharing, which builds C' once) is blocked by an independent
-    constraint (MWF), forcing the LESS economical non-bulk-sharing
-    structure. The precondition `0 < pm ∨ 0 < pl` ensures there is at
-    least some phrasal structure to share — which holds for any
-    non-trivial clause. -/
-theorem cwh_bulk_beats_nonbulk (hm hl pm pl wm wl : Nat) (h : 0 < pm ∨ 0 < pl) :
-    strictlyMoreEconomical
-      (cwhBulkMDCost hm hl pm pl wm wl)
-      (cwhNonBulkCost hm hl pm pl wm wl) := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩
-  all_goals simp only [cwhBulkMDCost, cwhNonBulkCost]
-  all_goals omega
-
-/-! ### Identifying economy winners
-
-The Theorems 1-3 above establish *strict-domination* facts; combining
-each with `Minimalist.economy_winner_of_pair` (which discharges the
-existence guarantee from `economy_admits_winner` for the binary case)
-identifies the actual economy winner of the relevant 2-candidate
-reference set. These are the load-bearing wirings: C&G-Y's selection
-arguments need both "X dominates Y" AND "the reference set has a
-winner" to deliver "X is THE winner". -/
-
-/-- **CWH economy winner**: of the reference set `{cwhMDCost, cwhEllipsisCost}`,
-    `cwhMDCost` is an economy winner — no element of the set is
-    strictly more economical than it. Wires `cwh_md_beats_ellipsis`
-    through `Minimalist.economy_winner_of_pair`. -/
-theorem cwh_md_is_economy_winner (sm sl nsm nsl : Nat) :
-    ∀ alt ∈ ({cwhMDCost sm sl nsm nsl, cwhEllipsisCost sm sl nsm nsl} : Set _),
-      ¬ strictlyMoreEconomical alt (cwhMDCost sm sl nsm nsl) :=
-  Minimalist.economy_winner_of_pair (cwh_md_beats_ellipsis sm sl nsm nsl)
-
-/-- **CS economy winner**: of the reference set `{csBulkCost, csDoubleEllipsisCost}`,
-    `csBulkCost` is an economy winner. Wires `cs_bulk_beats_double_ellipsis`
-    through `Minimalist.economy_winner_of_pair`. -/
-theorem cs_bulk_is_economy_winner (sm sl nsm nsl : Nat) :
-    ∀ alt ∈ ({csBulkCost sm sl nsm nsl, csDoubleEllipsisCost sm sl nsm nsl} : Set _),
-      ¬ strictlyMoreEconomical alt (csBulkCost sm sl nsm nsl) :=
-  Minimalist.economy_winner_of_pair (cs_bulk_beats_double_ellipsis sm sl nsm nsl)
-
--- ============================================================================
--- § 5: Why CWHs Cannot Have the CS Structure
--- ============================================================================
-
-/-! The CS (bulk-sharing) structure places both wh-phrases inside a single
-vP. Both must pass through the vP phase edge, creating a phase node
-with multiple wh-specifiers (paper's (36b)/(37b)).
-
-In a non-MWF language like English, this configuration receives an
-asterisk at PF, crashing the derivation.
-
-Unlike CSs, CWHs do NOT involve ellipsis — the vP edge survives to PF,
-so the asterisk is not deleted and the crash is unavoidable.
-
-CSs survive because the E-feature on C triggers TP deletion (including
-the offending vP edge), removing the asterisk before PF interprets it. -/
-
-/-- The bulk-sharing structure for CWHs crashes in English:
-    2 wh-specifiers at vP edge in a non-MWF language. -/
-theorem cwh_bulk_crashes_in_english :
-    MWFViolation english 2 := by decide
-
-/-- CWHs have no ellipsis to repair the MWF violation —
-    the vP edge survives to PF, and the asterisk crashes. -/
-theorem cwh_no_ellipsis_repair :
-    ¬ EllipsisRepairsMWF english 2 (vpEdgeDeleted := false) := by decide
-
-/-- In English variety B (vP-only asterisk), CSs survive the same MWF
-    configuration because ellipsis deletes the vP edge. Variety A
-    (both-edges asterisk) is **not** repairable — CP-edge survives. -/
-theorem cs_ellipsis_repairs_mwf_varietyB :
-    EllipsisRepairsMWF english_varietyB.mwfParam 2 (vpEdgeDeleted := true) := by decide
-
--- ============================================================================
--- § 6: Why CSs Cannot Have the CWH Structure (per-op Pronunciation Economy)
--- ============================================================================
-
-/-! Paper p. 32 (re. ex (45c)): "If both Cs had the E feature, …
-Pronunciation Economy would be violated since the TP would be elided
-twice (once by the E feature on each C)."
-
-The argument depends on the CS structure where a **shared TP** has two
-Cs each bearing the E-feature. Both Cs fire the E-feature on the same
-TP — but only the first deletion has any PF effect; the second targets
-material the first already removed. This is the per-operation vacuity
-that requires the new `pronunciationEconomy : List PFOperation → Prop`
-shape: a whole-derivation `pfBefore ≠ pfAfter` check would let this
-through (the first deletion ensures the whole derivation's PF differs).
--/
-
-/-- Initial PF state of the shared TP: contains "John taught". -/
-def cs_twoEFeature_initialPF : List String := ["John", "taught"]
-
-/-- The first C's E-feature deletion: removes "John taught" from the
-    shared TP. Non-vacuous. -/
-def cs_twoEFeature_firstDeletion : PFOperation :=
-  { pfBefore := cs_twoEFeature_initialPF, pfAfter := [] }
-
-/-- The second C's E-feature deletion: tries to delete the same shared
-    TP, but it is already empty after the first deletion. Vacuous. -/
-def cs_twoEFeature_secondDeletion : PFOperation :=
-  { pfBefore := [], pfAfter := [] }
-
-/-- The full deletion sequence under a hypothetical two-E-feature CS
-    structure (paper's (45c) configuration). -/
-def cs_twoEFeature_deletions : List PFOperation :=
-  [cs_twoEFeature_firstDeletion, cs_twoEFeature_secondDeletion]
-
-/-- The second deletion is vacuous (its PF before/after coincide). -/
-theorem cs_twoEFeature_secondDeletion_vacuous :
-    cs_twoEFeature_secondDeletion.isVacuous := rfl
-
-/-- The two-E-feature CS structure violates Pronunciation Economy at
-    the second deletion. This is the paper's (45c) ban — the per-op
-    vacuity is what rules it out, even though the full derivation's
-    pfBefore (`["John", "taught"]`) ≠ pfAfter (`[]`) is satisfied.
-
-    A whole-derivation PF≠ check would pass this configuration
-    incorrectly; the per-op `pronunciationEconomy` correctly fails it. -/
-theorem cs_twoEFeature_violates_pronunciation_economy :
-    ¬ pronunciationEconomy cs_twoEFeature_deletions :=
-  pronunciationEconomy_violated_of_vacuous
-    (op := cs_twoEFeature_secondDeletion)
-    (by simp [cs_twoEFeature_deletions])
-    cs_twoEFeature_secondDeletion_vacuous
-
-/-- Whole-derivation PF differs (initial ["John","taught"] → final [])
-    even though the second op is vacuous. This is exactly what makes a
-    whole-derivation PF≠ check inadequate for the paper's argument. -/
-theorem cs_twoEFeature_wholeDeriv_pf_differs :
-    cs_twoEFeature_initialPF ≠ ([] : List String) := by decide
-
--- ============================================================================
--- § 7: Structural Summary — with populated sharedNodes
--- ============================================================================
-
-/-- The adopted CWH structure: non-bulk-sharing MD, no ellipsis (paper's (10b)).
-    Shared nodes: C and T are individually multiply dominated. -/
-def cwhStructure : PFReducedCoordination where
-  conjunct1 := mkLeaf .C [] 0
-  conjunct2 := mkLeaf .C [] 1
-  mechanisms := [.multidominance]
-  sharing := some .nonBulk
-  sharedNodes :=
-    [ { node := mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := mkLeaf .T [] 11, category := some .T, pronounced := false } ]
-  pfOutput := ["what", "and", "when", "should", "you", "teach"]
-
-/-- The adopted CS structure: bulk-sharing MD + ellipsis (paper's (20b)).
-    The E-feature on C (cf. `FeatureVal.ellipsis` in `Core/Features.lean`)
-    triggers TP deletion, repairing the MWF violation at the vP edge.
-    Shared nodes: entire C' is shared (includes C, TP, vP, VP). -/
-def csStructure : PFReducedCoordination where
-  conjunct1 := mkLeaf .C [] 0
-  conjunct2 := mkLeaf .C [] 1
-  mechanisms := [.multidominance, .ellipsis]
-  sharing := some .bulk
-  sharedNodes :=
-    [ { node := mkLeaf .C [] 10, category := some .C, pronounced := true }
-    , { node := mkLeaf .T [] 11, category := some .T, pronounced := false }
-    , { node := mkLeaf .v [] 12, category := some .v, pronounced := false } ]
-  pfOutput := ["what", "and", "when"]
-
-/-- Structural drift sentry over the four key properties of cwhStructure
-    and csStructure. Replaces five individual rfl theorems
-    (`cwh_uses_md_only`, `cs_uses_both`, `cwh_shares_heads_cs_shares_constituent`,
-    `cwh_shared_categories`, `cs_shared_categories`). -/
-theorem cwhStructure_csStructure_drift_sentry :
-    cwhStructure.UsesMD ∧ ¬ cwhStructure.UsesEllipsis ∧
-    csStructure.UsesBoth ∧
-    cwhStructure.sharedNodes.length = 2 ∧ csStructure.sharedNodes.length = 3 ∧
-    cwhStructure.sharedNodes.all (·.category.isSome) = true ∧
-    csStructure.sharedNodes.all (·.category.isSome) = true := by decide
-
--- ============================================================================
--- § 8: End-to-End Argumentation Chains
--- ============================================================================
-
-/-! The paper's central contribution is explaining WHY CWHs and CSs
-must have different structures — and therefore different empirical
-properties — despite their superficial similarity.
-
-**For CWHs** (§4.1):
-1. Bulk-sharing MD is most economical (`cwh_bulk_beats_nonbulk`)
-2. But bulk-sharing creates MWF violation at vP (`cwh_bulk_crashes_in_english`)
-3. CWHs have no ellipsis to repair MWF (`cwh_no_ellipsis_repair`)
-4. So non-bulk-sharing MD is selected (`cwh_md_beats_ellipsis` over ellipsis)
-
-**For CSs** (§4.2):
-1. Bulk-sharing MD + ellipsis is most economical (`cs_bulk_beats_double_ellipsis`)
-2. Bulk-sharing creates MWF at vP, but ellipsis repairs it
-   (`cs_ellipsis_repairs_mwf_varietyB`, in vP-only varieties)
-3. Non-bulk-sharing (CWH structure) violates Pronunciation Economy
-   (`cs_twoEFeature_violates_pronunciation_economy`)
-4. So bulk-sharing MD + ellipsis is selected
--/
-
-/-- The two constructions differ in which mechanisms they use. -/
-theorem different_mechanisms :
-    cwhStructure.mechanisms ≠ csStructure.mechanisms := by decide
-
-/-- The two constructions differ in sharing type. -/
-theorem different_sharing :
-    cwhStructure.sharing ≠ csStructure.sharing := by decide
-
-/-- End-to-end: CWHs cannot use bulk-sharing (most economical)
-    because the MWF violation at vP cannot be repaired without ellipsis.
-    Combines Theorem 3, `cwh_bulk_crashes_in_english`, and
-    `cwh_no_ellipsis_repair`. -/
-theorem cwh_forced_to_nonbulk (hm hl pm pl wm wl : Nat) (h : 0 < pm ∨ 0 < pl) :
-    -- Bulk-sharing IS more economical...
-    strictlyMoreEconomical (cwhBulkMDCost hm hl pm pl wm wl) (cwhNonBulkCost hm hl pm pl wm wl)
-    -- ...but it crashes in English (MWF at vP)...
-    ∧ MWFViolation english 2
-    -- ...and CWHs can't repair the crash (no ellipsis).
-    ∧ ¬ EllipsisRepairsMWF english 2 (vpEdgeDeleted := false) :=
-  ⟨cwh_bulk_beats_nonbulk hm hl pm pl wm wl h, by decide, by decide⟩
-
-/-- End-to-end: CSs use bulk-sharing because it is most economical AND the
-    MWF violation is repaired by ellipsis (in vP-only varieties); the CWH
-    (two-E-feature) structure is excluded by per-op Pronunciation Economy. -/
-theorem cs_forced_to_bulk (sm sl nsm nsl : Nat) :
-    -- Bulk-sharing beats double-ellipsis...
-    strictlyMoreEconomical (csBulkCost sm sl nsm nsl) (csDoubleEllipsisCost sm sl nsm nsl)
-    -- ...ellipsis repairs the MWF violation at vP (variety B / German / Greek)...
-    ∧ EllipsisRepairsMWF english_varietyB.mwfParam 2 (vpEdgeDeleted := true)
-    -- ...and the two-E-feature CWH-style CS violates Pronunciation Economy.
-    ∧ ¬ pronunciationEconomy cs_twoEFeature_deletions :=
-  ⟨cs_bulk_beats_double_ellipsis sm sl nsm nsl, by decide,
-   cs_twoEFeature_violates_pronunciation_economy⟩
-
--- ============================================================================
--- § 9: Right Node Raising — Ellipsis + MD Interaction
--- ============================================================================
-
-/-! Section 6.2 of the paper extends the economy analysis to Right Node
-Raising (RNR). RNR is a key test case because it can involve BOTH
-ellipsis and MD simultaneously — the "mix and match" analysis of
-[belk-neeleman-philip-2023] (and earlier [barros-vicente-2011]).
-
-The core claim: economy favors MD over ellipsis when both yield the same
-string and interpretation. In RNR, the shared pivot (rightmost material)
-is multiply dominated. When the pivot and antecedent are not morphologically
-identical (vehicle change), ellipsis is additionally required for the
-non-shared material in the first conjunct. -/
-
-/-- RNR pivot type: what is shared at the right edge. -/
-inductive RNRPivotType where
-  /-- Only the rightmost constituent (e.g., PP) is shared. -/
-  | minimal
-  /-- A larger constituent (e.g., VP) is shared. -/
-  | extended
-  deriving Repr, DecidableEq
-
-/-- An RNR datum captures the structural analysis. -/
-structure RNRDatum where
-  sentence : String
-  /-- The shared pivot string (right-edge material). -/
-  pivot : String
-  /-- Does the pivot exhibit morphological identity with the antecedent? -/
-  morphologicalIdentity : Bool
-  /-- Does the pivot exhibit properties of MD? (e.g., cumulative agreement,
-      internal reading of relational adjective) -/
-  mdProperties : Bool
-  /-- Does the construction involve ellipsis in addition to MD? -/
-  involvesEllipsis : Bool
-  pivotType : RNRPivotType
-  notes : String := ""
-  deriving Repr
-
-/-- Pure MD: identical verbs, no mismatch → economy selects MD only (ex 55). -/
-def rnr_pureMD : RNRDatum :=
-  { sentence := "Alice must, and Iris should, work on different topics."
-  , pivot := "work on different topics"
-  , morphologicalIdentity := true
-  , mdProperties := true
-  , involvesEllipsis := false
-  , pivotType := .extended
-  , notes := "No morphological mismatch; MD alone is most economical" }
-
-/-- Ellipsis + MD: verb morphology mismatch forces ellipsis for VP,
-    but PP pivot is still shared via MD (ex 52/53). -/
-def rnr_ellipsisPlusMD : RNRDatum :=
-  { sentence :=
-    "Alice must work on different topics, and Iris ought to be working on different topics."
-  , pivot := "on different topics"
-  , morphologicalIdentity := false
-  , mdProperties := true
-  , involvesEllipsis := true
-  , pivotType := .minimal
-  , notes :=
-    "Morphological mismatch (work vs working); PP shared via MD, VP ellipsis in first conjunct" }
-
-/-- Vehicle-change diagnostic from [barros-vicente-2011] ex (47):
-    morphological mismatch signals ellipsis (not MD).
-
-    The angled brackets mark the **first** conjunct's predicate as
-    PF-reduced under identity with the **second** conjunct's overt
-    predicate — backwards elision, not forwards RNR with a right-edge
-    pivot. The morphological mismatch (`wake` vs `wakes`) confirms
-    ellipsis (which tolerates vehicle change) over MD (which requires
-    morphological identity for a single multiply-dominated node). -/
-def rnr_ellipsisOnly : RNRDatum :=
-  { sentence := "I usually don't ⟨wake up early every day⟩, but Alice wakes up early every day."
-  , pivot := "wake up early every day"  -- the elided string in 1st conjunct
-  , morphologicalIdentity := false
-  , mdProperties := false
-  , involvesEllipsis := true
-  , pivotType := .extended
-  , notes := "[barros-vicente-2011] ex (47): backwards elision pattern; "
-           ++ "1st conjunct predicate PF-reduced under identity with 2nd; "
-           ++ "morphological mismatch ('wake' vs 'wakes') signals ellipsis not MD" }
-
-/-- Relational adjective with internal reading signals MD. -/
-def rnr_internalReading : RNRDatum :=
-  { sentence := "Alice composed, and Beatrix performed, different songs."
-  , pivot := "different songs"
-  , morphologicalIdentity := true
-  , mdProperties := true
-  , involvesEllipsis := false
-  , pivotType := .minimal
-  , notes := "Internal reading of 'different' requires c-command from both subjects → MD" }
-
-/-- RNR datum drift sentry: morphological-identity / MD-properties /
-    ellipsis-involvement consistent with the paper's typology. Replaces
-    `rnr_economy_prefers_md` and `rnr_mismatch_forces_ellipsis`. -/
-theorem rnr_typology_drift_sentry :
-    -- pureMD: morph match, MD, no ellipsis
-    rnr_pureMD.morphologicalIdentity = true ∧
-    rnr_pureMD.mdProperties = true ∧
-    rnr_pureMD.involvesEllipsis = false ∧
-    -- ellipsisPlusMD: morph mismatch, MD, ellipsis
-    rnr_ellipsisPlusMD.morphologicalIdentity = false ∧
-    rnr_ellipsisPlusMD.mdProperties = true ∧
-    rnr_ellipsisPlusMD.involvesEllipsis = true ∧
-    -- internalReading: morph match, MD (internal-reading diagnostic)
-    rnr_internalReading.mdProperties = true ∧
-    rnr_internalReading.involvesEllipsis = false := by decide
-
-/-- RNR pivot cost: MD derivation for the shared pivot.
-    The pivot is built once (MD) rather than twice (ellipsis). -/
-def rnrMDPivotCost (pivotMerge pivotLex nonsharedMerge nonsharedLex : Nat) :
-    DerivationCost where
-  mergeOps := pivotMerge + nonsharedMerge
-  lexicalItems := pivotLex + nonsharedLex
-  agreeOps := 0
-  ellipsisOps := 0
-
-/-- RNR cost with full ellipsis (no MD): pivot duplicated. -/
-def rnrEllipsisCost (pivotMerge pivotLex nonsharedMerge nonsharedLex : Nat) :
-    DerivationCost where
-  mergeOps := 2 * pivotMerge + nonsharedMerge
-  lexicalItems := 2 * pivotLex + nonsharedLex
-  agreeOps := 0
-  ellipsisOps := 1
-
-/-- **Theorem 4**: For RNR, MD is strictly more economical than
-    ellipsis when both yield the same string. Same shape as Theorem 1. -/
-theorem rnr_md_beats_ellipsis (pm pl nm nl : Nat) :
-    strictlyMoreEconomical (rnrMDPivotCost pm pl nm nl) (rnrEllipsisCost pm pl nm nl) := by
-  refine ⟨⟨?_, ?_, ?_, ?_⟩, ?_⟩
-  all_goals simp only [rnrMDPivotCost, rnrEllipsisCost]
-  all_goals omega
-
-/-- **RNR economy winner**: of the reference set `{rnrMDPivotCost, rnrEllipsisCost}`,
-    `rnrMDPivotCost` is an economy winner. Wires `rnr_md_beats_ellipsis`
-    through `Minimalist.economy_winner_of_pair`. -/
-theorem rnr_md_is_economy_winner (pm pl nm nl : Nat) :
-    ∀ alt ∈ ({rnrMDPivotCost pm pl nm nl, rnrEllipsisCost pm pl nm nl} : Set _),
-      ¬ strictlyMoreEconomical alt (rnrMDPivotCost pm pl nm nl) :=
-  Minimalist.economy_winner_of_pair (rnr_md_beats_ellipsis pm pl nm nl)
+/-- Each wh-phrase is interpreted in its own conjunct. -/
+theorem cwh_nonpaired : unboundTraces cwh = [] := by decide
+/-- The shared C′ carries a copy of each wh-phrase into the other conjunct. -/
+theorem cwhBulk_paired : Paired cwhBulk := by decide
+
+theorem cwh_beats_ellipsis : strictlyMoreEconomical (planarCost cwh) (planarCost cwhEllipsis) := by
+  decide
+theorem cwhBulk_beats_cwh : strictlyMoreEconomical (planarCost cwhBulk) (planarCost cwh) := by
+  decide
+/-- The null complementizer of (14) adds structure and nothing to pronunciation. -/
+theorem cwh_beats_nullC : strictlyMoreEconomical (planarCost cwh) (planarCost cwhNullC) := by decide
+theorem cwhEmbedded_beats_twoC :
+    strictlyMoreEconomical (planarCost cwhEmbedded) (planarCost cwhEmbeddedTwoC) := by decide
+
+/-- The shared C′ sends both wh-phrases through one vP edge, asterisked in English and
+pronounced. -/
+theorem cwhBulk_crashes : ¬ Converges cwhBulk englishA ∧ ¬ Converges cwhBulk englishB := by decide
+/-- Footnote 14: in a multiple-wh-fronting language the same object converges. -/
+theorem cwhBulk_converges_romanian : Converges cwhBulk romanian := by decide
+theorem cwh_converges : Converges cwh englishA ∧ Converges cwh englishB := by decide
+
+/-! ### Coordinated sluices (§3.2) -/
+
+theorem cs_pf : pfPhon cs = ["what", "when"] := by decide
+theorem csEllipsis_pf : pfPhon csEllipsis = pfPhon cs := by decide
+theorem cs_paired : Paired cs := by decide
+theorem cs_beats_ellipsis : strictlyMoreEconomical (planarCost cs) (planarCost csEllipsis) := by
+  decide
+theorem cs_beats_twoC : strictlyMoreEconomical (planarCost cs) (planarCost csTwoC) := by decide
+
+/-- The shared vP edge hosts two wh-specifiers: the asterisk of (26b). -/
+theorem cs_asterisked :
+    ∃ p ∈ vertices cs, IsAsterisked cs englishA p ∧ IsAsterisked cs englishB p := by decide
+/-- Elided, the asterisked edge never reaches PF. -/
+theorem cs_converges : Converges cs englishA ∧ Converges cs englishB := by decide
+
+/-- A multiple question crashes in English and converges in Bulgarian. -/
+theorem multipleQuestion_crashes :
+    ¬ Converges (multipleQuestion c) englishA ∧ ¬ Converges (multipleQuestion c) englishB := by
+  decide
+theorem multipleQuestion_converges_bulgarian : Converges (multipleQuestion c) bulgarian := by decide
+/-- Multiple sluicing elides the vP edge but not the CP edge: variety B, German and Greek
+converge, variety A does not. -/
+theorem multipleSluicing :
+    Converges (multipleQuestion cE) englishB ∧ Converges (multipleQuestion cE) german ∧
+      Converges (multipleQuestion cE) greek ∧ ¬ Converges (multipleQuestion cE) englishA := by
+  decide
+
+/-! ### Pronunciation Economy (§5, §6.1) -/
+
+/-- One shared [E] complementizer over two TPs: the second deletion silences nothing new. -/
+theorem csSharedC_vacuous : ¬ PronunciationEconomy csSharedC := by decide
+theorem csSharedC_pf : pfPhon csSharedC = pfPhon cs := by decide
+theorem csSharedC_nonpaired : ¬ Paired csSharedC := by decide
+theorem cs_economy : PronunciationEconomy cs ∧ PronunciationEconomy csEllipsis := by decide
+
+theorem csnr_pf : pfPhon csnr = pfPhon cs := by decide
+theorem csnr_economy : PronunciationEconomy csnr ∧ ¬ Paired csnr := by decide
+/-- Two [E] complementizers over shared material elide it twice. -/
+theorem csnrTwoE_vacuous : ¬ PronunciationEconomy csnrTwoE := by decide
+theorem csnr_beats_twoE : strictlyMoreEconomical (planarCost csnr) (planarCost csnrTwoE) := by
+  decide
+/-- The nonpaired sluice is the cheapest nonpaired object respecting Pronunciation Economy: the
+shared [E] complementizer of (45c) draws one token fewer but elides vacuously. -/
+theorem csnr_optimal : ∀ t ∈ [csSharedC, csnrTwoE],
+    strictlyMoreEconomical (planarCost csnr) (planarCost t) ∨ ¬ PronunciationEconomy t := by decide
+/-- Footnote 30: the verb, shared, occurs in the second conjunct outside the elided TP and is
+silenced all the same, so the object cannot surface as a coordinated wh-question. -/
+theorem csnr_silences_shared :
+    (∃ p ∈ occurrences csnr teach, ∀ K ∈ elidedDomains csnr, ¬ K <+: p) ∧
+      IsSilenced csnr teach := by decide
+
+/-! ### Right node raising (§6.2) -/
+
+def alice := tok 21 .D (phon := "Alice")
+def iris := tok 22 .D (phon := "Iris")
+def must := tok 23 .T [.V] "must"
+/-- `must` bearing [E]. -/
+def mustE := tok 24 .T [.V] "must" (ellipsis := true)
+def oughtToBe := tok 25 .T [.V] "ought to be"
+def shouldRNR := tok 26 .T [.V] "should"
+def work := tok 27 .V [.P] "work"
+def working := tok 28 .V [.P] "working"
+def on := tok 29 .P [.N] "on"
+def different := tok 30 .A (phon := "different")
+def topics := tok 31 .N (phon := "topics")
+def on' := tok 32 .P [.N] "on"
+def different' := tok 33 .A (phon := "different")
+def topics' := tok 34 .N (phon := "topics")
+
+/-- The pivot, `on different topics`. -/
+def pivot : RoseTree ChainLabel := nodeC (leafC on) (nodeC (leafC different) (leafC topics))
+
+/-- `[TP subj [T′ T VP]]`. -/
+def tp (subj T : LIToken) (VP : RoseTree ChainLabel) : RoseTree ChainLabel :=
+  nodeC (leafC subj) (nodeC (leafC T) VP)
+
+/-- (53b), after the pruning of [belk-neeleman-philip-2023] that removes the shared pivot from
+the first conjunct: the first verb phrase, the bare verb, elided under [E] on `must`. -/
+def rnrMixed : RoseTree ChainLabel :=
+  nodeC (tp alice mustE (leafC work)) (tp iris oughtToBe (nodeC (leafC working) pivot))
+/-- (54): the first verb phrase built with its own pivot and elided. -/
+def rnrElided : RoseTree ChainLabel :=
+  nodeC
+    (tp alice mustE
+      (nodeC (leafC work) (nodeC (leafC on') (nodeC (leafC different') (leafC topics')))))
+    (tp iris oughtToBe (nodeC (leafC working) pivot))
+/-- (55b): with matching verbs, the verb phrase shared. -/
+def rnrShared : RoseTree ChainLabel :=
+  let VP := nodeC (leafC work) pivot
+  nodeC (tp alice must VP) (tp iris shouldRNR VP)
+/-- The rival of (55b) with the shape of (53b). -/
+def rnrMatchedMixed : RoseTree ChainLabel :=
+  nodeC (tp alice mustE (leafC work)) (tp iris shouldRNR (nodeC (leafC working) pivot))
+
+theorem rnrMixed_pf : pfPhon rnrMixed =
+    ["Alice", "must", "Iris", "ought to be", "working", "on", "different", "topics"] := by decide
+theorem rnrElided_pf : pfPhon rnrElided = pfPhon rnrMixed := by decide
+theorem rnrMixed_beats_elided :
+    strictlyMoreEconomical (planarCost rnrMixed) (planarCost rnrElided) := by decide
+
+theorem rnrShared_pf : pfPhon rnrShared =
+    ["Alice", "must", "Iris", "should", "work", "on", "different", "topics"] := by decide
+theorem rnrShared_isShared : IsShared rnrShared work := by decide
+/-- With matching verbs, ellipsis is no longer an option. -/
+theorem rnrShared_beats_mixed :
+    strictlyMoreEconomical (planarCost rnrShared) (planarCost rnrMatchedMixed) := by decide
 
 end CitkoGracaninYuksek2025

--- a/Linglib/Syntax/Minimalist/Economy/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Economy/Basic.lean
@@ -18,10 +18,9 @@ and lexical resources.
   transderivational variant per [citko-gracanin-yuksek-2025] fn 3.
   The local-economy alternative ([collins-2001]) is not formalized.
 
-- **Pronunciation Economy** ([citko-gracanin-yuksek-2025] p. 27): no
-  PF-affecting operation is vacuous. Checked **per operation**, not on
-  whole-derivation PF before/after — see `pronunciationEconomy`'s
-  docstring for why a whole-derivation `≠` check under-rejects.
+- **Pronunciation Economy** ([citko-gracanin-yuksek-2025]): no application of
+  ellipsis is vacuous. It judges PF objects, so it lives with them:
+  `Minimalist.PronunciationEconomy` in `Linearization/Chain.lean`.
 
 ## Headline (§3): well-foundedness via Dickson's lemma
 
@@ -285,57 +284,5 @@ theorem economy_winner_of_pair {c c' : DerivationCost}
   · exact lt_asymm hlt ((strictlyMoreEconomical_iff_lt _ _).mp halt_lt)
 
 end WellFoundedness
-
-section PronunciationEconomy
-
-/-- A single PF-affecting operation: PF state immediately before vs
-    immediately after the op fires. Used to express
-    [citko-gracanin-yuksek-2025]'s **per-operation** vacuity check
-    (paper p. 27 ex (39); §3 PF reduction).
-
-    Whole-derivation Pronunciation Economy is the conjunction of per-op
-    economy across all PF-affecting operations in the derivation. -/
-structure PFOperation where
-  pfBefore : List String
-  pfAfter : List String
-  deriving Repr, DecidableEq
-
-/-- A PF operation is *vacuous* iff it has no effect on the PF string —
-    e.g., the deletion targets material already unpronounced because a
-    prior deletion removed it (paper p. 32 ex (45c)). -/
-def PFOperation.isVacuous (op : PFOperation) : Prop := op.pfBefore = op.pfAfter
-
-instance (op : PFOperation) : Decidable op.isVacuous := by
-  unfold PFOperation.isVacuous; infer_instance
-
-/-- **Pronunciation Economy** ([citko-gracanin-yuksek-2025] p. 27,
-    ex (39)): no PF-affecting operation in the derivation is vacuous.
-
-    Crucially **per-operation**, not on whole-derivation PF before/after.
-    A whole-derivation `pfBefore ≠ pfAfter` check under-rejects: any
-    derivation containing one non-vacuous deletion plus N vacuous ones
-    would pass, because the non-vacuous deletion alone ensures the whole
-    derivation's PF changes. The paper's centerpiece argument (p. 32
-    ex (45c)) needs to ban exactly that configuration: a CWH structure
-    where a shared C with E-feature deletes two TPs, the second of which
-    is vacuous. -/
-def pronunciationEconomy (ops : List PFOperation) : Prop :=
-  ∀ op ∈ ops, ¬ op.isVacuous
-
-instance (ops : List PFOperation) : Decidable (pronunciationEconomy ops) := by
-  unfold pronunciationEconomy; infer_instance
-
-/-- Pronunciation Economy holds iff no individual operation is vacuous. -/
-theorem pronunciationEconomy_iff_no_vacuous (ops : List PFOperation) :
-    pronunciationEconomy ops ↔ ¬ ∃ op ∈ ops, op.isVacuous := by
-  simp only [pronunciationEconomy, not_exists, not_and]
-
-/-- A derivation with any vacuous op violates Pronunciation Economy. -/
-theorem pronunciationEconomy_violated_of_vacuous {op : PFOperation}
-    {ops : List PFOperation} (hmem : op ∈ ops) (hvac : op.isVacuous) :
-    ¬ pronunciationEconomy ops := by
-  intro h; exact h op hmem hvac
-
-end PronunciationEconomy
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Linearization/Chain.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Chain.lean
@@ -7,26 +7,27 @@ import Linglib.Core.Data.RoseTree.Get
 /-!
 # Chains, sharing and PF reduction on planar syntactic objects
 
-A planar syntactic object in which a token occurs at several positions carries its chains: the
-copies that the CI interface sees ([marcolli-chomsky-berwick-2025], Lemma 1.2.7). An occurrence is
-a chain head when no other occurrence of the token c-commands it. Movement leaves one head, the
-highest copy; a constituent with two mothers — [citko-2005]'s Parallel Merge, which MCB §1.1.3.2
-places outside Merge as a grafting away from the root — leaves several, mutually incomparable
-heads, one per mother, and is *shared*. At PF a token is pronounced once, at its last chain head,
-so shared material follows all unshared material ([wilder-1999], [de-vries-2009]), and an [E]
-feature on a head silences every token with a chain head in the head's complement
-([merchant-2001]): eliding either occurrence of a shared constituent silences it everywhere,
-while a moved phrase survives the ellipsis of its launching site. An [E] head applies once per
-distinct complement, and an application whose tokens an earlier one already silenced is vacuous,
-the configuration [citko-gracanin-yuksek-2025]'s Pronunciation Economy bans. A `v` or `C`
-projection whose edge hosts several wh-specifiers receives the asterisk of the multiple-wh-fronting
-parameter and crashes at PF unless its head is silenced. The cost of the object is read off its
-distinct nodes and tokens: a shared constituent is built once.
+A planar syntactic object whose traces remember the token that moved carries the two ways one
+token comes to occupy several positions. Internal Merge leaves a trace, the cancellation `T/T_v`
+of [marcolli-chomsky-berwick-2025] with `T_v` remembered, so a token's chain is its occurrence
+with its traces, and a trace no occurrence of its token c-commands is unbound: seen from its own
+conjunct, a copy without its antecedent. A token occurring twice is *shared*, dominated by two
+mothers — [citko-2005]'s Parallel Merge, which MCB §1.1.3.2 places outside Merge as a grafting
+away from the root — and a shared constituent is an identical subtree at two positions. At PF a
+token is pronounced once, at its last occurrence, so shared material follows all unshared material
+([wilder-1999], [de-vries-2009]). An [E] feature on a head silences the head's complement
+([merchant-2001]), and since a shared token is one token, eliding either of its occurrences
+silences it everywhere. An [E] head applies once per distinct complement, and an application that
+silences no pronounceable token an earlier one had not already silenced is vacuous, the
+configuration [citko-gracanin-yuksek-2025]'s Pronunciation Economy bans. A `v` or `C` projection
+whose edge hosts several wh-specifiers, wh-tokens or their traces, receives the asterisk of the
+multiple-wh-fronting parameter and crashes at PF unless its head is silenced. The cost of the
+object is read off its distinct tokens and nodes: a shared constituent is built once.
 
 ## Main definitions
 
-* `occurrenceList`, `CCommands`, `chainHeads`, `IsShared`, `pronouncedAt`: the chains.
-* `elidedDomains`, `IsSilenced`, `pfYield`, `pfPhon`: pronunciation under [E].
+* `ChainLabel`, `tokenList`, `occurrences`, `unboundTraces`, `IsShared`: occurrences and chains.
+* `elidedDomains`, `IsSilenced`, `pfPhon`: pronunciation under [E].
 * `IsVacuous`, `PronunciationEconomy`: the ban on vacuous ellipsis.
 * `projection`, `phaseAt`, `IsAsterisked`, `Converges`: the multiple-wh-fronting asterisk.
 * `planarCost`: the object's `DerivationCost`.
@@ -39,90 +40,138 @@ distinct nodes and tokens: a shared constituent is built once.
 * [C. Wilder, *Right node raising and the LCA* (1999)][wilder-1999]
 * [M. de Vries, *On multidominance and linearization* (2009)][de-vries-2009]
 * [J. Merchant, *The Syntax of Silence* (2001)][merchant-2001]
-* [B. Citko and M. Gračanin-Yuksek, *Economy in PF Reduction*
-  (2025)][citko-gracanin-yuksek-2025]
+* [B. Citko and M. Gračanin-Yuksek, *Economy in PF reduction* (2025)][citko-gracanin-yuksek-2025]
 -/
 
 namespace Minimalist
 
-open RoseTree RoseTree.Pathed SyntacticObject
+open RoseTree RoseTree.Pathed
 open Syntax.Question (MWFParameter PhaseEdge)
 
-/-! ### Occurrences and chains -/
+/-! ### Objects with indexed traces -/
+
+/-- The label of a position in a planar object with indexed traces: a token, the trace of a
+moved token, or an internal node. -/
+inductive ChainLabel
+  | token (tok : LIToken)
+  | trace (tok : LIToken)
+  | inner
+  deriving DecidableEq, Repr
+
+namespace ChainLabel
+
+/-- The token at a token position. -/
+def token? : ChainLabel → Option LIToken
+  | token tok => some tok
+  | _ => none
+
+/-- The token at a trace position. -/
+def trace? : ChainLabel → Option LIToken
+  | trace tok => some tok
+  | _ => none
+
+/-- Forget the indices: the planar object of `Linearization/Replay.lean`. -/
+def toSOLabel : ChainLabel → SOLabel
+  | token tok => .inl tok
+  | trace _ | inner => .inr ()
+
+end ChainLabel
+
+/-- A token position. -/
+def leafC (tok : LIToken) : RoseTree ChainLabel := .node (.token tok) []
+
+/-- The trace of `tok`. -/
+def traceC (tok : LIToken) : RoseTree ChainLabel := .node (.trace tok) []
+
+/-- The Merge of two objects. -/
+def nodeC (l r : RoseTree ChainLabel) : RoseTree ChainLabel := .node .inner [l, r]
 
 mutual
-/-- The leaf tokens with their paths, left to right. -/
-def occurrenceList : RoseTree SOLabel → List (Path × LIToken)
-  | .node (.inl tok) _ => [([], tok)]
-  | .node (.inr ()) cs => occurrenceListAux 0 cs
-/-- Auxiliary: the occurrences of a children list from index `i`. -/
-def occurrenceListAux : ℕ → List (RoseTree SOLabel) → List (Path × LIToken)
+/-- The positions whose label `f` accepts, with their paths, left to right. -/
+def positions (f : ChainLabel → Option LIToken) : RoseTree ChainLabel → List (Path × LIToken)
+  | .node a cs => match f a with
+    | some tok => [([], tok)]
+    | none => positionsAux f 0 cs
+/-- Auxiliary: the positions in a children list from index `i`. -/
+def positionsAux (f : ChainLabel → Option LIToken) :
+    ℕ → List (RoseTree ChainLabel) → List (Path × LIToken)
   | _, [] => []
-  | i, c :: cs => (occurrenceList c).map (λ x => (i :: x.1, x.2)) ++ occurrenceListAux (i + 1) cs
+  | i, c :: cs => (positions f c).map (λ x => (i :: x.1, x.2)) ++ positionsAux f (i + 1) cs
 end
 
-variable (t : RoseTree SOLabel)
+/-- The tokens with their paths, left to right. -/
+def tokenList : RoseTree ChainLabel → List (Path × LIToken) := positions ChainLabel.token?
 
-/-- The tokens of `t`, each once. -/
-def distinctTokens : List LIToken := ((occurrenceList t).map (·.2)).eraseDups
+/-- The traces with their paths, left to right. -/
+def traceList : RoseTree ChainLabel → List (Path × LIToken) := positions ChainLabel.trace?
+
+variable (t : RoseTree ChainLabel)
 
 /-- The occurrences of `tok`. -/
 def occurrences (tok : LIToken) : List Path :=
-  (occurrenceList t).filterMap λ x => if x.2 = tok then some x.1 else none
+  (tokenList t).filterMap λ x => if x.2 = tok then some x.1 else none
 
-/-- `p` c-commands `q`: the sister of `p` dominates `q`, that is `p`'s mother is an ancestor of
-`q` while `p` itself is not. -/
+/-- The tokens of `t`, each once. -/
+def distinctTokens : List LIToken := ((tokenList t).map (·.2)).eraseDups
+
+/-- `tok` is shared, dominated by two mothers: it occurs twice. -/
+def IsShared (tok : LIToken) : Prop := 2 ≤ (occurrences t tok).length
+
+instance (tok : LIToken) : Decidable (IsShared t tok) := inferInstanceAs (Decidable (_ ≤ _))
+
+/-- `p` c-commands `q`: the mother of `p` dominates `q` while `p` does not. -/
 def CCommands (p q : Path) : Prop := p.dropLast <+: q ∧ ¬ p <+: q
 
 instance (p q : Path) : Decidable (CCommands p q) := inferInstanceAs (Decidable (_ ∧ _))
 
-/-- The chain heads of `tok`: its occurrences not c-commanded by another. -/
-def chainHeads (tok : LIToken) : List Path :=
-  (occurrences t tok).filter λ p => (occurrences t tok).all λ q => !decide (CCommands q p)
+/-- The trace `x` is bound: an occurrence of its token c-commands it. -/
+def IsBound (x : Path × LIToken) : Prop := ∃ q ∈ occurrences t x.2, CCommands q x.1
 
-/-- `tok` is shared, dominated by two mothers: it has several chain heads. -/
-def IsShared (tok : LIToken) : Prop := 2 ≤ (chainHeads t tok).length
+instance (x : Path × LIToken) : Decidable (IsBound t x) :=
+  inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-instance (tok : LIToken) : Decidable (IsShared t tok) := inferInstanceAs (Decidable (_ ≤ _))
+/-- The unbound traces: seen from their positions, copies without their antecedents. -/
+def unboundTraces : List (Path × LIToken) := (traceList t).filter (¬ IsBound t ·)
 
-/-- The occurrence at which `tok` is pronounced: its last chain head. -/
-def pronouncedAt (tok : LIToken) : Option Path := (chainHeads t tok).getLast?
+/-- The occurrence at which `tok` is pronounced: its last. -/
+def pronouncedAt (tok : LIToken) : Option Path := (occurrences t tok).getLast?
 
 /-! ### Ellipsis -/
 
-/-- The complement of the head at `p`: its sister in a binary node. -/
+/-- The complement of the head at `p`: its sister. -/
 def complementPath (p : Path) : Path := p.dropLast ++ [1 - p.getLastD 0]
 
-/-- The paths of the [E] heads. -/
+/-- The [E] heads. -/
 def eHeads : List Path :=
-  (occurrenceList t).filterMap λ x => if x.2.item.outerEllipsis then some x.1 else none
+  (tokenList t).filterMap λ x => if x.2.item.outerEllipsis then some x.1 else none
 
-/-- The domains ellipsis deletes, one per distinct complement of an [E] head, in the order of
-the heads: a shared head over one shared complement applies once, over two complements twice. -/
+/-- The elided domains, one per distinct complement of an [E] head, in the order of the heads:
+a shared head over one shared complement applies once, over two complements twice. -/
 def elidedDomains : List Path :=
   ((eHeads t).map complementPath).foldl
     (λ acc p => if acc.any (λ q => t.subtreeAt q = t.subtreeAt p) then acc else acc ++ [p]) []
 
-/-- `tok` is silenced: one of its chain heads lies in an elided domain. -/
+/-- `tok` is silenced: one of its occurrences lies in an elided domain. -/
 def IsSilenced (tok : LIToken) : Prop :=
-  ∃ p ∈ eHeads t, ∃ h ∈ chainHeads t tok, complementPath p <+: h
+  ∃ K ∈ elidedDomains t, ∃ p ∈ occurrences t tok, K <+: p
 
-instance (tok : LIToken) : Decidable (IsSilenced t tok) := inferInstanceAs (Decidable (∃ _ ∈ _, _))
+instance (tok : LIToken) : Decidable (IsSilenced t tok) :=
+  inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-/-- The pronounced tokens, left to right: each at its last chain head, unless silenced. -/
+/-- The pronounced tokens, left to right: each at its last occurrence, unless silenced. -/
 def pfYield : List LIToken :=
-  (occurrenceList t).filterMap λ x =>
+  (tokenList t).filterMap λ x =>
     if pronouncedAt t x.2 = some x.1 ∧ ¬ IsSilenced t x.2 then some x.2 else none
 
 /-- The pronounced forms, left to right. -/
 def pfPhon : List String := (pfYield t).filterMap LIToken.phonForm?
 
-/-- The tokens the application at the domain `K` silences: those with a chain head in `K`. -/
+/-- The pronounceable tokens the application at the domain `K` silences. -/
 def silencedBy (K : Path) : List LIToken :=
-  (distinctTokens t).filter λ s => (chainHeads t s).any λ h => decide (K <+: h)
+  (distinctTokens t).filter λ s => s.phonForm?.isSome ∧ (occurrences t s).any (decide <| K <+: ·)
 
-/-- The application at `K` is vacuous: every token it silences was silenced by an earlier
-application. -/
+/-- The application at `K` has no effect on pronunciation: every token it silences an earlier
+application silenced. -/
 def IsVacuous (K : Path) : Prop :=
   ∀ s ∈ silencedBy t K, ∃ K' ∈ (elidedDomains t).takeWhile (· ≠ K), s ∈ silencedBy t K'
 
@@ -136,39 +185,50 @@ instance : Decidable (PronunciationEconomy t) := inferInstanceAs (Decidable (∀
 
 /-! ### Phase edges and the multiple-wh-fronting asterisk -/
 
-/-- The specifiers and head of a projection of a head of category `c`: the left daughters down
-the right spine above the head, `none` when the spine reaches no such head. -/
-def projection (c : Cat) : RoseTree SOLabel → Option (List (RoseTree SOLabel) × LIToken)
-  | .node (.inr ()) [.node (.inl tok) [], r] =>
-      if tok.item.outerCat = c then some ([], tok)
-      else (projection c r).map λ x => (.node (.inl tok) [] :: x.1, x.2)
-  | .node (.inr ()) [l, r] => (projection c r).map λ x => (l :: x.1, x.2)
+/-- The specifiers and head of the projection of a head of category `c`: down the right spine,
+the left daughters above the head, which is the first selecting item met; `none` when that item
+has another category or the spine ends first. -/
+def projection (c : Cat) : RoseTree ChainLabel → Option (List (RoseTree ChainLabel) × LIToken)
+  | .node .inner [.node (.token tok) [], r] =>
+      if tok.item.outerSel = [] then
+        (projection c r).map λ x => (leafC tok :: x.1, x.2)
+      else if tok.item.outerCat = c then some ([], tok) else none
+  | .node .inner [l, r] => (projection c r).map λ x => (l :: x.1, x.2)
   | _ => none
 
-/-- The constituent contains a wh-token. -/
-def IsWhPhrase (s : RoseTree SOLabel) : Prop := ∃ x ∈ occurrenceList s, x.2.item.outerWh = true
+/-- The head of a constituent: the token or trace at a leaf, else the first selecting item down
+the right spine. -/
+def headToken? : RoseTree ChainLabel → Option LIToken
+  | .node (.token tok) _ | .node (.trace tok) _ => some tok
+  | .node .inner [.node (.token tok) [], r] =>
+      if tok.item.outerSel = [] then headToken? r else some tok
+  | .node .inner [_, r] => headToken? r
+  | .node .inner _ => none
 
-instance (s : RoseTree SOLabel) : Decidable (IsWhPhrase s) :=
+/-- The constituent is a wh-specifier: its head is a wh-token or its trace. -/
+def IsWhSpecifier (s : RoseTree ChainLabel) : Prop :=
+  ∃ tok ∈ (headToken? s).toList, tok.item.outerWh = true
+
+instance (s : RoseTree ChainLabel) : Decidable (IsWhSpecifier s) :=
   inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
 /-- The phase at `p`, a `v` or `C` projection: its edge, specifiers and head. -/
-def phaseAt (p : Path) : Option (PhaseEdge × List (RoseTree SOLabel) × LIToken) :=
+def phaseAt (p : Path) : Option (PhaseEdge × List (RoseTree ChainLabel) × LIToken) :=
   (t.subtreeAt p).bind λ s =>
     ((projection .v s).map λ x => (PhaseEdge.vP, x)).or
       ((projection .C s).map λ x => (PhaseEdge.CP, x))
 
-/-- The phase at `p` receives the asterisk of the parameter: its edge hosts as many
-wh-specifiers as the parameter forbids there ([citko-gracanin-yuksek-2025] (27)). -/
+/-- The phase at `p` receives the asterisk of the parameter ([citko-gracanin-yuksek-2025] (27)):
+its edge hosts more wh-specifiers than the parameter allows there. -/
 def IsAsterisked (param : MWFParameter) (p : Path) : Prop :=
-  ∃ x ∈ (phaseAt t p).toList, param.EdgeAsterisk x.1 (x.2.1.countP λ s => decide (IsWhPhrase s))
+  ∃ x ∈ (phaseAt t p).toList, param.EdgeAsterisk x.1 (x.2.1.countP (decide <| IsWhSpecifier ·))
 
 instance (param : MWFParameter) (p : Path) : Decidable (IsAsterisked t param p) :=
   inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-/-- The object converges at PF: every asterisked phase is elided, its head silenced. -/
+/-- The object converges at PF: the head of every asterisked phase is silenced. -/
 def Converges (param : MWFParameter) : Prop :=
-  ∀ p ∈ vertices t, ∀ x ∈ (phaseAt t p).toList,
-    param.EdgeAsterisk x.1 (x.2.1.countP λ s => decide (IsWhPhrase s)) → IsSilenced t x.2.2
+  ∀ p ∈ vertices t, IsAsterisked t param p → ∀ x ∈ (phaseAt t p).toList, IsSilenced t x.2.2
 
 instance (param : MWFParameter) : Decidable (Converges t param) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
@@ -176,8 +236,8 @@ instance (param : MWFParameter) : Decidable (Converges t param) :=
 /-! ### Cost -/
 
 /-- The internal nodes of `t`, a shared constituent's once. -/
-def distinctNodes : List (RoseTree SOLabel) :=
-  ((vertices t).filterMap t.subtreeAt).filter (λ s => !s.isLeaf) |>.eraseDups
+def distinctNodes : List (RoseTree ChainLabel) :=
+  (((vertices t).filterMap t.subtreeAt).filter λ s => decide (s.value = ChainLabel.inner)).eraseDups
 
 /-- The cost of the object: its distinct tokens are the lexical items drawn, its distinct
 internal nodes the Merges, and its elided domains the applications of ellipsis. -/

--- a/Linglib/Syntax/Question.lean
+++ b/Linglib/Syntax/Question.lean
@@ -23,8 +23,7 @@ WordOrder).
   with [citko-gracanin-yuksek-2025]'s tri-valued refinement
   splitting non-MWF into vP-only vs both-edges asterisk languages)
 - `PhaseEdge`: which phase edge an asterisk lands on
-- `EdgeAsterisk`/`MWFViolation`/`EllipsisRepairsMWF`: Prop predicates
-  derived from `MWFParameter`
+- `EdgeAsterisk`: the asterisk a phase edge receives, derived from `MWFParameter`
 
 ## Theory-laden caveats
 
@@ -274,42 +273,6 @@ instance (p : MWFParameter) (e : PhaseEdge) (n : Nat) :
   cases p <;> cases e <;> unfold EdgeAsterisk <;> infer_instance
 
 end MWFParameter
-
-/-- A multiple-wh-fronting violation: *some* phase edge incurs an
-    asterisk for `n` wh-specifiers. -/
-def MWFViolation (p : MWFParameter) (n : Nat) : Prop :=
-  p.EdgeAsterisk .vP n ∨ p.EdgeAsterisk .CP n
-
-instance (p : MWFParameter) (n : Nat) : Decidable (MWFViolation p n) := by
-  unfold MWFViolation; infer_instance
-
-/-- Ellipsis of the vP edge repairs an MWF violation iff doing so
-    eliminates every asterisk — i.e., there is no surviving CP-edge
-    asterisk. In `nonFrontsVPOnly` languages, deleting the vP edge
-    removes the only asterisk; in `nonFrontsBothEdges`, the CP-edge
-    asterisk survives. -/
-def EllipsisRepairsMWF (p : MWFParameter) (n : Nat) (vpEdgeDeleted : Bool) : Prop :=
-  ¬ MWFViolation p n ∨ (vpEdgeDeleted = true ∧ ¬ p.EdgeAsterisk .CP n)
-
-instance (p : MWFParameter) (n : Nat) (vpDel : Bool) :
-    Decidable (EllipsisRepairsMWF p n vpDel) := by
-  unfold EllipsisRepairsMWF; infer_instance
-
-/-- Single wh-specifier never triggers an MWF violation. -/
-theorem single_wh_no_violation (p : MWFParameter) :
-    ¬ MWFViolation p 1 := by
-  cases p <;> decide
-
-/-- Zero wh-specifiers never trigger an MWF violation. -/
-theorem zero_wh_no_violation (p : MWFParameter) :
-    ¬ MWFViolation p 0 := by
-  cases p <;> decide
-
-/-- MWF languages never have violations. -/
-theorem mwf_language_no_violation (p : MWFParameter)
-    (h : p.AllowsMWF) (n : Nat) : ¬ MWFViolation p n := by
-  cases p <;> simp_all [MWFParameter.AllowsMWF, MWFViolation,
-    MWFParameter.EdgeAsterisk]
 
 end Syntax.Question
 


### PR DESCRIPTION
The study's candidates become planar objects with indexed traces (`ChainLabel`), each prediction decided from the object: strings, unbound traces (paired readings), asterisks, costs.
- `Linearization/Chain.lean`: traces indexed by their token, so copies inside a shared constituent are not mistaken for sharing; [E] silences the complement; vacuity as effect on pronunciation.
- Retires `PFOperation`/`pronunciationEconomy` (Economy/Basic) and `MWFViolation`/`EllipsisRepairsMWF` (Syntax/Question), whose sole consumer was this study.