### PR TITLE
refactor(Studies/Deo2025): felicity from sincerity and consistency

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -680,6 +680,7 @@ import Linglib.Discourse.Coherence
 import Linglib.Discourse.Commitment.Basic
 import Linglib.Discourse.Commitment.Declarative
 import Linglib.Discourse.Commitment.Frame
+import Linglib.Discourse.Commitment.Preferential
 import Linglib.Discourse.Commitment.Space
 import Linglib.Discourse.Commitment.Table
 import Linglib.Discourse.CommonGround
@@ -3036,3 +3037,4 @@ import Linglib.Data.Examples.DeMarneffeNivre2019
 import Linglib.Data.Examples.Dendikken1995
 import Linglib.Data.Examples.Denic2023
 import Linglib.Data.Examples.DenicEtAl2021
+import Linglib.Data.Examples.Deo2025

--- a/Linglib/Data/Examples/Deo2025.json
+++ b/Linglib/Data/Examples/Deo2025.json
@@ -1,0 +1,618 @@
+[
+  {
+    "id": "deo2025_1",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(1)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "rəst-e kʰup nisərɖ-e ʣʰa-le ahe-t bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["rəst-e", "road.M-PL.NOM"], ["kʰup", "very"], ["nisərɖ-e", "slippery-M.PL.NOM"],
+      ["ʣʰa-le", "become-PERF.M.PL"], ["ahe-t", "be.PRES-3.PL"], ["bərə", "BARA"]
+    ],
+    "translation": "The roads have become very slippery, (keep this in mind).",
+    "context": "Anu is going to Mumbai and says to Bilal: I think it will be faster to drive. Bilal: Are you sure? There have been heavy rains...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "warning"]
+    ],
+    "comment": "Bilal warns Anu to take the road conditions into account before driving.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_2",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(2)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "tu mumbəi=la udya ʣa bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tu", "you.NOM"], ["mumbəi=la", "Bombay=DAT"], ["udya", "tomorrow"], ["ʣa", "go.IMP"],
+      ["bərə", "BARA"]
+    ],
+    "translation": "Go to Mumbai tomorrow, (just do as I say).",
+    "context": "Same as (1). Bilal: I absolutely don't want you to be driving in this weather...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "command"]
+    ],
+    "comment": "The particle intensifies the directive force of the imperative.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_3",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(3)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "tu maʤʰ-i ʦavi kuʈʰe ʈʰev-li-s bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tu", "you.ERG"], ["maʤʰ-i", "my-F.SG.NOM"], ["ʦavi", "key.F.SG.NOM"], ["kuʈʰe", "where"],
+      ["ʈʰev-li-s", "keep-PERF.F.SG-2.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Where did you keep my key? (you better answer right away!)",
+    "context": "Anu is annoyed because Bilal has hidden her bike key and she needs to get to work urgently. Anu: This is ridiculous...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "constituent"],
+      ["act", "question"]
+    ],
+    "comment": "The wh-interrogative use, which the paper leaves outside its analysis of declaratives and imperatives.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_4",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(4)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "mi ata ɔfis=la ʣa-te ahe bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["mi", "I.NOM"], ["ata", "now"], ["ɔfis=la", "office=DAT"], ["ʣa-te", "go-IMPF.F.SG"],
+      ["ahe", "be.PRES.1.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "I am going to the office now (alright?/ok?).",
+    "context": "Anu needs Bilal to stay at home because the plumber will be coming and someone needs to be in the house to meet him. Anu:",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "informing"]
+    ],
+    "comment": "New information relevant to the addressee's actions, with the expectation that he take it on as a commitment; the goal that the plumber be let in is a joint preference.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_5a",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(5a)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "aʣ kʰup paus pəɖ-to ahe bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["aʣ", "today"], ["kʰup", "much"], ["paus", "rain.M.SG.NOM"], ["pəɖ-to", "fall-IMPF.M.SG"],
+      ["ahe", "be.PRES.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "It is raining hard today (bear in mind).",
+    "context": "Anu is planning to go to Mumbai today by car. It is raining heavily along the route, impacting road conditions, but the weather will significantly improve tomorrow, making the drive much safer. Bilal says:",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "warning"]
+    ],
+    "comment": "Bilal wants Anu to alter her plan and not travel today, offering no alternative plan: her commitment to the content is a precondition for staying safe.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_5b",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(5b)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "udya ʦaŋgl-ə unʰ pəɖ-el bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["udya", "tomorrow"], ["ʦaŋgl-ə", "good-N.SG.NOM"], ["unʰ", "sunshine-N.SG.NOM"],
+      ["pəɖ-el", "fall-FUT.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Tomorrow, it will be quite sunny (#bear in mind).",
+    "context": "Anu is planning to go to Mumbai today by car. It is raining heavily along the route, impacting road conditions, but the weather will significantly improve tomorrow, making the drive much safer. Bilal says:",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "warning"],
+      ["infelicity", "precondition"]
+    ],
+    "comment": "The content points towards one alternative plan among many, so committing to it is not a precondition for the goal. All three consulted speakers rule it out, fn. 3.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_6",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(6)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "he əuʃədʰ tum-ʦ-a tap kəmi kər-el bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["he", "this.N.SG.NOM"], ["əuʃədʰ", "medicine.N.SG.NOM"], ["tum-ʦ-a", "you-GEN-M.SG.NOM"],
+      ["tap", "fever.M.SG.NOM"], ["kəmi", "less"], ["kər-el", "do-FUT.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "This medicine will lower your fever, (alright?/ok?).",
+    "context": "Anu has been sick and goes to the doctor, who diagnoses a viral infection. Doctor: Don't worry, the infection will run its course. Meanwhile...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "advice"]
+    ],
+    "comment": "The doctor's expertise gives the authority to express a preference for dependent commitment; the addressee has no action choices aligned with the goal yet.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_7ctx1",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(7), context 1"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "niʃa tiʧ-ya bəhiɳi=la aɳ-te ahe bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["niʃa", "Niśa.NOM"], ["tiʧ-ya", "her.GEN-OBL"], ["bəhiɳi=la", "sister.OBL=ACC"],
+      ["aɳ-te", "bring-IMPF.F.SG"], ["ahe", "PRES.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Niśa is bringing her sister with her.",
+    "context": "Anu and Bilal are hosting three friends for dinner and they both have been told that one of them will also bring her sister along. Bilal is setting the table. Bilal: Let's see, how many place settings do we need?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "reminder"],
+      ["infelicity", "alignment"]
+    ],
+    "comment": "Anu may reasonably assume that Bilal is aware of the content, so nothing shows his action choices misaligned with it.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_7ctx2",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(7), context 2"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "niʃa tiʧ-ya bəhiɳi=la aɳ-te ahe bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["niʃa", "Niśa.NOM"], ["tiʧ-ya", "her.GEN-OBL"], ["bəhiɳi=la", "sister.OBL=ACC"],
+      ["aɳ-te", "bring-IMPF.F.SG"], ["ahe", "PRES.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Niśa is bringing her sister with her.",
+    "context": "Anu and Bilal are hosting three friends for dinner and they both have been told that one of them will also bring her sister along. It's almost time for the guests and Bilal has laid the table with settings for only five people. Anu: We need six place settings...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "reminder"]
+    ],
+    "comment": "The table setting is evidence that Bilal's action choices do not reflect commitment to the content.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_8",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(8)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "tu=la dəmya-ʦa tras ahe bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tu=la", "you.OBL=DAT"], ["dəmya-ʦa", "asthma.OBL-GEN.M.SG.NOM"],
+      ["tras", "suffering.M.SG.NOM"], ["ahe", "be.PRES.3.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "You suffer from asthma, (don't forget).",
+    "context": "Anu has been offered a new job assignment, which requires her to move to a hilly, high-altitude location with steep roads for a year. She is excited about it and is considering it seriously. Bilal prefers that she not make the move for health reasons. Bilal: This could be really difficult for you health-wise...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "warning"]
+    ],
+    "comment": "Shared content uttered to warn of adverse consequences if it is left out of the decision: a warning and a reminder at once.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_9",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(9)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ho mi ti=la gʰe-un ye-te bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ho", "yes"], ["mi", "I.NOM"], ["ti=la", "her.OBL=ACC"], ["gʰe-un", "bring-GER"],
+      ["ye-te", "come-IMPF.F.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Sure, I'll pick her up!",
+    "context": "Anu and Bilal take turns picking up their daughter Deepa from after-school. It is Bilal's turn today. Bilal tells Anu that he is really busy that day and asks if Anu can pick Deepa up instead. Anu: I understand...",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "declarative"],
+      ["act", "commissive"],
+      ["infelicity", "source"]
+    ],
+    "comment": "A declarative used commissively aligns with a manifest addressee preference: Bilal, who asked, is already a source for the content.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_10a",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(10a)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "krupəya tumʰi mə=la həʣar rupye dy-a bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["krupəya", "please"], ["tumʰi", "you.PL.HON"], ["mə=la", "I.OBL=DAT"],
+      ["həʣar", "thousand"], ["rupye", "rupees"], ["dy-a", "give.IMP-PL"], ["bərə", "BARA"]
+    ],
+    "translation": "Please (sir), give me a thousand rupees.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "request"],
+      ["infelicity", "benefit"]
+    ],
+    "comment": "A request: realizing the content benefits the speaker and does not interfere with the addressee's existing preferences.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_10b",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(10b)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "koɳi=tari mə=la vihir=it=un baher kaɖʰ-a bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["koɳi=tari", "someone=PRT"], ["mə=la", "I.OBL=ACC"], ["vihir=it=un", "well.OBL=IN=FROM"],
+      ["baher", "out"], ["kaɖʰ-a", "bring.IMP-PL"], ["bərə", "BARA"]
+    ],
+    "translation": "Someone (please) help me come out from this well!",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "plea"],
+      ["infelicity", "benefit"]
+    ],
+    "comment": "A plea: realizing the content benefits the speaker and is presumed inconsistent with the addressee's existing preferences.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_11a",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(11a)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "tu hi rəbəɖi kʰa bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tu", "you.NOM"], ["hi", "this.F.SG.NOM"], ["rəbəɖi", "rabadi.F.SG.NOM"],
+      ["kʰa", "eat.IMP.SG"], ["bərə", "BARA"]
+    ],
+    "translation": "Try (lit. eat) this rabadi (milk-based dessert)!",
+    "context": "Anu has made a dessert and is offering it to Bilal to taste. She says:",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "offer"],
+      ["infelicity", "deference"]
+    ],
+    "comment": "With the particle the utterance is understood as a mock command or a veiled threat rather than an offer, fn. 4.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_11b",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(11b)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ho ʣa aɳi məʤa kər-a bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ho", "sure"], ["ʣa", "go.IMP.PL"], ["aɳi", "and"], ["məʤa", "fun"], ["kər-a", "do.IMP-PL"],
+      ["bərə", "BARA"]
+    ],
+    "translation": "Sure, go and have fun!",
+    "context": "Deepa and her friends are planning to go to the park and Deepa comes and asks her mother: Mom, can I go play in the park with my friends?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "permission"],
+      ["infelicity", "source"]
+    ],
+    "comment": "A permission with a well-wish: Deepa has asked, so she is a source for the content.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_11c",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(11c)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ʈʰik ahe ʣa kʰeɭay-la bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ʈʰik ahe", "alright"], ["ʣa", "go.IMP"], ["kʰeɭay-la", "play-INF"], ["bərə", "BARA"]
+    ],
+    "translation": "Alright! Go and play (if you aren't going to listen!)",
+    "context": "Anu has asked Deepa to finish her homework before going out to play. Deepa is badgering Anu because she wants to go play without finishing her homework. Anu gets exasperated and says:",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "concession"],
+      ["infelicity", "source"]
+    ],
+    "comment": "A concession: Deepa has revealed her preference for the content and is a source for it.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "deo2025_11d",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(11d)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ʣa kʰəɖɖya=t bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ʣa", "go.IMP"], ["kʰəɖɖya=t", "ditch.OBL=LOC"], ["bərə", "BARA"]
+    ],
+    "translation": "Go to hell (lit. into a ditch)!",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [
+      {"form": "ʣa məsəɳa=t bərə", "judgment": "unacceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "curse"],
+      ["infelicity", "benefit"]
+    ],
+    "comment": "A curse, detrimental to the addressee; the variant with məsəɳa=t 'burial.ground.OBL=LOC' is the same curse.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_12",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(12)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "tu ata ləgeʦ ʣopay-la ʣa bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tu", "you.NOM"], ["ata", "now"], ["ləgeʦ", "immediately"], ["ʣopay-la", "sleep-INF"],
+      ["ʣa", "go.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "Get into bed immediately now! (just do as I say)",
+    "context": "Deepa has stayed up way past her bedtime playing a video game. Anu gets annoyed because Deepa has school tomorrow and needs to be up early. She has already told Deepa several times to go to bed. Anu: You are stretching my patience now...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "command"]
+    ],
+    "comment": "Anu's authority is made salient; Deepa does not share the goal that she be rested, and her action choices are not aligned with it, fn. 12.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_13",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(13)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "kəɖʰəi=mədʰye ətta=ʦ tel ʈaku nəko bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kəɖʰəi=mədʰye", "pan.OBL=in"], ["ətta=ʦ", "now=EMPH"], ["tel", "oil.N.SG.NOM"],
+      ["ʈaku", "pour.INF"], ["nəko", "NEG.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "Don't pour the oil into the pan just yet! (or it will go up in flames)",
+    "context": "Deepa is making dal for the first time with Anu's help and has let the pan get too hot on the stove. She is about to put in some oil to start sautéing the onions. Anu:",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "warning"]
+    ],
+    "comment": "Deepa is expected to comply in order to ensure her own safety, a goal she most likely shares, fn. 12.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_14",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(14)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ata aʤi=la ek pətrə lihi bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ata", "now"], ["aʤi=la", "grandma.OBL=DAT"], ["ek", "one.NOM"], ["pətrə", "note.N.SG.NOM"],
+      ["lihi", "write.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "(Come) now, write a letter to grandma!",
+    "context": "Deepa got a lovely doll in the mail from Anu's mother and has been playing with it. Anu wants Deepa to thank her grandma before she forgets. Anu: Alright, you have played enough now...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "recommendation"]
+    ],
+    "comment": "A strong recommendation towards a goal, learning to express gratitude, that the addressee does not share, fn. 12.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_15ctx1",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(15), context 1"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "məg aʣ tu gaɖi gʰe-un ʣa bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["məg", "then"], ["aʣ", "today"], ["tu", "you.NOM"], ["gaɖi", "car.F.SG.NOM"],
+      ["gʰe-un", "take-GER"], ["ʣa", "go.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "Then, (go ahead and) take the car today.",
+    "context": "Bilal needs to be at a work meeting soon and he has missed the bus that he takes to work. Anu is the one who usually takes the car to work but Bilal would love to be able to drive to work today. Bilal tells Anu he missed the bus. Anu: Ok, so we need to figure out a solution...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "recommendation"]
+    ],
+    "comment": "Bilal's preference for taking the car is latent, so Anu's proposal sounds like a solicitous command that he will comply with; it cannot be conditionalized with 'if you like', fn. 7.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_15ctx2",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(15), context 2"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "məg aʣ tu gaɖi gʰe-un ʣa bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["məg", "then"], ["aʣ", "today"], ["tu", "you.NOM"], ["gaɖi", "car.F.SG.NOM"],
+      ["gʰe-un", "take-GER"], ["ʣa", "go.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "Then, (go ahead and) take the car today.",
+    "context": "Bilal needs to be at a work meeting soon and he has missed the bus that he takes to work. Anu is the one who usually takes the car to work but Bilal would love to be able to drive to work today. Bilal tells Anu he missed the bus and adds: I would really like to drive to work today so I don't miss my meeting. Anu:",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "recommendation"],
+      ["infelicity", "source"]
+    ],
+    "comment": "Bilal has revealed his preference, so he is a source for the content.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_16",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(16)"},
+    "reportedIn": null,
+    "language": "mara1378",
+    "primaryText": "ʧʰan tu ti=la gʰe-un ye bərə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ʧʰan", "great"], ["tu", "you.NOM"], ["ti=la", "her.OBL=ACC"], ["gʰe-un", "bring-GER"],
+      ["ye", "come.IMP"], ["bərə", "BARA"]
+    ],
+    "translation": "Great, you pick her up and get her (home)!",
+    "context": "Anu and Bilal take turns picking up their daughter Deepa from after-school. It is Bilal's turn today. Bilal tells Anu that he is really busy that day and doesn't know whether he will make it to the school in time. Anu: No worries, I am working from home today. I will pick her up! Bilal:",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["clauseType", "imperative"],
+      ["act", "agreement"],
+      ["infelicity", "source"]
+    ],
+    "comment": "An imperative agreeing with an actional commitment the addressee has undertaken: Anu is a source for the content.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "deo2025_19a",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(19a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Anu: Keep the discussion we had at this meeting confidential. Nina: Ok/Yes.",
+    "discourseSegments": [
+      "Keep the discussion we had at this meeting confidential.",
+      "Ok/Yes."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Anu and her secretary Nina, after a sensitive meeting with a small subset of Anu's team.",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Ok", "judgment": "acceptable"},
+      {"form": "Yes", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "responseParticle"]
+    ],
+    "comment": "Ok takes on Anu's preferential commitment as a dependent, yes commits to the preference independently; only ok admits the continuation 'I had been planning to circulate the minutes', fn. 10.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "deo2025_19b",
+    "source": {"bibkey": "deo-2025-bara", "paperLabel": "(19b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Nina: I will circulate the minutes among all the staff by tomorrow. Anu: No, keep the discussion we had at this meeting confidential. Nina: Ok/#Yes.",
+    "discourseSegments": [
+      "I will circulate the minutes among all the staff by tomorrow.",
+      "No, keep the discussion we had at this meeting confidential.",
+      "Ok/#Yes."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Anu and her secretary Nina, after a sensitive meeting with a small subset of Anu's team.",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Ok", "judgment": "acceptable"},
+      {"form": "Yes", "judgment": "unacceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "responseParticle"]
+    ],
+    "comment": "Nina has expressed an intention incompatible with the preference, so she can no longer commit to it independently with yes.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Deo2025.lean
+++ b/Linglib/Data/Examples/Deo2025.lean
@@ -1,0 +1,468 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Deo2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Deo2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Deo2025.Examples`.
+-/
+
+namespace Deo2025.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "deo2025_1"
+    source := ⟨"deo-2025-bara", "(1)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "rəst-e kʰup nisərɖ-e ʣʰa-le ahe-t bərə"
+    discourseSegments := []
+    glossedTokens := [("rəst-e", "road.M-PL.NOM"), ("kʰup", "very"), ("nisərɖ-e", "slippery-M.PL.NOM"), ("ʣʰa-le", "become-PERF.M.PL"), ("ahe-t", "be.PRES-3.PL"), ("bərə", "BARA")]
+    translation := "The roads have become very slippery, (keep this in mind)."
+    context := "Anu is going to Mumbai and says to Bilal: I think it will be faster to drive. Bilal: Are you sure? There have been heavy rains..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "warning")]
+    comment := "Bilal warns Anu to take the road conditions into account before driving."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_2 : LinguisticExample :=
+  { id := "deo2025_2"
+    source := ⟨"deo-2025-bara", "(2)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "tu mumbəi=la udya ʣa bərə"
+    discourseSegments := []
+    glossedTokens := [("tu", "you.NOM"), ("mumbəi=la", "Bombay=DAT"), ("udya", "tomorrow"), ("ʣa", "go.IMP"), ("bərə", "BARA")]
+    translation := "Go to Mumbai tomorrow, (just do as I say)."
+    context := "Same as (1). Bilal: I absolutely don't want you to be driving in this weather..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "command")]
+    comment := "The particle intensifies the directive force of the imperative."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_3 : LinguisticExample :=
+  { id := "deo2025_3"
+    source := ⟨"deo-2025-bara", "(3)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "tu maʤʰ-i ʦavi kuʈʰe ʈʰev-li-s bərə"
+    discourseSegments := []
+    glossedTokens := [("tu", "you.ERG"), ("maʤʰ-i", "my-F.SG.NOM"), ("ʦavi", "key.F.SG.NOM"), ("kuʈʰe", "where"), ("ʈʰev-li-s", "keep-PERF.F.SG-2.SG"), ("bərə", "BARA")]
+    translation := "Where did you keep my key? (you better answer right away!)"
+    context := "Anu is annoyed because Bilal has hidden her bike key and she needs to get to work urgently. Anu: This is ridiculous..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "constituent"), ("act", "question")]
+    comment := "The wh-interrogative use, which the paper leaves outside its analysis of declaratives and imperatives."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_4 : LinguisticExample :=
+  { id := "deo2025_4"
+    source := ⟨"deo-2025-bara", "(4)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "mi ata ɔfis=la ʣa-te ahe bərə"
+    discourseSegments := []
+    glossedTokens := [("mi", "I.NOM"), ("ata", "now"), ("ɔfis=la", "office=DAT"), ("ʣa-te", "go-IMPF.F.SG"), ("ahe", "be.PRES.1.SG"), ("bərə", "BARA")]
+    translation := "I am going to the office now (alright?/ok?)."
+    context := "Anu needs Bilal to stay at home because the plumber will be coming and someone needs to be in the house to meet him. Anu:"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "informing")]
+    comment := "New information relevant to the addressee's actions, with the expectation that he take it on as a commitment; the goal that the plumber be let in is a joint preference."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_5a : LinguisticExample :=
+  { id := "deo2025_5a"
+    source := ⟨"deo-2025-bara", "(5a)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "aʣ kʰup paus pəɖ-to ahe bərə"
+    discourseSegments := []
+    glossedTokens := [("aʣ", "today"), ("kʰup", "much"), ("paus", "rain.M.SG.NOM"), ("pəɖ-to", "fall-IMPF.M.SG"), ("ahe", "be.PRES.3.SG"), ("bərə", "BARA")]
+    translation := "It is raining hard today (bear in mind)."
+    context := "Anu is planning to go to Mumbai today by car. It is raining heavily along the route, impacting road conditions, but the weather will significantly improve tomorrow, making the drive much safer. Bilal says:"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "warning")]
+    comment := "Bilal wants Anu to alter her plan and not travel today, offering no alternative plan: her commitment to the content is a precondition for staying safe."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_5b : LinguisticExample :=
+  { id := "deo2025_5b"
+    source := ⟨"deo-2025-bara", "(5b)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "udya ʦaŋgl-ə unʰ pəɖ-el bərə"
+    discourseSegments := []
+    glossedTokens := [("udya", "tomorrow"), ("ʦaŋgl-ə", "good-N.SG.NOM"), ("unʰ", "sunshine-N.SG.NOM"), ("pəɖ-el", "fall-FUT.3.SG"), ("bərə", "BARA")]
+    translation := "Tomorrow, it will be quite sunny (#bear in mind)."
+    context := "Anu is planning to go to Mumbai today by car. It is raining heavily along the route, impacting road conditions, but the weather will significantly improve tomorrow, making the drive much safer. Bilal says:"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "warning"), ("infelicity", "precondition")]
+    comment := "The content points towards one alternative plan among many, so committing to it is not a precondition for the goal. All three consulted speakers rule it out, fn. 3."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_6 : LinguisticExample :=
+  { id := "deo2025_6"
+    source := ⟨"deo-2025-bara", "(6)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "he əuʃədʰ tum-ʦ-a tap kəmi kər-el bərə"
+    discourseSegments := []
+    glossedTokens := [("he", "this.N.SG.NOM"), ("əuʃədʰ", "medicine.N.SG.NOM"), ("tum-ʦ-a", "you-GEN-M.SG.NOM"), ("tap", "fever.M.SG.NOM"), ("kəmi", "less"), ("kər-el", "do-FUT.3.SG"), ("bərə", "BARA")]
+    translation := "This medicine will lower your fever, (alright?/ok?)."
+    context := "Anu has been sick and goes to the doctor, who diagnoses a viral infection. Doctor: Don't worry, the infection will run its course. Meanwhile..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "advice")]
+    comment := "The doctor's expertise gives the authority to express a preference for dependent commitment; the addressee has no action choices aligned with the goal yet."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_7ctx1 : LinguisticExample :=
+  { id := "deo2025_7ctx1"
+    source := ⟨"deo-2025-bara", "(7), context 1"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "niʃa tiʧ-ya bəhiɳi=la aɳ-te ahe bərə"
+    discourseSegments := []
+    glossedTokens := [("niʃa", "Niśa.NOM"), ("tiʧ-ya", "her.GEN-OBL"), ("bəhiɳi=la", "sister.OBL=ACC"), ("aɳ-te", "bring-IMPF.F.SG"), ("ahe", "PRES.3.SG"), ("bərə", "BARA")]
+    translation := "Niśa is bringing her sister with her."
+    context := "Anu and Bilal are hosting three friends for dinner and they both have been told that one of them will also bring her sister along. Bilal is setting the table. Bilal: Let's see, how many place settings do we need?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "reminder"), ("infelicity", "alignment")]
+    comment := "Anu may reasonably assume that Bilal is aware of the content, so nothing shows his action choices misaligned with it."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_7ctx2 : LinguisticExample :=
+  { id := "deo2025_7ctx2"
+    source := ⟨"deo-2025-bara", "(7), context 2"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "niʃa tiʧ-ya bəhiɳi=la aɳ-te ahe bərə"
+    discourseSegments := []
+    glossedTokens := [("niʃa", "Niśa.NOM"), ("tiʧ-ya", "her.GEN-OBL"), ("bəhiɳi=la", "sister.OBL=ACC"), ("aɳ-te", "bring-IMPF.F.SG"), ("ahe", "PRES.3.SG"), ("bərə", "BARA")]
+    translation := "Niśa is bringing her sister with her."
+    context := "Anu and Bilal are hosting three friends for dinner and they both have been told that one of them will also bring her sister along. It's almost time for the guests and Bilal has laid the table with settings for only five people. Anu: We need six place settings..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "reminder")]
+    comment := "The table setting is evidence that Bilal's action choices do not reflect commitment to the content."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_8 : LinguisticExample :=
+  { id := "deo2025_8"
+    source := ⟨"deo-2025-bara", "(8)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "tu=la dəmya-ʦa tras ahe bərə"
+    discourseSegments := []
+    glossedTokens := [("tu=la", "you.OBL=DAT"), ("dəmya-ʦa", "asthma.OBL-GEN.M.SG.NOM"), ("tras", "suffering.M.SG.NOM"), ("ahe", "be.PRES.3.SG"), ("bərə", "BARA")]
+    translation := "You suffer from asthma, (don't forget)."
+    context := "Anu has been offered a new job assignment, which requires her to move to a hilly, high-altitude location with steep roads for a year. She is excited about it and is considering it seriously. Bilal prefers that she not make the move for health reasons. Bilal: This could be really difficult for you health-wise..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "warning")]
+    comment := "Shared content uttered to warn of adverse consequences if it is left out of the decision: a warning and a reminder at once."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_9 : LinguisticExample :=
+  { id := "deo2025_9"
+    source := ⟨"deo-2025-bara", "(9)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ho mi ti=la gʰe-un ye-te bərə"
+    discourseSegments := []
+    glossedTokens := [("ho", "yes"), ("mi", "I.NOM"), ("ti=la", "her.OBL=ACC"), ("gʰe-un", "bring-GER"), ("ye-te", "come-IMPF.F.SG"), ("bərə", "BARA")]
+    translation := "Sure, I'll pick her up!"
+    context := "Anu and Bilal take turns picking up their daughter Deepa from after-school. It is Bilal's turn today. Bilal tells Anu that he is really busy that day and asks if Anu can pick Deepa up instead. Anu: I understand..."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "declarative"), ("act", "commissive"), ("infelicity", "source")]
+    comment := "A declarative used commissively aligns with a manifest addressee preference: Bilal, who asked, is already a source for the content."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_10a : LinguisticExample :=
+  { id := "deo2025_10a"
+    source := ⟨"deo-2025-bara", "(10a)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "krupəya tumʰi mə=la həʣar rupye dy-a bərə"
+    discourseSegments := []
+    glossedTokens := [("krupəya", "please"), ("tumʰi", "you.PL.HON"), ("mə=la", "I.OBL=DAT"), ("həʣar", "thousand"), ("rupye", "rupees"), ("dy-a", "give.IMP-PL"), ("bərə", "BARA")]
+    translation := "Please (sir), give me a thousand rupees."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "request"), ("infelicity", "benefit")]
+    comment := "A request: realizing the content benefits the speaker and does not interfere with the addressee's existing preferences."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_10b : LinguisticExample :=
+  { id := "deo2025_10b"
+    source := ⟨"deo-2025-bara", "(10b)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "koɳi=tari mə=la vihir=it=un baher kaɖʰ-a bərə"
+    discourseSegments := []
+    glossedTokens := [("koɳi=tari", "someone=PRT"), ("mə=la", "I.OBL=ACC"), ("vihir=it=un", "well.OBL=IN=FROM"), ("baher", "out"), ("kaɖʰ-a", "bring.IMP-PL"), ("bərə", "BARA")]
+    translation := "Someone (please) help me come out from this well!"
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "plea"), ("infelicity", "benefit")]
+    comment := "A plea: realizing the content benefits the speaker and is presumed inconsistent with the addressee's existing preferences."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_11a : LinguisticExample :=
+  { id := "deo2025_11a"
+    source := ⟨"deo-2025-bara", "(11a)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "tu hi rəbəɖi kʰa bərə"
+    discourseSegments := []
+    glossedTokens := [("tu", "you.NOM"), ("hi", "this.F.SG.NOM"), ("rəbəɖi", "rabadi.F.SG.NOM"), ("kʰa", "eat.IMP.SG"), ("bərə", "BARA")]
+    translation := "Try (lit. eat) this rabadi (milk-based dessert)!"
+    context := "Anu has made a dessert and is offering it to Bilal to taste. She says:"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "offer"), ("infelicity", "deference")]
+    comment := "With the particle the utterance is understood as a mock command or a veiled threat rather than an offer, fn. 4."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_11b : LinguisticExample :=
+  { id := "deo2025_11b"
+    source := ⟨"deo-2025-bara", "(11b)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ho ʣa aɳi məʤa kər-a bərə"
+    discourseSegments := []
+    glossedTokens := [("ho", "sure"), ("ʣa", "go.IMP.PL"), ("aɳi", "and"), ("məʤa", "fun"), ("kər-a", "do.IMP-PL"), ("bərə", "BARA")]
+    translation := "Sure, go and have fun!"
+    context := "Deepa and her friends are planning to go to the park and Deepa comes and asks her mother: Mom, can I go play in the park with my friends?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "permission"), ("infelicity", "source")]
+    comment := "A permission with a well-wish: Deepa has asked, so she is a source for the content."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_11c : LinguisticExample :=
+  { id := "deo2025_11c"
+    source := ⟨"deo-2025-bara", "(11c)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ʈʰik ahe ʣa kʰeɭay-la bərə"
+    discourseSegments := []
+    glossedTokens := [("ʈʰik ahe", "alright"), ("ʣa", "go.IMP"), ("kʰeɭay-la", "play-INF"), ("bərə", "BARA")]
+    translation := "Alright! Go and play (if you aren't going to listen!)"
+    context := "Anu has asked Deepa to finish her homework before going out to play. Deepa is badgering Anu because she wants to go play without finishing her homework. Anu gets exasperated and says:"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "concession"), ("infelicity", "source")]
+    comment := "A concession: Deepa has revealed her preference for the content and is a source for it."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_11d : LinguisticExample :=
+  { id := "deo2025_11d"
+    source := ⟨"deo-2025-bara", "(11d)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ʣa kʰəɖɖya=t bərə"
+    discourseSegments := []
+    glossedTokens := [("ʣa", "go.IMP"), ("kʰəɖɖya=t", "ditch.OBL=LOC"), ("bərə", "BARA")]
+    translation := "Go to hell (lit. into a ditch)!"
+    context := ""
+    judgment := .unacceptable
+    alternatives := [("ʣa məsəɳa=t bərə", .unacceptable)]
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "curse"), ("infelicity", "benefit")]
+    comment := "A curse, detrimental to the addressee; the variant with məsəɳa=t 'burial.ground.OBL=LOC' is the same curse."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_12 : LinguisticExample :=
+  { id := "deo2025_12"
+    source := ⟨"deo-2025-bara", "(12)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "tu ata ləgeʦ ʣopay-la ʣa bərə"
+    discourseSegments := []
+    glossedTokens := [("tu", "you.NOM"), ("ata", "now"), ("ləgeʦ", "immediately"), ("ʣopay-la", "sleep-INF"), ("ʣa", "go.IMP"), ("bərə", "BARA")]
+    translation := "Get into bed immediately now! (just do as I say)"
+    context := "Deepa has stayed up way past her bedtime playing a video game. Anu gets annoyed because Deepa has school tomorrow and needs to be up early. She has already told Deepa several times to go to bed. Anu: You are stretching my patience now..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "command")]
+    comment := "Anu's authority is made salient; Deepa does not share the goal that she be rested, and her action choices are not aligned with it, fn. 12."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_13 : LinguisticExample :=
+  { id := "deo2025_13"
+    source := ⟨"deo-2025-bara", "(13)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "kəɖʰəi=mədʰye ətta=ʦ tel ʈaku nəko bərə"
+    discourseSegments := []
+    glossedTokens := [("kəɖʰəi=mədʰye", "pan.OBL=in"), ("ətta=ʦ", "now=EMPH"), ("tel", "oil.N.SG.NOM"), ("ʈaku", "pour.INF"), ("nəko", "NEG.IMP"), ("bərə", "BARA")]
+    translation := "Don't pour the oil into the pan just yet! (or it will go up in flames)"
+    context := "Deepa is making dal for the first time with Anu's help and has let the pan get too hot on the stove. She is about to put in some oil to start sautéing the onions. Anu:"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "warning")]
+    comment := "Deepa is expected to comply in order to ensure her own safety, a goal she most likely shares, fn. 12."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_14 : LinguisticExample :=
+  { id := "deo2025_14"
+    source := ⟨"deo-2025-bara", "(14)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ata aʤi=la ek pətrə lihi bərə"
+    discourseSegments := []
+    glossedTokens := [("ata", "now"), ("aʤi=la", "grandma.OBL=DAT"), ("ek", "one.NOM"), ("pətrə", "note.N.SG.NOM"), ("lihi", "write.IMP"), ("bərə", "BARA")]
+    translation := "(Come) now, write a letter to grandma!"
+    context := "Deepa got a lovely doll in the mail from Anu's mother and has been playing with it. Anu wants Deepa to thank her grandma before she forgets. Anu: Alright, you have played enough now..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "recommendation")]
+    comment := "A strong recommendation towards a goal, learning to express gratitude, that the addressee does not share, fn. 12."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_15ctx1 : LinguisticExample :=
+  { id := "deo2025_15ctx1"
+    source := ⟨"deo-2025-bara", "(15), context 1"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "məg aʣ tu gaɖi gʰe-un ʣa bərə"
+    discourseSegments := []
+    glossedTokens := [("məg", "then"), ("aʣ", "today"), ("tu", "you.NOM"), ("gaɖi", "car.F.SG.NOM"), ("gʰe-un", "take-GER"), ("ʣa", "go.IMP"), ("bərə", "BARA")]
+    translation := "Then, (go ahead and) take the car today."
+    context := "Bilal needs to be at a work meeting soon and he has missed the bus that he takes to work. Anu is the one who usually takes the car to work but Bilal would love to be able to drive to work today. Bilal tells Anu he missed the bus. Anu: Ok, so we need to figure out a solution..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "recommendation")]
+    comment := "Bilal's preference for taking the car is latent, so Anu's proposal sounds like a solicitous command that he will comply with; it cannot be conditionalized with 'if you like', fn. 7."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_15ctx2 : LinguisticExample :=
+  { id := "deo2025_15ctx2"
+    source := ⟨"deo-2025-bara", "(15), context 2"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "məg aʣ tu gaɖi gʰe-un ʣa bərə"
+    discourseSegments := []
+    glossedTokens := [("məg", "then"), ("aʣ", "today"), ("tu", "you.NOM"), ("gaɖi", "car.F.SG.NOM"), ("gʰe-un", "take-GER"), ("ʣa", "go.IMP"), ("bərə", "BARA")]
+    translation := "Then, (go ahead and) take the car today."
+    context := "Bilal needs to be at a work meeting soon and he has missed the bus that he takes to work. Anu is the one who usually takes the car to work but Bilal would love to be able to drive to work today. Bilal tells Anu he missed the bus and adds: I would really like to drive to work today so I don't miss my meeting. Anu:"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "recommendation"), ("infelicity", "source")]
+    comment := "Bilal has revealed his preference, so he is a source for the content."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_16 : LinguisticExample :=
+  { id := "deo2025_16"
+    source := ⟨"deo-2025-bara", "(16)"⟩
+    reportedIn := none
+    language := "mara1378"
+    primaryText := "ʧʰan tu ti=la gʰe-un ye bərə"
+    discourseSegments := []
+    glossedTokens := [("ʧʰan", "great"), ("tu", "you.NOM"), ("ti=la", "her.OBL=ACC"), ("gʰe-un", "bring-GER"), ("ye", "come.IMP"), ("bərə", "BARA")]
+    translation := "Great, you pick her up and get her (home)!"
+    context := "Anu and Bilal take turns picking up their daughter Deepa from after-school. It is Bilal's turn today. Bilal tells Anu that he is really busy that day and doesn't know whether he will make it to the school in time. Anu: No worries, I am working from home today. I will pick her up! Bilal:"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("clauseType", "imperative"), ("act", "agreement"), ("infelicity", "source")]
+    comment := "An imperative agreeing with an actional commitment the addressee has undertaken: Anu is a source for the content."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_19a : LinguisticExample :=
+  { id := "deo2025_19a"
+    source := ⟨"deo-2025-bara", "(19a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Anu: Keep the discussion we had at this meeting confidential. Nina: Ok/Yes."
+    discourseSegments := ["Keep the discussion we had at this meeting confidential.", "Ok/Yes."]
+    glossedTokens := []
+    translation := ""
+    context := "Anu and her secretary Nina, after a sensitive meeting with a small subset of Anu's team."
+    judgment := .acceptable
+    alternatives := [("Ok", .acceptable), ("Yes", .acceptable)]
+    readings := []
+    paperFeatures := [("construction", "responseParticle")]
+    comment := "Ok takes on Anu's preferential commitment as a dependent, yes commits to the preference independently; only ok admits the continuation 'I had been planning to circulate the minutes', fn. 10."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_19b : LinguisticExample :=
+  { id := "deo2025_19b"
+    source := ⟨"deo-2025-bara", "(19b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Nina: I will circulate the minutes among all the staff by tomorrow. Anu: No, keep the discussion we had at this meeting confidential. Nina: Ok/#Yes."
+    discourseSegments := ["I will circulate the minutes among all the staff by tomorrow.", "No, keep the discussion we had at this meeting confidential.", "Ok/#Yes."]
+    glossedTokens := []
+    translation := ""
+    context := "Anu and her secretary Nina, after a sensitive meeting with a small subset of Anu's team."
+    judgment := .acceptable
+    alternatives := [("Ok", .acceptable), ("Yes", .unacceptable)]
+    readings := []
+    paperFeatures := [("construction", "responseParticle")]
+    comment := "Nina has expressed an intention incompatible with the preference, so she can no longer commit to it independently with yes."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1, ex_2, ex_3, ex_4, ex_5a, ex_5b, ex_6, ex_7ctx1, ex_7ctx2, ex_8, ex_9, ex_10a, ex_10b, ex_11a, ex_11b, ex_11c, ex_11d, ex_12, ex_13, ex_14, ex_15ctx1, ex_15ctx2, ex_16, ex_19a, ex_19b]
+
+end Deo2025.Examples

--- a/Linglib/Discourse/Commitment/Basic.lean
+++ b/Linglib/Discourse/Commitment/Basic.lean
@@ -109,6 +109,8 @@ def refuse (a : A) (p : Set W) (force : Force := .doxastic) (source : Source := 
 @[simp] theorem commit_content (a : A) (p : Set W) (f s) : (commit a p f s).content = p := rfl
 @[simp] theorem refuse_content (a : A) (p : Set W) (f s) : (refuse a p f s).content = p := rfl
 @[simp] theorem commit_committer (a : A) (p : Set W) (f s) : (commit a p f s).committer = a := rfl
+@[simp] theorem commit_force (a : A) (p : Set W) (f s) : (commit a p f s).force = f := rfl
+@[simp] theorem commit_source (a : A) (p : Set W) (f s) : (commit a p f s).source = s := rfl
 
 /-- The contents of the undertaken commitments in `K`. -/
 def contents : Set (Set W) :=

--- a/Linglib/Discourse/Commitment/Preferential.lean
+++ b/Linglib/Discourse/Commitment/Preferential.lean
@@ -1,0 +1,41 @@
+import Linglib.Discourse.Commitment.Basic
+import Linglib.Semantics.Attitudes.Desire.Preferential
+
+/-!
+# Preferential commitments and effective preferences
+
+A commitment of force `.preferential` is [condoravdi-lauer-2012]'s `PEP(a, p)`, `a`'s public
+commitment to act as though `p` were a maximal element of `a`'s effective preference structure,
+the consistent ranking of propositions that guides `a`'s actions. A commitment state is sincere
+at a world when each of its preferential commitments is an effective preference there,
+`Desire.Preferential.Want`: the sincerity condition on a directive use of an imperative. Through
+the consistency of the effective preference structure, sincerity is what makes successive
+imperatives consistent (`Studies/CondoravdiLauer2012.lean`) and what excludes a
+force-augmenting particle from contexts in which the preference it expresses is unrealizable
+(`Studies/Deo2025.lean`).
+
+## References
+
+* [condoravdi-lauer-2012]
+* [deo-2025-bara]
+-/
+
+namespace Commitment
+
+open Desire.Preferential
+
+variable {A W : Type*} (P : A → W → PreferenceStructure W)
+
+/-- The preferential commitments in `K` are effective preferences at `w`. -/
+def Sincere (K : State A W) (w : W) : Prop :=
+  ∀ c ∈ K, c.force = .preferential → c.polarity = .commit → Want P c.committer c.content w
+
+variable {P} {K L : State A W} {w : W}
+
+theorem Sincere.mono (hL : Sincere P L w) (h : K ⊆ L) : Sincere P K w := λ c hc => hL c (h hc)
+
+theorem Sincere.want (hs : Sincere P K w) {a : A} {p : Set W} (h : commit a p .preferential ∈ K) :
+    Want P a p w :=
+  hs _ h rfl rfl
+
+end Commitment

--- a/Linglib/Fragments/Marathi/Particles.lean
+++ b/Linglib/Fragments/Marathi/Particles.lean
@@ -1,23 +1,24 @@
 import Linglib.Syntax.Category.Particle.Basic
 
 /-!
-# Marathi Utterance-Final Particles
-[deo-2025-bara] [deo-2023]
+# Marathi utterance-final particles
 
-Utterance-final Marathi discourse particles as `Particle` values. The
-commitment semantics (dependent vs independent uptake) is analytical
-and lives in `Studies/Deo2025.lean`.
+The utterance-final discourse particles of Marathi as `Particle` values with their clause-type
+distribution. *Bərə* occurs with declaratives, imperatives and wh-interrogatives and never with
+polar interrogatives ([deo-2025-bara] §1); its commitment semantics is the subject of
+`Studies/Deo2025.lean`. *Na* signals a preference for independent shared commitment
+([deo-2023]); only its imperative use is recorded here, from [deo-2025-bara] fn. 5 and fn. 6.
+
+## References
+
+* [deo-2025-bara]
+* [deo-2023]
 -/
 
 namespace Marathi.Particles
 
-/-- *bərə* — utterance-final particle combining with declaratives,
-imperatives, and wh-interrogatives, never polar interrogatives
-([deo-2025-bara] §1). Conventionally signals that the speaker requests
-*dependent* doxastic or preferential commitment uptake tied to an
-addressee-benefiting goal ([deo-2025-bara] (20)–(21)); the apparatus
-and the preferential-vs-doxastic classification live in
-`Studies/Deo2025.lean`. -/
+/-- *bərə*: utterance-final, with declaratives, imperatives and wh-interrogatives, never with
+polar interrogatives ([deo-2025-bara] §1). -/
 def bara : Particle where
   form := "bərə"
   position := some .clauseFinal
@@ -28,11 +29,8 @@ def bara : Particle where
     | .imperative, .matrix => some .optional
     | _, _ => none
 
-/-- *na* — utterance-final particle analyzed in [deo-2023] as
-signalling preference for *independent* shared commitment (the doxastic
-mirror of *bərə*). Only the imperative-augmenting use is attested in
-[deo-2025-bara] (fn. 6, p. 392); other cells are unrecorded pending a
-[deo-2023] formalization. -/
+/-- *na*: utterance-final, augmenting an imperative while leaving the addressee the choice
+([deo-2025-bara] fn. 5); its other uses are not recorded. -/
 def na : Particle where
   form := "na"
   position := some .clauseFinal

--- a/Linglib/Semantics/Attitudes/Preference.lean
+++ b/Linglib/Semantics/Attitudes/Preference.lean
@@ -193,15 +193,18 @@ def discrete (S : Set (Set W)) : PreferenceStructure W where
 @[simp] theorem maxElts_discrete (S : Set (Set W)) : (discrete S).maxElts = S :=
   Set.ext λ _ => ⟨And.left, λ h => ⟨h, λ _ _ h => h⟩⟩
 
+/-- Unranked preferences are consistent when jointly belief-compatible. -/
+theorem consistent_discrete {S : Set (Set W)} {B : Set W} (h : (B ∩ ⋂₀ S).Nonempty) :
+    (discrete S).Consistent B := λ _ hX hXB =>
+  absurd hXB (h.mono (Set.inter_subset_inter_right _ (Set.sInter_subset_sInter hX))).ne_empty
+
 /-- The structure with the single preference `p`. -/
 abbrev single (p : Set W) : PreferenceStructure W := discrete {p}
 
 @[simp] theorem maxElts_single (p : Set W) : (single p).maxElts = {p} := maxElts_discrete _
 
 theorem consistent_single {p B : Set W} (h : (p ∩ B).Nonempty) : (single p).Consistent B :=
-  consistent_of_realistic_of_isChain
-    (λ _ hq => by rw [Set.mem_singleton_iff.1 hq]; exact h.ne_empty)
-    (Set.pairwise_singleton _ _) (h.mono Set.inter_subset_right)
+  consistent_discrete (by rwa [Set.sInter_singleton, Set.inter_comm])
 
 end PreferenceStructure
 

--- a/Linglib/Studies/CondoravdiLauer2012.lean
+++ b/Linglib/Studies/CondoravdiLauer2012.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Attitudes.Desire.Preferential
 import Linglib.Semantics.Modality.Kratzer.Operators
-import Linglib.Discourse.Commitment.Basic
+import Linglib.Discourse.Commitment.Preferential
 import Linglib.Data.Examples.CondoravdiLauer2012
 
 /-!
@@ -66,13 +66,8 @@ variable {A W : Type*} {P : A → W → PreferenceStructure W} {a : A} {p q : Se
 effective preference structure `P a w`, the distinguished consistent structure that determines
 `a`'s action choices, (28) and (29). The public commitments of §3.2 are `Commitment`s:
 `commit a p` is `PB(a, p)`, to act as though believing `p`, and `commit a p .preferential` is
-`PEP(a, p)`, to act as though `p` were a maximal effective preference. -/
-
-variable (P) in
-/-- The preferential commitments in `K` are effective preferences at `w`: a speaker commits to
-an effective preference only when holding it, condition (iii) of §3.4. -/
-def Sincere (K : State A W) (w : W) : Prop :=
-  ∀ c ∈ K, c.force = .preferential → c.polarity = .commit → Want P c.committer c.content w
+`PEP(a, p)`, to act as though `p` were a maximal effective preference; a speaker commits to an
+effective preference only when holding it, condition (iii) of §3.4, `Commitment.Sincere`. -/
 
 /-! ### The conventions -/
 
@@ -126,7 +121,7 @@ practical reasoning it leaves informal; without it, the only-if reading is what 
 theorem directive_want_addressee {K : State A W} {ad : A} (hs : Sincere P K w)
     (hp : commit a p .preferential ∈ K) (hii : p ⊆ {v | Want P ad p v}) :
     WantNecessary P a {v | Want P ad p v} w :=
-  (hs _ hp rfl rfl).wantNecessary.mono hii
+  (hs.want hp).wantNecessary.mono hii
 
 /-! ### Consistency -/
 
@@ -145,7 +140,7 @@ the second revises the speaker's effective preferences, (12) to (14). -/
 theorem imperatives_revise {K : State A W} {B : Set W} (hC : (P a w).Consistent B)
     (hp : commit a p .preferential ∈ K) (hq : commit a q .preferential ∈ K)
     (h : B ∩ (p ∩ q) = ∅) : ¬ Sincere P K w :=
-  λ hs => (hC.inter_inter_nonempty_of_mem_maxElts (hs _ hp rfl rfl) (hs _ hq rfl rfl)).ne_empty h
+  λ hs => (hC.inter_inter_nonempty_of_mem_maxElts (hs.want hp) (hs.want hq)).ne_empty h
 
 /-! ### Endorsement: advice, permission, concession -/
 

--- a/Linglib/Studies/Deo2025.lean
+++ b/Linglib/Studies/Deo2025.lean
@@ -1,218 +1,383 @@
-import Linglib.Discourse.Commitment.Basic
+import Linglib.Discourse.Commitment.Preferential
 import Linglib.Discourse.Roles
-import Linglib.Discourse.SpeechAct
-import Linglib.Discourse.Commitment.Declarative
 import Linglib.Fragments.Marathi.Particles
+import Linglib.Data.Examples.Deo2025
 
 /-!
-# Deo (2025): The Marathi Discourse Particle *bərə*
-[deo-2025-bara]
+# Deo (2025): Take on this commitment: the particle *bərə* in Marathi
 
-Take on This Commitment: The Particle *bərə* in Marathi (Indo-Aryan).
-*Proceedings of Sinn und Bedeutung 29*, ed. F. Longo and D. Panizza.
-Pp. 386–403.
+This file formalizes [deo-2025-bara]'s analysis of the Marathi utterance-final particle *bərə*
+in declaratives and imperatives. The particle turns a declarative into a warning, a piece of
+advice or a reminder and an imperative into a command, a warning or a strong recommendation,
+(1) to (8) and (12) to (15), and is out in a commissive and in the response to one, (9) and
+(16), and in the imperatives of requests, pleas, offers, permissions, concessions and curses,
+(10) and (11). The analysis is set in a commitment-based theory of sentential force
+([gunlogson-2001], [farkas-bruce-2010], [condoravdi-lauer-2012]): the discourse commitments of
+a participant are doxastic or preferential, (17a), the common ground and the joint preferences
+are their intersections across participants, (17b) and (17c), and a declarative or an
+imperative commits the speaker to its content under the one attitude or the other, (18).
+[gunlogson-2008]'s distinction between the participant who is the source of a commitment and
+one who is a dependent, taking it on from the other party's testimony or expressed preference,
+is extended to preferential commitments, §3.2. *Bərə* adds a commitment of its own, (20): the
+speaker's preferential commitment to the addressee's dependent uptake of the content. Its
+felicity condition, (21), is that the speaker takes the uptake to be a precondition for an
+addressee-benefiting goal among the speaker's effective preferences and, §3.3, that nothing
+shows the addressee's action choices already aligned with the goal. The profile follows, §3.4:
+when the addressee is manifestly a source for the content, the uptake is unrealizable and the
+*bərə* commitment cannot be sincere, which excludes permissions, concessions, commissives and
+their responses, and the revealed preference of (15); an offer or invitation leaves the choice
+to the addressee, against the preference for dependent uptake; a request, a plea or a curse
+serves no addressee-benefiting goal; and the warning of (5a) meets the felicity condition where
+(5b), whose content is one way among many to the goal, does not.
 
-## Empirical claim (§ 2)
+## Implementation notes
 
-Marathi utterance-final *bərə* combines with declaratives, imperatives,
-and wh-interrogatives (never polar interrogatives). It is felicitous in:
-warnings (1, 4, 5a, 8, 13), advice (6), reminders (7), commands (12),
-strong recommendations (14). Infelicitous with: requests (10a), pleas
-(10b), offers (11a), permissions/well-wishes (11b), concessions (11c),
-curses (11d), declarative commissives (9), agreement-with-addressee (16).
+The commitment state is indexed by worlds, as in `CondoravdiLauer2012.imp`, so that the uptake
+of a content is a proposition, the worlds at which the addressee is a dependent for it. Being a
+source for a content, the paper's `DC_x^ind`, is having a commitment of one's own to it under
+either attitude, and being a dependent is having a commitment to it on the other party's word
+and none of one's own; `Commitment.Source` supplies the coordinate. The paper's effective
+preferences `EP(s, w)` are `Desire.Preferential.Want` and the sincerity of the *bərə*
+commitment is `Commitment.Sincere`, so that its infelicity under a manifest addressee
+commitment is the unrealizability of the uptake, `PreferenceStructure.Consistent.realistic`,
+relative to the speaker's information state `B` as in `Studies/CondoravdiLauer2012.lean`. Whom
+a goal benefits is a primitive of the context, as in the paper, and the salient goal is a
+parameter of the felicity condition. An offer or invitation is rendered as the speaker's
+effective preference that any commitment of the addressee to the content be the addressee's
+own, the paper's one-line derivation. The speaker's authority over the addressee, §2.2, does no
+work in the paper's derivations and is not modeled; the wh-interrogative use, (3), and the
+compound *bərə ka*, §4, are outside the paper's analysis.
 
-## Architectural claim (§ 3)
+## TODO
 
-[deo-2025-bara] proposes a discourse model with two innovations
-beyond [farkas-bruce-2010] / [gunlogson-2001]:
+* The threat commissives of fn. 14 allow *bərə*; the paper leaves them unexplained.
 
-* Each interlocutor's discourse commitments split into doxastic vs
-  preferential (eq. 17a–c) — formalized at
-  `Commitment.Force`.
-* The [gunlogson-2001] source/dependent distinction lifts to
-  *both* commitment forces — the 2×2 cross
-  `Commitment.Source × Commitment.Force`, the four cells being the commitments of each
-  source and force.
+## References
 
-Deo's *bərə* convention (eq. 20): the speaker preferentially commits to
-the *meta-proposition* "addressee dependently commits to *p*". The
-agent-source asymmetry — speaker's commitment is self-sourced and
-preferential, embedded commitment is dependent on the addressee's side —
-makes this a higher-order operation that *uses* the 2×2, not a single
-2×2 cell.
-
-The secondary felicity condition (eq. 21): addressee uptake of *p* must
-be a precondition for fulfilling a contextually salient
-addressee-benefiting goal `g_c ∈ EP(s, w)`
-(a preferential background pointwise consistent with the belief
-state — `Semantics/Attitudes/Preference.lean`).
-
-## Out of scope
-
-(i) bərə + ka compound (§ 4, p. 401); (ii) wh-interrogative uses (per
-p. 387); (iii) threat-commissives (footnote 14, p. 400), which *are*
-felicitous — the `commissive` case below covers the cooperative
-commissive only.
+* [deo-2025-bara]
+* [condoravdi-lauer-2012]
+* [gunlogson-2001]
+* [gunlogson-2008]
+* [farkas-bruce-2010]
+* [rudin-2018]
 -/
 
 namespace Deo2025
 
-open Commitment
+open Commitment Desire.Preferential Discourse
 
-universe u
+variable {W : Type*}
 
-variable {W : Type u}
+/-! ### Sources and dependents, (17) and §3.2 -/
 
-/-! ## § 1. Bərə's denotation (eq. 20)
+/-- `x` is a source for `p` in `K`: a commitment of `x`'s own to `p` under either attitude,
+`p ∈ DC_x^ind`. -/
+def IsSource (K : State Role W) (x : Role) (p : Set W) : Prop :=
+  ∃ f, commit x p f .selfGenerated ∈ K
 
-The bərə convention is a higher-order update: the speaker (independent
-source) preferentially commits to the meta-proposition that *p* is in
-the addressee's dependent-commitment slate. The meta-proposition is a
-predicate on commitment sets. The corresponding state update is not formalized here: it
-would need commitment contents that are themselves scoreboard-relative.
--/
+/-- `x` is a dependent for `p` under the attitude `f` in `K`: a commitment to `p` on the other
+party's testimony or expressed preference, and none of `x`'s own, `p ∈ DC_x^dep`. -/
+def IsDependent (K : State Role W) (x : Role) (p : Set W) (f : Force) : Prop :=
+  commit x p f .otherGenerated ∈ K ∧ ¬ IsSource K x p
 
-/-- The bərə meta-content: "*p* is among the addressee's dependent
-    commitments." This is the proposition the speaker preferentially
-    commits to. [deo-2025-bara] (20). -/
-def baraMetaContent (p : Set W) (K : State Discourse.Role W) : Prop :=
-  commit .addressee p .doxastic .otherGenerated ∈ K
+/-- The contents every participant is committed to under `f`: the common ground for `.doxastic`
+and the joint preferences for `.preferential`, (17b) and (17c), [rudin-2018]'s teleological
+common ground. -/
+def joint (K : State Role W) (f : Force) : Set (Set W) :=
+  ⋂ x, contents (ofForce (ofCommitter K x) f)
 
-/-! ## § 3. Empirical felicity profile (Deo § 2) -/
+/-! ### The conventions, (18) and (20) -/
 
-/-- The illocutionary acts surveyed by [deo-2025-bara].
+variable (P : Role → W → PreferenceStructure W) (K : W → State Role W) (B : Set W)
+  (benefits : Set W → Role → Prop) (g p : Set W) (f : Force) (w : W)
 
-    Refines `SearleClass` for the
-    directive subset (warning/advice/reminder/command/strongRec/
-    request/plea/offer/permission/concession/curse all `.directive`),
-    plus `commissive` (`.commissive`) and `agreement` (`.assertive`).
-    The `toSearleClass` projection makes this refinement structural. -/
-inductive IllocutionaryAct
-  | warning | advice | reminder | command | strongRecommendation
-  | request | plea | offer | permission | concession | curse
-  | commissive | agreement
-  deriving DecidableEq, Repr
+/-- The uptake of `p` under `f`: the worlds at which `p` is among the addressee's dependent
+commitments, what the speaker prefers in (20). -/
+def uptake : Set W := {v | IsDependent (K v) .addressee p f}
 
-/-- The Searle class of each illocutionary act in Deo's enum. -/
-def IllocutionaryAct.toSearleClass : IllocutionaryAct → SearleClass
-  | .warning | .advice | .reminder | .command | .strongRecommendation
-  | .request | .plea | .offer | .permission | .concession | .curse => .directive
-  | .commissive => .commissive
-  | .agreement  => .assertive
+/-- Uttering `p` in a clause of force `f` at `w`, (18): a declarative commits the speaker to `p`
+doxastically and an imperative preferentially. -/
+def utter : State Role W := insert (commit .speaker p f) (K w)
 
-/-- Deo's reported empirical felicity of bərə across illocutionary acts.
-    Acts where bərə is felicitous (per [deo-2025-bara] § 2):
-    `warning` (exx. 1, 4, 5a, 8, 13), `advice` (ex. 6), `reminder`
-    (ex. 7), `command` (ex. 12), `strongRecommendation` (ex. 14). All
-    other acts in the enum are infelicitous: `request` (ex. 10a),
-    `plea` (ex. 10b), `offer` (ex. 11a), `permission` (ex. 11b),
-    `concession` (ex. 11c), `curse` (ex. 11d), `commissive` (ex. 9),
-    `agreement` (ex. 16).
+/-- Uttering `p` in a clause of force `f` with *bərə* at `w`: the clause-type commitment and,
+over and above it, the speaker's preferential commitment to the uptake of `p`, (20). -/
+def bara : State Role W := insert (commit .speaker (uptake K p f) .preferential) (utter K p f w)
 
-    The fine-grained warning/advice/reminder/command/strongRecommendation
-    partition is study-introduced for predicate clarity; Deo's text
-    (p. 392) clusters them as "strong directives" without sharp
-    boundaries. The `agreement` act is short for "expressing agreement
-    with or approval of an actional commitment undertaken by the
-    addressee" (p. 393, p. 400).
+/-- *Bərə* augments the force rather than modifying it, §4: whatever the plain utterance
+entails, the *bərə*-utterance entails. -/
+theorem slate_bara_le : slate (bara K p f w) ≤ slate (utter K p f w) :=
+  slate_mono (Set.subset_insert _ _)
 
-    Caveat: the `commissive` case reflects the *cooperative* commissive
-    (ex. 9). Deo's footnote 14 (p. 400) flags that *threat-commissives*
-    (e.g., "If you don't go to bed, I will take your video game bərə!")
-    *are* felicitous; this enum coarsens over that distinction. -/
-def empiricalFelicityClass : Set IllocutionaryAct :=
-  {.warning, .advice, .reminder, .command, .strongRecommendation}
+/-- *Bərə*'s own effect: the preferential context set narrows by the uptake and the doxastic one
+stays. -/
+theorem bara_contextSets :
+    contextSet (ofForce (bara K p f w) .preferential) =
+        uptake K p f ∩ contextSet (ofForce (utter K p f w) .preferential) ∧
+      contextSet (ofForce (bara K p f w) .doxastic) =
+        contextSet (ofForce (utter K p f w) .doxastic) :=
+  ⟨contextSet_ofForce_insert_of_eq_of_commit rfl rfl, contextSet_ofForce_insert_of_ne nofun⟩
 
-instance : DecidablePred (· ∈ empiricalFelicityClass) := fun act =>
-  inferInstanceAs (Decidable (act = .warning ∨ act = .advice ∨ act = .reminder ∨
-    act = .command ∨ act = .strongRecommendation))
+/-- A *bərə*-declarative, (22): the speaker believes the content and prefers its uptake. -/
+theorem declarative_contextSets :
+    contextSet (ofForce (bara K p .doxastic w) .doxastic) =
+        p ∩ contextSet (ofForce (K w) .doxastic) ∧
+      contextSet (ofForce (bara K p .doxastic w) .preferential) =
+        uptake K p .doxastic ∩ contextSet (ofForce (K w) .preferential) :=
+  ⟨(bara_contextSets K p .doxastic w).2.trans (contextSet_ofForce_insert_of_eq_of_commit rfl rfl),
+    (bara_contextSets K p .doxastic w).1.trans
+      (congrArg _ (contextSet_ofForce_insert_of_ne nofun))⟩
 
-/-! ## § 4. Architectural preconditions
+/-- A *bərə*-imperative, (23): the speaker prefers the content and its uptake and believes
+nothing new. -/
+theorem imperative_contextSets :
+    contextSet (ofForce (bara K p .preferential w) .preferential) =
+        uptake K p .preferential ∩ (p ∩ contextSet (ofForce (K w) .preferential)) ∧
+      contextSet (ofForce (bara K p .preferential w) .doxastic) =
+        contextSet (ofForce (K w) .doxastic) :=
+  ⟨(bara_contextSets K p .preferential w).1.trans
+      (congrArg _ (contextSet_ofForce_insert_of_eq_of_commit rfl rfl)),
+    (bara_contextSets K p .preferential w).2.trans (contextSet_ofForce_insert_of_ne nofun)⟩
 
-Deo (p. 392) identifies *two* preconditions on imperative–bərə felicity:
+/-- Once the addressee takes up the content of a *bərə*-utterance, dependently or not, it joins
+the joint commitments under its attitude, §4: the implicit preference that *bərə* makes
+explicit. -/
+theorem mem_joint_insert (s : Commitment.Source) :
+    p ∈ joint (insert (commit .addressee p f s) (bara K p f w)) f :=
+  Set.mem_iInter.2 λ x => match x with
+    | .speaker => ⟨commit .speaker p f, ⟨⟨⟨Or.inr (Or.inr (Or.inl rfl)), rfl⟩, rfl⟩, rfl⟩, rfl⟩
+    | .addressee => ⟨commit .addressee p f s, ⟨⟨⟨Or.inl rfl, rfl⟩, rfl⟩, rfl⟩, rfl⟩
 
-* **(a)** The addressee has no pre-existing preference to realize the
-  imperative content. Permissions and concessions fail this.
-* **(b)** It is appropriate for the speaker to presume authority over the
-  addressee in realizing the content (or to expect unquestioning
-  compliance). Requests, pleas, offers, invitations, and curses fail
-  this.
+/-! ### Felicity, (21) and §3.3 -/
 
-A *separate* semantic-component felicity condition (eq. 21) requires
-the speaker to have a contextually salient addressee-benefiting goal
-`g_c ∈ EP(s, w)` whose fulfilment is preconditioned on addressee uptake
-of the prejacent. This applies across both clause types and rules out
-acts where the goal benefits the speaker (requests, pleas) or
-detriments the addressee (curses).
+/-- The felicity condition on *bərə*, (21) with the contextual condition of §3.3, at `w` in a
+context with the speaker's information state `B`, the salient goal `g` and the primitive
+`benefits`: the speaker's preferential commitments are sincere; `g` is an effective preference
+of the speaker's that benefits the addressee and, by the speaker's information, is fulfilled
+only if the addressee takes up `p`; and the speaker's information does not already have the
+addressee taking up `p`. A content the addressee is taken to have taken up already, (7) in its
+first context, fails the last clause. -/
+def Felicitous : Prop :=
+  Sincere P (bara K p f w) w ∧ Want P .speaker g w ∧ benefits g .addressee ∧
+    B ∩ g ⊆ uptake K p f ∧ ¬ B ⊆ uptake K p f
 
-For declaratives (commissives ex. 9, agreement ex. 16), Deo applies the
-analog of (a) — the addressee has a *manifest* preference from a prior
-discourse move (p. 393, p. 400). The speaker-authority condition (b) is
-not directly applicable to declaratives but is treated as trivially
-satisfied for predicate-conjunction purposes. -/
+/-- An offer or invitation leaves the choice to the addressee: the speaker effectively prefers
+that any commitment of the addressee to `p` be the addressee's own, the complement of the
+uptake. -/
+def Defers : Prop := Want P .speaker (uptake K p f)ᶜ w
 
-/-- **(a)** Does the addressee have a pre-existing preference to realize
-    the content? -/
-def AddresseeHasPreExistingPref (act : IllocutionaryAct) : Prop :=
-  act = .permission ∨ act = .concession ∨ act = .commissive ∨ act = .agreement
+variable {P K B benefits g p f w}
 
-instance : DecidablePred AddresseeHasPreExistingPref := fun _ =>
-  inferInstanceAs (Decidable (_ ∨ _ ∨ _ ∨ _))
+/-- A sincere *bərə*-utterance is an effective preference for the uptake. -/
+theorem want_uptake_of_sincere (h : Sincere P (bara K p f w) w) :
+    Want P .speaker (uptake K p f) w :=
+  h.want (Set.mem_insert _ _)
 
-/-- **(b)** Does the speaker presume authority for realizing the content? -/
-def SpeakerHasAuthority (act : IllocutionaryAct) : Prop :=
-  ¬ (act = .request ∨ act = .plea ∨ act = .offer ∨ act = .curse)
+/-- The *bərə*-utterance is sincere when the speaker effectively prefers the uptake, prefers the
+content if the clause is an imperative, and was sincere before. -/
+theorem sincere_bara_iff :
+    Sincere P (bara K p f w) w ↔ Want P .speaker (uptake K p f) w ∧
+      (f = .preferential → Want P .speaker p w) ∧ Sincere P (K w) w := by
+  refine ⟨λ h => ⟨want_uptake_of_sincere h, λ hf => h _ (Or.inr (Or.inl rfl)) hf rfl,
+    h.mono ((Set.subset_insert _ _).trans (Set.subset_insert _ _))⟩, λ ⟨hu, hp, hK⟩ => ?_⟩
+  rintro c (rfl | rfl | hc) hf hpol
+  · exact hu
+  · exact hp hf
+  · exact hK c hc hf hpol
 
-instance : DecidablePred SpeakerHasAuthority := fun _ =>
-  inferInstanceAs (Decidable (¬ _))
+/-- When the speaker's information has the addressee a source for `p`, the uptake of `p` is
+unrealizable: a source is no dependent. -/
+theorem inter_uptake_eq_empty (h : ∀ v ∈ B, IsSource (K v) .addressee p) :
+    B ∩ uptake K p f = ∅ :=
+  Set.eq_empty_of_forall_notMem λ v hv => hv.2.2 (h v hv.1)
 
-/-- **(eq. 21)** Does the contextually salient goal benefit the addressee? -/
-def GoalBenefitsAddressee (act : IllocutionaryAct) : Prop :=
-  ¬ (act = .request ∨ act = .plea ∨ act = .curse)
+/-- A manifest commitment of the addressee, §3.4: with the addressee already a source for `p` by
+the speaker's information, a sincere *bərə* commitment would be an effective preference for the
+unrealizable, against the consistency of the speaker's effective preferences, so *bərə* is out:
+a permission or concession, (11b) and (11c), the revealed preference of (15), a commissive, (9),
+and the response to one, (16). -/
+theorem not_felicitous_of_isSource (benefits : Set W → Role → Prop) (g : Set W) (f : Force)
+    (hC : (P .speaker w).Consistent B) (h : ∀ v ∈ B, IsSource (K v) .addressee p) :
+    ¬ Felicitous P K B benefits g p f w :=
+  λ hf => hC.realistic _ (want_uptake_of_sincere hf.1).1
+    (by rw [Set.inter_comm]; exact inter_uptake_eq_empty h)
 
-instance : DecidablePred GoalBenefitsAddressee := fun _ =>
-  inferInstanceAs (Decidable (¬ _))
+/-- Deference, §3.4: the preference for dependent uptake and the preference that leaves the
+choice to the addressee are not jointly realizable, so *bərə* is out in an offer or invitation,
+(11a). -/
+theorem not_felicitous_of_defers (benefits : Set W → Role → Prop) (g : Set W)
+    (hC : (P .speaker w).Consistent B) (h : Defers P K p f w) :
+    ¬ Felicitous P K B benefits g p f w :=
+  λ hf => (hC.inter_inter_nonempty_of_mem_maxElts (want_uptake_of_sincere hf.1) h).ne_empty
+    (by rw [Set.inter_compl_self, Set.inter_empty])
 
-/-- The conjunction of Deo's two imperative preconditions ((a) negated +
-    (b)) and the secondary felicity condition (eq. 21). -/
-def BaraFelicitous (act : IllocutionaryAct) : Prop :=
-  ¬ AddresseeHasPreExistingPref act
-  ∧ SpeakerHasAuthority act
-  ∧ GoalBenefitsAddressee act
+/-- A goal that does not benefit the addressee, §3.4: a request or plea serves the speaker
+alone, (10), and a curse harms the addressee, (11d). -/
+theorem not_felicitous_of_not_benefits (P : Role → W → PreferenceStructure W)
+    (K : W → State Role W) (B p : Set W) (f : Force) (w : W) (h : ¬ benefits g .addressee) :
+    ¬ Felicitous P K B benefits g p f w :=
+  λ hf => h hf.2.2.1
 
-instance : DecidablePred BaraFelicitous := fun _ =>
-  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
+/-! ### The warning of (5): a precondition against a way among many -/
 
-/-! ## § 5. Deo's central characterization theorem -/
+/-- A world of the scenario of (5): whether it rains today, whether tomorrow is sunny, whether
+Anu drives today, and whether she has taken up, on Bilal's word, each of the two weather
+facts. -/
+structure Weather where
+  /-- It rains today. -/
+  rain : Bool
+  /-- Tomorrow is sunny. -/
+  sunny : Bool
+  /-- Anu drives today. -/
+  drives : Bool
+  /-- Anu has taken up on Bilal's word that it rains today. -/
+  upRain : Bool
+  /-- Anu has taken up on Bilal's word that tomorrow is sunny. -/
+  upSunny : Bool
+  deriving DecidableEq
 
-/-- **Deo's central claim**: the three architectural conditions
-    (`¬ AddresseeHasPreExistingPref ∧ SpeakerHasAuthority ∧
-    GoalBenefitsAddressee`) characterize the empirically attested
-    felicity class — the strong-directive subset
-    `{warning, advice, reminder, command, strongRecommendation}`.
+namespace Weather
 
-    The substantive content is in the structural decomposition: that
-    Deo's three independently motivated conditions exactly carve out
-    the cluster of acts where bərə is reported felicitous, with no
-    over- or under-prediction across the 13-act survey. -/
-theorem deo_characterization (act : IllocutionaryAct) :
-    BaraFelicitous act ↔ act ∈ empiricalFelicityClass := by
-  cases act <;> decide
+/-- The content of (5a): it rains today. -/
+def raining : Set Weather := {v | v.rain}
 
-/-! ## § 6. Bərə vs the Searle taxonomy
+/-- The content of (5b): tomorrow is sunny. -/
+def sunnyTomorrow : Set Weather := {v | v.sunny}
 
-Bərə-felicitous acts are all `.directive` in the Searle classification,
-but the converse fails: many directive acts (`request`, `plea`, `offer`,
-`permission`, `concession`, `curse`) are bərə-infelicitous. Bərə picks
-out a strict subset of the directive class.
--/
+/-- Bilal's goal: Anu stays safe, not driving today. -/
+def safe : Set Weather := {v | ¬ v.drives}
 
-theorem felicitous_implies_directive (act : IllocutionaryAct) :
-    BaraFelicitous act → act.toSearleClass = .directive := by
-  cases act <;> decide
+/-- The addressee's dependent doxastic commitments at a world: to whichever weather facts she has
+taken up. -/
+def state (v : Weather) : State Role Weather :=
+  {c | c.committer = .addressee ∧ c.polarity = .commit ∧ c.force = .doxastic ∧
+    c.source = .otherGenerated ∧
+    ((c.content = raining ∧ v.upRain) ∨ (c.content = sunnyTomorrow ∧ v.upSunny))}
 
-theorem directive_class_strictly_larger :
-    ∃ act, act.toSearleClass = .directive ∧ ¬ BaraFelicitous act :=
-  ⟨.request, by decide, by decide⟩
+/-- Bilal's information: the weather facts, and that Anu stays home only if she takes his word on
+the rain. -/
+def info : Set Weather := {v | v.rain ∧ v.sunny ∧ (¬ v.drives → v.upRain)}
+
+/-- Bilal effectively prefers that Anu take up the rain and that she be safe; Anu's preferences
+play no part. -/
+def prefs : Role → Weather → PreferenceStructure Weather
+  | .speaker, _ => .discrete {uptake state raining .doxastic, safe}
+  | .addressee, _ => .discrete ∅
+
+/-- Staying safe is what benefits anyone here. -/
+def benefit (q : Set Weather) (_ : Role) : Prop := q = safe
+
+/-- The world of utterance: it rains, tomorrow is sunny, Anu is set to drive and has taken up
+neither fact. -/
+def w₀ : Weather := ⟨true, true, true, false, false⟩
+
+theorem raining_ne_sunnyTomorrow : raining ≠ sunnyTomorrow := λ h => by
+  simpa [raining, sunnyTomorrow] using Set.ext_iff.1 h ⟨true, false, false, false, false⟩
+
+theorem not_isSource (v : Weather) (q : Set Weather) : ¬ IsSource (state v) .addressee q :=
+  λ ⟨_, h⟩ => by simp [state] at h
+
+theorem mem_state_raining {v : Weather} :
+    commit .addressee raining .doxastic .otherGenerated ∈ state v ↔ v.upRain := by
+  simp [state, raining_ne_sunnyTomorrow]
+
+theorem mem_state_sunnyTomorrow {v : Weather} :
+    commit .addressee sunnyTomorrow .doxastic .otherGenerated ∈ state v ↔ v.upSunny := by
+  simp [state, raining_ne_sunnyTomorrow.symm]
+
+theorem mem_uptake_raining {v : Weather} : v ∈ uptake state raining .doxastic ↔ v.upRain := by
+  simp [uptake, IsDependent, mem_state_raining, not_isSource]
+
+theorem mem_uptake_sunnyTomorrow {v : Weather} :
+    v ∈ uptake state sunnyTomorrow .doxastic ↔ v.upSunny := by
+  simp [uptake, IsDependent, mem_state_sunnyTomorrow, not_isSource]
+
+/-- The warning of (5a) is felicitous: by Bilal's information Anu stays safe only if she takes his
+word on the rain, and she may yet drive without doing so. -/
+theorem felicitous_raining : Felicitous prefs state info benefit safe raining .doxastic w₀ := by
+  refine ⟨sincere_bara_iff.2 ⟨⟨Or.inl rfl, λ _ _ h => h⟩, nofun, λ c hc hf _ =>
+    absurd (hc.2.2.1.symm.trans hf) nofun⟩, ⟨Or.inr rfl, λ _ _ h => h⟩, rfl, ?_, ?_⟩
+  · rintro v ⟨⟨-, -, hv⟩, hs⟩
+    exact mem_uptake_raining.2 (hv hs)
+  · intro h
+    simpa [w₀] using mem_uptake_raining.1 (h (show w₀ ∈ info from ⟨rfl, rfl, λ h => (h rfl).elim⟩))
+
+/-- (5b) is not: Anu can stay safe without taking Bilal's word on tomorrow's weather. -/
+theorem not_felicitous_sunnyTomorrow :
+    ¬ Felicitous prefs state info benefit safe sunnyTomorrow .doxastic w₀ := λ h => by
+  have hv : (⟨true, true, false, true, false⟩ : Weather) ∈ info ∩ safe :=
+    ⟨⟨rfl, rfl, λ _ => rfl⟩, Bool.false_ne_true⟩
+  simpa [mem_uptake_sunnyTomorrow] using h.2.2.2.1 hv
+
+end Weather
+
+/-! ### The recommendation of (15): a latent against a revealed preference -/
+
+/-- A world of the scenario of (15): whether Bilal takes the car and whether he has taken up
+doing so on Anu's proposal. -/
+structure Car where
+  /-- Bilal takes the car. -/
+  takes : Bool
+  /-- Bilal has taken up taking the car on Anu's proposal. -/
+  up : Bool
+  deriving DecidableEq
+
+namespace Car
+
+/-- The content of (15): Bilal takes the car today. -/
+def taking : Set Car := {v | v.takes}
+
+/-- The first context: Bilal's only commitment to taking the car, when he has one, is dependent
+on Anu's proposal. -/
+def latent (v : Car) : State Role Car :=
+  {c | c.committer = .addressee ∧ c.polarity = .commit ∧ c.force = .preferential ∧
+    c.source = .otherGenerated ∧ c.content = taking ∧ v.up}
+
+/-- The second context: Bilal has revealed his preference for taking the car. -/
+def revealed (v : Car) : State Role Car :=
+  insert (commit .addressee taking .preferential) (latent v)
+
+/-- Anu's information: Bilal takes the car only on her proposal. -/
+def info : Set Car := {v | v.takes → v.up}
+
+/-- Anu effectively prefers that Bilal take the car and take it up from her; Bilal prefers to
+take the car, a preference he has not revealed. -/
+def prefs : Role → Car → PreferenceStructure Car
+  | .speaker, _ => .discrete {uptake latent taking .preferential, taking}
+  | .addressee, _ => .single taking
+
+/-- Making the meeting is what benefits anyone here. -/
+def benefit (q : Set Car) (_ : Role) : Prop := q = taking
+
+/-- The world of utterance: Bilal has neither taken the car nor taken up doing so. -/
+def w₀ : Car := ⟨false, false⟩
+
+theorem not_isSource (v : Car) (q : Set Car) : ¬ IsSource (latent v) .addressee q :=
+  λ ⟨_, h⟩ => by simp [latent] at h
+
+theorem mem_latent {v : Car} :
+    commit .addressee taking .preferential .otherGenerated ∈ latent v ↔ v.up := by
+  simp [latent]
+
+theorem mem_uptake {v : Car} : v ∈ uptake latent taking .preferential ↔ v.up := by
+  simp [uptake, IsDependent, mem_latent, not_isSource]
+
+/-- The first context of (15): Bilal's preference for the car is latent, and the recommendation
+with *bərə* is felicitous. -/
+theorem felicitous_latent :
+    Felicitous prefs latent info benefit taking taking .preferential w₀ ∧
+      Want prefs .addressee taking w₀ := by
+  refine ⟨⟨sincere_bara_iff.2 ⟨⟨Or.inl rfl, λ _ _ h => h⟩, λ _ => ⟨Or.inr rfl, λ _ _ h => h⟩,
+    λ c hc _ _ => absurd hc.2.2.2.2.2 Bool.false_ne_true⟩, ⟨Or.inr rfl, λ _ _ h => h⟩, rfl,
+    λ v hv => mem_uptake.2 (hv.1 hv.2), λ h => ?_⟩, ⟨rfl, λ _ _ h => h⟩⟩
+  simpa [w₀] using mem_uptake.1 (h (show w₀ ∈ info from λ h => h))
+
+/-- The second context of (15): Bilal has revealed his preference and is a source for the
+content, so under any consistent effective preferences of Anu's *bərə* is out. -/
+theorem not_felicitous_revealed (P : Role → Car → PreferenceStructure Car)
+    (hC : (P .speaker w₀).Consistent info) :
+    ¬ Felicitous P revealed info benefit taking taking .preferential w₀ :=
+  not_felicitous_of_isSource _ _ _ hC λ _ _ => ⟨.preferential, Or.inl rfl⟩
+
+end Car
 
 end Deo2025

--- a/references.bib
+++ b/references.bib
@@ -3323,7 +3323,7 @@
     subfield  = {pragmatics/assertion},
   validated = {true},
   role      = {formalized},
-  sources   = {Core/Order/PreferenceStructure.lean;Core/Order/PreferenceStructure/EffectivePreference.lean;Semantics/Attitudes/CondoravdiLauer.lean;Discourse/SpeechAct.lean;Discourse/Commitment/Basic.lean;Discourse/Commitment/Space.lean}
+  sources   = {Discourse/SpeechAct.lean;Semantics/Attitudes/Desire/Preferential.lean;Semantics/Attitudes/Preference.lean}
 }
 @incollection{condoravdi-lauer-2011,
   author    = {Condoravdi, Cleo and Lauer, Sven},
@@ -3348,7 +3348,7 @@
   url       = {http://www.cssp.cnrs.fr/eiss9/eiss9_condoravdi-and-lauer.pdf},
   subfield  = {pragmatics/assertion},
   role      = {formalized},
-  sources   = {Studies/CondoravdiLauer2012.lean;Semantics/Attitudes/Preference.lean;Semantics/Attitudes/Desire/Preferential.lean;Discourse/Commitment/Basic.lean;Data/Examples/CondoravdiLauer2012.json}
+  sources   = {Data/Examples/CondoravdiLauer2012.json;Discourse/Commitment/Basic.lean;Discourse/Commitment/Preferential.lean;Discourse/SpeechAct.lean;Semantics/Attitudes/Desire/Preferential.lean;Semantics/Attitudes/Preference.lean;Semantics/Dynamic/UpdateSemantics/Necessity.lean;Studies/CondoravdiLauer2012.lean;Studies/Deo2025.lean}
 }
 @article{condoravdi-lauer-2016,
   author    = {Condoravdi, Cleo and Lauer, Sven},
@@ -3396,7 +3396,7 @@
   publisher = {University of Messina, C.U.M.O.},
   subfield  = {pragmatics/assertion},
   role      = {formalized},
-  sources   = {Fragments/Marathi/Particles.lean;Studies/Deo2025.lean}
+  sources   = {Data/Examples/Deo2025.json;Discourse/Commitment/Preferential.lean;Fragments/Marathi/Particles.lean;Studies/Deo2025.lean}
 }
 @misc{deo-2023,
   author    = {Deo, Ashwini},
@@ -3416,7 +3416,7 @@
   doi       = {10.3765/salt.v28i0.4400},
   subfield  = {pragmatics/assertion},
   role      = {cited},
-  sources   = {Studies/FarkasRoelofsen2017.lean}
+  sources   = {Studies/Deo2025.lean;Studies/FarkasRoelofsen2017.lean}
 }
 @inproceedings{roberts-rudin-2024,
   author    = {Roberts, Tom and Rudin, Deniz},
@@ -3477,7 +3477,7 @@
   sources   = {Studies/Faller2019.lean}
 }
 
-@incollection{gunlogson-2008,
+@article{gunlogson-2008,
   author    = {Gunlogson, Christine},
   year      = {2008},
   title     = {A Question of Commitment},
@@ -3487,7 +3487,7 @@
   doi       = {10.1075/bjl.22.06gun},
   subfield  = {pragmatics/assertion},
   role      = {cited},
-  sources   = {Studies/Faller2019.lean;Studies/FarkasRoelofsen2017.lean}
+  sources   = {Discourse/Commitment/Basic.lean;Discourse/Commitment/Declarative.lean;Studies/Deo2025.lean;Studies/Faller2019.lean;Studies/FarkasRoelofsen2017.lean}
 }
 @article{portner-2007,
   author    = {Portner, Paul},
@@ -3616,7 +3616,7 @@
   subfield  = {pragmatics/assertion},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/FarkasBruce2010.lean}
+  sources   = {Discourse/Commitment/Table.lean;Discourse/CommonGround.lean;Pragmatics/Bias.lean;Studies/Deo2025.lean;Studies/Faller2019.lean;Studies/FarkasBruce2010.lean;Studies/FarkasRoelofsen2017.lean;Studies/Krifka2015.lean;Studies/Kubota2026.lean;Studies/Rudin2025LI.lean}
 }
 @book{gunlogson-2004,
   author    = {Gunlogson, Christine},
@@ -6424,7 +6424,7 @@
   subfield  = {pragmatics/assertion},
   role      = {formalized},
   validated = {true},
-  sources   = {Discourse/Commitment/Declarative.lean;Studies/Gunlogson2001.lean}
+  sources   = {Data/Examples/Gunlogson2001.json;Discourse/Commitment/Declarative.lean;Studies/Deo2025.lean;Studies/FarkasRoelofsen2017.lean;Studies/Gunlogson2001.lean}
 }% REF: Haspelmath, M. (2001). The European linguistic area: Standard Average European. In Haspelmath et al. (eds.), Language Ty
 @incollection{haspelmath-2001,
   author    = {Haspelmath, Martin},


### PR DESCRIPTION
Deep cleanse of Deo (2025) on Marathi bərə: the felicity profile is derived from the two conventions on a world-indexed commitment state instead of a stipulated act table.

- Uptake of a content is the proposition that the addressee is a dependent for it; manifest sourcehood makes it unrealizable, so sincerity plus preference consistency excludes permissions, concessions, commissives and their responses; deference excludes offers; a non-addressee-benefiting goal excludes requests, pleas and curses; the (5a)/(5b) and (15) contrasts are finite witnesses.
- `Commitment.Sincere` promoted from CondoravdiLauer2012 to `Discourse/Commitment/Preferential.lean`; `PreferenceStructure.consistent_discrete` and `commit_force`/`commit_source` added; 25 rows in `Data/Examples/Deo2025.json`.
- `gunlogson-2008` corrected to an article entry; bib sources recomputed.