### PR TITLE
refactor(Studies/FoxSpector2018): economy over continuations

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3064,3 +3064,4 @@ import Linglib.Data.Examples.Fox2007
 import Linglib.Data.Examples.Fox2018
 import Linglib.Data.Examples.FoxKatzir2011
 import Linglib.Data.Examples.FoxPesetsky2005
+import Linglib.Data.Examples.FoxSpector2018

--- a/Linglib/Data/Examples/FoxSpector2018.json
+++ b/Linglib/Data/Examples/FoxSpector2018.json
@@ -1,0 +1,568 @@
+[
+  {
+    "id": "foxspector2018_ex14a",
+    "source": {
+      "bibkey": "hurford-1974",
+      "paperLabel": "Hurford's Constraint"
+    },
+    "language": "stan1293",
+    "primaryText": "John was born in France or Paris.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "no"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "The second disjunct entails the first and no scalar alternative lets exhaustification break the entailment.",
+    "reportedIn": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(14a)"
+    }
+  },
+  {
+    "id": "foxspector2018_ex14b",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(14b)"
+    },
+    "language": "stan1293",
+    "primaryText": "I have a dog or a German Shepherd.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "no"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxspector2018_ex16a",
+    "source": {
+      "bibkey": "hurford-1974",
+      "paperLabel": "(16a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John talked to Mary or Sue or both.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "Exhaustifying the first disjunct excludes 'both', so the second no longer entails it.",
+    "reportedIn": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(16a)"
+    }
+  },
+  {
+    "id": "foxspector2018_ex16b",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(16b)"
+    },
+    "language": "stan1293",
+    "primaryText": "John did some or all of the homework.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxspector2018_ex16c",
+    "source": {
+      "bibkey": "gazdar-1979",
+      "paperLabel": "(16c)"
+    },
+    "language": "stan1293",
+    "primaryText": "John read three books or more.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "",
+    "reportedIn": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(16c)"
+    }
+  },
+  {
+    "id": "foxspector2018_ex18a",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(18a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John has three or six children.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "yes"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "Exhaustification of the first disjunct has a detectable effect: four or five children falsify it."
+  },
+  {
+    "id": "foxspector2018_ex18b",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(18b)"
+    },
+    "language": "stan1293",
+    "primaryText": "The water is warm or absolutely boiling.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "yes"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxspector2018_ex12b",
+    "source": {
+      "bibkey": "singh-2008",
+      "paperLabel": "Singh's Asymmetry"
+    },
+    "language": "stan1293",
+    "primaryText": "John talked to both Mary and Sue, or to Mary or Sue.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "reverse"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "Exhaustifying the final disjunct is incrementally vacuous.",
+    "reportedIn": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(12b)"
+    }
+  },
+  {
+    "id": "foxspector2018_ex46",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(46)"
+    },
+    "language": "stan1293",
+    "primaryText": "The water is absolutely boiling or somewhat warm.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "reverse"
+      ],
+      [
+        "distant",
+        "yes"
+      ],
+      [
+        "de",
+        "0"
+      ]
+    ],
+    "comment": "A reverse Hurford disjunction of distant entailing disjuncts: exhaustification is not vacuous."
+  },
+  {
+    "id": "foxspector2018_ex10a",
+    "source": {
+      "bibkey": "gajewski-sharvit-2012",
+      "paperLabel": "Hurford under negation"
+    },
+    "language": "stan1293",
+    "primaryText": "John didn't talk to Mary or Sue, or both.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "1"
+      ]
+    ],
+    "comment": "Under one downward-entailing operator exhaustification is incrementally weakening.",
+    "reportedIn": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(10a)"
+    }
+  },
+  {
+    "id": "foxspector2018_ex65a",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(65a)"
+    },
+    "language": "stan1293",
+    "primaryText": "John didn't hand in the first or second assignment or both.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "1"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxspector2018_ex65b",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(65b)"
+    },
+    "language": "stan1293",
+    "primaryText": "Everyone who didn't hand in the first or second assignment or both failed the class.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "2"
+      ]
+    ],
+    "comment": "Two downward-entailing operators make the context upward-entailing again."
+  },
+  {
+    "id": "foxspector2018_ex66a",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(66a)"
+    },
+    "language": "stan1293",
+    "primaryText": "I would go to the movies without John or Bill or both.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "1"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "foxspector2018_ex66b",
+    "source": {
+      "bibkey": "fox-spector-2018",
+      "paperLabel": "(66b)"
+    },
+    "language": "stan1293",
+    "primaryText": "I wouldn't go to the movies without John or Bill or both.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "hurford",
+        "yes"
+      ],
+      [
+        "rescuable",
+        "yes"
+      ],
+      [
+        "order",
+        "canonical"
+      ],
+      [
+        "distant",
+        "no"
+      ],
+      [
+        "de",
+        "2"
+      ]
+    ],
+    "comment": ""
+  }
+]

--- a/Linglib/Data/Examples/FoxSpector2018.lean
+++ b/Linglib/Data/Examples/FoxSpector2018.lean
@@ -1,0 +1,270 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `FoxSpector2018` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/FoxSpector2018.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace FoxSpector2018.Examples`.
+-/
+
+namespace FoxSpector2018.Examples
+
+open Data.Examples
+
+def ex14a : LinguisticExample :=
+  { id := "foxspector2018_ex14a"
+    source := ⟨"hurford-1974", "Hurford's Constraint"⟩
+    reportedIn := some ⟨"fox-spector-2018", "(14a)"⟩
+    language := "stan1293"
+    primaryText := "John was born in France or Paris."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "no"), ("order", "canonical"), ("distant", "no"), ("de", "0")]
+    comment := "The second disjunct entails the first and no scalar alternative lets exhaustification break the entailment."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14b : LinguisticExample :=
+  { id := "foxspector2018_ex14b"
+    source := ⟨"fox-spector-2018", "(14b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I have a dog or a German Shepherd."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "no"), ("order", "canonical"), ("distant", "no"), ("de", "0")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16a : LinguisticExample :=
+  { id := "foxspector2018_ex16a"
+    source := ⟨"hurford-1974", "(16a)"⟩
+    reportedIn := some ⟨"fox-spector-2018", "(16a)"⟩
+    language := "stan1293"
+    primaryText := "John talked to Mary or Sue or both."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "0")]
+    comment := "Exhaustifying the first disjunct excludes 'both', so the second no longer entails it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16b : LinguisticExample :=
+  { id := "foxspector2018_ex16b"
+    source := ⟨"fox-spector-2018", "(16b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John did some or all of the homework."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "0")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16c : LinguisticExample :=
+  { id := "foxspector2018_ex16c"
+    source := ⟨"gazdar-1979", "(16c)"⟩
+    reportedIn := some ⟨"fox-spector-2018", "(16c)"⟩
+    language := "stan1293"
+    primaryText := "John read three books or more."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "0")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex18a : LinguisticExample :=
+  { id := "foxspector2018_ex18a"
+    source := ⟨"fox-spector-2018", "(18a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John has three or six children."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "yes"), ("de", "0")]
+    comment := "Exhaustification of the first disjunct has a detectable effect: four or five children falsify it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex18b : LinguisticExample :=
+  { id := "foxspector2018_ex18b"
+    source := ⟨"fox-spector-2018", "(18b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The water is warm or absolutely boiling."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "yes"), ("de", "0")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex12b : LinguisticExample :=
+  { id := "foxspector2018_ex12b"
+    source := ⟨"singh-2008", "Singh's Asymmetry"⟩
+    reportedIn := some ⟨"fox-spector-2018", "(12b)"⟩
+    language := "stan1293"
+    primaryText := "John talked to both Mary and Sue, or to Mary or Sue."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "reverse"), ("distant", "no"), ("de", "0")]
+    comment := "Exhaustifying the final disjunct is incrementally vacuous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex46 : LinguisticExample :=
+  { id := "foxspector2018_ex46"
+    source := ⟨"fox-spector-2018", "(46)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The water is absolutely boiling or somewhat warm."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "reverse"), ("distant", "yes"), ("de", "0")]
+    comment := "A reverse Hurford disjunction of distant entailing disjuncts: exhaustification is not vacuous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex10a : LinguisticExample :=
+  { id := "foxspector2018_ex10a"
+    source := ⟨"gajewski-sharvit-2012", "Hurford under negation"⟩
+    reportedIn := some ⟨"fox-spector-2018", "(10a)"⟩
+    language := "stan1293"
+    primaryText := "John didn't talk to Mary or Sue, or both."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "1")]
+    comment := "Under one downward-entailing operator exhaustification is incrementally weakening."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex65a : LinguisticExample :=
+  { id := "foxspector2018_ex65a"
+    source := ⟨"fox-spector-2018", "(65a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John didn't hand in the first or second assignment or both."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "1")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex65b : LinguisticExample :=
+  { id := "foxspector2018_ex65b"
+    source := ⟨"fox-spector-2018", "(65b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everyone who didn't hand in the first or second assignment or both failed the class."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "2")]
+    comment := "Two downward-entailing operators make the context upward-entailing again."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex66a : LinguisticExample :=
+  { id := "foxspector2018_ex66a"
+    source := ⟨"fox-spector-2018", "(66a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I would go to the movies without John or Bill or both."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "1")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex66b : LinguisticExample :=
+  { id := "foxspector2018_ex66b"
+    source := ⟨"fox-spector-2018", "(66b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I wouldn't go to the movies without John or Bill or both."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("hurford", "yes"), ("rescuable", "yes"), ("order", "canonical"), ("distant", "no"), ("de", "2")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex14a, ex14b, ex16a, ex16b, ex16c, ex18a, ex18b, ex12b, ex46, ex10a, ex65a, ex65b, ex66a, ex66b]
+
+end FoxSpector2018.Examples

--- a/Linglib/Semantics/Exhaustification/InnocentExclusion.lean
+++ b/Linglib/Semantics/Exhaustification/InnocentExclusion.lean
@@ -353,6 +353,41 @@ theorem exhIE_eq_of_iff (hfin : ALT.Finite) {P : Set World → Prop}
   · rintro ⟨hw, h'⟩
     exact ⟨hw, λ q hq => h' q hq.1 ((h q hq.1).1 hq)⟩
 
+/-- Exhaustification entails its prejacent. -/
+theorem exhIE_subset : exhIE ALT φ ⊆ φ := λ _ h => h φ (self_mem_IE ALT φ)
+
+/-- Without alternatives, exhaustification is vacuous. -/
+theorem exhIE_empty : exhIE ∅ φ = φ :=
+  Set.Subset.antisymm (exhIE_subset ∅ φ) λ _ hu =>
+    (mem_exhIE_iff ∅ φ (Set.finite_empty)).2 ⟨hu, λ _ h => h.1.elim⟩
+
+/-- Exhaustification is antitone in the innocently excludable alternatives: more of them, a
+stronger result. -/
+theorem exhIE_subset_exhIE {ALT' : Set (Set World)} (hfin : ALT.Finite) (hfin' : ALT'.Finite)
+    (h : ∀ q, IsInnocentlyExcludable ALT' φ q → IsInnocentlyExcludable ALT φ q) :
+    exhIE ALT φ ⊆ exhIE ALT' φ := λ _ hu =>
+  (mem_exhIE_iff ALT' φ hfin').2
+    ⟨((mem_exhIE_iff ALT φ hfin).1 hu).1, λ q hq => ((mem_exhIE_iff ALT φ hfin).1 hu).2 q (h q hq)⟩
+
+/-- Against one alternative that some prejacent world falsifies, exhaustification denies exactly
+it. -/
+theorem exhIE_pair_sdiff {d : Set World} (hne : (φ \ d).Nonempty) : exhIE {φ, d} φ = φ \ d := by
+  obtain ⟨w, hw⟩ := hne
+  have hIE : IsInnocentlyExcludable {φ, d} φ d :=
+    .of_forall_subset_or_notMem (by simp) hw.1 hw.2 λ b hb => by
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hb
+      obtain h1 | h1 := hb <;> subst b
+      · exact Or.inl subset_rfl
+      · exact Or.inr hw.2
+  ext u
+  rw [mem_exhIE_iff _ _ (Set.toFinite _), Set.mem_sdiff]
+  refine ⟨λ ⟨hu, h⟩ => ⟨hu, h d hIE⟩, λ ⟨hu, hud⟩ => ⟨hu, λ q hq => ?_⟩⟩
+  have hq1 := hq.1
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hq1
+  obtain h1 | h1 := hq1 <;> subst q
+  · exact (not_isInnocentlyExcludable_of_phi_subset (Set.toFinite _) ⟨u, hu⟩ subset_rfl hq).elim
+  · exact hud
+
 
 /-- A world is minimal iff it verifies some maximal compatible set. -/
 theorem mem_exhMW_iff_exists_isMCSet (u : World) :

--- a/Linglib/Studies/FoxSpector2018.lean
+++ b/Linglib/Studies/FoxSpector2018.lean
@@ -1,467 +1,294 @@
-import Mathlib.Tactic.DeriveFintype
 import Linglib.Semantics.Exhaustification.InnocentExclusion
-import Linglib.Semantics.Exhaustification.Finite
+import Linglib.Data.Examples.FoxSpector2018
 
 /-!
-# Fox & Spector 2018: Economy and Embedded Exhaustification
-[fox-spector-2018]
+# Fox and Spector (2018): Economy and Embedded Exhaustification
 
-Fox, D. & Spector, B. (2018). Economy and embedded exhaustification.
-Natural Language Semantics, 26(1), 1–50.
+This file formalizes [fox-spector-2018]'s economy condition on the exhaustivity operator: an
+occurrence of `exh` is licensed only if it is not incrementally weakening, that is, unless for
+every continuation of the sentence at that point eliminating it leaves the meaning unchanged or
+stronger (`Licensed`). The condition derives Singh's asymmetry between the two orders of a
+Hurford disjunction (`singh_canonical`, `singh_reverse`), its disappearance for distant
+entailing disjuncts (`licensed_orRight_iff`), and the ban on Hurford disjunctions under one
+downward-entailing operator but not two (`not_licensed_of_forall_antitone`,
+`licensed_iff_of_forall_monotone`). The comparison-class refinement of the condition,
+`GloballyWeakeningCC`, is what forces narrow focus under a downward-entailing operator: with
+more innocently excludable alternatives the two-layered exhaustification is weaker
+(`op_exh_mono`), and the exclusive construal of a disjunction under negation becomes
+conjunctive (`exh_neg_exh`, `exh_neg_exh_or`) though not under a negative quantifier
+(`exh_no_exh`).
 
-## Empirical support: [chemla-spector-2011]
+## Implementation notes
 
-The economy-condition framework predicts that embedded `exh` is
-licensed precisely when its insertion is non-vacuous. CS11's §4.4.5
-distributivity finding (page 20) is direct empirical support: for the
-'or' item under STRONG condition, sub-cases STRONG[≠] (where
-distributivity inferences are non-vacuous) are rated significantly
-higher than STRONG[=] (where they are vacuous), 99.5% vs 73%, W = 78,
-p < .005.
+Sentences are propositions `Set W`; a continuation is a map on the meaning of the constituent,
+and the continuations available at a point are a set of such maps, so "incrementally" is
+quantification over that set. Downward-entailing operators are antitone maps and the paper's
+exhaustivity operator is Fox's innocent exclusion `Exhaustification.exhIE`. Focus and the
+Minimize Focus principle of §8 are not represented; the rows record the distribution of Hurford
+disjunctions by the paper's own classification of each sentence.
 
-## Core Argument
+## References
 
-Where can `exh` be inserted in the parse tree? Fox & Spector propose
-an **economy condition**: `exh` is licensed only if it is neither
-incrementally vacuous nor incrementally weakening. This single
-constraint derives three previously independent generalizations:
-
-1. **Hurford's Constraint**: disjunctions where one disjunct entails
-   the other are infelicitous (unless rescued by embedded `exh`)
-2. **Singh's Asymmetry**: "p or q, or both" is acceptable but
-   "both, or p or q" is not ([singh-2008])
-3. **Implicature Focus Generalization (IFG)**: embedded `exh` under
-   DE operators requires focus on the scalar item
-
-## Formalized Results
-
-- Economy condition (original and comparison-class formulations)
-- Hurford's Constraint derived from economy (`hurford_from_economy`)
-- Singh's Asymmetry from economy (`singh_weak_exh_nonvacuous`,
-  `singh_strong_exh_vacuous`)
-- `exh` is always globally weakening under DE (`exh_weakening_under_de`)
-- More IE alternatives → stronger result (`exhIE_stronger_of_more_IE`)
-- Under DE, more IE → weaker global result (`de_weakening_of_more_IE`)
-- The exh–exh prediction: `exh[¬exh(p∨q)] = p∧q` (`exh_exh_conjunctive`)
-- Bridge to `Symmetry.lean`: vacuous `exh` violates economy
-  (`vacuous_violates_economy`)
-
-## Connection to the Symmetry Problem
-
-Economy interacts with the symmetry problem (`Symmetry.lean`)
-indirectly. When symmetric alternatives S₁, S₂ are the only
-non-weaker alternatives, `exh` is vacuous (proved by
-`symmetric_exhB_vacuous`). Vacuous `exh` violates economy
-(`vacuous_violates_economy`), so the grammar rejects the parse
-rather than producing wrong results. But economy does not *derive*
-the correct SI — that requires [katzir-2007]'s structural
-complexity restricting the alternative set (see
-`Structural.lean`).
-
-Economy and structural complexity are **complementary**:
-- [katzir-2007] determines *which* alternatives enter the set
-  → breaks symmetry → `exh` derives the correct SI
-- Economy determines *whether* `exh` is licensed given those
-  alternatives → blocks vacuous/weakening insertions
+* [fox-spector-2018]
+* [chierchia-fox-spector-2012]
+* [hurford-1974]
+* [singh-2008]
+* [gajewski-sharvit-2012]
+* [schlenker-2008]
+* [chierchia-2004]
 -/
 
 namespace FoxSpector2018
 
-open Exhaustification
-
-
--- ============================================================
--- SECTION 1: Continuations and Parse Points
--- ============================================================
-
-variable {World : Type*}
-
-/-- Binary disjunction for `Prop'`. -/
-private def por (φ ψ : Set World) : Set World := fun w => φ w ∨ ψ w
-
-/-- A continuation context represents "the rest of the sentence"
-    after a parse point. -/
-abbrev Continuation (World : Type*) := Set World → Set World
-
-/-- Negation continuation. -/
-def negCont : Continuation World := (·)ᶜ
-
-/-- A parse point: a proposition with alternatives and possible
-    continuations. -/
-structure ParsePoint (World : Type*) where
-  prop : Set World
-  alts : Set (Set World)
-  continuations : Set (Continuation World)
-
-
--- ============================================================
--- SECTION 2: Economy Condition (definition 63)
--- ============================================================
-
-/-- Incremental vacuity: `exh` makes no difference for ANY
-    continuation. -/
-def isIncrementallyVacuous (ALT : Set (Set World)) (φ : Set World)
-    (conts : Set (Continuation World)) : Prop :=
-  ∀ C ∈ conts, ∀ w : World, C (exhIE ALT φ) w ↔ C φ w
-
-/-- Incremental weakening: `exh` weakens the meaning for ALL
-    continuations. In DE contexts, local strengthening = global
-    weakening. -/
-def isIncrementallyWeakening (ALT : Set (Set World)) (φ : Set World)
-    (conts : Set (Continuation World)) : Prop :=
-  ∀ C ∈ conts, C φ ⊆ C (exhIE ALT φ)
-
-/-- **Economy Condition on Exhaustification** (definition 63):
-    `exh(φ)` is licensed only if it is neither incrementally
-    vacuous nor incrementally weakening. -/
-def economyConditionMet (ALT : Set (Set World)) (φ : Set World)
-    (conts : Set (Continuation World)) : Prop :=
-  ¬isIncrementallyVacuous ALT φ conts ∧
-  ¬isIncrementallyWeakening ALT φ conts
-
-
--- ============================================================
--- SECTION 3: Comparison-Class Economy (definitions 85/86)
--- ============================================================
-
-/-!
-## Comparison-Class Economy
-
-The refined economy condition compares `exh_C(φ)` not just against
-`φ`, but against `exh_{C'}(φ)` for every subset C' of alternatives.
-Economy bans adding alternatives that only weaken the result.
--/
-
-/-- Global weakening (definition 84): `exh` is globally weakening
-    if the sentence without `exh` entails the sentence with `exh`. -/
-def isGloballyWeakening (ALT : Set (Set World)) (φ : Set World)
-    (S : Continuation World) : Prop :=
-  ∀ w, S φ w → S (exhIE ALT φ) w
-
-/-- Generalized global weakening (definition 86): `exh_C` is
-    globally weakening if there exists C' with strictly fewer IE
-    alternatives such that S(exh_{C'}(A)) entails S(exh_C(A)).
-    Using fewer alternatives gives a stronger result. -/
-def isGloballyWeakeningGen (ALT : Set (Set World)) (φ : Set World)
-    (S : Continuation World) : Prop :=
-  ∃ ALT' : Set (Set World),
-    IE ALT' φ ⊂ IE ALT φ ∧
-    ∀ w, S (exhIE ALT' φ) w → S (exhIE ALT φ) w
-
-
--- ============================================================
--- SECTION 4: Hurford's Constraint from Economy
--- ============================================================
-
-/-!
-## Hurford's Constraint
-
-"A disjunction of the form 'A or B' sounds redundant and is odd
-when one of the disjuncts entails the other."
-
-Fox & Spector derive this from economy rather than stipulating it.
--/
-
-/-- Hurford violation: one disjunct entails the other. -/
-def hurfordViolation (A B : Set World) : Prop :=
-  (A ⊆ B) ∨ (B ⊆ A)
-
-/-- A disjunction satisfies Hurford's Constraint if neither
-    disjunct entails the other. -/
-def satisfiesHC (A B : Set World) : Prop :=
-  ¬(A ⊆ B) ∧ ¬(B ⊆ A)
-
-/-- A Hurford disjunction can be rescued by embedding `exh` in the
-    weaker disjunct if the exhaustified disjunct no longer entails
-    the stronger one. -/
-def isRescuedByExh (ALT : Set (Set World)) (A B : Set World) :
-    Prop :=
-  ¬(exhIE ALT A ⊆ B)
-
-/-- The disjunction continuation: (λp. A ∨ p). -/
-def disjCont (A : Set World) : Continuation World :=
-  fun p => por A p
-
-/-- **Hurford from Economy**: if B ⊆ A and `exh(B)` cannot break
-    the entailment, then `exh(B)` is incrementally weakening in
-    the disjunction context — economy blocks the parse.
-
-    This derives Hurford's Constraint from economy rather than
-    stipulating it as a surface filter. -/
-theorem hurford_from_economy (ALT : Set (Set World)) (A B : Set World)
-    (hBA : B ⊆ A) (_hstill : exhIE ALT B ⊆ A) :
-    isIncrementallyWeakening ALT B {disjCont A} := by
-  intro C hC w hCBw
-  simp only [Set.mem_singleton_iff] at hC
-  rw [hC] at hCBw ⊢
-  simp only [disjCont, por] at hCBw ⊢
-  rcases hCBw with hAw | hBw
-  · left; exact hAw
-  · left; exact hBA hBw
-
-
--- ============================================================
--- SECTION 5: Singh's Asymmetry from Economy
--- ============================================================
-
-/-!
-## Singh's Asymmetry ([singh-2008])
-
-"Mary read [A or B] or [A and B]" ✓ (weak first)
-"Mary read [A and B] or [A or B]" # (strong first)
-
-Economy derives this: `exh` on the weak disjunct is non-vacuous
-(derives exclusive or), while `exh` on the strong disjunct is
-vacuous (nothing to exclude).
--/
-
-/-- **Singh weak-first**: `exh` on the weak disjunct is non-vacuous
-    when `exh` genuinely excludes something. Economy is met.
-
-    The hypothesis `h_excludes` says there is a world where the
-    weak disjunct holds but neither the exhaustified weak nor the
-    strong holds — this witnesses non-vacuity. -/
-theorem singh_weak_exh_nonvacuous (ALT : Set (Set World))
-    (weak strong : Set World)
-    (h_excludes : ∃ w, weak w ∧ ¬exhIE ALT weak w ∧ ¬strong w) :
-    ¬isIncrementallyVacuous ALT weak {disjCont strong} := by
-  intro hvacuous
-  have heq := hvacuous (disjCont strong) (Set.mem_singleton _)
-  obtain ⟨w, hweak, hnexh, hnstrong⟩ := h_excludes
-  have hright : disjCont strong weak w := Or.inr hweak
-  have hleft : disjCont strong (exhIE ALT weak) w := (heq w).mpr hright
-  rcases hleft with hstrong | hexh
-  · exact hnstrong hstrong
-  · exact hnexh hexh
-
-/-- **Singh strong-first**: `exh` on the strong disjunct is vacuous
-    when strong entails weak. The only alternative (weak) cannot be
-    excluded because its negation contradicts the prejacent.
-    Economy is violated.
-
-    The proof constructs {strong} as the unique MC-set: adding
-    ¬weak or ¬strong to the exclusion set makes it inconsistent
-    (since strong entails weak, every strong-world is a weak-world). -/
-theorem singh_strong_exh_vacuous (weak strong : Set World)
-    (h_entails : strong ⊆ weak) :
-    exhIE {weak, strong} strong = strong := by
-  apply Set.Subset.antisymm
-  · -- exhIE ⊆ strong: the prejacent is always in IE
-    intro w hexh
-    have hstrong_in_IE : strong ∈ IE {weak, strong} strong :=
-      fun E hE_mc => hE_mc.1.1
-    exact hexh strong hstrong_in_IE
-  · -- strong ⊆ exhIE: construct the unique MC-set {strong}
-    intro w hstrong_w ψ hψ_IE
-    have hE₀_compat : IsCompatible {weak, strong} strong {strong} := by
-      refine ⟨Set.mem_singleton _, ?_, ?_⟩
-      · intro ψ' hψ'
-        left; exact Set.mem_singleton_iff.mp hψ'
-      · exact ⟨w, fun ψ' hψ' => Set.mem_singleton_iff.mp hψ' ▸ hstrong_w⟩
-    have hE₀_maximal : IsMCSet {weak, strong} strong {strong} := by
-      refine ⟨hE₀_compat, ?_⟩
-      intro E' hE'_compat hE₀_sub_E' ψ' hψ'_E'
-      rcases hE'_compat.2.1 ψ' hψ'_E' with hψ'_eq | ⟨a, ha_ALT, hψ'_neg⟩
-      · exact Set.mem_singleton_iff.mpr hψ'_eq
-      · exfalso
-        simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at ha_ALT
-        obtain ⟨u, hu⟩ := hE'_compat.2.2
-        have hstrong_u : strong u := hu strong hE'_compat.1
-        rcases ha_ALT with ha_weak | ha_strong
-        · rw [ha_weak] at hψ'_neg
-          have hneg_weak_u := hu ψ' hψ'_E'
-          rw [hψ'_neg] at hneg_weak_u
-          exact hneg_weak_u (h_entails hstrong_u)
-        · rw [ha_strong] at hψ'_neg
-          have hneg_strong_u := hu ψ' hψ'_E'
-          rw [hψ'_neg] at hneg_strong_u
-          exact hneg_strong_u hstrong_u
-    rw [Set.mem_singleton_iff.mp (hψ_IE {strong} hE₀_maximal)]
-    exact hstrong_w
-
-
--- ============================================================
--- SECTION 6: DE Operators and Economy
--- ============================================================
-
-/-!
-## DE Operators and Economy
-
-A key observation: `exh` is **always** globally weakening under DE
-operators. Since `exhIE` entails its prejacent (it can only
-strengthen), DE reverses this, making the overall sentence weaker.
-
-This means economy blocks `exh` under DE unless:
-1. The DE scope is embedded under another DE operator (making the
-   overall context UE), or
-2. Two levels of `exh` are used: `exh[DE[exh(S)]]`, where the inner
-   `exh` strengthens, DE reverses, and the outer `exh` strengthens
-   again (§7, §10 of the paper)
-
-The second mechanism requires **focus** on the scalar item to provide
-the right alternatives for the inner `exh` — this derives the IFG.
--/
-
-/-- A continuation is **downward-entailing** if it reverses
-    entailment. -/
-def isDECont (S : Continuation World) : Prop :=
-  ∀ (p q : Set World), (∀ w, p w → q w) → ∀ w, S q w → S p w
-
-/-- Negation is DE. -/
-theorem negCont_is_DE : isDECont (Compl.compl (α := Set World)) := by
-  intro p q hpq w hnq hp
-  exact hnq (hpq w hp)
-
-/-- The prejacent is always in IE (it belongs to every compatible
-    set by definition, hence every MC-set). -/
-theorem prejacent_mem_IE (ALT : Set (Set World)) (φ : Set World) :
-    φ ∈ IE ALT φ :=
-  fun _E hE => hE.1.1
-
-/-- `exhIE` always entails its prejacent: exhaustification can
-    only strengthen, never weaken. -/
-theorem exhIE_entails_prejacent (ALT : Set (Set World))
-    (φ : Set World) : exhIE ALT φ ⊆ φ :=
-  fun _w h => h φ (prejacent_mem_IE ALT φ)
-
-/-- **`exh` is always globally weakening under DE**: since
-    `exhIE ALT φ ⊆ φ` and DE reverses entailment,
-    `S(φ) ⊆ S(exhIE ALT φ)`.
-
-    This is the core observation behind the IFG: embedded `exh`
-    under DE operators is blocked by economy unless focus provides
-    the right alternative set (via a two-level exh mechanism). -/
-theorem exh_weakening_under_de (ALT : Set (Set World))
-    (φ : Set World) (S_cont : Continuation World)
-    (hDE : isDECont S_cont) :
-    isGloballyWeakening ALT φ S_cont :=
-  fun w => hDE (exhIE ALT φ) φ (exhIE_entails_prejacent ALT φ) w
-
-/-- More IE alternatives means a stronger exhaustified meaning:
-    if IE(ALT') ⊆ IE(ALT), then exhIE ALT φ ⊆ exhIE ALT' φ.
-    More requirements to satisfy → fewer satisfying worlds. -/
-theorem exhIE_stronger_of_more_IE (ALT ALT' : Set (Set World))
-    (φ : Set World) (hIE : IE ALT' φ ⊆ IE ALT φ) :
-    exhIE ALT φ ⊆ exhIE ALT' φ :=
-  fun _w hexh ψ hψ => hexh ψ (hIE hψ)
-
-/-- **Under DE, more IE alternatives weakens the global result**.
-    If IE(ALT') ⊆ IE(ALT), then S(exhIE ALT' φ) ⊆ S(exhIE ALT φ).
-
-    This captures the core of theorem (88): under DE operators,
-    expanding the comparison class can only weaken the overall
-    sentence. The full theorem (88) additionally handles the
-    two-level exh structure `exh_{OP(S)}(OP[exh_C(S)])`, but this
-    lemma is the key step. -/
-theorem de_weakening_of_more_IE (S_cont : Continuation World)
-    (hDE : isDECont S_cont) (ALT ALT' : Set (Set World))
-    (φ : Set World) (hIE : IE ALT' φ ⊆ IE ALT φ) :
-    ∀ w, S_cont (exhIE ALT' φ) w → S_cont (exhIE ALT φ) w :=
-  fun w => hDE _ _ (exhIE_stronger_of_more_IE ALT ALT' φ hIE) w
-
-
--- ============================================================
--- SECTION 7: The exh–exh Prediction (§11.1)
--- ============================================================
-
-/-!
-## exh–exh: Conjunctive Readings Under Negation
-
-A key prediction (§11.1): when `exh` appears both above and below
-negation, the result is conjunctive:
-
-  exh[¬exh(p ∨ q)] = p ∧ q
-
-"Jack didn't talk to Mary OR Sue" (with focused `or`) yields "Jack
-talked to both" — embedded exclusive disjunction under negation
-always produces a conjunctive reading.
-
-The derivation:
-  exh(¬exh(p ∨ q))
-  = ¬exh(p ∨ q) ∧ (p ∨ q)            [exh negates ¬(p∨q)]
-  = [¬(p∨q) ∨ (p∧q)] ∧ (p∨q)         [expand ¬exh]
-  = (p ∧ q)                           [simplify]
--/
-
-section ExhExh
-
-/-- Four worlds for two atomic propositions p, q. -/
-inductive PQWorld where | pq | p_only | q_only | neither
-  deriving Repr, DecidableEq, Inhabited, Fintype
-
-open PQWorld
-open Exhaustification (innocent predToFinset altsFromPreds)
-
-private def p_or_q : PQWorld → Bool
-  | pq | p_only | q_only => true | neither => false
-private def p_and_q : PQWorld → Bool
-  | pq => true | _ => false
-
-/-- exh(p ∨ q) = exclusive or (with alternatives {p∨q, p∧q}). -/
-theorem exh_p_or_q_is_exclusive :
-    innocent.exh (altsFromPreds [p_or_q, p_and_q]) (predToFinset p_or_q) =
-    predToFinset (fun w => p_or_q w && !p_and_q w) := by decide
-
-/-- ¬exh(p ∨ q): "both or neither". -/
-private def neg_exh_p_or_q : PQWorld → Bool :=
-  fun w => decide (w ∉ innocent.exh (altsFromPreds [p_or_q, p_and_q]) (predToFinset p_or_q))
-
-/-- ¬(p ∨ q): "neither". -/
-private def neg_p_or_q : PQWorld → Bool
-  | neither => true | _ => false
-
-/-- **The exh–exh prediction**: exh[¬exh(p∨q)] = p∧q.
-
-    The higher `exh` has alternatives {¬exh(p∨q), ¬(p∨q)}, where
-    ¬(p∨q) is the version without the lower `exh`. Since ¬(p∨q) is
-    strictly stronger, it is innocently excludable. Negating it
-    adds (p∨q), which combined with ¬exh(p∨q) gives p∧q. -/
-theorem exh_exh_conjunctive :
-    innocent.exh (altsFromPreds [neg_exh_p_or_q, neg_p_or_q]) (predToFinset neg_exh_p_or_q) =
-    predToFinset p_and_q := by decide
-
-end ExhExh
-
-
--- ============================================================
--- SECTION 8: Bridge to Symmetry
--- ============================================================
-
-/-!
-## Economy and the Symmetry Problem
-
-Economy interacts with the symmetry problem indirectly. When
-symmetric alternatives S₁, S₂ are the only non-weaker alternatives,
-`exh` is vacuous (`symmetric_exhB_vacuous` in `Symmetry.lean`).
-Vacuous `exh` violates economy, so the grammar rejects the parse
-rather than producing wrong results.
-
-Economy and structural complexity are **complementary**:
-- [katzir-2007] determines *which* alternatives enter the set
-  → breaks symmetry → `exh` derives the correct SI
-- Economy determines *whether* `exh` is licensed given those
-  alternatives → blocks vacuous/weakening insertions
--/
-
-/-- Vacuous `exhIE` violates economy: if `exhIE = φ`, then `exh`
-    is incrementally vacuous for all extensional continuations, so
-    economy is not met.
-
-    The extensionality assumption (pointwise-equivalent inputs
-    produce pointwise-equivalent outputs) holds for all natural
-    language continuations: negation, quantifier restrictors,
-    coordination, etc. -/
-theorem vacuous_violates_economy (ALT : Set (Set World))
-    (φ : Set World) (conts : Set (Continuation World))
-    (_hne : conts.Nonempty)
-    (hvac : exhIE ALT φ = φ)
-    (hext : ∀ C ∈ conts, ∀ (p q : Set World),
-      (∀ w, p w ↔ q w) → ∀ w, C p w ↔ C q w) :
-    ¬economyConditionMet ALT φ conts := by
-  intro ⟨hnv, _⟩
-  apply hnv
-  intro C hC w
-  exact hext C hC (exhIE ALT φ) φ (fun w => Iff.of_eq (congrFun hvac w)) w
+open Exhaustification Set Data.Examples
 
+variable {W : Type*}
+
+/-- A continuation: what the rest of the sentence does with the constituent's meaning. -/
+abbrev Continuation (W : Type*) := Set W → Set W
+
+/-! ### The economy condition -/
+
+section Economy
+
+variable (S : Continuation W) (conts : Set (Continuation W)) (C : Set (Set W)) (A : Set W)
+
+/-- Globally vacuous: eliminating `exh` does not change the truth conditions. -/
+def GloballyVacuous : Prop := S (exhIE C A) = S A
+
+/-- Globally weakening: eliminating `exh` does not alter or strengthens the truth conditions. -/
+def GloballyWeakening : Prop := S A ⊆ S (exhIE C A)
+
+/-- Incrementally vacuous: vacuous for every continuation available at the point. -/
+def IncrementallyVacuous : Prop := ∀ S ∈ conts, GloballyVacuous S C A
+
+/-- Incrementally weakening: weakening for every continuation available at the point. -/
+def IncrementallyWeakening : Prop := ∀ S ∈ conts, GloballyWeakening S C A
+
+/-- The economy condition: an occurrence of `exh` is licensed unless it is incrementally
+weakening. -/
+def Licensed : Prop := ¬ IncrementallyWeakening conts C A
+
+variable {S conts C A}
+
+theorem GloballyVacuous.globallyWeakening (h : GloballyVacuous S C A) :
+    GloballyWeakening S C A := h.symm.subset
+
+/-- The first version of the condition, on vacuity, follows from the second. -/
+theorem not_licensed_of_incrementallyVacuous (h : IncrementallyVacuous conts C A) :
+    ¬ Licensed conts C A := λ hl => hl λ S hS => (h S hS).globallyWeakening
+
+/-- Vacuous exhaustification is never licensed. -/
+theorem not_licensed_of_eq (h : exhIE C A = A) : ¬ Licensed conts C A :=
+  λ hl => hl λ S _ => (congrArg S h).symm.subset
+
+/-- Under a downward-entailing continuation, `exh` is always weakening. -/
+theorem globallyWeakening_of_antitone (hS : Antitone S) : GloballyWeakening S C A :=
+  hS (exhIE_subset C A)
+
+/-- Under an upward-entailing continuation, `exh` is weakening only when it is vacuous. -/
+theorem globallyWeakening_iff_of_monotone (hS : Monotone S) :
+    GloballyWeakening S C A ↔ GloballyVacuous S C A :=
+  ⟨λ h => subset_antisymm (hS (exhIE_subset C A)) h, GloballyVacuous.globallyWeakening⟩
+
+/-- Under a downward-entailing operator, `exh` is never licensed. -/
+theorem not_licensed_of_forall_antitone (h : ∀ S ∈ conts, Antitone S) : ¬ Licensed conts C A :=
+  λ hl => hl λ S hS => globallyWeakening_of_antitone (h S hS)
+
+/-- Under upward-entailing continuations, as below two downward-entailing operators, `exh` is
+licensed exactly when it is not vacuous for one of them. -/
+theorem licensed_iff_of_forall_monotone (h : ∀ S ∈ conts, Monotone S) :
+    Licensed conts C A ↔ ∃ S ∈ conts, S (exhIE C A) ≠ S A := by
+  simp only [Licensed, IncrementallyWeakening, not_forall, exists_prop]
+  exact exists_congr λ S => and_congr_right λ hS =>
+    (globallyWeakening_iff_of_monotone (h S hS)).not
+
+end Economy
+
+/-! ### Hurford disjunctions -/
+
+section Hurford
+
+variable {C : Set (Set W)} {p q A X : Set W}
+
+/-- Hurford's Constraint is violated when one disjunct entails the other. -/
+def HurfordViolation (p q : Set W) : Prop := p ⊆ q ∨ q ⊆ p
+
+/-- The continuations of a first disjunct: any second disjunct may follow. -/
+def orLeft : Set (Continuation W) := range λ Y : Set W => λ A => A ∪ Y
+
+/-- The continuation of a final disjunct after `X`: nothing follows. -/
+def orRight (X : Set W) : Set (Continuation W) := {λ A => X ∪ A}
+
+/-- On a first disjunct, `exh` is licensed whenever it excludes something: the empty second
+disjunct is a continuation on which it is not vacuous. -/
+theorem licensed_orLeft (h : exhIE C A ≠ A) : Licensed orLeft C A := λ hw =>
+  h (subset_antisymm (exhIE_subset C A) (by simpa [GloballyWeakening] using hw _ ⟨∅, rfl⟩))
+
+/-- On a final disjunct, `exh` is licensed exactly when it strengthens the whole disjunction. -/
+theorem licensed_orRight_iff : Licensed (orRight X) C A ↔ ¬ X ∪ A ⊆ X ∪ exhIE C A := by
+  simp only [Licensed, IncrementallyWeakening, orRight, mem_singleton_iff, forall_eq,
+    GloballyWeakening]
+
+/-- Singh's asymmetry, canonical order: exhaustifying the weak disjunct of *p or q, or both* is
+licensed. -/
+theorem singh_canonical (h : (p ∩ q).Nonempty) (h' : ((p ∪ q) \ (p ∩ q)).Nonempty) :
+    Licensed orLeft {p ∪ q, p ∩ q} (p ∪ q) := by
+  refine licensed_orLeft ?_
+  rw [exhIE_pair_sdiff (p ∪ q) h']
+  obtain ⟨w, hw⟩ := h
+  intro he
+  have hw' : w ∈ p ∪ q := Or.inl hw.1
+  rw [← he] at hw'
+  exact hw'.2 hw
+
+/-- Singh's asymmetry, reverse order: exhaustifying the final weak disjunct of *both, or p or q*
+is vacuous, hence not licensed. -/
+theorem singh_reverse (h' : ((p ∪ q) \ (p ∩ q)).Nonempty) :
+    ¬ Licensed (orRight (p ∩ q)) {p ∪ q, p ∩ q} (p ∪ q) := by
+  rw [licensed_orRight_iff, exhIE_pair_sdiff (p ∪ q) h', not_not]
+  rintro w (hw | hw)
+  · exact Or.inl hw
+  · by_cases hpq : w ∈ p ∩ q
+    · exact Or.inl hpq
+    · exact Or.inr ⟨hw, hpq⟩
+
+/-- Distant entailing disjuncts in reverse order: `exh` on the final weak disjunct is licensed
+when the exhaustified disjunction is strictly stronger than the bare one. -/
+theorem licensed_orRight_of_ssubset (h : q ∪ exhIE C p ⊂ q ∪ p) : Licensed (orRight q) C p :=
+  licensed_orRight_iff.2 (ssubset_def ▸ h).2
+
+/-- Exhaustifying the first disjunct restores Hurford's Constraint once the exhaustified
+disjunct and the second are logically independent. -/
+theorem not_hurfordViolation_of_independent (h₁ : ¬ exhIE C p ⊆ q) (h₂ : ¬ q ⊆ exhIE C p) :
+    ¬ HurfordViolation (exhIE C p) q := λ h => h.elim h₁ h₂
+
+/-- A Hurford disjunction under negation: every continuation negates a disjunction or a
+conjunction containing the exhaustified disjunct, so `exh` is incrementally weakening. -/
+theorem not_licensed_neg :
+    ¬ Licensed (range (λ r : Set W => λ A => (A ∪ r)ᶜ) ∪ range λ r : Set W => λ A => (A ∩ r)ᶜ)
+      C A := by
+  refine not_licensed_of_forall_antitone ?_
+  rintro _ (⟨r, rfl⟩ | ⟨r, rfl⟩)
+  · exact λ _ _ h => compl_subset_compl.2 (union_subset_union_left r h)
+  · exact λ _ _ h => compl_subset_compl.2 (inter_subset_inter_left r h)
+
+end Hurford
+
+/-! ### The comparison class -/
+
+section ComparisonClass
+
+variable {S : Continuation W} {C C' : Set (Set W)} {A : Set W}
+
+/-- The innocently excludable alternatives. -/
+def excludable (C : Set (Set W)) (A : Set W) : Set (Set W) := {q | IsInnocentlyExcludable C A q}
+
+theorem mem_excludable {q : Set W} : q ∈ excludable C A ↔ IsInnocentlyExcludable C A q := Iff.rfl
+
+/-- Globally weakening relative to the comparison class: some set of alternatives with strictly
+fewer innocently excludable members gives a result at least as strong. -/
+def GloballyWeakeningCC (S : Continuation W) (C : Set (Set W)) (A : Set W) : Prop :=
+  ∃ C', excludable C' A ⊂ excludable C A ∧ S (exhIE C' A) ⊆ S (exhIE C A)
+
+/-- The comparison-class condition subsumes the earlier one: the empty set of alternatives is a
+comparison. -/
+theorem GloballyWeakening.globallyWeakeningCC (h : GloballyWeakening S C A)
+    (hne : (excludable C A).Nonempty) : GloballyWeakeningCC S C A := by
+  refine ⟨∅, ?_, by rwa [exhIE_empty]⟩
+  refine ssubset_of_subset_of_ne (λ _ hq => (mem_excludable.1 hq).1.elim) ?_
+  obtain ⟨q, hq⟩ := hne
+  exact λ h => (mem_excludable.1 (h ▸ hq : q ∈ excludable ∅ A)).1.elim
+
+/-- Under a downward-entailing operator, exhaustifying against the un-exhaustified sentence
+denies it. -/
+theorem exhIE_op (hne : (S (exhIE C A) \ S A).Nonempty) :
+    exhIE {S (exhIE C A), S A} (S (exhIE C A)) = S (exhIE C A) \ S A :=
+  exhIE_pair_sdiff _ hne
+
+/-- The theorem of §10: with more innocently excludable alternatives, the two-layered
+exhaustification under a downward-entailing operator is weaker, so economy forces the smaller
+alternative set, narrow focus. -/
+theorem op_exh_mono (hOP : Antitone S) (hC : C.Finite) (hC' : C'.Finite)
+    (hsub : excludable C' A ⊆ excludable C A) (hne : (S (exhIE C A) \ S A).Nonempty)
+    (hne' : (S (exhIE C' A) \ S A).Nonempty) :
+    exhIE {S (exhIE C' A), S A} (S (exhIE C' A)) ⊆ exhIE {S (exhIE C A), S A} (S (exhIE C A)) := by
+  rw [exhIE_op hne, exhIE_op hne']
+  exact Set.sdiff_subset_sdiff_left (hOP (exhIE_subset_exhIE C A hC hC' λ q hq => hsub hq))
+
+end ComparisonClass
+
+/-! ### Exhaustification under negation -/
+
+section NegExh
+
+variable {C : Set (Set W)} {A p q : Set W}
+
+/-- Under negation, the exhaustified sentence exhaustified against the bare one yields what the
+inner exhaustification excluded: the embedded implicature turns into its conjunctive dual. -/
+theorem exh_neg_exh (hne : (A \ exhIE C A).Nonempty) :
+    exhIE {(exhIE C A)ᶜ, Aᶜ} (exhIE C A)ᶜ = A \ exhIE C A := by
+  rw [exhIE_pair_sdiff (exhIE C A)ᶜ (d := Aᶜ) (by rwa [compl_sdiff_compl]), compl_sdiff_compl]
+
+/-- An exclusive construal of a disjunction under negation is conjunctive. -/
+theorem exh_neg_exh_or (h : (p ∩ q).Nonempty) (h' : ((p ∪ q) \ (p ∩ q)).Nonempty) :
+    exhIE {(exhIE {p ∪ q, p ∩ q} (p ∪ q))ᶜ, (p ∪ q)ᶜ} (exhIE {p ∪ q, p ∩ q} (p ∪ q))ᶜ = p ∩ q := by
+  rw [exh_neg_exh, exhIE_pair_sdiff (p ∪ q) h', sdiff_sdiff_right_self]
+  · exact inter_eq_right.2 (Set.inter_subset_left.trans Set.subset_union_left)
+  · rw [exhIE_pair_sdiff (p ∪ q) h', sdiff_sdiff_right_self]
+    obtain ⟨w, hw⟩ := h
+    exact ⟨w, Or.inl hw.1, hw⟩
+
+/-- Under a negative quantifier the construal is not conjunctive: no individual has the weak
+property without the strong one, and some individual has the strong one. -/
+theorem exh_no_exh {ι : Type*} {P Q : ι → Set W} (hQ : ∀ x, Q x ⊆ P x)
+    (hne : ((⋃ x, P x \ Q x)ᶜ ∩ ⋃ x, Q x).Nonempty) :
+    exhIE {(⋃ x, P x \ Q x)ᶜ, (⋃ x, P x)ᶜ} (⋃ x, P x \ Q x)ᶜ =
+      (⋃ x, P x \ Q x)ᶜ ∩ ⋃ x, Q x := by
+  have hne' : ((⋃ x, P x \ Q x)ᶜ \ (⋃ x, P x)ᶜ).Nonempty := by
+    obtain ⟨w, hw, hwQ⟩ := hne
+    exact ⟨w, hw, λ h => h (iUnion_mono (λ x => hQ x) hwQ)⟩
+  rw [exhIE_pair_sdiff _ hne']
+  ext w
+  simp only [mem_sdiff, mem_compl_iff, mem_iUnion, not_exists, not_forall, not_not, mem_inter_iff]
+  refine and_congr_right λ hw => ⟨?_, λ ⟨x, hx⟩ => ⟨x, hQ x hx⟩⟩
+  rintro ⟨x, hx⟩
+  by_contra hno
+  exact hw x ⟨hx, λ hq => hno ⟨x, hq⟩⟩
+
+end NegExh
+
+/-! ### The data -/
+
+/-- A disjunction of the data: whether its disjuncts stand in entailment, whether a scalar
+alternative lets exhaustification break it, the order of the disjuncts, whether they are
+distant entailing disjuncts, and how many downward-entailing operators scope over it. -/
+structure Row where
+  hurford : Bool
+  rescuable : Bool
+  canonical : Bool
+  distant : Bool
+  de : ℕ
+  judgment : Features.Judgment
+  deriving DecidableEq
+
+def yesNoTable : List (String × Bool) := [("yes", true), ("no", false)]
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let h ← ex.parse? "hurford" yesNoTable
+  let r ← ex.parse? "rescuable" yesNoTable
+  let o ← ex.parse? "order" [("canonical", true), ("reverse", false)]
+  let d ← ex.parse? "distant" yesNoTable
+  let n ← ex.nat? "de"
+  pure ⟨h, r, o, d, n, ex.judgment⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- Economy accounts for the distribution: a Hurford disjunction is acceptable when a scalar
+alternative lets `exh` break the entailment on a disjunct where it is licensed, the first one or
+a distant one, and no single downward-entailing operator makes it weakening. -/
+theorem rows_predicted : ∀ r ∈ rows, (r.judgment = .acceptable ↔
+    r.hurford = false ∨ (r.rescuable = true ∧ (r.canonical = true ∨ r.distant = true) ∧ r.de ≠ 1)) := by
+  decide
 
 end FoxSpector2018

--- a/references.bib
+++ b/references.bib
@@ -2796,7 +2796,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/ArgumentStructure/EventStructure.lean;Studies/BeaversZubair2013.lean;Studies/Chierchia2004.lean;Studies/Gajewski2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Krejci2012.lean;Studies/MeyerFeiman2021.lean;Studies/MunozPerez2026.lean;Studies/Ronai2024.lean}
+  sources   = {Semantics/ArgumentStructure/EventStructure.lean;Studies/BeaversZubair2013.lean;Studies/Chierchia2004.lean;Studies/FoxSpector2018.lean;Studies/Gajewski2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Krejci2012.lean;Studies/MeyerFeiman2021.lean;Studies/MunozPerez2026.lean;Studies/Ronai2024.lean}
 }
 @book{chierchia-2013,
   author    = {Chierchia, Gennaro},
@@ -2877,7 +2877,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Quantification/Numerals/Basic.lean;Pragmatics/Implicature/Defs.lean}
+  sources   = {Semantics/Quantification/Numerals/Basic.lean;Studies/BarLevFox2020.lean;Studies/FoxSpector2018.lean;Studies/KrizChemla2015.lean;Studies/Ronai2024.lean;Studies/Spector2013.lean}
 }
 @book{geurts-2010,
   author    = {Geurts, Bart},
@@ -2965,7 +2965,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/ChemlaSpector2011.json;Pragmatics/Implicature/SomeAll.lean;Studies/ChemlaSpector2011.lean;Studies/FoxSpector2018.lean;Studies/PottsEtAl2016.lean;Studies/Ronai2024.lean}
+  sources   = {Data/Examples/ChemlaSpector2011.json;Pragmatics/Implicature/SomeAll.lean;Studies/ChemlaSpector2011.lean;Studies/PottsEtAl2016.lean;Studies/Ronai2024.lean}
 }
 @article{fox-spector-2018,
   author    = {Fox, Danny and Spector, Benjamin},
@@ -2978,7 +2978,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/FoxSpector2018.lean}
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/FoxSpector2018.lean}
 }
 @inproceedings{alxatib-2014,
   author    = {Alxatib, Sam},
@@ -3134,6 +3134,18 @@
   validated = {true},
   sources   = {Studies/Gajewski2002.lean}
 }% REF: Sauerland, U. (2008). Implicated presuppositions.
+@article{gajewski-sharvit-2012,
+  author    = {Gajewski, Jon and Sharvit, Yael},
+  year      = {2012},
+  title     = {In Defense of the Grammatical Approach to Local Implicatures},
+  journal   = {Natural Language Semantics},
+  volume    = {20},
+  number    = {1},
+  pages     = {31--57},
+  subfield  = {pragmatics/neogricean},
+  role      = {cited},
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/FoxSpector2018.lean},
+}
 @article{singh-2008,
   author    = {Singh, Raj},
   year      = {2008},
@@ -3146,7 +3158,7 @@
   role      = {cited},
   doi       = {10.1007/s10988-008-9038-x},
   validated = {true},
-  sources   = {Studies/FoxSpector2018.lean}
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/FoxSpector2018.lean}
 }% REF: Gutzmann, D. (2015). Use-Conditional Meaning. OUP.
 @book{gutzmann-2015,
   author    = {Gutzmann, Daniel},
@@ -4587,7 +4599,7 @@
   address   = {New York},
   subfield  = {pragmatics/implicature},
   role      = {cited},
-  sources   = {Studies/DegenTonhauser2022.lean;Studies/FillmoreKayOConnor1988.lean}
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/DegenTonhauser2022.lean;Studies/FillmoreKayOConnor1988.lean}
 }% REF: Hobbs, J. R. (1979). Coherence and Coreference. *Cognitive Science* 3, 67–90.
 @article{hobbs-1979,
   author    = {Hobbs, Jerry R.},
@@ -15233,7 +15245,7 @@
   subfield  = {semantics/questions},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/KatzirSingh2015.lean;Semantics/Exhaustification/ScalePredictions.lean}
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/FoxSpector2018.lean;Studies/KatzirSingh2015.lean}
 }% REF: Grimshaw, J. (1979). Complement selection and the lexicon.
 @inproceedings{ladd-1981,
   author    = {Ladd, D. Robert},
@@ -15344,7 +15356,7 @@
   subfield  = {pragmatics/neogricean},
   role      = {formalized},
   validated = {true},
-  sources   = {Data/Examples/FoxKatzir2011.json;Semantics/Alternatives/Competition.lean;Semantics/Alternatives/Source.lean;Semantics/Alternatives/Structural.lean;Semantics/Alternatives/Symmetric.lean;Studies/BaleKhanjian2014.lean;Studies/BrehenyEtAl2018.lean;Studies/FoxKatzir2011.lean;Studies/FoxSpector2018.lean;Studies/Katzir2007.lean;Studies/KatzirSingh2015.lean;Studies/LoGuercio2025.lean;Studies/TrinhHaida2015.lean;Studies/Wang2025.lean;Syntax/Tree/Basic.lean}
+  sources   = {Data/Examples/FoxKatzir2011.json;Semantics/Alternatives/Competition.lean;Semantics/Alternatives/Source.lean;Semantics/Alternatives/Structural.lean;Semantics/Alternatives/Symmetric.lean;Studies/BaleKhanjian2014.lean;Studies/BrehenyEtAl2018.lean;Studies/FoxKatzir2011.lean;Studies/Katzir2007.lean;Studies/KatzirSingh2015.lean;Studies/LoGuercio2025.lean;Studies/TrinhHaida2015.lean;Studies/Wang2025.lean;Syntax/Tree/Basic.lean}
 }% REF: Groenendijk & Roelofsen (2009). Inquisitive Semantics and Pragmatics.
 @article{magri-2009,
   author    = {Magri, Giorgio},
@@ -26553,7 +26565,7 @@
   doi       = {10.1515/THLI.2008.013},
   subfield  = {semantics/presupposition},
   role      = {cited},
-  sources   = {Studies/SolstadBott2024.lean}
+  sources   = {Studies/FoxSpector2018.lean;Studies/SolstadBott2024.lean}
 }
 @article{bates-etal-2015,
   author    = {Bates, Douglas and M{\"a}chler, Martin and Bolker, Ben and Walker, Steve},


### PR DESCRIPTION
Deep cleanse of FoxSpector2018 against the paper (Zotero): the old file was a section-map docstring with an unverifiable Chemla & Spector statistic, a `ParsePoint` structure nothing used, Finset `decide` models of the exh–exh case, and a re-export bridge to the symmetry substrate; the recut states the economy condition over continuations and proves the paper's results in general.

- `GloballyVacuous`/`GloballyWeakening`/`IncrementallyWeakening`/`Licensed` (definitions (43), (63)–(64)); `globallyWeakening_of_antitone`, `globallyWeakening_iff_of_monotone`, `not_licensed_of_forall_antitone`, `licensed_iff_of_forall_monotone` (DE bans, DE-under-DE licenses); Singh's asymmetry `singh_canonical`/`singh_reverse` and its disappearance for distant entailing disjuncts `licensed_orRight_iff`; `not_licensed_neg` (Hurford under negation); the comparison-class condition `GloballyWeakeningCC` with `op_exh_mono` (the §10 theorem behind the implicature focus generalization); `exh_neg_exh`, `exh_neg_exh_or` (exclusive disjunction under negation is conjunctive) and `exh_no_exh` (not under a negative quantifier)
- Substrate `InnocentExclusion.lean`: `exhIE_subset`, `exhIE_empty`, `exhIE_subset_exhIE` (antitone in the innocently excludable alternatives), `exhIE_pair_sdiff`
- 14 JSON rows ((14), (16), (18), (12b), (46), (10a), (65), (66)) with `rows_predicted`: acceptable iff no entailment between disjuncts, or a scalar alternative lets a licensed `exh` break it under zero or two DE operators; `gajewski-sharvit-2012` added
