### PR TITLE
refactor(Studies/Filip2012): three verb classes over the substrate

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3056,3 +3056,4 @@ import Linglib.Data.Examples.FarkasRoelofsen2017
 import Linglib.Data.Examples.Faust2026
 import Linglib.Data.Examples.FaustLampitelli2026
 import Linglib.Data.Examples.Ferreira2023
+import Linglib.Data.Examples.Filip2012

--- a/Linglib/Data/Examples/Filip2012.json
+++ b/Linglib/Data/Examples/Filip2012.json
@@ -1,0 +1,467 @@
+[
+  {
+    "id": "filip2012_1a_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(1a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John recovered in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John recovered in an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "telic"
+      ],
+      [
+        "object",
+        "none"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_1a_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(1a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John recovered for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John recovered for an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "telic"
+      ],
+      [
+        "object",
+        "none"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": "Acceptable only on a shifted reading, the chapter's (*)."
+  },
+  {
+    "id": "filip2012_1b_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(1b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John swam in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John swam in an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "none"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": "Acceptable only on a shifted reading, the chapter's (*)."
+  },
+  {
+    "id": "filip2012_1b_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(1b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John swam for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John swam for an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "none"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_25a_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(25a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John ate two apples in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John ate two apples in an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "incremental"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_25a_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(25a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John ate two apples for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John ate two apples for an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "incremental"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_25b_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(25b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John ate apples in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John ate apples in an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "incremental"
+      ],
+      [
+        "object",
+        "cumulative"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": "Acceptable only on a shifted reading, the chapter's (*)."
+  },
+  {
+    "id": "filip2012_25b_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(25b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John ate apples for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John ate apples for an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "incremental"
+      ],
+      [
+        "object",
+        "cumulative"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_26a_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(26a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John watched two apples on the display in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John watched two apples on the display in an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": "Acceptable only on a shifted reading, the chapter's (*)."
+  },
+  {
+    "id": "filip2012_26a_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(26a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John watched two apples on the display for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John watched two apples on the display for an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_26b_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(26b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John watched apples on the display in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John watched apples on the display in an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "cumulative"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": "Acceptable only on a shifted reading, the chapter's (*)."
+  },
+  {
+    "id": "filip2012_26b_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(26b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John watched apples on the display for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John watched apples on the display for an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "atelic"
+      ],
+      [
+        "object",
+        "cumulative"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_31a_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(31a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John proved the theorem for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "John proved the theorem for an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "incremental"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": "Attributed to Zucchi (1998)."
+  },
+  {
+    "id": "filip2012_37a_for",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(37a)"
+    },
+    "language": "stan1293",
+    "primaryText": "The climbers reached the summit for an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The climbers reached the summit for an hour.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "telic"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "for"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "filip2012_37a_in",
+    "source": {
+      "bibkey": "filip-2012",
+      "paperLabel": "(37a)"
+    },
+    "language": "stan1293",
+    "primaryText": "The climbers reached the summit in an hour.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "The climbers reached the summit in an hour.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbClass",
+        "telic"
+      ],
+      [
+        "object",
+        "quantized"
+      ],
+      [
+        "adverbial",
+        "in"
+      ]
+    ],
+    "comment": ""
+  }
+]

--- a/Linglib/Data/Examples/Filip2012.lean
+++ b/Linglib/Data/Examples/Filip2012.lean
@@ -1,0 +1,288 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Filip2012` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Filip2012.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Filip2012.Examples`.
+-/
+
+namespace Filip2012.Examples
+
+open Data.Examples
+
+def ex_1a_in : LinguisticExample :=
+  { id := "filip2012_1a_in"
+    source := ⟨"filip-2012", "(1a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John recovered in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John recovered in an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "telic"), ("object", "none"), ("adverbial", "in")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_1a_for : LinguisticExample :=
+  { id := "filip2012_1a_for"
+    source := ⟨"filip-2012", "(1a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John recovered for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John recovered for an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "telic"), ("object", "none"), ("adverbial", "for")]
+    comment := "Acceptable only on a shifted reading, the chapter's (*)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_1b_in : LinguisticExample :=
+  { id := "filip2012_1b_in"
+    source := ⟨"filip-2012", "(1b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John swam in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John swam in an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "none"), ("adverbial", "in")]
+    comment := "Acceptable only on a shifted reading, the chapter's (*)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_1b_for : LinguisticExample :=
+  { id := "filip2012_1b_for"
+    source := ⟨"filip-2012", "(1b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John swam for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John swam for an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "none"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25a_in : LinguisticExample :=
+  { id := "filip2012_25a_in"
+    source := ⟨"filip-2012", "(25a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John ate two apples in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John ate two apples in an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "incremental"), ("object", "quantized"), ("adverbial", "in")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25a_for : LinguisticExample :=
+  { id := "filip2012_25a_for"
+    source := ⟨"filip-2012", "(25a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John ate two apples for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John ate two apples for an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "incremental"), ("object", "quantized"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25b_in : LinguisticExample :=
+  { id := "filip2012_25b_in"
+    source := ⟨"filip-2012", "(25b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John ate apples in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John ate apples in an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "incremental"), ("object", "cumulative"), ("adverbial", "in")]
+    comment := "Acceptable only on a shifted reading, the chapter's (*)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25b_for : LinguisticExample :=
+  { id := "filip2012_25b_for"
+    source := ⟨"filip-2012", "(25b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John ate apples for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John ate apples for an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "incremental"), ("object", "cumulative"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26a_in : LinguisticExample :=
+  { id := "filip2012_26a_in"
+    source := ⟨"filip-2012", "(26a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John watched two apples on the display in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John watched two apples on the display in an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "quantized"), ("adverbial", "in")]
+    comment := "Acceptable only on a shifted reading, the chapter's (*)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26a_for : LinguisticExample :=
+  { id := "filip2012_26a_for"
+    source := ⟨"filip-2012", "(26a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John watched two apples on the display for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John watched two apples on the display for an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "quantized"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26b_in : LinguisticExample :=
+  { id := "filip2012_26b_in"
+    source := ⟨"filip-2012", "(26b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John watched apples on the display in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John watched apples on the display in an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "cumulative"), ("adverbial", "in")]
+    comment := "Acceptable only on a shifted reading, the chapter's (*)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26b_for : LinguisticExample :=
+  { id := "filip2012_26b_for"
+    source := ⟨"filip-2012", "(26b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John watched apples on the display for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John watched apples on the display for an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "atelic"), ("object", "cumulative"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_31a_for : LinguisticExample :=
+  { id := "filip2012_31a_for"
+    source := ⟨"filip-2012", "(31a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John proved the theorem for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "John proved the theorem for an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "incremental"), ("object", "quantized"), ("adverbial", "for")]
+    comment := "Attributed to Zucchi (1998)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_37a_for : LinguisticExample :=
+  { id := "filip2012_37a_for"
+    source := ⟨"filip-2012", "(37a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The climbers reached the summit for an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The climbers reached the summit for an hour."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "telic"), ("object", "quantized"), ("adverbial", "for")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_37a_in : LinguisticExample :=
+  { id := "filip2012_37a_in"
+    source := ⟨"filip-2012", "(37a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The climbers reached the summit in an hour."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "The climbers reached the summit in an hour."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbClass", "telic"), ("object", "quantized"), ("adverbial", "in")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1a_in, ex_1a_for, ex_1b_in, ex_1b_for, ex_25a_in, ex_25a_for, ex_25b_in, ex_25b_for, ex_26a_in, ex_26a_for, ex_26b_in, ex_26b_for, ex_31a_for, ex_37a_for, ex_37a_in]
+
+end Filip2012.Examples

--- a/Linglib/Studies/Filip2012.lean
+++ b/Linglib/Studies/Filip2012.lean
@@ -1,151 +1,172 @@
-import Linglib.Semantics.Mereology
-import Linglib.Semantics.Events.Basic
-import Linglib.Semantics.ArgumentStructure.Thematic.Mereology
-import Linglib.Semantics.Aspect.Incremental
 import Linglib.Semantics.Aspect.Cumulativity
+import Linglib.Data.Examples.Filip2012
 
 /-!
-# [filip-2012]: "Lexical Aspect"
+# Filip (2012): Lexical aspect
 
-Filip's handbook chapter (Binnick ed., OUP) identifies a **three-way
-classification** of verb predicates beyond K89/K98's binary CUM/QUA:
+This file formalizes the mereological core of [filip-2012]'s survey of lexical aspect. The
+telic/atelic distinction is diagnosed by temporal adverbials — *in an hour* with telic and
+*for an hour* with atelic predicates (1) — and, following [krifka-1998], telic predicates are
+taken as quantized (23) and atelic ones as cumulative (24), the substrate's `QUA` and `CUM`.
+Aspectual composition (25)–(27) is [krifka-1989]'s: the predicate an incremental verb forms
+with its object is quantized or cumulative as the object is, the substrate's
+`qua_propagation` and `cum_propagation` for `IsSincVerb`, while a verb without the
+incremental mapping, like *watch*, is atelic whatever its object (26). Hence the three
+classes of (28): telic verbs, whose eventualities have no proper parts in the relation
+(`Quantized`, `telic_of_quantized`); atelic verbs, whose relation persists to the parts of an
+eventuality, the subinterval property (19) (`Persistent`, `not_telic_of_persistent`); and
+incremental verbs, lexically unmarked for telicity because their non-degeneracy provides both
+a quantized and a cumulative object (`incremental_underspecified`). Incrementality and
+telicity are independent (29): a quantized verb is not strictly incremental
+(`not_sinc_of_quantized`), and an incremental verb with a cumulative object is atelic. The
+diagnostic data (1), (25), (26), (31), (37) are rows of `Data/Examples/Filip2012.json`, and
+`rows_test` checks the adverbial judgments against the telicity the classification assigns.
 
-1. **Telic / quantized** (QUA): *recover*, *arrive*
-2. **Atelic / cumulative** (CUM): *run*, *push*
-3. **Neither** (¬CUM ∧ ¬QUA): *build*, *eat*, *write* — verbs whose
-   telicity is underspecified at the verb level and determined
-   compositionally by the object NP
+## Implementation notes
 
-The third class's compositional behavior:
-* QUA object → QUA VP: "eat two apples" (telic)
-* CUM object → CUM VP: "eat apples" (atelic)
-* ¬CUM ∧ ¬QUA object → ¬CUM ∧ ¬QUA VP: "drink margarita" (Moon's case)
-
-## Main definitions
-
-* `three_way_exhaustive` — Filip's distinctive observation: every
-  predicate is CUM, QUA, or ¬CUM ∧ ¬QUA
-* `not_cum_vp_of_witnesses` — ¬CUM lifts to VP under `[IsSincVerb θ]`
-* `middle_ground_stable` — ¬CUM ∧ ¬QUA lifts to VP under `[IsSincVerb θ]`
-  (the propagation-gap stability result; canonical typeclass-form
-  public API consumed by `Studies/Moon2026.lean`)
-
-## TODO
-
-* The propagation-gap substrate (§ 2 below) was inlined from former
-  `Semantics/Events/PropagationGap.lean` in 0.231.55 as
-  single-consumer substrate. If a second paper-anchored Studies file
-  consumes `middle_ground_stable`, lift back to substrate per CLAUDE.md
-  Theories/ ≥ 2 consumers rule.
+* Telicity is identified with quantization "for the purposes of this summary" (§7), so the
+  telic/atelic contrast is the substrate's `QUA`/`CUM` and the atelic verbs' persistence is
+  stated with `≤` on eventualities.
+* The verb classes of the rows are the chapter's: *recover* and *reach* telic, *swim* and
+  *watch* atelic, *eat* and *prove* incremental; `Row.Telic` states the classification's
+  verdict, whose semantic content is the theorems above.
+* The chapter's surveys of Vendler's and Dowty's classifications (§§3–6) and of degree-based
+  approaches (§8) summarize other authors' analyses and are not formalized here.
 
 ## References
 
-* [filip-2012] (primary)
-* [krifka-1998] §3.3 (CUM/QUA propagation machinery the gap rests on)
-* [krifka-1989] (the binary CUM/QUA antecedent Filip critiques)
-* [moon-2026] (canonical instance: mixed-drink nouns as concrete
-  witness of the topological-source ¬CUM ∧ ¬QUA middle ground)
+* [filip-2012]
+* [krifka-1989]
+* [krifka-1998]
+* [bennett-partee-1972]
+* [vendler-1957]
+* [dowty-1979]
 -/
 
 namespace Filip2012
 
-open _root_.Mereology
-open ArgumentStructure
-open Aspect.Incremental
-open Aspect.Cumulativity
-
-/-! ### Three-way exhaustiveness (Filip's distinctive observation) -/
-
-/-- The three classes are exhaustive: every predicate falls into
-    exactly one of CUM, QUA, or ¬CUM ∧ ¬QUA. Conceptually important:
-    the middle ground is a genuine third category, not a gap in our
-    analysis. -/
-theorem three_way_exhaustive {α : Type*} [SemilatticeSup α]
-    (P : α → Prop) :
-    CUM P ∨ QUA P ∨ (¬ CUM P ∧ ¬ QUA P) := by
-  by_cases hc : CUM P
-  · exact .inl hc
-  · by_cases hq : QUA P
-    · exact .inr (.inl hq)
-    · exact .inr (.inr ⟨hc, hq⟩)
-
-/-! ### Propagation gap substrate (inlined) -/
-
-/-! When OBJ is neither CUM nor QUA, neither `cum_propagation` nor
-    `qua_propagation` fires. Under SINC + UP + CumTheta verbs the
-    middle ground is **stable** — it lifts from OBJ to VP. The concrete
-    witness instance is [moon-2026]'s mixed drink nouns. -/
+open Mereology ArgumentStructure Aspect.Incremental Aspect.Cumulativity Data.Examples
 
 variable {α β : Type*} [SemilatticeSup α] [SemilatticeSup β]
 
-/-- ¬CUM lifts from OBJ to VP (explicit-witness smart constructor):
-    if two OBJ-entities x,y satisfy OBJ but their join x⊔y does not,
-    the corresponding VP events e₁,e₂ also witness ¬CUM(VP).
+/-! ### Telic and atelic predicates (23)–(24) -/
 
-    Proof: if CUM(VP) held, VP(e₁⊔e₂) would give ∃z. OBJ(z) ∧ θ(z, e₁⊔e₂).
-    CumTheta gives θ(x⊔y, e₁⊔e₂), and UP forces z = x⊔y.
-    But OBJ(x⊔y) contradicts hSum. -/
-private theorem not_cum_vp_of_cumTheta_up {θ : α → β → Prop} {OBJ : α → Prop}
-    (hCumTheta : CumTheta θ) (hUP : UP θ)
-    {x y : α} {e₁ e₂ : β}
-    (hx : OBJ x) (hy : OBJ y)
-    (hθ₁ : θ x e₁) (hθ₂ : θ y e₂)
-    (hSum : ¬ OBJ (x ⊔ y)) :
-    ¬ CUM (VP θ OBJ) := by
-  intro hCum
-  have hVP₁ : VP θ OBJ e₁ := ⟨x, hx, hθ₁⟩
-  have hVP₂ : VP θ OBJ e₂ := ⟨y, hy, hθ₂⟩
-  obtain ⟨z, hz_obj, hz_θ⟩ := hCum hVP₁ hVP₂
-  have hθ_sum := hCumTheta x y e₁ e₂ hθ₁ hθ₂
-  have hz_eq := hUP z (x ⊔ y) (e₁ ⊔ e₂) hz_θ hθ_sum
-  exact hSum (hz_eq ▸ hz_obj)
+/-- (23): a telic predicate is quantized. -/
+abbrev Telic (P : β → Prop) : Prop := QUA P
 
-/-- ¬CUM ∧ ¬QUA is stable under VP formation (explicit-witness
-    smart constructor): SINC's MSE maps OBJ proper part y < x to
-    proper sub-event e_y < e_x, witnessing ¬QUA on the VP. -/
-private theorem middle_ground_stable_of_postulates {θ : α → β → Prop} {OBJ : α → Prop}
-    (hCumTheta : CumTheta θ) (hUP : UP θ) (hSinc : SINC θ)
-    {a b : α} {e_a e_b : β}
-    (ha : OBJ a) (hb : OBJ b)
-    (hθ_a : θ a e_a) (hθ_b : θ b e_b)
-    (hSum : ¬ OBJ (a ⊔ b))
-    {x y : α} {e_x : β}
-    (hx : OBJ x) (hy : OBJ y) (hlt : y < x)
-    (hθ_x : θ x e_x) :
-    ¬ CUM (VP θ OBJ) ∧ ¬ QUA (VP θ OBJ) := by
-  constructor
-  · exact not_cum_vp_of_cumTheta_up hCumTheta hUP ha hb hθ_a hθ_b hSum
-  · intro hQua
-    obtain ⟨e_y, he_y_lt, hθ_y⟩ := hSinc.mse x e_x y hθ_x hlt
-    exact hQua ⟨y, hy, hθ_y⟩ ⟨x, hx, hθ_x⟩ he_y_lt.ne he_y_lt.le
+/-- (24): an atelic predicate is cumulative. -/
+abbrev Atelic (P : β → Prop) : Prop := CUM P
 
-/-- **¬CUM lifts to VP** (canonical typeclass form). `[IsSincVerb θ]`
-    bundles `CumTheta` (via `IsCumThetaVerb` parent class) and `UP`. -/
-theorem not_cum_vp_of_witnesses {θ : α → β → Prop} [IsSincVerb θ]
-    {OBJ : α → Prop}
-    {x y : α} {e₁ e₂ : β}
-    (hx : OBJ x) (hy : OBJ y)
-    (hθ₁ : θ x e₁) (hθ₂ : θ y e₂)
-    (hSum : ¬ OBJ (x ⊔ y)) :
-    ¬ CUM (VP θ OBJ) :=
-  not_cum_vp_of_cumTheta_up IsCumThetaVerb.cumTheta IsSincVerb.up
-    hx hy hθ₁ hθ₂ hSum
+/-! ### The three classes of verbs (28) -/
 
-/-- **Middle-ground gap lifts** (canonical typeclass form).
-    `[IsSincVerb θ]` bundles SINC + UP + CumTheta directly. The
-    recommended public API for the [filip-2012] propositional
-    gap-propagation result. -/
-theorem middle_ground_stable {θ : α → β → Prop} [IsSincVerb θ]
-    {OBJ : α → Prop}
-    {a b : α} {e_a e_b : β}
-    (ha : OBJ a) (hb : OBJ b)
-    (hθ_a : θ a e_a) (hθ_b : θ b e_b)
-    (hSum : ¬ OBJ (a ⊔ b))
-    {x y : α} {e_x : β}
-    (hx : OBJ x) (hy : OBJ y) (hlt : y < x)
-    (hθ_x : θ x e_x) :
-    ¬ CUM (VP θ OBJ) ∧ ¬ QUA (VP θ OBJ) :=
-  middle_ground_stable_of_postulates IsCumThetaVerb.cumTheta IsSincVerb.up
-    IsSincVerb.sinc ha hb hθ_a hθ_b hSum hx hy hlt hθ_x
+/-- A telic verb (28i): no eventuality in its relation has a proper part in it — *recover*,
+*arrive*, *burst*. -/
+def Quantized (θ : α → β → Prop) : Prop := ∀ x e, θ x e → ∀ y e', e' < e → ¬ θ y e'
+
+/-- An atelic verb (28ii): its relation persists to the parts of an eventuality, the subinterval
+property (19) — *run*, *watch*, *believe*. -/
+def Persistent (θ : α → β → Prop) : Prop := ∀ x e, θ x e → ∀ e', e' ≤ e → θ x e'
+
+omit [SemilatticeSup α] in
+/-- A telic verb forms a telic predicate with any object. -/
+theorem telic_of_quantized {θ : α → β → Prop} (h : Quantized θ) (OBJ : α → Prop) :
+    Telic (VP θ OBJ) :=
+  qua_of_forall λ _ _ ⟨_, _, hθ⟩ hlt ⟨_, _, hθ'⟩ => h _ _ hθ _ _ hlt hθ'
+
+omit [SemilatticeSup α] in
+/-- (26): an atelic verb forms no telic predicate whatever its object: a proper part of one of
+its eventualities is one too. -/
+theorem not_telic_of_persistent {θ : α → β → Prop} (h : Persistent θ) (OBJ : α → Prop)
+    {e e' : β} (hlt : e' < e) (he : VP θ OBJ e) : ¬ Telic (VP θ OBJ) := λ hQ =>
+  let ⟨x, hx, hθ⟩ := he
+  hQ ⟨x, hx, h x e hθ e' hlt.le⟩ he hlt.ne hlt.le
+
+/-- An atelic verb with a cumulative object forms a cumulative predicate. -/
+theorem atelic_of_persistent {θ : α → β → Prop} [IsCumThetaVerb θ] {OBJ : α → Prop}
+    (hObj : CUM OBJ) : Atelic (VP θ OBJ) :=
+  cum_propagation hObj
+
+/-- (27), (28iii), (29ii): an incremental verb is lexically unmarked for telicity — its
+non-degeneracy provides a quantized object with which its predicate is telic and a cumulative
+one with which it is atelic and not telic. -/
+theorem incremental_underspecified {θ : α → β → Prop} [IsSincVerb θ] :
+    (∃ OBJ : α → Prop, QUA OBJ ∧ Telic (VP θ OBJ) ∧ ∃ e, VP θ OBJ e) ∧
+    (∃ OBJ : α → Prop, CUM OBJ ∧ Atelic (VP θ OBJ) ∧ ¬ Telic (VP θ OBJ)) := by
+  obtain ⟨x, y, e, e', hlt, hlt', hθ, hθ'⟩ := (IsSincVerb.sinc (θ := θ)).extended
+  refine ⟨⟨(· = x), singleton_qua x, qua_propagation (singleton_qua x), e, x, rfl, hθ⟩,
+    ⟨λ _ => True, λ _ _ _ _ => trivial, cum_propagation (λ _ _ _ _ => trivial), λ hQ => ?_⟩⟩
+  exact hQ ⟨y, trivial, hθ'⟩ ⟨x, trivial, hθ⟩ hlt'.ne hlt'.le
+
+/-- (29i): telicity does not require incrementality — a quantized verb is not strictly
+incremental, its eventualities having no proper parts in the relation. -/
+theorem not_sinc_of_quantized {θ : α → β → Prop} (h : Quantized θ) : ¬ SINC θ := λ hS =>
+  let ⟨x, y, e, e', _, hlt', hθ, hθ'⟩ := hS.extended
+  h x e hθ y e' hlt' hθ'
+
+/-! ### The adverbial diagnostic (1) over the chapter's data -/
+
+/-- The verb classes of (28). -/
+inductive VerbClass where
+  | telic
+  | atelic
+  | incremental
+  deriving DecidableEq, Repr
+
+/-- The object's reference: quantized, cumulative, or absent. -/
+inductive Object where
+  | quantized
+  | cumulative
+  | none
+  deriving DecidableEq, Repr
+
+/-- The temporal adverbials of (1). -/
+inductive Adverbial where
+  | inNP
+  | forNP
+  deriving DecidableEq, Repr
+
+/-- A sentence of the diagnostic with its verb's class, its object's reference, its adverbial,
+and the chapter's judgment. -/
+structure Row where
+  cls : VerbClass
+  obj : Object
+  adverbial : Adverbial
+  judgment : Features.Judgment
+  deriving DecidableEq, Repr
+
+/-- The telicity the classification assigns: telic verbs form telic predicates
+(`telic_of_quantized`), atelic verbs never do (`not_telic_of_persistent`), and incremental
+verbs follow their object ((27): `qua_propagation`, `cum_propagation`). -/
+def Row.Telic (r : Row) : Prop :=
+  match r.cls, r.obj with
+  | .telic, _ => True
+  | .atelic, _ => False
+  | .incremental, .quantized => True
+  | .incremental, _ => False
+
+instance (r : Row) : Decidable r.Telic := by unfold Row.Telic; split <;> infer_instance
+
+def classTable : List (String × VerbClass) :=
+  [("telic", .telic), ("atelic", .atelic), ("incremental", .incremental)]
+
+def objectTable : List (String × Object) :=
+  [("quantized", .quantized), ("cumulative", .cumulative), ("none", .none)]
+
+def adverbialTable : List (String × Adverbial) := [("in", .inNP), ("for", .forNP)]
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let cls ← ex.parse? "verbClass" classTable
+  let obj ← ex.parse? "object" objectTable
+  let adverbial ← ex.parse? "adverbial" adverbialTable
+  pure ⟨cls, obj, adverbial, ex.judgment⟩
+
+theorem row_ofExample_isSome : ∀ ex ∈ Examples.all, (Row.ofExample ex).isSome := by decide
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- (1): the *in* adverbial is acceptable exactly with the telic predicates and the *for*
+adverbial exactly with the atelic ones, across (1), (25), (26), (31), (37). -/
+theorem rows_test : ∀ r ∈ rows, (r.judgment = .acceptable ↔ (r.adverbial = .inNP ↔ r.Telic)) := by
+  decide
 
 end Filip2012

--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Number.Interp
-import Linglib.Studies.Filip2012
+import Linglib.Semantics.Aspect.Cumulativity
 import Mathlib.Topology.Connected.Basic
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.NormNum
@@ -25,7 +25,7 @@ and [borer-2005]'s individuation operator excludes it (`div_excludes_mixed_drink
 half a drink with its ratios preserved is still a drink, so the denotation is not quantized
 either (`mixedDrink_not_qua`). Mixed drinks thus occupy the ¬CUM ∧ ¬QUA middle ground of
 [filip-2012] (`mixedDrink_middle_ground`), and the gap propagates to drinking VPs through
-`Filip2012.middle_ground_stable` (`mixedDrink_VP_propagation_gap`). Multipliers such as
+`middle_ground_stable` (`mixedDrink_VP_propagation_gap`). Multipliers such as
 *double* rescale the measured part's ratio constant rather than the whole (`doubleRecipe`,
 [wagiel-2021]'s subatomic quantification), and *dry* rescales another ingredient's
 (`modifyRatio`).
@@ -187,8 +187,34 @@ theorem mixedDrink_middle_ground {a b : α} (ha : mixedDrinkDen recipe μ phase 
     ¬ CUM (mixedDrinkDen recipe μ phase) ∧ ¬ QUA (mixedDrinkDen recipe μ phase) :=
   connectivity_middle_ground (fun _ => selfConnected_of_mixedDrinkDen) ha hb hDisc hx hy hlt
 
+omit [TopologicalSpace α] in
+/-- Neither cumulativity nor quantization of the object propagates to the VP, so neither
+`cum_propagation` nor `qua_propagation` fires; the gap itself propagates. Two objects whose
+sum is not an object witness the failure of cumulativity on the VP: the sum event's object
+would have to be their sum. -/
+private theorem not_cum_vp {β : Type*} [SemilatticeSup β] {θ : α → β → Prop} {OBJ : α → Prop}
+    (hCumTheta : ArgumentStructure.CumTheta θ) (hUP : ArgumentStructure.UP θ) {x y : α}
+    {e₁ e₂ : β} (hx : OBJ x) (hy : OBJ y) (hθ₁ : θ x e₁) (hθ₂ : θ y e₂) (hSum : ¬ OBJ (x ⊔ y)) :
+    ¬ CUM (VP θ OBJ) := by
+  intro hCum
+  obtain ⟨z, hz_obj, hz_θ⟩ := hCum ⟨x, hx, hθ₁⟩ ⟨y, hy, hθ₂⟩
+  exact hSum (hUP z (x ⊔ y) (e₁ ⊔ e₂) hz_θ (hCumTheta x y e₁ e₂ hθ₁ hθ₂) ▸ hz_obj)
+
+omit [TopologicalSpace α] in
+/-- With a strictly incremental verb, an object neither cumulative nor quantized yields a VP
+neither cumulative nor quantized: the sum witnesses refute cumulativity and a proper object
+part, mapped to a proper subevent, refutes quantization. -/
+theorem middle_ground_stable {β : Type*} [SemilatticeSup β] {θ : α → β → Prop} [IsSincVerb θ]
+    {OBJ : α → Prop} {a b : α} {e_a e_b : β} (ha : OBJ a) (hb : OBJ b) (hθ_a : θ a e_a)
+    (hθ_b : θ b e_b) (hSum : ¬ OBJ (a ⊔ b)) {x y : α} {e_x : β} (hx : OBJ x) (hy : OBJ y)
+    (hlt : y < x) (hθ_x : θ x e_x) : ¬ CUM (VP θ OBJ) ∧ ¬ QUA (VP θ OBJ) := by
+  refine ⟨not_cum_vp ArgumentStructure.IsCumThetaVerb.cumTheta IsSincVerb.up ha hb hθ_a hθ_b
+    hSum, λ hQua => ?_⟩
+  obtain ⟨e_y, he_y_lt, hθ_y⟩ := (IsSincVerb.sinc (θ := θ)).mse x e_x y hθ_x hlt
+  exact hQua ⟨y, hy, hθ_y⟩ ⟨x, hx, hθ_x⟩ he_y_lt.ne he_y_lt.le
+
 /-- The middle ground propagates to VPs: a strictly incremental drinking verb with a
-mixed-drink object is neither cumulative nor quantized (`Filip2012.middle_ground_stable`). -/
+mixed-drink object is neither cumulative nor quantized (`middle_ground_stable`). -/
 theorem mixedDrink_VP_propagation_gap {β : Type*} [SemilatticeSup β] (drinkTheme : α → β → Prop)
     [IsSincVerb drinkTheme] {a b : α} {e_a e_b : β} (ha : mixedDrinkDen recipe μ phase a)
     (hb : mixedDrinkDen recipe μ phase b) (hθ_a : drinkTheme a e_a) (hθ_b : drinkTheme b e_b)
@@ -197,7 +223,7 @@ theorem mixedDrink_VP_propagation_gap {β : Type*} [SemilatticeSup β] (drinkThe
     (hθ_x : drinkTheme x e_x) :
     ¬ CUM (VP drinkTheme (mixedDrinkDen recipe μ phase)) ∧
       ¬ QUA (VP drinkTheme (mixedDrinkDen recipe μ phase)) :=
-  Filip2012.middle_ground_stable ha hb hθ_a hθ_b hSum hx hy hlt hθ_x
+  middle_ground_stable ha hb hθ_a hθ_b hSum hx hy hlt hθ_x
 
 /-! ### Modifying the ratios -/
 

--- a/references.bib
+++ b/references.bib
@@ -1958,7 +1958,7 @@
   subfield  = {semantics/lexical},
   role      = {foundational},
   validated = {true},
-  sources   = {Semantics/Aspect/SubintervalProperty.lean}
+  sources   = {Semantics/Aspect/SubintervalProperty.lean;Studies/Filip2012.lean}
 }
 @phdthesis{benz-2025,
   author    = {Benz, Johanna},
@@ -8939,7 +8939,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Attitudes/RationalAttitude.lean;Semantics/Lexical/LevinClass.lean;Semantics/Causation/Progressive.lean;Semantics/Lexical/EventStructure.lean;Semantics/Aspect/SubintervalProperty.lean;Features/Aktionsart.lean}
+  sources   = {Features/Aktionsart.lean;Semantics/ArgumentStructure/EventStructure.lean;Semantics/ArgumentStructure/LevinClass.lean;Semantics/Aspect/SubintervalProperty.lean;Semantics/Causation/Progressive.lean;Studies/Cohen2013.lean;Studies/Filip2012.lean;Studies/FuscoSgrizzi2026.lean;Studies/Krejci2012.lean}
 }
 @book{fitting-mendelsohn-2023,
   author    = {Fitting, Melvin and Mendelsohn, Richard L.},
@@ -14274,7 +14274,7 @@
     subfield  = {semantics/lexical},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Krifka1989.lean}
+  sources   = {Core/Order/IntervalContent.lean;Features/Aktionsart.lean;Semantics/Aspect/Cumulativity.lean;Semantics/Degree/Measure/Basic.lean;Semantics/Degree/Measure/Dimensioned.lean;Semantics/Dynamic/PPCDRT/Cumulativity.lean;Semantics/Events/Basic.lean;Semantics/Mereology.lean;Semantics/Plurality/Algebra.lean;Semantics/Plurality/Cumulativity.lean;Semantics/Tense/RunTimes.lean;Studies/BaleKhanjian2014.lean;Studies/Filip2012.lean;Studies/HayKennedyLevin1999.lean;Studies/Karlsson2017.lean;Studies/Krifka1989.lean;Studies/Scontras2014.lean;Studies/Smith1997.lean;Studies/Sternefeld1998.lean}
 }
 @incollection{krifka-1998,
   author    = {Krifka, Manfred},
@@ -14297,10 +14297,12 @@
   booktitle = {The Oxford Handbook of Tense and Aspect},
   editor    = {Binnick, Robert I.},
   publisher = {Oxford University Press},
+  pages     = {721--751},
+  doi       = {10.1093/oxfordhb/9780195381979.013.0025},
   subfield  = {semantics/lexical},
   role      = {formalized},
-  validated = {false},
-  sources   = {Studies/Filip2012.lean}
+  validated = {true},
+  sources   = {Data/Examples/Filip2012.json;Features/Aktionsart.lean;Studies/Filip2012.lean;Studies/Moon2026.lean}
 }
 @article{kriz-spector-2021,
   author    = {Kri{\v{z}}, Manuel and Spector, Benjamin},
@@ -22501,7 +22503,7 @@
   subfield  = {semantics/events},
   validated = {true},
   role      = {foundational},
-  sources   = {Semantics/Verb/Defs.lean;Features/Aktionsart.lean}
+  sources   = {Features/Aktionsart.lean;Fragments/English/TemporalExpressions.lean;Studies/Filip2012.lean;Studies/StapsRooryck2024.lean;Syntax/Category/Verb/Defs.lean}
 }
 @article{bach-1986,
   author    = {Bach, Emmon},
@@ -22565,7 +22567,7 @@
   subfield  = {semantics/events},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Champollion2017.lean;Semantics/Aspect/Stratified.lean}
+  sources   = {Semantics/Aspect/AtomDist.lean;Semantics/Aspect/Cumulativity.lean;Semantics/Aspect/Stratified.lean;Semantics/Aspect/SubintervalProperty.lean;Semantics/Events/Adjacency.lean;Semantics/Events/Basic.lean;Semantics/Events/CEM.lean;Semantics/Mereology.lean;Semantics/Plurality/Algebra.lean;Semantics/Plurality/Cover.lean;Semantics/Tense/RunTimes.lean;Studies/Champollion2017.lean}
 }
 @article{hovda-2009,
   author    = {Hovda, Paul},


### PR DESCRIPTION
Deep cleanse of Filip2012 against the handbook chapter: the old file proved a tautology (`CUM ∨ QUA ∨ (¬CUM ∧ ¬QUA)`) as "Filip's distinctive observation" and carried the ¬CUM ∧ ¬QUA propagation theorem that Moon2026 needs but the chapter never states; the recut formalizes the chapter's mereological core and moves the propagation-gap theorem to its consumer.

- `Quantized`/`Persistent` are the telic and atelic verb classes of (28) with `telic_of_quantized` and `not_telic_of_persistent` (the subinterval property (19) behind (26)); `incremental_underspecified` derives (28iii)/(29ii) from SINC's non-degeneracy and `not_sinc_of_quantized` is (29i)
- 15 JSON rows for the in/for diagnostic (1), (25), (26), (31), (37); `rows_test` checks the judgments against the telicity the classification assigns
- `middle_ground_stable` now lives in Moon2026 (single consumer), which imports the cumulativity substrate directly; `filip-2012` gets its pages and DOI
