### PR TITLE
refactor(Studies/FuscoSgrizzi2026): anchored heads, size preorder

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3069,3 +3069,4 @@ import Linglib.Data.Examples.Francescotti1995
 import Linglib.Data.Examples.FrancikClark1985
 import Linglib.Data.Examples.FrischPierrehumbertBroe2004
 import Linglib.Data.Examples.Funakoshi2016
+import Linglib.Data.Examples.FuscoSgrizzi2026

--- a/Linglib/Data/Examples/FuscoSgrizzi2026.json
+++ b/Linglib/Data/Examples/FuscoSgrizzi2026.json
@@ -1,0 +1,886 @@
+[
+  {
+    "id": "fuscosgrizzi2026_ex4a",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(4a)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni di avere un figlio.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "di",
+        "di"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio.",
+        "child"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni that he has a child.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "cP"
+      ],
+      [
+        "diagnostic",
+        "belief"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "The belief reading: Marco causes Gianni to believe a state of affairs. PRO may be Marco or Gianni."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex4b",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(4b)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni a avere un figlio.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "a",
+        "a"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio.",
+        "child"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni to have a child.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "intention"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "The intention reading: Gianni comes to intend to bring the state of affairs about; at the time of the convincing he does not yet have a child."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex4a_control",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(4a)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni di avere un figlio.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "di",
+        "di"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio.",
+        "child"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni that he (Marco or Gianni) has a child.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "cP"
+      ],
+      [
+        "diagnostic",
+        "subjectControl"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "The di-infinitive allows subject as well as object control: FinP hosts the logophoric centre."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex4b_control",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(4b)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni a avere un figlio.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "a",
+        "a"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio.",
+        "child"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni that Marco will have a child.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "subjectControl"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The a-infinitive allows only object control: the matrix object is the closest referent for PRO. Footnote 1 reports a marginal subject-control reading for a causative complement."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex11a",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(11a)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni di avere un figlio, ma non è vero.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "di",
+        "di"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio,",
+        "child"
+      ],
+      [
+        "ma",
+        "but"
+      ],
+      [
+        "non",
+        "not"
+      ],
+      [
+        "è",
+        "be-PRS.3SG"
+      ],
+      [
+        "vero.",
+        "true"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni that he has a child, but it is not true.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "cP"
+      ],
+      [
+        "diagnostic",
+        "truthAssessable"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "A propositional complement can be assessed for truth."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex11b",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(11b)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni ad avere un figlio, ma non è vero.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "ad",
+        "a"
+      ],
+      [
+        "avere",
+        "have-INF"
+      ],
+      [
+        "un",
+        "a"
+      ],
+      [
+        "figlio,",
+        "child"
+      ],
+      [
+        "ma",
+        "but"
+      ],
+      [
+        "non",
+        "not"
+      ],
+      [
+        "è",
+        "be-PRS.3SG"
+      ],
+      [
+        "vero.",
+        "true"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni to have a child, but it is not true.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "truthAssessable"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The a-infinitive is not large enough to be a proposition; the continuation is infelicitous."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex12",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(12)"
+    },
+    "language": "ital1282",
+    "primaryText": "La conduttrice ha convinto l'ospite ad essere intervistato.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "La",
+        "the"
+      ],
+      [
+        "conduttrice",
+        "conductor"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "l'ospite",
+        "the.guest"
+      ],
+      [
+        "ad",
+        "a"
+      ],
+      [
+        "essere",
+        "be-INF"
+      ],
+      [
+        "intervistato.",
+        "interviewed-PST.PTCP.M"
+      ]
+    ],
+    "translation": "The conductor has convinced the guest to be interviewed.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "passive"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "Passive is available in the a-infinitive; the guest consents to the interview."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex13",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(13)"
+    },
+    "language": "ital1282",
+    "primaryText": "Marco ha convinto Gianni a cominciare a lavorare.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Marco",
+        "Marco"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "a",
+        "a"
+      ],
+      [
+        "cominciare",
+        "begin-INF"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "lavorare.",
+        "work-INF"
+      ]
+    ],
+    "translation": "Marco has convinced Gianni to start working.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "aspectual"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "Low aspectual restructuring verbs, merged at the edge of vP, fit inside the a-infinitive; the paper also gives continuare a and finire di."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex14",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(14)"
+    },
+    "language": "ital1282",
+    "primaryText": "L'operaio lo prova a costruire.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "L'operaio",
+        "the-worker"
+      ],
+      [
+        "lo",
+        "it"
+      ],
+      [
+        "prova",
+        "try-PRS.3SG"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "costruire.",
+        "build"
+      ]
+    ],
+    "translation": "The worker tries to build it.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "vP"
+      ],
+      [
+        "diagnostic",
+        "cliticClimbing"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "Under the restructuring verb provare the object clitic climbs over the matrix verb: the infinitive is no larger than vP."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex15",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(15)"
+    },
+    "language": "ital1282",
+    "primaryText": "Gianni lo pensa a costruire domani.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "lo",
+        "it"
+      ],
+      [
+        "pensa",
+        "think-PRS.3SG"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "costruire",
+        "build"
+      ],
+      [
+        "domani.",
+        "tomorrow"
+      ]
+    ],
+    "translation": "Gianni thinks about building it tomorrow.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "cliticClimbing"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Under an attitude verb the a-infinitive does not let the clitic climb."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex16",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(16)"
+    },
+    "language": "ital1282",
+    "primaryText": "Gianni mi ha convinto a non salutare più il capo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "mi",
+        "me.CL"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "non",
+        "not"
+      ],
+      [
+        "salutare",
+        "greet-INF"
+      ],
+      [
+        "più",
+        "anymore"
+      ],
+      [
+        "il",
+        "the"
+      ],
+      [
+        "capo.",
+        "boss"
+      ]
+    ],
+    "translation": "Gianni has convinced me not to say hello to the boss anymore.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "negation"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "The a-infinitive hosts negation, so it projects functional structure above vP."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex17",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(17)"
+    },
+    "language": "ital1282",
+    "primaryText": "Ieri Gianni mi ha convinto a comprare una macchina nuova il mese prossimo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Ieri",
+        "yesterday"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "mi",
+        "me.CL"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "convinto",
+        "convince-PST.PTCP"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "comprare",
+        "buy-INF"
+      ],
+      [
+        "una",
+        "a"
+      ],
+      [
+        "macchina",
+        "car"
+      ],
+      [
+        "nuova",
+        "new"
+      ],
+      [
+        "il",
+        "the"
+      ],
+      [
+        "mese",
+        "month"
+      ],
+      [
+        "prossimo.",
+        "next"
+      ]
+    ],
+    "translation": "Yesterday Gianni convinced me to buy a new car next month.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "aP"
+      ],
+      [
+        "diagnostic",
+        "independentTime"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "The a-infinitive is its own temporal domain and takes a temporal adverb of its own."
+  },
+  {
+    "id": "fuscosgrizzi2026_ex18",
+    "source": {
+      "bibkey": "fusco-sgrizzi-2026",
+      "paperLabel": "(18)"
+    },
+    "language": "ital1282",
+    "primaryText": "Ieri Gianni ha provato a riparare la macchina il mese prossimo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Ieri",
+        "yesterday"
+      ],
+      [
+        "Gianni",
+        "Gianni"
+      ],
+      [
+        "ha",
+        "have-PRS.3SG"
+      ],
+      [
+        "provato",
+        "try-PST.PTCP"
+      ],
+      [
+        "a",
+        "to"
+      ],
+      [
+        "riparare",
+        "repair"
+      ],
+      [
+        "la",
+        "the"
+      ],
+      [
+        "macchina",
+        "car"
+      ],
+      [
+        "il",
+        "the"
+      ],
+      [
+        "mese",
+        "month"
+      ],
+      [
+        "prossimo.",
+        "next"
+      ]
+    ],
+    "translation": "Yesterday Gianni has tried to repair the car next month.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "size",
+        "vP"
+      ],
+      [
+        "diagnostic",
+        "independentTime"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "A restructuring infinitive depends on the matrix clause for its temporal specification."
+  }
+]

--- a/Linglib/Data/Examples/FuscoSgrizzi2026.lean
+++ b/Linglib/Data/Examples/FuscoSgrizzi2026.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `FuscoSgrizzi2026` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/FuscoSgrizzi2026.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace FuscoSgrizzi2026.Examples`.
+-/
+
+namespace FuscoSgrizzi2026.Examples
+
+open Data.Examples
+
+def ex4a : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex4a"
+    source := ⟨"fusco-sgrizzi-2026", "(4a)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni di avere un figlio."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("di", "di"), ("avere", "have-INF"), ("un", "a"), ("figlio.", "child")]
+    translation := "Marco has convinced Gianni that he has a child."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "cP"), ("diagnostic", "belief"), ("grammatical", "yes")]
+    comment := "The belief reading: Marco causes Gianni to believe a state of affairs. PRO may be Marco or Gianni."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4b : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex4b"
+    source := ⟨"fusco-sgrizzi-2026", "(4b)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni a avere un figlio."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("a", "a"), ("avere", "have-INF"), ("un", "a"), ("figlio.", "child")]
+    translation := "Marco has convinced Gianni to have a child."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "intention"), ("grammatical", "yes")]
+    comment := "The intention reading: Gianni comes to intend to bring the state of affairs about; at the time of the convincing he does not yet have a child."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4a_control : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex4a_control"
+    source := ⟨"fusco-sgrizzi-2026", "(4a)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni di avere un figlio."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("di", "di"), ("avere", "have-INF"), ("un", "a"), ("figlio.", "child")]
+    translation := "Marco has convinced Gianni that he (Marco or Gianni) has a child."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "cP"), ("diagnostic", "subjectControl"), ("grammatical", "yes")]
+    comment := "The di-infinitive allows subject as well as object control: FinP hosts the logophoric centre."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4b_control : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex4b_control"
+    source := ⟨"fusco-sgrizzi-2026", "(4b)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni a avere un figlio."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("a", "a"), ("avere", "have-INF"), ("un", "a"), ("figlio.", "child")]
+    translation := "Marco has convinced Gianni that Marco will have a child."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "subjectControl"), ("grammatical", "no")]
+    comment := "The a-infinitive allows only object control: the matrix object is the closest referent for PRO. Footnote 1 reports a marginal subject-control reading for a causative complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11a : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex11a"
+    source := ⟨"fusco-sgrizzi-2026", "(11a)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni di avere un figlio, ma non è vero."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("di", "di"), ("avere", "have-INF"), ("un", "a"), ("figlio,", "child"), ("ma", "but"), ("non", "not"), ("è", "be-PRS.3SG"), ("vero.", "true")]
+    translation := "Marco has convinced Gianni that he has a child, but it is not true."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "cP"), ("diagnostic", "truthAssessable"), ("grammatical", "yes")]
+    comment := "A propositional complement can be assessed for truth."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11b : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex11b"
+    source := ⟨"fusco-sgrizzi-2026", "(11b)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni ad avere un figlio, ma non è vero."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("ad", "a"), ("avere", "have-INF"), ("un", "a"), ("figlio,", "child"), ("ma", "but"), ("non", "not"), ("è", "be-PRS.3SG"), ("vero.", "true")]
+    translation := "Marco has convinced Gianni to have a child, but it is not true."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "truthAssessable"), ("grammatical", "no")]
+    comment := "The a-infinitive is not large enough to be a proposition; the continuation is infelicitous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex12 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex12"
+    source := ⟨"fusco-sgrizzi-2026", "(12)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "La conduttrice ha convinto l'ospite ad essere intervistato."
+    discourseSegments := []
+    glossedTokens := [("La", "the"), ("conduttrice", "conductor"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("l'ospite", "the.guest"), ("ad", "a"), ("essere", "be-INF"), ("intervistato.", "interviewed-PST.PTCP.M")]
+    translation := "The conductor has convinced the guest to be interviewed."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "passive"), ("grammatical", "yes")]
+    comment := "Passive is available in the a-infinitive; the guest consents to the interview."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex13"
+    source := ⟨"fusco-sgrizzi-2026", "(13)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Marco ha convinto Gianni a cominciare a lavorare."
+    discourseSegments := []
+    glossedTokens := [("Marco", "Marco"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("Gianni", "Gianni"), ("a", "a"), ("cominciare", "begin-INF"), ("a", "to"), ("lavorare.", "work-INF")]
+    translation := "Marco has convinced Gianni to start working."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "aspectual"), ("grammatical", "yes")]
+    comment := "Low aspectual restructuring verbs, merged at the edge of vP, fit inside the a-infinitive; the paper also gives continuare a and finire di."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex14"
+    source := ⟨"fusco-sgrizzi-2026", "(14)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "L'operaio lo prova a costruire."
+    discourseSegments := []
+    glossedTokens := [("L'operaio", "the-worker"), ("lo", "it"), ("prova", "try-PRS.3SG"), ("a", "to"), ("costruire.", "build")]
+    translation := "The worker tries to build it."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "vP"), ("diagnostic", "cliticClimbing"), ("grammatical", "yes")]
+    comment := "Under the restructuring verb provare the object clitic climbs over the matrix verb: the infinitive is no larger than vP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex15 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex15"
+    source := ⟨"fusco-sgrizzi-2026", "(15)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Gianni lo pensa a costruire domani."
+    discourseSegments := []
+    glossedTokens := [("Gianni", "Gianni"), ("lo", "it"), ("pensa", "think-PRS.3SG"), ("a", "to"), ("costruire", "build"), ("domani.", "tomorrow")]
+    translation := "Gianni thinks about building it tomorrow."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "cliticClimbing"), ("grammatical", "no")]
+    comment := "Under an attitude verb the a-infinitive does not let the clitic climb."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex16"
+    source := ⟨"fusco-sgrizzi-2026", "(16)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Gianni mi ha convinto a non salutare più il capo."
+    discourseSegments := []
+    glossedTokens := [("Gianni", "Gianni"), ("mi", "me.CL"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("a", "to"), ("non", "not"), ("salutare", "greet-INF"), ("più", "anymore"), ("il", "the"), ("capo.", "boss")]
+    translation := "Gianni has convinced me not to say hello to the boss anymore."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "negation"), ("grammatical", "yes")]
+    comment := "The a-infinitive hosts negation, so it projects functional structure above vP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex17 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex17"
+    source := ⟨"fusco-sgrizzi-2026", "(17)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Ieri Gianni mi ha convinto a comprare una macchina nuova il mese prossimo."
+    discourseSegments := []
+    glossedTokens := [("Ieri", "yesterday"), ("Gianni", "Gianni"), ("mi", "me.CL"), ("ha", "have-PRS.3SG"), ("convinto", "convince-PST.PTCP"), ("a", "to"), ("comprare", "buy-INF"), ("una", "a"), ("macchina", "car"), ("nuova", "new"), ("il", "the"), ("mese", "month"), ("prossimo.", "next")]
+    translation := "Yesterday Gianni convinced me to buy a new car next month."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "aP"), ("diagnostic", "independentTime"), ("grammatical", "yes")]
+    comment := "The a-infinitive is its own temporal domain and takes a temporal adverb of its own."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex18 : LinguisticExample :=
+  { id := "fuscosgrizzi2026_ex18"
+    source := ⟨"fusco-sgrizzi-2026", "(18)"⟩
+    reportedIn := none
+    language := "ital1282"
+    primaryText := "Ieri Gianni ha provato a riparare la macchina il mese prossimo."
+    discourseSegments := []
+    glossedTokens := [("Ieri", "yesterday"), ("Gianni", "Gianni"), ("ha", "have-PRS.3SG"), ("provato", "try-PST.PTCP"), ("a", "to"), ("riparare", "repair"), ("la", "the"), ("macchina", "car"), ("il", "the"), ("mese", "month"), ("prossimo.", "next")]
+    translation := "Yesterday Gianni has tried to repair the car next month."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("size", "vP"), ("diagnostic", "independentTime"), ("grammatical", "no")]
+    comment := "A restructuring infinitive depends on the matrix clause for its temporal specification."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex4a, ex4b, ex4a_control, ex4b_control, ex11a, ex11b, ex12, ex13, ex14, ex15, ex16, ex17, ex18]
+
+end FuscoSgrizzi2026.Examples

--- a/Linglib/Studies/FuscoSgrizzi2026.lean
+++ b/Linglib/Studies/FuscoSgrizzi2026.lean
@@ -1,296 +1,216 @@
-import Linglib.Semantics.Modality.Kratzer.Flavor
-import Linglib.Semantics.Events.Basic
+import Linglib.Semantics.Modality.EventRelativity
+import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.Italian.Predicates
-import Linglib.Studies.Grano2024
+import Linglib.Data.Examples.FuscoSgrizzi2026
 
 /-!
-# Inertial modality for Italian non-finite belief/action readings
-[fusco-sgrizzi-2026] [dowty-1979] [kratzer-2012]
+# Fusco and Sgrizzi (2026): Belief or Action? Semantic Ambiguity in the Italian Non-finite Domain
 
-[fusco-sgrizzi-2026] analyse the belief/action ambiguity of Italian
-non-finite complements (*convincere a* + INF, *promettere di* + INF) via
-inertial modality in the [dowty-1979] sense, recast as a Kratzer
-circumstantial-base + inertial-ordering pair.
-
-## Main declarations
-
-* `InertialParams`: bundles a circumstantial modal base with an inertial
-  ordering source.
-* `inertialNecessity`, `inertialPossibility`: `□`/`◇` over the
-  best-inertial-continuation worlds.
-* `inertial_duality`: modal duality, delegated to `Kratzer.duality`.
-* `empty_inertia_is_simple`: with an empty ordering source, inertial
-  necessity collapses to circumstantial `simpleNecessity`.
-* `CausativeAttitude`: the single denotation of *convincere*-type
-  verbs (their ex. 24), with `beliefReading`/`intentionReading` the
-  two complement-size construals and the reading diagnostics.
+This file formalizes [fusco-sgrizzi-2026]'s account of the belief and intention readings of
+Italian *convincere* 'convince' with its two infinitival complements: *Marco ha convinto Gianni di
+avere un figlio* reports a belief, *Marco ha convinto Gianni a avere un figlio* an intention.
+Where [grano-2024] ties the alternation to mood and finiteness, the paper ties it to the size of
+the complement. The *di*-infinitive is a CP: it hosts modal auxiliaries, allows subject as well
+as object control, and can be assessed for truth. The *a*-infinitive stops below tense and above
+vP: it hosts negation, passive and low aspectual verbs and forms a temporal domain of its own, but
+blocks clitic climbing and subject control and cannot be assessed for truth. The readings follow
+from the size through one lexical entry: *convincere* causes a rational-attitude state with the
+property its complement supplies (`Frame.convincere`, the paper's (24)). A *di*-complement closes
+the eventuality argument of the bare infinitive into a proposition, which *di* quantifies over
+the state's content worlds; an *a*-complement keeps it open, and *a*, anchored to the state,
+quantifies over the state's inertia worlds and binds the event to the state by the causal
+relation (`aP`). Both heads are Kratzer necessity over backgrounds the state projects, the
+event-relative modality of [hacquard-2010]: *di* over a content background, *a* over a
+circumstantial base ordered by inertia ([dowty-1979], [kratzer-2013]). This is the causal
+self-referentiality of intention ([searle-1983]): in every inertia world the intended event is
+caused by the attitude state, hence later than it, the future orientation of *a*-infinitives
+([wurmbrand-2014]; `intention_future`). Complement size is the extended projection's
+`ComplementSize`, ordered by functional level; the reading is read off the CP threshold, and the
+diagnostics of sections 3 and 3.1 are predicted by the heads the complement reaches
+(`rows_predicted`).
 
 ## Implementation notes
 
-[dowty-1979]: w' is an inertia world of w iff w' matches w up to the
-reference time and the course of events in w continues without interruption.
-In Kratzer's framework this is a circumstantial modal base paired with an
-ordering source whose propositions describe normal continuation.
+* The *a*-infinitive is recorded with negation as its highest head, the highest the paper places
+  inside it. The functional sequence does not separate negation from tense and modal heads, so
+  the absence of modal auxiliaries ((9) and (10)) and the ban on past-oriented complements ((5))
+  stay in the prose and in `intention_future`.
+* The two heads are stated over abstract eventualities and worlds, with the content background,
+  the circumstantial base and the inertial ordering as anchoring functions of the state.
+* The examples are `Data.Examples.FuscoSgrizzi2026`; the lexical entries are those of
+  `Fragments/Italian/Predicates.lean`.
+
+## References
+
+* [fusco-sgrizzi-2026]
+* [grano-2024]
+* [searle-1983]
+* [wurmbrand-2014]
+* [dowty-1979]
+* [kratzer-2013]
+* [hacquard-2010]
+* [rizzi-1997]
 -/
 
 namespace FuscoSgrizzi2026
 
-open Modality Modality.Kratzer
-open Minimalist (ComplementSize fValue)
-open Italian.Predicates (InfComplementizer convincere credere)
+open Modality Modality.Kratzer Minimalist Italian.Predicates Data.Examples
 
-/-! ## Readings from complement size
+section Semantics
 
-The paper's structural hypothesis: a single *rational attitude*
-semantics whose belief or intention construal is fixed by complement
-size. A phase-sized (CP) complement is existentially closed into a
-proposition and evaluated against doxastic content; a smaller
-complement leaves the event variable open and is evaluated against
-inertial continuation. -/
+variable {I V W : Type*}
 
-/-- The two construals of a rational attitude verb: propositional
-    belief, evaluated against doxastic content, or sub-propositional
-    intention, evaluated against inertial continuation. -/
-inductive Reading where
+/-- Existential closure of the eventuality argument of a bare infinitive, the paper's (23b): the
+head a *di*-infinitive contains and an *a*-infinitive lacks. -/
+def closure (P : V → W → Prop) : W → Prop := λ w => ∃ e, P e w
+
+/-- The head *a* (25): anchored to the attitude state, it is necessity over the state's inertia
+worlds, the best worlds of a circumstantial base under an inertial ordering ([dowty-1979],
+[kratzer-2013]), with the eventuality of its complement bound to the state by the causal
+relation. -/
+def aP (circumstances : AnchoringFn V W) (inertia : OrderingFn V W)
+    (causeStar : V → V → W → Prop) (P : V → W → Prop) (s : V) (w : W) : Prop :=
+  necessity (circumstances s) (inertia s) (λ w' => ∃ e, causeStar s e w' ∧ P e w') w
+
+/-- The head *di* (26): necessity over the state's content worlds of a proposition. -/
+def diP (content : AnchoringFn V W) (Q : W → Prop) (s : V) (w : W) : Prop :=
+  simpleNecessity (content s) Q w
+
+/-- The relations the denotation (24) draws on: convincing events, the thematic relations,
+causation between eventualities, and the class of rational attitudes. -/
+structure Frame (I V W : Type*) where
+  convince : V → W → Prop
+  agent : V → I → W → Prop
+  patient : V → I → W → Prop
+  cause : V → V → Prop
+  rationalAttitude : V → Prop
+  experiencer : I → V → Prop
+
+/-- ⟦convincere⟧ (24): an event of `y` convincing `x` causes a rational-attitude state of `x`
+with the property `P` the complement supplies. -/
+def Frame.convincere (F : Frame I V W) (P : V → Prop) (x y : I) (e : V) (w : W) : Prop :=
+  ∃ s, F.convince e w ∧ F.agent e y w ∧ F.patient e x w ∧ F.cause e s ∧ F.rationalAttitude s ∧
+    F.experiencer x s ∧ P s
+
+variable (F : Frame I V W) (content circumstances : AnchoringFn V W) (inertia : OrderingFn V W)
+  (causeStar : V → V → W → Prop) (P : V → W → Prop) (x y : I) (e : V) (w : W)
+
+/-- The belief report: *convincere* with the *di*-complement, the closed proposition held at the
+state's content worlds. -/
+def beliefReport : Prop := F.convincere (λ s => diP content (closure P) s w) x y e w
+
+/-- The intention report: *convincere* with the *a*-complement. -/
+def intentionReport : Prop := F.convincere (λ s => aP circumstances inertia causeStar P s w) x y e w
+
+/-- Causal self-referentiality: an intention report puts the attitude state in a causal chain to
+the intended event throughout the state's inertia worlds. -/
+theorem intention_causal (h : intentionReport F circumstances inertia causeStar P x y e w) :
+    ∃ s, F.cause e s ∧
+      ∀ w', kratzerBestR (circumstances s) (inertia s) w w' → ∃ e', causeStar s e' w' ∧ P e' w' :=
+  let ⟨s, _, _, _, hc, _, _, ha⟩ := h
+  ⟨s, hc, ha⟩
+
+/-- Future orientation: when causes precede their effects, the intended event of an intention
+report lies after the attitude state in every inertia world, which excludes a past-oriented
+complement, as in (5b). -/
+theorem intention_future {T : Type*} [Preorder T] (τ : V → T)
+    (hτ : ∀ s e' w', causeStar s e' w' → τ s < τ e')
+    (h : intentionReport F circumstances inertia causeStar P x y e w) :
+    ∃ s, F.cause e s ∧
+      ∀ w', kratzerBestR (circumstances s) (inertia s) w w' → ∃ e', τ s < τ e' ∧ P e' w' :=
+  let ⟨s, hc, ha⟩ := intention_causal F circumstances inertia causeStar P x y e w h
+  ⟨s, hc, λ w' hw' => let ⟨e', hce, hP⟩ := ha w' hw'; ⟨e', hτ s e' w' hce, hP⟩⟩
+
+end Semantics
+
+/-! ### Readings from complement size -/
+
+/-- The two construals of a rational attitude. -/
+inductive Reading
   | belief
   | intention
   deriving DecidableEq, Repr
 
-/-- The construal determined by complement size: a phase-sized (CP)
-    complement is read as belief, a smaller one as intention. -/
+/-- The reading a complement size yields: a phase-sized complement carries the closure head and
+is read as belief, a smaller one as intention. -/
 def readingFromSize (cs : ComplementSize) : Reading :=
-  if cs.isPhaseSized then .belief else .intention
+  if ComplementSize.cP ≤ cs then .belief else .intention
 
-/-- Complement size determines the construal, with the CP phase
-    boundary as the threshold. -/
-theorem readingFromSize_eq_belief_iff (cs : ComplementSize) :
-    readingFromSize cs = .belief ↔ fValue .C ≤ cs.fLevel := by
-  unfold readingFromSize
-  cases h : cs.isPhaseSized <;>
-    simp_all [ComplementSize.isPhaseSized]
-
-/-! ## The Italian *di*/*a* alternation
-
-The paper's core data: *di*-infinitives are CP-sized (their ex. 22
-places *a*-infinitives at aP, mapped here to the nearest available
-`ComplementSize` below the CP threshold), so the *di*/*a* choice
-deterministically fixes the reading of *convincere*-type verbs. The
-lexical entries live in `Fragments/Italian/Predicates.lean`. -/
-
-/-- The complement size selected by each Italian infinitival
-    complementizer. -/
+/-- The complement each infinitival complementizer selects: *di* a CP (21), *a* a projection
+below tense with negation as its highest head (22). -/
 def InfComplementizer.complementSize : InfComplementizer → ComplementSize
   | .di => .cP
-  | .a_ => .vP
+  | .a_ => ⟨.Neg⟩
 
-/-- The reading derived from each complementizer. -/
-def InfComplementizer.reading : InfComplementizer → Reading :=
-  readingFromSize ∘ InfComplementizer.complementSize
+/-- The reading each complementizer yields. -/
+def InfComplementizer.reading (c : InfComplementizer) : Reading :=
+  readingFromSize (InfComplementizer.complementSize c)
 
-/-- *di*-infinitives yield belief readings. -/
-theorem di_yields_belief : InfComplementizer.reading .di = .belief := by decide
-
-/-- *a*-infinitives yield intention readings. -/
-theorem a_yields_intention : InfComplementizer.reading .a_ = .intention := by decide
-
-/-- *convincere* supports both readings, one per complementizer. -/
-theorem convincere_dual_reading :
+/-- *convincere* has both readings, one per complementizer. -/
+theorem convincere_readings :
     convincere.infComplements.map InfComplementizer.reading = [.belief, .intention] := by
   decide
 
-/-- *credere* supports only the belief reading. -/
-theorem credere_belief_only :
-    credere.infComplements.map InfComplementizer.reading = [.belief] := by
+/-- *credere* 'believe' has the belief reading only. -/
+theorem credere_readings : credere.infComplements.map InfComplementizer.reading = [.belief] := by
   decide
 
-/-- The *di*/*a* alternation in *convincere* is structurally grounded:
-    the two complementizers select different complement sizes, which
-    deterministically map to different readings. -/
-theorem convincere_alternation_is_structural :
-    InfComplementizer.complementSize .di ≠ InfComplementizer.complementSize .a_ ∧
-    InfComplementizer.reading .di ≠ InfComplementizer.reading .a_ := by
+/-! ### The diagnostics of sections 3 and 3.1 -/
+
+/-- A property of an infinitival complement the paper tests. -/
+inductive Diagnostic
+  | belief
+  | intention
+  | truthAssessable
+  | subjectControl
+  | passive
+  | aspectual
+  | negation
+  | independentTime
+  | cliticClimbing
+  deriving DecidableEq, Repr
+
+/-- What complement size predicts for a diagnostic: the readings by the phase threshold; truth
+assessment by propositionality; subject control by the finiteness head that hosts the logophoric
+centre ([rizzi-1997]); passive, low aspectual verbs and negation by the Voice, v and negation
+heads; a temporal domain of its own by structure above vP; clitic climbing by a complement no
+larger than vP. -/
+def Diagnostic.Predicted : Diagnostic → ComplementSize → Prop
+  | .belief, cs => readingFromSize cs = .belief
+  | .intention, cs => readingFromSize cs = .intention
+  | .truthAssessable, cs => .cP ≤ cs
+  | .subjectControl, cs => .finP ≤ cs
+  | .passive, cs => ⟨.Voice⟩ ≤ cs
+  | .aspectual, cs => .vP ≤ cs
+  | .negation, cs => ⟨.Neg⟩ ≤ cs
+  | .independentTime, cs => .vP < cs
+  | .cliticClimbing, cs => cs ≤ .vP
+
+instance (d : Diagnostic) (cs : ComplementSize) : Decidable (d.Predicted cs) := by
+  cases d <;> unfold Diagnostic.Predicted <;> infer_instance
+
+/-- A sentence of the paper: the size of its infinitival complement, the diagnostic it tests, and
+whether it is grammatical. -/
+structure Row where
+  size : ComplementSize
+  diagnostic : Diagnostic
+  grammatical : Bool
+  deriving DecidableEq
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let s ← ex.parse? "size" [("cP", InfComplementizer.complementSize .di),
+    ("aP", InfComplementizer.complementSize .a_), ("vP", ComplementSize.vP)]
+  let d ← ex.parse? "diagnostic" [("belief", Diagnostic.belief), ("intention", .intention),
+    ("truthAssessable", .truthAssessable), ("subjectControl", .subjectControl),
+    ("passive", .passive), ("aspectual", .aspectual), ("negation", .negation),
+    ("independentTime", .independentTime), ("cliticClimbing", .cliticClimbing)]
+  let g ← ex.parse? "grammatical" [("yes", true), ("no", false)]
+  pure ⟨s, d, g⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- The paper's sentences are grammatical exactly where complement size predicts. -/
+theorem rows_predicted : ∀ r ∈ rows, (r.grammatical = true ↔ r.diagnostic.Predicted r.size) := by
   decide
-
-variable {W : Type*}
-
-/-- Inertial modal parameters: circumstantial base + inertial ordering. -/
-structure InertialParams (W : Type*) where
-  /-- Circumstantial modal base: facts holding at the evaluation world. -/
-  circumstances : ModalBase W
-  /-- Inertial ordering: propositions describing normal continuation. -/
-  inertia : OrderingSource W
-
-/-- Extract Kratzer parameters from inertial parameters. -/
-def InertialParams.toKratzer (p : InertialParams W) : KratzerParams W where
-  base := p.circumstances
-  ordering := p.inertia
-
-/-- Inertial necessity: `p` holds in all best (most inertial) circumstantially
-    accessible worlds. For intention readings: in all worlds where the
-    experiencer's current course of action continues uninterrupted, the
-    intended event obtains. -/
-def inertialNecessity (p : InertialParams W) (prop : W → Prop) (w : W) : Prop :=
-  necessity p.circumstances p.inertia prop w
-
-/-- Inertial possibility: `p` holds in some best circumstantially accessible
-    world. -/
-def inertialPossibility (p : InertialParams W) (prop : W → Prop) (w : W) : Prop :=
-  possibility p.circumstances p.inertia prop w
-
-/-- Inertial modality satisfies modal duality: `□p ↔ ¬◇¬p`. -/
-theorem inertial_duality (p : InertialParams W) (prop : W → Prop) (w : W) :
-    inertialNecessity p prop w ↔ ¬ inertialPossibility p (fun w' => ¬ prop w') w :=
-  Kratzer.duality p.circumstances p.inertia prop w
-
-/-- With empty inertial ordering, inertial modality reduces to simple
-    circumstantial necessity (no preference among accessible worlds). -/
-theorem empty_inertia_is_simple (circ : ModalBase W) (prop : W → Prop) (w : W) :
-    inertialNecessity ⟨circ, emptyBackground⟩ prop w ↔
-    simpleNecessity circ prop w := by
-  simp only [inertialNecessity, necessity, simpleNecessity,
-             ModalLogic.box]
-  constructor
-  · intro h j hj
-    exact h j ((kratzerBestR_empty circ w j).mpr hj)
-  · intro h j hj
-    exact h j ((kratzerBestR_empty circ w j).mp hj)
-
-/-- Inertial modality maps to the circumstantial flavor tag. Both inertial
-    and teleological modality concern what happens given the facts — they
-    differ only in ordering source, not modal base. -/
-def InertialParams.flavorTag : ModalFlavor := .circumstantial
-
-/-! ## The single denotation of *convincere* (ex. 24)
-
-⟦convincere⟧ = λP.λx.λy.λe. ∃e'. Convince(e) ∧ Agent(e,y) ∧ Patient(e,x)
-∧ CAUSE(e,e') ∧ RATIONAL-ATTITUDE(e') ∧ Experiencer(x,e') ∧ P(e').
-The parameter P is supplied by the complement: a *di*-infinitive (CP)
-is existentially closed, yielding the belief reading; an
-*a*-infinitive (aP) leaves the event variable open, yielding the
-intention reading. The belief/intention split is compositional — one
-verb, two complement sizes. -/
-
-/-- A causative attitude verb: the agent causes the experiencer to
-    enter a rational attitude state whose content is the complement
-    predicate. -/
-structure CausativeAttitude (E T : Type*) [LinearOrder T] where
-  /-- The verb's descriptive predicate (Convince). -/
-  verbPred : Event T → Prop
-  /-- The agent of the matrix event. -/
-  agent : E
-  /-- The patient of the matrix event and experiencer of the attitude. -/
-  experiencer : E
-  /-- Agent thematic role. -/
-  isAgent : Event T → E → Prop
-  /-- Patient thematic role. -/
-  isPatient : Event T → E → Prop
-  /-- Experiencer thematic role, on the attitude event. -/
-  isExperiencer : Event T → E → Prop
-  /-- The matrix event causally brings about the attitude state. -/
-  cause : Event T → Event T → Prop
-
-variable {E T : Type*} [LinearOrder T]
-
-/-- The verb applied to a complement predicate `P`: some matrix event
-    causes a stative rational-attitude event satisfying `P`. -/
-def CausativeAttitude.denote (v : CausativeAttitude E T)
-    (P : Event T → Prop) : Prop :=
-  ∃ e e' : Event T,
-    v.verbPred e ∧ v.isAgent e v.agent ∧ v.isPatient e v.experiencer ∧
-    v.cause e e' ∧ e'.sort = .state ∧
-    v.isExperiencer e' v.experiencer ∧ P e'
-
-/-- Belief reading: the CP complement is existentially closed into a
-    proposition, evaluated against doxastic content. -/
-def CausativeAttitude.beliefReading (v : CausativeAttitude E T)
-    (embeddedVP : Event T → Prop) : Prop :=
-  v.denote (fun _ => ∃ e : Event T, embeddedVP e)
-
-/-- Intention reading: the sub-CP complement is applied directly as an
-    event predicate, evaluated against inertial continuation. -/
-def CausativeAttitude.intentionReading (v : CausativeAttitude E T)
-    (embeddedVP : Event T → Prop) : Prop :=
-  v.denote embeddedVP
-
-/-- The paper's central claim (ex. 24): both readings are the one
-    `denote` applied to different complement predicates — the
-    belief/intention split is compositional, not lexical. -/
-theorem CausativeAttitude.readings_from_single_denote
-    (v : CausativeAttitude E T) (VP : Event T → Prop) :
-    v.beliefReading VP = v.denote (fun _ => ∃ e, VP e) ∧
-    v.intentionReading VP = v.denote VP :=
-  ⟨rfl, rfl⟩
-
-/-! ## Reading diagnostics
-
-The paper's empirical differentiators of the two construals: belief
-readings are truth-assessable and host modal auxiliaries; intention
-readings are obligatorily future-oriented and object-control. -/
-
-/-- "It's true/false" can felicitously evaluate a belief but not an
-    intention. -/
-def truthAssessable : Reading → Bool
-  | .belief => true
-  | .intention => false
-
-/-- CP complements host modal auxiliary heads; sub-CP complements
-    lack the structural space. -/
-def allowsModalAux : Reading → Bool
-  | .belief => true
-  | .intention => false
-
-/-- The intended event is projected into inertia worlds, so intention
-    readings are obligatorily future-oriented. -/
-def forcedFutureOrientation : Reading → Bool
-  | .belief => false
-  | .intention => true
-
-/-- The experiencer must be the agent of the intended event, so
-    intention readings are obligatorily object-control. -/
-def objectControlOnly : Reading → Bool
-  | .belief => false
-  | .intention => true
-
-/-! ## Connection to Grano 2024: size → reading → mood
-
-[grano-2024]'s hybrid-predicate analysis (his §6.2) and this paper's
-complement-size analysis make the same prediction: the complement's
-structural size determines whether the reading is intentional
-(requiring eventuality abstraction, hence subjunctive) or
-propositional (existentially closed, hence indicative-compatible).
-`readingFromSize` composed with `readingToDeparture` and
-`Grano2024.DepartureKind.moodPrediction` gives the end-to-end chain
-complement size → reading → departure kind → mood prediction. -/
-
-open Grano2024 (DepartureKind)
-
-/-- Map a reading to a [grano-2024] departure kind: intention readings
-    require eventuality abstraction; belief readings are the default
-    clausal semantics, no departure. -/
-def readingToDeparture : Reading → Option DepartureKind
-  | .intention => some .eventualityAbstraction
-  | .belief    => none
-
-/-- Intention readings predict robust subjunctive selection. -/
-theorem intention_predicts_subjunctive :
-    (readingToDeparture .intention).map DepartureKind.moodPrediction =
-      some .subjunctiveSelecting := rfl
-
-/-- Belief readings predict no departure (default indicative). -/
-theorem belief_predicts_no_departure :
-    readingToDeparture .belief = none := rfl
-
-/-- End-to-end: sub-CP complement → intention → eventuality
-    abstraction → robust subjunctive selection. -/
-theorem subcp_to_subjunctive :
-    readingFromSize .vP = .intention ∧
-    readingToDeparture (readingFromSize .vP) = some .eventualityAbstraction ∧
-    (readingToDeparture (readingFromSize .vP)).map DepartureKind.moodPrediction =
-      some .subjunctiveSelecting := ⟨rfl, rfl, rfl⟩
-
-/-- End-to-end: CP complement → belief → no departure. -/
-theorem cp_to_indicative :
-    readingFromSize .cP = .belief ∧
-    readingToDeparture (readingFromSize .cP) = none := ⟨rfl, rfl⟩
 
 end FuscoSgrizzi2026

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/Basic.lean
@@ -23,6 +23,7 @@ Standard EPs:
 -/
 
 import Linglib.Syntax.Minimalist.SyntacticObject.Basic
+import Mathlib.Order.Basic
 
 namespace Minimalist
 
@@ -560,6 +561,29 @@ def ComplementSize.finP : ComplementSize := ⟨.Fin⟩
 def ComplementSize.cP : ComplementSize := ⟨.C⟩
 def ComplementSize.forceP : ComplementSize := ⟨.Force⟩
 def ComplementSize.saP : ComplementSize := ⟨.SA⟩
+
+/-- Complement sizes are ordered by F-level: a complement is at most another when it projects no
+higher in the functional sequence. Sizes with distinct highest heads at one F-level, such as
+tense and negation, are equivalent but not equal, so the order is a preorder. -/
+instance : Preorder ComplementSize := Preorder.lift ComplementSize.fLevel
+
+instance : DecidableLE ComplementSize := λ a b => inferInstanceAs (Decidable (a.fLevel ≤ b.fLevel))
+
+instance : DecidableLT ComplementSize := λ a b => inferInstanceAs (Decidable (a.fLevel < b.fLevel))
+
+theorem ComplementSize.le_def {a b : ComplementSize} : a ≤ b ↔ a.fLevel ≤ b.fLevel := Iff.rfl
+
+theorem ComplementSize.lt_def {a b : ComplementSize} : a < b ↔ a.fLevel < b.fLevel := Iff.rfl
+
+/-- Phase-sized complements are those at least as large as a CP. -/
+theorem ComplementSize.isPhaseSized_iff {cs : ComplementSize} :
+    cs.isPhaseSized = true ↔ ComplementSize.cP ≤ cs := by
+  simp [isPhaseSized, le_def, fLevel, cP]
+
+/-- Complements transparent to tense Agree are those smaller than a CP. -/
+theorem ComplementSize.transparentToTenseAgree_iff {cs : ComplementSize} :
+    cs.transparentToTenseAgree = true ↔ cs < ComplementSize.cP := by
+  simp [transparentToTenseAgree, lt_def, fLevel, cP]
 
 -- ── Bridge theorems ──
 

--- a/references.bib
+++ b/references.bib
@@ -8646,7 +8646,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {foundational},
-  sources   = {Fragments/Gitksan/Modals.lean;Logic/BeliefRevision.lean;Semantics/Conditionals/Counterfactual/Lumping.lean;Semantics/Conditionals/PremiseSemantic.lean;Semantics/Conditionals/Restrictor.lean;Semantics/Modality/Directive.lean;Semantics/Modality/Kratzer/ConversationalBackground.lean;Semantics/Modality/Kratzer/Flavor.lean;Semantics/Modality/Kratzer/Operators.lean;Semantics/Modality/Kratzer/Ordering.lean;Semantics/Modality/Kratzer/Premise.lean;Semantics/Modality/ModalTypes.lean;Semantics/Modality/ProbabilityOrdering.lean;Studies/Ferreira2023.lean;Studies/FuscoSgrizzi2026.lean;Studies/Kratzer1977.lean;Studies/Kratzer2012Conditionals.lean;Studies/Kratzer2012Informational.lean;Studies/Kratzer2012Lumping.lean;Studies/Matthewson2016.lean;Studies/RudolphKocurek2024.lean}
+  sources   = {Fragments/Gitksan/Modals.lean;Logic/BeliefRevision.lean;Semantics/Conditionals/Counterfactual/Lumping.lean;Semantics/Conditionals/PremiseSemantic.lean;Semantics/Conditionals/Restrictor.lean;Semantics/Modality/Directive.lean;Semantics/Modality/Kratzer/ConversationalBackground.lean;Semantics/Modality/Kratzer/Flavor.lean;Semantics/Modality/Kratzer/Operators.lean;Semantics/Modality/Kratzer/Ordering.lean;Semantics/Modality/Kratzer/Premise.lean;Semantics/Modality/ModalTypes.lean;Semantics/Modality/ProbabilityOrdering.lean;Studies/Ferreira2023.lean;Studies/Kratzer1977.lean;Studies/Kratzer2012Conditionals.lean;Studies/Kratzer2012Informational.lean;Studies/Kratzer2012Lumping.lean;Studies/Matthewson2016.lean;Studies/RudolphKocurek2024.lean}
 }
 @incollection{kratzer-2013,
   author    = {Kratzer, Angelika},
@@ -8661,7 +8661,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Attitudes/Anchor.lean}
+  sources   = {Semantics/Attitudes/Anchor.lean;Studies/FuscoSgrizzi2026.lean}
 }
 @article{phillips-brown-2025,
   author    = {Phillips-Brown, Milo},
@@ -9044,7 +9044,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Modality/EventRelativity.lean;Fragments/Italian/Modals.lean;Studies/Hacquard2010.lean;Studies/Hacquard2006.lean;Studies/Kim2024.lean}
+  sources   = {Fragments/Italian/Modals.lean;Semantics/Modality/Anchor.lean;Semantics/Modality/EventRelativity.lean;Studies/AnandHacquard2013.lean;Studies/FuscoSgrizzi2026.lean;Studies/Hacquard2006.lean;Studies/Hacquard2010.lean;Studies/Kim2024.lean;Studies/Matthewson2016.lean}
 }
 @book{kramer-2015,
   author    = {Kramer, Ruth},
@@ -12513,7 +12513,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Wurmbrand2014.lean}
+  sources   = {Data/Examples/Wurmbrand2014.json;Studies/FuscoSgrizzi2026.lean;Studies/LiuYip2026.lean;Studies/Ostrove2026.lean;Studies/Wurmbrand2014.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean}
 }
 @book{wurmbrand-2001,
   author    = {Wurmbrand, Susi},
@@ -16505,7 +16505,7 @@
   subfield  = {semantics/attitudes},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Attitudes/RationalAttitude.lean;Fragments/Italian/Predicates.lean;Studies/FuscoSgrizzi2026.lean}
+  sources   = {Data/Examples/FuscoSgrizzi2026.json;Fragments/English/Predicates/Verbal.lean;Fragments/Italian/Predicates.lean;Studies/FuscoSgrizzi2026.lean;Studies/Grano2024.lean}
 }
 @article{ying-zhi-xuan-wong-mansinghka-tenenbaum-2025,
   author    = {Ying, Lance and Zhi-Xuan, Tan and Wong, Lionel and Mansinghka, Vikash and Tenenbaum, Joshua B.},
@@ -24473,7 +24473,7 @@
   subfield  = {syntax/minimalism},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Mood/Defs.lean;Studies/Allotey2021.lean;Studies/Erlewine2016.lean;Studies/Fortuny2024.lean;Studies/Greco2020.lean;Studies/Holmberg2016.lean;Studies/Westergaard2009.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Features.lean}
+  sources   = {Semantics/Mood/Defs.lean;Studies/Allotey2021.lean;Studies/Erlewine2016.lean;Studies/Fortuny2024.lean;Studies/FuscoSgrizzi2026.lean;Studies/Greco2020.lean;Studies/Holmberg2016.lean;Studies/Westergaard2009.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Features.lean}
 }
 
 @inproceedings{zeijlstra-2007,
@@ -26722,6 +26722,7 @@
   doi       = {10.1007/s10988-023-09397-y},
   subfield  = {semantics/modality},
   role      = {cited},
+  sources   = {Fragments/English/Predicates/Verbal.lean;Fragments/Greek/StandardModern/Complementizers.lean;Fragments/Greek/StandardModern/MoodChoice.lean;Fragments/Italian/Predicates.lean;Fragments/Portuguese/MoodChoice.lean;Fragments/Romanian/MoodChoice.lean;Fragments/Spanish/MoodChoice.lean;Semantics/Mood/Defs.lean;Semantics/Mood/Eventuality.lean;Studies/FuscoSgrizzi2026.lean;Studies/Grano2024.lean;Studies/Noonan2007.lean}
 }
 @book{searle-1979,
   author    = {Searle, John R.},
@@ -26744,7 +26745,7 @@
   subfield  = {philosophy/mind},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Attitudes/RationalAttitude.lean;Discourse/SpeechAct.lean;Semantics/Attitudes/Doxastic.lean;Semantics/Mood/Basic.lean}
+  sources   = {Discourse/SpeechAct.lean;Semantics/Attitudes/Doxastic.lean;Semantics/Mood/Eventuality.lean;Studies/FuscoSgrizzi2026.lean;Studies/Grano2024.lean;Studies/Ney2026.lean}
 }
 @article{harman-1976,
   author    = {Harman, Gilbert},


### PR DESCRIPTION
Cleanse of FuscoSgrizzi2026 against the paper (lingbuzz/009428): the old file's inertial modality never touched its `convincere` denotation, its diagnostics were Bool tables, and it ended in a size → reading → mood chain the paper does not draw; the recut composes the paper's two heads and reads the diagnostics off the extended projection.

- `Syntax/Minimalist/ExtendedProjection/Basic.lean`: `ComplementSize` gets a `Preorder` lifted from `fLevel` with decidable `≤`/`<` and `isPhaseSized_iff`/`transparentToTenseAgree_iff`, so consumers compare sizes as `.cP ≤ cs`
- `aP` and `diP` are Kratzer necessity over backgrounds the attitude state projects (`AnchoringFn`/`OrderingFn` of `Modality/EventRelativity.lean`); `Frame.convincere` is (24), and `intention_future` derives the future orientation of *a*-infinitives from causal self-referentiality
- 13 JSON rows for the diagnostics of sections 3 and 3.1 with `rows_predicted`; the Grano2024 mood bridge and the `Reading → Bool` tables cut
