### PR TITLE
refactor(Studies/Dixon1994): hierarchy splits and pivot feeding

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3038,3 +3038,4 @@ import Linglib.Data.Examples.Dendikken1995
 import Linglib.Data.Examples.Denic2023
 import Linglib.Data.Examples.DenicEtAl2021
 import Linglib.Data.Examples.Deo2025
+import Linglib.Data.Examples.Dixon1994

--- a/Linglib/Data/Examples/Dixon1994.json
+++ b/Linglib/Data/Examples/Dixon1994.json
@@ -1,0 +1,969 @@
+[
+  {
+    "id": "dixon1994_1_2_5",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§1.2 (5)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"]
+    ],
+    "translation": "Father returned.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "simple"],
+      ["function", "S"]
+    ],
+    "comment": "A noun in S function bears absolutive case, with zero realisation; noun markers are omitted throughout, fn. 8.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_1_2_7",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§1.2 (7)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "Mother saw father.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "simple"],
+      ["function", "AO"]
+    ],
+    "comment": "A noun in O function is absolutive like S; A takes ergative -ŋgu; the verb cross-references none of S, A and O.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_1_2_12",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§1.2 (12)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma bural-ŋa-nyu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Father saw mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "antipassive"],
+      ["function", "S"]
+    ],
+    "comment": "The antipassive of §1.2 (8): underlying A becomes S, underlying O goes into dative case, and the verb bears -ŋa-y between root and inflection, (11).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_15",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (15)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "nyurra ŋana-na bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["nyurra", "you.all.NOM"], ["ŋana-na", "we.all-ACC"], ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "You all saw us.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "simple"],
+      ["function", "AO"]
+    ],
+    "comment": "First and second person pronouns inflect on a nominative-accusative pattern, Table 6.1: the split of Table 4.1.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_17",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (17)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu miyanda-nyu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"], ["miyanda-nyu", "laugh-NONFUT"]
+    ],
+    "translation": "Father returned and laughed.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "Possibility (a): the common NP is in pivot function S in both clauses and its second occurrence is omitted; there is no overt coordinator.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_19",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (19)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu yabu-ŋgu bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"], ["yabu-ŋgu", "mother-ERG"],
+      ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "Father returned and mother saw him.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "Possibility (b), S₁ = O₂: both are pivot functions under the S/O pivot.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_20",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (20)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋana banaga-nyu nyurra bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋana", "we.all.NOM"], ["banaga-nyu", "return-NONFUT"], ["nyurra", "you.all.NOM"],
+      ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "We returned and you all saw us.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "The pivot is S/O for pronouns too, although their morphology is accusative: ŋana is retained and ŋana-na omitted.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_21",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (21)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu bura-n banaga-nyu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["bura-n", "see-NONFUT"],
+      ["banaga-nyu", "return-NONFUT"]
+    ],
+    "translation": "Mother saw father and he returned.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "Possibility (d), O₁ = S₂.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_24",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (24)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu bura-n jaja-ŋgu ŋamba-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["bura-n", "see-NONFUT"],
+      ["jaja-ŋgu", "child-ERG"], ["ŋamba-n", "hear-NONFUT"]
+    ],
+    "translation": "Mother saw father and the child heard him.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "Possibility (f), O₁ = O₂.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_28",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (28)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu bura-n (yabu-ŋgu) ŋamba-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["bura-n", "see-NONFUT"],
+      ["(yabu-ŋgu)", "mother-ERG"], ["ŋamba-n", "hear-NONFUT"]
+    ],
+    "translation": "Mother saw and heard father.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "Possibility (j), O₁ = O₂ and A₁ = A₂: the pivot NP is the O; the A NP, always omittable, is understood as identical if unstated.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_32",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (32)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma bural-ŋa-nyu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Father saw mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "antipassive"],
+      ["function", "S"]
+    ],
+    "comment": "The antipassive version of (11) 'father saw mother', (31): underlying A into derived S, underlying O into dative.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_33",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (33)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋana bural-ŋa-nyu nyurra-ŋgu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋana", "we.all.NOM"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"],
+      ["nyurra-ŋgu", "you.all-DAT"]
+    ],
+    "translation": "We saw you all.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "antipassive"],
+      ["function", "S"]
+    ],
+    "comment": "The antipassive version of (16); dative is -ŋgu with pronouns.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_34",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (34)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu bural-ŋa-nyu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"],
+      ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Father returned and saw mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (c), S₁ = A₂: the second clause is antipassivized to bring the underlying A into derived S and satisfy the S/O pivot.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_36",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (36)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma jaja-ŋgu ŋamba-n bural-ŋa-nyu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["jaja-ŋgu", "child-ERG"], ["ŋamba-n", "hear-NONFUT"],
+      ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "The child heard father and he (father) saw mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (h), O₁ = A₂, with the second clause antipassivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_39",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (39)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu ŋamba-n bural-ŋa-nyu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["ŋamba-n", "hear-NONFUT"],
+      ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Mother heard father and he saw her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (k), O₁ = A₂ and A₁ = O₂: the O₁ = A₂ NP is the pivot; the final dative NP cannot be omitted.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_42",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (42)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma bural-ŋa-nyu yabu-gu banaga-nyu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"],
+      ["banaga-nyu", "return-NONFUT"]
+    ],
+    "translation": "Father saw mother and returned.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "S"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (e), A₁ = S₂, with the first clause antipassivized, which requires planning ahead; the -ŋurra construction of (46) is the alternative.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_44",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (44)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma bural-ŋa-nyu yabu-gu jaja-ŋgu ŋamba-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"],
+      ["jaja-ŋgu", "child-ERG"], ["ŋamba-n", "hear-NONFUT"]
+    ],
+    "translation": "Father saw mother and the child heard him.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "O"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (i), A₁ = O₂, with the first clause antipassivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_46",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (46)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yabu ŋuma-ŋgu bura-n (ŋuma) banaga-ŋurra",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yabu", "mother.ABS"], ["ŋuma-ŋgu", "father-ERG"], ["bura-n", "see-NONFUT"],
+      ["(ŋuma)", "father.ABS"], ["banaga-ŋurra", "return-ŊURRA"]
+    ],
+    "translation": "Father saw mother and then he immediately returned.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "S"],
+      ["derivation", "ngurra"]
+    ],
+    "comment": "The verbal inflection -ŋurra marks that the S or O of its clause is identical to the A of the preceding clause and that the event follows immediately; the common NP may be included or omitted.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_52",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (52)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma bural-ŋa-nyu yabu-gu ŋambal-ŋa-nyu jaja-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["bural-ŋa-nyu", "see-ANTIPASS-NONFUT"], ["yabu-gu", "mother-DAT"],
+      ["ŋambal-ŋa-nyu", "hear-ANTIPASS-NONFUT"], ["jaja-gu", "child-DAT"]
+    ],
+    "translation": "Father saw mother and he heard the child.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "Possibility (g), A₁ = A₂: both clauses are antipassivized; alternatively only the second is, with the -ŋurra construction, (54).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_56",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (56)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu yabu-ŋgu bura-li",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"], ["yabu-ŋgu", "mother-ERG"],
+      ["bura-li", "see-PURP"]
+    ],
+    "translation": "Father returned in order for mother to see him; or father returned and as a result mother saw him.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "purposive"],
+      ["first", "S"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "Purposive coordination obeys the same S/O pivot: main and purposive clause must share an NP in S or O function in each, contrary to the expectation of §4.4 that purposive clauses group S with A.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_57",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (57)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-nyu bural-ŋa-ygu yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-nyu", "return-NONFUT"],
+      ["bural-ŋa-ygu", "see-ANTIPASS-PURP"], ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Father returned in order to see mother; or father returned and as a result saw mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "purposive"],
+      ["first", "S"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "The purposive clause is antipassivized to bring its A into derived S.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_59",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (59)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yabu ŋuma-ŋgu giga-n gubi-ŋgu mawa-li",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yabu", "mother.ABS"], ["ŋuma-ŋgu", "father-ERG"], ["giga-n", "tell.to.do-NONFUT"],
+      ["gubi-ŋgu", "doctor-ERG"], ["mawa-li", "examine-PURP"]
+    ],
+    "translation": "Father told mother to be examined by the doctor.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "purposive"],
+      ["first", "O"],
+      ["second", "O"],
+      ["derivation", "none"]
+    ],
+    "comment": "O₁ = O₂ with the verb 'tell to do'; the author corrects an earlier statement that the O of giga-l must be coreferential with the A or S of its purposive clause, fn. 19.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_60",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (60)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yabu ŋuma-ŋgu giga-n bural-ŋa-ygu jaja-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yabu", "mother.ABS"], ["ŋuma-ŋgu", "father-ERG"], ["giga-n", "tell.to.do-NONFUT"],
+      ["bural-ŋa-ygu", "see-ANTIPASS-PURP"], ["jaja-gu", "child-DAT"]
+    ],
+    "translation": "Father told mother to look at the child.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "purposive"],
+      ["first", "O"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "O₁ = A₂: the purposive clause must be antipassivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_61",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (61)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma banaga-ŋu yabu-ŋgu bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["banaga-ŋu", "return-REL.ABS"], ["yabu-ŋgu", "mother-ERG"],
+      ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "Mother saw father who was returning.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "relative"],
+      ["first", "O"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "The common NP must be in S or O function within the relative clause; the relative verb bears -ŋu and a case inflection agreeing with the common NP in the main clause.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_62",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (62)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "ŋuma yabu-ŋgu banaga-ŋu-rru bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ŋuma", "father.ABS"], ["yabu-ŋgu", "mother-ERG"], ["banaga-ŋu-rru", "return-REL-ERG"],
+      ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "Mother, who was returning, saw father.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "relative"],
+      ["first", "A"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "The common NP may be in any core function in the main clause, here A, and the relative clause agrees in ergative case.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_63",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (63)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yabu bural-ŋa-ŋu ŋuma-gu banaga-nyu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yabu", "mother.ABS"], ["bural-ŋa-ŋu", "see-ANTIPASS-REL.ABS"], ["ŋuma-gu", "father-DAT"],
+      ["banaga-nyu", "return-NONFUT"]
+    ],
+    "translation": "Mother, who saw father, was returning.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "relative"],
+      ["first", "S"],
+      ["second", "A"],
+      ["derivation", "antipassive"]
+    ],
+    "comment": "The common NP is in A function in the relative clause, so antipassive applies before relativisation.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_66",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (66)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yugu ŋuma-ŋgu balgal-ma-n yabu-gu",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yugu", "stick.ABS"], ["ŋuma-ŋgu", "father-ERG"], ["balgal-ma-n", "hit-INSTV-NONFUT"],
+      ["yabu-gu", "mother-DAT"]
+    ],
+    "translation": "Father used a stick to hit mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "instrumentive"],
+      ["function", "O"]
+    ],
+    "comment": "The instrumentive derivation places an underlying instrumental NP into derived O function, demoting the underlying O to dative, with -ma-l on the verb; it feeds the S/O pivot, (67) and (68).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_68",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.2 (68)"},
+    "reportedIn": null,
+    "language": "dyir1250",
+    "primaryText": "yugu ŋuma-ŋgu balgal-ma-ŋu yabu-gu jaja-ŋgu bura-n",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["yugu", "stick.ABS"], ["ŋuma-ŋgu", "father-ERG"], ["balgal-ma-ŋu", "hit-INSTV-REL.ABS"],
+      ["yabu-gu", "mother-DAT"], ["jaja-ŋgu", "child-ERG"], ["bura-n", "see-NONFUT"]
+    ],
+    "translation": "The child saw the stick that was used by father to hit mother.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "relative"],
+      ["first", "O"],
+      ["second", "O"],
+      ["derivation", "instrumentive"]
+    ],
+    "comment": "The relative clause is first recast by the instrumentive derivation so that the common NP is in O function within it.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dixon1994_en_a",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill entered and sat down.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "English's S/A pivot constrains omission of the second occurrence of a common NP, not clause linking itself: a weak pivot.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_b",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill entered and was seen by Fred.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "O"],
+      ["derivation", "passive"]
+    ],
+    "comment": "S₁ = O₂: the second clause is passivized so that the common NP is in derived S.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_c",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (c)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill entered and saw Fred.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "S"],
+      ["second", "A"],
+      ["derivation", "none"]
+    ],
+    "comment": "S₁ = A₂.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_d",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (d)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill was seen by Fred and laughed.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "S"],
+      ["derivation", "passive"]
+    ],
+    "comment": "O₁ = S₂: the first clause is passivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_e",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (e)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Fred saw Bill and laughed.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "S"],
+      ["derivation", "none"]
+    ],
+    "comment": "A₁ = S₂.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_f",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (f)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bill was kicked by Tom and punched by Bob.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Tom kicked and Bob punched Bill.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "O"],
+      ["derivation", "passive"]
+    ],
+    "comment": "O₁ = O₂: both clauses are passivized; the alternative combines A-plus-verb from two clauses with the same O, which not all speakers accept.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_g",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (g)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bob kicked Jim and punched Bill.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "A"],
+      ["derivation", "none"]
+    ],
+    "comment": "A₁ = A₂.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_h",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (h)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bob was kicked by Tom and punched Bill.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "O"],
+      ["second", "A"],
+      ["derivation", "passive"]
+    ],
+    "comment": "O₁ = A₂: the first clause is passivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_i",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (i)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Bob punched Bill and was kicked by Tom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "O"],
+      ["derivation", "passive"]
+    ],
+    "comment": "A₁ = O₂: the second clause is passivized.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_j",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (j)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Fred punched and kicked Bill.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Fred punched Bill and kicked him.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "A"],
+      ["derivation", "none"]
+    ],
+    "comment": "O₁ = O₂ and A₁ = A₂: the verbs are coordinated so that each NP is stated once.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "dixon1994_en_k",
+    "source": {"bibkey": "dixon-1994", "paperLabel": "§6.2.1 (k)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Fred punched Bill and was kicked by him.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Fred punched and was kicked by Bill.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "coordination"],
+      ["first", "A"],
+      ["second", "O"],
+      ["derivation", "passive"]
+    ],
+    "comment": "O₁ = A₂ and A₁ = O₂: the A₁ = O₂ NP is the pivot and the second clause is passivized; not all speakers accept the alternative.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Dixon1994.lean
+++ b/Linglib/Data/Examples/Dixon1994.lean
@@ -1,0 +1,720 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Dixon1994` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Dixon1994.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Dixon1994.Examples`.
+-/
+
+namespace Dixon1994.Examples
+
+open Data.Examples
+
+def ex_1_2_5 : LinguisticExample :=
+  { id := "dixon1994_1_2_5"
+    source := ⟨"dixon-1994", "§1.2 (5)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT")]
+    translation := "Father returned."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "simple"), ("function", "S")]
+    comment := "A noun in S function bears absolutive case, with zero realisation; noun markers are omitted throughout, fn. 8."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_1_2_7 : LinguisticExample :=
+  { id := "dixon1994_1_2_7"
+    source := ⟨"dixon-1994", "§1.2 (7)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu bura-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT")]
+    translation := "Mother saw father."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "simple"), ("function", "AO")]
+    comment := "A noun in O function is absolutive like S; A takes ergative -ŋgu; the verb cross-references none of S, A and O."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_1_2_12 : LinguisticExample :=
+  { id := "dixon1994_1_2_12"
+    source := ⟨"dixon-1994", "§1.2 (12)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma bural-ŋa-nyu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "Father saw mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "antipassive"), ("function", "S")]
+    comment := "The antipassive of §1.2 (8): underlying A becomes S, underlying O goes into dative case, and the verb bears -ŋa-y between root and inflection, (11)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_15 : LinguisticExample :=
+  { id := "dixon1994_15"
+    source := ⟨"dixon-1994", "§6.2.2 (15)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "nyurra ŋana-na bura-n"
+    discourseSegments := []
+    glossedTokens := [("nyurra", "you.all.NOM"), ("ŋana-na", "we.all-ACC"), ("bura-n", "see-NONFUT")]
+    translation := "You all saw us."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "simple"), ("function", "AO")]
+    comment := "First and second person pronouns inflect on a nominative-accusative pattern, Table 6.1: the split of Table 4.1."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_17 : LinguisticExample :=
+  { id := "dixon1994_17"
+    source := ⟨"dixon-1994", "§6.2.2 (17)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu miyanda-nyu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT"), ("miyanda-nyu", "laugh-NONFUT")]
+    translation := "Father returned and laughed."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "S"), ("derivation", "none")]
+    comment := "Possibility (a): the common NP is in pivot function S in both clauses and its second occurrence is omitted; there is no overt coordinator."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_19 : LinguisticExample :=
+  { id := "dixon1994_19"
+    source := ⟨"dixon-1994", "§6.2.2 (19)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu yabu-ŋgu bura-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT")]
+    translation := "Father returned and mother saw him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "O"), ("derivation", "none")]
+    comment := "Possibility (b), S₁ = O₂: both are pivot functions under the S/O pivot."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_20 : LinguisticExample :=
+  { id := "dixon1994_20"
+    source := ⟨"dixon-1994", "§6.2.2 (20)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋana banaga-nyu nyurra bura-n"
+    discourseSegments := []
+    glossedTokens := [("ŋana", "we.all.NOM"), ("banaga-nyu", "return-NONFUT"), ("nyurra", "you.all.NOM"), ("bura-n", "see-NONFUT")]
+    translation := "We returned and you all saw us."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "O"), ("derivation", "none")]
+    comment := "The pivot is S/O for pronouns too, although their morphology is accusative: ŋana is retained and ŋana-na omitted."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_21 : LinguisticExample :=
+  { id := "dixon1994_21"
+    source := ⟨"dixon-1994", "§6.2.2 (21)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu bura-n banaga-nyu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT"), ("banaga-nyu", "return-NONFUT")]
+    translation := "Mother saw father and he returned."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "S"), ("derivation", "none")]
+    comment := "Possibility (d), O₁ = S₂."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_24 : LinguisticExample :=
+  { id := "dixon1994_24"
+    source := ⟨"dixon-1994", "§6.2.2 (24)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu bura-n jaja-ŋgu ŋamba-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT"), ("jaja-ŋgu", "child-ERG"), ("ŋamba-n", "hear-NONFUT")]
+    translation := "Mother saw father and the child heard him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "O"), ("derivation", "none")]
+    comment := "Possibility (f), O₁ = O₂."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_28 : LinguisticExample :=
+  { id := "dixon1994_28"
+    source := ⟨"dixon-1994", "§6.2.2 (28)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu bura-n (yabu-ŋgu) ŋamba-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT"), ("(yabu-ŋgu)", "mother-ERG"), ("ŋamba-n", "hear-NONFUT")]
+    translation := "Mother saw and heard father."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "O"), ("derivation", "none")]
+    comment := "Possibility (j), O₁ = O₂ and A₁ = A₂: the pivot NP is the O; the A NP, always omittable, is understood as identical if unstated."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_32 : LinguisticExample :=
+  { id := "dixon1994_32"
+    source := ⟨"dixon-1994", "§6.2.2 (32)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma bural-ŋa-nyu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "Father saw mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "antipassive"), ("function", "S")]
+    comment := "The antipassive version of (11) 'father saw mother', (31): underlying A into derived S, underlying O into dative."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_33 : LinguisticExample :=
+  { id := "dixon1994_33"
+    source := ⟨"dixon-1994", "§6.2.2 (33)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋana bural-ŋa-nyu nyurra-ŋgu"
+    discourseSegments := []
+    glossedTokens := [("ŋana", "we.all.NOM"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("nyurra-ŋgu", "you.all-DAT")]
+    translation := "We saw you all."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "antipassive"), ("function", "S")]
+    comment := "The antipassive version of (16); dative is -ŋgu with pronouns."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_34 : LinguisticExample :=
+  { id := "dixon1994_34"
+    source := ⟨"dixon-1994", "§6.2.2 (34)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu bural-ŋa-nyu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "Father returned and saw mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "Possibility (c), S₁ = A₂: the second clause is antipassivized to bring the underlying A into derived S and satisfy the S/O pivot."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_36 : LinguisticExample :=
+  { id := "dixon1994_36"
+    source := ⟨"dixon-1994", "§6.2.2 (36)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma jaja-ŋgu ŋamba-n bural-ŋa-nyu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("jaja-ŋgu", "child-ERG"), ("ŋamba-n", "hear-NONFUT"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "The child heard father and he (father) saw mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "Possibility (h), O₁ = A₂, with the second clause antipassivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_39 : LinguisticExample :=
+  { id := "dixon1994_39"
+    source := ⟨"dixon-1994", "§6.2.2 (39)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu ŋamba-n bural-ŋa-nyu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("ŋamba-n", "hear-NONFUT"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "Mother heard father and he saw her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "Possibility (k), O₁ = A₂ and A₁ = O₂: the O₁ = A₂ NP is the pivot; the final dative NP cannot be omitted."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_42 : LinguisticExample :=
+  { id := "dixon1994_42"
+    source := ⟨"dixon-1994", "§6.2.2 (42)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma bural-ŋa-nyu yabu-gu banaga-nyu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT"), ("banaga-nyu", "return-NONFUT")]
+    translation := "Father saw mother and returned."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "S"), ("derivation", "antipassive")]
+    comment := "Possibility (e), A₁ = S₂, with the first clause antipassivized, which requires planning ahead; the -ŋurra construction of (46) is the alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_44 : LinguisticExample :=
+  { id := "dixon1994_44"
+    source := ⟨"dixon-1994", "§6.2.2 (44)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma bural-ŋa-nyu yabu-gu jaja-ŋgu ŋamba-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT"), ("jaja-ŋgu", "child-ERG"), ("ŋamba-n", "hear-NONFUT")]
+    translation := "Father saw mother and the child heard him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "O"), ("derivation", "antipassive")]
+    comment := "Possibility (i), A₁ = O₂, with the first clause antipassivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_46 : LinguisticExample :=
+  { id := "dixon1994_46"
+    source := ⟨"dixon-1994", "§6.2.2 (46)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yabu ŋuma-ŋgu bura-n (ŋuma) banaga-ŋurra"
+    discourseSegments := []
+    glossedTokens := [("yabu", "mother.ABS"), ("ŋuma-ŋgu", "father-ERG"), ("bura-n", "see-NONFUT"), ("(ŋuma)", "father.ABS"), ("banaga-ŋurra", "return-ŊURRA")]
+    translation := "Father saw mother and then he immediately returned."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "S"), ("derivation", "ngurra")]
+    comment := "The verbal inflection -ŋurra marks that the S or O of its clause is identical to the A of the preceding clause and that the event follows immediately; the common NP may be included or omitted."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_52 : LinguisticExample :=
+  { id := "dixon1994_52"
+    source := ⟨"dixon-1994", "§6.2.2 (52)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma bural-ŋa-nyu yabu-gu ŋambal-ŋa-nyu jaja-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("bural-ŋa-nyu", "see-ANTIPASS-NONFUT"), ("yabu-gu", "mother-DAT"), ("ŋambal-ŋa-nyu", "hear-ANTIPASS-NONFUT"), ("jaja-gu", "child-DAT")]
+    translation := "Father saw mother and he heard the child."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "Possibility (g), A₁ = A₂: both clauses are antipassivized; alternatively only the second is, with the -ŋurra construction, (54)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_56 : LinguisticExample :=
+  { id := "dixon1994_56"
+    source := ⟨"dixon-1994", "§6.2.2 (56)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu yabu-ŋgu bura-li"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT"), ("yabu-ŋgu", "mother-ERG"), ("bura-li", "see-PURP")]
+    translation := "Father returned in order for mother to see him; or father returned and as a result mother saw him."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "purposive"), ("first", "S"), ("second", "O"), ("derivation", "none")]
+    comment := "Purposive coordination obeys the same S/O pivot: main and purposive clause must share an NP in S or O function in each, contrary to the expectation of §4.4 that purposive clauses group S with A."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_57 : LinguisticExample :=
+  { id := "dixon1994_57"
+    source := ⟨"dixon-1994", "§6.2.2 (57)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-nyu bural-ŋa-ygu yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-nyu", "return-NONFUT"), ("bural-ŋa-ygu", "see-ANTIPASS-PURP"), ("yabu-gu", "mother-DAT")]
+    translation := "Father returned in order to see mother; or father returned and as a result saw mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "purposive"), ("first", "S"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "The purposive clause is antipassivized to bring its A into derived S."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_59 : LinguisticExample :=
+  { id := "dixon1994_59"
+    source := ⟨"dixon-1994", "§6.2.2 (59)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yabu ŋuma-ŋgu giga-n gubi-ŋgu mawa-li"
+    discourseSegments := []
+    glossedTokens := [("yabu", "mother.ABS"), ("ŋuma-ŋgu", "father-ERG"), ("giga-n", "tell.to.do-NONFUT"), ("gubi-ŋgu", "doctor-ERG"), ("mawa-li", "examine-PURP")]
+    translation := "Father told mother to be examined by the doctor."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "purposive"), ("first", "O"), ("second", "O"), ("derivation", "none")]
+    comment := "O₁ = O₂ with the verb 'tell to do'; the author corrects an earlier statement that the O of giga-l must be coreferential with the A or S of its purposive clause, fn. 19."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_60 : LinguisticExample :=
+  { id := "dixon1994_60"
+    source := ⟨"dixon-1994", "§6.2.2 (60)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yabu ŋuma-ŋgu giga-n bural-ŋa-ygu jaja-gu"
+    discourseSegments := []
+    glossedTokens := [("yabu", "mother.ABS"), ("ŋuma-ŋgu", "father-ERG"), ("giga-n", "tell.to.do-NONFUT"), ("bural-ŋa-ygu", "see-ANTIPASS-PURP"), ("jaja-gu", "child-DAT")]
+    translation := "Father told mother to look at the child."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "purposive"), ("first", "O"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "O₁ = A₂: the purposive clause must be antipassivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_61 : LinguisticExample :=
+  { id := "dixon1994_61"
+    source := ⟨"dixon-1994", "§6.2.2 (61)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma banaga-ŋu yabu-ŋgu bura-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("banaga-ŋu", "return-REL.ABS"), ("yabu-ŋgu", "mother-ERG"), ("bura-n", "see-NONFUT")]
+    translation := "Mother saw father who was returning."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "relative"), ("first", "O"), ("second", "S"), ("derivation", "none")]
+    comment := "The common NP must be in S or O function within the relative clause; the relative verb bears -ŋu and a case inflection agreeing with the common NP in the main clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_62 : LinguisticExample :=
+  { id := "dixon1994_62"
+    source := ⟨"dixon-1994", "§6.2.2 (62)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "ŋuma yabu-ŋgu banaga-ŋu-rru bura-n"
+    discourseSegments := []
+    glossedTokens := [("ŋuma", "father.ABS"), ("yabu-ŋgu", "mother-ERG"), ("banaga-ŋu-rru", "return-REL-ERG"), ("bura-n", "see-NONFUT")]
+    translation := "Mother, who was returning, saw father."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "relative"), ("first", "A"), ("second", "S"), ("derivation", "none")]
+    comment := "The common NP may be in any core function in the main clause, here A, and the relative clause agrees in ergative case."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_63 : LinguisticExample :=
+  { id := "dixon1994_63"
+    source := ⟨"dixon-1994", "§6.2.2 (63)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yabu bural-ŋa-ŋu ŋuma-gu banaga-nyu"
+    discourseSegments := []
+    glossedTokens := [("yabu", "mother.ABS"), ("bural-ŋa-ŋu", "see-ANTIPASS-REL.ABS"), ("ŋuma-gu", "father-DAT"), ("banaga-nyu", "return-NONFUT")]
+    translation := "Mother, who saw father, was returning."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "relative"), ("first", "S"), ("second", "A"), ("derivation", "antipassive")]
+    comment := "The common NP is in A function in the relative clause, so antipassive applies before relativisation."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_66 : LinguisticExample :=
+  { id := "dixon1994_66"
+    source := ⟨"dixon-1994", "§6.2.2 (66)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yugu ŋuma-ŋgu balgal-ma-n yabu-gu"
+    discourseSegments := []
+    glossedTokens := [("yugu", "stick.ABS"), ("ŋuma-ŋgu", "father-ERG"), ("balgal-ma-n", "hit-INSTV-NONFUT"), ("yabu-gu", "mother-DAT")]
+    translation := "Father used a stick to hit mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "instrumentive"), ("function", "O")]
+    comment := "The instrumentive derivation places an underlying instrumental NP into derived O function, demoting the underlying O to dative, with -ma-l on the verb; it feeds the S/O pivot, (67) and (68)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_68 : LinguisticExample :=
+  { id := "dixon1994_68"
+    source := ⟨"dixon-1994", "§6.2.2 (68)"⟩
+    reportedIn := none
+    language := "dyir1250"
+    primaryText := "yugu ŋuma-ŋgu balgal-ma-ŋu yabu-gu jaja-ŋgu bura-n"
+    discourseSegments := []
+    glossedTokens := [("yugu", "stick.ABS"), ("ŋuma-ŋgu", "father-ERG"), ("balgal-ma-ŋu", "hit-INSTV-REL.ABS"), ("yabu-gu", "mother-DAT"), ("jaja-ŋgu", "child-ERG"), ("bura-n", "see-NONFUT")]
+    translation := "The child saw the stick that was used by father to hit mother."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "relative"), ("first", "O"), ("second", "O"), ("derivation", "instrumentive")]
+    comment := "The relative clause is first recast by the instrumentive derivation so that the common NP is in O function within it."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def en_a : LinguisticExample :=
+  { id := "dixon1994_en_a"
+    source := ⟨"dixon-1994", "§6.2.1 (a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill entered and sat down."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "S"), ("derivation", "none")]
+    comment := "English's S/A pivot constrains omission of the second occurrence of a common NP, not clause linking itself: a weak pivot."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_b : LinguisticExample :=
+  { id := "dixon1994_en_b"
+    source := ⟨"dixon-1994", "§6.2.1 (b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill entered and was seen by Fred."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "O"), ("derivation", "passive")]
+    comment := "S₁ = O₂: the second clause is passivized so that the common NP is in derived S."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_c : LinguisticExample :=
+  { id := "dixon1994_en_c"
+    source := ⟨"dixon-1994", "§6.2.1 (c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill entered and saw Fred."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "S"), ("second", "A"), ("derivation", "none")]
+    comment := "S₁ = A₂."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_d : LinguisticExample :=
+  { id := "dixon1994_en_d"
+    source := ⟨"dixon-1994", "§6.2.1 (d)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill was seen by Fred and laughed."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "S"), ("derivation", "passive")]
+    comment := "O₁ = S₂: the first clause is passivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_e : LinguisticExample :=
+  { id := "dixon1994_en_e"
+    source := ⟨"dixon-1994", "§6.2.1 (e)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fred saw Bill and laughed."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "S"), ("derivation", "none")]
+    comment := "A₁ = S₂."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_f : LinguisticExample :=
+  { id := "dixon1994_en_f"
+    source := ⟨"dixon-1994", "§6.2.1 (f)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bill was kicked by Tom and punched by Bob."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Tom kicked and Bob punched Bill.", .acceptable)]
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "O"), ("derivation", "passive")]
+    comment := "O₁ = O₂: both clauses are passivized; the alternative combines A-plus-verb from two clauses with the same O, which not all speakers accept."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_g : LinguisticExample :=
+  { id := "dixon1994_en_g"
+    source := ⟨"dixon-1994", "§6.2.1 (g)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bob kicked Jim and punched Bill."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "A"), ("derivation", "none")]
+    comment := "A₁ = A₂."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_h : LinguisticExample :=
+  { id := "dixon1994_en_h"
+    source := ⟨"dixon-1994", "§6.2.1 (h)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bob was kicked by Tom and punched Bill."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "O"), ("second", "A"), ("derivation", "passive")]
+    comment := "O₁ = A₂: the first clause is passivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_i : LinguisticExample :=
+  { id := "dixon1994_en_i"
+    source := ⟨"dixon-1994", "§6.2.1 (i)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bob punched Bill and was kicked by Tom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "O"), ("derivation", "passive")]
+    comment := "A₁ = O₂: the second clause is passivized."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_j : LinguisticExample :=
+  { id := "dixon1994_en_j"
+    source := ⟨"dixon-1994", "§6.2.1 (j)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fred punched and kicked Bill."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Fred punched Bill and kicked him.", .acceptable)]
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "A"), ("derivation", "none")]
+    comment := "O₁ = O₂ and A₁ = A₂: the verbs are coordinated so that each NP is stated once."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def en_k : LinguisticExample :=
+  { id := "dixon1994_en_k"
+    source := ⟨"dixon-1994", "§6.2.1 (k)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Fred punched Bill and was kicked by him."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Fred punched and was kicked by Bill.", .acceptable)]
+    readings := []
+    paperFeatures := [("construction", "coordination"), ("first", "A"), ("second", "O"), ("derivation", "passive")]
+    comment := "O₁ = A₂ and A₁ = O₂: the A₁ = O₂ NP is the pivot and the second clause is passivized; not all speakers accept the alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1_2_5, ex_1_2_7, ex_1_2_12, ex_15, ex_17, ex_19, ex_20, ex_21, ex_24, ex_28, ex_32, ex_33, ex_34, ex_36, ex_39, ex_42, ex_44, ex_46, ex_52, ex_56, ex_57, ex_59, ex_60, ex_61, ex_62, ex_63, ex_66, ex_68, en_a, en_b, en_c, en_d, en_e, en_f, en_g, en_h, en_i, en_j, en_k]
+
+end Dixon1994.Examples

--- a/Linglib/Studies/Dixon1994.lean
+++ b/Linglib/Studies/Dixon1994.lean
@@ -1,685 +1,329 @@
-import Linglib.Features.Case.Basic
-import Linglib.Features.Prominence
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Syntax.Case.Alignment
-import Linglib.Fragments.Dargwa.Case
-import Linglib.Fragments.Japanese.Case
-import Linglib.Fragments.Hindi.Case
-import Linglib.Syntax.Clause.ArgumentRole
+import Linglib.Data.Examples.Dixon1994
 
 /-!
-# Dixon (1994): Ergativity — typology + Silverstein hierarchy + ditransitives
-[dixon-1994] [dixon-1972] [silverstein-1976] [blake-1994]
-[comrie-1978] [comrie-2013] [haspelmath-2005]
-[haspelmath-2021] [bohnemeyer-2004] [sumbatova-2021]
+# Dixon (1994): Ergativity
 
-R. M. W. Dixon. *Ergativity*. Cambridge University Press, 1994. The
-canonical typological reference for ergative alignment + split ergativity,
-covering [silverstein-1976]'s prominence hierarchy and
-[dixon-1972]'s Dyirbal split-ergative analysis.
+This file formalizes the theory of [dixon-1994]. Its premiss is that every language works in
+terms of three universal syntactic-semantic relations, S, A and O, §1.1, and that a language is
+ergative at some level of its grammar when that level treats S like O and unlike A, and
+accusative when it treats S like A and unlike O, §8.2. Morphological marking may be split,
+Chapter 4. A split conditioned by the verb, §4.1, divides S into Sa, marked like A, and So,
+marked like O: a split-S language fixes each intransitive verb's class and a fluid-S language
+marks each instance of use by whether its referent controls the activity, and either system is
+accusative over Sa and ergative over So. A split conditioned by the NP, §4.2, follows the
+Nominal Hierarchy of Figure 4.5, from first person pronouns down to inanimate common nouns:
+accusative marking of O extends in from the left end and ergative marking of A from the right,
+the two segments either meeting, Dyirbal and Kuku-Yalanji, or overlapping in a tripartite
+zone, Cashinawa and Yidiny, while a gap in which neither applies would leave A and O
+undistinguished and is unattested, type (g) of the Appendix to Chapter 4. A split conditioned
+by tense, aspect or mood, §4.3, puts the ergative marking in the past or the perfective. At the
+level of inter-clausal syntax, Chapter 6, a pivot is the pair of functions, S/A or S/O, that an
+NP common to two linked clauses must bear in each; passive puts O into derived S and antipassive
+puts A into derived S, §6.1, so that passive alone feeds an S/A pivot for an NP in O function
+and antipassive alone feeds an S/O pivot for one in A function, which is why a language with a
+thoroughgoing S/O pivot must have an antipassive, §6.2.3. Of the eleven configurations of a
+common NP in two linked clauses, §6.2.1, English with its S/A pivot passivizes a clause in
+which the NP is O and Dyirbal with its S/O pivot antipassivizes one in which it is A, §6.2.2.
 
-This study file holds:
+## Implementation notes
 
-1. **The 22-language exemplar sample** spanning all five `AlignmentType`
-   values across the three WALS dimensions (Ch 98/99/100).
-2. **Cross-linguistic generalisations** including Dixon's NP-vs-pronoun
-   ergativity asymmetry, the absence of reverse-Dixon splits, and the
-   rarity of tripartite/active patterns.
-3. **Silverstein's hierarchy** as a threshold-based prominence function
-   with monotonicity proven, and the Dyirbal split as a specific instance.
-4. **Ditransitive alignment** ([haspelmath-2005]): the 6-language
-   indirective/secundative/neutral sample.
-5. **Fragment bridges**: theorems verifying the per-language alignment
-   classifications match the Fragment grammatical descriptions.
-6. **Bridges to `Syntax/Case/Alignment`**: theorems verifying
-   `marksAgent`/`marksPatient` projections agree with the case-assignment
-   functions on canonical S/A/P inputs.
+S, A and O are `ArgumentRole.S`, `.A` and `.P`, following the substrate's Comrie letters, and
+a marking of the core relations is any function out of `ArgumentRole`, so that ergativity and
+accusativity are the identifications of S the marking makes, as in `Alignment.coreSig`. The
+Nominal Hierarchy is a linear order with first person at the top; an NP-conditioned split is
+a pair of monotone marking functions, accusative marking an upper set and ergative a lower set,
+and the pattern at a position is the `AlignmentType` the two markings induce. The tables of
+§4.2 are given as cutoffs, with the optional accusative of Yidiny's proper names and kin terms
+counted as marking; Latin and Waga-Waga, the types with one marking absent or total, are given
+directly. Pivots and derivations are the framework of §6.2.1 over core functions, with the
+periphery as `none`; the constructions that satisfy a pivot without derivation, such as
+Dyirbal's *-ŋurra* and instrumentive, are recorded in the rows only. Not formalized: the
+markedness generalizations of §3.4, the bound-versus-free split of §4.2.1, the main-versus-
+subordinate split of §4.4, the universal category of subject of Chapter 5, and the mixed
+pivots of §6.2.4.
 
-WALS aggregate distribution theorems are kept with the WALS data, not here.
-Per-language Fragment-vs-WALS data-equality theorems are deliberately absent
-— see `feedback_no_per_lang_wals_grounding_in_studies` for the rationale.
+## References
+
+* [dixon-1994]
+* [dixon-1972]
+* [silverstein-1976]
+* [comrie-1978]
 -/
 
 namespace Dixon1994
 
 open Alignment
 
--- ============================================================================
--- §0. AlignmentProfile: the bundled per-language record (with its data here)
--- ============================================================================
-
-/-- A language's morphosyntactic alignment across the three case/agreement
-    domains (WALS Chs 98/99/100). The bundled per-language record for the
-    exemplar sample below; lives here with its data and analysis (relocated out
-    of the dissolved `Typology/Alignment.lean` — its only consumers are this
-    file and `Comrie1989`, which imports it). -/
-structure AlignmentProfile where
-  /-- Language name. -/
-  name : String
-  /-- ISO 639-3 code. -/
-  iso639 : String
-  /-- Ch 98: alignment of case marking of full NPs. -/
-  npAlignment : AlignmentType
-  /-- Ch 99: alignment of case marking of pronouns. -/
-  pronAlignment : AlignmentType
-  /-- Ch 100: alignment of verbal person marking. -/
-  verbAlignment : AlignmentType
-  /-- Notes on the alignment system. -/
-  notes : String := ""
-  deriving Repr, DecidableEq
-
-/-- Whether the language shows the classic NP-ergative / pronoun-accusative
-    split (Dixon's generalization). -/
-def AlignmentProfile.dixonSplit (p : AlignmentProfile) : Bool :=
-  p.npAlignment == .ergative && p.pronAlignment == .accusative
-
-/-- Whether all three alignment domains agree. -/
-def AlignmentProfile.fullyUniform (p : AlignmentProfile) : Bool :=
-  p.npAlignment == p.pronAlignment && p.pronAlignment == p.verbAlignment
-
--- ============================================================================
--- §1. The 22-language exemplar sample
--- ============================================================================
-
-/-- English: accusative case marking on pronouns (I/me, he/him), no case
-    on full NPs (neutral), and accusative verb agreement. -/
-def english : AlignmentProfile :=
-  { name := "English", iso639 := "eng"
-  , npAlignment := .neutral
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Case only on pronouns (I/me); verb agrees with S/A" }
-
-/-- Hindi-Urdu: split-ergative. Ergative case marking (-ne on A) in
-    perfective aspect for both NPs and pronouns. WALS codes the dominant
-    pattern as ergative for NPs, accusative for pronouns. Verb agreement
-    is neutral (agrees with unmarked argument). -/
-def hindiUrdu : AlignmentProfile :=
-  { name := "Hindi-Urdu", iso639 := "hin"
-  , npAlignment := .ergative
-  , pronAlignment := .accusative
-  , verbAlignment := .neutral
-  , notes := "Split ergative: -ne on A in perfective; verb agrees with unmarked arg" }
-
-/-- Basque: consistently ergative across all three domains. -/
-def basque : AlignmentProfile :=
-  { name := "Basque", iso639 := "eus"
-  , npAlignment := .ergative
-  , pronAlignment := .ergative
-  , verbAlignment := .ergative
-  , notes := "Consistently ergative; -k on A; verb cross-references abs and erg" }
-
-/-- Dyirbal (Pama-Nyungan, Australia): the textbook case of split
-    ergativity. NPs ergative, 1st/2nd person pronouns accusative.
-    No verb person agreement. -/
-def dyirbal : AlignmentProfile :=
-  { name := "Dyirbal", iso639 := "dbl"
-  , npAlignment := .ergative
-  , pronAlignment := .accusative
-  , verbAlignment := .neutral
-  , notes := "Dixon's (1972) textbook split-ergative: NPs erg, pronouns acc" }
-
-/-- Georgian: active (split-S) alignment determined by verb class. -/
-def georgian : AlignmentProfile :=
-  { name := "Georgian", iso639 := "kat"
-  , npAlignment := .active
-  , pronAlignment := .active
-  , verbAlignment := .active
-  , notes := "Active (split-S); verb class determines S alignment" }
-
-/-- Tagalog: WALS codes Philippine voice system as neutral. -/
-def tagalog : AlignmentProfile :=
-  { name := "Tagalog", iso639 := "tgl"
-  , npAlignment := .neutral
-  , pronAlignment := .neutral
-  , verbAlignment := .neutral
-  , notes := "Philippine voice system; WALS codes as neutral" }
-
-/-- Japanese: accusative NPs and pronouns; no verb agreement. -/
-def japanese : AlignmentProfile :=
-  { name := "Japanese", iso639 := "jpn"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .neutral
-  , notes := "ga/o case particles; no verb agreement" }
-
-/-- Latin: accusative NPs, pronouns, verb agreement. -/
-def latin : AlignmentProfile :=
-  { name := "Latin", iso639 := "lat"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Nom/acc case; verb agrees with S/A" }
-
-/-- Russian: accusative across all three domains. -/
-def russian : AlignmentProfile :=
-  { name := "Russian", iso639 := "rus"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Nom/acc; animacy-conditioned acc syncretism" }
-
-/-- Mandarin Chinese: neutral across all three. -/
-def mandarin : AlignmentProfile :=
-  { name := "Mandarin Chinese", iso639 := "cmn"
-  , npAlignment := .neutral
-  , pronAlignment := .neutral
-  , verbAlignment := .neutral
-  , notes := "No case, no agreement; word order encodes relations" }
-
-/-- Turkish: accusative. -/
-def turkish : AlignmentProfile :=
-  { name := "Turkish", iso639 := "tur"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Nom/acc case with DOM; verb agrees with S/A" }
-
-/-- Tongan (Austronesian): ergative on NPs and pronouns; no verb agreement. -/
-def tongan : AlignmentProfile :=
-  { name := "Tongan", iso639 := "ton"
-  , npAlignment := .ergative
-  , pronAlignment := .ergative
-  , verbAlignment := .neutral
-  , notes := "Ergative case on both NPs and pronouns; no verb agreement" }
-
-/-- Guarani (Tupian): active verb agreement with split-S prefixes. -/
-def guarani : AlignmentProfile :=
-  { name := "Guarani", iso639 := "grn"
-  , npAlignment := .neutral
-  , pronAlignment := .neutral
-  , verbAlignment := .active
-  , notes := "Active verb agreement; oral/nasal prefix split for S" }
-
-/-- Samoan: ergative NPs (e before A), accusative pronouns. -/
-def samoan : AlignmentProfile :=
-  { name := "Samoan", iso639 := "smo"
-  , npAlignment := .ergative
-  , pronAlignment := .accusative
-  , verbAlignment := .neutral
-  , notes := "Ergative NPs (e before A); accusative pronouns" }
-
-/-- German: accusative. -/
-def german : AlignmentProfile :=
-  { name := "German", iso639 := "deu"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Nom/acc case; verb agrees with S/A" }
-
-/-- Swahili (Bantu): no case, accusative verb agreement (subject prefix). -/
-def swahili : AlignmentProfile :=
-  { name := "Swahili", iso639 := "swh"
-  , npAlignment := .neutral
-  , pronAlignment := .neutral
-  , verbAlignment := .accusative
-  , notes := "No case; S/A subject prefix on verb" }
-
-/-- Tibetan (Lhasa): ergative NPs and pronouns; no verb agreement. -/
-def tibetan : AlignmentProfile :=
-  { name := "Tibetan (Lhasa)", iso639 := "bod"
-  , npAlignment := .ergative
-  , pronAlignment := .ergative
-  , verbAlignment := .neutral
-  , notes := "Ergative -gis, -kyis on A; no verb agreement" }
-
-/-- Nez Perce: tripartite NPs and pronouns (distinct nom, erg, acc);
-    accusative verb agreement. -/
-def nezPerce : AlignmentProfile :=
-  { name := "Nez Perce", iso639 := "nez"
-  , npAlignment := .tripartite
-  , pronAlignment := .tripartite
-  , verbAlignment := .accusative
-  , notes := "Tripartite case: distinct nom, erg, acc" }
-
-/-- Finnish: accusative. -/
-def finnish : AlignmentProfile :=
-  { name := "Finnish", iso639 := "fin"
-  , npAlignment := .accusative
-  , pronAlignment := .accusative
-  , verbAlignment := .accusative
-  , notes := "Nom/acc(partitive); verb agrees with S/A" }
-
-/-- Warlpiri (Pama-Nyungan): split-ergative — ergative NPs, accusative
-    pronouns; no verb agreement. -/
-def warlpiri : AlignmentProfile :=
-  { name := "Warlpiri", iso639 := "wbp"
-  , npAlignment := .ergative
-  , pronAlignment := .accusative
-  , verbAlignment := .neutral
-  , notes := "Split ergative: NPs erg, pronouns acc; free word order" }
-
-/-- Dargwa (Tanti; [sumbatova-2021]): consistently ergative across
-    all three domains. -/
-def dargwa : AlignmentProfile :=
-  { name := "Dargwa (Tanti)", iso639 := "dar"
-  , npAlignment := .ergative
-  , pronAlignment := .ergative
-  , verbAlignment := .ergative
-  , notes := "Consistently ergative; -li on A; gender agrees with absolutive" }
-
-/-- Yukatek Maya ([bohnemeyer-2004]): aspect-conditioned split
-    intransitivity — perfective triggers ergative-like marking, imperfective
-    triggers accusative-like marking. -/
-def yukatek : AlignmentProfile :=
-  { name := "Yukatek Maya", iso639 := "yua"
-  , npAlignment := .neutral
-  , pronAlignment := .neutral
-  , verbAlignment := .active
-  , notes := "Aspect-conditioned split-S: PRV → erg (set-B), IMPFV → acc (set-A)" }
-
-/-- All 22 alignment profiles. -/
-def allProfiles : List AlignmentProfile :=
-  [ english, hindiUrdu, basque, dyirbal, georgian, tagalog
-  , japanese, latin, russian, mandarin, turkish, tongan
-  , guarani, samoan, german, swahili, tibetan, nezPerce
-  , finnish, warlpiri, dargwa, yukatek ]
-
-theorem allProfiles_count : allProfiles.length = 22 := by native_decide
-
--- ============================================================================
--- §2. Sample-level statistics
--- ============================================================================
-
-theorem all_iso_nonempty :
-    allProfiles.all (λ p => p.iso639.length > 0) = true := by native_decide
-
-theorem all_iso_length_3 :
-    allProfiles.all (λ p => p.iso639.length == 3) = true := by native_decide
-
-theorem iso_codes_unique :
-    (allProfiles.map (·.iso639)).eraseDups.length = allProfiles.length := by
-  native_decide
-
-/-- Sample distribution counts. -/
-theorem sample_counts :
-    (allProfiles.filter (λ p => p.npAlignment == .ergative)).length = 8 ∧
-    (allProfiles.filter (λ p => p.pronAlignment == .ergative)).length = 4 ∧
-    (allProfiles.filter (·.dixonSplit)).length = 4 ∧
-    (allProfiles.filter (·.fullyUniform)).length = 10 := by
-  native_decide
-
--- ============================================================================
--- §3. Cross-linguistic generalisations (Dixon 1994)
--- ============================================================================
-
-/-- Accusative is the most common alignment for pronouns
-    ([dixon-1994]'s prominence hierarchy prediction). -/
-theorem accusative_most_common_pronouns :
-    (allProfiles.filter (fun p => p.pronAlignment == .accusative)).length >=
-    (allProfiles.filter (fun p => p.pronAlignment == .ergative)).length := by
-  native_decide
-
-/-- [dixon-1994]'s generalisation: ergative case marking is more
-    common on full NPs than on pronouns. -/
-theorem dixon_generalization :
-    (allProfiles.filter (fun p => p.npAlignment == .ergative)).length >
-    (allProfiles.filter (fun p => p.pronAlignment == .ergative)).length := by
-  native_decide
-
-/-- Split ergativity (NP-ergative + pronoun-accusative) is attested in
-    multiple languages (Dyirbal, Hindi-Urdu, Samoan, Warlpiri). -/
-theorem split_ergativity_attested :
-    (allProfiles.filter (fun p => p.dixonSplit)).length >= 4 := by
-  native_decide
-
-/-- The reverse-Dixon pattern (accusative NPs + ergative pronouns) is
-    predicted not to occur. The sample confirms it: whenever pronouns are
-    ergative, NPs are at least ergative too. -/
-theorem no_reverse_dixon :
-    allProfiles.all (fun p =>
-      if p.pronAlignment == .ergative
-      then p.npAlignment == .ergative || p.npAlignment == .tripartite
-      else true) = true := by
-  native_decide
-
-/-- Tripartite NP alignment is rare: only Nez Perce in the sample. -/
-theorem tripartite_rare_nps :
-    (allProfiles.filter (fun p => p.npAlignment == .tripartite)).length <= 1 := by
-  native_decide
-
-/-- Tripartite pronoun alignment is equally rare. -/
-theorem tripartite_rare_pronouns :
-    (allProfiles.filter (fun p => p.pronAlignment == .tripartite)).length <= 1 := by
-  native_decide
-
-/-- Active alignment is rare for case marking: only Georgian in the sample. -/
-theorem active_rare_case :
-    (allProfiles.filter (fun p => p.npAlignment == .active)).length <= 2 := by
-  native_decide
-
-/-- Aspect-conditioned split intransitivity ([bohnemeyer-2004]):
-    Yukatek Maya and Georgian both show active verbal person marking. -/
-theorem aspect_split_languages :
-    (allProfiles.filter (fun p => p.verbAlignment == .active)).length >= 2 := by
-  native_decide
-
-theorem yukatek_and_georgian_both_active :
-    yukatek.verbAlignment = .active ∧ georgian.verbAlignment = .active :=
-  ⟨rfl, rfl⟩
-
-/-- Languages with ergative NP marking tend to have ergative or neutral
-    verbal person marking (or accusative as a third option). -/
-theorem erg_np_verb_pattern :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .ergative
-      then p.verbAlignment == .ergative || p.verbAlignment == .neutral ||
-           p.verbAlignment == .accusative
-      else true) = true := by
-  native_decide
-
-/-- All five alignment types are attested for NPs. -/
-theorem all_np_types_attested :
-    allProfiles.any (fun p => p.npAlignment == .neutral) &&
-    allProfiles.any (fun p => p.npAlignment == .accusative) &&
-    allProfiles.any (fun p => p.npAlignment == .ergative) &&
-    allProfiles.any (fun p => p.npAlignment == .tripartite) &&
-    allProfiles.any (fun p => p.npAlignment == .active) = true := by
-  native_decide
-
-/-- All five alignment types are attested for pronouns. -/
-theorem all_pron_types_attested :
-    allProfiles.any (fun p => p.pronAlignment == .neutral) &&
-    allProfiles.any (fun p => p.pronAlignment == .accusative) &&
-    allProfiles.any (fun p => p.pronAlignment == .ergative) &&
-    allProfiles.any (fun p => p.pronAlignment == .tripartite) &&
-    allProfiles.any (fun p => p.pronAlignment == .active) = true := by
-  native_decide
-
-/-- Four of the five alignment types are attested for verbal person marking;
-    tripartite verb agreement is exceedingly rare cross-linguistically and
-    not represented here. -/
-theorem verb_types_attested :
-    allProfiles.any (fun p => p.verbAlignment == .neutral) &&
-    allProfiles.any (fun p => p.verbAlignment == .accusative) &&
-    allProfiles.any (fun p => p.verbAlignment == .ergative) &&
-    allProfiles.any (fun p => p.verbAlignment == .active) = true := by
-  native_decide
-
-theorem tripartite_verb_unattested :
-    allProfiles.all (fun p => p.verbAlignment != .tripartite) = true := by
-  native_decide
-
-/-- Neutral NP alignment implies neutral or accusative pronoun alignment
-    (English-style: case survives only on pronouns). Never ergative. -/
-theorem neutral_np_pronoun :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .neutral
-      then p.pronAlignment == .neutral || p.pronAlignment == .accusative
-      else true) = true := by
-  native_decide
-
-/-- Fully uniform alignment is common (Basque, Mandarin, Latin, Russian,
-    Turkish, Georgian, etc.). -/
-theorem uniform_common :
-    (allProfiles.filter (fun p => p.fullyUniform)).length >= 5 := by
-  native_decide
-
-/-- Among languages with non-neutral verb alignment, accusative agreement
-    is the most common (verb agrees with S/A). -/
-theorem accusative_verb_dominant :
-    (allProfiles.filter (fun p => p.verbAlignment == .accusative)).length >
-    (allProfiles.filter (fun p => p.verbAlignment == .ergative)).length ∧
-    (allProfiles.filter (fun p => p.verbAlignment == .accusative)).length >
-    (allProfiles.filter (fun p => p.verbAlignment == .active)).length := by
-  native_decide
-
--- ============================================================================
--- §4. Cross-domain correlation patterns
--- ============================================================================
-
-/-- Every language with accusative NP case also has accusative pronoun case
-    in the sample. Accusative does not split across NP/pronoun like ergative. -/
-theorem accusative_np_implies_accusative_pron :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .accusative
-      then p.pronAlignment == .accusative
-      else true) = true := by
-  native_decide
-
-/-- No language has tripartite NP without tripartite pronoun in the sample. -/
-theorem tripartite_np_implies_tripartite_pron :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .tripartite
-      then p.pronAlignment == .tripartite
-      else true) = true := by
-  native_decide
-
-/-- Active NP alignment implies active pronoun alignment in the sample. -/
-theorem active_np_implies_active_pron :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .active
-      then p.pronAlignment == .active
-      else true) = true := by
-  native_decide
-
--- ============================================================================
--- §5. Type-level alignment properties
--- ============================================================================
-
-/-- Languages with no case on NPs do not have ergative NP alignment. -/
-theorem neutral_np_not_ergative :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .neutral then !p.npAlignment.marksAgent
-      else true) = true := by
-  native_decide
-
-/-- Languages with tripartite case mark both A and P. -/
-theorem tripartite_marks_both :
-    allProfiles.all (fun p =>
-      if p.npAlignment == .tripartite
-      then p.npAlignment.marksAgent && p.npAlignment.marksPatient
-      else true) = true := by
-  native_decide
-
-/-- Ergative alignment marks agent but not patient (S = P grouping). -/
-theorem ergative_marks_agent_only :
-    AlignmentType.ergative.marksAgent = true ∧
-    AlignmentType.ergative.marksPatient = false := by native_decide
-
-/-- Accusative alignment marks patient but not agent (S = A grouping). -/
-theorem accusative_marks_patient_only :
-    AlignmentType.accusative.marksPatient = true ∧
-    AlignmentType.accusative.marksAgent = false := by native_decide
-
--- ============================================================================
--- §6. Silverstein hierarchy (1976)
--- ============================================================================
-
-/-! [silverstein-1976] predicts that ergative marking targets the **less
-    prominent** end of the animacy/definiteness scale. More prominent NPs
-    (pronouns, 1st/2nd person) get accusative treatment; less prominent NPs
-    (full NPs, 3rd person, inanimate) get ergative treatment. -/
-
-section SilversteinSplit
-
-open Features.Prominence (AnimacyLevel)
-
-/-- Silverstein's hierarchy: NPs at or above the prominence threshold get
-    accusative alignment; those below get ergative. -/
-def silverstein (threshold : Nat) (npProminence : Nat) : AlignmentFamily :=
-  if npProminence ≥ threshold then .accusative else .ergative
-
-/-- Silverstein is monotone: if prominence p₁ ≥ p₂ and p₂ gets accusative,
-    then p₁ gets accusative. -/
-theorem silverstein_monotone (threshold p₁ p₂ : Nat)
-    (h_ge : p₁ ≥ p₂) (h_acc : silverstein threshold p₂ = .accusative) :
-    silverstein threshold p₁ = .accusative := by
-  simp only [silverstein] at *
-  split at h_acc
-  · split
-    · rfl
-    · omega
-  · contradiction
-
-/-- Silverstein predicts Dixon's generalisation: with threshold 1, full NPs
-    (prominence 0) get ergative, pronouns (prominence 1) get accusative. -/
-theorem silverstein_predicts_dixon :
-    silverstein 1 0 = .ergative ∧ silverstein 1 1 = .accusative := ⟨rfl, rfl⟩
-
-/-- [dixon-1972] Dyirbal split: human/animate → accusative,
-    inanimate → ergative. -/
-def dyirbalSplit : Alignment.SplitErgativity AnimacyLevel :=
-  { ergCondition := fun a => a == .inanimate }
-
-theorem dyirbal_human_acc :
-    dyirbalSplit.alignment .human = .accusative := rfl
-
-theorem dyirbal_inanimate_erg :
-    dyirbalSplit.alignment .inanimate = .ergative := rfl
-
-/-- Dyirbal split matches the Dyirbal alignment profile: inanimate NPs get
-    ergative alignment. -/
-theorem dyirbal_split_matches_np :
-    (dyirbalSplit.alignment .inanimate).toAlignmentType
-    = dyirbal.npAlignment := rfl
-
-/-- Human/animate arguments get accusative alignment. -/
-theorem dyirbal_split_matches_pron :
-    (dyirbalSplit.alignment .human).toAlignmentType
-    = dyirbal.pronAlignment := rfl
-
-end SilversteinSplit
-
--- ============================================================================
--- §7. Ditransitive alignment ([haspelmath-2005])
--- ============================================================================
-
-def ditrans_english : DitransitiveProfile :=
-  { name := "English", iso639 := "eng"
-  , alignment := .indirective
-  , notes := "T = P (acc); R marked with 'to'" }
-
-def ditrans_german : DitransitiveProfile :=
-  { name := "German", iso639 := "deu"
-  , alignment := .indirective
-  , notes := "T = accusative; R = dative" }
-
-def ditrans_latin : DitransitiveProfile :=
-  { name := "Latin", iso639 := "lat"
-  , alignment := .indirective
-  , notes := "T = accusative; R = dative" }
-
-def ditrans_japanese : DitransitiveProfile :=
-  { name := "Japanese", iso639 := "jpn"
-  , alignment := .indirective
-  , notes := "T = o (accusative); R = ni (dative)" }
-
-def ditrans_swahili : DitransitiveProfile :=
-  { name := "Swahili", iso639 := "swh"
-  , alignment := .secundative
-  , notes := "R = P in applicative; T marked differently" }
-
-def ditrans_mandarin : DitransitiveProfile :=
-  { name := "Mandarin", iso639 := "cmn"
-  , alignment := .neutral
-  , notes := "R and T both unmarked; order distinguishes" }
-
-def allDitransProfiles : List DitransitiveProfile :=
-  [ ditrans_english, ditrans_german, ditrans_latin
-  , ditrans_japanese, ditrans_swahili, ditrans_mandarin ]
-
-theorem ditrans_indirective_attested :
-    allDitransProfiles.any (λ p => p.alignment == .indirective) = true := by
-  native_decide
-
-theorem ditrans_secundative_attested :
-    allDitransProfiles.any (λ p => p.alignment == .secundative) = true := by
-  native_decide
-
-theorem ditrans_neutral_attested :
-    allDitransProfiles.any (λ p => p.alignment == .neutral) = true := by
-  native_decide
-
-/-- Indirective is more common than secundative (parallel to accusative
-    being more common than ergative for monotransitives). -/
-theorem ditrans_indirective_more_common :
-    (allDitransProfiles.filter (λ p => p.alignment == .indirective)).length >
-    (allDitransProfiles.filter (λ p => p.alignment == .secundative)).length := by
-  native_decide
-
--- ============================================================================
--- §8. Fragment bridges
--- ============================================================================
-
-/-! Theorems verifying that the inline `AlignmentProfile` entries are
-    consistent with the grammatical facts described in each language's
-    Fragment directory. -/
-
-/-- Dargwa: Fragment says A=ERG, S/P=ABS → Typology says ergative NP
-    alignment. -/
-theorem dargwa_fragment_bridge :
-    Dargwa.Case.agentCase = .erg ∧
-    Dargwa.Case.patientCase = .abs ∧
-    dargwa.npAlignment = .ergative := ⟨rfl, rfl, rfl⟩
-
-/-- Dargwa: Fragment alignment family is ergative → Typology profile is
-    consistently ergative. -/
-theorem dargwa_alignment_family_bridge :
-    Dargwa.Case.alignment.toAlignmentType
-    = dargwa.npAlignment := rfl
-
-/-- Japanese: Fragment case inventory contains NOM and ACC → Typology says
-    accusative NP alignment. -/
-theorem japanese_fragment_bridge :
-    .nom ∈ Japanese.Case.caseInventory ∧
-    .acc ∈ Japanese.Case.caseInventory ∧
-    japanese.npAlignment = .accusative := ⟨by decide, by decide, rfl⟩
-
-/-- Hindi: Fragment split-ergative system perfective → ERG matches
-    Typology's ergative NP alignment. -/
-theorem hindi_fragment_bridge :
-    Alignment.hindiSplit.alignment .perfective = .ergative ∧
-    (Alignment.hindiSplit.alignment .perfective).toAlignmentType
-      = hindiUrdu.npAlignment := ⟨rfl, rfl⟩
-
-/-- Hindi: Fragment imperfective → ACC matches Typology's accusative
-    pronoun alignment. -/
-theorem hindi_split_bridge :
-    Alignment.hindiSplit.alignment .imperfective = .accusative ∧
-    (Alignment.hindiSplit.alignment .imperfective).toAlignmentType
-      = hindiUrdu.pronAlignment := ⟨rfl, rfl⟩
-
--- ============================================================================
--- §9. Bridges to Syntax/Case/Alignment
--- ============================================================================
-
-/-! The typology classifier `AlignmentType` (substrate) and the
-    case-assignment functions `_root_.Alignment.X.assignCase`
-    (`Syntax/Case/Alignment.lean`) are two views of the same
-    alignment dimension. The bridge theorems confirm that the typology's
-    `marksAgent`/`marksPatient` Bool projections agree pointwise with what
-    the case-assignment functions actually do on the canonical S/A/P inputs. -/
-
-section BridgesToTheoriesAlignment
-
-
-theorem ergative_function_marks_A :
-    (_root_.Alignment.ergative.assignCase .A != _root_.Alignment.ergative.assignCase .S) =
-      AlignmentType.ergative.marksAgent := by decide
-
-theorem ergative_function_does_not_mark_P :
-    (_root_.Alignment.ergative.assignCase .P != _root_.Alignment.ergative.assignCase .S) =
-      AlignmentType.ergative.marksPatient := by decide
-
-theorem accusative_function_marks_P :
-    (_root_.Alignment.nominativeAccusative.assignCase .P
-        != _root_.Alignment.nominativeAccusative.assignCase .S) =
-      AlignmentType.accusative.marksPatient := by decide
-
-theorem accusative_function_does_not_mark_A :
-    (_root_.Alignment.nominativeAccusative.assignCase .A
-        != _root_.Alignment.nominativeAccusative.assignCase .S) =
-      AlignmentType.accusative.marksAgent := by decide
-
-/-- Extended ergative is non-canonical (no `AlignmentType` constructor): it
-    groups S with A like accusative does, but marks them with GEN rather than
-    NOM. The Cholan non-perfective pattern is captured by the function only. -/
-theorem extendedErgative_groups_S_with_A_like_accusative :
-    (_root_.Alignment.extendedErgative.assignCase .S
-        = _root_.Alignment.extendedErgative.assignCase .A) ∧
-    _root_.Alignment.extendedErgative.assignCase .A ≠
-      _root_.Alignment.nominativeAccusative.assignCase .A := ⟨rfl, by decide⟩
-
-end BridgesToTheoriesAlignment
+/-! ### S, A and O, §1.1 and §8.2 -/
+
+variable {κ : Type*}
+
+/-- A marking of the core relations, by case, cross-referencing or constituent order, treats S
+like O and unlike A: ergativity at that level of the grammar, §8.2. -/
+def IsErgative (m : ArgumentRole → κ) : Prop := m .S = m .P ∧ m .S ≠ m .A
+
+/-- The marking treats S like A and unlike O: accusativity. -/
+def IsAccusative (m : ArgumentRole → κ) : Prop := m .S = m .A ∧ m .S ≠ m .P
+
+theorem isErgative_ergative : IsErgative ergative.assignCase := ⟨rfl, by decide⟩
+
+theorem isAccusative_nominativeAccusative : IsAccusative nominativeAccusative.assignCase :=
+  ⟨rfl, by decide⟩
+
+/-- No marking is ergative and accusative at once, since S can be identified with only one of A
+and O; a language is ergative in some parts of its grammar and accusative in others. -/
+theorem IsAccusative.not_isErgative {m : ArgumentRole → κ} (h : IsAccusative m) :
+    ¬ IsErgative m :=
+  λ h' => h.2 h'.1
+
+/-! ### Splits conditioned by the verb, §4.1 -/
+
+/-- The two subtypes of S in a split-S or fluid-S language: Sa, marked like A, and So, marked
+like O. -/
+inductive SClass
+  | sa
+  | so
+  deriving DecidableEq, Repr
+
+/-- A fluid-S system, §4.1.2: the S of an instance of use is Sa when its referent controls the
+activity and So otherwise. A split-S system, §4.1.1, is instead a fixed class for each verb. -/
+def fluidS {I : Type*} (control : I → Prop) [DecidablePred control] (i : I) : SClass :=
+  if control i then .sa else .so
+
+/-- The marking of an S of class `c` under a transitive marking `m`: like A or like O. -/
+def SClass.marking (m : ArgumentRole → κ) : SClass → ArgumentRole → κ
+  | c, .S => match c with
+    | .sa => m .A
+    | .so => m .P
+  | _, r => m r
+
+/-- A split system is a mixture of the two simple patterns, §4.1.1: over Sa verbs it is
+accusative and over So verbs ergative, whenever A and O are distinguished. -/
+theorem marking_sa_so {m : ArgumentRole → κ} (h : m .A ≠ m .P) :
+    IsAccusative (SClass.sa.marking m) ∧ IsErgative (SClass.so.marking m) :=
+  ⟨⟨rfl, h⟩, ⟨rfl, h.symm⟩⟩
+
+/-! ### Splits conditioned by the NP: the Nominal Hierarchy, §4.2 -/
+
+/-- The Nominal Hierarchy, Figure 4.5, by likelihood of being in A rather than in O function:
+first person pronouns, second person pronouns, demonstratives and third person pronouns,
+proper names, then common nouns with human, animate and inanimate reference. -/
+inductive Nominal
+  | firstPerson
+  | secondPerson
+  | thirdPerson
+  | properName
+  | human
+  | animate
+  | inanimate
+  deriving DecidableEq, Repr, Fintype
+
+/-- Position on the hierarchy, higher to the left. -/
+def Nominal.rank : Nominal → ℕ
+  | .firstPerson => 6
+  | .secondPerson => 5
+  | .thirdPerson => 4
+  | .properName => 3
+  | .human => 2
+  | .animate => 1
+  | .inanimate => 0
+
+instance : LinearOrder Nominal :=
+  LinearOrder.lift' Nominal.rank λ a b h => by cases a <;> cases b <;> simp_all [Nominal.rank]
+
+variable {H : Type*} [LinearOrder H]
+
+/-- An NP-conditioned split, §4.2: accusative marking of O extends in from the left of the
+hierarchy over an upper set of positions, and ergative marking of A extends in from the right
+over a lower set. -/
+structure HierarchySplit (H : Type*) [LinearOrder H] where
+  /-- The positions whose O is marked accusative. -/
+  accusative : H → Bool
+  /-- The positions whose A is marked ergative. -/
+  ergative : H → Bool
+  accusative_mono : ∀ p q, p ≤ q → accusative p → accusative q
+  ergative_anti : ∀ p q, p ≤ q → ergative q → ergative p
+
+namespace HierarchySplit
+
+variable (s : HierarchySplit H) (p q : H)
+
+/-- The pattern at a position: accusative where only O is marked, ergative where only A is,
+tripartite where both are, and neutral, all three functions alike, where neither is. -/
+def pattern : AlignmentType :=
+  if s.accusative p then (if s.ergative p then .tripartite else .accusative)
+  else (if s.ergative p then .ergative else .neutral)
+
+/-- The two markings must at least meet, §4.2: A and O are distinguished at a position exactly
+when one of them applies there. -/
+theorem marks_iff :
+    (s.pattern p).marksAgent ∨ (s.pattern p).marksPatient ↔ s.accusative p ∨ s.ergative p := by
+  unfold pattern
+  split_ifs <;> simp_all [AlignmentType.marksAgent, AlignmentType.marksPatient]
+
+theorem pattern_eq_accusative_iff :
+    s.pattern p = .accusative ↔ s.accusative p ∧ ¬ s.ergative p := by
+  unfold pattern; split_ifs <;> simp_all
+
+theorem pattern_eq_ergative_iff : s.pattern p = .ergative ↔ ¬ s.accusative p ∧ s.ergative p := by
+  unfold pattern; split_ifs <;> simp_all
+
+theorem pattern_eq_tripartite_iff :
+    s.pattern p = .tripartite ↔ s.accusative p ∧ s.ergative p := by
+  unfold pattern; split_ifs <;> simp_all
+
+theorem pattern_eq_neutral_iff : s.pattern p = .neutral ↔ ¬ s.accusative p ∧ ¬ s.ergative p := by
+  unfold pattern; split_ifs <;> simp_all
+
+variable {s p q}
+
+/-- Above an accusative position the pattern stays accusative. -/
+theorem pattern_eq_accusative (h : s.pattern p = .accusative) (hpq : p ≤ q) :
+    s.pattern q = .accusative := by
+  rw [pattern_eq_accusative_iff] at *
+  exact ⟨s.accusative_mono p q hpq h.1, λ hq => h.2 (s.ergative_anti p q hpq hq)⟩
+
+/-- Below an ergative position the pattern stays ergative. -/
+theorem pattern_eq_ergative (h : s.pattern q = .ergative) (hpq : p ≤ q) :
+    s.pattern p = .ergative := by
+  rw [pattern_eq_ergative_iff] at *
+  exact ⟨λ hp => h.1 (s.accusative_mono p q hpq hp), s.ergative_anti p q hpq h.2⟩
+
+/-- The overlap of the two markings and a gap between them exclude each other: a split is of
+type (d) of the Appendix to Chapter 4 or of the unattested type (g), never both. -/
+theorem not_tripartite_and_neutral (ht : s.pattern p = .tripartite)
+    (hn : s.pattern q = .neutral) : False := by
+  rw [pattern_eq_tripartite_iff] at ht
+  rw [pattern_eq_neutral_iff] at hn
+  rcases le_total p q with hpq | hqp
+  · exact hn.1 (s.accusative_mono p q hpq ht.1)
+  · exact hn.2 (s.ergative_anti q p hqp ht.2)
+
+/-- The split with accusative marking from the left down to `a` and ergative marking from the
+right up to `e`. -/
+def ofCutoffs (a e : H) : HierarchySplit H where
+  accusative p := decide (a ≤ p)
+  ergative p := decide (p ≤ e)
+  accusative_mono _ _ hpq h := by simpa using le_trans (by simpa using h) hpq
+  ergative_anti _ _ hpq h := by simpa using le_trans hpq (by simpa using h)
+
+end HierarchySplit
+
+/-- Dyirbal, Table 4.1: accusative for first and second person pronouns, ergative from third
+person pronouns rightwards, the two meeting without overlap. -/
+def dyirbal : HierarchySplit Nominal := .ofCutoffs .secondPerson .thirdPerson
+
+/-- Cashinawa, Table 4.2: accusative down to third person pronouns and ergative from third
+person pronouns rightwards, overlapping there. -/
+def cashinawa : HierarchySplit Nominal := .ofCutoffs .thirdPerson .thirdPerson
+
+/-- Yidiny, Table 4.3: accusative down to proper names and kin terms, ergative from human
+deictics rightwards, overlapping over the middle of the hierarchy. -/
+def yidiny : HierarchySplit Nominal := .ofCutoffs .properName .thirdPerson
+
+/-- Latin, type (a): accusative for pronouns and masculine and feminine nouns, no ergative, so
+that neuter nouns have one form for S, A and O. -/
+def latin : HierarchySplit Nominal where
+  accusative p := decide (.human ≤ p)
+  ergative _ := false
+  accusative_mono _ _ hpq h := by simpa using le_trans (by simpa using h) hpq
+  ergative_anti _ _ _ h := h
+
+/-- Waga-Waga, type (f), fn. 14: ergative on every NP constituent, accusative down to human
+common nouns, so that the left and middle of the hierarchy are tripartite. -/
+def wagaWaga : HierarchySplit Nominal where
+  accusative p := decide (.human ≤ p)
+  ergative _ := true
+  accusative_mono _ _ hpq h := by simpa using le_trans (by simpa using h) hpq
+  ergative_anti _ _ _ h := h
+
+/-- The patterns the cutoffs induce: Dyirbal's markings meet at third person pronouns, type
+(c); Cashinawa and Yidiny overlap in tripartite zones, type (d); Latin leaves neuter nouns
+neutral, type (a); Waga-Waga is tripartite down to human nouns and ergative below, type (f). -/
+theorem patterns :
+    (∀ p, dyirbal.pattern p ≠ .tripartite ∧ dyirbal.pattern p ≠ .neutral) ∧
+      dyirbal.pattern .secondPerson = .accusative ∧ dyirbal.pattern .thirdPerson = .ergative ∧
+      cashinawa.pattern .thirdPerson = .tripartite ∧ cashinawa.pattern .properName = .ergative ∧
+      yidiny.pattern .thirdPerson = .tripartite ∧ yidiny.pattern .properName = .tripartite ∧
+      yidiny.pattern .human = .ergative ∧ latin.pattern .animate = .neutral ∧
+      wagaWaga.pattern .human = .tripartite ∧ wagaWaga.pattern .animate = .ergative := by
+  decide
+
+/-! ### Splits conditioned by tense, aspect or mood, §4.3 -/
+
+/-- Dixon's generalization for an aspect-conditioned split: the ergative marking is found in
+the perfective, never in the imperfective alone. -/
+def AspectOriented (s : SplitErgativity Aspect) : Prop :=
+  s.ergCondition .imperfective → s.ergCondition .perfective
+
+theorem aspectOriented_hindiSplit : AspectOriented hindiSplit := λ h => nomatch h
+
+/-! ### Passive, antipassive and pivots, §6.1 and §6.2 -/
+
+/-- The two pivots, §6.2: the functions an NP common to two linked clauses must bear in each,
+S or A in a language with accusative syntax and S or O in one with ergative syntax. -/
+inductive Pivot
+  | SA
+  | SO
+  deriving DecidableEq, Repr, Fintype
+
+/-- Whether a core function is a pivot function. -/
+def Pivot.Admits : Pivot → ArgumentRole → Prop
+  | .SA, .S | .SA, .A => True
+  | .SO, .S | .SO, .P => True
+  | _, _ => False
+
+instance (π : Pivot) (r : ArgumentRole) : Decidable (π.Admits r) := by
+  cases π <;> cases r <;> unfold Pivot.Admits <;> infer_instance
+
+/-- The two derivations of §6.1, each forming an intransitive from a transitive clause. -/
+inductive Derivation
+  | passive
+  | antipassive
+  deriving DecidableEq, Repr, Fintype
+
+/-- The derived function of a core function: passive puts O into S and A into the periphery,
+antipassive puts A into S and O into the periphery, and the ditransitive roles are peripheral. -/
+def Derivation.apply : Derivation → ArgumentRole → Option ArgumentRole
+  | .passive, .P => some .S
+  | .antipassive, .A => some .S
+  | _, .S => some .S
+  | _, _ => none
+
+/-- A derivation feeds a pivot for an NP in function `r` when the derived function is a pivot
+function. -/
+def Feeds (π : Pivot) (d : Derivation) (r : ArgumentRole) : Prop :=
+  ∃ g, d.apply r = some g ∧ π.Admits g
+
+/-- A common NP needs a derivation in a clause exactly when its function there is not a pivot
+function: O under an S/A pivot and A under an S/O pivot. -/
+theorem not_admits_iff :
+    (∀ r ∈ ArgumentRole.core, ¬ Pivot.SA.Admits r ↔ r = .P) ∧
+      ∀ r ∈ ArgumentRole.core, ¬ Pivot.SO.Admits r ↔ r = .A := by
+  decide
+
+/-- Passive alone feeds an S/A pivot for an NP in O function, and antipassive alone feeds an
+S/O pivot for an NP in A function, §6.2.1 and §6.2.2; each derivation demotes the other
+function to the periphery. So a language with a thoroughgoing S/O pivot must have an
+antipassive, §6.2.3. -/
+theorem feeds_iff :
+    (∀ d, Feeds .SA d .P ↔ d = .passive) ∧ (∀ d, Feeds .SO d .A ↔ d = .antipassive) ∧
+      ¬ Feeds .SA .passive .A ∧ ¬ Feeds .SO .antipassive .P :=
+  ⟨λ d => by cases d <;> simp [Feeds, Derivation.apply, Pivot.Admits],
+    λ d => by cases d <;> simp [Feeds, Derivation.apply, Pivot.Admits],
+    (λ ⟨_, h, _⟩ => nomatch h), λ ⟨_, h, _⟩ => nomatch h⟩
+
+/-- Interchange A and O, leaving S and the ditransitive roles alone. -/
+def swapAO : ArgumentRole → ArgumentRole
+  | .A => .P
+  | .P => .A
+  | r => r
+
+/-- Passive and antipassive are parallel with A and O interchanged, §6.1. -/
+theorem apply_swapAO (r : ArgumentRole) :
+    Derivation.passive.apply r = Derivation.antipassive.apply (swapAO r) := by
+  cases r <;> rfl
 
 end Dixon1994

--- a/Linglib/Syntax/Case/Alignment.lean
+++ b/Linglib/Syntax/Case/Alignment.lean
@@ -241,8 +241,7 @@ theorem bell_three_eq_five :
 /-- The five `assignCase` functions realize only **three** of the five
     partitions: `nominativeAccusative`, `extendedErgative`, and `invertedErgative`
     all induce the accusative partition `{S,A}|{P}` — they differ only in Case
-    *labels*, not alignment (the kernel generalizing the one instance noticed in
-    `Dixon1994.extendedErgative_groups_S_with_A_like_accusative`). -/
+    *labels*, not alignment. -/
 theorem assignCase_partitions :
     coreSig nominativeAccusative.assignCase = (true, false, false) ∧
     coreSig extendedErgative.assignCase    = (true, false, false) ∧

--- a/references.bib
+++ b/references.bib
@@ -4399,7 +4399,7 @@
   role      = {cited},
   doi       = {10.1075/tilar.9.02com},
   validated = {true},
-  sources   = {Studies/Dixon1994.lean;Features/Prominence.lean}
+  sources   = {Studies/Comrie1989.lean;Studies/Dixon1994.lean;Syntax/Category/Verb/Argument.lean;Syntax/Clause/ArgumentRole.lean}
 }% REF: Hawkins, J. (1978). Definiteness and Indefiniteness. Croom Helm.
 @article{hawkins-1978,
   author    = {Hawkins, John},
@@ -5643,10 +5643,10 @@
   title     = {Ergativity},
   doi       = {10.1017/cbo9780511611896},
   publisher = {Cambridge University Press},
-  subfield  = {semantics/compositional},
-  role      = {cited},
+  subfield  = {typology/alignment},
+  role      = {formalized},
   validated = {true},
-  sources   = {Studies/Dixon1994.lean}
+  sources   = {Data/Examples/Dixon1994.json;Fragments/Mayan/Chol/Agreement.lean;Studies/Dixon1994.lean;Syntax/Case/Alignment.lean;Syntax/Voice/Alternation.lean}
 }% REF: Kanazawa, M. (1994). Weak vs. Strong Readings of Donkey Sentences.
 @article{kanazawa-1994,
   author    = {Kanazawa, Makoto},
@@ -5838,7 +5838,7 @@
   subfield  = {semantics/causation},
   role      = {formalized},
   validated = {true},
-  sources   = {Fragments/Mayan/Yukatek/VerbClasses.lean;Studies/Bohnemeyer2004.lean}
+  sources   = {Fragments/Mayan/Yukatek/VerbClasses.lean;Semantics/ArgumentStructure/EventStructure.lean;Studies/Bohnemeyer2004.lean}
 }% REF: Bochnak, M. R. (2015a). Underspecified modality in Washo.
 @inproceedings{bochnak-2015a,
   author    = {Bochnak, M Ryan},
@@ -7548,7 +7548,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/Dixon1994.lean;Syntax/Case/Alignment.lean}
+  sources   = {Syntax/Case/Alignment.lean}
 }% REF: Daniel, M. (2013). Plurality in Independent Personal Pronouns. In Dryer & Haspelmath (eds.), WALS Online (v2020.3). http
 @incollection{haspelmath-2013-ditransitive,
   author    = {Haspelmath, Martin},
@@ -7700,7 +7700,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {cited},
-  sources   = {Fragments/Dargwa/Case.lean;Fragments/Dargwa/Agreement.lean;Fragments/Dargwa/ComplexPredicates.lean;Fragments/Dargwa/Coordination.lean}
+  sources   = {Fragments/Dargwa/Agreement.lean;Fragments/Dargwa/Case.lean;Fragments/Dargwa/ComplexPredicates.lean;Fragments/Dargwa/Coordination.lean;Fragments/Dargwa/Locatives.lean}
 }% REF: van der Auwera, J. & Lejeune, L. (2013). The morphological imperative. In Dryer & Haspelmath (eds.), WALS Online (v2020.
 @incollection{van-der-auwera-lejeune-2013,
   author    = {van der Auwera, Johan and Lejeune, Ludo},
@@ -18239,7 +18239,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Features/Prominence.lean;Studies/Haspelmath2021.lean}
+  sources   = {Features/Person/Basic.lean;Features/Prominence.lean;Studies/Haspelmath2021.lean;Studies/Just2024.lean;Syntax/Category/Verb/Argument.lean;Syntax/Clause/ArgumentRole.lean}
 }
 @book{blake-1994,
   author    = {Blake, Barry J.},
@@ -18253,7 +18253,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {foundational},
-  sources   = {Features/Case/Capabilities.lean;Features/Case/Basic.lean;Syntax/Case/Alignment.lean;Morphology/Case/Allomorphy.lean;Syntax/Case/Order.lean;Syntax/RelativeClause/Basic.lean}
+  sources   = {Features/Case/Basic.lean;Features/Case/Capabilities.lean;Fragments/Basque/Agreement.lean;Fragments/Finnish/Case.lean;Fragments/Georgian/Agreement.lean;Fragments/German/Case.lean;Fragments/Greek/Case.lean;Fragments/Hindi/Case.lean;Fragments/Japanese/Case.lean;Fragments/Korean/Case.lean;Fragments/Latin/Case.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Mam/Agreement.lean;Fragments/Slavic/Belarusian/Case.lean;Fragments/Slavic/Case.lean;Fragments/Slavic/Cassubian/Case.lean;Fragments/Slavic/Czech/Case.lean;Fragments/Slavic/Polish/Case.lean;Fragments/Slavic/Russian/Case.lean;Fragments/Slavic/Serbian/Case.lean;Fragments/Slavic/Slovak/Case.lean;Fragments/Slavic/Slovenian/Case.lean;Fragments/Slavic/Sorbian/Case.lean;Fragments/Slavic/Ukrainian/Case.lean;Fragments/Tamil/Case.lean;Fragments/Turkish/Case.lean;Studies/Caha2009.lean;Syntax/Case/Alignment.lean;Syntax/Case/Order.lean;Syntax/RelativeClause/Basic.lean}
 }
 @book{kenesei-vago-fenyvesi-1998,
   author    = {Kenesei, István and Vago, Robert M. and Fenyvesi, Anna},
@@ -24180,7 +24180,8 @@
   publisher = {Australian Institute of Aboriginal Studies},
   subfield  = {typology/alignment},
   validated = {true},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Pragmatics/SocialMeaning/IndexicalField.lean;Studies/Comrie1989.lean;Studies/Dixon1994.lean;Studies/Ochs1992.lean;Studies/PrasertsonSmithCulbertson2026.lean}
 }
 @article{silverstein-2003,
   author    = {Silverstein, Michael},
@@ -24216,7 +24217,8 @@
   url       = {https://www.cambridge.org/core/books/dyirbal-language-of-north-queensland/A53B5C30FC4A967E169EC02F806851C8},
     subfield  = {typology/alignment},
   validated = {true},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Studies/Comrie1989.lean;Studies/Corbett1991.lean;Studies/Dixon1994.lean}
 }
 @book{givon-1983,
   author    = {Giv{\'o}n, Talmy},
@@ -26822,6 +26824,7 @@
   doi       = {10.1349/ps1.1537-0852.a.280},
   subfield  = {typology/alignment},
   role      = {cited},
+  sources   = {Syntax/Case/Alignment.lean}
 }% REF: Prasertsom, P., Smith, K. & Culbertson, J. (2026). Domain-general categorisation
 @article{prasertsom-smith-culbertson-2026,
   author    = {Prasertsom, Ponrawee and Smith, Kenny and Culbertson, Jennifer},


### PR DESCRIPTION
Deep cleanse of Dixon (1994): the invented 22-language alignment sample, its `native_decide` count theorems, the Haspelmath 2005 ditransitive profiles, and the Fragment read-backs are replaced by the book's own theory.

- Ergativity and accusativity as identifications of S under any marking; split-S and fluid-S with the mixture theorem of §4.1; the Nominal Hierarchy of Figure 4.5 with NP-conditioned splits as monotone accusative and ergative segments, the meet condition, contiguity, and the exclusion of overlap and gap, with Dyirbal, Cashinawa, Yidiny, Latin and Waga-Waga as cutoffs whose patterns are computed.
- Pivots and derivations of §6.1 and §6.2: passive alone feeds an S/A pivot for O and antipassive alone an S/O pivot for A, so an S/O-pivot language needs an antipassive; passive and antipassive swap A and O.
- 39 rows: the Dyirbal coordination, purposive, relative and instrumentive examples of §1.2 and §6.2.2 and the English (a)–(k) of §6.2.1; `dixon-1994` marked formalized under typology/alignment; a stale cross-reference in `Syntax/Case/Alignment.lean` dropped.