### PR TITLE
refactor(Syntax/Category/Noun): fragments extend one noun record

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2774,6 +2774,7 @@ import Linglib.Syntax.Category.Coordinator
 import Linglib.Syntax.Category.Degree.Basic
 import Linglib.Syntax.Category.Determiner.Basic
 import Linglib.Syntax.Category.ExpressiveModifier
+import Linglib.Syntax.Category.Noun.Basic
 import Linglib.Syntax.Category.Numeral.Basic
 import Linglib.Syntax.Category.Numeral.Composition
 import Linglib.Syntax.Category.Particle.Basic

--- a/Linglib/Fragments/Afar/Gender.lean
+++ b/Linglib/Fragments/Afar/Gender.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Afar noun gender
@@ -26,41 +26,33 @@ inductive Value where
 
 /-- An Afar noun with its gender, whether that gender comes from the referent's sex, and
 whether its citation form ends in an accented vowel. -/
-structure Noun where
-  form : String
-  gloss : String
-  /-- The agreement the noun takes. -/
-  attestedGender : Value
-  /-- Whether the gender comes from the referent's sex. -/
-  isNaturalGender : Bool
+structure Noun extends GenderedNoun Value where
   /-- Whether the citation form ends in an accented vowel. -/
   finalAccentedVowel : Bool
   deriving DecidableEq, Repr
 
-abbrev Noun.gender (n : Noun) : Value := n.attestedGender
-
-def baqla : Noun := ⟨"bàqla", "husband", .masc, true, false⟩
-def barra : Noun := ⟨"barrà", "woman, wife", .fem, true, true⟩
-def baxa : Noun := ⟨"bàxa", "son", .masc, true, false⟩
-def baxa' : Noun := ⟨"baxà", "daughter", .fem, true, true⟩
-def toobokoyta : Noun := ⟨"toobokòyta", "brother", .masc, true, false⟩
-def toobokoyta' : Noun := ⟨"toobokoytà", "sister", .fem, true, true⟩
-def bariseyna : Noun := ⟨"barisèyna", "male teacher", .masc, true, false⟩
-def bariseyna' : Noun := ⟨"bariseynà", "female teacher", .fem, true, true⟩
-def kuta : Noun := ⟨"kùta", "dog", .masc, true, false⟩
-def kuta' : Noun := ⟨"kutà", "bitch", .fem, true, true⟩
-def cato : Noun := ⟨"catò", "help", .fem, false, true⟩
-def karma : Noun := ⟨"karmà", "autumn", .fem, false, true⟩
-def ceder : Noun := ⟨"cedèr", "supper time", .masc, false, false⟩
-def gilal : Noun := ⟨"gilàl", "winter", .masc, false, false⟩
-def tamu : Noun := ⟨"tàmu", "taste", .masc, false, false⟩
-def baanta : Noun := ⟨"baànta", "trumpet", .masc, false, false⟩
+def baqla : Noun := ⟨⟨⟨"bàqla", "husband"⟩, .masc, true⟩, false⟩
+def barra : Noun := ⟨⟨⟨"barrà", "woman, wife"⟩, .fem, true⟩, true⟩
+def baxa : Noun := ⟨⟨⟨"bàxa", "son"⟩, .masc, true⟩, false⟩
+def baxa' : Noun := ⟨⟨⟨"baxà", "daughter"⟩, .fem, true⟩, true⟩
+def toobokoyta : Noun := ⟨⟨⟨"toobokòyta", "brother"⟩, .masc, true⟩, false⟩
+def toobokoyta' : Noun := ⟨⟨⟨"toobokoytà", "sister"⟩, .fem, true⟩, true⟩
+def bariseyna : Noun := ⟨⟨⟨"barisèyna", "male teacher"⟩, .masc, true⟩, false⟩
+def bariseyna' : Noun := ⟨⟨⟨"bariseynà", "female teacher"⟩, .fem, true⟩, true⟩
+def kuta : Noun := ⟨⟨⟨"kùta", "dog"⟩, .masc, true⟩, false⟩
+def kuta' : Noun := ⟨⟨⟨"kutà", "bitch"⟩, .fem, true⟩, true⟩
+def cato : Noun := ⟨⟨⟨"catò", "help"⟩, .fem, false⟩, true⟩
+def karma : Noun := ⟨⟨⟨"karmà", "autumn"⟩, .fem, false⟩, true⟩
+def ceder : Noun := ⟨⟨⟨"cedèr", "supper time"⟩, .masc, false⟩, false⟩
+def gilal : Noun := ⟨⟨⟨"gilàl", "winter"⟩, .masc, false⟩, false⟩
+def tamu : Noun := ⟨⟨⟨"tàmu", "taste"⟩, .masc, false⟩, false⟩
+def baanta : Noun := ⟨⟨⟨"baànta", "trumpet"⟩, .masc, false⟩, false⟩
 /-- *doònik* 'sail-boat': feminine against the accent rule. -/
-def doonik : Noun := ⟨"doònik", "sail-boat", .fem, false, false⟩
+def doonik : Noun := ⟨⟨⟨"doònik", "sail-boat"⟩, .fem, false⟩, false⟩
 /-- *abbà* 'father': masculine by sex against the accent rule. -/
-def abba : Noun := ⟨"abbà", "father", .masc, true, true⟩
+def abba : Noun := ⟨⟨⟨"abbà", "father"⟩, .masc, true⟩, true⟩
 /-- *gabbixeèra* 'slender-waisted female': feminine by sex against the accent rule. -/
-def gabbixeera : Noun := ⟨"gabbixeèra", "slender-waisted female", .fem, true, false⟩
+def gabbixeera : Noun := ⟨⟨⟨"gabbixeèra", "slender-waisted female"⟩, .fem, true⟩, false⟩
 
 def allNouns : List Noun :=
   [baqla, barra, baxa, baxa', toobokoyta, toobokoyta', bariseyna, bariseyna', kuta, kuta', cato,

--- a/Linglib/Fragments/Chichewa/Gender.lean
+++ b/Linglib/Fragments/Chichewa/Gender.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Chichewa noun gender
@@ -42,33 +42,25 @@ def Value.plSubjPrefix : Value → SubjPrefix
   | .g1_2 | .g5_6 => .a
   | .g7_8 => .zi
 
-/-- A plural noun with its gender and whether it denotes humans. -/
-structure Noun where
-  /-- The plural form, with its class prefix. -/
-  form : String
-  /-- The gloss. -/
-  gloss : String
-  /-- The agreement the noun takes. -/
-  attestedGender : Value
+/-- A plural noun, its form carrying its class prefix, with its gender and whether it
+denotes humans. -/
+structure Noun extends GenderedNoun Value where
   /-- Whether the noun denotes humans. -/
   human : Bool
   deriving DecidableEq, Repr
 
-/-- The gender the noun controls. -/
-abbrev Noun.gender (n : Noun) : Value := n.attestedGender
-
 /-- *a-mphaka* 'cats': gender 1/2 without denoting humans. -/
-def mphaka : Noun := ⟨"a-mphaka", "cats", .g1_2, false⟩
+def mphaka : Noun := { form := "a-mphaka", gloss := "cats", gender := .g1_2, human := false }
 /-- *a-galu* 'dogs'. -/
-def galu : Noun := ⟨"a-galu", "dogs", .g1_2, false⟩
+def galu : Noun := { form := "a-galu", gloss := "dogs", gender := .g1_2, human := false }
 /-- *a-na* 'children'. -/
-def ana : Noun := ⟨"a-na", "children", .g1_2, true⟩
+def ana : Noun := { form := "a-na", gloss := "children", gender := .g1_2, human := true }
 /-- *ma-lalanje* 'oranges'. -/
-def lalanje : Noun := ⟨"ma-lalanje", "oranges", .g5_6, false⟩
+def lalanje : Noun := { form := "ma-lalanje", gloss := "oranges", gender := .g5_6, human := false }
 /-- *ma-samba* 'leaves'. -/
-def samba : Noun := ⟨"ma-samba", "leaves", .g5_6, false⟩
+def samba : Noun := { form := "ma-samba", gloss := "leaves", gender := .g5_6, human := false }
 /-- *zipewa* 'hats'. -/
-def zipewa : Noun := ⟨"zipewa", "hats", .g7_8, false⟩
+def zipewa : Noun := { form := "zipewa", gloss := "hats", gender := .g7_8, human := false }
 
 /-- The nouns the sources cite. -/
 def allNouns : List Noun := [mphaka, galu, ana, lalanje, samba, zipewa]

--- a/Linglib/Fragments/Greek/StandardModern/Gender.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Modern Greek nouns by gender and humanness
@@ -15,41 +15,63 @@ whether they denote humans: conceptually gendered humans, fixed-gender humans su
 namespace Greek.StandardModern.Gender
 
 /-- A noun with its grammatical gender and whether it denotes a human. -/
-structure Noun where
-  form : String
-  gloss : String
-  gender : _root_.Gender
+structure Noun extends GenderedNoun _root_.Gender where
+  /-- Whether the noun denotes a human; the natural-gender flag marks the humans whose gender
+  is not fixed. -/
   human : Bool
   deriving DecidableEq, Repr
 
-def andras : Noun := ⟨"andras", "man", .masculine, true⟩
-def gineka : Noun := ⟨"gineka", "woman", .feminine, true⟩
-def petros : Noun := ⟨"Petros", "Petros", .masculine, true⟩
-def maria : Noun := ⟨"Maria", "Maria", .feminine, true⟩
-def kleftis : Noun := ⟨"kleftis", "thief", .masculine, true⟩
-def giorgos : Noun := ⟨"Giorgos", "Giorgos", .masculine, true⟩
-def adherfi : Noun := ⟨"adherfi", "sister", .feminine, true⟩
-def mitera : Noun := ⟨"mitera", "mother", .feminine, true⟩
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
+
+def andras : Noun :=
+  { form := "andras", gloss := "man", gender := .masculine, isNaturalGender := true, human := true }
+def gineka : Noun :=
+  { form := "gineka", gloss := "woman", gender := .feminine,
+    isNaturalGender := true, human := true }
+def petros : Noun :=
+  { form := "Petros", gloss := "Petros", gender := .masculine,
+    isNaturalGender := true, human := true }
+def maria : Noun :=
+  { form := "Maria", gloss := "Maria", gender := .feminine, isNaturalGender := true, human := true }
+def kleftis : Noun :=
+  { form := "kleftis", gloss := "thief", gender := .masculine,
+    isNaturalGender := true, human := true }
+def giorgos : Noun :=
+  { form := "Giorgos", gloss := "Giorgos", gender := .masculine,
+    isNaturalGender := true, human := true }
+def adherfi : Noun :=
+  { form := "adherfi", gloss := "sister", gender := .feminine,
+    isNaturalGender := true, human := true }
+def mitera : Noun :=
+  { form := "mitera", gloss := "mother", gender := .feminine,
+    isNaturalGender := true, human := true }
 /-- Fixed-gender human: feminine whatever the referent. -/
-def megalofiia : Noun := ⟨"megalofiia", "genius", .feminine, true⟩
+def megalofiia : Noun :=
+  { form := "megalofiia", gloss := "genius", gender := .feminine, human := true }
 /-- Fixed-gender human: neuter whatever the referent. -/
-def thima : Noun := ⟨"thima", "victim", .neuter, true⟩
-def koritsi : Noun := ⟨"koritsi", "girl", .neuter, true⟩
-def pinakas : Noun := ⟨"pinakas", "blackboard, painting", .masculine, false⟩
-def karekla : Noun := ⟨"karekla", "chair", .feminine, false⟩
-def piruni : Noun := ⟨"piruni", "fork", .neuter, false⟩
-def kutali : Noun := ⟨"kutali", "spoon", .neuter, false⟩
-def fusta : Noun := ⟨"fusta", "skirt", .feminine, false⟩
-def bluza : Noun := ⟨"bluza", "T-shirt", .feminine, false⟩
-def anaptiras : Noun := ⟨"anaptiras", "lighter", .masculine, false⟩
-def fakos : Noun := ⟨"fakos", "torch", .masculine, false⟩
-def scholio : Noun := ⟨"scholio", "school", .neuter, false⟩
-def ekklisia : Noun := ⟨"ekklisia", "church", .feminine, false⟩
-def balkoni : Noun := ⟨"balkoni", "balcony", .neuter, false⟩
-def dhiadhromos : Noun := ⟨"dhiadhromos", "corridor", .masculine, false⟩
-def daxtilidi : Noun := ⟨"daxtilidi", "ring", .neuter, false⟩
-def ombrela : Noun := ⟨"ombrela", "umbrella", .feminine, false⟩
-def fotografia : Noun := ⟨"fotografia", "picture", .feminine, false⟩
-def pukamiso : Noun := ⟨"pukamiso", "shirt", .neuter, false⟩
+def thima : Noun := { form := "thima", gloss := "victim", gender := .neuter, human := true }
+def koritsi : Noun := { form := "koritsi", gloss := "girl", gender := .neuter, human := true }
+def pinakas : Noun :=
+  { form := "pinakas", gloss := "blackboard, painting", gender := .masculine, human := false }
+def karekla : Noun := { form := "karekla", gloss := "chair", gender := .feminine, human := false }
+def piruni : Noun := { form := "piruni", gloss := "fork", gender := .neuter, human := false }
+def kutali : Noun := { form := "kutali", gloss := "spoon", gender := .neuter, human := false }
+def fusta : Noun := { form := "fusta", gloss := "skirt", gender := .feminine, human := false }
+def bluza : Noun := { form := "bluza", gloss := "T-shirt", gender := .feminine, human := false }
+def anaptiras : Noun :=
+  { form := "anaptiras", gloss := "lighter", gender := .masculine, human := false }
+def fakos : Noun := { form := "fakos", gloss := "torch", gender := .masculine, human := false }
+def scholio : Noun := { form := "scholio", gloss := "school", gender := .neuter, human := false }
+def ekklisia : Noun :=
+  { form := "ekklisia", gloss := "church", gender := .feminine, human := false }
+def balkoni : Noun := { form := "balkoni", gloss := "balcony", gender := .neuter, human := false }
+def dhiadhromos : Noun :=
+  { form := "dhiadhromos", gloss := "corridor", gender := .masculine, human := false }
+def daxtilidi : Noun := { form := "daxtilidi", gloss := "ring", gender := .neuter, human := false }
+def ombrela : Noun :=
+  { form := "ombrela", gloss := "umbrella", gender := .feminine, human := false }
+def fotografia : Noun :=
+  { form := "fotografia", gloss := "picture", gender := .feminine, human := false }
+def pukamiso : Noun := { form := "pukamiso", gloss := "shirt", gender := .neuter, human := false }
 
 end Greek.StandardModern.Gender

--- a/Linglib/Fragments/Hausa/Gender.lean
+++ b/Linglib/Fragments/Hausa/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Hausa Gender Fragment
@@ -10,9 +10,9 @@ correlate of feminine gender.
 
 ## Theory-neutral data layer
 
-The Fragment commits to two empirical fields per entry:
+Each entry is a `GenderedNoun` with two empirical fields:
 
-- `attestedGender : Gender` — the agreement-trigger fact
+- `gender : Gender` — the agreement-trigger fact
   (which gender determiners, possessive linkers, TAM clitics, and
   pronouns realize when referring to this noun). Verified against
   [newman-2000] Ch. 31 (pp. 201–215).
@@ -58,29 +58,12 @@ fields; Hausa is the pilot for theory-neutral Fragment-layer encoding.
 namespace Hausa
 
 
-/-- A Hausa noun: surface form, gloss, and two empirical gender fields.
-    No commitment to any specific theoretical framework — the DM
-    categorizer head, Corbett's controller-target classification, etc.
-    are projections that live in `Studies/`. -/
-structure Noun where
-  form : String
-  gloss : String
-  /-- The agreement-trigger fact: what gender does this noun realize
-      on agreeing elements (determiners, pronouns, TAM clitics)?
-      Verified against [newman-2000] Ch. 31. -/
-  attestedGender : Gender
-  /-- True iff the gender is semantically motivated by the referent's
-      biological sex (humans, sex-paired animals like *kāzā/zàkarā*).
-      False for inanimates and unsexed animals. -/
-  isNaturalGender : Bool
-  deriving DecidableEq, Repr
+/-- A Hausa noun: its gender, the agreement it takes on determiners, pronouns and TAM
+    clitics ([newman-2000] Ch. 31), and whether that gender follows the referent's sex
+    (humans, sex-paired animals like *kāzā/zàkarā*). -/
+abbrev Noun := GenderedNoun Gender
 
 namespace Noun
-
-/-- The noun's surface gender — the agreement-trigger fact stored
-    directly in the entry. Alias for `attestedGender` to make
-    `n.gender` read naturally at consumer sites. -/
-abbrev gender (n : Noun) : Gender := n.attestedGender
 
 /-- The *-ā* suffix diagnostic. Tone-tolerant: a trailing combining
     diacritic (e.g. low-tone grave on *kadā̀*) does not block the match,
@@ -102,36 +85,36 @@ end Noun
 -- ƙ = ejective velar). Each entry is verified against Newman's gender
 -- lists on pp. 201, 208–209, 213.
 
-def yarinya  : Noun := ⟨"yārinyā", "girl",     .feminine,  true⟩
+def yarinya : Noun := ⟨⟨"yārinyā", "girl"⟩, .feminine, true⟩
 /-- *mācè* 'woman' — feminine despite NOT ending in *-ā*.
     [newman-2000] p. 208 footnote [i] explicitly flags *mācè* as
     the canonical exception: feminine but ends in -è. Newman: *mācè*
     is historically a derived form ('female') from *mātā* 'woman/wife'
     that lost -ā; only later became a common noun. -/
-def mace     : Noun := ⟨"mācè",    "woman",    .feminine,  true⟩
+def mace : Noun := ⟨⟨"mācè", "woman"⟩, .feminine, true⟩
 /-- *kāzā* 'hen' — natural feminine. [newman-2000] p. 201 lists
     *kāzā* in the natural-gender feminine pair with *zàkarā* 'rooster'.
     Sex distinction is lexicalized (separate words for hen/rooster), so
     natural per Newman + per Kramer's "honoris causa" criterion
     ([kramer-2020] p. 57). -/
-def kaza     : Noun := ⟨"kāzā",    "hen",      .feminine,  true⟩
-def riga     : Noun := ⟨"rīgā",    "gown",     .feminine,  false⟩
-def yaro     : Noun := ⟨"yārō",    "boy",      .masculine, true⟩
-def mutum    : Noun := ⟨"mùtûm",   "man",      .masculine, true⟩
-def littafi  : Noun := ⟨"littāfī", "book",     .masculine, false⟩
+def kaza : Noun := ⟨⟨"kāzā", "hen"⟩, .feminine, true⟩
+def riga : Noun := ⟨⟨"rīgā", "gown"⟩, .feminine, false⟩
+def yaro : Noun := ⟨⟨"yārō", "boy"⟩, .masculine, true⟩
+def mutum : Noun := ⟨⟨"mùtûm", "man"⟩, .masculine, true⟩
+def littafi : Noun := ⟨⟨"littāfī", "book"⟩, .masculine, false⟩
 /-- *gidā* 'house' — masculine despite ending in *-ā*.
     [newman-2000] p. 209 class (c) "Erstwhile plurals" (alongside
     *karā* 'cornstalk', *ƙudā* 'housefly', *ruwā* 'water'): historically
     plural forms now used as singulars. Distinct historical class from
     the native ā-final masculines (kadā, ubā, zàkarā). -/
-def gida     : Noun := ⟨"gidā",    "house",    .masculine, false⟩
-def kasaLand : Noun := ⟨"ƙasā",    "land",     .feminine,  false⟩
-def rana     : Noun := ⟨"rānā",    "sun/day",  .feminine,  false⟩
+def gida : Noun := ⟨⟨"gidā", "house"⟩, .masculine, false⟩
+def kasaLand : Noun := ⟨⟨"ƙasā", "land"⟩, .feminine, false⟩
+def rana : Noun := ⟨⟨"rānā", "sun/day"⟩, .feminine, false⟩
 /-- *kadā̀* 'crocodile' — masculine despite ending in *-ā*.
     [newman-2000] p. 209 class (a) "Native" ā-final masculines.
     [kramer-2020] ex. 22e (p. 55) cites this from Newman as the
     canonical counterexample to phonological assignment. -/
-def kada     : Noun := ⟨"kadā̀",   "crocodile", .masculine, false⟩
+def kada : Noun := ⟨⟨"kadā̀", "crocodile"⟩, .masculine, false⟩
 /-- *ùbā* 'father' — natural masculine ending in *-ā*.
     [newman-2000] p. 209 class (a) "Native" ā-final masculines.
     [kramer-2015] Ch. 1 cites this as one of two introductory
@@ -140,7 +123,7 @@ def kada     : Noun := ⟨"kadā̀",   "crocodile", .masculine, false⟩
     AND a masculine -ā witness — refutes phonological assignment from a
     different angle than *kadā̀* (which is non-natural): even
     semantically male-denoting nouns in Hausa can end in -ā. -/
-def uba      : Noun := ⟨"ùbā",     "father",   .masculine, true⟩
+def uba : Noun := ⟨⟨"ùbā", "father"⟩, .masculine, true⟩
 
 def allNouns : List Noun :=
   [yarinya, mace, kaza, riga, yaro, mutum, littafi, gida,

--- a/Linglib/Fragments/Icelandic/Gender.lean
+++ b/Linglib/Fragments/Icelandic/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Icelandic nouns by gender and humanness
@@ -14,22 +14,26 @@ and whether they denote humans, including the fixed-gender neuter *skáld* 'poet
 namespace Icelandic.Gender
 
 /-- A noun with its grammatical gender and whether it denotes a human. -/
-structure Noun where
-  form : String
-  gloss : String
-  gender : _root_.Gender
+structure Noun extends GenderedNoun _root_.Gender where
+  /-- Whether the noun denotes a human; the natural-gender flag marks the humans whose gender
+  is not fixed. -/
   human : Bool
   deriving DecidableEq, Repr
 
-def madur : Noun := ⟨"maður", "man", .masculine, true⟩
-def kona : Noun := ⟨"kona", "woman", .feminine, true⟩
-def jon : Noun := ⟨"Jón", "Jón", .masculine, true⟩
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
+
+def madur : Noun :=
+  { form := "maður", gloss := "man", gender := .masculine, isNaturalGender := true, human := true }
+def kona : Noun :=
+  { form := "kona", gloss := "woman", gender := .feminine, isNaturalGender := true, human := true }
+def jon : Noun :=
+  { form := "Jón", gloss := "Jón", gender := .masculine, isNaturalGender := true, human := true }
 /-- Fixed-gender human: neuter whatever the referent. -/
-def skald : Noun := ⟨"skáld", "poet", .neuter, true⟩
-def fraegd : Noun := ⟨"frægð", "fame", .feminine, false⟩
-def frami : Noun := ⟨"frami", "success", .masculine, false⟩
-def skeid : Noun := ⟨"skeið", "spoon", .feminine, false⟩
-def stoll : Noun := ⟨"stóll", "chair", .masculine, false⟩
-def epli : Noun := ⟨"epli", "apple", .neuter, false⟩
+def skald : Noun := { form := "skáld", gloss := "poet", gender := .neuter, human := true }
+def fraegd : Noun := { form := "frægð", gloss := "fame", gender := .feminine, human := false }
+def frami : Noun := { form := "frami", gloss := "success", gender := .masculine, human := false }
+def skeid : Noun := { form := "skeið", gloss := "spoon", gender := .feminine, human := false }
+def stoll : Noun := { form := "stóll", gloss := "chair", gender := .masculine, human := false }
+def epli : Noun := { form := "epli", gloss := "apple", gender := .neuter, human := false }
 
 end Icelandic.Gender

--- a/Linglib/Fragments/Italian/NumberGender.lean
+++ b/Linglib/Fragments/Italian/NumberGender.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 import Linglib.Syntax.Category.Classifier.Basic
 
 /-!
@@ -21,46 +21,49 @@ inductive PluralClass where
   | regular
   deriving DecidableEq, Repr, Fintype
 
-/-- A noun with its singular and plural forms and genders. -/
-structure Noun where
-  formSg : String
+/-- A noun with its singular form and gender, its plural form and gender, and its plural
+class. -/
+structure Noun extends GenderedNoun Gender where
+  /-- The plural form. -/
   formPl : String
-  gloss : String
-  sgGender : Gender
+  /-- The gender of the plural. -/
   plGender : Gender
+  /-- The plural class. -/
   pluralClass : PluralClass
   deriving DecidableEq, Repr
 
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
+
 /-- The *-a* plurals. -/
 def aPlurals : List Noun :=
-  [⟨"braccio", "braccia", "arm", .masculine, .feminine, .aPlural⟩,
-    ⟨"budello", "budella", "intestine", .masculine, .feminine, .aPlural⟩,
-    ⟨"cervello", "cervella", "brain", .masculine, .feminine, .aPlural⟩,
-    ⟨"ciglio", "ciglia", "eyelash", .masculine, .feminine, .aPlural⟩,
-    ⟨"corno", "corna", "horn", .masculine, .feminine, .aPlural⟩,
-    ⟨"dito", "dita", "finger", .masculine, .feminine, .aPlural⟩,
-    ⟨"fondamento", "fondamenta", "foundation", .masculine, .feminine, .aPlural⟩,
-    ⟨"ginocchio", "ginocchia", "knee", .masculine, .feminine, .aPlural⟩,
-    ⟨"grido", "grida", "shout", .masculine, .feminine, .aPlural⟩,
-    ⟨"labbro", "labbra", "lip", .masculine, .feminine, .aPlural⟩,
-    ⟨"lenzuolo", "lenzuola", "sheet", .masculine, .feminine, .aPlural⟩,
-    ⟨"membro", "membra", "limb", .masculine, .feminine, .aPlural⟩,
-    ⟨"miglio", "miglia", "mile", .masculine, .feminine, .aPlural⟩,
-    ⟨"muro", "mura", "wall", .masculine, .feminine, .aPlural⟩,
-    ⟨"osso", "ossa", "bone", .masculine, .feminine, .aPlural⟩,
-    ⟨"paio", "paia", "pair", .masculine, .feminine, .aPlural⟩,
-    ⟨"riso", "risa", "laugh", .masculine, .feminine, .aPlural⟩,
-    ⟨"sopracciglio", "sopracciglia", "eyebrow", .masculine, .feminine, .aPlural⟩,
-    ⟨"strido", "strida", "shriek", .masculine, .feminine, .aPlural⟩,
-    ⟨"uovo", "uova", "egg", .masculine, .feminine, .aPlural⟩,
-    ⟨"urlo", "urla", "howl", .masculine, .feminine, .aPlural⟩]
+  [⟨⟨⟨"braccio", "arm"⟩, .masculine, false⟩, "braccia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"budello", "intestine"⟩, .masculine, false⟩, "budella", .feminine, .aPlural⟩,
+    ⟨⟨⟨"cervello", "brain"⟩, .masculine, false⟩, "cervella", .feminine, .aPlural⟩,
+    ⟨⟨⟨"ciglio", "eyelash"⟩, .masculine, false⟩, "ciglia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"corno", "horn"⟩, .masculine, false⟩, "corna", .feminine, .aPlural⟩,
+    ⟨⟨⟨"dito", "finger"⟩, .masculine, false⟩, "dita", .feminine, .aPlural⟩,
+    ⟨⟨⟨"fondamento", "foundation"⟩, .masculine, false⟩, "fondamenta", .feminine, .aPlural⟩,
+    ⟨⟨⟨"ginocchio", "knee"⟩, .masculine, false⟩, "ginocchia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"grido", "shout"⟩, .masculine, false⟩, "grida", .feminine, .aPlural⟩,
+    ⟨⟨⟨"labbro", "lip"⟩, .masculine, false⟩, "labbra", .feminine, .aPlural⟩,
+    ⟨⟨⟨"lenzuolo", "sheet"⟩, .masculine, false⟩, "lenzuola", .feminine, .aPlural⟩,
+    ⟨⟨⟨"membro", "limb"⟩, .masculine, false⟩, "membra", .feminine, .aPlural⟩,
+    ⟨⟨⟨"miglio", "mile"⟩, .masculine, false⟩, "miglia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"muro", "wall"⟩, .masculine, false⟩, "mura", .feminine, .aPlural⟩,
+    ⟨⟨⟨"osso", "bone"⟩, .masculine, false⟩, "ossa", .feminine, .aPlural⟩,
+    ⟨⟨⟨"paio", "pair"⟩, .masculine, false⟩, "paia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"riso", "laugh"⟩, .masculine, false⟩, "risa", .feminine, .aPlural⟩,
+    ⟨⟨⟨"sopracciglio", "eyebrow"⟩, .masculine, false⟩, "sopracciglia", .feminine, .aPlural⟩,
+    ⟨⟨⟨"strido", "shriek"⟩, .masculine, false⟩, "strida", .feminine, .aPlural⟩,
+    ⟨⟨⟨"uovo", "egg"⟩, .masculine, false⟩, "uova", .feminine, .aPlural⟩,
+    ⟨⟨⟨"urlo", "howl"⟩, .masculine, false⟩, "urla", .feminine, .aPlural⟩]
 
 /-- Regular plurals. -/
 def regulars : List Noun :=
-  [⟨"libro", "libri", "book", .masculine, .masculine, .regular⟩,
-    ⟨"ragazzo", "ragazzi", "boy", .masculine, .masculine, .regular⟩,
-    ⟨"casa", "case", "house", .feminine, .feminine, .regular⟩,
-    ⟨"ragazza", "ragazze", "girl", .feminine, .feminine, .regular⟩]
+  [⟨⟨⟨"libro", "book"⟩, .masculine, false⟩, "libri", .masculine, .regular⟩,
+    ⟨⟨⟨"ragazzo", "boy"⟩, .masculine, true⟩, "ragazzi", .masculine, .regular⟩,
+    ⟨⟨⟨"casa", "house"⟩, .feminine, false⟩, "case", .feminine, .regular⟩,
+    ⟨⟨⟨"ragazza", "girl"⟩, .feminine, true⟩, "ragazze", .feminine, .regular⟩]
 
 end Italian.NumberGender
 

--- a/Linglib/Fragments/Romanian/Gender.lean
+++ b/Linglib/Fragments/Romanian/Gender.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Romanian noun gender
@@ -27,31 +27,23 @@ inductive Value where
 
 /-- A Romanian noun with its controller gender and whether it denotes an animate, and if so
 whether its gender comes from the referent's sex. -/
-structure Noun where
-  form : String
-  gloss : String
-  /-- The agreement the noun takes. -/
-  attestedGender : Value
+structure Noun extends GenderedNoun Value where
   /-- Whether the noun denotes an animate. -/
   animate : Bool
-  /-- Whether the gender comes from the referent's sex. -/
-  isNaturalGender : Bool
   deriving DecidableEq, Repr
 
-abbrev Noun.gender (n : Noun) : Value := n.attestedGender
-
-def barbat : Noun := ⟨"bărbat", "man", .masc, true, true⟩
-def fata : Noun := ⟨"fată", "girl", .fem, true, true⟩
-def scaun : Noun := ⟨"scaun", "chair", .neut, false, false⟩
-def femeie : Noun := ⟨"femeie", "woman", .fem, true, true⟩
-def baiat : Noun := ⟨"băiat", "boy", .masc, true, true⟩
-def usa : Noun := ⟨"uşă", "door", .fem, false, false⟩
-def perete : Noun := ⟨"perete", "wall", .masc, false, false⟩
-def masa : Noun := ⟨"masă", "table", .fem, false, false⟩
-def nuc : Noun := ⟨"nuc", "walnut tree", .masc, false, false⟩
-def prun : Noun := ⟨"prun", "plum tree", .masc, false, false⟩
-def frigider : Noun := ⟨"frigider", "refrigerator", .neut, false, false⟩
-def televizor : Noun := ⟨"televizor", "television", .neut, false, false⟩
+def barbat : Noun := ⟨⟨⟨"bărbat", "man"⟩, .masc, true⟩, true⟩
+def fata : Noun := ⟨⟨⟨"fată", "girl"⟩, .fem, true⟩, true⟩
+def scaun : Noun := ⟨⟨⟨"scaun", "chair"⟩, .neut, false⟩, false⟩
+def femeie : Noun := ⟨⟨⟨"femeie", "woman"⟩, .fem, true⟩, true⟩
+def baiat : Noun := ⟨⟨⟨"băiat", "boy"⟩, .masc, true⟩, true⟩
+def usa : Noun := ⟨⟨⟨"uşă", "door"⟩, .fem, false⟩, false⟩
+def perete : Noun := ⟨⟨⟨"perete", "wall"⟩, .masc, false⟩, false⟩
+def masa : Noun := ⟨⟨⟨"masă", "table"⟩, .fem, false⟩, false⟩
+def nuc : Noun := ⟨⟨⟨"nuc", "walnut tree"⟩, .masc, false⟩, false⟩
+def prun : Noun := ⟨⟨⟨"prun", "plum tree"⟩, .masc, false⟩, false⟩
+def frigider : Noun := ⟨⟨⟨"frigider", "refrigerator"⟩, .neut, false⟩, false⟩
+def televizor : Noun := ⟨⟨⟨"televizor", "television"⟩, .neut, false⟩, false⟩
 
 def allNouns : List Noun :=
   [barbat, fata, scaun, femeie, baiat, usa, perete, masa, nuc, prun, frigider, televizor]

--- a/Linglib/Fragments/Slavic/Russian/Gender.lean
+++ b/Linglib/Fragments/Slavic/Russian/Gender.lean
@@ -1,4 +1,5 @@
-import Linglib.Features.Gender.Basic
+import Mathlib.Tactic.DeriveFintype
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Russian Noun Gender
@@ -10,11 +11,11 @@ and partly by morphological declension class.
 
 ## Theory-neutral data layer
 
-The Fragment carries empirical fields per entry:
+Each entry is a `GenderedNoun` over the three controller genders, with a
+declension class besides:
 
-- `attestedGender : Gender` — the agreement-trigger fact
-  (verified against [wade-2020]). Three values for Russian:
-  masculine, feminine, neuter.
+- `gender : Value` — the agreement-trigger fact (verified against
+  [wade-2020]).
 - `isNaturalGender : Bool` — whether the gender comes from the
   referent's biological sex.
 - `declClass : Option DeclClass` — Russian-specific morphological
@@ -47,10 +48,25 @@ Class III neuter group.
 
 namespace Russian.Gender
 
+-- ============================================================================
+-- § 1: Genders and Declension Classes ([wade-2020])
+-- ============================================================================
 
--- ============================================================================
--- § 1: Declension Classes ([wade-2020])
--- ============================================================================
+/-- Russian's three controller genders — the carrier of its
+    `Gender.System` ([corbett-1991]; [kramer-2015] ch. 7). -/
+inductive Value where
+  | masc
+  | fem
+  | neut
+  deriving DecidableEq, Repr, Fintype
+
+/-- The comparative label of each gender. -/
+def Value.toLabel : Value → Gender
+  | .masc => .masculine
+  | .fem => .feminine
+  | .neut => .neuter
+
+instance : HasGender Value := ⟨λ g => genderOf g.toLabel⟩
 
 /-- Russian declension classes. Gender correlates with class but neither
     fully determines the other ([corbett-1991];
@@ -66,69 +82,46 @@ inductive DeclClass where
 -- § 2: Russian Noun (theory-neutral schema)
 -- ============================================================================
 
-/-- A Russian noun. Empirical agreement-gender + natural-gender +
-    optional declension class. No commitment to any specific theoretical
-    framework — Kramer's DM categorizing head, Corbett's controller-target
-    are projections in `Studies/`. -/
-structure RussianNoun where
-  form : String
-  gloss : String
-  /-- Empirical agreement-trigger fact ([wade-2020]). -/
-  attestedGender : Gender
-  /-- True iff the gender comes from biological sex of the referent.
-      For *vrač* 'doctor' (hybrid) the morphological gender is encoded
-      here as masculine; the hybrid female-referent agreement is the
-      datum `Kramer2020.hybridTargets`. -/
-  isNaturalGender : Bool
+/-- A Russian noun: its gender, whether that gender comes from the
+    referent's sex, and its declension class. No commitment to any
+    specific theoretical framework — Kramer's DM categorizing head and
+    Corbett's controller-target classification are projections in
+    `Studies/`. For *vrač* 'doctor' (hybrid) the morphological gender is
+    encoded; the hybrid female-referent agreement is the datum
+    `Kramer2020.hybridTargets`. -/
+structure Noun extends GenderedNoun Value where
   /-- Optional declension class. Semantic-core nouns may omit since
       their gender is determined by the referent. -/
   declClass : Option DeclClass := none
   deriving DecidableEq, Repr
 
-namespace RussianNoun
-
-abbrev gender (n : RussianNoun) : Gender := n.attestedGender
-
-end RussianNoun
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
 
 -- ============================================================================
 -- § 3: Semantic Core ([kramer-2020] ex. 17)
 -- ============================================================================
 
-def otec   : RussianNoun :=
-  { form := "otec",   gloss := "father",  attestedGender := .masculine, isNaturalGender := true }
-def mat'   : RussianNoun :=
-  { form := "mat'",   gloss := "mother",  attestedGender := .feminine,  isNaturalGender := true }
-def brat   : RussianNoun :=
-  { form := "brat",   gloss := "brother", attestedGender := .masculine, isNaturalGender := true }
-def sestra : RussianNoun :=
-  { form := "sestra", gloss := "sister",  attestedGender := .feminine,  isNaturalGender := true }
-def byk    : RussianNoun :=
-  { form := "byk",    gloss := "bull",    attestedGender := .masculine, isNaturalGender := true }
-def korova : RussianNoun :=
-  { form := "korova", gloss := "cow",     attestedGender := .feminine,  isNaturalGender := true }
+def otec : Noun := { form := "otec", gloss := "father", gender := .masc, isNaturalGender := true }
+def mat' : Noun := { form := "mat'", gloss := "mother", gender := .fem, isNaturalGender := true }
+def brat : Noun := { form := "brat", gloss := "brother", gender := .masc, isNaturalGender := true }
+def sestra : Noun :=
+  { form := "sestra", gloss := "sister", gender := .fem, isNaturalGender := true }
+def byk : Noun := { form := "byk", gloss := "bull", gender := .masc, isNaturalGender := true }
+def korova : Noun := { form := "korova", gloss := "cow", gender := .fem, isNaturalGender := true }
 /-- *djadja* 'uncle': declension II like most feminines, masculine by sex ([wade-2020];
     [corbett-1991]). -/
-def djadja : RussianNoun :=
-  { form := "djadja", gloss := "uncle", attestedGender := .masculine, isNaturalGender := true
+def djadja : Noun :=
+  { form := "djadja", gloss := "uncle", gender := .masc, isNaturalGender := true
   , declClass := some .II }
 
 -- ============================================================================
 -- § 4: Remainder — Declension-Class Correlation ([kramer-2020] ex. 18)
 -- ============================================================================
 
-def zakon : RussianNoun :=
-  { form := "zakon", gloss := "law",    attestedGender := .masculine
-  , isNaturalGender := false, declClass := some .I }
-def škola : RussianNoun :=
-  { form := "škola", gloss := "school", attestedGender := .feminine
-  , isNaturalGender := false, declClass := some .II }
-def kost' : RussianNoun :=
-  { form := "kost'", gloss := "bone",   attestedGender := .feminine
-  , isNaturalGender := false, declClass := some .III }
-def vino  : RussianNoun :=
-  { form := "vino",  gloss := "wine",   attestedGender := .neuter
-  , isNaturalGender := false, declClass := some .IV }
+def zakon : Noun := { form := "zakon", gloss := "law", gender := .masc, declClass := some .I }
+def škola : Noun := { form := "škola", gloss := "school", gender := .fem, declClass := some .II }
+def kost' : Noun := { form := "kost'", gloss := "bone", gender := .fem, declClass := some .III }
+def vino : Noun := { form := "vino", gloss := "wine", gender := .neut, declClass := some .IV }
 
 -- ============================================================================
 -- § 5: Class III Exceptions ([kramer-2020] ex. 19)
@@ -136,16 +129,13 @@ def vino  : RussianNoun :=
 
 /-- *znamja* 'banner': Class III but neuter, not feminine (the -мя
     neuter group; [corbett-1991]; [kramer-2020] ex. 19a). -/
-def znamja : RussianNoun :=
-  { form := "znamja", gloss := "banner", attestedGender := .neuter
-  , isNaturalGender := false, declClass := some .III }
+def znamja : Noun :=
+  { form := "znamja", gloss := "banner", gender := .neut, declClass := some .III }
 
 /-- *put'* 'way': the only masculine noun in Class III
     ([wade-2020] §6397: "путь is qualified by masculine adjectives";
     [corbett-1991]; [kramer-2020] ex. 19b). -/
-def put'   : RussianNoun :=
-  { form := "put'", gloss := "way", attestedGender := .masculine
-  , isNaturalGender := false, declClass := some .III }
+def put' : Noun := { form := "put'", gloss := "way", gender := .masc, declClass := some .III }
 
 -- ============================================================================
 -- § 6: Hybrid Noun ([kramer-2020] ex. 15–16)
@@ -156,21 +146,19 @@ def put'   : RussianNoun :=
     (verified at [wade-2020] "Врач обязана…" with feminine-agreeing
     predicate). The Fragment encodes morphological gender; the hybrid
     behavior is the datum `Kramer2020.hybridTargets`. -/
-def vrač : RussianNoun :=
-  { form := "vrač", gloss := "doctor", attestedGender := .masculine
-  , isNaturalGender := false, declClass := some .I }
+def vrač : Noun := { form := "vrač", gloss := "doctor", gender := .masc, declClass := some .I }
 
 -- ============================================================================
 -- § 7: Inventory
 -- ============================================================================
 
-def semanticCoreNouns : List RussianNoun :=
+def semanticCoreNouns : List Noun :=
   [otec, mat', brat, sestra, byk, korova, djadja]
 
-def remainderNouns : List RussianNoun :=
+def remainderNouns : List Noun :=
   [zakon, škola, kost', vino, znamja, put']
 
-def allNouns : List RussianNoun :=
+def allNouns : List Noun :=
   semanticCoreNouns ++ remainderNouns ++ [vrač]
 
 -- ============================================================================
@@ -179,23 +167,13 @@ def allNouns : List RussianNoun :=
 
 /-- Declension class does not determine gender: *znamja* and *kost'*
     share Class III but differ in surface gender (the Class III
-    counter-correlation [corbett-1991] highlights). Stated
-    directly over `attestedGender` (no DM intermediary). -/
+    counter-correlation [corbett-1991] highlights). -/
 theorem declClass_ne_gender :
-    znamja.declClass = kost'.declClass ∧
-    znamja.attestedGender ≠ kost'.attestedGender := ⟨rfl, by decide⟩
+    znamja.declClass = kost'.declClass ∧ znamja.gender ≠ kost'.gender := ⟨rfl, by decide⟩
 
 -- ============================================================================
 -- § 9: Gender System (`Gender.System` instantiation)
 -- ============================================================================
-
-/-- Russian's three controller genders — the carrier of its
-    `Gender.System` ([corbett-1991]; [kramer-2015] ch. 7). -/
-inductive Value where
-  | masc
-  | fem
-  | neut
-  deriving DecidableEq, Repr, Fintype
 
 /-- Past-tense verbal concord exponents: *-∅* / *-a* / *-o*
     ([wade-2020]). Evidence type for `Gender.Faithful`. -/
@@ -236,48 +214,26 @@ theorem faithful_adjEnding : Function.Injective (Value.adjEnding · false) := by
     nouns like *vino* of [corbett-1991]'s declension rule surface neuter,
     at `Kramer2020.declensionGender`). -/
 def system : Gender.System Value where
-  label := fun g => match g with
-    | .masc => some .masculine
-    | .fem  => some .feminine
-    | .neut => some .neuter
+  label := λ g => some g.toLabel
   default := .neut
 
-/-- Comparative label → controller gender (ingestion). -/
-def Value.ofLabel : Gender → Value
-  | .feminine => .fem
-  | .neuter   => .neut
-  | _         => .masc
-
-/-- Controller gender of a noun, from the attested agreement fact. For
-    the hybrid *vrač* this is the morphological masculine; the
+/-- The assigned system: every noun gets its controller gender. For the
+    hybrid *vrač* this is the morphological masculine; the
     female-referent agreement alternation is the datum
     `Kramer2020.hybridTargets`. -/
-def RussianNoun.controllerGender (n : RussianNoun) : Value :=
-  Value.ofLabel n.attestedGender
-
-/-- The assigned system: every noun gets its controller gender. -/
-def assigned : Gender.System.Assigned RussianNoun Value :=
-  { system with assign := RussianNoun.controllerGender }
+def assigned : Gender.System.Assigned Noun Value := { system with assign := (·.gender) }
 
 /-- The carrier is faithful to the past-tense concord evidence:
     *-∅* / *-a* / *-o* distinguishes all three genders on a single
-    target. [corbett-1991]'s genders-are-agreement-classes criterion,
-    discharged via `Gender.Faithful`. -/
-theorem faithful_pastConcord :
-    Gender.Faithful (fun (g : Value) (_ : Unit) => g.pastConcord) := by decide
-
-/-- Label ∘ assign recovers the attested gender across the inventory. -/
-theorem system_label_assign :
-    ∀ n ∈ allNouns,
-      system.label n.controllerGender = some n.attestedGender := by decide
+    target. [corbett-1991]'s genders-are-agreement-classes criterion. -/
+theorem faithful_pastConcord : Function.Injective Value.pastConcord := by decide
 
 /-- [kramer-2015]'s (7ii) / [dahl-2000]'s generalization instantiated:
-    on the natural-gender core, assignment factors through the attested
-    gender (= referent sex on that core). The hybrid *vrač* and the
+    the natural-gender nouns form a semantic core, their gender being the
+    referent-sex classification. The hybrid *vrač* and the
     declension-class remainder are outside the core. -/
 theorem assigned_semanticCore :
-    assigned.SemanticCore {n | n.isNaturalGender = true}
-      (·.attestedGender) := by
-  exact ⟨⟨mat', rfl⟩, fun a b _ _ h => congrArg Value.ofLabel h⟩
+    assigned.SemanticCore {n | n.isNaturalGender = true} (·.gender) :=
+  ⟨⟨mat', rfl⟩, λ _ _ _ _ h => h⟩
 
 end Russian.Gender

--- a/Linglib/Fragments/Slavic/Serbian/Gender.lean
+++ b/Linglib/Fragments/Slavic/Serbian/Gender.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Bosnian/Croatian/Serbian nouns by gender and humanness
@@ -14,22 +14,29 @@ grammatical gender and whether they denote humans; neuter nouns are mass or coll
 namespace Serbian.Gender
 
 /-- A noun with its grammatical gender and whether it denotes a human. -/
-structure Noun where
-  form : String
-  gloss : String
-  gender : _root_.Gender
+structure Noun extends GenderedNoun _root_.Gender where
+  /-- Whether the noun denotes a human; the natural-gender flag marks the humans whose gender
+  is not fixed. -/
   human : Bool
   deriving DecidableEq, Repr
 
-def muskarac : Noun := ⟨"muškarac", "man", .masculine, true⟩
-def zena : Noun := ⟨"žena", "woman", .feminine, true⟩
-def covek : Noun := ⟨"čovek", "person, man", .masculine, true⟩
-def znanje : Noun := ⟨"znanje", "knowledge", .neuter, false⟩
-def intuicija : Noun := ⟨"intuicija", "intuition", .feminine, false⟩
-def selo : Noun := ⟨"selo", "village", .neuter, false⟩
-def brdo : Noun := ⟨"brdo", "hill", .neuter, false⟩
-def knjiga : Noun := ⟨"knjiga", "book", .feminine, false⟩
-def pesak : Noun := ⟨"pesak", "sand", .masculine, false⟩
-def mleko : Noun := ⟨"mleko", "milk", .neuter, false⟩
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
+
+def muskarac : Noun :=
+  { form := "muškarac", gloss := "man", gender := .masculine,
+    isNaturalGender := true, human := true }
+def zena : Noun :=
+  { form := "žena", gloss := "woman", gender := .feminine, isNaturalGender := true, human := true }
+def covek : Noun :=
+  { form := "čovek", gloss := "person, man", gender := .masculine,
+    isNaturalGender := true, human := true }
+def znanje : Noun := { form := "znanje", gloss := "knowledge", gender := .neuter, human := false }
+def intuicija : Noun :=
+  { form := "intuicija", gloss := "intuition", gender := .feminine, human := false }
+def selo : Noun := { form := "selo", gloss := "village", gender := .neuter, human := false }
+def brdo : Noun := { form := "brdo", gloss := "hill", gender := .neuter, human := false }
+def knjiga : Noun := { form := "knjiga", gloss := "book", gender := .feminine, human := false }
+def pesak : Noun := { form := "pesak", gloss := "sand", gender := .masculine, human := false }
+def mleko : Noun := { form := "mleko", gloss := "milk", gender := .neuter, human := false }
 
 end Serbian.Gender

--- a/Linglib/Fragments/Somali/Gender.lean
+++ b/Linglib/Fragments/Somali/Gender.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Somali noun gender
@@ -50,32 +50,23 @@ def Value.verbPrefix : Value → Bool → VerbPrefix
   | _, _ => .y
 
 /-- A Somali noun with its gender, its plural stem, and whether that plural is reduplicated. -/
-structure Noun where
-  /-- The citation form. -/
-  form : String
-  /-- The gloss. -/
-  gloss : String
-  /-- The agreement the noun takes. -/
-  attestedGender : Value
+structure Noun extends GenderedNoun Value where
   /-- The plural stem. -/
   plural : String
   /-- Whether the plural is formed by reduplication, keeping the singular article. -/
   reduplicatedPlural : Bool
   deriving DecidableEq, Repr
 
-/-- The gender the noun controls. -/
-abbrev Noun.gender (n : Noun) : Value := n.attestedGender
-
 /-- The article a noun takes in each number; a reduplicated plural keeps the singular's. -/
 def Noun.article (n : Noun) (plural : Bool) : Article :=
   n.gender.article (plural && !n.reduplicatedPlural)
 
 /-- *ìnan* 'boy'. -/
-def inan : Noun := ⟨"ìnan", "boy", .masc, "inammá", false⟩
+def inan : Noun := ⟨⟨⟨"ìnan", "boy"⟩, .masc, true⟩, "inammá", false⟩
 /-- *inán* 'girl'. -/
-def inan' : Noun := ⟨"inán", "girl", .fem, "ináma", false⟩
+def inan' : Noun := ⟨⟨⟨"inán", "girl"⟩, .fem, true⟩, "ináma", false⟩
 /-- *nin* 'man', with the reduplicated plural *niman*. -/
-def nin : Noun := ⟨"nin", "man", .masc, "niman", true⟩
+def nin : Noun := ⟨⟨⟨"nin", "man"⟩, .masc, true⟩, "niman", true⟩
 
 /-- The nouns the sources cite. -/
 def allNouns : List Noun := [inan, inan', nin]

--- a/Linglib/Fragments/Spanish/Gender.lean
+++ b/Linglib/Fragments/Spanish/Gender.lean
@@ -1,4 +1,5 @@
-import Linglib.Features.Gender.Basic
+import Mathlib.Tactic.DeriveFintype
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Spanish Noun Gender
@@ -15,20 +16,19 @@ of referent.
 
 ## Theory-neutral data layer
 
-The Fragment carries two empirical fields per entry:
-
-- `attestedGender : Gender` — the agreement-trigger fact
-  (verified against [butt-benjamin-2019] §1.2-1.3).
-- `isNaturalGender : Bool` — whether the gender is semantically
-  motivated by the referent's biological sex. False for inanimates,
-  for non-natural-gender animals (cf. §1.3.1), and for the §1.2.11
-  fixed-gender common-gender exceptions (*persona*, *ángel*).
+Each entry is a `GenderedNoun` over the two controller genders: its
+`gender` is the agreement-trigger fact (verified against
+[butt-benjamin-2019] §1.2-1.3), and `isNaturalGender` records whether
+that gender is semantically motivated by the referent's biological sex.
+False for inanimates, for non-natural-gender animals (cf. §1.3.1), and
+for the §1.2.11 fixed-gender common-gender exceptions (*persona*,
+*ángel*).
 
 These two fields suffice to project every entry's structural analysis
 under [kramer-2015] Ch. 6's Set-1 DM categorizer (the projection
 lives in `Studies/Kramer2020.lean`); they also support
 [harris-1991]'s lexical-rule analysis directly (Harris's [FEMALE]
-and [HUMAN] features map onto `attestedGender` and the natural-gender
+and [HUMAN] features map onto the gender and the natural-gender
 inference).
 
 ## Per-entry verification
@@ -43,130 +43,113 @@ textbook-consensus genders documented in [butt-benjamin-2019].
 
 namespace Spanish.Gender
 
-
--- ============================================================================
--- § 1: Spanish Noun (theory-neutral schema)
--- ============================================================================
-
-/-- A Spanish noun. No commitment to any specific theoretical framework
-    — Kramer's DM categorizing head, Harris's lexical rule, etc. are
-    projections that live in `Studies/`. -/
-structure SpanishNoun where
-  form : String
-  gloss : String
-  /-- Empirical agreement-trigger fact ([butt-benjamin-2019]). -/
-  attestedGender : Gender
-  /-- True iff the gender is semantically motivated by the referent's
-      biological sex. False for inanimates, for non-natural-gender
-      animals, and for the [butt-benjamin-2019] §1.2.11 common-gender
-      fixed-assignment exceptions (*persona* feminine for any sex;
-      *ángel* masculine for any sex). -/
-  isNaturalGender : Bool
-  deriving DecidableEq, Repr
-
-namespace SpanishNoun
-
-/-- Surface gender alias for ergonomic consumer access. -/
-abbrev gender (n : SpanishNoun) : Gender := n.attestedGender
-
-end SpanishNoun
-
--- ============================================================================
--- § 2: Natural-Gender Nouns (Group A, [butt-benjamin-2019] §1.2)
--- ============================================================================
-
-def hombre : SpanishNoun := ⟨"hombre", "man",    .masculine, true⟩
-def mujer  : SpanishNoun := ⟨"mujer",  "woman",  .feminine,  true⟩
-def niño   : SpanishNoun := ⟨"niño",   "boy",    .masculine, true⟩
-def niña   : SpanishNoun := ⟨"niña",   "girl",   .feminine,  true⟩
-def rey    : SpanishNoun := ⟨"rey",    "king",   .masculine, true⟩
-def reina  : SpanishNoun := ⟨"reina",  "queen",  .feminine,  true⟩
-def gato   : SpanishNoun := ⟨"gato",   "cat.M",  .masculine, true⟩
-def gata   : SpanishNoun := ⟨"gata",   "cat.F",  .feminine,  true⟩
-
--- ============================================================================
--- § 3: Arbitrary Feminines (Group B, [butt-benjamin-2019] §1.3)
--- ============================================================================
-
-def mesa    : SpanishNoun := ⟨"mesa",    "table",  .feminine, false⟩
-def silla   : SpanishNoun := ⟨"silla",   "chair",  .feminine, false⟩
-def casa    : SpanishNoun := ⟨"casa",    "house",  .feminine, false⟩
-def puerta  : SpanishNoun := ⟨"puerta",  "door",   .feminine, false⟩
-def ventana : SpanishNoun := ⟨"ventana", "window", .feminine, false⟩
-def cama    : SpanishNoun := ⟨"cama",    "bed",    .feminine, false⟩
-/-- *persona* 'person': common-gender noun ([butt-benjamin-2019]
-    §1.2.11) — feminine regardless of referent's sex. The famous
-    [kramer-2015] §6.2 exception: human-denoting noun with
-    structurally arbitrary feminine gender. `isNaturalGender = false`
-    captures that the gender does NOT come from biological sex (even
-    though referent is human). -/
-def persona : SpanishNoun := ⟨"persona", "person", .feminine, false⟩
-
--- ============================================================================
--- § 4: Default Masculines (Group B, [butt-benjamin-2019] §1.3)
--- ============================================================================
-
-def libro  : SpanishNoun := ⟨"libro",  "book",  .masculine, false⟩
-def zapato : SpanishNoun := ⟨"zapato", "shoe",  .masculine, false⟩
-def coche  : SpanishNoun := ⟨"coche",  "car",   .masculine, false⟩
-def árbol  : SpanishNoun := ⟨"árbol",  "tree",  .masculine, false⟩
-def cielo  : SpanishNoun := ⟨"cielo",  "sky",   .masculine, false⟩
-def vaso   : SpanishNoun := ⟨"vaso",   "glass", .masculine, false⟩
-/-- *ángel* 'angel': common-gender noun ([butt-benjamin-2019]
-    §1.2.11) — masculine for any sex. Companion to *persona*: the
-    masculine fixed-gender exception. `isNaturalGender = false`. -/
-def ángel  : SpanishNoun := ⟨"ángel",  "angel", .masculine, false⟩
-
--- ============================================================================
--- § 5: Same-Root Nominals ([kramer-2020] §2.2.3)
--- ============================================================================
-
-/-- Same-root nominals: a single root that surfaces as either masculine
-    or feminine depending on the referent's sex. Empirically polymorphic
-    in gender (one form, two genders), distinct from the atomic
-    `SpanishNoun` schema. The DM analysis (combination with i[+FEM] vs
-    i[−FEM]) lives in `Studies/Kramer2020.lean`. -/
-structure SameRootEntry where
-  form : String
-  gloss : String
-  deriving DecidableEq, Repr
-
-def soldado    : SameRootEntry := ⟨"soldado",    "soldier"⟩
-def estudiante : SameRootEntry := ⟨"estudiante", "student"⟩
-def artista    : SameRootEntry := ⟨"artista",    "artist"⟩
-
--- ============================================================================
--- § 6: Inventory
--- ============================================================================
-
-def naturalFemNouns : List SpanishNoun :=
-  [mujer, niña, reina, gata]
-
-def naturalMascNouns : List SpanishNoun :=
-  [hombre, niño, rey, gato]
-
-def arbitraryFemNouns : List SpanishNoun :=
-  [mesa, silla, casa, puerta, ventana, cama, persona]
-
-def defaultMascNouns : List SpanishNoun :=
-  [libro, zapato, coche, árbol, cielo, vaso, ángel]
-
-def allNouns : List SpanishNoun :=
-  naturalFemNouns ++ naturalMascNouns ++ arbitraryFemNouns ++ defaultMascNouns
-
-def sameRootNouns : List SameRootEntry :=
-  [soldado, estudiante, artista]
-
--- ============================================================================
--- § 7: Gender System (`Gender.System` instantiation)
--- ============================================================================
-
 /-- Spanish's two controller genders — the carrier of its `Gender.System`
     ([corbett-1991]; [kramer-2015]). -/
 inductive Value where
   | masc
   | fem
   deriving DecidableEq, Repr, Fintype
+
+/-- The comparative label of each gender. -/
+def Value.toLabel : Value → Gender
+  | .masc => .masculine
+  | .fem => .feminine
+
+instance : HasGender Value := ⟨λ g => genderOf g.toLabel⟩
+
+/-- A Spanish noun: its gender, the agreement it takes ([butt-benjamin-2019]),
+    and whether that gender follows the referent's sex — false for
+    inanimates, for non-natural-gender animals, and for the §1.2.11
+    common-gender exceptions (*persona* feminine for any sex; *ángel*
+    masculine for any sex). -/
+abbrev Noun := GenderedNoun Value
+
+-- ============================================================================
+-- § 1: Natural-Gender Nouns (Group A, [butt-benjamin-2019] §1.2)
+-- ============================================================================
+
+def hombre : Noun := ⟨⟨"hombre", "man"⟩, .masc, true⟩
+def mujer : Noun := ⟨⟨"mujer", "woman"⟩, .fem, true⟩
+def niño : Noun := ⟨⟨"niño", "boy"⟩, .masc, true⟩
+def niña : Noun := ⟨⟨"niña", "girl"⟩, .fem, true⟩
+def rey : Noun := ⟨⟨"rey", "king"⟩, .masc, true⟩
+def reina : Noun := ⟨⟨"reina", "queen"⟩, .fem, true⟩
+def gato : Noun := ⟨⟨"gato", "cat.M"⟩, .masc, true⟩
+def gata : Noun := ⟨⟨"gata", "cat.F"⟩, .fem, true⟩
+
+-- ============================================================================
+-- § 2: Arbitrary Feminines (Group B, [butt-benjamin-2019] §1.3)
+-- ============================================================================
+
+def mesa : Noun := ⟨⟨"mesa", "table"⟩, .fem, false⟩
+def silla : Noun := ⟨⟨"silla", "chair"⟩, .fem, false⟩
+def casa : Noun := ⟨⟨"casa", "house"⟩, .fem, false⟩
+def puerta : Noun := ⟨⟨"puerta", "door"⟩, .fem, false⟩
+def ventana : Noun := ⟨⟨"ventana", "window"⟩, .fem, false⟩
+def cama : Noun := ⟨⟨"cama", "bed"⟩, .fem, false⟩
+/-- *persona* 'person': common-gender noun ([butt-benjamin-2019]
+    §1.2.11) — feminine regardless of referent's sex. The famous
+    [kramer-2015] §6.2 exception: human-denoting noun with
+    structurally arbitrary feminine gender. `isNaturalGender = false`
+    captures that the gender does NOT come from biological sex (even
+    though referent is human). -/
+def persona : Noun := ⟨⟨"persona", "person"⟩, .fem, false⟩
+
+-- ============================================================================
+-- § 3: Default Masculines (Group B, [butt-benjamin-2019] §1.3)
+-- ============================================================================
+
+def libro : Noun := ⟨⟨"libro", "book"⟩, .masc, false⟩
+def zapato : Noun := ⟨⟨"zapato", "shoe"⟩, .masc, false⟩
+def coche : Noun := ⟨⟨"coche", "car"⟩, .masc, false⟩
+def árbol : Noun := ⟨⟨"árbol", "tree"⟩, .masc, false⟩
+def cielo : Noun := ⟨⟨"cielo", "sky"⟩, .masc, false⟩
+def vaso : Noun := ⟨⟨"vaso", "glass"⟩, .masc, false⟩
+/-- *ángel* 'angel': common-gender noun ([butt-benjamin-2019]
+    §1.2.11) — masculine for any sex. Companion to *persona*: the
+    masculine fixed-gender exception. `isNaturalGender = false`. -/
+def ángel : Noun := ⟨⟨"ángel", "angel"⟩, .masc, false⟩
+
+-- ============================================================================
+-- § 4: Same-Root Nominals ([kramer-2020] §2.2.3)
+-- ============================================================================
+
+/-- Same-root nominals: a single root that surfaces as either masculine
+    or feminine depending on the referent's sex. Empirically polymorphic
+    in gender (one form, two genders), so a noun entry without a fixed
+    gender. The DM analysis (combination with i[+FEM] vs i[−FEM]) lives
+    in `Studies/Kramer2020.lean`. -/
+abbrev SameRootEntry := _root_.Noun
+
+def soldado : SameRootEntry := ⟨"soldado", "soldier"⟩
+def estudiante : SameRootEntry := ⟨"estudiante", "student"⟩
+def artista : SameRootEntry := ⟨"artista", "artist"⟩
+
+-- ============================================================================
+-- § 5: Inventory
+-- ============================================================================
+
+def naturalFemNouns : List Noun :=
+  [mujer, niña, reina, gata]
+
+def naturalMascNouns : List Noun :=
+  [hombre, niño, rey, gato]
+
+def arbitraryFemNouns : List Noun :=
+  [mesa, silla, casa, puerta, ventana, cama, persona]
+
+def defaultMascNouns : List Noun :=
+  [libro, zapato, coche, árbol, cielo, vaso, ángel]
+
+def allNouns : List Noun :=
+  naturalFemNouns ++ naturalMascNouns ++ arbitraryFemNouns ++ defaultMascNouns
+
+def sameRootNouns : List SameRootEntry :=
+  [soldado, estudiante, artista]
+
+-- ============================================================================
+-- § 6: Gender System (`Gender.System` instantiation)
+-- ============================================================================
 
 /-- Adjectival concord exponents: the *-o* vs *-a* desinence contrast
     ([butt-benjamin-2019]). Evidence type for `Gender.Faithful`. -/
@@ -185,46 +168,25 @@ def Value.concord : Value → Concord
     surface masculine — the underspecified determiner of
     [kramer-2020] (25), at `Kramer2020.determiner_iMasc_eq_plain`). -/
 def system : Gender.System Value where
-  label := fun g => match g with
-    | .masc => some .masculine
-    | .fem  => some .feminine
+  label := λ g => some g.toLabel
   default := .masc
 
-/-- Comparative label → controller gender (ingestion). -/
-def Value.ofLabel : Gender → Value
-  | .feminine => .fem
-  | _         => .masc
-
-/-- Controller gender of a noun, from the attested agreement fact. -/
-def SpanishNoun.controllerGender (n : SpanishNoun) : Value :=
-  Value.ofLabel n.attestedGender
-
 /-- The assigned system: every noun gets its controller gender. -/
-def assigned : Gender.System.Assigned SpanishNoun Value :=
-  { system with assign := SpanishNoun.controllerGender }
+def assigned : Gender.System.Assigned Noun Value := { system with assign := (·.gender) }
 
 /-- The carrier is faithful to the adjectival concord evidence: *-o* vs
     *-a* distinguishes the two genders. [corbett-1991]'s
-    genders-are-agreement-classes criterion, discharged via
-    `Gender.Faithful`. -/
-theorem faithful_concord :
-    Gender.Faithful (fun (g : Value) (_ : Unit) => g.concord) := by decide
-
-/-- Label ∘ assign recovers the attested gender across the inventory:
-    the system view and the per-noun data agree. -/
-theorem system_label_assign :
-    ∀ n ∈ allNouns,
-      system.label n.controllerGender = some n.attestedGender := by decide
+    genders-are-agreement-classes criterion. -/
+theorem faithful_concord : Function.Injective Value.concord := by decide
 
 /-- [kramer-2015]'s (7ii) / [dahl-2000]'s generalization instantiated:
-    on the natural-gender core (Group A), assignment factors through the
-    attested gender — which on that core is the referent-sex
-    classification (that is what `isNaturalGender` asserts). *persona*
-    and *ángel* are outside the core (`isNaturalGender = false`), so the
-    fixed-gender exceptions do not disturb the factoring. -/
+    the natural-gender nouns (Group A) form a semantic core, their gender
+    being the referent-sex classification (that is what `isNaturalGender`
+    asserts). *persona* and *ángel* are outside the core
+    (`isNaturalGender = false`), so the fixed-gender exceptions do not
+    disturb the factoring. -/
 theorem assigned_semanticCore :
-    assigned.SemanticCore {n | n.isNaturalGender = true}
-      (·.attestedGender) := by
-  exact ⟨⟨mujer, rfl⟩, fun a b _ _ h => congrArg Value.ofLabel h⟩
+    assigned.SemanticCore {n | n.isNaturalGender = true} (·.gender) :=
+  ⟨⟨mujer, rfl⟩, λ _ _ _ _ h => h⟩
 
 end Spanish.Gender

--- a/Linglib/Fragments/Swahili/Nouns.lean
+++ b/Linglib/Fragments/Swahili/Nouns.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.Swahili.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Swahili nouns
@@ -25,89 +26,83 @@ inductive Evaluative where
 
 /-- A Swahili noun: its morphological class (the prefixes on the noun), the gender whose
 agreements it controls, and whether it denotes an animate. -/
-structure Noun where
-  form : String
-  gloss : String
+structure Noun extends GenderedNoun Gender where
   /-- The class pair whose prefixes the noun carries. -/
   morphClass : Gender
-  /-- The class pair whose agreements the noun controls. -/
-  attestedGender : Gender
   /-- Whether the noun denotes an animate. -/
   animate : Bool
   /-- Augmentative or diminutive derivation, if any. -/
   evaluative : Option Evaluative := none
   deriving DecidableEq, Repr
 
-abbrev Noun.gender (n : Noun) : Gender := n.attestedGender
-
 def kikapu : Noun :=
   { form := "kikapu", gloss := "basket", morphClass := .genderD,
-    attestedGender := .genderD, animate := false }
+    gender := .genderD, animate := false }
 def kiti : Noun :=
   { form := "kiti", gloss := "stool", morphClass := .genderD,
-    attestedGender := .genderD, animate := false }
+    gender := .genderD, animate := false }
 def mti : Noun :=
   { form := "mti", gloss := "tree", morphClass := .genderB,
-    attestedGender := .genderB, animate := false }
+    gender := .genderB, animate := false }
 def mguu : Noun :=
   { form := "mguu", gloss := "leg", morphClass := .genderB,
-    attestedGender := .genderB, animate := false }
+    gender := .genderB, animate := false }
 def nyumba : Noun :=
   { form := "nyumba", gloss := "house", morphClass := .genderE,
-    attestedGender := .genderE, animate := false }
+    gender := .genderE, animate := false }
 def mtu : Noun :=
   { form := "mtu", gloss := "person", morphClass := .genderA,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def mwalimu : Noun :=
   { form := "mwalimu", gloss := "teacher", morphClass := .genderA,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def mnyama : Noun :=
   { form := "mnyama", gloss := "animal", morphClass := .genderA,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def mdudu : Noun :=
   { form := "mdudu", gloss := "insect", morphClass := .genderA,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 /-- *kifaru* 'rhinoceros': class 7 prefix, class 1/2 agreements. -/
 def kifaru : Noun :=
   { form := "kifaru", gloss := "rhinoceros", morphClass := .genderD,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 /-- *kiboko* 'hippopotamus': class 7 prefix, class 1/2 agreements. -/
 def kiboko : Noun :=
   { form := "kiboko", gloss := "hippopotamus", morphClass := .genderD,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def mjusi : Noun :=
   { form := "mjusi", gloss := "lizard", morphClass := .genderB,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def jogoo : Noun :=
   { form := "jogoo", gloss := "rooster", morphClass := .genderC,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def kipofu : Noun :=
   { form := "kipofu", gloss := "blind person", morphClass := .genderD,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def tembo : Noun :=
   { form := "tembo", gloss := "elephant", morphClass := .genderE,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def nyoka : Noun :=
   { form := "nyoka", gloss := "snake", morphClass := .genderE,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def rafiki : Noun :=
   { form := "rafiki", gloss := "friend", morphClass := .genderE,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 def ngombe : Noun :=
   { form := "ng'ombe", gloss := "cow", morphClass := .genderE,
-    attestedGender := .genderA, animate := true }
+    gender := .genderA, animate := true }
 /-- *joka* 'giant snake', the augmentative of *nyoka*. -/
 def joka : Noun :=
   { form := "joka", gloss := "giant snake", morphClass := .genderC,
-    attestedGender := .genderC, animate := true, evaluative := some .augmentative }
+    gender := .genderC, animate := true, evaluative := some .augmentative }
 /-- *kitoto* 'baby', the diminutive of *mtoto* 'child'. -/
 def kitoto : Noun :=
   { form := "kitoto", gloss := "baby", morphClass := .genderD,
-    attestedGender := .genderD, animate := true, evaluative := some .diminutive }
+    gender := .genderD, animate := true, evaluative := some .diminutive }
 /-- *kijoka* 'tiny snake', the diminutive of *joka*. -/
 def kijoka : Noun :=
   { form := "kijoka", gloss := "tiny snake", morphClass := .genderD,
-    attestedGender := .genderD, animate := true, evaluative := some .diminutive }
+    gender := .genderD, animate := true, evaluative := some .diminutive }
 
 def allNouns : List Noun :=
   [kikapu, kiti, mti, mguu, nyumba, mtu, mwalimu, mnyama, mdudu, kifaru, kiboko, mjusi, jogoo,

--- a/Linglib/Fragments/Tamil/Gender.lean
+++ b/Linglib/Fragments/Tamil/Gender.lean
@@ -1,5 +1,5 @@
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Tamil noun gender
@@ -26,32 +26,24 @@ inductive Value where
 
 /-- A Tamil noun with the agreement it takes and the two semantic facts the gender tracks:
 whether the referent is rational, and whether the gender comes from the referent's sex. -/
-structure Noun where
-  form : String
-  gloss : String
-  /-- The agreement the noun takes. -/
-  attestedGender : Value
+structure Noun extends GenderedNoun Value where
   /-- Whether the referent is rational: a human or a deity. -/
   rational : Bool
-  /-- Whether the gender comes from the referent's sex. -/
-  isNaturalGender : Bool
   deriving DecidableEq, Repr
 
-abbrev Noun.gender (n : Noun) : Value := n.attestedGender
-
-def aaN : Noun := ⟨"aaN", "man", .masc, true, true⟩
-def civaN : Noun := ⟨"CivaN", "Shiva", .masc, true, true⟩
-def peN : Noun := ⟨"peN", "woman", .fem, true, true⟩
-def kaali : Noun := ⟨"kaali", "Kali", .fem, true, true⟩
-def maram : Noun := ⟨"maram", "tree", .neut, false, false⟩
-def viiTu : Noun := ⟨"viiTu", "house", .neut, false, false⟩
-def raaman : Noun := ⟨"raaman", "Raman", .masc, true, true⟩
-def murukan : Noun := ⟨"murukan", "Murugan", .masc, true, true⟩
-def akkaa : Noun := ⟨"akkaa", "elder sister", .fem, true, true⟩
-def tankacci : Noun := ⟨"tankacci", "younger sister", .fem, true, true⟩
-def annan : Noun := ⟨"annan", "elder brother", .masc, true, true⟩
-def naay : Noun := ⟨"naay", "dog", .neut, false, false⟩
-def puune : Noun := ⟨"puune", "cat", .neut, false, false⟩
+def aaN : Noun := ⟨⟨⟨"aaN", "man"⟩, .masc, true⟩, true⟩
+def civaN : Noun := ⟨⟨⟨"CivaN", "Shiva"⟩, .masc, true⟩, true⟩
+def peN : Noun := ⟨⟨⟨"peN", "woman"⟩, .fem, true⟩, true⟩
+def kaali : Noun := ⟨⟨⟨"kaali", "Kali"⟩, .fem, true⟩, true⟩
+def maram : Noun := ⟨⟨⟨"maram", "tree"⟩, .neut, false⟩, false⟩
+def viiTu : Noun := ⟨⟨⟨"viiTu", "house"⟩, .neut, false⟩, false⟩
+def raaman : Noun := ⟨⟨⟨"raaman", "Raman"⟩, .masc, true⟩, true⟩
+def murukan : Noun := ⟨⟨⟨"murukan", "Murugan"⟩, .masc, true⟩, true⟩
+def akkaa : Noun := ⟨⟨⟨"akkaa", "elder sister"⟩, .fem, true⟩, true⟩
+def tankacci : Noun := ⟨⟨⟨"tankacci", "younger sister"⟩, .fem, true⟩, true⟩
+def annan : Noun := ⟨⟨⟨"annan", "elder brother"⟩, .masc, true⟩, true⟩
+def naay : Noun := ⟨⟨⟨"naay", "dog"⟩, .neut, false⟩, false⟩
+def puune : Noun := ⟨⟨⟨"puune", "cat"⟩, .neut, false⟩, false⟩
 
 def allNouns : List Noun :=
   [aaN, civaN, peN, kaali, maram, viiTu, raaman, murukan, akkaa, tankacci, annan, naay, puune]
@@ -87,10 +79,13 @@ def system : Gender.System Value where
   default := .neut
 
 /-- Every noun gets its controller gender. -/
-def assigned : Gender.System.Assigned Noun Value := { system with assign := Noun.gender }
+def assigned : Gender.System.Assigned Noun Value := { system with assign := (·.gender) }
+
+instance : HasGender Value := ⟨λ g => system.label g⟩
+
+instance : HasGender Noun := ⟨λ n => genderOf n.gender⟩
 
 /-- Singular verb agreement alone distinguishes the three genders. -/
-theorem faithful_sgConcord : Gender.Faithful (λ (g : Value) (_ : Unit) => g.sgConcord) := by
-  decide
+theorem faithful_sgConcord : Function.Injective Value.sgConcord := by decide
 
 end Tamil.Gender

--- a/Linglib/Fragments/Teop/Nouns.lean
+++ b/Linglib/Fragments/Teop/Nouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Gender.Basic
+import Linglib.Syntax.Category.Noun.Basic
 
 /-!
 # Teop nouns
@@ -27,33 +27,35 @@ def Gender.toGender : Gender → _root_.Gender
   | .gI => .animate
   | .gII => .inanimate
 
+instance : HasGender Gender := ⟨λ g => ↑g.toGender⟩
+
 /-- A noun with its gloss and the gender it takes unpossessed. -/
-structure Noun where
-  form : String
-  gloss : String
-  gender : Gender
-  deriving DecidableEq, Repr
+abbrev Noun := GenderedNoun Gender
 
 /-- Gender I nouns. -/
 def genderINouns : List Noun :=
-  [⟨"moon", "woman", .gI⟩, ⟨"beikoo", "child", .gI⟩, ⟨"keusu", "rat", .gI⟩,
-    ⟨"naovana", "bird", .gI⟩, ⟨"overe", "coconut", .gI⟩, ⟨"pauna", "banana", .gI⟩,
-    ⟨"kepaa", "clay pot", .gI⟩, ⟨"anoo", "peeler (pearl shell)", .gI⟩,
-    ⟨"taba'ani", "food", .gI⟩, ⟨"tahii", "sea", .gI⟩, ⟨"huan", "rain", .gI⟩,
-    ⟨"uruuru", "love", .gI⟩]
+  [⟨⟨"moon", "woman"⟩, .gI, false⟩, ⟨⟨"beikoo", "child"⟩, .gI, false⟩,
+    ⟨⟨"keusu", "rat"⟩, .gI, false⟩, ⟨⟨"naovana", "bird"⟩, .gI, false⟩,
+    ⟨⟨"overe", "coconut"⟩, .gI, false⟩, ⟨⟨"pauna", "banana"⟩, .gI, false⟩,
+    ⟨⟨"kepaa", "clay pot"⟩, .gI, false⟩, ⟨⟨"anoo", "peeler (pearl shell)"⟩, .gI, false⟩,
+    ⟨⟨"taba'ani", "food"⟩, .gI, false⟩, ⟨⟨"tahii", "sea"⟩, .gI, false⟩,
+    ⟨⟨"huan", "rain"⟩, .gI, false⟩, ⟨⟨"uruuru", "love"⟩, .gI, false⟩]
 
 /-- Gender II nouns. -/
 def genderIINouns : List Noun :=
-  [⟨"paka", "leaf", .gII⟩, ⟨"pus", "stump", .gII⟩, ⟨"hinahoo", "taro planting stick", .gII⟩,
-    ⟨"sinivi", "canoe", .gII⟩, ⟨"overe", "coconut palm", .gII⟩, ⟨"overe", "banana tree", .gII⟩,
-    ⟨"kurita", "octopus", .gII⟩, ⟨"demdem", "snail", .gII⟩, ⟨"paku", "feast", .gII⟩,
-    ⟨"suraa", "fire", .gII⟩, ⟨"giigii", "shooting star", .gII⟩, ⟨"koara", "language", .gII⟩]
+  [⟨⟨"paka", "leaf"⟩, .gII, false⟩, ⟨⟨"pus", "stump"⟩, .gII, false⟩,
+    ⟨⟨"hinahoo", "taro planting stick"⟩, .gII, false⟩, ⟨⟨"sinivi", "canoe"⟩, .gII, false⟩,
+    ⟨⟨"overe", "coconut palm"⟩, .gII, false⟩, ⟨⟨"overe", "banana tree"⟩, .gII, false⟩,
+    ⟨⟨"kurita", "octopus"⟩, .gII, false⟩, ⟨⟨"demdem", "snail"⟩, .gII, false⟩,
+    ⟨⟨"paku", "feast"⟩, .gII, false⟩, ⟨⟨"suraa", "fire"⟩, .gII, false⟩,
+    ⟨⟨"giigii", "shooting star"⟩, .gII, false⟩, ⟨⟨"koara", "language"⟩, .gII, false⟩]
 
 /-- Body-part nouns, gender II unpossessed and gender I with an inalienable possessor. -/
 def bodyPartNouns : List Noun :=
-  [⟨"bina", "spleen", .gII⟩, ⟨"kuri", "hand", .gII⟩, ⟨"iru", "back of head", .gII⟩,
-    ⟨"vuha", "heart", .gII⟩, ⟨"ihu", "nose", .gII⟩, ⟨"revasin", "blood", .gII⟩,
-    ⟨"hena", "name", .gII⟩, ⟨"moo", "leg", .gII⟩]
+  [⟨⟨"bina", "spleen"⟩, .gII, false⟩, ⟨⟨"kuri", "hand"⟩, .gII, false⟩,
+    ⟨⟨"iru", "back of head"⟩, .gII, false⟩, ⟨⟨"vuha", "heart"⟩, .gII, false⟩,
+    ⟨⟨"ihu", "nose"⟩, .gII, false⟩, ⟨⟨"revasin", "blood"⟩, .gII, false⟩,
+    ⟨⟨"hena", "name"⟩, .gII, false⟩, ⟨⟨"moo", "leg"⟩, .gII, false⟩]
 
 /-- Body-part nouns whose unpossessed form carries the suffix *-na*. -/
 def derelationalized : List String := ["moo-na", "kuri-na", "ihu-na"]

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -308,7 +308,7 @@ def numberPosition : PluralClass → NumberPosition
 reach. -/
 theorem gender_change_iff_local :
     ∀ n ∈ aPlurals ++ regulars,
-      n.sgGender ≠ n.plGender ↔
+      n.gender ≠ n.plGender ↔
         genderLocalityHypothesis (numberPosition n.pluralClass).toPosition = true := by
   decide
 

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -145,7 +145,8 @@ def system : System where
   vocabulary := threeWay
 
 /-- An inanimate's bundle: interpretable CLASS beside its arbitrary gender. -/
-def inanimate (n : Noun) : Bundle Node := system.conceptual .thing ++ system.arbitrary n.gender
+def inanimate (n : Greek.StandardModern.Gender.Noun) : Bundle Node :=
+  system.conceptual .thing ++ system.arbitrary n.gender
 
 theorem fem_entails_masc : system.geometry.Entails .fem .masc := by decide
 
@@ -265,7 +266,8 @@ def system : System where
     | _ => .cls
   vocabulary := threeWay
 
-def inanimate (n : Noun) : Bundle Node := system.conceptual .thing ++ system.arbitrary n.gender
+def inanimate (n : Icelandic.Gender.Noun) : Bundle Node :=
+  system.conceptual .thing ++ system.arbitrary n.gender
 
 theorem fem_not_entails_masc : ¬ system.geometry.Entails .fem .masc := by decide
 
@@ -318,7 +320,7 @@ def system : System where
     [[.fem, .anim, .masc, .indiv] ⟷ .feminine, [.anim, .masc, .indiv] ⟷ .masculine,
       [.indiv] ⟷ .masculine, [] ⟷ .neuter]
 
-def inanimate (n : Noun) : Bundle Node :=
+def inanimate (n : Serbian.Gender.Noun) : Bundle Node :=
   system.conceptual (if n.gender = .neuter then .mass else .thing) ++ system.arbitrary n.gender
 
 /-- *Muškarac i žena su sretni*. -/

--- a/Linglib/Studies/Corbett1991.lean
+++ b/Linglib/Studies/Corbett1991.lean
@@ -219,7 +219,7 @@ namespace Tamil
 open _root_.Tamil.Gender
 
 /-- What the rules read: rationality, and the natural gender of a sex-differentiable noun. -/
-def sem (n : Noun) : Bool × Option Value :=
+def sem (n : Tamil.Gender.Noun) : Bool × Option Value :=
   (n.rational, if n.isNaturalGender then some n.gender else none)
 
 /-- Table 2.1: male rationals masculine, female rationals feminine, the residue neuter. -/
@@ -256,7 +256,7 @@ inductive Declension where
 
 /-- The fragment's declension classes under Corbett's typing: *znamja* and *put'* are of the
 irregular third declension. -/
-def declension (n : RussianNoun) : Option Declension :=
+def declension (n : Russian.Gender.Noun) : Option Declension :=
   if n = znamja ∨ n = put' then some .irregularIII else
     n.declClass.map λ
       | .I => .I
@@ -265,8 +265,8 @@ def declension (n : RussianNoun) : Option Declension :=
       | .IV => .IV
 
 /-- The natural gender of a sex-differentiable noun. -/
-def sem (n : RussianNoun) : Option Value :=
-  if n.isNaturalGender then some n.controllerGender else none
+def sem (n : Russian.Gender.Noun) : Option Value :=
+  if n.isNaturalGender then some n.gender else none
 
 /-- The rules of §3.1.1 for declinable nouns: males masculine and females feminine; then
 declension I masculine, declensions II and III feminine, the rest neuter. The rules for
@@ -282,7 +282,7 @@ def system : AssignmentSystem (Option Value) (Option Declension) Value where
 /-- The rules assign every noun of the fragment its gender, *put'* excepted, which the book
 leaves as an isolated exception with an irregular lexical marker. -/
 theorem assign_eq_gender :
-    ∀ n ∈ allNouns, n ≠ put' → system.assign sem declension n = n.controllerGender := by
+    ∀ n ∈ allNouns, n ≠ put' → system.assign sem declension n = n.gender := by
   decide
 
 /-- *djadja* 'uncle': the morphological rule would make it feminine, the semantic rule makes
@@ -305,7 +305,7 @@ namespace Swahili
 open _root_.Swahili
 
 /-- What the semantic rules read: evaluative derivation and animacy. -/
-def sem (n : Noun) : Option Evaluative × Bool := (n.evaluative, n.animate)
+def sem (n : Swahili.Noun) : Option Evaluative × Bool := (n.evaluative, n.animate)
 
 /-- The rules of §3.1.2: augmentatives to 5/6, diminutives to 7/8, remaining animates to
 1/2; then each morphological class to its own gender, over the fragment's five genders (the
@@ -340,7 +340,7 @@ namespace Afar
 open _root_.Afar.Gender
 
 /-- The natural gender of a sex-differentiable noun. -/
-def sem (n : Noun) : Option Value := if n.isNaturalGender then some n.gender else none
+def sem (n : Afar.Gender.Noun) : Option Value := if n.isNaturalGender then some n.gender else none
 
 /-- Sex first; then a citation form ending in an accented vowel is feminine, the rest
 masculine. -/
@@ -369,7 +369,7 @@ namespace Hausa
 open _root_.Hausa
 
 /-- The natural gender of a sex-differentiable noun. -/
-def sem (n : Noun) : Option Gender := if n.isNaturalGender then some n.gender else none
+def sem (n : Hausa.Noun) : Option Gender := if n.isNaturalGender then some n.gender else none
 
 /-- Sex first; then a noun in *-ā* is feminine, the rest masculine. -/
 def system : AssignmentSystem (Option Gender) Bool Gender where
@@ -1003,13 +1003,14 @@ namespace Romanian
 open _root_.Romanian.Gender
 
 /-- Whether a noun denotes a male animate. -/
-def MaleAnimate (n : Noun) : Prop := n.animate ∧ n.isNaturalGender ∧ n.gender = .masc
+def MaleAnimate (n : Romanian.Gender.Noun) : Prop :=
+  n.animate ∧ n.isNaturalGender ∧ n.gender = .masc
 
 instance : DecidablePred MaleAnimate := λ _ => by unfold MaleAnimate; infer_instance
 
 /-- §9.5, collapsed: a male animate, masculine; all masculine, masculine; otherwise
 feminine, over the fragment's nouns. -/
-def rules : List (Rule Noun Value) :=
+def rules : List (Rule Romanian.Gender.Noun Value) :=
   [⟨.any, MaleAnimate, .masc⟩, ⟨.all, (·.gender = .masc), .masc⟩, Rule.otherwise .fem]
 
 /-- (69): a masculine and a neuter inanimate resolve to the feminine, the form the neuter

--- a/Linglib/Studies/Corbett1998.lean
+++ b/Linglib/Studies/Corbett1998.lean
@@ -304,18 +304,18 @@ namespace Chichewa
 open _root_.Chichewa.Gender Corbett1991
 
 /-- Coordinated plural nouns that would take one target form take it. -/
-def sharedFormRules : List (Rule Noun SubjPrefix) :=
+def sharedFormRules : List (Rule Chichewa.Gender.Noun SubjPrefix) :=
   [⟨.all, (·.gender.plSubjPrefix = .a), .a⟩, ⟨.all, (·.gender.plSubjPrefix = .zi), .zi⟩]
 
 /-- The regular rule: humans take the plural of gender 1/2 and the rest the plural of 7/8. -/
-def semanticRules : List (Rule Noun SubjPrefix) :=
+def semanticRules : List (Rule Chichewa.Gender.Noun SubjPrefix) :=
   [⟨.all, (·.human = true), .a⟩, Rule.otherwise .zi]
 
 /-- The shared form is preferred; the regular rule applies where there is none. -/
-def rules : List (Rule Noun SubjPrefix) := sharedFormRules ++ semanticRules
+def rules : List (Rule Chichewa.Gender.Noun SubjPrefix) := sharedFormRules ++ semanticRules
 
 /-- Syncretism licenses agreement, (18) and (19): conjuncts sharing a form take it. -/
-theorem resolve_of_shared {cs : List Noun} (hne : cs ≠ []) {f : SubjPrefix}
+theorem resolve_of_shared {cs : List Chichewa.Gender.Noun} (hne : cs ≠ []) {f : SubjPrefix}
     (h : ∀ c ∈ cs, c.gender.plSubjPrefix = f) : resolve rules cs = some f := by
   obtain ⟨c, hc⟩ := List.exists_mem_of_ne_nil cs hne
   simp only [rules, sharedFormRules, List.cons_append, List.nil_append]
@@ -326,7 +326,7 @@ theorem resolve_of_shared {cs : List Noun} (hne : cs ≠ []) {f : SubjPrefix}
     · exact λ h' => absurd ((h' c hc).symm.trans (h c hc)) (by decide)
 
 /-- Were the forms not syncretic, the regular rule would apply. -/
-theorem resolve_of_ne {cs : List Noun} (ha : ∃ c ∈ cs, c.gender.plSubjPrefix ≠ .a)
+theorem resolve_of_ne {cs : List Chichewa.Gender.Noun} (ha : ∃ c ∈ cs, c.gender.plSubjPrefix ≠ .a)
     (hz : ∃ c ∈ cs, c.gender.plSubjPrefix ≠ .zi) : resolve rules cs = resolve semanticRules cs := by
   obtain ⟨a, ha, ha'⟩ := ha
   obtain ⟨z, hz, hz'⟩ := hz
@@ -335,7 +335,7 @@ theorem resolve_of_ne {cs : List Noun} (ha : ∃ c ∈ cs, c.gender.plSubjPrefix
   simp [rules, sharedFormRules, resolve, Rule.Applies, h₁, h₂]
 
 /-- The regular rule on its own: gender 1/2 for humans, 7/8 for the rest. -/
-theorem resolve_semanticRules (cs : List Noun) :
+theorem resolve_semanticRules (cs : List Chichewa.Gender.Noun) :
     resolve semanticRules cs = some (if ∀ c ∈ cs, c.human = true then .a else .zi) := by
   unfold semanticRules
   split_ifs with hh

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -58,8 +58,6 @@ namespace Kramer2020
 
 open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology
-open Spanish.Gender (SpanishNoun)
-open Russian.Gender (DeclClass)
 
 /-! ### The semantic core (§1.2) -/
 
@@ -140,7 +138,7 @@ def tamil : Remainder Gender := ⟨{.masculine, .feminine}, {.neuter}⟩
 /-- Spanish: the remainder split arbitrarily over both core genders
 (Table 1), read off the Fragment. -/
 def spanish : Remainder Gender :=
-  ofNouns Spanish.Gender.allNouns (·.isNaturalGender) (·.attestedGender)
+  ofNouns Spanish.Gender.allNouns (·.isNaturalGender) (·.gender.toLabel)
 
 /-- Blackfoot: animates animate; inanimates in a novel inanimate gender or
 the recycled animate one. -/
@@ -166,7 +164,7 @@ end Remainder
 
 /-- [corbett-1991]'s assignment for the Russian remainder (18): Class I
 masculine, Class II or III feminine, all others neuter. -/
-def declensionGender : DeclClass → Gender
+def declensionGender : Russian.Gender.DeclClass → Gender
   | .I => .masculine
   | .II | .III => .feminine
   | .IV => .neuter
@@ -175,7 +173,7 @@ def declensionGender : DeclClass → Gender
 and masculine *put'*. -/
 theorem declension_exceptions :
     Russian.Gender.remainderNouns.filter
-        (fun n => n.declClass.map declensionGender ≠ some n.attestedGender) =
+        (fun n => n.declClass.map declensionGender ≠ some n.gender.toLabel) =
       [Russian.Gender.znamja, Russian.Gender.put'] := by
   decide
 
@@ -188,14 +186,14 @@ def phonologicalRule (n : Hausa.Noun) : Gender :=
 
 /-- (22e): *kadā̀* 'crocodile' ends in *-ā* and is masculine, so (26) is
 false. -/
-theorem phonologicalRule_kada : phonologicalRule Hausa.kada ≠ Hausa.kada.attestedGender := by
+theorem phonologicalRule_kada : phonologicalRule Hausa.kada ≠ Hausa.kada.gender := by
   decide
 
 /-- The correlation in its valid direction, feminine gender realized as
 *-ā*: every feminine noun outside the semantic core ends in *-ā*. -/
 theorem feminine_remainder_aa :
     ∀ n ∈ Hausa.allNouns,
-      n.isNaturalGender = false → n.attestedGender = .feminine → n.EndsInAa := by
+      n.isNaturalGender = false → n.gender = .feminine → n.EndsInAa := by
   decide
 
 /-! ### Lexical gender assignment (§3.2) -/
@@ -227,13 +225,14 @@ end LexicalEntry
 /-- The lexical entry of a Fragment noun: [human] for the natural-gender
 nouns (higher animals honoris causa), [female] for the female-denoting
 ones, and a listed [f] for the arbitrarily feminine remainder. -/
-def lexicalEntry (n : SpanishNoun) : LexicalEntry :=
-  ⟨n.isNaturalGender, n.isNaturalGender && n.attestedGender == .feminine,
-    !n.isNaturalGender && n.attestedGender == .feminine⟩
+def lexicalEntry (n : Spanish.Gender.Noun) : LexicalEntry :=
+  ⟨n.isNaturalGender, n.isNaturalGender && n.gender == .fem,
+    !n.isNaturalGender && n.gender == .fem⟩
 
 /-- The lexical account recovers every Fragment gender. -/
 theorem lexical_faithful :
-    ∀ n ∈ Spanish.Gender.allNouns, (lexicalEntry n).humanGender.gender = n.attestedGender := by
+    ∀ n ∈ Spanish.Gender.allNouns,
+      (lexicalEntry n).humanGender.gender = n.gender.toLabel := by
   decide
 
 /-- *persona*, listed with [f], stays feminine under Human Cloning. -/
@@ -249,15 +248,15 @@ def spanishHeads : List Categorizer.Head := [.n_iFem, .n_iMasc, .n_plain, .n_uFe
 /-- The n of a Fragment noun: interpretable gender for the natural-gender
 nouns, u[+fem] for the arbitrarily feminine remainder — *persona* among
 them — and plain n otherwise. -/
-def nHead (n : SpanishNoun) : Categorizer.Head :=
-  match n.attestedGender, n.isNaturalGender with
-  | .feminine, true => .n_iFem
-  | .masculine, true => .n_iMasc
-  | .feminine, false => .n_uFem
+def nHead (n : Spanish.Gender.Noun) : Categorizer.Head :=
+  match n.gender, n.isNaturalGender with
+  | .fem, true => .n_iFem
+  | .masc, true => .n_iMasc
+  | .fem, false => .n_uFem
   | _, _ => .n_plain
 
-theorem nHead_mem_spanishHeads (n : SpanishNoun) : nHead n ∈ spanishHeads := by
-  obtain ⟨_, _, g, b⟩ := n; cases g <;> cases b <;> simp [nHead, spanishHeads]
+theorem nHead_mem_spanishHeads (n : Spanish.Gender.Noun) : nHead n ∈ spanishHeads := by
+  obtain ⟨_, g, b⟩ := n; cases g <;> cases b <;> simp [nHead, spanishHeads]
 
 /-- Same-root nominals (14a) combine with either interpretable n. -/
 def sameRootHeads : List Categorizer.Head := [.n_iFem, .n_iMasc]
@@ -295,7 +294,7 @@ theorem determiner_iFem_eq_uFem :
 /-- The structural account recovers every Fragment gender. -/
 theorem structural_faithful :
     ∀ n ∈ Spanish.Gender.allNouns,
-      determiner (nHead n) = some (if n.attestedGender = .feminine then "la" else "el") := by
+      determiner (nHead n) = some (if n.gender = .fem then "la" else "el") := by
   decide
 
 /-- On Spanish the two accounts agree (§3.3). -/

--- a/Linglib/Syntax/Category/Noun/Basic.lean
+++ b/Linglib/Syntax/Category/Noun/Basic.lean
@@ -1,0 +1,44 @@
+import Linglib.Features.Gender.Capabilities
+
+/-!
+# Noun
+
+The noun as a lexical entry: its citation form and its gloss, everything a noun of any
+language carries. A language with gender extends the entry with the controller gender in
+its own carrier, the gender the language's assignment rules give the noun, and with whether
+that gender follows the referent's sex, the one facet every system with a semantic core
+reads; the facets particular rules read besides, animacy, rationality, declension class or
+accent, are the fields of the fragments' further extensions. The general concept takes the
+plain name and the specializations extend it, as in mathlib; a gendered noun bears the
+comparative label its carrier does.
+
+## Implementation notes
+
+* A fragment's extension is its own `Noun`, in its namespace; a file that opens that
+  namespace qualifies the name, the root `Noun` being in scope too.
+
+## Main declarations
+
+* `Noun` — the noun entry.
+* `GenderedNoun G` — the entry with its controller gender over the carrier `G`.
+-/
+
+/-- A noun entry: citation form and gloss. -/
+structure Noun where
+  /-- The citation form. -/
+  form : String
+  /-- The gloss. -/
+  gloss : String
+  deriving DecidableEq, Repr
+
+/-- A noun with its controller gender over the carrier `G`, and whether that gender follows
+the referent's sex. -/
+structure GenderedNoun (G : Type*) extends Noun where
+  /-- The controller gender: the agreements the noun takes. -/
+  gender : G
+  /-- Whether the gender follows the referent's sex. -/
+  isNaturalGender : Bool := false
+  deriving DecidableEq, Repr
+
+/-- A gendered noun bears the comparative label of its gender. -/
+instance {G : Type*} [HasGender G] : HasGender (GenderedNoun G) := ⟨λ n => genderOf n.gender⟩


### PR DESCRIPTION
Add the substrate noun entry, `Noun` (form, gloss) with `GenderedNoun G` extending it by the controller gender in the language's own carrier and the natural-gender flag, and migrate the fourteen fragment noun records onto it, retiring their local copies.

- Spanish and Russian move onto their `Value` carriers, with the comparative label derived through the system and the label-to-carrier inverse retired
- Each gendered fragment gets a `HasGender` instance through its carrier's label; consumers qualify a fragment's `Noun` where its namespace is open
- The unit-target `Gender.Faithful` idiom becomes `Function.Injective`