### PR TITLE
refactor(Studies/ElkinsTorrenceBrown2026): reflex sites along the movement path

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3046,3 +3046,4 @@ import Linglib.Data.Examples.Downing1996
 import Linglib.Data.Examples.Egressy2026
 import Linglib.Data.Examples.Elbourne2013
 import Linglib.Data.Examples.Elbourne2026
+import Linglib.Data.Examples.ElkinsTorrenceBrown2026

--- a/Linglib/Data/Examples/ElkinsTorrenceBrown2026.json
+++ b/Linglib/Data/Examples/ElkinsTorrenceBrown2026.json
@@ -1,0 +1,772 @@
+[
+  {
+    "id": "elkinstorrencebrown2026_10b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(10b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alkye kyim?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["alkye", "who"], ["∅-∅-kyim", "COMPL-B2/3S-die"]
+    ],
+    "translation": "Who died?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.1"],
+      ["mover", "absolutive"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "Absolutive extraction is unmarked: no =(y)a' with an intransitive subject.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_11b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(11b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Titi' tjaq' Li'y?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["titi'", "what"], ["∅-∅-t-jaq'", "COMPL-B2/3SG-A2/3SG-open"], ["Li'y", "María"]
+    ],
+    "translation": "What did María open?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.1"],
+      ["mover", "absolutive"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "Absolutive extraction is unmarked: no =(y)a' with a direct object.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_12b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(12b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alkye jq'on te tjpel ja'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["alkye", "who"], ["∅-∅-jq'o-n", "COMPL-B2/3S-open-ANTIP"], ["t-e", "A2/3S-RN:PAT"],
+      ["tjpel", "door"], ["ja'", "house"]
+    ],
+    "translation": "Who opened the door?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.1"],
+      ["mover", "ergative"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "The Ergative Extraction Constraint: the agent is extracted through an antipassive, which demotes the theme to a relational-noun phrase; no =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_13a",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(13a)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "El tsu'n Li'y spik'b'il tu'n xb'uy.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["∅-∅-el", "COMPL-B2/3SG-DIR"], ["t-su-'n", "A2/3SG-clean-DS"], ["Li'y", "María"],
+      ["spik'b'il", "window"], ["t-u'n", "A2/3SG-RN:INS"], ["xb'uy", "rag"]
+    ],
+    "translation": "María cleaned the window with a rag.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "El tsu'na' Li'y spik'b'il tu'n xb'uy.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.1"],
+      ["mover", "none"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "With the instrument in situ the enclitic is impossible: =(y)a' is associated with extraction, not with the presence of the adjunct.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_13b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(13b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alqu'n el tsu'n(a') Li'y spik'b'il?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["al-qu'n", "what-RN:INS"], ["∅-∅-el", "COMPL-B2/3SG-DIR"],
+      ["t-su-'n(=a')", "A2/3SG-clean-DS=MVMT"], ["Li'y", "María"], ["spik'b'il", "window"]
+    ],
+    "translation": "With what did María clean the window?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Alqu'n el tsu'na' Li'y spik'b'il?", "judgment": "acceptable"},
+      {"form": "Alqu'n el tsu'n Li'y spik'b'il?", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.1"],
+      ["mover", "instrument"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Instrument extraction optionally triggers =(y)a'; the relational noun inverts around the wh-word (pied-piping with inversion).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_14b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(14b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alqe tjaq'(a')ya tjpel ja'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["al-qe", "who-RN:BEN"], ["∅-∅-t-jaq'(=a')=ya", "COMPL-B2/3SG-A2/3SG-open=MVMT=2P"],
+      ["tjpel", "door"], ["ja'", "house"]
+    ],
+    "translation": "For whom did you open the door?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.2"],
+      ["mover", "benefactive"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Benefactive extraction optionally triggers =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_15b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(15b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alqe' xi' kq'o'n(a)ye' saqchb'il?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["al-qe", "who-RN:DAT"], ["∅-∅-xi'", "COMPL-B2/3SG-DIR"],
+      ["k-q'o-'n(=a')=ye'", "A2/3P-give-DS=MVMT=2P"], ["saqchb'il", "toy"]
+    ],
+    "translation": "To whom did you give the toys?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.2"],
+      ["mover", "dative"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Dative extraction optionally triggers =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_16b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(16b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja e' chiyon(a') tx'yan ewi?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja", "where"], ["∅-e'", "COMPL-B2/3P"], ["chiyo-n(=a')", "bark-ANTIP=MVMT"],
+      ["tx'yan", "dog"]
+    ],
+    "translation": "Where did the dogs bark?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.3"],
+      ["mover", "locative"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Locative extraction optionally triggers =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_17b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(17b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Tiqu'n el tsu'n(a') Li'y spik'b'il tu'n xb'uy?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ti'-qu'n", "what-RN:REASON"], ["∅-∅-el", "COMPL-B2/3SG-DIR"],
+      ["t-su-'n(=a')", "A2/3SG-clean-DS=MVMT"], ["Li'y", "María"], ["spik'b'il", "window"],
+      ["t-u'n", "A2/3SG-RN:INS"], ["xb'uy", "rag"]
+    ],
+    "translation": "Why did María clean the window with a rag?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.4"],
+      ["mover", "reason"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Reason extraction optionally triggers =(y)a'; the wh-expression is the wh-word plus the relational noun u'n.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_18b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(18b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Tiqu'n tjoy(a') Xwan tx'yol toj k'ul?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ti'-qu'n", "what-RN:PURP"], ["∅-∅-t-joy(=a')", "COMPL-B2/3S-A2/3S-look.for=MVMT"],
+      ["Xwan", "Juan"], ["tx'yol", "mushroom"], ["t-oj", "A2/3S-RN:in"], ["k'ul", "forest"]
+    ],
+    "translation": "Why did Juan look for mushrooms in the forest?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.4"],
+      ["mover", "purpose"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Purpose extraction optionally triggers =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_19b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(19b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Se'ntu'mel kub' tpa'n(a') Li'y lmet?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["se'n=tu'mel", "how=ENCL"], ["∅-∅-kub'", "COMPL-B2/3SG-DIR"],
+      ["t-pa-'n(=a')", "A2/3SG-break-DS=MVMT"], ["Li'y", "María"], ["lmet", "bottle"]
+    ],
+    "translation": "How did María break the bottle?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.5"],
+      ["mover", "manner"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "Manner extraction optionally triggers =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_20b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(20b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Jtoj kxe'l telq'a'n Xwan chmek'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["jtoj", "when.NON.PST"], ["k-xe'-l", "B2/3S-DIR-POT"], ["t-elq'a-'n", "A2/3S-steal-DS"],
+      ["Xwan", "Juan"], ["chmek'", "turkey"]
+    ],
+    "translation": "When will Juan steal the turkey?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Jtoj kxe'l telq'a'na' Xwan chmek'?", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.6"],
+      ["mover", "temporal"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "Temporal extraction does not license =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_21b",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(21b)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Jtoje xi' telq'a'n Xwan chmek'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["jtoje", "when.PST"], ["∅-∅-xi'", "COMPL-B2/3S-DIR"], ["t-elq'a-'n", "A2/3S-steal-DS"],
+      ["Xwan", "Juan"], ["chmek'", "turkey"]
+    ],
+    "translation": "When did Juan steal the turkey?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Jtoje xi' telq'a'na' Xwan chmek'?", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2.6"],
+      ["mover", "temporal"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "Temporal extraction does not license =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_22",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(22)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja jaw(a') xhchin(a') Luch?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja", "where"], ["∅-∅-jaw(=a')", "COMPL-B2/3S-DIR=MVMT"],
+      ["xhchi-n(=a')", "shout-ANTIP=MVMT"], ["Luch", "Pedro"]
+    ],
+    "translation": "Where did Pedro shout?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.1"],
+      ["mover", "locative"],
+      ["directionals", "1"],
+      ["hosts", "2"]
+    ],
+    "comment": "Multiple exponence: the enclitic may appear on the predicate and on the directional, each optionally and independently, so four combinations are equivalent.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_24",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(24)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Se'ntu'mel in tma'n(a') Li'y kye tzaj wulin(a') Xwan weye'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["se'n=tu'mel", "how=ENCL"], ["in", "INC"], ["∅-t-ma-'n(=a')", "B2/3S-A2/3S-say-DS=MVMT"],
+      ["Li'y", "María"], ["kye", "COMP"], ["∅-∅-tzaj", "COM-B2/3S-DIR"],
+      ["wuli-n(=a')", "insult-ANTIP=MVMT"], ["Xwan", "Juan"], ["w-e=ye'", "A1S-RN:DAT=1S"]
+    ],
+    "translation": "How did María say that Juan insulted me?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.2"],
+      ["mover", "manner"],
+      ["embeddedSize", "cP"],
+      ["landing", "matrix"],
+      ["matrixReflex", "licensed"],
+      ["embeddedReflex", "licensed"]
+    ],
+    "comment": "Long-distance extraction from a kye complement: =(y)a' on both the matrix and the embedded predicate, each optional.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_26",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(26)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Mixti' b'i'n wu'ne' se'n kub' tbincha'n(a') Li'y bisiklet.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["mixti'", "NEG"], ["∅-b'i-'n(*=a')", "B2/3S-know-PASS=MVMT"], ["w-u'n=e'", "A1S-RN:AGT=1S"],
+      ["se'n", "how"], ["∅-∅-kub'(=a')", "COM-B2/3S-DIR=MVMT"],
+      ["t-b'incha-'n(=a')", "A2/3S-repair-DS=MVMT"], ["Li'y", "María"], ["bisiklet", "bicycle"]
+    ],
+    "translation": "I don't know how María repaired the bicycle.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.2"],
+      ["mover", "manner"],
+      ["embeddedSize", "cP"],
+      ["landing", "embedded"],
+      ["matrixReflex", "blocked"],
+      ["embeddedReflex", "licensed"]
+    ],
+    "comment": "Embedded question: the wh-expression moves within the embedded clause only, and =(y)a' is unavailable on the matrix predicate.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_28",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(28)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja xi'(ya') telq'a'n(a) Xwan chmek' aju tzaj klq'o'n qya?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja", "where"], ["∅-∅-xi'(=ya')", "COMPL-B2/3S-DIR=MVMT"],
+      ["t-elq'a-'n(=a')", "A2/3S-steal-DS=MVMT"], ["Xwan", "Juan"], ["chmek'", "turkey"],
+      ["aju", "REL"], ["∅-∅-tzaj", "COMPL-B2/3S-DIR"], ["k-lq'o-'n", "A2/3P-buy-DS"],
+      ["qya", "woman"]
+    ],
+    "translation": "Where did Juan steal the turkey that the women bought?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "matrix locative (where Juan stole it)", "judgment": "acceptable"},
+      {"name": "relative-clause locative (where the women bought it)", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["section", "3.2"],
+      ["mover", "locative"]
+    ],
+    "comment": "The relative clause is an island: the enclitic appears only on the matrix predicate and the question has only the matrix reading.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_29a",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(29a)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja xi' telq'a'n Xwan chmek' aju tzaj(a') klq'o'n(a') qya?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja", "where"], ["∅-∅-xi'", "COMPL-B2/3S-DIR"], ["t-elq'a-'n", "A2/3S-steal-DS"],
+      ["Xwan", "Juan"], ["chmek'", "turkey"], ["aju", "REL"],
+      ["∅-∅-tzaj(=a')", "COMPL-B2/3S-DIR=MVMT"], ["k-lq'o-'n(=a')", "A2/3P-buy-DS=MVMT"],
+      ["qya", "woman"]
+    ],
+    "translation": "Where did Juan steal the turkey that the women bought?",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.2"],
+      ["mover", "locative"]
+    ],
+    "comment": "=(y)a' inside the relative-clause island is rejected, and does not ameliorate extraction from the island.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_31",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(31)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Jatu'mel chu'xh(a) tu'n tk'a'yit(a') chmek'?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja=tu'mel", "where=ENCL"], ["∅-chu'x(=a')", "B2/3S-be.difficult=MVMT"],
+      ["t-u'n", "A2/3S-RN:PURP"], ["t-k'a'y-it(=a')", "A1S-sell-PASS=MVMT"], ["chmek'", "turkey"]
+    ],
+    "translation": "Where is it difficult to sell turkeys?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.3"],
+      ["mover", "locative"],
+      ["embeddedSize", "voiceP"],
+      ["landing", "matrix"],
+      ["matrixReflex", "licensed"],
+      ["embeddedReflex", "licensed"]
+    ],
+    "comment": "Extraction from a VoiceP-sized aspectless clause: =(y)a' on both predicates although the embedded clause has no CP layer, so the locus of the enclitic is below C.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_34",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(34)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alqe ok(a') kq'on(a')ye' Pabl jqol(*a') spik'b'il?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["al-qe", "who-RN:BEN"], ["∅-∅-ok(=a')", "COM-B2/3S-DIR=MVMT"],
+      ["k-q'o-n(=a')=ye'", "A2/3P-make-DS=MVMT=2P"], ["Pabl", "Pablo"],
+      ["jqo-l(*=a')", "open-INF=MVMT"], ["spik'b'il", "window"]
+    ],
+    "translation": "For whom did y'all make Pablo open windows?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.4"],
+      ["mover", "benefactive"],
+      ["embeddedSize", "bareVP"],
+      ["landing", "matrix"],
+      ["matrixReflex", "licensed"],
+      ["embeddedReflex", "blocked"]
+    ],
+    "comment": "Extraction from a VP-sized nonfinite clause: =(y)a' on the matrix predicate only, so the locus of the enclitic is above VP. The primary text follows the glossed line; the paper's unglossed line differs.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_35c",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(35c)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Iku' tzaj tlq'ona'.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["iku'", "yes"], ["∅-∅-tzaj", "COM-B2/3S-DIR"], ["t-lq'o-'n=a'", "A2/3-buy-DS=MVMT"]
+    ],
+    "translation": "Yes, there he bought them.",
+    "context": "Answering: Did Juan buy the jocotes in the market?",
+    "judgment": "ungrammatical",
+    "alternatives": [
+      {"form": "Iku', atzu tzaj tlq'o'na'.", "judgment": "acceptable"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.5"],
+      ["mover", "none"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "=(y)a' cannot refer anaphorically to a previously established locative without an extracted adjunct; with the fronted atzu 'there' it is fine. So the enclitic is not a resumptive pronoun.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_37",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(37)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja'tumel e' k'a'yinjtz(a') muqin tu'n Xwan?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja=tu'mel", "where=ENCL"], ["e'", "COMPL"], ["∅-k'a'yi-njtz(=a')", "B2/3S-sell-PASS=MVMT"],
+      ["muqin", "tortilla"], ["t-u'n", "A2/3S-RN:AGT"], ["Xwan", "Juan"]
+    ],
+    "translation": "Where were the tortillas sold by Juan?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.6"],
+      ["mover", "locative"],
+      ["reflex", "licensed"],
+      ["voice", "passive"]
+    ],
+    "comment": "=(y)a' co-occurs with the passive suffix, unlike an Agent Focus morpheme, which is in complementary distribution with valency morphology.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_38",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(38)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Alkye tmaya qa el sun te spik'b'il tu'n xb'uy?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["alkye", "who"], ["∅-∅-t-ma=ya", "COM-B2/3S-A2/3S-say=2S"], ["qa", "COMP"],
+      ["∅-∅-el", "COM-B2/3S-DIR"], ["su-n", "clean-ANTIP"], ["t-e", "A2/3S-RN:PAT"],
+      ["spik'b'il", "window"], ["t-u'n", "A2/3S-RN:AGT"], ["xb'uy", "rag"]
+    ],
+    "translation": "Who did you say cleaned the window with a rag?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "3.6"],
+      ["mover", "ergative"],
+      ["antipassive", "embedded only"]
+    ],
+    "comment": "Long-distance ergative extraction: only the clause in which the agent originates is antipassivized, whereas =(y)a' is licensed in each clause along an adjunct's path.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_63",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(63)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Ja e' b'aj(a') el(a') laqj(a') kwetiy?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["ja", "where"], ["∅-e'", "COM-B2/3PL"], ["b'aj=a'", "DIR=MVMT"], ["el=a'", "DIR=MVMT"],
+      ["laqj=a'", "explode=MVMT"], ["kwetiy", "fireworks"]
+    ],
+    "translation": "Where did the fireworks go off?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.2"],
+      ["mover", "locative"],
+      ["directionals", "2"],
+      ["hosts", "3"]
+    ],
+    "comment": "An intransitive predicate with its sole argument, two directionals and three instances of =(y)a': more reflexes than intervening DPs.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_65",
+    "source": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(65)"},
+    "reportedIn": null,
+    "language": "mamm1241",
+    "primaryText": "Jni' hor kub' kjone' chib'j?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["jni'", "how.many"], ["hor", "hour"], ["∅-∅-kub'", "COMPL-B2/3S-DIR"],
+      ["k-jon(*=a)=e'", "A2/3PL-cut-DS=MVMT=2PL"], ["chib'j", "meat"]
+    ],
+    "translation": "At what time did y'all cut the meat?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Jni' hor kub' kjonae' chib'j?", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.3"],
+      ["mover", "temporal"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "Even a nominal-looking temporal phrase fails to trigger the enclitic; the featural characterization of the triggers is left open.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_51",
+    "source": {"bibkey": "mendes-ranero-2021", "paperLabel": "(2)"},
+    "reportedIn": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(51)"},
+    "language": "kich1262",
+    "primaryText": "Jawii xatb'ee wi iwiir?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jawii", "where"], ["x-at-b'ee", "COMPL-B2SG-go"], ["*(wi)", "FP"], ["iwiir", "yesterday"]
+    ],
+    "translation": "Where did you go yesterday?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Jawii xatb'ee iwiir?", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.1"],
+      ["mover", "locative"],
+      ["reflex", "licensed"]
+    ],
+    "comment": "The K'iche' fronting particle wi is obligatory under low-adjunct extraction.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_52",
+    "source": {"bibkey": "mendes-ranero-2021", "paperLabel": "(17)"},
+    "reportedIn": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(52)"},
+    "language": "kich1262",
+    "primaryText": "Jawi xkib'iij wi chi ke'e wi?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jawi", "where"], ["x-∅-ki-b'iij", "COMPL-B3SG-A3SG-say"], ["*(wi)", "FP"], ["chi", "COMP"],
+      ["k-e-'e", "INC-B3PL-go"], ["*(wi)", "FP"]
+    ],
+    "translation": "Where did they say that they would go?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.1"],
+      ["mover", "locative"],
+      ["embeddedSize", "cP"],
+      ["landing", "matrix"],
+      ["matrixReflex", "licensed"],
+      ["embeddedReflex", "licensed"]
+    ],
+    "comment": "With an overt complementizer, wi appears in every clause along the path.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_53",
+    "source": {"bibkey": "mendes-ranero-2021", "paperLabel": "(19)"},
+    "reportedIn": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(53)"},
+    "language": "kich1262",
+    "primaryText": "Jas ruuk' karayiij katij wi le wa?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jas", "WH"], ["r-uuk'", "A3SG-RN"], ["k-∅-a-rayii-j", "INC-B3SG-A2SG-desire-ACT"],
+      ["(*wi)", "FP"], ["k-∅-a-tij", "INC-B3SG-A2SG-eat"], ["*(wi)", "FP"], ["le", "DET"],
+      ["wa", "food"]
+    ],
+    "translation": "With what do you desire to eat the food?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.1"],
+      ["mover", "instrument"],
+      ["embeddedSize", "aspP"],
+      ["landing", "matrix"],
+      ["matrixReflex", "blocked"],
+      ["embeddedReflex", "licensed"]
+    ],
+    "comment": "From a reduced AspP complement without a complementizer, wi appears in the embedded clause only: the Fronting Particle Generalization.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "elkinstorrencebrown2026_64",
+    "source": {"bibkey": "mendes-ranero-2021", "paperLabel": "(14a)"},
+    "reportedIn": {"bibkey": "elkins-torrence-brown-2026", "paperLabel": "(64)"},
+    "language": "kich1262",
+    "primaryText": "Achike ruma xsamäj ri a Juan?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Achike", "what"], ["ru-ma", "A3SG-RN"], ["x-∅-samäj", "COMPL-B3SG-work"], ["(*wi)", "FP"],
+      ["ri", "DET"], ["a", "CLF"], ["Juan", "Juan"]
+    ],
+    "translation": "Why did Juan work?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Achike ruma xsamäj wi ri a Juan?", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.3"],
+      ["mover", "reason"],
+      ["reflex", "blocked"]
+    ],
+    "comment": "A reason adjunct, high in K'ichean, does not trigger wi, whereas Mam tiqu'n 'why' licenses =(y)a'.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Data/Examples/ElkinsTorrenceBrown2026.lean
@@ -1,0 +1,540 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `ElkinsTorrenceBrown2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/ElkinsTorrenceBrown2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace ElkinsTorrenceBrown2026.Examples`.
+-/
+
+namespace ElkinsTorrenceBrown2026.Examples
+
+open Data.Examples
+
+def ex_10b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_10b"
+    source := ⟨"elkins-torrence-brown-2026", "(10b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alkye kyim?"
+    discourseSegments := []
+    glossedTokens := [("alkye", "who"), ("∅-∅-kyim", "COMPL-B2/3S-die")]
+    translation := "Who died?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.1"), ("mover", "absolutive"), ("reflex", "blocked")]
+    comment := "Absolutive extraction is unmarked: no =(y)a' with an intransitive subject."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_11b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_11b"
+    source := ⟨"elkins-torrence-brown-2026", "(11b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Titi' tjaq' Li'y?"
+    discourseSegments := []
+    glossedTokens := [("titi'", "what"), ("∅-∅-t-jaq'", "COMPL-B2/3SG-A2/3SG-open"), ("Li'y", "María")]
+    translation := "What did María open?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.1"), ("mover", "absolutive"), ("reflex", "blocked")]
+    comment := "Absolutive extraction is unmarked: no =(y)a' with a direct object."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_12b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_12b"
+    source := ⟨"elkins-torrence-brown-2026", "(12b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alkye jq'on te tjpel ja'?"
+    discourseSegments := []
+    glossedTokens := [("alkye", "who"), ("∅-∅-jq'o-n", "COMPL-B2/3S-open-ANTIP"), ("t-e", "A2/3S-RN:PAT"), ("tjpel", "door"), ("ja'", "house")]
+    translation := "Who opened the door?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.1"), ("mover", "ergative"), ("reflex", "blocked")]
+    comment := "The Ergative Extraction Constraint: the agent is extracted through an antipassive, which demotes the theme to a relational-noun phrase; no =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_13a : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_13a"
+    source := ⟨"elkins-torrence-brown-2026", "(13a)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "El tsu'n Li'y spik'b'il tu'n xb'uy."
+    discourseSegments := []
+    glossedTokens := [("∅-∅-el", "COMPL-B2/3SG-DIR"), ("t-su-'n", "A2/3SG-clean-DS"), ("Li'y", "María"), ("spik'b'il", "window"), ("t-u'n", "A2/3SG-RN:INS"), ("xb'uy", "rag")]
+    translation := "María cleaned the window with a rag."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("El tsu'na' Li'y spik'b'il tu'n xb'uy.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "2.2.1"), ("mover", "none"), ("reflex", "blocked")]
+    comment := "With the instrument in situ the enclitic is impossible: =(y)a' is associated with extraction, not with the presence of the adjunct."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_13b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_13b"
+    source := ⟨"elkins-torrence-brown-2026", "(13b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alqu'n el tsu'n(a') Li'y spik'b'il?"
+    discourseSegments := []
+    glossedTokens := [("al-qu'n", "what-RN:INS"), ("∅-∅-el", "COMPL-B2/3SG-DIR"), ("t-su-'n(=a')", "A2/3SG-clean-DS=MVMT"), ("Li'y", "María"), ("spik'b'il", "window")]
+    translation := "With what did María clean the window?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Alqu'n el tsu'na' Li'y spik'b'il?", .acceptable), ("Alqu'n el tsu'n Li'y spik'b'il?", .acceptable)]
+    readings := []
+    paperFeatures := [("section", "2.2.1"), ("mover", "instrument"), ("reflex", "licensed")]
+    comment := "Instrument extraction optionally triggers =(y)a'; the relational noun inverts around the wh-word (pied-piping with inversion)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_14b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_14b"
+    source := ⟨"elkins-torrence-brown-2026", "(14b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alqe tjaq'(a')ya tjpel ja'?"
+    discourseSegments := []
+    glossedTokens := [("al-qe", "who-RN:BEN"), ("∅-∅-t-jaq'(=a')=ya", "COMPL-B2/3SG-A2/3SG-open=MVMT=2P"), ("tjpel", "door"), ("ja'", "house")]
+    translation := "For whom did you open the door?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.2"), ("mover", "benefactive"), ("reflex", "licensed")]
+    comment := "Benefactive extraction optionally triggers =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_15b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_15b"
+    source := ⟨"elkins-torrence-brown-2026", "(15b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alqe' xi' kq'o'n(a)ye' saqchb'il?"
+    discourseSegments := []
+    glossedTokens := [("al-qe", "who-RN:DAT"), ("∅-∅-xi'", "COMPL-B2/3SG-DIR"), ("k-q'o-'n(=a')=ye'", "A2/3P-give-DS=MVMT=2P"), ("saqchb'il", "toy")]
+    translation := "To whom did you give the toys?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.2"), ("mover", "dative"), ("reflex", "licensed")]
+    comment := "Dative extraction optionally triggers =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_16b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_16b"
+    source := ⟨"elkins-torrence-brown-2026", "(16b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja e' chiyon(a') tx'yan ewi?"
+    discourseSegments := []
+    glossedTokens := [("ja", "where"), ("∅-e'", "COMPL-B2/3P"), ("chiyo-n(=a')", "bark-ANTIP=MVMT"), ("tx'yan", "dog")]
+    translation := "Where did the dogs bark?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.3"), ("mover", "locative"), ("reflex", "licensed")]
+    comment := "Locative extraction optionally triggers =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_17b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_17b"
+    source := ⟨"elkins-torrence-brown-2026", "(17b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Tiqu'n el tsu'n(a') Li'y spik'b'il tu'n xb'uy?"
+    discourseSegments := []
+    glossedTokens := [("ti'-qu'n", "what-RN:REASON"), ("∅-∅-el", "COMPL-B2/3SG-DIR"), ("t-su-'n(=a')", "A2/3SG-clean-DS=MVMT"), ("Li'y", "María"), ("spik'b'il", "window"), ("t-u'n", "A2/3SG-RN:INS"), ("xb'uy", "rag")]
+    translation := "Why did María clean the window with a rag?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.4"), ("mover", "reason"), ("reflex", "licensed")]
+    comment := "Reason extraction optionally triggers =(y)a'; the wh-expression is the wh-word plus the relational noun u'n."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_18b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_18b"
+    source := ⟨"elkins-torrence-brown-2026", "(18b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Tiqu'n tjoy(a') Xwan tx'yol toj k'ul?"
+    discourseSegments := []
+    glossedTokens := [("ti'-qu'n", "what-RN:PURP"), ("∅-∅-t-joy(=a')", "COMPL-B2/3S-A2/3S-look.for=MVMT"), ("Xwan", "Juan"), ("tx'yol", "mushroom"), ("t-oj", "A2/3S-RN:in"), ("k'ul", "forest")]
+    translation := "Why did Juan look for mushrooms in the forest?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.4"), ("mover", "purpose"), ("reflex", "licensed")]
+    comment := "Purpose extraction optionally triggers =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_19b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_19b"
+    source := ⟨"elkins-torrence-brown-2026", "(19b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Se'ntu'mel kub' tpa'n(a') Li'y lmet?"
+    discourseSegments := []
+    glossedTokens := [("se'n=tu'mel", "how=ENCL"), ("∅-∅-kub'", "COMPL-B2/3SG-DIR"), ("t-pa-'n(=a')", "A2/3SG-break-DS=MVMT"), ("Li'y", "María"), ("lmet", "bottle")]
+    translation := "How did María break the bottle?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2.5"), ("mover", "manner"), ("reflex", "licensed")]
+    comment := "Manner extraction optionally triggers =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_20b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_20b"
+    source := ⟨"elkins-torrence-brown-2026", "(20b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Jtoj kxe'l telq'a'n Xwan chmek'?"
+    discourseSegments := []
+    glossedTokens := [("jtoj", "when.NON.PST"), ("k-xe'-l", "B2/3S-DIR-POT"), ("t-elq'a-'n", "A2/3S-steal-DS"), ("Xwan", "Juan"), ("chmek'", "turkey")]
+    translation := "When will Juan steal the turkey?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Jtoj kxe'l telq'a'na' Xwan chmek'?", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "2.2.6"), ("mover", "temporal"), ("reflex", "blocked")]
+    comment := "Temporal extraction does not license =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_21b : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_21b"
+    source := ⟨"elkins-torrence-brown-2026", "(21b)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Jtoje xi' telq'a'n Xwan chmek'?"
+    discourseSegments := []
+    glossedTokens := [("jtoje", "when.PST"), ("∅-∅-xi'", "COMPL-B2/3S-DIR"), ("t-elq'a-'n", "A2/3S-steal-DS"), ("Xwan", "Juan"), ("chmek'", "turkey")]
+    translation := "When did Juan steal the turkey?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Jtoje xi' telq'a'na' Xwan chmek'?", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "2.2.6"), ("mover", "temporal"), ("reflex", "blocked")]
+    comment := "Temporal extraction does not license =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_22 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_22"
+    source := ⟨"elkins-torrence-brown-2026", "(22)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja jaw(a') xhchin(a') Luch?"
+    discourseSegments := []
+    glossedTokens := [("ja", "where"), ("∅-∅-jaw(=a')", "COMPL-B2/3S-DIR=MVMT"), ("xhchi-n(=a')", "shout-ANTIP=MVMT"), ("Luch", "Pedro")]
+    translation := "Where did Pedro shout?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1"), ("mover", "locative"), ("directionals", "1"), ("hosts", "2")]
+    comment := "Multiple exponence: the enclitic may appear on the predicate and on the directional, each optionally and independently, so four combinations are equivalent."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_24 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_24"
+    source := ⟨"elkins-torrence-brown-2026", "(24)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Se'ntu'mel in tma'n(a') Li'y kye tzaj wulin(a') Xwan weye'?"
+    discourseSegments := []
+    glossedTokens := [("se'n=tu'mel", "how=ENCL"), ("in", "INC"), ("∅-t-ma-'n(=a')", "B2/3S-A2/3S-say-DS=MVMT"), ("Li'y", "María"), ("kye", "COMP"), ("∅-∅-tzaj", "COM-B2/3S-DIR"), ("wuli-n(=a')", "insult-ANTIP=MVMT"), ("Xwan", "Juan"), ("w-e=ye'", "A1S-RN:DAT=1S")]
+    translation := "How did María say that Juan insulted me?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("mover", "manner"), ("embeddedSize", "cP"), ("landing", "matrix"), ("matrixReflex", "licensed"), ("embeddedReflex", "licensed")]
+    comment := "Long-distance extraction from a kye complement: =(y)a' on both the matrix and the embedded predicate, each optional."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_26 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_26"
+    source := ⟨"elkins-torrence-brown-2026", "(26)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Mixti' b'i'n wu'ne' se'n kub' tbincha'n(a') Li'y bisiklet."
+    discourseSegments := []
+    glossedTokens := [("mixti'", "NEG"), ("∅-b'i-'n(*=a')", "B2/3S-know-PASS=MVMT"), ("w-u'n=e'", "A1S-RN:AGT=1S"), ("se'n", "how"), ("∅-∅-kub'(=a')", "COM-B2/3S-DIR=MVMT"), ("t-b'incha-'n(=a')", "A2/3S-repair-DS=MVMT"), ("Li'y", "María"), ("bisiklet", "bicycle")]
+    translation := "I don't know how María repaired the bicycle."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("mover", "manner"), ("embeddedSize", "cP"), ("landing", "embedded"), ("matrixReflex", "blocked"), ("embeddedReflex", "licensed")]
+    comment := "Embedded question: the wh-expression moves within the embedded clause only, and =(y)a' is unavailable on the matrix predicate."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_28 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_28"
+    source := ⟨"elkins-torrence-brown-2026", "(28)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja xi'(ya') telq'a'n(a) Xwan chmek' aju tzaj klq'o'n qya?"
+    discourseSegments := []
+    glossedTokens := [("ja", "where"), ("∅-∅-xi'(=ya')", "COMPL-B2/3S-DIR=MVMT"), ("t-elq'a-'n(=a')", "A2/3S-steal-DS=MVMT"), ("Xwan", "Juan"), ("chmek'", "turkey"), ("aju", "REL"), ("∅-∅-tzaj", "COMPL-B2/3S-DIR"), ("k-lq'o-'n", "A2/3P-buy-DS"), ("qya", "woman")]
+    translation := "Where did Juan steal the turkey that the women bought?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("matrix locative (where Juan stole it)", .acceptable), ("relative-clause locative (where the women bought it)", .unacceptable)]
+    paperFeatures := [("section", "3.2"), ("mover", "locative")]
+    comment := "The relative clause is an island: the enclitic appears only on the matrix predicate and the question has only the matrix reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_29a : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_29a"
+    source := ⟨"elkins-torrence-brown-2026", "(29a)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja xi' telq'a'n Xwan chmek' aju tzaj(a') klq'o'n(a') qya?"
+    discourseSegments := []
+    glossedTokens := [("ja", "where"), ("∅-∅-xi'", "COMPL-B2/3S-DIR"), ("t-elq'a-'n", "A2/3S-steal-DS"), ("Xwan", "Juan"), ("chmek'", "turkey"), ("aju", "REL"), ("∅-∅-tzaj(=a')", "COMPL-B2/3S-DIR=MVMT"), ("k-lq'o-'n(=a')", "A2/3P-buy-DS=MVMT"), ("qya", "woman")]
+    translation := "Where did Juan steal the turkey that the women bought?"
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("mover", "locative")]
+    comment := "=(y)a' inside the relative-clause island is rejected, and does not ameliorate extraction from the island."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_31 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_31"
+    source := ⟨"elkins-torrence-brown-2026", "(31)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Jatu'mel chu'xh(a) tu'n tk'a'yit(a') chmek'?"
+    discourseSegments := []
+    glossedTokens := [("ja=tu'mel", "where=ENCL"), ("∅-chu'x(=a')", "B2/3S-be.difficult=MVMT"), ("t-u'n", "A2/3S-RN:PURP"), ("t-k'a'y-it(=a')", "A1S-sell-PASS=MVMT"), ("chmek'", "turkey")]
+    translation := "Where is it difficult to sell turkeys?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.3"), ("mover", "locative"), ("embeddedSize", "voiceP"), ("landing", "matrix"), ("matrixReflex", "licensed"), ("embeddedReflex", "licensed")]
+    comment := "Extraction from a VoiceP-sized aspectless clause: =(y)a' on both predicates although the embedded clause has no CP layer, so the locus of the enclitic is below C."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_34 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_34"
+    source := ⟨"elkins-torrence-brown-2026", "(34)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alqe ok(a') kq'on(a')ye' Pabl jqol(*a') spik'b'il?"
+    discourseSegments := []
+    glossedTokens := [("al-qe", "who-RN:BEN"), ("∅-∅-ok(=a')", "COM-B2/3S-DIR=MVMT"), ("k-q'o-n(=a')=ye'", "A2/3P-make-DS=MVMT=2P"), ("Pabl", "Pablo"), ("jqo-l(*=a')", "open-INF=MVMT"), ("spik'b'il", "window")]
+    translation := "For whom did y'all make Pablo open windows?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.4"), ("mover", "benefactive"), ("embeddedSize", "bareVP"), ("landing", "matrix"), ("matrixReflex", "licensed"), ("embeddedReflex", "blocked")]
+    comment := "Extraction from a VP-sized nonfinite clause: =(y)a' on the matrix predicate only, so the locus of the enclitic is above VP. The primary text follows the glossed line; the paper's unglossed line differs."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_35c : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_35c"
+    source := ⟨"elkins-torrence-brown-2026", "(35c)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Iku' tzaj tlq'ona'."
+    discourseSegments := []
+    glossedTokens := [("iku'", "yes"), ("∅-∅-tzaj", "COM-B2/3S-DIR"), ("t-lq'o-'n=a'", "A2/3-buy-DS=MVMT")]
+    translation := "Yes, there he bought them."
+    context := "Answering: Did Juan buy the jocotes in the market?"
+    judgment := .ungrammatical
+    alternatives := [("Iku', atzu tzaj tlq'o'na'.", .acceptable)]
+    readings := []
+    paperFeatures := [("section", "3.5"), ("mover", "none"), ("reflex", "blocked")]
+    comment := "=(y)a' cannot refer anaphorically to a previously established locative without an extracted adjunct; with the fronted atzu 'there' it is fine. So the enclitic is not a resumptive pronoun."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_37 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_37"
+    source := ⟨"elkins-torrence-brown-2026", "(37)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja'tumel e' k'a'yinjtz(a') muqin tu'n Xwan?"
+    discourseSegments := []
+    glossedTokens := [("ja=tu'mel", "where=ENCL"), ("e'", "COMPL"), ("∅-k'a'yi-njtz(=a')", "B2/3S-sell-PASS=MVMT"), ("muqin", "tortilla"), ("t-u'n", "A2/3S-RN:AGT"), ("Xwan", "Juan")]
+    translation := "Where were the tortillas sold by Juan?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.6"), ("mover", "locative"), ("reflex", "licensed"), ("voice", "passive")]
+    comment := "=(y)a' co-occurs with the passive suffix, unlike an Agent Focus morpheme, which is in complementary distribution with valency morphology."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_38 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_38"
+    source := ⟨"elkins-torrence-brown-2026", "(38)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Alkye tmaya qa el sun te spik'b'il tu'n xb'uy?"
+    discourseSegments := []
+    glossedTokens := [("alkye", "who"), ("∅-∅-t-ma=ya", "COM-B2/3S-A2/3S-say=2S"), ("qa", "COMP"), ("∅-∅-el", "COM-B2/3S-DIR"), ("su-n", "clean-ANTIP"), ("t-e", "A2/3S-RN:PAT"), ("spik'b'il", "window"), ("t-u'n", "A2/3S-RN:AGT"), ("xb'uy", "rag")]
+    translation := "Who did you say cleaned the window with a rag?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.6"), ("mover", "ergative"), ("antipassive", "embedded only")]
+    comment := "Long-distance ergative extraction: only the clause in which the agent originates is antipassivized, whereas =(y)a' is licensed in each clause along an adjunct's path."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_63 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_63"
+    source := ⟨"elkins-torrence-brown-2026", "(63)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Ja e' b'aj(a') el(a') laqj(a') kwetiy?"
+    discourseSegments := []
+    glossedTokens := [("ja", "where"), ("∅-e'", "COM-B2/3PL"), ("b'aj=a'", "DIR=MVMT"), ("el=a'", "DIR=MVMT"), ("laqj=a'", "explode=MVMT"), ("kwetiy", "fireworks")]
+    translation := "Where did the fireworks go off?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.2"), ("mover", "locative"), ("directionals", "2"), ("hosts", "3")]
+    comment := "An intransitive predicate with its sole argument, two directionals and three instances of =(y)a': more reflexes than intervening DPs."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_65 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_65"
+    source := ⟨"elkins-torrence-brown-2026", "(65)"⟩
+    reportedIn := none
+    language := "mamm1241"
+    primaryText := "Jni' hor kub' kjone' chib'j?"
+    discourseSegments := []
+    glossedTokens := [("jni'", "how.many"), ("hor", "hour"), ("∅-∅-kub'", "COMPL-B2/3S-DIR"), ("k-jon(*=a)=e'", "A2/3PL-cut-DS=MVMT=2PL"), ("chib'j", "meat")]
+    translation := "At what time did y'all cut the meat?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Jni' hor kub' kjonae' chib'j?", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "5.3"), ("mover", "temporal"), ("reflex", "blocked")]
+    comment := "Even a nominal-looking temporal phrase fails to trigger the enclitic; the featural characterization of the triggers is left open."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_51 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_51"
+    source := ⟨"mendes-ranero-2021", "(2)"⟩
+    reportedIn := some ⟨"elkins-torrence-brown-2026", "(51)"⟩
+    language := "kich1262"
+    primaryText := "Jawii xatb'ee wi iwiir?"
+    discourseSegments := []
+    glossedTokens := [("Jawii", "where"), ("x-at-b'ee", "COMPL-B2SG-go"), ("*(wi)", "FP"), ("iwiir", "yesterday")]
+    translation := "Where did you go yesterday?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Jawii xatb'ee iwiir?", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "5.1"), ("mover", "locative"), ("reflex", "licensed")]
+    comment := "The K'iche' fronting particle wi is obligatory under low-adjunct extraction."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_52 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_52"
+    source := ⟨"mendes-ranero-2021", "(17)"⟩
+    reportedIn := some ⟨"elkins-torrence-brown-2026", "(52)"⟩
+    language := "kich1262"
+    primaryText := "Jawi xkib'iij wi chi ke'e wi?"
+    discourseSegments := []
+    glossedTokens := [("Jawi", "where"), ("x-∅-ki-b'iij", "COMPL-B3SG-A3SG-say"), ("*(wi)", "FP"), ("chi", "COMP"), ("k-e-'e", "INC-B3PL-go"), ("*(wi)", "FP")]
+    translation := "Where did they say that they would go?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.1"), ("mover", "locative"), ("embeddedSize", "cP"), ("landing", "matrix"), ("matrixReflex", "licensed"), ("embeddedReflex", "licensed")]
+    comment := "With an overt complementizer, wi appears in every clause along the path."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_53 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_53"
+    source := ⟨"mendes-ranero-2021", "(19)"⟩
+    reportedIn := some ⟨"elkins-torrence-brown-2026", "(53)"⟩
+    language := "kich1262"
+    primaryText := "Jas ruuk' karayiij katij wi le wa?"
+    discourseSegments := []
+    glossedTokens := [("Jas", "WH"), ("r-uuk'", "A3SG-RN"), ("k-∅-a-rayii-j", "INC-B3SG-A2SG-desire-ACT"), ("(*wi)", "FP"), ("k-∅-a-tij", "INC-B3SG-A2SG-eat"), ("*(wi)", "FP"), ("le", "DET"), ("wa", "food")]
+    translation := "With what do you desire to eat the food?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.1"), ("mover", "instrument"), ("embeddedSize", "aspP"), ("landing", "matrix"), ("matrixReflex", "blocked"), ("embeddedReflex", "licensed")]
+    comment := "From a reduced AspP complement without a complementizer, wi appears in the embedded clause only: the Fronting Particle Generalization."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_64 : LinguisticExample :=
+  { id := "elkinstorrencebrown2026_64"
+    source := ⟨"mendes-ranero-2021", "(14a)"⟩
+    reportedIn := some ⟨"elkins-torrence-brown-2026", "(64)"⟩
+    language := "kich1262"
+    primaryText := "Achike ruma xsamäj ri a Juan?"
+    discourseSegments := []
+    glossedTokens := [("Achike", "what"), ("ru-ma", "A3SG-RN"), ("x-∅-samäj", "COMPL-B3SG-work"), ("(*wi)", "FP"), ("ri", "DET"), ("a", "CLF"), ("Juan", "Juan")]
+    translation := "Why did Juan work?"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Achike ruma xsamäj wi ri a Juan?", .ungrammatical)]
+    readings := []
+    paperFeatures := [("section", "5.3"), ("mover", "reason"), ("reflex", "blocked")]
+    comment := "A reason adjunct, high in K'ichean, does not trigger wi, whereas Mam tiqu'n 'why' licenses =(y)a'."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [ex_10b, ex_11b, ex_12b, ex_13a, ex_13b, ex_14b, ex_15b, ex_16b, ex_17b, ex_18b, ex_19b, ex_20b, ex_21b, ex_22, ex_24, ex_26, ex_28, ex_29a, ex_31, ex_34, ex_35c, ex_37, ex_38, ex_63, ex_65, ex_51, ex_52, ex_53, ex_64]
+
+end ElkinsTorrenceBrown2026.Examples

--- a/Linglib/Fragments/Mayan/Kiche/Extraction.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Extraction.lean
@@ -2,230 +2,32 @@ import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 
 /-!
-# K'iche' Extraction Morphology
+# K'iche' extraction marking
 
-Theory-neutral data on the extraction particle *wi* (the "fronting
-particle") in K'iche' and Kaqchikel (K'ichean Mayan), following
-[mendes-ranero-2021], [elkins-torrence-brown-2026], and [mondloch-2017].
-When a low adjunct (locative, instrumental, comitative, indirect object)
-undergoes Ā-extraction, *wi* appears as a verbal enclitic;
-[mendes-ranero-2021] analyze it as Chain Reduction via Substitution,
-with the lower copy of the moved adjunct (bearing [APPL]) substituted by
-*wi* rather than deleted.
+The extraction marking of K'iche' (K'ichean Mayan) as reflex cells: subject extraction switches
+the verb to Agent Focus, the voice marker *-n* ([mondloch-2017]), and the extraction of a low
+adjunct adds the fronting particle *wi* to the verbal complex ([mendes-ranero-2021]); core-object
+extraction is unmarked. The distribution of *wi* across adjunct types and clause sizes, and its
+contrast with Mam =(y)a', is the matter of `Studies/ElkinsTorrenceBrown2026.lean`.
 
-## Main declarations
+## References
 
-* `Kiche.KicheExtractionDatum`, `Kiche.allData`: the *wi*-distribution
-  data points.
-* `Kiche.KicheLongDistanceDatum`, `Kiche.ldData`: long-distance
-  extraction data across embedded CP vs AspP.
-* `Kiche.fronting_particle_generalization`: matrix *wi* is contingent on
-  an overt embedded complementizer.
-* `Kiche.Extraction.realize`: the AF- and *wi*-based extraction marking,
-  with `Kiche.Extraction.strategy` as the WALS-style label.
-
-## Implementation notes
-
-*wi* triggers only on low adjuncts introduced in Spec,ApplP
-(instrumentals, locatives, comitatives, indirect objects); temporal and
-reason adjuncts do not trigger it. It is obligatory in K'iche', optional
-in Patzún Kaqchikel, and absent in some Kaqchikel dialects (e.g.
-Tecpán). [mendes-ranero-2021] §4 argues *wi* is not a pronoun,
-applicative head, movement trigger, or AF morpheme. The Fronting
-Particle Generalization ([mendes-ranero-2021] definition (5), first
-observed by Can Pixabaj 2015) is stated and checked at
-`fronting_particle_generalization`.
+* [mendes-ranero-2021]
+* [mondloch-2017]
+* [elkins-torrence-brown-2026]
 -/
 
-open Extraction (ExtractionTarget ExtractionMarkingStrategy Marked)
+open Extraction
 
-namespace Kiche
+namespace Kiche.Extraction
 
-/-! ### Extracted argument types -/
-
-/-- Types of extracted arguments relevant for *wi* distribution. -/
-inductive ExtractedArgType where
-  | obliqueSpatial       -- 'where', 'from where' (locative/source PPs)
-  | obliqueTemporal      -- 'when'
-  | obliqueReason        -- 'why'
-  | obliqueInstrumental  -- 'with what'
-  | subject              -- 'who' (agent — triggers Agent Focus, not *wi*)
-  | object               -- 'what' (patient)
-  deriving DecidableEq, Repr
-
-/-- Is this argument type an oblique? -/
-def ExtractedArgType.isOblique : ExtractedArgType → Bool
-  | .obliqueSpatial | .obliqueTemporal | .obliqueReason | .obliqueInstrumental => true
-  | .subject | .object => false
-
-/-! ### *wi* distribution data -/
-
-/-- A K'iche' extraction data point: what is extracted and whether *wi*
-    appears after the verb. -/
-structure KicheExtractionDatum where
-  label : String
-  reference : String
-  extractedType : ExtractedArgType
-  wiLicensed : Bool
-  deriving Repr
-
-/-- Spatial oblique extraction ("Where did you go yesterday?"): *wi* licensed.
-    [mondloch-2017] Lesson 14; [mendes-ranero-2021] §2, ex. (9a). -/
-def spatialOblExtraction : KicheExtractionDatum :=
-  { label := "Spatial oblique extraction (wi)"
-  , reference := "Mondloch 2017, Lesson 14; Mendes & Ranero 2021, §2, ex. (9a)"
-  , extractedType := .obliqueSpatial
-  , wiLicensed := true }
-
-/-- Instrumental oblique extraction ("With what did they eat their food?"):
-    *wi* licensed. [mendes-ranero-2021] §2, ex. (9b). -/
-def instrumentalOblExtraction : KicheExtractionDatum :=
-  { label := "Instrumental oblique extraction (wi)"
-  , reference := "Mendes & Ranero 2021, §2, ex. (9b)"
-  , extractedType := .obliqueInstrumental
-  , wiLicensed := true }
-
-/-- Temporal oblique extraction ("When did you eat beans?"): *wi* NOT
-    licensed — parallel to Mam, where temporal obliques are also exempt.
-    [mendes-ranero-2021] §2, ex. (12c). -/
-def temporalOblExtraction : KicheExtractionDatum :=
-  { label := "Temporal oblique extraction (no wi)"
-  , reference := "Mendes & Ranero 2021, §2, ex. (12c)"
-  , extractedType := .obliqueTemporal
-  , wiLicensed := false }
-
-/-- Reason oblique extraction ("Why did Juan work?"): *wi* NOT licensed —
-    key contrast with Mam, where SJO =(y)a' IS licensed with reason
-    extraction. [mendes-ranero-2021] §2 (adapted from Elkins et al. Table 3). -/
-def reasonOblExtraction : KicheExtractionDatum :=
-  { label := "Reason oblique extraction (no wi)"
-  , reference := "Mendes & Ranero 2021, §2; Elkins et al. Table 3"
-  , extractedType := .obliqueReason
-  , wiLicensed := false }
-
-/-- Subject extraction ("Who bought it?"): *wi* NOT licensed — Agent Focus
-    morphology *-Vk* appears instead. [mendes-ranero-2021] §2, item (6c). -/
-def subjectExtraction : KicheExtractionDatum :=
-  { label := "Subject extraction (AF, no wi)"
-  , reference := "Mendes & Ranero 2021, §2, item (6c)"
-  , extractedType := .subject
-  , wiLicensed := false }
-
-/-- Object extraction ("What did you buy?"): *wi* NOT licensed.
-    [elkins-torrence-brown-2026]. -/
-def objectExtraction : KicheExtractionDatum :=
-  { label := "Object extraction (no wi)"
-  , reference := "Elkins et al. 2026"
-  , extractedType := .object
-  , wiLicensed := false }
-
-/-- All K'iche' extraction data points. -/
-def allData : List KicheExtractionDatum :=
-  [ spatialOblExtraction
-  , instrumentalOblExtraction
-  , temporalOblExtraction
-  , reasonOblExtraction
-  , subjectExtraction
-  , objectExtraction ]
-
-/-! ### Generalizations -/
-
-/-- Among the formalized data points, *wi* is licensed exactly for
-    spatial and instrumental obliques; the full trigger set also includes
-    comitatives and indirect objects ([mendes-ranero-2021] §2;
-    [elkins-torrence-brown-2026] Table 3), not yet formalized here. -/
-theorem wi_subset_of_obliques :
-    allData.all (λ d =>
-      d.wiLicensed == (d.extractedType == .obliqueSpatial ||
-                       d.extractedType == .obliqueInstrumental)) = true := by
-  decide
-
-/-- *wi* does not appear with subject or object extraction. -/
-theorem wi_not_core_args :
-    subjectExtraction.wiLicensed = false ∧
-    objectExtraction.wiLicensed = false := ⟨rfl, rfl⟩
-
-/-- Temporal exemption is shared across Mayan: neither *wi* (K'ichean)
-    nor =(y)a' (Mam) appears with temporal oblique extraction. -/
-theorem temporal_exempt : temporalOblExtraction.wiLicensed = false := rfl
-
-/-! ### Embedded clause types and the Fronting Particle Generalization -/
-
-/-- Embedded clause types for long-distance *wi* distribution: whether the
-    embedded clause has an overt complementizer (CP) or not (a structurally
-    reduced AspP). [mendes-ranero-2021] §2, exx. (17)–(20), (34)–(37). -/
-inductive KicheEmbeddedClauseType where
-  /-- Full CP with overt complementizer *chi*. -/
-  | cp
-  /-- Reduced AspP without complementizer. -/
-  | aspP
-  deriving DecidableEq, Repr
-
-/-- Does this clause type have an overt complementizer? -/
-def KicheEmbeddedClauseType.hasComp : KicheEmbeddedClauseType → Bool
-  | .cp => true
-  | .aspP => false
-
-/-- Long-distance extraction datum for K'ichean *wi*. -/
-structure KicheLongDistanceDatum where
-  label : String
-  reference : String
-  embeddedType : KicheEmbeddedClauseType
-  /-- Does *wi* appear on the matrix predicate? -/
-  wiOnMatrix : Bool
-  /-- Does *wi* appear on the embedded predicate? -/
-  wiOnEmbedded : Bool
-  deriving Repr
-
-/-- LD from embedded CP: *wi* on BOTH matrix and embedded predicates.
-    [mendes-ranero-2021] §3, ex. (34); adapted from Can Pixabaj 2015: 166–167. -/
-def ldFromCP : KicheLongDistanceDatum :=
-  { label := "LD extraction from embedded CP (wi on both)"
-  , reference := "Mendes & Ranero 2021, §3, ex. (34)"
-  , embeddedType := .cp
-  , wiOnMatrix := true
-  , wiOnEmbedded := true }
-
-/-- LD from embedded AspP: *wi* only on embedded predicate, NOT matrix.
-    [mendes-ranero-2021] §3, ex. (35); adapted from Can Pixabaj 2015: 163. -/
-def ldFromAspP : KicheLongDistanceDatum :=
-  { label := "LD extraction from embedded AspP (wi on embedded only)"
-  , reference := "Mendes & Ranero 2021, §3, ex. (35)"
-  , embeddedType := .aspP
-  , wiOnMatrix := false
-  , wiOnEmbedded := true }
-
-def ldData : List KicheLongDistanceDatum := [ldFromCP, ldFromAspP]
-
-/-- The Fronting Particle Generalization ([mendes-ranero-2021] definition
-    (5); first discussed by Can Pixabaj 2015): in long-distance
-    Ā-extraction of a low adjunct from a single embedded clause, matrix
-    *wi* is contingent on an overt complementizer in the embedded clause.
-    Structurally ([mendes-ranero-2021] §3), C⁰ is a phase head — an
-    embedded CP forces a stopover in embedded Spec,CP whose intermediate
-    copy undergoes Chain Reduction via Substitution (matrix *wi*), while an
-    embedded AspP has no phase boundary and the adjunct moves directly to
-    matrix Spec,CP (no matrix *wi*). -/
-theorem fronting_particle_generalization :
-    ldData.all (λ d => d.embeddedType.hasComp == d.wiOnMatrix) = true := by
-  decide
-
-/-! ### Extraction marking -/
-
-namespace Extraction
-
-/-- Reflex hosts for K'iche' extraction marking. -/
-inductive Site where
+/-- Reflex host of K'iche' extraction marking: the verbal complex. -/
+inductive Site
   | verb
   deriving DecidableEq, Repr
 
-/-- K'iche' marks two extraction cells on the verb: subject extraction
-    switches it to AF (the voice marker *-n*, [mondloch-2017] Lesson 22;
-    Lessons 30, 33 for radical transitives and perfect aspect; shared
-    with the Absolutive Antipassive of Lesson 21, from which AF differs
-    syntactically, not morphologically), and oblique extraction adds
-    *wi* via copy spellout at the foot of the Ā-chain
-    ([mendes-ranero-2021]). Core-object extraction is unmarked. -/
+/-- The two marked cells: subject extraction takes Agent Focus, oblique extraction adds *wi*;
+core-object extraction is unmarked. -/
 def realize : ExtractionTarget → List (Features.Reflex Site)
   | .subject => [.morpheme .verb]
   | .oblique => [.morpheme .verb]
@@ -236,6 +38,4 @@ def strategy : ExtractionMarkingStrategy := .dedicatedMorpheme
 
 theorem marks_oblique : Marked realize .oblique := by decide
 
-end Extraction
-
-end Kiche
+end Kiche.Extraction

--- a/Linglib/Fragments/Mayan/Mam/Extraction.lean
+++ b/Linglib/Fragments/Mayan/Mam/Extraction.lean
@@ -1,345 +1,38 @@
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
-import Linglib.Data.UD.Basic
 
 /-!
-# Mam Extraction Morphology Fragment
+# Mam extraction marking
 
-Theory-neutral data on extraction morphology in San Juan Ostuncalco
-(SJO) Mam (Mayan, Western Highlands of Guatemala), following
-[elkins-torrence-brown-2026]. When an oblique undergoes Ā-movement
-(wh-movement, focus fronting, relativization), the optional enclitic
-=(y)a' may appear on the verbal complex — on Voice⁰ or Dir⁰
-(directional auxiliary). Its distribution is conditioned by clause size
-(licensed only where Voice⁰ projects; impossible in VP-sized infinitival
-complements, [elkins-torrence-brown-2026] §6) and by extraction target
-(oblique extraction only — subject extraction triggers Agent Focus *-a*,
-object extraction triggers neither, §3.1; temporal 'when' obliques also
-do not trigger it, §8.1).
+The extraction marking of Mam (Mayan, Western Highlands of Guatemala) as reflex cells: subject
+(ergative) extraction switches the verb to an antipassive, the Mayan repair for the Ergative
+Extraction Constraint ([aissen-2017]; the San Juan Atitán forms in [scott-2023]), oblique
+extraction places the movement enclitic =(y)a' on the Voice or directional head of the verbal
+complex ([england-1989], [elkins-torrence-brown-2026]), and absolutive extraction is unmarked. The
+distribution of the enclitic across adjunct types, clause sizes and movement paths is the matter
+of `Studies/ElkinsTorrenceBrown2026.lean`.
 
-The central finding is multiple spellout: in long-distance extraction
-through full CPs and aspectless clauses, =(y)a' can appear on both the
-matrix and embedded predicates — one per Voice/Dir head along the
-successive-cyclic movement path (Table 4, §6.2).
+## References
 
-## Main declarations
-
-* `Mam.MamClauseType` with `.projectsVoice`: the three clause sizes
-  (full CP, aspectless, infinitival) and whether each projects Voice.
-* `Mam.MamExtractionDatum`, `Mam.monoData`: monoclausal extraction data
-  points and their pooled list.
-* `Mam.MamLongDistanceDatum`, `Mam.ldData`: long-distance data tracking
-  =(y)a' on the matrix and embedded predicates independently (Table 4).
-* `Mam.eqya_iff_voice_and_oblique`: the core generalization — =(y)a' is
-  licensed iff the clause projects Voice and a non-temporal oblique
-  extracts.
-* `Mam.MovementReflex` with `.islandSensitive`: island sensitivity
-  derived from movement being phase-bounded rather than stipulated.
-* `Mam.Extraction.realize`: the AF- and =(y)a'-based extraction marking,
-  with `Mam.Extraction.strategy` as the WALS-style label.
-
-## Implementation notes
-
-All data is from [elkins-torrence-brown-2026], "Wh-movement paths and
-oblique extraction in Mam (Mayan)", cited by section/example number.
+* [elkins-torrence-brown-2026]
+* [england-1989]
+* [scott-2023]
+* [aissen-2017]
 -/
 
-open Extraction (ExtractionTarget ExtractionMarkingStrategy Marked)
+open Extraction
 
-namespace Mam
+namespace Mam.Extraction
 
-/-! ### Clause types -/
-
-/-- The three clause sizes relevant for =(y)a' distribution — different
-    structural sizes of the verbal domain ([elkins-torrence-brown-2026]
-    §6.1, following [coon-2019]). -/
-inductive MamClauseType where
-  /-- Full finite clause with aspect; projects Voice, so =(y)a' is
-      licensed on oblique extraction. -/
-  | fullCP
-  /-- VoiceP-sized complement: no aspect but projects Voice, so =(y)a'
-      is licensed ([elkins-torrence-brown-2026] §6.1). -/
-  | aspectless
-  /-- VP-sized infinitival complement: no Voice projected, so =(y)a' is
-      impossible — no Voice⁰ to host [oblique] ([elkins-torrence-brown-2026] §6.1). -/
-  | infinitival
-  deriving DecidableEq, Repr
-
-/-- Does this clause type project Voice? -/
-def MamClauseType.projectsVoice : MamClauseType → Bool
-  | .fullCP => true
-  | .aspectless => true
-  | .infinitival => false
-
-/-! ### Extraction judgments -/
-
-/-- Status of =(y)a' in a configuration — `licensed` (may grammatically
-    appear; it is an optional enclitic) or `blocked`; optionality when
-    licensed is orthogonal to the distributional constraints. -/
-inductive MamExtractionJudgment where
-  /-- =(y)a' is licensed (may appear) in this configuration -/
-  | licensed
-  /-- =(y)a' is blocked (may not appear) in this configuration -/
-  | blocked
-  deriving DecidableEq, Repr
-
-/-! ### Monoclausal data -/
-
-/-- A monoclausal extraction data point: a clause type, what is extracted,
-    and whether =(y)a' is licensed. -/
-structure MamExtractionDatum where
-  /-- Descriptive label -/
-  label : String
-  /-- Section/example reference in [elkins-torrence-brown-2026] -/
-  reference : String
-  /-- Type of clause -/
-  clauseType : MamClauseType
-  /-- Is an oblique being extracted? -/
-  obliqueExtracted : Bool
-  /-- Is the extracted oblique temporal ('when')? Temporal obliques do not
-      trigger =(y)a' though genuinely oblique and extracted (§8.1, ex. 56)
-      — encoded honestly rather than as `obliqueExtracted := false`. The
-      paper leaves this unexplained: "we leave an account of this for
-      future work" (§8.1). -/
-  isTemporal : Bool := false
-  /-- Judgment on =(y)a' -/
-  judgment : MamExtractionJudgment
-  deriving Repr
-
-/-- Transitive clause, oblique extraction: =(y)a' licensed.
-    "With what did María clean the window?" — =(y)a' on predicate.
-    Elkins et al. §4.1, ex. (22b). -/
-def transOblExtraction : MamExtractionDatum :=
-  { label := "Transitive, oblique wh-extraction"
-  , reference := "§4.1, ex. (22b)"
-  , clauseType := .fullCP
-  , obliqueExtracted := true
-  , judgment := .licensed }
-
-/-- Transitive clause, subject extraction: =(y)a' blocked.
-    "Who opened the door?" — antipassive required, no =(y)a'.
-    Elkins et al. §3.2, ex. (19). -/
-def transSubjExtraction : MamExtractionDatum :=
-  { label := "Transitive, subject wh-extraction (AF)"
-  , reference := "§3.2, ex. (19)"
-  , clauseType := .fullCP
-  , obliqueExtracted := false
-  , judgment := .blocked }
-
-/-- Transitive clause, object extraction: =(y)a' blocked.
-    "What did María open?" — no =(y)a'.
-    Elkins et al. §3.2, ex. (18b). -/
-def transObjExtraction : MamExtractionDatum :=
-  { label := "Transitive, object wh-extraction"
-  , reference := "§3.2, ex. (18b)"
-  , clauseType := .fullCP
-  , obliqueExtracted := false
-  , judgment := .blocked }
-
-/-- Passive clause, oblique extraction: =(y)a' licensed.
-    "Where were the tortillas sold by Juan?" — =(y)a' co-occurs with passive *-njtz*.
-    Elkins et al. §7.2, ex. (54). -/
-def passiveOblExtraction : MamExtractionDatum :=
-  { label := "Passive, oblique wh-extraction"
-  , reference := "§7.2, ex. (54)"
-  , clauseType := .fullCP
-  , obliqueExtracted := true
-  , judgment := .licensed }
-
-/-- Temporal oblique extraction: =(y)a' BLOCKED. "When" (*b'iix taq*) does
-    not trigger =(y)a', unlike spatial and other obliques (§8.1, ex. (56));
-    encoded honestly as `obliqueExtracted := true, isTemporal := true`.
-    Unexplained: "we leave an account of this for future work" (§8.1). -/
-def temporalOblExtraction : MamExtractionDatum :=
-  { label := "Temporal oblique wh-extraction (no MVMT)"
-  , reference := "§8.1, ex. (56)"
-  , clauseType := .fullCP
-  , obliqueExtracted := true
-  , isTemporal := true
-  , judgment := .blocked }
-
-/-- All monoclausal extraction data points. -/
-def monoData : List MamExtractionDatum :=
-  [ transOblExtraction
-  , transSubjExtraction
-  , transObjExtraction
-  , passiveOblExtraction
-  , temporalOblExtraction ]
-
-/-! ### Long-distance data (Table 4) -/
-
-/-- A long-distance extraction data point: tracks =(y)a' status on both
-    the matrix and embedded predicates independently. This captures the
-    paper's central empirical finding (Table 4, §6.2): =(y)a' can appear
-    on BOTH predicates along the successive-cyclic movement path. -/
-structure MamLongDistanceDatum where
-  /-- Descriptive label -/
-  label : String
-  /-- Section/example reference -/
-  reference : String
-  /-- Type of embedded clause -/
-  embeddedClauseType : MamClauseType
-  /-- =(y)a' status on the matrix predicate -/
-  matrixJudgment : MamExtractionJudgment
-  /-- =(y)a' status on the embedded predicate -/
-  embeddedJudgment : MamExtractionJudgment
-  deriving Repr
-
-/-- Long-distance extraction from full CP: =(y)a' licensed on BOTH
-    matrix and embedded predicates. Table 4, Row 1; §6.2, ex. (38)–(39). -/
-def ldFullCP : MamLongDistanceDatum :=
-  { label := "LD extraction from full CP"
-  , reference := "§6.2, Table 4, Row 1"
-  , embeddedClauseType := .fullCP
-  , matrixJudgment := .licensed
-  , embeddedJudgment := .licensed }
-
-/-- Long-distance extraction from aspectless clause: =(y)a' licensed on
-    BOTH. Table 4, Row 2; §6.2. -/
-def ldAspectless : MamLongDistanceDatum :=
-  { label := "LD extraction from aspectless clause"
-  , reference := "§6.2, Table 4, Row 2"
-  , embeddedClauseType := .aspectless
-  , matrixJudgment := .licensed
-  , embeddedJudgment := .licensed }
-
-/-- Long-distance extraction from infinitival: =(y)a' licensed on
-    matrix but BLOCKED on embedded. Table 4, Row 3; §6.2, ex. (46). -/
-def ldInfinitival : MamLongDistanceDatum :=
-  { label := "LD extraction from infinitival"
-  , reference := "§6.2, Table 4, Row 3"
-  , embeddedClauseType := .infinitival
-  , matrixJudgment := .licensed
-  , embeddedJudgment := .blocked }
-
-/-- Embedded question (1-step extraction): =(y)a' BLOCKED on matrix,
-    licensed on embedded. Table 4, Row 4; §6.2, ex. (41). -/
-def ldEmbeddedQuestion : MamLongDistanceDatum :=
-  { label := "Embedded question (oblique EQ)"
-  , reference := "§6.2, Table 4, Row 4"
-  , embeddedClauseType := .fullCP
-  , matrixJudgment := .blocked
-  , embeddedJudgment := .licensed }
-
-/-- All long-distance extraction data points (Table 4). -/
-def ldData : List MamLongDistanceDatum :=
-  [ ldFullCP, ldAspectless, ldInfinitival, ldEmbeddedQuestion ]
-
-/-! ### Per-datum verification -/
-
-theorem trans_obl_licensed : transOblExtraction.judgment = .licensed := rfl
-theorem trans_subj_blocked : transSubjExtraction.judgment = .blocked := rfl
-theorem trans_obj_blocked : transObjExtraction.judgment = .blocked := rfl
-theorem passive_obl_licensed : passiveOblExtraction.judgment = .licensed := rfl
-theorem temporal_obl_blocked : temporalOblExtraction.judgment = .blocked := rfl
-
-/-! ### Generalizations -/
-
-/-- Core generalization (monoclausal): =(y)a' is licensed iff the clause
-    projects Voice AND a non-temporal oblique is extracted.
-
-    The `!d.isTemporal` conjunct is a stipulation — the paper does not
-    explain why temporal obliques are exempt (§8.1). It is separated out
-    as a distinct condition rather than hidden in `obliqueExtracted`. -/
-theorem eqya_iff_voice_and_oblique :
-    monoData.all (λ d =>
-      (d.clauseType.projectsVoice && d.obliqueExtracted && !d.isTemporal) ==
-      (d.judgment == .licensed)) = true := by
-  decide
-
-/-- Multiple spellout: in long-distance extraction, =(y)a' is licensed
-    on each predicate whose clause projects Voice. Matrix clause always
-    projects Voice (it's a full CP). -/
-theorem ld_embedded_tracks_voice :
-    ldData.all (λ d =>
-      d.embeddedClauseType.projectsVoice == (d.embeddedJudgment == .licensed)) = true := by
-  decide
-
-/-- =(y)a' tracks oblique, not extraction in general: subject and object
-    extraction in the same clause size do not trigger =(y)a'. -/
-theorem eqya_tracks_oblique_not_extraction :
-    transSubjExtraction.clauseType = transOblExtraction.clauseType ∧
-    transObjExtraction.clauseType = transOblExtraction.clauseType ∧
-    transSubjExtraction.judgment = .blocked ∧
-    transObjExtraction.judgment = .blocked ∧
-    transOblExtraction.judgment = .licensed := ⟨rfl, rfl, rfl, rfl, rfl⟩
-
-/-- Temporal obliques are genuine obliques that undergo genuine extraction,
-    but are exempt from =(y)a' marking. This is an open question. -/
-theorem temporal_is_oblique_but_exempt :
-    temporalOblExtraction.obliqueExtracted = true ∧
-    temporalOblExtraction.isTemporal = true ∧
-    temporalOblExtraction.judgment = .blocked := ⟨rfl, rfl, rfl⟩
-
-/-! ### Island sensitivity -/
-
-/-- A morphological reflex of Ā-movement inherits movement's locality:
-    since Ā-movement is phase-bounded (Phase Impenetrability Condition,
-    `Phase.lean`), any morpheme requiring movement through a probe's
-    specifier is island-sensitive. Deriving island sensitivity from these
-    two properties replaces a stipulated `Bool` ([chomsky-2000] on PIC;
-    [elkins-torrence-brown-2026] §7.1). -/
-structure MovementReflex where
-  /-- Spellout of features valued via Agree with an Ā-moved constituent
-      (Agree analysis, §5). -/
-  requiresMovement : Bool
-  /-- Movement is phase-bounded (PIC, `Phase.lean`); islands are
-      configurations where the phase edge is unavailable. -/
-  movementPhaseBounded : Bool
-  deriving DecidableEq, Repr
-
-/-- Island sensitivity is derived: a movement reflex is island-sensitive
-    iff the morpheme requires movement AND movement is phase-bounded.
-    No movement → no Agree → no spellout. -/
-def MovementReflex.islandSensitive (mr : MovementReflex) : Bool :=
-  mr.requiresMovement && mr.movementPhaseBounded
-
-/-- =(y)a' is a movement reflex: it requires Ā-movement of the oblique
-    through Spec,VoiceP (so Voice can Agree [uOblique]), and movement
-    is phase-bounded (PIC). -/
-def eqyaMovementReflex : MovementReflex :=
-  { requiresMovement := true
-  , movementPhaseBounded := true }
-
-/-- Island sensitivity of =(y)a' follows from its being a movement reflex.
-    Derived from `requiresMovement ∧ movementPhaseBounded`, not stipulated. -/
-def eqyaIslandSensitive : Bool := eqyaMovementReflex.islandSensitive
-
-/-- Proof that the derivation yields island sensitivity. -/
-theorem eqya_island_sensitive_derived :
-    eqyaMovementReflex.islandSensitive = true := rfl
-
-/-! ### Against Agent Focus -/
-
-/-- =(y)a' co-occurs with passive morphology *-njtz* ([elkins-torrence-brown-2026]
-    §7.2, ex. (53)–(54)): passive is conditioned by `Voice.Flavor` and
-    =(y)a' by [+oblique] features — independent fields in `Voice.Head`, so
-    the flavor does not affect the features (structural derivation in
-    `MinimalismOblExtraction.eqya_not_agent_focus`). -/
-theorem passive_oblique_cooccurrence :
-    passiveOblExtraction.judgment = .licensed := rfl
-
-/-! ### Extraction marking -/
-
-namespace Extraction
-
-/-- Reflex hosts for SJA Mam extraction marking: the verb (AF suffixes)
-    and the Voice/Dir head hosting =(y)a'. -/
-inductive Site where
+/-- Reflex hosts of Mam extraction marking: the verb, and the Voice or directional head hosting
+=(y)a'. -/
+inductive Site
   | verb
   | voiceHead
   deriving DecidableEq, Repr
 
-/-- SJA Mam marks two extraction cells. Subject (A) extraction switches
-    the verb to AF ([scott-2023] §2.5.4.1 ex. 169, §2.7.1), combining
-    the antipassive suffix *-(a)n* with the AF-specific *-ta*
-    (`b'yo-n-ta` 'hit-AP-AF') — morphologically distinct from K'iche''s
-    bare antipassive *-n* ([mondloch-2017] Lesson 22); the SSAL-repair
-    analysis lives in `Studies/Erlewine2016.lean`, and rival accounts
-    are not encoded here. Oblique extraction places =(y)a' on the
-    Voice/Dir head — conditioned by clause size, exempting temporal
-    obliques (§8.1), island-sensitive (§7.1). Core-object extraction is
-    unmarked. -/
+/-- The two marked cells: subject extraction antipassivizes the verb, oblique extraction places
+=(y)a' on a Voice or directional head; core-object extraction is unmarked. -/
 def realize : ExtractionTarget → List (Features.Reflex Site)
   | .subject => [.morpheme .verb]
   | .oblique => [.morpheme .voiceHead]
@@ -350,11 +43,8 @@ def strategy : ExtractionMarkingStrategy := .dedicatedMorpheme
 
 theorem marks_oblique : Marked realize .oblique := by decide
 
-/-- =(y)a' tracks obliques, not subjects: no voice-head reflex under
-    subject extraction (subject marking is verb-hosted AF instead). -/
-theorem eqya_not_on_subject :
-    Features.Reflex.morpheme Site.voiceHead ∉ realize .subject := by decide
+/-- =(y)a' tracks obliques, not subjects: no voice-head reflex under subject extraction. -/
+theorem eqya_not_on_subject : Features.Reflex.morpheme Site.voiceHead ∉ realize .subject := by
+  decide
 
-end Extraction
-
-end Mam
+end Mam.Extraction

--- a/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
+++ b/Linglib/Fragments/Mayan/Mam/VoiceSystem.lean
@@ -20,16 +20,10 @@ Voice does not determine the pivot for extraction; instead it carries
 
 ## Implementation notes
 
-The Minimalist `Voice.Head`, `ClauseSpine`, and `MamDirHead` apparatus
-(=(y)a' analysis, antipassive) that previously lived here now lives in
-`Studies/ElkinsTorrenceBrown2026.lean` — the primary anchor for the
-Minimalist treatment of =(y)a' / oblique extraction
-([elkins-torrence-brown-2026]), which also houses the antipassive Voice
-apparatus from [scott-2023] §2.5.4.1; `Studies/Scott2023.lean` imports
-that Mam Voice to compare φ-Agree and oblique-Agree pipelines. SJO Mam
-(San Juan Ostuncalco, [elkins-torrence-brown-2026]) and SJA Mam (San
-Juan Atitán, [scott-2023]) are distinct varieties; this profile
-abstracts over the distinction.
+The Minimalist Voice head of the =(y)a' analysis is paper-specific apparatus and lives in
+`Studies/ElkinsTorrenceBrown2026.lean`. SJO Mam (San Juan Ostuncalco,
+[elkins-torrence-brown-2026]) and SJA Mam (San Juan Atitán, [scott-2023]) are distinct
+varieties; this profile abstracts over the distinction.
 -/
 
 namespace Mam

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -1,532 +1,392 @@
-import Linglib.Fragments.Mayan.Mam.Extraction
-import Linglib.Fragments.Mayan.Mam.VoiceSystem
-import Linglib.Fragments.Mayan.Kiche.Extraction
+import Linglib.Data.Examples.ElkinsTorrenceBrown2026
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Syntax.Minimalist.Agree.Basic
-import Linglib.Syntax.Minimalist.SyntacticObject.Build
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.FeatureBundle
-import Linglib.Studies.Scott2023
 
 /-!
-# Oblique Extraction in Mayan
-[elkins-torrence-brown-2026] [mendes-ranero-2021] [imanishi-2020]
+# Elkins, Torrence and Brown (2026): Wh-movement paths and oblique extraction in Mam
 
-## Part I: Cross-Linguistic Comparison
+This file formalizes [elkins-torrence-brown-2026]'s analysis of the movement enclitic =(y)a' of
+San Juan Ostuncalco Mam (Mayan), which optionally appears on the predicate, and on any directional
+auxiliary, when an instrument, benefactive, dative, locative, reason, purpose or manner adjunct is
+extracted, but not with absolutive or ergative arguments ([aissen-2017]'s Ergative Extraction
+Constraint sends the agent through an antipassive) or with temporals. The enclitic may occur once
+per Voice⁰ and Dir⁰ of a clause and, in long-distance extraction, once per clause along the
+dependency: in the embedded clause exactly when that clause is at least VoiceP-sized, so on both
+predicates over a full CP or an aspectless VoiceP complement, on the matrix predicate only over a
+nonfinite VP complement, and on the embedded predicate only in an embedded question. The authors
+analyse the enclitic as the spellout of Ā-agreement between the extracted adjunct and the
+[Ā]-bearing heads Voice⁰ and Dir⁰ it passes through under Relativized-Minimality successive
+cyclicity ([rizzi-1990], [abels-2003]): Attract Closest forces the mover through the specifier of
+each intervening [Ā]-bearer, each Voice⁰ or Dir⁰ copies the [obl] Case feature the mover receives
+from its relational noun, and the bundle [Ā, obl] is realized as =(y)a' or as ∅. The rival Chain
+Reduction via Substitution of [mendes-ranero-2021] for the K'ichean fronting particle *wi*, which
+spells out lower copies at the base position and at each Spec,CP stopover and so derives the
+Fronting Particle Generalization, predicts a single reflex within a clause, none in the matrix
+clause over an aspectless complement, and one inside a nonfinite complement, all contrary to the
+Mam data; DP-intervention leapfrogging ([keine-zeijlstra-2025]) predicts at most one reflex per
+intervening argument, contrary to a clause with three; and an Agent-Focus-like analysis fails
+because the enclitic co-occurs with the passive and appears in every clause of the path while the
+antipassive is confined to the clause of origin. The two systems also differ in which adjuncts
+trigger the reflex: reasons, purposes and manners do in Mam but are high adjuncts without [appl]
+in K'ichean, and temporals trigger neither.
 
-Cross-linguistic comparison of extraction morphology in two Mayan
-language groups: SJO Mam (=(y)a') and K'ichean (*wi*). Both mark
-oblique extraction with a dedicated morpheme, but the underlying
-mechanisms and distributional properties differ.
+## Implementation notes
 
-### Shared Properties
+* Clause sizes are the substrate's `ClauseSpine`s, full CP, VoiceP and bare VP, with the
+  directional head `Head.dir`, a Mayan-specific category above VoiceP, spliced in by `spine`. A
+  dependency is the list of clauses the mover crosses, bottom-up; its `path` is the [Ā]-bearers of
+  those clauses and its `sites` the Voice and Dir heads among them, so the reflex in a clause is
+  decided by whether the clause projects Voice (`licensed_iff_projects_voice`). The rival
+  mechanisms are predicates on the same dependencies, and the rows discriminate them.
+* The Agree-and-insertion step is the substrate's `applyAgree` and `spellout` on a Voice head with
+  an unvalued [oblique] probe and the vocabulary item (46a); the null exponent (46b) is the
+  independent optionality of each site, `patterns`.
+* [obl] on the movers is the article's featural hypothesis (§1.3, §4.2, §5.3): relational nouns
+  assign it, the locative and manner wh-words are assumed to acquire it, temporals lack it.
+* The examples are `Data.Examples.ElkinsTorrenceBrown2026`; the K'iche' rows are
+  [mendes-ranero-2021]'s as reported there. The variety is SJO Mam; [scott-2023]'s San Juan
+  Atitán Mam is a distinct variety.
 
-- Both mark oblique extraction (spatial, instrumental)
-- Both exempt temporal obliques ('when')
-- Neither marks subject extraction (Agent Focus instead)
-- Neither marks object extraction
+## References
 
-### Parametric Differences
-
-| Property                      | Mam =(y)a'          | K'ichean *wi*         |
-|-------------------------------|---------------------|-----------------------|
-| Locus                         | On probe (Voice⁰)  | At extraction site    |
-| Mechanism                     | Agree reflex        | Copy spellout         |
-| Reason obliques ('why')       | =(y)a' ✓            | *wi* ✗                |
-| FPG (matrix wi ↔ embedded comp) | Does not hold    | Holds                 |
-| Conditioned by clause size    | Yes (Voice project.)| No                    |
-| Multiple spellout in LD       | Yes (per Voice/Dir) | Unclear               |
-
-## Part II: Minimalist Analysis
-
-Connects three Minimalist abstractions — ClauseSpine, Agree/feature-valuation,
-and Spellout — to the empirical data on =(y)a' distribution in SJO Mam.
-
-1. Voice⁰ (and Dir⁰) in Mam carry [uOblique] (an unvalued probe feature).
-2. When an oblique DP undergoes successive-cyclic Ā-movement through
-   Spec,VoiceP, Agree values [uOblique] as [+oblique] on Voice⁰.
-3. At Spellout (PF), [+oblique] on Voice⁰ is realized as =(y)a'.
-4. In infinitival complements, Voice is not projected (VP-sized), so there
-   is no [uOblique] probe — =(y)a' cannot appear.
-5. In long-distance extraction, each Voice⁰/Dir⁰ along the movement path
-   independently Agrees, yielding multiple =(y)a' (one per Voice/Dir).
+* [elkins-torrence-brown-2026]
+* [mendes-ranero-2021]
+* [rizzi-1990]
+* [abels-2003]
+* [keine-zeijlstra-2025]
+* [van-urk-2018]
+* [scott-2023]
+* [england-1989]
+* [aissen-2017]
 -/
 
 namespace ElkinsTorrenceBrown2026
 
--- ============================================================================
--- Part I: Cross-Linguistic Comparison
--- ============================================================================
-
-open Mam Kiche
-
--- ============================================================================
--- § 1: Shared Properties
--- ============================================================================
-
-/-- Both Mam and K'ichean use dedicated morphemes for oblique extraction. -/
-theorem both_mark_oblique :
-    Mam.Extraction.strategy = .dedicatedMorpheme ∧
-    Kiche.Extraction.strategy = .dedicatedMorpheme := ⟨rfl, rfl⟩
-
-/-- Both exempt temporal obliques from extraction marking. -/
-theorem both_exempt_temporal :
-    (Mam.temporalOblExtraction.isTemporal = true ∧
-     Mam.temporalOblExtraction.judgment = .blocked) ∧
-    Kiche.temporalOblExtraction.wiLicensed = false :=
-  ⟨⟨rfl, rfl⟩, rfl⟩
-
-/-- Neither marks subject extraction (Agent Focus instead). -/
-theorem neither_marks_subject :
-    transSubjExtraction.judgment = .blocked ∧
-    Kiche.subjectExtraction.wiLicensed = false := ⟨rfl, rfl⟩
-
-/-- Neither marks object extraction. -/
-theorem neither_marks_object :
-    transObjExtraction.judgment = .blocked ∧
-    Kiche.objectExtraction.wiLicensed = false := ⟨rfl, rfl⟩
-
--- ============================================================================
--- § 2: Parametric Differences
--- ============================================================================
-
-/-- KEY CONTRAST — Reason obliques ('why'):
-    Mam =(y)a' IS licensed with reason extraction; K'ichean *wi* is NOT. -/
-theorem reason_oblique_contrast :
-    transOblExtraction.judgment = .licensed ∧
-    Kiche.reasonOblExtraction.wiLicensed = false := ⟨rfl, rfl⟩
-
-/-- Mam =(y)a' is conditioned by clause size (Voice must project);
-    K'ichean *wi* is conditioned by complementizer presence (FPG). -/
-theorem clause_size_sensitivity :
-    MamClauseType.fullCP.projectsVoice = true ∧
-    MamClauseType.aspectless.projectsVoice = true ∧
-    MamClauseType.infinitival.projectsVoice = false := ⟨rfl, rfl, rfl⟩
-
-/-- The FPG holds for K'ichean: matrix *wi* tracks overt complementizer. -/
-theorem kichean_fpg_holds :
-    Kiche.ldData.all (λ d =>
-      d.embeddedType.hasComp == d.wiOnMatrix) = true := by
-  decide
-
--- ============================================================================
--- § 3: Theoretical Implications
--- ============================================================================
-
-/-- Genuinely different mechanisms producing superficially similar patterns. -/
-inductive ExtractionMorphologyMechanism where
-  | agreeReflex     -- Morpheme on probe head (Mam =(y)a')
-  | copySpellout    -- Morpheme at extraction site (K'ichean *wi*)
-  deriving DecidableEq, Repr
-
-def mamMechanism : ExtractionMorphologyMechanism := .agreeReflex
-def kicheanMechanism : ExtractionMorphologyMechanism := .copySpellout
-
-theorem different_mechanisms :
-    mamMechanism ≠ kicheanMechanism := by decide
-
--- ============================================================================
--- Part II: Minimalist Analysis
--- ============================================================================
-
-open Minimalist SyntacticObject
-open DistributedMorphology (VocabularyItem)
+open Minimalist DistributedMorphology Data.Examples ElkinsTorrenceBrown2026.Examples
 open scoped DistributedMorphology.VocabularyItem
 
-/-! ### Mam Voice substrate (Minimalist)
+/-! ### The extended verbal domain (§1.3) -/
 
-This subsection houses the Minimalist `Voice.Head`, `ClauseSpine`, and
-`MamDirHead` definitions for Mam, formerly in
-`Linglib/Fragments/Mayan/Mam/VoiceSystem.lean`. Per CLAUDE.md
-"Per-language paper-specific apparatus lives in Studies, not
-Fragments," these belong with the paper that anchors them
-([elkins-torrence-brown-2026] for the =(y)a' analysis;
-[scott-2023] for the antipassive). The Fragment file retains only
-the per-language `Mam.VoiceSystem.voices`/`symmetry` defs.
-
-`Studies/Scott2023.lean` consumes `mamVoice` and
-`eqYaVocab` from this file via cross-Studies import. -/
-
-/-- Mam agentive Voice head with [uOblique] probe.
-
-    In Mam, Voice⁰ probes for an oblique feature on a passing
-    Ā-moved constituent. When an oblique DP moves through Spec,VoiceP,
-    Agree values [uOblique] as [+oblique], which is then spelled out
-    as =(y)a' at PF. -/
-def mamVoice : Voice.Head :=
-  { flavor := .agentive
-  , hasD := true
-  , features := .ofGramFeatures [.unvalued (.oblique false)] }
-
-/-- Mam transitive clause spine: full CP with Voice. -/
-def mamTransitiveSpine : ClauseSpine := ClauseSpine.cP
-
-/-- Mam aspectless complement spine: VoiceP-sized.
-    Still has Voice → =(y)a' possible. -/
-def mamAspectlessSpine : ClauseSpine := ClauseSpine.voiceP
-
-/-- Mam infinitival complement spine: VP-sized.
-    No Voice → =(y)a' impossible. -/
-def mamInfinitivalSpine : ClauseSpine := ClauseSpine.bareVP
-
-/-- Mam directional auxiliary head (Dir⁰).
-
-    Dir is NOT a universal category — it is specific to Mayan languages.
-    Modeled as a language-specific type rather than added to `Cat`.
-    In Elkins et al.'s analysis, Dir⁰ occupies V1 position in the verbal
-    template (Voice > V1(Dir) > Appl > V2(root)). Like Voice⁰, Dir⁰
-    bears [uOblique] and can host =(y)a'. -/
-structure MamDirHead where
-  /-- Cislocative (toward speaker) vs translocative (away). -/
-  cislocative : Bool
-  /-- Whether this Dir head carries [uOblique]. -/
-  hasUOblique : Bool := false
+/-- A head of the SJO Mam clausal spine: a head of the substrate spine, or a directional auxiliary
+Dir⁰, the Mayan-specific head whose projection dominates VoiceP (8). -/
+inductive Head
+  | cat (c : Cat)
+  | dir
   deriving DecidableEq, Repr
 
-/-- Dir⁰'s probe features when it carries [uOblique]. -/
-def MamDirHead.features (d : MamDirHead) : FeatureBundle :=
-  if d.hasUOblique then .ofGramFeatures [.unvalued (.oblique false)] else ⊥
+/-- A clause as its projected heads, bottom-up. -/
+abbrev Spine := List Head
 
-/-- Cislocative directional with [uOblique]. -/
-def dirCis : MamDirHead := { cislocative := true, hasUOblique := true }
+/-- A clause of the given size with `n` directionals above Voice (8). Nonfinite clauses, which lack
+Voice, lack directionals (§3.4). -/
+def spine (s : ClauseSpine) (n : ℕ) : Spine :=
+  s.projectedHeads.flatMap λ c =>
+    if c = .Voice then .cat .Voice :: List.replicate n .dir else [.cat c]
 
-/-- Translocative directional with [uOblique]. -/
-def dirTrans : MamDirHead := { cislocative := false, hasUOblique := true }
+/-- The reduced K'ichean complement of [mendes-ranero-2021], an AspP without a CP layer (§5.1). -/
+def aspP : ClauseSpine := ⟨[.V, .Appl, .v, .Voice, .Asp], by decide⟩
 
-/-- The Vocabulary Item for =(y)a': [+oblique] on Voice⁰ spells out as "=(y)a'". -/
-def eqYaVocab : VocabularyItem GramFeature String := [.valued (.oblique true)] ⟷ "=(y)a'"
+/-- The feature bearers of [Ā], (41) and (44): C⁰, Voice⁰ and Dir⁰. -/
+def BearsA (h : Head) : Prop := h = .cat .C ∨ h = .cat .Voice ∨ h = .dir
 
-/-- The items Voice⁰ consults in Mam: just =(y)a'. -/
-def mamVoiceVocab : List (VocabularyItem GramFeature String) := [eqYaVocab]
+instance : DecidablePred BearsA := λ _ => inferInstanceAs (Decidable (_ ∨ _ ∨ _))
 
-/-- Mam passive Voice head: carries [uOblique] just like agentive Voice.
-    [elkins-torrence-brown-2026] §7.2: =(y)a' co-occurs with
-    passive *-njtz*. -/
-def mamPassiveVoice : Voice.Head :=
-  { flavor := .nonThematic
-  , hasD := false
-  , features := .ofGramFeatures [.unvalued (.oblique false)] }
+/-- The heads that copy the mover's [obl] and host the reflex, (45)–(46): Voice⁰ and Dir⁰. C⁰
+attracts by [Ā] alone, so there is no C-domain reflex. -/
+def HostsReflex (h : Head) : Prop := h = .cat .Voice ∨ h = .dir
 
-/-- Mam antipassive Voice head ([scott-2023] §2.5.4.1).
-    Subject gets ABS not ERG; not a phase head. -/
-def mamAntipassiveVoice : Voice.Head :=
-  { flavor := .antipassive
-  , hasD := true
-  , features := ⊥ }
+instance : DecidablePred HostsReflex := λ _ => inferInstanceAs (Decidable (_ ∨ _))
 
--- ── Substrate-level theorems ─────────────────────────────────────────
+theorem HostsReflex.bearsA {h : Head} (hh : HostsReflex h) : BearsA h := Or.inr hh
 
-/-- Mam Voice head carries [uOblique]. -/
-theorem mamVoice_has_uOblique :
-    mamVoice.features.hasUnvaluedFeature .oblique = true := by decide
+/-! ### The movement path (§4.1–4.3) -/
 
-/-- Mam Voice is a phase head. -/
-theorem mamVoice_is_phase : mamVoice.IsPhasal := by decide
+/-- A dependency: the clauses the extracted adjunct crosses, bottom-up, the clause of origin
+first. -/
+abbrev Dependency := List Spine
 
-/-- Mam Voice assigns a θ-role (agentive). -/
-theorem mamVoice_assigns_theta : mamVoice.AssignsTheta := by decide
+/-- The movement path, (43): the [Ā]-bearing heads of the clauses crossed, bottom-up and tagged by
+clause. By Attract Closest (39) the mover stops in the specifier of each. -/
+def path (d : Dependency) : List (ℕ × Head) :=
+  (List.range d.length).flatMap λ i =>
+    ((d.getD i []).filter λ h => decide (BearsA h)).map (i, ·)
 
-/-- Mam transitive spine projects Voice. -/
-theorem mamTransitive_has_voice :
-    mamTransitiveSpine.projects .Voice = true := by decide
+/-- The sites of the reflex: the Agree relations with Voice⁰ or Dir⁰ along the path (§4.2). -/
+def sites (d : Dependency) : List (ℕ × Head) :=
+  (path d).filter λ p => decide (HostsReflex p.2)
 
-/-- Mam aspectless spine projects Voice. -/
-theorem mamAspectless_has_voice :
-    mamAspectlessSpine.projects .Voice = true := by decide
+/-- =(y)a' is licensed in clause `i` of the dependency when the path has a site there. -/
+def Licensed (d : Dependency) (i : ℕ) : Prop := i ∈ (sites d).map Prod.fst
 
-/-- Mam infinitival spine does NOT project Voice. -/
-theorem mamInfinitival_lacks_voice :
-    mamInfinitivalSpine.projects .Voice = false := by decide
+instance (d : Dependency) (i : ℕ) : Decidable (Licensed d i) :=
+  inferInstanceAs (Decidable (_ ∈ _))
 
-/-- Cislocative Dir carries [uOblique]. -/
-theorem dirCis_has_uOblique : dirCis.hasUOblique = true := rfl
+theorem mem_path {d : Dependency} {i : ℕ} {h : Head} :
+    (i, h) ∈ path d ↔ i < d.length ∧ h ∈ d.getD i [] ∧ BearsA h := by
+  simp only [path, List.mem_flatMap, List.mem_range, List.mem_map, List.mem_filter,
+    decide_eq_true_eq, Prod.mk.injEq]
+  constructor
+  · rintro ⟨j, hj, h', ⟨hmem, hb⟩, rfl, rfl⟩
+    exact ⟨hj, hmem, hb⟩
+  · rintro ⟨hi, hmem, hb⟩
+    exact ⟨i, hi, h, ⟨hmem, hb⟩, rfl, rfl⟩
 
-/-- Translocative Dir carries [uOblique]. -/
-theorem dirTrans_has_uOblique : dirTrans.hasUOblique = true := rfl
+/-- The reflex is licensed in a clause exactly when the clause contains a reflex host: every
+Voice⁰ or Dir⁰ crossed is an [Ā]-bearer and so a stopover. -/
+theorem licensed_iff {d : Dependency} {i : ℕ} :
+    Licensed d i ↔ ∃ h ∈ d.getD i [], HostsReflex h := by
+  simp only [Licensed, sites, List.mem_map, List.mem_filter, decide_eq_true_eq]
+  constructor
+  · rintro ⟨⟨j, h⟩, ⟨hp, hh⟩, rfl⟩
+    exact ⟨h, (mem_path.mp hp).2.1, hh⟩
+  · rintro ⟨h, hmem, hh⟩
+    refine ⟨(i, h), ⟨mem_path.mpr ⟨?_, hmem, hh.bearsA⟩, hh⟩, rfl⟩
+    by_contra hlt
+    rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (Nat.le_of_not_lt hlt)] at hmem
+    exact List.not_mem_nil hmem
 
-/-- Dir's probe features match Voice's. -/
-theorem dir_features_match_voice :
-    dirCis.features = mamVoice.features := by decide
+/-- A clause of a given size contains a reflex host exactly when the size projects Voice, since
+directionals come only with Voice. -/
+theorem exists_hostsReflex_spine_iff (s : ClauseSpine) (n : ℕ) :
+    (∃ h ∈ spine s n, HostsReflex h) ↔ .Voice ∈ s.projectedHeads := by
+  simp only [spine, List.mem_flatMap]
+  constructor
+  · rintro ⟨h, ⟨c, hc, hmem⟩, hh⟩
+    split at hmem
+    · next hcv => exact hcv ▸ hc
+    · next hcv =>
+      rw [List.mem_singleton] at hmem
+      rcases hh with rfl | rfl
+      · exact absurd (Head.cat.inj hmem).symm hcv
+      · exact Head.noConfusion hmem
+  · intro hv
+    exact ⟨.cat .Voice, ⟨.Voice, hv, by simp⟩, Or.inl rfl⟩
 
-/-- Passive and agentive Voice differ in flavor but share the same
-    oblique probe features. -/
-theorem passive_voice_same_features :
-    mamPassiveVoice.features = mamVoice.features ∧
-    mamPassiveVoice.flavor ≠ mamVoice.flavor := ⟨rfl, by decide⟩
+theorem projects_voice_iff (s : ClauseSpine) :
+    s.projects .Voice = true ↔ .Voice ∈ s.projectedHeads := by
+  simp [ClauseSpine.projects]
 
-/-- Antipassive Voice assigns a θ-role (the agent is present). -/
-theorem mamAntipassive_assigns_theta :
-    mamAntipassiveVoice.AssignsTheta := by decide
+/-- Table 3: =(y)a' is licensed in a clause of the dependency exactly when that clause's size
+projects Voice, so in full CP and aspectless complements but not in nonfinite ones (§3.3–3.4,
+§4.3). -/
+theorem licensed_iff_projects_voice {d : Dependency} {i : ℕ} {s : ClauseSpine} {n : ℕ}
+    (hd : d.getD i [] = spine s n) : Licensed d i ↔ s.projects .Voice = true := by
+  rw [licensed_iff, hd, exists_hostsReflex_spine_iff, projects_voice_iff]
 
-/-- Antipassive Voice is NOT a phase head. -/
-theorem mamAntipassive_not_phase :
-    ¬ mamAntipassiveVoice.IsPhasal := by decide
+/-! ### Multiple exponence (§3.1, §5.2) -/
 
-/-- Antipassive and agentive Voice differ in phase-head status but both
-    assign θ-roles. -/
-theorem antipassive_vs_agentive :
-    (mamAntipassiveVoice.AssignsTheta ↔ mamVoice.AssignsTheta) ∧
-    (mamAntipassiveVoice.IsPhasal ↔ ¬ mamVoice.IsPhasal) := by decide
+/-- Within a clause the sites are Voice⁰ and each directional, (45): `n + 1` of them. -/
+theorem sites_monoclausal (n : ℕ) :
+    sites [spine .cP n] = (0, .cat .Voice) :: List.replicate n (0, .dir) := by
+  simp [sites, path, spine, ClauseSpine.cP, BearsA, HostsReflex, List.map_replicate]
 
--- ============================================================================
--- § 4: Spellout Theorems
--- ============================================================================
+theorem sites_monoclausal_length (n : ℕ) : (sites [spine .cP n]).length = n + 1 := by
+  rw [sites_monoclausal]
+  simp
 
-/-- Valued [+oblique] on Voice spells out as =(y)a'. -/
-theorem spellout_oblique_voice :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
+/-- (46b): each site is independently realized as =(y)a' or as ∅, so the surface patterns of a
+dependency are the sublists of its sites. -/
+def patterns (d : Dependency) : List (List (ℕ × Head)) := (sites d).sublists
+
+/-- (22): with one directional the enclitic may appear on both hosts, on neither, or on either
+alone, four combinations. -/
+theorem patterns_length_22 : (patterns [spine .cP 1]).length = 4 := by decide
+
+/-- (63): with two directionals there are three sites although the intransitive clause has a
+single argument DP, so leapfrogging over intervening DPs ([keine-zeijlstra-2025]) yields too few
+stopovers (§5.2). -/
+theorem sites_exceed_interveners : 1 < (sites [spine .cP 2]).length := by
+  rw [sites_monoclausal_length]
   decide
 
-/-- Without [+oblique], Voice has no exponent from this vocabulary. -/
-theorem spellout_no_oblique :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique false)]) = none := by
+/-! ### The rival mechanisms (§3.6, §5.1) -/
+
+/-- Chain Reduction via Substitution, (55)–(57): the reflex spells out the lower copies of the
+mover, the base copy in the clause of origin and the intermediate copy in each Spec,CP crossed,
+which linearizes onto the predicate of the next clause up. -/
+def CopyLicensed (d : Dependency) (i : ℕ) : Prop :=
+  i = 0 ∨ (0 < i ∧ i < d.length ∧ .cat .C ∈ d.getD (i - 1) [])
+
+instance (d : Dependency) (i : ℕ) : Decidable (CopyLicensed d i) :=
+  inferInstanceAs (Decidable (_ ∨ _ ∧ _ ∧ _))
+
+/-- The Fronting Particle Generalization (54): over a single embedded clause, the matrix reflex is
+contingent on the embedded clause projecting C. -/
+theorem fpg (e m : Spine) : CopyLicensed [e, m] 1 ↔ .cat .C ∈ e := by
+  simp [CopyLicensed]
+
+/-- Applied to Mam, copy spellout allows a single reflex in a monoclausal dependency, whereas
+Ā-agreement gives one per Voice⁰ and Dir⁰ (§3.1, §5.1). -/
+theorem copy_single_site (n : ℕ) : (∀ i, CopyLicensed [spine .cP n] i → i = 0) ∧
+    (sites [spine .cP n]).length = n + 1 :=
+  ⟨λ i h => h.elim id λ h' => by
+    have h1 := h'.1
+    have h2 := h'.2.1
+    simp only [List.length_singleton] at h2
+    omega, sites_monoclausal_length n⟩
+
+/-- Over an aspectless complement, (31): copy spellout predicts no matrix reflex, since the
+complement has no Spec,CP, whereas Ā-agreement predicts one at the matrix Voice⁰. -/
+theorem copy_fails_aspectless :
+    ¬ CopyLicensed [spine .voiceP 0, spine .cP 0] 1 ∧
+      Licensed [spine .voiceP 0, spine .cP 0] 1 := by
   decide
 
--- ============================================================================
--- § 5: Prediction Function
--- ============================================================================
-
-/-- Predict whether =(y)a' is licensed from a clause spine and extraction type. -/
-def predictEqYa (spine : ClauseSpine) (obliqueExtracted : Bool)
-    (isTemporal : Bool := false) : MamExtractionJudgment :=
-  if spine.projects .Voice && obliqueExtracted && !isTemporal then .licensed
-  else .blocked
-
--- ============================================================================
--- § 6: Per-Datum Theorems (Monoclausal)
--- ============================================================================
-
-/-- Transitive clause + oblique extraction → =(y)a' licensed. -/
-theorem bridge_trans_obl :
-    mamTransitiveSpine.projects .Voice = true ∧
-    predictEqYa mamTransitiveSpine true = .licensed ∧
-    transOblExtraction.judgment = .licensed := by
-  exact ⟨by decide, by decide, rfl⟩
-
-/-- Transitive + subject extraction → no =(y)a'. -/
-theorem bridge_trans_subj :
-    predictEqYa mamTransitiveSpine false = .blocked ∧
-    transSubjExtraction.judgment = .blocked := by
-  exact ⟨by decide, rfl⟩
-
-/-- Transitive + object extraction → no =(y)a'. -/
-theorem bridge_trans_obj :
-    predictEqYa mamTransitiveSpine false = .blocked ∧
-    transObjExtraction.judgment = .blocked := by
-  exact ⟨by decide, rfl⟩
-
-/-- Passive + oblique → =(y)a' licensed. -/
-theorem bridge_passive_obl :
-    mamTransitiveSpine.projects .Voice = true ∧
-    predictEqYa mamTransitiveSpine true = .licensed ∧
-    passiveOblExtraction.judgment = .licensed := by
-  exact ⟨by decide, by decide, rfl⟩
-
-/-- Temporal oblique + full clause → =(y)a' BLOCKED. -/
-theorem bridge_temporal_obl :
-    predictEqYa mamTransitiveSpine true (isTemporal := true) = .blocked ∧
-    temporalOblExtraction.judgment = .blocked := by
-  exact ⟨by decide, rfl⟩
-
--- ============================================================================
--- § 7: Long-Distance Theorems
--- ============================================================================
-
-/-- Map MamClauseType to the corresponding ClauseSpine. -/
-def spineOf : MamClauseType → ClauseSpine
-  | .fullCP => mamTransitiveSpine
-  | .aspectless => mamAspectlessSpine
-  | .infinitival => mamInfinitivalSpine
-
-/-- LD from full CP → =(y)a' licensed on both predicates. -/
-theorem bridge_ld_fullCP :
-    (spineOf ldFullCP.embeddedClauseType).projects .Voice = true ∧
-    ldFullCP.matrixJudgment = .licensed ∧
-    ldFullCP.embeddedJudgment = .licensed := by
-  exact ⟨by decide, rfl, rfl⟩
-
-/-- LD from aspectless → =(y)a' licensed on both. -/
-theorem bridge_ld_aspectless :
-    (spineOf ldAspectless.embeddedClauseType).projects .Voice = true ∧
-    ldAspectless.matrixJudgment = .licensed ∧
-    ldAspectless.embeddedJudgment = .licensed := by
-  exact ⟨by decide, rfl, rfl⟩
-
-/-- LD from infinitival → =(y)a' on matrix only. -/
-theorem bridge_ld_infinitival :
-    (spineOf ldInfinitival.embeddedClauseType).projects .Voice = false ∧
-    ldInfinitival.matrixJudgment = .licensed ∧
-    ldInfinitival.embeddedJudgment = .blocked := by
-  exact ⟨by decide, rfl, rfl⟩
-
-/-- EQ → =(y)a' on embedded only. -/
-theorem bridge_ld_eq :
-    ldEmbeddedQuestion.matrixJudgment = .blocked ∧
-    ldEmbeddedQuestion.embeddedJudgment = .licensed := ⟨rfl, rfl⟩
-
--- ============================================================================
--- § 8: Completeness
--- ============================================================================
-
-/-- All monoclausal predictions match. -/
-theorem all_mono_predictions_match :
-    monoData.all (λ d =>
-      predictEqYa (spineOf d.clauseType) d.obliqueExtracted d.isTemporal
-        == d.judgment) = true := by
+/-- Over a nonfinite complement, (34): copy spellout predicts a reflex in the complement, where
+the base copy sits, whereas Ā-agreement finds no Voice⁰ there. -/
+theorem copy_fails_nonfinite :
+    CopyLicensed [spine .bareVP 0, spine .cP 0] 0 ∧
+      ¬ Licensed [spine .bareVP 0, spine .cP 0] 0 := by
   decide
 
-/-- All LD embedded predictions match. -/
-theorem all_ld_embedded_predictions_match :
-    ldData.all (λ d =>
-      d.embeddedClauseType.projectsVoice == (d.embeddedJudgment == .licensed)) = true := by
+/-- Conversely, Ā-agreement through the verbal domain would put a matrix reflex over a K'ichean
+AspP complement, (53), against the Fronting Particle Generalization; copy spellout does not. -/
+theorem agree_fails_fpg :
+    Licensed [spine aspP 0, spine .cP 0] 1 ∧ ¬ CopyLicensed [spine aspP 0, spine .cP 0] 1 := by
   decide
 
--- ============================================================================
--- § 9: Against Alternative Analyses
--- ============================================================================
-
-/-- Against resumptive-pronoun analysis: =(y)a' is island-sensitive. -/
-theorem eqya_not_resumptive :
-    eqyaIslandSensitive = true := rfl
-
-/-- Against Agent Focus analysis: =(y)a' co-occurs with passive voice. -/
-theorem eqya_not_agent_focus :
-    mamPassiveVoice.features = mamVoice.features ∧
-    mamPassiveVoice.flavor ≠ mamVoice.flavor ∧
-    passiveOblExtraction.judgment = .licensed ∧
-    transSubjExtraction.judgment = .blocked ∧
-    transOblExtraction.judgment = .licensed := by
-  exact ⟨rfl, by decide, rfl, rfl, rfl⟩
-
-/-- Against copy spellout: =(y)a' disappears when Voice is absent. -/
-theorem eqya_not_copy_spellout :
-    (spineOf MamClauseType.aspectless).projects .Voice = true ∧
-    (spineOf MamClauseType.infinitival).projects .Voice = false ∧
-    ldAspectless.embeddedJudgment = .licensed ∧
-    ldInfinitival.embeddedJudgment = .blocked := by
-  exact ⟨by decide, by decide, rfl, rfl⟩
-
--- ============================================================================
--- § 10: ClauseSpine vs. ComplementSize
--- ============================================================================
-
-/-- ClauseSpine is finer than ComplementSize: it can distinguish
-    infinitival (VP) from aspectless (VoiceP). -/
-theorem clauseSpine_finer_than_complementSize :
-    mamAspectlessSpine.projects .Voice = true ∧
-    mamInfinitivalSpine.projects .Voice = false := by
-  exact ⟨by decide, by decide⟩
-
--- ============================================================================
--- § 11: Dir⁰ Spellout
--- ============================================================================
-
-/-- Dir⁰ also carries [uOblique]. -/
-theorem dir_probe_matches_voice :
-    dirCis.features = mamVoice.features := by decide
-
-/-- Dir⁰ with valued [+oblique] also spells out as =(y)a'. -/
-theorem dir_spellout_eqya :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
+/-- An Agent-Focus-like reflex is confined to the clause of origin, as the antipassive is in
+(38); =(y)a' is licensed in every clause of the path, (24). -/
+theorem origin_only_fails : Licensed [spine .cP 0, spine .cP 0] 1 ∧ (1 : ℕ) ≠ 0 := by
   decide
 
--- ============================================================================
--- § 12: Derivation Tree
--- ============================================================================
+/-! ### Which movers trigger the reflex (§2, §5.3) -/
 
-section Derivation
+/-- The adjunct classes of §2.2. -/
+inductive Adjunct
+  | instrument
+  | benefactive
+  | dative
+  | locative
+  | reason
+  | purpose
+  | manner
+  | temporal
+  deriving DecidableEq, Fintype
 
-open RoseTree UnorderedTree
+/-- The article's featural hypothesis (9), footnotes 3 and 12, §5.3: every adjunct class but the
+temporals bears the [obl] Case feature that Voice⁰ and Dir⁰ copy. -/
+def Adjunct.BearsObl (a : Adjunct) : Prop := a ≠ .temporal
 
-/-- Leaf tokens for the SJO Mam transitive-CP derivation. -/
-private def obliqueTok : LIToken := ⟨.simple .D [] "jawu'", 1⟩
-private def verbTok    : LIToken := ⟨.simple .V [.D] "loq'", 2⟩
-private def objectTok  : LIToken := ⟨.simple .D [] "wääy", 3⟩
-private def voiceTok   : LIToken := ⟨.simple .Voice [.V] "", 4⟩
-private def tTok       : LIToken := ⟨.simple .T [.Voice] "", 5⟩
-private def cTok       : LIToken := ⟨.simple .C [.T] "", 6⟩
+instance : DecidablePred Adjunct.BearsObl := λ _ => inferInstanceAs (Decidable (_ ≠ _))
 
-/-- The full CP derivation, built planar-first (Merge `SyntacticObject.merge` is noncomputable,
-    so concrete `decide`-able trees use the planar DSL): the oblique DP undergoes
-    successive-cyclic Ā-movement, surfacing at Spec,CP with a trace lower down.
-    Structure: `[CP oblique [C' C [TP T [VoiceP oblique [Voice' Voice [VP V obj]]]]]]`. -/
-private def cp : PlanarSyntacticObject :=
-  
-    (obliqueTok * (cTok * (tTok * (obliqueTok * (voiceTok * (verbTok * objectTok))))))
+/-- [mendes-ranero-2021]'s low adjuncts, merged in Spec,ApplP with [appl], which alone trigger
+*wi* (§5.3). -/
+def Adjunct.IsLow (a : Adjunct) : Prop :=
+  a = .instrument ∨ a = .benefactive ∨ a = .dative ∨ a = .locative
 
-theorem derivation_tree_size : cp.toSyntacticObject.nodeCount = 6 := by decide
+instance : DecidablePred Adjunct.IsLow := λ _ => inferInstanceAs (Decidable (_ ∨ _ ∨ _ ∨ _))
 
-theorem voice_has_uOblique :
-    mamVoice.features.hasUnvaluedFeature .oblique = true := by decide
-
-private def oblique_goal_features : FeatureBundle := .ofGramFeatures [.valued (.oblique true)]
-
-/-- Agree at Voice: [uOblique] valued by oblique DP's [+oblique]. -/
-theorem voice_agree_values_oblique :
-    applyAgree mamVoice.features oblique_goal_features .oblique =
-    some (.ofGramFeatures [.valued (.oblique true)]) := by
+/-- Table 4: the Mam and K'ichean triggers differ exactly at reasons, purposes and manners. -/
+theorem table4 (a : Adjunct) :
+    ¬ (a.BearsObl ↔ a.IsLow) ↔ a = .reason ∨ a = .purpose ∨ a = .manner := by
+  revert a
   decide
 
-/-- Spellout: valued [+oblique] on Voice maps to "=(y)a'". -/
-theorem voice_spellout_eqya :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) =
-    some "=(y)a'" := by
+/-- What is extracted, if anything: an absolutive argument, an ergative argument, or an adjunct. -/
+inductive Mover
+  | none
+  | absolutive
+  | ergative
+  | adjunct (a : Adjunct)
+  deriving DecidableEq
+
+/-- Only an adjunct with [obl] feeds the reflex: absolutives and ergatives lack it (§4.2). -/
+def Mover.BearsObl : Mover → Prop
+  | .adjunct a => a.BearsObl
+  | _ => False
+
+instance : ∀ m : Mover, Decidable m.BearsObl
+  | .adjunct a => inferInstanceAs (Decidable a.BearsObl)
+  | .none => inferInstanceAs (Decidable False)
+  | .absolutive => inferInstanceAs (Decidable False)
+  | .ergative => inferInstanceAs (Decidable False)
+
+/-- The reflex is realizable in clause `i` when the mover bears [obl] and the path has a site
+there. -/
+def Realizable (m : Mover) (d : Dependency) (i : ℕ) : Prop := m.BearsObl ∧ Licensed d i
+
+instance (m : Mover) (d : Dependency) (i : ℕ) : Decidable (Realizable m d i) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-! ### Agree and insertion (§4.2) -/
+
+/-- Voice⁰ of the analysis: an [Ā]-bearing head with an unvalued [oblique] probe that Agree with
+the mover values, (45a). -/
+def voice : Voice.Head :=
+  { flavor := .agentive, hasD := true, features := .ofGramFeatures [.unvalued (.oblique false)] }
+
+/-- (46a): the vocabulary item realizing the valued [obl] on Voice⁰ or Dir⁰. -/
+def eqYa : VocabularyItem GramFeature String := [.valued (.oblique true)] ⟷ "=(y)a'"
+
+/-- Agree with an [obl] mover followed by insertion yields the enclitic. -/
+theorem agree_spellout :
+    (applyAgree voice.features (.ofGramFeatures [.valued (.oblique true)]) .oblique).bind
+      (spellout [eqYa]) = some "=(y)a'" := by
   decide
 
-/-- Full derivation pipeline: Agree then Spellout → "=(y)a'". -/
-theorem full_derivation_pipeline :
-    (applyAgree mamVoice.features oblique_goal_features .oblique).bind
-      (λ fb => spellout mamVoiceVocab fb) = some "=(y)a'" := by
+/-- A mover without [obl], an absolutive argument or a temporal, transmits nothing to Voice⁰. -/
+theorem no_obl_no_agree : applyAgree voice.features ⊥ .oblique = none := by
   decide
 
-end Derivation
+/-! ### The rows (§2, §3, §5) -/
 
--- ============================================================================
--- § 13: Unified Agree — Ā-agreement and φ-agreement as One Operation
--- (back-reference to [scott-2023]; this lives in ETB 2026 because
---  the cross-paper bridge runs from later → earlier per CLAUDE.md
---  chronological-dependency rule.)
--- ============================================================================
+/-- The movers as named in the rows. -/
+def moverTable : List (String × Mover) :=
+  [("none", .none), ("absolutive", .absolutive), ("ergative", .ergative),
+    ("instrument", .adjunct .instrument), ("benefactive", .adjunct .benefactive),
+    ("dative", .adjunct .dative), ("locative", .adjunct .locative), ("reason", .adjunct .reason),
+    ("purpose", .adjunct .purpose), ("manner", .adjunct .manner), ("temporal", .adjunct .temporal)]
 
-/-! Voice⁰ in Mam carries two independent probes:
+/-- Whether the reflex may appear, as recorded in the rows. -/
+def reflexTable : List (String × Bool) := [("licensed", true), ("blocked", false)]
 
-1. **φ-probe** [uPerson, uNumber] (analyzed by [scott-2023]):
-   Agrees with agent in Spec,VoiceP, yielding Set A morphology.
-2. **Oblique probe** [uOblique] (analyzed by [elkins-torrence-brown-2026],
-   this file): Agrees with a passing Ā-moved oblique, yielding =(y)a'
-   on Voice⁰.
+/-- The monoclausal Mam rows of §2 and §3.5–3.6: the enclitic is licensed exactly for the movers
+bearing [obl]. -/
+theorem mamRows_realizable :
+    ∀ e ∈ [ex_10b, ex_11b, ex_12b, ex_13a, ex_13b, ex_14b, ex_15b, ex_16b, ex_17b, ex_18b, ex_19b,
+        ex_20b, ex_21b, ex_35c, ex_37, ex_65],
+      ∀ m, e.parse? "mover" moverTable = some m → ∀ b, e.parse? "reflex" reflexTable = some b →
+        (b = true ↔ Realizable m [spine .cP 0] 0) := by
+  decide
 
-Both are instances of the same abstract Agree operation: probe searches
-c-command domain, finds closest matching goal, copies features, and the
-valued features are spelled out by Vocabulary Insertion. They differ only
-in which features they probe for and what vocabulary entries match. -/
+/-- The K'iche' rows (51) and (64): *wi* is licensed exactly for the low adjuncts. -/
+theorem kicheRows_low :
+    ∀ e ∈ [ex_51, ex_64], ∀ a, e.parse? "mover" moverTable = some (.adjunct a) →
+      ∀ b, e.parse? "reflex" reflexTable = some b → (b = true ↔ a.IsLow) := by
+  decide
 
-section UnifiedAgree
-open Scott2023
+/-- The rows with directionals, (22) and (63): one host per Voice⁰ and directional. -/
+theorem directionalRows_sites :
+    ∀ e ∈ [ex_22, ex_63], ∀ n, e.nat? "directionals" = some n →
+      ∀ k, e.nat? "hosts" = some k → (sites [spine .cP n]).length = k := by
+  decide
 
-/-- Voice's oblique probe features (paired with Scott 2023's φ-probe). -/
-private def voiceOblProbe : FeatureBundle := mamVoice.features
+/-- The clause sizes as named in the rows. -/
+def sizeTable : List (String × ClauseSpine) :=
+  [("cP", .cP), ("voiceP", .voiceP), ("bareVP", .bareVP), ("aspP", aspP)]
 
-/-- Both Voice probes are unvalued features. -/
-theorem both_probes_unvalued :
-    (Minimalist.FeatureBundle.toGramFeatures voiceProbe).all GramFeature.isUnvalued = true ∧
-    (Minimalist.FeatureBundle.toGramFeatures voiceOblProbe).all GramFeature.isUnvalued = true := by
-  exact ⟨by decide, by decide⟩
+/-- The dependency of a long-distance row: the embedded clause and, when the wh-expression lands
+in the matrix clause, the full-CP matrix clause above it. -/
+def dependencyOf (e : LinguisticExample) : Option Dependency :=
+  (e.parse? "embeddedSize" sizeTable).bind λ s =>
+    e.parse? "landing" [("embedded", [spine s 0]), ("matrix", [spine s 0, spine .cP 0])]
 
-/-- φ-Agree (Scott 2023) and oblique-Agree (this paper) are parallel
-    instances of the same operation, differing only in which features
-    are probed and which vocabulary entries match. -/
-theorem phi_and_oblique_agree_parallel :
-    -- φ-Agree pipeline: value person, then number, then spellout
-    (applyAgree voiceProbe dp3sg .person).bind
-      (λ fb => applyAgree fb dp3sg .number) = some voiceFullyAgreed ∧
-    spellout setAVocab voiceFullyAgreed = some "t-" ∧
-    -- Oblique-Agree pipeline: value oblique, then spellout
-    applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) .oblique =
-      some (.ofGramFeatures [.valued (.oblique true)]) ∧
-    spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
-  exact ⟨by decide, by decide, by decide, by decide⟩
+/-- The long-distance Mam rows (24), (26), (31) and (34), Table 3: the reflex in each clause
+follows from Ā-agreement along the path. -/
+theorem mamLD_licensed :
+    ∀ e ∈ [ex_24, ex_26, ex_31, ex_34], ∀ d, dependencyOf e = some d →
+      (∀ b, e.parse? "embeddedReflex" reflexTable = some b → (b = true ↔ Licensed d 0)) ∧
+        ∀ b, e.parse? "matrixReflex" reflexTable = some b → (b = true ↔ Licensed d 1) := by
+  decide
 
-end UnifiedAgree
+/-- The long-distance K'iche' rows (52) and (53) follow from copy spellout. -/
+theorem kicheLD_copy :
+    ∀ e ∈ [ex_52, ex_53], ∀ d, dependencyOf e = some d →
+      (∀ b, e.parse? "embeddedReflex" reflexTable = some b → (b = true ↔ CopyLicensed d 0)) ∧
+        ∀ b, e.parse? "matrixReflex" reflexTable = some b → (b = true ↔ CopyLicensed d 1) := by
+  decide
 
 end ElkinsTorrenceBrown2026

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -679,13 +679,6 @@ theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
     valuationOutcome mamInflSatisfaction (voiceTR :: rest) = .unvalued :=
   ⟨rfl, rfl⟩
 
--- The former §13 (Unified Agree — bridging Scott 2023's φ-Agree pipeline
--- with Elkins-Torrence-Brown 2026's oblique-Agree pipeline) violated the
--- chronological dependency rule (a 2023 study cross-referencing a 2026
--- study). It moved to `Studies/ElkinsTorrenceBrown2026.lean`
--- (the later paper, which can correctly back-reference Scott 2023's
--- φ-probe + Set A vocabulary defs).
-
 -- ============================================================================
 -- § 14: Impoverishment — Connecting to DM ([scott-2023], §4.4.3)
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
@@ -93,7 +93,7 @@ def ClauseSpine.vP : ClauseSpine :=
 
 /-- VoiceP-sized clause: [V, Appl, v, Voice]. Projects Voice head.
     In Mam, this is the size of "aspectless" complements — Voice is projected,
-    so [oblique] can be hosted, and =(y)a' is obligatory on oblique extraction. -/
+    so [oblique] can be hosted, and =(y)a' is licensed on oblique extraction. -/
 def ClauseSpine.voiceP : ClauseSpine :=
   ⟨[.V, .Appl, .v, .Voice], by decide⟩
 

--- a/references.bib
+++ b/references.bib
@@ -14801,7 +14801,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Scott2021.lean}
+  sources   = {Studies/ElkinsTorrenceBrown2026.lean}
 }
 @article{van-rooy-2003,
   author    = {van Rooij, Robert},
@@ -17444,7 +17444,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/Mayan/Mam/Agreement.lean;Studies/Scott2023.lean}
+  sources   = {Fragments/Mayan/Chol/Agreement.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Kiche/Agreement.lean;Fragments/Mayan/Mam/Agreement.lean;Fragments/Mayan/Mam/Extraction.lean;Fragments/Mayan/Mam/Pronouns.lean;Fragments/Mayan/Mam/VoiceSystem.lean;Fragments/Mayan/Params.lean;Morphology/DistributedMorphology/Impoverishment.lean;Studies/ElkinsTorrenceBrown2026.lean;Studies/Marantz1991.lean;Studies/Scott2023.lean;Syntax/Agreement/Paradigm.lean;Syntax/Case/Alignment.lean;Syntax/Minimalist/Probe/Satisfaction.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }
 @article{storme-2026,
   author    = {Storme, Benjamin},
@@ -17780,7 +17780,7 @@
   url       = {https://ling.auf.net/lingbuzz/009783},
   subfield  = {syntax},
   role      = {formalized},
-  sources   = {Studies/ElkinsTorrenceBrown2026.lean}
+  sources   = {Data/Examples/ElkinsTorrenceBrown2026.json;Fragments/Mayan/Kiche/Extraction.lean;Fragments/Mayan/Mam/Extraction.lean;Fragments/Mayan/Mam/VoiceSystem.lean;Studies/ElkinsTorrenceBrown2026.lean;Studies/Scott2023.lean;Syntax/Extraction.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean;Syntax/Minimalist/Features.lean}
 }
 @phdthesis{ross-1967,
   author    = {Ross, John Robert},
@@ -22547,7 +22547,7 @@
   subfield  = {semantics/events},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/Mayan/Chuj/RootClasses.lean;Studies/Coon2019.lean;Studies/Lucy1994.lean;Data/Examples/Coon2019.json}
+  sources   = {Data/Examples/Coon2019.json;Fragments/Mayan/Chuj/RootClasses.lean;Fragments/Mayan/Chuj/VoiceSystem.lean;Semantics/ArgumentStructure/SalienceClass.lean;Semantics/ArgumentStructure/Valency.lean;Semantics/Root/Defs.lean;Studies/BeaversEtAl2021.lean;Studies/Coon2019.lean;Studies/Lucy1994.lean;Studies/Pietraszko2026.lean;Syntax/Clause/Arguments.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 @book{karlsson-2017,
   author    = {Karlsson, Fred},
@@ -23281,7 +23281,7 @@
   doi       = {10.5334/gjgl.1087},
   subfield  = {syntax},
   role      = {formalized},
-  sources   = {Studies/ElkinsTorrenceBrown2026.lean;Fragments/Mayan/Kiche/VoiceSystem.lean;Fragments/Mayan/Kiche/ExtractionMorphology.lean}
+  sources   = {Data/Examples/ElkinsTorrenceBrown2026.json;Fragments/Mayan/Kiche/Extraction.lean;Fragments/Mayan/Kiche/VoiceSystem.lean;Studies/ElkinsTorrenceBrown2026.lean}
 }
 @book{mondloch-2017,
   author    = {Mondloch, James L.},
@@ -23294,7 +23294,7 @@
   subfield  = {morphology},
   role      = {formalized},
   validated = {true},
-  sources   = {}
+  sources   = {Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Kiche/Adposition.lean;Fragments/Mayan/Kiche/Agreement.lean;Fragments/Mayan/Kiche/Extraction.lean;Fragments/Mayan/Kiche/VoiceSystem.lean;Fragments/Mayan/Kiche/WordOrder.lean;Fragments/Mayan/Params.lean;Studies/Greenberg1963.lean}
 }% REF: Sauerland, U. & K. Yatsushiro (2017). Remind-me presuppositions and speech-act decomposition. Linguistic Inquiry 48.
 @article{sauerland-yatsushiro-2017,
   author    = {Sauerland, Uli and Yatsushiro, Kazuko},
@@ -23500,7 +23500,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Mayan/Kaqchikel/Focus.lean}
+  sources   = {Fragments/Mayan/Kaqchikel/Focus.lean;Fragments/Mayan/Mam/Extraction.lean;Fragments/Mayan/Yukatek/Agreement.lean;Studies/ElkinsTorrenceBrown2026.lean}
 }% REF: Aissen, J. (2017). Information structure in Mayan. In Aissen et al. (eds.) The Mayan Languages, pp. 293-324.
 @incollection{hofling-2017,
   author    = {Hofling, Charles Andrew},
@@ -23556,7 +23556,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/ElkinsTorrenceBrown2026.lean;Studies/Imanishi2020.lean}
+  sources   = {Fragments/Mayan/Chol/Agreement.lean;Fragments/Mayan/Params.lean;Fragments/Mayan/Qanjobal/Agreement.lean;Studies/Imanishi2014.lean;Studies/Imanishi2020.lean;Syntax/Case/Alignment.lean}
 }% REF: Alonso-Ovalle, L. & Royer, J. (2021). On Chuj modal indefinites.
 @article{alonso-ovalle-royer-2021,
   author    = {Alonso-Ovalle, Luis and Royer, Justin},
@@ -25973,7 +25973,7 @@
   doi       = {10.1002/9780470756416.ch4},
   subfield  = {syntax/minimalism},
   role      = {cited},
-  sources   = {Syntax/Minimalist/Movement/Smuggling.lean;Syntax/Minimalist/Phi/Geometry.lean}
+  sources   = {Studies/ElkinsTorrenceBrown2026.lean;Studies/Preminger2014.lean;Syntax/Minimalist/Phi/Geometry.lean}
 }
 @book{dendikken-2006,
   author    = {den Dikken, Marcel},
@@ -43095,4 +43095,39 @@
   subfield  = {semantics/lexical},
   role      = {cited},
   sources   = {Data/Examples/Elbourne2026.json;Studies/Elbourne2026.lean}
+}
+@article{keine-zeijlstra-2025,
+  author    = {Keine, Stefan and Zeijlstra, Hedde},
+  year      = {2025},
+  title     = {Clause-internal successive cyclicity: Phasality or {DP} intervention?},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {43},
+  number    = {3},
+  pages     = {1119--1182},
+  doi       = {10.1007/s11049-024-09627-3},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/ElkinsTorrenceBrown2026.lean}
+}
+@article{england-1989,
+  author    = {England, Nora C.},
+  year      = {1989},
+  title     = {Comparing {M}am ({M}ayan) clause structures: Subordinate versus main clauses},
+  journal   = {International Journal of American Linguistics},
+  volume    = {55},
+  number    = {3},
+  pages     = {283--308},
+  doi       = {10.1086/466121},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Fragments/Mayan/Mam/Extraction.lean;Studies/ElkinsTorrenceBrown2026.lean}
+}
+@phdthesis{abels-2003,
+  author    = {Abels, Klaus},
+  year      = {2003},
+  title     = {Successive cyclicity, anti-locality, and adposition stranding},
+  school    = {University of Connecticut},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/ElkinsTorrenceBrown2026.lean;Studies/Erlewine2016.lean}
 }


### PR DESCRIPTION
Deep cleanse of ElkinsTorrenceBrown2026 against the lingbuzz paper (whose example numbering the old file did not follow): the String/Bool data structs and `List.all` checks in the Mam and K'iche' extraction fragments, the rfl read-backs, the `MovementReflex` Bool derivation, the planar derivation tree and the editorial φ-Agree bridge to Scott 2023 go; the examples become `Data/Examples/ElkinsTorrenceBrown2026.json` (29 glossed rows, K'iche' rows sourced to Mendes & Ranero) and the analysis is the paper's own.

- the movement path: `Head` = substrate `Cat` plus the Mayan directional Dir⁰, `spine` splices directionals above Voice into the substrate `ClauseSpine` sizes, `path` is the [Ā]-bearers of a dependency (Attract Closest), `sites` the Voice/Dir heads among them; `licensed_iff_projects_voice` derives Table 3 from clause size, `sites_monoclausal` gives one site per Voice⁰ and directional ((22)/(63): `patterns_length_22`, `sites_exceed_interveners` against DP-intervention), and `mamRows_realizable`/`mamLD_licensed`/`directionalRows_sites` decide the rows
- the rivals as predicates on the same dependencies: `CopyLicensed` (Mendes & Ranero's Chain Reduction via Substitution) derives the Fronting Particle Generalization (`fpg`) and the K'iche' rows (`kicheLD_copy`) but fails Mam's aspectless, nonfinite and monoclausal facts (`copy_fails_*`), while Ā-agreement fails the FPG (`agree_fails_fpg`); `table4` locates the Mam/K'ichean trigger mismatch at reasons, purposes and manners
- substrate: `applyAgree`/`spellout` pipeline kept as the positive and negative witnesses; fragments reduced to their reflex cells; bib adds keine-zeijlstra-2025 and england-1989 (Crossref) and abels-2003
