### PR TITLE
refactor(Semantics/Questions): the presupposition on a state and under necessity

### DIFF
--- a/Linglib/Semantics/Questions/Exhaustivity.lean
+++ b/Linglib/Semantics/Questions/Exhaustivity.lean
@@ -18,8 +18,14 @@ operator on the members of `H` true at `w`:
   member: the least true member under entailment, `IsLeast`. Its existence is
   Dayal's existential presupposition `IsExhaustivelyResolvable`; `dayalAns`
   returns it and `dayalStrongAns` applies Heim's strengthening to it;
+- `IsExhaustivelyResolvableOn H s`, the presupposition on an information
+  state: a least member the state supports, Dayal's at the singleton `{w}`;
+- `box H R`, the question under necessity, whose presupposition at a world is
+  the prejacent's on that world's modal base (`isExhaustivelyResolvable_box_iff`);
 - `exhCell H p` and `exhaustifiedPartition H`, [fox-2018]'s cells;
-- `relExh H w M`, [xiang-2022]'s exhaustivity relative to a modal base.
+- `relExh H w M`, [xiang-2022]'s exhaustivity relative to a modal base;
+- `ofFinset F`, a finite family of finite propositions, on which the
+  presuppositions are decidable.
 
 The presupposition holds exactly when the weak answer is itself a member
 (`isExhaustivelyResolvable_iff`), so Dayal's operator agrees with Heim's and
@@ -211,6 +217,59 @@ theorem dayalAns_eq_none_iff : dayalAns H w = none ↔ ¬ IsExhaustivelyResolvab
   rw [isExhaustivelyResolvable_iff, dayalAns]
   split_ifs with h <;> simp [h]
 
+/-! ### Resolvability on an information state -/
+
+/-- The members of `H` an information state `s` supports. -/
+def supported (s : Set W) : Set (Set W) := {p ∈ H | s ⊆ p}
+
+@[simp] theorem mem_supported {s p : Set W} : p ∈ supported H s ↔ p ∈ H ∧ s ⊆ p := Iff.rfl
+
+@[simp] theorem supported_singleton : supported H {w} = trueAnswers H w := by
+  ext p
+  simp [supported, trueAnswers]
+
+/-- Dayal's presupposition on an information state: a least supported member. On the
+singleton state `{w}` it is the presupposition at `w`. -/
+def IsExhaustivelyResolvableOn (s : Set W) : Prop := ∃ p, IsLeast (supported H s) p
+
+theorem isExhaustivelyResolvableOn_singleton :
+    IsExhaustivelyResolvableOn H {w} ↔ IsExhaustivelyResolvable H w := by
+  rw [IsExhaustivelyResolvableOn, supported_singleton]
+  rfl
+
+/-! ### Questions under necessity -/
+
+/-- The question `□Q` over the accessibility `R`: every member necessitated, holding at `x`
+when it holds at every world accessible from `x`. -/
+def box {W' : Type*} (R : W' → W → Prop) : Set (Set W') :=
+  (fun p => {x | ∀ v, R x v → v ∈ p}) '' H
+
+theorem mem_box {W' : Type*} {R : W' → W → Prop} {q : Set W'} :
+    q ∈ box H R ↔ ∃ p ∈ H, {x | ∀ v, R x v → v ∈ p} = q := Iff.rfl
+
+/-- Necessity lifts the presupposition: `□Q` is resolvable at `x` iff `Q` is resolvable on the
+worlds accessible from `x`, provided every world is the sole world accessible from some `x`. -/
+theorem isExhaustivelyResolvable_box_iff {W' : Type*} {R : W' → W → Prop}
+    (hR : ∀ v, ∃ x, ∀ u, R x u ↔ u = v) {x : W'} {s : Set W} (hs : ∀ v, R x v ↔ v ∈ s) :
+    IsExhaustivelyResolvable (box H R) x ↔ IsExhaustivelyResolvableOn H s := by
+  have mem : ∀ p, x ∈ {y | ∀ v, R y v → v ∈ p} ↔ s ⊆ p := fun p =>
+    ⟨fun h v hv => h v ((hs v).2 hv), fun h v hv => h ((hs v).1 hv)⟩
+  have mono : ∀ p q : Set W, p ⊆ q →
+      {y | ∀ v, R y v → v ∈ p} ⊆ {y | ∀ v, R y v → v ∈ q} :=
+    fun _ _ hpq _ h v hv => hpq (h v hv)
+  have refl : ∀ p q : Set W,
+      {y | ∀ v, R y v → v ∈ p} ⊆ {y | ∀ v, R y v → v ∈ q} → p ⊆ q := by
+    intro p q h v hv
+    obtain ⟨y, hy⟩ := hR v
+    exact h (fun u hu => ((hy u).1 hu) ▸ hv) v ((hy v).2 rfl)
+  constructor
+  · rintro ⟨q, ⟨⟨p, hp, rfl⟩, hx⟩, hmin⟩
+    refine ⟨p, ⟨hp, (mem p).1 hx⟩, fun r ⟨hr, hsr⟩ => refl p r (hmin ⟨⟨r, hr, rfl⟩, (mem r).2 hsr⟩)⟩
+  · rintro ⟨p, ⟨hp, hsp⟩, hmin⟩
+    refine ⟨_, ⟨⟨p, hp, rfl⟩, (mem p).2 hsp⟩, ?_⟩
+    rintro q ⟨⟨r, hr, rfl⟩, hx⟩
+    exact mono p r (hmin ⟨hr, (mem r).1 hx⟩)
+
 /-! ### Cells ([fox-2018]) -/
 
 /-- The cell of `p`: the worlds where `p` is the strongest true member. -/
@@ -314,6 +373,24 @@ theorem isExhaustivelyResolvable_ofFinset_iff (F : Finset (Finset W)) (w : W) :
 instance [DecidableEq W] (F : Finset (Finset W)) (w : W) :
     Decidable (IsExhaustivelyResolvable (ofFinset F) w) :=
   decidable_of_iff _ (isExhaustivelyResolvable_ofFinset_iff F w).symm
+
+theorem isExhaustivelyResolvableOn_ofFinset_iff (F : Finset (Finset W)) (s : Finset W) :
+    IsExhaustivelyResolvableOn (ofFinset F) ↑s ↔
+      ∃ p ∈ F, s ⊆ p ∧ ∀ q ∈ F, s ⊆ q → p ⊆ q := by
+  constructor
+  · rintro ⟨p, ⟨hp, hs⟩, hmin⟩
+    obtain ⟨p', hp', rfl⟩ := mem_ofFinset.1 hp
+    exact ⟨p', hp', Finset.coe_subset.1 hs, fun q hq hsq =>
+      Finset.coe_subset.1 (hmin ⟨mem_ofFinset.2 ⟨q, hq, rfl⟩, Finset.coe_subset.2 hsq⟩)⟩
+  · rintro ⟨p, hp, hs, hmin⟩
+    refine ⟨↑p, ⟨mem_ofFinset.2 ⟨p, hp, rfl⟩, Finset.coe_subset.2 hs⟩, ?_⟩
+    rintro q ⟨hq, hsq⟩
+    obtain ⟨q', hq', rfl⟩ := mem_ofFinset.1 hq
+    exact Finset.coe_subset.2 (hmin q' hq' (Finset.coe_subset.1 hsq))
+
+instance [DecidableEq W] (F : Finset (Finset W)) (s : Finset W) :
+    Decidable (IsExhaustivelyResolvableOn (ofFinset F) ↑s) :=
+  decidable_of_iff _ (isExhaustivelyResolvableOn_ofFinset_iff F s).symm
 
 end Finite
 

--- a/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
+++ b/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
@@ -164,58 +164,29 @@ theorem farsi :
 
 /-! ### Questions with *must* (30)–(36) and collective predicates (56)–(57) -/
 
-/-- A deontic world: the nonempty set of permitted buy-worlds. -/
+/-- A deontic world: the nonempty set of buy-worlds it permits. -/
 abbrev Base := {A : Finset World // A.Nonempty}
 
-instance : Fintype Base := Subtype.fintype fun A : Finset World => A.Nonempty
+/-- *Must*'s accessibility: the buy-worlds a deontic world permits. -/
+def permits (A : Base) (v : World) : Prop := v ∈ A.1
 
-/-- *Must* over a proposition about buy-worlds: it holds in every permitted world. -/
-def box (p : Finset World) : Finset Base := univ.filter fun A => ∀ v ∈ A.1, v ∈ p
-
-theorem mem_box {p : Finset World} {A : Base} : A ∈ box p ↔ A.1 ⊆ p := by
-  simp [box, Finset.subset_iff]
-
-theorem box_subset_iff {p q : Finset World} : box p ⊆ box q ↔ p ⊆ q := by
-  refine ⟨fun h v hv => ?_, fun h A hA => mem_box.2 ((mem_box.1 hA).trans h)⟩
-  have := h (mem_box.2 (Finset.singleton_subset_iff.2 hv) :
-    (⟨{v}, Finset.singleton_nonempty v⟩ : Base) ∈ box p)
-  exact Finset.singleton_subset_iff.1 (mem_box.1 this)
-
-/-- Resolvability of the modalized question at the permitted worlds `A`, stated on the
-buy-world Hamblin set. -/
-def ResolvableAt (H : Finset (Finset World)) (A : Finset World) : Prop :=
-  ∃ p ∈ H, A ⊆ p ∧ ∀ q ∈ H, A ⊆ q → p ⊆ q
-
-instance (H : Finset (Finset World)) (A : Finset World) : Decidable (ResolvableAt H A) :=
-  inferInstanceAs (Decidable (∃ p ∈ H, _ ∧ ∀ q ∈ H, _ → _))
-
-/-- The question with *must* is resolvable at a deontic world iff its buy-world Hamblin set
-is resolvable at the permitted worlds. -/
-theorem isExhaustivelyResolvable_image_box (H : Finset (Finset World)) (A : Base) :
-    IsExhaustivelyResolvable (ofFinset (H.image box)) A ↔ ResolvableAt H A.1 := by
-  rw [isExhaustivelyResolvable_ofFinset_iff]
-  constructor
-  · rintro ⟨_, hP, hA, hmax⟩
-    obtain ⟨p, hp, rfl⟩ := Finset.mem_image.1 hP
-    refine ⟨p, hp, mem_box.1 hA, fun q hq hAq => ?_⟩
-    exact box_subset_iff.1 (hmax _ (Finset.mem_image_of_mem _ hq) (mem_box.2 hAq))
-  · rintro ⟨p, hp, hA, hmax⟩
-    refine ⟨box p, Finset.mem_image_of_mem _ hp, mem_box.2 hA, fun Q hQ hAQ => ?_⟩
-    obtain ⟨q, hq, rfl⟩ := Finset.mem_image.1 hQ
-    exact box_subset_iff.2 (hmax q hq (mem_box.1 hAQ))
+/-- Every buy-world is the sole world some deontic world permits. -/
+theorem permits_singleton (v : World) : ∃ A : Base, ∀ u, permits A u ↔ u = v :=
+  ⟨⟨{v}, Finset.singleton_nonempty v⟩, fun _ => Finset.mem_singleton⟩
 
 /-- (59): Forood must buy one of two things, and either is permitted. -/
 def freeChoice : Base := ⟨{{0}, {1}}, by decide⟩
 
-/-- (35)–(36) vs. (32)–(33): with the interrogative binding into the scope of *must* (34),
-only □(b₁ ∨ b₂) is true in the free-choice scenario, so the presupposition holds iff the
-interrogative ranges over disjunctions — which *-ro* removes, (62)–(63). -/
+/-- (35)–(36) vs. (32)–(33): with the interrogative binding into the scope of *must* (34), the
+question is resolvable in the free-choice scenario iff the interrogative ranges over
+disjunctions — which *-ro* removes, (62)–(63). -/
 theorem modal_gq :
-    (IsExhaustivelyResolvable (ofFinset ((hamblin bought neutral).image box)) freeChoice ∧
-        IsExhaustivelyResolvable (ofFinset ((hamblin bought atoms).image box)) freeChoice) ∧
-      (¬ IsExhaustivelyResolvable (ofFinset ((hamblinRo bought neutral).image box)) freeChoice ∧
-        ¬ IsExhaustivelyResolvable (ofFinset ((hamblinRo bought atoms).image box)) freeChoice) := by
-  simp only [isExhaustivelyResolvable_image_box]; decide
+    ∀ D ∈ [neutral, atoms],
+      IsExhaustivelyResolvable (box (ofFinset (hamblin bought D)) permits) freeChoice ∧
+        ¬ IsExhaustivelyResolvable (box (ofFinset (hamblinRo bought D)) permits) freeChoice := by
+  simp only [isExhaustivelyResolvable_box_iff _ permits_singleton (x := freeChoice)
+    (s := (↑freeChoice.1 : Set World)) fun _ => Iff.rfl]
+  decide
 
 /-- *Mixed together*: a collective predicate, true of a plurality that was bought. -/
 def mixed (e : Entity) (w : World) : Prop := 2 ≤ e.card ∧ e ⊆ w
@@ -269,11 +240,12 @@ theorem rows_agree :
 example : (Examples.all.filter fun row => (predicted row).isSome).length = 16 := by decide +kernel
 
 /-- (60)–(63): the embedded questions are felicitous in (59) iff their interrogative ranges
-over disjunctions (`isExhaustivelyResolvable_image_box` relates this to the modalized
-question). -/
+over disjunctions (`isExhaustivelyResolvable_box_iff` relates this to the question with
+*must*). -/
 theorem scenario_rows :
     ∀ row ∈ Examples.all, row.feature? "scenario" = some "freeChoice59" →
-      (hamblinOf row).map (fun H => decide (ResolvableAt H freeChoice.1)) =
+      (hamblinOf row).map
+          (fun H => decide (IsExhaustivelyResolvableOn (ofFinset H) ↑freeChoice.1)) =
         some (row.feature? "verdict" == some "true") := by decide +kernel
 
 end AlonsoOvalleMoghiseh2025b


### PR DESCRIPTION
Follow-up to #2760: Dayal's presupposition generalizes from a world to an information state (`IsExhaustivelyResolvableOn`, the least member the state supports; `{w}` recovers the original), and necessity lifts it: `box H R` is resolvable at a world iff `H` is resolvable on that world's accessible set (`isExhaustivelyResolvable_box_iff`).

- AlonsoOvalleMoghiseh2025b's `modal_gq` is now one `decide` over the free-choice base through the lift lemma; the study's Finset `box`, `mem_box`, `box_subset_iff`, `ResolvableAt`, and bridge theorem are gone.
- Both presuppositions are decidable on `ofFinset`.