### PR TITLE
refactor(Syntax/Minimalist/Economy): cost per dimension over the terms

### DIFF
--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -23,11 +23,11 @@ the second deletion silences nothing new, and it forces the nonpaired sluice to 
 complementizers, only one bearing [E]. In right node raising the same economy prefers sharing
 the pivot to building it twice and, when the verbs match, sharing the verb phrase to eliding it.
 
-Each candidate is a planar object of `Linearization/Chain.lean`: a token at two positions is
-shared, a moved wh-phrase leaves indexed traces at the vP edge and its base position, and the
-coordinator is left out, so a string is its conjuncts' words. The predictions decide: the
-pronounced strings, the unbound traces that carry the paired reading, the asterisks, and the
-costs the winners beat.
+Each candidate is a planar object of `Linearization/Chain.lean`, and forgetting its trace indices
+a syntactic object of `SyntacticObject/Basic.lean`: a token at two positions is shared, a moved
+wh-phrase leaves indexed traces at the vP edge and its base position, and the coordinator is left
+out, so a string is its conjuncts' words. The predictions decide: the pronounced strings, the
+unbound traces that carry the paired reading, the asterisks, and the costs the winners beat.
 
 ## References
 
@@ -156,6 +156,12 @@ def Paired (t : RoseTree ChainLabel) : Prop :=
   ∃ x ∈ unboundTraces t, x.2 = what ∧ x.1.head? = some 1
 
 instance : DecidablePred Paired := λ _ => inferInstanceAs (Decidable (∃ _ ∈ _, _))
+
+/-- The candidates are syntactic objects. -/
+theorem candidates_isSO : ∀ t ∈ [cwh, cwhEllipsis, cwhBulk, cwhNullC, cwhNullCSecond, cwhEmbedded,
+      cwhEmbeddedTwoC, cwhTwoAux, cs, csTwoC, csEllipsis, csSharedC, csnrTwoE, csnr,
+      multipleQuestion c, multipleQuestion cE],
+    isSOPlanar (t.map ChainLabel.toSOLabel) = true := by decide
 
 /-! ### The multiple-wh-fronting parameter (27) by language -/
 

--- a/Linglib/Syntax/Minimalist/Economy/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Economy/Basic.lean
@@ -1,22 +1,23 @@
 import Mathlib.Data.DFinsupp.WellFounded
-import Mathlib.Data.Fin.VecNotation
-import Mathlib.Order.Hom.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Derivational economy
 
 Economy of derivation ([chomsky-1991], [chomsky-1995]) compares the derivations that converge on
-the same string with the same interpretation and keeps the least costly. The cost of a derivation
-is the number of lexical items it draws, of Merge operations, of Agree operations and of
-applications of ellipsis, the four counts [citko-gracanin-yuksek-2025] weigh when they argue that
-multidominance is more economical than ellipsis; a derivation is more economical than another when
-it is no worse on every count and better on one, the product order on `ℕ⁴`. That order is
-well-founded (Dickson's lemma, `Pi.wellFoundedLT`), so every reference set has a winner
-(`WellFoundedLT.exists_minimal`).
+the same string with the same interpretation and keeps the least costly. A cost is a count per
+dimension: the lexical items drawn and the Merge operations, which are the distinct terms of the
+object built, its lexical leaves and its internal vertices each once, so that a shared constituent
+is built once; and the Agree operations and applications of ellipsis that
+[citko-gracanin-yuksek-2025] weigh alongside them. Costs are ordered pointwise: a derivation is
+more economical than another when it is no worse on every dimension and better on one. The order
+is well-founded (Dickson's lemma, `Pi.wellFoundedLT`), so every reference set has a winner
+(`WellFoundedLT.exists_minimal`). The cost of a planar object is read off its terms by
+`Minimalist.planarCost` in `Linearization/Chain.lean`.
 
 ## Main definitions
 
-* `DerivationCost`: the four counts, partially ordered as their profile in `Fin 4 → ℕ`.
+* `CostDimension`, `DerivationCost`: the dimensions and a count per dimension.
 
 ## References
 
@@ -27,41 +28,20 @@ well-founded (Dickson's lemma, `Pi.wellFoundedLT`), so every reference set has a
 
 namespace Minimalist
 
-/-- The cost of a derivation: the lexical items drawn, the Merge operations, the Agree operations
-and the applications of ellipsis. -/
-structure DerivationCost where
-  lexicalItems : ℕ
-  mergeOps : ℕ
-  agreeOps : ℕ
-  ellipsisOps : ℕ
-  deriving Repr, DecidableEq
+/-- The dimensions of derivational cost. -/
+inductive CostDimension
+  | lexicalItems
+  | mergeOps
+  | agreeOps
+  | ellipsisOps
+  deriving DecidableEq, Fintype, Repr
 
-namespace DerivationCost
+/-- The cost of a derivation: a count per dimension, ordered pointwise. -/
+abbrev DerivationCost := CostDimension → ℕ
 
-/-- The four counts as a vector. -/
-def profile (c : DerivationCost) : Fin 4 → ℕ :=
-  ![c.lexicalItems, c.mergeOps, c.agreeOps, c.ellipsisOps]
-
-theorem profile_injective : Function.Injective profile := by
-  rintro ⟨_, _, _, _⟩ ⟨_, _, _, _⟩ h
-  simp_all [profile, Matrix.vecCons_inj]
-
-/-- A cost is at most another when it is at most on every count. -/
-instance : PartialOrder DerivationCost := PartialOrder.lift profile profile_injective
-
-instance : DecidableLE DerivationCost := λ a b =>
-  inferInstanceAs (Decidable (∀ i, a.profile i ≤ b.profile i))
+instance : DecidableLE DerivationCost := λ a b => inferInstanceAs (Decidable (∀ i, a i ≤ b i))
 
 instance : DecidableLT DerivationCost := λ a b =>
   decidable_of_iff (a ≤ b ∧ ¬ b ≤ a) lt_iff_le_not_ge.symm
-
-/-- The costs embed in `Fin 4 → ℕ`. -/
-def profileEmbedding : DerivationCost ↪o (Fin 4 → ℕ) := ⟨⟨profile, profile_injective⟩, Iff.rfl⟩
-
-/-- Dickson's lemma: no derivation is beaten by an infinite descent of ever more economical
-ones. -/
-instance : WellFoundedLT DerivationCost := profileEmbedding.wellFoundedLT
-
-end DerivationCost
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Linearization/Chain.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Chain.lean
@@ -22,11 +22,14 @@ silences no pronounceable token an earlier one had not already silenced is vacuo
 configuration [citko-gracanin-yuksek-2025]'s Pronunciation Economy bans. A `v` or `C` projection
 whose edge hosts several wh-specifiers, wh-tokens or their traces, receives the asterisk of the
 multiple-wh-fronting parameter and crashes at PF unless its head is silenced. The cost of the
-object is read off its distinct tokens and nodes: a shared constituent is built once.
+object is read off its terms, the distinct subtrees as MCB's `subtrees` taken each once: the lexical
+leaves are the items drawn and the internal vertices the Merges, so a shared constituent is built
+once.
 
 ## Main definitions
 
 * `ChainLabel`, `tokenList`, `occurrences`, `unboundTraces`, `IsShared`: occurrences and chains.
+* `terms`: the distinct subtrees, a shared constituent's once.
 * `elidedDomains`, `IsSilenced`, `pfPhon`: pronunciation under [E].
 * `IsVacuous`, `PronunciationEconomy`: the ban on vacuous ellipsis.
 * `projection`, `phaseAt`, `IsAsterisked`, `Converges`: the multiple-wh-fronting asterisk.
@@ -112,7 +115,10 @@ def occurrences (tok : LIToken) : List Path :=
   (tokenList t).filterMap λ x => if x.2 = tok then some x.1 else none
 
 /-- The tokens of `t`, each once. -/
-def distinctTokens : List LIToken := ((tokenList t).map (·.2)).eraseDups
+def tokens : Finset LIToken := ((tokenList t).map (·.2)).toFinset
+
+/-- The terms of `t`: its subtrees, a shared constituent's once. -/
+def terms : Finset (RoseTree ChainLabel) := ((vertices t).filterMap t.subtreeAt).toFinset
 
 /-- `tok` is shared, dominated by two mothers: it occurs twice. -/
 def IsShared (tok : LIToken) : Prop := 2 ≤ (occurrences t tok).length
@@ -167,15 +173,15 @@ def pfYield : List LIToken :=
 def pfPhon : List String := (pfYield t).filterMap LIToken.phonForm?
 
 /-- The pronounceable tokens the application at the domain `K` silences. -/
-def silencedBy (K : Path) : List LIToken :=
-  (distinctTokens t).filter λ s => s.phonForm?.isSome ∧ (occurrences t s).any (decide <| K <+: ·)
+def silencedBy (K : Path) : Finset LIToken :=
+  (tokens t).filter λ s => s.phonForm?.isSome ∧ (occurrences t s).any (decide <| K <+: ·)
 
-/-- The application at `K` has no effect on pronunciation: every token it silences an earlier
-application silenced. -/
+/-- The application at `K` has no effect on pronunciation: the earlier applications silenced
+every token it silences. -/
 def IsVacuous (K : Path) : Prop :=
-  ∀ s ∈ silencedBy t K, ∃ K' ∈ (elidedDomains t).takeWhile (· ≠ K), s ∈ silencedBy t K'
+  silencedBy t K ⊆ ((elidedDomains t).takeWhile (· ≠ K)).toFinset.biUnion (silencedBy t)
 
-instance (K : Path) : Decidable (IsVacuous t K) := inferInstanceAs (Decidable (∀ _ ∈ _, _))
+instance (K : Path) : Decidable (IsVacuous t K) := by unfold IsVacuous; infer_instance
 
 /-- **Pronunciation Economy** ([citko-gracanin-yuksek-2025] (39)): no application of ellipsis is
 vacuous. -/
@@ -235,16 +241,12 @@ instance (param : MWFParameter) : Decidable (Converges t param) :=
 
 /-! ### Cost -/
 
-/-- The internal nodes of `t`, a shared constituent's once. -/
-def distinctNodes : List (RoseTree ChainLabel) :=
-  (((vertices t).filterMap t.subtreeAt).filter λ s => decide (s.value = ChainLabel.inner)).eraseDups
-
-/-- The cost of the object: its distinct tokens are the lexical items drawn, its distinct
-internal nodes the Merges, and its elided domains the applications of ellipsis. -/
-def planarCost : DerivationCost where
-  lexicalItems := (distinctTokens t).length
-  mergeOps := (distinctNodes t).length
-  agreeOps := 0
-  ellipsisOps := (elidedDomains t).length
+/-- The cost of the object: its tokens are the lexical items drawn, its internal terms the Merges,
+and its elided domains the applications of ellipsis. -/
+def planarCost : DerivationCost
+  | .lexicalItems => (tokens t).card
+  | .mergeOps => ((terms t).filter λ s => s.value = ChainLabel.inner).card
+  | .agreeOps => 0
+  | .ellipsisOps => (elidedDomains t).length
 
 end Minimalist


### PR DESCRIPTION
`DerivationCost` becomes `CostDimension → ℕ` under mathlib's pointwise order (decidable, well-founded by `Pi.wellFoundedLT`), and an object's cost is read off its terms, the distinct subtrees as MCB's `subtrees` each once: tokens are the items drawn, internal terms the Merges.
- Vacuity of an ellipsis application is a `Finset` inclusion: its silenced tokens are covered by the earlier applications'.
- The study proves its candidates are MCB syntactic objects once the trace indices are forgotten.