### PR TITLE
feat(Phonology/Subregular): class assimilation as a rewrite effect

### DIFF
--- a/Linglib/Core/Data/List/DropRight.lean
+++ b/Linglib/Core/Data/List/DropRight.lean
@@ -60,6 +60,11 @@ theorem rtake_append_of_le_length {n : ℕ} (l₁ l₂ : List α) (h : n ≤ l�
   rw [rdrop_eq_reverse_drop_reverse, rtake_eq_reverse_take_reverse, ← reverse_append,
     take_append_drop, reverse_reverse]
 
+/-- A nonempty right window ends where the list ends. -/
+theorem getLast?_rtake (l : List α) {n : ℕ} (h : 1 ≤ n) : (l.rtake n).getLast? = l.getLast? := by
+  rw [List.rtake_eq_reverse_take_reverse, List.getLast?_reverse, List.head?_take,
+    if_neg (by omega), List.head?_reverse]
+
 /-- Taking a suffix of a suffix takes the shorter of the two. -/
 theorem rtake_rtake (m n : ℕ) (l : List α) : (l.rtake n).rtake m = l.rtake (min m n) := by
   simp [rtake_eq_reverse_take_reverse, take_take]

--- a/Linglib/Phonology/Subregular/LocalRewrite.lean
+++ b/Linglib/Phonology/Subregular/LocalRewrite.lean
@@ -2,9 +2,20 @@
 Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
+
+## References
+
+* [N. Chomsky and M. Halle, *The Sound Pattern of English* (1968)][chomsky-halle-1968]
+* [C. D. Johnson, *Formal Aspects of Phonological Description* (1972)][johnson-1972]
+* [R. M. Kaplan and M. Kay, *Regular Models of Phonological Rule Systems* (1994)][kaplan-kay-1994]
+* [B. P. Hayes, *Introductory Phonology* (2009)][hayes-2009]
+* [J. Chandlee, *Strictly Local Phonological Processes* (2014)][chandlee-2014]
+* [J. Chandlee and J. Heinz, *Strict Locality and Phonological Maps* (2018)][chandlee-heinz-2018]
+* [M. Mohri, *Finite-State Transducers in Language and Speech Processing* (1997)][mohri-1997]
 -/
 import Linglib.Phonology.Segmental.Basic
 import Linglib.Phonology.Subregular.ISL
+import Mathlib.Data.Finset.Piecewise
 
 /-!
 # Local phonological rewrite rules
@@ -12,20 +23,22 @@ import Linglib.Phonology.Subregular.ISL
 A **local rewrite rule** is a triple `(target, effect, context)` denoting a
 featurally-conditioned transformation of segment strings. The SPE notation
 `A → B / C __ D` — "every segment matching natural class `A` becomes `B`
-between context `C` and `D`" — originates with [chomsky-halle-1968]; the
-characterization of ordered SPE-rule cascades as regular relations is
-[johnson-1972], [kaplan-kay-1994], with pedagogical exposition in [hayes-2009].
+between context `C` and `D`" — originates with Chomsky and Halle; the
+characterization of ordered SPE-rule cascades as regular relations is due to
+Johnson and to Kaplan and Kay, with pedagogical exposition in Hayes.
 
 In the modern subregular setting these rules are a surface notation for the
-**Input Strictly Local (ISL)** functions of [chandlee-2014], [chandlee-heinz-2018],
+**Input Strictly Local (ISL)** functions of Chandlee and of Chandlee and Heinz,
 rather than a cognitive theory of phonological grammar (that role is held by
 constraint-based frameworks such as `Phonology/OptimalityTheory/`).
 
 ## Main definitions
 
 * `ContextElem` — a segment pattern or word boundary.
-* `Effect` — feature merge or deletion.
-* `Rule` — the `target / effect / leftContext / rightContext` schema.
+* `Effect` — feature merge, deletion, or assimilation of a feature class to a
+  neighbour (SPE alpha-variables; node spreading when the class is natural).
+* `Rule` — the `target / effect / leftContext / rightContext` schema, with
+  `Rule.leftReach` and `Rule.rightReach` the input it inspects on each side.
 * `Rule.apply` — a single left-to-right scan with simultaneous application.
 * `derive` — an ordered-rule cascade (extrinsic ordering, the SPE convention).
 * `Rule.toISLRule`, `Rule.toSubsequentialTransducer` — the two machine
@@ -33,33 +46,35 @@ constraint-based frameworks such as `Phonology/OptimalityTheory/`).
 
 ## Main results
 
-* `matchRightContext_take`, `matchLeftContext_rtake` — a context of length `n`
-  reads at most `n` symbols, so both matchers factor through a bounded window.
-* `Rule.isLeftInputStrictlyLocal` — a rule with no right context is
-  `(|leftContext| + 1)`-Left-ISL.
+* `matchRightContext_take`, `matchLeftContext_rtake`, `Effect.apply_rtake`,
+  `Effect.apply_append` — contexts and effects read bounded windows, so a verdict
+  factors through `leftReach` symbols to the left and `rightReach` to the right.
+* `Rule.isLeftInputStrictlyLocal` — a rule reading nothing to its right is
+  `(leftReach + 1)`-Left-ISL.
 * `Rule.isLeftSubsequential` — over a finite segment alphabet every rule is
-  Left-Subsequential, via a transducer that delays emission by `|rightContext|`
+  Left-Subsequential, via a transducer that delays emission by `rightReach`
   symbols and flushes the buffer at the word end.
 
 ## Implementation notes
 
-Application is single-pass and simultaneous: context matches are evaluated
-against the input, not the partially-rewritten output ([chomsky-halle-1968],
-[chandlee-heinz-2018]). `Effect` covers only feature change and deletion, so
-insertion, metathesis, coalescence, and alpha-notation agreement variables are
-not expressible, and application is neither iterative/directional nor cyclic.
-Iterative spreading lies in the strictly larger Output Strictly Local class
-(`Subregular.OSLRule`).
+Application is single-pass and simultaneous: context matches and copied values
+are read from the input, not the partially-rewritten output (Chomsky and Halle,
+Chandlee and Heinz). `Effect` covers feature change, deletion, and copying a
+feature class from the adjacent input segment — Chomsky and Halle's
+alpha-variables, which is `Finset.piecewise` on the class — so insertion,
+metathesis and coalescence are not expressible, and application is neither
+iterative/directional nor cyclic. Iterative spreading lies in the strictly
+larger Output Strictly Local class (`Subregular.OSLRule`).
 
 ## Todo
 
 * `Rule.apply` over **boundary-augmented** input. Padding the string with word
   boundaries turns the right context into lookahead the padding pays for, and
   the rule becomes `k`-Left-ISL with
-  `k = r.leftContext.length + r.rightContext.length + 1`. Over raw strings that
-  statement does not hold in general — a bounded left window cannot see the
-  right context — which is why `Rule.isLeftInputStrictlyLocal` assumes an empty
-  right context and `Rule.isLeftSubsequential` is what survives without it.
+  `k = r.leftReach + r.rightReach + 1`. Over raw strings that statement does
+  not hold in general — a bounded left window cannot see the right context —
+  which is why `Rule.isLeftInputStrictlyLocal` assumes no right reach and
+  `Rule.isLeftSubsequential` is what survives without it.
 -/
 
 namespace Subregular.LocalRewrite
@@ -84,13 +99,55 @@ inductive Effect where
   | changeFeatures : Segment → Effect
   /-- Delete the target segment. SPE notation: `A → ∅`. -/
   | delete : Effect
+  /-- Assimilate the features of the class `C` to the following segment: the alpha-variable
+      change `A → [αF, βG, …] / __ [αF, βG, …]` for `C = {F, G, …}`, and the spreading of a
+      class node when `C` is a natural class (`Phonology/FeatureGeometry.lean`). -/
+  | copyRight : Finset Feature → Effect
+  /-- Assimilate the features of the class `C` to the preceding segment. -/
+  | copyLeft : Finset Feature → Effect
 
-/-- Apply an effect to a target segment. Returns `none` if the segment
-is deleted; `some s'` if features are merged into `s'`. -/
-def Effect.apply (e : Effect) (s : Segment) : Option Segment :=
+/-- How many segments to the left of the target an effect reads. -/
+def Effect.leftReach : Effect → ℕ
+  | .copyLeft _ => 1
+  | _ => 0
+
+/-- How many segments to the right of the target an effect reads. -/
+def Effect.rightReach : Effect → ℕ
+  | .copyRight _ => 1
+  | _ => 0
+
+/-- Apply an effect to a target `s` standing between the prefix `w` and the suffix `d`:
+`none` deletes the segment, and a class copy takes the neighbour's values on the class,
+leaving the target unchanged at a word edge. -/
+def Effect.apply (e : Effect) (w : List Segment) (s : Segment) (d : List Segment) :
+    Option Segment :=
   match e with
   | .changeFeatures change => some (Features.Bundle.merge change s)
   | .delete => none
+  | .copyRight C => some (d.head?.elim s λ t => C.piecewise t s)
+  | .copyLeft C => some (w.getLast?.elim s λ t => C.piecewise t s)
+
+/-- An effect reads at most `leftReach` symbols of the prefix. -/
+theorem Effect.apply_rtake (e : Effect) {n : ℕ} (h : e.leftReach ≤ n) (w : List Segment)
+    (s : Segment) (d : List Segment) : e.apply (w.rtake n) s d = e.apply w s d := by
+  cases e with
+  | changeFeatures _ => rfl
+  | delete => rfl
+  | copyRight _ => rfl
+  | copyLeft C =>
+    have h1 : 1 ≤ n := by simpa [Effect.leftReach] using h
+    simp only [Effect.apply, List.getLast?_rtake _ h1]
+
+/-- An effect reads at most `rightReach` symbols of the suffix. -/
+theorem Effect.apply_append (e : Effect) (w : List Segment) (s : Segment) (d d' : List Segment)
+    (h : e.rightReach ≤ d.length) : e.apply w s (d ++ d') = e.apply w s d := by
+  cases e with
+  | changeFeatures _ => rfl
+  | delete => rfl
+  | copyLeft _ => rfl
+  | copyRight C =>
+    have hd : d ≠ [] := by rintro rfl; simp [Effect.rightReach] at h
+    simp only [Effect.apply, List.head?_append_of_ne_nil d hd]
 
 /-! ### Rules -/
 
@@ -109,6 +166,14 @@ structure Rule where
   effect : Effect
   leftContext : List ContextElem := []
   rightContext : List ContextElem := []
+
+/-- The input symbols to the left of the target a rule reads: its left context and whatever its
+effect copies. -/
+def Rule.leftReach (r : Rule) : ℕ := max r.leftContext.length r.effect.leftReach
+
+/-- The input symbols to the right of the target a rule reads: its right context and whatever
+its effect copies. -/
+def Rule.rightReach (r : Rule) : ℕ := max r.rightContext.length r.effect.rightReach
 
 /-! ### Context matching -/
 
@@ -134,10 +199,10 @@ def matchLeftContext (ctx : List ContextElem) (left : List Segment) : Bool :=
 /-- Apply a single rule to a segment string. Scans left-to-right; at
 every position where the target and contexts match, applies the effect.
 Application is **simultaneous** in the SPE sense (convention (39),
-[chomsky-halle-1968] p. 344): contexts are matched against the *input*,
+Chomsky and Halle p. 344): contexts are matched against the *input*,
 not the partially-rewritten output — the prefix `left` accumulates the
 original segments, so a rule's own output never feeds its later matches.
-Cf. [chandlee-heinz-2018].
+Cf. Chandlee and Heinz.
 
 The recursion is structural on `right` (the unprocessed suffix), so
 `Rule.apply` reduces cleanly under `decide` for finite inputs. -/
@@ -150,7 +215,7 @@ where
       if decide (r.target ≤ s)
           && matchLeftContext r.leftContext left
           && matchRightContext r.rightContext right then
-        match r.effect.apply s with
+        match r.effect.apply left s right with
         | some s' => s' :: go (left ++ [s]) right
         | none => go (left ++ [s]) right  -- deletion
       else
@@ -182,6 +247,19 @@ theorem matchLeftContext_rtake (ctx : List ContextElem) (left : List Segment) :
     simp [List.rtake_eq_reverse_take_reverse]
   rw [matchLeftContext, h, matchRightContext_take, matchLeftContext]
 
+/-- Any window at least as long as the context reads the same. -/
+theorem matchLeftContext_rtake_of_le (ctx : List ContextElem) {n : ℕ} (h : ctx.length ≤ n)
+    (left : List Segment) : matchLeftContext ctx (left.rtake n) = matchLeftContext ctx left := by
+  rw [← matchLeftContext_rtake ctx (left.rtake n), List.rtake_rtake, min_eq_left h,
+    matchLeftContext_rtake]
+
+/-- A suffix at least as long as the context reads the same as its extensions. -/
+theorem matchRightContext_append_of_le (ctx : List ContextElem) {d : List Segment}
+    (d' : List Segment) (h : ctx.length ≤ d.length) :
+    matchRightContext ctx (d ++ d') = matchRightContext ctx d := by
+  rw [← matchRightContext_take ctx d, ← matchRightContext_take ctx (d ++ d'),
+    List.take_append_of_le_length h]
+
 /-! ### The verdict at a position -/
 
 /-- The output block a rule contributes at one position: the effect applied when
@@ -191,7 +269,7 @@ def Rule.verdict (r : Rule) (w : List Segment) (s : Segment) (d : List Segment) 
     List Segment :=
   if decide (r.target ≤ s) && matchLeftContext r.leftContext w
       && matchRightContext r.rightContext d then
-    (r.effect.apply s).toList
+    (r.effect.apply w s d).toList
   else [s]
 
 /-- `Rule.apply` emits one `Rule.verdict` per input position. -/
@@ -201,32 +279,34 @@ theorem Rule.apply_go_cons (r : Rule) (left : List Segment) (s : Segment)
       = r.verdict left s right ++ Rule.apply.go r (left ++ [s]) right := by
   cases hc : decide (r.target ≤ s) && matchLeftContext r.leftContext left
       && matchRightContext r.rightContext right <;>
-    cases he : r.effect.apply s <;> simp [Rule.apply.go, Rule.verdict, hc, he]
+    cases he : r.effect.apply left s right <;> simp [Rule.apply.go, Rule.verdict, hc, he]
 
-/-- The verdict reads only the last `|leftContext|` symbols of the prefix. -/
+/-- The verdict reads only the last `leftReach` symbols of the prefix. -/
 theorem Rule.verdict_rtake (r : Rule) (w : List Segment) (s : Segment) (d : List Segment) :
-    r.verdict (w.rtake r.leftContext.length) s d = r.verdict w s d := by
-  rw [Rule.verdict, Rule.verdict, matchLeftContext_rtake]
+    r.verdict (w.rtake r.leftReach) s d = r.verdict w s d := by
+  rw [Rule.verdict, Rule.verdict,
+    matchLeftContext_rtake_of_le r.leftContext (n := r.leftReach) (le_max_left _ _),
+    Effect.apply_rtake r.effect (n := r.leftReach) (le_max_right _ _)]
 
-/-- The verdict reads only the first `|rightContext|` symbols of the suffix. -/
+/-- The verdict reads only the first `rightReach` symbols of the suffix. -/
 theorem Rule.verdict_append (r : Rule) (w : List Segment) (s : Segment) (d e : List Segment)
-    (h : r.rightContext.length ≤ d.length) : r.verdict w s (d ++ e) = r.verdict w s d := by
-  rw [Rule.verdict, Rule.verdict, ← matchRightContext_take r.rightContext d,
-    ← matchRightContext_take r.rightContext (d ++ e), List.take_append_of_le_length h]
+    (h : r.rightReach ≤ d.length) : r.verdict w s (d ++ e) = r.verdict w s d := by
+  rw [Rule.verdict, Rule.verdict,
+    matchRightContext_append_of_le _ _
+      ((le_max_left _ _ : r.rightContext.length ≤ r.rightReach).trans h),
+    Effect.apply_append _ _ _ _ _ ((le_max_right _ _ : r.effect.rightReach ≤ r.rightReach).trans h)]
 
 /-! ### The bounded-window scan -/
 
-/-- `Rule.apply` rewritten to carry only the last `|leftContext|` input symbols:
-the unbounded prefix of `Rule.apply.go` is replaced by the window the rule can
-actually inspect. -/
+/-- `Rule.apply` rewritten to carry only the last `leftReach` input symbols: the unbounded
+prefix of `Rule.apply.go` is replaced by the window the rule can actually inspect. -/
 def Rule.scan (r : Rule) (w : List Segment) : List Segment → List Segment
   | [] => []
-  | s :: right =>
-    r.verdict w s right ++ r.scan ((w ++ [s]).rtake r.leftContext.length) right
+  | s :: right => r.verdict w s right ++ r.scan ((w ++ [s]).rtake r.leftReach) right
 
-/-- Truncating the prefix to the rule's left-context length loses nothing. -/
+/-- Truncating the prefix to the rule's left reach loses nothing. -/
 theorem Rule.scan_rtake (r : Rule) (left right : List Segment) :
-    r.scan (left.rtake r.leftContext.length) right = Rule.apply.go r left right := by
+    r.scan (left.rtake r.leftReach) right = Rule.apply.go r left right := by
   induction right generalizing left with
   | nil => rfl
   | cons s right ih =>
@@ -238,45 +318,45 @@ theorem Rule.apply_eq_scan (r : Rule) : r.apply = r.scan [] := by
   show Rule.apply.go r [] input = _
   simpa using (r.scan_rtake [] input).symm
 
-/-! ### No right context: Input Strict Locality
+/-! ### No right reach: Input Strict Locality
 
-With `rightContext = []` a verdict depends only on the last `|leftContext|`
-input symbols and the current one — exactly the `(|leftContext| + 1)`-ISL
-window of [chandlee-2014], [chandlee-heinz-2018]. -/
+A rule that reads nothing to its right — no right context and no copy from the right —
+has a verdict depending only on the last `leftReach` input symbols and the current one,
+exactly the `(leftReach + 1)`-ISL window of Chandlee and of Chandlee and Heinz. -/
 
-/-- The ISL rule computing a rewrite with no right context. The hypothesis is
-the applicability condition: with a nonempty `rightContext` the lookahead `[]`
-supplied here is the end-of-word one, not the one `Rule.apply` uses. -/
-def Rule.toISLRule (r : Rule) (_h : r.rightContext = []) :
-    ISLRule (r.leftContext.length + 1) Segment Segment where
+/-- The ISL rule computing a rewrite with no right reach. The hypothesis is the
+applicability condition: with a positive right reach the lookahead `[]` supplied here is
+the end-of-word one, not the one `Rule.apply` uses. -/
+def Rule.toISLRule (r : Rule) (_h : r.rightReach = 0) :
+    ISLRule (r.leftReach + 1) Segment Segment where
   windowOutput w s := r.verdict w s []
 
-private theorem Rule.applyAux_toISLRule (r : Rule) (h : r.rightContext = [])
+private theorem Rule.applyAux_toISLRule (r : Rule) (h : r.rightReach = 0)
     (w input : List Segment) : (r.toISLRule h).applyAux w input = r.scan w input := by
   induction input generalizing w with
   | nil => rfl
   | cons s xs ih =>
     have hv : (r.toISLRule h).windowOutput w s = r.verdict w s xs := by
       show r.verdict w s [] = r.verdict w s xs
-      simp [Rule.verdict, h, matchRightContext]
+      simpa using (r.verdict_append w s [] xs (by simp [h])).symm
     rw [ISLRule.applyAux_cons, hv, Nat.add_sub_cancel, Rule.scan, ih]
 
-theorem Rule.toISLRule_apply (r : Rule) (h : r.rightContext = []) :
+theorem Rule.toISLRule_apply (r : Rule) (h : r.rightReach = 0) :
     (r.toISLRule h).apply = r.apply := by
   funext input
   show (r.toISLRule h).applyAux [] input = _
   rw [r.applyAux_toISLRule h, Rule.apply_eq_scan]
 
-/-- **A rewrite rule with no right context is Left-ISL**, with `k` one more than
-the length of its left context. -/
-theorem Rule.isLeftInputStrictlyLocal (r : Rule) (h : r.rightContext = []) :
-    IsLeftInputStrictlyLocal (r.leftContext.length + 1) r.apply :=
+/-- **A rewrite rule with no right reach is Left-ISL**, with `k` one more than its left
+reach. -/
+theorem Rule.isLeftInputStrictlyLocal (r : Rule) (h : r.rightReach = 0) :
+    IsLeftInputStrictlyLocal (r.leftReach + 1) r.apply :=
   ⟨r.toISLRule h, r.toISLRule_apply h⟩
 
 /-! ### The general case: left-subsequentiality
 
-A nonempty right context is lookahead, which a left-to-right scan cannot have.
-The transducer buys it with delay: it leaves the last `|rightContext|` segments
+A positive right reach is lookahead, which a left-to-right scan cannot have.
+The transducer buys it with delay: it leaves the last `rightReach` segments
 unjudged in a buffer, so that the oldest buffered segment always has its full
 right context in hand, and judges what remains buffered against the word end in
 `finalOutput`. That final flush is what the right context costs — `ofWindow`,
@@ -286,8 +366,8 @@ and with it every ISL rule, emits nothing at the end. -/
 paired with the lookahead buffer of segments whose right context is still
 incomplete. -/
 abbrev Rule.State (r : Rule) : Type :=
-  {l : List Segment // l.length ≤ r.leftContext.length} ×
-    {l : List Segment // l.length ≤ r.rightContext.length}
+  {l : List Segment // l.length ≤ r.leftReach} ×
+    {l : List Segment // l.length ≤ r.rightReach}
 
 /-- The delayed transducer for an arbitrary rewrite rule. Reading `x` appends it
 to the buffer; whatever that pushes out of the buffer has acquired its full right
@@ -298,12 +378,12 @@ def Rule.toSubsequentialTransducer (r : Rule) :
     SubsequentialTransducer r.State Segment Segment where
   start := (⟨[], Nat.zero_le _⟩, ⟨[], Nat.zero_le _⟩)
   step s x :=
-    (⟨(s.1.val ++ (s.2.val ++ [x]).rdrop r.rightContext.length).rtake r.leftContext.length,
+    (⟨(s.1.val ++ (s.2.val ++ [x]).rdrop r.rightReach).rtake r.leftReach,
         List.length_rtake_le _ _⟩,
-      ⟨(s.2.val ++ [x]).rtake r.rightContext.length, List.length_rtake_le _ _⟩)
+      ⟨(s.2.val ++ [x]).rtake r.rightReach, List.length_rtake_le _ _⟩)
   output s x :=
-    ((s.2.val ++ [x]).rdrop r.rightContext.length).flatMap fun b =>
-      r.verdict s.1.val b ((s.2.val ++ [x]).rtake r.rightContext.length)
+    ((s.2.val ++ [x]).rdrop r.rightReach).flatMap fun b =>
+      r.verdict s.1.val b ((s.2.val ++ [x]).rtake r.rightReach)
   finalOutput s := r.scan s.1.val s.2.val
 
 /-- From any state the delayed transducer judges the buffer and the remaining
@@ -317,17 +397,17 @@ theorem Rule.runFrom_toSubsequentialTransducer (r : Rule) (s : r.State)
     obtain ⟨⟨w, hw⟩, buf, hbuf⟩ := s
     rw [SubsequentialTransducer.runFrom_cons, ih]
     simp only [Rule.toSubsequentialTransducer, show buf ++ x :: xs = (buf ++ [x]) ++ xs by simp]
-    rcases Nat.lt_or_ge buf.length r.rightContext.length with h | h
-    · have hle : (buf ++ [x]).length ≤ r.rightContext.length := by simp; omega
-      rw [show (buf ++ [x]).rdrop r.rightContext.length = [] by simp [List.rdrop]; omega,
+    rcases Nat.lt_or_ge buf.length r.rightReach with h | h
+    · have hle : (buf ++ [x]).length ≤ r.rightReach := by simp; omega
+      rw [show (buf ++ [x]).rdrop r.rightReach = [] by simp [List.rdrop]; omega,
         List.rtake_of_length_le hle]
       simp [List.rtake_of_length_le hw]
     · obtain ⟨b, rest, hb⟩ : ∃ b rest, buf ++ [x] = b :: rest :=
         List.exists_cons_of_ne_nil (by simp)
-      have hrest : rest.length = r.rightContext.length := by
+      have hrest : rest.length = r.rightReach := by
         have hl := congrArg List.length hb; simp at hl; omega
-      rw [hb, show (b :: rest).rdrop r.rightContext.length = [b] by simp [List.rdrop, hrest],
-        show (b :: rest).rtake r.rightContext.length = rest by simp [List.rtake, hrest],
+      rw [hb, show (b :: rest).rdrop r.rightReach = [b] by simp [List.rdrop, hrest],
+        show (b :: rest).rtake r.rightReach = rest by simp [List.rtake, hrest],
         List.cons_append, Rule.scan, r.verdict_append w b rest xs hrest.ge]
       simp
 
@@ -339,9 +419,9 @@ theorem Rule.run_toSubsequentialTransducer (r : Rule) :
   simp [Rule.apply_eq_scan, Rule.toSubsequentialTransducer]
 
 /-- **Every local rewrite rule is Left-Subsequential.** `Segment` is a partial
-valuation of the 26 features of [hayes-2009], so it is finite but carries no
+valuation of the 26 features of Hayes, so it is finite but carries no
 `Fintype` instance (its `Flat` slots are deliberately opaque); the hypothesis
-supplies the finite alphabet [mohri-1997] assumes without forcing a
+supplies the finite alphabet Mohri assumes without forcing a
 `3 ^ 26`-element enumeration on every consumer of this file. -/
 theorem Rule.isLeftSubsequential [Fintype Segment] (r : Rule) :
     IsLeftSubsequential r.apply :=

--- a/Linglib/Studies/Clements1985.lean
+++ b/Linglib/Studies/Clements1985.lean
@@ -1,5 +1,6 @@
 import Linglib.Fragments.English.Phonology
 import Linglib.Phonology.FeatureGeometry
+import Linglib.Phonology.Subregular.LocalRewrite
 
 /-!
 # Clements (1985): the geometry of phonological features
@@ -30,7 +31,9 @@ flags as possibly superfluous, is dropped by the later geometries formalized her
   features (§4).
 * `Spreading`, `Spreading.features`, `Spreading.apply` — what one rule may spread, the
   root, a class node or one feature ((5)), and the assimilation it effects.
-* `CoronalAssimilation.Applies`, `coronalAssimilation` — the English rule (12).
+* `rule12`, `rule14`, `rule14Nasal` — the English rule (12) as a local rewrite rule copying
+  the place class, its SPE statement (14) copying `[anterior]` and `[distributed]`, and the
+  `[αnasal]` variant the paper contrasts with it.
 
 ## Main results
 
@@ -40,9 +43,12 @@ flags as possibly superfluous, is dropped by the later geometries formalized her
   against the `[αnasal]` variant of (14); `eq_root_of_continuant_of_voice` is the Kikuyu
   case of §5.1 and `supralaryngeal_subset_of_anterior_of_continuant` the palatalisation
   case of §5.2.
-* `coronalAssimilation_n_θ`, `coronalAssimilation_t_θ`, `coronalAssimilation_d_θ`,
-  `coronalAssimilation_n_esh` — *tenth*, *eighth*, *hundredth*, *insure* from table (11):
-  the target takes the trigger's place features and nothing else.
+* `rule12_n_θ`, `rule12_t_θ`, `rule12_d_θ`, `rule12_n_esh` — *tenth*, *eighth*,
+  *hundredth*, *insure* from table (11): the target takes the trigger's place features and
+  nothing else; `rule12_n_p` and `rule12_s_θ` are the non-sites.
+* `rule14_n_θ`, `rule14_n_esh`, `no_spreading_nasal_distributed` — (14) agrees with (12) on
+  the English data, but its alpha-variables accept the `[αnasal]` variant that no single-node
+  spreading can express.
 * `preaspiration` — spreading the vowel's supralaryngeal node onto the delinked first half
   of an aspirated geminate keeps the stop's laryngeal features ((7)), by the substrate's
   disjointness of sister classes.
@@ -58,9 +64,9 @@ so the trigger's unspecified features under the node replace the target's, as th
 convention of (13) requires; single-feature spreading is `Features.Bundle.assimilate`
 (`Spreading.apply_feature`). The English segments are the Fragment's; its /r/ is
 [+anterior] where table (10) has [−anterior, −distributed], so the retroflex row of (11)
-(*tree*, *dream*, *enrol*) is not derived. The SPE rule (14) needs α-variables that
-`Subregular.LocalRewrite` does not provide, so the comparison with (12) is stated on the
-geometric side only.
+(*tree*, *dream*, *enrol*) is not derived. The SPE rule (14) is `Effect.copyRight` on the
+two-feature set and (12) the same effect on the place class, so the comparison is between
+the sets a rule may copy, not between formalisms.
 
 ## TODO
 
@@ -86,7 +92,7 @@ geometric side only.
 
 namespace Clements1985
 
-open Phonology Phonology.FeatureGeometry English.Phonology
+open Phonology Phonology.FeatureGeometry English.Phonology Subregular.LocalRewrite
 
 attribute [local instance] Set.decidableEqOnOfFintype
 
@@ -233,49 +239,61 @@ theorem supralaryngeal_subset_of_anterior_of_continuant (h₁ : Feature.anterior
     naturalClass Node.supralaryngeal ⊆ σ.features := by
   revert σ; decide
 
-/-! ### English coronal place assimilation ((10)–(13)) -/
+/-! ### English coronal place assimilation ((10)–(14)) -/
 
-namespace CoronalAssimilation
+/-- Rule (12) as a local rewrite rule: a `[−continuant, +coronal, +anterior]` target, one of
+/t d n/, takes the place node of a following `[+consonantal, +coronal]` segment. -/
+def rule12 : Rule where
+  target := Segment.ofSpecs [(.continuant, false), (.coronal, true), (.anterior, true)]
+  effect := .copyRight (naturalClass Node.place)
+  rightContext := [.seg (Segment.ofSpecs [(.consonantal, true), (.coronal, true)])]
 
-/-- The structural description of (12): a `[−continuant, +coronal, +anterior]` target, one
-of /t d n/, before a `[+consonantal, +coronal]` trigger. -/
-def Applies (tgt trg : Segment) : Prop :=
-  tgt.HasValue .continuant false ∧ tgt.HasValue .coronal true ∧ tgt.HasValue .anterior true ∧
-    trg.HasValue .consonantal true ∧ trg.HasValue .coronal true
+/-- The SPE statement (14): the same target before a `[+coronal]` segment copies that
+segment's `[anterior]` and `[distributed]` by alpha-variables. -/
+def rule14 : Rule where
+  target := Segment.ofSpecs [(.coronal, true), (.anterior, true), (.continuant, false)]
+  effect := .copyRight {Feature.anterior, Feature.distributed}
+  rightContext := [.seg (Segment.ofSpecs [(.coronal, true)])]
 
-instance : DecidableRel Applies := λ _ _ => inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ _ ∧ _))
-
-end CoronalAssimilation
-
-/-- Rule (12): where its structural description holds, spread the trigger's place node onto
-the target. -/
-def coronalAssimilation (tgt trg : Segment) : Segment :=
-  if CoronalAssimilation.Applies tgt trg then (Spreading.node .place).apply trg tgt else tgt
+/-- The variant of (14) with `[αnasal]` for `[αanterior]`: "no more and no less ordinary" as
+an SPE rule, and unattested. -/
+def rule14Nasal : Rule := { rule14 with effect := .copyRight {Feature.nasal, Feature.distributed} }
 
 /-- *tenth*: /n/ before /θ/ takes `[+distributed]` and nothing else — a dental nasal. -/
-theorem coronalAssimilation_n_θ : coronalAssimilation n θ = n.setFeature .distributed true := by
-  decide
+theorem rule12_n_θ : rule12.apply [n, θ] = [n.setFeature .distributed true, θ] := by decide
 
 /-- *eighth*: /t/ before /θ/. -/
-theorem coronalAssimilation_t_θ : coronalAssimilation t θ = t.setFeature .distributed true := by
-  decide
+theorem rule12_t_θ : rule12.apply [t, θ] = [t.setFeature .distributed true, θ] := by decide
 
 /-- *hundredth*: /d/ before /θ/. -/
-theorem coronalAssimilation_d_θ : coronalAssimilation d θ = d.setFeature .distributed true := by
-  decide
+theorem rule12_d_θ : rule12.apply [d, θ] = [d.setFeature .distributed true, θ] := by decide
 
 /-- *insure*: /n/ before /ʃ/ is postalveolar, `[−anterior, +distributed]`, and still a
 non-strident nasal, `[strident]` and `[nasal]` being manner features. -/
-theorem coronalAssimilation_n_esh :
-    coronalAssimilation n esh = (n.setFeature .anterior false).setFeature .distributed true := by
+theorem rule12_n_esh :
+    rule12.apply [n, esh] = [(n.setFeature .anterior false).setFeature .distributed true, esh] := by
   decide
 
 /-- A labial trigger is no site: *impossible* falls to the separate nasal assimilation
 rule. -/
-example : ¬ CoronalAssimilation.Applies n p := by decide
+theorem rule12_n_p : rule12.apply [n, p] = [n, p] := by decide
 
 /-- A fricative target is no site: the rule affects the stops /t d n/ only. -/
-example : ¬ CoronalAssimilation.Applies s θ := by decide
+theorem rule12_s_θ : rule12.apply [s, θ] = [s, θ] := by decide
+
+/-- On the English data (14) is not distinguishable from (12). -/
+theorem rule14_n_θ : rule14.apply [n, θ] = rule12.apply [n, θ] := by decide
+
+theorem rule14_n_esh : rule14.apply [n, esh] = rule12.apply [n, esh] := by decide
+
+/-- What separates them: the `[αnasal]` variant is a rule of the same form and applies, while
+no single-node spreading carries `[nasal]` and `[distributed]` without the whole
+supralaryngeal class (`supralaryngeal_subset_of_nasal_of_distributed`). -/
+theorem no_spreading_nasal_distributed :
+    ∀ σ : Spreading, σ.features ≠ {Feature.nasal, Feature.distributed} := by
+  decide
+
+theorem rule14Nasal_n_θ : rule14Nasal.apply [n, θ] ≠ [n, θ] := by decide
 
 /-! ### Supralaryngeal spreading: Icelandic preaspiration ((6)–(7)) -/
 


### PR DESCRIPTION
Add the alpha-variable change to local rewrite rules: `Effect.copyRight C` and `Effect.copyLeft C` assimilate the feature class `C` to the adjacent input segment, which is `Finset.piecewise` on `C`, so SPE `[αF, βG]` rules, node spreading (when `C` is a natural class) and AGREE on a class are one operation. Rules now carry `leftReach`/`rightReach` (context length or effect reach), and the window lemmas, bounded scan, ISL result (`rightReach = 0`) and delayed transducer are restated over reaches.

- `Core/Data/List/DropRight.lean` gains `getLast?_rtake`.
- Clements 1985: rule (12) and its SPE statement (14) are now `Rule`s; the table (11) derivations run through `Rule.apply`, (14) agrees with (12) on the English data, and the `[αnasal]` variant is a legal SPE rule that no single-node spreading matches.
- The rewrite file's docstrings move to the References-only citation convention.
