### PR TITLE
refactor(Syntax/Minimalist/Economy): derivation cost as a lifted partial order

### DIFF
--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -187,14 +187,12 @@ theorem cwh_nonpaired : unboundTraces cwh = [] := by decide
 /-- The shared C′ carries a copy of each wh-phrase into the other conjunct. -/
 theorem cwhBulk_paired : Paired cwhBulk := by decide
 
-theorem cwh_beats_ellipsis : strictlyMoreEconomical (planarCost cwh) (planarCost cwhEllipsis) := by
-  decide
-theorem cwhBulk_beats_cwh : strictlyMoreEconomical (planarCost cwhBulk) (planarCost cwh) := by
-  decide
+theorem cwh_beats_ellipsis : planarCost cwh < planarCost cwhEllipsis := by decide
+theorem cwhBulk_beats_cwh : planarCost cwhBulk < planarCost cwh := by decide
 /-- The null complementizer of (14) adds structure and nothing to pronunciation. -/
-theorem cwh_beats_nullC : strictlyMoreEconomical (planarCost cwh) (planarCost cwhNullC) := by decide
+theorem cwh_beats_nullC : planarCost cwh < planarCost cwhNullC := by decide
 theorem cwhEmbedded_beats_twoC :
-    strictlyMoreEconomical (planarCost cwhEmbedded) (planarCost cwhEmbeddedTwoC) := by decide
+    planarCost cwhEmbedded < planarCost cwhEmbeddedTwoC := by decide
 
 /-- The shared C′ sends both wh-phrases through one vP edge, asterisked in English and
 pronounced. -/
@@ -208,9 +206,8 @@ theorem cwh_converges : Converges cwh englishA ∧ Converges cwh englishB := by 
 theorem cs_pf : pfPhon cs = ["what", "when"] := by decide
 theorem csEllipsis_pf : pfPhon csEllipsis = pfPhon cs := by decide
 theorem cs_paired : Paired cs := by decide
-theorem cs_beats_ellipsis : strictlyMoreEconomical (planarCost cs) (planarCost csEllipsis) := by
-  decide
-theorem cs_beats_twoC : strictlyMoreEconomical (planarCost cs) (planarCost csTwoC) := by decide
+theorem cs_beats_ellipsis : planarCost cs < planarCost csEllipsis := by decide
+theorem cs_beats_twoC : planarCost cs < planarCost csTwoC := by decide
 
 /-- The shared vP edge hosts two wh-specifiers: the asterisk of (26b). -/
 theorem cs_asterisked :
@@ -242,12 +239,11 @@ theorem csnr_pf : pfPhon csnr = pfPhon cs := by decide
 theorem csnr_economy : PronunciationEconomy csnr ∧ ¬ Paired csnr := by decide
 /-- Two [E] complementizers over shared material elide it twice. -/
 theorem csnrTwoE_vacuous : ¬ PronunciationEconomy csnrTwoE := by decide
-theorem csnr_beats_twoE : strictlyMoreEconomical (planarCost csnr) (planarCost csnrTwoE) := by
-  decide
+theorem csnr_beats_twoE : planarCost csnr < planarCost csnrTwoE := by decide
 /-- The nonpaired sluice is the cheapest nonpaired object respecting Pronunciation Economy: the
 shared [E] complementizer of (45c) draws one token fewer but elides vacuously. -/
 theorem csnr_optimal : ∀ t ∈ [csSharedC, csnrTwoE],
-    strictlyMoreEconomical (planarCost csnr) (planarCost t) ∨ ¬ PronunciationEconomy t := by decide
+    planarCost csnr < planarCost t ∨ ¬ PronunciationEconomy t := by decide
 /-- Footnote 30: the verb, shared, occurs in the second conjunct outside the elided TP and is
 silenced all the same, so the object cannot surface as a coordinated wh-question. -/
 theorem csnr_silences_shared :
@@ -301,13 +297,13 @@ theorem rnrMixed_pf : pfPhon rnrMixed =
     ["Alice", "must", "Iris", "ought to be", "working", "on", "different", "topics"] := by decide
 theorem rnrElided_pf : pfPhon rnrElided = pfPhon rnrMixed := by decide
 theorem rnrMixed_beats_elided :
-    strictlyMoreEconomical (planarCost rnrMixed) (planarCost rnrElided) := by decide
+    planarCost rnrMixed < planarCost rnrElided := by decide
 
 theorem rnrShared_pf : pfPhon rnrShared =
     ["Alice", "must", "Iris", "should", "work", "on", "different", "topics"] := by decide
 theorem rnrShared_isShared : IsShared rnrShared work := by decide
 /-- With matching verbs, ellipsis is no longer an option. -/
 theorem rnrShared_beats_mixed :
-    strictlyMoreEconomical (planarCost rnrShared) (planarCost rnrMatchedMixed) := by decide
+    planarCost rnrShared < planarCost rnrMatchedMixed := by decide
 
 end CitkoGracaninYuksek2025

--- a/Linglib/Studies/Longobardi2005.lean
+++ b/Linglib/Studies/Longobardi2005.lean
@@ -1,7 +1,6 @@
 import Linglib.Semantics.Reference.Basic
 import Linglib.Semantics.Reference.Kripke
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
-import Linglib.Syntax.Minimalist.Economy.Basic
 import Linglib.Studies.Longobardi2001
 
 /-!

--- a/Linglib/Syntax/Minimalist/Economy/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Economy/Basic.lean
@@ -1,288 +1,67 @@
-import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
-import Linglib.Syntax.Minimalist.Agree.Checking
-import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Data.DFinsupp.WellFounded
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Order.Hom.Basic
 
 /-!
-# Derivational Economy
+# Derivational economy
 
-Economy compares competing derivations that converge on the same PF
-string and LF interpretation, selecting the one with fewest operations
-and lexical resources.
+Economy of derivation ([chomsky-1991], [chomsky-1995]) compares the derivations that converge on
+the same string with the same interpretation and keeps the least costly. The cost of a derivation
+is the number of lexical items it draws, of Merge operations, of Agree operations and of
+applications of ellipsis, the four counts [citko-gracanin-yuksek-2025] weigh when they argue that
+multidominance is more economical than ellipsis; a derivation is more economical than another when
+it is no worse on every count and better on one, the product order on `ℕ⁴`. That order is
+well-founded (Dickson's lemma, `Pi.wellFoundedLT`), so every reference set has a winner
+(`WellFoundedLT.exists_minimal`).
 
-## Two principles
+## Main definitions
 
-- **Least Effort**: Pareto-minimize on lexical items / Merge ops / Agree
-  ops / E-feature deletions. Drawn from [chomsky-1991],
-  [chomsky-1995], [boskovic-1997]; the **global**
-  transderivational variant per [citko-gracanin-yuksek-2025] fn 3.
-  The local-economy alternative ([collins-2001]) is not formalized.
-
-- **Pronunciation Economy** ([citko-gracanin-yuksek-2025]): no application of
-  ellipsis is vacuous. It judges PF objects, so it lives with them:
-  `Minimalist.PronunciationEconomy` in `Linearization/Chain.lean`.
-
-## Headline (§3): well-foundedness via Dickson's lemma
-
-`instance : WellFoundedLT DerivationCost` lifts `Pi.wellFoundedLT` on
-`Fin 4 → Nat` (= Dickson 1913 applied to `Nat^n`) through the order
-embedding `DerivationCost.profileEmbedding`. This is what makes "economy
-selects an optimum from the reference set" mathematically *coherent*:
-without WF, an infinite chain of ever-more-economical derivations could
-exist and "the economy winner" would be ill-defined. WF is a
-precondition for the linguistic content, not a corollary.
-
-The load-bearing corollary `economy_admits_winner` says any non-empty
-`R : Set DerivationCost` admits a Pareto-minimum. Consumers identifying
-a *specific* winner of a binary reference set (the common C&G-Y pattern)
-use the `economy_winner_of_pair` helper.
-
-## Architectural realization
-
-`DerivationCost` is a 4-Nat record. Its preorder is the pullback of
-`Pi.preorder` on `Fin 4 → Nat` through `DerivationCost.profile`,
-realized via `Core.Order.PullbackPreorder.ofProj`. Same shape as
-`Core/Optimization/Pareto.lean`'s `paretoPullbackPreorder` (used for OT/HG
-candidate comparison); the OT side wraps in `ConstraintSystem` with
-candidate set + decoder, but Minimalist economy needs neither, so we
-register `Preorder DerivationCost` directly. `coarsen_via_monotone` from
-`Core/Order/PullbackPreorder.lean` is then available for free.
+* `DerivationCost`: the four counts, partially ordered as their profile in `Fin 4 → ℕ`.
 
 ## References
 
-* [chomsky-1991], [chomsky-1995], [boskovic-1997], [collins-2001]
-* [citko-gracanin-yuksek-2025]
+* [N. Chomsky, *Some notes on economy of derivation and representation* (1991)][chomsky-1991]
+* [N. Chomsky, *The Minimalist Program* (1995)][chomsky-1995]
+* [B. Citko and M. Gračanin-Yuksek, *Economy in PF reduction* (2025)][citko-gracanin-yuksek-2025]
 -/
 
 namespace Minimalist
 
-section DerivationCost
-
-/-- 4-dimensional cost of a syntactic derivation, measured by operation
-    and resource counts. The dimensions are exactly those
-    [citko-gracanin-yuksek-2025] (p. 3) compares when arguing
-    multidominance is more economical than ellipsis: lexical items drawn
-    from the numeration, Merge operations, Agree operations, and
-    E-feature triggered PF deletions. -/
+/-- The cost of a derivation: the lexical items drawn, the Merge operations, the Agree operations
+and the applications of ellipsis. -/
 structure DerivationCost where
-  lexicalItems : Nat
-  mergeOps : Nat
-  agreeOps : Nat
-  ellipsisOps : Nat
+  lexicalItems : ℕ
+  mergeOps : ℕ
+  agreeOps : ℕ
+  ellipsisOps : ℕ
   deriving Repr, DecidableEq
 
 namespace DerivationCost
 
-/-- The 4-vector projection: `profile c i` is the i-th cost dimension
-    (0 = lexicalItems, 1 = mergeOps, 2 = agreeOps, 3 = ellipsisOps).
-    Feature map for the `Core.Order.PullbackPreorder` instance. -/
-def profile (c : DerivationCost) : Fin 4 → Nat
-  | ⟨0, _⟩ => c.lexicalItems
-  | ⟨1, _⟩ => c.mergeOps
-  | ⟨2, _⟩ => c.agreeOps
-  | ⟨3, _⟩ => c.ellipsisOps
+/-- The four counts as a vector. -/
+def profile (c : DerivationCost) : Fin 4 → ℕ :=
+  ![c.lexicalItems, c.mergeOps, c.agreeOps, c.ellipsisOps]
 
-@[simp] theorem profile_zero (c : DerivationCost) : c.profile 0 = c.lexicalItems := rfl
-@[simp] theorem profile_one (c : DerivationCost) : c.profile 1 = c.mergeOps := rfl
-@[simp] theorem profile_two (c : DerivationCost) : c.profile 2 = c.agreeOps := rfl
-@[simp] theorem profile_three (c : DerivationCost) : c.profile 3 = c.ellipsisOps := rfl
-
-/-- Cost-comparison preorder via `PullbackPreorder.ofProj` pullback
-    through `profile`, with `Pi.preorder` (pointwise ≤) on the
-    `Fin 4 → Nat` feature space.
-
-    See module docstring § "Architectural realization" for the parallel
-    with `Core/Optimization/Pareto.lean`'s `paretoPullbackPreorder`. -/
-def pullbackPreorder : Core.Order.PullbackPreorder DerivationCost (Fin 4 → Nat) :=
-  Core.Order.PullbackPreorder.ofProj profile (fun a a' =>
-    decidable_of_iff (∀ i, a.profile i ≤ a'.profile i) Iff.rfl)
-
-instance : Preorder DerivationCost := pullbackPreorder.toPreorder
-
-end DerivationCost
-
-/-- Extract cost from a core `Derivation` (step-based model).
-
-    `lexicalItems`: each `emL`/`emR`/`wlm` step draws one lexical item
-    from the numeration. (Wholesale Late Merger
-    [takahashi-hulsey-2009] introduces a restrictor — also a
-    numeration draw.)
-    `mergeOps`: total step count.
-    `agreeOps`/`ellipsisOps`: not tracked by the step-based model. -/
-def SyntacticObject.Derivation.cost (d : Derivation) : DerivationCost where
-  lexicalItems :=
-    d.steps.filter
-      (match · with | .emL _ | .emR _ => true | _ => false)
-      |>.length
-  mergeOps := d.steps.length
-  agreeOps := 0
-  ellipsisOps := 0
-
-end DerivationCost
-
-section EconomyComparison
-
-/-- Componentwise Pareto: `c1` is at-least-as-economical as `c2` iff every
-    cost dimension is no worse. Linguistic-named alias for the underlying
-    `Preorder.le` from `DerivationCost.pullbackPreorder`.
-
-    NB: this is **not** a flat sum. Earlier revisions used `totalOps :=
-    mergeOps + agreeOps + ellipsisOps` followed by 2-tuple
-    `(totalOps, lexicalItems)` comparison, which lets a derivation with
-    `agreeOps=0, mergeOps=100` "beat" one with `agreeOps=10, mergeOps=50`
-    purely on the sum (110 vs 60) — a comparison
-    [citko-gracanin-yuksek-2025] (p. 3) explicitly does not endorse:
-    they argue MD is more economical than ellipsis on the *each-dimension*
-    reading (fewer lexical items AND fewer Merge AND fewer Agree). -/
-def atLeastAsEconomical (c1 c2 : DerivationCost) : Prop :=
-  c1.lexicalItems ≤ c2.lexicalItems ∧
-  c1.mergeOps ≤ c2.mergeOps ∧
-  c1.agreeOps ≤ c2.agreeOps ∧
-  c1.ellipsisOps ≤ c2.ellipsisOps
-
-instance (c1 c2 : DerivationCost) : Decidable (atLeastAsEconomical c1 c2) := by
-  unfold atLeastAsEconomical; infer_instance
-
-/-- Strict Pareto: at-least-as-economical AND strictly better on at least
-    one dimension. Equivalent to `<` from the `Preorder` instance
-    (cf. `strictlyMoreEconomical_iff_lt`), but not definitionally equal. -/
-def strictlyMoreEconomical (c1 c2 : DerivationCost) : Prop :=
-  atLeastAsEconomical c1 c2 ∧
-  (c1.lexicalItems < c2.lexicalItems ∨ c1.mergeOps < c2.mergeOps ∨
-   c1.agreeOps < c2.agreeOps ∨ c1.ellipsisOps < c2.ellipsisOps)
-
-instance (c1 c2 : DerivationCost) : Decidable (strictlyMoreEconomical c1 c2) := by
-  unfold strictlyMoreEconomical; infer_instance
-
-/-- The linguistic alias agrees with `≤` from the `PullbackPreorder` pullback
-    componentwise. Tagged `@[simp]` so consumers can rewrite freely between
-    the linguistic and order-theoretic forms. -/
-@[simp] theorem atLeastAsEconomical_iff_le (c1 c2 : DerivationCost) :
-    atLeastAsEconomical c1 c2 ↔ c1 ≤ c2 := by
-  refine ⟨fun ⟨h0, h1, h2, h3⟩ i => ?_, fun h => ?_⟩
-  · match i with
-    | ⟨0, _⟩ => exact h0
-    | ⟨1, _⟩ => exact h1
-    | ⟨2, _⟩ => exact h2
-    | ⟨3, _⟩ => exact h3
-  · exact ⟨h ⟨0, by decide⟩, h ⟨1, by decide⟩, h ⟨2, by decide⟩, h ⟨3, by decide⟩⟩
-
-/-- Strict economy is the strict order of the `Preorder` instance:
-    `at-least-as-economical AND strictly better on at least one dimension`
-    iff `c1 ≤ c2 ∧ ¬ c2 ≤ c1`. -/
-theorem strictlyMoreEconomical_iff_lt (c1 c2 : DerivationCost) :
-    strictlyMoreEconomical c1 c2 ↔ c1 < c2 := by
-  rw [lt_iff_le_not_ge, ← atLeastAsEconomical_iff_le, ← atLeastAsEconomical_iff_le]
-  unfold strictlyMoreEconomical atLeastAsEconomical
-  refine ⟨fun ⟨⟨hl, hm, ha, he⟩, hstrict⟩ =>
-    ⟨⟨hl, hm, ha, he⟩, fun ⟨hl', hm', ha', he'⟩ => ?_⟩,
-    fun ⟨⟨hl, hm, ha, he⟩, hnot⟩ => ⟨⟨hl, hm, ha, he⟩, ?_⟩⟩
-  · rcases hstrict with h | h | h | h <;> omega
-  · by_contra hbad
-    push Not at hbad
-    obtain ⟨hl', hm', ha', he'⟩ := hbad
-    exact hnot ⟨by omega, by omega, by omega, by omega⟩
-
-end EconomyComparison
-
-section WellFoundedness
-
-/-! ### Well-Foundedness — the headline (Dickson's lemma) -/
-
-namespace DerivationCost
-
-/-- `profile` is injective: a derivation cost is determined by its 4
-    components. Foundational fact for the `OrderEmbedding` and
-    `PartialOrder` instances below. -/
 theorem profile_injective : Function.Injective profile := by
-  intro c1 c2 h
-  cases c1; cases c2
-  congr 1
-  · exact congrFun h 0
-  · exact congrFun h 1
-  · exact congrFun h 2
-  · exact congrFun h 3
+  rintro ⟨_, _, _, _⟩ ⟨_, _, _, _⟩ h
+  simp_all [profile, Matrix.vecCons_inj]
 
-/-- Order embedding of `DerivationCost` into the 4-vector Pareto preorder
-    on `Fin 4 → Nat`. `map_rel_iff'` is `Iff.rfl` because the
-    `Preorder DerivationCost` instance is `pullbackPreorder.toPreorder =
-    Preorder.lift profile` (`≤` is *definitionally* `profile a ≤
-    profile b`). -/
-def profileEmbedding : DerivationCost ↪o (Fin 4 → Nat) where
-  toFun := profile
-  inj' := profile_injective
-  map_rel_iff' := Iff.rfl
+/-- A cost is at most another when it is at most on every count. -/
+instance : PartialOrder DerivationCost := PartialOrder.lift profile profile_injective
+
+instance : DecidableLE DerivationCost := λ a b =>
+  inferInstanceAs (Decidable (∀ i, a.profile i ≤ b.profile i))
+
+instance : DecidableLT DerivationCost := λ a b =>
+  decidable_of_iff (a ≤ b ∧ ¬ b ≤ a) lt_iff_le_not_ge.symm
+
+/-- The costs embed in `Fin 4 → ℕ`. -/
+def profileEmbedding : DerivationCost ↪o (Fin 4 → ℕ) := ⟨⟨profile, profile_injective⟩, Iff.rfl⟩
+
+/-- Dickson's lemma: no derivation is beaten by an infinite descent of ever more economical
+ones. -/
+instance : WellFoundedLT DerivationCost := profileEmbedding.wellFoundedLT
 
 end DerivationCost
-
-/-- `DerivationCost` is a `PartialOrder`, not just a `Preorder`:
-    antisymmetry from componentwise `Nat.le_antisymm` lifted by
-    `profile_injective`. Mathlib's order algebra (`IsAntichain`,
-    `Maximal`, `Minimal`) gets the partial-order flavor for free. -/
-instance : PartialOrder DerivationCost where
-  __ := (inferInstance : Preorder DerivationCost)
-  le_antisymm a b hab hba := DerivationCost.profile_injective <| by
-    funext i
-    exact le_antisymm (hab i) (hba i)
-
-/-- **The headline (Dickson's lemma applied to derivational economy)**:
-    the Pareto-strict order on `DerivationCost` is well-founded.
-
-    Lifted from `Pi.wellFoundedLT` on `Fin 4 → Nat` — which IS Dickson's
-    lemma applied to `Nat^n` — through the order embedding
-    `DerivationCost.profileEmbedding` via `OrderEmbedding.wellFounded`.
-
-    **Structural significance**: this is what makes the [chomsky-1995]
-    / [citko-gracanin-yuksek-2025] claim that "economy selects an
-    optimum from the reference set" *coherent*. Without well-foundedness,
-    an infinite chain `c₀ > c₁ > c₂ > …` of ever-more-economical
-    derivations could exist, and "the economy winner" would be
-    ill-defined. The well-foundedness theorem is a *precondition* for the
-    linguistic content, not a corollary of it.
-
-    Mathematically: Dickson 1913, foundational for the Robbiano-Buchberger
-    Gröbner basis termination argument and Hilbert's basis theorem on
-    monomial ideals. The classical statement "every monomial ideal in
-    `k[x₁, …, xₙ]` is finitely generated" reduces to exactly this
-    well-foundedness on `Nat^n` under the divisibility order, which is
-    the Pareto-componentwise order on exponent vectors. -/
-instance : WellFoundedLT DerivationCost :=
-  ⟨DerivationCost.profileEmbedding.wellFounded
-    (Function.wellFoundedLT (α := Nat)).wf⟩
-
-/-- **Existence of economy winners**: any non-empty set `R` of derivation
-    costs admits at least one Pareto-minimum — a "winner" not strictly
-    dominated by any other element of `R`.
-
-    Direct corollary of `WellFoundedLT DerivationCost` via mathlib's
-    `WellFounded.has_min`, with the `<` ↔ `strictlyMoreEconomical`
-    translation through `strictlyMoreEconomical_iff_lt`.
-
-    Linguistically: the [citko-gracanin-yuksek-2025] selection
-    procedure is mathematically well-defined; whatever else economy +
-    Pronunciation Economy + MWF do to break ties among winners, the set
-    of winners is non-empty for any non-empty reference set. -/
-theorem economy_admits_winner {R : Set DerivationCost} (hR : R.Nonempty) :
-    ∃ winner ∈ R, ∀ alt ∈ R, ¬ strictlyMoreEconomical alt winner := by
-  obtain ⟨winner, hwR, hmin⟩ := wellFounded_lt.has_min R hR
-  exact ⟨winner, hwR, fun alt haltR hsme =>
-    hmin alt haltR ((strictlyMoreEconomical_iff_lt _ _).mp hsme)⟩
-
-/-- **Consumer-friendly form**: in a 2-element reference set `{c, c'}`
-    where `c` strictly beats `c'`, `c` is the economy winner. The common
-    pattern in [citko-gracanin-yuksek-2025]-style cost-comparison
-    arguments: pair MD-cost vs ellipsis-cost, prove MD beats ellipsis,
-    conclude MD is the winner.
-
-    Discharges via `lt_irrefl` (anti-self-domination) + asymmetry of `<`. -/
-theorem economy_winner_of_pair {c c' : DerivationCost}
-    (h : strictlyMoreEconomical c c') :
-    ∀ alt ∈ ({c, c'} : Set DerivationCost), ¬ strictlyMoreEconomical alt c := by
-  have hlt : c < c' := (strictlyMoreEconomical_iff_lt _ _).mp h
-  rintro alt (rfl | rfl) halt_lt
-  · exact lt_irrefl _ ((strictlyMoreEconomical_iff_lt _ _).mp halt_lt)
-  · exact lt_asymm hlt ((strictlyMoreEconomical_iff_lt _ _).mp halt_lt)
-
-end WellFoundedness
 
 end Minimalist

--- a/references.bib
+++ b/references.bib
@@ -17826,6 +17826,19 @@
   role      = {cited},
   sources   = {Fragments/Hungarian/Case.lean;Studies/Caha2009.lean}
 }
+@incollection{chomsky-1991,
+  author    = {Chomsky, Noam},
+  year      = {1991},
+  title     = {Some notes on economy of derivation and representation},
+  booktitle = {Principles and Parameters in Comparative Grammar},
+  editor    = {Freidin, Robert},
+  pages     = {417--454},
+  publisher = {MIT Press},
+  subfield  = {syntax},
+  role      = {foundational},
+  sources   = {Syntax/Minimalist/Economy/Basic.lean}
+}
+
 @book{chomsky-1995,
   author    = {Chomsky, Noam},
   year      = {1995},


### PR DESCRIPTION
`DerivationCost` is ordered by `PartialOrder.lift` through its profile in `Fin 4 → ℕ`, with decidable `≤`/`<` and `WellFoundedLT` from the order embedding; the study compares costs with `<` directly.
- Retires `atLeastAsEconomical`/`strictlyMoreEconomical` and their bridge lemmas, `economy_admits_winner` (mathlib's `WellFoundedLT.exists_minimal`), `economy_winner_of_pair`, and the unconsumed `Derivation.cost` stub.
- Adds `chomsky-1991` to the bib; drops Longobardi2005's unused import.