### PR TITLE
refactor(Discourse): hoist DiscourseRole out of the namespace

### DIFF
--- a/Linglib/Discourse/Commitment/Declarative.lean
+++ b/Linglib/Discourse/Commitment/Declarative.lean
@@ -35,7 +35,6 @@ self-generated, the `Commitment.Source` coordinate.
 
 namespace Commitment
 
-open Discourse (DiscourseRole)
 
 variable {W : Type*} (K : State DiscourseRole W) (x : DiscourseRole) (p : Set W)
 

--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -349,7 +349,7 @@ theorem mem_toIssue_iff {i : Set W} :
 
 /-- The common ground of a space is what its root entails; the speaker's assertion is
 Stalnakerian on it. -/
-instance : HasAssertion (Space (State Discourse.DiscourseRole W)) W where
+instance : HasAssertion (Space (State DiscourseRole W)) W where
   commonGround C := slate C.root
   initial := full ∅
   assert C φ := C.assert .speaker φ

--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -14,10 +14,6 @@ needs `DiscourseRole` for `Illocutionary.authority`) and the act-side material i
 classes and direction of fit).
 -/
 
-namespace Discourse
-
-open Semantics.Context
-
 /-- The two fundamental discourse participants. `.addressee` matches
     `KContext.addressee` (not `.listener` as in `DynamicSemantics`). -/
 inductive DiscourseRole where
@@ -25,29 +21,27 @@ inductive DiscourseRole where
   | addressee
   deriving DecidableEq, Repr, Inhabited
 
+namespace DiscourseRole
+
+open Semantics.Context
+
+variable {W E P T : Type*} (tower : ContextTower (KContext W E P T))
+
 /-- Resolve a discourse role to a concrete entity via a `ContextTower`,
     reading from the origin (speech-act context).
     `.speaker → tower.origin.agent`, `.addressee → tower.origin.addressee`. -/
-def resolveRole {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
-    DiscourseRole → E
+def resolve : DiscourseRole → E
   | .speaker   => tower.origin.agent
   | .addressee => tower.origin.addressee
 
-theorem resolve_speaker_is_agent {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
-    resolveRole tower .speaker = tower.origin.agent := rfl
+theorem resolve_speaker : resolve tower .speaker = tower.origin.agent := rfl
 
-theorem resolve_addressee_is_addressee {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
-    resolveRole tower .addressee = tower.origin.addressee := rfl
+theorem resolve_addressee : resolve tower .addressee = tower.origin.addressee := rfl
 
 /-- Discourse role resolution is invariant under tower push: discourse
     roles reflect speech-act participants (from origin), not embedded ones. -/
-theorem resolveRole_shift_invariant {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T))
-    (σ : ContextShift (KContext W E P T)) (r : DiscourseRole) :
-    resolveRole (tower.push σ) r = resolveRole tower r := by
-  cases r <;> simp only [resolveRole, ContextTower.push_origin]
+theorem resolve_push (σ : ContextShift (KContext W E P T)) (r : DiscourseRole) :
+    resolve (tower.push σ) r = resolve tower r := by
+  cases r <;> simp only [resolve, ContextTower.push_origin]
 
-end Discourse
+end DiscourseRole

--- a/Linglib/Semantics/Conditionals/ConditionalType.lean
+++ b/Linglib/Semantics/Conditionals/ConditionalType.lean
@@ -33,7 +33,6 @@ This explains why PCs block NPIs despite being semantically DE!
 
 namespace Conditionals
 open Commitment
-open Discourse (DiscourseRole)
 
 -- Conditional Type: HC vs PC
 

--- a/Linglib/Semantics/Conditionals/LeftNested.lean
+++ b/Linglib/Semantics/Conditionals/LeftNested.lean
@@ -43,7 +43,6 @@ that can be genuinely supposed without prior discourse.
 namespace Conditionals
 
 open Commitment
-open Discourse (DiscourseRole)
 
 -- Left-Nested Conditional Structure
 

--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -36,7 +36,6 @@ The Searle-class and direction-of-fit API for `Illocutionary` is in
 
 namespace Mood
 
-open Discourse (DiscourseRole)
 
 /-! ### Grammatical mood -/
 

--- a/Linglib/Studies/CohenKrifka2014.lean
+++ b/Linglib/Studies/CohenKrifka2014.lean
@@ -298,7 +298,6 @@ not among the commitments ((53)), and three is the least grantable value ((48)).
 section Model
 
 open Numerals
-open Discourse (DiscourseRole)
 
 /-- The free space over counting worlds, with no prior commitments. -/
 def rabbits : Space (State DiscourseRole ℕ) := full ∅
@@ -368,7 +367,6 @@ states while asserting reaches only the second. -/
 
 section Granting
 
-open Discourse (DiscourseRole)
 
 /-- It is raining, over two weather worlds. -/
 def raining : Set Bool := {true}

--- a/Linglib/Studies/CondoravdiLauer2012.lean
+++ b/Linglib/Studies/CondoravdiLauer2012.lean
@@ -26,7 +26,6 @@ preferential one does not, and conversely for an imperative.
 namespace CondoravdiLauer2012
 
 open Commitment
-open Discourse (DiscourseRole)
 
 /-- Whether the addressee is sitting. -/
 inductive AddrPosture

--- a/Linglib/Studies/Deo2025.lean
+++ b/Linglib/Studies/Deo2025.lean
@@ -57,7 +57,6 @@ commissive only.
 
 namespace Deo2025
 
-open Discourse
 open Commitment
 
 universe u
@@ -76,7 +75,7 @@ would need commitment contents that are themselves scoreboard-relative.
 /-- The bərə meta-content: "*p* is among the addressee's dependent
     commitments." This is the proposition the speaker preferentially
     commits to. [deo-2025-bara] (20). -/
-def baraMetaContent (p : Set W) (K : State Discourse.DiscourseRole W) : Prop :=
+def baraMetaContent (p : Set W) (K : State DiscourseRole W) : Prop :=
   commit .addressee p .doxastic .otherGenerated ∈ K
 
 /-! ## § 3. Empirical felicity profile (Deo § 2) -/

--- a/Linglib/Studies/FarkasBruce2010.lean
+++ b/Linglib/Studies/FarkasBruce2010.lean
@@ -26,7 +26,6 @@ confirmation and denial can react to it, and a denial leaves the conversation in
 namespace FarkasBruce2010
 
 open Commitment
-open Discourse (DiscourseRole)
 
 variable {W : Type*} (K : Table DiscourseRole W) (p : Set W)
 

--- a/Linglib/Studies/FarkasRoelofsen2017.lean
+++ b/Linglib/Studies/FarkasRoelofsen2017.lean
@@ -560,7 +560,6 @@ Explicit F_b and the unmarked-equals-F_b reduction structurally
 enforce what the paper states in prose. -/
 
 open Commitment
-open Discourse (DiscourseRole)
 
 /-- F_b — F&R 2017's "basic convention of use" (eq. (48), p. 265).
     Per F&R: "If a discourse participant x utters a declarative or

--- a/Linglib/Studies/Gunlogson2001.lean
+++ b/Linglib/Studies/Gunlogson2001.lean
@@ -24,7 +24,6 @@ addressee, which is what the two updates do.
 namespace Gunlogson2001
 
 open Commitment
-open Discourse (DiscourseRole)
 
 variable {W : Type*} (K : State DiscourseRole W) (p : Set W)
 

--- a/Linglib/Studies/Krifka2015.lean
+++ b/Linglib/Studies/Krifka2015.lean
@@ -51,7 +51,6 @@ negation (45).
 namespace Krifka2015
 
 open Commitment Commitment.Space
-open Discourse (DiscourseRole)
 open Questions.Bias (ContextualEvidence)
 open Features (Acceptability)
 

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -123,7 +123,6 @@ theorem composeI_eq_composeII (atFn naiFn : (W → Prop) → (W → Prop)) (β :
 
 open Semantics.Highlighting (HighlightingContext Highlighted AddressesQUD addSalient)
 open Evidential
-open Discourse (DiscourseRole)
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -485,7 +485,6 @@ simultaneously be both values.
 namespace Discourse.QuotationFBOntology
 
 open Commitment
-open Discourse (DiscourseRole)
 open Mood (Illocutionary)
 open Semantics.Quotation.Demonstration
 
@@ -666,7 +665,6 @@ namespace Rudin2025LI
 open Semantics.Quotation.Demonstration
 open Discourse.QuotationFBOntology
 open Commitment
-open Discourse (DiscourseRole)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Empirical Taxonomy

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -39,7 +39,7 @@ the content.
 
 - **Semantics/Context/Tower.lean**: `KContext.agent` = SPEAKER,
   `KContext.addressee` = HEARER; P-roles resolve through the canonical
-  `Discourse.resolveRole` over a `ContextTower`.
+  `DiscourseRole.resolve` over a `ContextTower`.
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP is the highest phase.
 - **ExtendedProjection/Basic.lean**: `fValue .SA = 7 > fValue .C = 6`.
 - **Semantics/Mood/Defs.lean**: the configurational seat-of-knowledge
@@ -178,7 +178,7 @@ def seatOfKnowledge (m : SAPMood) : PRole :=
 /-- Map P-roles to framework-agnostic discourse roles.
     SPEAKER → speaker, HEARER → addressee, SEAT OF KNOWLEDGE → speaker
     (default; use `seatOfKnowledge` for mood-sensitive resolution). -/
-def PRole.toDiscourseRole : PRole → Discourse.DiscourseRole
+def PRole.toDiscourseRole : PRole → DiscourseRole
   | .speaker         => .speaker
   | .hearer          => .addressee
   | .seatOfKnowledge => .speaker  -- default; varies by mood
@@ -212,11 +212,11 @@ theorem seatOfKnowledge_agrees_with_authority_off_imperative
 /-! ### Context grounding -/
 
 /-- Resolve a P-role to a discourse participant through a `ContextTower`,
-    reusing the canonical `Discourse.resolveRole` (which reads from the
+    reusing the canonical `DiscourseRole.resolve` (which reads from the
     speech-act origin). SEAT OF KNOWLEDGE resolves through its default
     discourse role; use `resolvePRoleInMood` for mood-sensitive resolution. -/
 def resolvePRole {W E P T : Type*} (tower : ContextTower (KContext W E P T)) (r : PRole) : E :=
-  Discourse.resolveRole tower r.toDiscourseRole
+  DiscourseRole.resolve tower r.toDiscourseRole
 
 /-- Mood-sensitive role resolution: SEAT OF KNOWLEDGE is resolved through
     `seatOfKnowledge` before mapping to a participant. -/
@@ -236,12 +236,12 @@ theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (KContext W 
 /-- **Key Claim 4 as a theorem.** P-roles are resolved from the SPEECH-ACT
     context (SAP is the highest phase), so resolution is invariant under
     context shift / embedding — inherited from
-    `Discourse.resolveRole_shift_invariant`. -/
+    `DiscourseRole.resolve_push`. -/
 theorem resolvePRole_shift_invariant {W E P T : Type*}
     (tower : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T))
     (r : PRole) :
     resolvePRole (tower.push σ) r = resolvePRole tower r := by
-  simp only [resolvePRole, Discourse.resolveRole_shift_invariant]
+  simp only [resolvePRole, DiscourseRole.resolve_push]
 
 /-- In declaratives the seat of knowledge resolves to the speaker (agent). -/
 theorem seatOfKnowledge_declarative_resolves {W E P T : Type*}

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -422,7 +422,7 @@ theorem direct_argument_reasonable_stalnaker {W : Type*}
 /-- The same inference on a commitment space ([krifka-2015]), whose common ground is what its
 root entails: `HasAssertion` abstracts over the representation. -/
 theorem direct_argument_reasonable_krifka {W : Type*}
-    (s : Commitment.Space (Commitment.State Discourse.DiscourseRole W))
+    (s : Commitment.Space (Commitment.State DiscourseRole W))
     (sel : SelectionFunction W)
     (notA B AorB : W → Prop)
     (h_AorB_decomp : ∀ w, AorB w → notA w → B w)


### PR DESCRIPTION
`Discourse.DiscourseRole` was a stutter — the type name already says it. Now a root-level `DiscourseRole` with `DiscourseRole.resolve`/`resolve_speaker`/`resolve_addressee`/`resolve_push` as members (were `Discourse.resolveRole` + `_is_agent`/`_is_addressee`/`_shift_invariant`), and every `open Discourse (DiscourseRole)` line deleted. The `Discourse` namespace keeps its genuine members (QUD, `HasIssue`, Centering, …).