### PR TITLE
refactor(Studies/CremersWilcoxSpector2023): anti-exhaustivity conditions

### DIFF
--- a/Linglib/Core/Probability/JointPosterior.lean
+++ b/Linglib/Core/Probability/JointPosterior.lean
@@ -87,6 +87,45 @@ theorem posterior_fst_lt_iff
   -- Both sides are `(...) / marginal κ joint c`. Shared denominator cancels via div_lt_div_iff_left.
   exact ENNReal.div_lt_div_iff_left h (marginal_ne_top κ joint c)
 
+/-- **The marginalized posterior exceeds the marginalized prior** at `a` exactly when the
+conditional joint mass of the fibre over `a` exceeds the prior mass times the marginal
+likelihood. -/
+theorem fst_lt_posterior_fst_iff
+    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
+    (h : marginal κ joint c ≠ 0) (a : α) :
+    joint.fst a < (posterior κ joint c h).fst a
+      ↔ joint.fst a * marginal κ joint c < ∑ b : β, joint (a, b) * κ (a, b) c := by
+  rw [posterior_fst_apply,
+    ENNReal.lt_div_iff_mul_lt (Or.inl h) (Or.inl (marginal_ne_top κ joint c))]
+
+/-- **The marginalized posterior falls below the marginalized prior** at `a` exactly when the
+conditional joint mass of the fibre over `a` falls below the prior mass times the marginal
+likelihood. -/
+theorem posterior_fst_lt_fst_iff
+    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
+    (h : marginal κ joint c ≠ 0) (a : α) :
+    (posterior κ joint c h).fst a < joint.fst a
+      ↔ (∑ b : β, joint (a, b) * κ (a, b) c) < joint.fst a * marginal κ joint c := by
+  rw [posterior_fst_apply, ENNReal.div_lt_iff (Or.inl h) (Or.inl (marginal_ne_top κ joint c))]
+
+/-- The `≤` companion of `fst_lt_posterior_fst_iff`. -/
+theorem fst_le_posterior_fst_iff
+    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
+    (h : marginal κ joint c ≠ 0) (a : α) :
+    joint.fst a ≤ (posterior κ joint c h).fst a
+      ↔ joint.fst a * marginal κ joint c ≤ ∑ b : β, joint (a, b) * κ (a, b) c := by
+  rw [← not_lt, ← not_lt, not_iff_not]
+  exact posterior_fst_lt_fst_iff κ joint c h a
+
+/-- The `≤` companion of `posterior_fst_lt_fst_iff`. -/
+theorem posterior_fst_le_fst_iff
+    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
+    (h : marginal κ joint c ≠ 0) (a : α) :
+    (posterior κ joint c h).fst a ≤ joint.fst a
+      ↔ (∑ b : β, joint (a, b) * κ (a, b) c) ≤ joint.fst a * marginal κ joint c := by
+  rw [← not_lt, ← not_lt, not_iff_not]
+  exact fst_lt_posterior_fst_iff κ joint c h a
+
 /-- **Companion `≤` form** of `posterior_fst_lt_iff`. -/
 theorem posterior_fst_le_iff
     (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)

--- a/Linglib/Core/Probability/Posterior.lean
+++ b/Linglib/Core/Probability/Posterior.lean
@@ -516,6 +516,38 @@ theorem posterior_le_iff_score_le {α β : Type*} (κ : α → PMF β) (μ : PMF
   rw [← not_lt, ← not_lt, not_iff_not]
   exact posterior_lt_iff_score_lt κ μ b h a₂ a₁
 
+/-- **The posterior exceeds the prior** at `a` exactly when the likelihood of the observation
+at `a` exceeds its marginal likelihood. -/
+theorem lt_posterior_iff_marginal_lt {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
+    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
+    μ a < posterior κ μ b h a ↔ marginal κ μ b < κ a b := by
+  rw [posterior_apply, ← div_eq_mul_inv,
+    ENNReal.lt_div_iff_mul_lt (Or.inl h) (Or.inl (marginal_ne_top κ μ b)),
+    ENNReal.mul_lt_mul_iff_right ha (PMF.apply_ne_top μ a)]
+
+/-- **The posterior falls below the prior** at `a` exactly when the likelihood of the
+observation at `a` falls below its marginal likelihood. -/
+theorem posterior_lt_iff_lt_marginal {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
+    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
+    posterior κ μ b h a < μ a ↔ κ a b < marginal κ μ b := by
+  rw [posterior_apply, ← div_eq_mul_inv,
+    ENNReal.div_lt_iff (Or.inl h) (Or.inl (marginal_ne_top κ μ b)),
+    ENNReal.mul_lt_mul_iff_right ha (PMF.apply_ne_top μ a)]
+
+/-- The `≤` companion of `lt_posterior_iff_marginal_lt`. -/
+theorem le_posterior_iff_marginal_le {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
+    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
+    μ a ≤ posterior κ μ b h a ↔ marginal κ μ b ≤ κ a b := by
+  rw [← not_lt, ← not_lt, not_iff_not]
+  exact posterior_lt_iff_lt_marginal κ μ b h ha
+
+/-- The `≤` companion of `posterior_lt_iff_lt_marginal`. -/
+theorem posterior_le_iff_le_marginal {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
+    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
+    posterior κ μ b h a ≤ μ a ↔ κ a b ≤ marginal κ μ b := by
+  rw [← not_lt, ← not_lt, not_iff_not]
+  exact lt_posterior_iff_marginal_lt κ μ b h ha
+
 /-- **Set-version of `posterior_lt_iff_score_lt`**: comparing the
 outer-measure-of-Finset values of a posterior at two `Finset`s reduces to
 comparing the corresponding conditional joint sums. The shared

--- a/Linglib/Core/Probability/Softmax.lean
+++ b/Linglib/Core/Probability/Softmax.lean
@@ -2,6 +2,7 @@ import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import Mathlib.Probability.Distributions.Uniform
 import Mathlib.MeasureTheory.Measure.Tilted
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
+import Mathlib.Analysis.SpecialFunctions.Sigmoid
 
 /-!
 # Softmax distribution on PMFs
@@ -271,3 +272,21 @@ theorem softmax_natMul_log_apply {α : Type*} [Fintype α] (n : ℕ) (w : α →
   simp_rw [softmaxWeight_natMul_log_eq_pow]
 
 end PMF
+
+/-! ## Two applicable atoms -/
+
+/-- The softmax of one of two real scores is the logistic function of their difference. -/
+theorem Real.exp_div_add_exp_eq_sigmoid (x y : ℝ) :
+    Real.exp x / (Real.exp x + Real.exp y) = Real.sigmoid (x - y) := by
+  have hx := Real.exp_pos x
+  have hy := Real.exp_pos y
+  rw [Real.sigmoid_def, neg_sub, Real.exp_sub]
+  field_simp
+
+/-- The `ℝ≥0∞` form of `Real.exp_div_add_exp_eq_sigmoid`: the softmax mass of an atom when
+exactly one other atom is applicable. -/
+theorem ENNReal.ofReal_exp_div_add_ofReal_exp (x y : ℝ) :
+    ENNReal.ofReal (Real.exp x) / (ENNReal.ofReal (Real.exp x) + ENNReal.ofReal (Real.exp y)) =
+      ENNReal.ofReal (Real.sigmoid (x - y)) := by
+  rw [← ENNReal.ofReal_add (Real.exp_pos x).le (Real.exp_pos y).le,
+    ← ENNReal.ofReal_div_of_pos (by positivity), Real.exp_div_add_exp_eq_sigmoid]

--- a/Linglib/Pragmatics/RSA/Canonical.lean
+++ b/Linglib/Pragmatics/RSA/Canonical.lean
@@ -118,6 +118,42 @@ noncomputable def rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) (�
     (w : W) (u : U) : EReal :=
   (α : EReal) * (ENNReal.log (L0 w u) - (cost u : EReal))
 
+/-- The standard utility is `⊥` at an inapplicable utterance and otherwise the real
+`α·(log L0 − cost)`. -/
+theorem rsaUtility_eq (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α) {w : W} {u : U}
+    (hL : L0 w u ≠ ⊤) :
+    rsaUtility L0 cost α w u =
+      if L0 w u = 0 then ⊥ else ((α * (Real.log (L0 w u).toReal - cost u) : ℝ) : EReal) := by
+  unfold rsaUtility
+  split_ifs with h
+  · rw [h, ENNReal.log_zero, EReal.bot_sub, EReal.mul_bot_of_pos (by exact_mod_cast hα)]
+  · rw [ENNReal.log_pos_real h hL]; norm_cast
+
+/-- The standard utility is viable when the literal listener is finite and every world has an
+applicable utterance. -/
+theorem viableSpeaker_rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α)
+    (hL : ∀ w u, L0 w u ≠ ⊤) (hw : ∀ w, ∃ u, L0 w u ≠ 0) :
+    ViableSpeaker (rsaUtility L0 cost α) where
+  no_top w u := by
+    rw [rsaUtility_eq L0 cost hα (hL w u)]
+    split_ifs
+    · exact bot_ne_top
+    · exact EReal.coe_ne_top _
+  some_finite w := (hw w).imp λ u hu => by
+    rw [rsaUtility_eq L0 cost hα (hL w u), if_neg hu]; exact EReal.coe_ne_bot _
+
+/-- The softmax weight of the standard utility: `0` at an inapplicable utterance and otherwise
+`exp (α·(log L0 − cost))`. -/
+theorem softmaxWeight_rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α)
+    {w : W} {u : U} (hL : L0 w u ≠ ⊤) :
+    PMF.softmaxWeight (rsaUtility L0 cost α w) u =
+      if L0 w u = 0 then 0
+      else ENNReal.ofReal (Real.exp (α * (Real.log (L0 w u).toReal - cost u))) := by
+  rw [PMF.softmaxWeight_apply, rsaUtility_eq L0 cost hα hL]
+  split_ifs
+  · exact EReal.exp_bot
+  · exact EReal.exp_coe _
+
 end StandardSpeaker
 
 /-! ### Pragmatic listener -/

--- a/Linglib/Pragmatics/RSA/LatentOperators.lean
+++ b/Linglib/Pragmatics/RSA/LatentOperators.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Probability.JointPosterior
 import Linglib.Pragmatics.RSA.Operators
 
 /-!
@@ -289,6 +290,12 @@ of the joint posterior. -/
 noncomputable def jointListener {U : Type*} (S1 : W × L → PMF U) (μ : PMF (W × L))
     (u : U) (h : PMF.marginal S1 μ u ≠ 0) : PMF W :=
   (PMF.posterior S1 μ u h).map Prod.fst
+
+/-- Closed form of the joint-prior listener: the latent-summed score over the marginal. -/
+theorem jointListener_apply {U : Type*} [Fintype W] [Fintype L] [DecidableEq W]
+    (S1 : W × L → PMF U) (μ : PMF (W × L)) (u : U) (h : PMF.marginal S1 μ u ≠ 0) (w : W) :
+    jointListener S1 μ u h w = (∑ l, μ (w, l) * S1 (w, l) u) / PMF.marginal S1 μ u :=
+  PMF.posterior_fst_apply S1 μ u h w
 
 /-- **Inequality decomposition for `jointListener`** — joint-prior analogue of
 `posterior_lt_iff_kernel_lt_of_uniform`; the marginal normaliser cancels. -/

--- a/Linglib/Studies/CremersWilcoxSpector2023.lean
+++ b/Linglib/Studies/CremersWilcoxSpector2023.lean
@@ -1,1470 +1,1205 @@
-import Linglib.Pragmatics.RSA.Operators
+import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Pragmatics.RSA.LatentOperators
-import Linglib.Core.Probability.Posterior
+import Linglib.Pragmatics.RSA.QUD
 import Linglib.Semantics.Exhaustification.Finite
-import Mathlib.Data.ENNReal.Inv
 
 /-!
-# [cremers-wilcox-spector-2023]: Exhaustivity and Anti-Exhaustivity in RSA
+# Exhaustivity and anti-exhaustivity in the Rational Speech Act framework
 
-"Exhaustivity and Anti-Exhaustivity in the RSA Framework: Testing the
-Effect of Prior Beliefs." Cognitive Science 47(5), e13286.
+A listener who hears *A* where *A and B* was available infers that B is false. In the
+baseline Rational Speech Act model the inference can reverse: a prior biased towards the
+world where both A and B hold makes the literal listener already expect that world on
+hearing *A*, so the speaker uses the cheap *A* there rather than in the world where only A
+holds, and the pragmatic listener raises the probability of both A and B above her prior.
+Over two worlds and the messages *A*, *A and B* and *A and not B*, the speaker prefers *A* to
+*A and B* in the world of both exactly when the information *A and B* would add, the negated
+log prior, is not worth its cost, and the listener is anti-exhaustive exactly when the log
+odds of the prior exceed the cost disadvantage of *A and not B* over *A and B*, a condition
+independent of the rationality parameter. The models that lift a parameter of the baseline
+divide by whether they block this. Lexical uncertainty over free strengthenings, where *A*
+may mean *A and B*, and the wonky-world models, where the listener doubts the speaker's
+prior, remain anti-exhaustive for suitable priors, the Bayesian wonky model exactly when a
+wonkiness-weighted difference of logistic values is positive. Lexical uncertainty restricted
+to the grammatical exhaustification of *A*, the lexical-intentions speaker who chooses a
+message together with its interpretation, and the supervaluationist speaker who addresses a
+question under discussion and averages over the interpretations, all keep the posterior of
+both A and B below its prior whenever *A and B* costs no more than *A and not B*, the
+supervaluationist model for every cost. The experiment found no anti-exhaustivity in
+production or in comprehension; the wonky and supervaluationist models fit best, and once the
+two conjunctions are constrained to cost the same the models that cannot block
+anti-exhaustivity fall behind.
 
-## The Symmetry Problem
+## Implementation notes
 
-In baseline RSA, hearing "A" can *increase* belief in w_ab (where both A
-and B are true) when priors are biased toward w_ab. This "anti-exhaustive"
-behavior contradicts human interpretation — humans always exhaust "A" to
-mean "A and not B."
+* Meanings are interpretation functions on the three messages; the exhaustified one is
+  derived by innocent exclusion from the substrate rather than stipulated. The literal
+  listener is the substrate's prior-weighted conditioning, the speaker its softmax of the
+  standard informativity utility with the paper's rationality and costs, and the pragmatic
+  listener its Bayesian posterior; latent interpretations, questions and backgrounds enter
+  through the substrate's marginalised and joint listeners. Every result is stated for an
+  arbitrary prior in the open unit interval, positive rationality and arbitrary costs of the
+  two conjunctions, as in the paper's appendix; the supervaluationist listener takes any prior
+  on the questions that gives the fine one positive probability, while its speaker fixes the
+  two interpretations equiprobable, as the paper's fits do.
+* The supervaluationist speaker's expected utility over the two interpretations is defined
+  here, on the substrate's projection of a listener onto the cells of a question; the prior of
+  the question, common to every message, is left out of the utility.
+* The paper's anti-exhaustivity is the posterior of both A and B exceeding the prior; the
+  substrate's comparison of a posterior with its prior reduces it, over two worlds, to the
+  comparison of the two likelihoods of *A*, and the closed forms of those likelihoods are
+  logistic functions of utility differences. The non-Bayesian wonky model's anti-exhaustivity
+  is reduced to the paper's rational inequality, which the paper resolves numerically.
 
-## Key Result
+## TODO
 
-Models with grammatical exhaustification (EXH-LU, RSA-LI) block
-anti-exhaustivity regardless of prior bias. The EXH parse makes A false
-in w_ab, so S1 never uses A to convey w_ab under that parse. The prior
-bias is overridden by the structural asymmetry in meaning.
+* The non-Bayesian wonky model's limits in the prior for positive wonkiness, anti-exhaustive
+  as the prior tends to zero and exhaustive as it tends to one, are not proved.
+* The Bayesian wonky model's threshold on the wonkiness, the limit of its condition as the
+  prior tends to one, is not derived from the condition.
+* Higher-order speakers and listeners, at which anti-exhaustivity can reappear in the
+  grammatical models, the second-level analyses of the supervaluationist model, and the model
+  fits are prose.
 
-The paper's experimental data (comprehension task) found **no evidence of
-anti-exhaustivity**: listeners consistently infer "A and not B" from "A",
-regardless of prior bias. This supports grammatical models (EXH-LU,
-RSA-LI, svRSA) over baseline RSA and wRSA.
+## References
 
-## Domain
-
-- **Worlds**: w_a (only A true), w_ab (A and B both true)
-- **Utterances**: A (cost 0), A∧B (cost c), A∧¬B (cost c)
-- **Parses** (EXH-LU): literal (A true in both worlds) vs exh (A true only in w_a)
-
-## PMF stack
-
-Each model is a latent-variable RSA model on mathlib `PMF`, with the latent
-type the model's distinctive mechanism (parse / QUD / interpretation). For a
-fixed config with latent meaning `meaning : Latent → Utterance → World → ℝ≥0∞`:
-
-* `L0 lex u : PMF World` — `RSA.L0OfMeaning` (normalise the prior-weighted
-  meaning over worlds), so `L0(w | u, lex) ∝ P(w) · ⟦u⟧_lex(w)` (eq. 1).
-* `S1 lex w : PMF Utterance` — `RSA.S1Belief (L0 lex) (fun _ => 1) 2 w`
-  (α = 2, no utterance cost): `S1(u | w, lex) ∝ L0(w | u, lex)^2`.
-* `marginalSpeaker w : PMF Utterance` — `RSA.marginalizeKernel` of `S1`
-  against the uniform `Latent` prior.
-* `L1 u : PMF World` — `PMF.posterior marginalSpeaker (uniform World) u`.
-
-The L1 anti-exhaustivity test is `L1(.A) .w_ab > L1(.A) .w_a`, which under a
-uniform world prior reduces (via `PMF.posterior_lt_iff_kernel_lt_of_uniform`) to
-`marginalSpeaker .w_ab .A > marginalSpeaker .w_a .A` — exactly the marginalised
-speaker comparison `T(w) = Σ_l S1(.A | w, l)` of the paper (Appendix A.1).
-
-## Prior Placement
-
-The paper's L0 includes the prior (eq. 1): L0(w|u) ∝ P(w) · ⟦u⟧(w). The paper
-also has P(w) at L1 (eq. 3): L1(w|u) ∝ P(w) · S1(u|w). So P(w) enters twice.
-For the anti-exhaustivity classification at equal costs (Appendix A.1, eq. A.4)
-the L1 prior is a constant factor that cancels in the comparison, so we use a
-uniform world prior at L1 and bake `P(w)` into `meaning` for the prior-in-L0
-models (baseline, EXH-LU, FREE-LU). For svRSA the prior does NOT enter meaning;
-under the coarse QUD all A-true worlds collapse into one cell, neutralising the
-prior's effect on S1 (Appendix A.3), which we encode by unit meaning weights.
-
-## Anti-Exhaustivity Definition
-
-The paper's definition (Eq. 6b, equal costs): L1(w_ab|A) > P(w_ab),
-equivalently T(w_ab) > T(w_a) (Appendix A.1, eq. A.4), with
-T(w) = Σ_l S1(A|w,l). With the uniform world prior this reduces to
-`marginalSpeaker .w_ab .A > marginalSpeaker .w_a .A`.
-
-## Utterance Costs
-
-The paper includes costs c(A) = 0, c(A∧B) = c(A∧¬B) = c (eq. 2):
-S1(u|w) ∝ L0(w|u)^α · exp(-λc(u)). With equal costs for A∧B and A∧¬B, the cost
-terms cancel in the anti-exhaustivity condition (eq. 6b). We set all costs to 0
-(`costFactor = fun _ => 1`); the analytic condition in
-`antiExhaustivityCondition` handles the general case.
-
-## Model Classification
-
-The paper's 9 models fall into two groups by anti-exhaustivity behavior:
-
-| # | Model | Mechanism | Anti-exhaustive? | Listener |
-|---|-------|-----------|-----------------|--------|
-| 1 | Baseline RSA | — | Yes | `baselineL1` |
-| 2 | wRSA | Prior-in-L0 via background | Yes | `wRSAL1` |
-| 3 | BwRSA | Bayesian wRSA | Yes (= wRSA at L1) | `wRSAL1` |
-| 4 | svRSA1 | QUD blocks at S1 | No | `svRSAL1` |
-| 5 | svRSA2 | QUD blocks at S1 | No | `svRSAL1` |
-| 6 | FREE-LU | Free parse choice | Yes | `freeLUL1` |
-| 7 | EXH-LU | EXH blocks at L0 | No | `exhLUL1` |
-| 8 | RSA-LI1 | EXH blocks at L0 | No (= EXH-LU at L1) | `rsaLIL1` |
-| 9 | RSA-LI2 | EXH blocks at L0 | No (= EXH-LU at L1) | `rsaLIL1` |
-
-RSA-LI (Models 8–9) is [franke-bergen-2020]'s Lexical Intentions model;
-at L1 with uniform P(i) and equal costs it equals EXH-LU (Table 1).
-wRSA and BwRSA are identical at L1 (BwRSA adds a Bayesian S2 layer).
-svRSA uses no prior in L0 meaning — QUD projection neutralizes it
-(Appendix A.3), giving categorical blocking.
-
-### wRSA is a joint world–background listener
-
-wRSA's latent prior is **world-dependent**: P(w|b)·P(b) ([degen-etal-2015]) puts
-the 3:1 bias on the `default_` background and a uniform world prior on `wonky`
-(§4.1). Rather than a marginalised per-world speaker, the listener is jointly
-uncertain about `(w, b)`: its world belief is the `World`-marginal of the
-`(World × Background)` posterior, built with `RSA.jointPrior` + `RSA.jointListener`
-(the world-dependent-latent-prior siblings of `marginalizeKernel`/`PMF.posterior`).
-The anti-exhaustivity test reduces — via `RSA.jointListener_lt_iff_sum_score_lt`,
-the marginal normaliser cancelling — to the latent-summed score comparison
-`Σ_b μ(w_ab,b)·S1(.A|w_ab,b) > Σ_b μ(w_a,b)·S1(.A|w_a,b)`. The per-background
-speaker reuses the file's proven closed forms: `default_` is `baselineS1` (biased
-prior in L0) and `wonky` is `svRSAS1 .coarse` (unit meaning). The other four
-configs have world-independent uniform latent priors and use the
-`marginalizeKernel` stack.
-
-## Connection to Other Formalizations
-
-- `ExhaustivityLimit.lean`: proves RSA at α→∞ recovers Fox's exh,
-  using the same IE infrastructure (`Exhaustification.exhIE`)
-  as our `exhMeaning`.
-- `FrankeBergen2020.lean`: formalizes four RSA models (vanilla, LU, LI, GI)
-  for nested quantifiers, using compositional exhaustification.
-- `ScopeExpressivity.lean`: demonstrates the scope-blind vs scope-sensitive
-  expressivity gap between standard RSA and compositional EXH.
-- `PottsEtAl2016.lean`: the same latent-marginalisation PMF idiom
-  (`L0OfMeaning`/`S1Belief`/`marginalizeKernel`/`PMF.posterior`) for embedded
-  implicatures under lexical uncertainty.
+* [A. Cremers, E. G. Wilcox, B. Spector, *Exhaustivity and anti-exhaustivity in the RSA
+  framework* (2023)][cremers-wilcox-spector-2023]
+* [M. C. Frank, N. D. Goodman, *Predicting pragmatic reasoning in language games*
+  (2012)][frank-goodman-2012]
+* [J. Degen et al., *Wonky worlds* (2015)][degen-etal-2015]
+* [B. Spector, *The pragmatics of plural predication* (2017)][spector-2017]
+* [L. Bergen, R. Levy, N. D. Goodman, *Pragmatic reasoning through semantic inference*
+  (2016)][bergen-levy-goodman-2016]
+* [M. Franke, L. Bergen, *Theory-driven statistical modeling for semantics and pragmatics*
+  (2020)][franke-bergen-2020]
 -/
 
 open scoped ENNReal
+open RSA.Canonical
 
 namespace CremersWilcoxSpector2023
 
-/-! ### Domain types -/
+/-! ### Worlds, messages and interpretations -/
 
-/-- Two-world model for exhaustivity.
-    - `w_a`: A true, B false (A ∧ ¬B)
-    - `w_ab`: A and B both true (A ∧ B)
+/-- The two worlds: only A true, or both A and B true. -/
+inductive World where
+  | wa
+  | wab
+  deriving DecidableEq, Repr, Fintype, Inhabited
 
-    No w_b or w_none because we condition on A being true.
-    The question is whether B is also true. -/
-inductive CWSWorld where
-  | w_a : CWSWorld
-  | w_ab : CWSWorld
-  deriving DecidableEq, Repr, Inhabited, Fintype
+/-- The three messages: *A*, *A and B*, *A and not B*. -/
+inductive Message where
+  | a
+  | aAndB
+  | aAndNotB
+  deriving DecidableEq, Repr, Fintype
 
-/-- Three utterances in the minimal exhaustivity domain. -/
-inductive CWSUtterance where
-  | A : CWSUtterance
-  | AandB : CWSUtterance
-  | AandNotB : CWSUtterance
-  deriving DecidableEq, Repr, Inhabited, Fintype
+/-- The literal meaning of each message. -/
+def truth : Message → World → Bool
+  | .a, _ => true
+  | .aAndB, .wab => true
+  | .aAndB, .wa => false
+  | .aAndNotB, .wa => true
+  | .aAndNotB, .wab => false
 
-/-! ### Literal semantics -/
+/-- The alternatives of a message: *A* has the scale-mate *A and B*. -/
+def alternatives : Message → List (World → Bool)
+  | .a => [truth .a, truth .aAndB]
+  | u => [truth u]
 
-/-- Literal truth: which utterance is true in which world. -/
-def literalTruth : CWSWorld → CWSUtterance → Bool
-  | .w_a, .A => true
-  | .w_a, .AandB => false
-  | .w_a, .AandNotB => true
-  | .w_ab, .A => true
-  | .w_ab, .AandB => true
-  | .w_ab, .AandNotB => false
+/-- The exhaustified meaning, by innocent exclusion of the alternatives. -/
+def exh (u : Message) (w : World) : Bool :=
+  decide (w ∈ Exhaustification.innocent.exh (Exhaustification.altsFromPreds (alternatives u))
+    (Exhaustification.predToFinset (truth u)))
 
-/-- A is true in both worlds. -/
-theorem A_true_everywhere : ∀ w, literalTruth w .A = true := by
-  intro w; cases w <;> rfl
+/-- Exhaustification reads *A* as *A and not B*. -/
+theorem exh_a (w : World) : exh .a w = truth .aAndNotB w := by cases w <;> decide
 
-/-- A∧B only true in w_ab. -/
-theorem AandB_only_in_wab : literalTruth .w_a .AandB = false ∧ literalTruth .w_ab .AandB = true := by
-  constructor <;> rfl
+/-- *A and B* has no stronger alternative. -/
+theorem exh_aAndB (w : World) : exh .aAndB w = truth .aAndB w := by cases w <;> decide
 
-/-- A∧¬B only true in w_a. -/
-theorem AandNotB_only_in_wa : literalTruth .w_a .AandNotB = true ∧ literalTruth .w_ab .AandNotB = false := by
-  constructor <;> rfl
+/-- *A and not B* has no stronger alternative. -/
+theorem exh_aAndNotB (w : World) : exh .aAndNotB w = truth .aAndNotB w := by
+  cases w <;> decide
 
-/-! ### Exhaustification (Innocent Exclusion) -/
+/-- An interpretation function under which every message is true somewhere and every world
+is described by some message, so that the literal listener and the speaker are defined. -/
+structure Meaning where
+  /-- The truth value of a message at a world. -/
+  sat : Message → World → Bool
+  /-- Every message is true somewhere. -/
+  exists_world : ∀ u, ∃ w, sat u w = true
+  /-- Every world is described by some message. -/
+  exists_message : ∀ w, ∃ u, sat u w = true
 
-open Exhaustification (innocent predToFinset altsFromPreds)
+/-- The literal interpretation. -/
+def literal : Meaning := ⟨truth, by decide, by decide⟩
 
-/-- Alternatives for each utterance: A has scale-mate A∧B. -/
-def alternatives (u : CWSUtterance) : List (CWSWorld → Bool) :=
-  match u with
-  | .A => [fun w => literalTruth w .A, fun w => literalTruth w .AandB]
-  | _ => [fun w => literalTruth w u]
+/-- The exhaustified interpretation, *A* read as *A and not B*. -/
+def exhaustified : Meaning := ⟨exh, by decide, by decide⟩
 
-/-- Exhaustified meaning derived via Innocent Exclusion.
-    IE negates A∧B (the non-entailed stronger alternative to A),
-    giving EXH(A) = A ∧ ¬(A∧B) = A ∧ ¬B. -/
-def exhMeaning (w : CWSWorld) (u : CWSUtterance) : Bool :=
-  decide (w ∈ innocent.exh (altsFromPreds (alternatives u))
-                    (predToFinset (fun w' => literalTruth w' u)))
+/-- The anti-exhaustive interpretation of the free lexical-uncertainty model, *A* read as
+*A and B*. -/
+def antiExhaustive : Meaning :=
+  ⟨λ u w => match u with | .a => truth .aAndB w | u => truth u w, by decide, by decide⟩
 
-/-- EXH(A) is only true in w_a — derived from IE, not stipulated. -/
-theorem exhA_only_in_wa : exhMeaning .w_a .A = true ∧ exhMeaning .w_ab .A = false := by
-  constructor <;> decide
+/-- The two grammatical interpretations, literal and exhaustified. -/
+inductive Interpretation where
+  | lit
+  | exh
+  deriving DecidableEq, Repr, Fintype, Inhabited
 
-/-- EXH(A∧B) unchanged: A∧B has no stronger alternative. -/
-theorem exhAB_unchanged : ∀ w, exhMeaning w .AandB = literalTruth w .AandB := by
-  decide
+/-- The meaning of a grammatical interpretation. -/
+def Interpretation.meaning : Interpretation → Meaning
+  | .lit => literal
+  | .exh => exhaustified
 
-/-- EXH(A∧¬B) unchanged: A∧¬B has no stronger alternative. -/
-theorem exhAnotB_unchanged : ∀ w, exhMeaning w .AandNotB = literalTruth w .AandNotB := by
-  decide
+/-- The three interpretations of the free lexical-uncertainty model. -/
+inductive FreeInterpretation where
+  | lit
+  | exh
+  | antiExh
+  deriving DecidableEq, Repr, Fintype, Inhabited
 
-/-- Per-cell `exhMeaning` values (derived from IE via `decide`), `@[simp]` so the
-prior-weighted meaning functions reduce without re-evaluating Innocent Exclusion. -/
-@[simp] private theorem exhMeaning_A_wa : exhMeaning .w_a .A = true := by decide
-@[simp] private theorem exhMeaning_A_wab : exhMeaning .w_ab .A = false := by decide
-@[simp] private theorem exhMeaning_AandB_wa : exhMeaning .w_a .AandB = false := by decide
-@[simp] private theorem exhMeaning_AandB_wab : exhMeaning .w_ab .AandB = true := by decide
-@[simp] private theorem exhMeaning_AandNotB_wa : exhMeaning .w_a .AandNotB = true := by decide
-@[simp] private theorem exhMeaning_AandNotB_wab : exhMeaning .w_ab .AandNotB = false := by decide
+/-- The meaning of a free interpretation. -/
+def FreeInterpretation.meaning : FreeInterpretation → Meaning
+  | .lit => literal
+  | .exh => exhaustified
+  | .antiExh => antiExhaustive
 
-/-! ### Parse-dependent meaning -/
+/-- The wonky-world listener's two backgrounds: the speaker assumes a uniform prior or the
+measured one. -/
+inductive Background where
+  | wonky
+  | measured
+  deriving DecidableEq, Repr, Fintype
 
-/-- Parse = whether EXH is applied. -/
-inductive CWSParse where
-  | literal : CWSParse
-  | exh : CWSParse
-  deriving DecidableEq, Repr, Inhabited, Fintype
+/-- The questions under discussion: whether A holds, which the two worlds answer alike, or
+which world obtains. -/
+inductive QUD where
+  | coarse
+  | fine
+  deriving DecidableEq, Repr, Fintype
 
-/-- Meaning with parse-dependent exhaustification. -/
-def parseMeaning : CWSParse → CWSWorld → CWSUtterance → Bool
-  | .literal, w, u => literalTruth w u
-  | .exh, w, u => exhMeaning w u
+section Sums
 
-/-! ### Prior weight and cost -/
+variable {β : Type*} [AddCommMonoid β]
 
-/-- Prior weight for each world: 1:3 bias toward w_ab.
+/-- A sum over the two worlds. -/
+theorem sum_World (f : World → β) : ∑ w, f w = f .wa + f .wab := by
+  rw [show ∑ w, f w = f .wa + (f .wab + 0) from rfl, add_zero]
 
-    Baked into `meaning` for prior-in-L0 models so that
-    `L0(w|u) ∝ P(w) · ⟦u⟧(w)`, matching the paper's eq. (1). This makes S1
-    asymmetric for utterances true in both worlds, which is the source of
-    anti-exhaustivity. -/
-def priorWeight : CWSWorld → ℝ
-  | .w_a => 1
-  | .w_ab => 3
+/-- A sum over the three messages. -/
+theorem sum_Message (f : Message → β) : ∑ u, f u = f .a + f .aAndB + f .aAndNotB := by
+  rw [show ∑ u, f u = f .a + (f .aAndB + (f .aAndNotB + 0)) from rfl, add_zero, add_assoc]
 
-/-- Utterance cost (Appendix A.1, eq. A.1). The paper uses c(A) = 0 and
-    positive c for A∧B and A∧¬B, but with equal costs the classification
-    is prior-determined (eq. 6b). We set all costs to 0; the general case
-    is handled analytically by `antiExhaustivityCondition`. -/
-def utteranceCost : CWSUtterance → ℝ
-  | .A => 0
-  | .AandB => 0
-  | .AandNotB => 0
+/-- A sum over the two grammatical interpretations. -/
+theorem sum_Interpretation (f : Interpretation → β) : ∑ i, f i = f .lit + f .exh := by
+  rw [show ∑ i, f i = f .lit + (f .exh + 0) from rfl, add_zero]
 
-/-! ### Anti-exhaustivity condition (Eq. 6b) -/
+/-- A sum over the three free interpretations. -/
+theorem sum_FreeInterpretation (f : FreeInterpretation → β) :
+    ∑ i, f i = f .lit + f .exh + f .antiExh := by
+  rw [show ∑ i, f i = f .lit + (f .exh + (f .antiExh + 0)) from rfl, add_zero, add_assoc]
 
-/-- The paper's analytic condition for when baseline RSA is anti-exhaustive.
+/-- A sum over the two backgrounds. -/
+theorem sum_Background (f : Background → β) : ∑ b, f b = f .wonky + f .measured := by
+  rw [show ∑ b, f b = f .wonky + (f .measured + 0) from rfl, add_zero]
 
-    Full condition (Eq. 6b): `log P(w_ab) - log P(w_a) > c(A∧¬B) - c(A∧B)`.
-    When the cost of the exhaustive paraphrase A∧¬B exceeds the conjunctive
-    alternative A∧B, the speaker's dispreference for the paraphrase makes
-    anti-exhaustivity easier to trigger. With equal costs, any prior bias
-    toward w_ab suffices. -/
-def antiExhaustivityCondition (log_p_wab log_p_wa c_AnotB c_AB : ℚ) : Bool :=
-  log_p_wab - log_p_wa > c_AnotB - c_AB
+/-- A sum over the two questions. -/
+theorem sum_QUD (f : QUD → β) : ∑ q, f q = f .coarse + f .fine := by
+  rw [show ∑ q, f q = f .coarse + (f .fine + 0) from rfl, add_zero]
 
-/-- Equal costs: anti-exhaustivity iff P(w_ab) > P(w_a) (i.e., log ratio > 0). -/
-theorem equal_costs_reduces_to_prior (log_wab log_wa c : ℚ) :
-    antiExhaustivityCondition log_wab log_wa c c = (log_wab > log_wa) := by
-  simp [antiExhaustivityCondition, sub_self]
+end Sums
 
-/-- Uniform prior with equal costs: no anti-exhaustivity. -/
-theorem uniform_no_antiexh :
-    antiExhaustivityCondition 0 0 1 1 = false := by
-  simp only [antiExhaustivityCondition, decide_eq_false_iff_not]; norm_num
+/-! ### Priors and parameters -/
 
-/-- Biased prior with equal costs: anti-exhaustivity triggered. -/
-theorem biased_triggers_antiexh :
-    antiExhaustivityCondition 3 1 1 1 = true := by
-  simp only [antiExhaustivityCondition, decide_eq_true_iff]; norm_num
+/-- The parameters of a model: the prior probability of both A and B, the rationality, and
+the costs of the two conjunctions, *A* itself costing nothing. -/
+structure Setting where
+  /-- The prior probability of the world where both A and B hold. -/
+  p : ℝ
+  /-- The rationality, the paper's λ. -/
+  lam : ℝ
+  /-- The cost of *A and B*. -/
+  cAB : ℝ
+  /-- The cost of *A and not B*. -/
+  cAnotB : ℝ
+  /-- The world of both has positive prior probability. -/
+  p_pos : 0 < p
+  /-- The world of A alone has positive prior probability. -/
+  p_lt_one : p < 1
+  /-- The rationality is positive. -/
+  lam_pos : 0 < lam
 
-/-- Asymmetric costs can block anti-exhaustivity even with biased prior:
-    if c(A∧¬B) is much more expensive than c(A∧B), the cost gap
-    c(A∧¬B) - c(A∧B) exceeds the log prior ratio. -/
-theorem cost_asymmetry_can_block :
-    antiExhaustivityCondition 3 1 10 0 = false := by
-  simp only [antiExhaustivityCondition, decide_eq_false_iff_not]; norm_num
+namespace Setting
 
-/-! ### Shared sum unfolders and α = 2 score reduction
+variable (s : Setting)
 
-The PMF stack below reduces partition functions over `CWSWorld` / `CWSUtterance`
-to concrete two/three-term sums via the `rfl` unfolders, and the speaker score
-`(L0 u w)^(2:ℝ) · 1` to a nat power `(L0 u w)^(2:ℕ)` so it lands as
-`ofReal (r^2)`. -/
+/-- The cost of a message. -/
+def cost : Message → ℝ
+  | .a => 0
+  | .aAndB => s.cAB
+  | .aAndNotB => s.cAnotB
 
-/-- Sum-over-`CWSWorld` unfolder, proved by `rfl`. -/
-theorem CWSWorld_sum_univ {β : Type*} [AddCommMonoid β] (f : CWSWorld → β) :
-    ∑ i, f i = f .w_a + (f .w_ab + 0) := by rfl
+/-- The measured prior over the two worlds. -/
+noncomputable def prior : PMF World :=
+  PMF.ofFintype (λ w => match w with
+    | .wa => ENNReal.ofReal (1 - s.p)
+    | .wab => ENNReal.ofReal s.p) (by
+    rw [sum_World]
+    show ENNReal.ofReal (1 - s.p) + ENNReal.ofReal s.p = 1
+    rw [← ENNReal.ofReal_add (by linarith [s.p_lt_one]) s.p_pos.le, sub_add_cancel,
+      ENNReal.ofReal_one])
 
-/-- Sum-over-`CWSUtterance` unfolder, proved by `rfl`. -/
-theorem CWSUtterance_sum_univ {β : Type*} [AddCommMonoid β] (f : CWSUtterance → β) :
-    ∑ i, f i = f .A + (f .AandB + (f .AandNotB + 0)) := by rfl
+/-- The prior of the world of A alone. -/
+theorem prior_wa : s.prior .wa = ENNReal.ofReal (1 - s.p) := rfl
 
-/-- α = 2 score reduction: the speaker score `(L0 u w)^(2:ℝ) · 1` is the *square*
-`(L0 u w)^(2:ℕ)`. The `(2:ℝ)` rpow becomes a `(2:ℕ)` power via
-`ENNReal.rpow_natCast`; this is the α≠1 analogue of Potts' `rpow_one` collapse.
-Used by the partition-function reductions below. -/
-theorem rpow_two_mul_one (x : ℝ≥0∞) : x ^ (2 : ℝ) * 1 = x ^ (2 : ℕ) := by
-  rw [mul_one, show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, ENNReal.rpow_natCast]
+/-- The prior of the world of both. -/
+theorem prior_wab : s.prior .wab = ENNReal.ofReal s.p := rfl
 
-/-- `ofReal r` squared (α = 2): `(ofReal r)^(2:ℕ) = ofReal (r^2)` for `0 ≤ r`.
-Carries the squared L0 closed forms into the `Z` / `marginalSpeaker` arithmetic. -/
-theorem sq_ofReal (r : ℝ) (hr : 0 ≤ r) :
-    (ENNReal.ofReal r) ^ (2 : ℕ) = ENNReal.ofReal (r ^ 2) :=
-  (ENNReal.ofReal_pow hr 2).symm
+/-- The prior is positive on both worlds. -/
+theorem prior_ne_zero (w : World) : s.prior w ≠ 0 := by
+  cases w
+  · exact (ENNReal.ofReal_pos.mpr (by linarith [s.p_lt_one])).ne'
+  · exact (ENNReal.ofReal_pos.mpr s.p_pos).ne'
 
-/-! ### Baseline RSA (Model 1)
+/-- The prior of the world of A alone, as a real. -/
+theorem prior_wa_toReal : (s.prior .wa).toReal = 1 - s.p :=
+  ENNReal.toReal_ofReal (by linarith [s.p_lt_one])
 
-Prior-in-L0, no latent (`Unit`): `meaning(u,w) = P(w) · ⟦u⟧(w)`, so
-`L0(w_a|A) = 1/4, L0(w_ab|A) = 3/4`. With α = 2 the speaker is asymmetric:
-`S1(A|w_ab) = 9/25 > 1/17 = S1(A|w_a)`. The speaker preferentially uses the
-cheap utterance A when w_ab is true (L0 already favours w_ab given A), driving
-genuine anti-exhaustivity (Eq. 6b, Fig. 1). With no latent, the marginal
-speaker is `S1` itself. -/
+/-- The prior of the world of both, as a real. -/
+theorem prior_wab_toReal : (s.prior .wab).toReal = s.p := ENNReal.toReal_ofReal s.p_pos.le
 
-/-- Baseline meaning: `P(w)·⟦u⟧(w)` lifted to `ℝ≥0∞`. -/
-def baselineMeaning (u : CWSUtterance) (w : CWSWorld) : ℝ≥0∞ :=
-  if literalTruth w u then ENNReal.ofReal (priorWeight w) else 0
+/-- The prior sums to one. -/
+theorem prior_add : s.prior .wa + s.prior .wab = 1 := by
+  rw [prior_wa, prior_wab, ← ENNReal.ofReal_add (by linarith [s.p_lt_one]) s.p_pos.le,
+    sub_add_cancel, ENNReal.ofReal_one]
 
-theorem baselineMeaning_apply (u : CWSUtterance) (w : CWSWorld) :
-    baselineMeaning u w = if literalTruth w u then ENNReal.ofReal (priorWeight w) else 0 := rfl
+end Setting
 
-theorem baselineMeaning_ne_top (u : CWSUtterance) : (∑' w, baselineMeaning u w) ≠ ∞ :=
-  ENNReal.tsum_ne_top_of_fintype
-    (fun w => by rw [baselineMeaning_apply]; split <;> simp [ENNReal.ofReal_ne_top])
+/-- The wonky prior: uniform over the two worlds. -/
+noncomputable def wonkyPrior : PMF World := PMF.uniformOfFintype World
 
-theorem baselineMeaning_pos (u : CWSUtterance) : (∑' w, baselineMeaning u w) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
+/-- The wonky prior gives each world a half. -/
+theorem wonkyPrior_apply (w : World) : wonkyPrior w = 2⁻¹ := by
+  rw [wonkyPrior, PMF.uniformOfFintype_apply, show Fintype.card World = 2 from rfl]
+  norm_cast
+
+/-- The wonky prior is positive on both worlds. -/
+theorem wonkyPrior_ne_zero (w : World) : wonkyPrior w ≠ 0 := by rw [wonkyPrior_apply]; simp
+
+/-- The wonky prior of a world, as a real. -/
+theorem wonkyPrior_toReal (w : World) : (wonkyPrior w).toReal = 2⁻¹ := by
+  rw [wonkyPrior_apply, ENNReal.toReal_inv]; simp
+
+/-! ### The literal listener and the speaker under an interpretation (eqs. 1 to 3) -/
+
+section Speaker
+
+variable (P : PMF World) (hP : ∀ w, P w ≠ 0) (m : Meaning)
+include hP
+
+/-- The prior mass of a message's extension is positive. -/
+theorem meaning_ne_zero (u : Message) :
+    (∑' w, P w * (if m.sat u w then (1 : ℝ≥0∞) else 0)) ≠ 0 := by
+  obtain ⟨w, hw⟩ := m.exists_world u
+  exact ENNReal.summable.tsum_ne_zero_iff.mpr ⟨w, by rw [hw]; simpa using hP w⟩
+
+/-- eq. (1): the literal listener, the prior conditioned on the message's meaning. -/
+noncomputable def L0 (u : Message) : PMF World :=
+  RSA.L0LassiterGoodman P m.sat u (meaning_ne_zero P hP m u)
+
+/-- The literal listener in closed form. -/
+theorem L0_apply (u : Message) (w : World) :
+    L0 P hP m u w =
+      P w * (if m.sat u w then 1 else 0) * (∑' w', P w' * (if m.sat u w' then 1 else 0))⁻¹ :=
+  RSA.L0LassiterGoodman_apply _ _ _ _ _
+
+/-- A message true at a world has positive mass there. -/
+theorem L0_ne_zero {u : Message} {w : World} (h : m.sat u w = true) : L0 P hP m u w ≠ 0 :=
+  (PMF.mem_support_iff _ _).mp
+    ((RSA.mem_support_L0LassiterGoodman_iff _ _ _ _ w).mpr ⟨hP w, h⟩)
+
+/-- A message false at a world gets no mass there. -/
+theorem L0_eq_zero {u : Message} {w : World} (h : m.sat u w = false) : L0 P hP m u w = 0 := by
+  rw [L0_apply, h]; simp
+
+/-- A message true at one world only puts all its mass there. -/
+theorem L0_eq_one {u : Message} {w : World} (h : m.sat u w = true)
+    (h' : ∀ w', m.sat u w' = true → w' = w) : L0 P hP m u w = 1 := by
+  rw [L0_apply, tsum_eq_single w (λ w' hne => by
+    rw [Bool.eq_false_iff.mpr (λ hw => hne (h' w' hw))]; simp), h]
+  simp [ENNReal.mul_inv_cancel (hP w) (PMF.apply_ne_top P w)]
+
+/-- The tautology *A* leaves the prior unchanged. -/
+theorem L0_literal_a (w : World) : L0 P hP literal .a w = P w :=
+  RSA.L0LassiterGoodman_apply_of_meaning_true P truth .a (λ w => by cases w <;> rfl) _ w
+
+/-- *A and B* singles out the world of both. -/
+theorem L0_literal_aAndB_wab : L0 P hP literal .aAndB .wab = 1 :=
+  L0_eq_one _ _ _ rfl (by decide)
+
+/-- *A and B* is false in the world of A alone. -/
+theorem L0_literal_aAndB_wa : L0 P hP literal .aAndB .wa = 0 := L0_eq_zero _ _ _ rfl
+
+/-- *A and not B* singles out the world of A alone. -/
+theorem L0_literal_aAndNotB_wa : L0 P hP literal .aAndNotB .wa = 1 :=
+  L0_eq_one _ _ _ rfl (by decide)
+
+/-- *A and not B* is false in the world of both. -/
+theorem L0_literal_aAndNotB_wab : L0 P hP literal .aAndNotB .wab = 0 := L0_eq_zero _ _ _ rfl
+
+/-- Exhaustified *A* singles out the world of A alone. -/
+theorem L0_exhaustified_a_wa : L0 P hP exhaustified .a .wa = 1 :=
+  L0_eq_one _ _ _ (by decide) (by decide)
+
+/-- Exhaustified *A* is false in the world of both. -/
+theorem L0_exhaustified_a_wab : L0 P hP exhaustified .a .wab = 0 :=
+  L0_eq_zero _ _ _ (by decide)
+
+/-- Under exhaustification *A and B* still singles out the world of both. -/
+theorem L0_exhaustified_aAndB_wab : L0 P hP exhaustified .aAndB .wab = 1 :=
+  L0_eq_one _ _ _ (by decide) (by decide)
+
+/-- Under exhaustification *A and B* is still false in the world of A alone. -/
+theorem L0_exhaustified_aAndB_wa : L0 P hP exhaustified .aAndB .wa = 0 :=
+  L0_eq_zero _ _ _ (by decide)
+
+/-- Under exhaustification *A and not B* still singles out the world of A alone. -/
+theorem L0_exhaustified_aAndNotB_wa : L0 P hP exhaustified .aAndNotB .wa = 1 :=
+  L0_eq_one _ _ _ (by decide) (by decide)
+
+/-- Under exhaustification *A and not B* is still false in the world of both. -/
+theorem L0_exhaustified_aAndNotB_wab : L0 P hP exhaustified .aAndNotB .wab = 0 :=
+  L0_eq_zero _ _ _ (by decide)
+
+/-- Anti-exhaustive *A* singles out the world of both. -/
+theorem L0_antiExhaustive_a_wab : L0 P hP antiExhaustive .a .wab = 1 :=
+  L0_eq_one _ _ _ rfl (by decide)
+
+/-- Anti-exhaustive *A* is false in the world of A alone. -/
+theorem L0_antiExhaustive_a_wa : L0 P hP antiExhaustive .a .wa = 0 := L0_eq_zero _ _ _ rfl
+
+/-- Under the anti-exhaustive reading *A and B* still singles out the world of both. -/
+theorem L0_antiExhaustive_aAndB_wab : L0 P hP antiExhaustive .aAndB .wab = 1 :=
+  L0_eq_one _ _ _ rfl (by decide)
+
+/-- Under the anti-exhaustive reading *A and not B* is still false in the world of both. -/
+theorem L0_antiExhaustive_aAndNotB_wab : L0 P hP antiExhaustive .aAndNotB .wab = 0 :=
+  L0_eq_zero _ _ _ rfl
+
+variable (s : Setting)
+
+/-- eq. (2): the utility of a message at a world for the literal listener under the
+interpretation, the rationality times the log probability of the world less the cost. -/
+noncomputable def utility (w : World) (u : Message) : EReal :=
+  rsaUtility (λ w u => L0 P hP m u w) s.cost s.lam w u
+
+instance : ViableSpeaker (utility P hP m s) :=
+  viableSpeaker_rsaUtility _ _ s.lam_pos (λ _ _ => PMF.apply_ne_top _ _) λ w =>
+    let ⟨u, hu⟩ := m.exists_message w
+    ⟨u, L0_ne_zero P hP m hu⟩
+
+/-- eq. (3): the speaker, the softmax of the utility. -/
+noncomputable def speaker (w : World) : PMF Message := S1 (utility P hP m s) w
+
+/-- The utility is `⊥` at a message false at the world and otherwise real. -/
+theorem utility_eq (w : World) (u : Message) :
+    utility P hP m s w u =
+      if L0 P hP m u w = 0 then ⊥
+      else ((s.lam * (Real.log (L0 P hP m u w).toReal - s.cost u) : ℝ) : EReal) :=
+  rsaUtility_eq _ _ s.lam_pos (PMF.apply_ne_top _ _)
+
+/-- The softmax weight of a message: zero at a message false at the world. -/
+theorem softmaxWeight_utility (w : World) (u : Message) :
+    PMF.softmaxWeight (utility P hP m s w) u =
+      if L0 P hP m u w = 0 then 0
+      else ENNReal.ofReal (Real.exp (s.lam * (Real.log (L0 P hP m u w).toReal - s.cost u))) :=
+  softmaxWeight_rsaUtility _ _ s.lam_pos (PMF.apply_ne_top _ _)
+
+/-- The speaker in closed form. -/
+theorem speaker_apply (w : World) (u : Message) :
+    speaker P hP m s w u =
+      PMF.softmaxWeight (utility P hP m s w) u / ∑ v, PMF.softmaxWeight (utility P hP m s w) v :=
+  PMF.softmax_apply _ (ViableSpeaker.no_top w) (ViableSpeaker.some_finite w) u
+
+/-- The speaker uses every message true at the world. -/
+theorem speaker_ne_zero {w : World} {u : Message} (h : m.sat u w = true) :
+    speaker P hP m s w u ≠ 0 :=
+  S1_ne_zero _ (by rw [utility_eq, if_neg (L0_ne_zero P hP m h)]; exact EReal.coe_ne_bot _)
+
+end Speaker
+
+/-- The literal listener with the measured prior. -/
+noncomputable abbrev Setting.L0 (s : Setting) (m : Meaning) : Message → PMF World :=
+  CremersWilcoxSpector2023.L0 s.prior s.prior_ne_zero m
+
+/-- The speaker with the measured prior in the literal listener. -/
+noncomputable abbrev Setting.speaker (s : Setting) (m : Meaning) : World → PMF Message :=
+  CremersWilcoxSpector2023.speaker s.prior s.prior_ne_zero m s
+
+/-! ### Closed forms: the speaker's use of *A* is a logistic function -/
+
+section ClosedForms
+
+variable (P : PMF World) (hP : ∀ w, P w ≠ 0) (s : Setting)
+
+/-- eq. (A.3): in the world of both, the literal speaker's use of *A* is the logistic
+function of the cost of *A and B* plus the log prior. -/
+theorem speaker_literal_wab_a :
+    speaker P hP literal s .wab .a =
+      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAB + Real.log (P .wab).toReal))) := by
+  rw [speaker_apply, sum_Message]
+  simp only [softmaxWeight_utility, L0_literal_a, L0_literal_aAndB_wab, L0_literal_aAndNotB_wab,
+    hP .wab, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost]
+  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
+  congr 2; ring
+
+/-- eq. (A.2): in the world of A alone, the use of *A* is the logistic function of the
+cost of *A and not B* plus the log prior. -/
+theorem speaker_literal_wa_a :
+    speaker P hP literal s .wa .a =
+      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAnotB + Real.log (P .wa).toReal))) := by
+  rw [speaker_apply, sum_Message]
+  simp only [softmaxWeight_utility, L0_literal_a, L0_literal_aAndB_wa, L0_literal_aAndNotB_wa,
+    hP .wa, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost]
+  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
+  congr 2; ring
+
+/-- Under the exhaustified interpretation *A* is as informative as *A and not B* in the
+world of A alone, so its use is the logistic function of the latter's cost. -/
+theorem speaker_exhaustified_wa_a :
+    speaker P hP exhaustified s .wa .a = ENNReal.ofReal (Real.sigmoid (s.lam * s.cAnotB)) := by
+  rw [speaker_apply, sum_Message]
+  simp only [softmaxWeight_utility, L0_exhaustified_a_wa, L0_exhaustified_aAndB_wa,
+    L0_exhaustified_aAndNotB_wa, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one,
+    Real.log_one, Setting.cost]
+  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
+  congr 2; ring
+
+/-- Under the exhaustified interpretation *A* is false in the world of both. -/
+theorem speaker_exhaustified_wab_a : speaker P hP exhaustified s .wab .a = 0 := by
+  rw [speaker_apply, softmaxWeight_utility, L0_exhaustified_a_wab, if_pos rfl, ENNReal.zero_div]
+
+/-- Under the anti-exhaustive interpretation *A* is as informative as *A and B* in the world
+of both. -/
+theorem speaker_antiExhaustive_wab_a :
+    speaker P hP antiExhaustive s .wab .a = ENNReal.ofReal (Real.sigmoid (s.lam * s.cAB)) := by
+  rw [speaker_apply, sum_Message]
+  simp only [softmaxWeight_utility, L0_antiExhaustive_a_wab, L0_antiExhaustive_aAndB_wab,
+    L0_antiExhaustive_aAndNotB_wab, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one,
+    Real.log_one, Setting.cost]
+  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
+  congr 2; ring
+
+/-- Under the anti-exhaustive interpretation *A* is false in the world of A alone. -/
+theorem speaker_antiExhaustive_wa_a : speaker P hP antiExhaustive s .wa .a = 0 := by
+  rw [speaker_apply, softmaxWeight_utility, L0_antiExhaustive_a_wa, if_pos rfl,
+    ENNReal.zero_div]
+
+end ClosedForms
+
+/-! ### Two-world Bayes -/
+
+/-- Against a two-point prior, the likelihood at a point exceeds the marginal likelihood
+exactly when it exceeds the likelihood at the other point. -/
+private theorem two_world_lt {a b x y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hx : x ≠ ⊤) :
+    a * y + b * x < x ↔ y < x := by
+  have ha' : a ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_self_add)
+  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
+  have h : a * y + b * x < a * x + b * x ↔ y < x := by
+    rw [ENNReal.add_lt_add_iff_right (ENNReal.mul_ne_top hb' hx),
+      ENNReal.mul_lt_mul_iff_right ha ha']
+  rwa [← add_mul, hab, one_mul] at h
+
+private theorem lt_two_world {a b x y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hx : x ≠ ⊤) :
+    x < a * y + b * x ↔ x < y := by
+  have ha' : a ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_self_add)
+  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
+  have h : a * x + b * x < a * y + b * x ↔ x < y := by
+    rw [ENNReal.add_lt_add_iff_right (ENNReal.mul_ne_top hb' hx),
+      ENNReal.mul_lt_mul_iff_right ha ha']
+  rwa [← add_mul, hab, one_mul] at h
+
+/-! ### The baseline model (§3) -/
+
+section Baseline
+
+variable (s : Setting)
+
+/-- (6a): in the world of both, the speaker prefers *A* to *A and B* exactly when the
+information *A and B* would add, the negated log prior, does not exceed its cost. -/
+theorem baseline_aAndB_lt_a_iff :
+    s.speaker literal .wab .aAndB < s.speaker literal .wab .a ↔ -s.cAB < Real.log s.p := by
+  dsimp only [Setting.speaker]
+  rw [speaker, S1_prefers_iff, utility_eq, utility_eq, L0_literal_aAndB_wab, L0_literal_a,
+    if_neg one_ne_zero, if_neg (s.prior_ne_zero _), Setting.prior_wab_toReal,
+    ENNReal.toReal_one, Real.log_one, EReal.coe_lt_coe_iff]
+  simp only [Setting.cost, zero_sub, sub_zero]
+  exact mul_lt_mul_iff_of_pos_left s.lam_pos
+
+/-- (7): in the world of A alone, the speaker prefers *A and not B* to *A* exactly when
+the negated log prior exceeds its cost. -/
+theorem baseline_a_lt_aAndNotB_iff :
+    s.speaker literal .wa .a < s.speaker literal .wa .aAndNotB ↔
+      Real.log (1 - s.p) < -s.cAnotB := by
+  dsimp only [Setting.speaker]
+  rw [speaker, S1_prefers_iff, utility_eq, utility_eq, L0_literal_aAndNotB_wa, L0_literal_a,
+    if_neg one_ne_zero, if_neg (s.prior_ne_zero _), Setting.prior_wa_toReal,
+    ENNReal.toReal_one, Real.log_one, EReal.coe_lt_coe_iff]
+  simp only [Setting.cost, zero_sub, sub_zero]
+  exact mul_lt_mul_iff_of_pos_left s.lam_pos
+
+/-- Every message is used somewhere, so has positive marginal likelihood. -/
+theorem baseline_marginal_ne_zero (u : Message) :
+    PMF.marginal (s.speaker literal) s.prior u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (speaker_ne_zero _ _ _ _ hw)
+
+/-- eq. (4): the pragmatic listener. -/
+noncomputable def listener (u : Message) : PMF World :=
+  RSA.L1 (s.speaker literal) s.prior u (baseline_marginal_ne_zero s u)
+
+/-- (A.4): the listener is anti-exhaustive, the posterior of both A and B exceeding the
+prior, exactly when the speaker uses *A* more in the world of both than in the world of A
+alone. -/
+theorem prior_lt_listener_iff_speaker_lt :
+    s.prior .wab < listener s .a .wab ↔ s.speaker literal .wa .a < s.speaker literal .wab .a := by
+  rw [listener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum, sum_World]
+  exact two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _)
+
+/-- (6b): the listener is anti-exhaustive exactly when the log odds of the prior exceed the
+cost disadvantage of *A and not B* over *A and B*, whatever the rationality. -/
+theorem prior_lt_listener_iff :
+    s.prior .wab < listener s .a .wab ↔
+      s.cAnotB - s.cAB < Real.log s.p - Real.log (1 - s.p) := by
+  rw [prior_lt_listener_iff_speaker_lt]
+  dsimp only [Setting.speaker]
+  rw [speaker_literal_wa_a, speaker_literal_wab_a, Setting.prior_wa_toReal,
+    Setting.prior_wab_toReal, ENNReal.ofReal_lt_ofReal_iff (Real.sigmoid_pos _),
+    Real.sigmoid_lt_iff, mul_lt_mul_iff_of_pos_left s.lam_pos]
+  constructor <;> intro h <;> linarith
+
+/-- With equal costs, anti-exhaustivity is a prior biased towards the world of both. -/
+theorem prior_lt_listener_iff_of_cost_eq (hc : s.cAB = s.cAnotB) :
+    s.prior .wab < listener s .a .wab ↔ 1 / 2 < s.p := by
+  rw [prior_lt_listener_iff, hc, sub_self, sub_pos,
+    Real.log_lt_log_iff (by linarith [s.p_lt_one]) s.p_pos]
+  constructor <;> intro <;> linarith
+
+/-- At the costs of the paper's first figure, a half and one, anti-exhaustivity sets in
+where the log odds of the prior exceed a half, whatever the rationality. -/
+theorem prior_lt_listener_iff_of_cost (hAB : s.cAB = 1 / 2) (hAnotB : s.cAnotB = 1) :
+    s.prior .wab < listener s .a .wab ↔ 1 / 2 < Real.log s.p - Real.log (1 - s.p) := by
+  rw [prior_lt_listener_iff, hAB, hAnotB]; norm_num
+
+end Baseline
+
+/-! ### Lexical uncertainty (§4.3) -/
+
+section LexicalUncertainty
+
+variable (s : Setting)
+
+/-- The speaker of the grammatical lexical-uncertainty model, marginalised over the two
+equiprobable interpretations. -/
+noncomputable def luSpeaker (w : World) : PMF Message :=
+  RSA.marginalizeKernel (PMF.uniformOfFintype Interpretation)
+    (λ i w => s.speaker i.meaning w) w
+
+/-- The grammatical lexical-uncertainty speaker in closed form. -/
+theorem luSpeaker_apply (w : World) (u : Message) :
+    luSpeaker s w u = 2⁻¹ * s.speaker literal w u + 2⁻¹ * s.speaker exhaustified w u := by
+  rw [luSpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_Interpretation]
+  simp [PMF.uniformOfFintype_apply, Interpretation.meaning, show Fintype.card Interpretation = 2
+    from rfl]
+
+/-- Every message is used somewhere, so has positive marginal likelihood. -/
+theorem luMarginal_ne_zero (u : Message) : PMF.marginal (luSpeaker s) s.prior u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
+    rw [luSpeaker_apply]
+    intro h
+    rcases mul_eq_zero.mp (add_eq_zero.mp h).1 with h | h
+    · simp at h
+    · exact speaker_ne_zero _ _ _ _ hw h)
+
+/-- item 4 of the §4.3 model: the pragmatic listener of the grammatical lexical-uncertainty
+model. -/
+noncomputable def luListener (u : Message) : PMF World :=
+  RSA.L1 (luSpeaker s) s.prior u (luMarginal_ne_zero s u)
+
+/-- Grammatical lexical uncertainty blocks anti-exhaustivity whenever *A and B* costs no more
+than *A and not B*: the exhaustified interpretation never uses *A* in the world of both but
+uses it in the world of A alone more than the literal interpretation uses it in the world of
+both. -/
+theorem luListener_lt_prior (hc : s.cAB ≤ s.cAnotB) : luListener s .a .wab < s.prior .wab := by
+  rw [luListener, RSA.L1, PMF.posterior_lt_iff_lt_marginal _ _ _ _ (s.prior_ne_zero _)]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum, sum_World,
+    lt_two_world s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), luSpeaker_apply,
+    luSpeaker_apply]
+  dsimp only [Setting.speaker]
+  rw [speaker_literal_wab_a, speaker_exhaustified_wab_a, speaker_literal_wa_a,
+    speaker_exhaustified_wa_a, mul_zero, add_zero, ← mul_add,
+    ENNReal.mul_lt_mul_iff_right (by simp) (by simp), Setting.prior_wab_toReal,
+    Setting.prior_wa_toReal, ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
+    ENNReal.ofReal_lt_ofReal_iff (add_pos (Real.sigmoid_pos _) (Real.sigmoid_pos _))]
+  calc Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) < Real.sigmoid (s.lam * s.cAnotB) :=
+        Real.sigmoid_lt (mul_lt_mul_of_pos_left
+          (by linarith [Real.log_neg s.p_pos s.p_lt_one]) s.lam_pos)
+    _ ≤ _ := le_add_of_nonneg_left (Real.sigmoid_nonneg _)
+
+/-- The speaker of the free lexical-uncertainty model, marginalised over the three
+equiprobable interpretations. -/
+noncomputable def freeSpeaker (w : World) : PMF Message :=
+  RSA.marginalizeKernel (PMF.uniformOfFintype FreeInterpretation)
+    (λ i w => s.speaker i.meaning w) w
+
+/-- The free lexical-uncertainty speaker in closed form. -/
+theorem freeSpeaker_apply (w : World) (u : Message) :
+    freeSpeaker s w u =
+      3⁻¹ * s.speaker literal w u + 3⁻¹ * s.speaker exhaustified w u +
+        3⁻¹ * s.speaker antiExhaustive w u := by
+  rw [freeSpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_FreeInterpretation]
+  simp [PMF.uniformOfFintype_apply, FreeInterpretation.meaning,
+    show Fintype.card FreeInterpretation = 3 from rfl]
+
+/-- Every message is used somewhere, so has positive marginal likelihood. -/
+theorem freeMarginal_ne_zero (u : Message) : PMF.marginal (freeSpeaker s) s.prior u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
+    rw [freeSpeaker_apply]
+    intro h
+    rcases mul_eq_zero.mp (add_eq_zero.mp (add_eq_zero.mp h).1).1 with h | h
+    · simp at h
+    · exact speaker_ne_zero _ _ _ _ hw h)
+
+/-- The pragmatic listener of the free lexical-uncertainty model. -/
+noncomputable def freeListener (u : Message) : PMF World :=
+  RSA.L1 (freeSpeaker s) s.prior u (freeMarginal_ne_zero s u)
+
+/-- Free lexical uncertainty is anti-exhaustive exactly when the literal and anti-exhaustive
+uses of *A* in the world of both outweigh the literal and exhaustified uses in the world of A
+alone. -/
+theorem prior_lt_freeListener_iff :
+    s.prior .wab < freeListener s .a .wab ↔
+      Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p))) +
+          Real.sigmoid (s.lam * s.cAnotB) <
+        Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) + Real.sigmoid (s.lam * s.cAB) := by
+  rw [freeListener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum, sum_World,
+    two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), freeSpeaker_apply,
+    freeSpeaker_apply]
+  dsimp only [Setting.speaker]
+  rw [speaker_literal_wab_a, speaker_exhaustified_wab_a, speaker_antiExhaustive_wab_a,
+    speaker_literal_wa_a, speaker_exhaustified_wa_a, speaker_antiExhaustive_wa_a]
+  simp only [mul_zero, add_zero]
+  rw [← mul_add, ← mul_add, ENNReal.mul_lt_mul_iff_right (by simp) (by simp),
+    Setting.prior_wab_toReal, Setting.prior_wa_toReal,
+    ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
+    ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
+    ENNReal.ofReal_lt_ofReal_iff (add_pos (Real.sigmoid_pos _) (Real.sigmoid_pos _))]
+
+/-- With equal costs, free lexical uncertainty is anti-exhaustive exactly when the baseline
+is: for a prior biased towards the world of both. -/
+theorem prior_lt_freeListener_iff_of_cost_eq (hc : s.cAB = s.cAnotB) :
+    s.prior .wab < freeListener s .a .wab ↔ 1 / 2 < s.p := by
+  rw [prior_lt_freeListener_iff, hc, add_lt_add_iff_right, Real.sigmoid_lt_iff,
+    mul_lt_mul_iff_of_pos_left s.lam_pos, add_lt_add_iff_left,
+    Real.log_lt_log_iff (by linarith [s.p_lt_one]) s.p_pos]
+  constructor <;> intro <;> linarith
+
+end LexicalUncertainty
+
+/-! ### Lexical intentions (§4.4) -/
+
+section LexicalIntentions
+
+variable (s : Setting)
+
+/-- item 2 of the §4.4 model: the utility of a message together with the interpretation the
+literal listener will give it. -/
+noncomputable def liUtility (w : World) (x : Message × Interpretation) : EReal :=
+  rsaUtility (λ w x => s.L0 x.2.meaning x.1 w) (λ x => s.cost x.1) s.lam w x
+
+instance : ViableSpeaker (liUtility s) :=
+  viableSpeaker_rsaUtility _ _ s.lam_pos (λ _ _ => PMF.apply_ne_top _ _) λ w =>
+    ⟨(.a, .lit), L0_ne_zero _ _ _ (by cases w <;> rfl)⟩
+
+/-- item 3 of the §4.4 model: the joint speaker over messages and interpretations. -/
+noncomputable def liSpeaker (w : World) : PMF (Message × Interpretation) := S1 (liUtility s) w
+
+/-- item 5 of the §4.4 model: the speaker's messages, the interpretations marginalised. -/
+noncomputable def liMessageSpeaker (w : World) : PMF Message := (liSpeaker s w).map Prod.fst
+
+/-- The lexical-intentions speaker's use of a message sums its two interpretations. -/
+theorem liMessageSpeaker_apply (w : World) (u : Message) :
+    liMessageSpeaker s w u = liSpeaker s w (u, .lit) + liSpeaker s w (u, .exh) := by
+  rw [liMessageSpeaker, PMF.map_apply, tsum_fintype, Fintype.sum_prod_type, sum_Message]
+  cases u <;> simp [sum_Interpretation]
+
+/-- The joint speaker in closed form. -/
+theorem liSpeaker_apply (w : World) (x : Message × Interpretation) :
+    liSpeaker s w x =
+      PMF.softmaxWeight (liUtility s w) x / ∑ y, PMF.softmaxWeight (liUtility s w) y :=
+  PMF.softmax_apply _ (ViableSpeaker.no_top w) (ViableSpeaker.some_finite w) x
+
+/-- The lexical-intentions utility is `⊥` at a message false at the world under its
+interpretation and otherwise real. -/
+theorem liUtility_eq (w : World) (x : Message × Interpretation) :
+    liUtility s w x =
+      if s.L0 x.2.meaning x.1 w = 0 then ⊥
+      else ((s.lam * (Real.log (s.L0 x.2.meaning x.1 w).toReal - s.cost x.1) : ℝ) : EReal) :=
+  rsaUtility_eq _ _ s.lam_pos (PMF.apply_ne_top _ _)
+
+/-- The softmax weight of a message under an interpretation. -/
+theorem softmaxWeight_liUtility (w : World) (x : Message × Interpretation) :
+    PMF.softmaxWeight (liUtility s w) x =
+      if s.L0 x.2.meaning x.1 w = 0 then 0
+      else ENNReal.ofReal (Real.exp
+        (s.lam * (Real.log (s.L0 x.2.meaning x.1 w).toReal - s.cost x.1))) :=
+  softmaxWeight_rsaUtility _ _ s.lam_pos (PMF.apply_ne_top _ _)
+
+/-- In the world of both, the lexical-intentions speaker uses *A*, under its literal
+interpretation only, against the two interpretations of *A and B*. -/
+theorem liMessageSpeaker_wab_a :
+    liMessageSpeaker s .wab .a =
+      ENNReal.ofReal (Real.exp (s.lam * Real.log s.p) /
+        (Real.exp (s.lam * Real.log s.p) + 2 * Real.exp (-(s.lam * s.cAB)))) := by
+  rw [liMessageSpeaker_apply, liSpeaker_apply, liSpeaker_apply, Fintype.sum_prod_type,
+    sum_Message]
+  simp only [sum_Interpretation, softmaxWeight_liUtility, Interpretation.meaning, Setting.L0,
+    L0_literal_a, L0_exhaustified_a_wab, L0_literal_aAndB_wab, L0_exhaustified_aAndB_wab,
+    L0_literal_aAndNotB_wab, L0_exhaustified_aAndNotB_wab, s.prior_ne_zero, one_ne_zero,
+    ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost,
+    Setting.prior_wab_toReal, sub_zero, zero_sub, mul_neg]
+  rw [ENNReal.div_add_div_same, ← ENNReal.ofReal_add (Real.exp_pos _).le (Real.exp_pos _).le,
+    ← two_mul, add_zero, ← ENNReal.ofReal_add (Real.exp_pos _).le (by positivity),
+    ← ENNReal.ofReal_div_of_pos (by positivity)]
+
+/-- In the world of A alone, the lexical-intentions speaker uses *A* under both
+interpretations, the exhaustified one as informative as *A and not B*. -/
+theorem liMessageSpeaker_wa_a :
+    liMessageSpeaker s .wa .a =
+      ENNReal.ofReal ((Real.exp (s.lam * Real.log (1 - s.p)) + 1) /
+        (Real.exp (s.lam * Real.log (1 - s.p)) + 1 + 2 * Real.exp (-(s.lam * s.cAnotB)))) := by
+  rw [liMessageSpeaker_apply, liSpeaker_apply, liSpeaker_apply, Fintype.sum_prod_type,
+    sum_Message]
+  simp only [sum_Interpretation, softmaxWeight_liUtility, Interpretation.meaning, Setting.L0,
+    L0_literal_a, L0_exhaustified_a_wa, L0_literal_aAndB_wa, L0_exhaustified_aAndB_wa,
+    L0_literal_aAndNotB_wa, L0_exhaustified_aAndNotB_wa, s.prior_ne_zero, one_ne_zero,
+    ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost,
+    Setting.prior_wa_toReal, sub_zero, zero_sub, mul_neg, mul_zero, Real.exp_zero,
+    ENNReal.ofReal_one]
+  rw [ENNReal.div_add_div_same, ← ENNReal.ofReal_one,
+    ← ENNReal.ofReal_add (Real.exp_pos _).le zero_le_one,
+    ← ENNReal.ofReal_add (Real.exp_pos _).le (Real.exp_pos _).le, ← two_mul,
+    ← ENNReal.ofReal_add (by positivity) (by positivity),
+    ← ENNReal.ofReal_div_of_pos (by positivity)]
+
+/-- Every message is used somewhere, so has positive marginal likelihood. -/
+theorem liMarginal_ne_zero (u : Message) : PMF.marginal (liMessageSpeaker s) s.prior u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
+    rw [liMessageSpeaker_apply]
+    intro h
+    exact S1_ne_zero (liUtility s) (u := (u, .lit)) (by
+      rw [liUtility_eq, if_neg]
+      · exact EReal.coe_ne_bot _
+      · exact L0_ne_zero _ _ _ hw) (add_eq_zero.mp h).1)
+
+/-- item 6 of the §4.4 model: the pragmatic listener of the lexical-intentions model. -/
+noncomputable def liListener (u : Message) : PMF World :=
+  RSA.L1 (liMessageSpeaker s) s.prior u (liMarginal_ne_zero s u)
+
+/-- The lexical-intentions model blocks anti-exhaustivity whenever *A and B* costs no more
+than *A and not B*: *A* is never likelier in the world of both than in the world of A
+alone. -/
+theorem liListener_lt_prior (hc : s.cAB ≤ s.cAnotB) : liListener s .a .wab < s.prior .wab := by
+  rw [liListener, RSA.L1, PMF.posterior_lt_iff_lt_marginal _ _ _ _ (s.prior_ne_zero _)]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum, sum_World,
+    lt_two_world s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), liMessageSpeaker_wab_a,
+    liMessageSpeaker_wa_a, ENNReal.ofReal_lt_ofReal_iff (by positivity),
+    div_lt_div_iff₀ (by positivity) (by positivity)]
+  have h₁ : Real.exp (s.lam * Real.log s.p) < 1 :=
+    Real.exp_lt_one_iff.mpr (mul_neg_of_pos_of_neg s.lam_pos (Real.log_neg s.p_pos s.p_lt_one))
+  have h₂ : Real.exp (-(s.lam * s.cAnotB)) ≤ Real.exp (-(s.lam * s.cAB)) :=
+    Real.exp_le_exp.mpr (by nlinarith [s.lam_pos])
+  have h₃ := Real.exp_pos (-(s.lam * s.cAnotB))
+  have h₄ := Real.exp_pos (s.lam * Real.log (1 - s.p))
+  nlinarith [mul_lt_mul_of_pos_right h₁ h₃, mul_pos h₄ (Real.exp_pos (-(s.lam * s.cAB)))]
+
+end LexicalIntentions
+
+/-! ### The supervaluationist model (§4.2) -/
+
+section Supervaluationist
+
+variable (s : Setting)
+
+/-- The cells of a question: the coarse question does not distinguish the worlds, the fine
+one does. -/
+def QUD.project : QUD → World → Option World
+  | .coarse, _ => none
+  | .fine, w => some w
+
+/-- item 3 of the §4.2 model, conditioned on the question: the literal listener's mass,
+under an interpretation, on the cell of a world in a question. -/
+noncomputable def cell (i : Interpretation) (q : QUD) (u : Message) (w : World) : ℝ≥0∞ :=
+  RSA.QUD.proj QUD.project (s.L0 i.meaning u) q w
+
+/-- The fine question's cells are the worlds. -/
+theorem cell_fine (i : Interpretation) (u : Message) (w : World) :
+    cell s i .fine u w = s.L0 i.meaning u w := by
+  simp [cell, RSA.QUD.proj, QUD.project, Finset.filter_eq']
+
+/-- The coarse question has one cell, which carries all the mass. -/
+theorem cell_coarse (i : Interpretation) (u : Message) (w : World) :
+    cell s i .coarse u w = 1 := by
+  simp only [cell, RSA.QUD.proj, QUD.project, Finset.filter_true_of_mem (λ _ _ => trivial)]
+  exact (tsum_fintype _).symm.trans (PMF.tsum_coe _)
+
+/-- A cell's mass is finite. -/
+theorem cell_ne_top (i : Interpretation) (q : QUD) (u : Message) (w : World) :
+    cell s i q u w ≠ ⊤ :=
+  RSA.QUD.proj_ne_top_of_pmf _ _ _ _
+
+/-- item 4 of the §4.2 model: the supervaluationist utility, the expected log probability of
+the cell over the two interpretations, taken equiprobable, less the cost; the prior of the
+question, common to every message, is left out. -/
+noncomputable def svUtility (x : World × QUD) (u : Message) : EReal :=
+  (s.lam : EReal) *
+    (((1 / 2 : ℝ) : EReal) * ENNReal.log (cell s .lit x.2 u x.1) +
+      ((1 / 2 : ℝ) : EReal) * ENNReal.log (cell s .exh x.2 u x.1) - (s.cost u : EReal))
+
+/-- The supervaluationist utility is `⊥` when the message is false on the cell under some
+interpretation, and otherwise real. -/
+theorem svUtility_eq (x : World × QUD) (u : Message) :
+    svUtility s x u =
+      if cell s .lit x.2 u x.1 = 0 ∨ cell s .exh x.2 u x.1 = 0 then ⊥
+      else ((s.lam * (1 / 2 * Real.log (cell s .lit x.2 u x.1).toReal +
+        1 / 2 * Real.log (cell s .exh x.2 u x.1).toReal - s.cost u) : ℝ) : EReal) := by
+  unfold svUtility
+  split_ifs with h
+  · rcases h with h | h
+    · rw [h, ENNReal.log_zero, EReal.mul_bot_of_pos (by norm_num), EReal.bot_add, EReal.bot_sub,
+        EReal.mul_bot_of_pos (by exact_mod_cast s.lam_pos)]
+    · rw [h, ENNReal.log_zero, EReal.mul_bot_of_pos (by norm_num), EReal.add_bot, EReal.bot_sub,
+        EReal.mul_bot_of_pos (by exact_mod_cast s.lam_pos)]
+  · push Not at h
+    rw [ENNReal.log_pos_real h.1 (cell_ne_top _ _ _ _ _),
+      ENNReal.log_pos_real h.2 (cell_ne_top _ _ _ _ _)]
+    norm_cast
+
+/-- Under the fine question a message true at a world under both interpretations has finite
+utility there. -/
+theorem svUtility_fine_ne_bot {w : World} {u : Message} (hl : truth u w = true)
+    (he : exh u w = true) : svUtility s (w, .fine) u ≠ ⊥ := by
+  rw [svUtility_eq, if_neg (by
+    simp only [cell_fine, Interpretation.meaning, Setting.L0, not_or]
+    exact ⟨L0_ne_zero _ _ _ hl, L0_ne_zero _ _ _ he⟩)]
+  exact EReal.coe_ne_bot _
+
+instance : ViableSpeaker (svUtility s) where
+  no_top x u := by
+    rw [svUtility_eq]
+    split_ifs
+    · exact bot_ne_top
+    · exact EReal.coe_ne_top _
+  some_finite x := by
+    obtain ⟨w, q⟩ := x
+    cases q
+    · exact ⟨.a, by
+        rw [svUtility_eq, if_neg (by simp [cell_coarse])]
+        exact EReal.coe_ne_bot _⟩
+    · cases w
+      · exact ⟨.a, svUtility_fine_ne_bot s rfl (by decide)⟩
+      · exact ⟨.aAndB, svUtility_fine_ne_bot s rfl (by decide)⟩
+
+/-- item 5 of the §4.2 model: the supervaluationist speaker, at a world and a question. -/
+noncomputable def svSpeaker (x : World × QUD) : PMF Message := S1 (svUtility s) x
+
+/-- Under the coarse question every message is true on the one cell, so the speaker does not
+depend on the world. -/
+theorem svSpeaker_coarse : svSpeaker s (.wa, .coarse) = svSpeaker s (.wab, .coarse) := by
+  have h : svUtility s (.wa, .coarse) = svUtility s (.wab, .coarse) := by
+    funext u; simp only [svUtility, cell_coarse]
+  exact PMF.ext λ u => by
+    rw [svSpeaker, svSpeaker, S1, S1, PMF.softmax_apply, PMF.softmax_apply, h]
+
+/-- Under the fine question the exhaustified *A* is false in the world of both, so its
+expected utility there is `⊥` and the speaker never uses it. -/
+theorem svSpeaker_wab_fine_a : svSpeaker s (.wab, .fine) .a = 0 := by
+  have h : svUtility s (.wab, .fine) .a = ⊥ := by
+    rw [svUtility_eq, if_pos (Or.inr (by
+      simp [cell_fine, Interpretation.meaning, L0_exhaustified_a_wab]))]
+  rw [svSpeaker, S1, PMF.softmax_apply, PMF.softmaxWeight_apply, h, EReal.exp_bot,
+    ENNReal.zero_div]
+
+/-- Under the fine question *A* is used in the world of A alone. -/
+theorem svSpeaker_wa_fine_a_ne_zero : svSpeaker s (.wa, .fine) .a ≠ 0 :=
+  S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide))
+
+/-- Appendix A.3, the speaker: under either question, *A* is used no more in the world of
+both than in the world of A alone. -/
+theorem svSpeaker_wab_le_wa (q : QUD) : svSpeaker s (.wab, q) .a ≤ svSpeaker s (.wa, q) .a := by
+  cases q
+  · rw [svSpeaker_coarse]
+  · rw [svSpeaker_wab_fine_a]; exact zero_le
+
+variable (Q : PMF QUD) (hQ : Q .fine ≠ 0)
+
+/-- The joint prior over worlds and questions, independent. -/
+noncomputable def svJoint : PMF (World × QUD) := RSA.jointPrior Q (λ _ => s.prior)
+
+/-- The joint prior factors. -/
+theorem svJoint_apply (w : World) (q : QUD) : svJoint s Q (w, q) = Q q * s.prior w :=
+  RSA.jointPrior_apply _ _ _ _
+
+/-- The world marginal of the joint prior is the measured prior. -/
+theorem svJoint_fst (w : World) : (svJoint s Q).fst w = s.prior w := by
+  rw [PMF.fst_apply, sum_QUD, svJoint_apply, svJoint_apply, ← add_mul, ← sum_QUD,
+    (tsum_fintype _).symm.trans (PMF.tsum_coe Q), one_mul]
+
+include hQ in
+/-- Every message is used somewhere under the fine question, so has positive marginal
+likelihood. -/
+theorem svMarginal_ne_zero (u : Message) : PMF.marginal (svSpeaker s) (svJoint s Q) u ≠ 0 := by
   cases u
-  · exact ⟨.w_a, by rw [baselineMeaning_apply]; simp [literalTruth, priorWeight]⟩
-  · exact ⟨.w_ab, by rw [baselineMeaning_apply]; simp [literalTruth, priorWeight]⟩
-  · exact ⟨.w_a, by rw [baselineMeaning_apply]; simp [literalTruth, priorWeight]⟩
-
-/-- Baseline literal listener: `L0(w|u) ∝ P(w)·⟦u⟧(w)` (eq. 1). -/
-noncomputable def baselineL0 (u : CWSUtterance) : PMF CWSWorld :=
-  RSA.L0OfMeaning baselineMeaning u (baselineMeaning_pos u) (baselineMeaning_ne_top u)
-
-private theorem baselineL0_ofReal (u : CWSUtterance) (w : CWSWorld) (r : ℝ)
-    (h : baselineMeaning u w * (∑' w', baselineMeaning u w')⁻¹ = ENNReal.ofReal r) :
-    baselineL0 u w = ENNReal.ofReal r := by
-  unfold baselineL0; rw [RSA.L0OfMeaning_apply]; exact h
-
-theorem baselineL0_A_wa : baselineL0 .A .w_a = ENNReal.ofReal (1/4) := by
-  apply baselineL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [baselineMeaning_apply, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem baselineL0_A_wab : baselineL0 .A .w_ab = ENNReal.ofReal (3/4) := by
-  apply baselineL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [baselineMeaning_apply, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem baselineL0_AandB_wa : baselineL0 .AandB .w_a = ENNReal.ofReal 0 := by
-  apply baselineL0_ofReal; rw [baselineMeaning_apply]; simp [literalTruth]
-
-theorem baselineL0_AandB_wab : baselineL0 .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply baselineL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [baselineMeaning_apply, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]; simp
-
-theorem baselineL0_AandNotB_wa : baselineL0 .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply baselineL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [baselineMeaning_apply, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]; simp
-
-theorem baselineL0_AandNotB_wab : baselineL0 .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply baselineL0_ofReal; rw [baselineMeaning_apply]; simp [literalTruth]
-
-/-- Baseline speaker normaliser at world `w`. -/
-noncomputable def baselineZ (w : CWSWorld) : ℝ≥0∞ := ∑' u, (baselineL0 u w : ℝ≥0∞) ^ (2 : ℝ) * 1
-
-theorem baselineZ_eq_sum (w : CWSWorld) : baselineZ w = ∑' u, (baselineL0 u w) ^ (2 : ℕ) := by
-  unfold baselineZ; simp_rw [rpow_two_mul_one]
-
-theorem baselineZ_ne_top (w : CWSWorld) : (∑' u, (baselineL0 u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ ∞ := by
-  refine ENNReal.tsum_ne_top_of_fintype (fun u => ?_)
-  rw [rpow_two_mul_one]; exact ENNReal.pow_ne_top (PMF.apply_ne_top _ _)
-
-theorem baselineZ_ne_zero (w : CWSWorld) : (∑' u, (baselineL0 u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  refine ⟨.A, ?_⟩; rw [rpow_two_mul_one]; cases w
-  · rw [baselineL0_A_wa]; simp
-  · rw [baselineL0_A_wab]; simp
-
-theorem baselineZ_wa : baselineZ .w_a = ENNReal.ofReal (17/16) := by
-  rw [baselineZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, baselineL0_A_wa, 
-    baselineL0_AandB_wa, baselineL0_AandNotB_wa, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem baselineZ_wab : baselineZ .w_ab = ENNReal.ofReal (25/16) := by
-  rw [baselineZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, baselineL0_A_wab,
-    baselineL0_AandB_wab, baselineL0_AandNotB_wab,
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (3/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-/-- Baseline speaker (α = 2, no cost). With `Unit` latent this is the marginal
-speaker the listener inverts. -/
-noncomputable def baselineS1 (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.S1Belief baselineL0 (fun _ => 1) 2 w (baselineZ_ne_zero w) (baselineZ_ne_top w)
-
-theorem baselineS1_apply (w : CWSWorld) (u : CWSUtterance) :
-    baselineS1 w u =
-      (baselineL0 u w) ^ (2 : ℝ) * 1 * (∑' u', (baselineL0 u' w : ℝ≥0∞) ^ (2 : ℝ) * 1)⁻¹ := by
-  unfold baselineS1; rw [RSA.S1Belief_apply]
-
-theorem baselineS1_A_wa : baselineS1 .w_a .A = ENNReal.ofReal (1/17) := by
-  rw [baselineS1_apply, rpow_two_mul_one,
-      show (∑' u', (baselineL0 u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = baselineZ .w_a from rfl,
-      baselineZ_wa, baselineL0_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
-  norm_num
-
-theorem baselineS1_A_wab : baselineS1 .w_ab .A = ENNReal.ofReal (9/25) := by
-  rw [baselineS1_apply, rpow_two_mul_one,
-      show (∑' u', (baselineL0 u' .w_ab : ℝ≥0∞) ^ (2 : ℝ) * 1) = baselineZ .w_ab from rfl,
-      baselineZ_wab, baselineL0_A_wab, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]
-  norm_num
-
-theorem baseline_hMarg :
-    PMF.marginal baselineS1 (PMF.uniformOfFintype CWSWorld) .A ≠ 0 := by
-  refine PMF.marginal_ne_zero baselineS1 _ _ (a := CWSWorld.w_a) ?_ ?_
-  · exact (PMF.uniformOfFintype CWSWorld).mem_support_iff CWSWorld.w_a |>.mp
-      (PMF.mem_support_uniformOfFintype CWSWorld.w_a)
-  · rw [baselineS1_A_wa]; simp
-
-/-- Baseline pragmatic listener: Bayesian inversion of `baselineS1` against the
-uniform world prior. -/
-noncomputable def baselineL1 (u : CWSUtterance)
-    (h : PMF.marginal baselineS1 (PMF.uniformOfFintype CWSWorld) u ≠ 0) : PMF CWSWorld :=
-  PMF.posterior baselineS1 (PMF.uniformOfFintype CWSWorld) u h
-
-/-! ### EXH-LU RSA (Models 7–9)
-
-Parse is a latent variable; meaning under each parse bakes in the prior,
-`meaning(p,u,w) = P(w)·⟦u⟧_p(w)`. Under the `exh` parse EXH(A) is false at
-w_ab, so `L0(·|A, exh)` puts all mass on w_a and `S1(A|w_ab, exh) = 0`. The
-exh-parse blocking (`S1(A|w_a, exh) = 1/2`) outweighs the literal parse's prior
-amplification, giving `T(w_a) = 19/34 > 9/25 = T(w_ab)` despite the 3:1 bias.
-With a uniform parse prior the marginal speaker halves these, so the listener
-inverts `ms(w_a) = 19/68 > 9/50 = ms(w_ab)`.
-
-RSA-LI (Models 8–9) is [franke-bergen-2020]'s Lexical Intentions model; at L1
-with uniform P(i) and equal costs it equals EXH-LU (`rsaLI* := exhLU*`). -/
-
-/-- Parse-dependent meaning lifted to `ℝ≥0∞` (prior baked in). -/
-def parseMeaningE (p : CWSParse) (u : CWSUtterance) (w : CWSWorld) : ℝ≥0∞ :=
-  if parseMeaning p w u then ENNReal.ofReal (priorWeight w) else 0
-
-theorem parseMeaningE_apply (p : CWSParse) (u : CWSUtterance) (w : CWSWorld) :
-    parseMeaningE p u w = if parseMeaning p w u then ENNReal.ofReal (priorWeight w) else 0 := rfl
-
-theorem parseMeaningE_ne_top (p : CWSParse) (u : CWSUtterance) :
-    (∑' w, parseMeaningE p u w) ≠ ∞ :=
-  ENNReal.tsum_ne_top_of_fintype
-    (fun w => by rw [parseMeaningE_apply]; split <;> simp [ENNReal.ofReal_ne_top])
-
-theorem parseMeaningE_pos (p : CWSParse) (u : CWSUtterance) :
-    (∑' w, parseMeaningE p u w) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases p <;> cases u
-  · exact ⟨.w_a, by rw [parseMeaningE_apply]; simp [parseMeaning, literalTruth, priorWeight]⟩
-  · exact ⟨.w_ab, by rw [parseMeaningE_apply]; simp [parseMeaning, literalTruth, priorWeight]⟩
-  · exact ⟨.w_a, by rw [parseMeaningE_apply]; simp [parseMeaning, literalTruth, priorWeight]⟩
-  · exact ⟨.w_a, by rw [parseMeaningE_apply]; simp [parseMeaning, priorWeight]⟩
-  · exact ⟨.w_ab, by rw [parseMeaningE_apply]; simp [parseMeaning, priorWeight]⟩
-  · exact ⟨.w_a, by rw [parseMeaningE_apply]; simp [parseMeaning, priorWeight]⟩
-
-/-- EXH-LU per-parse literal listener. -/
-noncomputable def exhLUL0 (p : CWSParse) (u : CWSUtterance) : PMF CWSWorld :=
-  RSA.L0OfMeaning (parseMeaningE p) u (parseMeaningE_pos p u) (parseMeaningE_ne_top p u)
-
-private theorem exhLUL0_ofReal (p : CWSParse) (u : CWSUtterance) (w : CWSWorld) (r : ℝ)
-    (h : parseMeaningE p u w * (∑' w', parseMeaningE p u w')⁻¹ = ENNReal.ofReal r) :
-    exhLUL0 p u w = ENNReal.ofReal r := by
-  unfold exhLUL0; rw [RSA.L0OfMeaning_apply]; exact h
-
-/-- Closes an EXH-LU L0 cell that is uniquely true at `w` (value `1`). -/
-private theorem exhLUL0_unique (p : CWSParse) (u : CWSUtterance) (w : CWSWorld)
-    (h : parseMeaningE p u w * (∑' w', parseMeaningE p u w')⁻¹ = 1) :
-    exhLUL0 p u w = ENNReal.ofReal 1 := by
-  unfold exhLUL0; rw [RSA.L0OfMeaning_apply, h]; simp
-
--- literal parse: identical to baseline
-theorem exhLUL0_lit_A_wa : exhLUL0 .literal .A .w_a = ENNReal.ofReal (1/4) := by
-  apply exhLUL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem exhLUL0_lit_A_wab : exhLUL0 .literal .A .w_ab = ENNReal.ofReal (3/4) := by
-  apply exhLUL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem exhLUL0_lit_AandB_wa : exhLUL0 .literal .AandB .w_a = ENNReal.ofReal 0 := by
-  apply exhLUL0_ofReal; rw [parseMeaningE_apply]; simp [parseMeaning, literalTruth]
-
-theorem exhLUL0_lit_AandB_wab : exhLUL0 .literal .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply exhLUL0_unique; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem exhLUL0_lit_AandNotB_wa : exhLUL0 .literal .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply exhLUL0_unique; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem exhLUL0_lit_AandNotB_wab : exhLUL0 .literal .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply exhLUL0_ofReal; rw [parseMeaningE_apply]; simp [parseMeaning, literalTruth]
-
--- exh parse: EXH(A) true only at w_a
-theorem exhLUL0_exh_A_wa : exhLUL0 .exh .A .w_a = ENNReal.ofReal 1 := by
-  apply exhLUL0_unique; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, exhMeaning_A_wa, exhMeaning_A_wab, priorWeight,
-    Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem exhLUL0_exh_A_wab : exhLUL0 .exh .A .w_ab = ENNReal.ofReal 0 := by
-  apply exhLUL0_ofReal; rw [parseMeaningE_apply]; simp [parseMeaning]
-
-theorem exhLUL0_exh_AandB_wa : exhLUL0 .exh .AandB .w_a = ENNReal.ofReal 0 := by
-  apply exhLUL0_ofReal; rw [parseMeaningE_apply]; simp [parseMeaning]
-
-theorem exhLUL0_exh_AandB_wab : exhLUL0 .exh .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply exhLUL0_unique; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, exhMeaning_AandB_wa, exhMeaning_AandB_wab,
-    priorWeight, Bool.false_eq_true, ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem exhLUL0_exh_AandNotB_wa : exhLUL0 .exh .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply exhLUL0_unique; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [parseMeaningE_apply, parseMeaning, exhMeaning_AandNotB_wa, exhMeaning_AandNotB_wab,
-    priorWeight, Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem exhLUL0_exh_AandNotB_wab : exhLUL0 .exh .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply exhLUL0_ofReal; rw [parseMeaningE_apply]; simp [parseMeaning]
-
-/-- Sum-over-`CWSParse` unfolder, proved by `rfl`. -/
-theorem CWSParse_sum_univ {β : Type*} [AddCommMonoid β] (f : CWSParse → β) :
-    ∑ i, f i = f .literal + (f .exh + 0) := by rfl
-
-noncomputable def exhLUZ (p : CWSParse) (w : CWSWorld) : ℝ≥0∞ :=
-  ∑' u, (exhLUL0 p u w : ℝ≥0∞) ^ (2 : ℝ) * 1
-
-theorem exhLUZ_eq_sum (p : CWSParse) (w : CWSWorld) :
-    exhLUZ p w = ∑' u, (exhLUL0 p u w) ^ (2 : ℕ) := by unfold exhLUZ; simp_rw [rpow_two_mul_one]
-
-theorem exhLUZ_ne_top (p : CWSParse) (w : CWSWorld) :
-    (∑' u, (exhLUL0 p u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ ∞ := by
-  refine ENNReal.tsum_ne_top_of_fintype (fun u => ?_)
-  rw [rpow_two_mul_one]; exact ENNReal.pow_ne_top (PMF.apply_ne_top _ _)
-
-theorem exhLUZ_ne_zero (p : CWSParse) (w : CWSWorld) :
-    (∑' u, (exhLUL0 p u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases p <;> cases w
-  · exact ⟨.A, by rw [rpow_two_mul_one, exhLUL0_lit_A_wa]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, exhLUL0_lit_A_wab]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, exhLUL0_exh_A_wa]; simp⟩
-  · exact ⟨.AandB, by rw [rpow_two_mul_one, exhLUL0_exh_AandB_wab]; simp⟩
-
-theorem exhLUZ_lit_wa : exhLUZ .literal .w_a = ENNReal.ofReal (17/16) := by
-  rw [exhLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    exhLUL0_lit_A_wa, exhLUL0_lit_AandB_wa, 
-    exhLUL0_lit_AandNotB_wa, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem exhLUZ_lit_wab : exhLUZ .literal .w_ab = ENNReal.ofReal (25/16) := by
-  rw [exhLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    exhLUL0_lit_A_wab, exhLUL0_lit_AandB_wab,
-    exhLUL0_lit_AandNotB_wab, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (3/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem exhLUZ_exh_wa : exhLUZ .exh .w_a = ENNReal.ofReal 2 := by
-  rw [exhLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    exhLUL0_exh_A_wa, 
-    exhLUL0_exh_AandB_wa, exhLUL0_exh_AandNotB_wa, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem exhLUZ_exh_wab : exhLUZ .exh .w_ab = ENNReal.ofReal 1 := by
-  rw [exhLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    exhLUL0_exh_A_wab,
-    exhLUL0_exh_AandB_wab, exhLUL0_exh_AandNotB_wab,
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero, zero_add]
-  norm_num
-
-/-- EXH-LU per-parse speaker (α = 2, no cost). -/
-noncomputable def exhLUS1 (p : CWSParse) (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.S1Belief (exhLUL0 p) (fun _ => 1) 2 w (exhLUZ_ne_zero p w) (exhLUZ_ne_top p w)
-
-theorem exhLUS1_apply (p : CWSParse) (w : CWSWorld) (u : CWSUtterance) :
-    exhLUS1 p w u =
-      (exhLUL0 p u w) ^ (2 : ℝ) * 1 * (∑' u', (exhLUL0 p u' w : ℝ≥0∞) ^ (2 : ℝ) * 1)⁻¹ := by
-  unfold exhLUS1; rw [RSA.S1Belief_apply]
-
-theorem exhLUS1_lit_A_wa : exhLUS1 .literal .w_a .A = ENNReal.ofReal (1/17) := by
-  rw [exhLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (exhLUL0 .literal u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = exhLUZ .literal .w_a from rfl,
-      exhLUZ_lit_wa, exhLUL0_lit_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem exhLUS1_lit_A_wab : exhLUS1 .literal .w_ab .A = ENNReal.ofReal (9/25) := by
-  rw [exhLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (exhLUL0 .literal u' .w_ab : ℝ≥0∞) ^ (2 : ℝ) * 1) = exhLUZ .literal .w_ab from rfl,
-      exhLUZ_lit_wab, exhLUL0_lit_A_wab, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem exhLUS1_exh_A_wa : exhLUS1 .exh .w_a .A = ENNReal.ofReal (1/2) := by
-  rw [exhLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (exhLUL0 .exh u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = exhLUZ .exh .w_a from rfl,
-      exhLUZ_exh_wa, exhLUL0_exh_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem exhLUS1_exh_A_wab : exhLUS1 .exh .w_ab .A = ENNReal.ofReal 0 := by
-  rw [exhLUS1_apply, rpow_two_mul_one, exhLUL0_exh_A_wab, sq_ofReal _ (le_refl 0)]; simp
-
-/-- EXH-LU marginal speaker over a uniform parse prior. -/
-noncomputable def exhLUMarginalSpeaker (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.marginalizeKernel (PMF.uniformOfFintype CWSParse) (fun p w => exhLUS1 p w) w
-
-private theorem uniformParse_apply (p : CWSParse) :
-    (PMF.uniformOfFintype CWSParse) p = ENNReal.ofReal (1/2) := by
-  rw [PMF.uniformOfFintype_apply, show Fintype.card CWSParse = 2 from by decide,
-      show ((2 : ℕ) : ℝ≥0∞) = ENNReal.ofReal 2 from by norm_num,
-      ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-theorem exhLUMarginalSpeaker_apply (w : CWSWorld) (u : CWSUtterance) :
-    exhLUMarginalSpeaker w u =
-      ENNReal.ofReal (1/2) * exhLUS1 .literal w u +
-        (ENNReal.ofReal (1/2) * exhLUS1 .exh w u + 0) := by
-  unfold exhLUMarginalSpeaker
-  rw [RSA.marginalizeKernel_apply, tsum_fintype, CWSParse_sum_univ,
-      uniformParse_apply, uniformParse_apply]
-
-theorem exhLU_ms_wa : exhLUMarginalSpeaker .w_a .A = ENNReal.ofReal (19/68) := by
-  rw [exhLUMarginalSpeaker_apply, exhLUS1_lit_A_wa, exhLUS1_exh_A_wa, add_zero,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem exhLU_ms_wab : exhLUMarginalSpeaker .w_ab .A = ENNReal.ofReal (9/50) := by
-  rw [exhLUMarginalSpeaker_apply, exhLUS1_lit_A_wab, exhLUS1_exh_A_wab,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num), add_zero,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem exhLU_hMarg :
-    PMF.marginal exhLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) .A ≠ 0 := by
-  refine PMF.marginal_ne_zero exhLUMarginalSpeaker _ _ (a := CWSWorld.w_a) ?_ ?_
-  · exact (PMF.uniformOfFintype CWSWorld).mem_support_iff CWSWorld.w_a |>.mp
-      (PMF.mem_support_uniformOfFintype CWSWorld.w_a)
-  · rw [exhLU_ms_wa]; simp
-
-/-- EXH-LU pragmatic listener (also RSA-LI at L1). -/
-noncomputable def exhLUL1 (u : CWSUtterance)
-    (h : PMF.marginal exhLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u ≠ 0) : PMF CWSWorld :=
-  PMF.posterior exhLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u h
-
-/-- RSA-LI (Models 8–9): at L1 with uniform P(i) and equal costs, identical to
-EXH-LU (Table 1 of [franke-bergen-2020]). -/
-noncomputable abbrev rsaLIL1 := exhLUL1
-
-/-! ### svRSA (Models 4–5) — [spector-2017] supervaluationist RSA
-
-QUD is a latent variable, and the prior does **not** enter `meaning` (unit
-weights). Under the coarse QUD `Q_A` (all A-true worlds in one cell), L0 is
-uniform `1/2` over both worlds, so `S1(A|w, coarse) = 1/5` is world-independent
-— the prior's effect on S1 is neutralised (Appendix A.3). Under the fine QUD
-`Q_fine`, exh makes A false at w_ab, so `S1(A|w_ab, fine) = 0` while
-`S1(A|w_a, fine) = 1/2`. With a uniform QUD prior the marginal speaker is
-`ms(w_a) = 7/20 > 1/10 = ms(w_ab)`: **categorical blocking**
-(`ms(w_a) = ms(w_ab) + (1/2)·S1(A|w_a, fine) > ms(w_ab)`), matching Appendix A.3.
-The QUD values correspond to `Discourse.QUD.trivial` (coarse) and
-`Discourse.QUD.exact` (fine). svRSA1 and svRSA2 differ only at S2; both block at
-L1. -/
-
-/-- QUD for svRSA. `coarse` = `Q_A`; `fine` = `Q_fine`. -/
-inductive CWSQUD where
-  | coarse : CWSQUD
-  | fine : CWSQUD
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- svRSA meaning: unit weights (no prior). Coarse uses literal truth, fine uses
-exhaustified truth. -/
-def qudMeaning (q : CWSQUD) (u : CWSUtterance) (w : CWSWorld) : ℝ≥0∞ :=
-  match q with
-  | .coarse => if literalTruth w u then 1 else 0
-  | .fine => if exhMeaning w u then 1 else 0
-
-theorem qudMeaning_coarse_apply (u : CWSUtterance) (w : CWSWorld) :
-    qudMeaning .coarse u w = if literalTruth w u then 1 else 0 := rfl
-
-theorem qudMeaning_fine_apply (u : CWSUtterance) (w : CWSWorld) :
-    qudMeaning .fine u w = if exhMeaning w u then 1 else 0 := rfl
-
-theorem qudMeaning_ne_top (q : CWSQUD) (u : CWSUtterance) : (∑' w, qudMeaning q u w) ≠ ∞ :=
-  ENNReal.tsum_ne_top_of_fintype
-    (fun w => by cases q <;> simp only [qudMeaning] <;> split <;> simp)
-
-theorem qudMeaning_pos (q : CWSQUD) (u : CWSUtterance) : (∑' w, qudMeaning q u w) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases q <;> cases u
-  · exact ⟨.w_a, by rw [qudMeaning_coarse_apply, if_pos (by simp [literalTruth])]; simp⟩
-  · exact ⟨.w_ab, by rw [qudMeaning_coarse_apply, if_pos (by simp [literalTruth])]; simp⟩
-  · exact ⟨.w_a, by rw [qudMeaning_coarse_apply, if_pos (by simp [literalTruth])]; simp⟩
-  · exact ⟨.w_a, by rw [qudMeaning_fine_apply, if_pos (by simp)]; simp⟩
-  · exact ⟨.w_ab, by rw [qudMeaning_fine_apply, if_pos (by simp)]; simp⟩
-  · exact ⟨.w_a, by rw [qudMeaning_fine_apply, if_pos (by simp)]; simp⟩
-
-noncomputable def svRSAL0 (q : CWSQUD) (u : CWSUtterance) : PMF CWSWorld :=
-  RSA.L0OfMeaning (qudMeaning q) u (qudMeaning_pos q u) (qudMeaning_ne_top q u)
-
-private theorem svRSAL0_ofReal (q : CWSQUD) (u : CWSUtterance) (w : CWSWorld) (r : ℝ)
-    (h : qudMeaning q u w * (∑' w', qudMeaning q u w')⁻¹ = ENNReal.ofReal r) :
-    svRSAL0 q u w = ENNReal.ofReal r := by
-  unfold svRSAL0; rw [RSA.L0OfMeaning_apply]; exact h
-
-private theorem svRSAL0_one (q : CWSQUD) (u : CWSUtterance) (w : CWSWorld)
-    (h : qudMeaning q u w * (∑' w', qudMeaning q u w')⁻¹ = 1) :
-    svRSAL0 q u w = ENNReal.ofReal 1 := by
-  unfold svRSAL0; rw [RSA.L0OfMeaning_apply, h]; simp
-
--- coarse: uniform 1/2 on A-true worlds (both), 1 on uniquely-true cells
-theorem svRSAL0_coarse_A_wa : svRSAL0 .coarse .A .w_a = ENNReal.ofReal (1/2) := by
-  apply svRSAL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_coarse_apply, literalTruth, ↓reduceIte, add_zero]
-  rw [show (1 : ℝ≥0∞) + 1 = ENNReal.ofReal 2 by rw [← ENNReal.ofReal_one,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]; norm_num,
-      ← ENNReal.ofReal_one, ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem svRSAL0_coarse_A_wab : svRSAL0 .coarse .A .w_ab = ENNReal.ofReal (1/2) := by
-  apply svRSAL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_coarse_apply, literalTruth, ↓reduceIte, add_zero]
-  rw [show (1 : ℝ≥0∞) + 1 = ENNReal.ofReal 2 by rw [← ENNReal.ofReal_one,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]; norm_num,
-      ← ENNReal.ofReal_one, ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem svRSAL0_coarse_AandB_wa : svRSAL0 .coarse .AandB .w_a = ENNReal.ofReal 0 := by
-  apply svRSAL0_ofReal; rw [qudMeaning_coarse_apply]; simp [literalTruth]
-
-theorem svRSAL0_coarse_AandB_wab : svRSAL0 .coarse .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply svRSAL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_coarse_apply, literalTruth, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem svRSAL0_coarse_AandNotB_wa : svRSAL0 .coarse .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply svRSAL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_coarse_apply, literalTruth, Bool.false_eq_true,
-    ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem svRSAL0_coarse_AandNotB_wab : svRSAL0 .coarse .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply svRSAL0_ofReal; rw [qudMeaning_coarse_apply]; simp [literalTruth]
-
--- fine: exh truth, unit weights
-theorem svRSAL0_fine_A_wa : svRSAL0 .fine .A .w_a = ENNReal.ofReal 1 := by
-  apply svRSAL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_fine_apply, exhMeaning_A_wa, exhMeaning_A_wab, Bool.false_eq_true,
-    ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem svRSAL0_fine_A_wab : svRSAL0 .fine .A .w_ab = ENNReal.ofReal 0 := by
-  apply svRSAL0_ofReal; rw [qudMeaning_fine_apply]; simp
-
-theorem svRSAL0_fine_AandB_wa : svRSAL0 .fine .AandB .w_a = ENNReal.ofReal 0 := by
-  apply svRSAL0_ofReal; rw [qudMeaning_fine_apply]; simp
-
-theorem svRSAL0_fine_AandB_wab : svRSAL0 .fine .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply svRSAL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_fine_apply, exhMeaning_AandB_wa, exhMeaning_AandB_wab, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem svRSAL0_fine_AandNotB_wa : svRSAL0 .fine .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply svRSAL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [qudMeaning_fine_apply, exhMeaning_AandNotB_wa, exhMeaning_AandNotB_wab,
-    Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem svRSAL0_fine_AandNotB_wab : svRSAL0 .fine .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply svRSAL0_ofReal; rw [qudMeaning_fine_apply]; simp
-
-/-- Sum-over-`CWSQUD` unfolder, proved by `rfl`. -/
-theorem CWSQUD_sum_univ {β : Type*} [AddCommMonoid β] (f : CWSQUD → β) :
-    ∑ i, f i = f .coarse + (f .fine + 0) := by rfl
-
-noncomputable def svRSAZ (q : CWSQUD) (w : CWSWorld) : ℝ≥0∞ :=
-  ∑' u, (svRSAL0 q u w : ℝ≥0∞) ^ (2 : ℝ) * 1
-
-theorem svRSAZ_eq_sum (q : CWSQUD) (w : CWSWorld) :
-    svRSAZ q w = ∑' u, (svRSAL0 q u w) ^ (2 : ℕ) := by unfold svRSAZ; simp_rw [rpow_two_mul_one]
-
-theorem svRSAZ_ne_top (q : CWSQUD) (w : CWSWorld) :
-    (∑' u, (svRSAL0 q u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ ∞ := by
-  refine ENNReal.tsum_ne_top_of_fintype (fun u => ?_)
-  rw [rpow_two_mul_one]; exact ENNReal.pow_ne_top (PMF.apply_ne_top _ _)
-
-theorem svRSAZ_ne_zero (q : CWSQUD) (w : CWSWorld) :
-    (∑' u, (svRSAL0 q u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases q <;> cases w
-  · exact ⟨.A, by rw [rpow_two_mul_one, svRSAL0_coarse_A_wa]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, svRSAL0_coarse_A_wab]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, svRSAL0_fine_A_wa]; simp⟩
-  · exact ⟨.AandB, by rw [rpow_two_mul_one, svRSAL0_fine_AandB_wab]; simp⟩
-
-theorem svRSAZ_coarse_wa : svRSAZ .coarse .w_a = ENNReal.ofReal (5/4) := by
-  rw [svRSAZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    svRSAL0_coarse_A_wa, svRSAL0_coarse_AandB_wa, 
-    svRSAL0_coarse_AandNotB_wa, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1/2) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem svRSAZ_coarse_wab : svRSAZ .coarse .w_ab = ENNReal.ofReal (5/4) := by
-  rw [svRSAZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    svRSAL0_coarse_A_wab, svRSAL0_coarse_AandB_wab,
-    svRSAL0_coarse_AandNotB_wab, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1/2) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem svRSAZ_fine_wa : svRSAZ .fine .w_a = ENNReal.ofReal 2 := by
-  rw [svRSAZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    svRSAL0_fine_A_wa, 
-    svRSAL0_fine_AandB_wa, svRSAL0_fine_AandNotB_wa,
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem svRSAZ_fine_wab : svRSAZ .fine .w_ab = ENNReal.ofReal 1 := by
-  rw [svRSAZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    svRSAL0_fine_A_wab,
-    svRSAL0_fine_AandB_wab, 
-    svRSAL0_fine_AandNotB_wab, ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero, zero_add]
-  norm_num
-
-noncomputable def svRSAS1 (q : CWSQUD) (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.S1Belief (svRSAL0 q) (fun _ => 1) 2 w (svRSAZ_ne_zero q w) (svRSAZ_ne_top q w)
-
-theorem svRSAS1_apply (q : CWSQUD) (w : CWSWorld) (u : CWSUtterance) :
-    svRSAS1 q w u =
-      (svRSAL0 q u w) ^ (2 : ℝ) * 1 * (∑' u', (svRSAL0 q u' w : ℝ≥0∞) ^ (2 : ℝ) * 1)⁻¹ := by
-  unfold svRSAS1; rw [RSA.S1Belief_apply]
-
-theorem svRSAS1_coarse_A_wa : svRSAS1 .coarse .w_a .A = ENNReal.ofReal (1/5) := by
-  rw [svRSAS1_apply, rpow_two_mul_one,
-      show (∑' u', (svRSAL0 .coarse u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = svRSAZ .coarse .w_a from rfl,
-      svRSAZ_coarse_wa, svRSAL0_coarse_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem svRSAS1_coarse_A_wab : svRSAS1 .coarse .w_ab .A = ENNReal.ofReal (1/5) := by
-  rw [svRSAS1_apply, rpow_two_mul_one,
-      show (∑' u', (svRSAL0 .coarse u' .w_ab : ℝ≥0∞) ^ (2 : ℝ) * 1) = svRSAZ .coarse .w_ab from rfl,
-      svRSAZ_coarse_wab, svRSAL0_coarse_A_wab, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem svRSAS1_fine_A_wa : svRSAS1 .fine .w_a .A = ENNReal.ofReal (1/2) := by
-  rw [svRSAS1_apply, rpow_two_mul_one,
-      show (∑' u', (svRSAL0 .fine u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = svRSAZ .fine .w_a from rfl,
-      svRSAZ_fine_wa, svRSAL0_fine_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem svRSAS1_fine_A_wab : svRSAS1 .fine .w_ab .A = ENNReal.ofReal 0 := by
-  rw [svRSAS1_apply, rpow_two_mul_one, svRSAL0_fine_A_wab, sq_ofReal _ (le_refl 0)]; simp
-
-noncomputable def svRSAMarginalSpeaker (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.marginalizeKernel (PMF.uniformOfFintype CWSQUD) (fun q w => svRSAS1 q w) w
-
-private theorem uniformQUD_apply (q : CWSQUD) :
-    (PMF.uniformOfFintype CWSQUD) q = ENNReal.ofReal (1/2) := by
-  rw [PMF.uniformOfFintype_apply, show Fintype.card CWSQUD = 2 from by decide,
-      show ((2 : ℕ) : ℝ≥0∞) = ENNReal.ofReal 2 from by norm_num,
-      ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-theorem svRSAMarginalSpeaker_apply (w : CWSWorld) (u : CWSUtterance) :
-    svRSAMarginalSpeaker w u =
-      ENNReal.ofReal (1/2) * svRSAS1 .coarse w u +
-        (ENNReal.ofReal (1/2) * svRSAS1 .fine w u + 0) := by
-  unfold svRSAMarginalSpeaker
-  rw [RSA.marginalizeKernel_apply, tsum_fintype, CWSQUD_sum_univ,
-      uniformQUD_apply, uniformQUD_apply]
-
-theorem svRSA_ms_wa : svRSAMarginalSpeaker .w_a .A = ENNReal.ofReal (7/20) := by
-  rw [svRSAMarginalSpeaker_apply, svRSAS1_coarse_A_wa, svRSAS1_fine_A_wa, add_zero,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem svRSA_ms_wab : svRSAMarginalSpeaker .w_ab .A = ENNReal.ofReal (1/10) := by
-  rw [svRSAMarginalSpeaker_apply, svRSAS1_coarse_A_wab, svRSAS1_fine_A_wab,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num), add_zero,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem svRSA_hMarg :
-    PMF.marginal svRSAMarginalSpeaker (PMF.uniformOfFintype CWSWorld) .A ≠ 0 := by
-  refine PMF.marginal_ne_zero svRSAMarginalSpeaker _ _ (a := CWSWorld.w_a) ?_ ?_
-  · exact (PMF.uniformOfFintype CWSWorld).mem_support_iff CWSWorld.w_a |>.mp
-      (PMF.mem_support_uniformOfFintype CWSWorld.w_a)
-  · rw [svRSA_ms_wa]; simp
-
-/-- svRSA pragmatic listener. -/
-noncomputable def svRSAL1 (u : CWSUtterance)
-    (h : PMF.marginal svRSAMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u ≠ 0) : PMF CWSWorld :=
-  PMF.posterior svRSAMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u h
-
-/-! ### FREE-LU (Model 6) — [bergen-levy-goodman-2016]
-
-Three interpretations as latent variables (literal / exh / antiExh), each with
-the prior baked into `meaning`. The anti-exhaustive interpretation makes A mean
-A∧B (true only at w_ab). With prior-in-L0, the literal parse is asymmetric
-(`S1(A|w_ab, lit) = 9/25 > 1/17 = S1(A|w_a, lit)`), and the anti-exh parse
-contributes `S1(A|w_ab, antiExh) = 1/2` at w_ab (`0` at w_a). So
-`T(w_ab) = 9/25 + 0 + 1/2 = 43/50 > 19/34 = 1/17 + 1/2 + 0 = T(w_a)`. With the
-uniform interpretation prior the marginal speaker is `ms(w_ab) = 43/150 >
-19/102 = ms(w_a)`: genuine anti-exhaustivity, matching the paper. -/
-
-/-- Interpretation for FREE-LU. `literal`, `exh` (A∧¬B), `antiExh` (A∧B). -/
-inductive CWSInterpretation where
-  | literal : CWSInterpretation
-  | exh : CWSInterpretation
-  | antiExh : CWSInterpretation
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- Anti-exhaustive meaning: A means A ∧ B (true only in w_ab); A∧B and A∧¬B
-unaffected. -/
-def antiExhMeaning : CWSWorld → CWSUtterance → Bool
-  | .w_a, .A => false
-  | .w_ab, .A => true
-  | w, u => literalTruth w u
-
-/-- Meaning under each interpretation. -/
-def interpMeaning : CWSInterpretation → CWSWorld → CWSUtterance → Bool
-  | .literal => literalTruth
-  | .exh => exhMeaning
-  | .antiExh => antiExhMeaning
-
-/-- FREE-LU meaning lifted to `ℝ≥0∞` (prior baked in). -/
-def interpMeaningE (i : CWSInterpretation) (u : CWSUtterance) (w : CWSWorld) : ℝ≥0∞ :=
-  if interpMeaning i w u then ENNReal.ofReal (priorWeight w) else 0
-
-theorem interpMeaningE_apply (i : CWSInterpretation) (u : CWSUtterance) (w : CWSWorld) :
-    interpMeaningE i u w = if interpMeaning i w u then ENNReal.ofReal (priorWeight w) else 0 := rfl
-
-theorem interpMeaningE_ne_top (i : CWSInterpretation) (u : CWSUtterance) :
-    (∑' w, interpMeaningE i u w) ≠ ∞ :=
-  ENNReal.tsum_ne_top_of_fintype
-    (fun w => by rw [interpMeaningE_apply]; split <;> simp [ENNReal.ofReal_ne_top])
-
-theorem interpMeaningE_pos (i : CWSInterpretation) (u : CWSUtterance) :
-    (∑' w, interpMeaningE i u w) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases i <;> cases u
-  · exact ⟨.w_a, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, literalTruth])]; simp [priorWeight]⟩
-  · exact ⟨.w_ab, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, literalTruth])]; simp [priorWeight]⟩
-  · exact ⟨.w_a, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, literalTruth])]; simp [priorWeight]⟩
-  · exact ⟨.w_a, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning])]; simp [priorWeight]⟩
-  · exact ⟨.w_ab, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning])]; simp [priorWeight]⟩
-  · exact ⟨.w_a, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning])]; simp [priorWeight]⟩
-  · exact ⟨.w_ab, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, antiExhMeaning])]; simp [priorWeight]⟩
-  · exact ⟨.w_ab, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, antiExhMeaning, literalTruth])]; simp [priorWeight]⟩
-  · exact ⟨.w_a, by rw [interpMeaningE_apply, if_pos (by simp [interpMeaning, antiExhMeaning, literalTruth])]; simp [priorWeight]⟩
-
-noncomputable def freeLUL0 (i : CWSInterpretation) (u : CWSUtterance) : PMF CWSWorld :=
-  RSA.L0OfMeaning (interpMeaningE i) u (interpMeaningE_pos i u) (interpMeaningE_ne_top i u)
-
-private theorem freeLUL0_ofReal (i : CWSInterpretation) (u : CWSUtterance) (w : CWSWorld) (r : ℝ)
-    (h : interpMeaningE i u w * (∑' w', interpMeaningE i u w')⁻¹ = ENNReal.ofReal r) :
-    freeLUL0 i u w = ENNReal.ofReal r := by
-  unfold freeLUL0; rw [RSA.L0OfMeaning_apply]; exact h
-
-private theorem freeLUL0_one (i : CWSInterpretation) (u : CWSUtterance) (w : CWSWorld)
-    (h : interpMeaningE i u w * (∑' w', interpMeaningE i u w')⁻¹ = 1) :
-    freeLUL0 i u w = ENNReal.ofReal 1 := by
-  unfold freeLUL0; rw [RSA.L0OfMeaning_apply, h]; simp
-
--- only the `.A` cells (the prediction touches only S1 at .A) plus the full per-parse
--- Z need every cell; provide all 18.
-theorem freeLUL0_lit_A_wa : freeLUL0 .literal .A .w_a = ENNReal.ofReal (1/4) := by
-  apply freeLUL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem freeLUL0_lit_A_wab : freeLUL0 .literal .A .w_ab = ENNReal.ofReal (3/4) := by
-  apply freeLUL0_ofReal; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, literalTruth, priorWeight, ↓reduceIte, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num), ← ENNReal.ofReal_inv_of_pos (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem freeLUL0_lit_AandB_wa : freeLUL0 .literal .AandB .w_a = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning, literalTruth]
-
-theorem freeLUL0_lit_AandB_wab : freeLUL0 .literal .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_lit_AandNotB_wa : freeLUL0 .literal .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, literalTruth, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_lit_AandNotB_wab : freeLUL0 .literal .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning, literalTruth]
-
-theorem freeLUL0_exh_A_wa : freeLUL0 .exh .A .w_a = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, exhMeaning_A_wa, exhMeaning_A_wab, priorWeight,
-    Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_exh_A_wab : freeLUL0 .exh .A .w_ab = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning]
-
-theorem freeLUL0_exh_AandB_wa : freeLUL0 .exh .AandB .w_a = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning]
-
-theorem freeLUL0_exh_AandB_wab : freeLUL0 .exh .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, exhMeaning_AandB_wa, exhMeaning_AandB_wab,
-    priorWeight, Bool.false_eq_true, ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_exh_AandNotB_wa : freeLUL0 .exh .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, exhMeaning_AandNotB_wa, exhMeaning_AandNotB_wab,
-    priorWeight, Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_exh_AandNotB_wab : freeLUL0 .exh .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning]
-
-theorem freeLUL0_anti_A_wa : freeLUL0 .antiExh .A .w_a = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning, antiExhMeaning]
-
-theorem freeLUL0_anti_A_wab : freeLUL0 .antiExh .A .w_ab = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, antiExhMeaning, priorWeight, Bool.false_eq_true,
-    ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_anti_AandB_wa : freeLUL0 .antiExh .AandB .w_a = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning, antiExhMeaning, literalTruth]
-
-theorem freeLUL0_anti_AandB_wab : freeLUL0 .antiExh .AandB .w_ab = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, antiExhMeaning, literalTruth, priorWeight,
-    Bool.false_eq_true, ↓reduceIte, add_zero, zero_add]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_anti_AandNotB_wa : freeLUL0 .antiExh .AandNotB .w_a = ENNReal.ofReal 1 := by
-  apply freeLUL0_one; rw [tsum_fintype, CWSWorld_sum_univ]
-  simp only [interpMeaningE_apply, interpMeaning, antiExhMeaning, literalTruth, priorWeight,
-    Bool.false_eq_true, ↓reduceIte, add_zero]
-  rw [ENNReal.mul_inv_cancel (by simp) (by simp)]
-
-theorem freeLUL0_anti_AandNotB_wab : freeLUL0 .antiExh .AandNotB .w_ab = ENNReal.ofReal 0 := by
-  apply freeLUL0_ofReal; rw [interpMeaningE_apply]; simp [interpMeaning, antiExhMeaning, literalTruth]
-
-/-- Sum-over-`CWSInterpretation` unfolder, proved by `rfl`. -/
-theorem CWSInterpretation_sum_univ {β : Type*} [AddCommMonoid β] (f : CWSInterpretation → β) :
-    ∑ i, f i = f .literal + (f .exh + (f .antiExh + 0)) := by rfl
-
-noncomputable def freeLUZ (i : CWSInterpretation) (w : CWSWorld) : ℝ≥0∞ :=
-  ∑' u, (freeLUL0 i u w : ℝ≥0∞) ^ (2 : ℝ) * 1
-
-theorem freeLUZ_eq_sum (i : CWSInterpretation) (w : CWSWorld) :
-    freeLUZ i w = ∑' u, (freeLUL0 i u w) ^ (2 : ℕ) := by unfold freeLUZ; simp_rw [rpow_two_mul_one]
-
-theorem freeLUZ_ne_top (i : CWSInterpretation) (w : CWSWorld) :
-    (∑' u, (freeLUL0 i u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ ∞ := by
-  refine ENNReal.tsum_ne_top_of_fintype (fun u => ?_)
-  rw [rpow_two_mul_one]; exact ENNReal.pow_ne_top (PMF.apply_ne_top _ _)
-
-theorem freeLUZ_ne_zero (i : CWSInterpretation) (w : CWSWorld) :
-    (∑' u, (freeLUL0 i u w : ℝ≥0∞) ^ (2 : ℝ) * 1) ≠ 0 := by
-  apply ENNReal.summable.tsum_ne_zero_iff.mpr
-  cases i <;> cases w
-  · exact ⟨.A, by rw [rpow_two_mul_one, freeLUL0_lit_A_wa]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, freeLUL0_lit_A_wab]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, freeLUL0_exh_A_wa]; simp⟩
-  · exact ⟨.AandB, by rw [rpow_two_mul_one, freeLUL0_exh_AandB_wab]; simp⟩
-  · exact ⟨.AandNotB, by rw [rpow_two_mul_one, freeLUL0_anti_AandNotB_wa]; simp⟩
-  · exact ⟨.A, by rw [rpow_two_mul_one, freeLUL0_anti_A_wab]; simp⟩
-
-theorem freeLUZ_lit_wa : freeLUZ .literal .w_a = ENNReal.ofReal (17/16) := by
-  rw [freeLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    freeLUL0_lit_A_wa, freeLUL0_lit_AandB_wa,
-    freeLUL0_lit_AandNotB_wa, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem freeLUZ_lit_wab : freeLUZ .literal .w_ab = ENNReal.ofReal (25/16) := by
-  rw [freeLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    freeLUL0_lit_A_wab, 
-    freeLUL0_lit_AandB_wab, freeLUL0_lit_AandNotB_wab, 
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (3/4) (by norm_num), sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem freeLUZ_anti_wab : freeLUZ .antiExh .w_ab = ENNReal.ofReal 2 := by
-  rw [freeLUZ_eq_sum, tsum_fintype]
-  simp +decide only [CWSUtterance_sum_univ, 
-    freeLUL0_anti_A_wab, 
-    freeLUL0_anti_AandB_wab, freeLUL0_anti_AandNotB_wab,
-    ENNReal.ofReal_zero, add_zero]
-  rw [sq_ofReal (1:ℝ) (by norm_num)]
-  simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, add_zero]
-  rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-noncomputable def freeLUS1 (i : CWSInterpretation) (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.S1Belief (freeLUL0 i) (fun _ => 1) 2 w (freeLUZ_ne_zero i w) (freeLUZ_ne_top i w)
-
-theorem freeLUS1_apply (i : CWSInterpretation) (w : CWSWorld) (u : CWSUtterance) :
-    freeLUS1 i w u =
-      (freeLUL0 i u w) ^ (2 : ℝ) * 1 * (∑' u', (freeLUL0 i u' w : ℝ≥0∞) ^ (2 : ℝ) * 1)⁻¹ := by
-  unfold freeLUS1; rw [RSA.S1Belief_apply]
-
-theorem freeLUS1_lit_A_wa : freeLUS1 .literal .w_a .A = ENNReal.ofReal (1/17) := by
-  rw [freeLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (freeLUL0 .literal u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = freeLUZ .literal .w_a from rfl,
-      freeLUZ_lit_wa, freeLUL0_lit_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem freeLUS1_lit_A_wab : freeLUS1 .literal .w_ab .A = ENNReal.ofReal (9/25) := by
-  rw [freeLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (freeLUL0 .literal u' .w_ab : ℝ≥0∞) ^ (2 : ℝ) * 1) = freeLUZ .literal .w_ab from rfl,
-      freeLUZ_lit_wab, freeLUL0_lit_A_wab, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-/-- exh interpretation: A false at w_a (`S1 = 0`). -/
-theorem freeLUS1_exh_A_wa : freeLUS1 .exh .w_a .A = ENNReal.ofReal (1/2) := by
-  rw [freeLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (freeLUL0 .exh u' .w_a : ℝ≥0∞) ^ (2 : ℝ) * 1) = freeLUZ .exh .w_a from rfl]
-  -- freeLUZ .exh .w_a = 2 (A=1, AandB=0, AandNotB=1 squared)
-  rw [show freeLUZ .exh .w_a = ENNReal.ofReal 2 by
-        rw [freeLUZ_eq_sum, tsum_fintype]
-        simp +decide only [CWSUtterance_sum_univ, 
-          freeLUL0_exh_A_wa,
-          freeLUL0_exh_AandB_wa, 
-          freeLUL0_exh_AandNotB_wa, 
-          ENNReal.ofReal_zero, add_zero]
-        rw [sq_ofReal (1:ℝ) (by norm_num)]
-        simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, zero_add]
-        rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-        congr 1; norm_num,
-      freeLUL0_exh_A_wa, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-theorem freeLUS1_exh_A_wab : freeLUS1 .exh .w_ab .A = ENNReal.ofReal 0 := by
-  rw [freeLUS1_apply, rpow_two_mul_one, freeLUL0_exh_A_wab, sq_ofReal _ (le_refl 0)]; simp
-
-theorem freeLUS1_anti_A_wa : freeLUS1 .antiExh .w_a .A = ENNReal.ofReal 0 := by
-  rw [freeLUS1_apply, rpow_two_mul_one, freeLUL0_anti_A_wa, sq_ofReal _ (le_refl 0)]; simp
-
-theorem freeLUS1_anti_A_wab : freeLUS1 .antiExh .w_ab .A = ENNReal.ofReal (1/2) := by
-  rw [freeLUS1_apply, rpow_two_mul_one,
-      show (∑' u', (freeLUL0 .antiExh u' .w_ab : ℝ≥0∞) ^ (2 : ℝ) * 1) = freeLUZ .antiExh .w_ab from rfl,
-      freeLUZ_anti_wab, freeLUL0_anti_A_wab, sq_ofReal _ (by norm_num),
-      ← ENNReal.ofReal_inv_of_pos (by norm_num), ← ENNReal.ofReal_mul (by norm_num)]; norm_num
-
-noncomputable def freeLUMarginalSpeaker (w : CWSWorld) : PMF CWSUtterance :=
-  RSA.marginalizeKernel (PMF.uniformOfFintype CWSInterpretation) (fun i w => freeLUS1 i w) w
-
-private theorem uniformInterp_apply (i : CWSInterpretation) :
-    (PMF.uniformOfFintype CWSInterpretation) i = ENNReal.ofReal (1/3) := by
-  rw [PMF.uniformOfFintype_apply, show Fintype.card CWSInterpretation = 3 from by decide,
-      show ((3 : ℕ) : ℝ≥0∞) = ENNReal.ofReal 3 from by norm_num,
-      ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-theorem freeLUMarginalSpeaker_apply (w : CWSWorld) (u : CWSUtterance) :
-    freeLUMarginalSpeaker w u =
-      ENNReal.ofReal (1/3) * freeLUS1 .literal w u +
-        (ENNReal.ofReal (1/3) * freeLUS1 .exh w u +
-          (ENNReal.ofReal (1/3) * freeLUS1 .antiExh w u + 0)) := by
-  unfold freeLUMarginalSpeaker
-  rw [RSA.marginalizeKernel_apply, tsum_fintype, CWSInterpretation_sum_univ,
-      uniformInterp_apply, uniformInterp_apply, uniformInterp_apply]
-
-theorem freeLU_ms_wa : freeLUMarginalSpeaker .w_a .A = ENNReal.ofReal (19/102) := by
-  rw [freeLUMarginalSpeaker_apply, freeLUS1_lit_A_wa, freeLUS1_exh_A_wa, freeLUS1_anti_A_wa,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num), add_zero,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem freeLU_ms_wab : freeLUMarginalSpeaker .w_ab .A = ENNReal.ofReal (43/150) := by
-  rw [freeLUMarginalSpeaker_apply, freeLUS1_lit_A_wab, freeLUS1_exh_A_wab, freeLUS1_anti_A_wab,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num), add_zero,
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem freeLU_hMarg :
-    PMF.marginal freeLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) .A ≠ 0 := by
-  refine PMF.marginal_ne_zero freeLUMarginalSpeaker _ _ (a := CWSWorld.w_a) ?_ ?_
-  · exact (PMF.uniformOfFintype CWSWorld).mem_support_iff CWSWorld.w_a |>.mp
-      (PMF.mem_support_uniformOfFintype CWSWorld.w_a)
-  · rw [freeLU_ms_wa]; simp
-
-/-- FREE-LU pragmatic listener. -/
-noncomputable def freeLUL1 (u : CWSUtterance)
-    (h : PMF.marginal freeLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u ≠ 0) : PMF CWSWorld :=
-  PMF.posterior freeLUMarginalSpeaker (PMF.uniformOfFintype CWSWorld) u h
-
-/-! ### wRSA (Models 2–3) — [degen-etal-2015] joint world–background listener
-
-wRSA's distinctive mechanism is a **world-dependent latent prior** `P(w|b)·P(b)`:
-the background `b` is `wonky` (a uniform world prior) or `default_` (the 3:1
-bias). The listener is jointly uncertain about `(w, b)`, so the model is a clean
-`RSA.jointListener` over the joint prior `RSA.jointPrior`, with the world belief
-read off as the `W`-marginal of the `(World × Background)` posterior — no
-bundled-config encoding needed. The per-background speaker reuses the already-proven
-closed forms: under `default_` the biased prior is baked into L0 (eq. 1 of §4.1),
-so its speaker is `baselineS1`; under `wonky` it uses uniform-prior literal
-meaning, the plain literal RSA speaker — which coincides by construction with
-`svRSAS1 .coarse` (whose coarse QUD is the trivial partition), reused here to
-avoid duplicating the closed forms rather than as a dependence on svRSA.
-
-The anti-exhaustivity test `wRSAL1(.A) w_ab > wRSAL1(.A) w_a` reduces (via
-`RSA.jointListener_lt_iff_sum_score_lt`, the marginal normaliser cancelling) to
-the latent-summed score comparison
-`Σ_b μ(w_ab,b)·S1(.A|w_ab,b) > Σ_b μ(w_a,b)·S1(.A|w_a,b)`. The prediction is
-**anti-exhaustive** (`w_ab > w_a`), preserving the model's classification: even
-averaging in the wonky (uniform) background, the biased `default_` background
-amplifies S1 toward w_ab. -/
-
-/-- Background assumption for wRSA: `wonky` (uniform prior over worlds) vs
-`default_` (prior follows the bias). -/
-inductive CWSBackground where
-  | wonky : CWSBackground
-  | default_ : CWSBackground
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- World prior conditioned on the background `P(w|b)`. Under `default_`, w_ab
-gets 3× the weight of w_a (P(w_a)=1/4, P(w_ab)=3/4 — the 1:3 bias); under
-`wonky`, both worlds are equally likely (1/2, 1/2). -/
-noncomputable def worldGivenBg : CWSBackground → PMF CWSWorld
-  | .wonky => PMF.ofFintype (fun _ => ENNReal.ofReal (1/2))
-      (by rw [CWSWorld_sum_univ, add_zero,
-              ← ENNReal.ofReal_add (by norm_num) (by norm_num)]; norm_num)
-  | .default_ => PMF.ofFintype
-      (fun w => match w with | .w_a => ENNReal.ofReal (1/4) | .w_ab => ENNReal.ofReal (3/4))
-      (by rw [CWSWorld_sum_univ, add_zero,
-              ← ENNReal.ofReal_add (by norm_num) (by norm_num)]; norm_num)
-
-theorem worldGivenBg_wonky (w : CWSWorld) : worldGivenBg .wonky w = ENNReal.ofReal (1/2) := rfl
-theorem worldGivenBg_default_wa : worldGivenBg .default_ .w_a = ENNReal.ofReal (1/4) := rfl
-theorem worldGivenBg_default_wab : worldGivenBg .default_ .w_ab = ENNReal.ofReal (3/4) := rfl
-
-/-- Background prior `P(b)`: uniform over `CWSBackground`. -/
-noncomputable def bgPrior : PMF CWSBackground := PMF.uniformOfFintype CWSBackground
-
-theorem bgPrior_apply (b : CWSBackground) : bgPrior b = ENNReal.ofReal (1/2) := by
-  rw [bgPrior, PMF.uniformOfFintype_apply, show Fintype.card CWSBackground = 2 from by decide,
-      show ((2 : ℕ) : ℝ≥0∞) = ENNReal.ofReal 2 from by norm_num,
-      ← ENNReal.ofReal_inv_of_pos (by norm_num)]
-  norm_num
-
-/-- The joint world–background prior `μ(w,b) = P(b)·P(w|b)` ([degen-etal-2015]). -/
-noncomputable def wRSAJointPrior : PMF (CWSWorld × CWSBackground) :=
-  RSA.jointPrior bgPrior worldGivenBg
-
-/-- Per-background speaker, reusing this file's proven closed forms by shared
-construction: `default_` bakes the biased prior into L0, so it is `baselineS1`;
-`wonky` uses uniform-prior literal meaning, so it is the plain literal RSA
-speaker (= `svRSAS1 .coarse`, whose coarse QUD is the trivial partition). -/
-noncomputable def wRSAS1Kernel : CWSWorld × CWSBackground → PMF CWSUtterance
-  | (w, .wonky) => svRSAS1 .coarse w
-  | (w, .default_) => baselineS1 w
-
-theorem wRSAJointPrior_apply (w : CWSWorld) (b : CWSBackground) :
-    wRSAJointPrior (w, b) = bgPrior b * worldGivenBg b w := by
-  rw [wRSAJointPrior, RSA.jointPrior_apply]
-
-theorem wRSA_hMarg : PMF.marginal wRSAS1Kernel wRSAJointPrior .A ≠ 0 := by
-  refine PMF.marginal_ne_zero wRSAS1Kernel _ _ (a := (CWSWorld.w_ab, CWSBackground.default_)) ?_ ?_
-  · rw [wRSAJointPrior_apply, bgPrior_apply, worldGivenBg_default_wab]; simp
-  · show baselineS1 .w_ab .A ≠ 0; rw [baselineS1_A_wab]; simp
-
-/-- wRSA pragmatic listener: the world-marginal of the joint `(World ×
-Background)` posterior (BwRSA is identical at L1). -/
-noncomputable def wRSAL1 (u : CWSUtterance)
-    (h : PMF.marginal wRSAS1Kernel wRSAJointPrior u ≠ 0) : PMF CWSWorld :=
-  RSA.jointListener wRSAS1Kernel wRSAJointPrior u h
-
-/-- Sum over the 2-element background latent. -/
-private theorem background_sum {M : Type*} [AddCommMonoid M] (f : CWSBackground → M) :
-    ∑ l, f l = f CWSBackground.wonky + f CWSBackground.default_ :=
-  Fintype.sum_eq_add CWSBackground.wonky CWSBackground.default_ (by decide)
-    (fun x ⟨_, _⟩ => by cases x <;> simp_all)
-
-/-! ### Predictions
-
-Each prediction reduces, under the uniform world prior, to a `marginalSpeaker`
-comparison via `PMF.posterior_lt_iff_kernel_lt_of_uniform`, then to a rational
-comparison via `ENNReal.ofReal_lt_ofReal_iff`. -/
-
-/-- Baseline RSA is genuinely anti-exhaustive: `L1(.A) w_ab > L1(.A) w_a`.
-
-    With prior-in-L0, S1 is asymmetric (`S1(A|w_ab) = 9/25 > 1/17 = S1(A|w_a)`)
-    because `L0(w_ab|A) = 3/4 > 1/4 = L0(w_a|A)`. The speaker preferentially uses
-    A when w_ab is true, since L0 already favours w_ab given A. This is the
-    paper's central problematic prediction (Eq. 6b, Fig. 1). -/
-theorem baseline_antiexhaustive :
-    baselineL1 .A baseline_hMarg .w_ab > baselineL1 .A baseline_hMarg .w_a := by
-  rw [baselineL1, gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      baselineS1_A_wa, baselineS1_A_wab]
-  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
-
-/-- EXH-LU blocks anti-exhaustivity: even with prior-in-L0 and 3:1 bias,
-    `L1(.A) w_a > L1(.A) w_ab`. The exh parse contributes `S1(A|w_a, exh) = 1/2`
-    but `S1(A|w_ab, exh) = 0`, outweighing the literal parse's prior
-    amplification: `ms(w_a) = 19/68 > 9/50 = ms(w_ab)`. -/
-theorem exhlu_blocks_antiexhaustivity :
-    exhLUL1 .A exhLU_hMarg .w_a > exhLUL1 .A exhLU_hMarg .w_ab := by
-  rw [exhLUL1, gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      exhLU_ms_wab, exhLU_ms_wa]
-  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
-
-/-- EXH(A) is false in w_ab — the structural basis for blocking. -/
-theorem exh_meaning_blocks_wab : exhMeaning .w_ab .A = false := exhMeaning_A_wab
-
-/-- RSA-LI blocks anti-exhaustivity (same as EXH-LU at L1). -/
-theorem rsali_blocks_antiexhaustivity :
-    rsaLIL1 .A exhLU_hMarg .w_a > rsaLIL1 .A exhLU_hMarg .w_ab :=
-  exhlu_blocks_antiexhaustivity
-
-/-- svRSA blocks anti-exhaustivity **categorically** (Appendix A.3): under the
-    coarse QUD `S1(A|w, coarse) = 1/5` for both worlds, and under the fine QUD
-    `S1(A|w_ab, fine) = 0` while `S1(A|w_a, fine) = 1/2`. So
-    `ms(w_a) = 7/20 > 1/10 = ms(w_ab)`. -/
-theorem svRSA_blocks_antiexhaustivity :
-    svRSAL1 .A svRSA_hMarg .w_a > svRSAL1 .A svRSA_hMarg .w_ab := by
-  rw [svRSAL1, gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      svRSA_ms_wab, svRSA_ms_wa]
-  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
-
-/-- FREE-LU is genuinely anti-exhaustive: with prior-in-L0 the literal parse's
-    S1 asymmetry makes the anti-exh interpretation dominant at w_ab.
-    `ms(w_ab) = 43/150 > 19/102 = ms(w_a)`. -/
-theorem freelu_antiexhaustive :
-    freeLUL1 .A freeLU_hMarg .w_ab > freeLUL1 .A freeLU_hMarg .w_a := by
-  rw [freeLUL1, gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      freeLU_ms_wa, freeLU_ms_wab]
-  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
-
-/-- wRSA is anti-exhaustive: the `default_` background bakes the biased prior into
-    L0, making S1 asymmetric; even averaging in the wonky (uniform) background,
-    the biased background dominates. Reduces to the latent-summed score comparison
-    `Σ_b μ(w_ab,b)·S1(.A|w_ab,b) > Σ_b μ(w_a,b)·S1(.A|w_a,b)`, i.e.
-    `1/20 + 27/200 > 1/20 + 1/136`. -/
-theorem wRSA_biased_antiexhaustive :
-    wRSAL1 .A wRSA_hMarg .w_ab > wRSAL1 .A wRSA_hMarg .w_a := by
-  rw [wRSAL1, gt_iff_lt, RSA.jointListener_lt_iff_sum_score_lt,
-      background_sum (fun b => wRSAJointPrior (.w_a, b) * wRSAS1Kernel (.w_a, b) .A),
-      background_sum (fun b => wRSAJointPrior (.w_ab, b) * wRSAS1Kernel (.w_ab, b) .A)]
-  simp only [wRSAJointPrior_apply, bgPrior_apply, worldGivenBg_wonky, worldGivenBg_default_wa,
-    worldGivenBg_default_wab]
-  show ENNReal.ofReal (1/2) * ENNReal.ofReal (1/2) * svRSAS1 .coarse .w_a .A +
-        ENNReal.ofReal (1/2) * ENNReal.ofReal (1/4) * baselineS1 .w_a .A <
-       ENNReal.ofReal (1/2) * ENNReal.ofReal (1/2) * svRSAS1 .coarse .w_ab .A +
-        ENNReal.ofReal (1/2) * ENNReal.ofReal (3/4) * baselineS1 .w_ab .A
-  rw [svRSAS1_coarse_A_wa, svRSAS1_coarse_A_wab, baselineS1_A_wa, baselineS1_A_wab,
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_mul (by norm_num), ← ENNReal.ofReal_mul (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num),
-      ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  exact (ENNReal.ofReal_lt_ofReal_iff (by norm_num)).mpr (by norm_num)
-
-/-! ### Classification
-
-The paper's central result: the 9 RSA models fall into two groups. The
-**anti-exhaustive** group (baseline, wRSA/BwRSA, FREE-LU) lets the prior bias
-amplify through S1, predicting listeners infer w_ab from "A" — contradicting the
-experimental data. The **exhaustive** group (EXH-LU, RSA-LI1/2, svRSA1/2) blocks
-anti-exhaustivity via grammatical exhaustification or QUD gating, matching the
-data. -/
-
-theorem antiexhaustive_group :
-    baselineL1 .A baseline_hMarg .w_ab > baselineL1 .A baseline_hMarg .w_a ∧
-    wRSAL1 .A wRSA_hMarg .w_ab > wRSAL1 .A wRSA_hMarg .w_a ∧
-    freeLUL1 .A freeLU_hMarg .w_ab > freeLUL1 .A freeLU_hMarg .w_a :=
-  ⟨baseline_antiexhaustive, wRSA_biased_antiexhaustive, freelu_antiexhaustive⟩
-
-theorem exhaustive_group :
-    exhLUL1 .A exhLU_hMarg .w_a > exhLUL1 .A exhLU_hMarg .w_ab ∧
-    rsaLIL1 .A exhLU_hMarg .w_a > rsaLIL1 .A exhLU_hMarg .w_ab ∧
-    svRSAL1 .A svRSA_hMarg .w_a > svRSAL1 .A svRSA_hMarg .w_ab :=
-  ⟨exhlu_blocks_antiexhaustivity, rsali_blocks_antiexhaustivity, svRSA_blocks_antiexhaustivity⟩
+  · exact PMF.marginal_ne_zero _ _ _ (a := (.wa, .fine))
+      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
+      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
+  · exact PMF.marginal_ne_zero _ _ _ (a := (.wab, .fine))
+      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
+      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
+  · exact PMF.marginal_ne_zero _ _ _ (a := (.wa, .fine))
+      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
+      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
+
+/-- item 6 of the §4.2 model: the pragmatic listener, jointly over worlds and questions. -/
+noncomputable def svListener (u : Message) : PMF (World × QUD) :=
+  RSA.Canonical.L1 (svSpeaker s) (svJoint s Q) u (svMarginal_ne_zero s Q hQ u)
+
+private theorem sv_aux {a b c d z y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hb : b ≠ 0)
+    (hc : c ≠ ⊤) (hd : d ≠ 0) (hz : z ≠ ⊤) (hy : y ≠ 0) :
+    c * b * z < b * (c * a * z + d * a * y + c * b * z) := by
+  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
+  have h : b * (c * a * z + d * a * y + c * b * z) = c * b * z + b * (d * a * y) := by
+    calc b * (c * a * z + d * a * y + c * b * z) = c * b * ((a + b) * z) + b * (d * a * y) := by
+          ring
+      _ = _ := by rw [hab, one_mul]
+  rw [h]
+  exact ENNReal.lt_add_right (ENNReal.mul_ne_top (ENNReal.mul_ne_top hc hb') hz)
+    (mul_ne_zero hb (mul_ne_zero (mul_ne_zero hd ha) hy))
+
+/-- Appendix A.3, the listener: the posterior of both A and B falls below its prior, for
+every prior in the open interval, every prior on the questions that gives the fine one
+positive probability, and every cost, since the fine question contributes a use of *A* in the
+world of A alone and none in the world of both. -/
+theorem svListener_fst_lt_prior : (svListener s Q hQ .a).fst .wab < s.prior .wab := by
+  rw [svListener, RSA.Canonical.L1, ← svJoint_fst s Q, PMF.posterior_fst_lt_fst_iff, svJoint_fst]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum]
+  simp only [Fintype.sum_prod_type, sum_World, sum_QUD, svJoint_apply, svSpeaker_wab_fine_a,
+    ← svSpeaker_coarse, mul_zero, add_zero]
+  exact sv_aux s.prior_add (s.prior_ne_zero _) (s.prior_ne_zero _) (PMF.apply_ne_top _ _) hQ
+    (PMF.apply_ne_top _ _) (svSpeaker_wa_fine_a_ne_zero s)
+
+end Supervaluationist
+
+/-! ### The wonky-world models (§4.1) -/
+
+section Wonky
+
+variable (s : Setting) (ω : ℝ) (hω₀ : 0 ≤ ω) (hω₁ : ω ≤ 1)
+
+/-- The speaker under a background: the literal listener uses the uniform prior in the wonky
+background and the measured prior otherwise. -/
+noncomputable def bgSpeaker : Background → World → PMF Message
+  | .wonky => speaker wonkyPrior wonkyPrior_ne_zero literal s
+  | .measured => s.speaker literal
+
+/-- The prior on backgrounds: wonky with the wonkiness. -/
+noncomputable def bgPrior : PMF Background :=
+  PMF.ofFintype (λ b => match b with
+    | .wonky => ENNReal.ofReal ω
+    | .measured => ENNReal.ofReal (1 - ω)) (by
+    rw [sum_Background]
+    show ENNReal.ofReal ω + ENNReal.ofReal (1 - ω) = 1
+    rw [← ENNReal.ofReal_add hω₀ (by linarith), add_sub_cancel, ENNReal.ofReal_one])
+
+/-- The prior of the wonky background. -/
+theorem bgPrior_wonky : bgPrior ω hω₀ hω₁ .wonky = ENNReal.ofReal ω := rfl
+
+/-- The prior of the measured background. -/
+theorem bgPrior_measured : bgPrior ω hω₀ hω₁ .measured = ENNReal.ofReal (1 - ω) := rfl
+
+/-- The wonky speaker's use of *A* in the world of both: the logistic function of the cost of
+*A and B* less the log of two. -/
+theorem bgSpeaker_wonky_wab_a :
+    bgSpeaker s .wonky .wab .a =
+      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAB - Real.log 2))) := by
+  rw [bgSpeaker, speaker_literal_wab_a, wonkyPrior_toReal, Real.log_inv, ← sub_eq_add_neg]
+
+/-- The wonky speaker's use of *A* in the world of A alone: the logistic function of the cost
+of *A and not B* less the log of two. -/
+theorem bgSpeaker_wonky_wa_a :
+    bgSpeaker s .wonky .wa .a =
+      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAnotB - Real.log 2))) := by
+  rw [bgSpeaker, speaker_literal_wa_a, wonkyPrior_toReal, Real.log_inv, ← sub_eq_add_neg]
+
+/-- item 5 of the §4.1 model, the Bayesian version: the speaker marginalised over the
+listener's uncertainty about the speaker's prior. -/
+noncomputable def bayesWonkySpeaker (w : World) : PMF Message :=
+  RSA.marginalizeKernel (bgPrior ω hω₀ hω₁) (λ b w => bgSpeaker s b w) w
+
+/-- The Bayesian wonky speaker in closed form. -/
+theorem bayesWonkySpeaker_apply (w : World) (u : Message) :
+    bayesWonkySpeaker s ω hω₀ hω₁ w u =
+      ENNReal.ofReal ω * bgSpeaker s .wonky w u +
+        ENNReal.ofReal (1 - ω) * bgSpeaker s .measured w u := by
+  rw [bayesWonkySpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_Background,
+    bgPrior_wonky, bgPrior_measured]
+
+/-- Without wonkiness the Bayesian wonky speaker is the baseline speaker. -/
+theorem bayesWonkySpeaker_zero (w : World) :
+    bayesWonkySpeaker s 0 le_rfl zero_le_one w = s.speaker literal w :=
+  PMF.ext λ u => by
+    rw [bayesWonkySpeaker_apply, ENNReal.ofReal_zero, zero_mul, zero_add, sub_zero,
+      ENNReal.ofReal_one, one_mul, bgSpeaker]
+
+/-- Every message is used somewhere under either background, so has positive marginal
+likelihood. -/
+theorem bayesWonkyMarginal_ne_zero (u : Message) :
+    PMF.marginal (bayesWonkySpeaker s ω hω₀ hω₁) s.prior u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
+    rw [bayesWonkySpeaker_apply]
+    intro h
+    rcases add_eq_zero.mp h with ⟨h₁, h₂⟩
+    rcases mul_eq_zero.mp h₁ with h₁ | h₁
+    · rcases mul_eq_zero.mp h₂ with h₂ | h₂
+      · rw [ENNReal.ofReal_eq_zero] at h₁ h₂; linarith
+      · exact speaker_ne_zero _ _ _ _ hw h₂
+    · exact speaker_ne_zero _ _ _ _ hw h₁)
+
+/-- The Bayesian wonky listener, with the measured prior. -/
+noncomputable def bayesWonkyListener (u : Message) : PMF World :=
+  RSA.L1 (bayesWonkySpeaker s ω hω₀ hω₁) s.prior u (bayesWonkyMarginal_ne_zero s ω hω₀ hω₁ u)
+
+/-- Appendix A.2, the Bayesian model: anti-exhaustivity exactly when the wonkiness-weighted
+excess of the use of *A* in the world of both over its use in the world of A alone is
+positive. -/
+theorem prior_lt_bayesWonkyListener_iff :
+    s.prior .wab < bayesWonkyListener s ω hω₀ hω₁ .a .wab ↔
+      0 < (1 - ω) * (Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) -
+          Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p)))) +
+        ω * (Real.sigmoid (s.lam * (s.cAB - Real.log 2)) -
+          Real.sigmoid (s.lam * (s.cAnotB - Real.log 2))) := by
+  have hσ₁ := Real.sigmoid_pos (s.lam * (s.cAnotB - Real.log 2))
+  have hσ₂ := Real.sigmoid_pos (s.lam * (s.cAB - Real.log 2))
+  have hσ₃ := Real.sigmoid_pos (s.lam * (s.cAnotB + Real.log (1 - s.p)))
+  have hσ₄ := Real.sigmoid_pos (s.lam * (s.cAB + Real.log s.p))
+  have hω' : 0 ≤ 1 - ω := by linarith
+  rw [bayesWonkyListener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum, sum_World,
+    two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _),
+    bayesWonkySpeaker_apply, bayesWonkySpeaker_apply, bgSpeaker_wonky_wab_a,
+    bgSpeaker_wonky_wa_a, bgSpeaker]
+  dsimp only [Setting.speaker]
+  rw [speaker_literal_wab_a, speaker_literal_wa_a, Setting.prior_wab_toReal,
+    Setting.prior_wa_toReal]
+  simp (disch := positivity) only [← ENNReal.ofReal_mul, ← ENNReal.ofReal_add]
+  rw [ENNReal.ofReal_lt_ofReal_iff (by
+    rcases hω₁.lt_or_eq with hω | hω
+    · exact add_pos_of_nonneg_of_pos (by positivity) (mul_pos (by linarith) hσ₄)
+    · exact add_pos_of_pos_of_nonneg (mul_pos (by linarith) hσ₂) (by positivity))]
+  constructor <;> intro h <;> nlinarith
+
+/-- The joint prior of the non-Bayesian model: the background, then the world under it. -/
+noncomputable def wonkyJoint : PMF (World × Background) :=
+  RSA.jointPrior (bgPrior ω hω₀ hω₁) λ b => match b with
+    | .wonky => wonkyPrior
+    | .measured => s.prior
+
+/-- The joint prior of a world under the wonky background. -/
+theorem wonkyJoint_wonky (w : World) :
+    wonkyJoint s ω hω₀ hω₁ (w, .wonky) = ENNReal.ofReal ω * 2⁻¹ := by
+  rw [wonkyJoint, RSA.jointPrior_apply, bgPrior_wonky, wonkyPrior_apply]
+
+/-- The joint prior of a world under the measured background. -/
+theorem wonkyJoint_measured (w : World) :
+    wonkyJoint s ω hω₀ hω₁ (w, .measured) = ENNReal.ofReal (1 - ω) * s.prior w := by
+  rw [wonkyJoint, RSA.jointPrior_apply, bgPrior_measured]
+
+/-- The speaker of the non-Bayesian model, at a world under a background. -/
+noncomputable abbrev wonkySpeaker : World × Background → PMF Message :=
+  λ x => bgSpeaker s x.2 x.1
+
+/-- Every message is used somewhere under whichever background has positive prior, so has
+positive marginal likelihood. -/
+theorem wonkyMarginal_ne_zero (u : Message) :
+    PMF.marginal (wonkySpeaker s) (wonkyJoint s ω hω₀ hω₁) u ≠ 0 :=
+  let ⟨w, hw⟩ := literal.exists_world u
+  (hω₀.lt_or_eq).elim
+    (λ hω => PMF.marginal_ne_zero _ _ _ (a := (w, .wonky))
+      (by rw [wonkyJoint_wonky]; exact mul_ne_zero (ENNReal.ofReal_pos.mpr hω).ne' (by simp))
+      (speaker_ne_zero _ _ _ _ hw))
+    (λ hω => PMF.marginal_ne_zero _ _ _ (a := (w, .measured))
+      (by
+        rw [wonkyJoint_measured]
+        exact mul_ne_zero (ENNReal.ofReal_pos.mpr (by linarith)).ne' (s.prior_ne_zero _))
+      (speaker_ne_zero _ _ _ _ hw))
+
+/-- item 4 of the §4.1 model: the non-Bayesian listener, uncertain about the world and the
+speaker's background jointly. -/
+noncomputable def wonkyListener (u : Message) : PMF World :=
+  RSA.jointListener (wonkySpeaker s) (wonkyJoint s ω hω₀ hω₁) u
+    (wonkyMarginal_ne_zero s ω hω₀ hω₁ u)
+
+/-- (A.5a): the non-Bayesian model is anti-exhaustive with respect to the measured prior
+exactly when the prior times the marginal use of *A* falls below the background-weighted use
+of *A* in the world of both; the paper resolves this inequality numerically. -/
+theorem prior_lt_wonkyListener_iff :
+    s.prior .wab < wonkyListener s ω hω₀ hω₁ .a .wab ↔
+      s.p * (ω * 2⁻¹ * (Real.sigmoid (s.lam * (s.cAnotB - Real.log 2)) +
+          Real.sigmoid (s.lam * (s.cAB - Real.log 2))) +
+        (1 - ω) * ((1 - s.p) * Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p))) +
+          s.p * Real.sigmoid (s.lam * (s.cAB + Real.log s.p)))) <
+      ω * 2⁻¹ * Real.sigmoid (s.lam * (s.cAB - Real.log 2)) +
+        (1 - ω) * (s.p * Real.sigmoid (s.lam * (s.cAB + Real.log s.p))) := by
+  have hσ₁ := Real.sigmoid_pos (s.lam * (s.cAnotB - Real.log 2))
+  have hσ₂ := Real.sigmoid_pos (s.lam * (s.cAB - Real.log 2))
+  have hσ₃ := Real.sigmoid_pos (s.lam * (s.cAnotB + Real.log (1 - s.p)))
+  have hσ₄ := Real.sigmoid_pos (s.lam * (s.cAB + Real.log s.p))
+  have hω' : 0 ≤ 1 - ω := by linarith
+  have hp := s.p_pos
+  have hp' : 0 ≤ 1 - s.p := by linarith [s.p_lt_one]
+  rw [wonkyListener, RSA.jointListener_apply,
+    ENNReal.lt_div_iff_mul_lt (Or.inl (wonkyMarginal_ne_zero s ω hω₀ hω₁ _))
+      (Or.inl (PMF.marginal_ne_top _ _ _))]
+  unfold PMF.marginal
+  rw [PMF.bind_apply_eq_finset_sum]
+  simp only [Fintype.sum_prod_type, sum_World, sum_Background, wonkyJoint_wonky,
+    wonkyJoint_measured, wonkySpeaker, bgSpeaker, Setting.speaker, speaker_literal_wab_a,
+    speaker_literal_wa_a, wonkyPrior_toReal, Setting.prior_wa, Setting.prior_wab,
+    ENNReal.toReal_ofReal hp', ENNReal.toReal_ofReal hp.le, Real.log_inv, ← sub_eq_add_neg]
+  rw [show (2 : ℝ≥0∞)⁻¹ = ENNReal.ofReal 2⁻¹ from by
+    rw [ENNReal.ofReal_inv_of_pos (by norm_num), ENNReal.ofReal_ofNat]]
+  simp (disch := positivity) only [← ENNReal.ofReal_mul, ← ENNReal.ofReal_add]
+  rw [ENNReal.ofReal_lt_ofReal_iff (by
+    rcases hω₁.lt_or_eq with hω | hω
+    · exact add_pos_of_nonneg_of_pos (by positivity) (by positivity)
+    · subst hω; simp only [sub_self, zero_mul, add_zero]; positivity)]
+  constructor <;> intro h <;> linarith
+
+end Wonky
 
 end CremersWilcoxSpector2023

--- a/references.bib
+++ b/references.bib
@@ -5876,6 +5876,20 @@
   role      = {formalized},
   validated = {true},
   sources   = {Fragments/Koryak/Modals.lean}
+}
+@inproceedings{spector-2017,
+  author    = {Spector, Benjamin},
+  year      = {2017},
+  title     = {The pragmatics of plural predication: Homogeneity and non-maximality within the {Rational} {Speech} {Act} model},
+  booktitle = {Proceedings of the 21st Amsterdam Colloquium},
+  editor    = {Cremers, Alexandre and van Gessel, Thom and Roelofsen, Floris},
+  publisher = {ILLC},
+  address   = {Amsterdam},
+  pages     = {435--444},
+  doi       = {10.53437/3dfdbq80},
+  subfield  = {pragmatics/rsa},
+  role      = {cited},
+  sources   = {Crossref 10.53437/3dfdbq80; Studies/CremersWilcoxSpector2023.lean}
 }% REF: Krämer, M. & Wunderlich, D. (1999). Transitivity alternations in Yucatec, and the correlation between aspect and argument roles.
 @article{kraemer-wunderlich-1999,
   author    = {Krämer, Martin and Wunderlich, Dieter},


### PR DESCRIPTION
Rebuild the study as general theorems over a symbolic prior, rationality and costs, matching the paper's appendix.
- Baseline (6a), (6b), (7), (A.4); grammatical and free lexical uncertainty; lexical intentions; supervaluationist speaker and listener for any QUD prior; Bayesian and non-Bayesian wonky listeners.
- Substrate: `Real.exp_div_add_exp_eq_sigmoid`, `ENNReal.ofReal_exp_div_add_ofReal_exp`, posterior-vs-prior comparison lemmas, `rsaUtility_eq`, `softmaxWeight_rsaUtility`, `viableSpeaker_rsaUtility`, `jointListener_apply`.
- Adds the missing `spector-2017` bib entry.