### PR TITLE
refactor(Studies/Fox2018): question partition matching over Hamblin sets

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1825,6 +1825,7 @@ import Linglib.Semantics.Quantification.Syllogistic.Trees
 import Linglib.Semantics.Quantification.UnifiedUniversal
 import Linglib.Semantics.Questions.Basic
 import Linglib.Semantics.Questions.Bias
+import Linglib.Semantics.Questions.Closure
 import Linglib.Semantics.Questions.Entailment
 import Linglib.Semantics.Questions.Exhaustivity
 import Linglib.Semantics.Questions.Hamblin
@@ -3060,3 +3061,4 @@ import Linglib.Data.Examples.Filip2012
 import Linglib.Data.Examples.Flemming2021
 import Linglib.Data.Examples.Fortuny2024
 import Linglib.Data.Examples.Fox2007
+import Linglib.Data.Examples.Fox2018

--- a/Linglib/Data/Examples/Fox2018.json
+++ b/Linglib/Data/Examples/Fox2018.json
@@ -1,0 +1,411 @@
+[
+  {
+    "id": "fox2018_ex16a",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(16a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Tell me how fast you drove.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "family",
+        "degree"
+      ],
+      [
+        "negation",
+        "no"
+      ],
+      [
+        "modal",
+        "no"
+      ],
+      [
+        "number",
+        "na"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "fox2018_ex16b",
+    "source": {
+      "bibkey": "fox-hackl-2006",
+      "paperLabel": "negative islands"
+    },
+    "language": "stan1293",
+    "primaryText": "Tell me how fast you didn't drive.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "family",
+        "degree"
+      ],
+      [
+        "negation",
+        "yes"
+      ],
+      [
+        "modal",
+        "no"
+      ],
+      [
+        "number",
+        "na"
+      ],
+      [
+        "blocked",
+        "yes"
+      ]
+    ],
+    "comment": "No smallest degree above the actual speed: no maximally informative true member.",
+    "reportedIn": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(16b)"
+    }
+  },
+  {
+    "id": "fox2018_ex16c",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(16c)"
+    },
+    "language": "stan1293",
+    "primaryText": "Tell me how fast you are not allowed to drive.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "family",
+        "degree"
+      ],
+      [
+        "negation",
+        "yes"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "na"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": "The modal base can entail a least bound, so maximality can be met."
+  },
+  {
+    "id": "fox2018_ex24",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(24)"
+    },
+    "language": "stan1293",
+    "primaryText": "What are you required to read for this class? -- War and Peace or Brothers Karamazov.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "required > or",
+        "judgment": "acceptable"
+      },
+      {
+        "name": "or > required",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "no"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "neutral"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": "Both scopes: the trace may range over individuals or over generalized quantifiers."
+  },
+  {
+    "id": "fox2018_ex26",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(26)"
+    },
+    "language": "stan1293",
+    "primaryText": "What did you not read for this class? -- War and Peace or Brothers Karamazov.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not > or",
+        "judgment": "unacceptable"
+      },
+      {
+        "name": "or > not",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "yes"
+      ],
+      [
+        "modal",
+        "no"
+      ],
+      [
+        "number",
+        "neutral"
+      ],
+      [
+        "blocked",
+        "yes"
+      ]
+    ],
+    "comment": "The higher-order denotation always contains the weak negated conjunction (28), which identifies no cell: Non-Vacuity fails."
+  },
+  {
+    "id": "fox2018_ex27",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(27)"
+    },
+    "language": "stan1293",
+    "primaryText": "What are you not allowed to read for this class? -- War and Peace or Brothers Karamazov.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not > or",
+        "judgment": "acceptable"
+      },
+      {
+        "name": "or > not",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "yes"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "neutral"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": "Marked ? for the narrow-scope reading; the necessity modal lets (29) be the strongest true member."
+  },
+  {
+    "id": "fox2018_ex47a",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(47a)"
+    },
+    "language": "stan1293",
+    "primaryText": "What are you required to read for this class? -- War and Peace or Brothers Karamazov.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "required > or",
+        "judgment": "acceptable"
+      },
+      {
+        "name": "or > required",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "no"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "neutral"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "fox2018_ex47b",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(47b)"
+    },
+    "language": "stan1293",
+    "primaryText": "Which books are you required to read for this class? -- The Russian books or the French books.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "required > or",
+        "judgment": "acceptable"
+      },
+      {
+        "name": "or > required",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "no"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "plural"
+      ],
+      [
+        "blocked",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "fox2018_ex48",
+    "source": {
+      "bibkey": "fox-2018",
+      "paperLabel": "(48)"
+    },
+    "language": "stan1293",
+    "primaryText": "Which book are you required to read for this class? -- War and Peace or Brothers Karamazov.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "required > or",
+        "judgment": "unacceptable"
+      },
+      {
+        "name": "or > required",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "family",
+        "higherOrder"
+      ],
+      [
+        "negation",
+        "no"
+      ],
+      [
+        "modal",
+        "yes"
+      ],
+      [
+        "number",
+        "singular"
+      ],
+      [
+        "blocked",
+        "yes"
+      ]
+    ],
+    "comment": "Singular wh-phrases cannot quantify over higher-type traces."
+  }
+]

--- a/Linglib/Data/Examples/Fox2018.lean
+++ b/Linglib/Data/Examples/Fox2018.lean
@@ -1,0 +1,180 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Fox2018` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Fox2018.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Fox2018.Examples`.
+-/
+
+namespace Fox2018.Examples
+
+open Data.Examples
+
+def ex16a : LinguisticExample :=
+  { id := "fox2018_ex16a"
+    source := ⟨"fox-2018", "(16a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Tell me how fast you drove."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("family", "degree"), ("negation", "no"), ("modal", "no"), ("number", "na"), ("blocked", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16b : LinguisticExample :=
+  { id := "fox2018_ex16b"
+    source := ⟨"fox-hackl-2006", "negative islands"⟩
+    reportedIn := some ⟨"fox-2018", "(16b)"⟩
+    language := "stan1293"
+    primaryText := "Tell me how fast you didn't drive."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("family", "degree"), ("negation", "yes"), ("modal", "no"), ("number", "na"), ("blocked", "yes")]
+    comment := "No smallest degree above the actual speed: no maximally informative true member."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16c : LinguisticExample :=
+  { id := "fox2018_ex16c"
+    source := ⟨"fox-2018", "(16c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Tell me how fast you are not allowed to drive."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("family", "degree"), ("negation", "yes"), ("modal", "yes"), ("number", "na"), ("blocked", "no")]
+    comment := "The modal base can entail a least bound, so maximality can be met."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex24 : LinguisticExample :=
+  { id := "fox2018_ex24"
+    source := ⟨"fox-2018", "(24)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "What are you required to read for this class? -- War and Peace or Brothers Karamazov."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("required > or", .acceptable), ("or > required", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "no"), ("modal", "yes"), ("number", "neutral"), ("blocked", "no")]
+    comment := "Both scopes: the trace may range over individuals or over generalized quantifiers."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex26 : LinguisticExample :=
+  { id := "fox2018_ex26"
+    source := ⟨"fox-2018", "(26)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "What did you not read for this class? -- War and Peace or Brothers Karamazov."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not > or", .unacceptable), ("or > not", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "yes"), ("modal", "no"), ("number", "neutral"), ("blocked", "yes")]
+    comment := "The higher-order denotation always contains the weak negated conjunction (28), which identifies no cell: Non-Vacuity fails."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex27 : LinguisticExample :=
+  { id := "fox2018_ex27"
+    source := ⟨"fox-2018", "(27)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "What are you not allowed to read for this class? -- War and Peace or Brothers Karamazov."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not > or", .acceptable), ("or > not", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "yes"), ("modal", "yes"), ("number", "neutral"), ("blocked", "no")]
+    comment := "Marked ? for the narrow-scope reading; the necessity modal lets (29) be the strongest true member."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex47a : LinguisticExample :=
+  { id := "fox2018_ex47a"
+    source := ⟨"fox-2018", "(47a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "What are you required to read for this class? -- War and Peace or Brothers Karamazov."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("required > or", .acceptable), ("or > required", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "no"), ("modal", "yes"), ("number", "neutral"), ("blocked", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex47b : LinguisticExample :=
+  { id := "fox2018_ex47b"
+    source := ⟨"fox-2018", "(47b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Which books are you required to read for this class? -- The Russian books or the French books."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("required > or", .acceptable), ("or > required", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "no"), ("modal", "yes"), ("number", "plural"), ("blocked", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex48 : LinguisticExample :=
+  { id := "fox2018_ex48"
+    source := ⟨"fox-2018", "(48)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Which book are you required to read for this class? -- War and Peace or Brothers Karamazov."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("required > or", .unacceptable), ("or > required", .acceptable)]
+    paperFeatures := [("family", "higherOrder"), ("negation", "no"), ("modal", "yes"), ("number", "singular"), ("blocked", "yes")]
+    comment := "Singular wh-phrases cannot quantify over higher-type traces."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex16a, ex16b, ex16c, ex24, ex26, ex27, ex47a, ex47b, ex48]
+
+end Fox2018.Examples

--- a/Linglib/Semantics/Exhaustification/InnocentExclusion.lean
+++ b/Linglib/Semantics/Exhaustification/InnocentExclusion.lean
@@ -340,6 +340,19 @@ theorem mem_exhIE_iff (hfin : ALT.Finite) {u : World} :
   · exact hu
   · exact h a ⟨ha, hψ⟩
 
+/-- With the innocently excludable alternatives characterized, the exhaustifier denies exactly
+them. -/
+theorem exhIE_eq_of_iff (hfin : ALT.Finite) {P : Set World → Prop}
+    (h : ∀ q ∈ ALT, IsInnocentlyExcludable ALT φ q ↔ P q) :
+    exhIE ALT φ = {w | w ∈ φ ∧ ∀ q ∈ ALT, P q → w ∉ q} := by
+  ext w
+  rw [mem_exhIE_iff ALT φ hfin]
+  constructor
+  · rintro ⟨hw, h'⟩
+    exact ⟨hw, λ q hq hP => h' q ((h q hq).2 hP)⟩
+  · rintro ⟨hw, h'⟩
+    exact ⟨hw, λ q hq => h' q hq.1 ((h q hq.1).1 hq)⟩
+
 
 /-- A world is minimal iff it verifies some maximal compatible set. -/
 theorem mem_exhMW_iff_exists_isMCSet (u : World) :

--- a/Linglib/Semantics/Exhaustification/InnocentInclusion.lean
+++ b/Linglib/Semantics/Exhaustification/InnocentInclusion.lean
@@ -234,6 +234,39 @@ theorem exhIEII_singleton (hsat : ∃ w, φ w) : exhIEII {φ} φ = φ := by
   · rw [Set.mem_singleton_iff.1 hr.1]; exact hw
 
 
+/-! ### Cells from a characterization of innocent exclusion -/
+
+/-- With the innocently excludable alternatives characterized, the cell denies them and asserts
+the rest. -/
+theorem cell_eq_of_iff {P : Set World → Prop}
+    (h : ∀ q ∈ ALT, IsInnocentlyExcludable ALT φ q ↔ P q) :
+    cell ALT φ = {w | w ∈ φ ∧ ∀ q ∈ ALT, (w ∈ q ↔ ¬ P q)} := by
+  ext w
+  constructor
+  · rintro ⟨hw, hIE, hne⟩
+    exact ⟨hw, λ q hq => ⟨λ hwq hP => hIE q ((h q hq).2 hP) hwq,
+      λ hP => hne q ⟨hq, λ hIE' => hP ((h q hq).1 hIE')⟩⟩⟩
+  · rintro ⟨hw, h'⟩
+    exact ⟨hw, λ q hIE hwq => (h' q hIE.1).1 hwq ((h q hIE.1).1 hIE),
+      λ r hr => (h' r hr.1).2 λ hP => hr.2 ((h r hr.1).2 hP)⟩
+
+/-- Over alternatives indexed by a family, the cell denies the indices characterized as
+innocently excludable and asserts the rest. -/
+theorem cell_image_eq {ι : Type*} {f : ι → Set World} {I : Set ι} {P : ι → Prop}
+    (h : ∀ i ∈ I, IsInnocentlyExcludable (f '' I) φ (f i) ↔ P i) :
+    cell (f '' I) φ = {w | w ∈ φ ∧ ∀ i ∈ I, (w ∈ f i ↔ ¬ P i)} := by
+  ext w
+  constructor
+  · rintro ⟨hw, hIE, hne⟩
+    exact ⟨hw, λ i hi => ⟨λ hwi hP => hIE _ ((h i hi).2 hP) hwi,
+      λ hP => hne _ ⟨⟨i, hi, rfl⟩, λ hIE' => hP ((h i hi).1 hIE')⟩⟩⟩
+  · rintro ⟨hw, h'⟩
+    refine ⟨hw, λ q hIE => ?_, λ r hr => ?_⟩
+    · obtain ⟨i, hi, rfl⟩ := hIE.1
+      exact λ hwi => (h' i hi).1 hwi ((h i hi).1 hIE)
+    · obtain ⟨i, hi, rfl⟩ := hr.1
+      exact (h' i hi).2 λ hP => hr.2 ((h i hi).2 hP)
+
 /-! ### Representative minimal worlds -/
 
 section MinimalCover

--- a/Linglib/Semantics/Questions/Closure.lean
+++ b/Linglib/Semantics/Questions/Closure.lean
@@ -1,0 +1,102 @@
+import Linglib.Semantics.Questions.Exhaustivity
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Order.CompleteLattice.Finset
+
+/-!
+# Hamblin sets closed under conjunction or disjunction
+
+A wh-question over atomic answers `a i` denotes, under [dayal-1996]'s sum-closed restrictor,
+the family of conjunctions `conj a S` over non-empty groups `S`; under [spector-2008]'s
+higher-order quantification (pruned to disjunctions of atoms, as in [fox-2018]) it denotes the
+family of disjunctions `disj a S`. Both families are read off a world's `profile`, the atoms
+true there, and both induce the same strong answers.
+
+## References
+
+* [dayal-1996]
+* [spector-2008]
+* [fox-2007]
+* [fox-2018]
+-/
+
+namespace Questions
+
+variable {W ι : Type*} (a : ι → Set W)
+
+/-- The atoms true at a world. -/
+def profile (w : W) : Set ι := {i | w ∈ a i}
+
+/-- The conjunction of the atoms in a group. -/
+def conj (S : Finset ι) : Set W := ⋂ i ∈ S, a i
+
+/-- The disjunction of the atoms in a group. -/
+def disj (S : Finset ι) : Set W := ⋃ i ∈ S, a i
+
+/-- The Hamblin set closed under conjunction: one member per non-empty group. -/
+def conjClosure : Set (Set W) := conj a '' {S | S.Nonempty}
+
+/-- The Hamblin set closed under disjunction: one member per non-empty group. -/
+def disjClosure : Set (Set W) := disj a '' {S | S.Nonempty}
+
+variable {a}
+
+@[simp] theorem mem_profile {w : W} {i : ι} : i ∈ profile a w ↔ w ∈ a i := Iff.rfl
+
+theorem mem_conj {S : Finset ι} {w : W} : w ∈ conj a S ↔ ∀ i ∈ S, w ∈ a i := Set.mem_iInter₂
+
+theorem mem_disj {S : Finset ι} {w : W} : w ∈ disj a S ↔ ∃ i ∈ S, w ∈ a i := by simp [disj]
+
+theorem mem_conj_iff_subset {S : Finset ι} {w : W} : w ∈ conj a S ↔ ↑S ⊆ profile a w :=
+  mem_conj.trans ⟨λ h _ hi => h _ hi, λ h _ hi => h hi⟩
+
+theorem conj_singleton (i : ι) : conj a {i} = a i := Finset.set_biInter_singleton i a
+
+theorem disj_singleton (i : ι) : disj a {i} = a i := Finset.set_biUnion_singleton i a
+
+theorem conj_mem_conjClosure {S : Finset ι} (hS : S.Nonempty) : conj a S ∈ conjClosure a :=
+  ⟨S, hS, rfl⟩
+
+theorem disj_mem_disjClosure {S : Finset ι} (hS : S.Nonempty) : disj a S ∈ disjClosure a :=
+  ⟨S, hS, rfl⟩
+
+theorem conjClosure_finite [Fintype ι] : (conjClosure a).Finite :=
+  (Set.toFinite {S : Finset ι | S.Nonempty}).image _
+
+theorem disjClosure_finite [Fintype ι] : (disjClosure a).Finite :=
+  (Set.toFinite {S : Finset ι | S.Nonempty}).image _
+
+/-- Under either closure, two worlds give the same strong answer iff they have the same
+profile. -/
+theorem mem_strongAnswer_conjClosure_iff {w v : W} :
+    v ∈ strongAnswer (conjClosure a) w ↔ profile a v = profile a w := by
+  rw [mem_strongAnswer]
+  constructor
+  · intro h
+    ext i
+    have := h _ (conj_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩)
+    rw [conj_singleton] at this
+    exact this.symm
+  · rintro h _ ⟨S, -, rfl⟩
+    rw [mem_conj_iff_subset, mem_conj_iff_subset, h]
+
+theorem mem_strongAnswer_disjClosure_iff {w v : W} :
+    v ∈ strongAnswer (disjClosure a) w ↔ profile a v = profile a w := by
+  rw [mem_strongAnswer]
+  constructor
+  · intro h
+    ext i
+    have := h _ (disj_mem_disjClosure ⟨i, Finset.mem_singleton_self i⟩)
+    rw [disj_singleton] at this
+    exact this.symm
+  · rintro h _ ⟨S, -, rfl⟩
+    have hi : ∀ i, w ∈ a i ↔ v ∈ a i := λ i => by
+      change i ∈ profile a w ↔ i ∈ profile a v
+      rw [h]
+    simp only [mem_disj, hi]
+
+/-- Both closures induce the same logical partition. -/
+theorem strongAnswer_conjClosure_eq_disjClosure (w : W) :
+    strongAnswer (conjClosure a) w = strongAnswer (disjClosure a) w :=
+  Set.ext λ _ => mem_strongAnswer_conjClosure_iff.trans mem_strongAnswer_disjClosure_iff.symm
+
+end Questions

--- a/Linglib/Studies/Fox2007.lean
+++ b/Linglib/Studies/Fox2007.lean
@@ -1,8 +1,7 @@
 import Linglib.Semantics.Exhaustification.InnocentExclusion
+import Linglib.Semantics.Questions.Closure
 import Linglib.Logic.Modal.Defs
 import Linglib.Data.Examples.Fox2007
-import Mathlib.Data.Fintype.Powerset
-import Mathlib.Order.CompleteLattice.Finset
 
 /-!
 # Fox (2007): Free Choice and the Theory of Scalar Implicatures
@@ -17,8 +16,8 @@ of the paper's note on the diamond configuration, `IsDiamond.exh₂_eq` and
 exactly when `e` is stronger than `s ∩ n`. Disjunction under a possibility modal, under an
 existential quantifier, and conjunction under a negated necessity modal instantiate the diamond
 with `e` strictly stronger; unembedded disjunction has `e = s ∩ n`, so its second
-exhaustification is vacuous. `exhIE_hamblin` is the paper's `some GIRL` computation: against
-Hamblin alternatives, innocent exclusion yields *exactly one*.
+exhaustification is vacuous. `exhIE_conjClosure` is the paper's `some GIRL` computation: against
+the Hamblin alternatives closed under conjunction, innocent exclusion yields *exactly one*.
 
 ## Implementation notes
 
@@ -113,8 +112,9 @@ end Recursive
 /-- A disjunction against its disjuncts and one further alternative: only the further
 alternative is innocently excludable, when each disjunct can hold without the other and
 without it. -/
-theorem exhIE_pair {A B D : Set W} (hA : ((A \ B) \ D).Nonempty)
-    (hB : ((B \ A) \ D).Nonempty) : exhIE {A ∪ B, A, B, D} (A ∪ B) = (A ∪ B) \ D := by
+theorem isInnocentlyExcludable_pair_iff {A B D : Set W} (hA : ((A \ B) \ D).Nonempty)
+    (hB : ((B \ A) \ D).Nonempty) {q : Set W} (hq : q ∈ ({A ∪ B, A, B, D} : Set (Set W))) :
+    IsInnocentlyExcludable {A ∪ B, A, B, D} (A ∪ B) q ↔ q = D := by
   obtain ⟨a, ha⟩ := hA
   obtain ⟨b, hb⟩ := hB
   have notIE : ∀ {A B : Set W} {a : W}, a ∈ (A \ B) \ D →
@@ -158,18 +158,22 @@ theorem exhIE_pair {A B D : Set W} (hA : ((A \ B) \ D).Nonempty)
         exact hE.1.2.1
       exact ⟨a, key ha hAE (union_comm B A ▸ hE.1.1) hE'⟩
     · exact ⟨b, key hb hBE hE.1.1 hE.1.2.1⟩
+  simp only [mem_insert_iff, mem_singleton_iff] at hq
+  obtain h1 | h1 | h1 | h1 := hq <;> subst q
+  · exact iff_of_false (not_isInnocentlyExcludable_of_phi_subset (toFinite _) ⟨a, Or.inl ha.1.1⟩
+      subset_rfl) λ h => ha.2 (h ▸ Or.inl ha.1.1)
+  · exact iff_of_false (notIE ha) λ h => ha.2 (h ▸ ha.1.1)
+  · refine iff_of_false ?_ λ h => hb.2 (h ▸ hb.1.1)
+    have := notIE hb
+    rwa [union_comm B A, insert_comm B A] at this
+  · exact iff_of_true hD rfl
+
+/-- Exhaustifying the disjunction denies only the further alternative. -/
+theorem exhIE_pair {A B D : Set W} (hA : ((A \ B) \ D).Nonempty)
+    (hB : ((B \ A) \ D).Nonempty) : exhIE {A ∪ B, A, B, D} (A ∪ B) = (A ∪ B) \ D := by
+  rw [exhIE_eq_of_iff _ _ (toFinite _) λ q hq => isInnocentlyExcludable_pair_iff hA hB hq]
   ext u
-  rw [mem_exhIE_iff _ _ (toFinite _), mem_sdiff]
-  refine and_congr_right λ hu => ⟨λ h => h D hD, λ h c hc => ?_⟩
-  have hc1 := hc.1
-  simp only [mem_insert_iff, mem_singleton_iff] at hc1
-  obtain h1 | h1 | h1 | h1 := hc1 <;> subst c
-  · exact (not_isInnocentlyExcludable_of_phi_subset (toFinite _) ⟨u, hu⟩ subset_rfl hc).elim
-  · exact (notIE ha hc).elim
-  · have := notIE hb
-    rw [union_comm B A, insert_comm B A] at this
-    exact (this hc).elim
-  · exact h
+  exact ⟨λ ⟨hu, h⟩ => ⟨hu, h D (by simp) rfl⟩, λ ⟨hu, huD⟩ => ⟨hu, λ _ _ hqD => hqD ▸ huD⟩⟩
 
 /-- Exclusive *or*: the Sauerland alternatives of a disjunction exclude only the conjunction. -/
 theorem exhIE_or {p q : Set W} (hp : (p \ q).Nonempty) (hq : (q \ p).Nonempty) :
@@ -204,6 +208,12 @@ theorem notMem : w ∉ ({s, n, e} : Set (Set W)) := by
   · exact ha.2 (hn (h1 ▸ (Or.inl ha.1 : a ∈ s ∪ n)))
 
 /-- Only the strongest alternative is innocently excludable given the weakest. -/
+theorem isInnocentlyExcludable_iff {q : Set W} (hq : q ∈ ({w, s, n, e} : Set (Set W))) :
+    IsInnocentlyExcludable {w, s, n, e} w q ↔ q = e := by
+  obtain ⟨rfl, hs, hn, ⟨a, ha⟩, ⟨b, hb⟩⟩ := h
+  exact isInnocentlyExcludable_pair_iff ⟨a, ha, λ hae => ha.2 (hn hae)⟩
+    ⟨b, hb, λ hbe => hb.2 (hs hbe)⟩ hq
+
 theorem exhIE_w : exhIE {w, s, n, e} w = w \ e := by
   obtain ⟨rfl, hs, hn, ⟨a, ha⟩, ⟨b, hb⟩⟩ := h
   exact exhIE_pair ⟨a, ha, λ hae => ha.2 (hn hae)⟩ ⟨b, hb, λ hbe => hb.2 (hs hbe)⟩
@@ -417,34 +427,18 @@ end Existential
 
 section Hamblin
 
-variable {ι : Type*} (a : ι → Set W)
+open Questions
 
-/-- The Hamblin alternative for a group: the answer holds of every member. -/
-def hamblinAlt (S : Finset ι) : Set W := ⋂ i ∈ S, a i
-
-/-- The Hamblin alternatives: one per non-empty group. -/
-def hamblin : Set (Set W) := hamblinAlt a '' {S | S.Nonempty}
-
-variable {a}
-
-theorem mem_hamblinAlt {S : Finset ι} {u : W} : u ∈ hamblinAlt a S ↔ ∀ i ∈ S, u ∈ a i :=
-  mem_iInter₂
-
-theorem hamblinAlt_singleton (i : ι) : hamblinAlt a {i} = a i :=
-  Finset.set_biInter_singleton i a
-
-theorem hamblinAlt_mem_hamblin {S : Finset ι} (hS : S.Nonempty) : hamblinAlt a S ∈ hamblin a :=
-  ⟨S, hS, rfl⟩
-
+variable {ι : Type*} {a : ι → Set W}
 variable (hsolo : ∀ i, ∃ u, u ∈ a i ∧ ∀ j, j ≠ i → u ∉ a j)
 include hsolo
 
 /-- A group of two or more is innocently excludable given the existential answer. -/
-theorem isInnocentlyExcludable_hamblinAlt {S : Finset ι} {i j : ι} (hi : i ∈ S) (hj : j ∈ S)
-    (hij : i ≠ j) : IsInnocentlyExcludable (hamblin a) (⋃ i, a i) (hamblinAlt a S) := by
-  refine .of_extension_consistent (hamblinAlt_mem_hamblin ⟨i, hi⟩) λ E hE => ?_
+theorem isInnocentlyExcludable_conj {S : Finset ι} {i j : ι} (hi : i ∈ S) (hj : j ∈ S)
+    (hij : i ≠ j) : IsInnocentlyExcludable (conjClosure a) (⋃ i, a i) (conj a S) := by
+  refine .of_extension_consistent (conj_mem_conjClosure ⟨i, hi⟩) λ E hE => ?_
   obtain ⟨v, hv⟩ := hE.1.2.2
-  by_cases hvS : v ∈ hamblinAlt a S
+  by_cases hvS : v ∈ conj a S
   · obtain ⟨u, hui, hu⟩ := hsolo i
     refine ⟨u, ?_⟩
     rintro ψ (hψ | hψ)
@@ -452,13 +446,13 @@ theorem isInnocentlyExcludable_hamblinAlt {S : Finset ι} {i j : ι} (hi : i ∈
       · exact mem_iUnion.2 ⟨i, hui⟩
       · intro huT
         have hTi : ∀ k ∈ T, k = i := λ k hk =>
-          by_contra λ hki => hu k hki (mem_hamblinAlt.1 huT k hk)
-        refine hv _ hψ (mem_hamblinAlt.2 λ k hk => ?_)
+          by_contra λ hki => hu k hki (mem_conj.1 huT k hk)
+        refine hv _ hψ (mem_conj.2 λ k hk => ?_)
         rw [hTi k hk]
-        exact mem_hamblinAlt.1 hvS i hi
+        exact mem_conj.1 hvS i hi
     · rw [mem_singleton_iff] at hψ
       subst hψ
-      exact λ huS => hu j hij.symm (mem_hamblinAlt.1 huS j hj)
+      exact λ huS => hu j hij.symm (mem_conj.1 huS j hj)
   · refine ⟨v, ?_⟩
     rintro ψ (hψ | hψ)
     · exact hv ψ hψ
@@ -467,10 +461,10 @@ theorem isInnocentlyExcludable_hamblinAlt {S : Finset ι} {i j : ι} (hi : i ∈
 
 /-- A single individual is not innocently excludable given the existential answer. -/
 theorem not_isInnocentlyExcludable_atom (i : ι) :
-    ¬ IsInnocentlyExcludable (hamblin a) (⋃ i, a i) (a i) := by
+    ¬ IsInnocentlyExcludable (conjClosure a) (⋃ i, a i) (a i) := by
   obtain ⟨u, hui, hu⟩ := hsolo i
-  have hmem : ∀ k, a k ∈ hamblin a := λ k =>
-    hamblinAlt_singleton (a := a) k ▸ hamblinAlt_mem_hamblin ⟨k, Finset.mem_singleton_self k⟩
+  have hmem : ∀ k, a k ∈ conjClosure a := λ k =>
+    conj_singleton (a := a) k ▸ conj_mem_conjClosure ⟨k, Finset.mem_singleton_self k⟩
   rw [isInnocentlyExcludable_iff_exhMW_subset_compl _ _ _ (hmem i)]
   refine λ h => h ⟨mem_iUnion.2 ⟨i, hui⟩, ?_⟩ hui
   rintro ⟨v, hv, hvu, hnuv⟩
@@ -479,23 +473,22 @@ theorem not_isInnocentlyExcludable_atom (i : ι) :
   subst k
   refine hnuv λ c hc huc => ?_
   obtain ⟨T, -, rfl⟩ := hc
-  refine mem_hamblinAlt.2 λ m hm => ?_
-  have hmi : m = i := by_contra λ hmi => hu m hmi (mem_hamblinAlt.1 huc m hm)
+  refine mem_conj.2 λ m hm => ?_
+  have hmi : m = i := by_contra λ hmi => hu m hmi (mem_conj.1 huc m hm)
   rw [hmi]
   exact hkv
 
 /-- Exhaustifying the existential answer against its Hamblin alternatives yields *exactly one*,
 provided each individual can be the sole witness. -/
-theorem exhIE_hamblin [Fintype ι] [DecidableEq ι] :
-    exhIE (hamblin a) (⋃ i, a i) = {u | ∃! i, u ∈ a i} := by
-  have hfin : (hamblin a).Finite := (toFinite {S : Finset ι | S.Nonempty}).image _
+theorem exhIE_conjClosure [Fintype ι] [DecidableEq ι] :
+    exhIE (conjClosure a) (⋃ i, a i) = {u | ∃! i, u ∈ a i} := by
   ext u
-  rw [mem_exhIE_iff _ _ hfin, mem_iUnion, mem_ofPred_eq]
+  rw [mem_exhIE_iff _ _ conjClosure_finite, mem_iUnion, mem_ofPred_eq]
   constructor
   · rintro ⟨⟨i, hi⟩, h⟩
     refine ⟨i, hi, λ j hj => by_contra λ hji =>
-      h (hamblinAlt a {i, j}) ?_ (mem_hamblinAlt.2 λ m hm => ?_)⟩
-    · exact isInnocentlyExcludable_hamblinAlt hsolo (S := {i, j}) (Finset.mem_insert_self i _)
+      h (conj a {i, j}) ?_ (mem_conj.2 λ m hm => ?_)⟩
+    · exact isInnocentlyExcludable_conj hsolo (S := {i, j}) (Finset.mem_insert_self i _)
         (Finset.mem_insert_of_mem (Finset.mem_singleton_self j)) λ h' => hji h'.symm
     · rcases Finset.mem_insert.1 hm with h1 | h1
       · rw [h1]
@@ -508,11 +501,11 @@ theorem exhIE_hamblin [Fintype ι] [DecidableEq ι] :
     by_cases hSi : ∀ j ∈ S, j = i
     · obtain ⟨j, hj⟩ := hS
       have : S = {i} := Finset.eq_singleton_iff_unique_mem.2 ⟨hSi j hj ▸ hj, hSi⟩
-      rw [this, hamblinAlt_singleton] at hc
+      rw [this, conj_singleton] at hc
       exact not_isInnocentlyExcludable_atom hsolo i hc
     · obtain ⟨j, hj⟩ := not_forall.1 hSi
       obtain ⟨hjS, hji⟩ := Classical.not_imp.1 hj
-      exact hji (huniq j (mem_hamblinAlt.1 huc j hjS))
+      exact hji (huniq j (mem_conj.1 huc j hjS))
 
 end Hamblin
 

--- a/Linglib/Studies/Fox2018.lean
+++ b/Linglib/Studies/Fox2018.lean
@@ -1,170 +1,534 @@
-import Linglib.Semantics.Questions.Basic
-import Linglib.Semantics.Questions.Resolution
-import Linglib.Semantics.Questions.Exhaustivity
+import Linglib.Semantics.Questions.Closure
+import Linglib.Semantics.Exhaustification.InnocentInclusion
+import Linglib.Studies.Fox2007
+import Linglib.Data.Examples.Fox2018
 
 /-!
-# [fox-2018]: Partition by Exhaustification: Comments on Dayal 1996
-[dayal-1996] [heim-1994] [groenendijk-stokhof-1984] [spector-2008]
+# Fox (2018): Partition by Exhaustification
 
-Single-paper formalisation of [fox-2018], "Partition by
-Exhaustification: Comments on Dayal 1996" (ZAS Papers in Linguistics
-60 / Sinn und Bedeutung 22). Fox derives Dayal's maximality
-presupposition from the demand that question denotations *partition*
-the Stalnakerian context-set via point-wise exhaustification of the
-question's Hamblin members.
+This file formalizes [fox-2018]'s reconstruction of [dayal-1996]'s maximality presupposition as a
+matching condition between a question's Hamblin set and the partition it induces. Each member is
+exhaustified pointwise into a cell of the contextual partition; Cell Identification demands that
+every cell be so reached and Non-Vacuity that every member reach a cell, and
+`qpm_iff_partitionsBy` shows that together they say that pointwise exhaustification partitions
+the context set. With exhaustification as the strongest true member, Cell Identification is
+Dayal's presupposition (`cellIdentification_exhCell_iff`) and Non-Vacuity fails whenever the set
+contains the disjunction of two incomparable members, the negative island of higher-order
+questions (`not_nonVacuity_exhCell_of_union`), unless a necessity modal intervenes
+(`nonVacuity_box`). With exhaustification as [bar-lev-fox-2020]'s cell operator, a question closed
+under conjunction and its disjunctive counterpart identify the same cells by different members
+(`cell_conj`, `cell_disj`), and the answer set of the paper's revised answer operator is a
+singleton for the former but not for the latter: mention-all against mention-some.
 
-## Substrate identifications
+## Implementation notes
 
-Fox's central operator is the `Exh`-derived **cell identifier**: the
-set of worlds where a given proposition `p` is the maximally
-informative true Hamblin alternative.
+Questions are Hamblin sets `Set (Set W)` rather than `Question` lower sets, since the paper's sets
+are not antichains. The three-location model is a family of atoms `a : ι → Set W` with every
+profile realized (`Rich`); `Questions.conjClosure` and `Questions.disjClosure` are the paper's two
+denotations; their innocently excludable sets are characterized and the cells read off. Sections 5–7
+on the distribution of mention-some enter only through the rows on singular wh-phrases.
 
-| [fox-2018]                        | substrate                         |
-|----------------------------------------|-----------------------------------|
-| `Exh(Q,p) = λw. w∈p ∧ ∀q∈Q[w∈q → p⊆q]` (eq 11) | `exhCell (alt Q) p` |
-| `Max_inf(Q,w)` (eq 9b)                 | the unique `p` with `IsStrongestTrueAnswer (alt Q) w p` (when EP holds) |
-| `Partition_L(Q)` (eq 3)                | logical partition by `strongAnswer`-equivalence |
-| `Partition_C(Q,A)` (eq 10)             | contextual partition (A-restricted) |
-| Dayal's `Ans_D` presupposition         | `IsExhaustivelyResolvable` (Exhaustivity.lean) |
-| **Cell Identification (CI)** (eq 19)   | `CellIdentification` defined here |
-| **Non-Vacuity (NV)** (eq 20b)          | `NonVacuity` defined here         |
-| **Question Partition Matching (QPM)** (eq 20) | `QPM = CI ∧ NV`              |
+## References
 
-## Section coverage
-
-* **§1.1** Question duality (partition vs Hamblin set) — captured by
-  the substrate's `Question W = LowerSet (Set W)` (Hamblin shape) and
-  `strongAnswer (alt Q) w` (the partition view as equivalence classes).
-* **§1.2** Dayal's solution — `IsExhaustivelyResolvable` is already
-  the substrate's predicate; `Exh` here connects it to Fox's
-  partition-by-exhaustification view.
-* **§1.3** Empirical evidence (singular *wh* inferences, negative
-  islands) — paper-anchored prose; substrate captures the
-  uniqueness/existence inferences via `IsStrongestTrueAnswer`.
-* **§1.4** Interim summary — defines `CI` and `QPM`; both are formalised
-  here.
-* **§2.1** Mention-some challenge — `Ans_D` over-restricts;
-  `IsExhaustivelyResolvable` fails for MS questions (`where can I
-  get gas in Cambridge`).
-* **§2.2** Higher-order quantification (Spector 2008) — requires
-  generalised-quantifier *wh*-restrictors over UE quantifiers;
-  deferred to a future Spector 2008 study file.
-* **§3** Over-generation + QPM — formalised here.
-* **§4** Alternative `Exh` definition (Bar-Lev & Fox 2017 free-choice
-  conjunctive `Exh`) — requires free-choice machinery; deferred.
-
-## What this file does NOT cover
-
-* The Free-Choice / scalar-implicature interpretation of `Exh` (Krifka
-  1995 / Bar-Lev & Fox 2017): the substrate's `Exh` here is the
-  *strongest-true-answer* set, not the formula-level FC operator.
-* Negative islands as Maximality Failure (Fox & Hackl 2006; Abrusán
-  2007/2014): require degree-question / dense-domain machinery.
-* The §6 type-shift and §7 MS-distribution predictions: paper-internal
-  empirical claims about distribution of higher-order interpretations.
+* [fox-2018]
+* [dayal-1996]
+* [spector-2008]
+* [bar-lev-fox-2020]
+* [fox-hackl-2006]
+* [heim-1994]
 -/
 
 namespace Fox2018
 
-open Question
-open Questions
+open Questions Exhaustification Set Data.Examples
 
 variable {W : Type*}
 
-/-! ### §1 Exh-derived cells (eq 11) — substrate-level primitives
+/-! ### Question Partition Matching -/
 
-Fox's `Exh(Q,p)` and `Partition_L(Q)` are substrate primitives now —
-see `Semantics/Questions/Exhaustivity.lean::exhCell` and
-`exhaustifiedPartition`. We re-export them here under Fox's names for
-paper-faithfulness, and define the paper-specific contextual variant
-locally. -/
+section Matching
 
-/-- [fox-2018] (11): the **Exh-cell** of proposition `p` in
-    question `Q`. Substrate primitive `exhCell` re-exported under
-    Fox's notation. -/
-abbrev Exh (Q : Question W) (p : Set W) : Set W := exhCell (alt Q) p
+variable (Exh : Set W → Set W) (H : Set (Set W)) (A : Set W)
 
-/-! ### §1.1 Logical and contextual partitions (eq 3, eq 10) -/
+/-- The contextual partition: the strong answers restricted to the context set. -/
+def contextualPartition : Set (Set W) := {C | ∃ w ∈ A, C = strongAnswer H w ∩ A}
 
-/-- [fox-2018] (3): the **Logical Partition** of `Q`. Substrate
-    primitive `exhaustifiedPartition` re-exported under Fox's notation. -/
-abbrev LogicalPartition (Q : Question W) : Set (Set W) :=
-  exhaustifiedPartition (alt Q)
+/-- Cell Identification: every cell of the contextual partition is the exhaustification of some
+member. -/
+def CellIdentification : Prop := ∀ C ∈ contextualPartition H A, ∃ p ∈ H, Exh p ∩ A = C
 
-/-- [fox-2018] (10): the **Contextual Partition** of `Q` over
-    context-set `A` — the Logical Partition cells intersected with `A`.
-    Paper-specific variant; the substrate primitive `exhaustifiedPartition`
-    is the unrestricted form. -/
-def ContextualPartition (Q : Question W) (A : Set W) : Set (Set W) :=
-  {C | ∃ w ∈ A, C = strongAnswer (alt Q) w ∩ A}
+/-- Non-Vacuity: every member exhaustifies to a cell of the contextual partition. -/
+def NonVacuity : Prop := ∀ p ∈ H, ∃ C ∈ contextualPartition H A, Exh p ∩ A = C
 
-theorem mem_ContextualPartition (Q : Question W) (A : Set W) (C : Set W) :
-    C ∈ ContextualPartition Q A ↔ ∃ w ∈ A, C = strongAnswer (alt Q) w ∩ A :=
-  Iff.rfl
+/-- Question Partition Matching. -/
+def QPM : Prop := CellIdentification Exh H A ∧ NonVacuity Exh H A
 
-/-! ### §1.4 Cell Identification, Non-Vacuity, QPM (eq 19, eq 20) -/
+/-- The pointwise exhaustifications partition the context set. -/
+def PartitionsBy : Prop :=
+  (∀ p ∈ H, (Exh p ∩ A).Nonempty) ∧
+    (∀ p ∈ H, ∀ q ∈ H, Exh p ∩ A = Exh q ∩ A ∨ Disjoint (Exh p ∩ A) (Exh q ∩ A)) ∧
+    ∀ w ∈ A, ∃ p ∈ H, w ∈ Exh p
 
-/-- [fox-2018] (19): **Cell Identification (CI)** — every cell
-    in `Partition_C(Q, A)` is identifiable by some `Exh(Q, p)`
-    intersected with `A`. -/
-def CellIdentification (Q : Question W) (A : Set W) : Prop :=
-  ∀ C ∈ ContextualPartition Q A, ∃ p ∈ alt Q, C = Exh Q p ∩ A
+/-- An exhaustifier identifies cells when each of its non-empty values is a strong answer. -/
+def IsCellValued : Prop := ∀ p ∈ H, ∀ w ∈ Exh p, Exh p = strongAnswer H w
 
-/-- [fox-2018] (20b): **Non-Vacuity (NV)** — every alternative
-    `p ∈ alt Q` identifies *some* cell of `Partition_C(Q, A)`. -/
-def NonVacuity (Q : Question W) (A : Set W) : Prop :=
-  ∀ p ∈ alt Q, Exh Q p ∩ A ≠ ∅ → ∃ C ∈ ContextualPartition Q A, C = Exh Q p ∩ A
+variable {Exh H A}
 
-/-- [fox-2018] (20): **Question Partition Matching (QPM)** —
-    `Q` and the context-set `A` jointly satisfy CI and NV. -/
-def QPM (Q : Question W) (A : Set W) : Prop :=
-  CellIdentification Q A ∧ NonVacuity Q A
+theorem mem_contextualPartition {C : Set W} :
+    C ∈ contextualPartition H A ↔ ∃ w ∈ A, C = strongAnswer H w ∩ A := Iff.rfl
 
-/-! ### §1.2 Dayal's EP ↔ CI (the central bridge)
+/-- For a cell-identifying exhaustifier, matching is partitioning. -/
+theorem qpm_iff_partitionsBy (h : IsCellValued Exh H) : QPM Exh H A ↔ PartitionsBy Exh H A := by
+  constructor
+  · rintro ⟨hCI, hNV⟩
+    refine ⟨λ p hp => ?_, λ p hp q hq => ?_, λ w hw => ?_⟩
+    · obtain ⟨_, ⟨w, hw, rfl⟩, hpw⟩ := hNV p hp
+      exact ⟨w, by rw [hpw]; exact ⟨self_mem_strongAnswer H w, hw⟩⟩
+    · obtain ⟨_, ⟨w, hw, rfl⟩, hpw⟩ := hNV p hp
+      obtain ⟨_, ⟨v, hv, rfl⟩, hqv⟩ := hNV q hq
+      rw [hpw, hqv]
+      rcases strongAnswer_eq_or_disjoint H w v with heq | hdisj
+      · exact Or.inl (by rw [heq])
+      · exact Or.inr (Disjoint.mono inter_subset_left inter_subset_left hdisj)
+    · obtain ⟨p, hp, hpw⟩ := hCI _ ⟨w, hw, rfl⟩
+      have : w ∈ Exh p ∩ A := by rw [hpw]; exact ⟨self_mem_strongAnswer H w, hw⟩
+      exact ⟨p, hp, this.1⟩
+  · rintro ⟨hne, -, hcov⟩
+    refine ⟨?_, λ p hp => ?_⟩
+    · rintro _ ⟨w, hw, rfl⟩
+      obtain ⟨p, hp, hwp⟩ := hcov w hw
+      exact ⟨p, hp, by rw [h p hp w hwp]⟩
+    · obtain ⟨w, hwp, hwA⟩ := hne p hp
+      exact ⟨_, ⟨w, hwA, rfl⟩, by rw [h p hp w hwp]⟩
 
-Fox's central claim (eq 11–12): when Dayal's maximality presupposition
-is met (i.e., every world in `A` has a maximally informative true
-answer), the contextual partition is exactly the image of `Exh`.
-The substrate-level form of this connection: `IsExhaustivelyResolvable
-(alt Q) w` for every `w ∈ A` implies `CellIdentification Q A`. -/
+end Matching
 
-/-- [fox-2018] eq (11)→(12): if every world in the context-set
-    has a maximally informative true answer, every cell of the
-    contextual partition is `Exh`-identifiable. The substrate
-    counterpart of the Dayal-EP-implies-CI direction. -/
-theorem cellIdentification_of_isExhaustivelyResolvable
-    (Q : Question W) (A : Set W)
-    (hEP : ∀ w ∈ A, IsExhaustivelyResolvable (alt Q) w) :
-    CellIdentification Q A := by
-  rintro C ⟨w, hwA, rfl⟩
-  obtain ⟨p, hp⟩ := hEP w hwA
-  exact ⟨p, hp.1.1, congrArg (· ∩ A) (exhCell_eq_strongAnswer _ w hp).symm⟩
+/-! ### Dayal's presupposition -/
 
-/-! ### §2.1 Mention-some challenge
+section Dayal
 
-[fox-2018] §2.1 (21): "Mary knows where we can get gas in
-Cambridge" has an MS reading not derivable from `Ans_D` (which
-demands the maximally informative answer). The substrate mirror:
-some questions have `¬ IsExhaustivelyResolvable (alt Q) w` at the
-evaluation world even though they are perfectly answerable in the MS
-sense (`Resolves σ Q` succeeds for some non-maximal `p`). -/
+variable {H : Set (Set W)} {A : Set W}
 
-/-- A question can fail Dayal's EP at world `w` while still being
-    `Resolves`-supported there. The substrate-level distinction
-    underlying Fox §2.1's MS challenge. The hypothesis `hp₁p₂ : ¬ p₁ ⊆
-    p₂` together with maximality of both alts witnesses the
-    incomparability that defeats EP. -/
-theorem resolves_can_succeed_when_EP_fails
-    (Q : Question W) (w : W) (σ p₁ p₂ : Set W)
-    (hp₁ : p₁ ∈ alt Q) (hp₂ : p₂ ∈ alt Q)
-    (hwp₁ : w ∈ p₁) (hwp₂ : w ∈ p₂)
-    (hp₁p₂ : ¬ p₁ ⊆ p₂)
-    (hσp₁ : σ ⊆ p₁) :
-    Resolves σ Q ∧ ¬ IsExhaustivelyResolvable (alt Q) w := by
-  refine ⟨⟨p₁, hp₁, hσp₁⟩, fun ⟨q, hq⟩ => ?_⟩
-  rw [isStrongestTrueAnswer_alt_iff] at hq
-  have h₁ : p₁ = q := Set.mem_singleton_iff.1 (hq ▸ (⟨hp₁, hwp₁⟩ : p₁ ∈ trueAnswers (alt Q) w))
-  have h₂ : p₂ = q := Set.mem_singleton_iff.1 (hq ▸ (⟨hp₂, hwp₂⟩ : p₂ ∈ trueAnswers (alt Q) w))
-  exact hp₁p₂ (by rw [h₁, h₂])
+theorem isCellValued_exhCell : IsCellValued (exhCell H) H :=
+  λ _ _ w hw => exhCell_eq_strongAnswer H w hw
+
+/-- With exhaustification as the strongest true member, Cell Identification is Dayal's
+presupposition on the context set. -/
+theorem cellIdentification_exhCell_iff :
+    CellIdentification (exhCell H) H A ↔ ∀ w ∈ A, IsExhaustivelyResolvable H w := by
+  constructor
+  · intro h w hw
+    obtain ⟨p, -, hpw⟩ := h _ ⟨w, hw, rfl⟩
+    have : w ∈ exhCell H p ∩ A := by rw [hpw]; exact ⟨self_mem_strongAnswer H w, hw⟩
+    exact ⟨p, this.1⟩
+  · rintro h _ ⟨w, hw, rfl⟩
+    obtain ⟨p, hp⟩ := h w hw
+    exact ⟨p, hp.1.1, by rw [exhCell_eq_strongAnswer H w hp]⟩
+
+/-- Non-Vacuity: every member is the strongest true member at some context world. -/
+theorem nonVacuity_exhCell_iff :
+    NonVacuity (exhCell H) H A ↔ ∀ p ∈ H, ∃ w ∈ A, IsStrongestTrueAnswer H w p := by
+  constructor
+  · intro h p hp
+    obtain ⟨_, ⟨w, hw, rfl⟩, hpw⟩ := h p hp
+    have : w ∈ exhCell H p ∩ A := by rw [hpw]; exact ⟨self_mem_strongAnswer H w, hw⟩
+    exact ⟨w, hw, this.1⟩
+  · intro h p hp
+    obtain ⟨w, hw, hwp⟩ := h p hp
+    exact ⟨_, ⟨w, hw, rfl⟩, by rw [exhCell_eq_strongAnswer H w hwp]⟩
+
+/-- A singular which-question: over pairwise incomparable atoms, Dayal's presupposition is that
+exactly one is true. -/
+theorem isExhaustivelyResolvable_range_iff {ι : Type*} {a : ι → Set W}
+    (ha : ∀ i j, a i ⊆ a j → i = j) (w : W) :
+    IsExhaustivelyResolvable (range a) w ↔ ∃! i, w ∈ a i := by
+  constructor
+  · rintro ⟨_, ⟨⟨i, rfl⟩, hwi⟩, hmin⟩
+    exact ⟨i, hwi, λ j hwj => (ha _ _ (hmin ⟨⟨j, rfl⟩, hwj⟩)).symm⟩
+  · rintro ⟨i, hwi, huniq⟩
+    refine ⟨a i, ⟨⟨i, rfl⟩, hwi⟩, ?_⟩
+    rintro _ ⟨⟨j, rfl⟩, hwj⟩
+    rw [huniq j hwj]
+
+/-- A plural which-question: closed under conjunction, the set is resolvable wherever some
+member is true. -/
+theorem isExhaustivelyResolvable_conjClosure {ι : Type*} [Fintype ι] {a : ι → Set W} {w : W}
+    (hw : ∃ i, w ∈ a i) : IsExhaustivelyResolvable (conjClosure a) w := by
+  classical
+  obtain ⟨i, hi⟩ := hw
+  let T : Finset ι := Finset.univ.filter (λ i => w ∈ a i)
+  have hT : ∀ i, i ∈ T ↔ w ∈ a i := λ i => by simp [T]
+  refine ⟨conj a T, ⟨conj_mem_conjClosure ⟨i, (hT i).2 hi⟩, mem_conj.2 λ i hi => (hT i).1 hi⟩, ?_⟩
+  rintro _ ⟨⟨S, -, rfl⟩, hwS⟩ v hv
+  exact mem_conj.2 λ j hj => mem_conj.1 hv j ((hT j).2 (mem_conj.1 hwS j hj))
+
+/-! ### Negative islands -/
+
+/-- The disjunction of two incomparable members is never the strongest true member. -/
+theorem not_isStrongestTrueAnswer_union {q₁ q₂ : Set W} (h₁ : q₁ ∈ H) (h₂ : q₂ ∈ H)
+    (h₁₂ : ¬ q₁ ⊆ q₂) (h₂₁ : ¬ q₂ ⊆ q₁) (w : W) : ¬ IsStrongestTrueAnswer H w (q₁ ∪ q₂) := by
+  rintro ⟨⟨-, hw⟩, hmin⟩
+  rcases hw with hw | hw
+  · exact h₂₁ (subset_union_right.trans (hmin ⟨h₁, hw⟩))
+  · exact h₁₂ (subset_union_left.trans (hmin ⟨h₂, hw⟩))
+
+/-- A higher-order question under negation contains the negated conjunction of two readings
+together with each negated reading, so Non-Vacuity fails: the negative island. -/
+theorem not_nonVacuity_exhCell_of_union {q₁ q₂ : Set W} (h₁ : q₁ ∈ H) (h₂ : q₂ ∈ H)
+    (hu : q₁ ∪ q₂ ∈ H) (h₁₂ : ¬ q₁ ⊆ q₂) (h₂₁ : ¬ q₂ ⊆ q₁) : ¬ NonVacuity (exhCell H) H A := by
+  rw [nonVacuity_exhCell_iff]
+  intro h
+  obtain ⟨w, -, hw⟩ := h _ hu
+  exact not_isStrongestTrueAnswer_union h₁ h₂ h₁₂ h₂₁ w hw
+
+/-- Under a necessity modal, a member that is exactly the modal base of a context world is the
+strongest true member there: the island is obviated. -/
+theorem isStrongestTrueAnswer_box {W' : Type*} {R : W' → W → Prop} {p : Set W} (hp : p ∈ H)
+    {x : W'} (hx : ∀ v, R x v ↔ v ∈ p) :
+    IsStrongestTrueAnswer (box H R) x {y | ∀ v, R y v → v ∈ p} := by
+  refine ⟨⟨⟨p, hp, rfl⟩, λ v hv => (hx v).1 hv⟩, ?_⟩
+  rintro _ ⟨⟨q, -, rfl⟩, hxq⟩ y hy v hyv
+  exact hxq v ((hx v).2 (hy v hyv))
+
+/-- Non-Vacuity holds for the necessitated question whenever every member is exactly the modal
+base of some context world. -/
+theorem nonVacuity_box {W' : Type*} {R : W' → W → Prop} {A : Set W'}
+    (h : ∀ p ∈ H, ∃ x ∈ A, ∀ v, R x v ↔ v ∈ p) :
+    NonVacuity (exhCell (box H R)) (box H R) A := by
+  rw [nonVacuity_exhCell_iff]
+  rintro _ ⟨p, hp, rfl⟩
+  obtain ⟨x, hx, hxp⟩ := h p hp
+  exact ⟨x, hx, isStrongestTrueAnswer_box hp hxp⟩
+
+end Dayal
+
+/-! ### Exhaustivity as cell identification -/
+
+section Cell
+
+variable {H : Set (Set W)}
+
+/-- The cell operator identifies cells: each of its non-empty values is a strong answer. -/
+theorem cell_eq_strongAnswer {p : Set W} (hp : p ∈ H) {w : W} (hw : w ∈ cell H p) :
+    cell H p = strongAnswer H w := by
+  ext v
+  rw [mem_strongAnswer]
+  constructor
+  · intro hv q hq
+    by_cases hIE : IsInnocentlyExcludable H p q
+    · exact ⟨λ hwq => (hw.2.1 q hIE hwq).elim, λ hvq => (hv.2.1 q hIE hvq).elim⟩
+    · exact ⟨λ _ => hv.2.2 q ⟨hq, hIE⟩, λ _ => hw.2.2 q ⟨hq, hIE⟩⟩
+  · intro hv
+    exact ⟨(hv p hp).1 hw.1, λ q hIE hvq => hw.2.1 q hIE ((hv q hIE.1).2 hvq),
+      λ r hr => (hv r hr.1).1 (hw.2.2 r hr)⟩
+
+theorem isCellValued_cell : IsCellValued (cell H) H := λ _ hp _ hw => cell_eq_strongAnswer hp hw
+
+/-- With the cell operator, matching is partitioning. -/
+theorem qpm_cell_iff_partitionsBy {A : Set W} : QPM (cell H) H A ↔ PartitionsBy (cell H) H A :=
+  qpm_iff_partitionsBy isCellValued_cell
+
+/-- Free choice in one step: on [fox-2007]'s diamond the cell operator asserts both independent
+alternatives and denies the strongest. -/
+theorem cell_diamond {w s n e : Set W} (h : Fox2007.IsDiamond w s n e) :
+    cell {w, s, n, e} w = (s ∩ n) \ e := by
+  rw [cell_eq_of_iff _ _ λ q hq => h.isInnocentlyExcludable_iff hq]
+  have hne : ∀ q ∈ ({w, s, n} : Set (Set W)), q ≠ e := by
+    obtain ⟨rfl, hs, hn, ⟨a, ha⟩, ⟨b, hb⟩⟩ := h
+    rintro q (rfl | rfl | rfl) hqe
+    · exact ha.2 (hn (hqe ▸ Or.inl ha.1))
+    · exact ha.2 (hn (hqe ▸ ha.1))
+    · exact hb.2 (hs (hqe ▸ hb.1))
+  ext x
+  constructor
+  · rintro ⟨-, hx⟩
+    exact ⟨⟨(hx s (by simp)).2 (hne s (by simp)), (hx n (by simp)).2 (hne n (by simp))⟩,
+      λ hxe => (hx e (by simp)).1 hxe rfl⟩
+  · rintro ⟨⟨hxs, hxn⟩, hxe⟩
+    refine ⟨h.union ▸ Or.inl hxs, λ q hq => ?_⟩
+    simp only [mem_insert_iff, mem_singleton_iff] at hq
+    obtain h1 | h1 | h1 | h1 := hq <;> subst q
+    · exact iff_of_true (h.union ▸ Or.inl hxs) (hne _ (by simp))
+    · exact iff_of_true hxs (hne _ (by simp))
+    · exact iff_of_true hxn (hne _ (by simp))
+    · exact iff_of_false hxe λ h' => h' rfl
+
+/-- The cell operator agrees with [fox-2007]'s recursive exhaustification wherever free choice
+is consistent. -/
+theorem cell_eq_exh₂ {w s n e : Set W} (h : Fox2007.IsDiamond w s n e)
+    (hne : ((s ∩ n) \ e).Nonempty) : cell {w, s, n, e} w = Fox2007.exh₂ {w, s, n, e} w := by
+  rw [cell_diamond h, h.exh₂_eq hne]
+
+end Cell
+
+/-! ### Mention-some and mention-all -/
+
+section Closures
+
+variable {ι : Type*} {a : ι → Set W}
+
+/-- Every profile is realized by some world. -/
+def Rich (a : ι → Set W) : Prop := ∀ T : Finset ι, ∃ w, profile a w = ↑T
+
+/-- The worlds with a given profile: a cell of the logical partition of either closure. -/
+def profileCell (a : ι → Set W) (T : Finset ι) : Set W := {v | profile a v = ↑T}
+
+theorem mem_profileCell {T : Finset ι} {v : W} : v ∈ profileCell a T ↔ profile a v = ↑T := Iff.rfl
+
+/-- Both closures induce the profile cells. -/
+theorem strongAnswer_conjClosure_eq {T : Finset ι} {w : W} (hw : profile a w = ↑T) :
+    strongAnswer (conjClosure a) w = profileCell a T := by
+  ext v
+  rw [mem_strongAnswer_conjClosure_iff, hw, mem_profileCell]
+
+theorem strongAnswer_disjClosure_eq {T : Finset ι} {w : W} (hw : profile a w = ↑T) :
+    strongAnswer (disjClosure a) w = profileCell a T := by
+  ext v
+  rw [mem_strongAnswer_disjClosure_iff, hw, mem_profileCell]
+
+/-- Under either closure, a world lies below another iff its profile is included. -/
+theorem leALT_conjClosure_iff {u v : W} :
+    (u ≤[conjClosure a] v) ↔ profile a u ⊆ profile a v := by
+  constructor
+  · intro h i hi
+    exact h _ (conj_singleton (a := a) i ▸ conj_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩) hi
+  · rintro h _ ⟨S, -, rfl⟩ hu
+    exact mem_conj_iff_subset.2 ((mem_conj_iff_subset.1 hu).trans h)
+
+theorem leALT_disjClosure_iff {u v : W} :
+    (u ≤[disjClosure a] v) ↔ profile a u ⊆ profile a v := by
+  constructor
+  · intro h i hi
+    exact h _ (disj_singleton (a := a) i ▸ disj_mem_disjClosure ⟨i, Finset.mem_singleton_self i⟩) hi
+  · rintro h _ ⟨S, -, rfl⟩ hu
+    obtain ⟨i, hi, hui⟩ := mem_disj.1 hu
+    exact mem_disj.2 ⟨i, hi, h hui⟩
+
+variable (hrich : Rich a)
+include hrich
+
+theorem conj_subset_conj_iff {S T : Finset ι} : conj a T ⊆ conj a S ↔ S ⊆ T := by
+  constructor
+  · intro h i hi
+    obtain ⟨w, hw⟩ := hrich T
+    have := mem_conj_iff_subset.1 (h (mem_conj_iff_subset.2 (by rw [hw]))) (Finset.mem_coe.2 hi)
+    rw [hw] at this
+    exact Finset.mem_coe.1 this
+  · exact λ h _ hv => mem_conj.2 λ i hi => mem_conj.1 hv i (h hi)
+
+theorem disj_subset_disj_iff {S T : Finset ι} : disj a S ⊆ disj a T ↔ S ⊆ T := by
+  constructor
+  · intro h i hi
+    obtain ⟨w, hw⟩ := hrich ({i} : Finset ι)
+    have hwi : w ∈ a i := by
+      change i ∈ profile a w
+      rw [hw]
+      exact Finset.mem_coe.2 (Finset.mem_singleton_self i)
+    obtain ⟨j, hj, hwj⟩ := mem_disj.1 (h (mem_disj.2 ⟨i, hi, hwi⟩))
+    have : j ∈ profile a w := hwj
+    rw [hw, Finset.coe_singleton, mem_singleton_iff] at this
+    exact this ▸ hj
+  · rintro h _ hv
+    obtain ⟨i, hi, hvi⟩ := mem_disj.1 hv
+    exact mem_disj.2 ⟨i, h hi, hvi⟩
+
+/-- Given the conjunction over a group, a member is innocently excludable iff its group is not
+included: the paper's computation for the low-type question. -/
+theorem isInnocentlyExcludable_conj_iff [Fintype ι] {S T : Finset ι} (hS : S.Nonempty) :
+    IsInnocentlyExcludable (conjClosure a) (conj a T) (conj a S) ↔ ¬ S ⊆ T := by
+  obtain ⟨w₀, hw₀⟩ := hrich T
+  have hw₀T : w₀ ∈ conj a T := mem_conj_iff_subset.2 (by rw [hw₀])
+  constructor
+  · exact λ hIE hST => not_isInnocentlyExcludable_of_phi_subset conjClosure_finite ⟨w₀, hw₀T⟩
+      ((conj_subset_conj_iff hrich).2 hST) hIE
+  · intro hST
+    refine .of_forall_subset_or_notMem (conj_mem_conjClosure hS) hw₀T ?_ ?_
+    · rw [mem_conj_iff_subset, hw₀]
+      exact λ h => hST (Finset.coe_subset.1 h)
+    · rintro _ ⟨U, -, rfl⟩
+      by_cases hUT : U ⊆ T
+      · exact Or.inl ((conj_subset_conj_iff hrich).2 hUT)
+      · right
+        rw [mem_conj_iff_subset, hw₀]
+        exact λ h => hUT (Finset.coe_subset.1 h)
+
+/-- The minimal worlds given the disjunction over a group: the sole witnesses of its members. -/
+theorem mem_exhMW_disjClosure_iff {T : Finset ι} {u : W} :
+    u ∈ exhMW (disjClosure a) (disj a T) ↔ ∃ i ∈ T, profile a u = ↑({i} : Finset ι) := by
+  have hsing : ∀ {i : ι} {v : W}, profile a v = ↑({i} : Finset ι) → v ∈ a i := λ {i v} hv => by
+    change i ∈ profile a v
+    rw [hv]
+    exact Finset.mem_coe.2 (Finset.mem_singleton_self i)
+  constructor
+  · rintro ⟨hu, hmin⟩
+    obtain ⟨i, hi, hui⟩ := mem_disj.1 hu
+    obtain ⟨v, hv⟩ := hrich ({i} : Finset ι)
+    have hvu : v ≤[disjClosure a] u := leALT_disjClosure_iff.2 (by
+      rw [hv, Finset.coe_singleton]
+      exact singleton_subset_iff.2 hui)
+    have huv : u ≤[disjClosure a] v :=
+      by_contra λ h => hmin ⟨v, mem_disj.2 ⟨i, hi, hsing hv⟩, hvu, h⟩
+    refine ⟨i, hi, subset_antisymm ?_ ?_⟩
+    · rw [← hv]
+      exact leALT_disjClosure_iff.1 huv
+    · rw [Finset.coe_singleton]
+      exact singleton_subset_iff.2 hui
+  · rintro ⟨i, hi, hu⟩
+    refine ⟨mem_disj.2 ⟨i, hi, hsing hu⟩, ?_⟩
+    rintro ⟨v, hv, hvu, hnuv⟩
+    obtain ⟨j, -, hvj⟩ := mem_disj.1 hv
+    have hj : j ∈ profile a v := hvj
+    have hji : j ∈ profile a u := leALT_disjClosure_iff.1 hvu hj
+    rw [hu, Finset.coe_singleton, mem_singleton_iff] at hji
+    subst hji
+    refine hnuv (leALT_disjClosure_iff.2 ?_)
+    rw [hu, Finset.coe_singleton]
+    exact singleton_subset_iff.2 hj
+
+/-- Given the disjunction over a group, a member is innocently excludable iff its group is
+disjoint from it: the paper's computation for the high-type question. -/
+theorem isInnocentlyExcludable_disj_iff {S T : Finset ι} (hS : S.Nonempty) :
+    IsInnocentlyExcludable (disjClosure a) (disj a T) (disj a S) ↔ Disjoint S T := by
+  rw [isInnocentlyExcludable_iff_exhMW_subset_compl _ _ _ (disj_mem_disjClosure hS),
+    Finset.disjoint_left]
+  constructor
+  · intro h i hiS hiT
+    obtain ⟨v, hv⟩ := hrich ({i} : Finset ι)
+    refine h ((mem_exhMW_disjClosure_iff hrich).2 ⟨i, hiT, hv⟩) (mem_disj.2 ⟨i, hiS, ?_⟩)
+    change i ∈ profile a v
+    rw [hv]
+    exact Finset.mem_coe.2 (Finset.mem_singleton_self i)
+  · intro h u hu huS
+    obtain ⟨i, hiT, hui⟩ := (mem_exhMW_disjClosure_iff hrich).1 hu
+    obtain ⟨j, hjS, huj⟩ := mem_disj.1 huS
+    have : j ∈ profile a u := huj
+    rw [hui, Finset.coe_singleton, mem_singleton_iff] at this
+    exact h hjS (this ▸ hiT)
+
+/-- For the conjunctive question, the member for a group identifies the cell of that profile. -/
+theorem cell_conj [Fintype ι] (T : Finset ι) :
+    cell (conjClosure a) (conj a T) = profileCell a T := by
+  rw [conjClosure, cell_image_eq _ λ S hS => isInnocentlyExcludable_conj_iff hrich hS]
+  ext x
+  simp only [mem_ofPred_eq, mem_conj_iff_subset, not_not, mem_profileCell]
+  constructor
+  · rintro ⟨-, h⟩
+    ext i
+    have := h {i} ⟨i, Finset.mem_singleton_self i⟩
+    rw [Finset.coe_singleton, singleton_subset_iff, Finset.singleton_subset_iff] at this
+    exact this.trans Finset.mem_coe.symm
+  · intro hx
+    exact ⟨by rw [hx], λ S _ => by rw [hx, Finset.coe_subset]⟩
+
+/-- For the disjunctive question, the member for a group identifies the same cell. -/
+theorem cell_disj {T : Finset ι} (hT : T.Nonempty) :
+    cell (disjClosure a) (disj a T) = profileCell a T := by
+  rw [disjClosure, cell_image_eq _ λ S hS => isInnocentlyExcludable_disj_iff hrich hS]
+  ext x
+  simp only [mem_ofPred_eq, mem_disj, Finset.not_disjoint_iff, mem_profileCell]
+  constructor
+  · rintro ⟨-, h⟩
+    ext i
+    have := h {i} ⟨i, Finset.mem_singleton_self i⟩
+    simp only [Finset.mem_singleton, exists_eq_left] at this
+    exact this.trans Finset.mem_coe.symm
+  · intro hx
+    obtain ⟨i, hi⟩ := hT
+    have hmem : ∀ j, x ∈ a j ↔ j ∈ T := λ j => by
+      change j ∈ profile a x ↔ j ∈ T
+      rw [hx, Finset.mem_coe]
+    refine ⟨⟨i, hi, (hmem i).2 hi⟩, λ S _ => ?_⟩
+    simp only [hmem]
+
+/-- The revised answer operator: the true members entailing the cell identifier. -/
+def ans (Exh : Set W → Set W) (H : Set (Set W)) (w : W) : Set (Set W) :=
+  {q ∈ H | w ∈ q ∧ ∀ p ∈ H, w ∈ Exh p → q ⊆ p}
+
+/-- Mention-all: the conjunctive question's answer set is the conjunction over the profile. -/
+theorem ans_conjClosure [Fintype ι] {T : Finset ι} (hT : T.Nonempty) {w : W} (hw : profile a w = ↑T) :
+    ans (cell (conjClosure a)) (conjClosure a) w = {conj a T} := by
+  ext q
+  rw [mem_singleton_iff]
+  constructor
+  · rintro ⟨⟨S, -, rfl⟩, hwS, h⟩
+    have h1 : S ⊆ T := by
+      have := mem_conj_iff_subset.1 hwS
+      rw [hw] at this
+      exact Finset.coe_subset.1 this
+    have h2 : T ⊆ S := (conj_subset_conj_iff hrich).1
+      (h _ (conj_mem_conjClosure hT) (by rw [cell_conj hrich T]; exact hw))
+    rw [Finset.Subset.antisymm h1 h2]
+  · rintro rfl
+    refine ⟨conj_mem_conjClosure hT, mem_conj_iff_subset.2 (by rw [hw]), ?_⟩
+    rintro _ ⟨U, hU, rfl⟩ hwU
+    rw [cell_conj hrich U] at hwU
+    have hwU' : profile a w = ↑U := hwU
+    rw [hw, Finset.coe_inj] at hwU'
+    subst hwU'
+    exact subset_rfl
+
+/-- Mention-some: the disjunctive question's answer set is every disjunction over a sub-group of
+the profile. -/
+theorem ans_disjClosure {T : Finset ι} (hT : T.Nonempty) {w : W} (hw : profile a w = ↑T) :
+    ans (cell (disjClosure a)) (disjClosure a) w = disj a '' {S | S.Nonempty ∧ S ⊆ T} := by
+  ext q
+  constructor
+  · rintro ⟨⟨S, hS, rfl⟩, -, h⟩
+    exact ⟨S, ⟨hS, (disj_subset_disj_iff hrich).1
+      (h _ (disj_mem_disjClosure hT) (by rw [cell_disj hrich hT]; exact hw))⟩, rfl⟩
+  · rintro ⟨S, ⟨⟨i, hi⟩, hST⟩, rfl⟩
+    refine ⟨disj_mem_disjClosure ⟨i, hi⟩, mem_disj.2 ⟨i, hi, ?_⟩, ?_⟩
+    · change i ∈ profile a w
+      rw [hw]
+      exact Finset.mem_coe.2 (hST hi)
+    · rintro _ ⟨U, hU, rfl⟩ hwU
+      rw [cell_disj hrich hU] at hwU
+      have hwU' : profile a w = ↑U := hwU
+      rw [hw, Finset.coe_inj] at hwU'
+      subst hwU'
+      exact (disj_subset_disj_iff hrich).2 hST
+
+/-- With two or more true atoms, the disjunctive question's answer set has more than one
+member: the mention-some reading. -/
+theorem not_subsingleton_ans_disjClosure {T : Finset ι} (hT : 1 < T.card) {w : W}
+    (hw : profile a w = ↑T) : ¬ (ans (cell (disjClosure a)) (disjClosure a) w).Subsingleton := by
+  obtain ⟨i, hi, j, hj, hij⟩ := Finset.one_lt_card.1 hT
+  rw [ans_disjClosure hrich ⟨i, hi⟩ hw]
+  intro h
+  have := h ⟨{i}, ⟨⟨i, Finset.mem_singleton_self i⟩, Finset.singleton_subset_iff.2 hi⟩, rfl⟩
+    ⟨T, ⟨⟨i, hi⟩, subset_rfl⟩, rfl⟩
+  have := (disj_subset_disj_iff hrich).1 this.ge
+  exact hij (Finset.mem_singleton.1 (this hj)).symm
+
+end Closures
+
+/-! ### The data -/
+
+/-- A question of the data: whether it is a degree question, whether negation and a modal
+intervene, whether the wh-phrase is singular, and whether the island reading is blocked. -/
+structure Row where
+  negation : Bool
+  modal : Bool
+  singular : Bool
+  blocked : Bool
+  deriving DecidableEq
+
+def yesNoTable : List (String × Bool) := [("yes", true), ("no", false)]
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let n ← ex.parse? "negation" yesNoTable
+  let m ← ex.parse? "modal" yesNoTable
+  let s ← ex.parse? "number"
+    [("singular", true), ("plural", false), ("neutral", false), ("na", false)]
+  let b ← ex.parse? "blocked" yesNoTable
+  pure ⟨n, m, s, b⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- The islands of the data: a reading is blocked under negation without an intervening modal,
+or for a singular wh-phrase. -/
+theorem rows_predicted :
+    ∀ r ∈ rows, (r.blocked = true ↔ (r.negation = true ∧ r.modal = false) ∨ r.singular = true) := by
+  decide
 
 end Fox2018

--- a/Linglib/Studies/Xiang2022.lean
+++ b/Linglib/Studies/Xiang2022.lean
@@ -151,8 +151,7 @@ theorem relExhPresupposition_of_pointwise_EP
 answer; MS rejects this for `can`-questions. The substrate-level
 shadow: a question can fail Dayal's EP at `w` while having
 `Resolves σ Q` succeed for some non-maximal witness — same
-phenomenon as in [fox-2018] §2.1 (already formalised in
-`Fox2018.resolves_can_succeed_when_EP_fails`). RelExh resolves the
+phenomenon as in [fox-2018] §2.1 (`Fox2018.ans_disjClosure`). RelExh resolves the
 dilemma by relativising the EP to a per-accessible-world basis. -/
 
 /-- The defining contrast: a non-modalised question can fail Dayal's

--- a/references.bib
+++ b/references.bib
@@ -2850,7 +2850,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Questions/Exhaustivity.lean}
+  sources   = {Data/Examples/Fox2018.json;Semantics/Questions/Closure.lean;Semantics/Questions/Exhaustivity.lean;Studies/Fox2018.lean;Studies/Xiang2022.lean}
 }
 @incollection{fox-2007,
   author    = {Fox, Danny},
@@ -2864,7 +2864,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
+  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Semantics/Questions/Closure.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Fox2018.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
 }
 @incollection{chierchia-fox-spector-2012,
   author    = {Chierchia, Gennaro and Fox, Danny and Spector, Benjamin},
@@ -2929,6 +2929,19 @@
   validated = {true},
   role      = {cited},
   sources   = {Studies/GeurtsPouscoulous2009.lean}
+}
+@article{spector-2008,
+  author    = {Spector, Benjamin},
+  year      = {2008},
+  title     = {An Unnoticed Reading for Wh-Questions: Elided Answers and Weak Islands},
+  journal   = {Linguistic Inquiry},
+  volume    = {39},
+  number    = {4},
+  pages     = {677--686},
+  doi       = {10.1162/ling.2008.39.4.677},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Semantics/Questions/Closure.lean;Studies/Fox2018.lean;Studies/Xiang2022.lean},
 }
 @phdthesis{spector-2006,
   author    = {Spector, Benjamin},
@@ -3038,7 +3051,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/BarLevFox2020.json;Semantics/Exhaustification/Disjunctive.lean;Semantics/Exhaustification/InnocentInclusion.lean;Semantics/Exhaustification/Presuppositional.lean;Studies/AghaJeretic2026.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/DelPinalBassiSauerland2024.lean;Studies/ElliottSudo2025.lean;Studies/ZaniCiardelliSanfelici2026.lean}
+  sources   = {Data/Examples/BarLevFox2020.json;Semantics/Exhaustification/Disjunctive.lean;Semantics/Exhaustification/InnocentInclusion.lean;Semantics/Exhaustification/Presuppositional.lean;Studies/AghaJeretic2026.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/DelPinalBassiSauerland2024.lean;Studies/ElliottSudo2025.lean;Studies/Fox2018.lean;Studies/ZaniCiardelliSanfelici2026.lean}
 }
 @article{delpinal-bassi-sauerland-2024,
   author    = {Del Pinal, Guillermo and Bassi, Itai and Sauerland, Uli},
@@ -6218,7 +6231,7 @@
   pages     = {128--144},
   subfield  = {semantics/compositional},
   role      = {formalized},
-  sources   = {Semantics/Quantification/ChoiceFunction.lean;Studies/Heim1994.lean;Studies/Mirrazi2024.lean;Studies/Dayal2016.lean;Semantics/Questions/Exhaustivity.lean}
+  sources   = {Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Resolution.lean;Studies/Dayal2016.lean;Studies/Fox2018.lean;Studies/George2011.lean;Studies/Heim1994.lean;Studies/Mirrazi2024.lean}
 }% REF: Kearns, K. (2000). Semantics. New York: St. Martin's.
 @book{kearns-2000,
   author    = {Kearns, Kate},
@@ -12772,7 +12785,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {foundational},
-  sources   = {Studies/FoxHackl2006.lean}
+  sources   = {Data/Examples/Fox2018.json;Data/Examples/FoxHackl2006.json;Semantics/Alternatives/Extremum.lean;Semantics/Degree/Predicate.lean;Semantics/Exhaustification/Chain.lean;Studies/Bale2008.lean;Studies/Fox2018.lean;Studies/FoxHackl2006.lean;Studies/Heim2001.lean;Studies/Mihoc2019.lean;Studies/Rouillard2026.lean}
 }% REF: Fox, D. (1995). Economy and scope.
 @article{fox-1995,
   author    = {Fox, Danny},
@@ -15131,7 +15144,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {foundational},
-  sources   = {Data/Examples/Dayal2016.json;Data/Examples/GroenendijkStokhof1984.json;Discourse/Gameboard/Basic.lean;Semantics/Exhaustification/Alternatives.lean;Semantics/Mood/State.lean;Semantics/Mood/Verbal.lean;Semantics/Questions/Entailment.lean;Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Partition/Basic.lean;Semantics/Questions/Partition/Cells.lean;Semantics/Questions/Partition/Lattice.lean;Semantics/Questions/Resolution.lean;Studies/Dayal2016.lean;Studies/DeoThomas2025.lean;Studies/Fox2018.lean;Studies/George2011.lean;Studies/GroenendijkStokhof1984.lean;Studies/Heim1994.lean;Studies/VanRooy2003.lean;Studies/VonFintel2001.lean}
+  sources   = {Data/Examples/Dayal2016.json;Data/Examples/GroenendijkStokhof1984.json;Discourse/Gameboard/Basic.lean;Semantics/Exhaustification/Alternatives.lean;Semantics/Mood/State.lean;Semantics/Mood/Verbal.lean;Semantics/Questions/Entailment.lean;Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Partition/Basic.lean;Semantics/Questions/Partition/Cells.lean;Semantics/Questions/Partition/Lattice.lean;Semantics/Questions/Resolution.lean;Studies/Dayal2016.lean;Studies/DeoThomas2025.lean;Studies/George2011.lean;Studies/GroenendijkStokhof1984.lean;Studies/Heim1994.lean;Studies/VanRooy2003.lean;Studies/VonFintel2001.lean}
 }
 @article{xiang-2022,
   author    = {Xiang, Yimei},
@@ -15145,7 +15158,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Questions/Exhaustivity.lean;Studies/Xiang2022.lean}
+  sources   = {Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Resolution.lean;Studies/Xiang2022.lean}
 }
 @article{johnston-2023,
   author    = {Johnston, William},
@@ -15457,7 +15470,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Polarity/Licensing.lean;Syntax/Minimalist/LeftPeriphery.lean;Semantics/Questions/Exhaustivity.lean;Studies/Dayal2016.lean;Data/Examples/Dayal2016.json;Studies/Dayal2025.lean}
+  sources   = {Data/Examples/AlonsoOvalle2009.json;Data/Examples/Dayal2016.json;Semantics/Polarity/Licensing.lean;Semantics/Questions/Closure.lean;Semantics/Questions/Exhaustivity.lean;Studies/AlonsoOvalle2009.lean;Studies/AlonsoOvalleMoghiseh2025b.lean;Studies/Dayal2016.lean;Studies/Dayal2025.lean;Studies/Fox2018.lean;Studies/FoxHackl2006.lean;Studies/George2011.lean;Studies/Karttunen1977.lean;Studies/Xiang2022.lean}
 }
 @article{shannon-1948,
   author    = {Shannon, Claude E.},


### PR DESCRIPTION
Deep cleanse of Fox2018 against the paper (SuB 22, open access): the old file re-exported two substrate names, stated Non-Vacuity with a guard the paper does not have, and used `Question` lower sets whose `alt` drops the non-maximal members of the paper's Hamblin sets; the recut states Question Partition Matching over Hamblin sets for any exhaustifier and proves the paper's results.

- `CellIdentification`/`NonVacuity`/`QPM`/`PartitionsBy` over `Set (Set W)` with `qpm_iff_partitionsBy` for cell-valued exhaustifiers ((37) ≡ (38)); with the strongest-true-member operator, `cellIdentification_exhCell_iff` is Dayal's presupposition, `not_nonVacuity_exhCell_of_union` the negative island of higher-order questions, `nonVacuity_box` its modal obviation; `isExhaustivelyResolvable_range_iff` (singular *which*: exactly one) and `isExhaustivelyResolvable_conjClosure` (plural: existence)
- With Bar-Lev & Fox's cell operator: `cell_diamond` (free choice in one step) and `cell_eq_exh₂` (agrees with Fox 2007's recursive layer), the IE characterizations `isInnocentlyExcludable_conj_iff`/`_disj_iff`, `cell_conj`/`cell_disj` (both denotations identify the profile cells by different members), and the revised answer set `ans_conjClosure` (singleton, mention-all) vs `ans_disjClosure`/`not_subsingleton_ans_disjClosure` (mention-some)
- Substrate: `Semantics/Questions/Closure.lean` (`conj`/`disj`/`profile`, the two closures, equal strong answers) promoted from Fox2007; `exhIE_eq_of_iff`, `cell_eq_of_iff`, `cell_image_eq` compute an exhaustifier from a characterization of its innocently excludable set (Fox2007's pair/diamond characterizations exported to use them); 9 JSON rows with `rows_predicted` on the islands; `spector-2008` added
