### PR TITLE
refactor(Studies/FoxKatzir2011): symmetry over propositions

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3062,3 +3062,4 @@ import Linglib.Data.Examples.Flemming2021
 import Linglib.Data.Examples.Fortuny2024
 import Linglib.Data.Examples.Fox2007
 import Linglib.Data.Examples.Fox2018
+import Linglib.Data.Examples.FoxKatzir2011

--- a/Linglib/Data/Examples/FoxKatzir2011.json
+++ b/Linglib/Data/Examples/FoxKatzir2011.json
@@ -1,0 +1,570 @@
+[
+  {
+    "id": "foxkatzir2011_ex1",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(1)"
+    },
+    "language": "stan1293",
+    "primaryText": "John did some of the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John did all of the homework",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "no"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex2",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(2)"
+    },
+    "language": "stan1293",
+    "primaryText": "John did the reading or the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John did the reading and the homework",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "no"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex3",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(3)"
+    },
+    "language": "stan1293",
+    "primaryText": "John has three children.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John has four children",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "no"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex29",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(29)"
+    },
+    "language": "stan1293",
+    "primaryText": "John only [read three books]F.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John read four books",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "no"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Context: What did John do? The symmetric 'read exactly three books' is not a formal alternative."
+  },
+  {
+    "id": "foxkatzir2011_ex33",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(33)"
+    },
+    "language": "stan1293",
+    "primaryText": "John only [read three books]F.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John read exactly three books",
+        "judgment": "unacceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "no"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Context: Mary read exactly three books. What did John do? Making the symmetric alternative salient does not let context keep it and prune 'four books'."
+  },
+  {
+    "id": "foxkatzir2011_ex38",
+    "source": {
+      "bibkey": "sauerland-2004",
+      "paperLabel": "disjunction"
+    },
+    "language": "stan1293",
+    "primaryText": "John did all of the homework or none of the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John did all of the homework",
+        "judgment": "unacceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "no"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Neither disjunct's negation is an implicature; the disjuncts partition the assertion.",
+    "reportedIn": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(38)"
+    }
+  },
+  {
+    "id": "foxkatzir2011_ex40",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(40)"
+    },
+    "language": "stan1293",
+    "primaryText": "John is determined to do all of the homework or none of the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John is determined to do all of the homework",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "yes"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Both implicatures arise: the universal operator removes the symmetry."
+  },
+  {
+    "id": "foxkatzir2011_ex41",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(41)"
+    },
+    "language": "stan1293",
+    "primaryText": "Each of my students did all of the homework or none of the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: Each of my students did all of the homework",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "yes"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex42a",
+    "source": {
+      "bibkey": "katzir-2007",
+      "paperLabel": "Matsumoto examples"
+    },
+    "language": "stan1293",
+    "primaryText": "John did some of the homework yesterday, and he did just some of the homework today.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John did just some of the homework yesterday",
+        "judgment": "unacceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "no"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "'Just some' is salient, so both it and 'all' are formal alternatives of 'some'; context cannot keep one and prune the other.",
+    "reportedIn": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(42a)"
+    }
+  },
+  {
+    "id": "foxkatzir2011_ex44",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(44)"
+    },
+    "language": "stan1293",
+    "primaryText": "John was required to do some of the homework yesterday, and he was required to do just some of the homework today.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: John was required to do just some of the homework yesterday",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "yes"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Also: not required to do all of it yesterday."
+  },
+  {
+    "id": "foxkatzir2011_ex46",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(46)"
+    },
+    "language": "stan1293",
+    "primaryText": "Every single student got some of the questions right last week; today every single student got just some of the questions right.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: Last week, every student got just some of the questions right",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "yes"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex47a",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(47a)"
+    },
+    "language": "stan1293",
+    "primaryText": "In last week's robbery they only [stole the books]F. In today's robbery they [stole the books but not the jewelry]F.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: In last week's robbery they stole the books but not the jewelry",
+        "judgment": "unacceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "no"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxkatzir2011_ex49a",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(49a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Detective A only concluded that the robbers [stole the books]F. Detective B concluded that the robbers [stole the books but not the jewelry]F.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: Detective A concluded that the robbers stole the books but not the jewelry",
+        "judgment": "acceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "yes"
+      ],
+      [
+        "symmetric",
+        "yes"
+      ],
+      [
+        "universal",
+        "yes"
+      ],
+      [
+        "compatible",
+        "no"
+      ]
+    ],
+    "comment": "Also: not that they stole the books and the jewelry."
+  },
+  {
+    "id": "foxkatzir2011_ex53",
+    "source": {
+      "bibkey": "fox-katzir-2011",
+      "paperLabel": "(53)"
+    },
+    "language": "stan1293",
+    "primaryText": "Yesterday, John talked to Mary or Sue, and today, John talked to Mary.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {
+        "name": "not: Yesterday, John talked to Mary",
+        "judgment": "unacceptable"
+      }
+    ],
+    "paperFeatures": [
+      [
+        "inference",
+        "no"
+      ],
+      [
+        "symmetric",
+        "no"
+      ],
+      [
+        "universal",
+        "no"
+      ],
+      [
+        "compatible",
+        "yes"
+      ]
+    ],
+    "comment": "The disjuncts are compatible, so not symmetric; the pruned disjunct is exhaustively relevant given the restriction, which the allowable-restriction condition forbids."
+  }
+]

--- a/Linglib/Data/Examples/FoxKatzir2011.lean
+++ b/Linglib/Data/Examples/FoxKatzir2011.lean
@@ -1,0 +1,270 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `FoxKatzir2011` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/FoxKatzir2011.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace FoxKatzir2011.Examples`.
+-/
+
+namespace FoxKatzir2011.Examples
+
+open Data.Examples
+
+def ex1 : LinguisticExample :=
+  { id := "foxkatzir2011_ex1"
+    source := ⟨"fox-katzir-2011", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John did some of the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John did all of the homework", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "no"), ("universal", "no"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2 : LinguisticExample :=
+  { id := "foxkatzir2011_ex2"
+    source := ⟨"fox-katzir-2011", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John did the reading or the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John did the reading and the homework", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "no"), ("universal", "no"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3 : LinguisticExample :=
+  { id := "foxkatzir2011_ex3"
+    source := ⟨"fox-katzir-2011", "(3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John has three children."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John has four children", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "no"), ("universal", "no"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex29 : LinguisticExample :=
+  { id := "foxkatzir2011_ex29"
+    source := ⟨"fox-katzir-2011", "(29)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John only [read three books]F."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John read four books", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "no"), ("universal", "no"), ("compatible", "no")]
+    comment := "Context: What did John do? The symmetric 'read exactly three books' is not a formal alternative."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex33 : LinguisticExample :=
+  { id := "foxkatzir2011_ex33"
+    source := ⟨"fox-katzir-2011", "(33)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John only [read three books]F."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John read exactly three books", .unacceptable)]
+    paperFeatures := [("inference", "no"), ("symmetric", "yes"), ("universal", "no"), ("compatible", "no")]
+    comment := "Context: Mary read exactly three books. What did John do? Making the symmetric alternative salient does not let context keep it and prune 'four books'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex38 : LinguisticExample :=
+  { id := "foxkatzir2011_ex38"
+    source := ⟨"sauerland-2004", "disjunction"⟩
+    reportedIn := some ⟨"fox-katzir-2011", "(38)"⟩
+    language := "stan1293"
+    primaryText := "John did all of the homework or none of the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John did all of the homework", .unacceptable)]
+    paperFeatures := [("inference", "no"), ("symmetric", "yes"), ("universal", "no"), ("compatible", "no")]
+    comment := "Neither disjunct's negation is an implicature; the disjuncts partition the assertion."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex40 : LinguisticExample :=
+  { id := "foxkatzir2011_ex40"
+    source := ⟨"fox-katzir-2011", "(40)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John is determined to do all of the homework or none of the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John is determined to do all of the homework", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "yes"), ("universal", "yes"), ("compatible", "no")]
+    comment := "Both implicatures arise: the universal operator removes the symmetry."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex41 : LinguisticExample :=
+  { id := "foxkatzir2011_ex41"
+    source := ⟨"fox-katzir-2011", "(41)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Each of my students did all of the homework or none of the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: Each of my students did all of the homework", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "yes"), ("universal", "yes"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex42a : LinguisticExample :=
+  { id := "foxkatzir2011_ex42a"
+    source := ⟨"katzir-2007", "Matsumoto examples"⟩
+    reportedIn := some ⟨"fox-katzir-2011", "(42a)"⟩
+    language := "stan1293"
+    primaryText := "John did some of the homework yesterday, and he did just some of the homework today."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John did just some of the homework yesterday", .unacceptable)]
+    paperFeatures := [("inference", "no"), ("symmetric", "yes"), ("universal", "no"), ("compatible", "no")]
+    comment := "'Just some' is salient, so both it and 'all' are formal alternatives of 'some'; context cannot keep one and prune the other."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex44 : LinguisticExample :=
+  { id := "foxkatzir2011_ex44"
+    source := ⟨"fox-katzir-2011", "(44)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John was required to do some of the homework yesterday, and he was required to do just some of the homework today."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: John was required to do just some of the homework yesterday", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "yes"), ("universal", "yes"), ("compatible", "no")]
+    comment := "Also: not required to do all of it yesterday."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex46 : LinguisticExample :=
+  { id := "foxkatzir2011_ex46"
+    source := ⟨"fox-katzir-2011", "(46)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every single student got some of the questions right last week; today every single student got just some of the questions right."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: Last week, every student got just some of the questions right", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "yes"), ("universal", "yes"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex47a : LinguisticExample :=
+  { id := "foxkatzir2011_ex47a"
+    source := ⟨"fox-katzir-2011", "(47a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "In last week's robbery they only [stole the books]F. In today's robbery they [stole the books but not the jewelry]F."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: In last week's robbery they stole the books but not the jewelry", .unacceptable)]
+    paperFeatures := [("inference", "no"), ("symmetric", "yes"), ("universal", "no"), ("compatible", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex49a : LinguisticExample :=
+  { id := "foxkatzir2011_ex49a"
+    source := ⟨"fox-katzir-2011", "(49a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Detective A only concluded that the robbers [stole the books]F. Detective B concluded that the robbers [stole the books but not the jewelry]F."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: Detective A concluded that the robbers stole the books but not the jewelry", .acceptable)]
+    paperFeatures := [("inference", "yes"), ("symmetric", "yes"), ("universal", "yes"), ("compatible", "no")]
+    comment := "Also: not that they stole the books and the jewelry."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex53 : LinguisticExample :=
+  { id := "foxkatzir2011_ex53"
+    source := ⟨"fox-katzir-2011", "(53)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Yesterday, John talked to Mary or Sue, and today, John talked to Mary."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("not: Yesterday, John talked to Mary", .unacceptable)]
+    paperFeatures := [("inference", "no"), ("symmetric", "no"), ("universal", "no"), ("compatible", "yes")]
+    comment := "The disjuncts are compatible, so not symmetric; the pruned disjunct is exhaustively relevant given the restriction, which the allowable-restriction condition forbids."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex1, ex2, ex3, ex29, ex33, ex38, ex40, ex41, ex42a, ex44, ex46, ex47a, ex49a, ex53]
+
+end FoxKatzir2011.Examples

--- a/Linglib/Semantics/Alternatives/Symmetric.lean
+++ b/Linglib/Semantics/Alternatives/Symmetric.lean
@@ -1,149 +1,75 @@
-/-!
-# Symmetric Alternatives
-
-The **symmetry problem** is the central challenge for any theory of scalar
-implicatures based on alternatives. The problem: for any stronger
-alternative A of an assertion S, the sentence S ∧ ¬A is also stronger
-than S and yields the *opposite* implicature. A theory of alternatives
-must explain why A enters the alternative set but S ∧ ¬A does not.
-
-The problem emerged in the early 1970s: [horn-1972] established
-the Gricean derivation of scalar implicatures, and [kroch-1972]
-discussed the same reasoning for quantifiers, creating the conditions
-for recognizing that symmetric alternatives pose a fundamental obstacle.
-Every subsequent theory of alternatives is shaped by this problem:
-
-- [katzir-2007] addresses it via **structural complexity**: S ∧ ¬A
-  is structurally more complex than S, so it is excluded from F(S)
-- [fox-2007]'s **innocent exclusion** correctly handles symmetric
-  alternatives (they land in different MCEs, so neither is in I-E)
-- [fox-katzir-2011] show that **contextual restriction cannot
-  break symmetry** — only the formal alternative set F can
-- [breheny-et-al-2018] show that none of these fully solve
-  the problem (indirect SIs, gradable adjectives, too many/few
-  lexical alternatives remain problematic)
-- [fox-spector-2018]'s **economy condition** constrains where
-  `exh` can be inserted (not vacuous, not weakening)
-- **RSA** ([frank-goodman-2012], [franke-2011]) **dissolves**
-  rather than solves the symmetry problem: the utterance space is
-  specified directly, and utterance cost penalizes complex expressions
-  like "some but not all"
-
-This file defines the core concepts — `isSymmetric`, complement
-equivalence, and contextual relevance closure — as theory-neutral
-infrastructure that any approach can import. The definition follows
-[fox-katzir-2011] definition 12, but the concept is not specific
-to that paper.
-
-The Fox 2007 innocent-exclusion bridge theorems (`symmetric_not_ie`,
-`exhB_vacuous_of_ie_empty`, `symmetric_exhB_vacuous`,
-`both_excluded_inconsistent`) lived in this file in the legacy
-`Bool`/`List` API. They were never called outside their own
-docstrings, so the post-`Excluder` reorganization simply drops them
-rather than re-deriving Finset versions speculatively. The vacuity
-fact for the new API now lives next to its object as
-`Exhaustification.innocent_exh_eq_phi_of_innocentlyExcludable_empty`
-in `Exhaustification/Finite.lean`.
-
-## Key Definitions and Theorems
-
-- `isSymmetric`: S₁, S₂ partition S's denotation (def 12)
-- `symmetric_complement`: S ∧ ¬S₁ = S₂ when symmetric
-- `RelevanceClosure`: closure under ¬ and ∧ (condition 50)
-- `context_cannot_break_symmetry`: C preserves symmetry (constraint 28)
--/
-
-namespace Alternatives.Symmetric
-
--- ============================================================
--- SECTION 1: The Symmetry Predicate
--- ============================================================
-
-/-- Two propositions are **symmetric alternatives** of S if they
-    partition S's denotation: their union equals S and they are
-    mutually exclusive.
-
-    Formalized from [fox-katzir-2011] definition 12. The
-    underlying problem was recognized in the early 1970s
-    ([horn-1972], [kroch-1972]).
-
-    Note: this is stricter than mere non-innocent-excludability.
-    Disjuncts p, q of p∨q are often mutually compatible (p ∩ q ≠ ∅)
-    and hence NOT symmetric, though they still resist innocent
-    exclusion for related reasons ([fox-katzir-2011] fn. 18). -/
-def isSymmetric {W : Type} (domain : List W)
-    (s s₁ s₂ : W → Bool) : Bool :=
-  -- (a) ⟦S₁⟧ ∪ ⟦S₂⟧ = ⟦S⟧
-  domain.all (fun w => (s₁ w || s₂ w) == s w) &&
-  -- (b) ⟦S₁⟧ ∩ ⟦S₂⟧ = ∅
-  domain.all (fun w => !(s₁ w && s₂ w))
-
-
--- ============================================================
--- SECTION 2: Core Properties
--- ============================================================
-
-/-- When S₁, S₂ are symmetric alternatives of S, S ∧ ¬S₁ is
-    extensionally equal to S₂. This is the key fact underlying
-    the relevance argument: showing S ∧ ¬S₁ is relevant suffices
-    to show S₂ is relevant. -/
-theorem symmetric_complement {W : Type} (domain : List W)
-    (s s₁ s₂ : W → Bool)
-    (hsym : isSymmetric domain s s₁ s₂ = true) :
-    domain.all (fun w => (s w && !s₁ w) == s₂ w) = true := by
-  unfold isSymmetric at hsym
-  have ⟨ha, hb⟩ := Bool.and_eq_true_iff.mp hsym
-  rw [List.all_eq_true] at ha hb ⊢
-  intro w hw
-  specialize ha w hw
-  specialize hb w hw
-  simp [BEq.beq] at ha hb ⊢
-  cases h1 : s₁ w <;> cases h2 : s₂ w <;> simp_all
-
-
--- ============================================================
--- SECTION 3: Relevance Closure and Constraint 28
--- ============================================================
+import Mathlib.Order.BooleanSubalgebra
+import Mathlib.Data.Finset.Basic
 
 /-!
-## Context Cannot Break Symmetry
+# Symmetric alternatives
 
-The set of contextually relevant sentences C must satisfy closure
-conditions ([fox-katzir-2011] condition 50):
+Two alternatives are symmetric for an assertion when they partition it: negating either one
+asserts the other, so no theory that strengthens an assertion by negating alternatives can
+negate one of them without the other. This is the configuration of [kroch-1972]'s symmetry
+problem for scalar implicature, and [fox-katzir-2011]'s definition of it. The file defines
+`IsSymmetric`, shows that the second symmetric alternative is the assertion without the first,
+and that a set of propositions closed under negation and conjunction, a `BooleanSubalgebra`,
+contains both or neither.
 
-(50a) If S is relevant, so is ¬S.
-(50b) If S₁, S₂ are relevant, so is S₁ ∧ S₂.
+## References
 
-From these conditions, constraint (28) follows: **symmetry cannot be
-broken in C**. If S₁ is relevant and S is relevant, then S ∧ ¬S₁ is
-relevant (by 50a + 50b). But when S₁, S₂ are symmetric, S ∧ ¬S₁ ≡ S₂
-(by `symmetric_complement`). So S₂ is also relevant, and contextual
-restriction cannot selectively eliminate one symmetric alternative
-while keeping the other.
+* [kroch-1972]
+* [horn-1972]
+* [katzir-2007]
+* [fox-katzir-2011]
 -/
 
-/-- Closure conditions on relevance (condition 50). -/
-structure RelevanceClosure (W : Type) where
-  relevant : (W → Bool) → Bool
-  negClosed : ∀ (p : W → Bool), relevant p = true →
-    relevant (fun w => !p w) = true
-  conjClosed : ∀ (p q : W → Bool), relevant p = true →
-    relevant q = true → relevant (fun w => p w && q w) = true
+namespace Alternatives
 
-/-- **C cannot break symmetry (constraint 28)**: if S₁ is relevant
-    and S is relevant, then the symmetric partner S ∧ ¬S₁ (which
-    equals S₂ when S₁, S₂ are symmetric by `symmetric_complement`)
-    is also relevant.
+variable {W : Type*} {s s₁ s₂ : Set W}
 
-    Therefore any contextual restriction that keeps S₁ must also
-    keep S₂. Symmetry breaking must happen in F, not in C. -/
-theorem context_cannot_break_symmetry {W : Type}
-    (rc : RelevanceClosure W)
-    (s s₁ : W → Bool)
-    (hs : rc.relevant s = true)
-    (h₁ : rc.relevant s₁ = true) :
-    rc.relevant (fun w => s w && !s₁ w) = true :=
-  rc.conjClosed s (fun w => !s₁ w) hs (rc.negClosed s₁ h₁)
+/-- `s₁` and `s₂` are symmetric alternatives of `s`: they partition it. -/
+structure IsSymmetric (s s₁ s₂ : Set W) : Prop where
+  union : s₁ ∪ s₂ = s
+  disjoint : Disjoint s₁ s₂
 
+/-- The assertion without an alternative it entails is that alternative's symmetric partner. -/
+theorem isSymmetric_sdiff {t : Set W} (h : t ⊆ s) : IsSymmetric s t (s \ t) :=
+  ⟨Set.union_sdiff_cancel h, Set.disjoint_sdiff_right⟩
 
-end Alternatives.Symmetric
+namespace IsSymmetric
+
+theorem symm (h : IsSymmetric s s₁ s₂) : IsSymmetric s s₂ s₁ :=
+  ⟨(Set.union_comm _ _).trans h.union, h.disjoint.symm⟩
+
+theorem subset_left (h : IsSymmetric s s₁ s₂) : s₁ ⊆ s := h.union ▸ Set.subset_union_left
+
+theorem subset_right (h : IsSymmetric s s₁ s₂) : s₂ ⊆ s := h.union ▸ Set.subset_union_right
+
+/-- The second symmetric alternative is the assertion without the first. -/
+theorem sdiff_eq (h : IsSymmetric s s₁ s₂) : s \ s₁ = s₂ := by
+  rw [← h.union, Set.union_sdiff_left]
+  exact h.disjoint.symm.sdiff_eq_left
+
+theorem not_subset_left (h : IsSymmetric s s₁ s₂) (hne : s₂.Nonempty) : ¬ s ⊆ s₁ :=
+  λ hsub => let ⟨_, hw⟩ := hne; Set.disjoint_left.1 h.disjoint (hsub (h.subset_right hw)) hw
+
+theorem ssubset_left (h : IsSymmetric s s₁ s₂) (hne : s₂.Nonempty) : s₁ ⊂ s :=
+  h.subset_left.ssubset_of_not_subset (h.not_subset_left hne)
+
+/-- Contextual restriction cannot break symmetry: a set of propositions closed under negation
+and conjunction that contains the assertion and one symmetric alternative contains the other. -/
+theorem mem_of_mem (h : IsSymmetric s s₁ s₂) {R : BooleanSubalgebra (Set W)} (hs : s ∈ R)
+    (h₁ : s₁ ∈ R) : s₂ ∈ R :=
+  h.sdiff_eq ▸ BooleanSubalgebra.sdiff_mem hs h₁
+
+end IsSymmetric
+
+/-- Symmetry over finite sets is decidable through the underlying finsets. -/
+theorem isSymmetric_coe [DecidableEq W] (A B C : Finset W) :
+    IsSymmetric (↑A : Set W) ↑B ↑C ↔ B ∪ C = A ∧ B ∩ C = ∅ := by
+  constructor
+  · rintro ⟨hu, hd⟩
+    refine ⟨Finset.coe_inj.1 (by rw [Finset.coe_union, hu]), ?_⟩
+    exact Finset.disjoint_iff_inter_eq_empty.1 (Finset.disjoint_coe.1 hd)
+  · rintro ⟨hu, hd⟩
+    refine ⟨by rw [← Finset.coe_union, hu], ?_⟩
+    exact Finset.disjoint_coe.2 (Finset.disjoint_iff_inter_eq_empty.2 hd)
+
+end Alternatives

--- a/Linglib/Studies/BrehenyEtAl2018.lean
+++ b/Linglib/Studies/BrehenyEtAl2018.lean
@@ -52,7 +52,7 @@ right ones derive the observed implicature.
 namespace BrehenyEtAl2018
 
 open Exhaustification (innocent predToFinset altsFromPreds)
-open Alternatives.Symmetric
+open Alternatives
 
 /-!
 ## The Problem of Indirect Scalar Implicatures
@@ -271,8 +271,9 @@ private def ranAndNotSmoked : ActivityWorld → Bool
 /-- "smoked" and "ran ∧ ¬smoked" are symmetric alternatives of "ran":
     they partition ran's denotation (ex. 19). -/
 theorem particularised_symmetric :
-    isSymmetric actDomain ran smoked ranAndNotSmoked = true := by
-  decide
+    IsSymmetric (↑(predToFinset ran) : Set ActivityWorld) (↑(predToFinset smoked) : Set ActivityWorld)
+      (↑(predToFinset ranAndNotSmoked) : Set ActivityWorld) :=
+  (isSymmetric_coe _ _ _).2 (by decide)
 
 /-- With the symmetric alternative present, exh is vacuous —
     the inference "John smoked" is not derived. -/
@@ -338,8 +339,9 @@ private def isOptional : DeonticWorld → Bool
     they are symmetric alternatives (cf. some/all and some-but-not-all
     in `Symmetry.lean`). -/
 theorem swanson_symmetric :
-    isSymmetric deonticDomain isPermitted isRequired isOptional
-      = true := by decide
+    IsSymmetric (↑(predToFinset isPermitted) : Set DeonticWorld)
+      (↑(predToFinset isRequired) : Set DeonticWorld) (↑(predToFinset isOptional) : Set DeonticWorld) :=
+  (isSymmetric_coe _ _ _).2 (by decide)
 
 /-- With both lexicalized symmetric alternatives, exh is vacuous.
     The structural approach cannot block "optional" from F because

--- a/Linglib/Studies/FoxKatzir2011.lean
+++ b/Linglib/Studies/FoxKatzir2011.lean
@@ -1,476 +1,319 @@
-import Mathlib.Tactic.DeriveFintype
-import Linglib.Semantics.Alternatives.Structural
 import Linglib.Semantics.Alternatives.Symmetric
-import Linglib.Semantics.Exhaustification.Finite
+import Linglib.Semantics.Alternatives.Structural
+import Linglib.Semantics.Exhaustification.InnocentExclusion
+import Linglib.Logic.Modal.Defs
+import Linglib.Data.Examples.FoxKatzir2011
 
 /-!
-# Fox & Katzir 2011: On the Characterization of Alternatives
-[fox-katzir-2011]
+# Fox and Katzir (2011): On the Characterization of Alternatives
 
-Fox, D. & Katzir, R. (2011). On the characterization of alternatives.
-Natural Language Semantics, 19(1), 87–107.
+This file formalizes [fox-katzir-2011]'s argument that the alternatives of scalar implicature
+and of association with focus are one set, [katzir-2007]'s structural alternatives extended by
+the salient constituents of the context (`formalAlternatives`), and that symmetry among
+alternatives is broken only there: contextual restriction never keeps one of two alternatives
+that partition the assertion while pruning the other. The implicature and *only* operators
+`SM` and `Only` negate the strictly stronger and the non-weaker alternatives; on symmetric
+alternatives both are contradictory (`SM_eq_empty_of_isSymmetric`), a universal operator above
+the assertion removes the symmetry and both inferences arise (`mem_SM_nec`), innocent exclusion
+negates neither symmetric alternative (`exhIE_eq_self_of_isSymmetric`), and a contextual set
+closed under negation and conjunction keeps both or neither
+(`Alternatives.IsSymmetric.mem_of_mem`). The paper's stronger condition, allowable restriction
+through exhaustive relevance, forbids pruning one of two compatible disjuncts as well
+(`not_isAllowableRestriction_pair`).
 
-## Core Argument
+## Implementation notes
 
-The formal alternatives for Scalar Implicatures (SI) and Association
-with Focus (AF) are determined the same way — via [katzir-2007]'s
-structural complexity, not via Horn scales (for SI) or Rooth's focus
-semantics (for AF). The single unified definition (eq. 37) takes a
-contextual parameter C and is focus-sensitive.
+Sentences are propositions `Set W`, alternative sets are `Set (Set W)`, and the operators are
+intersections of complements, the paper's propositional rendering of *only*. The structural
+definition is stated without focus marking, so `formalAlternatives` contains the paper's set;
+its one new clause, salient constituents, is what brings a symmetric alternative into the set
+(`mem_formalAlternatives_of_salient`). Universal operators are `ModalLogic.box` over an
+accessibility relation, covering the modal and the quantificational cases alike.
 
-## Section-by-section map
+## References
 
-| F&K eq. | What it says                              | Where formalized |
-| :-----: | ----------------------------------------- | ---------------- |
-| (4)     | `SI_A(S) = ⋀{¬Sᵢ : Sᵢ ∈ N_SI(A,S)}`       | §4 below (`SI`) |
-| (12)    | symmetric alternatives                    | `Symmetric.isSymmetric` |
-| (17)    | `EXC_A(S) = ⋀{¬Sᵢ : Sᵢ ∈ N_AF(A,S)}`      | §5 below (`EXC`) |
-| (18)    | `Only_A(S) = S ∧ EXC_A(S)`                | §5 below (`Only`) |
-| (28)    | "Symmetry cannot be broken in C"          | `Symmetric.context_cannot_break_symmetry` (re-exported §7) |
-| (35)    | `SS(X,C) = lex ∪ subtrees(X) ∪ salient C` | §3 below (`substitutionSourceFC`) |
-| (37)    | `F(S, C)` via `≼_C`                       | §3 below (`formalAlternatives`) — focus restriction simplified |
-| (38–41) | "John did all or none" disjunction        | §6 below |
-| (50)    | relevance closure under ¬, ∧              | `Symmetric.RelevanceClosure` |
-
-## What this file proves directly
-
-1. §1: Some/all symmetric (eq. 12 instantiated); symmetric_complement verified.
-2. §2: Innocent exclusion vacuous on the symmetric alt set; correct on Horn-restricted.
-3. §3: F(S,C) extends Katzir 2007 with salient context. Without focus marking,
-   our `formalAlternatives` is a (conservative) superset of F&K's eq. 37.
-4. §4: SI / N_SI selectors.
-5. §5: EXC / Only / N_AF — F&K's exhaustification operators.
-6. §6: Second worked example — disjunction "John did all or none" (§4.1).
-7. §7: Cross-reference to `Symmetric.context_cannot_break_symmetry` (eq. 28).
-
-## Limitations (tracked, not fixed here)
-
-- **Focus marking not represented** (eq. 37 simplification — see §3 docstring).
-- **§5.2 allowable restriction / exhaustive relevance** (eqs. 55–56) is out of scope.
+* [fox-katzir-2011]
+* [katzir-2007]
+* [kroch-1972]
+* [horn-1972]
+* [rooth-1985]
+* [sauerland-2004]
+* [fox-2007]
 -/
 
 namespace FoxKatzir2011
 
-open Alternatives.Symmetric
-open Exhaustification (innocent predToFinset altsFromPreds)
+open Alternatives Exhaustification ModalLogic Set Data.Examples
 
+variable {W : Type*}
 
--- ============================================================
--- SECTION 1: Worked Example — Some/All (§1.1, p. 88)
--- ============================================================
+/-! ### Formal alternatives -/
 
-/-!
-## The Canonical Symmetric Example
+section Formal
 
-S = "John did some of the homework"
-S₁ = "John did all of the homework"
-S₂ = "John did some but not all of the homework"
+open Syntax Alternatives.Structural
 
-⟦S₁⟧ ∪ ⟦S₂⟧ = ⟦S⟧ and ⟦S₁⟧ ∩ ⟦S₂⟧ = ∅ — the classic partition.
--/
+variable {C V : Type} (lex : List (Tree C V)) (φ : Tree C V) (salient : List (Tree C V))
 
-section SomeAll
+/-- The substitution source in a context: the lexicon, the sub-constituents of the sentence,
+and the salient constituents of the context. -/
+def contextualSource : List (Tree C V) := lex ++ φ.subtrees ++ salient
 
-/-- Three homework worlds: did all, did some (but not all), did none. -/
-inductive HWWorld where | all_ | someNotAll | none_
-  deriving Repr, DecidableEq, Fintype
+/-- The formal alternatives in a context: whatever is at most as complex as the sentence over
+the contextual substitution source. -/
+def formalAlternatives : Set (Tree C V) :=
+  {ψ | atMostAsComplex (contextualSource lex φ salient) ψ φ}
 
-private def hwDomain : List HWWorld := [.all_, .someNotAll, .none_]
+/-- Without salient constituents the alternatives are [katzir-2007]'s. -/
+theorem formalAlternatives_nil : formalAlternatives lex φ [] = structuralAlternatives lex φ := by
+  rw [formalAlternatives, contextualSource, List.append_nil]
+  rfl
 
-private def didSome : HWWorld → Bool
-  | .all_ | .someNotAll => true | .none_ => false
-private def didAll : HWWorld → Bool
-  | .all_ => true | _ => false
-private def didSomeNotAll : HWWorld → Bool
-  | .someNotAll => true | _ => false
+/-- A salient constituent of the sentence's category is a formal alternative. -/
+theorem mem_formalAlternatives_of_salient {ψ : Tree C V} (hψ : ψ ∈ salient)
+    (hcat : ψ.cat = φ.cat) : ψ ∈ formalAlternatives lex φ salient :=
+  Relation.ReflTransGen.single (StructOp.subst hcat (by simp [contextualSource, hψ]))
 
-/-- "All" and "some but not all" are symmetric alternatives of "some":
-    they partition "some"'s denotation. -/
-theorem some_all_symmetric :
-    isSymmetric hwDomain didSome didAll didSomeNotAll = true := by
-  native_decide
+/-- The symmetric *some but not all* is not a structural alternative of *some*, but it becomes a
+formal alternative once it is salient. -/
+theorem someButNotAll_mem_formalAlternatives :
+    someButNotAllSentence ∈ formalAlternatives exLexicon someSentence [someButNotAllSentence] :=
+  mem_formalAlternatives_of_salient _ _ _ (List.mem_singleton_self _) rfl
 
-/-- Symmetric complement verified: some ∧ ¬all = sbna on this domain. -/
-theorem some_all_complement :
-    hwDomain.all (fun w => (didSome w && !didAll w) == didSomeNotAll w)
-      = true := by
-  native_decide
+end Formal
 
-/-- Alternatives for "some": {some, all, sbna}. -/
-private def someAlts : Finset (Finset HWWorld) :=
-  altsFromPreds [didSome, didAll, didSomeNotAll]
-
-/-- Horn-scale alternatives: {some, all} only — no symmetric partner. -/
-private def hornAlts : Finset (Finset HWWorld) :=
-  altsFromPreds [didSome, didAll]
-
-/-- The prejacent: "some". -/
-private def somePrej : Finset HWWorld := predToFinset didSome
-
-/-- With both symmetric alternatives, neither is innocently excludable:
-    MCE₁ excludes all (index 1), MCE₂ excludes sbna (index 2). -/
-theorem some_symmetric_neither_ie :
-    predToFinset didAll ∉ innocent.excluded someAlts somePrej ∧
-    predToFinset didSomeNotAll ∉ innocent.excluded someAlts somePrej := by
-  decide
-
-/-- Without the symmetric alternative sbna (i.e., with Horn-scale
-    alternatives {some, all}), "all" IS innocently excludable. -/
-theorem some_hornscale_all_ie :
-    predToFinset didAll ∈ innocent.excluded hornAlts somePrej := by
-  decide
-
-/-- The symmetry problem in a nutshell: with the full set
-    {some, all, sbna}, exh is vacuous (no SIs — exhIE = some). With the
-    restricted set {some, all}, exh correctly derives ¬all (exhIE
-    excludes the all-world). -/
-theorem symmetry_problem :
-    innocent.exh someAlts somePrej = somePrej ∧
-    innocent.exh hornAlts somePrej = predToFinset didSome \ predToFinset didAll := by
-  decide
-
-end SomeAll
-
-
--- ============================================================
--- SECTION 2: F Breaks Symmetry — Bridge to Katzir 2007 (§2–3)
--- ============================================================
-
-/-!
-## F Breaks Symmetry
-
-While C cannot break symmetry, the formal alternatives F(S) can.
-[katzir-2007]'s structural definition excludes "some but not all"
-from F("some") because it requires ConjP/NegP structure not derivable
-from the substitution source.
-
-- `all_is_alternative_to_some`: "all" ∈ F("some")
-- `symmetry_problem_solved`: "some but not all" ∉ F("some")
-
-These are re-exported from `Structural.lean`.
--/
-
-section FBreaksSymmetry
-
-open Alternatives.Structural
-
-/-- F contains the non-symmetric alternative (all) but excludes the
-    symmetric partner (sbna). This is exactly what's needed for exh
-    to derive the correct SI ¬all. -/
-theorem f_breaks_symmetry :
-    allSentence ∈ structuralAlternatives exLexicon someSentence ∧
-    someButNotAllSentence ∉ structuralAlternatives exLexicon
-      someSentence :=
-  ⟨all_is_alternative_to_some, symmetry_problem_solved⟩
-
-end FBreaksSymmetry
-
-
--- ============================================================
--- SECTION 3: Unified F for SI and AF (claim 27, p. 94)
--- ============================================================
-
-/-!
-## Unified Definition: F_SI = F_AF (claim 27)
-
-Fox & Katzir argue that the formal alternatives for SI and AF should
-be defined identically — both via structural complexity (extending
-[katzir-2007] to focused constituents).
-
-The standard view (26):
-- For SI: F(S) = Horn scales (stipulated)
-- For AF: F(S) = Rooth's focus semantics (type-based)
-
-Their proposal (37): both use structural alternatives restricted to
-focused constituents:
-  F(S, C) = {S' : S' derived from S by replacing focused
-             constituents with items ≲_C-comparable}
-
-This preserves focus sensitivity (from Rooth) while allowing symmetry
-breaking (from Katzir).
-
-**Simplification**: our `formalAlternatives` does not enforce the focus
-restriction (replacements may target any constituent, not only focused
-ones). The full definition 37 would require focus-marking on parse tree
-nodes. This simplification is conservative: the actual F(S,C) is a
-subset of our `formalAlternatives`.
--/
-
-/-- The substitution source for F(S, C) (conditions 34–35):
-    Lexicon ∪ sub-constituents of S ∪ salient constituents in C.
-
-    This extends [katzir-2007]'s substitution source (def 41)
-    with contextually salient material, enabling examples like
-    Matsumoto's "warm"/"a little bit more than warm" (ex. 36). -/
-def substitutionSourceFC {C W : Type}
-    (lexicon : List (Syntax.Tree C W))
-    (φ : Syntax.Tree C W)
-    (salient : List (Syntax.Tree C W)) :
-    List (Syntax.Tree C W) :=
-  lexicon ++ φ.subtrees ++ salient
-
-/-- Structural alternatives with contextual extension (definition 37).
-    F(S, C) = {S' : S' ≲_C S}, where the substitution source includes
-    salient constituents from context C.
-
-    When `salient = []`, this reduces to [katzir-2007]'s original
-    `structuralAlternatives` (modulo the focus restriction; see above). -/
-def formalAlternatives {C W : Type}
-    (lex : List (Syntax.Tree C W))
-    (φ : Syntax.Tree C W)
-    (salient : List (Syntax.Tree C W)) :
-    Set (Syntax.Tree C W) :=
-  {ψ | Alternatives.Structural.atMostAsComplex
-    (substitutionSourceFC lex φ salient) ψ φ}
-
-
--- ============================================================
--- SECTION 4: N_SI / N_AF — the alternative-selectors (fn. 4, §1.2)
--- ============================================================
-
-/-!
-## Which alternatives get negated?
-
-Once F(S,C) is fixed, two further selections matter:
-
-- `nSI` (footnote 4 in `[fox-katzir-2011]`): for SI, the "standard
-  view" picks the strictly stronger alternatives — those whose
-  denotations are proper subsets of the prejacent.
-- `nAF` (footnote 8 in `[fox-katzir-2011]`): for AF/Only, the
-  standard view picks the *non-weaker* alternatives — those whose
-  denotations are not supersets of the prejacent (so the prejacent
-  itself, anything strictly stronger, and anything logically
-  independent, but not the entailers of the prejacent).
-
-We work at the proposition level: alternatives are elements of
-`Finset (Finset W)` and the prejacent is a `Finset W`. Subset =
-entailment. -/
-
-section Selectors
-
-variable {W : Type} [Fintype W] [DecidableEq W]
-
-/-- N_SI(A, S) (footnote 4): alternatives strictly stronger than S. -/
-def nSI (alts : Finset (Finset W)) (S : Finset W) : Finset (Finset W) :=
-  alts.filter (fun p => p ⊂ S)
-
-/-- N_AF(A, S) (footnote 8): alternatives non-weaker than S. -/
-def nAF (alts : Finset (Finset W)) (S : Finset W) : Finset (Finset W) :=
-  alts.filter (fun p => ¬ S ⊆ p)
-
-omit [Fintype W] in
-/-- Every strictly-stronger alternative is non-weaker, so N_SI ⊆ N_AF.
-    This is why the AF exhaustifier `Only` is at least as informative
-    as the SI strengthener `SM` on the same alternative set. -/
-theorem nSI_subset_nAF (alts : Finset (Finset W)) (S : Finset W) :
-    nSI alts S ⊆ nAF alts S := by
-  intro p hp
-  simp only [nSI, nAF, Finset.mem_filter] at hp ⊢
-  exact ⟨hp.1, hp.2.2⟩
-
-end Selectors
-
-
--- ============================================================
--- SECTION 5: SI / EXC / Only — F&K's exhaustification operators
--- ============================================================
-
-/-!
-## The operators
-
-At the proposition level (treating each sentence as the set of worlds
-where it is true), conjoining the negations of a set of alternatives
-just removes their union from the universe. The four operators are
-therefore set-difference operators parameterised by which N(A,S) we
-use and whether we conjoin with the prejacent:
-
-| operator | F&K eq. | what it returns                                |
-| -------- | :-----: | ---------------------------------------------- |
-| `SI`     | (4)     | `Univ \ ⋃ N_SI(A,S)` — the SI alone            |
-| `SM`     | (5)     | `S \ ⋃ N_SI(A,S)` — strengthened meaning       |
-| `EXC`    | (17)    | `Univ \ ⋃ N_AF(A,S)` — the only-exclusion alone |
-| `Only`   | (18)    | `S \ ⋃ N_AF(A,S)` — `S ∧ EXC_A(S)`             |
--/
+/-! ### The operators -/
 
 section Operators
 
-variable {W : Type} [Fintype W] [DecidableEq W]
+variable (A : Set (Set W)) (S : Set W)
 
-/-- SI_A(S) (eq. 4): conjunction of negations of N_SI(A,S),
-    rendered as the complement of the union of strictly-stronger alts. -/
-def SI (alts : Finset (Finset W)) (S : Finset W) : Finset W :=
-  Finset.univ \ (nSI alts S).biUnion id
+/-- The alternatives negated for scalar implicature: the strictly stronger members. -/
+def nSI : Set (Set W) := {p ∈ A | p ⊂ S}
 
-/-- SM_A(S) = S ∧ SI_A(S) (eq. 5): the strengthened meaning. -/
-def SM (alts : Finset (Finset W)) (S : Finset W) : Finset W :=
-  S \ (nSI alts S).biUnion id
+/-- The alternatives negated by *only*: the non-weaker members. -/
+def nAF : Set (Set W) := {p ∈ A | ¬ S ⊆ p}
 
-/-- EXC_A(S) (eq. 17): the only-style exclusion. -/
-def EXC (alts : Finset (Finset W)) (S : Finset W) : Finset W :=
-  Finset.univ \ (nAF alts S).biUnion id
+/-- The scalar implicature: the negations of the strictly stronger alternatives. -/
+def SI : Set W := ⋂ p ∈ nSI A S, pᶜ
 
-/-- Only_A(S) = S ∧ EXC_A(S) (eq. 18). -/
-def Only (alts : Finset (Finset W)) (S : Finset W) : Finset W :=
-  S \ (nAF alts S).biUnion id
+/-- The strengthened meaning. -/
+def SM : Set W := S ∩ SI A S
 
-omit [Fintype W] in
-theorem SM_subset_S (alts : Finset (Finset W)) (S : Finset W) :
-    SM alts S ⊆ S :=
-  fun _ hw => (Finset.mem_sdiff.mp hw).1
+/-- The exclusion of *only*: the negations of the non-weaker alternatives. -/
+def EXC : Set W := ⋂ p ∈ nAF A S, pᶜ
 
-omit [Fintype W] in
-theorem Only_subset_S (alts : Finset (Finset W)) (S : Finset W) :
-    Only alts S ⊆ S :=
-  fun _ hw => (Finset.mem_sdiff.mp hw).1
+/-- *Only*: the prejacent with the non-weaker alternatives denied. -/
+def Only : Set W := S ∩ EXC A S
 
-omit [Fintype W] in
-/-- Because `nSI ⊆ nAF`, removing the union of N_AF removes at least
-    as much, so `Only` is at least as informative as `SM`. -/
-theorem Only_subset_SM (alts : Finset (Finset W)) (S : Finset W) :
-    Only alts S ⊆ SM alts S := by
-  intro w hw
-  simp only [Only, SM, Finset.mem_sdiff, Finset.mem_biUnion, id_eq] at hw ⊢
-  refine ⟨hw.1, ?_⟩
-  rintro ⟨p, hp_si, hwp⟩
-  exact hw.2 ⟨p, nSI_subset_nAF alts S hp_si, hwp⟩
+variable {A S}
+
+theorem mem_SM {w : W} : w ∈ SM A S ↔ w ∈ S ∧ ∀ p ∈ A, p ⊂ S → w ∉ p := by
+  simp only [SM, SI, nSI, mem_inter_iff, mem_iInter₂, mem_ofPred_eq, mem_compl_iff]
+  exact and_congr_right λ _ =>
+    ⟨λ h p hp hps => h p ⟨hp, hps⟩, λ h p ⟨hp, hps⟩ => h p hp hps⟩
+
+theorem mem_Only {w : W} : w ∈ Only A S ↔ w ∈ S ∧ ∀ p ∈ A, ¬ S ⊆ p → w ∉ p := by
+  simp only [Only, EXC, nAF, mem_inter_iff, mem_iInter₂, mem_ofPred_eq, mem_compl_iff]
+  exact and_congr_right λ _ =>
+    ⟨λ h p hp hps => h p ⟨hp, hps⟩, λ h p ⟨hp, hps⟩ => h p hp hps⟩
+
+theorem nSI_subset_nAF : nSI A S ⊆ nAF A S := λ _ ⟨hp, hps⟩ => ⟨hp, (ssubset_def ▸ hps).2⟩
+
+/-- *Only* is at least as strong as the strengthened meaning. -/
+theorem Only_subset_SM : Only A S ⊆ SM A S := λ _ hw =>
+  mem_SM.2 ⟨(mem_Only.1 hw).1, λ p hp hps => (mem_Only.1 hw).2 p hp (ssubset_def ▸ hps).2⟩
 
 end Operators
 
+/-! ### Symmetry -/
 
--- ============================================================
--- SECTION 6: §4.1 second worked example — disjunction symmetry
--- ============================================================
+section Symmetry
 
-/-!
-## "John did all or none" (eqs. 38–41)
+variable {A : Set (Set W)} {S S₁ S₂ : Set W}
 
-Bare disjunction `(38)`: ⟦all⟧ and ⟦none⟧ partition ⟦all or none⟧, so
-they are symmetric alternatives. Innocent exclusion is therefore
-vacuous — neither disjunct can be negated.
+/-- The symmetry problem: with both symmetric alternatives in the set, the strengthened meaning
+is contradictory, since negating either asserts the other. -/
+theorem SM_eq_empty_of_isSymmetric (h : IsSymmetric S S₁ S₂) (h₁ : S₁ ∈ A) (h₂ : S₂ ∈ A)
+    (hne₁ : S₁.Nonempty) (hne₂ : S₂.Nonempty) : SM A S = ∅ := by
+  ext w
+  simp only [mem_SM, mem_empty_iff_false, iff_false, not_and]
+  intro hw hall
+  have hw' : w ∈ S₁ ∪ S₂ := h.union ▸ hw
+  rcases hw' with hw₁ | hw₂
+  · exact hall S₁ h₁ (h.ssubset_left hne₂) hw₁
+  · exact hall S₂ h₂ (h.symm.ssubset_left hne₁) hw₂
 
-Embedded under a universal `(40)`: the previously symmetric pair
-becomes non-symmetric, because the universal admits worlds where the
-disjunction holds but neither disjunct does. Innocent exclusion now
-derives both SIs.
--/
+/-- *Only* on symmetric alternatives is contradictory as well. -/
+theorem Only_eq_empty_of_isSymmetric (h : IsSymmetric S S₁ S₂) (h₁ : S₁ ∈ A) (h₂ : S₂ ∈ A)
+    (hne₁ : S₁.Nonempty) (hne₂ : S₂.Nonempty) : Only A S = ∅ :=
+  subset_empty_iff.1 ((SM_eq_empty_of_isSymmetric h h₁ h₂ hne₁ hne₂) ▸ Only_subset_SM)
 
-section BareDisjunction
+/-- Neither symmetric alternative is innocently excludable given the assertion. -/
+theorem not_isInnocentlyExcludable_of_isSymmetric (h : IsSymmetric S S₁ S₂)
+    (hne₁ : S₁.Nonempty) : ¬ IsInnocentlyExcludable {S, S₁, S₂} S S₁ := by
+  rw [isInnocentlyExcludable_iff_exhMW_subset_compl _ _ _ (by simp)]
+  obtain ⟨a, ha⟩ := hne₁
+  refine λ h' => h' ⟨h.subset_left ha, ?_⟩ ha
+  rintro ⟨v, hv, hva, hnav⟩
+  have hv' : v ∈ S₁ ∪ S₂ := h.union ▸ hv
+  rcases hv' with hv₁ | hv₂
+  · refine hnav λ c hc hac => ?_
+    simp only [mem_insert_iff, mem_singleton_iff] at hc
+    obtain h1 | h1 | h1 := hc <;> subst c
+    · exact hv
+    · exact hv₁
+    · exact (disjoint_left.1 h.disjoint ha hac).elim
+  · exact disjoint_left.1 h.disjoint ha (hva S₂ (by simp) hv₂)
 
-private def didNone : HWWorld → Bool
-  | .none_ => true | _ => false
+/-- Innocent exclusion negates neither symmetric alternative: exhaustification is vacuous. -/
+theorem exhIE_eq_self_of_isSymmetric (h : IsSymmetric S S₁ S₂) (hne₁ : S₁.Nonempty)
+    (hne₂ : S₂.Nonempty) : exhIE {S, S₁, S₂} S = S := by
+  ext w
+  rw [mem_exhIE_iff _ _ (toFinite _)]
+  refine ⟨λ hw => hw.1, λ hw => ⟨hw, λ q hq => ?_⟩⟩
+  have hq1 := hq.1
+  simp only [mem_insert_iff, mem_singleton_iff] at hq1
+  obtain h1 | h1 | h1 := hq1 <;> subst q
+  · exact (not_isInnocentlyExcludable_of_phi_subset (toFinite _) ⟨w, hw⟩ subset_rfl hq).elim
+  · exact (not_isInnocentlyExcludable_of_isSymmetric h hne₁ hq).elim
+  · have := not_isInnocentlyExcludable_of_isSymmetric h.symm hne₂
+    rw [pair_comm S₂ S₁] at this
+    exact (this hq).elim
 
-/-- "John did all of the homework or did none of it." -/
-private def didAllOrNone : HWWorld → Bool
-  | .all_ | .none_ => true | .someNotAll => false
+/-- With the symmetric alternative absent, as under Horn scales, the other is innocently
+excludable and the implicature arises. -/
+theorem exhIE_pair_eq_sdiff (h : IsSymmetric S S₁ S₂) (hne₂ : S₂.Nonempty) :
+    exhIE {S, S₁} S = S₂ := by
+  obtain ⟨b, hb⟩ := hne₂
+  have hIE : IsInnocentlyExcludable {S, S₁} S S₁ := by
+    refine .of_forall_subset_or_notMem (by simp) (h.subset_right hb)
+      (disjoint_left.1 h.disjoint.symm hb) ?_
+    rintro c hc
+    simp only [mem_insert_iff, mem_singleton_iff] at hc
+    obtain h1 | h1 := hc <;> subst c
+    · exact Or.inl subset_rfl
+    · exact Or.inr (disjoint_left.1 h.disjoint.symm hb)
+  ext w
+  rw [mem_exhIE_iff _ _ (toFinite _), ← h.sdiff_eq, mem_sdiff]
+  refine ⟨λ ⟨hw, h'⟩ => ⟨hw, h' S₁ hIE⟩, λ ⟨hw, hw₁⟩ => ⟨hw, λ q hq => ?_⟩⟩
+  have hq1 := hq.1
+  simp only [mem_insert_iff, mem_singleton_iff] at hq1
+  obtain h1 | h1 := hq1 <;> subst q
+  · exact (not_isInnocentlyExcludable_of_phi_subset (toFinite _) ⟨w, hw⟩ subset_rfl hq).elim
+  · exact hw₁
 
-/-- Eq. 39: ⟦all⟧ and ⟦none⟧ are symmetric alternatives of ⟦all or none⟧. -/
-theorem all_none_symmetric :
-    isSymmetric hwDomain didAllOrNone didAll didNone = true := by
+end Symmetry
+
+/-! ### Universal operators -/
+
+section Universal
+
+variable {R : W → W → Prop} {S S₁ S₂ : Set W}
+
+/-- Necessity as a proposition: the worlds all of whose accessible worlds satisfy `p`. -/
+def nec (R : W → W → Prop) (p : Set W) : Set W := {x | □[R] (· ∈ p) x}
+
+/-- Under a universal operator the alternatives are no longer symmetric whenever some world's
+accessible worlds fall on both sides. -/
+theorem not_isSymmetric_nec {x : W} (hx : x ∈ nec R S) (hx₁ : x ∉ nec R S₁) (hx₂ : x ∉ nec R S₂) :
+    ¬ IsSymmetric (nec R S) (nec R S₁) (nec R S₂) := λ h => by
+  have : x ∈ nec R S₁ ∪ nec R S₂ := h.union ▸ hx
+  exact this.elim hx₁ hx₂
+
+/-- Both implicatures arise under the universal operator: such a world lies in the strengthened
+meaning. -/
+theorem mem_SM_nec {x : W} (hx : x ∈ nec R S) (hx₁ : x ∉ nec R S₁) (hx₂ : x ∉ nec R S₂) :
+    x ∈ SM {nec R S, nec R S₁, nec R S₂} (nec R S) := by
+  refine mem_SM.2 ⟨hx, λ p hp hps => ?_⟩
+  simp only [mem_insert_iff, mem_singleton_iff] at hp
+  obtain h1 | h1 | h1 := hp <;> subst p
+  · exact (ssubset_irrefl _ hps).elim
+  · exact hx₁
+  · exact hx₂
+
+/-- Both exclusions of *only* arise under the universal operator. -/
+theorem mem_Only_nec {x : W} (hx : x ∈ nec R S) (hx₁ : x ∉ nec R S₁) (hx₂ : x ∉ nec R S₂) :
+    x ∈ Only {nec R S, nec R S₁, nec R S₂} (nec R S) := by
+  refine mem_Only.2 ⟨hx, λ p hp hps => ?_⟩
+  simp only [mem_insert_iff, mem_singleton_iff] at hp
+  obtain h1 | h1 | h1 := hp <;> subst p
+  · exact (hps subset_rfl).elim
+  · exact hx₁
+  · exact hx₂
+
+end Universal
+
+/-! ### Contextual restriction -/
+
+section Restriction
+
+variable {S S₁ S₂ : Set W} {F : Set (Set W)}
+
+/-- Context cannot break symmetry: with the context set the relevant propositions, closed under
+negation and conjunction, the actual alternatives keep both symmetric alternatives or
+neither. -/
+theorem mem_inter_of_isSymmetric (h : IsSymmetric S S₁ S₂) (R : BooleanSubalgebra (Set W))
+    (hS : S ∈ R) (hF : S₂ ∈ F) (h₁ : S₁ ∈ (R : Set (Set W)) ∩ F) :
+    S₂ ∈ (R : Set (Set W)) ∩ F :=
+  ⟨h.mem_of_mem hS h₁.1, hF⟩
+
+/-- Exhaustively relevant given a restriction: its *only*-meaning lies in the Boolean closure of
+the restriction. -/
+def ExhaustivelyRelevant (A : Set (Set W)) (p : Set W) : Prop :=
+  Only A p ∈ BooleanSubalgebra.closure A
+
+/-- An allowable restriction of the formal alternatives: it keeps the assertion, and prunes
+nothing exhaustively relevant. -/
+def IsAllowableRestriction (F A : Set (Set W)) (S : Set W) : Prop :=
+  S ∈ A ∧ ∀ p ∈ F \ A, ¬ ExhaustivelyRelevant A p
+
+/-- Neither disjunct of a disjunction can be pruned in favour of the other, symmetric or not:
+its *only*-meaning is the assertion without the kept disjunct. -/
+theorem not_isAllowableRestriction_pair (hS : S = S₁ ∪ S₂) (h₂₁ : ¬ S₂ ⊆ S₁) (hF : S₂ ∈ F)
+    (h₂ : S₂ ∉ ({S, S₁} : Set (Set W))) : ¬ IsAllowableRestriction F {S, S₁} S := by
+  rintro ⟨-, hall⟩
+  refine hall S₂ ⟨hF, h₂⟩ ?_
+  have hOnly : Only {S, S₁} S₂ = S \ S₁ := by
+    subst hS
+    ext w
+    rw [mem_Only, union_sdiff_left, mem_sdiff]
+    simp only [mem_insert_iff, mem_singleton_iff, forall_eq_or_imp, forall_eq]
+    exact ⟨λ ⟨hw, _, h⟩ => ⟨hw, h h₂₁⟩,
+      λ ⟨hw, h⟩ => ⟨hw, λ hn => (hn subset_union_right).elim, λ _ => h⟩⟩
+  rw [ExhaustivelyRelevant, hOnly]
+  exact BooleanSubalgebra.sdiff_mem (BooleanSubalgebra.subset_closure (by simp))
+    (BooleanSubalgebra.subset_closure (by simp))
+
+end Restriction
+
+/-! ### The data -/
+
+/-- A sentence of the data: whether its formal alternatives contain a symmetric pair, whether a
+universal operator intervenes, whether the alternatives at issue are compatible, and whether
+the inference arises. -/
+structure Row where
+  symmetric : Bool
+  universal : Bool
+  compatible : Bool
+  inference : Bool
+  deriving DecidableEq
+
+def yesNoTable : List (String × Bool) := [("yes", true), ("no", false)]
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let s ← ex.parse? "symmetric" yesNoTable
+  let u ← ex.parse? "universal" yesNoTable
+  let c ← ex.parse? "compatible" yesNoTable
+  let i ← ex.parse? "inference" yesNoTable
+  pure ⟨s, u, c, i⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- The inference arises exactly when a universal operator removes the symmetry, or when the
+formal alternatives contain neither a symmetric pair nor compatible disjuncts. -/
+theorem rows_predicted : ∀ r ∈ rows,
+    (r.inference = true ↔ r.universal = true ∨ (r.symmetric = false ∧ r.compatible = false)) := by
   decide
-
-/-- The disjunction's alternative set: {all-or-none, all, none}. -/
-private def disjAlts : Finset (Finset HWWorld) :=
-  altsFromPreds [didAllOrNone, didAll, didNone]
-
-private def disjPrej : Finset HWWorld := predToFinset didAllOrNone
-
-/-- Eq. 38: with both symmetric disjuncts in the alternative set, neither
-    is innocently excludable. -/
-theorem disjunction_neither_ie :
-    predToFinset didAll ∉ innocent.excluded disjAlts disjPrej ∧
-    predToFinset didNone ∉ innocent.excluded disjAlts disjPrej := by
-  decide
-
-/-- Eq. 38: bare disjunction has no SIs — innocent-exclusion exh is vacuous. -/
-theorem disjunction_no_si :
-    innocent.exh disjAlts disjPrej = disjPrej := by
-  decide
-
-end BareDisjunction
-
-
-section EmbeddedDisjunction
-
-/-- Worlds tracking deontic profile: what John's accessible homework
-    completions look like. `reqEither` holds when the accessible worlds
-    contain both an all-world and a none-world but not a some-not-all
-    world — making the disjunction true throughout while neither
-    disjunct is. -/
-inductive RWorld where | reqAll | reqNone | reqEither | reqSomeNotAll
-  deriving Repr, DecidableEq, Fintype
-
-private def rDomain : List RWorld := [.reqAll, .reqNone, .reqEither, .reqSomeNotAll]
-
-/-- ⟦John is determined to do all or none⟧ — true wherever every
-    accessible world has John doing all or none, i.e., everywhere
-    except `reqSomeNotAll`. -/
-private def reqAllOrNone : RWorld → Bool
-  | .reqAll | .reqNone | .reqEither => true
-  | .reqSomeNotAll => false
-
-private def reqAll : RWorld → Bool
-  | .reqAll => true | _ => false
-
-private def reqNone : RWorld → Bool
-  | .reqNone => true | _ => false
-
-/-- Eq. 41: under universal embedding, the previously symmetric pair fails
-    to partition the disjunction — `reqEither` witnesses the gap. -/
-theorem embedded_not_symmetric :
-    isSymmetric rDomain reqAllOrNone reqAll reqNone = false := by
-  decide
-
-private def reqAlts : Finset (Finset RWorld) :=
-  altsFromPreds [reqAllOrNone, reqAll, reqNone]
-
-private def reqPrej : Finset RWorld := predToFinset reqAllOrNone
-
-/-- Eq. 40: under universal embedding both `reqAll` and `reqNone` are
-    innocently excludable. The SIs ¬reqAll and ¬reqNone arise. -/
-theorem embedded_admits_si :
-    predToFinset reqAll ∈ innocent.excluded reqAlts reqPrej ∧
-    predToFinset reqNone ∈ innocent.excluded reqAlts reqPrej := by
-  decide
-
-/-- Eq. 40 (consequence): exhaustification narrows the embedded
-    disjunction to the `reqEither` world — every accessible world has
-    all or none, but not all the same way. -/
-theorem embedded_exh_isolates_either :
-    innocent.exh reqAlts reqPrej = {RWorld.reqEither} := by
-  decide
-
-end EmbeddedDisjunction
-
-
--- ============================================================
--- SECTION 7: §5.1 — Relevance closure ⟹ C cannot break symmetry
--- ============================================================
-
-/-!
-## Why C cannot break symmetry (constraint 28)
-
-Eq. 28 is derived in [fox-katzir-2011] §5.1 from the relevance-
-closure conditions of eq. 50. The theorem itself lives on its theory-
-neutral substrate in `Alternatives/Symmetric.lean` (it predates F&K and
-is used across the post-2011 exhaustification literature); we re-state
-it here so the paper anchor surfaces it.
-
-`Alternatives.Symmetric.context_cannot_break_symmetry` — if a
-`RelevanceClosure` is closed under negation and conjunction (eq. 50),
-and both `S` and `S₁` are relevant, then `S ∧ ¬S₁` is also relevant.
-Combined with `Symmetric.symmetric_complement`
-(`S ∧ ¬S₁ ≡ S₂` whenever `S₁`, `S₂` are symmetric alternatives of `S`),
-this forces `S₂` to be relevant whenever `S₁` is — so contextual
-restriction cannot keep one symmetric alternative while eliminating the
-other.
--/
-
-theorem context_cannot_break_symmetry_FK2011 {W : Type}
-    (rc : Alternatives.Symmetric.RelevanceClosure W)
-    (s s₁ : W → Bool) (hs : rc.relevant s = true)
-    (h₁ : rc.relevant s₁ = true) :
-    rc.relevant (fun w => s w && !s₁ w) = true :=
-  Alternatives.Symmetric.context_cannot_break_symmetry rc s s₁ hs h₁
-
 
 end FoxKatzir2011

--- a/Linglib/Studies/TrinhHaida2015.lean
+++ b/Linglib/Studies/TrinhHaida2015.lean
@@ -56,7 +56,7 @@ namespace TrinhHaida2015
 
 open Syntax (Tree Cat)
 open Syntax.Cat
-open Alternatives.Symmetric (isSymmetric)
+open Alternatives
 open Exhaustification (innocent predToFinset altsFromPreds)
 
 
@@ -321,8 +321,9 @@ theorem full_domain_valid :
 /-- "exactly_three" and "four" are symmetric alternatives of "three":
     they partition its denotation. -/
 theorem cookies_symmetric :
-    isSymmetric cwDomain three exactlyThree four = true := by
-  native_decide
+    IsSymmetric (↑(predToFinset three) : Set CW) (↑(predToFinset exactlyThree) : Set CW)
+      (↑(predToFinset four) : Set CW) :=
+  (isSymmetric_coe _ _ _).2 (by decide)
 
 /-- With A = F(S) (the only valid domain), exhIE is vacuous:
     the symmetric alternatives make exhaustification identity. -/

--- a/references.bib
+++ b/references.bib
@@ -297,7 +297,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {}
+  sources   = {Core/Probability/Softmax.lean;Pragmatics/Bidirectional.lean;Pragmatics/RSA/Basic.lean;Pragmatics/RSA/Canonical.lean;Pragmatics/RSA/Gibbs.lean;Pragmatics/RSA/Operators.lean;Studies/Anderson2021.lean;Studies/BellerGerstenberg2025.lean;Studies/BergenGoodman2015.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/CremersWilcoxSpector2023.lean;Studies/DegenEtAl2020.lean;Studies/FrankGoodman2012.lean;Studies/FrankeBergen2020.lean;Studies/GoldszmidtPearl1996.lean;Studies/HardingGerstenbergIcard2025.lean;Studies/KaoEtAl2014PMFMetaphor.lean;Studies/Kennedy2015.lean;Studies/Kennedy2015PMF.lean;Studies/LassiterGoodman2017.lean;Studies/QingFranke2015.lean;Studies/SikosEtAl2021.lean;Studies/SumersEtAl2023.lean;Studies/TesslerGoodman2019.lean;Studies/Thomas2026.lean}
 }
 @article{sikos-etal-2021,
   author    = {Sikos, Les and Venhuizen, Noortje J. and Drenhaus, Heiner and Crocker, Matthew W.},
@@ -425,7 +425,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Franke2011.json;Pragmatics/Bidirectional.lean;Pragmatics/GameTheory.lean;Pragmatics/SignalingGame/Basic.lean;Pragmatics/SignalingGame/Interpretation.lean;Semantics/Alternatives/Symmetric.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/Franke2011.lean;Studies/Jaeger2014.lean;Studies/Kennedy2015.lean}
+  sources   = {Data/Examples/Franke2011.json;Pragmatics/Bidirectional.lean;Pragmatics/GameTheory.lean;Pragmatics/SignalingGame/Basic.lean;Pragmatics/SignalingGame/Interpretation.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/Franke2011.lean;Studies/Jaeger2014.lean;Studies/Kennedy2015.lean}
 }
 @incollection{qing-franke-2015,
   author    = {Qing, Ciyang and Franke, Michael},
@@ -2626,7 +2626,7 @@
   subfield    = {pragmatics/neogricean},
   validated   = {true},
   role        = {cited},
-  sources     = {Semantics/Alternatives/Symmetric.lean}
+  sources   = {Semantics/Alternatives/Symmetric.lean;Studies/FoxKatzir2011.lean}
 }
 @phdthesis{kroch-1974,
   author    = {Kroch, Anthony},
@@ -2648,7 +2648,7 @@
     subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {foundational},
-  sources   = {Fragments/English/Determiners.lean;Fragments/English/Scales.lean;Pragmatics/Implicature/SomeAll.lean;Semantics/Alternatives/Lexical.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Degree/Adjective.lean;Semantics/Exhaustification/Chain.lean;Semantics/Quantification/Lexicon.lean;Semantics/Quantification/Numerals/Basic.lean;Studies/FillmoreKayOConnor1988.lean;Studies/Horn1972.lean;Studies/Mihoc2019.lean;Studies/ScontrasPearl2021.lean;Studies/Spector2013.lean;Studies/TieuEtAl2020.lean}
+  sources   = {Fragments/English/Determiners.lean;Fragments/English/Scales.lean;Pragmatics/Implicature/SomeAll.lean;Semantics/Alternatives/Lexical.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Degree/Adjective.lean;Semantics/Exhaustification/Chain.lean;Semantics/Quantification/Lexicon.lean;Semantics/Quantification/Numerals/Basic.lean;Studies/FillmoreKayOConnor1988.lean;Studies/FoxKatzir2011.lean;Studies/Horn1972.lean;Studies/Mihoc2019.lean;Studies/ScontrasPearl2021.lean;Studies/Spector2013.lean;Studies/TieuEtAl2020.lean}
 }
 @incollection{horn-1984,
   author    = {Horn, Laurence R.},
@@ -2717,7 +2717,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/TurkHirsch2026.lean;Fragments/Turkish/QuestionParticles.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Studies/BrehenyEtAl2018.lean;Studies/Denic2023.lean;Studies/ElliottSudo2025.lean;Studies/FoxKatzir2011.lean;Studies/LoGuercio2025.lean;Studies/TrinhHaida2015.lean;Studies/TurkHirsch2026.lean}
+  sources   = {Data/Examples/FoxKatzir2011.json;Data/Examples/TurkHirsch2026.lean;Fragments/Turkish/QuestionParticles.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Studies/BrehenyEtAl2018.lean;Studies/Denic2023.lean;Studies/ElliottSudo2025.lean;Studies/FoxKatzir2011.lean;Studies/LoGuercio2025.lean;Studies/TrinhHaida2015.lean;Studies/TurkHirsch2026.lean}
 }
 @article{spector-2016,
   author    = {Spector, Benjamin},
@@ -2835,7 +2835,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {cited},
-  sources   = {Pragmatics/NeoGricean/Basic.lean;Studies/Ahn2015.lean;Studies/Fox2007.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Kennedy2015.lean;Studies/Ronai2024.lean;Studies/Sauerland2004.lean;Studies/VanTielEtAl2016.lean}
+  sources   = {Data/Examples/FoxKatzir2011.json;Pragmatics/NeoGricean/Basic.lean;Studies/Ahn2015.lean;Studies/Fox2007.lean;Studies/FoxKatzir2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Kennedy2015.lean;Studies/Ronai2024.lean;Studies/Sauerland2004.lean;Studies/VanTielEtAl2016.lean}
 }
 @inproceedings{fox-2018,
   author    = {Fox, Danny},
@@ -2864,7 +2864,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Alternatives/Symmetric.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Semantics/Questions/Closure.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Fox2018.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
+  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Semantics/Questions/Closure.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Fox2018.lean;Studies/FoxKatzir2011.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
 }
 @incollection{chierchia-fox-spector-2012,
   author    = {Chierchia, Gennaro and Fox, Danny and Spector, Benjamin},
@@ -11029,7 +11029,7 @@
     subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Alternatives/AltMeaning.lean}
+  sources   = {Semantics/Alternatives/Basic.lean;Studies/Charlow2014.lean;Studies/FoxKatzir2011.lean;Studies/MartinezVera2026.lean;Studies/Rooth1992.lean;Studies/Sternefeld1998.lean;Studies/TurkHirsch2026.lean}
 }% REF: Schwarzschild, R. (1999). GIVENness, AvoidF, and other constraints on the placement of focus. NLS 7: 141-177.
 @article{schwarzschild-1999,
   author    = {Schwarzschild, Roger},
@@ -15344,7 +15344,7 @@
   subfield  = {pragmatics/neogricean},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Wang2025.lean;Studies/Katzir2007.lean}
+  sources   = {Data/Examples/FoxKatzir2011.json;Semantics/Alternatives/Competition.lean;Semantics/Alternatives/Source.lean;Semantics/Alternatives/Structural.lean;Semantics/Alternatives/Symmetric.lean;Studies/BaleKhanjian2014.lean;Studies/BrehenyEtAl2018.lean;Studies/FoxKatzir2011.lean;Studies/FoxSpector2018.lean;Studies/Katzir2007.lean;Studies/KatzirSingh2015.lean;Studies/LoGuercio2025.lean;Studies/TrinhHaida2015.lean;Studies/Wang2025.lean;Syntax/Tree/Basic.lean}
 }% REF: Groenendijk & Roelofsen (2009). Inquisitive Semantics and Pragmatics.
 @article{magri-2009,
   author    = {Magri, Giorgio},


### PR DESCRIPTION
Deep cleanse of FoxKatzir2011 against the paper (NALS 19): the old file was three-world `native_decide` models of the some/all and all-or-none examples, Finset operators, a table-of-sections docstring, and a re-export of the substrate's Bool relevance lemma; the recut states the paper's operators over propositions and proves its claims in general.

- `contextualSource`/`formalAlternatives` (the substitution source with salient constituents; reduces to Katzir 2007 without them, and a salient constituent of the sentence's category is an alternative, so `someButNotAllSentence` enters once salient); `nSI`/`nAF`/`SI`/`SM`/`EXC`/`Only` with `Only_subset_SM`; on symmetric alternatives `SM_eq_empty_of_isSymmetric`, `Only_eq_empty_of_isSymmetric`, and innocent exclusion's `exhIE_eq_self_of_isSymmetric` vs `exhIE_pair_eq_sdiff` under Horn scales; under a universal operator `not_isSymmetric_nec`, `mem_SM_nec`, `mem_Only_nec`; §5: `mem_inter_of_isSymmetric` (context cannot break symmetry), `ExhaustivelyRelevant`/`IsAllowableRestriction` with `not_isAllowableRestriction_pair` for compatible disjuncts
- Substrate `Semantics/Alternatives/Symmetric.lean` recut from Bool/List to `IsSymmetric (s s₁ s₂ : Set W)` (structure, namespace `Alternatives`) with `sdiff_eq`, `ssubset_left`, `mem_of_mem` over a mathlib `BooleanSubalgebra (Set W)` (the paper's closure under negation and conjunction), and `isSymmetric_coe` for finite models; BrehenyEtAl2018 and TrinhHaida2015 migrated (one `native_decide` gone)
- 14 JSON rows ((1)–(3), (29), (33), (38)–(42a), (44), (46), (47a), (49a), (53)) with `rows_predicted`: the inference arises iff a universal operator intervenes or the alternatives are neither symmetric nor compatible
