### PR TITLE
refactor(Core/Data/Trivalent): retire meetWeak presuppose lemmas

### DIFF
--- a/Linglib/Core/Data/Trivalent.lean
+++ b/Linglib/Core/Data/Trivalent.lean
@@ -477,20 +477,6 @@ theorem meetWeak_assoc (a b c : Trivalent) :
     meetWeak a b = .false ↔ (a = .false ∧ b ≠ .indet) ∨ (a ≠ .indet ∧ b = .false) := by
   cases a <;> cases b <;> decide
 
-/-- A presupposed conjunct makes the Weak Kleene conjunction undefined unless it is true. -/
-theorem meetWeak_presuppose_eq_indet_iff (a b : Trivalent) :
-    meetWeak (presuppose a) b = .indet ↔ a ≠ .true ∨ b = .indet := by simp
-
-/-- The Weak Kleene conjunction with a presupposed conjunct is true iff both are. -/
-theorem meetWeak_presuppose_eq_true_iff (a b : Trivalent) :
-    meetWeak (presuppose a) b = .true ↔ a = .true ∧ b = .true := by simp
-
-/-- The Weak Kleene conjunction with a presupposed conjunct is false iff the presupposition
-holds and the other conjunct is false. -/
-theorem meetWeak_presuppose_eq_false_iff (a b : Trivalent) :
-    meetWeak (presuppose a) b = .false ↔ a = .true ∧ b = .false := by
-  cases a <;> cases b <;> decide
-
 /-- Negation passes through a Weak Kleene conjunction whose first conjunct is never false. -/
 theorem neg_meetWeak_of_ne_false {a : Trivalent} (h : a ≠ .false) (b : Trivalent) :
     neg (meetWeak a b) = meetWeak a (neg b) := by

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -324,13 +324,13 @@ variable (o : Ω)
 /-- A *tycka* report is undefined exactly when its complement is not strongly discretionary
 relative to the state: the subjectivity requirement is a presupposition, (28)–(29). -/
 theorem tycka_eq_indet_iff : tycka ρ R p C o = .indet ↔ ¬ StronglyDiscretionaryOn ρ p C := by
-  simp [tycka, meetWeak_presuppose_eq_indet_iff]
+  simp [tycka]
 
 /-- A *tycka* report is true iff its complement is strongly discretionary and the agent
 accepts it. -/
 theorem tycka_eq_true_iff :
     tycka ρ R p C o = .true ↔ StronglyDiscretionaryOn ρ p C ∧ Accepts R p o := by
-  simp [tycka, meetWeak_presuppose_eq_true_iff]
+  simp [tycka]
 
 /-- *tycka* and *think* agree wherever the former is defined: the verbs differ only in the
 presupposition. -/

--- a/Linglib/Studies/CoppockBeaver2015.lean
+++ b/Linglib/Studies/CoppockBeaver2015.lean
@@ -128,7 +128,8 @@ variable [DecidableRel (Exclusive (E := E))] {P : Prop3 E} {x : E}
 theorem only_eq_true_iff : only P x = .true ↔ P x = .true ∧ Exclusive P x := by simp [only]
 
 theorem only_eq_false_iff : only P x = .false ↔ P x = .true ∧ ∃ y, y ≠ x ∧ P y = .true := by
-  simp only [only, meetWeak_presuppose_eq_false_iff, ofProp_eq_false_iff, not_exclusive_iff]
+  simp only [only, meetWeak_eq_false_iff, presuppose_ne_false, presuppose_eq_indet_iff,
+    ofProp_eq_false_iff, not_exclusive_iff, false_and, false_or, ne_eq, not_not]
 
 /-- *Only* presupposes its prejacent. -/
 theorem only_eq_indet_iff : only P x = .indet ↔ P x ≠ .true := by simp [only]


### PR DESCRIPTION
The three `meetWeak_presuppose_eq_*_iff` lemmas were one-`simp` corollaries of the simp-tagged `meetWeak_eq_*_iff` and `presuppose_eq_*_iff`; their three uses (Coppock2018, CoppockBeaver2015) now go through the general lemmas.