### PR TITLE
refactor(Studies/FoxPesetsky2005): scenarios over arbitrary terminals

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3063,3 +3063,4 @@ import Linglib.Data.Examples.Fortuny2024
 import Linglib.Data.Examples.Fox2007
 import Linglib.Data.Examples.Fox2018
 import Linglib.Data.Examples.FoxKatzir2011
+import Linglib.Data.Examples.FoxPesetsky2005

--- a/Linglib/Data/Examples/FoxPesetsky2005.json
+++ b/Linglib/Data/Examples/FoxPesetsky2005.json
@@ -1,0 +1,390 @@
+[
+  {
+    "id": "foxpesetsky2005_ex19a",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(19a)"
+    },
+    "language": "swed1254",
+    "primaryText": "Jag kysste henne inte",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Jag",
+        "I"
+      ],
+      [
+        "kysste",
+        "kissed"
+      ],
+      [
+        "henne",
+        "her"
+      ],
+      [
+        "inte",
+        "not"
+      ]
+    ],
+    "translation": "I didn't kiss her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "yes"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "none"
+      ],
+      [
+        "intervenerMoved",
+        "no"
+      ]
+    ],
+    "comment": "Verb-second: the finite verb moves to C and the pronoun shifts."
+  },
+  {
+    "id": "foxpesetsky2005_ex19b",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(19b)"
+    },
+    "language": "swed1254",
+    "primaryText": "att jag henne inte kysste",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "att",
+        "that"
+      ],
+      [
+        "jag",
+        "I"
+      ],
+      [
+        "henne",
+        "her"
+      ],
+      [
+        "inte",
+        "not"
+      ],
+      [
+        "kysste",
+        "kissed"
+      ]
+    ],
+    "translation": "that I didn't kiss her",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "no"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "none"
+      ],
+      [
+        "intervenerMoved",
+        "no"
+      ]
+    ],
+    "comment": "Embedded clause: the complementizer blocks verb movement."
+  },
+  {
+    "id": "foxpesetsky2005_ex19c",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(19c)"
+    },
+    "language": "swed1254",
+    "primaryText": "Jag har henne inte kysst",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Jag",
+        "I"
+      ],
+      [
+        "har",
+        "have"
+      ],
+      [
+        "henne",
+        "her"
+      ],
+      [
+        "inte",
+        "not"
+      ],
+      [
+        "kysst",
+        "kissed"
+      ]
+    ],
+    "translation": "I haven't kissed her.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "no"
+      ],
+      [
+        "aux",
+        "yes"
+      ],
+      [
+        "intervener",
+        "none"
+      ],
+      [
+        "intervenerMoved",
+        "no"
+      ]
+    ],
+    "comment": "The auxiliary moves to C and the participle stays in VP."
+  },
+  {
+    "id": "foxpesetsky2005_ex23a",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(23a)"
+    },
+    "language": "swed1254",
+    "primaryText": "Jag gav den inte Elsa",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Jag",
+        "I"
+      ],
+      [
+        "gav",
+        "gave"
+      ],
+      [
+        "den",
+        "it"
+      ],
+      [
+        "inte",
+        "not"
+      ],
+      [
+        "Elsa",
+        "Elsa"
+      ]
+    ],
+    "translation": "I didn't give it to Elsa.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "yes"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "firstObject"
+      ],
+      [
+        "intervenerMoved",
+        "no"
+      ]
+    ],
+    "comment": "The first object precedes the shifted object in VP."
+  },
+  {
+    "id": "foxpesetsky2005_ex23b",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(23b)"
+    },
+    "language": "swed1254",
+    "primaryText": "Dom kastade mej inte ut",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Dom",
+        "they"
+      ],
+      [
+        "kastade",
+        "threw"
+      ],
+      [
+        "mej",
+        "me"
+      ],
+      [
+        "inte",
+        "not"
+      ],
+      [
+        "ut",
+        "out"
+      ]
+    ],
+    "translation": "They didn't throw me out.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "yes"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "particle"
+      ],
+      [
+        "intervenerMoved",
+        "no"
+      ]
+    ],
+    "comment": "The particle precedes the shifted object in VP."
+  },
+  {
+    "id": "foxpesetsky2005_ex25a",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(25a)"
+    },
+    "language": "swed1254",
+    "primaryText": "Vem gav du den inte",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Vem",
+        "who"
+      ],
+      [
+        "gav",
+        "gave"
+      ],
+      [
+        "du",
+        "you"
+      ],
+      [
+        "den",
+        "it"
+      ],
+      [
+        "inte",
+        "not"
+      ]
+    ],
+    "translation": "Who didn't you give it to?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "yes"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "firstObject"
+      ],
+      [
+        "intervenerMoved",
+        "yes"
+      ]
+    ],
+    "comment": "The first object is wh-moved through the VP edge."
+  },
+  {
+    "id": "foxpesetsky2005_ex25b",
+    "source": {
+      "bibkey": "fox-pesetsky-2005",
+      "paperLabel": "(25b)"
+    },
+    "language": "swed1254",
+    "primaryText": "Ut kastade dom mej inte",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Ut",
+        "out"
+      ],
+      [
+        "kastade",
+        "threw"
+      ],
+      [
+        "dom",
+        "they"
+      ],
+      [
+        "mej",
+        "me"
+      ],
+      [
+        "inte",
+        "not"
+      ]
+    ],
+    "translation": "Out they didn't throw me.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verbToC",
+        "yes"
+      ],
+      [
+        "aux",
+        "no"
+      ],
+      [
+        "intervener",
+        "particle"
+      ],
+      [
+        "intervenerMoved",
+        "yes"
+      ]
+    ],
+    "comment": "The particle is topicalized through the VP edge."
+  }
+]

--- a/Linglib/Data/Examples/FoxPesetsky2005.lean
+++ b/Linglib/Data/Examples/FoxPesetsky2005.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `FoxPesetsky2005` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/FoxPesetsky2005.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace FoxPesetsky2005.Examples`.
+-/
+
+namespace FoxPesetsky2005.Examples
+
+open Data.Examples
+
+def ex19a : LinguisticExample :=
+  { id := "foxpesetsky2005_ex19a"
+    source := ⟨"fox-pesetsky-2005", "(19a)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Jag kysste henne inte"
+    discourseSegments := []
+    glossedTokens := [("Jag", "I"), ("kysste", "kissed"), ("henne", "her"), ("inte", "not")]
+    translation := "I didn't kiss her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "yes"), ("aux", "no"), ("intervener", "none"), ("intervenerMoved", "no")]
+    comment := "Verb-second: the finite verb moves to C and the pronoun shifts."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex19b : LinguisticExample :=
+  { id := "foxpesetsky2005_ex19b"
+    source := ⟨"fox-pesetsky-2005", "(19b)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "att jag henne inte kysste"
+    discourseSegments := []
+    glossedTokens := [("att", "that"), ("jag", "I"), ("henne", "her"), ("inte", "not"), ("kysste", "kissed")]
+    translation := "that I didn't kiss her"
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "no"), ("aux", "no"), ("intervener", "none"), ("intervenerMoved", "no")]
+    comment := "Embedded clause: the complementizer blocks verb movement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex19c : LinguisticExample :=
+  { id := "foxpesetsky2005_ex19c"
+    source := ⟨"fox-pesetsky-2005", "(19c)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Jag har henne inte kysst"
+    discourseSegments := []
+    glossedTokens := [("Jag", "I"), ("har", "have"), ("henne", "her"), ("inte", "not"), ("kysst", "kissed")]
+    translation := "I haven't kissed her."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "no"), ("aux", "yes"), ("intervener", "none"), ("intervenerMoved", "no")]
+    comment := "The auxiliary moves to C and the participle stays in VP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex23a : LinguisticExample :=
+  { id := "foxpesetsky2005_ex23a"
+    source := ⟨"fox-pesetsky-2005", "(23a)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Jag gav den inte Elsa"
+    discourseSegments := []
+    glossedTokens := [("Jag", "I"), ("gav", "gave"), ("den", "it"), ("inte", "not"), ("Elsa", "Elsa")]
+    translation := "I didn't give it to Elsa."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "yes"), ("aux", "no"), ("intervener", "firstObject"), ("intervenerMoved", "no")]
+    comment := "The first object precedes the shifted object in VP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex23b : LinguisticExample :=
+  { id := "foxpesetsky2005_ex23b"
+    source := ⟨"fox-pesetsky-2005", "(23b)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Dom kastade mej inte ut"
+    discourseSegments := []
+    glossedTokens := [("Dom", "they"), ("kastade", "threw"), ("mej", "me"), ("inte", "not"), ("ut", "out")]
+    translation := "They didn't throw me out."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "yes"), ("aux", "no"), ("intervener", "particle"), ("intervenerMoved", "no")]
+    comment := "The particle precedes the shifted object in VP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex25a : LinguisticExample :=
+  { id := "foxpesetsky2005_ex25a"
+    source := ⟨"fox-pesetsky-2005", "(25a)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Vem gav du den inte"
+    discourseSegments := []
+    glossedTokens := [("Vem", "who"), ("gav", "gave"), ("du", "you"), ("den", "it"), ("inte", "not")]
+    translation := "Who didn't you give it to?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "yes"), ("aux", "no"), ("intervener", "firstObject"), ("intervenerMoved", "yes")]
+    comment := "The first object is wh-moved through the VP edge."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex25b : LinguisticExample :=
+  { id := "foxpesetsky2005_ex25b"
+    source := ⟨"fox-pesetsky-2005", "(25b)"⟩
+    reportedIn := none
+    language := "swed1254"
+    primaryText := "Ut kastade dom mej inte"
+    discourseSegments := []
+    glossedTokens := [("Ut", "out"), ("kastade", "threw"), ("dom", "they"), ("mej", "me"), ("inte", "not")]
+    translation := "Out they didn't throw me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbToC", "yes"), ("aux", "no"), ("intervener", "particle"), ("intervenerMoved", "yes")]
+    comment := "The particle is topicalized through the VP edge."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex19a, ex19b, ex19c, ex23a, ex23b, ex25a, ex25b]
+
+end FoxPesetsky2005.Examples

--- a/Linglib/Studies/ErlewineSommerlot2025.lean
+++ b/Linglib/Studies/ErlewineSommerlot2025.lean
@@ -366,12 +366,6 @@ theorem rows_grammatical :
 
 /-! ### The ordering paradoxes -/
 
-/-- A derivation with two contradictory Spell-out statements does not linearize. -/
-theorem not_consistent_of_pair {d : Derivation} {a b : Term}
-    (h₁ : List.Sublist [a, b] d.voicePSpellout) (h₂ : List.Sublist [b, a] d.cpSpellout) :
-    ¬ Consistent [d.voicePSpellout, d.cpSpellout] :=
-  λ h => h a (.tail (.single ⟨_, List.mem_cons_self, h₁⟩) ⟨_, by simp, h₂⟩)
-
 /-- (57): with Voice overt and the agent left in Spec,vP at VoiceP Spell-out, the agent's later
 movement to Spec,TP orders it before Voice at CP, against VoiceP; the derivation cannot
 linearize, whatever else it contains. -/
@@ -383,7 +377,7 @@ theorem overt_voice_paradox (d : Derivation) (hv : d.voiceExp.isSome = true)
     unfold Derivation.moved
     rcases d.extracted with _ | ⟨_⟩ | _ <;> rcases d.subject with _ | _ <;> simp
   have hagent : Term.dp .agent ∈ d.moved := by simp [Derivation.moved, hs]
-  refine not_consistent_of_pair (a := .voice) (b := .dp .agent) ?_ ?_
+  refine not_consistent_of_pair (a := .voice) (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
   · unfold Derivation.voicePSpellout
     rw [if_pos hv, if_pos hi]
     exact (((List.sublist_append_right _ [Term.voice]).append_right [Term.dp .agent]).trans
@@ -401,7 +395,7 @@ theorem bare_passive_agent_paradox (d : Derivation) (ha : d.agentProjected = tru
   have hi : d.agentInSitu = true := by simp [Derivation.agentInSitu, ha, hsp]
   have hm : d.moved = [.dp .agent, .dp .theme] := by
     unfold Derivation.moved; rw [he, hs]; decide
-  refine not_consistent_of_pair (a := .dp .theme) (b := .dp .agent) ?_ ?_
+  refine not_consistent_of_pair (a := .dp .theme) (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
   · unfold Derivation.voicePSpellout
     rw [if_pos hi, if_pos hsp, hsp]
     exact ((((List.sublist_append_right _ [Term.dp .theme]).trans

--- a/Linglib/Studies/ErlewineSommerlot2025.lean
+++ b/Linglib/Studies/ErlewineSommerlot2025.lean
@@ -377,7 +377,8 @@ theorem overt_voice_paradox (d : Derivation) (hv : d.voiceExp.isSome = true)
     unfold Derivation.moved
     rcases d.extracted with _ | ⟨_⟩ | _ <;> rcases d.subject with _ | _ <;> simp
   have hagent : Term.dp .agent ∈ d.moved := by simp [Derivation.moved, hs]
-  refine not_consistent_of_pair (a := .voice) (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
+  refine not_consistent_of_pair (p := d.voicePSpellout) (q := d.cpSpellout) (a := .voice)
+    (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
   · unfold Derivation.voicePSpellout
     rw [if_pos hv, if_pos hi]
     exact (((List.sublist_append_right _ [Term.voice]).append_right [Term.dp .agent]).trans
@@ -395,7 +396,8 @@ theorem bare_passive_agent_paradox (d : Derivation) (ha : d.agentProjected = tru
   have hi : d.agentInSitu = true := by simp [Derivation.agentInSitu, ha, hsp]
   have hm : d.moved = [.dp .agent, .dp .theme] := by
     unfold Derivation.moved; rw [he, hs]; decide
-  refine not_consistent_of_pair (a := .dp .theme) (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
+  refine not_consistent_of_pair (p := d.voicePSpellout) (q := d.cpSpellout) (a := .dp .theme)
+    (b := .dp .agent) List.mem_cons_self (by simp) ?_ ?_
   · unfold Derivation.voicePSpellout
     rw [if_pos hi, if_pos hsp, hsp]
     exact ((((List.sublist_append_right _ [Term.dp .theme]).trans

--- a/Linglib/Studies/FoxPesetsky2005.lean
+++ b/Linglib/Studies/FoxPesetsky2005.lean
@@ -1,93 +1,182 @@
-/-
-Copyright (c) 2026 Robert Hawkins. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Robert Hawkins
--/
 import Linglib.Syntax.Minimalist.Linearization.Cyclic
+import Linglib.Data.Examples.FoxPesetsky2005
 
 /-!
-# Fox & Pesetsky 2005: cyclic linearization
+# Fox and Pesetsky (2005): Cyclic Linearization of Syntactic Structure
 
-[fox-pesetsky-2005]'s worked examples, kernel-checked against the
-`Minimalist.Linearization` spell-out order: the two movement scenarios ((13), (14)),
-successive-cyclic *wh*-movement ((3)–(8)), order-preserving simultaneous movement,
-and Holmberg's Generalization (§3) — plus the paper's central architectural claim,
-that convergence is a property of the derivational history rather than of the
-output string (`history_dependence`).
+This file formalizes [fox-pesetsky-2005]'s account of successive cyclicity and Holmberg's
+Generalization. Spell-out linearizes each domain as the derivation builds it, its ordering
+statements are never deleted, and a derivation converges only if they cohere
+(`Minimalist.Linearization.Consistent`). The paper's derivational scenarios are theorems over
+arbitrary terminals: movement from the left edge of a domain converges (`scenario1`),
+movement from a non-edge position crashes on the pair it reorders (`scenario2`), and moving
+the edge material along restores the order (`scenario3`). Object Shift in Swedish is these
+scenarios with the verb, the object and an intervener as the terminals: it converges only when
+the verb, and any other VP-internal material preceding the object, leaves VP as well
+(`objectShift_verbToC`, `objectShift_embedded`, `objectShift_intervener`,
+`objectShift_intervener_fronted`), and `rows_predicted` computes convergence for the paper's
+Swedish sentences from their configurations.
+
+## Implementation notes
+
+Spell-out domains are lists of terminals and a derivation is its list of snapshots, so the
+scenarios quantify over any type of labels; the consistent cases need the final snapshot to be
+duplicate-free. The Swedish rows record the paper's analysis of each sentence, whether the
+verb moves to C, whether an auxiliary occupies C instead, whether a first object or particle
+precedes the object in VP, and whether that intervener fronts through the VP edge, and
+`Config.phases` builds the VP and CP snapshots of the paper's sketches from them.
+
+## References
+
+* [fox-pesetsky-2005]
+* [chomsky-2000]
+* [chomsky-2001]
 -/
 
 namespace FoxPesetsky2005
 
-open Minimalist.Linearization
+open Minimalist.Linearization Data.Examples
 
-/-- Scenario 1 ([fox-pesetsky-2005] (13)): leftward movement from a left-edge
-    position. `X` was at the left edge of `D`; moving further left in `D′` is
-    consistent with the order established at `D`. -/
-theorem edge_movement_consistent :
-    Consistent [["X", "Y", "Z"], ["X", "α", "Y", "Z"]] := by decide
+variable {α : Type*} {X Y Z a : α}
 
-/-- Scenario 2 ([fox-pesetsky-2005] (14)): leftward movement from a non-edge
-    position. `Y` was not at the left edge of `D`, so moving it left in `D′`
-    contradicts the order established at `D`. -/
-theorem non_edge_movement_contradiction :
-    ¬ Consistent [["X", "Y", "Z"], ["Y", "α", "X", "Z"]] := by decide
+/-! ### Derivational scenarios -/
 
-/-- Successive-cyclic *wh*-movement ([fox-pesetsky-2005] (6)–(8)): *to whom* moves
-    through the VP edge before Spec,CP, preserving VP-internal order. -/
-theorem successive_cyclic_ok :
-    Consistent [["to_whom", "gave", "the_book"],
-                ["to_whom", "that", "Mary", "gave", "the_book"]] := by decide
+/-- Scenario 1: leftward movement from the left edge of a domain converges. -/
+theorem scenario1 [DecidableEq α] (hnd : [X, a, Y, Z].Nodup) :
+    Consistent [[X, Y, Z], [X, a, Y, Z]] := by
+  refine consistent_of_forall_sublist (λ p hp => ?_) hnd
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl
+  · exact (((List.Sublist.refl [Y, Z]).cons a).cons_cons X)
+  · exact List.Sublist.refl _
 
-/-- Non-successive-cyclic movement ([fox-pesetsky-2005] (3)–(5)): *to whom* skips
-    the VP edge, contradicting VP-internal order. -/
-theorem non_successive_cyclic_bad :
-    ¬ Consistent [["gave", "the_book", "to_whom"],
-                  ["to_whom", "that", "Mary", "gave", "the_book"]] := by decide
+/-- Scenario 2: leftward movement from a non-edge position reorders the moved element and the
+edge, and the derivation crashes whatever else it contains. -/
+theorem scenario2 : ¬ Consistent [[X, Y, Z], [Y, a, X, Z]] :=
+  not_consistent_of_pair List.mem_cons_self (by simp)
+    (((List.nil_sublist [Z]).cons_cons Y).cons_cons X)
+    ((((List.nil_sublist [Z]).cons_cons X).cons a).cons_cons Y)
 
-/-- **The paper's central architectural claim**: convergence is a property of the
-    derivational history, not the output — the same final Spell-out converges after
-    successive-cyclic movement through the VP edge and crashes without it. The
-    spell-out order does not factor through the final string. -/
-theorem history_dependence :
-    Consistent [["to_whom", "gave", "the_book"],
-                ["to_whom", "that", "Mary", "gave", "the_book"]] ∧
-    ¬ Consistent [["gave", "the_book", "to_whom"],
-                  ["to_whom", "that", "Mary", "gave", "the_book"]] :=
-  ⟨successive_cyclic_ok, non_successive_cyclic_bad⟩
+/-- Scenario 3: moving the edge material along with the non-edge element preserves their order,
+so the derivation converges. -/
+theorem scenario3 [DecidableEq α] (hnd : [X, Y, a, Z].Nodup) :
+    Consistent [[X, Y, Z], [X, Y, a, Z]] := by
+  refine consistent_of_forall_sublist (λ p hp => ?_) hnd
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl
+  · exact ((((List.Sublist.refl [Z]).cons a).cons_cons Y).cons_cons X)
+  · exact List.Sublist.refl _
 
-/-- Simultaneous movement preserving relative order creates no contradiction
-    (the configuration behind Malayic object extraction,
-    `Studies/ErlewineSommerlot2025.lean`). -/
-theorem simultaneous_order_preserving :
-    Consistent [["A", "B", "C"], ["A", "B", "D", "C"]] := by decide
+/-- An ordering cycle through several Spell-outs crashes as well: the crash condition is the
+acyclicity of the accumulated order, not a directly contradicted pair. -/
+theorem cycle {b c : α} : ¬ Consistent [[a, b], [b, c], [c, a]] := λ h =>
+  h a (.tail (.tail (.single ⟨[a, b], by simp, List.Sublist.refl _⟩) ⟨[b, c], by simp,
+    List.Sublist.refl _⟩) ⟨[c, a], by simp, List.Sublist.refl _⟩)
 
-/-- Simultaneous movement reversing relative order contradicts. -/
-theorem simultaneous_order_reversing :
-    ¬ Consistent [["B", "A", "C"], ["A", "B", "D", "C"]] := by decide
+/-! ### Holmberg's Generalization -/
 
-/-- A purely transitive ordering cycle also crashes: the crash condition is
-    acyclicity of the full spell-out order, not the absence of a directly
-    contradicting pair. -/
-theorem transitive_cycle_crashes :
-    ¬ Consistent [["a", "b"], ["b", "c"], ["c", "a"]] := by decide
+section Holmberg
 
-/-! ### Holmberg's Generalization ([fox-pesetsky-2005] §3)
+variable {S V O adv C aux XP : α}
 
-Object Shift in Scandinavian is possible only when the verb also moves out of VP:
-VP Spell-out establishes V < Obj, and a shifted object with an in-situ verb reverses
-it at the higher domain. -/
+/-- Object Shift with the verb in C: VP orders the verb before the object and CP keeps it so. -/
+theorem objectShift_verbToC [DecidableEq α] (hnd : [S, V, O, adv].Nodup) :
+    Consistent [[V, O], [S, V, O, adv]] := by
+  refine consistent_of_forall_sublist (λ p hp => ?_) hnd
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl
+  · exact ((((List.nil_sublist [adv]).cons_cons O).cons_cons V).cons S)
+  · exact List.Sublist.refl _
 
-/-- Baseline: no Object Shift, verb moves to I. -/
-theorem no_object_shift :
-    Consistent [["V", "Obj"], ["Subj", "V", "Neg", "Obj"]] := by decide
+/-- Object Shift in an embedded clause, where the verb stays in VP: the shifted object precedes
+the verb at CP against VP, and the derivation crashes. -/
+theorem objectShift_embedded : ¬ Consistent [[V, O], [C, S, O, adv, V]] :=
+  not_consistent_of_pair List.mem_cons_self (by simp) (List.Sublist.refl _)
+    ((((((List.nil_sublist []).cons_cons V).cons adv).cons_cons O).cons S).cons C)
 
-/-- Object Shift with verb movement: V < Obj is preserved past Neg. -/
-theorem object_shift_with_verb_movement :
-    Consistent [["V", "Obj"], ["Subj", "V", "Obj", "Neg"]] := by decide
+/-- Object Shift under an auxiliary in C: the same contradiction. -/
+theorem objectShift_aux : ¬ Consistent [[V, O], [S, aux, O, adv, V]] :=
+  not_consistent_of_pair List.mem_cons_self (by simp) (List.Sublist.refl _)
+    ((((((List.nil_sublist []).cons_cons V).cons adv).cons_cons O).cons aux).cons S)
 
-/-- Object Shift without verb movement reverses V < Obj — this crash **is**
-    Holmberg's Generalization, derived from cyclic linearization. -/
-theorem object_shift_without_verb_movement :
-    ¬ Consistent [["V", "Obj"], ["Subj", "Obj", "Neg", "V"]] := by decide
+/-- Any VP-internal material preceding the object blocks Object Shift, verb movement or not:
+the intervener precedes the object at VP and follows it at CP. -/
+theorem objectShift_intervener : ¬ Consistent [[V, XP, O], [S, V, O, adv, XP]] :=
+  not_consistent_of_pair List.mem_cons_self (by simp)
+    ((((List.nil_sublist []).cons_cons O).cons_cons XP).cons V)
+    ((((((List.nil_sublist []).cons_cons XP).cons adv).cons_cons O).cons V).cons S)
+
+/-- An intervener that fronts through the VP edge no longer blocks Object Shift: the order
+established at VP is the order at CP. -/
+theorem objectShift_intervener_fronted [DecidableEq α] (hnd : [XP, V, S, O, adv].Nodup) :
+    Consistent [[XP, V, O], [XP, V, S, O, adv]] := by
+  refine consistent_of_forall_sublist (λ p hp => ?_) hnd
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hp
+  rcases hp with rfl | rfl
+  · exact (((((List.nil_sublist [adv]).cons_cons O).cons S).cons_cons V).cons_cons XP)
+  · exact List.Sublist.refl _
+
+end Holmberg
+
+/-! ### The Swedish data -/
+
+/-- The terminals of the paper's Object Shift sketches. -/
+inductive Label
+  | S
+  | V
+  | O
+  | adv
+  | C
+  | aux
+  | XP
+  deriving DecidableEq, Repr
+
+/-- The paper's analysis of an Object Shift sentence: whether the finite verb moves to C,
+whether an auxiliary occupies C instead, whether a first object or particle precedes the object
+in VP, and whether that intervener fronts through the VP edge. -/
+structure Config where
+  verbToC : Bool
+  aux : Bool
+  intervener : Bool
+  intervenerMoved : Bool
+  deriving DecidableEq, Repr
+
+namespace Config
+
+/-- The VP snapshot: an intervener that will front has first moved to the VP edge. -/
+def vp (c : Config) : List Label :=
+  if c.intervener then (if c.intervenerMoved then [.XP, .V, .O] else [.V, .XP, .O]) else [.V, .O]
+
+/-- The CP snapshot after Object Shift. -/
+def cp (c : Config) : List Label :=
+  (if c.verbToC then (if c.intervenerMoved then [.XP, .V, .S] else [.S, .V])
+    else if c.aux then [.S, .aux] else [.C, .S]) ++
+  [.O, .adv] ++ (if c.verbToC then [] else [.V]) ++
+  (if c.intervener ∧ ¬ c.intervenerMoved then [.XP] else [])
+
+/-- The derivation's snapshots. -/
+def phases (c : Config) : List (List Label) := [c.vp, c.cp]
+
+end Config
+
+structure Row where
+  config : Config
+  judgment : Features.Judgment
+  deriving DecidableEq
+
+def yesNoTable : List (String × Bool) := [("yes", true), ("no", false)]
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let v ← ex.parse? "verbToC" yesNoTable
+  let x ← ex.parse? "aux" yesNoTable
+  let i ← ex.parse? "intervener" [("none", false), ("firstObject", true), ("particle", true)]
+  let m ← ex.parse? "intervenerMoved" yesNoTable
+  pure ⟨⟨v, x, i, m⟩, ex.judgment⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- The paper's Swedish sentences are acceptable exactly when their derivations linearize. -/
+theorem rows_predicted : ∀ r ∈ rows, (r.judgment = .acceptable ↔ Consistent r.config.phases) := by
+  decide
 
 end FoxPesetsky2005

--- a/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
@@ -85,6 +85,12 @@ theorem spelloutOrder_perm (h : ps.Perm qs) : spelloutOrder ps = spelloutOrder q
   exact propext ⟨spelloutOrder_mono fun p hp => h.mem_iff.mp hp,
     spelloutOrder_mono fun p hp => h.mem_iff.mpr hp⟩
 
+/-- Two Spell-outs ordering a pair both ways make an ordering contradiction: the derivation does
+not linearize, whatever else it contains. -/
+theorem not_consistent_of_pair {p q : List α} (hp : p ∈ phases) (hq : q ∈ phases)
+    (h₁ : [a, b] <+ p) (h₂ : [b, a] <+ q) : ¬ Consistent phases :=
+  fun h => h a (.tail (.single ⟨p, hp, h₁⟩) ⟨q, hq, h₂⟩)
+
 variable [DecidableEq α]
 
 /-- On a single duplicate-free snapshot, the induced order is index order. -/
@@ -112,11 +118,6 @@ theorem consistent_of_forall_sublist {q : List α} (h : ∀ p ∈ phases, p <+ q
     (Relation.TransGen.mono (fun _ _ ⟨p, hp, hs⟩ => ⟨q, List.mem_singleton_self q, hs.trans (h p hp)⟩)
       a a hab)
 
-/-- Two Spell-outs ordering a pair both ways make an ordering contradiction: the derivation does
-not linearize, whatever else it contains. -/
-theorem not_consistent_of_pair {p q : List α} (hp : p ∈ phases) (hq : q ∈ phases)
-    (h₁ : [a, b] <+ p) (h₂ : [b, a] <+ q) : ¬ Consistent phases :=
-  fun h => h a (.tail (.single ⟨p, hp, h₁⟩) ⟨q, hq, h₂⟩)
 
 /-! ### Decidability
 

--- a/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Cyclic.lean
@@ -104,6 +104,20 @@ theorem spelloutOrder_singleton_idxOf {p : List α} (hnd : p.Nodup)
 theorem consistent_singleton {p : List α} (hnd : p.Nodup) : Consistent [p] :=
   fun _ h => Nat.lt_irrefl _ (spelloutOrder_singleton_idxOf hnd h)
 
+/-- Order Preservation at work: a derivation every one of whose Spell-outs is a sub-order of one
+duplicate-free Spell-out linearizes. -/
+theorem consistent_of_forall_sublist {q : List α} (h : ∀ p ∈ phases, p <+ q) (hnd : q.Nodup) :
+    Consistent phases := fun a hab =>
+  consistent_singleton hnd a
+    (Relation.TransGen.mono (fun _ _ ⟨p, hp, hs⟩ => ⟨q, List.mem_singleton_self q, hs.trans (h p hp)⟩)
+      a a hab)
+
+/-- Two Spell-outs ordering a pair both ways make an ordering contradiction: the derivation does
+not linearize, whatever else it contains. -/
+theorem not_consistent_of_pair {p q : List α} (hp : p ∈ phases) (hq : q ∈ phases)
+    (h₁ : [a, b] <+ p) (h₂ : [b, a] <+ q) : ¬ Consistent phases :=
+  fun h => h a (.tail (.single ⟨p, hp, h₁⟩) ⟨q, hq, h₂⟩)
+
 /-! ### Decidability
 
 `Consistent` decides on concrete phase data: the candidate order's generator only

--- a/references.bib
+++ b/references.bib
@@ -18058,7 +18058,7 @@
     subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {}
+  sources   = {Features/Slot.lean;Studies/BakerVinokurova2010.lean;Studies/BejarRezac2003.lean;Studies/FoxPesetsky2005.lean;Studies/LiuYip2026.lean;Studies/Scott2023.lean;Studies/Zeijlstra2012.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/LateMerger.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
 }
 @incollection{chomsky-2001,
   author    = {Chomsky, Noam},
@@ -18072,7 +18072,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Syntax/Minimalist/Features.lean;Syntax/Minimalist/Verbal/Voice.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Movement/Smuggling.lean;Syntax/Case/Filter.lean;Syntax/Case/Dependent.lean}
+  sources   = {Studies/BakerVinokurova2010.lean;Studies/CoonMateoPedroPreminger2014.lean;Studies/FoxPesetsky2005.lean;Studies/Greco2020.lean;Studies/LiuYip2026.lean;Studies/Scott2023.lean;Syntax/Minimalist/Case.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }
 % REF: Richards, N. (1997). What Moves Where When in Which Language? MIT dissertation.
 @phdthesis{richards-1997,
@@ -19783,7 +19783,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/ErlewineSommerlot2025.lean;Studies/FoxPesetsky2005.lean;Studies/SandeClemDabkowski2026.lean;Studies/ShenHuang2026.lean;Syntax/Minimalist/Linearization/Cyclic.lean;Syntax/Minimalist/Phase/Basic.lean}
+  sources   = {Data/Examples/FoxPesetsky2005.json;Studies/ErlewineSommerlot2025.lean;Studies/FoxPesetsky2005.lean;Studies/SandeClemDabkowski2026.lean;Studies/ShenHuang2026.lean;Syntax/Minimalist/Linearization/Cyclic.lean;Syntax/Minimalist/Phase/Basic.lean}
 }
 @book{abels-2012,
   author    = {Abels, Klaus},


### PR DESCRIPTION
Cleanse of FoxPesetsky2005 against the paper (Zotero): the old file checked string-labelled snapshots by `decide` with no data and no references; the recut states the paper's derivational scenarios and Holmberg's Generalization as theorems over arbitrary terminals and computes convergence for the paper's Swedish sentences.

- Substrate `Linearization/Cyclic.lean`: `consistent_of_forall_sublist` (Order Preservation: snapshots that are sub-orders of one duplicate-free Spell-out converge) and `not_consistent_of_pair` (a pair ordered both ways crashes), the latter promoted from ErlewineSommerlot2025's local lemma
- `scenario1`/`scenario2`/`scenario3` and `cycle`; `objectShift_verbToC`, `objectShift_embedded`, `objectShift_aux`, `objectShift_intervener`, `objectShift_intervener_fronted` for the sketches of §4; `Config` (verb to C, auxiliary, intervener, intervener fronted) with `Config.phases` building the VP and CP snapshots
- 7 Swedish JSON rows ((19a–c), (23a–b), (25a–b)) with `rows_predicted`: acceptable iff the derived snapshots linearize
