### PR TITLE
refactor(Semantics/Questions): fold namespace Questions into Question

### DIFF
--- a/Linglib/Fragments/German/PolarityMarking.lean
+++ b/Linglib/Fragments/German/PolarityMarking.lean
@@ -18,7 +18,7 @@ German's strategy is non-particulate.
 
 ## Cross-Module Connections
 
-- `Questions.VerumFocus`: VERUM in questions — a
+- `Question.VerumFocus`: VERUM in questions — a
   different phenomenon from the declarative Verum focus encoded here
 - `German.Particles`: German *denn* (question-flavoring)
 

--- a/Linglib/Semantics/Plurality/Cover.lean
+++ b/Linglib/Semantics/Plurality/Cover.lean
@@ -31,7 +31,7 @@ extending it to the temporal domain via stratified reference.
   literature grounding.
 * `IsPartition` — a cover whose parts are pairwise disjoint. The
   `Set`-valued, possibly-infinite analogue of mathlib's `Finpartition`;
-  distinct from the `Setoid`-based `Questions.Partition.IsPartition`.
+  distinct from the `Setoid`-based `Question.Partition.IsPartition`.
 * `IsFinCover` — finite-cover specialisation via `Finset.sup'`, bridged
   to the general notion by `isFinCover_iff_isCover`.
 * `algClosure_of_finCover` / `exists_finCover_of_algClosure` /
@@ -82,7 +82,7 @@ def IsCover {α : Type*} [Preorder α] (parts : Set α) (whole : α) : Prop :=
     arbitrary (possibly overlapping) covers to handle readings like
     [gillon-1987]'s *the men wrote musicals*. The `Set`-valued,
     possibly-infinite analogue of mathlib's `Finpartition`; not the
-    `Setoid`-based `Questions.Partition.IsPartition`. Disjointness is
+    `Setoid`-based `Question.Partition.IsPartition`. Disjointness is
     meet-bottom, so the carrier needs `Lattice` + `OrderBot`. -/
 def IsPartition {α : Type*} [Lattice α] [OrderBot α]
     (parts : Set α) (whole : α) : Prop :=

--- a/Linglib/Semantics/Polarity/CzechNegation.lean
+++ b/Linglib/Semantics/Polarity/CzechNegation.lean
@@ -15,7 +15,7 @@ without importing them. NCI licensing by Agree follows [zeijlstra-2004].
 
 namespace Czech.Negation
 
-open Questions
+open Question
 
 /-- The three LF positions for negation in Czech PQs ([stankova-2026], her (16)).
 

--- a/Linglib/Semantics/Questions/Bias.lean
+++ b/Linglib/Semantics/Questions/Bias.lean
@@ -21,7 +21,7 @@ frames lives study-side (`Studies/RomeroHan2004.lean`).
 * `originalBiasOK`, `evidenceBiasOK` — Romero's compatibility tables.
 -/
 
-namespace Questions
+namespace Question
 
 /-- The three polar question forms ([romero-2024] §1).
 
@@ -131,4 +131,4 @@ theorem hiNQ_evidence_against_ok :
 theorem hiNQ_evidence_neutral_ok :
     evidenceBiasOK .HiNQ .neutral = true := rfl
 
-end Questions
+end Question

--- a/Linglib/Semantics/Questions/Closure.lean
+++ b/Linglib/Semantics/Questions/Closure.lean
@@ -6,7 +6,7 @@ import Mathlib.Order.CompleteLattice.Finset
 # Hamblin sets closed under conjunction or disjunction
 
 A wh-question over atomic answers `a i` denotes, under [dayal-1996]'s sum-closed restrictor,
-the family of conjunctions `conj a S` over non-empty groups `S`; under [spector-2008]'s
+the family of conjunctions `conjFamily a S` over non-empty groups `S`; under [spector-2008]'s
 higher-order quantification (pruned to disjunctions of atoms, as in [fox-2018]) it denotes the
 family of disjunctions `disj a S`. Both families are read off a world's `profile`, the atoms
 true there, and both induce the same strong answers.
@@ -19,7 +19,7 @@ true there, and both induce the same strong answers.
 * [fox-2018]
 -/
 
-namespace Questions
+namespace Question
 
 variable {W ι : Type*} (a : ι → Set W)
 
@@ -27,13 +27,13 @@ variable {W ι : Type*} (a : ι → Set W)
 def profile (w : W) : Set ι := {i | w ∈ a i}
 
 /-- The conjunction of the atoms in a group. -/
-def conj (S : Finset ι) : Set W := ⋂ i ∈ S, a i
+def conjFamily (S : Finset ι) : Set W := ⋂ i ∈ S, a i
 
 /-- The disjunction of the atoms in a group. -/
 def disj (S : Finset ι) : Set W := ⋃ i ∈ S, a i
 
 /-- The Hamblin set closed under conjunction: one member per non-empty group. -/
-def conjClosure : Set (Set W) := conj a '' {S | S.Nonempty}
+def conjClosure : Set (Set W) := conjFamily a '' {S | S.Nonempty}
 
 /-- The Hamblin set closed under disjunction: one member per non-empty group. -/
 def disjClosure : Set (Set W) := disj a '' {S | S.Nonempty}
@@ -42,18 +42,20 @@ variable {a}
 
 @[simp] theorem mem_profile {w : W} {i : ι} : i ∈ profile a w ↔ w ∈ a i := Iff.rfl
 
-theorem mem_conj {S : Finset ι} {w : W} : w ∈ conj a S ↔ ∀ i ∈ S, w ∈ a i := Set.mem_iInter₂
+theorem mem_conjFamily {S : Finset ι} {w : W} : w ∈ conjFamily a S ↔ ∀ i ∈ S, w ∈ a i :=
+  Set.mem_iInter₂
 
 theorem mem_disj {S : Finset ι} {w : W} : w ∈ disj a S ↔ ∃ i ∈ S, w ∈ a i := by simp [disj]
 
-theorem mem_conj_iff_subset {S : Finset ι} {w : W} : w ∈ conj a S ↔ ↑S ⊆ profile a w :=
-  mem_conj.trans ⟨λ h _ hi => h _ hi, λ h _ hi => h hi⟩
+theorem mem_conjFamily_iff_subset {S : Finset ι} {w : W} : w ∈ conjFamily a S ↔ ↑S ⊆ profile a w :=
+  mem_conjFamily.trans ⟨λ h _ hi => h _ hi, λ h _ hi => h hi⟩
 
-theorem conj_singleton (i : ι) : conj a {i} = a i := Finset.set_biInter_singleton i a
+theorem conjFamily_singleton (i : ι) : conjFamily a {i} = a i := Finset.set_biInter_singleton i a
 
 theorem disj_singleton (i : ι) : disj a {i} = a i := Finset.set_biUnion_singleton i a
 
-theorem conj_mem_conjClosure {S : Finset ι} (hS : S.Nonempty) : conj a S ∈ conjClosure a :=
+theorem conjFamily_mem_conjClosure {S : Finset ι} (hS : S.Nonempty) :
+    conjFamily a S ∈ conjClosure a :=
   ⟨S, hS, rfl⟩
 
 theorem disj_mem_disjClosure {S : Finset ι} (hS : S.Nonempty) : disj a S ∈ disjClosure a :=
@@ -73,11 +75,11 @@ theorem mem_strongAnswer_conjClosure_iff {w v : W} :
   constructor
   · intro h
     ext i
-    have := h _ (conj_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩)
-    rw [conj_singleton] at this
+    have := h _ (conjFamily_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩)
+    rw [conjFamily_singleton] at this
     exact this.symm
   · rintro h _ ⟨S, -, rfl⟩
-    rw [mem_conj_iff_subset, mem_conj_iff_subset, h]
+    rw [mem_conjFamily_iff_subset, mem_conjFamily_iff_subset, h]
 
 theorem mem_strongAnswer_disjClosure_iff {w v : W} :
     v ∈ strongAnswer (disjClosure a) w ↔ profile a v = profile a w := by
@@ -99,4 +101,4 @@ theorem strongAnswer_conjClosure_eq_disjClosure (w : W) :
     strongAnswer (conjClosure a) w = strongAnswer (disjClosure a) w :=
   Set.ext λ _ => mem_strongAnswer_conjClosure_iff.trans mem_strongAnswer_disjClosure_iff.symm
 
-end Questions
+end Question

--- a/Linglib/Semantics/Questions/Exhaustivity.lean
+++ b/Linglib/Semantics/Questions/Exhaustivity.lean
@@ -53,7 +53,7 @@ of [dayal-2016] needs Hamblin sets whose members entail one another, which
 * [xiang-2022]
 -/
 
-namespace Questions
+namespace Question
 
 open Question
 
@@ -547,4 +547,4 @@ theorem strongAnswer_ofSet_of_pos {p : Set W} {w : W} (hwp : w ∈ p) :
   ext v
   simp [strongAnswer, alt_ofSet, hwp]
 
-end Questions
+end Question

--- a/Linglib/Semantics/Questions/Probabilistic.lean
+++ b/Linglib/Semantics/Questions/Probabilistic.lean
@@ -43,7 +43,7 @@ that introduced them) since their only consumer is the IKW 2025
 discourse-*only* study file.
 -/
 
-namespace Questions
+namespace Question
 
 open Question PMF
 
@@ -293,7 +293,7 @@ a Current Question — an RQ need not be a CQ, only relevant to one. -/
     `R` shifts the probability of some alternative of `Q`.
     [thomas-2026] Def 61. The relation is also lifted to
     declarative-as-singleton-issue contexts via `IsRelevantOf`. -/
-def IsRelevantTo (R Q : Question W) (μ : PMF W) : Prop :=
+def IsRelevantToUnder (R Q : Question W) (μ : PMF W) : Prop :=
   ∃ A ∈ alt R, ∃ A' ∈ alt Q, μ.condProbSet A A' ≠ μ.probOfSet A'
 
 /-- A *proposition* `R` is relevant to a question `Q` if conditioning
@@ -346,4 +346,4 @@ theorem IsResolutionEvidencedBy.isRelevantPropOf
   push Not at hcon
   exact absurd (hindep hcon) (ne_of_gt hRes.raises_prob)
 
-end Questions
+end Question

--- a/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
+++ b/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
@@ -17,7 +17,7 @@ interrogatives keeps atoms only (42) (`neutral`, `atoms`); and *-ro* restricts t
 selection function to singletons (52), the `IsSingleton` functions of
 [alonso-ovalle-menendez-benito-2010], which collapses ⊓ and ⊔ to individual answers
 (`hamblinRo`, `hamblinRo_neutral`). Dayal's answerhood operator (8) presupposes a maximally
-strong true answer (`Questions.IsExhaustivelyResolvable` on the finite Hamblin set); a plural
+strong true answer (`Question.IsExhaustivelyResolvable` on the finite Hamblin set); a plural
 answer is available iff the presupposition holds in a world where two atoms were bought
 (`farsi`, (40)/(45)/(53)/(55)).
 
@@ -44,7 +44,7 @@ removes (`modal_gq`, (58)–(63)); collective predicates need pluralities in the
 
 namespace AlonsoOvalleMoghiseh2025b
 
-open Quantification Questions Data.Examples Finset
+open Quantification Question Data.Examples Finset
 
 /-! ### Entities, worlds, and answers -/
 

--- a/Linglib/Studies/BuringGunlogson2000.lean
+++ b/Linglib/Studies/BuringGunlogson2000.lean
@@ -38,7 +38,7 @@ inner-negation NPQ, `HiNQ` its outer-negation NPQ.
 
 namespace BuringGunlogson2000
 
-open Questions
+open Question
 
 /-! ### Compelling contextual evidence -/
 

--- a/Linglib/Studies/Dayal2016.lean
+++ b/Linglib/Studies/Dayal2016.lean
@@ -68,7 +68,7 @@ comparisons, and check the chapter's judgments.
 
 namespace Dayal2016
 
-open Questions Data.Examples Set
+open Question Data.Examples Set
 
 /-! ### Scope marking (34)–(37): the truth requirement leaves the denotation -/
 

--- a/Linglib/Studies/Dayal2025.lean
+++ b/Linglib/Studies/Dayal2025.lean
@@ -65,7 +65,7 @@ lacks. Question particles sit at the layer their embedding distribution shows.
 
 namespace Dayal2025
 
-open Minimalist Questions Features Data.Examples Clause
+open Minimalist Question Features Data.Examples Clause
 open English.Predicates.Verbal English.QuestionParticles HindiUrdu.Particles Japanese.Particles
 
 /-! ### The three layers (7), (20) -/

--- a/Linglib/Studies/Fox2007.lean
+++ b/Linglib/Studies/Fox2007.lean
@@ -427,7 +427,7 @@ end Existential
 
 section Hamblin
 
-open Questions
+open Question
 
 variable {ι : Type*} {a : ι → Set W}
 variable (hsolo : ∀ i, ∃ u, u ∈ a i ∧ ∀ j, j ≠ i → u ∉ a j)
@@ -435,10 +435,10 @@ include hsolo
 
 /-- A group of two or more is innocently excludable given the existential answer. -/
 theorem isInnocentlyExcludable_conj {S : Finset ι} {i j : ι} (hi : i ∈ S) (hj : j ∈ S)
-    (hij : i ≠ j) : IsInnocentlyExcludable (conjClosure a) (⋃ i, a i) (conj a S) := by
-  refine .of_extension_consistent (conj_mem_conjClosure ⟨i, hi⟩) λ E hE => ?_
+    (hij : i ≠ j) : IsInnocentlyExcludable (conjClosure a) (⋃ i, a i) (conjFamily a S) := by
+  refine .of_extension_consistent (conjFamily_mem_conjClosure ⟨i, hi⟩) λ E hE => ?_
   obtain ⟨v, hv⟩ := hE.1.2.2
-  by_cases hvS : v ∈ conj a S
+  by_cases hvS : v ∈ conjFamily a S
   · obtain ⟨u, hui, hu⟩ := hsolo i
     refine ⟨u, ?_⟩
     rintro ψ (hψ | hψ)
@@ -446,13 +446,13 @@ theorem isInnocentlyExcludable_conj {S : Finset ι} {i j : ι} (hi : i ∈ S) (h
       · exact mem_iUnion.2 ⟨i, hui⟩
       · intro huT
         have hTi : ∀ k ∈ T, k = i := λ k hk =>
-          by_contra λ hki => hu k hki (mem_conj.1 huT k hk)
-        refine hv _ hψ (mem_conj.2 λ k hk => ?_)
+          by_contra λ hki => hu k hki (mem_conjFamily.1 huT k hk)
+        refine hv _ hψ (mem_conjFamily.2 λ k hk => ?_)
         rw [hTi k hk]
-        exact mem_conj.1 hvS i hi
+        exact mem_conjFamily.1 hvS i hi
     · rw [mem_singleton_iff] at hψ
       subst hψ
-      exact λ huS => hu j hij.symm (mem_conj.1 huS j hj)
+      exact λ huS => hu j hij.symm (mem_conjFamily.1 huS j hj)
   · refine ⟨v, ?_⟩
     rintro ψ (hψ | hψ)
     · exact hv ψ hψ
@@ -464,7 +464,7 @@ theorem not_isInnocentlyExcludable_atom (i : ι) :
     ¬ IsInnocentlyExcludable (conjClosure a) (⋃ i, a i) (a i) := by
   obtain ⟨u, hui, hu⟩ := hsolo i
   have hmem : ∀ k, a k ∈ conjClosure a := λ k =>
-    conj_singleton (a := a) k ▸ conj_mem_conjClosure ⟨k, Finset.mem_singleton_self k⟩
+    conjFamily_singleton (a := a) k ▸ conjFamily_mem_conjClosure ⟨k, Finset.mem_singleton_self k⟩
   rw [isInnocentlyExcludable_iff_exhMW_subset_compl _ _ _ (hmem i)]
   refine λ h => h ⟨mem_iUnion.2 ⟨i, hui⟩, ?_⟩ hui
   rintro ⟨v, hv, hvu, hnuv⟩
@@ -473,8 +473,8 @@ theorem not_isInnocentlyExcludable_atom (i : ι) :
   subst k
   refine hnuv λ c hc huc => ?_
   obtain ⟨T, -, rfl⟩ := hc
-  refine mem_conj.2 λ m hm => ?_
-  have hmi : m = i := by_contra λ hmi => hu m hmi (mem_conj.1 huc m hm)
+  refine mem_conjFamily.2 λ m hm => ?_
+  have hmi : m = i := by_contra λ hmi => hu m hmi (mem_conjFamily.1 huc m hm)
   rw [hmi]
   exact hkv
 
@@ -487,7 +487,7 @@ theorem exhIE_conjClosure [Fintype ι] [DecidableEq ι] :
   constructor
   · rintro ⟨⟨i, hi⟩, h⟩
     refine ⟨i, hi, λ j hj => by_contra λ hji =>
-      h (conj a {i, j}) ?_ (mem_conj.2 λ m hm => ?_)⟩
+      h (conjFamily a {i, j}) ?_ (mem_conjFamily.2 λ m hm => ?_)⟩
     · exact isInnocentlyExcludable_conj hsolo (S := {i, j}) (Finset.mem_insert_self i _)
         (Finset.mem_insert_of_mem (Finset.mem_singleton_self j)) λ h' => hji h'.symm
     · rcases Finset.mem_insert.1 hm with h1 | h1
@@ -501,11 +501,11 @@ theorem exhIE_conjClosure [Fintype ι] [DecidableEq ι] :
     by_cases hSi : ∀ j ∈ S, j = i
     · obtain ⟨j, hj⟩ := hS
       have : S = {i} := Finset.eq_singleton_iff_unique_mem.2 ⟨hSi j hj ▸ hj, hSi⟩
-      rw [this, conj_singleton] at hc
+      rw [this, conjFamily_singleton] at hc
       exact not_isInnocentlyExcludable_atom hsolo i hc
     · obtain ⟨j, hj⟩ := not_forall.1 hSi
       obtain ⟨hjS, hji⟩ := Classical.not_imp.1 hj
-      exact hji (huniq j (mem_conj.1 huc j hjS))
+      exact hji (huniq j (mem_conjFamily.1 huc j hjS))
 
 end Hamblin
 

--- a/Linglib/Studies/Fox2018.lean
+++ b/Linglib/Studies/Fox2018.lean
@@ -17,14 +17,14 @@ contains the disjunction of two incomparable members, the negative island of hig
 questions (`not_nonVacuity_exhCell_of_union`), unless a necessity modal intervenes
 (`nonVacuity_box`). With exhaustification as [bar-lev-fox-2020]'s cell operator, a question closed
 under conjunction and its disjunctive counterpart identify the same cells by different members
-(`cell_conj`, `cell_disj`), and the answer set of the paper's revised answer operator is a
+(`cell_conjFamily`, `cell_disj`), and the answer set of the paper's revised answer operator is a
 singleton for the former but not for the latter: mention-all against mention-some.
 
 ## Implementation notes
 
 Questions are Hamblin sets `Set (Set W)` rather than `Question` lower sets, since the paper's sets
 are not antichains. The three-location model is a family of atoms `a : ι → Set W` with every
-profile realized (`Rich`); `Questions.conjClosure` and `Questions.disjClosure` are the paper's two
+profile realized (`Rich`); `Question.conjClosure` and `Question.disjClosure` are the paper's two
 denotations; their innocently excludable sets are characterized and the cells read off. Sections 5–7
 on the distribution of mention-some enter only through the rows on singular wh-phrases.
 
@@ -40,7 +40,7 @@ on the distribution of mention-some enter only through the rows on singular wh-p
 
 namespace Fox2018
 
-open Questions Exhaustification Set Data.Examples
+open Question Exhaustification Set Data.Examples
 
 variable {W : Type*}
 
@@ -158,9 +158,10 @@ theorem isExhaustivelyResolvable_conjClosure {ι : Type*} [Fintype ι] {a : ι �
   obtain ⟨i, hi⟩ := hw
   let T : Finset ι := Finset.univ.filter (λ i => w ∈ a i)
   have hT : ∀ i, i ∈ T ↔ w ∈ a i := λ i => by simp [T]
-  refine ⟨conj a T, ⟨conj_mem_conjClosure ⟨i, (hT i).2 hi⟩, mem_conj.2 λ i hi => (hT i).1 hi⟩, ?_⟩
+  refine ⟨conjFamily a T, ⟨conjFamily_mem_conjClosure ⟨i, (hT i).2 hi⟩,
+    mem_conjFamily.2 λ i hi => (hT i).1 hi⟩, ?_⟩
   rintro _ ⟨⟨S, -, rfl⟩, hwS⟩ v hv
-  exact mem_conj.2 λ j hj => mem_conj.1 hv j ((hT j).2 (mem_conj.1 hwS j hj))
+  exact mem_conjFamily.2 λ j hj => mem_conjFamily.1 hv j ((hT j).2 (mem_conjFamily.1 hwS j hj))
 
 /-! ### Negative islands -/
 
@@ -291,9 +292,10 @@ theorem leALT_conjClosure_iff {u v : W} :
     (u ≤[conjClosure a] v) ↔ profile a u ⊆ profile a v := by
   constructor
   · intro h i hi
-    exact h _ (conj_singleton (a := a) i ▸ conj_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩) hi
+    exact h _ (conjFamily_singleton (a := a) i ▸
+      conjFamily_mem_conjClosure ⟨i, Finset.mem_singleton_self i⟩) hi
   · rintro h _ ⟨S, -, rfl⟩ hu
-    exact mem_conj_iff_subset.2 ((mem_conj_iff_subset.1 hu).trans h)
+    exact mem_conjFamily_iff_subset.2 ((mem_conjFamily_iff_subset.1 hu).trans h)
 
 theorem leALT_disjClosure_iff {u v : W} :
     (u ≤[disjClosure a] v) ↔ profile a u ⊆ profile a v := by
@@ -307,14 +309,16 @@ theorem leALT_disjClosure_iff {u v : W} :
 variable (hrich : Rich a)
 include hrich
 
-theorem conj_subset_conj_iff {S T : Finset ι} : conj a T ⊆ conj a S ↔ S ⊆ T := by
+theorem conjFamily_subset_conjFamily_iff {S T : Finset ι} :
+    conjFamily a T ⊆ conjFamily a S ↔ S ⊆ T := by
   constructor
   · intro h i hi
     obtain ⟨w, hw⟩ := hrich T
-    have := mem_conj_iff_subset.1 (h (mem_conj_iff_subset.2 (by rw [hw]))) (Finset.mem_coe.2 hi)
+    have := mem_conjFamily_iff_subset.1 (h (mem_conjFamily_iff_subset.2 (by rw [hw])))
+      (Finset.mem_coe.2 hi)
     rw [hw] at this
     exact Finset.mem_coe.1 this
-  · exact λ h _ hv => mem_conj.2 λ i hi => mem_conj.1 hv i (h hi)
+  · exact λ h _ hv => mem_conjFamily.2 λ i hi => mem_conjFamily.1 hv i (h hi)
 
 theorem disj_subset_disj_iff {S T : Finset ι} : disj a S ⊆ disj a T ↔ S ⊆ T := by
   constructor
@@ -335,21 +339,21 @@ theorem disj_subset_disj_iff {S T : Finset ι} : disj a S ⊆ disj a T ↔ S ⊆
 /-- Given the conjunction over a group, a member is innocently excludable iff its group is not
 included: the paper's computation for the low-type question. -/
 theorem isInnocentlyExcludable_conj_iff [Fintype ι] {S T : Finset ι} (hS : S.Nonempty) :
-    IsInnocentlyExcludable (conjClosure a) (conj a T) (conj a S) ↔ ¬ S ⊆ T := by
+    IsInnocentlyExcludable (conjClosure a) (conjFamily a T) (conjFamily a S) ↔ ¬ S ⊆ T := by
   obtain ⟨w₀, hw₀⟩ := hrich T
-  have hw₀T : w₀ ∈ conj a T := mem_conj_iff_subset.2 (by rw [hw₀])
+  have hw₀T : w₀ ∈ conjFamily a T := mem_conjFamily_iff_subset.2 (by rw [hw₀])
   constructor
   · exact λ hIE hST => not_isInnocentlyExcludable_of_phi_subset conjClosure_finite ⟨w₀, hw₀T⟩
-      ((conj_subset_conj_iff hrich).2 hST) hIE
+      ((conjFamily_subset_conjFamily_iff hrich).2 hST) hIE
   · intro hST
-    refine .of_forall_subset_or_notMem (conj_mem_conjClosure hS) hw₀T ?_ ?_
-    · rw [mem_conj_iff_subset, hw₀]
+    refine .of_forall_subset_or_notMem (conjFamily_mem_conjClosure hS) hw₀T ?_ ?_
+    · rw [mem_conjFamily_iff_subset, hw₀]
       exact λ h => hST (Finset.coe_subset.1 h)
     · rintro _ ⟨U, -, rfl⟩
       by_cases hUT : U ⊆ T
-      · exact Or.inl ((conj_subset_conj_iff hrich).2 hUT)
+      · exact Or.inl ((conjFamily_subset_conjFamily_iff hrich).2 hUT)
       · right
-        rw [mem_conj_iff_subset, hw₀]
+        rw [mem_conjFamily_iff_subset, hw₀]
         exact λ h => hUT (Finset.coe_subset.1 h)
 
 /-- The minimal worlds given the disjunction over a group: the sole witnesses of its members. -/
@@ -406,11 +410,11 @@ theorem isInnocentlyExcludable_disj_iff {S T : Finset ι} (hS : S.Nonempty) :
     exact h hjS (this ▸ hiT)
 
 /-- For the conjunctive question, the member for a group identifies the cell of that profile. -/
-theorem cell_conj [Fintype ι] (T : Finset ι) :
-    cell (conjClosure a) (conj a T) = profileCell a T := by
+theorem cell_conjFamily [Fintype ι] (T : Finset ι) :
+    cell (conjClosure a) (conjFamily a T) = profileCell a T := by
   rw [conjClosure, cell_image_eq _ λ S hS => isInnocentlyExcludable_conj_iff hrich hS]
   ext x
-  simp only [mem_ofPred_eq, mem_conj_iff_subset, not_not, mem_profileCell]
+  simp only [mem_ofPred_eq, mem_conjFamily_iff_subset, not_not, mem_profileCell]
   constructor
   · rintro ⟨-, h⟩
     ext i
@@ -446,22 +450,22 @@ def ans (Exh : Set W → Set W) (H : Set (Set W)) (w : W) : Set (Set W) :=
 
 /-- Mention-all: the conjunctive question's answer set is the conjunction over the profile. -/
 theorem ans_conjClosure [Fintype ι] {T : Finset ι} (hT : T.Nonempty) {w : W} (hw : profile a w = ↑T) :
-    ans (cell (conjClosure a)) (conjClosure a) w = {conj a T} := by
+    ans (cell (conjClosure a)) (conjClosure a) w = {conjFamily a T} := by
   ext q
   rw [mem_singleton_iff]
   constructor
   · rintro ⟨⟨S, -, rfl⟩, hwS, h⟩
     have h1 : S ⊆ T := by
-      have := mem_conj_iff_subset.1 hwS
+      have := mem_conjFamily_iff_subset.1 hwS
       rw [hw] at this
       exact Finset.coe_subset.1 this
-    have h2 : T ⊆ S := (conj_subset_conj_iff hrich).1
-      (h _ (conj_mem_conjClosure hT) (by rw [cell_conj hrich T]; exact hw))
+    have h2 : T ⊆ S := (conjFamily_subset_conjFamily_iff hrich).1
+      (h _ (conjFamily_mem_conjClosure hT) (by rw [cell_conjFamily hrich T]; exact hw))
     rw [Finset.Subset.antisymm h1 h2]
   · rintro rfl
-    refine ⟨conj_mem_conjClosure hT, mem_conj_iff_subset.2 (by rw [hw]), ?_⟩
+    refine ⟨conjFamily_mem_conjClosure hT, mem_conjFamily_iff_subset.2 (by rw [hw]), ?_⟩
     rintro _ ⟨U, hU, rfl⟩ hwU
-    rw [cell_conj hrich U] at hwU
+    rw [cell_conjFamily hrich U] at hwU
     have hwU' : profile a w = ↑U := hwU
     rw [hw, Finset.coe_inj] at hwU'
     subst hwU'

--- a/Linglib/Studies/GarassinoJacob2018.lean
+++ b/Linglib/Studies/GarassinoJacob2018.lean
@@ -55,7 +55,7 @@ a preceding negative turn.
 
 namespace GarassinoJacob2018
 
-open Question Questions Discourse Data.Examples
+open Question Discourse Data.Examples
 
 variable {W F : Type*}
 

--- a/Linglib/Studies/GartnerGyuris2017.lean
+++ b/Linglib/Studies/GartnerGyuris2017.lean
@@ -31,7 +31,7 @@ and verified against the delimiting principles.
 
 namespace GartnerGyuris2017
 
-open Questions
+open Question
 
 -- ============================================================================
 -- §1: Core Types

--- a/Linglib/Studies/George2011.lean
+++ b/Linglib/Studies/George2011.lean
@@ -53,7 +53,7 @@ defeats it (`knowsQ_not_reducible`), whereas the existential rule makes any pred
 
 namespace George2011
 
-open Questions Data.Examples
+open Question Data.Examples
 
 variable {W τ E : Type*}
 

--- a/Linglib/Studies/Heim1994.lean
+++ b/Linglib/Studies/Heim1994.lean
@@ -67,7 +67,7 @@ contexts).
 namespace Heim1994
 
 open Question
-open Questions
+open Question
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Holmberg2016.lean
+++ b/Linglib/Studies/Holmberg2016.lean
@@ -161,7 +161,7 @@ theorem pol_feature_matches :
 theorem pol_ne_neg :
     FeatureVal.sameType (.pol true) (.neg true) = false := rfl
 
-/-! ### Question syntax: ForceP/FinP/PolP (relocated from Minimalist/Questions.lean)
+/-! ### Question syntax: ForceP/FinP/PolP (relocated from Minimalist/Question.lean)
 
 Syntactic projections involved in question formation.
 

--- a/Linglib/Studies/IppolitoKissWilliams2022.lean
+++ b/Linglib/Studies/IppolitoKissWilliams2022.lean
@@ -45,7 +45,7 @@ agreement. Both relations are symmetric in their `S`/`S'` arguments.
 
 namespace IppolitoKissWilliams2022
 
-open Question Questions
+open Question
 
 variable {W : Type*}
 

--- a/Linglib/Studies/IppolitoKissWilliams2025.lean
+++ b/Linglib/Studies/IppolitoKissWilliams2025.lean
@@ -106,7 +106,7 @@ answer whose existence the definedness condition requires.
 
 namespace IppolitoKissWilliams2025
 
-open Question Questions
+open Question
 open Question (isRelevantTo_polar_iff)
 open IppolitoKissWilliams2022
 

--- a/Linglib/Studies/Karttunen1977.lean
+++ b/Linglib/Studies/Karttunen1977.lean
@@ -56,7 +56,7 @@ substrate is in place.
 namespace Karttunen1977
 
 open Question
-open Questions
+open Question
 
 variable {W : Type*}
 

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -228,14 +228,14 @@ theorem wxdy_incongruity_survives_negation {W : Type*}
 
 /-! ### The two readings (§2.1) -/
 
-open Questions
+open Question
 
 /-- PerspP status separates the two readings of ex. 4: a speaker whose only doxastic
 alternative is the evaluation world (the diner sees the fly) cannot be possibly ignorant
 of the answer, so the utterance is not a genuine question; a speaker with every world
 open is, whenever the answer is not trivial. -/
 theorem perspP_disambiguates_wxdy {W : Type*} (H : Set (Set W)) (w : W)
-    (hH : Questions.weakAnswer H w ≠ Set.univ) :
+    (hH : Question.weakAnswer H w ≠ Set.univ) :
     ¬ PossiblyIgnorant H {w} (fun (_ : Unit) w v => v = w) () ∧
       PossiblyIgnorant H {w} (fun (_ : Unit) _ _ => True) () :=
   ⟨fun ⟨_, hv, hk⟩ => by

--- a/Linglib/Studies/Krifka2015.lean
+++ b/Linglib/Studies/Krifka2015.lean
@@ -51,7 +51,7 @@ negation (45).
 namespace Krifka2015
 
 open Commitment Commitment.Space
-open Questions
+open Question
 open Features (Acceptability)
 
 /-! ### The fixture -/

--- a/Linglib/Studies/Romero2024.lean
+++ b/Linglib/Studies/Romero2024.lean
@@ -30,7 +30,7 @@ predicate-level bridge below is the right granularity.
 namespace Romero2024
 
 open Pragmatics.Bias
-open Questions
+open Question
 
 /-- HiNQ's original-bias filter requires speaker bias for p. The
     licensed bias profile's `contradictsPriorBelief` axis is the

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -423,7 +423,7 @@ theorem verum_falsum_opposite_epistemic :
     The [+positive]/[+negative] values map directly. [neutral] maps to
     neutral. The "minus" values have no direct Romero counterpart — they
     encode incompatibility constraints rather than positive evidence. -/
-def evidentialToContextualEvidence : BiasValue → Option Questions.ContextualEvidence
+def evidentialToContextualEvidence : BiasValue → Option Question.ContextualEvidence
   | .plusPos  => some .forP
   | .plusNeg  => some .againstP
   | .neutral  => some .neutral
@@ -435,7 +435,7 @@ def evidentialToContextualEvidence : BiasValue → Option Questions.ContextualEv
     [+positive] maps to forP (speaker expected p). [+negative] maps to
     againstP. [neutral] maps to neutral. The "minus" values are not
     directly representable in Romero's three-valued system. -/
-def epistemicToOriginalBias : BiasValue → Option Questions.OriginalBias
+def epistemicToOriginalBias : BiasValue → Option Question.OriginalBias
   | .plusPos  => some .forP
   | .plusNeg  => some .againstP
   | .neutral  => some .neutral
@@ -492,14 +492,14 @@ theorem val_creates_questions :
     particle's bias requirement is the analysis, so it lives here):
     felicitous only in contexts with contextual evidence for the
     proposition, matching the evidential bias of PDQs and NRQs. -/
-def valContextualEvidence : Option Questions.ContextualEvidence :=
+def valContextualEvidence : Option Question.ContextualEvidence :=
   some .forP
 
 /-- S&R's classification, epistemic dimension: *väl* signals epistemic
     *uncertainty* — the speaker suspects p but is not certain,
     corresponding to the [-positive] epistemic bias of PDQs — so it
     imposes no original-bias requirement (contrast `dochWohlOriginalBias`). -/
-def valOriginalBias : Option Questions.OriginalBias := none
+def valOriginalBias : Option Question.OriginalBias := none
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10. German *doch wohl* marks RQs via REJECTQ
@@ -511,11 +511,11 @@ def valOriginalBias : Option Questions.OriginalBias := none
     and epistemic presuppositions in the REJECTQ definition (eq. 40).
     Shares its evidential value with `valContextualEvidence`; the
     epistemic dimension is where German is stricter than Swedish. -/
-def dochWohlContextualEvidence : Option Questions.ContextualEvidence :=
+def dochWohlContextualEvidence : Option Question.ContextualEvidence :=
   some .forP
 
 /-- See `dochWohlContextualEvidence`: prior speaker bias against p. -/
-def dochWohlOriginalBias : Option Questions.OriginalBias :=
+def dochWohlOriginalBias : Option Question.OriginalBias :=
   some .againstP
 
 /-- *doch wohl* is not usable in assertions — it marks questions.

--- a/Linglib/Studies/Simik2024.lean
+++ b/Linglib/Studies/Simik2024.lean
@@ -56,12 +56,12 @@ def razveFamily : List Particle :=
 for the prejacent (§4.2.4), extended here to the kin the chapter reports
 as similar in meaning. -/
 def evidentialRequirement (p : Particle) :
-    Option Questions.ContextualEvidence :=
+    Option Question.ContextualEvidence :=
   if p ∈ razveFamily then some .forP else none
 
 /-- *Razve*'s prior epistemic bias runs against the prejacent — the
 'I thought that ¬p' component of exx. 39 and 42. -/
-def razveOriginalBias : Option Questions.OriginalBias :=
+def razveOriginalBias : Option Question.OriginalBias :=
   some .againstP
 
 /-- *Razve* is a root phenomenon while *li* is obligatory in subordinated

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -177,7 +177,7 @@ end Stankova2026
 
 namespace Czech.Negation
 
-open Questions
+open Question
 open Stankova2026 (CzechPQForm)
 open StankovaSimik2025 (VerbPosition)
 
@@ -210,7 +210,7 @@ end Czech.Negation
 namespace Stankova2026
 
 open Czech.Negation
-open Questions
+open Question
 open StankovaSimik2025 (VerbPosition)
 
 /-- [romero-2024] PQ form of each [simik-2024] grid cell: InterNPQ is

--- a/Linglib/Studies/StankovaSimik2025.lean
+++ b/Linglib/Studies/StankovaSimik2025.lean
@@ -28,7 +28,7 @@ namespace StankovaSimik2025
 open Czech.Particles (nahodou snad copak)
 open Czech.Determiners (zadny nejaky)
 open Czech.Negation
-open Questions
+open Question
 open Features (Judgment)
 
 /-! ### The main experiment (§5)

--- a/Linglib/Studies/Theiler2021.lean
+++ b/Linglib/Studies/Theiler2021.lean
@@ -45,7 +45,7 @@ theorem denn_is_PerspP :
     (whose classification lives in `Zheng2025`), and the point on which
     Bayer/Obenauer-style evidence-sensitive analyses of *denn* would
     disagree. -/
-def dennBias : Option Questions.ContextualEvidence := none
+def dennBias : Option Question.ContextualEvidence := none
 
 /-- Unlike Mandarin *nandao*, *denn* is licensed in constituent
     questions. Both are PerspP-layer particles, but *denn* lacks

--- a/Linglib/Studies/Thomas2026.lean
+++ b/Linglib/Studies/Thomas2026.lean
@@ -10,7 +10,7 @@ Formalisation of [thomas-2026], which unifies the canonical additive use of
 *too* with a previously unstudied "argument-building" use by stating felicity
 in terms of Bayesian inquisitive answerhood. The substrate primitives
 (`Answers`, `IsResolutionEvidencedBy`, `evidencesResolutionMore`,
-`IsRelevantTo`) live in `Semantics/Questions/Probabilistic.lean`; this file
+`IsRelevantToUnder`) live in `Semantics/Questions/Probabilistic.lean`; this file
 encodes the felicity conditions of [thomas-2026] Def 64 and their abstract
 consequences.
 
@@ -44,7 +44,7 @@ consequences.
 
 The relevant question RQ need not be a Current Question; [thomas-2026] §5.4.3
 requires only that it be relevant to some discourse question, which
-`IsTooLicensedByDQ` captures via `IsRelevantTo`. The two prejacent conditions
+`IsTooLicensedByDQ` captures via `IsRelevantToUnder`. The two prejacent conditions
 rule out the [beaver-clark-2008] ecstatic case (the prejacent already entails
 the answer) and the "some-instrument vs cello" case (a weaker prejacent would
 do); see the per-field docstrings of `IsTooFelicitous`.
@@ -52,7 +52,7 @@ do); see the per-field docstrings of `IsTooFelicitous`.
 
 namespace Thomas2026
 
-open Question Questions
+open Question
 
 variable {W : Type*} {μ : PMF W}
   {prejacent antecedent : Set W} {rq : Question W}
@@ -120,7 +120,7 @@ theorem IsTooFelicitous.exists_strict_improvement
     need not be a Current Question — §5.4.3 requires only relevance to a DQ. -/
 def IsTooLicensedByDQ (prejacent antecedent : Set W)
     (rq dq : Question W) (μ : PMF W) : Prop :=
-  IsTooFelicitous prejacent antecedent rq μ ∧ IsRelevantTo rq dq μ
+  IsTooFelicitous prejacent antecedent rq μ ∧ IsRelevantToUnder rq dq μ
 
 /-! ### Predicted infelicity -/
 
@@ -161,7 +161,7 @@ caller to exhibit. -/
 
 namespace Thomas2026.Witness
 
-open Question Questions
+open Question
 open scoped ENNReal
 
 abbrev W := Fin 3

--- a/Linglib/Studies/Xiang2022.lean
+++ b/Linglib/Studies/Xiang2022.lean
@@ -67,7 +67,7 @@ defer that lift and work with the propositional projection here.
 namespace Xiang2022
 
 open Question
-open Questions
+open Question
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -194,13 +194,13 @@ open Mandarin.QuestionParticles (nandao)
 
 /-- *Nandao* requires contextual evidence for p — Zheng's evidential
 classification, the lexical face of `evidential_bias_necessary`. -/
-def nandaoContextualEvidence : Option Questions.ContextualEvidence :=
+def nandaoContextualEvidence : Option Question.ContextualEvidence :=
   some .forP
 
 /-- *Nandao* does not require epistemic bias — it is compatible with a
 neutral epistemic state (pure inquiry use, ex. 3); the lexical face of
 `epistemic_bias_not_necessary`. -/
-def nandaoOriginalBias : Option Questions.OriginalBias := none
+def nandaoOriginalBias : Option Question.OriginalBias := none
 
 /-- `nandaoFelicitous` entails `evidenceSupports`, connecting the felicity
 predicate to `nandaoContextualEvidence` and the empirical generalization

--- a/Linglib/Syntax/Minimalist/LeftPeriphery.lean
+++ b/Linglib/Syntax/Minimalist/LeftPeriphery.lean
@@ -8,7 +8,7 @@ import Linglib.Fragments.English.Predicates.Verbal
 `[SAP SA_ASK [PerspP PRO Persp_CQ [CP C_WH [TP …]]]]`: clause-typing at C,
 where a proposition becomes a set of propositions (`WHFeature`); centering at
 PerspP, which introduces a perspectival center who may not know the answer
-(`Questions.PossiblyIgnorant`); and the illocutionary act at SAP. Embedding
+(`Question.PossiblyIgnorant`); and the illocutionary act at SAP. Embedding
 predicates select up to one of the layers (`SelectionClass`, read off a
 lexical entry by `deriveSelectionClass`): rogatives take CP only, PerspP, or
 SAP, responsives take CP and, where their meaning leaves the center's

--- a/Linglib/Syntax/Minimalist/Probe/Profile.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Profile.lean
@@ -175,7 +175,7 @@ of `Probe.Profile` rather than as a parallel new structure: any Probe with
 `isĀProbe = true` IS an Ā-dependency primitive in Deal's sense.
 
 This avoids cascade: existing consumers of `Probe.Profile` (wh-licensing in
-`Questions.lean`, the keine probes here, language-specific configurations)
+`Question.lean`, the keine probes here, language-specific configurations)
 remain unchanged, and `AbarDep` is a thin wrapper providing only the predicate
 `isĀProbe = true` as a proof-relevant invariant. -/
 

--- a/Linglib/Syntax/Question.lean
+++ b/Linglib/Syntax/Question.lean
@@ -40,7 +40,7 @@ WordOrder).
   it at `C` with PerspP-shift. `QuestionProfile` is silent on this — see
   `Studies/Dayal2025.lean`,
   `Studies/Holmberg2016.lean`, and
-  `Syntax/Minimalist/Questions.lean` for competing analyses.
+  `Syntax/Minimalist/Question.lean` for competing analyses.
 
 ## WALS aggregates
 


### PR DESCRIPTION
`Questions` was a directory namespace declared by `Semantics/Questions/{Exhaustivity,Bias,Closure,Probabilistic}.lean` and opened beside the type namespace `Question` in 35 files (`open Question Questions`); namespaces follow the main type, so it is folded into `Question`.

- Two name collisions resolved first: Closure's finite conjunction `conj` (with `mem_conj`, `mem_conj_iff_subset`, `conj_singleton`, `conj_mem_conjClosure`, and Fox2018's `conj_subset_conj_iff`/`cell_conj`) becomes `conjFamily`, and Probabilistic's PMF-relative `IsRelevantTo` becomes `IsRelevantToUnder`, distinct from Resolution's `Question.IsRelevantTo`
- Mechanical otherwise: `namespace`/`end Questions` → `Question`, `Questions.x` → `Question.x`, `open … Questions` deduplicated; import paths and the per-language fragment namespaces (`English.Questions`, …) untouched
- Verified with a whole-library incremental build
