### PR TITLE
docs(Studies): trim three headers to mathlib register

### DIFF
--- a/Linglib/Studies/CremersWilcoxSpector2023.lean
+++ b/Linglib/Studies/CremersWilcoxSpector2023.lean
@@ -8,65 +8,21 @@ import Linglib.Semantics.Exhaustification.Finite
 # Exhaustivity and anti-exhaustivity in the Rational Speech Act framework
 
 A listener who hears *A* where *A and B* was available infers that B is false. In the
-baseline Rational Speech Act model the inference can reverse: a prior biased towards the
-world where both A and B hold makes the literal listener already expect that world on
-hearing *A*, so the speaker uses the cheap *A* there rather than in the world where only A
-holds, and the pragmatic listener raises the probability of both A and B above her prior.
+baseline Rational Speech Act model a prior biased towards the world of both A and B reverses
+the inference: the listener is anti-exhaustive exactly when the log odds of the prior exceed
+the cost disadvantage of *A and not B* over *A and B*, whatever the rationality. Lexical
+uncertainty over free strengthenings and the wonky-world models stay anti-exhaustive for
+suitable priors, while grammatical lexical uncertainty, the lexical-intentions speaker and
+the supervaluationist speaker keep the posterior of both below the prior whenever *A and B*
+costs no more than *A and not B*. The experiment finds no anti-exhaustivity.
 
-Over two worlds and the messages *A*, *A and B* and *A and not B*, the speaker prefers *A* to
-*A and B* in the world of both exactly when the information *A and B* would add, the negated
-log prior, is not worth its cost, and the listener is anti-exhaustive exactly when the log
-odds of the prior exceed the cost disadvantage of *A and not B* over *A and B*, a condition
-independent of the rationality parameter.
-
-The models that lift a parameter of the baseline divide by whether they block this. Lexical
-uncertainty over free strengthenings, where *A* may mean *A and B*, and the wonky-world
-models, where the listener doubts the speaker's prior, remain anti-exhaustive for suitable
-priors, the Bayesian wonky model exactly when a wonkiness-weighted difference of logistic
-values is positive. Lexical uncertainty restricted to the grammatical exhaustification of
-*A*, the lexical-intentions speaker who chooses a message together with its interpretation,
-and the supervaluationist speaker who addresses a question under discussion and averages
-over the interpretations, all keep the posterior of both A and B below its prior whenever
-*A and B* costs no more than *A and not B*, the supervaluationist model for every cost.
-
-The experiment found no anti-exhaustivity in production or in comprehension; the wonky and
-supervaluationist models fit best, and once the two conjunctions are constrained to cost the
-same the models that cannot block anti-exhaustivity fall behind.
-
-## Implementation notes
-
-* Meanings are interpretation functions on the three messages; the exhaustified one is
-  derived by innocent exclusion from the substrate rather than stipulated.
-* The literal listener is the substrate's prior conditioned on the extension, the speaker
-  its power-weight best response with the rationality as exponent and the exponentiated costs
-  as factors, so that the paper's exponentiated utility is a power of the literal listener
-  times a cost factor, and the pragmatic listener is mathlib's posterior kernel. Lexical
-  uncertainty and the Bayesian wonky model average the speaker over the latent as a mixture
-  of kernels, the lexical-intentions speaker is pushed forward along the message coordinate,
-  and the supervaluationist and non-Bayesian wonky listeners are posteriors over a joint
-  state, as the paper's numbered definitions have them.
-* Every result is stated on reals for an arbitrary prior in the open unit interval, positive
-  rationality and arbitrary costs of the two conjunctions, as in the paper's appendix; the
-  supervaluationist listener takes any prior on the questions that gives the fine one
-  positive probability, while its speaker fixes the two interpretations equiprobable, as the
-  paper's fits do. The supervaluationist speaker's weight is the geometric mean of the two
-  interpretations' literal listeners on the cell of the question, times the cost factor; the
-  prior of the question, common to every message, is left out.
-* The paper's anti-exhaustivity is the posterior of both A and B exceeding the prior; the
-  substrate's comparison of a posterior with its prior reduces it, over two worlds, to the
-  comparison of the two likelihoods of *A*, and the closed forms of those likelihoods are
-  logistic functions of utility differences. The non-Bayesian wonky model's anti-exhaustivity
-  is reduced to the paper's rational inequality, which the paper resolves numerically.
+We state each model on the substrate's kernel face and prove the paper's conditions on reals
+for an arbitrary prior, rationality and costs.
 
 ## TODO
 
-* The non-Bayesian wonky model's limits in the prior for positive wonkiness, anti-exhaustive
-  as the prior tends to zero and exhaustive as it tends to one, are not proved.
-* The Bayesian wonky model's threshold on the wonkiness, the limit of its condition as the
-  prior tends to one, is not derived from the condition.
-* Higher-order speakers and listeners, at which anti-exhaustivity can reappear in the
-  grammatical models, the second-level analyses of the supervaluationist model, and the model
-  fits are prose.
+* The non-Bayesian wonky model's limits in the prior and the Bayesian wonky model's
+  wonkiness threshold are not derived.
 
 ## References
 

--- a/Linglib/Studies/Cresswell1976.lean
+++ b/Linglib/Studies/Cresswell1976.lean
@@ -6,61 +6,25 @@ import Linglib.Data.Examples.Cresswell1976
 /-!
 # The semantics of degree
 
-Cresswell's degrees of comparison are pairs of a point and the ordering of the scale it lies
-on, and the comparative *er than* relates two properties of degrees: it holds when both are
-instantiated and every degree of the first exceeds every degree of the second on their common
-scale. Degrees on distinct scales never stand in the ordering, so a comparative whose terms
-measure on different scales, *taller man than … clever man*, *taller than … beautiful*, or
-*longer* of a meeting and a road, is semantically anomalous without any syntactic feature, and
-since a degree carries its ordering, *six feet*, which names a degree on the upward scale, lies
-outside the domain of *short*, which takes degrees read downward. A disjoined standard is
-compared universally, so *taller than Arabella or Clarissa* means taller than both, and the
-equative *as as* is the weak comparison that *exactly* strengthens to identity.
+Cresswell's degree of comparison is a point paired with the ordering of its scale, and
+*er than* holds of two degree properties when both are instantiated and every degree of the
+first exceeds every degree of the second on their common scale, so a comparative across
+scales is anomalous and a disjoined standard is compared universally. Mass nouns and plurals
+carry degrees of volume and of number through the totality operator, degrees need no units
+since any comparison relation yields a scale by quotienting, and the counterfactual *shorter
+than he is* compares heights across worlds.
 
-Mass nouns and plurals carry degrees of the same kind. The totality operator picks the greatest
-degree among the parts satisfying a predicate, so *more water ebbs than mud flows* compares two
-volumes, and pluralization turns a count noun into a predicate of sets carrying their
-cardinality, so *more men walk than birds fly* compares two numbers and *all men walk* comes
-out synonymous with *every man walks* although *all* applies to the pluralized noun, as it
-does to a mass noun, and *every* to the count noun. Degrees need no units: any comparison
-relation yields a scale by quotienting its field by indistinguishability, and since the things
-compared are things at worlds, the counterfactual *if Bill had been a smoker he would be
-shorter than he is* compares his height at the nearest world where he smokes with his actual
-height.
-
-We take the degrees on a family of scales to be mathlib's disjoint sum of the scales' orders
-and prove from it the same-scale restriction and the anomaly of the paper's starred
-comparatives, the universal reading of disjoined standards, the reduction of the totality
-comparatives to comparisons of volumes and of cardinalities, the synonymy of *all* and *every*
-given that the noun is instantiated, the comparative on constructed degrees, and the reading
-of the counterfactual through a Stalnaker selection function, on which it is false whenever
-Bill is in fact a smoker.
+We take degrees on a family of scales to be mathlib's disjoint sum of the scales' orders and
+prove the same-scale restriction, the universal reading of disjoined standards, the reduction
+of the totality comparatives to volumes and cardinalities, the synonymy of *all* and *every*
+given that there are men, the comparative on constructed degrees, and the counterfactual
+through a Stalnaker selection function.
 
 ## Implementation notes
 
-* A degree property is a set of degrees, and the comparative, the equative and the totality
-  operator are stated on sets over any ordered type; the scale-tagged degrees of (2.1) are the
-  case of a sigma type with mathlib's fiberwise order, where the same-scale requirement of
-  (2.3) is that the order never relates distinct fibers. The downward reading of *short*
-  ((39), (72)) is the order dual of the spatial scale, on which the comparative is the
-  substrate's negative-polarity comparative. The paper places the bare degree *six feet* as
-  the second term of *er than* ((35), (36)); here that term is the singleton of the degree.
-  The uniqueness of a totality's degree uses antisymmetry of the scale, which the paper
-  declines to require of the ordering of a degree (§2).
-* The plural (3.6) is read as in (49): a nonempty set of things satisfying the noun together
-  with its cardinality, a positive integer as the paper has the scale. As printed, (3.6) fixes
-  the set to all of them, on which (54) would require the set of all men to walk; the (49)
-  reading gives (55). Predicates of sets are taken distributive where the paper compares
-  numbers. Since the plural's degrees are positive, *all* carries existential import, and the
-  synonymy of (56) and (57) holds given that there are men.
-* The positive form (2.5), *much* and *deg* (3.3), the syntax of §5, and the differential and
-  factor comparatives through a natural metric (the end of §4, §6) are not formalized.
-
-## TODO
-
-* (50), *Arabella is more beautiful than Tom is clever*, is listed without an asterisk as an
-  instance of *more* with an adjective, although it compares distinct scales like the starred
-  (65); the paper's as-if order-preserving mapping between scales ((66)) is not formalized.
+* The plural is read as in (49), a nonempty set of things satisfying the noun with its
+  cardinality; as printed, (3.6) fixes the set to all of them, on which (54) would require
+  the set of all men to walk.
 
 ## References
 

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -6,63 +6,28 @@ import Linglib.Data.Examples.Cumming2026
 /-!
 # Tense and evidence
 
-Ninan observed that a future-tense sentence can be asserted on prior inferential grounds
-while the past-tense sentence about the same event, uttered once the event has passed on the
-same grounds, cannot, although the two are true in the same circumstances. In Cumming's
-version, *Alma will enjoy the meal* is assertible before the meal and *Alma enjoyed the meal*
-is not the next day, yet *Alma will have enjoyed the meal* is, which tells against an
-epistemic account of the asymmetry. Cumming's explanation is linguistic and amends
-Cariani's: the constraint that the speaker's evidence be causally downstream of the event
-described, which Cariani places on every predicate and lets modals obviate, belongs to the
-nonfuture tenses of English as non-truth-conditional meaning, and the future forms lack it.
-The evidential paradigms of Korean and Bulgarian show the same recruitment of tense. Under
-the evidentials *-te*, *-ney* and *-l*, tense fixes the evidential perspective, the relation
-of the event to the acquisition of the evidence; *-te* and *-ney* place the acquisition in the
-past of speech and at speech, and for *-l* it suffices that evidence is acquired by the time
-of speech; and the utterance perspective, the ordinary contribution of tense, is derived:
-present evidence that is prospective is evidence for a future event, downstream evidence
-acquired by the time of speech is evidence for a nonfuture event, and past evidence that is
-prospective leaves the utterance perspective open. The past- and present-directed *will have*
-and *will now* carry the prospective constraint with a past or present utterance perspective.
-No language should have a true future restricted to downstream evidence, since the speaker
-would have to acquire the evidence after speaking. Where Cariani's account offers the
-downstream constraint or its obviation, Korean under *-te* and the English *will* forms show a
-third option, the positive restriction to prospective evidence. Planned or scheduled events
-are exempt from both perspectives, as in the futurate.
+Ninan's puzzle is that a future-tense sentence can be asserted on prior inferential grounds
+while the past-tense sentence about the same event, on the same grounds, cannot, though
+*will have* is assertible again. Cumming's answer, amending Cariani, is that the nonfuture
+tenses carry, as non-truth-conditional meaning, the constraint that the speaker's evidence be
+causally downstream of the event, and the future forms do not. Under the Korean evidentials
+*-te* and *-ney* and the Bulgarian *-l*, tense fixes the evidential perspective, the
+evidential the relation of the acquisition of evidence to speech, and the utterance
+perspective is derived from the two; the English *will have* and *will now* restrict evidence
+to the prospective; no true future can be restricted to downstream evidence; and planned
+events are exempt, as in the futurate.
 
 We derive the utterance-perspective column of the Korean and Bulgarian paradigms as the
-composition of the evidential-perspective column with the cell relating the acquisition of
-the evidence to speech, show that the future cells leave the utterance perspective open,
-prove that a downstream-restricted future is unsatisfiable and that the prospective cells lie
-beyond obviation, and check the paper's felicity judgments against the paradigm cells on the
+composition of the evidential-perspective column with the evidential's cell, prove that a
+downstream-restricted future is unsatisfiable and that the prospective cells lie beyond
+Cariani's obviation, and check the paper's felicity judgments against the cells on the
 frames its scenarios fix.
 
 ## Implementation notes
 
-* Paradigm cells are the fragments' rows, each an evidential-perspective and an
-  utterance-perspective constraint on a frame of speech, acquisition and event times, read
-  temporally as in the paper's tables. Cumming's own constraint is causal, and he declines
-  the temporal reading of Lee's and Koev's accounts; evidence temporally after but causally
-  independent of the event, or before it yet downstream, as the rewatched film of footnote
-  9, is not represented.
-* The cells relating acquisition to speech, the past for *-te*, the present for *-ney*, and
-  the nonfuture for *-l* as for any assertion, are the paper's; the utterance perspective is
-  their composition with the evidential perspective by the substrate's cell composition.
-* The paper calls the constraint non-truth-conditional and a felicity condition; the
-  substrate renders it as a presupposition, and the shared assertion of cells differing in
-  tense holds there by construction rather than being derived.
-* The felicity data enter each scenario's times as small integers on one line; scenarios
-  the paper does not spell out are reconstructed and say so. The futurate exemption is
-  recorded as a flag on the planned or scheduled examples rather than derived, since the
-  paper leaves the criterion for it open.
-* The unmarked pattern of §7, the ranking of evidential sources and the acquaintance
-  inference, is prose.
-
-## TODO
-
-* Causal downstreamness, on which the paper's decisive cases turn, needs a relation between
-  the evidence-acquiring event and the described event with the temporal constraint as a
-  consequence.
+* The constraints are read temporally, as in the paper's tables; Cumming's own constraint is
+  causal, and cases turning on the difference, as the rewatched film of footnote 9, are not
+  represented.
 
 ## References
 


### PR DESCRIPTION
The CremersWilcoxSpector2023, Cresswell1976 and Cumming2026 headers shrink to one claim paragraph, one sentence on what is proved, and references, with a note only where a modelling decision departs from the printed text.