### PR TITLE
fix(Studies/Dendikken1995ParticleVerbs): the renamed leaf-count lemma

### DIFF
--- a/Linglib/Studies/Dendikken1995ParticleVerbs.lean
+++ b/Linglib/Studies/Dendikken1995ParticleVerbs.lean
@@ -104,7 +104,7 @@ unfolding `pvToSmallClause`. -/
 theorem pvToSmallClause_toSO_shape (pv : ParticleVerb) (dpId prtId : Nat) :
     (pvToSmallClause pv dpId prtId).toSO.leafCount = 2 := by
   simp only [pvToSmallClause, SmallClause.toSO, leafCount_node,
-    mkLeafPhon, leafCount_lexLeaf]
+    mkLeafPhon, leafCount_leaf]
 
 /-- The `predCat` field of `pvToSmallClause` agrees with the
     `predicate.headCat` reading — the well-formedness invariant

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
@@ -31,7 +31,7 @@ lexical-leaf value and a trace value, and inherit `Perm`-invariance from
 
 * `Minimalist.SyntacticObject.hom_ext`: morphisms of magmas out of
   `SyntacticObject` agreeing on lexical and trace leaves are equal.
-* `Minimalist.SyntacticObject.liftN_node`: the nonplanar magma law.
+* `Minimalist.SyntacticObject.liftN_merge`: the magma law on the unordered carrier.
 -/
 
 namespace Minimalist.SyntacticObject

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -16,7 +16,7 @@ because substitution preserves the arity of every vertex. The copy-theory use is
 the Merge-algebraic Internal Merge is the coproduct composition of `Merge/Internal.lean`, with
 traces as cut remainders and chains held at the workspace level, and `replace` supports the
 transformational view that study files are written in. It is noncomputable; concrete cases
-reduce by `replace_self`, `replace_node_of_ne`, and the leaf lemmas.
+reduce by `replace_self`, `replace_merge_of_ne`, and the leaf lemmas.
 
 ## Main definitions
 


### PR DESCRIPTION
`leafCount_lexLeaf` became `leafCount_leaf` in #2688; this study sat outside the cone built locally and CI's cache let it through. Two docstring mentions of renamed lemmas updated alongside.