### PR TITLE
refactor(Phonology/Segmental): name the feature classes FeatureClass

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1391,7 +1391,7 @@ import Linglib.Phonology.Subregular.TierRule
 import Linglib.Phonology.Subregular.TierStrictlyLocal
 import Linglib.Phonology.Subregular.Transduction
 import Linglib.Phonology.Segmental.Basic
-import Linglib.Phonology.Segmental.Classes
+import Linglib.Phonology.Segmental.FeatureClass
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Phonology.Segmental.ElementTheory
 import Linglib.Phonology.Tone.Basic

--- a/Linglib/Fragments/Finnish/VowelHarmony.lean
+++ b/Linglib/Fragments/Finnish/VowelHarmony.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Segmental.Basic
-import Linglib.Phonology.Segmental.Classes
+import Linglib.Phonology.Segmental.FeatureClass
 import Linglib.Phonology.Subregular.LocalRewrite
 import Linglib.Phonology.Subregular.Harmony
 
@@ -36,7 +36,7 @@ are skipped by `triggerValue` (not triggers) and `harmonizeOne` (not targets).
 
 namespace Finnish.VowelHarmony
 
-open Phonology (Segment Feature)
+open Phonology (Segment Feature FeatureClass)
 open Subregular.Harmony (System triggerValue
   harmonizeOne spreadSuffix)
 
@@ -184,7 +184,7 @@ theorem back_with_neutral :
 
 /-- The /a/–/ä/ pair differs only in [back]: dorsal agreement fails
     between them, confirming they belong to different harmony classes. -/
-theorem a_ä_dorsal_disagree : ¬ Set.EqOn a_vowel ä_vowel ↑Feature.Category.dorsal.features := by
+theorem a_ä_dorsal_disagree : ¬ Set.EqOn a_vowel ä_vowel ↑FeatureClass.dorsal.features := by
   decide
 
 /-- Dorsal agreement holds between /a/ and /o/ (both [+back]). -/

--- a/Linglib/Phonology/FeatureGeometry.lean
+++ b/Linglib/Phonology/FeatureGeometry.lean
@@ -20,7 +20,7 @@ a class from `src` onto `tgt` is `Finset.piecewise`, agreement on a class is `Se
 geometry is an instance naming which sets are natural. The feature type is a parameter, so an
 instance may range over a binary inventory, over feature tokens indexed by position as in
 Vowel-Place Theory, over privative elements, or over tone features; the flat segmental
-classes are `Phonology/Segmental/Classes.lean`, and the trees of Clements, Sagey
+classes are `Phonology/Segmental/FeatureClass.lean`, and the trees of Clements, Sagey
 and Halle, Vaux and Wolfe are instances in their studies.
 
 ## Main definitions

--- a/Linglib/Phonology/Segmental/FeatureClass.lean
+++ b/Linglib/Phonology/Segmental/FeatureClass.lean
@@ -3,7 +3,7 @@ import Linglib.Core.Data.Fintype.Sets
 import Mathlib.Data.Finset.Card
 
 /-!
-# Segmental feature classes
+# Feature classes
 
 The grouping of Hayes's features by the sections of his feature chapter — manner
 (§4.4, including the sonority features), laryngeal (§4.7), and the three major articulators
@@ -26,22 +26,22 @@ Designated articulators are the articulator features a segment is specified for
 
 ## Main definitions
 
-* `Feature.Category`, `Feature.category` — the five groups and each feature's group.
-* `Feature.Category.features`, `Feature.Category.place` — a group's features, and the place
-  class as the union of the articulator groups.
+* `FeatureClass`, `Feature.featureClass` — the five classes and each feature's class.
+* `FeatureClass.features`, `FeatureClass.place` — a class's features, and the place class as
+  the union of the articulator classes.
 * `Segment.articulators`, `Segment.IsComplex` — designated articulators and complex segments.
 
 ## Main results
 
-* `Feature.Category.mem_features`, `Feature.Category.mem_place` — membership in a group and
-  in the place class.
+* `FeatureClass.mem_features`, `FeatureClass.mem_place` — membership in a class and in the
+  place class.
 
 ## Implementation notes
 
 The contested placements are Hayes's: [strident] and [lateral] are coronal where
 Gussenhoven and Jacobs, Davenport and Hannahs and Clements make them manner
 features, and [tense] is a vowel feature under dorsal where the tree-drawing textbooks give
-[ATR] its own radical or pharyngeal node. Agreement on a group or on the place class is
+[ATR] its own radical or pharyngeal node. Agreement on a class or on the place class is
 decidable, so AGREE-style facts about Fragment segments close by `decide`.
 
 ## References
@@ -64,16 +64,16 @@ decidable, so AGREE-style facts about Fragment segments close by `decide`.
 
 namespace Phonology
 
-/-! ### The groups -/
+/-! ### The classes -/
 
-/-- Hayes's five feature groups: manner, laryngeal, and the three major articulators. -/
-inductive Feature.Category where
+/-- Hayes's five feature classes: manner, laryngeal, and the three major articulators. -/
+inductive FeatureClass where
   | manner | laryngeal | labial | coronal | dorsal
   deriving DecidableEq, Repr, Fintype
 
-/-- The group of each feature, by the sections of Hayes's feature chapter (see the
-module docstring). -/
-def Feature.category : Feature → Feature.Category
+/-- The class of each feature, by the sections of Hayes's feature chapter (see the module
+docstring). -/
+def Feature.featureClass : Feature → FeatureClass
   | .syllabic | .consonantal | .sonorant | .approximant | .continuant | .delayedRelease
   | .nasal | .tap | .trill => .manner
   | .voice | .spreadGlottis | .constrGlottis => .laryngeal
@@ -81,30 +81,31 @@ def Feature.category : Feature → Feature.Category
   | .coronal | .anterior | .distributed | .strident | .lateral => .coronal
   | .dorsal | .high | .low | .front | .back | .tense => .dorsal
 
-namespace Feature.Category
+namespace FeatureClass
 
-/-- The features of a group. -/
-def features (c : Category) : Finset Feature := Finset.univ.filter (·.category = c)
+/-- The features of a class. -/
+def features (c : FeatureClass) : Finset Feature := Finset.univ.filter (·.featureClass = c)
 
-/-- The place class: the union of the three articulator groups (Padgett p. 83's "Place
+/-- The place class: the union of the three articulator classes (Padgett p. 83's "Place
 simply stands for the set {[labial], [coronal], [dorsal], …}"). -/
 def place : Finset Feature := labial.features ∪ coronal.features ∪ dorsal.features
 
-variable {f : Feature} {c : Category}
+variable {f : Feature} {c : FeatureClass}
 
-theorem mem_features : f ∈ c.features ↔ f.category = c := by simp [features]
+theorem mem_features : f ∈ c.features ↔ f.featureClass = c := by simp [features]
 
 theorem mem_place :
-    f ∈ place ↔ f.category = .labial ∨ f.category = .coronal ∨ f.category = .dorsal := by
+    f ∈ place ↔
+      f.featureClass = .labial ∨ f.featureClass = .coronal ∨ f.featureClass = .dorsal := by
   simp [place, mem_features]
 
-instance (s₁ s₂ : Segment) (c : Category) : Decidable (Set.EqOn s₁ s₂ ↑c.features) :=
+instance (s₁ s₂ : Segment) (c : FeatureClass) : Decidable (Set.EqOn s₁ s₂ ↑c.features) :=
   Set.decidableEqOnOfFintype _ _ _
 
 instance (s₁ s₂ : Segment) : Decidable (Set.EqOn s₁ s₂ ↑place) :=
   Set.decidableEqOnOfFintype _ _ _
 
-end Feature.Category
+end FeatureClass
 
 /-! ### Complex segments -/
 

--- a/Linglib/Studies/HalleVauxWolfe2000.lean
+++ b/Linglib/Studies/HalleVauxWolfe2000.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.FeatureGeometry
-import Linglib.Phonology.Segmental.Classes
+import Linglib.Phonology.Segmental.FeatureClass
 
 /-!
 # Halle, Vaux and Wolfe (2000): feature spreading and the representation of place

--- a/Linglib/Studies/Sagey1986.lean
+++ b/Linglib/Studies/Sagey1986.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.FeatureGeometry
-import Linglib.Phonology.Segmental.Classes
+import Linglib.Phonology.Segmental.FeatureClass
 import Linglib.Phonology.Autosegmental.NonCrossing
 import Linglib.Phonology.Subregular.LocalRewrite
 import Linglib.Core.Order.Interval
@@ -16,7 +16,7 @@ vocal tract articulator, establishing the labial, coronal, dorsal, and
 soft palate nodes (`Node` below, an instance of
 `Phonology/FeatureGeometry.lean`). The geometry predicts which multiply-articulated
 (complex) segments are possible in human language
-(`Segment.IsComplex` in `Phonology/Segmental/Classes.lean`).
+(`Segment.IsComplex` in `Phonology/Segmental/FeatureClass.lean`).
 
 This study file formalizes Sagey-specific contributions that go beyond
 the consensus geometry:

--- a/references.bib
+++ b/references.bib
@@ -22936,7 +22936,7 @@
   subfield  = {phonology},
   validated = {true},
   role      = {foundational},
-  sources   = {Studies/Clements1985.lean, Phonology/Segmental/Classes.lean, Features/Phi/Geometry.lean, Phonology/FeatureGeometry.lean}
+  sources   = {Studies/Clements1985.lean, Phonology/Segmental/FeatureClass.lean, Features/Phi/Geometry.lean, Phonology/FeatureGeometry.lean}
 }
 @unpublished{mohanan-1983,
   author    = {Mohanan, K. P.},
@@ -22999,7 +22999,7 @@
   doi       = {10.1162/002438900554398},
   subfield  = {phonology},
   role      = {foundational},
-  sources   = {Phonology/Segmental/Classes.lean, Studies/HalleVauxWolfe2000.lean, Phonology/FeatureGeometry.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean, Studies/HalleVauxWolfe2000.lean, Phonology/FeatureGeometry.lean}
 }
 @article{padgett-2002,
   author    = {Padgett, Jaye},
@@ -23012,7 +23012,7 @@
   doi       = {10.1353/lan.2002.0046},
   subfield  = {phonology},
   role      = {foundational},
-  sources   = {Phonology/Segmental/Classes.lean, Phonology/FeatureGeometry.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean, Phonology/FeatureGeometry.lean}
 }
 @article{brown-meyer-2024,
   author    = {Brown, Jason and Meyer, Johanna},
@@ -23024,7 +23024,7 @@
   doi       = {10.1007/s11049-023-09606-0},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean, Phonology/FeatureGeometry.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean, Phonology/FeatureGeometry.lean}
 }
 @book{gussenhoven-jacobs-2017,
   author    = {Gussenhoven, Carlos and Jacobs, Haike},
@@ -23035,7 +23035,7 @@
   address   = {Abingdon},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean}
 }
 @incollection{broe-1992,
   author    = {Broe, Michael},
@@ -23048,7 +23048,7 @@
   pages     = {149--165},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean}
 }
 @book{bale-reiss-2018,
   author    = {Bale, Alan and Reiss, Charles},
@@ -23058,7 +23058,7 @@
   address   = {Cambridge, MA},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean}
 }
 @book{zsiga-2020,
   author    = {Zsiga, Elizabeth C.},
@@ -23068,7 +23068,7 @@
   address   = {Edinburgh},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean}
 }
 @book{davenport-hannahs-2020,
   author    = {Davenport, Mike and Hannahs, S. J.},
@@ -23079,7 +23079,7 @@
   address   = {Abingdon},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Segmental/Classes.lean}
+  sources   = {Phonology/Segmental/FeatureClass.lean}
 }
 @phdthesis{sagey-1986,
   author    = {Sagey, Elizabeth C.},
@@ -23090,7 +23090,7 @@
     subfield  = {phonology},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Sagey1986.lean, Phonology/Segmental/Classes.lean, Phonology/FeatureGeometry.lean}
+  sources   = {Studies/Sagey1986.lean, Phonology/Segmental/FeatureClass.lean, Phonology/FeatureGeometry.lean}
 }
 @incollection{stojkovic-2026,
   author    = {Stojkovi{\'c}, Jelena},
@@ -23115,7 +23115,7 @@
   subfield  = {phonology},
   validated = {true},
   role      = {foundational},
-  sources   = {Fragments/Korean/Phonology.lean;Fragments/English/Phonology.lean;Fragments/Finnish/ConsonantGradation.lean;Phonology/Segmental/Classes.lean;Morphology/MorphWord.lean;Phonology/Subregular/LocalRewrite.lean;Phonology/Segmental/Defs.lean}
+  sources   = {Fragments/Korean/Phonology.lean;Fragments/English/Phonology.lean;Fragments/Finnish/ConsonantGradation.lean;Phonology/Segmental/FeatureClass.lean;Morphology/MorphWord.lean;Phonology/Subregular/LocalRewrite.lean;Phonology/Segmental/Defs.lean}
 }
 @article{hayes-wilson-2008,
   author    = {Hayes, Bruce and Wilson, Colin},


### PR DESCRIPTION
Make the type match the file: the five Hayes groups are `FeatureClass` (Padgett's term), the map is `Feature.featureClass`, the sets are `FeatureClass.features` and `FeatureClass.place`, and the file is `Phonology/Segmental/FeatureClass.lean`; the old `Feature.Category` name survived the previous rename only by inertia.

- Finnish, the Sagey and Halle–Vaux–Wolfe studies, the root import list and the bib `sources` paths follow the rename; no definitions change.
