### PR TITLE
refactor(Studies/Dolatian2020): cyclic strata and the prosodic stem

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3039,3 +3039,4 @@ import Linglib.Data.Examples.Denic2023
 import Linglib.Data.Examples.DenicEtAl2021
 import Linglib.Data.Examples.Deo2025
 import Linglib.Data.Examples.Dixon1994
+import Linglib.Data.Examples.Dolatian2020

--- a/Linglib/Data/Examples/Dolatian2020.json
+++ b/Linglib/Data/Examples/Dolatian2020.json
@@ -1,0 +1,460 @@
+[
+  {
+    "id": "dolatian2020_1",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(1)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "kórd͡z, kord͡z-avór, kord͡z-avor-nér, kord͡z-avor-nér-ə",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kórd͡z", "work"], ["kord͡z-avór", "work-er"], ["kord͡z-avor-nér", "work-er-PL"],
+      ["kord͡z-avor-nér-ə", "work-er-PL-with"]
+    ],
+    "translation": "work; worker; workers; with workers",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["process", "stress"]
+    ],
+    "comment": "Stress falls on the rightmost full vowel, whether in the root, a derivational suffix or an inflectional suffix, but never on a schwa.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_2",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(2)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "hín, hən-utjún; teʁín, teʁn-orág",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["hín", "old"], ["hən-utjún", "old-ness"], ["teʁín", "yellow"], ["teʁn-orág", "yellow-ish"]
+    ],
+    "translation": "old, oldness; yellow, yellowish",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "both"]
+    ],
+    "comment": "A destressed high vowel reduces to schwa, hín ~ hən-utjún, or deletes, teʁín ~ teʁn-orág.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_3b",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(3b)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "had͡záχ, had͡zaχ-él; darpér, darper-él",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["had͡záχ", "frequent"], ["had͡zaχ-él", "frequent-INF"], ["darpér", "different"],
+      ["darper-él", "different-INF"]
+    ],
+    "translation": "frequent, to frequent; different, to distinguish",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "had͡zχ-él", "judgment": "ungrammatical"},
+      {"form": "darpr-él", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "none"]
+    ],
+    "comment": "Low and mid vowels do not reduce when destressed.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_4",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(4)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "amusín, amusn-utjún; irigún, irign-ajín",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["amusín", "husband"], ["amusn-utjún", "husband-ness"], ["irigún", "evening"],
+      ["irign-ajín", "evening-ADJ"]
+    ],
+    "translation": "husband, marriage; evening, evening (adj.)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "amsin-utjún", "judgment": "ungrammatical"},
+      {"form": "irgun-ajín", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "deletion"]
+    ],
+    "comment": "Only the destressed high vowel reduces, the one stressed in the base and unstressed in the derivative; the other high vowels of the base stay.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_5a",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(5a)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "d͡zín, d͡zən-únt, d͡zən-ənt-agán",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["d͡zín", "birth"], ["d͡zən-únt", "birth-NMLZ"], ["d͡zən-ənt-agán", "birth-NMLZ-ADJ"]
+    ],
+    "translation": "birth; birth; generative",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "schwa"]
+    ],
+    "comment": "Unbounded cyclicity: reduction applies to a sequence of destressed high vowels, each new morpheme triggering a new cycle of stress shift and reduction.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_5c",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(5c)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "kír, kər-ít͡ʃ, dúp, kər-t͡ʃ-a-dup",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kír", "handwriting"], ["kər-ít͡ʃ", "handwriting-AGT"], ["dúp", "box"],
+      ["kər-t͡ʃ-a-dup", "handwriting-AGT-LV-box"]
+    ],
+    "translation": "handwriting; pen; box; pencil-box",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "compound"],
+      ["reduction", "both"]
+    ],
+    "comment": "Reduction applies to suffixes and in compounds: the suffix vowel of kər-ít͡ʃ is destressed and deleted in the compound.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_7a",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(7a)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "amusín, amusn-utjún, amusin-óv",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["amusín", "husband"], ["amusn-utjún", "husband-ness"], ["amusin-óv", "husband-INST"]
+    ],
+    "translation": "husband; marriage; husband (instrumental)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "vInflection"],
+      ["reduction", "none"]
+    ],
+    "comment": "In Western Armenian derivational suffixes trigger reduction and inflectional suffixes only stress shift: the stem-level against the word-level cophonology.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_7b",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(7b)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "zərújt͡s, zərut͡s-él, zərujt͡s-óv",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["zərújt͡s", "conversation"], ["zərut͡s-él", "conversation-INF"],
+      ["zərujt͡s-óv", "conversation-INST"]
+    ],
+    "translation": "conversation; to converse; conversation (instrumental)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "vInflection"],
+      ["reduction", "diphthong"]
+    ],
+    "comment": "The destressed diphthong uj reduces to u in derivation and not in inflection.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_10c",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(10c)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "amusn-óv",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["amusn-óv", "husband-INST"]
+    ],
+    "translation": "husband (instrumental)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "vInflection"],
+      ["reduction", "deletion"]
+    ],
+    "comment": "Vowel-initial inflection triggers reduction in Eastern Armenian: the resyllabified stem-final consonant misaligns the Prosodic Stem, which expands and triggers its own cophonology, (78).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_10e",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(10e)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "amusin-nér",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["amusin-nér", "husband-PL"]
+    ],
+    "translation": "husbands",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "cInflection"],
+      ["reduction", "none"]
+    ],
+    "comment": "Consonant-initial inflection leaves the Prosodic Stem aligned with the morphological stem and the syllable, so only the word-level cophonology applies, in both dialects.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_12a",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(12a)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "zərújt͡sʰ, zərut͡sʰ-él, zərújt͡sʰ-óv",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["zərújt͡sʰ", "conversation"], ["zərut͡sʰ-él", "conversation-INF"],
+      ["zərújt͡sʰ-óv", "conversation-INST"]
+    ],
+    "translation": "conversation; to converse; conversation (instrumental)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "vInflection"],
+      ["reduction", "diphthong"]
+    ],
+    "comment": "In both dialects the destressed diphthong reduces in derivation and not in inflection; Eastern vowel-initial inflection triggers high vowel reduction but not diphthong reduction, so the Prosodic Stem cophonology lies between the word-level and the stem-level, (76).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_41",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(41)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "darí, darí-k; kaxtní, kaxtní-k; parí, parí-k",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["darí", "year"], ["darí-k", "year-NMLZ"], ["kaxtní", "secret"], ["kaxtní-k", "secret-NMLZ"],
+      ["parí", "good"], ["parí-k", "good-NMLZ"]
+    ],
+    "translation": "year, age; secret (adj.), secret (n.); good, charity",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "none"]
+    ],
+    "comment": "A suffix without a full vowel cannot shift stress, so there is no destressed vowel and no reduction.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_42",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(42)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "amusín, amusn-utjún; aznív, aznəv-utjún",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["amusín", "husband"], ["amusn-utjún", "husband-ness"], ["aznív", "honest"],
+      ["aznəv-utjún", "honest-ness"]
+    ],
+    "translation": "husband, marriage; honest, honesty",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "amusən-utjún", "judgment": "ungrammatical"},
+      {"form": "aznv-utjún", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "both"]
+    ],
+    "comment": "Reduction deletes the vowel unless deletion would create an unsyllabifiable cluster, in which case the vowel is replaced by schwa, (46).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_47a",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(47a)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "hivánt, hivant-anál; hankíst, hankəst-anál; amusín, amusn-anál",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["hivánt", "sick"], ["hivant-anál", "sick-INCH"], ["hankíst", "relaxed"],
+      ["hankəst-anál", "relaxed-INCH"], ["amusín", "husband"], ["amusn-anál", "husband-INCH"]
+    ],
+    "translation": "sick, to become sick; relaxed, to relax; husband, to marry",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "həvant-anál", "judgment": "ungrammatical"},
+      {"form": "hankist-anál", "judgment": "ungrammatical"},
+      {"form": "amsin-anál", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "both"]
+    ],
+    "comment": "The derivation of (47b): the unstressed high vowel of hivánt does not reduce, the destressed vowel of hankíst reduces to schwa because deletion would leave an unsyllabifiable cluster, and that of amusín deletes.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_48a",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(48a)"},
+    "reportedIn": null,
+    "language": "homs1234",
+    "primaryText": "ázk, azk-ajín, azk-ajn-agán",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ázk", "nation"], ["azk-ajín", "nation-ADJ"], ["azk-ajn-agán", "nation-ADJ-ADJ"]
+    ],
+    "translation": "nation; national; nationalist",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "western"],
+      ["suffix", "derivational"],
+      ["reduction", "deletion"]
+    ],
+    "comment": "A destressed high vowel in a suffix reduces too.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_65",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(65)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "tʰúxtʰ, tʰəx.tʰ-í, tʰəx.tʰ-ít͡sʰ, tʰəx.tʰ-óv, tʰəx.tʰ-úm; amusín, amus.n-ú, amus.n-ít͡sʰ, amus.n-óv, amus.n-úm",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tʰúxtʰ", "paper"], ["tʰəx.tʰ-í", "paper-DAT"], ["tʰəx.tʰ-óv", "paper-INST"],
+      ["amusín", "husband"], ["amus.n-ú", "husband-DAT"], ["amus.n-óv", "husband-INST"]
+    ],
+    "translation": "paper and its case forms; husband and its case forms",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "vInflection"],
+      ["reduction", "both"]
+    ],
+    "comment": "All case suffixes are vowel-initial and Eastern Armenian reduces before each of them, Western Armenian before none: tux.t-í, amusi.n-óv.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_66",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(66)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "tʰəx.tʰ-ér, tʰəx.tʰ-er-óv; amusin.-nér, amusin.-ner-óv",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["tʰəx.tʰ-ér", "paper-PL"], ["tʰəx.tʰ-er-óv", "paper-PL-INST"],
+      ["amusin.-nér", "husband-PL"], ["amusin.-ner-óv", "husband-PL-INST"]
+    ],
+    "translation": "papers, with papers; husbands, with husbands",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "plural"],
+      ["reduction", "both"]
+    ],
+    "comment": "The plural is -er after monosyllabic bases and -ner after polysyllabic ones; the vowel-initial allomorph reduces the base and the consonant-initial one does not, whatever case follows.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "dolatian2020_72",
+    "source": {"bibkey": "dolatian-2020", "paperLabel": "(72)"},
+    "reportedIn": null,
+    "language": "nucl1235",
+    "primaryText": "manúk, mank-akán, mank-án, manuk-í; lúrd͡ʒ, lərd͡ʒ-anál, lurd͡ʒ-í; fílm, film-ajín, film-ér",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["manúk", "child"], ["mank-akán", "child-ish"], ["mank-án", "child-GEN.irregular"],
+      ["manuk-í", "child-GEN.regular"], ["lúrd͡ʒ", "serious"], ["lərd͡ʒ-anál", "serious-INCH"],
+      ["lurd͡ʒ-í", "serious-GEN"], ["fílm", "film"], ["film-ajín", "film-ADJ"],
+      ["film-ér", "film-PL"]
+    ],
+    "translation": "child, childish, child's; serious, to get serious, of the serious one; film, cinematic, films",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["dialect", "eastern"],
+      ["suffix", "vInflection"],
+      ["reduction", "none"]
+    ],
+    "comment": "Pre-inflectional reduction does not apply in regularized inflection, inflected adjectives or loanwords: it is a lexical process and not a post-cyclic word-level one, against the recursive prosodic word analysis of §2.5.3.2.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Dolatian2020.lean
+++ b/Linglib/Data/Examples/Dolatian2020.lean
@@ -1,0 +1,342 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Dolatian2020` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Dolatian2020.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Dolatian2020.Examples`.
+-/
+
+namespace Dolatian2020.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "dolatian2020_1"
+    source := ⟨"dolatian-2020", "(1)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "kórd͡z, kord͡z-avór, kord͡z-avor-nér, kord͡z-avor-nér-ə"
+    discourseSegments := []
+    glossedTokens := [("kórd͡z", "work"), ("kord͡z-avór", "work-er"), ("kord͡z-avor-nér", "work-er-PL"), ("kord͡z-avor-nér-ə", "work-er-PL-with")]
+    translation := "work; worker; workers; with workers"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("process", "stress")]
+    comment := "Stress falls on the rightmost full vowel, whether in the root, a derivational suffix or an inflectional suffix, but never on a schwa."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_2 : LinguisticExample :=
+  { id := "dolatian2020_2"
+    source := ⟨"dolatian-2020", "(2)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "hín, hən-utjún; teʁín, teʁn-orág"
+    discourseSegments := []
+    glossedTokens := [("hín", "old"), ("hən-utjún", "old-ness"), ("teʁín", "yellow"), ("teʁn-orág", "yellow-ish")]
+    translation := "old, oldness; yellow, yellowish"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "both")]
+    comment := "A destressed high vowel reduces to schwa, hín ~ hən-utjún, or deletes, teʁín ~ teʁn-orág."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_3b : LinguisticExample :=
+  { id := "dolatian2020_3b"
+    source := ⟨"dolatian-2020", "(3b)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "had͡záχ, had͡zaχ-él; darpér, darper-él"
+    discourseSegments := []
+    glossedTokens := [("had͡záχ", "frequent"), ("had͡zaχ-él", "frequent-INF"), ("darpér", "different"), ("darper-él", "different-INF")]
+    translation := "frequent, to frequent; different, to distinguish"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("had͡zχ-él", .ungrammatical), ("darpr-él", .ungrammatical)]
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "none")]
+    comment := "Low and mid vowels do not reduce when destressed."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_4 : LinguisticExample :=
+  { id := "dolatian2020_4"
+    source := ⟨"dolatian-2020", "(4)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "amusín, amusn-utjún; irigún, irign-ajín"
+    discourseSegments := []
+    glossedTokens := [("amusín", "husband"), ("amusn-utjún", "husband-ness"), ("irigún", "evening"), ("irign-ajín", "evening-ADJ")]
+    translation := "husband, marriage; evening, evening (adj.)"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("amsin-utjún", .ungrammatical), ("irgun-ajín", .ungrammatical)]
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "deletion")]
+    comment := "Only the destressed high vowel reduces, the one stressed in the base and unstressed in the derivative; the other high vowels of the base stay."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_5a : LinguisticExample :=
+  { id := "dolatian2020_5a"
+    source := ⟨"dolatian-2020", "(5a)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "d͡zín, d͡zən-únt, d͡zən-ənt-agán"
+    discourseSegments := []
+    glossedTokens := [("d͡zín", "birth"), ("d͡zən-únt", "birth-NMLZ"), ("d͡zən-ənt-agán", "birth-NMLZ-ADJ")]
+    translation := "birth; birth; generative"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "schwa")]
+    comment := "Unbounded cyclicity: reduction applies to a sequence of destressed high vowels, each new morpheme triggering a new cycle of stress shift and reduction."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_5c : LinguisticExample :=
+  { id := "dolatian2020_5c"
+    source := ⟨"dolatian-2020", "(5c)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "kír, kər-ít͡ʃ, dúp, kər-t͡ʃ-a-dup"
+    discourseSegments := []
+    glossedTokens := [("kír", "handwriting"), ("kər-ít͡ʃ", "handwriting-AGT"), ("dúp", "box"), ("kər-t͡ʃ-a-dup", "handwriting-AGT-LV-box")]
+    translation := "handwriting; pen; box; pencil-box"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "compound"), ("reduction", "both")]
+    comment := "Reduction applies to suffixes and in compounds: the suffix vowel of kər-ít͡ʃ is destressed and deleted in the compound."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_7a : LinguisticExample :=
+  { id := "dolatian2020_7a"
+    source := ⟨"dolatian-2020", "(7a)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "amusín, amusn-utjún, amusin-óv"
+    discourseSegments := []
+    glossedTokens := [("amusín", "husband"), ("amusn-utjún", "husband-ness"), ("amusin-óv", "husband-INST")]
+    translation := "husband; marriage; husband (instrumental)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "vInflection"), ("reduction", "none")]
+    comment := "In Western Armenian derivational suffixes trigger reduction and inflectional suffixes only stress shift: the stem-level against the word-level cophonology."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_7b : LinguisticExample :=
+  { id := "dolatian2020_7b"
+    source := ⟨"dolatian-2020", "(7b)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "zərújt͡s, zərut͡s-él, zərujt͡s-óv"
+    discourseSegments := []
+    glossedTokens := [("zərújt͡s", "conversation"), ("zərut͡s-él", "conversation-INF"), ("zərujt͡s-óv", "conversation-INST")]
+    translation := "conversation; to converse; conversation (instrumental)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "vInflection"), ("reduction", "diphthong")]
+    comment := "The destressed diphthong uj reduces to u in derivation and not in inflection."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_10c : LinguisticExample :=
+  { id := "dolatian2020_10c"
+    source := ⟨"dolatian-2020", "(10c)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "amusn-óv"
+    discourseSegments := []
+    glossedTokens := [("amusn-óv", "husband-INST")]
+    translation := "husband (instrumental)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "vInflection"), ("reduction", "deletion")]
+    comment := "Vowel-initial inflection triggers reduction in Eastern Armenian: the resyllabified stem-final consonant misaligns the Prosodic Stem, which expands and triggers its own cophonology, (78)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_10e : LinguisticExample :=
+  { id := "dolatian2020_10e"
+    source := ⟨"dolatian-2020", "(10e)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "amusin-nér"
+    discourseSegments := []
+    glossedTokens := [("amusin-nér", "husband-PL")]
+    translation := "husbands"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "cInflection"), ("reduction", "none")]
+    comment := "Consonant-initial inflection leaves the Prosodic Stem aligned with the morphological stem and the syllable, so only the word-level cophonology applies, in both dialects."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_12a : LinguisticExample :=
+  { id := "dolatian2020_12a"
+    source := ⟨"dolatian-2020", "(12a)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "zərújt͡sʰ, zərut͡sʰ-él, zərújt͡sʰ-óv"
+    discourseSegments := []
+    glossedTokens := [("zərújt͡sʰ", "conversation"), ("zərut͡sʰ-él", "conversation-INF"), ("zərújt͡sʰ-óv", "conversation-INST")]
+    translation := "conversation; to converse; conversation (instrumental)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "vInflection"), ("reduction", "diphthong")]
+    comment := "In both dialects the destressed diphthong reduces in derivation and not in inflection; Eastern vowel-initial inflection triggers high vowel reduction but not diphthong reduction, so the Prosodic Stem cophonology lies between the word-level and the stem-level, (76)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_41 : LinguisticExample :=
+  { id := "dolatian2020_41"
+    source := ⟨"dolatian-2020", "(41)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "darí, darí-k; kaxtní, kaxtní-k; parí, parí-k"
+    discourseSegments := []
+    glossedTokens := [("darí", "year"), ("darí-k", "year-NMLZ"), ("kaxtní", "secret"), ("kaxtní-k", "secret-NMLZ"), ("parí", "good"), ("parí-k", "good-NMLZ")]
+    translation := "year, age; secret (adj.), secret (n.); good, charity"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "none")]
+    comment := "A suffix without a full vowel cannot shift stress, so there is no destressed vowel and no reduction."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_42 : LinguisticExample :=
+  { id := "dolatian2020_42"
+    source := ⟨"dolatian-2020", "(42)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "amusín, amusn-utjún; aznív, aznəv-utjún"
+    discourseSegments := []
+    glossedTokens := [("amusín", "husband"), ("amusn-utjún", "husband-ness"), ("aznív", "honest"), ("aznəv-utjún", "honest-ness")]
+    translation := "husband, marriage; honest, honesty"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("amusən-utjún", .ungrammatical), ("aznv-utjún", .ungrammatical)]
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "both")]
+    comment := "Reduction deletes the vowel unless deletion would create an unsyllabifiable cluster, in which case the vowel is replaced by schwa, (46)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_47a : LinguisticExample :=
+  { id := "dolatian2020_47a"
+    source := ⟨"dolatian-2020", "(47a)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "hivánt, hivant-anál; hankíst, hankəst-anál; amusín, amusn-anál"
+    discourseSegments := []
+    glossedTokens := [("hivánt", "sick"), ("hivant-anál", "sick-INCH"), ("hankíst", "relaxed"), ("hankəst-anál", "relaxed-INCH"), ("amusín", "husband"), ("amusn-anál", "husband-INCH")]
+    translation := "sick, to become sick; relaxed, to relax; husband, to marry"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("həvant-anál", .ungrammatical), ("hankist-anál", .ungrammatical), ("amsin-anál", .ungrammatical)]
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "both")]
+    comment := "The derivation of (47b): the unstressed high vowel of hivánt does not reduce, the destressed vowel of hankíst reduces to schwa because deletion would leave an unsyllabifiable cluster, and that of amusín deletes."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_48a : LinguisticExample :=
+  { id := "dolatian2020_48a"
+    source := ⟨"dolatian-2020", "(48a)"⟩
+    reportedIn := none
+    language := "homs1234"
+    primaryText := "ázk, azk-ajín, azk-ajn-agán"
+    discourseSegments := []
+    glossedTokens := [("ázk", "nation"), ("azk-ajín", "nation-ADJ"), ("azk-ajn-agán", "nation-ADJ-ADJ")]
+    translation := "nation; national; nationalist"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "western"), ("suffix", "derivational"), ("reduction", "deletion")]
+    comment := "A destressed high vowel in a suffix reduces too."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_65 : LinguisticExample :=
+  { id := "dolatian2020_65"
+    source := ⟨"dolatian-2020", "(65)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "tʰúxtʰ, tʰəx.tʰ-í, tʰəx.tʰ-ít͡sʰ, tʰəx.tʰ-óv, tʰəx.tʰ-úm; amusín, amus.n-ú, amus.n-ít͡sʰ, amus.n-óv, amus.n-úm"
+    discourseSegments := []
+    glossedTokens := [("tʰúxtʰ", "paper"), ("tʰəx.tʰ-í", "paper-DAT"), ("tʰəx.tʰ-óv", "paper-INST"), ("amusín", "husband"), ("amus.n-ú", "husband-DAT"), ("amus.n-óv", "husband-INST")]
+    translation := "paper and its case forms; husband and its case forms"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "vInflection"), ("reduction", "both")]
+    comment := "All case suffixes are vowel-initial and Eastern Armenian reduces before each of them, Western Armenian before none: tux.t-í, amusi.n-óv."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_66 : LinguisticExample :=
+  { id := "dolatian2020_66"
+    source := ⟨"dolatian-2020", "(66)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "tʰəx.tʰ-ér, tʰəx.tʰ-er-óv; amusin.-nér, amusin.-ner-óv"
+    discourseSegments := []
+    glossedTokens := [("tʰəx.tʰ-ér", "paper-PL"), ("tʰəx.tʰ-er-óv", "paper-PL-INST"), ("amusin.-nér", "husband-PL"), ("amusin.-ner-óv", "husband-PL-INST")]
+    translation := "papers, with papers; husbands, with husbands"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "plural"), ("reduction", "both")]
+    comment := "The plural is -er after monosyllabic bases and -ner after polysyllabic ones; the vowel-initial allomorph reduces the base and the consonant-initial one does not, whatever case follows."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def ex_72 : LinguisticExample :=
+  { id := "dolatian2020_72"
+    source := ⟨"dolatian-2020", "(72)"⟩
+    reportedIn := none
+    language := "nucl1235"
+    primaryText := "manúk, mank-akán, mank-án, manuk-í; lúrd͡ʒ, lərd͡ʒ-anál, lurd͡ʒ-í; fílm, film-ajín, film-ér"
+    discourseSegments := []
+    glossedTokens := [("manúk", "child"), ("mank-akán", "child-ish"), ("mank-án", "child-GEN.irregular"), ("manuk-í", "child-GEN.regular"), ("lúrd͡ʒ", "serious"), ("lərd͡ʒ-anál", "serious-INCH"), ("lurd͡ʒ-í", "serious-GEN"), ("fílm", "film"), ("film-ajín", "film-ADJ"), ("film-ér", "film-PL")]
+    translation := "child, childish, child's; serious, to get serious, of the serious one; film, cinematic, films"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("dialect", "eastern"), ("suffix", "vInflection"), ("reduction", "none")]
+    comment := "Pre-inflectional reduction does not apply in regularized inflection, inflected adjectives or loanwords: it is a lexical process and not a post-cyclic word-level one, against the recursive prosodic word analysis of §2.5.3.2."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def all : List LinguisticExample := [ex_1, ex_2, ex_3b, ex_4, ex_5a, ex_5c, ex_7a, ex_7b, ex_10c, ex_10e, ex_12a, ex_41, ex_42, ex_47a, ex_48a, ex_65, ex_66, ex_72]
+
+end Dolatian2020.Examples

--- a/Linglib/Studies/Dolatian2020.lean
+++ b/Linglib/Studies/Dolatian2020.lean
@@ -1,186 +1,369 @@
-import Mathlib.Data.List.Basic
 import Linglib.Phonology.Subregular.Transduction
+import Linglib.Data.Examples.Dolatian2020
 
 /-!
-# Dolatian 2020: pre-inflectional vowel reduction and the Prosodic Stem
-[dolatian-2020]
+# Dolatian (2020): Computational locality of cyclic phonology in Armenian
 
-Dolatian, H. (2020). *Computational locality of cyclic phonology in Armenian.*
-PhD dissertation, Stony Brook University.
+This file formalizes the analysis of destressed high vowel reduction in Chapters 1 and 2 of
+[dolatian-2020] and its computational rendering in Chapter 6. Armenian stress falls on the
+rightmost full vowel of a word, (1), and is reassigned as each suffix is added; a high vowel
+that was stressed in the base and loses stress in the derivative, and only such a vowel,
+reduces, deleting when the cluster it leaves is syllabifiable and otherwise becoming schwa,
+(46). Reduction is cyclic without bound, (5) and (48): each morpheme may trigger a new round
+of stress shift and reduction. It is stratal, after [kiparsky-1982]: in Western Armenian the
+derivational suffixes that build morphological stems trigger the stem-level cophonology of
+stress shift with reduction, while the inflectional suffixes that build morphological words
+trigger the word-level cophonology of stress shift alone, (7) to (9). And it is prosodic: in
+Eastern Armenian vowel-initial inflection reduces as well, (10) and (65), because onset
+maximization resyllabifies the stem-final consonant and misaligns the Prosodic Stem of
+[downing-1999] that the morphological stem maps to; the misaligned stem expands over the
+suffix and triggers a cophonology of its own, which reduces high vowels in Eastern but not in
+Western Armenian and reduces the diphthong *uj* in neither, (76) and (78). The plural
+allomorphy of (66), *-er* after monosyllables and *-ner* after polysyllables, thereby decides
+whether a plural reduces its base. Reduction itself is a quantifier-free logical transduction
+in the sense of [chandlee-2014], §6.6.1: given the destressing diacritic, deletion and schwa
+are read off two segments on either side of the target.
 
-Eastern Armenian Destressed High Vowel Reduction (DHR) overapplies *before
-V-initial inflection* but not *before C-initial inflection*: *amusín* 'husband'
-→ *amusn-óv* (INST, V-initial: reduces) vs *amusin-nér* (PL, C-initial: no
-reduction). Dolatian argues the conditioning constituent is neither the foot
-(§2.5.3.1, fails) nor a (recursive) prosodic word (§2.5.3.2, argued *against*),
-but Downing's **Prosodic Stem** (PStem), an intermediate constituent mapped from
-the morphological stem. Before V-initial inflection the PStem is *misaligned*
-from syllable boundaries (onset maximization resyllabifies the stem-final
-consonant) and *expands*; expansion triggers the PStem-level cophonology, which
-in Eastern Armenian reduces, in Western Armenian only shifts stress (§2.5.4 (76),
-(78)). Before C-initial inflection the PStem stays isomorphic with the MStem, so
-nothing triggers.
+## Implementation notes
 
-This is **not** an OT analysis: Dolatian formalizes it as a serial/cyclic
-derivation (and computationally as MSO logical transductions), explicitly noting
-(fn. 20) that an OT/Match-theoretic formalization is an *alternative* he does not
-adopt. We therefore model the mechanism derivationally — onset-maximization
-syllabification → PStem misalignment → PStem-cophonology → DHR — rather than as
-constraint optimization. DHR is *derived* from the mechanism (see `dhr_iff`), not
-stipulated as a dialect × inflection table.
+Segments are kept at the granularity the analysis reads: consonant, high vowel, other full
+vowel, the diphthong *uj*, and schwa, so that *u* and *i* are one symbol and the segmental
+detail of [vaux-1998] is not represented. Stress is computed as the position of the rightmost
+full vowel rather than as the logical transduction of Chapter 5, and destressing compares that
+position across a cycle; the reduction step is the transduction `dhr`, run on the string with
+the destressed vowel marked, so a cycle composes a stress function with a quantifier-free map,
+and the domain label that the dissertation's SETTINGS constant supplies to the reduction
+formulas is the cophonology argument of `reduce`. Syllabifiability, (46), is the condition
+that the destressed vowel be flanked by single consonants that themselves neighbour nuclei.
+Prosodic Stem misalignment is read off the stem-final consonant and the suffix-initial vowel,
+without a syllabification. The foot and recursive prosodic word alternatives of §2.5.3, the
+lexical exceptions of (72) and the variation of §2.7.3, and the compound bracketing paradox of
+Chapter 3 are not formalized.
 
-Dolatian also formalizes the phonology *computationally*, as MSO/quantifier-free
-logical transductions over word models (§4), whose locality (QF ⟹ Input Strictly
-Local, hence learnable) is his central computational claim. The final section
-realizes the Eastern Armenian cophonology in that framework
-(`Phonology.Subregular.Transduction`): DHR is the local rewrite `H → ∅ / _ C V`,
-and the cyclic derivation is transduction composition. Reproducing the *amusin*
-contrast segmentally recovers the serial result by a different route
-(`transduction_matches_trigger`).
+## TODO
 
-## Main definitions
+The complex-coda clause of (46), a second consonant before the target licensed when the two
+form a falling-sonority coda, needs a sonority scale over consonants; with one consonant
+symbol, `dhr` gives schwa where the dissertation deletes, as in *jergír* ~ *jergr-a-kúnt*, (17).
 
-* `Dolatian2020.pstemMisaligned` — the MStem boundary no longer coincides with a
-  syllable boundary (V-initial suffix resyllabified the stem-final consonant).
-* `Dolatian2020.dhrApplies` — DHR derived from PStem expansion × dialect cophonology.
-* `Dolatian2020.dhrEast` / `dhrWest` — the dialect cophonologies as quantifier-free
-  logical transductions; `dhrEast` deletes the destressed high vowel before `C V`.
+## References
+
+* [dolatian-2020]
+* [kiparsky-1982]
+* [downing-1999]
+* [vaux-1998]
+* [chandlee-2014]
 -/
 
 namespace Dolatian2020
 
-/-- Coarse segment type — enough for onset-maximization syllabification. -/
-inductive Seg | C | V
-  deriving DecidableEq, Repr
-
-/-- An inflectional suffix, as a segment string (only its initial segment matters
-    for syllabification/misalignment). -/
-abbrev Suffix := List Seg
-
-/-- Western vs Eastern Armenian. The dialects share the morphology and the PStem;
-    they differ only in the PStem-level cophonology ([dolatian-2020] §2.5.4 (76)). -/
-inductive Dialect | eArm | wArm
-  deriving DecidableEq, Repr
-
-/-- The PStem-level cophonology: Eastern Armenian's PStem triggers stress *and*
-    DHR; Western Armenian's triggers only stress ([dolatian-2020] (76)). -/
-def Dialect.pstemReduces : Dialect → Bool
-  | .eArm => true
-  | .wArm => false
-
-/-- Onset maximization: a V-initial suffix pulls a single stem-final consonant
-    into its onset, resyllabifying it across the MStem boundary. A C-initial
-    suffix leaves the boundary at a syllable edge. -/
-def resyllabifiesAcrossStemBoundary (stem : List Seg) (suf : Suffix) : Bool :=
-  (stem.getLast? == some .C) && (suf.head? == some .V)
-
-/-- PStem misalignment ([dolatian-2020] §2.5.3): the MStem boundary no longer
-    coincides with a syllable boundary, because a V-initial suffix resyllabified
-    the stem-final consonant. -/
-def pstemMisaligned (stem : List Seg) (suf : Suffix) : Bool :=
-  resyllabifiesAcrossStemBoundary stem suf
-
-/-- The PStem-level cophonology is triggered exactly when the PStem is
-    misaligned and so expands by incorporating the V-initial suffix
-    ([dolatian-2020]: the PStem cophonology applies *only* to misaligned PStems). -/
-def pstemCophonologyTriggered (stem : List Seg) (suf : Suffix) : Bool :=
-  pstemMisaligned stem suf
-
-/-- Destressed High Vowel Reduction applies iff the expanded PStem-level
-    cophonology is triggered **and** the dialect's PStem reduces. The pattern is
-    *derived* from the cyclic mechanism, not a stipulated table (see `dhr_iff`). -/
-def dhrApplies (d : Dialect) (stem : List Seg) (suf : Suffix) : Bool :=
-  pstemCophonologyTriggered stem suf && d.pstemReduces
-
-/-! ### Worked forms: *amusin* 'husband' with V- and C-initial inflection -/
-
-/-- *amusin* = a.mu.sin, consonant-final. -/
-def amusin : List Seg := [.V, .C, .V, .C, .V, .C]
-/-- *-ov* (INST): V-initial. -/
-def sufOv  : Suffix := [.V, .C]
-/-- *-ner* (PL): C-initial. -/
-def sufNer : Suffix := [.C, .V, .C]
-
--- The misalignment contrast is the V- vs C-initial discriminator, prior to DHR.
-theorem ov_misaligns  : pstemMisaligned amusin sufOv  = true  := by decide
-theorem ner_aligned   : pstemMisaligned amusin sufNer = false := by decide
-
--- The faithful 2×2 ([dolatian-2020] (78)): DHR overapplies only in EArm before
--- V-initial inflection.
-theorem earm_ov_reduces  : dhrApplies .eArm amusin sufOv  = true  := by decide  -- amusn-óv
-theorem earm_ner_blocks  : dhrApplies .eArm amusin sufNer = false := by decide  -- amusin-nér
-theorem warm_ov_blocks   : dhrApplies .wArm amusin sufOv  = false := by decide  -- amusin-óv (stress only)
-theorem warm_ner_blocks  : dhrApplies .wArm amusin sufNer = false := by decide
-
-/-- Characterization: pre-inflectional DHR is exactly Eastern Armenian with a
-    misaligned PStem. The V- vs C-initial split falls out of onset-maximization
-    syllabification; the dialect split out of the PStem cophonology — neither is
-    stipulated as a lookup table. -/
-theorem dhr_iff (d : Dialect) (stem : List Seg) (suf : Suffix) :
-    dhrApplies d stem suf = true ↔ d = .eArm ∧ pstemMisaligned stem suf = true := by
-  cases d <;>
-    simp [dhrApplies, Dialect.pstemReduces, pstemCophonologyTriggered]
-
-/-! ### The cophonology as a quantifier-free logical transduction
-
-[dolatian-2020]'s computational formalization (§4): the cophonology as an MSO/quantifier-free
-logical transduction over a word model. Eastern Armenian DHR is the local rewrite `H → ∅ / _ C V`
-— the stem-final high vowel drops when a following consonant resyllabifies into a V-initial
-suffix's onset — realized with `Phonology.Subregular.Transduction`. The rewrite reads a bounded
-right context, so it is quantifier-free, hence subregular and learnable (Dolatian's thesis). -/
-
-section Transductions
-
 open Subregular
 
-/-- Segments refined with the high-vowel target `H` of DHR. -/
-inductive Phone | C | V | H
+/-! ### Segments and stress, (1) -/
+
+/-- Segments at the granularity of the analysis: a consonant, a high vowel, another full vowel,
+the diphthong *uj*, and schwa. -/
+inductive Seg
+  | c
+  | h
+  | v
+  | uj
+  | schwa
   deriving DecidableEq, Repr
+
+/-- A full vowel bears stress: a high or other full vowel or the diphthong, not schwa. -/
+def Seg.Full : Seg → Prop
+  | .h | .v | .uj => True
+  | _ => False
+
+/-- A syllable nucleus: any vowel, schwa included. -/
+def Seg.Nucleus : Seg → Prop
+  | .c => False
+  | _ => True
+
+instance : DecidablePred Seg.Full := λ s => by cases s <;> unfold Seg.Full <;> infer_instance
+
+instance : DecidablePred Seg.Nucleus := λ s => by
+  cases s <;> unfold Seg.Nucleus <;> infer_instance
+
+/-- The position of the stressed vowel, the rightmost full vowel, (1). -/
+def stress (w : List Seg) : Option ℕ := (w.findIdxs (decide <| Seg.Full ·)).getLast?
+
+/-! ### Reduction as a quantifier-free transduction, (46) and §6.6.1 -/
 
 private def x : Term := .var
 
-/-- Eastern Armenian DHR as a logical transduction: delete a high vowel before `C V` (the
-resyllabification-and-expansion context); every other segment is faithful. A high vowel in that
-context matches no clause and is dropped. -/
-def dhrEast : Transduction Phone Phone where
+/-- The guard that a term reads a nucleus not carrying the destressing mark. -/
+private def nucleusAt (t : Term) : QF (Seg × Bool) :=
+  .disj (.label (.h, false) t) (.disj (.label (.v, false) t)
+    (.disj (.label (.uj, false) t) (.label (.schwa, false) t)))
+
+/-- The context in which deletion leaves a syllabifiable cluster, (46): a nucleus and a single
+consonant before the target and a single consonant and a nucleus after it. -/
+private def deletable : QF (Seg × Bool) :=
+  .conj (nucleusAt x.pred.pred) (.conj (.label (.c, false) x.pred)
+    (.conj (.label (.c, false) x.succ) (nucleusAt x.succ.succ)))
+
+/-- Destressed high vowel reduction as a quantifier-free transduction, (46): the destressed high
+vowel, marked `true`, becomes schwa unless deletion is licensed, in which case it matches no
+clause and is deleted; every other segment is faithful. -/
+def dhr : Transduction (Seg × Bool) Seg where
   copies := 1
   clause _ :=
-    [ (QF.conj (.label .H x)
-        (QF.neg (QF.conj (.label .C x.succ) (.label .V x.succ.succ))), .H),
-      (.label .C x, .C), (.label .V x, .V) ]
+    [(.conj (.label (.h, true) x) deletable.neg, .schwa),
+      (.label (.c, false) x, .c), (.label (.h, false) x, .h), (.label (.v, false) x, .v),
+      (.label (.uj, false) x, .uj), (.label (.schwa, false) x, .schwa),
+      (.label (.c, true) x, .c), (.label (.v, true) x, .v), (.label (.uj, true) x, .uj),
+      (.label (.schwa, true) x, .schwa)]
 
-/-- Western Armenian: the PStem cophonology shifts stress but does not reduce, so the high vowel is
-faithful in every context ([dolatian-2020] (76)). -/
-def dhrWest : Transduction Phone Phone where
-  copies := 1
-  clause _ := [(.label .H x, .H), (.label .C x, .C), (.label .V x, .V)]
+/-- The string with the destressed position marked. -/
+def mark (w : List Seg) (p : ℕ) : List (Seg × Bool) := w.mapIdx λ n s => (s, decide (n = p))
 
-/-- *amusin* a-mu-si-n, segmentally `V C V C H C` (the stem-final high vowel is `H`). -/
-def amusinP : List Phone := [.V, .C, .V, .C, .H, .C]
-/-- *-ov* (INST), V-initial. -/
-def ovP : List Phone := [.V, .C]
-/-- *-ner* (PL), C-initial. -/
-def nerP : List Phone := [.C, .V, .C]
+/-! ### Cophonologies, (76) -/
 
--- Eastern Armenian: the high vowel deletes before V-initial *-ov* (→ amusn-ov) but survives before
--- C-initial *-ner* (→ amusin-ner) — Dolatian's (78), recovered at the segmental level.
-theorem dhrEast_ov : dhrEast.apply (amusinP ++ ovP) = [.V, .C, .V, .C, .C, .V, .C] := by decide
-theorem dhrEast_ner : dhrEast.apply (amusinP ++ nerP) = amusinP ++ nerP := by decide
--- Western Armenian reduces in neither context.
-theorem dhrWest_ov : dhrWest.apply (amusinP ++ ovP) = amusinP ++ ovP := by decide
+/-- The reductions a cophonology applies: destressed high vowel reduction and destressed
+diphthong reduction. -/
+structure Cophonology where
+  /-- Destressed high vowel reduction applies. -/
+  dhr : Bool
+  /-- Destressed diphthong reduction applies. -/
+  ddr : Bool
+  deriving DecidableEq, Repr
 
-/-- The transduction's segmental action agrees with the serial trigger `dhrApplies`: the form
-changes exactly when (Eastern, misaligned) DHR is predicted — the two formalizations coincide. -/
-theorem transduction_matches_trigger :
-    (dhrEast.apply (amusinP ++ ovP) ≠ amusinP ++ ovP ∧ dhrApplies .eArm amusin sufOv = true) ∧
-    (dhrEast.apply (amusinP ++ nerP) = amusinP ++ nerP ∧ dhrApplies .eArm amusin sufNer = false) := by
-  refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> decide
+/-- The stem-level cophonology, triggered by derivation: both reductions. -/
+def stemLevel : Cophonology := ⟨true, true⟩
 
-/-- Cyclicity ([dolatian-2020]: interactionist derivation = transduction composition): a further
-cophonology cycle composes with the first, and DHR is stable under re-application. -/
-theorem dhr_cyclic_stable :
-    dhrEast.applyComp dhrEast (amusinP ++ ovP) = dhrEast.apply (amusinP ++ ovP) := by decide
+/-- The word-level cophonology, triggered by inflection: stress shift alone. -/
+def wordLevel : Cophonology := ⟨false, false⟩
 
-end Transductions
+/-- The two standard dialects, which share the morphology and the Prosodic Stem and differ in
+its cophonology. -/
+inductive Dialect
+  | eastern
+  | western
+  deriving DecidableEq, Repr
+
+/-- The Prosodic Stem cophonology, (76): high vowel reduction without diphthong reduction in
+Eastern Armenian, stress shift alone in Western Armenian. -/
+def Dialect.pstemLevel : Dialect → Cophonology
+  | .eastern => ⟨true, false⟩
+  | .western => wordLevel
+
+/-- Apply a cophonology's reductions to the destressed vowel at `p`. -/
+def reduce (c : Cophonology) (w : List Seg) (p : ℕ) : List Seg :=
+  match w[p]? with
+  | some .h => if c.dhr then dhr.apply (mark w p) else w
+  | some .uj => if c.ddr then w.set p .h else w
+  | _ => w
+
+/-! ### Strata, the Prosodic Stem and the cycle, (9), (14) and (78) -/
+
+/-- Whether a suffix builds a morphological stem, derivation, or a morphological word,
+inflection. -/
+inductive Stratum
+  | stem
+  | word
+  deriving DecidableEq, Repr
+
+/-- A suffix: its segments and the stratum it triggers. -/
+structure Suffix where
+  /-- The segments of the suffix. -/
+  segs : List Seg
+  /-- The stratum the suffix triggers. -/
+  stratum : Stratum
+
+/-- The Prosodic Stem mapped from the base is misaligned from the syllables by a vowel-initial
+suffix after a consonant-final base, §2.5.3: onset maximization resyllabifies the final
+consonant, and the stem expands over the suffix. -/
+def Misaligned (base suf : List Seg) : Prop :=
+  base.getLast? = some .c ∧ ∃ s ∈ suf.head?, s.Nucleus
+
+instance (base suf : List Seg) : Decidable (Misaligned base suf) := by
+  unfold Misaligned; infer_instance
+
+/-- The cophonology a cycle triggers, (76) and (78): the stem-level for derivation, and for
+inflection the Prosodic Stem cophonology of the dialect when the stem is misaligned and the
+word-level otherwise. -/
+def cophonology (d : Dialect) (base : List Seg) (s : Suffix) : Cophonology :=
+  match s.stratum with
+  | .stem => stemLevel
+  | .word => if Misaligned base s.segs then d.pstemLevel else wordLevel
+
+/-- One cycle: the suffix is spelled out, stress is reassigned, and the vowel stressed in the
+base, if it has lost stress, reduces according to the cophonology the cycle triggers. -/
+def cycle (d : Dialect) (base : List Seg) (s : Suffix) : List Seg :=
+  match stress base with
+  | none => base ++ s.segs
+  | some p =>
+    if stress (base ++ s.segs) = some p then base ++ s.segs
+    else reduce (cophonology d base s) (base ++ s.segs) p
+
+/-- The cyclic derivation of a root with its suffixes, in order: unbounded cyclicity, §2.3.2.2. -/
+def derive (d : Dialect) (root : List Seg) (sufs : List Suffix) : List Seg :=
+  sufs.foldl (cycle d) root
+
+/-- The plural allomorph, (66): *-er* after a monosyllabic base and *-ner* after a polysyllabic
+one. -/
+def plural (base : List Seg) : Suffix :=
+  ⟨if base.countP (decide <| Seg.Nucleus ·) = 1 then [.v, .c] else [.c, .v, .c], .word⟩
+
+/-! ### What the cophonologies exclude -/
+
+variable (base : List Seg) (s : Suffix)
+
+theorem reduce_of_none {c : Cophonology} (h : c.dhr = false) (h' : c.ddr = false)
+    (w : List Seg) (p : ℕ) : reduce c w p = w := by
+  unfold reduce
+  split <;> simp_all
+
+/-- A cycle whose cophonology is the word-level shifts stress alone. -/
+theorem cycle_of_cophonology_eq (d : Dialect) (h : cophonology d base s = wordLevel) :
+    cycle d base s = base ++ s.segs := by
+  unfold cycle
+  rw [h]
+  split
+  · rfl
+  · split
+    · rfl
+    · exact reduce_of_none rfl rfl _ _
+
+/-- Inflection triggers the word-level cophonology in Western Armenian whether or not the
+Prosodic Stem is misaligned, (76). -/
+theorem cophonology_western_word (h : s.stratum = .word) :
+    cophonology .western base s = wordLevel := by
+  simp only [cophonology, h, Dialect.pstemLevel, ite_self]
+
+/-- Inflection over an aligned Prosodic Stem triggers the word-level cophonology in either
+dialect, (78). -/
+theorem cophonology_word_of_not_misaligned (d : Dialect) (h : s.stratum = .word)
+    (hm : ¬ Misaligned base s.segs) : cophonology d base s = wordLevel := by
+  simp only [cophonology, h, if_neg hm]
+
+/-- The dialects differ only where a misaligned Prosodic Stem triggers its cophonology under
+inflection, (76). -/
+theorem cophonology_dialect_eq (h : s.stratum = .stem ∨ ¬ Misaligned base s.segs) :
+    cophonology .eastern base s = cophonology .western base s := by
+  unfold cophonology
+  rcases h with h | h
+  · rw [h]
+  · cases s.stratum
+    · rfl
+    · rw [if_neg h, if_neg h]
+
+/-- Diphthong reduction is stem-level only, (76): no inflection triggers it. -/
+theorem cophonology_word_ddr (d : Dialect) (h : s.stratum = .word) :
+    (cophonology d base s).ddr = false := by
+  simp only [cophonology, h]
+  split <;> cases d <;> rfl
+
+/-- Inflection never reduces in Western Armenian, (7) and (37). -/
+theorem cycle_western_word (h : s.stratum = .word) : cycle .western base s = base ++ s.segs :=
+  cycle_of_cophonology_eq base s _ (cophonology_western_word base s h)
+
+/-- Consonant-initial inflection, and inflection of a vowel-final base, never reduces in either
+dialect, (10e): the Prosodic Stem stays aligned. -/
+theorem cycle_word_of_not_misaligned (d : Dialect) (h : s.stratum = .word)
+    (hm : ¬ Misaligned base s.segs) : cycle d base s = base ++ s.segs :=
+  cycle_of_cophonology_eq base s d (cophonology_word_of_not_misaligned base s d h hm)
+
+/-- Derivation, and inflection over an aligned Prosodic Stem, run alike in the two dialects. -/
+theorem cycle_dialect_eq (h : s.stratum = .stem ∨ ¬ Misaligned base s.segs) :
+    cycle .eastern base s = cycle .western base s := by
+  unfold cycle
+  rw [cophonology_dialect_eq base s h]
+
+/-- Inflection never reduces a destressed diphthong in either dialect, (12). -/
+theorem cycle_word_diphthong (d : Dialect) (h : s.stratum = .word) {p : ℕ}
+    (hp : stress base = some p) (hd : (base ++ s.segs)[p]? = some .uj) :
+    cycle d base s = base ++ s.segs := by
+  simp only [cycle, hp]
+  split
+  · rfl
+  · simp [reduce, hd, cophonology_word_ddr base s d h]
+
+/-! ### The forms, (5), (10), (12), (42), (47), (48), (65) and (66) -/
+
+/-- *amusín* 'husband': a.mu.sín. -/
+def amusin : List Seg := [.v, .c, .h, .c, .h, .c]
+
+/-- *-utjun*, derivational. -/
+def utjun : Suffix := ⟨[.h, .c, .c, .h, .c], .stem⟩
+
+/-- *-anal*, derivational inchoative. -/
+def anal : Suffix := ⟨[.v, .c, .v, .c], .stem⟩
+
+/-- *-ov*, the instrumental. -/
+def ov : Suffix := ⟨[.v, .c], .word⟩
+
+/-- *-ner*, the plural after polysyllables. -/
+def ner : Suffix := ⟨[.c, .v, .c], .word⟩
+
+/-- Derivation reduces in both dialects, (7a) and (77): *amusn-utjún*. -/
+theorem amusin_utjun (d : Dialect) :
+    derive d amusin [utjun] = [.v, .c, .h, .c, .c, .h, .c, .c, .h, .c] := by
+  cases d <;> decide
+
+/-- Vowel-initial inflection reduces in Eastern Armenian alone, (10c) and (10d): *amusn-óv*
+against *amusin-óv*. -/
+theorem amusin_ov :
+    derive .eastern amusin [ov] = [.v, .c, .h, .c, .c, .v, .c] ∧
+      derive .western amusin [ov] = amusin ++ ov.segs := by
+  decide
+
+/-- Consonant-initial inflection reduces in neither dialect, (10e): *amusin-nér*. -/
+theorem amusin_ner (d : Dialect) : derive d amusin [ner] = amusin ++ ner.segs :=
+  cycle_word_of_not_misaligned amusin ner d rfl (by decide)
+
+/-- The derivations of (47): *hivánt* keeps its unstressed high vowel, *hankíst* reduces to
+schwa because deletion would leave an unsyllabifiable cluster, *amusín* deletes. -/
+theorem forms_47 :
+    derive .western [.c, .h, .c, .v, .c, .c] [anal] = [.c, .h, .c, .v, .c, .c] ++ anal.segs ∧
+      derive .western [.c, .v, .c, .c, .h, .c, .c] [anal] =
+        [.c, .v, .c, .c, .schwa, .c, .c] ++ anal.segs ∧
+      derive .western amusin [anal] = [.v, .c, .h, .c, .c] ++ anal.segs := by
+  decide
+
+/-- *aznív* reduces to schwa before *-utjun*, (42b): the vowel is preceded by two consonants. -/
+theorem azniv_utjun :
+    derive .western [.v, .c, .c, .h, .c] [utjun] = [.v, .c, .c, .schwa, .c] ++ utjun.segs := by
+  decide
+
+/-- Unbounded cyclicity, (5a): *d͡zín*, *d͡zən-únt*, *d͡zən-ənt-agán*, each cycle destressing
+and reducing the vowel stressed in its base. -/
+theorem dzin :
+    derive .western [.c, .h, .c] [⟨[.h, .c, .c], .stem⟩] = [.c, .schwa, .c, .h, .c, .c] ∧
+      derive .western [.c, .h, .c] [⟨[.h, .c, .c], .stem⟩, ⟨[.v, .c, .v, .c], .stem⟩] =
+        [.c, .schwa, .c, .schwa, .c, .c, .v, .c, .v, .c] := by
+  decide
+
+/-- A destressed high vowel in a suffix reduces, (48a): *ázk*, *azk-ajín*, *azk-ajn-agán*. -/
+theorem azk :
+    derive .western [.v, .c, .c] [⟨[.v, .c, .h, .c], .stem⟩, ⟨[.v, .c, .v, .c], .stem⟩] =
+      [.v, .c, .c, .v, .c, .c, .v, .c, .v, .c] := by
+  decide
+
+/-- The diphthong, (12) and (62): *zərújt͡s* reduces to *zərut͡s-él* in derivation, while Eastern
+vowel-initial inflection, which reduces high vowels, leaves *zərújt͡s-óv* alone. -/
+theorem zerujts :
+    derive .eastern [.c, .schwa, .c, .uj, .c] [⟨[.v, .c], .stem⟩] =
+        [.c, .schwa, .c, .h, .c, .v, .c] ∧
+      derive .eastern [.c, .schwa, .c, .uj, .c] [ov] = [.c, .schwa, .c, .uj, .c] ++ ov.segs := by
+  decide
+
+/-- The plural, (66): the monosyllable *tʰúxtʰ* takes *-er* and reduces, *tʰəxtʰ-ér*, while
+*amusín* takes *-ner* and does not; a following case suffix changes nothing. -/
+theorem plurals :
+    derive .eastern [.c, .h, .c, .c] [plural [.c, .h, .c, .c]] = [.c, .schwa, .c, .c, .v, .c] ∧
+      derive .eastern amusin [plural amusin] = amusin ++ ner.segs ∧
+      derive .eastern [.c, .h, .c, .c] [plural [.c, .h, .c, .c], ov] =
+        [.c, .schwa, .c, .c, .v, .c] ++ ov.segs ∧
+      derive .eastern amusin [plural amusin, ov] = amusin ++ ner.segs ++ ov.segs := by
+  decide
+
+/-- Western Armenian reduces before no case suffix, (65): *amusi.n-óv*, *amusi.n-í*. -/
+theorem western_cases :
+    derive .western amusin [ov] = amusin ++ ov.segs ∧
+      derive .western amusin [⟨[.h], .word⟩] = amusin ++ [.h] :=
+  ⟨cycle_western_word amusin ov rfl, cycle_western_word amusin ⟨[.h], .word⟩ rfl⟩
 
 end Dolatian2020

--- a/references.bib
+++ b/references.bib
@@ -1557,7 +1557,36 @@
   title     = {Computational Locality of Cyclic Phonology in {Armenian}},
   school    = {Stony Brook University},
   subfield  = {phonology},
-  role      = {foundational},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Data/Examples/Dolatian2020.json;Phonology/Prosody/Syllable.lean;Phonology/Prosody/Word.lean;Studies/Dolatian2020.lean}
+}
+@incollection{downing-1999,
+  author    = {Downing, Laura J.},
+  year      = {1999},
+  title     = {Prosodic Stem $\neq$ Prosodic Word in {Bantu}},
+  booktitle = {Studies on the Phonological Word},
+  editor    = {Hall, T. Alan and Kleinhenz, Ursula},
+  publisher = {John Benjamins},
+  series    = {Current Issues in Linguistic Theory},
+  volume    = {174},
+  pages     = {73--98},
+  doi       = {10.1075/cilt.174.05dow},
+  subfield  = {phonology},
+  validated = {true},
+  role      = {cited},
+  sources   = {Studies/Dolatian2020.lean}
+}
+@book{vaux-1998,
+  author    = {Vaux, Bert},
+  year      = {1998},
+  title     = {The Phonology of {Armenian}},
+  publisher = {Clarendon Press},
+  address   = {Oxford},
+  doi       = {10.1093/oso/9780198236610.001.0001},
+  subfield  = {phonology},
+  validated = {true},
+  role      = {cited},
   sources   = {Studies/Dolatian2020.lean}
 }
 @incollection{cser-2010,
@@ -29439,7 +29468,7 @@
   address   = {Seoul},
   subfield  = {phonology},
   role      = {cited},
-  sources   = {Phonology/Tone/Grammatical.lean;Phonology/OptimalityTheory/Cophonology.lean;Phonology/Segmental/Defs.lean}
+  sources   = {Phonology/OptimalityTheory/Cophonology.lean;Phonology/Segmental/Defs.lean;Phonology/Tone/Grammatical.lean;Studies/Dolatian2020.lean}
 }
 
 % REF: Kiparsky & Halle (1977). Towards a reconstruction of the IE accent.
@@ -33735,7 +33764,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Phonology/Subregular/ISL.lean}
+  sources   = {Phonology/Subregular/LocalRewrite.lean;Phonology/Subregular/QF.lean;Phonology/Subregular/Transduction.lean;Studies/Dolatian2020.lean}
 }
 
 % REF: Chandlee, Eyraud & Heinz (2015). Output Strictly Local Functions.


### PR DESCRIPTION
Deep cleanse of Dolatian2020 against the dissertation: the stipulated dialect table becomes a cyclic derivation whose cophonology is derived from the stratum and Prosodic Stem alignment.

- `cycle`/`derive` compose rightmost-full-vowel stress with the QF transduction `dhr` (46); the (76) table and the (78) derivations follow by `decide`, and the Western/aligned/diphthong exclusions are general theorems
- plural allomorphy (66) derives which Eastern plurals reduce their base
- 18 rows from (1)–(72) in `Data/Examples/Dolatian2020.json`; bib adds verified downing-1999 and vaux-1998
