### PR TITLE
refactor(Studies/Glass2025): two negations of the factive presupposition

### DIFF
--- a/Linglib/Data/Examples/Glass2025.json
+++ b/Linglib/Data/Examples/Glass2025.json
@@ -1,0 +1,394 @@
+[
+  {
+    "id": "glass2025_1a",
+    "source": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(1a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Alex knows there's a meeting.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "There is a meeting.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "know"
+      ],
+      [
+        "state",
+        "p"
+      ]
+    ],
+    "comment": "The inference that there is a meeting projects through questions and negation, (1b)–(1c)."
+  },
+  {
+    "id": "glass2025_2a_p",
+    "source": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(2a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Alex thinks there's a meeting.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "There is a meeting.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "think"
+      ],
+      [
+        "state",
+        "p"
+      ]
+    ],
+    "comment": "Whether there is a meeting depends on Alex's trustworthiness and the plausibility of a meeting."
+  },
+  {
+    "id": "glass2025_2a_unsettled",
+    "source": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(2a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Alex thinks there's a meeting.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "It is open whether there is a meeting.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "think"
+      ],
+      [
+        "state",
+        "unsettled"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "glass2025_2a_notP",
+    "source": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(2a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Alex thinks there's a meeting.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "There is no meeting.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "think"
+      ],
+      [
+        "state",
+        "notP"
+      ]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "glass2025_4_notP",
+    "source": {
+      "bibkey": "glass-2023",
+      "paperLabel": "(4)"
+    },
+    "language": "mand1415",
+    "primaryText": "Māma yǐwéi wǒ bìng le",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Māma",
+        "mom"
+      ],
+      [
+        "yǐwéi",
+        "yǐwéi"
+      ],
+      [
+        "wǒ",
+        "1sg"
+      ],
+      [
+        "bìng",
+        "sick"
+      ],
+      [
+        "le",
+        "asp"
+      ]
+    ],
+    "translation": "Mom is under the impression that I'm sick.",
+    "context": "The speaker faked illness to avoid school.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "yiwei"
+      ],
+      [
+        "state",
+        "notP"
+      ]
+    ],
+    "comment": "Excerpted from Glass 2023, p. 2.",
+    "reportedIn": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(4)"
+    }
+  },
+  {
+    "id": "glass2025_4_p",
+    "source": {
+      "bibkey": "glass-2023",
+      "paperLabel": "(4)"
+    },
+    "language": "mand1415",
+    "primaryText": "Māma yǐwéi wǒ bìng le",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Māma",
+        "mom"
+      ],
+      [
+        "yǐwéi",
+        "yǐwéi"
+      ],
+      [
+        "wǒ",
+        "1sg"
+      ],
+      [
+        "bìng",
+        "sick"
+      ],
+      [
+        "le",
+        "asp"
+      ]
+    ],
+    "translation": "Mom is under the impression that I'm sick.",
+    "context": "The speaker is definitely sick.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "yiwei"
+      ],
+      [
+        "state",
+        "p"
+      ]
+    ],
+    "comment": "Nonsensical if the speaker is definitely sick.",
+    "reportedIn": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(4)"
+    }
+  },
+  {
+    "id": "glass2025_5_notP",
+    "source": {
+      "bibkey": "glass-2023",
+      "paperLabel": "(5)"
+    },
+    "language": "mand1415",
+    "primaryText": "Māma rènwéi wǒ bìng le",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Māma",
+        "mom"
+      ],
+      [
+        "rènwéi",
+        "think"
+      ],
+      [
+        "wǒ",
+        "1sg"
+      ],
+      [
+        "bìng",
+        "sick"
+      ],
+      [
+        "le",
+        "asp"
+      ]
+    ],
+    "translation": "Mom thinks I'm sick.",
+    "context": "The speaker faked illness to avoid school.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "renwei"
+      ],
+      [
+        "state",
+        "notP"
+      ]
+    ],
+    "comment": "Adapted from Glass 2023, p. 2.",
+    "reportedIn": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(5)"
+    }
+  },
+  {
+    "id": "glass2025_5_unsettled",
+    "source": {
+      "bibkey": "glass-2023",
+      "paperLabel": "(5)"
+    },
+    "language": "mand1415",
+    "primaryText": "Māma rènwéi wǒ bìng le",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Māma",
+        "mom"
+      ],
+      [
+        "rènwéi",
+        "think"
+      ],
+      [
+        "wǒ",
+        "1sg"
+      ],
+      [
+        "bìng",
+        "sick"
+      ],
+      [
+        "le",
+        "asp"
+      ]
+    ],
+    "translation": "Mom thinks I'm sick.",
+    "context": "The speaker feels exhausted and thinks she may indeed be sick, citing her mother's belief as evidence.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "renwei"
+      ],
+      [
+        "state",
+        "unsettled"
+      ]
+    ],
+    "comment": "",
+    "reportedIn": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(5)"
+    }
+  },
+  {
+    "id": "glass2025_7",
+    "source": {
+      "bibkey": "glass-2023",
+      "paperLabel": "(7)"
+    },
+    "language": "mand1415",
+    "primaryText": "wǒ bù zhīdào yǒu-méi-yǒu défēn, dànshì zhège qiúyuán yǐwéi défēn le",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "wǒ",
+        "I"
+      ],
+      [
+        "bù",
+        "not"
+      ],
+      [
+        "zhīdào",
+        "know"
+      ],
+      [
+        "yǒu-méi-yǒu",
+        "have-not-have"
+      ],
+      [
+        "défēn",
+        "score"
+      ],
+      [
+        "dànshì",
+        "but"
+      ],
+      [
+        "zhège",
+        "this-cl"
+      ],
+      [
+        "qiúyuán",
+        "ball-player"
+      ],
+      [
+        "yǐwéi",
+        "yǐwéi"
+      ],
+      [
+        "défēn",
+        "score"
+      ],
+      [
+        "le",
+        "asp"
+      ]
+    ],
+    "translation": "I don't know whether the player scored or not, but he's under the impression that he did.",
+    "context": "The athlete caught the ball on the edge of the end zone and celebrates while the referees debate the catch; the speaker does not know whether he scored.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "verb",
+        "yiwei"
+      ],
+      [
+        "state",
+        "unsettled"
+      ]
+    ],
+    "comment": "Glass 2023, p. 6. Odd if the speaker has no reason to question the athlete's belief; a presupposition of not-p would contradict the ignorance expressed in the first clause.",
+    "reportedIn": {
+      "bibkey": "glass-2025",
+      "paperLabel": "(7)"
+    }
+  }
+]

--- a/Linglib/Data/Examples/Glass2025.lean
+++ b/Linglib/Data/Examples/Glass2025.lean
@@ -1,0 +1,180 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Glass2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Glass2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Glass2025.Examples`.
+-/
+
+namespace Glass2025.Examples
+
+open Data.Examples
+
+def ex_1a : LinguisticExample :=
+  { id := "glass2025_1a"
+    source := ⟨"glass-2025", "(1a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Alex knows there's a meeting."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "There is a meeting."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "know"), ("state", "p")]
+    comment := "The inference that there is a meeting projects through questions and negation, (1b)–(1c)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2a_p : LinguisticExample :=
+  { id := "glass2025_2a_p"
+    source := ⟨"glass-2025", "(2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Alex thinks there's a meeting."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "There is a meeting."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "think"), ("state", "p")]
+    comment := "Whether there is a meeting depends on Alex's trustworthiness and the plausibility of a meeting."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2a_unsettled : LinguisticExample :=
+  { id := "glass2025_2a_unsettled"
+    source := ⟨"glass-2025", "(2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Alex thinks there's a meeting."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "It is open whether there is a meeting."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "think"), ("state", "unsettled")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2a_notP : LinguisticExample :=
+  { id := "glass2025_2a_notP"
+    source := ⟨"glass-2025", "(2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Alex thinks there's a meeting."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "There is no meeting."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "think"), ("state", "notP")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4_notP : LinguisticExample :=
+  { id := "glass2025_4_notP"
+    source := ⟨"glass-2023", "(4)"⟩
+    reportedIn := some ⟨"glass-2025", "(4)"⟩
+    language := "mand1415"
+    primaryText := "Māma yǐwéi wǒ bìng le"
+    discourseSegments := []
+    glossedTokens := [("Māma", "mom"), ("yǐwéi", "yǐwéi"), ("wǒ", "1sg"), ("bìng", "sick"), ("le", "asp")]
+    translation := "Mom is under the impression that I'm sick."
+    context := "The speaker faked illness to avoid school."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "yiwei"), ("state", "notP")]
+    comment := "Excerpted from Glass 2023, p. 2."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_4_p : LinguisticExample :=
+  { id := "glass2025_4_p"
+    source := ⟨"glass-2023", "(4)"⟩
+    reportedIn := some ⟨"glass-2025", "(4)"⟩
+    language := "mand1415"
+    primaryText := "Māma yǐwéi wǒ bìng le"
+    discourseSegments := []
+    glossedTokens := [("Māma", "mom"), ("yǐwéi", "yǐwéi"), ("wǒ", "1sg"), ("bìng", "sick"), ("le", "asp")]
+    translation := "Mom is under the impression that I'm sick."
+    context := "The speaker is definitely sick."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "yiwei"), ("state", "p")]
+    comment := "Nonsensical if the speaker is definitely sick."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5_notP : LinguisticExample :=
+  { id := "glass2025_5_notP"
+    source := ⟨"glass-2023", "(5)"⟩
+    reportedIn := some ⟨"glass-2025", "(5)"⟩
+    language := "mand1415"
+    primaryText := "Māma rènwéi wǒ bìng le"
+    discourseSegments := []
+    glossedTokens := [("Māma", "mom"), ("rènwéi", "think"), ("wǒ", "1sg"), ("bìng", "sick"), ("le", "asp")]
+    translation := "Mom thinks I'm sick."
+    context := "The speaker faked illness to avoid school."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "renwei"), ("state", "notP")]
+    comment := "Adapted from Glass 2023, p. 2."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_5_unsettled : LinguisticExample :=
+  { id := "glass2025_5_unsettled"
+    source := ⟨"glass-2023", "(5)"⟩
+    reportedIn := some ⟨"glass-2025", "(5)"⟩
+    language := "mand1415"
+    primaryText := "Māma rènwéi wǒ bìng le"
+    discourseSegments := []
+    glossedTokens := [("Māma", "mom"), ("rènwéi", "think"), ("wǒ", "1sg"), ("bìng", "sick"), ("le", "asp")]
+    translation := "Mom thinks I'm sick."
+    context := "The speaker feels exhausted and thinks she may indeed be sick, citing her mother's belief as evidence."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "renwei"), ("state", "unsettled")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_7 : LinguisticExample :=
+  { id := "glass2025_7"
+    source := ⟨"glass-2023", "(7)"⟩
+    reportedIn := some ⟨"glass-2025", "(7)"⟩
+    language := "mand1415"
+    primaryText := "wǒ bù zhīdào yǒu-méi-yǒu défēn, dànshì zhège qiúyuán yǐwéi défēn le"
+    discourseSegments := []
+    glossedTokens := [("wǒ", "I"), ("bù", "not"), ("zhīdào", "know"), ("yǒu-méi-yǒu", "have-not-have"), ("défēn", "score"), ("dànshì", "but"), ("zhège", "this-cl"), ("qiúyuán", "ball-player"), ("yǐwéi", "yǐwéi"), ("défēn", "score"), ("le", "asp")]
+    translation := "I don't know whether the player scored or not, but he's under the impression that he did."
+    context := "The athlete caught the ball on the edge of the end zone and celebrates while the referees debate the catch; the speaker does not know whether he scored."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb", "yiwei"), ("state", "unsettled")]
+    comment := "Glass 2023, p. 6. Odd if the speaker has no reason to question the athlete's belief; a presupposition of not-p would contradict the ignorance expressed in the first clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1a, ex_2a_p, ex_2a_unsettled, ex_2a_notP, ex_4_notP, ex_4_p, ex_5_notP, ex_5_unsettled, ex_7]
+
+end Glass2025.Examples

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -65,6 +65,14 @@ def yiwei : MandarinVerbEntry := .mk' {
   opaqueContext := true
   attitude := some (.doxastic .nonVeridical) }
 
+/-- 认为 "rènwéi" — think, hold the view that: the neutral nonveridical doxastic verb. -/
+def renwei : MandarinVerbEntry := .mk' {
+  form := "renwei"
+  frames := [Frame.finiteClause]
+  passivizable := false
+  opaqueContext := true
+  attitude := some (.doxastic .nonVeridical) }
+
 /-! ## Liu & Yip 2026 complement-taking predicates
 
 Seven additional Mandarin CTPs cited by [liu-yip-2026] (lists in (18)
@@ -133,7 +141,7 @@ def shefa : MandarinVerbEntry := .mk' {
   opaqueContext := false }
 
 def allVerbs : List MandarinVerbEntry :=
-  [qidai, danxin, xiwang, haipa, yiwei,
+  [qidai, danxin, xiwang, haipa, yiwei, renwei,
    xiang, rang, xiangxin, quan, bi, dasuan, shefa]
 
 def lookup (form : String) : Option MandarinVerbEntry :=

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -1,512 +1,251 @@
 import Linglib.Semantics.Attitudes.Doxastic
-import Linglib.Semantics.Attitudes.NegRaising
 import Linglib.Semantics.Presupposition.Context
-import Linglib.Syntax.Category.Verb.Basic
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.Mandarin.Predicates
+import Linglib.Data.Examples.Glass2025
 
 /-!
 # Glass (2025): Attested versus unattested contrafactive belief verbs
-[glass-2025] [glass-2023] [roberts-ozyildiz-2025]
 
-Semantics and Pragmatics 18, Article 8: 1-17.
+This file formalizes [glass-2025]'s reframing of [holton-2017]'s contrafactive gap. The factive
+presupposition of *know* requires its complement to be Common Ground, true throughout the context
+set (`EntailsP`); a contrafactive can negate it in two places, requiring that not-p be Common
+Ground (`EntailsNot`) or that the Common Ground be compatible with not-p (`CompatibleNot`), the
+narrow and the wide scope of the negation as in neg-raising (`entailsNot_iff`,
+`compatibleNot_iff`). The stronger requirement is unattested; the weaker is the postsupposition
+of Mandarin yǐwéi in [glass-2023], a definedness condition on the context updated with the belief
+report (`yiweiDefined`), from which the report's usual suggestion that the complement is false
+follows for a speaker with an opinion about it (`entailsNot_of_opinionated`). Table 1 is derived:
+each profile admits a set of states of the Common Ground (`Profile.Admits`,
+`Profile.condition_iff`); *know* and the hypothetical *contra* are complementary but leave the
+unsettled state to neither (`not_entailsP_and_entailsNot`, `know_contra_gap`), *know* and yǐwéi
+complementary and exhaustive (`not_entailsP_and_compatibleNot`, `know_yiwei_exhaustive`). The
+fragments' veridicality gives *know* and *think* their profiles, and the factive presupposition of
+the substrate's veridical predicates is the requirement that the complement be Common Ground
+(`presupSatisfied_toPartialProp_veridical`); the rows check the reported judgments against the
+admitted states (`rows_admits`).
 
-## Key Claims
+## Implementation notes
 
-1. **Two ways to negate the factive presupposition**: A contrafactive could
-   *require* ¬p (all CommonGround worlds are ¬p worlds) or require *compatibility*
-   with ¬p (some CommonGround world is a ¬p world).
+* Context sets are the substrate's `Set W`; Table 1 depicts the Common Ground after the report is
+  accepted, so the profiles' conditions take the updated context, the intersection with the
+  report's at-issue content, as their argument.
+* The attestation facts, no strong contrafactive and yǐwéi a weak one, are the empirical premise
+  of the reframed question (`Profile.Attested`), which [roberts-ozyildiz-2025] derives causally.
+* Verbs' profiles come from their fragment entries' veridicality except yǐwéi's, the paper's own
+  analysis, since the fragment records only that it is non-veridical.
 
-2. **Strong contrafactives are unattested**: No verb presupposes ¬p (requiring
-   CommonGround ⊨ ¬p). This follows from the Predicate Lexicalization Constraint
-   ([roberts-ozyildiz-2025]): ¬p cannot causally support B(x)(p).
+## References
 
-3. **Weak contrafactives exist**: Mandarin yǐwéi ([glass-2023]) has a
-   postsupposition ◇¬p — after utterance, the CommonGround must be compatible with ¬p.
-   This is a definedness condition on the *output* context, not a presupposition
-   on the input context.
-
-4. **Revised question**: "Why are there belief verbs like *know* (CommonGround ⊨ p)
-   and yǐwéi (CommonGround ◇ ¬p), but none like *contra* (CommonGround ⊨ ¬p)?"
-
-## Formalization Strategy
-
-Belief verb denotations are `PartialProp W` values produced by
-`DoxasticPredicate.toPartialProp`. The presup field captures the factive
-presupposition (or lack thereof). yǐwéi's postsupposition is a
-`Postsupposition` value (§2 below). The `PresupClass` typology and the
-attestation classifier `presupClassIsValid` are defined here; their
-causal derivation via the Predicate Lexicalization Constraint is
-[roberts-ozyildiz-2025]'s account, prosecuted in
-`Studies/RobertsOzyildiz2025.lean`.
+* [glass-2025]
+* [glass-2023]
+* [holton-2017]
+* [roberts-ozyildiz-2025]
+* [brasoveanu-2009]
+* [stalnaker-1978]
 -/
 
 namespace Glass2025
 
-open Doxastic
-open Presupposition
-open ArgumentStructure
-open English.Predicates.Verbal
-open Mandarin.Predicates
+open Doxastic Presupposition Data.Examples Features
+open English.Predicates.Verbal Mandarin.Predicates
 
+variable {W : Type*} {c : Set W} {p : W → Prop}
 
-/-! ### The presuppositional classes
+/-! ### Two ways to negate the factive presupposition -/
 
-The typology of belief verbs by presuppositional profile: factive
-(*know* — CommonGround must entail p), nonfactive (*think* — no
-requirement), contrafactive (hypothetical *contra* — CommonGround must
-entail ¬p; UNATTESTED), with yǐwéi's ◇¬p requirement a postsupposition
-(§2), not a presupposition. The class of a verb is derived from its
-veridicality, and `presupClassIsValid` records the attestation facts —
-valid iff not contrafactive. -/
+/-- (10): `p` is Common Ground, true throughout the context set. -/
+def EntailsP (c : Set W) (p : W → Prop) : Prop := ∀ w ∈ c, p w
 
-/-- Presuppositional profile of a doxastic verb. -/
-inductive PresupClass where
-  /-- Presupposes p (*know*). -/
+/-- (11): not-`p` is Common Ground. -/
+def EntailsNot (c : Set W) (p : W → Prop) : Prop := ∀ w ∈ c, ¬ p w
+
+/-- (12): the Common Ground is compatible with not-`p`. -/
+def CompatibleNot (c : Set W) (p : W → Prop) : Prop := ∃ w ∈ c, ¬ p w
+
+/-- (11) is the narrow-scope negation: it is not possible that `p`. -/
+theorem entailsNot_iff : EntailsNot c p ↔ ¬ ∃ w ∈ c, p w := by
+  simp [EntailsNot]
+
+/-- (12) is the wide-scope negation: `p` is not Common Ground. -/
+theorem compatibleNot_iff : CompatibleNot c p ↔ ¬ EntailsP c p := by
+  simp [CompatibleNot, EntailsP]
+
+/-- The stronger requirement entails the weaker on a nonempty Common Ground. -/
+theorem compatibleNot_of_entailsNot (hc : c.Nonempty) (h : EntailsNot c p) : CompatibleNot c p :=
+  let ⟨w, hw⟩ := hc
+  ⟨w, hw, h w hw⟩
+
+/-- The weaker requirement does not entail the stronger. -/
+theorem not_entailsNot_of_compatibleNot :
+    ∃ (c : Set Bool) (p : Bool → Prop), CompatibleNot c p ∧ ¬ EntailsNot c p :=
+  ⟨Set.univ, (· = true), ⟨false, Set.mem_univ _, Bool.false_ne_true⟩,
+    λ h => h true (Set.mem_univ _) rfl⟩
+
+/-- *know* and *contra* are complementary on a nonempty Common Ground. -/
+theorem not_entailsP_and_entailsNot (hc : c.Nonempty) : ¬ (EntailsP c p ∧ EntailsNot c p) :=
+  λ ⟨h, h'⟩ => let ⟨w, hw⟩ := hc; h' w hw (h w hw)
+
+/-- The gap between *know* and *contra*: a Common Ground on which `p` is unsettled satisfies
+neither requirement. -/
+theorem know_contra_gap :
+    ∃ (c : Set Bool) (p : Bool → Prop), ¬ EntailsP c p ∧ ¬ EntailsNot c p :=
+  ⟨Set.univ, (· = true), λ h => Bool.false_ne_true (h false (Set.mem_univ _)),
+    λ h => h true (Set.mem_univ _) rfl⟩
+
+/-- *know* and yǐwéi are complementary. -/
+theorem not_entailsP_and_compatibleNot : ¬ (EntailsP c p ∧ CompatibleNot c p) :=
+  λ ⟨h, h'⟩ => compatibleNot_iff.1 h' h
+
+/-- *know* and yǐwéi exhaust the space: `p` is Common Ground or it is not. -/
+theorem know_yiwei_exhaustive : EntailsP c p ∨ CompatibleNot c p := by
+  by_cases h : EntailsP c p
+  · exact Or.inl h
+  · exact Or.inr (compatibleNot_iff.2 h)
+
+/-! ### The factive presupposition in the substrate -/
+
+variable {E : Type*}
+
+/-- A veridical predicate's presupposition is satisfied exactly when its complement is Common
+Ground: the factive presupposition (10). -/
+theorem presupSatisfied_toPartialProp_veridical (V : DoxasticPredicate W E)
+    (hV : V.veridicality = .veridical) (a : E) (worlds : List W) :
+    Context.presupSatisfied c (V.toPartialProp a p worlds) ↔ EntailsP c p := by
+  simp only [Context.presupSatisfied, DoxasticPredicate.toPartialProp, hV, VeridicalityHolds,
+    Set.subset_def]
+  exact Iff.rfl
+
+/-- A non-veridical predicate places no condition on the Common Ground. -/
+theorem presupSatisfied_toPartialProp_nonVeridical (V : DoxasticPredicate W E)
+    (hV : V.veridicality = .nonVeridical) (a : E) (worlds : List W) :
+    Context.presupSatisfied c (V.toPartialProp a p worlds) := by
+  simp only [Context.presupSatisfied, DoxasticPredicate.toPartialProp, hV, VeridicalityHolds,
+    Set.subset_def]
+  exact λ _ _ => trivial
+
+/-! ### yǐwéi's postsupposition -/
+
+/-- (14): *x yǐwéi p* updates the Common Ground with `x`'s belief that `p`, and is defined only if
+the result is compatible with not-`p`, a postsupposition in the sense of [brasoveanu-2009]. -/
+def yiweiDefined (c belief : Set W) (p : W → Prop) : Prop := CompatibleNot (c ∩ belief) p
+
+/-- A speaker with an opinion about `p`, whose Common Ground entails it or its negation, and who
+signals that the Common Ground is compatible with not-`p`, holds that not-`p`: why *x yǐwéi p*
+usually conveys that `p` is false. -/
+theorem entailsNot_of_opinionated (h : EntailsP c p ∨ EntailsNot c p) (hy : CompatibleNot c p) :
+    EntailsNot c p :=
+  h.resolve_left (compatibleNot_iff.1 hy)
+
+/-! ### Table 1 -/
+
+/-- The projective profiles of belief verbs: requiring `p` (*know*), nothing (*think*),
+compatibility with not-`p` (yǐwéi), and not-`p` (the hypothetical *contra*). -/
+inductive Profile
   | factive
-  /-- Would presuppose ¬p (hypothetical *contra*; unattested). -/
-  | contrafactive
-  /-- No presupposition (*believe*, *think*). -/
   | nonfactive
-  /-- None of the above. -/
-  | other
-  deriving DecidableEq, Repr
-
-/-- Classify a doxastic verb by its veridicality. -/
-def classifyVeridicality : Veridicality → PresupClass
-  | .veridical => .factive
-  | .nonVeridical => .nonfactive
-
-/-- The attestation facts: every profile is attested except the
-    contrafactive. The causal derivation of this table is
-    `RobertsOzyildiz2025.presupClassIsValid_eq_via_plc`. -/
-def presupClassIsValid : PresupClass → Bool
-  | .factive       => true
-  | .nonfactive    => true
-  | .contrafactive => false
-  | .other         => true
-
-/-- Factive presuppositions are attested. -/
-theorem factive_presup_valid : presupClassIsValid .factive = true := rfl
-
-/-- Contrafactive presuppositions are unattested. -/
-theorem contrafactive_presup_invalid :
-    presupClassIsValid .contrafactive = false := rfl
-
-/-- Nonfactive profiles are attested (no presupposition to check). -/
-theorem nonfactive_presup_valid :
-    presupClassIsValid .nonfactive = true := rfl
-
--- ============================================================================
--- §1. MiniWorld Model
--- ============================================================================
-
-/-!
-Minimal 2-world model for exercising Table 1.
-- `w0`: p is true
-- `w1`: p is false
--/
-
-private inductive MiniWorld | w0 | w1
-  deriving DecidableEq, Repr, Inhabited
-
-/-- The complement proposition: true at w0, false at w1. -/
-private def prop : MiniWorld → Bool
-  | .w0 => true
-  | .w1 => false
-
-/-- Factive context: all worlds satisfy p (CommonGround ⊨ p). -/
-private def factiveCtx : List MiniWorld := [.w0]
-
-/-- Neutral context: p is open (CommonGround ◇ p ∧ CommonGround ◇ ¬p). -/
-private def neutralCtx : List MiniWorld := [.w0, .w1]
-
-/-- Contrafactive context: no world satisfies p (CommonGround ⊨ ¬p). -/
-private def contrafactiveCtx : List MiniWorld := [.w1]
-
--- ============================================================================
--- §2. Postsuppositions
--- ============================================================================
-
-/-!
-Output-context constraints ([brasoveanu-2013]): conditions on the Common
-Ground *after* an utterance updates it, as opposed to presuppositions,
-which constrain the *input* context. [glass-2025] argues Mandarin yǐwéi
-carries the postsupposition ◇¬p: after accepting "x yǐwéi p", the
-CommonGround must be compatible with ¬p — a condition not derivable from
-veridicality alone.
--/
-
-/-- A postsupposition: a constraint on the output context after a discourse
-    update, taking the context set (as `List W`) and the embedded
-    proposition. -/
-structure Postsupposition (W : Type*) where
-  condition : List W → (W → Prop) → Prop
-
-namespace Postsupposition
-
-variable {W : Type*}
-
-/-- No postsupposition (trivially satisfied). -/
-protected def none : Postsupposition W := ⟨fun _ _ => True⟩
-
-/-- Weak contrafactive: the output context is *compatible* with ¬p — some
-    world in the output context falsifies p. This is yǐwéi's ◇¬p
-    ([glass-2025], [glass-2023]). -/
-def weakContrafactive : Postsupposition W :=
-  ⟨fun cs p => ∃ w ∈ cs, ¬ p w⟩
-
-/-- Strong contrafactive: the output context *entails* ¬p — every world in
-    the output context falsifies p. The hypothetical *contra* verb's
-    requirement — UNATTESTED. -/
-def strongContrafactive : Postsupposition W :=
-  ⟨fun cs p => ∀ w ∈ cs, ¬ p w⟩
-
-/-- The trivial postsupposition is always satisfied. -/
-theorem none_condition (cs : List W) (p : W → Prop) :
-    Postsupposition.none.condition cs p := trivial
-
-/-- Strong contrafactivity entails weak (nonempty contexts): CommonGround ⊨ ¬p
-    forces CommonGround ◇ ¬p — [glass-2025]'s observation that yǐwéi's
-    requirement is strictly weaker than *contra*'s. -/
-theorem strong_entails_weak {cs : List W} {p : W → Prop} (hne : cs ≠ [])
-    (h : strongContrafactive.condition cs p) :
-    weakContrafactive.condition cs p :=
-  match cs, hne with
-  | w :: _, _ => ⟨w, by simp, h w (by simp)⟩
-
-/-- Weak contrafactivity does not entail strong: a context can be compatible
-    with ¬p without entailing ¬p. -/
-theorem weak_not_entails_strong :
-    ∃ (cs : List Bool) (p : Bool → Prop),
-      weakContrafactive.condition cs p ∧ ¬ strongContrafactive.condition cs p :=
-  ⟨[true, false], (· = true), ⟨false, by simp, by simp⟩,
-    fun h => h true (by simp) rfl⟩
-
-end Postsupposition
-
--- ============================================================================
--- §3. Belief Verb PartialProps
--- ============================================================================
-
-/-!
-Construct presuppositional denotations for four verb types directly
-from veridicality, matching [glass-2025] Table 1.
-
-We define the presup fields directly (rather than instantiating full
-`DoxasticPredicate`s) to keep the model minimal. The connection to
-`DoxasticPredicate.toPartialProp` is established by the classification
-theorems in §4.
--/
-
-/-- *know*: presupposes p (factive). -/
-private def knowPresup : PartialProp MiniWorld where
-  presup := λ w => prop w = true
-  assertion := λ _ => True
-
-/-- *think*: no presupposition (nonfactive). -/
-private def thinkPresup : PartialProp MiniWorld where
-  presup := λ _ => True
-  assertion := λ _ => True
-
-/-- Hypothetical *contra*: presupposes ¬p (strong contrafactive). -/
-private def contraPresup : PartialProp MiniWorld where
-  presup := λ w => prop w = false
-  assertion := λ _ => True
-
-/-- yǐwéi: nonfactive PartialProp + postsupposition ◇¬p. -/
-private def yiweiPresup : PartialProp MiniWorld where
-  presup := λ _ => True
-  assertion := λ _ => True
-
-/-- yǐwéi's postsupposition: CommonGround must be compatible with ¬p. -/
-private def yiweiPostsup : Postsupposition MiniWorld :=
-  Postsupposition.weakContrafactive
-
--- ============================================================================
--- §4. Table 1: Context-Set Satisfaction ([glass-2025])
--- ============================================================================
-
-/-!
-Table 1 from [glass-2025]: possible states of the Common Ground
-*after* updating with each utterance.
-
-|  Utterance   | Projective content | p   | ◇p ∧ ◇¬p | not-p |
-|--------------|-------------------|-----|-----------|-------|
-| x knows p    | requires p        | ✓   | ✗         | ✗     |
-| x thinks p   | (none)            | ✓   | ✓         | ✓     |
-| x yǐwéi p   | requires ◇(¬p)    | ✗   | ✓         | ✓     |
-| x contra p   | requires ¬p       | ✗   | ✗         | ✓     |
-
-We verify this by checking the presup field against each context type.
--/
-
--- know: presup satisfied only in factive context
-
-theorem know_satisfied_factive :
-    ∀ w ∈ factiveCtx, knowPresup.presup w := by
-  intro w hw; simp only [factiveCtx, List.mem_cons, List.mem_nil_iff, or_false] at hw
-  subst hw; rfl
-
-theorem know_fails_neutral :
-    ¬∀ w ∈ neutralCtx, knowPresup.presup w := by
-  intro h; have := h .w1 (List.mem_cons.mpr (.inr (List.mem_cons.mpr (.inl rfl))))
-  simp [knowPresup, prop] at this
-
-theorem know_fails_contrafactive :
-    ¬∀ w ∈ contrafactiveCtx, knowPresup.presup w := by
-  intro h; have := h .w1 (List.mem_cons.mpr (.inl rfl))
-  simp [knowPresup, prop] at this
-
--- think: presup satisfied in all contexts (no constraint)
-
-theorem think_satisfied_factive :
-    ∀ w ∈ factiveCtx, thinkPresup.presup w := by
-  intro _ _; trivial
-
-theorem think_satisfied_neutral :
-    ∀ w ∈ neutralCtx, thinkPresup.presup w := by
-  intro _ _; trivial
-
-theorem think_satisfied_contrafactive :
-    ∀ w ∈ contrafactiveCtx, thinkPresup.presup w := by
-  intro _ _; trivial
-
--- yǐwéi: presup (input) satisfied everywhere; postsup fails in factive ctx
-
-theorem yiwei_presup_satisfied_factive :
-    ∀ w ∈ factiveCtx, yiweiPresup.presup w := by
-  intro _ _; trivial
-
-theorem yiwei_presup_satisfied_neutral :
-    ∀ w ∈ neutralCtx, yiweiPresup.presup w := by
-  intro _ _; trivial
-
-theorem yiwei_postsup_fails_factive :
-    ¬ yiweiPostsup.condition factiveCtx (prop · = true) := by
-  simp [yiweiPostsup, Postsupposition.weakContrafactive, factiveCtx, prop]
-
-theorem yiwei_postsup_satisfied_neutral :
-    yiweiPostsup.condition neutralCtx (prop · = true) :=
-  ⟨.w1, by simp [neutralCtx], by simp [prop]⟩
-
-theorem yiwei_postsup_satisfied_contrafactive :
-    yiweiPostsup.condition contrafactiveCtx (prop · = true) :=
-  ⟨.w1, by simp [contrafactiveCtx], by simp [prop]⟩
-
--- contra: presup satisfied only in contrafactive context
-
-theorem contra_fails_factive :
-    ¬∀ w ∈ factiveCtx, contraPresup.presup w := by
-  intro h; have := h .w0 (List.mem_cons.mpr (.inl rfl))
-  simp [contraPresup, prop] at this
-
-theorem contra_fails_neutral :
-    ¬∀ w ∈ neutralCtx, contraPresup.presup w := by
-  intro h; have := h .w0 (List.mem_cons.mpr (.inl rfl))
-  simp [contraPresup, prop] at this
-
-theorem contra_satisfied_contrafactive :
-    ∀ w ∈ contrafactiveCtx, contraPresup.presup w := by
-  intro w hw; simp only [contrafactiveCtx, List.mem_cons, List.mem_nil_iff, or_false] at hw
-  subst hw; rfl
-
--- ============================================================================
--- §5. Per-Verb Verification: Fragment Entries → PresupClass
--- ============================================================================
-
-/-!
-Each English/Mandarin attitude verb's `PresupClass` is DERIVED from its
-veridicality in the Fragment entry. These theorems will BREAK if:
-1. A verb's `attitude` changes
-2. The `classifyVeridicality` function changes
-3. The `veridicality` derivation from `Attitude` changes
--/
-
--- Factive verbs → .factive
-
-theorem know_is_factive :
-    know.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  decide
-
-theorem realize_is_factive :
-    realize.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  decide
-
-theorem discover_is_factive :
-    discover.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  decide
-
-theorem notice_is_factive :
-    notice.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  decide
-
--- Non-factive verbs → .nonfactive
-
-theorem believe_is_nonfactive :
-    believe.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  decide
-
-theorem think_is_nonfactive :
-    think.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  decide
-
-theorem hope_is_nonfactive :
-    hope.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  decide
-
-theorem fear_is_nonfactive :
-    fear.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  decide
-
--- yǐwéi: classified as nonfactive by veridicality alone
-
-theorem yiwei_veridicality_nonfactive :
-    yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  decide
-
--- ============================================================================
--- §6. yǐwéi Exception: Postsupposition Not Derivable from Veridicality
--- ============================================================================
-
-/-!
-yǐwéi is classified as nonfactive by veridicality (§5), but it has an
-additional postsupposition ◇¬p that is NOT derivable from veridicality.
-Veridicality is a derivable property of the canonical Mandarin entry; the
-postsupposition is [glass-2025]'s paper-specific overlay, recorded here
-in the study rather than as a field on the Fragment entry.
--/
-
-/-- Postsupposition type: output-context constraint distinct from
-    presuppositions ([glass-2025]). The world-type-independent tag; the
-    concrete construct is `Postsupposition` (§2). -/
-inductive PostsupType where
-  /-- Output context must be compatible with ¬p: ◇¬p ([glass-2025]). -/
   | weakContrafactive
-  /-- Output context must entail ¬p: ⊨¬p (hypothetical, UNATTESTED). -/
   | strongContrafactive
   deriving DecidableEq, Repr
 
-/-- [glass-2025] classifies yǐwéi as carrying a weak contrafactive
-    postsupposition. This is the paper's analytical claim about the canonical
-    Mandarin `yiwei` entry — not a field on that entry. -/
-def yiweiPostsupType : PostsupType := .weakContrafactive
+/-- The requirement a profile places on the Common Ground after the report is accepted. -/
+def Profile.condition : Profile → Set W → (W → Prop) → Prop
+  | .factive, c, p => EntailsP c p
+  | .nonfactive, _, _ => True
+  | .weakContrafactive, c, p => CompatibleNot c p
+  | .strongContrafactive, c, p => EntailsNot c p
 
-/-- yǐwéi's veridicality gives nonfactive — no presupposition. -/
-theorem yiwei_derived_nonfactive :
-    yiwei.toVerb.veridicality = some .nonVeridical := by decide
+/-- The states of the Common Ground regarding `p` distinguished in Table 1. -/
+inductive State
+  | p
+  | unsettled
+  | notP
+  deriving DecidableEq, Repr
 
-/-- The postsupposition IS necessary: veridicality alone gives .nonfactive
-    (no presupposition), but yǐwéi actually has a weak contrafactive
-    postsupposition. Pairing the canonical entry's derivable veridicality with
-    Glass's postsupposition classification shows the two diverge — veridicality
-    is blind to the postsupposition. -/
-theorem yiwei_postsup_not_from_veridicality :
-    yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive ∧
-    yiweiPostsupType = .weakContrafactive :=
-  ⟨by decide, rfl⟩
+open Classical in
+/-- The state of a Common Ground regarding `p`. -/
+noncomputable def state (c : Set W) (p : W → Prop) : State :=
+  if EntailsP c p then .p else if EntailsNot c p then .notP else .unsettled
 
--- ============================================================================
--- §7. The Contrafactive Gap
--- ============================================================================
+/-- The states each profile admits: the rows of Table 1. -/
+def Profile.Admits : Profile → State → Prop
+  | .factive, s => s = .p
+  | .nonfactive, _ => True
+  | .weakContrafactive, s => s ≠ .p
+  | .strongContrafactive, s => s = .notP
 
-/-!
-The contrafactive gap DERIVED from the Predicate Lexicalization Constraint:
+instance (pr : Profile) (s : State) : Decidable (pr.Admits s) := by
+  cases pr <;> simp only [Profile.Admits] <;> infer_instance
 
-- Factive (know): presup = p → PLC satisfied (p → indic(p) → B(a)(p)) ✓
-- Nonfactive (think): no presupposition → PLC not applicable ✓
-- Contrafactive (contra): presup = ¬p → PLC violated (¬p ↛ B(a)(p)) ✗
+/-- Table 1 as a theorem: on a nonempty Common Ground, a profile's requirement holds exactly when
+the profile admits the Common Ground's state. -/
+theorem Profile.condition_iff (hc : c.Nonempty) (pr : Profile) :
+    pr.condition c p ↔ pr.Admits (state c p) := by
+  by_cases h₁ : EntailsP c p
+  · have h₂ : ¬ EntailsNot c p := λ h₂ => not_entailsP_and_entailsNot hc ⟨h₁, h₂⟩
+    cases pr <;> simp [Profile.condition, Profile.Admits, state, h₁, h₂, compatibleNot_iff]
+  · by_cases h₂ : EntailsNot c p
+    · cases pr <;> simp [Profile.condition, Profile.Admits, state, h₁, h₂, compatibleNot_iff]
+    · cases pr <;> simp [Profile.condition, Profile.Admits, state, h₁, h₂, compatibleNot_iff]
 
-This is not a stipulation — it follows from the causal structure of
-belief formation ([roberts-ozyildiz-2025]).
--/
+/-- Attestation: every profile but the strong contrafactive is attested, by *know*, *think* and
+yǐwéi; this is the empirical premise of the reframed question. -/
+def Profile.Attested : Profile → Prop
+  | .strongContrafactive => False
+  | _ => True
 
-/-- The contrafactive gap: factive and nonfactive are valid;
-    contrafactive is invalid. -/
-theorem contrafactive_gap :
-    presupClassIsValid .factive = true ∧
-    presupClassIsValid .nonfactive = true ∧
-    presupClassIsValid .contrafactive = false :=
-  ⟨factive_presup_valid, nonfactive_presup_valid, contrafactive_presup_invalid⟩
+instance : DecidablePred Profile.Attested := λ pr => by
+  cases pr <;> simp only [Profile.Attested] <;> infer_instance
 
-/-- All English attitude verbs have valid presuppositional profiles. -/
-theorem all_english_attitude_verbs_valid :
-    [know, realize, discover, notice, believe, think, want, hope,
-     expect, wish, fear, dread, worry].all (fun v =>
-      v.toVerb.veridicality.map classifyVeridicality |>.map
-        presupClassIsValid |>.getD true) = true := by
+/-! ### The verbs -/
+
+/-- The profile a verb's veridicality determines; postsuppositions are invisible to it. -/
+def Profile.ofVeridicality : Veridicality → Profile
+  | .veridical => .factive
+  | .nonVeridical => .nonfactive
+
+/-- yǐwéi's profile on the paper's analysis, beyond the non-veridicality its fragment entry
+records. -/
+def yiweiProfile : Profile := .weakContrafactive
+
+theorem know_profile : know.toVerb.veridicality.map Profile.ofVeridicality = some .factive := by
   decide
 
--- ============================================================================
--- §8. End-to-End Derivation
--- ============================================================================
+theorem think_profile :
+    think.toVerb.veridicality.map Profile.ofVeridicality = some .nonfactive := by
+  decide
 
-/-!
-The full derivation chain:
-  Fragment entry → attitude → veridicality → PresupClass
-    → presupClassIsValid → PLC check
+/-- The fragment's veridicality alone makes yǐwéi nonfactive. -/
+theorem yiwei_profile_ofVeridicality :
+    yiwei.toVerb.veridicality.map Profile.ofVeridicality = some .nonfactive := by
+  decide
 
-This section exercises the complete pipeline for representative verbs.
--/
+/-- A belief report of the paper: the verb's profile, the state of the Common Ground in the
+context described, and the reported judgment. -/
+structure Row where
+  profile : Profile
+  state : State
+  judgment : Judgment
+  deriving DecidableEq
 
-/-- End-to-end: "know" is factive, and factive presuppositions are valid. -/
-theorem know_endtoend_valid :
-    (know.toVerb.veridicality.map classifyVeridicality).map
-      presupClassIsValid = some true := by decide
+/-- The profiles of the rows' verbs: *know*, *think* and rènwéi from their fragment entries'
+veridicality, yǐwéi from the paper's analysis. -/
+def verbProfiles : List (String × Profile) :=
+  [("know", (know.toVerb.veridicality.map Profile.ofVeridicality).getD .nonfactive),
+   ("think", (think.toVerb.veridicality.map Profile.ofVeridicality).getD .nonfactive),
+   ("renwei", (renwei.toVerb.veridicality.map Profile.ofVeridicality).getD .nonfactive),
+   ("yiwei", yiweiProfile)]
 
-/-- End-to-end: "believe" is nonfactive, and nonfactive is valid. -/
-theorem believe_endtoend_valid :
-    (believe.toVerb.veridicality.map classifyVeridicality).map
-      presupClassIsValid = some true := by decide
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let profile ← ex.parse? "verb" verbProfiles
+  let state ← ex.parse? "state" [("p", .p), ("unsettled", .unsettled), ("notP", .notP)]
+  pure ⟨profile, state, ex.judgment⟩
 
-/-- End-to-end: know's presupposition is satisfied in a factive context. -/
-theorem know_presup_satisfied_endtoend :
-    factiveCtx.all prop = true := rfl
+/-- The nine reports of (1), (2), (4), (5) and (7). -/
+def rows : List Row := Examples.all.filterMap Row.ofExample
 
-/-- End-to-end: know's presupposition fails in a neutral context. -/
-theorem know_presup_fails_endtoend :
-    neutralCtx.all prop = false := rfl
-
-/-- End-to-end: yǐwéi's postsupposition is satisfied in a neutral context
-    (where veridicality-based presupposition is vacuously OK). -/
-theorem yiwei_endtoend :
-    (∀ w ∈ neutralCtx, yiweiPresup.presup w) ∧
-    yiweiPostsup.condition neutralCtx (prop · = true) :=
-  ⟨fun _ _ => trivial, ⟨.w1, by simp [neutralCtx], by simp [prop]⟩⟩
-
--- ============================================================================
--- §9. Connection to Neg-Raising ([glass-2025] §4.2)
--- ============================================================================
-
-/-!
-[glass-2025] §4.2 notes that yǐwéi supports neg-raising, like other
-nonfactive verbs. This follows from `Veridicality`: neg-raising is available
-for non-veridical predicates ([gajewski-2007], `NegRaising.lean`).
-
-Since `PresupClass.nonfactive` verbs are exactly the non-veridical ones,
-the neg-raising gap aligns with the contrafactive gap.
--/
-
-open NegRaising (negRaisingAvailable)
-
-/-- Nonfactive verbs (including yǐwéi) support neg-raising. -/
-theorem nonfactive_supports_negRaising :
-    negRaisingAvailable .nonVeridical = true := rfl
-
-/-- Factive verbs do NOT support neg-raising. -/
-theorem factive_blocks_negRaising :
-    negRaisingAvailable .veridical = false := rfl
-
-/-- The contrafactive gap and the neg-raising gap trace to the same
-    source: veridicality. Factives satisfy PLC but block neg-raising;
-    nonfactives escape PLC (no presupposition) and support neg-raising. -/
-theorem veridicality_determines_both :
-    -- Factive: satisfies PLC, blocks neg-raising
-    presupClassIsValid .factive = true ∧
-    negRaisingAvailable .veridical = false ∧
-    -- Nonfactive: PLC not applicable, supports neg-raising
-    presupClassIsValid .nonfactive = true ∧
-    negRaisingAvailable .nonVeridical = true :=
-  ⟨factive_presup_valid, rfl, nonfactive_presup_valid, rfl⟩
+/-- The reports are judged acceptable exactly in the states their profiles admit. -/
+theorem rows_admits : ∀ r ∈ rows, r.judgment = .acceptable ↔ r.profile.Admits r.state := by
+  decide
 
 end Glass2025

--- a/Linglib/Studies/RobertsOzyildiz2025.lean
+++ b/Linglib/Studies/RobertsOzyildiz2025.lean
@@ -23,8 +23,8 @@ not for p, so no chain reaches B(a)(p)) — the gap follows
 B(a)(¬p) is fine). Weak contrafactives like Mandarin yǐwéi escape:
 their falsity inference is a postsupposition about the output context
 ([glass-2025]), not a presupposition inside the same eventuality, so
-the PLC does not apply. `presupClassIsValid_eq_via_plc` derives
-[glass-2025]'s attestation table from the causal account.
+the PLC does not apply. `attested_iff_plc` derives [glass-2025]'s
+attestation table from the causal account.
 
 The belief-formation model is a deterministic `BoolSEM` over the
 `Causation` substrate; the PLC check runs `developDetOn` over a
@@ -141,23 +141,23 @@ theorem contrafactive_gap_is_structural :
     class: factives pair `p` with `B(a)(p)`, contrafactives `¬p` with
     `B(a)(p)`; the PLC does not apply to nonfactives (no
     presupposition) or postsuppositional profiles. -/
-def presupClassToCausalVars : PresupClass → Option (BeliefVar × BeliefVar)
+def presupClassToCausalVars : Profile → Option (BeliefVar × BeliefVar)
   | .factive => some (.p, .B_a_p)
-  | .contrafactive => some (.not_p, .B_a_p)
+  | .strongContrafactive => some (.not_p, .B_a_p)
   | .nonfactive => none
-  | .other => none
+  | .weakContrafactive => none
 
 /-- PLC verdict per class: `none` where the PLC does not apply. -/
-noncomputable def presupClassSatisfiesPLC (pc : PresupClass) : Option Bool :=
+noncomputable def presupClassSatisfiesPLC (pc : Profile) : Option Bool :=
   match presupClassToCausalVars pc with
   | none => none
   | some (presup, atIssue) => some (decide (SatisfiesPLC presup atIssue))
 
-/-- [glass-2025]'s attestation table is derived from the PLC: a class
+/-- [glass-2025]'s attestation table is derived from the PLC: a profile
     is attested iff it satisfies the PLC or the PLC does not apply. -/
-theorem presupClassIsValid_eq_via_plc (pc : PresupClass) :
-    presupClassIsValid pc = (presupClassSatisfiesPLC pc).getD true := by
-  cases pc <;> simp [presupClassIsValid, presupClassSatisfiesPLC,
+theorem attested_iff_plc (pc : Profile) :
+    pc.Attested ↔ (presupClassSatisfiesPLC pc).getD true = true := by
+  cases pc <;> simp [Profile.Attested, presupClassSatisfiesPLC,
     presupClassToCausalVars]
   · exact factive_satisfies_plc
   · exact strong_contrafactive_violates_plc

--- a/references.bib
+++ b/references.bib
@@ -3748,7 +3748,7 @@
   subfield  = {pragmatics/assertion},
   validated = {true},
   role      = {formalized},
-  sources   = {Discourse/CommonGround.lean;Semantics/Dynamic/UpdateSemantics/Necessity.lean;Studies/AnandNevins2004.lean;Studies/Caie2023.lean;Studies/Dekker2012.lean;Studies/FarkasBruce2010.lean;Studies/Mandelkern2022.lean;Studies/Rudin2025.lean}
+  sources   = {Discourse/CommonGround.lean;Semantics/Dynamic/UpdateSemantics/Necessity.lean;Studies/AnandNevins2004.lean;Studies/Caie2023.lean;Studies/Dekker2012.lean;Studies/FarkasBruce2010.lean;Studies/Glass2025.lean;Studies/Mandelkern2022.lean;Studies/Rudin2025.lean}
 }% REF: Stalnaker, R. (1981). A Defense of Conditional Excluded Middle.
 @incollection{stalnaker-1981,
   author    = {Stalnaker, Robert C.},
@@ -4110,7 +4110,7 @@
   subfield  = {semantics/compositional},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Attitudes/NegRaising.lean;Studies/Glass2025.lean;Semantics/Plurality/Homogeneity/Decided.lean}
+  sources   = {Semantics/Attitudes/NegRaising.lean;Semantics/Homogeneity/Decided.lean}
 }
 @book{breitholtz-2020,
   author    = {Breitholtz, Ellen},
@@ -16296,7 +16296,7 @@
   subfield  = {semantics/presupposition},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/Glass2025.lean}
+  sources   = {Data/Examples/Glass2025.json;Studies/Glass2025.lean}
 }
 @article{glass-2023b,
   author    = {Glass, Lelia},
@@ -16323,8 +16323,34 @@
   subfield  = {semantics/presupposition},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Attitudes/Doxastic.lean;Studies/Glass2025.lean}
-}% REF: Qing, C., Özyıldız, D., Roelofsen, F., Romero, M., & Uegaki, W. (2025). When can non-veridical preferential attitude predicates take questions?
+  sources   = {Data/Examples/Glass2025.json;Fragments/Mandarin/Predicates.lean;Semantics/Attitudes/Doxastic.lean;Studies/Glass2025.lean;Studies/RobertsOzyildiz2025.lean}
+}@article{holton-2017,
+  author    = {Holton, Richard},
+  year      = {2017},
+  title     = {Facts, Factives, and Contrafactives},
+  journal   = {Aristotelian Society Supplementary Volume},
+  volume    = {91},
+  number    = {1},
+  pages     = {245--266},
+  doi       = {10.1093/arisup/akx003},
+  subfield  = {semantics/attitudes},
+  role      = {cited},
+  sources   = {Studies/Glass2025.lean}
+}
+@incollection{brasoveanu-2009,
+  author    = {Brasoveanu, Adrian},
+  year      = {2009},
+  title     = {Modified Numerals as Post-suppositions},
+  booktitle = {Logic, Language and Meaning: 17th Amsterdam Colloquium, Revised Selected Papers},
+  editor    = {Aloni, Maria and Bastiaanse, Harald and de Jager, Tikitu and Schulz, Katrin},
+  publisher = {Springer},
+  pages     = {203--212},
+  doi       = {10.1007/978-3-642-14287-1_21},
+  subfield  = {semantics/presupposition},
+  role      = {cited},
+  sources   = {Studies/Glass2025.lean}
+}
+% REF: Qing, C., Özyıldız, D., Roelofsen, F., Romero, M., & Uegaki, W. (2025). When can non-veridical preferential attitude predicates take questions?
 @inproceedings{qing-2021,
   author    = {Qing, Ciyang},
   year      = {2021},
@@ -16423,7 +16449,7 @@
   url       = {https://ling.auf.net/lingbuzz/009050},
   subfield  = {semantics/presupposition},
   role      = {cited},
-  sources   = {Semantics/Attitudes/Doxastic.lean;Studies/Glass2025.lean}
+  sources   = {Semantics/Attitudes/Doxastic.lean;Studies/Glass2025.lean;Studies/RobertsOzyildiz2025.lean}
 }% REF: Yagi, Y. (2025). Conflicting presuppositions in disjunction. S&P 18:7.
 @article{yagi-2025,
   author    = {Yagi, Yusuke},
@@ -32552,7 +32578,7 @@
   publisher = {Japan Society for the Promotion of Science},
   subfield  = {semantics/presupposition},
   role      = {cited},
-  sources   = {Studies/JereticEtAl2025.lean}
+  sources   = {Studies/CoppockBeaver2015.lean;Studies/JereticEtAl2025.lean}
 }
 % REF: Buccola, Križ, Chemla (2018). Conceptual Alternatives: Competition in
 % Language and Beyond. Manuscript, ENS Paris.


### PR DESCRIPTION
Recuts `Glass2025` from a Bool attestation table and a two-world model into the squib's argument over context sets: the factive presupposition as the complement being Common Ground (`EntailsP`), its two negations (`EntailsNot`, `CompatibleNot`) related as narrow and wide scope (`entailsNot_iff`, `compatibleNot_iff`), yǐwéi's postsupposition on the updated context (`yiweiDefined`) with the falsity inference derived for opinionated speakers (`entailsNot_of_opinionated`), and Table 1 as a theorem (`Profile.condition_iff`): *know* and *contra* complementary but leaving the unsettled state to neither, *know* and yǐwéi complementary and exhaustive.

- The substrate's veridical predicates are tied to (10): `presupSatisfied_toPartialProp_veridical`; profiles of *know*, *think* and rènwéi come from the fragments' veridicality, yǐwéi's from the paper
- Nine rows (exx. 1, 2, 4, 5, 7 with the Mandarin data reported from Glass 2023) checked by `rows_admits`; `Fragments/Mandarin/Predicates.lean` gains rènwéi
- `RobertsOzyildiz2025` adapted: `PresupClass`/`presupClassIsValid` become `Profile`/`Profile.Attested` (`attested_iff_plc`); the `Postsupposition` structure, `MiniWorld`, the per-verb `decide` tables and the neg-raising `rfl` checks are cut; bib: `holton-2017`, `brasoveanu-2009`
