### PR TITLE
refactor(Syntax/Minimalist): index the trace leaf by the moved head

### DIFF
--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -104,14 +104,14 @@ private def tokDem : LIToken := ⟨.simple .Dem [], 4⟩
 /-- The tree contains the overt noun; a trace does not count (7b-vi). -/
 private def hasN : RoseTree SOLabel → Bool
   | .node (.inl t) _ => t == tokN
-  | .node (.inr ()) [l, r] => hasN l || hasN r
-  | .node (.inr ()) _ => false
+  | .node (.inr none) [l, r] => hasN l || hasN r
+  | .node (.inr _) _ => false
 
 /-- The noun is the tree's specifier, `[NP [XP]]` (fn. 21). -/
 private def specHasN : RoseTree SOLabel → Bool
   | .node (.inl t) _ => t == tokN
-  | .node (.inr ()) [l, _] => hasN l
-  | .node (.inr ()) _ => false
+  | .node (.inr none) [l, _] => hasN l
+  | .node (.inr _) _ => false
 
 private def subtrees : RoseTree SOLabel → List (RoseTree SOLabel)
   | t@(.node _ []) => [t]

--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -23,11 +23,11 @@ the second deletion silences nothing new, and it forces the nonpaired sluice to 
 complementizers, only one bearing [E]. In right node raising the same economy prefers sharing
 the pivot to building it twice and, when the verbs match, sharing the verb phrase to eliding it.
 
-Each candidate is a planar object of `Linearization/Chain.lean`, and forgetting its trace indices
-a syntactic object of `SyntacticObject/Basic.lean`: a token at two positions is shared, a moved
-wh-phrase leaves indexed traces at the vP edge and its base position, and the coordinator is left
-out, so a string is its conjuncts' words. The predictions decide: the pronounced strings, the
-unbound traces that carry the paired reading, the asterisks, and the costs the winners beat.
+Each candidate is a planar syntactic object with the chains of `Linearization/Chain.lean`: a token
+at two positions is shared, a moved wh-phrase leaves the traces of its head at the vP edge and its
+base position, and the coordinator is left out, so a string is its conjuncts' words. The predictions
+decide: the pronounced strings, the unbound traces that carry the paired reading, the asterisks, and
+the costs the winners beat.
 
 ## References
 
@@ -39,7 +39,7 @@ unbound traces that carry the paired reading, the asterisks, and the costs the w
 
 namespace CitkoGracaninYuksek2025
 
-open Minimalist RoseTree RoseTree.Pathed
+open Minimalist Minimalist.SyntacticObject RoseTree RoseTree.Pathed
 open Syntax.Question (MWFParameter)
 
 /-! ### The lexicon -/
@@ -78,51 +78,51 @@ def saw := tok 20 .V [.D] "saw"
 
 /-- `[CP wh [C′ c [TP subj [T′ T [vP wh [v′ v VP]]]]]]`: the wh-phrase moved through the edge of
 vP. -/
-def clause (wh c subj T v : LIToken) (VP : RoseTree ChainLabel) : RoseTree ChainLabel :=
-  nodeC (leafC wh) (nodeC (leafC c)
-    (nodeC (leafC subj) (nodeC (leafC T) (nodeC (traceC wh) (nodeC (leafC v) VP)))))
+def clause (wh c subj T v : LIToken) (VP : RoseTree SOLabel) : RoseTree SOLabel :=
+  nodeP (leafP wh) (nodeP (leafP c)
+    (nodeP (leafP subj) (nodeP (leafP T) (nodeP (traceOfP wh) (nodeP (leafP v) VP)))))
 
 /-- Non-bulk sharing under the complementizers `c₁` and `c₂`: each wh-phrase in its own
 conjunct, the subject, T, v and verb shared ((10b), (14), (16b), (38d), (45b), (46b)). -/
-def nonBulk (c₁ c₂ : LIToken) : RoseTree ChainLabel :=
-  nodeC (clause what c₁ you T v (nodeC (leafC teach) (traceC what)))
-    (clause when c₂ you T v (nodeC (leafC teach) (traceC when)))
+def nonBulk (c₁ c₂ : LIToken) : RoseTree SOLabel :=
+  nodeP (clause what c₁ you T v (nodeP (leafP teach) (traceOfP what)))
+    (clause when c₂ you T v (nodeP (leafP teach) (traceOfP when)))
 
 /-- Bulk sharing: one C′ under both wh-phrases, both of which moved through its vP edge ((12b),
 (20b)). -/
-def bulk (c : LIToken) : RoseTree ChainLabel :=
-  let c' := nodeC (leafC c) (nodeC (leafC you) (nodeC (leafC T) (nodeC (traceC what)
-    (nodeC (traceC when)
-      (nodeC (leafC v) (nodeC (nodeC (leafC teach) (traceC what)) (traceC when)))))))
-  nodeC (nodeC (leafC what) c') (nodeC (leafC when) c')
+def bulk (c : LIToken) : RoseTree SOLabel :=
+  let c' := nodeP (leafP c) (nodeP (leafP you) (nodeP (leafP T) (nodeP (traceOfP what)
+    (nodeP (traceOfP when)
+      (nodeP (leafP v) (nodeP (nodeP (leafP teach) (traceOfP what)) (traceOfP when)))))))
+  nodeP (nodeP (leafP what) c') (nodeP (leafP when) c')
 
 /-- Footnote 21's alternative to `bulk`: a shared TP under two complementizers. -/
-def bulkTP (c₁ c₂ : LIToken) : RoseTree ChainLabel :=
-  let tp := nodeC (leafC you) (nodeC (leafC T) (nodeC (traceC what)
-    (nodeC (traceC when)
-      (nodeC (leafC v) (nodeC (nodeC (leafC teach) (traceC what)) (traceC when))))))
-  nodeC (nodeC (leafC what) (nodeC (leafC c₁) tp)) (nodeC (leafC when) (nodeC (leafC c₂) tp))
+def bulkTP (c₁ c₂ : LIToken) : RoseTree SOLabel :=
+  let tp := nodeP (leafP you) (nodeP (leafP T) (nodeP (traceOfP what)
+    (nodeP (traceOfP when)
+      (nodeP (leafP v) (nodeP (nodeP (leafP teach) (traceOfP what)) (traceOfP when))))))
+  nodeP (nodeP (leafP what) (nodeP (leafP c₁) tp)) (nodeP (leafP when) (nodeP (leafP c₂) tp))
 
 /-- Two clauses from separate tokens, the first elided under its [E] complementizer with its
 auxiliary in T, as the Sluicing-COMP generalization requires of a sluice: the ellipsis analysis
 of the coordinated wh-question (11b). -/
-def cwhEllipsis : RoseTree ChainLabel :=
-  nodeC (nodeC (leafC what) (nodeC (leafC cE) (nodeC (leafC you) (nodeC (leafC shouldT)
-      (nodeC (traceC what) (nodeC (leafC v) (nodeC (leafC teach) (traceC what))))))))
-    (clause when should you' T' v' (nodeC (leafC teach') (traceC when)))
+def cwhEllipsis : RoseTree SOLabel :=
+  nodeP (nodeP (leafP what) (nodeP (leafP cE) (nodeP (leafP you) (nodeP (leafP shouldT)
+      (nodeP (traceOfP what) (nodeP (leafP v) (nodeP (leafP teach) (traceOfP what))))))))
+    (clause when should you' T' v' (nodeP (leafP teach') (traceOfP when)))
 
 /-- Two clauses from separate tokens, both elided, the second's object the pronoun of vehicle
 change: the double-ellipsis analysis of the coordinated sluice (19b). -/
-def csEllipsis : RoseTree ChainLabel :=
-  nodeC (clause what cE you T v (nodeC (leafC teach) (traceC what)))
-    (clause when cE' you' T' v' (nodeC (nodeC (leafC teach') (leafC it)) (traceC when)))
+def csEllipsis : RoseTree SOLabel :=
+  nodeP (clause what cE you T v (nodeP (leafP teach) (traceOfP what)))
+    (clause when cE' you' T' v' (nodeP (nodeP (leafP teach') (leafP it)) (traceOfP when)))
 
 /-- A multiple question, both wh-phrases fronted through the vP edge: (28b), and the multiple
 sluice (29b) under an [E] complementizer. -/
-def multipleQuestion (c : LIToken) : RoseTree ChainLabel :=
-  nodeC (leafC who) (nodeC (leafC what) (nodeC (leafC c) (nodeC (traceC who) (nodeC (leafC T)
-    (nodeC (traceC who)
-      (nodeC (traceC what) (nodeC (leafC v) (nodeC (leafC saw) (traceC what)))))))))
+def multipleQuestion (c : LIToken) : RoseTree SOLabel :=
+  nodeP (leafP who) (nodeP (leafP what) (nodeP (leafP c) (nodeP (traceOfP who) (nodeP (leafP T)
+    (nodeP (traceOfP who)
+      (nodeP (traceOfP what) (nodeP (leafP v) (nodeP (leafP saw) (traceOfP what)))))))))
 
 /-- The coordinated wh-question (10b), its complementizer shared. -/
 abbrev cwh := nonBulk should should
@@ -152,7 +152,7 @@ abbrev csnr := nonBulk cE c
 
 /-- The paired reading: the second conjunct holds an unbound trace of the first conjunct's
 wh-phrase, the copy that vehicle change reads as an E-type pronoun (footnote 20). -/
-def Paired (t : RoseTree ChainLabel) : Prop :=
+def Paired (t : RoseTree SOLabel) : Prop :=
   ∃ x ∈ unboundTraces t, x.2 = what ∧ x.1.head? = some 1
 
 instance : DecidablePred Paired := λ _ => inferInstanceAs (Decidable (∃ _ ∈ _, _))
@@ -161,7 +161,7 @@ instance : DecidablePred Paired := λ _ => inferInstanceAs (Decidable (∃ _ ∈
 theorem candidates_isSO : ∀ t ∈ [cwh, cwhEllipsis, cwhBulk, cwhNullC, cwhNullCSecond, cwhEmbedded,
       cwhEmbeddedTwoC, cwhTwoAux, cs, csTwoC, csEllipsis, csSharedC, csnrTwoE, csnr,
       multipleQuestion c, multipleQuestion cE],
-    isSOPlanar (t.map ChainLabel.toSOLabel) = true := by decide
+    isSOPlanar t = true := by decide
 
 /-! ### The multiple-wh-fronting parameter (27) by language -/
 
@@ -275,29 +275,29 @@ def different' := tok 33 .A (phon := "different")
 def topics' := tok 34 .N (phon := "topics")
 
 /-- The pivot, `on different topics`. -/
-def pivot : RoseTree ChainLabel := nodeC (leafC on) (nodeC (leafC different) (leafC topics))
+def pivot : RoseTree SOLabel := nodeP (leafP on) (nodeP (leafP different) (leafP topics))
 
 /-- `[TP subj [T′ T VP]]`. -/
-def tp (subj T : LIToken) (VP : RoseTree ChainLabel) : RoseTree ChainLabel :=
-  nodeC (leafC subj) (nodeC (leafC T) VP)
+def tp (subj T : LIToken) (VP : RoseTree SOLabel) : RoseTree SOLabel :=
+  nodeP (leafP subj) (nodeP (leafP T) VP)
 
 /-- (53b), after the pruning of [belk-neeleman-philip-2023] that removes the shared pivot from
 the first conjunct: the first verb phrase, the bare verb, elided under [E] on `must`. -/
-def rnrMixed : RoseTree ChainLabel :=
-  nodeC (tp alice mustE (leafC work)) (tp iris oughtToBe (nodeC (leafC working) pivot))
+def rnrMixed : RoseTree SOLabel :=
+  nodeP (tp alice mustE (leafP work)) (tp iris oughtToBe (nodeP (leafP working) pivot))
 /-- (54): the first verb phrase built with its own pivot and elided. -/
-def rnrElided : RoseTree ChainLabel :=
-  nodeC
+def rnrElided : RoseTree SOLabel :=
+  nodeP
     (tp alice mustE
-      (nodeC (leafC work) (nodeC (leafC on') (nodeC (leafC different') (leafC topics')))))
-    (tp iris oughtToBe (nodeC (leafC working) pivot))
+      (nodeP (leafP work) (nodeP (leafP on') (nodeP (leafP different') (leafP topics')))))
+    (tp iris oughtToBe (nodeP (leafP working) pivot))
 /-- (55b): with matching verbs, the verb phrase shared. -/
-def rnrShared : RoseTree ChainLabel :=
-  let VP := nodeC (leafC work) pivot
-  nodeC (tp alice must VP) (tp iris shouldRNR VP)
+def rnrShared : RoseTree SOLabel :=
+  let VP := nodeP (leafP work) pivot
+  nodeP (tp alice must VP) (tp iris shouldRNR VP)
 /-- The rival of (55b) with the shape of (53b). -/
-def rnrMatchedMixed : RoseTree ChainLabel :=
-  nodeC (tp alice mustE (leafC work)) (tp iris shouldRNR (nodeC (leafC working) pivot))
+def rnrMatchedMixed : RoseTree SOLabel :=
+  nodeP (tp alice mustE (leafP work)) (tp iris shouldRNR (nodeP (leafP working) pivot))
 
 theorem rnrMixed_pf : pfPhon rnrMixed =
     ["Alice", "must", "Iris", "ought to be", "working", "on", "different", "topics"] := by decide

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -284,9 +284,8 @@ Traces left by movement are interpreted as variables bound by
 
 #### Trace convention
 
-On the index-free `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025] Def 1.2.1,
-chain identity is workspace-level) a trace is the **single** bare trace leaf
-`SyntacticObject.traceLeaf`, recognized by `SyntacticObject.isTrace`. The semantic trace *index* `n`
+On the `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025] Def 1.2.1) a trace is here
+the bare trace leaf `SyntacticObject.traceLeaf`, recognized by `SyntacticObject.isTrace`. The semantic trace *index* `n`
 is
 not carried by the leaf: it is supplied by the binder (λ-abstraction) at the
 landing site, exactly as in the H&K rule ⟦t_n⟧^g = g(n). The interpretation
@@ -346,7 +345,7 @@ def soSemanticType (so : Minimalist.SyntacticObject) : Option Ty :=
 /--
 Interpret a trace leaf in a syntactic object at a given index.
 
-On the index-free `SyntacticObject` carrier the trace leaf carries no index; the binder at
+The bare trace leaf carries no index; the binder at
 the landing site supplies `n` (H&K's ⟦t_n⟧^g = g(n)). Returns `none` when `so`
 is not the trace leaf.
 -/
@@ -361,11 +360,7 @@ def interpSOTrace {E : Type} (n : ℕ) (so : Minimalist.SyntacticObject) :
 /-- A lexical leaf is not a trace, so it gets no carrier-level type. -/
 @[simp] theorem soSemanticType_lexLeaf (tok : Minimalist.LIToken) :
     soSemanticType (lexLeaf tok) = none := by
-  have hne : ¬ isTrace (lexLeaf tok) := by
-    intro h
-    have hg := congrArg getLIToken h
-    rw [getLIToken_lexLeaf, getLIToken_traceLeaf] at hg
-    exact Option.some_ne_none tok hg
+  have hne : ¬ isTrace (lexLeaf tok) := not_isTrace_lexLeaf tok
   simp only [soSemanticType, if_neg hne]
 
 -- ============================================================================

--- a/Linglib/Studies/MarcolliChomskyBerwick2025.lean
+++ b/Linglib/Studies/MarcolliChomskyBerwick2025.lean
@@ -24,7 +24,7 @@ open RoseTree RoseTree.Nonplanar Minimalist SyntacticObject
 
 /-- A determiner over a noun: `D` selects `N`, so `D` projects. -/
 private def theDog : SyntacticObject :=
-  ⟨Nonplanar.mk (.node (Sum.inr ())
+  ⟨Nonplanar.mk (.node (Sum.inr none)
     [.node (Sum.inl ⟨.simple .D [.N] (phonForm := "the"), 0⟩) [],
      .node (Sum.inl ⟨.simple .N [] (phonForm := "dog"), 1⟩) []]), by decide⟩
 
@@ -40,7 +40,7 @@ example : theDog.phonYield .final = some ["dog", "the"] := by decide
 /-- Exocentric Merge: two saturated `N`s, neither selecting the other — no head,
     no order ([marcolli-chomsky-berwick-2025] §1.13.2). -/
 private def exoNN : SyntacticObject :=
-  ⟨Nonplanar.mk (.node (Sum.inr ())
+  ⟨Nonplanar.mk (.node (Sum.inr none)
     [.node (Sum.inl ⟨.simple .N [] (phonForm := "cats"), 0⟩) [],
      .node (Sum.inl ⟨.simple .N [] (phonForm := "dogs"), 1⟩) []]), by decide⟩
 

--- a/Linglib/Syntax/Minimalist/Agree/Consistency.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Consistency.lean
@@ -20,7 +20,7 @@ checking over all substructures" (§3.1.5).
 
 This file instantiates that map for **feature consistency** in the Boolean (parsing) semiring of
 §3.5: the target `Consistency = {inconsistent, consistent}` with `∨`/`∧`. The syntactic object `S`
-(a `Nonplanar SOLabel` subtree, `SOLabel = LIToken ⊕ Unit`) embeds into the Hopf algebra via
+(a `Nonplanar SOLabel` subtree, `SOLabel = LIToken ⊕ Option LIToken`) embeds into the Hopf algebra via
 `ofTree S.val` (no head decoration — the single MCB carrier, `FreeCommMagma`/`toNonplanar`
 retired). A local feature character `φ` is renormalized by the weight-`+1` semiring Birkhoff
 factorization (`ConnesKreimer.SemiringRenorm`) into the consistency map `φ₊`.

--- a/Linglib/Syntax/Minimalist/Defs.lean
+++ b/Linglib/Syntax/Minimalist/Defs.lean
@@ -10,7 +10,7 @@ This file defines that alphabet: categorial features `Cat`, a selectional stack 
 consumed left to right, the feature bundle `SimpleLI` of a category and its selectional
 requirements, `LexicalItem` as a nonempty list of bundles (a head that has incorporated another
 carries both), and `LIToken`, an instantiated lexical item. It is carrier-agnostic; the carrier
-built over `LIToken ⊕ Unit` is `SyntacticObject/Basic.lean`. `LIToken.selects` is c-selection
+built over `LIToken ⊕ Option LIToken` is `SyntacticObject/Basic.lean`. `LIToken.selects` is c-selection
 between tokens, `ConventionDir` the harmonic head-side parameter, and `uposToCat` the map from
 Universal Dependencies part-of-speech tags into `Cat`.
 

--- a/Linglib/Syntax/Minimalist/Linearization/Chain.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Chain.lean
@@ -28,7 +28,7 @@ once.
 
 ## Main definitions
 
-* `ChainLabel`, `tokenList`, `occurrences`, `unboundTraces`, `IsShared`: occurrences and chains.
+* `tokenList`, `occurrences`, `unboundTraces`, `IsShared`: occurrences and chains.
 * `terms`: the distinct subtrees, a shared constituent's once.
 * `elidedDomains`, `IsSilenced`, `pfPhon`: pronunciation under [E].
 * `IsVacuous`, `PronunciationEconomy`: the ban on vacuous ellipsis.
@@ -48,67 +48,31 @@ once.
 
 namespace Minimalist
 
-open RoseTree RoseTree.Pathed
+open RoseTree RoseTree.Pathed SyntacticObject
 open Syntax.Question (MWFParameter PhaseEdge)
 
-/-! ### Objects with indexed traces -/
-
-/-- The label of a position in a planar object with indexed traces: a token, the trace of a
-moved token, or an internal node. -/
-inductive ChainLabel
-  | token (tok : LIToken)
-  | trace (tok : LIToken)
-  | inner
-  deriving DecidableEq, Repr
-
-namespace ChainLabel
-
-/-- The token at a token position. -/
-def token? : ChainLabel → Option LIToken
-  | token tok => some tok
-  | _ => none
-
-/-- The token at a trace position. -/
-def trace? : ChainLabel → Option LIToken
-  | trace tok => some tok
-  | _ => none
-
-/-- Forget the indices: the planar object of `Linearization/Replay.lean`. -/
-def toSOLabel : ChainLabel → SOLabel
-  | token tok => .inl tok
-  | trace _ | inner => .inr ()
-
-end ChainLabel
-
-/-- A token position. -/
-def leafC (tok : LIToken) : RoseTree ChainLabel := .node (.token tok) []
-
-/-- The trace of `tok`. -/
-def traceC (tok : LIToken) : RoseTree ChainLabel := .node (.trace tok) []
-
-/-- The Merge of two objects. -/
-def nodeC (l r : RoseTree ChainLabel) : RoseTree ChainLabel := .node .inner [l, r]
+/-! ### Occurrences and chains -/
 
 mutual
 /-- The positions whose label `f` accepts, with their paths, left to right. -/
-def positions (f : ChainLabel → Option LIToken) : RoseTree ChainLabel → List (Path × LIToken)
+def positions (f : SOLabel → Option LIToken) : RoseTree SOLabel → List (Path × LIToken)
   | .node a cs => match f a with
     | some tok => [([], tok)]
     | none => positionsAux f 0 cs
 /-- Auxiliary: the positions in a children list from index `i`. -/
-def positionsAux (f : ChainLabel → Option LIToken) :
-    ℕ → List (RoseTree ChainLabel) → List (Path × LIToken)
+def positionsAux (f : SOLabel → Option LIToken) :
+    ℕ → List (RoseTree SOLabel) → List (Path × LIToken)
   | _, [] => []
   | i, c :: cs => (positions f c).map (λ x => (i :: x.1, x.2)) ++ positionsAux f (i + 1) cs
 end
 
 /-- The tokens with their paths, left to right. -/
-def tokenList : RoseTree ChainLabel → List (Path × LIToken) := positions ChainLabel.token?
+def tokenList : RoseTree SOLabel → List (Path × LIToken) := positions (Sum.elim some λ _ => none)
 
 /-- The traces with their paths, left to right. -/
-def traceList : RoseTree ChainLabel → List (Path × LIToken) := positions ChainLabel.trace?
+def traceList : RoseTree SOLabel → List (Path × LIToken) := positions (Sum.elim (λ _ => none) id)
 
-variable (t : RoseTree ChainLabel)
+variable (t : RoseTree SOLabel)
 
 /-- The occurrences of `tok`. -/
 def occurrences (tok : LIToken) : List Path :=
@@ -118,7 +82,7 @@ def occurrences (tok : LIToken) : List Path :=
 def tokens : Finset LIToken := ((tokenList t).map (·.2)).toFinset
 
 /-- The terms of `t`: its subtrees, a shared constituent's once. -/
-def terms : Finset (RoseTree ChainLabel) := ((vertices t).filterMap t.subtreeAt).toFinset
+def terms : Finset (RoseTree SOLabel) := ((vertices t).filterMap t.subtreeAt).toFinset
 
 /-- `tok` is shared, dominated by two mothers: it occurs twice. -/
 def IsShared (tok : LIToken) : Prop := 2 ≤ (occurrences t tok).length
@@ -194,32 +158,32 @@ instance : Decidable (PronunciationEconomy t) := inferInstanceAs (Decidable (∀
 /-- The specifiers and head of the projection of a head of category `c`: down the right spine,
 the left daughters above the head, which is the first selecting item met; `none` when that item
 has another category or the spine ends first. -/
-def projection (c : Cat) : RoseTree ChainLabel → Option (List (RoseTree ChainLabel) × LIToken)
-  | .node .inner [.node (.token tok) [], r] =>
+def projection (c : Cat) : RoseTree SOLabel → Option (List (RoseTree SOLabel) × LIToken)
+  | .node (.inr none) [.node (.inl tok) [], r] =>
       if tok.item.outerSel = [] then
-        (projection c r).map λ x => (leafC tok :: x.1, x.2)
+        (projection c r).map λ x => (leafP tok :: x.1, x.2)
       else if tok.item.outerCat = c then some ([], tok) else none
-  | .node .inner [l, r] => (projection c r).map λ x => (l :: x.1, x.2)
+  | .node (.inr none) [l, r] => (projection c r).map λ x => (l :: x.1, x.2)
   | _ => none
 
 /-- The head of a constituent: the token or trace at a leaf, else the first selecting item down
 the right spine. -/
-def headToken? : RoseTree ChainLabel → Option LIToken
-  | .node (.token tok) _ | .node (.trace tok) _ => some tok
-  | .node .inner [.node (.token tok) [], r] =>
+def headToken? : RoseTree SOLabel → Option LIToken
+  | .node (.inl tok) _ | .node (.inr (some tok)) _ => some tok
+  | .node (.inr none) [.node (.inl tok) [], r] =>
       if tok.item.outerSel = [] then headToken? r else some tok
-  | .node .inner [_, r] => headToken? r
-  | .node .inner _ => none
+  | .node (.inr none) [_, r] => headToken? r
+  | .node (.inr none) _ => none
 
 /-- The constituent is a wh-specifier: its head is a wh-token or its trace. -/
-def IsWhSpecifier (s : RoseTree ChainLabel) : Prop :=
+def IsWhSpecifier (s : RoseTree SOLabel) : Prop :=
   ∃ tok ∈ (headToken? s).toList, tok.item.outerWh = true
 
-instance (s : RoseTree ChainLabel) : Decidable (IsWhSpecifier s) :=
+instance (s : RoseTree SOLabel) : Decidable (IsWhSpecifier s) :=
   inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
 /-- The phase at `p`, a `v` or `C` projection: its edge, specifiers and head. -/
-def phaseAt (p : Path) : Option (PhaseEdge × List (RoseTree ChainLabel) × LIToken) :=
+def phaseAt (p : Path) : Option (PhaseEdge × List (RoseTree SOLabel) × LIToken) :=
   (t.subtreeAt p).bind λ s =>
     ((projection .v s).map λ x => (PhaseEdge.vP, x)).or
       ((projection .C s).map λ x => (PhaseEdge.CP, x))
@@ -245,7 +209,7 @@ instance (param : MWFParameter) : Decidable (Converges t param) :=
 and its elided domains the applications of ellipsis. -/
 def planarCost : DerivationCost
   | .lexicalItems => (tokens t).card
-  | .mergeOps => ((terms t).filter λ s => s.value = ChainLabel.inner).card
+  | .mergeOps => ((terms t).filter λ s => s.isLeaf = false).card
   | .agreeOps => 0
   | .ellipsisOps => (elidedDomains t).length
 

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -174,7 +174,7 @@ noncomputable def headHom : SyntacticObject →ₙ* LinearizationState side :=
     check — two morphisms agreeing on the leaves (`hom_ext`). -/
 theorem sel_comp_headHom :
     LinearizationState.sel.comp (headHom side) = selCheckHom :=
-  hom_ext (fun _ => rfl) rfl
+  hom_ext (fun _ => rfl) rfl (fun _ => rfl)
 
 /-- The surface token order under head-side convention `side`
     ([marcolli-chomsky-berwick-2025] §1.12.1): the yield readout of the

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -41,8 +41,8 @@ language `L`") rather than a noncanonical `Quot.out`. The fold below replays the
 an **ordered `RoseTree SOLabel` accumulator**, giving a fully **computable** PF: it never
 calls the noncomputable `SyntacticObject.node`/`SyntacticObject.replace` (it uses planar tree
 surgery + a
-`Nonplanar.mk` equality test), so surface orders `decide`. Index-free traces are sound
-here: traces are unpronounced, dropped by `planarYield`.
+`Nonplanar.mk` equality test), so surface orders `decide`. Traces are unpronounced,
+dropped by `planarYield`.
 
 The formal Π-bridge faithfulness theorem (`SyntacticObject.Derivation.externalizeP?_faithful`,
 below)
@@ -58,12 +58,11 @@ def SyntacticObject.toPlanarLeaf? (s : SyntacticObject) : Option (RoseTree SOLab
   | none     => if s = traceLeaf then some traceP else none
 
 /-- Plain left-to-right token yield of an *already-ordered* planar tree; traces
-    (`Sum.inr ()`) are unpronounced and contribute nothing. -/
+    (`Sum.inr none`) are unpronounced and contribute nothing. -/
 def planarYield : RoseTree SOLabel → List LIToken
   | .node (.inl tok) _   => [tok]
-  | .node (.inr ()) []   => []
-  | .node (.inr ()) [l, r] => planarYield l ++ planarYield r
-  | .node (.inr ()) _    => []
+  | .node (.inr none) [l, r] => planarYield l ++ planarYield r
+  | .node (.inr _) _    => []
 
 /-- "Projects to `target`": a planar subtree whose nonplanar projection is the `SyntacticObject`
     `target` — the predicate the `im` replay uses to locate a mover. Computable
@@ -86,12 +85,24 @@ def planarReplaceWhereP (p : RoseTree SOLabel → Bool) (rep : RoseTree SOLabel)
       else .node a [planarReplaceWhereP p rep l, planarReplaceWhereP p rep r]
   | t@(.node _ _)      => if p t then rep else t
 
+/-- The planar trace a moved object leaves: `SyntacticObject.trace` as a planar leaf. -/
+def SyntacticObject.tracePlanar (s : SyntacticObject) : RoseTree SOLabel :=
+  s.selHead.elim traceP traceOfP
+
+theorem SyntacticObject.mk_tracePlanar (s : SyntacticObject) :
+    Nonplanar.mk s.tracePlanar = s.trace.val := by
+  unfold tracePlanar trace; cases s.selHead <;> rfl
+
+theorem SyntacticObject.isSOPlanar_tracePlanar (s : SyntacticObject) :
+    isSOPlanar s.tracePlanar = true := by
+  unfold tracePlanar; cases s.selHead <;> rfl
+
 /-- Internal Merge on the ordered accumulator: raise the leftmost subtree projecting to
-    `mover` to the LEFT edge, leaving the bare trace `SyntacticObject.traceP`. `none` if absent. -/
+    `mover` to the LEFT edge, leaving the trace of its head. `none` if absent. -/
 def moveLeftPlanarP (acc : RoseTree SOLabel) (mover : SyntacticObject) :
     Option (RoseTree SOLabel) :=
   (planarFindP? (projEqP mover) acc).map fun s =>
-    nodeP s (planarReplaceWhereP (projEqP mover) traceP acc)
+    nodeP s (planarReplaceWhereP (projEqP mover) mover.tracePlanar acc)
 
 /-- One externalization step on the ordered accumulator (mirrors `SyntacticObject.Step.apply`). -/
 def externStepP (acc? : Option (RoseTree SOLabel)) (step : Step) :
@@ -141,7 +152,7 @@ private theorem isSOPlanar_nodeP {a b : RoseTree SOLabel}
 
 /-- `Nonplanar.mk` of the planar binary builder is the bare binary nonplanar node. -/
 private theorem mk_nodeP (a b : RoseTree SOLabel) :
-    Nonplanar.mk (nodeP a b) = Nonplanar.node (Sum.inr ()) {Nonplanar.mk a, Nonplanar.mk b} := by
+    Nonplanar.mk (nodeP a b) = Nonplanar.node (Sum.inr none) {Nonplanar.mk a, Nonplanar.mk b} := by
   rw [show ({Nonplanar.mk a, Nonplanar.mk b} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([a, b].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
 
@@ -169,6 +180,9 @@ private theorem toPlanarLeaf?_mk {s : SyntacticObject} {ip : RoseTree SOLabel}
     rw [toPlanarLeaf?, getLIToken_traceLeaf, if_pos rfl] at h
     obtain rfl : ip = traceP := by simpa using h.symm
     exact ⟨rfl, rfl⟩
+  | traceOf tok =>
+    rw [toPlanarLeaf?, getLIToken_traceOf, if_neg (traceOf_ne_traceLeaf tok)] at h
+    exact absurd h (by simp)
   | node l r _ _ =>
     rw [toPlanarLeaf?, getLIToken_node,
         if_neg (node_ne_traceLeaf l r)] at h
@@ -210,10 +224,10 @@ private theorem planarFindP?_isSOPlanar {p : RoseTree SOLabel → Bool} {t s : R
   | case2 => exact absurd h (by simp)
   | case3 => obtain rfl := Option.some.inj h; exact ht
   | case4 a l r _ ihl ihr =>
-    have hcase : a = Sum.inr () := by
-      cases a with
-      | inl _ => simp [isSOPlanar] at ht
-      | inr u => cases u; rfl
+    have hcase : a = Sum.inr none := by
+      match a with
+      | .inr none => rfl
+      | .inl _ | .inr (some _) => simp [isSOPlanar] at ht
     subst hcase
     obtain ⟨hl', hr'⟩ := isSOPlanar_pair_children ht
     rcases hlf : planarFindP? p l with _ | sl
@@ -225,13 +239,12 @@ private theorem planarFindP?_isSOPlanar {p : RoseTree SOLabel → Bool} {t s : R
 /-- Under `isSOPlanar`, a node has either no children or exactly two. -/
 private theorem isSOPlanar_length {a : SOLabel} {cs : List (RoseTree SOLabel)}
     (ht : isSOPlanar (RoseTree.node a cs) = true) : cs.length = 0 ∨ cs.length = 2 := by
-  cases a with
-  | inl _ =>
+  match a with
+  | .inl _ | .inr (some _) =>
     rw [isSOPlanar] at ht
     rw [List.isEmpty_iff] at ht
     exact Or.inl (by rw [ht]; rfl)
-  | inr u =>
-    cases u
+  | .inr none =>
     rw [isSOPlanar, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq, beq_iff_eq] at ht
     exact ht.1
 
@@ -241,22 +254,21 @@ private theorem not_projEqP {target : SyntacticObject} {s : RoseTree SOLabel}
   rw [projEqP, decide_eq_true_eq] at h; exact h
 
 /-- **Lemma 4 (CRUX): the replace bridge.** On a well-formed planar tree, the computable
-    planar replacement (`planarReplaceWhereP (projEqP target) SyntacticObject.traceP`) projects
-    under
-    `Nonplanar.mk` to the abstract structural substitution `Nonplanar.replace target
-    SyntacticObject.traceLeaf`,
-    and stays well-formed. The two `if`-conditions agree (`projEqP target s = true ↔
-    Nonplanar.mk s = target.val`), and the recursive bare-binary case lines up with
-    `Nonplanar.replace_node_pair`'s else branch (`{·,·}` multiset built from the two daughters). -/
-private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabel}
-    (ht : isSOPlanar t = true) :
-    Nonplanar.mk (planarReplaceWhereP (projEqP target) traceP t)
-        = Nonplanar.replace target.val traceLeaf.val (Nonplanar.mk t)
-      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) traceP t) = true := by
-  fun_induction planarReplaceWhereP (projEqP target) traceP t with
+    planar replacement by a well-formed leaf `rep` projecting to `R` projects under `Nonplanar.mk`
+    to the abstract structural substitution `Nonplanar.replace target R`, and stays well-formed.
+    The two `if`-conditions agree (`projEqP target s = true ↔ Nonplanar.mk s = target.val`), and
+    the recursive bare-binary case lines up with `Nonplanar.replace_node_pair`'s else branch
+    (`{·,·}` multiset built from the two daughters). -/
+private theorem replaceWhereP_mk (target : SyntacticObject) {rep : RoseTree SOLabel}
+    {R : SyntacticObject} (hrep : isSOPlanar rep = true) (hmkr : Nonplanar.mk rep = R.val)
+    {t : RoseTree SOLabel} (ht : isSOPlanar t = true) :
+    Nonplanar.mk (planarReplaceWhereP (projEqP target) rep t)
+        = Nonplanar.replace target.val R.val (Nonplanar.mk t)
+      ∧ isSOPlanar (planarReplaceWhereP (projEqP target) rep t) = true := by
+  fun_induction planarReplaceWhereP (projEqP target) rep t with
   | case1 _ hp =>
-    refine ⟨?_, rfl⟩
-    rw [projEqP_eq hp, Nonplanar.replace_self]; rfl
+    refine ⟨?_, hrep⟩
+    rw [projEqP_eq hp, Nonplanar.replace_self]; exact hmkr
   | case2 b hp =>
     refine ⟨?_, ht⟩
     rw [show Nonplanar.mk (RoseTree.node b []) = Nonplanar.leaf b from rfl,
@@ -264,25 +276,25 @@ private theorem replaceWhereP_mk (target : SyntacticObject) {t : RoseTree SOLabe
     rw [show Nonplanar.leaf b = Nonplanar.mk (RoseTree.node b []) from rfl]
     exact not_projEqP hp
   | case3 _ _ _ hp =>
-    refine ⟨?_, rfl⟩
-    rw [projEqP_eq hp, Nonplanar.replace_self]; rfl
+    refine ⟨?_, hrep⟩
+    rw [projEqP_eq hp, Nonplanar.replace_self]; exact hmkr
   | case4 a l r hp ihl ihr =>
-    have hcase : a = Sum.inr () := by
-      cases a with
-      | inl _ => simp [isSOPlanar] at ht
-      | inr u => cases u; rfl
+    have hcase : a = Sum.inr none := by
+      match a with
+      | .inr none => rfl
+      | .inl _ | .inr (some _) => simp [isSOPlanar] at ht
     subst hcase
     obtain ⟨hl', hr'⟩ := isSOPlanar_pair_children ht
     obtain ⟨ihle, ihls⟩ := ihl hl'
     obtain ⟨ihre, ihrs⟩ := ihr hr'
     refine ⟨?_, isSOPlanar_nodeP ihls ihrs⟩
-    have hne : Nonplanar.node (Sum.inr ()) {Nonplanar.mk l, Nonplanar.mk r} ≠ target.val := by
+    have hne : Nonplanar.node (Sum.inr none) {Nonplanar.mk l, Nonplanar.mk r} ≠ target.val := by
       rw [← mk_nodeP]; exact not_projEqP hp
-    rw [show RoseTree.node (Sum.inr ())
-          [planarReplaceWhereP (projEqP target) traceP l,
-          planarReplaceWhereP (projEqP target) traceP r]
-        = nodeP (planarReplaceWhereP (projEqP target) traceP l)
-          (planarReplaceWhereP (projEqP target) traceP r) from rfl,
+    rw [show RoseTree.node (Sum.inr none)
+          [planarReplaceWhereP (projEqP target) rep l,
+          planarReplaceWhereP (projEqP target) rep r]
+        = nodeP (planarReplaceWhereP (projEqP target) rep l)
+          (planarReplaceWhereP (projEqP target) rep r) from rfl,
       mk_nodeP, ihle, ihre, mk_nodeP, Nonplanar.replace_node_pair, if_neg hne]
   | case5 _ cs hnil hpair _ =>
     rcases isSOPlanar_length ht with hlen | hlen
@@ -328,11 +340,12 @@ private theorem externStepP_step {acc : SyntacticObject} {accp p' : RoseTree SOL
       obtain rfl := Option.some.inj h
       have hmks : Nonplanar.mk s = mover.val := projEqP_eq (planarFindP?_pred hfind)
       have hwfs : isSOPlanar s = true := planarFindP?_isSOPlanar hfind hwf
-      obtain ⟨hrwe, hrws⟩ := replaceWhereP_mk mover hwf
+      obtain ⟨hrwe, hrws⟩ :=
+        replaceWhereP_mk mover mover.isSOPlanar_tracePlanar mover.mk_tracePlanar hwf
       refine ⟨isSOPlanar_nodeP hwfs hrws, ?_⟩
       rw [Step.apply, node_val,
           deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
-      exact congrArg (Nonplanar.node (Sum.inr ())) (Multiset.cons_swap _ _ _)
+      exact congrArg (Nonplanar.node (Sum.inr none)) (Multiset.cons_swap _ _ _)
 
 /-- `none` is absorbing for the replay fold: once externalization fails, it stays failed. -/
 private theorem foldl_externStepP_none (steps : List Step) :
@@ -389,7 +402,8 @@ private def xNum : SyntacticObject := mkLeaf .Num [] 3
 private def xD : SyntacticObject := mkLeaf .D [] 4
 /-- The pied-piped `[N [A t]]` mover (built planar-first, so it is computable). -/
 private def xNAt : SyntacticObject :=
-  ofPlanar (nodeP (leafP ⟨.simple .N [], 1⟩) (nodeP (leafP ⟨.simple .A [], 2⟩) traceP))
+  ofPlanar (nodeP (leafP ⟨.simple .N [], 1⟩)
+    (nodeP (leafP ⟨.simple .A [], 2⟩) (traceOfP ⟨.simple .N [], 1⟩)))
 /-- The pied-piped `[A N]` mover. -/
 private def xAN : SyntacticObject :=
   ofPlanar (nodeP (leafP ⟨.simple .A [], 2⟩) (leafP ⟨.simple .N [], 1⟩))

--- a/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
+++ b/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
@@ -10,7 +10,7 @@ import Linglib.Syntax.Minimalist.Workspace.Basic
 # Merge on the syntactic-object carrier
 
 Merge on the carrier is the bare binary node `SyntacticObject.node` with root label
-`Sum.inr ()`. This file identifies it with the algebraic Merge operator of `Merge/Basic.lean` on
+`Sum.inr none`. This file identifies it with the algebraic Merge operator of `Merge/Basic.lean` on
 workspaces lifted along `of'`: External Merge of two objects is `mergeOp_pair`, and Internal
 Merge of a mover with its remainder is the two-stage composition `mergeOp_im_composition`, given
 the unique Δ^ρ cut extracting the mover.
@@ -33,7 +33,7 @@ open RoseTree RoseTree.Nonplanar ConnesKreimer
 /-- External Merge on the carrier is the algebraic Merge with the bare root label on the
     two-object workspace. -/
 theorem mergeOp_node (S S' : SyntacticObject) :
-    Merge.mergeOp (R := ℤ) (Sum.inr ()) S.val S'.val
+    Merge.mergeOp (R := ℤ) (Sum.inr none) S.val S'.val
         (of' ({S.val, S'.val} : Forest (Nonplanar SOLabel)))
       = of' (R := ℤ) ({(node S S').val} : Forest (Nonplanar SOLabel)) := by
   rw [Merge.mergeOp_pair, node_val]
@@ -46,12 +46,12 @@ theorem mergeOp_node_im (mover remainder T : SyntacticObject)
         (fun p => p.1 = ({mover.val} : Forest (Nonplanar SOLabel))) = {p0})
     (h_remainder : p0.2 = remainder.val)
     (hT : T.val ≠ mover.val) :
-    Merge.mergeOp (R := ℤ) (Sum.inr ()) remainder.val mover.val
+    Merge.mergeOp (R := ℤ) (Sum.inr none) remainder.val mover.val
         (Merge.mergeOpUnit (R := ℤ) mover.val
           (of' ({T.val} : Forest (Nonplanar SOLabel))))
       = of' (R := ℤ)
           ({(node remainder mover).val} : Forest (Nonplanar SOLabel)) := by
-  rw [Merge.mergeOp_im_composition (Sum.inr ()) mover.val T.val remainder.val
+  rw [Merge.mergeOp_im_composition (Sum.inr none) mover.val T.val remainder.val
         p0 h_filter h_remainder hT, node_val]
 
 end Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
@@ -13,11 +13,12 @@ import Linglib.Syntax.Minimalist.Defs
 A syntactic object is a binary, nonplanar, rooted tree with leaves labelled by the lexical
 alphabet and no labels at internal vertices: the elements of the free non-associative commutative
 magma on `SO₀`. This file builds that carrier as the well-formed subset of
-`Nonplanar (LIToken ⊕ Unit)`, the same nonplanar trees the Merge algebra is defined on. The
-label `Sum.inr ()` is the single bare marker, and its two occurrences are told apart by arity: a
-childless bare vertex is a trace leaf, a binary bare vertex is an internal node. Chain identity
-is a property of workspaces, so the trace leaf carries no index, and the head of a node is
-supplied by a head function, not stored on the tree.
+`Nonplanar (LIToken ⊕ Option LIToken)`, the same nonplanar trees the Merge algebra is defined
+on. The label `Sum.inr none` is the bare marker, its two occurrences told apart by arity: a
+childless bare vertex is an index-free trace leaf, a binary bare vertex an internal node. The
+label `Sum.inr (some tok)` on a leaf is the trace of `tok`, the cancellation `T/T_v` remembering
+the head of `T_v`, which is what chains and their PF reduction read off a single object. The head
+of a node is supplied by a head function, not stored on the tree.
 
 ## Main definitions
 
@@ -41,9 +42,9 @@ namespace Minimalist
 
 open RoseTree RoseTree.Nonplanar
 
-/-- The label alphabet: a lexical token on a leaf, or the bare marker `Sum.inr ()` on a trace
-    leaf or an internal node, the two told apart by arity. -/
-abbrev SOLabel : Type := LIToken ⊕ Unit
+/-- The label alphabet: a lexical token on a leaf, the bare marker `Sum.inr none` on an index-free
+    trace leaf or an internal node, the two told apart by arity, or the trace of a token. -/
+abbrev SOLabel : Type := LIToken ⊕ Option LIToken
 
 /-! ### Well-formedness `IsSO` (binary, lexical/trace leaves, bare internals) -/
 
@@ -52,7 +53,8 @@ mutual
     childless or binary with well-formed children. -/
 def isSOPlanar : RoseTree SOLabel → Bool
   | .node (.inl _) cs  => cs.isEmpty
-  | .node (.inr ()) cs => (cs.length == 0 || cs.length == 2) && isSOPlanarList cs
+  | .node (.inr (some _)) cs => cs.isEmpty
+  | .node (.inr none) cs => (cs.length == 0 || cs.length == 2) && isSOPlanarList cs
 /-- Every tree in the list is well-formed. -/
 def isSOPlanarList : List (RoseTree SOLabel) → Bool
   | []      => true
@@ -67,12 +69,12 @@ end
 private theorem isSOPlanar_node_congr {a : SOLabel} {cs ds : List (RoseTree SOLabel)}
     (hlen : cs.length = ds.length) (hlist : isSOPlanarList cs = isSOPlanarList ds) :
     isSOPlanar (.node a cs) = isSOPlanar (.node a ds) := by
-  cases a with
-  | inl _ =>
+  match a with
+  | .inr none => simp only [isSOPlanar, hlen, hlist]
+  | .inl _ | .inr (some _) =>
     simp only [isSOPlanar]
     rw [Bool.eq_iff_iff]
     simp only [List.isEmpty_iff_length_eq_zero, hlen]
-  | inr u => cases u; simp only [isSOPlanar, hlen, hlist]
 
 mutual
 /-- `isSOPlanar` is invariant under `Perm`, hence descends to the quotient. At a node
@@ -118,15 +120,19 @@ instance : DecidableEq SyntacticObject := Subtype.instDecidableEq
 def SyntacticObject.lexLeaf (tok : LIToken) : SyntacticObject := ⟨Nonplanar.leaf (Sum.inl tok), rfl⟩
 
 /-- The trace leaf: a childless bare vertex, the mark an admissible cut leaves in the remaining
-    tree ([marcolli-chomsky-berwick-2025], Definition 1.2.6). It carries no index. -/
-def SyntacticObject.traceLeaf : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr ()), by decide⟩
+    tree ([marcolli-chomsky-berwick-2025], Definition 1.2.6). It carries no index; `traceOf` is the indexed trace. -/
+def SyntacticObject.traceLeaf : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr none), by decide⟩
+
+/-- The trace of `tok`. -/
+def SyntacticObject.traceOf (tok : LIToken) : SyntacticObject :=
+  ⟨Nonplanar.leaf (Sum.inr (some tok)), rfl⟩
 
 /-- A bare binary node is well-formed exactly when both daughters are. -/
 theorem isSO_node_pair (a b : Nonplanar SOLabel) :
-    isSO (Nonplanar.node (Sum.inr ()) ({a, b} : Multiset (Nonplanar SOLabel)))
+    isSO (Nonplanar.node (Sum.inr none) ({a, b} : Multiset (Nonplanar SOLabel)))
       = (isSO a && isSO b) := by
   refine Quotient.inductionOn₂ a b fun pa pb => ?_
-  show isSO (Nonplanar.node (Sum.inr ()) {Nonplanar.mk pa, Nonplanar.mk pb})
+  show isSO (Nonplanar.node (Sum.inr none) {Nonplanar.mk pa, Nonplanar.mk pb})
       = (isSO (Nonplanar.mk pa) && isSO (Nonplanar.mk pb))
   rw [show ({Nonplanar.mk pa, Nonplanar.mk pb} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([pa, pb].map Nonplanar.mk) from rfl,
@@ -138,21 +144,21 @@ theorem isSO_node_pair (a b : Nonplanar SOLabel) :
     Noncomputable, since it goes through the smart constructor `Nonplanar.node`; concrete
     results are built planar-first and related by `node_mk`. -/
 noncomputable def SyntacticObject.node (l r : SyntacticObject) : SyntacticObject :=
-  ⟨Nonplanar.node (Sum.inr ()) {l.val, r.val}, by
-    show isSO (Nonplanar.node (Sum.inr ()) {l.val, r.val}) = true
+  ⟨Nonplanar.node (Sum.inr none) {l.val, r.val}, by
+    show isSO (Nonplanar.node (Sum.inr none) {l.val, r.val}) = true
     have hl : isSO l.val = true := l.2
     have hr : isSO r.val = true := r.2
     rw [isSO_node_pair, hl, hr, Bool.and_self]⟩
 
 @[simp] theorem SyntacticObject.node_val (l r : SyntacticObject) :
-    (SyntacticObject.node l r).val = Nonplanar.node (Sum.inr ()) {l.val, r.val} := rfl
+    (SyntacticObject.node l r).val = Nonplanar.node (Sum.inr none) {l.val, r.val} := rfl
 
 /-- A node of two planar-built objects is the planar binary node, so concrete results are
     `decide`-able. -/
 theorem SyntacticObject.node_mk (pl pr : RoseTree SOLabel)
     (hl : IsSO (Nonplanar.mk pl)) (hr : IsSO (Nonplanar.mk pr)) :
     (SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩).val
-      = Nonplanar.mk (.node (Sum.inr ()) [pl, pr]) := by
+      = Nonplanar.mk (.node (Sum.inr none) [pl, pr]) := by
   rw [SyntacticObject.node_val,
       show ({Nonplanar.mk pl, Nonplanar.mk pr} : Multiset (Nonplanar SOLabel))
         = Multiset.ofList ([pl, pr].map Nonplanar.mk) from rfl,
@@ -172,12 +178,13 @@ theorem isSOPlanar_of_mem {cs : List (RoseTree SOLabel)} (h : isSOPlanarList cs 
     · exact h.1
     · exact ih h.2 c hmem
 
-/-- Induction on syntactic objects: every syntactic object is a lexical leaf, the trace leaf, or
-    a node of two syntactic objects. -/
+/-- Induction on syntactic objects: every syntactic object is a lexical leaf, a trace leaf, or a
+    node of two syntactic objects. -/
 @[elab_as_elim]
 theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
     (lex : ∀ tok, motive (SyntacticObject.lexLeaf tok))
     (trace : motive SyntacticObject.traceLeaf)
+    (traceOf : ∀ tok, motive (SyntacticObject.traceOf tok))
     (node : ∀ l r : SyntacticObject, motive l → motive r → motive (SyntacticObject.node l r))
     (s : SyntacticObject) : motive s := by
   suffices H : ∀ n (p : RoseTree SOLabel) (hp : IsSO (Nonplanar.mk p)),
@@ -197,7 +204,13 @@ theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
       · exact lex tok
       · simp at hpl
     | inr u =>
-      cases u
+      cases u with
+      | some tok =>
+        rw [isSOPlanar] at hpl
+        rcases cs with _ | ⟨c, cs'⟩
+        · exact traceOf tok
+        · simp at hpl
+      | none =>
       rw [isSOPlanar, Bool.and_eq_true] at hpl
       obtain ⟨hlen, hlist⟩ := hpl
       rcases cs with _ | ⟨pl, _ | ⟨pr, _ | ⟨x, rest⟩⟩⟩
@@ -205,7 +218,7 @@ theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
       · simp at hlen
       · have hl : isSOPlanar pl = true := isSOPlanar_of_mem hlist pl (by simp)
         have hr : isSOPlanar pr = true := isSOPlanar_of_mem hlist pr (by simp)
-        have hnode : (⟨Nonplanar.mk (RoseTree.node (Sum.inr ()) [pl, pr]), hp⟩ : SyntacticObject)
+        have hnode : (⟨Nonplanar.mk (RoseTree.node (Sum.inr none) [pl, pr]), hp⟩ : SyntacticObject)
             = SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩ :=
           Subtype.ext (SyntacticObject.node_mk pl pr hl hr).symm
         rw [hnode]
@@ -214,13 +227,14 @@ theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
         exact node _ _ (IH pl.numNodes (by omega) pl hl rfl) (IH pr.numNodes (by omega) pr hr rfl)
       · simp at hlen
 
-/-- Every syntactic object is a lexical leaf, the trace leaf, or a node. -/
+/-- Every syntactic object is a lexical leaf, a trace leaf, or a node. -/
 theorem SyntacticObject.exists_form (s : SyntacticObject) :
     (∃ tok, s = SyntacticObject.lexLeaf tok) ∨ s = SyntacticObject.traceLeaf ∨
-      (∃ l r, s = SyntacticObject.node l r) := by
+      (∃ tok, s = SyntacticObject.traceOf tok) ∨ (∃ l r, s = SyntacticObject.node l r) := by
   induction s using SyntacticObject.ind with
   | lex tok => exact Or.inl ⟨tok, rfl⟩
   | trace => exact Or.inr (Or.inl rfl)
-  | node l r _ _ => exact Or.inr (Or.inr ⟨l, r, rfl⟩)
+  | traceOf tok => exact Or.inr (Or.inr (Or.inl ⟨tok, rfl⟩))
+  | node l r _ _ => exact Or.inr (Or.inr (Or.inr ⟨l, r, rfl⟩))
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -14,7 +14,7 @@ obligation is discharged by `decide`; `SyntacticObject.node_mk` relates such a b
 so theorems stated over `node` apply to it. Merge on the carrier is the node itself, written
 `*`: External Merge of two objects, and the re-merge of a mover with the remainder in Internal
 Merge. The accessors read the root token, leaf and node counts, and the trace predicate; since
-the trace leaf carries no index, `isTrace` is equality with `traceLeaf`.
+`isTrace` recognizes the trace leaves, bare or indexed.
 
 ## Main definitions
 
@@ -34,9 +34,12 @@ namespace SyntacticObject
 /-- A planar lexical leaf. -/
 abbrev leafP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inl tok) []
 /-- The planar trace leaf. -/
-abbrev traceP : RoseTree SOLabel := .node (Sum.inr ()) []
+abbrev traceP : RoseTree SOLabel := .node (Sum.inr none) []
+
+/-- The planar trace of `tok`. -/
+abbrev traceOfP (tok : LIToken) : RoseTree SOLabel := .node (Sum.inr (some tok)) []
 /-- A planar bare binary node. -/
-abbrev nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel := .node (Sum.inr ()) [l, r]
+abbrev nodeP (l r : RoseTree SOLabel) : RoseTree SOLabel := .node (Sum.inr none) [l, r]
 
 /-- The syntactic object of a well-formed planar tree; on a concrete tree the obligation is
     discharged by `decide`. -/
@@ -78,22 +81,35 @@ def mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) : Syntact
 def getLIToken (s : SyntacticObject) : Option LIToken :=
   match Nonplanar.rootValue s.val with
   | .inl tok => some tok
-  | .inr () => none
+  | .inr _ => none
 
 @[simp] theorem getLIToken_lexLeaf (tok : LIToken) : (lexLeaf tok).getLIToken = some tok := rfl
 
 @[simp] theorem getLIToken_traceLeaf : traceLeaf.getLIToken = none := rfl
 
+@[simp] theorem getLIToken_traceOf (tok : LIToken) : (traceOf tok).getLIToken = none := rfl
+
+theorem traceOf_ne_traceLeaf (tok : LIToken) : traceOf tok ≠ traceLeaf := by
+  intro h
+  have h' : (Sum.inr (some tok) : SOLabel) = Sum.inr none :=
+    congrArg (fun s : SyntacticObject => Nonplanar.rootValue s.val) h
+  simp at h'
+
 @[simp] theorem getLIToken_node (l r : SyntacticObject) : (node l r).getLIToken = none := by
   rw [getLIToken, node_val, Nonplanar.rootValue_node]
 
-/-- `isTrace s ↔ s = traceLeaf`, since the trace leaf carries no index. -/
-def isTrace (s : SyntacticObject) : Prop := s = traceLeaf
+/-- A trace leaf, bare or indexed. -/
+def isTrace (s : SyntacticObject) : Prop :=
+  (Nonplanar.rootValue s.val).isRight = true ∧ Nonplanar.numNodes s.val = 1
 
-instance (s : SyntacticObject) : Decidable (isTrace s) :=
-  inferInstanceAs (Decidable (_ = _))
+instance (s : SyntacticObject) : Decidable (isTrace s) := inferInstanceAs (Decidable (_ ∧ _))
 
-@[simp] theorem isTrace_traceLeaf : isTrace traceLeaf := rfl
+@[simp] theorem isTrace_traceOf (tok : LIToken) : isTrace (traceOf tok) := ⟨rfl, rfl⟩
+
+@[simp] theorem not_isTrace_lexLeaf (tok : LIToken) : ¬ isTrace (lexLeaf tok) := fun h =>
+  Bool.false_ne_true h.1
+
+@[simp] theorem isTrace_traceLeaf : isTrace traceLeaf := ⟨rfl, rfl⟩
 
 /-- The number of leaves, traces included. -/
 def leafCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val
@@ -138,14 +154,14 @@ example : isTrace traceLeaf ∧ ¬ isTrace (lexLeaf (mkTraceToken 0)) := by deci
 /-- A bare binary node over a lexical leaf and a bare trace, the shape of an Internal-Merge
     result, is a syntactic object. -/
 example :
-    IsSO (Nonplanar.mk (.node (Sum.inr ())
-      [.leaf (Sum.inl (mkTraceToken 0)), .leaf (Sum.inr ())])) := by decide
+    IsSO (Nonplanar.mk (.node (Sum.inr none)
+      [.leaf (Sum.inl (mkTraceToken 0)), .leaf (Sum.inr none)])) := by decide
 /-- A lexical item with children is rejected: lexical items are leaves. -/
 example :
-    ¬ IsSO (Nonplanar.mk (.node (Sum.inl (mkTraceToken 0)) [.leaf (Sum.inr ())])) := by decide
+    ¬ IsSO (Nonplanar.mk (.node (Sum.inl (mkTraceToken 0)) [.leaf (Sum.inr none)])) := by decide
 /-- A ternary bare node is rejected: syntactic objects are binary. -/
 example :
-    ¬ IsSO (Nonplanar.mk (.node (Sum.inr ())
-      [.leaf (Sum.inr ()), .leaf (Sum.inr ()), .leaf (Sum.inr ())])) := by decide
+    ¬ IsSO (Nonplanar.mk (.node (Sum.inr none)
+      [.leaf (Sum.inr none), .leaf (Sum.inr none), .leaf (Sum.inr none)])) := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -4,19 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Syntax.Minimalist.SyntacticObject.Replace
+import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 
 /-!
 # Derivations
 
-An ordered derivation is an initial syntactic object with a sequence of Merge steps. External
-Merge adds an item as the left or right daughter, and Internal Merge raises a mover: the step
-re-merges the mover with the remainder `deleteAccessible mover current`, the current object with
-the mover's occurrences replaced by the trace leaf. Each step applies the carrier node, so the
-derivation's Merge is the workspace Merge by construction, and the node being commutative,
-`emL` and `emR` build the same object; the left-right distinction matters only for the surface
-order, which `Linearization/Replay.lean` recovers on an ordered planar accumulator, since the
-final object is an unordered quotient. Since `node` is noncomputable, so are `Step.apply` and
-`Derivation.final`, while the movers are read off the steps.
+An ordered derivation is an initial syntactic object with a sequence of Merge steps. External Merge
+adds an item as the left or right daughter, and Internal Merge raises a mover: the step re-merges
+the mover with the remainder `deleteAccessible mover current`, the current object with the mover's
+occurrences replaced by the trace of the mover's head. Each step applies the carrier node, so the
+derivation's Merge is the workspace Merge by construction, and the node being commutative, `emL` and
+`emR` build the same object; the left-right distinction matters only for the surface order, which
+`Linearization/Replay.lean` recovers on an ordered planar accumulator, since the final object is an
+unordered quotient. Since `node` is noncomputable, so are `Step.apply` and `Derivation.final`, while
+the movers are read off the steps.
 
 ## Main definitions
 
@@ -37,26 +38,29 @@ namespace SyntacticObject
 
 /-! ### Steps -/
 
-/-- A derivation step. `im` records only the mover; the trace it leaves is the bare trace leaf.
--/
+/-- A derivation step. `im` records only the mover; the trace it leaves is that of its head. -/
 inductive Step where
   /-- External Merge, new item as the left daughter. -/
   | emL (item : SyntacticObject)
   /-- External Merge, new item as the right daughter. -/
   | emR (item : SyntacticObject)
-  /-- Internal Merge: raise `mover`, leaving the bare trace in its place. -/
+  /-- Internal Merge: raise `mover`, leaving the trace of its head in its place. -/
   | im (mover : SyntacticObject)
 
+/-- The trace a moved object leaves: the trace of its head by selection, the bare trace when it
+    has none. -/
+def trace (s : SyntacticObject) : SyntacticObject := s.selHead.elim traceLeaf traceOf
+
 /-- The remainder `T/mover`: the current object with the mover's occurrences replaced by the
-    trace leaf, the remaining tree of an admissible cut ([marcolli-chomsky-berwick-2025],
+    trace of its head, the remaining tree of an admissible cut ([marcolli-chomsky-berwick-2025],
     Definition 1.2.6). For a uniquely accessible mover this is the deletion remainder that
     `Merge.mergeOp_im_composition` extracts; `replace` extends it to a chain of occurrences. -/
 noncomputable def deleteAccessible (mover current : SyntacticObject) : SyntacticObject :=
-  current.replace mover traceLeaf
+  current.replace mover mover.trace
 
 @[simp] theorem deleteAccessible_val (mover current : SyntacticObject) :
     (deleteAccessible mover current).val
-      = Nonplanar.replace mover.val traceLeaf.val current.val := rfl
+      = Nonplanar.replace mover.val mover.trace.val current.val := rfl
 
 /-- Apply a step: External Merge is the node with the item on the given side, Internal Merge the
     node of the remainder and the mover. -/

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
@@ -43,14 +43,20 @@ variable {β : Type*}
 /-- The node algebra of a magma-with-zero: lexical leaf ↦ `ℓ`, trace leaf ↦ `τ`,
     bare binary node ↦ `*`, off-carrier arities ↦ `0`. -/
 def mergeAlgebra [Mul β] [Zero β] (ℓ : LIToken → β) (τ : β) : SOLabel → List β → β
-  | .inl tok, _     => ℓ tok
-  | .inr (), []     => τ
-  | .inr (), [x, y] => x * y
-  | .inr (), _      => 0
+  | .inl tok, _       => ℓ tok
+  | .inr _, []        => τ
+  | .inr none, [x, y] => x * y
+  | .inr _, _         => 0
+
+/-- The trace of a token is a leaf: any daughters put it off the carrier. -/
+private theorem mergeAlgebra_some [Mul β] [Zero β] (ℓ : LIToken → β) (τ : β) (tok : LIToken)
+    (l : List β) : mergeAlgebra ℓ τ (Sum.inr (some tok)) l = if l.isEmpty then τ else 0 := by
+  match l with
+  | [] | [_] | [_, _] | _ :: _ :: _ :: _ => rfl
 
 /-- A daughter list of three or more is off the carrier. -/
 private theorem mergeAlgebra_big [Mul β] [Zero β] {ℓ : LIToken → β} {τ : β} {l : List β}
-    (h : 2 < l.length) : mergeAlgebra ℓ τ (Sum.inr ()) l = 0 := by
+    (h : 2 < l.length) : mergeAlgebra ℓ τ (Sum.inr none) l = 0 := by
   match l with
   | _ :: _ :: _ :: _ => rfl
   | [] | [_] | [_, _] => simp at h
@@ -62,8 +68,10 @@ theorem mergeAlgebra_perm [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : 
   cases a with
   | inl tok => rfl
   | inr u =>
-    cases u
-    exact h.congr_arity₂ (fun x y => _root_.mul_comm x y) fun _ h => mergeAlgebra_big h
+    cases u with
+    | none => exact h.congr_arity₂ (fun x y => _root_.mul_comm x y) fun _ h => mergeAlgebra_big h
+    | some tok =>
+      simp only [mergeAlgebra_some, List.isEmpty_iff_length_eq_zero, h.length_eq]
 
 /-- The induced algebra on the nonplanar carrier: the catamorphism descends by
     `mergeAlgebra_perm`. -/
@@ -78,7 +86,7 @@ def liftN [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) : Nonplanar 
 /-- The nonplanar magma law: Merge multiplies values. -/
 theorem liftN_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (a b : Nonplanar SOLabel) :
-    liftN ℓ τ (Nonplanar.node (Sum.inr ()) {a, b}) = liftN ℓ τ a * liftN ℓ τ b := by
+    liftN ℓ τ (Nonplanar.node (Sum.inr none) {a, b}) = liftN ℓ τ a * liftN ℓ τ b := by
   refine Nonplanar.inductionOn₂ a b fun pa pb => ?_
   rw [Nonplanar.node_pair_mk]
   exact rfl
@@ -92,6 +100,9 @@ def liftFun [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) (s : Synta
 
 @[simp] theorem liftFun_traceLeaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
     liftFun ℓ τ traceLeaf = τ := rfl
+
+@[simp] theorem liftFun_traceOf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (tok : LIToken) : liftFun ℓ τ (traceOf tok) = τ := rfl
 
 @[simp] theorem liftFun_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (l r : SyntacticObject) :
@@ -113,11 +124,13 @@ noncomputable def lift [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     equal. -/
 theorem hom_ext [Mul β] {f g : SyntacticObject →ₙ* β}
     (hlex : ∀ tok, f (lexLeaf tok) = g (lexLeaf tok))
-    (htrace : f traceLeaf = g traceLeaf) : f = g :=
+    (htrace : f traceLeaf = g traceLeaf) (htraceOf : ∀ tok, f (traceOf tok) = g (traceOf tok)) :
+    f = g :=
   MulHom.ext fun s => by
     induction s using SyntacticObject.ind with
     | lex tok => exact hlex tok
     | trace => exact htrace
+    | traceOf tok => exact htraceOf tok
     | node l r ihl ihr =>
       rw [show node l r = l * r from rfl, map_mul, map_mul, ihl, ihr]
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -37,15 +37,21 @@ theorem isSO_replace (target replacement s : SyntacticObject) :
     · exact replacement.2
     · exact (lexLeaf tok).2
   | trace =>
-    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl, Nonplanar.replace_leaf]
+    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl, Nonplanar.replace_leaf]
     split
     · exact replacement.2
     · exact traceLeaf.2
+  | traceOf tok =>
+    rw [show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
+      Nonplanar.replace_leaf]
+    split
+    · exact replacement.2
+    · exact (traceOf tok).2
   | node l r ihl ihr =>
     rw [node_val, Nonplanar.replace_node_pair]
     split
     · exact replacement.2
-    · show isSO (Nonplanar.node (Sum.inr ())
+    · show isSO (Nonplanar.node (Sum.inr none)
         {Nonplanar.replace target.val replacement.val l.val,
           Nonplanar.replace target.val replacement.val r.val}) = true
       rw [isSO_node_pair, ihl, ihr]; rfl
@@ -83,7 +89,7 @@ theorem replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SyntacticObj
 theorem replace_traceLeaf_of_ne {target replacement : SyntacticObject}
     (h : traceLeaf ≠ target) : replace traceLeaf target replacement = traceLeaf := by
   apply Subtype.ext
-  rw [replace_val, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+  rw [replace_val, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
       Nonplanar.replace_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -151,7 +151,7 @@ theorem SelectionState.head_mul {r : LIToken}
 /-! ### Selection check on the carriers -/
 
 /-- The selection algebra: the `SyntacticObject.mergeAlgebra` of token + `outerSel`
-    leaves and the saturated, index-free trace. -/
+    leaves and the saturated trace, indexed or not. -/
 def selNode : SOLabel → List SelectionState → SelectionState :=
   mergeAlgebra (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
@@ -182,7 +182,7 @@ def selCheckN : Nonplanar SOLabel → SelectionState :=
     selCheckN (Nonplanar.mk p) = selCheckPlanar p := rfl
 
 theorem selCheckN_node (a b : Nonplanar SOLabel) :
-    selCheckN (Nonplanar.node (Sum.inr ()) {a, b}) = selCheckN a * selCheckN b :=
+    selCheckN (Nonplanar.node (Sum.inr none) {a, b}) = selCheckN a * selCheckN b :=
   liftN_node _ _ a b
 
 /-! ### The selection-driven head on `SyntacticObject` -/

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
@@ -62,6 +62,12 @@ instance (x y : SyntacticObject) : Decidable (immediatelyContains x y) :=
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
+@[simp] theorem immediatelyContains_traceOf (tok : LIToken) (y : SyntacticObject) :
+    ¬ immediatelyContains (traceOf tok) y := by
+  simp only [immediatelyContains, traceOf, Nonplanar.leaf,
+    Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
+    Multiset.notMem_zero, not_false_iff]
+
 @[simp] theorem immediatelyContains_node (l r y : SyntacticObject) :
     immediatelyContains (node l r) y ↔ y = l ∨ y = r := by
   rw [immediatelyContains, node_val, Nonplanar.rootChildren_node,
@@ -83,9 +89,14 @@ theorem isSO_of_mem_subtrees (s : SyntacticObject) : ∀ m ∈ Nonplanar.subtree
     subst hm; exact (lexLeaf tok).2
   | trace =>
     intro m hm
-    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
         Nonplanar.mem_subtrees_leaf] at hm
     subst hm; exact traceLeaf.2
+  | traceOf tok =>
+    intro m hm
+    rw [show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
+        Nonplanar.mem_subtrees_leaf] at hm
+    subst hm; exact (traceOf tok).2
   | node l r ihl ihr =>
     intro m hm
     rw [node_val, Nonplanar.mem_subtrees_node_pair] at hm
@@ -124,9 +135,13 @@ theorem subtrees_subset_of_mem {w s : SyntacticObject} (h : w ∈ s.subtrees) :
         Nonplanar.mem_subtrees_leaf] at h
     rw [(Subtype.ext h : w = lexLeaf tok)]; exact Multiset.Subset.refl _
   | trace =>
-    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     rw [(Subtype.ext h : w = traceLeaf)]; exact Multiset.Subset.refl _
+  | traceOf tok =>
+    rw [mem_subtrees, show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
+        Nonplanar.mem_subtrees_leaf] at h
+    rw [(Subtype.ext h : w = traceOf tok)]; exact Multiset.Subset.refl _
   | node l r ihl ihr =>
     rw [mem_subtrees_node] at h
     rcases h with rfl | hl | hr
@@ -155,7 +170,7 @@ theorem Acc_card (s : SyntacticObject) : (s.Acc).card = Nonplanar.numNodes s.val
 
 @[simp] theorem Acc_traceLeaf : traceLeaf.Acc = 0 := by
   rw [← Multiset.card_eq_zero, Acc_card,
-      show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+      show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
       Nonplanar.numNodes_leaf]
 
 /-! ### Containment -/
@@ -176,9 +191,10 @@ theorem contains_trans {x y z : SyntacticObject} (hxy : contains x y) (hyz : con
 
 theorem immediatelyContains_lt_weight {x y : SyntacticObject} (h : immediatelyContains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
-  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨tok, rfl⟩ | ⟨l, r, rfl⟩
   · exact absurd h (immediatelyContains_lexLeaf tok y)
   · exact absurd h (immediatelyContains_traceLeaf y)
+  · exact absurd h (immediatelyContains_traceOf tok y)
   · rw [immediatelyContains_node] at h
     rw [node_val, Nonplanar.numNodes_node_pair]
     rcases h with rfl | rfl <;> omega
@@ -194,9 +210,10 @@ theorem contains_irrefl (x : SyntacticObject) : ¬ contains x x :=
 
 theorem mem_subtrees_of_immediatelyContains {x y : SyntacticObject}
     (h : immediatelyContains x y) : y ∈ x.subtrees := by
-  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨l, r, rfl⟩
+  rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨tok, rfl⟩ | ⟨l, r, rfl⟩
   · exact absurd h (immediatelyContains_lexLeaf tok y)
   · exact absurd h (immediatelyContains_traceLeaf y)
+  · exact absurd h (immediatelyContains_traceOf tok y)
   · rw [immediatelyContains_node] at h
     rcases h with heq | heq
     · rw [heq, mem_subtrees_node]
@@ -221,7 +238,11 @@ theorem mem_subtrees_iff_eq_or_contains {x y : SyntacticObject} :
         Nonplanar.mem_subtrees_leaf] at h
     exact Or.inl (Subtype.ext h)
   | trace =>
-    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr ()) from rfl,
+    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+        Nonplanar.mem_subtrees_leaf] at h
+    exact Or.inl (Subtype.ext h)
+  | traceOf tok =>
+    rw [mem_subtrees, show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     exact Or.inl (Subtype.ext h)
   | node l r ihl ihr =>
@@ -311,7 +332,7 @@ private def demoL : SyntacticObject :=
 private def demoR : SyntacticObject :=
   ⟨Nonplanar.mk (.node (Sum.inl (mkTraceToken 1)) []), by decide⟩
 private def demoT : SyntacticObject :=
-  ⟨Nonplanar.mk (.node (Sum.inr ())
+  ⟨Nonplanar.mk (.node (Sum.inr none)
     [.node (Sum.inl (mkTraceToken 0)) [], .node (Sum.inl (mkTraceToken 1)) []]), by decide⟩
 
 /-- The root contains its left daughter and not conversely. -/


### PR DESCRIPTION
`SOLabel` becomes `LIToken ⊕ Option LIToken`: `Sum.inr (some tok)` on a leaf is the trace of `tok`, the bare marker stays the internal node and the index-free trace. Internal Merge in a derivation, and its planar replay, now leave the trace of the mover's selection head, so the chains of `Linearization/Chain.lean` read off MCB objects directly and its separate label type is gone.
- `SyntacticObject.traceOf`, `trace`, `tracePlanar`; the induction principle, form lemma, lift, and replay bridge gain the indexed case; `isTrace` covers both kinds.
- The CGY study's candidates are now syntactic objects as built.