### PR TITLE
chore(Studies/Dayal2016): drop unused imports

### DIFF
--- a/Linglib/Studies/Dayal2016.lean
+++ b/Linglib/Studies/Dayal2016.lean
@@ -1,11 +1,9 @@
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Order.Atoms
-import Mathlib.Tactic.DeriveFintype
 import Linglib.Data.Examples.Dayal2016
 import Linglib.Features.Number.Basic
 import Linglib.Logic.Modal.Defs
 import Linglib.Semantics.Questions.Exhaustivity
-import Linglib.Semantics.Questions.Hamblin
 
 /-!
 # Dayal, *Questions* (2016)


### PR DESCRIPTION
Drops two imports the study does not use: nothing from `Questions/Hamblin` is referenced, and the `Fintype` derive handler already arrives through `Features/Number/Basic`.