### PR TITLE
refactor(Studies/DAmbrosioHedden2024): the paper's aggregation framework

### DIFF
--- a/Linglib/Semantics/Degree/Aggregation.lean
+++ b/Linglib/Semantics/Degree/Aggregation.lean
@@ -1,87 +1,458 @@
-import Mathlib.Data.Rat.Defs
-import Mathlib.Algebra.Order.Ring.Rat
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Field.Basic
-import Linglib.Semantics.Degree.Adjective
+import Mathlib.Algebra.Order.Ring.Rat
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Matrix.Mul
+import Mathlib.Order.Antisymmetrization
+import Mathlib.Order.Defs.Unbundled
+import Linglib.Core.Order.TotalPreorder
 
 /-!
-# Dimensional Aggregation for Multidimensional Predicates
-[dambrosio-hedden-2024] [sassoon-2013] [waldon-etal-2023]
-[sassoon-fadlon-2017] [tham-2025] [solt-2018-proportional]
+# Dimensional aggregation
 
-General mechanisms for combining dimensional assessments into overall
-predicate application. These apply to any multi-dimensional predicate —
-gradable adjectives (Sassoon, D'Ambrosio-Hedden), artifact nouns
-(Waldon, Sassoon-Fadlon), disturbance predicates (Tham), and
-proportional measures for vague quantity expressions (Solt).
+A multidimensional predicate applies to an object, or ranks two objects, according to how the
+objects stand on several underlying dimensions. Two aggregation vocabularies share this file.
 
-Aggregation is analogous to preference aggregation in social choice theory.
-Arrow's impossibility theorem and its escape routes characterize the
-available aggregation functions:
+*Rules*, in the value-function framework of [sen-1970] as [dambrosio-hedden-2024] transposes it
+to dimensions: a profile assigns each object its vector of dimensional values, and a rule sends
+profiles to an overall relation on the objects, read `x ⪰ y`. Sen's informational requirements
+are invariance under a class of transformation vectors (strictly increasing maps, common-unit
+positive affine maps, similarities). Arrow's conditions ([arrow-1950]) and the strong Pareto,
+Pareto-indifference and anonymity conditions are predicates on rules. Four classical rules are
+stated with the conditions they meet or fail: majority ([may-1952]) meets every Arrow condition
+but weak-ordering outputs, which Condorcet's cycle refutes; the Pareto rule ([weymark-1984]) is
+a quasi-ordering that leaves every trade-off incomparable; the utilitarian rule meets every
+Arrow condition but ordinal invariance, failing even ratio-scale invariance; the Cobb–Douglas
+rule ([tsui-weymark-1997]) is ratio-scale invariant on non-negative profiles.
 
-- **Counting** (§1): x is F iff ≥k dimensions are satisfied.
-  Subsumes Sassoon's conjunctive (k=n) and disjunctive (k=1).
-- **Majority** (§1): x is F iff a strict majority of dimensions are satisfied.
-- **Weighted** (§2): x is F iff Σᵢ wᵢ·fᵢ(x) ≥ θ (utilitarian aggregation).
-  Subsumes Waldon et al.'s eq. 8.
-- **Spatially-normalized weighted** (§2): x is F iff (Σᵢ wᵢ·fᵢ(x)) / s(x) ≥ θ,
-  where s : α → K is a host-extent measure on an ordered field `K`. Tham 2025's eq. 47b for
-  physical disturbance adjectives.
-- **Multiplicative** (§4): x is F iff Πᵢ fᵢ(x) ≥ θ (Cobb-Douglas aggregation).
-  Sassoon-Fadlon argue natural kinds compose multiplicatively.
+*Scores* for the positive form: a weighted sum of dimensional measures ([waldon-etal-2023]),
+its normalisation by the host's spatial extent ([tham-2025], [solt-2018-proportional]), and
+the multiplicative composition of [sassoon-fadlon-2017].
 
-Plus §6 Sassoon 2013 subsumption theorems showing all binding types
-reduce to counting aggregation.
+## Implementation notes
+
+* A rule is total on profiles, so Arrow's unrestricted-domain condition is built in; a domain
+  restriction, such as the non-negative profiles the Cobb–Douglas rule needs, is a hypothesis
+  of the statement.
+* Outputs are bare relations, because majority rule is not transitive; a weak-ordering-valued
+  rule bundles into `Core.Order.TotalPreorder`. `AsymmRel` is the strict part of a relation and
+  mathlib's `AntisymmRel` its indifference part.
+
+## TODO
+
+* The scores index dimensions by lists. Restating them over `ι → K`, so that the utilitarian
+  rule compares `weightedScore`s, awaits the cleanse of their consumers.
+
+## References
+
+* [K. J. Arrow, *A difficulty in the concept of social welfare* (1951)][arrow-1950]
+* [J. D'Ambrosio and B. Hedden, *Multidimensional adjectives* (2024)][dambrosio-hedden-2024]
+* [K. O. May, *A set of independent necessary and sufficient conditions for simple majority
+  decision* (1952)][may-1952]
+* [G. W. Sassoon and J. Fadlon, *The role of dimensions in classification under predicates
+  predicts their status in degree constructions* (2017)][sassoon-fadlon-2017]
+* [A. K. Sen, *Collective choice and social welfare* (1970)][sen-1970]
+* [S. Solt, *Proportional comparatives and relative scales* (2018)][solt-2018-proportional]
+* [S. W. Tham, *Multidimensionality and the scalar components of physical disturbance
+  predicates* (2025)][tham-2025]
+* [K.-Y. Tsui and J. A. Weymark, *Social welfare orderings for ratio-scale measurable
+  utilities* (1997)][tsui-weymark-1997]
+* [B. Waldon, C. Condoravdi, B. Levin and J. Degen, *On the context dependence of artifact
+  noun interpretation* (2023)][waldon-etal-2023]
+* [J. A. Weymark, *Arrow's theorem with social quasi-orderings* (1984)][weymark-1984]
 -/
+
+/-- The asymmetric part of a relation: `r a b` and not `r b a`. Mathlib's `AntisymmRel r` is
+the symmetric part. -/
+def AsymmRel {α : Type*} (r : α → α → Prop) (a b : α) : Prop := r a b ∧ ¬ r b a
+
+instance {α : Type*} (r : α → α → Prop) [DecidableRel r] (a b : α) :
+    Decidable (AsymmRel r a b) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
 namespace Degree.Aggregation
 
-variable {α K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+open Finset
 
-/-! ### Counting Aggregation -/
+variable {ι α K : Type*}
 
-/-- Counting aggregation: x satisfies the predicate iff at least `k` of
-    the dimension predicates in `dims` return `true` for `x`.
+/-- A profile: each object's vector of values, one per dimension. -/
+abbrev Profile (ι α K : Type*) := α → ι → K
 
-    Generalizes [sassoon-2013]'s binding types:
-    - `k = dims.length` → conjunctive (∀ dims)
-    - `k = 1` → disjunctive (∃ dim)
-    - intermediate `k` → mixed / "dimension counting" -/
-def countBinding (k : Nat) (dims : List (α → Bool)) (x : α) : Bool :=
-  decide ((dims.filter (fun d => d x)).length ≥ k)
+/-- An aggregation rule: a relation on the objects, read `x ⪰ y`, for each profile. -/
+abbrev Rule (ι α K : Type*) := Profile ι α K → α → α → Prop
 
-/-- Majority binding: x satisfies the predicate iff a strict majority
-    of dimensions are satisfied. May's theorem (1952) characterizes this
-    as the unique aggregation rule satisfying neutrality, anonymity, and
-    positive responsiveness. -/
-def majorityBinding (dims : List (α → Bool)) (x : α) : Bool :=
-  decide (2 * (dims.filter (fun d => d x)).length > dims.length)
+/-- Apply a vector of transformations, one per dimension, to a profile. -/
+def Profile.transform (f : ι → K → K) (v : Profile ι α K) : Profile ι α K :=
+  λ x i => f i (v x i)
 
-/-! ### Weighted Aggregation (over an ordered field) -/
+/-! ### Informational invariance -/
+
+/-- Invariance of a rule under a class of transformation vectors. -/
+def Invariant (T : Set (ι → K → K)) (a : Rule ι α K) : Prop :=
+  ∀ f ∈ T, ∀ v, a (v.transform f) = a v
+
+theorem Invariant.mono {S T : Set (ι → K → K)} (h : S ⊆ T) {a : Rule ι α K}
+    (ha : Invariant T a) : Invariant S a :=
+  λ f hf => ha f (h hf)
+
+/-- Vectors of strictly increasing transformations; invariance under them is ordinal
+non-comparability. -/
+def ordinal [Preorder K] : Set (ι → K → K) := {f | ∀ i, StrictMono (f i)}
+
+section Cardinal
+
+variable [Semiring K] [PartialOrder K]
+
+/-- Common-unit positive affine transformation vectors; invariance under them is cardinal unit
+comparability. -/
+def cardinalUnit : Set (ι → K → K) :=
+  {f | ∃ a : K, 0 < a ∧ ∃ b : ι → K, ∀ i t, f i t = a * t + b i}
+
+/-- Similarity transformation vectors; invariance under them is ratio-scale
+non-comparability. -/
+def ratio : Set (ι → K → K) := {f | ∃ a : ι → K, (∀ i, 0 < a i) ∧ ∀ i t, f i t = a i * t}
+
+variable [IsStrictOrderedRing K]
+
+theorem cardinalUnit_subset_ordinal : cardinalUnit ⊆ (ordinal : Set (ι → K → K)) := by
+  rintro f ⟨a, ha, b, hf⟩ i s t hst
+  simp only [hf]
+  exact add_lt_add_left (mul_lt_mul_of_pos_left hst ha) _
+
+theorem ratio_subset_ordinal : ratio ⊆ (ordinal : Set (ι → K → K)) := by
+  rintro f ⟨a, ha, hf⟩ i s t hst
+  simp only [hf]
+  exact mul_lt_mul_of_pos_left hst (ha i)
+
+end Cardinal
+
+/-! ### Conditions on rules -/
+
+section Conditions
+
+variable (a : Rule ι α K)
+
+/-- Pareto indifference: objects with the same vector of values are indifferent. -/
+def ParetoIndifferent : Prop := ∀ v x y, v x = v y → AntisymmRel (a v) x y
+
+/-- Independence of irrelevant alternatives: the verdict on a pair depends only on the vectors
+of that pair. -/
+def Independent : Prop := ∀ v w x y, v x = w x → v y = w y → (a v x y ↔ a w x y)
+
+/-- Every output is transitive. -/
+def Transitive : Prop := ∀ v, IsTrans α (a v)
+
+/-- Every output is complete. -/
+def Complete : Prop := ∀ v, Std.Total (a v)
+
+/-- Every output is a weak ordering, a complete preorder. -/
+def WeakOrderValued : Prop := Transitive a ∧ Complete a
+
+/-- Every output is a quasi-ordering, a preorder. -/
+def QuasiOrderValued : Prop := ∀ v, IsPreorder α (a v)
+
+/-- Anonymity: permuting the dimensions leaves the output unchanged. -/
+def Anonymous : Prop := ∀ (σ : Equiv.Perm ι) v, a (λ x => v x ∘ σ) = a v
+
+variable {a}
+
+/-- The output of a weak-ordering-valued rule at a profile, as a bundled total preorder. -/
+def WeakOrderValued.toTotalPreorder (h : WeakOrderValued a) (v : Profile ι α K) :
+    Core.Order.TotalPreorder α :=
+  haveI := h.1 v
+  haveI := h.2 v
+  ⟨a v, IsPreorder.mk, h.2 v⟩
+
+theorem WeakOrderValued.lt_toTotalPreorder (h : WeakOrderValued a) (v : Profile ι α K) :
+    (h.toTotalPreorder v).lt = AsymmRel (a v) :=
+  rfl
+
+theorem WeakOrderValued.quasiOrderValued (h : WeakOrderValued a) : QuasiOrderValued a :=
+  λ v =>
+    haveI := h.1 v
+    haveI := h.2 v
+    IsPreorder.mk
+
+variable (a) [Preorder K]
+
+/-- Weak Pareto: an object ranked strictly above another on every dimension is strictly
+preferred. -/
+def WeakPareto : Prop := ∀ v x y, (∀ i, v y i < v x i) → AsymmRel (a v) x y
+
+/-- Strong Pareto: an object ranked weakly above another on every dimension is weakly
+preferred, and strictly so if some dimension ranks it strictly above. -/
+def StrongPareto : Prop :=
+  ∀ v x y, v y ≤ v x → a v x y ∧ ((∃ i, v y i < v x i) → AsymmRel (a v) x y)
+
+/-- Dimension `i` is a dictator: its strict rankings are the strict overall rankings. -/
+def IsDictator (i : ι) : Prop := ∀ v x y, v y i < v x i → AsymmRel (a v) x y
+
+/-- No dimension is a dictator. -/
+def NonDictatorial : Prop := ∀ i, ¬ IsDictator a i
+
+end Conditions
+
+/-! ### Majority rule -/
+
+section Majority
+
+variable [Fintype ι] [LinearOrder K]
+
+/-- Majority rule: `x ⪰ y` iff at least as many dimensions rank `x` weakly above `y` as rank
+`y` weakly above `x`. -/
+def majority : Rule ι α K := λ v x y => #{i | v x i ≤ v y i} ≤ #{i | v y i ≤ v x i}
+
+instance (v : Profile ι α K) : DecidableRel (majority v) := λ _ _ => by
+  unfold majority; infer_instance
+
+theorem majority_weakPareto [Nonempty ι] : WeakPareto (majority : Rule ι α K) := by
+  intro v x y h
+  have h₁ : ({i | v x i ≤ v y i} : Finset ι) = ∅ := filter_false_of_mem λ i _ => (h i).not_ge
+  have h₂ : ({i | v y i ≤ v x i} : Finset ι) = univ := filter_true_of_mem λ i _ => (h i).le
+  simp [AsymmRel, majority, h₁, h₂, Fintype.card_ne_zero]
+
+theorem majority_independent : Independent (majority : Rule ι α K) := by
+  intro v w x y hx hy
+  simp only [majority, hx, hy]
+
+theorem majority_ordinalInvariant : Invariant ordinal (majority : Rule ι α K) := by
+  intro f hf v
+  funext x y
+  simp only [majority, Profile.transform, (hf _).le_iff_le]
+
+theorem majority_anonymous : Anonymous (majority : Rule ι α K) := by
+  intro σ v
+  funext x y
+  have h : ∀ z w : α, #{i | v z (σ i) ≤ v w (σ i)} = #{i | v z i ≤ v w i} :=
+    λ z w => card_equiv σ (by simp)
+  simp only [majority, Function.comp_apply, h]
+
+theorem majority_paretoIndifferent : ParetoIndifferent (majority : Rule ι α K) := by
+  intro v x y h
+  simp [AntisymmRel, majority, h]
+
+theorem majority_nonDictatorial [Nontrivial ι] [Nontrivial α] [Nontrivial K] :
+    NonDictatorial (majority : Rule ι α K) := by
+  intro i hi
+  obtain ⟨j, hj⟩ := exists_ne i
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne α
+  obtain ⟨k, k', hk⟩ : ∃ k k' : K, k < k' := by
+    obtain ⟨k, k', h⟩ := exists_pair_ne K
+    exact h.lt_or_gt.elim (λ h => ⟨k, k', h⟩) (λ h => ⟨k', k, h⟩)
+  classical
+  let v : Profile ι α K := λ z l => if (z = x ∧ l = i) ∨ (z = y ∧ l = j) then k' else k
+  have hv : v y i < v x i := by simp [v, hxy.symm, hj.symm, hk]
+  have e₁ : ({l | v x l ≤ v y l} : Finset ι) = univ.erase i := by
+    rw [← filter_ne']
+    refine filter_congr λ l _ => ?_
+    by_cases hl : l = i <;> by_cases hl' : l = j <;>
+      simp [v, hl, hl', hxy, hxy.symm, hj, hj.symm, hk.le, hk.not_ge]
+  have e₂ : ({l | v y l ≤ v x l} : Finset ι) = univ.erase j := by
+    rw [← filter_ne']
+    refine filter_congr λ l _ => ?_
+    by_cases hl : l = i <;> by_cases hl' : l = j <;>
+      simp [v, hl, hl', hxy, hxy.symm, hj, hj.symm, hk.le, hk.not_ge]
+  have hcard : #(univ.erase i) = #(univ.erase j) := by
+    rw [card_erase_of_mem (mem_univ _), card_erase_of_mem (mem_univ _)]
+  have := hi v x y hv
+  simp only [AsymmRel, majority, e₁, e₂, hcard, le_refl, not_true, and_false] at this
+
+/-- Condorcet's profile: three dimensions ranking three objects cyclically. -/
+def condorcet : Profile (Fin 3) (Fin 3) ℕ := ![![2, 0, 1], ![1, 2, 0], ![0, 1, 2]]
+
+/-- Condorcet's paradox: majority rule ranks the three objects in a strict cycle. -/
+theorem majority_condorcet :
+    AsymmRel (majority condorcet) 0 1 ∧ AsymmRel (majority condorcet) 1 2 ∧
+      AsymmRel (majority condorcet) 2 0 := by
+  decide
+
+/-- Majority rule does not output transitive relations. -/
+theorem not_transitive_majority : ¬ Transitive (majority : Rule (Fin 3) (Fin 3) ℕ) := by
+  intro h
+  obtain ⟨h₀₁, h₁₂, h₂₀⟩ := majority_condorcet
+  exact h₂₀.2 ((h condorcet).trans 0 1 2 h₀₁.1 h₁₂.1)
+
+end Majority
+
+/-! ### The Pareto rule -/
+
+section Pareto
+
+variable [Preorder K]
+
+/-- The Pareto rule: `x ⪰ y` iff every dimension ranks `x` weakly above `y`. -/
+def paretoRule : Rule ι α K := λ v x y => v y ≤ v x
+
+theorem paretoRule_quasiOrderValued : QuasiOrderValued (paretoRule : Rule ι α K) :=
+  λ _ => { refl := λ _ => le_rfl, trans := λ _ _ _ h h' => h'.trans h }
+
+theorem paretoRule_strongPareto : StrongPareto (paretoRule : Rule ι α K) :=
+  λ _ _ _ h => ⟨h, λ ⟨i, hi⟩ => ⟨h, λ h' => (h' i).not_gt hi⟩⟩
+
+theorem paretoRule_paretoIndifferent : ParetoIndifferent (paretoRule : Rule ι α K) :=
+  λ _ _ _ h => ⟨h.ge, h.le⟩
+
+theorem paretoRule_independent : Independent (paretoRule : Rule ι α K) := by
+  intro v w x y hx hy
+  simp only [paretoRule, hx, hy]
+
+theorem paretoRule_anonymous : Anonymous (paretoRule : Rule ι α K) := by
+  intro σ v
+  funext x y
+  simp only [paretoRule, Pi.le_def, Function.comp_apply]
+  exact propext ⟨λ h i => by simpa using h (σ.symm i), λ h i => h _⟩
+
+/-- A trade-off, one dimension ranking `x` strictly above `y` and another `y` above `x`, is
+incomparable under the Pareto rule. -/
+theorem paretoRule_incomparable {v : Profile ι α K} {x y : α} {i j : ι} (hi : v y i < v x i)
+    (hj : v x j < v y j) : ¬ paretoRule v x y ∧ ¬ paretoRule v y x :=
+  ⟨λ h => (h j).not_gt hj, λ h => (h i).not_gt hi⟩
+
+end Pareto
+
+theorem paretoRule_ordinalInvariant [LinearOrder K] :
+    Invariant ordinal (paretoRule : Rule ι α K) := by
+  intro f hf v
+  funext x y
+  simp only [paretoRule, Profile.transform, Pi.le_def, (hf _).le_iff_le]
+
+/-! ### The utilitarian rule -/
+
+section Utilitarian
+
+variable [Fintype ι] [Field K] [LinearOrder K]
+
+/-- The utilitarian rule with weights `c`: `x ⪰ y` iff the weighted sum of values favours
+`x`. -/
+def utilitarian (c : ι → K) : Rule ι α K := λ v x y => c ⬝ᵥ v y ≤ c ⬝ᵥ v x
+
+variable (c : ι → K)
+
+theorem utilitarian_weakOrderValued : WeakOrderValued (utilitarian c : Rule ι α K) :=
+  ⟨λ _ => ⟨λ _ _ _ h h' => h'.trans h⟩, λ _ => ⟨λ _ _ => le_total _ _⟩⟩
+
+theorem utilitarian_paretoIndifferent : ParetoIndifferent (utilitarian c : Rule ι α K) := by
+  intro v x y h
+  simp [AntisymmRel, utilitarian, h]
+
+theorem utilitarian_independent : Independent (utilitarian c : Rule ι α K) := by
+  intro v w x y hx hy
+  simp only [utilitarian, hx, hy]
+
+variable [IsStrictOrderedRing K]
+
+theorem utilitarian_weakPareto (hc : ∀ i, 0 ≤ c i) (hpos : ∃ i, 0 < c i) :
+    WeakPareto (utilitarian c : Rule ι α K) := by
+  intro v x y h
+  obtain ⟨i, hi⟩ := hpos
+  have : c ⬝ᵥ v y < c ⬝ᵥ v x :=
+    sum_lt_sum (λ i _ => mul_le_mul_of_nonneg_left (h i).le (hc i))
+      ⟨i, mem_univ _, mul_lt_mul_of_pos_left (h i) hi⟩
+  exact ⟨this.le, this.not_ge⟩
+
+theorem utilitarian_cardinalUnitInvariant :
+    Invariant cardinalUnit (utilitarian c : Rule ι α K) := by
+  rintro f ⟨s, hs, b, hf⟩ v
+  funext x y
+  have key : ∀ z, (v.transform f) z = s • v z + b := λ z => funext λ i => by
+    simp [Profile.transform, hf]
+  simp only [utilitarian, key, dotProduct_add, dotProduct_smul, smul_eq_mul,
+    add_le_add_iff_right, mul_le_mul_iff_of_pos_left hs]
+
+theorem utilitarian_nonDictatorial [Nontrivial α] (h₂ : ∀ i, ∃ j, j ≠ i ∧ 0 < c j) :
+    NonDictatorial (utilitarian c : Rule ι α K) := by
+  intro i hi
+  obtain ⟨j, hji, hj⟩ := h₂ i
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne α
+  classical
+  let v : Profile ι α K := λ z =>
+    if z = x then Pi.single i (c j) else if z = y then Pi.single j (c i + c j) else 0
+  have hv : v y i < v x i := by simp [v, hxy.symm, hji.symm, hj]
+  have hx : c ⬝ᵥ v x = c i * c j := by simp [v]
+  have hy : c ⬝ᵥ v y = c j * (c i + c j) := by simp [v, hxy.symm]
+  have := (hi v x y hv).1
+  simp only [utilitarian, hx, hy, mul_add, mul_comm (c j) (c i)] at this
+  exact (lt_add_of_pos_right _ (mul_pos hj hj)).not_ge this
+
+/-- With two positive weights the utilitarian rule is not even ratio-scale invariant: rescaling
+one dimension breaks a tie. -/
+theorem not_ratioInvariant_utilitarian [Nontrivial α] {i j : ι} (hij : i ≠ j) (hi : 0 < c i)
+    (hj : 0 < c j) : ¬ Invariant ratio (utilitarian c : Rule ι α K) := by
+  intro h
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne α
+  classical
+  let v : Profile ι α K := λ z =>
+    if z = x then Pi.single i (c j) else if z = y then Pi.single j (c i) else 0
+  let f : ι → K → K := λ l t => if l = j then 2 * t else t
+  have hf : f ∈ ratio := ⟨λ l => if l = j then 2 else 1,
+    λ l => by dsimp only; split_ifs <;> norm_num, λ l t => by simp only [f]; split_ifs <;> simp⟩
+  have hx : (v.transform f) x = Pi.single i (c j) := funext λ l => by
+    simp only [Profile.transform, v, f, if_true, Pi.single_apply]
+    split_ifs <;> simp_all
+  have hy : (v.transform f) y = Pi.single j (2 * c i) := funext λ l => by
+    simp only [Profile.transform, v, f, hxy.symm, if_false, if_true, Pi.single_apply]
+    split_ifs <;> simp_all
+  have := congrFun (congrFun (h f hf v) x) y
+  simp only [utilitarian, hx, hy, v, if_true, hxy.symm, if_false, dotProduct_single,
+    mul_comm (c j) (c i), eq_iff_iff] at this
+  have hpos := mul_pos hi hj
+  exact (this.2 le_rfl).not_gt (by linarith)
+
+theorem not_ordinalInvariant_utilitarian [Nontrivial α] {i j : ι} (hij : i ≠ j) (hi : 0 < c i)
+    (hj : 0 < c j) : ¬ Invariant ordinal (utilitarian c : Rule ι α K) :=
+  λ h => not_ratioInvariant_utilitarian c hij hi hj (h.mono ratio_subset_ordinal)
+
+end Utilitarian
+
+/-! ### The Cobb–Douglas rule -/
+
+section CobbDouglas
+
+variable [Fintype ι] (c : ι → ℝ)
+
+/-- The Cobb–Douglas rule with exponents `c`: `x ⪰ y` iff the weighted geometric product of
+values favours `x`. -/
+def cobbDouglas : Rule ι α ℝ := λ v x y => ∏ i, v y i ^ c i ≤ ∏ i, v x i ^ c i
+
+theorem cobbDouglas_weakOrderValued : WeakOrderValued (cobbDouglas c : Rule ι α ℝ) :=
+  ⟨λ _ => ⟨λ _ _ _ h h' => h'.trans h⟩, λ _ => ⟨λ _ _ => le_total _ _⟩⟩
+
+theorem cobbDouglas_paretoIndifferent : ParetoIndifferent (cobbDouglas c : Rule ι α ℝ) := by
+  intro v x y h
+  simp [AntisymmRel, cobbDouglas, h]
+
+theorem cobbDouglas_independent : Independent (cobbDouglas c : Rule ι α ℝ) := by
+  intro v w x y hx hy
+  simp only [cobbDouglas, hx, hy]
+
+/-- On non-negative profiles the Cobb–Douglas rule is ratio-scale invariant. -/
+theorem cobbDouglas_transform_of_nonneg {f : ι → ℝ → ℝ} (hf : f ∈ ratio) {v : Profile ι α ℝ}
+    (hv : ∀ x i, 0 ≤ v x i) : cobbDouglas c (v.transform f) = cobbDouglas c v := by
+  obtain ⟨s, hs, hf⟩ := hf
+  funext x y
+  simp only [cobbDouglas, Profile.transform, hf, Real.mul_rpow (hs _).le (hv _ _),
+    prod_mul_distrib]
+  exact propext (mul_le_mul_iff_of_pos_left (prod_pos λ i _ => Real.rpow_pos_of_pos (hs i) _))
+
+end CobbDouglas
+
+/-! ### Scores for the positive form -/
+
+section Scores
+
+variable [Field K] [LinearOrder K] [IsStrictOrderedRing K]
 
 /-- Lift Bool dimension predicates to `K`-valued measure functions.
-    Each `d : α → Bool` becomes `fun x => if d x then 1 else 0`. -/
+    Each `d : α → Bool` becomes `λ x => if d x then 1 else 0`. -/
 def boolMeasures (dims : List (α → Bool)) : List (α → K) :=
-  dims.map (fun d x => if d x then 1 else 0)
+  dims.map (λ d x => if d x then 1 else 0)
 
 /-- Weighted score: Σᵢ wᵢ · fᵢ(x), where each fᵢ : α → K is a
-    measure function along one dimension.
-
-    This is the unified core: [waldon-etal-2023]'s eq. (8) uses
-    `K`-valued measures directly; [dambrosio-hedden-2024]'s Bool
-    dimensions are the special case via `boolMeasures`. -/
+    measure function along one dimension ([waldon-etal-2023]'s eq. (8)). -/
 def weightedScore (weights : List K) (measures : List (α → K)) (x : α) : K :=
-  (weights.zip measures).foldl (fun acc (w, f) => acc + w * f x) 0
-
-/-- Weighted binding (Bool dimensions): x is F iff its weighted score
-    over Bool-lifted measures exceeds threshold θ. -/
-def weightedBinding (weights : List K) (θ : K)
-    (dims : List (α → Bool)) (x : α) : Bool :=
-  decide (weightedScore weights (boolMeasures dims) x ≥ θ)
-
-/-- Weighted binding over continuous `K`-valued measures. -/
-def weightedBindingQ (weights : List K) (θ : K)
-    (measures : List (α → K)) (x : α) : Bool :=
-  decide (weightedScore weights measures x ≥ θ)
+  (weights.zip measures).foldl (λ acc (w, f) => acc + w * f x) 0
 
 /-- Spatially-normalized weighted score: (Σᵢ wᵢ·fᵢ(x)) / s(x).
 
@@ -104,19 +475,12 @@ def spatialNormalizedBinding (weights : List K) (θ : K)
     (dims : List (α → Bool)) (spatial : α → K) (x : α) : Bool :=
   decide (spatialNormalizedScore weights (boolMeasures dims) spatial x ≥ θ)
 
-/-! ### Properties -/
-
-/-- Counting with threshold 0 is always satisfied (vacuously true). -/
-theorem countBinding_zero (dims : List (α → Bool)) (x : α) :
-    countBinding 0 dims x = true := by
-  simp [countBinding]
-
 /-- The spatial-normalization reduces to plain weighted score when
     `spatial x = 1` (constant unit host extent). -/
 @[simp]
 theorem spatialNormalizedScore_unit (weights : List K) (measures : List (α → K))
     (x : α) :
-    spatialNormalizedScore weights measures (fun _ => 1) x =
+    spatialNormalizedScore weights measures (λ _ => 1) x =
       weightedScore weights measures x := by
   unfold spatialNormalizedScore
   split_ifs with h
@@ -124,20 +488,16 @@ theorem spatialNormalizedScore_unit (weights : List K) (measures : List (α → 
   · exact div_one _
 
 omit [IsStrictOrderedRing K] in
-/-- Spatial normalization at a zero-extent host returns 0. Documents the
-    edge-case convention: a host with no spatial extent cannot exhibit a
-    physical disturbance, so the predicate is vacuously not satisfied. -/
+/-- Spatial normalisation at a zero-extent host returns 0: a host with no spatial extent
+exhibits no disturbance. -/
 @[simp]
 theorem spatialNormalizedScore_zero (weights : List K) (measures : List (α → K))
     (spatial : α → K) (x : α) (h : spatial x = 0) :
     spatialNormalizedScore weights measures spatial x = 0 := by
   simp [spatialNormalizedScore, h]
 
-/-- **Bounded-by-one normalization** (mathlib-style structural property).
-    When the weighted-score numerator is bounded by the spatial-extent
-    denominator, the normalized score is at most 1. This makes Tham
-    2025's "boundedness from spatial extent" claim (§3.4) into a
-    structural theorem rather than a stipulation. -/
+/-- A weighted score bounded by the host's spatial extent normalises to at most 1:
+[tham-2025]'s boundedness from spatial extent. -/
 theorem spatialNormalizedScore_le_one
     (weights : List K) (measures : List (α → K))
     (spatial : α → K) (x : α)
@@ -148,11 +508,9 @@ theorem spatialNormalizedScore_le_one
   rw [if_neg hpos.ne']
   exact div_le_one_of_le₀ hsum hpos.le
 
-/-- **Nonnegativity of normalized score**. When the weighted score is
-    nonnegative and the spatial extent is nonnegative, the normalized
-    score is nonnegative. Combined with `spatialNormalizedScore_le_one`,
-    this places the score in `[0, 1]` — the "fraction of the totality"
-    intuition Tham 2025 §3.4 and Solt 2018 eq. 21 both require. -/
+/-- A nonnegative weighted score over a nonnegative extent normalises to a nonnegative score;
+with `spatialNormalizedScore_le_one` it lies in `[0, 1]`, the fraction of the totality of
+[tham-2025] and [solt-2018-proportional]. -/
 theorem spatialNormalizedScore_nonneg
     (weights : List K) (measures : List (α → K))
     (spatial : α → K) (x : α)
@@ -164,83 +522,13 @@ theorem spatialNormalizedScore_nonneg
   · rw [if_pos h]
   · rw [if_neg h]; exact div_nonneg hnum hspatial
 
-/-! ### Multiplicative Aggregation (Cobb-Douglas) -/
-
 /-- Multiplicative (Cobb-Douglas) score: Πᵢ fᵢ(x).
     [sassoon-fadlon-2017] argue natural kind nouns compose
     multiplicatively: failure on ANY single dimension kills membership.
     Contrast with additive `weightedScore` for artifact nouns. -/
 def multiplicativeScore (measures : List (α → K)) (x : α) : K :=
-  measures.foldl (fun acc f => acc * f x) 1
+  measures.foldl (λ acc f => acc * f x) 1
 
-/-! ### Classification -/
-
-/-- Classification of dimensional aggregation mechanisms.
-    Each type corresponds to an escape route from Arrow's impossibility. -/
-inductive AggregationType where
-  /-- Threshold counting (rejects WO via non-transitivity or incompleteness). -/
-  | counting
-  /-- Weighted sum / utilitarian (rejects ONC, accepts interval scale IUC). -/
-  | utilitarian
-  /-- Weighted product / Cobb-Douglas (rejects ONC, accepts ratio scale RNC). -/
-  | cobbDouglas
-  deriving Repr, DecidableEq
-
-/-! ### Sassoon 2013 Subsumption Theorems -/
-
-private theorem all_eq_decide_filter_ge_length :
-    ∀ (dims : List (α → Bool)) (x : α),
-      dims.all (· x) = decide ((dims.filter (fun d => d x)).length ≥ dims.length)
-  | [], _ => rfl
-  | d :: ds, x => by
-    have ih := all_eq_decide_filter_ge_length ds x
-    simp only [List.all_cons, List.length_cons]
-    cases hd : d x
-    · rw [@List.filter_cons_of_neg _ (· x) d ds (by simp [hd])]
-      simp only [Bool.false_and]
-      exact (decide_eq_false_iff_not.mpr (by
-        have := List.length_filter_le (· x) ds; omega)).symm
-    · rw [@List.filter_cons_of_pos _ (· x) d ds hd]
-      simp only [Bool.true_and, List.length_cons, ih]
-      exact decide_eq_decide.mpr (by omega)
-
-private theorem any_eq_decide_filter_ge_one :
-    ∀ (dims : List (α → Bool)) (x : α),
-      dims.any (· x) = decide ((dims.filter (fun d => d x)).length ≥ 1)
-  | [], _ => rfl
-  | d :: ds, x => by
-    simp only [List.any_cons]
-    cases hd : d x
-    · rw [@List.filter_cons_of_neg _ (· x) d ds (by simp [hd])]
-      simp only [Bool.false_or]
-      exact any_eq_decide_filter_ge_one ds x
-    · rw [@List.filter_cons_of_pos _ (· x) d ds hd]
-      simp only [Bool.true_or, List.length_cons]
-      exact (decide_eq_true_iff.mpr (by omega)).symm
-
-/-- Conjunctive binding = counting with threshold k = dims.length.
-    [sassoon-2013]'s ∀-binding is a special case of counting. -/
-theorem conjunctive_is_countAll (dims : List (α → Bool)) (x : α) :
-    Degree.conjunctiveBinding dims x = countBinding dims.length dims x :=
-  all_eq_decide_filter_ge_length dims x
-
-/-- Disjunctive binding = counting with threshold k = 1.
-    [sassoon-2013]'s ∃-binding is a special case of counting. -/
-theorem disjunctive_is_countOne (dims : List (α → Bool)) (x : α) :
-    Degree.disjunctiveBinding dims x = countBinding 1 dims x :=
-  any_eq_decide_filter_ge_one dims x
-
-/-- [sassoon-2013]'s binding types all map to counting aggregation.
-    The key gap: Sassoon has no utilitarian or Cobb-Douglas mechanism. -/
-def toAggregationType : Degree.DimensionBindingType → AggregationType
-  | .conjunctive => .counting
-  | .disjunctive => .counting
-  | .mixed => .counting
-
-/-- All of Sassoon 2013's binding types are counting aggregation. -/
-theorem sassoon_all_counting :
-    ∀ b : Degree.DimensionBindingType,
-      toAggregationType b = AggregationType.counting := by
-  intro b; cases b <;> rfl
+end Scores
 
 end Degree.Aggregation

--- a/Linglib/Studies/DAmbrosioHedden2024.lean
+++ b/Linglib/Studies/DAmbrosioHedden2024.lean
@@ -1,211 +1,331 @@
+import Linglib.Semantics.Degree.Adjective
 import Linglib.Semantics.Degree.Aggregation
-import Linglib.Studies.Sassoon2013
+import Linglib.Studies.Kamp1975
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# [dambrosio-hedden-2024]
+# D'Ambrosio and Hedden, multidimensional adjectives (2024)
 
-D'Ambrosio, J. & Hedden, B. (2024). Multidimensional Adjectives.
-*Australasian Journal of Philosophy* 102(2): 253–277.
-DOI: 10.1080/00048402.2023.2277923
+An adjective is multidimensional when whether it applies to an object, and whether it applies
+to one object more than to another, depend on how the objects stand on several underlying
+dimensions. The paper gives such adjectives a semantics with explicit aggregation: a context
+supplies a profile of dimensional orderings, represented by value functions, a set of
+admissible aggregation rules from profiles to an overall ordering, and a standard object. *x
+is at least as F as y* holds relative to an admissible rule when it ranks x weakly above y, *x
+is F* when it ranks x weakly above the standard, and a sentence is determinately true when it
+is true relative to every admissible rule. The comparative is vague when more than one rule is
+admissible, and its vagueness is independent of the completeness and transitivity of the
+orderings the rules output, which the delineation approach conflates by turning disagreement
+between precisifications into incomparability. Transposed to social choice, Arrow's theorem
+makes an adjective governed by all of Arrow's conditions incoherent; giving up weak-ordering
+outputs admits majority rule or the Pareto rule, and giving up ordinal non-comparability admits
+utilitarian and Cobb–Douglas aggregation, whose free weights make the comparative vague.
+Sassoon's quantificational comparatives are the Pareto rule for conjunctive adjectives, a rule
+violating strong Pareto for disjunctive ones, and a rule violating weak Pareto for
+dimension-counting ones.
 
-## Key Claims
+We state the framework over `Degree.Aggregation`'s rules and conditions, the sorites on Suzy's
+cardiovascular health under utilitarian weightings, and the three verdicts on Sassoon's
+comparatives.
 
-1. Multidimensional adjectives require explicit **aggregation functions**
-   mapping dimensional assessments to overall assessments (§3).
+## Implementation notes
 
-2. Arrow's impossibility theorem (adapted): under constraints ONC + WO +
-   U + P + I + D, no aggregation function exists for ≥3 dimensions and
-   ≥3 objects. Multidimensional adjectives would be **incoherent** (§4.1).
+* The precisifications of the delineation comparative are the admissible rules with the
+  standard fixed, so that comparative is `Kamp1975.kampPreorder`.
+* Weighting the dimensions of *healthy*, as the paper's sorites does, is utilitarian
+  aggregation; the cut-off on Suzy's cardiovascular health is where her weighted sum reaches
+  Bill's.
 
-3. Escape routes determine aggregation type (§4.2–4.3):
-   - Reject WO (transitivity) → Majority Rule (May 1952)
-   - Reject WO (completeness) → Strong Pareto Rule (Weymark 1984)
-   - Reject ONC, accept IUC → Utilitarian / weighted sum (Sen 1970)
-   - Reject ONC, accept RNC → Cobb-Douglas / weighted product (Tsui-Weymark 1997)
+## TODO
 
-4. Multiple admissible aggregation functions → **comparative vagueness**,
-   a source of vagueness specific to multidimensionality (§4.3).
+* `arrow` states the adapted impossibility theorem for real-valued profiles and leaves its
+  proof open; the pivotal-dimension argument of [geanakoplos-2005] carries over.
 
-## Formalization
+## References
 
-- §1: Arrow's constraints
-- §2: *athletic* example (majority rule and weighted aggregation)
-- §3: Comparative vagueness from weight multiplicity
-- §4: Connection to [sassoon-2013] (binding types = counting)
+* [J. D'Ambrosio and B. Hedden, *Multidimensional adjectives* (2024)][dambrosio-hedden-2024]
+* [K. J. Arrow, *A difficulty in the concept of social welfare* (1951)][arrow-1950]
+* [J. Geanakoplos, *Three brief proofs of Arrow's impossibility theorem*
+  (2005)][geanakoplos-2005]
+* [H. Kamp, *Two theories about adjectives* (1975)][kamp-1975]
+* [G. W. Sassoon, *A typology of multidimensional adjectives* (2013)][sassoon-2013]
 -/
 
 namespace DAmbrosioHedden2024
 
-open Degree (DimensionBindingType conjunctiveBinding
-  disjunctiveBinding)
-open Degree.Aggregation
-open Degree.Aggregation
+open Degree.Aggregation Finset
 
--- ════════════════════════════════════════════════════
--- § 1. Arrow's Constraints
--- ════════════════════════════════════════════════════
+variable {ι O K : Type*}
 
-/-- Arrow's constraints on dimensional aggregation (§4, adapted from
-    social choice theory). -/
-structure ArrowConstraints where
-  /-- (U) Defined for all logically possible value profiles. -/
-  unrestrictedDomain : Bool
-  /-- (WO) Output is a weak ordering (reflexive, transitive, complete). -/
-  weakOrdering : Bool
-  /-- (P) Unanimous dimensional ranking → same overall ranking. -/
-  weakPareto : Bool
-  /-- (I) Overall ranking of x vs y depends only on their dim values. -/
-  independence : Bool
-  /-- (D) No single dimension dictates the overall ranking. -/
-  nonDictatorship : Bool
-  /-- (ONC) Only ordinal info used (invariant under monotone transforms). -/
-  ordinalNonComparability : Bool
-  deriving Repr, BEq
+/-! ### Contexts and determinacy -/
 
-/-- The full Arrovian constraint set (§4.1). -/
-def fullArrow : ArrowConstraints where
-  unrestrictedDomain := true
-  weakOrdering := true
-  weakPareto := true
-  independence := true
-  nonDictatorship := true
-  ordinalNonComparability := true
+/-- What a context supplies for a multidimensional adjective: the admissible aggregation rules
+and the standard object. Relative to an admissible rule `a` and a profile `v`, *x is at least
+as F as y* is `a v x y`, *x is F-er than y* is `AsymmRel (a v) x y`, *x and y are equally F* is
+`AntisymmRel (a v) x y`, and *x is F* is `a v x c.standard`. -/
+structure Context (ι O K : Type*) where
+  /-- The aggregation rules the context does not rule out. -/
+  adm : Set (Rule ι O K)
+  /-- The object that sets the standard for the positive form. -/
+  standard : O
 
-/-- `fullArrow` enables all six constraints. Arrow's impossibility
-    theorem (adapted, §4.1) says these are jointly unsatisfiable for
-    ≥3 dimensions and ≥3 objects — at least one must be abandoned,
-    and each escape route yields a different aggregation type.
+namespace Context
 
-    This theorem only records the constraint *specification*; the
-    impossibility proof itself would require formalizing aggregation
-    over orderings and is not attempted here. -/
-theorem fullArrow_all_enabled :
-    fullArrow.unrestrictedDomain = true ∧
-    fullArrow.weakOrdering = true ∧
-    fullArrow.weakPareto = true ∧
-    fullArrow.independence = true ∧
-    fullArrow.nonDictatorship = true ∧
-    fullArrow.ordinalNonComparability = true := ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+variable (c : Context ι O K) (P : Rule ι O K → Prop)
 
--- ════════════════════════════════════════════════════
--- § 2. *Athletic* Example
--- ════════════════════════════════════════════════════
+/-- Determinately true: true relative to every admissible rule. -/
+def Determinately : Prop := ∀ a ∈ c.adm, P a
 
-/-! The adjective *athletic* has three dimensions: speed (F₁), agility (F₂),
-    and endurance (F₃) (§3). We model two people and show how different
-    aggregation mechanisms yield different verdicts. -/
+/-- Determinately false: false relative to every admissible rule. -/
+def DeterminatelyNot : Prop := ∀ a ∈ c.adm, ¬ P a
 
-inductive Person where | alice | bob
-  deriving Repr, DecidableEq
+/-- Neither determinately true nor determinately false. -/
+def Indeterminate : Prop := ¬ c.Determinately P ∧ ¬ c.DeterminatelyNot P
 
-/-- Speed-heavy weights `[3, 1, 1]` over (speed, agility, endurance). -/
-def speedHeavy : List ℚ := [3, 1, 1]
+/-- No admissible rule: the adjective is incoherent. -/
+def Incoherent : Prop := c.adm = ∅
 
-/-- Endurance-heavy weights `[1, 1, 3]`. -/
-def enduranceHeavy : List ℚ := [1, 1, 3]
+/-- Exactly one admissible rule: the comparative is sharp. -/
+def Sharp : Prop := ∃ a, c.adm = {a}
 
-/-- Dimensional profiles for *athletic*:
-    - Alice: fast, agile, not enduring
-    - Bob: not fast, not agile, enduring -/
-def athleticDims : List (Person → Bool) :=
-  [fun p => p == .alice,    -- speed: Alice fast, Bob slow
-   fun p => p == .alice,    -- agility: Alice agile, Bob not
-   fun p => p == .bob]      -- endurance: Bob enduring, Alice not
+/-- More than one admissible rule: the comparative is vague. -/
+def Vague : Prop := c.adm.Nontrivial
 
-/-- Majority rule: Alice is athletic (2 of 3 dims). -/
-theorem alice_athletic_majority :
-    majorityBinding athleticDims .alice = true := by native_decide
+variable {c P}
 
-/-- Majority rule: Bob is NOT athletic (1 of 3 dims). -/
-theorem bob_not_athletic_majority :
-    majorityBinding athleticDims .bob = false := by native_decide
+/-- The three cases of §4. -/
+theorem incoherent_or_sharp_or_vague : c.Incoherent ∨ c.Sharp ∨ c.Vague :=
+  (Set.subsingleton_or_nontrivial c.adm).elim
+    (λ h => h.eq_empty_or_singleton.imp id Or.inl) (λ h => Or.inr (Or.inr h))
 
-/-- Under speed-heavy weights [3, 1, 1] with θ = 3, Alice IS athletic
-    (score = 3 + 1 + 0 = 4 ≥ 3) but Bob is NOT (score = 0 + 0 + 1 = 1). -/
-theorem alice_athletic_speed_heavy :
-    weightedBinding speedHeavy 3 athleticDims .alice = true := by native_decide
+/-- A sharp comparative settles every question. -/
+theorem Sharp.determinately_or (h : c.Sharp) (P : Rule ι O K → Prop) :
+    c.Determinately P ∨ c.DeterminatelyNot P := by
+  obtain ⟨a, ha⟩ := h
+  simp only [Determinately, DeterminatelyNot, ha, Set.mem_singleton_iff, forall_eq]
+  exact em (P a)
 
-theorem bob_not_athletic_speed_heavy :
-    weightedBinding speedHeavy 3 athleticDims .bob = false := by native_decide
+/-- Two admissible rules that disagree on `P` make `P` indeterminate. -/
+theorem indeterminate_of_disagree {a b : Rule ι O K} (ha : a ∈ c.adm) (hb : b ∈ c.adm)
+    (hPa : P a) (hPb : ¬ P b) : c.Indeterminate P :=
+  ⟨λ h => hPb (h b hb), λ h => h a ha hPa⟩
 
-/-- Under endurance-heavy weights [1, 1, 3] with θ = 3, Alice is NOT
-    athletic (score = 1 + 1 + 0 = 2 < 3) but Bob IS (0 + 0 + 3 = 3 ≥ 3). -/
-theorem alice_not_athletic_endurance_heavy :
-    weightedBinding enduranceHeavy 3 athleticDims .alice = false := by native_decide
+/-- Indeterminacy needs two admissible rules: it is comparative vagueness, whether it shows
+in the comparative or in the positive form. -/
+theorem Indeterminate.vague (h : c.Indeterminate P) : c.Vague := by
+  obtain ⟨h₁, h₂⟩ := h
+  simp only [Determinately, DeterminatelyNot, not_forall, not_not, exists_prop] at h₁ h₂
+  obtain ⟨a, ha, hPa⟩ := h₁
+  obtain ⟨b, hb, hPb⟩ := h₂
+  exact ⟨b, hb, a, ha, λ e => hPa (e ▸ hPb)⟩
 
-theorem bob_athletic_endurance_heavy :
-    weightedBinding enduranceHeavy 3 athleticDims .bob = true := by native_decide
+/-- With complete admissible rules, that one of two objects is at least as F as the other is
+determinate, however indeterminate it is which. -/
+theorem determinately_or_of_complete (h : c.Determinately Complete) (v : Profile ι O K)
+    (x y : O) : c.Determinately λ a => a v x y ∨ a v y x :=
+  λ a ha => (h a ha v).total x y
 
--- ════════════════════════════════════════════════════
--- § 3. Comparative Vagueness
--- ════════════════════════════════════════════════════
+/-! ### The delineation comparative -/
 
-/-! When multiple weight vectors are admissible, the comparative form
-    "x is more athletic than y" is **vague**: different admissible
-    aggregation functions rank the entities differently.
+/-- The delineation comparative of §2 with the admissible rules as precisifications and the
+standard fixed: `x` is at least as F as `y` iff every admissible rule that makes `y` F makes
+`x` F. -/
+abbrev delineation (c : Context ι O K) (v : Profile ι O K) : Preorder O :=
+  Kamp1975.kampPreorder (λ (a : Rule ι O K) x => a v x c.standard) c.adm
 
-    This is D&H's central prediction (§4.3): multidimensionality
-    generates comparative vagueness through admissibility multiplicity. -/
+/-- Admissible rules that disagree on which of two objects meets the standard leave the two
+incomparable under the delineation comparative: what the paper treats as vagueness the
+delineation approach turns into incompleteness. -/
+theorem delineation_incomparable (c : Context ι O K) {v : Profile ι O K} {x y : O}
+    {a b : Rule ι O K} (ha : a ∈ c.adm) (hb : b ∈ c.adm) (hax : a v x c.standard)
+    (hay : ¬ a v y c.standard) (hby : b v y c.standard) (hbx : ¬ b v x c.standard) :
+    ¬ (c.delineation v).le x y ∧ ¬ (c.delineation v).le y x :=
+  ⟨λ h => hbx (h b hb hby), λ h => hay (h a ha hax)⟩
 
-/-- Under speed-heavy weights, Alice outscores Bob. -/
-theorem speed_heavy_alice_wins :
-    weightedScore speedHeavy (boolMeasures athleticDims) .alice >
-    weightedScore speedHeavy (boolMeasures athleticDims) .bob := by native_decide
+end Context
 
-/-- Under endurance-heavy weights, Bob outscores Alice. -/
-theorem endurance_heavy_bob_wins :
-    weightedScore enduranceHeavy (boolMeasures athleticDims) .bob >
-    weightedScore enduranceHeavy (boolMeasures athleticDims) .alice := by native_decide
+/-! ### The sorites on Suzy's health -/
 
-/-- Comparative vagueness: when both weight vectors are admissible,
-    "Alice is more athletic than Bob" is **indeterminate** — one
-    aggregation function says yes, the other says no. -/
-theorem comparative_vagueness :
-    -- Speed-heavy: Alice > Bob
-    weightedScore speedHeavy (boolMeasures athleticDims) .alice >
-    weightedScore speedHeavy (boolMeasures athleticDims) .bob ∧
-    -- Endurance-heavy: Bob > Alice
-    weightedScore enduranceHeavy (boolMeasures athleticDims) .bob >
-    weightedScore enduranceHeavy (boolMeasures athleticDims) .alice :=
-  ⟨speed_heavy_alice_wins, endurance_heavy_bob_wins⟩
+/-- The dimensions of *healthy* in the sorites of §2. -/
+inductive Health
+  | musculoskeletal
+  | cardiovascular
+  deriving DecidableEq, Fintype
 
--- ════════════════════════════════════════════════════
--- § 4. Connection to Sassoon 2013
--- ════════════════════════════════════════════════════
+/-- Bill and a variant of Suzy. -/
+inductive Patient
+  | suzy
+  | bill
+  deriving DecidableEq
 
-/-! [sassoon-2013]'s framework classifies binding as conjunctive
-    (∀), disjunctive (∃), or mixed (dimension counting). D&H show all
-    three are **counting aggregation** — a single escape route from
-    Arrow's theorem. Utilitarian aggregation (weighted sum) is a
-    genuinely different mechanism that Sassoon's typology misses. -/
+/-- The sorites profile: Suzy's musculoskeletal health `mS` sits below Bill's `mB`, and her
+cardiovascular health `t` varies against Bill's `cB`. -/
+def health (mS mB cB t : K) : Profile Health Patient K
+  | .suzy, .musculoskeletal => mS
+  | .suzy, .cardiovascular => t
+  | .bill, .musculoskeletal => mB
+  | .bill, .cardiovascular => cB
 
-/-- All of Sassoon 2013's binding types are counting aggregation. -/
-theorem sassoon_framework_is_counting :
-    ∀ b : DimensionBindingType, toAggregationType b = .counting :=
-  sassoon_all_counting
+private theorem sum_health [AddCommMonoid K] (f : Health → K) :
+    ∑ i, f i = f .musculoskeletal + f .cardiovascular := by
+  rw [show (univ : Finset Health) = {.musculoskeletal, .cardiovascular} from by decide,
+    sum_pair (by decide)]
 
-/-- Utilitarian aggregation is NOT counting — it is a categorically
-    different escape route from Arrow's impossibility. -/
-theorem utilitarian_not_counting :
-    AggregationType.utilitarian ≠ .counting := by decide
+section Sorites
 
-/-- *healthy* under conjunctive binding: must satisfy ALL dimensions.
-    A person healthy on musculoskeletal and cardiovascular but with
-    disease present is NOT healthy. -/
-theorem healthy_conjunctive_rejects_partial :
-    conjunctiveBinding
-      [fun (_ : Unit) => true,   -- musculoskeletal: good
-       fun (_ : Unit) => true,   -- cardiovascular: good
-       fun (_ : Unit) => false]  -- freedom from disease: no
-      () = false := rfl
+variable [Field K] [LinearOrder K] [IsStrictOrderedRing K] {w w' : Health → K} {mS mB cB t t' : K}
 
-/-- But under counting with k = 2, the same person IS healthy
-    (passes on 2 of 3 dimensions). Counting and conjunctive diverge. -/
-theorem counting_accepts_partial :
-    countBinding 2
-      [fun (_ : Unit) => true,
-       fun (_ : Unit) => true,
-       fun (_ : Unit) => false]
-      () = true := by native_decide
+/-- The cut-off: Suzy is at least as healthy as Bill under weights `w` iff her cardiovascular
+health reaches Bill's plus the weighted musculoskeletal deficit. -/
+theorem health_utilitarian_iff (hw : 0 < w .cardiovascular) :
+    utilitarian w (health mS mB cB t) .suzy .bill ↔
+      cB + w .musculoskeletal / w .cardiovascular * (mB - mS) ≤ t := by
+  rw [← mul_le_mul_iff_of_pos_right hw, add_mul, div_mul_eq_mul_div, div_mul_cancel₀ _ hw.ne']
+  simp only [utilitarian, dotProduct, sum_health, health]
+  constructor <;> intro h <;> linarith
+
+/-- The inductive premise of the sorites: better cardiovascular health keeps Suzy at least as
+healthy as Bill. -/
+theorem health_mono (hw : 0 ≤ w .cardiovascular) (h : t ≤ t') :
+    utilitarian w (health mS mB cB t) .suzy .bill →
+      utilitarian w (health mS mB cB t') .suzy .bill := by
+  simp only [utilitarian, dotProduct, sum_health, health]
+  intro h'
+  linarith [mul_le_mul_of_nonneg_left h hw]
+
+/-- The first Suzy, worse than Bill on both dimensions, is not at least as healthy as Bill
+under any positive weighting. -/
+theorem not_health_of_lt (hm : mS < mB) (ht : t < cB) (hw : ∀ i, 0 ≤ w i)
+    (hpos : ∃ i, 0 < w i) : ¬ utilitarian w (health mS mB cB t) .suzy .bill :=
+  (utilitarian_weakPareto w hw hpos (health mS mB cB t) Patient.bill Patient.suzy λ i => by
+    cases i <;> [exact hm; exact ht]).2
+
+/-- In a context admitting two weightings with different cut-offs, every Suzy between the
+cut-offs is a borderline case of *at least as healthy as Bill*. -/
+theorem health_indeterminate (c : Context Health Patient K) (hw : utilitarian w ∈ c.adm)
+    (hw' : utilitarian w' ∈ c.adm) (hc : 0 < w .cardiovascular) (hc' : 0 < w' .cardiovascular)
+    (ht : cB + w .musculoskeletal / w .cardiovascular * (mB - mS) ≤ t)
+    (ht' : t < cB + w' .musculoskeletal / w' .cardiovascular * (mB - mS)) :
+    c.Indeterminate λ a => a (health mS mB cB t) .suzy .bill :=
+  c.indeterminate_of_disagree hw hw' ((health_utilitarian_iff hc).2 ht)
+    λ h => ((health_utilitarian_iff hc').1 h).not_gt ht'
+
+/-- Two admissible weightings with different cut-offs make *at least as healthy as* vague. -/
+theorem vague_of_cutoff_lt (c : Context Health Patient K) (hw : utilitarian w ∈ c.adm)
+    (hw' : utilitarian w' ∈ c.adm) (hc : 0 < w .cardiovascular) (hc' : 0 < w' .cardiovascular)
+    (h : cB + w .musculoskeletal / w .cardiovascular * (mB - mS) <
+      cB + w' .musculoskeletal / w' .cardiovascular * (mB - mS)) : c.Vague :=
+  (health_indeterminate (t := cB + w .musculoskeletal / w .cardiovascular * (mB - mS)) c hw hw'
+    hc hc' le_rfl h).vague
+
+/-! ### Vagueness against structure -/
+
+/-- Two utilitarian weightings with different cut-offs: the comparative is vague, yet
+determinately a weak ordering. -/
+theorem vague_determinately_weakOrderValued (c : Context Health Patient K)
+    (hadm : c.adm = {utilitarian w, utilitarian w'}) (hc : 0 < w .cardiovascular)
+    (hc' : 0 < w' .cardiovascular)
+    (h : cB + w .musculoskeletal / w .cardiovascular * (mB - mS) <
+      cB + w' .musculoskeletal / w' .cardiovascular * (mB - mS)) :
+    c.Vague ∧ c.Determinately WeakOrderValued := by
+  refine ⟨vague_of_cutoff_lt c (by simp [hadm]) (by simp [hadm]) hc hc' h, λ a ha => ?_⟩
+  rw [hadm] at ha
+  rcases ha with rfl | rfl <;> exact utilitarian_weakOrderValued _
+
+omit [IsStrictOrderedRing K] in
+/-- A utilitarian weighting beside the Pareto rule, on a profile where Suzy trades
+musculoskeletal for cardiovascular health: it is indeterminate whether the comparative is
+complete. -/
+theorem indeterminate_complete (c : Context Health Patient K) (hu : utilitarian w ∈ c.adm)
+    (hp : paretoRule ∈ c.adm) (hm : mS < mB) (ht : cB < t) : c.Indeterminate Complete :=
+  c.indeterminate_of_disagree hu hp (utilitarian_weakOrderValued w).2 λ h =>
+    ((h (health mS mB cB t)).total .suzy .bill).elim
+      (paretoRule_incomparable (i := Health.cardiovascular) (j := .musculoskeletal) ht hm).1
+      (paretoRule_incomparable (i := Health.cardiovascular) (j := .musculoskeletal) ht hm).2
+
+end Sorites
+
+/-! ### Arrow's theorem and incoherence -/
+
+/-- Arrow's conditions, transposed to dimensional aggregation. -/
+def Arrovian [Preorder K] (a : Rule ι O K) : Prop :=
+  Invariant ordinal a ∧ WeakOrderValued a ∧ WeakPareto a ∧ Independent a ∧ NonDictatorial a
+
+/-- Arrow's impossibility theorem, adapted: with finitely many dimensions and at least three
+objects, no rule meets all of Arrow's conditions. -/
+theorem arrow [Fintype ι] [Fintype O] (h₃ : 3 ≤ Fintype.card O) (a : Rule ι O ℝ) :
+    ¬ Arrovian a := by
+  sorry
+
+/-- An adjective whose admissible rules are all Arrovian is incoherent. -/
+theorem Context.incoherent_of_arrovian [Fintype ι] [Fintype O] (h₃ : 3 ≤ Fintype.card O)
+    (c : Context ι O ℝ) (h : c.Determinately Arrovian) : c.Incoherent :=
+  Set.eq_empty_iff_forall_notMem.2 λ a ha => arrow h₃ a (h a ha)
+
+/-! ### Escaping Arrow by weakening the outputs -/
+
+/-- Acyclicity as the paper states it: two strict steps yield a weak step. -/
+def Acyclic (r : O → O → Prop) : Prop := ∀ x y z, AsymmRel r x y → AsymmRel r y z → r x z
+
+/-- Majority rule violates even acyclicity: Condorcet's cycle. -/
+theorem not_acyclic_majority_condorcet : ¬ Acyclic (majority condorcet) :=
+  λ h => majority_condorcet.2.2.2 (h 0 1 2 majority_condorcet.1 majority_condorcet.2.1)
+
+/-! ### Sassoon's comparatives -/
+
+section Sassoon
+
+variable [Fintype ι] [LinearOrder K] (θ : ι → K)
+
+/-- The comparative the paper attributes to Sassoon for each binding type: universal
+quantification over the dimensions for conjunctive adjectives (*healthy*), existential for
+disjunctive ones (*sick*), and for mixed ones (*intelligent*) counting the dimensions on which
+the thresholds `θ` are met. -/
+def sassoon : Degree.DimensionBindingType → Rule ι O K
+  | .conjunctive => λ v x y => ∀ i, v y i ≤ v x i
+  | .disjunctive => λ v x y => ∃ i, v y i ≤ v x i
+  | .mixed => λ v x y => #{i | θ i ≤ v y i} ≤ #{i | θ i ≤ v x i}
+
+/-- The universal comparative is the Pareto rule, and inherits its incomparable trade-offs. -/
+theorem sassoon_conjunctive : sassoon θ .conjunctive = (paretoRule : Rule ι O K) := rfl
+
+/-- The existential comparative violates strong Pareto: an object tied with another on one
+dimension and below it on all others counts as at least as F. -/
+theorem not_strongPareto_sassoon_disjunctive [Nontrivial ι] [Nontrivial O] [Nontrivial K] :
+    ¬ StrongPareto (sassoon θ .disjunctive : Rule ι O K) := by
+  intro h
+  obtain ⟨i, j, hij⟩ := exists_pair_ne ι
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne O
+  obtain ⟨k, k', hk⟩ : ∃ k k' : K, k < k' := by
+    obtain ⟨k, k', h⟩ := exists_pair_ne K
+    exact h.lt_or_gt.elim (λ h => ⟨k, k', h⟩) (λ h => ⟨k', k, h⟩)
+  classical
+  let v : Profile ι O K := λ z l => if z = y ∧ l ≠ i then k' else k
+  have hle : v x ≤ v y := λ l => by
+    simp only [v, hxy, false_and, if_false]
+    split_ifs <;> simp [hk.le]
+  have hlt : ∃ l, v x l < v y l := ⟨j, by simp [v, hxy, hij.symm, hk]⟩
+  have hxy' : sassoon θ .disjunctive v x y := ⟨i, by simp [v, hxy]⟩
+  exact ((h v y x hle).2 hlt).2 hxy'
+
+/-- Dimension counting violates weak Pareto: two objects meeting the thresholds on the same
+dimensions are tied, even when one is strictly above the other on every dimension. -/
+theorem not_weakPareto_sassoon_mixed [Nonempty ι] [Nontrivial O] [NoMaxOrder K] :
+    ¬ WeakPareto (sassoon θ .mixed : Rule ι O K) := by
+  intro h
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne O
+  obtain ⟨k, hk⟩ := exists_gt (univ.sup' univ_nonempty θ)
+  obtain ⟨k', hk'⟩ := exists_gt k
+  classical
+  let v : Profile ι O K := λ z _ => if z = x then k' else k
+  have hθ : ∀ z i, θ i ≤ v z i := λ z i => by
+    have := (le_sup' θ (mem_univ i)).trans hk.le
+    simp only [v]
+    split_ifs <;> [exact this.trans hk'.le; exact this]
+  have := h v x y λ i => by simp [v, hxy.symm, hk']
+  simp only [AsymmRel, sassoon, filter_true_of_mem (λ i _ => hθ _ i), le_refl, not_true,
+    and_false] at this
+
+end Sassoon
 
 end DAmbrosioHedden2024

--- a/Linglib/Studies/WaldonEtAl2023.lean
+++ b/Linglib/Studies/WaldonEtAl2023.lean
@@ -419,13 +419,4 @@ theorem flashlight_multiplicative_negligible :
 theorem flashlight_additive_positive :
     weightedScore [1, 1, 1] allFeatures .flashlight > 1/2 := by native_decide
 
-/-- Artifact noun aggregation is utilitarian, not counting — the same
-    point made by [dambrosio-hedden-2024] for multidimensional
-    adjectives. [sassoon-2013]'s binding types (conjunctive,
-    disjunctive, mixed) are all counting aggregation and cannot
-    capture the weighted, continuous-measure structure of artifact
-    noun interpretation. -/
-theorem artifact_aggregation_is_utilitarian :
-    AggregationType.utilitarian ≠ .counting := by decide
-
 end WaldonEtAl2023

--- a/references.bib
+++ b/references.bib
@@ -1262,7 +1262,7 @@
   doi       = {10.1080/00048402.2023.2277923},
   subfield  = {semantics},
   role      = {formalized},
-  sources   = {Studies/DAmbrosioHedden2024.lean}
+  sources   = {Studies/DAmbrosioHedden2024.lean;Semantics/Degree/Aggregation.lean}
 }
 @phdthesis{erteschik-shir-1973,
   author    = {Erteschik-Shir, Nomi},
@@ -42391,4 +42391,79 @@
   subfield  = {morphology/number},
   role      = {cited},
   sources   = {Crossref 10.1017/S0041977X0010847X; Fragments/Bayso/Number.lean}
+}
+@article{arrow-1950,
+  author    = {Arrow, Kenneth J.},
+  year      = {1950},
+  title     = {A Difficulty in the Concept of Social Welfare},
+  journal   = {Journal of Political Economy},
+  volume    = {58},
+  number    = {4},
+  pages     = {328--346},
+  doi       = {10.1086/256963},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Semantics/Degree/Aggregation.lean;Studies/DAmbrosioHedden2024.lean}
+}
+@article{may-1952,
+  author    = {May, Kenneth O.},
+  year      = {1952},
+  title     = {A Set of Independent Necessary and Sufficient Conditions for Simple Majority Decision},
+  journal   = {Econometrica},
+  volume    = {20},
+  number    = {4},
+  pages     = {680--684},
+  doi       = {10.2307/1907651},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Semantics/Degree/Aggregation.lean}
+}
+@book{sen-1970,
+  author    = {Sen, Amartya K.},
+  year      = {1970},
+  title     = {Collective Choice and Social Welfare},
+  publisher = {Holden-Day},
+  address   = {San Francisco},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Semantics/Degree/Aggregation.lean}
+}
+@article{weymark-1984,
+  author    = {Weymark, John A.},
+  year      = {1984},
+  title     = {Arrow's Theorem with Social Quasi-Orderings},
+  journal   = {Public Choice},
+  volume    = {42},
+  number    = {3},
+  pages     = {235--246},
+  doi       = {10.1007/BF00124943},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Semantics/Degree/Aggregation.lean}
+}
+@article{tsui-weymark-1997,
+  author    = {Tsui, Kai-Yuen and Weymark, John A.},
+  year      = {1997},
+  title     = {Social Welfare Orderings for Ratio-Scale Measurable Utilities},
+  journal   = {Economic Theory},
+  volume    = {10},
+  number    = {2},
+  pages     = {241--256},
+  doi       = {10.1007/s001990050156},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Semantics/Degree/Aggregation.lean}
+}
+@article{geanakoplos-2005,
+  author    = {Geanakoplos, John},
+  year      = {2005},
+  title     = {Three Brief Proofs of {Arrow's} Impossibility Theorem},
+  journal   = {Economic Theory},
+  volume    = {26},
+  number    = {1},
+  pages     = {211--215},
+  doi       = {10.1007/s00199-004-0556-7},
+  subfield  = {decision-theory},
+  role      = {cited},
+  sources   = {Studies/DAmbrosioHedden2024.lean}
 }


### PR DESCRIPTION
Recut the study on the paper's own framework: profiles of value functions, admissible aggregation rules, a standard object, determinacy over the admissible set, and the social-choice conditions. The Bool-field "constraints", the invented Alice/Bob fixture and the `native_decide`s are gone.

- `Semantics/Degree/Aggregation.lean` gains the ordering-valued layer (`Rule`, Sen's invariance classes, Arrow's conditions, majority / Pareto / utilitarian / Cobb–Douglas with their proved properties, Condorcet's cycle) on mathlib's `dotProduct`, bridging to `Core.Order.TotalPreorder`; the orphaned Bool bindings and the `AggregationType` enum are deleted, with Waldon's vacuous `utilitarian ≠ counting` theorem.
- The study exercises `Kamp1975.kampPreorder` for the §2 delineation comparison, runs the sorites on Suzy's health under utilitarian weightings, states Arrow's adapted theorem (`sorry`, TODO) with the incoherence corollary, and proves the three verdicts on Sassoon's comparatives keyed on `Degree.DimensionBindingType`.
- Bib: arrow-1950, may-1952, sen-1970, weymark-1984, tsui-weymark-1997, geanakoplos-2005, DOIs resolved.