### PR TITLE
refactor(Studies/Gajewski2011): licensing over exhaustified meanings

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3071,3 +3071,4 @@ import Linglib.Data.Examples.FrischPierrehumbertBroe2004
 import Linglib.Data.Examples.Funakoshi2016
 import Linglib.Data.Examples.FuscoSgrizzi2026
 import Linglib.Data.Examples.Gajewski2002
+import Linglib.Data.Examples.Gajewski2011

--- a/Linglib/Data/Examples/Gajewski2011.json
+++ b/Linglib/Data/Examples/Gajewski2011.json
@@ -1,0 +1,632 @@
+[
+  {
+    "id": "gajewski2011_ex20a",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(20a)"
+    },
+    "language": "stan1293",
+    "primaryText": "No doctor has seen anyone.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "no"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "anyone"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "gajewski2011_ex21a",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(21a)"
+    },
+    "language": "stan1293",
+    "primaryText": "No doctor has seen Mary in weeks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "no"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "in weeks"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "No sits at the end of its scale, so its enriched meaning is its plain, downward-entailing meaning."
+  },
+  {
+    "id": "gajewski2011_ex20b",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(20b)"
+    },
+    "language": "stan1293",
+    "primaryText": "At most five doctors have seen anyone.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "atMostFive"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "anyone"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": "Downward entailing but not anti-additive."
+  },
+  {
+    "id": "gajewski2011_ex21b",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(21b)"
+    },
+    "language": "stan1293",
+    "primaryText": "At most five doctors have seen Mary in weeks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "atMostFive"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "in weeks"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Excluding the stronger alternative at most four leaves exactly five, which is not downward entailing."
+  },
+  {
+    "id": "gajewski2011_ex1f",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(1f)"
+    },
+    "language": "stan1293",
+    "primaryText": "Some student ever said anything.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "some"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "ever"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Upward entailing in its scope."
+  },
+  {
+    "id": "gajewski2011_ex2f",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(2f)"
+    },
+    "language": "stan1293",
+    "primaryText": "Some students left until their birthdays.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "some"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "until"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "gajewski2011_ex26a",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(26a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Only John has ever seen anyone.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "only"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "ever, anyone"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "gajewski2011_ex26b",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(26b)"
+    },
+    "language": "stan1293",
+    "primaryText": "Only John has seen Mary in weeks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "only"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "in weeks"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Only's presupposition that the focus satisfies the scope is upward entailing."
+  },
+  {
+    "id": "gajewski2011_ex26c",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(26c)"
+    },
+    "language": "stan1293",
+    "primaryText": "Only John likes pancakes, either.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "only"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "either"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Only's presupposition that the focus satisfies the scope is upward entailing. The paper credits the example to Nathan (1999)."
+  },
+  {
+    "id": "gajewski2011_ex26d",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(26d)"
+    },
+    "language": "stan1293",
+    "primaryText": "Only John arrived until his birthday.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "only"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "until"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "Only's presupposition that the focus satisfies the scope is upward entailing."
+  },
+  {
+    "id": "gajewski2011_ex27a",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(27a)"
+    },
+    "language": "stan1293",
+    "primaryText": "If Bill has ever seen anyone, he is keeping it a secret.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "conditional"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "ever, anyone"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "gajewski2011_ex27b",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(27b)"
+    },
+    "language": "stan1293",
+    "primaryText": "If Bill has seen Mary in weeks, he is keeping it a secret.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "conditional"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "in weeks"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The conditional's presupposition that its antecedent is possible is upward entailing."
+  },
+  {
+    "id": "gajewski2011_ex27c",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(27c)"
+    },
+    "language": "stan1293",
+    "primaryText": "If Bill likes pancakes, either, he is keeping it a secret.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "conditional"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "either"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The conditional's presupposition that its antecedent is possible is upward entailing."
+  },
+  {
+    "id": "gajewski2011_ex27d",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(27d)"
+    },
+    "language": "stan1293",
+    "primaryText": "If Bill arrived until Friday, he is keeping it a secret.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "conditional"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "until"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The conditional's presupposition that its antecedent is possible is upward entailing."
+  },
+  {
+    "id": "gajewski2011_ex28a",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(28a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Mary is sorry that she ever talked to anyone.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "sorry"
+      ],
+      [
+        "strength",
+        "weak"
+      ],
+      [
+        "npi",
+        "ever, anyone"
+      ],
+      [
+        "grammatical",
+        "yes"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "gajewski2011_ex28b",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(28b)"
+    },
+    "language": "stan1293",
+    "primaryText": "Mary is sorry that she has talked to Bill in weeks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "sorry"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "in weeks"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The factive presupposition of sorry is upward entailing in the complement."
+  },
+  {
+    "id": "gajewski2011_ex28c",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(28c)"
+    },
+    "language": "stan1293",
+    "primaryText": "Mary is sorry that she likes pancakes, either.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "sorry"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "either"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The factive presupposition of sorry is upward entailing in the complement."
+  },
+  {
+    "id": "gajewski2011_ex28d",
+    "source": {
+      "bibkey": "gajewski-2011",
+      "paperLabel": "(28d)"
+    },
+    "language": "stan1293",
+    "primaryText": "Mary is sorry that she arrived until Friday.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "licenser",
+        "sorry"
+      ],
+      [
+        "strength",
+        "strong"
+      ],
+      [
+        "npi",
+        "until"
+      ],
+      [
+        "grammatical",
+        "no"
+      ]
+    ],
+    "comment": "The factive presupposition of sorry is upward entailing in the complement."
+  }
+]

--- a/Linglib/Data/Examples/Gajewski2011.lean
+++ b/Linglib/Data/Examples/Gajewski2011.lean
@@ -1,0 +1,342 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Gajewski2011` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Gajewski2011.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Gajewski2011.Examples`.
+-/
+
+namespace Gajewski2011.Examples
+
+open Data.Examples
+
+def ex20a : LinguisticExample :=
+  { id := "gajewski2011_ex20a"
+    source := ⟨"gajewski-2011", "(20a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No doctor has seen anyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "no"), ("strength", "weak"), ("npi", "anyone"), ("grammatical", "yes")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex21a : LinguisticExample :=
+  { id := "gajewski2011_ex21a"
+    source := ⟨"gajewski-2011", "(21a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No doctor has seen Mary in weeks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "no"), ("strength", "strong"), ("npi", "in weeks"), ("grammatical", "yes")]
+    comment := "No sits at the end of its scale, so its enriched meaning is its plain, downward-entailing meaning."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex20b : LinguisticExample :=
+  { id := "gajewski2011_ex20b"
+    source := ⟨"gajewski-2011", "(20b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "At most five doctors have seen anyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "atMostFive"), ("strength", "weak"), ("npi", "anyone"), ("grammatical", "yes")]
+    comment := "Downward entailing but not anti-additive."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex21b : LinguisticExample :=
+  { id := "gajewski2011_ex21b"
+    source := ⟨"gajewski-2011", "(21b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "At most five doctors have seen Mary in weeks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "atMostFive"), ("strength", "strong"), ("npi", "in weeks"), ("grammatical", "no")]
+    comment := "Excluding the stronger alternative at most four leaves exactly five, which is not downward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex1f : LinguisticExample :=
+  { id := "gajewski2011_ex1f"
+    source := ⟨"gajewski-2011", "(1f)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Some student ever said anything."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "some"), ("strength", "weak"), ("npi", "ever"), ("grammatical", "no")]
+    comment := "Upward entailing in its scope."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2f : LinguisticExample :=
+  { id := "gajewski2011_ex2f"
+    source := ⟨"gajewski-2011", "(2f)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Some students left until their birthdays."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "some"), ("strength", "strong"), ("npi", "until"), ("grammatical", "no")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex26a : LinguisticExample :=
+  { id := "gajewski2011_ex26a"
+    source := ⟨"gajewski-2011", "(26a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Only John has ever seen anyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "only"), ("strength", "weak"), ("npi", "ever, anyone"), ("grammatical", "yes")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex26b : LinguisticExample :=
+  { id := "gajewski2011_ex26b"
+    source := ⟨"gajewski-2011", "(26b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Only John has seen Mary in weeks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "only"), ("strength", "strong"), ("npi", "in weeks"), ("grammatical", "no")]
+    comment := "Only's presupposition that the focus satisfies the scope is upward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex26c : LinguisticExample :=
+  { id := "gajewski2011_ex26c"
+    source := ⟨"gajewski-2011", "(26c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Only John likes pancakes, either."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "only"), ("strength", "strong"), ("npi", "either"), ("grammatical", "no")]
+    comment := "Only's presupposition that the focus satisfies the scope is upward entailing. The paper credits the example to Nathan (1999)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex26d : LinguisticExample :=
+  { id := "gajewski2011_ex26d"
+    source := ⟨"gajewski-2011", "(26d)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Only John arrived until his birthday."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "only"), ("strength", "strong"), ("npi", "until"), ("grammatical", "no")]
+    comment := "Only's presupposition that the focus satisfies the scope is upward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex27a : LinguisticExample :=
+  { id := "gajewski2011_ex27a"
+    source := ⟨"gajewski-2011", "(27a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Bill has ever seen anyone, he is keeping it a secret."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "conditional"), ("strength", "weak"), ("npi", "ever, anyone"), ("grammatical", "yes")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex27b : LinguisticExample :=
+  { id := "gajewski2011_ex27b"
+    source := ⟨"gajewski-2011", "(27b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Bill has seen Mary in weeks, he is keeping it a secret."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "conditional"), ("strength", "strong"), ("npi", "in weeks"), ("grammatical", "no")]
+    comment := "The conditional's presupposition that its antecedent is possible is upward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex27c : LinguisticExample :=
+  { id := "gajewski2011_ex27c"
+    source := ⟨"gajewski-2011", "(27c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Bill likes pancakes, either, he is keeping it a secret."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "conditional"), ("strength", "strong"), ("npi", "either"), ("grammatical", "no")]
+    comment := "The conditional's presupposition that its antecedent is possible is upward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex27d : LinguisticExample :=
+  { id := "gajewski2011_ex27d"
+    source := ⟨"gajewski-2011", "(27d)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Bill arrived until Friday, he is keeping it a secret."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "conditional"), ("strength", "strong"), ("npi", "until"), ("grammatical", "no")]
+    comment := "The conditional's presupposition that its antecedent is possible is upward entailing."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex28a : LinguisticExample :=
+  { id := "gajewski2011_ex28a"
+    source := ⟨"gajewski-2011", "(28a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary is sorry that she ever talked to anyone."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "sorry"), ("strength", "weak"), ("npi", "ever, anyone"), ("grammatical", "yes")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex28b : LinguisticExample :=
+  { id := "gajewski2011_ex28b"
+    source := ⟨"gajewski-2011", "(28b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary is sorry that she has talked to Bill in weeks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "sorry"), ("strength", "strong"), ("npi", "in weeks"), ("grammatical", "no")]
+    comment := "The factive presupposition of sorry is upward entailing in the complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex28c : LinguisticExample :=
+  { id := "gajewski2011_ex28c"
+    source := ⟨"gajewski-2011", "(28c)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary is sorry that she likes pancakes, either."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "sorry"), ("strength", "strong"), ("npi", "either"), ("grammatical", "no")]
+    comment := "The factive presupposition of sorry is upward entailing in the complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex28d : LinguisticExample :=
+  { id := "gajewski2011_ex28d"
+    source := ⟨"gajewski-2011", "(28d)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Mary is sorry that she arrived until Friday."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("licenser", "sorry"), ("strength", "strong"), ("npi", "until"), ("grammatical", "no")]
+    comment := "The factive presupposition of sorry is upward entailing in the complement."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex20a, ex21a, ex20b, ex21b, ex1f, ex2f, ex26a, ex26b, ex26c, ex26d, ex27a, ex27b, ex27c, ex27d, ex28a, ex28b, ex28c, ex28d]
+
+end Gajewski2011.Examples

--- a/Linglib/Logic/Natural/Strawson/Basic.lean
+++ b/Linglib/Logic/Natural/Strawson/Basic.lean
@@ -519,18 +519,34 @@ theorem condNecessity_isStrawsonAA {W : Type*} (domain : W → Set W) (β : Set 
       (fun _ _ => True) :=
   antiAdditive_implies_strawsonAA _ (condNecessity_isAntiAdditive domain β) _
 
-/-- [gajewski-2011] Appendix 1's actual `would` SAA result.
+/-- The full meaning of *would*: the conditional with its non-vacuity presupposition, that the
+modal base admits the antecedent ([von-fintel-1999]). -/
+def wouldFull {W : Type*} (domain : W → Set W) (p q : Set W) : Set W :=
+  fun w => (∃ w' ∈ domain w, p w') ∧ condNecessity domain p q w
 
-    vF's `would` has the same truth conditions as `condNecessity` but
-    with the non-vacuity presupposition `D_i(w) ∩ p ≠ ∅` (the modal
-    base intersected with the antecedent is non-empty). The SAA proof
-    is identical to the classical AA result; the non-vacuity is what
-    matters for non-trivial Strawson reasoning, not for the AA equation
-    itself. -/
+/-- With its presupposition in, *would* is not downward entailing in the antecedent: an empty
+antecedent fails the presupposition. -/
+theorem wouldFull_not_de :
+    ¬ Antitone (λ p => wouldFull (λ (_ : Fin 4) => Set.univ) p Set.univ) := λ h =>
+  have hu : (0 : Fin 4) ∈ wouldFull (λ (_ : Fin 4) => Set.univ) Set.univ Set.univ :=
+    ⟨⟨0, trivial, trivial⟩, λ _ _ _ => trivial⟩
+  (h (Set.empty_subset Set.univ) hu).1.elim λ _ hw => hw.2
+
+/-- *Would* is Strawson downward entailing in its antecedent: definedness supplies the
+non-vacuity a smaller antecedent could lose, and the conditional itself is antitone. -/
+theorem wouldFull_isStrawsonDE {W : Type*} (domain : W → Set W) (q : Set W) :
+    IsStrawsonDE (λ p => wouldFull domain p q) (λ p w => ∃ w' ∈ domain w, p w') :=
+  λ _ _ hpq _ hdef h => ⟨hdef, λ w' hw' hp => h.2 w' hw' (hpq hp)⟩
+
+/-- *Would* is Strawson anti-additive in its antecedent ([gajewski-2011]'s appendix): once both
+disjuncts are possible, the disjunctive antecedent is too, and the conditional distributes. -/
 theorem wouldFull_isStrawsonAA {W : Type*} (domain : W → Set W) (q : Set W) :
-    IsStrawsonAntiAdditive (fun p => condNecessity domain p q)
-      (fun p w => ∃ w' ∈ domain w, p w') :=
-  antiAdditive_implies_strawsonAA _ (condNecessity_isAntiAdditive domain q) _
+    IsStrawsonAntiAdditive (λ p => wouldFull domain p q) (λ p w => ∃ w' ∈ domain w, p w') :=
+  λ _ _ _ hp hp' =>
+    ⟨λ h => ⟨⟨hp, λ w' hw' hpw => h.2 w' hw' (Or.inl hpw)⟩,
+        ⟨hp', λ w' hw' hpw => h.2 w' hw' (Or.inr hpw)⟩⟩,
+      λ ⟨h₁, h₂⟩ => ⟨hp.imp λ _ ⟨hw', hpw⟩ => ⟨hw', Or.inl hpw⟩,
+        λ w' hw' h => h.elim (h₁.2 w' hw') (h₂.2 w' hw')⟩⟩
 
 /-! ### Strictness -/
 

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -1,681 +1,281 @@
 import Linglib.Logic.Natural.Strawson.Basic
-import Linglib.Semantics.Presupposition.Basic
-import Linglib.Semantics.Exhaustification.InnocentExclusion
-import Linglib.Semantics.Polarity.Licensing
-import Linglib.Semantics.Degree.Quantifier
-import Linglib.Studies.VonFintel1999
-import Linglib.Fragments.English.PolarityItems
-import Linglib.Semantics.Polarity.Item
+import Linglib.Semantics.Quantification.Counting
+import Linglib.Data.Examples.Gajewski2011
 
 /-!
-# [gajewski-2011] — Licensing strong NPIs
+# Gajewski (2011): Licensing strong NPIs
 
-  Gajewski, J. R. (2011). Licensing strong NPIs. Natural Language
-  Semantics 19(2), 109–148.
+This file formalizes [gajewski-2011]'s account of why weak negative polarity items (*any*,
+*ever*) and strong ones (*in weeks*, *either*, *until*) part ways under *only*, conditional
+antecedents and *sorry*. Those operators are Strawson anti-additive ([von-fintel-1999]), yet
+they license only the weak items, although anti-additivity is what the strong items were held
+to need ([zwarts-1998]). The paper's answer is that the two classes inspect different meanings:
+a weak item needs a licenser that is Strawson downward entailing, a strong item a licenser whose
+meaning enriched by scalar implicature is downward entailing in the plain sense. A determiner at
+the bottom of its Horn scale, *no*, is its own enriched meaning and licenses both; one above the
+bottom, *not every* or *at most five*, exhaustifies to a meaning with an upward-entailing
+conjunct and licenses only weak items; and a presupposition trigger's full meaning fails plain
+downward entailment for the same reason.
 
-The paper's central puzzle: the standard Zwarts/Ladusaw picture says
-strong NPIs (`either`, `in weeks`, punctual `until`) require an
-**anti-additive** licenser, whereas weak NPIs (`any`, `ever`) need only
-**downward entailment**. Once [von-fintel-1999] weakens DE to
-Strawson-DE, the natural extension is to weaken AA to Strawson-AA
-(SAA). But [rullmann-2003] and [gajewski-2011] observe that
-SAA is *too weak*: vF's recalcitrants (`only`, conditionals, emotive
-factives) are all SAA (Appendix 1) yet do *not* license strong NPIs.
+The exhaustivity operator `exh` enriches a determiner against its scale-mates in the manner of
+[fox-2007] over [chierchia-2004]'s alternatives, `Licensed` applies the two principles to each
+of the paper's licensers, and `rows_predicted` checks them against the paper's sentences. The
+Intolerance property of the paper's appendix ([horn-1989]), which sits strictly between
+anti-additivity and downward entailment, is `IsIntolerant`.
 
-Gajewski proposes that strong NPIs are sensitive to the licenser's
-**direct scalar implicatures**, while weak NPIs are not. Strong NPIs
-need DE assessed on the meaning *enriched with the licenser's direct
-implicature*; AA was the wrong property — it only happened to coincide
-with "DE + scalar endpoint" (Conjecture 48).
+## Implementation notes
 
-## What this study file covers
+* Entailment between scale-mates holds the restrictor fixed and quantifies over scopes, so *no*
+  entails *not every* whenever the restrictor is nonempty, which is what makes *no* the bottom
+  of its scale; letting the restrictor vary would break the entailment at an empty restrictor.
+  The scale is the pair of ends the paper's computation of exhaustified *not every* uses; the
+  intermediate scale-mates would sharpen that meaning further.
+* The presupposition triggers have no scale-mates, so their enriched meaning is their full
+  meaning, presupposition included, and the strong principle asks for its plain downward
+  entailment. The operators and their Strawson properties are the Strawson substrate's.
+* The paper's *at most five* against *at most four*, and the cardinal *fewer than four* of its
+  scale-truncation discussion, are checked on a six-element domain.
 
-- §3.3 puzzle (eqs. 39-41): strong NPIs ungrammatical under SAA
-  operators (`only`, conditionals, emotive factives). Documented in
-  the section docstrings; the formal SAA results live in
-  `Strawson/Basic.lean`.
-- Appendix 1 SAA proofs for vF's recalcitrants — formalized:
-  `onlyFull_isStrawsonAA`, `sorryFull_isStrawsonAA`,
-  `condNecessity_isStrawsonAA`, `superlative_isStrawsonAA` (all in
-  `Strawson/Basic.lean`). This file just cites them as
-  `gaj2011_appendix1_*` for paper-citation indexing.
-- Conjecture (eq. 48): a DE scalar item is AA iff it is the endpoint
-  of its scale. Documented in §3.3 docstring; the conjecture is
-  scale-theoretic and would need scale-side machinery to formalize.
-- `IsIntolerant` predicate (eq. 80) and the Appendix 2 result
-  AA ⊆ DE + Intolerant — both formalized below (demoted substrate),
-  re-exported as `gaj2011_appendix2_AA_implies_intolerant`.
-- `wouldFull_isStrawsonAA` — Gajewski Appendix 1's actual `would`-with-
-  non-vacuity-presupposition SAA result (in
-  `Logic/Natural/Strawson/Basic.lean`).
-- Strong-NPI registry consistency theorem
-  (`gaj2011_strongNPIs_excluded_from_strawson_only_contexts`) —
-  Gajewski's headline empirical claim made `decide`-checkable over the
-  Fragment registry.
-- Hoeksema S-comparative SAA bridge
-  (`bridge_hoeksema_gtOverSet_strawsonAA`) — the positive test case
-  for Gajewski's framework: classically AA → strong NPIs predicted ✓.
+## References
 
-## §4 framework — both halves now in skeleton
-
-- Conditions 1, 2 (eqs. 59, 66): formalized below (demoted substrate)
-  using `Exhaustification.exhMW` (Spector 2016) as the `O(F, G)` operator.
-  Trivial-ALT bridges proved (`condition1_with_no_alts_iff_de`,
-  `condition2_with_no_alts_iff_de`). `only`'s satisfaction of Cond 1, 2
-  in the trivial limit cited below.
-- Conditions 3, 4 (eqs. 93, 94): formalized below (demoted substrate)
-  via `KPOperator` over `PartialProp`. `only` satisfies Cond 3 ✓, fails
-  Cond 4 ✗ (`gaj2011_only_condition3_yes_condition4_no`).
-
-## What's still genuinely deferred
-
-- **Empirical Cond 2 failure for `only`** under attested ALT-1 sets
-  (Chierchia's "highest-scopal-item only" alternatives generated from
-  the strong NPI in scope). The substrate `Exhaustification.exhMW` and
-  `Exhaustification.exhIE` provide the O-operator; the Chierchia-side
-  ALT-1 generator (matching `Studies/Chierchia2006.lean`'s
-  `PSIProfile` framework) needs to be wired up. Concrete witness for
-  `only`'s Cond 2 failure would require this.
-- The Intolerance-based account of `few` licensing strong NPIs in
-  context (§4.3 eqs. 71-78). Requires scale truncation + context.
-- Strong Functional Application (eq. 52) and Scalar Enrichment (eq. 53)
-  as compositional rules — Conditions 1, 2 currently take alts as a
-  free parameter rather than as the output of compositional rules.
-- [crnic-2014] "Non-monotonicity in NPI licensing": direct
-  challenge to the Strawson-DE picture, the natural sequel paper.
+* [gajewski-2011]
+* [von-fintel-1999]
+* [zwarts-1998]
+* [chierchia-2004]
+* [fox-2007]
+* [horn-1989]
 -/
 
 namespace Gajewski2011
 
-open NaturalLogic
-/-! ## Demoted substrate — Intolerance + Karttunen-Peters Conditions
-
-Folded in from the former `Entailment/Intolerance` and
-`Entailment/PresuppositionLicensing` (single-consumer formalisations,
-per the anchoring rule): the Intolerance predicate ([gajewski-2011] eq. 80)
-and the Karttunen-Peters / Chierchia Conditions 1-4 (§4.1, §4.4) were
-consumed only by this study. -/
-
-/-- A GQ-typed function is **trivial** if it is constantly true or
-    constantly false. -/
-def IsTrivial {α : Type*} (f : Set α → Prop) : Prop :=
-  (∀ x : Set α, f x) ∨ (∀ x : Set α, ¬ f x)
-
-/-- [gajewski-2011] eq. 80: a function `f : Set α → Prop` is
-    **Intolerant** iff it is trivial, OR for every `x`, at most one of
-    `f x` and `f xᶜ` holds.
-
-    [horn-1989]: Intolerant functions are "above the midpoint of
-    their scale" — they cannot accept both a property and its
-    complement. -/
-def IsIntolerant {α : Type*} (f : Set α → Prop) : Prop :=
-  IsTrivial f ∨ ∀ x : Set α, ¬ f x ∨ ¬ f xᶜ
-
-/-- [gajewski-2011] Appendix 2 (p. 143): an anti-additive GQ is Intolerant.
-
-    Proof sketch (Gajewski's): suppose `f` is AA and not trivial. For
-    arbitrary `a`, suppose `f a = True` and `f aᶜ = True`. Then
-    `f (a ∪ aᶜ) ↔ f a ∧ f aᶜ` gives `f Set.univ = True`. Since AA
-    implies DE, every `y ⊆ Set.univ` has `f y = True` — contradicting
-    non-triviality. So either `¬f a` or `¬f aᶜ`. -/
-theorem antiAdditive_implies_intolerant {α : Type*} (f : Set α → Prop)
-    (hAA : IsAntiAdditive f) : IsIntolerant f := by
-  by_cases hTriv : IsTrivial f
-  · exact Or.inl hTriv
-  · refine Or.inr ?_
-    intro x
-    by_contra hNeither
-    push Not at hNeither
-    obtain ⟨hfx, hfxc⟩ := hNeither
-    -- Now f x = True and f xᶜ = True. Show f Set.univ = True via AA.
-    have hUnion : x ∪ xᶜ = Set.univ := by
-      ext y
-      simp only [Set.mem_union, Set.mem_compl_iff, Set.mem_univ, iff_true]
-      exact Classical.em (y ∈ x)
-    have hfUniv : f Set.univ := by
-      rw [← hUnion]
-      exact (isAntiAdditive_iff_gq.mp hAA x xᶜ).mpr ⟨hfx, hfxc⟩
-    -- By DE (which AA implies), every y has f y — contradicting
-    -- non-triviality.
-    apply hTriv
-    left
-    intro y
-    exact hAA.antitone (Set.subset_univ y) hfUniv
-
-/-- A **Karttunen-Peters operator**: a function from an argument set to
-    a presuppositional proposition (truth + presup). The presupposition
-    may depend on the argument (per K&P 1979's heritage function). -/
-abbrev KPOperator (W : Type*) : Type _ := Set W → Presupposition.PartialProp W
-
-/-- The truth-conditional projection of a K&P operator. -/
-def KPOperator.truth {W : Type*} (op : KPOperator W) : Set W → Set W :=
-  fun arg w => (op arg).assertion w
-
-/-- The presuppositional projection of a K&P operator (parameterized by
-    the argument). -/
-def KPOperator.opPresup {W : Type*} (op : KPOperator W) : Set W → W → Prop :=
-  fun arg w => (op arg).presup w
-
-/-- The full meaning of a K&P operator: assertion *and* presupposition.
-    What's checked for Condition 4 (strong NPI licensing). -/
-def KPOperator.full {W : Type*} (op : KPOperator W) : Set W → Set W :=
-  fun arg w => (op arg).assertion w ∧ (op arg).presup w
-
-/-- [gajewski-2011] eq. 93: **Condition 3** (weak NPI licensing).
-
-    A K&P operator licenses weak NPIs in its argument position iff its
-    truth-conditional projection is DE (Antitone) in the argument. The
-    operator's own presupposition does NOT enter the licensing check —
-    weak NPIs ignore the licenser's presupposition. -/
-def Condition3 {W : Type*} (op : KPOperator W) : Prop :=
-  Antitone op.truth
-
-/-- [gajewski-2011] eq. 94: **Condition 4** (strong NPI licensing).
-
-    A K&P operator licenses strong NPIs in its argument position iff
-    `assertion ∧ operator-presupposition` is DE in the argument. The
-    operator's presupposition CAN destroy DE-ness; if it does, the
-    operator licenses weak but not strong NPIs. -/
-def Condition4 {W : Type*} (op : KPOperator W) : Prop :=
-  Antitone op.full
-
-/-- Trivially: an operator with no presupposition (always-`True`) makes
-    Condition 3 and Condition 4 equivalent. -/
-theorem condition3_iff_condition4_of_trivial_presup {W : Type*}
-    (op : KPOperator W) (h : ∀ (arg : Set W) (w : W), (op arg).presup w) :
-    Condition3 op ↔ Condition4 op := by
-  constructor
-  · intro h3 p q hpq w hfull
-    exact ⟨h3 hpq hfull.1, h p w⟩
-  · intro h4 p q hpq w hassert
-    exact (h4 hpq ⟨hassert, h q w⟩).1
-
-/- Note on Condition 4 vs Condition 3 implication:
-
-   Adding more conjuncts to a meaning can destroy DE-ness in the
-   licensee position — that is precisely the Gajewski point. So
-   Condition 4 does not imply Condition 3 in general, nor vice versa.
-   They are *independent* DE checks on different conjunctions of the
-   K&P content. -/
-
--- ============================================================================
--- §2 Conditions 1, 2 — implicature-based licensing (Chierchia line)
--- ============================================================================
-
-/-!
-## Conditions 1, 2 — the implicature-based licensing line
-
-Whereas Conditions 3, 4 (above) handle presuppositions via the K&P
-framework, Conditions 1, 2 (Gajewski eqs. 59, 66) handle scalar
-implicatures via [chierchia-2004]'s O-operator and
-alternative-set machinery. The two frameworks make parallel
-predictions for `only`: weak NPIs licensed (Condition 1 / Condition 3)
-but strong NPIs blocked (Condition 2 / Condition 4) — once the
-implicatures (Cond 1/2) or presuppositions (Cond 3/4) of the licenser
-are factored in, DE-ness is destroyed.
-
-The substrate's O-operator is `Exhaustification.exhMW` (Spector 2016,
-based on minimal worlds) or its equivalent `exhIE` (innocent-exclusion
-based, agree under closure under conjunction; see Spector Theorem 9).
-We use `exhMW` because its trivial-ALT case is `exhMW ∅ φ = φ` cleanly,
-which simplifies the empty-implicature reduction.
-
-Gajewski's ALT vs ALT-1 distinction (eqs. 54, 55) is encoded as
-two parameters to Condition 2: the standard alternative set ALT and
-the restricted ALT-1 (Chierchia's "highest-scopal-item only").
--/
-
-/-- [gajewski-2011] eq. 59: **Condition 1** (weak NPI licensing).
-
-    Operator `op` licenses weak NPIs in its argument position iff
-    `O(op(γ), op(ALT(γ)))` is DE in γ, where `alts γ` generates the
-    alternative set against which `op(γ)` is exhaustified.
-
-    `Exhaustification.exhMW` plays the role of Gajewski's `O(F, G)`. -/
-def Condition1 {W : Type*} (op : Set W → Set W)
-    (alts : Set W → Set (Set W)) : Prop :=
-  Antitone (fun γ => Exhaustification.exhMW (alts γ) (op γ))
-
-/-- [gajewski-2011] eq. 66: **Condition 2** (strong NPI licensing).
-
-    Adds a parallel DE check against ALT-1 — the restricted alternative
-    set (Chierchia's "highest-scopal-item only", eq. 55). Strong NPIs
-    are licensed iff *both* DE checks pass: `O(op(γ), op(ALT(γ)))` AND
-    `O(op(γ), op(ALT-1(γ)))`. -/
-def Condition2 {W : Type*} (op : Set W → Set W)
-    (alts altsOne : Set W → Set (Set W)) : Prop :=
-  Condition1 op alts ∧
-  Antitone (fun γ => Exhaustification.exhMW (altsOne γ) (op γ))
-
-/-- Trivial-ALT lemma: with no alternatives, `exhMW` collapses to the
-    prejacent. Spector 2016's minimality reduces to `True` when there
-    are no alternatives to be minimal-with-respect-to. -/
-theorem exhMW_empty_eq {W : Type*} (φ : Set W) :
-    Exhaustification.exhMW (∅ : Set (Set W)) φ = φ := by
-  ext u
-  unfold Exhaustification.exhMW Exhaustification.ltALT Exhaustification.leALT
-  simp
-
-/-- **Trivial-ALT bridge for Cond 1**: Condition 1 with no alternatives
-    reduces to classical DE. -/
-theorem condition1_with_no_alts_iff_de {W : Type*} (op : Set W → Set W) :
-    Condition1 op (fun _ => ∅) ↔ Antitone op := by
-  unfold Condition1
-  have h : (fun γ => Exhaustification.exhMW (∅ : Set (Set W)) (op γ)) = op := by
-    funext γ
-    exact exhMW_empty_eq (op γ)
-  rw [h]
-
-/-- **Trivial-ALT bridge for Cond 2**: with no alternatives in either
-    ALT or ALT-1, Condition 2 reduces to classical DE. The empirical
-    discriminative power of Cond 2 vs Cond 1 only emerges with
-    non-trivial ALT-1 (Chierchia's "highest-scopal-item only"). -/
-theorem condition2_with_no_alts_iff_de {W : Type*} (op : Set W → Set W) :
-    Condition2 op (fun _ => ∅) (fun _ => ∅) ↔ Antitone op := by
-  unfold Condition2
-  rw [condition1_with_no_alts_iff_de]
-  constructor
-  · exact fun ⟨h, _⟩ => h
-  · intro h
-    refine ⟨h, ?_⟩
-    have heq : (fun γ => Exhaustification.exhMW (∅ : Set (Set W)) (op γ)) = op := by
-      funext γ; exact exhMW_empty_eq (op γ)
-    rw [heq]; exact h
-
-/-- **Bridge to Conditions 3, 4**: when `op`'s K&P-form has no
-    presupposition (so the operator is presupposition-free), Conditions
-    3 and 4 collapse, AND Condition 1 with no alternatives reduces to
-    classical DE. Hence presuppositionless + alternative-free ⇒ all
-    four Gajewski conditions reduce to classical DE.
-
-    This is the structural reason Gajewski's framework matters: both
-    presuppositions (the K&P side) AND implicatures (the Chierchia
-    side) can destroy DE-ness in the licensee position; the four
-    conditions track which side does what. -/
-theorem all_conditions_reduce_to_DE_when_trivial {W : Type*}
-    (op : KPOperator W)
-    (hPresup : ∀ arg w, (op arg).presup w)
-    (hOpFnDE : Antitone op.truth) :
-    Condition1 op.truth (fun _ => ∅) ∧
-    Condition3 op ∧
-    Condition4 op := by
-  refine ⟨?_, hOpFnDE, ?_⟩
-  · exact (condition1_with_no_alts_iff_de op.truth).mpr hOpFnDE
-  · -- Cond 4: assert ∧ presup is DE; presup is trivial, so equals assertion
-    intro p q hpq w hfull
-    exact ⟨hOpFnDE hpq hfull.1, hPresup p w⟩
-
-
-/-! ## §1 Background — recapitulating Zwarts and von Fintel
-
-The paper's §2 establishes:
-- `IsAntiAdditive f := ∀ p q, f (p ∪ q) ↔ f p ∧ f q`
-  (eq. 10; in linglib: `Logic/Natural/Additivity.lean`).
-- `Antitone f` (eq. 4; mathlib's own predicate).
-- AA ⇒ DE (eq. 11): standard textbook proof — already in linglib as
-  `IsAntiAdditive.antitone`.
-- Zwarts: strong NPIs (`either`, `in weeks`, until) need AA licensers (eq. 8).
-- vF: presuppositions are factored out by replacing DE with **Strawson-DE**
-  (eq. 22; in linglib: `Logic/Natural/Strawson/Basic.lean`).
--/
-
-/-! ## §3.3 The puzzle — Strawson-AA is too weak
-
-[gajewski-2011] (following [rullmann-2003] and
-[gajewski-2005]) observes that *all* of vF's Strawson-DE
-recalcitrants are also
-**Strawson-AA**. The Appendix 1 proofs are formalized in
-`Strawson/Basic.lean`; we cite them here as paper-anchored theorems.
-
-> (37) Only-Bill (A ∨ B) ⇒_S Only-Bill A ∧ Only-Bill B.
-> (38) Only-Bill A ∧ Only-Bill B ⇒_S Only-Bill (A ∨ B).
->      [Both directions go through under Strawson entailment;
->       hence `only` is SAA.] (p. 120)
-
-Yet strong NPIs are *ungrammatical* under all of these SAA operators
-(exs. 39-41):
-
-> (39) a. Only John has ever seen anyone. ✓
->      b. *Only John has seen Mary in weeks.
->      c. *Only John likes pancakes, either.
->      d. *Only John arrived until his birthday.
-> (40) a. If Bill has ever seen anyone, he is keeping it a secret. ✓
->      b. *If Bill has seen Mary in weeks, he is keeping it a secret.
->      c. *If Bill likes pancakes, either, he is keeping it a secret.
->      d. *If Bill arrived until Friday, he is keeping it a secret.
-> (41) a. Mary is sorry that she ever talked to anyone. ✓
->      b. *Mary is sorry that she has talked to Bill in weeks.
->      c. *Mary is sorry that she likes pancakes, either.
->      d. *Mary is sorry that she arrived until Friday.
-
-Conclusion (p. 121): "Strawson anti-additivity is too weak to account
-for the distribution of strong NPIs. Hence it appears that
-presuppositions must be taken into account when we assess the licensing
-of strong NPIs."
-
-The 2x2 puzzle (eq. 44):
-
->            | Standard entailment | Strawson entailment
->      DE    | ???                 | Weak NPIs
->      AA    | Strong NPIs         | ???
-
-vF's Strawson move correctly characterizes weak NPIs but the natural
-extension to AA does not characterize strong NPIs. Gajewski proposes
-the single distinction is whether the NPI attends to the licenser's
-non-truth-conditional meaning.
--/
-
-/-! ### Substrate index
-
-The four SAA proofs live in `Logic/Natural/Strawson/Basic.lean`:
-
-- `onlyFull_isStrawsonAA` — Gajewski body §3.3 eqs. 37-38 (p. 120).
-  (Appendix 1 sketches `sorry` and `would`; the `only` case is body text.)
-- `sorryFull_isStrawsonAA` — Appendix 1 (p. 142).
-- `condNecessity_isStrawsonAA` — Appendix 1 covers full `would` with
-  non-vacuity presup; the substrate's `condNecessity` is the
-  *idle-ordering* simpler case (see `wouldFull_isStrawsonAA` for the
-  Gajewski-faithful version with non-vacuity definedness).
-- `superlative_isStrawsonAA` — *not in Gajewski's text*. The body's
-  "all SAA" claim (p. 120) is gestural; the superlative case is an
-  extension of Gajewski's pattern.
--/
-
-/-- The collected Gajewski headline: all four vF-recalcitrant operators
-    come out Strawson-AA, yet (per exs. 39-41) none license strong NPIs.
-    The substrate proves SAA; the empirical "no strong-NPI licensing"
-    side is documented in the docstrings above (it requires a strong-NPI
-    licensing predicate Gajewski's full theory builds compositionally). -/
-theorem gaj2011_recalcitrants_all_strawsonAA :
-    -- §2 only
-    IsStrawsonAntiAdditive (onlyFull (· = (0 : Fin 4)))
-        (fun scope _w => ∃ w', w' = (0 : Fin 4) ∧ scope w') ∧
-    -- §3 sorry
-    IsStrawsonAntiAdditive
-        (sorryFull (fun (w : Fin 4) => ({w} : Set (Fin 4)))
-                   (fun (_ : Fin 4) => ({(1 : Fin 4)} : Set (Fin 4))))
-        (fun p w => ∀ w' ∈ ({w} : Set (Fin 4)), p w') ∧
-    -- §4.1 conditional
-    IsStrawsonAntiAdditive
-        (fun α => condNecessity (fun (_ : Fin 4) =>
-            ({(0 : Fin 4), (1 : Fin 4)} : Set (Fin 4))) α (fun _ => True))
-        (fun _ _ => True) ∧
-    -- §4.2 superlative
-    IsStrawsonAntiAdditive (superlativeAssert (0 : Fin 4))
-        (superlativePresup (0 : Fin 4)) :=
-  ⟨onlyFull_isStrawsonAA _,
-   sorryFull_isStrawsonAA _ _,
-   condNecessity_isStrawsonAA _ _,
-   superlative_isStrawsonAA _⟩
-
-/-! ## §4.3 The Intolerance-based intermediate category (eq. 80, Appendix 2)
-
-For readers unconvinced by the §4 implicature-based account, Gajewski
-offers an alternative: **DE + Intolerant** as an intermediate category
-between DE and AA. The conjecture (eq. 84): `AA ⊂ DE + Intolerant ⊂ DE`.
-
-Intolerance comes from [horn-1989]: a function is intolerant if it
-does not map both `x` and `xᶜ` to truth — i.e., it "locates" itself on
-one side of the midpoint of its scale.
-
-The substrate-level definitions (`IsTrivial`, `IsIntolerant`; GQ-typed
-anti-additivity and DE-ness are the `Set α → Prop` instances of
-`IsAntiAdditive` and `Antitone`) and the Appendix 2 proof
-(`antiAdditive_implies_intolerant`) are defined above (demoted substrate).
-
-The reverse strict inclusion (`AA ⊊ DE + Intolerant`, ex. 84) — i.e.
-exhibiting a DE+Intolerant function that is *not* AA — is asserted by
-Gajewski but not proved; would need a witness function. Open.
--/
-
-/-- Re-export the substrate Appendix 2 result for paper-citation indexing. -/
-theorem gaj2011_appendix2_AA_implies_intolerant {α : Type*}
-    (f : Set α → Prop)
-    (hAA : IsAntiAdditive f) :
-    IsIntolerant f :=
-  antiAdditive_implies_intolerant f hAA
-
-/-! ## §4.1 Conjecture (eq. 48): DE scalar item is AA iff endpoint of scale
-
-[gajewski-2011] (p. 123): "A DE scalar item is AA iff it is the
-endpoint of its scale."
-
-This is the load-bearing conjecture that lets Gajewski reduce strong-NPI
-licensing to "DE + endpoint-of-scale." `no NP` is the strong endpoint of
-the negative-existential scale ⟨no, few, not many, ...⟩; `few NP` is
-*just above* `no NP`, so on context-dependent scale truncation `few NP`
-can act as the endpoint — explaining why `few` sometimes licenses strong
-NPIs (exs. 71-73, contra Zwarts):
-
-> (71) He was one of the few dogs I'd met in years that I really liked.
-> (72) Few Americans have ever been to Spain. Few Canadians have either.
-> (73) He invited few people until he knew she liked them.
-
-Formalizing the conjecture requires scale-side machinery (Horn scales,
-context-dependent truncation à la Chierchia 2004 axiom (i)). Deferred.
--/
-
-/-! ## Cross-framework relationships
-
-- [von-fintel-1999]: provides the Strawson-DE substrate. Gajewski's
-  Appendix 1 SAA proofs use exactly the operators vF defined; see
-  `Studies/VonFintel1999.lean`.
-- [kadmon-landman-1993]: K&L's widening + strengthening account of
-  `any` precedes the Strawson framework; Gajewski's intolerance comes
-  from [horn-1989], not from K&L. K&L's `LicensingMechanism`
-  (`byStrengthening`/`byGenericIndefinite`/`byOtherMechanism`) is too
-  coarse to predict the SAA-but-not-AA pattern.
-- [chierchia-2013] ch. 3 takes Gajewski's analysis as input and
-  reconstructs strong-NPI licensing within the broader exhaustification
-  framework.
-- [crnic-2014] challenges Strawson-based analyses with a
-  non-monotonicity reanalysis; engages directly with this paper.
-- [hoeksema-1983] S-comparative is anti-additive (per
-  `bridge_hoeksema_gtOverSet_strawsonDE` in VonFintel1999) — hence,
-  per the Zwarts-classical theory, predicted to license strong NPIs.
-  Empirically borne out (Hoeksema's data).
--/
-
-/-! ## §4.4 Karttunen-Peters Conditions 3, 4 applied to `only`
-
-[gajewski-2011] eqs. 93-94 (p. 134) state two licensing conditions
-in the K&P two-dimensional ⟨truth, presup⟩ framework:
-
-- **Condition 3** (weak NPIs): the truth-conditional content alone must
-  be DE in the licensee position.
-- **Condition 4** (strong NPIs): truth-conditional content *plus the
-  operator's presupposition* must be DE.
-
-The predicates `Condition3` and `Condition4` are defined above (demoted
-substrate). Here we apply
-them to `only` and verify the empirical match: weak NPIs licensed
-(Condition 3 ✓), strong NPIs blocked (Condition 4 ✗).
--/
-
-open NaturalLogic
-open Presupposition
-
-/-- The K&P operator for `only x`: assertion = "no y ≠ x has scope",
-    presupposition = "some y has x and scope" (Horn 1996). Built directly
-    from `onlyPartialProp` in `Strawson/Basic.lean`. -/
-def onlyKP (x : Fin 4 → Prop) : KPOperator (Fin 4) :=
-  fun scope => onlyPartialProp x scope
-
-/-- Ex. 19a (p. 115) confirmed: `only` satisfies Condition 3 — its
-    truth-conditional assertion is *classically DE* in the scope.
-
-    Proof: `(∀ y, x y ∨ ¬ q y) → (∀ y, x y ∨ ¬ p y)` for any `p ⊆ q` —
-    if `q y` fails, so does `p y` (contrapositive of `p ⊆ q`). -/
-theorem only_satisfies_condition3 (x : Fin 4 → Prop) :
-    Condition3 (onlyKP x) := by
-  intro p q hpq w h y
-  rcases h y with hxy | hnq
-  · left; exact hxy
-  · right; intro hpy; exact hnq (hpq hpy)
-
-/-- Ex. 19a + ex. 39b (pp. 115, 120): `only` does **NOT** satisfy
-    Condition 4 — the existence presupposition of `only` is upward
-    entailing in scope, so the conjunction `assertion ∧ presupposition`
-    is not DE.
-
-    Witness: `p = ∅`, `q = {w0}`, focus on `w0`. At `w0`:
-    - `(onlyKP (· = w0)).full q w0` holds: assertion holds (only w0 ∈ q),
-      presup holds (∃ y = w0 ∧ q w0).
-    - `(onlyKP (· = w0)).full p w0` fails: presup `∃ y, y = w0 ∧ p y`
-      requires `p w0`, which is false (p = ∅).
-    - DE would require: q ⊇ p ∧ full q w0 → full p w0. Fails. -/
-theorem only_violates_condition4 :
-    ¬ Condition4 (onlyKP (· = (0 : Fin 4))) := by
-  intro hCond4
-  let p : Set (Fin 4) := fun _ => False
-  let q : Set (Fin 4) := fun w => w = (0 : Fin 4)
-  have hle : p ≤ q := fun _ h => h.elim
-  have hfull_q : (onlyKP (· = (0 : Fin 4))).full q (0 : Fin 4) := by
-    refine ⟨?_, ?_⟩
-    · intro y; by_cases h : y = (0 : Fin 4)
-      · left; exact h
-      · right; intro hy; cases h hy
-    · exact ⟨(0 : Fin 4), rfl, rfl⟩
-  have hfull_p : (onlyKP (· = (0 : Fin 4))).full p (0 : Fin 4) := hCond4 hle hfull_q
-  obtain ⟨_, _, hp_w0⟩ := hfull_p.2
-  exact hp_w0
-
-/-- [gajewski-2011] headline (K&P/presupposition side): `only` is
-    the canonical case of "Condition 3 ✓ but Condition 4 ✗" — licenses
-    weak NPIs (`any`, `ever`) but blocks strong NPIs (`either`,
-    `in weeks`, `until`), because its existence presupposition is UE
-    in the scope and destroys DE-ness of the conjunction. -/
-theorem gaj2011_only_condition3_yes_condition4_no :
-    Condition3 (onlyKP (· = (0 : Fin 4))) ∧
-    ¬ Condition4 (onlyKP (· = (0 : Fin 4))) :=
-  ⟨only_satisfies_condition3 _, only_violates_condition4⟩
-
-/-! ## §4.1 Conditions 1, 2 — the implicature side (Chierchia line)
-
-Parallel to §4.4's K&P-based Conditions 3, 4: Conditions 1, 2 (eqs.
-59, 66) handle the implicature side via Spector 2016's `exhMW`
-operator, treated as Gajewski's `O(F, G)`. The substrate substrate's
-`Exhaustification.exhMW` lives in
-`Semantics/Exhaustification/InnocentExclusion.lean`.
-
-The substrate's trivial-ALT bridge theorem
-(`condition1_with_no_alts_iff_de`) shows: with no alternatives,
-Condition 1 reduces to classical DE. So `only` (whose assertion is
-classically DE) satisfies Condition 1 with empty alternatives —
-parallel to its satisfaction of Condition 3.
-
-The full Gajewski analysis under Conditions 1, 2 requires non-trivial
-ALT-1 sets (Chierchia's "highest-scopal-item only", eq. 55). The
-[chierchia-2006] (file
-`Studies/Chierchia2006.lean`) and
-[chierchia-2013] formalizations would supply concrete ALT-1
-generators. Concrete `only` proofs under Conditions 1, 2 with
-non-trivial ALTs are deferred until that infrastructure is wired in.
--/
-
-/-- `only`'s assertion satisfies Condition 1 with empty alternatives
-    (which reduces to classical DE — and we proved
-    `only_satisfies_condition3` ≡ classical DE on the assertion). This
-    is the implicature-side parallel of `only_satisfies_condition3`. -/
-theorem only_satisfies_condition1_no_alts (x : Fin 4 → Prop) :
-    Condition1 (onlyKP x).truth (fun _ => ∅) :=
-  (condition1_with_no_alts_iff_de _).mpr (only_satisfies_condition3 x)
-
-/-- `only`'s assertion satisfies Condition 2 with no alternatives in
-    either ALT or ALT-1 (degenerate trivial case — both DE checks pass
-    because they collapse to classical DE on the assertion).
-
-    The substrate proves this is the *trivial limit* of Condition 2.
-    The empirical Gajewski result — that `only` *fails* Condition 2 on
-    the **attested** ALT-1 (Chierchia's "highest-scopal-item only"
-    alternatives generated from the strong NPI in scope) — requires a
-    scalar-alternative generator that lives in
-    `Studies/Chierchia2006.lean`'s `PSIProfile`
-    framework or equivalent. Wiring up a concrete ALT-1 generator
-    that demonstrates the empirical Cond 2 failure for `only` is
-    deferred to a follow-up study file (likely an extension of
-    `Chierchia2006.lean` or a new `Chierchia2013.lean` since the
-    relevant framework is Chierchia 2013 ch. 3). -/
-theorem only_satisfies_condition2_no_alts (x : Fin 4 → Prop) :
-    Condition2 (onlyKP x).truth (fun _ => ∅) (fun _ => ∅) :=
-  (condition2_with_no_alts_iff_de _).mpr (only_satisfies_condition3 x)
-
-/-! ## Hoeksema S-comparative — the positive test case
-
-[hoeksema-1983]'s S-comparative is *classically* anti-additive
-(`Semantics/Degree/Comparative.lean::gtOverSet_isAntiAdditive`),
-hence by `antiAdditive_implies_strawsonAA` it is also Strawson-AA.
-This is the **positive test** for Gajewski's framework: an AA operator
-licenses strong NPIs (Hoeksema's data confirms — "Mary is taller than
-anyone is", "in years"-style strong NPIs grammatical in than-S
-comparatives). Contrast vF's recalcitrants which are SAA-but-not-AA
-and hence don't license strong NPIs. -/
-theorem bridge_hoeksema_gtOverSet_strawsonAA
-    {Entity D : Type*} [Preorder D] (μ : Entity → D)
-    (defined : Set D → Entity → Prop) :
-    IsStrawsonAntiAdditive (Degree.Comparison.gt.overSet μ) defined :=
-  antiAdditive_implies_strawsonAA _
-    (Degree.gtOverSet_isAntiAdditive μ) _
-
-/-! ## Strong-NPI registry consistency
-
-Gajewski's headline empirical claim: strong NPIs are ungrammatical under
-operators that are only Strawson-DE/SAA (not classically AA). The
-Fragment registry encodes this through:
-
-- `Fragments/English/PolarityItems.lean`: strong NPIs (`liftAFinger`,
-  `budgeAnInch`, `inYears`, `until_`, `either_npi`) all list
-  `licensingContexts := [.negation, .nobody]` — i.e., classical-AA
-  contexts only.
-- `Polarity.LicensingContext.IsStrawsonOnly`: the four
-  Strawson-only contexts (`.onlyFocus`, `.adversative`,
-  `.sinceTemporal`, `.superlative`) carry `classicalSignature := none`.
-
-Gajewski's prediction: no strong NPI lists any Strawson-only
-context. The substrate makes this `decide`-checkable.
--/
-
-open Polarity (LicensingContext)
-open Polarity (LicensingContext)
-open English.PolarityItems
-  (any ever yet anymore atAll inTheLeast aSingle whatsoever
-   liftAFinger budgeAnInch inYears until_ either_npi)
-
-/-- [gajewski-2011] headline made registry-checkable: no strong
-    NPI in the English Fragment is licensed in any Strawson-only
-    context. The four enumerated strong NPIs all restrict their
-    licensing to classical-AA contexts (`.negation`, `.nobody`,
-    `.withoutClause`), excluding `.onlyFocus`, `.adversative`,
-    `.sinceTemporal`, `.superlative`. -/
-theorem gaj2011_strongNPIs_excluded_from_strawson_only_contexts :
-    ∀ ctx : LicensingContext, ctx.IsStrawsonOnly →
-      ctx ∉ liftAFinger.licensingContexts ∧
-      ctx ∉ budgeAnInch.licensingContexts ∧
-      ctx ∉ inYears.licensingContexts ∧
-      ctx ∉ until_.licensingContexts ∧
-      ctx ∉ either_npi.licensingContexts := by
-  intro ctx hStrawson
-  cases ctx <;> simp_all [LicensingContext.IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
-    until_, either_npi, LicensingContext.properties]
-
-/-- The registry agrees with keystone licensing on the strong NPIs: every
-context a strong NPI lists supplies anti-additive strength. -/
-theorem gaj2011_strong_npis_licensed :
-    ∀ e ∈ [liftAFinger, budgeAnInch, inYears, until_, either_npi],
-      ∀ c ∈ e.licensingContexts, c.licenses e := by decide
-
-/-- Same agreement for the weak NPIs — ungated: the keystone's mechanism
-dispatch covers the FC and entropy rows in *any*'s list that
-strength-only licensing had to exclude by hand. -/
-theorem gaj2011_weak_npis_licensed :
-    ∀ e ∈ [any, ever, yet, anymore, atAll, inTheLeast, aSingle, whatsoever],
-      ∀ c ∈ e.licensingContexts, c.licenses e := by decide
-
--- The strength cut as a derived prediction (Gajewski's few-contrast):
--- *few* (weak DE) licenses *any* but not *in years*; *nobody*
--- (anti-additive) licenses both.
-example : Polarity.LicensingContext.few.licenses any := by decide
-example : ¬ Polarity.LicensingContext.few.licenses inYears := by decide
-example : Polarity.LicensingContext.nobody.licenses inYears := by decide
+open NaturalLogic Quantification Data.Examples
+
+variable {α : Type*}
+
+/-! ### Enriched meanings -/
+
+/-- The implicature-enriched meaning of a quantified DP: the determiner's plain meaning together
+with the exclusion of every scale-mate that is true of the scope without being entailed, where
+entailment holds the restrictor fixed and quantifies over scopes. -/
+def exh (Q : GQ α) (C : Set (GQ α)) : GQ α :=
+  λ A P => Q A P ∧ ∀ Q' ∈ C, Q' A P → Q A ≤ Q' A
+
+/-- A scale-mate that is true but not entailed is excluded. -/
+theorem exh_not_of_not_le {Q Q' : GQ α} {C : Set (GQ α)} {A P : α → Prop} (hQ' : Q' ∈ C)
+    (hP : Q' A P) (h : ¬ Q A ≤ Q' A) : ¬ exh Q C A P :=
+  λ he => h (he.2 Q' hQ' hP)
+
+/-- At the bottom of its scale a determiner is its own enriched meaning. -/
+theorem exh_eq_of_forall_le {Q : GQ α} {C : Set (GQ α)} {A : α → Prop}
+    (h : ∀ Q' ∈ C, ∀ P, Q' A P → Q A ≤ Q' A) : exh Q C A = Q A :=
+  funext λ _ => propext ⟨And.left, λ hQ => ⟨hQ, λ Q' hQ' hP => h Q' hQ' _ hP⟩⟩
+
+/-- Exhaustified *no* is *no*. -/
+theorem exh_no : exh (no_sem : GQ α) {outerNeg every_sem} = no_sem := by
+  funext A
+  refine exh_eq_of_forall_le λ Q' hQ' P hP => ?_
+  rw [Set.mem_singleton_iff] at hQ'
+  subst hQ'
+  obtain ⟨x, hx⟩ := not_forall.mp hP
+  exact λ P' hno hev => hx λ hAx => absurd (hev x hAx) (hno x hAx)
+
+/-- Exhaustified *not every* is *some but not every* once the restrictor has two elements. -/
+theorem exh_notEvery {A : α → Prop} {x y : α} (hx : A x) (hy : A y) (hxy : x ≠ y) :
+    exh (outerNeg every_sem) {no_sem} A = λ P => some_sem A P ∧ outerNeg every_sem A P := by
+  funext P
+  refine propext ⟨λ ⟨hne, h⟩ => ⟨?_, hne⟩, λ ⟨⟨z, hz, hPz⟩, hne⟩ => ⟨hne, λ Q' hQ' hno => ?_⟩⟩
+  · by_contra hsome
+    exact h no_sem (Set.mem_singleton _) (λ z hz hPz => hsome ⟨z, hz, hPz⟩) (· = x)
+      (λ hall => hxy (hall y hy).symm) x hx rfl
+  · exact ((Set.mem_singleton_iff.mp hQ' ▸ hno) z hz hPz).elim
+
+/-- An enriched meaning satisfiable at a restrictor but excluded at the empty scope is not
+downward entailing in its scope. -/
+theorem not_scopeDownwardMono_exh {Q : GQ α} {C : Set (GQ α)} {A P : α → Prop}
+    (hP : exh Q C A P) (h : ¬ exh Q C A (λ _ => False)) : ¬ ScopeDownwardMono (exh Q C) :=
+  λ hde => h (hde A _ P (λ _ hf => hf.elim) hP)
+
+/-! ### The licensing principles -/
+
+/-- Exhaustified *no* is downward entailing, so *no* licenses strong items. -/
+theorem no_strong : ScopeDownwardMono (exh (no_sem : GQ α) {outerNeg every_sem}) := by
+  rw [exh_no]; exact no_scope_down
+
+/-- Exhaustified *not every* is not downward entailing: at the empty scope the stronger
+scale-mate *no* is true and excluded. -/
+theorem notEvery_not_strong [Nontrivial α] :
+    ¬ ScopeDownwardMono (exh (outerNeg every_sem : GQ α) {no_sem}) := by
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne α
+  refine not_scopeDownwardMono_exh (A := λ _ => True) (P := (· = x))
+    ⟨λ h => hxy (h y trivial).symm, λ Q' hQ' hno =>
+      ((Set.mem_singleton_iff.mp hQ' ▸ hno) x trivial rfl).elim⟩
+    (exh_not_of_not_le (Set.mem_singleton _) (λ _ _ hf => hf)
+      λ hle => hle (· = x) (λ h => hxy (h y trivial).symm) x trivial rfl)
+
+/-- Exhaustified *some* is not downward entailing: *some* itself fails at the empty scope. -/
+theorem some_not_strong [Nontrivial α] :
+    ¬ ScopeDownwardMono (exh (some_sem : GQ α) {every_sem}) := by
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne α
+  exact not_scopeDownwardMono_exh (A := λ _ => True) (P := (· = x))
+    ⟨⟨x, trivial, rfl⟩, λ Q' hQ' hev =>
+      (hxy ((Set.mem_singleton_iff.mp hQ' ▸ hev) y trivial).symm).elim⟩
+    λ h => h.1.elim λ _ h => h.2
+
+/-- Predicate counts with a foreign decidability instance, for the paper's numerals. -/
+private theorem count_congr {P Q : α → Prop} [Fintype α] {i : DecidablePred P} [DecidablePred Q]
+    (h : ∀ x, P x ↔ Q x) : @count α _ P i = count Q :=
+  @count_congr_iff α _ P Q i _ h
+
+private theorem at_most_n_sem_true_iff [Fintype α] {n : ℕ} {P Q : α → Prop} [DecidablePred Q]
+    (h : ∀ x, P x ↔ Q x) : at_most_n_sem n (λ _ => True) P ↔ count Q ≤ n := by
+  simp only [at_most_n_sem]
+  rw [count_congr (Q := Q) λ x => (and_iff_right trivial).trans (h x)]
+
+private theorem few_sem_true_iff [Fintype α] {P Q : α → Prop} [DecidablePred Q]
+    (h : ∀ x, P x ↔ Q x) : few_sem (λ _ => True) P ↔ count Q < count (λ x => ¬ Q x) := by
+  simp only [few_sem]
+  rw [count_congr (Q := Q) λ x => (and_iff_right trivial).trans (h x),
+    count_congr (Q := λ x => ¬ Q x) λ x => (and_iff_right trivial).trans (not_congr (h x))]
+
+/-- *At most five* sits above *at most four* on its scale; excluding the scale-mate leaves
+*exactly five*, which is not downward entailing. -/
+theorem atMostFive_not_strong :
+    ¬ ScopeDownwardMono (exh (at_most_n_sem 5 : GQ (Fin 6)) {at_most_n_sem 4}) := by
+  have h4 : ¬ at_most_n_sem 4 (λ _ : Fin 6 => True) (· ≠ 0) := by
+    rw [at_most_n_sem_true_iff λ _ => Iff.rfl]; decide
+  refine not_scopeDownwardMono_exh (A := λ _ => True) (P := (· ≠ 0))
+    ⟨by rw [at_most_n_sem_true_iff λ _ => Iff.rfl]; decide,
+      λ Q' hQ' h => (h4 (Set.mem_singleton_iff.mp hQ' ▸ h)).elim⟩
+    (exh_not_of_not_le (Set.mem_singleton _) (by rw [at_most_n_sem_true_iff λ _ => Iff.rfl]; decide)
+      λ hle => h4 (hle (· ≠ 0) (by rw [at_most_n_sem_true_iff λ _ => Iff.rfl]; decide)))
+
+/-- The paper's licensers. -/
+inductive Licenser
+  | no | atMostFive | some | only | conditional | sorryThat
+  deriving DecidableEq, Repr
+
+/-- Weak items are *any* and *ever*, strong ones *in weeks*, *either* and *until*. -/
+inductive Strength
+  | weak | strong
+  deriving DecidableEq, Repr
+
+/-- The two licensing principles applied to a licenser's analysis: a weak item needs the plain
+meaning Strawson downward entailing, a strong item needs the enriched meaning downward entailing,
+which for a presupposition trigger without scale-mates is its full meaning. -/
+def Licensed : Licenser → Strength → Prop
+  | .no, .weak => ∀ {α : Type}, ScopeDownwardMono (no_sem : GQ α)
+  | .no, .strong => ∀ {α : Type}, ScopeDownwardMono (exh (no_sem : GQ α) {outerNeg every_sem})
+  | .atMostFive, .weak => ∀ {α : Type} [Fintype α], ScopeDownwardMono (at_most_n_sem (α := α) 5)
+  | .atMostFive, .strong =>
+      ∀ {α : Type} [Fintype α], ScopeDownwardMono (exh (at_most_n_sem (α := α) 5) {at_most_n_sem 4})
+  | .some, .weak => ∀ {α : Type}, ScopeDownwardMono (some_sem : GQ α)
+  | .some, .strong => ∀ {α : Type}, ScopeDownwardMono (exh (some_sem : GQ α) {every_sem})
+  | .only, .weak =>
+      ∀ {W : Type} (x : W → Prop), IsStrawsonDE (onlyFull x) (λ scope _ => ∃ w', x w' ∧ scope w')
+  | .only, .strong => ∀ {W : Type} (x : W → Prop), Antitone (onlyFull x)
+  | .conditional, .weak => ∀ {W : Type} (domain : W → Set W) (q : Set W),
+      IsStrawsonDE (λ p => wouldFull domain p q) (λ p w => ∃ w' ∈ domain w, p w')
+  | .conditional, .strong =>
+      ∀ {W : Type} (domain : W → Set W) (q : Set W), Antitone (λ p => wouldFull domain p q)
+  | .sorryThat, .weak => ∀ {W : Type} (dox bestOf : W → Set W),
+      IsStrawsonDE (sorryFull dox bestOf) (λ p w => ∀ w' ∈ dox w, p w')
+  | .sorryThat, .strong => ∀ {W : Type} (dox bestOf : W → Set W), Antitone (sorryFull dox bestOf)
+
+/-- The Strawson anti-additive triggers license weak items but not strong ones: their full
+meanings are not downward entailing, the puzzle the two principles resolve. -/
+theorem strawsonAA_not_sufficient :
+    (Licensed .only .weak ∧ Licensed .conditional .weak ∧ Licensed .sorryThat .weak) ∧
+      ¬ Licensed .only .strong ∧ ¬ Licensed .conditional .strong ∧ ¬ Licensed .sorryThat .strong :=
+  ⟨⟨λ x => onlyFull_isStrawsonDE x, λ d q => wouldFull_isStrawsonDE d q,
+      λ d b => sorryFull_isStrawsonDE d b⟩,
+    λ h => onlyFull_not_de (h _), λ h => wouldFull_not_de (h _ _), λ h => sorryFull_not_de (h _ _)⟩
+
+/-! ### Intolerance -/
+
+/-- A function of properties is trivial when it is constantly true or constantly false. -/
+def IsTrivial (f : Set α → Prop) : Prop := (∀ x, f x) ∨ ∀ x, ¬ f x
+
+/-- A nontrivial function of properties is Intolerant when it never accepts both a property and
+its complement: the items above the midpoint of their scale ([horn-1989]). -/
+def IsIntolerant (f : Set α → Prop) : Prop := ¬ IsTrivial f → ∀ x, ¬ f x ∨ ¬ f xᶜ
+
+/-- Anti-additivity implies Intolerance: accepting `x` and `xᶜ` means accepting everything. -/
+theorem isIntolerant_of_isAntiAdditive {f : Set α → Prop} (h : IsAntiAdditive f) :
+    IsIntolerant f := λ hnt x => by
+  by_contra hx
+  push Not at hx
+  have huniv : f Set.univ := by
+    have := (isAntiAdditive_iff_gq.mp h) x xᶜ
+    rw [Set.union_compl_self] at this
+    exact this.mpr hx
+  exact hnt (Or.inl λ y => h.antitone (Set.subset_univ y) huniv)
+
+open Classical in
+/-- Proportional *few* is Intolerant: fewer than half in and fewer than half out is impossible. -/
+theorem few_isIntolerant [Fintype α] (A : α → Prop) : IsIntolerant (few_sem A) := λ _ x => by
+  by_contra hx
+  push Not at hx
+  obtain ⟨h₁, h₂⟩ := hx
+  simp only [few_sem] at h₁ h₂
+  rw [count_congr (P := λ z => A z ∧ xᶜ z) (Q := λ z => A z ∧ ¬ x z) λ _ => Iff.rfl,
+    count_congr (P := λ z => A z ∧ ¬ xᶜ z) (Q := λ z => A z ∧ x z)
+      λ _ => and_congr_right' ⟨λ hn => not_not.mp hn, λ hx hn => hn hx⟩] at h₂
+  omega
+
+/-- Cardinal *fewer than four* is not Intolerant: with six elements, three in and three out. -/
+theorem atMostThree_not_isIntolerant :
+    ¬ IsIntolerant (at_most_n_sem 3 (λ _ : Fin 6 => True)) := λ h =>
+  (h (λ ht => ht.elim (λ h => absurd (h (λ _ => True))
+      ((at_most_n_sem_true_iff λ _ => Iff.rfl).not.mpr (by decide)))
+    λ h => h (λ _ => False) ((at_most_n_sem_true_iff λ _ => Iff.rfl).mpr (by decide))) (· < 3)).elim
+    (· ((at_most_n_sem_true_iff λ _ => Iff.rfl).mpr (by decide)))
+    (· ((at_most_n_sem_true_iff (Q := (3 ≤ ·)) λ _ => not_lt).mpr (by decide)))
+
+/-- Proportional *few* is downward entailing and Intolerant but not anti-additive, so
+Intolerance is a proper intermediate between anti-additivity and downward entailment. -/
+theorem few_not_rightAntiAdditive : ¬ RightAntiAdditive (few_sem : GQ (Fin 4)) := λ h =>
+  absurd ((h (λ _ => True) (· = 0) (· = 1)).mpr
+      ⟨(few_sem_true_iff λ _ => Iff.rfl).mpr (by decide),
+        (few_sem_true_iff λ _ => Iff.rfl).mpr (by decide)⟩)
+    ((few_sem_true_iff λ _ => Iff.rfl).not.mpr (by decide))
+
+/-! ### The paper's sentences -/
+
+/-- A sentence of the paper: its licenser, the strength of its polarity item, and the judgment. -/
+structure Row where
+  licenser : Licenser
+  strength : Strength
+  grammatical : Bool
+  deriving DecidableEq, Repr
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let licenser ← ex.parse? "licenser" [("no", Licenser.no), ("atMostFive", .atMostFive),
+    ("some", .some), ("only", .only), ("conditional", .conditional), ("sorry", .sorryThat)]
+  let strength ← ex.parse? "strength" [("weak", Strength.weak), ("strong", .strong)]
+  let grammatical ← ex.parse? "grammatical" [("yes", true), ("no", false)]
+  pure ⟨licenser, strength, grammatical⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+theorem rows_eq : rows =
+    [⟨.no, .weak, true⟩, ⟨.no, .strong, true⟩, ⟨.atMostFive, .weak, true⟩,
+      ⟨.atMostFive, .strong, false⟩, ⟨.some, .weak, false⟩, ⟨.some, .strong, false⟩,
+      ⟨.only, .weak, true⟩, ⟨.only, .strong, false⟩, ⟨.only, .strong, false⟩,
+      ⟨.only, .strong, false⟩, ⟨.conditional, .weak, true⟩, ⟨.conditional, .strong, false⟩,
+      ⟨.conditional, .strong, false⟩, ⟨.conditional, .strong, false⟩, ⟨.sorryThat, .weak, true⟩,
+      ⟨.sorryThat, .strong, false⟩, ⟨.sorryThat, .strong, false⟩,
+      ⟨.sorryThat, .strong, false⟩] := by
+  decide
+
+/-- Every judgment in the paper follows from the two licensing principles. -/
+theorem rows_predicted : ∀ r ∈ rows, (r.grammatical = true ↔ Licensed r.licenser r.strength) := by
+  obtain ⟨⟨ow, cw, sw⟩, os, cs, ss⟩ := strawsonAA_not_sufficient
+  simp only [rows_eq, List.forall_mem_cons, List.mem_nil_iff, false_implies, implies_true,
+    and_true, true_iff, false_iff, Bool.false_eq_true]
+  refine ⟨λ {_} => no_scope_down, λ {_} => no_strong, λ {_} => at_most_n_scope_down 5,
+    λ h => atMostFive_not_strong h, λ h => ?_, λ h => some_not_strong (α := Bool) h,
+    ow, os, os, os, cw, cs, cs, cs, sw, ss, ss, ss⟩
+  exact (h (α := Bool) (λ _ => True) (λ _ => False) (λ _ => True) (λ _ hf => hf.elim)
+    ⟨true, trivial, trivial⟩).elim λ _ h => h.2
 
 end Gajewski2011

--- a/references.bib
+++ b/references.bib
@@ -2808,7 +2808,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/AlonsoOvalleMoghiseh2025a.json;Data/Examples/AlonsoOvalleRoyer2024.json;Data/Examples/Chierchia2013.json}
+  sources   = {Data/Examples/AlonsoOvalleMoghiseh2025a.json;Data/Examples/AlonsoOvalleRoyer2024.json;Data/Examples/Chierchia2013.json;Fragments/English/Scales.lean;Fragments/Italian/ModalIndefinites.lean;Fragments/Italian/PolarityItems.lean;Logic/Natural/Strawson/Basic.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/DomainAlternatives.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Polarity/Negation.lean;Studies/Ahn2015.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/AlonsoOvalleRoyer2024.lean;Studies/Alsop2024.lean;Studies/Chierchia2013.lean;Studies/ChowErlewine2022.lean;Studies/IatridouZeijlstra2021.lean;Studies/Mihoc2019.lean;Studies/Spector2016.lean}
 }
 @incollection{spector-2007,
   author    = {Spector, Benjamin},
@@ -2864,7 +2864,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Semantics/Questions/Closure.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Fox2018.lean;Studies/FoxKatzir2011.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
+  sources   = {Data/Examples/Fox2007.json;Fragments/English/Scales.lean;Semantics/Alternatives/Extremum.lean;Semantics/Exhaustification/Chain.lean;Semantics/Exhaustification/Excluder.lean;Semantics/Exhaustification/Finite.lean;Semantics/Exhaustification/InnocentExclusion.lean;Semantics/Exhaustification/PreExhaustified.lean;Semantics/Exhaustification/Trivalent.lean;Semantics/Plurality/Implicature.lean;Semantics/Quantification/Numerals/Basic.lean;Semantics/Questions/Closure.lean;Studies/AlonsoOvalleMoghiseh2025a.lean;Studies/BarLev2021.lean;Studies/BarLevFox2020.lean;Studies/BrehenyEtAl2018.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/ChowErlewine2022.lean;Studies/Denic2023.lean;Studies/Fox2007.lean;Studies/Fox2018.lean;Studies/FoxKatzir2011.lean;Studies/Franke2011.lean;Studies/FrankeBergen2020.lean;Studies/Gajewski2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Magri2009.lean;Studies/Magri2014.lean;Studies/MeyerFeiman2021.lean;Studies/Spector2013.lean;Studies/WangDavidson2026.lean}
 }
 @incollection{chierchia-fox-spector-2012,
   author    = {Chierchia, Gennaro and Fox, Danny and Spector, Benjamin},
@@ -4240,7 +4240,7 @@
   role      = {cited},
   doi       = {10.4324/9780203828779},
   validated = {true},
-  sources   = {Semantics/Entailment/StrawsonEntailment.lean}
+  sources   = {Logic/Natural/Strawson/Basic.lean;Studies/Belnap1970.lean}
 }% REF: Bush, R. R. & Mosteller, F. (1955). Stochastic Models for Learning. Wiley.
 @book{bush-mosteller-1955,
   author    = {Bush, Robert R. and Mosteller, Frederick},
@@ -4710,7 +4710,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Degree/Comparative.lean}
+  sources   = {Core/Order/SetPreimage.lean;Features/Indefinite.lean;Features/LicensingContext.lean;Fragments/Italian/PolarityItems.lean;Semantics/Degree/Basic.lean;Semantics/Degree/Comparison.lean;Semantics/Degree/Quantifier.lean;Semantics/Polarity/Licensing.lean;Studies/BhattPancheva2004.lean;Studies/Hoeksema1983.lean;Studies/VonFintel1999.lean}
 }% REF: Connes, A. & D. Kreimer (1998). Hopf Algebras, Renormalization and Noncommutative Geometry. Comm. Math. Phys. 199, 203–242. The original Connes-Kreimer Hopf algebra of rooted trees.
 @article{connes-kreimer-1998,
   author    = {Connes, Alain and Kreimer, Dirk},
@@ -5226,7 +5226,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/KirkGiannini2024.lean}
+  sources   = {Features/Antonymy.lean;Pragmatics/NeoGricean/Basic.lean;Semantics/Degree/Antonymy.lean;Studies/AlexandropoulouGotzner2024a.lean;Studies/AlexandropoulouGotzner2024b.lean;Studies/BaleEtAl2025.lean;Studies/Gajewski2011.lean;Studies/KirkGiannini2024.lean;Studies/Krifka2007.lean}
 }% REF: Kratzer, A. (1989). An investigation of the lumps of thought.
 @article{kratzer-1989,
   author    = {Kratzer, Angelika},
@@ -5580,7 +5580,7 @@
   subfield  = {semantics/compositional},
   role      = {formalized},
   validated = {true},
-  sources   = {}
+  sources   = {Features/LicensingContext.lean;Logic/Natural/Strawson/Basic.lean;Semantics/Polarity/Licensing.lean;Studies/KadmonLandman1993.lean;Studies/Lahiri1998.lean;Studies/RitchieSchiller2024.lean;Studies/VonFintel1999.lean}
 }% REF: Kamp, H. & Reyle, U. (1993). From Discourse to Logic.
 @book{kamp-reyle-1993,
   author    = {Kamp, Hans and Reyle, Uwe},
@@ -9404,7 +9404,7 @@
   role      = {cited},
   doi       = {10.1515/9783110126969.7.651},
   validated = {true},
-  sources   = {Semantics/Conditionals/Restrictor.lean}
+  sources   = {Logic/Natural/Strawson/Basic.lean;Semantics/Conditionals/Restrictor.lean;Studies/KadmonLandman1993.lean;Studies/VonFintel1999.lean}
 }% REF: Willett, T. (1988). A cross-linguistic survey of the grammaticalization of evidentiality. Studies in Language 12: 51--97
 @phdthesis{iatridou-1991,
   author    = {Iatridou, Sabine},
@@ -11224,7 +11224,7 @@
   subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Focus/Particles.lean}
+  sources   = {Logic/Natural/Strawson/Basic.lean;Semantics/Focus/Particles.lean;Studies/PhillipsBrown2025.lean}
 }% REF: Ahn (2015). The Semantics of Additive Either.
 @inproceedings{ahn-2015,
   author    = {Ahn, Dorothy},
@@ -12151,7 +12151,7 @@
   subfield  = {semantics/polarity},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Polarity/Licensing.lean;Semantics/Polarity/Item.lean}
+  sources   = {Logic/Natural/Additivity.lean;Semantics/Polarity/Item.lean;Semantics/Polarity/Licensing.lean;Semantics/Polarity/Strength.lean;Studies/Gajewski2011.lean;Studies/IatridouZeijlstra2021.lean;Studies/Ladusaw1979.lean;Studies/Roussou2010.lean}
 }
 @article{gajewski-2011,
   author    = {Gajewski, Jon},
@@ -12164,8 +12164,8 @@
   doi       = {10.1007/s11050-010-9067-1},
   subfield  = {semantics/polarity},
   validated = {true},
-  role      = {cited},
-  sources   = {Studies/Gajewski2011.lean}
+  role      = {formalized},
+  sources   = {Data/Examples/Gajewski2011.json;Fragments/English/PolarityItems.lean;Logic/Natural/Strawson/Basic.lean;Logic/Natural/Strawson/Soundness.lean;Semantics/Polarity/Licensing.lean;Studies/Gajewski2011.lean;Studies/IatridouZeijlstra2021.lean}
 }
 @unpublished{kiparsky-2002,
   author    = {Kiparsky, Paul},
@@ -15642,7 +15642,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Attitudes/Doxastic.lean}
+  sources   = {Data/Examples/AbneyKeshet2025.json;Features/Attitudes.lean;Logic/Natural/Strawson/Basic.lean;Semantics/Attitudes/Desire/Conditional.lean;Semantics/Conditionals/Presupposition.lean;Semantics/Dynamic/Partial.lean;Semantics/Presupposition/Basic.lean;Semantics/Presupposition/BeliefEmbedding.lean;Studies/Ahn2015.lean;Studies/AnandHacquard2013.lean;Studies/Grove2022.lean;Studies/Heim1992.lean;Studies/Kubota2026.lean;Studies/Lassiter2017.lean;Studies/PhillipsBrown2025.lean;Studies/Yan2023.lean;Syntax/Category/Verb/Defs.lean}
 }
 @article{von-fintel-1999,
   author    = {von Fintel, Kai},
@@ -15656,7 +15656,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {formalized},
-  sources   = {Semantics/Entailment/StrawsonEntailment.lean;Studies/VonFintel1999.lean}
+  sources   = {Data/Examples/AlonsoOvalle2009.json;Data/Examples/VonFintel1999.json;Fragments/English/PolarityItems.lean;Logic/Natural/Strawson/Basic.lean;Logic/Natural/Strawson/Soundness.lean;Semantics/Attitudes/Desire/BestWorlds.lean;Semantics/Conditionals/Basic.lean;Semantics/Homogeneity/Conditional.lean;Semantics/Modality/EventRelativity.lean;Semantics/Polarity/Licensing.lean;Semantics/Presupposition/Basic.lean;Studies/AlonsoOvalle2009.lean;Studies/Gajewski2011.lean;Studies/KadmonLandman1993.lean;Studies/Mandelkern2022.lean;Studies/PhillipsBrown2025.lean;Studies/VonFintel1999.lean}
 }
 @incollection{von-fintel-1999-subjunctive,
   author    = {von Fintel, Kai},
@@ -24624,7 +24624,8 @@
   doi       = {10.1007/s10988-007-9020-z},
   subfield  = {semantics/negation},
   validated = {true},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Data/Generalizations/HomogeneityProjection.lean;Studies/Kriz2016.lean;Studies/KrizChemla2015.lean;Studies/Magri2014.lean}
 }
 @phdthesis{laka-1990,
   author    = {Laka, Itziar},
@@ -25057,7 +25058,7 @@
   doi       = {10.1162/ling.2006.37.4.535},
   subfield  = {semantics},
   role      = {formalized},
-  sources   = {Data/Examples/Chierchia2006.json}
+  sources   = {Data/Examples/Chierchia2006.json;Features/Indefinite.lean;Fragments/English/PolarityItems.lean;Fragments/German/PolarityItems.lean;Fragments/Italian/PolarityItems.lean;Semantics/Exhaustification/Antiexhaustive.lean;Semantics/Polarity/Item.lean;Studies/AlonsoOvalleMenendezBenito2010.lean;Studies/Chierchia2006.lean;Studies/GeurtsPouscoulous2009.lean}
 }
 @article{fiske-cuddy-glick-xu-2002,
   author    = {Fiske, Susan T. and Cuddy, Amy J. C. and Glick, Peter and Xu, Jun},
@@ -33610,7 +33611,8 @@
   number    = {1},
   pages     = {1--40},
   year      = {1996},
-  subfield  = {semantics/entailment}
+  subfield  = {semantics/entailment},
+  sources   = {Logic/Natural/Strawson/Basic.lean;Semantics/Polarity/Licensing.lean}
 }
 
 @article{asher-1987,
@@ -33633,7 +33635,8 @@
   address   = {Cambridge, MA},
   pages     = {123--152},
   year      = {2000},
-  subfield  = {semantics/conditionals}
+  subfield  = {semantics/conditionals},
+  sources   = {Logic/Natural/Strawson/Basic.lean;Studies/AlonsoOvalle2009.lean;Studies/VonFintel1999.lean}
 }
 
 @article{sells-1987,
@@ -33675,7 +33678,8 @@
   number    = {4},
   pages     = {329--401},
   year      = {2003},
-  subfield  = {semantics/entailment}
+  subfield  = {semantics/entailment},
+  sources   = {Data/Examples/Ahn2015.json;Data/Examples/Thomas2026.json;Fragments/English/PolarityItems.lean;Studies/Ahn2015.lean}
 }
 
 @book{roberts-1993,


### PR DESCRIPTION
Cleanse of Gajewski2011 against the manuscript (Gajewski's site): the old file carried a demoted-substrate block, Karttunen–Peters conditions the paper only mentions, `gaj2011_*` re-exports, a Hoeksema bridge and registry `decide` checks; the recut states the paper's exhaustivity operator and two licensing principles and derives every judgment from them.

- `exh` enriches a determiner against its scale-mates; exhaustified *no* is *no* (`exh_no`) and exhaustified *not every* is *some but not every* (`exh_notEvery`), so *no* licenses strong items and *not every*, *at most five* and *some* do not; the Strawson anti-additive triggers license only weak items because their full meanings fail plain DE (`strawsonAA_not_sufficient`)
- Intolerance from the appendix: anti-additivity implies it, proportional *few* has it and is not anti-additive, cardinal *fewer than four* lacks it
- `Logic/Natural/Strawson/Basic.lean`: `wouldFull` with `wouldFull_isStrawsonDE`, `wouldFull_isStrawsonAA` restated on the full meaning, `wouldFull_not_de`; 18 JSON rows for (1f), (2f), (20)–(21), (26)–(28) with `rows_predicted`
