### PR TITLE
refactor(Studies/GiulianelliEtAl2026): alternatives over a forecast horizon

### DIFF
--- a/Linglib/Studies/GiulianelliEtAl2026.lean
+++ b/Linglib/Studies/GiulianelliEtAl2026.lean
@@ -1,105 +1,191 @@
-import Linglib.Processing.Expectation.LanguageModel
+import Mathlib.Data.Fintype.Vector
+import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import Linglib.Processing.Expectation.InformationValue
-import Mathlib.Probability.ProbabilityMassFunction.Monad
 
 /-!
-# Giulianelli, Wallbridge, Cotterell & Fernández (2026)
-[giulianelli-etal-2026]
+# Giulianelli, Wallbridge, Cotterell and Fernández (2026): Incremental Alternative Sampling as a Lens into the Temporal and Representational Resolution of Linguistic Prediction
 
-Incremental alternative sampling as a lens into the temporal and
-representational resolution of linguistic prediction.
-*Journal of Memory and Language*, 148, 104715.
+This file formalizes the incremental alternative sampling (IAS) family of [giulianelli-etal-2026]:
+a comprehender samples continuations of the context from a language model over a forecast horizon
+of `h` symbols (`gram`), and the generalised surprisal of the next unit is a warping of the expected
+score of the target against those alternatives (`genSurprisalH`, the horizon-`h` form of
+[giulianelli-opedal-cotterell-2024]'s definition in `Processing/Expectation/InformationValue.lean`).
+Standard surprisal is the member with the negative logarithm and the prefix indicator at every
+horizon, because the alternatives' first symbol is distributed as the model's next symbol
+(`map_head_gram`, `sum_prefixIndicator`, `genSurprisalH_indicator`); it thus evaluates alternatives
+by lexical identity alone, and the discrete distance shows what this conflates, since information
+value with it is the probability of error (`informationValue1_discrete`). Incremental information
+value replaces the indicator by a representational distance between each alternative and the
+observed unit followed by the alternatives sampled after it, the double expectation of the paper's
+definition (`iiv`), whose horizon-one case is the information value of the substrate (`iiv_zero`).
 
-## What this study contributes
+## Implementation notes
 
-The paper introduces **incremental alternative sampling (IAS)**, a
-generalisation of surprisal theory in which a comprehender continually
-samples plausible continuations of partial linguistic input and
-quantifies predictive uncertainty as the representational distance
-between alternatives generated before vs. after observing the next unit.
+* Alternatives are `h`-grams of `Option Voc`, `none` standing for end of string and padding the
+  continuation after it, so that expectations are finite sums over a `Fintype`.
+* The alternative-set reformulation with mean, minimum and maximum summary statistics, and its
+  reduction to the single-alternative definition under the mean, are not formalized; nor are the
+  representation functions, which the paper takes from a Transformer's layers and which enter
+  here only through the distance.
+* The paper's regression results, which horizon and layer best predict cloze probability, the
+  N400 and P600, and eye-tracked and self-paced reading times, are empirical fits and stay in
+  prose: explicit predictability peaks at horizon one and lexical representations, the ERP
+  components at horizon two, and self-paced reading of multi-sentence stimuli at longer horizons.
 
-Two structural claims sit at the formal core:
+## References
 
-1. **Standard surprisal is a special case** of the IAS family — the
-   instance with warping `−log` and indicator scoring at horizon 1.
-   Formalised in `Processing.PredictiveUncertainty.IAS` as
-   `standardSurprisal_denotes_surprisal`.
-
-2. **IAS is strictly more expressive than surprisal** — fixing the
-   language model and target, the IAS value depends on the choice of
-   distance / representation function in a way that surprisal cannot
-   capture. Formalised below as
-   `informationValue1_not_determined_by_surprisal`.
-
-## What this file does NOT formalise
-
-The paper's empirical findings — which (forecast horizon, layer)
-combinations best predict cloze probability, N400, P600, eye-tracked
-reading times, self-paced reading times — are regression-coefficient
-maxima from analyses on GPT-2 hidden states. They are not deductive
-claims and should not be encoded as Lean theorems.
-
-For the record, the paper reports (with sources cited as
-[giulianelli-etal-2026]):
-
-- Explicit predictability measures (cloze probability, predictability
-  ratings, cloze surprisal) peak at horizon h = 1 with representations
-  closest to lexical identity (embedding and final layers).
-- N400 and P600 ERP components peak at h = 2; N400 is best predicted by
-  the embedding layer, P600 by intermediate layers.
-- Self-paced reading time in multi-sentence stimuli (Natural Stories)
-  benefits from substantially longer horizons than sentence-level
-  stimuli, and correlates with low-to-intermediate layers.
-- The full IAS model outperforms standard surprisal for most measures,
-  with particularly strong gains for cloze probability, N400, and
-  multi-sentence self-paced reading.
-- Under the d^min summary statistic, surprisal correlates most strongly
-  with intermediate layers at h = 3–5 (Pearson up to 0.81), suggesting
-  surprisal's predictability is closest to a best-case (closest-
-  hypothesis) notion.
-- The directional hypothesis for P600 was refuted (negative observed
-  relationship despite predicted positive).
-
-These findings live in prose because their formal content is the
-underlying IAS family — already formalised in `IAS.lean` — together
-with the empirical question of which configuration best fits any given
-dataset. Linglib formalises the *parameter space* of processing theories,
-not the empirical-fit tables produced by analysing them on specific
-neural networks.
+* [giulianelli-etal-2026]
+* [giulianelli-opedal-cotterell-2024]
+* [levy-2008]
 -/
 
 namespace GiulianelliEtAl2026
 
-open Processing.PredictiveUncertainty
-open Processing.LanguageModel (LangModel)
+open Processing.PredictiveUncertainty Processing.LanguageModel Finset
 
--- ============================================================================
--- §1: IAS is strictly more expressive than surprisal
--- ============================================================================
+variable {Voc : Type*}
 
-/-- A trivial language model over `Unit` with point-mass on the unique
-symbol. Used as a witness in the strict-generalization theorem below. -/
-noncomputable def trivialLM : LangModel Unit where
-  next _ := PMF.pure (some ())
+/-! ### Sampling alternatives over a forecast horizon -/
 
-/-- **Strict generalization**: fixing the language model, context, and
-target, the IAS value at horizon 1 depends on the choice of distance
-function. Two distinct distances yield distinct IAS values, while the
-classical surprisal of the target is unchanged.
+/-- The alternatives of horizon `h`: `h` symbols sampled autoregressively from the model, `none`
+for end of string and padding the continuation after it. -/
+noncomputable def gram (lm : LangModel Voc) : List Voc → (h : ℕ) → PMF (List.Vector (Option Voc) h)
+  | _, 0 => PMF.pure List.Vector.nil
+  | c, h + 1 => (lm.next c).bind λ
+    | none => PMF.pure (List.Vector.replicate (h + 1) none)
+    | some w => (gram lm (c ++ [w]) h).map (List.Vector.cons (some w))
 
-This is the formal content of [giulianelli-etal-2026]'s claim that
-"the generalised definition of surprisal exposes two potential limitations
-of the standard surprisal model": surprisal collapses representational
-structure that IAS preserves. The paper's empirical case for IAS rests
-on this structural difference being psycholinguistically meaningful;
-this theorem records that the difference exists at the level of the
-mathematical objects, independently of any empirical fit. -/
-theorem informationValue1_not_determined_by_surprisal :
-    ∃ (d₁ d₂ : Option Unit → Unit → ℝ),
-      informationValue1 trivialLM d₁ [] () ≠
-      informationValue1 trivialLM d₂ [] () := by
-  refine ⟨fun _ _ => 0, fun _ _ => 1, ?_⟩
-  unfold informationValue1 trivialLM
-  simp
+/-- The first symbol of an alternative is distributed as the model's next symbol. -/
+theorem map_head_gram (lm : LangModel Voc) (c : List Voc) (h : ℕ) :
+    (gram lm c (h + 1)).map List.Vector.head = lm.next c := by
+  simp only [gram, PMF.map_bind]
+  conv_rhs => rw [← PMF.bind_pure (lm.next c)]
+  congr 1
+  funext o
+  cases o with
+  | none => simp [PMF.pure_map, List.Vector.replicate_succ]
+  | some w =>
+    rw [PMF.map_comp]
+    have hc : (List.Vector.head ∘ List.Vector.cons (some w) :
+        List.Vector (Option Voc) h → Option Voc) = Function.const _ (some w) :=
+      funext λ v => List.Vector.head_cons _ v
+    rw [hc, PMF.map_const]
+
+/-- Alternatives of horizon one are the model's next symbols. -/
+theorem gram_one (lm : LangModel Voc) (c : List Voc) :
+    gram lm c 1 = (lm.next c).map (λ o => List.Vector.cons o List.Vector.nil) := by
+  rw [gram, ← PMF.bind_pure_comp]
+  congr 1
+  funext o
+  cases o with
+  | none => rfl
+  | some w => simp [gram, PMF.pure_map]
+
+variable [Fintype Voc] [DecidableEq Voc]
+
+/-- Generalised surprisal at horizon `h`: a warping of the expected score of the target against
+the sampled alternatives. -/
+noncomputable def genSurprisalH (lm : LangModel Voc) (h : ℕ) (warp : ℝ → ℝ)
+    (score : List.Vector (Option Voc) h → Voc → List Voc → ℝ) (c : List Voc) (w : Voc) : ℝ :=
+  warp (∑ a, (gram lm c h a).toReal * score a w c)
+
+/-- The prefix indicator of surprisal's scoring function: `1` when the alternative starts with the
+target. -/
+def prefixIndicator {h : ℕ} (w : Voc) (a : List.Vector (Option Voc) (h + 1)) : ℝ :=
+  if a.head = some w then 1 else 0
+
+/-- The expected prefix indicator is the next-symbol probability, at every horizon. -/
+theorem sum_prefixIndicator (lm : LangModel Voc) (c : List Voc) (h : ℕ) (w : Voc) :
+    ∑ a, (gram lm c (h + 1) a).toReal * prefixIndicator w a = (lm.nextProb c w).toReal := by
+  have key : ∀ a : List.Vector (Option Voc) (h + 1),
+      (gram lm c (h + 1) a).toReal * prefixIndicator w a =
+        (if some w = a.head then gram lm c (h + 1) a else 0).toReal := by
+    intro a
+    unfold prefixIndicator
+    by_cases ha : a.head = some w
+    · simp [ha]
+    · simp [ha, Ne.symm ha]
+  simp_rw [key]
+  rw [← ENNReal.toReal_sum (λ a _ => by split_ifs <;> simp [PMF.apply_ne_top])]
+  congr 1
+  rw [LangModel.nextProb, ← map_head_gram lm c h, PMF.map_apply, tsum_fintype]
+  exact Finset.sum_congr rfl λ a _ => by congr
+
+/-- Standard surprisal is the generalised surprisal with the negative logarithm and the prefix
+indicator, at every horizon. -/
+theorem genSurprisalH_indicator (lm : LangModel Voc) (c : List Voc) (h : ℕ) (w : Voc) :
+    genSurprisalH lm (h + 1) (λ x => -Real.log x) (λ a w _ => prefixIndicator w a) c w =
+      lm.surprisal c w := by
+  unfold genSurprisalH LangModel.surprisal
+  rw [sum_prefixIndicator]
+
+/-! ### What the indicator conflates -/
+
+/-- The discrete distance on next symbols: an alternative is accurate only when identical to the
+target. -/
+def discrete (o : Option Voc) (w : Voc) : ℝ := if o = some w then 0 else 1
+
+/-- Information value with the discrete distance is the probability of error, `1 − p(w | c)`: the
+alternatives' similarity to the target counts for nothing, as under surprisal. -/
+theorem informationValue1_discrete (lm : LangModel Voc) (c : List Voc) (w : Voc) :
+    informationValue1 lm discrete c w = 1 - (lm.nextProb c w).toReal := by
+  unfold informationValue1 discrete
+  have h1 : ∑ o : Option Voc, ((lm.next c) o).toReal = 1 := by
+    have h := (lm.next c).tsum_coe
+    rw [tsum_fintype] at h
+    rw [← ENNReal.toReal_sum (λ _ _ => PMF.apply_ne_top _ _), h, ENNReal.toReal_one]
+  have h2 : ∀ o : Option Voc, ((lm.next c) o).toReal * (if o = some w then 0 else 1) =
+      ((lm.next c) o).toReal - (if o = some w then ((lm.next c) o).toReal else 0) := by
+    intro o
+    split_ifs <;> ring
+  simp_rw [h2, Finset.sum_sub_distrib, h1, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  rfl
+
+/-! ### Incremental information value -/
+
+/-- Incremental information value at horizon `h + 1`: the expected representational distance
+between an alternative sampled before the target and the target followed by an alternative
+sampled after it, the paper's double expectation. -/
+noncomputable def iiv (lm : LangModel Voc) (h : ℕ)
+    (d : List.Vector (Option Voc) (h + 1) → List.Vector (Option Voc) (h + 1) → ℝ)
+    (c : List Voc) (w : Voc) : ℝ :=
+  ∑ a, (gram lm c (h + 1) a).toReal *
+    ∑ a', (gram lm (c ++ [w]) h a').toReal * d a (List.Vector.cons (some w) a')
+
+/-- Next symbols and alternatives of horizon one correspond. -/
+def singletonEquiv : Option Voc ≃ List.Vector (Option Voc) 1 where
+  toFun o := List.Vector.cons o List.Vector.nil
+  invFun a := a.head
+  left_inv o := List.Vector.head_cons o List.Vector.nil
+  right_inv a := by
+    symm
+    rw [List.Vector.eq_cons_iff]
+    exact ⟨rfl, List.Vector.singleton_tail a⟩
+
+/-- At horizon one, incremental information value is the information value of the substrate,
+with the distance read on the single symbols. -/
+theorem iiv_zero (lm : LangModel Voc)
+    (d : List.Vector (Option Voc) 1 → List.Vector (Option Voc) 1 → ℝ) (c : List Voc) (w : Voc) :
+    iiv lm 0 d c w = informationValue1 lm (λ o w' => d (singletonEquiv o) (singletonEquiv (some w')))
+      c w := by
+  unfold iiv informationValue1
+  show ∑ a : List.Vector (Option Voc) 1, (gram lm c 1 a).toReal *
+      ∑ a' : List.Vector (Option Voc) 0, (gram lm (c ++ [w]) 0 a').toReal *
+        d a (List.Vector.cons (some w) a') = _
+  have inner : ∀ a : List.Vector (Option Voc) 1,
+      ∑ a' : List.Vector (Option Voc) 0, (gram lm (c ++ [w]) 0 a').toReal *
+        d a (List.Vector.cons (some w) a') = d a (singletonEquiv (some w)) := by
+    intro a
+    rw [Fintype.sum_eq_single List.Vector.nil (λ a' ha' => absurd (Subsingleton.elim a' _) ha')]
+    show ((PMF.pure List.Vector.nil : PMF (List.Vector (Option Voc) 0)) List.Vector.nil).toReal *
+      _ = _
+    rw [PMF.pure_apply_self, ENNReal.toReal_one, one_mul]
+    rfl
+  simp_rw [inner, gram_one]
+  rw [← singletonEquiv.sum_comp]
+  refine Finset.sum_congr rfl λ o _ => ?_
+  congr 2
+  rw [PMF.map_apply, tsum_fintype]
+  simp [singletonEquiv, List.Vector.eq_cons_iff, List.Vector.head_cons, Finset.sum_ite_eq]
 
 end GiulianelliEtAl2026

--- a/references.bib
+++ b/references.bib
@@ -27849,7 +27849,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/GiulianelliEtAl2026.lean}
+  sources   = {Processing/Expectation/Defs.lean;Processing/Expectation/InformationValue.lean;Processing/Expectation/LanguageModel.lean;Processing/Memory/SurprisalTradeoff.lean;Studies/GiulianelliEtAl2026.lean}
 }
 @inproceedings{giulianelli-opedal-cotterell-2024,
   author    = {Giulianelli, Mario and Opedal, Andreas and Cotterell, Ryan},
@@ -27860,7 +27860,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {false},
   role      = {foundational},
-  sources   = {Processing/Expectation/InformationValue.lean}
+  sources   = {Processing/Expectation/InformationValue.lean;Studies/GiulianelliEtAl2026.lean}
 }
 @article{levy-2008,
   author    = {Levy, Roger},
@@ -27874,7 +27874,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Levy2008.lean}
+  sources   = {Core/InformationTheory/KullbackLeibler/Cond.lean;Core/Probability/Constructions.lean;Processing/Expectation/Defs.lean;Processing/Expectation/InformationValue.lean;Processing/Expectation/LanguageModel.lean;Processing/Expectation/PrefixProbability.lean;Studies/GiulianelliEtAl2026.lean;Studies/Hale2001.lean;Studies/Levy2008.lean;Studies/PaapeVasishth2026.lean}
 }
 @article{smith-levy-2013,
   author    = {Smith, Nathaniel J. and Levy, Roger},


### PR DESCRIPTION
Recuts `GiulianelliEtAl2026` from a one-witness file into the paper's incremental alternative sampling family: alternatives of forecast horizon `h` are sampled autoregressively from a `LangModel` as `h`-grams over a `Fintype` (`gram`), generalised surprisal at horizon `h` is a warping of the expected score against them (`genSurprisalH`), and standard surprisal is the member with the negative logarithm and the prefix indicator at every horizon, because the alternatives' first symbol is distributed as the model's next symbol (`map_head_gram`, `sum_prefixIndicator`, `genSurprisalH_indicator`); incremental information value is the paper's double expectation over alternatives sampled before and after the target (`iiv`), whose horizon-one case is the substrate's `informationValue1` (`iiv_zero`), and information value with the discrete distance is the probability of error `1 − p(w | c)` (`informationValue1_discrete`).

- Header in the mathlib register; the regression findings (which horizon and layer predict which measure) stay in one prose note per the processing-scope doctrine
- The old `trivialLM` witness theorem is dropped: `informationValue1_discrete` and `iiv` state the dependence on the distance directly
- Not formalized, noted: the alternative-set reformulation and its mean/min/max summary statistics
