### PR TITLE
chore: union merge driver for Linglib.lean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Every PR inserts its own import line here; the union driver keeps both sides instead of conflicting.
+Linglib.lean merge=union


### PR DESCRIPTION
Every study PR inserts one import line into Linglib.lean at its alphabetical slot, so alphabetically adjacent PRs (#2861 against #2865) conflict on nothing but that line. The union driver keeps both sides' lines for local rebases; the lakefile globs all submodules, so the root import list is only a documentation root and line order is immaterial.