### PR TITLE
refactor(Studies/Fitting2021): products generate strict/tolerant pairs

### DIFF
--- a/Linglib/Core/Order/Bilattice/Basic.lean
+++ b/Linglib/Core/Order/Bilattice/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Order.Bilattice.Product
+import Linglib.Core.Order.DeMorganAlgebra.Defs
 
 /-!
 # Evidential bilattices over a chain
@@ -91,6 +92,80 @@ theorem guard_of_pro_bot {x : Evidential S} (h : x.pro = ⊥) (y : Evidential S)
   simp [guard, h]
 
 end Guard
+
+/-! ### Conflation from a De Morgan complement
+
+Over a lattice with an involutive antitone complement, `conf compl` is a conflation in the sense
+of `Bilattice.Conflation` — an involution preserving the truth order and reversing the knowledge
+order — and it commutes with Ginsberg negation ([fitting-1994] §7, [fitting-2021] §8.8). The
+exact, consistent and anticonsistent values then read off the coordinates. -/
+
+section Involution
+
+variable [LatticeWithInvolution S]
+
+theorem conf_conf (x : Evidential S) : Evidential.conf compl (Evidential.conf compl x) = x := by
+  ext <;> simp [Evidential.conf, LatticeWithInvolution.compl_compl]
+
+theorem conf_le_conf {x y : Evidential S} (h : x ≤ y) :
+    Evidential.conf compl x ≤ Evidential.conf compl y :=
+  ⟨LatticeWithInvolution.compl_le_compl h.2, LatticeWithInvolution.compl_le_compl h.1⟩
+
+theorem conf_kLE_conf {x y : Evidential S} (h : x ≤ₖ y) :
+    Evidential.conf compl y ≤ₖ Evidential.conf compl x :=
+  ⟨LatticeWithInvolution.compl_le_compl h.2, LatticeWithInvolution.compl_le_compl h.1⟩
+
+instance : Conflation (Evidential S) where
+  conf := Evidential.conf compl
+  conf_conf := conf_conf
+  conf_le_conf := conf_le_conf
+  conf_kLE_conf := conf_kLE_conf
+
+instance : NegConfComm (Evidential S) := ⟨λ _ => rfl⟩
+
+@[simp] theorem pro_conf (x : Evidential S) : (Conflation.conf x).pro = x.conᶜ := rfl
+@[simp] theorem con_conf (x : Evidential S) : (Conflation.conf x).con = x.proᶜ := rfl
+
+/-- The exact values are the pairs `⟨a, aᶜ⟩`. -/
+theorem isExact_iff (x : Evidential S) : IsExact x ↔ x.con = x.proᶜ :=
+  ⟨λ h => (congrArg Product.con h).symm,
+    λ h => Product.ext (by simp [h, LatticeWithInvolution.compl_compl]) (by simpa using h.symm)⟩
+
+/-- The consistent values: the evidence against is below the complement of the evidence for. -/
+theorem isConsistent_iff (x : Evidential S) : IsConsistent x ↔ x.con ≤ x.proᶜ :=
+  consistent_iff_con_le LatticeWithInvolution.compl_anti LatticeWithInvolution.compl_compl
+
+/-- The anticonsistent values: the complement of the evidence for is below the evidence
+against. -/
+theorem isAnticonsistent_iff (x : Evidential S) : IsAnticonsistent x ↔ x.proᶜ ≤ x.con :=
+  ⟨And.right, λ h => ⟨(LatticeWithInvolution.compl_le_compl h).trans
+    (LatticeWithInvolution.compl_compl x.pro).le, h⟩⟩
+
+end Involution
+
+/-! ### The truth lattice as a De Morgan lattice
+
+With Ginsberg negation as complement, the truth lattice of `S ⊙ S` is a lattice with involution,
+distributive when `S` is: `FOUR` under `≤ₜ` is a De Morgan algebra ([fitting-2021] §8.3). -/
+
+section Involutive
+
+variable [Lattice S] [BoundedOrder S]
+
+instance : LatticeWithInvolution (Evidential S) where
+  toLattice := inferInstance
+  toBoundedOrder := inferInstance
+  compl := Product.neg
+  compl_compl := Product.neg_neg
+  compl_le_compl := Product.neg_le_neg
+
+@[simp] theorem compl_eq_neg (x : Evidential S) : xᶜ = neg x := rfl
+
+end Involutive
+
+instance [DistribLattice S] [BoundedOrder S] : DeMorganAlgebra (Evidential S) :=
+  { (inferInstance : DistribLattice (Evidential S)),
+    (inferInstance : LatticeWithInvolution (Evidential S)) with }
 
 end Evidential
 

--- a/Linglib/Core/Order/Bilattice/Interlaced.lean
+++ b/Linglib/Core/Order/Bilattice/Interlaced.lean
@@ -395,6 +395,12 @@ instance [DecidableLE (Know B)] : DecidablePred (IsConsistent (B := B)) :=
   fun a => inferInstanceAs (Decidable (a ≤ₖ conf a))
 instance [DecidableLE (Know B)] : DecidablePred (IsAnticonsistent (B := B)) :=
   fun a => inferInstanceAs (Decidable (conf a ≤ₖ a))
+instance [DecidableRel (kLE (B := B))] : DecidablePred (IsConsistent (B := B)) :=
+  λ a => inferInstanceAs (Decidable (a ≤ₖ conf a))
+
+instance [DecidableRel (kLE (B := B))] : DecidablePred (IsAnticonsistent (B := B)) :=
+  λ a => inferInstanceAs (Decidable (conf a ≤ₖ a))
+
 instance [DecidableEq B] : DecidablePred (IsExact (B := B)) :=
   fun a => inferInstanceAs (Decidable (conf a = a))
 

--- a/Linglib/Core/Order/Bilattice/Product.lean
+++ b/Linglib/Core/Order/Bilattice/Product.lean
@@ -192,7 +192,7 @@ theorem know_bot_eq [Preorder L] [Preorder R] [BoundedOrder L] [BoundedOrder R] 
     (⊥ : Know (L ⊙ R)) = toKnow (mk ⊥ ⊥) := rfl
 
 /-- The knowledge order on the projections. -/
-theorem kLE_def [Preorder L] [Preorder R] {x y : L ⊙ R} :
+theorem kLE_iff [Preorder L] [Preorder R] {x y : L ⊙ R} :
     x ≤ₖ y ↔ x.pro ≤ y.pro ∧ x.con ≤ y.con := Iff.rfl
 
 section KProj

--- a/Linglib/Studies/Fitting1994.lean
+++ b/Linglib/Studies/Fitting1994.lean
@@ -14,15 +14,17 @@ product bilattices `L ⊙ L` of [ginsberg-1988], where the guard is `⟨a, b⟩ 
 (Definition 9.4).
 
 The main results are the identities of Figure 4 for the guard, the closure theorems for exact
-and consistent values (Theorems 9.2 and 9.3, `IsClassical.inf`, `Consistent.kSup`), the
+and consistent values (Theorems 9.2 and 9.3, `not_isExact_kTop`, `isConsistent_kSup`), the
 identification of the Lisp and weak connectives on Kleene's values with `Trivalent.meetMiddle`
 and `Trivalent.meetWeak`, and the collapse for bilinear bilattices: an equivalence of formulas
 holds in `L ⊙ L` for a linear `L` iff it holds in `FOUR` (Theorem 10.5, `equivalent_iff_four`).
 
 ## Implementation notes
 
-* The product, its negation and the conflation of §§6–7 are `Bilattice.Product`, the `Negation`
-  instance on `L ⊙ L`, and `Evidential.conf`; a De Morgan lattice is a `DeMorganAlgebra`.
+* The product, its negation and the conflation of §§6–7 are `Bilattice.Product` and the
+  `Negation` and `Conflation` instances on `L ⊙ L`; a De Morgan lattice is a `DeMorganAlgebra`.
+  The closure clauses of Theorems 9.2 and 9.3 are the substrate's `IsExact.inf`,
+  `IsConsistent.neg` and their kin; the study keeps what the substrate lacks.
 * The representation theorems of §8 are `Bilattice.decompose` ([avron-1996]); their
   negation- and conflation-preserving refinements (Theorems 8.2 and 8.3) and the tableau system
   of §4 are not formalized.
@@ -332,126 +334,51 @@ theorem extremal :
 
 end Product
 
-section Conflation
 
-variable {L : Type*} [LatticeWithInvolution L] (x y : L ⊙ L)
+/-! ### Kleene's logics generalized (§9)
 
-/-- §7: the conflation `−(x, y) = (yᶜ, xᶜ)` from a De Morgan complement is an involution
-(Definition 6.2). -/
-theorem conf_conf :
-    Evidential.conf compl (Evidential.conf compl x) = x := by
-  ext <;> simp [Evidential.conf, LatticeWithInvolution.compl_compl]
-
-/-- Conflation preserves the truth order (Definition 6.2). -/
-theorem conf_le_conf {x y :
-    L ⊙ L} (h : x ≤ y) : Evidential.conf compl x ≤ Evidential.conf compl y :=
-  ⟨LatticeWithInvolution.compl_le_compl h.2, LatticeWithInvolution.compl_le_compl h.1⟩
-
-/-- Conflation reverses the knowledge order (Definition 6.2). -/
-theorem conf_kLE_conf {x y :
-    L ⊙ L} (h : x ≤ₖ y) : Evidential.conf compl y ≤ₖ Evidential.conf compl x :=
-  ⟨LatticeWithInvolution.compl_le_compl h.2, LatticeWithInvolution.compl_le_compl h.1⟩
-
-/-- Negation and conflation commute (§7). -/
-theorem neg_conf :
-    neg (Evidential.conf compl x) = Evidential.conf compl (neg x) := rfl
-
-end Conflation
-
-/-! ### Kleene's logics generalized (§9) -/
+Definition 9.1's exact and consistent values are `IsExact` and `IsConsistent`, read off the
+coordinates by `Evidential.isExact_iff` and `isConsistent_iff`; their closure under the truth
+connectives and negation (Theorems 9.2 and 9.3) is `IsExact.inf`, `IsExact.sup`, `IsExact.neg`,
+`IsConsistent.inf`, `IsConsistent.sup` and `IsConsistent.neg`. -/
 
 section Generalized
 
 variable {L : Type*} [DeMorganAlgebra L]
 
-/-- Definition 9.1: `x` is consistent, `x ≤ₖ −x`, iff its evidence against is below the
-complement of its evidence for. -/
-theorem consistent_iff (x : L ⊙ L) : Consistent compl x ↔ x.con ≤ x.proᶜ :=
-  consistent_iff_con_le LatticeWithInvolution.compl_anti LatticeWithInvolution.compl_compl
-
-/-- Definition 9.1: `x` is exact, `x = −x`, iff its evidence for is the complement of its
-evidence against. -/
-theorem isClassical_iff (x : L ⊙ L) : IsClassical compl x ↔ x.pro = x.conᶜ :=
-  ⟨λ h => congrArg pro h,
-    λ h => Product.ext h (by simp [Evidential.conf, h, LatticeWithInvolution.compl_compl])⟩
-
 variable {x y z : L ⊙ L}
 
-/-- Theorem 9.2: `true` is exact. -/
-theorem isClassical_top : IsClassical compl (⊤ : L ⊙ L) := (isClassical_iff _).2 (by simp)
-
-/-- Theorem 9.2: `false` is exact. -/
-theorem isClassical_bot : IsClassical compl (⊥ : L ⊙ L) := (isClassical_iff _).2 (by simp)
-
-/-- Theorem 9.2: the exact values are closed under `∧`. -/
-theorem IsClassical.inf (hx : IsClassical compl x) (hy : IsClassical compl y) :
-    IsClassical compl (x ⊓ y) := by
-  rw [isClassical_iff] at *
-  simp [hx, hy]
-
-/-- Theorem 9.2: the exact values are closed under `∨`. -/
-theorem IsClassical.sup (hx : IsClassical compl x) (hy : IsClassical compl y) :
-    IsClassical compl (x ⊔ y) := by
-  rw [isClassical_iff] at *
-  simp [hx, hy]
-
-/-- Theorem 9.2: the exact values are closed under negation. -/
-theorem IsClassical.neg (hx : IsClassical compl x) : IsClassical compl (neg x) := by
-  rw [isClassical_iff] at *
-  simp [hx, LatticeWithInvolution.compl_compl]
-
 /-- Theorem 9.2: the knowledge top `⊤ = (⊤, ⊤)` is not exact. -/
-theorem not_isClassical_kTop [Nontrivial L] : ¬ IsClassical compl (mk ⊤ ⊤ : L ⊙ L) := by
-  rw [isClassical_iff]
+theorem not_isExact_kTop [Nontrivial L] : ¬ IsExact (mk ⊤ ⊤ : L ⊙ L) := by
+  rw [isExact_iff]
   simp
 
 /-- Theorem 9.2: the knowledge bottom `⊥ = (⊥, ⊥)` is not exact. -/
-theorem not_isClassical_kBot [Nontrivial L] : ¬ IsClassical compl (mk ⊥ ⊥ : L ⊙ L) := by
-  rw [isClassical_iff]
+theorem not_isExact_kBot [Nontrivial L] : ¬ IsExact (mk ⊥ ⊥ : L ⊙ L) := by
+  rw [isExact_iff]
   simp
 
 /-- Theorem 9.2: the exact values are not closed under `⊗`: `true ⊗ false = ⊥`. -/
-theorem not_isClassical_kInf [Nontrivial L] : ¬ IsClassical compl ((⊤ : L ⊙ L) ⊗ ⊥) := by
-  rw [isClassical_iff]
+theorem not_isExact_kInf [Nontrivial L] : ¬ IsExact ((⊤ : L ⊙ L) ⊗ ⊥) := by
+  rw [isExact_iff]
   simp
 
 /-- Theorem 9.2: the exact values are not closed under `⊕`: `true ⊕ false = ⊤`. -/
-theorem not_isClassical_kSup [Nontrivial L] : ¬ IsClassical compl ((⊤ : L ⊙ L) ⊕ ⊥ : L ⊙ L) := by
-  rw [isClassical_iff]
+theorem not_isExact_kSup [Nontrivial L] : ¬ IsExact ((⊤ : L ⊙ L) ⊕ ⊥ : L ⊙ L) := by
+  rw [isExact_iff]
   simp
-
-/-- Theorem 9.3: the exact values are consistent. -/
-theorem Consistent.of_isClassical (hx : IsClassical compl x) : Consistent compl x := by
-  rw [Evidential.Consistent, ← hx]
-
-/-- Theorem 9.3: the consistent values are closed under `∧`. -/
-theorem Consistent.inf (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (x ⊓ y) := by
-  rw [consistent_iff] at *
-  simpa using sup_le_sup hx hy
-
-/-- Theorem 9.3: the consistent values are closed under `∨`. -/
-theorem Consistent.sup (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (x ⊔ y) := by
-  rw [consistent_iff] at *
-  simpa using inf_le_inf hx hy
-
-/-- Theorem 9.3: the consistent values are closed under negation. -/
-theorem Consistent.neg (hx : Consistent compl x) : Consistent compl (neg x) := by
-  rw [consistent_iff] at *
-  simpa using LatticeWithInvolution.le_compl_comm.1 hx
 
 /-- Theorem 9.3: the consistent values are closed under consensus `⊗` — indeed the consensus of a
 consistent value with any value is consistent. -/
-theorem Consistent.kInf (hx : Consistent compl x) (y : L ⊙ L) : Consistent compl (x ⊗ y) := by
-  rw [consistent_iff] at *
+theorem isConsistent_kInf (hx : IsConsistent x) (y : L ⊙ L) : IsConsistent (x ⊗ y) := by
+  rw [isConsistent_iff] at *
   simpa using inf_le_left.trans (hx.trans le_sup_left)
 
 /-- Theorem 9.3: the consistent values are closed under gullibility `⊕` below a common consistent
 upper bound. -/
-theorem Consistent.kSup (hx : Consistent compl x) (hy : Consistent compl y)
-    (hz : Consistent compl z) (hxz : x ≤ₖ z) (hyz : y ≤ₖ z) : Consistent compl (x ⊕ y) := by
-  rw [consistent_iff] at *
+theorem isConsistent_kSup (hx : IsConsistent x) (hy : IsConsistent y)
+    (hz : IsConsistent z) (hxz : x ≤ₖ z) (hyz : y ≤ₖ z) : IsConsistent (x ⊕ y) := by
+  rw [isConsistent_iff] at *
   simp only [pro_kSup, con_kSup, LatticeWithInvolution.compl_sup]
   exact sup_le (le_inf hx (hxz.2.trans (hz.trans (LatticeWithInvolution.compl_le_compl hyz.1))))
     (le_inf (hyz.2.trans (hz.trans (LatticeWithInvolution.compl_le_compl hxz.1))) hy)
@@ -463,9 +390,9 @@ theorem guard_eq_kSup_neg (x y : L ⊙ L) :
   ext <;> simp [Evidential.guard]
 
 /-- §9: the guard of a consistent value is consistent. -/
-theorem Consistent.guard (hy :
-    Consistent compl y) (x : L ⊙ L) : Consistent compl (Evidential.guard x y) := by
-  rw [consistent_iff] at *
+theorem isConsistent_guard (hy : IsConsistent y) (x : L ⊙ L) :
+    IsConsistent (Evidential.guard x y) := by
+  rw [isConsistent_iff] at *
   simpa [Evidential.guard] using inf_le_right.trans (hy.trans le_sup_right)
 
 variable {x' y' : L ⊙ L}
@@ -489,21 +416,21 @@ theorem lorW_kLE_lorW (hx : x ≤ₖ x') (hy : y ≤ₖ y') : lorW x y ≤ₖ lo
     inf_le_inf (lorL_kLE_lorL hx hy).2 (lorL_kLE_lorL hy hx).2⟩
 
 /-- §9: the consistent values are closed under the four Kleene connectives. -/
-theorem Consistent.landL (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (landL x y) :=
-  Consistent.inf hx (Consistent.guard hy x)
+theorem isConsistent_landL (hx : IsConsistent x) (hy : IsConsistent y) :
+    IsConsistent (landL x y) :=
+  hx.inf (isConsistent_guard hy x)
 
-theorem Consistent.lorL (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (lorL x y) :=
-  Consistent.sup hx (Consistent.guard hy (Bilattice.neg x))
+theorem isConsistent_lorL (hx : IsConsistent x) (hy : IsConsistent y) :
+    IsConsistent (lorL x y) :=
+  hx.sup (isConsistent_guard hy (neg x))
 
-theorem Consistent.landW (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (landW x y) :=
-  Consistent.kInf (Consistent.landL hx hy) _
+theorem isConsistent_landW (hx : IsConsistent x) (hy : IsConsistent y) :
+    IsConsistent (landW x y) :=
+  isConsistent_kInf (isConsistent_landL hx hy) _
 
-theorem Consistent.lorW (hx : Consistent compl x) (hy : Consistent compl y) :
-    Consistent compl (lorW x y) :=
-  Consistent.kInf (Consistent.lorL hx hy) _
+theorem isConsistent_lorW (hx : IsConsistent x) (hy : IsConsistent y) :
+    IsConsistent (lorW x y) :=
+  isConsistent_kInf (isConsistent_lorL hx hy) _
 
 end Generalized
 

--- a/Linglib/Studies/Fitting2021.lean
+++ b/Linglib/Studies/Fitting2021.lean
@@ -1,52 +1,54 @@
 import Linglib.Core.Order.Bilattice.Basic
+import Linglib.Core.Data.Trivalent
 
 /-!
-# Fitting 2021: strict/tolerant logics from logical bilattices
-[fitting-2021]
+# Fitting (2021): The strict/tolerant idea and bilattices
 
-[fitting-2021] generalizes the strict/tolerant phenomenon of
-[cobreros-etal-2012] — `ST` has exactly classical logic's
-consequence relation yet differs at the metaconsequence level — from three
-truth values to any *logical bilattice*: an interlaced bilattice with negation
-and conflation together with a prime bifilter `F` of designated values (the
-designated-value theory of [arieli-avron-1996], [arieli-avron-1998]). From
-such a pair, two logics arise ([fitting-2021] Def 8.7.1): `ST⟨B,F⟩` runs
-valuations over the *anticonsistent* values with strict (exact designated)
-premises and tolerant (anticonsistent designated) conclusions; `C⟨B,F⟩` — the
-classical-like logic — runs valuations over the *exact* values.
+This file formalizes [fitting-2021]'s generalization of the strict/tolerant logic `ST` of
+[cobreros-etal-2012] from three values to any logical bilattice: an interlaced bilattice with
+negation and conflation together with a prime bifilter of designated values
+([arieli-avron-1996]). Over its exact values `−a = a` and anticonsistent values `−a ≤ₖ a` live
+two logics (Definition 8.7.1): `ST⟨B, F⟩` reads premises strictly and conclusions tolerantly
+over anticonsistent valuations, `C⟨B, F⟩` reads both strictly over exact valuations. They
+validate the same sequents (Proposition 8.7.2, `stValid_iff_cValid`), yet cut is locally valid
+only in the second (Proposition 8.7.3, `cut_not_local_stValid`).
 
-The chapter's central results, formalized here over the
-`Core.Order.Bilattice` substrate:
+The examples come from products `L ⊙ L` of De Morgan algebras: the exact values of `L ⊙ L` are
+`L` (Proposition 8.8.3, `exactIso`), `D × L` is a prime bifilter for every prime filter `D`
+(Lemma 8.9.2, `PrimeFilter.prod`), and `C⟨L ⊙ L, D × L⟩` is the logic `⟨L, D⟩` itself
+(Proposition 8.9.3, `cValid_prod_iff`). Hence every logical De Morgan algebra has a
+strict/tolerant counterpart with the same consequence relation (Proposition 8.10.1,
+`stValid_prod_iff`): classical logic from `Bool`, `K3` and `LP` from `Trivalent`, and `FDE`
+from `FOUR` (Examples 8.10.2–8.10.5).
 
-* **`stValid_iff_cValid`** ([fitting-2021] Prop 8.7.2): `ST⟨B,F⟩` and
-  `C⟨B,F⟩` validate exactly the same sequents. (Both directions are proved
-  directly: right-to-left builds an exact valuation knowledge-below the given
-  anticonsistent one by the interpolation lemma and transports along
-  knowledge-monotonicity, rather than contraposing as in the chapter.)
-* **`cut_cSatisfies` / `cut_not_local_stValid`** ([fitting-2021] Prop 8.7.3):
-  the cut scheme is locally valid in `C⟨B,F⟩` but fails in `ST⟨B,F⟩` — the
-  two logics differ at the metaconsequence level. The countermodel sends a
-  letter to the knowledge top: designated and anticonsistent but not exact.
-* **the `FOUR` instance** ([fitting-2021] Example 8.7.4): `FOUR`'s exact
-  values are `{F, T}`, its anticonsistent values `{F, T, I}`, and `{T, I}` is
-  a prime bifilter; the resulting pair is the original
-  [cobreros-etal-2012] `ST` alongside classical logic, so the
-  collapse and the cut failure specialize to the classic case.
+## Implementation notes
 
-The §8.8–8.10 extension — every non-distributive logical De Morgan algebra
-generates a strict/tolerant counterpart via the product `L ⊙ L` — remains
-TODO; its bilattice ingredients (`Product`, the diagonal `Negation` instance,
-factor recovery) are already in the substrate.
+* Formulas have conjunction, disjunction and negation only (Definition 8.6.1); prime bifilters and
+  prime filters carry the nonemptiness and properness that §8.2 requires of designated sets.
+* Lemma 8.8.2, the general interlaced-bilattice route to Proposition 8.8.3, is not formalized;
+  the proposition is proved in coordinates for the product.
+* Locators use the chapter's numbering, `8.n` for the preprint's `§n`.
+
+## References
+
+* [fitting-2021]
+* [cobreros-etal-2012]
+* [arieli-avron-1996]
+* [arieli-avron-1998]
+* [belnap-1977]
+* [priest-1979]
 -/
 
-open Bilattice
+open Bilattice Product
 
 namespace Fitting2021
 
 variable {B α : Type*}
 
-/-- Formulas over propositional letters ([fitting-2021] Def 8.6.1):
-conjunction, disjunction, negation — no implication. -/
+/-! ### Formulas and valuations (§8.6) -/
+
+/-- Formulas over propositional letters ([fitting-2021] Def 8.6.1): conjunction, disjunction,
+negation, no implication. -/
 inductive Fml (α : Type*) where
   | atom (p : α)
   | and (φ ψ : Fml α)
@@ -57,7 +59,7 @@ section Eval
 
 variable [Lattice B] [Lattice (Know B)] [Negation B]
 
-/-- Valuation extension ([fitting-2021] Def 8.6.2). -/
+/-- The extension of a valuation to formulas ([fitting-2021] Def 8.6.2). -/
 def Fml.eval (v : α → B) : Fml α → B
   | atom p => v p
   | and φ ψ => φ.eval v ⊓ ψ.eval v
@@ -76,8 +78,7 @@ theorem eval_isExact {v : α → B} (hv : ∀ p, IsExact (v p)) :
 
 variable [Interlaced B]
 
-/-- Anticonsistent valuations evaluate to anticonsistent values
-([fitting-2021] Prop 8.6.3). -/
+/-- Anticonsistent valuations evaluate to anticonsistent values ([fitting-2021] Prop 8.6.3). -/
 theorem eval_isAnticonsistent {v : α → B} (hv : ∀ p, IsAnticonsistent (v p)) :
     ∀ φ : Fml α, IsAnticonsistent (φ.eval v)
   | .atom p => hv p
@@ -86,8 +87,7 @@ theorem eval_isAnticonsistent {v : α → B} (hv : ∀ p, IsAnticonsistent (v p)
   | .not φ => (eval_isAnticonsistent hv φ).neg
 
 omit [Conflation B] [NegConfComm B] in
-/-- Evaluation is knowledge-monotone in the valuation
-([fitting-2021] Prop 8.6.4). -/
+/-- Evaluation is knowledge-monotone in the valuation ([fitting-2021] Prop 8.6.4). -/
 theorem eval_kLE_eval {v w : α → B} (h : ∀ p, v p ≤ₖ w p) :
     ∀ φ : Fml α, φ.eval v ≤ₖ φ.eval w
   | .atom p => h p
@@ -113,10 +113,9 @@ section Bifilter
 
 variable [Lattice B] [Lattice (Know B)]
 
-/-- A prime bifilter: a proper nonempty subset that is a prime filter for both
-the truth and the knowledge lattice operations ([fitting-2021] Def 8.6.5,
-generalizing the designated values `{t, ⊤}` of `FOUR` per
-[arieli-avron-1996], [arieli-avron-1998]). -/
+/-- A prime bifilter: a proper nonempty subset that is a prime filter for both the truth and the
+knowledge lattice operations ([fitting-2021] Def 8.6.5), generalizing the designated values
+`{t, ⊤}` of `FOUR` ([arieli-avron-1996], [arieli-avron-1998]). -/
 structure PrimeBifilter (B : Type*) [Lattice B] [Lattice (Know B)] where
   /-- The designated values. -/
   carrier : Set B
@@ -127,25 +126,23 @@ structure PrimeBifilter (B : Type*) [Lattice B] [Lattice (Know B)] where
   sup_mem_iff {a b : B} : a ⊔ b ∈ carrier ↔ a ∈ carrier ∨ b ∈ carrier
   kSup_mem_iff {a b : B} : (a ⊕ b : B) ∈ carrier ↔ a ∈ carrier ∨ b ∈ carrier
 
-instance : Membership B (PrimeBifilter B) := ⟨fun F a => a ∈ F.carrier⟩
+instance : Membership B (PrimeBifilter B) := ⟨λ F a => a ∈ F.carrier⟩
 
-/-- Prime bifilters are upward closed in the knowledge order
-([fitting-2021] Prop 8.6.6). -/
-theorem PrimeBifilter.mem_of_kLE (F : PrimeBifilter B) {a b : B} (ha : a ∈ F)
-    (h : a ≤ₖ b) : b ∈ F := by
+/-- Prime bifilters are upward closed in the knowledge order ([fitting-2021] Prop 8.6.6). -/
+theorem PrimeBifilter.mem_of_kLE (F : PrimeBifilter B) {a b : B} (ha : a ∈ F) (h : a ≤ₖ b) :
+    b ∈ F := by
   have hab : (a ⊕ b : B) = b :=
     toKnow.injective (by simpa only [toKnow_kSup] using sup_eq_right.mpr h)
   exact hab ▸ F.kSup_mem_iff.mpr (Or.inl ha)
 
-/-- Prime bifilters are upward closed in the truth order
-([fitting-2021] Prop 8.6.6). -/
-theorem PrimeBifilter.mem_of_le (F : PrimeBifilter B) {a b : B} (ha : a ∈ F)
-    (h : a ≤ b) : b ∈ F :=
+/-- Prime bifilters are upward closed in the truth order ([fitting-2021] Prop 8.6.6). -/
+theorem PrimeBifilter.mem_of_le (F : PrimeBifilter B) {a b : B} (ha : a ∈ F) (h : a ≤ b) :
+    b ∈ F :=
   sup_eq_right.mpr h ▸ F.sup_mem_iff.mpr (Or.inl ha)
 
 end Bifilter
 
-/-! ### The strict/tolerant and classical logics of a logical bilattice -/
+/-! ### The strict/tolerant and classical logics of a logical bilattice (§8.7) -/
 
 section Logics
 
@@ -154,67 +151,67 @@ variable [Lattice B] [Lattice (Know B)] [Negation B] [Conflation B]
 /-- Strictly designated: designated and exact ([fitting-2021] Def 8.7.1). -/
 def StrictlyDesignated (F : PrimeBifilter B) (a : B) : Prop := a ∈ F ∧ IsExact a
 
-/-- Tolerantly designated: designated and anticonsistent
-([fitting-2021] Def 8.7.1). -/
-def TolerantlyDesignated (F : PrimeBifilter B) (a : B) : Prop :=
-  a ∈ F ∧ IsAnticonsistent a
+/-- Tolerantly designated: designated and anticonsistent ([fitting-2021] Def 8.7.1). -/
+def TolerantlyDesignated (F : PrimeBifilter B) (a : B) : Prop := a ∈ F ∧ IsAnticonsistent a
 
-/-- A valuation satisfies a sequent strict-to-tolerantly: if every premise is
-strictly designated, some conclusion is tolerantly designated. -/
+/-- A valuation satisfies a sequent strict-to-tolerantly: if every premise is strictly
+designated, some conclusion is tolerantly designated. -/
 def STSatisfies (F : PrimeBifilter B) (v : α → B) (Γ Δ : List (Fml α)) : Prop :=
-  (∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v)) →
-    ∃ ψ ∈ Δ, TolerantlyDesignated F (ψ.eval v)
+  (∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v)) → ∃ ψ ∈ Δ, TolerantlyDesignated F (ψ.eval v)
 
 /-- A valuation satisfies a sequent strictly on both sides. -/
 def CSatisfies (F : PrimeBifilter B) (v : α → B) (Γ Δ : List (Fml α)) : Prop :=
-  (∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v)) →
-    ∃ ψ ∈ Δ, StrictlyDesignated F (ψ.eval v)
+  (∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v)) → ∃ ψ ∈ Δ, StrictlyDesignated F (ψ.eval v)
 
-/-- `ST⟨B,F⟩` validity ([fitting-2021] Def 8.7.1): over valuations into the
-anticonsistent values, strict premises entail a tolerant conclusion. -/
+/-- `ST⟨B, F⟩` validity ([fitting-2021] Def 8.7.1): over valuations into the anticonsistent
+values, strict premises entail a tolerant conclusion. -/
 def STValid (F : PrimeBifilter B) (Γ Δ : List (Fml α)) : Prop :=
   ∀ v : α → B, (∀ p, IsAnticonsistent (v p)) → STSatisfies F v Γ Δ
 
-/-- `C⟨B,F⟩` validity ([fitting-2021] Def 8.7.1): over valuations into the
-exact values, strict premises entail a strict conclusion. -/
+/-- `C⟨B, F⟩` validity ([fitting-2021] Def 8.7.1): over valuations into the exact values, strict
+premises entail a strict conclusion. -/
 def CValid (F : PrimeBifilter B) (Γ Δ : List (Fml α)) : Prop :=
   ∀ v : α → B, (∀ p, IsExact (v p)) → CSatisfies F v Γ Δ
 
+instance {F : PrimeBifilter B} [DecidablePred (· ∈ F)] [DecidablePred (IsExact (B := B))]
+    (a : B) : Decidable (StrictlyDesignated F a) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+instance {F : PrimeBifilter B} [DecidablePred (· ∈ F)]
+    [DecidablePred (IsAnticonsistent (B := B))] (a : B) : Decidable (TolerantlyDesignated F a) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
 variable [Interlaced B] [NegConfComm B]
 
-/-- **[fitting-2021] Prop 8.7.2**: the strict/tolerant and classical logics of
-a logical bilattice validate exactly the same sequents. Right-to-left replaces
-the chapter's contraposition: given an anticonsistent valuation, choose an
-exact valuation knowledge-below it (interpolation), win there classically, and
-transport the witness up along knowledge-monotonicity and bifilter closure. -/
+/-- [fitting-2021] Prop 8.7.2: the strict/tolerant and classical logics of a logical bilattice
+validate exactly the same sequents. Right-to-left replaces the chapter's contraposition: given an
+anticonsistent valuation, choose an exact valuation knowledge-below it, win there classically,
+and transport the witness up along knowledge-monotonicity and bifilter closure. -/
 theorem stValid_iff_cValid (F : PrimeBifilter B) (Γ Δ : List (Fml α)) :
     STValid F Γ Δ ↔ CValid F Γ Δ := by
   constructor
   · intro hST v hv hΓ
-    obtain ⟨ψ, hψΔ, hψF, _⟩ := hST v (fun p => (hv p).isAnticonsistent) hΓ
+    obtain ⟨ψ, hψΔ, hψF, _⟩ := hST v (λ p => (hv p).isAnticonsistent) hΓ
     exact ⟨ψ, hψΔ, hψF, eval_isExact hv ψ⟩
   · intro hC v hv hΓ
-    choose v' hexact hle using fun p => (hv p).exists_exact_kLE
+    choose v' hexact hle using λ p => (hv p).exists_exact_kLE
     have hmono : ∀ φ : Fml α, φ.eval v' ≤ₖ φ.eval v := eval_kLE_eval hle
-    have hΓ' : ∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v') := fun φ hφ => by
+    have hΓ' : ∀ φ ∈ Γ, StrictlyDesignated F (φ.eval v') := λ φ hφ => by
       have hx := hΓ φ hφ
-      have heq : φ.eval v' = φ.eval v :=
-        (eval_isExact hexact φ).eq_of_kLE hx.2 (hmono φ)
+      have heq : φ.eval v' = φ.eval v := (eval_isExact hexact φ).eq_of_kLE hx.2 (hmono φ)
       rw [heq]; exact hx
     obtain ⟨ψ, hψΔ, hψF, _⟩ := hC v' hexact hΓ'
     exact ⟨ψ, hψΔ, F.mem_of_kLE hψF (hmono ψ), eval_isAnticonsistent hv ψ⟩
 
 omit [Interlaced B] [NegConfComm B] in
-/-- Cut is locally valid in `C⟨B,F⟩` ([fitting-2021] Prop 8.7.3): any
-valuation satisfying both premises of a cut instance satisfies its
-conclusion. -/
-theorem cut_cSatisfies (F : PrimeBifilter B) {Γ Δ : List (Fml α)} {A : Fml α}
-    {v : α → B} (h₁ : CSatisfies F v (A :: Γ) Δ) (h₂ : CSatisfies F v Γ (A :: Δ)) :
-    CSatisfies F v Γ Δ := by
+/-- Cut is locally valid in `C⟨B, F⟩` ([fitting-2021] Prop 8.7.3): a valuation satisfying both
+premises of a cut instance satisfies its conclusion. -/
+theorem cut_cSatisfies (F : PrimeBifilter B) {Γ Δ : List (Fml α)} {A : Fml α} {v : α → B}
+    (h₁ : CSatisfies F v (A :: Γ) Δ) (h₂ : CSatisfies F v Γ (A :: Δ)) : CSatisfies F v Γ Δ := by
   intro hΓ
   obtain ⟨ψ, hψ, hd⟩ := h₂ hΓ
   rcases List.mem_cons.mp hψ with rfl | hψΔ
-  · exact h₁ fun φ hφ => by
+  · exact h₁ λ φ hφ => by
       rcases List.mem_cons.mp hφ with rfl | h
       exacts [hd, hΓ _ h]
   · exact ⟨ψ, hψΔ, hd⟩
@@ -222,18 +219,16 @@ theorem cut_cSatisfies (F : PrimeBifilter B) {Γ Δ : List (Fml α)} {A : Fml α
 variable [BoundedOrder (Know B)]
 
 omit [Interlaced B] [NegConfComm B] in
-/-- **[fitting-2021] Prop 8.7.3, `ST` half**: the cut scheme fails locally in
-`ST⟨B,F⟩` (for a nontrivial knowledge order). The countermodel sends a letter
-to the knowledge top — designated and anticonsistent, but not exact — so both
-cut premises hold while the empty conclusion fails. -/
-theorem cut_not_local_stValid (F : PrimeBifilter B) (p : α)
-    (hbt : (⊥ : Know B) ≠ ⊤) :
+/-- [fitting-2021] Prop 8.7.3, the `ST` half: the cut scheme fails locally in `ST⟨B, F⟩` when the
+knowledge order is nontrivial. The countermodel sends a letter to the knowledge top — designated
+and anticonsistent but not exact — so both cut premises hold while the empty conclusion fails. -/
+theorem cut_not_local_stValid (F : PrimeBifilter B) (p : α) (hbt : (⊥ : Know B) ≠ ⊤) :
     ¬ ∀ v : α → B, (∀ q, IsAnticonsistent (v q)) →
       STSatisfies F v [.atom p] [] → STSatisfies F v [] [.atom p] →
       STSatisfies F v ([] : List (Fml α)) [] := by
   intro h
   set kT : B := ofKnow (⊤ : Know B) with hkT
-  have hle_top : ∀ x : B, x ≤ₖ kT := fun x => by
+  have hle_top : ∀ x : B, x ≤ₖ kT := λ x => by
     rw [hkT, kLE_def, toKnow_ofKnow]; exact le_top
   have hanti : IsAnticonsistent kT := hle_top _
   have hnexact : ¬ IsExact kT := by
@@ -245,96 +240,287 @@ theorem cut_not_local_stValid (F : PrimeBifilter B) (p : α)
   have hmem : kT ∈ F := by
     obtain ⟨a, ha⟩ := F.nonempty
     exact F.mem_of_kLE ha (hle_top a)
-  have hfinal := h (fun _ => kT) (fun _ => hanti)
-    (fun hΓ => absurd (hΓ _ (List.Mem.head _)).2 hnexact)
-    (fun _ => ⟨.atom p, List.Mem.head _, hmem, hanti⟩)
-  obtain ⟨ψ, hψ, -⟩ := hfinal (fun φ hφ => nomatch hφ)
+  have hfinal := h (λ _ => kT) (λ _ => hanti)
+    (λ hΓ => absurd (hΓ _ (List.Mem.head _)).2 hnexact)
+    (λ _ => ⟨.atom p, List.Mem.head _, hmem, hanti⟩)
+  obtain ⟨ψ, hψ, -⟩ := hfinal (λ φ hφ => nomatch hφ)
   exact nomatch hψ
 
 end Logics
 
-/-! ### The `FOUR` instance ([fitting-2021] Example 8.7.4)
+/-! ### Products of De Morgan algebras (§§8.8–8.9) -/
 
-Belnap's `FOUR` with the designated values `{t, ⊤}` is the paradigm logical
-bilattice: its exact values are the classical `{F, T}`, its anticonsistent
-values `{F, T, I}` (Priest's LP space), and the resulting logic pair is the
-original strict/tolerant logic of [cobreros-etal-2012] alongside classical
-logic. -/
+section DeMorgan
 
-section FOURInstance
+variable {L : Type*} [LatticeWithInvolution L]
 
-private theorem four_conf_conf : ∀ a : FOUR, FOUR.conf (FOUR.conf a) = a := by decide
-private theorem four_conf_le : ∀ a b : FOUR, a ≤ b → FOUR.conf a ≤ FOUR.conf b := by
+/-- [fitting-2021] Prop 8.8.3: the exact members of `L ⊙ L` are the pairs `⟨a, aᶜ⟩`, and under
+the truth order they are `L`. -/
+def exactIso : {x : L ⊙ L // IsExact x} ≃o L where
+  toFun x := x.1.pro
+  invFun a := ⟨mk a aᶜ, (Evidential.isExact_iff _).2 rfl⟩
+  left_inv x := Subtype.ext (Product.ext rfl ((Evidential.isExact_iff _).1 x.2).symm)
+  right_inv _ := rfl
+  map_rel_iff' {x y} := by
+    show x.1.pro ≤ y.1.pro ↔ x ≤ y
+    rw [← Subtype.coe_le_coe, le_def, (Evidential.isExact_iff _).1 x.2,
+      (Evidential.isExact_iff _).1 y.2, LatticeWithInvolution.compl_le_compl_iff_le, and_self]
+
+/-- A prime filter of `L` ([fitting-2021] Def 8.9.1): the designated values of a logical De Morgan
+algebra `⟨L, D⟩`, nonempty and proper as §8.2 requires. -/
+structure PrimeFilter (L : Type*) [Lattice L] where
+  /-- The designated values. -/
+  carrier : Set L
+  nonempty : carrier.Nonempty
+  ne_univ : carrier ≠ Set.univ
+  inf_mem_iff {a b : L} : a ⊓ b ∈ carrier ↔ a ∈ carrier ∧ b ∈ carrier
+  sup_mem_iff {a b : L} : a ⊔ b ∈ carrier ↔ a ∈ carrier ∨ b ∈ carrier
+
+instance : Membership L (PrimeFilter L) := ⟨λ D a => a ∈ D.carrier⟩
+
+/-- [fitting-2021] Lemma 8.9.2: `D × L` is a prime bifilter of `L ⊙ L`. -/
+def PrimeFilter.prod (D : PrimeFilter L) : PrimeBifilter (L ⊙ L) where
+  carrier := {x | x.pro ∈ D}
+  nonempty := let ⟨a, ha⟩ := D.nonempty; ⟨Product.mk a ⊥, ha⟩
+  ne_univ h := D.ne_univ (Set.eq_univ_of_forall λ a =>
+    (show Product.mk a ⊥ ∈ {x : L ⊙ L | x.pro ∈ D} from h ▸ Set.mem_univ _))
+  inf_mem_iff := D.inf_mem_iff
+  kInf_mem_iff := D.inf_mem_iff
+  sup_mem_iff := D.sup_mem_iff
+  kSup_mem_iff := D.sup_mem_iff
+
+theorem PrimeFilter.mem_prod_iff (D : PrimeFilter L) (x : L ⊙ L) : x ∈ D.prod ↔ x.pro ∈ D :=
+  Iff.rfl
+
+instance (D : PrimeFilter L) [DecidablePred (· ∈ D)] : DecidablePred (· ∈ D.prod) :=
+  λ x => inferInstanceAs (Decidable (x.pro ∈ D))
+
+/-- In `D × L` the strictly designated values are the exact pairs `⟨a, aᶜ⟩` with `a ∈ D`. -/
+theorem strictlyDesignated_prod_iff (D : PrimeFilter L) (x : L ⊙ L) :
+    StrictlyDesignated D.prod x ↔ x.pro ∈ D ∧ x.con = x.proᶜ :=
+  and_congr Iff.rfl (Evidential.isExact_iff x)
+
+/-- In `D × L` the tolerantly designated values are the anticonsistent pairs with `a ∈ D`. -/
+theorem tolerantlyDesignated_prod_iff (D : PrimeFilter L) (x : L ⊙ L) :
+    TolerantlyDesignated D.prod x ↔ x.pro ∈ D ∧ x.proᶜ ≤ x.con :=
+  and_congr Iff.rfl (Evidential.isAnticonsistent_iff x)
+
+/-- The logic `⟨L, D⟩`: formulas evaluated in `L` by meet, join and the De Morgan complement. -/
+def Fml.evalL (v : α → L) : Fml α → L
+  | atom p => v p
+  | and φ ψ => φ.evalL v ⊓ ψ.evalL v
+  | or φ ψ => φ.evalL v ⊔ ψ.evalL v
+  | not φ => (φ.evalL v)ᶜ
+
+/-- Validity in the logic `⟨L, D⟩` (§8.2): designated premises entail a designated conclusion. -/
+def LValid (D : PrimeFilter L) (Γ Δ : List (Fml α)) : Prop :=
+  ∀ v : α → L, (∀ φ ∈ Γ, φ.evalL v ∈ D) → ∃ ψ ∈ Δ, ψ.evalL v ∈ D
+
+/-- The exact valuation of `L ⊙ L` a valuation in `L` determines, `p ↦ ⟨v p, (v p)ᶜ⟩`. -/
+def exactVal (v : α → L) (p : α) : L ⊙ L := mk (v p) (v p)ᶜ
+
+theorem exactVal_isExact (v : α → L) (p : α) : IsExact (exactVal v p) :=
+  (Evidential.isExact_iff _).2 rfl
+
+/-- Exact valuations are exactly the `exactVal`s. -/
+theorem eq_exactVal_of_isExact {v : α → L ⊙ L} (hv : ∀ p, IsExact (v p)) :
+    v = exactVal λ p => (v p).pro :=
+  funext λ p => Product.ext rfl ((Evidential.isExact_iff _).1 (hv p))
+
+/-- Evaluation in `L ⊙ L` along an exact valuation is evaluation in `L`. -/
+theorem eval_exactVal (v : α → L) : ∀ φ : Fml α, φ.eval (exactVal v) = mk (φ.evalL v) (φ.evalL v)ᶜ
+  | .atom _ => rfl
+  | .and φ ψ => by
+    rw [Fml.eval, Fml.evalL, eval_exactVal v φ, eval_exactVal v ψ, mk_inf_mk,
+      LatticeWithInvolution.compl_inf]
+  | .or φ ψ => by
+    rw [Fml.eval, Fml.evalL, eval_exactVal v φ, eval_exactVal v ψ, mk_sup_mk,
+      LatticeWithInvolution.compl_sup]
+  | .not φ => by
+    rw [Fml.eval, Fml.evalL, eval_exactVal v φ, neg_mk', LatticeWithInvolution.compl_compl]
+
+/-- [fitting-2021] Prop 8.9.3: `C⟨L ⊙ L, D × L⟩` is the logic `⟨L, D⟩` — the two validate the same
+sequents, the exact values of the product corresponding to `L` and `(D × L) ∩ E` to `D`. -/
+theorem cValid_prod_iff (D : PrimeFilter L) (Γ Δ : List (Fml α)) :
+    CValid D.prod Γ Δ ↔ LValid D Γ Δ := by
+  constructor
+  · intro h v hΓ
+    obtain ⟨ψ, hψ, hD, -⟩ := h (exactVal v) (exactVal_isExact v) λ φ hφ =>
+      ⟨by rw [PrimeFilter.mem_prod_iff, eval_exactVal, pro_mk]; exact hΓ φ hφ,
+        eval_isExact (exactVal_isExact v) φ⟩
+    rw [PrimeFilter.mem_prod_iff, eval_exactVal, pro_mk] at hD
+    exact ⟨ψ, hψ, hD⟩
+  · intro h v hv hΓ
+    rw [eq_exactVal_of_isExact hv] at hΓ ⊢
+    obtain ⟨ψ, hψ, hD⟩ := h (λ p => (v p).pro) λ φ hφ => by
+      have := (hΓ φ hφ).1
+      rwa [PrimeFilter.mem_prod_iff, eval_exactVal, pro_mk] at this
+    exact ⟨ψ, hψ, by rw [PrimeFilter.mem_prod_iff, eval_exactVal, pro_mk]; exact hD,
+      eval_isExact (exactVal_isExact _) ψ⟩
+
+/-! ### Generating strict/tolerant examples (§8.10) -/
+
+/-- [fitting-2021] Prop 8.10.1: the strict/tolerant counterpart `ST⟨L ⊙ L, D × L⟩` of a logical
+De Morgan algebra `⟨L, D⟩` has the same consequence relation. -/
+theorem stValid_prod_iff (D : PrimeFilter L) (Γ Δ : List (Fml α)) :
+    STValid D.prod Γ Δ ↔ LValid D Γ Δ :=
+  (stValid_iff_cValid _ _ _).trans (cValid_prod_iff D Γ Δ)
+
+/-- [fitting-2021] Prop 8.10.1: and it differs at the metaconsequence level — cut fails locally in
+the counterpart. -/
+theorem cut_not_local_prod [Nontrivial L] (D : PrimeFilter L) (p : α) :
+    ¬ ∀ v : α → L ⊙ L, (∀ q, IsAnticonsistent (v q)) →
+      STSatisfies D.prod v [.atom p] [] → STSatisfies D.prod v [] [.atom p] →
+      STSatisfies D.prod v ([] : List (Fml α)) [] :=
+  cut_not_local_stValid D.prod p λ h =>
+    bot_ne_top (congrArg (λ k : Know (L ⊙ L) => (ofKnow k).pro) h)
+
+end DeMorgan
+
+/-! ### Examples 8.10.2–8.10.5: classical logic, `K3`, `LP` and `FDE` -/
+
+section Examples
+
+/-- Classical logic as a logical De Morgan algebra: `Bool` with `{true}` designated. -/
+def classicalFilter : PrimeFilter Bool where
+  carrier := {b | b = true}
+  nonempty := ⟨true, rfl⟩
+  ne_univ h := absurd (h ▸ Set.mem_univ false) (by decide)
+  inf_mem_iff {a b} := by revert a b; decide
+  sup_mem_iff {a b} := by revert a b; decide
+
+instance : DecidablePred (· ∈ classicalFilter) := λ b => inferInstanceAs (Decidable (b = true))
+
+/-- The designated values `{t, ⊤}` of `FOUR` ([fitting-2021] Example 8.7.4) are `{true} × Bool`
+([fitting-2021] Example 8.10.2). -/
+abbrev fourBifilter : PrimeBifilter FOUR := classicalFilter.prod
+
+theorem mem_fourBifilter_iff : ∀ x : FOUR, x ∈ fourBifilter ↔ x = FOUR.T ∨ x = FOUR.I := by
   decide
-private theorem four_conf_kLE : ∀ a b : FOUR, a ≤ₖ b → FOUR.conf b ≤ₖ FOUR.conf a := by
-  decide
 
-/-- Boolean-complement conflation makes `FOUR` a bilattice with conflation. -/
-instance : Conflation FOUR where
-  conf := FOUR.conf
-  conf_conf := four_conf_conf
-  conf_le_conf {a b} h := four_conf_le a b h
-  conf_kLE_conf {a b} h := four_conf_kLE a b h
+/-- `FOUR`'s exact values are the classical `{F, T}` ([fitting-2021] Example 8.7.4). -/
+theorem four_isExact_iff : ∀ x : FOUR, IsExact x ↔ x = FOUR.F ∨ x = FOUR.T := by decide
 
-/-- Negation and conflation commute on `FOUR`. -/
-instance : NegConfComm FOUR where
-  neg_conf := by decide
-
-/-- `FOUR`'s exact values are the classical `{F, T}`
-([fitting-2021] Example 8.7.4). -/
-theorem four_isExact_iff : ∀ x : FOUR, IsExact x ↔ x = FOUR.F ∨ x = FOUR.T := by
-  decide
-
-/-- `FOUR`'s anticonsistent values are `{F, T, I}` — Priest's LP value space
+/-- `FOUR`'s anticonsistent values are `{F, T, I}`, the value space of `LP`
 ([fitting-2021] Example 8.7.4). -/
 theorem four_isAnticonsistent_iff :
     ∀ x : FOUR, IsAnticonsistent x ↔ x = FOUR.F ∨ x = FOUR.T ∨ x = FOUR.I := by
   decide
 
-private theorem four_bif_inf : ∀ a b : FOUR,
-    (a ⊓ b = FOUR.T ∨ a ⊓ b = FOUR.I) ↔
-      ((a = FOUR.T ∨ a = FOUR.I) ∧ (b = FOUR.T ∨ b = FOUR.I)) := by decide
-private theorem four_bif_kInf : ∀ a b : FOUR,
-    ((a ⊗ b : FOUR) = FOUR.T ∨ (a ⊗ b : FOUR) = FOUR.I) ↔
-      ((a = FOUR.T ∨ a = FOUR.I) ∧ (b = FOUR.T ∨ b = FOUR.I)) := by decide
-private theorem four_bif_sup : ∀ a b : FOUR,
-    (a ⊔ b = FOUR.T ∨ a ⊔ b = FOUR.I) ↔
-      ((a = FOUR.T ∨ a = FOUR.I) ∨ (b = FOUR.T ∨ b = FOUR.I)) := by decide
-private theorem four_bif_kSup : ∀ a b : FOUR,
-    ((a ⊕ b : FOUR) = FOUR.T ∨ (a ⊕ b : FOUR) = FOUR.I) ↔
-      ((a = FOUR.T ∨ a = FOUR.I) ∨ (b = FOUR.T ∨ b = FOUR.I)) := by decide
-
-/-- The designated values `{t, ⊤}` of `FOUR` form a prime bifilter
-([fitting-2021] Example 8.7.4; the designated-value choice of
-[arieli-avron-1996]). -/
-def fourBifilter : PrimeBifilter FOUR where
-  carrier := {x | x = FOUR.T ∨ x = FOUR.I}
-  nonempty := ⟨FOUR.T, Or.inl rfl⟩
-  ne_univ h := by
-    have : FOUR.U ∈ ({x | x = FOUR.T ∨ x = FOUR.I} : Set FOUR) :=
-      h ▸ Set.mem_univ FOUR.U
-    exact absurd this (by decide)
-  inf_mem_iff {a b} := four_bif_inf a b
-  kInf_mem_iff {a b} := four_bif_kInf a b
-  sup_mem_iff {a b} := four_bif_sup a b
-  kSup_mem_iff {a b} := four_bif_kSup a b
-
-/-- The original strict/tolerant collapse ([cobreros-etal-2012], via
-[fitting-2021] Example 8.7.4): over `FOUR` with designated `{t, ⊤}`, `ST` and
-classical logic validate exactly the same sequents. -/
+/-- The original collapse ([cobreros-etal-2012], via [fitting-2021] Example 8.7.4): `ST` and
+classical logic validate the same sequents. -/
 theorem four_stValid_iff_cValid {α : Type*} (Γ Δ : List (Fml α)) :
     STValid fourBifilter Γ Δ ↔ CValid fourBifilter Γ Δ :=
   stValid_iff_cValid fourBifilter Γ Δ
 
-/-- And the pair separates at the metaconsequence level: cut fails locally in
-`ST` over `FOUR`. -/
+/-- And cut fails locally in `ST` over `FOUR`. -/
 theorem four_cut_not_local {α : Type*} (p : α) :
     ¬ ∀ v : α → FOUR, (∀ q, IsAnticonsistent (v q)) →
-      STSatisfies fourBifilter v [.atom p] [] →
-      STSatisfies fourBifilter v [] [.atom p] →
+      STSatisfies fourBifilter v [.atom p] [] → STSatisfies fourBifilter v [] [.atom p] →
       STSatisfies fourBifilter v ([] : List (Fml α)) [] :=
-  cut_not_local_stValid fourBifilter p (by decide)
+  cut_not_local_prod classicalFilter p
 
-end FOURInstance
+/-- `K3`, Kleene's strong three-valued logic: `Trivalent` with `{true}` designated
+([fitting-2021] Example 8.10.3). -/
+def k3Filter : PrimeFilter Trivalent where
+  carrier := {a | a = .true}
+  nonempty := ⟨.true, rfl⟩
+  ne_univ h := absurd (h ▸ Set.mem_univ Trivalent.false) (by decide)
+  inf_mem_iff {a b} := by revert a b; decide
+  sup_mem_iff {a b} := by revert a b; decide
+
+instance : DecidablePred (· ∈ k3Filter) := λ a => inferInstanceAs (Decidable (a = .true))
+
+/-- `LP`, Priest's logic of paradox ([priest-1979]): the same values with `{½, 1}` designated
+([fitting-2021] Example 8.10.4). -/
+def lpFilter : PrimeFilter Trivalent where
+  carrier := {a | a ≠ .false}
+  nonempty := ⟨.true, by decide⟩
+  ne_univ h := absurd (h ▸ Set.mem_univ Trivalent.false) (by decide)
+  inf_mem_iff {a b} := by revert a b; decide
+  sup_mem_iff {a b} := by revert a b; decide
+
+instance : DecidablePred (· ∈ lpFilter) := λ a => inferInstanceAs (Decidable (a ≠ .false))
+
+/-- The bilattice `NINE = Trivalent ⊙ Trivalent` of Figure 4 ([fitting-2021] Example 8.10.3). -/
+abbrev NINE := Trivalent ⊙ Trivalent
+
+/-- `NINE`'s exact values are `{f, d⊤, t}` ([fitting-2021] §8.5). -/
+theorem nine_isExact_iff : ∀ x : NINE,
+    IsExact x ↔ x = mk .false .true ∨ x = mk .indet .indet ∨ x = mk .true .false := by
+  decide
+
+/-- `NINE`'s consistent values are the exact ones with `{df, ⊥, dt}` ([fitting-2021] §8.5). -/
+theorem nine_isConsistent_iff : ∀ x : NINE, IsConsistent x ↔ IsExact x ∨
+    x = mk .false .indet ∨ x = mk .false .false ∨ x = mk .indet .false := by
+  decide
+
+/-- `NINE`'s anticonsistent values are the exact ones with `{of, ⊤, ot}`
+([fitting-2021] §8.5). -/
+theorem nine_isAnticonsistent_iff : ∀ x : NINE, IsAnticonsistent x ↔ IsExact x ∨
+    x = mk .indet .true ∨ x = mk .true .true ∨ x = mk .true .indet := by
+  decide
+
+/-- The two prime bifilters of `NINE` ([fitting-2021] Examples 8.7.5 and 8.10.4): `{t, ot, ⊤}`
+from `K3` and the six-element `{dt, t, d⊤, ot, of, ⊤}` from `LP`. -/
+theorem nine_bifilters : (∀ x : NINE, x ∈ k3Filter.prod ↔
+      x = mk .true .false ∨ x = mk .true .indet ∨ x = mk .true .true) ∧
+    ∀ x : NINE, x ∈ lpFilter.prod ↔ x = mk .indet .false ∨ x = mk .true .false ∨
+      x = mk .indet .indet ∨ x = mk .true .indet ∨ x = mk .indet .true ∨ x = mk .true .true := by
+  decide
+
+/-- With `K3` the strictly designated values reduce to `{t}`, so `C⟨NINE, {1} × K3⟩` is `K3`
+([fitting-2021] Example 8.7.5). -/
+theorem k3_strict_iff : ∀ x : NINE, StrictlyDesignated k3Filter.prod x ↔ x = mk .true .false := by
+  decide
+
+/-- With `LP` the strictly designated values are `{d⊤, t}` and the tolerantly designated ones
+`{t, d⊤, ot, of, ⊤}` ([fitting-2021] Example 8.10.4). -/
+theorem lp_designated : (∀ x : NINE, StrictlyDesignated lpFilter.prod x ↔
+      x = mk .indet .indet ∨ x = mk .true .false) ∧
+    ∀ x : NINE, TolerantlyDesignated lpFilter.prod x ↔ x = mk .true .false ∨
+      x = mk .indet .indet ∨ x = mk .true .indet ∨ x = mk .indet .true ∨ x = mk .true .true := by
+  decide
+
+/-- `P, ¬P ⇒ Q` fails in strict/tolerant `LP` as in `LP`: `v(P) = d⊤`, `v(Q) = f`
+([fitting-2021] Example 8.10.4). -/
+theorem lp_explosion_fails :
+    ¬ STValid lpFilter.prod [.atom true, .not (.atom true)] [.atom false] := λ h =>
+  absurd (h (λ b => if b then mk .indet .indet else mk .false .true) (by decide) (by decide))
+    (by decide)
+
+/-- `FDE` as a logical De Morgan algebra: `FOUR` under the truth order with `{t, ⊤}` designated
+([fitting-2021] Example 8.10.5). -/
+def fdeFilter : PrimeFilter FOUR where
+  carrier := {x | x = FOUR.T ∨ x = FOUR.I}
+  nonempty := ⟨FOUR.T, Or.inl rfl⟩
+  ne_univ h := absurd (h ▸ Set.mem_univ FOUR.U) (by decide)
+  inf_mem_iff {a b} := by revert a b; decide
+  sup_mem_iff {a b} := by revert a b; decide
+
+instance : DecidablePred (· ∈ fdeFilter) :=
+  λ x => inferInstanceAs (Decidable (x = FOUR.T ∨ x = FOUR.I))
+
+/-- The bilattice `SIXTEEN = FOUR ⊙ FOUR` of Figure 6 ([fitting-2021] Example 8.10.5). -/
+abbrev SIXTEEN := FOUR ⊙ FOUR
+
+
+/-- `FDE`'s strict/tolerant counterpart validates exactly the sequents of `FDE`
+([fitting-2021] Example 8.10.5). -/
+theorem fde_stValid_iff {α : Type*} (Γ Δ : List (Fml α)) :
+    STValid fdeFilter.prod Γ Δ ↔ LValid fdeFilter Γ Δ :=
+  stValid_prod_iff fdeFilter Γ Δ
+
+/-- Not every value is exact, consistent or anticonsistent: `⟨⊥, ⊤⟩` and `⟨⊤, ⊥⟩` of `SIXTEEN` are
+none ([fitting-2021] §8.5, Example 8.10.5). -/
+theorem sixteen_neither :
+    ¬ IsConsistent (mk FOUR.U FOUR.I : SIXTEEN) ∧
+      ¬ IsAnticonsistent (mk FOUR.U FOUR.I : SIXTEEN) ∧
+      ¬ IsConsistent (mk FOUR.I FOUR.U : SIXTEEN) ∧
+      ¬ IsAnticonsistent (mk FOUR.I FOUR.U : SIXTEEN) := by
+  simp only [Evidential.isConsistent_iff, Evidential.isAnticonsistent_iff]
+  decide
+
+end Examples
 
 end Fitting2021

--- a/references.bib
+++ b/references.bib
@@ -24621,7 +24621,7 @@
   doi       = {10.1007/s10992-010-9165-z},
   subfield  = {philosophical logic},
   role      = {primary},
-  sources   = {Studies/CobrerosEtAl2012.lean;Logic/Consequence.lean;Logic/Bilateral/Classical.lean;Logic/Trivalent/Propositional.lean;Core/Data/Trivalent.lean},
+  sources   = {Core/Data/Trivalent.lean;Logic/Bilateral/Classical.lean;Logic/Consequence.lean;Logic/Trivalent/Propositional.lean;Semantics/Degree/Delineation.lean;Studies/CobrerosEtAl2012.lean;Studies/Fitting2021.lean;Studies/LassiterGoodman2017.lean},
 }
 @article{alxatib-pelletier-2011,
   author    = {Alxatib, Sam and Pelletier, Francis Jeffry},
@@ -40980,6 +40980,18 @@
   sources   = {Core/Data/Trivalent.lean;Core/Order/Bilattice/Basic.lean;Core/Order/Bilattice/Interlaced.lean;Studies/Fitting1994.lean}
 }
 
+@article{priest-1979,
+  author    = {Priest, Graham},
+  year      = {1979},
+  title     = {The Logic of Paradox},
+  journal   = {Journal of Philosophical Logic},
+  volume    = {8},
+  number    = {1},
+  pages     = {219--241},
+  subfield  = {semantics/vagueness},
+  role      = {cited},
+  sources   = {Studies/Fitting2021.lean}
+}
 @incollection{fitting-2021,
   author    = {Fitting, Melvin},
   title     = {The Strict/Tolerant Idea and Bilattices},
@@ -40993,7 +41005,7 @@
   doi       = {10.1007/978-3-030-71258-7_8},
   subfield  = {semantics/vagueness},
   role      = {formalized},
-  sources   = {Studies/Fitting2021.lean}
+  sources   = {Core/Order/Bilattice/Basic.lean;Core/Order/Bilattice/Interlaced.lean;Studies/Fitting2021.lean}
 }
 
 @article{arieli-avron-1998,
@@ -41105,7 +41117,7 @@
   doi       = {10.1007/BF00215626},
   subfield  = {semantics/presupposition},
   role      = {cited},
-  sources   = {Core/Logic/Bilattice/Basic.lean}
+  sources   = {Core/Order/Bilattice/Basic.lean;Studies/Fitting2021.lean}
 }
 
 @incollection{belnap-1977,
@@ -41119,7 +41131,7 @@
   doi       = {10.1007/978-94-010-1161-7_2},
   subfield  = {semantics/presupposition},
   role      = {cited},
-  sources   = {Core/Order/Bilattice/Basic.lean;Studies/Fitting1994.lean}
+  sources   = {Core/Order/Bilattice/Basic.lean;Studies/Fitting1994.lean;Studies/Fitting2021.lean}
 }
 
 @article{ginsberg-1988,


### PR DESCRIPTION
Deep cleanse of Fitting2021 against the chapter (preprint via the author's site): the old file stopped at Prop 8.7.3 and the `FOUR` example; the recut adds the chapter's second half — the exact members of `L ⊙ L` are `L`, `D × L` is a prime bifilter, the classical-like logic of the product is the original logic, so every logical De Morgan algebra has a strict/tolerant counterpart — with the substrate both Fitting studies stipulated now shared.

- §§8.8–8.10: `exactIso` (Prop 8.8.3), `PrimeFilter`/`PrimeFilter.prod` (Def 8.9.1, Lemma 8.9.2), `Fml.evalL`/`LValid` with `cValid_prod_iff` (Prop 8.9.3) and `stValid_prod_iff`/`cut_not_local_prod` (Prop 8.10.1); Examples 8.10.2–8.10.5 as `classicalFilter`, `k3Filter`, `lpFilter`, `fdeFilter` with the `NINE` value classes, `NINE`'s two prime bifilters, the `LP` explosion counterexample, and the two `SIXTEEN` values in no class
- Substrate: `Conflation`/`NegConfComm` instances on `Evidential S` from a De Morgan complement, `Evidential S` itself as a lattice with involution (`FOUR` under `≤ₜ`), coordinate lemmas `isExact_iff`/`isConsistent_iff`/`isAnticonsistent_iff`, decidability of the consistent classes; Fitting1994 §§7 and 9 now cite these instead of restating them
- Header in the mathlib register; `priest-1979` added
