### PR TITLE
refactor(Semantics/Events): the sort of an eventuality as its own kind

### DIFF
--- a/Linglib/Features/Aktionsart.lean
+++ b/Linglib/Features/Aktionsart.lean
@@ -23,7 +23,8 @@ The CUM/QUA/DIV algebra over event predicates lives in `Semantics/Mereology.lean
 the `Telicity` here is the Smith-flavored lexical label.
 
 Sibling formalizations of competitor lexical-aspect frameworks:
-[bach-1986]; the event-token sort is this `Dynamicity` feature (`Event.sort`);
+[bach-1986]'s event-token sort is `Event.Kind` in `Semantics/Events/Basic.lean`, of which this
+lexical feature is the verb-entry label;
 [krifka-1989]/[krifka-1998] CUM/QUA/DIV in
 `Semantics/Events/CEM.lean`; [dowty-1979] SIP in
 `Semantics/Aspect/SubintervalProperty.lean`;

--- a/Linglib/Semantics/ArgumentStructure/Thematic/Basic.lean
+++ b/Linglib/Semantics/ArgumentStructure/Thematic/Basic.lean
@@ -41,10 +41,10 @@ class ThematicAxioms (Entity T : Type*) [LinearOrder T]
     (frame : ThematicFrame Entity T) where
   /-- Agents only participate in actions (dynamic events). -/
   agent_selects_action : ∀ (x : Entity) (e : Event T),
-    frame.agent x e → e.sort = .dynamic
+    frame.agent x e → e.sort = .action
   /-- Holders only participate in states. -/
   holder_selects_state : ∀ (x : Entity) (e : Event T),
-    frame.holder x e → e.sort = .stative
+    frame.holder x e → e.sort = .state
   /-- Each event has at most one agent. -/
   agent_unique : ∀ (x y : Entity) (e : Event T),
     frame.agent x e → frame.agent y e → x = y

--- a/Linglib/Semantics/Aspect/Stratified.lean
+++ b/Linglib/Semantics/Aspect/Stratified.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Mereology
 import Linglib.Semantics.Events.Basic
+import Linglib.Features.Aktionsart
 
 /-!
 # Stratified Reference [champollion-2017]

--- a/Linglib/Semantics/Aspect/SubeventStructure.lean
+++ b/Linglib/Semantics/Aspect/SubeventStructure.lean
@@ -206,7 +206,7 @@ theorem impf_phasePred {T : Type*} [LinearOrder T]
   simp only [IMPF, phasePred, Event.τ]
   constructor
   · rintro ⟨e, hSub, rfl⟩; exact hSub
-  · intro h; exact ⟨⟨phase, .dynamic⟩, h, rfl⟩
+  · intro h; exact ⟨⟨phase, .action⟩, h, rfl⟩
 
 /-- PRFV applied to a phase predicate reduces to the phase interval being
     contained in the reference time. -/
@@ -216,7 +216,7 @@ theorem prfv_phasePred {T : Type*} [LinearOrder T]
   simp only [PRFV, phasePred, Event.τ]
   constructor
   · rintro ⟨e, hSub, rfl⟩; exact hSub
-  · intro h; exact ⟨⟨phase, .dynamic⟩, h, rfl⟩
+  · intro h; exact ⟨⟨phase, .action⟩, h, rfl⟩
 
 /-! ### ViewpointAspect ↔ Decomposition Bridge -/
 

--- a/Linglib/Semantics/Aspect/SubintervalProperty.lean
+++ b/Linglib/Semantics/Aspect/SubintervalProperty.lean
@@ -188,14 +188,14 @@ theorem imperfective_paradox_possible
   have hSub := hall P
   -- Construct an event e₁ with runtime [t₁, t₂]; P holds (finish = t₂)
   -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
-  let e₁ : Event T := ⟨⟨⟨t₁, t₂⟩, le_of_lt hlt⟩, .dynamic⟩
+  let e₁ : Event T := ⟨⟨⟨t₁, t₂⟩, le_of_lt hlt⟩, .action⟩
   have hPe₁ : P w e₁ := rfl
   -- [t₁, t₁] is a subinterval of [t₁, t₂]
   let sub : NonemptyInterval T := ⟨⟨t₁, t₁⟩, le_refl t₁⟩
   have hSI : sub ≤ e₁.τ := NonemptyInterval.le_def.mpr ⟨le_refl t₁, le_of_lt hlt⟩
   -- SIP says P must hold for any event with runtime [t₁, t₁]
   -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
-  let e₂ : Event T := ⟨sub, .dynamic⟩
+  let e₂ : Event T := ⟨sub, .action⟩
   have hPe₂ := hSub e₁ w hPe₁ sub hSI e₂ rfl
   -- But P w e₂ means t₁ = t₂, contradicting t₁ < t₂
   exact absurd hPe₂ (ne_of_lt hlt)

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -22,7 +22,7 @@ differ along three dimensions:
 | Counterfactual | effect persists after cause ceases | effect ceases with cause |
 
 The first three properties are formalized using existing Linglib types:
-`Features.Dynamicity`, `NonemptyInterval.precedes`/`.overlaps`.
+`Event.Kind`, `NonemptyInterval.precedes`/`.overlaps`.
 The fourth uses `universalCounterfactual` from `Counterfactual.lean`.
 
 ## Key results
@@ -49,9 +49,9 @@ open Conditionals.Counterfactual (universalCounterfactual)
     causation (representation → state persistence). -/
 structure PsychCausalLink (T : Type*) [LinearOrder T] where
   /-- Ontological sort of the causing eventuality -/
-  causeSort : Features.Dynamicity
+  causeSort : Event.Kind
   /-- Ontological sort of the caused eventuality -/
-  effectSort : Features.Dynamicity
+  effectSort : Event.Kind
   /-- Does the effect involve a transition (BECOME in [rappaport-hovav-levin-1998])?
       Eventive: [CAUSE [BECOME [STATE]]] — yes.
       Maintenance: [CAUSE [STATE]] — no. -/
@@ -68,8 +68,8 @@ structure PsychCausalLink (T : Type*) [LinearOrder T] where
     Example: "The noise frightened John" — the noise event happens,
     THEN John enters the frightened state. -/
 def eventiveLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
-  { causeSort := .dynamic
-    effectSort := .dynamic
+  { causeSort := .action
+    effectSort := .action
     involvesTransition := true
     temporalConstraint := NonemptyInterval.precedes }
 
@@ -86,8 +86,8 @@ def eventiveLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
     (b) Temporal contemporaneity (τ(cause) overlaps τ(effect))
     (c) Counterfactual dependence (effect ceases when cause ceases) -/
 def maintenanceLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
-  { causeSort := .stative
-    effectSort := .stative
+  { causeSort := .state
+    effectSort := .state
     involvesTransition := false
     temporalConstraint := NonemptyInterval.overlaps }
 
@@ -133,13 +133,13 @@ theorem precedes_excludes_overlap {T : Type*} [LinearOrder T]
 
 /-- Maintenance relates two states ([kim-2024] property (a)). -/
 theorem maintenance_both_states {T : Type*} [LinearOrder T] :
-    (maintenanceLink T).causeSort = .stative ∧
-    (maintenanceLink T).effectSort = .stative := ⟨rfl, rfl⟩
+    (maintenanceLink T).causeSort = .state ∧
+    (maintenanceLink T).effectSort = .state := ⟨rfl, rfl⟩
 
 /-- Eventive causation relates two dynamic eventualities. -/
 theorem eventive_both_dynamic {T : Type*} [LinearOrder T] :
-    (eventiveLink T).causeSort = .dynamic ∧
-    (eventiveLink T).effectSort = .dynamic := ⟨rfl, rfl⟩
+    (eventiveLink T).causeSort = .action ∧
+    (eventiveLink T).effectSort = .action := ⟨rfl, rfl⟩
 
 /-- Maintenance involves no transition (no BECOME). -/
 theorem maintenance_no_transition {T : Type*} [LinearOrder T] :
@@ -151,8 +151,8 @@ theorem eventive_has_transition {T : Type*} [LinearOrder T] :
 
 /-- The two causal flavors assign opposite values on every dimension. -/
 theorem flavors_differ_on_all_dimensions {T : Type*} [LinearOrder T] :
-    (eventiveLink T).causeSort = .dynamic ∧
-    (maintenanceLink T).causeSort = .stative ∧
+    (eventiveLink T).causeSort = .action ∧
+    (maintenanceLink T).causeSort = .state ∧
     (eventiveLink T).involvesTransition = true ∧
     (maintenanceLink T).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩
@@ -231,7 +231,7 @@ theorem dependent_excludes_persistent {W : Type*} [DecidableEq W] [Fintype W]
 /-- The three defining properties of maintenance causation from
     [kim-2024], formalized using existing infrastructure:
 
-    (a) Relates two eventualities — both are states (`Features.Dynamicity.stative`)
+    (a) Relates two eventualities — both are states (`Event.Kind.state`)
     (b) Temporal contemporaneity — `NonemptyInterval.overlaps`
     (c) No transition — effect is a persisting state, not a change
 
@@ -243,8 +243,8 @@ theorem dependent_excludes_persistent {W : Type*} [DecidableEq W] [Fintype W]
     for WHY maintenance-caused states are counterfactually dependent. -/
 theorem maintenance_three_properties {T : Type*} [LinearOrder T] :
     -- (a) Both eventualities are states
-    (maintenanceLink T).causeSort = .stative ∧
-    (maintenanceLink T).effectSort = .stative ∧
+    (maintenanceLink T).causeSort = .state ∧
+    (maintenanceLink T).effectSort = .state ∧
     -- (b) Temporal contemporaneity (overlaps, not precedes)
     (maintenanceLink T).temporalConstraint = NonemptyInterval.overlaps ∧
     -- (c) No transition (no BECOME)

--- a/Linglib/Semantics/Events/Basic.lean
+++ b/Linglib/Semantics/Events/Basic.lean
@@ -1,7 +1,6 @@
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Image
 import Linglib.Core.Order.Interval
-import Linglib.Features.Aktionsart
 
 /-!
 # Neo-Davidsonian Event Semantics
@@ -13,10 +12,10 @@ events; thematic roles are independent two-place predicates
 
 ## Main definitions
 
-* `Event` — the unified event type: a runtime interval + `Features.Dynamicity` sort
+* `Event.Kind` — the two sorts of eventualities, actions and states ([bach-1986])
+* `Event` — the unified event type: a runtime interval + its sort
 * `Event.τ` — temporal trace function
 * `Event.isAction` / `Event.isState` — decidable `Prop` sort predicates
-  (the `dynamic` / `stative` poles of `Features.Dynamicity`)
 * `Event.isPunctual` / `Event.isDurative` — decidable `Prop` duration predicates
 * `Event.existsClosure` — Davidsonian existential closure
 * `Event.Mereology` — part-of typeclass with τ-monotonicity + sort-preservation
@@ -32,7 +31,9 @@ sense, non-state) has largely collapsed in current practice —
 [champollion-2017] and [zhao-2025] both use "event"
 generically with sort/aktionsart as an inherent attribute. Tense-aspect
 code that doesn't care about sort simply doesn't reference `.sort`;
-sortless construction sites default to `.dynamic`.
+sortless construction sites default to `.action`. The lexical feature
+`Features.Dynamicity` labels verb entries; the sort here is the ontological
+attribute of a token.
 
 ## References
 
@@ -43,16 +44,19 @@ sortless construction sites default to `.dynamic`.
 * [liefke-2024] §4.3 (manner ontology)
 -/
 
-open Features
+/-- The two sorts of eventualities: actions, which involve change, and states, which do not
+([bach-1986]). -/
+inductive Event.Kind where
+  | action
+  | state
+  deriving DecidableEq, Repr
 
 /-- An event: a temporal individual with ontological sort. -/
 structure Event (T : Type*) [LinearOrder T] where
   /-- The temporal extent of this event -/
   runtime : NonemptyInterval T
-  /-- Ontological sort (aktionsart): `dynamic` or `stative` ([bach-1986]).
-      This is the `Features.Dynamicity` feature — the action/state distinction
-      at the event-token level. -/
-  sort : Features.Dynamicity
+  /-- Ontological sort: action or state ([bach-1986]). -/
+  sort : Event.Kind
 
 namespace Event
 
@@ -67,19 +71,19 @@ def τ (e : Event T) : NonemptyInterval T :=
 
 /-! ### Sort predicates -/
 
-/-- Is this event an action (dynamic event)? -/
+/-- Is this event an action? -/
 def isAction (e : Event T) : Prop :=
-  e.sort = .dynamic
+  e.sort = .action
 
-/-- Is this event a state (stative event)? -/
+/-- Is this event a state? -/
 def isState (e : Event T) : Prop :=
-  e.sort = .stative
+  e.sort = .state
 
 instance : DecidablePred (isAction (T := T)) :=
-  fun e => decEq e.sort .dynamic
+  fun e => decEq e.sort .action
 
 instance : DecidablePred (isState (T := T)) :=
-  fun e => decEq e.sort .stative
+  fun e => decEq e.sort .state
 
 /-- `isAction` and `isState` are complementary. -/
 theorem isAction_iff_not_isState (e : Event T) :
@@ -215,11 +219,11 @@ end Denotation
 
 /-- Example: a running event from time 1 to 5. -/
 def exampleRun : Event ℤ :=
-  ⟨⟨⟨1, 5⟩, by omega⟩, .dynamic⟩
+  ⟨⟨⟨1, 5⟩, by omega⟩, .action⟩
 
 /-- Example: a knowing state from time 0 to 10. -/
 def exampleKnow : Event ℤ :=
-  ⟨⟨⟨0, 10⟩, by omega⟩, .stative⟩
+  ⟨⟨⟨0, 10⟩, by omega⟩, .state⟩
 
 /-- The run event is an action. -/
 theorem exampleRun_isAction : exampleRun.isAction := rfl

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -247,7 +247,7 @@ theorem earlier_lb_not_weaker_impf :
   intro hall
   -- Counterexample: event runtime [1,5], tLB₁=0, tLB₂=2, tc=4
   -- sort defaults to .action; the proof doesn't reference .sort
-  let e₀ : Event ℤ := ⟨⟨⟨1, 5⟩, by omega⟩, .dynamic⟩
+  let e₀ : Event ℤ := ⟨⟨⟨1, 5⟩, by omega⟩, .action⟩
   let V : Unit → Event ℤ → Prop := fun _ e => e = e₀
   -- Premise: PERF_XN(IMPF(V), {2})(⟨(), 4⟩)
   -- PTS = [2,4], event [1,5]: [2,4] ⊂ [1,5] ✓

--- a/Linglib/Studies/Bhadra2024.lean
+++ b/Linglib/Studies/Bhadra2024.lean
@@ -234,12 +234,12 @@ section Examples
 /-- The base event. -/
 private def ev₁ : Event ℤ where
   runtime := ⟨⟨0, 5⟩, by omega⟩
-  sort := .dynamic
+  sort := .action
 
 /-- The prefixed event. -/
 private def ev₂ : Event ℤ where
   runtime := ⟨⟨10, 15⟩, by omega⟩
-  sort := .dynamic
+  sort := .action
 
 private theorem ev₁_precedes_ev₂ : (Event.τ ev₁).precedes (Event.τ ev₂) := by
   show (5 : ℤ) < 10; omega

--- a/Linglib/Studies/Condoravdi2002.lean
+++ b/Linglib/Studies/Condoravdi2002.lean
@@ -56,7 +56,6 @@ paper's examples as rows.
 namespace Condoravdi2002
 
 open Aspect HistoricalAlternatives Data.Examples
-open Features (Dynamicity)
 open Modality (TemporalPerspective TemporalOrientation)
 
 variable {W T : Type*} [LinearOrder T] {P : W → Event T → Prop} {Q Q' : SortedProperty W T}
@@ -384,7 +383,7 @@ def Scope.Sat (s : Scope) (z : Zone) : Prop :=
 
 private theorem winOn_at (d : ℤ) {r : Interval (WithTop ℤ)} (h : Interval.pure ↑d ≤ r) :
     At r () (.eventive (winOn d)) :=
-  ⟨⟨_, .dynamic⟩, rfl, h⟩
+  ⟨⟨_, .action⟩, rfl, h⟩
 
 /-- The zone table is the satisfiability table: a scoping admits a period exactly when its
 sentence about that period can be true, the deviant cells being `frame_modal_past` and
@@ -439,7 +438,7 @@ structure Adverbial where
   /-- The scoping. -/
   scope : Scope
   /-- The sort of the predicate. -/
-  sort : Dynamicity
+  sort : Event.Kind
   /-- The zone of the period. -/
   zone : Zone
 
@@ -447,7 +446,7 @@ structure Adverbial where
 def Adverbial.ofRow (row : LinguisticExample) : Option Adverbial := do
   guard (row.feature? "construction" = some "adverb")
   return ⟨← parse? scopes row "scope",
-    ← parse? [("eventive", Dynamicity.dynamic), ("stative", .stative)] row "sort",
+    ← parse? [("eventive", Event.Kind.action), ("stative", .state)] row "sort",
     ← parse? [("past", Zone.past), ("present", .present), ("future", .future)] row "adverb"⟩
 
 /-- The adverbial patterns of [1], [2], [29], [34] and [35]: a frame adverbial is deviant
@@ -457,7 +456,7 @@ the semantics admits by an event within the present. -/
 theorem adverb_rows : ∀ row ∈ Examples.all, ∀ a ∈ Adverbial.ofRow row,
     (row.judgment = .ungrammatical ↔ a.zone ∉ a.scope.zones) ∧
       (row.judgment = .questionable ↔
-        a.scope = .modal ∧ a.sort = .dynamic ∧ a.zone = .present) := by
+        a.scope = .modal ∧ a.sort = .action ∧ a.zone = .present) := by
   decide
 
 /-- What the context says about the issue. -/

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -187,7 +187,7 @@ theorem agent_is_agentive_subfeature {Entity T : Type*} [LinearOrder T]
     [ax : ThematicAxioms Entity T frame]
     (x : Entity) (e : Event T)
     (h : frame.agent x e) :
-    profile.hasAgentive x e ∧ e.sort = .dynamic :=
+    profile.hasAgentive x e ∧ e.sort = .action :=
   ⟨link.agent_implies_agentive x e h, ax.agent_selects_action x e h⟩
 
 -- ════════════════════════════════════════════════════
@@ -272,16 +272,16 @@ theorem make_lexicalizes_sufficient_initiative :
 
     Witness: "John is standing" — volitive (John can stop standing)
     but stative (no change over the interval). The do-test passes
-    via the volitive feature, even though e.sort =.state.
+    via the volitive feature, even though e.sort = .state.
 
     This shows the do-test is strictly broader than Parsons' `agent`
-    role, which requires e.sort =.action. -/
+    role, which requires e.sort = .action. -/
 theorem stative_can_pass_doTest :
     ∃ (profile : AgentivityProfile Unit ℤ) (x : Unit) (e : Event ℤ),
-      e.sort = .stative ∧ passesDoTest x e profile := by
+      e.sort = .state ∧ passesDoTest x e profile := by
   -- Witness: a profile where () has volitive in a stative event
   refine ⟨⟨λ _ _ => True, λ _ _ => False, λ _ _ => False, λ _ _ => False⟩,
-          (), ⟨⟨⟨0, 10⟩, by omega⟩, .stative⟩, rfl, ?_⟩
+          (), ⟨⟨⟨0, 10⟩, by omega⟩, .state⟩, rfl, ?_⟩
   exact Or.inl trivial
 
 /-- Parsons' `agent_selects_action` is NOT contradicted by stative
@@ -298,7 +298,7 @@ theorem agent_selects_action_consistent {Entity T : Type*} [LinearOrder T]
     {frame : ThematicFrame Entity T}
     [ax : ThematicAxioms Entity T frame]
     (x : Entity) (e : Event T)
-    (hState : e.sort = .stative)
+    (hState : e.sort = .state)
     (hAgent : frame.agent x e) :
     False := by
   have hAction := ax.agent_selects_action x e hAgent

--- a/Linglib/Studies/FuscoSgrizzi2026.lean
+++ b/Linglib/Studies/FuscoSgrizzi2026.lean
@@ -197,7 +197,7 @@ def CausativeAttitude.denote (v : CausativeAttitude E T)
     (P : Event T → Prop) : Prop :=
   ∃ e e' : Event T,
     v.verbPred e ∧ v.isAgent e v.agent ∧ v.isPatient e v.experiencer ∧
-    v.cause e e' ∧ e'.sort = .stative ∧
+    v.cause e e' ∧ e'.sort = .state ∧
     v.isExperiencer e' v.experiencer ∧ P e'
 
 /-- Belief reading: the CP complement is existentially closed into a

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -134,7 +134,7 @@ theorem prfvDen_not_subinterval_closed :
       t ∈ prfvDen P → ∀ t', t' ≤ t → t' ∈ prfvDen P := by
   intro h
   -- sort defaults to .action; the proof doesn't reference .sort
-  let e₀ : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .dynamic⟩
+  let e₀ : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .action⟩
   let P : Unit → Event ℤ → Prop := fun _ e => e = e₀
   let sub : NonemptyInterval ℤ := ⟨⟨1, 3⟩, by omega⟩
   have hrt : e₀.τ ∈ prfvDen P := ⟨e₀, rfl, rfl⟩
@@ -196,7 +196,7 @@ theorem impfDen_singleton_eq_stativeDenotation
   constructor
   · rintro ⟨e, hSub, rfl⟩; exact hSub
     -- sort defaults to .action; the proof doesn't reference .sort
-  · intro h; exact ⟨⟨i, .dynamic⟩, h, rfl⟩
+  · intro h; exact ⟨⟨i, .action⟩, h, rfl⟩
 
 /-- For a single event, the PRFV denotation is exactly the accomplishment
     denotation (singleton containing just the runtime). -/
@@ -209,7 +209,7 @@ theorem prfvDen_singleton_eq_accomplishmentDenotation
   constructor
   · rintro ⟨e, rfl, rfl⟩; rfl
     -- sort is irrelevant here (defaults to .dynamic); the proof never reads .sort
-  · intro h; exact ⟨⟨i, .dynamic⟩, rfl, h.symm⟩
+  · intro h; exact ⟨⟨i, .action⟩, rfl, h.symm⟩
 
 -- ============================================================================
 -- § 5: Time Traces Coincide
@@ -279,7 +279,7 @@ theorem scope_readings_distinct :
     ∃ (A : Unit → Event ℤ → Prop) (B : RunTimes ℤ),
       wideScopeNotUntil A B ∧ ¬ narrowScopeNotUntil A B := by
   -- sort defaults to .action; the proof doesn't reference .sort
-  let e₀ : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .dynamic⟩
+  let e₀ : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .action⟩
   let A : Unit → Event ℤ → Prop := fun _ e => e = e₀
   let iB : NonemptyInterval ℤ := ⟨⟨7, 7⟩, by omega⟩
   let B : RunTimes ℤ := {iB}
@@ -306,7 +306,7 @@ theorem scope_readings_independent :
     ∃ (A : Unit → Event ℤ → Prop) (B : RunTimes ℤ),
       ¬ wideScopeNotUntil A B ∧ narrowScopeNotUntil A B := by
   -- sort defaults to .action; the proof doesn't reference .sort
-  let e₀ : Event ℤ := ⟨⟨⟨5, 10⟩, by omega⟩, .dynamic⟩
+  let e₀ : Event ℤ := ⟨⟨⟨5, 10⟩, by omega⟩, .action⟩
   let A : Unit → Event ℤ → Prop := fun _ e => e = e₀
   let iB : NonemptyInterval ℤ := ⟨⟨3, 7⟩, by omega⟩
   let B : RunTimes ℤ := {iB}

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -216,7 +216,7 @@ def intentionHolds {E W T : Type*} [LinearOrder T]
     (causeStar : Event T → Event T → W → Prop)
     (agent : E) (P : E → W → Event T → Prop) (w : W) : Prop :=
   ∃ s : Event T,
-    s.sort = .stative ∧ isIntention s w ∧ holder agent s w ∧
+    s.sort = .state ∧ isIntention s w ∧ holder agent s w ∧
     ∀ p ∈ content s, ∃ e : Event T, causeStar s e p.1 ∧ P p.2 p.1 e
 
 /-- Plain belief reports need no causal self-reference: the complement

--- a/Linglib/Studies/IatridouZeijlstra2021.lean
+++ b/Linglib/Studies/IatridouZeijlstra2021.lean
@@ -396,7 +396,7 @@ theorem impf_subdomain_entailed (P : W → Event T → Prop)
     ⟨le_trans hImpf.1 hτ'.1, le_trans hτ'.2 hImpf.2⟩
   -- By SUB, any event with runtime τ' is a P-event
   -- sort defaults to .action; the proof doesn't reference .sort
-  exact ⟨⟨τ', .dynamic⟩, ⟨le_refl _, le_refl _⟩, hSub e w hP τ' h_sub_e ⟨τ', .dynamic⟩ rfl⟩
+  exact ⟨⟨τ', .action⟩, ⟨le_refl _, le_refl _⟩, hSub e w hP τ' h_sub_e ⟨τ', .action⟩ rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 11. Bridge: Constant's Observation

--- a/Linglib/Studies/KennedyLevin2008.lean
+++ b/Linglib/Studies/KennedyLevin2008.lean
@@ -326,7 +326,7 @@ theorem atelic_of_noMaxOrder [NoMaxOrder δ] :
     ¬ ∃ g : δ, Quantized (reachesSome (δ := δ)) g := by
   rintro ⟨g, hg⟩
   obtain ⟨b, hb⟩ := exists_gt g
-  have hbg : b = g := hg Patient.mk ⟨⟨⟨b, b⟩, le_refl b⟩, .dynamic⟩ ⟨_, rfl⟩
+  have hbg : b = g := hg Patient.mk ⟨⟨⟨b, b⟩, le_refl b⟩, .action⟩ ⟨_, rfl⟩
   exact absurd hbg hb.ne'
 
 /-- Synthesis: with a greatest degree, the telic reading builds the Beavers

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -260,7 +260,7 @@ theorem existential_eq_perf_prfv {T : Type*} [LinearOrder T]
   constructor
   · rintro ⟨pts, hR, hSub⟩
     -- sort defaults to .action; the proof doesn't reference .sort
-    exact ⟨pts, hR, ⟨d.runtime, .dynamic⟩, hSub, rfl⟩
+    exact ⟨pts, hR, ⟨d.runtime, .action⟩, hSub, rfl⟩
   · rintro ⟨pts, hR, e, hSub, heq⟩
     exact ⟨pts, hR, heq ▸ hSub⟩
 
@@ -276,7 +276,7 @@ theorem universal_eq_perf_unbounded {T : Type*} [LinearOrder T]
   constructor
   · rintro ⟨pts, hR, hSub⟩
     -- sort defaults to .action; the proof doesn't reference .sort
-    exact ⟨pts, hR, ⟨d.runtime, .dynamic⟩, hSub, rfl⟩
+    exact ⟨pts, hR, ⟨d.runtime, .action⟩, hSub, rfl⟩
   · rintro ⟨pts, hR, e, hSub, heq⟩
     exact ⟨pts, hR, heq ▸ hSub⟩
 

--- a/Linglib/Studies/Koev2017.lean
+++ b/Linglib/Studies/Koev2017.lean
@@ -362,17 +362,17 @@ def LearningScenario.toEvidentialProp (s : LearningScenario ℤ)
 /-! ### Concrete Scenarios -/
 
 /-- Described event: interval [0, 5]. -/
-def describedEvent : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .dynamic⟩
+def describedEvent : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .action⟩
 
 /-- Learning event (indirect): interval [10, 15] — strictly later. -/
-def learningEventIndirect : Event ℤ := ⟨⟨⟨10, 15⟩, by omega⟩, .stative⟩
+def learningEventIndirect : Event ℤ := ⟨⟨⟨10, 15⟩, by omega⟩, .state⟩
 
 /-- Learning event (direct witness): interval [2, 4] — overlaps described. -/
-def learningEventDirect : Event ℤ := ⟨⟨⟨2, 4⟩, by omega⟩, .stative⟩
+def learningEventDirect : Event ℤ := ⟨⟨⟨2, 4⟩, by omega⟩, .state⟩
 
 /-- Learning event (spatial distance): interval [0, 5] — same time,
     different place (smoke from chimney). -/
-def learningEventSpatial : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .stative⟩
+def learningEventSpatial : Event ℤ := ⟨⟨⟨0, 5⟩, by omega⟩, .state⟩
 
 /-- Indirect evidence scenario: described event [0,5], learning event [10,15]. -/
 def indirectScenario : LearningScenario ℤ where

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -358,8 +358,8 @@ theorem after_veridicality_derived {P Q : Event T → Prop} (h : eventAfter P Q)
 satisfies it. -/
 theorem before_nonveridicality_derived :
     ∃ (P Q : Event ℤ → Prop), eventBefore P Q ∧ ¬ ∃ e : Event ℤ, Q e :=
-  ⟨fun e => e = ⟨⟨⟨0, 1⟩, by decide⟩, .dynamic⟩, fun _ => False,
-    ⟨⟨⟨⟨0, 1⟩, by decide⟩, .dynamic⟩, rfl, fun _ h => h.elim⟩, fun ⟨_, h⟩ => h⟩
+  ⟨fun e => e = ⟨⟨⟨0, 1⟩, by decide⟩, .action⟩, fun _ => False,
+    ⟨⟨⟨⟨0, 1⟩, by decide⟩, .action⟩, rfl, fun _ h => h.elim⟩, fun ⟨_, h⟩ => h⟩
 
 /-- Both connectives commit to the main clause. -/
 theorem eventBefore_veridical_main {P Q : Event T → Prop} (h : eventBefore P Q) :
@@ -390,8 +390,8 @@ theorem not_eventBefore_of_anscombe :
     ¬ ∀ (P Q : Event ℤ → Prop),
       Anscombe.beforeEver (eventDenotation P) (eventDenotation Q) → eventBefore P Q := by
   intro h
-  let eP : Event ℤ := ⟨⟨⟨1, 5⟩, by decide⟩, .dynamic⟩
-  let eQ : Event ℤ := ⟨⟨⟨3, 8⟩, by decide⟩, .dynamic⟩
+  let eP : Event ℤ := ⟨⟨⟨1, 5⟩, by decide⟩, .action⟩
+  let eQ : Event ℤ := ⟨⟨⟨3, 8⟩, by decide⟩, .action⟩
   have hansc : Anscombe.beforeEver (eventDenotation (· = eP)) (eventDenotation (· = eQ)) := by
     refine ⟨1, ?_, ?_⟩
     · rw [timeTrace_eventDenotation]
@@ -413,10 +413,10 @@ theorem not_eventBefore_of_anscombe :
     - arriving event at time 0
     O&ST predicts: after(leave, arrive) holds (τ(arrive) ≺ τ(leave)). -/
 theorem scenario_after_punctual :
-    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩
-    let arrive : Event ℤ := ⟨⟨⟨0, 0⟩, le_refl _⟩, .dynamic⟩
+    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩
+    let arrive : Event ℤ := ⟨⟨⟨0, 0⟩, le_refl _⟩, .action⟩
     eventAfter (· = leave) (· = arrive) := by
-  refine ⟨⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩, ⟨⟨⟨0, 0⟩, le_refl _⟩, .dynamic⟩, rfl, rfl, ?_⟩
+  refine ⟨⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩, ⟨⟨⟨0, 0⟩, le_refl _⟩, .action⟩, rfl, rfl, ?_⟩
   simp [NonemptyInterval.precedes, Event.τ]
 
 /-- Scenario: "He left₁ before she arrived₃" with punctual events.
@@ -424,19 +424,19 @@ theorem scenario_after_punctual :
     - arriving event at time 3
     O&ST predicts: before(leave, arrive) holds (τ(leave) ≺ τ(arrive)). -/
 theorem scenario_before_punctual :
-    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩
-    let arrive : Event ℤ := ⟨⟨⟨3, 3⟩, le_refl _⟩, .dynamic⟩
+    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩
+    let arrive : Event ℤ := ⟨⟨⟨3, 3⟩, le_refl _⟩, .action⟩
     eventBefore (· = leave) (· = arrive) := by
-  refine ⟨⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩, rfl, ?_⟩
+  refine ⟨⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩, rfl, ?_⟩
   intro e₂ rfl
   simp [NonemptyInterval.precedes, Event.τ]
 
 /-- Scenario: "The bomb exploded₅ before anyone defused it" (nobody defused it).
     O&ST predicts: before(explode, defuse) holds vacuously (no defuse-events). -/
 theorem scenario_before_counterfactual :
-    let explode : Event ℤ := ⟨⟨⟨5, 5⟩, le_refl _⟩, .dynamic⟩
+    let explode : Event ℤ := ⟨⟨⟨5, 5⟩, le_refl _⟩, .action⟩
     eventBefore (· = explode) (fun _ => False) := by
-  exact ⟨⟨⟨⟨5, 5⟩, le_refl _⟩, .dynamic⟩, rfl, fun _ h => h.elim⟩
+  exact ⟨⟨⟨⟨5, 5⟩, le_refl _⟩, .action⟩, rfl, fun _ h => h.elim⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13: Cross-Level Projection Verification
@@ -445,15 +445,15 @@ theorem scenario_before_counterfactual :
 /-- The punctual after-scenario projects correctly through eventDenotation:
     O&ST.after implies Anscombe.after on the projected interval sets. -/
 theorem scenario_after_projects :
-    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩
-    let arrive : Event ℤ := ⟨⟨⟨0, 0⟩, le_refl _⟩, .dynamic⟩
+    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩
+    let arrive : Event ℤ := ⟨⟨⟨0, 0⟩, le_refl _⟩, .action⟩
     Anscombe.after (eventDenotation (· = leave)) (eventDenotation (· = arrive)) :=
   anscombe_after_of_eventAfter scenario_after_punctual
 
 /-- The punctual before-scenario projects correctly through eventDenotation. -/
 theorem scenario_before_projects :
-    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .dynamic⟩
-    let arrive : Event ℤ := ⟨⟨⟨3, 3⟩, le_refl _⟩, .dynamic⟩
+    let leave : Event ℤ := ⟨⟨⟨1, 1⟩, le_refl _⟩, .action⟩
+    let arrive : Event ℤ := ⟨⟨⟨3, 3⟩, le_refl _⟩, .action⟩
     Anscombe.beforeEver (eventDenotation (· = leave)) (eventDenotation (· = arrive)) :=
   anscombe_before_of_eventBefore scenario_before_punctual
 

--- a/Linglib/Studies/Rudin2025LI.lean
+++ b/Linglib/Studies/Rudin2025LI.lean
@@ -799,7 +799,7 @@ postulates hold by `rfl`. The discriminator for verb classes is
 witnesses and exclusions. -/
 
 /-- A canonical event for each verb class, indexed by `runtime.start`. -/
-def E (n : ℕ) : Event ℕ := ⟨⟨⟨n, n⟩, le_refl _⟩, .dynamic⟩
+def E (n : ℕ) : Event ℕ := ⟨⟨⟨n, n⟩, le_refl _⟩, .action⟩
 
 /-- The REENACT relation: per verb-class events have different REENACT
     targets, chosen so the postulates' universal quantifiers reduce to


### PR DESCRIPTION
Give the event ontology its own sort, `Event.Kind` with `action` and `state`, instead of borrowing the lexical feature `Features.Dynamicity` for `Event.sort`.

- `Semantics/Events/Basic` no longer imports `Features/Aktionsart`; the lexical feature stays there as the verb-entry label.
- Consumers rewrite `.dynamic`/`.stative` on event tokens to `.action`/`.state`; the psych-causation link and the thematic axioms take `Event.Kind`; Condoravdi2002's adverbial rows use it for the predicate's sort.