### PR TITLE
refactor(Semantics/Aspect): instantiation at a ray as simp lemmas

### DIFF
--- a/Linglib/Core/Order/Interval.lean
+++ b/Linglib/Core/Order/Interval.lean
@@ -311,11 +311,37 @@ theorem isLeast_Ici : IsLeast (↑(Ici a) : Set (WithTop α)) ↑a := isLeast_co
 @[simp] theorem pure_le_Ici : pure (↑b : WithTop α) ≤ Ici a ↔ a ≤ b := by
   simp
 
+/-- An interval lies within the ray from `a` exactly when all its times are at or after `a`. -/
+theorem le_Ici_iff {s : Interval (WithTop α)} : s ≤ Ici a ↔ ∀ x ∈ s, ↑a ≤ x := by
+  simp [← coe_subset_coe, Set.subset_def]
+
+/-- A bounded interval lies within the ray from `a` exactly when it starts at or after `a`. -/
+theorem withTop_le_Ici : (↑i.withTop : Interval (WithTop α)) ≤ Ici a ↔ a ≤ i.fst := by
+  simp only [coe_le_iff, NonemptyInterval.fst_withTop, NonemptyInterval.snd_withTop, mem_Ici,
+    WithTop.coe_le_coe]
+  exact ⟨And.left, λ h => ⟨h, le_trans h i.fst_le_snd⟩⟩
+
 /-- A bounded interval precedes the ray from `a` exactly when it ends before `a`. -/
 theorem precedes_withTop_Ici :
     (↑i.withTop : Interval (WithTop α)).Precedes (Ici a) ↔ i.snd < a := by
   rw [Ici, precedes_coe_coe]; simp [NonemptyInterval.precedes]
 
+/-- A bounded interval precedes the point `a` exactly when it ends before `a`. -/
+theorem precedes_withTop_pure :
+    (↑i.withTop : Interval (WithTop α)).Precedes (pure ↑a) ↔ i.snd < a := by
+  rw [pure, precedes_coe_coe]; simp [NonemptyInterval.precedes]
+
 end WithTop
+
+section WithTopLattice
+
+variable {α : Type*} [Lattice α] {i : NonemptyInterval α} {a : α}
+
+/-- A bounded interval meets the ray from `a` exactly when it ends at or after `a`. -/
+theorem not_disjoint_withTop_Ici :
+    ¬ Disjoint (↑i.withTop : Interval (WithTop α)) (Ici a) ↔ a ≤ i.snd := by
+  rw [Ici, not_disjoint_coe_coe]; simp [NonemptyInterval.overlaps]
+
+end WithTopLattice
 
 end Interval

--- a/Linglib/Semantics/Aspect/Instantiation.lean
+++ b/Linglib/Semantics/Aspect/Instantiation.lean
@@ -19,6 +19,8 @@ the stative clause.
 ## Main results
 
 * `Aspect.At.mono` — instantiation of an eventuality is monotone in the interval.
+* `Aspect.at_Ici_eventive_iff`, `Aspect.at_Ici_stative_iff` — instantiation at a ray: the event
+  starts no earlier, the state persists at or past.
 * `Aspect.at_eventive_withTop_iff_prfv` — on a bounded interval, eventive instantiation is
   `PRFV`.
 
@@ -76,6 +78,16 @@ theorem At.mono (hQ : Q.IsEventuality) (h : r ≤ r') (hr : At r w Q) : At r' w 
     obtain ⟨e, he, hd⟩ := hr
     exact ⟨e, he, λ hd' => hd (hd'.mono_right h)⟩
   | temporal R => exact hQ.elim
+
+/-- An event is instantiated at the ray from `t` when it starts no earlier than `t`. -/
+@[simp] theorem at_Ici_eventive_iff {t : T} :
+    At (Interval.Ici t) w (.eventive P) ↔ ∃ e, P w e ∧ t ≤ e.τ.fst := by
+  simp [At, Interval.withTop_le_Ici]
+
+/-- A state is instantiated at the ray from `t` when it persists at or past `t`. -/
+@[simp] theorem at_Ici_stative_iff {t : T} :
+    At (Interval.Ici t) w (.stative P) ↔ ∃ e, P w e ∧ t ≤ e.τ.snd := by
+  simp [At, Interval.not_disjoint_withTop_Ici]
 
 /-- On a bounded interval, eventive instantiation is the perfective viewpoint. -/
 theorem at_eventive_withTop_iff_prfv {i : NonemptyInterval T} :

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -6,9 +6,9 @@ import Linglib.Semantics.Conditionals.Counterfactual
 /-!
 # Psych Verb Causal Links
 
-[kim-2024] [allen-1983] [bach-1986] Formal integration of [kim-2024]'s maintenance relation with existing [lewis-1973]
-infrastructure: temporal intervals, event sorts,
-and counterfactual semantics.
+Formal integration of [kim-2024]'s maintenance relation with existing infrastructure:
+[allen-1983]'s temporal intervals, [bach-1986]'s event sorts, and [lewis-1973]'s
+counterfactual semantics.
 
 Kim's core claim: stative Class II psych verbs involve a
 **maintenance** causal relation, not eventive causation. The two flavors
@@ -22,7 +22,7 @@ differ along three dimensions:
 | Counterfactual | effect persists after cause ceases | effect ceases with cause |
 
 The first three properties are formalized using existing Linglib types:
-`Event.Kind`, `NonemptyInterval.precedes`/`.overlaps`.
+`Event.Kind`, `Interval.Precedes` and `Disjoint`.
 The fourth uses `universalCounterfactual` from `Counterfactual.lean`.
 
 ## Key results
@@ -57,7 +57,7 @@ structure PsychCausalLink (T : Type*) [LinearOrder T] where
       Maintenance: [CAUSE [STATE]] — no. -/
   involvesTransition : Bool
   /-- Temporal constraint on the runtimes of cause and effect -/
-  temporalConstraint : NonemptyInterval T → NonemptyInterval T → Prop
+  temporalConstraint : Interval T → Interval T → Prop
 
 /-! ### Eventive and Maintenance Links -/
 
@@ -71,7 +71,7 @@ def eventiveLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
   { causeSort := .action
     effectSort := .action
     involvesTransition := true
-    temporalConstraint := NonemptyInterval.precedes }
+    temporalConstraint := Interval.Precedes }
 
 /-- Maintenance causation: a mental representation MAINTAINS a
     psychological state. Cause and effect are temporally contemporaneous.
@@ -89,7 +89,7 @@ def maintenanceLink (T : Type*) [LinearOrder T] : PsychCausalLink T :=
   { causeSort := .state
     effectSort := .state
     involvesTransition := false
-    temporalConstraint := NonemptyInterval.overlaps }
+    temporalConstraint := λ s t => ¬ Disjoint s t }
 
 /-! ### CausalSource → PsychCausalLink -/
 
@@ -104,30 +104,30 @@ def CausalSource.toLink (T : Type*) [LinearOrder T] :
 /-! ### Temporal Theorems -/
 
 /-- Maintenance is temporally symmetric: if cause overlaps effect,
-    effect overlaps cause. Delegates to `NonemptyInterval.overlaps_symm`. -/
+    effect overlaps cause. -/
 theorem maintenance_temporal_symmetric {T : Type*} [LinearOrder T]
-    (i₁ i₂ : NonemptyInterval T)
-    (h : (maintenanceLink T).temporalConstraint i₁ i₂) :
-    (maintenanceLink T).temporalConstraint i₂ i₁ :=
-  NonemptyInterval.overlaps_symm h
+    (s t : Interval T)
+    (h : (maintenanceLink T).temporalConstraint s t) :
+    (maintenanceLink T).temporalConstraint t s :=
+  λ hd => h hd.symm
 
 /-- Eventive causation is temporally irreflexive: no eventuality
-    can precede itself. Delegates to `NonemptyInterval.precedes_irrefl`. -/
+    can precede itself. -/
 theorem eventive_temporal_irrefl {T : Type*} [LinearOrder T]
     (i : NonemptyInterval T) :
-    ¬ (eventiveLink T).temporalConstraint i i :=
-  NonemptyInterval.precedes_irrefl i
+    ¬ (eventiveLink T).temporalConstraint ↑i ↑i :=
+  λ h => NonemptyInterval.precedes_irrefl i (Interval.precedes_coe_coe.1 h)
 
 /-- Precedence and overlap are mutually exclusive: if cause precedes
     effect, they cannot overlap. This is the structural basis for the
     eventive/stative dichotomy — the two temporal configurations are
-    incompatible for any given pair of eventualities.
-    Delegates to `NonemptyInterval.precedes_not_overlaps`. -/
+    incompatible for any given pair of eventualities. -/
 theorem precedes_excludes_overlap {T : Type*} [LinearOrder T]
     (i₁ i₂ : NonemptyInterval T)
-    (h : (eventiveLink T).temporalConstraint i₁ i₂) :
-    ¬ (maintenanceLink T).temporalConstraint i₁ i₂ :=
-  NonemptyInterval.precedes_not_overlaps h
+    (h : (eventiveLink T).temporalConstraint ↑i₁ ↑i₂) :
+    ¬ (maintenanceLink T).temporalConstraint ↑i₁ ↑i₂ :=
+  λ hn => NonemptyInterval.precedes_not_overlaps (Interval.precedes_coe_coe.1 h)
+    (Interval.not_disjoint_coe_coe.1 hn)
 
 /-! ### Event Sort Properties -/
 
@@ -232,7 +232,7 @@ theorem dependent_excludes_persistent {W : Type*} [DecidableEq W] [Fintype W]
     [kim-2024], formalized using existing infrastructure:
 
     (a) Relates two eventualities — both are states (`Event.Kind.state`)
-    (b) Temporal contemporaneity — `NonemptyInterval.overlaps`
+    (b) Temporal contemporaneity — the runtimes are not disjoint
     (c) No transition — effect is a persisting state, not a change
 
     Property (c) is formalized structurally (no BECOME) rather than
@@ -246,7 +246,7 @@ theorem maintenance_three_properties {T : Type*} [LinearOrder T] :
     (maintenanceLink T).causeSort = .state ∧
     (maintenanceLink T).effectSort = .state ∧
     -- (b) Temporal contemporaneity (overlaps, not precedes)
-    (maintenanceLink T).temporalConstraint = NonemptyInterval.overlaps ∧
+    (maintenanceLink T).temporalConstraint = (λ s t => ¬ Disjoint s t) ∧
     -- (c) No transition (no BECOME)
     (maintenanceLink T).involvesTransition = false :=
   ⟨rfl, rfl, rfl, rfl⟩

--- a/Linglib/Studies/Condoravdi2002.lean
+++ b/Linglib/Studies/Condoravdi2002.lean
@@ -82,11 +82,11 @@ def WOLL (MB : W → T → Set W) (Q : SortedProperty W T) : SortedProperty W T 
   .temporal λ w t => ∃ t₀ : T, IsLeast (t : Set (WithTop T)) ↑t₀ ∧
     ∀ w' ∈ MB w t₀, At (Interval.Ici t₀) w' Q
 
-/-- A frame adverbial such as *yesterday*: instantiation within the intersection of the
-reference interval with the period named, undefined on properties of times. -/
-def frame (period : Interval (WithTop T)) : SortedProperty W T → Option (SortedProperty W T)
-  | .temporal _ => none
-  | Q => some (.temporal λ w t => At (t ⊓ period) w Q)
+/-- A frame adverbial such as *yesterday*, on a property of eventualities: instantiation within
+the intersection of the reference interval with the period named. The paper leaves it undefined
+on properties of times, which the theorems carry as `IsEventuality`. -/
+def frame (period : Interval (WithTop T)) (Q : SortedProperty W T) : SortedProperty W T :=
+  .temporal λ w t => At (t ⊓ period) w Q
 
 /-- *Already*, *yet* and *still*: the identity on properties of states and of times, undefined
 on properties of events. -/
@@ -94,48 +94,65 @@ def phase : SortedProperty W T → Option (SortedProperty W T)
   | .eventive _ => none
   | Q => some Q
 
-/-- A frame adverbial applies to a property of eventualities. -/
-theorem isEventuality_of_frame {period : Interval (WithTop T)} (hf : frame period Q = some Q') :
-    Q.IsEventuality := by
-  cases Q <;> trivial
-
-/-- Instantiation of the framed property is instantiation within the period. -/
-theorem at_of_frame {period : Interval (WithTop T)} (hf : frame period Q = some Q')
-    (h : At r w Q') : At (r ⊓ period) w Q := by
-  cases Q <;> cases hf <;> exact h
-
-/-! ### The three readings -/
+/-! ### Characterizations -/
 
 variable {MB : W → T → Set W} {now : T}
+
+/-- MAY at a nonempty interval: the base is taken at the interval's start. -/
+theorem at_coe_may_iff {i : NonemptyInterval (WithTop T)} :
+    At ↑i w (MAY MB Q) ↔ ∃ t₀ : T, i.fst = ↑t₀ ∧ ∃ w' ∈ MB w t₀, At (Interval.Ici t₀) w' Q :=
+  exists_congr λ _ => and_congr_left λ _ =>
+    ⟨λ h => (h.unique Interval.isLeast_coe_fst).symm, λ h => h ▸ Interval.isLeast_coe_fst⟩
+
+/-- MAY at the present: some world of the base at the present has the property throughout the
+forward interval. -/
+@[simp] theorem pres_may_iff :
+    PRES now (MAY MB Q) w ↔ ∃ w' ∈ MB w now, At (Interval.Ici now) w' Q := by
+  rw [PRES, Interval.pure, at_coe_may_iff]
+  constructor
+  · rintro ⟨t₀, ht₀, h⟩
+    obtain rfl : t₀ = now := (WithTop.coe_eq_coe.1 ht₀).symm
+    exact h
+  · exact λ h => ⟨now, rfl, h⟩
+
+/-- The perfect of an event at a ray: the event ended before the ray starts. -/
+@[simp] theorem at_Ici_perf_eventive_iff {t : T} :
+    At (Interval.Ici t) w (PERF (.eventive P)) ↔ ∃ e, P w e ∧ e.τ.snd < t := by
+  constructor
+  · rintro ⟨t', ht', e, he, hle⟩
+    exact ⟨e, he, WithTop.coe_lt_coe.1
+      (ht' (Interval.coe_le_iff.1 hle).2 (Interval.mem_Ici.2 le_rfl))⟩
+  · rintro ⟨e, he, h⟩
+    exact ⟨e.τ.withTop, Interval.precedes_withTop_Ici.2 h, e, he, le_rfl⟩
+
+/-- The perfect over MAY at the present: some past time has, in some world of the base at that
+time, the property throughout that time's forward interval. -/
+@[simp] theorem pres_perf_may_iff :
+    PRES now (PERF (MAY MB Q)) w ↔ ∃ t' < now, ∃ w' ∈ MB w t', At (Interval.Ici t') w' Q := by
+  constructor
+  · rintro ⟨i, hi, hat⟩
+    obtain ⟨t', hfst, w', hw', h⟩ := at_coe_may_iff.1 hat
+    refine ⟨t', WithTop.coe_lt_coe.1 (hi ?_ (Interval.mem_pure.2 rfl)), w', hw', h⟩
+    exact hfst ▸ Interval.isLeast_coe_fst.1
+  · rintro ⟨t', ht', w', hw', h⟩
+    exact ⟨(NonemptyInterval.pure t').withTop, Interval.precedes_withTop_pure.2 ht',
+      at_coe_may_iff.2 ⟨t', rfl, w', hw', h⟩⟩
+
+/-! ### The three readings -/
 
 /-- A modal for the present with an eventive predicate, *he might run*: some world of the base
 at the present has the event starting no earlier than the present. Future orientation is
 obligatory. -/
 theorem pres_may_eventive_iff :
     PRES now (MAY MB (.eventive P)) w ↔ ∃ w' ∈ MB w now, ∃ e, P w' e ∧ now ≤ e.τ.fst := by
-  simp only [PRES, MAY, At, Interval.coe_le_iff, NonemptyInterval.fst_withTop,
-    NonemptyInterval.snd_withTop, Interval.mem_Ici, WithTop.coe_le_coe]
-  constructor
-  · rintro ⟨t₀, ht₀, w', hw', e, he, h, -⟩
-    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-    exact ⟨w', hw', e, he, h⟩
-  · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Interval.isLeast_pure, w', hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
+  simp
 
 /-- A modal for the present with a stative predicate, *he might be here*: some world of the base
 at the present has the state persisting at or past the present. The state may have started
 earlier, so future orientation is optional. -/
 theorem pres_may_stative_iff :
     PRES now (MAY MB (.stative P)) w ↔ ∃ w' ∈ MB w now, ∃ e, P w' e ∧ now ≤ e.τ.snd := by
-  simp only [PRES, MAY, At, Interval.not_disjoint_iff, NonemptyInterval.mem_coe_interval,
-    NonemptyInterval.mem_withTop, Interval.mem_Ici]
-  constructor
-  · rintro ⟨t₀, ht₀, w', hw', e, he, x, ⟨-, hx⟩, hx'⟩
-    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-    exact ⟨w', hw', e, he, WithTop.coe_le_coe.1 (le_trans hx' hx)⟩
-  · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Interval.isLeast_pure, w', hw', e, he, ↑e.τ.snd,
-      ⟨WithTop.coe_le_coe.2 e.τ.fst_le_snd, le_rfl⟩, WithTop.coe_le_coe.2 h⟩
+  simp
 
 /-- The modal over the perfect, *he may have won*: some world of the base at the present has
 the event ending before the present. Present perspective, past orientation: the epistemic
@@ -143,15 +160,7 @@ reading. -/
 theorem pres_may_perf_eventive_iff :
     PRES now (MAY MB (PERF (.eventive P))) w ↔
       ∃ w' ∈ MB w now, ∃ e, P w' e ∧ e.τ.snd < now := by
-  simp only [PRES, MAY, PERF, At]
-  constructor
-  · rintro ⟨t₀, ht₀, w', hw', t', ht', e, he, hle⟩
-    obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-    refine ⟨w', hw', e, he, WithTop.coe_lt_coe.1 (ht' ?_ (Interval.mem_Ici.2 le_rfl))⟩
-    exact (Interval.coe_le_iff.1 hle).2
-  · rintro ⟨w', hw', e, he, h⟩
-    exact ⟨now, Interval.isLeast_pure, w', hw', e.τ.withTop,
-      Interval.precedes_withTop_Ici.2 h, e, he, le_rfl⟩
+  simp
 
 /-- The perfect over the modal, *he might have won*: some past time has, in some world of the
 base at that time, the event starting no earlier than it. Past perspective, future
@@ -159,40 +168,31 @@ orientation: the counterfactual reading, Mondadori's future in the past. -/
 theorem pres_perf_may_eventive_iff :
     PRES now (PERF (MAY MB (.eventive P))) w ↔
       ∃ t' < now, ∃ w' ∈ MB w t', ∃ e, P w' e ∧ t' ≤ e.τ.fst := by
-  simp only [PRES, PERF, MAY, At, Interval.coe_le_iff, NonemptyInterval.fst_withTop,
-    NonemptyInterval.snd_withTop, Interval.mem_Ici, WithTop.coe_le_coe]
-  constructor
-  · rintro ⟨t'', ht'', t', ht', w', hw', e, he, h, -⟩
-    refine ⟨t', ?_, w', hw', e, he, h⟩
-    exact WithTop.coe_lt_coe.1 (ht'' ht'.1 (Interval.mem_pure.2 rfl))
-  · rintro ⟨t', ht', w', hw', e, he, h⟩
-    exact ⟨(NonemptyInterval.pure t').withTop,
-      Interval.precedes_coe_coe.2 (WithTop.coe_lt_coe.2 ht'), t', Interval.isLeast_pure, w',
-      hw', e, he, h, le_trans h e.τ.fst_le_snd⟩
+  simp
 
 /-! ### Frame adverbials -/
 
 /-- A modal for the present rejects a period wholly before the present, *he may win
 yesterday*: the forward interval meets it in the null interval. -/
-theorem frame_modal_past {period : Interval (WithTop T)}
-    (hp : period.Precedes (Interval.Ici now)) (hf : frame period Q = some Q') :
-    ¬ PRES now (MAY MB Q') w := by
-  rintro ⟨t₀, ht₀, w', -, h⟩
-  obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-  obtain ⟨x, hx⟩ := exists_mem_of_at (isEventuality_of_frame hf) (at_of_frame hf h)
+theorem frame_modal_past (hQ : Q.IsEventuality) {period : Interval (WithTop T)}
+    (hp : period.Precedes (Interval.Ici now)) : ¬ PRES now (MAY MB (frame period Q)) w := by
+  simp only [pres_may_iff]
+  rintro ⟨w', -, h⟩
+  obtain ⟨x, hx⟩ := exists_mem_of_at hQ h
   simp only [Interval.mem_inf] at hx
   exact lt_irrefl _ (hp hx.2 hx.1)
 
 /-- The modal over the perfect rejects a period lying at or after the present, *he must have
 been available next month* and *it must have been raining now*: the interval the perfect
 supplies precedes the present, and so the period. -/
-theorem frame_modalPerf_nonpast {period : Interval (WithTop T)} (hp : ∀ y ∈ period, ↑now ≤ y)
-    (hf : frame period Q = some Q') : ¬ PRES now (MAY MB (PERF Q')) w := by
-  rintro ⟨t₀, ht₀, w', -, t', ht', h⟩
-  obtain rfl : t₀ = now := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-  obtain ⟨x, hx⟩ := exists_mem_of_at (isEventuality_of_frame hf) (at_of_frame hf h)
+theorem frame_modalPerf_nonpast (hQ : Q.IsEventuality) {period : Interval (WithTop T)}
+    (hp : period ≤ Interval.Ici now) : ¬ PRES now (MAY MB (PERF (frame period Q))) w := by
+  simp only [pres_may_iff]
+  rintro ⟨w', -, t', ht', h⟩
+  obtain ⟨x, hx⟩ := exists_mem_of_at hQ h
   simp only [Interval.mem_inf] at hx
-  exact lt_irrefl _ (lt_of_lt_of_le (ht' hx.1 (Interval.mem_Ici.2 le_rfl)) (hp _ hx.2))
+  exact lt_irrefl _
+    (lt_of_lt_of_le (ht' hx.1 (Interval.mem_Ici.2 le_rfl)) (Interval.le_Ici_iff.1 hp _ hx.2))
 
 /-! ### Live options shrink -/
 
@@ -203,19 +203,16 @@ whose presupposition is a prior negative phase, cannot, *he may already win*; re
 is why *he may win this game* is false once he has lost. -/
 theorem may_antitone {history : HistoricalAlternatives W T}
     (hBC : history.backwardsClosed) (hQ : Q.IsEventuality) :
-    Antitone λ t : T => At (Interval.pure ↑t) w (MAY (metaphysicalBase history) Q) := by
-  rintro t' t h ⟨t₀, ht₀, w', hw', hat⟩
-  obtain rfl : t₀ = t := WithTop.coe_eq_coe.1 (ht₀.unique Interval.isLeast_pure)
-  exact ⟨t', Interval.isLeast_pure, w', metaphysicalBase_antitone hBC w h hw',
-    hat.mono hQ (Interval.antitone_Ici h)⟩
+    Antitone λ t : T => PRES t (MAY (metaphysicalBase history) Q) w := by
+  simp only [pres_may_iff]
+  rintro t' t h ⟨w', hw', hat⟩
+  exact ⟨w', metaphysicalBase_antitone hBC w h hw', hat.mono hQ (Interval.antitone_Ici h)⟩
 
 /-- The prior-phase half of Löbner's presupposition of *already*: a prior negative phase. -/
-def AlreadyPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop :=
-  ∃ t' < now, ¬ At (Interval.pure ↑t') w Q
+def AlreadyPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop := ∃ t' < now, ¬ PRES t' Q w
 
 /-- The prior-phase half of Löbner's presupposition of *still*: a prior positive phase. -/
-def StillPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop :=
-  ∃ t' < now, At (Interval.pure ↑t') w Q
+def StillPresup (Q : SortedProperty W T) (w : W) (now : T) : Prop := ∃ t' < now, PRES t' Q w
 
 /-- *He may already win*: the presupposition of *already* over a metaphysical possibility
 contradicts its assertion. -/
@@ -275,12 +272,9 @@ theorem settled_perf {history : HistoricalAlternatives W T} (h : FixesPast histo
 /-- Instantiation at the present, a stative with *now*, is settled in every common ground: the
 forward interval restricted to the present is the present. -/
 theorem settled_present {history : HistoricalAlternatives W T} (h : FixesPast history Q)
-    (hf : frame (Interval.pure ↑t) Q = some Q') (cg : Set W) :
-    settled history cg t (λ w => At (Interval.Ici t) w Q') := by
-  intro w _ w' hw'
-  cases Q <;> cases hf
-  all_goals
-    exact h t w w' hw' _ λ x hx => (Interval.mem_pure.1 (Interval.mem_inf.1 hx).2).le
+    (cg : Set W) (t : T) :
+    settled history cg t (λ w => At (Interval.Ici t) w (frame (Interval.pure ↑t) Q)) :=
+  λ w _ w' hw' => h t w w' hw' _ λ _ hx => (Interval.mem_pure.1 (Interval.mem_inf.1 hx).2).le
 
 omit [LinearOrder T] in
 /-- A common ground that settles a property fails the diversity condition for the metaphysical
@@ -307,8 +301,7 @@ theorem counterfactual_outside_cg {history : HistoricalAlternatives W T} {cg : S
     (hcf : PRES t₀ (PERF (MAY (metaphysicalBase history) Q)) w)
     (hnow : ∀ t' < t₀, ∀ w' ∈ metaphysicalBase history w t₀, ¬ At (Interval.Ici t') w' Q) :
     ∃ t' < t₀, ∃ w' ∉ cg, w' ∈ metaphysicalBase history w t' ∧ At (Interval.Ici t') w' Q := by
-  obtain ⟨t'', ht'', t', ht', w', hw', hat⟩ := hcf
-  have hlt : t' < t₀ := WithTop.coe_lt_coe.1 (ht'' ht'.1 (Interval.mem_pure.2 rfl))
+  obtain ⟨t', hlt, w', hw', hat⟩ := pres_perf_may_iff.1 hcf
   exact ⟨t', hlt, w', h w hw t' hlt.le w' hw' (λ hmem => hnow t' hlt w' hmem hat), hw', hat⟩
 
 /-! ### Perspective and orientation -/
@@ -379,7 +372,7 @@ def Scope.zones : Scope → Finset Zone
 /-- In the model, the scoping's sentence about a winning on the zone's day, framed by that day
 and uttered on day 0, is true. -/
 def Scope.Sat (s : Scope) (z : Zone) : Prop :=
-  ∃ Q ∈ frame z.period (.eventive (winOn z.day)), PRES 0 (s.lf anyWorld Q) ()
+  PRES 0 (s.lf anyWorld (frame z.period (.eventive (winOn z.day)))) ()
 
 private theorem winOn_at (d : ℤ) {r : Interval (WithTop ℤ)} (h : Interval.pure ↑d ≤ r) :
     At r () (.eventive (winOn d)) :=
@@ -390,37 +383,29 @@ sentence about that period can be true, the deviant cells being `frame_modal_pas
 `frame_modalPerf_nonpast`, the others witnessed. -/
 theorem zones_iff : ∀ s : Scope, ∀ z : Zone, z ∈ s.zones ↔ s.Sat z := by
   intro s z
-  cases s <;> cases z
-  · refine iff_of_false (by decide) ?_
-    rintro ⟨Q, hQ, h⟩
-    refine frame_modal_past ?_ (Option.mem_def.1 hQ) h
-    exact λ x hx y hy => lt_of_le_of_lt (Interval.mem_pure.1 hx).le
-      (lt_of_lt_of_le (WithTop.coe_lt_coe.2 (by decide)) (Interval.mem_Ici.1 hy))
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
-      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
-      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, 0, Interval.isLeast_pure, (), trivial,
+  cases s <;> cases z <;> simp only [Scope.Sat, Scope.lf]
+  · refine iff_of_false (by decide) (frame_modal_past ?_ λ x hx y hy => ?_)
+    · trivial
+    · exact lt_of_le_of_lt (Interval.mem_pure.1 hx).le
+        (lt_of_lt_of_le (WithTop.coe_lt_coe.2 (by decide)) (Interval.mem_Ici.1 hy))
+  · exact iff_of_true (by decide) (pres_may_iff.2 ⟨(), trivial,
+      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩)
+  · exact iff_of_true (by decide) (pres_may_iff.2 ⟨(), trivial,
+      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩)
+  · exact iff_of_true (by decide) (pres_may_iff.2 ⟨(), trivial,
       (NonemptyInterval.pure (-1)).withTop, Interval.precedes_withTop_Ici.2 (by decide),
-      winOn_at (-1) (le_inf le_rfl le_rfl)⟩
-  · refine iff_of_false (by decide) ?_
-    rintro ⟨Q, hQ, h⟩
-    exact frame_modalPerf_nonpast (λ y hy => (Interval.mem_pure.1 hy).ge) (Option.mem_def.1 hQ)
-      h
-  · refine iff_of_false (by decide) ?_
-    rintro ⟨Q, hQ, h⟩
-    refine frame_modalPerf_nonpast (λ y hy => ?_) (Option.mem_def.1 hQ) h
-    rw [Interval.mem_pure.1 hy]
-    exact WithTop.coe_le_coe.2 (by decide)
-  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
-      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
-      winOn_at (-1) (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
-      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
-      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
-  · exact iff_of_true (by decide) ⟨_, rfl, (NonemptyInterval.pure (-1)).withTop,
-      Interval.precedes_coe_coe.2 (by decide), -1, Interval.isLeast_pure, (), trivial,
-      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩
+      winOn_at (-1) (le_inf le_rfl le_rfl)⟩)
+  · refine iff_of_false (by decide) (frame_modalPerf_nonpast ?_ (Interval.pure_le_Ici.2 le_rfl))
+    trivial
+  · refine iff_of_false (by decide)
+      (frame_modalPerf_nonpast ?_ (Interval.pure_le_Ici.2 (by decide)))
+    trivial
+  · exact iff_of_true (by decide) (pres_perf_may_iff.2 ⟨-1, by decide, (), trivial,
+      winOn_at (-1) (le_inf (Interval.pure_le_Ici.2 le_rfl) le_rfl)⟩)
+  · exact iff_of_true (by decide) (pres_perf_may_iff.2 ⟨-1, by decide, (), trivial,
+      winOn_at 0 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩)
+  · exact iff_of_true (by decide) (pres_perf_may_iff.2 ⟨-1, by decide, (), trivial,
+      winOn_at 1 (le_inf (Interval.pure_le_Ici.2 (by decide)) le_rfl)⟩)
 
 /-! ### The rows -/
 

--- a/Linglib/Studies/Kim2024_UPH.lean
+++ b/Linglib/Studies/Kim2024_UPH.lean
@@ -225,7 +225,7 @@ variable {T : Type*} [LinearOrder T]
     per-verb stipulation. -/
 theorem external_predicts_precedence :
     (CausalSource.toLink T .external).temporalConstraint =
-      NonemptyInterval.precedes ∧
+      Interval.Precedes ∧
     (CausalSource.toLink T .external).involvesTransition = true :=
   ⟨rfl, rfl⟩
 
@@ -234,7 +234,7 @@ theorem external_predicts_precedence :
     Cause and effect coexist (maintenance relation). -/
 theorem internal_predicts_overlap :
     (CausalSource.toLink T .internal).temporalConstraint =
-      NonemptyInterval.overlaps ∧
+      (λ s t => ¬ Disjoint s t) ∧
     (CausalSource.toLink T .internal).involvesTransition = false :=
   ⟨rfl, rfl⟩
 
@@ -244,7 +244,7 @@ theorem internal_predicts_overlap :
 theorem frighten_temporal :
     frighten.causalSource = some .external ∧
     (CausalSource.toLink T .external).temporalConstraint =
-      NonemptyInterval.precedes ∧
+      Interval.Precedes ∧
     (CausalSource.toLink T .external).involvesTransition = true :=
   ⟨rfl, rfl, rfl⟩
 
@@ -253,7 +253,7 @@ theorem frighten_temporal :
 theorem concern_temporal :
     concern.causalSource = some .internal ∧
     (CausalSource.toLink T .internal).temporalConstraint =
-      NonemptyInterval.overlaps ∧
+      (λ s t => ¬ Disjoint s t) ∧
     (CausalSource.toLink T .internal).involvesTransition = false :=
   ⟨rfl, rfl, rfl⟩
 
@@ -264,9 +264,9 @@ theorem concern_temporal :
 theorem uph_causal_link_level :
     -- Different temporal behavior
     (CausalSource.toLink T .external).temporalConstraint =
-      NonemptyInterval.precedes ∧
+      Interval.Precedes ∧
     (CausalSource.toLink T .internal).temporalConstraint =
-      NonemptyInterval.overlaps ∧
+      (λ s t => ¬ Disjoint s t) ∧
     -- Different event structure
     (CausalSource.toLink T .external).involvesTransition = true ∧
     (CausalSource.toLink T .internal).involvesTransition = false :=


### PR DESCRIPTION
Characterizes sorted instantiation at rays and points as simp lemmas so Condoravdi2002's readings are one-line simp corollaries.

- `Interval.le_Ici_iff`, `withTop_le_Ici`, `precedes_withTop_pure`, `not_disjoint_withTop_Ici` in Core
- `at_Ici_eventive_iff`/`at_Ici_stative_iff` in Aspect/Instantiation; PsychLink and Kim2024_UPH on `Interval.Precedes`/`Disjoint`
- Condoravdi2002: `pres_may_iff`, `pres_perf_may_iff`, total `frame`, readings by `simp`