### PR TITLE
refactor(Studies/FutrellEtAl2020): Table 2 as generated UD data, bib key fixed

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3073,3 +3073,5 @@ import Linglib.Data.Examples.FuscoSgrizzi2026
 import Linglib.Data.Examples.Gajewski2002
 import Linglib.Data.Examples.Gajewski2011
 import Linglib.Data.Examples.George2011
+import Linglib.Data.UD.DependencyLength.Schema
+import Linglib.Data.UD.DependencyLength.FutrellEtAl2020

--- a/Linglib/Data/README.md
+++ b/Linglib/Data/README.md
@@ -35,6 +35,16 @@ See [`Examples/README.md`](Examples/README.md). Per-paper JSON; generator
 inserts into Studies files via marker blocks. JSON (not CSV) because the
 schema has nested fields.
 
+### UD dependency length by language
+
+Per-paper corpus statistics over Universal Dependencies treebanks: the
+proportion of head-final dependencies and the mean dependency length per word
+at fixed sentence lengths, as a paper prints them (values as scaled integers).
+
+- **Schema**: `Linglib/Data/UD/DependencyLength/Schema.lean`
+- **Generator**: `scripts/gen_ud_deplength.py` (`--check` verifies sync)
+- **Input/Output**: `Linglib/Data/UD/DependencyLength/{Paper}.json` → `{Paper}.lean`
+
 ### PHOIBLE 2.0
 
 - **Source**: [PHOIBLE Online](https://phoible.org/) (Moran & McCloy 2019)

--- a/Linglib/Data/UD/DependencyLength/FutrellEtAl2020.json
+++ b/Linglib/Data/UD/DependencyLength/FutrellEtAl2020.json
@@ -1,0 +1,377 @@
+{
+  "meta": {
+    "bibkey": "futrell-levy-gibson-2020",
+    "locator": "Table 2",
+    "description": "Table 2 of the paper: for each of the 46 languages with more than 1500 sentences in Universal Dependencies 2.1, the proportion of head-final dependencies and the mean dependency length per word at sentence lengths 10, 15 and 20, with content words heading function words as in the UD annotation. The language codes are UD codes matching the keys of the paper's analysis pipeline (CLIQS, typology3.csv)."
+  },
+  "rows": [
+    {
+      "language": "Korean",
+      "isoCode": "ko",
+      "propHeadFinal1000": 881,
+      "depLengthAt10_100": 201,
+      "depLengthAt15_100": 249,
+      "depLengthAt20_100": 284
+    },
+    {
+      "language": "Japanese",
+      "isoCode": "ja",
+      "propHeadFinal1000": 809,
+      "depLengthAt10_100": 170,
+      "depLengthAt15_100": 198,
+      "depLengthAt20_100": 226
+    },
+    {
+      "language": "Turkish",
+      "isoCode": "tr",
+      "propHeadFinal1000": 778,
+      "depLengthAt10_100": 199,
+      "depLengthAt15_100": 236,
+      "depLengthAt20_100": 261
+    },
+    {
+      "language": "Hindi",
+      "isoCode": "hi",
+      "propHeadFinal1000": 763,
+      "depLengthAt10_100": 188,
+      "depLengthAt15_100": 226,
+      "depLengthAt20_100": 257
+    },
+    {
+      "language": "Urdu",
+      "isoCode": "ur",
+      "propHeadFinal1000": 745,
+      "depLengthAt10_100": 186,
+      "depLengthAt15_100": 227,
+      "depLengthAt20_100": 249
+    },
+    {
+      "language": "Hungarian",
+      "isoCode": "hu",
+      "propHeadFinal1000": 726,
+      "depLengthAt10_100": 178,
+      "depLengthAt15_100": 213,
+      "depLengthAt20_100": 240
+    },
+    {
+      "language": "Mandarin",
+      "isoCode": "zh",
+      "propHeadFinal1000": 661,
+      "depLengthAt10_100": 203,
+      "depLengthAt15_100": 251,
+      "depLengthAt20_100": 298
+    },
+    {
+      "language": "Basque",
+      "isoCode": "eu",
+      "propHeadFinal1000": 587,
+      "depLengthAt10_100": 177,
+      "depLengthAt15_100": 210,
+      "depLengthAt20_100": 229
+    },
+    {
+      "language": "Ancient Greek",
+      "isoCode": "grc",
+      "propHeadFinal1000": 566,
+      "depLengthAt10_100": 234,
+      "depLengthAt15_100": 274,
+      "depLengthAt20_100": 308
+    },
+    {
+      "language": "Latin",
+      "isoCode": "la",
+      "propHeadFinal1000": 547,
+      "depLengthAt10_100": 227,
+      "depLengthAt15_100": 272,
+      "depLengthAt20_100": 299
+    },
+    {
+      "language": "Northern Sami",
+      "isoCode": "sme",
+      "propHeadFinal1000": 542,
+      "depLengthAt10_100": 185,
+      "depLengthAt15_100": 220,
+      "depLengthAt20_100": 262
+    },
+    {
+      "language": "Dutch",
+      "isoCode": "nl",
+      "propHeadFinal1000": 533,
+      "depLengthAt10_100": 207,
+      "depLengthAt15_100": 248,
+      "depLengthAt20_100": 274
+    },
+    {
+      "language": "Afrikaans",
+      "isoCode": "af",
+      "propHeadFinal1000": 524,
+      "depLengthAt10_100": 216,
+      "depLengthAt15_100": 248,
+      "depLengthAt20_100": 278
+    },
+    {
+      "language": "Finnish",
+      "isoCode": "fi",
+      "propHeadFinal1000": 521,
+      "depLengthAt10_100": 167,
+      "depLengthAt15_100": 192,
+      "depLengthAt20_100": 216
+    },
+    {
+      "language": "Latvian",
+      "isoCode": "lv",
+      "propHeadFinal1000": 513,
+      "depLengthAt10_100": 171,
+      "depLengthAt15_100": 193,
+      "depLengthAt20_100": 216
+    },
+    {
+      "language": "Estonian",
+      "isoCode": "et",
+      "propHeadFinal1000": 508,
+      "depLengthAt10_100": 184,
+      "depLengthAt15_100": 213,
+      "depLengthAt20_100": 232
+    },
+    {
+      "language": "German",
+      "isoCode": "de",
+      "propHeadFinal1000": 500,
+      "depLengthAt10_100": 204,
+      "depLengthAt15_100": 245,
+      "depLengthAt20_100": 281
+    },
+    {
+      "language": "Modern Greek",
+      "isoCode": "el",
+      "propHeadFinal1000": 472,
+      "depLengthAt10_100": 159,
+      "depLengthAt15_100": 186,
+      "depLengthAt20_100": 202
+    },
+    {
+      "language": "English",
+      "isoCode": "en",
+      "propHeadFinal1000": 460,
+      "depLengthAt10_100": 167,
+      "depLengthAt15_100": 193,
+      "depLengthAt20_100": 210
+    },
+    {
+      "language": "Danish",
+      "isoCode": "da",
+      "propHeadFinal1000": 420,
+      "depLengthAt10_100": 172,
+      "depLengthAt15_100": 201,
+      "depLengthAt20_100": 213
+    },
+    {
+      "language": "Swedish",
+      "isoCode": "sv",
+      "propHeadFinal1000": 420,
+      "depLengthAt10_100": 166,
+      "depLengthAt15_100": 193,
+      "depLengthAt20_100": 213
+    },
+    {
+      "language": "Slovenian",
+      "isoCode": "sl",
+      "propHeadFinal1000": 419,
+      "depLengthAt10_100": 173,
+      "depLengthAt15_100": 195,
+      "depLengthAt20_100": 219
+    },
+    {
+      "language": "Slovak",
+      "isoCode": "sk",
+      "propHeadFinal1000": 412,
+      "depLengthAt10_100": 165,
+      "depLengthAt15_100": 185,
+      "depLengthAt20_100": 210
+    },
+    {
+      "language": "Norwegian (B)",
+      "isoCode": "nb",
+      "propHeadFinal1000": 401,
+      "depLengthAt10_100": 163,
+      "depLengthAt15_100": 190,
+      "depLengthAt20_100": 208
+    },
+    {
+      "language": "Persian",
+      "isoCode": "fa",
+      "propHeadFinal1000": 401,
+      "depLengthAt10_100": 226,
+      "depLengthAt15_100": 265,
+      "depLengthAt20_100": 288
+    },
+    {
+      "language": "Norwegian (N)",
+      "isoCode": "nn",
+      "propHeadFinal1000": 390,
+      "depLengthAt10_100": 163,
+      "depLengthAt15_100": 192,
+      "depLengthAt20_100": 206
+    },
+    {
+      "language": "Czech",
+      "isoCode": "cs",
+      "propHeadFinal1000": 389,
+      "depLengthAt10_100": 169,
+      "depLengthAt15_100": 194,
+      "depLengthAt20_100": 213
+    },
+    {
+      "language": "Italian",
+      "isoCode": "it",
+      "propHeadFinal1000": 384,
+      "depLengthAt10_100": 150,
+      "depLengthAt15_100": 180,
+      "depLengthAt20_100": 188
+    },
+    {
+      "language": "Croatian",
+      "isoCode": "hr",
+      "propHeadFinal1000": 380,
+      "depLengthAt10_100": 168,
+      "depLengthAt15_100": 189,
+      "depLengthAt20_100": 206
+    },
+    {
+      "language": "French",
+      "isoCode": "fr",
+      "propHeadFinal1000": 374,
+      "depLengthAt10_100": 151,
+      "depLengthAt15_100": 175,
+      "depLengthAt20_100": 189
+    },
+    {
+      "language": "Portuguese",
+      "isoCode": "pt",
+      "propHeadFinal1000": 373,
+      "depLengthAt10_100": 155,
+      "depLengthAt15_100": 181,
+      "depLengthAt20_100": 200
+    },
+    {
+      "language": "Bulgarian",
+      "isoCode": "bg",
+      "propHeadFinal1000": 372,
+      "depLengthAt10_100": 156,
+      "depLengthAt15_100": 181,
+      "depLengthAt20_100": 197
+    },
+    {
+      "language": "Gothic",
+      "isoCode": "got",
+      "propHeadFinal1000": 372,
+      "depLengthAt10_100": 197,
+      "depLengthAt15_100": 234,
+      "depLengthAt20_100": 275
+    },
+    {
+      "language": "Catalan",
+      "isoCode": "ca",
+      "propHeadFinal1000": 371,
+      "depLengthAt10_100": 155,
+      "depLengthAt15_100": 178,
+      "depLengthAt20_100": 194
+    },
+    {
+      "language": "Ukrainian",
+      "isoCode": "uk",
+      "propHeadFinal1000": 368,
+      "depLengthAt10_100": 161,
+      "depLengthAt15_100": 189,
+      "depLengthAt20_100": 206
+    },
+    {
+      "language": "Galician",
+      "isoCode": "gl",
+      "propHeadFinal1000": 365,
+      "depLengthAt10_100": 150,
+      "depLengthAt15_100": 220,
+      "depLengthAt20_100": 210
+    },
+    {
+      "language": "Russian",
+      "isoCode": "ru",
+      "propHeadFinal1000": 358,
+      "depLengthAt10_100": 156,
+      "depLengthAt15_100": 181,
+      "depLengthAt20_100": 207
+    },
+    {
+      "language": "Serbian",
+      "isoCode": "sr",
+      "propHeadFinal1000": 349,
+      "depLengthAt10_100": 160,
+      "depLengthAt15_100": 182,
+      "depLengthAt20_100": 200
+    },
+    {
+      "language": "Church Slavonic",
+      "isoCode": "cu",
+      "propHeadFinal1000": 341,
+      "depLengthAt10_100": 200,
+      "depLengthAt15_100": 241,
+      "depLengthAt20_100": 272
+    },
+    {
+      "language": "Vietnamese",
+      "isoCode": "vi",
+      "propHeadFinal1000": 339,
+      "depLengthAt10_100": 165,
+      "depLengthAt15_100": 195,
+      "depLengthAt20_100": 212
+    },
+    {
+      "language": "Spanish",
+      "isoCode": "es",
+      "propHeadFinal1000": 332,
+      "depLengthAt10_100": 145,
+      "depLengthAt15_100": 171,
+      "depLengthAt20_100": 186
+    },
+    {
+      "language": "Polish",
+      "isoCode": "pl",
+      "propHeadFinal1000": 325,
+      "depLengthAt10_100": 156,
+      "depLengthAt15_100": 180,
+      "depLengthAt20_100": 205
+    },
+    {
+      "language": "Hebrew",
+      "isoCode": "he",
+      "propHeadFinal1000": 314,
+      "depLengthAt10_100": 154,
+      "depLengthAt15_100": 181,
+      "depLengthAt20_100": 195
+    },
+    {
+      "language": "Romanian",
+      "isoCode": "ro",
+      "propHeadFinal1000": 301,
+      "depLengthAt10_100": 160,
+      "depLengthAt15_100": 179,
+      "depLengthAt20_100": 195
+    },
+    {
+      "language": "Indonesian",
+      "isoCode": "id",
+      "propHeadFinal1000": 244,
+      "depLengthAt10_100": 148,
+      "depLengthAt15_100": 175,
+      "depLengthAt20_100": 194
+    },
+    {
+      "language": "Arabic",
+      "isoCode": "ar",
+      "propHeadFinal1000": 103,
+      "depLengthAt10_100": 140,
+      "depLengthAt15_100": 168,
+      "depLengthAt20_100": 193
+    }
+  ]
+}

--- a/Linglib/Data/UD/DependencyLength/FutrellEtAl2020.lean
+++ b/Linglib/Data/UD/DependencyLength/FutrellEtAl2020.lean
@@ -1,0 +1,69 @@
+import Linglib.Data.UD.DependencyLength.Schema
+
+/-!
+# FutrellEtAl2020 — dependency length by language (generated)
+[futrell-levy-gibson-2020]
+
+Auto-generated from `Linglib/Data/UD/DependencyLength/FutrellEtAl2020.json` by
+`scripts/gen_ud_deplength.py`. **Do not edit by hand** — edit the JSON and
+re-run the generator.
+
+Table 2 of the paper: for each of the 46 languages with more than 1500 sentences in Universal
+Dependencies 2.1, the proportion of head-final dependencies and the mean dependency length per
+word at sentence lengths 10, 15 and 20, with content words heading function words as in the UD
+annotation. The language codes are UD codes matching the keys of the paper's analysis pipeline
+(CLIQS, typology3.csv).
+-/
+
+namespace Data.UD.DependencyLength.FutrellEtAl2020
+
+/-- The 46 languages of Table 2, in the paper's row order. -/
+def rows : List Row :=
+  [⟨"Korean", "ko", 881, 201, 249, 284⟩,
+   ⟨"Japanese", "ja", 809, 170, 198, 226⟩,
+   ⟨"Turkish", "tr", 778, 199, 236, 261⟩,
+   ⟨"Hindi", "hi", 763, 188, 226, 257⟩,
+   ⟨"Urdu", "ur", 745, 186, 227, 249⟩,
+   ⟨"Hungarian", "hu", 726, 178, 213, 240⟩,
+   ⟨"Mandarin", "zh", 661, 203, 251, 298⟩,
+   ⟨"Basque", "eu", 587, 177, 210, 229⟩,
+   ⟨"Ancient Greek", "grc", 566, 234, 274, 308⟩,
+   ⟨"Latin", "la", 547, 227, 272, 299⟩,
+   ⟨"Northern Sami", "sme", 542, 185, 220, 262⟩,
+   ⟨"Dutch", "nl", 533, 207, 248, 274⟩,
+   ⟨"Afrikaans", "af", 524, 216, 248, 278⟩,
+   ⟨"Finnish", "fi", 521, 167, 192, 216⟩,
+   ⟨"Latvian", "lv", 513, 171, 193, 216⟩,
+   ⟨"Estonian", "et", 508, 184, 213, 232⟩,
+   ⟨"German", "de", 500, 204, 245, 281⟩,
+   ⟨"Modern Greek", "el", 472, 159, 186, 202⟩,
+   ⟨"English", "en", 460, 167, 193, 210⟩,
+   ⟨"Danish", "da", 420, 172, 201, 213⟩,
+   ⟨"Swedish", "sv", 420, 166, 193, 213⟩,
+   ⟨"Slovenian", "sl", 419, 173, 195, 219⟩,
+   ⟨"Slovak", "sk", 412, 165, 185, 210⟩,
+   ⟨"Norwegian (B)", "nb", 401, 163, 190, 208⟩,
+   ⟨"Persian", "fa", 401, 226, 265, 288⟩,
+   ⟨"Norwegian (N)", "nn", 390, 163, 192, 206⟩,
+   ⟨"Czech", "cs", 389, 169, 194, 213⟩,
+   ⟨"Italian", "it", 384, 150, 180, 188⟩,
+   ⟨"Croatian", "hr", 380, 168, 189, 206⟩,
+   ⟨"French", "fr", 374, 151, 175, 189⟩,
+   ⟨"Portuguese", "pt", 373, 155, 181, 200⟩,
+   ⟨"Bulgarian", "bg", 372, 156, 181, 197⟩,
+   ⟨"Gothic", "got", 372, 197, 234, 275⟩,
+   ⟨"Catalan", "ca", 371, 155, 178, 194⟩,
+   ⟨"Ukrainian", "uk", 368, 161, 189, 206⟩,
+   ⟨"Galician", "gl", 365, 150, 220, 210⟩,
+   ⟨"Russian", "ru", 358, 156, 181, 207⟩,
+   ⟨"Serbian", "sr", 349, 160, 182, 200⟩,
+   ⟨"Church Slavonic", "cu", 341, 200, 241, 272⟩,
+   ⟨"Vietnamese", "vi", 339, 165, 195, 212⟩,
+   ⟨"Spanish", "es", 332, 145, 171, 186⟩,
+   ⟨"Polish", "pl", 325, 156, 180, 205⟩,
+   ⟨"Hebrew", "he", 314, 154, 181, 195⟩,
+   ⟨"Romanian", "ro", 301, 160, 179, 195⟩,
+   ⟨"Indonesian", "id", 244, 148, 175, 194⟩,
+   ⟨"Arabic", "ar", 103, 140, 168, 193⟩]
+
+end Data.UD.DependencyLength.FutrellEtAl2020

--- a/Linglib/Data/UD/DependencyLength/Schema.lean
+++ b/Linglib/Data/UD/DependencyLength/Schema.lean
@@ -1,0 +1,39 @@
+/-!
+# Dependency length by language: schema
+
+Typed schema for the per-language corpus statistics a paper reports over Universal
+Dependencies treebanks: the proportion of head-final dependencies and the mean dependency
+length per word at fixed sentence lengths. Generated rows live in
+`Data/UD/DependencyLength/<Paper>.lean`, emitted from the canonical `<Paper>.json` by
+`scripts/gen_ud_deplength.py`.
+
+This is data: it imports nothing from `Linglib/` and states no theorems. Values are scaled
+integers, permille for the head-final proportion and hundredths for dependency lengths, at
+the precision the papers print, so that consumers compute over them by `decide`. The language
+code is a UD language code, an annotation for cross-study joins rather than a printed value.
+
+## References
+
+* [de-marneffe-zeman-2021]
+-/
+
+namespace Data.UD.DependencyLength
+
+/-- One language's head-final proportion and mean dependency length per word at sentence
+lengths 10, 15 and 20, over a UD treebank. -/
+structure Row where
+  /-- The language name as the paper prints it. -/
+  language : String
+  /-- The UD language code. -/
+  isoCode : String
+  /-- The proportion of head-final dependencies, in permille. -/
+  propHeadFinal1000 : Nat
+  /-- Mean dependency length per word at sentence length 10, in hundredths. -/
+  depLengthAt10_100 : Nat
+  /-- Mean dependency length per word at sentence length 15, in hundredths. -/
+  depLengthAt15_100 : Nat
+  /-- Mean dependency length per word at sentence length 20, in hundredths. -/
+  depLengthAt20_100 : Nat
+  deriving DecidableEq, Repr
+
+end Data.UD.DependencyLength

--- a/Linglib/Studies/FutrellEtAl2020.lean
+++ b/Linglib/Studies/FutrellEtAl2020.lean
@@ -8,22 +8,34 @@ import Linglib.Syntax.DependencyGrammar.Projectivity
 import Linglib.Syntax.DependencyGrammar.Length
 
 /-!
-# Dependency Locality as an Explanatory Principle for Word Order
-[futrell-gibson-2020]
+# Futrell, Levy and Gibson (2020): Dependency Locality as an Explanatory Principle for Word Order
 
-This file formalizes the worked examples of [futrell-gibson-2020]
-("Dependency locality as an explanatory principle for word order",
-*Language* 96(2):371–412) — the §2.3–2.4 dependency trees, with every
-total dependency length checked against the printed figure — and
-transcribes its Table 2 (per-language head-final proportion and mean
-dependency length over UD 2.1 corpora). The Monte Carlo corpus studies
-of §4–5 are not formalized.
+This file formalizes the worked examples of [futrell-levy-gibson-2020]'s case for dependency
+length minimization as a source of word-order universals: the dependency trees of its sections
+2.3 and 2.4, with every total dependency length checked against the printed figure.
+Displacement makes trees nonprojective, but only mildly, at gap degree one, in extraposition and
+*wh*-movement ((3) and (4)). Short-before-long order minimizes dependency length after a
+head-initial head, and its mirror image, long-before-short, before a head-final one ((7) and
+(8)); a chain of single dependents is shortest with consistent head direction (9), while a head
+with several short dependents does better splitting them across itself (10), the exceptions to
+harmony that [gildea-temperley-2010] derived. Heavy NP shift is the flagship case (11): keeping
+the object before the particle costs one unit for a light object and five for a heavy one. The
+random-order baseline of the corpus studies is illustrated by (13), the attested order against a
+reordering of the same tree. The corpus results of sections 4 and 5, the Monte Carlo comparisons
+with random baselines, are not formalized; the per-language head-final proportions and mean
+dependency lengths of Table 2 are the rows of `Data.UD.DependencyLength.FutrellEtAl2020`.
 
-English words come from the Fragment lexicon, and the trees follow the
-paper's drawing convention in which a preposition heads its noun, so arc
-lengths match the printed diagrams. Mirror-image and reordering claims
-are stated through `Graph.relabel`/`Graph.mirror`, so they hold by the
-general invariance theorem rather than by inspection of hand-typed twins.
+## Implementation notes
+
+* English words come from the Fragment lexicon, and the trees follow the paper's drawing
+  convention, on which a preposition heads its noun, so arc lengths match the printed diagrams.
+* Mirror-image and reordering claims go through `Graph.mirror` and `Graph.relabel`, so they
+  hold by the general invariance theorems rather than by inspection of hand-typed twins.
+
+## References
+
+* [futrell-levy-gibson-2020]
+* [gildea-temperley-2010]
 -/
 
 namespace FutrellEtAl2020
@@ -208,90 +220,5 @@ example : reorderingB.totalLength = 9 := by decide
     assertion but a definition. -/
 theorem attested_below_reordering :
     attestedOrder.totalLength < reorderingB.totalLength := by decide
-
-/-! ### Table 2: head-finality and dependency length
-
-For each of the 46 languages measured over UD 2.1 corpora, the proportion
-of head-final dependencies and the mean dependency length per word at
-sentence lengths 10, 15, and 20. The paper reads the table together with
-its scatterplots: more head-final languages have longer dependencies, and
-the languages with especially long dependencies are predominantly
-head-final ones such as Japanese, Korean, and Turkish.
-
-Values are scaled integers — permille for the head-final proportion, ×100
-for dependency lengths (mirroring the table's two decimal places) — so
-that downstream list computations kernel-`decide`. UD language codes are
-linglib annotation for cross-study joins (`Studies/LevshinaEtAl2023`);
-they are not printed in the table, but match the language keys of the
-paper's analysis pipeline, the CLIQS codebase its footnote cites
-(<https://github.com/langprocgroup/cliqs/>, `typology3.csv`). -/
-
-/-- One row of Table 2: head-final proportion and mean per-word dependency
-lengths for one UD 2.1 language. -/
-structure DepLengthRow where
-  /-- Language name as printed in the table (e.g. "Norwegian (B)"). -/
-  language : String
-  /-- UD language code (linglib annotation, not part of the table). -/
-  isoCode : String
-  /-- Proportion of head-final dependencies, permille (881 = 0.881). -/
-  propHeadFinal1000 : Nat
-  /-- Mean dependency length per word at sentence length 10, ×100. -/
-  depLengthAt10_100 : Nat
-  /-- Mean dependency length per word at sentence length 15, ×100. -/
-  depLengthAt15_100 : Nat
-  /-- Mean dependency length per word at sentence length 20, ×100. -/
-  depLengthAt20_100 : Nat
-  deriving Repr, DecidableEq
-
-/-- Table 2, in the paper's row order (descending head-final proportion). -/
-def table2 : List DepLengthRow := [
-  ⟨"Korean", "ko", 881, 201, 249, 284⟩,
-  ⟨"Japanese", "ja", 809, 170, 198, 226⟩,
-  ⟨"Turkish", "tr", 778, 199, 236, 261⟩,
-  ⟨"Hindi", "hi", 763, 188, 226, 257⟩,
-  ⟨"Urdu", "ur", 745, 186, 227, 249⟩,
-  ⟨"Hungarian", "hu", 726, 178, 213, 240⟩,
-  ⟨"Mandarin", "zh", 661, 203, 251, 298⟩,
-  ⟨"Basque", "eu", 587, 177, 210, 229⟩,
-  ⟨"Ancient Greek", "grc", 566, 234, 274, 308⟩,
-  ⟨"Latin", "la", 547, 227, 272, 299⟩,
-  ⟨"Northern Sami", "sme", 542, 185, 220, 262⟩,
-  ⟨"Dutch", "nl", 533, 207, 248, 274⟩,
-  ⟨"Afrikaans", "af", 524, 216, 248, 278⟩,
-  ⟨"Finnish", "fi", 521, 167, 192, 216⟩,
-  ⟨"Latvian", "lv", 513, 171, 193, 216⟩,
-  ⟨"Estonian", "et", 508, 184, 213, 232⟩,
-  ⟨"German", "de", 500, 204, 245, 281⟩,
-  ⟨"Modern Greek", "el", 472, 159, 186, 202⟩,
-  ⟨"English", "en", 460, 167, 193, 210⟩,
-  ⟨"Danish", "da", 420, 172, 201, 213⟩,
-  ⟨"Swedish", "sv", 420, 166, 193, 213⟩,
-  ⟨"Slovenian", "sl", 419, 173, 195, 219⟩,
-  ⟨"Slovak", "sk", 412, 165, 185, 210⟩,
-  ⟨"Norwegian (B)", "nb", 401, 163, 190, 208⟩,
-  ⟨"Persian", "fa", 401, 226, 265, 288⟩,
-  ⟨"Norwegian (N)", "nn", 390, 163, 192, 206⟩,
-  ⟨"Czech", "cs", 389, 169, 194, 213⟩,
-  ⟨"Italian", "it", 384, 150, 180, 188⟩,
-  ⟨"Croatian", "hr", 380, 168, 189, 206⟩,
-  ⟨"French", "fr", 374, 151, 175, 189⟩,
-  ⟨"Portuguese", "pt", 373, 155, 181, 200⟩,
-  ⟨"Bulgarian", "bg", 372, 156, 181, 197⟩,
-  ⟨"Gothic", "got", 372, 197, 234, 275⟩,
-  ⟨"Catalan", "ca", 371, 155, 178, 194⟩,
-  ⟨"Ukrainian", "uk", 368, 161, 189, 206⟩,
-  ⟨"Galician", "gl", 365, 150, 220, 210⟩,
-  ⟨"Russian", "ru", 358, 156, 181, 207⟩,
-  ⟨"Serbian", "sr", 349, 160, 182, 200⟩,
-  ⟨"Church Slavonic", "cu", 341, 200, 241, 272⟩,
-  ⟨"Vietnamese", "vi", 339, 165, 195, 212⟩,
-  ⟨"Spanish", "es", 332, 145, 171, 186⟩,
-  ⟨"Polish", "pl", 325, 156, 180, 205⟩,
-  ⟨"Hebrew", "he", 314, 154, 181, 195⟩,
-  ⟨"Romanian", "ro", 301, 160, 179, 195⟩,
-  ⟨"Indonesian", "id", 244, 148, 175, 194⟩,
-  ⟨"Arabic", "ar", 103, 140, 168, 193⟩ ]
-
-example : table2.length = 46 := rfl
 
 end FutrellEtAl2020

--- a/Linglib/Studies/LevshinaEtAl2023.lean
+++ b/Linglib/Studies/LevshinaEtAl2023.lean
@@ -1,5 +1,5 @@
 import Linglib.Studies.Gibson2025
-import Linglib.Studies.FutrellEtAl2020
+import Linglib.Data.UD.DependencyLength.FutrellEtAl2020
 
 /-!
 # Levshina et al. 2023: Gradient Word Order
@@ -274,16 +274,16 @@ theorem harmony_is_gradient_not_binary :
     harmonicProportion1000 voSubordinator ≠ harmonicProportion1000 voRelativeClause := by
   constructor <;> decide
 
--- Bridge 3: Head-final proportion ↔ SO proportion (FutrellEtAl2020.lean)
+-- Bridge 3: Head-final proportion ↔ SO proportion (Data/UD/DependencyLength/FutrellEtAl2020)
 
 /-- Languages with a high head-final proportion (> 700‰) in
-    [futrell-gibson-2020]'s Table 2 have high soProportion (> 700) in
+    [futrell-levy-gibson-2020]'s Table 2 have high soProportion (> 700) in
     Levshina: head-final ≈ SOV ≈ high SO proportion. -/
 theorem head_final_correlates_with_so :
     let shared := allProfiles.filter (λ p =>
-      FutrellEtAl2020.table2.any (·.isoCode == p.isoCode))
+      Data.UD.DependencyLength.FutrellEtAl2020.rows.any (·.isoCode == p.isoCode))
     let highHF := shared.filter (λ p =>
-      match FutrellEtAl2020.table2.find? (·.isoCode == p.isoCode) with
+      match Data.UD.DependencyLength.FutrellEtAl2020.rows.find? (·.isoCode == p.isoCode) with
       | some f => f.propHeadFinal1000 > 700
       | none => false)
     highHF.all (·.soProportion1000 > 700) = true := by decide

--- a/Linglib/Syntax/DependencyGrammar/Length.lean
+++ b/Linglib/Syntax/DependencyGrammar/Length.lean
@@ -32,7 +32,7 @@ random-reordering baselines that test the claim.
 
 [behaghel-1932] — Deutsche Syntax IV, source of the "Oberstes Gesetz"
 threshold
-[futrell-gibson-2020] — Dependency locality as an explanatory principle
+[futrell-levy-gibson-2020] — Dependency locality as an explanatory principle
 for word order, source of the minimisation claim and the
 random-reordering baselines
 -/
@@ -99,7 +99,7 @@ theorem _root_.Fin.dist_rev_rev (v w : Fin n) :
 
 /-- The mirror image of a graph has the same total dependency length —
     the head-final preference is the exact mirror of the head-initial one
-    ([futrell-gibson-2020], examples (7)–(8)). -/
+    ([futrell-levy-gibson-2020], examples (7)–(8)). -/
 theorem Graph.totalLength_mirror (g : Graph n) :
     g.mirror.totalLength = g.totalLength :=
   g.totalLength_relabel _ (λ v w => Fin.dist_rev_rev v w)

--- a/references.bib
+++ b/references.bib
@@ -8210,7 +8210,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Syntax/Tree/Cat.lean;Data/UD/Basic.lean;Features/Case/Basic.lean}
+  sources   = {Data/UD/Basic.lean;Data/UD/DependencyLength/Schema.lean;Features/Case/Basic.lean;Syntax/Tree/Cat.lean}
 }% REF: Denić, M., Homer, V., Rothschild, D. & Chemla, E. (2021). The influence of polarity items on inferential judgments. Cogn
 @article{le-bruyn-de-swart-2022,
   author    = {Le Bruyn, Bert and de Swart, Henriëtte},
@@ -21843,7 +21843,7 @@
   validated = {true},
   sources   = {Syntax/DependencyGrammar/Crossings.lean}
 }% REF: Futrell, R., Levy, R. & Gibson, E. (2020). Dependency locality as an explanatory principle for word order. Language 96(2
-@article{futrell-gibson-2020,
+@article{futrell-levy-gibson-2020,
   author    = {Futrell, Richard and Levy, Roger P. and Gibson, Edward},
   year      = {2020},
   title     = {Dependency locality as an explanatory principle for word order},
@@ -21853,9 +21853,9 @@
   pages     = {371--412},
   doi       = {10.1353/lan.2020.0024},
   subfield  = {syntax},
-  role      = {cited},
+  role      = {formalized},
   validated = {true},
-  sources   = {Syntax/DependencyGrammar/Formal/DependencyLength.lean;Syntax/DependencyGrammar/Formal/HarmonicOrder.lean;Studies/FutrellEtAl2020.lean}
+  sources   = {Data/UD/DependencyLength/FutrellEtAl2020.lean;Studies/FutrellEtAl2020.lean;Studies/LevshinaEtAl2023.lean;Syntax/DependencyGrammar/Length.lean}
 }
 
 @article{gildea-temperley-2010,

--- a/scripts/gen_ud_deplength.py
+++ b/scripts/gen_ud_deplength.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Generate typed dependency-length rows from canonical per-paper JSON.
+
+Per-language corpus statistics a paper prints — the proportion of head-final
+dependencies and the mean dependency length per word at fixed sentence
+lengths, measured over Universal Dependencies treebanks — are canonical JSON
+at `Linglib/Data/UD/DependencyLength/<Paper>.json`; this emits the
+kernel-reducible typed Lean module
+`Linglib/Data/UD/DependencyLength/<Paper>.lean` (`<Paper>.rows`). Mirrors
+`gen_protoroles.py`: the generated Lean is never hand-edited — edit the JSON
+and re-run.
+
+    python3 scripts/gen_ud_deplength.py FutrellEtAl2020       # (re)generate
+    python3 scripts/gen_ud_deplength.py --check [<Paper>]     # verify, no writes (CI)
+    python3 scripts/gen_ud_deplength.py --all                 # every JSON
+"""
+import sys, json, re, textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "Linglib" / "Data" / "UD" / "DependencyLength"
+FIELDS = ["propHeadFinal1000", "depLengthAt10_100", "depLengthAt15_100", "depLengthAt20_100"]
+
+
+def row_lit(r: dict) -> str:
+    nums = ", ".join(str(int(r[f])) for f in FIELDS)
+    return f"⟨{json.dumps(r['language'])}, {json.dumps(r['isoCode'])}, {nums}⟩"
+
+
+def render(paper: str, meta: dict, rows: list) -> str:
+    lits = ",\n   ".join(row_lit(r) for r in rows)
+    return f"""import Linglib.Data.UD.DependencyLength.Schema
+
+/-!
+# {paper} — dependency length by language (generated)
+[{meta['bibkey']}]
+
+Auto-generated from `Linglib/Data/UD/DependencyLength/{paper}.json` by
+`scripts/gen_ud_deplength.py`. **Do not edit by hand** — edit the JSON and
+re-run the generator.
+
+{textwrap.fill(meta['description'], 96)}
+-/
+
+namespace Data.UD.DependencyLength.{paper}
+
+/-- The {len(rows)} languages of {meta['locator']}, in the paper's row order. -/
+def rows : List Row :=
+  [{lits}]
+
+end Data.UD.DependencyLength.{paper}
+"""
+
+
+def ensure_import(file_path: Path, module: str) -> bool:
+    body = file_path.read_text(encoding="utf-8")
+    stmt = f"import {module}"
+    if re.search(rf"^{re.escape(stmt)}\s*$", body, flags=re.M):
+        return False
+    lines = body.splitlines(keepends=True)
+    last = max((i for i, l in enumerate(lines) if l.startswith("import ")), default=-1)
+    lines.insert(last + 1, stmt + "\n")
+    file_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def process(paper: str, check: bool) -> bool:
+    json_path = DATA_DIR / f"{paper}.json"
+    if not json_path.exists():
+        sys.stderr.write(f"FATAL: JSON not found at {json_path.relative_to(ROOT)}\n")
+        sys.exit(1)
+    doc = json.loads(json_path.read_text(encoding="utf-8"))
+    content = render(paper, doc["meta"], doc["rows"])
+    out = DATA_DIR / f"{paper}.lean"
+    if check:
+        cur = out.read_text(encoding="utf-8") if out.exists() else ""
+        if cur != content:
+            sys.stderr.write(f"[check] DRIFT: {out.relative_to(ROOT)} out of sync with JSON\n")
+            return False
+        for mod in (f"Linglib.Data.UD.DependencyLength.{paper}",
+                    "Linglib.Data.UD.DependencyLength.Schema"):
+            if f"import {mod}" not in (ROOT / "Linglib.lean").read_text(encoding="utf-8"):
+                sys.stderr.write(f"[check] DRIFT: {mod} missing from Linglib.lean\n")
+                return False
+        sys.stdout.write(f"[check] {out.relative_to(ROOT)} in sync ({len(doc['rows'])} rows)\n")
+        return True
+    out.write_text(content, encoding="utf-8")
+    sys.stdout.write(f"[gen] {out.relative_to(ROOT)} ← {json_path.relative_to(ROOT)} ({len(doc['rows'])} rows)\n")
+    ensure_import(ROOT / "Linglib.lean", "Linglib.Data.UD.DependencyLength.Schema")
+    if ensure_import(ROOT / "Linglib.lean", f"Linglib.Data.UD.DependencyLength.{paper}"):
+        sys.stdout.write(f"[gen] added Linglib.Data.UD.DependencyLength.{paper} import to Linglib.lean\n")
+    return True
+
+
+def main():
+    args = sys.argv[1:]
+    check = "--check" in args
+    args = [a for a in args if a != "--check"]
+    if args == ["--all"] or (not args and check):
+        papers = sorted(p.stem for p in DATA_DIR.glob("*.json"))
+    elif len(args) == 1:
+        papers = args
+    else:
+        sys.stderr.write(__doc__)
+        sys.exit(2)
+    ok = all(process(p, check) for p in papers)
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Cleanse of FutrellEtAl2020 against the paper (Zotero manuscript): the worked trees and their printed totals check out; the hand-typed Table 2 leaves the Lean file for a generated data module, and the bib key gains its missing author.

- `Data/UD/DependencyLength/`: `Schema.lean` (`Row`), `FutrellEtAl2020.json` (46 rows, verified against Table 2 row by row) and the generated `FutrellEtAl2020.lean` from the new `scripts/gen_ud_deplength.py`; README entry
- LevshinaEtAl2023's head-final bridge now joins on the data module instead of importing the study
- `futrell-gibson-2020` → `futrell-levy-gibson-2020` (the entry already listed Levy) across its three citers; role formalized; module docstring in the mathlib register
