### PR TITLE
refactor(Features/Person): fold Clusivity.System into Person.Clusivity

### DIFF
--- a/Linglib/Features/Person/Basic.lean
+++ b/Linglib/Features/Person/Basic.lean
@@ -150,7 +150,7 @@ def hierarchyRank : Person → Nat
 
 /-- A language's person system: the analytical values its paradigms
     distinguish ([cysouw-2003]; the paradigm-level marking typology is
-    `Person.Clusivity.System`, his Table 3.2). -/
+    `Person.Clusivity`, his Table 3.2). -/
 structure System where
   /-- The person values the system distinguishes. -/
   values : List Person

--- a/Linglib/Features/Person/Clusivity.lean
+++ b/Linglib/Features/Person/Clusivity.lean
@@ -2,22 +2,22 @@ import Linglib.Core.Data.Setoid.Basic
 import Linglib.Features.Person.Decomposition
 
 /-!
-# Clusivity systems: marking types of the first person complex
+# Clusivity: marking types of the first person complex
 
 A person paradigm marks the three 'we' categories 1+2, 1+2+3 and 1+3 either by a morpheme
 of their own or by one that also marks a singular category, and groups them in some way.
 [cysouw-2003]'s Fig. 3.1 writes such a pattern with a letter per specialized morpheme class
 and a dash where a singular morpheme is reused; of the fifteen possible patterns five are
-common (his Table 3.2) and form `System`. Each type's `pattern` is that notation as a setoid
-on `Cell`, the four speaker-including categories, the singular speaker standing for any
-singular morpheme, and the four questions of his Fig. 3.10 are read off the setoid. The
-First Person Hierarchy (3.26) is the linear order on the types, along which each question's
-answer is monotone.
+common (his Table 3.2) and form `Clusivity`. Each type's `toPattern` is that notation as a
+setoid on `Clusivity.Cell`, the four speaker-including categories, the singular speaker
+standing for any singular morpheme, and the four questions of his Fig. 3.10 are read off the
+setoid. The First Person Hierarchy (3.26) is the linear order on the types, along which each
+question's answer is monotone.
 
-The five rare attested patterns ((Pf)–(Pj), his §3.6.6) are not systems in this sense and
-live with the study. The typology is finer than [cysouw-2013]'s WALS chapter, which
-collapses minimal/augmented into inclusive/exclusive and whose "no 'we'" value is the absence
-of any first-person non-singular, not `System.noWe`.
+The five rare attested patterns ((Pf)–(Pj), his §3.6.6) are not types in this sense and live
+with the study. The typology is finer than [cysouw-2013]'s WALS chapter, which collapses
+minimal/augmented into inclusive/exclusive and whose "no 'we'" value is the absence of any
+first-person non-singular, not `Clusivity.noWe`.
 
 ## References
 
@@ -25,7 +25,25 @@ of any first-person non-singular, not `System.noWe`.
 * [M. Cysouw, *Inclusive/Exclusive Distinction in Independent Pronouns* (2013)][cysouw-2013]
 -/
 
-namespace Person.Clusivity
+namespace Person
+
+/-- The five common marking types of the first person complex ([cysouw-2003] Table 3.2, the
+common five of the fifteen patterns of his Fig. 3.1). -/
+inductive Clusivity where
+  /-- No 'we' category has a specialized morpheme, as in the English inflection (Pb). -/
+  | noWe
+  /-- All three 'we' categories share one specialized morpheme, as English *we* (Pa). -/
+  | unifiedWe
+  /-- 1+2 and 1+2+3 share a specialized morpheme and 1+3 has none, as in Maká (Pc). -/
+  | onlyInclusive
+  /-- 1+2 and 1+2+3 share one specialized morpheme and 1+3 has another, as in Apalai (Pd). -/
+  | inclusiveExclusive
+  /-- All three 'we' categories have separate specialized morphemes, as Ilocano
+  *ta* ~ *tayo* ~ *mi* (Pe, his Fig. 3.6). -/
+  | minimalAugmented
+  deriving DecidableEq, Repr, Fintype
+
+namespace Clusivity
 
 /-- Fig. 3.1's four cells, the categories that include the speaker; the singular speaker
 stands for every singular morpheme. -/
@@ -47,9 +65,13 @@ def excl : Cell := ⟨.excl, by decide⟩
 
 end Cell
 
-section Questions
+/-- A marking pattern of the first person complex, Fig. 3.1's notation as a setoid on the
+four cells. -/
+abbrev Pattern := Setoid Cell
 
-variable (r : Setoid Cell)
+namespace Pattern
+
+variable (r : Pattern)
 
 /-- Some 'we' cell is not marked like the speaker (Fig. 3.10's first question). -/
 def SpecializedWe : Prop := ∃ c : Cell, c.1.IsFirstPersonComplex ∧ ¬ r c Cell.s1
@@ -71,36 +93,16 @@ def SplitInclusive : Prop :=
 
 variable [DecidableRel (⇑r)]
 
-instance : Decidable (SpecializedWe r) := by unfold SpecializedWe; infer_instance
-instance : Decidable (SpecializedInclusive r) := by
-  unfold SpecializedInclusive; infer_instance
-instance : Decidable (SpecializedExclusive r) := by
-  unfold SpecializedExclusive; infer_instance
-instance : Decidable (SplitInclusive r) := by unfold SplitInclusive; infer_instance
+instance : Decidable r.SpecializedWe := by unfold SpecializedWe; infer_instance
+instance : Decidable r.SpecializedInclusive := by unfold SpecializedInclusive; infer_instance
+instance : Decidable r.SpecializedExclusive := by unfold SpecializedExclusive; infer_instance
+instance : Decidable r.SplitInclusive := by unfold SplitInclusive; infer_instance
 
-end Questions
-
-/-- The five common marking types of the first person complex ([cysouw-2003] Table 3.2, the
-common five of the fifteen patterns of his Fig. 3.1). -/
-inductive System where
-  /-- No 'we' category has a specialized morpheme, as in the English inflection (Pb). -/
-  | noWe
-  /-- All three 'we' categories share one specialized morpheme, as English *we* (Pa). -/
-  | unifiedWe
-  /-- 1+2 and 1+2+3 share a specialized morpheme and 1+3 has none, as in Maká (Pc). -/
-  | onlyInclusive
-  /-- 1+2 and 1+2+3 share one specialized morpheme and 1+3 has another, as in Apalai (Pd). -/
-  | inclusiveExclusive
-  /-- All three 'we' categories have separate specialized morphemes, as Ilocano
-  *ta* ~ *tayo* ~ *mi* (Pe, his Fig. 3.6). -/
-  | minimalAugmented
-  deriving DecidableEq, Repr, Fintype
-
-namespace System
+end Pattern
 
 /-- Fig. 3.2's letters as morpheme classes, `0` being the class of the singular speaker,
 Fig. 3.1's dash, in which every category outside the first person complex is placed. -/
-def labels : System → Category → ℕ
+def labels : Clusivity → Category → ℕ
   | .unifiedWe, .minIncl | .unifiedWe, .augIncl | .unifiedWe, .excl => 1
   | .onlyInclusive, .minIncl | .onlyInclusive, .augIncl => 1
   | .inclusiveExclusive, .minIncl | .inclusiveExclusive, .augIncl => 1
@@ -111,45 +113,34 @@ def labels : System → Category → ℕ
   | _, _ => 0
 
 /-- The type's pattern, Fig. 3.2's column as a setoid on the four cells. -/
-abbrev pattern (t : System) : Setoid Cell := Setoid.ker (t.labels ∘ Subtype.val)
-
-/-- Some specialized 'we' morpheme exists. -/
-abbrev SpecializedWe (t : System) : Prop := Clusivity.SpecializedWe t.pattern
-
-/-- The inclusive has a specialized morpheme of its own. -/
-abbrev SpecializedInclusive (t : System) : Prop := Clusivity.SpecializedInclusive t.pattern
-
-/-- The exclusive has a specialized morpheme of its own. -/
-abbrev SpecializedExclusive (t : System) : Prop := Clusivity.SpecializedExclusive t.pattern
-
-/-- Minimal and augmented inclusive are marked apart. -/
-abbrev SplitInclusive (t : System) : Prop := Clusivity.SplitInclusive t.pattern
+abbrev toPattern (t : Clusivity) : Pattern := Setoid.ker (t.labels ∘ Subtype.val)
 
 /-- The five patterns are distinct. -/
-theorem pattern_injective : Function.Injective pattern := by
-  show ∀ s t : System, _ → _; decide +kernel
+theorem toPattern_injective : Function.Injective toPattern := by
+  show ∀ s t : Clusivity, _ → _; decide +kernel
 
 /-- A specialized exclusive requires a specialized inclusive ((3.23), Fig. 3.8). -/
-theorem specializedInclusive_of_specializedExclusive {t : System}
-    (h : t.SpecializedExclusive) : t.SpecializedInclusive := by
-  revert t h; show ∀ t : System, _; decide +kernel
+theorem specializedInclusive_of_specializedExclusive {t : Clusivity}
+    (h : t.toPattern.SpecializedExclusive) : t.toPattern.SpecializedInclusive := by
+  revert t h; show ∀ t : Clusivity, _; decide +kernel
 
 /-- The converse of (3.23) fails at only-inclusive. -/
-theorem onlyInclusive_specializedInclusive : onlyInclusive.SpecializedInclusive := by
+theorem onlyInclusive_specializedInclusive : onlyInclusive.toPattern.SpecializedInclusive := by
   decide +kernel
 
-theorem onlyInclusive_not_specializedExclusive : ¬ onlyInclusive.SpecializedExclusive := by
+theorem onlyInclusive_not_specializedExclusive :
+    ¬ onlyInclusive.toPattern.SpecializedExclusive := by
   decide +kernel
 
 /-- A split inclusive requires a specialized exclusive ((3.24), Fig. 3.9). -/
-theorem specializedExclusive_of_splitInclusive {t : System} (h : t.SplitInclusive) :
-    t.SpecializedExclusive := by
-  revert t h; show ∀ t : System, _; decide +kernel
+theorem specializedExclusive_of_splitInclusive {t : Clusivity}
+    (h : t.toPattern.SplitInclusive) : t.toPattern.SpecializedExclusive := by
+  revert t h; show ∀ t : Clusivity, _; decide +kernel
 
 /-- Position on the First Person Hierarchy (3.26), the number of Fig. 3.10's questions
 answered positively: no-we, unified-we, only-inclusive, inclusive/exclusive,
 minimal/augmented. -/
-def hierarchyRank : System → ℕ
+def hierarchyRank : Clusivity → ℕ
   | .noWe => 0
   | .unifiedWe => 1
   | .onlyInclusive => 2
@@ -157,26 +148,26 @@ def hierarchyRank : System → ℕ
   | .minimalAugmented => 4
 
 /-- The First Person Hierarchy (3.26) as the order on the types. -/
-instance : LinearOrder System := LinearOrder.lift' hierarchyRank (by decide)
+instance : LinearOrder Clusivity := LinearOrder.lift' hierarchyRank (by decide)
 
 /-- Each of Fig. 3.10's answers is monotone along the hierarchy, so each type's profile
 extends its predecessor's by one positive answer. -/
-theorem specializedWe_of_le {s t : System} (h : s ≤ t) (hs : s.SpecializedWe) :
-    t.SpecializedWe := by
-  revert s t h hs; show ∀ s t : System, _; decide +kernel
+theorem specializedWe_of_le {s t : Clusivity} (h : s ≤ t) (hs : s.toPattern.SpecializedWe) :
+    t.toPattern.SpecializedWe := by
+  revert s t h hs; show ∀ s t : Clusivity, _; decide +kernel
 
-theorem specializedInclusive_of_le {s t : System} (h : s ≤ t) (hs : s.SpecializedInclusive) :
-    t.SpecializedInclusive := by
-  revert s t h hs; show ∀ s t : System, _; decide +kernel
+theorem specializedInclusive_of_le {s t : Clusivity} (h : s ≤ t)
+    (hs : s.toPattern.SpecializedInclusive) : t.toPattern.SpecializedInclusive := by
+  revert s t h hs; show ∀ s t : Clusivity, _; decide +kernel
 
-theorem specializedExclusive_of_le {s t : System} (h : s ≤ t) (hs : s.SpecializedExclusive) :
-    t.SpecializedExclusive := by
-  revert s t h hs; show ∀ s t : System, _; decide +kernel
+theorem specializedExclusive_of_le {s t : Clusivity} (h : s ≤ t)
+    (hs : s.toPattern.SpecializedExclusive) : t.toPattern.SpecializedExclusive := by
+  revert s t h hs; show ∀ s t : Clusivity, _; decide +kernel
 
-theorem splitInclusive_of_le {s t : System} (h : s ≤ t) (hs : s.SplitInclusive) :
-    t.SplitInclusive := by
-  revert s t h hs; show ∀ s t : System, _; decide +kernel
+theorem splitInclusive_of_le {s t : Clusivity} (h : s ≤ t) (hs : s.toPattern.SplitInclusive) :
+    t.toPattern.SplitInclusive := by
+  revert s t h hs; show ∀ s t : Clusivity, _; decide +kernel
 
-end System
+end Clusivity
 
-end Person.Clusivity
+end Person

--- a/Linglib/Fragments/Tagalog/Plurals.lean
+++ b/Linglib/Fragments/Tagalog/Plurals.lean
@@ -52,7 +52,7 @@ underdetermines Tagalog's actual paradigm: *kata* (1+2 minimal-inclusive,
 the "we two" form per S&O Chart 7 p. 88), *tayo* (1+2 augmented-inclusive
 covering any 1+2+others grouping per S&O p. 89 — not specifically 1+2+3),
 and *kami* (1+3 exclusive) instantiate Cysouw's *minimal-augmented* type
-(see `Tagalog.clusivitySystem` in
+(see `Tagalog.clusivity` in
 `Fragments/Tagalog/Pronouns.lean`). The full Table 12.2 paradigm from
 [himmelmann-2005-tagalog] is also documented there.
 -/

--- a/Linglib/Fragments/Tagalog/Pronouns.lean
+++ b/Linglib/Fragments/Tagalog/Pronouns.lean
@@ -64,7 +64,7 @@ namespace Tagalog
     lost the dual; this field reflects the textbook paradigm, not
     colloquial usage. Refines the binary WALS Ch 39 value
     `Pronoun.inclusiveExclusive "tgl"` (derived from `Data.WALS`). -/
-def clusivitySystem : Person.Clusivity.System := .minimalAugmented
+def clusivity : Person.Clusivity := .minimalAugmented
 
 -- ============================================================================
 -- Pronoun paradigm (person + number + clusivity, three case series)
@@ -146,8 +146,8 @@ theorem minimal_augmented :
 /-- Cross-substrate consistency: the inventory contains a minimal-inclusive
     (dual inclusive) form iff the language commits to the minimal-augmented
     clusivity system. -/
-theorem clusivity_system_consistent :
-    (∃ p ∈ pronouns, p.category = some .minIncl) ↔ clusivitySystem.SplitInclusive := by
+theorem clusivity_consistent :
+    (∃ p ∈ pronouns, p.category = some .minIncl) ↔ clusivity.toPattern.SplitInclusive := by
   decide
 
 /-- Every Tagalog pronoun is well-formed: clusivity is borne only by the
@@ -160,6 +160,6 @@ theorem all_wellFormed : pronouns.all (fun p => decide p.WellFormed) = true := b
     between WALS and the clusivity commitment. -/
 theorem wals_clusivity_consistent :
     Pronoun.inclusiveExclusive "tgl" =
-      some (Pronoun.InclusiveExclusive.fromClusivity clusivitySystem) := by decide
+      some (Pronoun.InclusiveExclusive.fromClusivity clusivity) := by decide
 
 end Tagalog

--- a/Linglib/Studies/Cysouw2003.lean
+++ b/Linglib/Studies/Cysouw2003.lean
@@ -54,7 +54,7 @@ explicitness hierarchy.
 
 namespace Cysouw2003
 
-open Person Person.Clusivity Morphology
+open Person Morphology
 
 variable (s : Setoid Category)
 
@@ -96,12 +96,12 @@ def Specialized (c : Category) : Prop := ∀ x : Category, x.IsSingular → ¬ s
 
 /-- Fig. 3.1's reading of two speaker cells as alike: both specialized and syncretic, or
 neither specialized. -/
-def WeRel (a b : Cell) : Prop :=
+def WeRel (a b : Clusivity.Cell) : Prop :=
   (Specialized s a ∧ Specialized s b ∧ s a b) ∨ (¬ Specialized s a ∧ ¬ Specialized s b)
 
 /-- Fig. 3.1's pattern of a structure, its speaker cells grouped by `WeRel`; the dash class is
 the speaker's. -/
-def wePattern : Setoid Cell where
+@[instance_reducible] def wePattern : Clusivity.Pattern where
   r := WeRel s
   iseqv :=
     { refl := λ a => by
@@ -119,7 +119,7 @@ def wePattern : Setoid Cell where
         · exact .inr ⟨ha, hc⟩ }
 
 /-- The structure is of the common type `t`. -/
-abbrev HasSystem (t : Clusivity.System) : Prop := wePattern s = t.pattern
+abbrev HasClusivity (t : Clusivity) : Prop := wePattern s = t.toPattern
 
 /-! ### The Horizontal Homophony Hierarchy (§4.7, §10.1.4) -/
 
@@ -132,9 +132,9 @@ def RespectsHorizontalHierarchy : Prop :=
       b.person.prominence ≤ a.person.prominence → HorizontalHomophonyAt s b
 
 variable {s} in
-theorem HasSystem.unique {t t' : Clusivity.System} (h : HasSystem s t) (h' : HasSystem s t') :
+theorem HasClusivity.unique {t t' : Clusivity} (h : HasClusivity s t) (h' : HasClusivity s t') :
     t = t' :=
-  Clusivity.System.pattern_injective (h.symm.trans h')
+  Clusivity.toPattern_injective (h.symm.trans h')
 
 variable [DecidableRel (⇑s)]
 
@@ -247,7 +247,7 @@ def labels : RarePattern → Category → ℕ
   | _, _ => 0
 
 /-- The rare pattern as a setoid on the four cells. -/
-abbrev pattern (q : RarePattern) : Setoid Cell := Setoid.ker (q.labels ∘ Subtype.val)
+abbrev pattern (q : RarePattern) : Clusivity.Pattern := Setoid.ker (q.labels ∘ Subtype.val)
 
 /-- The rare patterns are distinct from each other. -/
 theorem pattern_injective : Function.Injective pattern := by
@@ -255,7 +255,7 @@ theorem pattern_injective : Function.Injective pattern := by
 
 /-- The rare patterns are distinct from the common types, so ten of the fifteen patterns are
 attested (Figs. 3.1–3.2). -/
-theorem pattern_ne (q : RarePattern) (t : Clusivity.System) : q.pattern ≠ t.pattern := by
+theorem pattern_ne (q : RarePattern) (t : Clusivity) : q.pattern ≠ t.toPattern := by
   revert q t; decide +kernel
 
 end RarePattern
@@ -311,12 +311,12 @@ theorem pattern_injective : Function.Injective pattern := by
 /-- Their first person complexes (Fig. 4.4): the Maricopa type has no 'we', the Sierra
 Popoluca type only an inclusive, the Maranao type a minimal/augmented one, the other types
 with an inclusive/exclusive opposition are inclusive/exclusive and the rest unified. -/
-theorem hasSystem_pattern :
-    HasSystem maricopa.pattern .noWe ∧ HasSystem sierraPopoluca.pattern .onlyInclusive ∧
-    HasSystem maranao.pattern .minimalAugmented ∧
-    (∀ k ∈ [mandara, tupiGuarani, kwakiutl], HasSystem k.pattern .inclusiveExclusive) ∧
+theorem hasClusivity_pattern :
+    HasClusivity maricopa.pattern .noWe ∧ HasClusivity sierraPopoluca.pattern .onlyInclusive ∧
+    HasClusivity maranao.pattern .minimalAugmented ∧
+    (∀ k ∈ [mandara, tupiGuarani, kwakiutl], HasClusivity k.pattern .inclusiveExclusive) ∧
     ∀ k ∈ [latin, sinhalese, berik, slave, nezPerce, kombai, omie],
-      HasSystem k.pattern .unifiedWe := by
+      HasClusivity k.pattern .unifiedWe := by
   decide +kernel
 
 /-- Every named structure respects the horizontal hierarchy. -/
@@ -400,7 +400,7 @@ namespace Row
 abbrev syncretism (r : Row) : Setoid Category := Morphology.syncretism r.forms
 
 /-- The row's pattern of the first person complex. -/
-abbrev wePattern (r : Row) : Setoid Cell := Cysouw2003.wePattern r.syncretism
+abbrev wePattern (r : Row) : Clusivity.Pattern := Cysouw2003.wePattern r.syncretism
 
 /-- A feature that may be absent but, when present, must parse. -/
 private def optional? {α : Type*} (e : Data.Examples.LinguisticExample) (key : String)
@@ -448,19 +448,20 @@ theorem rows_rare : ∀ r ∈ rows, ∀ q, r.rare = some q → r.wePattern = q.p
 
 /-- Every chapter-4 paradigm has one of the five common types, §4.2 having set the rare
 patterns aside. -/
-theorem rows_hasSystem : ∀ r ∈ rows, r.chapter = 4 → ∃ t, HasSystem r.syncretism t := by
+theorem rows_hasClusivity :
+    ∀ r ∈ rows, r.chapter = 4 → ∃ t, HasClusivity r.syncretism t := by
   decide +kernel
 
 /-- Addressee inclusion implication I (3.23) over the printed paradigms, Binandere the one
 exception. -/
 theorem rows_specializedInclusive_of_specializedExclusive :
     ∀ r ∈ rows, r.rare ≠ some .pj →
-      SpecializedExclusive r.wePattern → SpecializedInclusive r.wePattern := by
+      r.wePattern.SpecializedExclusive → r.wePattern.SpecializedInclusive := by
   decide +kernel
 
 theorem binandere :
-    ∃ r ∈ rows, r.rare = some .pj ∧ SpecializedExclusive r.wePattern ∧
-      ¬ SpecializedInclusive r.wePattern := by
+    ∃ r ∈ rows, r.rare = some .pj ∧ r.wePattern.SpecializedExclusive ∧
+      ¬ r.wePattern.SpecializedInclusive := by
   decide +kernel
 
 /-- Addressee inclusion implication II (3.24) over the printed paradigms. Its exceptions are
@@ -468,17 +469,17 @@ the rare patterns that mark the two inclusives apart: (Pf) and (Pg), which the b
 and (Ph), whose paradigm (3.20) the book's list overlooks. -/
 theorem rows_specializedExclusive_of_splitInclusive :
     ∀ r ∈ rows, (r.rare = none ∨ r.rare = some .pi ∨ r.rare = some .pj) →
-      SplitInclusive r.wePattern → SpecializedExclusive r.wePattern := by
+      r.wePattern.SplitInclusive → r.wePattern.SpecializedExclusive := by
   decide +kernel
 
 theorem rows_splitInclusive_not_specializedExclusive :
     ∀ r ∈ rows, (r.rare = some .pf ∨ r.rare = some .pg ∨ r.rare = some .ph) →
-      SplitInclusive r.wePattern ∧ ¬ SpecializedExclusive r.wePattern := by
+      r.wePattern.SplitInclusive ∧ ¬ r.wePattern.SpecializedExclusive := by
   decide +kernel
 
 /-- The strong universal 'we' (3.7) fails: the English inflection (4.68) has no 'we'. -/
 theorem english_inflection_noWe :
-    ∃ r ∈ rows, r.id = "cysouw2003_4.68" ∧ HasSystem r.syncretism .noWe := by
+    ∃ r ∈ rows, r.id = "cysouw2003_4.68" ∧ HasClusivity r.syncretism .noWe := by
   decide +kernel
 
 /-- The Homophony Implication (2.14), (10.4) over the printed paradigms: singular homophony
@@ -529,7 +530,8 @@ theorem rows_rare_of_verticalHomophony_inclusiveExclusive :
 /-- Fig. 10.4's exemplars occupy the five rungs: the Waskia present (4.66), the Una undergoer
 suffixes (4.64), then the Latin, Mandara and Maranao types. -/
 theorem explicitness_fig10_4 :
-    ∃ waskia ∈ rows, ∃ una ∈ rows, waskia.id = "cysouw2003_4.66" ∧ una.id = "cysouw2003_4.64" ∧
+    ∃ waskia ∈ rows, ∃ una ∈ rows,
+      waskia.id = "cysouw2003_4.66" ∧ una.id = "cysouw2003_4.64" ∧
       explicitness waskia.syncretism = some .singularHomophony ∧
       explicitness una.syncretism = some .verticalHomophony ∧
       explicitness Kind.latin.pattern = some (.we .unified) ∧

--- a/Linglib/Syntax/Category/Pronoun/WALS.lean
+++ b/Linglib/Syntax/Category/Pronoun/WALS.lean
@@ -380,10 +380,10 @@ end Pronoun
 namespace Pronoun
 
 /-- WALS Ch 39 image of a Cysouw first-person-complex type
-    (`Person.Clusivity.System`): WALS Ch 39 (Cysouw's own chapter)
+    (`Person.Clusivity`): WALS Ch 39 (Cysouw's own chapter)
     collapses the minimal/augmented split, so the map is many-to-one —
     given a WALS value, the paradigm type is underdetermined. -/
-def InclusiveExclusive.fromClusivity : Person.Clusivity.System → InclusiveExclusive
+def InclusiveExclusive.fromClusivity : Person.Clusivity → InclusiveExclusive
   | .noWe                => .noWe
   | .unifiedWe           => .noDistinction
   | .onlyInclusive       => .onlyInclusive


### PR DESCRIPTION
Follow-up to #2748: the clusivity marking type is `Person.Clusivity` itself, so `open Person` reaches everything and `Person.System` (the person inventory) no longer shares a name with it.

- `Clusivity.Cell` and `Clusivity.Pattern := Setoid Cell` sit under the type; Fig. 3.10's four questions are dot-notation members of `Pattern`, and each type's pattern is `t.toPattern`.
- Cysouw2003 opens only `Person Morphology`; `HasSystem` becomes `HasClusivity`, rows theorems read `r.wePattern.SplitInclusive`.
- Tagalog's `clusivitySystem` becomes `clusivity : Person.Clusivity`; WALS bridge and docstrings updated.