### PR TITLE
refactor(Studies/DeganoAloni2025): profiles derived from the atoms, atoms as substrate

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -213,6 +213,7 @@ import Linglib.Logic.Orthologic.FrameSemantics
 import Linglib.Logic.RankingFunction
 import Linglib.Logic.SystemZ
 import Linglib.Logic.Team.Algebra
+import Linglib.Logic.Team.Atoms
 import Linglib.Logic.Team.Closure
 import Linglib.Logic.Team.Definability
 import Linglib.Logic.Temporal.Basic

--- a/Linglib/Fragments/Slavic/Russian/Indefinites.lean
+++ b/Linglib/Fragments/Slavic/Russian/Indefinites.lean
@@ -23,7 +23,7 @@ specific-unknown function (not also non-specific) is due to paradigmatic
 competition with *-nibud'*. The D&A theoretical profile of type iv
 permits both SU and NS, but *-to*'s actual distribution is SU only —
 captured by `IndefinitePronoun.consistentWith` in
-`Semantics/Quantification/DeganoAloni2025.lean`.
+`Studies/DeganoAloni2025.lean`.
 -/
 
 namespace Russian.Indefinites

--- a/Linglib/Fragments/Yakut/Indefinites.lean
+++ b/Linglib/Fragments/Yakut/Indefinites.lean
@@ -24,7 +24,7 @@ matching WALS's classification for `iso = "sah"` (verified in
 
 The Degano & Aloni 7-type classification of `ere` and `eme` (types ii and
 iii respectively, after [bubnov-2026] Table 1) is theory-side
-projection — see `Semantics/Quantification/DeganoAloni2025.lean`.
+projection — see `Studies/DeganoAloni2025.lean`.
 The free-choice and polarity-sensitive series (`bayarar`, `da`) fall
 outside D&A's SK/SU/NS subdivision; their D&A surface-classification is
 `none` by design.

--- a/Linglib/Logic/Team/Atoms.lean
+++ b/Linglib/Logic/Team/Atoms.lean
@@ -1,0 +1,61 @@
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Dependence and variation atoms
+
+This file defines the two atoms of first-order team semantics over a team of assignments: the
+dependence atom of [vaananen-2007], that assignments agreeing on the parameters agree on the
+dependent variable, and its failure, the variation atom, that two assignments agreeing on the
+parameters differ on it. Widening the parameters weakens dependence and strengthens variation,
+which is how the atoms compose into the constancy and variation conditions of
+[degano-aloni-2025]. Teams are finite so that the atoms are decidable over a finite domain.
+
+## References
+
+* [hodges-1997]
+* [vaananen-2007]
+* [degano-aloni-2025]
+-/
+
+namespace Team
+
+variable {V E : Type*}
+
+/-- The dependence atom `dep(Z, u)`: assignments of the team agreeing on every variable of `Z`
+agree on `u`; with `Z` empty, `u` is constant across the team. -/
+def Dep (T : Finset (V → E)) (Z : Finset V) (u : V) : Prop :=
+  ∀ i ∈ T, ∀ j ∈ T, (∀ z ∈ Z, i z = j z) → i u = j u
+
+/-- The variation atom `var(Z, u)`: two assignments of the team agree on `Z` and differ on
+`u`. -/
+def Var (T : Finset (V → E)) (Z : Finset V) (u : V) : Prop :=
+  ∃ i ∈ T, ∃ j ∈ T, (∀ z ∈ Z, i z = j z) ∧ i u ≠ j u
+
+instance [DecidableEq E] (T : Finset (V → E)) (Z : Finset V) (u : V) : Decidable (Dep T Z u) :=
+  inferInstanceAs (Decidable (∀ i ∈ T, ∀ j ∈ T, (∀ z ∈ Z, i z = j z) → i u = j u))
+
+instance [DecidableEq E] (T : Finset (V → E)) (Z : Finset V) (u : V) : Decidable (Var T Z u) :=
+  inferInstanceAs (Decidable (∃ i ∈ T, ∃ j ∈ T, (∀ z ∈ Z, i z = j z) ∧ i u ≠ j u))
+
+/-- Variation is the failure of dependence. -/
+theorem var_iff_not_dep (T : Finset (V → E)) (Z : Finset V) (u : V) :
+    Var T Z u ↔ ¬ Dep T Z u :=
+  ⟨λ ⟨i, hi, j, hj, hZ, hne⟩ hdep => hne (hdep i hi j hj hZ),
+    λ h => by unfold Dep at h; push Not at h; exact h⟩
+
+/-- Dependence on fewer parameters is dependence on more. -/
+theorem Dep.mono {T : Finset (V → E)} {Z Z' : Finset V} {u : V} (hZ : Z ⊆ Z') (h : Dep T Z u) :
+    Dep T Z' u :=
+  λ i hi j hj hagree => h i hi j hj λ z hz => hagree z (hZ hz)
+
+/-- Variation on more parameters is variation on fewer. -/
+theorem Var.anti {T : Finset (V → E)} {Z Z' : Finset V} {u : V} (hZ : Z ⊆ Z') (h : Var T Z' u) :
+    Var T Z u :=
+  let ⟨i, hi, j, hj, hagree, hne⟩ := h
+  ⟨i, hi, j, hj, λ z hz => hagree z (hZ hz), hne⟩
+
+/-- Dependence excludes variation on the same parameters. -/
+theorem Dep.not_var {T : Finset (V → E)} {Z : Finset V} {u : V} (h : Dep T Z u) : ¬ Var T Z u :=
+  λ hv => (var_iff_not_dep T Z u).1 hv h
+
+end Team

--- a/Linglib/Studies/Bubnov2026.lean
+++ b/Linglib/Studies/Bubnov2026.lean
@@ -52,7 +52,7 @@ whichever direction it takes along the map.
 
 namespace Bubnov2026
 
-open DeganoAloni2025 DeganoAloni2025.DependenceLogic Dekier2021 Indefinite Morphology.Containment
+open DeganoAloni2025 Dekier2021 Indefinite Morphology.Containment
 open Russian.Indefinites English.Indefinites German.Indefinites Latin.Indefinites
 open Yakut.Indefinites Kannada.Indefinites
 
@@ -67,18 +67,11 @@ theorem russian_spans_properly_nested :
       (spelloutWinner russianLex suRank).map SpanRule.spans = some 1 ∧
       (spelloutWinner russianLex skRank).map SpanRule.spans = some 2 := by decide
 
-/-! ### The unattested type -/
+/-! ### The unattested type
 
-/-- The unattested type would have to require constancy of the value across all epistemic
-alternatives and variation of it within one of them at once. Variation within one alternative
-already gives variation across all of them, so the two requirements cannot be met together, and the
-type can be stated only as a disjunction. -/
-theorem type_vi_contradictory {V E : Type} [DecidableEq V] [DecidableEq E]
-    (t : AssignmentTeam V E) (v null x : V)
-    (hnull : ∀ a₁ a₂ : V → E, a₁ null = a₂ null)
-    (hdep : constancy t null x = true) (hvar : variation t v x = true) : False :=
-  constancy_excludes_variation t null x hdep
-    (variation_monotone t v null x hvar fun a₁ a₂ _ => hnull a₁ a₂)
+The unattested type would have to require constancy of the value across all epistemic
+alternatives and variation of it within one of them at once, which cannot be met
+(`DeganoAloni2025.not_requires_skPlusNS`), so the type can be stated only as a disjunction. -/
 
 /-- The same type is the one the implicational map excludes: its profile skips the
 specific-unknown function lying between the two it covers. The semantic account and the hierarchy
@@ -143,20 +136,20 @@ def witnesses : List (IndefinitePronoun × DAType) :=
 
 /-- Every witness covers exactly the functions its type permits. -/
 theorem paradigms_realize_types :
-    ∀ w ∈ witnesses, w.1.surfaceDAType = some w.2 := by decide
+    ∀ w ∈ witnesses, typeOf w.1 = some w.2 := by decide
 
 /-- Russian *-to* is the epistemic type, but covers only the specific-unknown function: *-nibud'*
 is the non-specific form of the same paradigm and takes that function from it. Coverage is the
 restriction net of paradigmatic competition, which is why the surface classification of *-to* is
 narrower than its type. -/
 theorem to_is_epistemic_under_competition :
-    toEntry.consistentWith .epistemic = true ∧ toEntry.functions ≠ DAType.epistemic.profile := by
+    ConsistentWith toEntry .epistemic ∧ toEntry.functions ≠ DAType.epistemic.profile := by
   refine ⟨by decide, fun h => absurd h (by decide)⟩
 
 /-- German *irgend-* instantiates the change from a non-specific form to an epistemic one, and its
 epistemic restriction is the one the modal-indefinite literature attributes to it. -/
 theorem irgend_is_epistemic :
-    irgendEntry.surfaceDAType = some .epistemic ∧
+    typeOf irgendEntry = some .epistemic ∧
       DAType.nonSpecific.profile ⊆ DAType.epistemic.profile := by decide
 
 end Bubnov2026

--- a/Linglib/Studies/DeganoAloni2025.lean
+++ b/Linglib/Studies/DeganoAloni2025.lean
@@ -1,258 +1,183 @@
-import Linglib.Syntax.Category.Pronoun.IndefiniteParadigm
+import Linglib.Logic.Team.Atoms
+import Linglib.Syntax.Category.Pronoun.Indefinite
+import Linglib.Fragments.German.Indefinites
+import Linglib.Fragments.Kannada.Indefinites
+import Linglib.Fragments.Slavic.Russian.Indefinites
 
 /-!
-# Degano & Aloni 2025: 7-type team-semantic typology of indefinites
-[degano-aloni-2025] [hodges-1997] [vaananen-2007]
+# Degano and Aloni (2025): How to be (non-)specific?
 
-Degano & Aloni 2025's 7-type classification of indefinite pronouns,
-projected from the consensus `Indefinite.IndefinitePronoun`
-substrate (Haspelmath 1997 function-coverage data).
+This file formalizes the typology of marked indefinites of [degano-aloni-2025]. An indefinite
+has three uses, specific known, specific unknown and non-specific, and a marked indefinite is
+restricted to some of them: of the seven possible restrictions, six are attested and the one
+covering the specific known and the non-specific use without the specific unknown is not. In
+two-sorted team semantics a team of assignments to a world variable and an individual variable
+is the speaker's information state, and the uses are constancy and variation conditions on the
+individual variable, (11): constancy across the team for specific known, constancy within a
+world with variation across the team for specific unknown, and variation within a world for
+non-specific. Each marked type requires an atom, Table 14, and a type admits a use when the
+use's condition entails its requirement. The requirements reproduce the attested profiles,
+while the unattested type's requirement, constancy across the team together with variation
+within a world, cannot be met, since variation within a world is variation across the team,
+so that type admits no use at all. German *irgend-*, Russian *koe-* and *-nibud'* and Kannada
+*-oo* instantiate types (iv), (v), (iii) and (vii) from their Fragments' coverage of
+[haspelmath-1997]'s map, the non-specific use being the irrealis function.
 
-The team-semantic logic primitives D&A use (Hodges 1997 / Väänänen 2007:
-assignment teams, `variation`, `constancy`) are inlined here as a
-private namespace prelude — they currently have only one downstream
-linguistic consumer (this file + Bubnov 2026), so general placement in
-`Logic/` would be premature. When a second framework (branching
-quantifiers, IF-logic for definites, partial-information ellipsis)
-needs them, extract.
+## References
 
-## D&A's classification ↔ Haspelmath's map
-
-D&A's typology operates on the **SK/SU/NS triangle**:
-- **SK** = specific known: speaker has a particular referent in mind, hearer can identify
-- **SU** = specific unknown: speaker has a referent in mind, hearer cannot
-- **NS** = non-specific: no particular referent
-
-These map 1:1 to Haspelmath 1997's first three slots:
-- D&A SK ↔ Haspelmath `specificKnown`
-- D&A SU ↔ Haspelmath `specificUnknown`
-- D&A NS ↔ Haspelmath `irrealis` (D&A focus on irrealis-modal non-specific uses;
-  Haspelmath's `irrealis` slot is broader but D&A treat it as the canonical
-  NS-bearing region — see D&A 2025 §2)
-
-The `DAType.profile` function below uses the Haspelmath identifiers because
-that's the substrate the projection consumes; the D&A column heading in the
-type table is for reference.
-
-## Schema
-
-- `DAType`: the 7 types arising from Boolean combinations of `var(y,x)`
-  and `dep(y,x)` with within-world (`v`) and across-all-worlds (`∅`)
-  parameter choices.
-- `DAType.profile`: each type's theoretical coverage on the
-  Haspelmath SK/SU/irrealis triangle.
-- `IndefinitePronoun.surfaceDAType`: classify an entry by exact match
-  of its actual function-coverage to a D&A type's profile. Returns
-  `none` when the entry covers a region D&A doesn't subdivide (e.g.,
-  free choice, polarity-sensitive forms) or when actual ⊊ profile.
-- `IndefinitePronoun.consistentWith`: weaker relation — actual coverage
-  is a subset of the theoretical profile. Used for entries where
-  paradigmatic competition narrows the actual distribution
-  (e.g., Russian *kto-to* ⊊ type-iv epistemic profile).
-
-## Type table (D&A's row labels; Haspelmath identifiers in `profile`)
-
-| Type | Requirement       | D&A profile (SK/SU/NS) | Example          |
-|------|-------------------|------------------------|------------------|
-| (i)   | (none)           | {SK, SU, NS}          | English *some-* |
-| (ii)  | dep(v,x)         | {SK, SU}              | Yakut *kim ere* |
-| (iii) | var(v,x)         | {NS}                  | Russian *-nibud'*|
-| (iv)  | var(∅,x)         | {SU, NS}              | German *irgend-*|
-| (v)   | dep(∅,x)         | {SK}                  | Russian *koe-*  |
-| (vi)  | dep(∅,x)∧var(v,x)| {SK, NS}              | *unattested*    |
-| (vii) | dep(v,x)∧var(∅,x)| {SU}                  | Kannada *yāru-oo*|
+* [degano-aloni-2025]
+* [haspelmath-1997]
 -/
-
--- ============================================================================
--- §0. Private prelude: Hodges/Väänänen team-semantic primitives
--- [hodges-1997] [vaananen-2007]
--- ============================================================================
--- Inlined here pending a second consumer (currently only D&A 2025 + Bubnov 2026
--- use these primitives). Promotion to `Logic/DependenceLogic.lean` would
--- create substrate without independent consumers, the anti-pattern noted in
--- memory `project_pmf_check_mathlib_first.md`.
-
-namespace DeganoAloni2025.DependenceLogic
-
-/-- An assignment team: a list of variable-to-entity assignments.
-    The setting for dependence logic ([vaananen-2007]) and D&A's
-    indefinite semantics. -/
-abbrev AssignmentTeam (V E : Type) := List (V → E)
-
-/-- **Variation**: variable `x` varies w.r.t. parameter `y` in team `t`.
-    `var(y, x)` holds iff there exist two assignments in `t` that agree on `y`
-    but disagree on `x`. -/
-def variation {V E : Type} [DecidableEq V] [DecidableEq E]
-    (t : AssignmentTeam V E) (y x : V) : Bool :=
-  t.any λ a₁ => t.any λ a₂ => a₁ y == a₂ y && a₁ x != a₂ x
-
-/-- **Constancy** (functional dependence): `x` depends on `y` in team `t`.
-    `dep(y, x)` holds iff all assignments agreeing on `y` also agree on `x`. -/
-def constancy {V E : Type} [DecidableEq V] [DecidableEq E]
-    (t : AssignmentTeam V E) (y x : V) : Bool :=
-  t.all λ a₁ => t.all λ a₂ => a₁ y != a₂ y || a₁ x == a₂ x
-
-/-- Concrete witness: a 2-assignment team where `var(y,x)` holds and `dep(y,x)` fails. -/
-theorem constancy_excludes_variation_witness :
-    let t : AssignmentTeam (Fin 2) (Fin 2) :=
-      [λ v => if v = 0 then 0 else 0,
-       λ v => if v = 0 then 0 else 1]
-    variation t 0 1 = true ∧ constancy t 0 1 = false := by decide
-
-/-- Constancy and variation are jointly unsatisfiable. -/
-theorem constancy_excludes_variation {V E : Type} [DecidableEq V] [DecidableEq E]
-    (t : AssignmentTeam V E) (y x : V)
-    (hdep : constancy t y x = true)
-    (hvar : variation t y x = true) : False := by
-  unfold constancy at hdep
-  unfold variation at hvar
-  simp only [List.all_eq_true, List.any_eq_true,
-             Bool.and_eq_true, Bool.or_eq_true,
-             bne_iff_ne, ne_eq, beq_iff_eq] at hdep hvar
-  obtain ⟨a₁, ha₁, a₂, ha₂, hyeq, hxne⟩ := hvar
-  have := hdep a₁ ha₁ a₂ ha₂
-  rcases this with hyneq | hxeq
-  · exact hyneq hyeq
-  · exact hxne hxeq
-
-/-- Variation lifts to a coarser parameter: if `v`-agreement implies `y`-agreement,
-    then `var(v, x) → var(y, x)`. Grounds D&A's diachronic prediction
-    `var(v, x) → var(∅, x)` (see [bubnov-2026] §6). -/
-theorem variation_monotone {V E : Type} [DecidableEq V] [DecidableEq E]
-    (t : AssignmentTeam V E) (v y x : V)
-    (hvar : variation t v x = true)
-    (h_agree : ∀ (a₁ a₂ : V → E), a₁ v = a₂ v → a₁ y = a₂ y) :
-    variation t y x = true := by
-  unfold variation at hvar ⊢
-  simp only [List.any_eq_true, Bool.and_eq_true,
-             bne_iff_ne, ne_eq, beq_iff_eq] at hvar ⊢
-  obtain ⟨a₁, ha₁, a₂, ha₂, hveq, hxne⟩ := hvar
-  exact ⟨a₁, ha₁, a₂, ha₂, h_agree a₁ a₂ hveq, hxne⟩
-
-end DeganoAloni2025.DependenceLogic
-
--- ============================================================================
--- §1. The 7-type classification
--- ============================================================================
 
 namespace DeganoAloni2025
 
-open Indefinite
+open Team Indefinite
 
-/-- [degano-aloni-2025]'s seven-type team-semantic typology. -/
-inductive DAType where
-  /-- (i) No restriction. Profile: SK ∪ SU ∪ NS. -/
-  | unmarked
-  /-- (ii) `dep(v,x)`: constancy within each epistemic world. Profile: SK + SU. -/
-  | specific
-  /-- (iii) `var(v,x)`: variation within some epistemic world. Profile: NS only. -/
-  | nonSpecific
-  /-- (iv) `var(∅,x)`: variation across all epistemic worlds. Profile: SU + NS. -/
-  | epistemic
-  /-- (v) `dep(∅,x)`: constancy across all epistemic worlds. Profile: SK only. -/
+/-! ### Uses and types -/
+
+/-- The three uses of an indefinite, (3). -/
+inductive Use where
   | specificKnown
-  /-- (vi) `dep(∅,x) ∧ var(v,x)`: jointly forbidden by team-semantic
-      logic AND empirically unattested in D&A's surveyed languages.
-      The two failure modes are independent: even if some non-team-semantic
-      account licensed it, the {SK, NS} profile would still need a witness. -/
-  | skPlusNS
-  /-- (vii) `dep(v,x) ∧ var(∅,x)`: rare conjunctive type; profile SU only. -/
   | specificUnknown
-  deriving DecidableEq, Repr, BEq
+  | nonSpecific
+  deriving DecidableEq, Repr
 
-/-- D&A theoretical profile: the SK/SU/NS subset of Haspelmath functions
-    a type's semantics PERMITS. Actual paradigm distribution may be
-    narrower due to competition with more-specific forms. -/
+/-- The function on Haspelmath's map a use is: the non-specific use is the irrealis
+function. -/
+def Use.haspelmath : Use → HaspelmathFunction
+  | .specificKnown => .specificKnown
+  | .specificUnknown => .specificUnknown
+  | .nonSpecific => .irrealis
+
+/-- The seven types of Table 14: the restriction a marked indefinite imposes on its uses, the
+unmarked indefinite imposing none. -/
+inductive DAType where
+  | unmarked
+  | specific
+  | nonSpecific
+  | epistemic
+  | specificKnown
+  | skPlusNS
+  | specificUnknown
+  deriving DecidableEq, Repr
+
+def DAType.all : List DAType :=
+  [.unmarked, .specific, .nonSpecific, .epistemic, .specificKnown, .skPlusNS, .specificUnknown]
+
+/-- The uses a type is built for, the check marks of Table 14. -/
 def DAType.profile : DAType → Finset HaspelmathFunction
-  | .unmarked        => {.specificKnown, .specificUnknown, .irrealis}
-  | .specific        => {.specificKnown, .specificUnknown}
-  | .nonSpecific     => {.irrealis}
-  | .epistemic       => {.specificUnknown, .irrealis}
-  | .specificKnown   => {.specificKnown}
-  | .skPlusNS        => {.specificKnown, .irrealis}
+  | .unmarked => {.specificKnown, .specificUnknown, .irrealis}
+  | .specific => {.specificKnown, .specificUnknown}
+  | .nonSpecific => {.irrealis}
+  | .epistemic => {.specificUnknown, .irrealis}
+  | .specificKnown => {.specificKnown}
+  | .skPlusNS => {.specificKnown, .irrealis}
   | .specificUnknown => {.specificUnknown}
 
-/-- Type (vi) `skPlusNS` is jointly forbidden by team-semantic logic AND
-    empirically unattested. The team-semantic argument: `dep(∅,x)` forbids
-    cross-world variation while `var(v,x)` requires intra-world variation.
-    The empirical argument is independent: D&A find no surveyed language
-    with a form whose distribution exactly matches the `{SK, NS}` profile.
-    Both arguments must hold; the predicate marks attestation, not logical
-    consistency. -/
-def DAType.IsAttested (t : DAType) : Prop := t ≠ .skPlusNS
+/-! ### Conditions on teams -/
 
-instance : DecidablePred DAType.IsAttested :=
-  fun _ => inferInstanceAs (Decidable (_ ≠ _))
+section Teams
 
-theorem skPlusNS_unattested : ¬ DAType.IsAttested .skPlusNS := by decide
+variable {V E : Type*} [DecidableEq E] (T : Finset (V → E)) (v x : V)
 
--- ----------------------------------------------------------------------------
--- Projection-range characterization
--- ----------------------------------------------------------------------------
+/-- The rendering (11) of a use on a team, `v` the world variable and `x` the individual:
+constancy, constancy within a world with variation across the team, and variation within a
+world. -/
+def Use.Renders : Use → Prop
+  | .specificKnown => Dep T ∅ x
+  | .specificUnknown => Dep T {v} x ∧ Var T ∅ x
+  | .nonSpecific => Var T {v} x
 
-/-- The Haspelmath functions that D&A's `profile` projection ranges over:
-    the **specificity triangle** (specificKnown, specificUnknown, irrealis).
-    D&A's typology is built around the SK/SU/NS dimension; D&A's `irrealis`
-    slot identifies with Haspelmath's `irrealis` (see the module docstring's
-    "D&A ↔ Haspelmath" section). -/
-def specificityRegion : Finset HaspelmathFunction :=
-  {.specificKnown, .specificUnknown, .irrealis}
+instance : (u : Use) → Decidable (u.Renders T v x)
+  | .specificKnown => inferInstanceAs (Decidable (Dep T ∅ x))
+  | .specificUnknown => inferInstanceAs (Decidable (_ ∧ _))
+  | .nonSpecific => inferInstanceAs (Decidable (Var T {v} x))
 
-/-- **Projection range, not framework scope.** Every D&A type's `profile` is
-    a subset of `specificityRegion`. This is a structural fact about the
-    *projection function* `DAType.profile`, not a claim about the empirical
-    reach of D&A 2025's framework: D&A's account empirically covers
-    polarity-sensitive uses of indefinites (e.g., German *irgendein* under
-    modals) through composition mechanisms that are not captured by the
-    direct `profile` projection. The theorem says only that the *range* of
-    `profile` lies in the specificity region; what each type *predicts in
-    composition* is a separate question.
+/-- The atom a type requires, Table 14. -/
+def DAType.Requires : DAType → Prop
+  | .unmarked => True
+  | .specific => Dep T {v} x
+  | .nonSpecific => Var T {v} x
+  | .epistemic => Var T ∅ x
+  | .specificKnown => Dep T ∅ x
+  | .skPlusNS => Dep T ∅ x ∧ Var T {v} x
+  | .specificUnknown => Dep T {v} x ∧ Var T ∅ x
 
-    See the audit notes in `0.230.529`'s CHANGELOG entry on why the
-    symmetric Chierchia-side scope theorem fails: Chierchia's
-    `PSIProfile.predictedFunctions` for plain indefinites
-    (`obligatoryDomainAlts := false`) ranges over `{SK, SU, irrealis}` too,
-    so the would-be "disjoint scope" picture collapses. The structural
-    pattern only survives on the D&A side. -/
-theorem DAType.profile_subset_specificityRegion (t : DAType) :
-    t.profile ⊆ specificityRegion := by
-  cases t <;> decide
+instance : (t : DAType) → Decidable (t.Requires T v x)
+  | .unmarked => inferInstanceAs (Decidable True)
+  | .specific => inferInstanceAs (Decidable (Dep T {v} x))
+  | .nonSpecific => inferInstanceAs (Decidable (Var T {v} x))
+  | .epistemic => inferInstanceAs (Decidable (Var T ∅ x))
+  | .specificKnown => inferInstanceAs (Decidable (Dep T ∅ x))
+  | .skPlusNS => inferInstanceAs (Decidable (_ ∧ _))
+  | .specificUnknown => inferInstanceAs (Decidable (_ ∧ _))
+
+omit [DecidableEq E] in
+/-- The unattested type's requirement cannot be met: constancy across the team is constancy
+within a world, which excludes variation there, footnote 16. -/
+theorem not_requires_skPlusNS : ¬ DAType.skPlusNS.Requires T v x :=
+  λ ⟨hdep, hvar⟩ => (hdep.mono (Finset.empty_subset _)).not_var hvar
+
+end Teams
+
+/-- A type admits a use when every team on which the use holds meets the type's
+requirement. -/
+def Admits (t : DAType) (u : Use) : Prop :=
+  ∀ {V E : Type} [DecidableEq E] (T : Finset (V → E)) (v x : V), u.Renders T v x → t.Requires T v x
+
+/-- One world with one individual: the specific known use. -/
+private def known : Finset (Fin 2 → Fin 2) := {λ _ => 0}
+
+/-- Two worlds, each with its own individual: the specific unknown use. -/
+private def unknown : Finset (Fin 2 → Fin 2) := {λ _ => 0, λ _ => 1}
+
+/-- One world with two individuals: the non-specific use. -/
+private def open_ : Finset (Fin 2 → Fin 2) := {λ _ => 0, λ k => if k = 0 then 0 else 1}
+
+/-- The requirements reproduce the profiles: an attested type admits exactly the uses Table 14
+lists for it. -/
+theorem admits_iff {t : DAType} (ht : t ≠ .skPlusNS) (u : Use) :
+    Admits t u ↔ u.haspelmath ∈ t.profile := by
+  cases t <;> cases u <;> first
+    | exact absurd rfl ht
+    | exact iff_of_true (λ _ _ _ _ => trivial) (by decide)
+    | exact iff_of_true (λ _ _ _ h => h) (by decide)
+    | exact iff_of_true (λ _ _ _ h => h.1) (by decide)
+    | exact iff_of_true (λ _ _ _ h => h.2) (by decide)
+    | exact iff_of_true (λ _ _ _ h => h.mono (Finset.empty_subset _)) (by decide)
+    | exact iff_of_true (λ _ _ _ h => h.anti (Finset.empty_subset _)) (by decide)
+    | exact iff_of_false (λ h => absurd (h known 0 1 (by decide)) (by decide)) (by decide)
+    | exact iff_of_false (λ h => absurd (h unknown 0 1 (by decide)) (by decide)) (by decide)
+    | exact iff_of_false (λ h => absurd (h open_ 0 1 (by decide)) (by decide)) (by decide)
+
+/-- The unattested type admits no use, not even the two it is built for. -/
+theorem not_admits_skPlusNS (u : Use) : ¬ Admits .skPlusNS u := by
+  cases u <;> first
+    | exact λ h => not_requires_skPlusNS _ _ _ (h known 0 1 (by decide))
+    | exact λ h => not_requires_skPlusNS _ _ _ (h unknown 0 1 (by decide))
+    | exact λ h => not_requires_skPlusNS _ _ _ (h open_ 0 1 (by decide))
+
+/-! ### The types on the map -/
+
+/-- The type a form instantiates: the one whose profile is exactly the form's coverage of the
+map, none for a form covering a region the typology does not subdivide. -/
+def typeOf (e : IndefinitePronoun) : Option DAType :=
+  DAType.all.find? λ t => decide (e.functions = t.profile)
+
+/-- Coverage within a type's profile, as for a form whose paradigm mates take some of its uses
+from it. -/
+def ConsistentWith (e : IndefinitePronoun) (t : DAType) : Prop := e.functions ⊆ t.profile
+
+instance (e : IndefinitePronoun) (t : DAType) : Decidable (ConsistentWith e t) :=
+  inferInstanceAs (Decidable (e.functions ⊆ t.profile))
+
+/-- Table 14's examples from the Fragments: German *irgend-* is epistemic, Russian *koe-*
+specific known, Russian *-nibud'* non-specific, and Kannada *-oo* specific unknown. -/
+theorem examples :
+    typeOf German.Indefinites.irgendEntry = some .epistemic ∧
+      typeOf Russian.Indefinites.koeEntry = some .specificKnown ∧
+      typeOf Russian.Indefinites.nibudEntry = some .nonSpecific ∧
+      typeOf Kannada.Indefinites.ooEntry = some .specificUnknown := by
+  decide
 
 end DeganoAloni2025
-
--- ============================================================================
--- §2. IndefinitePronoun projections
--- ============================================================================
-
-/- Methods on `IndefinitePronoun` live in its own namespace so that
-   dot notation (`entry.surfaceDAType`) resolves them. -/
-namespace Indefinite.IndefinitePronoun
-
-open DeganoAloni2025
-
-/-- Surface-classifier: project an entry to the D&A type whose theoretical
-    profile exactly matches the entry's actual function-coverage.
-
-    Returns `none` when the entry covers a region D&A doesn't subdivide
-    (free choice, polarity-sensitive uses, or any function outside
-    SK/SU/NS) or when actual coverage is a proper subset of any type's
-    profile (a paradigmatic-competition case — see `consistentWith`). -/
-def surfaceDAType (e : IndefinitePronoun) : Option DAType :=
-  if e.functions = DAType.unmarked.profile then some .unmarked
-  else if e.functions = DAType.specific.profile then some .specific
-  else if e.functions = DAType.nonSpecific.profile then some .nonSpecific
-  else if e.functions = DAType.epistemic.profile then some .epistemic
-  else if e.functions = DAType.specificKnown.profile then some .specificKnown
-  else if e.functions = DAType.skPlusNS.profile then some .skPlusNS
-  else if e.functions = DAType.specificUnknown.profile then some .specificUnknown
-  else none
-
-/-- Consistency relation: an entry's actual coverage is contained in
-    `t`'s theoretical profile. Allows actual ⊊ profile, capturing
-    paradigmatic-competition cases such as Russian *kto-to* (type-iv
-    epistemic profile permits SU + NS, but *-to* covers only SU because
-    *-nibud'* blocks it from NS — see [bubnov-2026] §7). -/
-def consistentWith (e : IndefinitePronoun) (t : DAType) : Bool :=
-  decide (e.functions ⊆ t.profile)
-
-end Indefinite.IndefinitePronoun

--- a/Linglib/Studies/Dekier2021.lean
+++ b/Linglib/Studies/Dekier2021.lean
@@ -416,7 +416,7 @@ theorem hierarchy_ordering : nsRank < suRank ∧ suRank < skRank :=
 /-! Connect the nanosyntactic spellout results to the typed indefinite
     entries in the fragment files. The fragment entries use the
     [haspelmath-1997] function-coverage substrate; the D&A typology
-    is a projection living in `Semantics/Quantification/DeganoAloni2025.lean`.
+    is a projection living in `Studies/DeganoAloni2025.lean`.
     Dekier's syntactic hierarchy is the candidate counterpart on the
     morphological side; the bridge here pairs each Fragment entry's
     function coverage with the lexicon's spellout result. -/

--- a/references.bib
+++ b/references.bib
@@ -5953,7 +5953,7 @@
   role      = {cited},
   doi       = {10.1093/oso/9780198235606.001.0001},
   validated = {true},
-  sources   = {Studies/Haspelmath1997Polarity.lean;Studies/Haspelmath1997.lean}
+  sources   = {}
 }% REF: Stachowski, M. & Menz, A. (1998). Yakut. In Johanson & Csató (eds.), The Turkic Languages, 417–433. Routledge.
 @incollection{stachowski-menz-1998,
   author    = {Stachowski, Marek and Menz, Astrid},
@@ -29841,7 +29841,7 @@
   subfield  = {morphology},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Bubnov2026.lean}
+  sources   = {}
 }
 @article{dekier-2021,
   author    = {Dekier, Jakub},
@@ -29866,7 +29866,7 @@
   subfield  = {semantics/dynamic},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Bubnov2026.lean;Studies/DeganoAloni2025.lean}
+  sources   = {}
 }
 @article{hodges-1997,
   author    = {Hodges, Wilfrid},
@@ -29880,7 +29880,7 @@
   subfield  = {semantics/dynamic},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/Bubnov2026.lean;Studies/DeganoAloni2025.lean}
+  sources   = {}
 }
 @book{vaananen-2007,
   author    = {V{\"a}{\"a}n{\"a}nen, Jouko},
@@ -29893,7 +29893,7 @@
   subfield  = {semantics/dynamic},
   role      = {cited},
   validated = {true},
-  sources   = {Logic/Team/Algebra.lean;Logic/Team/Dependence.lean}
+  sources   = {}
 }
 @incollection{vaananen-2008,
   author    = {V{\"a}{\"a}n{\"a}nen, Jouko},


### PR DESCRIPTION
Deep cleanse of DeganoAloni2025: the dependence and variation atoms of first-order team semantics become substrate (`Logic/Team/Atoms`, consumed here and by Bubnov2026), the seven types carry the paper's requirements, and a theorem derives the attested profiles from the requirements while showing the unattested type's requirement unsatisfiable, so it admits no use.

- The private "prelude" with its meta-commentary, the `IsAttested := t ≠ skPlusNS` stipulation, the projection-range theorem, and the Bool consistency relation are gone; Table 14's examples are checked from the German, Russian and Kannada Fragments.
- Bubnov2026 consumes the substrate atoms and the new names; three stale path comments pointing at `Semantics/Quantification/` are fixed.