### PR TITLE
refactor(Studies/Grove2022): the readings as general theorems

### DIFF
--- a/Linglib/Data/Examples/Grove2022.json
+++ b/Linglib/Data/Examples/Grove2022.json
@@ -1,0 +1,255 @@
+[
+  {
+    "id": "grove2022_1",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(1)"},
+    "language": "stan1293",
+    "primaryText": "If Theo has a brother, he'll bring his wetsuit.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "presupposes that Theo has a wetsuit", "judgment": "acceptable"},
+      {"name": "presupposes that Theo has a wetsuit if he has a brother", "judgment": "questionable"}
+    ],
+    "paperFeatures": [
+      ["section", "2.1"],
+      ["phenomenon", "provisoProblem"],
+      ["trigger", "his wetsuit"],
+      ["filter", "conditional"]
+    ],
+    "comment": "What one tends to accommodate is the unconditional presupposition; the satisfaction account predicts the conditional one."
+  },
+  {
+    "id": "grove2022_2",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(2)"},
+    "language": "stan1293",
+    "primaryText": "If Theo is a scuba diver, he'll bring his wetsuit.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "presupposes that Theo has a wetsuit if he is a scuba diver", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["section", "2"],
+      ["phenomenon", "provisoProblem"],
+      ["trigger", "his wetsuit"],
+      ["filter", "conditional"]
+    ],
+    "comment": "The conditional presupposition is relatively clear here."
+  },
+  {
+    "id": "grove2022_6",
+    "source": {"bibkey": "heim-1992", "paperLabel": "(6)"},
+    "reportedIn": {"bibkey": "grove-2022", "paperLabel": "(6)"},
+    "language": "stan1293",
+    "primaryText": "John: I am already in bed. Mary: My parents think I am also in bed.",
+    "discourseSegments": [
+      "John: I am already in bed.",
+      "Mary: My parents think I am also in bed."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "presupposes that John is in bed", "judgment": "acceptable"},
+      {"name": "presupposes that Mary's parents think John is in bed", "judgment": "questionable"}
+    ],
+    "paperFeatures": [
+      ["section", "2.1"],
+      ["phenomenon", "trappedTrigger"],
+      ["trigger", "also"],
+      ["filter", "think"]
+    ],
+    "comment": "Heim's (1992) example: the utterance is consistent with the parents' ignorance of John's claim."
+  },
+  {
+    "id": "grove2022_7",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(7)"},
+    "language": "stan1293",
+    "primaryText": "John was limping earlier; I don't know why. Maybe he has a stress fracture. I don't know if he plays any sports, but if he has a stress fracture, then he'll stop running cross-country now.",
+    "discourseSegments": [
+      "John was limping earlier; I don't know why.",
+      "Maybe he has a stress fracture.",
+      "I don't know if he plays any sports, but if he has a stress fracture, then he'll stop running cross-country now."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "questionable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2"],
+      ["phenomenon", "provisoProblem"],
+      ["trigger", "stop"],
+      ["filter", "conditional"]
+    ],
+    "comment": "Mandelkern's judgment: odd because the unconditional presupposition that John runs cross-country conflicts with the assertion of ignorance."
+  },
+  {
+    "id": "grove2022_8",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(8)"},
+    "language": "stan1293",
+    "primaryText": "I saw John limping earlier. If he has a stress fracture, then I assume that he runs cross-country. Indeed, if he has a stress fracture, then he'll stop running cross-country now.",
+    "discourseSegments": [
+      "I saw John limping earlier.",
+      "If he has a stress fracture, then I assume that he runs cross-country.",
+      "Indeed, if he has a stress fracture, then he'll stop running cross-country now."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2"],
+      ["phenomenon", "conditionalReadingContext"],
+      ["trigger", "stop"],
+      ["filter", "conditional"]
+    ],
+    "comment": "Felicitous and does not imply that John runs cross-country: the conditional presupposition is available in context."
+  },
+  {
+    "id": "grove2022_9",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(9)"},
+    "language": "stan1293",
+    "primaryText": "We're going scuba diving later, and I don't know if Theo owns a wetsuit. But it seems that everyone who has a brother got a wetsuit for Christmas. So, if Theo has a brother, he'll bring his wetsuit.",
+    "discourseSegments": [
+      "We're going scuba diving later, and I don't know if Theo owns a wetsuit.",
+      "But it seems that everyone who has a brother got a wetsuit for Christmas.",
+      "So, if Theo has a brother, he'll bring his wetsuit."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "2.2"],
+      ["phenomenon", "conditionalReadingContext"],
+      ["trigger", "his wetsuit"],
+      ["filter", "conditional"]
+    ],
+    "comment": "A context in which (1) is understood with the conditional inference."
+  },
+  {
+    "id": "grove2022_22",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(22)"},
+    "language": "stan1293",
+    "primaryText": "Theo believes he lost his wetsuit.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "presupposes that Theo has a wetsuit, his wetsuit de re", "judgment": "acceptable"},
+      {"name": "presupposes that Theo believes he has a wetsuit, his wetsuit de dicto", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["section", "4.2"],
+      ["phenomenon", "attitude"],
+      ["trigger", "his wetsuit"],
+      ["filter", "believe"]
+    ],
+    "comment": "The global presupposition coincides with the de re reading and the local one with the de dicto reading."
+  },
+  {
+    "id": "grove2022_23",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(23)"},
+    "language": "stan1293",
+    "primaryText": "Theo believes he has a wetsuit, and he believes he lost his wetsuit.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "4.2"],
+      ["phenomenon", "attitude"],
+      ["trigger", "his wetsuit"],
+      ["filter", "believe"]
+    ],
+    "comment": "Most easily understood as presupposition-free: the local presupposition is satisfied."
+  },
+  {
+    "id": "grove2022_24",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(24)"},
+    "language": "stan1293",
+    "primaryText": "Theo believes he has a wetsuit. He hopes his wetsuit is dry.",
+    "discourseSegments": [
+      "Theo believes he has a wetsuit.",
+      "He hopes his wetsuit is dry."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "4.2"],
+      ["phenomenon", "attitude"],
+      ["trigger", "his wetsuit"],
+      ["filter", "hope"]
+    ],
+    "comment": "The second sentence's presupposition of belief is satisfied by the first."
+  },
+  {
+    "id": "grove2022_25",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(25)"},
+    "language": "stan1293",
+    "primaryText": "Theo has a wetsuit, and he believes he lost his wetsuit.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "4.2"],
+      ["phenomenon", "attitude"],
+      ["trigger", "his wetsuit"],
+      ["filter", "believe"]
+    ],
+    "comment": "The presupposition of (22) is satisfied by a context in which Theo has a wetsuit."
+  },
+  {
+    "id": "grove2022_26",
+    "source": {"bibkey": "grove-2022", "paperLabel": "(26)"},
+    "language": "stan1293",
+    "primaryText": "Theo has a wetsuit. He hopes his wetsuit is dry.",
+    "discourseSegments": [
+      "Theo has a wetsuit.",
+      "He hopes his wetsuit is dry."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "4.2"],
+      ["phenomenon", "attitude"],
+      ["trigger", "his wetsuit"],
+      ["filter", "hope"]
+    ],
+    "comment": "The presupposition of the second sentence of (24) is satisfied by a context in which Theo has a wetsuit."
+  }
+]

--- a/Linglib/Data/Examples/Grove2022.lean
+++ b/Linglib/Data/Examples/Grove2022.lean
@@ -1,0 +1,216 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Grove2022` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Grove2022.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Grove2022.Examples`.
+-/
+
+namespace Grove2022.Examples
+
+open Data.Examples
+
+def ex_1 : LinguisticExample :=
+  { id := "grove2022_1"
+    source := ⟨"grove-2022", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Theo has a brother, he'll bring his wetsuit."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("presupposes that Theo has a wetsuit", .acceptable), ("presupposes that Theo has a wetsuit if he has a brother", .questionable)]
+    paperFeatures := [("section", "2.1"), ("phenomenon", "provisoProblem"), ("trigger", "his wetsuit"), ("filter", "conditional")]
+    comment := "What one tends to accommodate is the unconditional presupposition; the satisfaction account predicts the conditional one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2 : LinguisticExample :=
+  { id := "grove2022_2"
+    source := ⟨"grove-2022", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If Theo is a scuba diver, he'll bring his wetsuit."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("presupposes that Theo has a wetsuit if he is a scuba diver", .acceptable)]
+    paperFeatures := [("section", "2"), ("phenomenon", "provisoProblem"), ("trigger", "his wetsuit"), ("filter", "conditional")]
+    comment := "The conditional presupposition is relatively clear here."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_6 : LinguisticExample :=
+  { id := "grove2022_6"
+    source := ⟨"heim-1992", "(6)"⟩
+    reportedIn := some ⟨"grove-2022", "(6)"⟩
+    language := "stan1293"
+    primaryText := "John: I am already in bed. Mary: My parents think I am also in bed."
+    discourseSegments := ["John: I am already in bed.", "Mary: My parents think I am also in bed."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("presupposes that John is in bed", .acceptable), ("presupposes that Mary's parents think John is in bed", .questionable)]
+    paperFeatures := [("section", "2.1"), ("phenomenon", "trappedTrigger"), ("trigger", "also"), ("filter", "think")]
+    comment := "Heim's (1992) example: the utterance is consistent with the parents' ignorance of John's claim."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_7 : LinguisticExample :=
+  { id := "grove2022_7"
+    source := ⟨"grove-2022", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John was limping earlier; I don't know why. Maybe he has a stress fracture. I don't know if he plays any sports, but if he has a stress fracture, then he'll stop running cross-country now."
+    discourseSegments := ["John was limping earlier; I don't know why.", "Maybe he has a stress fracture.", "I don't know if he plays any sports, but if he has a stress fracture, then he'll stop running cross-country now."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .questionable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2"), ("phenomenon", "provisoProblem"), ("trigger", "stop"), ("filter", "conditional")]
+    comment := "Mandelkern's judgment: odd because the unconditional presupposition that John runs cross-country conflicts with the assertion of ignorance."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_8 : LinguisticExample :=
+  { id := "grove2022_8"
+    source := ⟨"grove-2022", "(8)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I saw John limping earlier. If he has a stress fracture, then I assume that he runs cross-country. Indeed, if he has a stress fracture, then he'll stop running cross-country now."
+    discourseSegments := ["I saw John limping earlier.", "If he has a stress fracture, then I assume that he runs cross-country.", "Indeed, if he has a stress fracture, then he'll stop running cross-country now."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2"), ("phenomenon", "conditionalReadingContext"), ("trigger", "stop"), ("filter", "conditional")]
+    comment := "Felicitous and does not imply that John runs cross-country: the conditional presupposition is available in context."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_9 : LinguisticExample :=
+  { id := "grove2022_9"
+    source := ⟨"grove-2022", "(9)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "We're going scuba diving later, and I don't know if Theo owns a wetsuit. But it seems that everyone who has a brother got a wetsuit for Christmas. So, if Theo has a brother, he'll bring his wetsuit."
+    discourseSegments := ["We're going scuba diving later, and I don't know if Theo owns a wetsuit.", "But it seems that everyone who has a brother got a wetsuit for Christmas.", "So, if Theo has a brother, he'll bring his wetsuit."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.2"), ("phenomenon", "conditionalReadingContext"), ("trigger", "his wetsuit"), ("filter", "conditional")]
+    comment := "A context in which (1) is understood with the conditional inference."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_22 : LinguisticExample :=
+  { id := "grove2022_22"
+    source := ⟨"grove-2022", "(22)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Theo believes he lost his wetsuit."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("presupposes that Theo has a wetsuit, his wetsuit de re", .acceptable), ("presupposes that Theo believes he has a wetsuit, his wetsuit de dicto", .acceptable)]
+    paperFeatures := [("section", "4.2"), ("phenomenon", "attitude"), ("trigger", "his wetsuit"), ("filter", "believe")]
+    comment := "The global presupposition coincides with the de re reading and the local one with the de dicto reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_23 : LinguisticExample :=
+  { id := "grove2022_23"
+    source := ⟨"grove-2022", "(23)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Theo believes he has a wetsuit, and he believes he lost his wetsuit."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "4.2"), ("phenomenon", "attitude"), ("trigger", "his wetsuit"), ("filter", "believe")]
+    comment := "Most easily understood as presupposition-free: the local presupposition is satisfied."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_24 : LinguisticExample :=
+  { id := "grove2022_24"
+    source := ⟨"grove-2022", "(24)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Theo believes he has a wetsuit. He hopes his wetsuit is dry."
+    discourseSegments := ["Theo believes he has a wetsuit.", "He hopes his wetsuit is dry."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "4.2"), ("phenomenon", "attitude"), ("trigger", "his wetsuit"), ("filter", "hope")]
+    comment := "The second sentence's presupposition of belief is satisfied by the first."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25 : LinguisticExample :=
+  { id := "grove2022_25"
+    source := ⟨"grove-2022", "(25)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Theo has a wetsuit, and he believes he lost his wetsuit."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "4.2"), ("phenomenon", "attitude"), ("trigger", "his wetsuit"), ("filter", "believe")]
+    comment := "The presupposition of (22) is satisfied by a context in which Theo has a wetsuit."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_26 : LinguisticExample :=
+  { id := "grove2022_26"
+    source := ⟨"grove-2022", "(26)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Theo has a wetsuit. He hopes his wetsuit is dry."
+    discourseSegments := ["Theo has a wetsuit.", "He hopes his wetsuit is dry."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "4.2"), ("phenomenon", "attitude"), ("trigger", "his wetsuit"), ("filter", "hope")]
+    comment := "The presupposition of the second sentence of (24) is satisfied by a context in which Theo has a wetsuit."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_1, ex_2, ex_6, ex_7, ex_8, ex_9, ex_22, ex_23, ex_24, ex_25, ex_26]
+
+end Grove2022.Examples

--- a/Linglib/Studies/Grove2022.lean
+++ b/Linglib/Studies/Grove2022.lean
@@ -1,582 +1,258 @@
-import Linglib.Logic.Trivalent.Prop3
-import Linglib.Semantics.Presupposition.Basic
+import Linglib.Data.Examples.Grove2022
+import Mathlib.Data.Option.Basic
+import Mathlib.Tactic.SplitIfs
 
 /-!
-# [grove-2022]: Presupposition Projection as a Scope Phenomenon
+# Grove (2022): Presupposition Projection as a Scope Phenomenon
 
-Julian Grove (2022). "Presupposition projection as a scope phenomenon."
-*Semantics and Pragmatics* 15, Article 15: 1–39.
-<https://doi.org/10.3765/sp.15.15>
+This file formalizes the scope theory of presupposition projection of [grove-2022],
+"Presupposition projection as a scope phenomenon", on which a presupposition trigger denotes a
+value of a maybe type, undefined on presupposition failure, and its presupposition projects to
+the constituent over which it takes scope. The maybe types are `Option`, whose unit and bind
+are the type shifts of (15); the intensional monad of section 4.1 is the reader transformer
+over it, as the paper's footnote says (`Iₚ`); the connective of (16) is the middle Kleene
+material conditional (`materialCond`); the presuppositional universal of (27) is undefined
+wherever its scope is; and *believe* is the Hintikka quantifier (28) over them. The proviso
+problem of section 2.1 then dissolves into a scope ambiguity. For *If Theo has a brother,
+he'll bring his wetsuit*, the trigger in situ yields the conditional presupposition of the
+satisfaction theory (`localReading_isSome_iff`), the consequent pied-piped over the conditional
+yields the unconditional one (`globalReading_isSome_iff`), and the two readings agree wherever
+the global one is defined. For *Theo believes he lost his wetsuit*, section 4.2, the clause in
+situ presupposes a wetsuit at every doxastic alternative and the clause scoped above the verb a
+wetsuit at the evaluation index, with the at-issue content reconstructing by Left Identity
+(`believeGlobal_eq_some_true_iff`).
 
-## Thesis
+## Implementation notes
 
-The proviso problem — where [heim-1983]'s satisfaction theory predicts
-weak conditional presuppositions for sentences that intuitively have
-unconditional ones — dissolves when presupposition projection is treated
-as **scope-taking**. Presupposition triggers have `α#`-typed denotations
-(= `Option α`); they interact with the surrounding context via monadic
-bind, exactly paralleling [charlow-2020]'s treatment of indefinites with
-the set monad.
+The truth-value type is `Bool`, so the possibly undefined truth values are `Option Bool`, the
+library's `Trivalent` in monadic form, and the predicates of the models are decidable
+propositions turned into truth values by `decide`. The universal of (27) quantifies over a whole
+type and is defined classically. The readings are stated for arbitrary index and entity types,
+the trigger *his wetsuit* being an `Iₚ I E` value, so the presupposition theorems are general
+rather than checked on a finite model. The monad laws of Figure 7 are Lean's lawful-monad
+instance for the reader transformer. The paper's judged sentences are rows of
+`Data.Examples.Grove2022`.
 
-The paper develops the apparatus (Part I below) and applies it to the
-classic "If Theo has a brother, he'll bring his wetsuit" minimal pair
-plus attitude-verb examples (Part II).
+## References
 
-## Part I — Apparatus (Grove §§3–4)
+* [grove-2022]
+* [heim-1983]
+* [heim-1992]
+* [charlow-2020]
+* [beaver-krahmer-2001]
 
-* `materialCond` — material conditional with middle Kleene semantics
-  (eq. 16): `⊤ ⇒ ψ = ψ`, `⊥ ⇒ ψ = ⊤`, `# ⇒ ψ = #`
-* `meetWK` / `joinWK` — weak Kleene conjunction / disjunction (used by
-  the presuppositional universal, where undefinedness absorbs from
-  either side)
-* `Iₚ I := ReaderT I Option` — Grove's `I#` (footnote 18: "Reader monad
-  transformer applied to the maybe monad"); `Iₚ` is a Lean-typographical
-  rename since `#` isn't a Lean subscript
-* Monad laws (Figure 7) inherited via mathlib's `LawfulMonad ReaderT`
-* `evalI` — evaluation `(·)^ž` (eq. 20)
-* `forallP` / `existsP` — presuppositional quantifiers (eq. 27)
-* `believe` — doxastic attitude verb (eq. 28)
-* Bridges to `Trivalent`, `Prop3`, `PartialProp`
+## TODO
 
-## Part II — Empirical predictions (Grove §3, §4.2)
-
-For "If Theo has a brother, he'll bring his wetsuit":
-
-* **Local reading** (narrow scope): trigger stays in the consequent →
-  presupposition is `hasBrother → hasWetsuit` (conditional)
-* **Global reading** (wide scope): trigger scopes over the conditional
-  via roll-up pied-piping → presupposition is `hasWetsuit` (unconditional)
-
-The two readings are a genuine **scope ambiguity**, not a semantic +
-pragmatic strengthening. The proviso problem does not arise because the
-unconditional presupposition is semantically available.
-
-For attitude verbs ("Theo believes he lost his wetsuit"), the same
-mechanism derives:
-* **Local** (de dicto): presupposition is that Theo *believes* he has
-  a wetsuit
-* **Global** (de re): presupposition is that Theo *has* a wetsuit
-
-This connects to the know/believe contrast of `Heim1992.lean` but
-derives it from scope rather than from local-context filtering.
-
-## Parallel with the set monad ([charlow-2020])
-
-| | Alternatives ([charlow-2020]) | Presupposition ([grove-2022]) |
-|---|---|---|
-| Monad | `S α = α → Prop` (sets) | `Option α` (maybe) |
-| Unit | `η_S(x) = {x}` | `η_#(v) = some v` |
-| Bind | `m ⫝̸_S f = ⋃_{x∈m} f(x)` | `v ⋆_# k = k(v); # ⋆_# k = #` |
-| Effect | Indeterminacy | Partiality |
-| Scope | Indefinites escape islands | Presuppositions project past filters |
+The syntax of roll-up pied-piping in Figures 2 and 6 and the sketched *also* of (29) are not
+represented; the readings are the meanings the derivations deliver.
 -/
 
 namespace Grove2022
 
-open Trivalent (Prop3)
-open Presupposition
+variable {I E : Type}
 
-/-! ## Part I — Apparatus -/
+/-- The intensional presuppositional monad `I#` of section 4.1: a reader over the maybe monad. -/
+abbrev Iₚ (I : Type) := ReaderT I Option
 
-/-! ### §1 Connectives on `Option Bool`
+/-- The monad laws of Figure 7 for `I#`: Left Identity is semantic reconstruction, and
+Associativity is what licenses cyclic scope. -/
+theorem monad_laws {α β γ : Type} (v : α) (m : Iₚ I α) (k : α → Iₚ I β) (n : β → Iₚ I γ) :
+    (pure v >>= k) = k v ∧ (m >>= pure) = m ∧ (m >>= k >>= n) = (m >>= λ x => k x >>= n) :=
+  ⟨pure_bind v k, bind_pure m, bind_assoc m k n⟩
 
-Grove uses two distinct gap-propagation policies:
-
-* **Middle Kleene** for the material conditional `⇒`: left-undefined
-  absorbs, but right-undefined does NOT absorb when the left is false
-  (`⊥ ⇒ # = ⊤`).
-* **Weak Kleene** for `∀_#`: undefinedness absorbs from either side
-  (`⊥ ∧ # = #`, unlike Strong Kleene where `⊥ ∧ # = ⊥`). -/
-
-section Connectives
-
-/-- Material conditional `⇒` with **middle Kleene** semantics (eq. 16):
-`⊤ ⇒ ψ = ψ`, `⊥ ⇒ ψ = ⊤`, `# ⇒ ψ = #`. The conditional is true when
-its antecedent is false (regardless of consequent definedness), and
-propagates the consequent when the antecedent is true. Undefinedness
-in the antecedent absorbs. -/
+/-- The material conditional of (16), with middle Kleene semantics: an undefined antecedent
+absorbs, a false one makes the conditional true whatever the consequent. -/
 def materialCond : Option Bool → Option Bool → Option Bool
   | none, _ => none
   | some false, _ => some true
   | some true, ψ => ψ
 
-/-- **Weak Kleene** conjunction (used by `forallP`). Undefinedness
-absorbs from either side, then falsity absorbs. (Contrast Strong
-Kleene: `⊥ ∧ # = ⊥` vs Weak Kleene `⊥ ∧ # = #`.) -/
-def meetWK : Option Bool → Option Bool → Option Bool
-  | none, _ | _, none => none
-  | some false, _ | _, some false => some false
-  | some true, some true => some true
-
-/-- **Weak Kleene** disjunction. Dual of `meetWK`. -/
-def joinWK : Option Bool → Option Bool → Option Bool
-  | none, _ | _, none => none
-  | some true, _ | _, some true => some true
-  | some false, some false => some false
-
-theorem materialCond_false_absorbs (ψ : Option Bool) :
-    materialCond (some false) ψ = some true := rfl
-
-theorem materialCond_true_passes (ψ : Option Bool) :
-    materialCond (some true) ψ = ψ := rfl
-
-theorem materialCond_undef_absorbs (ψ : Option Bool) :
-    materialCond none ψ = none := rfl
-
-theorem meetWK_comm (a b : Option Bool) : meetWK a b = meetWK b a := by
-  cases a with
-  | none => cases b <;> rfl
-  | some a => cases b with
-    | none => rfl
-    | some b => cases a <;> cases b <;> rfl
-
-private theorem meetWK_none_right (a : Option Bool) : meetWK a none = none := by
-  cases a with | none => rfl | some b => cases b <;> rfl
-
-/-- Once the accumulator is `none`, folding with `meetWK` preserves it. -/
-private theorem foldl_meetWK_none {α : Type} (ys : List α) (φ : α → Option Bool) :
-    ys.foldl (λ acc x => meetWK acc (φ x)) none = none := by
-  induction ys with
-  | nil => rfl
-  | cons _ ys ih => exact ih
-
-end Connectives
-
-/-! ### §2 The intensional-presuppositional monad `Iₚ`
-
-`Iₚ I α = I → Option α`: the Reader monad transformer applied to the
-maybe monad. An expression of type `Iₚ I α` reads an index `i` (world,
-world-assignment pair, etc.) and returns `some v` if defined at `i`,
-or `none` on presupposition failure — Grove §4.1's uniform treatment
-of intensionality and presupposition (replacing `t` with `t_#` in the
-intensional type `i → t`).
-
-Defining `Iₚ` as `ReaderT I Option` makes `pure`/`>>=` Grove's
-`η_#`/`⋆_#` and inherits `Monad`/`LawfulMonad` from mathlib. (Grove
-writes `I#`; `Iₚ` here is a Lean-friendly rename since `#` isn't a
-subscript glyph.) -/
-
-abbrev Iₚ (I : Type) := ReaderT I Option
-
-/-! ### §3 Monad laws
-
-`Iₚ = ReaderT I Option` is a `LawfulMonad`, so Grove's three laws
-(Figure 7: Left Identity, Right Identity, Associativity) hold via
-`pure_bind`, `bind_pure`, `bind_assoc` — no standalone `rfl` theorems
-needed. Left Identity and Associativity are the load-bearing
-scope-taking properties: Left Identity gives reconstruction (`η` + `⋆`
-= no scope; fn. 13), and Associativity makes cyclic scope-taking
-(roll-up pied-piping) sound (the presuppositional analog of
-[charlow-2020]'s ASSOCIATIVITY for the set monad). -/
-
-/-! ### §4 Semantic operations -/
-
-section Operations
-
-variable {I : Type}
-
-/-- Evaluation function `(·)^ž` (eq. 20). Given `φ : Iₚ I (I → Bool)`
-(a proposition that reads an index, possibly undefined, to return an
-intension), `evalI φ` feeds the index to itself:
-`evalI φ i = (φ i).map (· i)`. -/
-def evalI (φ : Iₚ I (I → Bool)) : Iₚ I Bool :=
-  λ i => (φ i).map (· i)
-
-/-- Presuppositional universal `∀_#` (eq. 27). Weak Kleene: `none`
-absorbs (if the scope is undefined at any value, the whole universal
-is undefined). -/
-def forallP {α : Type} (xs : List α) (φ : α → Option Bool) : Option Bool :=
-  xs.foldl (λ acc x => meetWK acc (φ x)) (some true)
-
-/-- Presuppositional existential (dual of `forallP`). -/
-def existsP {α : Type} (xs : List α) (φ : α → Option Bool) : Option Bool :=
-  xs.foldl (λ acc x => joinWK acc (φ x)) (some false)
-
-/-- `forallP` on an all-true list is `some true`. -/
-theorem forallP_all_true {α : Type} (xs : List α) (φ : α → Option Bool)
-    (h : ∀ x, x ∈ xs → φ x = some true) :
-    forallP xs φ = some true := by
-  induction xs with
-  | nil => rfl
-  | cons x xs ih =>
-    simp [forallP, List.foldl]
-    rw [show meetWK (some true) (φ x) = φ x from by
-      cases hx : φ x <;> simp [meetWK]; cases ‹Bool› <;> rfl]
-    rw [h x List.mem_cons_self]
-    exact ih (λ y hy => h y (List.mem_cons_of_mem x hy))
-
-/-- Helper: folding `meetWK` with an element that maps to `none` yields
-`none`, regardless of the accumulator or subsequent elements. -/
-private theorem foldl_meetWK_hits_none {α : Type}
-    (pre : List α) (x : α) (post : List α) (φ : α → Option Bool)
-    (acc : Option Bool) (hu : φ x = none) :
-    (pre ++ x :: post).foldl (λ a y => meetWK a (φ y)) acc = none := by
-  rw [List.foldl_append]
-  simp only [List.foldl]
-  rw [show meetWK (pre.foldl (λ a y => meetWK a (φ y)) acc) (φ x) = none from by
-    rw [hu]; exact meetWK_none_right _]
-  exact foldl_meetWK_none post φ
-
-/-- `forallP` with an undefined element is `none` — `meetWK` has `none`
-as a zero element, so once any `φ(x) = none` is encountered, the
-accumulator becomes `none` and stays `none`. -/
-theorem forallP_undef {α : Type} (xs : List α) (φ : α → Option Bool)
-    (x : α) (hx : x ∈ xs) (hu : φ x = none) :
-    forallP xs φ = none := by
-  obtain ⟨pre, post, rfl⟩ := List.mem_iff_append.mp hx
-  exact foldl_meetWK_hits_none pre x post φ (some true) hu
-
-end Operations
-
-/-! ### §5 Attitude verb semantics (Grove §4.2, eq. 28)
-
-`believe = λφ,x,i. ∀_# j : dox(x,i,j) ⇒ φ(j)` — the verb quantifies
-over doxastically accessible worlds with `∀_#` and uses the material
-conditional `⇒`. The `⇒` contributes the key filtering behavior: when
-`dox(x,i,j) = false`, `⇒` returns `some true` regardless of `φ(j)`'s
-definedness. -/
-
-section AttitudeVerbs
-
-variable {W E : Type}
-
-/-- `believe` (eq. 28). Given an accessibility relation `dox`, a list
-of worlds, a complement `φ : Iₚ W Bool`, an agent `x`, and an
-evaluation world `i`:
-`believe dox worlds φ x i = ∀_# j ∈ worlds : dox(x,i,j) ⇒ φ(j)` -/
-def believe (dox : E → W → W → Bool) (worlds : List W)
-    (φ : Iₚ W Bool) (x : E) : Iₚ W Bool :=
-  λ i => forallP worlds (λ j => materialCond (some (dox x i j)) (φ j))
-
-end AttitudeVerbs
-
-/-! ### §6 Bridges to existing linglib types
-
-`Option Bool`, `Trivalent`, and `PartialProp W` are three representations of
-possibly-undefined truth values. These conversions connect Grove's
-formalisation to the rest of the presupposition infrastructure. -/
-
-section Bridges
-
-/-- Convert `Option Bool` to `Trivalent`. -/
-def toTruth : Option Bool → Trivalent
-  | some true => .true
-  | some false => .false
-  | none => .indet
-
-/-- Convert `Trivalent` to `Option Bool`. -/
-def ofTruth : Trivalent → Option Bool
-  | .true => some true
-  | .false => some false
-  | .indet => none
-
-theorem roundtrip_truth3 (v : Trivalent) : toTruth (ofTruth v) = v := by
-  cases v <;> rfl
-
-theorem roundtrip_option (v : Option Bool) : ofTruth (toTruth v) = v := by
-  cases v with
-  | none => rfl
-  | some b => cases b <;> rfl
-
-/-- Middle Kleene implication on `Trivalent`. -/
-def impMK : Trivalent → Trivalent → Trivalent
-  | .indet, _ => .indet
-  | .false, _ => .true
-  | .true, ψ => ψ
-
-/-- `materialCond` corresponds to middle Kleene implication on `Trivalent`. -/
-theorem materialCond_eq_truth3 (p q : Option Bool) :
-    toTruth (materialCond p q) = impMK (toTruth p) (toTruth q) := by
-  cases p with
-  | none => rfl
-  | some b => cases b <;> cases q with
-    | none => rfl
-    | some c => cases c <;> rfl
-
-/-- `meetWK` corresponds to `Trivalent.meetWeak`. -/
-theorem meetWK_eq_truth3 (p q : Option Bool) :
-    toTruth (meetWK p q) = Trivalent.meetWeak (toTruth p) (toTruth q) := by
-  cases p with
-  | none => cases q with | none => rfl | some c => cases c <;> rfl
-  | some b => cases b <;> cases q with
-    | none => rfl
-    | some c => cases c <;> rfl
-
-/-- `joinWK` corresponds to `Trivalent.joinWeak`. -/
-theorem joinWK_eq_truth3 (p q : Option Bool) :
-    toTruth (joinWK p q) = Trivalent.joinWeak (toTruth p) (toTruth q) := by
-  cases p with
-  | none => cases q with | none => rfl | some c => cases c <;> rfl
-  | some b => cases b <;> cases q with
-    | none => rfl
-    | some c => cases c <;> rfl
-
-/-- Convert `Iₚ W Bool` to `Prop3 W` (world-indexed three-valued
-proposition). -/
-def toProp3 {W : Type} (φ : Iₚ W Bool) : Prop3 W :=
-  λ w => toTruth (φ w)
-
-/-- Convert `Iₚ W Bool` to `PartialProp W`. The presupposition field is
-`isSome` (defined?), and the assertion is the Bool value (defaulting
-to `false` when undefined). -/
-def toPartialProp {W : Type} (φ : Iₚ W Bool) : PartialProp W :=
-  { presup := λ w => (φ w).isSome
-  , assertion := λ w => (φ w).getD false }
-
-theorem toPartialProp_presup {W : Type} (φ : Iₚ W Bool) (w : W) :
-    (toPartialProp φ).presup w = (φ w).isSome := rfl
-
-theorem toPartialProp_assertion {W : Type} (φ : Iₚ W Bool) (w : W) (v : Bool)
-    (h : φ w = some v) :
-    (toPartialProp φ).assertion w = v := by
-  simp [toPartialProp, h]
-
-end Bridges
-
-/-! ## Part II — Empirical predictions -/
-
-/-! ### §7 World model for the conditional cases
-
-Four worlds varying two properties: whether Theo has a brother, and
-whether Theo has a (unique) wetsuit. -/
-
-inductive CWorld where
-  | broSuit   -- has brother, has wetsuit
-  | broNoSuit -- has brother, no wetsuit
-  | noBroSuit -- no brother, has wetsuit
-  | noBro     -- no brother, no wetsuit
-  deriving DecidableEq, Repr
-
-open CWorld
-
-def hasBrother : CWorld → Bool
-  | .broSuit | .broNoSuit => true
-  | .noBroSuit | .noBro => false
-
-def hasWetsuit : CWorld → Bool
-  | .broSuit | .noBroSuit => true
-  | .broNoSuit | .noBro => false
-
-/-- Whether Theo brings his wetsuit (only meaningful when he has one). -/
-def bringsWetsuit : CWorld → Bool
-  | .broSuit => true
-  | _ => false
-
-/-! ### §8 The presupposition trigger "his wetsuit"
-
-"His wetsuit" denotes type `e_#` (= `Option Entity`): defined when
-Theo has a unique wetsuit, undefined otherwise. In our simplified
-model, the entity is irrelevant — what matters is the definedness
-condition. So we model the trigger's contribution to the truth value
-as `Option Bool`: defined (with value `bring(t)`) when `hasWetsuit`,
-undefined otherwise. -/
-
-/-- "his wetsuit" contributes definedness + the `bring` predicate.
-
-* At worlds where Theo has a wetsuit: `some (bringsWetsuit w)`
-* At worlds where he doesn't: `none` (presupposition failure) -/
-def hisWetsuit : CWorld → Option Bool :=
-  λ w => if hasWetsuit w then some (bringsWetsuit w) else none
-
-/-! ### §9 Local reading: conditional presupposition
-
-The trigger takes scope within the consequent clause. The conditional's
-interpretation uses `materialCond`, which checks the consequent only
-when the antecedent is true. Result: the presupposition is conditional
-(`hasBrother → hasWetsuit`). -/
-
-/-- Local reading of "If Theo has a brother, he'll bring his wetsuit."
-The trigger stays inside the consequent. The conditional filters:
-`materialCond (some (hasBrother w)) (hisWetsuit w)`. -/
-def localReading : CWorld → Option Bool :=
-  λ w => materialCond (some (hasBrother w)) (hisWetsuit w)
-
-/-- At `broSuit`: brother ✓, wetsuit ✓, brings ✓ → `some true`. -/
-theorem local_broSuit : localReading .broSuit = some true := rfl
-
-/-- At `broNoSuit`: brother ✓, no wetsuit → `none` (presup failure). -/
-theorem local_broNoSuit : localReading .broNoSuit = none := rfl
-
-/-- At `noBroSuit`: no brother → `some true` (conditional vacuously true). -/
-theorem local_noBroSuit : localReading .noBroSuit = some true := rfl
-
-/-- At `noBro`: no brother → `some true` (vacuously true). -/
-theorem local_noBro : localReading .noBro = some true := rfl
-
-/-- The local reading is defined iff `hasBrother → hasWetsuit`. This is
-the **conditional presupposition** that [geurts-1996] observed
-satisfaction accounts predict — and which Grove argues is merely one of
-two available readings. -/
-theorem local_definedness (w : CWorld) :
-    (localReading w).isSome = (!hasBrother w || hasWetsuit w) := by
-  cases w <;> rfl
-
-/-! ### §10 Global reading: unconditional presupposition
-
-The trigger takes scope over the entire conditional via cyclic
-scope-taking (roll-up pied-piping). The trigger's definedness is
-checked first; only then does the conditional apply. Result: the
-presupposition is unconditional (`hasWetsuit`). -/
-
-/-- Global reading: the trigger scopes over the conditional.
-`hisWetsuit w >>= (λ b => materialCond (some (hasBrother w)) (some b))`.
-First check definedness of the trigger; then, if defined, evaluate the
-conditional with a fully-defined consequent. -/
-def globalReading : CWorld → Option Bool :=
-  λ w => hisWetsuit w >>= (λ b => materialCond (some (hasBrother w)) (some b))
-
-/-- At `broSuit`: wetsuit ✓ → defined. Brother ✓, brings ✓ → `some true`. -/
-theorem global_broSuit : globalReading .broSuit = some true := rfl
-
-/-- At `broNoSuit`: no wetsuit → `none` (presup failure). -/
-theorem global_broNoSuit : globalReading .broNoSuit = none := rfl
-
-/-- At `noBroSuit`: wetsuit ✓ → defined. No brother → `some true`. -/
-theorem global_noBroSuit : globalReading .noBroSuit = some true := rfl
-
-/-- At `noBro`: no wetsuit → `none` (presup failure). -/
-theorem global_noBro : globalReading .noBro = none := rfl
-
-/-- The global reading is defined iff `hasWetsuit`. This is the
-**unconditional presupposition** that speakers actually accommodate for
-"If Theo has a brother, he'll bring his wetsuit." The proviso problem
-does not arise: this reading is semantically available without
-pragmatic strengthening. -/
-theorem global_definedness (w : CWorld) :
-    (globalReading w).isSome = hasWetsuit w := by
-  cases w <;> rfl
-
-/-! ### §11 Scope ambiguity = no proviso problem
-
-The two readings differ only in scope. At worlds where both readings
-are defined, they agree on truth value — the readings differ only in
-their **presuppositions** (definedness conditions). -/
-
-/-- Where both readings are defined, they agree on truth value. -/
-theorem readings_agree_when_defined (w : CWorld)
-    (_hl : (localReading w).isSome = true)
-    (_hg : (globalReading w).isSome = true) :
-    localReading w = globalReading w := by
-  cases w <;> simp_all [localReading, globalReading, hisWetsuit,
-    materialCond, hasBrother, hasWetsuit, bringsWetsuit]
-
-/-- The global presupposition is strictly stronger than the local one:
-`hasWetsuit → (hasBrother → hasWetsuit)` but not vice versa. -/
-theorem global_stronger_than_local :
-    (∀ w, hasWetsuit w = true → (!hasBrother w || hasWetsuit w) = true)
-    ∧ ¬(∀ w, (!hasBrother w || hasWetsuit w) = true → hasWetsuit w = true) := by
-  constructor
-  · intro w hw; simp [hw, Bool.or_true]
-  · intro h; have := h .noBro (by rfl); simp [hasWetsuit] at this
-
-/-- Left Identity ensures that `η`-shifting inside the trigger's scope
-and then binding is the same as not shifting at all — this is why the
-narrow-scope derivation is equivalent to the standard satisfaction-
-theory prediction (Grove fn. 13). -/
-theorem eta_bind_reconstructs (w : CWorld) :
-    (some (hisWetsuit w) >>= id) = hisWetsuit w := by
-  cases hisWetsuit w <;> rfl
-
-/-! ### §12 Attitude verbs: "Theo believes he lost his wetsuit"
-
-A two-world model — `actual` (Theo has no wetsuit) and `believed` (his
-belief world, where he has one) — on which the scope theory derives the
-know/believe contrast of [heim-1992] via scope rather than local-context
-filtering. -/
-
-/-- `actual` (no wetsuit) and `believed` (Theo's belief world). -/
-inductive AttWorld where
-  | actual
-  | believed
-  deriving DecidableEq
-
-/-- Theo's doxastic accessibility: from either world, only `believed`. -/
-def dox : AttWorld → AttWorld → Bool
-  | _, .believed => true
-  | _, .actual => false
-
-/-- The complement "he lost his wetsuit" as an `Iₚ`-typed meaning.
-Presupposes Theo has a wetsuit at the evaluation world. When defined,
-asserts he lost it. At `believed`: has wetsuit ✓, lost it ✓. At
-`actual`: no wetsuit → undefined. -/
-def lostWetsuit : Iₚ AttWorld Bool
-  | .believed => some true   -- has wetsuit, lost it
-  | .actual => none          -- no wetsuit: presupposition failure
-
-/-- Local reading of "Theo believes he lost his wetsuit." The
-complement stays in situ; `believe` quantifies over doxastic
-alternatives with the complement evaluated locally. -/
-def believeLocal : Iₚ AttWorld Bool :=
-  believe (λ _ => dox) [AttWorld.actual, AttWorld.believed]
-    lostWetsuit () -- () stands for Theo (single-agent model)
-
-/-- Local reading at `actual`: Theo's only belief-world is `believed`,
-where the complement is defined and true → `some true`. -/
-theorem believe_local_actual : believeLocal .actual = some true := rfl
-
-/-- Local reading at `believed`: same → `some true`. -/
-theorem believe_local_believed : believeLocal .believed = some true := rfl
-
-/-- The local reading is always defined. The presupposition is that
-Theo **believes** he has a wetsuit (= the complement is defined at all
-doxastic alternatives). Since `believed` is the only belief-accessible
-world from either world, and the complement is defined there, this
-always holds. No projection to the actual world. -/
-theorem believe_local_always_defined (w : AttWorld) :
-    (believeLocal w).isSome = true := by
-  cases w <;> rfl
-
-/-- Global reading: the complement scopes out. The complement's
-definedness is evaluated at the actual world (not within the scope of
-`believe`). -/
-def believeGlobal : Iₚ AttWorld Bool :=
-  λ i => lostWetsuit i >>= (λ b =>
-    believe (λ _ => dox) [AttWorld.actual, AttWorld.believed]
-      (pure b) () i)
-
-/-- Global reading at `actual`: complement is undefined → `none`. The
-presupposition projects globally: Theo must *actually* have a wetsuit
-at the evaluation world. -/
-theorem believe_global_actual : believeGlobal .actual = none := rfl
-
-/-- Global reading at `believed`: complement defined → `some true`. -/
-theorem believe_global_believed : believeGlobal .believed = some true := rfl
-
-/-- The global reading is defined iff the complement is defined at the
-evaluation world — the presupposition projects past `believe`. -/
-theorem believe_global_definedness (w : AttWorld) :
-    (believeGlobal w).isSome = (lostWetsuit w).isSome := by
-  cases w <;> rfl
-
-/-! ### §13 Bridge to [heim-1992]
-
-In `Heim1992.lean` the know/believe contrast follows from the partial
-context change potentials of *believe* (rule (18)) and factive *know*.
-The scope theory provides an alternative explanation: the
-asymmetry arises because the trigger can take different scopes relative
-to the attitude verb.
-
-The **local** reading corresponds to Heim's standard satisfaction-
-theory prediction. The **global** reading is what the satisfaction
-theory cannot derive — and what the scope theory adds. -/
-
-/-- The local reading's definedness matches Heim's belief-embedding
-prediction: the presupposition is filtered (projected into the attitude
-holder's beliefs, not to the actual world). -/
-theorem local_matches_heim_belief :
-    -- Local reading defined at actual (no projection to actual world)
-    (believeLocal .actual).isSome = true
-    -- Even though the complement's presupposition fails at actual
-    ∧ (lostWetsuit .actual).isSome = false := by
-  exact ⟨rfl, rfl⟩
-
-/-- The global reading adds what Heim's account lacks: a reading where
-the presupposition projects past the attitude verb entirely. -/
-theorem global_projects_past_attitude :
-    -- Global reading undefined at actual (projects to actual world)
-    (believeGlobal .actual).isSome = false
-    -- Because the complement's presupposition fails at actual
-    ∧ (lostWetsuit .actual).isSome = false := by
-  exact ⟨rfl, rfl⟩
+theorem materialCond_decide (P : Prop) [Decidable P] (ψ : Option Bool) :
+    materialCond (some (decide P)) ψ = if P then ψ else some true := by
+  by_cases h : P <;> simp [h, materialCond]
+
+open Classical in
+/-- The presuppositional universal of (27): true if its scope is true everywhere, undefined if
+its scope is undefined somewhere, and false otherwise. -/
+noncomputable def forallP {α : Type*} (φ : α → Option Bool) : Option Bool :=
+  if ∃ x, φ x = none then none else if ∀ x, φ x = some true then some true else some false
+
+theorem forallP_eq_none_iff {α : Type*} (φ : α → Option Bool) :
+    forallP φ = none ↔ ∃ x, φ x = none := by
+  unfold forallP
+  split_ifs with h₁ h₂ <;> simp [h₁]
+
+theorem forallP_eq_some_true_iff {α : Type*} (φ : α → Option Bool) :
+    forallP φ = some true ↔ ∀ x, φ x = some true := by
+  unfold forallP
+  split_ifs with h₁ h₂
+  · obtain ⟨x, hx⟩ := h₁
+    simp only [false_iff, not_forall]
+    exact ⟨x, by simp [hx]⟩
+  · simp [h₂]
+  · simp [h₂]
+
+theorem forallP_isSome_iff {α : Type*} (φ : α → Option Bool) :
+    (forallP φ).isSome ↔ ∀ x, (φ x).isSome := by
+  simp only [Option.isSome_iff_ne_none, ne_eq, forallP_eq_none_iff, not_exists]
+
+/-- The evaluation of (20): identify the index an `I# (i → t)` value reads with the index of
+the intension it returns. -/
+def evalI (φ : Iₚ I (I → Bool)) : Iₚ I Bool := λ i => (φ i).map (· i)
+
+/-- *believe*, (28): the Hintikka quantifier over doxastic alternatives, the conditional
+filtering the inaccessible indices. -/
+noncomputable def believe (dox : E → I → I → Prop) [∀ x i j, Decidable (dox x i j)]
+    (φ : Iₚ I Bool) (x : E) : Iₚ I Bool :=
+  λ i => forallP λ j => materialCond (some (decide (dox x i j))) (φ j)
+
+/-! ### The conditional, section 3
+
+*If Theo has a brother, he'll bring his wetsuit*, (1): `bro` is the antecedent, `wetsuit` the
+trigger *his wetsuit*, Theo's unique wetsuit at an index if he has one, and `bring` the
+predicate. -/
+
+section Conditional
+
+variable (bro : I → Prop) [DecidablePred bro] (wetsuit : Iₚ I E) (bring : E → I → Prop)
+  [∀ x i, Decidable (bring x i)]
+
+/-- The consequent with the trigger scoped to its edge, Figure 5: the lifted trigger over the
+abstracted clause, of type `t#`. -/
+def consequent : Iₚ I Bool := λ i => wetsuit i >>= λ x => pure (decide (bring x i))
+
+/-- The local reading of (1), Figure 5: the conditional applied to the consequent. -/
+def localReading : Iₚ I Bool :=
+  λ i => materialCond (some (decide (bro i))) (consequent wetsuit bring i)
+
+/-- The global reading of (1), Figure 6: the consequent, of type `t##` after two units in the
+trigger's scope, takes scope over the conditional. -/
+def globalReading : Iₚ I Bool := λ i =>
+  (wetsuit i >>= λ x => pure (pure (decide (bring x i)))) >>= λ ψ =>
+    materialCond (some (decide (bro i))) ψ
+
+/-- The local reading is undefined exactly when Theo has a brother but no wetsuit: the
+conditional presupposition of the satisfaction theory, Figure 3. -/
+theorem localReading_eq_none_iff (i : I) :
+    localReading bro wetsuit bring i = none ↔ bro i ∧ wetsuit i = none := by
+  simp only [localReading, consequent, materialCond_decide]
+  cases wetsuit i <;> split_ifs <;> simp_all
+
+theorem localReading_eq_some_true_iff (i : I) :
+    localReading bro wetsuit bring i = some true ↔
+      (bro i → ∃ x, wetsuit i = some x ∧ bring x i) := by
+  simp only [localReading, consequent, materialCond_decide]
+  cases wetsuit i <;> split_ifs <;> simp_all
+
+theorem localReading_isSome_iff (i : I) :
+    (localReading bro wetsuit bring i).isSome ↔ (bro i → (wetsuit i).isSome) := by
+  simp only [Option.isSome_iff_ne_none, ne_eq, localReading_eq_none_iff, not_and]
+
+/-- The global reading is undefined exactly when Theo has no wetsuit: the unconditional
+presupposition, Figure 4, available without pragmatic strengthening. -/
+theorem globalReading_eq_none_iff (i : I) :
+    globalReading bro wetsuit bring i = none ↔ wetsuit i = none := by
+  simp only [globalReading, materialCond_decide]
+  cases wetsuit i <;> split_ifs <;> simp_all
+
+theorem globalReading_eq_some_true_iff (i : I) :
+    globalReading bro wetsuit bring i = some true ↔
+      ∃ x, wetsuit i = some x ∧ (bro i → bring x i) := by
+  simp only [globalReading, materialCond_decide]
+  cases wetsuit i <;> split_ifs <;> simp_all
+
+theorem globalReading_isSome_iff (i : I) :
+    (globalReading bro wetsuit bring i).isSome ↔ (wetsuit i).isSome := by
+  simp only [Option.isSome_iff_ne_none, ne_eq, globalReading_eq_none_iff]
+
+/-- The two readings differ only in their presuppositions: wherever the global reading is
+defined, so is the local one, with the same value. -/
+theorem globalReading_eq_localReading_of_isSome (i : I) (h : (wetsuit i).isSome) :
+    globalReading bro wetsuit bring i = localReading bro wetsuit bring i := by
+  simp only [globalReading, localReading, consequent, materialCond_decide]
+  cases hw : wetsuit i <;> split_ifs <;> simp_all
+
+/-- Left Identity, the paper's footnote on Figure 6: a unit applied outside the trigger's scope
+reconstructs, giving the local reading again rather than the global one. -/
+theorem reconstruct (i : I) :
+    (pure (consequent wetsuit bring i) >>= λ ψ => materialCond (some (decide (bro i))) ψ) =
+      localReading bro wetsuit bring i :=
+  pure_bind _ _
+
+end Conditional
+
+/-! ### Propositional attitudes, section 4.2
+
+*Theo believes he lost his wetsuit*, (22): the complement is derived with intensions, Figure 8,
+and either evaluated in situ under the verb, Figure 9, or scoped above it, Figure 10. -/
+
+section Attitude
+
+variable (dox : E → I → I → Prop) [∀ x i j, Decidable (dox x i j)] (wetsuit : Iₚ I E)
+  (lose : E → I → Prop) [∀ x i, Decidable (lose x i)] (theo : E)
+
+/-- *he lost his wetsuit* with the trigger scoped over the clause, an `I# (i → t)` value. -/
+def lostClause : Iₚ I (I → Bool) := λ j => wetsuit j >>= λ x => pure λ i => decide (lose x i)
+
+/-- The local reading of (22), Figure 9: the evaluated complement under *believe*. -/
+noncomputable def believeLocal : Iₚ I Bool := believe dox (evalI (lostClause wetsuit lose)) theo
+
+/-- The global reading of (22), Figure 10: the clause scopes above the verb through the reader
+bind, its trigger read at the evaluation index. -/
+noncomputable def believeGlobal : Iₚ I Bool :=
+  lostClause wetsuit lose >>= λ φ => believe dox (λ j => pure (φ j)) theo
+
+/-- Evaluation of the clause, (21): the trigger and the predicate read the same index. -/
+theorem evalI_lostClause (j : I) :
+    evalI (lostClause wetsuit lose) j = wetsuit j >>= λ x => pure (decide (lose x j)) := by
+  simp only [evalI, lostClause]
+  cases wetsuit j <;> rfl
+
+/-- In situ, the presupposition is that Theo has a wetsuit at every doxastic alternative: the
+prediction of [heim-1992] for (22). -/
+theorem believeLocal_isSome_iff (i : I) :
+    (believeLocal dox wetsuit lose theo i).isSome ↔
+      ∀ j, dox theo i j → (wetsuit j).isSome := by
+  simp only [believeLocal, believe, forallP_isSome_iff, evalI_lostClause, materialCond_decide]
+  refine forall_congr' λ j => ?_
+  cases wetsuit j <;> split_ifs <;> simp_all
+
+theorem believeLocal_eq_some_true_iff (i : I) :
+    believeLocal dox wetsuit lose theo i = some true ↔
+      ∀ j, dox theo i j → ∃ x, wetsuit j = some x ∧ lose x j := by
+  simp only [believeLocal, believe, forallP_eq_some_true_iff, evalI_lostClause,
+    materialCond_decide]
+  refine forall_congr' λ j => ?_
+  cases wetsuit j <;> split_ifs <;> simp_all
+
+/-- Scoped above the verb, the presupposition is that Theo has a wetsuit at the evaluation
+index: it projects past *believe*, and *his wetsuit* is read de re. -/
+theorem believeGlobal_isSome_iff (i : I) :
+    (believeGlobal dox wetsuit lose theo i).isSome ↔ (wetsuit i).isSome := by
+  show (lostClause wetsuit lose i >>= λ φ => believe dox (λ j => pure (φ j)) theo i).isSome ↔ _
+  simp only [lostClause, believe, materialCond_decide]
+  cases wetsuit i
+  · rfl
+  · simp only [Option.pure_def, Option.bind_eq_bind, Option.bind, Option.isSome_some,
+      forallP_isSome_iff, iff_true]
+    intro j
+    split_ifs <;> rfl
+
+/-- The at-issue content reconstructs: the global reading is true exactly when Theo has a
+wetsuit that he lost at all his doxastic alternatives. -/
+theorem believeGlobal_eq_some_true_iff (i : I) :
+    believeGlobal dox wetsuit lose theo i = some true ↔
+      ∃ x, wetsuit i = some x ∧ ∀ j, dox theo i j → lose x j := by
+  show (lostClause wetsuit lose i >>= λ φ => believe dox (λ j => pure (φ j)) theo i) =
+    some true ↔ _
+  simp only [lostClause, believe, materialCond_decide]
+  cases wetsuit i
+  · simp
+  · simp only [Option.pure_def, Option.bind_eq_bind, Option.bind, Option.some.injEq,
+      exists_eq_left', forallP_eq_some_true_iff]
+    refine forall_congr' λ j => ?_
+    split_ifs <;> simp_all
+
+end Attitude
 
 end Grove2022


### PR DESCRIPTION
Deep cleanse of Grove2022 against the paper (the Semantics and Pragmatics PDF): the study now proves the scope theory's presupposition predictions as general theorems over arbitrary index and entity types instead of checking them on four- and two-world models.

- `Iₚ` is the reader transformer over `Option` (the paper's footnote), `materialCond` is (16), `forallP` is (27) defined classically over a whole type, `believe` is (28); the readings of (1) are built by the paper's own derivations (Figures 5 and 6) with the trigger an `Iₚ I E` value, and `localReading_isSome_iff` / `globalReading_isSome_iff` are the conditional and unconditional presuppositions, with agreement wherever the global reading is defined and Left Identity's reconstruction; (22)'s two readings give `believeLocal_isSome_iff` (a wetsuit at every doxastic alternative, Heim 1992's prediction) and `believeGlobal_isSome_iff` / `believeGlobal_eq_some_true_iff` (a wetsuit at the evaluation index, de re, the at-issue content reconstructing).
- New `Data/Examples/Grove2022.json` (11 rows: (1), (2), (6), (7) to (9), (22) to (26), with the readings the paper distinguishes by their presuppositions).
- Cut: the `Trivalent`/`PartialProp` bridge section, the per-world `rfl` theorems, the `Bool`-valued definedness equations, and the Heim1992 "bridge" conjunctions of `rfl`s; header rewritten in register.
