### PR TITLE
refactor(Studies/EngelhardtEtAl2006): the paper's displays and instructions

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3047,3 +3047,4 @@ import Linglib.Data.Examples.Elbourne2013
 import Linglib.Data.Examples.Elbourne2026
 import Linglib.Data.Examples.ElkinsTorrenceBrown2026
 import Linglib.Data.Examples.Elliott2025
+import Linglib.Data.Examples.EngelhardtEtAl2006

--- a/Linglib/Data/Examples/EngelhardtEtAl2006.json
+++ b/Linglib/Data/Examples/EngelhardtEtAl2006.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "engelhardtetal2006_1",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "(1)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple on the towel in the box.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple on the towel in the box.",
+    "context": "A display with one apple, on a towel; an empty towel; an empty box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["ambiguity", "ambiguous"]
+    ],
+    "comment": "The temporarily ambiguous instruction of Tanenhaus et al. (1995), on the towel a modifier of the apple or the destination: listeners fixate the empty towel on hearing the prepositional phrase in the one-referent display."
+  },
+  {
+    "id": "engelhardtetal2006_2",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "(2)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple that's on the towel in the box.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple that's on the towel in the box.",
+    "context": "A display with one apple, on a towel; an empty towel; an empty box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["ambiguity", "unambiguous"]
+    ],
+    "comment": "The unambiguous counterpart of (1)."
+  },
+  {
+    "id": "engelhardtetal2006_3",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "Table 1, (3)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple on the towel.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple on the towel.",
+    "context": "The apple is on a towel and is to be moved to the other towel.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["target", "bare"],
+      ["destination", "towel"]
+    ],
+    "comment": "Bare target, matching location: the location is under-described, since the apple is already on a towel. Speakers never produced it and listeners rated it lowest of the four."
+  },
+  {
+    "id": "engelhardtetal2006_4",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "Table 1, (4)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple in the box.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple in the box.",
+    "context": "The apple is on a towel and is to be moved to the box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["target", "bare"],
+      ["destination", "box"]
+    ],
+    "comment": "Bare target, different location: concise in the one-referent display, an under-description of the target in the two-referent display."
+  },
+  {
+    "id": "engelhardtetal2006_5",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "Table 1, (5)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple on the towel on the other towel.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple on the towel on the other towel.",
+    "context": "The apple is on a towel and is to be moved to the other towel.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["target", "modified"],
+      ["destination", "otherTowel"]
+    ],
+    "comment": "Modified target, matching location: the target is over-described in the one-referent display; the location carries the pre-nominal modifier other."
+  },
+  {
+    "id": "engelhardtetal2006_6",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "Table 1, (6)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple on the towel in the box.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple on the towel in the box.",
+    "context": "The apple is on a towel and is to be moved to the box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["target", "modified"],
+      ["destination", "box"]
+    ],
+    "comment": "Modified target, different location: an over-description in the one-referent display, the modification required in the two-referent display. In Experiment 3 listeners fixated the empty towel on hearing on the towel and were delayed in fixating the box."
+  },
+  {
+    "id": "engelhardtetal2006_7",
+    "source": {"bibkey": "engelhardt-etal-2006", "paperLabel": "(7)"},
+    "language": "stan1293",
+    "primaryText": "Put the apple in the box on the towel.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "Put the apple in the box on the towel.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Recorded so that the bare target instruction of the matching condition could be cut from it with the prosody of (6)."
+  }
+]

--- a/Linglib/Data/Examples/EngelhardtEtAl2006.lean
+++ b/Linglib/Data/Examples/EngelhardtEtAl2006.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `EngelhardtEtAl2006` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/EngelhardtEtAl2006.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace EngelhardtEtAl2006.Examples`.
+-/
+
+namespace EngelhardtEtAl2006.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "engelhardtetal2006_1"
+    source := ⟨"engelhardt-etal-2006", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple on the towel in the box."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple on the towel in the box."
+    context := "A display with one apple, on a towel; an empty towel; an empty box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("ambiguity", "ambiguous")]
+    comment := "The temporarily ambiguous instruction of Tanenhaus et al. (1995), on the towel a modifier of the apple or the destination: listeners fixate the empty towel on hearing the prepositional phrase in the one-referent display."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2 : LinguisticExample :=
+  { id := "engelhardtetal2006_2"
+    source := ⟨"engelhardt-etal-2006", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple that's on the towel in the box."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple that's on the towel in the box."
+    context := "A display with one apple, on a towel; an empty towel; an empty box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("ambiguity", "unambiguous")]
+    comment := "The unambiguous counterpart of (1)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_3 : LinguisticExample :=
+  { id := "engelhardtetal2006_3"
+    source := ⟨"engelhardt-etal-2006", "Table 1, (3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple on the towel."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple on the towel."
+    context := "The apple is on a towel and is to be moved to the other towel."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("target", "bare"), ("destination", "towel")]
+    comment := "Bare target, matching location: the location is under-described, since the apple is already on a towel. Speakers never produced it and listeners rated it lowest of the four."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4 : LinguisticExample :=
+  { id := "engelhardtetal2006_4"
+    source := ⟨"engelhardt-etal-2006", "Table 1, (4)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple in the box."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple in the box."
+    context := "The apple is on a towel and is to be moved to the box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("target", "bare"), ("destination", "box")]
+    comment := "Bare target, different location: concise in the one-referent display, an under-description of the target in the two-referent display."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5 : LinguisticExample :=
+  { id := "engelhardtetal2006_5"
+    source := ⟨"engelhardt-etal-2006", "Table 1, (5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple on the towel on the other towel."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple on the towel on the other towel."
+    context := "The apple is on a towel and is to be moved to the other towel."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("target", "modified"), ("destination", "otherTowel")]
+    comment := "Modified target, matching location: the target is over-described in the one-referent display; the location carries the pre-nominal modifier other."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_6 : LinguisticExample :=
+  { id := "engelhardtetal2006_6"
+    source := ⟨"engelhardt-etal-2006", "Table 1, (6)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple on the towel in the box."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple on the towel in the box."
+    context := "The apple is on a towel and is to be moved to the box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("target", "modified"), ("destination", "box")]
+    comment := "Modified target, different location: an over-description in the one-referent display, the modification required in the two-referent display. In Experiment 3 listeners fixated the empty towel on hearing on the towel and were delayed in fixating the box."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_7 : LinguisticExample :=
+  { id := "engelhardtetal2006_7"
+    source := ⟨"engelhardt-etal-2006", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put the apple in the box on the towel."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "Put the apple in the box on the towel."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Recorded so that the bare target instruction of the matching condition could be cut from it with the prosody of (6)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1, ex_2, ex_3, ex_4, ex_5, ex_6, ex_7]
+
+end EngelhardtEtAl2006.Examples

--- a/Linglib/Studies/EngelhardtEtAl2006.lean
+++ b/Linglib/Studies/EngelhardtEtAl2006.lean
@@ -1,290 +1,215 @@
+import Linglib.Data.Examples.EngelhardtEtAl2006
 import Linglib.Pragmatics.GriceanMaxims
-import Linglib.Studies.SedivyEtAl1999
+import Mathlib.Data.Fin.VecNotation
 
 /-!
-# [engelhardt-etal-2006]
-[sedivy-etal-1999] [grice-1975] [dale-reiter-1995]
+# Engelhardt et al. (2006): Do Speakers and Listeners Observe the Gricean Maxim of Quantity?
 
-Do Speakers and Listeners Observe the Gricean Maxim of Quantity?
-*Journal of Memory and Language* 54(4), 554–573.
+This file formalizes [engelhardt-etal-2006]'s reading of the Maxim of Quantity of [grice-1975]
+for referring expressions over a visual world. A description under-describes when it does not let
+the addressee identify the intended referent, and over-describes when it carries a modifier that
+identification does not require: with one apple in the display *the apple* suffices and *the
+apple on the towel* over-describes it, while with two apples *the apple* under-describes. The
+instructions of Table 1 cross a prepositional-phrase modifier on the target with a destination
+that matches the target's current location or differs from it, and their status follows. Over
+the one-referent display, (4) is concise, (5) and (6) over-describe the target, and (3)
+under-describes the destination, since the apple already rests on a towel and only *the other
+towel* singles out the empty one; over the two-referent display the modifier of (6) is required.
+The three experiments ask whether speakers and listeners observe the maxim. The ten speakers of
+Experiment 1 modified the target on 98% of two-referent trials and never left a matching
+destination unmodified, but modified the target on 30% of one-referent trials. The twenty-two
+listeners of Experiment 2 rated (3) lowest of the four instructions and the bare target of the
+two-referent display far below the modified one, and once the destination was modified
+throughout rated over-descriptions no worse than concise instructions. In the visual world of
+Experiment 3, listeners hearing (6) over the one-referent display fixated the empty towel at *on
+the towel* and reached the box later than with (4), the pattern of [tanenhaus-etal-1995] and
+[spivey-etal-2002], and hearing (3) or (5) kept fixating the apple. Under-descriptions are
+avoided and penalized; over-descriptions are produced, as in [deutsch-pechmann-1982], tolerated
+in judgment, and still cost the listener. The paper takes the looks to the empty towel to show
+an initial location parse of *on the towel* that the pragmatics of the instruction cannot drive,
+since speakers never produce (3) in that context, and attributes it to Minimal Attachment or to
+the saturation of *put*'s location argument rather than to the Referential Model; the
+over-descriptions it attributes to the speaker's representation of the apple as an apple on a
+towel, which a concise description would have to edit away.
 
-## Core Argument
+## Implementation notes
 
-Three experiments test whether speakers and listeners follow the Gricean
-Maxim of Quantity — the requirement that contributions be as informative
-as required but not more informative than required.
+* A display is five objects, each a kind with the object it rests on; the towel under the apple
+  is an object, so that *the towel* is ambiguous between it and the empty towel and *the other
+  towel* excludes it. The displays are the paper's running example, an apple on a towel, a frog
+  or a second apple, an empty towel and an empty box.
+* Over-description is measured against the bare noun, the paper's one contrast of modified with
+  bare target. Production rates, ratings and fixation proportions stay in the prose above.
+* The examples are `Data.Examples.EngelhardtEtAl2006`.
 
-- **Exp 1** (production, N = 24): Speakers over-describe ~31% of the
-  time, using unnecessary modifiers (color adjectives, relative clauses,
-  prepositional phrases) when a bare NP suffices.
-- **Exp 2** (judgment, N = 72): Listeners rate over-descriptions no
-  worse than concise descriptions, but rate under-descriptions
-  significantly worse.
-- **Exp 3** (eye-tracking, N = 48): Over-descriptions cause implicit
-  processing costs — longer first-pass reading times on the head noun
-  and more regressions back to the unnecessary modifier.
+## References
 
-Conclusion: the language processing system is "only moderately Gricean."
-Speakers routinely violate the "not more informative" half of Quantity,
-listeners are explicitly tolerant of these violations but implicitly
-sensitive to them.
-
-## Connection to Contrastive Inference
-
-The eye-tracking processing cost for unnecessary modifiers is the
-complement of [sedivy-etal-1999]'s contrastive inference benefit
-from necessary modifiers. Both effects confirm that the comprehension
-system is sensitive to modifier presence and its pragmatic licensing.
-
-## Verified Data
-
-Eye-tracking F-statistics and reading times verified against running
-text (§4). Judgment t-test significance levels verified against running
-text (§3). Production proportions and judgment mean ratings read from
-Tables 1–2 (not restated in running text).
+* [engelhardt-etal-2006]
+* [grice-1975]
+* [tanenhaus-etal-1995]
+* [spivey-etal-2002]
+* [deutsch-pechmann-1982]
 -/
 
 namespace EngelhardtEtAl2006
 
--- ============================================================================
--- § Experiment 1: Production (§2, N = 24)
--- ============================================================================
+open Pragmatics.GriceanMaxims Data.Examples EngelhardtEtAl2006.Examples
 
-/-- Over-description and modification rates from Exp 1 (Table 1).
-    In 1-referent displays, speakers used modified NPs 31% of the time
-    when a bare NP would have been sufficient. -/
-structure ProductionRate where
-  /-- Proportion of modified NP productions -/
-  modified : ℚ
-  /-- Standard error -/
-  se : ℚ
-  deriving Repr
+/-- The kinds of object of the running example (Table 2): the apple to be moved, the frog, and
+the two kinds of destination. -/
+inductive Kind
+  | apple
+  | frog
+  | towel
+  | box
+  deriving DecidableEq, Repr
 
-/-- 1-referent target: 31% over-description (Table 1). -/
-def exp1_target_1ref : ProductionRate := { modified := 0.31, se := 0.05 }
+/-- An object of a display: its kind and the object it rests on or in, if any. -/
+structure Object where
+  kind : Kind
+  support : Option (Fin 5) := none
+  deriving DecidableEq, Repr
 
-/-- 2-referent target: 90% modification — necessary (Table 1). -/
-def exp1_target_2ref : ProductionRate := { modified := 0.90, se := 0.04 }
+/-- A display of five objects, the target first and the object it rests on second. -/
+abbrev Display := Fin 5 → Object
 
-/-- No-competitor goal: 19% over-description (Table 1). -/
-def exp1_goal_noCompetitor : ProductionRate := { modified := 0.19, se := 0.05 }
+/-- The one-referent display, Fig. 2A: an apple on a towel, a frog, an empty towel, an empty
+box. -/
+def oneReferent : Display := ![⟨.apple, some 1⟩, ⟨.towel, none⟩, ⟨.frog, none⟩, ⟨.towel, none⟩,
+  ⟨.box, none⟩]
 
-/-- Competitor goal: 92% modification — necessary (Table 1). -/
-def exp1_goal_competitor : ProductionRate := { modified := 0.92, se := 0.03 }
+/-- The two-referent display of Experiment 1, Fig. 1B with one apple by itself: an apple on a
+towel, a second apple, an empty towel, an empty box. -/
+def twoReferent : Display := ![⟨.apple, some 1⟩, ⟨.towel, none⟩, ⟨.apple, none⟩, ⟨.towel, none⟩,
+  ⟨.box, none⟩]
 
--- ============================================================================
--- § Experiment 2: Judgment (§3, N = 72)
--- ============================================================================
+/-! ### Descriptions and the maxim -/
 
-/-- Judgment result: between-subjects t-test comparing two instruction
-    types. Rating scale 1–5 (1 = "very bad", 5 = "very good").
-    The three participant groups each saw a different instruction version,
-    so comparisons use independent-sample t-tests. -/
-structure JudgmentResult where
-  /-- Mean rating for concise instruction -/
-  conciseRating : ℚ
-  /-- Mean rating for alternative instruction (over-described or modified) -/
-  altRating : ℚ
-  /-- Degrees of freedom -/
-  df : Nat
-  /-- t-statistic; `none` when paper reports "< 1" -/
-  tStat : Option ℚ
-  /-- Significant at p < .05 -/
-  significant : Bool
-  deriving Repr
+/-- A referring expression of the instructions: a bare noun, a noun with a prepositional-phrase
+modifier naming what the referent rests on, or *the other* noun, which excludes the object the
+target rests on. -/
+inductive Description
+  | bare (k : Kind)
+  | on (k loc : Kind)
+  | other (k : Kind)
+  deriving DecidableEq, Repr
 
-/-- 1-referent target: over-description NOT rated worse than concise.
-    Concise 3.93 vs over-described 3.89, t₁(46) < 1 (§3). -/
-def exp2_target_1ref : JudgmentResult :=
-  { conciseRating := 3.93, altRating := 3.89, df := 46
-  , tStat := none, significant := false }
+/-- The noun of a description. -/
+def Description.kind : Description → Kind
+  | .bare k | .on k _ | .other k => k
 
-/-- 2-referent target: under-description rated significantly worse.
-    Concise (= under-described) 3.31 vs modified 3.88,
-    t₁(46) = 3.69, p < .001 (§3). -/
-def exp2_target_2ref : JudgmentResult :=
-  { conciseRating := 3.31, altRating := 3.88, df := 46
-  , tStat := some 3.69, significant := true }
+/-- The bare noun a description is measured against. -/
+def Description.bareOf (d : Description) : Description := .bare d.kind
 
-/-- No-competitor goal: over-description NOT rated worse.
-    Concise 3.56 vs over-described 3.59, t₁(46) < 1 (§3). -/
-def exp2_goal_noCompetitor : JudgmentResult :=
-  { conciseRating := 3.56, altRating := 3.59, df := 46
-  , tStat := none, significant := false }
+/-- The object `i` satisfies the description, *other* read relative to the target `t`. -/
+def Refers (D : Display) (t i : Fin 5) : Description → Prop
+  | .bare k => (D i).kind = k
+  | .on k loc => (D i).kind = k ∧ ∃ j, (D i).support = some j ∧ (D j).kind = loc
+  | .other k => (D i).kind = k ∧ (D t).support ≠ some i
 
-/-- Competitor goal: under-description rated significantly worse.
-    Concise (= under-described) 3.36 vs modified 3.69,
-    t₁(46) = 2.01, p < .05 (§3). -/
-def exp2_goal_competitor : JudgmentResult :=
-  { conciseRating := 3.36, altRating := 3.69, df := 46
-  , tStat := some 2.01, significant := true }
+instance (D : Display) (t i : Fin 5) (d : Description) : Decidable (Refers D t i d) := by
+  cases d <;> unfold Refers <;> infer_instance
 
--- ============================================================================
--- § Experiment 3: Eye-Tracking (§4, N = 48)
--- ============================================================================
+/-- The description lets the addressee identify the intended referent `r`: it holds of `r` and
+of nothing else in the display. -/
+def Identifies (D : Display) (t r : Fin 5) (d : Description) : Prop :=
+  Refers D t r d ∧ ∀ i, Refers D t i d → i = r
 
-/-- Eye-tracking ANOVA result with by-subjects (F₁) and by-items (F₂)
-    statistics. -/
-structure AnovaResult where
-  F1 : ℚ
-  df1 : Nat
-  F2 : ℚ
-  df2 : Nat
-  significant : Bool
-  deriving Repr
+instance (D : Display) (t r : Fin 5) (d : Description) : Decidable (Identifies D t r d) := by
+  unfold Identifies; infer_instance
 
-/-- Eye-tracking reading measure with mean values and ANOVA. -/
-structure ReadingMeasure where
-  /-- Mean for modified (over-described) condition -/
-  modified : ℚ
-  /-- Mean for bare (concise) condition -/
-  bare : ℚ
-  /-- ANOVA result -/
-  anova : AnovaResult
-  deriving Repr
+/-- The Quantity violation of a description of `r`, if any: an under-description does not
+identify `r`, and an over-description identifies it with a modifier its bare noun does not
+need. -/
+def violation (D : Display) (t r : Fin 5) (d : Description) : Option QuantityViolation :=
+  if ¬ Identifies D t r d then some .underInformative
+  else if d ≠ d.bareOf ∧ Identifies D t r d.bareOf then some .overInformative
+  else none
 
-/-- Head noun first-pass reading time: modified 531ms vs bare 489ms.
-    Listeners spend significantly longer reading the head noun after
-    an unnecessary modifier. F₁(1,47) = 9.31, p < .01;
-    F₂(1,23) = 7.32, p < .05 (§4, non-matching condition). -/
-def exp3_headNoun_firstPass : ReadingMeasure :=
-  { modified := 531, bare := 489
-  , anova := { F1 := 9.31, df1 := 47, F2 := 7.32, df2 := 23
-             , significant := true } }
+/-- A modified description that identifies its referent over-describes it exactly when the bare
+noun already identifies it. -/
+theorem violation_eq_over_iff {D : Display} {t r : Fin 5} {d : Description}
+    (hd : Identifies D t r d) (hb : d ≠ d.bareOf) :
+    violation D t r d = some .overInformative ↔ Identifies D t r d.bareOf := by
+  simp [violation, hd, hb]
 
-/-- Post-noun regressions back to adjective: modified 14.6% vs bare 7.3%.
-    Listeners regress to re-read the unnecessary modifier significantly
-    more often. F₁(1,47) = 17.74, p < .001; F₂(1,23) = 14.15, p < .001
-    (§4, non-matching condition). -/
-def exp3_postNoun_regressions : ReadingMeasure :=
-  { modified := 14.6, bare := 7.3
-  , anova := { F1 := 17.74, df1 := 47, F2 := 14.15, df2 := 23
-             , significant := true } }
+/-- With one apple, *the apple* identifies it and *the apple on the towel* over-describes it. -/
+theorem oneReferent_target :
+    violation oneReferent 0 0 (.bare .apple) = none ∧
+      violation oneReferent 0 0 (.on .apple .towel) = some .overInformative := by
+  decide
 
-/-- Head noun first-fixation duration: marginal by subjects, significant
-    by items. F₁(1,47) = 3.19, p < .08; F₂(1,23) = 5.12, p < .05
-    (§4, non-matching condition). -/
-def exp3_headNoun_firstFixation : AnovaResult :=
-  { F1 := 3.19, df1 := 47, F2 := 5.12, df2 := 23, significant := false }
+/-- With two apples, *the apple* under-describes and the modifier is required. -/
+theorem twoReferent_target :
+    violation twoReferent 0 0 (.bare .apple) = some .underInformative ∧
+      violation twoReferent 0 0 (.on .apple .towel) = none := by
+  decide
 
--- ============================================================================
--- § Bridge: Q1/Q2 Asymmetry
--- ============================================================================
+/-- The destinations: *the towel* under-describes the empty towel in either display, as the
+apple already rests on a towel, *the other towel* identifies it, and *the box* is identified
+bare. -/
+theorem destinations :
+    ∀ D ∈ [oneReferent, twoReferent],
+      violation D 0 3 (.bare .towel) = some .underInformative ∧
+        violation D 0 3 (.other .towel) = none ∧ violation D 0 4 (.bare .box) = none := by
+  decide
 
-open Pragmatics.GriceanMaxims
+/-! ### The instructions of Table 1 -/
 
-/-- Q1 and Q2 violations map to under- and over-description. -/
-theorem violation_mapping :
-    QuantityViolation.underInformative.submaxim = .Q1 ∧
-    QuantityViolation.overInformative.submaxim = .Q2 :=
-  ⟨rfl, rfl⟩
+/-- An instruction, *Put the apple … in/on the …*: the target description and the destination
+description. -/
+structure Instruction where
+  target : Description
+  destination : Description
+  deriving DecidableEq, Repr
 
-/-- The two sub-maxims of Quantity behave asymmetrically in explicit
-    judgments: Q1 violations (under-description) are penalized, but
-    Q2 violations (over-description) are not. -/
-theorem q1_q2_asymmetry :
-    -- Q2 violations (over-description): NOT penalized
-    ¬exp2_target_1ref.significant ∧
-    ¬exp2_goal_noCompetitor.significant ∧
-    -- Q1 violations (under-description): IS penalized
-    exp2_target_2ref.significant ∧
-    exp2_goal_competitor.significant :=
-  ⟨by decide, by decide, rfl, rfl⟩
+/-- The target descriptions as named in the rows. -/
+def targetTable : List (String × Description) :=
+  [("bare", .bare .apple), ("modified", .on .apple .towel)]
 
-/-- Despite explicit tolerance of Q2 violations, over-descriptions
-    incur implicit processing costs: both first-pass reading times
-    and regression rates are significantly elevated. -/
-theorem q2_implicit_processing_cost :
-    exp3_headNoun_firstPass.anova.significant ∧
-    exp3_postNoun_regressions.anova.significant :=
-  ⟨rfl, rfl⟩
+/-- The destination descriptions as named in the rows. -/
+def destinationTable : List (String × Description) :=
+  [("towel", .bare .towel), ("otherTowel", .other .towel), ("box", .bare .box)]
 
-/-- Over-descriptions slow head-noun reading: 531ms > 489ms. -/
-theorem over_description_slows_reading :
-    exp3_headNoun_firstPass.modified > exp3_headNoun_firstPass.bare := by
-  norm_num [exp3_headNoun_firstPass]
+/-- An instruction from a row of Table 1. -/
+def Instruction.ofExample (ex : LinguisticExample) : Option Instruction := do
+  pure ⟨← ex.parse? "target" targetTable, ← ex.parse? "destination" destinationTable⟩
 
-/-- Over-descriptions double regression rate: 14.6% vs 7.3%. -/
-theorem over_description_doubles_regressions :
-    exp3_postNoun_regressions.modified > exp3_postNoun_regressions.bare := by
-  norm_num [exp3_postNoun_regressions]
+theorem ofExample_isSome :
+    ∀ ex ∈ Examples.all, (ex.feature? "target").isSome → (Instruction.ofExample ex).isSome := by
+  decide
 
-/-- Speakers are sensitive to discriminability: necessary modification
-    is near-ceiling (~90%) while unnecessary modification is ~31%. -/
-theorem speakers_distinguish_necessity :
-    exp1_target_2ref.modified > exp1_target_1ref.modified ∧
-    exp1_goal_competitor.modified > exp1_goal_noCompetitor.modified := by
-  constructor <;> norm_num [exp1_target_2ref, exp1_target_1ref, exp1_goal_competitor, exp1_goal_noCompetitor]
+/-- The four instructions (3)–(6). -/
+def instructions : List Instruction := Examples.all.filterMap Instruction.ofExample
 
--- ============================================================================
--- § Bridge: Connection to Contrastive Inference
--- ============================================================================
+/-- The destination matches the target's current location, a towel. -/
+def Instruction.Matching (ins : Instruction) : Prop := ins.destination.kind = .towel
 
-/-- Both this study and [sedivy-etal-1999] show that adjective
-    modifiers affect eye-movement patterns, but in complementary ways:
+/-- The intended destination in either display: the empty towel or the box. -/
+def Instruction.goal (ins : Instruction) : Fin 5 := if ins.destination.kind = .towel then 3 else 4
 
-    - [sedivy-etal-1999]: *necessary* modifiers trigger contrastive
-      inferences, speeding target identification (competitor fixation).
-    - This study: *unnecessary* modifiers impose a processing cost,
-      slowing head-noun reading and increasing regressions.
+/-- The Quantity violations of an instruction over a display, of its target and of its
+destination. -/
+def Instruction.violations (D : Display) (ins : Instruction) :
+    Option QuantityViolation × Option QuantityViolation :=
+  (violation D 0 0 ins.target, violation D 0 ins.goal ins.destination)
 
-    Both effects are significant, confirming that the comprehension system
-    is sensitive to modifier presence and its pragmatic licensing. The
-    Sedivy side of this complementarity is encoded in
-    `SedivyEtAl1999.SatisfiesSedivyPattern`; here we record only the
-    Engelhardt-side significance claims. -/
-theorem complementary_eye_tracking :
-    -- This study: unnecessary modifiers cause processing cost
-    exp3_headNoun_firstPass.anova.significant ∧
-    exp3_postNoun_regressions.anova.significant :=
-  ⟨rfl, rfl⟩
+/-- Over the one-referent display, the modified target of (5) and (6) is an over-description and
+the bare destination of (3) an under-description; (4) is concise. -/
+theorem instructions_oneReferent :
+    ∀ ins ∈ instructions,
+      ins.violations oneReferent =
+        (if ins.target = .bare .apple then none else some .overInformative,
+          if ins.destination = .bare .towel then some .underInformative else none) := by
+  decide
 
--- ============================================================================
--- § Bridge: Moderately Gricean
--- ============================================================================
-
-/-- The paper's main conclusion: the language processing system is "only
-    moderately Gricean." Evidence:
-
-    1. Speakers violate Q2 31% of the time (over-description)
-    2. Listeners don't explicitly penalize Q2 violations (tolerant)
-    3. But listeners implicitly detect Q2 violations (processing cost)
-    4. Listeners DO penalize Q1 violations (under-description)
-
-    Q1 (informativeness) is enforced; Q2 (non-redundancy) operates
-    implicitly rather than explicitly. -/
-theorem moderately_gricean :
-    -- Production: speakers violate Q2 (over-describe)
-    exp1_target_1ref.modified > 0.2 ∧
-    -- Judgment: Q2 violations tolerated, Q1 violations penalized
-    ¬exp2_target_1ref.significant ∧
-    exp2_target_2ref.significant ∧
-    -- Eye-tracking: Q2 violations implicitly detected
-    exp3_headNoun_firstPass.anova.significant ∧
-    exp3_postNoun_regressions.anova.significant := by
-  refine ⟨?_, by decide, rfl, rfl, rfl⟩; norm_num [exp1_target_1ref]
-
--- ============================================================================
--- § Bridge: Support for the Incremental Algorithm (Dale & Reiter 1995)
--- ============================================================================
-
-/-- [dale-reiter-1995]'s Incremental Algorithm interprets Q2 without
-    brevity: speakers use a fixed preference order and include any
-    discriminating attribute without optimizing for length.
-    This study provides direct empirical support:
-
-    1. Speakers over-describe 31% of the time (Q2 violated in production)
-    2. Over-descriptions are not penalized in judgment (Q2 tolerated)
-    3. Under-descriptions ARE penalized (Q1 enforced)
-
-    Q1 is enforced, Q2 is not, as the Incremental Algorithm has it. -/
-theorem supports_incrementalAlgorithm :
-    -- Production: speakers over-describe
-    exp1_target_1ref.modified > 0.2 ∧
-    -- Judgment: over-description not penalized (Q2 not enforced)
-    ¬exp2_target_1ref.significant ∧
-    -- Judgment: under-description penalized (Q1 enforced)
-    exp2_target_2ref.significant := by
-  refine ⟨?_, by decide, rfl⟩; norm_num [exp1_target_1ref]
+/-- Over the two-referent display, the bare target of (3) and (4) is an under-description and
+the modifier of (5) and (6) is required. -/
+theorem instructions_twoReferent :
+    ∀ ins ∈ instructions,
+      ins.violations twoReferent =
+        (if ins.target = .bare .apple then some .underInformative else none,
+          if ins.destination = .bare .towel then some .underInformative else none) := by
+  decide
 
 end EngelhardtEtAl2006

--- a/Linglib/Studies/GilesEtAl2026.lean
+++ b/Linglib/Studies/GilesEtAl2026.lean
@@ -263,16 +263,19 @@ theorem frequency_does_not_explain :
 -- §11. Bridge: [engelhardt-etal-2006] Over-Description Rates
 -- ============================================================================
 
-/-- Both this study and [engelhardt-etal-2006] demonstrate that
-    speakers routinely over-describe. The search efficiency view
-    reinterprets these violations of Gricean Q2 as communicatively
-    efficient: the "extra" information facilitates listener search. -/
+/-- Both this study and [engelhardt-etal-2006] find that speakers
+    routinely over-describe: a third of Engelhardt et al.'s one-referent
+    instructions carried the modifier that makes *the apple on the towel*
+    an over-description. The search efficiency view reinterprets these
+    violations of Gricean Q2 as communicatively efficient: the "extra"
+    information facilitates listener search. -/
 theorem overinformativeness_is_efficient :
-    -- Engelhardt: speakers over-describe 31% of the time
-    EngelhardtEtAl2006.exp1_target_1ref.modified > 0.2 ∧
+    -- Engelhardt: the modified target of the one-referent display over-describes
+    EngelhardtEtAl2006.violation EngelhardtEtAl2006.oneReferent 0 0 (.on .apple .towel) =
+      some .overInformative ∧
     -- This study: over-description tracks search efficiency
     exp1_sHighRLow.IsSignificant :=
-  ⟨by norm_num [EngelhardtEtAl2006.exp1_target_1ref],
+  ⟨EngelhardtEtAl2006.oneReferent_target.2,
    by norm_num [BayesianCoefficient.IsSignificant, exp1_sHighRLow]⟩
 
 -- ============================================================================

--- a/references.bib
+++ b/references.bib
@@ -1249,7 +1249,7 @@
   doi       = {10.1016/0364-0213(95)90018-7},
   subfield  = {pragmatics},
   role      = {formalized},
-  sources   = {}
+  sources   = {Studies/DaleReiter1995.lean;Studies/QingFranke2015.lean;Studies/WesterbeekKoolenMaes2015.lean}
 }
 @article{dambrosio-hedden-2024,
   author    = {D'Ambrosio, Justin and Hedden, Brian},
@@ -1274,6 +1274,48 @@
   role      = {referenced},
   sources   = {Semantics/Focus/ExtractionClash.lean, Studies/LuPanDegen2025.lean}
 }
+% REF: Tanenhaus, M. K., Spivey-Knowlton, M. J., Eberhard, K. M., & Sedivy, J. C. (1995). Integration of visual and linguistic information in spoken language comprehension. Science 268(5217), 1632-1634.
+@article{tanenhaus-etal-1995,
+  author    = {Tanenhaus, Michael K. and Spivey-Knowlton, Michael J. and Eberhard, Kathleen M. and Sedivy, Julie C.},
+  year      = {1995},
+  title     = {Integration of Visual and Linguistic Information in Spoken Language Comprehension},
+  journal   = {Science},
+  volume    = {268},
+  number    = {5217},
+  pages     = {1632--1634},
+  doi       = {10.1126/science.7777863},
+  subfield  = {processing},
+  role      = {cited},
+  sources   = {Studies/EngelhardtEtAl2006.lean}
+}
+% REF: Spivey, M. J., Tanenhaus, M. K., Eberhard, K. M., & Sedivy, J. C. (2002). Eye movements and spoken language comprehension: Effects of visual context on syntactic ambiguity resolution. Cognitive Psychology 45(4), 447-481.
+@article{spivey-etal-2002,
+  author    = {Spivey, Michael J. and Tanenhaus, Michael K. and Eberhard, Kathleen M. and Sedivy, Julie C.},
+  year      = {2002},
+  title     = {Eye Movements and Spoken Language Comprehension: Effects of Visual Context on Syntactic Ambiguity Resolution},
+  journal   = {Cognitive Psychology},
+  volume    = {45},
+  number    = {4},
+  pages     = {447--481},
+  doi       = {10.1016/S0010-0285(02)00503-0},
+  subfield  = {processing},
+  role      = {cited},
+  sources   = {Studies/EngelhardtEtAl2006.lean}
+}
+% REF: Deutsch, W., & Pechmann, T. (1982). Social interaction and the development of definite descriptions. Cognition 11(2), 159-184.
+@article{deutsch-pechmann-1982,
+  author    = {Deutsch, Werner and Pechmann, Thomas},
+  year      = {1982},
+  title     = {Social Interaction and the Development of Definite Descriptions},
+  journal   = {Cognition},
+  volume    = {11},
+  number    = {2},
+  pages     = {159--184},
+  doi       = {10.1016/0010-0277(82)90024-5},
+  subfield  = {pragmatics},
+  role      = {cited},
+  sources   = {Studies/EngelhardtEtAl2006.lean}
+}
 @article{engelhardt-etal-2006,
   author    = {Engelhardt, Paul E. and Bailey, Karl G. D. and Ferreira, Fernanda},
   year      = {2006},
@@ -1286,7 +1328,7 @@
   subfield  = {pragmatics},
   validated = {true},
   role      = {formalized},
-  sources   = {}
+  sources   = {Data/Examples/EngelhardtEtAl2006.json;Pragmatics/GriceanMaxims.lean;Studies/EngelhardtEtAl2006.lean;Studies/GilesEtAl2026.lean}
 }
 @article{egre-etal-2023,
   author    = {{\'E}gr{\'e}, Paul and Spector, Benjamin and Mortier, Ad{\`e}le and Verheyen, Steven},
@@ -2437,7 +2479,8 @@
   pages     = {109--147},
   doi       = {10.1016/S0010-0277(99)00025-6},
   subfield  = {pragmatics/rsa},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Semantics/Definiteness/Basic.lean;Studies/PaapeVasishth2026.lean;Studies/RonderosEtAl2024.lean;Studies/SedivyEtAl1999.lean}
 }
 @article{sedivy-2007,
   author    = {Sedivy, Julie C.},
@@ -9208,7 +9251,7 @@
   subfield  = {semantics/modality},
   role      = {cited},
   validated = {true},
-  sources   = {}
+  sources   = {Pragmatics/GriceanMaxims.lean;Pragmatics/Implicature/Diagnostics.lean;Studies/AhnKocabDavidson2026.lean;Studies/DaleReiter1995.lean;Studies/EngelhardtEtAl2006.lean;Studies/QingFranke2015.lean}
 }% REF: Grove, J. (2022). Presupposition projection as a scope phenomenon.
 @article{grove-2022,
   author    = {Grove, Julian},


### PR DESCRIPTION
Deep cleanse of EngelhardtEtAl2006 against the JML paper (Ferreira-lab PDF): the old file's tables were not the paper's — Experiment 1 had ten speakers in a one/two-referent × matching/different design (no "goal competitor" cell), Experiment 2 rated the four instructions of Table 1 on a five-point scale (no t-tests with the typed values), Experiment 3 was a visual-world study (no first-pass reading times or regressions), and the paper cites neither Dale & Reiter nor a Sedivy complementarity. The recut formalizes what the paper defines and then reports its results in prose.

- displays as five objects with what each rests on, descriptions bare / with a PP modifier / *the other N*, `Identifies` and `violation : Option QuantityViolation` (under- vs over-description, the paper's §1 definitions); `violation_eq_over_iff` (over-description iff the bare noun already identifies), the one- and two-referent verdicts for the target, and *the towel* vs *the other towel* vs *the box* for the destination
- Table 1's instructions (3)–(6) as `Data/Examples/EngelhardtEtAl2006.json` rows (with (1), (2), (7)), classified over both displays by `instructions_oneReferent` / `instructions_twoReferent`; production rates, ratings and fixation patterns stay in the docstring
- GilesEtAl2026's bridge now cites the over-description verdict instead of the deleted `exp1_target_1ref`; bib gains tanenhaus-etal-1995, spivey-etal-2002, deutsch-pechmann-1982 (Crossref-verified)
