### PR TITLE
refactor(Studies/Chierchia2006): derive regions and entries from profiles

### DIFF
--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -57,7 +57,7 @@ inductive HaspelmathFunction where
   | directNeg
   /-- Function 9: Free choice. -/
   | freeChoice
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr
 
 /-- All nine functions, listed in map order. -/
 def HaspelmathFunction.all : List HaspelmathFunction :=
@@ -197,7 +197,7 @@ inductive OntologicalCategory where
   | determiner
   /-- Reason / cause: 'for some reason' (interrogative *why?*) — non-universal. -/
   | reason
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr
 
 /-- The seven core ontological categories realized "practically everywhere"
     ([haspelmath-1997] §3.1.3); excludes the non-universal `determiner`
@@ -224,7 +224,7 @@ inductive MorphologicalBasis where
   | special
   /-- An existential predication construction. -/
   | existentialConstruction
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr
 
 end Indefinite
 
@@ -235,8 +235,9 @@ end Indefinite
     contiguous region of the implicational map it covers — over any word-class representation.
 
     Word-class-neutral by design (`Indefinite` ≠ pronoun): the sole current carrier is
-    `Indefinite.IndefinitePronoun` (`Syntax/Category/Pronoun/Indefinite.lean`), but an indefinite determiner
-    (over `Definiteness`'s `Determiner`) or pro-adverb supplies its own `instance : Indefinite That`
+    `Indefinite.IndefinitePronoun` (`Syntax/Category/Pronoun/Indefinite.lean`), but an indefinite
+    determiner (over `Definiteness`'s `Determiner`) or pro-adverb supplies its own
+    `instance : Indefinite That`
     and is then read by the same generic `[Indefinite α]` code. This is the indefinite analogue of
     mathlib's `MonoidHomClass`-over-`MonoidHom`/`RingHom`. -/
 class Indefinite (α : Type*) where

--- a/Linglib/Studies/Chierchia2006.lean
+++ b/Linglib/Studies/Chierchia2006.lean
@@ -3,252 +3,143 @@ import Linglib.Semantics.Polarity.Item
 import Linglib.Fragments.English.PolarityItems
 import Linglib.Fragments.Italian.PolarityItems
 import Linglib.Fragments.German.PolarityItems
-import Linglib.Semantics.Exhaustification.InnocentExclusion
-import Linglib.Semantics.Exhaustification.Antiexhaustive
-import Linglib.Studies.Chierchia2013
 import Linglib.Data.Examples.Chierchia2006
 /-!
-# Chierchia 2006: domain widening and the polarity-item typology
+# Chierchia (2006): Broaden your views
 
 This file formalizes the parametric decomposition of polarity-sensitive items in
 [chierchia-2006]. An item's distribution follows from two things about its alternatives: how
 fine-grained the domain alternatives are, and whether exhaustification over them must strictly
 strengthen. Together with whether domain alternatives are obligatory and whether the item has
-scalar alternatives, these fix a class — pure negative-polarity item, negative-polarity and
-free-choice item, pure free-choice item, and their existential-free-choice counterparts — and each
-class's eligible region turns out to be a contiguous stretch of [haspelmath-1997]'s implicational
-map, which is why indefinite series cover contiguous function ranges.
+scalar alternatives, these fix a class, pure negative-polarity item, negative-polarity and
+free-choice item, pure free-choice item, and their existential-free-choice counterparts, and
+each class's eligible region turns out to be a contiguous stretch of [haspelmath-1997]'s
+implicational map, which is why indefinite series cover contiguous function ranges. The
+proper-strengthening parameter separates Italian *qualsiasi* from English *any* under negation:
+exhaustification of *any* in a downward-entailing context is vacuous, which its weak
+alternative set tolerates, so the negative-polarity reading survives, while *qualsiasi* requires
+proper strengthening, which a downward-entailing context cannot supply, so only the rhetorical
+¬∀ reading remains. The Italian judgments are rows, and the theorems derive the regions, the
+contrast under negation, the Fragment entries' parameters and the judgments from the profiles.
 
-The proper-strengthening parameter is what separates Italian *qualsiasi* from English *any* under
-negation. Exhaustification of *any* in a downward-entailing context is vacuous, which its weak
-alternative-set tolerates, so the negative-polarity reading survives; *qualsiasi* requires proper
-strengthening, which a downward-entailing context cannot supply, so only the rhetorical ¬∀ reading
-remains. The Italian judgments of §2 are rows in `Data/Examples/Chierchia2006.json`.
+## TODO
 
-## Main definitions
-
-* `PSIProfile`, `PSIProfile.predictedFunctions` — the parameters and the eligible region they fix
-* `pureNPI`, `npiFCI`, `pureFCI`, `efciNpiFci`, `efciPureFci` — the classes
-* `PSIProfile.predictedLicensor`, `PSIProfile.predictedFC`, `PSIProfile.toFCIFlavor` — what a
-  profile predicts about a Fragment entry
-* `sigmaBoldDefined` — the presuppositional alternative-set of the proper-strengthening items
-
-## Main results
-
-* `all_psi_classes_contiguous` — every class's eligible region is a contiguous Haspelmath stretch
-* `dMax_presuppositional_empty` — requiring both downward-entailing contexts and proper
-  strengthening is contradictory, so that cell of the typology is empty
-* `sample_series_within_predicted`, `fragment_entries_match_profiles` — the sampled series and the
-  Fragment entries fall inside what their classes predict
-* `sigma_bold_fails_in_de`, `dMax_enrichment_vacuous_in_de`, `fci_universal_from_oMinus` — why
-  proper strengthening fails in a downward-entailing context, and where the universal force of a
-  free-choice item comes from
-* `force_tracks_construction`, `subtrigging_rescues_universal`,
-  `subtrigging_does_not_rescue_existential`, `negation_rhetorical_only` — the Italian data
+* The German *irgend*-series is checked without `specificUnknown`, the [kratzer-shimoyama-2002]
+  ignorance reading, which `PSIProfile.predictedFunctions` does not generate.
 
 ## References
 
 * [chierchia-2006]
 * [haspelmath-1997]
-* [kadmon-landman-1993]
 * [kratzer-shimoyama-2002]
-* [fox-2007]
 -/
 
 namespace Chierchia2006
 
-open Haspelmath1997
-open Indefinite
-open Chierchia2013 (FCIFlavor)
+open Haspelmath1997 Indefinite Data.Examples
 
--- ============================================================================
--- §1. The PSI Parameter Space
--- ============================================================================
+/-! ### The parameters -/
 
-/-- Domain alternative grain size.
-
-    [chierchia-2006] table (76)/(94):
-    - `max`: Only large subdomains. Triggers even-like enrichment (E):
-      the speaker chose the strongest alternative she has evidence for.
-      Pure NPIs (*alcuno*, *mai*, *ever*).
-    - `min`: All subdomains including singletons. Triggers antiexhaustive
-      enrichment (O⁻ in 2006; IE+II in 2026): every subdomain must be
-      satisfiable, yielding universal-like force.
-      FCIs (*any*, *qualsiasi*, *irgendein*). -/
+/-- The grain of an item's domain alternatives: only large subdomains, which trigger the
+even-like enrichment of the pure negative-polarity items *alcuno*, *mai*, *ever*, or every
+subdomain down to the singletons, which trigger the antiexhaustive enrichment of the free-choice
+items *any*, *qualsiasi*, *irgendein*. -/
 inductive DomainAltGrain where
-  | max  -- Pure NPIs: large D-alternatives → even-like
-  | min  -- FCIs: all D-alternatives → antiexhaustive
+  | max
+  | min
   deriving DecidableEq, Repr
 
-/-- The PSI profile: the 2026-consensus distillation of
-    [chierchia-2006]'s parametric PSI typology.
-
-    The original paper used σ (weak) vs σ̃ (presuppositional) for
-    implicature freezing, and O/E/O⁻ for enrichment. These specific
-    operators have been superseded by IE+II ([bar-lev-fox-2020]),
-    but the *parameters* they encode remain the standard way to
-    classify PSIs cross-linguistically. -/
+/-- The parameters that fix a polarity-sensitive item's class: the grain of its domain
+alternatives, whether they are obligatorily active, whether exhaustification over them must
+properly strengthen, the presupposition of the operator σ̃, and whether scalar alternatives are
+active too. -/
 structure PSIProfile where
-  /-- Domain alternative grain (MAX vs MIN) -/
   grain : DomainAltGrain
-  /-- Whether domain alternatives are obligatorily active -/
   obligatoryDomainAlts : Bool
-  /-- Whether exhaustification must yield proper strengthening
-      (corresponds to [chierchia-2006]'s presuppositional σ̃) -/
   requiresProperStrengthening : Bool
-  /-- Whether scalar alternatives are also activated -/
   hasScalarAlts : Bool
   deriving DecidableEq, Repr
 
--- ============================================================================
--- §2. The Five PSI Classes (table (94))
--- ============================================================================
+/-! ### The five classes -/
 
-/-- Pure NPIs: *alcuno* (Italian), *mai* (Italian), *ever* (English).
-    D-MAX, obligatory, weak σ, no scalar. -/
+/-- The pure negative-polarity items *alcuno*, *mai*, *ever*: large domain alternatives,
+obligatory, weak σ, no scalar alternatives. -/
 def pureNPI : PSIProfile :=
   { grain := .max
   , obligatoryDomainAlts := true
   , requiresProperStrengthening := false
   , hasScalarAlts := false }
 
-/-- NPI/FCIs: English *any*.
-    D-MIN, obligatory, weak σ, no scalar.
-    NPI in DE (exhaustification vacuous), FCI under modals. -/
+/-- English *any*, a negative-polarity item in downward-entailing contexts, where
+exhaustification is vacuous, and a free-choice item under modals: every domain alternative,
+obligatory, weak σ, no scalar alternatives. -/
 def npiFCI : PSIProfile :=
   { grain := .min
   , obligatoryDomainAlts := true
   , requiresProperStrengthening := false
   , hasScalarAlts := false }
 
-/-- Pure universal FCIs: Italian *qualsiasi/qualunque*.
-    D-MIN, obligatory, presuppositional σ̃, no scalar.
-    Positive polarity: proper strengthening fails in DE. -/
+/-- The pure free-choice items *qualsiasi* and *qualunque*: every domain alternative,
+obligatory, the presuppositional σ̃, no scalar alternatives. -/
 def pureFCI : PSIProfile :=
   { grain := .min
   , obligatoryDomainAlts := true
   , requiresProperStrengthening := true
   , hasScalarAlts := false }
 
-/-- Existential FCI (NPI/FCI): German *irgendein*.
-    D-MIN, obligatory, weak σ, with scalar alts.
-    Like *any* but with scalar implicatures; needs rescue mechanisms. -/
+/-- German *irgendein*, an existential free-choice item: like *any* with scalar alternatives
+active. -/
 def efciNpiFci : PSIProfile :=
   { grain := .min
   , obligatoryDomainAlts := true
   , requiresProperStrengthening := false
   , hasScalarAlts := true }
 
-/-- Existential pure FCI: Italian *uno qualsiasi*.
-    D-MIN, obligatory, presuppositional σ̃, with scalar alts. -/
+/-- Italian *uno qualsiasi*, an existential pure free-choice item: like *qualsiasi* with
+scalar alternatives active. -/
 def efciPureFci : PSIProfile :=
   { grain := .min
   , obligatoryDomainAlts := true
   , requiresProperStrengthening := true
   , hasScalarAlts := true }
 
--- ============================================================================
--- §3. Predicted Haspelmath Functions
--- ============================================================================
+/-! ### Eligible regions on the implicational map -/
 
-/-!
-## Connecting PSI Theory to Distributional Typology
-
-Each PSI class predicts an **eligible region** on [haspelmath-1997]'s
-implicational map — the set of functions where items of that class can
-appear. The eligible region is **derived** from the PSI parameters and the
-monotonicity classification of Haspelmath functions (`isDE`, `isFC`),
-not hardcoded.
-
-The derivation:
-- **No obligatory alts** (plain indefinites): No polarity sensitivity →
-  eligible only where neither DE licensing nor FC licensing is required.
-- **D-MAX, weak σ** (pure NPIs): Even-like enrichment (E) is informative
-  only in DE contexts → filter to DE functions.
-- **D-MAX, σ̃**: Contradictory — even-like enrichment requires DE, but σ̃'s
-  proper strengthening fails in DE (`sigma_bold_fails_in_de`) → empty.
-- **D-MIN, weak σ** (NPI/FCIs): In DE, exhaustification is vacuous → NPI;
-  under modals, antiexhaustive → FC. Also usable in irrealis. Filter to
-  DE ∪ FC ∪ irrealis.
-- **D-MIN, σ̃** (pure FCIs): Proper strengthening fails in DE → filter to
-  FC only.
--/
-
-/-- The Haspelmath functions predicted by a PSI class.
-
-    Derived from PSI parameters via the monotonicity classification of
-    Haspelmath functions (`HaspelmathFunction.isDE`, `HaspelmathFunction.isFC`).
-    Each branch filters `HaspelmathFunction.all` by the semantic property
-    that the PSI class's enrichment mechanism targets. -/
+/-- The functions of the implicational map a class is eligible for, from its parameters and
+the monotonicity of the functions: a plain indefinite needs neither downward-entailing nor
+free-choice licensing; even-like enrichment over large alternatives is informative only in a
+downward-entailing context, and never together with proper strengthening; fine alternatives
+under weak σ are vacuously exhaustified in a downward-entailing context and antiexhaustified
+under a modal, irrealis included; under σ̃ only the free-choice functions remain. -/
 def PSIProfile.predictedFunctions (p : PSIProfile) : List HaspelmathFunction :=
-  HaspelmathFunction.all.filter (λ f =>
-    if !p.obligatoryDomainAlts then
-      -- Plain indefinites: no polarity sensitivity, no FC
-      !f.isDE && !f.isFC
+  HaspelmathFunction.all.filter λ f =>
+    if !p.obligatoryDomainAlts then !f.isDE && !f.isFC
     else match p.grain, p.requiresProperStrengthening with
-      -- D-MAX, weak σ: even-like enrichment informative only in DE
       | .max, false => f.isDE
-      -- D-MAX, σ̃: contradictory (DE + proper strengthening = ⊥)
-      | .max, true  => false
-      -- D-MIN, weak σ: NPI in DE + FCI under modals + irrealis
+      | .max, true => false
       | .min, false => f.isDE || f.isFC || f == .irrealis
-      -- D-MIN, σ̃: proper strengthening fails in DE → FC only
-      | .min, true  => f.isFC)
+      | .min, true => f.isFC
 
--- ============================================================================
--- §4. Contiguity Theorems
--- ============================================================================
+/-- The five classes. -/
+def classes : List PSIProfile := [pureNPI, npiFCI, pureFCI, efciNpiFci, efciPureFci]
 
-/-!
-## Each PSI class maps to a contiguous Haspelmath region
+/-- Every class's eligible region is a contiguous stretch of the implicational map, which is
+why an indefinite series covers a contiguous range of functions. -/
+theorem classes_contiguous :
+    ∀ p ∈ classes, HaspelmathFunction.isContiguous p.predictedFunctions = true := by
+  decide
 
-This is the central bridge between [chierchia-2006]'s exhaustification
-theory and [haspelmath-1997]'s typological generalization. It explains
-*why* indefinite pronoun series cover contiguous function ranges: each
-PSI class's eligible region is contiguous, and surface forms cover
-contiguous subsets of their class's region.
--/
-
-/-- All five PSI classes have contiguous predicted function ranges. -/
-theorem all_psi_classes_contiguous :
-    [pureNPI, npiFCI, pureFCI, efciNpiFci, efciPureFci].all
-      (λ p => HaspelmathFunction.isContiguous p.predictedFunctions) = true := by decide
-
-/-- D-MAX + presuppositional is unattested: the combination of requiring
-    DE contexts (D-MAX) and proper strengthening (σ̃) is contradictory,
-    since DE contexts are exactly where strengthening fails. -/
+/-- Large domain alternatives with proper strengthening is an empty cell: even-like enrichment
+needs a downward-entailing context, which is where strengthening fails. -/
 theorem dMax_presuppositional_empty :
-    ({ grain := .max, obligatoryDomainAlts := true,
-       requiresProperStrengthening := true, hasScalarAlts := false
-       : PSIProfile }).predictedFunctions = [] := rfl
+    (PSIProfile.mk .max true true false).predictedFunctions = [] := rfl
 
--- ============================================================================
--- §5. Cross-Linguistic Verification (derived from Typology.lean)
--- ============================================================================
+/-! ### The sampled series -/
 
-/-!
-## Matching cross-linguistic data to PSI predictions
-
-Each surface form's actual Haspelmath functions (from
-[haspelmath-1997]'s typological data in `Typology.lean`) should be
-a subset of its PSI class's predicted (eligible) region.
-
-**All function lists are derived from `Typology.lean` profiles** — not
-hardcoded — so changes to the typological data will break exactly the
-theorems they should.
--/
-
-private def functionsSubset (actual predicted : List HaspelmathFunction) : Bool :=
-  actual.all (λ f => predicted.contains f)
-
-/-- Extract Haspelmath functions for a named form from a language paradigm.
-    Uses `e.functionList` (the computable list extraction) rather than
-    `Finset.toList` (noncomputable). -/
-private def seriesFunctions (profile : IndefiniteParadigm) (form : String)
-    : List HaspelmathFunction :=
-  match profile.forms.find? (·.form == form) with
-  | some e => e.functionList
-  | none => []
+/-- The functions a named form of a paradigm covers. -/
+private def seriesFunctions (profile : IndefiniteParadigm) (form : String) :
+    List HaspelmathFunction :=
+  ((profile.forms.find? (·.form == form)).map (·.functionList)).getD []
 
 /-- The plain indefinite profile: no obligatory domain alternatives and no proper-strengthening
 requirement. -/
@@ -256,288 +147,133 @@ private def plainIndefinite : PSIProfile :=
   { grain := .max, obligatoryDomainAlts := false,
     requiresProperStrengthening := false, hasScalarAlts := false }
 
-/-- Every series in the sample covers a subset of the region its class predicts. The German
-*irgend*-series is checked without `specificUnknown`, the [kratzer-shimoyama-2002] ignorance
-reading, which the eligibility encoding does not generate — a gap in the encoding rather than in
-the data. -/
+/-- Every series in the sample covers a subset of the region its class predicts. -/
 theorem sample_series_within_predicted :
-    [ (seriesFunctions italian "nessuno", pureNPI)
-    , (seriesFunctions italian "qualunque/qualsiasi", pureFCI)
-    , (seriesFunctions italian "qualcuno", plainIndefinite)
-    , (seriesFunctions english "any- (NPI)", npiFCI)
-    , (seriesFunctions english "any- (FC)", npiFCI)
-    , ((seriesFunctions german "irgendwer").filter (· != .specificUnknown), efciNpiFci)
-    , (seriesFunctions mandarin "shéi (谁, non-interrog.)", npiFCI) ].all
-      (fun p => functionsSubset p.1 p.2.predictedFunctions) = true := by decide
+    ∀ p ∈ [(seriesFunctions italian "nessuno", pureNPI),
+        (seriesFunctions italian "qualunque/qualsiasi", pureFCI),
+        (seriesFunctions italian "qualcuno", plainIndefinite),
+        (seriesFunctions english "any- (NPI)", npiFCI),
+        (seriesFunctions english "any- (FC)", npiFCI),
+        ((seriesFunctions german "irgendwer").filter (· != .specificUnknown), efciNpiFci),
+        (seriesFunctions mandarin "shéi (谁, non-interrog.)", npiFCI)],
+      ∀ f ∈ p.1, f ∈ p.2.predictedFunctions := by
+  decide
 
--- ============================================================================
--- §6. The qualsiasi/any Contrast Under Negation
--- ============================================================================
+/-! ### *qualsiasi* and *any* under negation -/
 
-/-!
-## Deriving the core empirical contrast
+/-- A pure negative-polarity item is eligible in every downward-entailing function and in no
+free-choice function: even-like enrichment is informative only under downward entailment, and
+large alternatives give no antiexhaustive enrichment. -/
+theorem pureNPI_region :
+    ∀ f ∈ HaspelmathFunction.all,
+      (f.isDE = true → f ∈ pureNPI.predictedFunctions) ∧
+        (f.isFC = true → f ∉ pureNPI.predictedFunctions) := by
+  decide
 
-[chierchia-2006]'s most striking prediction: Italian *qualsiasi*
-and English *any* differ under negation.
-
-- "I didn't see any student" — grammatical (NPI reading)
-- "Non ho visto qualsiasi studente" — marginal, only rhetorical ¬∀
-
-This follows from `requiresProperStrengthening`: *any* (weak σ) allows
-vacuous exhaustification in DE; *qualsiasi* (presuppositional σ̃) requires
-proper strengthening, which fails in DE since the exhaustified meaning
-is not strictly stronger than the plain meaning.
-
-The paper derives two LF representations for *any* under negation:
-1. σ scopes above ¬ → freeze implicature, then negate → rhetorical reading
-2. σ scopes below ¬ → negate, then check implicature → NPI reading
-   (implicature is entailed by assertion, so it vanishes)
-
-For *qualsiasi*, only option (1) is available: σ̃ requires proper
-strengthening, which option (2) cannot deliver (the implicature is
-vacuous in DE). This is formalized as the `requiresProperStrengthening`
-parameter blocking DE eligibility.
--/
-
-/-- Every DE Haspelmath function is in the NPI/FCI eligible region.
-    D-MIN + weak σ: exhaustification is vacuous in DE (NPI reading). -/
-theorem npiFCI_eligible_in_all_de :
-    (HaspelmathFunction.all.filter (·.isDE)).all
-      (npiFCI.predictedFunctions.contains ·) = true := by decide
-
-/-- No DE Haspelmath function is in the pure FCI eligible region.
-    D-MIN + σ̃: proper strengthening fails in DE (`sigma_bold_fails_in_de`). -/
-theorem pureFCI_not_eligible_in_any_de :
-    (HaspelmathFunction.all.filter (·.isDE)).all
-      (λ f => !pureFCI.predictedFunctions.contains f) = true := by decide
-
-/-- Every DE function is in the pure NPI eligible region.
-    D-MAX + weak σ: even-like enrichment is informative in DE. -/
-theorem pureNPI_eligible_in_all_de :
-    (HaspelmathFunction.all.filter (·.isDE)).all
-      (pureNPI.predictedFunctions.contains ·) = true := by decide
-
-/-- No FC function is in the pure NPI eligible region.
-    D-MAX items lack antiexhaustive enrichment. -/
-theorem pureNPI_not_eligible_in_fc :
-    (HaspelmathFunction.all.filter (·.isFC)).all
-      (λ f => !pureNPI.predictedFunctions.contains f) = true := by decide
-
-/-- The *qualsiasi*/*any* contrast: among D-MIN items, every DE function
-    is included by weak σ (*any*) and excluded by σ̃ (*qualsiasi*). -/
+/-- The contrast between *any* and *qualsiasi*: with every domain alternative active, each
+downward-entailing function is eligible under weak σ, where exhaustification is vacuous, and
+ineligible under σ̃, whose proper strengthening the context cannot supply, leaving *qualsiasi*
+under negation only the rhetorical ¬∀ reading. -/
 theorem dMin_sigma_determines_de :
-    (HaspelmathFunction.all.filter (·.isDE)).all
-      (λ f => npiFCI.predictedFunctions.contains f &&
-              !pureFCI.predictedFunctions.contains f) = true := by decide
+    ∀ f ∈ HaspelmathFunction.all, f.isDE = true →
+      f ∈ npiFCI.predictedFunctions ∧ f ∉ pureFCI.predictedFunctions := by
+  decide
 
-/-- Map PSI profiles to FCI flavor (none if not an FCI).
-    Only D-MIN items are FCIs — D-MAX items are pure NPIs. -/
-def PSIProfile.toFCIFlavor (p : PSIProfile) : Option FCIFlavor :=
-  if !p.obligatoryDomainAlts then none
-  else match p.grain with
-    | .max => none  -- D-MAX = pure NPI, not an FCI
-    | .min => if p.hasScalarAlts then some .existential else some .universal
+/-! ### The Fragment entries -/
 
--- *irgendein* = existential FCI
-theorem irgendein_is_existential :
-    efciNpiFci.toFCIFlavor = some .existential := rfl
+/-- The licensor strength a profile predicts: an item whose obligatory alternatives are
+exhaustified under weak σ is licensed by any downward-entailing operator, since vacuous
+exhaustification is tolerated there, and no other item is licensed by strength. -/
+def PSIProfile.predictedLicensor (p : PSIProfile) : Option Polarity.DEStrength :=
+  if p.obligatoryDomainAlts && !p.requiresProperStrengthening then some .weak else none
 
--- *any* = universal FCI
-theorem any_is_universal :
-    npiFCI.toFCIFlavor = some .universal := rfl
+/-- A profile predicts free-choice licensing when its obligatory alternatives are fine. -/
+def PSIProfile.PredictsFreeChoice (p : PSIProfile) : Prop :=
+  p.obligatoryDomainAlts = true ∧ p.grain = .min
 
--- *qualsiasi* = universal FCI
-theorem qualsiasi_is_universal :
-    pureFCI.toFCIFlavor = some .universal := rfl
-
--- Pure NPIs are NOT FCIs (D-MAX → not an FCI)
-theorem pureNPI_not_fci :
-    pureNPI.toFCIFlavor = none := rfl
-
--- ============================================================================
--- §8. Fragment Bridges (PSIProfile → PolarityType)
--- ============================================================================
-
-/-!
-## Bridging PSI profiles to Fragment entries
-
-`PSIProfile` is a 4-parameter theoretical decomposition; each PSI class
-predicts the item's licensing parameters (`licensor` strength and
-free-choice licensing), and each Fragment entry's instantiated parameters
-should match its profile's prediction.
--/
-
-open Polarity
-open English.PolarityItems (any ever)
-open Italian.PolarityItems
-  (mai qualsiasi nessuno qualunque uno_qualsiasi alcuno)
-open German.PolarityItems (irgendein)
-
-/-- The licensor strength a PSI profile predicts (`none` = not
-    strength-licensed). -/
-def PSIProfile.predictedLicensor (p : PSIProfile) :
-    Option Polarity.DEStrength :=
-  if !p.obligatoryDomainAlts then none
-  else match p.grain, p.requiresProperStrengthening with
-    | .max, false => some .weak         -- D-MAX, weak σ → pure NPI
-    | .max, true  => some .antiAdditive -- D-MAX, presuppositional (unattested)
-    | .min, false => some .weak         -- D-MIN, weak σ → NPI/FCI (any)
-    | .min, true  => none               -- D-MIN, σ̃ → pure FCI (qualsiasi)
-
-/-- Whether the profile predicts free-choice (mechanism) licensing. -/
-def PSIProfile.predictedFC (p : PSIProfile) : Bool :=
-  p.obligatoryDomainAlts && p.grain == .min
+instance : DecidablePred PSIProfile.PredictsFreeChoice :=
+  λ _ => inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Each Fragment entry's licensor and free-choice fields are what its class predicts. -/
 theorem fragment_entries_match_profiles :
-    [ (any, npiFCI), (ever, pureNPI), (mai, pureNPI), (alcuno, pureNPI), (nessuno, pureNPI)
-    , (qualsiasi, pureFCI), (qualunque, pureFCI), (uno_qualsiasi, efciPureFci)
-    , (irgendein, efciNpiFci) ].all
-      (fun e => e.1.licensor == e.2.predictedLicensor && e.1.freeChoice == e.2.predictedFC)
-      = true := by decide
+    ∀ e ∈ [(English.PolarityItems.any, npiFCI), (English.PolarityItems.ever, pureNPI),
+        (Italian.PolarityItems.mai, pureNPI), (Italian.PolarityItems.alcuno, pureNPI),
+        (Italian.PolarityItems.nessuno, pureNPI), (Italian.PolarityItems.qualsiasi, pureFCI),
+        (Italian.PolarityItems.qualunque, pureFCI),
+        (Italian.PolarityItems.uno_qualsiasi, efciPureFci),
+        (German.PolarityItems.irgendein, efciNpiFci)],
+      e.1.licensor = e.2.predictedLicensor ∧ (e.1.freeChoice = true ↔ e.2.PredictsFreeChoice) := by
+  decide
 
--- ============================================================================
--- §10. Exhaustification Theory: σ̃, SI Vacuity, and O⁻
--- ============================================================================
+/-! ### Proper strengthening and downward entailment -/
 
-/-!
-## Exercising the Exhaustification theory layer
-
-This section connects [chierchia-2006]'s PSI typology to the formal
-results in `Exhaustification`.
-
-### σ̃: Presuppositional implicature freezing (§3.3, §5.3)
-
-σ "freezes" the implicature; σ̃ adds a **presupposition** that the frozen
-meaning is **strictly stronger** than the plain meaning (definition (72)).
-`sigma_bold_fails_in_de` delegates to `entailment_reversal_in_de`.
-
-### SI vacuity in DE (§4.1)
-
-D-MAX (even-like) enrichment is an SI. SIs are vacuous in DE
-(`si_vacuous_in_de`), explaining why pure NPIs are confined to DE.
-
-### O⁻ yields universal force (§5.1)
-
-Antiexhaustive enrichment of ∃x∈D.P(x) with D-MIN alternatives gives
-∀a∈D. P(a) (`antiexh_yields_universal`). This is the "birth of universal
-readings" behind FCI universal force.
--/
-
-section SigmaOperators
+section Strengthening
 
 variable {World : Type*}
 
-open Exhaustification (oMinus antiexh_yields_universal)
+/-- The presupposition of σ̃: the enriched meaning is strictly stronger than the plain one. -/
+def ProperlyStrengthens (plain enriched : World → Prop) : Prop :=
+  (∀ w, enriched w → plain w) ∧ ¬ ∀ w, plain w → enriched w
 
-/-- σ̃'s presupposition: the enriched meaning is **strictly stronger**
-    than the plain meaning. [chierchia-2006] definition (72).
+/-- The presupposition fails in a downward-entailing context: an enrichment that properly
+strengthens at the base is reversed there, so the enriched meaning is the weaker one. This is
+what keeps *qualsiasi* out of negative-polarity positions. -/
+theorem not_properlyStrengthens_of_de (C : (World → Prop) → (World → Prop))
+    (hDE : ∀ p q : World → Prop, (∀ w, p w → q w) → ∀ w, C q w → C p w)
+    (plain enriched : World → Prop) (h : ∀ w, enriched w → plain w) :
+    ¬ ProperlyStrengthens (C plain) (C enriched) :=
+  λ ⟨_, hnotrev⟩ => hnotrev (hDE enriched plain h)
 
-    This must hold for σ̃ to be defined (felicitous). Items selecting σ̃
-    (*qualsiasi*, *qualunque*) require proper strengthening; items selecting
-    plain σ (*any*, *ever*) don't. -/
-def sigmaBoldDefined (plain enriched : World → Prop) : Prop :=
-  (∀ w, enriched w → plain w) ∧ ¬(∀ w, plain w → enriched w)
+/-- A scalar implicature is vacuous in a downward-entailing context: the weak alternative never
+holds there while the strong one fails, which is why even-like enrichment is informative only
+outside such contexts. -/
+theorem dMax_enrichment_vacuous_in_de (C : (World → Prop) → (World → Prop))
+    (hDE : ∀ p q : World → Prop, (∀ w, p w → q w) → ∀ w, C q w → C p w)
+    (weak strong : World → Prop) (h : ∀ w, strong w → weak w) :
+    ∀ w, ¬ (C weak w ∧ ¬ C strong w) :=
+  λ w ⟨hCw, hnCs⟩ => hnCs (hDE strong weak h w hCw)
 
-/-- **σ̃'s presupposition fails in DE contexts.**
+end Strengthening
 
-    [chierchia-2006] §5.3: This is the formal content of the
-    *qualsiasi*/*any* contrast. If enrichment properly strengthens at the
-    base level (enriched ⊂ plain), then embedding in a DE context
-    *reverses* the entailment: C(plain) ⊆ C(enriched), making the
-    enriched meaning under C strictly WEAKER, not stronger.
-
-    The DE reversal gives C(plain) ⊆ C(enriched), which contradicts σ̃'s
-    requirement that C(enriched) be strictly stronger than C(plain). -/
-theorem sigma_bold_fails_in_de
-    (C : (World → Prop) → (World → Prop))
-    (hDE : ∀ (p q : World → Prop), (∀ w, p w → q w) → (∀ w, C q w → C p w))
-    (plain enriched : World → Prop)
-    (h_stronger : ∀ w, enriched w → plain w) :
-    ¬sigmaBoldDefined (C plain) (C enriched) :=
-  fun ⟨_, hnotrev⟩ => hnotrev (hDE enriched plain h_stronger)
-
-/-- **SI vacuity in DE blocks D-MAX enrichment in UE.**
-
-    [chierchia-2006] §4.1: D-MAX items (pure NPIs) trigger
-    even-like (E) enrichment, which is an SI. SIs are vacuous in DE, so E
-    enrichment is informative only in non-DE contexts — but D-MAX items
-    *require* DE. This is why pure NPIs are confined to DE contexts. -/
-theorem dMax_enrichment_vacuous_in_de
-    (C : (World → Prop) → (World → Prop))
-    (hDE : ∀ (p q : World → Prop), (∀ w, p w → q w) → (∀ w, C q w → C p w))
-    (weak strong : World → Prop) (h_ent : ∀ w, strong w → weak w) :
-    ∀ w, ¬(C weak w ∧ ¬C strong w) :=
-  fun w ⟨hCw, hnCs⟩ => hnCs (hDE strong weak h_ent w hCw)
-
-/-- **O⁻ yields universal force from existential base (§5.1).**
-
-    D-MIN items (FCIs) activate all subdomain alternatives. When
-    antiexhaustive enrichment (O⁻) is applied to ∃x∈D.P(x) with
-    D-MIN alternatives, the result entails ∀a∈D. P(a).
-
-    This is the "birth of universal readings" — re-exported from
-    `Exhaustification.antiexh_yields_universal`. -/
-theorem fci_universal_from_oMinus
-    {Entity : Type*}
-    (D : List Entity) (P : Entity → World → Prop) (w : World)
-    (h : oMinus (Exhaustification.dMinAlts D P) (Exhaustification.existsIn D P) w) :
-    ∀ a ∈ D, P a w :=
-  antiexh_yields_universal D P w h
-
-end SigmaOperators
-
-/-! ### The Italian free-choice data
-
-The judgments of §2 are rows in `Data/Examples/Chierchia2006.json`, each tagged with the
-free-choice construction it uses ([qualsiasi N] against [un N qualsiasi]), the environment it
-appears in, and the quantificational force available there. Three contrasts drive the account: the
-two constructions differ in force, a bare universal free-choice item is marginal in an episodic
-context until a relative clause subtriggs it, and under negation the universal item yields only
-the rhetorical ¬∀ reading rather than the ¬∃ reading a negative-polarity item would. -/
-
-open Data.Examples in
-/-- A row's value for one of the paper's feature keys. -/
-private def feature (e : LinguisticExample) (k : String) : Option String :=
-  (e.paperFeatures.find? (·.1 == k)).map Prod.snd
+/-! ### The Italian free-choice data -/
 
 /-- The two constructions differ in force outside negation: the universal free-choice item admits
 both readings and the existential one only the existential reading. -/
 theorem force_tracks_construction :
-    (∀ e ∈ Examples.all, feature e "environment" = some "future" ∨
-        feature e "environment" = some "imperative" →
-        feature e "fciType" = some "universal" → feature e "force" = some "ambiguous") ∧
-      (∀ e ∈ Examples.all, feature e "fciType" = some "existential" →
-        feature e "force" = some "existential") := by decide
+    (∀ e ∈ Examples.all, e.feature? "environment" = some "future" ∨
+        e.feature? "environment" = some "imperative" →
+        e.feature? "fciType" = some "universal" → e.feature? "force" = some "ambiguous") ∧
+      (∀ e ∈ Examples.all, e.feature? "fciType" = some "existential" →
+        e.feature? "force" = some "existential") := by decide
 
 /-- Subtrigging rescues a universal free-choice item in an episodic context: bare it is marginal,
 with a relative clause it is acceptable. -/
 theorem subtrigging_rescues_universal :
-    (∀ e ∈ Examples.all, feature e "fciType" = some "universal" →
-        feature e "environment" = some "episodicBare" → e.judgment = .marginal) ∧
-      (∀ e ∈ Examples.all, feature e "fciType" = some "universal" →
-        feature e "environment" = some "episodicSubtrigged" → e.judgment = .acceptable) := by
+    (∀ e ∈ Examples.all, e.feature? "fciType" = some "universal" →
+        e.feature? "environment" = some "episodicBare" → e.judgment = .marginal) ∧
+      (∀ e ∈ Examples.all, e.feature? "fciType" = some "universal" →
+        e.feature? "environment" = some "episodicSubtrigged" → e.judgment = .acceptable) := by
   decide
 
-/-- It does nothing for an existential one, which stays marginal in an episodic context either
-way — and both episodic existential rows are attested, so the claim is not vacuous. -/
+/-- It does nothing for an existential one, which stays marginal in an episodic context with or
+without a relative clause. -/
 theorem subtrigging_does_not_rescue_existential :
-    (∀ e ∈ Examples.all, feature e "fciType" = some "existential" →
-        feature e "environment" = some "episodicBare" ∨
-          feature e "environment" = some "episodicSubtrigged" → e.judgment = .marginal) ∧
-      (∃ e ∈ Examples.all, feature e "environment" = some "episodicBare" ∧
-        feature e "fciType" = some "existential") ∧
-      (∃ e ∈ Examples.all, feature e "environment" = some "episodicSubtrigged" ∧
-        feature e "fciType" = some "existential") := by decide
+    (∀ e ∈ Examples.all, e.feature? "fciType" = some "existential" →
+        e.feature? "environment" = some "episodicBare" ∨
+          e.feature? "environment" = some "episodicSubtrigged" → e.judgment = .marginal) ∧
+      (∃ e ∈ Examples.all, e.feature? "environment" = some "episodicBare" ∧
+        e.feature? "fciType" = some "existential") ∧
+      (∃ e ∈ Examples.all, e.feature? "environment" = some "episodicSubtrigged" ∧
+        e.feature? "fciType" = some "existential") := by decide
 
 /-- Under bare negation the universal free-choice item has only the universal (rhetorical ¬∀)
 reading; adding a relative clause makes the other readings available again. This is the
 *qualsiasi*/*any* contrast: *qualsiasi* under negation is not a negative-polarity item. -/
 theorem negation_rhetorical_only :
-    (∀ e ∈ Examples.all, feature e "environment" = some "negationBare" →
-        feature e "force" = some "universal") ∧
-      (∀ e ∈ Examples.all, feature e "environment" = some "negationSubtrigged" →
-        feature e "force" = some "ambiguous") ∧
-      (∃ e ∈ Examples.all, feature e "environment" = some "negationBare") := by decide
+    (∀ e ∈ Examples.all, e.feature? "environment" = some "negationBare" →
+        e.feature? "force" = some "universal") ∧
+      (∀ e ∈ Examples.all, e.feature? "environment" = some "negationSubtrigged" →
+        e.feature? "force" = some "ambiguous") ∧
+      (∃ e ∈ Examples.all, e.feature? "environment" = some "negationBare") := by decide
 
 end Chierchia2006

--- a/references.bib
+++ b/references.bib
@@ -2791,7 +2791,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/Chierchia2006.lean;Studies/ChowErlewine2022.lean;Studies/CiardelliGuerrini2026.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
+  sources   = {}
 }
 @incollection{chierchia-fox-spector-2012,
   author    = {Chierchia, Gennaro and Fox, Danny and Spector, Benjamin},
@@ -2965,7 +2965,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/BarLevFox2020.lean}
+  sources   = {Data/Examples/BarLevFox2020.json}
 }
 @article{delpinal-bassi-sauerland-2024,
   author    = {Del Pinal, Guillermo and Bassi, Itai and Sauerland, Uli},
@@ -5402,7 +5402,7 @@
   subfield  = {semantics/compositional},
   role      = {formalized},
   validated = {true},
-  sources   = {Fragments/English/PolarityItems.lean;Studies/KadmonLandman1993.lean}
+  sources   = {}
 }% REF: Kamp, H. & Reyle, U. (1993). From Discourse to Logic.
 @book{kamp-reyle-1993,
   author    = {Kamp, Hans and Reyle, Uwe},
@@ -24524,8 +24524,8 @@
   pages     = {535--590},
   doi       = {10.1162/ling.2006.37.4.535},
   subfield  = {semantics},
-  role      = {cited},
-  sources   = {Studies/Chierchia2006.lean}
+  role      = {formalized},
+  sources   = {Data/Examples/Chierchia2006.json}
 }
 @article{fiske-cuddy-glick-xu-2002,
   author    = {Fiske, Susan T. and Cuddy, Amy J. C. and Glick, Peter and Xu, Jun},


### PR DESCRIPTION
Second-pass cleanse of Chierchia2006: the class regions, licensor strengths, and Fragment parameters are derived from the parameter profiles, the Chierchia2013 import is cut (chronology), and the rows theorems read features directly.

- `Features/Indefinite`: drop the derived `BEq` instances, which shadowed the lawful one from `DecidableEq` and blocked list-membership decidability.
- Delete the `fci_universal_from_oMinus` wrapper; the substrate theorem already cites the paper.
- Bib: `chierchia-2006` marked formalized; sources recomputed for the keys the header dropped.