### PR TITLE
refactor(Studies/GonzalezPootMcGinnis2006): judgments and the appendix

### DIFF
--- a/Linglib/Studies/GonzalezPootMcGinnis2006.lean
+++ b/Linglib/Studies/GonzalezPootMcGinnis2006.lean
@@ -4,82 +4,72 @@ import Linglib.Features.Person.Decomposition
 import Linglib.Data.Examples.GonzalezPootMcGinnis2006
 
 /-!
-# Local versus long-distance Fission in Distributed Morphology
+# González Poot and McGinnis (2006): Local versus Long-Distance Fission in Distributed Morphology
 
-[gonzalez-poot-mcginnis-2006]: the verbal agreement suffixes of Yucatec
-Maya come from one node, Agr3, which agrees with both the ergative subject
-and the nominative object and is realized by strict scansion of the
-Vocabulary (27) with local Fission — an item discharges its features from
-one of the node's two matrices and the residue stays available to the
-items below. The second- and third-person plural suffixes *-éːʃ* and
-*-oʔob* are unspecified for case, so their order is fixed by specificity,
-*-éːʃ* before *-oʔob* whatever the grammatical roles ((19)–(22)), and one
-scansion never inserts *-oʔob* twice ((23)–(24)); the object–subject
-template (18) gets both wrong. Long-distance Fission is rejected: the
-split of ergative person onto the auxiliary (Agr1, (43)) and number onto
-the verb runs across a word boundary, and first-person number is a person
-distinction ((42), on the feature-geometric treatment of first person).
-
-## Main definitions
-
-* `matrix`, `ergMatrix`: an argument's matrix over `Minimalist.FeatureVal` —
-  the person features of (26) from `Person.toFeatures`, number, and case.
-* `agr3`, `agr1`, `agr2`: the Vocabularies (27), (43), (44).
-* `suffixes`: Agr3's exponents for a subject and an object, by `scansion`.
-* `templateSuffixes`: the rival template (18), one node per argument.
-
-## Main results
-
-* `suffixes_rows`: every row of the pool is grammatical iff its suffixes are
-  `suffixes`' output.
-* `template_predicts_starred`, `template_fails_grammatical`: the template
-  predicts the starred orders of (21) and (23) and fails (22) and (24).
-* `aux_prefix_rows`: (43) and (44) recover the auxiliary suffix and the
-  verbal prefix of every row.
-* `first_person_no_verbal_number`: a first-person ergative argument takes no
-  verbal number suffix ((3)–(4)), since its number is not [+Pl].
+This file formalizes [gonzalez-poot-mcginnis-2006]'s argument that Yucatec Maya has local but
+not long-distance Fission. The verbal agreement suffixes come from one node, Agr3, which agrees
+with both the ergative subject and the nominative object and is realized by strict scansion of
+the Vocabulary (27) with local Fission ([halle-1997]): an item discharges its features from one
+of the node's two matrices and the residue stays available to the items below (`suffixes`). The
+second- and third-person plural suffixes *-éːʃ* and *-oʔob* are unspecified for case, so their
+order is fixed by specificity whatever the grammatical roles, (19) to (22), and one scansion
+never inserts *-oʔob* twice, (23) and (24) (`suffixes_rows`), whereas the object–subject template
+(18) predicts exactly the starred forms (`template_rows`). Long-distance Fission is rejected: the
+split of ergative person onto the auxiliary and number onto the verb, (39), crosses a word
+boundary, and first-person number is a person distinction, (42), so the auxiliary and prefix
+Vocabularies (43) and (44) recover every row (`aux_prefix_rows`) and derive the paradigm (39)
+that the paper aligns with Hebrew, Basque, and Georgian (`ergative_paradigm`,
+`first_person_paradigm`). The appendix's privative implementation over [harley-ritter-2002]'s
+features, (A1) to (A4), recovers the auxiliary and the prefix (`privative_aux_prefix`) but not
+the suffixes: without negative values, the nominative residue of a second-person plural object
+still matches *-en*, so (A4) over-generates on (20) (`privative_suffixes`).
 
 ## Implementation notes
 
-Agr3's list (27) needs the nominative first-person plural to carry [+PSE]
-and the singular not to, the reverse of the assignment (42) gives the
-ergative auxiliary; the paper does not reconcile the two, so `matrix` follows
-(27) for nominative first person and (42) otherwise. The elsewhere *-Ø* is
-inserted but not counted among a row's overt suffixes.
+The person features of (26), [±PSE, ±Auth], are the substrate's [±participant, ±author]
+decomposition, and [±Pl] a binary feature value. Agr3's list (27) needs the nominative
+first-person plural to carry [+PSE] and the singular not to, the reverse of the assignment (42)
+gives the ergative auxiliary; the paper does not reconcile the two, so `matrix` follows (27) for
+nominative first person and (42) otherwise. The elsewhere *-Ø* is inserted but not counted among
+a row's overt suffixes.
 
 ## References
 
-* [H. Harley and E. Ritter, *Person and number in pronouns*][harley-ritter-2002]
+* [gonzalez-poot-mcginnis-2006]
+* [halle-1997]
+* [noyer-1992]
+* [halle-marantz-1993]
+* [harley-ritter-2002]
 -/
 
 namespace GonzalezPootMcGinnis2006
 
-open DistributedMorphology Data.Examples
+open DistributedMorphology Data.Examples Features
 open Minimalist (FeatureVal)
 open scoped DistributedMorphology.VocabularyItem
 
-/-! ### Features and matrices (§3–4) -/
+/-! ### Features and matrices, sections 3 to 5 -/
 
-/-- The person features of (26), [±PSE, ±Auth], as the substrate's
-[±participant, ±author] decomposition of a person. -/
+/-- The person features of (26), [±PSE, ±Auth], as the substrate's [±participant, ±author]
+decomposition of a person. -/
 def personFeatures (p : Person) : List FeatureVal :=
   match Person.toFeatures p with
   | some f => [.participant f.hasParticipant, .author f.hasAuthor]
   | none => []
 
-/-- Number as [±Pl]: plural or singular. -/
+/-- Number as the feature [±Pl]. -/
 def number (pl : Bool) : FeatureVal := .phi (.number (if pl then .plural else .singular))
 
-/-- An ergative argument's matrix ((42)): first-person number is a person
-distinction — singular [+PSE, +Auth], plural [+Auth]. -/
+/-- An ergative argument's matrix, (42): first-person number is a person distinction, singular
+[+PSE, +Auth] and plural [+Auth]. -/
 def ergMatrix : Person → Bool → List FeatureVal
   | .first, false => [.participant true, .author true, .case .erg]
   | .first, true => [.author true, .case .erg]
   | p, pl => personFeatures p ++ [number pl, .case .erg]
 
-/-- An argument's matrix for Agr3: (42) for ergative arguments and for
-second and third person; for nominative first person the assignment (27)
-presupposes — *-oʔon* 1pl [+PSE, +Auth, NOM], *-en* 1sg [+Auth, NOM]. -/
+/-- An argument's matrix for Agr3: (42) for ergative arguments and for second and third person;
+for nominative first person the assignment (27) presupposes, *-oʔon* 1pl [+PSE, +Auth, NOM] and
+*-en* 1sg [+Auth, NOM]. -/
 def matrix : Person → Bool → Case → List FeatureVal
   | .first, false, .nom => [.author true, .case .nom]
   | .first, true, .nom => [.participant true, .author true, .case .nom]
@@ -104,83 +94,150 @@ def agr1 : List (VocabularyItem FeatureVal String) :=
 def agr2 : List (VocabularyItem FeatureVal String) :=
   [[.participant true] ⟷ "w", [.participant false] ⟷ "j", [] ⟷ ""]
 
-/-- The overt verbal suffixes of a clause: Agr3 bears the subject's matrix
-and, in a transitive clause, the object's ((25), (28b)); strict scansion of
-(27) realizes them, and the elsewhere *-Ø* is not overt. -/
+/-- The overt verbal suffixes of a clause: Agr3 bears the subject's matrix and, in a transitive
+clause, the object's, (25) and (28b); strict scansion of (27) realizes them, and the elsewhere
+*-Ø* is not overt. -/
 def suffixes (subj : Person × Bool) (obj : Option (Person × Bool)) : List String :=
   (scansion agr3 ∅
-    (matrix subj.1 subj.2 .erg :: (obj.map fun o => [matrix o.1 o.2 .nom]).getD []))
+    (matrix subj.1 subj.2 .erg :: (obj.map λ o => [matrix o.1 o.2 .nom]).getD []))
     |>.filter (· ≠ "Ø")
 
-/-- The rival template (18): object agreement then subject agreement, each a
-node of its own realized by the Subset Principle over (27). -/
+/-- The auxiliary suffix of an ergative subject, by the Subset Principle over (43). -/
+def aux (subj : Person × Bool) : Option String := subsetPrinciple agr1 (ergMatrix subj.1 subj.2)
+
+/-- The verbal prefix of an ergative subject, by the Subset Principle over (44). -/
+def verbPrefix (subj : Person × Bool) : Option String :=
+  subsetPrinciple agr2 (ergMatrix subj.1 subj.2)
+
+/-- The rival template (18): object agreement then subject agreement, each a node of its own
+realized by the Subset Principle over (27). -/
 def templateSuffixes (subj obj : Person × Bool) : List String :=
   ((subsetPrinciple agr3 (matrix obj.1 obj.2 .nom)).toList ++
     (subsetPrinciple agr3 (matrix subj.1 subj.2 .erg)).toList).filter (· ≠ "Ø")
 
-/-! ### The data pool -/
+/-! ### The data pool: (3) to (8), (16), (19) to (24) -/
 
-/-- A row of the pool: the arguments, the auxiliary suffix, the verbal
-prefix, the overt verbal suffixes, and the judgment. -/
+/-- A row of the pool: the arguments, the auxiliary suffix, the verbal prefix, the overt
+verbal suffixes, and the judgment. -/
 structure Row where
   subj : Person × Bool
   obj : Option (Person × Bool)
   aux : String
-  prefix_ : String
+  verbPrefix : String
   suffixes : List String
-  accepted : Bool
+  judgment : Judgment
   deriving DecidableEq, Repr
 
-def personOfString : String → Option Person
-  | "1" => some .first | "2" => some .second | "3" => some .third | _ => none
-
 def Row.ofExample (ex : LinguisticExample) : Option Row := do
-  let fs := ex.paperFeatures
-  let sp ← fs.lookup "subjPerson" >>= personOfString
-  let sn ← fs.lookup "subjNumber"
-  let obj ← match fs.lookup "objPerson", fs.lookup "objNumber" with
-    | some p, some n => (personOfString p).map fun op => some (op, decide (n = "pl"))
-    | _, _ => some none
-  let aux ← fs.lookup "aux"
-  let prefix_ ← fs.lookup "prefix"
-  let s₁ ← fs.lookup "suffix1"
-  let s₂ ← fs.lookup "suffix2"
-  pure ⟨(sp, sn = "pl"), obj, aux, prefix_, [s₁, s₂].filter (· ≠ ""), ex.judgment = .acceptable⟩
+  let person := [("1", Person.first), ("2", .second), ("3", .third)]
+  let plural := [("sg", false), ("pl", true)]
+  let subj ← ex.parse? "subjPerson" person
+  let subjPl ← ex.parse? "subjNumber" plural
+  let obj ← match ex.parse? "objPerson" person, ex.parse? "objNumber" plural with
+    | some p, some pl => some (some (p, pl))
+    | none, none => some none
+    | _, _ => none
+  let aux ← ex.feature? "aux"
+  let verbPrefix ← ex.feature? "prefix"
+  let s₁ ← ex.feature? "suffix1"
+  let s₂ ← ex.feature? "suffix2"
+  pure ⟨(subj, subjPl), obj, aux, verbPrefix, [s₁, s₂].filter (· ≠ ""), ex.judgment⟩
 
 theorem row_ofExample_isSome : ∀ ex ∈ Examples.all, (Row.ofExample ex).isSome := by decide
 
 def rows : List Row := Examples.all.filterMap Row.ofExample
 
-/-- **Local Fission** ((19)–(24), (16)): a row is grammatical iff its overt
-verbal suffixes are what strict scansion of (27) inserts — *-éːʃ* before
-*-oʔob* in both (20) and (22), *-oʔob* once in (24). -/
-theorem suffixes_rows : ∀ r ∈ rows, r.accepted = (suffixes r.subj r.obj = r.suffixes) := by
+/-- Local Fission, (19) to (24): a row is grammatical iff its overt verbal suffixes are what
+strict scansion of (27) inserts, *-éːʃ* before *-oʔob* in both (20) and (22) and *-oʔob* once in
+(24). -/
+theorem suffixes_rows :
+    ∀ r ∈ rows, r.judgment = .acceptable ↔ suffixes r.subj r.obj = r.suffixes := by
   decide
 
-/-- The template (18) predicts every starred form — *-oʔob-éːʃ* for (21),
-*-oʔob-oʔob* for (23). -/
-theorem template_predicts_starred :
-    ∀ r ∈ rows, ∀ o ∈ r.obj, r.accepted = false → templateSuffixes r.subj o = r.suffixes := by
+/-- The template (18) predicts every starred form, *-oʔob-éːʃ* for (21) and *-oʔob-oʔob* for
+(23), and fails the grammatical (22) and (24), whose orders it reverses or doubles. -/
+theorem template_rows :
+    (∀ r ∈ rows, ∀ o ∈ r.obj,
+        r.judgment = .ungrammatical → templateSuffixes r.subj o = r.suffixes) ∧
+      ∃ r ∈ rows, r.judgment = .acceptable ∧
+        ∃ o ∈ r.obj, templateSuffixes r.subj o ≠ r.suffixes := by
   decide
 
-/-- The template (18) fails a grammatical row — (22) and (24), whose orders
-it reverses or doubles — while fitting (19) and (20). -/
-theorem template_fails_grammatical :
-    ∃ r ∈ rows, r.accepted ∧ ∃ o ∈ r.obj, templateSuffixes r.subj o ≠ r.suffixes := by
-  decide
-
-/-- Agr1 (43) and Agr2 (44) recover the auxiliary suffix and verbal prefix of
-every row ((17), (39)). -/
+/-- Agr1 (43) and Agr2 (44) recover the auxiliary suffix and verbal prefix of every row, (17) and
+(39). -/
 theorem aux_prefix_rows :
-    ∀ r ∈ rows, subsetPrinciple agr1 (ergMatrix r.subj.1 r.subj.2) = some r.aux ∧
-      subsetPrinciple agr2 (ergMatrix r.subj.1 r.subj.2) = some r.prefix_ := by
+    ∀ r ∈ rows, aux r.subj = some r.aux ∧ verbPrefix r.subj = some r.verbPrefix := by
   decide
 
-/-- A first-person ergative argument takes no verbal number suffix ((3)–(4)):
-its number is a person distinction, so no item of (27) matches beyond the
-elsewhere. -/
-theorem first_person_no_verbal_number (pl : Bool) :
-    suffixes (.first, pl) none = [] := by
+/-! ### Against long-distance Fission, section 5 -/
+
+/-- The paradigm (39) for second and third person: the auxiliary suffix and the prefix mark
+person alone, and plurality is a verbal suffix, the distribution of (36) to (38). -/
+theorem ergative_paradigm (p : Person) (h : p = .second ∨ p = .third) :
+    aux (p, false) = aux (p, true) ∧ verbPrefix (p, false) = verbPrefix (p, true) ∧
+      suffixes (p, false) none = [] ∧ suffixes (p, true) none ≠ [] := by
+  rcases h with rfl | rfl <;> decide
+
+/-- The paradigm (39) for first person: the auxiliary distinguishes singular from plural and no
+verbal suffix marks number, since (42) makes first-person number a person distinction, (3) and
+(4). -/
+theorem first_person_paradigm :
+    aux (.first, false) ≠ aux (.first, true) ∧ ∀ pl, suffixes (.first, pl) none = [] := by
+  refine ⟨by decide, λ pl => ?_⟩
   cases pl <;> decide
+
+/-! ### The appendix: a privative implementation -/
+
+/-- [harley-ritter-2002]'s privative features, with the case feature the appendix adds. -/
+inductive Privative where
+  | participant
+  | speaker
+  | addressee
+  | group
+  | nom
+  deriving DecidableEq, Repr
+
+/-- The specifications (A1), with nominative case on a nominative argument. -/
+def privMatrix (p : Person) (pl : Bool) (c : Case) : List Privative :=
+  (match p, pl with
+    | .first, false => [.participant]
+    | .first, true => [.participant, .speaker]
+    | .second, false => [.participant, .addressee]
+    | .second, true => [.participant, .addressee, .group]
+    | _, false => []
+    | _, true => [.group]) ++ if c = .nom then [.nom] else []
+
+/-- The Agr1 Vocabulary Items (A2). -/
+def agr1' : List (VocabularyItem Privative String) :=
+  [[.speaker] ⟷ "k", [.addressee] ⟷ "a", [.participant] ⟷ "in", [] ⟷ "u"]
+
+/-- The Agr2 Vocabulary Items (A3). -/
+def agr2' : List (VocabularyItem Privative String) :=
+  [[.speaker] ⟷ "", [.participant] ⟷ "w", [] ⟷ "j"]
+
+/-- The Agr3 Vocabulary Items (A4). -/
+def agr3' : List (VocabularyItem Privative String) :=
+  [[.addressee, .group] ⟷ "éːʃ", [.addressee, .nom] ⟷ "etʃ", [.speaker, .nom] ⟷ "oʔon",
+    [.participant, .nom] ⟷ "en", [.group] ⟷ "oʔob", [] ⟷ "Ø"]
+
+/-- The overt verbal suffixes under (A4). -/
+def suffixes' (subj : Person × Bool) (obj : Option (Person × Bool)) : List String :=
+  (scansion agr3' ∅
+    (privMatrix subj.1 subj.2 .erg :: (obj.map λ o => [privMatrix o.1 o.2 .nom]).getD []))
+    |>.filter (· ≠ "Ø")
+
+/-- The privative Agr1 and Agr2 lists (A2) and (A3) recover the auxiliary suffix and the verbal
+prefix of every row. -/
+theorem privative_aux_prefix :
+    ∀ r ∈ rows, subsetPrinciple agr1' (privMatrix r.subj.1 r.subj.2 .erg) = aux r.subj ∧
+      subsetPrinciple agr2' (privMatrix r.subj.1 r.subj.2 .erg) = verbPrefix r.subj := by
+  decide
+
+/-- The privative Agr3 list (A4) fails a grammatical row: in (20) the object's residue after
+*-éːʃ* is [Participant, NOM], which *-en* matches, where the binary [−Auth] of (27) blocks it. -/
+theorem privative_suffixes :
+    suffixes' (.third, true) (some (.second, true)) = ["éːʃ", "en", "oʔob"] ∧
+      ∃ r ∈ rows, r.judgment = .acceptable ∧ suffixes' r.subj r.obj ≠ r.suffixes := by
+  decide
 
 end GonzalezPootMcGinnis2006

--- a/references.bib
+++ b/references.bib
@@ -13627,7 +13627,7 @@
   url       = {https://dspace.mit.edu/handle/1721.1/12895},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/DistributedMorphology/Fission.lean}
+  sources   = {Fragments/Mayan/Mam/Agreement.lean;Fragments/Mayan/Mam/Pronouns.lean;Morphology/DistributedMorphology/Fission.lean;Studies/DalrympleKaplan2000.lean;Studies/GonzalezPootMcGinnis2006.lean;Studies/SmithMoskalEtAl2019.lean}
 }
 @incollection{cohen-2013,
   author    = {Cohen, Ariel},
@@ -23200,7 +23200,7 @@
   subfield  = {morphology},
   role      = {formalized},
   validated = {true},
-  sources   = {Data/Examples/HalleMarantz1993.json;Fragments/Basque/Postsyntax.lean;Morphology/DistributedMorphology/Categorizer/Basic.lean;Morphology/DistributedMorphology/Defs.lean;Morphology/DistributedMorphology/Fusion.lean;Morphology/DistributedMorphology/Root.lean;Morphology/DistributedMorphology/Spellout.lean;Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean;Studies/Bobaljik2000.lean;Studies/Embick2010.lean;Studies/Embick2015.lean;Studies/HalleMarantz1993.lean;Studies/KalinBjorkmanEtAl2026.lean;Studies/Middleton2026.lean;Studies/Preminger2014.lean;Studies/RathiHahnFutrell2026.lean}
+  sources   = {Data/Examples/HalleMarantz1993.json;Fragments/Basque/Postsyntax.lean;Morphology/DistributedMorphology/Categorizer/Basic.lean;Morphology/DistributedMorphology/Defs.lean;Morphology/DistributedMorphology/Fusion.lean;Morphology/DistributedMorphology/Root.lean;Morphology/DistributedMorphology/Spellout.lean;Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean;Studies/Bobaljik2000.lean;Studies/Embick2010.lean;Studies/Embick2015.lean;Studies/GonzalezPootMcGinnis2006.lean;Studies/HalleMarantz1993.lean;Studies/KalinBjorkmanEtAl2026.lean;Studies/Middleton2026.lean;Studies/Preminger2014.lean;Studies/RathiHahnFutrell2026.lean}
 }
 @incollection{marantz-1993,
   author    = {Marantz, Alec},
@@ -29672,7 +29672,7 @@
   doi       = {10.1353/lan.2002.0158},
   subfield  = {syntax},
   role      = {cited},
-  sources   = {Studies/AdamsonAnagnostopoulou2025.lean}
+  sources   = {Data/Examples/HarleyRitter2002.json;Features/ContainmentPair.lean;Features/Person/Decomposition.lean;Features/Phi/Geometry.lean;Studies/AdamsonAnagnostopoulou2025.lean;Studies/BejarRezac2003.lean;Studies/BejarRezac2009.lean;Studies/CoonKeine2021.lean;Studies/GonzalezPootMcGinnis2006.lean;Studies/HarleyRitter2002.lean;Studies/KonnellyCowper2020.lean;Studies/McGinnis2013.lean;Studies/Preminger2014.lean;Syntax/Minimalist/Agree/Cyclic.lean;Syntax/Minimalist/Phi/Geometry.lean;Syntax/Minimalist/Probe/Phi.lean}
 }
 @article{taraldsen-et-al-2018,
   author    = {Taraldsen, Knut Tarald and Taraldsen Medov\'{a}, Lucie and Langa, David},
@@ -31425,7 +31425,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/GonzalezPootMcGinnis2006.lean;Morphology/DistributedMorphology/Fission.lean}
+  sources   = {Data/Examples/GonzalezPootMcGinnis2006.json;Morphology/DistributedMorphology/Fission.lean;Studies/GonzalezPootMcGinnis2006.lean;Studies/McGinnis2013.lean}
 }
 @incollection{halle-1997,
   author    = {Halle, Morris},
@@ -31439,7 +31439,7 @@
   publisher = {MITWPL},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/DistributedMorphology/ComplexHead.lean;Morphology/DistributedMorphology/Fission.lean;Morphology/Exponence/Decomposition.lean;Studies/AdamsonAnagnostopoulou2025.lean;Studies/Zompi2023.lean}
+  sources   = {Morphology/DistributedMorphology/ComplexHead.lean;Morphology/DistributedMorphology/Fission.lean;Morphology/Exponence/Decomposition.lean;Studies/AdamsonAnagnostopoulou2025.lean;Studies/GonzalezPootMcGinnis2006.lean;Studies/Zompi2023.lean}
 }
 
 @article{harbour-2003,


### PR DESCRIPTION
Deep cleanse of GonzalezPootMcGinnis2006 against the paper (Calgary repository PDF): header in register, rows as judgments, the paradigm (39) derived, and the appendix's privative Vocabularies checked.

- Rows carry `Judgment` and parse through `parse?`; the template (18) theorems and `suffixes_rows` are stated as iffs over the pool; `ergative_paradigm`/`first_person_paradigm` derive the (39) distribution the paper aligns with Hebrew, Basque, and Georgian from (27), (43), (44).
- Appendix (A1)–(A4): the privative Agr1/Agr2 lists recover every auxiliary and prefix, but the privative Agr3 list over-generates *-en* on the paper's own (20), since the nominative residue keeps [Participant, NOM] once negative values are gone (`privative_suffixes`).
- bib sources recomputed for the five keys.
