### PR TITLE
refactor(Phonology/Segmental): feature geometry as a typeclass

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2220,6 +2220,7 @@ import Linglib.Studies.HahnDegenFutrell2021
 import Linglib.Studies.HahnDegenFutrell2021Morphology
 import Linglib.Studies.Hale2001
 import Linglib.Studies.HalleMarantz1993
+import Linglib.Studies.HalleVauxWolfe2000
 import Linglib.Studies.Halpert2012
 import Linglib.Studies.Halpert2019
 import Linglib.Studies.HalpertHammerly2026

--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -37,7 +37,7 @@ are skipped by `triggerValue` (not triggers) and `harmonizeOne` (not targets).
 namespace Finnish.VowelHarmony
 
 open Phonology (Segment Feature)
-open Phonology.FeatureGeometry (Node)
+open Phonology.FeatureGeometry (naturalClass)
 open Subregular.Harmony (System triggerValue
   harmonizeOne spreadSuffix)
 
@@ -185,7 +185,8 @@ theorem back_with_neutral :
 
 /-- The /a/–/ä/ pair differs only in [back]: dorsal agreement fails
     between them, confirming they belong to different harmony classes. -/
-theorem a_ä_dorsal_disagree : ¬ Set.EqOn a_vowel ä_vowel ↑Node.dorsal.features := by
+theorem a_ä_dorsal_disagree :
+    ¬ Set.EqOn a_vowel ä_vowel ↑(naturalClass Feature.Category.dorsal) := by
   decide
 
 /-- Dorsal agreement holds between /a/ and /o/ (both [+back]). -/

--- a/Linglib/Phonology/Segmental/Defs.lean
+++ b/Linglib/Phonology/Segmental/Defs.lean
@@ -65,34 +65,6 @@ inductive Feature where
 
 namespace Feature
 
-variable (f : Feature)
-
-/-! ### Feature classification -/
-
-/-- The articulator category of a feature: manner/root, laryngeal, or place. -/
-inductive Category where
-  | manner | laryngeal | labial | coronal | dorsal
-  deriving DecidableEq, Repr
-
-/-- The articulator category of each distinctive feature. -/
-def category : Feature → Category
-  | .syllabic | .consonantal | .sonorant | .approximant
-  | .continuant | .delayedRelease | .nasal | .lateral
-  | .strident | .tap | .trill                        => .manner
-  | .voice | .spreadGlottis | .constrGlottis         => .laryngeal
-  | .labial | .round | .labiodental                  => .labial
-  | .coronal | .anterior | .distributed              => .coronal
-  | .dorsal | .high | .low | .front | .back | .tense => .dorsal
-
-/-- Is this a laryngeal feature? -/
-abbrev IsLaryngeal : Prop := f.category = .laryngeal
-
-/-- Is this a dorsal place feature? -/
-abbrev IsDorsal : Prop := f.category = .dorsal
-
-/-- Is this a place feature (any articulator node)? -/
-abbrev IsPlace : Prop := f.category = .labial ∨ f.category = .coronal ∨ f.category = .dorsal
-
 /-! ### Enumeration -/
 
 /-- All features, in declaration order. -/
@@ -130,7 +102,8 @@ variable (s : Segment)
 /-- Does feature `f` have value `v`? -/
 def HasValue (f : Feature) (v : Bool) : Prop := s f = some v
 
-instance (f : Feature) (v : Bool) : Decidable (s.HasValue f v) := inferInstanceAs (Decidable (_ = _))
+instance (f : Feature) (v : Bool) : Decidable (s.HasValue f v) :=
+  inferInstanceAs (Decidable (_ = _))
 
 /-- A segment is **unspecified** for feature `f` iff its value there is `none`. -/
 def Unspecified (f : Feature) : Prop := s f = none

--- a/Linglib/Phonology/Segmental/Geometry.lean
+++ b/Linglib/Phonology/Segmental/Geometry.lean
@@ -1,303 +1,206 @@
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Core.Data.Fintype.Sets
-import Mathlib.Logic.Relation
+import Mathlib.Data.Finset.Piecewise
+import Mathlib.Data.Finset.Card
+import Mathlib.Order.Preorder.Chain
+import Mathlib.Order.Interval.Set.Defs
 
 /-!
 # Feature geometry
 
-The class-node tree over the distinctive features: a root node dominating a laryngeal
-and a supralaryngeal node, the latter dominating the soft-palate and the place node, and
-place dominating the articulator nodes labial, coronal and dorsal. The skeleton root >
-laryngeal, supralaryngeal > place is [clements-1985]'s; the soft-palate node and the
-articulators are [sagey-1986]'s, and [clements-1985]'s manner node, which the paper
-itself flags as possibly superfluous, is dropped. Every terminal feature of
-[hayes-2009]'s inventory hangs from one class node, and the natural class of a node is
-the finite set of features it dominates. Spreading a node `n` from `src` onto `tgt` is
-`n.features.piecewise src tgt` and agreement at `n` is `Set.EqOn s₁ s₂ ↑n.features`, so
-node spreading and node agreement are mathlib's `Finset.piecewise` and `Set.EqOn` on the
-natural class rather than operations of their own.
-
-    Root [±syll, ±cons, ±son, ±approx, ±del.rel., ±tap, ±trill]
-    ├── Laryngeal [±voice, ±s.g., ±c.g.]
-    └── Supralaryngeal [±cont]
-        ├── Soft Palate [±nasal]
-        └── Place
-            ├── Labial [±lab, ±round, ±labiodental]
-            ├── Coronal [±cor, ±ant, ±dist, ±lat, ±strid]
-            └── Dorsal [±dor, ±high, ±low, ±front, ±back, ±tense]
+A feature geometry is a finite rooted tree of class nodes with each terminal feature attached
+below at most one node: dominance is `≤`, the root is `⊥`, and every principal downset is a
+chain, so the natural classes (the features a node dominates) are nested along dominance and
+disjoint across incomparable nodes. The class-node idea and the thesis that assimilation
+spreads a single node are [clements-1985]'s; the articulator nodes are [sagey-1986]'s;
+[halle-vaux-wolfe-2000] lists the four innovations since then (Unified Feature Theory,
+Vowel-Place Theory, Partial Spreading, Strict Locality) and records that no consensus exists on
+which to adopt, while [padgett-2002] drops constituency and lets constraints refer to classes as
+sets. Current analyses refer to classes rather than to trees — [brown-meyer-2024]'s
+AGREE[place] is agreement on the place features — so the class-set is the primitive here:
+`FeatureGeometry` is a typeclass any node type can instantiate, natural classes are `Finset`s,
+spreading a class from `src` onto `tgt` is `Finset.piecewise`, and agreement on a class is
+`Set.EqOn`. The only instance in the substrate is the theory-neutral `Feature.Category`
+grouping of [hayes-2009]'s chart (manner, laryngeal, labial, coronal, dorsal under a root),
+with Place the union of the three articulator classes rather than a node; the trees of
+[clements-1985], [sagey-1986] and [halle-vaux-wolfe-2000] are instances in their studies.
 
 ## Main definitions
 
-* `Node`, `Node.parent`, `Node.Dominates` — the class nodes, the tree, and the
-  reflexive-transitive ancestor relation.
-* `Feature.node` — each feature's dominating node.
-* `Node.features` — the natural class a node dominates.
-* `Node.IsArticulator`, `Segment.activeArticulators`, `Segment.IsComplex` — the place
-  articulators and a segment's simultaneous (complex) articulations ([sagey-1986]).
+* `FeatureGeometry` — the class: `isChain_Iic` (principal downsets are chains) and `node`
+  (each feature's class node, if any).
+* `FeatureGeometry.naturalClass` — the features a node dominates.
+* `Feature.Category`, `Feature.category`, `Feature.Category.place` — the consensus grouping
+  and the place class.
+* `Segment.articulators`, `Segment.IsComplex` — designated articulators as features and
+  complex segments.
 
 ## Main results
 
-* `Node.dominates_iff` — dominance unrolls to the depth-≤ 3 parent chain, the decidable
-  face the `decide` facts run through.
-* `IsLaryngeal_iff_laryngeal_DominatedBy`, `IsDorsal_iff_dorsal_DominatedBy` — two flat
-  predicates coincide with single-node dominance; `IsPlace` is only a subset.
-* `Segment.activeArticulators_nodup` — complex-segment well-formedness holds by
-  construction ([sagey-1986]).
+* `naturalClass_anti`, `disjoint_naturalClass` — natural classes shrink along dominance and
+  are disjoint across incomparable nodes.
+* `eqOn_piecewise_of_le`, `eqOn_piecewise_of_not_le` — spreading a node carries every class it
+  dominates and leaves every incomparable class untouched.
+* `mem_naturalClass_bot` — the root's class is every attached feature: total assimilation.
 
 ## Implementation notes
 
-The placement of individual terminals is theory-specific. [clements-1985] puts
-`[consonantal]`, `[sonorant]`, `[continuant]`, `[lateral]`, `[strident]` and `[nasal]`
-under a manner node below supralaryngeal (his geometry is `Studies/Clements1985.lean`);
-[sagey-1986] argues `[continuant]` is articulator-level (`Studies/Sagey1986.lean`); and
-`[lateral]`/`[strident]` sit here under coronal although their manner class
-(`Feature.category`) is manner, so the flat predicates (`Feature.IsPlace` &c.) do not
-coincide with single-node dominance. Total, partial and single-feature assimilation
-([clements-1985]) are `Node.root.features.piecewise`, `n.features.piecewise` for a class
-node `n`, and `({f} : Finset Feature).piecewise`, the last being
-`Features.Bundle.assimilate f` by `Finset.piecewise_singleton`. The association of a
-spread node to several anchors is the tier-association object `AR`
-(`Autosegmental/AR.lean`) and is not recorded on segments here.
+Instances build dominance from a parent function: `up n` is `n` with its ancestors,
+`PartialOrder.lift up` is dominance, the root is `⊥`, and the chain axiom is `decide`d.
+`node` is `Option`-valued so a geometry may leave features unplaced; the consensus grouping is
+total. Spreading an arbitrary set of terminals ([halle-vaux-wolfe-2000]'s partial spreading,
+[padgett-2002]'s partial class behaviour) is `Finset.piecewise` on that set with no further
+apparatus, and single-feature spreading is `Features.Bundle.assimilate`
+(`Finset.piecewise_singleton`). The linking of a spread node to several anchors is the
+tier-association object `AR` (`Autosegmental/AR.lean`), not recorded on segments.
 
 ## References
 
-* [clements-1985] — class nodes, the root/laryngeal/supralaryngeal/place skeleton,
-  assimilation as single-node spreading.
-* [sagey-1986] — the soft-palate and articulator nodes, complex segments.
-* [hayes-2009] — the terminal feature inventory.
+* [clements-1985] — class nodes and single-node spreading.
+* [sagey-1986] — articulator nodes and complex segments.
+* [halle-vaux-wolfe-2000] — the four innovations and the absence of consensus (§1.1),
+  designated articulators as features (§1.2.2), terminal spreading (§1.2.3).
+* [padgett-2002] — feature classes as sets targeted by constraints.
+* [brown-meyer-2024] — AGREE[place] and AGREE[voice] over classes.
+* [hayes-2009] — the feature inventory and its chart grouping.
 -/
-
-namespace Phonology.FeatureGeometry
-
-/-! ### Geometric nodes -/
-
-/-- The class nodes of the feature-geometry tree ([clements-1985]; [sagey-1986]). -/
-inductive Node where
-  /-- The root node, dominating all others. -/
-  | root
-  /-- The laryngeal node: voicing and glottal features. -/
-  | laryngeal
-  /-- The supralaryngeal node, mediating root and place. -/
-  | supralaryngeal
-  /-- The soft-palate (velum) node: nasality. -/
-  | softPalate
-  /-- The place node, over the three oral articulators. -/
-  | place
-  /-- The labial articulator (the lips). -/
-  | labial
-  /-- The coronal articulator (the tongue blade/tip). -/
-  | coronal
-  /-- The dorsal articulator (the tongue body). -/
-  | dorsal
-  deriving DecidableEq, Repr
-
-variable (n m : Node)
-
-/-! ### Tree structure -/
-
-/-- The parent of each node; `root` alone has none. -/
-def Node.parent : Node → Option Node
-  | .root           => none
-  | .laryngeal      => some .root
-  | .supralaryngeal => some .root
-  | .softPalate     => some .supralaryngeal
-  | .place          => some .supralaryngeal
-  | .labial         => some .place
-  | .coronal        => some .place
-  | .dorsal         => some .place
-
-/-- All eight nodes. -/
-def Node.allNodes : List Node :=
-  [.root, .laryngeal, .supralaryngeal, .softPalate, .place, .labial, .coronal, .dorsal]
-
-/-- The children of `n`: the nodes whose parent is `n`. -/
-def Node.children : List Node := allNodes.filter (λ k => k.parent == some n)
-
-/-! ### Dominance -/
-
-/-- `n` dominates `m`: it is `m` or one of its ancestors — the reflexive-transitive
-    closure of "is the parent of", walked up from `m`. Depth-agnostic. -/
-def Node.Dominates : Prop := Relation.ReflTransGen (λ a b => a.parent = some b) m n
-
-/-- Dominance unrolls to the depth-≤ 3 parent chain — the decidable face the
-    `decide` facts below run through. -/
-theorem Node.dominates_iff :
-    n.Dominates m ↔ n = m ∨ m.parent = some n ∨
-      (m.parent.bind Node.parent) = some n ∨
-      ((m.parent.bind Node.parent).bind Node.parent) = some n := by
-  unfold Node.Dominates
-  constructor
-  · intro h
-    induction h with
-    | refl => exact Or.inl rfl
-    | @tail b c _ hbc ih =>
-      rcases ih with rfl | h | h | h
-      · exact Or.inr (Or.inl hbc)
-      · exact Or.inr (Or.inr (Or.inl (by rw [h, Option.bind_some]; exact hbc)))
-      · exact Or.inr (Or.inr (Or.inr (by rw [h, Option.bind_some]; exact hbc)))
-      · exfalso; revert h hbc; cases m <;> cases b <;> cases c <;> decide
-  · rintro (rfl | h | h | h)
-    · exact .refl
-    · exact .single h
-    · obtain ⟨p, hmp, hpn⟩ := Option.bind_eq_some_iff.mp h
-      exact .tail (.single hmp) hpn
-    · obtain ⟨q, hq, hqn⟩ := Option.bind_eq_some_iff.mp h
-      obtain ⟨p, hmp, hpq⟩ := Option.bind_eq_some_iff.mp hq
-      exact .tail (.tail (.single hmp) hpq) hqn
-
-instance : DecidableRel Node.Dominates := λ n m => decidable_of_iff _ (Node.dominates_iff n m).symm
-
-end Phonology.FeatureGeometry
-
-/-! ### Feature-to-node mapping -/
 
 namespace Phonology
 
-open FeatureGeometry
+/-! ### The class -/
 
-/-- Each terminal feature's dominating class node — this geometry's assignment
-    (contested for `[continuant]`/`[nasal]`/`[lateral]`; see the module docstring). -/
-def Feature.node : Feature → Node
-  | .syllabic | .consonantal | .sonorant | .approximant
-  | .delayedRelease | .tap | .trill => .root
-  | .voice | .spreadGlottis | .constrGlottis => .laryngeal
-  | .continuant => .supralaryngeal
-  | .nasal => .softPalate
-  | .labial | .round | .labiodental => .labial
-  | .coronal | .anterior | .distributed | .lateral | .strident => .coronal
-  | .dorsal | .high | .low | .front | .back | .tense => .dorsal
+/-- A feature geometry: a finite rooted tree of class nodes — dominance `≤`, root `⊥`, every
+principal downset a chain — with each terminal feature attached below at most one node. -/
+class FeatureGeometry (N : Type*) [PartialOrder N] [OrderBot N] where
+  /-- Every principal downset is a chain: the nodes dominating a node are linearly ordered. -/
+  isChain_Iic (c : N) : IsChain (· ≤ ·) (Set.Iic c)
+  /-- The class node a terminal feature hangs from, if the geometry places it. -/
+  node : Feature → Option N
 
-/-- Does node `n` dominate the node feature `f` belongs to? -/
-@[reducible] def Feature.DominatedBy (f : Feature) (n : Node) : Prop := n.Dominates f.node
+namespace FeatureGeometry
 
-end Phonology
-
-namespace Phonology.FeatureGeometry
-
-variable (n : Node) (f : Feature)
+variable {N : Type*} [PartialOrder N] [OrderBot N] [FeatureGeometry N] [DecidableLE N]
 
 /-! ### Natural classes -/
 
-/-- The features dominated by `n` — its natural class, the features that pattern
-    together under processes targeting `n`. -/
-def Node.features : Finset Feature := Finset.univ.filter (λ g => n.Dominates g.node)
+/-- The natural class of a node: the features attached at or below it. -/
+def naturalClass (a : N) : Finset Feature :=
+  Finset.univ.filter λ f => ∃ m ∈ (node f : Option N), a ≤ m
 
-instance (s₁ s₂ : Segment) : Decidable (Set.EqOn s₁ s₂ ↑n.features) :=
+variable {a b : N} {f : Feature}
+
+theorem mem_naturalClass : f ∈ naturalClass a ↔ ∃ m ∈ (node f : Option N), a ≤ m := by
+  simp [naturalClass]
+
+/-- The root's class is every attached feature: spreading it is total assimilation. -/
+theorem mem_naturalClass_bot : f ∈ naturalClass (⊥ : N) ↔ (node f : Option N).isSome := by
+  simp [mem_naturalClass, Option.isSome_iff_exists]
+
+/-- Natural classes shrink along dominance. -/
+theorem naturalClass_anti (h : a ≤ b) : naturalClass b ⊆ naturalClass a := λ g hg => by
+  rw [mem_naturalClass] at hg ⊢
+  obtain ⟨m, hm, hbm⟩ := hg
+  exact ⟨m, hm, h.trans hbm⟩
+
+/-- Incomparable nodes have disjoint natural classes. -/
+theorem disjoint_naturalClass (h₁ : ¬ a ≤ b) (h₂ : ¬ b ≤ a) :
+    Disjoint (naturalClass a) (naturalClass b) := by
+  rw [Finset.disjoint_left]
+  intro g hga hgb
+  rw [mem_naturalClass] at hga hgb
+  obtain ⟨m, hm, ham⟩ := hga
+  obtain ⟨m', hm', hbm⟩ := hgb
+  rw [Option.mem_def] at hm hm'
+  rw [hm, Option.some.injEq] at hm'
+  subst hm'
+  rcases eq_or_ne a b with rfl | hab
+  · exact h₁ le_rfl
+  · exact (isChain_Iic m ham hbm hab).elim h₁ h₂
+
+/-! ### Spreading -/
+
+variable (src tgt : Segment)
+
+/-- Spreading node `a` from `src` onto `tgt` carries every class `a` dominates. -/
+theorem eqOn_piecewise_of_le (h : a ≤ b) :
+    Set.EqOn ((naturalClass a).piecewise src tgt) src ↑(naturalClass b) :=
+  λ _ hg => Finset.piecewise_eq_of_mem _ _ _ (naturalClass_anti h hg)
+
+/-- Spreading node `a` leaves every class incomparable with `a` untouched. -/
+theorem eqOn_piecewise_of_not_le (h₁ : ¬ a ≤ b) (h₂ : ¬ b ≤ a) :
+    Set.EqOn ((naturalClass a).piecewise src tgt) tgt ↑(naturalClass b) :=
+  λ _ hg =>
+    Finset.piecewise_eq_of_notMem _ _ _ (Finset.disjoint_right.1 (disjoint_naturalClass h₁ h₂) hg)
+
+instance (s₁ s₂ : Segment) (a : N) : Decidable (Set.EqOn s₁ s₂ ↑(naturalClass a)) :=
   Set.decidableEqOnOfFintype _ _ _
 
-/-! ### Tree structure (verification) -/
+end FeatureGeometry
 
-theorem root_has_no_parent : Node.root.parent = none := rfl
+/-! ### The consensus classification -/
 
-theorem nonroot_has_parent (h : n ≠ .root) : n.parent.isSome = true := by
-  cases n <;> simp_all [Node.parent]
+/-- The theory-neutral grouping of the features, [hayes-2009]'s chart read as [padgett-2002]'s
+classes: the manner and major-class features, the laryngeal features, and the features of the
+three oral articulators, under a root standing for the whole segment. Place is the union of
+the articulator classes and not a node, since whether it is a constituent and how vowel place
+relates to it is where the geometries of `Studies/Clements1985.lean`, `Studies/Sagey1986.lean`
+and `Studies/HalleVauxWolfe2000.lean` part ways. -/
+inductive Feature.Category where
+  | root | manner | laryngeal | labial | coronal | dorsal
+  deriving DecidableEq, Repr, Fintype
 
-theorem allNodes_complete : n ∈ Node.allNodes := by cases n <;> simp [Node.allNodes]
+namespace Feature.Category
 
-/-! ### Flat-predicate subsumption
+/-- Every class hangs from the root. -/
+def parent : Category → Option Category
+  | .root => none
+  | _ => some .root
 
-`IsLaryngeal`/`IsDorsal` coincide with single-node dominance; `IsPlace` is only a
-*subset* (manner features like `[lateral]`/`[strident]` sit geometrically under Coronal). -/
+/-- A class and its ancestors. -/
+def up (c : Category) : Finset Category :=
+  ((List.range 2).filterMap λ i => (· >>= parent)^[i] (some c)).toFinset
 
-theorem IsLaryngeal_iff_laryngeal_DominatedBy : f.IsLaryngeal ↔ f.DominatedBy .laryngeal := by
-  cases f <;> decide
+instance : PartialOrder Category := PartialOrder.lift up (by decide)
 
-theorem IsDorsal_iff_dorsal_DominatedBy : f.IsDorsal ↔ f.DominatedBy .dorsal := by
-  cases f <;> decide
+instance : DecidableLE Category := λ a b => inferInstanceAs (Decidable (up a ⊆ up b))
 
-theorem IsPlace_implies_place_DominatedBy : f.IsPlace → f.DominatedBy .place := by
-  cases f <;> decide
+instance : OrderBot Category where
+  bot := .root
+  bot_le := by decide
 
-theorem lateral_geometrically_under_place : Feature.lateral.DominatedBy .place := by decide
+end Feature.Category
 
-theorem strident_geometrically_under_place : Feature.strident.DominatedBy .place := by decide
+/-- The class of each feature, by [hayes-2009]'s chart. -/
+def Feature.category : Feature → Feature.Category
+  | .syllabic | .consonantal | .sonorant | .approximant | .continuant | .delayedRelease
+  | .nasal | .lateral | .strident | .tap | .trill => .manner
+  | .voice | .spreadGlottis | .constrGlottis => .laryngeal
+  | .labial | .round | .labiodental => .labial
+  | .coronal | .anterior | .distributed => .coronal
+  | .dorsal | .high | .low | .front | .back | .tense => .dorsal
 
-/-!
-## Complex and contour segments
-[sagey-1986]
+instance : FeatureGeometry Feature.Category where
+  isChain_Iic := by unfold IsChain Set.Pairwise; decide +revert
+  node f := some f.category
 
-**Complex segments** have one root node with several *place* articulators active
-simultaneously (e.g. labiovelars [k͡p]); they fill one timing slot and their
-articulations are unordered. **Contour segments** have two root nodes on one timing
-slot, with articulations in sequence (e.g. affricates [ts]). A single-bundle
-`Segment` has one value per feature, so it can host only complex (one-root)
-segments, via `activeArticulators`; sequential contours need the multi-anchor
-autosegmental representation (`Autosegmental/`).
-
-The geometry predicts which complex segments are possible: only those combining
-*distinct* articulators. Palatal–velar stops are impossible (both are dorsal);
-labiovelars are possible (labial and dorsal are independent).
--/
-
-/-! ### Articulator nodes -/
-
-/-- A place articulator — labial, coronal, or dorsal — the independent articulators
-    whose distinct combinations give complex segments ([sagey-1986]). -/
-def Node.IsArticulator : Node → Prop
-  | .labial | .coronal | .dorsal => True
-  | _ => False
-
-instance : DecidablePred Node.IsArticulator :=
-  λ n => by cases n <;> unfold Node.IsArticulator <;> infer_instance
-
-/-- The articulator nodes. -/
-def articulatorNodes : List Node := Node.allNodes.filter (λ n => decide n.IsArticulator)
-
-/-! ### Articulator geometry (verification) -/
-
-/-- Articulators are exactly the leaf nodes. -/
-theorem articulators_are_leaves : ∀ n ∈ articulatorNodes, n.children = [] := by decide
-
-/-- Every articulator is dominated by root. -/
-theorem articulators_under_root : ∀ n ∈ articulatorNodes, Node.root.Dominates n := by decide
-
-/-- Every articulator is dominated by place. -/
-theorem articulators_under_place : ∀ n ∈ articulatorNodes, Node.place.Dominates n := by decide
-
-/-- The three place articulators are pairwise distinct — giving three complex types
-    (labio-coronal, labio-dorsal, corono-dorsal). -/
-theorem place_articulators_distinct :
-    Node.labial ≠ .coronal ∧ Node.labial ≠ .dorsal ∧ Node.coronal ≠ .dorsal := by decide
-
-/-- The soft palate is a *sibling* of place, not under it — so nasal assimilation
-    (spreading soft palate) is independent of place assimilation. -/
-theorem softPalate_not_under_place : ¬ Node.place.Dominates .softPalate := by decide
-
-/-- The soft palate is not an articulator — a velar nasal [ŋ] is simple despite
-    activating both dorsal and soft palate. -/
-theorem softPalate_not_articulator : ¬ Node.softPalate.IsArticulator := by decide
-
-end Phonology.FeatureGeometry
-
-namespace Phonology
-
-open FeatureGeometry (Node articulatorNodes)
-
-variable (s : Segment)
-
-/-! ### Active articulators -/
-
-/-- The articulator nodes with at least one specified feature in `s`. -/
-def Segment.activeArticulators : List Node :=
-  articulatorNodes.filter (λ n => decide (∃ g ∈ n.features, (s g).isSome))
-
-/-- The number of active articulator nodes in `s`. -/
-def Segment.articulatorCount : Nat := s.activeArticulators.length
+open FeatureGeometry in
+/-- The place class: the union of the three articulator classes ([padgett-2002] p. 83's
+"Place simply stands for the set {[labial], [coronal], [dorsal], …}"). -/
+def Feature.Category.place : Finset Feature :=
+  naturalClass labial ∪ naturalClass coronal ∪ naturalClass dorsal
 
 /-! ### Complex segments -/
 
-/-- A complex segment has two or more simultaneously active articulators — e.g. a
-    labiovelar [k͡p] (labial + dorsal). -/
-def Segment.IsComplex : Prop := s.articulatorCount ≥ 2
+/-- The designated articulators of a segment, as the articulator features it is specified `+`
+for ([halle-vaux-wolfe-2000] §1.2.2). -/
+def Segment.articulators (s : Segment) : Finset Feature :=
+  ({.labial, .coronal, .dorsal} : Finset Feature).filter (s · = some true)
 
-instance : DecidablePred Segment.IsComplex := λ _ => inferInstanceAs (Decidable (_ ≥ _))
+/-- A complex segment has more than one designated articulator: the labiovelar [k͡p] carries
+[labial] and [dorsal], the labialised [kʷ] only [dorsal] beside [+round] ([sagey-1986];
+[halle-vaux-wolfe-2000] p. 435). -/
+def Segment.IsComplex (s : Segment) : Prop := 1 < s.articulators.card
 
-/-- **Complex-segment well-formedness holds by construction**: a segment's active
-    articulators are always distinct, being filtered from the duplicate-free
-    `articulatorNodes`. The distinct-articulator condition is a theorem, not a
-    separate constraint ([sagey-1986]). -/
-theorem Segment.activeArticulators_nodup : s.activeArticulators.Nodup := by
-  unfold Segment.activeArticulators
-  exact (by decide : articulatorNodes.Nodup).filter _
+instance : DecidablePred Segment.IsComplex := λ _ => inferInstanceAs (Decidable (1 < _))
 
 end Phonology

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -1,6 +1,5 @@
 import Linglib.Fragments.English.Phonology
-import Linglib.Core.Data.Fintype.Sets
-import Mathlib.Data.Finset.Piecewise
+import Linglib.Phonology.Segmental.Geometry
 
 /-!
 # Clements (1985): the geometry of phonological features
@@ -18,17 +17,15 @@ preaspiration ((6)–(7), after [thrainsson-1978]), Klamath lateral rules ((8)�
 [barker-1964]), Sierra Popoluca nasalisation and release ((15)–(20), after [elson-1947]
 and [steriade-1982]'s Shared Features Convention) and the Kikuyu and palatalisation cases
 of §5, and §4 splits the place features into a primary set P, present in consonants and
-vowels, and a secondary set S, normally absent from plain consonants. Only the root,
-laryngeal, supralaryngeal and place nodes survive into the geometry of
-`Phonology/Segmental/Geometry.lean`; the manner node, which the paper itself flags as
-possibly superfluous, does not.
+vowels, and a secondary set S, normally absent from plain consonants. The tree is an
+instance of the substrate's `FeatureGeometry`; its manner node, which the paper itself
+flags as possibly superfluous, appears in no later geometry (`Studies/Sagey1986.lean`,
+`Studies/HalleVauxWolfe2000.lean`).
 
 ## Main definitions
 
-* `Node`, `Node.parent`, `Node.Dominates`, `Node.features` — the five class nodes of (3),
-  the tree, dominance, and the natural class a node dominates.
-* `classNode?` — the class node each terminal feature hangs from (§4); features the paper
-  does not place have none.
+* `Node`, `Node.parent`, `classNode?` — the five class nodes of (3), the tree, and the class
+  node each terminal feature hangs from (§4); together the `FeatureGeometry` instance.
 * `PlaceSet`, `placeSet?`, `PlaceSet.features` — the primary/secondary split of the place
   features (§4).
 * `Spreading`, `Spreading.features`, `Spreading.apply` — what one rule may spread, the
@@ -37,9 +34,6 @@ possibly superfluous, does not.
 
 ## Main results
 
-* `features_subset_of_dominates`, `disjoint_features` — natural classes nest along
-  dominance and are disjoint across incomparable nodes, so spreading a node leaves its
-  sisters' features untouched (`Spreading.apply_eqOn_of_not_dominates`).
 * `supralaryngeal_subset_of_nasal_of_distributed`,
   `apply_eqOn_supralaryngeal_of_nasal_of_distributed` — every spreading that reaches
   both `[nasal]` and `[distributed]` is total supralaryngeal assimilation, the argument
@@ -50,22 +44,23 @@ possibly superfluous, does not.
   `coronalAssimilation_n_esh` — *tenth*, *eighth*, *hundredth*, *insure* from table (11):
   the target takes the trigger's place features and nothing else.
 * `preaspiration` — spreading the vowel's supralaryngeal node onto the delinked first half
-  of an aspirated geminate keeps the stop's laryngeal features ((7)).
-* `mem_place_features_iff`, `primary_separates_stops` — the place features are P ∪ S, and
-  P alone separates the English stop places (table (22)).
+  of an aspirated geminate keeps the stop's laryngeal features ((7)), by the substrate's
+  disjointness of sister classes.
+* `mem_place_naturalClass_iff`, `primary_separates_stops` — the place features are P ∪ S,
+  and P alone separates the English stop places (table (22)).
 
 ## Implementation notes
 
-`classNode?` is defined on the features the paper names and is `none` elsewhere, so
-`Node.root.features` is the paper's inventory rather than all of [hayes-2009]'s;
-`[labial]` counts as primary by table (22). Spreading is `Finset.piecewise` on a node's
-natural class, so the trigger's unspecified features under the node replace the target's,
-as the delinking convention of (13) requires; single-feature spreading is
-`Features.Bundle.assimilate` (`Spreading.apply_feature`). The English segments are the
-Fragment's; its /r/ is [+anterior] where table (10) has [−anterior, −distributed], so the
-retroflex row of (11) (*tree*, *dream*, *enrol*) is not derived. The SPE rule (14) needs
-α-variables that `Subregular.LocalRewrite` does not provide, so the comparison with (12)
-is stated on the geometric side only.
+`classNode?` is defined on the features the paper names and is `none` elsewhere, so the
+root's natural class is the paper's inventory rather than all of [hayes-2009]'s; `[labial]`
+counts as primary by table (22). Spreading is `Finset.piecewise` on a node's natural class,
+so the trigger's unspecified features under the node replace the target's, as the delinking
+convention of (13) requires; single-feature spreading is `Features.Bundle.assimilate`
+(`Spreading.apply_feature`). The English segments are the Fragment's; its /r/ is
+[+anterior] where table (10) has [−anterior, −distributed], so the retroflex row of (11)
+(*tree*, *dream*, *enrol*) is not derived. The SPE rule (14) needs α-variables that
+`Subregular.LocalRewrite` does not provide, so the comparison with (12) is stated on the
+geometric side only.
 
 ## TODO
 
@@ -91,7 +86,7 @@ is stated on the geometric side only.
 
 namespace Clements1985
 
-open Phonology English.Phonology
+open Phonology Phonology.FeatureGeometry English.Phonology
 
 attribute [local instance] Set.decidableEqOnOfFintype
 
@@ -111,12 +106,17 @@ def parent : Node → Option Node
   | .laryngeal | .supralaryngeal => some .root
   | .manner | .place => some .supralaryngeal
 
-/-- `a` dominates `b`: `a` lies on the path from `b` to the root, `b` included (Appendix);
-the tree has depth two, so the chain is unrolled. -/
-def Dominates (a b : Node) : Prop :=
-  a = b ∨ b.parent = some a ∨ b.parent.bind parent = some a
+/-- A node and its ancestors; the tree has depth two. -/
+def up (n : Node) : Finset Node :=
+  ((List.range 3).filterMap λ i => (· >>= parent)^[i] (some n)).toFinset
 
-instance : DecidableRel Dominates := λ _ _ => inferInstanceAs (Decidable (_ ∨ _ ∨ _))
+instance : PartialOrder Node := PartialOrder.lift up (by decide)
+
+instance : DecidableLE Node := λ a b => inferInstanceAs (Decidable (up a ⊆ up b))
+
+instance : OrderBot Node where
+  bot := .root
+  bot_le := by decide
 
 end Node
 
@@ -132,6 +132,10 @@ def classNode? : Feature → Option Node
   | .labial | .coronal | .anterior | .distributed | .high | .back | .round => some .place
   | _ => none
 
+instance : FeatureGeometry Node where
+  isChain_Iic := by unfold IsChain Set.Pairwise; decide +revert
+  node := classNode?
+
 /-- The two sets of place features: P, distinguishing place in consonants, and S,
 distinguishing place in vowels (§4). -/
 inductive PlaceSet where
@@ -145,39 +149,14 @@ def placeSet? : Feature → Option PlaceSet
   | .high | .back | .round => some .secondary
   | _ => none
 
-/-- The natural class of a node: the terminal features it dominates ("each feature
-characterises every node that dominates it", Appendix). -/
-def Node.features (a : Node) : Finset Feature :=
-  Finset.univ.filter λ f => ∃ b, classNode? f = some b ∧ a.Dominates b
-
 /-- The features of a place set. -/
 def PlaceSet.features (π : PlaceSet) : Finset Feature :=
   Finset.univ.filter (placeSet? · = some π)
 
-variable {a b : Node} (f : Feature)
-
-theorem mem_features_iff : f ∈ a.features ↔ ∃ b, classNode? f = some b ∧ a.Dominates b := by
-  simp [Node.features]
-
-/-- The root is characterised by every feature of the representation (Appendix). -/
-theorem mem_root_features_iff : f ∈ Node.root.features ↔ (classNode? f).isSome := by
-  cases f <;> decide
-
 /-- The place features are exactly P ∪ S. -/
-theorem mem_place_features_iff : f ∈ Node.place.features ↔ (placeSet? f).isSome := by
+theorem mem_place_naturalClass_iff (f : Feature) :
+    f ∈ naturalClass Node.place ↔ (placeSet? f).isSome := by
   cases f <;> decide
-
-/-! ### Nesting and disjointness -/
-
-/-- Natural classes nest along dominance. -/
-theorem features_subset_of_dominates (h : a.Dominates b) : b.features ⊆ a.features := by
-  revert a b; decide
-
-/-- Nodes neither of which dominates the other have disjoint natural classes: the sisters
-laryngeal and supralaryngeal, or manner and place, share no feature. -/
-theorem disjoint_features (h₁ : ¬ a.Dominates b) (h₂ : ¬ b.Dominates a) :
-    Disjoint a.features b.features := by
-  revert a b; decide
 
 /-! ### Assimilation as spreading ((5)) -/
 
@@ -195,7 +174,7 @@ variable (σ : Spreading) (src tgt : Segment)
 
 /-- The features a spreading carries. -/
 def features : Spreading → Finset Feature
-  | .node a => a.features
+  | .node a => naturalClass a
   | .feature f => {f}
 
 /-- Spread from `src` onto `tgt`: the carried features take `src`'s values, specified or
@@ -206,20 +185,9 @@ theorem apply_eqOn : Set.EqOn (σ.apply src tgt) src ↑σ.features :=
   λ _ hf => Finset.piecewise_eq_of_mem _ _ _ hf
 
 /-- Single-feature spreading is the bundle primitive `Features.Bundle.assimilate`. -/
-theorem apply_feature : (feature f).apply src tgt = Features.Bundle.assimilate f src tgt :=
+theorem apply_feature (f : Feature) :
+    (feature f).apply src tgt = Features.Bundle.assimilate f src tgt :=
   Finset.piecewise_singleton _ _ _
-
-/-- Spreading a node carries every feature of the nodes it dominates. -/
-theorem apply_eqOn_of_dominates (h : a.Dominates b) :
-    Set.EqOn ((node a).apply src tgt) src ↑b.features :=
-  (apply_eqOn _ src tgt).mono (Finset.coe_subset.2 (features_subset_of_dominates h))
-
-/-- Spreading a node leaves the features of every node it neither dominates nor is
-dominated by untouched. -/
-theorem apply_eqOn_of_not_dominates (h₁ : ¬ a.Dominates b) (h₂ : ¬ b.Dominates a) :
-    Set.EqOn ((node a).apply src tgt) tgt ↑b.features :=
-  λ _ hf =>
-    Finset.piecewise_eq_of_notMem _ _ _ (Finset.disjoint_right.1 (disjoint_features h₁ h₂) hf)
 
 end Spreading
 
@@ -230,22 +198,23 @@ variable (σ : Spreading) (src tgt : Segment)
 /-- Place spreading carries `[anterior]` and `[distributed]` together and leaves `[nasal]`
 alone, so (12) is a single-node rule while its `[αnasal]` variant of (14) is not. -/
 theorem anterior_distributed_subset_place :
-    {Feature.anterior, Feature.distributed} ⊆ Node.place.features := by
+    {Feature.anterior, Feature.distributed} ⊆ naturalClass Node.place := by
   decide
 
-theorem nasal_notMem_place : Feature.nasal ∉ Node.place.features := by decide
+theorem nasal_notMem_place : Feature.nasal ∉ naturalClass Node.place := by decide
 
 /-- No spreading reaches both `[nasal]`, a manner feature, and `[distributed]`, a place
 feature, without carrying the whole supralaryngeal class (§3). -/
 theorem supralaryngeal_subset_of_nasal_of_distributed (h₁ : Feature.nasal ∈ σ.features)
-    (h₂ : Feature.distributed ∈ σ.features) : Node.supralaryngeal.features ⊆ σ.features := by
+    (h₂ : Feature.distributed ∈ σ.features) :
+    naturalClass Node.supralaryngeal ⊆ σ.features := by
   revert σ; decide
 
 /-- A rule assimilating `[nasal]` and `[distributed]` at once is total supralaryngeal
 assimilation. -/
 theorem apply_eqOn_supralaryngeal_of_nasal_of_distributed (h₁ : Feature.nasal ∈ σ.features)
     (h₂ : Feature.distributed ∈ σ.features) :
-    Set.EqOn (σ.apply src tgt) src ↑Node.supralaryngeal.features :=
+    Set.EqOn (σ.apply src tgt) src ↑(naturalClass Node.supralaryngeal) :=
   (σ.apply_eqOn src tgt).mono
     (Finset.coe_subset.2 (supralaryngeal_subset_of_nasal_of_distributed σ h₁ h₂))
 
@@ -260,7 +229,8 @@ theorem eq_root_of_continuant_of_voice (h₁ : Feature.continuant ∈ σ.feature
 one spreading doing both is supralaryngeal, so the paper decomposes it into spirantisation
 and place assimilation. -/
 theorem supralaryngeal_subset_of_anterior_of_continuant (h₁ : Feature.anterior ∈ σ.features)
-    (h₂ : Feature.continuant ∈ σ.features) : Node.supralaryngeal.features ⊆ σ.features := by
+    (h₂ : Feature.continuant ∈ σ.features) :
+    naturalClass Node.supralaryngeal ⊆ σ.features := by
   revert σ; decide
 
 /-! ### English coronal place assimilation ((10)–(13)) -/
@@ -314,9 +284,9 @@ takes the preceding vowel's, so the output shares every supralaryngeal feature w
 vowel and keeps only the stop's laryngeal features `[+spread, −voiced]` — an [h]. Klamath
 (9a) and Sierra Popoluca (16) spread the same node from a lateral and from a nasal. -/
 theorem preaspiration (v c : Segment) :
-    Set.EqOn ((Spreading.node .supralaryngeal).apply v c) v ↑Node.supralaryngeal.features ∧
-      Set.EqOn ((Spreading.node .supralaryngeal).apply v c) c ↑Node.laryngeal.features :=
-  ⟨Spreading.apply_eqOn _ v c, Spreading.apply_eqOn_of_not_dominates v c (by decide) (by decide)⟩
+    Set.EqOn ((Spreading.node .supralaryngeal).apply v c) v ↑(naturalClass Node.supralaryngeal) ∧
+      Set.EqOn ((Spreading.node .supralaryngeal).apply v c) c ↑(naturalClass Node.laryngeal) :=
+  ⟨Spreading.apply_eqOn _ v c, eqOn_piecewise_of_not_le v c (by decide) (by decide)⟩
 
 /-! ### Primary and secondary place features (§4) -/
 

--- a/Linglib/Studies/HalleVauxWolfe2000.lean
+++ b/Linglib/Studies/HalleVauxWolfe2000.lean
@@ -1,0 +1,142 @@
+import Linglib.Phonology.Segmental.Geometry
+
+/-!
+# Halle, Vaux and Wolfe (2000): feature spreading and the representation of place
+
+[halle-vaux-wolfe-2000] reviews the four innovations proposed since [clements-1985] — Unified
+Feature Theory, Vowel-Place Theory, Partial Spreading and Strict Locality — records that no
+consensus exists on which to adopt (§1.1), and proposes Revised Articulator Theory, which keeps
+Partial Spreading and rejects the other three. Its tree (1) groups the features of the six
+articulators under the nodes Lips, Tongue Blade, Tongue Body, Soft Palate, Tongue Root and
+Larynx, with Place over the three oral articulators, Guttural over tongue root and larynx, and
+the articulator-free features [continuant], [strident], [lateral] and [suction] beside the root
+features [consonantal] and [sonorant] attached to the root. Designated articulators are terminal
+features rather than nodes, so the labiovelar [k͡p] carries both [labial] and [dorsal] while the
+labialised [kʷ] carries [dorsal] beside [+round] (§1.2.2, p. 435). Spreading operates on
+terminal features (§1.2.3), so a rule may spread any subset of a node's features and the tree
+only names the natural sets.
+
+## Main definitions
+
+* `Node`, `Node.parent`, `node` — tree (1) as a `FeatureGeometry` instance over [hayes-2009]'s
+  inventory.
+* `kp`, `kw` — the feature complements of the labiovelar and the labialised velar (p. 435).
+
+## Main results
+
+* `articulatorFree_mem_naturalClass_iff` — an articulator-free or root feature lies in the
+  root's class and no other.
+* `nasal_notMem_place`, `place_eq_union` — Soft Palate is not under Place, and Place is exactly
+  the three oral articulators.
+* `isComplex_kp`, `not_isComplex_kw` — [k͡p] is complex and [kʷ] is not.
+
+## Implementation notes
+
+Features of [hayes-2009]'s inventory absent from (1) are placed by the paper's own
+articulator-bound/free criterion (§1.2): [approximant], [delayed release], [tap], [trill] and
+[syllabic] are articulator-free and go to the root, [labiodental] to Lips, [front] to Tongue
+Body, and [voice], executed by the larynx, to Larynx; [tense] is left unplaced, since the paper's
+tongue-root features are [ATR] and [RTR] and Hayes's [tense] is not identified with them.
+[suction], [rhinal], [ATR], [RTR], [radical], [stiff vocal folds], [slack vocal folds] and
+[glottal] have no counterpart in the inventory, so Tongue Root dominates nothing here.
+
+## TODO
+
+* §2's arguments against Unified Feature Theory and Vowel-Place Theory, §3's analyses (Barra
+  Gaelic vowel copy, Irish nasal place and dorsal assimilation) and §1.2.4's full specification.
+
+## References
+
+* [halle-vaux-wolfe-2000]
+* [clements-1985] — the class-node geometry the paper revises.
+* [sagey-1986] — the articulator model it descends from.
+* [hayes-2009] — the feature inventory.
+-/
+
+namespace HalleVauxWolfe2000
+
+open Phonology Phonology.FeatureGeometry
+
+/-! ### Tree (1) -/
+
+/-- The nodes of tree (1): the root; Place over Lips, Tongue Blade and Tongue Body; Soft Palate;
+Guttural over Tongue Root and Larynx. -/
+inductive Node where
+  | root | place | lips | tongueBlade | tongueBody | softPalate | guttural | tongueRoot | larynx
+  deriving DecidableEq, Repr, Fintype
+
+namespace Node
+
+/-- The node immediately dominating each node; the root alone has none. -/
+def parent : Node → Option Node
+  | .root => none
+  | .place | .softPalate | .guttural => some .root
+  | .lips | .tongueBlade | .tongueBody => some .place
+  | .tongueRoot | .larynx => some .guttural
+
+/-- A node and its ancestors; the tree has depth two. -/
+def up (n : Node) : Finset Node :=
+  ((List.range 3).filterMap λ i => (· >>= parent)^[i] (some n)).toFinset
+
+instance : PartialOrder Node := PartialOrder.lift up (by decide)
+
+instance : DecidableLE Node := λ a b => inferInstanceAs (Decidable (up a ⊆ up b))
+
+instance : OrderBot Node where
+  bot := .root
+  bot_le := by decide
+
+end Node
+
+/-- The terminal features of (1), read over [hayes-2009]'s inventory (see the module
+docstring for the features the paper does not list). -/
+def node : Feature → Option Node
+  | .consonantal | .sonorant | .continuant | .strident | .lateral
+  | .syllabic | .approximant | .delayedRelease | .tap | .trill => some .root
+  | .labial | .round | .labiodental => some .lips
+  | .coronal | .anterior | .distributed => some .tongueBlade
+  | .dorsal | .high | .low | .back | .front => some .tongueBody
+  | .nasal => some .softPalate
+  | .voice | .spreadGlottis | .constrGlottis => some .larynx
+  | .tense => none
+
+instance : FeatureGeometry Node where
+  isChain_Iic := by unfold IsChain Set.Pairwise; decide +revert
+  node := node
+
+/-! ### Articulator-free features and Place -/
+
+/-- The articulator-free features and the root features belong to the root's class alone: no
+articulator node dominates them. -/
+theorem articulatorFree_mem_naturalClass_iff :
+    ∀ f ∈ ({.consonantal, .sonorant, .continuant, .strident, .lateral} : Finset Feature),
+      ∀ a : Node, f ∈ naturalClass a ↔ a = ⊥ := by
+  decide
+
+/-- Soft Palate is a sister of Place, not under it. -/
+theorem nasal_notMem_place : Feature.nasal ∉ naturalClass Node.place := by decide
+
+/-- Place dominates exactly the three oral articulators. -/
+theorem place_eq_union :
+    naturalClass Node.place =
+      naturalClass Node.lips ∪ naturalClass Node.tongueBlade ∪ naturalClass Node.tongueBody := by
+  decide
+
+/-! ### Designated articulators (p. 435) -/
+
+/-- The labiovelar stop: `[dorsal, labial, +consonantal, −sonorant, −round, −continuant]`. -/
+def kp : Segment :=
+  Segment.ofSpecs [(.dorsal, true), (.labial, true), (.consonantal, true), (.sonorant, false),
+    (.round, false), (.continuant, false)]
+
+/-- The labialised velar stop: `[dorsal, +consonantal, −sonorant, +round, −continuant]`, with no
+specification for [labial]. -/
+def kw : Segment :=
+  Segment.ofSpecs [(.dorsal, true), (.consonantal, true), (.sonorant, false), (.round, true),
+    (.continuant, false)]
+
+theorem isComplex_kp : kp.IsComplex := by decide
+
+theorem not_isComplex_kw : ¬ kw.IsComplex := by decide
+
+end HalleVauxWolfe2000

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -12,10 +12,10 @@ PhD dissertation, Massachusetts Institute of Technology.
 
 [sagey-1986] proposes a hierarchical feature geometry organized by
 vocal tract articulator, establishing the labial, coronal, dorsal, and
-soft palate nodes that are now standard in phonological theory
-(`Phonology/Segmental/Geometry.lean`). The geometry predicts which
-multiply-articulated (complex) segments are possible in human language
-(`Phonology/Segmental/Geometry.lean`).
+soft palate nodes (`Node` below, an instance of the substrate's
+`FeatureGeometry`). The geometry predicts which multiply-articulated
+(complex) segments are possible in human language
+(`Segment.IsComplex` in `Phonology/Segmental/Geometry.lean`).
 
 This study file formalizes Sagey-specific contributions that go beyond
 the consensus geometry:
@@ -39,7 +39,7 @@ the consensus geometry:
 -/
 
 open Phonology (Segment Feature)
-open Phonology.FeatureGeometry (Node)
+open Phonology.FeatureGeometry (naturalClass)
 
 namespace Autosegmental
 
@@ -272,6 +272,62 @@ end Autosegmental
 
 namespace Sagey1986
 
+/-! ### The articulator geometry -/
+
+/-- The class nodes: root; laryngeal and supralaryngeal; soft palate and place below
+supralaryngeal; the articulators labial, coronal and dorsal below place. -/
+inductive Node where
+  | root | laryngeal | supralaryngeal | softPalate | place | labial | coronal | dorsal
+  deriving DecidableEq, Repr, Fintype
+
+namespace Node
+
+/-- The node immediately dominating each node; the root alone has none. -/
+def parent : Node → Option Node
+  | .root => none
+  | .laryngeal | .supralaryngeal => some .root
+  | .softPalate | .place => some .supralaryngeal
+  | .labial | .coronal | .dorsal => some .place
+
+/-- A node and its ancestors; the tree has depth three. -/
+def up (n : Node) : Finset Node :=
+  ((List.range 4).filterMap λ i => (· >>= parent)^[i] (some n)).toFinset
+
+instance : PartialOrder Node := PartialOrder.lift up (by decide)
+
+instance : DecidableLE Node := λ a b => inferInstanceAs (Decidable (up a ⊆ up b))
+
+instance : OrderBot Node where
+  bot := .root
+  bot_le := by decide
+
+/-- The articulator nodes — labial, coronal, dorsal — whose distinct combinations give complex
+segments. -/
+def IsArticulator : Node → Prop
+  | .labial | .coronal | .dorsal => True
+  | _ => False
+
+instance : DecidablePred IsArticulator :=
+  λ n => by cases n <;> unfold IsArticulator <;> infer_instance
+
+end Node
+
+/-- The terminal features under each node. TODO: the placement of `[continuant]` under
+supralaryngeal and of `[lateral]`/`[strident]` under coronal is unverified against the
+dissertation. -/
+def node : Feature → Node
+  | .syllabic | .consonantal | .sonorant | .approximant | .delayedRelease | .tap | .trill => .root
+  | .voice | .spreadGlottis | .constrGlottis => .laryngeal
+  | .continuant => .supralaryngeal
+  | .nasal => .softPalate
+  | .labial | .round | .labiodental => .labial
+  | .coronal | .anterior | .distributed | .lateral | .strident => .coronal
+  | .dorsal | .high | .low | .front | .back | .tense => .dorsal
+
+instance : Phonology.FeatureGeometry Node where
+  isChain_Iic := by unfold IsChain Set.Pairwise; decide +revert
+  node f := some (node f)
+
 -- ============================================================================
 -- § 1: Major/Minor Articulator Distinction (Ch. 3)
 -- ============================================================================
@@ -328,7 +384,7 @@ inductive DegreeOfClosure where
 structure ArticulatorSpec where
   node : Node
   closure : DegreeOfClosure
-  node_is_articulator : node.IsArticulator = true
+  node_is_articulator : node.IsArticulator
 
 /-- A click's anterior closure (coronal, full stop). -/
 def click_anterior : ArticulatorSpec where
@@ -352,19 +408,18 @@ def click_posterior : ArticulatorSpec where
     cross-linguistically simpler and more common than place assimilation:
     it involves spreading a smaller constituent. -/
 theorem nasal_assimilation_scope :
-    Node.softPalate.features.card < Node.place.features.card := by
+    (naturalClass Node.softPalate).card < (naturalClass Node.place).card := by
   decide
 
 /-- Nasality is NOT under the place node — spreading place does not
     spread nasality. This is Sagey's core structural argument for the
     soft palate node as a separate constituent. -/
-theorem nasal_not_under_place :
-    ¬ Feature.nasal.DominatedBy .place := by decide
+theorem nasal_not_under_place : Feature.nasal ∉ naturalClass Node.place := by decide
 
 /-- Nasality IS under supralaryngeal (via the soft palate node), so
     total assimilation (spreading supralaryngeal) does spread nasality. -/
-theorem nasal_under_supralaryngeal :
-    Feature.nasal.DominatedBy .supralaryngeal := by decide
+theorem nasal_under_supralaryngeal : Feature.nasal ∈ naturalClass Node.supralaryngeal := by
+  decide
 
 -- ============================================================================
 -- § 4: Nupe Labiovelars
@@ -379,11 +434,6 @@ def nupe_kp_segment : Segment :=
 
 /-- The Nupe /k͡p/ is a complex segment (two active place articulators). -/
 theorem nupe_kp_is_complex : Segment.IsComplex nupe_kp_segment := by decide
-
-/-- The Nupe /k͡p/ is well-formed: its active articulators (labial, dorsal) are
-    distinct — an instance of the by-construction guarantee. -/
-theorem nupe_kp_wf : nupe_kp_segment.activeArticulators.Nodup :=
-  Segment.activeArticulators_nodup _
 
 /-- A simple /p/ (labial only) is not complex. -/
 def simple_p : Segment :=
@@ -404,11 +454,6 @@ def velar_nasal : Segment :=
      (.nasal, true), (.voice, true), (.dorsal, true)]
 
 theorem velar_nasal_not_complex : ¬ Segment.IsComplex velar_nasal := by decide
-
-/-- The velar nasal is well-formed (only one place articulator: dorsal), its
-    active articulators trivially distinct. -/
-theorem velar_nasal_wf : velar_nasal.activeArticulators.Nodup :=
-  Segment.activeArticulators_nodup _
 
 -- ============================================================================
 -- § 5: Impossible Complex Segments (Ch. 2)

--- a/references.bib
+++ b/references.bib
@@ -22988,6 +22988,44 @@
   role      = {cited},
   sources   = {Studies/Clements1985.lean}
 }
+@article{halle-vaux-wolfe-2000,
+  author    = {Halle, Morris and Vaux, Bert and Wolfe, Andrew},
+  year      = {2000},
+  title     = {On Feature Spreading and the Representation of Place of Articulation},
+  journal   = {Linguistic Inquiry},
+  volume    = {31},
+  number    = {3},
+  pages     = {387--444},
+  doi       = {10.1162/002438900554398},
+  subfield  = {phonology},
+  role      = {foundational},
+  sources   = {Phonology/Segmental/Geometry.lean, Studies/HalleVauxWolfe2000.lean}
+}
+@article{padgett-2002,
+  author    = {Padgett, Jaye},
+  year      = {2002},
+  title     = {Feature Classes in Phonology},
+  journal   = {Language},
+  volume    = {78},
+  number    = {1},
+  pages     = {81--110},
+  doi       = {10.1353/lan.2002.0046},
+  subfield  = {phonology},
+  role      = {foundational},
+  sources   = {Phonology/Segmental/Geometry.lean}
+}
+@article{brown-meyer-2024,
+  author    = {Brown, Jason and Meyer, Johanna},
+  year      = {2024},
+  title     = {Assimilation and Morpheme Boundaries in {Mgira}},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {42},
+  pages     = {1353--1370},
+  doi       = {10.1007/s11049-023-09606-0},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Phonology/Segmental/Geometry.lean}
+}
 @phdthesis{sagey-1986,
   author    = {Sagey, Elizabeth C.},
   year      = {1986},
@@ -22997,7 +23035,7 @@
     subfield  = {phonology},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Sagey1986.lean}
+  sources   = {Studies/Sagey1986.lean, Phonology/Segmental/Geometry.lean}
 }
 @incollection{stojkovic-2026,
   author    = {Stojkovi{\'c}, Jelena},


### PR DESCRIPTION
Make the class-set the phonological substrate's primitive and geometries instances of it: `FeatureGeometry` is a typeclass over a node poset (dominance `≤`, root `⊥`, principal downsets chains) with an `Option`-valued feature attachment, natural classes are `Finset`s, spreading is `Finset.piecewise` and agreement is `Set.EqOn`; the only substrate instance is the theory-neutral `Feature.Category` grouping of Hayes 2009's chart, with Place a union of the articulator classes rather than a node.

- Trees live in their studies: Sagey 1986's eight-node tree moves out of the substrate into `Studies/Sagey1986.lean` (placement of [continuant]/[lateral]/[strident] flagged unverified), Clements 1985 instantiates the class, and a new `Studies/HalleVauxWolfe2000.lean` carries tree (1) of Revised Articulator Theory with the [k͡p]/[kʷ] designated-articulator contrast (checked against the PDF).
- Generic lemmas replace per-tree `decide` facts: `naturalClass_anti`, `disjoint_naturalClass`, `eqOn_piecewise_of_le`, `eqOn_piecewise_of_not_le`; `Segment.IsComplex` becomes "more than one designated articulator feature", and the vacuous `activeArticulators_nodup` theorems go.
- The flat `Feature.category` classification moves from `Defs.lean` to `Geometry.lean` as the consensus instance, dropping the `IsPlace`/`IsLaryngeal`/`IsDorsal` predicates and their bridge theorems (no consumers); bib gains halle-vaux-wolfe-2000, padgett-2002 and brown-meyer-2024.
