### PR TITLE
refactor(Syntax/Minimalist): remnant fronting on Derivation

### DIFF
--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -4,6 +4,7 @@ import Linglib.Fragments.TobaBatak.Basic
 import Linglib.Semantics.ArgumentStructure.Valency
 import Linglib.Syntax.Minimalist.Movement.Freezing
 import Linglib.Syntax.Minimalist.Movement.Reconstruction
+import Linglib.Syntax.Minimalist.Movement.Remnant
 
 /-!
 # Cole and Hermon 2008: VP raising in a VOS language
@@ -36,10 +37,11 @@ patient bind it but never the converse.
 
 The derivation is a `Derivation` on the syntactic-object carrier, freezing and binding at a
 stage are the substrate's `Derivation.Frozen`, `CCommandsAt` and `BindsAtSomeStage`, and the
-paper's examples are the rows: `vos_hypothesis_only` and `derivational_only` single out, among
-the candidate analyses of word order and of binding, the paper's own, `table1` derives its
-three grades, `stageAt_sides` and `surface_sides` are the §6 claim over every attachment
-choice, and `english_passive` the §7 contrast.
+paper's examples are the rows: `vos_remnant` says that the raised VoiceP is a remnant,
+`vos_hypothesis_only` and `derivational_only` single out, among the candidate analyses of word
+order and of binding, the paper's own, `table1` derives its three grades, `stageAt_sides` and
+`surface_sides` are the §6 claim over every attachment choice, and `english_passive` the §7
+contrast.
 
 ## Implementation notes
 
@@ -261,6 +263,13 @@ theorem ex81_orders :
 /-- The SVO ditransitive (85), S-V-O-IO. -/
 theorem ex85_svoi :
     ex85.svo.surfacePhon = ["si-John", "mang-", "alean", "aha", "tu si-Mary"] := by decide
+
+/-- VoiceP raising is remnant movement (§4.1–§4.2): the raised VoiceP holds the traces of the
+verb, Voice, the pivot and, in (56), the goal. -/
+theorem vos_remnant :
+    ex49.vos.IsRemnantStep (ex49.svoStage.length + 1) ∧
+      ex56.vos.IsRemnantStep (ex56.svoStage.length + 1) := by
+  decide
 
 /-! ### Every clause goes through a VOS stage (§5) -/
 

--- a/Linglib/Studies/SandeClemDabkowski2026.lean
+++ b/Linglib/Studies/SandeClemDabkowski2026.lean
@@ -30,7 +30,7 @@ is their (44): harmony iff V is spelled out inside vP.
   particle's surface value ((12)–(13)), and the (46)/(47) ranking as a tableau.
 * `FrozenATR`, `guebiePICMode`: the per-cycle harmony record (§6.1) and the PIC
   stance (§6.2).
-* `guebiePredicateDoubling`: the §3 movement witnesses.
+* `guebieFronting`: the §3 movement witness, their (31) on the carrier.
 * `HarmonyProfile`, `WolofShape`: the §7 prediction schema — trigger and target
   co-spelled-out low, movement after — instantiated by Guébie and Wolof.
 
@@ -42,8 +42,8 @@ is their (44): harmony iff V is spelled out inside vP.
   linearizes; the §6.2 escape-hatch counterfactual crashes.
 * `optimal_eq_surfaceATR`, `PartSAuxOV_atr_persists_through_fronting`: the ranking
   derives the surface value, and it survives the CP cycle.
-* `guebie_VDIS_positive_instance`: doubling is narrow-syntactic ((25)–(30),
-  contra [landau-2006]).
+* `guebie_remnant_fronting`: the verb moves and the VP fronts as a remnant, so doubling
+  is narrow-syntactic ((25)–(30), contra [landau-2006]).
 * `guebie_profile`, `wolof_profile`, `wolof_discontinuous`: both languages
   instantiate the §7 schema ([sy-2005], [martinovic-2019]).
 
@@ -285,48 +285,32 @@ theorem guebie_PIC_admits_remnant_movement (φ : Minimalist.Phase)
 Three diagnostics: successive cyclicity ((25)–(26)), island sensitivity
 ((27)–(28)), and island creation ((29)–(30)). This registers Guébie beside
 [harizanov-gribanova-2019]'s Russian as a construction whose verb doubling is syntactic,
-against [landau-2006]'s PF-driven Hebrew analysis. The witnesses are schematic: the
-fronted remnant is an evacuation trace plus the verb copy, per their (31). -/
+against [landau-2006]'s PF-driven Hebrew analysis. The witness is the schematic derivation
+of their (31): the verb raises out of the VP and the remnant, the particle over the verb's
+trace, fronts to Spec,CP; the carrier pronounces no trace, so the doubling, the lower copy
+spelled out for recoverability per [koopman-1997], lies beyond it. -/
 
-open Minimalist (SyntacticObject LIToken)
-open Minimalist.Movement (RemnantFronting PredicateDoubling properRemnant)
+open Minimalist (SyntacticObject LIToken PlanarSyntacticObject)
 open Minimalist.SyntacticObject
 
-private def guebieVerbTok : LIToken := ⟨.simple .V [], 1⟩
-private def guebieVerbLeaf : SyntacticObject := leaf guebieVerbTok
+private def V₀ : LIToken := ⟨.simple .V [], 1⟩
+private def Part₀ : LIToken := ⟨.simple .P [], 2⟩
+private def T₀ : LIToken := ⟨.simple .T [], 3⟩
+private def C₀ : LIToken := ⟨.simple .C [], 4⟩
 
-/-- The remnant VP of the verb-doubling configuration ((31)): an evacuation trace
-    plus the verb copy, pronounced for recoverability per [koopman-1997]. -/
-private def guebieFrontedVP : SyntacticObject :=
-  ↑(Minimalist.PlanarSyntacticObject.trace * guebieVerbTok)
+/-- The remnant VP of (31): the particle over the verb's trace. -/
+private def remnantVP : PlanarSyntacticObject :=
+  {PlanarSyntacticObject.leaf Part₀, PlanarSyntacticObject.traceOf V₀}
 
-private def guebieLandingTok : LIToken := ⟨.simple .C [], 2⟩
-private def guebieLandingSite : SyntacticObject := leaf guebieLandingTok
+/-- (31) on the carrier: the verb Merges with the particle and raises to T, and the remnant
+    VP fronts to Spec,CP. -/
+def guebieFronting : Derivation :=
+  ⟨V₀, [.em .left Part₀, .em .left T₀, .im V₀, .em .left C₀, .im remnantVP]⟩
 
-/-- The Guébie predicate-fronting witness: V evacuates, the remnant VP fronts to
-    Spec,CP, and the trace is pronounced — verb doubling. -/
-def guebiePredicateDoubling : PredicateDoubling :=
-  { frontedXP        := guebieFrontedVP
-    evacuatedHeads   := [guebieVerbLeaf]
-    landingSite      := guebieLandingSite
-    verb             := guebieVerbLeaf
-    verb_evacuated   := List.mem_singleton.mpr rfl
-    trace_pronounced := true }
-
-/-- The evacuated verb sat inside the fronted remnant. -/
-theorem guebie_properRemnant :
-    properRemnant guebiePredicateDoubling.toRemnantFronting := by decide
-
-/-- On the carrier, Internal Merge leaves a trace at the deeper position
-    ([marcolli-chomsky-berwick-2025] §1.4.3); surface doubling is the pronunciation
-    of both positions. -/
-def guebieFrontingDerivation : Derivation :=
-  { initial := guebieFrontedVP
-    steps   := [.im guebieVerbLeaf] }
-
-/-- The verb is a mover of the Guébie derivation, so its doubling is syntactic (§3's
-    diagnostics; decidable from the derivation structure). -/
-theorem guebie_verb_moved : guebieVerbLeaf ∈ guebieFrontingDerivation.movedItems := by
+/-- The verb is a mover and the VP fronts as a remnant: the doubling configuration is built
+    in the narrow syntax (§3's diagnostics), decidable from the derivation. -/
+theorem guebie_remnant_fronting :
+    (V₀ : SyntacticObject) ∈ guebieFronting.movedItems ∧ guebieFronting.IsRemnantStep 4 := by
   decide
 
 /-! ### The §7 prediction and the Wolof parallel

--- a/Linglib/Syntax/Minimalist/Movement/Remnant.lean
+++ b/Linglib/Syntax/Minimalist/Movement/Remnant.lean
@@ -1,154 +1,70 @@
-import Linglib.Syntax.Minimalist.Phase.Basic
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Minimalist.SyntacticObject.Derivation
+import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
 
 /-!
-# Remnant XP Movement
-[koopman-1997] [aboh-dyakonova-2009] [van-urk-2024]
+# Remnant movement
 
-A constituent X′ moves to Spec,FocP (or Spec,CP) **after** some
-sub-constituent Y has independently moved out of X′. The fronted X′
-is a *remnant* of the original XP — what's left after Y evacuated.
-The classic empirical signature is **predicate doubling**: the verb
-appears twice — once at the head of its own movement chain (e.g. in T)
-and once inside the fronted remnant VP (where its trace is spelled
-out for recoverability).
+A constituent moves after part of it has moved out, so what fronts is a remnant carrying the
+trace of what left it: [koopman-1997]'s predicate clefts in Vata and Nweh, where the VP fronts
+after the verb has raised, the Gungbe and Kwa predicate doubling of [aboh-dyakonova-2009], the
+constraints on predicate fronting [van-urk-2024] surveys, Toba Batak's VoiceP raising after the
+goal and the subject have evacuated it ([cole-hermon-2008], `Studies/ColeHermon2008.lean`), and
+Guébie's particle fronting after the verb has left the VP ([sande-clem-dabkowski-2026],
+`Studies/SandeClemDabkowski2026.lean`). On a derivation
+the notion is exact: step `i` fronts a remnant when its mover contains the trace the head of an
+earlier mover left. Whether the evacuee's lower copy is pronounced inside the remnant, the verb
+doubling of predicate clefts, is a matter of chain pronunciation, phonological for
+[landau-2006] and syntactic for [koopman-1997] and [harizanov-gribanova-2017]; the carrier
+pronounces no trace and does not decide it. Remnant movement is the converse of smuggling
+(`Movement/Smuggling.lean`, [collins-2005]), in which the larger constituent moves with the
+smaller one still inside it.
 
-## Where this substrate is consumed
+## Main definitions
 
-Remnant-XP movement is referenced informally across multiple existing
-Studies files; this substrate centralizes the construct so that the
-reasoning is shared rather than re-stipulated:
+* `Minimalist.SyntacticObject.Derivation.IsRemnantStep`
 
-- [koopman-1997] (originator): predicate clefts in Vata (Kru)
-  and Nweh (Grassfields Bantu) — VP fronts after V→T head movement.
-- [aboh-dyakonova-2009]: predicate doubling and parallel chains
-  in {Gungbe} and across {Kwa}.
-- [harizanov-gribanova-2017] / [harizanov-gribanova-2019]:
-  alternative analysis (postsyntactic amalgamation), with the
-  syntactic-vs-PF dichotomy.
-- [van-urk-2024]: cross-linguistic constraints on predicate
-  fronting; alternative substantive proposals.
-- [sande-clem-dabkowski-2026]: Guébie particle-fronting in
-  predicate clefts — the fronted constituent is the remnant VP after
-  V → v → T head movement and object shift, leaving only the particle
-  in the remnant.
-- [cole-hermon-2008]: {Toba Batak} VoiceP raising after the goal and
-  the subject evacuate, derived step by step on the syntactic-object
-  carrier in `Studies/ColeHermon2008.lean`, where the fronted remnant
-  holds the evacuees' traces rather than the evacuees.
+## Main results
 
-## Design
+* `Minimalist.SyntacticObject.Derivation.IsRemnantStep.append`: a remnant step of a derivation
+  is one of every extension.
 
-`RemnantFronting` records three pieces:
-- `frontedXP`: the larger constituent that lands in Spec,Foc/CP
-- `evacuatedHeads`: the sub-constituents (typically heads) that moved
-  out of `frontedXP` *before* it fronted
-- `landingSite`: where `frontedXP` lands
+## References
 
-`properRemnant` is the structural predicate that the fronted XP no
-longer literally contains the evacuated heads as overt material — the
-characteristic property of "remnant" movement, which distinguishes it
-from non-remnant XP fronting (where the whole XP, contents intact,
-moves).
-
-For verb-doubling derivations, the evacuated head (V) leaves a trace
-inside the fronted XP that may be spelled out for recoverability.
-[landau-2006] argues this recoverability requirement is purely
-phonological; [koopman-1997] and [harizanov-gribanova-2017]
-take it to be a syntactic chain property. The substrate does not
-adjudicate — the predicate `properRemnant` is silent on whether the
-trace is overt.
-
-## What this substrate does NOT do
-
-It does not (yet) provide a typed bridge to `HeadDisplacement` (the
-syntactic-vs-PF dichotomy of [harizanov-gribanova-2019]),
-nor does it state cross-linguistic generalizations about which
-constructions license remnant fronting. Those are downstream Studies
-content. The substrate is intentionally minimal — just enough to type
-the construct so per-paper analyses share vocabulary.
-
-## Relationship to `Movement/Smuggling.lean`
-
-Sibling file `Smuggling.lean` ([collins-2005]) covers a different
-XP-movement variant: a constituent YP containing XP moves *with* XP
-inside it to a position c-commanding an intervener W (smuggling XP
-past W). Remnant fronting is the converse: a sub-element Y has been
-evacuated *before* the larger constituent fronts. They share the
-structural feature "large XP moves" but differ in whether the
-sub-constituent has been extracted (remnant) or remains inside
-(smuggling). The substrates are not unified because the structural
-preconditions differ; consumers should pick the one that matches
-their analysis. SCD 2026's predicate-fronting is remnant; Collins
-2005's passive-via-smuggling is smuggling.
+* [koopman-1997]
+* [aboh-dyakonova-2009]
+* [van-urk-2024]
+* [landau-2006]
+* [harizanov-gribanova-2017]
+* [collins-2005]
+* [cole-hermon-2008]
+* [sande-clem-dabkowski-2026]
 -/
 
-namespace Minimalist.Movement
+namespace Minimalist.SyntacticObject.Derivation
 
-open SyntacticObject
+variable {d : Derivation} {steps : List Step} {i : Nat}
 
--- ============================================================================
--- § 1: Remnant Fronting Record
--- ============================================================================
+/-- Step `i` of `d` fronts a remnant: its mover contains the trace left by an earlier mover. -/
+def IsRemnantStep (d : Derivation) (i : Nat) : Prop :=
+  ∃ m ∈ d.steps[i]? >>= Step.mover?, ∃ x ∈ (d.take i).movedItems, contains m x.headTrace
 
-/-- A remnant XP movement: `frontedXP` lands at `landingSite` after
-    `evacuatedHeads` have moved out of it. -/
-structure RemnantFronting where
-  /-- The larger constituent that fronts (typically VP, vP, VoiceP,
-      or — under [harizanov-gribanova-2017] — AspP). -/
-  frontedXP : SyntacticObject
-  /-- Heads that moved out of `frontedXP` before it fronted (typically
-      V, sometimes also Object). Listed in evacuation order. -/
-  evacuatedHeads : List SyntacticObject
-  /-- Landing position of `frontedXP` (typically Spec,FocP or Spec,CP). -/
-  landingSite : SyntacticObject
+instance (d : Derivation) (i : Nat) : Decidable (d.IsRemnantStep i) := by
+  unfold IsRemnantStep; infer_instance
 
--- ============================================================================
--- § 2: Proper Remnant Predicate
--- ============================================================================
+/-- A remnant step of a derivation is one of every extension. -/
+theorem IsRemnantStep.append (h : d.IsRemnantStep i) : (d.append steps).IsRemnantStep i := by
+  obtain ⟨m, hm, x, hx, hc⟩ := h
+  have hi : i < d.length := by
+    by_contra hlt
+    rw [List.getElem?_eq_none (Nat.le_of_not_lt hlt)] at hm
+    simp at hm
+  refine ⟨m, ?_, x, ?_, hc⟩
+  · rwa [Derivation.append, List.getElem?_append_left hi]
+  · rwa [take_append_of_le hi.le]
 
-/-- Structural definition of a *proper* remnant: every head listed in
-    `evacuatedHeads` originally sat inside `frontedXP` (so it actually
-    evacuated; vacuous evacuations don't count).
-
-    This is the substrate-side commitment that justifies the term
-    "remnant" — the fronted XP is the original XP minus the evacuated
-    sub-constituents. The predicate is silent on whether the evacuated
-    heads' traces are spelled out (verb doubling vs. silent copy) — that
-    is a per-construction choice. -/
-def properRemnant (rf : RemnantFronting) : Prop :=
-  ∀ h ∈ rf.evacuatedHeads, contains rf.frontedXP h
-
-instance (rf : RemnantFronting) : Decidable (properRemnant rf) := by
-  unfold properRemnant; infer_instance
-
--- ============================================================================
--- § 3: Predicate Doubling Schema ([koopman-1997])
--- ============================================================================
-
-/-- A predicate-doubling derivation: V undergoes head movement to T (or
-    higher), and the remnant VP — containing V's trace, possibly
-    pronounced — fronts to Spec,CP. The pronounced lower copy is what
-    yields surface verb doubling.
-
-    This is the canonical Koopman-1997 schema instantiated in Vata,
-    Nweh, and (per [sande-clem-dabkowski-2026]) Guébie. -/
-structure PredicateDoubling extends RemnantFronting where
-  /-- The verbal head V whose movement creates the doubling. -/
-  verb : SyntacticObject
-  /-- V is among the evacuated heads (otherwise this isn't doubling). -/
-  verb_evacuated : verb ∈ evacuatedHeads
-  /-- The verb's trace inside `frontedXP` is pronounced (= verb doubling).
-      Per [landau-2006] this is a phonological recoverability
-      requirement; per [koopman-1997] and [harizanov-gribanova-2017]
-      it reflects syntactic chain pronunciation rules. The substrate
-      records the empirical fact without taking sides. -/
-  trace_pronounced : Bool
-
-/-- Verb doubling implies the verb evacuated, hence by `properRemnant`
-    sat originally inside the fronted XP. -/
-theorem predicateDoubling_verb_in_frontedXP
-    (pd : PredicateDoubling) (h : properRemnant pd.toRemnantFronting) :
-    contains pd.frontedXP pd.verb :=
-  h pd.verb pd.verb_evacuated
-
-end Minimalist.Movement
+end Minimalist.SyntacticObject.Derivation

--- a/references.bib
+++ b/references.bib
@@ -19111,7 +19111,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Syntax/Minimalist/Movement/Smuggling.lean;Studies/Collins2005.lean;Syntax/Minimalist/Verbal/Voice.lean}
+  sources   = {Syntax/Minimalist/Movement/Smuggling.lean;Studies/Collins2005.lean;Syntax/Minimalist/Verbal/Voice.lean;Syntax/Minimalist/Movement/Remnant.lean}
 }
 @unpublished{copley-harley-2022,
   author    = {Copley, Bridget and Harley, Heidi},


### PR DESCRIPTION
`Remnant.lean` becomes a predicate on derivations, `IsRemnantStep d i`: the mover of step `i` contains the trace an earlier mover left.
- Replaces the `RemnantFronting`/`PredicateDoubling` record, whose `properRemnant` is false for every carrier remnant (it holds traces, not evacuees); monotone under extension.
- SandeClemDabkowski2026's §3 witness is now the (31) derivation with `guebie_remnant_fronting`; ColeHermon2008 gains `vos_remnant`.
- The header's dangling `guebie_VDIS_positive_instance` pointer is fixed in passing.