### PR TITLE
refactor(Studies/GartnerGyuris2017): bias profiles as cell-to-choice functions with structural counts

### DIFF
--- a/Linglib/Data/Examples/GartnerGyuris2017.json
+++ b/Linglib/Data/Examples/GartnerGyuris2017.json
@@ -1,0 +1,311 @@
+[
+  {
+    "id": "gg2017_1",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(1)"
+    },
+    "language": "stan1293",
+    "primaryText": "Is it sunny outside?",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "A enters S's windowless office in a manifestly dripping wet raincoat.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "English V1"
+      ],
+      [
+        "form",
+        "PPQ"
+      ],
+      [
+        "dimension",
+        "evidential"
+      ],
+      [
+        "value",
+        "-"
+      ]
+    ],
+    "comment": "A positive polar question is infelicitous under compelling evidence against p."
+  },
+  {
+    "id": "gg2017_2a",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(2a)"
+    },
+    "language": "stan1293",
+    "primaryText": "Didn't John go to the party?",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "S has just learned that A hosted a party last night but has no idea who did or should have attended.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "English V1"
+      ],
+      [
+        "form",
+        "IN-NPQ"
+      ],
+      [
+        "dimension",
+        "epistemic"
+      ],
+      [
+        "value",
+        "%"
+      ]
+    ],
+    "comment": "A negative polar question conveys the speaker's expectation that p, so it is odd without one."
+  },
+  {
+    "id": "gg2017_2b",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(2b)"
+    },
+    "language": "stan1293",
+    "primaryText": "Did John not go to the party?",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "S has just learned that A hosted a party last night but has no idea who did or should have attended.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "English V1"
+      ],
+      [
+        "form",
+        "IN-NPQ"
+      ],
+      [
+        "dimension",
+        "epistemic"
+      ],
+      [
+        "value",
+        "%"
+      ]
+    ],
+    "comment": "As (2a)."
+  },
+  {
+    "id": "gg2017_8_neg",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(8)"
+    },
+    "language": "hung1274",
+    "primaryText": "Süt-e a nap?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Süt-e",
+        "shine-Q"
+      ],
+      [
+        "a",
+        "the"
+      ],
+      [
+        "nap",
+        "sun"
+      ]
+    ],
+    "translation": "Is it sunny?",
+    "context": "A enters S's windowless office in a manifestly dripping wet raincoat.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "Hungarian e"
+      ],
+      [
+        "form",
+        "PPQ"
+      ],
+      [
+        "dimension",
+        "evidential"
+      ],
+      [
+        "value",
+        "-"
+      ]
+    ],
+    "comment": "The e-interrogative's evidential anti-bias: infelicitous under compelling evidence against p."
+  },
+  {
+    "id": "gg2017_8_pos",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(8)"
+    },
+    "language": "hung1274",
+    "primaryText": "Süt-e a nap?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Süt-e",
+        "shine-Q"
+      ],
+      [
+        "a",
+        "the"
+      ],
+      [
+        "nap",
+        "sun"
+      ]
+    ],
+    "translation": "Is it sunny?",
+    "context": "A comes in with dark sunglasses, T-shirt, shorts, a straw hat and suntan lotion, humming a song about sunshine.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "Hungarian e"
+      ],
+      [
+        "form",
+        "PPQ"
+      ],
+      [
+        "dimension",
+        "evidential"
+      ],
+      [
+        "value",
+        "+"
+      ]
+    ],
+    "comment": "The e-interrogative's evidential anti-bias: infelicitous under compelling evidence for p too."
+  },
+  {
+    "id": "gg2017_9a",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(9a)"
+    },
+    "language": "hung1274",
+    "primaryText": "Nincs-e itt egy francia étterem?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Nincs-e",
+        "not.is-Q"
+      ],
+      [
+        "itt",
+        "here"
+      ],
+      [
+        "egy",
+        "a"
+      ],
+      [
+        "francia",
+        "French"
+      ],
+      [
+        "étterem",
+        "restaurant"
+      ]
+    ],
+    "translation": "Isn't there a French restaurant here?",
+    "context": "S and A stand in front of a billboard in a small village saying that the last restaurant there has just closed for good.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "Hungarian e"
+      ],
+      [
+        "form",
+        "ON-NPQ"
+      ],
+      [
+        "dimension",
+        "evidential"
+      ],
+      [
+        "value",
+        "-"
+      ]
+    ],
+    "comment": "The e-interrogative expressing an outside-negation question keeps the anti-bias."
+  },
+  {
+    "id": "gg2017_9b",
+    "source": {
+      "bibkey": "gartner-gyuris-2017",
+      "paperLabel": "(9b)"
+    },
+    "language": "hung1274",
+    "primaryText": "Nincs-e itt egy étterem?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Nincs-e",
+        "not.is-Q"
+      ],
+      [
+        "itt",
+        "here"
+      ],
+      [
+        "egy",
+        "a"
+      ],
+      [
+        "étterem",
+        "restaurant"
+      ]
+    ],
+    "translation": "Isn't there a restaurant here?",
+    "context": "The billboard announces the opening of several new restaurants in the village.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "Hungarian e"
+      ],
+      [
+        "form",
+        "ON-NPQ"
+      ],
+      [
+        "dimension",
+        "evidential"
+      ],
+      [
+        "value",
+        "+"
+      ]
+    ],
+    "comment": "As (9a), under compelling evidence for p."
+  }
+]

--- a/Linglib/Data/Examples/GartnerGyuris2017.lean
+++ b/Linglib/Data/Examples/GartnerGyuris2017.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `GartnerGyuris2017` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/GartnerGyuris2017.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace GartnerGyuris2017.Examples`.
+-/
+
+namespace GartnerGyuris2017.Examples
+
+open Data.Examples
+
+def gg2017_1 : LinguisticExample :=
+  { id := "gg2017_1"
+    source := ⟨"gartner-gyuris-2017", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Is it sunny outside?"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "A enters S's windowless office in a manifestly dripping wet raincoat."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "English V1"), ("form", "PPQ"), ("dimension", "evidential"), ("value", "-")]
+    comment := "A positive polar question is infelicitous under compelling evidence against p."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_2a : LinguisticExample :=
+  { id := "gg2017_2a"
+    source := ⟨"gartner-gyuris-2017", "(2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Didn't John go to the party?"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "S has just learned that A hosted a party last night but has no idea who did or should have attended."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "English V1"), ("form", "IN-NPQ"), ("dimension", "epistemic"), ("value", "%")]
+    comment := "A negative polar question conveys the speaker's expectation that p, so it is odd without one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_2b : LinguisticExample :=
+  { id := "gg2017_2b"
+    source := ⟨"gartner-gyuris-2017", "(2b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Did John not go to the party?"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "S has just learned that A hosted a party last night but has no idea who did or should have attended."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "English V1"), ("form", "IN-NPQ"), ("dimension", "epistemic"), ("value", "%")]
+    comment := "As (2a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_8_neg : LinguisticExample :=
+  { id := "gg2017_8_neg"
+    source := ⟨"gartner-gyuris-2017", "(8)"⟩
+    reportedIn := none
+    language := "hung1274"
+    primaryText := "Süt-e a nap?"
+    discourseSegments := []
+    glossedTokens := [("Süt-e", "shine-Q"), ("a", "the"), ("nap", "sun")]
+    translation := "Is it sunny?"
+    context := "A enters S's windowless office in a manifestly dripping wet raincoat."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "Hungarian e"), ("form", "PPQ"), ("dimension", "evidential"), ("value", "-")]
+    comment := "The e-interrogative's evidential anti-bias: infelicitous under compelling evidence against p."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_8_pos : LinguisticExample :=
+  { id := "gg2017_8_pos"
+    source := ⟨"gartner-gyuris-2017", "(8)"⟩
+    reportedIn := none
+    language := "hung1274"
+    primaryText := "Süt-e a nap?"
+    discourseSegments := []
+    glossedTokens := [("Süt-e", "shine-Q"), ("a", "the"), ("nap", "sun")]
+    translation := "Is it sunny?"
+    context := "A comes in with dark sunglasses, T-shirt, shorts, a straw hat and suntan lotion, humming a song about sunshine."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "Hungarian e"), ("form", "PPQ"), ("dimension", "evidential"), ("value", "+")]
+    comment := "The e-interrogative's evidential anti-bias: infelicitous under compelling evidence for p too."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_9a : LinguisticExample :=
+  { id := "gg2017_9a"
+    source := ⟨"gartner-gyuris-2017", "(9a)"⟩
+    reportedIn := none
+    language := "hung1274"
+    primaryText := "Nincs-e itt egy francia étterem?"
+    discourseSegments := []
+    glossedTokens := [("Nincs-e", "not.is-Q"), ("itt", "here"), ("egy", "a"), ("francia", "French"), ("étterem", "restaurant")]
+    translation := "Isn't there a French restaurant here?"
+    context := "S and A stand in front of a billboard in a small village saying that the last restaurant there has just closed for good."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "Hungarian e"), ("form", "ON-NPQ"), ("dimension", "evidential"), ("value", "-")]
+    comment := "The e-interrogative expressing an outside-negation question keeps the anti-bias."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def gg2017_9b : LinguisticExample :=
+  { id := "gg2017_9b"
+    source := ⟨"gartner-gyuris-2017", "(9b)"⟩
+    reportedIn := none
+    language := "hung1274"
+    primaryText := "Nincs-e itt egy étterem?"
+    discourseSegments := []
+    glossedTokens := [("Nincs-e", "not.is-Q"), ("itt", "here"), ("egy", "a"), ("étterem", "restaurant")]
+    translation := "Isn't there a restaurant here?"
+    context := "The billboard announces the opening of several new restaurants in the village."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "Hungarian e"), ("form", "ON-NPQ"), ("dimension", "evidential"), ("value", "+")]
+    comment := "As (9a), under compelling evidence for p."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [gg2017_1, gg2017_2a, gg2017_2b, gg2017_8_neg, gg2017_8_pos, gg2017_9a, gg2017_9b]
+
+end GartnerGyuris2017.Examples

--- a/Linglib/Semantics/Questions/Bias.lean
+++ b/Linglib/Semantics/Questions/Bias.lean
@@ -1,3 +1,5 @@
+import Mathlib.Tactic.DeriveFintype
+
 /-!
 # Polar Question Bias — vocabulary
 [romero-2024] [romero-han-2004] [ladd-1981] [buring-gunlogson-2000]
@@ -35,7 +37,7 @@ inductive PQForm where
   /-- High negation question: [n't p?]. "Isn't Jane coming?"
       In Czech: interrogative (VSO) word order. -/
   | HiNQ
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
 /-- Original speaker bias: belief or expectation that p is true, based on the
 speaker's epistemic state *prior to* the current situation and exchange. -/

--- a/Linglib/Studies/GartnerGyuris2017.lean
+++ b/Linglib/Studies/GartnerGyuris2017.lean
@@ -1,657 +1,443 @@
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Fintype.Sigma
+import Mathlib.Data.Fintype.Sum
+import Mathlib.Tactic.DeriveFintype
 import Linglib.Semantics.Questions.Bias
-import Linglib.Studies.Stankova2026
+import Linglib.Data.Examples.GartnerGyuris2017
 
 /-!
-# Gärtner & Gyuris (2017): Delimiting the Space of Bias Profiles
-[gartner-gyuris-2017]
+# Gärtner and Gyuris (2017): On Delimiting the Space of Bias Profiles for Polar Interrogatives
 
-Formalization of the bias profile framework from [gartner-gyuris-2017],
-which defines bias profiles as non-empty power-set choices from {+, −, %}
-for evidential and epistemic dimensions across PPQ/IN-NPQ/ON-NPQ forms.
+This file formalizes [gartner-gyuris-2017]'s space of bias profiles. Following [sudo-2013], a polar
+interrogative clause type is biased evidentially (by compelling contextual evidence for p, against
+p, or neither) and epistemically (by the speaker's expectation that p, that not p, or neither), and
+separately for each of the three polar questions it can express, the positive question and the
+negative questions with inside and outside negation ([ladd-1981]). A bias profile chooses a nonempty
+set of the three values for each of the six cells, so there are 7⁶ = 117649 profiles
+(`card_profile`). The paper's delimiting principles are predicates on profiles, and the sizes of the
+spaces they leave are theorems: the principles that constrain cells separately count as products
+over cells (`card_cellwise`), those relating a positive question to its negative counterparts count
+as sums over the positive question's value (`card_perDim`, `card_byForm`), giving 46656 for
+Convexity, 2744 for Narrow Epistemic Choice, 512 for Static Complementarity with Convexity, 729 and
+4096 for the two versions of Polarity Match, 63504 for PPQ ≠ NPQ, and 33856 and 56536 for
+distributive and collective Quantitative Markedness. Avoid Disagreement entails Convexity and
+excludes Narrow Epistemic Choice (`not_avoidDisagreement_of_narrowEpistemic`), the paper's reason to
+confine Polarity Match to the evidential dimension. Appendix A's five total profiles from
+[sudo-2013] and [gyuris-2017] are checked against every principle (`sample_staticComplementarity`),
+and the infelicity judgments of examples (1), (2), (8), and (9) follow from the profiles
+(`rows_felicity`).
 
-## Key Results
+## Implementation notes
 
-- **Space size**: 7³ × 7³ = 117649 total profiles
-- **7 delimiting principles** (§2) reduce the space progressively:
-  1. No Uniformity (§2.1)
-  2. PPQ ≠ NPQ (§2.2)
-  3. Markedness (§2.3)
-  4. Polarity Match / QA Alignment (§2.4)
-  5. Convexity (§2.5)
-  6. Narrow Epistemic Choice (§2.6)
-  7. Static Complementarity (§2.7)
-- **Final reduction**: Convexity + Narrow Epistemic Choice + Static
-  Complementarity together yield (4 × 2)³ = 512 permissible profiles.
+The three question forms are the substrate's `PQForm`, whose `PosQ`, `LoNQ`, and `HiNQ` are the
+paper's PPQ, IN-NPQ, and ON-NPQ; the six cells and the seven choices are enumerated types, so that
+every decision the kernel makes ranges over a literal list. The Hungarian *e*-interrogative cannot
+express an inside-negation question, so it is a partial profile kept apart from the five total
+ones; the paper's Czech and Romero comparisons belong to the later papers' studies.
 
-## Cross-Linguistic Data (Appendix A)
+## References
 
-Six bias profiles from English, Japanese, and Hungarian are encoded
-and verified against the delimiting principles.
+* [gartner-gyuris-2017]
+* [sudo-2013]
+* [gyuris-2017]
+* [ladd-1981]
+* [buring-gunlogson-2000]
 -/
 
 namespace GartnerGyuris2017
 
-open Question
-
--- ============================================================================
--- §1: Core Types
--- ============================================================================
-
-/-- Bias values: positive (+), negative (−), neutral (%). -/
-inductive BiasValue where
-  | pos   -- +: evidence for p / belief that p
-  | neg   -- −: evidence for ¬p / belief that ¬p
-  | neut  -- %: no compelling evidence / agnostic
-  deriving DecidableEq, Repr
-
-/-- A bias choice is a non-empty subset of {+, −, %}.
-There are 2³ − 1 = 7 such subsets. We represent them as sorted lists
-for decidable equality and enumeration. -/
-def BiasChoice := List BiasValue
-
-instance : BEq BiasChoice := inferInstanceAs (BEq (List BiasValue))
-instance : DecidableEq BiasChoice := inferInstanceAs (DecidableEq (List BiasValue))
-instance : Repr BiasChoice := inferInstanceAs (Repr (List BiasValue))
-
-/-- The 7 non-empty subsets of {+, −, %}. -/
-def allBiasChoices : List BiasChoice :=
-  [ [.pos], [.neg], [.neut],
-    [.pos, .neut], [.pos, .neg], [.neut, .neg],
-    [.pos, .neut, .neg] ]
-
-theorem seven_bias_choices : allBiasChoices.length = 7 := rfl
-
-/-- Bias dimension: evidential vs epistemic. -/
-inductive BiasDimension where
-  | evidential  -- ev: based on contextual evidence
-  | epistemic   -- ep: based on speaker's prior belief/expectation
-  deriving DecidableEq, Repr
-
-/-- G&G's PQ form typology: PPQ, IN-NPQ, ON-NPQ.
-These map to Romero's PosQ, LoNQ, HiNQ respectively. -/
-inductive GGPQForm where
-  | PPQ     -- Positive polar question (?p)
-  | IN_NPQ  -- NPQ with inside (propositional) negation (?¬p)
-  | ON_NPQ  -- NPQ with outside negation (?~p)
-  deriving DecidableEq, Repr
-
-/-- Map G&G forms to Romero's typology. -/
-def GGPQForm.toRomero : GGPQForm → PQForm
-  | .PPQ    => .PosQ
-  | .IN_NPQ => .LoNQ
-  | .ON_NPQ => .HiNQ
-
-/-- A cell in the bias profile grid: one PQ form × one bias dimension. -/
-structure BiasCell where
-  form : GGPQForm
-  dim  : BiasDimension
-  deriving DecidableEq, Repr
-
-/-- A bias profile assigns a non-empty bias choice to each of 6 cells
-(3 PQ forms × 2 bias dimensions). -/
-structure BiasProfile where
-  ppqEv    : BiasChoice
-  ppqEp    : BiasChoice
-  inNpqEv  : BiasChoice
-  inNpqEp  : BiasChoice
-  onNpqEv  : BiasChoice
-  onNpqEp  : BiasChoice
-  deriving DecidableEq, Repr
-
-/-- Access a bias profile by cell. -/
-def BiasProfile.get (bp : BiasProfile) : BiasCell → BiasChoice
-  | ⟨.PPQ, .evidential⟩    => bp.ppqEv
-  | ⟨.PPQ, .epistemic⟩     => bp.ppqEp
-  | ⟨.IN_NPQ, .evidential⟩ => bp.inNpqEv
-  | ⟨.IN_NPQ, .epistemic⟩  => bp.inNpqEp
-  | ⟨.ON_NPQ, .evidential⟩ => bp.onNpqEv
-  | ⟨.ON_NPQ, .epistemic⟩  => bp.onNpqEp
-
--- ============================================================================
--- §2: Space Size
--- ============================================================================
-
-/-- Total space: 7 choices per cell, 6 cells = 7⁶ = 117649. -/
-theorem total_space_size : 7 ^ 6 = 117649 := by native_decide
-
--- ============================================================================
--- §3: Delimiting Principle 1 — No Uniformity (§2.1)
--- ============================================================================
-
-/-- No Uniformity: a bias profile is not entirely uniform, i.e., not all 6
-cells have exactly the same bias choice.
-
-"none of them consist of exactly the same choice, e.g., {+}, for each of
-its 6 dimensions." -/
-def noUniformity (bp : BiasProfile) : Bool :=
-  !(bp.ppqEv == bp.ppqEp &&
-    bp.ppqEp == bp.inNpqEv &&
-    bp.inNpqEv == bp.inNpqEp &&
-    bp.inNpqEp == bp.onNpqEv &&
-    bp.onNpqEv == bp.onNpqEp)
-
-/-- No Uniformity removes exactly 7 profiles (one per uniform choice). -/
-theorem noUniformity_removes : 117649 - 7 = 117642 := by native_decide
-
--- ============================================================================
--- §4: Delimiting Principle 2 — PPQ ≠ NPQ (§2.2)
--- ============================================================================
-
-/-- PPQ ≠ NPQ: Negation has an impact on bias. Both the evidential AND
-epistemic choices of PPQ must differ from those of each NPQ form.
-
-"PPQ ≠ NPQ (interpreted more precisely as PPQ^ev ≠ NPQ^ev &
-PPQ^ep ≠ NPQ^ep)" — §2.2. -/
-def ppqNeqNpq (bp : BiasProfile) : Bool :=
-  -- PPQ ≠ IN-NPQ (both dimensions must differ)
-  (bp.ppqEv != bp.inNpqEv && bp.ppqEp != bp.inNpqEp) &&
-  -- PPQ ≠ ON-NPQ (both dimensions must differ)
-  (bp.ppqEv != bp.onNpqEv && bp.ppqEp != bp.onNpqEp)
-
-/-- PPQ ≠ NPQ reduces the space to 7² × 6² × 6² = 63504. -/
-theorem ppqNeqNpq_space : 7 * 7 * 6 * 6 * 6 * 6 = 63504 := by native_decide
-
--- ============================================================================
--- §5: Delimiting Principle 3 — Markedness (§2.3)
--- ============================================================================
-
-/-- Quantitative Markedness (distributive, §2.3 eq. 11a): expressing marked
-(negative) meanings does not lead to more options than expressing their
-unmarked (positive) counterpart.
-
-|PPQ^ev| ≥ |IN-NPQ^ev| & |PPQ^ev| ≥ |ON-NPQ^ev| &
-|PPQ^ep| ≥ |IN-NPQ^ep| & |PPQ^ep| ≥ |ON-NPQ^ep| -/
-def markednessDistributive (bp : BiasProfile) : Bool :=
-  Nat.ble bp.inNpqEv.length bp.ppqEv.length &&
-  Nat.ble bp.onNpqEv.length bp.ppqEv.length &&
-  Nat.ble bp.inNpqEp.length bp.ppqEp.length &&
-  Nat.ble bp.onNpqEp.length bp.ppqEp.length
-
-/-- Quantitative Markedness (collective, §2.3 eq. 11b):
-|PPQ^ev| + |PPQ^ep| ≥ |IN-NPQ^ev| + |IN-NPQ^ep| &
-|PPQ^ev| + |PPQ^ep| ≥ |ON-NPQ^ev| + |ON-NPQ^ep| -/
-def markednessCollective (bp : BiasProfile) : Bool :=
-  Nat.ble (bp.inNpqEv.length + bp.inNpqEp.length) (bp.ppqEv.length + bp.ppqEp.length) &&
-  Nat.ble (bp.onNpqEv.length + bp.onNpqEp.length) (bp.ppqEv.length + bp.ppqEp.length)
-
-/-- Distributive Markedness yields 33856 profiles (Appendix B [1]).
-Per dimension: 3×3² + 3×6² + 1×7² = 184 (PPQ,NPQ) triples.
-Two independent dimensions: 184² = 33856. -/
-theorem markedness_distributive_space : Nat.mul 184 184 = 33856 := by native_decide
-
-/-- Collective Markedness yields 56536 profiles (Appendix B [2]):
-9×9² + 18×27² + 15×42² + 6×48² + 1×49² = 56536, summed over
-|PPQ^ev|+|PPQ^ep| = 2..6, counting NPQ pairs with sum ≤ PPQ sum. -/
-theorem markedness_collective_space :
-    Nat.add (Nat.add (Nat.add (Nat.add (Nat.mul 9 81) (Nat.mul 18 729))
-      (Nat.mul 15 1764)) (Nat.mul 6 2304)) (Nat.mul 1 2401) = 56536 := by native_decide
-
--- ============================================================================
--- §6: Delimiting Principle 4 — Polarity Match / QA Alignment (§2.4)
--- ============================================================================
-
-/-- Avoid Disagreement: − ∉ PPQ and + ∉ NPQ.
-The polarity of the question and the direction of bias should not
-totally contradict each other. -/
-def avoidDisagreement (bp : BiasProfile) : Bool :=
-  -- − ∉ PPQ (neither evidential nor epistemic)
-  !bp.ppqEv.contains .neg && !bp.ppqEp.contains .neg &&
-  -- + ∉ IN-NPQ
-  !bp.inNpqEv.contains .pos && !bp.inNpqEp.contains .pos &&
-  -- + ∉ ON-NPQ
-  !bp.onNpqEv.contains .pos && !bp.onNpqEp.contains .pos
-
-/-- Don't Rule Out Agreement: each cell of PPQ must contain +, and each
-cell of NPQ must contain −. The constraint applies per-cell, not per-row.
-
-This yields 4 choices per cell (subsets containing the matching polarity),
-so 4⁶ = 4096 total (§2.4, chart (19)). -/
-def dontRuleOutAgreement (bp : BiasProfile) : Bool :=
-  -- + ∈ each PPQ cell
-  bp.ppqEv.contains .pos && bp.ppqEp.contains .pos &&
-  -- − ∈ each IN-NPQ cell
-  bp.inNpqEv.contains .neg && bp.inNpqEp.contains .neg &&
-  -- − ∈ each ON-NPQ cell
-  bp.onNpqEv.contains .neg && bp.onNpqEp.contains .neg
-
-/-- Avoid Disagreement yields 3⁶ = 729 profiles. -/
-theorem avoidDisagreement_space : 3 ^ 6 = 729 := by native_decide
-
-/-- Don't Rule Out Agreement yields 4⁶ = 4096 profiles. -/
-theorem dontRuleOutAgreement_space : 4 ^ 6 = 4096 := by native_decide
-
--- ============================================================================
--- §7: Delimiting Principle 5 — Convexity (§2.5)
--- ============================================================================
-
-/-- A bias choice is convex if it doesn't "skip" intermediate values in the
-Hasse ordering + > % > −. Concretely, {+, −} is ruled out because it
-crosses over % without including it.
-
-The convex non-empty subsets of {+, %, −} are:
-{+}, {−}, {%}, {+,%}, {%,−}, {+,%,−} — six options. -/
-def isConvex (bc : BiasChoice) : Bool :=
-  !(bc.contains .pos && bc.contains .neg && !bc.contains .neut)
-
-/-- A bias profile satisfies Convexity if all 6 cells are convex. -/
-def convexity (bp : BiasProfile) : Bool :=
-  isConvex bp.ppqEv && isConvex bp.ppqEp &&
-  isConvex bp.inNpqEv && isConvex bp.inNpqEp &&
-  isConvex bp.onNpqEv && isConvex bp.onNpqEp
-
-/-- {+, −} is ruled out by Convexity. -/
-theorem pos_neg_not_convex : isConvex [.pos, .neg] = false := rfl
-
-/-- All singletons are convex. -/
-theorem singletons_convex :
-    isConvex [.pos] = true ∧
-    isConvex [.neg] = true ∧
-    isConvex [.neut] = true := ⟨rfl, rfl, rfl⟩
-
-/-- {+, %} and {%, −} are convex. -/
-theorem adjacent_pairs_convex :
-    isConvex [.pos, .neut] = true ∧
-    isConvex [.neut, .neg] = true := ⟨rfl, rfl⟩
-
-/-- {+, %, −} is convex (the full set). -/
-theorem full_set_convex : isConvex [.pos, .neut, .neg] = true := rfl
-
-/-- Convexity yields 6⁶ = 46656 profiles. -/
-theorem convexity_space : 6 ^ 6 = 46656 := by native_decide
-
--- ============================================================================
--- §8: Delimiting Principle 6 — Narrow Epistemic Choice (§2.6)
--- ============================================================================
-
-/-- Narrow Epistemic Choice: epistemic bias is either {+^ep} or
-{+^ep, −^ep, %^ep} (the full set).
-
-"the number of epistemic bias options is rather narrow, that is, we
-predominantly find {+^ep} or {+^ep,−^ep,%^ep}" -/
-def narrowEpistemicChoice (bc : BiasChoice) : Bool :=
-  bc == [.pos] || bc == [.pos, .neut, .neg]
-
-/-- A bias profile satisfies Narrow Epistemic Choice if all 3 epistemic
-cells use either {+} or {+,%,−}. -/
-def narrowEpistemic (bp : BiasProfile) : Bool :=
-  narrowEpistemicChoice bp.ppqEp &&
-  narrowEpistemicChoice bp.inNpqEp &&
-  narrowEpistemicChoice bp.onNpqEp
-
-/-- Narrow Epistemic Choice alone yields (7 × 2)³ = 2744 profiles. -/
-theorem narrowEpistemic_space : (7 * 2) ^ 3 = 2744 := by native_decide
-
--- ============================================================================
--- §9: Delimiting Principle 7 — Static Complementarity (§2.7)
--- ============================================================================
-
-/-- The 4 evidential options surviving Static Complementarity + Convexity:
-{+,%}, {%,−}, {%}, {−}.
-
-These are the convex subsets minus {+}, {+,%,−} (which are the epistemic
-options) and minus {+,−} (non-convex). -/
-def staticComplementarityEvChoices : List BiasChoice :=
-  [ [.pos, .neut], [.neut, .neg], [.neut], [.neg] ]
-
-/-- A bias profile satisfies Static Complementarity if:
-- Epistemic cells use {+} or {+,%,−} (Narrow Epistemic Choice)
-- Evidential cells use {+,%}, {%,−}, {%}, or {−} -/
-def isStaticComplementaryEv (bc : BiasChoice) : Bool :=
-  bc == [.pos, .neut] || bc == [.neut, .neg] ||
-  bc == [.neut] || bc == [.neg]
-
-def staticComplementarity (bp : BiasProfile) : Bool :=
-  narrowEpistemic bp &&
-  isStaticComplementaryEv bp.ppqEv &&
-  isStaticComplementaryEv bp.inNpqEv &&
-  isStaticComplementaryEv bp.onNpqEv
-
-/-- Static Complementarity + Convexity yields (4 × 2)³ = 512 profiles. -/
-theorem staticComplementarity_space : (4 * 2) ^ 3 = 512 := by native_decide
-
--- ============================================================================
--- §10: Cross-Linguistic Data — Appendix A
--- ============================================================================
-
-/-- [1] English V1-Interrogative (Appendix A [1],
-from Sudo 2013:284).
-
-PPQ:    ⟨{+,  %}, {+, −, %}⟩
-IN-NPQ: ⟨{−},     {+}⟩
-ON-NPQ: ⟨{−, %},  {+}⟩ -/
-def englishV1 : BiasProfile where
-  ppqEv   := [.pos, .neut]
-  ppqEp   := [.pos, .neut, .neg]
-  inNpqEv := [.neg]
-  inNpqEp := [.pos]
-  onNpqEv := [.neut, .neg]
-  onNpqEp := [.pos]
-
-/-- [2] Japanese ∅-Interrogative (Appendix A [2],
-from Sudo 2013:285).
-
-PPQ:    ⟨{%},      {+, −, %}⟩
-IN-NPQ: ⟨{−},      {+, −, %}⟩
-ON-NPQ: ⟨{+, %},   {+}⟩ -/
-def japaneseNull : BiasProfile where
-  ppqEv   := [.neut]
-  ppqEp   := [.pos, .neut, .neg]
-  inNpqEv := [.neg]
-  inNpqEp := [.pos, .neut, .neg]
-  onNpqEv := [.pos, .neut]
-  onNpqEp := [.pos]
-
-/-- [3] Japanese *no*-Interrogative (Appendix A [3],
-= ex. (4), from Sudo 2013:288).
-
-PPQ:    ⟨{+},           {+, −, %}⟩
-IN-NPQ: ⟨{−},           {+}⟩
-ON-NPQ: ⟨{+, −, %},     {+}⟩ -/
-def japaneseNo : BiasProfile where
-  ppqEv   := [.pos]
-  ppqEp   := [.pos, .neut, .neg]
-  inNpqEv := [.neg]
-  inNpqEp := [.pos]
-  onNpqEv := [.pos, .neut, .neg]
-  onNpqEp := [.pos]
-
-/-- [4] Japanese *desho*-Interrogative (Appendix A [4],
-= ex. (23), from Sudo 2013:290).
-
-PPQ:    ⟨{+, −, %},  {+}⟩
-IN-NPQ: ⟨{+, −, %},  {−}⟩
-ON-NPQ: ⟨{−, %},     {−}⟩ -/
-def japaneseDesho : BiasProfile where
-  ppqEv   := [.pos, .neut, .neg]
-  ppqEp   := [.pos]
-  inNpqEv := [.pos, .neut, .neg]
-  inNpqEp := [.neg]
-  onNpqEv := [.neut, .neg]
-  onNpqEp := [.neg]
-
-/-- [5] Hungarian ∧-Interrogative (Appendix A [5],
-from Gyuris 2017: Section 4).
-
-PPQ:    ⟨{+, %},    {+, −, %}⟩
-IN-NPQ: ⟨{−},       {+}⟩
-ON-NPQ: ⟨{−, %},    {+}⟩ -/
-def hungarianWedge : BiasProfile where
-  ppqEv   := [.pos, .neut]
-  ppqEp   := [.pos, .neut, .neg]
-  inNpqEv := [.neg]
-  inNpqEp := [.pos]
-  onNpqEv := [.neut, .neg]
-  onNpqEp := [.pos]
-
-/-- [6] Hungarian *e*-Interrogative (Appendix A [6],
-= ex. (10), from Gyuris 2017: Section 4). IN-NPQ is not expressible.
-
-PPQ:    ⟨{%},   {+, −, %}⟩
-ON-NPQ: ⟨{%},   {+}⟩ -/
-structure PartialBiasProfile where
-  ppqEv    : BiasChoice
-  ppqEp    : BiasChoice
-  onNpqEv  : BiasChoice
-  onNpqEp  : BiasChoice
-  deriving Repr
-
-def hungarianE : PartialBiasProfile where
-  ppqEv   := [.neut]
-  ppqEp   := [.pos, .neut, .neg]
-  onNpqEv := [.neut]
-  onNpqEp := [.pos]
-
--- ============================================================================
--- §11: Verification — Principles Against Data
--- ============================================================================
-
-/-- English V1 satisfies No Uniformity. -/
-theorem englishV1_noUniformity : noUniformity englishV1 = true := rfl
-
-/-- English V1 satisfies PPQ ≠ NPQ. -/
-theorem englishV1_ppqNeqNpq : ppqNeqNpq englishV1 = true := rfl
-
-/-- English V1 satisfies Convexity. -/
-theorem englishV1_convexity : convexity englishV1 = true := rfl
-
-/-- English V1 satisfies Narrow Epistemic Choice. -/
-theorem englishV1_narrowEpistemic : narrowEpistemic englishV1 = true := rfl
-
-/-- English V1 satisfies Static Complementarity. -/
-theorem englishV1_staticComplementarity :
-    staticComplementarity englishV1 = true := rfl
-
-/-- Hungarian ∧-Interrogative has the same bias profile as English V1
-(Appendix A: [5] = [1]). -/
-theorem hungarianWedge_eq_englishV1 : hungarianWedge = englishV1 := rfl
-
-/-- Japanese ∅-Interrogative satisfies No Uniformity. -/
-theorem japaneseNull_noUniformity : noUniformity japaneseNull = true := rfl
-
-/-- Japanese ∅-Interrogative violates PPQ ≠ NPQ: PPQ^ep = IN-NPQ^ep = {+,−,%}.
-Under the AND interpretation (both ev and ep must differ), identical
-epistemic values suffice to violate the constraint. -/
-theorem japaneseNull_violates_ppqNeqNpq : ppqNeqNpq japaneseNull = false := rfl
-
-/-- Japanese ∅-Interrogative satisfies Convexity. -/
-theorem japaneseNull_convexity : convexity japaneseNull = true := rfl
-
-/-- Japanese ∅-Interrogative satisfies Static Complementarity:
-all ev cells ∈ {{+,%},{%,−},{%},{−}} and all ep cells ∈ {{+},{+,−,%}}.
-Despite violating PPQ ≠ NPQ, its profile is within the 512-profile
-SC-permissible space. -/
-theorem japaneseNull_staticComplementarity :
-    staticComplementarity japaneseNull = true := rfl
-
-/-- Japanese *no*-Interrogative satisfies No Uniformity. -/
-theorem japaneseNo_noUniformity : noUniformity japaneseNo = true := rfl
-
-/-- Japanese *no*-Interrogative satisfies PPQ ≠ NPQ. -/
-theorem japaneseNo_ppqNeqNpq : ppqNeqNpq japaneseNo = true := rfl
-
--- §11.1: Known counterexamples to principles
-
-/-- Japanese *no*-Interrogative violates Distributive Markedness:
-|PPQ^ev| = 1 < |ON-NPQ^ev| = 3. This is a known counterexample
-noted by §2.3. -/
-theorem japaneseNo_violates_distributiveMarkedness :
-    markednessDistributive japaneseNo = false := rfl
-
-/-- Japanese *no*-Interrogative violates Static Complementarity:
-ON-NPQ^ev = {+,−,%} which is not in the static complementarity set
-of evidential options. -/
-theorem japaneseNo_violates_staticComplementarity :
-    staticComplementarity japaneseNo = false := rfl
-
-/-- Japanese *desho*-Interrogative violates Avoid Disagreement:
-IN-NPQ^ev contains + and PPQ^ev contains −. -/
-theorem japaneseDesho_violates_avoidDisagreement :
-    avoidDisagreement japaneseDesho = false := rfl
-
-/-- Japanese *desho*-Interrogative violates Narrow Epistemic Choice:
-IN-NPQ^ep and ON-NPQ^ep select {−}, which is neither {+} nor {+,%,−}. -/
-theorem japaneseDesho_violates_narrowEpistemic :
-    narrowEpistemic japaneseDesho = false := rfl
-
-/-- Japanese *desho*-Interrogative violates PPQ ≠ NPQ:
-PPQ^ev = IN-NPQ^ev = {+,−,%}. -/
-theorem japaneseDesho_violates_ppqNeqNpq :
-    ppqNeqNpq japaneseDesho = false := rfl
-
-/-- Japanese *desho*-Interrogative violates Static Complementarity
-(via narrowEpistemic failure). -/
-theorem japaneseDesho_violates_staticComplementarity :
-    staticComplementarity japaneseDesho = false := rfl
-
--- §11.2: Polarity Match / QA Alignment incompatibility (§3.1.2)
-
-/-- English V1 violates Avoid Disagreement: PPQ^ep = {+,−,%} contains −,
-and IN-NPQ^ep = {+} contains +. This exemplifies the systematic
-incompatibility between Narrow Epistemic Choice and Polarity Match
-for epistemic cells (§3.1.2). -/
-theorem englishV1_violates_avoidDisagreement :
-    avoidDisagreement englishV1 = false := rfl
-
-/-- English V1 violates Don't Rule Out Agreement: IN-NPQ^ep = {+} does
-not contain −. Again, the epistemic dimension conflicts with NEC-derived
-empirical patterns (§3.1.2). -/
-theorem englishV1_violates_dontRuleOutAgreement :
-    dontRuleOutAgreement englishV1 = false := rfl
-
-/-- English V1 satisfies Distributive Markedness. -/
-theorem englishV1_markednessDistributive :
-    markednessDistributive englishV1 = true := rfl
-
-/-- English V1 satisfies Collective Markedness. -/
-theorem englishV1_markednessCollective :
-    markednessCollective englishV1 = true := rfl
-
--- ============================================================================
--- §12: Bridge to Romero Typology
--- ============================================================================
-
-/-- Map G&G's evidential bias choice to Romero/Bias ContextualEvidence
-compatibility. A bias choice lists which evidence types are felicitous. -/
-def evidentiallyCompatible (bc : BiasChoice) (ce : ContextualEvidence) : Bool :=
-  match ce with
-  | .forP     => bc.contains .pos
-  | .neutral  => bc.contains .neut
-  | .againstP => bc.contains .neg
-
-/-- Map G&G's epistemic bias choice to Romero/Bias OriginalBias
-compatibility. -/
-def epistemicallyCompatible (bc : BiasChoice) (ob : OriginalBias) : Bool :=
-  match ob with
-  | .forP     => bc.contains .pos
-  | .neutral  => bc.contains .neut
-  | .againstP => bc.contains .neg
-
-/-- English V1 IN-NPQ (= Romero's LoNQ) requires evidence against p,
-matching Romero's Table 2 prediction. -/
-theorem englishV1_inNpq_evidence_matches_romero :
-    evidentiallyCompatible englishV1.inNpqEv .forP = false ∧
-    evidentiallyCompatible englishV1.inNpqEv .neutral = false ∧
-    evidentiallyCompatible englishV1.inNpqEv .againstP = true := ⟨rfl, rfl, rfl⟩
-
-/-- English V1 ON-NPQ (= Romero's HiNQ) has epistemic bias for p only,
-matching Romero's requirement that HiNQ conveys original bias for p. -/
-theorem englishV1_onNpq_epistemic_matches_romero :
-    epistemicallyCompatible englishV1.onNpqEp .forP = true ∧
-    epistemicallyCompatible englishV1.onNpqEp .neutral = false ∧
-    epistemicallyCompatible englishV1.onNpqEp .againstP = false := ⟨rfl, rfl, rfl⟩
-
-/-- English V1 PPQ (= Romero's PosQ) is compatible with evidence for p
-or neutral evidence, matching Romero's Table 2. -/
-theorem englishV1_ppq_evidence_matches_romero :
-    evidentiallyCompatible englishV1.ppqEv .forP = true ∧
-    evidentiallyCompatible englishV1.ppqEv .neutral = true ∧
-    evidentiallyCompatible englishV1.ppqEv .againstP = false := ⟨rfl, rfl, rfl⟩
-
-/-- Hungarian *e*-Interrogative has evidential "anti-bias" {%^ev} for PPQ:
-requiring *neutral* evidence only. This is the key counterexample to
-PPQ ≠ NPQ noted by §2.2.
-
-This contrasts with standard PPQs which admit positive evidence. -/
-theorem hungarianE_ppq_antibias :
-    hungarianE.ppqEv = [BiasValue.neut] := rfl
-
--- ============================================================================
--- §13: Czech Integration — Derive G&G Profile from czechBiasProfile
--- ============================================================================
-
-open Stankova2026 (CzechPQForm czechBiasProfile)
-
-/-- Derive a G&G evidential bias choice for a Czech PQ form by checking
-which contextual evidence values admit that form (across any epistemic bias). -/
-private def czechEvChoice (f : CzechPQForm) : BiasChoice :=
-  let forP := [OriginalBias.forP, .neutral, .againstP].any
-    λ ob => (czechBiasProfile .forP ob).contains f
-  let neut := [OriginalBias.forP, .neutral, .againstP].any
-    λ ob => (czechBiasProfile .neutral ob).contains f
-  let againstP := [OriginalBias.forP, .neutral, .againstP].any
-    λ ob => (czechBiasProfile .againstP ob).contains f
-  (if forP then [BiasValue.pos] else []) ++
-  (if neut then [BiasValue.neut] else []) ++
-  (if againstP then [BiasValue.neg] else [])
-
-/-- Derive a G&G epistemic bias choice for a Czech PQ form by checking
-which original bias values admit that form (across any evidence). -/
-private def czechEpChoice (f : CzechPQForm) : BiasChoice :=
-  let forP := [ContextualEvidence.forP, .neutral, .againstP].any
-    λ ev => (czechBiasProfile ev .forP).contains f
-  let neut := [ContextualEvidence.forP, .neutral, .againstP].any
-    λ ev => (czechBiasProfile ev .neutral).contains f
-  let againstP := [ContextualEvidence.forP, .neutral, .againstP].any
-    λ ev => (czechBiasProfile ev .againstP).contains f
-  (if forP then [BiasValue.pos] else []) ++
-  (if neut then [BiasValue.neut] else []) ++
-  (if againstP then [BiasValue.neg] else [])
-
-/-- Czech bias profile in G&G format, derived from [simik-2024] Table 2
-via `czechBiasProfile`.
-
-Czech V1-Interrogative (InterPPQ/InterNPQ as PPQ/ON-NPQ):
-- InterPPQ = PPQ: ev={%}, ep={+,%}
-- DeclNPQ = IN-NPQ: ev={−}, ep={+,%}
-- InterNPQ = ON-NPQ: ev={+,%,−}, ep={+,%} -/
-def czechV1 : BiasProfile where
-  ppqEv   := czechEvChoice .interPPQ
-  ppqEp   := czechEpChoice .interPPQ
-  inNpqEv := czechEvChoice .declNPQ
-  inNpqEp := czechEpChoice .declNPQ
-  onNpqEv := czechEvChoice .interNPQ
-  onNpqEp := czechEpChoice .interNPQ
-
-/-- Czech PPQ (InterPPQ) admits only neutral evidence — narrower than
-English V1 PPQ. Czech InterPPQ is the default unbiased PQ, felicitous
-only when there is no compelling evidence either way. -/
-theorem czechV1_ppq_ev : czechV1.ppqEv = [.neut] := rfl
-
-/-- Czech ON-NPQ (InterNPQ) has *broader* evidential distribution than
-English — it admits +, %, and − evidence, reflecting FALSUM^CZ's weaker
-requirements ([simik-2024] §5). -/
-theorem czechV1_onNpq_ev : czechV1.onNpqEv = [.pos, .neut, .neg] := rfl
-
-/-- Czech ON-NPQ (InterNPQ) epistemic bias admits + and % (speaker believes
-p or is neutral). Unlike English HiNQ which requires bias for p, Czech
-InterNPQ is also felicitous in explanation-seeking contexts (neutral
-epistemic bias, [simik-2024] §5.2). -/
-theorem czechV1_onNpq_ep : czechV1.onNpqEp = [.pos, .neut] := rfl
-
-/-- Czech V1 profile satisfies No Uniformity. -/
-theorem czechV1_noUniformity : noUniformity czechV1 = true := rfl
-
-/-- Czech V1 profile violates PPQ ≠ NPQ: PPQ^ep = IN-NPQ^ep = {+,%}.
-Czech InterPPQ and DeclNPQ share the same epistemic bias distribution,
-reflecting that both forms are felicitous when the speaker either believes
-p or is neutral. -/
-theorem czechV1_violates_ppqNeqNpq : ppqNeqNpq czechV1 = false := rfl
-
-/-- Czech V1 profile satisfies Convexity. -/
-theorem czechV1_convexity : convexity czechV1 = true := rfl
-
-/-- Czech ON-NPQ evidential {+,%,−} violates Static Complementarity —
-this is expected because Czech FALSUM^CZ has broader distribution than
-English FALSUM, allowing all evidence types. The G&G framework was
-designed for English/Japanese/Hungarian where ON-NPQ evidence is narrower. -/
-theorem czechV1_violates_staticComplementarity :
-    staticComplementarity czechV1 = false := rfl
-
-/-- The key Czech vs English difference: Czech ON-NPQ admits positive
-evidence while English ON-NPQ does not. This is the empirical core of
-[simik-2024]'s FALSUM^CZ proposal. -/
-theorem czech_vs_english_onNpq_evidence :
-    -- Czech ON-NPQ: positive evidence OK
-    evidentiallyCompatible czechV1.onNpqEv .forP = true ∧
-    -- English ON-NPQ: positive evidence NOT OK
-    evidentiallyCompatible englishV1.onNpqEv .forP = false := ⟨rfl, rfl⟩
-
-/-- Czech InterPPQ shares the "anti-bias" evidential pattern {%^ev} with
-Hungarian *e*-interrogatives — both require neutral evidence only. This
-parallel is striking given that Czech InterPPQ and Hungarian *e*-PPQ
-serve different functions: Czech InterPPQ is the default unbiased PQ,
-while Hungarian *e*-PPQ carries positive epistemic bias. -/
-theorem czech_hungarian_shared_antibias :
-    czechV1.ppqEv = hungarianE.ppqEv := rfl
+open Question Features Data.Examples
+
+/-- A bias value: evidence or expectation for p (+), against p (−), or neither (%). -/
+inductive Bias where
+  | pos
+  | neg
+  | neut
+  deriving DecidableEq, Fintype
+
+/-- A bias choice: one of the seven nonempty sets of bias values. -/
+inductive Choice where
+  | pos
+  | neg
+  | neut
+  | posNeut
+  | posNeg
+  | negNeut
+  | all
+  deriving DecidableEq, Fintype
+
+/-- The values a choice admits. -/
+def Choice.toFinset : Choice → Finset Bias
+  | .pos => {.pos}
+  | .neg => {.neg}
+  | .neut => {.neut}
+  | .posNeut => {.pos, .neut}
+  | .posNeg => {.pos, .neg}
+  | .negNeut => {.neg, .neut}
+  | .all => Finset.univ
+
+theorem card_choice : Fintype.card Choice = 7 := by decide
+
+/-- The dimension a bias is drawn from. -/
+inductive Dimension where
+  | evidential
+  | epistemic
+  deriving DecidableEq, Fintype
+
+/-- The six cells of a profile: a polar question form in a bias dimension. -/
+inductive Cell where
+  | ppqEv
+  | ppqEp
+  | inEv
+  | inEp
+  | onEv
+  | onEp
+  deriving DecidableEq, Fintype
+
+/-- The question form of a cell. -/
+def Cell.form : Cell → PQForm
+  | .ppqEv | .ppqEp => .PosQ
+  | .inEv | .inEp => .LoNQ
+  | .onEv | .onEp => .HiNQ
+
+/-- The dimension of a cell. -/
+def Cell.dim : Cell → Dimension
+  | .ppqEv | .inEv | .onEv => .evidential
+  | .ppqEp | .inEp | .onEp => .epistemic
+
+/-- The cell of a form in a dimension. -/
+def Cell.of : PQForm → Dimension → Cell
+  | .PosQ, .evidential => .ppqEv
+  | .PosQ, .epistemic => .ppqEp
+  | .LoNQ, .evidential => .inEv
+  | .LoNQ, .epistemic => .inEp
+  | .HiNQ, .evidential => .onEv
+  | .HiNQ, .epistemic => .onEp
+
+/-- A bias profile: a choice for each cell. -/
+abbrev Profile := Cell → Choice
+
+theorem card_profile : Fintype.card Profile = 117649 := by
+  simp only [Fintype.card_fun, card_choice]; decide
+
+/-! ### Counting principles -/
+
+/-- A principle that constrains each cell on its own. -/
+abbrev Cellwise (A : Cell → Choice → Prop) (p : Profile) : Prop := ∀ c, A c (p c)
+
+/-- A cellwise principle leaves the product over cells of the choices it allows there. -/
+theorem card_cellwise (A : Cell → Choice → Prop) [∀ c, DecidablePred (A c)] :
+    Fintype.card {p : Profile // Cellwise A p} = ∏ c, Fintype.card {x // A c x} :=
+  (Fintype.card_congr (Equiv.subtypePiEquivPi (p := A))).trans Fintype.card_pi
+
+/-- A profile by dimension. -/
+def byDim (p : Profile) (d : Dimension) : PQForm → Choice := λ q => p (.of q d)
+
+/-- A form's evidential and epistemic choices. -/
+def pair (p : Profile) (q : PQForm) : Choice × Choice :=
+  (p (.of q .evidential), p (.of q .epistemic))
+
+/-- A principle relating the positive question's value to each negative question's value factors
+through the positive question's value. -/
+def formEquiv {X : Type*} (R : X → X → Prop) :
+    {g : PQForm → X // R (g .PosQ) (g .LoNQ) ∧ R (g .PosQ) (g .HiNQ)} ≃
+      Σ x : X, {y // R x y} × {y // R x y} where
+  toFun g := ⟨g.1 .PosQ, ⟨g.1 .LoNQ, g.2.1⟩, ⟨g.1 .HiNQ, g.2.2⟩⟩
+  invFun s :=
+    ⟨λ q => match q with | .PosQ => s.1 | .LoNQ => s.2.1.1 | .HiNQ => s.2.2.1, s.2.1.2, s.2.2.2⟩
+  left_inv g := Subtype.ext (funext λ q => by cases q <;> rfl)
+  right_inv s := by rcases s with ⟨x, ⟨y, hy⟩, ⟨z, hz⟩⟩; rfl
+
+theorem card_form {X : Type*} [Fintype X] [DecidableEq X] (R : X → X → Prop) [DecidableRel R] :
+    Fintype.card {g : PQForm → X // R (g .PosQ) (g .LoNQ) ∧ R (g .PosQ) (g .HiNQ)} =
+      ∑ x : X, Fintype.card {y // R x y} * Fintype.card {y // R x y} :=
+  (Fintype.card_congr (formEquiv R)).trans (Fintype.card_sigma.trans (by simp [Fintype.card_prod]))
+
+/-- Profiles as functions from dimensions to form triples. -/
+def dimEquiv : Profile ≃ (Dimension → PQForm → Choice) where
+  toFun p d q := p (.of q d)
+  invFun f c := f c.dim c.form
+  left_inv p := funext λ c => by cases c <;> rfl
+  right_inv f := funext λ d => funext λ q => by cases d <;> cases q <;> rfl
+
+/-- A principle imposed within each dimension counts as the square of the per-dimension count. -/
+theorem card_perDim (Q : (PQForm → Choice) → Prop) [DecidablePred Q] :
+    Fintype.card {p : Profile // ∀ d, Q (byDim p d)} = Fintype.card {g // Q g} ^ 2 :=
+  (Fintype.card_congr ((Equiv.subtypeEquiv dimEquiv λ _ => Iff.rfl).trans
+    (Equiv.subtypePiEquivPi (p := λ _ => Q)))).trans
+    (Fintype.card_pi.trans (by simp only [Finset.prod_const, Finset.card_univ]; rfl))
+
+/-- Profiles as functions from forms to pairs of choices. -/
+def formsEquiv : Profile ≃ (PQForm → Choice × Choice) where
+  toFun p q := pair p q
+  invFun f c := match c.dim with | .evidential => (f c.form).1 | .epistemic => (f c.form).2
+  left_inv p := funext λ c => by cases c <;> rfl
+  right_inv f := funext λ q => by cases q <;> rfl
+
+/-- A principle relating each negative question's pair of choices to the positive question's. -/
+theorem card_byForm (R : Choice × Choice → Choice × Choice → Prop) [DecidableRel R] :
+    Fintype.card {p : Profile //
+        R (pair p .PosQ) (pair p .LoNQ) ∧ R (pair p .PosQ) (pair p .HiNQ)} =
+      ∑ x : Choice × Choice, Fintype.card {y // R x y} * Fintype.card {y // R x y} :=
+  (Fintype.card_congr (Equiv.subtypeEquiv formsEquiv λ _ => Iff.rfl)).trans (card_form R)
+
+/-! ### The delimiting principles (section 2) -/
+
+/-- Section 2.1, No Uniformity: not every cell makes the same choice. -/
+abbrev NoUniformity (p : Profile) : Prop := ¬ ∃ x, ∀ c, p c = x
+
+/-- The uniform profiles are the choices. -/
+def uniformEquiv : Choice ≃ {p : Profile // ∃ x, ∀ c, p c = x} where
+  toFun x := ⟨λ _ => x, x, λ _ => rfl⟩
+  invFun p := p.1 .ppqEv
+  left_inv _ := rfl
+  right_inv p := by
+    obtain ⟨p, x, hx⟩ := p
+    exact Subtype.ext (funext λ c => by simp only [hx c, hx .ppqEv])
+
+theorem card_noUniformity : Fintype.card {p : Profile // NoUniformity p} = 117642 := by
+  have h : Fintype.card {p : Profile // ∃ x, ∀ c, p c = x} +
+      Fintype.card {p : Profile // NoUniformity p} = Fintype.card Profile := by
+    rw [← Fintype.card_sum]
+    exact Fintype.card_congr (Equiv.sumCompl _)
+  rw [card_profile, ← Fintype.card_congr uniformEquiv, card_choice] at h
+  omega
+
+/-- Section 2.2, PPQ ≠ NPQ: in each dimension, negation changes the bias. -/
+abbrev PPQNeqNPQ (p : Profile) : Prop :=
+  ∀ d, byDim p d .PosQ ≠ byDim p d .LoNQ ∧ byDim p d .PosQ ≠ byDim p d .HiNQ
+
+theorem card_ppqNeqNpq : Fintype.card {p : Profile // PPQNeqNPQ p} = 63504 :=
+  (card_perDim (λ g => g .PosQ ≠ g .LoNQ ∧ g .PosQ ≠ g .HiNQ)).trans
+    (by rw [card_form (· ≠ ·)]; decide)
+
+/-- Section 2.3.1, distributive Quantitative Markedness (11a): in each dimension the positive
+question has at least as many options as each negative question. -/
+abbrev MarkednessDistributive (p : Profile) : Prop :=
+  ∀ d, (byDim p d .LoNQ).toFinset.card ≤ (byDim p d .PosQ).toFinset.card ∧
+    (byDim p d .HiNQ).toFinset.card ≤ (byDim p d .PosQ).toFinset.card
+
+theorem card_markednessDistributive :
+    Fintype.card {p : Profile // MarkednessDistributive p} = 33856 :=
+  (card_perDim (λ g => (g .LoNQ).toFinset.card ≤ (g .PosQ).toFinset.card ∧
+    (g .HiNQ).toFinset.card ≤ (g .PosQ).toFinset.card)).trans
+    (by rw [card_form (λ x y : Choice => y.toFinset.card ≤ x.toFinset.card)]; decide)
+
+/-- The number of bias options a form has across both dimensions. -/
+def size (h : Choice × Choice) : ℕ := h.1.toFinset.card + h.2.toFinset.card
+
+/-- Section 2.3.1, collective Quantitative Markedness (11b): across both dimensions the positive
+question has at least as many options as each negative question. -/
+abbrev MarkednessCollective (p : Profile) : Prop :=
+  size (pair p .LoNQ) ≤ size (pair p .PosQ) ∧ size (pair p .HiNQ) ≤ size (pair p .PosQ)
+
+theorem card_markednessCollective :
+    Fintype.card {p : Profile // MarkednessCollective p} = 56536 :=
+  (card_byForm (λ x y => size y ≤ size x)).trans (by decide)
+
+/-- Section 2.3.2, generalized Qualitative Markedness: the neutral value belongs to the positive
+question's cells and to no negative question's cell. -/
+abbrev QualitativeMarkedness : Profile → Prop :=
+  Cellwise λ c x => (c.form = .PosQ → .neut ∈ x.toFinset) ∧ (c.form ≠ .PosQ → .neut ∉ x.toFinset)
+
+theorem card_qualitativeMarkedness :
+    Fintype.card {p : Profile // QualitativeMarkedness p} = 1296 :=
+  (card_cellwise _).trans (by decide)
+
+/-- Section 2.4, Avoid Disagreement: no negative value for a positive question, no positive value
+for a negative one. -/
+abbrev AvoidDisagreement : Profile → Prop :=
+  Cellwise λ c x => (c.form = .PosQ → .neg ∉ x.toFinset) ∧ (c.form ≠ .PosQ → .pos ∉ x.toFinset)
+
+theorem card_avoidDisagreement : Fintype.card {p : Profile // AvoidDisagreement p} = 729 :=
+  (card_cellwise _).trans (by decide)
+
+/-- Section 2.4, Don't Rule Out Agreement: every positive-question cell admits the positive value
+and every negative-question cell the negative one. -/
+abbrev DontRuleOutAgreement : Profile → Prop :=
+  Cellwise λ c x => (c.form = .PosQ → .pos ∈ x.toFinset) ∧ (c.form ≠ .PosQ → .neg ∈ x.toFinset)
+
+theorem card_dontRuleOutAgreement :
+    Fintype.card {p : Profile // DontRuleOutAgreement p} = 4096 :=
+  (card_cellwise _).trans (by decide)
+
+/-- Section 2.5: a choice is convex when it does not skip the neutral value between the positive
+and the negative one, that is, when it is not {+, −}. -/
+abbrev Convex (x : Choice) : Prop := x ≠ .posNeg
+
+/-- Section 2.5, Convexity: every cell is convex. -/
+abbrev Convexity : Profile → Prop := Cellwise λ _ => Convex
+
+theorem card_convexity : Fintype.card {p : Profile // Convexity p} = 46656 :=
+  (card_cellwise _).trans (by decide)
+
+/-- Section 2.6: the epistemic options the sample exhibits, {+} and {+, −, %}. -/
+abbrev NarrowChoice (x : Choice) : Prop := x = .pos ∨ x = .all
+
+/-- Section 2.6, Narrow Epistemic Choice: every epistemic cell is {+} or {+, −, %}. -/
+abbrev NarrowEpistemic : Profile → Prop :=
+  Cellwise λ c x => c.dim = .epistemic → NarrowChoice x
+
+theorem card_narrowEpistemic : Fintype.card {p : Profile // NarrowEpistemic p} = 2744 :=
+  (card_cellwise _).trans (by decide)
+
+/-- Section 2.7, Static Complementarity: epistemic cells take the narrow options and evidential
+cells the remaining ones. -/
+abbrev StaticComplementarity : Profile → Prop :=
+  Cellwise λ c x => (c.dim = .epistemic → NarrowChoice x) ∧ (c.dim ≠ .epistemic → ¬ NarrowChoice x)
+
+theorem card_staticComplementarity_convexity :
+    Fintype.card {p : Profile // StaticComplementarity p ∧ Convexity p} = 512 := by
+  have h : ∀ p : Profile, StaticComplementarity p ∧ Convexity p ↔ Cellwise (λ c x =>
+      ((c.dim = .epistemic → NarrowChoice x) ∧ (c.dim ≠ .epistemic → ¬ NarrowChoice x)) ∧
+        Convex x) p :=
+    λ p => (forall_and (α := Cell)).symm
+  rw [Fintype.card_congr (Equiv.subtypeEquiv (Equiv.refl _) h), card_cellwise]
+  decide
+
+/-! ### Relations among the principles (section 3.1.2) -/
+
+/-- Avoid Disagreement entails Convexity: a cell without one of the poles cannot be {+, −}. -/
+theorem Convexity_of_avoidDisagreement {p : Profile} (h : AvoidDisagreement p) : Convexity p := by
+  intro c hc
+  obtain ⟨h₁, h₂⟩ := h c
+  rw [hc] at h₁ h₂
+  by_cases hq : c.form = .PosQ
+  · exact h₁ hq (by decide)
+  · exact h₂ hq (by decide)
+
+/-- Narrow Epistemic Choice gives every negative question the positive epistemic value, which
+Avoid Disagreement forbids; Polarity Match can only be meant evidentially. -/
+theorem not_avoidDisagreement_of_narrowEpistemic {p : Profile} (h : NarrowEpistemic p) :
+    ¬ AvoidDisagreement p := by
+  intro had
+  have h₁ := h .inEp rfl
+  have h₂ := (had .inEp).2 (by decide)
+  rcases h₁ with h₁ | h₁ <;> rw [h₁] at h₂ <;> exact h₂ (by decide)
+
+/-! ### Appendix A: the sample -/
+
+/-- A profile from its six cells, in the order positive, inside-negation, outside-negation question,
+each evidential then epistemic. -/
+def mk (ppqEv ppqEp inEv inEp onEv onEp : Choice) : Profile
+  | .ppqEv => ppqEv
+  | .ppqEp => ppqEp
+  | .inEv => inEv
+  | .inEp => inEp
+  | .onEv => onEv
+  | .onEp => onEp
+
+/-- [1] English V1-interrogative ([sudo-2013]). -/
+def englishV1 : Profile := mk .posNeut .all .neg .pos .negNeut .pos
+/-- [2] Japanese ∅-interrogative ([sudo-2013]). -/
+def japaneseNull : Profile := mk .neut .all .neg .all .posNeut .pos
+/-- [3] Japanese *no*-interrogative ([sudo-2013]). -/
+def japaneseNo : Profile := mk .pos .all .neg .pos .all .pos
+/-- [4] Japanese *desho*-interrogative ([sudo-2013]). -/
+def japaneseDesho : Profile := mk .all .pos .all .neg .negNeut .neg
+/-- [5] Hungarian fall-rise interrogative ([gyuris-2017]). -/
+def hungarianFallRise : Profile := mk .posNeut .all .neg .pos .negNeut .pos
+
+/-- [6] Hungarian *e*-interrogative ([gyuris-2017]): it cannot express an inside-negation
+question, so its profile is partial. -/
+def hungarianE : Cell → Option Choice
+  | .ppqEv => some .neut
+  | .ppqEp => some .all
+  | .inEv | .inEp => none
+  | .onEv => some .neut
+  | .onEp => some .pos
+
+/-- The five total profiles of the sample. -/
+def sample : List Profile :=
+  [englishV1, japaneseNull, japaneseNo, japaneseDesho, hungarianFallRise]
+
+/-- The Hungarian fall-rise interrogative shares the English profile. -/
+theorem hungarianFallRise_eq_englishV1 : hungarianFallRise = englishV1 := rfl
+
+private theorem mem_sample {p : Profile} (h : p ∈ sample) :
+    p = englishV1 ∨ p = japaneseNull ∨ p = japaneseNo ∨ p = japaneseDesho ∨
+      p = hungarianFallRise := by
+  simpa [sample] using h
+
+/-- No Uniformity and collective Quantitative Markedness hold throughout the sample. -/
+theorem sample_noUniformity_markednessCollective :
+    ∀ p ∈ sample, NoUniformity p ∧ MarkednessCollective p := by
+  intro p hp; rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide
+
+/-- Distributive Quantitative Markedness fails for the Japanese ∅- and *no*-interrogatives, whose
+outside-negation questions have more evidential options than their positive questions. -/
+theorem sample_markednessDistributive :
+    ∀ p ∈ sample, MarkednessDistributive p ↔ p ≠ japaneseNull ∧ p ≠ japaneseNo := by
+  intro p hp; rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide
+
+/-- PPQ ≠ NPQ fails within the sample for the Japanese ∅- and *desho*-interrogatives, whose
+inside-negation question shares a choice with the positive question, and the paper's own
+counterexample is the Hungarian *e*-interrogative, whose positive and outside-negation questions
+share the evidential anti-bias {%}. -/
+theorem sample_ppqNeqNpq :
+    (∀ p ∈ sample, PPQNeqNPQ p ↔ p ≠ japaneseNull ∧ p ≠ japaneseDesho) ∧
+      hungarianE .ppqEv = hungarianE .onEv :=
+  ⟨λ p hp => by rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide, rfl⟩
+
+/-- Avoid Disagreement fails throughout the sample, while Don't Rule Out Agreement holds only for
+the *desho*-interrogative. -/
+theorem sample_polarityMatch :
+    ∀ p ∈ sample, ¬ AvoidDisagreement p ∧ (DontRuleOutAgreement p ↔ p = japaneseDesho) := by
+  intro p hp; rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide
+
+/-- Convexity holds throughout the sample; Narrow Epistemic Choice fails only for the
+*desho*-interrogative, whose negative questions carry {−}. -/
+theorem sample_convexity_narrowEpistemic :
+    ∀ p ∈ sample, Convexity p ∧ (NarrowEpistemic p ↔ p ≠ japaneseDesho) := by
+  intro p hp; rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide
+
+/-- Static Complementarity fails exactly for the Japanese *no*- and *desho*-interrogatives, the six
+violations of (26). -/
+theorem sample_staticComplementarity :
+    ∀ p ∈ sample, StaticComplementarity p ↔ p ≠ japaneseNo ∧ p ≠ japaneseDesho := by
+  intro p hp; rcases mem_sample hp with rfl | rfl | rfl | rfl | rfl <;> decide
+
+/-! ### Examples (1), (2), (8), (9): infelicity from the profiles -/
+
+/-- The clause types whose examples the paper judges. -/
+inductive Construction where
+  | englishV1
+  | hungarianE
+  deriving DecidableEq
+
+/-- A clause type's choice for a cell. -/
+def Construction.cell : Construction → Cell → Option Choice
+  | .englishV1, c => some (GartnerGyuris2017.englishV1 c)
+  | .hungarianE, c => GartnerGyuris2017.hungarianE c
+
+/-- An example: the clause type, the question it expresses, and the bias value the scenario fixes
+in one dimension, with the judgment. -/
+structure Row where
+  construction : Construction
+  form : PQForm
+  dimension : Dimension
+  value : Bias
+  judgment : Judgment
+  deriving DecidableEq
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let construction ← ex.parse? "construction"
+    [("English V1", .englishV1), ("Hungarian e", .hungarianE)]
+  let form ← ex.parse? "form" [("PPQ", .PosQ), ("IN-NPQ", .LoNQ), ("ON-NPQ", .HiNQ)]
+  let dimension ← ex.parse? "dimension" [("evidential", .evidential), ("epistemic", .epistemic)]
+  let value ← ex.parse? "value" [("+", .pos), ("-", .neg), ("%", .neut)]
+  pure ⟨construction, form, dimension, value, ex.judgment⟩
+
+/-- The judged examples (1), (2a), (2b), (8), (9a), (9b). -/
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+example : rows.length = Examples.all.length := by decide
+
+/-- An example is felicitous exactly when the scenario's bias value is among the clause type's
+options for that cell: the judgments follow from the profiles. -/
+theorem rows_felicity :
+    ∀ r ∈ rows, r.judgment = .acceptable ↔
+      ∃ x ∈ r.construction.cell (.of r.form r.dimension), r.value ∈ x.toFinset := by
+  decide
 
 end GartnerGyuris2017

--- a/references.bib
+++ b/references.bib
@@ -3392,7 +3392,7 @@
   subfield  = {semantics/questions},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/SeeligerRepp2018.lean}
+  sources   = {Studies/GartnerGyuris2017.lean;Studies/SeeligerRepp2018.lean}
 }
 % REF: Lo Guercio, N. (2025). Maximize Conventional Implicatures! S&P 18(9).
 @article{lo-guercio-2025,
@@ -6353,7 +6353,7 @@
   subfield  = {semantics/compositional},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/BuringGunlogson2000.lean;Studies/Dayal2025.lean}
+  sources   = {Semantics/Questions/Bias.lean;Studies/BuringGunlogson2000.lean;Studies/Dayal2025.lean;Studies/GartnerGyuris2017.lean;Studies/Krifka2015.lean}
 }
 @book{corbett-2000,
   author    = {Corbett, Greville G.},
@@ -15332,7 +15332,7 @@
   subfield  = {semantics/questions},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/RomeroHan2004.lean;Studies/BuringGunlogson2000.lean}
+  sources   = {Fragments/English/PolarityItems.lean;Semantics/Questions/Bias.lean;Studies/BuringGunlogson2000.lean;Studies/GartnerGyuris2017.lean;Studies/RomeroHan2004.lean}
 }% REF: Belnap (1972). S-P Interrogatives.
 @incollection{belnap-1982,
   author    = {Belnap, Nuel D.},
@@ -24877,7 +24877,7 @@
   subfield  = {semantics/questions},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/GartnerGyuris2017.lean}
+  sources   = {Data/Examples/GartnerGyuris2017.json;Studies/GartnerGyuris2017.lean;Studies/Stankova2026.lean}
 }
 @inproceedings{kracht-1993,
   author    = {Kracht, Marcus},
@@ -43670,4 +43670,16 @@
   subfield  = {syntax/learning},
   role      = {cited},
   sources   = {Studies/GoldwaterJohnson2003.lean}
+}
+@article{gyuris-2017,
+  author    = {Gyuris, Be{\'a}ta},
+  year      = {2017},
+  title     = {New Perspectives on Bias in Polar Questions: A Study of {H}ungarian -e},
+  journal   = {International Review of Pragmatics},
+  volume    = {9},
+  number    = {1},
+  pages     = {1--50},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Studies/GartnerGyuris2017.lean}
 }


### PR DESCRIPTION
Deep cleanse of GartnerGyuris2017 against the paper: the bias-profile space and its delimiting principles as predicates on profiles, with the paper's counts proved structurally.

- Profiles are functions from six enumerated cells to seven enumerated choices; the counts (117649, 63504, 33856, 56536, 1296, 729, 4096, 46656, 2744, 512) are products over cells and sums over the positive question's value, with `decide` only on per-cell subtypes.
- Appendix A's five total profiles and the partial Hungarian *e* profile are checked against every principle by a per-profile case split, and the judgments of (1), (2), (8), (9) follow from the profiles via generated example rows.
- `PQForm` derives `Fintype`; bib gains gyuris-2017.
