### PR TITLE
refactor(Studies/Elbourne2013): situation semantics for the definite article

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3044,3 +3044,4 @@ import Linglib.Data.Examples.Dixon1994
 import Linglib.Data.Examples.Dolatian2020
 import Linglib.Data.Examples.Downing1996
 import Linglib.Data.Examples.Egressy2026
+import Linglib.Data.Examples.Elbourne2013

--- a/Linglib/Data/Examples/Elbourne2013.json
+++ b/Linglib/Data/Examples/Elbourne2013.json
@@ -1,0 +1,497 @@
+[
+  {
+    "id": "elbourne2013_ch3_5",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 3, (5)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "The cat grins.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "referential situation pronoun", "judgment": "acceptable"},
+      {"name": "bound situation pronoun", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "3"],
+      ["structure", "[[[the cat] s1] grins] or [ς1 [[[the cat] s1] grins]]"]
+    ],
+    "comment": "Two analyses: a referential situation pronoun discharges the uniqueness condition at its referent, a bound one carries it to the topic situation by λ-Conversion II.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch5_2",
+    "source": {"bibkey": "donnellan-1966", "paperLabel": "pp. 285–286"},
+    "reportedIn": {"bibkey": "elbourne-2013", "paperLabel": "ch. 5, (2)"},
+    "language": "stan1293",
+    "primaryText": "The murderer is insane.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Attributive: Smith is found foully murdered and no one knows by whom. Referential: Jones is on trial for the murder and behaving oddly in court.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "referential", "judgment": "acceptable"},
+      {"name": "attributive", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "5"],
+      ["referential", "free situation pronoun"],
+      ["attributive", "bound situation pronoun"]
+    ],
+    "comment": "The referential use has a situation pronoun referring to the courtroom; the attributive use has it bound, so the description is evaluated at the topic situation.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch5_13",
+    "source": {"bibkey": "donnellan-1966", "paperLabel": "p. 287"},
+    "reportedIn": {"bibkey": "elbourne-2013", "paperLabel": "ch. 5, (13)"},
+    "language": "stan1293",
+    "primaryText": "Who is the man drinking a martini?",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The man gestured at is drinking water from a martini glass.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "5"],
+      ["misdescription", "yes"]
+    ],
+    "comment": "Misdescription: a question about a particular person is asked, and the Fregean account locates what went wrong in a false presupposition of existence.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch5_16",
+    "source": {"bibkey": "russell-1905", "paperLabel": "pp. 487–488"},
+    "reportedIn": {"bibkey": "elbourne-2013", "paperLabel": "ch. 5, (16)"},
+    "language": "stan1293",
+    "primaryText": "Scott is the author of Waverley.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Scott is Scott.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "5"],
+      ["use", "predicative"]
+    ],
+    "comment": "Predicative use is attributive use: the bound description gives a proposition false at situations where someone else authored Waverley, unlike the identity statement.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch6_3",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 6, (3)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Every man who owns a donkey beats the donkey.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "strong", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "6"],
+      ["anaphora", "donkey-anaphoric definite description"]
+    ],
+    "comment": "The description's situation pronoun is bound by σ to the minimal situations of the restrictor, each of which contains exactly one donkey.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch6_15",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 6, (15)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "If a man beats a donkey, the donkey always kicks him.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "If a man beats a donkey, the donkey kicks him.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "6"],
+      ["anaphora", "donkey-anaphoric definite description under a quantificational adverb"]
+    ],
+    "comment": "The quantificational adverb quantifies over minimal situations in which a man beats a donkey; both descriptions are bound to those situations.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch6_21",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 6, (21)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "John fed no cat of Mary's before the cat was bathed.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "covarying", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "6"],
+      ["anaphora", "c-commanded bound definite description"]
+    ],
+    "comment": "The covarying description in the scope of the quantifier is bound by the same mechanism as a donkey description.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch7_7",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 7, (7)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Mary believes that the man who lives upstairs is a spy.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "de dicto", "judgment": "acceptable"},
+      {"name": "de re", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "7"],
+      ["de dicto", "situation pronoun bound below believes"],
+      ["de re", "situation pronoun referring to the actual world"]
+    ],
+    "comment": "De dicto: every doxastic alternative contains exactly one man upstairs. De re: the man upstairs in the actual world need not live upstairs in Mary's alternatives.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch7_16",
+    "source": {"bibkey": "kripke-1977", "paperLabel": "p. 9"},
+    "reportedIn": {"bibkey": "elbourne-2013", "paperLabel": "ch. 7, (16)"},
+    "language": "stan1293",
+    "primaryText": "The number of the planets is necessarily odd.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The speaker does not know how many planets there are, but astronomical theory dictates that the number is odd.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "attributive de re", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "7"],
+      ["structure", "[ς2 [[[the [number [of [[the planets] s2]]]] s2] [is [necessarily odd]]]]"]
+    ],
+    "comment": "Attributive yet de re: the description is bound by a binder above the modal, so the number is fixed in the topic situation and oddness is claimed in every accessible world.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch8_3",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 8, (3)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Hans wants the ghost in his attic to be quiet tonight.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Hans wants there to be exactly one ghost in his attic and for it to be quiet tonight.", "judgment": "unacceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "8"],
+      ["presupposition", "Hans believes there is exactly one ghost in his attic"]
+    ],
+    "comment": "The Russellian paraphrase attributes to Hans the desire to have a ghost; the Fregean analysis presupposes that Hans believes there is exactly one.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch8_5",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 8, (5)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "If the ghost in his attic is quiet tonight, Hans will hold a party.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "8"],
+      ["presupposition", "there is exactly one ghost in Hans's attic"]
+    ],
+    "comment": "The antecedent of a conditional is a hole: the existence presupposition projects to the whole sentence.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch8_22",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 8, (22)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "I do not know whether there are any ghosts in Hans's attic. But if the ghost in his attic is quiet tonight, he will hold a party.",
+    "discourseSegments": [
+      "I do not know whether there are any ghosts in Hans's attic.",
+      "But if the ghost in his attic is quiet tonight, he will hold a party."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [
+      {"form": "I do not know whether there are any ghosts in Hans's attic. But if there is exactly one ghost in his attic and it is quiet tonight, he will hold a party.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "8"],
+      ["contrast", "definite description against its Russellian paraphrase"]
+    ],
+    "comment": "The speaker sounds self-contradictory with the description but not with the Russellian paraphrase, so the paraphrase cannot be accurate.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch8_33",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 8, (31), (33)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "I am unsure whether there is a ghost in my attic. I would like the ghost in my attic to be quiet tonight.",
+    "discourseSegments": [
+      "I am unsure whether there is a ghost in my attic.",
+      "I would like the ghost in my attic to be quiet tonight."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Hans sincerely says both.",
+    "judgment": "unacceptable",
+    "alternatives": [
+      {"form": "I am unsure whether there is a ghost in my attic. I would like there to be an entity such that it is a ghost in my attic and nothing else is a ghost in my attic and it is quiet tonight.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "8"],
+      ["contrast", "definite description against its Russellian paraphrase under an attitude verb"]
+    ],
+    "comment": "Hans's attitudes are inconsistent with the description and consistent with the Russellian paraphrase: the description presupposes that he believes there is exactly one ghost.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch8_36",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 8, (36)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Ponce de León is wondering whether the fountain of youth is in Florida.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The speaker does not believe in the existence of a fountain of youth.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "no speaker commitment to a fountain of youth", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "8"],
+      ["presupposition", "Ponce de León believes there is exactly one fountain of youth"]
+    ],
+    "comment": "The description under the attitude verb commits the subject, not the speaker, to the existence of a fountain of youth.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch9_4",
+    "source": {"bibkey": "strawson-1950", "paperLabel": "p. 332"},
+    "reportedIn": {"bibkey": "elbourne-2013", "paperLabel": "ch. 9, (4)"},
+    "language": "stan1293",
+    "primaryText": "The table is covered with books.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Said in a room containing exactly one table, in a world containing many.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "9"],
+      ["incompleteness", "situation pronoun referring to the room"]
+    ],
+    "comment": "An incomplete description: the uniqueness condition is relativized to the restrictor situation contributed by the situation pronoun.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch9_17a",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 9, (17a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "In this village, if a farmer owns a donkey, he beats the donkey and the priest beats the donkey too.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The final verb phrase is downstressed.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "strict", "judgment": "acceptable"},
+      {"name": "sloppy", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "9"],
+      ["description", "the donkey"]
+    ],
+    "comment": "No sloppy reading: the priest is not said to beat his own donkey. A situation pronoun in the final description cannot covary with the priest.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch9_17b",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 9, (17b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "In this village, if a farmer owns a donkey, he beats the donkey he owns and the priest beats the donkey he owns too.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The final verb phrase is downstressed.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "strict", "judgment": "acceptable"},
+      {"name": "sloppy", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "9"],
+      ["description", "the donkey he owns"]
+    ],
+    "comment": "With an overt bound pronoun in the description the sloppy reading is available, as relation-variable theories predict for (17a) too, wrongly.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch10_10a",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 10, (10a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Every man who owns a donkey beats it.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "strong", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "10"],
+      ["structure", "[σ3 [Q [beats [[it donkey] s3]]]]"]
+    ],
+    "comment": "The donkey pronoun is the definite article with a deleted NP; its LF and meaning are those of the description in ch. 6, (3).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch10_21",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 10, (21)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "I saw the Junior Dean. He was worried about the Bollinger dinner.",
+    "discourseSegments": [
+      "I saw the Junior Dean.",
+      "He was worried about the Bollinger dinner."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "10"],
+      ["structure", "[[he [Junior Dean]] s1]"]
+    ],
+    "comment": "A referential pronoun with a deleted NP recovered from its linguistic antecedent.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch10_34",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 10, (34)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "He is usually an Italian.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Said while pointing at Benedict XVI.",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Benedict XVI is usually an Italian.", "judgment": "unacceptable"}
+    ],
+    "readings": [
+      {"name": "descriptive indexical", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["chapter", "10"],
+      ["structure", "[[he Pope] s3]"]
+    ],
+    "comment": "A descriptive indexical: the pronoun is the article with the NP Pope, and usually quantifies over papal reigns.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "elbourne2013_ch10_47",
+    "source": {"bibkey": "elbourne-2013", "paperLabel": "ch. 10, (47)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "He Who Must Not Be Named",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "It which rolls fastest gathers no moss.", "judgment": "ungrammatical"},
+      {"form": "he of the fiery sword", "judgment": "acceptable"},
+      {"form": "he of Mary", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["chapter", "10"],
+      ["structure", "[[he [person [who ...]]] si]"]
+    ],
+    "comment": "A Voldemort phrase: the pronoun combines with a restrictive relative clause on a silent NP person, so pronouns form definite descriptions in the open.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Elbourne2013.lean
+++ b/Linglib/Data/Examples/Elbourne2013.lean
@@ -1,0 +1,396 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Elbourne2013` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Elbourne2013.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Elbourne2013.Examples`.
+-/
+
+namespace Elbourne2013.Examples
+
+open Data.Examples
+
+def ch3_5 : LinguisticExample :=
+  { id := "elbourne2013_ch3_5"
+    source := ⟨"elbourne-2013", "ch. 3, (5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The cat grins."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("referential situation pronoun", .acceptable), ("bound situation pronoun", .acceptable)]
+    paperFeatures := [("chapter", "3"), ("structure", "[[[the cat] s1] grins] or [ς1 [[[the cat] s1] grins]]")]
+    comment := "Two analyses: a referential situation pronoun discharges the uniqueness condition at its referent, a bound one carries it to the topic situation by λ-Conversion II."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch5_2 : LinguisticExample :=
+  { id := "elbourne2013_ch5_2"
+    source := ⟨"donnellan-1966", "pp. 285–286"⟩
+    reportedIn := some ⟨"elbourne-2013", "ch. 5, (2)"⟩
+    language := "stan1293"
+    primaryText := "The murderer is insane."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Attributive: Smith is found foully murdered and no one knows by whom. Referential: Jones is on trial for the murder and behaving oddly in court."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("referential", .acceptable), ("attributive", .acceptable)]
+    paperFeatures := [("chapter", "5"), ("referential", "free situation pronoun"), ("attributive", "bound situation pronoun")]
+    comment := "The referential use has a situation pronoun referring to the courtroom; the attributive use has it bound, so the description is evaluated at the topic situation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch5_13 : LinguisticExample :=
+  { id := "elbourne2013_ch5_13"
+    source := ⟨"donnellan-1966", "p. 287"⟩
+    reportedIn := some ⟨"elbourne-2013", "ch. 5, (13)"⟩
+    language := "stan1293"
+    primaryText := "Who is the man drinking a martini?"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The man gestured at is drinking water from a martini glass."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("chapter", "5"), ("misdescription", "yes")]
+    comment := "Misdescription: a question about a particular person is asked, and the Fregean account locates what went wrong in a false presupposition of existence."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch5_16 : LinguisticExample :=
+  { id := "elbourne2013_ch5_16"
+    source := ⟨"russell-1905", "pp. 487–488"⟩
+    reportedIn := some ⟨"elbourne-2013", "ch. 5, (16)"⟩
+    language := "stan1293"
+    primaryText := "Scott is the author of Waverley."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Scott is Scott.", .acceptable)]
+    readings := []
+    paperFeatures := [("chapter", "5"), ("use", "predicative")]
+    comment := "Predicative use is attributive use: the bound description gives a proposition false at situations where someone else authored Waverley, unlike the identity statement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch6_3 : LinguisticExample :=
+  { id := "elbourne2013_ch6_3"
+    source := ⟨"elbourne-2013", "ch. 6, (3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every man who owns a donkey beats the donkey."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("strong", .acceptable)]
+    paperFeatures := [("chapter", "6"), ("anaphora", "donkey-anaphoric definite description")]
+    comment := "The description's situation pronoun is bound by σ to the minimal situations of the restrictor, each of which contains exactly one donkey."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch6_15 : LinguisticExample :=
+  { id := "elbourne2013_ch6_15"
+    source := ⟨"elbourne-2013", "ch. 6, (15)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If a man beats a donkey, the donkey always kicks him."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("If a man beats a donkey, the donkey kicks him.", .acceptable)]
+    readings := []
+    paperFeatures := [("chapter", "6"), ("anaphora", "donkey-anaphoric definite description under a quantificational adverb")]
+    comment := "The quantificational adverb quantifies over minimal situations in which a man beats a donkey; both descriptions are bound to those situations."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch6_21 : LinguisticExample :=
+  { id := "elbourne2013_ch6_21"
+    source := ⟨"elbourne-2013", "ch. 6, (21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John fed no cat of Mary's before the cat was bathed."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("covarying", .acceptable)]
+    paperFeatures := [("chapter", "6"), ("anaphora", "c-commanded bound definite description")]
+    comment := "The covarying description in the scope of the quantifier is bound by the same mechanism as a donkey description."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch7_7 : LinguisticExample :=
+  { id := "elbourne2013_ch7_7"
+    source := ⟨"elbourne-2013", "ch. 7, (7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary believes that the man who lives upstairs is a spy."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("de dicto", .acceptable), ("de re", .acceptable)]
+    paperFeatures := [("chapter", "7"), ("de dicto", "situation pronoun bound below believes"), ("de re", "situation pronoun referring to the actual world")]
+    comment := "De dicto: every doxastic alternative contains exactly one man upstairs. De re: the man upstairs in the actual world need not live upstairs in Mary's alternatives."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch7_16 : LinguisticExample :=
+  { id := "elbourne2013_ch7_16"
+    source := ⟨"kripke-1977", "p. 9"⟩
+    reportedIn := some ⟨"elbourne-2013", "ch. 7, (16)"⟩
+    language := "stan1293"
+    primaryText := "The number of the planets is necessarily odd."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The speaker does not know how many planets there are, but astronomical theory dictates that the number is odd."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("attributive de re", .acceptable)]
+    paperFeatures := [("chapter", "7"), ("structure", "[ς2 [[[the [number [of [[the planets] s2]]]] s2] [is [necessarily odd]]]]")]
+    comment := "Attributive yet de re: the description is bound by a binder above the modal, so the number is fixed in the topic situation and oddness is claimed in every accessible world."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch8_3 : LinguisticExample :=
+  { id := "elbourne2013_ch8_3"
+    source := ⟨"elbourne-2013", "ch. 8, (3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Hans wants the ghost in his attic to be quiet tonight."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Hans wants there to be exactly one ghost in his attic and for it to be quiet tonight.", .unacceptable)]
+    readings := []
+    paperFeatures := [("chapter", "8"), ("presupposition", "Hans believes there is exactly one ghost in his attic")]
+    comment := "The Russellian paraphrase attributes to Hans the desire to have a ghost; the Fregean analysis presupposes that Hans believes there is exactly one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch8_5 : LinguisticExample :=
+  { id := "elbourne2013_ch8_5"
+    source := ⟨"elbourne-2013", "ch. 8, (5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If the ghost in his attic is quiet tonight, Hans will hold a party."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("chapter", "8"), ("presupposition", "there is exactly one ghost in Hans's attic")]
+    comment := "The antecedent of a conditional is a hole: the existence presupposition projects to the whole sentence."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch8_22 : LinguisticExample :=
+  { id := "elbourne2013_ch8_22"
+    source := ⟨"elbourne-2013", "ch. 8, (22)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I do not know whether there are any ghosts in Hans's attic. But if the ghost in his attic is quiet tonight, he will hold a party."
+    discourseSegments := ["I do not know whether there are any ghosts in Hans's attic.", "But if the ghost in his attic is quiet tonight, he will hold a party."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .unacceptable
+    alternatives := [("I do not know whether there are any ghosts in Hans's attic. But if there is exactly one ghost in his attic and it is quiet tonight, he will hold a party.", .acceptable)]
+    readings := []
+    paperFeatures := [("chapter", "8"), ("contrast", "definite description against its Russellian paraphrase")]
+    comment := "The speaker sounds self-contradictory with the description but not with the Russellian paraphrase, so the paraphrase cannot be accurate."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch8_33 : LinguisticExample :=
+  { id := "elbourne2013_ch8_33"
+    source := ⟨"elbourne-2013", "ch. 8, (31), (33)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I am unsure whether there is a ghost in my attic. I would like the ghost in my attic to be quiet tonight."
+    discourseSegments := ["I am unsure whether there is a ghost in my attic.", "I would like the ghost in my attic to be quiet tonight."]
+    glossedTokens := []
+    translation := ""
+    context := "Hans sincerely says both."
+    judgment := .unacceptable
+    alternatives := [("I am unsure whether there is a ghost in my attic. I would like there to be an entity such that it is a ghost in my attic and nothing else is a ghost in my attic and it is quiet tonight.", .acceptable)]
+    readings := []
+    paperFeatures := [("chapter", "8"), ("contrast", "definite description against its Russellian paraphrase under an attitude verb")]
+    comment := "Hans's attitudes are inconsistent with the description and consistent with the Russellian paraphrase: the description presupposes that he believes there is exactly one ghost."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch8_36 : LinguisticExample :=
+  { id := "elbourne2013_ch8_36"
+    source := ⟨"elbourne-2013", "ch. 8, (36)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Ponce de León is wondering whether the fountain of youth is in Florida."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The speaker does not believe in the existence of a fountain of youth."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("no speaker commitment to a fountain of youth", .acceptable)]
+    paperFeatures := [("chapter", "8"), ("presupposition", "Ponce de León believes there is exactly one fountain of youth")]
+    comment := "The description under the attitude verb commits the subject, not the speaker, to the existence of a fountain of youth."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch9_4 : LinguisticExample :=
+  { id := "elbourne2013_ch9_4"
+    source := ⟨"strawson-1950", "p. 332"⟩
+    reportedIn := some ⟨"elbourne-2013", "ch. 9, (4)"⟩
+    language := "stan1293"
+    primaryText := "The table is covered with books."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Said in a room containing exactly one table, in a world containing many."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("chapter", "9"), ("incompleteness", "situation pronoun referring to the room")]
+    comment := "An incomplete description: the uniqueness condition is relativized to the restrictor situation contributed by the situation pronoun."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch9_17a : LinguisticExample :=
+  { id := "elbourne2013_ch9_17a"
+    source := ⟨"elbourne-2013", "ch. 9, (17a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "In this village, if a farmer owns a donkey, he beats the donkey and the priest beats the donkey too."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The final verb phrase is downstressed."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("strict", .acceptable), ("sloppy", .unacceptable)]
+    paperFeatures := [("chapter", "9"), ("description", "the donkey")]
+    comment := "No sloppy reading: the priest is not said to beat his own donkey. A situation pronoun in the final description cannot covary with the priest."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch9_17b : LinguisticExample :=
+  { id := "elbourne2013_ch9_17b"
+    source := ⟨"elbourne-2013", "ch. 9, (17b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "In this village, if a farmer owns a donkey, he beats the donkey he owns and the priest beats the donkey he owns too."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The final verb phrase is downstressed."
+    judgment := .acceptable
+    alternatives := []
+    readings := [("strict", .acceptable), ("sloppy", .acceptable)]
+    paperFeatures := [("chapter", "9"), ("description", "the donkey he owns")]
+    comment := "With an overt bound pronoun in the description the sloppy reading is available, as relation-variable theories predict for (17a) too, wrongly."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch10_10a : LinguisticExample :=
+  { id := "elbourne2013_ch10_10a"
+    source := ⟨"elbourne-2013", "ch. 10, (10a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every man who owns a donkey beats it."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("strong", .acceptable)]
+    paperFeatures := [("chapter", "10"), ("structure", "[σ3 [Q [beats [[it donkey] s3]]]]")]
+    comment := "The donkey pronoun is the definite article with a deleted NP; its LF and meaning are those of the description in ch. 6, (3)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch10_21 : LinguisticExample :=
+  { id := "elbourne2013_ch10_21"
+    source := ⟨"elbourne-2013", "ch. 10, (21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I saw the Junior Dean. He was worried about the Bollinger dinner."
+    discourseSegments := ["I saw the Junior Dean.", "He was worried about the Bollinger dinner."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("chapter", "10"), ("structure", "[[he [Junior Dean]] s1]")]
+    comment := "A referential pronoun with a deleted NP recovered from its linguistic antecedent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch10_34 : LinguisticExample :=
+  { id := "elbourne2013_ch10_34"
+    source := ⟨"elbourne-2013", "ch. 10, (34)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "He is usually an Italian."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Said while pointing at Benedict XVI."
+    judgment := .acceptable
+    alternatives := [("Benedict XVI is usually an Italian.", .unacceptable)]
+    readings := [("descriptive indexical", .acceptable)]
+    paperFeatures := [("chapter", "10"), ("structure", "[[he Pope] s3]")]
+    comment := "A descriptive indexical: the pronoun is the article with the NP Pope, and usually quantifies over papal reigns."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ch10_47 : LinguisticExample :=
+  { id := "elbourne2013_ch10_47"
+    source := ⟨"elbourne-2013", "ch. 10, (47)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "He Who Must Not Be Named"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := [("It which rolls fastest gathers no moss.", .ungrammatical), ("he of the fiery sword", .acceptable), ("he of Mary", .ungrammatical)]
+    readings := []
+    paperFeatures := [("chapter", "10"), ("structure", "[[he [person [who ...]]] si]")]
+    comment := "A Voldemort phrase: the pronoun combines with a restrictive relative clause on a silent NP person, so pronouns form definite descriptions in the open."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ch3_5, ch5_2, ch5_13, ch5_16, ch6_3, ch6_15, ch6_21, ch7_7, ch7_16, ch8_3, ch8_5, ch8_22, ch8_33, ch8_36, ch9_4, ch9_17a, ch9_17b, ch10_10a, ch10_21, ch10_34, ch10_47]
+
+end Elbourne2013.Examples

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -1,796 +1,526 @@
-import Linglib.Semantics.Presupposition.Basic
-import Linglib.Semantics.Definiteness.Defs
+import Linglib.Data.Examples.Elbourne2013
 import Linglib.Semantics.Definiteness.Maximality
-import Linglib.Semantics.Tense.Pronoun
+import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Quantification.ChoiceFunction
-import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Semantics.Definiteness.Basic
-import Linglib.Semantics.Reference.Donnellan
-import Linglib.Fragments.English.Determiners
-import Linglib.Fragments.English.Pronouns
-import Linglib.Fragments.English.Nouns
+import Mathlib.Order.Minimal
 
 /-!
-# [elbourne-2013]: Situation-Semantic Definite Descriptions [elbourne-2013]
-[barwise-perry-1983] [elbourne-2005] [heim-1982] [postal-1966] [schwarz-2009] [kamp-1981] [stanley-szab-2000] [tonhauser-beaver-roberts-simons-2013] [roberts-2012]
-[donnellan-1966] [kripke-1977] [karttunen-1974-presupposition]
+# Elbourne (2013): Definite Descriptions
 
-Formalizes the core theoretical machinery and empirical predictions from:
+This file formalizes [elbourne-2013]'s Fregean situation semantics for the definite article.
+Situations are parts of possible worlds, ordered by parthood, with worlds the maximal situations
+([kratzer-1989], [barwise-perry-1983]); quantifiers range over minimal situations. The article
+takes a property and a situation and, on the domain condition that exactly one thing has the
+property in that situation, denotes that thing, so a definite description is a partial function
+from situations to individuals. Its situation pronoun may be free, referring to a contextually
+given situation, or bound by the abstractor of the containing proposition. The choice yields the
+book's unifications: a free pronoun discharges the uniqueness presupposition at its referent and
+makes the sentence about a particular individual, Donnellan's referential use; a bound pronoun
+carries the presupposition to the situation the proposition is applied to, the attributive use,
+by the rule λ-Conversion II. Binding below an intensional operator gives the de dicto reading,
+reference to the actual world inside it the de re reading, and binding above it Kripke's
+attributive-yet-de-re number of the planets. Under attitude verbs the presupposition projects to
+the subject's beliefs ([karttunen-1974-presupposition]), which is why a definite description,
+unlike its Russellian paraphrase, makes Hans inconsistent when he is unsure whether there is a
+ghost in his attic. Donkey-anaphoric descriptions are bound to the minimal situations introduced
+by the restrictor, each of which contains exactly one donkey, so *every man who owns a donkey
+beats the donkey* gets the strong reading; and since a description depends only on its situation,
+a downstressed repetition of *the donkey* has no sloppy reading, unlike the relation-variable
+descriptions of [stanley-szab-2000]. Pronouns have the article's lexical entry, their noun phrase
+supplied by NP-deletion.
 
-  Elbourne, P. (2013). Definite Descriptions.
-  Oxford Studies in Semantics and Pragmatics 1.
+## Implementation notes
 
-Elbourne argues that definite descriptions have a Fregean/Strawsonian
-semantics — they are type e, introduce a presupposition of existence +
-uniqueness, and are evaluated *relative to situations* (parts of worlds).
+* Situations are any partial order; minimality is mathlib's `Minimal`, and the lexical entries of
+  §2.3.3 are transcribed with it. The article is `russellIota` at the situation, so its domain
+  condition is `∃!` (`the_isSome_iff`), and a sentence is `PartialProp.presupOfReferent` of the
+  description; the free/bound status of a situation pronoun is the substrate's `SitVarStatus`,
+  whose two values the book introduced. A description inside a scope contributes `∃ z ∈ the f s`,
+  the assertion of `presupOfReferent` with `Option` membership.
+* Intensional operators are universal over an accessibility relation and lift partial
+  propositions by requiring presupposition and assertion throughout the accessible situations;
+  attitude verbs check the presupposition in the subject's doxastic alternatives and the
+  assertion in the verb's own, Karttunen's projection.
+* The village of ch. 6 and ch. 9 is a concrete model: situations are finite sets of atomic
+  facts ordered by inclusion, [kratzer-1989]'s states of affairs, so minimal situations are
+  computed and the strong reading of the donkey sentence is a theorem rather than a reading of
+  the truth conditions.
+* The examples are `Data.Examples.Elbourne2013`.
 
-The single lexical entry ⟦the⟧ = λf.λs : ∃!x f(x)(s) = 1. ιx f(x)(s) = 1
-unifies:
-- Referential vs attributive uses (Ch 5): free vs bound situation pronoun
-- Presupposition projection (Ch 4): domain conditions + λ-Conversion
-- Donkey anaphora (Ch 6): pronouns = the + NP-deletion; minimal situations
-- De re / de dicto (Ch 7): scope of situation binding, not DP scope
-- Incomplete definites (Ch 9): situation restricts evaluation domain
-- Existence entailments (Ch 8): presupposition projects to belief states
+## TODO
 
-## Key Results
+* Ch. 4's projection through possibility modals, disjunction and negation, ch. 7's modal
+  subordination and counterfactuals, and ch. 10's descriptive indexicals are not represented.
 
-- `the_sit` / `the_sit'`: Elbourne's situation-relative ⟦the⟧
-- `the_sit_at_world_eq_the_uniq_w`: specializes to existing `the_uniq_w`
-- `attributive_is_the_sit_bound`: Donnellan's attributive = `the_sit'` (bound s)
-- `donkey_uniqueness_from_minimality`: minimal situations yield uniqueness
-- `pronoun_is_definite_article`: ⟦it⟧ = ⟦the⟧
-- `the_sit_assertion_implies_presup`: assertion entails presupposition
+## References
 
-## Empirical Chain
-
-```
-Fragments/English/Determiners.lean
-  "the": qforce =.definite → the_sit / the_sit'
-Fragments/English/Pronouns.lean
-  "it"/"he"/"she": pronounType =.personal, person =.third → the_sit' + NP-deletion
-    ↓
-(this file: theory + empirical predictions)
-  referential/attributive → truth values → match empirical judgments
-  incomplete definites → situation-relative uniqueness
-  donkey anaphora → minimality → uniqueness
-```
-
+* [elbourne-2013]
+* [elbourne-2005]
+* [kratzer-1989]
+* [barwise-perry-1983]
+* [heim-kratzer-1998]
+* [buring-2004]
+* [strawson-1950]
+* [russell-1905]
+* [donnellan-1966]
+* [kripke-1977]
+* [karttunen-1974-presupposition]
+* [stanley-szab-2000]
+* [geach-1962]
 -/
 
 namespace Elbourne2013
 
-open Semantics.Context (Index)
+open Definiteness Presupposition Quantification.ChoiceFunction
 
-open Presupposition
-open Presupposition.PartialProp
-open Definiteness
-open Definiteness
-open Tense (ReferentialMode)
-open Quantification.ChoiceFunction (SitVarStatus)
-open Definiteness
-open Reference.Donnellan (UseMode definiteNominal)
+/-! ### Quantification over minimal situations (§2.3.3) -/
 
--- ════════════════════════════════════════════════════════════════
--- §1: Situation Ontology ([barwise-perry-1983], [kratzer-1989])
--- ════════════════════════════════════════════════════════════════
+section Quantification
 
-/-- A situation frame: the ontological foundation for Elbourne's system.
+variable {S : Type*} [PartialOrder S] {E : Type*}
 
-Situations are parts of worlds, ordered by a part-of relation ≤.
-Worlds are maximal situations. Properties and quantifiers are evaluated
-relative to situations rather than worlds, enabling situation-dependent
-uniqueness and domain restriction.
+/-- The morpheme `Q` (22): an extended situation, a minimal situation between `s'` and `s` in
+which `x` has the property. -/
+def Q (f : E → S → Prop) (x : E) (s s' : S) : Prop :=
+  ∃ s'', Minimal (λ s'' => s' ≤ s'' ∧ s'' ≤ s ∧ f x s'') s''
 
-Based on [barwise-perry-1983]: situations are "individuals having
-properties and standing in relations at various spatiotemporal locations".
-[kratzer-1989]: situations are parts of worlds with a mereological structure. -/
-structure SituationFrame where
-  /-- Domain of situations (D_s) — includes both partial situations and worlds -/
-  Sit : Type
-  /-- Domain of entities (D_e) -/
-  Ent : Type
-  /-- Part-of relation (≤): s₁ ≤ s₂ means s₁ is part of s₂ -/
-  le : Sit → Sit → Prop
-  /-- Reflexivity: every situation is part of itself -/
-  le_refl : ∀ s, le s s
-  /-- Transitivity: part-of is transitive -/
-  le_trans : ∀ s₁ s₂ s₃, le s₁ s₂ → le s₂ s₃ → le s₁ s₃
-  /-- Antisymmetry: mutual part-of implies identity -/
-  le_antisymm : ∀ s₁ s₂, le s₁ s₂ → le s₂ s₁ → s₁ = s₂
+/-- `every` (20): every minimal situation, within the restrictor situation `s₀` and the
+truth-supporting situation `s`, in which an individual has the restrictor property satisfies the
+nuclear scope. -/
+def every (s₀ : S) (f : E → S → Prop) (g : E → S → S → Prop) (s : S) : Prop :=
+  ∀ x s', Minimal (λ s' => s' ≤ s₀ ∧ s' ≤ s ∧ f x s') s' → g x s s'
 
-/-- A world is a maximal situation — one that no other situation properly extends. -/
-def SituationFrame.isWorld (F : SituationFrame) (s : F.Sit) : Prop :=
-  ∀ s', F.le s s' → s = s'
+/-- `a` (21): some minimal restrictor situation satisfies the nuclear scope. -/
+def a (s₀ : S) (f : E → S → Prop) (g : E → S → S → Prop) (s : S) : Prop :=
+  ∃ x s', Minimal (λ s' => s' ≤ s₀ ∧ s' ≤ s ∧ f x s') s' ∧ g x s s'
 
-/-- A situation s is minimal for property P iff P holds at s and at
-no proper part of s. Minimality is key for donkey anaphora (Ch 6):
-in a minimal situation where "a farmer owns a donkey", there is
-exactly one farmer and one donkey, securing uniqueness. -/
-def SituationFrame.isMinimal (F : SituationFrame)
-    (P : F.Sit → Bool) (s : F.Sit) : Prop :=
-  P s = true ∧ ∀ s', F.le s' s → P s' = true → s' = s
+/-- `always` (33): every minimal situation in `s` satisfying the antecedent satisfies the
+consequent. -/
+def always (p : S → Prop) (q : S → S → Prop) (s : S) : Prop :=
+  ∀ s', Minimal (λ s' => s' ≤ s ∧ p s') s' → q s s'
 
--- ════════════════════════════════════════════════════════════════
--- §2: The Situation-Relative Definite Article ([elbourne-2013], Ch 3)
--- ════════════════════════════════════════════════════════════════
+/-- The morpheme `Q_A` (34), the propositional counterpart of `Q`. -/
+def QA (p : S → Prop) (s s' : S) : Prop :=
+  ∃ s'', Minimal (λ s'' => s' ≤ s'' ∧ s'' ≤ s ∧ p s'') s''
 
-/-- ⟦the⟧ in Elbourne's system: the situation-relative Fregean definite.
+end Quantification
 
-⟦the⟧ = λf_{⟨e,st⟩}.λs : s ∈ D_s ∧ ∃!x f(x)(s) = 1. ιx f(x)(s) = 1
+/-! ### The article and its situation pronoun (ch. 3–5) -/
 
-Takes a restrictor (property of entities relative to situations) and a
-situation, presupposes existence+uniqueness *in that situation*, and
-returns the unique satisfier.
+section Article
 
-Built from the canonical `presupOfReferent` combinator with
-`russellIotaList` as the per-situation referent selector.
+variable {S E : Type*}
 
-The situation parameter `s` may be:
-- **Free** (referential use, Ch 5): mapped to a contextually salient s*
-- **Bound** (attributive use, Ch 5): bound by a higher operator (ς, Σ)
-- **Bound by quantifier** (donkey anaphora, Ch 6): bound by always/GEN -/
-def the_sit (F : SituationFrame) (domain : List F.Ent)
-    (restrictor : F.Ent → F.Sit → Bool)
-    (scope : F.Ent → F.Sit → Bool)
-    : PartialProp F.Sit :=
-  presupOfReferent (fun s => russellIotaList domain (fun e => restrictor e s))
-                   (fun e s => scope e s = true)
+/-- The definite article, (3) of ch. 3: `λf.λs : ∃!x f(x)(s). ιx f(x)(s)`, a partial function
+from situations to the unique satisfier of the property in the situation. -/
+noncomputable def the (f : E → S → Prop) (s : S) : Option E := russellIota (f · s)
 
-/-- `the_sit` instantiated with bare type parameters (no SituationFrame).
-    Coincides with the canonical definite (`Donnellan.definiteNominal`
-    resolved) — the same Russellian iota factored through `presupOfReferent`. -/
-def the_sit' {W E : Type} (domain : List E)
-    (restrictor : E → W → Bool) (scope : E → W → Bool) : PartialProp W :=
-  presupOfReferent (fun w => russellIotaList domain (fun e => restrictor e w))
-                   (fun e w => scope e w = true)
+/-- The domain condition of the article: exactly one satisfier in the situation. -/
+theorem the_isSome_iff (f : E → S → Prop) (s : S) : (the f s).isSome ↔ ∃! x, f x s :=
+  russellIota_isSome_iff_exists_unique _
 
--- ════════════════════════════════════════════════════════════════
--- §3: Bridge to the canonical definite (`Donnellan.definiteNominal`)
--- ════════════════════════════════════════════════════════════════
+theorem the_eq_some_iff (f : E → S → Prop) (s : S) (x : E) :
+    the f s = some x ↔ f x s ∧ ∀ y, f y s → y = x :=
+  russellIota_eq_some_iff _ _
 
-/-- `the_sit'` and the canonical definite (`definiteNominal` resolved) denote
-    the same `PartialProp`: both factor through `presupOfReferent` applied to a
-    Russellian iota over the domain. The two names reflect different lineages
-    (Elbourne's situation semantics vs. Donnellan's attributive use); the
-    denotation is one and the same. -/
-theorem the_sit'_eq_definite
-    {W E : Type} (domain : List E)
-    (restrictor : E → W → Bool) (scope : E → W → Bool) :
-    the_sit' domain restrictor scope
-      = (definiteNominal domain restrictor).resolve
-          (fun e w => scope e w = true) ⟨⟩ :=
+/-- A pronoun, (4b) of ch. 10: the article's entry, its noun phrase supplied by NP-deletion. -/
+noncomputable def pronoun (np : E → S → Prop) : S → Option E := the np
+
+/-- The situation a situation pronoun contributes at evaluation situation `s`: its referent `s₀`
+when free, the situation abstracted over by the containing proposition when bound (Situation
+Binding I and λ-Conversion II). -/
+def sitValue : SitVarStatus → S → S → S
+  | .free, s₀, _ => s₀
+  | .bound, _, s => s
+
+/-- `[[the NP] sᵢ]`, (4) of ch. 3: the description with its situation pronoun. -/
+noncomputable def description (st : SitVarStatus) (s₀ : S) (f : E → S → Prop) (s : S) :
+    Option E :=
+  the f (sitValue st s₀ s)
+
+/-- `[[[the NP] sᵢ] VP]`: the sentence as a partial proposition, (3) of ch. 4 for a free pronoun
+and (4) for a bound one. -/
+noncomputable def sentence (st : SitVarStatus) (s₀ : S) (f vp : E → S → Prop) : PartialProp S :=
+  PartialProp.presupOfReferent (description st s₀ f) vp
+
+/-- A referential situation pronoun discharges the domain condition at its referent, whatever
+situation the proposition is applied to. -/
+theorem sentence_free_presup (s₀ : S) (f vp : E → S → Prop) (s : S) :
+    (sentence .free s₀ f vp).presup s ↔ ∃! x, f x s₀ :=
+  the_isSome_iff f s₀
+
+/-- A bound situation pronoun carries the domain condition to the topic situation: the
+proposition is partial, and presupposes exactly one satisfier where it is applied. -/
+theorem sentence_bound_presup (s₀ : S) (f vp : E → S → Prop) (s : S) :
+    (sentence .bound s₀ f vp).presup s ↔ ∃! x, f x s :=
+  the_isSome_iff f s
+
+/-- Where the description denotes, the sentence says of that individual what the predicate says
+of it; a referential description makes the proposition object-dependent, (12) of ch. 5. -/
+theorem sentence_assertion (st : SitVarStatus) (s₀ : S) (f vp : E → S → Prop) {s : S} {x : E}
+    (h : description st s₀ f s = some x) : (sentence st s₀ f vp).assertion s ↔ vp x s :=
+  Iff.of_eq (PartialProp.presupOfReferent_assertion_some _ _ _ _ h)
+
+/-- Attributive use, (15) of ch. 5: the description is bound, so which individual is described
+is a function of the situation of evaluation, not of the context. -/
+theorem description_bound (s₀ : S) (f : E → S → Prop) (s : S) :
+    description .bound s₀ f s = the f s :=
   rfl
 
-/-- The presupposition of `the_sit'` is determined solely by the filter result. -/
-theorem the_sit_presup_depends_on_filter
-    {W E : Type} (domain₁ domain₂ : List E)
-    (restrictor scope : E → W → Bool) (w : W)
-    (h : domain₁.filter (λ e => restrictor e w) =
-         domain₂.filter (λ e => restrictor e w)) :
-    (the_sit' domain₁ restrictor scope).presup w =
-    (the_sit' domain₂ restrictor scope).presup w := by
-  simp only [the_sit', presupOfReferent_presup, russellIotaList, h]
-
-/-- A true assertion entails a satisfied presupposition. -/
-theorem the_sit_assertion_implies_presup
-    {W E : Type} (domain : List E)
-    (restrictor : E → W → Bool) (scope : E → W → Bool)
-    (w : W) (h : (the_sit' domain restrictor scope).assertion w) :
-    (the_sit' domain restrictor scope).presup w := by
-  simp only [the_sit', presupOfReferent, russellIotaList] at h ⊢
-  split at h <;> simp_all [Option.isSome]
-
--- ════════════════════════════════════════════════════════════════
--- §4: Referential vs Attributive ([elbourne-2013], Ch 5)
--- ════════════════════════════════════════════════════════════════
-
-/-- Donnellan's attributive semantics (the canonical `definiteNominal`
-resolved) IS `the_sit'` with a bound situation variable. -/
-theorem attributive_is_the_sit_bound
-    {W E : Type} (domain : List E)
-    (restrictor : E → W → Bool) (scope : E → W → Bool) :
-    (definiteNominal domain restrictor).resolve (fun e w => scope e w = true) ⟨⟩ =
-    the_sit' domain restrictor scope := rfl
-
--- ════════════════════════════════════════════════════════════════
--- §5: Donkey Anaphora via Minimal Situations ([elbourne-2013], Ch 6)
--- ════════════════════════════════════════════════════════════════
-
-/-- In Elbourne's system, donkey pronouns are definite articles with
-phonologically null NP complements (NP-deletion). -/
-structure DonkeyConfig (F : SituationFrame) where
-  /-- The restrictor property (e.g., "donkey") -/
-  nounContent : F.Ent → F.Sit → Bool
-  /-- The pronoun's situation variable -/
-  sitVar : F.Sit
-  /-- The domain of entities -/
-  domain : List F.Ent
-
-/-- Uniqueness in donkey contexts derives from minimality of situations. -/
-theorem donkey_uniqueness_from_minimality
-    (F : SituationFrame) (domain : List F.Ent)
-    (restrictor : F.Ent → F.Sit → Bool) (scope : F.Ent → F.Sit → Bool)
-    (s : F.Sit)
-    (h_minimal : F.isMinimal (λ s => match domain.filter (λ e => restrictor e s) with
-                                      | [_] => true | _ => false) s) :
-    (the_sit F domain restrictor scope).presup s := by
-  have hbool := h_minimal.1
-  simp only [the_sit, presupOfReferent_presup, russellIotaList]
-  match hf : domain.filter (fun e => restrictor e s) with
-  | [_] => rfl
-  | [] => simp [hf] at hbool
-  | _ :: _ :: _ => simp [hf] at hbool
-
--- ════════════════════════════════════════════════════════════════
--- §6: De Re / De Dicto and Situation Variable Scope
--- ════════════════════════════════════════════════════════════════
-
-/-- Donnellan's referential/attributive distinction maps to Elbourne's
-free/bound situation variable distinction. -/
-def useModeToSitVar : UseMode → SitVarStatus
-  | .referential => .free
-  | .attributive => .bound
-
-/-- Mapping is total and injective. -/
-theorem useMode_sitVar_roundtrip :
-    ∀ m : UseMode, (match useModeToSitVar m with
-      | .free => UseMode.referential
-      | .bound => UseMode.attributive) = m := by
-  intro m; cases m <;> rfl
-
--- ════════════════════════════════════════════════════════════════
--- §7: Existence Entailments ([elbourne-2013], Ch 8)
--- ════════════════════════════════════════════════════════════════
-
-structure ExistenceEntailmentDatum where
-  /-- The sentence -/
-  sentence : String
-  /-- Does the speaker presuppose existence? -/
-  speakerPresupposes : Bool
-  /-- Does the subject believe in existence? -/
-  subjectBelieves : Bool
-  /-- Is existence actually the case? -/
-  existenceActual : Bool
-  /-- Elbourne's prediction -/
-  elbournePrediction : String
-  /-- Source -/
-  source : String := "Elbourne 2013"
-
--- ════════════════════════════════════════════════════════════════
--- §8: Incomplete Definites ([elbourne-2013], Ch 9)
--- ════════════════════════════════════════════════════════════════
-
-inductive IncompletenessSource where
-  | situationVariable
-  | relationVariable
-  | pragmaticEnrichment
-  | explicitApproach
-  | lotRelationVariable
-  deriving DecidableEq, Repr
-
-def elbournePreferred : IncompletenessSource := .situationVariable
-
--- ════════════════════════════════════════════════════════════════
--- §9: Pronouns as Definite Descriptions ([elbourne-2013], Ch 10)
--- ════════════════════════════════════════════════════════════════
-
-/-- How the deleted NP content is recovered. -/
-inductive NPDeletionSource where
-  | antecedent
-  | visualCue
-  | generalKnowledge
-  | donkeyRestrictor
-  deriving DecidableEq, Repr
-
-structure PronounAsDefinite where
-  pronounForm : String
-  deletedNP : String
-  npSource : NPDeletionSource
-  equivalentDefinite : String
-  deriving Repr, BEq
-
-/-- Pronoun denotation: ⟦it⟧ = ⟦the⟧ + NP-deletion. -/
-abbrev pronounDenot {W E : Type} (domain : List E)
-    (recoveredNP : E → W → Bool) (scope : E → W → Bool) : PartialProp W :=
-  the_sit' domain recoveredNP scope
-
-/-- Pronouns = definite articles. -/
-theorem pronoun_is_definite_article
-    {W E : Type} (domain : List E)
-    (restrictor scope : E → W → Bool) :
-    pronounDenot domain restrictor scope = the_sit' domain restrictor scope :=
+/-- Referential use, (11) of ch. 5: the referent enters via the context and is the same at every
+situation of evaluation. -/
+theorem description_free (s₀ : S) (f : E → S → Prop) (s s' : S) :
+    description .free s₀ f s = description .free s₀ f s' :=
   rfl
 
-/-- Pronoun assertions entail pronoun presuppositions. -/
-theorem pronoun_assertion_implies_presup
-    {W E : Type} (domain : List E)
-    (recoveredNP : E → W → Bool) (scope : E → W → Bool)
-    (w : W) (h : (pronounDenot domain recoveredNP scope).assertion w) :
-    (pronounDenot domain recoveredNP scope).presup w :=
-  the_sit_assertion_implies_presup domain recoveredNP scope w h
-
--- ════════════════════════════════════════════════════════════════
--- §10: Situation Binding Operators ([elbourne-2013], Ch 2)
--- ════════════════════════════════════════════════════════════════
-
-/-- Elbourne's three situation binders. -/
-inductive SitBinder where
-  | iota (index : Nat)
-  | sigma (index : Nat)
-  | sigmaSub (index : Nat)
-  deriving DecidableEq, Repr
-
-/-- A situation variable — either free or indexed for binding. -/
-inductive SitVar where
-  | free (salience : Nat := 0)
-  | bound (index : Nat)
-  deriving DecidableEq, Repr
-
--- ════════════════════════════════════════════════════════════════
--- §11: QUD–Situation Bridge ([roberts-1996], [kratzer-2004])
--- ════════════════════════════════════════════════════════════════
-
-/-- A QUD over worlds induces a "relevance" relation on situations. -/
-def qudRelevantSituation
-    (F : SituationFrame) [DecidableEq F.Sit]
-    (leDecide : F.Sit → F.Sit → Bool)
-    (q : QUD F.Sit)
-    (w : F.Sit) (_hw : F.isWorld w)
-    (s : F.Sit) : Prop :=
-  F.le s w
-  ∧ q.r w s
-  ∧ F.isMinimal (λ s' => leDecide s' w && q.sameAnswer w s') s
-
-theorem situation_pronoun_tracks_qud
-    (F : SituationFrame) [DecidableEq F.Sit]
-    (leDecide : F.Sit → F.Sit → Bool)
-    (q : QUD F.Sit)
-    (w : F.Sit) (hw : F.isWorld w)
-    (s : F.Sit) (hs : qudRelevantSituation F leDecide q w hw s)
-    (domain : List F.Ent) [DecidableEq F.Ent]
-    (restrictor scope : F.Ent → F.Sit → Bool)
-    (hRestr : ∀ e, restrictor e s = restrictor e w)
-    (hScope : ∀ e, scope e s = scope e w) :
-    (the_sit F domain restrictor scope).assertion s =
-    (the_sit F domain restrictor scope).assertion w := by
-  unfold the_sit presupOfReferent
-  have hFilter : (fun e => restrictor e s) = (fun e => restrictor e w) := by
-    funext e; exact hRestr e
-  simp only [hFilter]
-  match h : russellIotaList domain (fun e => restrictor e w) with
-  | some e => simp [hScope e]
-  | none => rfl
-
-theorem qud_refinement_monotone
-    (F : SituationFrame) [DecidableEq F.Sit]
-    (leDecide : F.Sit → F.Sit → Bool)
-    (q₁ q₂ : QUD F.Sit)
-    (w : F.Sit) (hw : F.isWorld w)
-    (s₁ s₂ : F.Sit)
-    (hRefine : ∀ a b, q₂.r a b → q₁.r a b)
-    (hs₁ : qudRelevantSituation F leDecide q₁ w hw s₁)
-    (hs₂ : qudRelevantSituation F leDecide q₂ w hw s₂)
-    (hUniq : ∀ s, F.le s w → q₁.r w s → F.le s₁ s) :
-    F.le s₁ s₂ := by
-  exact hUniq s₂ hs₂.1 (hRefine w s₂ hs₂.2.1)
-
--- ════════════════════════════════════════════════════════════════
--- § Fragment Bridge: English Lexical Entries → Elbourne's System
--- ════════════════════════════════════════════════════════════════
-
-/-! ### Bridge 1: "the" → the_sit -/
-
-theorem the_is_definite :
-    English.Determiners.the.definiteness = .definite := rfl
-
-theorem english_the_is_uniqueness :
-    DefPresupType.uniqueness ∈ English.Determiners.the.presupTypes := by
-  decide
-
-theorem english_demonstratives_are_definite :
-    English.Determiners.this.deictic = .proximal ∧
-    English.Determiners.that.deictic = .distal :=
-  ⟨rfl, rfl⟩
-
-/-! ### Bridge 3: Pronouns → the_sit + NP-deletion -/
-
--- These are personal pronouns *by type* (`PersonalPronoun`), so the former
--- `.pronounType = .personal` conjunct is now true by construction; only the
--- φ-feature content is stated.
-theorem it_entry_classification :
-    English.Pronouns.it.person = some .third ∧
-    English.Pronouns.it.number = some .singular :=
-  ⟨rfl, rfl⟩
-
-theorem he_entry_classification :
-    English.Pronouns.he.person = some .third ∧
-    English.Pronouns.he.number = some .singular ∧
-    English.Pronouns.he.case_ = some .nom :=
-  ⟨rfl, rfl, rfl⟩
-
-theorem she_entry_classification :
-    English.Pronouns.she.person = some .third ∧
-    English.Pronouns.she.number = some .singular ∧
-    English.Pronouns.she.case_ = some .nom :=
-  ⟨rfl, rfl, rfl⟩
-
-/-! ### Bridge 4: Donnellan → Elbourne -/
-
-theorem referential_is_free :
-    useModeToSitVar .referential = .free := rfl
-theorem attributive_is_bound :
-    useModeToSitVar .attributive = .bound := rfl
-
-/-! ### Bridge 5: Pronoun-as-definite examples -/
-
-def donkeyPronounExample : PronounAsDefinite :=
-  { pronounForm := "it"
-  , deletedNP := "donkey"
-  , npSource := .donkeyRestrictor
-  , equivalentDefinite := "the donkey" }
-
-def anaphoricPronounExample : PronounAsDefinite :=
-  { pronounForm := "he"
-  , deletedNP := "Junior Dean"
-  , npSource := .antecedent
-  , equivalentDefinite := "the Junior Dean" }
-
-def voldemortExample : PronounAsDefinite :=
-  { pronounForm := "he"
-  , deletedNP := "person"
-  , npSource := .generalKnowledge
-  , equivalentDefinite := "the person who hesitates" }
-
--- ════════════════════════════════════════════════════════════════
--- § Example 1: Referential vs Attributive (Ch 5)
--- "The murderer of Smith is insane"
--- ════════════════════════════════════════════════════════════════
-
-section RefAttr
-
--- TODO: Bool→Prop migration of isMurderer/isInsane/isTable/isCoveredWithBooks/
--- isDonkey/isBeaten/isPresident/isSpy/isGhost/isQuiet cascades to
--- Linglib/Semantics/Presupposition/Basic.lean (presupOfReferent : (W → Option E) → ...)
--- and Linglib/Semantics/Definiteness/Maximality.lean (russellIotaList : List E → (E → Bool) → Option E).
--- These predicates feed into the_sit'/the_sit/definiteNominal which require E → W → Bool.
--- Migration deferred until those external Core APIs migrate to Prop with [DecidablePred].
-
-inductive Sit where
-  | sCourtroom | sOffice | wActual
-  deriving DecidableEq, Repr
-
-inductive Ent where
-  | jones | smith | wilson | table1 | table2 | table3
-  deriving DecidableEq, Repr
-
-def allEnts : List Ent := [.jones, .smith, .wilson, .table1, .table2, .table3]
-
-def isMurderer : Ent → Sit → Bool
-  | .jones, .sCourtroom => true
-  | .wilson, .wActual => true
-  | _, _ => false
-
-def isInsane : Ent → Sit → Bool
-  | .jones, _ => true
-  | _, _ => false
-
-def theMurderer : PartialProp Sit := the_sit' allEnts isMurderer isInsane
-
-theorem referential_presup :
-    theMurderer.presup .sCourtroom := rfl
-theorem referential_assertion :
-    theMurderer.assertion .sCourtroom := rfl
-
-theorem attributive_presup :
-    theMurderer.presup .wActual := rfl
-theorem attributive_assertion :
-    ¬ theMurderer.assertion .wActual := by
-  show ¬ ((false : Bool) = true); decide
-
-theorem ref_attr_diverge :
-    theMurderer.assertion .sCourtroom ∧ ¬ theMurderer.assertion .wActual :=
-  ⟨referential_assertion, attributive_assertion⟩
-
-def refSitVar : SitVar := .free
-def attrSitVar : SitVar := .bound 1
-
-theorem same_entry_both_readings :
-    theMurderer = theMurderer := rfl
-
-end RefAttr
-
--- ════════════════════════════════════════════════════════════════
--- § Example 2: Incomplete Definites (Ch 9)
--- "The table is covered with books"
--- ════════════════════════════════════════════════════════════════
-
-section Incomplete
-
-def isTable : Ent → Sit → Bool
-  | .table1, .sOffice => true
-  | .table1, .wActual => true
-  | .table2, .wActual => true
-  | .table3, .wActual => true
-  | _, _ => false
-
-def isCoveredWithBooks : Ent → Sit → Bool
-  | .table1, _ => true
-  | _, _ => false
-
-def theTable : PartialProp Sit := the_sit' allEnts isTable isCoveredWithBooks
-
-theorem incomplete_presup_office :
-    theTable.presup .sOffice := rfl
-theorem incomplete_presup_world :
-    ¬ theTable.presup .wActual := by show ¬ ((false : Bool) = true); decide
-theorem incomplete_assertion_office :
-    theTable.assertion .sOffice := rfl
-
-theorem incompleteness_is_situation_variable :
-    elbournePreferred = .situationVariable := rfl
-
-end Incomplete
-
--- ════════════════════════════════════════════════════════════════
--- § Example 3: Donkey Anaphora via Minimality (Ch 6)
--- "Every farmer who owns a donkey beats it"
--- ════════════════════════════════════════════════════════════════
-
-section Donkey
-
-inductive DkEnt where
-  | farmer1 | farmer2 | donkey_a | donkey_b | donkey_c
-  deriving DecidableEq, Repr
-
-inductive DkSit where
-  | sMin1 | sMin2 | wActual
-  deriving DecidableEq, Repr
-
-def dkLe : DkSit → DkSit → Prop
-  | _, .wActual => True
-  | .sMin1, .sMin1 => True
-  | .sMin2, .sMin2 => True
-  | _, _ => False
-
-private theorem dkLe_refl : ∀ s, dkLe s s := by
-  intro s; cases s <;> exact trivial
-
-private theorem dkLe_trans : ∀ s₁ s₂ s₃, dkLe s₁ s₂ → dkLe s₂ s₃ → dkLe s₁ s₃ := by
-  intro s₁ s₂ s₃ h₁ h₂
-  cases s₁ <;> cases s₂ <;> cases s₃ <;>
-    first | exact trivial | exact h₁.elim | exact h₂.elim
-
-private theorem dkLe_antisymm : ∀ s₁ s₂, dkLe s₁ s₂ → dkLe s₂ s₁ → s₁ = s₂ := by
-  intro s₁ s₂ h₁ h₂
-  cases s₁ <;> cases s₂ <;>
-    first | rfl | exact h₁.elim | exact h₂.elim
-
-def DkF : SituationFrame where
-  Sit := DkSit
-  Ent := DkEnt
-  le := dkLe
-  le_refl := dkLe_refl
-  le_trans := dkLe_trans
-  le_antisymm := dkLe_antisymm
-
-def dkEnts : List DkEnt := [.farmer1, .farmer2, .donkey_a, .donkey_b, .donkey_c]
-
-def isDonkey : DkEnt → DkSit → Bool
-  | .donkey_a, .sMin1 => true
-  | .donkey_b, .sMin2 => true
-  | .donkey_a, .wActual => true
-  | .donkey_b, .wActual => true
-  | .donkey_c, .wActual => true
-  | _, _ => false
-
-def isBeaten : DkEnt → DkSit → Bool
-  | .donkey_a, _ => true
-  | .donkey_b, _ => true
-  | _, _ => false
-
-def donkeyPronoun : PartialProp DkSit := the_sit' dkEnts isDonkey isBeaten
-
-theorem donkey_presup_min1 :
-    donkeyPronoun.presup .sMin1 := rfl
-theorem donkey_presup_min2 :
-    donkeyPronoun.presup .sMin2 := rfl
-theorem donkey_presup_world_fails :
-    ¬ donkeyPronoun.presup .wActual := by show ¬ ((false : Bool) = true); decide
-
-theorem donkey_assertion_min1 :
-    donkeyPronoun.assertion .sMin1 := rfl
-theorem donkey_assertion_min2 :
-    donkeyPronoun.assertion .sMin2 := rfl
-
-def donkeyConfig1 : DonkeyConfig DkF where
-  nounContent := isDonkey
-  sitVar := .sMin1
-  domain := dkEnts
-
-def donkeyConfig2 : DonkeyConfig DkF where
-  nounContent := isDonkey
-  sitVar := .sMin2
-  domain := dkEnts
-
-theorem donkey_uniqueness_via_minimality_min1 :
-    DkF.isMinimal (λ s => match dkEnts.filter (λ e => isDonkey e s) with
-                           | [_] => true | _ => false) .sMin1 := by
-  refine ⟨rfl, ?_⟩
-  intro s' hle _
-  cases s' with
-  | sMin1 => rfl
-  | sMin2 => exact hle.elim
-  | wActual => exact hle.elim
-
-theorem donkey_uniqueness_via_minimality_min2 :
-    DkF.isMinimal (λ s => match dkEnts.filter (λ e => isDonkey e s) with
-                           | [_] => true | _ => false) .sMin2 := by
-  refine ⟨rfl, ?_⟩
-  intro s' hle _
-  cases s' with
-  | sMin1 => exact hle.elim
-  | sMin2 => rfl
-  | wActual => exact hle.elim
-
-end Donkey
-
--- ════════════════════════════════════════════════════════════════
--- § Example 4: De Re / De Dicto with Definites (Ch 7)
--- "Mary believes the president is a spy"
--- ════════════════════════════════════════════════════════════════
-
-section DeReDeDicto
-
-inductive BSit where
-  | actual | belief
-  deriving DecidableEq, Repr
-
-inductive BEnt where
-  | jones | smith | mary
-  deriving DecidableEq, Repr
-
-def bEnts : List BEnt := [.jones, .smith, .mary]
-
-def isPresident : BEnt → BSit → Bool
-  | .jones, .actual => true
-  | .smith, .belief => true
-  | _, _ => false
-
-def isSpy : BEnt → BSit → Bool
-  | .smith, _ => true
-  | _, _ => false
-
-def thePresident : PartialProp BSit := the_sit' bEnts isPresident isSpy
-
-theorem deRe_presup : thePresident.presup .actual := rfl
-theorem deRe_assertion : ¬ thePresident.assertion .actual := by
-  show ¬ ((false : Bool) = true); decide
-
-theorem deDicto_presup : thePresident.presup .belief := rfl
-theorem deDicto_assertion : thePresident.assertion .belief := rfl
-
-theorem deRe_deDicto_diverge :
-    ¬ thePresident.assertion .actual ∧ thePresident.assertion .belief :=
-  ⟨deRe_assertion, deDicto_assertion⟩
-
-theorem deRe_is_free : SitVarStatus.free = useModeToSitVar .referential := rfl
-theorem deDicto_is_bound : SitVarStatus.bound = useModeToSitVar .attributive := rfl
-
-def deReVar : SitVar := .free
-def deDictoVar : SitVar := .bound 1
-
-end DeReDeDicto
-
-/-! ### The Partee tense modes under situation-variable status
-
-[elbourne-2013] generalizes [partee-1973]'s tense–pronoun analogy from
-times to situations: his free/bound `SitVarStatus` collapses Partee's
-three-way mode classification — indexical and anaphoric expressions both
-carry free variables, differing only in how the free variable is
-pragmatically resolved (utterance context vs discourse salience). -/
-
-/-- The coarsening of Partee's three modes to Elbourne's two: free expressions, indexical or
-anaphoric, carry free situation variables. -/
-def toSitVarStatus (m : ReferentialMode) : SitVarStatus := if m.isFree then .free else .bound
-
-/-- Surjective: Partee's classification is at least as fine as Elbourne's. -/
-theorem toSitVarStatus_surjective : ∀ s : SitVarStatus, ∃ m, toSitVarStatus m = s
-  | .free => ⟨.indexical, rfl⟩
-  | .bound => ⟨.bound, rfl⟩
-
-/-- Not injective: indexical ≠ anaphoric but both map to free — the
-    indexical/anaphoric distinction is a pragmatic refinement invisible
-    to the structural free/bound semantics. -/
-theorem toSitVarStatus_not_injective :
-    ReferentialMode.indexical ≠ ReferentialMode.anaphoric ∧
-    toSitVarStatus .indexical = toSitVarStatus .anaphoric :=
-  ⟨nofun, rfl⟩
-
--- ════════════════════════════════════════════════════════════════
--- § Example 5: Existence Entailments under Attitudes (Ch 8)
--- "Hans wants the ghost in his attic to be quiet"
--- ════════════════════════════════════════════════════════════════
-
-section ExistenceEntailment
-
-def hansGhost : ExistenceEntailmentDatum :=
-  { sentence := "Hans wants the ghost in his attic to be quiet tonight."
-  , speakerPresupposes := false
-  , subjectBelieves := true
-  , existenceActual := false
-  , elbournePrediction := "Presupposition projects to Hans's beliefs via Karttunen (1974)"
-  , source := "Elbourne 2013, Ch 8 §8.6" }
-
-def ponceFountain : ExistenceEntailmentDatum :=
-  { sentence := "Ponce de León is wondering whether the fountain of youth is in Florida."
-  , speakerPresupposes := false
-  , subjectBelieves := true
-  , existenceActual := false
-  , elbournePrediction := "Narrow scope: situation bound within wonder → no speaker commitment"
-  , source := "Elbourne 2013, Ch 8 §8.8" }
-
-inductive GhostSit where
-  | actual | belief
-  deriving DecidableEq, Repr
-
-inductive GhostEnt where
-  | hans | ghost
-  deriving DecidableEq, Repr
-
-def ghostEnts : List GhostEnt := [.hans, .ghost]
-
-def isGhost : GhostEnt → GhostSit → Bool
-  | .ghost, .belief => true
-  | _, _ => false
-
-def isQuiet : GhostEnt → GhostSit → Bool
-  | .ghost, _ => true
-  | _, _ => false
-
-def theGhost : PartialProp GhostSit := the_sit' ghostEnts isGhost isQuiet
-
-theorem ghost_presup_belief :
-    theGhost.presup .belief := rfl
-theorem ghost_presup_actual :
-    ¬ theGhost.presup .actual := by show ¬ ((false : Bool) = true); decide
-
-theorem ghost_matches_datum :
-    hansGhost.speakerPresupposes = false ∧
-    hansGhost.subjectBelieves = true ∧
-    hansGhost.existenceActual = false :=
-  ⟨rfl, rfl, rfl⟩
-
-theorem ponce_matches_datum :
-    ponceFountain.speakerPresupposes = false ∧
-    ponceFountain.subjectBelieves = true ∧
-    ponceFountain.existenceActual = false :=
-  ⟨rfl, rfl, rfl⟩
-
-end ExistenceEntailment
-
--- ════════════════════════════════════════════════════════════════
--- § Example 6: Pronouns as Definite Articles (Ch 10)
--- ════════════════════════════════════════════════════════════════
-
-section PronounAsDefiniteExample
-
-def itAsDonkey : PartialProp DkSit :=
-  pronounDenot dkEnts isDonkey isBeaten
-
-theorem pronoun_matches_definite_min1 :
-    itAsDonkey = donkeyPronoun := rfl
-theorem pronoun_presup_min1 :
-    itAsDonkey.presup .sMin1 := rfl
-theorem pronoun_presup_world_fails :
-    ¬ itAsDonkey.presup .wActual := by show ¬ ((false : Bool) = true); decide
-
-theorem np_sources_exercised :
-    donkeyPronounExample.npSource = .donkeyRestrictor ∧
-    anaphoricPronounExample.npSource = .antecedent ∧
-    voldemortExample.npSource = .generalKnowledge :=
-  ⟨rfl, rfl, rfl⟩
-
-end PronounAsDefiniteExample
+/-! ### Intensional operators: de re, de dicto, attributive de re (ch. 7) -/
+
+/-- A universal intensional operator over an accessibility relation, on partial propositions:
+presupposition and assertion of the prejacent are required throughout the accessible
+situations, as in (12) and (14) of ch. 7. -/
+def box (R : S → Set S) (p : PartialProp S) : PartialProp S where
+  presup := λ s => ∀ w ∈ R s, p.presup w
+  assertion := λ s => ∀ w ∈ R s, p.assertion w
+
+/-- De dicto, (11) of ch. 7: the situation pronoun bound by `ς` immediately below the operator. -/
+noncomputable def deDicto (R : S → Set S) (s₀ : S) (f vp : E → S → Prop) : PartialProp S :=
+  box R (sentence .bound s₀ f vp)
+
+/-- De re, (13) of ch. 7: a referential situation pronoun, to the actual world `w₀`, inside the
+operator. -/
+noncomputable def deRe (R : S → Set S) (w₀ : S) (f vp : E → S → Prop) : PartialProp S :=
+  box R (sentence .free w₀ f vp)
+
+/-- Attributive de re, (17) and (25) of ch. 7: the pronoun bound above the operator, so the
+description is evaluated at the topic situation and only the predicate is modalized. -/
+noncomputable def attributiveDeRe (R : S → Set S) (f vp : E → S → Prop) : PartialProp S :=
+  PartialProp.presupOfReferent (the f) λ x s => ∀ w ∈ R s, vp x w
+
+/-- De dicto: every accessible situation must contain exactly one satisfier, and the satisfiers
+may differ. -/
+theorem deDicto_presup (R : S → Set S) (s₀ : S) (f vp : E → S → Prop) (s : S) :
+    (deDicto R s₀ f vp).presup s ↔ ∀ w ∈ R s, ∃! x, f x w :=
+  forall₂_congr λ w _ => sentence_bound_presup s₀ f vp w
+
+/-- De re: the satisfier is fixed in the actual world, and need not satisfy the property in the
+accessible situations. -/
+theorem deRe_presup (R : S → Set S) (w₀ : S) (f vp : E → S → Prop) (s : S) :
+    (deRe R w₀ f vp).presup s ↔ ∀ w ∈ R s, ∃! x, f x w₀ :=
+  forall₂_congr λ w _ => sentence_free_presup w₀ f vp w
+
+/-- Attributive de re presupposes exactly one satisfier in the topic situation. -/
+theorem attributiveDeRe_presup (R : S → Set S) (f vp : E → S → Prop) (s : S) :
+    (attributiveDeRe R f vp).presup s ↔ ∃! x, f x s :=
+  the_isSome_iff f s
+
+/-- Kripke's number of the planets, (16) of ch. 7: attributive, since the speaker need not know
+which number, yet de re, since the number in the topic situation is what is odd in every
+accessible world. -/
+theorem attributiveDeRe_assertion (R : S → Set S) (f vp : E → S → Prop) {s : S} {x : E}
+    (h : the f s = some x) : (attributiveDeRe R f vp).assertion s ↔ ∀ w ∈ R s, vp x w :=
+  Iff.of_eq (PartialProp.presupOfReferent_assertion_some _ _ _ _ h)
+
+/-! ### Existence entailments (ch. 8) -/
+
+/-- An attitude verb with [karttunen-1974-presupposition]'s projection (§8.6): the complement's
+presupposition is presupposed to hold throughout the subject's doxastic alternatives, its
+assertion throughout the verb's own alternatives, doxastic for *believe* and bouletic for
+*want*. -/
+def attitude (dox R : S → Set S) (p : PartialProp S) : PartialProp S where
+  presup := λ s => ∀ w ∈ dox s, p.presup w
+  assertion := λ s => ∀ w ∈ R s, p.assertion w
+
+/-- (40)–(41) of ch. 8: *Hans wants the ghost in his attic to be quiet* presupposes that Hans
+believes there is exactly one ghost in his attic. -/
+theorem attitude_presup (dox R : S → Set S) (s₀ : S) (f vp : E → S → Prop) (s : S) :
+    (attitude dox R (sentence .bound s₀ f vp)).presup s ↔ ∀ w ∈ dox s, ∃! x, f x w :=
+  forall₂_congr λ w _ => sentence_bound_presup s₀ f vp w
+
+/-- (31) with (33b): a subject unsure whether there is a ghost in his attic cannot felicitously
+want the ghost in his attic to be quiet, since the presupposition attributes the belief to him. -/
+theorem attitude_inconsistent_of_agnostic (dox R : S → Set S) (s₀ : S) (f vp : E → S → Prop)
+    {s : S} (h : ∃ w ∈ dox s, ¬ ∃ x, f x w) :
+    ¬ (attitude dox R (sentence .bound s₀ f vp)).presup s := by
+  rw [attitude_presup]
+  intro hp
+  obtain ⟨w, hw, hno⟩ := h
+  exact hno (hp w hw).exists
+
+/-- The Russellian paraphrase (33a): existence and uniqueness asserted inside the attitude. -/
+def russellian (R : S → Set S) (f vp : E → S → Prop) (s : S) : Prop :=
+  ∀ w ∈ R s, ∃ x, f x w ∧ (∀ y, f y w → y = x) ∧ vp x w
+
+/-- (39) of ch. 8: the antecedent of a conditional is a hole, so the existence presupposition of
+the description projects to the whole conditional. -/
+theorem conditional_presup (s₀ : S) (f vp : E → S → Prop) (q : PartialProp S) (s : S) :
+    (PartialProp.imp (sentence .bound s₀ f vp) q).presup s ↔ (∃! x, f x s) ∧ q.presup s :=
+  and_congr_left' (sentence_bound_presup s₀ f vp s)
+
+end Article
+
+/-- (31) with (33a): the Russellian paraphrase is consistent with agnosticism, since the
+existence claim sits inside the bouletic alternatives; a witness with two situations, one
+without a ghost that the subject leaves open and one with a quiet ghost that he wants. -/
+theorem russellian_consistent :
+    ∃ (dox R : Bool → Set Bool) (f vp : Unit → Bool → Prop),
+      (∃ w ∈ dox true, ¬ ∃ x, f x w) ∧ russellian R f vp true :=
+  ⟨λ _ => Set.univ, λ _ => {true}, λ _ w => w = true, λ _ _ => True,
+    ⟨false, Set.mem_univ _, by simp⟩, λ w hw => ⟨(), hw, λ _ _ => rfl, trivial⟩⟩
+
+/-- (36) of ch. 8: under an attitude verb the description commits the subject, not the speaker,
+to a fountain of youth. The presupposition holds although there is none in the topic
+situation. -/
+theorem attitude_presup_not_speaker :
+    ∃ (dox R : Bool → Set Bool) (f vp : Unit → Bool → Prop) (s : Bool),
+      (attitude dox R (sentence .bound s f vp)).presup s ∧ ¬ ∃ x, f x s :=
+  ⟨λ _ => {true}, λ _ => {true}, λ _ w => w = true, λ _ _ => True, false,
+    (attitude_presup _ _ _ _ _ _).mpr λ w hw => ⟨(), hw, λ _ _ => rfl⟩, by simp⟩
+
+/-! ### The village: situations as sets of facts (ch. 6, ch. 9) -/
+
+/-- Atomic facts of a village: [kratzer-1989]'s states of affairs, thin particulars instantiating
+properties and relations. -/
+inductive Fact (E : Type*)
+  | farmer (x : E)
+  | donkey (x : E)
+  | priest (x : E)
+  | table (x : E)
+  | covered (x : E)
+  | owns (x y : E)
+  | beats (x y : E)
+  deriving DecidableEq
+
+/-- A situation is a finite set of facts, parthood is inclusion, and a world is the set of all
+the facts that hold in it. -/
+abbrev Village (E : Type*) := Finset (Fact E)
+
+section Village
+
+variable {E : Type*}
+
+/-- The minimal situations containing a fact within two bounds are the singleton. -/
+theorem exists_minimal_singleton_iff {t u : Village E} (φ : Fact E) (g : Village E → Prop) :
+    (∃ s, Minimal (λ s => s ≤ t ∧ s ≤ u ∧ φ ∈ s) s ∧ g s) ↔ φ ∈ t ∧ φ ∈ u ∧ g {φ} := by
+  have hmin (ht : φ ∈ t) (hu : φ ∈ u) (s : Village E) :
+      Minimal (λ s => s ≤ t ∧ s ≤ u ∧ φ ∈ s) s ↔ s = {φ} :=
+    minimal_iff_eq ⟨Finset.singleton_subset_iff.mpr ht, Finset.singleton_subset_iff.mpr hu,
+      Finset.mem_singleton_self φ⟩ λ _ h => Finset.singleton_subset_iff.mpr h.2.2
+  constructor
+  · rintro ⟨s, hs, hg⟩
+    have ht := hs.prop.1 hs.prop.2.2
+    have hu := hs.prop.2.1 hs.prop.2.2
+    exact ⟨ht, hu, (hmin ht hu s).mp hs ▸ hg⟩
+  · rintro ⟨ht, hu, hg⟩
+    exact ⟨{φ}, (hmin ht hu _).mpr rfl, hg⟩
+
+variable [DecidableEq E]
+
+/-- An extended situation for a set of facts exists exactly when the facts hold in the
+truth-supporting situation. -/
+theorem Q_subset_iff (Φ : E → Village E) (x : E) (s s' : Village E) :
+    Q (λ x s'' => Φ x ⊆ s'') x s s' ↔ s' ≤ s ∧ Φ x ⊆ s := by
+  constructor
+  · rintro ⟨s'', hs''⟩
+    exact ⟨hs''.prop.1.trans hs''.prop.2.1, hs''.prop.2.2.trans hs''.prop.2.1⟩
+  · rintro ⟨hle, hsub⟩
+    exact ⟨s' ∪ Φ x, (minimal_iff_eq ⟨Finset.subset_union_left, Finset.union_subset hle hsub,
+      Finset.subset_union_right⟩ λ _ h => Finset.union_subset h.1 h.2.2).mpr rfl⟩
+
+/-- The singleton case: an extended situation for a fact. -/
+theorem Q_mem_iff (φ : E → Fact E) (x : E) (s s' : Village E) :
+    Q (λ x s'' => φ x ∈ s'') x s s' ↔ s' ≤ s ∧ φ x ∈ s := by
+  simpa only [Finset.singleton_subset_iff] using Q_subset_iff (λ x => {φ x}) x s s'
+
+/-- *man who owns a donkey*, the restrictor of (4) in ch. 6 with `a` and `Q` inside the relative
+clause. -/
+def ownsADonkey (s₀ : Village E) (x : E) (s' : Village E) : Prop :=
+  Fact.farmer x ∈ s' ∧
+    a s₀ (λ y (s : Village E) => Fact.donkey y ∈ s)
+      (λ y => Q (λ y (s : Village E) => Fact.owns x y ∈ s) y) s'
+
+/-- The relative clause unfolds to facts in the situation. -/
+theorem ownsADonkey_iff (s₀ : Village E) (x : E) {s' : Village E} (h : s' ≤ s₀) :
+    ownsADonkey s₀ x s' ↔ Fact.farmer x ∈ s' ∧ ∃ y, Fact.donkey y ∈ s' ∧ Fact.owns x y ∈ s' := by
+  simp only [ownsADonkey, a, exists_minimal_singleton_iff, Q_mem_iff, Finset.singleton_subset_iff]
+  constructor
+  · rintro ⟨hf, y, -, hd, -, ho⟩
+    exact ⟨hf, y, hd, ho⟩
+  · rintro ⟨hf, y, hd, ho⟩
+    exact ⟨hf, y, h hd, hd, hd, ho⟩
+
+/-- The minimal situations of a farmer owning a donkey within the world: one per owned donkey,
+consisting of the farmer, the donkey and the owning. -/
+theorem minimal_ownsADonkey_iff (w : Village E) (x : E) (s' : Village E) :
+    Minimal (λ s' => s' ≤ w ∧ s' ≤ w ∧ ownsADonkey w x s') s' ↔
+      ∃ y, Fact.farmer x ∈ w ∧ Fact.donkey y ∈ w ∧ Fact.owns x y ∈ w ∧
+        s' = {Fact.farmer x, Fact.donkey y, Fact.owns x y} := by
+  constructor
+  · intro hs
+    obtain ⟨hw, -, hr⟩ := hs.prop
+    obtain ⟨hf, y, hd, ho⟩ := (ownsADonkey_iff w x hw).mp hr
+    have hsub : ({Fact.farmer x, Fact.donkey y, Fact.owns x y} : Village E) ≤ s' := by
+      simp only [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨hf, hd, ho⟩
+    have hA : ({Fact.farmer x, Fact.donkey y, Fact.owns x y} : Village E) ≤ w := hsub.trans hw
+    refine ⟨y, hw hf, hw hd, hw ho, hs.eq_of_ge ⟨hA, hA, ?_⟩ hsub⟩
+    rw [ownsADonkey_iff w x hA]
+    simp
+  · rintro ⟨y, hf, hd, ho, rfl⟩
+    have hA : ({Fact.farmer x, Fact.donkey y, Fact.owns x y} : Village E) ≤ w := by
+      simp only [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨hf, hd, ho⟩
+    refine ⟨⟨hA, hA, ?_⟩, ?_⟩
+    · rw [ownsADonkey_iff w x hA]
+      simp
+    · intro s hs hle
+      obtain ⟨hf', y', hd', ho'⟩ := (ownsADonkey_iff w x hs.1).mp hs.2.2
+      have hy : y' = y := by
+        have := hle hd'
+        simp only [Finset.mem_insert, Finset.mem_singleton, reduceCtorEq, false_or, or_false,
+          Fact.donkey.injEq] at this
+        exact this
+      subst hy
+      simp only [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+      exact ⟨hf', hd', ho'⟩
+
+/-- In the minimal situation of a farmer owning a donkey, *the donkey* denotes that donkey:
+uniqueness from minimality. -/
+theorem the_donkey_minimal (x y : E) :
+    the (λ z (s : Village E) => Fact.donkey z ∈ s) {Fact.farmer x, Fact.donkey y, Fact.owns x y} =
+      some y := by
+  rw [the_eq_some_iff]
+  refine ⟨by simp, λ z hz => ?_⟩
+  simp only [Finset.mem_insert, Finset.mem_singleton, reduceCtorEq, false_or, or_false,
+    Fact.donkey.injEq] at hz
+  exact hz
+
+/-- The domain condition of the donkey-anaphoric description is met by minimality: every minimal
+situation of a farmer owning a donkey contains exactly one donkey, §6.2. -/
+theorem existsUnique_donkey_of_minimal (w : Village E) (x : E) {s' : Village E}
+    (hs : Minimal (λ s' => s' ≤ w ∧ s' ≤ w ∧ ownsADonkey w x s') s') :
+    ∃! z, Fact.donkey z ∈ s' := by
+  obtain ⟨y, -, -, -, rfl⟩ := (minimal_ownsADonkey_iff w x s').mp hs
+  exact (the_isSome_iff (λ z (s : Village E) => Fact.donkey z ∈ s) _).mp
+    (by rw [the_donkey_minimal]; rfl)
+
+/-- The nuclear scope of (4) in ch. 6, `σ₃ [Q [beats [the donkey s₃]]]`: Situation Binding III
+binds the description to the restrictor's minimal situation `s'`, and `Q` extends `s'` to a
+situation in which the beating holds. -/
+noncomputable def beatsTheDonkey (x : E) (s s' : Village E) : Prop :=
+  Q (λ x s'' => ∃ z ∈ the (λ z (s : Village E) => Fact.donkey z ∈ s) s', Fact.beats x z ∈ s'')
+    x s s'
+
+/-- (3) of ch. 6, *every man who owns a donkey beats the donkey*, with the LF (4). -/
+noncomputable def everyOwnerBeatsTheDonkey (s₀ s : Village E) : Prop :=
+  every s₀ (ownsADonkey s₀) beatsTheDonkey s
+
+/-- (10a) of ch. 10, *every man who owns a donkey beats it*: the pronoun with its deleted noun
+phrase in place of the description. -/
+noncomputable def everyOwnerBeatsIt (s₀ s : Village E) : Prop :=
+  every s₀ (ownsADonkey s₀)
+    (λ x s s' => Q (λ x s'' => ∃ z ∈ pronoun (λ z (s : Village E) => Fact.donkey z ∈ s) s',
+      Fact.beats x z ∈ s'') x s s') s
+
+private theorem beatsTheDonkey_iff (w : Village E) (x y : E) :
+    beatsTheDonkey x w {Fact.farmer x, Fact.donkey y, Fact.owns x y} ↔
+      {Fact.farmer x, Fact.donkey y, Fact.owns x y} ≤ w ∧ Fact.beats x y ∈ w := by
+  unfold beatsTheDonkey
+  rw [the_donkey_minimal]
+  simp only [Option.mem_def, Option.some.injEq, exists_eq_left']
+  exact Q_mem_iff (λ x => Fact.beats x y) x w _
+
+/-- The neat semantics for donkey sentences (§6.2): in the village world, the sentence is true
+iff every farmer beats every donkey he owns. The bound description picks out the unique donkey
+of each minimal owning situation, so the reading is the strong one. -/
+theorem everyOwnerBeatsTheDonkey_iff (w : Village E) :
+    everyOwnerBeatsTheDonkey w w ↔
+      ∀ x y, Fact.farmer x ∈ w → Fact.donkey y ∈ w → Fact.owns x y ∈ w → Fact.beats x y ∈ w := by
+  constructor
+  · intro h x y hf hd ho
+    exact ((beatsTheDonkey_iff w x y).mp
+      (h x _ ((minimal_ownsADonkey_iff w x _).mpr ⟨y, hf, hd, ho, rfl⟩))).2
+  · intro h x s' hs
+    obtain ⟨y, hf, hd, ho, rfl⟩ := (minimal_ownsADonkey_iff w x s').mp hs
+    exact (beatsTheDonkey_iff w x y).mpr ⟨hs.prop.1, h x y hf hd ho⟩
+
+/-- The pronoun sentence has the same meaning, being the same LF up to the null noun phrase. -/
+theorem everyOwnerBeatsIt_iff (w : Village E) :
+    everyOwnerBeatsIt w w ↔
+      ∀ x y, Fact.farmer x ∈ w → Fact.donkey y ∈ w → Fact.owns x y ∈ w → Fact.beats x y ∈ w :=
+  everyOwnerBeatsTheDonkey_iff w
+
+/-! ### Incompleteness and the argument from sloppy identity (ch. 9) -/
+
+/-- The room of (4) in ch. 9, with one table, covered with books. -/
+def room : Village Bool := {Fact.table true, Fact.covered true}
+
+/-- The world containing the room and a second table. -/
+def world : Village Bool := {Fact.table true, Fact.table false, Fact.covered true}
+
+theorem room_le_world : room ≤ world := by decide
+
+/-- Incompleteness, (4) of ch. 9: *the table is covered with books* said in a room with one table.
+The referential situation pronoun to the room satisfies the domain condition although the world
+contains two tables. -/
+theorem incomplete_description :
+    (sentence .free room (λ x (s : Village Bool) => Fact.table x ∈ s)
+        (λ x s => Fact.covered x ∈ s)).presup world ∧
+      ¬ ∃! x, Fact.table x ∈ world :=
+  ⟨(sentence_free_presup _ _ _ _).mpr ⟨true, by decide, by decide⟩, λ ⟨_, _, h⟩ =>
+    Bool.noConfusion ((h true (by decide)).trans (h false (by decide)).symm)⟩
+
+/-- A relation-variable description, §9.2.1: `the [f v] NP`, the unique NP-satisfier standing in
+the covert relation to the individual variable `v`, which a higher quantifier may bind. -/
+noncomputable def relDescription {S : Type*} (rel : E → E → S → Prop) (np : E → S → Prop) (v : E)
+    (s : S) : Option E :=
+  russellIota λ x => np x s ∧ rel x v s
+
+omit [DecidableEq E] in
+/-- The relation-variable description covaries with its individual variable: *the donkey* as
+*the donkey v owns* denotes each owner's own donkey, which licenses the sloppy reading of (17b)
+in ch. 9 and would wrongly license one for (17a). -/
+theorem relDescription_eq_some_iff {S : Type*} (rel : E → E → S → Prop) (np : E → S → Prop)
+    (v : E) (s : S) (x : E) :
+    relDescription rel np v s = some x ↔
+      (np x s ∧ rel x v s) ∧ ∀ y, np y s → rel y v s → y = x := by
+  rw [relDescription, russellIota_eq_some_iff]
+  simp only [and_imp]
+
+/-- (29) of ch. 9 with the LF (31): *every farmer who owns a donkey beats the donkey, and the
+priest beats the donkey too*. The quantifier scopes over the conjunction, and both occurrences of
+*the donkey* are bound by `σ` to the same minimal situation. -/
+noncomputable def everyOwnerBeatsTheDonkeyAndThePriestToo (s₀ s : Village E) : Prop :=
+  every s₀ (ownsADonkey s₀)
+    (λ x s s' => Q (λ x s'' => ∃ z ∈ the (λ z (s : Village E) => Fact.donkey z ∈ s) s',
+      Fact.beats x z ∈ s'' ∧
+        ∃ p ∈ the (λ p (s : Village E) => Fact.priest p ∈ s) s₀, Fact.beats p z ∈ s'') x s s') s
+
+/-- The strict reading, (32) of ch. 9: the priest beats each farmer's donkey. A sloppy reading,
+on which the priest beats his own donkey, would need the description to depend on an individual
+variable, which the situation-variable description lacks. -/
+theorem everyOwnerBeatsTheDonkeyAndThePriestToo_iff (w : Village E) {p : E}
+    (hp : the (λ p (s : Village E) => Fact.priest p ∈ s) w = some p) :
+    everyOwnerBeatsTheDonkeyAndThePriestToo w w ↔
+      ∀ x y, Fact.farmer x ∈ w → Fact.donkey y ∈ w → Fact.owns x y ∈ w →
+        Fact.beats x y ∈ w ∧ Fact.beats p y ∈ w := by
+  have key (x y : E) : Q (λ x' s'' => ∃ z ∈ the (λ z (s : Village E) => Fact.donkey z ∈ s)
+        {Fact.farmer x, Fact.donkey y, Fact.owns x y}, Fact.beats x' z ∈ s'' ∧
+          ∃ p ∈ the (λ p (s : Village E) => Fact.priest p ∈ s) w, Fact.beats p z ∈ s'')
+        x w {Fact.farmer x, Fact.donkey y, Fact.owns x y} ↔
+      {Fact.farmer x, Fact.donkey y, Fact.owns x y} ≤ w ∧
+        Fact.beats x y ∈ w ∧ Fact.beats p y ∈ w := by
+    rw [the_donkey_minimal, hp]
+    simp only [Option.mem_def, Option.some.injEq, exists_eq_left']
+    simpa only [Finset.insert_subset_iff, Finset.singleton_subset_iff] using
+      Q_subset_iff (λ x => {Fact.beats x y, Fact.beats p y}) x w
+        {Fact.farmer x, Fact.donkey y, Fact.owns x y}
+  constructor
+  · intro h x y hf hd ho
+    exact ((key x y).mp (h x _ ((minimal_ownsADonkey_iff w x _).mpr ⟨y, hf, hd, ho, rfl⟩))).2
+  · intro h x s' hs
+    obtain ⟨y, hf, hd, ho, rfl⟩ := (minimal_ownsADonkey_iff w x s').mp hs
+    exact (key x y).mpr ⟨hs.prop.1, h x y hf hd ho⟩
+
+end Village
 
 end Elbourne2013

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -29,7 +29,7 @@ referential mechanism operates over different domains.
 
 Later engagements with the analogy live in their own studies:
 `Ogihara1989` (operator–referential reconciliation), `Kratzer1998` (zero
-tense, SOT deletion), `Elbourne2013` (situation-variable coarsening).
+tense, SOT deletion), `Elbourne2013` (situation pronouns, free or bound).
 -/
 
 open Tense

--- a/references.bib
+++ b/references.bib
@@ -4602,7 +4602,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/TypeTheoretic/Discourse.lean;Semantics/TypeTheoretic/Basic.lean;Semantics/Intensional/Situations.lean}
+  sources   = {Studies/Elbourne2013.lean}
 }% REF: Hoeksema, J. (1983). Negative polarity and the comparative.
 @article{hoeksema-1983,
   author    = {Hoeksema, Jack},
@@ -5133,7 +5133,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Conditionals/Counterfactual/Lumping.lean;Semantics/Attitudes/ClauseDenotation/Situation.lean;Semantics/Intensional/Situations.lean}
+  sources   = {Semantics/Attitudes/Anchor.lean;Semantics/Conditionals/Counterfactual/Lumping.lean;Studies/Bondarenko2022.lean;Studies/Elbourne2013.lean}
 }% REF: Kraus, S., Lehmann, D. & Magidor, M. (1990). Nonmonotonic Reasoning, Preferential Models and Cumulative Logics. Artifici
 @article{kraus-magidor-1990,
   author    = {Kraus, Sarit and Lehmann, Daniel and Magidor, Menachem},
@@ -6104,7 +6104,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/German/Tense.lean;Logic/Assignment.lean;Logic/CylindricAlgebra.lean;Semantics/Attitudes/Anchor.lean;Semantics/Composition/Assignment.lean;Semantics/Composition/Coordination.lean;Semantics/Composition/LexEntry.lean;Semantics/Composition/Reduction.lean;Semantics/Composition/Tree.lean;Semantics/Composition/TypeShifting.lean;Semantics/Modification/RelativeClause.lean;Semantics/Reference/Binding.lean;Studies/AbneyKeshet2025.lean;Studies/ArreguiKusumoto1998.lean;Studies/Asudeh2022.lean;Studies/Barker2002.lean;Studies/BeckOdaSugisaki2004.lean;Studies/BumfordCharlow2024.lean;Studies/Charlow2018.lean;Studies/DelPinal2015.lean;Studies/HawkinsGweonGoodman2021.lean;Studies/HeimKratzer1998.lean;Studies/Percus2000.lean;Studies/Snyder2026.lean;Studies/VonStechow2009.lean;Studies/Wellwood2015.lean;Syntax/Tree/Basic.lean}
+  sources   = {Fragments/German/Tense.lean;Logic/Assignment.lean;Logic/CylindricAlgebra.lean;Semantics/Attitudes/Anchor.lean;Semantics/Composition/Assignment.lean;Semantics/Composition/Coordination.lean;Semantics/Composition/LexEntry.lean;Semantics/Composition/Reduction.lean;Semantics/Composition/Tree.lean;Semantics/Composition/TypeShifting.lean;Semantics/Modification/RelativeClause.lean;Semantics/Reference/Binding.lean;Studies/AbneyKeshet2025.lean;Studies/ArreguiKusumoto1998.lean;Studies/Asudeh2022.lean;Studies/Barker2002.lean;Studies/BeckOdaSugisaki2004.lean;Studies/BumfordCharlow2024.lean;Studies/Charlow2018.lean;Studies/DelPinal2015.lean;Studies/Elbourne2013.lean;Studies/HawkinsGweonGoodman2021.lean;Studies/HeimKratzer1998.lean;Studies/Percus2000.lean;Studies/Snyder2026.lean;Studies/VonStechow2009.lean;Studies/Wellwood2015.lean;Syntax/Tree/Basic.lean}
 }% REF: Lahiri, U. (1998). Focus and negative polarity in Hindi.
 @article{lahiri-1998,
   author    = {Lahiri, Utpal},
@@ -8765,7 +8765,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Presupposition/PhiFeatures.lean}
+  sources   = {Data/Examples/Elbourne2013.json;Semantics/Presupposition/PhiFeatures.lean;Studies/Elbourne2013.lean}
 }
 @article{zeevat-1992,
   author    = {Zeevat, Henk},
@@ -9991,7 +9991,7 @@
   subfield  = {semantics/reference},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Reference/Donnellan.lean}
+  sources   = {Data/Examples/Elbourne2013.json;Semantics/Definiteness/Basic.lean;Semantics/Reference/Almog2014.lean;Semantics/Reference/Donnellan.lean;Studies/Elbourne2013.lean;Studies/Ney2026.lean}
 }
 @article{dayal-jiang-2023,
   author    = {Dayal, Veneeta and Jiang, Li Julie},
@@ -10056,6 +10056,20 @@
   role      = {cited},
   sources   = {Studies/Elbourne2026.lean}
 }
+@article{buring-2004,
+  author    = {B{\"u}ring, Daniel},
+  year      = {2004},
+  title     = {Crossover Situations},
+  journal   = {Natural Language Semantics},
+  volume    = {12},
+  number    = {1},
+  pages     = {23--62},
+  doi       = {10.1023/B:NALS.0000011144.81075.a8},
+  subfield  = {semantics/binding},
+  validated = {true},
+  role      = {cited},
+  sources   = {Studies/Elbourne2013.lean}
+}
 @book{elbourne-2013,
   author    = {Elbourne, Paul},
   year      = {2013},
@@ -10068,7 +10082,7 @@
   subfield  = {semantics/reference},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Elbourne2013.lean}
+  sources   = {Data/Examples/Elbourne2013.json;Semantics/Quantification/ChoiceFunction.lean;Studies/CoppockBeaver2015.lean;Studies/Elbourne2013.lean}
 }% REF: Frege, G. (1892). Über Sinn und Bedeutung.
 @article{kripke-1977,
   author    = {Kripke, Saul and },
@@ -10081,7 +10095,7 @@
   role      = {cited},
   doi       = {10.1111/j.1475-4975.1977.tb00045.x},
   validated = {true},
-  sources   = {Studies/Elbourne2013.lean}
+  sources   = {Data/Examples/Elbourne2013.json;Semantics/Reference/Donnellan.lean;Studies/Elbourne2013.lean}
 }% REF: Kripke (1963). Semantical Considerations on Modal Logic.
 @article{kripke-1963,
   author    = {Kripke, Saul},
@@ -12454,7 +12468,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Dynamic/Partial.lean;Semantics/Presupposition/Context.lean;Studies/Heim1992.lean;Studies/Yagi2025.lean;Studies/Elbourne2013.lean}
+  sources   = {Discourse/CommonGround.lean;Semantics/Dynamic/Partial.lean;Semantics/Presupposition/Context.lean;Studies/Elbourne2013.lean;Studies/Heim1992.lean;Studies/TonhauserEtAl2013.lean;Studies/Yagi2025.lean}
 }
 @inproceedings{karttunen-1974,
   author    = {Karttunen, Lauri},
@@ -14359,7 +14373,7 @@
   role      = {cited},
   doi       = {10.1093/mind/XIV.4.479},
   validated = {true},
-  sources   = {Semantics/Reference/Donnellan.lean;Semantics/Definiteness/Maximality.lean;Semantics/Definiteness/Basic.lean}
+  sources   = {Data/Examples/Elbourne2013.json;Data/Examples/VonStechow1984.json;Semantics/Definiteness/Basic.lean;Semantics/Definiteness/Maximality.lean;Studies/Elbourne2013.lean;Studies/VonStechow1984.lean}
 }% REF: Strawson, P. (1950). On Referring. Mind.
 @phdthesis{milsark-1974,
   author    = {Milsark, Gary L.},
@@ -14564,7 +14578,7 @@
   subfield  = {semantics/lexical},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Quantification/DomainRestriction.lean}
+  sources   = {Semantics/Quantification/DomainRestriction.lean;Studies/DavidsonGagne2022.lean;Studies/Elbourne2013.lean}
 }% REF: Simons, M. (2001). On the conversational basis of some presuppositions.
 @article{meier-2003,
   author    = {Meier, Cécile},
@@ -16968,7 +16982,7 @@
     subfield  = {semantics/dynamic},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Reference/PronounDenotation.lean}
+  sources   = {Semantics/Reference/PronounDenotation.lean;Studies/Elbourne2013.lean;Studies/Hanink2021.lean;Studies/PatelGroszGrosz2017.lean}
 }% REF: Brasoveanu, A. (2006). Donkey Pluralities.
 @unpublished{brasoveanu-2006,
   author    = {Brasoveanu, Adrian},
@@ -40673,6 +40687,7 @@
   address   = {Ithaca, NY},
   subfield  = {semantics/anaphora},
   role      = {cited},
+  sources   = {Data/Examples/AbneyKeshet2025.json;Data/Examples/AbramskySadrzadeh2014.json;Data/Examples/Geach1962.json;Data/Examples/Kanazawa1994.json;Studies/AbramskySadrzadeh2014.lean;Studies/Elbourne2013.lean}
 }
 
 @article{gasparri-2025,


### PR DESCRIPTION
Deep cleanse of Elbourne2013 against the book: the String/Bool structs, the `SitBinder`/`SitVar` re-encoding, the `IncompletenessSource` and `PronounAsDefinite` tables, the QUD and Partee bridges and the fragment read-backs go; the examples become `Data/Examples/Elbourne2013.json` (21 rows with the referential/attributive, de re/de dicto and strict/sloppy judgments) and the analysis is the book's own situation semantics.

- the article is `russellIota` at a situation, its domain condition `∃!`, and a sentence is `PartialProp.presupOfReferent` of the description; `sitValue` over the substrate's `SitVarStatus` derives the referential/attributive split (`sentence_free_presup`, `sentence_bound_presup`), the ch. 7 de re / de dicto / attributive-de-re readings under a universal `box`, and ch. 8's Karttunen projection under `attitude` with the agnostic-Hans inconsistency and the Russellian paraphrase's consistency as theorems
- the village of ch. 6 and ch. 9 is a model where situations are finite sets of facts: `minimal_ownsADonkey_iff` computes the minimal restrictor situations, `existsUnique_donkey_of_minimal` discharges the description's domain condition, `everyOwnerBeatsTheDonkey_iff` derives the strong reading, and `everyOwnerBeatsTheDonkeyAndThePriestToo_iff` derives the strict reading of the sloppy-identity argument against relation-variable descriptions (`relDescription_eq_some_iff`)
- bib adds buring-2004 (Crossref); Partee1973's cross-reference docstring line follows the new API
