### PR TITLE
chore(Morphology,Data): scope the DM notation, export Judgment

### DIFF
--- a/Linglib/Data/Examples/Schema.lean
+++ b/Linglib/Data/Examples/Schema.lean
@@ -54,7 +54,7 @@ grow optional fields without breaking existing rows.
 
 namespace Data.Examples
 
-open Features (Judgment)
+export Features (Judgment)
 
 /-- Glottolog 5.0 language identifier (e.g. "stan1293" for Standard English).
     Type alias only; values are not validated against Glottolog at the type

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -64,7 +64,6 @@ conditioning of v.
 namespace DistributedMorphology.Allosemy
 
 open DistributedMorphology (Categorizer Categorizer.Head)
-open scoped DistributedMorphology.VocabularyItem
 open Minimalist.Voice (Flavor Head)
 
 /-! ### The alloseme carrier

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -39,8 +39,12 @@ def features (i : VocabularyItem F E) : List F := i.site.focus
 /-- A context-free item: the features it spells out and its exponent. -/
 def ofFeatures (fs : List F) (e : E) : VocabularyItem F E := ⟨fs, e⟩
 
+end VocabularyItem
+
 /-- `fs ⟷ e`: the context-free Vocabulary Item spelling out `fs` as `e`. -/
-scoped infixr:25 " ⟷ " => ofFeatures
+scoped infixr:25 " ⟷ " => VocabularyItem.ofFeatures
+
+namespace VocabularyItem
 
 @[simp] theorem site_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).site = ↑fs := rfl
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -51,7 +51,6 @@ and *nanVh* 'face' take the gender of an inalienable possessor on their agreemen
 namespace Adamson2024
 
 open DistributedMorphology
-open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology.Categorizer (Head)
 
 /-! ### The gender locality hypothesis -/

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -51,7 +51,6 @@ mismatch resolution (`mismatchResolution`), and Table 2 follows from the geometr
 namespace AdamsonAnagnostopoulou2025
 
 open Minimalist.Coordination DistributedMorphology Morphology.Exponence
-open scoped DistributedMorphology.VocabularyItem
 
 /-- The privative gender nodes of the three geometries. -/
 inductive Node where

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -39,7 +39,6 @@ theorems are the Word-to-Phrase rerankings of (68).
 namespace Aitha2026
 
 open Morphology.Case.Allomorphy DistributedMorphology Prosody Data.Examples
-open scoped DistributedMorphology.VocabularyItem
 open Core Constraints OptimalityTheory Core.Optimization Core.Optimization.Evaluation
 
 /-! ### Case -/

--- a/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
+++ b/Linglib/Studies/AlexeyenkoZeijlstra2025.lean
@@ -38,7 +38,7 @@ positions (`orderOf`) and checked against the profiles and the judgments.
 
 namespace AlexeyenkoZeijlstra2025
 
-open Features Data.Examples
+open Data.Examples
 
 /-! ### Agreement marking -/
 

--- a/Linglib/Studies/Bobaljik2000.lean
+++ b/Linglib/Studies/Bobaljik2000.lean
@@ -38,7 +38,6 @@ namespace Bobaljik2000
 
 open DistributedMorphology
 open Data.Examples (LinguisticExample)
-open scoped DistributedMorphology.VocabularyItem
 
 inductive Feature where
   | root (s : String) | classII | tense | classMarker

--- a/Linglib/Studies/Bresnan1973.lean
+++ b/Linglib/Studies/Bresnan1973.lean
@@ -38,7 +38,7 @@ the ambiguities of 1.8 beyond the homophony of *more* are not formalized.
 
 namespace Bresnan1973
 
-open Data.Examples Features
+open Data.Examples
 
 /-! ### The quantifier phrase (1.1–1.3) -/
 

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -65,7 +65,6 @@ in K'ichean, and temporals trigger neither.
 namespace ElkinsTorrenceBrown2026
 
 open Minimalist DistributedMorphology Data.Examples ElkinsTorrenceBrown2026.Examples
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The extended verbal domain (§1.3) -/
 

--- a/Linglib/Studies/Embick2015.lean
+++ b/Linglib/Studies/Embick2015.lean
@@ -49,7 +49,6 @@ may see the phonological features of a realized exponent.
 namespace Embick2015
 
 open DistributedMorphology Data.Examples Embick2015.Examples
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The Latin fragment -/
 

--- a/Linglib/Studies/Erlewine2016.lean
+++ b/Linglib/Studies/Erlewine2016.lean
@@ -59,7 +59,7 @@ cross-referencing highest and has no AF.
 
 namespace Erlewine2016
 
-open Constraints OptimalityTheory Data.Examples Erlewine2016.Examples Features
+open Constraints OptimalityTheory Data.Examples Erlewine2016.Examples
 
 /-- The arguments of a verb. -/
 inductive Arg

--- a/Linglib/Studies/GartnerGyuris2017.lean
+++ b/Linglib/Studies/GartnerGyuris2017.lean
@@ -46,7 +46,7 @@ ones; the paper's Czech and Romero comparisons belong to the later papers' studi
 
 namespace GartnerGyuris2017
 
-open Question Features Data.Examples
+open Question Data.Examples
 
 /-- A bias value: evidence or expectation for p (+), against p (−), or neither (%). -/
 inductive Bias where

--- a/Linglib/Studies/Gasparri2025.lean
+++ b/Linglib/Studies/Gasparri2025.lean
@@ -38,7 +38,7 @@ a referentialist needs must introduce the naming predicate itself.
 
 namespace Gasparri2025
 
-open Quantification Data.Examples Features Semantics.Composition.TypeShifting
+open Quantification Data.Examples Semantics.Composition.TypeShifting
 
 /-- A referential name shifted to its identity property and fed to the generic operator returns
 the token reading, so a generic use of a bare name needs the naming predicate. -/

--- a/Linglib/Studies/Geurts2005.lean
+++ b/Linglib/Studies/Geurts2005.lean
@@ -43,7 +43,7 @@ later paper that draws it, `Studies/Yagi2025.lean`.
 
 namespace Geurts2005
 
-open Modality Features Data.Examples Function
+open Modality Data.Examples Function
 
 variable {W : Type*}
 

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -47,7 +47,7 @@ admitted states (`rows_admits`).
 
 namespace Glass2025
 
-open Doxastic Presupposition Data.Examples Features
+open Doxastic Presupposition Data.Examples
 open English.Predicates.Verbal Mandarin.Predicates
 
 variable {W : Type*} {c : Set W} {p : W → Prop}

--- a/Linglib/Studies/GoldbergJackendoff2004.lean
+++ b/Linglib/Studies/GoldbergJackendoff2004.lean
@@ -38,7 +38,7 @@ derives a label only where the citation frame carries an entailment profile.
 
 namespace GoldbergJackendoff2004
 
-open ConstructionGrammar.Resultatives ArgumentStructure Features Data.Examples
+open ConstructionGrammar.Resultatives ArgumentStructure Data.Examples
 open English.Predicates.Verbal
 
 /-- An example row: the verb, the subconstruction, how its subevents relate, the object

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -42,7 +42,6 @@ paper's separate rule system and is outside this file.
 namespace HalleMarantz1993
 
 open DistributedMorphology Data.Examples
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The fused Tns–Agr node -/
 

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -62,7 +62,6 @@ categorizing head.
 namespace Harley2014
 
 open DistributedMorphology
-open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology.Allosemy (toInterpreted embedding)
 open Morphology.Exponence (selectBy)
 open Clause (Arguments)

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -44,7 +44,7 @@ namespace KonnellyCowper2020
 open DistributedMorphology (Contrastivity GenderFeature
   Interpretability Categorizer.Head PhiBundle)
 open DistributedMorphology (VocabularyItem subsetPrinciple)
-open scoped DistributedMorphology.VocabularyItem
+open scoped DistributedMorphology
 
 -- ============================================================================
 -- § 1: Morphosyntactic Features for English Pronouns

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -56,7 +56,6 @@ semantic core from the structural account alone.
 
 namespace Kramer2020
 
-open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology
 
 /-! ### The semantic core (§1.2) -/

--- a/Linglib/Studies/McGinnis2013.lean
+++ b/Linglib/Studies/McGinnis2013.lean
@@ -57,7 +57,6 @@ geometry supplies the [#] of the revised *-t* (13c).
 namespace McGinnis2013
 
 open DistributedMorphology Phi.Geometry Data.Examples
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### Features and arguments -/
 

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -66,7 +66,6 @@ namespace Middleton2026
 
 open Minimalist DistributedMorphology
      Taos.Agreement Basque.Postsyntax
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### Metathesis Rule
 

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -45,7 +45,6 @@ syntactic ({D} and φ, the transitive configuration of (24)), and relational
 namespace Myler2016
 
 open DistributedMorphology DistributedMorphology.Allosemy Data.Examples
-open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The copula's context and form -/
 

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -66,7 +66,7 @@ infinitival classification.
 namespace Ostrove2026
 
 open Minimalist.MinimalPronoun
-open scoped DistributedMorphology.VocabularyItem
+open scoped DistributedMorphology
 open Control
 open Minimalist (InfinitivalTenseClass)
 open Mixtec.SMPM (EmbeddedClauseType clauseProperties)

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -125,7 +125,7 @@ namespace Preminger2014
 open Kaqchikel
 open Minimalist
 open DistributedMorphology (VocabularyItem)
-open scoped DistributedMorphology.VocabularyItem
+open scoped DistributedMorphology
 open Agreement
 
 /-! ### Feature decomposition (grounded in `Phi/Geometry.lean`) -/

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -53,7 +53,6 @@ derive it.
 namespace Scott2021
 
 open Swahili Syntax DistributedMorphology Data.Examples
-open scoped DistributedMorphology.VocabularyItem
 open Minimalist (FeatureVal PhiFeature GramFeature)
 
 /-! ### The structure of pronouns (§5.1) -/

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -167,7 +167,7 @@ section AgreeSpellout
 open Minimalist Mam
 open Agreement
 open DistributedMorphology (VocabularyItem)
-open scoped DistributedMorphology.VocabularyItem
+open scoped DistributedMorphology
 
 -- ============================================================================
 -- § 0: Minimalism-Specific Vocabulary (Set A / Set B as VI entries)


### PR DESCRIPTION
Open-line sweep: the two substrate placements that forced extra `open` lines on studies, and the studies that carried them.

- `⟷` is now scoped in `DistributedMorphology` rather than `DistributedMorphology.VocabularyItem`, so a plain `open DistributedMorphology` enables it; the 19 `open scoped …VocabularyItem` lines go (three files that open the namespace only by parenthesized lists get `open scoped DistributedMorphology`).
- `Data.Examples` re-exports `Judgment`, so rows-based studies need not open `Features` for it; eight studies drop `Features` from their open line (the others still need it for other names and are untouched).
- GonzalezPootMcGinnis2006 opens `Minimalist` whole instead of a parenthesized `FeatureVal` list.
