### PR TITLE
refactor(Studies/DelPinalBassiSauerland2024): negative free choice under negation derived

### DIFF
--- a/Linglib/Semantics/Exhaustification/Presuppositional.lean
+++ b/Linglib/Semantics/Exhaustification/Presuppositional.lean
@@ -3,83 +3,35 @@ import Linglib.Semantics.Exhaustification.InnocentExclusion
 import Linglib.Semantics.Exhaustification.InnocentInclusion
 
 /-!
-# Presuppositional Exhaustification (pex)
-[delpinal-bassi-sauerland-2024] [bassi-delpinal-sauerland-2021]
+# Presuppositional exhaustification
 
-Formalization of [delpinal-bassi-sauerland-2024] "Free choice and
-presuppositional exhaustification" Semantics & Pragmatics 17, Article 3: 1–52.
+This file defines the presuppositional exhaustivity operator `pex^{IE+II}` of
+[delpinal-bassi-sauerland-2024], after the `pex^{IE}` of [bassi-delpinal-sauerland-2021]: it
+asserts its prejacent alone and presupposes the negation of the relevant innocently excludable
+alternatives together with homogeneity over the relevant innocently includable alternatives
+of [bar-lev-fox-2020]. Where `exh^{IE+II}` returns one flat proposition, `pex` returns a
+`PartialProp` whose two components project differently: negation denies the assertion and
+leaves the presupposition in place, and on a prejacent without relevant includable
+alternatives the presupposition is the negated excludable alternatives alone, (11a).
 
-## Core idea
+## References
 
-Standard exhaustification (**exh**) produces flat, fully assertive output:
-it asserts the prejacent plus negated IE alternatives plus II alternatives.
-**pex** splits this output into two dimensions:
-
-- **asserts**: only the prejacent φ
-- **presupposes**: (i) the negation of each IE alternative, and
-  (ii) a *homogeneity presupposition* — that all II alternatives have the
-  same truth value
-
-This structuring is the mirror image of **only**: *only* presupposes its
-prejacent and asserts the negation of alternatives.
-
-## Why it matters
-
-The assertive/presuppositional split lets pex derive:
-1. Free choice for ◇∨ from local application
-2. Double prohibition for ¬◇∨ from negation over pex's assertive component
-3. Negative FC for ¬□∧ analogously
-4. Correct predictions for embedded FC puzzles (under negative factives,
-   in disjunctions, under quantifiers) via standard presupposition
-   projection and filtering
-
-Standard **exh** cannot solve these embedded puzzles because its output is
-flat — negation, factives, and filtering operators cannot distinguish
-assertive from presuppositional content.
-
-## Architecture
-
-`pexIEII` takes the same IE/II computation from `Operators.lean` and
-produces a `PartialProp World` — a Prop-based partial proposition with separate
-assertive and presuppositional components. This directly integrates with
-the presupposition projection infrastructure in `Presupposition`.
-
-This file contains only the abstract pex theory (parameterized by an
-arbitrary `World` type and abstract `ALT`, `φ`). The concrete worked
-example over `FCWorld` (the five-world toy from [bar-lev-fox-2020]) and
-all consequences specific to that example — `pexFC`, `pex_fc`,
-`pex_double_prohibition`, the negative-FC isomorphism, and the embedding
-puzzles from §3–§5 — live in the study file
-`Studies/DelPinalBassiSauerland2024.lean`.
+* [delpinal-bassi-sauerland-2024]
+* [bassi-delpinal-sauerland-2021]
+* [bar-lev-fox-2020]
 -/
 
 namespace Exhaustification.Presuppositional
 
-open Exhaustification
-open Presupposition
+open Exhaustification Presupposition
 
 variable {World : Type*}
 
--- ============================================================================
--- SECTION 2: Homogeneity
--- ============================================================================
-
-/-!
-## Homogeneity
-
-A set of propositions is **homogeneous** at a world `w` when all members
-agree on their truth value at `w`: either all true or all false.
-
-This captures the presupposition triggered by pex for II alternatives.
-For FC: the II alternatives are ◇p and ◇q, so homogeneity gives ◇p ↔ ◇q.
--/
-
-/-- Homogeneity: all propositions in a set have the same truth value.
-    For the empty set, homogeneity holds vacuously. -/
+/-- Homogeneity: every proposition of the set has the same truth value at `w`. -/
 def homogeneous (S : Set (Set World)) (w : World) : Prop :=
   ∀ α ∈ S, ∀ β ∈ S, (α w ↔ β w)
 
-/-- Homogeneity over a two-element set is biconditional. -/
+/-- Homogeneity over a pair is their biconditional. -/
 theorem homogeneous_pair (p q : Set World) (w : World) :
     homogeneous {p, q} w ↔ (p w ↔ q w) := by
   constructor
@@ -90,164 +42,36 @@ theorem homogeneous_pair (p q : Set World) (w : World) :
     rcases hα with rfl | rfl <;> rcases hβ with rfl | rfl <;>
       first | exact Iff.rfl | exact hiff | exact hiff.symm
 
-/-- Homogeneity + at-least-one-holds → all hold. -/
-theorem homogeneous_and_exists_imp_all (S : Set (Set World)) (w : World)
-    (hHomog : homogeneous S w) (α : Set World) (hα : α ∈ S) (ha : α w) :
-    ∀ β ∈ S, β w :=
-  fun β hβ => (hHomog α hα β hβ).mp ha
-
--- ============================================================================
--- SECTION 3: pex^{IE+II}
--- ============================================================================
-
-/-!
-## pex^{IE+II}: Presuppositional Exhaustification
-
-Definition (9) from the paper. For a structure φ of propositional type
-and a local context c:
-
-⟦pex^{IE+II}(φ)⟧:
-  a. **asserts**: ⟦φ⟧
-  b. **presupposes**:
-     (i) ⋂₀ {¬⟦ψ⟧ : ψ ∈ IE(φ) ∧ ⟦ψ⟧ ∈ Rₓ}
-     (ii) homogeneity over relevant II alternatives
-
-We treat Rₓ (the relevance predicate) as a parameter; for basic cases
-all alternatives are relevant.
--/
-
-/-- **pex^{IE+II}**: Presuppositional exhaustification with IE and II.
-
-    Unlike `exhIEII` which returns `Set World` (flat, fully assertive),
-    `pexIEII` returns `PartialProp World` (assertive + presuppositional).
-
-    - **assertion** = φ (the prejacent)
-    - **presupposition** = (negation of relevant IE alternatives) ∧
-                           (homogeneity of relevant II alternatives) -/
-def pexIEII (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) : PartialProp World where
+/-- `pex^{IE+II}`, (9): assert the prejacent, presuppose that the relevant innocently
+excludable alternatives are false and that the relevant innocently includable alternatives
+are homogeneous. -/
+def pexIEII (ALT : Set (Set World)) (φ : Set World) (Rc : Set (Set World)) :
+    PartialProp World where
   assertion := φ
-  presup := fun w =>
-    -- (i) all relevant IE alternatives are false
-    (∀ ψ, IsInnocentlyExcludable ALT φ ψ → ψ ∈ Rc → ¬ψ w) ∧
-    -- (ii) relevant II alternatives are homogeneous
-    homogeneous {α ∈ II ALT φ | α ∈ Rc} w
+  presup := λ w =>
+    (∀ ψ, IsInnocentlyExcludable ALT φ ψ → ψ ∈ Rc → ¬ψ w) ∧ homogeneous {α ∈ II ALT φ | α ∈ Rc} w
 
-/-- pex with all alternatives relevant (the default case). -/
+/-- `pex^{IE+II}` with every alternative relevant. -/
 def pexIEII_full (ALT : Set (Set World)) (φ : Set World) : PartialProp World :=
   pexIEII ALT φ ALT
 
--- ============================================================================
--- SECTION 4: Basic Properties
--- ============================================================================
+variable (ALT : Set (Set World)) (φ : Set World) (Rc : Set (Set World))
 
-/-- pex asserts the prejacent. -/
-theorem pex_assertion_eq (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) :
-    (pexIEII ALT φ Rc).assertion = φ := rfl
+theorem pex_assertion_eq : (pexIEII ALT φ Rc).assertion = φ := rfl
 
-/-- The overall meaning of pex (presupposition ∧ assertion) entails φ. -/
-theorem pex_holds_entails_prejacent (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) (w : World)
-    (h : (pexIEII ALT φ Rc).holds w) : φ w :=
+theorem pex_holds_entails_prejacent (w : World) (h : (pexIEII ALT φ Rc).holds w) : φ w :=
   h.2
 
-/-- Negation applies only to the assertive component; presupposition projects. -/
-theorem pex_neg_assertion (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) :
-    ((pexIEII ALT φ Rc).neg).assertion = fun w => ¬φ w := rfl
+/-- Negation denies the assertion. -/
+theorem pex_neg_assertion : (pexIEII ALT φ Rc).neg.assertion = λ w => ¬φ w := rfl
 
-/-- Negation preserves the presupposition (projection from under negation). -/
-theorem pex_neg_presup (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World)) :
-    ((pexIEII ALT φ Rc).neg).presup = (pexIEII ALT φ Rc).presup := rfl
+/-- Negation leaves the presupposition in place. -/
+theorem pex_neg_presup : (pexIEII ALT φ Rc).neg.presup = (pexIEII ALT φ Rc).presup := rfl
 
--- ============================================================================
--- SECTION 5: Negative FC entailment (abstract)
--- ============================================================================
+/-- (11a): with no relevant includable alternative, as for a basic scalar sentence, the
+presupposition is the negated excludable alternatives alone. -/
+theorem pex_basic_scalar (hII : ∀ α, α ∈ II ALT φ → α ∈ Rc → False) (w : World) :
+    (pexIEII ALT φ Rc).presup w ↔ ∀ ψ, IsInnocentlyExcludable ALT φ ψ → ψ ∈ Rc → ¬ψ w :=
+  ⟨λ ⟨hIE, _⟩ => hIE, λ hIE => ⟨hIE, λ α ⟨hα, hRc⟩ => absurd hRc λ h => hII α hα h⟩⟩
 
-/-!
-## Negative Free Choice (abstract entailment)
-
-For ¬□(p ∧ q)-sentences:
-- φ = ¬□(p ∧ q)
-- The pex output presupposes ¬□p ↔ ¬□q
-
-Combined with ¬□(p ∧ q), this entails ¬□p ∧ ¬□q.
-
-This result is stated as a pure entailment theorem: the interaction
-of the assertion ¬□(p ∧ q) and homogeneity ¬□p ↔ ¬□q suffices for
-negative FC, regardless of how IE/II are computed.
--/
-
-/-- Negative FC entailment: ¬□(p ∧ q) + homogeneity(¬□p, ¬□q) → ¬□p ∧ ¬□q.
-
-    This is the paper's (19a):
-    ⟦pex^{IE+II}[¬□[T ∧ B]]⟧ = (¬□T ∨ ¬□B)_{¬□T↔¬□B} ⊨ ¬□T ∧ ¬□B -/
-theorem negative_fc_entailment {W : Type*}
-    (boxP boxQ : Set W) (w : W)
-    (hassert : ¬(boxP w ∧ boxQ w))
-    (hhomog : (¬boxP w) ↔ (¬boxQ w)) :
-    ¬boxP w ∧ ¬boxQ w := by
-  -- hassert: ¬(□p ∧ □q), i.e., ¬□p ∨ ¬□q
-  -- hhomog: ¬□p ↔ ¬□q
-  -- From ¬(□p ∧ □q): at least one of ¬□p, ¬□q holds
-  -- By homogeneity: both hold
-  constructor
-  · intro hP
-    -- □p holds → ¬(¬□p) → ¬(¬□q) by homogeneity → □q → □p ∧ □q → contradiction
-    exact hassert ⟨hP, by_contra fun hNQ => absurd (hhomog.mpr hNQ) (not_not.mpr hP)⟩
-  · intro hQ
-    exact hassert ⟨by_contra fun hNP => absurd (hhomog.mp hNP) (not_not.mpr hQ), hQ⟩
-
--- ============================================================================
--- SECTION 6: Equivalence with exhIEII for Basic Cases (§2.1)
--- ============================================================================
-
-/-!
-## Equivalence for Non-FC Cases
-
-For basic (non-FC) scalar sentences, pex^{IE+II} and exh^{IE+II} predict
-the same overall entailments. When II is empty (no innocent inclusion),
-pex reduces to asserting φ and presupposing ¬IE — matching pex^{IE}.
-
-This is the paper's (11a): ⟦pex^{IE+II}(∃)⟧ = ⟦pex^{IE}(∃)⟧ = ∃_{¬∀}
--/
-
-/-- For basic scalar sentences (where II ∩ Rc is empty), pex's presupposition
-    reduces to just the negated IE alternatives (homogeneity is vacuous). -/
-theorem pex_basic_scalar (ALT : Set (Set World)) (φ : Set World)
-    (Rc : Set (Set World))
-    (hII_empty : ∀ α, α ∈ II ALT φ → α ∈ Rc → False) (w : World) :
-    (pexIEII ALT φ Rc).presup w ↔
-      (∀ ψ, IsInnocentlyExcludable ALT φ ψ → ψ ∈ Rc → ¬ψ w) := by
-  simp only [pexIEII]
-  constructor
-  · exact fun ⟨hIE, _⟩ => hIE
-  · intro hIE
-    exact ⟨hIE, fun α ⟨hα_II, hα_Rc⟩ => absurd hα_Rc (fun h => hII_empty α hα_II h)⟩
-
--- ============================================================================
--- SECTION 7: Comparison with exhIEII (structural note)
--- ============================================================================
-
-/-!
-## Structural Difference: pex vs exh
-
-The key structural difference:
-
-  **exh^{IE+II}(φ)** = φ ∧ ¬IE ∧ II                (flat, fully assertive)
-  **pex^{IE+II}(φ)** = φ_{¬IE ∧ homog(II)}          (structured)
-
-For FC (φ = ◇(p∨q)):
-  exh: ◇(p∨q) ∧ ◇p ∧ ◇q ∧ ¬◇(p∧q)
-  pex: asserts ◇(p∨q), presupposes (◇p ↔ ◇q) ∧ ¬◇(p∧q)
-
-The overall entailments are the same (both entail ◇p ∧ ◇q), but the
-at-issue structure differs. This difference is what allows pex to solve
-the embedded FC puzzles that exh cannot.
-
-For the concrete worked example over `FCWorld` and the embedded FC
-puzzles, see `Studies/DelPinalBassiSauerland2024.lean`.
--/
 end Exhaustification.Presuppositional

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -1,41 +1,55 @@
 import Linglib.Semantics.Exhaustification.Presuppositional
-import Linglib.Semantics.Presupposition.BeliefEmbedding
+import Linglib.Semantics.Presupposition.Context
 import Linglib.Studies.BarLevFox2020
 
 /-!
-# Del Pinal, Bassi & Sauerland (2024): free choice and presuppositional exhaustification
+# Del Pinal, Bassi and Sauerland (2024): Free choice and presuppositional exhaustification
 
-[delpinal-bassi-sauerland-2024] derive free choice with `pex^{IE+II}`
-(`Exhaustification.Presuppositional.pexIEII`), which asserts its prejacent and
-*presupposes* the negation of the innocently excludable alternatives together with
-homogeneity over the innocently includable ones. On `◇(p ∨ q)` this is (14): the
-presupposed `◇p ↔ ◇q` with the asserted disjunction entails `◇p ∧ ◇q` (`pex_fc`), and the
-same structure gives double prohibition under negation (16) (`pex_double_prohibition`) and,
-with the necessity alternatives relabelled, negative free choice (19a)–(20)
-(`pex_negative_fc`, `pex_double_requirement`). The split is what flat `exh^{IE+II}`
-lacks, and the paper's embedded puzzles turn on it. Under a negative factive (§3), the
-factive presupposes the whole `pex` output, so free choice is presupposed
-(`fc_presupposed_under_neg_factive`), while the assertion denies belief in the bare
-prejacent, which denies belief in either disjunct (`pex_unaware_target`); a flat `exh`
-complement yields only denial of belief in the exhaustified conjunction, which a believer
-in free choice can satisfy (`exh_unaware_too_weak`). In a disjunction (§4) the homogeneity
-presupposition of the second disjunct is filtered in its local context
-([schlenker-2009]) and free choice follows there (`filtering_fc`), whereas flat `exh`
-leaves nothing to project (`exh_filtering_trivial`). Under quantifiers (§5.1) universal
-projection of the presupposition gives universal, universal-negative, and existential
-free choice, (62), (63), (75) (`universal_fc`, `universal_negative_fc`, `existential_fc`),
-and under *exactly one* (§5.2) the salient readings of (76)–(77) of
-[gotzner-romoli-santorio-2020] (`exactly_one_fc`, `exactly_one_double_prohibition`).
-The alternative set and the free-choice strengthening are [bar-lev-fox-2020]'s.
+This file formalizes the derivation of free choice in [delpinal-bassi-sauerland-2024] with
+the presuppositional exhaustivity operator `pex^{IE+II}`, which asserts its prejacent and
+presupposes the negation of the innocently excludable alternatives together with homogeneity
+over the innocently includable ones, the alternatives and includability being those of
+[bar-lev-fox-2020]. On `◇(p ∨ q)` the presupposed `◇p ↔ ◇q` with the asserted disjunction
+entails `◇p ∧ ◇q`, (14); negation denies the assertion and leaves the presupposition, so
+`¬pex[◇(p ∨ q)]` is double prohibition, (16), and the same structure gives negative free
+choice for `¬□(p ∧ q)`, (19a), and for `¬pex[□(p ∧ q)]`, (20), where `□p` and `□q` are
+includable. The split between the two components is what the flat `exh^{IE+II}` lacks, and
+the embedded puzzles turn on it. Under a negative factive, §3, the factive presupposes the
+whole `pex` output, so free choice is presupposed, (21a), while the assertion denies belief
+in the bare prejacent and so in either disjunct, (21b); a flat `exh` complement only denies
+belief in the exhaustified conjunction, which someone who believes one disjunct satisfies,
+(24a). In a disjunction, §4, the homogeneity presupposition projects out of the negated
+first disjunct and the second disjunct's free-choice presupposition is satisfied in its
+local context, since the negation of the first disjunct is free choice, (53c), which neither
+parse of a flat `exh` achieves, (46c) and (47), and likewise for negative free choice, (57c).
+Under quantifiers, §5, universal projection of the homogeneity presupposition gives
+universal free choice, (67), universal negative free choice, (68), universal double
+prohibition, (71), and existential free choice under either projection, (74) and (75), and
+under *exactly one* the readings of [gotzner-romoli-santorio-2020], (83) and (84).
+
+## Implementation notes
+
+The disjunction rule (45), that `p ∨ q_r` presupposes `¬p → r`, is rendered through the
+substrate's local context of a second disjunct, the global context restricted to the
+negation of the first disjunct's assertion, with the first disjunct's own presupposition
+assumed in the global context. The quantifier cases are stated as the paper states them,
+with the universally projected homogeneity presupposition as a premise; *exactly one* is
+`∃!`.
+
+## References
+
+* [delpinal-bassi-sauerland-2024]
+* [bar-lev-fox-2020]
+* [gotzner-romoli-santorio-2020]
+* [heim-1982]
 -/
 
 namespace DelPinalBassiSauerland2024
 
-open Presupposition
+open Presupposition Presupposition.Context
 open Exhaustification Exhaustification.Presuppositional BarLevFox2020 ModalLogic
-open Presupposition.Context
 
-/-! ### `pex^{IE+II}` on `◇(p ∨ q)` (§2) -/
+/-! ### `pex^{IE+II}` on `◇(p ∨ q)`, §2 -/
 
 section FreeChoice
 
@@ -68,7 +82,7 @@ omit h₁ h₂ h in
 is double prohibition. -/
 theorem pex_double_prohibition (hw : (pexFC R a b).neg.holds w) :
     w ∉ poss R a ∧ w ∉ poss R b :=
-  ⟨fun hA => hw.2 (poss_union.ge (.inl hA)), fun hB => hw.2 (poss_union.ge (.inr hB))⟩
+  ⟨λ hA => hw.2 (poss_union.ge (.inl hA)), λ hB => hw.2 (poss_union.ge (.inr hB))⟩
 
 omit h₁ h₂ h in
 /-- (19a): `¬□(T ∧ B)` is `◇(¬T ∨ ¬B)`, whose alternatives `¬□T`, `¬□B`, `¬□(T ∨ B)` have the
@@ -79,105 +93,212 @@ theorem pex_negative_fc {T B : Set W} (h₁ : ∃ w ∈ poss R Tᶜ, w ∉ poss 
     w ∉ nec R T ∧ w ∉ nec R B := by
   simpa only [poss_compl, Set.mem_compl_iff] using pex_fc h₁ h₂ h hw
 
-omit h₁ h₂ h in
-/-- (20): `¬pex^{IE+II}[¬□(T ∧ B)]` gives double requirement. -/
-theorem pex_double_requirement {T B : Set W} (hw : (pexFC R Tᶜ Bᶜ).neg.holds w) :
-    w ∈ nec R T ∧ w ∈ nec R B := by
-  simpa only [poss_compl, Set.mem_compl_iff, not_not] using pex_double_prohibition hw
+end FreeChoice
 
-/-! ### Free choice under negative factives (§3) -/
+section NegativeFreeChoice
 
-/-- Under a negative factive the whole `pex` output is presupposed, so free choice is
-presupposed, (21a). -/
+variable {W : Type*} (R : W → W → Prop) (T B : Set W)
+
+/-- The alternatives of `□(T ∧ B)`: the conjunction replaced by its conjuncts and their
+disjunction. -/
+def necAlts : Set (Set W) := {nec R (T ∩ B), nec R T, nec R B, nec R (T ∪ B)}
+
+/-- (20): `pex^{IE+II}[□(T ∧ B)]`. -/
+def pexNec : PartialProp W := pexIEII_full (necAlts R T B) (nec R (T ∩ B))
+
+variable {R T B}
+
+theorem nec_inter : nec R (T ∩ B) = nec R T ∩ nec R B :=
+  Set.ext λ _ => ⟨λ h => ⟨λ v hv => (h v hv).1, λ v hv => (h v hv).2⟩,
+    λ h v hv => ⟨h.1 v hv, h.2 v hv⟩⟩
+
+/-- Every alternative of `□(T ∧ B)` is entailed by it, so none is excludable and, given a
+world where it holds, `□T` and `□B` are includable. -/
+theorem nec_mem_II (hsat : ∃ w, w ∈ nec R (T ∩ B)) :
+    nec R T ∈ II (necAlts R T B) (nec R (T ∩ B)) ∧
+      nec R B ∈ II (necAlts R T B) (nec R (T ∩ B)) := by
+  obtain ⟨w₀, hw₀⟩ := hsat
+  have hsub : ∀ q ∈ necAlts R T B, nec R (T ∩ B) ⊆ q := by
+    intro q hq
+    simp only [necAlts, Set.mem_insert_iff, Set.mem_singleton_iff] at hq
+    rcases hq with rfl | rfl | rfl | rfl
+    · exact le_rfl
+    · exact box_mono R Set.inter_subset_left
+    · exact box_mono R Set.inter_subset_right
+    · exact box_mono R (Set.inter_subset_left.trans Set.subset_union_left)
+  have hfin : (necAlts R T B).Finite :=
+    ((Set.finite_singleton _).insert _).insert _ |>.insert _
+  have hcell : cell (necAlts R T B) (nec R (T ∩ B)) w₀ :=
+    ⟨hw₀, λ q hq => absurd hq (not_isInnocentlyExcludable_of_phi_subset hfin ⟨w₀, hw₀⟩
+      (hsub q hq.1)), λ r hr => hsub r hr.1 hw₀⟩
+  exact ⟨mem_II_of_cell_witness _ _ (by simp [necAlts]) w₀ hcell
+      (hsub (nec R T) (by simp [necAlts]) hw₀),
+    mem_II_of_cell_witness _ _ (by simp [necAlts]) w₀ hcell
+      (hsub (nec R B) (by simp [necAlts]) hw₀)⟩
+
+/-- (20): `¬pex^{IE+II}[□(T ∧ B)]` gives negative free choice, the homogeneity `□T ↔ □B`
+projecting out of the negation of the strong prejacent. -/
+theorem pex_negative_fc_under_neg (hsat : ∃ w, w ∈ nec R (T ∩ B)) {w : W}
+    (hw : (pexNec R T B).neg.holds w) : w ∉ nec R T ∧ w ∉ nec R B := by
+  obtain ⟨hT, hB⟩ := nec_mem_II hsat
+  have hiff : w ∈ nec R T ↔ w ∈ nec R B :=
+    hw.1.2 (nec R T) ⟨hT, by simp [necAlts]⟩ (nec R B) ⟨hB, by simp [necAlts]⟩
+  have hne : w ∉ nec R (T ∩ B) := hw.2
+  rw [nec_inter] at hne
+  exact ⟨λ h => hne ⟨h, hiff.1 h⟩, λ h => hne ⟨hiff.2 h, h⟩⟩
+
+end NegativeFreeChoice
+
+/-! ### Free choice under negative factives, §3 -/
+
+section NegativeFactive
+
+variable {W : Type*} {R : W → W → Prop} {a b : Set W}
+  (h₁ : ∃ w ∈ poss R a, w ∉ poss R b) (h₂ : ∃ w ∈ poss R b, w ∉ poss R a)
+  (h : ∃ w ∈ poss R a ∩ poss R b, w ∉ poss R (a ∩ b)) {w : W}
+include h₁ h₂ h
+
+/-- (21a): under a negative factive the whole `pex` output is presupposed, so free choice is
+presupposed. -/
 theorem fc_presupposed_under_neg_factive (believes : (W → Prop) → W → Prop)
     (hw : (PartialProp.negFactive (pexFC R a b) believes).presup w) :
     w ∈ poss R a ∧ w ∈ poss R b :=
   pex_fc h₁ h₂ h hw
 
 omit h₁ h₂ h in
-/-- The factive's assertion denies belief in the prejacent `◇(p ∨ q)`, hence belief in either
-disjunct, (21b). -/
+/-- (21b): the factive's assertion denies belief in the prejacent `◇(p ∨ q)`, hence belief in
+either disjunct. -/
 theorem pex_unaware_target (R' : W → W → Prop)
     (hw : (PartialProp.negFactive (pexFC R a b) (box R')).assertion w) :
     ¬ box R' (poss R a) w ∧ ¬ box R' (poss R b) w :=
-  ⟨fun hA => hw (box_mono R' (λ _ hv => poss_union.ge (.inl hv)) w hA),
-   fun hB => hw (box_mono R' (λ _ hv => poss_union.ge (.inr hv)) w hB)⟩
+  ⟨λ hA => hw (box_mono R' (λ _ hv => poss_union.ge (.inl hv)) w hA),
+   λ hB => hw (box_mono R' (λ _ hv => poss_union.ge (.inr hv)) w hB)⟩
 
-/-- With a flat `exh` complement the factive's assertion only denies belief in the
-exhaustified conjunction, which an attitude holder who believes free choice but not
-exclusivity satisfies (§3.1): given a world permitting `p ∧ q`, believing only it. -/
-theorem exh_unaware_too_weak (hboth : ∃ w, w ∈ poss R (a ∩ b)) :
-    ∃ R' : W → W → Prop, (box R' (poss R a) w ∧ box R' (poss R b) w) ∧
+/-- (24a): with a flat `exh` complement the factive only denies belief in the exhaustified
+conjunction, which an attitude holder who believes Olivia can take Logic but not Algebra
+satisfies, so the target that he believes neither is missed. -/
+theorem exh_unaware_too_weak :
+    ∃ R' : W → W → Prop, box R' (poss R a) w ∧
       ¬ box R' (exhIEII (fcAlts R a b) (poss R (a ∪ b))) w := by
-  obtain ⟨w₀, hw₀⟩ := hboth
-  refine ⟨fun _ v => v = w₀, ⟨fun _ hv => hv ▸ (poss_inter_subset hw₀).1,
-    fun _ hv => hv ▸ (poss_inter_subset hw₀).2⟩, fun hbox => ?_⟩
-  have := hbox w₀ rfl
+  obtain ⟨w₁, hw₁a, hw₁b⟩ := id h₁
+  refine ⟨λ _ v => v = w₁, λ _ hv => hv ▸ hw₁a, λ hbox => ?_⟩
+  have := hbox w₁ rfl
   rw [freeChoice h₁ h₂ h] at this
-  exact this.2 hw₀
+  exact hw₁b this.1.2
 
-/-! ### Filtering free choice (§4) -/
+end NegativeFactive
 
-/-- In `A or pex[◇(p ∨ q)]` the homogeneity presupposition is satisfied in the second
-disjunct's local context `c ∧ ¬A`, and free choice follows there. -/
-theorem filtering_fc (c : Set W) (A : PartialProp W) (hc : w ∈ c)
-    (hA : ¬ A.assertion w) (hf : presupSatisfied (localCtxSecondDisjunct c A) (pexFC R a b))
-    (hassert : (pexFC R a b).assertion w) : w ∈ poss R a ∧ w ∈ poss R b :=
-  pex_fc h₁ h₂ h ⟨hf ⟨hc, hA⟩, hassert⟩
+/-! ### Filtering free choice, §4 -/
 
-omit h₁ h₂ h in
-/-- A flat `exh` second disjunct has nothing to filter: its free-choice content is
-assertive and stays inside the disjunct (§4.1). -/
-theorem exh_filtering_trivial (c : Set W) (A : PartialProp W) :
-    presupSatisfied (localCtxSecondDisjunct c A)
-      (PartialProp.ofProp (exhIEII (fcAlts R a b) (poss R (a ∪ b)))) :=
-  fun _ _ => trivial
+section Filtering
 
-end FreeChoice
+variable {W : Type*} {R : W → W → Prop} {a b A B : Set W} (hA : a ⊆ A) (hB : b ⊆ B)
+include hA hB
 
-/-! ### Free choice under quantifiers (§5) -/
+/-- (53c): in `¬pex[◇(a ∨ b)] ∨ C`, with `C` presupposing `◇A ∧ ◇B` for `a ⊆ A` and `b ⊆ B`,
+the presupposition is satisfied in `C`'s local context once the first disjunct's own
+presupposition is in the global context: the negation of the first disjunct is free choice
+for `a` and `b`. So the disjunction rule (45) filters it. -/
+theorem filtering (h₁ : ∃ w ∈ poss R a, w ∉ poss R b) (h₂ : ∃ w ∈ poss R b, w ∉ poss R a)
+    (h : ∃ w ∈ poss R a ∩ poss R b, w ∉ poss R (a ∩ b)) {c : Set W}
+    (hc : c ⊆ (pexFC R a b).presup) (C : W → Prop) :
+    presupSatisfied (localCtxSecondDisjunct c (pexFC R a b).neg)
+      ⟨λ w => w ∈ poss R A ∧ w ∈ poss R B, C⟩ := by
+  intro w ⟨hcw, hna⟩
+  have hfc := pex_fc h₁ h₂ h ⟨hc hcw, not_not.1 hna⟩
+  exact ⟨poss_mono hA hfc.1, poss_mono hB hfc.2⟩
+
+omit hA hB in
+/-- (46c): without exhaustification under the negation the antecedent of the conditional
+presupposition is only `◇(a ∨ b)`, which does not entail `◇A ∧ ◇B`: a world permitting `a`
+but not `B` refutes it. -/
+theorem no_filtering_without_pex (hw : ∃ w ∈ poss R a, w ∉ poss R B) :
+    ¬ ∀ w, w ∈ poss R (a ∪ b) → w ∈ poss R A ∧ w ∈ poss R B :=
+  λ hall => let ⟨w, hwa, hwB⟩ := hw; hwB (hall w (poss_mono Set.subset_union_left hwa)).2
+
+omit hA hB in
+/-- (47): a flat `exh` under the negation filters but loses double prohibition, since the
+negated exhaustified disjunction is compatible with permitting `a`. -/
+theorem exh_loses_double_prohibition (h₁ : ∃ w ∈ poss R a, w ∉ poss R b)
+    (h₂ : ∃ w ∈ poss R b, w ∉ poss R a)
+    (h : ∃ w ∈ poss R a ∩ poss R b, w ∉ poss R (a ∩ b)) :
+    ∃ w, w ∉ exhIEII (fcAlts R a b) (poss R (a ∪ b)) ∧ w ∈ poss R a := by
+  obtain ⟨w₁, hw₁a, hw₁b⟩ := id h₁
+  exact ⟨w₁, λ hex => by rw [freeChoice h₁ h₂ h] at hex; exact hw₁b hex.1.2, hw₁a⟩
+
+/-- (57c): in `pex[□(A ∧ B)] ∨ C`, with `C` presupposing `¬□a ∧ ¬□b`, the negation of the
+first disjunct is negative free choice for `A` and `B`, which entails it, so the disjunction
+rule filters it. -/
+theorem filtering_negative (hsat : ∃ w, w ∈ nec R (A ∩ B)) {c : Set W}
+    (hc : c ⊆ (pexNec R A B).presup) (C : W → Prop) :
+    presupSatisfied (localCtxSecondDisjunct c (pexNec R A B))
+      ⟨λ w => w ∉ nec R a ∧ w ∉ nec R b, C⟩ := by
+  intro w ⟨hcw, hna⟩
+  have := pex_negative_fc_under_neg hsat (w := w) ⟨hc hcw, hna⟩
+  exact ⟨λ ha => this.1 (box_mono R hA w ha), λ hb => this.2 (box_mono R hB w hb)⟩
+
+end Filtering
+
+/-! ### Free choice under quantifiers, §5 -/
 
 variable {Student : Type*} (S : Student → Prop)
 
-/-- (62): universal projection of homogeneity and the universal assertion give universal free
-choice. -/
+/-- (67): universal projection of homogeneity with the universal assertion gives universal
+free choice. -/
 theorem universal_fc (permC permIC : Student → Prop)
     (hassert : ∀ x, S x → permC x ∨ permIC x) (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
     (∀ x, S x → permC x) ∧ ∀ x, S x → permIC x :=
-  ⟨fun x hx => (hassert x hx).elim id (hhomog x hx).2,
-   fun x hx => (hassert x hx).elim (hhomog x hx).1 id⟩
+  ⟨λ x hx => (hassert x hx).elim id (hhomog x hx).2,
+   λ x hx => (hassert x hx).elim (hhomog x hx).1 id⟩
 
-/-- (63): with a negated existential assertion, universal negative free choice. -/
+/-- (68): with a negated existential assertion, universal negative free choice. -/
 theorem universal_negative_fc (reqA reqB : Student → Prop)
     (hassert : ¬ ∃ x, S x ∧ reqA x ∧ reqB x) (hhomog : ∀ x, S x → (reqA x ↔ reqB x)) :
     (¬ ∃ x, S x ∧ reqA x) ∧ ¬ ∃ x, S x ∧ reqB x :=
-  ⟨fun ⟨x, hx, hA⟩ => hassert ⟨x, hx, hA, (hhomog x hx).1 hA⟩,
-   fun ⟨x, hx, hB⟩ => hassert ⟨x, hx, (hhomog x hx).2 hB, hB⟩⟩
+  ⟨λ ⟨x, hx, hA⟩ => hassert ⟨x, hx, hA, (hhomog x hx).1 hA⟩,
+   λ ⟨x, hx, hB⟩ => hassert ⟨x, hx, (hhomog x hx).2 hB, hB⟩⟩
 
-/-- (75): with an existential assertion, existential free choice. -/
+/-- (71): with a negated existential disjunctive assertion, universal double prohibition, the
+reading the elided second sentence of (69) needs. -/
+theorem universal_double_prohibition (permC permIC : Student → Prop)
+    (hassert : ¬ ∃ x, S x ∧ (permC x ∨ permIC x)) :
+    (¬ ∃ x, S x ∧ permC x) ∧ ¬ ∃ x, S x ∧ permIC x :=
+  ⟨λ ⟨x, hx, hC⟩ => hassert ⟨x, hx, .inl hC⟩, λ ⟨x, hx, hIC⟩ => hassert ⟨x, hx, .inr hIC⟩⟩
+
+/-- (74): with an existential assertion and universal projection, existential free choice. -/
 theorem existential_fc (permC permIC : Student → Prop)
     (hassert : ∃ x, S x ∧ (permC x ∨ permIC x)) (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
     ∃ x, S x ∧ permC x ∧ permIC x :=
   let ⟨x, hx, h⟩ := hassert
-  ⟨x, hx, h.elim (fun hC => ⟨hC, (hhomog x hx).1 hC⟩) fun hIC => ⟨(hhomog x hx).2 hIC, hIC⟩⟩
+  ⟨x, hx, h.elim (λ hC => ⟨hC, (hhomog x hx).1 hC⟩) λ hIC => ⟨(hhomog x hx).2 hIC, hIC⟩⟩
 
-/-- (76a): under *exactly one*, the witness has free choice and every other student double
-prohibition. -/
-theorem exactly_one_fc (permL permC : Student → Prop) (x₀ : Student) (hx₀ : S x₀)
-    (hpos : permL x₀ ∨ permC x₀) (hneg : ∀ x, S x → x ≠ x₀ → ¬ (permL x ∨ permC x))
-    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
-    (permL x₀ ∧ permC x₀) ∧ ∀ x, S x → x ≠ x₀ → ¬ permL x ∧ ¬ permC x :=
-  ⟨hpos.elim (fun h => ⟨h, (hhomog x₀ hx₀).1 h⟩) fun h => ⟨(hhomog x₀ hx₀).2 h, h⟩,
-   fun x hx hne => ⟨fun h => hneg x hx hne (.inl h), fun h => hneg x hx hne (.inr h)⟩⟩
+/-- (75): with existential projection bound by the quantifier, existential free choice
+again. -/
+theorem existential_fc_bound (permC permIC : Student → Prop)
+    (hassert : ∃ x, S x ∧ (permC x ↔ permIC x) ∧ (permC x ∨ permIC x)) :
+    ∃ x, S x ∧ permC x ∧ permIC x :=
+  let ⟨x, hx, hiff, h⟩ := hassert
+  ⟨x, hx, h.elim (λ hC => ⟨hC, hiff.1 hC⟩) λ hIC => ⟨hiff.2 hIC, hIC⟩⟩
 
-/-- (77a): under *exactly one … can't*, the witness has double prohibition and every other
-student free choice. -/
-theorem exactly_one_double_prohibition (permL permC : Student → Prop) (x₀ : Student)
-    (hneg : ¬ (permL x₀ ∨ permC x₀)) (hpos : ∀ x, S x → x ≠ x₀ → permL x ∨ permC x)
-    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
-    (¬ permL x₀ ∧ ¬ permC x₀) ∧ ∀ x, S x → x ≠ x₀ → permL x ∧ permC x :=
-  ⟨⟨fun h => hneg (.inl h), fun h => hneg (.inr h)⟩,
-   fun x hx hne => (hpos x hx hne).elim (fun h => ⟨h, (hhomog x hx).1 h⟩)
-     fun h => ⟨(hhomog x hx).2 h, h⟩⟩
+/-- (83): under *exactly one*, universal homogeneity turns the assertion that exactly one
+student may take Logic or Calculus into exactly one having free choice, every other student
+having double prohibition. -/
+theorem exactly_one_fc (permL permC : Student → Prop)
+    (hassert : ∃! x, S x ∧ (permL x ∨ permC x)) (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
+    (∃! x, S x ∧ permL x ∧ permC x) ∧
+      ∀ x, S x → ¬ (permL x ∨ permC x) → ¬ permL x ∧ ¬ permC x := by
+  obtain ⟨x₀, ⟨hx₀, hor⟩, huniq⟩ := hassert
+  refine ⟨⟨x₀, ⟨hx₀, hor.elim (λ h => ⟨h, (hhomog x₀ hx₀).1 h⟩) λ h => ⟨(hhomog x₀ hx₀).2 h, h⟩⟩,
+    λ y ⟨hy, hL, _⟩ => huniq y ⟨hy, .inl hL⟩⟩, λ _ _ hn => ⟨λ h => hn (.inl h), λ h => hn (.inr h)⟩⟩
+
+/-- (84): under *exactly one … can't*, exactly one student has double prohibition and every
+other has free choice. -/
+theorem exactly_one_double_prohibition (permL permC : Student → Prop)
+    (hassert : ∃! x, S x ∧ ¬ (permL x ∨ permC x)) (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
+    (∃! x, S x ∧ ¬ permL x ∧ ¬ permC x) ∧ ∀ x, S x → permL x ∨ permC x → permL x ∧ permC x := by
+  obtain ⟨x₀, ⟨hx₀, hn⟩, huniq⟩ := hassert
+  refine ⟨⟨x₀, ⟨hx₀, λ h => hn (.inl h), λ h => hn (.inr h)⟩,
+    λ y ⟨hy, hL, hC⟩ => huniq y ⟨hy, λ h => h.elim hL hC⟩⟩,
+    λ x hx h => h.elim (λ h => ⟨h, (hhomog x hx).1 h⟩) λ h => ⟨(hhomog x hx).2 h, h⟩⟩
 
 end DelPinalBassiSauerland2024

--- a/references.bib
+++ b/references.bib
@@ -2203,7 +2203,7 @@
   subfield  = {semantics/exhaustification},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/Ronai2024.lean}
+  sources   = {Studies/DelPinalBassiSauerland2024.lean}
 }% REF: Mazzarella, D. et al. (2018). Saying, presupposing and implicating.
 @phdthesis{alok-2020,
   author    = {Alok, Deepak},
@@ -2965,7 +2965,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/BarLevFox2020.json}
+  sources   = {Data/Examples/BarLevFox2020.json;Semantics/Exhaustification/Disjunctive.lean;Semantics/Exhaustification/InnocentInclusion.lean;Semantics/Exhaustification/Presuppositional.lean;Studies/AghaJeretic2026.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/DelPinalBassiSauerland2024.lean;Studies/ZaniCiardelliSanfelici2026.lean}
 }
 @article{delpinal-bassi-sauerland-2024,
   author    = {Del Pinal, Guillermo and Bassi, Itai and Sauerland, Uli},
@@ -2979,7 +2979,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Exhaustification/Presuppositional.lean;Studies/DelPinalBassiSauerland2024.lean}
+  sources   = {Semantics/Exhaustification/Presuppositional.lean;Semantics/Presupposition/Basic.lean;Semantics/Presupposition/BeliefEmbedding.lean;Studies/DelPinalBassiSauerland2024.lean;Studies/Enguehard2024.lean}
 }
 % REF: Del Pinal, G. (2015). Dual Content Semantics, privative adjectives, and dynamic compositionality.
 @article{delpinal-2015,
@@ -15281,7 +15281,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Schlenker2009.lean}
+  sources   = {Semantics/Presupposition/Basic.lean;Semantics/Presupposition/BeliefEmbedding.lean;Semantics/Presupposition/Context.lean;Studies/Geurts2005.lean;Studies/Heim1992.lean;Studies/Mandelkern2022.lean;Studies/Schlenker2009.lean;Studies/SolstadBott2024.lean;Studies/TonhauserEtAl2013.lean;Studies/Yagi2025.lean}
 }
 @article{heim-1990,
   author    = {Heim, Irene},
@@ -16300,7 +16300,7 @@
   doi       = {10.5281/zenodo.8100765},
   validated = {true},
   role      = {foundational},
-  sources   = {Data/Examples/Heim1982.json;Logic/CylindricAlgebra.lean;Semantics/Definiteness/Basic.lean;Semantics/Definiteness/Defs.lean;Semantics/Definiteness/Description.lean;Semantics/Dynamic/FileChange.lean;Semantics/Dynamic/Partial.lean;Semantics/Dynamic/Possibility.lean;Semantics/Dynamic/State.lean;Semantics/Dynamic/Transition.lean;Semantics/Dynamic/Update.lean;Semantics/Mood/Dynamic.lean;Semantics/Tense/Dynamic.lean;Studies/Dekker2012.lean;Studies/Elbourne2013.lean;Studies/Heim1982.lean;Studies/Mandelkern2022.lean;Studies/Spector2025.lean;Studies/Yagi2025.lean}
+  sources   = {Data/Examples/Heim1982.json;Logic/CylindricAlgebra.lean;Semantics/Definiteness/Basic.lean;Semantics/Definiteness/Defs.lean;Semantics/Definiteness/Description.lean;Semantics/Dynamic/FileChange.lean;Semantics/Dynamic/Partial.lean;Semantics/Dynamic/Possibility.lean;Semantics/Dynamic/State.lean;Semantics/Dynamic/Transition.lean;Semantics/Dynamic/Update.lean;Semantics/Mood/Dynamic.lean;Semantics/Tense/Dynamic.lean;Studies/Dekker2012.lean;Studies/DelPinalBassiSauerland2024.lean;Studies/Elbourne2013.lean;Studies/Heim1982.lean;Studies/Mandelkern2022.lean;Studies/Spector2025.lean;Studies/Yagi2025.lean}
 }
 @article{krahmer-muskens-1995,
   author    = {Krahmer, Emiel and Muskens, Reinhard},


### PR DESCRIPTION
Deep cleanse of Del Pinal, Bassi and Sauerland (2024): every locator checked against the paper, (20) now derived from `pex^{IE+II}` over the necessity alternatives, and the filtering section rebuilt on the substrate's local context.

- `necAlts`/`pexNec` with `nec_mem_II` and `pex_negative_fc_under_neg` (20) replace the mislabelled double-requirement theorem; `exh_unaware_too_weak` restated as the paper's (24a) witness; `filtering` (53c), `no_filtering_without_pex` (46c), `exh_loses_double_prohibition` (47), `filtering_negative` (57c); `universal_double_prohibition` (71) and `existential_fc_bound` (75) added; *exactly one* as `∃!`, (83)–(84)
- `Semantics/Exhaustification/Presuppositional.lean` header in mathlib register, banners gone, two unused lemmas dropped; Enguehard2024 unaffected
- bib `sources` recomputed for the cited keys