### PR TITLE
refactor(Studies/Grimm2018): the systems of Tables 20, 23, and 24

### DIFF
--- a/Linglib/Studies/Grimm2018.lean
+++ b/Linglib/Studies/Grimm2018.lean
@@ -1,174 +1,123 @@
-import Mathlib.Order.Interval.Set.OrdConnected
 import Linglib.Features.Individuation
-import Linglib.Features.MassCount
-import Linglib.Features.Number.Basic
 import Linglib.Features.Prominence
+import Mathlib.Order.Interval.Set.OrdConnected
 
 /-!
-# Grimm (2018) — Grammatical Number and the Scale of Individuation
-[grimm-2018]
+# Grimm (2018): Grammatical Number and the Scale of Individuation
 
-Formalizes the core framework of:
+This file formalizes [grimm-2018]'s thesis that a language's grammatical number categories
+partition the scale of individuation, substances below granular aggregates below collective
+aggregates below individuals (`IndividuationType`), by an order-preserving map (section 3.4).
+The consequence the paper draws, that no category spans two disconnected segments of the scale,
+is the order-connectedness of the fibres of a monotone map (`ordConnected_fiber_of_monotone`),
+and the impossible system of Table 21 fails it under every ordering of its classes
+(`bad_not_monotone`). The systems of Table 20 and section 4.1, Dagaare with a class per type, the
+tripartite Welsh, Turkana, Maltese, and Miraña, binary English, and Yudja with number on humans
+alone, are monotone classifications (`welsh_monotone` and its siblings). Markedness follows the
+scale: the zero-coded value of a class is single reference for individuals and multiple reference
+for aggregates, with no contrast at the bottom (`welsh_default_monotone` and its siblings), and
+Dagaare's inverse marking is one coded value read in the two directions. Animacy refines the
+picture (section 4.2): on the product of the scale with the animacy hierarchy, the
+collective/singulative class ascends from below, the inverse of [smith-stark-1974]'s plural
+marking, and the regions of Maltese, Welsh, and Turkana nest (`collective_regions_nest`).
 
-  Grimm, S. (2018). Grammatical number and the scale of individuation.
-  *Language* 94(3). 527–574.
+## Implementation notes
 
-## Core contributions
+Each language's countability classes are an enumeration ordered by scale position, and the
+classification of the four individuation types is the language's row of Table 20, 23, or 24.
+Turkana and Maltese share Welsh's partition and differ in agreement and animacy reach, Yudja
+shares English's and differs in restricting the contrast to humans; the classification does not
+record these. The animacy tiers are the simplified hierarchy of Fig. 3, after
+[haspelmath-2005]'s split of animates, mapped into the library's `AnimacyRank`; the full
+animacy–individuation lattice, an [aissen-2003] product, and the connected region constraint
+(28) over it are not formalized.
 
-1. **The scale of individuation** (his (17)/(19)): individuation types —
-   equivalence classes of nominal descriptions by individuation
-   properties — are linearly ordered:
-   substance < granular aggregate < collective aggregate < individual.
+## References
 
-2. **The order-preservation thesis** (his §3.4): a language's grammatical
-   countability classes also partition nominal descriptions, and the
-   classification map from individuation types to countability classes is
-   **order-preserving**. Consequently every countability class is a
-   *contiguous segment* of the scale — formally, the fibers of a monotone
-   classification are `Set.OrdConnected` (the same mathlib predicate that
-   states [harbour-2014]'s convexity condition in
-   `Syntax/Minimalist/Phi/Recursion.lean`). His hypothetical
-   discontinuous system (Table 21) is refuted by `decide`.
-
-3. **Countability beyond the binary** (his §2): Welsh, Turkana, Maltese
-   (tripartite: non-countable, collective/singulative, singular/plural) and
-   Dagaare (four classes, including an inverse-marked one) against
-   English's binary cut and Yudja's near-absent cut.
-
-4. **The markedness/coding prediction** (his §4.4, after Jakobson and
-   Greenberg): which value of a class's contrast is zero-coded tracks the
-   class's position on the scale — single-reference default for highly
-   individuated classes, multiple-reference default for aggregate classes
-   (the singulative), no contrast at the bottom. Dagaare's inverse number
-   marking is this prediction at work, *not* a `Number` value — confirming
-   the canonical inventory's exclusion of `UD.Number.Inv`.
-
-5. **Animacy refinement** (his §4.2): collective/singulative classes
-   *ascend* the animacy hierarchy (inverse of Smith-Stark plural marking);
-   the per-language collective regions nest (Maltese ⊆ Welsh ⊆ Turkana).
-
-## Connections
-
-* Countability classes are not `Number` values: Welsh collectives take
-  plural agreement while Maltese collectives take singular ([grimm-2018]
-  §2.1, §2.3), so the unit/aggregate contrast cross-cuts the agreement
-  values — vindicating the value space of `Features/Number/Basic.lean`.
-* Each class carries a `Number.System` (`WelshClass.system` etc.), so
-  Grimm's classes plug into the implicational universals; this generalizes
-  the count-against-mass split of [corbett-2000] to a system per class.
-* English's binary partition is `Features.MassCount`
-  (`english_matches_massCount`) — the binary feature becomes the 2-cell
-  instance of the scale, not a primitive.
-* `countable : Bool` as a lexical field is refuted twice over: structurally
-  by [borer-2005] (see `Studies/Borer2005.lean`) and scalarly here.
+* [grimm-2018]
+* [smith-stark-1974]
+* [aissen-2003]
+* [haspelmath-2005]
 -/
 
 namespace Grimm2018
 
+/-! ### The order-preservation thesis, section 3.4 -/
 
-/-! ### The scale of individuation
-
-`IndividuationType` — the scale substance < granular aggregate <
-collective aggregate < individual ([grimm-2018] (17)/(19)) — lives in
-`Features/Individuation.lean`, shared with [sutton-filip-2021]'s
-count/mass lexicalization options (`Studies/SuttonFilip2021.lean`). -/
-
-/-! ### The order-preservation thesis
-
-[grimm-2018] §3.4: nominal descriptions are partitioned both into
-individuation types (Π_I, ordered by the scale) and into a language's
-grammatical countability classes (Π_G, ordered); the thesis is that the
-classification map is order-preserving (`Monotone`). The structural
-consequence — each grammatical class is a contiguous segment of the scale,
-"no category spans two disconnected segments" — is the `Set.OrdConnected`-ness
-of the classification's fibers. -/
-
-/-- A monotone classification has order-convex fibers: each countability
-    class picks out a contiguous segment of the scale. One composition of
-    mathlib primitives (`Set.ordConnected_singleton.preimage_mono`); the
-    predicate is the same `Set.OrdConnected` that states [harbour-2014]'s
-    convexity condition (`ordConnectedHull_eq_self`). -/
-theorem ordConnected_fiber_of_monotone {α C : Type*} [Preorder α]
-    [PartialOrder C] {f : α → C} (hf : Monotone f) (c : C) :
-    (f ⁻¹' {c}).OrdConnected :=
+/-- A monotone classification has order-convex fibres: each countability class picks out a
+contiguous segment of the scale. -/
+theorem ordConnected_fiber_of_monotone {α C : Type*} [Preorder α] [PartialOrder C] {f : α → C}
+    (hf : Monotone f) (c : C) : (f ⁻¹' {c}).OrdConnected :=
   Set.ordConnected_singleton.preimage_mono hf
 
-/-! ### Per-language countability systems ([grimm-2018] §2, Tables 19–20)
+/-! ### The number systems, Tables 20, 23, and 24 -/
 
-Each language's classes are ordered by their scale position; the
-classification maps are the language rows of Table 20 (Dagaare, Welsh,
-English) and the §2 descriptions (Turkana §2.2, Maltese §2.3, Yudja §4.1).
-Monotonicity is checked by `decide`; convexity of every class follows from
-`ordConnected_fiber_of_monotone`. -/
-
-/-- Welsh ([grimm-2018] §2.1, Table 2): tripartite — non-countable
-    (*llefrith* 'milk'), collective/unit (*adar*/*ader-yn* 'birds/bird'),
-    singular/plural (*cadair*/*cadair-iau* 'chair/chairs'). -/
-inductive WelshClass where
-  | nonCountable | collectiveUnit | singularPlural
+/-- The tripartite systems: non-countable, collective/unit, singular/plural. -/
+inductive TripartiteClass where
+  | nonCountable
+  | collectiveUnit
+  | singularPlural
   deriving DecidableEq, Repr, Fintype
 
-namespace WelshClass
-
-def toNat : WelshClass → Nat
+/-- The class's position on the scale. -/
+def TripartiteClass.toNat : TripartiteClass → ℕ
   | .nonCountable => 0
   | .collectiveUnit => 1
   | .singularPlural => 2
 
-instance : LinearOrder WelshClass :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+instance : LinearOrder TripartiteClass :=
+  .lift' TripartiteClass.toNat
+    (λ a b h => by cases a <;> cases b <;> simp_all [TripartiteClass.toNat])
 
-end WelshClass
-
-/-- Welsh's classification of the scale ([grimm-2018] Table 20 and fn. 20):
-    substances are non-countable, granular and collective aggregates fall in
-    the collective/unit class, individuals in singular/plural. -/
-def welshClassify : IndividuationType → WelshClass
+/-- Welsh (Table 20): substances are non-countable (*llefrith* 'milk'), granular and collective
+aggregates take the singulative (*adar* ~ *aderyn* 'birds' ~ 'bird'), individuals the plural
+(*cadair* ~ *cadeiriau* 'chair' ~ 'chairs'). -/
+def welshClassify : IndividuationType → TripartiteClass
   | .substance => .nonCountable
-  | .granularAggregate => .collectiveUnit
+  | .granularAggregate | .collectiveAggregate => .collectiveUnit
+  | .individualEntity => .singularPlural
+
+theorem welsh_monotone : Monotone welshClassify := by decide
+
+/-- Turkana (section 2.2) partitions the scale as Welsh does; its collective class reaches
+types of people. -/
+abbrev turkanaClassify := welshClassify
+
+/-- Maltese (section 2.3) partitions the scale as Welsh does; its collective agrees in the
+singular and reaches barely beyond insects. -/
+abbrev malteseClassify := welshClassify
+
+/-- Miraña (Table 23): granular aggregates join the substances as non-countable, collective
+aggregates form the class whose bare form names a collection and whose class-marked form a
+unit, individuals inflect for plural. -/
+def miranaClassify : IndividuationType → TripartiteClass
+  | .substance | .granularAggregate => .nonCountable
   | .collectiveAggregate => .collectiveUnit
   | .individualEntity => .singularPlural
 
-/-- Welsh respects the scale ([grimm-2018] fn. 20 works this case). -/
-theorem welsh_monotone : Monotone welshClassify := by decide
+theorem mirana_monotone : Monotone miranaClassify := by decide
 
-/-- Turkana ([grimm-2018] §2.2, Tables 5–7) patterns with Welsh: same
-    tripartite shape, with the collective/singulative class reaching types
-    of people (the animacy difference is §4.2 material, not a different
-    class structure on the four-type scale). -/
-abbrev turkanaClassify : IndividuationType → WelshClass := welshClassify
-
-/-- Maltese ([grimm-2018] §2.3, Tables 8–11): same tripartite shape;
-    differs in agreement (collective is formally singular) and in admitting
-    foodstuffs/materials with conventional-portion singulatives. -/
-abbrev malteseClassify : IndividuationType → WelshClass := welshClassify
-
-/-- Dagaare ([grimm-2018] §2.4, Table 20): four classes — non-countable,
-    optional-singulative non-countable (*-ruu*, granular aggregates),
-    plural-default countable (*-ri* codes the singular: inverse marking),
-    and singular-default countable (*-ri* codes the plural). -/
+/-- Dagaare (Table 20): non-countable, optionally singulative (*-ruu*) non-countable,
+plural-default with *-ri* coding the singular, and singular-default with *-ri* coding the
+plural. -/
 inductive DagaareClass where
-  | nonCountable | singulativeNonCount | pluralDefault | singularDefault
+  | nonCountable
+  | singulativeNonCount
+  | pluralDefault
+  | singularDefault
   deriving DecidableEq, Repr, Fintype
 
-namespace DagaareClass
-
-def toNat : DagaareClass → Nat
+/-- The class's position on the scale. -/
+def DagaareClass.toNat : DagaareClass → ℕ
   | .nonCountable => 0
   | .singulativeNonCount => 1
   | .pluralDefault => 2
   | .singularDefault => 3
 
 instance : LinearOrder DagaareClass :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+  .lift' DagaareClass.toNat (λ a b h => by cases a <;> cases b <;> simp_all [DagaareClass.toNat])
 
-end DagaareClass
-
-/-- Dagaare's classification ([grimm-2018] Table 20): each individuation
-    type gets its own grammatical class — the partition is exactly as
-    fine-grained as the scale. -/
+/-- Dagaare's classification (Table 20): a class for each individuation type. -/
 def dagaareClassify : IndividuationType → DagaareClass
   | .substance => .nonCountable
   | .granularAggregate => .singulativeNonCount
@@ -177,288 +126,194 @@ def dagaareClassify : IndividuationType → DagaareClass
 
 theorem dagaare_monotone : Monotone dagaareClassify := by decide
 
-/-- English ([grimm-2018] Table 20): binary — non-countable covers
-    substances *and* aggregates (*foliage*, *rice*), singular/plural covers
-    individuals. -/
-inductive EnglishClass where
-  | nonCountable | singularPlural
+/-- The binary systems: non-countable and singular/plural. -/
+inductive BinaryClass where
+  | nonCountable
+  | singularPlural
   deriving DecidableEq, Repr, Fintype
 
-namespace EnglishClass
-
-def toNat : EnglishClass → Nat
+/-- The class's position on the scale. -/
+def BinaryClass.toNat : BinaryClass → ℕ
   | .nonCountable => 0
   | .singularPlural => 1
 
-instance : LinearOrder EnglishClass :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+instance : LinearOrder BinaryClass :=
+  .lift' BinaryClass.toNat (λ a b h => by cases a <;> cases b <;> simp_all [BinaryClass.toNat])
 
-end EnglishClass
-
-def englishClassify : IndividuationType → EnglishClass
+/-- English (Table 20): substances and both kinds of aggregate (*rice*, *foliage*) are
+non-countable, individuals take the plural. -/
+def englishClassify : IndividuationType → BinaryClass
   | .individualEntity => .singularPlural
   | _ => .nonCountable
 
 theorem english_monotone : Monotone englishClassify := by decide
 
-/-- Yudja ([grimm-2018] §4.1, Table 24): the limiting case — only the most
-    highly individuated nouns (humans) manifest grammatical number (optional
-    *-i*); everything else is unspecified. Formally the same binary shape as
-    English with the cut moved to the top of the scale; we record it through
-    `EnglishClass` with its own classification. -/
-def yudjaClassify : IndividuationType → EnglishClass
-  | _ => .nonCountable
+/-- Yudja (Table 24) cuts the scale where English does, with the optional plural *-i* on
+individuals restricted to humans. -/
+abbrev yudjaClassify := englishClassify
 
-theorem yudja_monotone : Monotone yudjaClassify := by decide
+/-! ### The impossible system, Table 21
 
-/-! ### The impossible system ([grimm-2018] Table 21)
+Granular aggregates and individuals share a singular/plural class while the collective
+aggregates between them form a collective/singulative class, so the singular/plural class is
+discontinuous on the scale. -/
 
-A hypothetical language whose singular/plural class covers granular
-aggregates and individuals while a distinct collective/singulative class
-intervenes. The singular/plural fiber is discontinuous on the scale, so no
-order on the classes makes the classification monotone. -/
-
-/-- Table 21's "Bad System": granular aggregates and individuals share a
-    class that excludes the intervening collective aggregates. -/
-def badClassify : IndividuationType → WelshClass
+/-- Table 21's bad system. -/
+def badClassify : IndividuationType → TripartiteClass
   | .substance => .nonCountable
-  | .granularAggregate => .singularPlural
+  | .granularAggregate | .individualEntity => .singularPlural
   | .collectiveAggregate => .collectiveUnit
-  | .individualEntity => .singularPlural
 
-/-- The Bad System's singular/plural class is *not* a contiguous segment of
-    the scale. -/
+/-- The bad system's singular/plural class is not a contiguous segment of the scale. -/
 theorem bad_fiber_not_ordConnected :
-    ¬ (badClassify ⁻¹' {WelshClass.singularPlural}).OrdConnected := by
+    ¬ (badClassify ⁻¹' {TripartiteClass.singularPlural}).OrdConnected := by
   intro h
   have : badClassify .collectiveAggregate = .singularPlural :=
-    h.out (x := .granularAggregate) rfl (y := .individualEntity) rfl
-      ⟨by decide, by decide⟩
+    h.out (x := .granularAggregate) rfl (y := .individualEntity) rfl ⟨by decide, by decide⟩
   exact absurd this (by decide)
 
-/-- Hence no partial order on the classes makes the Bad System
-    order-preserving ([grimm-2018] fn. 21): with the given class order it is
-    not monotone, and `ordConnected_fiber_of_monotone` rules out every
-    other order as well. -/
-theorem bad_not_monotone (po : PartialOrder WelshClass) :
+/-- No ordering of the classes makes the bad system order-preserving, the paper's footnote 21
+generalized from its two candidate orders to all. -/
+theorem bad_not_monotone (po : PartialOrder TripartiteClass) :
     letI := po
-    ¬ Monotone badClassify := by
-  letI := po
-  exact fun hf =>
-    bad_fiber_not_ordConnected (ordConnected_fiber_of_monotone hf _)
+    ¬ Monotone badClassify :=
+  λ hf => bad_fiber_not_ordConnected (@ordConnected_fiber_of_monotone _ _ _ po _ hf _)
 
-/-! ### Coding and markedness ([grimm-2018] §3.4 Table 20, §4.4)
+/-! ### Coding and markedness, sections 3.4 and 4.4
 
-Each class codes one value of its contrast overtly and leaves the other
-zero. The prediction (after Jakobson, Greenberg via [grimm-2018] §4.4): the
-default (zero-coded) designation tracks individuation — multiple-reference
-default for aggregate classes, single-reference default for individual
-classes. Dagaare's *inverse number marking* is the visible signature: the
-same morpheme *-ri* codes plural on singular-default nouns and singular on
-plural-default nouns. The inverse is a *coding* fact, not a number value —
-`UD.Number.Inv` has no `Number` preimage by design
-(`Features/Number/Basic.lean`). -/
+Each class codes one value of its contrast and leaves the other zero. The prediction: the
+zero-coded default of a class tracks its individuation, multiple reference for aggregate classes
+and single reference for individual classes, with no contrast at the bottom. -/
 
-/-- The coding pattern of a countability class ([grimm-2018] Table 20):
-    which value, if any, is overtly coded against a zero-coded default. -/
+/-- The coding pattern of a countability class. -/
 inductive ClassCoding where
-  /-- No number contrast (Welsh *llefrith* 'milk'). -/
+  /-- No number contrast. -/
   | noContrast
-  /-- Zero-coded aggregate, coded unit — the singulative
-      (Welsh *-yn*, Turkana, Maltese *-a*, Dagaare *-ruu*). -/
+  /-- A zero-coded aggregate and a coded unit, the singulative. -/
   | codedUnit
-  /-- Zero-coded plural, coded singular (Dagaare *-ri* on plural-default
-      nouns: inverse marking). -/
+  /-- A zero-coded plural and a coded singular, Dagaare's inverse marking. -/
   | codedSingular
-  /-- Zero-coded singular, coded plural (English *-s*, Welsh *-au*,
-      Dagaare *-ri* on singular-default nouns). -/
+  /-- A zero-coded singular and a coded plural. -/
   | codedPlural
   deriving DecidableEq, Repr, Fintype
 
-/-- The default (zero-coded) designation of a class: nothing, multiple
-    referents, or a single referent. -/
+/-- The zero-coded default of a class: nothing, multiple referents, or a single referent. -/
 inductive DefaultReference where
-  | none | multiple | single
+  | none
+  | multiple
+  | single
   deriving DecidableEq, Repr, Fintype
 
-namespace DefaultReference
-
-def toNat : DefaultReference → Nat
+/-- The default's position on the scale. -/
+def DefaultReference.toNat : DefaultReference → ℕ
   | .none => 0
   | .multiple => 1
   | .single => 2
 
 instance : LinearOrder DefaultReference :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
-
-end DefaultReference
+  .lift' DefaultReference.toNat
+    (λ a b h => by cases a <;> cases b <;> simp_all [DefaultReference.toNat])
 
 /-- What a coding pattern leaves as the zero-coded default. -/
 def ClassCoding.default : ClassCoding → DefaultReference
   | .noContrast => .none
-  | .codedUnit => .multiple
-  | .codedSingular => .multiple
+  | .codedUnit | .codedSingular => .multiple
   | .codedPlural => .single
 
-/-- Welsh coding by class (Table 20): 0 / 0+singulative *-yn* /
-    0+plural *-au*. -/
-def welshCoding : WelshClass → ClassCoding
+/-- Welsh coding by class (Table 20): nothing, the singulative *-yn*, the plural *-od*. -/
+def welshCoding : TripartiteClass → ClassCoding
   | .nonCountable => .noContrast
   | .collectiveUnit => .codedUnit
   | .singularPlural => .codedPlural
 
-/-- Dagaare coding by class (Table 20): 0 / optional singulative *-ruu* /
-    inverse singular *-ri* / plural *-ri*. -/
+/-- Dagaare coding by class (Table 20): nothing, the optional singulative *-ruu*, the singular
+*-ri*, the plural *-ri*. -/
 def dagaareCoding : DagaareClass → ClassCoding
   | .nonCountable => .noContrast
   | .singulativeNonCount => .codedUnit
   | .pluralDefault => .codedSingular
   | .singularDefault => .codedPlural
 
-/-- English coding by class: 0 / plural *-s*. -/
-def englishCoding : EnglishClass → ClassCoding
+/-- English coding by class (Table 20): nothing, the plural *-s*. -/
+def englishCoding : BinaryClass → ClassCoding
   | .nonCountable => .noContrast
   | .singularPlural => .codedPlural
 
-/-! **The markedness prediction** ([grimm-2018] §4.4): along the scale, the
-zero-coded default ascends none → multiple → single — the more individuated
-the class, the more likely single reference is the default. Verified per
-language. -/
-
-theorem welsh_default_monotone :
-    Monotone (fun i => (welshCoding (welshClassify i)).default) := by decide
+/-- Along the scale the zero-coded default ascends from no contrast through multiple to single
+reference. -/
+theorem welsh_default_monotone : Monotone (λ i => (welshCoding (welshClassify i)).default) := by
+  decide
 
 theorem dagaare_default_monotone :
-    Monotone (fun i => (dagaareCoding (dagaareClassify i)).default) := by
+    Monotone (λ i => (dagaareCoding (dagaareClassify i)).default) := by
   decide
 
 theorem english_default_monotone :
-    Monotone (fun i => (englishCoding (englishClassify i)).default) := by
+    Monotone (λ i => (englishCoding (englishClassify i)).default) := by
   decide
 
-/-- Dagaare's two *-ri* classes differ only in coding direction — the
-    formal content of "inverse number marking" ([grimm-2018] §2.4,
-    Tables 15–17). -/
+/-- Dagaare's two *-ri* classes differ only in the direction of coding, the content of inverse
+number marking (section 2.4). -/
 theorem dagaare_inverse_marking :
     (dagaareCoding .pluralDefault).default = .multiple ∧
-    (dagaareCoding .singularDefault).default = .single ∧
-    dagaareCoding .pluralDefault ≠ dagaareCoding .singularDefault := by
+      (dagaareCoding .singularDefault).default = .single ∧
+      dagaareCoding .pluralDefault ≠ dagaareCoding .singularDefault := by
   decide
 
-/-! ### Classes carry number systems
+/-! ### Countability and animacy, section 4.2
 
-A countability class determines which `Number` values its nouns contrast —
-the per-class generalization of [corbett-2000]'s count-against-mass split
-(count system vs. mass system). All class systems satisfy the implicational
-universals. -/
+Plural marking descends the animacy hierarchy from the top ([smith-stark-1974]); the
+collective/singulative class ascends it from below, since the more animate an entity the more it
+is construed as occurring singly. Welsh's collective class stops at small and middle-sized
+animals, Turkana's reaches types of people, Maltese's barely passes insects (Fig. 4). -/
 
-/-- The `Number.System` a Welsh countability class makes available. The
-    collective/unit class contrasts an aggregate with a unit; its
-    *agreement* values are singular and plural ([grimm-2018] (5)–(6):
-    collective *adar* takes plural agreement, singulative *ader-yn*
-    singular), so its system coincides with singular/plural — the class
-    difference lives in coding (`welshCoding`), not in the value
-    inventory. -/
-def WelshClass.system : WelshClass → Number.System
-  | .nonCountable => { name := "Welsh non-countable", values := [] }
-  | .collectiveUnit =>
-      { name := "Welsh collective/unit", values := [.singular, .plural] }
-  | .singularPlural =>
-      { name := "Welsh singular/plural", values := [.singular, .plural] }
-
-/-- Every Welsh class system satisfies the implicational universals. -/
-theorem welsh_systems_wellFormed : ∀ c : WelshClass, c.system.WellFormed := by
-  decide
-
-/-! ### English's binary cut is `MassCount`
-
-[grimm-2018]'s Table 20 row for English *is* the mass/count distinction:
-the binary feature of `Features/MassCount.lean` is the 2-cell instance of a
-scale partition, not an independent primitive. (Lexical `countable : Bool`
-is refuted structurally by [borer-2005] and scalarly here — the field's
-honest replacement is an individuation type.) -/
-
-/-- English's countability classes through `MassCount`. -/
-def englishMassCount : IndividuationType → MassCount
-  | .individualEntity => .count
-  | _ => .mass
-
-/-- The English classification and the mass/count feature are the same
-    partition. -/
-theorem english_matches_massCount :
-    ∀ i, englishClassify i = .singularPlural ↔ englishMassCount i = .count := by
-  decide
-
-/-! ### Animacy refinement ([grimm-2018] §4.2)
-
-Collective/singulative classes interact with animacy *inversely* to
-Smith-Stark plural marking: plural marking descends the animacy hierarchy
-from the top, while collective classes ascend it from below — Welsh's
-collective class stops at inanimates and small/mid animals, Turkana's
-reaches types of people, Maltese's is essentially limited to insects.
-Membership regions nest along animacy. We record the animacy reach of the
-collective class on the simplified hierarchy [grimm-2018] adopts
-(human > higher animate > lower animate > inanimate, after Haspelmath's
-higher/lower animate split) and verify the nesting; the full
-animacy-individuation product lattice (his Fig. 3) and the connectedness
-conjecture over it are left as the documented next step. -/
-
-/-- Simplified animacy tiers for the collective class ([grimm-2018] §4.2). -/
+/-- The simplified animacy hierarchy of Fig. 3. -/
 inductive AnimacyTier where
-  | inanimate | lowerAnimate | higherAnimate | human
+  | inanimate
+  | lowerAnimate
+  | higherAnimate
+  | human
   deriving DecidableEq, Repr, Fintype
 
-namespace AnimacyTier
-
-def toNat : AnimacyTier → Nat
+/-- The tier's position on the hierarchy. -/
+def AnimacyTier.toNat : AnimacyTier → ℕ
   | .inanimate => 0
   | .lowerAnimate => 1
   | .higherAnimate => 2
   | .human => 3
 
 instance : LinearOrder AnimacyTier :=
-  LinearOrder.lift' toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [toNat])
+  .lift' AnimacyTier.toNat (λ a b h => by cases a <;> cases b <;> simp_all [AnimacyTier.toNat])
 
-end AnimacyTier
-
-/-- Grimm's simplified tiers refine into the library's animacy substrate
-    (`Features.Prominence.AnimacyRank`, the scale `Studies/Corbett2000.lean`
-    states the Animacy Hierarchy constraints over). -/
+/-- The tiers within the library's animacy ranks. -/
 def AnimacyTier.toRank : AnimacyTier → Features.Prominence.AnimacyRank
   | .inanimate => .discreteInanimate
   | .lowerAnimate => .lowerAnimal
   | .higherAnimate => .higherAnimal
   | .human => .human
 
-/-- The refinement preserves the animacy order (stated through
-    `AnimacyRank.toNat`, the substrate's ranking). -/
-theorem AnimacyTier.toRank_monotone :
-    Monotone (fun t : AnimacyTier => (t.toRank).toNat) := by decide
+theorem AnimacyTier.toRank_monotone : Monotone (λ t : AnimacyTier => t.toRank.toNat) := by
+  decide
 
-/-- The three languages with tripartite systems, as anchors for the §4.2
-    animacy data. -/
+/-- The three tripartite languages of Fig. 4. -/
 inductive CollectiveLang where
-  | maltese | welsh | turkana
+  | maltese
+  | welsh
+  | turkana
   deriving DecidableEq, Repr, Fintype
 
-/-- The animacy ceiling of each language's collective/singulative class
-    ([grimm-2018] §4.2, Fig. 4): Maltese ≈ insects (lower animates), Welsh
-    ≈ small and mid-sized animals (higher animates), Turkana ≈ types of
-    people (humans). The region is upward-bounded: everything from
-    inanimate aggregates up to the ceiling. -/
+/-- The highest animacy tier each language's collective/singulative class reaches (Fig. 4); the
+class covers everything from inanimate aggregates up to it. -/
 def collectiveCeiling : CollectiveLang → AnimacyTier
   | .maltese => .lowerAnimate
   | .welsh => .higherAnimate
   | .turkana => .human
 
-/-- The collective regions nest along animacy: Maltese ⊆ Welsh ⊆ Turkana
-    ([grimm-2018] Fig. 4). Since each region is the down-set of its
-    ceiling, nesting is ceiling order. -/
+/-- The collective regions nest, Maltese within Welsh within Turkana: each is the down-set of
+its ceiling. -/
 theorem collective_regions_nest :
     collectiveCeiling .maltese ≤ collectiveCeiling .welsh ∧
-    collectiveCeiling .welsh ≤ collectiveCeiling .turkana := by decide
+      collectiveCeiling .welsh ≤ collectiveCeiling .turkana := by
+  decide
 
 end Grimm2018

--- a/references.bib
+++ b/references.bib
@@ -6365,7 +6365,7 @@
   subfield  = {typology/number},
   role      = {formalized},
   validated = {true},
-  sources   = {Data/Examples/Corbett2000.json}
+  sources   = {Data/Examples/Corbett2000.json;Features/Number/Basic.lean;Features/Number/Capabilities.lean;Features/Number/Interp.lean;Features/Number/Resolve.lean;Features/Prominence.lean;Fragments/Bayso/Number.lean;Studies/Corbett2000.lean;Studies/Harbour2016.lean;Syntax/Minimalist/Phi/Recursion.lean}
 }% REF: Corbett, G. G. (2006). Agreement. Cambridge: Cambridge University Press.
 @article{comrie-1975,
   author    = {Comrie, Bernard},
@@ -18541,7 +18541,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Borer2005.lean}
+  sources   = {Fragments/English/Nouns.lean;Studies/Borer2005.lean;Studies/KonnellyCowper2020.lean;Studies/LittleMoroneyRoyer2022.lean;Studies/Moon2026.lean;Studies/RappaportHovavLevin2024.lean;Studies/Sudo2016.lean;Studies/WangSun2026.lean;Syntax/Mereological/Interpretation.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean}
 }% REF: Atlas, J. & Levinson, S. (1981). It-clefts, informativeness and logical form. In P. Cole (ed.), Radical Pragmatics, 1–61. Academic Press.
 @incollection{atlas-levinson-1981,
   author    = {Atlas, Jay David and Levinson, Stephen C.},
@@ -18579,7 +18579,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Core/Order/Markedness.lean;Features/Prominence.lean;Fragments/Turkish/Definiteness.lean;Studies/AhnKocabDavidson2026.lean;Studies/Aissen2003.lean;Studies/DeHoopMalchukov2008.lean;Studies/Haspelmath2021.lean;Studies/Just2024.lean}
+  sources   = {Core/Order/Markedness.lean;Features/Prominence.lean;Fragments/Turkish/Definiteness.lean;Studies/AhnKocabDavidson2026.lean;Studies/Aissen2003.lean;Studies/DeHoopMalchukov2008.lean;Studies/Grimm2018.lean;Studies/Haspelmath2021.lean;Studies/Just2024.lean}
 }
 @article{de-hoop-malchukov-2008,
   author    = {de Hoop, Helen and Malchukov, Andrej},
@@ -22910,7 +22910,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Harbour2014.lean}
+  sources   = {Features/Gender/Basic.lean;Features/Number/Basic.lean;Features/Number/Decomposition.lean;Features/Number/Interp.lean;Features/Number/Resolve.lean;Fragments/Basque/Postsyntax.lean;Fragments/English/Determiners.lean;Fragments/Taos/Agreement.lean;Studies/Harbour2014.lean;Studies/Harbour2016.lean;Studies/Landman2020.lean;Studies/Middleton2026.lean;Studies/SmithMoskalEtAl2019.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phi/Recursion.lean}
 }
 @incollection{adger-harbour-2008,
   author    = {Adger, David and Harbour, Daniel},
@@ -26697,7 +26697,7 @@
   pages     = {657--671},
   subfield  = {typology/morphology},
   role      = {cited},
-  sources   = {Features/Prominence.lean;Studies/Corbett2000.lean;Studies/Downing1996.lean}
+  sources   = {Features/Prominence.lean;Studies/Corbett2000.lean;Studies/Downing1996.lean;Studies/Grimm2018.lean}
 }
 @book{saltarelli-etal-1988,
   author    = {Saltarelli, Mario and Azkarate, Miren and Farwell, David and {Ortiz de Urbina}, Jon and O{\~n}ederra, Lourdes},
@@ -27290,7 +27290,7 @@
   doi       = {10.1349/ps1.1537-0852.a.280},
   subfield  = {typology/alignment},
   role      = {cited},
-  sources   = {Syntax/Case/Alignment.lean}
+  sources   = {Studies/Grimm2018.lean;Syntax/Case/Alignment.lean}
 }% REF: Prasertsom, P., Smith, K. & Culbertson, J. (2026). Domain-general categorisation
 @article{prasertsom-smith-culbertson-2026,
   author    = {Prasertsom, Ponrawee and Smith, Kenny and Culbertson, Jennifer},
@@ -30809,7 +30809,7 @@
   subfield  = {semantics/countability},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/SuttonFilip2021.lean;Features/Individuation.lean}
+  sources   = {Features/Individuation.lean;Semantics/Mereology.lean;Studies/Landman2020.lean;Studies/SuttonFilip2021.lean}
 }
 
 @article{grimm-2018,
@@ -30824,7 +30824,7 @@
   subfield  = {semantics/countability},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Grimm2018.lean}
+  sources   = {Features/Individuation.lean;Features/Number/Basic.lean;Studies/Grimm2018.lean;Studies/GrimmDocekal2021.lean;Studies/Harbour2014.lean;Studies/SuttonFilip2021.lean;Syntax/Minimalist/Phi/Recursion.lean}
 }
 
 @incollection{grimm-docekal-2021,


### PR DESCRIPTION
Deep cleanse of Grimm2018 against the published paper (LSA PDF): the order-preservation thesis, Table 21, markedness, and the animacy nesting stand; the systems are corrected and completed.

- Yudja (Table 24) gives its individuals the optional plural *-i*, so it cuts the scale where English does rather than mapping everything to non-countable as before; Miraña (Table 23) is added, with granular aggregates joining the substances. The tripartite and binary class types are shared across the languages that partition the scale alike, with the differences the classification does not record stated in the notes.
- Cut: the `Number.System` per class and its well-formedness check, and the English-equals-`MassCount` bridge, neither of which is in the paper; the header is rewritten in register.
