### PR TITLE
refactor(Studies/Cohen2013): cleanse against the chapter

### DIFF
--- a/Linglib/Semantics/Quantification/Generic.lean
+++ b/Linglib/Semantics/Quantification/Generic.lean
@@ -3,32 +3,25 @@ import Linglib.Semantics.Quantification.Counting
 /-!
 # Generic quantifiers as generalized-quantifier schemas
 
-Rival semantics for the silent generic operator `Gen`, expressed as instances of
-the existing `Quantification.GQ α` generalized-quantifier interface
-([barwise-cooper-1981]) rather than as bespoke per-paper types. The competing
-theories then differ by a **property of the `GQ`**, not by an incompatible
-signature: all are `Conservative`; only the majority schema is `Proportional`.
+Rival semantics for the silent generic operator Gen, expressed as instances of the
+existing `Quantification.GQ α` generalized-quantifier interface rather than as bespoke
+per-paper types. The competing theories then differ by a property of the `GQ`, not by an
+incompatible signature: all are `Conservative`, and only the majority schema is
+`Proportional`. The traditional schema is a normalcy-restricted universal — the kind's
+normal members satisfy the scope; Nickel's replaces the single normalcy predicate by ways
+of being normal, some one of which makes all of its normal members satisfy the scope. The
+third schema, Cohen's majority reading, is the existing `Quantification.most_sem`, and
+`most_proportional` records that it alone is proportional — its truth is a function of the
+|R ∩ S| : |R ∖ S| ratio. That is the precise "generics as majority quantification"
+characterization the later genericity literature rejects as a theory of generics; it is
+true of this operator, not of generics in general.
 
-* `genNormalcy` — the traditional normalcy-restricted universal
-  ([krifka-etal-1995]): the kind's NORMAL members satisfy the scope.
-* `genWays` — [nickel-2009]'s ways-of-normality: SOME way of being normal makes
-  all of its normal members satisfy the scope.
-
-The third schema, the majority/absolute-reading operator ([cohen-1999a]), is the
-existing `Quantification.most_sem`; `most_proportional` records that it — alone
-among the three — is `Proportional` (its truth is a function of the
-|R ∩ S| : |R ∖ S| ratio). That is the precise "generics as majority
-quantification" characterization the genericity literature ([nickel-2009],
-[leslie-2008]) rejects as a *theory of generics*; it is true of this operator,
-not of generics in general.
-
-The per-paper operators are shown EQUAL to these schemas in the study files
-(`Cohen1999.gen_univ_eq_most_sem`, `Nickel2009.nickelGEN_univ_eq_genWays`),
-so the unification subsumes them rather than paralleling them. Those bridges are
-to the operators *as linglib formalizes them*, inheriting their documented
-simplifications (Cohen's `gen` is the absolute reading with the alternative set at
-its extensional disjunction; `genWays` takes
-Nickel's modal "ways" at their actual extension).
+The per-paper operators are shown equal to these schemas in the study files
+(`Cohen1999.gen_univ_eq_most_sem`, `Nickel2009.nickelGEN_univ_eq_genWays`), so the
+unification subsumes them rather than paralleling them. Those bridges are to the operators
+as linglib formalizes them, inheriting their documented simplifications: Cohen's operator
+enters at the absolute reading with the alternative set at its extensional disjunction,
+and the ways schema takes Nickel's modal ways at their actual extensions.
 
 ## Main definitions
 
@@ -39,19 +32,26 @@ Nickel's modal "ways" at their actual extension).
 
 * `genNormalcy_conservative`, `genWays_conservative` — the generic schemas are
   conservative.
-* `genWays_singleton` — one way of normality reduces `genWays` to `genNormalcy`
-  (Nickel generalizes the traditional account).
-* `genNormalcy_not_ratio_determined` — the normalcy schema is not ratio-determined,
-  so (unlike the majority schema, `Counting.most_proportional`) it is not
-  `Proportional`: equal cardinality ratio, opposite generic verdict.
+* `genWays_singleton` — one way of normality reduces `genWays` to `genNormalcy`.
+* `genNormalcy_not_ratio_determined` — equal cardinality ratio, opposite generic verdict,
+  so the normalcy schema is not `Proportional`.
 
 ## Implementation notes
 
-`GQ α` is whole-carrier (`Fintype`); the study operators take an explicit
-`Finset` domain and bridge at `Finset.univ`. `most_sem`/`Proportional` are stated
-over the noncomputable classical `count`, so the proportionality contrast is
-witnessed by a decidable cardinality example rather than a `Proportional`
-counterexample.
+`GQ α` is whole-carrier (`Fintype`); the study operators take an explicit `Finset` domain
+and bridge at `Finset.univ`. `most_sem` and `Proportional` are stated over the
+noncomputable classical `count`, so the proportionality contrast is witnessed by a
+decidable cardinality example rather than a `Proportional` counterexample.
+
+## References
+
+* [J. Barwise and R. Cooper, *Generalized Quantifiers and Natural Language*
+  (1981)][barwise-cooper-1981]
+* [M. Krifka, F. J. Pelletier, G. N. Carlson, A. ter Meulen, G. Chierchia and G. Link,
+  *Genericity: An Introduction* (1995)][krifka-etal-1995]
+* [A. Cohen, *Think Generic! The Meaning and Use of Generic Sentences* (1999)][cohen-1999a]
+* [B. Nickel, *Generics and the Ways of Normality* (2009)][nickel-2009]
+* [S.-J. Leslie, *Generics: Cognition and Acquisition* (2008)][leslie-2008]
 -/
 
 namespace Quantification
@@ -60,15 +60,15 @@ variable {α : Type*} [Fintype α]
 
 /-! ### The generic schemas as generalized quantifiers -/
 
-/-- **Traditional `Gen`** ([krifka-etal-1995]) as a generalized quantifier: the
-    restrictor's NORMAL members all satisfy the scope — a normalcy-restricted
-    universal, i.e. `Gen` with a hidden normalcy parameter. -/
+/-- The traditional Gen as a generalized quantifier ([krifka-etal-1995]): the
+    restrictor's normal members all satisfy the scope — a restricted universal
+    with a hidden normalcy parameter. -/
 def genNormalcy (normal : α → Prop) : GQ α :=
   fun R S => everyOn Finset.univ (fun x => normal x ∧ R x) S
 
-/-- **[nickel-2009]'s ways-of-normality `Gen`** as a generalized quantifier:
-    SOME way of being normal makes all of its normal members satisfy the scope.
-    The actual-extension proxy of Nickel's modal "ways" (his own simplification). -/
+/-- The ways-of-normality Gen as a generalized quantifier ([nickel-2009]): some
+    way of being normal makes all of its normal members satisfy the scope, with
+    the ways taken at their actual extensions. -/
 def genWays {ι : Type*} (normalIn : α → ι → Prop) (ways : Finset ι) : GQ α :=
   fun R S => ∃ w ∈ ways, everyOn Finset.univ (fun x => normalIn x w ∧ R x) S
 
@@ -99,14 +99,10 @@ theorem genWays_singleton {ι : Type*} (normalIn : α → ι → Prop) (w : ι) 
 
 /-! ### Proportionality separates majority from normalcy
 
-The majority operator is already `Proportional` (`most_proportional`, in
-`Counting`): the formal content of "generics as majority quantification" — true
-of *this operator* ([cohen-1999a]'s absolute reading), which his homogeneity and
-relative reading, and the later literature ([nickel-2009], [leslie-2008]), reject
-as a theory of generics. The normalcy schema is not proportional. -/
+The majority operator is `Proportional` (`most_proportional`, in `Counting`); the
+normalcy schema is not. -/
 
-/-- The normalcy generic is NOT ratio-determined (hence not `Proportional`,
-    unlike `most_sem` / `most_proportional`): over
+/-- The normalcy generic is not ratio-determined, hence not `Proportional`: over
     `Fin 2` with only `0` normal, `{0}`-in-scope is generic-true while
     `{1}`-in-scope is generic-false, yet both have |R ∩ S| : |R ∖ S| = 1 : 1. -/
 theorem genNormalcy_not_ratio_determined :

--- a/Linglib/Studies/Cohen1999.lean
+++ b/Linglib/Studies/Cohen1999.lean
@@ -54,7 +54,7 @@ hypothesis, and a salient cell with an empty reference class imposes no conditio
 * [W. C. Salmon, *Objectively Homogeneous Reference Classes* (1977)][salmon-1977]
 * [R. Thomason, *Theories of Nonmonotonicity and Natural Language Generics*
   (1988)][thomason-1988]
-* [G. N. Carlson, *Reference to Kinds in English* (1977)][carlson-1977]
+* [G. N. Carlson, *Reference to Kinds in English* (1977)][carlson-1977a]
 -/
 
 namespace Cohen1999
@@ -123,6 +123,13 @@ theorem gen_conservativity :
   unfold gen prevalenceOn
   rw [countOn_congr (P := fun x => (ψ x ∧ alt x) ∧ ψ x ∧ φ x)
     (Q := fun x => (ψ x ∧ alt x) ∧ φ x) fun x _ => by tauto]
+
+/-- A generic whose scope exhausts its alternatives is true on any inhabited reference
+class — the reading of refutation statements, whose negation denies existence (§5.7). -/
+theorem gen_self (hR : 0 < countOn domain (fun x => ψ x ∧ φ x)) :
+    gen domain ψ φ φ := by
+  rw [gen, (prevalenceOn_eq_one_iff hR).mpr fun y _ hy => hy.2]
+  norm_num
 
 /-! ### The generalized-quantifier interface
 

--- a/Linglib/Studies/Cohen2013.lean
+++ b/Linglib/Studies/Cohen2013.lean
@@ -1,521 +1,238 @@
-import Linglib.Semantics.Quantification.Counting
-import Linglib.Semantics.Composition.Scope
+import Linglib.Studies.Cohen1999
 
 /-!
-# [cohen-2013]: No Quantification without Reinterpretation
+# Cohen (2013): No quantification without reinterpretation
 
-Ariel Cohen, "No Quantification without Reinterpretation." Chapter 13 in
-*Genericity* (ed. Mari, Beyssade, Del Prete), OUP, pp. 334–351.
+A generic or habitual sentence contains no audible quantifier, so the hearer must
+introduce one by reinterpreting the quantifierless input, and the introducing device —
+not a phonologically null determiner — fixes the quantifier's scope. Generics arise by
+Nunberg's Predicate Transfer: when predicating a property of a kind makes no pragmatic
+sense, the predicate is transferred to one true of a kind whose instances generically
+bear it. Pragmatic triggering leaves the transfer free to apply at any level of
+composition, after Nunberg and Recanati, so "Storks have a favorite nesting area" is
+scopally ambiguous — transfer of the verb leaves the generic under the existential,
+transfer of the whole phrase puts it above (§13.4.1) — though never out of an opaque
+context, since transfer needs the property's intension. Habituals arise by a type-shift: an eventive verb is evaluated at
+intervals while the present tense supplies a moment (after Taylor and Dowty), and the
+shift γ resolves the mismatch at the verb, before the object composes, so "Mary smokes a
+cigarette" keeps the generic under the existential and is odd, while the brand variant is
+fine (§13.4.2). That a type-shift applies only at its trigger site is argued from Partee
+and Rooth's SHIFT: negating a shifted verb differs from shifting a negated one, and only
+the first order is attested (§13.3.1, after the conjunction *needed but didn't buy*).
+Scope alone also does not exhaust the generic–negation interaction: focus fixes the
+alternative set of Cohen's earlier generic quantifier, so "Cows do not eat [nettles]"
+generalizes with exceptions while "Cows do [not] eat nettles" denies that any cow eats
+them (§13.2.1).
 
-## Thesis
+We state the two devices with the generic quantifier of `Studies/Cohen1999.lean` in the
+transferred and shifted predicates, derive both scopes of the storks sentence from the
+transfer's freedom of level and the infelicity of the cigarette sentence from the shift's
+locality, and check the focus readings of the nettles sentence against the two
+alternative sets.
 
-The generic quantifier GEN is not a phonologically null version of an overt
-quantifier — it is introduced by the hearer through reinterpretation of
-quantifier-free input. The two reinterpretation mechanisms (Predicate Transfer
-for generics, type-shifting for habituals) explain the different scopal
-properties of generics vs habituals.
+## Implementation notes
 
-## Empirical Generalizations (§13.2)
+The generic quantifier inside the reinterpretation operators is the absolute reading
+with trivial alternatives, per the chapter's own pointer to Cohen's earlier work for its
+content. Kinds are `Unit`, individuals and intervals `Fin n`; a felicity judgment is
+derived as the absence of a true reading among the available ones.
 
-| Construction                  | Scope behavior                          |
-|-------------------------------|-----------------------------------------|
-| Overt quantifier (every, ∀)   | Full scope ambiguity                    |
-| Generic (bare plural subject) | Ambiguous, except in opaque contexts    |
-| Habitual (no restrictor)      | Narrow scope only                       |
-| Habitual (with restrictor)    | Ambiguous (restrictor provides Q site)  |
-| Bare plural in habitual       | Scope below habitual (DRT constraint)   |
+## TODO
 
-## Core Proposal (§§13.3–13.4)
+* Bare plurals under habituals ((18): gen above the existential only) follow from bare
+  plurals introducing no discourse referent, a duplex condition under an existential
+  being no well-formed DRS (after Cohen and Erteschik-Shir); this needs the DRT box
+  substrate.
+* Predicate Transfer's ban on scoping out of opaque contexts (§13.4.1) rests on its need
+  for the property's intension, which these extensional models cannot state.
+* The wide-scope generic objects of (19)–(20), which refute a syntactic account
+  (§13.2.3), presuppose a subject–object asymmetry not encoded here.
 
-- **Generics** arise from **Predicate Transfer** (T_g, [nunberg-1995]):
-  T_g can apply locally (narrow scope) or globally (wide scope), yielding
-  scope ambiguity. But T_g requires the intension of the transferred
-  property, so it cannot scope out of opaque contexts like *believe*.
+## References
 
-- **Habituals** arise from **type-shifting** (γ):
-  Eventive verbs require interval arguments; present tense provides a
-  moment → type mismatch → γ fires at the verb level (locally). Since the
-  shift is local, the resulting GEN takes narrow scope only. With an overt
-  restrictor or contextual restriction, there is no mismatch, so normal
-  scope obtains.
-
-## Argumentation Chain (§13.3.1 → §13.4.2)
-
-The paper's key argument flows through the Partee-Rooth SHIFT operator:
-
-1. SHIFT does not commute with negation (`shift_neg_noncommutative`)
-2. Any type-shift shares this non-commutativity property
-3. γ is a type-shift, so γ does not commute with ∃ (`gamma_noncommutative`)
-4. Therefore γ must apply at the type-mismatch site (locally)
-5. Therefore the existential from the indefinite scopes over γ
-6. Therefore habituals take narrow scope (`habitual_narrow_scope`)
-
-## Formalization Strategy
-
-We verify Cohen's scope predictions using finite models, with definitions
-built directly on `transferGen` and `gamma` from (below):
-
-1. **Storks / nesting areas**: T_g applied locally vs globally gives
-   different truth conditions → generics are scopally ambiguous
-2. **Mary / cigarettes**: γ applied locally gives the implausible narrow-
-   scope reading; the plausible wide-scope reading would require global γ,
-   which is unavailable because the type mismatch is at the verb level
-3. **Scope hierarchy**: overt > predicateTransfer > typeShift
-
-These connect to (below) (T_g, γ, SHIFT, `QuantifierSource`),
-the canonical relativized restricted universal `Quantification.everyOn`
-(`Counting.lean`) that both T_g and γ bottom out in, and `Scope.lean`
-(ScopeConfig). A local 3-cell `Occasion` enum (below) supplies the
-habitual-side domain.
+* [A. Cohen, *No Quantification without Reinterpretation* (2013)][cohen-2013]
+* [G. Nunberg, *Transfers of Meaning* (1995)][nunberg-1995]
+* [B. Partee and M. Rooth, *Generalized Conjunction and Type Ambiguity*
+  (1983)][partee-rooth-1983]
+* [A. Cohen, *Think Generic! The Meaning and Use of Generic Sentences*
+  (1999)][cohen-1999a]
+* [G. N. Carlson, *Reference to Kinds in English* (1977)][carlson-1977a]
+* [M. Krifka, F. J. Pelletier, G. N. Carlson, A. ter Meulen, G. Chierchia and G. Link,
+  *Genericity: An Introduction* (1995)][krifka-etal-1995]
+* [A. Cohen and N. Erteschik-Shir, *Topic, Focus, and the Interpretation of Bare
+  Plurals* (2002)][cohen-erteschik-shir-2002]
+* [F. Recanati, *Embedded Implicatures* (2003)][recanati-2003]
+* [B. Taylor, *Tense and Continuity* (1977)][taylor-1977]
+* [D. R. Dowty, *Word Meaning and Montague Grammar* (1979)][dowty-1979]
 -/
 
 namespace Cohen2013
 
 open Quantification
-open Semantics.Scope (ScopeConfig)
 
-/-! ### Reinterpretation mechanisms ([cohen-2013], [nunberg-1995])
+/-! ### The two reinterpretation devices (§13.3) -/
 
-Two mechanisms that introduce covert quantifiers into logical form with
-different scope consequences: **Predicate Transfer** (T_g, [nunberg-1995]),
-pragmatically triggered and applicable at any composition level (→ scope
-ambiguity except in opaque contexts), and **habitual type-shift** (γ,
-[cohen-2013]), semantically triggered by type mismatch and applied
-locally (→ narrow scope only). Same quantifier (GEN), different
-scope behavior driven by the introducing mechanism.
-
-The argument for γ's locality goes through the Partee-Rooth SHIFT operator:
-since SHIFT does not commute with negation (`shift_neg_noncommutative`),
-neither does γ — so γ must apply before negation, i.e., locally. -/
-
-/-- Predicate Transfer for generics ([nunberg-1995]): transforms a
-kind-level predicate into a quantified predicate over instances of the kind.
-`T_g(P) = λx. gen_y[C(y,x)][P(y)]`, where `C(y,x)` says y is an instance of
-kind x. When `P(∩pandas)` is pragmatically anomalous (kinds don't eat —
-individuals do), Predicate Transfer applies, yielding
-`gen_y[C(y, ∩pandas)][P(y)]`. -/
-@[reducible] def transferGen {Kind Ind : Type}
-    (gen : (Ind → Bool) → (Ind → Bool) → Prop)
-    (instanceOf : Ind → Kind → Bool)
-    (P : Ind → Bool) : Kind → Prop :=
-  fun x => gen (fun y => instanceOf y x) P
-
-/-- Partee-Rooth SHIFT: lift an extensional transitive verb to take a
-generalized quantifier as its object argument. `SHIFT(V) = λQ.λx.Q(λy.V(x,y))`.
-[partee-rooth-1983] propose this to resolve type mismatches between
-extensional and intensional transitive verbs. [cohen-2013] §13.3.1 uses
-SHIFT's non-commutativity with negation to argue type-shifts must be
-LOCAL — see `shift_neg_noncommutative`. -/
-def SHIFT {E : Type} (V : E → E → Bool) : ((E → Bool) → Bool) → E → Bool :=
+/-- Partee and Rooth's SHIFT, lifting an extensional transitive verb to take a
+quantifier object. -/
+def SHIFT {E : Type*} (V : E → E → Prop) : ((E → Prop) → Prop) → E → Prop :=
   fun Q x => Q (fun y => V x y)
 
-/-- SHIFT does not commute with negation. For `V(x,y) = y`, `Q(P) = P true ∨ P false`,
-`x = true`: LHS `!Q(λy.y) = !(true ∨ false) = false`; RHS
-`Q(λy.¬y) = false ∨ true = true`. This non-commutativity ([cohen-2013] §13.3.1)
-forces type-shifts to apply LOCALLY (before negation) — the argument
-carries over to γ. -/
-theorem shift_neg_noncommutative :
-    ∃ (V : Bool → Bool → Bool) (Q : (Bool → Bool) → Bool) (x : Bool),
-    !(SHIFT V Q x) ≠ SHIFT (fun a b => !(V a b)) Q x :=
-  ⟨fun _ y => y, fun P => P true || P false, true, by decide⟩
+/-- Negating a shifted verb differs from shifting the negated verb, and only the first
+order is attested ((25)): a type-shift applies at its trigger site, before further
+composition. -/
+theorem not_shift_ne_shift_not :
+    ∃ (V : Bool → Bool → Prop) (Q : (Bool → Prop) → Prop) (x : Bool),
+      ¬ (¬ SHIFT V Q x ↔ SHIFT (fun a b => ¬ V a b) Q x) :=
+  ⟨fun _ y => y = true, fun P => P true ∨ P false, true, by unfold SHIFT; decide⟩
 
-/-- γ: type-shift turning an eventive predicate (property of intervals)
-into a stative one (property of moments). `γP = λt. gen_e[e ≤ int(t)][P(e)]`.
-Triggered by the present-tense / eventive-verb type mismatch, which forces
-γ to fire at the verb level (locally). Locality is why habituals take
-narrow scope. Like SHIFT, γ does not commute with other operators — see
-`gamma_noncommutative` for the concrete instance. -/
-@[reducible] def gamma {Interval Moment : Type}
-    (gen : (Interval → Bool) → (Interval → Bool) → Prop)
-    (containedIn : Interval → Moment → Bool)
-    (P : Interval → Bool) : Moment → Prop :=
-  fun t => gen (fun e => containedIn e t) P
+/-- Predicate Transfer for generics (§13.4.1): a property of individuals becomes the
+property of a kind whose instances generically bear it. -/
+def transfer {Kind Ind : Type*} [Fintype Ind] (instanceOf : Ind → Kind → Prop)
+    [∀ k, DecidablePred (fun y => instanceOf y k)] (P : Ind → Prop) [DecidablePred P] :
+    Kind → Prop :=
+  fun k => Cohen1999.gen Finset.univ (fun y => instanceOf y k) (fun _ => True) P
 
-/-- The mechanism introducing a covert quantifier; determines its scope
-behavior ([cohen-2013] §13.4). -/
-inductive QuantifierSource where
-  /-- Pragmatic; can apply at any composition level. -/
+instance {Kind Ind : Type*} [Fintype Ind] (instanceOf : Ind → Kind → Prop)
+    [∀ k, DecidablePred (fun y => instanceOf y k)] (P : Ind → Prop) [DecidablePred P]
+    (k : Kind) : Decidable (transfer instanceOf P k) := by
+  unfold transfer; infer_instance
+
+/-- The habitual type-shift γ (§13.4.2): a property of intervals becomes the property of
+a moment in whose surrounding interval it generically holds. -/
+def gamma {Interval Moment : Type*} [Fintype Interval]
+    (containedIn : Interval → Moment → Prop)
+    [∀ t, DecidablePred (fun e => containedIn e t)] (P : Interval → Prop)
+    [DecidablePred P] : Moment → Prop :=
+  fun t => Cohen1999.gen Finset.univ (fun e => containedIn e t) (fun _ => True) P
+
+instance {Interval Moment : Type*} [Fintype Interval]
+    (containedIn : Interval → Moment → Prop)
+    [∀ t, DecidablePred (fun e => containedIn e t)] (P : Interval → Prop)
+    [DecidablePred P] (t : Moment) : Decidable (gamma containedIn P t) := by
+  unfold gamma; infer_instance
+
+/-- The level at which a reinterpretation device applies: the mismatching word itself, or
+the containing phrase. -/
+inductive Level
+  | word
+  | phrase
+  deriving DecidableEq
+
+/-- The two devices that introduce covert quantifiers (§13.3). -/
+inductive Device
   | predicateTransfer
-  /-- Semantic; applies locally at the type-mismatch site. -/
   | typeShift
-  /-- Phonologically realized (always, usually, often, …). -/
-  | overt
-  deriving DecidableEq, Repr
-
-/-- Type-shifted elements take narrow scope only (local application);
-Predicate Transfer and overt quantifiers can take wide scope. -/
-def QuantifierSource.canTakeWideScope : QuantifierSource → Bool
-  | .predicateTransfer => true
-  | .typeShift => false
-  | .overt => true
-
-/-- Predicate Transfer cannot scope out of opaque (intensional) contexts —
-it requires the property's intension, unavailable outside an attitude verb's
-scope. Overt quantifiers can (de re readings); type-shifts are already local. -/
-def QuantifierSource.canScopeOutOfOpaque : QuantifierSource → Bool
-  | .predicateTransfer => false
-  | .typeShift => false
-  | .overt => true
-
-/-- Strict scope-freedom ordering: overt > predicateTransfer > typeShift. -/
-theorem scope_freedom_ordering :
-    (QuantifierSource.overt.canTakeWideScope = true ∧
-     QuantifierSource.overt.canScopeOutOfOpaque = true) ∧
-    (QuantifierSource.predicateTransfer.canTakeWideScope = true ∧
-     QuantifierSource.predicateTransfer.canScopeOutOfOpaque = false) ∧
-    (QuantifierSource.typeShift.canTakeWideScope = false ∧
-     QuantifierSource.typeShift.canScopeOutOfOpaque = false) :=
-  ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
-
--- ============================================================================
--- §13.2: Scopal Data
--- ============================================================================
-
-/-- A datum recording the scope behavior of a construction type
-    with respect to another operator (negation, existential, attitude). -/
-structure ScopeDatum where
-  sentence : String
-  constructionType : String
-  scopePartner : String
-  wideAvailable : Bool   -- can the covert Q take wide scope?
-  narrowAvailable : Bool -- can the covert Q take narrow scope?
-  source : String
-
-/-- §13.2.1: Generics interact scopally with negation.
-    "Cows do not eat nettles" — ambiguous between gen > ¬ and ¬ > gen. -/
-def genericNegation : ScopeDatum :=
-  { sentence := "Cows do not eat nettles"
-  , constructionType := "generic"
-  , scopePartner := "negation"
-  , wideAvailable := true   -- gen > ¬: "In general, cows don't eat nettles"
-  , narrowAvailable := true -- ¬ > gen: "It's false that cows generally eat nettles"
-  , source := "Krifka et al. 1995" }
-
-/-- §13.2.1: Generics cannot scope out of opaque contexts.
-    "The King believes enemy spies are loyal" — only bel > gen. -/
-def genericOpaque : ScopeDatum :=
-  { sentence := "The King believes enemy spies are loyal to him"
-  , constructionType := "generic"
-  , scopePartner := "believe"
-  , wideAvailable := false  -- *gen > bel: not available
-  , narrowAvailable := true -- bel > gen: "The King believes that gen..."
-  , source := "Carlson 1977a" }
-
-/-- §13.2.1: Generics exhibit scope ambiguity in transparent contexts.
-    "Storks have a favorite nesting area" — gen > ∃ and ∃ > gen. -/
-def genericTransparent : ScopeDatum :=
-  { sentence := "Storks have a favorite nesting area"
-  , constructionType := "generic"
-  , scopePartner := "existential"
-  , wideAvailable := true   -- gen > ∃: each stork has some area
-  , narrowAvailable := true -- ∃ > gen: one area for all storks
-  , source := "Schubert & Pelletier 1989" }
-
-/-- §13.2.2: Habituals without restrictor take narrow scope only.
-    "#John smokes a cigarette" — only ∃ > hab (implausible). -/
-def habitualNoRestrictor : ScopeDatum :=
-  { sentence := "#John smokes a cigarette"
-  , constructionType := "habitual (no restrictor)"
-  , scopePartner := "existential"
-  , wideAvailable := false  -- *hab > ∃: unavailable
-  , narrowAvailable := true -- ∃ > hab: one cigarette he always smokes
-  , source := "Krifka et al. 1995" }
-
-/-- §13.2.2: Habituals WITH restrictor are ambiguous.
-    "John smokes a cigarette when he is nervous" — hab > ∃ and ∃ > hab. -/
-def habitualWithRestrictor : ScopeDatum :=
-  { sentence := "John smokes a cigarette when he is nervous"
-  , constructionType := "habitual (with restrictor)"
-  , scopePartner := "existential"
-  , wideAvailable := true   -- ∃ > hab: there's a cigarette s.t. hab smokes it
-  , narrowAvailable := true -- hab > ∃: each time, some cigarette
-  , source := "Krifka et al. 1995" }
-
-/-- §13.2.2: Bare plurals in habituals take scope below the habitual.
-    "John smokes cigarettes" — only hab > gen (not gen > hab). -/
-def barePluralInHabitual : ScopeDatum :=
-  { sentence := "John smokes cigarettes"
-  , constructionType := "bare plural in habitual"
-  , scopePartner := "habitual"
-  , wideAvailable := false  -- gen > hab: unavailable (DRT constraint)
-  , narrowAvailable := true -- hab > gen: habitual scopes over bare plural
-  , source := "Carlson 1977a, Cohen & Erteschik-Shir 2002" }
-
--- ============================================================================
--- §13.4.1: Generics via Predicate Transfer — Scope Ambiguity
--- ============================================================================
-
-/-! ### Storks / Nesting Areas
-
-"Storks have a favorite nesting area"
-
-Initial LF: ∃x(nesting-area(x) ∧ have(∩storks, x))
-
-This is anomalous: kinds don't have nesting areas — individuals do.
-So Predicate Transfer applies (T_g from (below)),
-with two options depending on the level of application:
-
-- **Local T_g** (on the verb `have`):
-  ∃x(area(x) ∧ T_g(λy.have(y,x))(∩storks))
-  = ∃x(area(x) ∧ gen_y[stork(y)][have(y,x)]) — GEN takes **narrow** scope
-
-- **Global T_g** (on the VP `have a favorite nesting area`):
-  T_g(λy.∃x(area(x) ∧ have(y,x)))(∩storks)
-  = gen_y[stork(y)][∃x(area(x) ∧ have(y,x))] — GEN takes **wide** scope
-
-The kind ∩storks is modeled as `Unit` (a single kind-level entity); instances
-are individual storks. This follows [chierchia-1998]'s ∩ (down) operator,
-where `∩storks` denotes the kind, and ∪(∩storks) gives the extension (the
-set of individual storks). Here `instanceOfStork` plays the role of ∪.
--/
-
-section GenericScope
-
-inductive Stork where | s1 | s2 deriving DecidableEq, Repr
-inductive NestArea where | a1 | a2 deriving DecidableEq, Repr
-
-def storks : List Stork := [.s1, .s2]
-def areas : List NestArea := [.a1, .a2]
-
-/-- Each stork nests in a different area: s1→a1, s2→a2 -/
-def nestsIn : Stork → NestArea → Bool
-  | .s1, .a1 => true
-  | .s2, .a2 => true
-  | _, _ => false
-
-/-- GEN as the canonical relativized universal over storks (simplified: all
-    storks are "normal"). -/
-@[reducible] def genStork (restrictor scope : Stork → Bool) : Prop :=
-  everyOn storks.toFinset (fun y => restrictor y = true) (fun y => scope y = true)
-
-/-- Chierchia's ∪ applied to ∩storks: every Stork is an instance of the kind. -/
-def instanceOfStork (_ : Stork) (_ : Unit) : Bool := true
-
-/-- The kind ∩storks (a single kind-level entity). -/
-def storkKind : Unit := ()
-
-/-- **Local T_g**: ∃area(T_g(λy.nestsIn(y, area))(∩storks))
-    = ∃area(gen_y[stork(y)][nestsIn(y, area)])
-    "There is one area that, in general, storks nest in." -/
-@[reducible] def localTransfer : Prop :=
-  ∃ a ∈ areas, transferGen genStork instanceOfStork (fun y => nestsIn y a) storkKind
-
-/-- **Global T_g**: T_g(λy.∃area(nestsIn(y, area)))(∩storks)
-    = gen_y[stork(y)][∃area(nestsIn(y, area))]
-    "In general, storks nest in some area (possibly different)." -/
-@[reducible] def globalTransfer : Prop :=
-  transferGen genStork instanceOfStork
-    (fun y => areas.any fun a => nestsIn y a) storkKind
-
--- Local T_g is false: no single area works for all storks.
-example : ¬ localTransfer := by decide
-
--- Global T_g is true: each stork has some area.
-example : globalTransfer := by decide
-
-/-- **Generic scope ambiguity**: local and global T_g yield different
-    truth conditions. This is why generics in transparent contexts
-    are scopally ambiguous — Predicate Transfer can apply at either level.
-
-    The two readings correspond to `ScopeConfig.surface` (∃ > gen)
-    and `ScopeConfig.inverse` (gen > ∃). -/
-theorem generic_scope_ambiguity :
-    ¬ localTransfer ∧ globalTransfer := ⟨by decide, by decide⟩
-
-/-- The scope ambiguity matches the empirical datum: both readings available. -/
-theorem generic_both_scopes :
-    genericTransparent.wideAvailable = true ∧
-    genericTransparent.narrowAvailable = true := ⟨rfl, rfl⟩
-
-end GenericScope
-
--- ============================================================================
--- §13.3.1 → §13.4.2: Type-Shift Locality
--- ============================================================================
-
-/-! ### From SHIFT Non-Commutativity to γ Locality
-
-Cohen's argument for habitual narrow scope flows through the Partee-Rooth
-SHIFT operator ([partee-rooth-1983]):
-
-1. `shift_neg_noncommutative` (in (below)) proves that
-   SHIFT does not commute with negation: ¬SHIFT(V) ≠ SHIFT(¬V).
-
-2. γ is a type-shift (it resolves a type mismatch between eventive predicates
-   and moments). Like any type-shift, γ does not commute with other operators.
-
-3. `gamma_noncommutative` below proves the concrete instance: γ does not
-   commute with the existential quantifier over our finite model.
-
-4. Therefore γ must apply at the type-mismatch site — the verb level —
-   before the existential from the indefinite object is composed in.
-
-5. This forces the existential to scope over the habitual GEN.
--/
-
--- ============================================================================
--- §13.4.2: Habituals via Type-Shifting — Narrow Scope Only
--- ============================================================================
-
-/-! ### Mary / Cigarettes
-
-"Mary smokes a cigarette"
-
-The verb *smoke* is eventive: λy.λx.λe.smoke(x, y, e). In present
-tense, it applies to the speech time t₀ (a moment). Since an eventive
-verb requires an interval but receives a moment, there is a type
-mismatch. γ fires at the verb level:
-
-γ(λe.smoke(m, c, e))(t₀) — this is what happens. THEN the object
-composes, yielding: ∃c(cigarette(c) ∧ γ(λe.smoke(m, c, e))(t₀))
-
-The existential (from the indefinite) takes wide scope over γ, giving
-the implausible reading "there is one cigarette that Mary habitually smokes."
-
-The plausible reading (different cigarettes each time) would require
-GEN to scope over ∃. But that would need γ to apply globally — after
-the existential is composed in — which is unavailable because the type
-mismatch is at the verb level (step 4 of the argumentation chain above).
--/
-
-section HabitualScope
-
-inductive Occasion where | e1 | e2 | e3 deriving DecidableEq, Repr
-inductive Cigarette where | c1 | c2 | c3 deriving DecidableEq, Repr
-
-def occasions : List Occasion := [.e1, .e2, .e3]
-def cigarettes : List Cigarette := [.c1, .c2, .c3]
-
-/-- Mary smokes a different cigarette each time. -/
-def smokes : Cigarette → Occasion → Bool
-  | .c1, .e1 => true
-  | .c2, .e2 => true
-  | .c3, .e3 => true
-  | _, _ => false
-
-/-- GEN over occasions as the canonical relativized universal (simplified:
-    all occasions are relevant). -/
-@[reducible] def genHab (restrictor scope : Occasion → Bool) : Prop :=
-  everyOn occasions.toFinset (fun e => restrictor e = true) (fun e => scope e = true)
-
-/-- All occasions are contained in the relevant interval of speech time t₀. -/
-def containedInSpeech : Occasion → Unit → Bool := fun _ _ => true
-
-/-- The speech time (a moment). -/
-def speechTime : Unit := ()
-
-/-- **Local γ** (γ at verb, then object composes):
-    ∃c(cigarette(c) ∧ γ(λe.smoke(m,c,e))(t₀))
-    "There is one cigarette that Mary habitually smokes." -/
-@[reducible] def localGamma : Prop :=
-  ∃ c ∈ cigarettes, gamma genHab containedInSpeech (fun e => smokes c e) speechTime
-
-/-- **Global γ** (hypothetical — if γ could apply to the whole VP):
-    γ(λe.∃c(cigarette(c) ∧ smoke(m,c,e)))(t₀)
-    "Mary is habitually in a situation where she smokes some cigarette." -/
-@[reducible] def globalGamma : Prop :=
-  gamma genHab containedInSpeech
-    (fun e => cigarettes.any fun c => smokes c e) speechTime
-
--- Local γ is false: no single cigarette is smoked at all occasions.
-example : ¬ localGamma := by decide
-
--- Global γ is true: at each occasion, some cigarette is smoked.
-example : globalGamma := by decide
-
-/-- **Habitual narrow scope**: local and global γ differ, but only
-    local is available. The plausible wide-scope reading is blocked
-    because γ must apply at the type-mismatch site (the verb level).
-
-    This explains why "#John smokes a cigarette" is odd: the only
-    available reading (∃ > hab) is implausible. -/
-theorem habitual_narrow_scope :
-    ¬ localGamma ∧ globalGamma := ⟨by decide, by decide⟩
-
-/-- The narrow-scope-only prediction matches the empirical datum. -/
-theorem habitual_matches_datum :
-    habitualNoRestrictor.wideAvailable = false := rfl
-
-/-- **γ does not commute with ∃** on our model.
-
-    This is the concrete instance of the general non-commutativity argument
-    from §13.3.1 (proved abstractly for SHIFT in `shift_neg_noncommutative`).
-    The non-commutativity is what forces γ to apply locally. -/
-theorem gamma_noncommutative :
-    ¬ (localGamma ↔ globalGamma) := by decide
-
-end HabitualScope
-
--- ============================================================================
--- §13.4: Scope Hierarchy — Source Determines Behavior
--- ============================================================================
-
-/-- Cohen's core thesis: the mechanism that introduces GEN determines
-    its scope behavior. The three sources form a strict hierarchy:
-
-    overt > predicateTransfer > typeShift
-
-    in scope freedom. `QuantifierSource` in (below)
-    encodes this hierarchy. -/
-theorem scope_hierarchy :
-    QuantifierSource.overt.canTakeWideScope = true ∧
-    QuantifierSource.overt.canScopeOutOfOpaque = true ∧
-    QuantifierSource.predicateTransfer.canTakeWideScope = true ∧
-    QuantifierSource.predicateTransfer.canScopeOutOfOpaque = false ∧
-    QuantifierSource.typeShift.canTakeWideScope = false ∧
-    QuantifierSource.typeShift.canScopeOutOfOpaque = false :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- The scope behavior of each construction type matches
-    its QuantifierSource prediction. -/
-theorem predictions_match_data :
-    -- Generics (PT): wide scope available
-    genericTransparent.wideAvailable =
-      QuantifierSource.predicateTransfer.canTakeWideScope ∧
-    -- Generics in opaque contexts: wide scope blocked
-    genericOpaque.wideAvailable =
-      QuantifierSource.predicateTransfer.canScopeOutOfOpaque ∧
-    -- Habituals (type-shift): wide scope unavailable
-    habitualNoRestrictor.wideAvailable =
-      QuantifierSource.typeShift.canTakeWideScope :=
-  ⟨rfl, rfl, rfl⟩
-
--- ============================================================================
--- Connection to Existing Infrastructure
--- ============================================================================
-
-/-- Both T_g and γ bottom out in the canonical relativized universal
-    `Quantification.everyOn`, confirming that they share the common logical
-    form. The difference is upstream (how the quantifier is introduced), not
-    downstream (what it evaluates to).
-
-    T_g with our stork model reduces to `everyOn storks.toFinset` with the
-    restrictor `instanceOfStork · ∩storks` and the scope; γ likewise reduces
-    to `everyOn occasions.toFinset`. Both are `rfl` because `transferGen`/`gamma`
-    are definitionally the relativized universal applied to the kind/moment. -/
-theorem both_reduce_to_everyOn :
-    -- T_g(nestsIn(·, a1))(∩storks) = everyOn storks.toFinset (instanceOf · ∩storks) (nestsIn · .a1)
-    transferGen genStork instanceOfStork (fun y => nestsIn y .a1) storkKind =
-    everyOn storks.toFinset (fun y => instanceOfStork y storkKind = true)
-      (fun y => nestsIn y .a1 = true) ∧
-    -- γ(smoke(c1, ·))(t₀) = everyOn occasions.toFinset (containedIn · t₀) (smokes .c1 ·)
-    gamma genHab containedInSpeech (fun e => smokes .c1 e) speechTime =
-    everyOn occasions.toFinset (fun e => containedInSpeech e speechTime = true)
-      (fun e => smokes .c1 e = true) :=
-  ⟨rfl, rfl⟩
-
-/-- The available scope configurations for generics: both surface
-    and inverse scope (matching `Scope.allScopeConfigs`). -/
-theorem generic_scope_configs :
-    [ScopeConfig.surface, ScopeConfig.inverse] =
-    Semantics.Scope.allScopeConfigs := rfl
-
-/-- The available scope configuration for unrestricted habituals:
-    surface scope only (the covert Q takes narrow scope). -/
-def habitualScopeConfigs : List ScopeConfig := [.surface]
-
-theorem habitual_scope_restricted :
-    habitualScopeConfigs.length < Semantics.Scope.allScopeConfigs.length := by
-  native_decide
+  deriving DecidableEq
+
+/-- Where a device may apply (§13.3): Predicate Transfer is pragmatically triggered and
+free to apply at any level; a type-shift fires at the type-mismatch site only. -/
+def Device.AppliesAt : Device → Level → Prop
+  | .predicateTransfer, _ => True
+  | .typeShift, l => l = .word
+
+/-! ### Storks have a favorite nesting area (§13.4.1)
+
+Two storks, each nesting in its own area. Transfer at the verb quantifies each area's
+candidate nesters, transfer at the phrase quantifies the storks' own areas: the readings
+differ in truth value, and both are available to Predicate Transfer, so the sentence is
+scopally ambiguous and true on one reading. -/
+
+/-- Each of two storks nests in its own area. -/
+abbrev nestsIn : Fin 2 → Fin 2 → Prop := (· = ·)
+
+/-- Every individual stork instantiates the kind. -/
+abbrev storkOf : Fin 2 → Unit → Prop := fun _ _ => True
+
+/-- The two logical forms of the storks sentence, by level of transfer. -/
+def storksReading : Level → Prop
+  | .word => ∃ a : Fin 2, transfer storkOf (fun s => nestsIn s a) ()
+  | .phrase => transfer storkOf (fun s => ∃ a, nestsIn s a) ()
+
+instance : ∀ l, Decidable (storksReading l) := fun l => by
+  cases l <;> (unfold storksReading; infer_instance)
+
+/-- The two levels yield distinct readings: no single area serves most storks, while
+every stork has its own. -/
+theorem storksReading_word_ne_phrase :
+    ¬ storksReading .word ∧ storksReading .phrase := by
+  constructor <;> decide +kernel
+
+/-- Predicate Transfer makes a true reading available: the sentence is felicitous. -/
+theorem storks_true_reading_available :
+    ∃ l, Device.predicateTransfer.AppliesAt l ∧ storksReading l :=
+  ⟨.phrase, trivial, storksReading_word_ne_phrase.2⟩
+
+/-! ### Mary smokes a cigarette (§13.4.2)
+
+Three occasions in the interval around the speech moment, a different cigarette each
+time. The type mismatch sits at the eventive verb, so γ may apply only there, leaving
+the existential above the generic; that sole available reading is false, which is the
+oddness of (17a)/(45). The brand variant (17b) is the same shift with a constant
+witness, so its narrow reading is true and the sentence is fine. -/
+
+/-- Mary smokes a different cigarette at each of three occasions. -/
+abbrev smokes : Fin 3 → Fin 3 → Prop := (· = ·)
+
+/-- Every occasion falls in the interval around the speech moment. -/
+abbrev inSpeechInterval : Fin 3 → Unit → Prop := fun _ _ => True
+
+/-- The two logical forms of the cigarette sentence, by level of the shift. -/
+def cigaretteReading : Level → Prop
+  | .word => ∃ c : Fin 3, gamma inSpeechInterval (fun e => smokes c e) ()
+  | .phrase => gamma inSpeechInterval (fun e => ∃ c, smokes c e) ()
+
+instance : ∀ l, Decidable (cigaretteReading l) := fun l => by
+  cases l <;> (unfold cigaretteReading; infer_instance)
+
+/-- The two levels yield distinct readings: no one cigarette is smoked at most
+occasions, while each occasion has its cigarette. -/
+theorem cigaretteReading_word_ne_phrase :
+    ¬ cigaretteReading .word ∧ cigaretteReading .phrase := by
+  constructor <;> decide +kernel
+
+/-- The shift's locality leaves no true reading available: the oddness of the
+restrictorless habitual. -/
+theorem cigarette_no_true_reading_available :
+    ∀ l, Device.typeShift.AppliesAt l → ¬ cigaretteReading l := by
+  intro l hl
+  have h : l = .word := hl
+  subst h
+  exact cigaretteReading_word_ne_phrase.1
+
+/-- One brand, smoked at every occasion. -/
+abbrev smokesBrand : Fin 1 → Fin 3 → Prop := fun _ _ => True
+
+/-- With a constant witness the same local shift yields a true reading: the brand
+variant (17b) is fine. -/
+theorem brand_true_reading_available :
+    ∃ l, Device.typeShift.AppliesAt l ∧
+      ∃ b : Fin 1, gamma inSpeechInterval (fun e => smokesBrand b e) () :=
+  ⟨.word, rfl, ⟨0, by decide +kernel⟩⟩
+
+/-! ### Cows do not eat nettles (§13.2.1)
+
+Five cows, one a nettle-eater. With focus on the object, the alternatives are the ways
+of eating and the generic scopes over negation: cows in general eat something other than
+nettles, exceptions tolerated ((9a)). With focus on the auxiliary, the scope is its own
+sole alternative, the generic is the trivially true refutation reading, and the negated
+sentence denies that any cow eats nettles — false here ((9b)). -/
+
+/-- The one nettle-eating cow among five. -/
+abbrev eatsNettles : Fin 5 → Prop := (·.val = 4)
+
+/-- Every cow eats something: the disjoined alternatives under object focus. -/
+abbrev eatsSomething : Fin 5 → Prop := fun _ => True
+
+/-- Object focus, generic over negation: most eating cows avoid nettles ((9a)). -/
+theorem cows_gen_over_neg :
+    Cohen1999.gen Finset.univ (fun _ => True) eatsSomething (fun x => ¬ eatsNettles x) := by
+  rw [Cohen1999.gen_iff_thresholdGt _ _ _ _ (by decide)]
+  decide
+
+/-- Auxiliary focus, negation over the generic: the inner refutation reading is true as
+long as one cow eats nettles, so the sentence is false ((9b)). -/
+theorem cows_neg_over_gen_false :
+    Cohen1999.gen Finset.univ (fun _ => True) eatsNettles eatsNettles :=
+  Cohen1999.gen_self _ _ _ (by decide)
 
 end Cohen2013

--- a/references.bib
+++ b/references.bib
@@ -12905,6 +12905,16 @@
   validated = {true},
   sources   = {Studies/Cohen1999.lean}
 }
+@article{taylor-1977,
+  author    = {Taylor, Barry},
+  year      = {1977},
+  title     = {Tense and Continuity},
+  journal   = {Linguistics and Philosophy},
+  volume    = {1},
+  pages     = {199--220},
+  subfield  = {semantics},
+  role      = {cited},
+}
 @article{salmon-1977,
   author    = {Salmon, Wesley C.},
   year      = {1977},
@@ -13501,6 +13511,14 @@
   validated = {true},
   role      = {formalized},
   sources   = {Semantics/Possession/Basic.lean;Semantics/Possession/Relationalizer.lean;Morphology/DistributedMorphology/CategorizerSemantics.lean;Semantics/Possession/Quantifier.lean}
+}
+@phdthesis{carlson-1977a,
+  author    = {Carlson, Gregory N.},
+  year      = {1977},
+  title     = {Reference to Kinds in {English}},
+  school    = {University of Massachusetts, Amherst},
+  subfield  = {semantics},
+  role      = {cited},
 }
 @article{carlson-1977,
   author    = {Carlson, Gregory N.},


### PR DESCRIPTION
Rebuild against the Genericity volume (Zotero PDF): Predicate Transfer and the habitual type-shift stated with the Cohen 1999 generic quantifier inside, both scopes of the storks sentence derived from the transfer's freedom of level, the infelicity of restrictorless "Mary smokes a cigarette" (and the felicity of the brand variant) derived from the shift's locality, SHIFT's non-commutativity with negation, and §13.2.1's focus readings of "Cows do not eat nettles" via two alternative sets.
- The old file's String-field scope-datum tables, Bool answer-key `QuantifierSource`, rfl "predictions match data" checks, proof-equality bridge, and a `native_decide` are deleted; application sites are now the stipulated theory postulate and scope availability is derived.
- `Cohen1999.gen_self` added (the §5.7 refutation reading, used by the nettles model); Generic.lean docstrings brought to register; bib gains taylor-1977 and carlson-1977a (the dissertation, fixing a title mismatch in Cohen1999's reference list).