### PR TITLE
refactor(Studies/Glass2023): cause under uncertainty over Boolean models

### DIFF
--- a/Linglib/Studies/Glass2023.lean
+++ b/Linglib/Studies/Glass2023.lean
@@ -2,145 +2,278 @@ import Linglib.Semantics.Causation.SEM.Counterfactual
 import Linglib.Studies.NadathurLauer2020
 
 /-!
-# Glass 2023: Anna Karenina Principle and *cause*
-[glass-2023b]
+# Glass (2023): Using the Anna Karenina Principle to explain why *cause* favors negative-sentiment complements
 
-Using the Anna Karenina Principle to explain why *cause* favors
-negative-sentiment complements. Semantics and Pragmatics 16, Article 6.
+This file formalizes [glass-2023b]'s account of why *cause* collocates with undesirable outcomes.
+Over a deterministic causal model ([halpern-pearl-2005]), a value of a variable is locally
+sufficient for a value of a downstream variable when some setting of the other variables
+guarantees it, the sufficient sets of [mackie-1965], and globally sufficient when every setting
+does; necessity is the mirror image, the absence of the cause being sufficient for the absence of
+the effect (`GloballySufficient`, `LocallySufficient`, `GloballyNecessary`, `LocallyNecessary`,
+`globallyNecessary_iff`). The global notions entail the local ones
+(`LocallySufficient.of_globally`, `LocallyNecessary.of_globally`). *C causes E* asserted on a
+state of knowledge requires that the effect develop in every settlement of what is unknown
+(`Cause`), so knowing the cause alone it is assertable exactly when the cause is globally
+sufficient (`cause_extend_empty_iff`): a globally sufficient cause licenses *cause* under
+uncertainty, a merely necessary one only under full information, which is the asymmetry of the
+paper's Table 2, worked out on its lightbulb (`Light`). Since the Anna Karenina Principle assigns
+desired outcomes conjunctive models, in which each factor is necessary but insufficient, and
+undesired ones disjunctive models, in which each factor suffices, *C causes E* is true in more
+states of knowledge when E is bad. Glass's *cause* asserts only local sufficiency where
+[nadathur-lauer-2020] make it assert necessity, so the two diverge on the latter's bus scenario
+(`glass_nl_diverge_on_bus`).
 
-## Core contributions
+## Implementation notes
 
-1. Cross-cuts necessity/sufficiency into **local** (∃ background) vs
-   **global** (∀ backgrounds) variants.
+* Backgrounds are the substrate's partial valuations developed by the eager deterministic
+  dynamics, which settles an unspecified exogenous variable by its mechanism's default; "no matter
+  what happens to any other variable" quantifies over all backgrounds leaving the effect open.
+* The lightbulb of the paper's figures, on exactly when both switches are, is the conjunctive
+  model for the light being on and the disjunctive model for its being off.
+* The derivation of the Anna Karenina Principle from strategic model construction, the experiment
+  supporting it (wanted outcomes drew "you had to do everything right" far more often than
+  unwanted ones) and the corpus skew that motivates the paper stay in prose.
 
-2. Shows that **global sufficiency licenses inference under uncertainty**
-   while global necessity does not — the key asymmetry (Table 2).
+## References
 
-3. Proposes that *cause* **entails** local sufficiency and only
-   **implicates** local necessity — reversing [nadathur-lauer-2020]'s
-   assignment where *cause* entails necessity.
-
-4. Links the asymmetry to sentiment via the **Anna Karenina Principle**
-   (Diamond 1997): desirable outcomes get conjunctive models
-   (multiple necessary factors), undesirable outcomes get disjunctive
-   models (single sufficient factors), so *C causes E* is true in
-   more contexts when *E* is bad.
-
-## V2 substrate
-
-This file uses V2 `BoolSEM` directly. The legacy `CausalDynamics`-based
-formalization (576 LOC including conjunctive/disjunctive helper lemmas
-and the Anna Karenina sentiment theorems) was deleted in Phase D-H; the
-core local/global concepts are re-stated here over `BoolSEM`. The
-sentiment-asymmetry theorems are recoverable from this scaffolding when
-needed.
+* [glass-2023b]
+* [nadathur-lauer-2020]
+* [halpern-pearl-2005]
+* [mackie-1965]
 -/
 
 namespace Glass2023
 
-open Causation Causation.Mechanism Causation.SEM
+open Causation Causation.SEM Causation.Mechanism
 
-/-! ## Local vs Global Sufficiency / Necessity (defs 8–11)
+section General
 
-Glass's quartet of distinctions over `BoolSEM`:
+variable {V : Type*} (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
 
-- `GloballySufficient`: setting cause = true develops effect = true
-  in every background where cause and effect are undetermined.
-- `LocallySufficient`: there exists some such background.
-- `GloballyNecessary`: in every background where cause and effect
-  are undetermined, effect does NOT develop.
-- `LocallyNecessary`: there exists some such background.
+/-! ### Local and global necessity and sufficiency -/
 
-The local/global distinction matters because Glass argues that *cause*
-asserts only local sufficiency but pragmatically implicates the
-stronger global form. -/
+/-- `C = c` is globally sufficient for `E = e`: in every background leaving `E` open in which
+`C = c`, the model develops `E = e`. -/
+def GloballySufficient (C : V) (c : Bool) (E : V) (e : Bool) : Prop :=
+  ∀ bg : Valuation (λ _ : V => Bool),
+    bg.get E = none → bg.hasValue C c → (M.developDet bg).hasValue E e
 
-/-- **Globally sufficient** ([glass-2023b] def 11). -/
-noncomputable def GloballySufficient {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (cause effect : V) : Prop :=
-  ∀ bg : Valuation (fun _ : V => Bool),
-    bg.get cause = none → bg.get effect = none →
-    (M.developDet (bg.extend cause true)).hasValue effect true
+/-- `C = c` is locally sufficient for `E = e`: in some background leaving `E` open in which
+`C = c`, the model develops `E = e`. -/
+def LocallySufficient (C : V) (c : Bool) (E : V) (e : Bool) : Prop :=
+  ∃ bg : Valuation (λ _ : V => Bool),
+    bg.get E = none ∧ bg.hasValue C c ∧ (M.developDet bg).hasValue E e
 
-/-- **Locally sufficient** ([glass-2023b] def 10). -/
-noncomputable def LocallySufficient {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (cause effect : V) : Prop :=
-  ∃ bg : Valuation (fun _ : V => Bool),
-    bg.get effect = none ∧
-    (M.developDet (bg.extend cause true)).hasValue effect true
+/-- `C = c` is globally necessary for `E = e`: without it, in every background leaving `E` open,
+`E = e` fails. -/
+def GloballyNecessary (C : V) (c : Bool) (E : V) (e : Bool) : Prop :=
+  ∀ bg : Valuation (λ _ : V => Bool),
+    bg.get E = none → bg.hasValue C (!c) → (M.developDet bg).hasValue E (!e)
 
-/-- **Globally necessary** ([glass-2023b] def 9). -/
-noncomputable def GloballyNecessary {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (cause effect : V) : Prop :=
-  ∀ bg : Valuation (fun _ : V => Bool),
-    bg.get cause = none → bg.get effect = none →
-    ¬ (M.developDet bg).hasValue effect true
+/-- `C = c` is locally necessary for `E = e`: without it, in some background leaving `E` open,
+`E = e` fails. -/
+def LocallyNecessary (C : V) (c : Bool) (E : V) (e : Bool) : Prop :=
+  ∃ bg : Valuation (λ _ : V => Bool),
+    bg.get E = none ∧ bg.hasValue C (!c) ∧ (M.developDet bg).hasValue E (!e)
 
-/-- **Locally necessary** ([glass-2023b] def 8). -/
-noncomputable def LocallyNecessary {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (cause effect : V) : Prop :=
-  ∃ bg : Valuation (fun _ : V => Bool),
-    bg.get cause = none ∧ bg.get effect = none ∧
-    ¬ (M.developDet bg).hasValue effect true
+/-- *C causes E* asserted on the state of knowledge `k`: the cause is known, and the effect
+develops in every background that settles the unknown variables, keeping what is known. -/
+def Cause (k : Valuation (λ _ : V => Bool)) (C : V) (c : Bool) (E : V) (e : Bool) : Prop :=
+  k.hasValue C c ∧
+    ∀ bg : Valuation (λ _ : V => Bool), (∀ v x, k.hasValue v x → bg.hasValue v x) →
+      bg.get E = none → (M.developDet bg).hasValue E e
 
-/-! ## Entailment: Global → Local
+variable {M} {C E : V} {c e : Bool} {k : Valuation (λ _ : V => Bool)}
 
-Both global → local entailments are immediate: instantiate the universal
-with `Valuation.empty`, which trivially has cause and effect undetermined. -/
+/-- Necessity is the mirror image of sufficiency: the absence of a necessary cause suffices for
+the absence of the effect. -/
+theorem globallyNecessary_iff :
+    GloballyNecessary M C c E e ↔ GloballySufficient M C (!c) E (!e) := Iff.rfl
 
-/-- Global sufficiency entails local sufficiency ([glass-2023b] (22a)). -/
-theorem global_sufficient_implies_local {V : Type*} [Fintype V] [DecidableEq V]
-    {M : BoolSEM V} [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    {cause effect : V} (h : GloballySufficient M cause effect) :
-    LocallySufficient M cause effect :=
-  ⟨Valuation.empty, rfl, h Valuation.empty rfl rfl⟩
+theorem locallyNecessary_iff :
+    LocallyNecessary M C c E e ↔ LocallySufficient M C (!c) E (!e) := Iff.rfl
 
-/-- Global necessity entails local necessity ([glass-2023b] (21a)). -/
-theorem global_necessary_implies_local {V : Type*} [Fintype V] [DecidableEq V]
-    {M : BoolSEM V} [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    {cause effect : V} (h : GloballyNecessary M cause effect) :
-    LocallyNecessary M cause effect :=
-  ⟨Valuation.empty, rfl, rfl, h Valuation.empty rfl rfl⟩
+/-- A globally sufficient cause licenses *cause* whatever else is known or unknown. -/
+theorem Cause.of_globallySufficient (h : GloballySufficient M C c E e) (hk : k.hasValue C c) :
+    Cause M k C c E e :=
+  ⟨hk, λ bg hkb hE => h bg hE (hkb C c hk)⟩
 
-/-! ## Glass's *cause* (def 12)
+variable [DecidableEq V]
 
-Glass argues that *cause* truth-conditionally requires only LOCAL
-sufficiency — `causeSemGlass` collapses to `BoolSEM.causallySufficient`.
-This is truth-conditionally identical to [nadathur-lauer-2020]'s
-*make*; the difference is that Glass relegates necessity to pragmatic
-implicature. -/
+/-- Global sufficiency entails local sufficiency (22a). -/
+theorem LocallySufficient.of_globally (hCE : C ≠ E) (h : GloballySufficient M C c E e) :
+    LocallySufficient M C c E e :=
+  ⟨Valuation.empty.extend C c, by rw [Valuation.extend_get_ne hCE.symm]; rfl,
+    Valuation.extend_get_same _ _ _,
+    h _ (by rw [Valuation.extend_get_ne hCE.symm]; rfl) (Valuation.extend_get_same _ _ _)⟩
 
-/-- Glass's proposed truth condition for "C causes E" ([glass-2023b]
-    def 12): C is causally sufficient for E in the actual background. -/
-abbrev causeSemGlass {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (bg : Valuation (fun _ : V => Bool)) (cause effect : V) : Prop :=
-  Causation.BoolSEM.causallySufficient M bg cause effect
+/-- Global necessity entails local necessity (21a). -/
+theorem LocallyNecessary.of_globally (hCE : C ≠ E) (h : GloballyNecessary M C c E e) :
+    LocallyNecessary M C c E e :=
+  LocallySufficient.of_globally hCE h
 
-/-- Glass's *cause* is truth-conditionally identical to N&L's *make*
-    (`causallySufficient`). The difference is pragmatic. -/
-theorem glass_cause_is_causallySufficient {V : Type*} [Fintype V] [DecidableEq V]
-    (M : BoolSEM V) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    (bg : Valuation (fun _ : V => Bool)) (cause effect : V) :
-    causeSemGlass M bg cause effect ↔
-      Causation.BoolSEM.causallySufficient M bg cause effect := Iff.rfl
+/-- Knowing the cause alone, *C causes E* is assertable exactly when the cause is globally
+sufficient: the asymmetry of the paper's Table 2. -/
+theorem cause_extend_empty_iff (hCE : C ≠ E) :
+    Cause M (Valuation.empty.extend C c) C c E e ↔ GloballySufficient M C c E e := by
+  constructor
+  · rintro ⟨-, h⟩ bg hE hC
+    refine h bg (λ v x hv => ?_) hE
+    by_cases hvC : v = C
+    · subst hvC
+      unfold Valuation.hasValue at hv
+      rw [Valuation.extend_get_same, Option.some.injEq] at hv
+      subst hv
+      exact hC
+    · unfold Valuation.hasValue at hv
+      rw [Valuation.extend_get_ne hvC] at hv
+      exact absurd hv (by simp)
+  · exact λ h => Cause.of_globallySufficient h (Valuation.extend_get_same _ _ _)
 
-/-- **Glass vs N&L diverge on the Bus scenario**: "Ava's training caused
-    Lia to take the bus" is true on Glass's sufficiency-based *cause* but
-    false on [nadathur-lauer-2020]'s necessity-based *cause* — the same
-    verb, the same scenario, opposite predictions. The two conjuncts are
-    [nadathur-lauer-2020]'s own (33a)/(33b) verdicts, repackaged as the
-    rival-accounts comparison this paper draws. -/
+end General
+
+/-! ### The lightbulb (Figure 2, Tables 1 and 2)
+
+Two switches and a light that is on exactly when both are: each switch being on is necessary but
+insufficient for the light to be on, and each being off suffices for it to be off. -/
+
+namespace Light
+
+/-- The two switches and the light. -/
+inductive V
+  | S1
+  | S2
+  | L
+  deriving DecidableEq, Fintype, Repr
+
+def graph : CausalGraph V := ⟨λ | .S1 => ∅ | .S2 => ∅ | .L => {.S1, .S2}⟩
+
+def depth : V → ℕ := λ | .S1 => 0 | .S2 => 0 | .L => 1
+
+private lemma depth_lt : ∀ {u v : V}, u ∈ graph.parents v → depth u < depth v := by
+  intro u v h
+  revert h
+  cases u <;> cases v <;> decide
+
+private def ranking : CausalGraph.Ranking graph := ⟨depth, depth_lt⟩
+
+instance : CausalGraph.IsDAG graph := ranking.isDAG
+
+/-- The light is on exactly when both switches are. -/
+noncomputable def light : BoolSEM V :=
+  { graph := graph
+    mech := λ
+      | .S1 => const (G := graph) false
+      | .S2 => const (G := graph) false
+      | .L => deterministic (λ ρ => ρ ⟨.S1, by simp [graph]⟩ && ρ ⟨.S2, by simp [graph]⟩) }
+
+instance : CausalGraph.IsDAG light.graph := inferInstanceAs (CausalGraph.IsDAG graph)
+
+noncomputable instance : SEM.IsDeterministic light where
+  mech_det v := match v with
+    | .S1 | .S2 => inferInstanceAs (Mechanism.IsDeterministic (const _))
+    | .L => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+
+/-- The light develops as the conjunction of the developed switches. -/
+theorem developDetVtx_L {bg : Valuation (λ _ : V => Bool)} (h : bg.get .L = none) :
+    developDetVtx light bg .L = (developDetVtx light bg .S1 && developDetVtx light bg .S2) := by
+  rw [developDetVtx_undet _ _ _ h]
+  rfl
+
+/-- Switch 1 being off is globally sufficient for the light to be off. -/
+theorem s1_off_globallySufficient : GloballySufficient light .S1 false .L false := by
+  intro bg hL hS1
+  rw [developDet_hasValue_iff, developDetVtx_L hL, developDetVtx_extended _ _ _ _ hS1]
+  rfl
+
+/-- Switch 1 being on is globally necessary for the light to be on: the mirror image. -/
+theorem s1_on_globallyNecessary : GloballyNecessary light .S1 true .L true :=
+  s1_off_globallySufficient
+
+/-- The background with switch 1 on and switch 2 off. -/
+noncomputable def s1OnS2Off : Valuation (λ _ : V => Bool) :=
+  Valuation.empty.extend .S1 true |>.extend .S2 false
+
+/-- Switch 1 being on is not globally sufficient for the light to be on. -/
+theorem s1_on_not_globallySufficient : ¬ GloballySufficient light .S1 true .L true := by
+  intro h
+  have hL : s1OnS2Off.get .L = none := by
+    rw [s1OnS2Off, Valuation.extend_get_ne (show (V.L : V) ≠ .S2 by decide),
+      Valuation.extend_get_ne (show (V.L : V) ≠ .S1 by decide)]
+    rfl
+  have hS1 : s1OnS2Off.hasValue .S1 true := by
+    unfold Valuation.hasValue
+    rw [s1OnS2Off, Valuation.extend_get_ne (show (V.S1 : V) ≠ .S2 by decide),
+      Valuation.extend_get_same]
+  have hS2 : s1OnS2Off.get .S2 = some false := by
+    rw [s1OnS2Off, Valuation.extend_get_same]
+  have := h s1OnS2Off hL hS1
+  rw [developDet_hasValue_iff, developDetVtx_L hL, developDetVtx_extended _ _ _ _ hS2] at this
+  simp at this
+
+/-- Bottom right of Table 2: knowing only that switch 1 is off, it caused the light to be off. -/
+theorem s1_off_causes_off_uncertain :
+    Cause light (Valuation.empty.extend .S1 false) .S1 false .L false :=
+  (cause_extend_empty_iff (by decide)).2 s1_off_globallySufficient
+
+/-- Bottom left of Table 2: knowing only that switch 1 is on, one cannot say it caused the light
+to be on. -/
+theorem not_s1_on_causes_on_uncertain :
+    ¬ Cause light (Valuation.empty.extend .S1 true) .S1 true .L true :=
+  λ h => s1_on_not_globallySufficient ((cause_extend_empty_iff (by decide)).1 h)
+
+/-- The background with both switches on. -/
+noncomputable def bothOn : Valuation (λ _ : V => Bool) :=
+  Valuation.empty.extend .S1 true |>.extend .S2 true
+
+theorem bothOn_S1 : bothOn.hasValue .S1 true := by
+  unfold Valuation.hasValue
+  rw [bothOn, Valuation.extend_get_ne (show (V.S1 : V) ≠ .S2 by decide),
+    Valuation.extend_get_same]
+
+theorem bothOn_S2 : bothOn.hasValue .S2 true := by
+  unfold Valuation.hasValue
+  rw [bothOn, Valuation.extend_get_same]
+
+/-- Top left of Table 2: with both switches known to be on, switch 1 caused the light to be on. -/
+theorem s1_on_causes_on_certain : Cause light bothOn .S1 true .L true := by
+  refine ⟨bothOn_S1, λ bg hle hL => ?_⟩
+  rw [developDet_hasValue_iff, developDetVtx_L hL,
+    developDetVtx_extended _ _ _ _ (hle _ _ bothOn_S1),
+    developDetVtx_extended _ _ _ _ (hle _ _ bothOn_S2)]
+  rfl
+
+end Light
+
+/-! ### Against necessity-based *cause* -/
+
+namespace Bus
+
+open NadathurLauer2020.Bus
+
+/-- Lia takes the bus when it rains or her bike is gone. -/
+theorem developDetVtx_Bs {bg : Valuation (λ _ : V => Bool)} (h : bg.get .Bs = none) :
+    developDetVtx busSEM bg .Bs =
+      (developDetVtx busSEM bg .Rn || developDetVtx busSEM bg .Bk) := by
+  rw [developDetVtx_undet _ _ _ h]
+  rfl
+
+theorem s_b_Rn : (s_b.extend .Tr true).hasValue .Rn true := by
+  unfold Valuation.hasValue
+  rw [Valuation.extend_get_ne (show (V.Rn : V) ≠ .Tr by decide), s_b, Valuation.extend_get_same]
+
+/-- In the bus scenario, with Ava's visit and the rain forecast known, Ava's training is a
+locally sufficient cause of Lia's taking the bus, so Glass's *cause* accepts "Ava's training
+caused Lia to take the bus", which [nadathur-lauer-2020]'s necessity-based *cause* rejects: the
+same verb, the same scenario, opposite verdicts. -/
 theorem glass_nl_diverge_on_bus :
-    causeSemGlass NadathurLauer2020.Bus.busSEM NadathurLauer2020.Bus.s_b .Tr .Bs ∧
-    ¬ Necessity.causeSem NadathurLauer2020.Bus.busSEM NadathurLauer2020.Bus.s_b
-        .Tr true .Bs true :=
-  ⟨SEM.causallySufficient_of_causallyEntails
-      NadathurLauer2020.Bus.make_felicitous_for_bus.2,
-   NadathurLauer2020.Bus.cause_infelicitous_for_bus⟩
+    Cause busSEM (s_b.extend .Tr true) .Tr true .Bs true ∧
+      ¬ Necessity.causeSem busSEM s_b .Tr true .Bs true := by
+  refine ⟨⟨Valuation.extend_get_same _ _ _, λ bg hle hBs => ?_⟩, cause_infelicitous_for_bus⟩
+  rw [developDet_hasValue_iff, developDetVtx_Bs hBs,
+    developDetVtx_extended _ _ _ _ (hle _ _ s_b_Rn)]
+  rfl
+
+end Bus
 
 end Glass2023

--- a/references.bib
+++ b/references.bib
@@ -2100,7 +2100,7 @@
   role      = {cited},
   doi       = {10.1093/bjps/axi147},
   validated = {true},
-  sources   = {Studies/HardingGerstenbergIcard2025.lean}
+  sources   = {Studies/BellerGerstenberg2025.lean;Studies/Glass2023.lean;Studies/HardingGerstenbergIcard2025.lean}
 }% REF: Baker, Saxe & Tenenbaum (2009). Action Understanding as Inverse Planning.
 @article{geurts-pouscoulous-2009,
   author    = {Geurts, Bart and Pouscoulous, Nausicaa},
@@ -11352,7 +11352,7 @@
   subfield  = {semantics/causation},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/NadathurLauer2020.lean}
+  sources   = {Fragments/English/Predicates/Verbal.lean;Semantics/Causation/CoerciveImplication.lean;Semantics/Causation/Interpretation.lean;Semantics/Causation/Necessity.lean;Semantics/Causation/SEM/Counterfactual.lean;Semantics/Causation/Sufficiency.lean;Semantics/Causation/VerbClass.lean;Semantics/Conditionals/Counterfactual.lean;Studies/CaoWhiteLassiter2025.lean;Studies/Glass2023.lean;Studies/JinKoenig2021.lean;Studies/NadathurLauer2020.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 
 @misc{martin-rose-nichols-2025,
@@ -40585,7 +40585,8 @@
   number    = {4},
   pages     = {245--264},
   subfield  = {philosophy/causation},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Studies/Glass2023.lean}
 }
 
 @book{edwards-1992,


### PR DESCRIPTION
Recuts `Glass2023` from a scaffold of four definitions into the paper's argument: local and global sufficiency and necessity over the substrate's Boolean structural models with necessity as the mirror of sufficiency (`globallyNecessary_iff`), the global-to-local entailments, *C causes E* asserted on a state of knowledge as the effect developing in every settlement of the unknowns (`Cause`), and the Table 2 asymmetry as a theorem: knowing the cause alone, *cause* is assertable exactly when the cause is globally sufficient (`cause_extend_empty_iff`), so a sufficient cause of a bad outcome is assertable under uncertainty while a necessary cause of a good one needs full information.

- The paper's lightbulb is built as a `BoolSEM` (`Light.light`) and its four Table 2 quadrants proved by developing the model (`s1_off_causes_off_uncertain`, `not_s1_on_causes_on_uncertain`, `s1_on_causes_on_certain`), with switch 1 on globally necessary but not globally sufficient for the light being on
- The comparison with Nadathur and Lauer 2020 is restated on their bus scenario with Glass's own truth condition rather than the substrate's `causallySufficient` alias
- Header in the mathlib register; the Anna Karenina experiment and the corpus skew stay in prose
