### PR TITLE
refactor(Syntax/Minimalist): ordered syntactic objects as a carrier

### DIFF
--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -95,84 +95,99 @@ private def tThemeD : LIToken := ⟨.simple .D [], 13⟩
 private def tThemeN : LIToken := ⟨.simple .N [], 14⟩
 private def tPivot : LIToken := ⟨.simple .N [], 15⟩
 
-private def C₀ : SyntacticObject := lexLeaf tC
-private def T₀ : SyntacticObject := lexLeaf tT
-private def Appl₀ : SyntacticObject := lexLeaf tAppl
-private def Psr : SyntacticObject := lexLeaf tPsr
-private def D₀ : SyntacticObject := lexLeaf tD
-private def Agt : SyntacticObject := lexLeaf tAgt
-private def SubjD : SyntacticObject := lexLeaf tSubjD
-private def ThemeD : SyntacticObject := lexLeaf tThemeD
+private def C₀ : SyntacticObject := leaf tC
+private def T₀ : SyntacticObject := leaf tT
+private def Appl₀ : SyntacticObject := leaf tAppl
+private def Psr : SyntacticObject := leaf tPsr
+private def D₀ : SyntacticObject := leaf tD
+private def Agt : SyntacticObject := leaf tAgt
+private def SubjD : SyntacticObject := leaf tSubjD
+private def ThemeD : SyntacticObject := leaf tThemeD
 
 /-- A non-specific possessive, `[PossP Psr Psm]`. -/
-private def possP : Planar := Planar.merge (Planar.leaf tPsr) (Planar.leaf tPsm)
+private def possP : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tPsr) (PlanarSyntacticObject.leaf tPsm)
 
 /-- A specific possessive, `[DP D⁰ [PossP Psr Psm]]`. -/
-private def dp : Planar := Planar.merge (Planar.leaf tD) possP
+private def dp : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tD) possP
 
 /-- A locative PP over a non-specific possessive, `[PP P [PossP Psr Psm]]`. -/
-private def pp : Planar := Planar.merge (Planar.leaf tP) possP
+private def pp : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tP) possP
 
 /-- (9c) with a non-specific possessive S_O: `[TP T⁰ [VP V⁰ PossP]]`. -/
-private def unaccPossP : Planar := Planar.merge (Planar.leaf tT) (Planar.merge
-  (Planar.leaf tV) possP)
+private def unaccPossP : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
+  (PlanarSyntacticObject.leaf tV) possP)
 
 /-- (9c) with a specific possessive S_O: `[TP T⁰ [VP V⁰ DP]]`. -/
-private def unaccDP : Planar := Planar.merge (Planar.leaf tT) (Planar.merge (Planar.leaf tV) dp)
+private def unaccDP : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) dp)
 
 /-- (9a) with a non-specific possessive O: `[TP T⁰ [vP Agt [v' v⁰ [VP V⁰ PossP]]]]`. -/
-private def transPossP : Planar :=
-  Planar.merge (Planar.leaf tT) (Planar.merge (Planar.leaf tAgt) (Planar.merge (Planar.leaf tv)
-    (Planar.merge (Planar.leaf tV) possP)))
+private def transPossP : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tAgt) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tv)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) possP)))
 
 /-- (29) the raising applicative: `[vP Agt [v' v⁰ [ApplP Appl⁰ [VP V⁰ PossP]]]]` under T⁰. -/
-private def raisingAppl : Planar :=
-  Planar.merge (Planar.leaf tT)
-    (Planar.merge (Planar.leaf tAgt) (Planar.merge (Planar.leaf tv) (Planar.merge
-      (Planar.leaf tAppl)
-      (Planar.merge (Planar.leaf tV) possP))))
+private def raisingAppl : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tAgt) (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tv) (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tAppl)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) possP))))
 
 /-- (9b) with a locative PP, `[TP T⁰ [vP S_A [v' v⁰ [VP V⁰ PP]]]]`, for a specific or a
 non-specific S_A. -/
-private def unerg (subj : LIToken) : Planar :=
-  Planar.merge (Planar.leaf tT) (Planar.merge (Planar.leaf subj) (Planar.merge (Planar.leaf tv)
-    (Planar.merge (Planar.leaf tV) pp)))
+private def unerg (subj : LIToken) : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf subj) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tv)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) pp)))
 
 /-- (71) theme over locative, `[TP T⁰ [VP V⁰ [Theme PP]]]`, for a specific or a non-specific
 theme: path verbs, locative existentials and locative copulas. -/
-private def themeLoc (theme : LIToken) : Planar :=
-  Planar.merge (Planar.leaf tT) (Planar.merge (Planar.leaf tV) (Planar.merge
-    (Planar.leaf theme) pp))
+private def themeLoc (theme : LIToken) : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tV) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf theme) pp))
 
 /-- (83) the experiencer PP merged above the theme, `[TP T⁰ [VP PP [V' V⁰ Theme]]]`. -/
-private def experiencer : Planar :=
-  Planar.merge (Planar.leaf tT) (Planar.merge pp (Planar.merge (Planar.leaf tV)
-    (Planar.leaf tThemeD)))
+private def experiencer : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge pp
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV)
+    (PlanarSyntacticObject.leaf tThemeD)))
 
 /-- (40a) an existential with a bare pivot, `[TP T⁰ [VP V⁰ NP]]`. -/
-private def existential : Planar :=
-  Planar.merge (Planar.leaf tT) (Planar.merge (Planar.leaf tV) (Planar.leaf tPivot))
+private def existential : PlanarSyntacticObject :=
+  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tV) (PlanarSyntacticObject.leaf tPivot))
 
 /-! ### Nominal opacity -/
 
 /-- The possessor of a specific S_O is invisible to C⁰'s wh-probe. -/
 theorem psr_invisible_dp :
-    Invisible nominalOpacity (ofPlanar (Planar.merge (Planar.leaf tC) unaccDP)) C₀ Psr :=
+    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tC) unaccDP)) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- So is the possessor of a non-specific S_O: opacity does not depend on size. -/
 theorem psr_invisible_possP :
-    Invisible nominalOpacity (ofPlanar (Planar.merge (Planar.leaf tC) unaccPossP)) C₀ Psr :=
+    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tC) unaccPossP)) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- And the possessor inside a locative PP: PP islands follow from nominal opacity. -/
 theorem psr_invisible_pp :
-    Invisible nominalOpacity (ofPlanar (Planar.merge (Planar.leaf tC) (themeLoc tThemeN))) C₀ Psr :=
+    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tC) (themeLoc tThemeN))) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- The D head of a specific possessive is visible, so the whole DP can be pied-piped. -/
 theorem dHead_visible :
-    ¬ Invisible nominalOpacity (ofPlanar (Planar.merge (Planar.leaf tC) unaccDP)) C₀ D₀ :=
+    ¬ Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tC) unaccDP)) C₀ D₀ :=
   fun ⟨_, hh, hb⟩ => by
     simp only [nominalOpacity, Option.some.injEq] at hh
     exact absurd (hh ▸ hb) (by decide)
@@ -181,51 +196,55 @@ theorem dHead_visible :
 
 /-- The possessor of a non-specific S_O is T⁰'s closest D-goal: it raises to Spec,TP and can
 strand the possessum. -/
-theorem unacc_possP_psr_closest : isClosestGoalIn (ofPlanar unaccPossP) T₀ Psr hasD := by
+theorem unacc_possP_psr_closest : isClosestGoalIn
+    (PlanarSyntacticObject.toSyntacticObject unaccPossP) T₀ Psr hasD := by
   decide
 
 /-- In a specific S_O the D layer is the closer goal: the whole DP raises and the possessor is
 shielded. -/
 theorem unacc_dp_dHead_closest :
-    isClosestGoalIn (ofPlanar unaccDP) T₀ D₀ hasD ∧
-      ¬ isClosestGoalIn (ofPlanar unaccDP) T₀ Psr hasD :=
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject unaccDP) T₀ D₀ hasD ∧
+      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject unaccDP) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- The agent of a transitive is the closer goal, so the possessor of O cannot reach Spec,TP. -/
 theorem trans_agt_closest :
-    isClosestGoalIn (ofPlanar transPossP) T₀ Agt hasD ∧
-      ¬ isClosestGoalIn (ofPlanar transPossP) T₀ Psr hasD :=
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject transPossP) T₀ Agt hasD ∧
+      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject transPossP) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- In the raising applicative the possessor of O is Appl⁰'s closest D-goal: it externalizes to
 Spec,ApplP. -/
-theorem appl_psr_closest : isClosestGoalIn (ofPlanar raisingAppl) Appl₀ Psr hasD := by decide
+theorem appl_psr_closest : isClosestGoalIn
+    (PlanarSyntacticObject.toSyntacticObject raisingAppl) Appl₀ Psr hasD := by decide
 
 /-- A specific unergative subject stops T⁰ before the possessor inside the locative PP. -/
 theorem unerg_specific_blocks :
-    isClosestGoalIn (ofPlanar (unerg tSubjD)) T₀ SubjD hasD ∧
-      ¬ isClosestGoalIn (ofPlanar (unerg tSubjD)) T₀ Psr hasD :=
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (unerg tSubjD)) T₀ SubjD hasD ∧
+      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (unerg tSubjD)) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- A non-specific unergative subject is no DP, so the possessor is the closest goal. -/
-theorem unerg_nonspecific_psr_closest : isClosestGoalIn (ofPlanar (unerg tSubjN)) T₀ Psr hasD := by
+theorem unerg_nonspecific_psr_closest : isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject
+    (unerg tSubjN)) T₀ Psr hasD := by
   decide
 
 /-- A specific theme c-commanding the locative PP raises instead of the possessor. -/
 theorem theme_specific_blocks :
-    isClosestGoalIn (ofPlanar (themeLoc tThemeD)) T₀ ThemeD hasD ∧
-      ¬ isClosestGoalIn (ofPlanar (themeLoc tThemeD)) T₀ Psr hasD :=
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (themeLoc tThemeD)) T₀ ThemeD hasD ∧
+      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (themeLoc tThemeD)) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- A non-specific theme lets T⁰ reach the possessor inside the PP. -/
 theorem theme_nonspecific_psr_closest :
-    isClosestGoalIn (ofPlanar (themeLoc tThemeN)) T₀ Psr hasD := by decide
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject
+      (themeLoc tThemeN)) T₀ Psr hasD := by decide
 
 /-- With the experiencer PP merged above the theme, neither c-commands the other and both are
 closest goals; the experiential reading requires the experiencer to raise. -/
 theorem experiencer_both_closest :
-    isClosestGoalIn (ofPlanar experiencer) T₀ Psr hasD ∧
-      isClosestGoalIn (ofPlanar experiencer) T₀ ThemeD hasD :=
+    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject experiencer) T₀ Psr hasD ∧
+      isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject experiencer) T₀ ThemeD hasD :=
   ⟨by decide, by decide⟩
 
 /-! ### Judgment type -/
@@ -246,10 +265,12 @@ def judgment (root probe : SyntacticObject) : JudgmentType :=
   if ∃ g ∈ root.subtrees, isClosestGoalIn root probe g hasD then .categorical else .thetic
 
 /-- An existential with a bare pivot contains no DP: the clause is thetic. -/
-theorem existential_thetic : judgment (ofPlanar existential) T₀ = .thetic := by decide
+theorem existential_thetic : judgment (PlanarSyntacticObject.toSyntacticObject existential) T₀
+    = .thetic := by decide
 
 /-- Predicative possession is categorical, with the possessor as ψ-subject. -/
-theorem possession_categorical : judgment (ofPlanar unaccPossP) T₀ = .categorical := by decide
+theorem possession_categorical : judgment (PlanarSyntacticObject.toSyntacticObject unaccPossP) T₀
+    = .categorical := by decide
 
 /-! ### The paper's examples -/
 

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -110,33 +110,34 @@ def to_tok : LIToken := ⟨.simple .P [.D] "to", 409⟩
 object is the argument of the applicative head, merged above the projection containing the second,
 so it asymmetrically c-commands it. -/
 def docTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf subj_tok)
-      (Planar.merge (Planar.leaf v_tok)
-        (Planar.merge (Planar.leaf gave_tok)
-          (Planar.merge (Planar.leaf goal_tok) (Planar.merge (Planar.leaf appl_tok)
-            (Planar.leaf theme_tok))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subj_tok)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf goal_tok)
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf appl_tok)
+            (PlanarSyntacticObject.leaf theme_tok))))))
 
 /-- The quantifiers competing for attraction in the double object construction. -/
-def docQuantifiers : List SyntacticObject := [lexLeaf goal_tok, lexLeaf theme_tok]
+def docQuantifiers : List SyntacticObject := [leaf goal_tok, leaf theme_tok]
 
 /-- The first object asymmetrically c-commands the second ([barss-lasnik-1986]). -/
 theorem doc_goal_asym_theme :
-    asymCCommandsIn docTree (lexLeaf goal_tok) (lexLeaf theme_tok) := by decide
+    asymCCommandsIn docTree (leaf goal_tok) (leaf theme_tok) := by decide
 
 /-- Only the first object may be attracted first, so the derivation fixes the base order and the
 second object cannot come to scope over the first: *I gave a (#different) child each doll*. -/
 theorem doc_frozen :
-    LicensedFirst docTree (lexLeaf v_tok) docQuantifiers (lexLeaf goal_tok) ∧
-      ¬ LicensedFirst docTree (lexLeaf v_tok) docQuantifiers (lexLeaf theme_tok) :=
+    LicensedFirst docTree (leaf v_tok) docQuantifiers (leaf goal_tok) ∧
+      ¬ LicensedFirst docTree (leaf v_tok) docQuantifiers (leaf theme_tok) :=
   ⟨by decide,
-    not_licensedFirst_of_asymCCommand (y := lexLeaf goal_tok) (by simp [docQuantifiers])
+    not_licensedFirst_of_asymCCommand (y := leaf goal_tok) (by simp [docQuantifiers])
       (by decide) doc_goal_asym_theme⟩
 
 /-- No two candidates may be attracted first: the double object construction is unambiguous. -/
-theorem doc_not_ambiguous : ¬ Ambiguous docTree (lexLeaf v_tok) docQuantifiers := by
+theorem doc_not_ambiguous : ¬ Ambiguous docTree (leaf v_tok) docQuantifiers := by
   rintro ⟨x, hx, y, hy, hne, hlx, hly⟩
-  have hcases : ∀ z ∈ docQuantifiers, z = lexLeaf goal_tok ∨ z = lexLeaf theme_tok := by
+  have hcases : ∀ z ∈ docQuantifiers, z = leaf goal_tok ∨ z = leaf theme_tok := by
     simp [docQuantifiers]
   rcases hcases x hx with rfl | rfl <;> rcases hcases y hy with rfl | rfl
   exacts [hne rfl, doc_frozen.2 hly, doc_frozen.2 hlx, hne rfl]
@@ -146,28 +147,32 @@ theorem doc_not_ambiguous : ¬ Ambiguous docTree (lexLeaf v_tok) docQuantifiers 
 /-- The locative structure `[Ozzy [v [gave [every telescope [to a girl]]]]]`: the direct object and
 the PP are co-arguments of the same head, hence sisters, and c-command each other. -/
 def locativeTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf subj_tok)
-      (Planar.merge (Planar.leaf v_tok)
-        (Planar.merge (Planar.leaf gave_tok)
-          (Planar.merge (Planar.leaf theme_tok) (Planar.merge (Planar.leaf to_tok)
-            (Planar.leaf goal_tok))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subj_tok)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf theme_tok)
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf to_tok)
+            (PlanarSyntacticObject.leaf goal_tok))))))
 
 /-- The candidates in the locative: the direct object, and the PP that pied-pipes the goal. -/
 def locativeQuantifiers : List SyntacticObject :=
-  [lexLeaf theme_tok, ofPlanar (Planar.merge (Planar.leaf to_tok) (Planar.leaf goal_tok))]
+  [leaf theme_tok, PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok))]
 
 /-- Direct object and PP c-command each other, so neither asymmetrically c-commands the other. -/
 theorem locative_mutual_cCommand :
-    cCommandsIn locativeTree (lexLeaf theme_tok)
-        (ofPlanar (Planar.merge (Planar.leaf to_tok) (Planar.leaf goal_tok))) ∧
-      cCommandsIn locativeTree (ofPlanar (Planar.merge (Planar.leaf to_tok) (Planar.leaf goal_tok)))
-        (lexLeaf theme_tok) := by
+    cCommandsIn locativeTree (leaf theme_tok)
+        (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+          (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok))) ∧
+      cCommandsIn locativeTree (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+        (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok)))
+        (leaf theme_tok) := by
   constructor <;> decide
 
 /-- Either candidate may be attracted first, so the locative is ambiguous: *I gave a doll to each
 child* has both readings. -/
-theorem locative_ambiguous : Ambiguous locativeTree (lexLeaf v_tok) locativeQuantifiers := by
+theorem locative_ambiguous : Ambiguous locativeTree (leaf v_tok) locativeQuantifiers := by
   refine ambiguous_of_mutual_cCommand (by simp [locativeQuantifiers])
     (by simp [locativeQuantifiers]) (by decide) (by decide) (by decide)
     locative_mutual_cCommand.1 locative_mutual_cCommand.2 ?_
@@ -179,23 +184,24 @@ theorem locative_ambiguous : Ambiguous locativeTree (lexLeaf v_tok) locativeQuan
 competes with the objects for attraction — which is why either object can take scope over it even
 where the two objects' relative scope is frozen. -/
 theorem subject_not_attractable :
-    ¬ Attractable docTree (lexLeaf v_tok) (lexLeaf subj_tok) := by decide
+    ¬ Attractable docTree (leaf v_tok) (leaf subj_tok) := by decide
 
 /-- The passive of a double object construction: with no external argument, the goal raises to the
 subject position, out of the attractor's domain, leaving the theme as the only candidate. -/
 def passiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf goal_tok)
-      (Planar.merge (Planar.leaf v_tok)
-        (Planar.merge (Planar.leaf gave_tok) (Planar.merge (Planar.leaf appl_tok)
-          (Planar.leaf theme_tok)))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf goal_tok)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf appl_tok)
+          (PlanarSyntacticObject.leaf theme_tok)))))
 
 /-- In the passive the derived subject is no longer attractable while the theme is, so Shortest
 imposes no order between them and the ambiguity returns: *a (different) girl was given every
 telescope*. -/
 theorem passive_ambiguous :
-    ¬ Attractable passiveTree (lexLeaf v_tok) (lexLeaf goal_tok) ∧
-      Attractable passiveTree (lexLeaf v_tok) (lexLeaf theme_tok) := by
+    ¬ Attractable passiveTree (leaf v_tok) (leaf goal_tok) ∧
+      Attractable passiveTree (leaf v_tok) (leaf theme_tok) := by
   constructor <;> decide
 
 end Bruening2001

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -89,7 +89,7 @@ combine it with English's binding-class classifier.
 /-! #### C-command from tree geometry -/
 
 /-- Convert a word to a Minimalist lexical-item token (UPOS mapped to `Cat`,
-    phonological form attached). The smart Merge `SyntacticObject.node` is noncomputable, so
+    phonological form attached). The smart Merge `SyntacticObject.merge` is noncomputable, so
     concrete trees are built planar-first from these tokens and `decide`d over. -/
 private def wordTok (w : Word) (id : Nat) : LIToken :=
   ⟨.simple (uposToCat w.cat) [] w.form, id⟩
@@ -99,17 +99,18 @@ private def wordTok (w : Word) (id : Nat) : LIToken :=
     `{subj, verb}`. C-command follows from the geometry. Built planar-first so
     the containment / c-command decision procedures reduce. -/
 def toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
-  let subjP := Planar.leaf (wordTok clause.subject 0)
-  let verbP := Planar.leaf (wordTok clause.verb 1)
+  let subjP := PlanarSyntacticObject.leaf (wordTok clause.subject 0)
+  let verbP := PlanarSyntacticObject.leaf (wordTok clause.verb 1)
   match clause.object with
-  | none => ofPlanar (Planar.merge subjP verbP)
-  | some obj => ofPlanar (Planar.merge subjP (Planar.merge verbP (Planar.leaf (wordTok obj 2))))
+  | none => PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge subjP verbP)
+  | some obj => PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge subjP
+    (PlanarSyntacticObject.merge verbP (PlanarSyntacticObject.leaf (wordTok obj 2))))
 
 private def subjectSO (clause : SimpleClause) : SyntacticObject :=
-  lexLeaf (wordTok clause.subject 0)
+  leaf (wordTok clause.subject 0)
 
 private def objectSO? (clause : SimpleClause) : Option SyntacticObject :=
-  clause.object.map fun obj => lexLeaf (wordTok obj 2)
+  clause.object.map fun obj => leaf (wordTok obj 2)
 
 /-- Subject c-commands object: in `{subj, {verb, obj}}`, the subject's sister
     `{verb, obj}` contains the object. -/

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -102,18 +102,18 @@ private def tokNum : LIToken := ⟨.simple .Num [], 3⟩
 private def tokDem : LIToken := ⟨.simple .Dem [], 4⟩
 
 /-- The tree contains the overt noun; a trace does not count (7b-vi). -/
-private def hasN : Planar → Bool
+private def hasN : RoseTree SyntacticObject.Vertex → Bool
   | .node (.inl t) _ => t == tokN
   | .node (.inr none) [l, r] => hasN l || hasN r
   | .node (.inr _) _ => false
 
 /-- The noun is the tree's specifier, `[NP [XP]]` (fn. 21). -/
-private def specHasN : Planar → Bool
+private def specHasN : RoseTree SyntacticObject.Vertex → Bool
   | .node (.inl t) _ => t == tokN
   | .node (.inr none) [l, _] => hasN l
   | .node (.inr _) _ => false
 
-private def subtrees : Planar → List (Planar)
+private def subtrees : RoseTree SyntacticObject.Vertex → List (RoseTree SyntacticObject.Vertex)
   | t@(.node _ []) => [t]
   | t@(.node _ [l, r]) => t :: (subtrees l ++ subtrees r)
   | t@(.node _ _) => [t]
@@ -121,34 +121,35 @@ private def subtrees : Planar → List (Planar)
 /-- The marked option used by raising `s` past a modifier whose complement is `c`: the whole
 complement pied-pipes, of the whose-picture type when the noun is its specifier and of the
 picture-of-who type otherwise, and a proper part strands the rest. -/
-private def markOf (c s : Planar) : Option Marked :=
+private def markOf (c s : RoseTree SyntacticObject.Vertex) : Option Marked :=
   if s == c then (if specHasN s then none else some .pictureOfWho) else some .withoutPiedPiping
 
 /-- A stage of the enumeration: the derivation, its ordered form, the marked options of its raises
 and their number. -/
 structure Stage where
   derivation : Derivation
-  planar : Planar
+  planar : PlanarSyntacticObject
   marks : List Marked
   raises : ℕ
 
 /-- Merge the modifier `m` above the current object, then optionally raise a subtree containing
 the overt noun to the left edge. -/
 private def step (m : LIToken) (st : Stage) : List Stage :=
-  let d : Derivation := ⟨st.derivation.initial, st.derivation.steps ++ [.emL (lexLeaf m)]⟩
-  let p := Planar.merge (Planar.leaf m) st.planar
+  let d : Derivation := ⟨st.derivation.initial, st.derivation.steps ++ [.emL (leaf m)]⟩
+  let p := PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf m) st.planar
   ⟨d, p, st.marks, st.raises⟩ ::
-    ((subtrees st.planar).filter hasN).filterMap fun s =>
-      if h : Planar.isSyntacticObject s = true then
-        (moveLeftPlanarP p (ofPlanar s h)).map fun p' =>
-          ⟨⟨d.initial, d.steps ++ [.im (ofPlanar s h)]⟩, p',
-            (markOf st.planar s).toList ++ st.marks, st.raises + 1⟩
+    ((subtrees st.planar.val).filter hasN).filterMap fun s =>
+      if h : IsSyntacticObject (Nonplanar.mk s) then
+        (p.moveLeft (PlanarSyntacticObject.toSyntacticObject ⟨s, h⟩)).map fun p' =>
+          ⟨⟨d.initial, d.steps ++ [.im (PlanarSyntacticObject.toSyntacticObject ⟨s, h⟩)]⟩, p',
+            (markOf st.planar.val s).toList ++ st.marks, st.raises + 1⟩
       else none
 
 /-- The derivations (7) allows: the noun Merged with A, Num and Dem in turn, with an optional
 raise after each. -/
 def stages : List Stage :=
-  [⟨⟨lexLeaf tokN, []⟩, Planar.leaf tokN, [], 0⟩].flatMap (step tokA) |>.flatMap (step tokNum)
+  [⟨⟨leaf tokN, []⟩, PlanarSyntacticObject.leaf tokN, [], 0⟩].flatMap (step tokA) |>.flatMap
+    (step tokNum)
     |>.flatMap (step tokDem)
 
 /-- The surface order of a stage, read by the substrate's externalization. -/

--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -39,7 +39,7 @@ the costs the winners beat.
 
 namespace CitkoGracaninYuksek2025
 
-open Minimalist Minimalist.Planar RoseTree.Pathed
+open Minimalist Minimalist.PlanarSyntacticObject RoseTree.Pathed
 open Syntax.Question (MWFParameter)
 
 /-! ### The lexicon -/
@@ -78,26 +78,26 @@ def saw := tok 20 .V [.D] "saw"
 
 /-- `[CP wh [C′ c [TP subj [T′ T [vP wh [v′ v VP]]]]]]`: the wh-phrase moved through the edge of
 vP. -/
-def clause (wh c subj T v : LIToken) (VP : Planar) : Planar :=
+def clause (wh c subj T v : LIToken) (VP : PlanarSyntacticObject) : PlanarSyntacticObject :=
   merge (leaf wh) (merge (leaf c)
     (merge (leaf subj) (merge (leaf T) (merge (traceOf wh) (merge (leaf v) VP)))))
 
 /-- Non-bulk sharing under the complementizers `c₁` and `c₂`: each wh-phrase in its own
 conjunct, the subject, T, v and verb shared ((10b), (14), (16b), (38d), (45b), (46b)). -/
-def nonBulk (c₁ c₂ : LIToken) : Planar :=
+def nonBulk (c₁ c₂ : LIToken) : PlanarSyntacticObject :=
   merge (clause what c₁ you T v (merge (leaf teach) (traceOf what)))
     (clause when c₂ you T v (merge (leaf teach) (traceOf when)))
 
 /-- Bulk sharing: one C′ under both wh-phrases, both of which moved through its vP edge ((12b),
 (20b)). -/
-def bulk (c : LIToken) : Planar :=
+def bulk (c : LIToken) : PlanarSyntacticObject :=
   let c' := merge (leaf c) (merge (leaf you) (merge (leaf T) (merge (traceOf what)
     (merge (traceOf when)
       (merge (leaf v) (merge (merge (leaf teach) (traceOf what)) (traceOf when)))))))
   merge (merge (leaf what) c') (merge (leaf when) c')
 
 /-- Footnote 21's alternative to `bulk`: a shared TP under two complementizers. -/
-def bulkTP (c₁ c₂ : LIToken) : Planar :=
+def bulkTP (c₁ c₂ : LIToken) : PlanarSyntacticObject :=
   let tp := merge (leaf you) (merge (leaf T) (merge (traceOf what)
     (merge (traceOf when)
       (merge (leaf v) (merge (merge (leaf teach) (traceOf what)) (traceOf when))))))
@@ -106,20 +106,20 @@ def bulkTP (c₁ c₂ : LIToken) : Planar :=
 /-- Two clauses from separate tokens, the first elided under its [E] complementizer with its
 auxiliary in T, as the Sluicing-COMP generalization requires of a sluice: the ellipsis analysis
 of the coordinated wh-question (11b). -/
-def cwhEllipsis : Planar :=
+def cwhEllipsis : PlanarSyntacticObject :=
   merge (merge (leaf what) (merge (leaf cE) (merge (leaf you) (merge (leaf shouldT)
       (merge (traceOf what) (merge (leaf v) (merge (leaf teach) (traceOf what))))))))
     (clause when should you' T' v' (merge (leaf teach') (traceOf when)))
 
 /-- Two clauses from separate tokens, both elided, the second's object the pronoun of vehicle
 change: the double-ellipsis analysis of the coordinated sluice (19b). -/
-def csEllipsis : Planar :=
+def csEllipsis : PlanarSyntacticObject :=
   merge (clause what cE you T v (merge (leaf teach) (traceOf what)))
     (clause when cE' you' T' v' (merge (merge (leaf teach') (leaf it)) (traceOf when)))
 
 /-- A multiple question, both wh-phrases fronted through the vP edge: (28b), and the multiple
 sluice (29b) under an [E] complementizer. -/
-def multipleQuestion (c : LIToken) : Planar :=
+def multipleQuestion (c : LIToken) : PlanarSyntacticObject :=
   merge (leaf who) (merge (leaf what) (merge (leaf c) (merge (traceOf who) (merge (leaf T)
     (merge (traceOf who)
       (merge (traceOf what) (merge (leaf v) (merge (leaf saw) (traceOf what)))))))))
@@ -152,16 +152,11 @@ abbrev csnr := nonBulk cE c
 
 /-- The paired reading: the second conjunct holds an unbound trace of the first conjunct's
 wh-phrase, the copy that vehicle change reads as an E-type pronoun (footnote 20). -/
-def Paired (t : Planar) : Prop :=
+def Paired (t : PlanarSyntacticObject) : Prop :=
   ∃ x ∈ unboundTraces t, x.2 = what ∧ x.1.head? = some 1
 
 instance : DecidablePred Paired := λ _ => inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-/-- The candidates are syntactic objects. -/
-theorem candidates_isSO : ∀ t ∈ [cwh, cwhEllipsis, cwhBulk, cwhNullC, cwhNullCSecond, cwhEmbedded,
-      cwhEmbeddedTwoC, cwhTwoAux, cs, csTwoC, csEllipsis, csSharedC, csnrTwoE, csnr,
-      multipleQuestion c, multipleQuestion cE],
-    Planar.isSyntacticObject t = true := by decide
 
 /-! ### The multiple-wh-fronting parameter (27) by language -/
 
@@ -217,7 +212,7 @@ theorem cs_beats_twoC : planarCost cs < planarCost csTwoC := by decide
 
 /-- The shared vP edge hosts two wh-specifiers: the asterisk of (26b). -/
 theorem cs_asterisked :
-    ∃ p ∈ vertices cs, IsAsterisked cs englishA p ∧ IsAsterisked cs englishB p := by decide
+    ∃ p ∈ vertices cs.val, IsAsterisked cs englishA p ∧ IsAsterisked cs englishB p := by decide
 /-- Elided, the asterisked edge never reaches PF. -/
 theorem cs_converges : Converges cs englishA ∧ Converges cs englishB := by decide
 
@@ -275,28 +270,28 @@ def different' := tok 33 .A (phon := "different")
 def topics' := tok 34 .N (phon := "topics")
 
 /-- The pivot, `on different topics`. -/
-def pivot : Planar := merge (leaf on) (merge (leaf different) (leaf topics))
+def pivot : PlanarSyntacticObject := merge (leaf on) (merge (leaf different) (leaf topics))
 
 /-- `[TP subj [T′ T VP]]`. -/
-def tp (subj T : LIToken) (VP : Planar) : Planar :=
+def tp (subj T : LIToken) (VP : PlanarSyntacticObject) : PlanarSyntacticObject :=
   merge (leaf subj) (merge (leaf T) VP)
 
 /-- (53b), after the pruning of [belk-neeleman-philip-2023] that removes the shared pivot from
 the first conjunct: the first verb phrase, the bare verb, elided under [E] on `must`. -/
-def rnrMixed : Planar :=
+def rnrMixed : PlanarSyntacticObject :=
   merge (tp alice mustE (leaf work)) (tp iris oughtToBe (merge (leaf working) pivot))
 /-- (54): the first verb phrase built with its own pivot and elided. -/
-def rnrElided : Planar :=
+def rnrElided : PlanarSyntacticObject :=
   merge
     (tp alice mustE
       (merge (leaf work) (merge (leaf on') (merge (leaf different') (leaf topics')))))
     (tp iris oughtToBe (merge (leaf working) pivot))
 /-- (55b): with matching verbs, the verb phrase shared. -/
-def rnrShared : Planar :=
+def rnrShared : PlanarSyntacticObject :=
   let VP := merge (leaf work) pivot
   merge (tp alice must VP) (tp iris shouldRNR VP)
 /-- The rival of (55b) with the shape of (53b). -/
-def rnrMatchedMixed : Planar :=
+def rnrMatchedMixed : PlanarSyntacticObject :=
   merge (tp alice mustE (leaf work)) (tp iris shouldRNR (merge (leaf working) pivot))
 
 theorem rnrMixed_pf : pfPhon rnrMixed =

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -35,11 +35,11 @@ base-generation. Three lines of evidence converge:
 
 ## Carrier note (P4 single-carrier flip)
 
-On the MCB-faithful `SyntacticObject` carrier, Merge (`SyntacticObject.node`/`*`) is noncomputable,
+On the MCB-faithful `SyntacticObject` carrier, Merge (`SyntacticObject.merge`/`*`) is noncomputable,
 so `SyntacticObject.Derivation.final`/`.stageAt` do not `decide`. The computable layers —
 `movedItems` and the externalized surface order (`surfacePhon`) — are proved
 over the `SyntacticObject.Derivation` directly. The c-command predictions are stated over
-the **derived/base trees built planar-first** (`SyntacticObject.ofPlanar (Planar.merge
+the **derived/base trees built planar-first** (`(PlanarSyntacticObject.merge
 …)`),
 i.e. the very trees each derivation produces, written out explicitly per the
 prose diagrams; c-command (`SyntacticObject.cCommandsIn`) reduces on those.
@@ -128,10 +128,12 @@ private def tok_t          : LIToken := ⟨.simple .T [.v], 5⟩
 /-- The VP constituent `[VP V Obj]` — the phrase that raises. Built
     planar-first so containment over it `decide`s. -/
 def vp : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf tok_mangatuk) (Planar.leaf tok_biangi))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tok_mangatuk) (PlanarSyntacticObject.leaf tok_biangi))
 
 /-- The VP as a planar subtree (for embedding in larger result trees). -/
-private def vpP : Planar := Planar.merge (Planar.leaf tok_mangatuk) (Planar.leaf tok_biangi)
+private def vpP : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tok_mangatuk) (PlanarSyntacticObject.leaf tok_biangi)
 
 -- ============================================================================
 -- § 2: Toba Batak VOS Derivation
@@ -158,20 +160,21 @@ def tobaBatakVOS : Derivation :=
 /-- The VOS **base** tree at stage 4 (pre-movement):
     `[TP T [vP Subj [v' v [VP V Obj]]]]`. Built planar-first. -/
 def tobaBatakBaseTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_t)
-      (Planar.merge (Planar.leaf tok_dakdanakan)
-        (Planar.merge (Planar.leaf tok_v) vpP)))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_dakdanakan)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v) vpP)))
 
 /-- The VOS **derived** tree after VP-raising:
     `[TP [VP V Obj] [T' T [vP Subj [v' v tVP]]]]`. The raised VP sits at
     the left edge; the original VP position is the bare trace. -/
 def tobaBatakDerivedTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge vpP
-      (Planar.merge (Planar.leaf tok_t)
-        (Planar.merge (Planar.leaf tok_dakdanakan)
-          (Planar.merge (Planar.leaf tok_v) Planar.trace))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge vpP
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_dakdanakan)
+          (PlanarSyntacticObject.merge
+            (PlanarSyntacticObject.leaf tok_v) PlanarSyntacticObject.trace))))
 
 -- ============================================================================
 -- § 3: English SVO Derivation (Comparison)
@@ -206,11 +209,12 @@ def englishSVO : Derivation :=
     `[TP T [vP John [v' v [VP saw Mary]]]]`. Built planar-first; same shape
     as `tobaBatakBaseTree`, modulo lexical content. -/
 def englishBaseTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_t2)
-      (Planar.merge (Planar.leaf tok_john_en)
-        (Planar.merge (Planar.leaf tok_v2)
-          (Planar.merge (Planar.leaf tok_saw) (Planar.leaf tok_mary_en)))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t2)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john_en)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v2)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_saw)
+            (PlanarSyntacticObject.leaf tok_mary_en)))))
 
 -- ============================================================================
 -- § 4: Word Order Predictions
@@ -601,9 +605,10 @@ private def tok_t_pass     : LIToken := ⟨.simple .T [.v], 25⟩
 
 /-- The passive VP: `[VP patient [V' V agent-PP]]`. Built planar-first. -/
 def vp_passive : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_boy) (Planar.merge (Planar.leaf tok_injured)
-      (Planar.leaf tok_by_himself)))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_boy) (PlanarSyntacticObject.merge
+      (PlanarSyntacticObject.leaf tok_injured)
+      (PlanarSyntacticObject.leaf tok_by_himself)))
 
 /-- English passive derivation (trees 97–100 of the paper).
 
@@ -628,12 +633,13 @@ def englishPassive : Derivation :=
     sits at the top edge above its base trace; the agent is a low
     complement of V. -/
 def englishPassiveDerivedTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_boy)
-      (Planar.merge (Planar.leaf tok_t_pass)
-        (Planar.merge (Planar.leaf tok_v_pass)
-          (Planar.merge Planar.trace
-            (Planar.merge (Planar.leaf tok_injured) (Planar.leaf tok_by_himself))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_boy)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t_pass)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v_pass)
+          (PlanarSyntacticObject.merge PlanarSyntacticObject.trace
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_injured)
+              (PlanarSyntacticObject.leaf tok_by_himself))))))
 
 /-- English passive yields patient-verb-agent surface order. -/
 theorem english_passive_order :

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -446,18 +446,19 @@ private def voiceTok   : LIToken := ⟨.simple .Voice [.V] "", 4⟩
 private def tTok       : LIToken := ⟨.simple .T [.Voice] "", 5⟩
 private def cTok       : LIToken := ⟨.simple .C [.T] "", 6⟩
 
-/-- The full CP derivation, built planar-first (Merge `SyntacticObject.node` is noncomputable,
+/-- The full CP derivation, built planar-first (Merge `SyntacticObject.merge` is noncomputable,
     so concrete `decide`-able trees use the planar DSL): the oblique DP undergoes
     successive-cyclic Ā-movement, surfacing at Spec,CP with a trace lower down.
     Structure: `[CP oblique [C' C [TP T [VoiceP oblique [Voice' Voice [VP V obj]]]]]]`. -/
 private def cp : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf obliqueTok)
-      (Planar.merge (Planar.leaf cTok)
-        (Planar.merge (Planar.leaf tTok)
-          (Planar.merge (Planar.leaf obliqueTok)
-            (Planar.merge (Planar.leaf voiceTok)
-              (Planar.merge (Planar.leaf verbTok) (Planar.leaf objectTok)))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf obliqueTok)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf cTok)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tTok)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf obliqueTok)
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceTok)
+              (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf verbTok)
+                (PlanarSyntacticObject.leaf objectTok)))))))
 
 theorem derivation_tree_size : cp.nodeCount = 6 := by decide
 

--- a/Linglib/Studies/HeimKratzer1998.lean
+++ b/Linglib/Studies/HeimKratzer1998.lean
@@ -285,7 +285,7 @@ Traces left by movement are interpreted as variables bound by
 #### Trace convention
 
 On the `SyntacticObject` carrier ([marcolli-chomsky-berwick-2025] Def 1.2.1) a trace is here the
-bare trace leaf `SyntacticObject.traceLeaf`, recognized by `SyntacticObject.isTrace`. The semantic
+bare trace leaf `SyntacticObject.trace`, recognized by `SyntacticObject.isTrace`. The semantic
 trace *index* `n` is not carried by the leaf: it is supplied by the binder (λ-abstraction) at the
 landing site, exactly as in the H&K rule ⟦t_n⟧^g = g(n). The interpretation functions below
 therefore take the index as an explicit argument. -/
@@ -352,13 +352,13 @@ def interpSOTrace {E : Type} (n : ℕ) (so : Minimalist.SyntacticObject) :
   if isTrace so then some (interpTrace n) else none
 
 /-- The trace leaf is recognized as type `e`. -/
-@[simp] theorem soSemanticType_traceLeaf :
-    soSemanticType traceLeaf = some .e := rfl
+@[simp] theorem soSemanticType_trace :
+    soSemanticType trace = some .e := rfl
 
 /-- A lexical leaf is not a trace, so it gets no carrier-level type. -/
-@[simp] theorem soSemanticType_lexLeaf (tok : Minimalist.LIToken) :
-    soSemanticType (lexLeaf tok) = none := by
-  have hne : ¬ isTrace (lexLeaf tok) := not_isTrace_lexLeaf tok
+@[simp] theorem soSemanticType_leaf (tok : Minimalist.LIToken) :
+    soSemanticType (leaf tok) = none := by
+  have hne : ¬ isTrace (leaf tok) := not_isTrace_leaf tok
   simp only [soSemanticType, if_neg hne]
 
 -- ============================================================================

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -56,7 +56,7 @@ section TreeDerivations
 
 open Minimalist SyntacticObject
 
--- Leaf tokens (the smart Merge `SyntacticObject.node` is noncomputable, so concrete trees
+-- Leaf tokens (the smart Merge `SyntacticObject.merge` is noncomputable, so concrete trees
 -- are built planar-first from `LIToken`s and `decide`d over).
 
 def voice_ag_t  : LIToken := ⟨.simple .Voice [.v]  "Voice[AG]",  200⟩
@@ -76,73 +76,77 @@ def DP_door_t   : LIToken := ⟨.simple .D     []    "the door",   217⟩
 /-- Transitive: "John broke the vase"
     `[VoiceP John [Voice' Voice_AG [vP v [VP broke [DP the vase]]]]]` -/
 def transitiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf DP_john_t)
-      (Planar.merge (Planar.leaf voice_ag_t)
-        (Planar.merge (Planar.leaf v_head_t)
-          (Planar.merge (Planar.leaf V_broke_t) (Planar.leaf DP_vase_t)))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf DP_john_t)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_ag_t)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_broke_t)
+            (PlanarSyntacticObject.leaf DP_vase_t)))))
 
 /-- Anticausative: "The vase broke"
     `[VoiceP Voice_∅ [vP v [VP broke [DP the vase]]]]` -/
 def anticausativeTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf voice_nth_t)
-      (Planar.merge (Planar.leaf v_head_t)
-        (Planar.merge (Planar.leaf V_broke_t) (Planar.leaf DP_vase_t))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_nth_t)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_broke_t)
+          (PlanarSyntacticObject.leaf DP_vase_t))))
 
 /-- Unaccusative: "The ship sank"
     `[VoiceP Voice_∅ [vP v [VP sank [DP the ship]]]]` -/
 def unaccusativeTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf voice_nth_t)
-      (Planar.merge (Planar.leaf v_head_t)
-        (Planar.merge (Planar.leaf V_sank_t) (Planar.leaf DP_ship_t))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_nth_t)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_sank_t)
+          (PlanarSyntacticObject.leaf DP_ship_t))))
 
 /-- Middle: "The door opened"
     `[VoiceP Voice_MID [vP v [VP opened [DP the door]]]]` -/
 def middleTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf voice_mid_t)
-      (Planar.merge (Planar.leaf v_head_t)
-        (Planar.merge (Planar.leaf V_opened_t) (Planar.leaf DP_door_t))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_mid_t)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_opened_t)
+          (PlanarSyntacticObject.leaf DP_door_t))))
 
 -- C-command predictions
 
 /-- Agent c-commands theme in the transitive. -/
 theorem transitive_agent_ccommands_theme :
-    cCommandsIn transitiveTree (lexLeaf DP_john_t) (lexLeaf DP_vase_t) := by decide
+    cCommandsIn transitiveTree (leaf DP_john_t) (leaf DP_vase_t) := by decide
 
 /-- Theme does NOT c-command agent. -/
 theorem transitive_theme_not_ccommands_agent :
-    ¬ cCommandsIn transitiveTree (lexLeaf DP_vase_t) (lexLeaf DP_john_t) := by decide
+    ¬ cCommandsIn transitiveTree (leaf DP_vase_t) (leaf DP_john_t) := by decide
 
 /-- Anticausative contains theme but no agent DP. -/
 theorem anticausative_contains_theme :
-    contains anticausativeTree (lexLeaf DP_vase_t) := by decide
+    contains anticausativeTree (leaf DP_vase_t) := by decide
 
 /-- Unaccusative contains theme. -/
 theorem unaccusative_contains_theme :
-    contains unaccusativeTree (lexLeaf DP_ship_t) := by decide
+    contains unaccusativeTree (leaf DP_ship_t) := by decide
 
 /-- Middle contains theme. -/
 theorem middle_contains_theme :
-    contains middleTree (lexLeaf DP_door_t) := by decide
+    contains middleTree (leaf DP_door_t) := by decide
 
 -- Causative alternation
 
 /-- The transitive and anticausative share the VP core:
     both contain V("broke") and DP("the vase"). -/
 theorem causative_pair_shared_vp :
-    contains transitiveTree (lexLeaf V_broke_t) ∧
-    contains transitiveTree (lexLeaf DP_vase_t) ∧
-    contains anticausativeTree (lexLeaf V_broke_t) ∧
-    contains anticausativeTree (lexLeaf DP_vase_t) := by
+    contains transitiveTree (leaf V_broke_t) ∧
+    contains transitiveTree (leaf DP_vase_t) ∧
+    contains anticausativeTree (leaf V_broke_t) ∧
+    contains anticausativeTree (leaf DP_vase_t) := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 /-- The transitive has an agent DP; the anticausative does not. -/
 theorem causative_pair_agent_contrast :
-    contains transitiveTree (lexLeaf DP_john_t) ∧
-    ¬ contains anticausativeTree (lexLeaf DP_john_t) := by
+    contains transitiveTree (leaf DP_john_t) ∧
+    ¬ contains anticausativeTree (leaf DP_john_t) := by
   constructor <;> decide
 
 /-- Voice determines the alternation: agentive assigns θ,

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -41,7 +41,7 @@ import Linglib.Semantics.ArgumentStructure.Linking
 
 ## Carrier note (P4 single-carrier flip)
 
-The MCB-faithful `SyntacticObject` carrier makes Merge (`SyntacticObject.node`/`*`) noncomputable,
+The MCB-faithful `SyntacticObject` carrier makes Merge (`SyntacticObject.merge`/`*`) noncomputable,
 so
 `SyntacticObject.Derivation.final` (the folded result tree) does not `decide`. The
 *movement bookkeeping* (`movedItems`) and the *externalized surface order*
@@ -49,7 +49,7 @@ so
 are proved over the `SyntacticObject.Derivation` directly.
 
 The c-command asymmetries are stated over the **derived tree built
-planar-first** (`SyntacticObject.ofPlanar (Planar.merge …)`), i.e. the very tree each
+planar-first** (`(PlanarSyntacticObject.merge …).toSyntacticObject`), i.e. the very tree each
 derivation produces, written out explicitly per the file's prose diagrams.
 This is faithful: the derivation records the operations; the planar tree
 is its result, and c-command (`SyntacticObject.cCommandsIn`) reduces on it.
@@ -103,7 +103,8 @@ private def tok_kick   : LIToken := ⟨.simple .V [.D] (phonForm := "kicked"), 3
 private def tok_ball   : LIToken := ⟨.simple .D [] (phonForm := "the ball"), 311⟩
 
 /-- The `[PP to Mary]` constituent as a planar subtree. -/
-private def ppToMaryP : Planar := Planar.merge (Planar.leaf tok_to) (Planar.leaf tok_mary)
+private def ppToMaryP : PlanarSyntacticObject := PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tok_to) (PlanarSyntacticObject.leaf tok_mary)
 
 -- ============================================================================
 -- § 2: Oblique Dative Derivation
@@ -121,7 +122,7 @@ private def ppToMaryP : Planar := Planar.merge (Planar.leaf tok_to) (Planar.leaf
 def obliqueDative : Derivation :=
   { initial := V_send
     steps := [
-      .emR (ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (PlanarSyntacticObject.toSyntacticObject ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .emL DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
     ] }
@@ -129,10 +130,10 @@ def obliqueDative : Derivation :=
 /-- The oblique dative result tree: `[John [letter [send [to Mary]]]]`.
     Built planar-first; this is exactly what `obliqueDative` produces. -/
 def obliqueDativeTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_john)
-      (Planar.merge (Planar.leaf tok_letter)
-        (Planar.merge (Planar.leaf tok_send) ppToMaryP)))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_send) ppToMaryP)))
 
 -- Oblique dative c-command predictions
 
@@ -170,7 +171,7 @@ Derivation steps:
 def docDativeShift : Derivation :=
   { initial := V_send
     steps := [
-      .emR (ofPlanar ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (PlanarSyntacticObject.toSyntacticObject ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .im DP_mary,                    -- DATIVE SHIFT: Mary moves to Spec
       .emL DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
@@ -180,12 +181,13 @@ def docDativeShift : Derivation :=
     the shell, asymmetrically c-commanding the theme; the original Mary
     position is the bare trace. `[John [Mary [letter [send [to t]]]]]`. -/
 def docDativeShiftTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_john)
-      (Planar.merge (Planar.leaf tok_mary)
-        (Planar.merge (Planar.leaf tok_letter)
-          (Planar.merge (Planar.leaf tok_send)
-            (Planar.merge (Planar.leaf tok_to) Planar.trace)))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_mary)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_send)
+            (PlanarSyntacticObject.merge
+              (PlanarSyntacticObject.leaf tok_to) PlanarSyntacticObject.trace)))))
 
 -- DOC c-command predictions: the asymmetries are REVERSED
 
@@ -227,10 +229,11 @@ def standardPassive : Derivation :=
 /-- The passive result tree: the ball (promoted) sits above John (demoted),
     leaving a trace in object position. `[ball [John [kicked t]]]`. -/
 def standardPassiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_ball)
-      (Planar.merge (Planar.leaf tok_john)
-        (Planar.merge (Planar.leaf tok_kick) Planar.trace)))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_ball)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
+        (PlanarSyntacticObject.merge
+          (PlanarSyntacticObject.leaf tok_kick) PlanarSyntacticObject.trace)))
 
 -- Passive c-command: promoted object c-commands demoted subject
 
@@ -403,7 +406,8 @@ def allDativeVerbs : List DativeVerbEntry :=
     do not (V assigns only Beneficiary, *to*'s Goal is non-redundant). -/
 theorem recoverability_predicts_dative_shift :
     (allDativeVerbs.filter recoverable).map (·.verb) = ["give", "send", "promise"] ∧
-    (allDativeVerbs.filter (! recoverable ·)).map (·.verb) = ["donate", "distribute", "contribute"] := by
+    (allDativeVerbs.filter (! recoverable ·)).map (·.verb) = ["donate", "distribute",
+      "contribute"] := by
   constructor <;> decide
 
 -- ============================================================================
@@ -462,7 +466,8 @@ private def tok_to2     : LIToken := ⟨.simple .P [.D] (phonForm := "to"), 323�
 def indirectPassive : Derivation :=
   { initial := V_sent
     steps := [
-      .emR (ofPlanar (Planar.merge (Planar.leaf tok_to2) (Planar.leaf tok_mary2))),
+      .emR (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+        (PlanarSyntacticObject.leaf tok_to2) (PlanarSyntacticObject.leaf tok_mary2))),
                        -- [V' sent [PP to Mary]]
       .emL DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
       .im DP_mary2,    -- DATIVE SHIFT: Mary to inner Spec
@@ -480,12 +485,13 @@ def indirectPassive : Derivation :=
     intermediate landing site; it gives the same Mary-c-commands-letter
     asymmetry but is *not* what the two-step derivation emits.) -/
 def indirectPassiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf tok_mary2)
-      (Planar.merge Planar.trace
-        (Planar.merge (Planar.leaf tok_letter2)
-          (Planar.merge (Planar.leaf tok_sent)
-            (Planar.merge (Planar.leaf tok_to2) Planar.trace)))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_mary2)
+      (PlanarSyntacticObject.merge PlanarSyntacticObject.trace
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter2)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_sent)
+            (PlanarSyntacticObject.merge
+              (PlanarSyntacticObject.leaf tok_to2) PlanarSyntacticObject.trace)))))
 
 /-- In the indirect passive, the promoted IO (Mary) c-commands the
     stranded DO (a letter). -/

--- a/Linglib/Studies/MarcolliLarson2025.lean
+++ b/Linglib/Studies/MarcolliLarson2025.lean
@@ -182,10 +182,10 @@ def anchoredGiveComb : Bud.Tree (Color LIToken) :=
     structure of *Brian gave the book to Mary*. -/
 theorem realize_anchoredGiveComb :
     realize (anchoredGiveComb brian gave theBook toMary) =
-      some ((SyntacticObject.lexLeaf brian).node
-        ((SyntacticObject.lexLeaf theBook).node
-          ((SyntacticObject.lexLeaf toMary).node
-            (SyntacticObject.lexLeaf gave)))) := rfl
+      some ((SyntacticObject.leaf brian).merge
+        ((SyntacticObject.leaf theBook).merge
+          ((SyntacticObject.leaf toMary).merge
+            (SyntacticObject.leaf gave)))) := rfl
 
 /-- A movement landing site above the anchored comb realizes to the same
     syntactic object: the empty-tree marker exists only for the

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -396,25 +396,25 @@ private def kProbeV  : LIToken := ⟨.simple .V [.D] (phonForm := "see"), 902⟩
 
 /-- A K-headed leaf is detected by `isKLeaf`; a D-headed leaf is not. -/
 private theorem isKLeaf_detects :
-    isKLeaf (lexLeaf kProbeK) = true ∧ isKLeaf (lexLeaf kProbeD) = false := by
+    isKLeaf (leaf kProbeK) = true ∧ isKLeaf (leaf kProbeD) = false := by
   decide
 
 /-- Positive: `[K DP]` (a K daughter present) is a KP. -/
 private theorem isKP_detects_kp :
-    isKP (node (lexLeaf kProbeK) (lexLeaf kProbeD)) :=
-  ⟨lexLeaf kProbeK, (immediatelyContains_node _ _ _).mpr (Or.inl rfl), by decide⟩
+    isKP (merge (leaf kProbeK) (leaf kProbeD)) :=
+  ⟨leaf kProbeK, (immediatelyContains_merge _ _ _).mpr (Or.inl rfl), by decide⟩
 
 /-- Negative: `[V DP]` (no K daughter) is not a KP. -/
 private theorem isKP_rejects_non_kp :
-    ¬ isKP (node (lexLeaf kProbeV) (lexLeaf kProbeD)) := by
+    ¬ isKP (merge (leaf kProbeV) (leaf kProbeD)) := by
   rintro ⟨d, hd, hk⟩
-  rw [immediatelyContains_node] at hd
+  rw [immediatelyContains_merge] at hd
   rcases hd with rfl | rfl <;> exact absurd hk (by decide)
 
 /-- Negative: a bare K *leaf* is a K head, not a KP — it has no daughters. -/
-private theorem isKP_rejects_bare_K_leaf : ¬ isKP (lexLeaf kProbeK) := by
+private theorem isKP_rejects_bare_K_leaf : ¬ isKP (leaf kProbeK) := by
   rintro ⟨d, hd, _⟩
-  exact (immediatelyContains_lexLeaf kProbeK d) hd
+  exact (immediatelyContains_leaf kProbeK d) hd
 
 -- ============================================================================
 -- § 9: Anti-Redundancy in Agreement
@@ -747,8 +747,8 @@ theorem impersonal_passive_converges : passiveV.features.hasD = false := rfl
 -- c-commands the other → symmetric binding (either can passivize).
 
 -- Concrete trees are built **planar-first**
--- (`SyntacticObject.ofPlanar`/`Planar.merge`/`Planar.leaf`)
--- because Merge (`SyntacticObject.node`) is noncomputable; the c-command decision procedure
+-- (`PlanarSyntacticObject.merge`/`leaf`, then `toSyntacticObject`)
+-- because Merge (`SyntacticObject.merge`) is noncomputable; the c-command decision procedure
 -- then reduces under `decide`. Each leaf is a lexical leaf over a token, and the
 -- tree references the same tokens via the planar DSL so the two match
 -- definitionally.
@@ -768,10 +768,12 @@ private def DO₁ : LIToken := tok .D "DO" 13
 private def XP₁ : LIToken := tok .P "to-Mary" 14
 
 def lowXPTree : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf agent₁)
-    (Planar.merge (Planar.leaf v₁)
-      (Planar.merge (Planar.leaf DO₁)
-        (Planar.merge (Planar.leaf V₁) (Planar.leaf XP₁)))))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf agent₁)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v₁)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf DO₁)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V₁)
+          (PlanarSyntacticObject.leaf XP₁)))))
 
 -- DOC ditransitive: V: [·D·], v: [·D·][·X·][·V·]
 -- Structure: [vP VP [vP agent [v' v IO]]]
@@ -785,9 +787,11 @@ private def DO₂ : LIToken := tok .D "DO" 23
 private def IO₂ : LIToken := tok .D "IO" 24
 
 def docTree : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.merge (Planar.leaf V₂) (Planar.leaf DO₂))
-    (Planar.merge (Planar.leaf agent₂)
-      (Planar.merge (Planar.leaf v₂) (Planar.leaf IO₂))))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf V₂) (PlanarSyntacticObject.leaf DO₂))
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf agent₂)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v₂)
+        (PlanarSyntacticObject.leaf IO₂))))
 
 -- § 10a: Internal argument binding asymmetry
 
@@ -795,30 +799,30 @@ def docTree : SyntacticObject :=
     DO (specifier of V, by Non-DP First) c-commands into the
     complement position. -/
 theorem low_xp_DO_ccommands_XP :
-    cCommandsIn lowXPTree (lexLeaf DO₁) (lexLeaf XP₁) := by decide
+    cCommandsIn lowXPTree (leaf DO₁) (leaf XP₁) := by decide
 
 theorem low_xp_XP_not_ccommands_DO :
-    ¬ cCommandsIn lowXPTree (lexLeaf XP₁) (lexLeaf DO₁) := by decide
+    ¬ cCommandsIn lowXPTree (leaf XP₁) (leaf DO₁) := by decide
 
 /-- DOC: neither internal argument c-commands the other — symmetric.
     DO is inside VP (outer specifier), IO is complement of v.
     They are in separate branches. -/
 theorem doc_DO_not_ccommands_IO :
-    ¬ cCommandsIn docTree (lexLeaf DO₂) (lexLeaf IO₂) := by decide
+    ¬ cCommandsIn docTree (leaf DO₂) (leaf IO₂) := by decide
 
 theorem doc_IO_not_ccommands_DO :
-    ¬ cCommandsIn docTree (lexLeaf IO₂) (lexLeaf DO₂) := by decide
+    ¬ cCommandsIn docTree (leaf IO₂) (leaf DO₂) := by decide
 
 /-- The structural asymmetry derived from VP-as-specifier:
     VP-as-complement gives binding asymmetry between internal
     arguments; VP-as-specifier gives symmetric binding. -/
 theorem binding_asymmetry_iff_vp_complement :
     -- Low-XP (VP complement): DO c-commands XP, not vice versa
-    (cCommandsIn lowXPTree (lexLeaf DO₁) (lexLeaf XP₁) ∧
-     ¬ cCommandsIn lowXPTree (lexLeaf XP₁) (lexLeaf DO₁)) ∧
+    (cCommandsIn lowXPTree (leaf DO₁) (leaf XP₁) ∧
+     ¬ cCommandsIn lowXPTree (leaf XP₁) (leaf DO₁)) ∧
     -- DOC (VP specifier): neither c-commands the other
-    (¬ cCommandsIn docTree (lexLeaf DO₂) (lexLeaf IO₂) ∧
-     ¬ cCommandsIn docTree (lexLeaf IO₂) (lexLeaf DO₂)) := by
+    (¬ cCommandsIn docTree (leaf DO₂) (leaf IO₂) ∧
+     ¬ cCommandsIn docTree (leaf IO₂) (leaf DO₂)) := by
   refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> decide
 
 -- § 10b: Agent c-command differences
@@ -826,19 +830,19 @@ theorem binding_asymmetry_iff_vp_complement :
 /-- In the low-XP structure, the agent c-commands both internal
     arguments (VP is complement, fully inside agent's sister). -/
 theorem low_xp_agent_ccommands_DO :
-    cCommandsIn lowXPTree (lexLeaf agent₁) (lexLeaf DO₁) := by decide
+    cCommandsIn lowXPTree (leaf agent₁) (leaf DO₁) := by decide
 
 theorem low_xp_agent_ccommands_XP :
-    cCommandsIn lowXPTree (lexLeaf agent₁) (lexLeaf XP₁) := by decide
+    cCommandsIn lowXPTree (leaf agent₁) (leaf XP₁) := by decide
 
 /-- In the DOC structure with Tucking In, the agent (inner specifier)
     c-commands IO (complement of v) but NOT DO (inside VP, the outer
     specifier). The agent and VP are in separate branches — a direct
     consequence of VP being a specifier rather than a complement. -/
 theorem doc_agent_ccommands_IO :
-    cCommandsIn docTree (lexLeaf agent₂) (lexLeaf IO₂) := by decide
+    cCommandsIn docTree (leaf agent₂) (leaf IO₂) := by decide
 
 theorem doc_agent_not_ccommands_DO :
-    ¬ cCommandsIn docTree (lexLeaf agent₂) (lexLeaf DO₂) := by decide
+    ¬ cCommandsIn docTree (leaf agent₂) (leaf DO₂) := by decide
 
 end Newman2024

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -148,18 +148,19 @@ def subjectTraceToken : LIToken :=
   { item := LexicalItem.simple .D [], id := idSubjectTrace }
 
 /-- The subject DP at its base position (Spec,vP). Class 1 (uZondi). -/
-def subjectAtBase : SyntacticObject := lexLeaf subjectToken
+def subjectAtBase : SyntacticObject := leaf subjectToken
 
 /-- The subject DP after movement to Spec,VoiceP (a fresh copy, since
     each `LIToken` in copy theory is a distinct token). -/
-def subjectAtSpecVoiceP : SyntacticObject := lexLeaf subjectToken
+def subjectAtSpecVoiceP : SyntacticObject := leaf subjectToken
 
 /-- A trace at the base position after movement (distinct LIToken). -/
-def subjectTrace : SyntacticObject := lexLeaf subjectTraceToken
+def subjectTrace : SyntacticObject := leaf subjectTraceToken
 
-/-! The trees below are built **planar-first** via the DSL (`SyntacticObject.ofPlanar`
-    / `Planar.merge` / `Planar.leaf`) because the smart Merge
-    `SyntacticObject.node` is
+/-! The trees below are built **planar-first** via the DSL
+  (`PlanarSyntacticObject.toSyntacticObject`
+    / `PlanarSyntacticObject.merge` / `PlanarSyntacticObject.leaf`) because the smart Merge
+    `SyntacticObject.merge` is
     noncomputable; planar construction keeps the `decide` PIC proofs
     reducing. -/
 
@@ -167,17 +168,21 @@ def subjectTrace : SyntacticObject := lexLeaf subjectTraceToken
     Structure: `voice (subject v)`. Voice is the phase; its complement
     is the entire vP, which contains the subject. -/
 def voiceP_noSpec : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf voiceToken)
-    (Planar.merge (Planar.leaf subjectToken) (Planar.leaf vToken)))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf voiceToken)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
+      (PlanarSyntacticObject.leaf vToken)))
 
 /-- The Voice projection with subject at Spec,VoiceP (phase edge).
     Structure: `subject (voice (trace v))`. The OUTER node is not the
     phase; the inner `voice (trace v)` is the phase, and the subject
     (sister to it) is at the edge. -/
 def voiceP_withSpec : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf subjectToken)
-    (Planar.merge (Planar.leaf voiceToken)
-      (Planar.merge (Planar.leaf subjectTraceToken) (Planar.leaf vToken))))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf subjectToken)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectTraceToken)
+        (PlanarSyntacticObject.leaf vToken))))
 
 /-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
     `voiceP_noSpec`. Its interior (= the head's c-command domain, the
@@ -194,21 +199,25 @@ def voicePhase_withSpec : Phase :=
 
 /-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
 def auxVTree_inSitu : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf tToken)
-    (Planar.merge (Planar.leaf aspToken)
-      (Planar.merge (Planar.leaf voiceToken)
-        (Planar.merge (Planar.leaf subjectToken) (Planar.leaf vToken)))))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tToken)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf aspToken)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
+          (PlanarSyntacticObject.leaf vToken)))))
 
 /-- The full Aux-V tree with subject moved to Spec,VoiceP. T's probe will
     additionally attract the subject to Spec,TP — that movement is the
     derivational step we don't model here; the salient question is just
     whether T's probe *finds* the subject under PIC. -/
 def auxVTree_subjectMoved : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf tToken)
-    (Planar.merge (Planar.leaf aspToken)
-      (Planar.merge (Planar.leaf subjectToken)
-        (Planar.merge (Planar.leaf voiceToken)
-          (Planar.merge (Planar.leaf subjectTraceToken) (Planar.leaf vToken))))))
+  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tToken)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf aspToken)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectTraceToken)
+            (PlanarSyntacticObject.leaf vToken))))))
 
 end Sample
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -362,8 +362,8 @@ def DP_wife_t   := mkLeafPhon .D     []      "wife"        409
 def DP_food_t   := mkLeafPhon .D     []      "food"        410
 
 /-! Planar leaf tokens, used to build the concrete trees the c-command
-    theorems reason over (Merge `SyntacticObject.node` is noncomputable; trees are
-    built planar-first via `SyntacticObject.ofPlanar`). -/
+    theorems reason over (Merge `SyntacticObject.merge` is noncomputable; trees are
+    built planar-first via `PlanarSyntacticObject.toSyntacticObject`). -/
 
 private def t_voice_ag  : LIToken := ⟨.simple .Voice [.V] (phonForm := "Voice[AG]"), 400⟩
 private def t_appl_low  : LIToken := ⟨.simple .Appl [.D] (phonForm := "Appl[LOW]"), 402⟩
@@ -390,12 +390,13 @@ private def t_DP_food   : LIToken := ⟨.simple .D [] (phonForm := "food"), 410�
     asymmetry that IO asymmetrically c-commands DO. Built planar-first
     so the c-command theorems `decide`. -/
 def ditransitiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf t_DP_john)
-      (Planar.merge (Planar.leaf t_voice_ag)
-        (Planar.merge (Planar.leaf t_V_sent)
-          (Planar.merge (Planar.leaf t_DP_mary)
-            (Planar.merge (Planar.leaf t_appl_low) (Planar.leaf t_DP_letter))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_john)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_voice_ag)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_V_sent)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_mary)
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_appl_low)
+              (PlanarSyntacticObject.leaf t_DP_letter))))))
 
 /-- High applicative benefactive (Chaga pattern): "he ate food for wife"
 
@@ -406,12 +407,13 @@ def ditransitiveTree : SyntacticObject :=
     theme). High Appl is attested in Bantu languages (Chaga, Luganda,
     Venda) and Albanian, but NOT in English. -/
 def benefactiveTree : SyntacticObject :=
-  ofPlanar
-    (Planar.merge (Planar.leaf t_DP_john)
-      (Planar.merge (Planar.leaf t_voice_ag)
-        (Planar.merge (Planar.leaf t_DP_wife)
-          (Planar.merge (Planar.leaf t_appl_high)
-            (Planar.merge (Planar.leaf t_V_eat) (Planar.leaf t_DP_food))))))
+  PlanarSyntacticObject.toSyntacticObject
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_john)
+      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_voice_ag)
+        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_wife)
+          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_appl_high)
+            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_V_eat)
+              (PlanarSyntacticObject.leaf t_DP_food))))))
 
 -- ============================================================================
 -- § 3: C-command Predictions

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -293,15 +293,17 @@ open Minimalist.Movement (RemnantFronting PredicateDoubling properRemnant)
 open Minimalist.SyntacticObject
 
 private def guebieVerbTok : LIToken := ⟨.simple .V [], 1⟩
-private def guebieVerbLeaf : SyntacticObject := lexLeaf guebieVerbTok
+private def guebieVerbLeaf : SyntacticObject := leaf guebieVerbTok
 
 /-- The remnant VP of the verb-doubling configuration ((31)): an evacuation trace
     plus the verb copy, pronounced for recoverability per [koopman-1997]. -/
 private def guebieFrontedVP : SyntacticObject :=
-  ofPlanar (Minimalist.Planar.merge Minimalist.Planar.trace (Minimalist.Planar.leaf guebieVerbTok))
+  Minimalist.PlanarSyntacticObject.toSyntacticObject
+    (Minimalist.PlanarSyntacticObject.merge Minimalist.PlanarSyntacticObject.trace
+      (Minimalist.PlanarSyntacticObject.leaf guebieVerbTok))
 
 private def guebieLandingTok : LIToken := ⟨.simple .C [], 2⟩
-private def guebieLandingSite : SyntacticObject := lexLeaf guebieLandingTok
+private def guebieLandingSite : SyntacticObject := leaf guebieLandingTok
 
 /-- The Guébie predicate-fronting witness: V evacuates, the remnant VP fronts to
     Spec,CP, and the trace is pronounced — verb doubling. -/

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -43,8 +43,8 @@ its structural conditions are read off one tree and one assignment. -/
 def headBundle (feats : LIToken → FeatureBundle) (s : SyntacticObject) : FeatureBundle :=
   (s.selHead.map feats).getD ⊥
 
-@[simp] theorem headBundle_lexLeaf (feats : LIToken → FeatureBundle) (tok : LIToken) :
-    headBundle feats (lexLeaf tok) = feats tok := rfl
+@[simp] theorem headBundle_leaf (feats : LIToken → FeatureBundle) (tok : LIToken) :
+    headBundle feats (SyntacticObject.leaf tok) = feats tok := rfl
 
 /-- Valid Agree under a feature assignment: `probe` c-commands `goal` in
     `root`, the probe's head bears an unvalued `t`-slot, and the goal's head

--- a/Linglib/Syntax/Minimalist/Linearization/Chain.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Chain.lean
@@ -55,34 +55,34 @@ open Syntax.Question (MWFParameter PhaseEdge)
 
 mutual
 /-- The positions whose label `f` accepts, with their paths, left to right. -/
-def positions (f : Vertex → Option LIToken) : Planar → List (Path × LIToken)
+def positions (f : Vertex → Option LIToken) : RoseTree Vertex → List (Path × LIToken)
   | .node a cs => match f a with
     | some tok => [([], tok)]
     | none => positionsAux f 0 cs
 /-- Auxiliary: the positions in a children list from index `i`. -/
 def positionsAux (f : Vertex → Option LIToken) :
-    ℕ → List (Planar) → List (Path × LIToken)
+    ℕ → List (RoseTree Vertex) → List (Path × LIToken)
   | _, [] => []
   | i, c :: cs => (positions f c).map (λ x => (i :: x.1, x.2)) ++ positionsAux f (i + 1) cs
 end
 
 /-- The tokens with their paths, left to right. -/
-def tokenList : Planar → List (Path × LIToken) := positions (Sum.elim some λ _ => none)
+def tokenList : RoseTree Vertex → List (Path × LIToken) := positions (Sum.elim some λ _ => none)
 
 /-- The traces with their paths, left to right. -/
-def traceList : Planar → List (Path × LIToken) := positions (Sum.elim (λ _ => none) id)
+def traceList : RoseTree Vertex → List (Path × LIToken) := positions (Sum.elim (λ _ => none) id)
 
-variable (t : Planar)
+variable (t : PlanarSyntacticObject)
 
 /-- The occurrences of `tok`. -/
 def occurrences (tok : LIToken) : List Path :=
-  (tokenList t).filterMap λ x => if x.2 = tok then some x.1 else none
+  (tokenList t.val).filterMap λ x => if x.2 = tok then some x.1 else none
 
 /-- The tokens of `t`, each once. -/
-def tokens : Finset LIToken := ((tokenList t).map (·.2)).toFinset
+def tokens : Finset LIToken := ((tokenList t.val).map (·.2)).toFinset
 
 /-- The terms of `t`: its subtrees, a shared constituent's once. -/
-def terms : Finset (Planar) := ((vertices t).filterMap t.subtreeAt).toFinset
+def terms : Finset (RoseTree Vertex) := ((vertices t.val).filterMap t.val.subtreeAt).toFinset
 
 /-- `tok` is shared, dominated by two mothers: it occurs twice. -/
 def IsShared (tok : LIToken) : Prop := 2 ≤ (occurrences t tok).length
@@ -101,7 +101,7 @@ instance (x : Path × LIToken) : Decidable (IsBound t x) :=
   inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
 /-- The unbound traces: seen from their positions, copies without their antecedents. -/
-def unboundTraces : List (Path × LIToken) := (traceList t).filter (¬ IsBound t ·)
+def unboundTraces : List (Path × LIToken) := (traceList t.val).filter (¬ IsBound t ·)
 
 /-- The occurrence at which `tok` is pronounced: its last. -/
 def pronouncedAt (tok : LIToken) : Option Path := (occurrences t tok).getLast?
@@ -113,13 +113,14 @@ def complementPath (p : Path) : Path := p.dropLast ++ [1 - p.getLastD 0]
 
 /-- The [E] heads. -/
 def eHeads : List Path :=
-  (tokenList t).filterMap λ x => if x.2.item.outerEllipsis then some x.1 else none
+  (tokenList t.val).filterMap λ x => if x.2.item.outerEllipsis then some x.1 else none
 
 /-- The elided domains, one per distinct complement of an [E] head, in the order of the heads:
 a shared head over one shared complement applies once, over two complements twice. -/
 def elidedDomains : List Path :=
   ((eHeads t).map complementPath).foldl
-    (λ acc p => if acc.any (λ q => t.subtreeAt q = t.subtreeAt p) then acc else acc ++ [p]) []
+    (λ acc p => if acc.any (λ q => t.val.subtreeAt q = t.val.subtreeAt p) then acc else acc ++ [p])
+      []
 
 /-- `tok` is silenced: one of its occurrences lies in an elided domain. -/
 def IsSilenced (tok : LIToken) : Prop :=
@@ -130,7 +131,7 @@ instance (tok : LIToken) : Decidable (IsSilenced t tok) :=
 
 /-- The pronounced tokens, left to right: each at its last occurrence, unless silenced. -/
 def pfYield : List LIToken :=
-  (tokenList t).filterMap λ x =>
+  (tokenList t.val).filterMap λ x =>
     if pronouncedAt t x.2 = some x.1 ∧ ¬ IsSilenced t x.2 then some x.2 else none
 
 /-- The pronounced forms, left to right. -/
@@ -158,17 +159,17 @@ instance : Decidable (PronunciationEconomy t) := inferInstanceAs (Decidable (∀
 /-- The specifiers and head of the projection of a head of category `c`: down the right spine,
 the left daughters above the head, which is the first selecting item met; `none` when that item
 has another category or the spine ends first. -/
-def projection (c : Cat) : Planar → Option (List (Planar) × LIToken)
+def projection (c : Cat) : RoseTree Vertex → Option (List (RoseTree Vertex) × LIToken)
   | .node (.inr none) [.node (.inl tok) [], r] =>
       if tok.item.outerSel = [] then
-        (projection c r).map λ x => (Planar.leaf tok :: x.1, x.2)
+        (projection c r).map λ x => (.node (.inl tok) [] :: x.1, x.2)
       else if tok.item.outerCat = c then some ([], tok) else none
   | .node (.inr none) [l, r] => (projection c r).map λ x => (l :: x.1, x.2)
   | _ => none
 
 /-- The head of a constituent: the token or trace at a leaf, else the first selecting item down
 the right spine. -/
-def headToken? : Planar → Option LIToken
+def headToken? : RoseTree Vertex → Option LIToken
   | .node (.inl tok) _ | .node (.inr (some tok)) _ => some tok
   | .node (.inr none) [.node (.inl tok) [], r] =>
       if tok.item.outerSel = [] then headToken? r else some tok
@@ -176,15 +177,15 @@ def headToken? : Planar → Option LIToken
   | .node (.inr none) _ => none
 
 /-- The constituent is a wh-specifier: its head is a wh-token or its trace. -/
-def IsWhSpecifier (s : Planar) : Prop :=
+def IsWhSpecifier (s : RoseTree Vertex) : Prop :=
   ∃ tok ∈ (headToken? s).toList, tok.item.outerWh = true
 
-instance (s : Planar) : Decidable (IsWhSpecifier s) :=
+instance (s : RoseTree Vertex) : Decidable (IsWhSpecifier s) :=
   inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
 /-- The phase at `p`, a `v` or `C` projection: its edge, specifiers and head. -/
-def phaseAt (p : Path) : Option (PhaseEdge × List (Planar) × LIToken) :=
-  (t.subtreeAt p).bind λ s =>
+def phaseAt (p : Path) : Option (PhaseEdge × List (RoseTree Vertex) × LIToken) :=
+  (t.val.subtreeAt p).bind λ s =>
     ((projection .v s).map λ x => (PhaseEdge.vP, x)).or
       ((projection .C s).map λ x => (PhaseEdge.CP, x))
 
@@ -198,7 +199,7 @@ instance (param : MWFParameter) (p : Path) : Decidable (IsAsterisked t param p) 
 
 /-- The object converges at PF: the head of every asterisked phase is silenced. -/
 def Converges (param : MWFParameter) : Prop :=
-  ∀ p ∈ vertices t, IsAsterisked t param p → ∀ x ∈ (phaseAt t p).toList, IsSilenced t x.2.2
+  ∀ p ∈ vertices t.val, IsAsterisked t param p → ∀ x ∈ (phaseAt t p).toList, IsSilenced t x.2.2
 
 instance (param : MWFParameter) : Decidable (Converges t param) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -151,16 +151,16 @@ variable (side : ConventionDir)
 def linearizationState (s : SyntacticObject) : LinearizationState side :=
   liftFun (fun tok => .of tok tok.item.outerSel [tok]) (.of (mkTraceToken 0) [] []) s
 
-@[simp] theorem linearizationState_lexLeaf (tok : LIToken) :
-    (lexLeaf tok).linearizationState side = .of tok tok.item.outerSel [tok] := rfl
+@[simp] theorem linearizationState_leaf (tok : LIToken) :
+    (SyntacticObject.leaf tok).linearizationState side = .of tok tok.item.outerSel [tok] := rfl
 
-@[simp] theorem linearizationState_traceLeaf :
-    traceLeaf.linearizationState side = .of (mkTraceToken 0) [] [] := rfl
+@[simp] theorem linearizationState_trace :
+    trace.linearizationState side = .of (mkTraceToken 0) [] [] := rfl
 
 @[simp] theorem linearizationState_node (l r : SyntacticObject) :
-    (node l r).linearizationState side =
+    (merge l r).linearizationState side =
       l.linearizationState side * r.linearizationState side :=
-  liftFun_node _ _ l r
+  liftFun_merge _ _ l r
 
 /-- The head function as a morphism of magmas ([marcolli-chomsky-berwick-2025]
     §1.13's algebraic frame): Merge multiplies constituents, `h` multiplies states. -/
@@ -186,10 +186,10 @@ def linearize (s : SyntacticObject) : Option (List LIToken) :=
 def phonYield (s : SyntacticObject) : Option (List String) :=
   (s.linearize side).map (·.filterMap LIToken.phonForm?)
 
-@[simp] theorem linearize_lexLeaf (tok : LIToken) :
-    (lexLeaf tok).linearize side = some [tok] := rfl
+@[simp] theorem linearize_leaf (tok : LIToken) :
+    (SyntacticObject.leaf tok).linearize side = some [tok] := rfl
 
-@[simp] theorem linearize_traceLeaf : traceLeaf.linearize side = some [] := rfl
+@[simp] theorem linearize_trace : trace.linearize side = some [] := rfl
 
 end SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -6,197 +6,84 @@ Authors: Robert Hawkins
 import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
 
 /-!
-# Derivation-grounded externalization (computable PF order)
+# Derivation-grounded externalization
 
 [marcolli-chomsky-berwick-2025] §1.12. `SyntacticObject.Derivation.final` is an unordered
-`Nonplanar` quotient, so the surface left-to-right order is not recoverable from it.
-But a `Derivation` *records* the planarization choices: `emL`/`im` place material on
-the LEFT edge, `emR` on the right — exactly MCB's externalization section σ_L, here
-fixed by the derivation ("the language `L`") rather than a noncanonical `Quot.out`.
-`externalizeP?` replays the steps on an ordered `Planar` accumulator,
-giving a fully **computable** PF: it never calls the noncomputable
-`SyntacticObject.node`/`SyntacticObject.replace` (planar tree surgery + a `Nonplanar.mk` equality
-test), so
-surface orders `decide`. Traces are unpronounced, dropped by `planarYield`.
+object, so the surface left-to-right order is not recoverable from it, but a `Derivation`
+records the planarization choices: `emL` and `im` place material on the left edge, `emR` on
+the right, MCB's externalization section `σ_L` fixed by the derivation rather than by a
+noncanonical choice of representative. `Derivation.externalize?` replays the steps on an
+ordered accumulator, a `PlanarSyntacticObject`, so surface orders `decide`; it is partial by
+design, `none` when a merged item is complex or a mover is absent. Traces are unpronounced,
+dropped by the yield. The faithfulness theorem `externalize?_faithful` says the replay commutes
+with forgetting the order: whenever it succeeds, its result is the derived object itself, so the
+surface readouts `surfaceTokens`, `surfaceCats` and `surfacePhon` are the word order of the
+actual derived syntactic object. Sibling accounts of linearization: the selection-induced
+harmonic order (`Linearization/Externalization.lean`) and Fox–Pesetsky cyclic linearization
+(`Linearization/Cyclic.lean`).
 
-The Π-bridge faithfulness theorem `SyntacticObject.Derivation.externalizeP?_faithful` proves
-`Nonplanar.mk externalizeP? = final` whenever the replay succeeds: the surface
-readouts (`surfaceTokens`/`surfaceCats`/`surfacePhon`) are the word order of the
-*actual* derived object. Sibling accounts of linearization: the selection-induced
-harmonic order (`Linearization/Externalization.lean`) and Fox-Pesetsky cyclic
-linearization (`Linearization/Cyclic.lean`).
+## Main definitions
+
+* `Minimalist.PlanarSyntacticObject.moveLeft`, `Minimalist.externStep`,
+  `Minimalist.SyntacticObject.Derivation.externalize?`: the replay.
+* `Minimalist.SyntacticObject.Derivation.surfaceTokens`, `surfaceCats`, `surfacePhon`.
+
+## Main results
+
+* `Minimalist.SyntacticObject.Derivation.externalize?_faithful`: a successful replay forgets to
+  `final`.
+
+## References
+
+* [marcolli-chomsky-berwick-2025], §1.12
 -/
 
 namespace Minimalist
 
 open RoseTree RoseTree.Nonplanar SyntacticObject
 
-/-! ## Derivation-grounded externalization (computable PF order)
+/-! ### Operations on ordered trees -/
 
-[marcolli-chomsky-berwick-2025] §1.12. `final` is an unordered `Nonplanar` quotient, so
-the surface left-to-right order is not recoverable from it. But a `Derivation` *records*
-the planarization choices: `emL`/`im` place material on the LEFT edge, `emR` on the
-right — exactly MCB's externalization section `σ_L`, here fixed by the derivation ("the
-language `L`") rather than a noncanonical `Quot.out`. The fold below replays the steps on
-an **ordered `Planar` accumulator**, giving a fully **computable** PF: it never
-calls the noncomputable `SyntacticObject.node`/`SyntacticObject.replace` (it uses planar tree
-surgery + a
-`Nonplanar.mk` equality test), so surface orders `decide`. Traces are unpronounced,
-dropped by `planarYield`.
-
-The formal Π-bridge faithfulness theorem (`SyntacticObject.Derivation.externalizeP?_faithful`,
-below)
-proves `Nonplanar.mk externalizeP? = final` whenever the replay succeeds: the surface
-readouts are the word order of the *actual* derived object, not just a replay that happens
-to reproduce attested orders. The `decide` demos below exercise concrete derivations. -/
-
-/-- Planar form of a leaf/trace `SyntacticObject` (the only items merged in canonical derivations);
-    `none` for a complex `SyntacticObject` (no recorded internal order). -/
-def SyntacticObject.toPlanarLeaf? (s : SyntacticObject) : Option (Planar) :=
+/-- The ordered leaf of a leaf object; `none` on a complex object. -/
+def SyntacticObject.toPlanarLeaf? (s : SyntacticObject) : Option PlanarSyntacticObject :=
   match s.getLIToken with
-  | some tok => some (Planar.leaf tok)
-  | none     => if s = traceLeaf then some Planar.trace else none
+  | some tok => some (PlanarSyntacticObject.leaf tok)
+  | none     => if s = trace then some PlanarSyntacticObject.trace else none
 
-/-- Plain left-to-right token yield of an *already-ordered* planar tree; traces
-    (`Sum.inr none`) are unpronounced and contribute nothing. -/
-def planarYield : Planar → List LIToken
-  | .node (.inl tok) _   => [tok]
+/-- Left-to-right token yield of an ordered tree; traces are unpronounced. -/
+def planarYield : RoseTree Vertex → List LIToken
+  | .node (.inl tok) _ => [tok]
   | .node (.inr none) [l, r] => planarYield l ++ planarYield r
-  | .node (.inr _) _    => []
+  | .node (.inr _) _ => []
 
-/-- "Projects to `target`": a planar subtree whose nonplanar projection is the `SyntacticObject`
-    `target` — the predicate the `im` replay uses to locate a mover. Computable
-    (`DecidableEq (Nonplanar …)`), so it `decide`s. -/
-def projEqP (target : SyntacticObject) (s : Planar) : Bool :=
+/-- The subtree projects to `target`: its unordered tree is `target`'s. -/
+def projEqP (target : SyntacticObject) (s : RoseTree Vertex) : Bool :=
   decide (Nonplanar.mk s = target.val)
 
-/-- Leftmost (root-first) subtree satisfying `p`. -/
-def planarFindP? (p : Planar → Bool) : Planar → Option (Planar)
+/-- The leftmost, root-first subtree satisfying `p`. -/
+def planarFindP? (p : RoseTree Vertex → Bool) : RoseTree Vertex → Option (RoseTree Vertex)
   | t@(.node _ [])     => if p t then some t else none
   | t@(.node _ [l, r]) => if p t then some t else (planarFindP? p l).or (planarFindP? p r)
   | t@(.node _ _)      => if p t then some t else none
 
 /-- Replace every subtree satisfying `p` by `rep`. -/
-def planarReplaceWhereP (p : Planar → Bool) (rep : Planar) :
-    Planar → Planar
+def planarReplaceWhereP (p : RoseTree Vertex → Bool) (rep : RoseTree Vertex) :
+    RoseTree Vertex → RoseTree Vertex
   | t@(.node _ [])     => if p t then rep else t
   | t@(.node a [l, r]) =>
       if p t then rep
       else .node a [planarReplaceWhereP p rep l, planarReplaceWhereP p rep r]
   | t@(.node _ _)      => if p t then rep else t
 
-/-- The planar trace a moved object leaves: `SyntacticObject.trace` as a planar leaf. -/
-def SyntacticObject.tracePlanar (s : SyntacticObject) : Planar :=
-  s.selHead.elim Planar.trace Planar.traceOf
+private theorem projEqP_eq {target : SyntacticObject} {s : RoseTree Vertex}
+    (h : projEqP target s = true) : Nonplanar.mk s = target.val := of_decide_eq_true h
 
-theorem SyntacticObject.mk_tracePlanar (s : SyntacticObject) :
-    Nonplanar.mk s.tracePlanar = s.trace.val := by
-  unfold tracePlanar trace; cases s.selHead <;> rfl
+private theorem not_projEqP {target : SyntacticObject} {s : RoseTree Vertex}
+    (h : ¬ projEqP target s = true) : Nonplanar.mk s ≠ target.val := by
+  rw [projEqP, decide_eq_true_eq] at h; exact h
 
-theorem SyntacticObject.isSyntacticObject_tracePlanar (s : SyntacticObject) :
-    Planar.isSyntacticObject s.tracePlanar = true := by
-  unfold tracePlanar; cases s.selHead <;> rfl
-
-/-- Internal Merge on the ordered accumulator: raise the leftmost subtree projecting to
-    `mover` to the LEFT edge, leaving the trace of its head. `none` if absent. -/
-def moveLeftPlanarP (acc : Planar) (mover : SyntacticObject) :
-    Option (Planar) :=
-  (planarFindP? (projEqP mover) acc).map fun s =>
-    Planar.merge s (planarReplaceWhereP (projEqP mover) mover.tracePlanar acc)
-
-/-- One externalization step on the ordered accumulator (mirrors `SyntacticObject.Step.apply`). -/
-def externStepP (acc? : Option (Planar)) (step : Step) :
-    Option (Planar) :=
-  acc?.bind fun acc => match step with
-    | .emL item  => item.toPlanarLeaf?.map (fun p => Planar.merge p acc)
-    | .emR item  => item.toPlanarLeaf?.map (fun p => Planar.merge acc p)
-    | .im mover  => moveLeftPlanarP acc mover
-
-namespace SyntacticObject.Derivation
-
-/-- The derivation's ordered planar representative (MCB `σ_L` for this derivation),
-    or `none` if a merged item is complex / a mover is missing. -/
-def externalizeP? (d : Derivation) : Option (Planar) :=
-  d.initial.toPlanarLeaf?.bind fun init => d.steps.foldl externStepP (some init)
-
-/-- Surface (pronounced) tokens, left-to-right; traces dropped. Empty if
-    externalization fails. -/
-def surfaceTokens (d : Derivation) : List LIToken :=
-  (d.externalizeP?.map planarYield).getD []
-
-/-- Surface category sequence — the readout used by word-order studies. -/
-def surfaceCats (d : Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
-
-/-- Surface phonological string: pronounced forms left-to-right (empty forms dropped). -/
-def surfacePhon (d : Derivation) : List String :=
-  d.surfaceTokens.filterMap LIToken.phonForm?
-
-end SyntacticObject.Derivation
-
-/-! ### Π-bridge faithfulness: `Nonplanar.mk externalizeP? = final`
-
-[marcolli-chomsky-berwick-2025] §1.12. The externalization replay (`externStepP` on an
-ordered `Planar` accumulator) is *faithful* to the abstract derived object: each
-planar op's `Nonplanar.mk` equals the corresponding noncomputable `SyntacticObject` op, so whenever
-the replay succeeds its nonplanar projection is exactly `final`. This upgrades
-`surfaceCats`/`surfacePhon` from "validated by `decide` demos" to "provably the word
-order of the actual derived SyntacticObject" — the guarantee the word-order studies (Cinque2005,
-ColeHermon2008, Chomsky1995, …) rely on. -/
-
-/-- `Planar.isSyntacticObject` of a bare binary node is the conjunction of the children's. -/
-private theorem Planar.isSyntacticObject_nodeP {a b : Planar}
-    (ha : Planar.isSyntacticObject a = true) (hb : Planar.isSyntacticObject b = true) :
-    Planar.isSyntacticObject (Planar.merge a b) = true := by
-  simp only [Planar.isSyntacticObject, Planar.isSyntacticObjectList, ha, hb, List.length_cons,
-    List.length_nil,
-    Nat.reduceAdd, Nat.reduceBEq, Bool.or_true, Bool.and_self]
-
-/-- `Nonplanar.mk` of the planar binary builder is the bare binary nonplanar node. -/
-private theorem mk_nodeP (a b : Planar) :
-    Nonplanar.mk (Planar.merge a b) = Nonplanar.node (Sum.inr none) {Nonplanar.mk a,
-      Nonplanar.mk b} := by
-  rw [show ({Nonplanar.mk a, Nonplanar.mk b} : Multiset (Nonplanar Vertex))
-        = Multiset.ofList ([a, b].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
-
-/-- A bare binary node (two children) is never the trace leaf (no children). -/
-private theorem SyntacticObject.node_ne_traceLeaf (l r : SyntacticObject) :
-    node l r ≠ traceLeaf := by
-  intro heq
-  have ha : (node l r).val.rootChildren = traceLeaf.val.rootChildren := by rw [heq]
-  rw [node_val, Nonplanar.rootChildren_node] at ha
-  simp only [traceLeaf, Nonplanar.leaf_def, Nonplanar.rootChildren_mk,
-    RoseTree.children, Multiset.insert_eq_cons] at ha
-  exact Multiset.cons_ne_zero ha
-
-/-- **Lemma 1.** A successful `toPlanarLeaf?` projects (under `Nonplanar.mk`) back to the
-    `SyntacticObject` it came from, and is a well-formed planar leaf. -/
-private theorem toPlanarLeaf?_mk {s : SyntacticObject} {ip : Planar}
-    (h : s.toPlanarLeaf? = some ip) :
-    Nonplanar.mk ip = s.val ∧ Planar.isSyntacticObject ip = true := by
-  induction s using ind with
-  | lex tok =>
-    rw [toPlanarLeaf?, getLIToken_lexLeaf] at h
-    obtain rfl : ip = Planar.leaf tok := by simpa using h.symm
-    exact ⟨rfl, rfl⟩
-  | trace =>
-    rw [toPlanarLeaf?, getLIToken_traceLeaf, if_pos rfl] at h
-    obtain rfl : ip = Planar.trace := by simpa using h.symm
-    exact ⟨rfl, rfl⟩
-  | traceOf tok =>
-    rw [toPlanarLeaf?, getLIToken_traceOf, if_neg (traceOf_ne_traceLeaf tok)] at h
-    exact absurd h (by simp)
-  | node l r _ _ =>
-    rw [toPlanarLeaf?, getLIToken_node,
-        if_neg (node_ne_traceLeaf l r)] at h
-    exact absurd h (by simp)
-
-/-- **Lemma 2.** `projEqP target s` certifies that `s` projects to `target`. -/
-private theorem projEqP_eq {target : SyntacticObject} {s : Planar}
-    (h : projEqP target s = true) :
-    Nonplanar.mk s = target.val := of_decide_eq_true h
-
-/-- **Lemma 3a.** A subtree raised by `planarFindP?` satisfies the predicate. -/
-private theorem planarFindP?_pred {p : Planar → Bool} {t s : Planar}
+/-- A subtree raised by `planarFindP?` satisfies the predicate. -/
+private theorem planarFindP?_pred {p : RoseTree Vertex → Bool} {t s : RoseTree Vertex}
     (h : planarFindP? p t = some s) : p s = true := by
   fun_induction planarFindP? p t generalizing s with
   | case1 _ hp => obtain rfl := Option.some.inj h; exact hp
@@ -209,20 +96,15 @@ private theorem planarFindP?_pred {p : Planar → Bool} {t s : Planar}
   | case5 _ _ _ _ hp => obtain rfl := Option.some.inj h; exact hp
   | case6 => exact absurd h (by simp)
 
-/-- A bare binary node's children are both well-formed when the node is. -/
-private theorem Planar.isSyntacticObject_pair_children {l r : Planar}
-    (ht : Planar.isSyntacticObject (Planar.merge l r) = true) :
-    Planar.isSyntacticObject l = true ∧ Planar.isSyntacticObject r = true := by
-  rw [Planar.merge, Planar.isSyntacticObject, Planar.isSyntacticObjectList,
-    Planar.isSyntacticObjectList, Planar.isSyntacticObjectList,
-    Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at ht
-  exact ⟨ht.2.1, ht.2.2.1⟩
+/-- The daughters of a well-formed binary node are well-formed. -/
+private theorem wellFormed_pair_children {l r : RoseTree Vertex}
+    (ht : wellFormed (.node (Sum.inr none) [l, r]) = true) :
+    wellFormed l = true ∧ wellFormed r = true := by
+  rwa [wellFormed_merge, Bool.and_eq_true] at ht
 
-/-- **Lemma 3b.** A subtree raised by `planarFindP?` from a well-formed tree is itself
-    well-formed. -/
-private theorem planarFindP?_isSyntacticObject {p : Planar → Bool} {t s : Planar}
-    (h : planarFindP? p t = some s) (ht : Planar.isSyntacticObject t = true)
-      : Planar.isSyntacticObject s = true := by
+/-- A subtree raised by `planarFindP?` from a well-formed tree is well-formed. -/
+private theorem planarFindP?_wellFormed {p : RoseTree Vertex → Bool} {t s : RoseTree Vertex}
+    (h : planarFindP? p t = some s) (ht : wellFormed t = true) : wellFormed s = true := by
   fun_induction planarFindP? p t generalizing s with
   | case1 => obtain rfl := Option.some.inj h; exact ht
   | case2 => exact absurd h (by simp)
@@ -231,46 +113,23 @@ private theorem planarFindP?_isSyntacticObject {p : Planar → Bool} {t s : Plan
     have hcase : a = Sum.inr none := by
       match a with
       | .inr none => rfl
-      | .inl _ | .inr (some _) => simp [Planar.isSyntacticObject] at ht
+      | .inl _ | .inr (some _) => simp [wellFormed] at ht
     subst hcase
-    obtain ⟨hl', hr'⟩ := Planar.isSyntacticObject_pair_children ht
+    obtain ⟨hl', hr'⟩ := wellFormed_pair_children ht
     rcases hlf : planarFindP? p l with _ | sl
     · rw [hlf, Option.none_or] at h; exact ihr h hr'
     · rw [hlf, Option.some_or] at h; obtain rfl := Option.some.inj h; exact ihl hlf hl'
   | case5 => obtain rfl := Option.some.inj h; exact ht
   | case6 => exact absurd h (by simp)
 
-/-- Under `Planar.isSyntacticObject`, a node has either no children or exactly two. -/
-private theorem Planar.isSyntacticObject_length {a : Vertex} {cs : List (Planar)}
-    (ht : Planar.isSyntacticObject (RoseTree.node a cs) = true) : cs.length = 0 ∨ cs.length
-      = 2 := by
-  match a with
-  | .inl _ | .inr (some _) =>
-    rw [Planar.isSyntacticObject] at ht
-    rw [List.isEmpty_iff] at ht
-    exact Or.inl (by rw [ht]; rfl)
-  | .inr none =>
-    rw [Planar.isSyntacticObject, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq, beq_iff_eq] at ht
-    exact ht.1
-
-/-- `projEqP` reflects (in)equality of the nonplanar projection to the target. -/
-private theorem not_projEqP {target : SyntacticObject} {s : Planar}
-    (h : ¬ projEqP target s = true) : Nonplanar.mk s ≠ target.val := by
-  rw [projEqP, decide_eq_true_eq] at h; exact h
-
-/-- **Lemma 4 (CRUX): the replace bridge.** On a well-formed planar tree, the computable
-    planar replacement by a well-formed leaf `rep` projecting to `R` projects under `Nonplanar.mk`
-    to the abstract structural substitution `Nonplanar.replace target R`, and stays well-formed.
-    The two `if`-conditions agree (`projEqP target s = true ↔ Nonplanar.mk s = target.val`), and
-    the recursive bare-binary case lines up with `Nonplanar.replace_node_pair`'s else branch
-    (`{·,·}` multiset built from the two daughters). -/
-private theorem replaceWhereP_mk (target : SyntacticObject) {rep : Planar}
-    {R : SyntacticObject} (hrep : Planar.isSyntacticObject rep = true) (hmkr : Nonplanar.mk rep
-      = R.val)
-    {t : Planar} (ht : Planar.isSyntacticObject t = true) :
+/-- The ordered replacement by a well-formed leaf `rep` projecting to `R` forgets to the
+    structural substitution `Nonplanar.replace target R` and stays well-formed. -/
+private theorem replaceWhereP_mk (target : SyntacticObject) {rep : RoseTree Vertex}
+    {R : SyntacticObject} (hrep : wellFormed rep = true) (hmkr : Nonplanar.mk rep = R.val)
+    {t : RoseTree Vertex} (ht : wellFormed t = true) :
     Nonplanar.mk (planarReplaceWhereP (projEqP target) rep t)
         = Nonplanar.replace target.val R.val (Nonplanar.mk t)
-      ∧ Planar.isSyntacticObject (planarReplaceWhereP (projEqP target) rep t) = true := by
+      ∧ wellFormed (planarReplaceWhereP (projEqP target) rep t) = true := by
   fun_induction planarReplaceWhereP (projEqP target) rep t with
   | case1 _ hp =>
     refine ⟨?_, hrep⟩
@@ -288,131 +147,235 @@ private theorem replaceWhereP_mk (target : SyntacticObject) {rep : Planar}
     have hcase : a = Sum.inr none := by
       match a with
       | .inr none => rfl
-      | .inl _ | .inr (some _) => simp [Planar.isSyntacticObject] at ht
+      | .inl _ | .inr (some _) => simp [wellFormed] at ht
     subst hcase
-    obtain ⟨hl', hr'⟩ := Planar.isSyntacticObject_pair_children ht
+    obtain ⟨hl', hr'⟩ := wellFormed_pair_children ht
     obtain ⟨ihle, ihls⟩ := ihl hl'
     obtain ⟨ihre, ihrs⟩ := ihr hr'
-    refine ⟨?_, Planar.isSyntacticObject_nodeP ihls ihrs⟩
+    refine ⟨?_, by rw [wellFormed_merge, ihls, ihrs]; rfl⟩
     have hne : Nonplanar.node (Sum.inr none) {Nonplanar.mk l, Nonplanar.mk r} ≠ target.val := by
-      rw [← mk_nodeP]; exact not_projEqP hp
-    rw [show RoseTree.node (Sum.inr none)
-          [planarReplaceWhereP (projEqP target) rep l,
-          planarReplaceWhereP (projEqP target) rep r]
-        = Planar.merge (planarReplaceWhereP (projEqP target) rep l)
-          (planarReplaceWhereP (projEqP target) rep r) from rfl,
-      mk_nodeP, ihle, ihre, mk_nodeP, Nonplanar.replace_node_pair, if_neg hne]
+      rw [← merge_mk_raw]; exact not_projEqP hp
+    rw [merge_mk_raw, ihle, ihre, merge_mk_raw, Nonplanar.replace_node_pair, if_neg hne]
   | case5 _ cs hnil hpair _ =>
-    rcases Planar.isSyntacticObject_length ht with hlen | hlen
+    rcases wellFormed_length ht with hlen | hlen
     · exact absurd (List.length_eq_zero_iff.mp hlen) hnil
     · obtain ⟨x, y, rfl⟩ := List.length_eq_two.mp hlen; exact absurd rfl (hpair x y)
   | case6 _ cs hnil hpair _ =>
-    rcases Planar.isSyntacticObject_length ht with hlen | hlen
+    rcases wellFormed_length ht with hlen | hlen
     · exact absurd (List.length_eq_zero_iff.mp hlen) hnil
     · obtain ⟨x, y, rfl⟩ := List.length_eq_two.mp hlen; exact absurd rfl (hpair x y)
+where
+  /-- `Nonplanar.mk` of the ordered binary node is the unordered binary node. -/
+  merge_mk_raw (a b : RoseTree Vertex) :
+      Nonplanar.mk (RoseTree.node (Sum.inr none) [a, b])
+        = Nonplanar.node (Sum.inr none) {Nonplanar.mk a, Nonplanar.mk b} := by
+    rw [show ({Nonplanar.mk a, Nonplanar.mk b} : Multiset (Nonplanar Vertex))
+          = Multiset.ofList ([a, b].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
 
-/-- **Lemma 6: per-step faithfulness.** A successful replay step on a well-formed
-    accumulator stays well-formed and projects to the abstract `SyntacticObject.Step.apply`. -/
-private theorem externStepP_step {acc : SyntacticObject} {accp p' : Planar}
-    {step : Step}
-    (h : externStepP (some accp) step = some p') (hwf : Planar.isSyntacticObject accp = true)
-    (hmk : Nonplanar.mk accp = acc.val) :
-    Planar.isSyntacticObject p' = true ∧ Nonplanar.mk p' = (step.apply acc).val := by
+/-! ### The replay on ordered objects -/
+
+namespace PlanarSyntacticObject
+
+/-- The leftmost subtree projecting to `target`. -/
+def find? (target : SyntacticObject) (acc : PlanarSyntacticObject) :
+    Option PlanarSyntacticObject :=
+  (planarFindP? (projEqP target) acc.val).bind fun s =>
+    if h : wellFormed s = true then some ⟨s, h⟩ else none
+
+/-- Every subtree projecting to `target` replaced by the leaf `rep`. -/
+def replaceWhere (target : SyntacticObject) (rep acc : PlanarSyntacticObject) :
+    PlanarSyntacticObject :=
+  ⟨planarReplaceWhereP (projEqP target) rep.val acc.val,
+    (replaceWhereP_mk target (R := rep.toSyntacticObject) rep.2 rfl acc.2).2⟩
+
+theorem toSyntacticObject_find? {target : SyntacticObject} {acc s : PlanarSyntacticObject}
+    (h : find? target acc = some s) : s.toSyntacticObject = target := by
+  unfold find? at h
+  rcases hf : planarFindP? (projEqP target) acc.val with _ | s'
+  · rw [hf] at h; exact absurd h (by simp)
+  · rw [hf] at h
+    change (if h : wellFormed s' = true then some (⟨s', h⟩ : PlanarSyntacticObject) else none)
+      = some s at h
+    split at h
+    · obtain rfl := Option.some.inj h
+      exact Subtype.ext (projEqP_eq (planarFindP?_pred hf))
+    · exact absurd h (by simp)
+
+/-- Replacement forgets to the structural substitution `SyntacticObject.replace`. -/
+theorem toSyntacticObject_replaceWhere (target : SyntacticObject) (rep acc : PlanarSyntacticObject)
+    :
+    (replaceWhere target rep acc).toSyntacticObject
+      = acc.toSyntacticObject.replace target rep.toSyntacticObject :=
+  Subtype.ext (replaceWhereP_mk target (R := rep.toSyntacticObject) rep.2 rfl acc.2).1
+
+end PlanarSyntacticObject
+
+/-- The ordered trace a moved object leaves, `SyntacticObject.headTrace` with its order. -/
+def SyntacticObject.tracePlanar (s : SyntacticObject) : PlanarSyntacticObject :=
+  s.selHead.elim PlanarSyntacticObject.trace PlanarSyntacticObject.traceOf
+
+@[simp] theorem SyntacticObject.toSyntacticObject_tracePlanar (s : SyntacticObject) :
+    s.tracePlanar.toSyntacticObject = s.headTrace := by
+  unfold tracePlanar headTrace; cases s.selHead <;> rfl
+
+namespace PlanarSyntacticObject
+
+/-- Internal Merge on the ordered accumulator: the leftmost subtree projecting to `mover` is
+    raised to the left edge, leaving the trace of its head; `none` if absent. -/
+def moveLeft (acc : PlanarSyntacticObject) (mover : SyntacticObject) :
+    Option PlanarSyntacticObject :=
+  (find? mover acc).map fun s => merge s (replaceWhere mover mover.tracePlanar acc)
+
+/-- Internal Merge on the ordered accumulator forgets to Internal Merge on the object. -/
+theorem toSyntacticObject_moveLeft {acc p' : PlanarSyntacticObject} {mover : SyntacticObject}
+    (h : moveLeft acc mover = some p') :
+    p'.toSyntacticObject = SyntacticObject.merge
+      (deleteAccessible mover acc.toSyntacticObject) mover := by
+  unfold moveLeft at h
+  rcases hf : find? mover acc with _ | s
+  · rw [hf, Option.map_none] at h; exact absurd h (by simp)
+  · rw [hf, Option.map_some] at h
+    obtain rfl := Option.some.inj h
+    rw [toSyntacticObject_merge, toSyntacticObject_find? hf, toSyntacticObject_replaceWhere,
+      toSyntacticObject_tracePlanar, SyntacticObject.merge_comm]
+    rfl
+
+end PlanarSyntacticObject
+
+/-- One replay step, mirroring `SyntacticObject.Step.apply`. -/
+def externStep (acc? : Option PlanarSyntacticObject) (step : Step) :
+    Option PlanarSyntacticObject :=
+  acc?.bind fun acc => match step with
+    | .emL item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc)
+    | .emR item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·)
+    | .im mover => acc.moveLeft mover
+
+namespace SyntacticObject.Derivation
+
+/-- The derivation's ordered object, MCB's `σ_L` for this derivation, or `none` if a merged
+    item is complex or a mover is absent. -/
+def externalize? (d : Derivation) : Option PlanarSyntacticObject :=
+  d.initial.toPlanarLeaf?.bind fun init => d.steps.foldl externStep (some init)
+
+/-- The pronounced tokens, left to right; empty if externalization fails. -/
+def surfaceTokens (d : Derivation) : List LIToken :=
+  (d.externalize?.map (planarYield ·.val)).getD []
+
+/-- The surface category sequence, the readout of word-order studies. -/
+def surfaceCats (d : Derivation) : List Cat := d.surfaceTokens.map (·.item.outerCat)
+
+/-- The surface string: pronounced forms left to right, empty forms dropped. -/
+def surfacePhon (d : Derivation) : List String :=
+  d.surfaceTokens.filterMap LIToken.phonForm?
+
+end SyntacticObject.Derivation
+
+/-! ### Faithfulness -/
+
+private theorem SyntacticObject.merge_ne_trace (l r : SyntacticObject) : merge l r ≠ trace := by
+  intro heq
+  have ha : (merge l r).val.rootChildren = trace.val.rootChildren := by rw [heq]
+  rw [merge_val, Nonplanar.rootChildren_node] at ha
+  simp only [trace, Nonplanar.leaf_def, Nonplanar.rootChildren_mk,
+    RoseTree.children, Multiset.insert_eq_cons] at ha
+  exact Multiset.cons_ne_zero ha
+
+/-- A successful `toPlanarLeaf?` forgets to the object it came from. -/
+private theorem toPlanarLeaf?_toSyntacticObject {s : SyntacticObject} {ip : PlanarSyntacticObject}
+    (h : s.toPlanarLeaf? = some ip) : ip.toSyntacticObject = s := by
+  induction s using ind with
+  | leaf tok =>
+    rw [toPlanarLeaf?, getLIToken_leaf] at h
+    obtain rfl : ip = PlanarSyntacticObject.leaf tok := by simpa using h.symm
+    rfl
+  | trace =>
+    rw [toPlanarLeaf?, getLIToken_trace, if_pos rfl] at h
+    obtain rfl : ip = PlanarSyntacticObject.trace := by simpa using h.symm
+    rfl
+  | traceOf tok =>
+    rw [toPlanarLeaf?, getLIToken_traceOf, if_neg (traceOf_ne_trace tok)] at h
+    exact absurd h (by simp)
+  | merge l r _ _ =>
+    rw [toPlanarLeaf?, getLIToken_merge, if_neg (merge_ne_trace l r)] at h
+    exact absurd h (by simp)
+
+/-- A successful replay step forgets to `Step.apply`. -/
+private theorem externStep_toSyntacticObject {acc p' : PlanarSyntacticObject} {step : Step}
+    (h : externStep (some acc) step = some p') :
+    p'.toSyntacticObject = step.apply acc.toSyntacticObject := by
   cases step with
   | emL item =>
-    change item.toPlanarLeaf?.map (fun p => Planar.merge p accp) = some p' at h
+    change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
-      obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
-      refine ⟨Planar.isSyntacticObject_nodeP hwfip hwf, ?_⟩
-      rw [Step.apply, node_val, mk_nodeP, hmkip, hmk]
+      rw [Step.apply, PlanarSyntacticObject.toSyntacticObject_merge,
+        toPlanarLeaf?_toSyntacticObject hip]
   | emR item =>
-    change item.toPlanarLeaf?.map (fun p => Planar.merge accp p) = some p' at h
+    change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·) = some p' at h
     rcases hip : item.toPlanarLeaf? with _ | ip
     · rw [hip, Option.map_none] at h; exact absurd h (by simp)
     · rw [hip, Option.map_some] at h
       obtain rfl := Option.some.inj h
-      obtain ⟨hmkip, hwfip⟩ := toPlanarLeaf?_mk hip
-      refine ⟨Planar.isSyntacticObject_nodeP hwf hwfip, ?_⟩
-      rw [Step.apply, node_val, mk_nodeP, hmkip, hmk]
+      rw [Step.apply, PlanarSyntacticObject.toSyntacticObject_merge,
+        toPlanarLeaf?_toSyntacticObject hip]
   | im mover =>
-    change moveLeftPlanarP accp mover = some p' at h
-    rw [moveLeftPlanarP] at h
-    rcases hfind : planarFindP? (projEqP mover) accp with _ | s
-    · rw [hfind, Option.map_none] at h; exact absurd h (by simp)
-    · rw [hfind, Option.map_some] at h
-      obtain rfl := Option.some.inj h
-      have hmks : Nonplanar.mk s = mover.val := projEqP_eq (planarFindP?_pred hfind)
-      have hwfs : Planar.isSyntacticObject s = true := planarFindP?_isSyntacticObject hfind hwf
-      obtain ⟨hrwe, hrws⟩ :=
-        replaceWhereP_mk mover mover.isSyntacticObject_tracePlanar mover.mk_tracePlanar hwf
-      refine ⟨Planar.isSyntacticObject_nodeP hwfs hrws, ?_⟩
-      rw [Step.apply, node_val,
-          deleteAccessible_val, mk_nodeP, hmks, hrwe, hmk]
-      exact congrArg (Nonplanar.node (Sum.inr none)) (Multiset.cons_swap _ _ _)
+    change acc.moveLeft mover = some p' at h
+    rw [Step.apply]; exact PlanarSyntacticObject.toSyntacticObject_moveLeft h
 
-/-- `none` is absorbing for the replay fold: once externalization fails, it stays failed. -/
-private theorem foldl_externStepP_none (steps : List Step) :
-    steps.foldl externStepP none = none := by
+/-- `none` is absorbing for the replay fold. -/
+private theorem foldl_externStep_none (steps : List Step) :
+    steps.foldl externStep none = none := by
   induction steps with
   | nil => rfl
-  | cons st rest ih => rw [List.foldl_cons, show externStepP none st = none from rfl]; exact ih
+  | cons st rest ih => rw [List.foldl_cons, show externStep none st = none from rfl]; exact ih
 
-/-- **Lemma 7: foldl faithfulness.** A successful replay fold from a well-formed,
-    faithful accumulator projects to the abstract `final`-style fold of
-    `SyntacticObject.Step.apply`. -/
-private theorem foldl_externStepP_mk :
-    ∀ (steps : List Step) {acc : SyntacticObject} {accp p : Planar},
-    steps.foldl externStepP (some accp) = some p → Planar.isSyntacticObject accp = true →
-    Nonplanar.mk accp = acc.val →
-    Nonplanar.mk p = (steps.foldl (fun so st => st.apply so) acc).val
-  | [], acc, accp, p, h, _, hmk => by
-      rw [List.foldl_nil] at h ⊢; obtain rfl := Option.some.inj h; exact hmk
-  | st :: rest, acc, accp, p, h, hwf, hmk => by
+/-- A successful replay fold forgets to the fold of `Step.apply`. -/
+private theorem foldl_externStep_toSyntacticObject :
+    ∀ (steps : List Step) {acc p : PlanarSyntacticObject},
+    steps.foldl externStep (some acc) = some p →
+    p.toSyntacticObject = steps.foldl (fun so st => st.apply so) acc.toSyntacticObject
+  | [], acc, p, h => by
+      rw [List.foldl_nil] at h ⊢; obtain rfl := Option.some.inj h; rfl
+  | st :: rest, acc, p, h => by
       rw [List.foldl_cons] at h ⊢
-      rcases hstep : externStepP (some accp) st with _ | accp'
-      · rw [hstep, foldl_externStepP_none] at h; exact absurd h (by simp)
-      · obtain ⟨hwf', hmk'⟩ := externStepP_step hstep hwf hmk
-        rw [hstep] at h
-        exact foldl_externStepP_mk rest h hwf' hmk'
+      rcases hstep : externStep (some acc) st with _ | acc'
+      · rw [hstep, foldl_externStep_none] at h; exact absurd h (by simp)
+      · rw [hstep] at h
+        rw [foldl_externStep_toSyntacticObject rest h, externStep_toSyntacticObject hstep]
 
-/-- **Π-bridge faithfulness** ([marcolli-chomsky-berwick-2025] §1.12): whenever the
-    computable externalization replay `externalizeP?` succeeds, its nonplanar projection
-    is exactly the abstract derived object `final`. So the surface readouts
-    (`surfaceTokens`/`surfaceCats`/`surfacePhon`) are provably the word order of the *actual*
-    derived syntactic object — the guarantee the word-order studies depend on. The replay
-    is partial by design (EM of a complex item / a missing mover ⇒ `none`, making the claim
-    vacuous there); on the canonical leaf/trace derivations the studies build, it succeeds. -/
-theorem SyntacticObject.Derivation.externalizeP?_faithful (d : Derivation)
-    {p : Planar} (h : d.externalizeP? = some p) : Nonplanar.mk p = d.final.val := by
-  rw [Derivation.externalizeP?] at h
+/-- **Faithfulness** ([marcolli-chomsky-berwick-2025] §1.12): a successful replay forgets to the
+    derived object, so the surface readouts are the word order of `final` itself. -/
+theorem SyntacticObject.Derivation.externalize?_faithful (d : Derivation)
+    {p : PlanarSyntacticObject} (h : d.externalize? = some p) : p.toSyntacticObject = d.final := by
+  rw [Derivation.externalize?] at h
   rcases hinit : d.initial.toPlanarLeaf? with _ | init
   · rw [hinit] at h; exact absurd h (by simp [Option.bind])
   · rw [hinit] at h
-    change d.steps.foldl externStepP (some init) = some p at h
-    obtain ⟨hmkinit, hwfinit⟩ := toPlanarLeaf?_mk hinit
-    exact foldl_externStepP_mk d.steps h hwfinit hmkinit
+    change d.steps.foldl externStep (some init) = some p at h
+    rw [foldl_externStep_toSyntacticObject d.steps h, toPlanarLeaf?_toSyntacticObject hinit]
+    rfl
 
-/-! ### Verification: the [cinque-2005] pied-piping contrast
+/-! ### The [cinque-2005] pied-piping contrast
 
-Phrasal pied-piping preserves the moved constituent's internal order, so deriving
-Dem-N-A-Num (raise N around A, then pied-pipe `[N A]` around Num) is distinct from
-Dem-A-N-Num (pied-pipe `[A N]` around Num). Movers are built with the computable DSL so
-the surface orders `decide`. (`.D` stands in for the demonstrative.) -/
+Phrasal pied-piping preserves the moved constituent's internal order: raising N around A and
+pied-piping `[N A]` around Num gives Dem-N-A-Num, pied-piping `[A N]` around Num gives
+Dem-A-N-Num. `.D` stands in for the demonstrative. -/
 
 private def xN : SyntacticObject := mkLeaf .N [] 1
 private def xA : SyntacticObject := mkLeaf .A [] 2
 private def xNum : SyntacticObject := mkLeaf .Num [] 3
 private def xD : SyntacticObject := mkLeaf .D [] 4
-/-- The pied-piped `[N [A t]]` mover (built planar-first, so it is computable). -/
+/-- The pied-piped `[N [A t]]` mover. -/
 private def xNAt : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf ⟨.simple .N [], 1⟩)
-    (Planar.merge (Planar.leaf ⟨.simple .A [], 2⟩) (Planar.traceOf ⟨.simple .N [], 1⟩)))
+  (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf ⟨.simple .N [], 1⟩)
+    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf ⟨.simple .A [], 2⟩)
+      (PlanarSyntacticObject.traceOf ⟨.simple .N [], 1⟩))).toSyntacticObject
 /-- The pied-piped `[A N]` mover. -/
 private def xAN : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf ⟨.simple .A [], 2⟩) (Planar.leaf ⟨.simple .N [], 1⟩))
+  (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf ⟨.simple .A [], 2⟩)
+    (PlanarSyntacticObject.leaf ⟨.simple .N [], 1⟩)).toSyntacticObject
 
 /-- No movement: `Dem Num A N`. -/
 private def xDerivBase : Derivation := ⟨xN, [.emL xA, .emL xNum, .emL xD]⟩
@@ -424,8 +387,6 @@ private def xDerivN : Derivation := ⟨xN, [.emL xA, .emL xNum, .im xAN, .emL xD
 example : xDerivBase.surfaceCats = [.D, .Num, .A, .N] := by decide
 example : xDerivO.surfaceCats = [.D, .N, .A, .Num] := by decide
 example : xDerivN.surfaceCats = [.D, .A, .N, .Num] := by decide
-/-- Pied-piping preserves internal order: `o` and `n` diverge. -/
 example : xDerivO.surfaceCats ≠ xDerivN.surfaceCats := by decide
-
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
+++ b/Linglib/Syntax/Minimalist/Merge/SyntacticObject.lean
@@ -9,7 +9,7 @@ import Linglib.Syntax.Minimalist.Workspace.Basic
 /-!
 # Merge on the syntactic-object carrier
 
-Merge on the carrier is the bare binary node `SyntacticObject.node` with root label
+Merge on the carrier is the bare binary node `SyntacticObject.merge` with root label
 `Sum.inr none`. This file identifies it with the algebraic Merge operator of `Merge/Basic.lean` on
 workspaces lifted along `of'`: External Merge of two objects is `mergeOp_pair`, and Internal
 Merge of a mover with its remainder is the two-stage composition `mergeOp_im_composition`, given
@@ -35,12 +35,12 @@ open RoseTree RoseTree.Nonplanar ConnesKreimer
 theorem mergeOp_node (S S' : SyntacticObject) :
     Merge.mergeOp (R := ℤ) (Sum.inr none) S.val S'.val
         (of' ({S.val, S'.val} : Forest (Nonplanar Vertex)))
-      = of' (R := ℤ) ({(node S S').val} : Forest (Nonplanar Vertex)) := by
-  rw [Merge.mergeOp_pair, node_val]
+      = of' (R := ℤ) ({(merge S S').val} : Forest (Nonplanar Vertex)) := by
+  rw [Merge.mergeOp_pair, merge_val]
 
 /-- Internal Merge on the carrier is the two-stage algebraic Merge, given the unique Δ^ρ cut `p0`
     of `T` extracting `mover` with remainder `remainder`. -/
-theorem mergeOp_node_im (mover remainder T : SyntacticObject)
+theorem mergeOp_merge_im (mover remainder T : SyntacticObject)
     (p0 : Forest (Nonplanar Vertex) × Nonplanar Vertex)
     (h_filter : (cutSummandsN T.val).filter
         (fun p => p.1 = ({mover.val} : Forest (Nonplanar Vertex))) = {p0})
@@ -50,8 +50,8 @@ theorem mergeOp_node_im (mover remainder T : SyntacticObject)
         (Merge.mergeOpUnit (R := ℤ) mover.val
           (of' ({T.val} : Forest (Nonplanar Vertex))))
       = of' (R := ℤ)
-          ({(node remainder mover).val} : Forest (Nonplanar Vertex)) := by
+          ({(merge remainder mover).val} : Forest (Nonplanar Vertex)) := by
   rw [Merge.mergeOp_im_composition (Sum.inr none) mover.val T.val remainder.val
-        p0 h_filter h_remainder hT, node_val]
+        p0 h_filter h_remainder hT, merge_val]
 
 end Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/Phase/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Basic.lean
@@ -160,7 +160,7 @@ variable {P : Type*}
 /-- A trigger applies to a phase iff its `selector` matches the phase head (the head
 leaf `ph.head`, as a leaf SyntacticObject). -/
 def Trigger.appliesTo (tr : Trigger P) (ph : Phase) : Bool :=
-  tr.selector (lexLeaf ph.head)
+  tr.selector (SyntacticObject.leaf ph.head)
 
 /-- The *first* registered trigger whose `selector` matches the phase head —
 first-match encodes lexicographic precedence (the elsewhere ordering of

--- a/Linglib/Syntax/Minimalist/Phase/Domain.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Domain.lean
@@ -29,7 +29,7 @@ decidable P2 substrate (`subtrees`/`Acc`/`containsOrEq`/`areSistersIn`/`cCommand
 
 The keystone identity: the **interior Φ°_ℓ (Def 1.14.3) is the phase head's
 c-command domain**, `{T_v ∈ Acc(T) | T_v ⊆ T_{s_ℓ}} = Acc.filter (cCommandsIn …
-(lexLeaf ℓ))` — the standard "complement domain = head's c-command domain" falling
+(leaf ℓ))` — the standard "complement domain = head's c-command domain" falling
 out of the formalization.
 -/
 
@@ -49,9 +49,9 @@ namespace SyntacticObject
     `isPhaseHeadOf .D` ([citko-2014]); SA — `isPhaseHeadOf .SA`. -/
 def isPhaseHeadOf (c : Cat) (s : SyntacticObject) : Bool := s.outerCatC == some c
 
-@[simp] theorem isPhaseHeadOf_lexLeaf (c : Cat) (tok : LIToken) :
-    isPhaseHeadOf c (lexLeaf tok) = (tok.item.outerCat == c) := by
-  rw [isPhaseHeadOf, outerCatC_lexLeaf]; rfl
+@[simp] theorem isPhaseHeadOf_leaf (c : Cat) (tok : LIToken) :
+    isPhaseHeadOf c (SyntacticObject.leaf tok) = (tok.item.outerCat == c) := by
+  rw [isPhaseHeadOf, outerCatC_leaf]; rfl
 
 /-! ### The phase domain (MCB Def 1.14.2–1.14.3)
 
@@ -63,10 +63,10 @@ subterm API (`subtrees`/`Acc`/`containsOrEq`/`areSistersIn`/`cCommandsIn`), so i
 
 /-- **L_Φ(T)** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.1): `ℓ` is a
     **phase head** in `T` when its projection path γ_ℓ is nontrivial — the leaf
-    `lexLeaf ℓ` has a mother whose head is still `ℓ` (so γ_ℓ reaches an internal
+    `leaf ℓ` has a mother whose head is still `ℓ` (so γ_ℓ reaches an internal
     vertex). Read off `selHead` at the mother; section-free. -/
 def isPhaseHead (T : SyntacticObject) (ℓ : LIToken) : Prop :=
-  ∃ n ∈ T.subtrees, immediatelyContains n (lexLeaf ℓ) ∧ n.selHead = some ℓ
+  ∃ n ∈ T.subtrees, immediatelyContains n (SyntacticObject.leaf ℓ) ∧ n.selHead = some ℓ
 
 instance (T : SyntacticObject) (ℓ : LIToken) : Decidable (isPhaseHead T ℓ) :=
   Multiset.decidableExistsMultiset
@@ -94,11 +94,11 @@ def phase (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
     accessible terms; the part the PIC freezes ("Z is the interior of the phase").
 
     This **is the phase head's c-command domain**: `T_v ⊆ T_{s_ℓ}` exactly when the
-    sister of `ℓ` contains-or-equals `T_v`, i.e. `cCommandsIn T (lexLeaf ℓ) T_v`
+    sister of `ℓ` contains-or-equals `T_v`, i.e. `cCommandsIn T (leaf ℓ) T_v`
     (#798). The textbook "complement domain = head's c-command domain", by
     construction — and `Acc(T) = T.Acc` (non-root). -/
 def phaseInterior (T : SyntacticObject) (ℓ : LIToken) : Multiset SyntacticObject :=
-  T.Acc.filter (fun Tv => cCommandsIn T (lexLeaf ℓ) Tv)
+  T.Acc.filter (fun Tv => cCommandsIn T (SyntacticObject.leaf ℓ) Tv)
 
 /-- **The edge ∂Φ_ℓ** ([marcolli-chomsky-berwick-2025] Def 1.14.3 eq 1.14.4):
     `{T_v ∈ Acc'(T) | T_v ⊆ T_{v_ℓ} ∧ T_v ⊄ T_{s_ℓ}}` — the phase content not in
@@ -126,7 +126,7 @@ instance (T : SyntacticObject) (ℓ : LIToken) (goal : SyntacticObject) :
 /-- **The interior is the phase head's (non-root) c-command domain** — the keystone
     identity (MCB Def 1.14.3, "Z is the interior of the phase"). -/
 @[simp] theorem mem_phaseInterior {T : SyntacticObject} {ℓ : LIToken} {Tv : SyntacticObject} :
-    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (lexLeaf ℓ) Tv :=
+    Tv ∈ T.phaseInterior ℓ ↔ Tv ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.leaf ℓ) Tv :=
   Multiset.mem_filter
 
 @[simp] theorem mem_phaseEdge {T : SyntacticObject} {ℓ : LIToken} {Tv : SyntacticObject} :
@@ -135,7 +135,7 @@ instance (T : SyntacticObject) (ℓ : LIToken) (goal : SyntacticObject) :
 
 /-- The PIC freezes exactly the head's (non-root) c-command domain. -/
 theorem Impenetrable_iff {T : SyntacticObject} {ℓ : LIToken} {goal : SyntacticObject} :
-    Impenetrable T ℓ goal ↔ goal ∈ T.Acc ∧ T.cCommandsIn (lexLeaf ℓ) goal :=
+    Impenetrable T ℓ goal ↔ goal ∈ T.Acc ∧ T.cCommandsIn (SyntacticObject.leaf ℓ) goal :=
   mem_phaseInterior
 
 end SyntacticObject
@@ -147,9 +147,10 @@ left head c-selects the right: the selector projects, regardless of which side i
 sits on (the carrier is unordered) — so the phase head is the selector. -/
 
 /-- A two-leaf bare node over the given tokens (built planar-first via the DSL;
-    `SyntacticObject.node` is noncomputable). -/
+    `SyntacticObject.merge` is noncomputable). -/
 private def clause (head comp : LIToken) : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf head) (Planar.leaf comp))
+  (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf head)
+    (PlanarSyntacticObject.leaf comp)).toSyntacticObject
 
 /-- A C selecting a T projects C: the node is a **C-phase**, not a v-phase. -/
 example :
@@ -180,18 +181,19 @@ private def tTok : LIToken := ⟨.simple .T [.V], 1⟩
 private def vTok : LIToken := ⟨.simple .V [], 2⟩
 
 private def cP : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf cTok) (Planar.merge (Planar.leaf tTok) (Planar.leaf vTok)))
+  (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf cTok) (PlanarSyntacticObject.merge
+    (PlanarSyntacticObject.leaf tTok) (PlanarSyntacticObject.leaf vTok))).toSyntacticObject
 
 /-- C heads a nontrivial phase (it projects over the TP). -/
 example : isPhaseHead cP cTok := by decide
 
 /-- The embedded `V` is in C's complement domain — **frozen** by the PIC. -/
-example : Impenetrable cP cTok (lexLeaf vTok) := by decide
+example : Impenetrable cP cTok (SyntacticObject.leaf vTok) := by decide
 
 /-- The phase head `C` is at the **edge** — *not* frozen (it can still probe out). -/
-example : ¬ Impenetrable cP cTok (lexLeaf cTok) := by decide
+example : ¬ Impenetrable cP cTok (SyntacticObject.leaf cTok) := by decide
 
 /-- …and `C` sits in the edge, not the interior. -/
-example : lexLeaf cTok ∈ cP.phaseEdge cTok := by decide
+example : SyntacticObject.leaf cTok ∈ cP.phaseEdge cTok := by decide
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
@@ -10,32 +10,35 @@ import Linglib.Syntax.Minimalist.Defs
 /-!
 # Syntactic objects
 
-A syntactic object is a binary, nonplanar, rooted tree with leaves labelled by the lexical
-alphabet and no labels at internal vertices: the elements of the free non-associative commutative
-magma on `SO₀`. This file builds that carrier as the well-formed subset of
-`Nonplanar (LIToken ⊕ Option LIToken)`, the same nonplanar trees the Merge algebra is defined
-on. The label `Sum.inr none` is the bare marker, its two occurrences told apart by arity: a
-childless bare vertex is an index-free trace leaf, a binary bare vertex an internal node. The
-label `Sum.inr (some tok)` on a leaf is the trace of `tok`, the cancellation `T/T_v` remembering
-the head of `T_v`, which is what chains and their PF reduction read off a single object. The head
-of a node is supplied by a head function, not stored on the tree.
+A syntactic object is a binary rooted tree with leaves labelled by the lexical alphabet and no
+labels at internal vertices: an element of the free non-associative commutative magma on `SO₀`.
+This file builds two carriers for it over one alphabet `Vertex := LIToken ⊕ Option LIToken`, in
+which `Sum.inl tok` is a lexical item, `Sum.inr none` the bare marker, an internal node when
+binary and the index-free trace when childless, and `Sum.inr (some tok)` on a leaf the trace of
+`tok`, the cancellation `T/T_v` remembering the head of `T_v`. `SyntacticObject` is the
+well-formed unordered tree over `Vertex`, the object Merge builds, and `PlanarSyntacticObject` the
+well-formed ordered tree, [marcolli-chomsky-berwick-2025]'s planar embedding, the form
+linearization and PF read. Well-formedness is stated once, on ordered trees, and descends to the
+quotient; `PlanarSyntacticObject.toSyntacticObject` forgets the order and is a homomorphism for
+the vocabulary the two carriers share, `leaf`, `trace`, `traceOf` and `merge`.
 
 ## Main definitions
 
-* `Minimalist.SyntacticObject.Vertex`, `Minimalist.IsSyntacticObject`, `Minimalist.SyntacticObject`
-* `Minimalist.SyntacticObject.lexLeaf`, `traceLeaf`, `node`: the three shapes.
+* `Minimalist.SyntacticObject.Vertex`, `Minimalist.IsSyntacticObject`
+* `Minimalist.SyntacticObject`, `Minimalist.PlanarSyntacticObject`: the unordered and the ordered
+  carrier, each with `leaf`, `trace`, `traceOf` and `merge`.
+* `Minimalist.PlanarSyntacticObject.toSyntacticObject`: forgetting the order.
 
 ## Main results
 
-* `Minimalist.SyntacticObject.ind`, `exists_form`: induction and case analysis over the three
-  shapes.
-* `Minimalist.SyntacticObject.node_mk`: a node of two planar-built objects is the planar node,
-  so concrete results are `decide`-able.
+* `Minimalist.SyntacticObject.ind`, `exists_form`: induction and case analysis over the shapes.
+* `Minimalist.PlanarSyntacticObject.toSyntacticObject_merge`: forgetting the order commutes with
+  Merge.
 
 ## References
 
-* [marcolli-chomsky-berwick-2025], §1.1 (Definition 1.1.1, §1.1.3) and §1.2 (Definitions 1.2.1,
-  1.2.6)
+* [marcolli-chomsky-berwick-2025], §1.1 (Definition 1.1.1, §1.1.3), §1.2 (Definitions 1.2.1,
+  1.2.6) and §1.12
 -/
 
 namespace Minimalist
@@ -46,175 +49,214 @@ open RoseTree RoseTree.Nonplanar
     leaf or an internal node, the two told apart by arity, or the trace of a token. -/
 abbrev SyntacticObject.Vertex : Type := LIToken ⊕ Option LIToken
 
-/-- The ordered form of a syntactic object: a planar tree of vertices. -/
-abbrev Planar : Type := RoseTree SyntacticObject.Vertex
+namespace SyntacticObject
 
-open SyntacticObject
-
-/-- A lexical leaf. -/
-abbrev Planar.leaf (tok : LIToken) : Planar := .node (Sum.inl tok) []
-
-/-- The bare trace. -/
-abbrev Planar.trace : Planar := .node (Sum.inr none) []
-
-/-- The trace of `tok`. -/
-abbrev Planar.traceOf (tok : LIToken) : Planar := .node (Sum.inr (some tok)) []
-
-/-- The Merge of two planar objects. -/
-abbrev Planar.merge (l r : Planar) : Planar := .node (Sum.inr none) [l, r]
-
-/-! ### Well-formedness `IsSyntacticObject` (binary, lexical/trace leaves, bare internals) -/
+/-! ### Well-formedness -/
 
 mutual
-/-- Well-formedness of a planar tree: a lexical vertex is a leaf, and a bare vertex is either
+/-- Well-formedness of an ordered tree: a lexical or trace vertex is a leaf, and a bare vertex is
     childless or binary with well-formed children. -/
-def Planar.isSyntacticObject : Planar → Bool
-  | .node (.inl _) cs  => cs.isEmpty
+def wellFormed : RoseTree Vertex → Bool
+  | .node (.inl _) cs => cs.isEmpty
   | .node (.inr (some _)) cs => cs.isEmpty
-  | .node (.inr none) cs => (cs.length == 0 || cs.length == 2) && Planar.isSyntacticObjectList cs
+  | .node (.inr none) cs => (cs.length == 0 || cs.length == 2) && wellFormedList cs
 /-- Every tree in the list is well-formed. -/
-def Planar.isSyntacticObjectList : List (Planar) → Bool
-  | []      => true
-  | c :: cs => Planar.isSyntacticObject c && Planar.isSyntacticObjectList cs
+def wellFormedList : List (RoseTree Vertex) → Bool
+  | [] => true
+  | c :: cs => wellFormed c && wellFormedList cs
 end
 
-/-! ### `Planar.isSyntacticObject` is `Perm`-invariant (so it lifts) -/
-
-/-- Congruence for `Planar.isSyntacticObject` at a node whose children agree in length and in
-    `Planar.isSyntacticObjectList`: a lexical label reads only the emptiness (via length), a bare
-    label only the arity check (length) and the recursive `Planar.isSyntacticObjectList`. -/
-private theorem Planar.isSyntacticObject_node_congr {a : Vertex} {cs ds : List (Planar)}
-    (hlen : cs.length = ds.length) (hlist : Planar.isSyntacticObjectList cs
-      = Planar.isSyntacticObjectList ds) :
-    Planar.isSyntacticObject (.node a cs) = Planar.isSyntacticObject (.node a ds) := by
+private theorem wellFormed_node_congr {a : Vertex} {cs ds : List (RoseTree Vertex)}
+    (hlen : cs.length = ds.length) (hlist : wellFormedList cs = wellFormedList ds) :
+    wellFormed (.node a cs) = wellFormed (.node a ds) := by
   match a with
-  | .inr none => simp only [Planar.isSyntacticObject, hlen, hlist]
+  | .inr none => simp only [wellFormed, hlen, hlist]
   | .inl _ | .inr (some _) =>
-    simp only [Planar.isSyntacticObject]
+    simp only [wellFormed]
     rw [Bool.eq_iff_iff]
     simp only [List.isEmpty_iff_length_eq_zero, hlen]
 
 mutual
-/-- `Planar.isSyntacticObject` is invariant under `Perm`, hence descends to the quotient. At a node
-    the arity check is fixed by the equal children lengths and the recursive check by
-    the `PermList` companion. -/
-theorem Planar.isSyntacticObject_perm : ∀ {t s : Planar}, RoseTree.Perm t s →
-    Planar.isSyntacticObject t = Planar.isSyntacticObject s
-  | _, _, .node h => Planar.isSyntacticObject_node_congr h.length_eq
-    (Planar.isSyntacticObjectList_permList h)
-  | _, _, .trans h₁ h₂ => (Planar.isSyntacticObject_perm h₁).trans
-    (Planar.isSyntacticObject_perm h₂)
+/-- Well-formedness is invariant under permuting children, hence descends to the quotient. -/
+theorem wellFormed_perm : ∀ {t s : RoseTree Vertex}, RoseTree.Perm t s →
+    wellFormed t = wellFormed s
+  | _, _, .node h => wellFormed_node_congr h.length_eq (wellFormedList_permList h)
+  | _, _, .trans h₁ h₂ => (wellFormed_perm h₁).trans (wellFormed_perm h₂)
 
-/-- `Planar.isSyntacticObjectList` is a conjunction over children, hence `PermList`-invariant. -/
-theorem Planar.isSyntacticObjectList_permList : ∀ {cs ds : List (Planar)},
-    RoseTree.PermList cs ds → Planar.isSyntacticObjectList cs = Planar.isSyntacticObjectList ds
+/-- `wellFormedList` is a conjunction over children, hence `PermList`-invariant. -/
+theorem wellFormedList_permList : ∀ {cs ds : List (RoseTree Vertex)},
+    RoseTree.PermList cs ds → wellFormedList cs = wellFormedList ds
   | _, _, .nil => rfl
   | _, _, .cons h hs => by
-    simp only [Planar.isSyntacticObjectList, Planar.isSyntacticObject_perm h,
-      Planar.isSyntacticObjectList_permList hs]
-  | _, _, .swap _ _ _ => by simp only [Planar.isSyntacticObjectList, Bool.and_left_comm]
-  | _, _, .trans h₁ h₂ => (Planar.isSyntacticObjectList_permList h₁).trans
-    (Planar.isSyntacticObjectList_permList h₂)
+    simp only [wellFormedList, wellFormed_perm h, wellFormedList_permList hs]
+  | _, _, .swap _ _ _ => by simp only [wellFormedList, Bool.and_left_comm]
+  | _, _, .trans h₁ h₂ => (wellFormedList_permList h₁).trans (wellFormedList_permList h₂)
 end
 
-/-! ### The carrier: `IsSyntacticObject` on `Nonplanar` + the `SyntacticObject` subtype -/
-
-/-- Well-formedness on the nonplanar carrier, lifted from `Planar.isSyntacticObject`. -/
-def isSyntacticObject : Nonplanar Vertex → Bool :=
-  Nonplanar.lift Planar.isSyntacticObject (fun _ _ h => Planar.isSyntacticObject_perm h)
-
-@[simp] theorem isSyntacticObject_mk (t : Planar) : isSyntacticObject (Nonplanar.mk t)
-    = Planar.isSyntacticObject t := rfl
-
-/-- A nonplanar tree over `Vertex` is a syntactic object when it is binary with lexical or
-    trace leaves and bare internal vertices. -/
-def IsSyntacticObject (t : Nonplanar Vertex) : Prop := isSyntacticObject t = true
-
-instance : DecidablePred IsSyntacticObject := fun t => inferInstanceAs (Decidable
-    (isSyntacticObject t = true))
-
-/-- The syntactic objects: the well-formed nonplanar trees over `Vertex`. -/
-def SyntacticObject : Type := { t : Nonplanar Vertex // IsSyntacticObject t }
-
-instance : DecidableEq SyntacticObject := Subtype.instDecidableEq
-
-/-! ### The three shapes -/
-
-/-- A lexical leaf. -/
-def SyntacticObject.lexLeaf (tok : LIToken) : SyntacticObject := ⟨Nonplanar.leaf (Sum.inl tok), rfl⟩
-
-/-- The trace leaf: a childless bare vertex, the mark an admissible cut leaves in the remaining
-    tree ([marcolli-chomsky-berwick-2025], Definition 1.2.6). It carries no index; `traceOf` is the
-    indexed trace. -/
-def SyntacticObject.traceLeaf : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr none), by decide⟩
-
-/-- The trace of `tok`. -/
-def SyntacticObject.traceOf (tok : LIToken) : SyntacticObject :=
-  ⟨Nonplanar.leaf (Sum.inr (some tok)), rfl⟩
-
-/-- A bare binary node is well-formed exactly when both daughters are. -/
-theorem isSyntacticObject_node_pair (a b : Nonplanar Vertex) :
-    isSyntacticObject (Nonplanar.node (Sum.inr none) ({a, b} : Multiset (Nonplanar Vertex)))
-      = (isSyntacticObject a && isSyntacticObject b) := by
-  refine Quotient.inductionOn₂ a b fun pa pb => ?_
-  show isSyntacticObject (Nonplanar.node (Sum.inr none) {Nonplanar.mk pa, Nonplanar.mk pb})
-      = (isSyntacticObject (Nonplanar.mk pa) && isSyntacticObject (Nonplanar.mk pb))
-  rw [show ({Nonplanar.mk pa, Nonplanar.mk pb} : Multiset (Nonplanar Vertex))
-        = Multiset.ofList ([pa, pb].map Nonplanar.mk) from rfl,
-      Nonplanar.node_mk_tree_list]
-  simp only [isSyntacticObject_mk, Planar.isSyntacticObject, Planar.isSyntacticObjectList,
-    List.length_cons, List.length_nil,
-             Nat.reduceAdd, Nat.reduceBEq, Bool.or_true, Bool.true_and, Bool.and_true]
-
-/-- The bare binary node over two syntactic objects: Merge on the carrier, also written `*`.
-    Noncomputable, since it goes through the smart constructor `Nonplanar.node`; concrete
-    results are built planar-first and related by `node_mk`. -/
-noncomputable def SyntacticObject.node (l r : SyntacticObject) : SyntacticObject :=
-  ⟨Nonplanar.node (Sum.inr none) {l.val, r.val}, by
-    show isSyntacticObject (Nonplanar.node (Sum.inr none) {l.val, r.val}) = true
-    have hl : isSyntacticObject l.val = true := l.2
-    have hr : isSyntacticObject r.val = true := r.2
-    rw [isSyntacticObject_node_pair, hl, hr, Bool.and_self]⟩
-
-@[simp] theorem SyntacticObject.node_val (l r : SyntacticObject) :
-    (SyntacticObject.node l r).val = Nonplanar.node (Sum.inr none) {l.val, r.val} := rfl
-
-/-- A node of two planar-built objects is the planar binary node, so concrete results are
-    `decide`-able. -/
-theorem SyntacticObject.node_mk (pl pr : Planar)
-    (hl : IsSyntacticObject (Nonplanar.mk pl)) (hr : IsSyntacticObject (Nonplanar.mk pr)) :
-    (SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩).val
-      = Nonplanar.mk (.node (Sum.inr none) [pl, pr]) := by
-  rw [SyntacticObject.node_val,
-      show ({Nonplanar.mk pl, Nonplanar.mk pr} : Multiset (Nonplanar Vertex))
-        = Multiset.ofList ([pl, pr].map Nonplanar.mk) from rfl,
-      Nonplanar.node_mk_tree_list]
-
-/-! ### Induction and case analysis -/
-
-/-- The children of a well-formed node are well-formed. -/
-theorem Planar.isSyntacticObject_of_mem {cs : List (Planar)} (h : Planar.isSyntacticObjectList cs
-    = true) :
-    ∀ c ∈ cs, Planar.isSyntacticObject c = true := by
+/-- The children of a well-formed list are well-formed. -/
+theorem wellFormed_of_mem {cs : List (RoseTree Vertex)} (h : wellFormedList cs = true) :
+    ∀ c ∈ cs, wellFormed c = true := by
   induction cs with
   | nil => intro _ hc; exact absurd hc List.not_mem_nil
   | cons hd tl ih =>
-    rw [Planar.isSyntacticObjectList, Bool.and_eq_true] at h
+    rw [wellFormedList, Bool.and_eq_true] at h
     intro c hc
     rcases List.mem_cons.mp hc with rfl | hmem
     · exact h.1
     · exact ih h.2 c hmem
 
-/-- Induction on syntactic objects: every syntactic object is a lexical leaf, a trace leaf, or a
-    node of two syntactic objects. -/
+/-- A bare binary node is well-formed exactly when both daughters are. -/
+@[simp] theorem wellFormed_merge (l r : RoseTree Vertex) :
+    wellFormed (.node (Sum.inr none) [l, r]) = (wellFormed l && wellFormed r) := by
+  simp [wellFormed, wellFormedList]
+
+/-- Under well-formedness, a node has either no children or exactly two. -/
+theorem wellFormed_length {a : Vertex} {cs : List (RoseTree Vertex)}
+    (ht : wellFormed (.node a cs) = true) : cs.length = 0 ∨ cs.length = 2 := by
+  match a with
+  | .inl _ | .inr (some _) =>
+    rw [wellFormed, List.isEmpty_iff] at ht
+    exact Or.inl (by rw [ht]; rfl)
+  | .inr none =>
+    rw [wellFormed, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq, beq_iff_eq] at ht
+    exact ht.1
+
+end SyntacticObject
+
+/-- An unordered tree over `Vertex` is a syntactic object when its ordered representatives are
+    well-formed: binary, with lexical or trace leaves and bare internal vertices. -/
+def IsSyntacticObject (t : Nonplanar SyntacticObject.Vertex) : Prop :=
+  Nonplanar.lift SyntacticObject.wellFormed (fun _ _ h => SyntacticObject.wellFormed_perm h) t
+    = true
+
+instance : DecidablePred IsSyntacticObject := fun _ => inferInstanceAs (Decidable (_ = true))
+
+@[simp] theorem isSyntacticObject_mk (t : RoseTree SyntacticObject.Vertex) :
+    IsSyntacticObject (Nonplanar.mk t) ↔ SyntacticObject.wellFormed t = true := Iff.rfl
+
+/-- The syntactic objects: the well-formed unordered trees over `Vertex`. -/
+def SyntacticObject : Type := { t : Nonplanar SyntacticObject.Vertex // IsSyntacticObject t }
+
+/-- The planar syntactic objects: the well-formed ordered trees over `Vertex`,
+    [marcolli-chomsky-berwick-2025] §1.12's planar embeddings. -/
+def PlanarSyntacticObject : Type :=
+  { t : RoseTree SyntacticObject.Vertex // IsSyntacticObject (Nonplanar.mk t) }
+
+instance : DecidableEq SyntacticObject := Subtype.instDecidableEq
+
+instance : DecidableEq PlanarSyntacticObject := Subtype.instDecidableEq
+
+/-! ### The shapes -/
+
+namespace SyntacticObject
+
+/-- A lexical leaf. -/
+def leaf (tok : LIToken) : SyntacticObject := ⟨Nonplanar.leaf (Sum.inl tok), rfl⟩
+
+/-- The bare trace: a childless bare vertex, the mark an admissible cut leaves in the remaining
+    tree ([marcolli-chomsky-berwick-2025], Definition 1.2.6). It carries no index; `traceOf` is
+    the indexed trace. -/
+def trace : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr none), by decide⟩
+
+/-- The trace of `tok`. -/
+def traceOf (tok : LIToken) : SyntacticObject := ⟨Nonplanar.leaf (Sum.inr (some tok)), rfl⟩
+
+/-- A bare binary node is a syntactic object exactly when both daughters are. -/
+theorem isSyntacticObject_merge_iff (a b : Nonplanar Vertex) :
+    IsSyntacticObject (Nonplanar.node (Sum.inr none) {a, b}) ↔
+      IsSyntacticObject a ∧ IsSyntacticObject b := by
+  refine Quotient.inductionOn₂ a b fun pa pb => ?_
+  show IsSyntacticObject (Nonplanar.node (Sum.inr none) {Nonplanar.mk pa, Nonplanar.mk pb}) ↔
+    IsSyntacticObject (Nonplanar.mk pa) ∧ IsSyntacticObject (Nonplanar.mk pb)
+  rw [show ({Nonplanar.mk pa, Nonplanar.mk pb} : Multiset (Nonplanar Vertex))
+        = Multiset.ofList ([pa, pb].map Nonplanar.mk) from rfl, Nonplanar.node_mk_tree_list]
+  exact (isSyntacticObject_mk _).trans (by rw [wellFormed_merge, Bool.and_eq_true]; exact Iff.rfl)
+
+/-- Merge on the carrier, the bare binary node over two syntactic objects, also written `*`.
+    Noncomputable, since it goes through the smart constructor `Nonplanar.node`; concrete results
+    are built ordered and forgotten by `PlanarSyntacticObject.toSyntacticObject`. -/
+noncomputable def merge (l r : SyntacticObject) : SyntacticObject :=
+  ⟨Nonplanar.node (Sum.inr none) {l.val, r.val}, (isSyntacticObject_merge_iff _ _).2 ⟨l.2, r.2⟩⟩
+
+@[simp] theorem merge_val (l r : SyntacticObject) :
+    (merge l r).val = Nonplanar.node (Sum.inr none) {l.val, r.val} := rfl
+
+theorem merge_comm (l r : SyntacticObject) : merge l r = merge r l :=
+  Subtype.ext (by rw [merge_val, merge_val, Multiset.pair_comm])
+
+/-- Merge of two ordered-built objects is the ordered binary node, so concrete results reduce. -/
+theorem merge_mk (pl pr : RoseTree Vertex)
+    (hl : IsSyntacticObject (Nonplanar.mk pl)) (hr : IsSyntacticObject (Nonplanar.mk pr)) :
+    (merge ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩).val
+      = Nonplanar.mk (.node (Sum.inr none) [pl, pr]) := by
+  rw [merge_val,
+      show ({Nonplanar.mk pl, Nonplanar.mk pr} : Multiset (Nonplanar Vertex))
+        = Multiset.ofList ([pl, pr].map Nonplanar.mk) from rfl,
+      Nonplanar.node_mk_tree_list]
+
+end SyntacticObject
+
+namespace PlanarSyntacticObject
+
+open SyntacticObject (Vertex wellFormed wellFormed_merge)
+
+/-- A lexical leaf. -/
+def leaf (tok : LIToken) : PlanarSyntacticObject := ⟨.node (Sum.inl tok) [], rfl⟩
+
+/-- The bare trace. -/
+def trace : PlanarSyntacticObject := ⟨.node (Sum.inr none) [], by decide⟩
+
+/-- The trace of `tok`. -/
+def traceOf (tok : LIToken) : PlanarSyntacticObject := ⟨.node (Sum.inr (some tok)) [], rfl⟩
+
+/-- Merge, with the daughters in the given order. -/
+def merge (l r : PlanarSyntacticObject) : PlanarSyntacticObject :=
+  ⟨.node (Sum.inr none) [l.val, r.val], by
+    show wellFormed _ = true
+    rw [wellFormed_merge, Bool.and_eq_true]; exact ⟨l.2, r.2⟩⟩
+
+@[simp] theorem leaf_val (tok : LIToken) : (leaf tok).val = .node (Sum.inl tok) [] := rfl
+@[simp] theorem trace_val : trace.val = .node (Sum.inr none) [] := rfl
+@[simp] theorem traceOf_val (tok : LIToken) : (traceOf tok).val = .node (Sum.inr (some tok)) [] :=
+  rfl
+@[simp] theorem merge_val (l r : PlanarSyntacticObject) :
+    (merge l r).val = .node (Sum.inr none) [l.val, r.val] := rfl
+
+/-- Forgetting the order: the quotient map to the syntactic object. -/
+def toSyntacticObject (p : PlanarSyntacticObject) : SyntacticObject := ⟨Nonplanar.mk p.val, p.2⟩
+
+@[simp] theorem toSyntacticObject_val (p : PlanarSyntacticObject) :
+    p.toSyntacticObject.val = Nonplanar.mk p.val := rfl
+
+@[simp] theorem toSyntacticObject_leaf (tok : LIToken) :
+    (leaf tok).toSyntacticObject = SyntacticObject.leaf tok := rfl
+
+@[simp] theorem toSyntacticObject_trace : trace.toSyntacticObject = SyntacticObject.trace := rfl
+
+@[simp] theorem toSyntacticObject_traceOf (tok : LIToken) :
+    (traceOf tok).toSyntacticObject = SyntacticObject.traceOf tok := rfl
+
+/-- Forgetting the order commutes with Merge. -/
+@[simp] theorem toSyntacticObject_merge (l r : PlanarSyntacticObject) :
+    (merge l r).toSyntacticObject = SyntacticObject.merge l.toSyntacticObject r.toSyntacticObject :=
+  Subtype.ext (SyntacticObject.merge_mk l.val r.val l.2 r.2).symm
+
+end PlanarSyntacticObject
+
+/-! ### Induction and case analysis -/
+
+namespace SyntacticObject
+
+/-- Induction on syntactic objects: every syntactic object is a lexical leaf, a trace, or the
+    Merge of two syntactic objects. -/
 @[elab_as_elim]
-theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
-    (lex : ∀ tok, motive (SyntacticObject.lexLeaf tok))
-    (trace : motive SyntacticObject.traceLeaf)
-    (traceOf : ∀ tok, motive (SyntacticObject.traceOf tok))
-    (node : ∀ l r : SyntacticObject, motive l → motive r → motive (SyntacticObject.node l r))
+theorem ind {motive : SyntacticObject → Prop}
+    (leaf : ∀ tok, motive (leaf tok))
+    (trace : motive trace)
+    (traceOf : ∀ tok, motive (traceOf tok))
+    (merge : ∀ l r : SyntacticObject, motive l → motive r → motive (merge l r))
     (s : SyntacticObject) : motive s := by
-  suffices H : ∀ n (p : Planar) (hp : IsSyntacticObject (Nonplanar.mk p)),
+  suffices H : ∀ n (p : RoseTree Vertex) (hp : IsSyntacticObject (Nonplanar.mk p)),
       p.numNodes = n → motive ⟨Nonplanar.mk p, hp⟩ by
     obtain ⟨t, ht⟩ := s
     refine Quotient.inductionOn (motive := fun t => ∀ (ht : IsSyntacticObject t), motive ⟨t, ht⟩)
@@ -223,47 +265,46 @@ theorem SyntacticObject.ind {motive : SyntacticObject → Prop}
   induction n using Nat.strong_induction_on with
   | _ n IH =>
     rintro ⟨lbl, cs⟩ hp hw
-    have hpl : Planar.isSyntacticObject (RoseTree.node lbl cs) = true := hp
+    have hpl : wellFormed (RoseTree.node lbl cs) = true := hp
     cases lbl with
     | inl tok =>
-      rw [Planar.isSyntacticObject] at hpl
+      rw [wellFormed] at hpl
       rcases cs with _ | ⟨c, cs'⟩
-      · exact lex tok
+      · exact leaf tok
       · simp at hpl
     | inr u =>
       cases u with
       | some tok =>
-        rw [Planar.isSyntacticObject] at hpl
+        rw [wellFormed] at hpl
         rcases cs with _ | ⟨c, cs'⟩
         · exact traceOf tok
         · simp at hpl
       | none =>
-      rw [Planar.isSyntacticObject, Bool.and_eq_true] at hpl
+      rw [wellFormed, Bool.and_eq_true] at hpl
       obtain ⟨hlen, hlist⟩ := hpl
       rcases cs with _ | ⟨pl, _ | ⟨pr, _ | ⟨x, rest⟩⟩⟩
       · exact trace
       · simp at hlen
-      · have hl : Planar.isSyntacticObject pl = true := Planar.isSyntacticObject_of_mem hlist pl
-          (by simp)
-        have hr : Planar.isSyntacticObject pr = true := Planar.isSyntacticObject_of_mem hlist pr
-          (by simp)
-        have hnode : (⟨Nonplanar.mk (RoseTree.node (Sum.inr none) [pl, pr]), hp⟩ : SyntacticObject)
-            = SyntacticObject.node ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩ :=
-          Subtype.ext (SyntacticObject.node_mk pl pr hl hr).symm
-        rw [hnode]
+      · have hl : wellFormed pl = true := wellFormed_of_mem hlist pl (by simp)
+        have hr : wellFormed pr = true := wellFormed_of_mem hlist pr (by simp)
+        have hmerge : (⟨Nonplanar.mk (RoseTree.node (Sum.inr none) [pl, pr]), hp⟩ : SyntacticObject)
+            = SyntacticObject.merge ⟨Nonplanar.mk pl, hl⟩ ⟨Nonplanar.mk pr, hr⟩ :=
+          Subtype.ext (merge_mk pl pr hl hr).symm
+        rw [hmerge]
         simp only [RoseTree.numNodes_node, List.map_cons, List.map_nil, List.sum_cons,
           List.sum_nil] at hw
-        exact node _ _ (IH pl.numNodes (by omega) pl hl rfl) (IH pr.numNodes (by omega) pr hr rfl)
+        exact merge _ _ (IH pl.numNodes (by omega) pl hl rfl) (IH pr.numNodes (by omega) pr hr rfl)
       · simp at hlen
 
-/-- Every syntactic object is a lexical leaf, a trace leaf, or a node. -/
-theorem SyntacticObject.exists_form (s : SyntacticObject) :
-    (∃ tok, s = SyntacticObject.lexLeaf tok) ∨ s = SyntacticObject.traceLeaf ∨
-      (∃ tok, s = SyntacticObject.traceOf tok) ∨ (∃ l r, s = SyntacticObject.node l r) := by
-  induction s using SyntacticObject.ind with
-  | lex tok => exact Or.inl ⟨tok, rfl⟩
+/-- Every syntactic object is a lexical leaf, a trace, or a Merge. -/
+theorem exists_form (s : SyntacticObject) :
+    (∃ tok, s = leaf tok) ∨ s = trace ∨ (∃ tok, s = traceOf tok) ∨ (∃ l r, s = merge l r) := by
+  induction s using ind with
+  | leaf tok => exact Or.inl ⟨tok, rfl⟩
   | trace => exact Or.inr (Or.inl rfl)
   | traceOf tok => exact Or.inr (Or.inr (Or.inl ⟨tok, rfl⟩))
-  | node l r _ _ => exact Or.inr (Or.inr (Or.inr ⟨l, r, rfl⟩))
+  | merge l r _ _ => exact Or.inr (Or.inr (Or.inr ⟨l, r, rfl⟩))
+
+end SyntacticObject
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -8,18 +8,14 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Basic
 /-!
 # Building and reading syntactic objects
 
-The node constructor is noncomputable, so concrete syntactic objects are built planar-first with
-`Planar.leaf`, `Planar.trace`, and `Planar.merge` and quotiented once by `ofPlanar`, whose
-well-formedness obligation is discharged by `decide`; `SyntacticObject.node_mk` relates such a build
-to `node`, so theorems stated over `node` apply to it. Merge on the carrier is the node itself,
-written `*`: External Merge of two objects, and the re-merge of a mover with the remainder in
-Internal Merge. The accessors read the root token, leaf and node counts, and the trace predicate;
-since `isTrace` recognizes the trace leaves, bare or indexed.
+Merge on the carrier is written `*`: External Merge of two objects, and the re-merge of a mover
+with the remainder in Internal Merge. Concrete objects are built ordered, as
+`PlanarSyntacticObject`s, and forgotten to the carrier by `toSyntacticObject`. The accessors read
+the root token, the leaf and node counts, and the trace predicate, which recognizes the trace
+leaves, bare or indexed.
 
 ## Main definitions
 
-* `Minimalist.SyntacticObject.ofPlanar`, `Planar.leaf`, `Planar.trace`, `Planar.merge`: planar
-construction.
 * `Minimalist.SyntacticObject.mkLeaf`, `mkLeafPhon`: lexical leaves from features.
 * `Minimalist.SyntacticObject.getLIToken`, `isTrace`, `leafCount`, `nodeCount`, `IsLeaf`.
 -/
@@ -30,41 +26,27 @@ open RoseTree RoseTree.Nonplanar SyntacticObject
 
 namespace SyntacticObject
 
-/-! ### Computable planar construction DSL -/
-
-/-- The syntactic object of a well-formed planar tree; on a concrete tree the obligation is
-    discharged by `decide`. -/
-def ofPlanar (p : Planar) (h : Planar.isSyntacticObject p = true :=
-  by first | rfl | decide) : SyntacticObject :=
-  ⟨Nonplanar.mk p, h⟩
-
-@[simp] theorem ofPlanar_leafP (tok : LIToken) : ofPlanar (Planar.leaf tok) = lexLeaf tok := rfl
-
-@[simp] theorem ofPlanar_traceP : ofPlanar Planar.trace = traceLeaf := rfl
-
-/-- The default syntactic object is the trace leaf. -/
-instance : Inhabited SyntacticObject := ⟨traceLeaf⟩
+/-- The default syntactic object is the bare trace. -/
+instance : Inhabited SyntacticObject := ⟨trace⟩
 
 /-! ### Merge as multiplication -/
 
-/-- `l * r = node l r`: Merge on the carrier. -/
-noncomputable instance : Mul SyntacticObject := ⟨node⟩
+/-- `l * r = merge l r`: Merge on the carrier. -/
+noncomputable instance : Mul SyntacticObject := ⟨merge⟩
 
-@[simp] theorem mul_def (l r : SyntacticObject) : l * r = node l r := rfl
+@[simp] theorem mul_def (l r : SyntacticObject) : l * r = merge l r := rfl
 
-theorem mul_comm (l r : SyntacticObject) : l * r = r * l := by
-  apply Subtype.ext
-  rw [mul_def, mul_def, node_val, node_val, Multiset.pair_comm]
+theorem mul_comm (l r : SyntacticObject) : l * r = r * l := merge_comm l r
 
 /-! ### Lexical leaves from features -/
 
 /-- A lexical leaf from a category and selectional stack. -/
 def mkLeaf (cat : Cat) (sel : SelStack) (id : Nat) : SyntacticObject :=
-  lexLeaf ⟨.simple cat sel, id⟩
+  SyntacticObject.leaf ⟨.simple cat sel, id⟩
 
 /-- A lexical leaf with a phonological form. -/
 def mkLeafPhon (cat : Cat) (sel : SelStack) (phon : String) (id : Nat) : SyntacticObject :=
-  lexLeaf ⟨.simple cat sel (phonForm := phon), id⟩
+  SyntacticObject.leaf ⟨.simple cat sel (phonForm := phon), id⟩
 
 /-! ### Accessors -/
 
@@ -74,20 +56,21 @@ def getLIToken (s : SyntacticObject) : Option LIToken :=
   | .inl tok => some tok
   | .inr _ => none
 
-@[simp] theorem getLIToken_lexLeaf (tok : LIToken) : (lexLeaf tok).getLIToken = some tok := rfl
+@[simp] theorem getLIToken_leaf (tok : LIToken) : (SyntacticObject.leaf tok).getLIToken
+    = some tok := rfl
 
-@[simp] theorem getLIToken_traceLeaf : traceLeaf.getLIToken = none := rfl
+@[simp] theorem getLIToken_trace : trace.getLIToken = none := rfl
 
 @[simp] theorem getLIToken_traceOf (tok : LIToken) : (traceOf tok).getLIToken = none := rfl
 
-theorem traceOf_ne_traceLeaf (tok : LIToken) : traceOf tok ≠ traceLeaf := by
+theorem traceOf_ne_trace (tok : LIToken) : traceOf tok ≠ trace := by
   intro h
   have h' : (Sum.inr (some tok) : Vertex) = Sum.inr none :=
     congrArg (fun s : SyntacticObject => Nonplanar.rootValue s.val) h
   simp at h'
 
-@[simp] theorem getLIToken_node (l r : SyntacticObject) : (node l r).getLIToken = none := by
-  rw [getLIToken, node_val, Nonplanar.rootValue_node]
+@[simp] theorem getLIToken_merge (l r : SyntacticObject) : (merge l r).getLIToken = none := by
+  rw [getLIToken, merge_val, Nonplanar.rootValue_node]
 
 /-- A trace leaf, bare or indexed. -/
 def isTrace (s : SyntacticObject) : Prop :=
@@ -97,10 +80,10 @@ instance (s : SyntacticObject) : Decidable (isTrace s) := inferInstanceAs (Decid
 
 @[simp] theorem isTrace_traceOf (tok : LIToken) : isTrace (traceOf tok) := ⟨rfl, rfl⟩
 
-@[simp] theorem not_isTrace_lexLeaf (tok : LIToken) : ¬ isTrace (lexLeaf tok) := fun h =>
+@[simp] theorem not_isTrace_leaf (tok : LIToken) : ¬ isTrace (SyntacticObject.leaf tok) := fun h =>
   Bool.false_ne_true h.1
 
-@[simp] theorem isTrace_traceLeaf : isTrace traceLeaf := ⟨rfl, rfl⟩
+@[simp] theorem isTrace_trace : isTrace trace := ⟨rfl, rfl⟩
 
 /-- The number of leaves, traces included. -/
 def leafCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val
@@ -110,38 +93,40 @@ def IsLeaf (s : SyntacticObject) : Prop := s.leafCount = 1
 
 instance : DecidablePred IsLeaf := fun _ => inferInstanceAs (Decidable (_ = _))
 
-@[simp] theorem isLeaf_lexLeaf (tok : LIToken) : IsLeaf (lexLeaf tok) := rfl
-@[simp] theorem isLeaf_traceLeaf : IsLeaf traceLeaf := rfl
+@[simp] theorem isLeaf_leaf (tok : LIToken) : IsLeaf (SyntacticObject.leaf tok) := rfl
+@[simp] theorem isLeaf_trace : IsLeaf trace := rfl
 
 /-- A shape summary; the full tree is a quotient with no faithful readout. -/
 instance : Repr SyntacticObject where
   reprPrec s _ := match s.getLIToken with
-    | some tok => f!"SyntacticObject.lexLeaf {repr tok}"
+    | some tok => f!"SyntacticObject.leaf {repr tok}"
     | none =>
-      if s.IsLeaf then f!"SyntacticObject.traceLeaf"
-      else f!"⟨SyntacticObject node, {s.leafCount} leaves⟩"
+      if s.IsLeaf then f!"SyntacticObject.trace"
+      else f!"⟨SyntacticObject merge, {s.leafCount} leaves⟩"
 
 /-- `nodeCount s = leafCount s - 1`, the number of internal vertices of a full binary tree. -/
 def nodeCount (s : SyntacticObject) : Nat := Nonplanar.numLeaves s.val - 1
 
-@[simp] theorem leafCount_lexLeaf (tok : LIToken) : (lexLeaf tok).leafCount = 1 := rfl
-@[simp] theorem leafCount_traceLeaf : traceLeaf.leafCount = 1 := rfl
+@[simp] theorem leafCount_leaf (tok : LIToken) : (SyntacticObject.leaf tok).leafCount = 1 := rfl
+@[simp] theorem leafCount_trace : trace.leafCount = 1 := rfl
 
 end SyntacticObject
 
 /-! ### Carrier tests -/
 
 private def demoVP : SyntacticObject :=
-  ofPlanar (Planar.merge (Planar.leaf (mkTraceToken 0)) (Planar.leaf (mkTraceToken 1)))
+  (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf (mkTraceToken 0))
+    (PlanarSyntacticObject.leaf (mkTraceToken 1))).toSyntacticObject
 
 /-- The DSL-built tree is a genuine syntactic object. -/
 example : IsSyntacticObject demoVP.val := by decide
 /-- Its head token reads back via `getLIToken` of the left leaf. -/
-example : (lexLeaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
+example : (SyntacticObject.leaf (mkTraceToken 0)).getLIToken = some (mkTraceToken 0) := by decide
 /-- It has two leaves and one internal node. -/
 example : demoVP.leafCount = 2 ∧ demoVP.nodeCount = 1 := by decide
 /-- The trace leaf is recognized; a lexical leaf is not a trace. -/
-example : isTrace traceLeaf ∧ ¬ isTrace (lexLeaf (mkTraceToken 0)) := by decide
+example : isTrace SyntacticObject.trace ∧ ¬ isTrace (SyntacticObject.leaf
+    (mkTraceToken 0)) := by decide
 /-- A bare binary node over a lexical leaf and a bare trace, the shape of an Internal-Merge
     result, is a syntactic object. -/
 example :

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -49,35 +49,35 @@ inductive Step where
 
 /-- The trace a moved object leaves: the trace of its head by selection, the bare trace when it
     has none. -/
-def trace (s : SyntacticObject) : SyntacticObject := s.selHead.elim traceLeaf traceOf
+def headTrace (s : SyntacticObject) : SyntacticObject := s.selHead.elim trace traceOf
 
 /-- The remainder `T/mover`: the current object with the mover's occurrences replaced by the
     trace of its head, the remaining tree of an admissible cut ([marcolli-chomsky-berwick-2025],
     Definition 1.2.6). For a uniquely accessible mover this is the deletion remainder that
     `Merge.mergeOp_im_composition` extracts; `replace` extends it to a chain of occurrences. -/
 noncomputable def deleteAccessible (mover current : SyntacticObject) : SyntacticObject :=
-  current.replace mover mover.trace
+  current.replace mover mover.headTrace
 
 @[simp] theorem deleteAccessible_val (mover current : SyntacticObject) :
     (deleteAccessible mover current).val
-      = Nonplanar.replace mover.val mover.trace.val current.val := rfl
+      = Nonplanar.replace mover.val mover.headTrace.val current.val := rfl
 
 /-- Apply a step: External Merge is the node with the item on the given side, Internal Merge the
     node of the remainder and the mover. -/
 noncomputable def Step.apply (step : Step) (current : SyntacticObject) : SyntacticObject :=
   match step with
-  | .emL item  => node item current
-  | .emR item  => node current item
-  | .im mover  => node (deleteAccessible mover current) mover
+  | .emL item  => merge item current
+  | .emR item  => merge current item
+  | .im mover  => merge (deleteAccessible mover current) mover
 
 theorem Step.apply_emL (item current : SyntacticObject) :
-    (Step.emL item).apply current = node item current := rfl
+    (Step.emL item).apply current = merge item current := rfl
 
 theorem Step.apply_emR (item current : SyntacticObject) :
-    (Step.emR item).apply current = node current item := rfl
+    (Step.emR item).apply current = merge current item := rfl
 
 theorem Step.apply_im (mover current : SyntacticObject) :
-    (Step.im mover).apply current = node (deleteAccessible mover current) mover := rfl
+    (Step.im mover).apply current = merge (deleteAccessible mover current) mover := rfl
 
 /-- `emL` and `emR` build the same object; they differ only at externalization. -/
 theorem Step.apply_emL_eq_emR (item current : SyntacticObject) :
@@ -126,7 +126,7 @@ end SyntacticObject
 
 /-! ### Carrier tests -/
 
-private def demoTok (i : Nat) : SyntacticObject := lexLeaf ⟨.simple .N [], i⟩
+private def demoTok (i : Nat) : SyntacticObject := SyntacticObject.leaf ⟨.simple .N [], i⟩
 
 example :
     (Derivation.mk (demoTok 0)

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
@@ -80,11 +80,11 @@ def liftN [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) : Nonplanar 
     fun _ _ h => RoseTree.fold_perm (fun a _ _ h' => mergeAlgebra_perm ℓ τ a h') h
 
 @[simp] theorem liftN_mk [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
-    (p : Planar) :
+    (p : RoseTree Vertex) :
     liftN ℓ τ (Nonplanar.mk p) = RoseTree.fold (mergeAlgebra ℓ τ) p := rfl
 
 /-- The nonplanar magma law: Merge multiplies values. -/
-theorem liftN_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+theorem liftN_merge [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (a b : Nonplanar Vertex) :
     liftN ℓ τ (Nonplanar.node (Sum.inr none) {a, b}) = liftN ℓ τ a * liftN ℓ τ b := by
   refine Nonplanar.inductionOn₂ a b fun pa pb => ?_
@@ -95,27 +95,27 @@ theorem liftN_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
 def liftFun [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) (s : SyntacticObject) : β :=
   liftN ℓ τ s.val
 
-@[simp] theorem liftFun_lexLeaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
-    (tok : LIToken) : liftFun ℓ τ (lexLeaf tok) = ℓ tok := rfl
+@[simp] theorem liftFun_leaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+    (tok : LIToken) : liftFun ℓ τ (SyntacticObject.leaf tok) = ℓ tok := rfl
 
-@[simp] theorem liftFun_traceLeaf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
-    liftFun ℓ τ traceLeaf = τ := rfl
+@[simp] theorem liftFun_trace [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
+    liftFun ℓ τ trace = τ := rfl
 
 @[simp] theorem liftFun_traceOf [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (tok : LIToken) : liftFun ℓ τ (traceOf tok) = τ := rfl
 
-@[simp] theorem liftFun_node [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
+@[simp] theorem liftFun_merge [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (l r : SyntacticObject) :
-    liftFun ℓ τ (node l r) = liftFun ℓ τ l * liftFun ℓ τ r := by
-  show liftN ℓ τ (node l r).val = liftN ℓ τ l.val * liftN ℓ τ r.val
-  rw [node_val, liftN_node]
+    liftFun ℓ τ (merge l r) = liftFun ℓ τ l * liftFun ℓ τ r := by
+  show liftN ℓ τ (merge l r).val = liftN ℓ τ l.val * liftN ℓ τ r.val
+  rw [merge_val, liftN_merge]
 
 /-- The universal property, existence half (cf. `FreeMagma.lift`): leaf data
     extends to a morphism of magmas out of the carrier. -/
 noncomputable def lift [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β) :
     SyntacticObject →ₙ* β where
   toFun := liftFun ℓ τ
-  map_mul' := liftFun_node ℓ τ
+  map_mul' := liftFun_merge ℓ τ
 
 @[simp] theorem lift_apply [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
     (s : SyntacticObject) : lift ℓ τ s = liftFun ℓ τ s := rfl
@@ -123,15 +123,15 @@ noncomputable def lift [CommMagma β] [Zero β] (ℓ : LIToken → β) (τ : β)
 /-- The universal property, uniqueness half: morphisms agreeing on the leaves are
     equal. -/
 theorem hom_ext [Mul β] {f g : SyntacticObject →ₙ* β}
-    (hlex : ∀ tok, f (lexLeaf tok) = g (lexLeaf tok))
-    (htrace : f traceLeaf = g traceLeaf) (htraceOf : ∀ tok, f (traceOf tok) = g (traceOf tok)) :
+    (hlex : ∀ tok, f (SyntacticObject.leaf tok) = g (SyntacticObject.leaf tok))
+    (htrace : f trace = g trace) (htraceOf : ∀ tok, f (traceOf tok) = g (traceOf tok)) :
     f = g :=
   MulHom.ext fun s => by
     induction s using SyntacticObject.ind with
-    | lex tok => exact hlex tok
+    | leaf tok => exact hlex tok
     | trace => exact htrace
     | traceOf tok => exact htraceOf tok
-    | node l r ihl ihr =>
-      rw [show node l r = l * r from rfl, map_mul, map_mul, ihl, ihr]
+    | merge l r ihl ihr =>
+      rw [show merge l r = l * r from rfl, map_mul, map_mul, ihl, ihr]
 
 end Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -12,7 +12,7 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Build
 `SyntacticObject.replace s target replacement` substitutes every subterm of `s` equal to
 `target` by `replacement`; it is `Nonplanar.replace` closed under well-formedness, which holds
 because substitution preserves the arity of every vertex. The copy-theory use is
-`s.replace mover traceLeaf`, leaving a trace where a mover was. This is a structural operation:
+`s.replace mover trace`, leaving a trace where a mover was. This is a structural operation:
 the Merge-algebraic Internal Merge is the coproduct composition of `Merge/Internal.lean`, with
 traces as cut remainders and chains held at the workspace level, and `replace` supports the
 transformational view that study files are written in. It is noncomputable; concrete cases
@@ -31,30 +31,28 @@ open RoseTree RoseTree.Nonplanar SyntacticObject
 theorem isSyntacticObject_replace (target replacement s : SyntacticObject) :
     IsSyntacticObject (Nonplanar.replace target.val replacement.val s.val) := by
   induction s using ind with
-  | lex tok =>
-    rw [show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl, Nonplanar.replace_leaf]
+  | leaf tok =>
+    rw [show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+      Nonplanar.replace_leaf]
     split
     · exact replacement.2
-    · exact (lexLeaf tok).2
+    · exact (SyntacticObject.leaf tok).2
   | trace =>
-    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl, Nonplanar.replace_leaf]
+    rw [show trace.val = Nonplanar.leaf (Sum.inr none) from rfl, Nonplanar.replace_leaf]
     split
     · exact replacement.2
-    · exact traceLeaf.2
+    · exact trace.2
   | traceOf tok =>
     rw [show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
       Nonplanar.replace_leaf]
     split
     · exact replacement.2
     · exact (traceOf tok).2
-  | node l r ihl ihr =>
-    rw [node_val, Nonplanar.replace_node_pair]
+  | merge l r ihl ihr =>
+    rw [merge_val, Nonplanar.replace_node_pair]
     split
     · exact replacement.2
-    · show isSyntacticObject (Nonplanar.node (Sum.inr none)
-        {Nonplanar.replace target.val replacement.val l.val,
-          Nonplanar.replace target.val replacement.val r.val}) = true
-      rw [isSyntacticObject_node_pair, ihl, ihr]; rfl
+    · exact (isSyntacticObject_merge_iff _ _).2 ⟨ihl, ihr⟩
 
 namespace SyntacticObject
 
@@ -71,34 +69,35 @@ noncomputable def replace (s target replacement : SyntacticObject) : SyntacticOb
   Subtype.ext (by rw [replace_val, Nonplanar.replace_self])
 
 /-- At a node other than the target, substitution recurses into both daughters. -/
-theorem replace_node_of_ne {l r target replacement : SyntacticObject} (h : node l r ≠ target) :
-    replace (node l r) target replacement
-      = node (replace l target replacement) (replace r target replacement) := by
+theorem replace_merge_of_ne {l r target replacement : SyntacticObject} (h : merge l r ≠ target) :
+    replace (merge l r) target replacement
+      = merge (replace l target replacement) (replace r target replacement) := by
   apply Subtype.ext
-  rw [replace_val, node_val, Nonplanar.replace_node_pair, if_neg, node_val, replace_val,
+  rw [replace_val, merge_val, Nonplanar.replace_node_pair, if_neg, merge_val, replace_val,
     replace_val]
-  rw [← node_val]
+  rw [← merge_val]
   exact fun heq => h (Subtype.ext heq)
 
 theorem replace_lexLeaf_of_ne {tok : LIToken} {target replacement : SyntacticObject}
-    (h : lexLeaf tok ≠ target) : replace (lexLeaf tok) target replacement = lexLeaf tok := by
+    (h : SyntacticObject.leaf tok ≠ target) : replace (SyntacticObject.leaf tok) target replacement
+      = SyntacticObject.leaf tok := by
   apply Subtype.ext
-  rw [replace_val, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+  rw [replace_val, show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
       Nonplanar.replace_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 
 theorem replace_traceLeaf_of_ne {target replacement : SyntacticObject}
-    (h : traceLeaf ≠ target) : replace traceLeaf target replacement = traceLeaf := by
+    (h : trace ≠ target) : replace trace target replacement = trace := by
   apply Subtype.ext
-  rw [replace_val, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+  rw [replace_val, show trace.val = Nonplanar.leaf (Sum.inr none) from rfl,
       Nonplanar.replace_leaf, if_neg]
   exact fun heq => h (Subtype.ext heq)
 
 /-- Moving the daughter `r` out of `[l r]` and leaving a trace yields `[l′ t]`, with `l′` the
     substituted left daughter; a tree is never its own daughter, taken here as a hypothesis. -/
-example (l r : SyntacticObject) (h : node l r ≠ r) :
-    replace (node l r) r traceLeaf = node (replace l r traceLeaf) traceLeaf := by
-  rw [replace_node_of_ne h, replace_self]
+example (l r : SyntacticObject) (h : merge l r ≠ r) :
+    replace (merge l r) r trace = merge (replace l r trace) trace := by
+  rw [replace_merge_of_ne h, replace_self]
 
 end SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -161,16 +161,16 @@ theorem selNode_perm (a : Vertex) {l₁ l₂ : List SelectionState} (h : l₁.Pe
   mergeAlgebra_perm _ _ a h
 
 /-- Selection check on a planar tree: the catamorphism of `selNode`. -/
-def selCheckPlanar : Planar → SelectionState :=
+def selCheckPlanar : RoseTree Vertex → SelectionState :=
   RoseTree.fold selNode
 
 /-- Reduction of `selCheckPlanar` at a node: fold the algebra over the daughters. -/
-theorem selCheckPlanar_node (a : Vertex) (cs : List (Planar)) :
+theorem selCheckPlanar_node (a : Vertex) (cs : List (RoseTree Vertex)) :
     selCheckPlanar (RoseTree.node a cs) = selNode a (cs.map selCheckPlanar) :=
   RoseTree.fold_node ..
 
 /-- `selCheckPlanar` is `Perm`-invariant, so it descends to the quotient. -/
-theorem selCheckPlanar_perm {t s : Planar} (h : RoseTree.Perm t s) :
+theorem selCheckPlanar_perm {t s : RoseTree Vertex} (h : RoseTree.Perm t s) :
     selCheckPlanar t = selCheckPlanar s :=
   RoseTree.fold_perm (fun a _ _ h' => selNode_perm a h') h
 
@@ -178,12 +178,12 @@ theorem selCheckPlanar_perm {t s : Planar} (h : RoseTree.Perm t s) :
 def selCheckN : Nonplanar Vertex → SelectionState :=
   liftN (fun tok => .of tok tok.item.outerSel) (.of (mkTraceToken 0) [])
 
-@[simp] theorem selCheckN_mk (p : Planar) :
+@[simp] theorem selCheckN_mk (p : RoseTree Vertex) :
     selCheckN (Nonplanar.mk p) = selCheckPlanar p := rfl
 
 theorem selCheckN_node (a b : Nonplanar Vertex) :
     selCheckN (Nonplanar.node (Sum.inr none) {a, b}) = selCheckN a * selCheckN b :=
-  liftN_node _ _ a b
+  liftN_merge _ _ a b
 
 /-! ### The selection-driven head on `SyntacticObject` -/
 
@@ -205,12 +205,13 @@ def checkedSel : Option (List Cat) := s.selCheck.residual
     exocentric nodes. -/
 def outerCatC : Option Cat := s.selHead.map (·.item.outerCat)
 
-@[simp] theorem selCheck_lexLeaf : (lexLeaf tok).selCheck = .of tok tok.item.outerSel := rfl
+@[simp] theorem selCheck_leaf : (SyntacticObject.leaf tok).selCheck
+    = .of tok tok.item.outerSel := rfl
 
-@[simp] theorem selCheck_traceLeaf : traceLeaf.selCheck = .of (mkTraceToken 0) [] := rfl
+@[simp] theorem selCheck_trace : trace.selCheck = .of (mkTraceToken 0) [] := rfl
 
 @[simp] theorem selCheck_node (l r : SyntacticObject) :
-    (node l r).selCheck = l.selCheck * r.selCheck := liftFun_node _ _ l r
+    (merge l r).selCheck = l.selCheck * r.selCheck := liftFun_merge _ _ l r
 
 /-- `selCheck` as a morphism of magmas ([marcolli-chomsky-berwick-2025] §1.13's
     algebraic frame): the `lift` of the leaf data. -/
@@ -219,17 +220,18 @@ noncomputable def selCheckHom : SyntacticObject →ₙ* SelectionState :=
 
 @[simp] theorem selCheckHom_apply : selCheckHom s = s.selCheck := rfl
 
-@[simp] theorem selHead_lexLeaf : (lexLeaf tok).selHead = some tok := rfl
+@[simp] theorem selHead_leaf : (SyntacticObject.leaf tok).selHead = some tok := rfl
 
 /-- **Endocentricity**: a node's projecting head is one of its daughters' heads —
     bare-phrase-structure projection ([chomsky-1995-bare] §4, abstracted as
     [marcolli-chomsky-berwick-2025] Definition 1.13.6 / Lemma 1.13.7). -/
-theorem selHead_node {l r : SyntacticObject} {h : LIToken} (hlr : (node l r).selHead = some h) :
+theorem selHead_node {l r : SyntacticObject} {h : LIToken} (hlr : (merge l r).selHead = some h) :
     l.selHead = some h ∨ r.selHead = some h := by
   simp only [selHead, selCheck_node] at hlr ⊢
   exact SelectionState.head_mul hlr
 
-@[simp] theorem outerCatC_lexLeaf : (lexLeaf tok).outerCatC = some tok.item.outerCat := rfl
+@[simp] theorem outerCatC_leaf : (SyntacticObject.leaf tok).outerCatC
+    = some tok.item.outerCat := rfl
 
 end SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
@@ -50,15 +50,15 @@ def immediatelyContains (x y : SyntacticObject) : Prop :=
 instance (x y : SyntacticObject) : Decidable (immediatelyContains x y) :=
   inferInstanceAs (Decidable (_ ∈ _))
 
-@[simp] theorem immediatelyContains_lexLeaf (tok : LIToken) (y : SyntacticObject) :
-    ¬ immediatelyContains (lexLeaf tok) y := by
-  simp only [immediatelyContains, lexLeaf, Nonplanar.leaf,
+@[simp] theorem immediatelyContains_leaf (tok : LIToken) (y : SyntacticObject) :
+    ¬ immediatelyContains (SyntacticObject.leaf tok) y := by
+  simp only [immediatelyContains, leaf, Nonplanar.leaf,
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem immediatelyContains_traceLeaf (y : SyntacticObject) :
-    ¬ immediatelyContains traceLeaf y := by
-  simp only [immediatelyContains, traceLeaf, Nonplanar.leaf,
+@[simp] theorem immediatelyContains_trace (y : SyntacticObject) :
+    ¬ immediatelyContains trace y := by
+  simp only [immediatelyContains, trace, Nonplanar.leaf,
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
@@ -68,9 +68,9 @@ instance (x y : SyntacticObject) : Decidable (immediatelyContains x y) :=
     Nonplanar.rootChildren_mk, RoseTree.leaf, RoseTree.children, List.map_nil, Multiset.coe_nil,
     Multiset.notMem_zero, not_false_iff]
 
-@[simp] theorem immediatelyContains_node (l r y : SyntacticObject) :
-    immediatelyContains (node l r) y ↔ y = l ∨ y = r := by
-  rw [immediatelyContains, node_val, Nonplanar.rootChildren_node,
+@[simp] theorem immediatelyContains_merge (l r y : SyntacticObject) :
+    immediatelyContains (merge l r) y ↔ y = l ∨ y = r := by
+  rw [immediatelyContains, merge_val, Nonplanar.rootChildren_node,
       Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton]
   exact ⟨fun h => h.imp Subtype.ext Subtype.ext,
          fun h => h.imp (congrArg Subtype.val) (congrArg Subtype.val)⟩
@@ -83,26 +83,26 @@ end SyntacticObject
 theorem isSyntacticObject_of_mem_subtrees (s : SyntacticObject) : ∀ m ∈ Nonplanar.subtrees s.val,
     IsSyntacticObject m := by
   induction s using ind with
-  | lex tok =>
+  | leaf tok =>
     intro m hm
-    rw [show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+    rw [show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         Nonplanar.mem_subtrees_leaf] at hm
-    subst hm; exact (lexLeaf tok).2
+    subst hm; exact (SyntacticObject.leaf tok).2
   | trace =>
     intro m hm
-    rw [show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+    rw [show trace.val = Nonplanar.leaf (Sum.inr none) from rfl,
         Nonplanar.mem_subtrees_leaf] at hm
-    subst hm; exact traceLeaf.2
+    subst hm; exact trace.2
   | traceOf tok =>
     intro m hm
     rw [show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
         Nonplanar.mem_subtrees_leaf] at hm
     subst hm; exact (traceOf tok).2
-  | node l r ihl ihr =>
+  | merge l r ihl ihr =>
     intro m hm
-    rw [node_val, Nonplanar.mem_subtrees_node_pair] at hm
+    rw [merge_val, Nonplanar.mem_subtrees_node_pair] at hm
     rcases hm with rfl | hl | hr
-    · exact (node l r).2
+    · exact (merge l r).2
     · exact ihl m hl
     · exact ihr m hr
 
@@ -122,33 +122,33 @@ def subtrees (s : SyntacticObject) : Multiset SyntacticObject :=
 theorem self_mem_subtrees (s : SyntacticObject) : s ∈ s.subtrees := by
   rw [mem_subtrees]; exact Nonplanar.self_mem_subtrees s.val
 
-@[simp] theorem mem_subtrees_node {x l r : SyntacticObject} :
-    x ∈ (node l r).subtrees ↔ x = node l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
-  rw [mem_subtrees, node_val, Nonplanar.mem_subtrees_node_pair, ← mem_subtrees, ← mem_subtrees]
-  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, node_val]⟩ Iff.rfl
+@[simp] theorem mem_subtrees_merge {x l r : SyntacticObject} :
+    x ∈ (merge l r).subtrees ↔ x = merge l r ∨ x ∈ l.subtrees ∨ x ∈ r.subtrees := by
+  rw [mem_subtrees, merge_val, Nonplanar.mem_subtrees_node_pair, ← mem_subtrees, ← mem_subtrees]
+  exact Iff.or ⟨fun h => Subtype.ext h, fun h => by rw [h, merge_val]⟩ Iff.rfl
 
 /-- A subterm of a subterm of `s` is a subterm of `s`. -/
 theorem subtrees_subset_of_mem {w s : SyntacticObject} (h : w ∈ s.subtrees) :
     w.subtrees ⊆ s.subtrees := by
   induction s using ind with
-  | lex tok =>
-    rw [mem_subtrees, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+  | leaf tok =>
+    rw [mem_subtrees, show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
-    rw [(Subtype.ext h : w = lexLeaf tok)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = SyntacticObject.leaf tok)]; exact Multiset.Subset.refl _
   | trace =>
-    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+    rw [mem_subtrees, show trace.val = Nonplanar.leaf (Sum.inr none) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
-    rw [(Subtype.ext h : w = traceLeaf)]; exact Multiset.Subset.refl _
+    rw [(Subtype.ext h : w = trace)]; exact Multiset.Subset.refl _
   | traceOf tok =>
     rw [mem_subtrees, show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     rw [(Subtype.ext h : w = traceOf tok)]; exact Multiset.Subset.refl _
-  | node l r ihl ihr =>
-    rw [mem_subtrees_node] at h
+  | merge l r ihl ihr =>
+    rw [mem_subtrees_merge] at h
     rcases h with rfl | hl | hr
     · exact Multiset.Subset.refl _
-    · intro z hz; rw [mem_subtrees_node]; exact Or.inr (Or.inl (ihl hl hz))
-    · intro z hz; rw [mem_subtrees_node]; exact Or.inr (Or.inr (ihr hr hz))
+    · intro z hz; rw [mem_subtrees_merge]; exact Or.inr (Or.inl (ihl hl hz))
+    · intro z hz; rw [mem_subtrees_merge]; exact Or.inr (Or.inr (ihr hr hz))
 
 /-- One subterm per vertex. -/
 theorem subtrees_card (s : SyntacticObject) : (s.subtrees).card = Nonplanar.numNodes s.val := by
@@ -164,14 +164,14 @@ theorem Acc_card (s : SyntacticObject) : (s.Acc).card = Nonplanar.numNodes s.val
   rw [Acc, Multiset.card_sub (Multiset.singleton_le.mpr (self_mem_subtrees s)),
       subtrees_card, Multiset.card_singleton]
 
-@[simp] theorem Acc_lexLeaf (tok : LIToken) : (lexLeaf tok).Acc = 0 := by
+@[simp] theorem Acc_leaf (tok : LIToken) : (SyntacticObject.leaf tok).Acc = 0 := by
   rw [← Multiset.card_eq_zero, Acc_card,
-      show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+      show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
       Nonplanar.numNodes_leaf]
 
-@[simp] theorem Acc_traceLeaf : traceLeaf.Acc = 0 := by
+@[simp] theorem Acc_trace : trace.Acc = 0 := by
   rw [← Multiset.card_eq_zero, Acc_card,
-      show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+      show trace.val = Nonplanar.leaf (Sum.inr none) from rfl,
       Nonplanar.numNodes_leaf]
 
 /-! ### Containment -/
@@ -193,11 +193,11 @@ theorem contains_trans {x y z : SyntacticObject} (hxy : contains x y) (hyz : con
 theorem immediatelyContains_lt_weight {x y : SyntacticObject} (h : immediatelyContains x y) :
     Nonplanar.numNodes y.val < Nonplanar.numNodes x.val := by
   rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨tok, rfl⟩ | ⟨l, r, rfl⟩
-  · exact absurd h (immediatelyContains_lexLeaf tok y)
-  · exact absurd h (immediatelyContains_traceLeaf y)
+  · exact absurd h (immediatelyContains_leaf tok y)
+  · exact absurd h (immediatelyContains_trace y)
   · exact absurd h (immediatelyContains_traceOf tok y)
-  · rw [immediatelyContains_node] at h
-    rw [node_val, Nonplanar.numNodes_node_pair]
+  · rw [immediatelyContains_merge] at h
+    rw [merge_val, Nonplanar.numNodes_node_pair]
     rcases h with rfl | rfl <;> omega
 
 theorem contains_lt_weight {x y : SyntacticObject} (h : contains x y) :
@@ -212,14 +212,14 @@ theorem contains_irrefl (x : SyntacticObject) : ¬ contains x x :=
 theorem mem_subtrees_of_immediatelyContains {x y : SyntacticObject}
     (h : immediatelyContains x y) : y ∈ x.subtrees := by
   rcases exists_form x with ⟨tok, rfl⟩ | rfl | ⟨tok, rfl⟩ | ⟨l, r, rfl⟩
-  · exact absurd h (immediatelyContains_lexLeaf tok y)
-  · exact absurd h (immediatelyContains_traceLeaf y)
+  · exact absurd h (immediatelyContains_leaf tok y)
+  · exact absurd h (immediatelyContains_trace y)
   · exact absurd h (immediatelyContains_traceOf tok y)
-  · rw [immediatelyContains_node] at h
+  · rw [immediatelyContains_merge] at h
     rcases h with heq | heq
-    · rw [heq, mem_subtrees_node]
+    · rw [heq, mem_subtrees_merge]
       exact Or.inr (Or.inl (self_mem_subtrees l))
-    · rw [heq, mem_subtrees_node]
+    · rw [heq, mem_subtrees_merge]
       exact Or.inr (Or.inr (self_mem_subtrees r))
 
 theorem mem_subtrees_of_contains {x y : SyntacticObject} (h : contains x y) :
@@ -234,30 +234,30 @@ theorem mem_subtrees_iff_eq_or_contains {x y : SyntacticObject} :
   refine ⟨fun h => ?_, fun h => h.elim (fun he => he ▸ self_mem_subtrees x)
     mem_subtrees_of_contains⟩
   induction x using ind with
-  | lex tok =>
-    rw [mem_subtrees, show (lexLeaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
+  | leaf tok =>
+    rw [mem_subtrees, show (SyntacticObject.leaf tok).val = Nonplanar.leaf (Sum.inl tok) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     exact Or.inl (Subtype.ext h)
   | trace =>
-    rw [mem_subtrees, show traceLeaf.val = Nonplanar.leaf (Sum.inr none) from rfl,
+    rw [mem_subtrees, show trace.val = Nonplanar.leaf (Sum.inr none) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     exact Or.inl (Subtype.ext h)
   | traceOf tok =>
     rw [mem_subtrees, show (traceOf tok).val = Nonplanar.leaf (Sum.inr (some tok)) from rfl,
         Nonplanar.mem_subtrees_leaf] at h
     exact Or.inl (Subtype.ext h)
-  | node l r ihl ihr =>
-    rw [mem_subtrees_node] at h
+  | merge l r ihl ihr =>
+    rw [mem_subtrees_merge] at h
     rcases h with rfl | hl | hr
     · exact Or.inl rfl
     · refine Or.inr ?_
       rcases ihl hl with heq | hc
-      · rw [heq]; exact .imm _ _ ((immediatelyContains_node l r l).mpr (Or.inl rfl))
-      · exact .trans _ _ l ((immediatelyContains_node l r l).mpr (Or.inl rfl)) hc
+      · rw [heq]; exact .imm _ _ ((immediatelyContains_merge l r l).mpr (Or.inl rfl))
+      · exact .trans _ _ l ((immediatelyContains_merge l r l).mpr (Or.inl rfl)) hc
     · refine Or.inr ?_
       rcases ihr hr with heq | hc
-      · rw [heq]; exact .imm _ _ ((immediatelyContains_node l r r).mpr (Or.inr rfl))
-      · exact .trans _ _ r ((immediatelyContains_node l r r).mpr (Or.inr rfl)) hc
+      · rw [heq]; exact .imm _ _ ((immediatelyContains_merge l r r).mpr (Or.inr rfl))
+      · exact .trans _ _ r ((immediatelyContains_merge l r r).mpr (Or.inr rfl)) hc
 
 /-- Containment is proper subterm membership, which decides it. -/
 theorem contains_iff_mem_subtrees_and_ne {x y : SyntacticObject} :

--- a/Linglib/Syntax/Minimalist/Theta/Realize.lean
+++ b/Linglib/Syntax/Minimalist/Theta/Realize.lean
@@ -56,17 +56,17 @@ theorem derives_node_of_thetaLocal {c : Color L}
     (and, degenerately, by bare-grid leaves, which do not occur in trees
     with terminal inputs). -/
 noncomputable def realize : Bud.Tree (Color LIToken) → Option SyntacticObject
-  | .leaf (.lex tok _) => some (.lexLeaf tok)
+  | .leaf (.lex tok _) => some (.leaf tok)
   | .leaf _ => none
   | .node _ l r =>
       match realize l, realize r with
-      | some L, some R => some (L.node R)
+      | some L, some R => some (L.merge R)
       | some L, none => some L
       | none, some R => some R
       | none, none => none
 
 @[simp] theorem realize_leaf_lex (tok : LIToken) (g : List PolarizedRole) :
-    realize (.leaf (.lex tok g)) = some (.lexLeaf tok) := rfl
+    realize (.leaf (.lex tok g)) = some (.leaf tok) := rfl
 
 @[simp] theorem realize_leaf_emptyTree :
     realize (.leaf .emptyTree) = none := rfl
@@ -77,7 +77,7 @@ noncomputable def realize : Bud.Tree (Color LIToken) → Option SyntacticObject
 theorem realize_node_some_some {l r : Bud.Tree (Color LIToken)}
     {c : Color LIToken} {L R : SyntacticObject} (hl : realize l = some L)
     (hr : realize r = some R) :
-    realize (.node c l r) = some (L.node R) := by
+    realize (.node c l r) = some (L.merge R) := by
   simp [realize, hl, hr]
 
 /-- The unit law `M(T, 1) = T`: a movement landing site realizes to its

--- a/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
@@ -79,12 +79,12 @@ structure SmallClause where
 
 /-- Build the syntactic object for a small clause: `[SC Subj Pred]`. -/
 noncomputable def SmallClause.toSO (sc : SmallClause) : SyntacticObject :=
-  node sc.subject sc.predicate
+  merge sc.subject sc.predicate
 
 /-- Embed a small clause under a verb: `V [SC Subj Pred]`. -/
 noncomputable def SmallClause.embedUnderV (v : SyntacticObject) (sc : SmallClause) :
     SyntacticObject :=
-  node v sc.toSO
+  merge v sc.toSO
 
 /-- The construction type name for each SC predicate category. -/
 def SCPredCategory.constructionName : SCPredCategory → String
@@ -124,7 +124,7 @@ abbrev SyntacticObject.headCat (so : SyntacticObject) : Option Cat := outerCatC 
 
 /-! ## Binary-node leaf/node counts
 
-`SyntacticObject.node` is noncomputable (the `Nonplanar` carrier
+`SyntacticObject.merge` is noncomputable (the `Nonplanar` carrier
 round-trips through `Quotient.out`), so `decide`/`rfl` can't read back the
 shape of a `node`-built tree. These two lemmas give the structural facts
 study files need — a binary node has the summed leaf count of its children
@@ -147,8 +147,8 @@ private theorem _root_.RoseTree.Nonplanar.numLeaves_node_pair {α : Type*} (a : 
 
 /-- Leaf count of a binary Merge node is the sum of its children's. -/
 theorem SyntacticObject.leafCount_node (l r : SyntacticObject) :
-    (node l r).leafCount = l.leafCount + r.leafCount := by
-  rw [leafCount, node_val, RoseTree.Nonplanar.numLeaves_node_pair]; rfl
+    (merge l r).leafCount = l.leafCount + r.leafCount := by
+  rw [leafCount, merge_val, RoseTree.Nonplanar.numLeaves_node_pair]; rfl
 
 /-- A syntactic object qualifies as a small-clause predicate iff its
     head category is one of [dendikken-1995]'s four SC-licensed
@@ -181,18 +181,18 @@ noncomputable instance : DecidablePred IsSmallClause := fun so => by
 
 /-- `IsSmallClause` at a node: the predicate is either daughter. -/
 theorem isSmallClause_node (l r : SyntacticObject) :
-    IsSmallClause (node l r) ↔ (IsSmallClausePredicate l ∨ IsSmallClausePredicate r) := by
+    IsSmallClause (merge l r) ↔ (IsSmallClausePredicate l ∨ IsSmallClausePredicate r) := by
   unfold IsSmallClause
   constructor
   · rintro ⟨pred, himm, hpred⟩
-    rw [immediatelyContains_node] at himm
+    rw [immediatelyContains_merge] at himm
     rcases himm with rfl | rfl
     · exact Or.inl hpred
     · exact Or.inr hpred
   · intro h
     rcases h with hl | hr
-    · exact ⟨l, (immediatelyContains_node l r l).mpr (Or.inl rfl), hl⟩
-    · exact ⟨r, (immediatelyContains_node l r r).mpr (Or.inr rfl), hr⟩
+    · exact ⟨l, (immediatelyContains_merge l r l).mpr (Or.inl rfl), hl⟩
+    · exact ⟨r, (immediatelyContains_merge l r r).mpr (Or.inr rfl), hr⟩
 
 /-- Round-trip: any `SmallClause` whose stored `predCat` agrees with
     its `predicate`'s actual head category yields a `SyntacticObject`

--- a/Linglib/Syntax/Minimalist/Workspace/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Basic.lean
@@ -37,7 +37,7 @@ abbrev Workspace : Type := Forest SyntacticObject
 def Workspace.chainMultiplicity (S : SyntacticObject) (W : Workspace) : Nat := W.count S
 
 /-- Two isomorphic components form a chain of two. -/
-example : Workspace.chainMultiplicity SyntacticObject.traceLeaf
-    {SyntacticObject.traceLeaf, SyntacticObject.traceLeaf} = 2 := by decide
+example : Workspace.chainMultiplicity SyntacticObject.trace
+    {SyntacticObject.trace, SyntacticObject.trace} = 2 := by decide
 
 end Minimalist


### PR DESCRIPTION
Two carriers over one alphabet: `SyntacticObject` is the well-formed unordered tree over `Vertex` and `PlanarSyntacticObject` the well-formed ordered one, MCB's planar embedding, both with `leaf`, `trace`, `traceOf`, `merge`; `toSyntacticObject` forgets the order and commutes with Merge. Well-formedness is stated once on ordered trees and lifted, so `ofPlanar` and its `decide` obligations, the planar Boolean checks, and the studies' well-formedness theorems are gone.
- Replay works on the ordered carrier; faithfulness is `p.toSyntacticObject = d.final`; `Derivation.externalize?` replaces `externalizeP?`.
- The mover's trace is `headTrace`; nonplanar `node`/`lexLeaf`/`traceLeaf` are `merge`/`leaf`/`trace`.