### PR TITLE
refactor(Discourse): DiscourseRole as Discourse.Role

### DIFF
--- a/Linglib/Discourse/Commitment/Declarative.lean
+++ b/Linglib/Discourse/Commitment/Declarative.lean
@@ -36,16 +36,16 @@ self-generated, the `Commitment.Source` coordinate.
 namespace Commitment
 
 
-variable {W : Type*} (K : State DiscourseRole W) (x : DiscourseRole) (p : Set W)
+variable {W : Type*} (K : State Discourse.Role W) (x : Discourse.Role) (p : Set W)
 
 /-- `cs_X` (60): the worlds compatible with `x`'s public commitments. -/
 def commitmentSet : Set W := contextSet (ofCommitter K x)
 
 /-- A falling declarative (78): the speaker commits to `p`. -/
-def falling : State DiscourseRole W := insert (commit .speaker p) K
+def falling : State Discourse.Role W := insert (commit .speaker p) K
 
 /-- A rising declarative (77): the addressee is committed to `p`, attributed by the speaker. -/
-def rising : State DiscourseRole W :=
+def rising : State Discourse.Role W :=
   insert (commit .addressee p .doxastic .otherGenerated) K
 
 /-- (63): `p` is a commitment of `x`. -/
@@ -68,7 +68,7 @@ def IsBiased : Prop := IsControversial K pᶜ ∧ ¬ IsControversial K p
 /-- (68): the context is neutral with respect to `p`. -/
 def IsNeutral : Prop := ¬ IsControversial K p ∧ ¬ IsControversial K pᶜ
 
-theorem ofCommitter_insert_of_eq (c : Commitment DiscourseRole W) (h : c.committer = x) :
+theorem ofCommitter_insert_of_eq (c : Commitment Discourse.Role W) (h : c.committer = x) :
     ofCommitter (insert c K) x = insert c (ofCommitter K x) := by
   ext d
   simp only [ofCommitter, Set.mem_ofPred_eq, Set.mem_insert_iff]
@@ -80,7 +80,7 @@ theorem ofCommitter_insert_of_eq (c : Commitment DiscourseRole W) (h : c.committ
     · exact ⟨Or.inl rfl, h⟩
     · exact ⟨Or.inr hd, hc⟩
 
-theorem ofCommitter_insert_of_ne (c : Commitment DiscourseRole W) (h : c.committer ≠ x) :
+theorem ofCommitter_insert_of_ne (c : Commitment Discourse.Role W) (h : c.committer ≠ x) :
     ofCommitter (insert c K) x = ofCommitter K x := by
   ext d
   simp only [ofCommitter, Set.mem_ofPred_eq, Set.mem_insert_iff]
@@ -92,7 +92,7 @@ theorem ofCommitter_insert_of_ne (c : Commitment DiscourseRole W) (h : c.committ
     exact ⟨Or.inr hd, hc⟩
 
 @[simp] theorem commitmentSet_empty :
-    commitmentSet (∅ : State DiscourseRole W) x = Set.univ := by
+    commitmentSet (∅ : State Discourse.Role W) x = Set.univ := by
   simp [commitmentSet, ofCommitter]
 
 /-- A falling declarative narrows the speaker's commitment set by its content and leaves the

--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -349,7 +349,7 @@ theorem mem_toIssue_iff {i : Set W} :
 
 /-- The common ground of a space is what its root entails; the speaker's assertion is
 Stalnakerian on it. -/
-instance : HasAssertion (Space (State DiscourseRole W)) W where
+instance : HasAssertion (Space (State Discourse.Role W)) W where
   commonGround C := slate C.root
   initial := full ∅
   assert C φ := C.assert .speaker φ

--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -9,19 +9,21 @@ entities.
 
 This file exists separately from `Discourse/SpeechAct.lean`
 to break a would-be cycle between `Semantics/Mood/Defs.lean` (which
-needs `DiscourseRole` for `Illocutionary.authority`) and the act-side material in
+needs `Discourse.Role` for `Illocutionary.authority`) and the act-side material in
 `SpeechAct.lean` (which extends `Illocutionary` with Searle
 classes and direction of fit).
 -/
 
+namespace Discourse
+
 /-- The two fundamental discourse participants. `.addressee` matches
     `KContext.addressee` (not `.listener` as in `DynamicSemantics`). -/
-inductive DiscourseRole where
+inductive Role where
   | speaker
   | addressee
   deriving DecidableEq, Repr, Inhabited
 
-namespace DiscourseRole
+namespace Role
 
 open Semantics.Context
 
@@ -30,7 +32,7 @@ variable {W E P T : Type*} (tower : ContextTower (KContext W E P T))
 /-- Resolve a discourse role to a concrete entity via a `ContextTower`,
     reading from the origin (speech-act context).
     `.speaker → tower.origin.agent`, `.addressee → tower.origin.addressee`. -/
-def resolve : DiscourseRole → E
+def resolve : Role → E
   | .speaker   => tower.origin.agent
   | .addressee => tower.origin.addressee
 
@@ -40,8 +42,10 @@ theorem resolve_addressee : resolve tower .addressee = tower.origin.addressee :=
 
 /-- Discourse role resolution is invariant under tower push: discourse
     roles reflect speech-act participants (from origin), not embedded ones. -/
-theorem resolve_push (σ : ContextShift (KContext W E P T)) (r : DiscourseRole) :
+theorem resolve_push (σ : ContextShift (KContext W E P T)) (r : Role) :
     resolve (tower.push σ) r = resolve tower r := by
   cases r <;> simp only [resolve, ContextTower.push_origin]
 
-end DiscourseRole
+end Role
+
+end Discourse

--- a/Linglib/Semantics/Conditionals/ConditionalType.lean
+++ b/Linglib/Semantics/Conditionals/ConditionalType.lean
@@ -86,7 +86,7 @@ A proposition p echoes the discourse if:
 This captures the requirement that premise conditionals must have their
 antecedent grounded in prior discourse.
 -/
-def echoesDiscourse {W : Type*} (ds : Table DiscourseRole W) (p : Set W)
+def echoesDiscourse {W : Type*} (ds : Table Discourse.Role W) (p : Set W)
     (worlds : List W) : Prop :=
   (∃ q ∈ ds.dc .speaker, ∀ w ∈ worlds, q w → p w) ∨
   (∃ q ∈ ds.cg, ∀ w ∈ worlds, w ∈ q → p w)
@@ -97,7 +97,7 @@ Weaker echo check: proposition is merely consistent with discourse.
 This is a looser condition - the antecedent is at least compatible with
 what's been established, even if not explicitly entailed.
 -/
-def consistentWithDiscourse {W : Type*} (ds : Table DiscourseRole W) (p : Set W)
+def consistentWithDiscourse {W : Type*} (ds : Table Discourse.Role W) (p : Set W)
     (worlds : List W) : Prop :=
   ∃ w ∈ worlds, w ∈ ds.contextSet ∧ p w
 
@@ -111,7 +111,7 @@ A PC "if p, then q" is felicitous in discourse state ds iff:
 
 This is the key felicity requirement that distinguishes PC from HC.
 -/
-def pcFelicitous {W : Type*} (ds : Table DiscourseRole W) (antecedent : Set W)
+def pcFelicitous {W : Type*} (ds : Table Discourse.Role W) (antecedent : Set W)
     (worlds : List W) : Prop :=
   echoesDiscourse ds antecedent worlds
 
@@ -125,7 +125,7 @@ An HC "if p, then q" is felicitous in discourse state ds iff:
 Note: The second condition is captured implicitly - if p were established,
 a PC reading would be preferred.
 -/
-def hcFelicitous {W : Type*} (ds : Table DiscourseRole W) (antecedent : Set W)
+def hcFelicitous {W : Type*} (ds : Table Discourse.Role W) (antecedent : Set W)
     (worlds : List W) : Prop :=
   consistentWithDiscourse ds antecedent worlds
 
@@ -211,7 +211,7 @@ end ConditionalPolarityContext
 
 This is the defining felicity condition for premise conditionals.
 -/
-theorem pc_felicity {W : Type*} (ds : Table DiscourseRole W) (p : Set W)
+theorem pc_felicity {W : Type*} (ds : Table Discourse.Role W) (p : Set W)
     (worlds : List W) :
     pcFelicitous ds p worlds = echoesDiscourse ds p worlds := rfl
 
@@ -279,7 +279,7 @@ def semantics (tc : TypedConditional W) : Set W :=
   materialImp tc.antecedent tc.consequent
 
 /-- Check felicity in a given discourse state -/
-def isFelicitous (tc : TypedConditional W) (ds : Table DiscourseRole W)
+def isFelicitous (tc : TypedConditional W) (ds : Table Discourse.Role W)
     (worlds : List W) : Prop :=
   match tc.condType with
   | .hypothetical => hcFelicitous ds tc.antecedent worlds

--- a/Linglib/Semantics/Conditionals/LeftNested.lean
+++ b/Linglib/Semantics/Conditionals/LeftNested.lean
@@ -144,7 +144,7 @@ Interpret an LNC given discourse context and content type.
 
 The main result of [cao-white-lassiter-2025]: bare LNCs default to PC interpretation.
 -/
-noncomputable def interpretLNC {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
+noncomputable def interpretLNC {W : Type*} (ds : Table Discourse.Role W) (lnc : LNC W)
     (content : InnerConditionalContent) (worlds : List W) : ConditionalType :=
   if content.allowsHCReading then
     -- Modal/generic/quantAdv: can be either HC or PC
@@ -161,7 +161,7 @@ noncomputable def interpretLNC {W : Type*} (ds : Table DiscourseRole W) (lnc : L
 /--
 Check if an LNC is felicitous in a given discourse state.
 -/
-noncomputable def lncFelicitous {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
+noncomputable def lncFelicitous {W : Type*} (ds : Table Discourse.Role W) (lnc : LNC W)
     (content : InnerConditionalContent) (worlds : List W) : Prop :=
   match interpretLNC ds lnc content worlds with
   | .hypothetical => hcFelicitous ds lnc.innerConditional worlds
@@ -175,7 +175,7 @@ noncomputable def lncFelicitous {W : Type*} (ds : Table DiscourseRole W) (lnc : 
 When the inner conditional has bare content (no modal/generic/quantAdv),
 the LNC is interpreted as a premise conditional, regardless of discourse.
 -/
-theorem bare_lnc_as_pc {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
+theorem bare_lnc_as_pc {W : Type*} (ds : Table Discourse.Role W) (lnc : LNC W)
     (worlds : List W) :
     interpretLNC ds lnc .bare worlds = .premise := by
   unfold interpretLNC InnerConditionalContent.allowsHCReading
@@ -187,7 +187,7 @@ theorem bare_lnc_as_pc {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
 When the inner conditional has modal content, the LNC can be interpreted
 as either HC or PC, depending on discourse context.
 -/
-theorem modal_lnc_allows_hc {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
+theorem modal_lnc_allows_hc {W : Type*} (ds : Table Discourse.Role W) (lnc : LNC W)
     (worlds : List W)
     (h_no_echo : ¬ echoesDiscourse ds lnc.innerConditional worlds) :
     interpretLNC ds lnc .modal worlds = .hypothetical := by
@@ -197,7 +197,7 @@ theorem modal_lnc_allows_hc {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC 
 /--
 **Modal LNCs prefer PC when discourse anchor exists.**
 -/
-theorem modal_lnc_prefers_pc {W : Type*} (ds : Table DiscourseRole W) (lnc : LNC W)
+theorem modal_lnc_prefers_pc {W : Type*} (ds : Table Discourse.Role W) (lnc : LNC W)
     (worlds : List W)
     (h_echo : echoesDiscourse ds lnc.innerConditional worlds) :
     interpretLNC ds lnc .modal worlds = .premise := by
@@ -237,17 +237,17 @@ namespace AnnotatedLNC
 variable {W : Type*}
 
 /-- Get interpretation in discourse context -/
-noncomputable def interpret (alnc : AnnotatedLNC W) (ds : Table DiscourseRole W)
+noncomputable def interpret (alnc : AnnotatedLNC W) (ds : Table Discourse.Role W)
     (worlds : List W) : ConditionalType :=
   interpretLNC ds alnc.lnc alnc.content worlds
 
 /-- Check felicity -/
-noncomputable def isFelicitous (alnc : AnnotatedLNC W) (ds : Table DiscourseRole W)
+noncomputable def isFelicitous (alnc : AnnotatedLNC W) (ds : Table Discourse.Role W)
     (worlds : List W) : Prop :=
   lncFelicitous ds alnc.lnc alnc.content worlds
 
 /-- Get polarity context for inner conditional antecedent -/
-noncomputable def innerAntecedentPolarity (alnc : AnnotatedLNC W) (ds : Table DiscourseRole W)
+noncomputable def innerAntecedentPolarity (alnc : AnnotatedLNC W) (ds : Table Discourse.Role W)
     (worlds : List W) : ConditionalPolarityContext :=
   ConditionalPolarityContext.fromConditionalType (alnc.interpret ds worlds)
 

--- a/Linglib/Semantics/Mood/Defs.lean
+++ b/Linglib/Semantics/Mood/Defs.lean
@@ -74,7 +74,7 @@ inductive Illocutionary where
 
 /-- The participant with epistemic authority for each force ([lakoff-1970]):
 the addressee for interrogatives, the speaker otherwise. -/
-def Illocutionary.authority : Illocutionary → DiscourseRole
+def Illocutionary.authority : Illocutionary → Discourse.Role
   | .declarative   => .speaker
   | .interrogative  => .addressee
   | .imperative     => .speaker
@@ -110,7 +110,7 @@ def ClauseType.polarQuestion : ClauseType :=
   { force := .interrogative, mood := .indicative }
 
 /-- The epistemic authority of a clause type, via its force. -/
-def ClauseType.authority (ct : ClauseType) : DiscourseRole :=
+def ClauseType.authority (ct : ClauseType) : Discourse.Role :=
   Illocutionary.authority ct.force
 
 /-! ### Mood components -/

--- a/Linglib/Studies/CohenKrifka2014.lean
+++ b/Linglib/Studies/CohenKrifka2014.lean
@@ -300,7 +300,7 @@ section Model
 open Numerals
 
 /-- The free space over counting worlds, with no prior commitments. -/
-def rabbits : Space (State DiscourseRole ℕ) := full ∅
+def rabbits : Space (State Discourse.Role ℕ) := full ∅
 
 theorem exactly_id_injective : Function.Injective (exactly (id : ℕ → ℕ)) := by
   intro m k h
@@ -308,7 +308,7 @@ theorem exactly_id_injective : Function.Injective (exactly (id : ℕ → ℕ)) :
   simpa [exactly] using hm rfl
 
 theorem rabbits_root_fresh (m : ℕ) :
-    commit DiscourseRole.speaker (exactly id m)ᶜ ∉ rabbits.root :=
+    commit Discourse.Role.speaker (exactly id m)ᶜ ∉ rabbits.root :=
   Set.notMem_empty _
 
 /-- The derived truth conditions of (1a) are the classical *at least three* ((82)). -/
@@ -330,7 +330,7 @@ theorem two_notMem_rabbits_atLeast :
 /-- The denial of four is not among the speaker's commitments ((53)): that (1a) is true at
 four is implicature, not entailment. -/
 theorem rabbits_atLeast_grant_four :
-    commit DiscourseRole.speaker (exactly id 4)ᶜ ∉
+    commit Discourse.Role.speaker (exactly id 4)ᶜ ∉
       (atLeast rabbits .speaker (exactly id) 3).root := by
   rw [atLeast, commit_mem_exclude_root_iff rabbits .speaker (exactly id) _ rabbits_root_fresh
     exactly_id_injective]
@@ -338,7 +338,7 @@ theorem rabbits_atLeast_grant_four :
 
 /-- Three is the least value the speaker leaves grantable ((48), (60a)). -/
 theorem rabbits_atLeast_isLeast :
-    IsLeast {m | commit DiscourseRole.speaker (exactly id m)ᶜ ∉
+    IsLeast {m | commit Discourse.Role.speaker (exactly id m)ᶜ ∉
       (atLeast rabbits .speaker (exactly id) 3).root} 3 :=
   atLeast_isLeast rabbits .speaker (exactly id) 3 rabbits_root_fresh exactly_id_injective
 
@@ -372,7 +372,7 @@ section Granting
 def raining : Set Bool := {true}
 
 /-- The two-state space: no commitments, or the speaker's assertion of `raining`. -/
-def granting : Space (State DiscourseRole Bool) :=
+def granting : Space (State Discourse.Role Bool) :=
   ⟨{∅, insert (commit .speaker raining) ∅}, ∅, Or.inl rfl,
     by rintro d (rfl | rfl) <;> simp⟩
 
@@ -381,9 +381,9 @@ theorem raining_ne_compl : (raining : Set Bool) ≠ rainingᶜ := fun h =>
 
 theorem granting_consistent : ∀ d ∈ granting.states,
     ¬((⟨.speaker, raining, .commit, .doxastic, .selfGenerated⟩ :
-        Commitment DiscourseRole Bool) ∈ d ∧
+        Commitment Discourse.Role Bool) ∈ d ∧
       (⟨.speaker, rainingᶜ, .commit, .doxastic, .selfGenerated⟩ :
-        Commitment DiscourseRole Bool) ∈ d) := by
+        Commitment Discourse.Role Bool) ∈ d) := by
   rintro d (rfl | rfl) ⟨h₁, h₂⟩
   · exact Set.notMem_empty _ h₁
   · rcases Set.mem_insert_iff.1 h₂ with h₂ | h₂

--- a/Linglib/Studies/CondoravdiLauer2012.lean
+++ b/Linglib/Studies/CondoravdiLauer2012.lean
@@ -37,20 +37,20 @@ inductive AddrPosture
 def isSitting : Set AddrPosture := {.sitting}
 
 /-- *The addressee is sitting.* -/
-def declarative : State DiscourseRole AddrPosture := {commit .speaker isSitting}
+def declarative : State Discourse.Role AddrPosture := {commit .speaker isSitting}
 
 /-- *Sit down!* -/
-def imperative : State DiscourseRole AddrPosture :=
+def imperative : State Discourse.Role AddrPosture :=
   {commit .speaker isSitting .preferential}
 
-theorem ofForce_singleton_self (c : Commitment DiscourseRole AddrPosture) (f : Force)
+theorem ofForce_singleton_self (c : Commitment Discourse.Role AddrPosture) (f : Force)
     (h : c.force = f) : ofForce {c} f = {c} := by
   ext d
   simp only [ofForce, Set.mem_ofPred_eq, Set.mem_singleton_iff, and_iff_left_iff_imp]
   rintro rfl
   exact h
 
-theorem ofForce_singleton_of_ne (c : Commitment DiscourseRole AddrPosture) {f : Force}
+theorem ofForce_singleton_of_ne (c : Commitment Discourse.Role AddrPosture) {f : Force}
     (h : c.force ≠ f) : ofForce {c} f = ∅ := by
   ext d
   simp only [ofForce, Set.mem_ofPred_eq, Set.mem_singleton_iff, Set.mem_empty_iff_false,
@@ -58,7 +58,7 @@ theorem ofForce_singleton_of_ne (c : Commitment DiscourseRole AddrPosture) {f : 
   rintro rfl
   exact h
 
-theorem contextSet_singleton_commit (c : Commitment DiscourseRole AddrPosture)
+theorem contextSet_singleton_commit (c : Commitment Discourse.Role AddrPosture)
     (h : c.polarity = .commit) : contextSet {c} = c.content := by
   have : contents {c} = {c.content} := by
     ext φ

--- a/Linglib/Studies/Deo2025.lean
+++ b/Linglib/Studies/Deo2025.lean
@@ -75,7 +75,7 @@ would need commitment contents that are themselves scoreboard-relative.
 /-- The bərə meta-content: "*p* is among the addressee's dependent
     commitments." This is the proposition the speaker preferentially
     commits to. [deo-2025-bara] (20). -/
-def baraMetaContent (p : Set W) (K : State DiscourseRole W) : Prop :=
+def baraMetaContent (p : Set W) (K : State Discourse.Role W) : Prop :=
   commit .addressee p .doxastic .otherGenerated ∈ K
 
 /-! ## § 3. Empirical felicity profile (Deo § 2) -/

--- a/Linglib/Studies/FarkasBruce2010.lean
+++ b/Linglib/Studies/FarkasBruce2010.lean
@@ -27,7 +27,7 @@ namespace FarkasBruce2010
 
 open Commitment
 
-variable {W : Type*} (K : Table DiscourseRole W) (p : Set W)
+variable {W : Type*} (K : Table Discourse.Role W) (p : Set W)
 
 /-- Assertion proposes: the common ground is exactly as before (9). -/
 theorem assert_cg : (K.assert .speaker p).cg = K.cg := rfl
@@ -35,7 +35,7 @@ theorem assert_cg : (K.assert .speaker p).cg = K.cg := rfl
 /-- A world can survive the assertion of `p` without satisfying `p`, since only the projected set
 moves; `Commitment.Table` is not a `HasAssertion` instance under its own `assert`. -/
 theorem assert_not_narrowing :
-    ∃ (K : Table DiscourseRole Bool) (p : Set Bool) (w : Bool),
+    ∃ (K : Table Discourse.Role Bool) (p : Set Bool) (w : Bool),
       w ∈ (K.assert .speaker p).contextSet ∧ w ∉ p :=
   ⟨.empty, {true}, false, by simp [Table.contextSet, Table.assert, Table.push, Table.commit],
     Bool.false_ne_true⟩

--- a/Linglib/Studies/FarkasRoelofsen2017.lean
+++ b/Linglib/Studies/FarkasRoelofsen2017.lean
@@ -583,8 +583,8 @@ open Commitment
     and she remains neutral." This is distinct from F&B's
     `polarQuestion`, which omits the trivial-commitment step.
     The vacuity is genuine — see `F_b_int_dcS_growth_is_vacuous` below. -/
-def F_b_dec {W : Type*} (content : Set W) (ds : Table DiscourseRole W) :
-    Table DiscourseRole W :=
+def F_b_dec {W : Type*} (content : Set W) (ds : Table Discourse.Role W) :
+    Table Discourse.Role W :=
   -- Single-alternative content {α}: informative content = α.
   -- Add α to commitments(speaker), push {α} as an issue (form .declarative).
   ds.assert .speaker content
@@ -596,8 +596,8 @@ def F_b_dec {W : Type*} (content : Set W) (ds : Table DiscourseRole W) :
     interrogatives, which skips the vacuous step. The two predictions
     differ in dcS shape but agree on `contextSet` (the Set.univ
     commit doesn't constrain anything; see the vacuity theorem below). -/
-def F_b_int {W : Type*} (content : Set W) (ds : Table DiscourseRole W) :
-    Table DiscourseRole W :=
+def F_b_int {W : Type*} (content : Set W) (ds : Table Discourse.Role W) :
+    Table Discourse.Role W :=
   (ds.polarQuestion content).commit .speaker Set.univ
 
 /-- Update a F&B discourse state by uttering `content` with marker form
@@ -622,7 +622,7 @@ def F_b_int {W : Type*} (content : Set W) (ds : Table DiscourseRole W) :
 
     Non-paper-canonical forms (interrogative + tag) are no-ops. -/
 def MarkerTriple.update {W : Type*} (form : MarkerTriple)
-    (content : Set W) (ds : Table DiscourseRole W) : Table DiscourseRole W :=
+    (content : Set W) (ds : Table Discourse.Role W) : Table Discourse.Role W :=
   match form with
   | ⟨.dec, .closed, false⟩ => F_b_dec content ds
   | ⟨.int, _, false⟩ => ds.polarQuestion content
@@ -638,7 +638,7 @@ def MarkerTriple.update {W : Type*} (form : MarkerTriple)
     is in §3 of the paper (that no special effects are needed for this
     form); the Lean encoding records that consensus. -/
 theorem update_eq_F_b_dec_falling {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     MarkerTriple.fallingDeclarative.update content ds = F_b_dec content ds := rfl
 
 /-- **Substrate divergence on polar interrogatives**: F&B's
@@ -647,7 +647,7 @@ theorem update_eq_F_b_dec_falling {W : Type*}
     requires. Concretely, F&R-verbatim F_b adds Set.univ to dcS; F&B's
     polarQuestion does not. -/
 theorem update_int_vs_F_b_int_diverge_on_dcS {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.fallingPolarInterrogative.update content ds).dc .speaker =
       ds.dc .speaker ∧
     (F_b_int content ds).dc .speaker = insert Set.univ (ds.dc .speaker) :=
@@ -660,7 +660,7 @@ theorem update_int_vs_F_b_int_diverge_on_dcS {W : Type*}
     `polarQuestion`. F&R prose (p. 267): "the speaker makes a
     trivial commitment and she remains neutral." -/
 theorem F_b_int_dcS_growth_is_vacuous {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (F_b_int content ds).contextSet =
       (ds.polarQuestion content).contextSet := by
   -- Both sides differ only in dcS ([Set.univ :: ...] vs [...]), and
@@ -669,7 +669,7 @@ theorem F_b_int_dcS_growth_is_vacuous {W : Type*}
 
 /-- Falling declarative writes to dcS (full commitment, p. 240 table). -/
 theorem fallingDec_writes_dcS {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.fallingDeclarative.update content ds).dc .speaker =
       insert content (ds.dc .speaker) := by
   simp [MarkerTriple.update, MarkerTriple.fallingDeclarative, F_b_dec]
@@ -677,17 +677,17 @@ theorem fallingDec_writes_dcS {W : Type*}
 /-- Polar interrogatives (either intonation) do NOT write to dcS
     (neutral, p. 240 table). -/
 theorem polarInt_doesnt_write_dcS_falling {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.fallingPolarInterrogative.update content ds).dc .speaker = ds.dc .speaker := rfl
 
 theorem polarInt_doesnt_write_dcS_rising {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.risingPolarInterrogative.update content ds).dc .speaker = ds.dc .speaker := rfl
 
 /-- Rising declarative does NOT write to dcS (bias, no full commitment;
     matches p. 240 table classification). -/
 theorem risingDec_doesnt_write_dcS {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.risingDeclarative.update content ds).dc .speaker = ds.dc .speaker := rfl
 
 /-- Tag interrogatives DO write to dcS (the declarative anchor commits;
@@ -695,13 +695,13 @@ theorem risingDec_doesnt_write_dcS {W : Type*}
     p. 240 thus has TWO structurally distinct realizations in F&B
     terms: rising declaratives don't commit, tags do. -/
 theorem tag_writes_dcS_falling {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.fallingTagInterrogative.update content ds).dc .speaker =
       insert content (ds.dc .speaker) := by
   simp [MarkerTriple.update, MarkerTriple.fallingTagInterrogative]
 
 theorem tag_writes_dcS_rising {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.risingTagInterrogative.update content ds).dc .speaker =
       insert content (ds.dc .speaker) := by
   simp [MarkerTriple.update, MarkerTriple.risingTagInterrogative]
@@ -710,7 +710,7 @@ theorem tag_writes_dcS_rising {W : Type*}
     The structural common ground per F&B: every utterance is
     table-bearing. -/
 theorem all_paper_forms_push_issue {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) (form : MarkerTriple)
+    (content : Set W) (ds : Table Discourse.Role W) (form : MarkerTriple)
     (h : form ∈ paperSentenceForms) :
     (form.update content ds).stack.length > ds.stack.length := by
   simp only [paperSentenceForms, List.mem_cons, List.not_mem_nil, or_false] at h
@@ -734,7 +734,7 @@ theorem all_paper_forms_push_issue {W : Type*}
     p. 240 commitment table abstracts over a structural distinction
     that F&B's substrate makes visible. -/
 theorem fullCommitment_iff_dcS_grows {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) (form : MarkerTriple)
+    (content : Set W) (ds : Table Discourse.Role W) (form : MarkerTriple)
     (h : form ∈ paperSentenceForms) :
     commitmentType form = .fullCommitment →
       (form.update content ds).dc .speaker = insert content (ds.dc .speaker) := by
@@ -749,7 +749,7 @@ theorem fullCommitment_iff_dcS_grows {W : Type*}
 
 /-- Complement direction: `neutral` commitment type ↔ no dcS write. -/
 theorem neutral_iff_dcS_unchanged {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) (form : MarkerTriple)
+    (content : Set W) (ds : Table Discourse.Role W) (form : MarkerTriple)
     (h : form ∈ paperSentenceForms) :
     commitmentType form = .neutral →
       (form.update content ds).dc .speaker = ds.dc .speaker := by
@@ -800,7 +800,7 @@ they claim happens. -/
 
 /-- F&R + F&B prediction for rising declarative: dcS is unchanged. -/
 theorem fr_rising_dec_no_speaker_commitment {W : Type*}
-    (content : Set W) (ds : Table DiscourseRole W) :
+    (content : Set W) (ds : Table Discourse.Role W) :
     (MarkerTriple.risingDeclarative.update content ds).dc .speaker = ds.dc .speaker := rfl
 
 /-- Gunlogson 2008 prediction for rising declarative from the empty
@@ -825,7 +825,7 @@ theorem gunlogson_rising_dec_writes_addressee {W : Type*} (content : Set W) :
 theorem fr_vs_gunlogson_rising_dec_state_shape {W : Type*} (content : Set W) :
     -- F&R + F&B from empty state: dcS empty (no speaker commitment recorded)
     (MarkerTriple.risingDeclarative.update content
-        (Table.empty : Table DiscourseRole W)).dc .speaker = ∅ ∧
+        (Table.empty : Table Discourse.Role W)).dc .speaker = ∅ ∧
     -- Gunlogson from empty state: the addressee's commitment set is narrowed to the content
     commitmentSet (rising ∅ content) .addressee = content :=
   ⟨by simp [MarkerTriple.update, MarkerTriple.risingDeclarative],
@@ -858,33 +858,33 @@ sequential signature vs Krifka's single-conjunction signature. -/
     declarative (from the assertion anchor), sequentially stacked. -/
 theorem fr_tag_pushes_two_issues {W : Type*} (content : Set W) :
     (MarkerTriple.fallingTagInterrogative.update content
-        (Table.empty : Table DiscourseRole W)).stack.length = 2 := rfl
+        (Table.empty : Table Discourse.Role W)).stack.length = 2 := rfl
 
 /-- The two issues F&R + F&B place on the table for a tag are of
     DIFFERENT forms — one interrogative (from the tag's polar
     question), one declarative (from the assertion anchor). -/
 theorem fr_tag_table_forms {W : Type*} (content : Set W) :
     (MarkerTriple.fallingTagInterrogative.update content
-        (Table.empty : Table DiscourseRole W)).stack.map (·.mood) =
+        (Table.empty : Table Discourse.Role W)).stack.map (·.mood) =
       [.interrogative, .declarative] := rfl
 
 /-- Krifka 2015's matching tag (44): a single move whose root carries both the speaker's and the
     addressee's commitment to the same content. -/
 theorem krifka_matching_tag_root {W : Type*} (φ : Set W) :
     (((Space.full ∅).assert .speaker φ).assert .addressee φ).root =
-      insert (Commitment.commit DiscourseRole.addressee φ)
-        (insert (Commitment.commit DiscourseRole.speaker φ) ∅) := rfl
+      insert (Commitment.commit Discourse.Role.addressee φ)
+        (insert (Commitment.commit Discourse.Role.speaker φ) ∅) := rfl
 
 /-- **Cross-framework structural divergence on tag interrogatives**: F&R + F&B place two
     distinct items of different forms on the Table; Krifka 2015's conjunction is one space whose
     root commits both participants to the same content. -/
 theorem fr_vs_krifka_tag_structural_divergence {W : Type*} (φ : Set W) :
     (MarkerTriple.fallingTagInterrogative.update φ
-        (Table.empty : Table DiscourseRole W)).stack.map (·.mood) =
+        (Table.empty : Table Discourse.Role W)).stack.map (·.mood) =
       [.interrogative, .declarative] ∧
     (((Space.full ∅).assert .speaker φ).assert .addressee φ).root =
-      insert (Commitment.commit DiscourseRole.addressee φ)
-        (insert (Commitment.commit DiscourseRole.speaker φ) ∅) :=
+      insert (Commitment.commit Discourse.Role.addressee φ)
+        (insert (Commitment.commit Discourse.Role.speaker φ) ∅) :=
   ⟨rfl, rfl⟩
 
 end FarkasRoelofsen2017

--- a/Linglib/Studies/Gunlogson2001.lean
+++ b/Linglib/Studies/Gunlogson2001.lean
@@ -25,7 +25,7 @@ namespace Gunlogson2001
 
 open Commitment
 
-variable {W : Type*} (K : State DiscourseRole W) (p : Set W)
+variable {W : Type*} (K : State Discourse.Role W) (p : Set W)
 
 /-- A rising declarative narrows the addressee's commitment set, attributing `p`, and leaves the
 speaker's untouched. -/

--- a/Linglib/Studies/Krifka2015.lean
+++ b/Linglib/Studies/Krifka2015.lean
@@ -69,10 +69,10 @@ theorem raining_ne_compl : raining ≠ rainingᶜ := fun h =>
   (Set.ext_iff.1 h .rain).1 rfl rfl
 
 /-- The initial commitment space: no commitments, every development licit. -/
-def C₀ : Space (State DiscourseRole Weather) := full ∅
+def C₀ : Space (State Discourse.Role Weather) := full ∅
 
-theorem mem_insert_empty_iff {x y : Commitment DiscourseRole Weather} :
-    x ∈ insert y (∅ : State DiscourseRole Weather) ↔ x = y := by simp
+theorem mem_insert_empty_iff {x y : Commitment Discourse.Role Weather} :
+    x ∈ insert y (∅ : State Discourse.Role Weather) ↔ x = y := by simp
 
 /-! ### Assertion (14) -/
 
@@ -84,7 +84,7 @@ theorem assert_root :
 it was (p. 331). -/
 theorem assert_contextSet_vs_farkasBruce_cg :
     contextSet (C₀.assert .speaker raining).root = raining ∧
-      ((Table.empty : Table DiscourseRole Weather).assert .speaker raining).cg = ⊤ :=
+      ((Table.empty : Table Discourse.Role Weather).assert .speaker raining).cg = ⊤ :=
   ⟨by rw [contextSet_assert_root, show C₀.root = ∅ from rfl, contextSet_empty, Set.inter_univ],
     rfl⟩
 
@@ -124,21 +124,21 @@ theorem highNegation_refusal_mem :
 
 /-- `¬S₂⊢φ` is weaker than `S₂⊢¬φ` (p. 340): a consistent commitment to `¬φ` already excludes
 a commitment to `φ`. -/
-theorem not_mem_slate_of_commit_compl (K : State DiscourseRole Weather)
+theorem not_mem_slate_of_commit_compl (K : State Discourse.Role Weather)
     (h : commit .addressee rainingᶜ ∈ K) (hne : (contextSet (ofCommitter K .addressee)).Nonempty) :
     raining ∉ slate (ofCommitter K .addressee) :=
   not_mem_slate_of_compl_mem _ ⟨_, ⟨⟨h, rfl⟩, rfl⟩, rfl⟩ hne
 
 /-! ### The issue projection -/
 
-theorem contextSet_insert_commit_empty (a : DiscourseRole) (φ : Set Weather) :
-    contextSet (insert (commit a φ) (∅ : State DiscourseRole Weather)) = φ := by
+theorem contextSet_insert_commit_empty (a : Discourse.Role) (φ : Set Weather) :
+    contextSet (insert (commit a φ) (∅ : State Discourse.Role Weather)) = φ := by
   rw [contextSet_insert_of_commit rfl, contextSet_empty, Set.inter_univ]
   rfl
 
 /-- Every continuation of the monopolar question records the addressee's commitment, so its
 context set lies inside `raining`. -/
-theorem monopolar_continuation_subset {c : State DiscourseRole Weather}
+theorem monopolar_continuation_subset {c : State Discourse.Role Weather}
     (hc : c ∈ (C₀.monopolarQuestion .addressee raining).continuations) :
     contextSet c ⊆ raining := by
   obtain ⟨hc, hne⟩ := hc
@@ -170,7 +170,7 @@ theorem monopolar_not_inquisitive :
   exact hmem
 
 /-- Every continuation of the bipolar question records one of the two answers. -/
-theorem bipolar_continuation_subset {c : State DiscourseRole Weather}
+theorem bipolar_continuation_subset {c : State Discourse.Role Weather}
     (hc : c ∈ (C₀.bipolarQuestion .addressee raining).continuations) :
     contextSet c ⊆ raining ∨ contextSet c ⊆ rainingᶜ := by
   obtain ⟨hc, hne⟩ := hc
@@ -250,16 +250,16 @@ theorem table1_columns_differ :
 
 /-! ### Question tags (44), (45) -/
 
-variable (C : Space (State DiscourseRole Weather)) (φ : Set Weather)
+variable (C : Space (State Discourse.Role Weather)) (φ : Set Weather)
 
 /-- A matching tag (44): the conjunction of the assertion with the monopolar question of the same
 content, whose result is the state in which both participants are committed. -/
-def matchingTag : Space (State DiscourseRole Weather) :=
+def matchingTag : Space (State Discourse.Role Weather) :=
   (C.assert .speaker φ).assert .addressee φ
 
 /-- A reverse tag (45): the disjunction of the assertion with the monopolar question of the
 negation, rooted at the current state. -/
-def reverseTag : Space (State DiscourseRole Weather) :=
+def reverseTag : Space (State Discourse.Role Weather) :=
   C.propose ((C.assert .speaker φ).states ∪ (C.monopolarQuestion .addressee φᶜ).states) <| by
     rintro d (hd | rfl | hd)
     · exact C.root_mem_lowerBounds_reroot (Set.subset_insert _ _) hd

--- a/Linglib/Studies/MartinezVera2026.lean
+++ b/Linglib/Studies/MartinezVera2026.lean
@@ -138,15 +138,15 @@ The `assert`/`present` distinction is [faller-2002] /
     scope proposition, evidential (not-at-issue) proposition, and
     commits-to-scope flag (`true` for `assert`, `false` for `present`). -/
 structure EvidentialAct (W : Type*) where
-  speaker : DiscourseRole
-  addressee : DiscourseRole
+  speaker : Discourse.Role
+  addressee : Discourse.Role
   scope : Set W
   evidentialContent : Set W
   commitsToScope : Bool
 
 /-- [faller-2002]/[faller-2019a]: `assert(⟨A, N⟩)` commits the
     speaker to both A and N. Used with direct evidentials. -/
-def assert (s a : DiscourseRole) (β : BiLayered W) : EvidentialAct W :=
+def assert (s a : Discourse.Role) (β : BiLayered W) : EvidentialAct W :=
   { speaker := s
   , addressee := a
   , scope := { w | β.atIssue w }
@@ -156,21 +156,21 @@ def assert (s a : DiscourseRole) (β : BiLayered W) : EvidentialAct W :=
 /-- [murray-2014]/[faller-2019a]: `present(⟨A, N⟩)` brings A
     to attention but does NOT commit to A; commits only to N. Used with
     reportative/inferential evidentials. -/
-def present (s a : DiscourseRole) (β : BiLayered W) : EvidentialAct W :=
+def present (s a : Discourse.Role) (β : BiLayered W) : EvidentialAct W :=
   { speaker := s
   , addressee := a
   , scope := { w | β.atIssue w }
   , evidentialContent := { w | β.notAtIssue w }
   , commitsToScope := false }
 
-@[simp] theorem assert_commitsToScope (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem assert_commitsToScope (s a : Discourse.Role) (β : BiLayered W) :
     (assert s a β).commitsToScope = true := rfl
 
-@[simp] theorem present_commitsToScope (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem present_commitsToScope (s a : Discourse.Role) (β : BiLayered W) :
     (present s a β).commitsToScope = false := rfl
 
 theorem assert_present_differ_only_in_scope_commitment
-    (s a : DiscourseRole) (β : BiLayered W) :
+    (s a : Discourse.Role) (β : BiLayered W) :
     (assert s a β).scope = (present s a β).scope ∧
     (assert s a β).evidentialContent = (present s a β).evidentialContent ∧
     (assert s a β).commitsToScope ≠ (present s a β).commitsToScope := by
@@ -184,21 +184,21 @@ theorem assert_present_differ_only_in_scope_commitment
 def EvidentialAct.raisedPropositions (a : EvidentialAct W) : Set (Set W) :=
   if a.commitsToScope then {a.scope} else {a.scope, a.scopeᶜ}
 
-@[simp] theorem assert_raisedPropositions (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem assert_raisedPropositions (s a : Discourse.Role) (β : BiLayered W) :
     (assert s a β).raisedPropositions = {{ w | β.atIssue w }} := by
   simp [EvidentialAct.raisedPropositions, assert]
 
-@[simp] theorem present_raisedPropositions (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem present_raisedPropositions (s a : Discourse.Role) (β : BiLayered W) :
     (present s a β).raisedPropositions =
       ({ { w | β.atIssue w }, { w | β.atIssue w }ᶜ } : Set (Set W)) := by
   simp [EvidentialAct.raisedPropositions, present]
 
-theorem present_raises_polar_negation (s a : DiscourseRole) (β : BiLayered W) :
+theorem present_raises_polar_negation (s a : Discourse.Role) (β : BiLayered W) :
     { w | β.atIssue w }ᶜ ∈ (present s a β).raisedPropositions := by
   simp
 
 theorem assert_does_not_raise_polar_negation
-    (s a : DiscourseRole) (β : BiLayered W) (hne : ∃ w, β.atIssue w) :
+    (s a : Discourse.Role) (β : BiLayered W) (hne : ∃ w, β.atIssue w) :
     { w | β.atIssue w }ᶜ ∉ (assert s a β).raisedPropositions := by
   simp only [assert_raisedPropositions, Set.mem_singleton_iff]
   intro h
@@ -244,20 +244,20 @@ theorem faller_reportative_flavour :
     (fallerCoarseSource .reportative).map IllocutionaryFlavour.ofCoarseSource
       = some .presentFlavour := rfl
 
-def applyDefault (src : CoarseSource) (s a : DiscourseRole) (β : BiLayered W) :
+def applyDefault (src : CoarseSource) (s a : Discourse.Role) (β : BiLayered W) :
     EvidentialAct W :=
   match IllocutionaryFlavour.ofCoarseSource src with
   | .assertFlavour => assert s a β
   | .presentFlavour => present s a β
 
-@[simp] theorem applyDefault_direct (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem applyDefault_direct (s a : Discourse.Role) (β : BiLayered W) :
     applyDefault .direct s a β = assert s a β := rfl
-@[simp] theorem applyDefault_hearsay (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem applyDefault_hearsay (s a : Discourse.Role) (β : BiLayered W) :
     applyDefault .hearsay s a β = present s a β := rfl
-@[simp] theorem applyDefault_inference (s a : DiscourseRole) (β : BiLayered W) :
+@[simp] theorem applyDefault_inference (s a : Discourse.Role) (β : BiLayered W) :
     applyDefault .inference s a β = present s a β := rfl
 
-theorem direct_commits_indirect_does_not (s a : DiscourseRole) (β : BiLayered W) :
+theorem direct_commits_indirect_does_not (s a : Discourse.Role) (β : BiLayered W) :
     (applyDefault .direct s a β).commitsToScope = true ∧
     (applyDefault .hearsay s a β).commitsToScope = false ∧
     (applyDefault .inference s a β).commitsToScope = false :=
@@ -362,7 +362,7 @@ is exercised once in the substrate; here the consequences fall out.
     conditions on the scope: the paper assumes contingent scopes throughout.
     The alternative set is the polar partition `{p, pᶜ}`. -/
 theorem mi_felicitous_after_present
-    (s a : DiscourseRole) (p : Set W) (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
+    (s a : Discourse.Role) (p : Set W) (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     miFelicitous
       (updateAfterAct (polarQUD p) (present s a (BiLayered.ofProp (· ∈ p))))
       ({p, pᶜ} : Set (Set W))
@@ -391,7 +391,7 @@ theorem mi_felicitous_after_present
     Paper ex. 47 — the contrast that motivates the present/assert
     distinction. -/
 theorem mi_infelicitous_after_assert
-    (s a : DiscourseRole) (p : Set W) (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
+    (s a : Discourse.Role) (p : Set W) (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
     ¬ miFelicitous
         (updateAfterAct (polarQUD p) (assert s a (BiLayered.ofProp (· ∈ p))))
         ({p, pᶜ} : Set (Set W))
@@ -543,7 +543,7 @@ commitment difference, formalised in the substrate's
 -/
 
 theorem direct_commits_reportative_does_not
-    (s a : DiscourseRole) (β : BiLayered W) :
+    (s a : Discourse.Role) (β : BiLayered W) :
     (assert s a β).commitsToScope = true ∧
     (present s a β).commitsToScope = false :=
   ⟨rfl, rfl⟩

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -531,7 +531,7 @@ variable {W : Type*}
     - **interrogative**: `polarQuestion` (pushes issue, no commit)
     - **rising declarative**: pushes issue without commit
       (the intermediate prosodic case [rudin-2025b] relies on) -/
-def update (u : FBPerformance W) (s : Table DiscourseRole W) : Table DiscourseRole W :=
+def update (u : FBPerformance W) (s : Table Discourse.Role W) : Table Discourse.Role W :=
   match u.rising, u.form with
   | true, _ =>
       s.push ⟨.declarative, {u.content}⟩
@@ -563,14 +563,14 @@ def RisingDecl (u : FBPerformance W) : Prop :=
     branch adds, the rising and interrogative branches do not — so this
     matches the structural classification "non-rising declarative". -/
 def Commits (u : FBPerformance W) : Prop :=
-  u.content ∈ (u.update (Table.empty : Table DiscourseRole W)).dc .speaker
+  u.content ∈ (u.update (Table.empty : Table Discourse.Role W)).dc .speaker
 
 /-- **F&B-derived** RaisesIssue: the performance's update grows the
     table. All three branches push to the table, so any well-formed
     speech act raises an issue. (RESP's discriminating power comes
     from `¬ Commits`, not from `RaisesIssue`.) -/
 def RaisesIssue (u : FBPerformance W) : Prop :=
-  (u.update (Table.empty : Table DiscourseRole W)).stack ≠ []
+  (u.update (Table.empty : Table Discourse.Role W)).stack ≠ []
 
 -- ════════════════════════════════════════════════════
 -- § 4. PerformanceOntology axiom obligations
@@ -650,7 +650,7 @@ theorem raises_issue_always (u : FBPerformance W) : u.RaisesIssue := by
     equals `s.assert .speaker content`, so `Table.mem_dc_assert` applies directly. -/
 theorem update_decl_eq_assert (u : FBPerformance W)
     (hr : u.rising = false) (hf : u.form = .declarative)
-    (s : Table DiscourseRole W) :
+    (s : Table Discourse.Role W) :
     u.update s = s.assert .speaker u.content := by
   unfold update
   rw [hr, hf]

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -39,7 +39,7 @@ the content.
 
 - **Semantics/Context/Tower.lean**: `KContext.agent` = SPEAKER,
   `KContext.addressee` = HEARER; P-roles resolve through the canonical
-  `DiscourseRole.resolve` over a `ContextTower`.
+  `Discourse.Role.resolve` over a `ContextTower`.
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP is the highest phase.
 - **ExtendedProjection/Basic.lean**: `fValue .SA = 7 > fValue .C = 6`.
 - **Semantics/Mood/Defs.lean**: the configurational seat-of-knowledge
@@ -178,7 +178,7 @@ def seatOfKnowledge (m : SAPMood) : PRole :=
 /-- Map P-roles to framework-agnostic discourse roles.
     SPEAKER → speaker, HEARER → addressee, SEAT OF KNOWLEDGE → speaker
     (default; use `seatOfKnowledge` for mood-sensitive resolution). -/
-def PRole.toDiscourseRole : PRole → DiscourseRole
+def PRole.toRole : PRole → Discourse.Role
   | .speaker         => .speaker
   | .hearer          => .addressee
   | .seatOfKnowledge => .speaker  -- default; varies by mood
@@ -198,7 +198,7 @@ def PRole.toEpistemicAuthority : PRole → EpistemicAuthority
     proposition, p.335), Lakoff with the SPEAKER (who has authority to
     command). -/
 theorem seatOfKnowledge_diverges_from_authority_on_imperative :
-    (seatOfKnowledge .imperative).toDiscourseRole ≠
+    (seatOfKnowledge .imperative).toRole ≠
       (SAPMood.imperative.toClauseType).authority := by
   decide
 
@@ -206,17 +206,17 @@ theorem seatOfKnowledge_diverges_from_authority_on_imperative :
     interrogative → addressee. The disagreement is isolated to imperatives. -/
 theorem seatOfKnowledge_agrees_with_authority_off_imperative
     (m : SAPMood) (h : m ≠ .imperative) :
-    (seatOfKnowledge m).toDiscourseRole = m.toClauseType.authority := by
+    (seatOfKnowledge m).toRole = m.toClauseType.authority := by
   cases m <;> first | exact absurd rfl h | rfl
 
 /-! ### Context grounding -/
 
 /-- Resolve a P-role to a discourse participant through a `ContextTower`,
-    reusing the canonical `DiscourseRole.resolve` (which reads from the
+    reusing the canonical `Discourse.Role.resolve` (which reads from the
     speech-act origin). SEAT OF KNOWLEDGE resolves through its default
     discourse role; use `resolvePRoleInMood` for mood-sensitive resolution. -/
 def resolvePRole {W E P T : Type*} (tower : ContextTower (KContext W E P T)) (r : PRole) : E :=
-  DiscourseRole.resolve tower r.toDiscourseRole
+  Discourse.Role.resolve tower r.toRole
 
 /-- Mood-sensitive role resolution: SEAT OF KNOWLEDGE is resolved through
     `seatOfKnowledge` before mapping to a participant. -/
@@ -236,12 +236,12 @@ theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (KContext W 
 /-- **Key Claim 4 as a theorem.** P-roles are resolved from the SPEECH-ACT
     context (SAP is the highest phase), so resolution is invariant under
     context shift / embedding — inherited from
-    `DiscourseRole.resolve_push`. -/
+    `Discourse.Role.resolve_push`. -/
 theorem resolvePRole_shift_invariant {W E P T : Type*}
     (tower : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T))
     (r : PRole) :
     resolvePRole (tower.push σ) r = resolvePRole tower r := by
-  simp only [resolvePRole, DiscourseRole.resolve_push]
+  simp only [resolvePRole, Discourse.Role.resolve_push]
 
 /-- In declaratives the seat of knowledge resolves to the speaker (agent). -/
 theorem seatOfKnowledge_declarative_resolves {W E P T : Type*}

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -422,7 +422,7 @@ theorem direct_argument_reasonable_stalnaker {W : Type*}
 /-- The same inference on a commitment space ([krifka-2015]), whose common ground is what its
 root entails: `HasAssertion` abstracts over the representation. -/
 theorem direct_argument_reasonable_krifka {W : Type*}
-    (s : Commitment.Space (Commitment.State DiscourseRole W))
+    (s : Commitment.Space (Commitment.State Discourse.Role W))
     (sel : SelectionFunction W)
     (notA B AorB : W → Prop)
     (h_AorB_decomp : ∀ w, AorB w → notA w → B w)


### PR DESCRIPTION
Follow-up to #2709, per the `Nat.Partition`/`Order.Ideal` idiom: the contested noun lives under its owner, so the type is `Discourse.Role` with members `Role.resolve`/`resolve_speaker`/`resolve_addressee`/`resolve_push`, used qualified everywhere (no `open` lines). `PRole.toDiscourseRole` becomes `PRole.toRole`.