### PR TITLE
refactor(Studies/Gong2022): condition (2) over the paper's chains

### DIFF
--- a/Linglib/Data/Examples/Gong2022.json
+++ b/Linglib/Data/Examples/Gong2022.json
@@ -1,0 +1,1322 @@
+[
+  {
+    "id": "gong2022_18b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(18b)"
+    },
+    "language": "halh1238",
+    "primaryText": "Bagš [Čemeg-in nom-ig] tüün-d ög-sön.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bagš",
+        "teacher.NOM"
+      ],
+      [
+        "Čemeg-in",
+        "Čemeg-GEN"
+      ],
+      [
+        "nom-ig",
+        "book-ACC"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "ög-sön",
+        "give-PST"
+      ]
+    ],
+    "translation": "(The) teacher gave Čemeg's book (to) her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "SS"
+      ],
+      [
+        "binder",
+        "IO"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Short scrambling of the DO over the dative binder: no reconstruction."
+  },
+  {
+    "id": "gong2022_19b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(19b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Čemeg-in nom-ig] bagš tüün-d ög-sön.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Čemeg-in",
+        "Čemeg-GEN"
+      ],
+      [
+        "nom-ig",
+        "book-ACC"
+      ],
+      [
+        "bagš",
+        "teacher.NOM"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "ög-sön",
+        "give-PST"
+      ]
+    ],
+    "translation": "Čemeg's book, (the) teacher gave (to) her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "IS"
+      ],
+      [
+        "binder",
+        "IO"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Intermediate scrambling over a dative binder: no reconstruction."
+  },
+  {
+    "id": "gong2022_20b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(20b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Čemeg-in nom-ig] ter ura-san.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Čemeg-in",
+        "Čemeg-GEN"
+      ],
+      [
+        "nom-ig",
+        "book-ACC"
+      ],
+      [
+        "ter",
+        "3SG.NOM"
+      ],
+      [
+        "ura-san",
+        "tear-PST"
+      ]
+    ],
+    "translation": "Čemeg's book, she tore.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "IS"
+      ],
+      [
+        "binder",
+        "subject"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Intermediate scrambling over a subject binder, transitive: obligatory reconstruction."
+  },
+  {
+    "id": "gong2022_21b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(21b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Čemeg-in nom-ig] ter Bat-ad ög-sön.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Čemeg-in",
+        "Čemeg-GEN"
+      ],
+      [
+        "nom-ig",
+        "book-ACC"
+      ],
+      [
+        "ter",
+        "3SG.NOM"
+      ],
+      [
+        "Bat-ad",
+        "Bat-DAT"
+      ],
+      [
+        "ög-sön",
+        "give-PST"
+      ]
+    ],
+    "translation": "Čemeg's book, she gave to Bat.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "IS"
+      ],
+      [
+        "binder",
+        "subject"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Intermediate scrambling over a subject binder, ditransitive."
+  },
+  {
+    "id": "gong2022_32b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(32b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in eej-iig] bi tüün-d [sain khün gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "eej-iig",
+        "mother-ACC"
+      ],
+      [
+        "bi",
+        "1SG.NOM"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "sain",
+        "good"
+      ],
+      [
+        "khün",
+        "person"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "I said to him that Bat's mother is a good person.",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "ACC-SUBJ"
+      ],
+      [
+        "binder",
+        "matrix DAT"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "The accusative embedded subject scrambles over the matrix dative binder: no obligatory reconstruction."
+  },
+  {
+    "id": "gong2022_33",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(33)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Baatar-in zokhiol-iig] ter [maš sain gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Baatar-in",
+        "Baatar-GEN"
+      ],
+      [
+        "zokhiol-iig",
+        "article-ACC"
+      ],
+      [
+        "ter",
+        "3SG.NOM"
+      ],
+      [
+        "maš",
+        "very"
+      ],
+      [
+        "sain",
+        "good"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Baatar's article, he said was very good.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "ACC-SUBJ"
+      ],
+      [
+        "binder",
+        "matrix subject"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "The accusative embedded subject scrambles over the matrix subject binder: obligatory reconstruction."
+  },
+  {
+    "id": "gong2022_40",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(40)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in esee-g] ter [bagš-iig unš-san gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "esee-g",
+        "essay-ACC"
+      ],
+      [
+        "ter",
+        "3SG.NOM"
+      ],
+      [
+        "bagš-iig",
+        "teacher-ACC"
+      ],
+      [
+        "unš-san",
+        "read-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Bat's essay, he said that the teacher read.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "LDS"
+      ],
+      [
+        "binder",
+        "matrix subject"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Long-distance scrambling of the embedded object over the matrix subject binder."
+  },
+  {
+    "id": "gong2022_41",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(41)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in esee-g] Zaya tüün-d [bagš-iig unš-san gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "esee-g",
+        "essay-ACC"
+      ],
+      [
+        "Zaya",
+        "Zaya.NOM"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "bagš-iig",
+        "teacher-ACC"
+      ],
+      [
+        "unš-san",
+        "read-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Bat's essay, Zaya said to him that the teacher read.",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "LDS"
+      ],
+      [
+        "binder",
+        "matrix DAT"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Long-distance scrambling over the matrix dative binder: no obligatory reconstruction."
+  },
+  {
+    "id": "gong2022_58a",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(58a)"
+    },
+    "language": "halh1238",
+    "primaryText": "Bi [Bat-in eej-iig] tüün-d [sain khün gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bi",
+        "1SG.NOM"
+      ],
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "eej-iig",
+        "mother-ACC"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "sain",
+        "good"
+      ],
+      [
+        "khün",
+        "person"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "I said to him that Bat's mother is a good person.",
+    "context": "",
+    "judgment": "marginal",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "ACC-SUBJ intermediate"
+      ],
+      [
+        "binder",
+        "matrix DAT"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "The mover surfaces at the matrix intermediate landing site; degraded, but the coindexation is obtained."
+  },
+  {
+    "id": "gong2022_58b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(58b)"
+    },
+    "language": "halh1238",
+    "primaryText": "Zaya [Bat-in esee-g] tüün-d [bagš-iig-aa unš-san gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Zaya",
+        "Zaya.NOM"
+      ],
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "esee-g",
+        "essay-ACC"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "bagš-iig-aa",
+        "teacher-ACC-REFL.POSS"
+      ],
+      [
+        "unš-san",
+        "read-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Zaya said to him that her teacher read Bat's essay.",
+    "context": "",
+    "judgment": "marginal",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "LDS intermediate"
+      ],
+      [
+        "binder",
+        "matrix DAT"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "As (58a), for the embedded object."
+  },
+  {
+    "id": "gong2022_61",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(61)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in em-iig] emč [tüün-iig uu-gaagüi gej] uurla-san.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "em-iig",
+        "medicine-ACC"
+      ],
+      [
+        "emč",
+        "doctor.NOM"
+      ],
+      [
+        "tüün-iig",
+        "3SG-ACC"
+      ],
+      [
+        "uu-gaagüi",
+        "drink-PST.NEG"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "uurla-san",
+        "become.angry-PST"
+      ]
+    ],
+    "translation": "Bat's medicine, the doctor became angry that he did not drink.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "LDS"
+      ],
+      [
+        "binder",
+        "embedded subject"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Long-distance scrambling over an embedded subject binder bleeds Condition C, against the Subject Binding Generalization."
+  },
+  {
+    "id": "gong2022_79",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(79)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Čemeg-in eej-id] ter nom ög-sön.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Čemeg-in",
+        "Čemeg-GEN"
+      ],
+      [
+        "eej-id",
+        "mother-DAT"
+      ],
+      [
+        "ter",
+        "3SG.NOM"
+      ],
+      [
+        "nom",
+        "book"
+      ],
+      [
+        "ög-sön",
+        "give-PST"
+      ]
+    ],
+    "translation": "(To) Čemeg's mother, she gave (a) book/books.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "IO"
+      ],
+      [
+        "binder",
+        "subject"
+      ],
+      [
+        "mover",
+        "DP-lexical"
+      ]
+    ],
+    "comment": "Scrambling the dative IO over the subject binder forces reconstruction."
+  },
+  {
+    "id": "gong2022_85b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(85b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in nom] bagš-aar tüün-d ögö-gd-sön.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "nom",
+        "book.NOM"
+      ],
+      [
+        "bagš-aar",
+        "teacher-INST"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "ögö-gd-sön",
+        "give-PASS-PST"
+      ]
+    ],
+    "translation": "Bat's book was given to him by the teacher.",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "passive"
+      ],
+      [
+        "binder",
+        "IO"
+      ],
+      [
+        "mover",
+        "DP"
+      ]
+    ],
+    "comment": "Passivization feeds nominative from T and bleeds Condition C."
+  },
+  {
+    "id": "gong2022_86",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(86)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Zorig-iin emee-d] bi [tüün-iig tusal-dag bai-san gej] bodo-j bai-na.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Zorig-iin",
+        "Zorig-GEN"
+      ],
+      [
+        "emee-d",
+        "grandmother-DAT"
+      ],
+      [
+        "bi",
+        "1SG.NOM"
+      ],
+      [
+        "tüün-iig",
+        "3SG-ACC"
+      ],
+      [
+        "tusal-dag",
+        "help-HABIT"
+      ],
+      [
+        "bai-san",
+        "COP-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "bodo-j",
+        "think-CVB"
+      ],
+      [
+        "bai-na",
+        "COP-NPST"
+      ]
+    ],
+    "translation": "Zorig's grandmother, I am thinking that he had been helping.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "LDS"
+      ],
+      [
+        "binder",
+        "embedded subject"
+      ],
+      [
+        "mover",
+        "DP-lexical"
+      ]
+    ],
+    "comment": "Long-distance scrambling of a lexically dative object: rejected by the speakers who accept (88) and (89)."
+  },
+  {
+    "id": "gong2022_93b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(93b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-in dontolt-in esreg] emč [tüün-iig kheden jil-iin turš temtse-j bai-san gej] nadad khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-in",
+        "Bat-GEN"
+      ],
+      [
+        "dontolt-in",
+        "addiction-GEN"
+      ],
+      [
+        "esreg",
+        "against"
+      ],
+      [
+        "emč",
+        "doctor"
+      ],
+      [
+        "tüün-iig",
+        "3SG-ACC"
+      ],
+      [
+        "kheden",
+        "some"
+      ],
+      [
+        "jil-iin",
+        "year-GEN"
+      ],
+      [
+        "turš",
+        "during"
+      ],
+      [
+        "temtse-j",
+        "fight-CVB"
+      ],
+      [
+        "bai-san",
+        "COP-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "nadad",
+        "1SG.DAT"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Against Bat's addiction, the doctor said that he has been fighting for years.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "PP-LDS"
+      ],
+      [
+        "binder",
+        "embedded subject"
+      ],
+      [
+        "mover",
+        "PP"
+      ]
+    ],
+    "comment": "PP-scrambling exhibits obligatory reconstruction."
+  },
+  {
+    "id": "gong2022_94b",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(94b)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Zorig-iin öwčin-ii esreg] Zaya tüün-d [emč nar-ig čadakh bükhn-eer-ee temtse-j bol-no gej] khel-sen.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Zorig-iin",
+        "Zorig-GEN"
+      ],
+      [
+        "öwčin-ii",
+        "disease-GEN"
+      ],
+      [
+        "esreg",
+        "against"
+      ],
+      [
+        "Zaya",
+        "Zaya.NOM"
+      ],
+      [
+        "tüün-d",
+        "3SG-DAT"
+      ],
+      [
+        "emč",
+        "doctor"
+      ],
+      [
+        "nar-ig",
+        "PL-ACC"
+      ],
+      [
+        "čadakh",
+        "ability"
+      ],
+      [
+        "bükhn-eer-ee",
+        "all-INST-REFL.POSS"
+      ],
+      [
+        "temtse-j",
+        "fight-CVB"
+      ],
+      [
+        "bol-no",
+        "be-NPST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "khel-sen",
+        "say-PST"
+      ]
+    ],
+    "translation": "Against Zorig's disease, Zaya said to him that the doctors will do their best to fight.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "scrambling"
+      ],
+      [
+        "construction",
+        "PP-LDS"
+      ],
+      [
+        "binder",
+        "matrix DAT"
+      ],
+      [
+        "mover",
+        "PP"
+      ]
+    ],
+    "comment": "PP-scrambling over a matrix dative binder still reconstructs."
+  },
+  {
+    "id": "gong2022_47",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(47)"
+    },
+    "language": "halh1238",
+    "primaryText": "Emč [Bat-ig em-ee uu-gaagüi gej] uurla-san.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Emč",
+        "doctor.NOM"
+      ],
+      [
+        "Bat-ig",
+        "Bat-ACC"
+      ],
+      [
+        "em-ee",
+        "medicine-REFL.POSS"
+      ],
+      [
+        "uu-gaagüi",
+        "drink-PST.NEG"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "uurla-san",
+        "become.angry-PST"
+      ]
+    ],
+    "translation": "The doctor became angry that Bat did not drink his medicine.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "accusative subject"
+      ],
+      [
+        "competitor",
+        "NOM"
+      ]
+    ],
+    "comment": "The matrix predicate assigns no accusative, yet the embedded subject is accusative."
+  },
+  {
+    "id": "gong2022_48",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(48)"
+    },
+    "language": "halh1238",
+    "primaryText": "Bi [Čang-iig amid bai-gaa gedeg]-t itgeltei bai-na.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bi",
+        "1SG.NOM"
+      ],
+      [
+        "Čang-iig",
+        "Čang-ACC"
+      ],
+      [
+        "amid",
+        "alive"
+      ],
+      [
+        "bai-gaa",
+        "COP-NPST.PTCP"
+      ],
+      [
+        "gedeg-t",
+        "C-DAT"
+      ],
+      [
+        "itgeltei",
+        "believe"
+      ],
+      [
+        "bai-na",
+        "COP-NPST"
+      ]
+    ],
+    "translation": "I believe that Čang is alive.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "accusative subject"
+      ],
+      [
+        "competitor",
+        "NOM"
+      ]
+    ],
+    "comment": "The embedded clause itself is dative-marked; the embedded subject is accusative by competition with the matrix subject."
+  },
+  {
+    "id": "gong2022_63",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(63)"
+    },
+    "language": "halh1238",
+    "primaryText": "[Bat-ig ger-iin daalgawr-aa khiikh ni] čukhal.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Bat-ig",
+        "Bat-ACC"
+      ],
+      [
+        "ger-iin",
+        "home-GEN"
+      ],
+      [
+        "daalgawr-aa",
+        "assignment-REFL.POSS"
+      ],
+      [
+        "khiikh",
+        "do.INF"
+      ],
+      [
+        "ni",
+        "3SG.POSS"
+      ],
+      [
+        "čukhal",
+        "important"
+      ]
+    ],
+    "translation": "It is important that Bat does his homework.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "accusative subject"
+      ],
+      [
+        "competitor",
+        "none"
+      ]
+    ],
+    "comment": "Under an impersonal predicate the embedded subject cannot be accusative; nominative and genitive are possible."
+  },
+  {
+    "id": "gong2022_64",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(64)"
+    },
+    "language": "halh1238",
+    "primaryText": "Saruul [Jon-ig šine mašin aw-san gej] uurla-san.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Saruul",
+        "Saruul.NOM"
+      ],
+      [
+        "Jon-ig",
+        "Jon-ACC"
+      ],
+      [
+        "šine",
+        "new"
+      ],
+      [
+        "mašin",
+        "car"
+      ],
+      [
+        "aw-san",
+        "buy-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "uurla-san",
+        "become.angry-PST"
+      ]
+    ],
+    "translation": "Saruul became angry that Jon bought a new car.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "accusative subject"
+      ],
+      [
+        "competitor",
+        "NOM"
+      ]
+    ],
+    "comment": "A nominative matrix argument competes for case."
+  },
+  {
+    "id": "gong2022_65",
+    "source": {
+      "bibkey": "gong-2022",
+      "paperLabel": "(65)"
+    },
+    "language": "halh1238",
+    "primaryText": "Saruul-d [Jon-ig šine mašin aw-san gej] sanagda-j bai-san.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "Saruul-d",
+        "Saruul-DAT"
+      ],
+      [
+        "Jon-ig",
+        "Jon-ACC"
+      ],
+      [
+        "šine",
+        "new"
+      ],
+      [
+        "mašin",
+        "car"
+      ],
+      [
+        "aw-san",
+        "buy-PST"
+      ],
+      [
+        "gej",
+        "C"
+      ],
+      [
+        "sanagda-j",
+        "seem-CVB"
+      ],
+      [
+        "bai-san",
+        "COP-PST"
+      ]
+    ],
+    "translation": "It seemed to Saruul that Jon bought a new car.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "kind",
+        "accusative subject"
+      ],
+      [
+        "competitor",
+        "DAT"
+      ]
+    ],
+    "comment": "A dative matrix argument is no competitor: the accusative subject is out, the nominative one in."
+  }
+]

--- a/Linglib/Data/Examples/Gong2022.lean
+++ b/Linglib/Data/Examples/Gong2022.lean
@@ -1,0 +1,396 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Gong2022` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Gong2022.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Gong2022.Examples`.
+-/
+
+namespace Gong2022.Examples
+
+open Data.Examples
+
+def ex_18b : LinguisticExample :=
+  { id := "gong2022_18b"
+    source := ⟨"gong-2022", "(18b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Bagš [Čemeg-in nom-ig] tüün-d ög-sön."
+    discourseSegments := []
+    glossedTokens := [("Bagš", "teacher.NOM"), ("Čemeg-in", "Čemeg-GEN"), ("nom-ig", "book-ACC"), ("tüün-d", "3SG-DAT"), ("ög-sön", "give-PST")]
+    translation := "(The) teacher gave Čemeg's book (to) her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "SS"), ("binder", "IO"), ("mover", "DP")]
+    comment := "Short scrambling of the DO over the dative binder: no reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_19b : LinguisticExample :=
+  { id := "gong2022_19b"
+    source := ⟨"gong-2022", "(19b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Čemeg-in nom-ig] bagš tüün-d ög-sön."
+    discourseSegments := []
+    glossedTokens := [("Čemeg-in", "Čemeg-GEN"), ("nom-ig", "book-ACC"), ("bagš", "teacher.NOM"), ("tüün-d", "3SG-DAT"), ("ög-sön", "give-PST")]
+    translation := "Čemeg's book, (the) teacher gave (to) her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "IS"), ("binder", "IO"), ("mover", "DP")]
+    comment := "Intermediate scrambling over a dative binder: no reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_20b : LinguisticExample :=
+  { id := "gong2022_20b"
+    source := ⟨"gong-2022", "(20b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Čemeg-in nom-ig] ter ura-san."
+    discourseSegments := []
+    glossedTokens := [("Čemeg-in", "Čemeg-GEN"), ("nom-ig", "book-ACC"), ("ter", "3SG.NOM"), ("ura-san", "tear-PST")]
+    translation := "Čemeg's book, she tore."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "IS"), ("binder", "subject"), ("mover", "DP")]
+    comment := "Intermediate scrambling over a subject binder, transitive: obligatory reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21b : LinguisticExample :=
+  { id := "gong2022_21b"
+    source := ⟨"gong-2022", "(21b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Čemeg-in nom-ig] ter Bat-ad ög-sön."
+    discourseSegments := []
+    glossedTokens := [("Čemeg-in", "Čemeg-GEN"), ("nom-ig", "book-ACC"), ("ter", "3SG.NOM"), ("Bat-ad", "Bat-DAT"), ("ög-sön", "give-PST")]
+    translation := "Čemeg's book, she gave to Bat."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "IS"), ("binder", "subject"), ("mover", "DP")]
+    comment := "Intermediate scrambling over a subject binder, ditransitive."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_32b : LinguisticExample :=
+  { id := "gong2022_32b"
+    source := ⟨"gong-2022", "(32b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in eej-iig] bi tüün-d [sain khün gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("eej-iig", "mother-ACC"), ("bi", "1SG.NOM"), ("tüün-d", "3SG-DAT"), ("sain", "good"), ("khün", "person"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "I said to him that Bat's mother is a good person."
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "ACC-SUBJ"), ("binder", "matrix DAT"), ("mover", "DP")]
+    comment := "The accusative embedded subject scrambles over the matrix dative binder: no obligatory reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_33 : LinguisticExample :=
+  { id := "gong2022_33"
+    source := ⟨"gong-2022", "(33)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Baatar-in zokhiol-iig] ter [maš sain gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Baatar-in", "Baatar-GEN"), ("zokhiol-iig", "article-ACC"), ("ter", "3SG.NOM"), ("maš", "very"), ("sain", "good"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "Baatar's article, he said was very good."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "ACC-SUBJ"), ("binder", "matrix subject"), ("mover", "DP")]
+    comment := "The accusative embedded subject scrambles over the matrix subject binder: obligatory reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_40 : LinguisticExample :=
+  { id := "gong2022_40"
+    source := ⟨"gong-2022", "(40)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in esee-g] ter [bagš-iig unš-san gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("esee-g", "essay-ACC"), ("ter", "3SG.NOM"), ("bagš-iig", "teacher-ACC"), ("unš-san", "read-PST"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "Bat's essay, he said that the teacher read."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "LDS"), ("binder", "matrix subject"), ("mover", "DP")]
+    comment := "Long-distance scrambling of the embedded object over the matrix subject binder."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_41 : LinguisticExample :=
+  { id := "gong2022_41"
+    source := ⟨"gong-2022", "(41)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in esee-g] Zaya tüün-d [bagš-iig unš-san gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("esee-g", "essay-ACC"), ("Zaya", "Zaya.NOM"), ("tüün-d", "3SG-DAT"), ("bagš-iig", "teacher-ACC"), ("unš-san", "read-PST"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "Bat's essay, Zaya said to him that the teacher read."
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "LDS"), ("binder", "matrix DAT"), ("mover", "DP")]
+    comment := "Long-distance scrambling over the matrix dative binder: no obligatory reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_58a : LinguisticExample :=
+  { id := "gong2022_58a"
+    source := ⟨"gong-2022", "(58a)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Bi [Bat-in eej-iig] tüün-d [sain khün gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Bi", "1SG.NOM"), ("Bat-in", "Bat-GEN"), ("eej-iig", "mother-ACC"), ("tüün-d", "3SG-DAT"), ("sain", "good"), ("khün", "person"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "I said to him that Bat's mother is a good person."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "ACC-SUBJ intermediate"), ("binder", "matrix DAT"), ("mover", "DP")]
+    comment := "The mover surfaces at the matrix intermediate landing site; degraded, but the coindexation is obtained."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_58b : LinguisticExample :=
+  { id := "gong2022_58b"
+    source := ⟨"gong-2022", "(58b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Zaya [Bat-in esee-g] tüün-d [bagš-iig-aa unš-san gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Zaya", "Zaya.NOM"), ("Bat-in", "Bat-GEN"), ("esee-g", "essay-ACC"), ("tüün-d", "3SG-DAT"), ("bagš-iig-aa", "teacher-ACC-REFL.POSS"), ("unš-san", "read-PST"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "Zaya said to him that her teacher read Bat's essay."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "LDS intermediate"), ("binder", "matrix DAT"), ("mover", "DP")]
+    comment := "As (58a), for the embedded object."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_61 : LinguisticExample :=
+  { id := "gong2022_61"
+    source := ⟨"gong-2022", "(61)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in em-iig] emč [tüün-iig uu-gaagüi gej] uurla-san."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("em-iig", "medicine-ACC"), ("emč", "doctor.NOM"), ("tüün-iig", "3SG-ACC"), ("uu-gaagüi", "drink-PST.NEG"), ("gej", "C"), ("uurla-san", "become.angry-PST")]
+    translation := "Bat's medicine, the doctor became angry that he did not drink."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "LDS"), ("binder", "embedded subject"), ("mover", "DP")]
+    comment := "Long-distance scrambling over an embedded subject binder bleeds Condition C, against the Subject Binding Generalization."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_79 : LinguisticExample :=
+  { id := "gong2022_79"
+    source := ⟨"gong-2022", "(79)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Čemeg-in eej-id] ter nom ög-sön."
+    discourseSegments := []
+    glossedTokens := [("Čemeg-in", "Čemeg-GEN"), ("eej-id", "mother-DAT"), ("ter", "3SG.NOM"), ("nom", "book"), ("ög-sön", "give-PST")]
+    translation := "(To) Čemeg's mother, she gave (a) book/books."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "IO"), ("binder", "subject"), ("mover", "DP-lexical")]
+    comment := "Scrambling the dative IO over the subject binder forces reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_85b : LinguisticExample :=
+  { id := "gong2022_85b"
+    source := ⟨"gong-2022", "(85b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in nom] bagš-aar tüün-d ögö-gd-sön."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("nom", "book.NOM"), ("bagš-aar", "teacher-INST"), ("tüün-d", "3SG-DAT"), ("ögö-gd-sön", "give-PASS-PST")]
+    translation := "Bat's book was given to him by the teacher."
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "passive"), ("binder", "IO"), ("mover", "DP")]
+    comment := "Passivization feeds nominative from T and bleeds Condition C."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_86 : LinguisticExample :=
+  { id := "gong2022_86"
+    source := ⟨"gong-2022", "(86)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Zorig-iin emee-d] bi [tüün-iig tusal-dag bai-san gej] bodo-j bai-na."
+    discourseSegments := []
+    glossedTokens := [("Zorig-iin", "Zorig-GEN"), ("emee-d", "grandmother-DAT"), ("bi", "1SG.NOM"), ("tüün-iig", "3SG-ACC"), ("tusal-dag", "help-HABIT"), ("bai-san", "COP-PST"), ("gej", "C"), ("bodo-j", "think-CVB"), ("bai-na", "COP-NPST")]
+    translation := "Zorig's grandmother, I am thinking that he had been helping."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "LDS"), ("binder", "embedded subject"), ("mover", "DP-lexical")]
+    comment := "Long-distance scrambling of a lexically dative object: rejected by the speakers who accept (88) and (89)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_93b : LinguisticExample :=
+  { id := "gong2022_93b"
+    source := ⟨"gong-2022", "(93b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-in dontolt-in esreg] emč [tüün-iig kheden jil-iin turš temtse-j bai-san gej] nadad khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Bat-in", "Bat-GEN"), ("dontolt-in", "addiction-GEN"), ("esreg", "against"), ("emč", "doctor"), ("tüün-iig", "3SG-ACC"), ("kheden", "some"), ("jil-iin", "year-GEN"), ("turš", "during"), ("temtse-j", "fight-CVB"), ("bai-san", "COP-PST"), ("gej", "C"), ("nadad", "1SG.DAT"), ("khel-sen", "say-PST")]
+    translation := "Against Bat's addiction, the doctor said that he has been fighting for years."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "PP-LDS"), ("binder", "embedded subject"), ("mover", "PP")]
+    comment := "PP-scrambling exhibits obligatory reconstruction."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_94b : LinguisticExample :=
+  { id := "gong2022_94b"
+    source := ⟨"gong-2022", "(94b)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Zorig-iin öwčin-ii esreg] Zaya tüün-d [emč nar-ig čadakh bükhn-eer-ee temtse-j bol-no gej] khel-sen."
+    discourseSegments := []
+    glossedTokens := [("Zorig-iin", "Zorig-GEN"), ("öwčin-ii", "disease-GEN"), ("esreg", "against"), ("Zaya", "Zaya.NOM"), ("tüün-d", "3SG-DAT"), ("emč", "doctor"), ("nar-ig", "PL-ACC"), ("čadakh", "ability"), ("bükhn-eer-ee", "all-INST-REFL.POSS"), ("temtse-j", "fight-CVB"), ("bol-no", "be-NPST"), ("gej", "C"), ("khel-sen", "say-PST")]
+    translation := "Against Zorig's disease, Zaya said to him that the doctors will do their best to fight."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "scrambling"), ("construction", "PP-LDS"), ("binder", "matrix DAT"), ("mover", "PP")]
+    comment := "PP-scrambling over a matrix dative binder still reconstructs."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_47 : LinguisticExample :=
+  { id := "gong2022_47"
+    source := ⟨"gong-2022", "(47)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Emč [Bat-ig em-ee uu-gaagüi gej] uurla-san."
+    discourseSegments := []
+    glossedTokens := [("Emč", "doctor.NOM"), ("Bat-ig", "Bat-ACC"), ("em-ee", "medicine-REFL.POSS"), ("uu-gaagüi", "drink-PST.NEG"), ("gej", "C"), ("uurla-san", "become.angry-PST")]
+    translation := "The doctor became angry that Bat did not drink his medicine."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "accusative subject"), ("competitor", "NOM")]
+    comment := "The matrix predicate assigns no accusative, yet the embedded subject is accusative."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_48 : LinguisticExample :=
+  { id := "gong2022_48"
+    source := ⟨"gong-2022", "(48)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Bi [Čang-iig amid bai-gaa gedeg]-t itgeltei bai-na."
+    discourseSegments := []
+    glossedTokens := [("Bi", "1SG.NOM"), ("Čang-iig", "Čang-ACC"), ("amid", "alive"), ("bai-gaa", "COP-NPST.PTCP"), ("gedeg-t", "C-DAT"), ("itgeltei", "believe"), ("bai-na", "COP-NPST")]
+    translation := "I believe that Čang is alive."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "accusative subject"), ("competitor", "NOM")]
+    comment := "The embedded clause itself is dative-marked; the embedded subject is accusative by competition with the matrix subject."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_63 : LinguisticExample :=
+  { id := "gong2022_63"
+    source := ⟨"gong-2022", "(63)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "[Bat-ig ger-iin daalgawr-aa khiikh ni] čukhal."
+    discourseSegments := []
+    glossedTokens := [("Bat-ig", "Bat-ACC"), ("ger-iin", "home-GEN"), ("daalgawr-aa", "assignment-REFL.POSS"), ("khiikh", "do.INF"), ("ni", "3SG.POSS"), ("čukhal", "important")]
+    translation := "It is important that Bat does his homework."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "accusative subject"), ("competitor", "none")]
+    comment := "Under an impersonal predicate the embedded subject cannot be accusative; nominative and genitive are possible."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_64 : LinguisticExample :=
+  { id := "gong2022_64"
+    source := ⟨"gong-2022", "(64)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Saruul [Jon-ig šine mašin aw-san gej] uurla-san."
+    discourseSegments := []
+    glossedTokens := [("Saruul", "Saruul.NOM"), ("Jon-ig", "Jon-ACC"), ("šine", "new"), ("mašin", "car"), ("aw-san", "buy-PST"), ("gej", "C"), ("uurla-san", "become.angry-PST")]
+    translation := "Saruul became angry that Jon bought a new car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "accusative subject"), ("competitor", "NOM")]
+    comment := "A nominative matrix argument competes for case."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_65 : LinguisticExample :=
+  { id := "gong2022_65"
+    source := ⟨"gong-2022", "(65)"⟩
+    reportedIn := none
+    language := "halh1238"
+    primaryText := "Saruul-d [Jon-ig šine mašin aw-san gej] sanagda-j bai-san."
+    discourseSegments := []
+    glossedTokens := [("Saruul-d", "Saruul-DAT"), ("Jon-ig", "Jon-ACC"), ("šine", "new"), ("mašin", "car"), ("aw-san", "buy-PST"), ("gej", "C"), ("sanagda-j", "seem-CVB"), ("bai-san", "COP-PST")]
+    translation := "It seemed to Saruul that Jon bought a new car."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("kind", "accusative subject"), ("competitor", "DAT")]
+    comment := "A dative matrix argument is no competitor: the accusative subject is out, the nominative one in."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_18b, ex_19b, ex_20b, ex_21b, ex_32b, ex_33, ex_40, ex_41, ex_58a, ex_58b, ex_61, ex_79, ex_85b, ex_86, ex_93b, ex_94b, ex_47, ex_48, ex_63, ex_64, ex_65]
+
+end Gong2022.Examples

--- a/Linglib/Fragments/Mongolian/Case.lean
+++ b/Linglib/Fragments/Mongolian/Case.lean
@@ -1,16 +1,14 @@
 import Linglib.Features.Case.Basic
 import Linglib.Syntax.Minimalist.Case.Dependent
-import Linglib.Syntax.Minimalist.LateMerger
 
 /-!
 # Mongolian case
 
 Mongolian (Khalkha and Chakhar) has an accusative-aligned system in which accusative is a
 dependent case, valued on the lower of two NPs in the clause, nominative is assigned by finite T
-under Agree, and dative is nonstructural. Because accusative is configurational it is available
-at intermediate positions of a scrambling chain wherever a case competitor exists, which is what
-Wholesale Late Merger needs to bleed Condition C; Condition C reconstruction tracks these case
-positions rather than scrambling type or the A/A-bar distinction.
+under Agree, and dative is nonstructural ([gong-2022], following [baker-vinokurova-2010]'s Sakha
+but without its dependent dative). The morphological inventory lacks a dedicated locative, which
+postpositions express.
 
 ## References
 
@@ -28,53 +26,10 @@ def grammar : CaseGrammar where
   domains := [(.D, {}), (.v, {}), (.C, { low := some .acc })]
   agree := [(.T, .nom), (.D, .gen)]
 
--- ============================================================================
--- S 2: Scrambling Types
--- ============================================================================
-
-/-- Scrambling types in Mongolian, classified by distance and landing site.
-    [gong-2022] section 2. -/
-inductive ScrambleType where
-  /-- Short scrambling: DO moves past IO within the clause. -/
-  | SS
-  /-- Intermediate scrambling: DO moves past the subject to
-      pre-subject position within the clause. -/
-  | IS
-  /-- Long-distance scrambling: an argument moves out of an
-      embedded finite clause into the matrix clause. -/
-  | LDS
-  deriving DecidableEq, Repr
-
-/-- The grammatical role of the pronoun binder in the base order.
-    This determines which case the binder bears, which in turn
-    determines the structural height of the binder and whether
-    a dependent ACC position exists above it. -/
-inductive BinderRole where
-  /-- Indirect object binder (bears DAT, nonstructural). -/
-  | io
-  /-- Subject binder (bears NOM, assigned by T). -/
-  | subject
-  deriving DecidableEq, Repr
-
--- ============================================================================
--- S 3: Mongolian Case Inventory
--- ============================================================================
-
-/-- Mongolian case inventory.
-    NOM, ACC, GEN, DAT, ABL, INST, COM.
-    [gong-2022]: the cases relevant to scrambling and WLM are
-    NOM (Agree-based), ACC (dependent), and DAT (nonstructural).
-
-    Note: Mongolian lacks a dedicated locative suffix (LOC is expressed
-    via postpositions like *deer* 'on'), creating a Blake hierarchy gap
-    at rank 3 between DAT (rank 4) and ABL/INST (rank 2). This is a
-    known counterexample to strict hierarchy contiguity. -/
+/-- The morphological case inventory: nominative, accusative, genitive, dative, ablative,
+    instrumental, and comitative. -/
 def caseInventory : Finset Case :=
   {.nom, .acc, .gen, .dat, .abl, .inst, .com}
-
--- ============================================================================
--- S 4: Deriving WLM from Dependent Case
--- ============================================================================
 
 /-- A Mongolian ditransitive: the subject above the direct object, shifted to the clause
     edge, above the dative indirect object. -/
@@ -86,14 +41,12 @@ def ditransitive : List PhasedNP :=
 def ditransitiveCases : List (NP × Valuation) := grammar.assign [(.T, .C)] ditransitive
 
 /-- The direct object is valued accusative by the dependent rule, the subject being the
-    caseless NP above it: the case position Wholesale Late Merger needs above the indirect
-    object. -/
+    caseless NP above it. -/
 theorem do_gets_dependent_acc :
     getCaseOf "DO" ditransitiveCases = some .acc ∧
     getMechanismOf "DO" ditransitiveCases = some .dependent := by decide
 
-/-- The subject is valued nominative by T, not by a dependent rule: there is no dependent
-    case position above it. -/
+/-- The subject is valued nominative by T, not by a dependent rule. -/
 theorem subject_gets_nom_by_agree :
     getCaseOf "subject" ditransitiveCases = some .nom ∧
     getMechanismOf "subject" ditransitiveCases = some .agree := by decide
@@ -101,75 +54,5 @@ theorem subject_gets_nom_by_agree :
 /-- The indirect object keeps its lexical dative and neither competes for dependent case nor
     creates a case position. -/
 theorem io_has_lexical_case : getMechanismOf "IO" ditransitiveCases = some .lexical := by decide
-
--- ============================================================================
--- S 5: Chain Positions for WLM (Derived)
--- ============================================================================
-
-/-- Structural height encoding for Mongolian clause positions.
-    Higher numbers = structurally higher positions. -/
-def ioHeight : Nat := 1
-def subjectHeight : Nat := 2
-def specVPHeight : Nat := 3  -- intermediate landing site (edge of VP phase)
-
-/-- Case positions available on a scrambling chain in Mongolian.
-
-    **These are derived from the dependent case algorithm**, not stipulated:
-    - Above IO: the direct object is valued dependent accusative
-      (`do_gets_dependent_acc`), so Spec,VP is a case position
-    - Above Subject: the subject is valued by T, not a dependent rule
-      (`subject_gets_nom_by_agree`), so no case position exists -/
-def casePositionsAbove (role : BinderRole) : List ChainPosition :=
-  match role with
-  | .io => [⟨specVPHeight, true⟩]
-  | .subject => []
-
-/-- Binder height from its grammatical role. -/
-def binderHeight (role : BinderRole) : Nat :=
-  match role with
-  | .io => ioHeight
-  | .subject => subjectHeight
-
--- ============================================================================
--- S 6: WLM Predictions
--- ============================================================================
-
-/-- Whether WLM predicts Condition C reconstruction in a given scenario.
-    This is the central prediction of [gong-2022]: reconstruction
-    tracks case positions, not scrambling type or A/A-bar status. -/
-def predictsReconstruction (role : BinderRole) : Bool :=
-  wlmForcesReconstruction (casePositionsAbove role) (binderHeight role)
-
-/-- Scrambling over IO: WLM bleeds Condition C.
-    [gong-2022] (4), (18b), (27): dependent ACC is available at
-    Spec,VP (`do_gets_dependent_acc`), so the NP restrictor
-    can merge above the IO binder without violating Condition C. -/
-theorem io_binder_no_reconstruction :
-    predictsReconstruction .io = false := by decide
-
-/-- Scrambling over Subject: WLM forces Condition C reconstruction.
-    [gong-2022] (3), (20), (21), (29): no dependent case position
-    exists above the subject (`subject_gets_nom_by_agree`),
-    so the NP restrictor must merge below the subject binder. -/
-theorem subject_binder_forces_reconstruction :
-    predictsReconstruction .subject = true := by decide
-
--- ============================================================================
--- S 7: PP-Scrambling
--- ============================================================================
-
-/-- PP-scrambling always forces Condition C reconstruction.
-    PPs lack the DP-internal structure (determiner + NP restrictor)
-    required for WLM. [gong-2022] (93)-(94): scrambling of PPs
-    headed by *esreg* 'against' always shows obligatory reconstruction,
-    regardless of whether the binder is an IO or Subject. -/
-def ppReconstructsOverIO : Bool := ppAlwaysReconstructs
-def ppReconstructsOverSubj : Bool := ppAlwaysReconstructs
-
-theorem pp_always_reconstructs_io :
-    ppReconstructsOverIO = true := rfl
-
-theorem pp_always_reconstructs_subj :
-    ppReconstructsOverSubj = true := rfl
 
 end Mongolian.Case

--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -30,7 +30,7 @@ the empirical claims of B&P, and bridge to neighbouring studies.
 
 - **§3** Late merger of degree clauses. The degree clause is a
   comparative-deletion construction that merges countercyclically with
-  DegP after movement. We instantiate `lateMergerBleeds` at the
+  DegP after movement. We instantiate `LateMergerBleeds` at the
   degree-specific admissibility predicate and witness the Condition C
   bleeding profile via `degree_lm_bleeds_iff_scope_position_above`.
 - **§4.1** Heim-Kennedy Constraint. We use `IsHeimKennedy` from the
@@ -70,9 +70,9 @@ namespace BhattPancheva2004
 
 open Hoeksema1983
 open Heim2001 (IntensionalVerbDatum intensionalVerbData)
-open Minimalist (lateMergerBleeds wlmBleedsCondC ChainPosition admissible_above_binder_bleeds)
+open Minimalist (ChainPosition)
 open Minimalist.DegreeMovement
-  (degreeClauseLateMergerBleeds scopeOK_above_binder_bleeds
+  (DegreeClauseLateMergerBleeds scopeOK_above_binder_bleeds
    ScopeBinding IsHeimKennedy not_isHeimKennedy_QP_above_bound_DegP
    isHeimKennedy_no_dependency isHeimKennedy_dependency_requires_high_DegP
    williams_scope_correlation williams_exempt_when_no_binding)
@@ -93,10 +93,9 @@ variable {Entity : Type*}
     encoding the §5.1 stimulus contrasts. We do not formalize those
     contrasts here. -/
 theorem degree_lm_bleeds_iff_scope_position_above
-    (chain : List ChainPosition) (binderHeight h : Nat)
-    (hgt : h > binderHeight) :
-    degreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight = true :=
-  scopeOK_above_binder_bleeds chain binderHeight h hgt
+    (chain : List ChainPosition) (binderHeight h : ℕ) (hgt : binderHeight < h) :
+    DegreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight :=
+  scopeOK_above_binder_bleeds hgt
 
 /-! ### Heim-Kennedy Constraint (B&P §4.1) -/
 

--- a/Linglib/Studies/Gong2022.lean
+++ b/Linglib/Studies/Gong2022.lean
@@ -1,300 +1,285 @@
+import Linglib.Syntax.Minimalist.LateMerger
 import Linglib.Fragments.Mongolian.Case
 import Linglib.Fragments.Yakut.Case
+import Linglib.Data.Examples.Gong2022
 
 /-!
-# Gong 2022 [gong-2022]
+# Gong (2022): Case in Wholesale Late Merger: Evidence from Mongolian Scrambling
 
-Case in Wholesale Late Merger: Evidence from Mongolian Scrambling.
-*Linguistic Inquiry*, Early Access.
+This file formalizes [gong-2022]'s argument that Condition C reconstruction in Mongolian
+scrambling tracks case rather than the A/Ā distinction or the subject status of the binder.
+Under [takahashi-hulsey-2009]'s wholesale late merger a determiner moves alone and its restrictor
+merges countercyclically at a chain position where the resulting DP receives case, so scrambling
+bleeds Condition C exactly when the chain has a case position above the pronoun binder, the
+paper's condition (2) (`Bleeds`). The hybrid case rules (26) make accusative a dependent case,
+valued on an NP that an unmarked argumental NP of the same domain c-commands, nominative the
+case finite T assigns, and dative nonstructural (`Site.DependentAcc`, `Site.Nominative`). Read
+off the derivations (27b), (28b), (29c), (55), and (57), the chain positions of short,
+intermediate, and long-distance scrambling predict every judgment of the pool
+(`rows_reconstruction`): a dative binder is bled and a subject binder is not, while the
+embedded-subject binder of (61) is bled because the matrix VP-adjoined position competes for case
+with the matrix subject, which refutes [frank-lee-rambow-1996]'s Subject Binding Generalization
+(`sbg_fails`) and is what an account by movement type cannot state (`is_not_uniform`). The same
+dependent-case rule licenses accusative on an embedded subject exactly when a nominative matrix
+competitor is present, section 5.1 (`acc_subjects`), and the Mongolian grammar differs from
+[baker-vinokurova-2010]'s Sakha only in having no dependent dative
+(`mongolian_differs_from_sakha_in_dat_only`).
 
-## Core claim
+## Implementation notes
 
-Condition C reconstruction effects in Mongolian scrambling are
-controlled by **case assignment**, not by the A/A-bar distinction or
-the special status of subject binders. Wholesale Late Merger (WLM)
-can bleed Condition C iff the movement chain has a case position above
-the pronoun binder.
+Heights order the positions of a clause and, for clause-external scrambling, the matrix clause
+above the embedded one. A site records the arguments of its spell-out domain with the case they
+bear when the mover lands, so the presubject position sees a subject already valued nominative,
+the paper's assumption that case is valued as soon as its conditions are met. A lexically cased
+DP is licensed in its base position and a PP has no restrictor to late-merge, so neither can be
+bled. The CP edge of an embedded clause is a step of successive-cyclic movement without a case
+competitor.
 
-## Mongolian hybrid case system
+## References
 
-- ACC = dependent case (assigned by competition between two NPs in
-  the same phase; [baker-vinokurova-2010])
-- NOM = assigned by finite T via Agree
-- DAT = nonstructural (inherent)
-
-## Key empirical patterns
-
-**Clause-internal scrambling:**
-- SS over IO (DAT) binder: no Condition C effect (WLM bleeds)
-- IS over IO binder: no Condition C effect
-- SS/IS over Subject (NOM) binder: obligatory Condition C reconstruction
-
-**Clause-external scrambling (LDS):**
-- LDS of ACC OBJ, matrix DAT binder: no obligatory Condition C effect
-- LDS of ACC OBJ, matrix NOM (Subject) binder: obligatory Condition C
-
-**PP-scrambling:**
-- Always shows obligatory Condition C reconstruction, regardless of
-  binder position (PPs lack the DP structure required for WLM)
-
-## Negative result
-
-The A/A-bar distinction does not predict these patterns. Mongolian SS and
-IS both behave like A-movement in terms of anaphor binding and WCO
-amelioration, yet they diverge in Condition C reconstruction when the
-binder changes between IO and Subject. The [frank-lee-rambow-1996]
-Subject Binding Generalization also fails for Mongolian: scrambling over
-a subject binder can bleed Condition C in LDS when a dependent ACC
-position is available in the matrix clause.
+* [gong-2022]
+* [takahashi-hulsey-2009]
+* [baker-vinokurova-2010]
+* [frank-lee-rambow-1996]
+* [lebeaux-1988]
 -/
 
 namespace Gong2022
 
-open Minimalist
-open Case
-open Mongolian.Case
+open Minimalist Features Data.Examples
 
--- ============================================================================
--- S 1: Scrambling Scenarios
--- ============================================================================
+/-! ### The hybrid case rules (26) at a landing site -/
 
-/-- A scrambling scenario encoding the empirical data from [gong-2022].
-    Each scenario records the scrambling type, the binder's grammatical role,
-    and whether Condition C reconstruction is observed. -/
-structure ScrambleScenario where
-  label : String
-  scrambleType : ScrambleType
-  binderRole : BinderRole
-  /-- `true` = obligatory Condition C reconstruction observed.
-      `false` = no Condition C effect (WLM bleeds reconstruction). -/
-  reconstructs : Bool
+/-- An argumental NP of a spell-out domain: its height and the case it bears, if any, when the
+mover lands. -/
+structure Arg where
+  height : ℕ
+  valued : Option Case
   deriving DecidableEq, Repr
 
--- ============================================================================
--- S 2: Clause-Internal Scrambling Data
--- ============================================================================
+/-- A landing site of a scrambling chain: its height, the arguments of its spell-out domain, and
+whether it is the specifier finite T agrees into. -/
+structure Site where
+  height : ℕ
+  domain : List Arg
+  specTP : Bool := false
+  deriving DecidableEq, Repr
 
-/-- (18b) SS over IO: DO containing R-expression *Cemeg* scrambled over
-    DAT pronoun binder *tuund*. No Condition C violation.
-    'Cemeg's book, (the) teacher gave (to) her.' -/
-def ss_io : ScrambleScenario :=
-  { label := "SS over IO (18b)"
-  , scrambleType := .SS
-  , binderRole := .io
-  , reconstructs := false }
+/-- (26a): an unmarked argument of the domain c-commands the site, so a DP there is valued
+accusative as a dependent case. -/
+def Site.DependentAcc (s : Site) : Prop := ∃ a ∈ s.domain, s.height < a.height ∧ a.valued = none
 
-/-- (18a) SS over IO, base order: DAT pronoun *tuund* c-commands
-    R-expression *Cemeg* inside the ACC DO. Condition C is violated.
-    '*The teacher gave her Cemeg's book.' -/
-def ss_io_base_ungrammatical : ScrambleScenario :=
-  { label := "SS over IO base order (18a)"
-  , scrambleType := .SS
-  , binderRole := .io
-  , reconstructs := true }  -- base order: R-expression is c-commanded
+/-- (26b): finite T values a DP at its specifier nominative when no unmarked argument is closer
+to T. -/
+def Site.Nominative (s : Site) : Prop :=
+  s.specTP = true ∧ ∀ a ∈ s.domain, s.height < a.height → a.valued ≠ none
 
-/-- (19b) IS over IO: DO scrambled past IO and subject. IO binder is
-    DAT. No Condition C violation.
-    'Cemeg's book, (the) teacher gave (to) her.' -/
-def is_io : ScrambleScenario :=
-  { label := "IS over IO (19b)"
-  , scrambleType := .IS
-  , binderRole := .io
-  , reconstructs := false }
+/-- A position where the late-merged restrictor's DP receives structural case. -/
+def Site.HasCase (s : Site) : Prop := s.DependentAcc ∨ s.Nominative
 
-/-- (20b) IS with Subject binding DO, transitive: Subject pronoun *ter*
-    (NOM) binds R-expression *Cemeg* inside DO. Obligatory reconstruction.
-    '*Cemeg's book, she tore.' -/
-def is_subj_transitive : ScrambleScenario :=
-  { label := "IS over Subj, transitive (20b)"
-  , scrambleType := .IS
-  , binderRole := .subject
-  , reconstructs := true }
+instance (s : Site) : Decidable s.DependentAcc := inferInstanceAs (Decidable (∃ _ ∈ _, _))
+instance (s : Site) : Decidable s.Nominative := inferInstanceAs (Decidable (_ ∧ _))
+instance (s : Site) : Decidable s.HasCase := inferInstanceAs (Decidable (_ ∨ _))
 
-/-- (21b) IS with Subject binding DO, ditransitive: Subject pronoun *ter*
-    (NOM) binds R-expression *Cemeg* inside DO. Obligatory reconstruction.
-    '*Cemeg's book, she gave to Bat.' -/
-def is_subj_ditransitive : ScrambleScenario :=
-  { label := "IS over Subj, ditransitive (21b)"
-  , scrambleType := .IS
-  , binderRole := .subject
-  , reconstructs := true }
+/-- What scrambles: a DP with structural case, a DP with lexical dative, or a PP. -/
+inductive Mover where
+  | dp
+  | lexicalDP
+  | pp
+  deriving DecidableEq, Repr
 
--- ============================================================================
--- S 3: Clause-External Scrambling (LDS)
--- ============================================================================
+/-- Condition (2): scrambling bleeds Condition C when the mover is a DP whose restrictor can
+receive structural case at a chain position above the binder. -/
+def Bleeds (m : Mover) (chain : List Site) (binder : ℕ) : Prop :=
+  m = .dp ∧ LateMergerBleeds Site.HasCase Site.height chain binder
 
-/-- (41) LDS of ACC OBJ with matrix DAT binder: no obligatory Condition C.
-    Embedded ACC object scrambled to matrix clause; matrix dative
-    argument *tuund* is the binder.
-    '?Bat's essay, Zaya said to him that the teacher read.' -/
-def lds_dat_binder : ScrambleScenario :=
-  { label := "LDS, matrix DAT binder (41)"
-  , scrambleType := .LDS
-  , binderRole := .io
-  , reconstructs := false }
+instance (m : Mover) (chain : List Site) (binder : ℕ) : Decidable (Bleeds m chain binder) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
-/-- (40) LDS of ACC OBJ with matrix Subject binder: obligatory Condition C.
-    Embedded ACC object scrambled to matrix clause; matrix Subject
-    *ter* (NOM) is the binder.
-    '*Bat's essay, he said that the teacher read.' -/
-def lds_subj_binder : ScrambleScenario :=
-  { label := "LDS, matrix Subj binder (40)"
-  , scrambleType := .LDS
-  , binderRole := .subject
-  , reconstructs := true }
+/-! ### The positions of the paper's derivations -/
 
--- ============================================================================
--- S 4: All Scenarios
--- ============================================================================
+/-- The subject at the edge of the verb phrase, unmarked until T merges, above the dative
+indirect object. -/
+def subjectUnmarked : Arg := ⟨3, none⟩
 
-def allScenarios : List ScrambleScenario :=
-  [ss_io, is_io, is_subj_transitive, is_subj_ditransitive,
-   lds_dat_binder, lds_subj_binder]
+/-- The dative indirect object. -/
+def io : Arg := ⟨1, some .dat⟩
 
--- ============================================================================
--- S 5: WLM Predictions Match Data
--- ============================================================================
+/-- The VP-edge position of (27b) and (28b): between the subject and the indirect object, valued
+accusative by competition with the subject. -/
+def vpEdge : Site := ⟨2, [subjectUnmarked, io], false⟩
 
-/-- WLM correctly predicts SS over IO: no reconstruction. -/
-theorem ss_io_correct :
-    predictsReconstruction ss_io.binderRole = ss_io.reconstructs := by decide
+/-- The presubject position of (29c): the subject below it is already nominative, and nothing
+c-commands it. -/
+def presubject : Site := ⟨4, [⟨3, some .nom⟩, io], false⟩
 
-/-- WLM correctly predicts IS over IO: no reconstruction. -/
-theorem is_io_correct :
-    predictsReconstruction is_io.binderRole = is_io.reconstructs := by decide
+/-- The edge of the embedded CP, a step of successive-cyclic movement, (55b). -/
+def cpEdge : Site := ⟨4, [], false⟩
 
-/-- WLM correctly predicts IS over Subject (transitive): reconstruction. -/
-theorem is_subj_transitive_correct :
-    predictsReconstruction is_subj_transitive.binderRole
-      = is_subj_transitive.reconstructs := by decide
+/-- The matrix VP-adjoined position of (55c): above the matrix dative argument, below the
+matrix subject, which has not yet been valued. -/
+def matrixVP : Site := ⟨6, [⟨7, none⟩, ⟨5, some .dat⟩], false⟩
 
-/-- WLM correctly predicts IS over Subject (ditransitive): reconstruction. -/
-theorem is_subj_ditransitive_correct :
-    predictsReconstruction is_subj_ditransitive.binderRole
-      = is_subj_ditransitive.reconstructs := by decide
+/-- The matrix presubject position of (57): the matrix subject is nominative by then. -/
+def matrixPresubject : Site := ⟨8, [⟨7, some .nom⟩, ⟨5, some .dat⟩], false⟩
 
-/-- WLM correctly predicts LDS with DAT binder: no reconstruction. -/
-theorem lds_dat_correct :
-    predictsReconstruction lds_dat_binder.binderRole
-      = lds_dat_binder.reconstructs := by decide
+/-- The specifier of finite T in the passive (85b): the agent is instrumental, the goal dative,
+so T values the derived subject nominative. -/
+def specTP : Site := ⟨4, [⟨2, some .inst⟩, io], true⟩
 
-/-- WLM correctly predicts LDS with Subject binder: reconstruction. -/
-theorem lds_subj_correct :
-    predictsReconstruction lds_subj_binder.binderRole
-      = lds_subj_binder.reconstructs := by decide
+/-- The VP edge is a dependent-case position, as the fragment's grammar values the shifted direct
+object of a ditransitive, and the presubject position is none. -/
+theorem vpEdge_dependentAcc :
+    vpEdge.DependentAcc ∧ ¬ presubject.HasCase ∧
+      Case.getMechanismOf "DO" Mongolian.Case.ditransitiveCases = some .dependent := by
+  decide
 
--- ============================================================================
--- S 6: Negative Result — A/A-bar Does Not Predict Reconstruction
--- ============================================================================
+/-! ### The scrambling constructions and their chains -/
 
-/-- The A/A-bar distinction does not predict Mongolian reconstruction.
-    SS over IO and SS over Subject involve the same scrambling type,
-    but differ in Condition C reconstruction. An A/A-bar account would
-    assign the same reconstruction prediction to both, since both
-    involve the same kind of movement. Case-based WLM correctly
-    captures the contrast by looking at case positions, not movement type.
+/-- The scrambling constructions of the pool. -/
+inductive Construction where
+  /-- Short scrambling, the direct object over the indirect object. -/
+  | SS
+  /-- Intermediate scrambling, an object to the presubject position. -/
+  | IS
+  /-- Clause-external scrambling of an accusative embedded subject or of an embedded object,
+  to the matrix presubject position. -/
+  | LDS
+  /-- Clause-external scrambling stopping at the matrix VP-adjoined position, (58). -/
+  | intermediate
+  /-- Scrambling of the dative indirect object over the subject, (79). -/
+  | IO
+  /-- Passivization, (85). -/
+  | passive
+  deriving DecidableEq, Repr
 
-    This connects to [keine-2020]'s probe profiles: even if the
-    scrambling probe is classified as A or A-bar, its classification is
-    constant across scenarios that differ in reconstruction behavior. -/
-theorem same_movement_different_reconstruction :
-    ss_io.scrambleType = ss_io_base_ungrammatical.scrambleType ∧
-    ss_io.reconstructs ≠ ss_io_base_ungrammatical.reconstructs := by decide
+/-- The chain positions each construction makes available, in the paper's derivations. -/
+def Construction.chain : Construction → List Site
+  | .SS => [vpEdge]
+  | .IS | .IO => [vpEdge, presubject]
+  | .LDS => [cpEdge, matrixVP, matrixPresubject]
+  | .intermediate => [cpEdge, matrixVP]
+  | .passive => [specTP]
 
-/-- The Subject Binding Generalization ([frank-lee-rambow-1996]) fails
-    for Mongolian. That generalization predicts that scrambling over a subject
-    binder *always* forces reconstruction. But in LDS, dependent ACC can be
-    assigned in the matrix clause, allowing WLM to bleed Condition C even
-    with a (matrix non-subject) binder. The generalization is too strong:
-    what matters is case positions, not the subject/non-subject status of
-    the binder per se. The correlation with subjects is an epiphenomenon of
-    the fact that subjects typically occupy the highest case position. -/
-theorem sbg_overpredicts :
-    -- Same binder role (IO/DAT) across local and long-distance scrambling
-    ss_io.binderRole = lds_dat_binder.binderRole ∧
-    -- Both correctly predicted by WLM as non-reconstructing
-    ss_io.reconstructs = false ∧
-    lds_dat_binder.reconstructs = false := by decide
+/-- The pronoun that binds the R-expression in the base order. -/
+inductive Binder where
+  | io
+  | subject
+  | matrixDat
+  | matrixSubject
+  | embeddedSubject
+  deriving DecidableEq, Repr
 
--- ============================================================================
--- S 7: Bridge — Dependent Case Algorithm Determines WLM
--- ============================================================================
+/-- The binder's height. -/
+def Binder.height : Binder → ℕ
+  | .io => 1
+  | .subject | .embeddedSubject => 3
+  | .matrixDat => 5
+  | .matrixSubject => 7
 
-/-- The dependent case algorithm *determines* WLM availability: the direct object being
-    valued dependent accusative at Spec,VP (above IO) is exactly what makes the case position
-    available for late merger, and the subject being valued by T rather than a dependent rule
-    is what leaves none above it. -/
-theorem dependent_acc_determines_wlm :
-    Case.getMechanismOf "DO" ditransitiveCases = some .dependent ∧
-    predictsReconstruction .io = false ∧
-    Case.getMechanismOf "subject" ditransitiveCases ≠ some .dependent ∧
-    predictsReconstruction .subject = true := by decide
+/-- Whether the binder is a subject, the Subject Binding Generalization's criterion. -/
+def Binder.IsSubject : Binder → Prop
+  | .subject | .matrixSubject | .embeddedSubject => True
+  | .io | .matrixDat => False
 
--- ============================================================================
--- S 8: PP-Scrambling Contrast
--- ============================================================================
+instance (b : Binder) : Decidable b.IsSubject := by
+  cases b <;> simp only [Binder.IsSubject] <;> infer_instance
 
-/-- PP-scrambling always reconstructs, unlike DP-scrambling.
-    [gong-2022] section 6.2: PPs lack the determiner + NP restrictor
-    structure required for WLM, so Condition C reconstruction is obligatory
-    regardless of the binder's position. This contrast between DP- and
-    PP-scrambling is a further prediction of the WLM account. -/
-theorem pp_vs_dp_contrast :
-    -- DP over IO: no reconstruction
-    predictsReconstruction .io = false ∧
-    -- PP over IO: always reconstructs (no WLM available)
-    ppReconstructsOverIO = true := by decide
+/-! ### The pool -/
 
--- ============================================================================
--- S 9: Successive-Cyclic LDS Through Phase Edges
--- ============================================================================
+/-- A scrambled order: its construction, the base-order binder, the mover, and the judgment. -/
+structure Row where
+  construction : Construction
+  binder : Binder
+  mover : Mover
+  judgment : Judgment
+  deriving DecidableEq, Repr
 
-/-- LDS involves successive-cyclic movement through the embedded CP edge.
+/-- The paper's obligatory reconstruction: the coindexed reading is rejected. -/
+def Row.Reconstructs (r : Row) : Prop :=
+  r.judgment = .ungrammatical ∨ r.judgment = .unacceptable
 
-    The embedded ACC object moves to Spec,CP of the embedded clause (phase
-    edge escape hatch per PIC), then to the matrix clause. The CP edge
-    does NOT provide a case position (C passes features to T via Feature
-    Inheritance, [chomsky-2008]). Case availability in the matrix
-    clause depends on whether a dependent case competitor exists.
+instance (r : Row) : Decidable r.Reconstructs := inferInstanceAs (Decidable (_ ∨ _))
 
-    This derives the LDS chain positions from phase theory rather than
-    stipulating them directly in `casePositionsAbove`. -/
-def ldsChain (binderRole : BinderRole) : List ChainPosition :=
-  ldsChainTemplate
-    (cpEdgeHeight := 4)      -- Spec,CP: above embedded clause
-    (matrixHeight := 5)      -- matrix landing site
-    (matrixCaseAvailable := match binderRole with
-      | .io => true           -- dependent ACC available above matrix IO
-      | .subject => false)    -- no case position above matrix subject
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let construction ← ex.parse? "construction"
+    [("SS", Construction.SS), ("IS", .IS), ("ACC-SUBJ", .LDS), ("LDS", .LDS), ("PP-LDS", .LDS),
+      ("ACC-SUBJ intermediate", .intermediate), ("LDS intermediate", .intermediate), ("IO", .IO),
+      ("passive", .passive)]
+  let binder ← ex.parse? "binder"
+    [("IO", Binder.io), ("subject", .subject), ("matrix DAT", .matrixDat),
+      ("matrix subject", .matrixSubject), ("embedded subject", .embeddedSubject)]
+  let mover ← ex.parse? "mover" [("DP", Mover.dp), ("DP-lexical", .lexicalDP), ("PP", .pp)]
+  pure ⟨construction, binder, mover, ex.judgment⟩
 
-/-- LDS chain predictions agree with the direct `casePositionsAbove`
-    predictions from the Mongolian fragment. The CP edge contributes
-    nothing (no case); only the matrix position matters. -/
-theorem lds_agrees_with_fragment_io :
-    wlmBleedsCondC (ldsChain .io) (binderHeight .io) =
-    wlmBleedsCondC (casePositionsAbove .io) (binderHeight .io) := by decide
+/-- The scrambled orders (18b) to (21b), (32b), (33), (40), (41), (58), (61), (79), (85b), (86),
+(93b), and (94b). -/
+def rows : List Row := Examples.all.filterMap Row.ofExample
 
-theorem lds_agrees_with_fragment_subj :
-    wlmForcesReconstruction (ldsChain .subject) (binderHeight .subject) =
-    wlmForcesReconstruction (casePositionsAbove .subject) (binderHeight .subject) := by decide
+example : rows.length = 16 := by decide
 
-/-- The CP edge alone — without a matrix case position — never
-    bleeds Condition C, regardless of the binder's height. -/
-theorem lds_cp_edge_irrelevant :
-    let cpEdge := successiveCyclicChain
-      [{ height := 4, admissible := false, phaseCat := .C }]
-    wlmForcesReconstruction cpEdge (binderHeight .io) = true ∧
-    wlmForcesReconstruction cpEdge (binderHeight .subject) = true := by
-  exact ⟨lds_cp_edge_alone_no_bleed 4 (binderHeight .io),
-          lds_cp_edge_alone_no_bleed 4 (binderHeight .subject)⟩
+/-- Condition (2) with the hybrid case rules predicts every judgment: reconstruction is
+obligatory exactly when no chain position above the binder receives case. -/
+theorem rows_reconstruction :
+    ∀ r ∈ rows, r.Reconstructs ↔ ¬ Bleeds r.mover r.construction.chain r.binder.height := by
+  decide
 
-/-! ### Dative is inherent, not dependent -/
+/-- Section 2.3: intermediate scrambling of a DP to one landing site reconstructs in (20b) but
+not in (19b), so no classification of the movement as A or Ā decides reconstruction. -/
+theorem is_not_uniform :
+    ∃ r₁ ∈ rows, ∃ r₂ ∈ rows, r₁.construction = .IS ∧ r₂.construction = .IS ∧
+      r₁.mover = .dp ∧ r₂.mover = .dp ∧ ¬ r₁.Reconstructs ∧ r₂.Reconstructs := by
+  decide
 
-/-! [gong-2022] adopts the Sakha grammar of [baker-vinokurova-2010] for
-Mongolian but takes dative to be inherent rather than dependent. Holding the
-other three mechanisms fixed and varying only `datMode`, the algorithm stops
-deriving dative at all, so the dative on a Mongolian goal must be supplied as
-lexical case. -/
+/-- Section 4.2: the Subject Binding Generalization (24) fits the clause-internal data, but (61),
+where the embedded subject binds, is bled because the matrix VP-adjoined position competes for
+case with the matrix subject; and the PP of (94b) reconstructs under a dative binder. -/
+theorem sbg_fails :
+    (∀ r ∈ rows, r.construction = .SS ∨ r.construction = .IS →
+      (r.Reconstructs ↔ r.binder.IsSubject)) ∧
+      (∃ r ∈ rows, r.binder = .embeddedSubject ∧ r.mover = .dp ∧ ¬ r.Reconstructs) ∧
+      ∃ r ∈ rows, ¬ r.binder.IsSubject ∧ r.Reconstructs := by
+  decide
+
+/-! ### Section 5.1: accusative on embedded subjects -/
+
+/-- The matrix argument that could compete with the embedded subject for case. -/
+inductive Competitor where
+  | nom
+  | dat
+  | absent
+  deriving DecidableEq, Repr
+
+/-- The embedded subject at the edge of its clause, in the matrix domain: the site (26a)
+evaluates. -/
+def Competitor.site : Competitor → Site
+  | .nom => ⟨4, [⟨7, none⟩], false⟩
+  | .dat => ⟨4, [⟨7, some .dat⟩], false⟩
+  | .absent => ⟨4, [], false⟩
+
+/-- An accusative-marked embedded subject with its matrix competitor and judgment. -/
+structure AccRow where
+  competitor : Competitor
+  judgment : Judgment
+  deriving DecidableEq, Repr
+
+def AccRow.ofExample (ex : LinguisticExample) : Option AccRow := do
+  let competitor ← ex.parse? "competitor" [("NOM", Competitor.nom), ("DAT", .dat), ("none", .absent)]
+  pure ⟨competitor, ex.judgment⟩
+
+/-- (47), (48), (63), (64), and (65). -/
+def accRows : List AccRow := Examples.all.filterMap AccRow.ofExample
+
+example : accRows.length = 5 := by decide
+
+/-- Accusative on the embedded subject is licensed exactly when an unmarked matrix argument
+c-commands it: a nominative subject competes, a dative or impersonal predicate's argument does
+not. -/
+theorem acc_subjects :
+    ∀ r ∈ accRows, r.judgment = .acceptable ↔ r.competitor.site.DependentAcc := by
+  decide
+
+/-! ### Section 5.3: dative is not a dependent case -/
 
 /-- Mongolian differs from Sakha in the verb phrase's high case alone: no dependent dative. -/
 theorem mongolian_differs_from_sakha_in_dat_only :
@@ -302,14 +287,14 @@ theorem mongolian_differs_from_sakha_in_dat_only :
     Mongolian.Case.grammar.rules .C = Yakut.Case.grammar.rules .C ∧
     Mongolian.Case.grammar.agree = Yakut.Case.grammar.agree := by decide
 
-/-- The Sakha ditransitive: a subject, a VP-internal goal, and a theme shifted to the
-    phase edge. -/
-def sakhaDitransitive : List Minimalist.PhasedNP :=
+/-- The Sakha ditransitive: a subject, a VP-internal goal, and a theme shifted to the phase
+edge. -/
+def sakhaDitransitive : List PhasedNP :=
   [{ label := "subject" }, { label := "goal", phase := .v },
    { label := "theme", phase := .v, shifted := true }]
 
-/-- The Mongolian grammar values no NP of the Sakha ditransitive dative — it mentions no
-    dative — so the goal Sakha values dative comes out otherwise. -/
+/-- The Mongolian grammar values no NP of the Sakha ditransitive dative, so the goal Sakha
+values dative comes out otherwise: the dative of a Mongolian goal is nonstructural. -/
 theorem mongolian_derives_no_dative :
     (∀ s ∈ Mongolian.Case.grammar.assign [(.T, .C)] sakhaDitransitive,
       s.2.map (·.1) ≠ some .dat) ∧

--- a/Linglib/Syntax/Minimalist/LateMerger.lean
+++ b/Linglib/Syntax/Minimalist/LateMerger.lean
@@ -1,303 +1,84 @@
-import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
+import Mathlib.Data.Nat.Notation
 
 /-!
-# Late Merger
-[lebeaux-1988] [takahashi-hulsey-2009] [bhatt-pancheva-2004]
+# Late merger
 
-Late merger (originally [lebeaux-1988] for adjuncts; extended to NP
-restrictors as Wholesale Late Merger by [takahashi-hulsey-2009];
-extended to degree clauses by [bhatt-pancheva-2004]) introduces
-some sub-constituent of a moved phrase countercyclically at a non-base
-position on the movement chain.
+Late merger introduces a sub-constituent of a moved phrase countercyclically at a non-base
+position of its movement chain: adjuncts in [lebeaux-1988], the NP restrictor of a determiner in
+[takahashi-hulsey-2009]'s wholesale late merger, degree clauses in [bhatt-pancheva-2004]. The
+flavors differ only in which chain positions admit the merger and share one Condition C profile:
+late merger bleeds Condition C exactly when an admissible position lies strictly above the
+pronoun binder. `LateMergerBleeds` is that profile, polymorphic in the position type and the
+admissibility predicate, and `WLMBleedsCondC` its case-licensing instance on `ChainPosition`,
+whose admissible positions are those where the resulting DP receives case; [gong-2022] shows
+that reconstruction under scrambling tracks these case positions rather than the A/Ā
+distinction.
 
-## Generic shape
+## References
 
-Late merger comes in flavors that differ only in *which positions are
-admissible targets* for late merger:
-
-- WLM (NP restrictors): admissible iff case can be assigned there.
-- B&P (degree clauses): admissible iff the position can host a ⟨t⟩-scope
-  for the degree quantifier (subject to the Heim-Kennedy Constraint).
-- Lebeaux (adjuncts): admissible everywhere on the chain.
-
-The Condition C bleeding profile is the same in every flavor: late
-merger bleeds Condition C iff there exists an *admissible* chain
-position strictly above the pronoun binder. We factor this shared
-shape into the polymorphic `lateMergerBleeds` operation, with
-`wlmBleedsCondC` as the case-licensing specialization for NPs.
-
-## Core ideas
-
-The late-merger account is theory-neutral about the encoding of
-movement chains. Under the **copy theory** of movement, a moved
-phrase leaves explicit copies at every position on its chain. Under
-the **trace-as-leaf encoding** that linglib's substrate currently
-uses (MCB ^ρ-form-with-indexing — see `Basic.lean` `SyntacticObject`
-docstring), each chain position is marked by a `.trace n` leaf
-sharing the index `n` with its mover. Either encoding licenses the
-same Late Merger reasoning: the sub-constituent is introduced at any
-admissible chain position, regardless of how that position is
-materialized in the SyntacticObject. This file's `chain : List ChainPosition`
-abstraction is encoding-agnostic at the API level; the substrate
-choice (trace-as-leaf) shows up only at the level of the concrete
-SyntacticObject produced after IM.
-
-If the late-merged constituent contains an R-expression that would be
-c-commanded by a coreferential pronoun at the base position, full
-reconstruction triggers a Condition C violation. Late merger can
-avoid this by introducing the constituent at a higher *admissible*
-copy position.
-
-[gong-2022] shows that for NP restrictors the case requirement is
-the key factor controlling Condition C reconstruction effects in
-Mongolian scrambling: reconstruction tracks case positions, not the
-A/A-bar distinction.
-
-## Definitions
-
-- `lateMergerBleeds` — generic late-merger bleeding test, polymorphic
-  in position type and admissibility predicate
-- `ChainPosition` — a position on a movement chain with its height and
-  case availability
-- `wlmBleedsCondC` — case-licensing specialization for NP restrictors
-- `wlmForcesReconstruction` — negation of `wlmBleedsCondC`
+* [lebeaux-1988]
+* [takahashi-hulsey-2009]
+* [bhatt-pancheva-2004]
+* [gong-2022]
 -/
 
 namespace Minimalist
 
-open SyntacticObject
+variable {α : Type*} {admissible : α → Prop} {height : α → ℕ} {chain : List α} {binder : ℕ}
 
--- ============================================================================
--- S 1: Generic Late-Merger Bleeding
--- ============================================================================
+/-- Late merger bleeds Condition C when an admissible chain position lies strictly above the
+binder. -/
+def LateMergerBleeds (admissible : α → Prop) (height : α → ℕ) (chain : List α) (binder : ℕ) :
+    Prop :=
+  ∃ p ∈ chain, admissible p ∧ binder < height p
 
-/-- Generic late-merger bleeding test.
+instance [DecidablePred admissible] :
+    Decidable (LateMergerBleeds admissible height chain binder) :=
+  inferInstanceAs (Decidable (∃ _ ∈ _, _))
 
-    Given a movement chain (any list of positions), a height projection,
-    an admissibility predicate, and a binder height: late merger bleeds
-    Condition C iff there exists an *admissible* chain position strictly
-    above the binder.
+/-- An admissible position above the binder bleeds Condition C. -/
+theorem lateMergerBleeds_cons_of (p : α) (hp : admissible p) (hgt : binder < height p) :
+    LateMergerBleeds admissible height (p :: chain) binder :=
+  ⟨p, List.mem_cons_self .., hp, hgt⟩
 
-    Specializations:
-    - `wlmBleedsCondC` ([takahashi-hulsey-2009]): NP restrictors,
-      admissible := case-available
-    - Late merger of degree clauses ([bhatt-pancheva-2004]): degree
-      clauses, admissible := position can host a ⟨t⟩-scope subject to
-      the Heim-Kennedy Constraint -/
-def lateMergerBleeds {α : Type*} (admissible : α → Bool) (height : α → Nat)
-    (chain : List α) (binderHeight : Nat) : Bool :=
-  chain.any (fun p => admissible p && height p > binderHeight)
+/-- Adding a chain position never removes bleeding. -/
+theorem LateMergerBleeds.cons (p : α) (h : LateMergerBleeds admissible height chain binder) :
+    LateMergerBleeds admissible height (p :: chain) binder :=
+  let ⟨q, hq, hpq⟩ := h; ⟨q, List.mem_cons_of_mem p hq, hpq⟩
 
-/-- Adding a chain position never removes late-merger bleeding. -/
-theorem lateMerger_bleeding_monotone {α : Type*}
-    (admissible : α → Bool) (height : α → Nat)
-    (chain : List α) (p : α) (binderHeight : Nat)
-    (h : lateMergerBleeds admissible height chain binderHeight = true) :
-    lateMergerBleeds admissible height (p :: chain) binderHeight = true := by
-  simp only [lateMergerBleeds, List.any_cons, Bool.or_eq_true]
-  right; exact h
+/-- A chain at or below the binder forces reconstruction, whatever is admissible. -/
+theorem not_lateMergerBleeds_of_le (h : ∀ p ∈ chain, height p ≤ binder) :
+    ¬ LateMergerBleeds admissible height chain binder :=
+  λ ⟨p, hp, _, hgt⟩ => absurd hgt (Nat.not_lt.mpr (h p hp))
 
-/-- Consing an admissible position above the binder guarantees bleeding. -/
-theorem admissible_above_binder_bleeds {α : Type*}
-    (admissible : α → Bool) (height : α → Nat)
-    (chain : List α) (p : α) (binderHeight : Nat)
-    (hadm : admissible p = true) (hgt : height p > binderHeight) :
-    lateMergerBleeds admissible height (p :: chain) binderHeight = true := by
-  simp only [lateMergerBleeds, List.any_cons, Bool.or_eq_true, Bool.and_eq_true,
-             decide_eq_true_eq]
-  left; exact ⟨hadm, hgt⟩
+/-- A chain without an admissible position forces reconstruction, whatever the heights. -/
+theorem not_lateMergerBleeds_of_none (h : ∀ p ∈ chain, ¬ admissible p) :
+    ¬ LateMergerBleeds admissible height chain binder :=
+  λ ⟨p, hp, hadm, _⟩ => h p hp hadm
 
-/-- If every chain position is at or below the binder, late merger
-    cannot bleed Condition C — regardless of which admissibility
-    predicate is used. -/
-theorem top_binder_no_bleed {α : Type*}
-    (admissible : α → Bool) (height : α → Nat)
-    (chain : List α) (binderHeight : Nat)
-    (h : ∀ p ∈ chain, height p ≤ binderHeight) :
-    lateMergerBleeds admissible height chain binderHeight = false := by
-  simp only [lateMergerBleeds]
-  rw [List.any_eq_false]
-  intro p hmem
-  simp only [Bool.and_eq_true, decide_eq_true_eq]
-  intro ⟨_, hgt⟩
-  exact absurd hgt (Nat.not_lt.mpr (h p hmem))
-
-/-- If no chain position is admissible, late merger cannot bleed. -/
-theorem no_admissible_no_bleed {α : Type*}
-    (admissible : α → Bool) (height : α → Nat)
-    (chain : List α) (binderHeight : Nat)
-    (h : ∀ p ∈ chain, admissible p = false) :
-    lateMergerBleeds admissible height chain binderHeight = false := by
-  simp only [lateMergerBleeds]
-  rw [List.any_eq_false]
-  intro p hmem
-  simp [h p hmem]
-
--- ============================================================================
--- S 2: Chain Positions for NP Late Merger
--- ============================================================================
-
-/-- A position on a movement chain.
-    `height` encodes structural position (higher = larger Nat).
-    `admissible` records whether this position is admissible for the
-    relevant late-merger licensing — case assignment (WLM / Condition C,
-    `wlmBleedsCondC`) or scope licensing (degree clauses,
-    `DegreeMovement.degreeClauseLateMergerBleeds`). -/
+/-- A position on a movement chain: its height and whether it admits the late merger, for NP
+restrictors whether the DP receives case there. -/
 structure ChainPosition where
-  height : Nat
+  height : ℕ
   admissible : Bool
   deriving DecidableEq, Repr
 
--- ============================================================================
--- S 3: WLM (NP Restrictors) and Condition C
--- ============================================================================
+/-- Wholesale late merger of an NP restrictor bleeds Condition C when a case position lies
+strictly above the binder ([takahashi-hulsey-2009], [gong-2022]'s condition (2)). -/
+def WLMBleedsCondC (chain : List ChainPosition) (binder : ℕ) : Prop :=
+  LateMergerBleeds (·.admissible = true) ChainPosition.height chain binder
 
-/-- Wholesale late merger bleeds Condition C iff there exists a position
-    on the movement chain that is (a) strictly above the pronoun binder
-    and (b) a position where case can be assigned.
+instance (chain : List ChainPosition) (binder : ℕ) : Decidable (WLMBleedsCondC chain binder) :=
+  inferInstanceAs (Decidable (LateMergerBleeds _ _ _ _))
 
-    Case-licensing specialization of `lateMergerBleeds`.
+/-- A case position above the binder bleeds Condition C. -/
+theorem wlmBleedsCondC_cons_of {chain : List ChainPosition} {binder h : ℕ} (hgt : binder < h) :
+    WLMBleedsCondC (⟨h, true⟩ :: chain) binder :=
+  lateMergerBleeds_cons_of _ rfl hgt
 
-    [gong-2022] condition (2): WLM may bleed Condition C if the
-    movement chain permits a case position higher than the pronoun
-    binder. -/
-def wlmBleedsCondC (chain : List ChainPosition) (binderHeight : Nat) : Bool :=
-  lateMergerBleeds (·.admissible) ChainPosition.height chain binderHeight
-
-/-- WLM forces Condition C reconstruction when no case position
-    on the chain is above the binder. The NP restrictor must merge
-    at its base position (or at least below the binder), placing the
-    R-expression within the binder's c-command domain. -/
-def wlmForcesReconstruction (chain : List ChainPosition) (binderHeight : Nat) : Bool :=
-  !wlmBleedsCondC chain binderHeight
-
-/-- PP-scrambling never benefits from WLM: PPs do not contain a
-    determiner with an NP restrictor that can be late-merged.
-    PP-scrambling always exhibits obligatory Condition C reconstruction.
-
-    [gong-2022] section 6.2: scrambling of PPs headed by *esreg*
-    'against' always forces reconstruction, regardless of the binder's
-    position. -/
-def ppAlwaysReconstructs : Bool := true
-
--- ============================================================================
--- S 4: WLM Structural Properties (specializations of generic lemmas)
--- ============================================================================
-
-/-- If every chain position is at or below the binder, WLM forces
-    reconstruction. Specialization of `top_binder_no_bleed`. -/
-theorem top_binder_forces_reconstruction
-    (chain : List ChainPosition) (binderHeight : Nat)
-    (h : ∀ cp ∈ chain, cp.height ≤ binderHeight) :
-    wlmForcesReconstruction chain binderHeight = true := by
-  simp [wlmForcesReconstruction, wlmBleedsCondC,
-        top_binder_no_bleed _ ChainPosition.height chain binderHeight h]
-
-/-- A case position above the binder guarantees WLM bleeds Condition C.
-    Specialization of `admissible_above_binder_bleeds`. -/
-theorem case_above_binder_bleeds
-    (chain : List ChainPosition) (binderHeight h : Nat)
-    (hgt : h > binderHeight) :
-    wlmBleedsCondC (⟨h, true⟩ :: chain) binderHeight = true :=
-  admissible_above_binder_bleeds _ _ chain ⟨h, true⟩ binderHeight rfl hgt
-
-/-- WLM bleeding is monotone: adding positions never removes it.
-    Specialization of `lateMerger_bleeding_monotone`. -/
-theorem wlm_bleeding_monotone
-    (chain : List ChainPosition) (cp : ChainPosition) (binderHeight : Nat)
-    (h : wlmBleedsCondC chain binderHeight = true) :
-    wlmBleedsCondC (cp :: chain) binderHeight = true :=
-  lateMerger_bleeding_monotone _ _ chain cp binderHeight h
-
-/-- If no chain position has case available, WLM forces reconstruction
-    regardless of heights. Specialization of `no_admissible_no_bleed`. -/
-theorem no_case_forces_reconstruction
-    (chain : List ChainPosition) (binderHeight : Nat)
-    (h : ∀ cp ∈ chain, cp.admissible = false) :
-    wlmForcesReconstruction chain binderHeight = true := by
-  simp [wlmForcesReconstruction, wlmBleedsCondC,
-        no_admissible_no_bleed (·.admissible) ChainPosition.height
-          chain binderHeight h]
-
--- ============================================================================
--- S 5: Condition C over Syntactic Objects
--- ============================================================================
-
-/-- Condition C violation check: does the binder c-command the
-    R-expression in tree `root`?
-
-    This is the structural condition checked on concrete
-    `SyntacticObject` trees, complementing the abstract chain-position
-    analysis in `wlmForcesReconstruction`. -/
-def conditionCViolation (root binder rExpr : SyntacticObject) : Bool :=
-  decide (cCommandsIn root binder rExpr)
-
-/-- Condition C is satisfied in a tree: the binder does NOT c-command
-    the R-expression. Takes the tree after any WLM has applied.
-    Returns `true` when the R-expression is free. -/
-def conditionCSatisfied (tree binder rExpr : SyntacticObject) : Bool :=
-  !conditionCViolation tree binder rExpr
-
--- ============================================================================
--- S 6: Successive-Cyclic Movement and Phase Edges
--- ============================================================================
-
-/-- A position at a phase edge on a movement chain.
-
-    Successive-cyclic movement creates an intermediate copy at each
-    phase edge the mover passes through ([chomsky-2000]).
-    Whether case is available at the edge determines whether WLM
-    can target that position ([gong-2022]). -/
-structure PhaseEdgePosition extends ChainPosition where
-  phaseCat : Cat
-  deriving DecidableEq, Repr
-
-/-- Derive chain positions from successive-cyclic movement through
-    phase edges. Each phase edge the mover passes through becomes a
-    position on the movement chain. -/
-def successiveCyclicChain (edges : List PhaseEdgePosition) : List ChainPosition :=
-  edges.map PhaseEdgePosition.toChainPosition
-
-/-- CP edges do not provide case positions. C does not assign structural
-    case; it passes tense/agreement features to T via Feature Inheritance
-    ([chomsky-2008]). -/
-theorem cp_edge_no_case (h : Nat) :
-    ({ height := h, admissible := false, phaseCat := .C : PhaseEdgePosition
-      }).toChainPosition.admissible = false := rfl
-
-/-- LDS chain template: movement from an embedded clause through the
-    CP edge to a matrix clause position. The CP edge provides no case,
-    but the matrix position may — depending on case competitors.
-
-    This is the structural template for [gong-2022]'s LDS data:
-    embedded ACC object → Spec,CP (no case) → matrix clause (case
-    depends on whether a dependent case competitor exists). -/
-def ldsChainTemplate (cpEdgeHeight matrixHeight : Nat) (matrixCaseAvailable : Bool)
-    : List ChainPosition :=
-  successiveCyclicChain [
-    { height := cpEdgeHeight, admissible := false, phaseCat := .C },
-    { height := matrixHeight, admissible := matrixCaseAvailable, phaseCat := .v }
-  ]
-
-/-- A CP edge alone never bleeds Condition C: case is unavailable. -/
-theorem lds_cp_edge_alone_no_bleed (cpEdgeHeight binderHeight : Nat) :
-    wlmForcesReconstruction
-      (successiveCyclicChain [{ height := cpEdgeHeight, admissible := false, phaseCat := .C }])
-      binderHeight = true := by
-  apply no_case_forces_reconstruction
-  simp [successiveCyclicChain, List.map, PhaseEdgePosition.toChainPosition]
-
-/-- LDS with a matrix case position above the binder bleeds Condition C.
-
-    [gong-2022] (41): embedded ACC object scrambled to matrix
-    clause; matrix dative argument is the binder. Dependent ACC is
-    available in the matrix clause (above the binder), so WLM bleeds. -/
-theorem lds_matrix_case_bleeds (cpEdgeHeight matrixHeight binderHeight : Nat)
-    (h : matrixHeight > binderHeight) :
-    wlmBleedsCondC (ldsChainTemplate cpEdgeHeight matrixHeight true) binderHeight = true := by
-  unfold ldsChainTemplate successiveCyclicChain
-  simp only [List.map, PhaseEdgePosition.toChainPosition]
-  exact wlm_bleeding_monotone _ _ _
-    (case_above_binder_bleeds [] binderHeight matrixHeight h)
+/-- A chain without a case position forces reconstruction. -/
+theorem not_wlmBleedsCondC_of_none {chain : List ChainPosition} {binder : ℕ}
+    (h : ∀ p ∈ chain, p.admissible = false) : ¬ WLMBleedsCondC chain binder :=
+  not_lateMergerBleeds_of_none λ p hp => by simp [h p hp]
 
 end Minimalist

--- a/Linglib/Syntax/Minimalist/Movement/DegreeMovement.lean
+++ b/Linglib/Syntax/Minimalist/Movement/DegreeMovement.lean
@@ -12,7 +12,7 @@ the Heim-Kennedy Constraint ([heim-2000]). Both constraints
 relate the LF position of a DegP to the LF position of any
 quantificational DP whose trace appears inside it.
 
-Specializes `lateMergerBleeds` for degree clauses, formalizes the
+Specializes `LateMergerBleeds` for degree clauses, formalizes the
 Heim-Kennedy Constraint as a structural filter, derives the Williams
 correlation as a corollary, and adds the [bhatt-takahashi-2011]
 §4 (43) base-position generalization.
@@ -45,32 +45,30 @@ open Minimalist
 -- § 1. Degree-Clause Late-Merger Admissibility
 -- ════════════════════════════════════════════════════
 
-/-- The B&P specialization of `lateMergerBleeds` for degree clauses:
+/-- The B&P specialization of `LateMergerBleeds` for degree clauses:
     the degree clause can late-merge above a Condition-C-relevant
     binder iff there is a *scope-licit* chain position above the binder.
     Chain positions are the shared `ChainPosition`; here `admissible`
     reads as "scope-licit" (Heim-Kennedy-compliant DegP scope) rather
     than "case-available". -/
-def degreeClauseLateMergerBleeds
-    (chain : List ChainPosition) (binderHeight : Nat) : Bool :=
-  lateMergerBleeds (·.admissible) ChainPosition.height chain binderHeight
+def DegreeClauseLateMergerBleeds (chain : List ChainPosition) (binderHeight : ℕ) : Prop :=
+  LateMergerBleeds (·.admissible = true) ChainPosition.height chain binderHeight
+
+instance (chain : List ChainPosition) (binderHeight : ℕ) :
+    Decidable (DegreeClauseLateMergerBleeds chain binderHeight) :=
+  inferInstanceAs (Decidable (LateMergerBleeds _ _ _ _))
 
 /-- A scope-licit position above the binder bleeds Condition C for
-    degree-clause late merger. Specialization of
-    `admissible_above_binder_bleeds`. -/
-theorem scopeOK_above_binder_bleeds
-    (chain : List ChainPosition) (binderHeight h : Nat)
-    (hgt : h > binderHeight) :
-    degreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight = true :=
-  admissible_above_binder_bleeds _ _ chain ⟨h, true⟩ binderHeight rfl hgt
+    degree-clause late merger. Specialization of `lateMergerBleeds_cons_of`. -/
+theorem scopeOK_above_binder_bleeds {chain : List ChainPosition} {binderHeight h : ℕ}
+    (hgt : binderHeight < h) : DegreeClauseLateMergerBleeds (⟨h, true⟩ :: chain) binderHeight :=
+  lateMergerBleeds_cons_of _ rfl hgt
 
 /-- If no chain position is scope-licit, the degree clause is forced to
-    reconstruct. Specialization of `no_admissible_no_bleed`. -/
-theorem no_scopeOK_forces_reconstruction
-    (chain : List ChainPosition) (binderHeight : Nat)
-    (h : ∀ p ∈ chain, p.admissible = false) :
-    degreeClauseLateMergerBleeds chain binderHeight = false :=
-  no_admissible_no_bleed _ _ chain binderHeight h
+    reconstruct. Specialization of `not_lateMergerBleeds_of_none`. -/
+theorem no_scopeOK_forces_reconstruction {chain : List ChainPosition} {binderHeight : ℕ}
+    (h : ∀ p ∈ chain, p.admissible = false) : ¬ DegreeClauseLateMergerBleeds chain binderHeight :=
+  not_lateMergerBleeds_of_none λ p hp => by simp [h p hp]
 
 -- ════════════════════════════════════════════════════
 -- § 2. Heim-Kennedy Constraint as a Structural Filter

--- a/references.bib
+++ b/references.bib
@@ -366,7 +366,7 @@
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Fragments/Mongolian/Case.lean;Studies/Gong2022.lean;Syntax/Minimalist/LateMerger.lean}
+  sources   = {Data/Examples/Gong2022.json;Fragments/Mongolian/Case.lean;Studies/Gong2022.lean;Syntax/Minimalist/LateMerger.lean}
 }
 @article{goodman-stuhlmuller-2013,
   author    = {Goodman, Noah D. and Stuhlm{\"u}ller, Andreas},
@@ -636,7 +636,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Syntax/Minimalist/LateMerger.lean}
+  sources   = {Studies/BhattPancheva2004.lean;Studies/Gong2022.lean;Syntax/Minimalist/LateMerger.lean}
 }
 @misc{tessler-franke-2019,
   author    = {Tessler, Michael Henry and Franke, Michael},
@@ -7018,7 +7018,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Degree/ThanClause.lean;Studies/Kennedy1999.lean;Studies/BhattPancheva2004.lean}
+  sources   = {Features/LicensingContext.lean;Semantics/Degree/Basic.lean;Semantics/Degree/Quantifier.lean;Semantics/Polarity/Licensing.lean;Studies/BhattPancheva2004.lean;Studies/Heim2001.lean;Syntax/Minimalist/LateMerger.lean;Syntax/Minimalist/Movement/DegreeMovement.lean}
 }% REF: Goldberg, A. E. & Jackendoff, R. (2004). The English Resultative as a Family of Constructions. Language, 80(3), 532-568.
 @article{goldberg-jackendoff-2004,
   author    = {Goldberg, Adele E. and Jackendoff, Ray},
@@ -18172,7 +18172,7 @@
     subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Features/Slot.lean;Studies/BakerVinokurova2010.lean;Studies/BejarRezac2003.lean;Studies/FoxPesetsky2005.lean;Studies/LiuYip2026.lean;Studies/Scott2023.lean;Studies/Zeijlstra2012.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/LateMerger.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
+  sources   = {Features/Slot.lean;Studies/BakerVinokurova2010.lean;Studies/BejarRezac2003.lean;Studies/FoxPesetsky2005.lean;Studies/LiuYip2026.lean;Studies/Scott2023.lean;Studies/Zeijlstra2012.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
 }
 @incollection{chomsky-2001,
   author    = {Chomsky, Noam},
@@ -18296,7 +18296,7 @@
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Fragments/Yakut/Case.lean;Studies/BakerVinokurova2010.lean}
+  sources   = {Data/Examples/BakerVinokurova2010.json;Fragments/Mongolian/Case.lean;Fragments/Yakut/Case.lean;Studies/Baker2015.lean;Studies/BakerVinokurova2010.lean;Studies/ClemDeal2024.lean;Studies/Gong2022.lean;Studies/Major2024.lean;Studies/Marantz1991.lean;Studies/Poole2024.lean;Syntax/Minimalist/Case/Dependent.lean}
 }
 @phdthesis{vinokurova-2005,
   author    = {Vinokurova, Nadezhda},
@@ -20945,7 +20945,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Syntax/Minimalist/LateMerger.lean;Syntax/Minimalist/Phase/Basic.lean}
+  sources   = {Syntax/Minimalist/Phase/Basic.lean}
 }% REF: Pylkkänen, L. (2008). *Introducing Arguments*. MIT Press.
 @book{pylkkanen-2008,
   author    = {Pylkkänen, Liina},
@@ -21877,7 +21877,7 @@
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Egressy2026.lean;Studies/Gong2022.lean;Studies/Keine2019.lean;Studies/Keine2020.lean;Studies/LiuYip2026.lean;Studies/Pietraszko2026.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Profile.lean}
+  sources   = {Studies/Egressy2026.lean;Studies/Keine2019.lean;Studies/Keine2020.lean;Studies/LiuYip2026.lean;Studies/Pietraszko2026.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Profile.lean}
 }% REF: Keine, S. (2019). "Selective Opacity"
 @article{keine-2019,
   author    = {Keine, Stefan},
@@ -29066,7 +29066,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Syntax/Minimalist/LateMerger.lean}
+  sources   = {Studies/BhattPancheva2004.lean;Studies/Gong2022.lean;Syntax/Minimalist/LateMerger.lean}
 }
 
 @unpublished{leben-2018,


### PR DESCRIPTION
Deep cleanse of Gong2022 against the paper (Zotero PDF): condition (2) on wholesale late merger with the hybrid case rules (26), applied to the paper's own derivations, predicts every judgment of the pool.

- Landing sites carry the arguments of their spell-out domain with the case they bear when the mover lands; `Site.DependentAcc`/`Site.Nominative` are rules (26a) and (26b), `Bleeds` is condition (2) through the substrate's `LateMergerBleeds`; 16 scrambled orders as rows (`rows_reconstruction`), the A/Ā non-uniformity of (19b) vs (20b), the Subject Binding Generalization refuted by (61) and (94b), and section 5.1's accusative embedded subjects (`acc_subjects`); the Sakha comparison kept.
- `Syntax/Minimalist/LateMerger.lean` recut to Prop (`LateMergerBleeds`, `WLMBleedsCondC`) with the Gong-specific LDS template, the `ppAlwaysReconstructs := true` stipulation, and the Bool Condition C wrappers deleted; DegreeMovement and BhattPancheva2004 adapted.
- `Fragments/Mongolian/Case.lean` keeps the case grammar and the ditransitive; the scrambling types, binder roles, and reconstruction predictions move out of the fragment into the study, where they are derived rather than stored.
