### PR TITLE
refactor(Syntax/Minimalist): Step sides, freezing and reconstruction

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2853,6 +2853,8 @@ import Linglib.Syntax.Minimalist.Merge.SyntacticObject
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Minimalist.Movement.DegreeMovement
 import Linglib.Syntax.Minimalist.Movement.InverseVoice
+import Linglib.Syntax.Minimalist.Movement.Freezing
+import Linglib.Syntax.Minimalist.Movement.Reconstruction
 import Linglib.Syntax.Minimalist.Movement.Remnant
 import Linglib.Syntax.Minimalist.Movement.Smuggling
 import Linglib.Syntax.Minimalist.Movement.VerbMovementParameter

--- a/Linglib/Studies/Chomsky1995.lean
+++ b/Linglib/Studies/Chomsky1995.lean
@@ -45,15 +45,15 @@ def nounToSO (n : NounEntry) (id : Nat) : SyntacticObject :=
   if n.proper then mkLeafPhon .D [] n.formSg id else mkLeafPhon .N [] n.formSg id
 
 /-- "John sees Mary" as a Minimalist Merge derivation: *see*'s complement
-    is *Mary* (`emR`), then *John* is added as specifier (`emL`). -/
+    is *Mary* (`em .right`), then *John* is added as specifier (`em .left`). -/
 def john_sees_mary : Derivation :=
   { initial := verbToSO English.Predicates.Verbal.see 31
-    steps   := [.emR (nounToSO English.Nouns.mary 11),
-                .emL (nounToSO English.Nouns.john 10)] }
+    steps   := [.em .right (nounToSO English.Nouns.mary 11),
+                .em .left (nounToSO English.Nouns.john 10)] }
 
 /-- The phonological yield of `john_sees_mary` is the SVO string
-    "John sees Mary": the Minimalist derivation (built by `emR` then
-    `emL` over `verbToSO`/`nounToSO`) linearizes subject-verb-object via the
+    "John sees Mary": the Minimalist derivation (built by `em .right` then
+    `em .left` over `verbToSO`/`nounToSO`) linearizes subject-verb-object via the
     derivation-grounded computable externalization (`SyntacticObject.Derivation.surfacePhon`). -/
 theorem models_svo_word_order :
     String.intercalate " " john_sees_mary.surfacePhon = "John sees Mary" := by decide

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -135,7 +135,7 @@ structure Stage where
 /-- Merge the modifier `m` above the current object, then optionally raise a subtree containing
 the overt noun to the left edge. -/
 private def step (m : LIToken) (st : Stage) : List Stage :=
-  let d : Derivation := ⟨st.derivation.initial, st.derivation.steps ++ [.emL (leaf m)]⟩
+  let d : Derivation := ⟨st.derivation.initial, st.derivation.steps ++ [.em .left (leaf m)]⟩
   let p := m * st.planar
   ⟨d, p, st.marks, st.raises⟩ ::
     ((subtrees st.planar.val).filter hasN).filterMap fun s =>

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -2,8 +2,8 @@ import Mathlib.Data.Fin.VecNotation
 import Linglib.Data.Examples.ColeHermon2008
 import Linglib.Fragments.TobaBatak.Basic
 import Linglib.Semantics.ArgumentStructure.Valency
-import Linglib.Syntax.Minimalist.Linearization.Replay
-import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
+import Linglib.Syntax.Minimalist.Movement.Freezing
+import Linglib.Syntax.Minimalist.Movement.Reconstruction
 
 /-!
 # Cole and Hermon 2008: VP raising in a VOS language
@@ -34,13 +34,12 @@ surface order, which the paper takes as grounds to propose that Merge is unorder
 a by-product of Move. English, whose passive agent is an adjunct below the patient, lets the
 patient bind it but never the converse.
 
-The derivation is a `Derivation` on the syntactic-object carrier with its stages read by the
-replay, `Frozen` is containment in a moved constituent, `CCommandsAt` c-command at a stage
-and `BindsAtSomeStage` at some stage, and the paper's examples are the rows:
-`vos_hypothesis_only` and `derivational_only` single out, among the candidate analyses of
-word order and of binding, the paper's own, `table1` derives its three grades, `stageAt_sides`
-and `surface_sides` are the §6 claim over every attachment choice, and `english_passive` the
-§7 contrast.
+The derivation is a `Derivation` on the syntactic-object carrier, freezing and binding at a
+stage are the substrate's `Derivation.Frozen`, `CCommandsAt` and `BindsAtSomeStage`, and the
+paper's examples are the rows: `vos_hypothesis_only` and `derivational_only` single out, among
+the candidate analyses of word order and of binding, the paper's own, `table1` derives its
+three grades, `stageAt_sides` and `surface_sides` are the §6 claim over every attachment
+choice, and `english_passive` the §7 contrast.
 
 ## Implementation notes
 
@@ -59,10 +58,9 @@ and `surface_sides` are the §6 claim over every attachment choice, and `english
   fronts it. The wh-step itself is not modelled: freezing asks whether the argument sits in a
   constituent some step of the derivation moved, which the remnant, carrying the evacuees'
   traces, decides; fn. 18's caveat on extraction from moved complements is the paper's.
-* Binding and freezing are stated on the derivation's own stages: the replay's object at a
-  stage forgets to `Derivation.stageAt`, so a c-command fact decided on the replay is one
-  about the unordered syntactic object. A stage whose replay fails c-commands nothing; the
-  surface-order theorems witness that every derivation here replays.
+* Binding at a stage is decided on the replay, which forgets to the derivation's own stage; a
+  stage whose replay fails c-commands nothing, and the surface-order theorems witness that
+  every derivation here replays.
 * The rows record their configuration in paper features; the theorems decode it into a
   schematic clause and compare the derivation's prediction with the row's judgment.
 
@@ -84,7 +82,6 @@ and `surface_sides` are the §6 claim over every attachment choice, and `english
 * [P. Schachter, *Semantic-Role-Based Syntax in Toba Batak* (1984)][schachter-1984]
 * [N. Sugamoto, *Reflexives in Toba Batak* (1984)][sugamoto-1984]
 * [R. K. Larson, *On the Double Object Construction* (1988)][larson-1988]
-* [J. R. Ross, *Constraints on Variables in Syntax* (1967)][ross-1967]
 * [C. Collins, *A Smuggling Approach to the Passive in English* (2005)][collins-2005]
 -/
 
@@ -93,37 +90,6 @@ namespace ColeHermon2008
 open Minimalist SyntacticObject
 open TobaBatak (Voice)
 open Data.Examples (LinguisticExample)
-
-/-! ### Stages, freezing and binding -/
-
-/-- `x` c-commands `y` at stage `n` of `d`: in the ordered object the replay reaches after `n`
-steps, which forgets to `d.stageAt n`. -/
-def CCommandsAt (d : Derivation) (n : ℕ) (x y : SyntacticObject) : Prop :=
-  ∃ p ∈ (d.take n).externalize?, cCommandsIn p x y
-
-instance (d : Derivation) (n : ℕ) (x y : SyntacticObject) : Decidable (CCommandsAt d n x y) := by
-  unfold CCommandsAt; infer_instance
-
-/-- The stage the predicate looks at is the derivation's own. -/
-theorem CCommandsAt.cCommandsIn_stageAt {d : Derivation} {n : ℕ} {x y : SyntacticObject}
-    (h : CCommandsAt d n x y) : cCommandsIn (d.stageAt n) x y :=
-  let ⟨_, hp, hc⟩ := h
-  d.externalize?_take_faithful n hp ▸ hc
-
-/-- Derivational binding, the paper's optional reconstruction (fn. 28): the antecedent
-c-commands the reflexive at some stage of the derivation. -/
-def BindsAtSomeStage (d : Derivation) (x y : SyntacticObject) : Prop :=
-  ∃ n ≤ d.length, CCommandsAt d n x y
-
-instance (d : Derivation) (x y : SyntacticObject) : Decidable (BindsAtSomeStage d x y) := by
-  unfold BindsAtSomeStage; infer_instance
-
-/-- `x` is frozen in `d`: it sits inside a constituent the derivation has moved, an island for
-later extraction (§4, after [ross-1967]'s Sentential Subject Constraint). -/
-def Frozen (d : Derivation) (x : SyntacticObject) : Prop := ∃ m ∈ d.movedItems, contains m x
-
-instance (d : Derivation) (x : SyntacticObject) : Decidable (Frozen d x) := by
-  unfold Frozen; infer_instance
 
 /-! ### The clause and its derivations (§4.1–§4.2) -/
 
@@ -161,11 +127,8 @@ private def v₀ : LIToken := ⟨.simple .v [], 6⟩
 /-- The `i`-th functional head F, for `i ≥ 1`. -/
 private def F (i : ℕ) : LIToken := ⟨.simple .T [], 6 + i⟩
 
-/-- The side at which each of the five base Merges attaches its item, `true` on the left. -/
-abbrev Sides := Fin 5 → Bool
-
-/-- External Merge on the side `left`. -/
-def em (left : Bool) (item : SyntacticObject) : Step := if left then .emL item else .emR item
+/-- The side at which each of the five base Merges attaches its item. -/
+abbrev Sides := Fin 5 → Side
 
 namespace Clause
 
@@ -194,14 +157,15 @@ def pivot : LIToken := if c.voice.promotes = .agent then c.agent else c.patient
 /-- The sides of the paper's own trees (50) and (57): complements on the right; the light verb,
 the agent, Voice and, in a ditransitive, the patient, [larson-1988]'s specifier of VP, on the
 left. -/
-def paperSides : Sides := ![false, c.goal.isSome, true, true, true]
+def paperSides : Sides :=
+  ![.right, if c.goal.isSome then .left else .right, .left, .left, .left]
 
 /-- The base (50), (57), `{Voice, {Agent, {v, VP}}}`: the verb takes the patient, or the goal
 and then the patient, then the light verb, the agent and Voice, each Merge on the side `σ`
 gives. -/
 def base (σ : Sides) : List Step :=
-  c.goal.toList.map (em (σ 0)) ++
-    [em (σ 1) c.patient, em (σ 2) v₀, em (σ 3) c.agent, em (σ 4) c.voiceHead]
+  c.goal.toList.map (Step.em (σ 0)) ++
+    [.em (σ 1) c.patient, .em (σ 2) v₀, .em (σ 3) c.agent, .em (σ 4) c.voiceHead]
 
 /-- The verb adjoins to Voice, (51)–(52): the verb raises and Voice raises over it. -/
 def verbToVoice : List Step := [.im c.verb, .im c.voiceHead]
@@ -209,7 +173,7 @@ def verbToVoice : List Step := [.im c.verb, .im c.voiceHead]
 /-- The goal, then the pivot, raise to specifiers of F, (59)–(60), (63)–(64), (72)–(73): the
 order of extraction that places the goal after the subject. -/
 def evacuate : List Step :=
-  (c.goal.toList.flatMap fun pp => [.emL (F 1), .im pp]) ++ [.emL (F 2), .im c.pivot]
+  (c.goal.toList.flatMap fun pp => [.em .left (F 1), .im pp]) ++ [.em .left (F 2), .im c.pivot]
 
 /-- The remnant VoiceP that raises, (55), (61): Voice and the verb over their traces, the pivot
 and the goal replaced by theirs. -/
@@ -230,23 +194,24 @@ def svoStage (σ : Sides := c.paperSides) : Derivation :=
 /-- The VOS derivation, (55), (61), (65), (74), (77): the remnant VoiceP raises over the
 evacuated goal and pivot. -/
 def vos (σ : Sides := c.paperSides) : Derivation :=
-  ⟨c.verb, (c.svoStage σ).steps ++ [.emL (F 3), .im c.remnant]⟩
+  (c.svoStage σ).append [.em .left (F 3), .im c.remnant]
 
 /-- The SVO derivation under the VOS Hypothesis, (83)–(84): the pivot raises once more, past
 the fronted VoiceP. -/
 def svo (σ : Sides := c.paperSides) : Derivation :=
-  ⟨c.verb, (c.vos σ).steps ++ [.emL (F 4), .im c.pivot]⟩
+  (c.vos σ).append [.em .left (F 4), .im c.pivot]
 
 /-- The SVO derivation under the SVO Hypothesis (§5), for which the paper draws no tree: the
 pivot raises and VoiceP, the goal inside it, stays. -/
 def svoInPlace (σ : Sides := c.paperSides) : Derivation :=
-  ⟨c.verb, c.base σ ++ c.verbToVoice ++ [.emL (F 2), .im c.pivot]⟩
+  ⟨c.verb, c.base σ ++ c.verbToVoice ++ [.em .left (F 2), .im c.pivot]⟩
 
 /-- The marked V-O-IO-S order (14), the pivot extracted before the goal; fn. 25 derives the
 adverbial (16) the same way. -/
 def vois (σ : Sides := c.paperSides) : Derivation :=
-  ⟨c.verb, c.base σ ++ c.verbToVoice ++ [.emL (F 1), .im c.pivot] ++
-    (c.goal.toList.flatMap fun pp => [.emL (F 2), .im pp]) ++ [.emL (F 3), .im c.remnant]⟩
+  ⟨c.verb, c.base σ ++ c.verbToVoice ++ [.em .left (F 1), .im c.pivot] ++
+    (c.goal.toList.flatMap fun pp => [.em .left (F 2), .im pp]) ++
+    [.em .left (F 3), .im c.remnant]⟩
 
 end Clause
 
@@ -300,16 +265,14 @@ theorem ex85_svoi :
 /-! ### Every clause goes through a VOS stage (§5) -/
 
 /-- The SVO derivation extends the VOS derivation. -/
-theorem svo_take_vos (c : Clause) (σ : Sides) : (c.svo σ).take (c.vos σ).length = c.vos σ := by
-  unfold Derivation.take
-  rw [Derivation.length, Clause.svo, List.take_left]
-  rfl
+theorem svo_take_vos (c : Clause) (σ : Sides) : (c.svo σ).take (c.vos σ).length = c.vos σ :=
+  Derivation.take_length_append _ _
 
 /-- Freezing is the same in SVO and VOS clauses: the further raising of the pivot, a leaf,
 freezes nothing. -/
 theorem frozen_svo_iff (c : Clause) (σ : Sides) (x : SyntacticObject) :
-    Frozen (c.svo σ) x ↔ Frozen (c.vos σ) x := by
-  simp [Frozen, Derivation.movedItems, Clause.svo, List.filterMap_append]
+    (c.svo σ).Frozen x ↔ (c.vos σ).Frozen x := by
+  simp [Clause.svo, Derivation.frozen_append_iff]
 
 /-! ### The rows -/
 
@@ -372,7 +335,7 @@ def clause (e : Extraction) : Clause :=
 /-- The prediction under a hypothesis: a fronted wh-phrase is licit exactly when it is not
 frozen; in situ it is unconstrained. -/
 def Licit (e : Extraction) (hyp : OrderHypothesis) : Prop :=
-  e.fronted → ∃ x ∈ e.clause.arg? e.extracted, ¬ Frozen (e.clause.derivation hyp e.order) x
+  e.fronted → ∃ x ∈ e.clause.arg? e.extracted, ¬ (e.clause.derivation hyp e.order).Frozen x
 
 instance (e : Extraction) (hyp : OrderHypothesis) : Decidable (e.Licit hyp) := by
   unfold Licit; infer_instance
@@ -451,10 +414,9 @@ inductive BindingTheory
 
 /-- The condition licenses the configuration. -/
 def BindingTheory.Licenses : BindingTheory → Reflexivization → Prop
-  | .surface, a => ∃ p ∈ a.pair?, CCommandsAt a.derivation a.derivation.length p.1 p.2
-  | .lastSVOStage, a =>
-      ∃ p ∈ a.pair?, CCommandsAt a.clause.svoStage a.clause.svoStage.length p.1 p.2
-  | .derivational, a => ∃ p ∈ a.pair?, BindsAtSomeStage a.derivation p.1 p.2
+  | .surface, a => ∃ p ∈ a.pair?, a.derivation.BindsAtSurface p.1 p.2
+  | .lastSVOStage, a => ∃ p ∈ a.pair?, a.clause.svoStage.BindsAtSurface p.1 p.2
+  | .derivational, a => ∃ p ∈ a.pair?, a.derivation.BindsAtSomeStage p.1 p.2
   | .semanticHierarchy, a => Outranks a.antecedent.role a.reflexive.role
 
 instance (th : BindingTheory) (a : Reflexivization) : Decidable (th.Licenses a) := by
@@ -494,25 +456,20 @@ patient once the verb has adjoined to Voice, stage 6, and not once the patient h
 patient c-commands the agent once raised and not before, and neither does at the surface, once
 VoiceP has raised. -/
 theorem passive_stages :
-    (CCommandsAt ex67.vos 6 ex67.agent ex67.patient ∧
-      ¬ CCommandsAt ex67.vos ex67.svoStage.length ex67.agent ex67.patient) ∧
-    (¬ CCommandsAt ex67.vos 6 ex67.patient ex67.agent ∧
-      CCommandsAt ex67.vos ex67.svoStage.length ex67.patient ex67.agent) ∧
-    (¬ CCommandsAt ex67.vos ex67.vos.length ex67.agent ex67.patient ∧
-      ¬ CCommandsAt ex67.vos ex67.vos.length ex67.patient ex67.agent) := by
+    (ex67.vos.CCommandsAt 6 ex67.agent ex67.patient ∧
+      ¬ ex67.vos.CCommandsAt ex67.svoStage.length ex67.agent ex67.patient) ∧
+    (¬ ex67.vos.CCommandsAt 6 ex67.patient ex67.agent ∧
+      ex67.vos.CCommandsAt ex67.svoStage.length ex67.patient ex67.agent) ∧
+    (¬ ex67.vos.BindsAtSurface ex67.agent ex67.patient ∧
+      ¬ ex67.vos.BindsAtSurface ex67.patient ex67.agent) := by
   decide
 
 /-! ### Merge is unordered (§6) -/
 
-/-- External Merge on either side has the same leftward form. -/
-@[simp] theorem leftward_em (left : Bool) (item : SyntacticObject) :
-    (em left item).leftward = .emL item := by
-  cases left <;> rfl
-
 /-- Up to the sides of its Merges, the VOS derivation is one derivation. -/
 theorem vos_leftward (c : Clause) (σ σ' : Sides) :
     (c.vos σ).leftward = (c.vos σ').leftward := by
-  simp [Derivation.leftward, Clause.vos, Clause.svoStage, Clause.base]
+  simp [Derivation.leftward, Derivation.append, Clause.vos, Clause.svoStage, Clause.base]
 
 /-- The sides at which the base Merges attach change no stage of the derivation, so binding,
 which reads the stages, cannot see them ((89)–(94)). -/
@@ -522,9 +479,8 @@ theorem stageAt_sides (c : Clause) (σ σ' : Sides) (n : ℕ) :
 
 /-- Nor can freezing, which reads the movers. -/
 theorem frozen_sides (c : Clause) (σ σ' : Sides) (x : SyntacticObject) :
-    Frozen (c.vos σ) x ↔ Frozen (c.vos σ') x := by
-  unfold Frozen
-  rw [← Derivation.movedItems_leftward, vos_leftward c σ σ', Derivation.movedItems_leftward]
+    (c.vos σ).Frozen x ↔ (c.vos σ').Frozen x := by
+  rw [← Derivation.frozen_leftward_iff, vos_leftward c σ σ', Derivation.frozen_leftward_iff]
 
 /-- Nor the surface order (56): every one of the thirty-two attachments, (57), (91) and, up to
 the omitted XP, (89) among them, externalizes to V-O-S-IO. -/
@@ -542,7 +498,8 @@ private def byHimself : LIToken := ⟨.simple .P [] (phonForm := "by himself"), 
 agent an adjunct, a *by*-phrase leaf below it, and no argument in Spec,vP, since the passive
 participle projects none; the patient raises to Spec,FP, Spec,TP in English. -/
 def englishPassive : Derivation :=
-  ⟨wasInjured, [.emR byHimself, .emL theBoy, .emL v₀, .emL (F 1), .im theBoy]⟩
+  ⟨wasInjured,
+    [.em .right byHimself, .em .left theBoy, .em .left v₀, .em .left (F 1), .im theBoy]⟩
 
 /-- (95) externalizes. -/
 theorem english_order :
@@ -566,7 +523,7 @@ in Toba Batak; the paper remarks, without arguing it, that if this treatment of 
 right, [collins-2005]'s smuggling derivation, in which the passive agent is Merged as in the
 active, cannot be maintained. -/
 theorem english_passive : ∀ row ∈ Examples.all, ∀ p ∈ englishPair? row,
-    (row.judgment ≠ .ungrammatical ↔ BindsAtSomeStage englishPassive p.1 p.2) := by
+    (row.judgment ≠ .ungrammatical ↔ englishPassive.BindsAtSomeStage p.1 p.2) := by
   decide
 
 end ColeHermon2008

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -121,9 +121,9 @@ private def ppToMaryP : PlanarSyntacticObject := tok_to * tok_mary
 def obliqueDative : Derivation :=
   { initial := V_send
     steps := [
-      .emR (ppToMaryP),  -- [V' send [PP to Mary]]
-      .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
-      .emL DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
+      .em .right (ppToMaryP),  -- [V' send [PP to Mary]]
+      .em .left DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
+      .em .left DP_john                    -- [VP John [VP a_letter [V' send [PP to Mary]]]]
     ] }
 
 /-- The oblique dative result tree: `[John [letter [send [to Mary]]]]`.
@@ -168,10 +168,10 @@ Derivation steps:
 def docDativeShift : Derivation :=
   { initial := V_send
     steps := [
-      .emR (ppToMaryP),  -- [V' send [PP to Mary]]
-      .emL DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
+      .em .right (ppToMaryP),  -- [V' send [PP to Mary]]
+      .em .left DP_letter,                 -- [VP a_letter [V' send [PP to Mary]]]
       .im DP_mary,                    -- DATIVE SHIFT: Mary moves to Spec
-      .emL DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
+      .em .left DP_john                    -- [VP John [VP Mary_i [VP a_letter ...]]]
     ] }
 
 /-- The DOC result tree: Mary, internally merged, sits at the left edge of
@@ -213,8 +213,8 @@ and Dative Shift share the same structural operation. -/
 def standardPassive : Derivation :=
   { initial := V_kick
     steps := [
-      .emR DP_ball,   -- [V' kicked [DP the ball]]
-      .emL DP_john,   -- [VP John [V' kicked [DP the ball]]]
+      .em .right DP_ball,   -- [V' kicked [DP the ball]]
+      .em .left DP_john,   -- [VP John [V' kicked [DP the ball]]]
       .im DP_ball     -- PASSIVE: ball promoted to Spec
     ] }
 
@@ -455,9 +455,9 @@ private def tok_to2     : LIToken := ‚ü®.simple .P [.D] (phonForm := "to"), 323‚
 def indirectPassive : Derivation :=
   { initial := V_sent
     steps := [
-      .emR (tok_to2 * tok_mary2 : PlanarSyntacticObject),
+      .em .right (tok_to2 * tok_mary2 : PlanarSyntacticObject),
                        -- [V' sent [PP to Mary]]
-      .emL DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
+      .em .left DP_letter2, -- [VP a_letter [V' sent [PP to Mary]]]
       .im DP_mary2,    -- DATIVE SHIFT: Mary to inner Spec
       .im DP_mary2     -- PASSIVE: Mary to outer Spec (subject)
     ] }

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -10,10 +10,10 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
 
 [marcolli-chomsky-berwick-2025] §1.12. `SyntacticObject.Derivation.final` is an unordered
 object, so the surface left-to-right order is not recoverable from it, but a `Derivation`
-records the planarization choices: `emL` and `im` place material on the left edge, `emR` on
-the right, MCB's externalization section `σ_L` fixed by the derivation rather than by a
-noncanonical choice of representative. `Derivation.externalize?` replays the steps on an
-ordered accumulator, a `PlanarSyntacticObject`, so surface orders `decide`; it is partial by
+records the planarization choices: `em .left` and `im` place material on the left edge,
+`em .right` on the right, MCB's externalization section `σ_L` fixed by the derivation rather
+than by a noncanonical choice of representative. `Derivation.externalize?` replays the steps on
+an ordered accumulator, a `PlanarSyntacticObject`, so surface orders `decide`; it is partial by
 design, `none` when a merged item is complex or a mover is absent. Traces are unpronounced,
 dropped by the yield. The faithfulness theorem `externalize?_faithful` says the replay commutes
 with forgetting the order: whenever it succeeds, its result is the derived object itself, so the
@@ -247,8 +247,8 @@ end PlanarSyntacticObject
 def externStep (acc? : Option PlanarSyntacticObject) (step : Step) :
     Option PlanarSyntacticObject :=
   acc?.bind fun acc => match step with
-    | .emL item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc)
-    | .emR item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·)
+    | .em .left item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc)
+    | .em .right item => item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·)
     | .im mover => acc.moveLeft mover
 
 namespace SyntacticObject.Derivation
@@ -305,22 +305,24 @@ private theorem externStep_toSyntacticObject {acc p' : PlanarSyntacticObject} {s
     (h : externStep (some acc) step = some p') :
     p'.toSyntacticObject = step.apply acc.toSyntacticObject := by
   cases step with
-  | emL item =>
-    change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc) = some p' at h
-    rcases hip : item.toPlanarLeaf? with _ | ip
-    · rw [hip, Option.map_none] at h; exact absurd h (by simp)
-    · rw [hip, Option.map_some] at h
-      obtain rfl := Option.some.inj h
-      rw [Step.apply, PlanarSyntacticObject.toSyntacticObject_merge,
-        toPlanarLeaf?_toSyntacticObject hip]
-  | emR item =>
-    change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·) = some p' at h
-    rcases hip : item.toPlanarLeaf? with _ | ip
-    · rw [hip, Option.map_none] at h; exact absurd h (by simp)
-    · rw [hip, Option.map_some] at h
-      obtain rfl := Option.some.inj h
-      rw [Step.apply, PlanarSyntacticObject.toSyntacticObject_merge,
-        toPlanarLeaf?_toSyntacticObject hip]
+  | em side item =>
+    cases side with
+    | left =>
+      change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge · acc) = some p' at h
+      rcases hip : item.toPlanarLeaf? with _ | ip
+      · rw [hip, Option.map_none] at h; exact absurd h (by simp)
+      · rw [hip, Option.map_some] at h
+        obtain rfl := Option.some.inj h
+        rw [Step.apply_em_left, PlanarSyntacticObject.toSyntacticObject_merge,
+          toPlanarLeaf?_toSyntacticObject hip]
+    | right =>
+      change item.toPlanarLeaf?.map (PlanarSyntacticObject.merge acc ·) = some p' at h
+      rcases hip : item.toPlanarLeaf? with _ | ip
+      · rw [hip, Option.map_none] at h; exact absurd h (by simp)
+      · rw [hip, Option.map_some] at h
+        obtain rfl := Option.some.inj h
+        rw [Step.apply_em_right, PlanarSyntacticObject.toSyntacticObject_merge,
+          toPlanarLeaf?_toSyntacticObject hip]
   | im mover =>
     change acc.moveLeft mover = some p' at h
     rw [Step.apply]; exact PlanarSyntacticObject.toSyntacticObject_moveLeft h
@@ -385,11 +387,12 @@ private def xAN : SyntacticObject :=
     (PlanarSyntacticObject.leaf ⟨.simple .N [], 1⟩)).toSyntacticObject
 
 /-- No movement: `Dem Num A N`. -/
-private def xDerivBase : Derivation := ⟨xN, [.emL xA, .emL xNum, .emL xD]⟩
+private def xDerivBase : Derivation := ⟨xN, [.em .left xA, .em .left xNum, .em .left xD]⟩
 /-- Raise N around A, pied-pipe `[N A]` around Num: `Dem N A Num`. -/
-private def xDerivO : Derivation := ⟨xN, [.emL xA, .im xN, .emL xNum, .im xNAt, .emL xD]⟩
+private def xDerivO : Derivation :=
+  ⟨xN, [.em .left xA, .im xN, .em .left xNum, .im xNAt, .em .left xD]⟩
 /-- Pied-pipe `[A N]` around Num, no sub-raise: `Dem A N Num`. -/
-private def xDerivN : Derivation := ⟨xN, [.emL xA, .emL xNum, .im xAN, .emL xD]⟩
+private def xDerivN : Derivation := ⟨xN, [.em .left xA, .em .left xNum, .im xAN, .em .left xD]⟩
 
 example : xDerivBase.surfaceCats = [.D, .Num, .A, .N] := by decide
 example : xDerivO.surfaceCats = [.D, .N, .A, .Num] := by decide

--- a/Linglib/Syntax/Minimalist/Movement/Freezing.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Freezing.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
+import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
+
+/-!
+# Freezing
+
+A constituent a derivation has moved is an island for later extraction, the freezing effect that
+descends from [ross-1967]'s Sentential Subject Constraint and that [chung-2006] makes the test
+of VP-raising analyses of VOS order: whatever a raised VP still contains cannot be extracted,
+whatever left it before it raised can. `Frozen d x` says that `x` sits inside some mover of `d`.
+Movers carry the traces of what evacuated them earlier, not the evacuees, so an evacuee is not
+frozen by the constituent it left; and a mover is itself available to move again. Freezing is
+monotone under extending the derivation and blind to the sides of External Merge.
+
+## Main definitions
+
+* `Minimalist.SyntacticObject.Derivation.Frozen`
+
+## Main results
+
+* `Minimalist.SyntacticObject.Derivation.frozen_append_iff`: extending a derivation freezes
+  what its new movers contain and nothing else.
+* `Minimalist.SyntacticObject.Derivation.Frozen.append`, `frozen_leftward_iff`.
+
+## References
+
+* [ross-1967]
+* [chung-2006]
+-/
+
+namespace Minimalist.SyntacticObject.Derivation
+
+variable {d : Derivation} {steps : List Step} {x : SyntacticObject}
+
+/-- `x` sits inside a constituent `d` has moved. -/
+def Frozen (d : Derivation) (x : SyntacticObject) : Prop := ∃ m ∈ d.movedItems, contains m x
+
+instance (d : Derivation) (x : SyntacticObject) : Decidable (d.Frozen x) := by
+  unfold Frozen; infer_instance
+
+/-- Extending a derivation freezes what its new movers contain and nothing else. -/
+theorem frozen_append_iff :
+    (d.append steps).Frozen x ↔
+      d.Frozen x ∨ ∃ m ∈ steps.filterMap Step.mover?, contains m x := by
+  simp [Frozen, movedItems_append, or_and_right, exists_or]
+
+/-- Freezing is monotone under extension. -/
+theorem Frozen.append (h : d.Frozen x) : (d.append steps).Frozen x :=
+  frozen_append_iff.2 (Or.inl h)
+
+/-- Freezing is blind to the sides of External Merge. -/
+@[simp] theorem frozen_leftward_iff : d.leftward.Frozen x ↔ d.Frozen x := by
+  unfold Frozen; rw [movedItems_leftward]
+
+end Minimalist.SyntacticObject.Derivation

--- a/Linglib/Syntax/Minimalist/Movement/Reconstruction.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Reconstruction.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.Linearization.Replay
+import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
+
+/-!
+# Binding at a stage of the derivation
+
+Movement reorders c-command, and binding may be evaluated before or after it: reconstruction.
+`CCommandsAt d n x y` says that `x` c-commands `y` in the object the replay of `d` reaches after
+`n` steps, which by faithfulness is `d.stageAt n` itself, so the predicate decides a fact about
+the unordered syntactic object; a stage whose replay fails c-commands nothing. `BindsAtSurface`
+evaluates binding at the last stage and `BindsAtSomeStage` at any, the derivational binding
+condition under which a sentence is well formed as soon as some stage satisfies it
+([cole-hermon-2008], fn. 28), reconstruction to any position the mover passed through. Binding
+at some stage is monotone under extending the derivation; binding at the surface is not.
+
+## Main definitions
+
+* `Minimalist.SyntacticObject.Derivation.CCommandsAt`, `BindsAtSurface`, `BindsAtSomeStage`
+
+## Main results
+
+* `Minimalist.SyntacticObject.Derivation.CCommandsAt.cCommandsIn_stageAt`: the predicate speaks
+  of the derivation's own stage.
+* `Minimalist.SyntacticObject.Derivation.cCommandsAt_append_of_le`, `BindsAtSomeStage.append`.
+
+## References
+
+* [cole-hermon-2008]
+-/
+
+namespace Minimalist.SyntacticObject.Derivation
+
+variable {d : Derivation} {steps : List Step} {n : Nat} {x y : SyntacticObject}
+
+/-- `x` c-commands `y` at stage `n` of `d`: in the ordered object the replay reaches after `n`
+steps. -/
+def CCommandsAt (d : Derivation) (n : Nat) (x y : SyntacticObject) : Prop :=
+  ∃ p ∈ (d.take n).externalize?, cCommandsIn p x y
+
+instance (d : Derivation) (n : Nat) (x y : SyntacticObject) :
+    Decidable (d.CCommandsAt n x y) := by
+  unfold CCommandsAt; infer_instance
+
+/-- The stage the predicate looks at is the derivation's own. -/
+theorem CCommandsAt.cCommandsIn_stageAt (h : d.CCommandsAt n x y) :
+    cCommandsIn (d.stageAt n) x y :=
+  let ⟨_, hp, hc⟩ := h
+  d.externalize?_take_faithful n hp ▸ hc
+
+/-- The early stages of an extended derivation are the original's. -/
+theorem cCommandsAt_append_of_le (h : n ≤ d.length) :
+    (d.append steps).CCommandsAt n x y ↔ d.CCommandsAt n x y := by
+  rw [CCommandsAt, CCommandsAt, take_append_of_le h]
+
+/-- Surface binding: c-command at the last stage. -/
+abbrev BindsAtSurface (d : Derivation) (x y : SyntacticObject) : Prop :=
+  d.CCommandsAt d.length x y
+
+/-- Derivational binding: c-command at some stage. -/
+def BindsAtSomeStage (d : Derivation) (x y : SyntacticObject) : Prop :=
+  ∃ n ≤ d.length, d.CCommandsAt n x y
+
+instance (d : Derivation) (x y : SyntacticObject) : Decidable (d.BindsAtSomeStage x y) := by
+  unfold BindsAtSomeStage; infer_instance
+
+/-- Binding at the surface is binding at some stage. -/
+theorem BindsAtSurface.bindsAtSomeStage (h : d.BindsAtSurface x y) : d.BindsAtSomeStage x y :=
+  ⟨d.length, le_rfl, h⟩
+
+/-- Binding at some stage is monotone under extension. -/
+theorem BindsAtSomeStage.append (h : d.BindsAtSomeStage x y) :
+    (d.append steps).BindsAtSomeStage x y :=
+  let ⟨n, hn, hc⟩ := h
+  ⟨n, by rw [length_append]; exact hn.trans (Nat.le_add_right _ _),
+    (cCommandsAt_append_of_le hn).2 hc⟩
+
+end Minimalist.SyntacticObject.Derivation

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Syntax.Minimalist.SyntacticObject.Replace
 import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 
@@ -10,20 +11,30 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 # Derivations
 
 An ordered derivation is an initial syntactic object with a sequence of Merge steps. External Merge
-adds an item as the left or right daughter, and Internal Merge raises a mover: the step re-merges
-the mover with the remainder `deleteAccessible mover current`, the current object with the mover's
+adds an item as the daughter on a side, and Internal Merge raises a mover: the step re-merges the
+mover with the remainder `deleteAccessible mover current`, the current object with the mover's
 occurrences replaced by the trace of the mover's head. Each step applies the carrier node, so the
-derivation's Merge is the workspace Merge by construction, and the node being commutative, `emL` and
-`emR` build the same object; the left-right distinction matters only for the surface order, which
-`Linearization/Replay.lean` recovers on an ordered planar accumulator, since the final object is an
-unordered quotient. Since `node` is noncomputable, so are `Step.apply` and `Derivation.final`, while
-the movers are read off the steps.
+derivation's Merge is the workspace Merge by construction, and the node being commutative, the two
+sides build the same object; the side is a planarization datum that matters only for the surface
+order, which `Linearization/Replay.lean` recovers on an ordered planar accumulator, since the final
+object is an unordered quotient. Since `node` is noncomputable, so are `Step.apply` and
+`Derivation.final`, while the movers are read off the steps. A derivation extends by further steps,
+whose early stages and movers are the original's, and normalizes by moving every External Merge to
+the left, which changes no stage and no mover.
 
 ## Main definitions
 
-* `Minimalist.SyntacticObject.Step`, `Step.apply`, `deleteAccessible`
+* `Minimalist.SyntacticObject.Side`, `Step`, `Step.apply`, `Step.mover?`, `deleteAccessible`
 * `Minimalist.SyntacticObject.Derivation`, `Derivation.final`, `stageAt`, `movedItems`, `take`,
-  `leftward`
+  `append`, `leftward`
+
+## Main results
+
+* `Minimalist.SyntacticObject.Step.apply_em`: the sides build the same object.
+* `Minimalist.SyntacticObject.Derivation.stageAt_append_of_le`, `movedItems_append`: extension
+  keeps the early stages and the movers.
+* `Minimalist.SyntacticObject.Derivation.stageAt_leftward`, `movedItems_leftward`: the sides
+  change no stage and no mover.
 
 ## References
 
@@ -39,12 +50,17 @@ namespace SyntacticObject
 
 /-! ### Steps -/
 
+/-- The side at which External Merge attaches the new item: the planarization datum that
+    externalization reads and the derived object ignores. -/
+inductive Side where
+  | left
+  | right
+  deriving DecidableEq, Repr, Fintype
+
 /-- A derivation step. `im` records only the mover; the trace it leaves is that of its head. -/
 inductive Step where
-  /-- External Merge, new item as the left daughter. -/
-  | emL (item : SyntacticObject)
-  /-- External Merge, new item as the right daughter. -/
-  | emR (item : SyntacticObject)
+  /-- External Merge, the new item as the daughter on `side`. -/
+  | em (side : Side) (item : SyntacticObject)
   /-- Internal Merge: raise `mover`, leaving the trace of its head in its place. -/
   | im (mover : SyntacticObject)
 
@@ -67,44 +83,57 @@ noncomputable def deleteAccessible (mover current : SyntacticObject) : Syntactic
     node of the remainder and the mover. -/
 noncomputable def Step.apply (step : Step) (current : SyntacticObject) : SyntacticObject :=
   match step with
-  | .emL item  => merge item current
-  | .emR item  => merge current item
-  | .im mover  => merge (deleteAccessible mover current) mover
+  | .em .left item => merge item current
+  | .em .right item => merge current item
+  | .im mover => merge (deleteAccessible mover current) mover
 
-theorem Step.apply_emL (item current : SyntacticObject) :
-    (Step.emL item).apply current = merge item current := rfl
+theorem Step.apply_em_left (item current : SyntacticObject) :
+    (Step.em .left item).apply current = merge item current := rfl
 
-theorem Step.apply_emR (item current : SyntacticObject) :
-    (Step.emR item).apply current = merge current item := rfl
+theorem Step.apply_em_right (item current : SyntacticObject) :
+    (Step.em .right item).apply current = merge current item := rfl
 
 theorem Step.apply_im (mover current : SyntacticObject) :
     (Step.im mover).apply current = merge (deleteAccessible mover current) mover := rfl
 
-/-- `emL` and `emR` build the same object; they differ only at externalization. -/
-theorem Step.apply_emL_eq_emR (item current : SyntacticObject) :
-    (Step.emL item).apply current = (Step.emR item).apply current :=
-  mul_comm item current
+/-- The sides build the same object; they differ only at externalization. -/
+theorem Step.apply_em (side : Side) (item current : SyntacticObject) :
+    (Step.em side item).apply current = merge item current := by
+  cases side
+  · rfl
+  · exact merge_comm current item
+
+/-- The mover of an Internal-Merge step. -/
+def Step.mover? : Step → Option SyntacticObject
+  | .im mover => some mover
+  | .em _ _ => none
+
+@[simp] theorem Step.mover?_em (side : Side) (item : SyntacticObject) :
+    (Step.em side item).mover? = none := rfl
+
+@[simp] theorem Step.mover?_im (mover : SyntacticObject) : (Step.im mover).mover? = some mover :=
+  rfl
 
 /-- The step with its External Merge on the left; Internal Merge is unchanged. -/
 def Step.leftward : Step → Step
-  | .emR item => .emL item
-  | step => step
+  | .em _ item => .em .left item
+  | .im mover => .im mover
 
-@[simp] theorem Step.leftward_emL (item : SyntacticObject) : (Step.emL item).leftward = .emL item :=
-  rfl
-
-@[simp] theorem Step.leftward_emR (item : SyntacticObject) : (Step.emR item).leftward = .emL item :=
-  rfl
+@[simp] theorem Step.leftward_em (side : Side) (item : SyntacticObject) :
+    (Step.em side item).leftward = .em .left item := rfl
 
 @[simp] theorem Step.leftward_im (mover : SyntacticObject) : (Step.im mover).leftward = .im mover :=
   rfl
+
+@[simp] theorem Step.mover?_leftward (step : Step) : step.leftward.mover? = step.mover? := by
+  cases step <;> rfl
 
 /-- A step and its leftward form build the same object. -/
 theorem Step.apply_leftward (step : Step) (current : SyntacticObject) :
     step.leftward.apply current = step.apply current := by
   cases step with
-  | emR item => exact Step.apply_emL_eq_emR item current
-  | emL _ | im _ => rfl
+  | em side item => rw [Step.leftward_em, Step.apply_em, Step.apply_em]
+  | im _ => rfl
 
 /-! ### Derivations -/
 
@@ -129,13 +158,13 @@ noncomputable def stageAt (d : Derivation) (n : Nat) : SyntacticObject :=
 def length (d : Derivation) : Nat := d.steps.length
 
 /-- The movers of the `im` steps. -/
-def movedItems (d : Derivation) : List SyntacticObject :=
-  d.steps.filterMap fun
-    | .im mover => some mover
-    | _ => none
+def movedItems (d : Derivation) : List SyntacticObject := d.steps.filterMap Step.mover?
 
 /-- The first `n` steps. -/
 def take (d : Derivation) (n : Nat) : Derivation := ⟨d.initial, d.steps.take n⟩
+
+/-- The derivation continued by `steps`. -/
+def append (d : Derivation) (steps : List Step) : Derivation := ⟨d.initial, d.steps ++ steps⟩
 
 @[simp] theorem stageAt_zero (d : Derivation) : d.stageAt 0 = d.initial := by
   simp [stageAt]
@@ -144,6 +173,36 @@ theorem stageAt_length (d : Derivation) : d.stageAt d.steps.length = d.final := 
   simp [stageAt, final, List.take_length]
 
 @[simp] theorem final_take (d : Derivation) (n : Nat) : (d.take n).final = d.stageAt n := rfl
+
+/-! ### Extension
+
+The early stages and the movers of an extended derivation are the original's. -/
+
+@[simp] theorem length_append (d : Derivation) (steps : List Step) :
+    (d.append steps).length = d.length + steps.length := by
+  simp [length, append]
+
+/-- The first `n ≤ d.length` steps of an extension are `d`'s. -/
+theorem take_append_of_le {d : Derivation} {n : Nat} (h : n ≤ d.length) (steps : List Step) :
+    (d.append steps).take n = d.take n := by
+  simp [take, append, List.take_append_of_le_length h]
+
+@[simp] theorem take_length_append (d : Derivation) (steps : List Step) :
+    (d.append steps).take d.length = d := by
+  unfold take append
+  rw [length, List.take_left]
+
+theorem stageAt_append_of_le {d : Derivation} {n : Nat} (h : n ≤ d.length) (steps : List Step) :
+    (d.append steps).stageAt n = d.stageAt n := by
+  rw [← final_take, ← final_take, take_append_of_le h]
+
+theorem final_append (d : Derivation) (steps : List Step) :
+    (d.append steps).final = steps.foldl (fun so step => step.apply so) d.final := by
+  simp [final, append, List.foldl_append]
+
+@[simp] theorem movedItems_append (d : Derivation) (steps : List Step) :
+    (d.append steps).movedItems = d.movedItems ++ steps.filterMap Step.mover? := by
+  simp [movedItems, append, List.filterMap_append]
 
 /-! ### The sides of External Merge
 
@@ -162,10 +221,7 @@ def leftward (d : Derivation) : Derivation := ⟨d.initial, d.steps.map Step.lef
   simp only [final, leftward, List.foldl_map, Step.apply_leftward]
 
 @[simp] theorem movedItems_leftward (d : Derivation) : d.leftward.movedItems = d.movedItems := by
-  simp only [movedItems, leftward, List.filterMap_map]
-  congr 1
-  funext step
-  cases step <;> rfl
+  simp [movedItems, leftward, List.filterMap_map]
 
 end Derivation
 
@@ -177,10 +233,16 @@ private def demoTok (i : Nat) : SyntacticObject := SyntacticObject.leaf ⟨.simp
 
 example :
     (Derivation.mk (demoTok 0)
-      [Step.emL (demoTok 1), Step.im (demoTok 1),
-       Step.emR (demoTok 2), Step.im (demoTok 2)]).movedItems = [demoTok 1, demoTok 2] := by
+      [Step.em .left (demoTok 1), Step.im (demoTok 1),
+       Step.em .right (demoTok 2), Step.im (demoTok 2)]).movedItems = [demoTok 1, demoTok 2] := by
   simp [Derivation.movedItems, demoTok]
 
-example : (Derivation.mk (demoTok 0) [Step.emL (demoTok 1)]).length = 1 := rfl
+example : (Derivation.mk (demoTok 0) [Step.em .left (demoTok 1)]).length = 1 := rfl
+
+/-- Extension keeps the movers and adds the new ones. -/
+example :
+    ((Derivation.mk (demoTok 0) [Step.em .left (demoTok 1)]).append
+      [Step.im (demoTok 1)]).movedItems = [demoTok 1] := by
+  simp [Derivation.movedItems, Derivation.append, demoTok]
 
 end Minimalist

--- a/references.bib
+++ b/references.bib
@@ -17300,7 +17300,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {foundational},
-  sources   = {Studies/Ross1967.lean}
+  sources   = {Studies/Ross1967.lean;Syntax/Minimalist/Movement/Freezing.lean}
 }
 @book{chomsky-1981,
   author    = {Chomsky, Noam},
@@ -18951,7 +18951,7 @@
   doi       = {10.1111/j.1467-9612.2008.00106.x},
   subfield  = {syntax},
   role      = {formalized},
-  sources   = {Studies/ColeHermon2008.lean;Data/Examples/ColeHermon2008.json;Fragments/TobaBatak/Basic.lean;Syntax/Minimalist/Movement/Remnant.lean}
+  sources   = {Studies/ColeHermon2008.lean;Data/Examples/ColeHermon2008.json;Fragments/TobaBatak/Basic.lean;Syntax/Minimalist/Movement/Remnant.lean;Syntax/Minimalist/Movement/Reconstruction.lean}
 }
 @incollection{chung-2006,
   author    = {Chung, Sandra},
@@ -18965,7 +18965,7 @@
   doi       = {10.1002/9780470996591.ch52},
   subfield  = {syntax},
   role      = {cited},
-  sources   = {Studies/ColeHermon2008.lean}
+  sources   = {Studies/ColeHermon2008.lean;Syntax/Minimalist/Movement/Freezing.lean}
 }
 @incollection{schachter-1984,
   author    = {Schachter, Paul},


### PR DESCRIPTION
Consolidate ColeHermon2008's study-local API into the Derivation substrate.
- `Step.em side item` replaces `emL`/`emR` (Chomsky1995, Cinque2005, Larson1988 and Replay swept); `Step.mover?`; `Derivation.append` with the prefix laws `take_length_append`, `stageAt_append_of_le`, `movedItems_append`.
- New `Movement/Freezing.lean` (`Derivation.Frozen`, monotone under extension, blind to sides) and `Movement/Reconstruction.lean` (`CCommandsAt`, `BindsAtSurface`, `BindsAtSomeStage`, monotone under extension).
- ColeHermon2008 consumes them; `svo_take_vos` and `frozen_svo_iff` become one-liners.