### PR TITLE
refactor(Syntax/Minimalist): Merge as multiplication on the ordered carrier

### DIFF
--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -33,7 +33,6 @@ judgment type off the same search, and the paper's examples are the rows, over w
 namespace AissenPolian2025
 
 open Minimalist SyntacticObject
-open RoseTree UnorderedTree
 
 /-! ### Probes -/
 
@@ -105,89 +104,63 @@ private def SubjD : SyntacticObject := leaf tSubjD
 private def ThemeD : SyntacticObject := leaf tThemeD
 
 /-- A non-specific possessive, `[PossP Psr Psm]`. -/
-private def possP : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tPsr) (PlanarSyntacticObject.leaf tPsm)
+private def possP : PlanarSyntacticObject := tPsr * tPsm
 
 /-- A specific possessive, `[DP D⁰ [PossP Psr Psm]]`. -/
-private def dp : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tD) possP
+private def dp : PlanarSyntacticObject := tD * possP
 
 /-- A locative PP over a non-specific possessive, `[PP P [PossP Psr Psm]]`. -/
-private def pp : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tP) possP
+private def pp : PlanarSyntacticObject := tP * possP
 
 /-- (9c) with a non-specific possessive S_O: `[TP T⁰ [VP V⁰ PossP]]`. -/
-private def unaccPossP : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
-  (PlanarSyntacticObject.leaf tV) possP)
+private def unaccPossP : PlanarSyntacticObject := tT * (tV * possP)
 
 /-- (9c) with a specific possessive S_O: `[TP T⁰ [VP V⁰ DP]]`. -/
-private def unaccDP : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) dp)
+private def unaccDP : PlanarSyntacticObject := tT * (tV * dp)
 
 /-- (9a) with a non-specific possessive O: `[TP T⁰ [vP Agt [v' v⁰ [VP V⁰ PossP]]]]`. -/
-private def transPossP : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tAgt) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tv)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) possP)))
+private def transPossP : PlanarSyntacticObject := tT * (tAgt * (tv * (tV * possP)))
 
 /-- (29) the raising applicative: `[vP Agt [v' v⁰ [ApplP Appl⁰ [VP V⁰ PossP]]]]` under T⁰. -/
-private def raisingAppl : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tAgt) (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tv) (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tAppl)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) possP))))
+private def raisingAppl : PlanarSyntacticObject := tT * (tAgt * (tv * (tAppl * (tV * possP))))
 
 /-- (9b) with a locative PP, `[TP T⁰ [vP S_A [v' v⁰ [VP V⁰ PP]]]]`, for a specific or a
 non-specific S_A. -/
-private def unerg (subj : LIToken) : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf subj) (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tv)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV) pp)))
+private def unerg (subj : LIToken) : PlanarSyntacticObject := tT * (subj * (tv * (tV * pp)))
 
 /-- (71) theme over locative, `[TP T⁰ [VP V⁰ [Theme PP]]]`, for a specific or a non-specific
 theme: path verbs, locative existentials and locative copulas. -/
-private def themeLoc (theme : LIToken) : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tV) (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf theme) pp))
+private def themeLoc (theme : LIToken) : PlanarSyntacticObject := tT * (tV * (theme * pp))
 
 /-- (83) the experiencer PP merged above the theme, `[TP T⁰ [VP PP [V' V⁰ Theme]]]`. -/
-private def experiencer : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge pp
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tV)
-    (PlanarSyntacticObject.leaf tThemeD)))
+private def experiencer : PlanarSyntacticObject := tT * (pp * (tV * tThemeD))
 
 /-- (40a) an existential with a bare pivot, `[TP T⁰ [VP V⁰ NP]]`. -/
-private def existential : PlanarSyntacticObject :=
-  PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tT) (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tV) (PlanarSyntacticObject.leaf tPivot))
+private def existential : PlanarSyntacticObject := tT * (tV * tPivot)
+
+/-- The clause under C⁰. -/
+private def cp (tp : PlanarSyntacticObject) : PlanarSyntacticObject := tC * tp
 
 /-! ### Nominal opacity -/
 
 /-- The possessor of a specific S_O is invisible to C⁰'s wh-probe. -/
 theorem psr_invisible_dp :
-    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tC) unaccDP)) C₀ Psr :=
+    Invisible nominalOpacity (cp unaccDP) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- So is the possessor of a non-specific S_O: opacity does not depend on size. -/
 theorem psr_invisible_possP :
-    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tC) unaccPossP)) C₀ Psr :=
+    Invisible nominalOpacity (cp unaccPossP) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- And the possessor inside a locative PP: PP islands follow from nominal opacity. -/
 theorem psr_invisible_pp :
-    Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tC) (themeLoc tThemeN))) C₀ Psr :=
+    Invisible nominalOpacity (cp (themeLoc tThemeN)) C₀ Psr :=
   ⟨.N, rfl, by decide⟩
 
 /-- The D head of a specific possessive is visible, so the whole DP can be pied-piped. -/
 theorem dHead_visible :
-    ¬ Invisible nominalOpacity (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tC) unaccDP)) C₀ D₀ :=
+    ¬ Invisible nominalOpacity (cp unaccDP) C₀ D₀ :=
   fun ⟨_, hh, hb⟩ => by
     simp only [nominalOpacity, Option.some.injEq] at hh
     exact absurd (hh ▸ hb) (by decide)
@@ -196,55 +169,43 @@ theorem dHead_visible :
 
 /-- The possessor of a non-specific S_O is T⁰'s closest D-goal: it raises to Spec,TP and can
 strand the possessum. -/
-theorem unacc_possP_psr_closest : isClosestGoalIn
-    (PlanarSyntacticObject.toSyntacticObject unaccPossP) T₀ Psr hasD := by
-  decide
+theorem unacc_possP_psr_closest : isClosestGoalIn unaccPossP T₀ Psr hasD := by decide
 
 /-- In a specific S_O the D layer is the closer goal: the whole DP raises and the possessor is
 shielded. -/
-theorem unacc_dp_dHead_closest :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject unaccDP) T₀ D₀ hasD ∧
-      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject unaccDP) T₀ Psr hasD :=
+theorem unacc_dp_dHead_closest : isClosestGoalIn unaccDP T₀ D₀ hasD ∧
+      ¬ isClosestGoalIn unaccDP T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- The agent of a transitive is the closer goal, so the possessor of O cannot reach Spec,TP. -/
-theorem trans_agt_closest :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject transPossP) T₀ Agt hasD ∧
-      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject transPossP) T₀ Psr hasD :=
+theorem trans_agt_closest : isClosestGoalIn transPossP T₀ Agt hasD ∧
+      ¬ isClosestGoalIn transPossP T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- In the raising applicative the possessor of O is Appl⁰'s closest D-goal: it externalizes to
 Spec,ApplP. -/
-theorem appl_psr_closest : isClosestGoalIn
-    (PlanarSyntacticObject.toSyntacticObject raisingAppl) Appl₀ Psr hasD := by decide
+theorem appl_psr_closest : isClosestGoalIn raisingAppl Appl₀ Psr hasD := by decide
 
 /-- A specific unergative subject stops T⁰ before the possessor inside the locative PP. -/
-theorem unerg_specific_blocks :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (unerg tSubjD)) T₀ SubjD hasD ∧
-      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (unerg tSubjD)) T₀ Psr hasD :=
+theorem unerg_specific_blocks : isClosestGoalIn (unerg tSubjD) T₀ SubjD hasD ∧
+      ¬ isClosestGoalIn (unerg tSubjD) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- A non-specific unergative subject is no DP, so the possessor is the closest goal. -/
-theorem unerg_nonspecific_psr_closest : isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject
-    (unerg tSubjN)) T₀ Psr hasD := by
-  decide
+theorem unerg_nonspecific_psr_closest : isClosestGoalIn (unerg tSubjN) T₀ Psr hasD := by decide
 
 /-- A specific theme c-commanding the locative PP raises instead of the possessor. -/
-theorem theme_specific_blocks :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (themeLoc tThemeD)) T₀ ThemeD hasD ∧
-      ¬ isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject (themeLoc tThemeD)) T₀ Psr hasD :=
+theorem theme_specific_blocks : isClosestGoalIn (themeLoc tThemeD) T₀ ThemeD hasD ∧
+      ¬ isClosestGoalIn (themeLoc tThemeD) T₀ Psr hasD :=
   ⟨by decide, by decide⟩
 
 /-- A non-specific theme lets T⁰ reach the possessor inside the PP. -/
-theorem theme_nonspecific_psr_closest :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject
-      (themeLoc tThemeN)) T₀ Psr hasD := by decide
+theorem theme_nonspecific_psr_closest : isClosestGoalIn (themeLoc tThemeN) T₀ Psr hasD := by decide
 
 /-- With the experiencer PP merged above the theme, neither c-commands the other and both are
 closest goals; the experiential reading requires the experiencer to raise. -/
-theorem experiencer_both_closest :
-    isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject experiencer) T₀ Psr hasD ∧
-      isClosestGoalIn (PlanarSyntacticObject.toSyntacticObject experiencer) T₀ ThemeD hasD :=
+theorem experiencer_both_closest : isClosestGoalIn experiencer T₀ Psr hasD ∧
+      isClosestGoalIn experiencer T₀ ThemeD hasD :=
   ⟨by decide, by decide⟩
 
 /-! ### Judgment type -/
@@ -265,33 +226,29 @@ def judgment (root probe : SyntacticObject) : JudgmentType :=
   if ∃ g ∈ root.subtrees, isClosestGoalIn root probe g hasD then .categorical else .thetic
 
 /-- An existential with a bare pivot contains no DP: the clause is thetic. -/
-theorem existential_thetic : judgment (PlanarSyntacticObject.toSyntacticObject existential) T₀
+theorem existential_thetic : judgment existential T₀
     = .thetic := by decide
 
 /-- Predicative possession is categorical, with the possessor as ψ-subject. -/
-theorem possession_categorical : judgment (PlanarSyntacticObject.toSyntacticObject unaccPossP) T₀
+theorem possession_categorical : judgment unaccPossP T₀
     = .categorical := by decide
 
 /-! ### The paper's examples -/
 
 /-- Stranding succeeds exactly when the possessum is non-specific and no DP or occupied
 external position stands between the possessor and its probe (Table 4). -/
-theorem stranding_iff :
-    ∀ row ∈ Examples.all, row.feature? "strategy" = some "stranding" →
+theorem stranding_iff : ∀ row ∈ Examples.all, row.feature? "strategy" = some "stranding" →
       (row.judgment = .acceptable ↔
         row.feature? "possessum" = some "nonSpecific" ∧
-          row.feature? "intervener" = some "none") := by
-  decide
+          row.feature? "intervener" = some "none") := by decide
 
 /-- Pied-piping succeeds only with a specific possessum, since only a DP can be wh-moved. -/
-theorem piedPiping_specific :
-    ∀ row ∈ Examples.all, row.feature? "strategy" = some "piedPiping" →
+theorem piedPiping_specific : ∀ row ∈ Examples.all, row.feature? "strategy" = some "piedPiping" →
       row.judgment = .acceptable → row.feature? "possessum" = some "specific" := by decide
 
 /-- In predicative possession and experiential collocations possessor and possessum form no
 constituent, so pied-piping is out. -/
-theorem psi_no_piedPiping :
-    ∀ row ∈ Examples.all, row.feature? "strategy" = some "piedPiping" →
+theorem psi_no_piedPiping : ∀ row ∈ Examples.all, row.feature? "strategy" = some "piedPiping" →
       (row.feature? "construction" = some "predicativePossession" ∨
         row.feature? "construction" = some "experientialCollocation") →
       row.judgment ≠ .acceptable := by decide

--- a/Linglib/Studies/Bruening2001.lean
+++ b/Linglib/Studies/Bruening2001.lean
@@ -109,14 +109,8 @@ def to_tok : LIToken := ⟨.simple .P [.D] "to", 409⟩
 /-- The double object structure `[Ozzy [v [gave [a girl [Appl every telescope]]]]]`: the first
 object is the argument of the applicative head, merged above the projection containing the second,
 so it asymmetrically c-commands it. -/
-def docTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subj_tok)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf goal_tok)
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf appl_tok)
-            (PlanarSyntacticObject.leaf theme_tok))))))
+def docTree : PlanarSyntacticObject :=
+  (subj_tok * (v_tok * (gave_tok * (goal_tok * (appl_tok * theme_tok)))))
 
 /-- The quantifiers competing for attraction in the double object construction. -/
 def docQuantifiers : List SyntacticObject := [leaf goal_tok, leaf theme_tok]
@@ -146,28 +140,19 @@ theorem doc_not_ambiguous : ¬ Ambiguous docTree (leaf v_tok) docQuantifiers := 
 
 /-- The locative structure `[Ozzy [v [gave [every telescope [to a girl]]]]]`: the direct object and
 the PP are co-arguments of the same head, hence sisters, and c-command each other. -/
-def locativeTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subj_tok)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf theme_tok)
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf to_tok)
-            (PlanarSyntacticObject.leaf goal_tok))))))
+def locativeTree : PlanarSyntacticObject :=
+  (subj_tok * (v_tok * (gave_tok * (theme_tok * (to_tok * goal_tok)))))
+
+/-- The PP that pied-pipes the goal. -/
+def ppToGoal : PlanarSyntacticObject := to_tok * goal_tok
 
 /-- The candidates in the locative: the direct object, and the PP that pied-pipes the goal. -/
-def locativeQuantifiers : List SyntacticObject :=
-  [leaf theme_tok, PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok))]
+def locativeQuantifiers : List SyntacticObject := [leaf theme_tok, ppToGoal]
 
 /-- Direct object and PP c-command each other, so neither asymmetrically c-commands the other. -/
 theorem locative_mutual_cCommand :
-    cCommandsIn locativeTree (leaf theme_tok)
-        (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-          (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok))) ∧
-      cCommandsIn locativeTree (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-        (PlanarSyntacticObject.leaf to_tok) (PlanarSyntacticObject.leaf goal_tok)))
-        (leaf theme_tok) := by
+    cCommandsIn locativeTree (leaf theme_tok) ppToGoal ∧
+      cCommandsIn locativeTree ppToGoal (leaf theme_tok) := by
   constructor <;> decide
 
 /-- Either candidate may be attracted first, so the locative is ambiguous: *I gave a doll to each
@@ -188,13 +173,8 @@ theorem subject_not_attractable :
 
 /-- The passive of a double object construction: with no external argument, the goal raises to the
 subject position, out of the attractor's domain, leaving the theme as the only candidate. -/
-def passiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf goal_tok)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_tok)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf gave_tok)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf appl_tok)
-          (PlanarSyntacticObject.leaf theme_tok)))))
+def passiveTree : PlanarSyntacticObject :=
+  (goal_tok * (v_tok * (gave_tok * (appl_tok * theme_tok))))
 
 /-- In the passive the derived subject is no longer attractable while the theme is, so Shortest
 imposes no order between them and the ambiguity returns: *a (different) girl was given every

--- a/Linglib/Studies/Chomsky1981.lean
+++ b/Linglib/Studies/Chomsky1981.lean
@@ -99,12 +99,11 @@ private def wordTok (w : Word) (id : Nat) : LIToken :=
     `{subj, verb}`. C-command follows from the geometry. Built planar-first so
     the containment / c-command decision procedures reduce. -/
 def toSyntacticObject (clause : SimpleClause) : SyntacticObject :=
-  let subjP := PlanarSyntacticObject.leaf (wordTok clause.subject 0)
-  let verbP := PlanarSyntacticObject.leaf (wordTok clause.verb 1)
+  let subjP : PlanarSyntacticObject := wordTok clause.subject 0
+  let verbP : PlanarSyntacticObject := wordTok clause.verb 1
   match clause.object with
-  | none => PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge subjP verbP)
-  | some obj => PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge subjP
-    (PlanarSyntacticObject.merge verbP (PlanarSyntacticObject.leaf (wordTok obj 2))))
+  | none => ↑(subjP * verbP)
+  | some obj => ↑(subjP * (verbP * wordTok obj 2))
 
 private def subjectSO (clause : SimpleClause) : SyntacticObject :=
   leaf (wordTok clause.subject 0)

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -136,7 +136,7 @@ structure Stage where
 the overt noun to the left edge. -/
 private def step (m : LIToken) (st : Stage) : List Stage :=
   let d : Derivation := ⟨st.derivation.initial, st.derivation.steps ++ [.emL (leaf m)]⟩
-  let p := PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf m) st.planar
+  let p := m * st.planar
   ⟨d, p, st.marks, st.raises⟩ ::
     ((subtrees st.planar.val).filter hasN).filterMap fun s =>
       if h : IsSyntacticObject (UnorderedTree.mk s) then

--- a/Linglib/Studies/CitkoGracaninYuksek2025.lean
+++ b/Linglib/Studies/CitkoGracaninYuksek2025.lean
@@ -79,50 +79,44 @@ def saw := tok 20 .V [.D] "saw"
 /-- `[CP wh [C′ c [TP subj [T′ T [vP wh [v′ v VP]]]]]]`: the wh-phrase moved through the edge of
 vP. -/
 def clause (wh c subj T v : LIToken) (VP : PlanarSyntacticObject) : PlanarSyntacticObject :=
-  merge (leaf wh) (merge (leaf c)
-    (merge (leaf subj) (merge (leaf T) (merge (traceOf wh) (merge (leaf v) VP)))))
+  wh * (c * (subj * (T * (traceOf wh * (v * VP)))))
 
 /-- Non-bulk sharing under the complementizers `c₁` and `c₂`: each wh-phrase in its own
 conjunct, the subject, T, v and verb shared ((10b), (14), (16b), (38d), (45b), (46b)). -/
 def nonBulk (c₁ c₂ : LIToken) : PlanarSyntacticObject :=
-  merge (clause what c₁ you T v (merge (leaf teach) (traceOf what)))
-    (clause when c₂ you T v (merge (leaf teach) (traceOf when)))
+  (clause what c₁ you T v (teach * traceOf what)) * (clause when c₂ you T v (teach * traceOf when))
 
 /-- Bulk sharing: one C′ under both wh-phrases, both of which moved through its vP edge ((12b),
 (20b)). -/
 def bulk (c : LIToken) : PlanarSyntacticObject :=
-  let c' := merge (leaf c) (merge (leaf you) (merge (leaf T) (merge (traceOf what)
-    (merge (traceOf when)
-      (merge (leaf v) (merge (merge (leaf teach) (traceOf what)) (traceOf when)))))))
-  merge (merge (leaf what) c') (merge (leaf when) c')
+  let c' := c * (you * (T * (traceOf what * (traceOf when * (v * ((teach * traceOf what) *
+    traceOf when))))))
+  (what * c') * (when * c')
 
 /-- Footnote 21's alternative to `bulk`: a shared TP under two complementizers. -/
 def bulkTP (c₁ c₂ : LIToken) : PlanarSyntacticObject :=
-  let tp := merge (leaf you) (merge (leaf T) (merge (traceOf what)
-    (merge (traceOf when)
-      (merge (leaf v) (merge (merge (leaf teach) (traceOf what)) (traceOf when))))))
-  merge (merge (leaf what) (merge (leaf c₁) tp)) (merge (leaf when) (merge (leaf c₂) tp))
+  let tp := you * (T * (traceOf what * (traceOf when * (v * ((teach * traceOf what) *
+    traceOf when)))))
+  (what * (c₁ * tp)) * (when * (c₂ * tp))
 
 /-- Two clauses from separate tokens, the first elided under its [E] complementizer with its
 auxiliary in T, as the Sluicing-COMP generalization requires of a sluice: the ellipsis analysis
 of the coordinated wh-question (11b). -/
 def cwhEllipsis : PlanarSyntacticObject :=
-  merge (merge (leaf what) (merge (leaf cE) (merge (leaf you) (merge (leaf shouldT)
-      (merge (traceOf what) (merge (leaf v) (merge (leaf teach) (traceOf what))))))))
-    (clause when should you' T' v' (merge (leaf teach') (traceOf when)))
+  (what * (cE * (you * (shouldT * (traceOf what * (v * (teach * traceOf what))))))) *
+    (clause when should you' T' v' (teach' * traceOf when))
 
 /-- Two clauses from separate tokens, both elided, the second's object the pronoun of vehicle
 change: the double-ellipsis analysis of the coordinated sluice (19b). -/
 def csEllipsis : PlanarSyntacticObject :=
-  merge (clause what cE you T v (merge (leaf teach) (traceOf what)))
-    (clause when cE' you' T' v' (merge (merge (leaf teach') (leaf it)) (traceOf when)))
+  (clause what cE you T v (teach * traceOf what)) * (clause when cE' you' T' v' ((teach' * it) *
+    traceOf when))
 
 /-- A multiple question, both wh-phrases fronted through the vP edge: (28b), and the multiple
 sluice (29b) under an [E] complementizer. -/
 def multipleQuestion (c : LIToken) : PlanarSyntacticObject :=
-  merge (leaf who) (merge (leaf what) (merge (leaf c) (merge (traceOf who) (merge (leaf T)
-    (merge (traceOf who)
-      (merge (traceOf what) (merge (leaf v) (merge (leaf saw) (traceOf what)))))))))
+  who * (what * (c * (traceOf who * (T * (traceOf who * (traceOf what * (v * (saw *
+    traceOf what))))))))
 
 /-- The coordinated wh-question (10b), its complementizer shared. -/
 abbrev cwh := nonBulk should should
@@ -270,29 +264,29 @@ def different' := tok 33 .A (phon := "different")
 def topics' := tok 34 .N (phon := "topics")
 
 /-- The pivot, `on different topics`. -/
-def pivot : PlanarSyntacticObject := merge (leaf on) (merge (leaf different) (leaf topics))
+def pivot : PlanarSyntacticObject := on * (different * topics)
 
 /-- `[TP subj [T′ T VP]]`. -/
 def tp (subj T : LIToken) (VP : PlanarSyntacticObject) : PlanarSyntacticObject :=
-  merge (leaf subj) (merge (leaf T) VP)
+  subj * (T * VP)
 
 /-- (53b), after the pruning of [belk-neeleman-philip-2023] that removes the shared pivot from
 the first conjunct: the first verb phrase, the bare verb, elided under [E] on `must`. -/
 def rnrMixed : PlanarSyntacticObject :=
-  merge (tp alice mustE (leaf work)) (tp iris oughtToBe (merge (leaf working) pivot))
+  (tp alice mustE (leaf work)) * (tp iris oughtToBe (working * pivot))
 /-- (54): the first verb phrase built with its own pivot and elided. -/
 def rnrElided : PlanarSyntacticObject :=
   merge
     (tp alice mustE
-      (merge (leaf work) (merge (leaf on') (merge (leaf different') (leaf topics')))))
-    (tp iris oughtToBe (merge (leaf working) pivot))
+      (work * (on' * (different' * topics'))))
+    (tp iris oughtToBe (working * pivot))
 /-- (55b): with matching verbs, the verb phrase shared. -/
 def rnrShared : PlanarSyntacticObject :=
-  let VP := merge (leaf work) pivot
-  merge (tp alice must VP) (tp iris shouldRNR VP)
+  let VP := work * pivot
+  (tp alice must VP) * (tp iris shouldRNR VP)
 /-- The rival of (55b) with the shape of (53b). -/
 def rnrMatchedMixed : PlanarSyntacticObject :=
-  merge (tp alice mustE (leaf work)) (tp iris shouldRNR (merge (leaf working) pivot))
+  (tp alice mustE (leaf work)) * (tp iris shouldRNR (working * pivot))
 
 theorem rnrMixed_pf : pfPhon rnrMixed =
     ["Alice", "must", "Iris", "ought to be", "working", "on", "different", "topics"] := by decide

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -39,8 +39,7 @@ On the MCB-faithful `SyntacticObject` carrier, Merge (`SyntacticObject.merge`/`*
 so `SyntacticObject.Derivation.final`/`.stageAt` do not `decide`. The computable layers —
 `movedItems` and the externalized surface order (`surfacePhon`) — are proved
 over the `SyntacticObject.Derivation` directly. The c-command predictions are stated over
-the **derived/base trees built planar-first** (`(PlanarSyntacticObject.merge
-…)`),
+the **derived/base trees built ordered** (products of tokens),
 i.e. the very trees each derivation produces, written out explicitly per the
 prose diagrams; c-command (`SyntacticObject.cCommandsIn`) reduces on those.
 
@@ -127,13 +126,11 @@ private def tok_t          : LIToken := ⟨.simple .T [.v], 5⟩
 
 /-- The VP constituent `[VP V Obj]` — the phrase that raises. Built
     planar-first so containment over it `decide`s. -/
-def vp : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tok_mangatuk) (PlanarSyntacticObject.leaf tok_biangi))
+def vp : PlanarSyntacticObject :=
+   (tok_mangatuk * tok_biangi)
 
 /-- The VP as a planar subtree (for embedding in larger result trees). -/
-private def vpP : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tok_mangatuk) (PlanarSyntacticObject.leaf tok_biangi)
+private def vpP : PlanarSyntacticObject := tok_mangatuk * tok_biangi
 
 -- ============================================================================
 -- § 2: Toba Batak VOS Derivation
@@ -159,22 +156,16 @@ def tobaBatakVOS : Derivation :=
 
 /-- The VOS **base** tree at stage 4 (pre-movement):
     `[TP T [vP Subj [v' v [VP V Obj]]]]`. Built planar-first. -/
-def tobaBatakBaseTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_dakdanakan)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v) vpP)))
+def tobaBatakBaseTree : PlanarSyntacticObject :=
+  
+    (tok_t * (tok_dakdanakan * (tok_v * vpP)))
 
 /-- The VOS **derived** tree after VP-raising:
     `[TP [VP V Obj] [T' T [vP Subj [v' v tVP]]]]`. The raised VP sits at
     the left edge; the original VP position is the bare trace. -/
-def tobaBatakDerivedTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge vpP
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_dakdanakan)
-          (PlanarSyntacticObject.merge
-            (PlanarSyntacticObject.leaf tok_v) PlanarSyntacticObject.trace))))
+def tobaBatakDerivedTree : PlanarSyntacticObject :=
+  
+    (vpP * (tok_t * (tok_dakdanakan * (tok_v * PlanarSyntacticObject.trace))))
 
 -- ============================================================================
 -- § 3: English SVO Derivation (Comparison)
@@ -208,13 +199,9 @@ def englishSVO : Derivation :=
 /-- The English SVO **base** tree at stage 4 (pre-movement):
     `[TP T [vP John [v' v [VP saw Mary]]]]`. Built planar-first; same shape
     as `tobaBatakBaseTree`, modulo lexical content. -/
-def englishBaseTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t2)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john_en)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v2)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_saw)
-            (PlanarSyntacticObject.leaf tok_mary_en)))))
+def englishBaseTree : PlanarSyntacticObject :=
+  
+    (tok_t2 * (tok_john_en * (tok_v2 * (tok_saw * tok_mary_en))))
 
 -- ============================================================================
 -- § 4: Word Order Predictions
@@ -234,8 +221,9 @@ theorem english_is_svo :
     noncomputable on the `SyntacticObject` carrier; the planar-built base trees are the
     trees those stages produce). -/
 theorem same_base_counts :
-    tobaBatakBaseTree.nodeCount = englishBaseTree.nodeCount ∧
-    tobaBatakBaseTree.leafCount = englishBaseTree.leafCount := by
+    tobaBatakBaseTree.toSyntacticObject.nodeCount = englishBaseTree.toSyntacticObject.nodeCount ∧
+    tobaBatakBaseTree.toSyntacticObject.leafCount
+      = englishBaseTree.toSyntacticObject.leafCount := by
   refine ⟨?_, ?_⟩ <;> decide
 
 /-- Toba Batak moves the VP (one moved item). -/
@@ -604,11 +592,9 @@ private def tok_v_pass     : LIToken := ⟨.simple .v [.V], 24⟩
 private def tok_t_pass     : LIToken := ⟨.simple .T [.v], 25⟩
 
 /-- The passive VP: `[VP patient [V' V agent-PP]]`. Built planar-first. -/
-def vp_passive : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_boy) (PlanarSyntacticObject.merge
-      (PlanarSyntacticObject.leaf tok_injured)
-      (PlanarSyntacticObject.leaf tok_by_himself)))
+def vp_passive : PlanarSyntacticObject :=
+  
+    (tok_boy * (tok_injured * tok_by_himself))
 
 /-- English passive derivation (trees 97–100 of the paper).
 
@@ -632,14 +618,10 @@ def englishPassive : Derivation :=
     `[TP patient [T' T [vP v [VP t [V' V agent]]]]]`. The patient (raised)
     sits at the top edge above its base trace; the agent is a low
     complement of V. -/
-def englishPassiveDerivedTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_boy)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_t_pass)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_v_pass)
-          (PlanarSyntacticObject.merge PlanarSyntacticObject.trace
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_injured)
-              (PlanarSyntacticObject.leaf tok_by_himself))))))
+def englishPassiveDerivedTree : PlanarSyntacticObject :=
+  
+    (tok_boy * (tok_t_pass * (tok_v_pass * (PlanarSyntacticObject.trace * (tok_injured *
+      tok_by_himself)))))
 
 /-- English passive yields patient-verb-agent surface order. -/
 theorem english_passive_order :

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -450,17 +450,11 @@ private def cTok       : LIToken := ⟨.simple .C [.T] "", 6⟩
     so concrete `decide`-able trees use the planar DSL): the oblique DP undergoes
     successive-cyclic Ā-movement, surfacing at Spec,CP with a trace lower down.
     Structure: `[CP oblique [C' C [TP T [VoiceP oblique [Voice' Voice [VP V obj]]]]]]`. -/
-private def cp : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf obliqueTok)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf cTok)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tTok)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf obliqueTok)
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceTok)
-              (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf verbTok)
-                (PlanarSyntacticObject.leaf objectTok)))))))
+private def cp : PlanarSyntacticObject :=
+  
+    (obliqueTok * (cTok * (tTok * (obliqueTok * (voiceTok * (verbTok * objectTok))))))
 
-theorem derivation_tree_size : cp.nodeCount = 6 := by decide
+theorem derivation_tree_size : cp.toSyntacticObject.nodeCount = 6 := by decide
 
 theorem voice_has_uOblique :
     mamVoice.features.hasUnvaluedFeature .oblique = true := by decide

--- a/Linglib/Studies/Kratzer1996.lean
+++ b/Linglib/Studies/Kratzer1996.lean
@@ -75,40 +75,27 @@ def DP_door_t   : LIToken := ⟨.simple .D     []    "the door",   217⟩
 
 /-- Transitive: "John broke the vase"
     `[VoiceP John [Voice' Voice_AG [vP v [VP broke [DP the vase]]]]]` -/
-def transitiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf DP_john_t)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_ag_t)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_broke_t)
-            (PlanarSyntacticObject.leaf DP_vase_t)))))
+def transitiveTree : PlanarSyntacticObject :=
+  
+    (DP_john_t * (voice_ag_t * (v_head_t * (V_broke_t * DP_vase_t))))
 
 /-- Anticausative: "The vase broke"
     `[VoiceP Voice_∅ [vP v [VP broke [DP the vase]]]]` -/
-def anticausativeTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_nth_t)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_broke_t)
-          (PlanarSyntacticObject.leaf DP_vase_t))))
+def anticausativeTree : PlanarSyntacticObject :=
+  
+    (voice_nth_t * (v_head_t * (V_broke_t * DP_vase_t)))
 
 /-- Unaccusative: "The ship sank"
     `[VoiceP Voice_∅ [vP v [VP sank [DP the ship]]]]` -/
-def unaccusativeTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_nth_t)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_sank_t)
-          (PlanarSyntacticObject.leaf DP_ship_t))))
+def unaccusativeTree : PlanarSyntacticObject :=
+  
+    (voice_nth_t * (v_head_t * (V_sank_t * DP_ship_t)))
 
 /-- Middle: "The door opened"
     `[VoiceP Voice_MID [vP v [VP opened [DP the door]]]]` -/
-def middleTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voice_mid_t)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v_head_t)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V_opened_t)
-          (PlanarSyntacticObject.leaf DP_door_t))))
+def middleTree : PlanarSyntacticObject :=
+  
+    (voice_mid_t * (v_head_t * (V_opened_t * DP_door_t)))
 
 -- C-command predictions
 

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -49,7 +49,7 @@ so
 are proved over the `SyntacticObject.Derivation` directly.
 
 The c-command asymmetries are stated over the **derived tree built
-planar-first** (`(PlanarSyntacticObject.merge …).toSyntacticObject`), i.e. the very tree each
+ordered**, as a product of tokens coerced to a syntactic object, i.e. the very tree each
 derivation produces, written out explicitly per the file's prose diagrams.
 This is faithful: the derivation records the operations; the planar tree
 is its result, and c-command (`SyntacticObject.cCommandsIn`) reduces on it.
@@ -103,8 +103,7 @@ private def tok_kick   : LIToken := ⟨.simple .V [.D] (phonForm := "kicked"), 3
 private def tok_ball   : LIToken := ⟨.simple .D [] (phonForm := "the ball"), 311⟩
 
 /-- The `[PP to Mary]` constituent as a planar subtree. -/
-private def ppToMaryP : PlanarSyntacticObject := PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tok_to) (PlanarSyntacticObject.leaf tok_mary)
+private def ppToMaryP : PlanarSyntacticObject := tok_to * tok_mary
 
 -- ============================================================================
 -- § 2: Oblique Dative Derivation
@@ -122,18 +121,16 @@ private def ppToMaryP : PlanarSyntacticObject := PlanarSyntacticObject.merge
 def obliqueDative : Derivation :=
   { initial := V_send
     steps := [
-      .emR (PlanarSyntacticObject.toSyntacticObject ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .emL DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
     ] }
 
 /-- The oblique dative result tree: `[John [letter [send [to Mary]]]]`.
     Built planar-first; this is exactly what `obliqueDative` produces. -/
-def obliqueDativeTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_send) ppToMaryP)))
+def obliqueDativeTree : PlanarSyntacticObject :=
+  
+    (tok_john * (tok_letter * (tok_send * ppToMaryP)))
 
 -- Oblique dative c-command predictions
 
@@ -171,7 +168,7 @@ Derivation steps:
 def docDativeShift : Derivation :=
   { initial := V_send
     steps := [
-      .emR (PlanarSyntacticObject.toSyntacticObject ppToMaryP),  -- [V' send [PP to Mary]]
+      .emR (ppToMaryP),  -- [V' send [PP to Mary]]
       .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .im DP_mary,                    -- DATIVE SHIFT: Mary moves to Spec
       .emL DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
@@ -180,14 +177,9 @@ def docDativeShift : Derivation :=
 /-- The DOC result tree: Mary, internally merged, sits at the left edge of
     the shell, asymmetrically c-commanding the theme; the original Mary
     position is the bare trace. `[John [Mary [letter [send [to t]]]]]`. -/
-def docDativeShiftTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_mary)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_send)
-            (PlanarSyntacticObject.merge
-              (PlanarSyntacticObject.leaf tok_to) PlanarSyntacticObject.trace)))))
+def docDativeShiftTree : PlanarSyntacticObject :=
+  
+    (tok_john * (tok_mary * (tok_letter * (tok_send * (tok_to * PlanarSyntacticObject.trace)))))
 
 -- DOC c-command predictions: the asymmetries are REVERSED
 
@@ -228,12 +220,9 @@ def standardPassive : Derivation :=
 
 /-- The passive result tree: the ball (promoted) sits above John (demoted),
     leaving a trace in object position. `[ball [John [kicked t]]]`. -/
-def standardPassiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_ball)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_john)
-        (PlanarSyntacticObject.merge
-          (PlanarSyntacticObject.leaf tok_kick) PlanarSyntacticObject.trace)))
+def standardPassiveTree : PlanarSyntacticObject :=
+  
+    (tok_ball * (tok_john * (tok_kick * PlanarSyntacticObject.trace)))
 
 -- Passive c-command: promoted object c-commands demoted subject
 
@@ -466,8 +455,7 @@ private def tok_to2     : LIToken := ⟨.simple .P [.D] (phonForm := "to"), 323�
 def indirectPassive : Derivation :=
   { initial := V_sent
     steps := [
-      .emR (PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-        (PlanarSyntacticObject.leaf tok_to2) (PlanarSyntacticObject.leaf tok_mary2))),
+      .emR (tok_to2 * tok_mary2 : PlanarSyntacticObject),
                        -- [V' sent [PP to Mary]]
       .emL DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
       .im DP_mary2,    -- DATIVE SHIFT: Mary to inner Spec
@@ -484,14 +472,10 @@ def indirectPassive : Derivation :=
     (The single-trace abbreviation `[Mary [letter [sent [to t]]]]` collapses the
     intermediate landing site; it gives the same Mary-c-commands-letter
     asymmetry but is *not* what the two-step derivation emits.) -/
-def indirectPassiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_mary2)
-      (PlanarSyntacticObject.merge PlanarSyntacticObject.trace
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_letter2)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf tok_sent)
-            (PlanarSyntacticObject.merge
-              (PlanarSyntacticObject.leaf tok_to2) PlanarSyntacticObject.trace)))))
+def indirectPassiveTree : PlanarSyntacticObject :=
+  
+    (tok_mary2 * (PlanarSyntacticObject.trace * (tok_letter2 * (tok_sent * (tok_to2 *
+      PlanarSyntacticObject.trace)))))
 
 /-- In the indirect passive, the promoted IO (Mary) c-commands the
     stranded DO (a letter). -/

--- a/Linglib/Studies/Newman2024.lean
+++ b/Linglib/Studies/Newman2024.lean
@@ -747,7 +747,7 @@ theorem impersonal_passive_converges : passiveV.features.hasD = false := rfl
 -- c-commands the other → symmetric binding (either can passivize).
 
 -- Concrete trees are built **planar-first**
--- (`PlanarSyntacticObject.merge`/`leaf`, then `toSyntacticObject`)
+-- (products of tokens, coerced to syntactic objects)
 -- because Merge (`SyntacticObject.merge`) is noncomputable; the c-command decision procedure
 -- then reduces under `decide`. Each leaf is a lexical leaf over a token, and the
 -- tree references the same tokens via the planar DSL so the two match
@@ -767,13 +767,8 @@ private def agent₁ : LIToken := tok .D "agent" 12
 private def DO₁ : LIToken := tok .D "DO" 13
 private def XP₁ : LIToken := tok .P "to-Mary" 14
 
-def lowXPTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf agent₁)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v₁)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf DO₁)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf V₁)
-          (PlanarSyntacticObject.leaf XP₁)))))
+def lowXPTree : PlanarSyntacticObject :=
+   (agent₁ * (v₁ * (DO₁ * (V₁ * XP₁))))
 
 -- DOC ditransitive: V: [·D·], v: [·D·][·X·][·V·]
 -- Structure: [vP VP [vP agent [v' v IO]]]
@@ -786,12 +781,8 @@ private def agent₂ : LIToken := tok .D "agent" 22
 private def DO₂ : LIToken := tok .D "DO" 23
 private def IO₂ : LIToken := tok .D "IO" 24
 
-def docTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf V₂) (PlanarSyntacticObject.leaf DO₂))
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf agent₂)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf v₂)
-        (PlanarSyntacticObject.leaf IO₂))))
+def docTree : PlanarSyntacticObject :=
+   ((V₂ * DO₂) * (agent₂ * (v₂ * IO₂)))
 
 -- § 10a: Internal argument binding asymmetry
 

--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -157,9 +157,8 @@ def subjectAtSpecVoiceP : SyntacticObject := leaf subjectToken
 /-- A trace at the base position after movement (distinct LIToken). -/
 def subjectTrace : SyntacticObject := leaf subjectTraceToken
 
-/-! The trees below are built **planar-first** via the DSL
-  (`PlanarSyntacticObject.toSyntacticObject`
-    / `PlanarSyntacticObject.merge` / `PlanarSyntacticObject.leaf`) because the smart Merge
+/-! The trees below are built **ordered**, as products of tokens coerced to syntactic
+    objects, because the smart Merge
     `SyntacticObject.merge` is
     noncomputable; planar construction keeps the `decide` PIC proofs
     reducing. -/
@@ -167,22 +166,15 @@ def subjectTrace : SyntacticObject := leaf subjectTraceToken
 /-- The Voice projection with NO Spec,VoiceP — subject remains in vP.
     Structure: `voice (subject v)`. Voice is the phase; its complement
     is the entire vP, which contains the subject. -/
-def voiceP_noSpec : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf voiceToken)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
-      (PlanarSyntacticObject.leaf vToken)))
+def voiceP_noSpec : PlanarSyntacticObject :=
+   (voiceToken * (subjectToken * vToken))
 
 /-- The Voice projection with subject at Spec,VoiceP (phase edge).
     Structure: `subject (voice (trace v))`. The OUTER node is not the
     phase; the inner `voice (trace v)` is the phase, and the subject
     (sister to it) is at the edge. -/
-def voiceP_withSpec : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf subjectToken)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectTraceToken)
-        (PlanarSyntacticObject.leaf vToken))))
+def voiceP_withSpec : PlanarSyntacticObject :=
+   (subjectToken * (voiceToken * (subjectTraceToken * vToken)))
 
 /-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
     `voiceP_noSpec`. Its interior (= the head's c-command domain, the
@@ -198,26 +190,15 @@ def voicePhase_withSpec : Phase :=
   { tree := voiceP_withSpec, head := voiceToken }
 
 /-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
-def auxVTree_inSitu : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tToken)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf aspToken)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
-          (PlanarSyntacticObject.leaf vToken)))))
+def auxVTree_inSitu : PlanarSyntacticObject :=
+   (tToken * (aspToken * (voiceToken * (subjectToken * vToken))))
 
 /-- The full Aux-V tree with subject moved to Spec,VoiceP. T's probe will
     additionally attract the subject to Spec,TP — that movement is the
     derivational step we don't model here; the salient question is just
     whether T's probe *finds* the subject under PIC. -/
-def auxVTree_subjectMoved : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject (PlanarSyntacticObject.merge
-    (PlanarSyntacticObject.leaf tToken)
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf aspToken)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectToken)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf voiceToken)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf subjectTraceToken)
-            (PlanarSyntacticObject.leaf vToken))))))
+def auxVTree_subjectMoved : PlanarSyntacticObject :=
+   (tToken * (aspToken * (subjectToken * (voiceToken * (subjectTraceToken * vToken)))))
 
 end Sample
 

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -363,7 +363,7 @@ def DP_food_t   := mkLeafPhon .D     []      "food"        410
 
 /-! Planar leaf tokens, used to build the concrete trees the c-command
     theorems reason over (Merge `SyntacticObject.merge` is noncomputable; trees are
-    built planar-first via `PlanarSyntacticObject.toSyntacticObject`). -/
+    built ordered, as products of tokens, and coerced). -/
 
 private def t_voice_ag  : LIToken := ⟨.simple .Voice [.V] (phonForm := "Voice[AG]"), 400⟩
 private def t_appl_low  : LIToken := ⟨.simple .Appl [.D] (phonForm := "Appl[LOW]"), 402⟩
@@ -389,14 +389,9 @@ private def t_DP_food   : LIToken := ⟨.simple .D [] (phonForm := "food"), 410�
     complement of Appl. This derives the [barss-lasnik-1986]
     asymmetry that IO asymmetrically c-commands DO. Built planar-first
     so the c-command theorems `decide`. -/
-def ditransitiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_john)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_voice_ag)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_V_sent)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_mary)
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_appl_low)
-              (PlanarSyntacticObject.leaf t_DP_letter))))))
+def ditransitiveTree : PlanarSyntacticObject :=
+  
+    (t_DP_john * (t_voice_ag * (t_V_sent * (t_DP_mary * (t_appl_low * t_DP_letter)))))
 
 /-- High applicative benefactive (Chaga pattern): "he ate food for wife"
 
@@ -406,14 +401,9 @@ def ditransitiveTree : SyntacticObject :=
     benefactive (wife) is in Spec-ApplP, relating to the event (not the
     theme). High Appl is attested in Bantu languages (Chaga, Luganda,
     Venda) and Albanian, but NOT in English. -/
-def benefactiveTree : SyntacticObject :=
-  PlanarSyntacticObject.toSyntacticObject
-    (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_john)
-      (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_voice_ag)
-        (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_DP_wife)
-          (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_appl_high)
-            (PlanarSyntacticObject.merge (PlanarSyntacticObject.leaf t_V_eat)
-              (PlanarSyntacticObject.leaf t_DP_food))))))
+def benefactiveTree : PlanarSyntacticObject :=
+  
+    (t_DP_john * (t_voice_ag * (t_DP_wife * (t_appl_high * (t_V_eat * t_DP_food)))))
 
 -- ============================================================================
 -- § 3: C-command Predictions

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -298,9 +298,7 @@ private def guebieVerbLeaf : SyntacticObject := leaf guebieVerbTok
 /-- The remnant VP of the verb-doubling configuration ((31)): an evacuation trace
     plus the verb copy, pronounced for recoverability per [koopman-1997]. -/
 private def guebieFrontedVP : SyntacticObject :=
-  Minimalist.PlanarSyntacticObject.toSyntacticObject
-    (Minimalist.PlanarSyntacticObject.merge Minimalist.PlanarSyntacticObject.trace
-      (Minimalist.PlanarSyntacticObject.leaf guebieVerbTok))
+  ↑(Minimalist.PlanarSyntacticObject.trace * guebieVerbTok)
 
 private def guebieLandingTok : LIToken := ⟨.simple .C [], 2⟩
 private def guebieLandingSite : SyntacticObject := leaf guebieLandingTok

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
@@ -151,7 +151,7 @@ instance : DecidableEq PlanarSyntacticObject := Subtype.instDecidableEq
 namespace SyntacticObject
 
 /-- A lexical leaf. -/
-def leaf (tok : LIToken) : SyntacticObject := ⟨UnorderedTree.leaf (Sum.inl tok), rfl⟩
+@[coe] def leaf (tok : LIToken) : SyntacticObject := ⟨UnorderedTree.leaf (Sum.inl tok), rfl⟩
 
 /-- The bare trace: a childless bare vertex, the mark an admissible cut leaves in the remaining
     tree ([marcolli-chomsky-berwick-2025], Definition 1.2.6). It carries no index; `traceOf` is
@@ -202,7 +202,7 @@ namespace PlanarSyntacticObject
 open SyntacticObject (Vertex wellFormed wellFormed_merge)
 
 /-- A lexical leaf. -/
-def leaf (tok : LIToken) : PlanarSyntacticObject := ⟨.node (Sum.inl tok) [], rfl⟩
+@[coe] def leaf (tok : LIToken) : PlanarSyntacticObject := ⟨.node (Sum.inl tok) [], rfl⟩
 
 /-- The bare trace. -/
 def trace : PlanarSyntacticObject := ⟨.node (Sum.inr none) [], by decide⟩
@@ -224,7 +224,8 @@ def merge (l r : PlanarSyntacticObject) : PlanarSyntacticObject :=
     (merge l r).val = .node (Sum.inr none) [l.val, r.val] := rfl
 
 /-- Forgetting the order: the quotient map to the syntactic object. -/
-def toSyntacticObject (p : PlanarSyntacticObject) : SyntacticObject := ⟨UnorderedTree.mk p.val, p.2⟩
+@[coe] def toSyntacticObject (p : PlanarSyntacticObject)
+  : SyntacticObject := ⟨UnorderedTree.mk p.val, p.2⟩
 
 @[simp] theorem toSyntacticObject_val (p : PlanarSyntacticObject) :
     p.toSyntacticObject.val = UnorderedTree.mk p.val := rfl

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -38,6 +38,39 @@ noncomputable instance : Mul SyntacticObject := ⟨merge⟩
 
 theorem mul_comm (l r : SyntacticObject) : l * r = r * l := merge_comm l r
 
+/-- A lexical item is a leaf. -/
+instance : Coe LIToken SyntacticObject := ⟨leaf⟩
+
+end SyntacticObject
+
+namespace PlanarSyntacticObject
+
+/-- `l * r = merge l r`: Merge on the ordered carrier, in the given order. -/
+instance : Mul PlanarSyntacticObject := ⟨merge⟩
+
+@[simp] theorem mul_def (l r : PlanarSyntacticObject) : l * r = merge l r := rfl
+
+/-- A lexical item is a leaf. -/
+instance : Coe LIToken PlanarSyntacticObject := ⟨leaf⟩
+
+/-- An ordered object is an object. -/
+instance : Coe PlanarSyntacticObject SyntacticObject := ⟨toSyntacticObject⟩
+
+/-- Forgetting the order is a homomorphism of magmas. -/
+def toSyntacticObjectHom : PlanarSyntacticObject →ₙ* SyntacticObject :=
+  ⟨toSyntacticObject, toSyntacticObject_merge⟩
+
+@[simp] theorem toSyntacticObjectHom_apply (p : PlanarSyntacticObject) :
+    toSyntacticObjectHom p = p.toSyntacticObject := rfl
+
+@[simp] theorem toSyntacticObject_mul (l r : PlanarSyntacticObject) :
+    (l * r).toSyntacticObject = l.toSyntacticObject * r.toSyntacticObject :=
+  toSyntacticObject_merge l r
+
+end PlanarSyntacticObject
+
+namespace SyntacticObject
+
 /-! ### Lexical leaves from features -/
 
 /-- A lexical leaf from a category and selectional stack. -/


### PR DESCRIPTION
Merge is written `*` on `PlanarSyntacticObject` as it already was on `SyntacticObject`, lexical items coerce to leaves, and ordered objects coerce to syntactic objects, with `toSyntacticObjectHom` the magma homomorphism. A study's structure is now `tT * (tV * possP)` and its theorems take the structure bare.
- Thirteen studies rewritten to the idiom; AissenPolian2025 audited fully.
- Elaboration note: a product of tokens alone needs a planar anchor or an ascription, else it lands on the noncomputable unordered Merge.