### PR TITLE
refactor(Studies/CremersWilcoxSpector2023): move onto the kernel face

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -50,6 +50,7 @@ import Linglib.Core.Algebra.Group.IdempotentPower
 import Linglib.Core.Algebra.Semigroup.Pseudovariety
 import Linglib.Core.Analysis.Convex.Function
 import Linglib.Core.Analysis.LeastSquares
+import Linglib.Core.Analysis.SpecialFunctions.Sigmoid
 import Linglib.Core.Analysis.SpecialFunctions.Softmax
 import Linglib.Core.Categorical.AgentCat
 import Linglib.Core.Categorical.PartitionCat
@@ -301,6 +302,7 @@ import Linglib.Core.Probability.Gumbel
 import Linglib.Core.Probability.Hypergeometric
 import Linglib.Core.Probability.JointPosterior
 import Linglib.Core.Probability.Kernel.Composition.Lemmas
+import Linglib.Core.Probability.Kernel.Mixture
 import Linglib.Core.Probability.Kernel.OfWeights
 import Linglib.Core.Probability.Kernel.Posterior
 import Linglib.Core.Probability.Uniform

--- a/Linglib/Core/Analysis/SpecialFunctions/Sigmoid.lean
+++ b/Linglib/Core/Analysis/SpecialFunctions/Sigmoid.lean
@@ -1,0 +1,19 @@
+import Mathlib.Analysis.SpecialFunctions.Sigmoid
+
+/-!
+# The logistic function as a two-term softmax
+
+The share of one of two exponentials in their sum is the logistic function of the difference
+of their exponents.
+-/
+
+namespace Real
+
+/-- The share of `exp x` in `exp x + exp y` is the logistic function of `x - y`. -/
+theorem exp_div_add_exp_eq_sigmoid (x y : ℝ) : exp x / (exp x + exp y) = sigmoid (x - y) := by
+  have hx := exp_pos x
+  have hy := exp_pos y
+  rw [sigmoid_def, neg_sub, exp_sub]
+  field_simp
+
+end Real

--- a/Linglib/Core/Probability/JointPosterior.lean
+++ b/Linglib/Core/Probability/JointPosterior.lean
@@ -87,45 +87,6 @@ theorem posterior_fst_lt_iff
   -- Both sides are `(...) / marginal κ joint c`. Shared denominator cancels via div_lt_div_iff_left.
   exact ENNReal.div_lt_div_iff_left h (marginal_ne_top κ joint c)
 
-/-- **The marginalized posterior exceeds the marginalized prior** at `a` exactly when the
-conditional joint mass of the fibre over `a` exceeds the prior mass times the marginal
-likelihood. -/
-theorem fst_lt_posterior_fst_iff
-    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
-    (h : marginal κ joint c ≠ 0) (a : α) :
-    joint.fst a < (posterior κ joint c h).fst a
-      ↔ joint.fst a * marginal κ joint c < ∑ b : β, joint (a, b) * κ (a, b) c := by
-  rw [posterior_fst_apply,
-    ENNReal.lt_div_iff_mul_lt (Or.inl h) (Or.inl (marginal_ne_top κ joint c))]
-
-/-- **The marginalized posterior falls below the marginalized prior** at `a` exactly when the
-conditional joint mass of the fibre over `a` falls below the prior mass times the marginal
-likelihood. -/
-theorem posterior_fst_lt_fst_iff
-    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
-    (h : marginal κ joint c ≠ 0) (a : α) :
-    (posterior κ joint c h).fst a < joint.fst a
-      ↔ (∑ b : β, joint (a, b) * κ (a, b) c) < joint.fst a * marginal κ joint c := by
-  rw [posterior_fst_apply, ENNReal.div_lt_iff (Or.inl h) (Or.inl (marginal_ne_top κ joint c))]
-
-/-- The `≤` companion of `fst_lt_posterior_fst_iff`. -/
-theorem fst_le_posterior_fst_iff
-    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
-    (h : marginal κ joint c ≠ 0) (a : α) :
-    joint.fst a ≤ (posterior κ joint c h).fst a
-      ↔ joint.fst a * marginal κ joint c ≤ ∑ b : β, joint (a, b) * κ (a, b) c := by
-  rw [← not_lt, ← not_lt, not_iff_not]
-  exact posterior_fst_lt_fst_iff κ joint c h a
-
-/-- The `≤` companion of `posterior_fst_lt_fst_iff`. -/
-theorem posterior_fst_le_fst_iff
-    (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)
-    (h : marginal κ joint c ≠ 0) (a : α) :
-    (posterior κ joint c h).fst a ≤ joint.fst a
-      ↔ (∑ b : β, joint (a, b) * κ (a, b) c) ≤ joint.fst a * marginal κ joint c := by
-  rw [← not_lt, ← not_lt, not_iff_not]
-  exact fst_lt_posterior_fst_iff κ joint c h a
-
 /-- **Companion `≤` form** of `posterior_fst_lt_iff`. -/
 theorem posterior_fst_le_iff
     (κ : (α × β) → PMF γ) (joint : PMF (α × β)) (c : γ)

--- a/Linglib/Core/Probability/Kernel/Mixture.lean
+++ b/Linglib/Core/Probability/Kernel/Mixture.lean
@@ -1,0 +1,69 @@
+import Linglib.Core.Probability.Kernel.OfWeights
+
+/-!
+# Mixtures of kernels
+
+`ProbabilityTheory.Kernel.mixture c κ` is the kernel whose row at `a` is the weighted sum
+`∑ i, c i • κ i a` of the rows of a finite family of kernels: the family averaged over a latent
+index the target does not see. Its rows are finite when the weights are finite and the members
+are finite kernels.
+
+## Main definitions
+
+* `ProbabilityTheory.Kernel.mixture` — the weighted sum of a finite family of kernels.
+
+## Main results
+
+* `ProbabilityTheory.Kernel.mixture_apply'`, `ProbabilityTheory.Kernel.mixture_real` — a row at
+  an event, in `ℝ≥0∞` and on reals.
+* `ProbabilityTheory.Kernel.mixture_apply_ne_zero_iff` — a row has mass on an event exactly
+  when some positively weighted member does.
+* `ProbabilityTheory.Kernel.isFiniteKernel_mixture` — finiteness under finite weights.
+-/
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace ProbabilityTheory.Kernel
+
+variable {α β ι : Type*} [MeasurableSpace α] [MeasurableSpace β] [Countable α]
+  [MeasurableSingletonClass α] [Fintype ι]
+
+/-- The mixture of a finite family of kernels by weights `c`: row `a` is `∑ i, c i • κ i a`. -/
+noncomputable def mixture (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) : Kernel α β :=
+  ofFunOfCountable λ a => ∑ i, c i • κ i a
+
+theorem mixture_apply (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) (a : α) :
+    mixture c κ a = ∑ i, c i • κ i a := rfl
+
+/-- A row of a mixture at an event is the weighted sum of the members' masses. -/
+theorem mixture_apply' (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) (a : α) (s : Set β) :
+    mixture c κ a s = ∑ i, c i * κ i a s := by
+  rw [mixture_apply, Measure.finsetSum_apply]
+  simp only [Measure.smul_apply, smul_eq_mul]
+
+/-- A row of a mixture has mass on an event exactly when some positively weighted member
+does. -/
+theorem mixture_apply_ne_zero_iff (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) (a : α) (s : Set β) :
+    mixture c κ a s ≠ 0 ↔ ∃ i, c i ≠ 0 ∧ κ i a s ≠ 0 := by
+  simp only [ne_eq, mixture_apply', Finset.sum_eq_zero_iff, Finset.mem_univ, true_implies,
+    mul_eq_zero, not_forall, not_or]
+
+/-- A row of a mixture of finite kernels with finite weights at an event, on reals. -/
+theorem mixture_real (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) [∀ i, IsFiniteKernel (κ i)]
+    (hc : ∀ i, c i ≠ ∞) (a : α) (s : Set β) :
+    (mixture c κ a).real s = ∑ i, (c i).toReal * (κ i a).real s := by
+  rw [measureReal_def, mixture_apply',
+    ENNReal.toReal_sum λ i _ => ENNReal.mul_ne_top (hc i) (measure_ne_top _ _)]
+  simp only [ENNReal.toReal_mul, measureReal_def]
+
+/-- A mixture of finite kernels with finite weights is a finite kernel. -/
+theorem isFiniteKernel_mixture (c : ι → ℝ≥0∞) (κ : ι → Kernel α β) [∀ i, IsFiniteKernel (κ i)]
+    (hc : ∀ i, c i ≠ ∞) : IsFiniteKernel (mixture c κ) :=
+  ⟨⟨∑ i, c i * (κ i).bound,
+    ENNReal.sum_lt_top.mpr λ i _ => (ENNReal.mul_ne_top (hc i) (κ i).bound_lt_top.ne).lt_top,
+    λ a => by
+      rw [mixture_apply']
+      exact Finset.sum_le_sum λ i _ => mul_le_mul' le_rfl ((κ i).measure_le_bound a _)⟩⟩
+
+end ProbabilityTheory.Kernel

--- a/Linglib/Core/Probability/Kernel/OfWeights.lean
+++ b/Linglib/Core/Probability/Kernel/OfWeights.lean
@@ -64,6 +64,26 @@ noncomputable def ofWeights (w : α → β → ℝ≥0∞) : Kernel α β :=
   rw [Measure.smul_apply, smul_eq_mul, Measure.sum_smul_dirac_apply_singleton,
     ENNReal.div_eq_inv_mul]
 
+/-- A zero weight gives zero mass. -/
+theorem ofWeights_apply_singleton_eq_zero {w : α → β → ℝ≥0∞} {a : α} {b : β} (h : w a b = 0) :
+    ofWeights w a {b} = 0 := by
+  rw [ofWeights_apply_singleton, h, ENNReal.zero_div]
+
+/-- A nonzero weight in a row of finite weights gives positive mass. -/
+theorem ofWeights_apply_singleton_ne_zero {w : α → β → ℝ≥0∞} {a : α} {b : β} (h : w a b ≠ 0)
+    (htop : ∀ c, w a c ≠ ∞) : ofWeights w a {b} ≠ 0 := by
+  rw [ofWeights_apply_singleton, ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  exact ⟨h, ENNReal.sum_ne_top.mpr λ c _ => htop c⟩
+
+/-- In a row with exactly two nonzero weights, both finite, the real mass of one is its share
+of the two. -/
+theorem ofWeights_real_singleton_of_pair {w : α → β → ℝ≥0∞} (a : α) {b b' : β} (hbb' : b ≠ b')
+    (htop : ∀ c, w a c ≠ ∞) (hsupp : ∀ c, w a c ≠ 0 → c = b ∨ c = b') :
+    (ofWeights w a).real {b} = (w a b).toReal / ((w a b).toReal + (w a b').toReal) := by
+  rw [measureReal_def, ofWeights_apply_singleton,
+    Fintype.sum_eq_add b b' hbb' (λ c hc => of_not_not (mt (hsupp c) (not_or.mpr hc))),
+    ENNReal.toReal_div, ENNReal.toReal_add (htop b) (htop b')]
+
 /-- The mass of a finite event under a weight-kernel row. -/
 theorem ofWeights_apply_finset (w : α → β → ℝ≥0∞) (a : α) (E : Finset β) :
     ofWeights w a ↑E = (∑ b ∈ E, w a b) / ∑ b, w a b := by
@@ -75,6 +95,11 @@ theorem ofWeights_real_finset (w : α → β → ℝ≥0∞) (a : α) (hw : ∀ 
     (ofWeights w a).real ↑E = (∑ b ∈ E, (w a b).toReal) / ∑ b, (w a b).toReal := by
   rw [measureReal_def, ofWeights_apply_finset, ENNReal.toReal_div,
     ENNReal.toReal_sum fun b _ => hw b, ENNReal.toReal_sum fun b _ => hw b]
+
+/-- The real mass of an atom under a weight-kernel row with finite weights. -/
+theorem ofWeights_real_singleton (w : α → β → ℝ≥0∞) (a : α) (hw : ∀ b, w a b ≠ ∞) (b : β) :
+    (ofWeights w a).real {b} = (w a b).toReal / ∑ b', (w a b').toReal := by
+  rw [← Finset.coe_singleton, ofWeights_real_finset w a hw, Finset.sum_singleton]
 
 /-- The real mass of a decidable event under a weight-kernel row with finite weights. -/
 theorem ofWeights_real_setOf (w : α → β → ℝ≥0∞) (a : α) (hw : ∀ b, w a b ≠ ∞) (p : β → Prop)

--- a/Linglib/Core/Probability/Kernel/Posterior.lean
+++ b/Linglib/Core/Probability/Kernel/Posterior.lean
@@ -127,6 +127,82 @@ theorem posterior_real_singleton {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (ω 
   rw [measureReal_def, posterior_apply_singleton κ μ hx, ENNReal.toReal_div, ENNReal.toReal_mul,
     measureReal_def, measureReal_def, measureReal_def]
 
+/-- The posterior exceeds the prior at a state exactly when the state's likelihood of the
+observation exceeds the observation's marginal. -/
+theorem real_lt_posterior_real_singleton_iff {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) {ω : Ω}
+    (hω : μ {ω} ≠ 0) :
+    μ.real {ω} < ((κ†μ) x).real {ω} ↔ (κ ∘ₘ μ).real {x} < (κ ω).real {x} := by
+  have hm : 0 < (κ ∘ₘ μ).real {x} := ENNReal.toReal_pos hx (measure_ne_top _ _)
+  have hμ : 0 < μ.real {ω} := ENNReal.toReal_pos hω (measure_ne_top _ _)
+  rw [posterior_real_singleton κ μ hx, lt_div_iff₀ hm, mul_lt_mul_iff_of_pos_left hμ]
+
+/-- The posterior falls below the prior at a state exactly when the state's likelihood of the
+observation falls below the observation's marginal. -/
+theorem posterior_real_singleton_lt_iff {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) {ω : Ω}
+    (hω : μ {ω} ≠ 0) :
+    ((κ†μ) x).real {ω} < μ.real {ω} ↔ (κ ω).real {x} < (κ ∘ₘ μ).real {x} := by
+  have hm : 0 < (κ ∘ₘ μ).real {x} := ENNReal.toReal_pos hx (measure_ne_top _ _)
+  have hμ : 0 < μ.real {ω} := ENNReal.toReal_pos hω (measure_ne_top _ _)
+  rw [posterior_real_singleton κ μ hx, div_lt_iff₀ hm, mul_lt_mul_iff_of_pos_left hμ]
+
+/-! ### Priors carried by two atoms
+
+The `_of_pair` lemmas assume the prior's support lies in a pair `{ω, ω'}`, so that the
+observation's marginal has two terms and the comparison of the posterior with the prior at
+one atom is the comparison of the two likelihoods. -/
+
+section Pair
+
+variable [Fintype Ω] {ω ω' : Ω} (hne : ω ≠ ω') (hsupp : ∀ ω'', μ {ω''} ≠ 0 → ω'' = ω ∨ ω'' = ω')
+include hne hsupp
+
+omit [StandardBorelSpace Ω] [Nonempty Ω] in
+/-- Under a prior carried by two atoms, the observation's marginal is the prior-weighted sum
+of the two likelihoods. -/
+theorem _root_.MeasureTheory.Measure.comp_real_singleton_of_pair (x : 𝓧) :
+    (κ ∘ₘ μ).real {x} = μ.real {ω} * (κ ω).real {x} + μ.real {ω'} * (κ ω').real {x} := by
+  rw [Measure.comp_real_singleton]
+  exact Fintype.sum_eq_add ω ω' hne λ c hc => by
+    rw [measureReal_def, of_not_not (mt (hsupp c) (not_or.mpr hc)), ENNReal.toReal_zero, zero_mul]
+
+omit [StandardBorelSpace Ω] [Nonempty Ω] [IsFiniteKernel κ] in
+/-- A probability measure carried by two atoms puts mass one on them together. -/
+theorem _root_.MeasureTheory.measureReal_singleton_add_singleton_of_pair
+    [IsProbabilityMeasure μ] : μ.real {ω} + μ.real {ω'} = 1 := by
+  have h := measure_univ (μ := μ)
+  rw [← Finset.coe_univ, ← sum_measure_singleton,
+    Fintype.sum_eq_add ω ω' hne (λ c hc => of_not_not (mt (hsupp c) (not_or.mpr hc)))] at h
+  rw [measureReal_def, measureReal_def,
+    ← ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _), h, ENNReal.toReal_one]
+
+variable [IsProbabilityMeasure μ] {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (hω : μ {ω} ≠ 0)
+  (hω' : μ {ω'} ≠ 0)
+include hx hω hω'
+
+/-- Under a prior carried by two atoms, the posterior exceeds the prior at one of them exactly
+when its likelihood of the observation exceeds the other's. -/
+theorem real_lt_posterior_real_singleton_iff_of_pair :
+    μ.real {ω} < ((κ†μ) x).real {ω} ↔ (κ ω').real {x} < (κ ω).real {x} := by
+  have h1 := measureReal_singleton_add_singleton_of_pair μ hne hsupp
+  have h2 : 0 < μ.real {ω'} := ENNReal.toReal_pos hω' (measure_ne_top _ _)
+  rw [real_lt_posterior_real_singleton_iff κ μ hx hω,
+    Measure.comp_real_singleton_of_pair κ μ hne hsupp,
+    show μ.real {ω} = 1 - μ.real {ω'} by linarith]
+  constructor <;> intro h <;> nlinarith
+
+/-- Under a prior carried by two atoms, the posterior falls below the prior at one of them
+exactly when its likelihood of the observation falls below the other's. -/
+theorem posterior_real_singleton_lt_iff_of_pair :
+    ((κ†μ) x).real {ω} < μ.real {ω} ↔ (κ ω).real {x} < (κ ω').real {x} := by
+  have h1 := measureReal_singleton_add_singleton_of_pair μ hne hsupp
+  have h2 : 0 < μ.real {ω'} := ENNReal.toReal_pos hω' (measure_ne_top _ _)
+  rw [posterior_real_singleton_lt_iff κ μ hx hω,
+    Measure.comp_real_singleton_of_pair κ μ hne hsupp,
+    show μ.real {ω} = 1 - μ.real {ω'} by linarith]
+  constructor <;> intro h <;> nlinarith
+
+end Pair
+
 /-- A single state of positive prior mass and positive emission witnesses a
 positive observation marginal. -/
 theorem comp_apply_singleton_ne_zero {Ω' 𝓧' : Type*} [MeasurableSpace Ω']
@@ -157,14 +233,34 @@ namespace ProbabilityTheory
 
 variable {𝓧 : Type*} [MeasurableSpace 𝓧] [MeasurableSingletonClass 𝓧]
 
+section Prod
+
+variable {A B : Type*} [MeasurableSpace A] [MeasurableSpace B] [MeasurableSingletonClass A]
+  [MeasurableSingletonClass B] [StandardBorelSpace A] [Nonempty A] [StandardBorelSpace B]
+  [Nonempty B] (κ : Kernel (A × B) 𝓧) (μ : Measure (A × B)) [IsFiniteMeasure μ]
+  [IsFiniteKernel κ] {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0)
+include hx
+
+/-- The state marginal of the posterior over a product parameter space, on reals:
+prior-weighted likelihoods pooled over the latent, normalized by the observation marginal. -/
+theorem posterior_fst_real_singleton [Fintype B] (a : A) :
+    ((κ†μ) x).fst.real {a}
+      = (∑ b, μ.real {(a, b)} * (κ (a, b)).real {x}) / (κ ∘ₘ μ).real {x} := by
+  rw [Measure.fst_real_singleton_eq_sum, Finset.sum_div]
+  exact Finset.sum_congr rfl λ b _ => posterior_real_singleton κ μ hx (a, b)
+
+/-- The latent marginal of the posterior over a product parameter space, on reals:
+prior-weighted likelihoods pooled over the states, normalized by the observation marginal. -/
+theorem posterior_snd_real_singleton [Fintype A] (b : B) :
+    ((κ†μ) x).snd.real {b}
+      = (∑ a, μ.real {(a, b)} * (κ (a, b)).real {x}) / (κ ∘ₘ μ).real {x} := by
+  rw [Measure.snd_real_singleton_eq_sum, Finset.sum_div]
+  exact Finset.sum_congr rfl λ a _ => posterior_real_singleton κ μ hx (a, b)
+
 /-- Marginal listener preference over a product parameter space, on reals:
 for latent-in-the-state models, the observation's marginal cancels and the
 latent pools. -/
-theorem posterior_fst_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableSpace B]
-    [MeasurableSingletonClass A] [MeasurableSingletonClass B] [Fintype B]
-    [StandardBorelSpace A] [Nonempty A] [StandardBorelSpace B] [Nonempty B]
-    (κ : Kernel (A × B) 𝓧) (μ : Measure (A × B)) [IsFiniteMeasure μ] [IsFiniteKernel κ]
-    {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (a₁ a₂ : A) :
+theorem posterior_fst_real_lt_iff [Fintype B] (a₁ a₂ : A) :
     ((κ†μ) x).fst.real {a₁} < ((κ†μ) x).fst.real {a₂}
       ↔ (∑ b, μ.real {(a₁, b)} * (κ (a₁, b)).real {x})
           < ∑ b, μ.real {(a₂, b)} * (κ (a₂, b)).real {x} := by
@@ -188,11 +284,7 @@ theorem posterior_fst_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableS
 
 /-- Marginal listener preference over the latent component of a product
 parameter space, on reals: the states pool. -/
-theorem posterior_snd_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableSpace B]
-    [MeasurableSingletonClass A] [MeasurableSingletonClass B] [Fintype A]
-    [StandardBorelSpace A] [Nonempty A] [StandardBorelSpace B] [Nonempty B]
-    (κ : Kernel (A × B) 𝓧) (μ : Measure (A × B)) [IsFiniteMeasure μ] [IsFiniteKernel κ]
-    {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (b₁ b₂ : B) :
+theorem posterior_snd_real_lt_iff [Fintype A] (b₁ b₂ : B) :
     ((κ†μ) x).snd.real {b₁} < ((κ†μ) x).snd.real {b₂}
       ↔ (∑ a, μ.real {(a, b₁)} * (κ (a, b₁)).real {x})
           < ∑ a, μ.real {(a, b₂)} * (κ (a, b₂)).real {x} := by
@@ -213,5 +305,7 @@ theorem posterior_snd_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableS
       ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
   simp_rw [ENNReal.toReal_mul]
   exact Iff.rfl
+
+end Prod
 
 end ProbabilityTheory

--- a/Linglib/Core/Probability/Posterior.lean
+++ b/Linglib/Core/Probability/Posterior.lean
@@ -516,38 +516,6 @@ theorem posterior_le_iff_score_le {α β : Type*} (κ : α → PMF β) (μ : PMF
   rw [← not_lt, ← not_lt, not_iff_not]
   exact posterior_lt_iff_score_lt κ μ b h a₂ a₁
 
-/-- **The posterior exceeds the prior** at `a` exactly when the likelihood of the observation
-at `a` exceeds its marginal likelihood. -/
-theorem lt_posterior_iff_marginal_lt {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
-    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
-    μ a < posterior κ μ b h a ↔ marginal κ μ b < κ a b := by
-  rw [posterior_apply, ← div_eq_mul_inv,
-    ENNReal.lt_div_iff_mul_lt (Or.inl h) (Or.inl (marginal_ne_top κ μ b)),
-    ENNReal.mul_lt_mul_iff_right ha (PMF.apply_ne_top μ a)]
-
-/-- **The posterior falls below the prior** at `a` exactly when the likelihood of the
-observation at `a` falls below its marginal likelihood. -/
-theorem posterior_lt_iff_lt_marginal {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
-    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
-    posterior κ μ b h a < μ a ↔ κ a b < marginal κ μ b := by
-  rw [posterior_apply, ← div_eq_mul_inv,
-    ENNReal.div_lt_iff (Or.inl h) (Or.inl (marginal_ne_top κ μ b)),
-    ENNReal.mul_lt_mul_iff_right ha (PMF.apply_ne_top μ a)]
-
-/-- The `≤` companion of `lt_posterior_iff_marginal_lt`. -/
-theorem le_posterior_iff_marginal_le {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
-    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
-    μ a ≤ posterior κ μ b h a ↔ marginal κ μ b ≤ κ a b := by
-  rw [← not_lt, ← not_lt, not_iff_not]
-  exact posterior_lt_iff_lt_marginal κ μ b h ha
-
-/-- The `≤` companion of `posterior_lt_iff_lt_marginal`. -/
-theorem posterior_le_iff_le_marginal {α β : Type*} (κ : α → PMF β) (μ : PMF α) (b : β)
-    (h : marginal κ μ b ≠ 0) {a : α} (ha : μ a ≠ 0) :
-    posterior κ μ b h a ≤ μ a ↔ κ a b ≤ marginal κ μ b := by
-  rw [← not_lt, ← not_lt, not_iff_not]
-  exact lt_posterior_iff_marginal_lt κ μ b h ha
-
 /-- **Set-version of `posterior_lt_iff_score_lt`**: comparing the
 outer-measure-of-Finset values of a posterior at two `Finset`s reduces to
 comparing the corresponding conditional joint sums. The shared

--- a/Linglib/Core/Probability/Softmax.lean
+++ b/Linglib/Core/Probability/Softmax.lean
@@ -2,7 +2,6 @@ import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import Mathlib.Probability.Distributions.Uniform
 import Mathlib.MeasureTheory.Measure.Tilted
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
-import Mathlib.Analysis.SpecialFunctions.Sigmoid
 
 /-!
 # Softmax distribution on PMFs
@@ -272,21 +271,3 @@ theorem softmax_natMul_log_apply {α : Type*} [Fintype α] (n : ℕ) (w : α →
   simp_rw [softmaxWeight_natMul_log_eq_pow]
 
 end PMF
-
-/-! ## Two applicable atoms -/
-
-/-- The softmax of one of two real scores is the logistic function of their difference. -/
-theorem Real.exp_div_add_exp_eq_sigmoid (x y : ℝ) :
-    Real.exp x / (Real.exp x + Real.exp y) = Real.sigmoid (x - y) := by
-  have hx := Real.exp_pos x
-  have hy := Real.exp_pos y
-  rw [Real.sigmoid_def, neg_sub, Real.exp_sub]
-  field_simp
-
-/-- The `ℝ≥0∞` form of `Real.exp_div_add_exp_eq_sigmoid`: the softmax mass of an atom when
-exactly one other atom is applicable. -/
-theorem ENNReal.ofReal_exp_div_add_ofReal_exp (x y : ℝ) :
-    ENNReal.ofReal (Real.exp x) / (ENNReal.ofReal (Real.exp x) + ENNReal.ofReal (Real.exp y)) =
-      ENNReal.ofReal (Real.sigmoid (x - y)) := by
-  rw [← ENNReal.ofReal_add (Real.exp_pos x).le (Real.exp_pos y).le,
-    ← ENNReal.ofReal_div_of_pos (by positivity), Real.exp_div_add_exp_eq_sigmoid]

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -95,6 +95,29 @@ theorem literalListener_indicator_apply_singleton_of_notMem [DiscreteMeasurableS
   rw [literalListener_indicator, Kernel.ofFunOfCountable_apply, cond_apply .of_discrete,
     Set.inter_comm, Set.singleton_inter_eq_empty.mpr h, measure_empty, mul_zero]
 
+/-- A tautology leaves a probability prior unchanged. -/
+theorem literalListener_indicator_apply_singleton_of_eq_univ [DiscreteMeasurableSpace W]
+    (μ : Measure W) [IsProbabilityMeasure μ] (sem : U → Set W) {u : U} (h : sem u = Set.univ)
+    (w : W) : literalListener μ (λ u => (sem u).indicator 1) u {w} = μ {w} := by
+  rw [literalListener_indicator_apply_singleton μ sem (by rw [h]; exact Set.mem_univ w), h,
+    measure_univ, inv_one, one_mul]
+
+/-- An utterance true at one state only puts all its mass there. -/
+theorem literalListener_indicator_apply_singleton_of_eq_singleton [DiscreteMeasurableSpace W]
+    (μ : Measure W) [IsFiniteMeasure μ] (sem : U → Set W) {u : U} {w : W} (h : sem u = {w})
+    (hμ : μ {w} ≠ 0) : literalListener μ (λ u => (sem u).indicator 1) u {w} = 1 := by
+  rw [literalListener_indicator_apply_singleton μ sem (by rw [h]; exact Set.mem_singleton w), h,
+    ENNReal.inv_mul_cancel hμ (measure_ne_top _ _)]
+
+/-- The literal listener of an utterance with a positive-mass extension is a probability
+measure. -/
+theorem literalListener_indicator_apply_univ [DiscreteMeasurableSpace W] (μ : Measure W)
+    [IsFiniteMeasure μ] (sem : U → Set W) {u : U} (h : μ (sem u) ≠ 0) :
+    literalListener μ (λ u => (sem u).indicator 1) u Set.univ = 1 := by
+  rw [literalListener_indicator, Kernel.ofFunOfCountable_apply]
+  have := cond_isProbabilityMeasure h
+  exact measure_univ
+
 /-- On a finite-mass extension the literal listener is a subprobability at members. -/
 theorem literalListener_indicator_apply_singleton_le_one [DiscreteMeasurableSpace W]
     (μ : Measure W) (sem : U → Set W) {u : U} (hfin : μ (sem u) ≠ ∞) {w : W} (h : w ∈ sem u) :
@@ -152,11 +175,9 @@ theorem speaker_apply_singleton_eq_zero {α : ℝ} (hα : 0 < α) {cost : U → 
 /-- A literally true utterance is produced with positive mass. -/
 theorem speaker_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {cost : U → ℝ≥0∞}
     (hc0 : ∀ u, cost u ≠ 0) (hctop : ∀ u, cost u ≠ ∞) {L : Kernel U W} {w : W}
-    (hle : ∀ u', L u' {w} ≤ 1) {u : U} (h : L u {w} ≠ 0) : speaker α cost L w {u} ≠ 0 := by
-  rw [speaker_apply_singleton, ne_eq, ENNReal.div_eq_zero_iff, not_or]
-  exact ⟨mul_ne_zero (weight_rpow_ne_zero hα h) (hc0 u),
-    ENNReal.sum_ne_top.mpr fun u' _ =>
-      ENNReal.mul_ne_top (weight_rpow_ne_top hα (hle u')) (hctop u')⟩
+    (hle : ∀ u', L u' {w} ≤ 1) {u : U} (h : L u {w} ≠ 0) : speaker α cost L w {u} ≠ 0 :=
+  Kernel.ofWeights_apply_singleton_ne_zero (mul_ne_zero (weight_rpow_ne_zero hα h) (hc0 u))
+    fun u' => ENNReal.mul_ne_top (weight_rpow_ne_top hα (hle u')) (hctop u')
 
 /-- A state with a unique applicable utterance produces it with certainty. -/
 theorem speaker_apply_singleton_eq_one {α : ℝ} (hα : 0 < α) {cost : U → ℝ≥0∞} {u : U}

--- a/Linglib/Pragmatics/RSA/Canonical.lean
+++ b/Linglib/Pragmatics/RSA/Canonical.lean
@@ -118,42 +118,6 @@ noncomputable def rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) (�
     (w : W) (u : U) : EReal :=
   (α : EReal) * (ENNReal.log (L0 w u) - (cost u : EReal))
 
-/-- The standard utility is `⊥` at an inapplicable utterance and otherwise the real
-`α·(log L0 − cost)`. -/
-theorem rsaUtility_eq (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α) {w : W} {u : U}
-    (hL : L0 w u ≠ ⊤) :
-    rsaUtility L0 cost α w u =
-      if L0 w u = 0 then ⊥ else ((α * (Real.log (L0 w u).toReal - cost u) : ℝ) : EReal) := by
-  unfold rsaUtility
-  split_ifs with h
-  · rw [h, ENNReal.log_zero, EReal.bot_sub, EReal.mul_bot_of_pos (by exact_mod_cast hα)]
-  · rw [ENNReal.log_pos_real h hL]; norm_cast
-
-/-- The standard utility is viable when the literal listener is finite and every world has an
-applicable utterance. -/
-theorem viableSpeaker_rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α)
-    (hL : ∀ w u, L0 w u ≠ ⊤) (hw : ∀ w, ∃ u, L0 w u ≠ 0) :
-    ViableSpeaker (rsaUtility L0 cost α) where
-  no_top w u := by
-    rw [rsaUtility_eq L0 cost hα (hL w u)]
-    split_ifs
-    · exact bot_ne_top
-    · exact EReal.coe_ne_top _
-  some_finite w := (hw w).imp λ u hu => by
-    rw [rsaUtility_eq L0 cost hα (hL w u), if_neg hu]; exact EReal.coe_ne_bot _
-
-/-- The softmax weight of the standard utility: `0` at an inapplicable utterance and otherwise
-`exp (α·(log L0 − cost))`. -/
-theorem softmaxWeight_rsaUtility (L0 : W → U → ℝ≥0∞) (cost : U → ℝ) {α : ℝ} (hα : 0 < α)
-    {w : W} {u : U} (hL : L0 w u ≠ ⊤) :
-    PMF.softmaxWeight (rsaUtility L0 cost α w) u =
-      if L0 w u = 0 then 0
-      else ENNReal.ofReal (Real.exp (α * (Real.log (L0 w u).toReal - cost u))) := by
-  rw [PMF.softmaxWeight_apply, rsaUtility_eq L0 cost hα hL]
-  split_ifs
-  · exact EReal.exp_bot
-  · exact EReal.exp_coe _
-
 end StandardSpeaker
 
 /-! ### Pragmatic listener -/

--- a/Linglib/Pragmatics/RSA/LatentOperators.lean
+++ b/Linglib/Pragmatics/RSA/LatentOperators.lean
@@ -1,4 +1,3 @@
-import Linglib.Core.Probability.JointPosterior
 import Linglib.Pragmatics.RSA.Operators
 
 /-!
@@ -290,12 +289,6 @@ of the joint posterior. -/
 noncomputable def jointListener {U : Type*} (S1 : W × L → PMF U) (μ : PMF (W × L))
     (u : U) (h : PMF.marginal S1 μ u ≠ 0) : PMF W :=
   (PMF.posterior S1 μ u h).map Prod.fst
-
-/-- Closed form of the joint-prior listener: the latent-summed score over the marginal. -/
-theorem jointListener_apply {U : Type*} [Fintype W] [Fintype L] [DecidableEq W]
-    (S1 : W × L → PMF U) (μ : PMF (W × L)) (u : U) (h : PMF.marginal S1 μ u ≠ 0) (w : W) :
-    jointListener S1 μ u h w = (∑ l, μ (w, l) * S1 (w, l) u) / PMF.marginal S1 μ u :=
-  PMF.posterior_fst_apply S1 μ u h w
 
 /-- **Inequality decomposition for `jointListener`** — joint-prior analogue of
 `posterior_lt_iff_kernel_lt_of_uniform`; the marginal normaliser cancels. -/

--- a/Linglib/Studies/CremersWilcoxSpector2023.lean
+++ b/Linglib/Studies/CremersWilcoxSpector2023.lean
@@ -1,6 +1,7 @@
-import Linglib.Pragmatics.RSA.Canonical
-import Linglib.Pragmatics.RSA.LatentOperators
-import Linglib.Pragmatics.RSA.QUD
+import Linglib.Core.Analysis.SpecialFunctions.Sigmoid
+import Linglib.Core.Probability.Kernel.Mixture
+import Linglib.Core.Probability.UniformOn
+import Linglib.Pragmatics.RSA.Basic
 import Linglib.Semantics.Exhaustification.Finite
 
 /-!
@@ -11,39 +12,46 @@ baseline Rational Speech Act model the inference can reverse: a prior biased tow
 world where both A and B hold makes the literal listener already expect that world on
 hearing *A*, so the speaker uses the cheap *A* there rather than in the world where only A
 holds, and the pragmatic listener raises the probability of both A and B above her prior.
+
 Over two worlds and the messages *A*, *A and B* and *A and not B*, the speaker prefers *A* to
 *A and B* in the world of both exactly when the information *A and B* would add, the negated
 log prior, is not worth its cost, and the listener is anti-exhaustive exactly when the log
 odds of the prior exceed the cost disadvantage of *A and not B* over *A and B*, a condition
-independent of the rationality parameter. The models that lift a parameter of the baseline
-divide by whether they block this. Lexical uncertainty over free strengthenings, where *A*
-may mean *A and B*, and the wonky-world models, where the listener doubts the speaker's
-prior, remain anti-exhaustive for suitable priors, the Bayesian wonky model exactly when a
-wonkiness-weighted difference of logistic values is positive. Lexical uncertainty restricted
-to the grammatical exhaustification of *A*, the lexical-intentions speaker who chooses a
-message together with its interpretation, and the supervaluationist speaker who addresses a
-question under discussion and averages over the interpretations, all keep the posterior of
-both A and B below its prior whenever *A and B* costs no more than *A and not B*, the
-supervaluationist model for every cost. The experiment found no anti-exhaustivity in
-production or in comprehension; the wonky and supervaluationist models fit best, and once the
-two conjunctions are constrained to cost the same the models that cannot block
-anti-exhaustivity fall behind.
+independent of the rationality parameter.
+
+The models that lift a parameter of the baseline divide by whether they block this. Lexical
+uncertainty over free strengthenings, where *A* may mean *A and B*, and the wonky-world
+models, where the listener doubts the speaker's prior, remain anti-exhaustive for suitable
+priors, the Bayesian wonky model exactly when a wonkiness-weighted difference of logistic
+values is positive. Lexical uncertainty restricted to the grammatical exhaustification of
+*A*, the lexical-intentions speaker who chooses a message together with its interpretation,
+and the supervaluationist speaker who addresses a question under discussion and averages
+over the interpretations, all keep the posterior of both A and B below its prior whenever
+*A and B* costs no more than *A and not B*, the supervaluationist model for every cost.
+
+The experiment found no anti-exhaustivity in production or in comprehension; the wonky and
+supervaluationist models fit best, and once the two conjunctions are constrained to cost the
+same the models that cannot block anti-exhaustivity fall behind.
 
 ## Implementation notes
 
 * Meanings are interpretation functions on the three messages; the exhaustified one is
-  derived by innocent exclusion from the substrate rather than stipulated. The literal
-  listener is the substrate's prior-weighted conditioning, the speaker its softmax of the
-  standard informativity utility with the paper's rationality and costs, and the pragmatic
-  listener its Bayesian posterior; latent interpretations, questions and backgrounds enter
-  through the substrate's marginalised and joint listeners. Every result is stated for an
-  arbitrary prior in the open unit interval, positive rationality and arbitrary costs of the
-  two conjunctions, as in the paper's appendix; the supervaluationist listener takes any prior
-  on the questions that gives the fine one positive probability, while its speaker fixes the
-  two interpretations equiprobable, as the paper's fits do.
-* The supervaluationist speaker's expected utility over the two interpretations is defined
-  here, on the substrate's projection of a listener onto the cells of a question; the prior of
-  the question, common to every message, is left out of the utility.
+  derived by innocent exclusion from the substrate rather than stipulated.
+* The literal listener is the substrate's prior conditioned on the extension, the speaker
+  its power-weight best response with the rationality as exponent and the exponentiated costs
+  as factors, so that the paper's exponentiated utility is a power of the literal listener
+  times a cost factor, and the pragmatic listener is mathlib's posterior kernel. Lexical
+  uncertainty and the Bayesian wonky model average the speaker over the latent as a mixture
+  of kernels, the lexical-intentions speaker is pushed forward along the message coordinate,
+  and the supervaluationist and non-Bayesian wonky listeners are posteriors over a joint
+  state, as the paper's numbered definitions have them.
+* Every result is stated on reals for an arbitrary prior in the open unit interval, positive
+  rationality and arbitrary costs of the two conjunctions, as in the paper's appendix; the
+  supervaluationist listener takes any prior on the questions that gives the fine one
+  positive probability, while its speaker fixes the two interpretations equiprobable, as the
+  paper's fits do. The supervaluationist speaker's weight is the geometric mean of the two
+  interpretations' literal listeners on the cell of the question, times the cost factor; the
+  prior of the question, common to every message, is left out.
 * The paper's anti-exhaustivity is the posterior of both A and B exceeding the prior; the
   substrate's comparison of a posterior with its prior reduces it, over two worlds, to the
   comparison of the two likelihoods of *A*, and the closed forms of those likelihoods are
@@ -74,8 +82,8 @@ anti-exhaustivity fall behind.
   (2020)][franke-bergen-2020]
 -/
 
+open MeasureTheory ProbabilityTheory
 open scoped ENNReal
-open RSA.Canonical
 
 namespace CremersWilcoxSpector2023
 
@@ -85,14 +93,18 @@ namespace CremersWilcoxSpector2023
 inductive World where
   | wa
   | wab
-  deriving DecidableEq, Repr, Fintype, Inhabited
+  deriving DecidableEq, Fintype, Nonempty
+
+instance : MeasurableSpace World := ⊤
 
 /-- The three messages: *A*, *A and B*, *A and not B*. -/
 inductive Message where
   | a
   | aAndB
   | aAndNotB
-  deriving DecidableEq, Repr, Fintype
+  deriving DecidableEq, Fintype, Nonempty
+
+instance : MeasurableSpace Message := ⊤
 
 /-- The literal meaning of each message. -/
 def truth : Message → World → Bool
@@ -113,14 +125,13 @@ def exh (u : Message) (w : World) : Bool :=
     (Exhaustification.predToFinset (truth u)))
 
 /-- Exhaustification reads *A* as *A and not B*. -/
-theorem exh_a (w : World) : exh .a w = truth .aAndNotB w := by cases w <;> decide
+theorem exh_a : exh .a = truth .aAndNotB := by decide
 
 /-- *A and B* has no stronger alternative. -/
-theorem exh_aAndB (w : World) : exh .aAndB w = truth .aAndB w := by cases w <;> decide
+theorem exh_aAndB : exh .aAndB = truth .aAndB := by decide
 
 /-- *A and not B* has no stronger alternative. -/
-theorem exh_aAndNotB (w : World) : exh .aAndNotB w = truth .aAndNotB w := by
-  cases w <;> decide
+theorem exh_aAndNotB : exh .aAndNotB = truth .aAndNotB := by decide
 
 /-- An interpretation function under which every message is true somewhere and every world
 is described by some message, so that the literal listener and the speaker are defined. -/
@@ -131,6 +142,28 @@ structure Meaning where
   exists_world : ∀ u, ∃ w, sat u w = true
   /-- Every world is described by some message. -/
   exists_message : ∀ w, ∃ u, sat u w = true
+
+namespace Meaning
+
+variable (m : Meaning)
+
+/-- The extension of a message. -/
+def extension (u : Message) : Set World := {w | m.sat u w = true}
+
+theorem mem_extension {u : Message} {w : World} : w ∈ m.extension u ↔ m.sat u w = true :=
+  Iff.rfl
+
+/-- A message true everywhere has the full extension. -/
+theorem extension_eq_univ {u : Message} (h : ∀ w, m.sat u w = true) :
+    m.extension u = Set.univ :=
+  Set.eq_univ_of_forall h
+
+/-- A message true at one world only has that world as its extension. -/
+theorem extension_eq_singleton {u : Message} {w : World}
+    (h : ∀ w', m.sat u w' = true ↔ w' = w) : m.extension u = {w} :=
+  Set.ext λ w' => (h w').trans Set.mem_singleton_iff.symm
+
+end Meaning
 
 /-- The literal interpretation. -/
 def literal : Meaning := ⟨truth, by decide, by decide⟩
@@ -147,7 +180,9 @@ def antiExhaustive : Meaning :=
 inductive Interpretation where
   | lit
   | exh
-  deriving DecidableEq, Repr, Fintype, Inhabited
+  deriving DecidableEq, Fintype
+
+instance : MeasurableSpace Interpretation := ⊤
 
 /-- The meaning of a grammatical interpretation. -/
 def Interpretation.meaning : Interpretation → Meaning
@@ -159,7 +194,7 @@ inductive FreeInterpretation where
   | lit
   | exh
   | antiExh
-  deriving DecidableEq, Repr, Fintype, Inhabited
+  deriving DecidableEq, Fintype
 
 /-- The meaning of a free interpretation. -/
 def FreeInterpretation.meaning : FreeInterpretation → Meaning
@@ -172,42 +207,46 @@ measured one. -/
 inductive Background where
   | wonky
   | measured
-  deriving DecidableEq, Repr, Fintype
+  deriving DecidableEq, Fintype, Nonempty
+
+instance : MeasurableSpace Background := ⊤
 
 /-- The questions under discussion: whether A holds, which the two worlds answer alike, or
 which world obtains. -/
 inductive QUD where
   | coarse
   | fine
-  deriving DecidableEq, Repr, Fintype
+  deriving DecidableEq, Fintype, Nonempty
+
+instance : MeasurableSpace QUD := ⊤
 
 section Sums
 
 variable {β : Type*} [AddCommMonoid β]
 
 /-- A sum over the two worlds. -/
-theorem sum_World (f : World → β) : ∑ w, f w = f .wa + f .wab := by
+theorem sum_world (f : World → β) : ∑ w, f w = f .wa + f .wab := by
   rw [show ∑ w, f w = f .wa + (f .wab + 0) from rfl, add_zero]
 
 /-- A sum over the three messages. -/
-theorem sum_Message (f : Message → β) : ∑ u, f u = f .a + f .aAndB + f .aAndNotB := by
+theorem sum_message (f : Message → β) : ∑ u, f u = f .a + f .aAndB + f .aAndNotB := by
   rw [show ∑ u, f u = f .a + (f .aAndB + (f .aAndNotB + 0)) from rfl, add_zero, add_assoc]
 
 /-- A sum over the two grammatical interpretations. -/
-theorem sum_Interpretation (f : Interpretation → β) : ∑ i, f i = f .lit + f .exh := by
+theorem sum_interpretation (f : Interpretation → β) : ∑ i, f i = f .lit + f .exh := by
   rw [show ∑ i, f i = f .lit + (f .exh + 0) from rfl, add_zero]
 
 /-- A sum over the three free interpretations. -/
-theorem sum_FreeInterpretation (f : FreeInterpretation → β) :
+theorem sum_freeInterpretation (f : FreeInterpretation → β) :
     ∑ i, f i = f .lit + f .exh + f .antiExh := by
   rw [show ∑ i, f i = f .lit + (f .exh + (f .antiExh + 0)) from rfl, add_zero, add_assoc]
 
 /-- A sum over the two backgrounds. -/
-theorem sum_Background (f : Background → β) : ∑ b, f b = f .wonky + f .measured := by
+theorem sum_background (f : Background → β) : ∑ b, f b = f .wonky + f .measured := by
   rw [show ∑ b, f b = f .wonky + (f .measured + 0) from rfl, add_zero]
 
 /-- A sum over the two questions. -/
-theorem sum_QUD (f : QUD → β) : ∑ q, f q = f .coarse + f .fine := by
+theorem sum_qud (f : QUD → β) : ∑ q, f q = f .coarse + f .fine := by
   rw [show ∑ q, f q = f .coarse + (f .fine + 0) from rfl, add_zero]
 
 end Sums
@@ -222,9 +261,9 @@ structure Setting where
   /-- The rationality, the paper's λ. -/
   lam : ℝ
   /-- The cost of *A and B*. -/
-  cAB : ℝ
+  cAndB : ℝ
   /-- The cost of *A and not B*. -/
-  cAnotB : ℝ
+  cAndNotB : ℝ
   /-- The world of both has positive prior probability. -/
   p_pos : 0 < p
   /-- The world of A alone has positive prior probability. -/
@@ -239,288 +278,292 @@ variable (s : Setting)
 /-- The cost of a message. -/
 def cost : Message → ℝ
   | .a => 0
-  | .aAndB => s.cAB
-  | .aAndNotB => s.cAnotB
+  | .aAndB => s.cAndB
+  | .aAndNotB => s.cAndNotB
+
+/-- The cost factor of a message: the exponential of its cost scaled by the rationality. -/
+noncomputable def costFactor (u : Message) : ℝ≥0∞ := ENNReal.ofReal (Real.exp (-(s.lam * s.cost u)))
+
+theorem costFactor_ne_zero (u : Message) : s.costFactor u ≠ 0 :=
+  (ENNReal.ofReal_pos.mpr (Real.exp_pos _)).ne'
+
+theorem costFactor_ne_top (u : Message) : s.costFactor u ≠ ∞ := ENNReal.ofReal_ne_top
+
+theorem costFactor_toReal (u : Message) :
+    (s.costFactor u).toReal = Real.exp (-(s.lam * s.cost u)) :=
+  ENNReal.toReal_ofReal (Real.exp_pos _).le
+
+/-- The paper's `f_λ`: the logistic function with rate the rationality. -/
+noncomputable def logistic (x : ℝ) : ℝ := Real.sigmoid (s.lam * x)
+
+theorem logistic_nonneg (x : ℝ) : 0 ≤ s.logistic x := Real.sigmoid_nonneg _
+
+theorem logistic_lt_iff {x y : ℝ} : s.logistic x < s.logistic y ↔ x < y := by
+  rw [logistic, logistic, Real.sigmoid_lt_iff, mul_lt_mul_iff_of_pos_left s.lam_pos]
+
+theorem logistic_lt {x y : ℝ} (h : x < y) : s.logistic x < s.logistic y :=
+  s.logistic_lt_iff.mpr h
+
+/-- The weight of a world under the measured prior. -/
+noncomputable def priorWeight : World → ℝ≥0∞
+  | .wa => ENNReal.ofReal (1 - s.p)
+  | .wab => ENNReal.ofReal s.p
 
 /-- The measured prior over the two worlds. -/
-noncomputable def prior : PMF World :=
-  PMF.ofFintype (λ w => match w with
-    | .wa => ENNReal.ofReal (1 - s.p)
-    | .wab => ENNReal.ofReal s.p) (by
-    rw [sum_World]
-    show ENNReal.ofReal (1 - s.p) + ENNReal.ofReal s.p = 1
-    rw [← ENNReal.ofReal_add (by linarith [s.p_lt_one]) s.p_pos.le, sub_add_cancel,
-      ENNReal.ofReal_one])
+noncomputable def prior : Measure World := ∑ w, s.priorWeight w • Measure.dirac w
+
+theorem prior_apply_singleton (w : World) : s.prior {w} = s.priorWeight w :=
+  Measure.sum_smul_dirac_apply_singleton _ w
 
 /-- The prior of the world of A alone. -/
-theorem prior_wa : s.prior .wa = ENNReal.ofReal (1 - s.p) := rfl
+theorem prior_wa : s.prior {.wa} = ENNReal.ofReal (1 - s.p) := prior_apply_singleton s .wa
 
 /-- The prior of the world of both. -/
-theorem prior_wab : s.prior .wab = ENNReal.ofReal s.p := rfl
+theorem prior_wab : s.prior {.wab} = ENNReal.ofReal s.p := prior_apply_singleton s .wab
+
+instance : IsProbabilityMeasure s.prior :=
+  ⟨by
+    rw [← Finset.coe_univ, ← sum_measure_singleton, sum_world, prior_wa, prior_wab,
+      ← ENNReal.ofReal_add (by linarith [s.p_lt_one]) s.p_pos.le, sub_add_cancel,
+      ENNReal.ofReal_one]⟩
 
 /-- The prior is positive on both worlds. -/
-theorem prior_ne_zero (w : World) : s.prior w ≠ 0 := by
+theorem prior_ne_zero (w : World) : s.prior {w} ≠ 0 := by
   cases w
-  · exact (ENNReal.ofReal_pos.mpr (by linarith [s.p_lt_one])).ne'
-  · exact (ENNReal.ofReal_pos.mpr s.p_pos).ne'
+  · exact prior_wa s ▸ (ENNReal.ofReal_pos.mpr (by linarith [s.p_lt_one])).ne'
+  · exact prior_wab s ▸ (ENNReal.ofReal_pos.mpr s.p_pos).ne'
+
+/-- The prior is carried by the two worlds. -/
+theorem prior_support (w : World) (_ : s.prior {w} ≠ 0) : w = .wab ∨ w = .wa := by
+  cases w <;> simp
 
 /-- The prior of the world of A alone, as a real. -/
-theorem prior_wa_toReal : (s.prior .wa).toReal = 1 - s.p :=
-  ENNReal.toReal_ofReal (by linarith [s.p_lt_one])
+theorem prior_real_wa : s.prior.real {.wa} = 1 - s.p := by
+  rw [measureReal_def, prior_wa, ENNReal.toReal_ofReal (by linarith [s.p_lt_one])]
 
 /-- The prior of the world of both, as a real. -/
-theorem prior_wab_toReal : (s.prior .wab).toReal = s.p := ENNReal.toReal_ofReal s.p_pos.le
-
-/-- The prior sums to one. -/
-theorem prior_add : s.prior .wa + s.prior .wab = 1 := by
-  rw [prior_wa, prior_wab, ← ENNReal.ofReal_add (by linarith [s.p_lt_one]) s.p_pos.le,
-    sub_add_cancel, ENNReal.ofReal_one]
+theorem prior_real_wab : s.prior.real {.wab} = s.p := by
+  rw [measureReal_def, prior_wab, ENNReal.toReal_ofReal s.p_pos.le]
 
 end Setting
 
 /-- The wonky prior: uniform over the two worlds. -/
-noncomputable def wonkyPrior : PMF World := PMF.uniformOfFintype World
+noncomputable def wonkyPrior : Measure World := uniformOn Set.univ
+
+instance : IsProbabilityMeasure wonkyPrior :=
+  isProbabilityMeasure_uniformOn Set.finite_univ Set.univ_nonempty
 
 /-- The wonky prior gives each world a half. -/
-theorem wonkyPrior_apply (w : World) : wonkyPrior w = 2⁻¹ := by
-  rw [wonkyPrior, PMF.uniformOfFintype_apply, show Fintype.card World = 2 from rfl]
+theorem wonkyPrior_apply_singleton (w : World) : wonkyPrior {w} = 2⁻¹ := by
+  rw [wonkyPrior, uniformOn_univ_apply_singleton, show Fintype.card World = 2 from rfl]
   norm_cast
 
 /-- The wonky prior is positive on both worlds. -/
-theorem wonkyPrior_ne_zero (w : World) : wonkyPrior w ≠ 0 := by rw [wonkyPrior_apply]; simp
+theorem wonkyPrior_ne_zero (w : World) : wonkyPrior {w} ≠ 0 := by
+  rw [wonkyPrior_apply_singleton]; simp
 
 /-- The wonky prior of a world, as a real. -/
-theorem wonkyPrior_toReal (w : World) : (wonkyPrior w).toReal = 2⁻¹ := by
-  rw [wonkyPrior_apply, ENNReal.toReal_inv]; simp
+theorem wonkyPrior_real_singleton (w : World) : wonkyPrior.real {w} = 2⁻¹ := by
+  rw [wonkyPrior, uniformOn_univ_real_singleton, show Fintype.card World = 2 from rfl]
+  norm_num
 
 /-! ### The literal listener and the speaker under an interpretation (eqs. 1 to 3) -/
 
 section Speaker
 
-variable (P : PMF World) (hP : ∀ w, P w ≠ 0) (m : Meaning)
-include hP
+variable (P : Measure World) [IsFiniteMeasure P] (hP : ∀ w, P {w} ≠ 0) (m : Meaning)
 
-/-- The prior mass of a message's extension is positive. -/
-theorem meaning_ne_zero (u : Message) :
-    (∑' w, P w * (if m.sat u w then (1 : ℝ≥0∞) else 0)) ≠ 0 := by
-  obtain ⟨w, hw⟩ := m.exists_world u
-  exact ENNReal.summable.tsum_ne_zero_iff.mpr ⟨w, by rw [hw]; simpa using hP w⟩
+/-- The literal listener: the prior conditioned on the message's extension (eq. 1). -/
+noncomputable def L0 : Kernel Message World :=
+  RSA.literalListener P λ u => (m.extension u).indicator 1
 
-/-- eq. (1): the literal listener, the prior conditioned on the message's meaning. -/
-noncomputable def L0 (u : Message) : PMF World :=
-  RSA.L0LassiterGoodman P m.sat u (meaning_ne_zero P hP m u)
+omit [IsFiniteMeasure P] in
+/-- The literal listener is a subprobability at every world. -/
+theorem L0_le_one (u : Message) (w : World) : L0 P m u {w} ≤ 1 :=
+  RSA.literalListener_apply_le_one _ _ _ _
 
-/-- The literal listener in closed form. -/
-theorem L0_apply (u : Message) (w : World) :
-    L0 P hP m u w =
-      P w * (if m.sat u w then 1 else 0) * (∑' w', P w' * (if m.sat u w' then 1 else 0))⁻¹ :=
-  RSA.L0LassiterGoodman_apply _ _ _ _ _
+omit [IsFiniteMeasure P] in
+theorem L0_ne_top (u : Message) (w : World) : L0 P m u {w} ≠ ∞ :=
+  ne_top_of_le_ne_top ENNReal.one_ne_top (L0_le_one P m u w)
 
-/-- A message true at a world has positive mass there. -/
-theorem L0_ne_zero {u : Message} {w : World} (h : m.sat u w = true) : L0 P hP m u w ≠ 0 :=
-  (PMF.mem_support_iff _ _).mp
-    ((RSA.mem_support_L0LassiterGoodman_iff _ _ _ _ w).mpr ⟨hP w, h⟩)
-
+omit [IsFiniteMeasure P] in
 /-- A message false at a world gets no mass there. -/
-theorem L0_eq_zero {u : Message} {w : World} (h : m.sat u w = false) : L0 P hP m u w = 0 := by
-  rw [L0_apply, h]; simp
+theorem L0_eq_zero {u : Message} {w : World} (h : m.sat u w = false) : L0 P m u {w} = 0 :=
+  RSA.literalListener_indicator_apply_singleton_of_notMem P m.extension
+    (by rw [Meaning.mem_extension, h]; exact Bool.false_ne_true)
 
-/-- A message true at one world only puts all its mass there. -/
-theorem L0_eq_one {u : Message} {w : World} (h : m.sat u w = true)
-    (h' : ∀ w', m.sat u w' = true → w' = w) : L0 P hP m u w = 1 := by
-  rw [L0_apply, tsum_eq_single w (λ w' hne => by
-    rw [Bool.eq_false_iff.mpr (λ hw => hne (h' w' hw))]; simp), h]
-  simp [ENNReal.mul_inv_cancel (hP w) (PMF.apply_ne_top P w)]
-
+omit [IsFiniteMeasure P] in
 /-- The tautology *A* leaves the prior unchanged. -/
-theorem L0_literal_a (w : World) : L0 P hP literal .a w = P w :=
-  RSA.L0LassiterGoodman_apply_of_meaning_true P truth .a (λ w => by cases w <;> rfl) _ w
-
-/-- *A and B* singles out the world of both. -/
-theorem L0_literal_aAndB_wab : L0 P hP literal .aAndB .wab = 1 :=
-  L0_eq_one _ _ _ rfl (by decide)
-
-/-- *A and B* is false in the world of A alone. -/
-theorem L0_literal_aAndB_wa : L0 P hP literal .aAndB .wa = 0 := L0_eq_zero _ _ _ rfl
-
-/-- *A and not B* singles out the world of A alone. -/
-theorem L0_literal_aAndNotB_wa : L0 P hP literal .aAndNotB .wa = 1 :=
-  L0_eq_one _ _ _ rfl (by decide)
-
-/-- *A and not B* is false in the world of both. -/
-theorem L0_literal_aAndNotB_wab : L0 P hP literal .aAndNotB .wab = 0 := L0_eq_zero _ _ _ rfl
-
-/-- Exhaustified *A* singles out the world of A alone. -/
-theorem L0_exhaustified_a_wa : L0 P hP exhaustified .a .wa = 1 :=
-  L0_eq_one _ _ _ (by decide) (by decide)
-
-/-- Exhaustified *A* is false in the world of both. -/
-theorem L0_exhaustified_a_wab : L0 P hP exhaustified .a .wab = 0 :=
-  L0_eq_zero _ _ _ (by decide)
-
-/-- Under exhaustification *A and B* still singles out the world of both. -/
-theorem L0_exhaustified_aAndB_wab : L0 P hP exhaustified .aAndB .wab = 1 :=
-  L0_eq_one _ _ _ (by decide) (by decide)
-
-/-- Under exhaustification *A and B* is still false in the world of A alone. -/
-theorem L0_exhaustified_aAndB_wa : L0 P hP exhaustified .aAndB .wa = 0 :=
-  L0_eq_zero _ _ _ (by decide)
-
-/-- Under exhaustification *A and not B* still singles out the world of A alone. -/
-theorem L0_exhaustified_aAndNotB_wa : L0 P hP exhaustified .aAndNotB .wa = 1 :=
-  L0_eq_one _ _ _ (by decide) (by decide)
-
-/-- Under exhaustification *A and not B* is still false in the world of both. -/
-theorem L0_exhaustified_aAndNotB_wab : L0 P hP exhaustified .aAndNotB .wab = 0 :=
-  L0_eq_zero _ _ _ (by decide)
-
-/-- Anti-exhaustive *A* singles out the world of both. -/
-theorem L0_antiExhaustive_a_wab : L0 P hP antiExhaustive .a .wab = 1 :=
-  L0_eq_one _ _ _ rfl (by decide)
-
-/-- Anti-exhaustive *A* is false in the world of A alone. -/
-theorem L0_antiExhaustive_a_wa : L0 P hP antiExhaustive .a .wa = 0 := L0_eq_zero _ _ _ rfl
-
-/-- Under the anti-exhaustive reading *A and B* still singles out the world of both. -/
-theorem L0_antiExhaustive_aAndB_wab : L0 P hP antiExhaustive .aAndB .wab = 1 :=
-  L0_eq_one _ _ _ rfl (by decide)
-
-/-- Under the anti-exhaustive reading *A and not B* is still false in the world of both. -/
-theorem L0_antiExhaustive_aAndNotB_wab : L0 P hP antiExhaustive .aAndNotB .wab = 0 :=
-  L0_eq_zero _ _ _ rfl
+theorem L0_literal_a [IsProbabilityMeasure P] (w : World) : L0 P literal .a {w} = P {w} :=
+  RSA.literalListener_indicator_apply_singleton_of_eq_univ P literal.extension
+    (literal.extension_eq_univ λ w => by cases w <;> rfl) w
 
 variable (s : Setting)
 
-/-- eq. (2): the utility of a message at a world for the literal listener under the
-interpretation, the rationality times the log probability of the world less the cost. -/
-noncomputable def utility (w : World) (u : Message) : EReal :=
-  rsaUtility (λ w u => L0 P hP m u w) s.cost s.lam w u
+/-- The speaker: the power-weight best response to the literal listener with the rationality
+as exponent and the cost factors as weights (eqs. 2 and 3). -/
+noncomputable def speaker : Kernel World Message := RSA.speaker s.lam s.costFactor (L0 P m)
 
-instance : ViableSpeaker (utility P hP m s) :=
-  viableSpeaker_rsaUtility _ _ s.lam_pos (λ _ _ => PMF.apply_ne_top _ _) λ w =>
-    let ⟨u, hu⟩ := m.exists_message w
-    ⟨u, L0_ne_zero P hP m hu⟩
+instance : IsFiniteKernel (speaker P m s) := inferInstanceAs (IsFiniteKernel (RSA.speaker _ _ _))
 
-/-- eq. (3): the speaker, the softmax of the utility. -/
-noncomputable def speaker (w : World) : PMF Message := S1 (utility P hP m s) w
+omit [IsFiniteMeasure P] in
+/-- The weight of a message is finite. -/
+theorem weight_ne_top (u : Message) (w : World) :
+    L0 P m u {w} ^ s.lam * s.costFactor u ≠ ∞ :=
+  ENNReal.mul_ne_top (RSA.weight_rpow_ne_top s.lam_pos.le (L0_le_one P m u w))
+    (s.costFactor_ne_top u)
 
-/-- The utility is `⊥` at a message false at the world and otherwise real. -/
-theorem utility_eq (w : World) (u : Message) :
-    utility P hP m s w u =
-      if L0 P hP m u w = 0 then ⊥
-      else ((s.lam * (Real.log (L0 P hP m u w).toReal - s.cost u) : ℝ) : EReal) :=
-  rsaUtility_eq _ _ s.lam_pos (PMF.apply_ne_top _ _)
+omit [IsFiniteMeasure P] in
+/-- A message false at a world has no weight there. -/
+theorem weight_eq_zero {u : Message} {w : World} (h : m.sat u w = false) :
+    L0 P m u {w} ^ s.lam * s.costFactor u = 0 := by
+  rw [L0_eq_zero P m h, ENNReal.zero_rpow_of_pos s.lam_pos, zero_mul]
 
-/-- The softmax weight of a message: zero at a message false at the world. -/
-theorem softmaxWeight_utility (w : World) (u : Message) :
-    PMF.softmaxWeight (utility P hP m s w) u =
-      if L0 P hP m u w = 0 then 0
-      else ENNReal.ofReal (Real.exp (s.lam * (Real.log (L0 P hP m u w).toReal - s.cost u))) :=
-  softmaxWeight_rsaUtility _ _ s.lam_pos (PMF.apply_ne_top _ _)
+omit [IsFiniteMeasure P] in
+/-- A message false at a world is never used there. -/
+theorem speaker_eq_zero {u : Message} {w : World} (h : m.sat u w = false) :
+    speaker P m s w {u} = 0 :=
+  RSA.speaker_apply_singleton_eq_zero s.lam_pos (L0_eq_zero P m h)
 
-/-- The speaker in closed form. -/
-theorem speaker_apply (w : World) (u : Message) :
-    speaker P hP m s w u =
-      PMF.softmaxWeight (utility P hP m s w) u / ∑ v, PMF.softmaxWeight (utility P hP m s w) v :=
-  PMF.softmax_apply _ (ViableSpeaker.no_top w) (ViableSpeaker.some_finite w) u
+include hP
 
-/-- The speaker uses every message true at the world. -/
-theorem speaker_ne_zero {w : World} {u : Message} (h : m.sat u w = true) :
-    speaker P hP m s w u ≠ 0 :=
-  S1_ne_zero _ (by rw [utility_eq, if_neg (L0_ne_zero P hP m h)]; exact EReal.coe_ne_bot _)
+/-- A message true at a world has positive mass there. -/
+theorem L0_ne_zero {u : Message} {w : World} (h : m.sat u w = true) : L0 P m u {w} ≠ 0 := by
+  rw [L0, RSA.literalListener_indicator_apply_singleton P m.extension h]
+  exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _)) (hP w)
+
+/-- A message true at one world only puts all its mass there. -/
+theorem L0_eq_one {u : Message} {w : World} (h : ∀ w', m.sat u w' = true ↔ w' = w) :
+    L0 P m u {w} = 1 :=
+  RSA.literalListener_indicator_apply_singleton_of_eq_singleton P m.extension
+    (m.extension_eq_singleton h) (hP w)
+
+/-- The literal listener is a probability measure. -/
+theorem L0_apply_univ (u : Message) : L0 P m u Set.univ = 1 :=
+  let ⟨w, hw⟩ := m.exists_world u
+  RSA.literalListener_indicator_apply_univ P m.extension λ h =>
+    hP w (measure_mono_null (Set.singleton_subset_iff.mpr hw) h)
+
+/-- A message true at a world has positive weight there. -/
+theorem weight_ne_zero {u : Message} {w : World} (h : m.sat u w = true) :
+    L0 P m u {w} ^ s.lam * s.costFactor u ≠ 0 :=
+  mul_ne_zero (RSA.weight_rpow_ne_zero s.lam_pos.le (L0_ne_zero P hP m h)) (s.costFactor_ne_zero u)
+
+/-- The weight of a message true at a world, on reals: the exponential of the paper's scaled
+utility. -/
+theorem weight_toReal {u : Message} {w : World} (h : m.sat u w = true) :
+    (L0 P m u {w} ^ s.lam * s.costFactor u).toReal =
+      Real.exp (s.lam * (Real.log (L0 P m u {w}).toReal - s.cost u)) := by
+  rw [ENNReal.toReal_mul, ← ENNReal.toReal_rpow,
+    Real.rpow_def_of_pos (ENNReal.toReal_pos (L0_ne_zero P hP m h) (L0_ne_top P m u w)),
+    Setting.costFactor_toReal, ← Real.exp_add]
+  congr 1; ring
+
+/-- A message true at a world is used there. -/
+theorem speaker_ne_zero {u : Message} {w : World} (h : m.sat u w = true) :
+    speaker P m s w {u} ≠ 0 :=
+  RSA.speaker_apply_singleton_ne_zero s.lam_pos.le s.costFactor_ne_zero s.costFactor_ne_top
+    (λ v => L0_le_one P m v w) (L0_ne_zero P hP m h)
+
+/-- Between two messages true at a world, the speaker prefers the one of higher utility. -/
+theorem speaker_real_singleton_lt_iff {u v : Message} {w : World} (hu : m.sat u w = true)
+    (hv : m.sat v w = true) :
+    (speaker P m s w).real {u} < (speaker P m s w).real {v} ↔
+      Real.log (L0 P m u {w}).toReal - s.cost u < Real.log (L0 P m v {w}).toReal - s.cost v := by
+  rw [speaker, RSA.speaker_real_singleton_lt_iff s.lam_pos.le s.costFactor_ne_top
+      (λ v => L0_le_one P m v w) ⟨u, weight_ne_zero P hP m s hu⟩,
+    ← ENNReal.toReal_lt_toReal (weight_ne_top P m s u w) (weight_ne_top P m s v w),
+    weight_toReal P hP m s hu, weight_toReal P hP m s hv, Real.exp_lt_exp,
+    mul_lt_mul_iff_of_pos_left s.lam_pos]
+
+/-- When exactly two messages are true at a world, the speaker's use of one is the logistic
+function of the utility difference. -/
+theorem speaker_real_singleton_of_pair {u v : Message} {w : World} (huv : u ≠ v)
+    (hu : m.sat u w = true) (hv : m.sat v w = true)
+    (hsupp : ∀ x, m.sat x w = true → x = u ∨ x = v) :
+    (speaker P m s w).real {u} =
+      s.logistic ((Real.log (L0 P m u {w}).toReal - s.cost u) -
+        (Real.log (L0 P m v {w}).toReal - s.cost v)) := by
+  rw [speaker, RSA.speaker, Kernel.ofWeights_real_singleton_of_pair w huv
+      (λ x => weight_ne_top P m s x w)
+      (λ x hx => hsupp x (of_not_not (mt (λ h => weight_eq_zero P m s
+        (Bool.eq_false_iff.mpr h)) hx))),
+    weight_toReal P hP m s hu, weight_toReal P hP m s hv, Real.exp_div_add_exp_eq_sigmoid,
+    Setting.logistic]
+  congr 1; ring
 
 end Speaker
 
 /-- The literal listener with the measured prior. -/
-noncomputable abbrev Setting.L0 (s : Setting) (m : Meaning) : Message → PMF World :=
-  CremersWilcoxSpector2023.L0 s.prior s.prior_ne_zero m
+noncomputable abbrev Setting.L0 (s : Setting) (m : Meaning) : Kernel Message World :=
+  CremersWilcoxSpector2023.L0 s.prior m
 
 /-- The speaker with the measured prior in the literal listener. -/
-noncomputable abbrev Setting.speaker (s : Setting) (m : Meaning) : World → PMF Message :=
-  CremersWilcoxSpector2023.speaker s.prior s.prior_ne_zero m s
+noncomputable abbrev Setting.speaker (s : Setting) (m : Meaning) : Kernel World Message :=
+  CremersWilcoxSpector2023.speaker s.prior m s
 
 /-! ### Closed forms: the speaker's use of *A* is a logistic function -/
 
 section ClosedForms
 
-variable (P : PMF World) (hP : ∀ w, P w ≠ 0) (s : Setting)
+variable (P : Measure World) [IsProbabilityMeasure P] (hP : ∀ w, P {w} ≠ 0) (s : Setting)
+include hP
 
-/-- eq. (A.3): in the world of both, the literal speaker's use of *A* is the logistic
-function of the cost of *A and B* plus the log prior. -/
+/-- In the world of both, the literal speaker's use of *A* is the logistic function of the
+cost of *A and B* plus the log prior (eq. A.3). -/
 theorem speaker_literal_wab_a :
-    speaker P hP literal s .wab .a =
-      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAB + Real.log (P .wab).toReal))) := by
-  rw [speaker_apply, sum_Message]
-  simp only [softmaxWeight_utility, L0_literal_a, L0_literal_aAndB_wab, L0_literal_aAndNotB_wab,
-    hP .wab, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost]
-  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
-  congr 2; ring
+    (speaker P literal s .wab).real {.a} = s.logistic (s.cAndB + Real.log (P.real {.wab})) := by
+  rw [speaker_real_singleton_of_pair P hP literal s (v := .aAndB) (by decide) rfl rfl
+    (by decide)]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one P hP literal, ENNReal.toReal_one,
+    Real.log_one, Setting.cost, ← measureReal_def]
+  congr 1; ring
 
-/-- eq. (A.2): in the world of A alone, the use of *A* is the logistic function of the
-cost of *A and not B* plus the log prior. -/
+/-- In the world of A alone, the use of *A* is the logistic function of the cost of
+*A and not B* plus the log prior (eq. A.2). -/
 theorem speaker_literal_wa_a :
-    speaker P hP literal s .wa .a =
-      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAnotB + Real.log (P .wa).toReal))) := by
-  rw [speaker_apply, sum_Message]
-  simp only [softmaxWeight_utility, L0_literal_a, L0_literal_aAndB_wa, L0_literal_aAndNotB_wa,
-    hP .wa, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost]
-  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
-  congr 2; ring
+    (speaker P literal s .wa).real {.a} = s.logistic (s.cAndNotB + Real.log (P.real {.wa})) := by
+  rw [speaker_real_singleton_of_pair P hP literal s (v := .aAndNotB) (by decide) rfl rfl
+    (by decide)]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one P hP literal, ENNReal.toReal_one,
+    Real.log_one, Setting.cost, ← measureReal_def]
+  congr 1; ring
+
+end ClosedForms
+
+section SettingClosedForms
+
+variable (s : Setting)
 
 /-- Under the exhaustified interpretation *A* is as informative as *A and not B* in the
 world of A alone, so its use is the logistic function of the latter's cost. -/
 theorem speaker_exhaustified_wa_a :
-    speaker P hP exhaustified s .wa .a = ENNReal.ofReal (Real.sigmoid (s.lam * s.cAnotB)) := by
-  rw [speaker_apply, sum_Message]
-  simp only [softmaxWeight_utility, L0_exhaustified_a_wa, L0_exhaustified_aAndB_wa,
-    L0_exhaustified_aAndNotB_wa, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one,
-    Real.log_one, Setting.cost]
-  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
-  congr 2; ring
+    (s.speaker exhaustified .wa).real {.a} = s.logistic s.cAndNotB := by
+  rw [Setting.speaker, speaker_real_singleton_of_pair s.prior s.prior_ne_zero exhaustified s
+    (v := .aAndNotB) (by decide) (by decide) (by decide) (by decide)]
+  simp (disch := decide) only [L0_eq_one s.prior s.prior_ne_zero exhaustified,
+    ENNReal.toReal_one, Real.log_one, Setting.cost]
+  congr 1; ring
 
 /-- Under the exhaustified interpretation *A* is false in the world of both. -/
-theorem speaker_exhaustified_wab_a : speaker P hP exhaustified s .wab .a = 0 := by
-  rw [speaker_apply, softmaxWeight_utility, L0_exhaustified_a_wab, if_pos rfl, ENNReal.zero_div]
+theorem speaker_exhaustified_wab_a : (s.speaker exhaustified .wab).real {.a} = 0 :=
+  (measureReal_eq_zero_iff (measure_ne_top _ _)).mpr (speaker_eq_zero _ _ _ (by decide))
 
 /-- Under the anti-exhaustive interpretation *A* is as informative as *A and B* in the world
 of both. -/
 theorem speaker_antiExhaustive_wab_a :
-    speaker P hP antiExhaustive s .wab .a = ENNReal.ofReal (Real.sigmoid (s.lam * s.cAB)) := by
-  rw [speaker_apply, sum_Message]
-  simp only [softmaxWeight_utility, L0_antiExhaustive_a_wab, L0_antiExhaustive_aAndB_wab,
-    L0_antiExhaustive_aAndNotB_wab, one_ne_zero, ↓reduceIte, add_zero, ENNReal.toReal_one,
-    Real.log_one, Setting.cost]
-  rw [ENNReal.ofReal_exp_div_add_ofReal_exp]
-  congr 2; ring
+    (s.speaker antiExhaustive .wab).real {.a} = s.logistic s.cAndB := by
+  rw [Setting.speaker, speaker_real_singleton_of_pair s.prior s.prior_ne_zero antiExhaustive s
+    (v := .aAndB) (by decide) rfl rfl (by decide)]
+  simp (disch := decide) only [L0_eq_one s.prior s.prior_ne_zero antiExhaustive,
+    ENNReal.toReal_one, Real.log_one, Setting.cost]
+  congr 1; ring
 
 /-- Under the anti-exhaustive interpretation *A* is false in the world of A alone. -/
-theorem speaker_antiExhaustive_wa_a : speaker P hP antiExhaustive s .wa .a = 0 := by
-  rw [speaker_apply, softmaxWeight_utility, L0_antiExhaustive_a_wa, if_pos rfl,
-    ENNReal.zero_div]
+theorem speaker_antiExhaustive_wa_a : (s.speaker antiExhaustive .wa).real {.a} = 0 :=
+  (measureReal_eq_zero_iff (measure_ne_top _ _)).mpr (speaker_eq_zero _ _ _ rfl)
 
-end ClosedForms
-
-/-! ### Two-world Bayes -/
-
-/-- Against a two-point prior, the likelihood at a point exceeds the marginal likelihood
-exactly when it exceeds the likelihood at the other point. -/
-private theorem two_world_lt {a b x y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hx : x ≠ ⊤) :
-    a * y + b * x < x ↔ y < x := by
-  have ha' : a ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_self_add)
-  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
-  have h : a * y + b * x < a * x + b * x ↔ y < x := by
-    rw [ENNReal.add_lt_add_iff_right (ENNReal.mul_ne_top hb' hx),
-      ENNReal.mul_lt_mul_iff_right ha ha']
-  rwa [← add_mul, hab, one_mul] at h
-
-private theorem lt_two_world {a b x y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hx : x ≠ ⊤) :
-    x < a * y + b * x ↔ x < y := by
-  have ha' : a ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_self_add)
-  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
-  have h : a * x + b * x < a * y + b * x ↔ x < y := by
-    rw [ENNReal.add_lt_add_iff_right (ENNReal.mul_ne_top hb' hx),
-      ENNReal.mul_lt_mul_iff_right ha ha']
-  rwa [← add_mul, hab, one_mul] at h
+end SettingClosedForms
 
 /-! ### The baseline model (§3) -/
 
@@ -528,73 +571,59 @@ section Baseline
 
 variable (s : Setting)
 
-/-- (6a): in the world of both, the speaker prefers *A* to *A and B* exactly when the
-information *A and B* would add, the negated log prior, does not exceed its cost. -/
+/-- In the world of both, the speaker prefers *A* to *A and B* exactly when the information
+*A and B* would add, the negated log prior, does not exceed its cost (6a). -/
 theorem baseline_aAndB_lt_a_iff :
-    s.speaker literal .wab .aAndB < s.speaker literal .wab .a ↔ -s.cAB < Real.log s.p := by
-  dsimp only [Setting.speaker]
-  rw [speaker, S1_prefers_iff, utility_eq, utility_eq, L0_literal_aAndB_wab, L0_literal_a,
-    if_neg one_ne_zero, if_neg (s.prior_ne_zero _), Setting.prior_wab_toReal,
-    ENNReal.toReal_one, Real.log_one, EReal.coe_lt_coe_iff]
-  simp only [Setting.cost, zero_sub, sub_zero]
-  exact mul_lt_mul_iff_of_pos_left s.lam_pos
+    (s.speaker literal .wab).real {.aAndB} < (s.speaker literal .wab).real {.a} ↔
+      -s.cAndB < Real.log s.p := by
+  rw [Setting.speaker, speaker_real_singleton_lt_iff s.prior s.prior_ne_zero literal s rfl rfl]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one s.prior s.prior_ne_zero literal,
+    ENNReal.toReal_one, Real.log_one, Setting.cost, ← measureReal_def, Setting.prior_real_wab,
+    zero_sub, sub_zero]
 
-/-- (7): in the world of A alone, the speaker prefers *A and not B* to *A* exactly when
-the negated log prior exceeds its cost. -/
+/-- In the world of A alone, the speaker prefers *A and not B* to *A* exactly when the
+negated log prior exceeds its cost (7). -/
 theorem baseline_a_lt_aAndNotB_iff :
-    s.speaker literal .wa .a < s.speaker literal .wa .aAndNotB ↔
-      Real.log (1 - s.p) < -s.cAnotB := by
-  dsimp only [Setting.speaker]
-  rw [speaker, S1_prefers_iff, utility_eq, utility_eq, L0_literal_aAndNotB_wa, L0_literal_a,
-    if_neg one_ne_zero, if_neg (s.prior_ne_zero _), Setting.prior_wa_toReal,
-    ENNReal.toReal_one, Real.log_one, EReal.coe_lt_coe_iff]
-  simp only [Setting.cost, zero_sub, sub_zero]
-  exact mul_lt_mul_iff_of_pos_left s.lam_pos
+    (s.speaker literal .wa).real {.a} < (s.speaker literal .wa).real {.aAndNotB} ↔
+      Real.log (1 - s.p) < -s.cAndNotB := by
+  rw [Setting.speaker, speaker_real_singleton_lt_iff s.prior s.prior_ne_zero literal s rfl rfl]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one s.prior s.prior_ne_zero literal,
+    ENNReal.toReal_one, Real.log_one, Setting.cost, ← measureReal_def, Setting.prior_real_wa,
+    zero_sub, sub_zero]
 
-/-- Every message is used somewhere, so has positive marginal likelihood. -/
-theorem baseline_marginal_ne_zero (u : Message) :
-    PMF.marginal (s.speaker literal) s.prior u ≠ 0 :=
+/-- Every message is used somewhere, so is heard with positive probability. -/
+theorem comp_speaker_literal_ne_zero (u : Message) : (s.speaker literal ∘ₘ s.prior) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (speaker_ne_zero _ _ _ _ hw)
+  comp_apply_singleton_ne_zero _ _ (s.prior_ne_zero w) (speaker_ne_zero _ s.prior_ne_zero _ s hw)
 
-/-- eq. (4): the pragmatic listener. -/
-noncomputable def listener (u : Message) : PMF World :=
-  RSA.L1 (s.speaker literal) s.prior u (baseline_marginal_ne_zero s u)
+/-- The pragmatic listener (eq. 4). -/
+noncomputable def listener : Kernel Message World :=
+  RSA.pragmaticListener s.lam s.costFactor (s.L0 literal) s.prior
 
-/-- (A.4): the listener is anti-exhaustive, the posterior of both A and B exceeding the
-prior, exactly when the speaker uses *A* more in the world of both than in the world of A
-alone. -/
+/-- The listener is anti-exhaustive, the posterior of both A and B exceeding the prior,
+exactly when the speaker uses *A* more in the world of both than in the world of A alone
+(A.4). -/
 theorem prior_lt_listener_iff_speaker_lt :
-    s.prior .wab < listener s .a .wab ↔ s.speaker literal .wa .a < s.speaker literal .wab .a := by
-  rw [listener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum, sum_World]
-  exact two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _)
+    s.prior.real {.wab} < (listener s .a).real {.wab} ↔
+      (s.speaker literal .wa).real {.a} < (s.speaker literal .wab).real {.a} :=
+  real_lt_posterior_real_singleton_iff_of_pair (s.speaker literal) s.prior (by decide)
+    s.prior_support (comp_speaker_literal_ne_zero s _) (s.prior_ne_zero _) (s.prior_ne_zero _)
 
-/-- (6b): the listener is anti-exhaustive exactly when the log odds of the prior exceed the
-cost disadvantage of *A and not B* over *A and B*, whatever the rationality. -/
+/-- The listener is anti-exhaustive exactly when the log odds of the prior exceed the cost
+disadvantage of *A and not B* over *A and B*, whatever the rationality (6b). -/
 theorem prior_lt_listener_iff :
-    s.prior .wab < listener s .a .wab ↔
-      s.cAnotB - s.cAB < Real.log s.p - Real.log (1 - s.p) := by
-  rw [prior_lt_listener_iff_speaker_lt]
-  dsimp only [Setting.speaker]
-  rw [speaker_literal_wa_a, speaker_literal_wab_a, Setting.prior_wa_toReal,
-    Setting.prior_wab_toReal, ENNReal.ofReal_lt_ofReal_iff (Real.sigmoid_pos _),
-    Real.sigmoid_lt_iff, mul_lt_mul_iff_of_pos_left s.lam_pos]
-  constructor <;> intro h <;> linarith
+    s.prior.real {.wab} < (listener s .a).real {.wab} ↔
+      s.cAndNotB - s.cAndB < Real.log s.p - Real.log (1 - s.p) := by
+  rw [prior_lt_listener_iff_speaker_lt, Setting.speaker, speaker_literal_wa_a _ s.prior_ne_zero,
+    speaker_literal_wab_a _ s.prior_ne_zero, Setting.prior_real_wa, Setting.prior_real_wab,
+    s.logistic_lt_iff, sub_lt_sub_iff, add_comm (Real.log s.p)]
 
 /-- With equal costs, anti-exhaustivity is a prior biased towards the world of both. -/
-theorem prior_lt_listener_iff_of_cost_eq (hc : s.cAB = s.cAnotB) :
-    s.prior .wab < listener s .a .wab ↔ 1 / 2 < s.p := by
+theorem prior_lt_listener_iff_of_cost_eq (hc : s.cAndB = s.cAndNotB) :
+    s.prior.real {.wab} < (listener s .a).real {.wab} ↔ 1 / 2 < s.p := by
   rw [prior_lt_listener_iff, hc, sub_self, sub_pos,
     Real.log_lt_log_iff (by linarith [s.p_lt_one]) s.p_pos]
   constructor <;> intro <;> linarith
-
-/-- At the costs of the paper's first figure, a half and one, anti-exhaustivity sets in
-where the log odds of the prior exceed a half, whatever the rationality. -/
-theorem prior_lt_listener_iff_of_cost (hAB : s.cAB = 1 / 2) (hAnotB : s.cAnotB = 1) :
-    s.prior .wab < listener s .a .wab ↔ 1 / 2 < Real.log s.p - Real.log (1 - s.p) := by
-  rw [prior_lt_listener_iff, hAB, hAnotB]; norm_num
 
 end Baseline
 
@@ -604,114 +633,96 @@ section LexicalUncertainty
 
 variable (s : Setting)
 
-/-- The speaker of the grammatical lexical-uncertainty model, marginalised over the two
-equiprobable interpretations. -/
-noncomputable def luSpeaker (w : World) : PMF Message :=
-  RSA.marginalizeKernel (PMF.uniformOfFintype Interpretation)
-    (λ i w => s.speaker i.meaning w) w
+/-- The speaker marginalised over the two equiprobable interpretations (item 4 of the §4.3
+model). -/
+noncomputable def luSpeaker : Kernel World Message :=
+  Kernel.mixture (λ _ : Interpretation => 2⁻¹) λ i => s.speaker i.meaning
 
-/-- The grammatical lexical-uncertainty speaker in closed form. -/
-theorem luSpeaker_apply (w : World) (u : Message) :
-    luSpeaker s w u = 2⁻¹ * s.speaker literal w u + 2⁻¹ * s.speaker exhaustified w u := by
-  rw [luSpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_Interpretation]
-  simp [PMF.uniformOfFintype_apply, Interpretation.meaning, show Fintype.card Interpretation = 2
-    from rfl]
+instance : IsFiniteKernel (luSpeaker s) :=
+  Kernel.isFiniteKernel_mixture _ _ λ _ => ENNReal.inv_ne_top.mpr two_ne_zero
 
-/-- Every message is used somewhere, so has positive marginal likelihood. -/
-theorem luMarginal_ne_zero (u : Message) : PMF.marginal (luSpeaker s) s.prior u ≠ 0 :=
+/-- The grammatical lexical-uncertainty speaker on reals. -/
+theorem luSpeaker_real_singleton (w : World) (u : Message) :
+    (luSpeaker s w).real {u} =
+      2⁻¹ * (s.speaker literal w).real {u} + 2⁻¹ * (s.speaker exhaustified w).real {u} := by
+  rw [luSpeaker, Kernel.mixture_real _ _ (λ _ => ENNReal.inv_ne_top.mpr two_ne_zero),
+    sum_interpretation]
+  simp only [Interpretation.meaning, ENNReal.toReal_inv, ENNReal.toReal_ofNat]
+
+/-- Every message is used somewhere, so is heard with positive probability. -/
+theorem comp_luSpeaker_ne_zero (u : Message) : (luSpeaker s ∘ₘ s.prior) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
-    rw [luSpeaker_apply]
-    intro h
-    rcases mul_eq_zero.mp (add_eq_zero.mp h).1 with h | h
-    · simp at h
-    · exact speaker_ne_zero _ _ _ _ hw h)
+  comp_apply_singleton_ne_zero _ _ (s.prior_ne_zero w)
+    ((Kernel.mixture_apply_ne_zero_iff _ _ _ _).mpr
+      ⟨.lit, by simp, speaker_ne_zero _ s.prior_ne_zero _ s hw⟩)
 
-/-- item 4 of the §4.3 model: the pragmatic listener of the grammatical lexical-uncertainty
-model. -/
-noncomputable def luListener (u : Message) : PMF World :=
-  RSA.L1 (luSpeaker s) s.prior u (luMarginal_ne_zero s u)
+/-- The Bayesian inverse of the marginalised speaker (item 4 of the §4.3 model). -/
+noncomputable def luListener : Kernel Message World := (luSpeaker s)†s.prior
 
 /-- Grammatical lexical uncertainty blocks anti-exhaustivity whenever *A and B* costs no more
 than *A and not B*: the exhaustified interpretation never uses *A* in the world of both but
 uses it in the world of A alone more than the literal interpretation uses it in the world of
 both. -/
-theorem luListener_lt_prior (hc : s.cAB ≤ s.cAnotB) : luListener s .a .wab < s.prior .wab := by
-  rw [luListener, RSA.L1, PMF.posterior_lt_iff_lt_marginal _ _ _ _ (s.prior_ne_zero _)]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum, sum_World,
-    lt_two_world s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), luSpeaker_apply,
-    luSpeaker_apply]
-  dsimp only [Setting.speaker]
-  rw [speaker_literal_wab_a, speaker_exhaustified_wab_a, speaker_literal_wa_a,
-    speaker_exhaustified_wa_a, mul_zero, add_zero, ← mul_add,
-    ENNReal.mul_lt_mul_iff_right (by simp) (by simp), Setting.prior_wab_toReal,
-    Setting.prior_wa_toReal, ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
-    ENNReal.ofReal_lt_ofReal_iff (add_pos (Real.sigmoid_pos _) (Real.sigmoid_pos _))]
-  calc Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) < Real.sigmoid (s.lam * s.cAnotB) :=
-        Real.sigmoid_lt (mul_lt_mul_of_pos_left
-          (by linarith [Real.log_neg s.p_pos s.p_lt_one]) s.lam_pos)
-    _ ≤ _ := le_add_of_nonneg_left (Real.sigmoid_nonneg _)
+theorem luListener_lt_prior (hc : s.cAndB ≤ s.cAndNotB) :
+    (luListener s .a).real {.wab} < s.prior.real {.wab} := by
+  rw [luListener, posterior_real_singleton_lt_iff_of_pair _ _ (by decide) s.prior_support
+      (comp_luSpeaker_ne_zero s _) (s.prior_ne_zero _) (s.prior_ne_zero _),
+    luSpeaker_real_singleton, luSpeaker_real_singleton, speaker_exhaustified_wab_a,
+    speaker_exhaustified_wa_a, Setting.speaker, speaker_literal_wab_a _ s.prior_ne_zero,
+    speaker_literal_wa_a _ s.prior_ne_zero, Setting.prior_real_wab, Setting.prior_real_wa]
+  have h₁ := s.logistic_lt (show s.cAndB + Real.log s.p < s.cAndNotB by
+    linarith [Real.log_neg s.p_pos s.p_lt_one])
+  have h₂ := s.logistic_nonneg (s.cAndNotB + Real.log (1 - s.p))
+  linarith
 
 /-- The speaker of the free lexical-uncertainty model, marginalised over the three
 equiprobable interpretations. -/
-noncomputable def freeSpeaker (w : World) : PMF Message :=
-  RSA.marginalizeKernel (PMF.uniformOfFintype FreeInterpretation)
-    (λ i w => s.speaker i.meaning w) w
+noncomputable def freeSpeaker : Kernel World Message :=
+  Kernel.mixture (λ _ : FreeInterpretation => 3⁻¹) λ i => s.speaker i.meaning
 
-/-- The free lexical-uncertainty speaker in closed form. -/
-theorem freeSpeaker_apply (w : World) (u : Message) :
-    freeSpeaker s w u =
-      3⁻¹ * s.speaker literal w u + 3⁻¹ * s.speaker exhaustified w u +
-        3⁻¹ * s.speaker antiExhaustive w u := by
-  rw [freeSpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_FreeInterpretation]
-  simp [PMF.uniformOfFintype_apply, FreeInterpretation.meaning,
-    show Fintype.card FreeInterpretation = 3 from rfl]
+instance : IsFiniteKernel (freeSpeaker s) :=
+  Kernel.isFiniteKernel_mixture _ _ λ _ => ENNReal.inv_ne_top.mpr three_ne_zero
 
-/-- Every message is used somewhere, so has positive marginal likelihood. -/
-theorem freeMarginal_ne_zero (u : Message) : PMF.marginal (freeSpeaker s) s.prior u ≠ 0 :=
+/-- The free lexical-uncertainty speaker on reals. -/
+theorem freeSpeaker_real_singleton (w : World) (u : Message) :
+    (freeSpeaker s w).real {u} =
+      3⁻¹ * (s.speaker literal w).real {u} + 3⁻¹ * (s.speaker exhaustified w).real {u} +
+        3⁻¹ * (s.speaker antiExhaustive w).real {u} := by
+  rw [freeSpeaker, Kernel.mixture_real _ _ (λ _ => ENNReal.inv_ne_top.mpr three_ne_zero),
+    sum_freeInterpretation]
+  simp only [FreeInterpretation.meaning, ENNReal.toReal_inv, ENNReal.toReal_ofNat]
+
+/-- Every message is used somewhere, so is heard with positive probability. -/
+theorem comp_freeSpeaker_ne_zero (u : Message) : (freeSpeaker s ∘ₘ s.prior) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
-    rw [freeSpeaker_apply]
-    intro h
-    rcases mul_eq_zero.mp (add_eq_zero.mp (add_eq_zero.mp h).1).1 with h | h
-    · simp at h
-    · exact speaker_ne_zero _ _ _ _ hw h)
+  comp_apply_singleton_ne_zero _ _ (s.prior_ne_zero w)
+    ((Kernel.mixture_apply_ne_zero_iff _ _ _ _).mpr
+      ⟨.lit, by simp, speaker_ne_zero _ s.prior_ne_zero _ s hw⟩)
 
 /-- The pragmatic listener of the free lexical-uncertainty model. -/
-noncomputable def freeListener (u : Message) : PMF World :=
-  RSA.L1 (freeSpeaker s) s.prior u (freeMarginal_ne_zero s u)
+noncomputable def freeListener : Kernel Message World := (freeSpeaker s)†s.prior
 
 /-- Free lexical uncertainty is anti-exhaustive exactly when the literal and anti-exhaustive
 uses of *A* in the world of both outweigh the literal and exhaustified uses in the world of A
 alone. -/
 theorem prior_lt_freeListener_iff :
-    s.prior .wab < freeListener s .a .wab ↔
-      Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p))) +
-          Real.sigmoid (s.lam * s.cAnotB) <
-        Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) + Real.sigmoid (s.lam * s.cAB) := by
-  rw [freeListener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum, sum_World,
-    two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), freeSpeaker_apply,
-    freeSpeaker_apply]
-  dsimp only [Setting.speaker]
-  rw [speaker_literal_wab_a, speaker_exhaustified_wab_a, speaker_antiExhaustive_wab_a,
-    speaker_literal_wa_a, speaker_exhaustified_wa_a, speaker_antiExhaustive_wa_a]
-  simp only [mul_zero, add_zero]
-  rw [← mul_add, ← mul_add, ENNReal.mul_lt_mul_iff_right (by simp) (by simp),
-    Setting.prior_wab_toReal, Setting.prior_wa_toReal,
-    ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
-    ← ENNReal.ofReal_add (Real.sigmoid_nonneg _) (Real.sigmoid_nonneg _),
-    ENNReal.ofReal_lt_ofReal_iff (add_pos (Real.sigmoid_pos _) (Real.sigmoid_pos _))]
+    s.prior.real {.wab} < (freeListener s .a).real {.wab} ↔
+      s.logistic (s.cAndNotB + Real.log (1 - s.p)) + s.logistic s.cAndNotB <
+        s.logistic (s.cAndB + Real.log s.p) + s.logistic s.cAndB := by
+  rw [freeListener, real_lt_posterior_real_singleton_iff_of_pair _ _ (by decide) s.prior_support
+      (comp_freeSpeaker_ne_zero s _) (s.prior_ne_zero _) (s.prior_ne_zero _),
+    freeSpeaker_real_singleton, freeSpeaker_real_singleton, speaker_exhaustified_wab_a,
+    speaker_exhaustified_wa_a, speaker_antiExhaustive_wab_a, speaker_antiExhaustive_wa_a,
+    Setting.speaker, speaker_literal_wab_a _ s.prior_ne_zero,
+    speaker_literal_wa_a _ s.prior_ne_zero, Setting.prior_real_wab, Setting.prior_real_wa]
+  constructor <;> intro h <;> linarith
 
 /-- With equal costs, free lexical uncertainty is anti-exhaustive exactly when the baseline
 is: for a prior biased towards the world of both. -/
-theorem prior_lt_freeListener_iff_of_cost_eq (hc : s.cAB = s.cAnotB) :
-    s.prior .wab < freeListener s .a .wab ↔ 1 / 2 < s.p := by
-  rw [prior_lt_freeListener_iff, hc, add_lt_add_iff_right, Real.sigmoid_lt_iff,
-    mul_lt_mul_iff_of_pos_left s.lam_pos, add_lt_add_iff_left,
-    Real.log_lt_log_iff (by linarith [s.p_lt_one]) s.p_pos]
+theorem prior_lt_freeListener_iff_of_cost_eq (hc : s.cAndB = s.cAndNotB) :
+    s.prior.real {.wab} < (freeListener s .a).real {.wab} ↔ 1 / 2 < s.p := by
+  rw [prior_lt_freeListener_iff, hc, add_lt_add_iff_right, s.logistic_lt_iff,
+    add_lt_add_iff_left, Real.log_lt_log_iff (by linarith [s.p_lt_one]) s.p_pos]
   constructor <;> intro <;> linarith
 
 end LexicalUncertainty
@@ -722,118 +733,110 @@ section LexicalIntentions
 
 variable (s : Setting)
 
-/-- item 2 of the §4.4 model: the utility of a message together with the interpretation the
-literal listener will give it. -/
-noncomputable def liUtility (w : World) (x : Message × Interpretation) : EReal :=
-  rsaUtility (λ w x => s.L0 x.2.meaning x.1 w) (λ x => s.cost x.1) s.lam w x
+/-- The literal listener of a message under a chosen interpretation (item 1 of the §4.4
+model). -/
+noncomputable def liL0 : Kernel (Message × Interpretation) World :=
+  RSA.literalListener s.prior λ x => (x.2.meaning.extension x.1).indicator 1
 
-instance : ViableSpeaker (liUtility s) :=
-  viableSpeaker_rsaUtility _ _ s.lam_pos (λ _ _ => PMF.apply_ne_top _ _) λ w =>
-    ⟨(.a, .lit), L0_ne_zero _ _ _ (by cases w <;> rfl)⟩
+theorem liL0_apply (x : Message × Interpretation) : liL0 s x = s.L0 x.2.meaning x.1 := rfl
 
-/-- item 3 of the §4.4 model: the joint speaker over messages and interpretations. -/
-noncomputable def liSpeaker (w : World) : PMF (Message × Interpretation) := S1 (liUtility s) w
+/-- The speaker over messages and interpretations (item 3 of the §4.4 model). -/
+noncomputable def liSpeaker : Kernel World (Message × Interpretation) :=
+  RSA.speaker s.lam (λ x => s.costFactor x.1) (liL0 s)
 
-/-- item 5 of the §4.4 model: the speaker's messages, the interpretations marginalised. -/
-noncomputable def liMessageSpeaker (w : World) : PMF Message := (liSpeaker s w).map Prod.fst
+instance : IsFiniteKernel (liSpeaker s) := inferInstanceAs (IsFiniteKernel (RSA.speaker _ _ _))
+
+/-- The speaker's messages, the interpretations marginalised (item 5 of the §4.4 model). -/
+noncomputable def liMessageSpeaker : Kernel World Message := (liSpeaker s).map Prod.fst
+
+instance : IsFiniteKernel (liMessageSpeaker s) :=
+  inferInstanceAs (IsFiniteKernel (Kernel.map _ _))
 
 /-- The lexical-intentions speaker's use of a message sums its two interpretations. -/
-theorem liMessageSpeaker_apply (w : World) (u : Message) :
-    liMessageSpeaker s w u = liSpeaker s w (u, .lit) + liSpeaker s w (u, .exh) := by
-  rw [liMessageSpeaker, PMF.map_apply, tsum_fintype, Fintype.sum_prod_type, sum_Message]
-  cases u <;> simp [sum_Interpretation]
+theorem liMessageSpeaker_apply_singleton (w : World) (u : Message) :
+    liMessageSpeaker s w {u} = liSpeaker s w {(u, .lit)} + liSpeaker s w {(u, .exh)} := by
+  rw [liMessageSpeaker, Kernel.map_apply _ measurable_fst]
+  exact (Measure.fst_apply_singleton (liSpeaker s w) u).trans (sum_interpretation _)
 
-/-- The joint speaker in closed form. -/
-theorem liSpeaker_apply (w : World) (x : Message × Interpretation) :
-    liSpeaker s w x =
-      PMF.softmaxWeight (liUtility s w) x / ∑ y, PMF.softmaxWeight (liUtility s w) y :=
-  PMF.softmax_apply _ (ViableSpeaker.no_top w) (ViableSpeaker.some_finite w) x
+/-- The lexical-intentions speaker's use of a message, on reals. -/
+theorem liMessageSpeaker_real_singleton (w : World) (u : Message) :
+    (liMessageSpeaker s w).real {u} =
+      (liSpeaker s w).real {(u, .lit)} + (liSpeaker s w).real {(u, .exh)} := by
+  rw [liMessageSpeaker, Kernel.map_apply _ measurable_fst]
+  exact (Measure.fst_real_singleton_eq_sum (liSpeaker s w) u).trans (sum_interpretation _)
 
-/-- The lexical-intentions utility is `⊥` at a message false at the world under its
-interpretation and otherwise real. -/
-theorem liUtility_eq (w : World) (x : Message × Interpretation) :
-    liUtility s w x =
-      if s.L0 x.2.meaning x.1 w = 0 then ⊥
-      else ((s.lam * (Real.log (s.L0 x.2.meaning x.1 w).toReal - s.cost x.1) : ℝ) : EReal) :=
-  rsaUtility_eq _ _ s.lam_pos (PMF.apply_ne_top _ _)
-
-/-- The softmax weight of a message under an interpretation. -/
-theorem softmaxWeight_liUtility (w : World) (x : Message × Interpretation) :
-    PMF.softmaxWeight (liUtility s w) x =
-      if s.L0 x.2.meaning x.1 w = 0 then 0
-      else ENNReal.ofReal (Real.exp
-        (s.lam * (Real.log (s.L0 x.2.meaning x.1 w).toReal - s.cost x.1))) :=
-  softmaxWeight_rsaUtility _ _ s.lam_pos (PMF.apply_ne_top _ _)
+/-- The weight of a message under an interpretation is finite. -/
+theorem liWeight_ne_top (w : World) (x : Message × Interpretation) :
+    liL0 s x {w} ^ s.lam * s.costFactor x.1 ≠ ∞ :=
+  weight_ne_top s.prior x.2.meaning s x.1 w
 
 /-- In the world of both, the lexical-intentions speaker uses *A*, under its literal
 interpretation only, against the two interpretations of *A and B*. -/
-theorem liMessageSpeaker_wab_a :
-    liMessageSpeaker s .wab .a =
-      ENNReal.ofReal (Real.exp (s.lam * Real.log s.p) /
-        (Real.exp (s.lam * Real.log s.p) + 2 * Real.exp (-(s.lam * s.cAB)))) := by
-  rw [liMessageSpeaker_apply, liSpeaker_apply, liSpeaker_apply, Fintype.sum_prod_type,
-    sum_Message]
-  simp only [sum_Interpretation, softmaxWeight_liUtility, Interpretation.meaning, Setting.L0,
-    L0_literal_a, L0_exhaustified_a_wab, L0_literal_aAndB_wab, L0_exhaustified_aAndB_wab,
-    L0_literal_aAndNotB_wab, L0_exhaustified_aAndNotB_wab, s.prior_ne_zero, one_ne_zero,
-    ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost,
-    Setting.prior_wab_toReal, sub_zero, zero_sub, mul_neg]
-  rw [ENNReal.div_add_div_same, ← ENNReal.ofReal_add (Real.exp_pos _).le (Real.exp_pos _).le,
-    ← two_mul, add_zero, ← ENNReal.ofReal_add (Real.exp_pos _).le (by positivity),
-    ← ENNReal.ofReal_div_of_pos (by positivity)]
+theorem liMessageSpeaker_real_wab_a :
+    (liMessageSpeaker s .wab).real {.a} =
+      Real.exp (s.lam * Real.log s.p) /
+        (Real.exp (s.lam * Real.log s.p) + 2 * Real.exp (-(s.lam * s.cAndB))) := by
+  rw [liMessageSpeaker_real_singleton, liSpeaker, RSA.speaker,
+    Kernel.ofWeights_real_singleton _ _ (liWeight_ne_top s .wab),
+    Kernel.ofWeights_real_singleton _ _ (liWeight_ne_top s .wab), Fintype.sum_prod_type,
+    sum_message]
+  simp (disch := decide) only [sum_interpretation, liL0_apply, Interpretation.meaning, Setting.L0,
+    weight_toReal s.prior s.prior_ne_zero, weight_eq_zero s.prior, ENNReal.toReal_zero]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one s.prior s.prior_ne_zero, ← measureReal_def,
+    Setting.prior_real_wab, ENNReal.toReal_one, Real.log_one, Setting.cost, sub_zero, zero_sub,
+    mul_neg, add_zero]
+  ring
 
 /-- In the world of A alone, the lexical-intentions speaker uses *A* under both
 interpretations, the exhaustified one as informative as *A and not B*. -/
-theorem liMessageSpeaker_wa_a :
-    liMessageSpeaker s .wa .a =
-      ENNReal.ofReal ((Real.exp (s.lam * Real.log (1 - s.p)) + 1) /
-        (Real.exp (s.lam * Real.log (1 - s.p)) + 1 + 2 * Real.exp (-(s.lam * s.cAnotB)))) := by
-  rw [liMessageSpeaker_apply, liSpeaker_apply, liSpeaker_apply, Fintype.sum_prod_type,
-    sum_Message]
-  simp only [sum_Interpretation, softmaxWeight_liUtility, Interpretation.meaning, Setting.L0,
-    L0_literal_a, L0_exhaustified_a_wa, L0_literal_aAndB_wa, L0_exhaustified_aAndB_wa,
-    L0_literal_aAndNotB_wa, L0_exhaustified_aAndNotB_wa, s.prior_ne_zero, one_ne_zero,
-    ↓reduceIte, add_zero, ENNReal.toReal_one, Real.log_one, Setting.cost,
-    Setting.prior_wa_toReal, sub_zero, zero_sub, mul_neg, mul_zero, Real.exp_zero,
-    ENNReal.ofReal_one]
-  rw [ENNReal.div_add_div_same, ← ENNReal.ofReal_one,
-    ← ENNReal.ofReal_add (Real.exp_pos _).le zero_le_one,
-    ← ENNReal.ofReal_add (Real.exp_pos _).le (Real.exp_pos _).le, ← two_mul,
-    ← ENNReal.ofReal_add (by positivity) (by positivity),
-    ← ENNReal.ofReal_div_of_pos (by positivity)]
+theorem liMessageSpeaker_real_wa_a :
+    (liMessageSpeaker s .wa).real {.a} =
+      (Real.exp (s.lam * Real.log (1 - s.p)) + 1) /
+        (Real.exp (s.lam * Real.log (1 - s.p)) + 1 + 2 * Real.exp (-(s.lam * s.cAndNotB))) := by
+  rw [liMessageSpeaker_real_singleton, liSpeaker, RSA.speaker,
+    Kernel.ofWeights_real_singleton _ _ (liWeight_ne_top s .wa),
+    Kernel.ofWeights_real_singleton _ _ (liWeight_ne_top s .wa), Fintype.sum_prod_type,
+    sum_message]
+  simp (disch := decide) only [sum_interpretation, liL0_apply, Interpretation.meaning, Setting.L0,
+    weight_toReal s.prior s.prior_ne_zero, weight_eq_zero s.prior, ENNReal.toReal_zero]
+  simp (disch := decide) only [L0_literal_a, L0_eq_one s.prior s.prior_ne_zero, ← measureReal_def,
+    Setting.prior_real_wa, ENNReal.toReal_one, Real.log_one, Setting.cost, sub_zero, zero_sub,
+    mul_neg, mul_zero, Real.exp_zero, add_zero]
+  ring
 
-/-- Every message is used somewhere, so has positive marginal likelihood. -/
-theorem liMarginal_ne_zero (u : Message) : PMF.marginal (liMessageSpeaker s) s.prior u ≠ 0 :=
+/-- A message true at a world is used there under its literal interpretation. -/
+theorem liSpeaker_ne_zero {w : World} {u : Message} (hw : literal.sat u w = true) :
+    liSpeaker s w {(u, .lit)} ≠ 0 :=
+  Kernel.ofWeights_apply_singleton_ne_zero (weight_ne_zero s.prior s.prior_ne_zero literal s hw)
+    (liWeight_ne_top s w)
+
+/-- Every message is used somewhere, so is heard with positive probability. -/
+theorem comp_liMessageSpeaker_ne_zero (u : Message) :
+    (liMessageSpeaker s ∘ₘ s.prior) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
-    rw [liMessageSpeaker_apply]
-    intro h
-    exact S1_ne_zero (liUtility s) (u := (u, .lit)) (by
-      rw [liUtility_eq, if_neg]
-      · exact EReal.coe_ne_bot _
-      · exact L0_ne_zero _ _ _ hw) (add_eq_zero.mp h).1)
+  comp_apply_singleton_ne_zero _ _ (s.prior_ne_zero w) (by
+    rw [liMessageSpeaker_apply_singleton]
+    exact ne_of_gt (lt_of_lt_of_le (pos_iff_ne_zero.mpr (liSpeaker_ne_zero s hw)) le_self_add))
 
-/-- item 6 of the §4.4 model: the pragmatic listener of the lexical-intentions model. -/
-noncomputable def liListener (u : Message) : PMF World :=
-  RSA.L1 (liMessageSpeaker s) s.prior u (liMarginal_ne_zero s u)
+/-- The pragmatic listener of the lexical-intentions model (item 6 of the §4.4 model). -/
+noncomputable def liListener : Kernel Message World := (liMessageSpeaker s)†s.prior
 
 /-- The lexical-intentions model blocks anti-exhaustivity whenever *A and B* costs no more
 than *A and not B*: *A* is never likelier in the world of both than in the world of A
 alone. -/
-theorem liListener_lt_prior (hc : s.cAB ≤ s.cAnotB) : liListener s .a .wab < s.prior .wab := by
-  rw [liListener, RSA.L1, PMF.posterior_lt_iff_lt_marginal _ _ _ _ (s.prior_ne_zero _)]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum, sum_World,
-    lt_two_world s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _), liMessageSpeaker_wab_a,
-    liMessageSpeaker_wa_a, ENNReal.ofReal_lt_ofReal_iff (by positivity),
+theorem liListener_lt_prior (hc : s.cAndB ≤ s.cAndNotB) :
+    (liListener s .a).real {.wab} < s.prior.real {.wab} := by
+  rw [liListener, posterior_real_singleton_lt_iff_of_pair _ _ (by decide) s.prior_support
+      (comp_liMessageSpeaker_ne_zero s _) (s.prior_ne_zero _) (s.prior_ne_zero _),
+    liMessageSpeaker_real_wab_a, liMessageSpeaker_real_wa_a,
     div_lt_div_iff₀ (by positivity) (by positivity)]
   have h₁ : Real.exp (s.lam * Real.log s.p) < 1 :=
     Real.exp_lt_one_iff.mpr (mul_neg_of_pos_of_neg s.lam_pos (Real.log_neg s.p_pos s.p_lt_one))
-  have h₂ : Real.exp (-(s.lam * s.cAnotB)) ≤ Real.exp (-(s.lam * s.cAB)) :=
+  have h₂ : Real.exp (-(s.lam * s.cAndNotB)) ≤ Real.exp (-(s.lam * s.cAndB)) :=
     Real.exp_le_exp.mpr (by nlinarith [s.lam_pos])
-  have h₃ := Real.exp_pos (-(s.lam * s.cAnotB))
+  have h₃ := Real.exp_pos (-(s.lam * s.cAndNotB))
   have h₄ := Real.exp_pos (s.lam * Real.log (1 - s.p))
-  nlinarith [mul_lt_mul_of_pos_right h₁ h₃, mul_pos h₄ (Real.exp_pos (-(s.lam * s.cAB)))]
+  nlinarith [mul_lt_mul_of_pos_right h₁ h₃, mul_pos h₄ (Real.exp_pos (-(s.lam * s.cAndB)))]
 
 end LexicalIntentions
 
@@ -843,173 +846,150 @@ section Supervaluationist
 
 variable (s : Setting)
 
-/-- The cells of a question: the coarse question does not distinguish the worlds, the fine
-one does. -/
-def QUD.project : QUD → World → Option World
-  | .coarse, _ => none
-  | .fine, w => some w
+/-- The cell of a world in a question: the coarse question does not distinguish the worlds,
+the fine one does. -/
+def QUD.cell : QUD → World → Set World
+  | .coarse, _ => Set.univ
+  | .fine, w => {w}
 
-/-- item 3 of the §4.2 model, conditioned on the question: the literal listener's mass,
-under an interpretation, on the cell of a world in a question. -/
+/-- The literal listener's mass, under an interpretation, on the cell of a world in a question
+(item 3 of the §4.2 model, conditioned on the question). -/
 noncomputable def cell (i : Interpretation) (q : QUD) (u : Message) (w : World) : ℝ≥0∞ :=
-  RSA.QUD.proj QUD.project (s.L0 i.meaning u) q w
-
-/-- The fine question's cells are the worlds. -/
-theorem cell_fine (i : Interpretation) (u : Message) (w : World) :
-    cell s i .fine u w = s.L0 i.meaning u w := by
-  simp [cell, RSA.QUD.proj, QUD.project, Finset.filter_eq']
+  s.L0 i.meaning u (q.cell w)
 
 /-- The coarse question has one cell, which carries all the mass. -/
 theorem cell_coarse (i : Interpretation) (u : Message) (w : World) :
-    cell s i .coarse u w = 1 := by
-  simp only [cell, RSA.QUD.proj, QUD.project, Finset.filter_true_of_mem (λ _ _ => trivial)]
-  exact (tsum_fintype _).symm.trans (PMF.tsum_coe _)
+    cell s i .coarse u w = 1 :=
+  L0_apply_univ s.prior s.prior_ne_zero _ u
 
-/-- A cell's mass is finite. -/
-theorem cell_ne_top (i : Interpretation) (q : QUD) (u : Message) (w : World) :
-    cell s i q u w ≠ ⊤ :=
-  RSA.QUD.proj_ne_top_of_pmf _ _ _ _
+/-- The fine question's cells are the worlds. -/
+theorem cell_fine (i : Interpretation) (u : Message) (w : World) :
+    cell s i .fine u w = s.L0 i.meaning u {w} := rfl
 
-/-- item 4 of the §4.2 model: the supervaluationist utility, the expected log probability of
-the cell over the two interpretations, taken equiprobable, less the cost; the prior of the
-question, common to every message, is left out. -/
-noncomputable def svUtility (x : World × QUD) (u : Message) : EReal :=
-  (s.lam : EReal) *
-    (((1 / 2 : ℝ) : EReal) * ENNReal.log (cell s .lit x.2 u x.1) +
-      ((1 / 2 : ℝ) : EReal) * ENNReal.log (cell s .exh x.2 u x.1) - (s.cost u : EReal))
+/-- A cell's mass is at most one. -/
+theorem cell_le_one (i : Interpretation) (q : QUD) (u : Message) (w : World) :
+    cell s i q u w ≤ 1 :=
+  RSA.literalListener_apply_le_one _ _ _ _
 
-/-- The supervaluationist utility is `⊥` when the message is false on the cell under some
-interpretation, and otherwise real. -/
-theorem svUtility_eq (x : World × QUD) (u : Message) :
-    svUtility s x u =
-      if cell s .lit x.2 u x.1 = 0 ∨ cell s .exh x.2 u x.1 = 0 then ⊥
-      else ((s.lam * (1 / 2 * Real.log (cell s .lit x.2 u x.1).toReal +
-        1 / 2 * Real.log (cell s .exh x.2 u x.1).toReal - s.cost u) : ℝ) : EReal) := by
-  unfold svUtility
-  split_ifs with h
-  · rcases h with h | h
-    · rw [h, ENNReal.log_zero, EReal.mul_bot_of_pos (by norm_num), EReal.bot_add, EReal.bot_sub,
-        EReal.mul_bot_of_pos (by exact_mod_cast s.lam_pos)]
-    · rw [h, ENNReal.log_zero, EReal.mul_bot_of_pos (by norm_num), EReal.add_bot, EReal.bot_sub,
-        EReal.mul_bot_of_pos (by exact_mod_cast s.lam_pos)]
-  · push Not at h
-    rw [ENNReal.log_pos_real h.1 (cell_ne_top _ _ _ _ _),
-      ENNReal.log_pos_real h.2 (cell_ne_top _ _ _ _ _)]
-    norm_cast
+/-- The supervaluationist weight: the geometric mean over the two interpretations, taken
+equiprobable, of the literal listener's mass on the cell, raised to the rationality, times the
+cost factor; the prior of the question, common to every message, is left out (item 4 of the
+§4.2 model). -/
+noncomputable def svWeight (x : World × QUD) (u : Message) : ℝ≥0∞ :=
+  cell s .lit x.2 u x.1 ^ (s.lam / 2) * cell s .exh x.2 u x.1 ^ (s.lam / 2) * s.costFactor u
 
-/-- Under the fine question a message true at a world under both interpretations has finite
-utility there. -/
-theorem svUtility_fine_ne_bot {w : World} {u : Message} (hl : truth u w = true)
-    (he : exh u w = true) : svUtility s (w, .fine) u ≠ ⊥ := by
-  rw [svUtility_eq, if_neg (by
-    simp only [cell_fine, Interpretation.meaning, Setting.L0, not_or]
-    exact ⟨L0_ne_zero _ _ _ hl, L0_ne_zero _ _ _ he⟩)]
-  exact EReal.coe_ne_bot _
+theorem svWeight_ne_top (x : World × QUD) (u : Message) : svWeight s x u ≠ ∞ :=
+  ENNReal.mul_ne_top
+    (ENNReal.mul_ne_top (RSA.weight_rpow_ne_top (half_pos s.lam_pos).le (cell_le_one s _ _ _ _))
+      (RSA.weight_rpow_ne_top (half_pos s.lam_pos).le (cell_le_one s _ _ _ _)))
+    (s.costFactor_ne_top u)
 
-instance : ViableSpeaker (svUtility s) where
-  no_top x u := by
-    rw [svUtility_eq]
-    split_ifs
-    · exact bot_ne_top
-    · exact EReal.coe_ne_top _
-  some_finite x := by
-    obtain ⟨w, q⟩ := x
-    cases q
-    · exact ⟨.a, by
-        rw [svUtility_eq, if_neg (by simp [cell_coarse])]
-        exact EReal.coe_ne_bot _⟩
-    · cases w
-      · exact ⟨.a, svUtility_fine_ne_bot s rfl (by decide)⟩
-      · exact ⟨.aAndB, svUtility_fine_ne_bot s rfl (by decide)⟩
+/-- Under the fine question a message true at a world under both interpretations has positive
+weight there. -/
+theorem svWeight_fine_ne_zero {w : World} {u : Message} (hl : truth u w = true)
+    (he : exh u w = true) : svWeight s (w, .fine) u ≠ 0 :=
+  mul_ne_zero
+    (mul_ne_zero
+      (RSA.weight_rpow_ne_zero (half_pos s.lam_pos).le
+        (L0_ne_zero s.prior s.prior_ne_zero literal hl))
+      (RSA.weight_rpow_ne_zero (half_pos s.lam_pos).le
+        (L0_ne_zero s.prior s.prior_ne_zero exhaustified he)))
+    (s.costFactor_ne_zero u)
 
-/-- item 5 of the §4.2 model: the supervaluationist speaker, at a world and a question. -/
-noncomputable def svSpeaker (x : World × QUD) : PMF Message := S1 (svUtility s) x
+/-- The supervaluationist speaker, at a world and a question (item 5 of the §4.2 model). -/
+noncomputable def svSpeaker : Kernel (World × QUD) Message := Kernel.ofWeights (svWeight s)
+
+instance : IsFiniteKernel (svSpeaker s) := inferInstanceAs (IsFiniteKernel (Kernel.ofWeights _))
 
 /-- Under the coarse question every message is true on the one cell, so the speaker does not
 depend on the world. -/
 theorem svSpeaker_coarse : svSpeaker s (.wa, .coarse) = svSpeaker s (.wab, .coarse) := by
-  have h : svUtility s (.wa, .coarse) = svUtility s (.wab, .coarse) := by
-    funext u; simp only [svUtility, cell_coarse]
-  exact PMF.ext λ u => by
-    rw [svSpeaker, svSpeaker, S1, S1, PMF.softmax_apply, PMF.softmax_apply, h]
+  have h : svWeight s (.wa, .coarse) = svWeight s (.wab, .coarse) :=
+    funext λ u => by simp only [svWeight, cell_coarse]
+  simp only [svSpeaker, Kernel.ofWeights, Kernel.ofFunOfCountable_apply, h]
 
-/-- Under the fine question the exhaustified *A* is false in the world of both, so its
-expected utility there is `⊥` and the speaker never uses it. -/
-theorem svSpeaker_wab_fine_a : svSpeaker s (.wab, .fine) .a = 0 := by
-  have h : svUtility s (.wab, .fine) .a = ⊥ := by
-    rw [svUtility_eq, if_pos (Or.inr (by
-      simp [cell_fine, Interpretation.meaning, L0_exhaustified_a_wab]))]
-  rw [svSpeaker, S1, PMF.softmax_apply, PMF.softmaxWeight_apply, h, EReal.exp_bot,
-    ENNReal.zero_div]
+/-- Under the fine question the exhaustified *A* is false in the world of both, so the
+speaker never uses it. -/
+theorem svSpeaker_wab_fine_a : svSpeaker s (.wab, .fine) {.a} = 0 :=
+  Kernel.ofWeights_apply_singleton_eq_zero (by
+    simp (disch := decide) only [svWeight, cell_fine, Setting.L0, Interpretation.meaning,
+      L0_eq_zero, ENNReal.zero_rpow_of_pos (half_pos s.lam_pos), mul_zero, zero_mul])
 
-/-- Under the fine question *A* is used in the world of A alone. -/
-theorem svSpeaker_wa_fine_a_ne_zero : svSpeaker s (.wa, .fine) .a ≠ 0 :=
-  S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide))
+theorem svSpeaker_real_wab_fine_a : (svSpeaker s (.wab, .fine)).real {.a} = 0 :=
+  (measureReal_eq_zero_iff (measure_ne_top _ _)).mpr (svSpeaker_wab_fine_a s)
 
-/-- Appendix A.3, the speaker: under either question, *A* is used no more in the world of
-both than in the world of A alone. -/
-theorem svSpeaker_wab_le_wa (q : QUD) : svSpeaker s (.wab, q) .a ≤ svSpeaker s (.wa, q) .a := by
+/-- Under the fine question a message true at a world under both interpretations is used
+there. -/
+theorem svSpeaker_fine_ne_zero {w : World} {u : Message} (hl : truth u w = true)
+    (he : exh u w = true) : svSpeaker s (w, .fine) {u} ≠ 0 :=
+  Kernel.ofWeights_apply_singleton_ne_zero (svWeight_fine_ne_zero s hl he) (svWeight_ne_top s _)
+
+/-- Under either question, *A* is used no more in the world of both than in the world of A
+alone (Appendix A.3, the speaker). -/
+theorem svSpeaker_wab_le_wa (q : QUD) : svSpeaker s (.wab, q) {.a} ≤ svSpeaker s (.wa, q) {.a} := by
   cases q
   · rw [svSpeaker_coarse]
   · rw [svSpeaker_wab_fine_a]; exact zero_le
 
-variable (Q : PMF QUD) (hQ : Q .fine ≠ 0)
+variable (Q : Measure QUD) [IsProbabilityMeasure Q] (hQ : Q {.fine} ≠ 0)
 
 /-- The joint prior over worlds and questions, independent. -/
-noncomputable def svJoint : PMF (World × QUD) := RSA.jointPrior Q (λ _ => s.prior)
+noncomputable def svJoint : Measure (World × QUD) := s.prior.prod Q
 
-/-- The joint prior factors. -/
-theorem svJoint_apply (w : World) (q : QUD) : svJoint s Q (w, q) = Q q * s.prior w :=
-  RSA.jointPrior_apply _ _ _ _
+instance : IsProbabilityMeasure (svJoint s Q) :=
+  inferInstanceAs (IsProbabilityMeasure (Measure.prod _ _))
 
-/-- The world marginal of the joint prior is the measured prior. -/
-theorem svJoint_fst (w : World) : (svJoint s Q).fst w = s.prior w := by
-  rw [PMF.fst_apply, sum_QUD, svJoint_apply, svJoint_apply, ← add_mul, ← sum_QUD,
-    (tsum_fintype _).symm.trans (PMF.tsum_coe Q), one_mul]
+omit [IsProbabilityMeasure Q] in
+theorem svJoint_apply_singleton (w : World) (q : QUD) :
+    svJoint s Q {(w, q)} = s.prior {w} * Q {q} := by
+  show (s.prior.prod Q) {(w, q)} = _
+  rw [← Set.singleton_prod_singleton, Measure.prod_prod]
+
+omit [IsProbabilityMeasure Q] in
+theorem svJoint_real_singleton (w : World) (q : QUD) :
+    (svJoint s Q).real {(w, q)} = s.prior.real {w} * Q.real {q} :=
+  Measure.prod_real_singleton _ _ _ _
+
+/-- Every message is true somewhere under both grammatical interpretations. -/
+theorem exists_truth_and_exh (u : Message) : ∃ w, truth u w = true ∧ exh u w = true := by
+  cases u
+  · exact ⟨.wa, rfl, by decide⟩
+  · exact ⟨.wab, rfl, by decide⟩
+  · exact ⟨.wa, rfl, by decide⟩
+
+omit [IsProbabilityMeasure Q] in
+include hQ in
+/-- Every message is used somewhere under the fine question, so is heard with positive
+probability. -/
+theorem comp_svSpeaker_ne_zero (u : Message) : (svSpeaker s ∘ₘ svJoint s Q) {u} ≠ 0 :=
+  let ⟨w, hw⟩ := exists_truth_and_exh u
+  have hj : svJoint s Q {(w, .fine)} ≠ 0 := by
+    rw [svJoint_apply_singleton]; exact mul_ne_zero (s.prior_ne_zero w) hQ
+  comp_apply_singleton_ne_zero _ _ hj (svSpeaker_fine_ne_zero s hw.1 hw.2)
+
+/-- The pragmatic listener, jointly over worlds and questions (item 6 of the §4.2 model). -/
+noncomputable def svListener : Kernel Message (World × QUD) := (svSpeaker s)†(svJoint s Q)
 
 include hQ in
-/-- Every message is used somewhere under the fine question, so has positive marginal
-likelihood. -/
-theorem svMarginal_ne_zero (u : Message) : PMF.marginal (svSpeaker s) (svJoint s Q) u ≠ 0 := by
-  cases u
-  · exact PMF.marginal_ne_zero _ _ _ (a := (.wa, .fine))
-      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
-      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
-  · exact PMF.marginal_ne_zero _ _ _ (a := (.wab, .fine))
-      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
-      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
-  · exact PMF.marginal_ne_zero _ _ _ (a := (.wa, .fine))
-      (by rw [svJoint_apply]; exact mul_ne_zero hQ (s.prior_ne_zero _))
-      (S1_ne_zero _ (svUtility_fine_ne_bot s rfl (by decide)))
-
-/-- item 6 of the §4.2 model: the pragmatic listener, jointly over worlds and questions. -/
-noncomputable def svListener (u : Message) : PMF (World × QUD) :=
-  RSA.Canonical.L1 (svSpeaker s) (svJoint s Q) u (svMarginal_ne_zero s Q hQ u)
-
-private theorem sv_aux {a b c d z y : ℝ≥0∞} (hab : a + b = 1) (ha : a ≠ 0) (hb : b ≠ 0)
-    (hc : c ≠ ⊤) (hd : d ≠ 0) (hz : z ≠ ⊤) (hy : y ≠ 0) :
-    c * b * z < b * (c * a * z + d * a * y + c * b * z) := by
-  have hb' : b ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top (hab ▸ le_add_self)
-  have h : b * (c * a * z + d * a * y + c * b * z) = c * b * z + b * (d * a * y) := by
-    calc b * (c * a * z + d * a * y + c * b * z) = c * b * ((a + b) * z) + b * (d * a * y) := by
-          ring
-      _ = _ := by rw [hab, one_mul]
-  rw [h]
-  exact ENNReal.lt_add_right (ENNReal.mul_ne_top (ENNReal.mul_ne_top hc hb') hz)
-    (mul_ne_zero hb (mul_ne_zero (mul_ne_zero hd ha) hy))
-
-/-- Appendix A.3, the listener: the posterior of both A and B falls below its prior, for
-every prior in the open interval, every prior on the questions that gives the fine one
-positive probability, and every cost, since the fine question contributes a use of *A* in the
-world of A alone and none in the world of both. -/
-theorem svListener_fst_lt_prior : (svListener s Q hQ .a).fst .wab < s.prior .wab := by
-  rw [svListener, RSA.Canonical.L1, ← svJoint_fst s Q, PMF.posterior_fst_lt_fst_iff, svJoint_fst]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum]
-  simp only [Fintype.sum_prod_type, sum_World, sum_QUD, svJoint_apply, svSpeaker_wab_fine_a,
-    ← svSpeaker_coarse, mul_zero, add_zero]
-  exact sv_aux s.prior_add (s.prior_ne_zero _) (s.prior_ne_zero _) (PMF.apply_ne_top _ _) hQ
-    (PMF.apply_ne_top _ _) (svSpeaker_wa_fine_a_ne_zero s)
+/-- The posterior of both A and B falls below its prior, for every prior in the open interval,
+every prior on the questions that gives the fine one positive probability, and every cost,
+since the fine question contributes a use of *A* in the world of A alone and none in the
+world of both (Appendix A.3, the listener). -/
+theorem svListener_fst_lt_prior : (svListener s Q .a).fst.real {.wab} < s.prior.real {.wab} := by
+  have hm : 0 < (svSpeaker s ∘ₘ svJoint s Q).real {.a} :=
+    ENNReal.toReal_pos (comp_svSpeaker_ne_zero s Q hQ _) (measure_ne_top _ _)
+  have hy : 0 < (svSpeaker s (.wa, .fine)).real {.a} :=
+    ENNReal.toReal_pos (svSpeaker_fine_ne_zero s rfl (by decide)) (measure_ne_top _ _)
+  have hqf : 0 < Q.real {.fine} := ENNReal.toReal_pos hQ (measure_ne_top _ _)
+  have hz := measureReal_nonneg (μ := svSpeaker s (.wa, .coarse)) (s := {.a})
+  have hqc := measureReal_nonneg (μ := Q) (s := {.coarse})
+  have hp' : 0 < 1 - s.p := by linarith [s.p_lt_one]
+  rw [svListener, posterior_fst_real_singleton _ _ (comp_svSpeaker_ne_zero s Q hQ _),
+    div_lt_iff₀ hm, Measure.comp_real_singleton]
+  simp only [Fintype.sum_prod_type, sum_world, sum_qud, svJoint_real_singleton,
+    Setting.prior_real_wa, Setting.prior_real_wab, svSpeaker_real_wab_fine_a, ← svSpeaker_coarse,
+    mul_zero, add_zero]
+  nlinarith [mul_pos (mul_pos (mul_pos s.p_pos hp') hqf) hy]
 
 end Supervaluationist
 
@@ -1019,185 +999,205 @@ section Wonky
 
 variable (s : Setting) (ω : ℝ) (hω₀ : 0 ≤ ω) (hω₁ : ω ≤ 1)
 
-/-- The speaker under a background: the literal listener uses the uniform prior in the wonky
-background and the measured prior otherwise. -/
-noncomputable def bgSpeaker : Background → World → PMF Message
-  | .wonky => speaker wonkyPrior wonkyPrior_ne_zero literal s
-  | .measured => s.speaker literal
+/-- The speaker's prior under a background: uniform in the wonky background, measured
+otherwise. -/
+noncomputable def worldPrior : Background → Measure World
+  | .wonky => wonkyPrior
+  | .measured => s.prior
 
-/-- The prior on backgrounds: wonky with the wonkiness. -/
-noncomputable def bgPrior : PMF Background :=
-  PMF.ofFintype (λ b => match b with
-    | .wonky => ENNReal.ofReal ω
-    | .measured => ENNReal.ofReal (1 - ω)) (by
-    rw [sum_Background]
-    show ENNReal.ofReal ω + ENNReal.ofReal (1 - ω) = 1
-    rw [← ENNReal.ofReal_add hω₀ (by linarith), add_sub_cancel, ENNReal.ofReal_one])
+instance (b : Background) : IsProbabilityMeasure (worldPrior s b) := by
+  cases b <;> dsimp only [worldPrior] <;> infer_instance
 
-/-- The prior of the wonky background. -/
-theorem bgPrior_wonky : bgPrior ω hω₀ hω₁ .wonky = ENNReal.ofReal ω := rfl
+theorem worldPrior_ne_zero (b : Background) (w : World) : worldPrior s b {w} ≠ 0 := by
+  cases b
+  · exact wonkyPrior_ne_zero w
+  · exact s.prior_ne_zero w
 
-/-- The prior of the measured background. -/
-theorem bgPrior_measured : bgPrior ω hω₀ hω₁ .measured = ENNReal.ofReal (1 - ω) := rfl
+/-- The speaker under a background, with the background's prior in the literal listener
+(items 1 to 3 of the §4.1 model). -/
+noncomputable def bgSpeaker (b : Background) : Kernel World Message :=
+  speaker (worldPrior s b) literal s
+
+instance (b : Background) : IsFiniteKernel (bgSpeaker s b) :=
+  inferInstanceAs (IsFiniteKernel (speaker _ _ _))
 
 /-- The wonky speaker's use of *A* in the world of both: the logistic function of the cost of
 *A and B* less the log of two. -/
 theorem bgSpeaker_wonky_wab_a :
-    bgSpeaker s .wonky .wab .a =
-      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAB - Real.log 2))) := by
-  rw [bgSpeaker, speaker_literal_wab_a, wonkyPrior_toReal, Real.log_inv, ← sub_eq_add_neg]
+    (bgSpeaker s .wonky .wab).real {.a} = s.logistic (s.cAndB - Real.log 2) := by
+  rw [bgSpeaker, speaker_literal_wab_a _ (worldPrior_ne_zero s .wonky), worldPrior,
+    wonkyPrior_real_singleton, Real.log_inv, ← sub_eq_add_neg]
 
 /-- The wonky speaker's use of *A* in the world of A alone: the logistic function of the cost
 of *A and not B* less the log of two. -/
 theorem bgSpeaker_wonky_wa_a :
-    bgSpeaker s .wonky .wa .a =
-      ENNReal.ofReal (Real.sigmoid (s.lam * (s.cAnotB - Real.log 2))) := by
-  rw [bgSpeaker, speaker_literal_wa_a, wonkyPrior_toReal, Real.log_inv, ← sub_eq_add_neg]
+    (bgSpeaker s .wonky .wa).real {.a} = s.logistic (s.cAndNotB - Real.log 2) := by
+  rw [bgSpeaker, speaker_literal_wa_a _ (worldPrior_ne_zero s .wonky), worldPrior,
+    wonkyPrior_real_singleton, Real.log_inv, ← sub_eq_add_neg]
 
-/-- item 5 of the §4.1 model, the Bayesian version: the speaker marginalised over the
-listener's uncertainty about the speaker's prior. -/
-noncomputable def bayesWonkySpeaker (w : World) : PMF Message :=
-  RSA.marginalizeKernel (bgPrior ω hω₀ hω₁) (λ b w => bgSpeaker s b w) w
+/-- The measured speaker's use of *A* in the world of both. -/
+theorem bgSpeaker_measured_wab_a :
+    (bgSpeaker s .measured .wab).real {.a} = s.logistic (s.cAndB + Real.log s.p) := by
+  rw [bgSpeaker, speaker_literal_wab_a _ (worldPrior_ne_zero s .measured), worldPrior,
+    Setting.prior_real_wab]
 
-/-- The Bayesian wonky speaker in closed form. -/
-theorem bayesWonkySpeaker_apply (w : World) (u : Message) :
-    bayesWonkySpeaker s ω hω₀ hω₁ w u =
-      ENNReal.ofReal ω * bgSpeaker s .wonky w u +
-        ENNReal.ofReal (1 - ω) * bgSpeaker s .measured w u := by
-  rw [bayesWonkySpeaker, RSA.marginalizeKernel_apply, tsum_fintype, sum_Background,
-    bgPrior_wonky, bgPrior_measured]
+/-- The measured speaker's use of *A* in the world of A alone. -/
+theorem bgSpeaker_measured_wa_a :
+    (bgSpeaker s .measured .wa).real {.a} = s.logistic (s.cAndNotB + Real.log (1 - s.p)) := by
+  rw [bgSpeaker, speaker_literal_wa_a _ (worldPrior_ne_zero s .measured), worldPrior,
+    Setting.prior_real_wa]
+
+/-- The weight of a background: wonky with the wonkiness. -/
+noncomputable def bgWeight : Background → ℝ≥0∞
+  | .wonky => ENNReal.ofReal ω
+  | .measured => ENNReal.ofReal (1 - ω)
+
+theorem bgWeight_ne_top (b : Background) : bgWeight ω b ≠ ∞ := by
+  cases b <;> exact ENNReal.ofReal_ne_top
+
+/-- Some background has positive weight. -/
+theorem bgWeight_exists_ne_zero : ∃ b, bgWeight ω b ≠ 0 :=
+  (le_or_gt ω 0).elim (λ h => ⟨.measured, by simp [bgWeight]; linarith⟩)
+    (λ h => ⟨.wonky, by simp [bgWeight, h]⟩)
+
+/-- The speaker marginalised over the listener's uncertainty about the speaker's prior (item 5
+of the §4.1 model, the Bayesian version). -/
+noncomputable def bayesWonkySpeaker : Kernel World Message :=
+  Kernel.mixture (bgWeight ω) (bgSpeaker s)
+
+instance : IsFiniteKernel (bayesWonkySpeaker s ω) :=
+  Kernel.isFiniteKernel_mixture _ _ (bgWeight_ne_top ω)
+
+include hω₀ hω₁ in
+/-- The Bayesian wonky speaker on reals. -/
+theorem bayesWonkySpeaker_real_singleton (w : World) (u : Message) :
+    (bayesWonkySpeaker s ω w).real {u} =
+      ω * (bgSpeaker s .wonky w).real {u} + (1 - ω) * (bgSpeaker s .measured w).real {u} := by
+  rw [bayesWonkySpeaker, Kernel.mixture_real _ _ (bgWeight_ne_top ω), sum_background]
+  simp only [bgWeight, ENNReal.toReal_ofReal hω₀, ENNReal.toReal_ofReal (sub_nonneg.mpr hω₁)]
 
 /-- Without wonkiness the Bayesian wonky speaker is the baseline speaker. -/
-theorem bayesWonkySpeaker_zero (w : World) :
-    bayesWonkySpeaker s 0 le_rfl zero_le_one w = s.speaker literal w :=
-  PMF.ext λ u => by
-    rw [bayesWonkySpeaker_apply, ENNReal.ofReal_zero, zero_mul, zero_add, sub_zero,
-      ENNReal.ofReal_one, one_mul, bgSpeaker]
+theorem bayesWonkySpeaker_zero (w : World) : bayesWonkySpeaker s 0 w = s.speaker literal w := by
+  rw [bayesWonkySpeaker, Kernel.mixture_apply, sum_background]
+  simp [bgWeight, bgSpeaker, worldPrior]
 
-/-- Every message is used somewhere under either background, so has positive marginal
-likelihood. -/
-theorem bayesWonkyMarginal_ne_zero (u : Message) :
-    PMF.marginal (bayesWonkySpeaker s ω hω₀ hω₁) s.prior u ≠ 0 :=
+/-- Every message is used somewhere under a positively weighted background, so is heard with
+positive probability. -/
+theorem comp_bayesWonkySpeaker_ne_zero (u : Message) :
+    (bayesWonkySpeaker s ω ∘ₘ s.prior) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  PMF.marginal_ne_zero _ _ _ (s.prior_ne_zero w) (by
-    rw [bayesWonkySpeaker_apply]
-    intro h
-    rcases add_eq_zero.mp h with ⟨h₁, h₂⟩
-    rcases mul_eq_zero.mp h₁ with h₁ | h₁
-    · rcases mul_eq_zero.mp h₂ with h₂ | h₂
-      · rw [ENNReal.ofReal_eq_zero] at h₁ h₂; linarith
-      · exact speaker_ne_zero _ _ _ _ hw h₂
-    · exact speaker_ne_zero _ _ _ _ hw h₁)
+  let ⟨b, hb⟩ := bgWeight_exists_ne_zero ω
+  comp_apply_singleton_ne_zero _ _ (s.prior_ne_zero w)
+    ((Kernel.mixture_apply_ne_zero_iff _ _ _ _).mpr
+      ⟨b, hb, speaker_ne_zero _ (worldPrior_ne_zero s b) _ s hw⟩)
 
 /-- The Bayesian wonky listener, with the measured prior. -/
-noncomputable def bayesWonkyListener (u : Message) : PMF World :=
-  RSA.L1 (bayesWonkySpeaker s ω hω₀ hω₁) s.prior u (bayesWonkyMarginal_ne_zero s ω hω₀ hω₁ u)
+noncomputable def bayesWonkyListener : Kernel Message World := (bayesWonkySpeaker s ω)†s.prior
 
-/-- Appendix A.2, the Bayesian model: anti-exhaustivity exactly when the wonkiness-weighted
-excess of the use of *A* in the world of both over its use in the world of A alone is
-positive. -/
+include hω₀ hω₁ in
+/-- Anti-exhaustivity exactly when the wonkiness-weighted excess of the use of *A* in the
+world of both over its use in the world of A alone is positive (Appendix A.2, the Bayesian
+model). -/
 theorem prior_lt_bayesWonkyListener_iff :
-    s.prior .wab < bayesWonkyListener s ω hω₀ hω₁ .a .wab ↔
-      0 < (1 - ω) * (Real.sigmoid (s.lam * (s.cAB + Real.log s.p)) -
-          Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p)))) +
-        ω * (Real.sigmoid (s.lam * (s.cAB - Real.log 2)) -
-          Real.sigmoid (s.lam * (s.cAnotB - Real.log 2))) := by
-  have hσ₁ := Real.sigmoid_pos (s.lam * (s.cAnotB - Real.log 2))
-  have hσ₂ := Real.sigmoid_pos (s.lam * (s.cAB - Real.log 2))
-  have hσ₃ := Real.sigmoid_pos (s.lam * (s.cAnotB + Real.log (1 - s.p)))
-  have hσ₄ := Real.sigmoid_pos (s.lam * (s.cAB + Real.log s.p))
-  have hω' : 0 ≤ 1 - ω := by linarith
-  rw [bayesWonkyListener, RSA.L1, PMF.lt_posterior_iff_marginal_lt _ _ _ _ (s.prior_ne_zero _)]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum, sum_World,
-    two_world_lt s.prior_add (s.prior_ne_zero _) (PMF.apply_ne_top _ _),
-    bayesWonkySpeaker_apply, bayesWonkySpeaker_apply, bgSpeaker_wonky_wab_a,
-    bgSpeaker_wonky_wa_a, bgSpeaker]
-  dsimp only [Setting.speaker]
-  rw [speaker_literal_wab_a, speaker_literal_wa_a, Setting.prior_wab_toReal,
-    Setting.prior_wa_toReal]
-  simp (disch := positivity) only [← ENNReal.ofReal_mul, ← ENNReal.ofReal_add]
-  rw [ENNReal.ofReal_lt_ofReal_iff (by
-    rcases hω₁.lt_or_eq with hω | hω
-    · exact add_pos_of_nonneg_of_pos (by positivity) (mul_pos (by linarith) hσ₄)
-    · exact add_pos_of_pos_of_nonneg (mul_pos (by linarith) hσ₂) (by positivity))]
+    s.prior.real {.wab} < (bayesWonkyListener s ω .a).real {.wab} ↔
+      0 < (1 - ω) * (s.logistic (s.cAndB + Real.log s.p) -
+          s.logistic (s.cAndNotB + Real.log (1 - s.p))) +
+        ω * (s.logistic (s.cAndB - Real.log 2) - s.logistic (s.cAndNotB - Real.log 2)) := by
+  rw [bayesWonkyListener, real_lt_posterior_real_singleton_iff_of_pair _ _ (by decide)
+      s.prior_support (comp_bayesWonkySpeaker_ne_zero s ω _) (s.prior_ne_zero _)
+      (s.prior_ne_zero _),
+    bayesWonkySpeaker_real_singleton s ω hω₀ hω₁, bayesWonkySpeaker_real_singleton s ω hω₀ hω₁,
+    bgSpeaker_wonky_wab_a, bgSpeaker_wonky_wa_a, bgSpeaker_measured_wab_a,
+    bgSpeaker_measured_wa_a]
   constructor <;> intro h <;> nlinarith
 
-/-- The joint prior of the non-Bayesian model: the background, then the world under it. -/
-noncomputable def wonkyJoint : PMF (World × Background) :=
-  RSA.jointPrior (bgPrior ω hω₀ hω₁) λ b => match b with
-    | .wonky => wonkyPrior
-    | .measured => s.prior
+/-- The prior on backgrounds: wonky with the wonkiness. -/
+noncomputable def bgPrior : Measure Background := ∑ b, bgWeight ω b • Measure.dirac b
 
-/-- The joint prior of a world under the wonky background. -/
-theorem wonkyJoint_wonky (w : World) :
-    wonkyJoint s ω hω₀ hω₁ (w, .wonky) = ENNReal.ofReal ω * 2⁻¹ := by
-  rw [wonkyJoint, RSA.jointPrior_apply, bgPrior_wonky, wonkyPrior_apply]
+theorem bgPrior_apply_singleton (b : Background) : bgPrior ω {b} = bgWeight ω b :=
+  Measure.sum_smul_dirac_apply_singleton _ b
 
-/-- The joint prior of a world under the measured background. -/
-theorem wonkyJoint_measured (w : World) :
-    wonkyJoint s ω hω₀ hω₁ (w, .measured) = ENNReal.ofReal (1 - ω) * s.prior w := by
-  rw [wonkyJoint, RSA.jointPrior_apply, bgPrior_measured]
+instance : IsFiniteMeasure (bgPrior ω) :=
+  ⟨by
+    rw [bgPrior, Measure.finsetSum_apply]
+    exact ENNReal.sum_lt_top.mpr λ b _ => by
+      rw [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply_of_mem (Set.mem_univ _), mul_one]
+      exact (bgWeight_ne_top ω b).lt_top⟩
 
-/-- The speaker of the non-Bayesian model, at a world under a background. -/
-noncomputable abbrev wonkySpeaker : World × Background → PMF Message :=
-  λ x => bgSpeaker s x.2 x.1
+/-- The world given the background. -/
+noncomputable def worldKernel : Kernel Background World := Kernel.ofFunOfCountable (worldPrior s)
 
-/-- Every message is used somewhere under whichever background has positive prior, so has
-positive marginal likelihood. -/
-theorem wonkyMarginal_ne_zero (u : Message) :
-    PMF.marginal (wonkySpeaker s) (wonkyJoint s ω hω₀ hω₁) u ≠ 0 :=
+instance : IsMarkovKernel (worldKernel s) :=
+  ⟨λ b => by rw [worldKernel, Kernel.ofFunOfCountable_apply]; infer_instance⟩
+
+/-- The prior of the non-Bayesian model: the background, then the world under it (item 4 of
+the §4.1 model). -/
+noncomputable def wonkyJoint : Measure (Background × World) := bgPrior ω ⊗ₘ worldKernel s
+
+instance : IsFiniteMeasure (wonkyJoint s ω) :=
+  inferInstanceAs (IsFiniteMeasure (bgPrior ω ⊗ₘ worldKernel s))
+
+theorem wonkyJoint_apply_singleton (b : Background) (w : World) :
+    wonkyJoint s ω {(b, w)} = bgWeight ω b * worldPrior s b {w} := by
+  rw [wonkyJoint, Measure.compProd_apply_singleton, bgPrior_apply_singleton, worldKernel,
+    Kernel.ofFunOfCountable_apply]
+
+theorem wonkyJoint_real_singleton (b : Background) (w : World) :
+    (wonkyJoint s ω).real {(b, w)} = (bgWeight ω b).toReal * (worldPrior s b).real {w} := by
+  rw [measureReal_def, wonkyJoint_apply_singleton, ENNReal.toReal_mul, measureReal_def]
+
+/-- The speaker of the non-Bayesian model, at a background and a world. -/
+noncomputable def wonkySpeaker : Kernel (Background × World) Message :=
+  Kernel.ofFunOfCountable λ x => bgSpeaker s x.1 x.2
+
+theorem wonkySpeaker_apply (x : Background × World) : wonkySpeaker s x = bgSpeaker s x.1 x.2 :=
+  rfl
+
+instance : IsFiniteKernel (wonkySpeaker s) :=
+  ⟨⟨1, ENNReal.one_lt_top, λ x => by
+    rw [wonkySpeaker_apply, bgSpeaker, speaker, RSA.speaker]
+    exact Kernel.ofWeights_apply_univ_le_one _ _⟩⟩
+
+/-- A message true at a world is used there under either background. -/
+theorem wonkySpeaker_ne_zero {w : World} {u : Message} (b : Background)
+    (hw : literal.sat u w = true) : wonkySpeaker s (b, w) {u} ≠ 0 := by
+  rw [wonkySpeaker_apply]
+  exact speaker_ne_zero _ (worldPrior_ne_zero s _) _ s hw
+
+/-- Every message is used somewhere under a positively weighted background, so is heard with
+positive probability. -/
+theorem comp_wonkySpeaker_ne_zero (u : Message) : (wonkySpeaker s ∘ₘ wonkyJoint s ω) {u} ≠ 0 :=
   let ⟨w, hw⟩ := literal.exists_world u
-  (hω₀.lt_or_eq).elim
-    (λ hω => PMF.marginal_ne_zero _ _ _ (a := (w, .wonky))
-      (by rw [wonkyJoint_wonky]; exact mul_ne_zero (ENNReal.ofReal_pos.mpr hω).ne' (by simp))
-      (speaker_ne_zero _ _ _ _ hw))
-    (λ hω => PMF.marginal_ne_zero _ _ _ (a := (w, .measured))
-      (by
-        rw [wonkyJoint_measured]
-        exact mul_ne_zero (ENNReal.ofReal_pos.mpr (by linarith)).ne' (s.prior_ne_zero _))
-      (speaker_ne_zero _ _ _ _ hw))
+  let ⟨b, hb⟩ := bgWeight_exists_ne_zero ω
+  have hj : wonkyJoint s ω {(b, w)} ≠ 0 := by
+    rw [wonkyJoint_apply_singleton]; exact mul_ne_zero hb (worldPrior_ne_zero s b w)
+  comp_apply_singleton_ne_zero _ _ hj (wonkySpeaker_ne_zero s b hw)
 
-/-- item 4 of the §4.1 model: the non-Bayesian listener, uncertain about the world and the
-speaker's background jointly. -/
-noncomputable def wonkyListener (u : Message) : PMF World :=
-  RSA.jointListener (wonkySpeaker s) (wonkyJoint s ω hω₀ hω₁) u
-    (wonkyMarginal_ne_zero s ω hω₀ hω₁ u)
+/-- The non-Bayesian listener, uncertain about the background and the world jointly (item 4
+of the §4.1 model). -/
+noncomputable def wonkyListener : Kernel Message (Background × World) :=
+  (wonkySpeaker s)†(wonkyJoint s ω)
 
-/-- (A.5a): the non-Bayesian model is anti-exhaustive with respect to the measured prior
-exactly when the prior times the marginal use of *A* falls below the background-weighted use
-of *A* in the world of both; the paper resolves this inequality numerically. -/
+include hω₀ hω₁ in
+/-- The non-Bayesian model is anti-exhaustive with respect to the measured prior exactly when
+the prior times the marginal use of *A* falls below the background-weighted use of *A* in the
+world of both; the paper resolves this inequality numerically (A.5a). -/
 theorem prior_lt_wonkyListener_iff :
-    s.prior .wab < wonkyListener s ω hω₀ hω₁ .a .wab ↔
-      s.p * (ω * 2⁻¹ * (Real.sigmoid (s.lam * (s.cAnotB - Real.log 2)) +
-          Real.sigmoid (s.lam * (s.cAB - Real.log 2))) +
-        (1 - ω) * ((1 - s.p) * Real.sigmoid (s.lam * (s.cAnotB + Real.log (1 - s.p))) +
-          s.p * Real.sigmoid (s.lam * (s.cAB + Real.log s.p)))) <
-      ω * 2⁻¹ * Real.sigmoid (s.lam * (s.cAB - Real.log 2)) +
-        (1 - ω) * (s.p * Real.sigmoid (s.lam * (s.cAB + Real.log s.p))) := by
-  have hσ₁ := Real.sigmoid_pos (s.lam * (s.cAnotB - Real.log 2))
-  have hσ₂ := Real.sigmoid_pos (s.lam * (s.cAB - Real.log 2))
-  have hσ₃ := Real.sigmoid_pos (s.lam * (s.cAnotB + Real.log (1 - s.p)))
-  have hσ₄ := Real.sigmoid_pos (s.lam * (s.cAB + Real.log s.p))
-  have hω' : 0 ≤ 1 - ω := by linarith
-  have hp := s.p_pos
-  have hp' : 0 ≤ 1 - s.p := by linarith [s.p_lt_one]
-  rw [wonkyListener, RSA.jointListener_apply,
-    ENNReal.lt_div_iff_mul_lt (Or.inl (wonkyMarginal_ne_zero s ω hω₀ hω₁ _))
-      (Or.inl (PMF.marginal_ne_top _ _ _))]
-  unfold PMF.marginal
-  rw [PMF.bind_apply_eq_finset_sum]
-  simp only [Fintype.sum_prod_type, sum_World, sum_Background, wonkyJoint_wonky,
-    wonkyJoint_measured, wonkySpeaker, bgSpeaker, Setting.speaker, speaker_literal_wab_a,
-    speaker_literal_wa_a, wonkyPrior_toReal, Setting.prior_wa, Setting.prior_wab,
-    ENNReal.toReal_ofReal hp', ENNReal.toReal_ofReal hp.le, Real.log_inv, ← sub_eq_add_neg]
-  rw [show (2 : ℝ≥0∞)⁻¹ = ENNReal.ofReal 2⁻¹ from by
-    rw [ENNReal.ofReal_inv_of_pos (by norm_num), ENNReal.ofReal_ofNat]]
-  simp (disch := positivity) only [← ENNReal.ofReal_mul, ← ENNReal.ofReal_add]
-  rw [ENNReal.ofReal_lt_ofReal_iff (by
-    rcases hω₁.lt_or_eq with hω | hω
-    · exact add_pos_of_nonneg_of_pos (by positivity) (by positivity)
-    · subst hω; simp only [sub_self, zero_mul, add_zero]; positivity)]
+    s.prior.real {.wab} < (wonkyListener s ω .a).snd.real {.wab} ↔
+      s.p * (ω * 2⁻¹ * (s.logistic (s.cAndNotB - Real.log 2) + s.logistic (s.cAndB - Real.log 2)) +
+        (1 - ω) * ((1 - s.p) * s.logistic (s.cAndNotB + Real.log (1 - s.p)) +
+          s.p * s.logistic (s.cAndB + Real.log s.p))) <
+      ω * 2⁻¹ * s.logistic (s.cAndB - Real.log 2) +
+        (1 - ω) * (s.p * s.logistic (s.cAndB + Real.log s.p)) := by
+  have hm : 0 < (wonkySpeaker s ∘ₘ wonkyJoint s ω).real {.a} :=
+    ENNReal.toReal_pos (comp_wonkySpeaker_ne_zero s ω _) (measure_ne_top _ _)
+  rw [wonkyListener, posterior_snd_real_singleton _ _ (comp_wonkySpeaker_ne_zero s ω _),
+    lt_div_iff₀ hm, Measure.comp_real_singleton]
+  simp only [Fintype.sum_prod_type, sum_background, sum_world, wonkyJoint_real_singleton,
+    wonkySpeaker_apply, bgSpeaker_wonky_wab_a, bgSpeaker_wonky_wa_a, bgSpeaker_measured_wab_a,
+    bgSpeaker_measured_wa_a, bgWeight, ENNReal.toReal_ofReal hω₀,
+    ENNReal.toReal_ofReal (sub_nonneg.mpr hω₁), worldPrior, wonkyPrior_real_singleton,
+    Setting.prior_real_wa, Setting.prior_real_wab]
   constructor <;> intro h <;> linarith
 
 end Wonky


### PR DESCRIPTION
Rebuild the study on `RSA/Basic.lean` (literal listener, power-weight speaker, posterior kernels, mixtures for latents) and retire the PMF-face lemmas #2737 added.
- Substrate: `Kernel.mixture` with its evaluation and finiteness lemmas; `Kernel.ofWeights_apply_singleton_ne_zero`, `_real_singleton`, `_real_singleton_of_pair`; posterior-versus-prior comparisons at an atom and under a two-atom prior; `posterior_fst/snd_real_singleton`; literal-listener values on tautologies and singleton extensions; `Real.exp_div_add_exp_eq_sigmoid` in its own Core file.
- Study: every result on `Measure.real` with the paper's logistic `f_λ` named; the two-world Bayes ritual and the closed-form speaker proofs each reduce to one substrate lemma; cell lemmas replaced by `simp (disch := decide)`.
- Reverts the PMF additions to `Posterior`, `JointPosterior`, `Softmax`, `Canonical`, `LatentOperators`.