### PR TITLE
refactor(Studies/George2011): answer sets from abstracts, reducibility

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3072,3 +3072,4 @@ import Linglib.Data.Examples.Funakoshi2016
 import Linglib.Data.Examples.FuscoSgrizzi2026
 import Linglib.Data.Examples.Gajewski2002
 import Linglib.Data.Examples.Gajewski2011
+import Linglib.Data.Examples.George2011

--- a/Linglib/Data/Examples/George2011.json
+++ b/Linglib/Data/Examples/George2011.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "george2011_ex12",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(12)"
+    },
+    "language": "stan1293",
+    "primaryText": "Maggie knows who was admitted to the program.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "admittedKnown"
+      ],
+      [
+        "holds",
+        "yes"
+      ]
+    ],
+    "comment": "True on the strongly exhaustive reading: Maggie knows the admitted list is complete."
+  },
+  {
+    "id": "george2011_ex13",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(13)"
+    },
+    "language": "stan1293",
+    "primaryText": "Maggie knows who wasn't admitted to the program.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "notAdmittedKnown"
+      ],
+      [
+        "holds",
+        "no"
+      ]
+    ],
+    "comment": "False on every reading: nothing Maggie knows excludes Robin not having applied, or further applicants."
+  },
+  {
+    "id": "george2011_ex4",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(4)"
+    },
+    "language": "stan1293",
+    "primaryText": "Maggie knows who was admitted to the program, but she doesn't know who wasn't admitted.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "admittedButNot"
+      ],
+      [
+        "holds",
+        "yes"
+      ]
+    ],
+    "comment": "Adapted from Sharvit (2002); consistent, and true here on strongly exhaustive readings of both questions."
+  },
+  {
+    "id": "george2011_ex17",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(17)"
+    },
+    "language": "stan1293",
+    "primaryText": "Rupert knows which of his four students were admitted, but he doesn't know which weren't.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Rupert's four students are Anne, Red, Alex and Jonathan; Anne and Red were admitted, Jonathan rejected, Alex neither. Rupert has the complete list of admitted students but does not know, for Jonathan and Alex, whether they were rejected or fall into another category.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "fourStudents"
+      ],
+      [
+        "holds",
+        "yes"
+      ]
+    ],
+    "comment": "Adapted from Guerzoni and Sharvit (2007); true when 'weren't admitted' is understood as 'were rejected'."
+  },
+  {
+    "id": "george2011_ex33",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(33)"
+    },
+    "language": "stan1293",
+    "primaryText": "Janna knows where Rupert can buy a newspaper.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Rupert can buy a newspaper at PaperWorld and not at Newstopia. Janna and Red both know the former and know the same propositions; Red falsely believes Rupert can buy one at Newstopia, Janna has no opinion about Newstopia.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "jannaNewspaper"
+      ],
+      [
+        "holds",
+        "yes"
+      ]
+    ],
+    "comment": "True on the mention-some reading."
+  },
+  {
+    "id": "george2011_ex34",
+    "source": {
+      "bibkey": "george-2011",
+      "paperLabel": "(34)"
+    },
+    "language": "stan1293",
+    "primaryText": "Red knows where Rupert can buy a newspaper.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Rupert can buy a newspaper at PaperWorld and not at Newstopia. Janna and Red both know the former and know the same propositions; Red falsely believes Rupert can buy one at Newstopia, Janna has no opinion about Newstopia.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "sentence",
+        "redNewspaper"
+      ],
+      [
+        "holds",
+        "no"
+      ]
+    ],
+    "comment": "Untrue: Red's beliefs about where newspapers are available are at odds with the facts."
+  }
+]

--- a/Linglib/Data/Examples/George2011.lean
+++ b/Linglib/Data/Examples/George2011.lean
@@ -1,0 +1,126 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `George2011` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/George2011.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace George2011.Examples`.
+-/
+
+namespace George2011.Examples
+
+open Data.Examples
+
+def ex12 : LinguisticExample :=
+  { id := "george2011_ex12"
+    source := ⟨"george-2011", "(12)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Maggie knows who was admitted to the program."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "admittedKnown"), ("holds", "yes")]
+    comment := "True on the strongly exhaustive reading: Maggie knows the admitted list is complete."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13 : LinguisticExample :=
+  { id := "george2011_ex13"
+    source := ⟨"george-2011", "(13)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Maggie knows who wasn't admitted to the program."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "notAdmittedKnown"), ("holds", "no")]
+    comment := "False on every reading: nothing Maggie knows excludes Robin not having applied, or further applicants."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4 : LinguisticExample :=
+  { id := "george2011_ex4"
+    source := ⟨"george-2011", "(4)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Maggie knows who was admitted to the program, but she doesn't know who wasn't admitted."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Three applicants, Riley, Adam and Robin; Riley and Adam were admitted and Robin rejected. Maggie, not on the admissions committee, was sent the complete list of admitted applicants and had never heard of any applicant before."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "admittedButNot"), ("holds", "yes")]
+    comment := "Adapted from Sharvit (2002); consistent, and true here on strongly exhaustive readings of both questions."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex17 : LinguisticExample :=
+  { id := "george2011_ex17"
+    source := ⟨"george-2011", "(17)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Rupert knows which of his four students were admitted, but he doesn't know which weren't."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Rupert's four students are Anne, Red, Alex and Jonathan; Anne and Red were admitted, Jonathan rejected, Alex neither. Rupert has the complete list of admitted students but does not know, for Jonathan and Alex, whether they were rejected or fall into another category."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "fourStudents"), ("holds", "yes")]
+    comment := "Adapted from Guerzoni and Sharvit (2007); true when 'weren't admitted' is understood as 'were rejected'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex33 : LinguisticExample :=
+  { id := "george2011_ex33"
+    source := ⟨"george-2011", "(33)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Janna knows where Rupert can buy a newspaper."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Rupert can buy a newspaper at PaperWorld and not at Newstopia. Janna and Red both know the former and know the same propositions; Red falsely believes Rupert can buy one at Newstopia, Janna has no opinion about Newstopia."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "jannaNewspaper"), ("holds", "yes")]
+    comment := "True on the mention-some reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex34 : LinguisticExample :=
+  { id := "george2011_ex34"
+    source := ⟨"george-2011", "(34)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Red knows where Rupert can buy a newspaper."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Rupert can buy a newspaper at PaperWorld and not at Newstopia. Janna and Red both know the former and know the same propositions; Red falsely believes Rupert can buy one at Newstopia, Janna has no opinion about Newstopia."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("sentence", "redNewspaper"), ("holds", "no")]
+    comment := "Untrue: Red's beliefs about where newspapers are available are at odds with the facts."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex12, ex13, ex4, ex17, ex33, ex34]
+
+end George2011.Examples

--- a/Linglib/Studies/George2011.lean
+++ b/Linglib/Studies/George2011.lean
@@ -1,186 +1,404 @@
-import Linglib.Semantics.Questions.Basic
-import Linglib.Semantics.Questions.Resolution
+import Mathlib.Data.Fin.VecNotation
 import Linglib.Semantics.Questions.Exhaustivity
+import Linglib.Data.Examples.George2011
 
 /-!
-# [george-2011]: Question Embedding and the Semantics of Answers
-[karttunen-1977] [groenendijk-stokhof-1984] [heim-1994] [dayal-1996]
+# George (2011): Question Embedding and the Semantics of Answers
 
-Single-paper formalisation of [george-2011], *Question Embedding
-and the Semantics of Answers* (UCLA Ph.D. dissertation). George's
-central methodological claim: the **weak/intermediate exhaustivity**
-that is widely posited to explain *Maggie-knows-was-admitted* /
-*Maggie-knows-wasn't-admitted* contrasts is *dispensable* — what
-appears to be a weak-exhaustivity reading is actually a strong
-reading under (a) **domain uncertainty** (the wh-restrictor's
-extension is not fixed) plus (b) **complementation failure** (the
-positive and negative *wh*-questions don't have the symmetric
-relationship Groenendijk-Stokhof assumed).
+This file formalizes the baseline theory of [george-2011] and the two arguments the dissertation
+builds on it. A *wh*-question is an abstract, a world-dependent property of the things the
+*wh*-phrase ranges over; the question operator turns it into its mention-some answer set, and
+composing with the exhaustivity operator, which tests extensions for identity, turns it into the
+strongly exhaustive answer set. A responsive predicate holds of a question when it holds of some
+answer. The strongly exhaustive answer of [groenendijk-stokhof-1984] and the weakly exhaustive
+answer of [heim-1994] are recovered as the answers of a world (`Strong`, `Weak`) and shown to be
+the substrate's `strongAnswer` and `weakAnswer` over the mention-some set; the strongly
+exhaustive set has a unique true member at each world while the weakly exhaustive set has only a
+least one, which is why the existential embedding rule cannot use it. Partial answers are the
+unions of answers.
 
-## Substrate identifications
+The first argument dismantles the case for weak exhaustivity from consistent pairs such as
+*Maggie knows who was admitted but not who wasn't* ([sharvit-2002]): with negation outscoping
+the restrictor the strongly exhaustive answer sets of a question and its negation coincide
+(`negation_generalization`), but once the restrictor sits outside the negation, uncertainty about
+its extension (`domain_uncertainty`) or a negation that is not complementation
+(`rupert_not_knows_rejected`) makes the pair true on strongly exhaustive readings alone. The
+second is that *know* lacks the reducibility property: agents with the same propositional
+knowledge can differ in question knowledge because a false belief in a mention-some answer
+defeats it (`knowsQ_not_reducible`), whereas the existential rule makes any predicate reducible
+(`reducible_embed`).
 
-| [george-2011]                              | substrate                              |
-|-------------------------------------------------|----------------------------------------|
-| **Strong** (eq 125): `λw λα λw'(α(w) = α(w'))`  | `Exhaustivity.strongAnswer`            |
-| **Weak** (eq 130): `λw λα λw' ∀β(α(w)(β) → α(w')(β))` | `Exhaustivity.weakAnswer`        |
-| Strongly-exhaustive answer set (eq 129)         | `Set.range (strongAnswer (alt Q))` (Fox 2018 LogicalPartition) |
-| Weakly-exhaustive answer set (eq 131)           | not directly named; corresponds to the maximal-true-member view of weakAnswer |
-| Mention-some answer (§2.6.1)                    | `Resolves σ Q`                         |
+## Implementation notes
 
-George's `Strong` operator (eq 125) takes a world `w` and an abstract
-`α` (an `⟨s, τ⟩` function) and returns the proposition that holds
-exactly at worlds where the abstract has the same extension as in
-`w`. On the substrate's `Question W` view (which fixes `τ = ⟨e, t⟩`-ish
-content), `Strong(w)(Q) = strongAnswer (alt Q) w`.
+* Abstracts are functions `W → τ → Prop`, the dissertation's intensions with the world argument
+  first; a product `τ` covers multiple *wh*. Answer sets are `Set (Set W)`, and an agent's
+  propositional knowledge in the admission scenarios is the entailment of the proposition by the
+  set of worlds compatible with what the agent was told.
+* The strongly exhaustive set built through the exhaustivity operator admits contradictory
+  members for extensions no world realizes; the set of Strong answers omits them, the
+  dissertation's own footnoted discrepancy (`exists_Strong_of_nonempty`).
+* The admission scenarios assign four candidates a status of not having applied, being admitted,
+  rejected or waitlisted. Knowledge in the newspaper scenario is true belief, the propositional
+  relation the dissertation holds fixed while varying belief.
 
-George's `Weak` operator (eq 130) takes an abstract `α` and returns
-the proposition that holds at worlds where `α`'s extension in the
-evaluation world is a *subset* of `α`'s extension here. On the
-substrate, this is `weakAnswer (alt Q) w` — the conjunction (intersection)
-of all alternatives true at `w`.
+## References
 
-## Section coverage
-
-* **§2.6.2** Strong operator (eq 125) — substrate identification.
-* **§2.6.3** Weak operator (eq 130) — substrate identification, plus
-  observation (paragraph after eq 132) that "the weakly exhaustive
-  answer is the maximal true member of the weakly-exhaustive answer
-  set" — captured by `weakAnswer` semantics.
-* **§3.1.1** Negation Generalization (eq 5–10) — formal argument that
-  `who walks` and `who doesn't walk` produce the same strongly
-  exhaustive answer SET (under classical bivalence + domain
-  constancy). Substrate-level: the formal equivalence holds *under
-  closed-world assumption*; in the substrate, `strongAnswer (alt Q) w` and
-  `strongAnswer (negation Q) w` are equivalent only if every world's
-  question denotation has the right complementarity. This file states
-  the assumption-relative equivalence.
-* **§3.1.2** Domain Uncertainty (eq 11–15) — George's first
-  dispensability argument: when the wh-restrictor's extension varies
-  across worlds (de dicto reading), the equivalence fails. The
-  Maggie-knows-(13)-but-not-(15) judgment is consistent with a
-  uniform STRONG reading, not evidence for weak.
-* **§3.1.3** Complementation Failure — second dispensability
-  argument; deferred (substrate captures the underlying machinery
-  via `info Q` and `compl`).
-* **Chapter 4** (Non-)Reducibility — George's argument that
-  responsive predicates' question-embedding semantics is *not*
-  always reducible to their that-clause-embedding semantics.
-  Requires a doxastic / attitudinal layer; deferred.
-
-## What this file does NOT cover
-
-* George's compositional system (Chapter 2): topical-property /
-  abstract machinery is richer than `Question W = LowerSet (Set W)`.
-* Chapters 5–6 alternative-question and mention-some scope account.
-* Chapter 7 strong-ish exhaustivity speculation.
+* [george-2011]
+* [groenendijk-stokhof-1984]
+* [heim-1994]
+* [karttunen-1977]
+* [lahiri-2002]
+* [sharvit-2002]
 -/
 
 namespace George2011
 
-open Question
-open Questions
+open Questions Data.Examples
 
-variable {W : Type*}
+variable {W τ E : Type*}
 
-/-! ### §2.6.2 Strong operator (eq 125) -/
+/-! ### Answer sets from abstracts -/
 
-/-- [george-2011] (125): the **Strong** answer operator,
-    `λw λα λw'(α(w) = α(w'))`. Substrate identification: the set of
-    worlds whose extension on every alternative matches `w`. Same as
-    the substrate's `strongAnswer (alt Q) w` (see `Heim1994` for the
-    bridge to ans₂). -/
-def Strong (Q : Question W) (w : W) : Set W :=
-  strongAnswer (alt Q) w
+/-- The question operator: the mention-some answers of an abstract, one per value. -/
+def mentionSome (α : W → τ → Prop) : Set (Set W) := Set.range λ β => {w | α w β}
 
-@[simp] theorem Strong_eq_strongAnswer (Q : Question W) (w : W) :
-    Strong Q w = strongAnswer (alt Q) w := rfl
+/-- The exhaustivity operator on extensions: identity with the given extension. -/
+def X (γ : τ → Prop) : (τ → Prop) → Prop := λ δ => γ = δ
 
-/-! ### §2.6.3 Weak operator (eq 130) -/
+/-- The strongly exhaustive answers: the question operator over the exhaustified abstract. -/
+def stronglyExhaustive (α : W → τ → Prop) : Set (Set W) := mentionSome λ w => X (α w)
 
-/-- [george-2011] (130): the **Weak** answer operator,
-    `λw λα λw' ∀β(α(w)(β) → α(w')(β))`. Substrate identification:
-    the set of worlds where the alternative's extension at `w` is a
-    subset of its extension here. Same as the substrate's
-    `weakAnswer (alt Q) w`. -/
-def Weak (Q : Question W) (w : W) : Set W :=
-  weakAnswer (alt Q) w
+theorem mem_mentionSome {α : W → τ → Prop} {p : Set W} :
+    p ∈ mentionSome α ↔ ∃ β, {w | α w β} = p := Set.mem_range
 
-@[simp] theorem Weak_eq_weakAnswer (Q : Question W) (w : W) :
-    Weak Q w = weakAnswer (alt Q) w := rfl
+theorem mem_stronglyExhaustive {α : W → τ → Prop} {p : Set W} :
+    p ∈ stronglyExhaustive α ↔ ∃ S, {w | α w = S} = p := Set.mem_range
 
-/-- [george-2011] §2.6.3: any state σ supporting the Strong
-    answer at `w` also supports the Weak answer at `w` — i.e., strong
-    exhaustivity entails weak exhaustivity. This is the formal trace
-    of George's claim that "weak exhaustivity is dispensable":
-    everywhere we'd want to use Weak, the stronger Strong already
-    serves. -/
-theorem Strong_subset_Weak (Q : Question W) (w : W) :
-    Strong Q w ⊆ Weak Q w :=
-  strongAnswer_subset_weakAnswer (alt Q) w
+/-- The strongly exhaustive answer of a world: the worlds where the abstract has the same
+extension. -/
+def Strong (w : W) (α : W → τ → Prop) : Set W := {w' | α w' = α w}
 
-/-! ### §3.1.1 Negation Generalization (eq 5)
+/-- The weakly exhaustive answer of a world: the worlds where the extension includes this one. -/
+def Weak (w : W) (α : W → τ → Prop) : Set W := {w' | ∀ β, α w β → α w' β}
 
-[george-2011] §3.1.1: under bivalence + domain constancy,
-the strongly exhaustive answer SET to *who walks* and to *who
-doesn't walk* coincide. Substrate-level: this requires a specific
-relationship between the question denotation and its complement —
-specifically, that for every alt `p` of `Q`, `pᶜ` (interpreted as
-the corresponding negative-question alt) is also in `alt Q'` for
-the negative `Q'`.
-
-We state George's claim assumption-relatively: *under* the
-bivalence-plus-constancy assumption (every world's alt-true-set
-determines the alt-false-set), the strong answers are equivalent.
-The substrate doesn't bake in bivalence (worlds can have arbitrary
-membership in alts) so the equivalence requires explicit
-hypotheses. -/
-
-/-- The §3.1.1 formal observation as a substrate-level conditional:
-    if two questions `Q` and `Q'` have alts that mutually decide
-    each other (i.e., `Q`-alts and `Q'`-alts agree as a partition),
-    then their `strongAnswer` cells coincide at every `w`.
-
-    Captures the [groenendijk-stokhof-1984] argument structure
-    that George dissects in (5)-(10). -/
-theorem strongAnswer_eq_when_alts_agree
-    (Q Q' : Question W) (w : W)
-    (hAgree : ∀ v, (∀ p ∈ alt Q, w ∈ p ↔ v ∈ p) ↔
-                   (∀ p ∈ alt Q', w ∈ p ↔ v ∈ p)) :
-    strongAnswer (alt Q) w = strongAnswer (alt Q') w := by
+theorem Strong_eq_strongAnswer (w : W) (α : W → τ → Prop) :
+    Strong w α = strongAnswer (mentionSome α) w := by
   ext v
-  exact hAgree v
+  simp only [Strong, Set.mem_ofPred_eq, strongAnswer, mentionSome, Set.forall_mem_range]
+  exact ⟨λ h β => h ▸ Iff.rfl, λ h => funext λ β => propext (h β).symm⟩
 
-/-! ### §3.1.2 Domain Uncertainty
+theorem Weak_eq_weakAnswer (w : W) (α : W → τ → Prop) :
+    Weak w α = weakAnswer (mentionSome α) w := by
+  ext v
+  simp [Weak, weakAnswer, trueAnswers, mentionSome]
 
-[george-2011] §3.1.2: the apparent inequivalence of
-*Maggie-knows-(12)* and *Maggie-knows-(13)* is consistent with a
-uniform STRONG-exhaustive reading, *provided* the wh-restrictor's
-extension varies across worlds (de dicto interpretation).
+theorem Strong_mem_stronglyExhaustive (w : W) (α : W → τ → Prop) :
+    Strong w α ∈ stronglyExhaustive α :=
+  ⟨α w, rfl⟩
 
-Substrate-level: when alternatives don't fully partition the
-worlds (e.g., domain restrictions like *which applicants* vary),
-strong-exhaustive-Q and strong-exhaustive-(negation Q) can have
-*different* extensions even though both encode "Maggie knows the
-strong-exhaustive answer". The two predications are consistent
-because they're about different sets of possibilities.
+/-- A satisfiable strongly exhaustive answer is the Strong answer of one of its worlds. -/
+theorem exists_Strong_of_nonempty {α : W → τ → Prop} {p : Set W} (hp : p ∈ stronglyExhaustive α)
+    (hne : p.Nonempty) : ∃ w, p = Strong w α := by
+  obtain ⟨S, rfl⟩ := hp
+  obtain ⟨w, hw⟩ := hne
+  have : α w = S := hw
+  subst this
+  exact ⟨w, rfl⟩
 
-This is a paper-level observation about the *space* of cases
-admitting weak ↔ strong inequivalence; we capture the substrate
-fact that `weakAnswer ⊆ strongAnswer ↔` does NOT hold in general,
-and the [george-2011] argument turns on which side of this
-asymmetry is empirically active. -/
+/-- Each world's Strong answer is the unique true strongly exhaustive answer there. -/
+theorem trueAnswers_stronglyExhaustive (w : W) (α : W → τ → Prop) :
+    trueAnswers (stronglyExhaustive α) w = {Strong w α} := by
+  ext p
+  simp only [trueAnswers, mem_stronglyExhaustive, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨⟨S, rfl⟩, hw⟩
+    have : α w = S := hw
+    subst this
+    rfl
+  · rintro rfl
+    exact ⟨⟨α w, rfl⟩, rfl⟩
 
-/-! [george-2011] §3.1.2 substrate fact: the converse
-    inclusion `weakAnswer (alt Q) w ⊆ strongAnswer (alt Q) w` does **not** hold
-    in general — strong exhaustivity is strictly stronger than weak.
-    Concrete intuition: with `W = {0, 1, 2}` and `Q`'s alts being
-    `{0,1}` and `{1,2}` (overlapping non-comparable propositions),
-    at `w = 0` the weak answer is `{0,1}` (only `{0,1}` is true at
-    `0`) but the strong answer is `{0}` alone (since `1` decides
-    `{1,2}` differently from `0`). Constructing this concrete
-    instance in Lean requires more substrate API for `alt` of
-    `Question.ofList`-style constructions; the substrate fact itself
-    is documented in `Exhaustivity.strongAnswer_subset_weakAnswer`'s
-    one-direction status. -/
+/-- The weakly exhaustive answers of the worlds. -/
+def weaklyExhaustive (α : W → τ → Prop) : Set (Set W) := Set.range λ w => Weak w α
+
+theorem self_mem_Weak (w : W) (α : W → τ → Prop) : w ∈ Weak w α := λ _ h => h
+
+/-- A world's Weak answer is the least true member of the weakly exhaustive set, not its only
+one: recovering it needs maximality, which the existential embedding rule cannot supply. -/
+theorem isStrongestTrueAnswer_Weak (w : W) (α : W → τ → Prop) :
+    IsStrongestTrueAnswer (weaklyExhaustive α) w (Weak w α) :=
+  ⟨⟨⟨w, rfl⟩, self_mem_Weak w α⟩,
+    λ _ ⟨⟨_, hv⟩, hwq⟩ => hv ▸ λ _ hw' β hβ => hw' β ((hv ▸ hwq) β hβ)⟩
+
+/-! ### Partial answers -/
+
+/-- The generalized partial answers: the unions of subsets of the answer set. -/
+def part (P : Set (Set W)) : Set (Set W) := Set.sUnion '' 𝒫 P
+
+theorem subset_part (P : Set (Set W)) : P ⊆ part P :=
+  λ p hp => ⟨{p}, Set.singleton_subset_iff.mpr hp, Set.sUnion_singleton p⟩
+
+theorem part_mono : Monotone (part : Set (Set W) → Set (Set W)) :=
+  λ _ _ h => Set.image_mono (Set.powerset_mono.mpr h)
+
+theorem part_part (P : Set (Set W)) : part (part P) = part P := by
+  refine Set.Subset.antisymm ?_ (subset_part _)
+  rintro p ⟨𝒬, h𝒬, rfl⟩
+  choose S hS hSq using λ q (hq : q ∈ 𝒬) => h𝒬 hq
+  refine ⟨{s | ∃ q, ∃ hq : q ∈ 𝒬, s ∈ S q hq}, λ s ⟨q, hq, hs⟩ => hS q hq hs, ?_⟩
+  ext w
+  simp only [Set.mem_sUnion, Set.mem_ofPred_eq]
+  constructor
+  · rintro ⟨s, ⟨q, hq, hs⟩, hw⟩
+    exact ⟨q, hq, hSq q hq ▸ Set.mem_sUnion.mpr ⟨s, hs, hw⟩⟩
+  · rintro ⟨q, hq, hw⟩
+    obtain ⟨s, hs, hws⟩ := Set.mem_sUnion.mp (hSq q hq ▸ hw)
+    exact ⟨s, ⟨q, hq, hs⟩, hws⟩
+
+/-- Every mention-some answer is a partial answer to the strongly exhaustive set: the union of
+the strongly exhaustive answers whose extension contains its value. -/
+theorem mentionSome_subset_part (α : W → τ → Prop) :
+    mentionSome α ⊆ part (stronglyExhaustive α) := by
+  rintro p ⟨β, rfl⟩
+  refine ⟨{q | ∃ S, S β ∧ {w | α w = S} = q}, λ q ⟨S, _, hq⟩ => ⟨S, hq⟩, ?_⟩
+  ext w
+  simp only [Set.mem_sUnion, Set.mem_ofPred_eq]
+  exact ⟨λ ⟨_, ⟨S, hS, rfl⟩, hw⟩ => (show α w = S from hw) ▸ hS,
+    λ h => ⟨{w' | α w' = α w}, ⟨α w, h, rfl⟩, rfl⟩⟩
+
+/-! ### Embedding and reducibility -/
+
+/-- The embedding rule: a responsive predicate holds of a question when it holds of some
+answer. -/
+def embed (R : Set W → E → Prop) (P : Set (Set W)) (x : E) : Prop := ∃ p ∈ P, R p x
+
+/-- The reducibility property: agents related to the same propositions are related to the same
+questions. -/
+def Reducible (R : Set W → E → Prop) (RQ : Set (Set W) → E → Prop) : Prop :=
+  ∀ a b, (∀ p, R p a ↔ R p b) → ∀ P, RQ P a ↔ RQ P b
+
+theorem reducible_embed (R : Set W → E → Prop) : Reducible R (embed R) :=
+  λ _ _ h _ => exists_congr λ p => and_congr_right λ _ => h p
+
+/-- Knowledge as true belief, the propositional relation the dissertation holds fixed. -/
+def knows (believes : Set W → E → Prop) (w : W) (p : Set W) (x : E) : Prop := believes p x ∧ w ∈ p
+
+/-- Question-embedding *know*: knowing an answer and believing no false one. -/
+def knowsQ (believes : Set W → E → Prop) (w : W) (P : Set (Set W)) (x : E) : Prop :=
+  embed (knows believes w) P x ∧ ∀ p ∈ P, believes p x → w ∈ p
+
+/-- Two agents with the same knowledge, one of whom believes a false answer: *know* lacks the
+reducibility property. -/
+theorem knowsQ_not_reducible {believes : Set W → E → Prop} {w : W} {P : Set (Set W)} {a b : E}
+    {p₁ p₂ : Set W} (h₁ : p₁ ∈ P) (h₂ : p₂ ∈ P) (hw₁ : w ∈ p₁) (hw₂ : w ∉ p₂)
+    (ha₁ : believes p₁ a) (hb₂ : believes p₂ b) (ha : ∀ p ∈ P, believes p a → w ∈ p)
+    (hab : ∀ p, w ∈ p → (believes p a ↔ believes p b)) :
+    ¬ Reducible (knows believes w) (knowsQ believes w) := λ h =>
+  hw₂ ((((h a b λ p => and_congr_left λ hp => hab p hp) P).mp ⟨⟨p₁, h₁, ha₁, hw₁⟩, ha⟩).2 p₂ h₂ hb₂)
+
+/-! ### The newspaper scenario -/
+
+/-- A world of the newspaper scenario: whether Rupert can buy one at PaperWorld and at Newstopia. -/
+abbrev Newspaper := Bool × Bool
+
+/-- The mention-some answers to *where can Rupert buy a newspaper*. -/
+def newspaperAnswers : Set (Set Newspaper) := {{w | w.1 = true}, {w | w.2 = true}}
+
+/-- Janna (`false`) believes what holds at PaperWorld, Red (`true`) also the Newstopia answer. -/
+def newspaperBelieves (p : Set Newspaper) : Bool → Prop
+  | false => {w | w.1 = true} ⊆ p
+  | true => {w | w.1 = true ∧ w.2 = true} ⊆ p
+
+private theorem janna_iff_red {p : Set Newspaper} (hp : (true, false) ∈ p) :
+    newspaperBelieves p false ↔ newspaperBelieves p true := by
+  refine ⟨λ h _ hw => h hw.1, λ h w hw => ?_⟩
+  obtain ⟨a, b⟩ := w
+  cases a <;> cases b
+  all_goals first | exact absurd hw Bool.false_ne_true | exact hp | exact h ⟨rfl, rfl⟩
+
+theorem newspaper_not_reducible :
+    ¬ Reducible (knows newspaperBelieves (true, false)) (knowsQ newspaperBelieves (true, false)) :=
+  knowsQ_not_reducible (P := newspaperAnswers) (a := false) (b := true) (p₁ := {w | w.1 = true})
+    (p₂ := {w | w.2 = true}) (Set.mem_insert _ _) (Set.mem_insert_of_mem _ rfl) rfl
+    Bool.false_ne_true (λ _ h => h) (λ _ h => h.2)
+    (λ p hp h => by
+      rcases Set.mem_insert_iff.mp hp with rfl | rfl
+      · rfl
+      · exact absurd (h (show (true, false) ∈ {w : Newspaper | w.1 = true} from rfl))
+          Bool.false_ne_true)
+    (λ _ hp => janna_iff_red hp)
+
+/-! ### Negation and strong exhaustivity -/
+
+/-- With negation outscoping the restrictor and a fixed domain, a question and its negation have
+the same strongly exhaustive answers. -/
+theorem negation_generalization (α : W → τ → Prop) :
+    stronglyExhaustive (λ w x => ¬ α w x) = stronglyExhaustive α := by
+  ext p
+  simp only [mem_stronglyExhaustive]
+  constructor
+  · rintro ⟨S, rfl⟩
+    refine ⟨λ x => ¬ S x, ?_⟩
+    ext w
+    simp only [Set.mem_ofPred_eq]
+    exact ⟨λ h => funext λ x => by rw [congrFun h x]; exact propext not_not,
+      λ h => funext λ x => by rw [← congrFun h x]; exact (propext not_not).symm⟩
+  · rintro ⟨S, rfl⟩
+    refine ⟨λ x => ¬ S x, ?_⟩
+    ext w
+    simp only [Set.mem_ofPred_eq]
+    exact ⟨λ h => funext λ x => propext (not_iff_not.mp (iff_of_eq (congrFun h x))),
+      λ h => h ▸ rfl⟩
+
+/-- A candidate's status in the admission scenarios. -/
+inductive Status
+  | notApplicant | admitted | rejected | waitlisted
+  deriving DecidableEq, Repr
+
+/-- A world assigns the four candidates a status. -/
+abbrev Admissions := Fin 4 → Status
+
+/-- *Which applicants were admitted*: the restrictor outside the negation. -/
+def admittedApplicant (w : Admissions) (x : Fin 4) : Prop :=
+  w x ≠ .notApplicant ∧ w x = .admitted
+
+/-- *Which applicants weren't admitted*. -/
+def notAdmittedApplicant (w : Admissions) (x : Fin 4) : Prop :=
+  w x ≠ .notApplicant ∧ w x ≠ .admitted
+
+/-- *Which students were rejected*, the reading of *weren't admitted* that is not
+complementation. -/
+def rejected (w : Admissions) (x : Fin 4) : Prop := w x = .rejected
+
+/-- An agent identified with the worlds compatible with what they know knows a proposition the
+state entails. -/
+def stateKnows (p σ : Set W) : Prop := σ ⊆ p
+
+/-- Maggie's state: Riley and Adam are the admitted applicants and nobody else was admitted. -/
+def maggie : Set Admissions := {w | ∀ x, w x = .admitted ↔ x = 0 ∨ x = 1}
+
+/-- Maggie's state is the strongly exhaustive answer that Riley and Adam were the admitted
+applicants. -/
+theorem maggie_eq : {w | admittedApplicant w = λ x => x = 0 ∨ x = 1} = maggie :=
+  Set.ext λ w => ⟨λ hw x => have hx := iff_of_eq (congrFun hw x)
+      ⟨λ h => hx.mp ⟨λ hn => Status.noConfusion (h.symm.trans hn), h⟩, λ h => (hx.mpr h).2⟩,
+    λ hw => funext λ x => propext ⟨λ h => (hw x).mp h.2,
+      λ h => ⟨λ hn => Status.noConfusion (((hw x).mpr h).symm.trans hn), (hw x).mpr h⟩⟩⟩
+
+private def robinRejected : Admissions :=
+  ![Status.admitted, Status.admitted, Status.rejected, Status.notApplicant]
+
+private def robinAbsent : Admissions :=
+  ![Status.admitted, Status.admitted, Status.notApplicant, Status.notApplicant]
+
+private theorem robinRejected_mem : robinRejected ∈ maggie :=
+  show ∀ x, robinRejected x = .admitted ↔ x = 0 ∨ x = 1 by decide
+
+private theorem robinAbsent_mem : robinAbsent ∈ maggie :=
+  show ∀ x, robinAbsent x = .admitted ↔ x = 0 ∨ x = 1 by decide
+
+/-- Maggie's state entails no strongly exhaustive answer about the applicants not admitted: it
+does not settle whether Robin applied. -/
+theorem maggie_not_knows_notAdmitted :
+    ¬ embed stateKnows (stronglyExhaustive notAdmittedApplicant) maggie := by
+  rintro ⟨p, ⟨S, rfl⟩, hσ⟩
+  have h₁ : notAdmittedApplicant robinRejected = S := hσ robinRejected_mem
+  have h₂ : notAdmittedApplicant robinAbsent = S := hσ robinAbsent_mem
+  exact (Eq.mp (congrFun (h₁.trans h₂.symm) 2) ⟨by decide, by decide⟩).1 rfl
+
+theorem maggie_knows_admitted :
+    embed stateKnows (stronglyExhaustive admittedApplicant) maggie :=
+  ⟨maggie, ⟨_, maggie_eq⟩, subset_rfl⟩
+
+/-- Once the restrictor sits outside the negation, the two answer sets come apart. -/
+theorem domain_uncertainty :
+    stronglyExhaustive notAdmittedApplicant ≠ stronglyExhaustive admittedApplicant := λ h =>
+  maggie_not_knows_notAdmitted ⟨maggie, h ▸ ⟨_, maggie_eq⟩, subset_rfl⟩
+
+/-- Rupert's state: all four students applied, Anne and Red are the admitted ones, and Alex and
+Jonathan were each rejected or waitlisted. -/
+def rupert : Set Admissions :=
+  {w | (∀ x, w x ≠ .notApplicant) ∧ ∀ x, w x = .admitted ↔ x = 0 ∨ x = 1}
+
+private def jonathanRejected : Admissions :=
+  ![Status.admitted, Status.admitted, Status.waitlisted, Status.rejected]
+
+private def jonathanWaitlisted : Admissions :=
+  ![Status.admitted, Status.admitted, Status.waitlisted, Status.waitlisted]
+
+private theorem jonathanRejected_mem : jonathanRejected ∈ rupert :=
+  show (∀ x, jonathanRejected x ≠ .notApplicant) ∧
+    ∀ x, jonathanRejected x = .admitted ↔ x = 0 ∨ x = 1 by decide
+
+private theorem jonathanWaitlisted_mem : jonathanWaitlisted ∈ rupert :=
+  show (∀ x, jonathanWaitlisted x ≠ .notApplicant) ∧
+    ∀ x, jonathanWaitlisted x = .admitted ↔ x = 0 ∨ x = 1 by decide
+
+theorem rupert_knows_admitted :
+    embed stateKnows (stronglyExhaustive admittedApplicant) rupert :=
+  ⟨maggie, ⟨_, maggie_eq⟩, λ _ hw => hw.2⟩
+
+/-- Complementation failure: with the domain known, Rupert still knows no strongly exhaustive
+answer to *which were rejected*. -/
+theorem rupert_not_knows_rejected :
+    ¬ embed stateKnows (stronglyExhaustive rejected) rupert := by
+  rintro ⟨p, ⟨S, rfl⟩, hσ⟩
+  have h₁ : rejected jonathanRejected = S := hσ jonathanRejected_mem
+  have h₂ : rejected jonathanWaitlisted = S := hσ jonathanWaitlisted_mem
+  exact absurd (Eq.mp (congrFun (h₁.trans h₂.symm) 3) rfl)
+    (by decide : jonathanWaitlisted 3 ≠ .rejected)
+
+/-! ### The dissertation's judgments -/
+
+/-- The sentences whose truth in their scenarios the file settles. -/
+inductive Sentence
+  | admittedKnown | notAdmittedKnown | admittedButNot | fourStudents | jannaNewspaper
+  | redNewspaper
+  deriving DecidableEq, Repr
+
+/-- What each sentence claims in its scenario, on the readings the dissertation assigns. -/
+def Verdict : Sentence → Prop
+  | .admittedKnown => embed stateKnows (stronglyExhaustive admittedApplicant) maggie
+  | .notAdmittedKnown => embed stateKnows (stronglyExhaustive notAdmittedApplicant) maggie
+  | .admittedButNot => embed stateKnows (stronglyExhaustive admittedApplicant) maggie ∧
+      ¬ embed stateKnows (stronglyExhaustive notAdmittedApplicant) maggie
+  | .fourStudents => embed stateKnows (stronglyExhaustive admittedApplicant) rupert ∧
+      ¬ embed stateKnows (stronglyExhaustive rejected) rupert
+  | .jannaNewspaper => knowsQ newspaperBelieves (true, false) newspaperAnswers false
+  | .redNewspaper => knowsQ newspaperBelieves (true, false) newspaperAnswers true
+
+structure Row where
+  sentence : Sentence
+  holds : Bool
+  deriving DecidableEq, Repr
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let sentence ← ex.parse? "sentence" [("admittedKnown", Sentence.admittedKnown),
+    ("notAdmittedKnown", .notAdmittedKnown), ("admittedButNot", .admittedButNot),
+    ("fourStudents", .fourStudents), ("jannaNewspaper", .jannaNewspaper),
+    ("redNewspaper", .redNewspaper)]
+  let holds ← ex.parse? "holds" [("yes", true), ("no", false)]
+  pure ⟨sentence, holds⟩
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+theorem rows_eq : rows = [⟨.admittedKnown, true⟩, ⟨.notAdmittedKnown, false⟩,
+    ⟨.admittedButNot, true⟩, ⟨.fourStudents, true⟩, ⟨.jannaNewspaper, true⟩,
+    ⟨.redNewspaper, false⟩] := by
+  decide
+
+/-- Every judgment the dissertation reports for its scenarios holds in the models. -/
+theorem rows_predicted : ∀ r ∈ rows, (r.holds = true ↔ Verdict r.sentence) := by
+  simp only [rows_eq, List.forall_mem_cons, List.mem_nil_iff, false_implies, implies_true,
+    and_true, true_iff, false_iff, Bool.false_eq_true]
+  refine ⟨maggie_knows_admitted, maggie_not_knows_notAdmitted,
+    ⟨maggie_knows_admitted, maggie_not_knows_notAdmitted⟩,
+    ⟨rupert_knows_admitted, rupert_not_knows_rejected⟩,
+    ⟨⟨_, Set.mem_insert _ _, λ _ h => h, rfl⟩, λ p hp h => ?_⟩, λ h => ?_⟩
+  · rcases Set.mem_insert_iff.mp hp with rfl | rfl
+    · rfl
+    · exact absurd (h (show (true, false) ∈ {w : Newspaper | w.1 = true} from rfl))
+        Bool.false_ne_true
+  · exact absurd (h.2 _ (Set.mem_insert_of_mem _ rfl) λ _ hw => hw.2) Bool.false_ne_true
 
 end George2011

--- a/references.bib
+++ b/references.bib
@@ -343,6 +343,18 @@
   type      = {Ph.D. Dissertation},
   subfield  = {semantics/compositional},
   role      = {formalized},
+  sources   = {Data/Examples/George2011.json;Semantics/Questions/Resolution.lean;Studies/George2011.lean;Studies/TheilerRoelofsenAloni2018.lean}
+}
+@article{sharvit-2002,
+  author    = {Sharvit, Yael},
+  year      = {2002},
+  title     = {Embedded Questions and `De Dicto' Readings},
+  journal   = {Natural Language Semantics},
+  volume    = {10},
+  number    = {2},
+  pages     = {97--123},
+  subfield  = {semantics/questions},
+  role      = {cited},
   sources   = {Studies/George2011.lean}
 }% REF: Gong, Z. M. (2022). Case in Wholesale Late Merger: Evidence from Mongolian Scrambling.
 @article{gong-2022,
@@ -6235,7 +6247,7 @@
   subfield  = {semantics/questions},
   role      = {cited},
   validated = {false},
-  sources   = {Studies/Dayal2016.lean}
+  sources   = {Studies/Dayal2016.lean;Studies/George2011.lean}
 }% REF: Heim, I. (1999). Notes on superlatives. Ms., MIT.
 @unpublished{heim-1999,
   author    = {Heim, Irene},
@@ -15496,7 +15508,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {cited},
-  sources   = {Data/Examples/AlonsoOvalle2009.json;Data/Examples/Dayal2016.json;Semantics/Polarity/Licensing.lean;Semantics/Questions/Closure.lean;Semantics/Questions/Exhaustivity.lean;Studies/AlonsoOvalle2009.lean;Studies/AlonsoOvalleMoghiseh2025b.lean;Studies/Dayal2016.lean;Studies/Dayal2025.lean;Studies/Fox2018.lean;Studies/FoxHackl2006.lean;Studies/George2011.lean;Studies/Karttunen1977.lean;Studies/Xiang2022.lean}
+  sources   = {Data/Examples/AlonsoOvalle2009.json;Data/Examples/Dayal2016.json;Semantics/Polarity/Licensing.lean;Semantics/Questions/Closure.lean;Semantics/Questions/Exhaustivity.lean;Studies/AlonsoOvalle2009.lean;Studies/AlonsoOvalleMoghiseh2025b.lean;Studies/Dayal2016.lean;Studies/Dayal2025.lean;Studies/Fox2018.lean;Studies/FoxHackl2006.lean;Studies/Karttunen1977.lean;Studies/Xiang2022.lean}
 }
 @article{shannon-1948,
   author    = {Shannon, Claude E.},


### PR DESCRIPTION
Cleanse of George2011 against the UCLA dissertation (Zotero PDF): the old file defined `Strong`/`Weak` as aliases of the substrate operators, proved one trivial inclusion, and deferred every argument the dissertation makes; the recut states the baseline theory and derives its two central results.

- Abstracts, the question operator `mentionSome`, the exhaustivity operator `X`, `stronglyExhaustive`; `Strong`/`Weak` proven equal to the substrate's `strongAnswer`/`weakAnswer`, the unique true strongly exhaustive answer (`trueAnswers_stronglyExhaustive`) against the merely least true weakly exhaustive one (`isStrongestTrueAnswer_Weak`); partial answers as unions with the four properties the dissertation lists
- `negation_generalization` (a question and its negation share strongly exhaustive answers when negation outscopes the restrictor), `domain_uncertainty` and the Maggie and Rupert admission models making the Sharvit and Guerzoni–Sharvit pairs true on strongly exhaustive readings
- `Reducible`, `reducible_embed` for the existential embedding rule, and `knowsQ_not_reducible` with the newspaper scenario; 6 rows for (4), (12), (13), (17), (33), (34) with `rows_predicted`; bib: sharvit-2002 added without DOI
