### PR TITLE
refactor(Semantics/Aspect): sorted instantiation over open intervals

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1508,6 +1508,7 @@ import Linglib.Semantics.ArgumentStructure.VerbDenotation
 import Linglib.Semantics.ArgumentStructure.VoiceSemantics
 import Linglib.Semantics.Aspect.AtomDist
 import Linglib.Semantics.Aspect.Basic
+import Linglib.Semantics.Aspect.Instantiation
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Semantics.Aspect.Composition
 import Linglib.Semantics.Aspect.Cumulativity

--- a/Linglib/Core/Order/Interval.lean
+++ b/Linglib/Core/Order/Interval.lean
@@ -1,7 +1,8 @@
+import Mathlib.Order.Hom.WithTopBot
 import Mathlib.Order.Interval.Basic
 
 /-!
-# Relational vocabulary for nonempty intervals
+# Relational vocabulary for intervals
 
 [allen-1983] [kamp-reyle-1993] [klein-1994]
 [pancheva-2003] [sagey-1986] [smith-1997]
@@ -17,6 +18,12 @@ Containment, the subinterval order, and point intervals are mathlib's
 own API: `t ∈ i` (`mem_def`), `i₁ ≤ i₂` (`le_def`), `i₁ < i₂`
 (strict containment, see `lt_def`), `pure t`.
 
+The same vocabulary on mathlib's `Interval α`, the closed intervals with
+the null interval `⊥`, where `≤` is inclusion and `⊓` intersection:
+`Interval.Precedes` is [allen-1983]'s *before*, a left endpoint is
+`IsLeast` of the coerced set, `NonemptyInterval.withTop` embeds a bounded
+interval into `WithTop α`, and `Interval.Ici a` is the ray from `a` to the
+end of time.
 -/
 
 namespace NonemptyInterval
@@ -183,4 +190,132 @@ theorem overlaps_not_transitive :
 
 end LinearOrder
 
+/-! ### Embedding into `WithTop` -/
+
+section WithTop
+
+variable {α : Type*} [Preorder α]
+
+/-- An interval of `α` as an interval of `WithTop α`. -/
+def withTop (i : NonemptyInterval α) : NonemptyInterval (WithTop α) :=
+  i.map WithTop.coeOrderHom.toOrderHom
+
+@[simp] theorem fst_withTop (i : NonemptyInterval α) : i.withTop.fst = ↑i.fst := rfl
+
+@[simp] theorem snd_withTop (i : NonemptyInterval α) : i.withTop.snd = ↑i.snd := rfl
+
+@[simp] theorem mem_withTop {i : NonemptyInterval α} {x : WithTop α} :
+    x ∈ i.withTop ↔ ↑i.fst ≤ x ∧ x ≤ ↑i.snd :=
+  Iff.rfl
+
+/-- The embedding preserves and reflects containment. -/
+@[simp] theorem withTop_le_withTop {i j : NonemptyInterval α} : i.withTop ≤ j.withTop ↔ i ≤ j := by
+  simp [le_def]
+
+end WithTop
+
 end NonemptyInterval
+
+/-! ### Intervals with a null element -/
+
+namespace Interval
+
+section PartialOrder
+
+variable {α : Type*} [PartialOrder α] {s t : Interval α} {i j : NonemptyInterval α} {a b x : α}
+
+/-- `s` precedes `t`: every element of `s` is below every element of `t` ([allen-1983]'s
+*before*), vacuously so at the null interval. -/
+def Precedes (s t : Interval α) : Prop := ∀ ⦃x⦄, x ∈ s → ∀ ⦃y⦄, y ∈ t → x < y
+
+@[simp] theorem notMem_bot : x ∉ (⊥ : Interval α) := by
+  simp [← SetLike.mem_coe]
+
+/-- A nonempty interval lies within `s` exactly when its endpoints do. -/
+theorem coe_le_iff : (↑i : Interval α) ≤ s ↔ i.fst ∈ s ∧ i.snd ∈ s := by
+  induction s using recBotCoe with
+  | bot => exact iff_of_false (λ h => WithBot.coe_ne_bot (le_bot_iff.1 h)) (λ h => notMem_bot h.1)
+  | coe j =>
+    refine ⟨λ h => ?_, λ ⟨h₁, h₂⟩ => WithBot.coe_le_coe.2 (NonemptyInterval.le_def.2
+      ⟨(NonemptyInterval.mem_def.1 h₁).1, (NonemptyInterval.mem_def.1 h₂).2⟩)⟩
+    obtain ⟨h₁, h₂⟩ := NonemptyInterval.le_def.1 (WithBot.coe_le_coe.1 h)
+    exact ⟨NonemptyInterval.mem_def.2 ⟨h₁, le_trans i.fst_le_snd h₂⟩,
+      NonemptyInterval.mem_def.2 ⟨le_trans h₁ i.fst_le_snd, h₂⟩⟩
+
+@[simp] theorem pure_le_iff : pure a ≤ s ↔ a ∈ s := by
+  simp [← coe_subset_coe]
+
+/-- The left endpoint is the least element. -/
+theorem isLeast_coe_fst : IsLeast (↑(↑i : Interval α) : Set α) i.fst :=
+  ⟨NonemptyInterval.mem_def.2 ⟨le_rfl, i.fst_le_snd⟩, λ _ hx => (NonemptyInterval.mem_def.1 hx).1⟩
+
+theorem isLeast_pure : IsLeast (↑(pure a : Interval α) : Set α) a := isLeast_coe_fst
+
+/-- Nonempty intervals precede exactly when the one ends before the other starts, the
+endpoint form of the relation. -/
+theorem precedes_coe_coe : (↑i : Interval α).Precedes ↑j ↔ i.precedes j :=
+  ⟨λ h => h (NonemptyInterval.mem_def.2 ⟨i.fst_le_snd, le_rfl⟩)
+      (NonemptyInterval.mem_def.2 ⟨le_rfl, j.fst_le_snd⟩),
+    λ h _ hx _ hy => lt_of_le_of_lt (NonemptyInterval.mem_def.1 hx).2
+      (lt_of_lt_of_le h (NonemptyInterval.mem_def.1 hy).1)⟩
+
+@[simp] theorem precedes_pure_pure : (pure a).Precedes (pure b) ↔ a < b := precedes_coe_coe
+
+end PartialOrder
+
+section Lattice
+
+variable {α : Type*} [Lattice α] {s t : Interval α} {x : α}
+
+theorem not_disjoint_iff : ¬ Disjoint s t ↔ ∃ x, x ∈ s ∧ x ∈ t := by
+  simp only [← disjoint_coe, Set.not_disjoint_iff, SetLike.mem_coe]
+
+/-- Nonempty intervals meet exactly when they overlap, the endpoint form of the relation. -/
+theorem not_disjoint_coe_coe {i j : NonemptyInterval α} :
+    ¬ Disjoint (↑i : Interval α) ↑j ↔ i.overlaps j := by
+  rw [not_disjoint_iff]
+  constructor
+  · rintro ⟨x, hx, hy⟩
+    exact ⟨le_trans (NonemptyInterval.mem_def.1 hx).1 (NonemptyInterval.mem_def.1 hy).2,
+      le_trans (NonemptyInterval.mem_def.1 hy).1 (NonemptyInterval.mem_def.1 hx).2⟩
+  · rintro ⟨h₁, h₂⟩
+    exact ⟨i.fst ⊔ j.fst, NonemptyInterval.mem_def.2 ⟨le_sup_left, sup_le i.fst_le_snd h₂⟩,
+      NonemptyInterval.mem_def.2 ⟨le_sup_right, sup_le h₁ j.fst_le_snd⟩⟩
+
+variable [DecidableLE α]
+
+@[simp] theorem mem_inf : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := by
+  simp [← SetLike.mem_coe]
+
+end Lattice
+
+/-! ### Rays to the end of time -/
+
+section WithTop
+
+variable {α : Type*} [PartialOrder α] {i : NonemptyInterval α} {a b : α} {x : WithTop α}
+
+/-- The interval from `a` to the end of time, `[a, ⊤]`. -/
+def Ici (a : α) : Interval (WithTop α) := ↑(⟨(↑a, ⊤), le_top⟩ : NonemptyInterval (WithTop α))
+
+@[simp] theorem mem_Ici : x ∈ Ici a ↔ ↑a ≤ x := by
+  simp [Ici, NonemptyInterval.mem_def]
+
+@[simp] theorem Ici_le_Ici : Ici a ≤ Ici b ↔ b ≤ a := by
+  simp [Ici, NonemptyInterval.le_def]
+
+theorem antitone_Ici : Antitone (Ici : α → Interval (WithTop α)) := λ _ _ h => Ici_le_Ici.2 h
+
+theorem isLeast_Ici : IsLeast (↑(Ici a) : Set (WithTop α)) ↑a := isLeast_coe_fst
+
+@[simp] theorem pure_le_Ici : pure (↑b : WithTop α) ≤ Ici a ↔ a ≤ b := by
+  simp
+
+/-- A bounded interval precedes the ray from `a` exactly when it ends before `a`. -/
+theorem precedes_withTop_Ici :
+    (↑i.withTop : Interval (WithTop α)).Precedes (Ici a) ↔ i.snd < a := by
+  rw [Ici, precedes_coe_coe]; simp [NonemptyInterval.precedes]
+
+end WithTop
+
+end Interval

--- a/Linglib/Semantics/Aspect/Instantiation.lean
+++ b/Linglib/Semantics/Aspect/Instantiation.lean
@@ -1,0 +1,96 @@
+import Linglib.Semantics.Aspect.Basic
+
+/-!
+# Instantiation of sorted properties
+
+A property of eventualities is instantiated at a reference interval by the temporal relation
+its sort selects: the runtime of an event is included in the interval, the runtime of a state
+overlaps it ([kamp-rohrer-1983], [partee-1984], [kamp-reyle-1993]), and a property of times
+applies to the interval. Reference intervals are `Interval (WithTop T)`, so that an interval
+may run to the end of time and the null interval is `⊥`. On a bounded interval the eventive
+clause is the perfective viewpoint `PRFV` of [klein-1994], and the imperfective `IMPF` entails
+the stative clause.
+
+## Main definitions
+
+* `Aspect.SortedProperty` — a property of events, of states, or of times.
+* `Aspect.At` — the instantiation relation `AT(t, w, P)`.
+
+## Main results
+
+* `Aspect.At.mono` — instantiation of an eventuality is monotone in the interval.
+* `Aspect.at_eventive_withTop_iff_prfv` — on a bounded interval, eventive instantiation is
+  `PRFV`.
+
+## References
+
+* [H. Kamp and C. Rohrer, *Tense in Texts* (1983)][kamp-rohrer-1983]
+* [B. Partee, *Nominal and Temporal Anaphora* (1984)][partee-1984]
+* [H. Kamp and U. Reyle, *From Discourse to Logic* (1993)][kamp-reyle-1993]
+* [W. Klein, *Time in Language* (1994)][klein-1994]
+-/
+
+namespace Aspect
+
+variable {W T : Type*} [LinearOrder T]
+
+/-- A property sorted by what it is a property of: events, states, or times. -/
+inductive SortedProperty (W T : Type*) [LinearOrder T]
+  | eventive (P : W → Event T → Prop)
+  | stative (P : W → Event T → Prop)
+  | temporal (P : W → Interval (WithTop T) → Prop)
+
+/-- A property of eventualities rather than of times. -/
+def SortedProperty.IsEventuality : SortedProperty W T → Prop
+  | .temporal _ => False
+  | _ => True
+
+/-- `At t w Q`: the property `Q` is instantiated in `w` at the interval `t`, by inclusion of the
+runtime for events, overlap for states, and application for properties of times. -/
+def At (t : Interval (WithTop T)) (w : W) : SortedProperty W T → Prop
+  | .eventive P => ∃ e, P w e ∧ ↑e.τ.withTop ≤ t
+  | .stative P => ∃ e, P w e ∧ ¬ Disjoint (↑e.τ.withTop) t
+  | .temporal P => P w t
+
+variable {P : W → Event T → Prop} {Q : SortedProperty W T} {r r' : Interval (WithTop T)} {w : W}
+
+/-- An eventuality instantiated at an interval gives the interval a time. -/
+theorem exists_mem_of_at (hQ : Q.IsEventuality) (h : At r w Q) : ∃ x, x ∈ r := by
+  cases Q with
+  | eventive R => obtain ⟨e, -, hle⟩ := h; exact ⟨_, (Interval.coe_le_iff.1 hle).1⟩
+  | stative R =>
+    obtain ⟨e, -, hd⟩ := h
+    obtain ⟨x, -, hx⟩ := Interval.not_disjoint_iff.1 hd
+    exact ⟨x, hx⟩
+  | temporal R => exact hQ.elim
+
+/-- Nothing is instantiated at the null interval but a property of times. -/
+theorem not_at_bot (hQ : Q.IsEventuality) : ¬ At ⊥ w Q :=
+  λ h => let ⟨_, hx⟩ := exists_mem_of_at hQ h; Interval.notMem_bot hx
+
+/-- Instantiation of an eventuality is monotone in the interval. -/
+theorem At.mono (hQ : Q.IsEventuality) (h : r ≤ r') (hr : At r w Q) : At r' w Q := by
+  cases Q with
+  | eventive R => obtain ⟨e, he, hle⟩ := hr; exact ⟨e, he, le_trans hle h⟩
+  | stative R =>
+    obtain ⟨e, he, hd⟩ := hr
+    exact ⟨e, he, λ hd' => hd (hd'.mono_right h)⟩
+  | temporal R => exact hQ.elim
+
+/-- On a bounded interval, eventive instantiation is the perfective viewpoint. -/
+theorem at_eventive_withTop_iff_prfv {i : NonemptyInterval T} :
+    At ↑i.withTop w (.eventive P) ↔ PRFV P w i := by
+  simp [At, PRFV, and_comm]
+
+/-- The imperfective viewpoint entails stative instantiation: proper inclusion of the interval
+in the runtime gives overlap. -/
+theorem at_stative_withTop_of_impf {i : NonemptyInterval T} (h : IMPF P w i) :
+    At ↑i.withTop w (.stative P) := by
+  obtain ⟨e, hlt, he⟩ := h
+  have hle := NonemptyInterval.le_def.1 hlt.le
+  refine ⟨e, he, Interval.not_disjoint_iff.2 ⟨↑i.fst, ?_, ?_⟩⟩
+  · exact NonemptyInterval.mem_withTop.2 ⟨WithTop.coe_le_coe.2 hle.1,
+      WithTop.coe_le_coe.2 (le_trans i.fst_le_snd hle.2)⟩
+  · exact NonemptyInterval.mem_withTop.2 ⟨le_rfl, WithTop.coe_le_coe.2 i.fst_le_snd⟩
+
+end Aspect

--- a/Linglib/Semantics/Modality/HistoricalAlternatives.lean
+++ b/Linglib/Semantics/Modality/HistoricalAlternatives.lean
@@ -18,6 +18,8 @@ perfectly match it in matters of particular fact up to that time
   `isMaximalHistory` : interval predicates indexing the situation-base slices;
 * `historicalBase`, `actualHistoryBase`, `futureHistoryBase` : the temporal
   slices of the historical modal base;
+* `ofDatedFacts` : the relation determined by a stock of dated facts, worlds agreeing up to a
+  time when they agree on every fact dated at or before it;
 * `histEquiv` : historical equivalence `≃_t` of [condoravdi-2002];
 * `metaphysicalBase` : the equivalence class of the evaluation world under `≃_t`;
 * `toTWFrame` : a relation with `HistoricalProperties`, viewed as a
@@ -25,6 +27,7 @@ perfectly match it in matters of particular fact up to that time
 
 ## Main results
 
+* `historicalProperties_ofDatedFacts` : agreement on dated facts has the standard properties;
 * `upperLimitConstraintModal_implies_value` : the Upper Limit Constraint
   ([abusch-1997]) is derived from `actualHistoryBase` membership;
 * `alternatives_antitone`, `metaphysicalBase_antitone` : the metaphysical base
@@ -182,6 +185,21 @@ structure HistoricalProperties [LE T]
   trans : h.transitive
   /-- Agreement is preserved for earlier times -/
   backwards : h.backwardsClosed
+
+/-- The historical alternatives determined by a stock of dated facts: worlds agree up to a time
+    when they agree on every fact dated at or before it, the world-time model of
+    [thomason-1984]. -/
+def ofDatedFacts [LE T] {F : Type*} (time : F → T) (holds : W → F → Prop) :
+    HistoricalAlternatives W T :=
+  λ s => {w' | ∀ f, time f ≤ s.time → (holds s.world f ↔ holds w' f)}
+
+/-- Agreement on dated facts is an equivalence at every time and is preserved backward. -/
+theorem historicalProperties_ofDatedFacts [Preorder T] {F : Type*} (time : F → T)
+    (holds : W → F → Prop) : HistoricalProperties (ofDatedFacts time holds) where
+  refl _ _ _ := Iff.rfl
+  symm _ _ _ h f hf := (h f hf).symm
+  trans _ _ _ _ h₁ h₂ f hf := (h₁ f hf).trans (h₂ f hf)
+  backwards _ _ _ _ hle h f hf := h f (le_trans hf hle)
 
 /-- A temporal proposition: true or false at each situation. The
     situation-semantic analog of `Prop' W`. -/

--- a/Linglib/Studies/Condoravdi2002.lean
+++ b/Linglib/Studies/Condoravdi2002.lean
@@ -1,89 +1,41 @@
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Data.Examples.Condoravdi2002
-import Linglib.Semantics.Aspect.Basic
+import Linglib.Semantics.Aspect.Instantiation
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Modality.ModalTypes
 
 /-!
 # Condoravdi 2002: Temporal Interpretation of Modals
 
-Non-root modals make one contribution to temporal interpretation: they expand the time of
-evaluation forward to the interval running from the perspective time to the end of time, and
-instantiate the property in their scope in the worlds of a modal base. Modals for the present,
-*may win*, and modals for the past, *may have won*, share this meaning; the second decomposes
-into the modal over the perfect, which shifts evaluation to an interval before its reference
-time, so that the past orientation is the perfect's. The adverbs *already*, *yet* and *still*
-show the decomposition: they select against properties of events and are fine with a modal
-plus *have* even when the verb is eventive, because the perfect turns the property of events
-into a property of times. Whether the modal shifts forward is then a matter of the sort of its
-complement, obligatory with events, which must fall within the forward interval, optional with
-states, which need only overlap it.
-
-Modals for the past are ambiguous. With the modal over the perfect the perspective is the time
-of utterance and the orientation past, the epistemic reading of *he may have won*; with the
-perfect over the modal the perspective is a past time and the orientation that time's future,
-the counterfactual reading of *at that point he might still have won*. The fourth cell of the
-table, past perspective with past orientation, has no expression. The frame adverbials fall
-out: *yesterday* restricts the reference interval, which for a modal for the present is the
-forward interval, so the intersection is null and *he may win yesterday* can never be true,
-while for the modal over the perfect the reference interval precedes the present, excluding
-*tomorrow* and *now*; the counterfactual scoping has the forward interval of a past time and
-admits all three.
-
-Which modal base a modal takes follows from the structure of possibilities. Historical
-alternatives at a time are the worlds identical up to it, an equivalence that coarsens as time
-goes back, so the live options of a world shrink as time advances: a possibility at the
-present was a possibility at every earlier time. That is why *still*, presupposing a prior
-positive phase, can scope over a possibility modal and *already*, presupposing a prior negative
-phase, cannot. The metaphysical modal base at a time is the world's equivalence class; a
-context may assign it to a possibility modal only under the diversity condition, that the base
-contain worlds disagreeing on the property, and a common ground that settles the property fails
-diversity. Instantiation in the past of the perspective, the modal over the perfect, or at the
-present, a stative with *now*, is settled in every common ground, leaving those readings
-epistemic; a future instantiation is settled only when the context says so, as in *it has been
-decided who he will meet with*. The counterfactual reading is the same possibility modal at a
-past perspective, whose base includes the present one; when no present alternative verifies
-the possibility, the world that does lies outside the common ground, whence the implication
-that the possibility went unrealized.
-
-The semantics is stated over the paper's own interval type `Ref`, and `AT` dispatches on the
-sort of the property, with `PRES`, `PERF`, `MAY`, `WOLL`, the phase adverbs and the frame
-adverbials as operators on properties. `pres_may_eventive_iff` through
-`pres_perf_may_eventive_iff` are the derivations of the three readings, `frame_modal_past` and
-`frame_modalPerf_nonpast` the two deviant adverbial patterns, `zones_iff` the satisfiable and
-unsatisfiable cells of scoping against period in a model, `may_antitone` the shrinking of
-possibilities behind *still* and *already*, `settled_perf` and `settled_present` the
-settledness of non-future instantiation, `not_diverse_of_settled` the exclusion of the
-metaphysical base, and `counterfactual_outside_cg` the counterfactual implication. The paper's
-rows are checked by `adverb_rows`, `reading_rows`, `sortal_rows`, `phase_rows` and
-`german_rows`.
+Non-root modals expand the time of evaluation forward and instantiate the property in their
+scope in the worlds of a modal base. Modals for the past are the same modals over the perfect,
+so *might have* is ambiguous between the modal over the perfect, an epistemic possibility about
+the past, and the perfect over the modal, a metaphysical possibility from a past perspective.
+Frame adverbials follow from intersecting the reference interval with the period named,
+*still* and *already* over a modal from the shrinking of live options as time advances, and
+the choice of modal base from the diversity condition, which a settled issue fails. We state
+the paper's operators over closed intervals of times that may run to the end of time, derive
+the three readings, the adverbial patterns in a model, the *still* ~ *already* asymmetry, the
+settledness of non-future instantiation and the counterfactual implication, and check the
+paper's examples as rows.
 
 ## Implementation notes
 
-* An interval of the paper is a closed interval of `WithTop T`, so the forward interval `[t, _)`
-  is `[t, ⊤]` and the null interval is the lattice bottom. The paper's `now` is an interval,
-  albeit a short one, and is taken as a point; a modal base is indexed by the time at which the
-  reference interval starts. Both are the formalizer's choices, made together: the paper's
-  `MB(w, t)` takes an interval and its `w ≃_t w'` a point, and indexing by the end of the
-  interval is the other way to reconcile them.
-* Settledness of past and present instantiation is the paper's reading of historical
-  equivalence as identity of the past; the substrate relation is abstract, so it enters as the
-  hypothesis `FixesPast`, from which the two settledness theorems follow. The counterfactual
-  implication likewise rests on the paper's footnote assumption, `PastAlternativesOutside`.
-* The sortal restriction of the phase adverbs is partiality, an `Option`-valued operator; the
-  prior-phase half of their Löbner presuppositions is stated separately, as the paper does.
-* The inclusion and overlap relations of `AT` are the paper's, after Kamp and Rohrer and
-  Partee; the substrate's viewpoint operators, under Klein's names, coincide with them on
-  bounded intervals, `AT_eventive_ofInterval_iff` and `AT_stative_of_IMPF`. `AT` takes its
-  arguments in the paper's order, and `PRES now Q` is the proposition the settledness
-  theorems consume.
+* The paper's *now* is an interval, albeit a short one, taken here as a point, and a modal base
+  is indexed by the start of the reference interval; the paper's `MB(w, t)` takes an interval
+  and its `w ≃_t w'` a point.
+* Identity of the past enters as `FixesPast`, discharged for histories built from dated facts
+  by `fixesPast_eventive` and `fixesPast_stative`; the counterfactual implication rests on
+  the paper's footnote assumption `PastAlternativesOutside`.
+* The sortal restriction of *already*, *yet* and *still* is partiality, and only the
+  prior-phase half of their Löbner presuppositions is stated.
 
 ## TODO
 
-* The embedded modals of *Mary believed that John may get sick*, whose perspective is the
-  attitude's internal now, are informal in the paper and absent here.
-* *He has still won* is excluded by the paper as well known rather than derived, and the
-  German *noch* pattern that rests on it is a row, not a theorem.
+* The embedded modals of *Mary believed that John may get sick* are informal in the paper and
+  absent here.
+* *He has still won* is excluded by the paper as well known rather than derived; the German
+  *noch* pattern that rests on it is a row, not a theorem.
 * `WOLL` is stated but unconsumed: the paper gives no data for *will* and *would*.
 
 ## References
@@ -95,13 +47,9 @@ rows are checked by `adverb_rows`, `reading_rows`, `sortal_rows`, `phase_rows` a
 * [M. Enç, *Tense and Modality* (1996)][enc-1996]
 * [J. Groenendijk and M. Stokhof, *Modality and Conversational Information*
   (1975)][groenendijk-stokhof-1975]
-* [H. Kamp and C. Rohrer, *Tense in Texts* (1983)][kamp-rohrer-1983]
-* [H. Kamp and U. Reyle, *From Discourse to Logic* (1993)][kamp-reyle-1993]
-* [W. Klein, *Time in Language* (1994)][klein-1994]
 * [A. Kratzer, *The Notional Category of Modality* (1981)][kratzer-1981]
 * [D. Lewis, *Counterfactual Dependence and Time's Arrow* (1979)][lewis-1979-time-arrow]
 * [S. Löbner, *German schon, erst, noch: An Integrated Analysis* (1989)][lobner-1989]
-* [B. Partee, *Nominal and Temporal Anaphora* (1984)][partee-1984]
 * [R. Thomason, *Combinations of Tense and Modality* (1984)][thomason-1984]
 -/
 
@@ -111,195 +59,50 @@ open Aspect HistoricalAlternatives Data.Examples
 open Features (Dynamicity)
 open Modality (TemporalPerspective TemporalOrientation)
 
-variable {W T : Type*} [LinearOrder T]
-
-/-! ### Intervals -/
-
-/-- The paper's intervals: closed intervals of times, possibly running to the end of time, and
-the null interval. -/
-abbrev Ref (T : Type*) [LE T] := Interval (WithTop T)
-
-namespace Ref
-
-/-- A bounded interval of times, as a nonempty interval of `WithTop T`. -/
-def lift (i : NonemptyInterval T) : NonemptyInterval (WithTop T) :=
-  i.map ⟨WithTop.some, WithTop.coe_mono⟩
-
-/-- A bounded interval of times. -/
-def ofInterval (i : NonemptyInterval T) : Ref T := ↑(lift i)
-
-/-- The point `t`. The paper's `now` is an interval, albeit a short one, taken here as a
-point. -/
-def point (t : T) : Ref T := Interval.pure ↑t
-
-/-- `[t, _)`: from `t` to the end of time. -/
-def ray (t : T) : Ref T := ↑(⟨(↑t, ⊤), le_top⟩ : NonemptyInterval (WithTop T))
-
-/-- `r` precedes `r'`: every time of `r` is before every time of `r'`. -/
-def Precedes (r r' : Ref T) : Prop := ∀ x ∈ r, ∀ y ∈ r', x < y
-
-/-- `r` and `r'` share a time. -/
-def Overlaps (r r' : Ref T) : Prop := ∃ x, x ∈ r ∧ x ∈ r'
-
-/-- `r` starts at the time `t`. -/
-def StartsAt (r : Ref T) (t : T) : Prop :=
-  ∃ i : NonemptyInterval (WithTop T), r = ↑i ∧ i.fst = ↑t
-
-variable {i : NonemptyInterval T} {r r' : Ref T} {t t' : T} {x : WithTop T}
-
-@[simp] theorem mem_ofInterval : x ∈ ofInterval i ↔ ↑i.fst ≤ x ∧ x ≤ ↑i.snd := by
-  simp [ofInterval, lift, NonemptyInterval.mem_def]
-
-@[simp] theorem mem_point : x ∈ point t ↔ x = ↑t := Interval.mem_pure
-
-@[simp] theorem mem_ray : x ∈ ray t ↔ ↑t ≤ x := by
-  simp [ray, NonemptyInterval.mem_def]
-
-@[simp] theorem notMem_bot : x ∉ (⊥ : Ref T) := by
-  simp [← SetLike.mem_coe]
-
-@[simp] theorem mem_inf : x ∈ r ⊓ r' ↔ x ∈ r ∧ x ∈ r' := by
-  simp [← SetLike.mem_coe]
-
-theorem mem_of_mem_of_le (h : r ≤ r') (hx : x ∈ r) : x ∈ r' :=
-  Interval.coe_subset_coe.2 h hx
-
-theorem point_le_iff : point t ≤ r ↔ ↑t ∈ r := by
-  rw [← Interval.coe_subset_coe, point, Interval.coe_pure, Set.singleton_subset_iff,
-    SetLike.mem_coe]
-
-theorem ofInterval_le_iff : ofInterval i ≤ r ↔ ↑i.fst ∈ r ∧ ↑i.snd ∈ r := by
-  induction r using Interval.recBotCoe with
-  | bot => exact iff_of_false (λ h => WithBot.coe_ne_bot (le_bot_iff.1 h)) (λ h => notMem_bot h.1)
-  | coe j =>
-    have hi := WithTop.coe_le_coe.2 i.fst_le_snd
-    refine ⟨λ h => ?_, λ ⟨h₁, h₂⟩ => WithBot.coe_le_coe.2 (NonemptyInterval.le_def.2
-      ⟨(NonemptyInterval.mem_def.1 h₁).1, (NonemptyInterval.mem_def.1 h₂).2⟩)⟩
-    obtain ⟨h₁, h₂⟩ := NonemptyInterval.le_def.1 (WithBot.coe_le_coe.1 h)
-    exact ⟨NonemptyInterval.mem_def.2 ⟨h₁, le_trans hi h₂⟩,
-      NonemptyInterval.mem_def.2 ⟨le_trans h₁ hi, h₂⟩⟩
-
-theorem ray_le_ray (h : t' ≤ t) : ray t ≤ ray t' :=
-  WithBot.coe_le_coe.2 (NonemptyInterval.le_def.2 ⟨WithTop.coe_le_coe.2 h, le_rfl⟩)
-
-theorem startsAt_point : (point t).StartsAt t := ⟨_, rfl, rfl⟩
-
-/-- The start of an interval is one of its times. -/
-theorem mem_of_startsAt (h : r.StartsAt t) : ↑t ∈ r := by
-  obtain ⟨j, rfl, hj⟩ := h
-  exact NonemptyInterval.mem_def.2 ⟨hj.le, hj ▸ j.fst_le_snd⟩
-
-theorem precedes_point_point : (point t').Precedes (point t) ↔ t' < t := by
-  simp [Precedes]
-
-theorem precedes_ofInterval_ray : (ofInterval i).Precedes (ray t) ↔ i.snd < t := by
-  refine ⟨λ h => WithTop.coe_lt_coe.1 (h _ (by simp [i.fst_le_snd]) _ (mem_ray.2 le_rfl)),
-    λ h x hx y hy => ?_⟩
-  rw [mem_ofInterval] at hx
-  exact lt_of_le_of_lt hx.2 (lt_of_lt_of_le (WithTop.coe_lt_coe.2 h) (mem_ray.1 hy))
-
-end Ref
-
-/-! ### Properties and the AT relation -/
-
-/-- A property of the paper's three sorts: of events, of states, or of times. -/
-inductive Property (W T : Type*) [LinearOrder T]
-  | eventive (P : W → Event T → Prop)
-  | stative (P : W → Event T → Prop)
-  | temporal (P : W → Ref T → Prop)
-
-/-- A property of eventualities rather than of times. -/
-def Property.IsEventuality : Property W T → Prop
-  | .temporal _ => False
-  | _ => True
-
-/-- The AT relation: property `P` is instantiated in `w` at `t`, by inclusion of the runtime for
-events, overlap for states, and application for properties of times. -/
-def AT (t : Ref T) (w : W) : Property W T → Prop
-  | .eventive P => ∃ e, P w e ∧ Ref.ofInterval e.τ ≤ t
-  | .stative P => ∃ e, P w e ∧ (Ref.ofInterval e.τ).Overlaps t
-  | .temporal P => P w t
-
-variable {P : W → Event T → Prop} {Q Q' : Property W T} {r r' : Ref T} {t t' : T} {w : W}
-
-/-- An eventuality instantiated at an interval gives the interval a time. -/
-theorem exists_mem_of_AT (hQ : Q.IsEventuality) (h : AT r w Q) : ∃ x, x ∈ r := by
-  cases Q with
-  | eventive R => obtain ⟨e, -, hle⟩ := h; exact ⟨_, (Ref.ofInterval_le_iff.1 hle).1⟩
-  | stative R => obtain ⟨e, -, x, -, hx⟩ := h; exact ⟨x, hx⟩
-  | temporal R => exact hQ.elim
-
-/-- Nothing is instantiated at the null interval but a property of times. -/
-theorem not_AT_bot (hQ : Q.IsEventuality) : ¬ AT ⊥ w Q :=
-  λ h => let ⟨_, hx⟩ := exists_mem_of_AT hQ h; Ref.notMem_bot hx
-
-/-- Instantiation of an eventuality is monotone in the interval. -/
-theorem AT_mono (hQ : Q.IsEventuality) (h : r ≤ r') (hr : AT r w Q) : AT r' w Q := by
-  cases Q with
-  | eventive R => obtain ⟨e, he, hle⟩ := hr; exact ⟨e, he, le_trans hle h⟩
-  | stative R =>
-    obtain ⟨e, he, x, hx, hx'⟩ := hr; exact ⟨e, he, x, hx, Ref.mem_of_mem_of_le h hx'⟩
-  | temporal R => exact hQ.elim
-
-/-- On a bounded interval, eventive instantiation is the substrate's perfective viewpoint. -/
-theorem AT_eventive_ofInterval_iff {i : NonemptyInterval T} :
-    AT (Ref.ofInterval i) w (.eventive P) ↔ PRFV P w i := by
-  simp only [AT, PRFV, Ref.ofInterval_le_iff, Ref.mem_ofInterval, NonemptyInterval.le_def,
-    WithTop.coe_le_coe]
-  constructor
-  · rintro ⟨e, he, ⟨h₁, -⟩, ⟨-, h₂⟩⟩; exact ⟨e, ⟨h₁, h₂⟩, he⟩
-  · rintro ⟨e, ⟨h₁, h₂⟩, he⟩
-    exact ⟨e, he, ⟨h₁, le_trans e.τ.fst_le_snd h₂⟩, ⟨le_trans h₁ e.τ.fst_le_snd, h₂⟩⟩
-
-/-- The substrate's imperfective viewpoint entails stative instantiation: proper inclusion of
-the interval in the runtime gives overlap. -/
-theorem AT_stative_of_IMPF {i : NonemptyInterval T} (h : IMPF P w i) :
-    AT (Ref.ofInterval i) w (.stative P) := by
-  obtain ⟨e, hlt, he⟩ := h
-  have hle := NonemptyInterval.le_def.1 hlt.le
-  exact ⟨e, he, ↑i.fst, Ref.mem_ofInterval.2 ⟨WithTop.coe_le_coe.2 hle.1,
-      WithTop.coe_le_coe.2 (le_trans i.fst_le_snd hle.2)⟩,
-    Ref.mem_ofInterval.2 ⟨le_rfl, WithTop.coe_le_coe.2 i.fst_le_snd⟩⟩
+variable {W T : Type*} [LinearOrder T] {P : W → Event T → Prop} {Q Q' : SortedProperty W T}
+  {r : Interval (WithTop T)} {t t' : T} {w : W}
 
 /-! ### The operators -/
 
 /-- Present tense: instantiation at the time of utterance. -/
-def PRES (now : T) (Q : Property W T) (w : W) : Prop := AT (Ref.point now) w Q
+def PRES (now : T) (Q : SortedProperty W T) (w : W) : Prop := At (Interval.pure ↑now) w Q
 
 /-- The perfect: instantiation at some interval preceding the reference interval. -/
-def PERF (Q : Property W T) : Property W T :=
-  .temporal λ w t => ∃ t' : NonemptyInterval (WithTop T), Ref.Precedes ↑t' t ∧ AT ↑t' w Q
+def PERF (Q : SortedProperty W T) : SortedProperty W T :=
+  .temporal λ w t => ∃ t' : NonemptyInterval (WithTop T), Interval.Precedes ↑t' t ∧ At ↑t' w Q
 
 /-- MAY and MIGHT: instantiation, in some world of the modal base at the start of the
 reference interval, throughout the interval expanded forward to the end of time. -/
-def MAY (MB : W → T → Set W) (Q : Property W T) : Property W T :=
-  .temporal λ w t => ∃ t₀, t.StartsAt t₀ ∧ ∃ w' ∈ MB w t₀, AT (Ref.ray t₀) w' Q
+def MAY (MB : W → T → Set W) (Q : SortedProperty W T) : SortedProperty W T :=
+  .temporal λ w t => ∃ t₀ : T, IsLeast (t : Set (WithTop T)) ↑t₀ ∧
+    ∃ w' ∈ MB w t₀, At (Interval.Ici t₀) w' Q
 
 /-- WOLL, the untensed modal of *will* and *would*: instantiation in every world of the modal
 base at the start of the reference interval, throughout the forward interval. -/
-def WOLL (MB : W → T → Set W) (Q : Property W T) : Property W T :=
-  .temporal λ w t => ∃ t₀, t.StartsAt t₀ ∧ ∀ w' ∈ MB w t₀, AT (Ref.ray t₀) w' Q
+def WOLL (MB : W → T → Set W) (Q : SortedProperty W T) : SortedProperty W T :=
+  .temporal λ w t => ∃ t₀ : T, IsLeast (t : Set (WithTop T)) ↑t₀ ∧
+    ∀ w' ∈ MB w t₀, At (Interval.Ici t₀) w' Q
 
 /-- A frame adverbial such as *yesterday*: instantiation within the intersection of the
 reference interval with the period named, undefined on properties of times. -/
-def frame (period : Ref T) : Property W T → Option (Property W T)
+def frame (period : Interval (WithTop T)) : SortedProperty W T → Option (SortedProperty W T)
   | .temporal _ => none
-  | Q => some (.temporal λ w t => AT (t ⊓ period) w Q)
+  | Q => some (.temporal λ w t => At (t ⊓ period) w Q)
 
 /-- *Already*, *yet* and *still*: the identity on properties of states and of times, undefined
 on properties of events. -/
-def phase : Property W T → Option (Property W T)
+def phase : SortedProperty W T → Option (SortedProperty W T)
   | .eventive _ => none
   | Q => some Q
 
 /-- A frame adverbial applies to a property of eventualities. -/
-theorem isEventuality_of_frame {period : Ref T} (hf : frame period Q = some Q') :
+theorem isEventuality_of_frame {period : Interval (WithTop T)} (hf : frame period Q = some Q') :
     Q.IsEventuality := by
   cases Q <;> trivial
 
 /-- Instantiation of the framed property is instantiation within the period. -/
-theorem AT_of_frame {period : Ref T} (hf : frame period Q = some Q') (h : AT r w Q') :
-    AT (r ⊓ period) w Q := by
+theorem at_of_frame {period : Interval (WithTop T)} (hf : frame period Q = some Q')
+    (h : At r w Q') : At (r ⊓ period) w Q := by
   cases Q <;> cases hf <;> exact h
 
 /-! ### The three readings -/
@@ -311,26 +114,28 @@ at the present has the event starting no earlier than the present. Future orient
 obligatory. -/
 theorem pres_may_eventive_iff :
     PRES now (MAY MB (.eventive P)) w ↔ ∃ w' ∈ MB w now, ∃ e, P w' e ∧ now ≤ e.τ.fst := by
-  simp only [PRES, MAY, AT, Ref.ofInterval_le_iff, Ref.mem_ray, WithTop.coe_le_coe]
+  simp only [PRES, MAY, At, Interval.coe_le_iff, NonemptyInterval.fst_withTop,
+    NonemptyInterval.snd_withTop, Interval.mem_Ici, WithTop.coe_le_coe]
   constructor
   · rintro ⟨t₀, ht₀, w', hw', e, he, h, -⟩
-    obtain rfl : t₀ = now := by simpa using Ref.mem_of_startsAt ht₀
+    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
     exact ⟨w', hw', e, he, h⟩
   · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Ref.startsAt_point, w', hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
+    exact ⟨now, Interval.isLeast_pure, w', hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
 
 /-- A modal for the present with a stative predicate, *he might be here*: some world of the base
 at the present has the state persisting at or past the present. The state may have started
 earlier, so future orientation is optional. -/
 theorem pres_may_stative_iff :
     PRES now (MAY MB (.stative P)) w ↔ ∃ w' ∈ MB w now, ∃ e, P w' e ∧ now ≤ e.τ.snd := by
-  simp only [PRES, MAY, AT, Ref.Overlaps, Ref.mem_ofInterval, Ref.mem_ray]
+  simp only [PRES, MAY, At, Interval.not_disjoint_iff, NonemptyInterval.mem_coe_interval,
+    NonemptyInterval.mem_withTop, Interval.mem_Ici]
   constructor
   · rintro ⟨t₀, ht₀, w', hw', e, he, x, ⟨-, hx⟩, hx'⟩
-    obtain rfl : t₀ = now := by simpa using Ref.mem_of_startsAt ht₀
+    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
     exact ⟨w', hw', e, he, WithTop.coe_le_coe.1 (le_trans hx' hx)⟩
   · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Ref.startsAt_point, w', hw', e, he, ↑e.τ.snd,
+    exact ⟨now, Interval.isLeast_pure, w', hw', e, he, ↑e.τ.snd,
       ⟨WithTop.coe_le_coe.2 e.τ.fst_le_snd, le_rfl⟩, WithTop.coe_le_coe.2 h⟩
 
 /-- The modal over the perfect, *he may have won*: some world of the base at the present has
@@ -339,15 +144,15 @@ reading. -/
 theorem pres_may_perf_eventive_iff :
     PRES now (MAY MB (PERF (.eventive P))) w ↔
       ∃ w' ∈ MB w now, ∃ e, P w' e ∧ e.τ.snd < now := by
-  simp only [PRES, MAY, PERF, AT]
+  simp only [PRES, MAY, PERF, At]
   constructor
   · rintro ⟨t₀, ht₀, w', hw', t', ht', e, he, hle⟩
-    obtain rfl : t₀ = now := by simpa using Ref.mem_of_startsAt ht₀
-    refine ⟨w', hw', e, he, WithTop.coe_lt_coe.1 (ht' _ ?_ _ (Ref.mem_ray.2 le_rfl))⟩
-    exact (Ref.ofInterval_le_iff.1 hle).2
+    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
+    refine ⟨w', hw', e, he, WithTop.coe_lt_coe.1 (ht' ?_ (Interval.mem_Ici.2 le_rfl))⟩
+    exact (Interval.coe_le_iff.1 hle).2
   · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Ref.startsAt_point, w', hw', Ref.lift e.τ,
-      Ref.precedes_ofInterval_ray.2 h, e, he, le_rfl⟩
+    exact ⟨now, Interval.isLeast_pure, w', hw', e.τ.withTop,
+      Interval.precedes_withTop_Ici.2 h, e, he, le_rfl⟩
 
 /-- The perfect over the modal, *he might have won*: some past time has, in some world of the
 base at that time, the event starting no earlier than it. Past perspective, future
@@ -355,37 +160,40 @@ orientation: the counterfactual reading, Mondadori's future in the past. -/
 theorem pres_perf_may_eventive_iff :
     PRES now (PERF (MAY MB (.eventive P))) w ↔
       ∃ t' < now, ∃ w' ∈ MB w t', ∃ e, P w' e ∧ t' ≤ e.τ.fst := by
-  simp only [PRES, PERF, MAY, AT, Ref.ofInterval_le_iff, Ref.mem_ray, WithTop.coe_le_coe]
+  simp only [PRES, PERF, MAY, At, Interval.coe_le_iff, NonemptyInterval.fst_withTop,
+    NonemptyInterval.snd_withTop, Interval.mem_Ici, WithTop.coe_le_coe]
   constructor
   · rintro ⟨t'', ht'', t', ht', w', hw', e, he, h, -⟩
     refine ⟨t', ?_, w', hw', e, he, h⟩
-    exact WithTop.coe_lt_coe.1 (ht'' _ (Ref.mem_of_startsAt ht') _ (Ref.mem_point.2 rfl))
+    exact WithTop.coe_lt_coe.1 (ht'' ht'.1 (Interval.mem_pure.2 rfl))
   · rintro ⟨t', ht', w', hw', e, he, h⟩
-    exact ⟨Ref.lift (NonemptyInterval.pure t'), Ref.precedes_point_point.2 ht', t',
-      Ref.startsAt_point, w', hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
+    exact ⟨(NonemptyInterval.pure t').withTop,
+      Interval.precedes_coe_coe.2 (WithTop.coe_lt_coe.2 ht'), t', Interval.isLeast_pure, w',
+      hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
 
 /-! ### Frame adverbials -/
 
 /-- A modal for the present rejects a period wholly before the present, *he may win
 yesterday*: the forward interval meets it in the null interval. -/
-theorem frame_modal_past {period : Ref T} (hp : period.Precedes (Ref.ray now))
-    (hf : frame period Q = some Q') : ¬ PRES now (MAY MB Q') w := by
+theorem frame_modal_past {period : Interval (WithTop T)}
+    (hp : period.Precedes (Interval.Ici now)) (hf : frame period Q = some Q') :
+    ¬ PRES now (MAY MB Q') w := by
   rintro ⟨t₀, ht₀, w', -, h⟩
-  obtain rfl : t₀ = now := by simpa using Ref.mem_of_startsAt ht₀
-  obtain ⟨x, hx⟩ := exists_mem_of_AT (isEventuality_of_frame hf) (AT_of_frame hf h)
-  simp only [Ref.mem_inf] at hx
-  exact lt_irrefl _ (hp _ hx.2 _ hx.1)
+  obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
+  obtain ⟨x, hx⟩ := exists_mem_of_at (isEventuality_of_frame hf) (at_of_frame hf h)
+  simp only [Interval.mem_inf] at hx
+  exact lt_irrefl _ (hp hx.2 hx.1)
 
 /-- The modal over the perfect rejects a period lying at or after the present, *he must have
 been available next month* and *it must have been raining now*: the interval the perfect
 supplies precedes the present, and so the period. -/
-theorem frame_modalPerf_nonpast {period : Ref T} (hp : ∀ y ∈ period, ↑now ≤ y)
+theorem frame_modalPerf_nonpast {period : Interval (WithTop T)} (hp : ∀ y ∈ period, ↑now ≤ y)
     (hf : frame period Q = some Q') : ¬ PRES now (MAY MB (PERF Q')) w := by
   rintro ⟨t₀, ht₀, w', -, t', ht', h⟩
-  obtain rfl : t₀ = now := by simpa using Ref.mem_of_startsAt ht₀
-  obtain ⟨x, hx⟩ := exists_mem_of_AT (isEventuality_of_frame hf) (AT_of_frame hf h)
-  simp only [Ref.mem_inf] at hx
-  exact lt_irrefl _ (lt_of_lt_of_le (ht' _ hx.1 _ (Ref.mem_ray.2 le_rfl)) (hp _ hx.2))
+  obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
+  obtain ⟨x, hx⟩ := exists_mem_of_at (isEventuality_of_frame hf) (at_of_frame hf h)
+  simp only [Interval.mem_inf] at hx
+  exact lt_irrefl _ (lt_of_lt_of_le (ht' hx.1 (Interval.mem_Ici.2 le_rfl)) (hp _ hx.2))
 
 /-! ### Live options shrink -/
 
@@ -396,19 +204,19 @@ whose presupposition is a prior negative phase, cannot, *he may already win*; re
 is why *he may win this game* is false once he has lost. -/
 theorem may_antitone {history : HistoricalAlternatives W T}
     (hBC : history.backwardsClosed) (hQ : Q.IsEventuality) :
-    Antitone λ t : T => AT (Ref.point t) w (MAY (metaphysicalBase history) Q) := by
+    Antitone λ t : T => At (Interval.pure ↑t) w (MAY (metaphysicalBase history) Q) := by
   rintro t' t h ⟨t₀, ht₀, w', hw', hat⟩
-  obtain rfl : t₀ = t := by simpa using Ref.mem_of_startsAt ht₀
-  exact ⟨t', Ref.startsAt_point, w', metaphysicalBase_antitone hBC w h hw',
-    AT_mono hQ (Ref.ray_le_ray h) hat⟩
+  obtain rfl : t₀ = t := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
+  exact ⟨t', Interval.isLeast_pure, w', metaphysicalBase_antitone hBC w h hw',
+    hat.mono hQ (Interval.antitone_Ici h)⟩
 
 /-- The prior-phase half of Löbner's presupposition of *already*: a prior negative phase. -/
-def AlreadyPresup (Q : Property W T) (w : W) (now : T) : Prop :=
-  ∃ t' < now, ¬ AT (Ref.point t') w Q
+def AlreadyPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop :=
+  ∃ t' < now, ¬ At (Interval.pure ↑t') w Q
 
 /-- The prior-phase half of Löbner's presupposition of *still*: a prior positive phase. -/
-def StillPresup (Q : Property W T) (w : W) (now : T) : Prop :=
-  ∃ t' < now, AT (Ref.point t') w Q
+def StillPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop :=
+  ∃ t' < now, At (Interval.pure ↑t') w Q
 
 /-- *He may already win*: the presupposition of *already* over a metaphysical possibility
 contradicts its assertion. -/
@@ -431,25 +239,49 @@ theorem still_may {history : HistoricalAlternatives W T}
 
 /-- The history relation fixes the instantiation of `Q` at every interval up to its time:
 worlds identical up to `t` agree on `Q` there. -/
-def FixesPast (history : HistoricalAlternatives W T) (Q : Property W T) : Prop :=
-  ∀ t w w', histEquiv history t w w' → ∀ r : Ref T, (∀ x ∈ r, x ≤ ↑t) → (AT r w Q ↔ AT r w' Q)
+def FixesPast (history : HistoricalAlternatives W T) (Q : SortedProperty W T) : Prop :=
+  ∀ t w w', histEquiv history t w w' →
+    ∀ r : Interval (WithTop T), (∀ x ∈ r, x ≤ ↑t) → (At r w Q ↔ At r w' Q)
+
+/-- Worlds agreeing on the events that have begun agree on which events lie within an interval
+of the past. -/
+theorem fixesPast_eventive :
+    FixesPast (ofDatedFacts (λ e : Event T => e.τ.fst) P) (.eventive P) := by
+  intro t w w' h r hr
+  have key : ∀ e : Event T, ↑e.τ.withTop ≤ r → e.τ.fst ≤ t := λ e he =>
+    WithTop.coe_le_coe.1 (hr _ (Interval.coe_le_iff.1 he).1)
+  exact ⟨λ ⟨e, he, hle⟩ => ⟨e, (h e (key e hle)).1 he, hle⟩,
+    λ ⟨e, he, hle⟩ => ⟨e, (h e (key e hle)).2 he, hle⟩⟩
+
+/-- Worlds agreeing on the states that have begun agree on which states overlap an interval of
+the past. -/
+theorem fixesPast_stative :
+    FixesPast (ofDatedFacts (λ e : Event T => e.τ.fst) P) (.stative P) := by
+  intro t w w' h r hr
+  have key : ∀ e : Event T, ¬ Disjoint (↑e.τ.withTop) r → e.τ.fst ≤ t := λ e hd => by
+    obtain ⟨x, hx, hx'⟩ := Interval.not_disjoint_iff.1 hd
+    rw [NonemptyInterval.mem_coe_interval, NonemptyInterval.mem_withTop] at hx
+    exact WithTop.coe_le_coe.1 (le_trans hx.1 (hr x hx'))
+  exact ⟨λ ⟨e, he, hd⟩ => ⟨e, (h e (key e hd)).1 he, hd⟩,
+    λ ⟨e, he, hd⟩ => ⟨e, (h e (key e hd)).2 he, hd⟩⟩
 
 /-- Instantiation in the past of the perspective, the modal over the perfect, is settled in
 every common ground. -/
 theorem settled_perf {history : HistoricalAlternatives W T} (h : FixesPast history Q)
-    (cg : Set W) (t : T) : settled history cg t (λ w => AT (Ref.ray t) w (PERF Q)) := by
+    (cg : Set W) (t : T) : settled history cg t (λ w => At (Interval.Ici t) w (PERF Q)) := by
   intro w _ w' hw'
   refine exists_congr λ r => and_congr_right λ hr => h t w w' hw' r λ x hx => ?_
-  exact (hr x hx _ (Ref.mem_ray.2 le_rfl)).le
+  exact (hr hx (Interval.mem_Ici.2 le_rfl)).le
 
 /-- Instantiation at the present, a stative with *now*, is settled in every common ground: the
 forward interval restricted to the present is the present. -/
 theorem settled_present {history : HistoricalAlternatives W T} (h : FixesPast history Q)
-    (hf : frame (Ref.point t) Q = some Q') (cg : Set W) :
-    settled history cg t (λ w => AT (Ref.ray t) w Q') := by
+    (hf : frame (Interval.pure ↑t) Q = some Q') (cg : Set W) :
+    settled history cg t (λ w => At (Interval.Ici t) w Q') := by
   intro w _ w' hw'
   cases Q <;> cases hf
-  all_goals exact h t w w' hw' _ λ x hx => (Ref.mem_point.1 (Ref.mem_inf.1 hx).2).le
+  all_goals
+    exact h t w w' hw' _ λ x hx => (Interval.mem_pure.1 (Interval.mem_inf.1 hx).2).le
 
 omit [LinearOrder T] in
 /-- A common ground that settles a property fails the diversity condition for the metaphysical
@@ -474,11 +306,10 @@ backtracking to a past perspective signals. -/
 theorem counterfactual_outside_cg {history : HistoricalAlternatives W T} {cg : Set W} {t₀ : T}
     (h : PastAlternativesOutside history cg t₀) (hw : w ∈ cg)
     (hcf : PRES t₀ (PERF (MAY (metaphysicalBase history) Q)) w)
-    (hnow : ∀ t' < t₀, ∀ w' ∈ metaphysicalBase history w t₀, ¬ AT (Ref.ray t') w' Q) :
-    ∃ t' < t₀, ∃ w' ∉ cg, w' ∈ metaphysicalBase history w t' ∧ AT (Ref.ray t') w' Q := by
+    (hnow : ∀ t' < t₀, ∀ w' ∈ metaphysicalBase history w t₀, ¬ At (Interval.Ici t') w' Q) :
+    ∃ t' < t₀, ∃ w' ∉ cg, w' ∈ metaphysicalBase history w t' ∧ At (Interval.Ici t') w' Q := by
   obtain ⟨t'', ht'', t', ht', w', hw', hat⟩ := hcf
-  have hlt : t' < t₀ :=
-    WithTop.coe_lt_coe.1 (ht'' _ (Ref.mem_of_startsAt ht') _ (Ref.mem_point.2 rfl))
+  have hlt : t' < t₀ := WithTop.coe_lt_coe.1 (ht'' ht'.1 (Interval.mem_pure.2 rfl))
   exact ⟨t', hlt, w', h w hw t' hlt.le w' hw' (λ hmem => hnow t' hlt w' hmem hat), hw', hat⟩
 
 /-! ### Perspective and orientation -/
@@ -494,7 +325,7 @@ inductive Scope
   deriving DecidableEq, Fintype
 
 /-- The scoping as an operator on the property under the modal. -/
-def Scope.lf (MB : W → T → Set W) : Scope → Property W T → Property W T
+def Scope.lf (MB : W → T → Set W) : Scope → SortedProperty W T → SortedProperty W T
   | .modal, Q => MAY MB Q
   | .modalPerf, Q => MAY MB (PERF Q)
   | .perfModal, Q => PERF (MAY MB Q)
@@ -537,7 +368,7 @@ def Zone.day : Zone → ℤ
   | .future => 1
 
 /-- The period a zone names: its day. -/
-def Zone.period (z : Zone) : Ref ℤ := Ref.point z.day
+def Zone.period (z : Zone) : Interval (WithTop ℤ) := Interval.pure ↑z.day
 
 /-- The zones a scoping's reference interval reaches: the forward interval of the present, the
 intervals before it, or the forward interval of a past time. -/
@@ -551,12 +382,9 @@ and uttered on day 0, is true. -/
 def Scope.Sat (s : Scope) (z : Zone) : Prop :=
   ∃ Q ∈ frame z.period (.eventive (winOn z.day)), PRES 0 (s.lf anyWorld Q) ()
 
-private theorem winOn_at (d : ℤ) {r : Ref ℤ} (h : Ref.point d ≤ r) :
-    AT r () (.eventive (winOn d)) :=
+private theorem winOn_at (d : ℤ) {r : Interval (WithTop ℤ)} (h : Interval.pure ↑d ≤ r) :
+    At r () (.eventive (winOn d)) :=
   ⟨⟨_, .dynamic⟩, rfl, h⟩
-
-private theorem point_le_ray_of_le {a b : ℤ} (h : a ≤ b) : Ref.point b ≤ Ref.ray a :=
-  Ref.point_le_iff.2 (Ref.mem_ray.2 (WithTop.coe_le_coe.2 h))
 
 /-- The zone table is the satisfiability table: a scoping admits a period exactly when its
 sentence about that period can be true, the deviant cells being `frame_modal_past` and
@@ -567,32 +395,33 @@ theorem zones_iff : ∀ s : Scope, ∀ z : Zone, z ∈ s.zones ↔ s.Sat z := by
   · refine iff_of_false (by decide) ?_
     rintro ⟨Q, hQ, h⟩
     refine frame_modal_past ?_ (Option.mem_def.1 hQ) h
-    exact λ x hx y hy => lt_of_le_of_lt (Ref.mem_point.1 hx).le
-      (lt_of_lt_of_le (WithTop.coe_lt_coe.2 (by decide)) (Ref.mem_ray.1 hy))
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Ref.startsAt_point, (), trivial,
-      winOn_at 0 (le_inf (point_le_ray_of_le le_rfl) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Ref.startsAt_point, (), trivial,
-      winOn_at 1 (le_inf (point_le_ray_of_le (by decide)) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Ref.startsAt_point, (), trivial,
-      Ref.lift (NonemptyInterval.pure (-1)), Ref.precedes_ofInterval_ray.2 (by decide),
+    exact λ x hx y hy => lt_of_le_of_lt (Interval.mem_pure.1 hx).le
+      (lt_of_lt_of_le (WithTop.coe_lt_coe.2 (by decide)) (Interval.mem_Ici.1 hy))
+  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
+      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩
+  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
+      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
+  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
+      (NonemptyInterval.pure (-1)).withTop, Interval.precedes_withTop_Ici.2 (by decide),
       winOn_at (-1) (le_inf le_rfl le_rfl)⟩
   · refine iff_of_false (by decide) ?_
     rintro ⟨Q, hQ, h⟩
-    exact frame_modalPerf_nonpast (λ y hy => (Ref.mem_point.1 hy).ge) (Option.mem_def.1 hQ) h
+    exact frame_modalPerf_nonpast (λ y hy => (Interval.mem_pure.1 hy).ge) (Option.mem_def.1 hQ)
+      h
   · refine iff_of_false (by decide) ?_
     rintro ⟨Q, hQ, h⟩
     refine frame_modalPerf_nonpast (λ y hy => ?_) (Option.mem_def.1 hQ) h
-    rw [Ref.mem_point.1 hy]
+    rw [Interval.mem_pure.1 hy]
     exact WithTop.coe_le_coe.2 (by decide)
-  · exact iff_of_true (by decide) ⟨_, rfl, Ref.lift (NonemptyInterval.pure (-1)),
-      Ref.precedes_point_point.2 (by decide), -1, Ref.startsAt_point, (), trivial,
-      winOn_at (-1) (le_inf (point_le_ray_of_le le_rfl) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, Ref.lift (NonemptyInterval.pure (-1)),
-      Ref.precedes_point_point.2 (by decide), -1, Ref.startsAt_point, (), trivial,
-      winOn_at 0 (le_inf (point_le_ray_of_le (by decide)) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, Ref.lift (NonemptyInterval.pure (-1)),
-      Ref.precedes_point_point.2 (by decide), -1, Ref.startsAt_point, (), trivial,
-      winOn_at 1 (le_inf (point_le_ray_of_le (by decide)) le_rfl)⟩
+  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
+      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
+      winOn_at (-1) (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩
+  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
+      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
+      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
+  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
+      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
+      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
 
 /-! ### The rows -/
 
@@ -675,7 +504,7 @@ inductive Complement
   deriving DecidableEq
 
 /-- A representative property of the complement's sort. -/
-def Complement.property : Complement → Property Unit Unit
+def Complement.property : Complement → SortedProperty Unit Unit
   | .eventive => .eventive λ _ _ => True
   | .perfect => PERF (.eventive λ _ _ => True)
 

--- a/Linglib/Studies/Matthewson2013.lean
+++ b/Linglib/Studies/Matthewson2013.lean
@@ -24,7 +24,7 @@ are formalized here against the existing infrastructure:
    [condoravdi-2002]'s English analysis, where prospectivity is
    baked into `may`. Structurally: Gitksan *imaa* would evaluate its
    prejacent at the point of the perspective, English *might* through
-   `Condoravdi2002.MAY` (forward expansion to `Ref.ray`). We do not introduce
+   `Condoravdi2002.MAY` (forward expansion to `Interval.Ici`). We do not introduce
    alias defs for the Gitksan/English projection here — that is a
    downstream choice that should land in a typed compositional `dim`
    operator (planned, see `ProspectiveMarkerPolicy` discussion in the


### PR DESCRIPTION
Move the interval algebra, the sorted instantiation relation and the fact-based history relation out of the Condoravdi 2002 study into the substrate, and shorten that study's header to mathlib register.

- `Core/Order/Interval`: Allen's *before* as `Interval.Precedes` and overlap as `¬ Disjoint` on mathlib's `Interval`, each with its endpoint form bridging the `NonemptyInterval` vocabulary; `NonemptyInterval.withTop` and the ray `Interval.Ici` to the end of time; left endpoints are `IsLeast` of the coerced set.
- `Semantics/Aspect/Instantiation`: `SortedProperty` and the `At` relation of Kamp–Rohrer and Partee, with `PRFV`/`IMPF` as its bounded specializations.
- `HistoricalAlternatives.ofDatedFacts` with its properties, so the study's settledness assumption is discharged for fact-based histories.