### PR TITLE
refactor(Studies/Francescotti1995): thresholds on counts of neighbors

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3065,3 +3065,4 @@ import Linglib.Data.Examples.Fox2018
 import Linglib.Data.Examples.FoxKatzir2011
 import Linglib.Data.Examples.FoxPesetsky2005
 import Linglib.Data.Examples.FoxSpector2018
+import Linglib.Data.Examples.Francescotti1995

--- a/Linglib/Data/Examples/Francescotti1995.json
+++ b/Linglib/Data/Examples/Francescotti1995.json
@@ -1,0 +1,192 @@
+[
+  {
+    "id": "francescotti1995_ex5",
+    "source": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(5)"
+    },
+    "language": "stan1293",
+    "primaryText": "Even Albert passed the exam.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Albert, one of the best chemistry students in the school's history, passed; Marie, the very best, was even more likely to pass.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "1"
+      ],
+      [
+        "neighbors",
+        "3"
+      ],
+      [
+        "felicitous",
+        "no"
+      ]
+    ],
+    "comment": "Albert's passing surpasses one neighbor, Marie's, in surprise, and no more: Bennett's condition wrongly licenses the sentence. The count of classmates is schematic."
+  },
+  {
+    "id": "francescotti1995_ex1",
+    "source": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(1)"
+    },
+    "language": "stan1293",
+    "primaryText": "Even Albert failed the exam.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Everyone in the class failed, Albert's failure being very surprising, and Marie's would be more so.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "2"
+      ],
+      [
+        "neighbors",
+        "3"
+      ],
+      [
+        "felicitous",
+        "yes"
+      ]
+    ],
+    "comment": "Albert's failure surpasses every neighbor but Marie's: the universal condition wrongly blocks the sentence. The count of classmates is schematic."
+  },
+  {
+    "id": "francescotti1995_ex7",
+    "source": {
+      "bibkey": "kay-1990",
+      "paperLabel": "lieutenant colonels"
+    },
+    "language": "stan1293",
+    "primaryText": "The administration was so bewildered that they even had lieutenant colonels making policy decisions.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "2"
+      ],
+      [
+        "neighbors",
+        "3"
+      ],
+      [
+        "felicitous",
+        "yes"
+      ]
+    ],
+    "comment": "Felicitous although majors, captains or sergeants making policy would be more extreme still. The counts are schematic.",
+    "reportedIn": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(7)"
+    }
+  },
+  {
+    "id": "francescotti1995_ex21far",
+    "source": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(21)"
+    },
+    "language": "stan1293",
+    "primaryText": "Even Andre cannot reach the top shelf.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Andre is by far the tallest person in the reference class.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "5"
+      ],
+      [
+        "neighbors",
+        "5"
+      ],
+      [
+        "felicitous",
+        "yes"
+      ]
+    ],
+    "comment": "Surpasses every neighbor by a wide margin: very felicitous. The count of the reference class is schematic."
+  },
+  {
+    "id": "francescotti1995_ex21near",
+    "source": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(21)"
+    },
+    "language": "stan1293",
+    "primaryText": "Even Andre cannot reach the top shelf.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Andre is the tallest person in the reference class, but only by a small margin.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "5"
+      ],
+      [
+        "neighbors",
+        "5"
+      ],
+      [
+        "felicitous",
+        "yes"
+      ]
+    ],
+    "comment": "Still felicitous, less so: the margin is the paper's first gradient of felicity."
+  },
+  {
+    "id": "francescotti1995_ex21half",
+    "source": {
+      "bibkey": "francescotti-1995",
+      "paperLabel": "(21)"
+    },
+    "language": "stan1293",
+    "primaryText": "Even Andre cannot reach the top shelf.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Half of the group is over six foot five, the other half under five foot, and Andre is barely in the taller half.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "surpassed",
+        "2"
+      ],
+      [
+        "neighbors",
+        "4"
+      ],
+      [
+        "felicitous",
+        "no"
+      ]
+    ],
+    "comment": "Andre is not taller than the majority, though far taller than average: not felicitous."
+  }
+]

--- a/Linglib/Data/Examples/Francescotti1995.lean
+++ b/Linglib/Data/Examples/Francescotti1995.lean
@@ -1,0 +1,126 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Francescotti1995` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Francescotti1995.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Francescotti1995.Examples`.
+-/
+
+namespace Francescotti1995.Examples
+
+open Data.Examples
+
+def ex5 : LinguisticExample :=
+  { id := "francescotti1995_ex5"
+    source := ⟨"francescotti-1995", "(5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Even Albert passed the exam."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Albert, one of the best chemistry students in the school's history, passed; Marie, the very best, was even more likely to pass."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "1"), ("neighbors", "3"), ("felicitous", "no")]
+    comment := "Albert's passing surpasses one neighbor, Marie's, in surprise, and no more: Bennett's condition wrongly licenses the sentence. The count of classmates is schematic."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1 : LinguisticExample :=
+  { id := "francescotti1995_ex1"
+    source := ⟨"francescotti-1995", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Even Albert failed the exam."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Everyone in the class failed, Albert's failure being very surprising, and Marie's would be more so."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "2"), ("neighbors", "3"), ("felicitous", "yes")]
+    comment := "Albert's failure surpasses every neighbor but Marie's: the universal condition wrongly blocks the sentence. The count of classmates is schematic."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex7 : LinguisticExample :=
+  { id := "francescotti1995_ex7"
+    source := ⟨"kay-1990", "lieutenant colonels"⟩
+    reportedIn := some ⟨"francescotti-1995", "(7)"⟩
+    language := "stan1293"
+    primaryText := "The administration was so bewildered that they even had lieutenant colonels making policy decisions."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "2"), ("neighbors", "3"), ("felicitous", "yes")]
+    comment := "Felicitous although majors, captains or sergeants making policy would be more extreme still. The counts are schematic."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex21far : LinguisticExample :=
+  { id := "francescotti1995_ex21far"
+    source := ⟨"francescotti-1995", "(21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Even Andre cannot reach the top shelf."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Andre is by far the tallest person in the reference class."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "5"), ("neighbors", "5"), ("felicitous", "yes")]
+    comment := "Surpasses every neighbor by a wide margin: very felicitous. The count of the reference class is schematic."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex21near : LinguisticExample :=
+  { id := "francescotti1995_ex21near"
+    source := ⟨"francescotti-1995", "(21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Even Andre cannot reach the top shelf."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Andre is the tallest person in the reference class, but only by a small margin."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "5"), ("neighbors", "5"), ("felicitous", "yes")]
+    comment := "Still felicitous, less so: the margin is the paper's first gradient of felicity."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex21half : LinguisticExample :=
+  { id := "francescotti1995_ex21half"
+    source := ⟨"francescotti-1995", "(21)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Even Andre cannot reach the top shelf."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Half of the group is over six foot five, the other half under five foot, and Andre is barely in the taller half."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("surpassed", "2"), ("neighbors", "4"), ("felicitous", "no")]
+    comment := "Andre is not taller than the majority, though far taller than average: not felicitous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex5, ex1, ex7, ex21far, ex21near, ex21half]
+
+end Francescotti1995.Examples

--- a/Linglib/Studies/Francescotti1995.lean
+++ b/Linglib/Studies/Francescotti1995.lean
@@ -1,171 +1,147 @@
-import Mathlib.Data.Rat.Defs
-import Mathlib.Tactic.NormNum
 import Linglib.Semantics.Focus.Particles
+import Linglib.Data.Examples.Francescotti1995
 
 /-!
-# Francescotti 1995 — the felicity condition of *even*
+# Francescotti (1995): Even: The Conventional Implicature Approach Reconsidered
 
-[francescotti-1995] defends the Implicature Account of *even* against
-[lycan-1991]'s quantifier approach and revises its felicity condition
-(§IV, p. 162): an *even*-sentence is felicitous iff its *even*-less
-core `S*` is more surprising than most of its true neighbors — pace
-[bennett-1982], for whom one true neighbor suffices, and
-[karttunen-peters-1979], who require all.
+This file formalizes [francescotti-1995]'s felicity condition for *even*: the sentence without
+*even* must be more surprising than most of its contextually determined true neighbors, against
+[bennett-1982]'s one neighbor and [karttunen-peters-1979]'s all. The three conditions are one
+threshold on the number of neighbors the prejacent surpasses (`Meets`); they are ordered
+(`meets_most_of_universal`, `meets_existential_of_most`), and the paper's two counterexamples
+are the two gaps between them: surpassing exactly one of several neighbors meets Bennett's
+condition but not the majority (`not_meets_most_of_one`), and surpassing all but one meets the
+majority but not Karttunen and Peters' (`meets_most_of_all_but_one`). The universal threshold
+is the scalar presupposition `Focus.Particles.evenPresup`.
 
-`EvenThreshold` compares the three conditions on the paper's two
-counterexamples (§I, pp. 155–156); the characters and dialectic are the
-paper's, the surprise levels and extra classmates ours. The paper's
-further requirement that neighbors be contextually determined, true,
-and part of a more general truth with `S*` is held fixed as background.
-The gradient discussion (pp. 163–164) contributes the margin dimension
-(`meanExcess`) and the proportion dimension, threshold work done by the
-vagueness of "most".
+## Implementation notes
+
+Neighbors are a list of alternatives with a surprise comparison, and the thresholds read the
+count of neighbors the prejacent surpasses, so the vagueness of *most* is the threshold itself;
+the paper's second gradient, the margin of surprise, is not formalized. The rows record the
+paper's scenarios by the counts its descriptions fix: how many neighbors the prejacent surpasses
+and how many there are.
+
+## References
+
+* [francescotti-1995]
+* [bennett-1982]
+* [karttunen-peters-1979]
+* [kay-1990]
+* [lycan-1991]
 -/
 
 namespace Francescotti1995
 
-open Focus.Particles (evenPresup)
+open Focus.Particles Data.Examples
 
-/-! ### The three threshold conditions -/
-
-/-- How many true neighbors `S*` must exceed in surprise for *even* to
-be felicitous: at least one ([bennett-1982], §I), all
-([karttunen-peters-1979]), or most ([francescotti-1995] §IV, p. 162). -/
-inductive EvenThreshold where
-  /-- `S*` more surprising than at least one true neighbor. -/
+/-- How many true neighbors the prejacent must surpass in surprise: at least one, all, or
+most. -/
+inductive Threshold
   | existential
-  /-- `S*` more surprising than all true neighbors. -/
   | universal
-  /-- `S*` more surprising than most (a strict majority of the) true
-  neighbors. -/
   | most
   deriving DecidableEq, Repr
 
-variable {α : Type*} (prejacent : α) (alternatives : List α)
-  (moreSurprising : α → α → Prop) [DecidableRel moreSurprising]
+/-- Surpassing `k` of `n` neighbors meets the threshold. -/
+def Meets : Threshold → ℕ → ℕ → Prop
+  | .existential, k, _ => 0 < k
+  | .universal, k, n => k = n
+  | .most, k, n => n < 2 * k
 
-/-- Number of alternatives the prejacent exceeds in surprise. -/
-def countExceeded : Nat :=
-  alternatives.countP fun a => decide (moreSurprising prejacent a)
+instance (t : Threshold) (k n : ℕ) : Decidable (Meets t k n) := by
+  unfold Meets; cases t <;> infer_instance
 
-/-- The *even* felicity condition, parameterized by threshold. -/
-def evenPresupWith (threshold : EvenThreshold) : Prop :=
-  match threshold with
-  | .existential => 0 < countExceeded prejacent alternatives moreSurprising
-  | .universal => countExceeded prejacent alternatives moreSurprising = alternatives.length
-  | .most => alternatives.length < 2 * countExceeded prejacent alternatives moreSurprising
+/-- All is most, when there are neighbors. -/
+theorem meets_most_of_universal {k n : ℕ} (hn : 0 < n) (h : Meets .universal k n) :
+    Meets .most k n := by
+  simp only [Meets] at h ⊢; omega
 
-instance (threshold : EvenThreshold) :
-    Decidable (evenPresupWith prejacent alternatives moreSurprising threshold) := by
-  unfold evenPresupWith; cases threshold <;> infer_instance
+/-- Most is at least one. -/
+theorem meets_existential_of_most {k n : ℕ} (h : Meets .most k n) : Meets .existential k n := by
+  simp only [Meets] at h ⊢; omega
 
-/-- The existential threshold is [bennett-1982]'s condition (iii). -/
-theorem evenPresupWith_existential_iff :
-    evenPresupWith prejacent alternatives moreSurprising .existential ↔
-      ∃ a ∈ alternatives, moreSurprising prejacent a := by
-  simp [evenPresupWith, countExceeded, List.countP_pos_iff]
+/-- Bennett's counterexample: surpassing exactly one of several neighbors, as Albert's passing
+surpasses Marie's, meets the existential threshold but not the majority. -/
+theorem not_meets_most_of_one {n : ℕ} (hn : 2 ≤ n) :
+    Meets .existential 1 n ∧ ¬ Meets .most 1 n := by
+  simp only [Meets]; omega
 
-/-- The universal threshold is [karttunen-peters-1979]'s "least likely"
-condition. -/
-theorem evenPresupWith_universal_iff :
-    evenPresupWith prejacent alternatives moreSurprising .universal ↔
-      ∀ a ∈ alternatives, moreSurprising prejacent a := by
-  simp [evenPresupWith, countExceeded, List.countP_eq_length]
+/-- The failing scenario: surpassing all but one neighbor, everyone but Marie, meets the majority
+but not the universal threshold. -/
+theorem meets_most_of_all_but_one {n : ℕ} (hn : 3 ≤ n) :
+    Meets .most (n - 1) n ∧ ¬ Meets .universal (n - 1) n := by
+  simp only [Meets]; omega
 
-/-- The universal threshold coincides with the traditional scalar
-presupposition of *even* (`Focus.Particles.evenPresup`). -/
-theorem evenPresup_iff_universal {W : Type*}
-    (r : Set W → Set W → Prop) [DecidableRel r] (p : Set W) (alts : List (Set W)) :
-    evenPresup r p alts ↔ evenPresupWith p alts r .universal :=
-  (evenPresupWith_universal_iff ..).symm
+/-- Exactly half is not most: Andre barely in the taller half. -/
+theorem not_meets_most_of_half {k : ℕ} : ¬ Meets .most k (2 * k) := by
+  simp only [Meets]; omega
 
-/-! ### The two counterexamples (§I, pp. 155–156) -/
+section Neighbors
 
-/-- A numeric *even* scenario: surprise levels for `S*` and its true
-neighbors (higher = more surprising), plus the reported felicity. -/
-structure EvenScenario where
-  /-- Surprise level of `S*`. -/
-  prejacent : Nat
-  /-- Surprise levels of the contextually-determined true neighbors. -/
-  neighbors : List Nat
-  /-- Reported felicity of the *even*-sentence. -/
+variable {α : Type*} (prejacent : α) (neighbors : List α) (moreSurprising : α → α → Prop)
+  [DecidableRel moreSurprising]
+
+/-- The number of neighbors the prejacent surpasses in surprise. -/
+def surpassed : ℕ := neighbors.countP λ a => decide (moreSurprising prejacent a)
+
+/-- The felicity condition at a threshold. -/
+def Felicitous (t : Threshold) : Prop :=
+  Meets t (surpassed prejacent neighbors moreSurprising) neighbors.length
+
+theorem surpassed_le : surpassed prejacent neighbors moreSurprising ≤ neighbors.length :=
+  List.countP_le_length
+
+/-- The existential threshold is Bennett's condition. -/
+theorem felicitous_existential_iff :
+    Felicitous prejacent neighbors moreSurprising .existential ↔
+      ∃ a ∈ neighbors, moreSurprising prejacent a := by
+  simp [Felicitous, Meets, surpassed, List.countP_pos_iff]
+
+/-- The universal threshold is Karttunen and Peters' condition. -/
+theorem felicitous_universal_iff :
+    Felicitous prejacent neighbors moreSurprising .universal ↔
+      ∀ a ∈ neighbors, moreSurprising prejacent a := by
+  simp [Felicitous, Meets, surpassed, List.countP_eq_length]
+
+/-- The universal threshold is the scalar presupposition of *even*. -/
+theorem evenPresup_iff_universal {W : Type*} (r : Set W → Set W → Prop) [DecidableRel r]
+    (p : Set W) (alts : List (Set W)) :
+    evenPresup r p alts ↔ Felicitous p alts r .universal :=
+  (felicitous_universal_iff ..).symm
+
+end Neighbors
+
+/-! ### The paper's scenarios -/
+
+/-- A scenario of the data: how many true neighbors the prejacent surpasses in surprise, how many
+there are, and whether the *even*-sentence is felicitous. -/
+structure Row where
+  surpassed : ℕ
+  neighbors : ℕ
   felicitous : Bool
-  deriving Repr
+  deriving DecidableEq
 
-/-- A threshold matches a scenario when its predicted felicity agrees
-with the reported judgment. -/
-def Matches (t : EvenThreshold) (s : EvenScenario) : Prop :=
-  evenPresupWith s.prejacent s.neighbors (· > ·) t ↔ s.felicitous
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let k ← ex.nat? "surpassed"
+  let n ← ex.nat? "neighbors"
+  let f ← ex.parse? "felicitous" [("yes", true), ("no", false)]
+  pure ⟨k, n, f⟩
 
-instance (t : EvenThreshold) (s : EvenScenario) : Decidable (Matches t s) :=
-  inferInstanceAs (Decidable (_ ↔ _))
+def rows : List Row := Examples.all.filterMap Row.ofExample
 
-/-- The passing scenario ((5), p. 155): Albert, one of the best students,
-passes unsurprisingly (2), Marie the very best (1), and three weaker
-classmates pass surprisingly (5, 7, 8; the roster completion is ours).
-"Even Albert passed the exam" is infelicitous. -/
-def scenario1 : EvenScenario :=
-  { prejacent := 2, neighbors := [1, 5, 7, 8], felicitous := false }
+/-- The majority threshold fits every scenario. -/
+theorem rows_most : ∀ r ∈ rows, (r.felicitous = true ↔ Meets .most r.surpassed r.neighbors) := by
+  decide
 
-/-- The failing scenario ((1), p. 156): everyone fails; Albert's failure
-is very surprising (8), Marie's would be more so (9), the weaker
-classmates' are not (3, 2, 1). "Even Albert failed the exam" is
-felicitous. -/
-def scenario2 : EvenScenario :=
-  { prejacent := 8, neighbors := [9, 3, 2, 1], felicitous := true }
+/-- Bennett's threshold does not: it licenses *Even Albert passed the exam*. -/
+theorem rows_not_existential :
+    ¬ ∀ r ∈ rows, (r.felicitous = true ↔ Meets .existential r.surpassed r.neighbors) := by
+  decide
 
-/-- The one-neighbor condition wrongly licenses "Even Albert passed the
-exam", though it gets the failing scenario right. -/
-theorem bennett_too_weak :
-    ¬ Matches .existential scenario1 ∧ Matches .existential scenario2 := by decide
-
-/-- The all-neighbors condition wrongly blocks "Even Albert failed the
-exam", since Marie is even less likely to fail. -/
-theorem karttunen_peters_too_strong :
-    Matches .universal scenario1 ∧ ¬ Matches .universal scenario2 := by decide
-
-/-- The most-threshold predicts both judgments correctly. -/
-theorem francescotti_correct :
-    Matches .most scenario1 ∧ Matches .most scenario2 := by decide
-
-/-! ### Gradient felicity (pp. 163–164)
-
-Felicity varies in degree in two ways: by how much `S*` surpasses its
-neighbors in surprise, and by how many it surpasses — the latter is
-threshold work done by the vagueness of "most". -/
-
-/-- Mean surprise margin over the neighbors exceeded: the paper's first
-gradient dimension, rendered numerically. -/
-def meanExcess (s : EvenScenario) : Rat :=
-  let exceeded := s.neighbors.filter (· < s.prejacent)
-  if exceeded.length = 0 then 0
-  else exceeded.foldl (fun (acc : Rat) (n : Nat) => acc + (s.prejacent : Rat) - (n : Rat)) 0 /
-    exceeded.length
-
-/-- Andre is by far the tallest ((21), pp. 163–164): "Even Andre cannot
-reach the top shelf" is very felicitous. -/
-def scenarioAndreFar : EvenScenario :=
-  { prejacent := 9, neighbors := [3, 4, 5, 2, 3], felicitous := true }
-
-/-- Andre is tallest by only a small margin (p. 163): the sentence is
-still felicitous, but less so. -/
-def scenarioAndreBarely : EvenScenario :=
-  { prejacent := 6, neighbors := [5, 5, 4, 5, 5], felicitous := true }
-
-/-- Both Andre scenarios exceed every neighbor, but the by-far scenario
-does so by a larger mean margin. -/
-theorem andre_margin :
-    meanExcess scenarioAndreBarely < meanExcess scenarioAndreFar := by
-  norm_num [meanExcess, scenarioAndreBarely, scenarioAndreFar]
-
-/-- Andre is barely in the taller half of a half-tall, half-short
-reference class (p. 164): not taller than the majority, so the sentence
-is infelicitous. -/
-def scenarioAndreHalf : EvenScenario :=
-  { prejacent := 8, neighbors := [9, 9, 1, 1], felicitous := false }
-
-/-- Exceeding exactly half the neighbors is not "most": the threshold
-correctly predicts infelicity. -/
-theorem andre_half_infelicitous : Matches .most scenarioAndreHalf := by decide
+/-- Karttunen and Peters' threshold does not: it blocks *Even Albert failed the exam*. -/
+theorem rows_not_universal :
+    ¬ ∀ r ∈ rows, (r.felicitous = true ↔ Meets .universal r.surpassed r.neighbors) := by
+  decide
 
 end Francescotti1995

--- a/references.bib
+++ b/references.bib
@@ -3778,7 +3778,7 @@
   subfield  = {pragmatics/assertion},
   role      = {cited},
   validated = {true},
-  sources   = {Pragmatics/DecisionTheoretic/Even.lean}
+  sources   = {Data/Examples/Francescotti1995.json;Pragmatics/DecisionTheoretic/Even.lean;Studies/Francescotti1995.lean}
 }% REF: Francescotti, R. (1995). Even: The conventional implicature approach reconsidered.
 @article{francescotti-1995,
   author    = {Francescotti, Robert M.},
@@ -3792,7 +3792,7 @@
   subfield  = {pragmatics/assertion},
   role      = {formalized},
   validated = {true},
-  sources   = {Pragmatics/DecisionTheoretic/Even.lean;Studies/Francescotti1995.lean}
+  sources   = {Data/Examples/Francescotti1995.json;Pragmatics/DecisionTheoretic/Even.lean;Semantics/Focus/Particles.lean;Studies/Francescotti1995.lean}
 }% REF: Lycan (1991). Even and Even If.
 @article{lycan-1991,
   author    = {Lycan, William G.},
@@ -11030,7 +11030,7 @@
   subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Focus/Particles.lean}
+  sources   = {Semantics/Conditionals/Presupposition.lean;Semantics/Focus/Particles.lean;Semantics/Presupposition/Trivalent.lean;Studies/Francescotti1995.lean;Studies/Lahiri1998.lean;Studies/Yagi2025.lean}
 }% REF: Rooth, M. (1985). Association with Focus. PhD Dissertation.
 @phdthesis{rooth-1985,
   author    = {Rooth, Mats},


### PR DESCRIPTION
Cleanse of Francescotti1995 against the paper (Zotero): the old file invented numeric surprise levels and roster completions for the paper's scenarios and a "mean excess" gradient of its own; the recut states the three thresholds on counts and proves the paper's dialectic in general.

- `Threshold` (one, all, most) and `Meets t k n` on counts, ordered by `meets_most_of_universal`/`meets_existential_of_most`; the two counterexamples as the gaps `not_meets_most_of_one` and `meets_most_of_all_but_one`, and `not_meets_most_of_half` for the Andre half-and-half group
- `surpassed`/`Felicitous` over a neighbor list with a surprise relation; the existential and universal thresholds are Bennett's and Karttunen and Peters' conditions, the latter the substrate's `evenPresup`
- 6 JSON rows ((5), (1), (7), (21) in three settings) recording the counts the paper's descriptions fix; `rows_most` fits them all, `rows_not_existential`/`rows_not_universal` show the rivals do not
