### PR TITLE
refactor(Studies/Grubic2015): chapter 7 entries and glossed rows

### DIFF
--- a/Linglib/Data/Examples/Grubic2015.json
+++ b/Linglib/Data/Examples/Grubic2015.json
@@ -1,0 +1,824 @@
+[
+  {
+    "id": "grubic2015_6_24",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(24)"},
+    "language": "ngam1282",
+    "primaryText": "Ne sakatari yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ne", "1SG.DEP"], ["sakatari", "secretary"], ["yak'i.", "only"]
+    ],
+    "translation": "I'm only a secretary.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "complement exclusion: I am nothing else in addition", "judgment": "acceptable"},
+      {"name": "rank order: I am nothing better", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "predicate"]
+    ],
+    "comment": "Both readings carry a mirative component: more, or something more prestigious, was expected.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_25a",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(25a)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Dimza yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Dimza", "Dimza"], ["yak'i.", "only"]
+    ],
+    "translation": "Only Dimza built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "markedSubjectFocus"],
+      ["inference", "Dimza built a house"],
+      ["inference", "nobody else built a house"]
+    ],
+    "comment": "Consultant: Dimza built a house, and nobody else built a house.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_25b",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(25b)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Dimza yak'i bu.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Dimza", "Dimza"], ["yak'i", "only"],
+      ["bu.", "NEG"]
+    ],
+    "translation": "Not only Dimza built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "markedSubjectFocus"],
+      ["inference", "Dimza built a house"],
+      ["inference", "other people also built a house"]
+    ],
+    "comment": "The exclusive component is asserted; the prejacent projects through negation.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_25c",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(25c)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Dimza yak'i ɗo?",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Dimza", "Dimza"], ["yak'i", "only"],
+      ["ɗo?", "Q"]
+    ],
+    "translation": "Did only Dimza build a house?",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "markedSubjectFocus"],
+      ["inference", "Dimza built a house"]
+    ],
+    "comment": "Consultant: Dimza built a house, and you want to confirm: alone or with other people?",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_26",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(26)"},
+    "language": "ngam1282",
+    "primaryText": "Esha=i Sama yak'i nzono, ke esha Hawwa nzono.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Esha=i", "call.PFV=BM"], ["Sama", "Sama"], ["yak'i", "only"], ["nzono,", "yesterday"],
+      ["ke", "also"], ["esha", "call.PFV"], ["Hawwa", "Hawwa"], ["nzono.", "yesterday"]
+    ],
+    "translation": "He only called Sama yesterday, and he also called Hawwa yesterday.",
+    "context": "Who did Njelu call yesterday?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "markedObjectFocus"]
+    ],
+    "comment": "The exclusive component is not cancellable.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_28",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(28)"},
+    "language": "ngam1282",
+    "primaryText": "Ne'e yak ne wa ampani yam ki korino bu.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ne'e", "1SG"], ["yak", "only"], ["ne", "1SG"], ["wa", "get.PFV"], ["ampani", "harvest"],
+      ["yam", "a.lot"], ["ki", "at"], ["korino", "farm=1SG.POSS"], ["bu.", "NEG"]
+    ],
+    "translation": "I didn't only get a good harvest.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "predicate"]
+    ],
+    "comment": "The mirative component projects: odd because a good harvest is not less than expected.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_140",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(140)"},
+    "language": "ngam1282",
+    "primaryText": "Kule yak salko bano mano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kule", "Kule"], ["yak", "only"], ["salko", "build.PFV"], ["bano", "house"],
+      ["mano.", "last.year"]
+    ],
+    "translation": "Kule only built a house last year.",
+    "context": "Kule wanted to build a house and a granary last year.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "unmarkedObjectFocus"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_145a",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(145a)"},
+    "language": "ngam1282",
+    "primaryText": "O'o, Kule yak onto agoggo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["O'o,", "no"], ["Kule", "Kule"], ["yak", "only"], ["onto", "give.PFV.3SG.F"],
+      ["agoggo.", "watch"]
+    ],
+    "translation": "No, Kule only gave a watch to her.",
+    "context": "Did Kule give a watch to Dimza and Jajei?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "dependentPronoun"]
+    ],
+    "comment": "Reinterpreted with the exclusive associating with the direct object: Jajei is expecting a watch and other things.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_145b",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(145b)"},
+    "language": "ngam1282",
+    "primaryText": "O'o, Kule onko agoggo=i ki te yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["O'o,", "no"], ["Kule", "Kule"], ["onko", "give.PFV"], ["agoggo=i", "watch=BM"],
+      ["ki", "to"], ["te", "3SG.F"], ["yak'i.", "only"]
+    ],
+    "translation": "No, Kule only gave a watch to her.",
+    "context": "Did Kule give a watch to Dimza and Jajei?",
+    "judgment": "marginal",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "independentPronoun"]
+    ],
+    "comment": "Marginal because it is hard to tell who te refers to without intermediate discussion of Jajei.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_148a",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(148a)"},
+    "language": "ngam1282",
+    "primaryText": "Hawwa=s, ne moishe Daho a esha=i te yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hawwa=s,", "Hawwa=DEF.DET.F"], ["ne", "1SG"], ["moishe", "see.HAB"], ["Daho", "Daho"],
+      ["a", "3SG.HAB"], ["esha=i", "call.HAB=BM"], ["te", "3SG.F"], ["yak'i.", "only"]
+    ],
+    "translation": "Hawwa, I think Daho only calls her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "the only person that Daho calls is Hawwa", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "resumptivePronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_148b",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(148b)"},
+    "language": "ngam1282",
+    "primaryText": "Hawwa=s, ne moishe Daho a esha yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hawwa=s,", "Hawwa=DEF.DET.F"], ["ne", "1SG"], ["moishe", "see.HAB"], ["Daho", "Daho"],
+      ["a", "3SG.HAB"], ["esha", "call.HAB"], ["yak'i.", "only"]
+    ],
+    "translation": "Hawwa, I think Daho only calls.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "the only person that Daho calls is Hawwa", "judgment": "unacceptable"},
+      {"name": "Daho does nothing but call", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "topicalizedGap"]
+    ],
+    "comment": "The exclusive cannot associate with the moved constituent.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_149",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(149)"},
+    "language": "ngam1282",
+    "primaryText": "Hawwa=s, ne moishe Daho lei ki tomiya a esha.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hawwa=s,", "Hawwa=DEF.DET.F"], ["ne", "1SG"], ["moishe", "see.HAB"], ["Daho", "Daho"],
+      ["lei", "at"], ["ki", "any"], ["tomiya", "time"], ["a", "3SG.HAB"], ["esha.", "call.HAB"]
+    ],
+    "translation": "Hawwa, I think Daho always calls.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "whenever Daho calls somebody, she calls Hawwa", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "leiKiTomiya"],
+      ["configuration", "topicalizedGap"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_150a",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(150a)"},
+    "language": "ngam1282",
+    "primaryText": "Hasha hoti maɗɗi a esha Lakka, Gamba me esha=i te yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hasha", "Hasha"], ["hoti", "day"], ["maɗɗi", "some"], ["a", "3SG.HAB"],
+      ["esha", "call.HAB"], ["Lakka,", "Lakka"], ["Gamba", "Gamba"], ["me", "but"],
+      ["esha=i", "call.HAB=BM"], ["te", "3SG.F"], ["yak'i.", "only"]
+    ],
+    "translation": "Hasha sometimes calls Lakka, and Gambo only calls her.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "focusedPronoun"]
+    ],
+    "comment": "Consultant: he always calls only her, never anybody else.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_150b",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(150b)"},
+    "language": "ngam1282",
+    "primaryText": "Hasha hoti maɗɗi a esha Lakka, Gambo me a esha yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hasha", "Hasha"], ["hoti", "day"], ["maɗɗi", "some"], ["a", "3SG.HAB"],
+      ["esha", "call.HAB"], ["Lakka,", "Lakka"], ["Gambo", "Gamba"], ["me", "but"],
+      ["a", "3SG.HAB"], ["esha", "call.HAB"], ["yak'i.", "only"]
+    ],
+    "translation": "Hasha sometimes calls Lakka, and Gambo only calls her.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "elidedPronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_151",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(151)"},
+    "language": "ngam1282",
+    "primaryText": "Hasha hoti maɗɗi a esha Lakka, Gambo me lei ki tomiya a esha.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hasha", "Hasha"], ["hoti", "day"], ["maɗɗi", "some"], ["a", "3SG.HAB"],
+      ["esha", "call.HAB"], ["Lakka,", "Lakka"], ["Gambo", "Gamba"], ["me", "but"], ["lei", "at"],
+      ["ki", "any"], ["tomiya", "time"], ["a", "3SG.HAB"], ["esha.", "call.HAB"]
+    ],
+    "translation": "Hasha sometimes calls Lakka, and Gambo always does.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "leiKiTomiya"],
+      ["configuration", "elidedPronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_153",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(153)"},
+    "language": "ngam1282",
+    "primaryText": "Biya ma maranko shinkafa a tishe yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Biya", "people"], ["ma", "REL"], ["maranko", "farm.PL.PFV"], ["shinkafa", "rice"],
+      ["a", "3SG.HAB"], ["tishe", "eat.HAB"], ["yak'i.", "only"]
+    ],
+    "translation": "People that grow rice only eat it.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "they don't sell it or give it out", "judgment": "acceptable"},
+      {"name": "they eat nothing else", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "elidedObject"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_158",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(158)"},
+    "language": "ngam1282",
+    "primaryText": "Samaye gitkok tishe=i jarabawa=to yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Samaye", "Samaye"], ["gitkok", "be.able.PFV.TOT"], ["tishe=i", "eat.HAB=BM"],
+      ["jarabawa=to", "exam=3SG.F.POSS"], ["yak'i.", "only"]
+    ],
+    "translation": "Samaye only managed to pass her exams.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "presupposition"]
+    ],
+    "comment": "The exclusive does not associate with the presupposition of gitko.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_159",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(159)"},
+    "language": "ngam1282",
+    "primaryText": "Samaye lei ki tomiya a gishentik tina=i jarabawa=to.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Samaye", "Samaye"], ["lei", "at"], ["ki", "any"], ["tomiya", "time"], ["a", "3SG.HAB"],
+      ["gishentik", "be.able.HAB.TOT"], ["tina=i", "eat.FUT=BM"],
+      ["jarabawa=to.", "exam=3SG.F.POSS"]
+    ],
+    "translation": "Samaye always manages to pass her exams.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "whenever she tries, she passes", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "leiKiTomiya"],
+      ["configuration", "presupposition"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_160",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(160)"},
+    "language": "ngam1282",
+    "primaryText": "Si onko agoggo=i ki Shuwa, si ke ono.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Si", "3SG.M"], ["onko", "give.PFV"], ["agoggo=i", "watch=BM"], ["ki", "to"],
+      ["Shuwa,", "Shuwa"], ["si", "3SG.M"], ["ke", "also"], ["ono.", "give.1SG.DEP"]
+    ],
+    "translation": "He gave a watch to Shuwa, and he also gave it to me.",
+    "context": "Whom did Kule give a watch?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "dependentPronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_162a",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(162a)"},
+    "language": "ngam1282",
+    "primaryText": "Kule esha=i Dimza, ke esha=i ne'e.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kule", "Kule"], ["esha=i", "call.PFV=BM"], ["Dimza,", "Dimza"], ["ke", "also"],
+      ["esha=i", "call.PFV=BM"], ["ne'e.", "1SG"]
+    ],
+    "translation": "Kule called Dimza and he also called me.",
+    "context": "Whom did Kule call?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "independentPronoun"]
+    ],
+    "comment": "Rejected in favour of a dependent pronoun with a totality-extended verb.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_162b",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(162b)"},
+    "language": "ngam1282",
+    "primaryText": "Kule esha=i Dimza ke eshino.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kule", "Kule"], ["esha=i", "call.PFV=BM"], ["Dimza", "Dimza"], ["ke", "also"],
+      ["eshino.", "call.PFV.TOT.1SG"]
+    ],
+    "translation": "Kule called Dimza and he also called me.",
+    "context": "Whom did Kule call?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "dependentPronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_163",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(163)"},
+    "language": "ngam1282",
+    "primaryText": "Ke salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ke", "also"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "He also built a house.",
+    "context": "I know that Hawwa built a house, but what about Kule? What did he build?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "elidedTopicalSubject"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_164",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(164)"},
+    "language": "ngam1282",
+    "primaryText": "Kule onko agoggo=i ki Shuwa, ke har ono.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kule", "Kule"], ["onko", "give.PFV"], ["agoggo=i", "watch=BM"], ["ki", "to"],
+      ["Shuwa,", "Shuwa"], ["ke", "and"], ["har", "even"], ["ono.", "give.PFV.1SG.DEP"]
+    ],
+    "translation": "Kule gave a watch to Shuwa, and he even gave one to me.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "har"],
+      ["configuration", "dependentPronoun"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_165",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(165)"},
+    "language": "ngam1282",
+    "primaryText": "Hawwa salko bano, Kule ke salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hawwa", "Hawwa"], ["salko", "build.PFV"], ["bano,", "house"], ["Kule", "Kule"],
+      ["ke", "also"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "Hawwa built a house, and Kule also built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "preverbalSubject"]
+    ],
+    "comment": "Preverbal subjects are out of focus, which the exclusive cannot associate with.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_166",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(166)"},
+    "language": "ngam1282",
+    "primaryText": "Dimza yak salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dimza", "Dimza"], ["yak", "only"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "Dimza only built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "unmarkedObjectFocus"],
+      ["inference", "Dimza didn't build anything else"],
+      ["inference", "he was expected to build more"],
+      ["inference", "Dimza built a house"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_167",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(167)"},
+    "language": "ngam1282",
+    "primaryText": "Dimza ke salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dimza", "Dimza"], ["ke", "also"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "Dimza also built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "unmarkedObjectFocus"],
+      ["inference", "Dimza built a house"],
+      ["inference", "Dimza built something else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_168",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(168)"},
+    "language": "ngam1282",
+    "primaryText": "Dimza har salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Dimza", "Dimza"], ["har", "even"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "Dimza even built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "har"],
+      ["configuration", "unmarkedObjectFocus"],
+      ["inference", "Dimza built a house"],
+      ["inference", "he was expected to build less"],
+      ["inference", "Dimza built something else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_169",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(169)"},
+    "language": "ngam1282",
+    "primaryText": "Ne sakatari yak'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ne", "1SG"], ["sakatari", "secretary"], ["yak'i.", "only"]
+    ],
+    "translation": "I'm only a secretary.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "yak"],
+      ["configuration", "predicate"],
+      ["inference", "the speaker is nothing better than a secretary"],
+      ["inference", "the speaker was expected to be something better"]
+    ],
+    "comment": "A rank-order scale: the prejacent inference does not survive negation.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_6_170",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(170)"},
+    "language": "ngam1282",
+    "primaryText": "Bah malum har'i.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Bah", "Bah"], ["malum", "teacher"], ["har'i.", "even"]
+    ],
+    "translation": "Bah is even a teacher.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "har"],
+      ["configuration", "predicate"],
+      ["inference", "Bah is a teacher"],
+      ["inference", "he was expected to be something worse"]
+    ],
+    "comment": "A rank-order scale: no additive inference.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_41",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(41)"},
+    "language": "ngam1282",
+    "primaryText": "Kaja mato=i Hawwa, salko bano=i ke Kule.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kaja", "buy.PFV"], ["mato=i", "car=BM"], ["Hawwa,", "Hawwa"], ["salko", "build.PFV"],
+      ["bano=i", "house=BM"], ["ke", "also"], ["Kule.", "Kule"]
+    ],
+    "translation": "Hawwa bought a car, Kule built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "distinctBackgroundDistinctFocus"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_42",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(42)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Kule, kaja mato=i ke Kule.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Kule,", "Kule"], ["kaja", "buy.PFV"],
+      ["mato=i", "car=BM"], ["ke", "also"], ["Kule.", "Kule"]
+    ],
+    "translation": "Kule built a house, and Kule also bought a car.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "distinctBackgroundParallelFocus"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_43",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(43)"},
+    "language": "ngam1282",
+    "primaryText": "Kule salko makaranta mano, Kule ke salko bano mano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kule", "Kule"], ["salko", "build.PFV"], ["makaranta", "school"], ["mano,", "last.year"],
+      ["Kule", "Kule"], ["ke", "also"], ["salko", "build.PFV"], ["bano", "house"],
+      ["mano.", "last.year"]
+    ],
+    "translation": "Kule built a school last year, and Kule also built a house last year.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "parallelUnmarkedBackground"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_44",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(44)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Hawwa, salko bano=i ke Kule.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Hawwa,", "Hawwa"], ["salko", "build.PFV"],
+      ["bano=i", "house=BM"], ["ke", "also"], ["Kule.", "Kule"]
+    ],
+    "translation": "Hawwa built a house, and Kule built a house, too.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "parallelMarkedBackground"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_46",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(46)"},
+    "language": "ngam1282",
+    "primaryText": "Bei a ina ham ɗoshi, ke a ina ham tuha ke'e.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Bei", "maybe"], ["a", "3SG"], ["ina", "do.FUT"], ["ham", "water"], ["ɗoshi,", "tomorrow"],
+      ["ke", "and"], ["a", "3SG"], ["ina", "do.FUT"], ["ham", "water"],
+      ["tuha", "day.after.tomorrow"], ["ke'e.", "also"]
+    ],
+    "translation": "It is possible that it will rain tomorrow, and it will also rain the day after tomorrow.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "modalizedAntecedent"]
+    ],
+    "comment": "The antecedent is merely given, not asserted to be true.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_48",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(48)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Hawwa, Kule ke salko bano.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Hawwa,", "Hawwa"], ["Kule", "Kule"],
+      ["ke", "also"], ["salko", "build.PFV"], ["bano.", "house"]
+    ],
+    "translation": "Hawwa built a house and Kule also built a house.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "nonParallel"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubic2015_7_49",
+    "source": {"bibkey": "grubic-2015", "paperLabel": "(49)"},
+    "language": "ngam1282",
+    "primaryText": "Salko bano=i Hawwa, ke salko bano=i ke Kule.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Salko", "build.PFV"], ["bano=i", "house=BM"], ["Hawwa,", "Hawwa"], ["ke", "also"],
+      ["salko", "build.PFV"], ["bano=i", "house=BM"], ["ke", "also"], ["Kule.", "Kule"]
+    ],
+    "translation": "Hawwa built a house, and Kule also built a house.",
+    "context": "",
+    "judgment": "marginal",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["particle", "ke"],
+      ["configuration", "parallelMarkedBackground"]
+    ],
+    "comment": "Possible if a temporal shift is accommodated: it is Hawwa that built the house and then Kule built a house.",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Grubic2015.lean
+++ b/Linglib/Data/Examples/Grubic2015.lean
@@ -1,0 +1,666 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Grubic2015` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Grubic2015.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Grubic2015.Examples`.
+-/
+
+namespace Grubic2015.Examples
+
+open Data.Examples
+
+def ex_6_24 : LinguisticExample :=
+  { id := "grubic2015_6_24"
+    source := ⟨"grubic-2015", "(24)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Ne sakatari yak'i."
+    discourseSegments := []
+    glossedTokens := [("Ne", "1SG.DEP"), ("sakatari", "secretary"), ("yak'i.", "only")]
+    translation := "I'm only a secretary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("complement exclusion: I am nothing else in addition", .acceptable), ("rank order: I am nothing better", .acceptable)]
+    paperFeatures := [("particle", "yak"), ("configuration", "predicate")]
+    comment := "Both readings carry a mirative component: more, or something more prestigious, was expected."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_25a : LinguisticExample :=
+  { id := "grubic2015_6_25a"
+    source := ⟨"grubic-2015", "(25a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Dimza yak'i."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Dimza", "Dimza"), ("yak'i.", "only")]
+    translation := "Only Dimza built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "markedSubjectFocus"), ("inference", "Dimza built a house"), ("inference", "nobody else built a house")]
+    comment := "Consultant: Dimza built a house, and nobody else built a house."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_25b : LinguisticExample :=
+  { id := "grubic2015_6_25b"
+    source := ⟨"grubic-2015", "(25b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Dimza yak'i bu."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Dimza", "Dimza"), ("yak'i", "only"), ("bu.", "NEG")]
+    translation := "Not only Dimza built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "markedSubjectFocus"), ("inference", "Dimza built a house"), ("inference", "other people also built a house")]
+    comment := "The exclusive component is asserted; the prejacent projects through negation."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_25c : LinguisticExample :=
+  { id := "grubic2015_6_25c"
+    source := ⟨"grubic-2015", "(25c)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Dimza yak'i ɗo?"
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Dimza", "Dimza"), ("yak'i", "only"), ("ɗo?", "Q")]
+    translation := "Did only Dimza build a house?"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "markedSubjectFocus"), ("inference", "Dimza built a house")]
+    comment := "Consultant: Dimza built a house, and you want to confirm: alone or with other people?"
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_26 : LinguisticExample :=
+  { id := "grubic2015_6_26"
+    source := ⟨"grubic-2015", "(26)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Esha=i Sama yak'i nzono, ke esha Hawwa nzono."
+    discourseSegments := []
+    glossedTokens := [("Esha=i", "call.PFV=BM"), ("Sama", "Sama"), ("yak'i", "only"), ("nzono,", "yesterday"), ("ke", "also"), ("esha", "call.PFV"), ("Hawwa", "Hawwa"), ("nzono.", "yesterday")]
+    translation := "He only called Sama yesterday, and he also called Hawwa yesterday."
+    context := "Who did Njelu call yesterday?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "markedObjectFocus")]
+    comment := "The exclusive component is not cancellable."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_28 : LinguisticExample :=
+  { id := "grubic2015_6_28"
+    source := ⟨"grubic-2015", "(28)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Ne'e yak ne wa ampani yam ki korino bu."
+    discourseSegments := []
+    glossedTokens := [("Ne'e", "1SG"), ("yak", "only"), ("ne", "1SG"), ("wa", "get.PFV"), ("ampani", "harvest"), ("yam", "a.lot"), ("ki", "at"), ("korino", "farm=1SG.POSS"), ("bu.", "NEG")]
+    translation := "I didn't only get a good harvest."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "predicate")]
+    comment := "The mirative component projects: odd because a good harvest is not less than expected."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_140 : LinguisticExample :=
+  { id := "grubic2015_6_140"
+    source := ⟨"grubic-2015", "(140)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kule yak salko bano mano."
+    discourseSegments := []
+    glossedTokens := [("Kule", "Kule"), ("yak", "only"), ("salko", "build.PFV"), ("bano", "house"), ("mano.", "last.year")]
+    translation := "Kule only built a house last year."
+    context := "Kule wanted to build a house and a granary last year."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "unmarkedObjectFocus")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_145a : LinguisticExample :=
+  { id := "grubic2015_6_145a"
+    source := ⟨"grubic-2015", "(145a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "O'o, Kule yak onto agoggo."
+    discourseSegments := []
+    glossedTokens := [("O'o,", "no"), ("Kule", "Kule"), ("yak", "only"), ("onto", "give.PFV.3SG.F"), ("agoggo.", "watch")]
+    translation := "No, Kule only gave a watch to her."
+    context := "Did Kule give a watch to Dimza and Jajei?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "dependentPronoun")]
+    comment := "Reinterpreted with the exclusive associating with the direct object: Jajei is expecting a watch and other things."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_145b : LinguisticExample :=
+  { id := "grubic2015_6_145b"
+    source := ⟨"grubic-2015", "(145b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "O'o, Kule onko agoggo=i ki te yak'i."
+    discourseSegments := []
+    glossedTokens := [("O'o,", "no"), ("Kule", "Kule"), ("onko", "give.PFV"), ("agoggo=i", "watch=BM"), ("ki", "to"), ("te", "3SG.F"), ("yak'i.", "only")]
+    translation := "No, Kule only gave a watch to her."
+    context := "Did Kule give a watch to Dimza and Jajei?"
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "independentPronoun")]
+    comment := "Marginal because it is hard to tell who te refers to without intermediate discussion of Jajei."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_148a : LinguisticExample :=
+  { id := "grubic2015_6_148a"
+    source := ⟨"grubic-2015", "(148a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hawwa=s, ne moishe Daho a esha=i te yak'i."
+    discourseSegments := []
+    glossedTokens := [("Hawwa=s,", "Hawwa=DEF.DET.F"), ("ne", "1SG"), ("moishe", "see.HAB"), ("Daho", "Daho"), ("a", "3SG.HAB"), ("esha=i", "call.HAB=BM"), ("te", "3SG.F"), ("yak'i.", "only")]
+    translation := "Hawwa, I think Daho only calls her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("the only person that Daho calls is Hawwa", .acceptable)]
+    paperFeatures := [("particle", "yak"), ("configuration", "resumptivePronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_148b : LinguisticExample :=
+  { id := "grubic2015_6_148b"
+    source := ⟨"grubic-2015", "(148b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hawwa=s, ne moishe Daho a esha yak'i."
+    discourseSegments := []
+    glossedTokens := [("Hawwa=s,", "Hawwa=DEF.DET.F"), ("ne", "1SG"), ("moishe", "see.HAB"), ("Daho", "Daho"), ("a", "3SG.HAB"), ("esha", "call.HAB"), ("yak'i.", "only")]
+    translation := "Hawwa, I think Daho only calls."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("the only person that Daho calls is Hawwa", .unacceptable), ("Daho does nothing but call", .acceptable)]
+    paperFeatures := [("particle", "yak"), ("configuration", "topicalizedGap")]
+    comment := "The exclusive cannot associate with the moved constituent."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_149 : LinguisticExample :=
+  { id := "grubic2015_6_149"
+    source := ⟨"grubic-2015", "(149)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hawwa=s, ne moishe Daho lei ki tomiya a esha."
+    discourseSegments := []
+    glossedTokens := [("Hawwa=s,", "Hawwa=DEF.DET.F"), ("ne", "1SG"), ("moishe", "see.HAB"), ("Daho", "Daho"), ("lei", "at"), ("ki", "any"), ("tomiya", "time"), ("a", "3SG.HAB"), ("esha.", "call.HAB")]
+    translation := "Hawwa, I think Daho always calls."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("whenever Daho calls somebody, she calls Hawwa", .acceptable)]
+    paperFeatures := [("particle", "leiKiTomiya"), ("configuration", "topicalizedGap")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_150a : LinguisticExample :=
+  { id := "grubic2015_6_150a"
+    source := ⟨"grubic-2015", "(150a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hasha hoti maɗɗi a esha Lakka, Gamba me esha=i te yak'i."
+    discourseSegments := []
+    glossedTokens := [("Hasha", "Hasha"), ("hoti", "day"), ("maɗɗi", "some"), ("a", "3SG.HAB"), ("esha", "call.HAB"), ("Lakka,", "Lakka"), ("Gamba", "Gamba"), ("me", "but"), ("esha=i", "call.HAB=BM"), ("te", "3SG.F"), ("yak'i.", "only")]
+    translation := "Hasha sometimes calls Lakka, and Gambo only calls her."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "focusedPronoun")]
+    comment := "Consultant: he always calls only her, never anybody else."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_150b : LinguisticExample :=
+  { id := "grubic2015_6_150b"
+    source := ⟨"grubic-2015", "(150b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hasha hoti maɗɗi a esha Lakka, Gambo me a esha yak'i."
+    discourseSegments := []
+    glossedTokens := [("Hasha", "Hasha"), ("hoti", "day"), ("maɗɗi", "some"), ("a", "3SG.HAB"), ("esha", "call.HAB"), ("Lakka,", "Lakka"), ("Gambo", "Gamba"), ("me", "but"), ("a", "3SG.HAB"), ("esha", "call.HAB"), ("yak'i.", "only")]
+    translation := "Hasha sometimes calls Lakka, and Gambo only calls her."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "elidedPronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_151 : LinguisticExample :=
+  { id := "grubic2015_6_151"
+    source := ⟨"grubic-2015", "(151)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hasha hoti maɗɗi a esha Lakka, Gambo me lei ki tomiya a esha."
+    discourseSegments := []
+    glossedTokens := [("Hasha", "Hasha"), ("hoti", "day"), ("maɗɗi", "some"), ("a", "3SG.HAB"), ("esha", "call.HAB"), ("Lakka,", "Lakka"), ("Gambo", "Gamba"), ("me", "but"), ("lei", "at"), ("ki", "any"), ("tomiya", "time"), ("a", "3SG.HAB"), ("esha.", "call.HAB")]
+    translation := "Hasha sometimes calls Lakka, and Gambo always does."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "leiKiTomiya"), ("configuration", "elidedPronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_153 : LinguisticExample :=
+  { id := "grubic2015_6_153"
+    source := ⟨"grubic-2015", "(153)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Biya ma maranko shinkafa a tishe yak'i."
+    discourseSegments := []
+    glossedTokens := [("Biya", "people"), ("ma", "REL"), ("maranko", "farm.PL.PFV"), ("shinkafa", "rice"), ("a", "3SG.HAB"), ("tishe", "eat.HAB"), ("yak'i.", "only")]
+    translation := "People that grow rice only eat it."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("they don't sell it or give it out", .acceptable), ("they eat nothing else", .unacceptable)]
+    paperFeatures := [("particle", "yak"), ("configuration", "elidedObject")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_158 : LinguisticExample :=
+  { id := "grubic2015_6_158"
+    source := ⟨"grubic-2015", "(158)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Samaye gitkok tishe=i jarabawa=to yak'i."
+    discourseSegments := []
+    glossedTokens := [("Samaye", "Samaye"), ("gitkok", "be.able.PFV.TOT"), ("tishe=i", "eat.HAB=BM"), ("jarabawa=to", "exam=3SG.F.POSS"), ("yak'i.", "only")]
+    translation := "Samaye only managed to pass her exams."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "presupposition")]
+    comment := "The exclusive does not associate with the presupposition of gitko."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_159 : LinguisticExample :=
+  { id := "grubic2015_6_159"
+    source := ⟨"grubic-2015", "(159)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Samaye lei ki tomiya a gishentik tina=i jarabawa=to."
+    discourseSegments := []
+    glossedTokens := [("Samaye", "Samaye"), ("lei", "at"), ("ki", "any"), ("tomiya", "time"), ("a", "3SG.HAB"), ("gishentik", "be.able.HAB.TOT"), ("tina=i", "eat.FUT=BM"), ("jarabawa=to.", "exam=3SG.F.POSS")]
+    translation := "Samaye always manages to pass her exams."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("whenever she tries, she passes", .acceptable)]
+    paperFeatures := [("particle", "leiKiTomiya"), ("configuration", "presupposition")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_160 : LinguisticExample :=
+  { id := "grubic2015_6_160"
+    source := ⟨"grubic-2015", "(160)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Si onko agoggo=i ki Shuwa, si ke ono."
+    discourseSegments := []
+    glossedTokens := [("Si", "3SG.M"), ("onko", "give.PFV"), ("agoggo=i", "watch=BM"), ("ki", "to"), ("Shuwa,", "Shuwa"), ("si", "3SG.M"), ("ke", "also"), ("ono.", "give.1SG.DEP")]
+    translation := "He gave a watch to Shuwa, and he also gave it to me."
+    context := "Whom did Kule give a watch?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "dependentPronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_162a : LinguisticExample :=
+  { id := "grubic2015_6_162a"
+    source := ⟨"grubic-2015", "(162a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kule esha=i Dimza, ke esha=i ne'e."
+    discourseSegments := []
+    glossedTokens := [("Kule", "Kule"), ("esha=i", "call.PFV=BM"), ("Dimza,", "Dimza"), ("ke", "also"), ("esha=i", "call.PFV=BM"), ("ne'e.", "1SG")]
+    translation := "Kule called Dimza and he also called me."
+    context := "Whom did Kule call?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "independentPronoun")]
+    comment := "Rejected in favour of a dependent pronoun with a totality-extended verb."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_162b : LinguisticExample :=
+  { id := "grubic2015_6_162b"
+    source := ⟨"grubic-2015", "(162b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kule esha=i Dimza ke eshino."
+    discourseSegments := []
+    glossedTokens := [("Kule", "Kule"), ("esha=i", "call.PFV=BM"), ("Dimza", "Dimza"), ("ke", "also"), ("eshino.", "call.PFV.TOT.1SG")]
+    translation := "Kule called Dimza and he also called me."
+    context := "Whom did Kule call?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "dependentPronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_163 : LinguisticExample :=
+  { id := "grubic2015_6_163"
+    source := ⟨"grubic-2015", "(163)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Ke salko bano."
+    discourseSegments := []
+    glossedTokens := [("Ke", "also"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "He also built a house."
+    context := "I know that Hawwa built a house, but what about Kule? What did he build?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "elidedTopicalSubject")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_164 : LinguisticExample :=
+  { id := "grubic2015_6_164"
+    source := ⟨"grubic-2015", "(164)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kule onko agoggo=i ki Shuwa, ke har ono."
+    discourseSegments := []
+    glossedTokens := [("Kule", "Kule"), ("onko", "give.PFV"), ("agoggo=i", "watch=BM"), ("ki", "to"), ("Shuwa,", "Shuwa"), ("ke", "and"), ("har", "even"), ("ono.", "give.PFV.1SG.DEP")]
+    translation := "Kule gave a watch to Shuwa, and he even gave one to me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "har"), ("configuration", "dependentPronoun")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_165 : LinguisticExample :=
+  { id := "grubic2015_6_165"
+    source := ⟨"grubic-2015", "(165)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Hawwa salko bano, Kule ke salko bano."
+    discourseSegments := []
+    glossedTokens := [("Hawwa", "Hawwa"), ("salko", "build.PFV"), ("bano,", "house"), ("Kule", "Kule"), ("ke", "also"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "Hawwa built a house, and Kule also built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "preverbalSubject")]
+    comment := "Preverbal subjects are out of focus, which the exclusive cannot associate with."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_166 : LinguisticExample :=
+  { id := "grubic2015_6_166"
+    source := ⟨"grubic-2015", "(166)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Dimza yak salko bano."
+    discourseSegments := []
+    glossedTokens := [("Dimza", "Dimza"), ("yak", "only"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "Dimza only built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "unmarkedObjectFocus"), ("inference", "Dimza didn't build anything else"), ("inference", "he was expected to build more"), ("inference", "Dimza built a house")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_167 : LinguisticExample :=
+  { id := "grubic2015_6_167"
+    source := ⟨"grubic-2015", "(167)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Dimza ke salko bano."
+    discourseSegments := []
+    glossedTokens := [("Dimza", "Dimza"), ("ke", "also"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "Dimza also built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "unmarkedObjectFocus"), ("inference", "Dimza built a house"), ("inference", "Dimza built something else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_168 : LinguisticExample :=
+  { id := "grubic2015_6_168"
+    source := ⟨"grubic-2015", "(168)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Dimza har salko bano."
+    discourseSegments := []
+    glossedTokens := [("Dimza", "Dimza"), ("har", "even"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "Dimza even built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "har"), ("configuration", "unmarkedObjectFocus"), ("inference", "Dimza built a house"), ("inference", "he was expected to build less"), ("inference", "Dimza built something else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_169 : LinguisticExample :=
+  { id := "grubic2015_6_169"
+    source := ⟨"grubic-2015", "(169)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Ne sakatari yak'i."
+    discourseSegments := []
+    glossedTokens := [("Ne", "1SG"), ("sakatari", "secretary"), ("yak'i.", "only")]
+    translation := "I'm only a secretary."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "yak"), ("configuration", "predicate"), ("inference", "the speaker is nothing better than a secretary"), ("inference", "the speaker was expected to be something better")]
+    comment := "A rank-order scale: the prejacent inference does not survive negation."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_6_170 : LinguisticExample :=
+  { id := "grubic2015_6_170"
+    source := ⟨"grubic-2015", "(170)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Bah malum har'i."
+    discourseSegments := []
+    glossedTokens := [("Bah", "Bah"), ("malum", "teacher"), ("har'i.", "even")]
+    translation := "Bah is even a teacher."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "har"), ("configuration", "predicate"), ("inference", "Bah is a teacher"), ("inference", "he was expected to be something worse")]
+    comment := "A rank-order scale: no additive inference."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_41 : LinguisticExample :=
+  { id := "grubic2015_7_41"
+    source := ⟨"grubic-2015", "(41)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kaja mato=i Hawwa, salko bano=i ke Kule."
+    discourseSegments := []
+    glossedTokens := [("Kaja", "buy.PFV"), ("mato=i", "car=BM"), ("Hawwa,", "Hawwa"), ("salko", "build.PFV"), ("bano=i", "house=BM"), ("ke", "also"), ("Kule.", "Kule")]
+    translation := "Hawwa bought a car, Kule built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "distinctBackgroundDistinctFocus")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_42 : LinguisticExample :=
+  { id := "grubic2015_7_42"
+    source := ⟨"grubic-2015", "(42)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Kule, kaja mato=i ke Kule."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Kule,", "Kule"), ("kaja", "buy.PFV"), ("mato=i", "car=BM"), ("ke", "also"), ("Kule.", "Kule")]
+    translation := "Kule built a house, and Kule also bought a car."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "distinctBackgroundParallelFocus")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_43 : LinguisticExample :=
+  { id := "grubic2015_7_43"
+    source := ⟨"grubic-2015", "(43)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kule salko makaranta mano, Kule ke salko bano mano."
+    discourseSegments := []
+    glossedTokens := [("Kule", "Kule"), ("salko", "build.PFV"), ("makaranta", "school"), ("mano,", "last.year"), ("Kule", "Kule"), ("ke", "also"), ("salko", "build.PFV"), ("bano", "house"), ("mano.", "last.year")]
+    translation := "Kule built a school last year, and Kule also built a house last year."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "parallelUnmarkedBackground")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_44 : LinguisticExample :=
+  { id := "grubic2015_7_44"
+    source := ⟨"grubic-2015", "(44)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Hawwa, salko bano=i ke Kule."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Hawwa,", "Hawwa"), ("salko", "build.PFV"), ("bano=i", "house=BM"), ("ke", "also"), ("Kule.", "Kule")]
+    translation := "Hawwa built a house, and Kule built a house, too."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "parallelMarkedBackground")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_46 : LinguisticExample :=
+  { id := "grubic2015_7_46"
+    source := ⟨"grubic-2015", "(46)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Bei a ina ham ɗoshi, ke a ina ham tuha ke'e."
+    discourseSegments := []
+    glossedTokens := [("Bei", "maybe"), ("a", "3SG"), ("ina", "do.FUT"), ("ham", "water"), ("ɗoshi,", "tomorrow"), ("ke", "and"), ("a", "3SG"), ("ina", "do.FUT"), ("ham", "water"), ("tuha", "day.after.tomorrow"), ("ke'e.", "also")]
+    translation := "It is possible that it will rain tomorrow, and it will also rain the day after tomorrow."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "modalizedAntecedent")]
+    comment := "The antecedent is merely given, not asserted to be true."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_48 : LinguisticExample :=
+  { id := "grubic2015_7_48"
+    source := ⟨"grubic-2015", "(48)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Hawwa, Kule ke salko bano."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Hawwa,", "Hawwa"), ("Kule", "Kule"), ("ke", "also"), ("salko", "build.PFV"), ("bano.", "house")]
+    translation := "Hawwa built a house and Kule also built a house."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "nonParallel")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_7_49 : LinguisticExample :=
+  { id := "grubic2015_7_49"
+    source := ⟨"grubic-2015", "(49)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Salko bano=i Hawwa, ke salko bano=i ke Kule."
+    discourseSegments := []
+    glossedTokens := [("Salko", "build.PFV"), ("bano=i", "house=BM"), ("Hawwa,", "Hawwa"), ("ke", "also"), ("salko", "build.PFV"), ("bano=i", "house=BM"), ("ke", "also"), ("Kule.", "Kule")]
+    translation := "Hawwa built a house, and Kule also built a house."
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "ke"), ("configuration", "parallelMarkedBackground")]
+    comment := "Possible if a temporal shift is accommodated: it is Hawwa that built the house and then Kule built a house."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [ex_6_24, ex_6_25a, ex_6_25b, ex_6_25c, ex_6_26, ex_6_28, ex_6_140, ex_6_145a, ex_6_145b, ex_6_148a, ex_6_148b, ex_6_149, ex_6_150a, ex_6_150b, ex_6_151, ex_6_153, ex_6_158, ex_6_159, ex_6_160, ex_6_162a, ex_6_162b, ex_6_163, ex_6_164, ex_6_165, ex_6_166, ex_6_167, ex_6_168, ex_6_169, ex_6_170, ex_7_41, ex_7_42, ex_7_43, ex_7_44, ex_7_46, ex_7_48, ex_7_49]
+
+end Grubic2015.Examples

--- a/Linglib/Studies/Grubic2015.lean
+++ b/Linglib/Studies/Grubic2015.lean
@@ -5,161 +5,126 @@ Authors: Robert Hawkins
 -/
 import Linglib.Semantics.Focus.Control
 import Linglib.Pragmatics.Expressives.Basic
+import Linglib.Data.Examples.Grubic2015
+import Mathlib.Data.Set.Lattice
 
 /-!
-# Alternative-sensitive particles in Ngamo
+# Grubic (2015): Focus and Alternative Sensitivity in Ngamo
 
-Formalises [grubic-2015] Ch. 6–7: the Ngamo particles *yak('i)*
-'only', *ke('e)* 'also', and *har('i)* 'even' in a Beaver &
-Clark-style QUD account. *yak(p)* presupposes *at least p* and
-asserts *at most p* over entailment-ranked alternatives (the Coppock
-& Beaver decomposition); *ke(p)* presupposes a given alternative
-about a different topic situation; *har(p)* presupposes a contextual
-implication of *p* ranked high on a salient scale (kept as prose).
+This file formalizes the question-under-discussion analysis of the Ngamo alternative-sensitive
+particles in chapter 7 of [grubic-2015], "Focus and alternative sensitivity in Ngamo
+(West-Chadic)", against the data of chapter 6, rows of `Data.Examples.Grubic2015`. The
+exclusive *yak('i)* has the entry (2) of [coppock-beaver-2014]'s exclusives: it presupposes
+that some alternative at least as strong as the prejacent on a salient scale is true and asserts
+that no true alternative is stronger (`yak`). On an entailment scale, the complement-exclusion
+reading of section 6.1.1, the presupposition entails the prejacent, which therefore projects
+through negation as in (29) (`prejacent_projects`), and over the conjunctions of independent
+atomic answers, the lattice of (11), the total content is the prejacent with every other atom
+false, the exclusive inference of (166) (`total_yak`). The additive *ke('e)* has no
+truth-conditional content and presupposes a salient antecedent about a different topic
+situation, (45), one that need not be true, (46), and one that parallel background-marked
+antecedents, being anaphoric, cannot supply, (44) and (49) (`ke_undefined_of_anaphoric`). The
+scalar *har('i)* asserts its prejacent and presupposes that a contextual implication of it, in
+the sense of (18), ranks highest among its alternatives, (17) (`har`).
 
-`yak_eq_prejacent_inter_onlyVia` reconciles the scalar and identity
-formulations of exclusivity: over the conjunction-closure of the
-atomic alternatives, *yak*'s total content (presupposition plus
-assertion) coincides with the prejacent exhaustified by the
-strong-theory `onlyVia` over the atoms — the Kiss-style
-identificational meaning derived from the scalar decomposition.
+## Implementation notes
 
-Distribution (her (10)–(12)): *yak* cannot associate with preverbal
-subjects but is fine in any focus construction; *ke/har* associate
-with preverbal subjects but are marginal with `=i/ye`-marked focus
-under parallel backgrounds — data recorded in `distribution`.
+The scale is a relation `S q p` read as `q` at least as strong as `p`, the entailment scale
+being `(· ⊆ ·)`; the VP and NP variants (5) and (6), which reach the propositional entry by the
+Geach rule, are not repeated. Topic situations are abstracted to a map from answers to a type
+of situations, so that the non-overlap of (45) is distinctness. The association facts of
+section 6.2, on which *yak('i)* alone associates with focus conventionally, are data rows and
+not theorems.
+
+## References
+
+* [grubic-2015]
+* [coppock-beaver-2014]
+* [beaver-clark-2008]
 -/
 
 namespace Grubic2015
 
-open Pragmatics.Expressives (TwoDimProp)
-open Focus (onlyVia)
+open Pragmatics.Expressives Focus
 
-variable {W : Type*}
+variable {W T : Type*} (S : Set W → Set W → Prop) (C : Set (Set W)) (p : Set W)
 
-/-! ## The Coppock & Beaver decomposition (Ch. 7) -/
+/-! ### The exclusive *yak('i)*, section 7.1 -/
 
-/-- *At least p*: some alternative at least as strong as the prejacent
-holds — *yak*'s presupposition. -/
-def atLeast (C : Set (Set W)) (p : Set W) : Set W :=
-  {w | ∃ q ∈ C, q ⊆ p ∧ w ∈ q}
+/-- (2i): some alternative at least as strong as the prejacent is true, the presupposition of
+*yak('i)*. -/
+def atLeast : Set W := {w | ∃ q ∈ C, w ∈ q ∧ S q p}
 
-/-- *At most p*: no alternative strictly stronger than the prejacent
-holds — *yak*'s assertion. -/
-def atMost (C : Set (Set W)) (p : Set W) : Set W :=
-  {w | ∀ q ∈ C, w ∈ q → ¬ q ⊂ p}
+/-- (2ii): no true alternative is stronger than the prejacent, the assertion of *yak('i)*. -/
+def atMost : Set W := {w | ∀ q ∈ C, w ∈ q → S p q}
 
-/-- *yak('i)* 'only': presupposes at least `p`, asserts at most `p`
-(her Ch. 7, following Coppock & Beaver's *only*). -/
-def yak (C : Set (Set W)) (p : Set W) : TwoDimProp W :=
-  .withCI (· ∈ atMost C p) (· ∈ atLeast C p)
+/-- *yak('i)* 'only', the propositional entry (2). -/
+def yak : TwoDimProp W := .withCI (· ∈ atMost S C p) (· ∈ atLeast S C p)
 
-/-- *ke('e)* 'also': presupposes that a distinct alternative is given
-(her Ch. 7; the different-topic-situation refinement is prose). -/
-def ke (given : Set (Set W)) (p : Set W) : TwoDimProp W :=
-  .withCI (· ∈ p) (fun w => ∃ q ∈ given, q ≠ p ∧ w ∈ q)
-
-/-- The total content of a two-dimensional meaning: at-issue plus
-presupposed. -/
+/-- The total content of a two-dimensional meaning, at-issue and presupposed together. -/
 def total (m : TwoDimProp W) : Set W := {w | m.atIssue w ∧ m.ci w}
 
-/-! ## Reconciling the scalar and identity formulations
+/-- On an entailment scale the presupposition entails the prejacent. -/
+theorem atLeast_subset : atLeast (· ⊆ ·) C p ⊆ p := λ _ ⟨_, _, hw, hq⟩ => hq hw
 
-On the building scenario (her (10)–(11)): worlds track which of the
-house and the granary Kule built. -/
+/-- (29): negation leaves the presupposition in place, so *not only Dimza built a house* still
+has Dimza building a house; on a rank-order scale, where alternatives need not entail the
+prejacent, nothing of the kind follows. -/
+theorem prejacent_projects {w : W} (h : (yak (· ⊆ ·) C p).neg.ci w) : w ∈ p :=
+  atLeast_subset C p h
 
-/-- Who-built-what worlds. -/
-structure BuildWorld where
-  house   : Bool
-  granary : Bool
-  deriving DecidableEq, Repr
+/-- The answers of (11): the nonempty conjunctions of a set of atomic answers. -/
+def conjunctions (atoms : Set (Set W)) : Set (Set W) :=
+  {q | ∃ A ⊆ atoms, A.Nonempty ∧ q = ⋂₀ A}
 
-def builtHouse : Set BuildWorld := {w | w.house}
-def builtGranary : Set BuildWorld := {w | w.granary}
-def builtBoth : Set BuildWorld := builtHouse ∩ builtGranary
-
-/-- The atomic alternatives. -/
-def atoms : Set (Set BuildWorld) := {builtHouse, builtGranary}
-
-/-- The QUD's answer space: the atoms and their conjunction. -/
-def answers : Set (Set BuildWorld) := {builtHouse, builtGranary, builtBoth}
-
-private theorem builtGranary_ne_builtHouse : builtGranary ≠ builtHouse := by
-  intro h
-  have hmem : (⟨false, true⟩ : BuildWorld) ∈ builtGranary := rfl
-  rw [h] at hmem
-  exact absurd hmem Bool.false_ne_true
-
-private theorem builtBoth_ssubset : builtBoth ⊂ builtHouse := by
-  constructor
-  · exact Set.inter_subset_left
-  · intro h
-    have hmem : (⟨true, false⟩ : BuildWorld) ∈ builtBoth :=
-      h (show (⟨true, false⟩ : BuildWorld) ∈ builtHouse from rfl)
-    exact absurd hmem.2 Bool.false_ne_true
-
-/-- The scalar and identity formulations coincide: *yak*'s total
-content over the conjunction-closed answer space equals the prejacent
-exhaustified by `onlyVia` over the atoms — the Kiss-style
-identificational meaning ('built the house and nothing else') derived
-from the at-least/at-most decomposition. -/
-theorem yak_eq_prejacent_inter_onlyVia :
-    total (yak answers builtHouse) =
-      builtHouse ∩ onlyVia atoms builtHouse := by
+/-- (166) and (25): over the conjunctions of independent atomic answers, the total content of
+*yak('i)* on the entailment scale is the prejacent with no other atom true, the exclusive
+inference in the form of the library's `Focus.onlyVia`. -/
+theorem total_yak {atoms : Set (Set W)} (hp : p ∈ atoms) (hind : ∀ q ∈ atoms, p ⊆ q → q = p) :
+    total (yak (· ⊆ ·) (conjunctions atoms) p) = p ∩ onlyVia atoms p := by
   ext w
   constructor
-  · rintro ⟨hmost, q, hq, hsub, hwq⟩
-    have hp : w ∈ builtHouse := hsub hwq
-    refine ⟨hp, fun r hr hwr => ?_⟩
-    rcases hr with rfl | rfl
-    · rfl
-    · exact absurd builtBoth_ssubset
-        (hmost builtBoth (Or.inr (Or.inr rfl)) ⟨hp, hwr⟩)
-  · rintro ⟨hp, honly⟩
-    refine ⟨fun q hq hwq hlt => ?_, builtHouse, Or.inl rfl, subset_rfl, hp⟩
-    rcases hq with rfl | rfl | rfl
-    · exact absurd rfl hlt.ne
-    · exact absurd (honly builtGranary (Or.inr rfl) hwq)
-        builtGranary_ne_builtHouse
-    · exact absurd (honly builtGranary (Or.inr rfl) hwq.2)
-        builtGranary_ne_builtHouse
+  · rintro ⟨hmost, _, ⟨A, hA, -, rfl⟩, hw, hq⟩
+    refine ⟨hq hw, λ r hr hwr => hind r hr λ x hx => ?_⟩
+    exact (hmost (p ∩ r) ⟨{p, r}, by simp [Set.insert_subset_iff, hp, hr], by simp, by simp⟩
+      ⟨hq hw, hwr⟩ hx).2
+  · rintro ⟨hw, honly⟩
+    refine ⟨?_, p, ⟨{p}, by simpa, Set.singleton_nonempty p, (Set.sInter_singleton p).symm⟩, hw,
+      subset_rfl⟩
+    rintro q ⟨A, hA, -, rfl⟩ hwq x hx
+    refine Set.mem_sInter.mpr λ a ha => ?_
+    rw [honly a (hA ha) (Set.mem_sInter.mp hwq a ha)]
+    exact hx
 
-/-- *ke*'s additive presupposition needs a distinct given alternative:
-with only the prejacent given, the presupposition fails everywhere —
-the anaphoricity behind her (12) parallel-background facts. -/
-theorem ke_needs_distinct_antecedent :
-    ∀ w, ¬ (ke {builtHouse} builtHouse).ci w :=
-  fun _ ⟨_, hq, hne, _⟩ => hne hq
+/-! ### The additive *ke('e)*, section 7.3 -/
 
-/-! ## Distribution (her (10)–(12)) -/
+/-- *ke('e)* 'also', (45): no truth-conditional contribution, and the presupposition of a salient
+antecedent about a different topic situation, one that need not itself be true, (46). -/
+def ke (given : Set (Set W)) (topic : Set W → T) : TwoDimProp W :=
+  .withCI (· ∈ p) (λ _ => ∃ q ∈ given, topic q ≠ topic p)
 
-/-- The particles. -/
-inductive Particle where
-  | yak | ke | har
-  deriving DecidableEq, Repr
+/-- (44) and (49): when every salient antecedent is anaphoric to the host's topic situation, as
+parallel background-marked antecedents are by default, *ke('e)* is undefined. -/
+theorem ke_undefined_of_anaphoric {given : Set (Set W)} {topic : Set W → T}
+    (h : ∀ q ∈ given, topic q = topic p) (w : W) : ¬ (ke p given topic).ci w :=
+  λ ⟨q, hq, hne⟩ => hne (h q hq)
 
-/-- The association configurations tested. -/
-inductive Host where
-  | preverbalSubject
-  | bmMarkedFocus
-  | plainFocus
-  deriving DecidableEq, Repr
+/-! ### The scalar *har('i)*, section 7.2 -/
 
-/-- Her (10)–(11) acceptability table: *yak* cannot associate with
-preverbal subjects; *ke/har* are marginal with `=i/ye`-marked focus
-(under parallel backgrounds — the (12) exception is prose). -/
-def acceptable : Particle → Host → Bool
-  | .yak, .preverbalSubject => false
-  | .yak, _                 => true
-  | _,    .bmMarkedFocus    => false
-  | _,    _                 => true
+/-- A contextual implication, (18): entailed by the common ground updated with the prejacent
+but not by the common ground alone. -/
+def CImpl (CG q : Set W) : Prop := ¬ CG ⊆ q ∧ CG ∩ p ⊆ q
 
-/-- No particle-host uniformity: the two asymmetries cross-cut —
-association possibilities do not follow from the particle or the
-host alone. -/
-theorem association_crosscuts :
-    acceptable .yak .bmMarkedFocus ≠ acceptable .ke .bmMarkedFocus ∧
-    acceptable .yak .preverbalSubject ≠ acceptable .ke .preverbalSubject := by
-  decide
+/-- *har('i)* 'even', (17): asserts the prejacent and presupposes that some contextual
+implication of it ranks highest among its alternatives on the salient scale. -/
+def har (CG : Set W) (alt : Set W → Set (Set W)) : TwoDimProp W :=
+  .withCI (· ∈ p) (λ w => ∃ q, CImpl p CG q ∧ ∀ q' ∈ alt q, w ∈ q' → S q q')
+
+/-- At a world of the common ground where the prejacent holds, the implication *har('i)*
+presupposes holds as well, so the scale is anchored by a true alternative. -/
+theorem har_impl_holds {CG : Set W} {alt : Set W → Set (Set W)} {w : W} (hw : w ∈ CG)
+    (hp : w ∈ p) (h : (har S p CG alt).ci w) : ∃ q, CImpl p CG q ∧ w ∈ q :=
+  let ⟨q, hq, _⟩ := h
+  ⟨q, hq, hq.2 ⟨hw, hp⟩⟩
 
 end Grubic2015

--- a/references.bib
+++ b/references.bib
@@ -11248,7 +11248,7 @@
   isbn      = {9781405112635},
   subfield  = {semantics/focus},
   role      = {cited},
-  sources   = {Data/Examples/DeoThomas2025.json;Data/Examples/Thomas2026.json;Studies/DeoThomas2025.lean;Studies/Thomas2026.lean}
+  sources   = {Data/Examples/DeoThomas2025.json;Data/Examples/Thomas2026.json;Studies/DeoThomas2025.lean;Studies/Grubic2015.lean;Studies/Thomas2026.lean}
 }
 @article{selkirk-2008,
   author    = {Selkirk, Elisabeth},
@@ -14923,7 +14923,7 @@
   subfield  = {semantics/lexical},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/DeoThomas2025.lean}
+  sources   = {Studies/DeoThomas2025.lean;Studies/Grubic2015.lean}
 }% REF: Burnett, H. (2017). Gradability in Natural Language.
 @book{burnett-2017,
   author    = {Burnett, Heather},
@@ -41651,7 +41651,7 @@
   school    = {Universit{\"a}t Potsdam},
   subfield  = {semantics},
   role      = {formalized},
-  sources   = {Studies/Grubic2015.lean}
+  sources   = {Data/Examples/Grubic2015.json;Studies/Grubic2015.lean}
 % REF: Grubic, Renans & Duah (2019). Focus, exhaustivity and existence in Akan, Ga and Ngamo. Linguistics 57(1):221-268.
 @article{grubic-renans-duah-2019,
   author    = {Grubic, Mira and Renans, Agata and Duah, Reginald Akuoko},
@@ -41664,7 +41664,7 @@
   doi       = {10.1515/ling-2018-0035},
   subfield  = {semantics},
   role      = {formalized},
-  sources   = {Data/Examples/GrubicRenansDuah2019.json;Studies/GrubicRenansDuah2019.lean}
+  sources   = {Data/Examples/Grubic2015.json;Studies/Grubic2015.lean}
 }
 
 % REF: Assmann, Büring, Jordanoska & Prüller (2023). Towards a theory of morphosyntactic focus marking. NLLT 41:1349-1396.


### PR DESCRIPTION
Deep cleanse of Grubic2015 against the dissertation (the Potsdam OA PDF): the three particle entries of chapter 7 stated as the paper states them, the chapter 6 data as rows.

- `yak` is Coppock and Beaver's exclusive (2) over a scale relation, with `atMost` corrected to the paper's (2ii) (every true alternative is at most as strong as the prejacent, not merely not strictly stronger); `prejacent_projects` is the projection of the prejacent through negation on entailment scales, (29), and `total_yak` the exclusive inference of (166)/(25) over the conjunctions of independent atoms, the lattice of (11), now a general theorem rather than a two-atom toy model. `ke` is (45) with topic situations abstracted and no truth requirement on the antecedent, (46), and `ke_undefined_of_anaphoric` is the (44)/(49) marginality; `har` is (17)/(18), previously prose.
- New `Data/Examples/Grubic2015.json` (36 glossed rows: the association tests of section 6.2, the meaning-component examples (24) to (28) and (166) to (170), and the antecedent configurations (41) to (49) of section 7.3).
- Cut: the `Bool` acceptability table `acceptable` and its `decide` theorem `association_crosscuts`, which sat on the wrong locator ((10) to (12) are the derivation and scale diagrams of section 7.1, not a distribution table); header rewritten in register.
