### PR TITLE
refactor(Studies/GrubicRenansDuah2019): the conditional presupposition

### DIFF
--- a/Linglib/Data/Examples/GrubicRenansDuah2019.json
+++ b/Linglib/Data/Examples/GrubicRenansDuah2019.json
@@ -1,0 +1,907 @@
+[
+  {
+    "id": "grubicrenansduah2019_36a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(36a)"},
+    "language": "ngam1282",
+    "primaryText": "Njèlù èshà=i Sàmá bù nzònò, ke èshá Hàwwâ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Njèlù", "Njelu"], ["èshà=i", "call.PFV=BM"], ["Sàmá", "Sama"], ["bù", "NEG"],
+      ["nzònò,", "yesterday"], ["ke", "also"], ["èshá", "call.PFV"], ["Hàwwâ.", "Hawwa"]
+    ],
+    "translation": "Njelu didn't phone Sama yesterday. He also phoned Hawwa.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "Negation targets the prejacent, so the additive particle lacks its antecedent.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_36b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(36b)"},
+    "language": "ngam1282",
+    "primaryText": "Njèlù èshà=i Sàmá yàk'i bù nzònò, ke èshá Hàwwâ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Njèlù", "Njelu"], ["èshà=i", "call.PFV=BM"], ["Sàmá", "Sama"], ["yàk'i", "only"],
+      ["bù", "NEG"], ["nzònò,", "yesterday"], ["ke", "also"], ["èshá", "call.PFV"],
+      ["Hàwwâ.", "Hawwa"]
+    ],
+    "translation": "Njelu didn't only phone Sama yesterday. He also phoned Hawwa.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_37a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(37a)"},
+    "language": "gaaa1244",
+    "primaryText": "Jèèè Fred nì è-fɔ̀ nìnè è-tsɛ́. È-tsɛ́ Gord hú.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jèèè", "NEG"], ["Fred", "Fred"], ["nì", "PRT"], ["è-fɔ̀", "3SG-throw"], ["nìnè", "hand"],
+      ["è-tsɛ́.", "3SG-call"], ["È-tsɛ́", "3SG-call"], ["Gord", "Gord"], ["hú.", "also"]
+    ],
+    "translation": "It wasn't Fred she invited. She also invited Gord.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_37b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(37b)"},
+    "language": "gaaa1244",
+    "primaryText": "Jèèè Fred pɛ́ è-fɔ̀ nìnè è-tsɛ́. È-tsɛ́ Gord hú.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jèèè", "NEG"], ["Fred", "Fred"], ["pɛ́", "only"], ["è-fɔ̀", "3SG-throw"], ["nìnè", "hand"],
+      ["è-tsɛ́.", "3SG-call"], ["È-tsɛ́", "3SG-call"], ["Gord", "Gord"], ["hú.", "also"]
+    ],
+    "translation": "She didn't only invite Fred. She also invited Gord.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_38a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(38a)"},
+    "language": "akan1250",
+    "primaryText": "Ɛ̀-ǹ-yɛ́ m̀pàbòá nà Owura tɔ́-ɔ̀èɛ́, ɔ̀-tɔ̀-ɔ̀ wɔ́kyè ńsó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ɛ̀-ǹ-yɛ́", "3SG.INA-NEG-be"], ["m̀pàbòá", "shoes"], ["nà", "PRT"], ["Owura", "Owura"],
+      ["tɔ́-ɔ̀èɛ́,", "buy-COMPL"], ["ɔ̀-tɔ̀-ɔ̀", "3SG-buy-COMPL"], ["wɔ́kyè", "watch"],
+      ["ńsó.", "too"]
+    ],
+    "translation": "It was not shoes that Owura bought, he also bought a watch.",
+    "context": "",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_38b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(38b)"},
+    "language": "akan1250",
+    "primaryText": "Arko á-ǹ-tɔ́ àsòmàdéɛ́ ńkóáá ɔ̀-tɔ̀-ɔ̀ àhwènéɛ́ ńsó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Arko", "Arko"], ["á-ǹ-tɔ́", "COMPL-NEG-buy"], ["àsòmàdéɛ́", "earrings"], ["ńkóáá", "only"],
+      ["ɔ̀-tɔ̀-ɔ̀", "3SG-buy-COMPL"], ["àhwènéɛ́", "beads"], ["ńsó.", "too"]
+    ],
+    "translation": "Arko did not buy only earrings, she bought beads too.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "negationAlso"]
+    ],
+    "comment": "Duah (2015: 18).",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_39a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(39a)"},
+    "language": "ngam1282",
+    "primaryText": "kìkà tùkò=ì Kúlè yàk'î",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kìkà", "because"], ["tùkò=ì", "eat.PFV=BM"], ["Kúlè", "Kule"], ["yàk'î", "only"]
+    ],
+    "translation": "because only Kule passed.",
+    "context": "The teacher had to repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: he doesn't want the other students to fail.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_39b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(39b)"},
+    "language": "ngam1282",
+    "primaryText": "kìkà tùkò=ì Kúlè",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kìkà", "because"], ["tùkò=ì", "eat.PFV=BM"], ["Kúlè", "Kule"]
+    ],
+    "translation": "because Kule passed",
+    "context": "The teacher had to repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: he doesn't want Kule to pass. The exhaustive inference is not the reason.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_40a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(40a)"},
+    "language": "gaaa1244",
+    "primaryText": "éjàáké Kòfí pɛ́ páásí",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["éjàáké", "because"], ["Kòfí", "Kofi"], ["pɛ́", "only"], ["páásí", "pass"]
+    ],
+    "translation": "because only Kofi passed",
+    "context": "The teacher will repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: the teacher wants everybody to pass, so he will repeat the exam.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_40b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(40b)"},
+    "language": "gaaa1244",
+    "primaryText": "éjàáké Kòfí nì páásí",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["éjàáké", "because"], ["Kòfí", "Kofi"], ["nì", "PRT"], ["páásí", "pass"]
+    ],
+    "translation": "because it was Kofi who passed",
+    "context": "The teacher will repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: the teacher didn't want Kofi to pass, so he will repeat the exam.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_41a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(41a)"},
+    "language": "akan1250",
+    "primaryText": "èfisɛ́ Yaw ǹkóáá nà ɔ̀-twá-à ǹsɔ́hwɛ́ nó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["èfisɛ́", "because"], ["Yaw", "Yaw"], ["ǹkóáá", "only"], ["nà", "PRT"],
+      ["ɔ̀-twá-à", "3SG.SBJ-pass-COMPL"], ["ǹsɔ́hwɛ́", "exam"], ["nó.", "DET"]
+    ],
+    "translation": "because only Yaw passed the exam",
+    "context": "The teacher will repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "only"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: the teacher wants everybody to pass, and since Yaw is the only one who passed, the teacher will repeat the exam.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_41b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(41b)"},
+    "language": "akan1250",
+    "primaryText": "èfisɛ́ Yaw nà ɔ̀-twá-à ǹsɔ́hwɛ́ nó",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["èfisɛ́", "because"], ["Yaw", "Yaw"], ["nà", "PRT"], ["ɔ̀-twá-à", "3SG.SBJ-pass"],
+      ["ǹsɔ́hwɛ́", "exam"], ["nó", "DET"]
+    ],
+    "translation": "because it was Yaw who passed the exam",
+    "context": "The teacher will repeat the exam,",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "reasonClause"]
+    ],
+    "comment": "Consultant: the teacher doesn't want Yaw to pass the exam, so he will repeat the exam.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_42",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(42)"},
+    "language": "ngam1282",
+    "primaryText": "Kàjà=i fárì kì gárgù, kè kàjà àyàbà.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kàjà=i", "buy.PFV=BM"], ["fárì", "watermelon"], ["kì", "at"], ["gárgù,", "village"],
+      ["kè", "also"], ["kàjà", "buy.PFV"], ["àyàbà.", "banana"]
+    ],
+    "translation": "She bought a watermelon in the village, and she also bought a banana.",
+    "context": "What did Burba buy in the village?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_43a1",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(43A1)"},
+    "language": "gaaa1244",
+    "primaryText": "Bàǹkú nì Kòfí yè nyɛ̀. Nì àmádàá hú Kòfí yè nyɛ̀.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Bàǹkú", "Banku"], ["nì", "PRT"], ["Kòfí", "Kofi"], ["yè", "eat"], ["nyɛ̀.", "yesterday"],
+      ["Nì", "and"], ["àmádàá", "plantain"], ["hú", "also"], ["Kòfí", "Kofi"], ["yè", "eat"],
+      ["nyɛ̀.", "yesterday"]
+    ],
+    "translation": "It was banku that Kofi ate yesterday. And he also ate plantain yesterday.",
+    "context": "What did Kofi eat yesterday?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_43a2",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(43A2)"},
+    "language": "gaaa1244",
+    "primaryText": "Kòfí yè bàǹkú nyɛ̀. Nì Kòfí yé àmádàá hú nyɛ̀.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kòfí", "Kofi"], ["yè", "eat"], ["bàǹkú", "banku"], ["nyɛ̀.", "yesterday"], ["Nì", "and"],
+      ["Kòfí", "Kofi"], ["yé", "eat"], ["àmádàá", "plantain"], ["hú", "also"],
+      ["nyɛ̀.", "yesterday"]
+    ],
+    "translation": "Kofi ate banku yesterday. And Kofi ate also plantain yesterday.",
+    "context": "What did Kofi eat yesterday?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_44a1",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(44A1)"},
+    "language": "akan1250",
+    "primaryText": "Àtààdéɛ́ nà mè-tɔ́-ɔ̀ɛ́ ɛ́nà mè-tɔ̀-ɔ̀ m̀pàbòá ńsó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Àtààdéɛ́", "shirt"], ["nà", "PRT"], ["mè-tɔ́-ɔ̀ɛ́", "1SG-buy-COMPL"], ["ɛ́nà", "and"],
+      ["mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"], ["m̀pàbòá", "shoes"], ["ńsó.", "also"]
+    ],
+    "translation": "It was a shirt that I bought and I bought shoes also.",
+    "context": "What did you buy?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_44a2",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(44A2)"},
+    "language": "akan1250",
+    "primaryText": "Mè-tɔ̀-ɔ̀ àtààdéɛ́ ɛ́nà mè-tɔ̀-ɔ̀ m̀pàbòá ńsó",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"], ["àtààdéɛ́", "shirt"], ["ɛ́nà", "and"],
+      ["mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"], ["m̀pàbòá", "shoes"], ["ńsó", "also"]
+    ],
+    "translation": "I bought a shirt and I bought shoes also.",
+    "context": "What did you buy?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_45",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(45)"},
+    "language": "ngam1282",
+    "primaryText": "Sàlko bànò=ì Dímzà, Umàr kè sàlkó bànò.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sàlko", "build.PFV"], ["bànò=ì", "house=BM"], ["Dímzà,", "Dimza"], ["Umàr", "Umar"],
+      ["kè", "also"], ["sàlkó", "build.PFV"], ["bànò.", "house"]
+    ],
+    "translation": "Dimza built a house, and Umar built a house, too.",
+    "context": "Who built a house?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_46",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(46)"},
+    "language": "gaaa1244",
+    "primaryText": "Felix nì káné wòlò nyɛ̀. Nì Kòfí hú káné wòlò nyɛ̀.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Felix", "Felix"], ["nì", "PRT"], ["káné", "read"], ["wòlò", "book"],
+      ["nyɛ̀.", "yesterday"], ["Nì", "and"], ["Kòfí", "Kofi"], ["hú", "also"], ["káné", "read"],
+      ["wòlò", "book"], ["nyɛ̀.", "yesterday"]
+    ],
+    "translation": "It was Felix who read a book yesterday. And Kofi also read a book yesterday.",
+    "context": "Who read a book?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_47",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(47)"},
+    "language": "akan1250",
+    "primaryText": "Nti nà ɔ̀-kɔ́-ɔ̀ sùkúù ɛ̀nórà. Ɛ́nà Yaw ńsó kɔ́-ɔ́ sùkúù.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Nti", "Nti"], ["nà", "PRT"], ["ɔ̀-kɔ́-ɔ̀", "3.SG.SBJ-go-COMPL"], ["sùkúù", "school"],
+      ["ɛ̀nórà.", "yesterday"], ["Ɛ́nà", "and"], ["Yaw", "Yaw"], ["ńsó", "also"],
+      ["kɔ́-ɔ́", "go-COMPL"], ["sùkúù.", "school"]
+    ],
+    "translation": "It was Nti who went to school. And Yaw also went to school.",
+    "context": "Who went to school yesterday?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "cancellation"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_48",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(48)"},
+    "language": "ngam1282",
+    "primaryText": "À bò'ytà járídà=ì ngô wòmmí'ì.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["À", "3SG.HAB"], ["bò'ytà", "sell.HAB"], ["járídà=ì", "newspaper=BM"], ["ngô", "man"],
+      ["wòmmí'ì.", "DEM"]
+    ],
+    "translation": "That man sells newspapers.",
+    "context": "The person asking wants to know the closest place to buy a newspaper. Who sells newspapers?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "mentionSome"]
+    ],
+    "comment": "Okay in a context where you just want to know the closest place to buy a newspaper.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_49",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(49)"},
+    "language": "gaaa1244",
+    "primaryText": "Kofi ni hɔ́ɔ̀ adafitswawoji.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kofi", "Kofi"], ["ni", "PRT"], ["hɔ́ɔ̀", "sell"], ["adafitswawoji.", "newspapers"]
+    ],
+    "translation": "It is Kofi who sells newspapers.",
+    "context": "We're at Makola market. There are many people who sell newspapers here but I want to find the closest one. Who sells newspapers?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "mentionSome"]
+    ],
+    "comment": "Consultant: it sounds like it's only Kofi who sells newspapers at Makola.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_50a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(50A)"},
+    "language": "akan1250",
+    "primaryText": "Ama tɔ̀nè bì.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ama", "Ama"], ["tɔ̀nè", "sell"], ["bì.", "some"]
+    ],
+    "translation": "Ama sells some (mangoes).",
+    "context": "The person asking wants to know the closest place to buy mangoes. Who sells mangoes?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "mentionSome"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_50a1",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(50A1)"},
+    "language": "akan1250",
+    "primaryText": "Ama nà ɔ̀-tɔ́nè bì",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ama", "Ama"], ["nà", "PRT"], ["ɔ̀-tɔ́nè", "3SG.SBJ-sell"], ["bì", "some"]
+    ],
+    "translation": "It is Ama who sells some (mangoes).",
+    "context": "The person asking wants to know the closest place to buy mangoes. Who sells mangoes?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "mentionSome"]
+    ],
+    "comment": "Consultant: the addressee will think that only Ama sells mangoes.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_54a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(54a)"},
+    "language": "gaaa1244",
+    "primaryText": "Fred nì è-fɔ̀ nìnè è-tsé lɛ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Fred", "Fred"], ["nì", "PRT"], ["è-fɔ̀", "3SG-throw"], ["nìnè", "hand"],
+      ["è-tsé", "3SG-call"], ["lɛ.", "PRT"]
+    ],
+    "translation": "It was Fred she invited.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "projection"],
+      ["inference", "if she invited Fred, then she didn't invite anybody else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_54b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(54b)"},
+    "language": "gaaa1244",
+    "primaryText": "Jèèè Fred nì è-fɔ̀ nìnè è-tsé lɛ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jèèè", "NEG"], ["Fred", "Fred"], ["nì", "PRT"], ["è-fɔ̀", "3SG-throw"], ["nìnè", "hand"],
+      ["è-tsé", "3SG-call"], ["lɛ.", "PRT"]
+    ],
+    "translation": "It wasn't Fred she invited.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "projection"],
+      ["inference", "if she invited Fred, then she didn't invite anybody else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_55a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(55a)"},
+    "language": "akan1250",
+    "primaryText": "Amo nà ɔ̀-frɛ́-ɛ̀ nó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Amo", "Amo"], ["nà", "PRT"], ["ɔ̀-frɛ́-ɛ̀", "3SG.SBJ-call-COMPL"], ["nó.", "3SG.OBJ"]
+    ],
+    "translation": "It was Amo that he called/invited.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "projection"],
+      ["inference", "if he invited Amo, then he didn't invite anybody else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_55b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(55b)"},
+    "language": "akan1250",
+    "primaryText": "Ɛ̀-ǹ-yɛ́ Amo nà ɔ̀-frɛ́-ɛ̀ nó.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ɛ̀-ǹ-yɛ́", "3SG.SBJ.INA-NEG-be"], ["Amo", "Amo"], ["nà", "PRT"],
+      ["ɔ̀-frɛ́-ɛ̀", "3SG.SBJ-call-COMPL"], ["nó.", "3SG.OBJ"]
+    ],
+    "translation": "It wasn't Amo he invited.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "projection"],
+      ["inference", "if he invited Amo, then he didn't invite anybody else"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_59a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(59a)"},
+    "language": "ngam1282",
+    "primaryText": "Èshà=i ngô bù nzònò.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Èshà=i", "call.PFV=BM"], ["ngô", "person"], ["bù", "NEG"], ["nzònò.", "yesterday"]
+    ],
+    "translation": "He called nobody yesterday.",
+    "context": "Who did Njelu call yesterday?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_59b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(59b)"},
+    "language": "ngam1282",
+    "primaryText": "Èshá nzònò=ì ngô bù.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Èshá", "call.PFV"], ["nzònò=ì", "yesterday=BM"], ["ngô", "person"], ["bù.", "NEG"]
+    ],
+    "translation": "He called nobody yesterday.",
+    "context": "Who did Njelu call yesterday?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_59c",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(59c)"},
+    "language": "ngam1282",
+    "primaryText": "Ngò=ì yò Njèlù èshá nzònò=ì ngô bù.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ngò=ì", "person=LINK"], ["yò", "REL"], ["Njèlù", "Njelu"], ["èshá", "call.PFV"],
+      ["nzònò=ì", "yesterday=DET"], ["ngô", "person"], ["bù.", "NEG"]
+    ],
+    "translation": "The one that Njelu called was nobody.",
+    "context": "Who did Njelu call yesterday?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "pseudocleft"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_60a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(60a)"},
+    "language": "akan1250",
+    "primaryText": "Ɔ̀-à-m̀-frɛ́ òbíárá.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ɔ̀-à-m̀-frɛ́", "3.SG.SBJ-COMPL-NEG-invite"], ["òbíárá.", "everybody/anybody"]
+    ],
+    "translation": "He did not invite anybody.",
+    "context": "Who did Kofi invite to the party?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_60b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(60b)"},
+    "language": "akan1250",
+    "primaryText": "Ɛ̀-ǹ-yɛ́ òbíárá nà ɔ̀-frɛ́-èɛ́",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ɛ̀-ǹ-yɛ́", "3SG.INA.SBJ-NEG-be"], ["òbíárá", "everybody/anyone"], ["nà", "PRT"],
+      ["ɔ̀-frɛ́-èɛ́", "3SG.SBJ-invite-COMPL"]
+    ],
+    "translation": "It was nobody that he invited.",
+    "context": "Who did Kofi invite to the party?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_61a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(61a)"},
+    "language": "gaaa1244",
+    "primaryText": "Kòfí tsɛ́-ɛɛ mòkò mòkò.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kòfí", "Kofi"], ["tsɛ́-ɛɛ", "call-NEG"], ["mòkò", "somebody"], ["mòkò.", "somebody"]
+    ],
+    "translation": "Kofi called nobody.",
+    "context": "Who did Kofi call yesterday?",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_61b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(61b)"},
+    "language": "gaaa1244",
+    "primaryText": "Jèèè mòkò mòkò nì Kòfí tsɛ́.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Jèèè", "NEG"], ["mòkò", "something"], ["mòkò", "something"], ["nì", "PRT"],
+      ["Kòfí", "Kofi"], ["tsɛ́.", "call"]
+    ],
+    "translation": "It was nobody that Kofi called.",
+    "context": "Who did Kofi call yesterday?",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "negativeQuantifier"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_64a",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(64a)"},
+    "language": "ngam1282",
+    "primaryText": "kìká èshá Sàmá bù nzònò...",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kìká", "because"], ["èshá", "call.PFV"], ["Sàmá", "Sama"], ["bù", "NEG"],
+      ["nzònò...", "yesterday"]
+    ],
+    "translation": "because he didn't call Sama yesterday,...",
+    "context": "Njelu hates calling, but his father forces him to call one family member per day. Sometimes, his father is not around, so Njelu doesn't call anybody. Did Njelu call somebody yesterday? I don't think so...",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "unmarked"],
+      ["diagnostic", "uncommittedContext"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_64b",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(64b)"},
+    "language": "ngam1282",
+    "primaryText": "kìká éshá=í Sámá bù nzònò...",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["kìká", "because"], ["éshá=í", "call.PFV=BM"], ["Sámá", "Sama"], ["bù", "NEG"],
+      ["nzònò...", "yesterday"]
+    ],
+    "translation": "because he didn't call Sama yesterday,...",
+    "context": "Njelu hates calling, but his father forces him to call one family member per day. Sometimes, his father is not around, so Njelu doesn't call anybody. Did Njelu call somebody yesterday? I don't think so...",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "uncommittedContext"]
+    ],
+    "comment": "The existence inference here arises from the negation's association with focus under a positive QUD, not from the marker.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_75",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(75)"},
+    "language": "gaaa1244",
+    "primaryText": "Kòfí ní sélé lɛ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Kòfí", "Kofi"], ["ní", "PRT"], ["sélé", "swim"], ["lɛ.", "DET"]
+    ],
+    "translation": "It is Kofi who swam",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "analysis"],
+      ["inference", "Kofi swam"],
+      ["inference", "if Kofi swam, then nobody else swam"],
+      ["inference", "somebody swam"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_76",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(76)"},
+    "language": "akan1250",
+    "primaryText": "Ama nà ɔ̀-dá-àɛ́.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ama", "Ama"], ["nà", "PRT"], ["ɔ̀-dá-àɛ́.", "3SG.SBJ-sleep-COMPL"]
+    ],
+    "translation": "It was Ama who slept.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "analysis"],
+      ["inference", "Ama slept"],
+      ["inference", "if Ama slept, then nobody else slept"],
+      ["inference", "somebody slept"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_77",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(77)"},
+    "language": "gaaa1244",
+    "primaryText": "Bàǹkú nì Kòfí yè nyɛ̀.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Bàǹkú", "Banku"], ["nì", "PRT"], ["Kòfí", "Kofi"], ["yè", "eat"], ["nyɛ̀.", "yesterday"]
+    ],
+    "translation": "It was banku that Kofi ate yesterday.",
+    "context": "It was banku and plantain that Kofi ate yesterday.",
+    "judgment": "unacceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "analysis"]
+    ],
+    "comment": "Banku was not the maximal thing Kofi ate, so the conditional presupposition fails.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "grubicrenansduah2019_78",
+    "source": {"bibkey": "grubic-renans-duah-2019", "paperLabel": "(78)"},
+    "language": "ngam1282",
+    "primaryText": "Mámmádì ònkò=ì àgóggò kì Dímzâ.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mámmádì", "Mammadi"], ["ònkò=ì", "give.PFV=PRT"], ["àgóggò", "watch"], ["kì", "to"],
+      ["Dímzâ.", "Dimza"]
+    ],
+    "translation": "Mammadi gave a watch to Dimza.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["construction", "marked"],
+      ["diagnostic", "analysis"],
+      ["inference", "Mammadi gave a watch to Dimza"],
+      ["inference", "that Mammadi gave or might have given something to Dimza is salient"]
+    ],
+    "comment": "",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/GrubicRenansDuah2019.lean
+++ b/Linglib/Data/Examples/GrubicRenansDuah2019.lean
@@ -1,0 +1,756 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `GrubicRenansDuah2019` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/GrubicRenansDuah2019.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace GrubicRenansDuah2019.Examples`.
+-/
+
+namespace GrubicRenansDuah2019.Examples
+
+open Data.Examples
+
+def ex_36a : LinguisticExample :=
+  { id := "grubicrenansduah2019_36a"
+    source := ⟨"grubic-renans-duah-2019", "(36a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Njèlù èshà=i Sàmá bù nzònò, ke èshá Hàwwâ."
+    discourseSegments := []
+    glossedTokens := [("Njèlù", "Njelu"), ("èshà=i", "call.PFV=BM"), ("Sàmá", "Sama"), ("bù", "NEG"), ("nzònò,", "yesterday"), ("ke", "also"), ("èshá", "call.PFV"), ("Hàwwâ.", "Hawwa")]
+    translation := "Njelu didn't phone Sama yesterday. He also phoned Hawwa."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negationAlso")]
+    comment := "Negation targets the prejacent, so the additive particle lacks its antecedent."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_36b : LinguisticExample :=
+  { id := "grubicrenansduah2019_36b"
+    source := ⟨"grubic-renans-duah-2019", "(36b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Njèlù èshà=i Sàmá yàk'i bù nzònò, ke èshá Hàwwâ."
+    discourseSegments := []
+    glossedTokens := [("Njèlù", "Njelu"), ("èshà=i", "call.PFV=BM"), ("Sàmá", "Sama"), ("yàk'i", "only"), ("bù", "NEG"), ("nzònò,", "yesterday"), ("ke", "also"), ("èshá", "call.PFV"), ("Hàwwâ.", "Hawwa")]
+    translation := "Njelu didn't only phone Sama yesterday. He also phoned Hawwa."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "negationAlso")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_37a : LinguisticExample :=
+  { id := "grubicrenansduah2019_37a"
+    source := ⟨"grubic-renans-duah-2019", "(37a)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Jèèè Fred nì è-fɔ̀ nìnè è-tsɛ́. È-tsɛ́ Gord hú."
+    discourseSegments := []
+    glossedTokens := [("Jèèè", "NEG"), ("Fred", "Fred"), ("nì", "PRT"), ("è-fɔ̀", "3SG-throw"), ("nìnè", "hand"), ("è-tsɛ́.", "3SG-call"), ("È-tsɛ́", "3SG-call"), ("Gord", "Gord"), ("hú.", "also")]
+    translation := "It wasn't Fred she invited. She also invited Gord."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negationAlso")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_37b : LinguisticExample :=
+  { id := "grubicrenansduah2019_37b"
+    source := ⟨"grubic-renans-duah-2019", "(37b)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Jèèè Fred pɛ́ è-fɔ̀ nìnè è-tsɛ́. È-tsɛ́ Gord hú."
+    discourseSegments := []
+    glossedTokens := [("Jèèè", "NEG"), ("Fred", "Fred"), ("pɛ́", "only"), ("è-fɔ̀", "3SG-throw"), ("nìnè", "hand"), ("è-tsɛ́.", "3SG-call"), ("È-tsɛ́", "3SG-call"), ("Gord", "Gord"), ("hú.", "also")]
+    translation := "She didn't only invite Fred. She also invited Gord."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "negationAlso")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_38a : LinguisticExample :=
+  { id := "grubicrenansduah2019_38a"
+    source := ⟨"grubic-renans-duah-2019", "(38a)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ɛ̀-ǹ-yɛ́ m̀pàbòá nà Owura tɔ́-ɔ̀èɛ́, ɔ̀-tɔ̀-ɔ̀ wɔ́kyè ńsó."
+    discourseSegments := []
+    glossedTokens := [("Ɛ̀-ǹ-yɛ́", "3SG.INA-NEG-be"), ("m̀pàbòá", "shoes"), ("nà", "PRT"), ("Owura", "Owura"), ("tɔ́-ɔ̀èɛ́,", "buy-COMPL"), ("ɔ̀-tɔ̀-ɔ̀", "3SG-buy-COMPL"), ("wɔ́kyè", "watch"), ("ńsó.", "too")]
+    translation := "It was not shoes that Owura bought, he also bought a watch."
+    context := ""
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negationAlso")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_38b : LinguisticExample :=
+  { id := "grubicrenansduah2019_38b"
+    source := ⟨"grubic-renans-duah-2019", "(38b)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Arko á-ǹ-tɔ́ àsòmàdéɛ́ ńkóáá ɔ̀-tɔ̀-ɔ̀ àhwènéɛ́ ńsó."
+    discourseSegments := []
+    glossedTokens := [("Arko", "Arko"), ("á-ǹ-tɔ́", "COMPL-NEG-buy"), ("àsòmàdéɛ́", "earrings"), ("ńkóáá", "only"), ("ɔ̀-tɔ̀-ɔ̀", "3SG-buy-COMPL"), ("àhwènéɛ́", "beads"), ("ńsó.", "too")]
+    translation := "Arko did not buy only earrings, she bought beads too."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "negationAlso")]
+    comment := "Duah (2015: 18)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_39a : LinguisticExample :=
+  { id := "grubicrenansduah2019_39a"
+    source := ⟨"grubic-renans-duah-2019", "(39a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "kìkà tùkò=ì Kúlè yàk'î"
+    discourseSegments := []
+    glossedTokens := [("kìkà", "because"), ("tùkò=ì", "eat.PFV=BM"), ("Kúlè", "Kule"), ("yàk'î", "only")]
+    translation := "because only Kule passed."
+    context := "The teacher had to repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: he doesn't want the other students to fail."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_39b : LinguisticExample :=
+  { id := "grubicrenansduah2019_39b"
+    source := ⟨"grubic-renans-duah-2019", "(39b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "kìkà tùkò=ì Kúlè"
+    discourseSegments := []
+    glossedTokens := [("kìkà", "because"), ("tùkò=ì", "eat.PFV=BM"), ("Kúlè", "Kule")]
+    translation := "because Kule passed"
+    context := "The teacher had to repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: he doesn't want Kule to pass. The exhaustive inference is not the reason."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_40a : LinguisticExample :=
+  { id := "grubicrenansduah2019_40a"
+    source := ⟨"grubic-renans-duah-2019", "(40a)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "éjàáké Kòfí pɛ́ páásí"
+    discourseSegments := []
+    glossedTokens := [("éjàáké", "because"), ("Kòfí", "Kofi"), ("pɛ́", "only"), ("páásí", "pass")]
+    translation := "because only Kofi passed"
+    context := "The teacher will repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: the teacher wants everybody to pass, so he will repeat the exam."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_40b : LinguisticExample :=
+  { id := "grubicrenansduah2019_40b"
+    source := ⟨"grubic-renans-duah-2019", "(40b)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "éjàáké Kòfí nì páásí"
+    discourseSegments := []
+    glossedTokens := [("éjàáké", "because"), ("Kòfí", "Kofi"), ("nì", "PRT"), ("páásí", "pass")]
+    translation := "because it was Kofi who passed"
+    context := "The teacher will repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: the teacher didn't want Kofi to pass, so he will repeat the exam."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_41a : LinguisticExample :=
+  { id := "grubicrenansduah2019_41a"
+    source := ⟨"grubic-renans-duah-2019", "(41a)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "èfisɛ́ Yaw ǹkóáá nà ɔ̀-twá-à ǹsɔ́hwɛ́ nó."
+    discourseSegments := []
+    glossedTokens := [("èfisɛ́", "because"), ("Yaw", "Yaw"), ("ǹkóáá", "only"), ("nà", "PRT"), ("ɔ̀-twá-à", "3SG.SBJ-pass-COMPL"), ("ǹsɔ́hwɛ́", "exam"), ("nó.", "DET")]
+    translation := "because only Yaw passed the exam"
+    context := "The teacher will repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "only"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: the teacher wants everybody to pass, and since Yaw is the only one who passed, the teacher will repeat the exam."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_41b : LinguisticExample :=
+  { id := "grubicrenansduah2019_41b"
+    source := ⟨"grubic-renans-duah-2019", "(41b)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "èfisɛ́ Yaw nà ɔ̀-twá-à ǹsɔ́hwɛ́ nó"
+    discourseSegments := []
+    glossedTokens := [("èfisɛ́", "because"), ("Yaw", "Yaw"), ("nà", "PRT"), ("ɔ̀-twá-à", "3SG.SBJ-pass"), ("ǹsɔ́hwɛ́", "exam"), ("nó", "DET")]
+    translation := "because it was Yaw who passed the exam"
+    context := "The teacher will repeat the exam,"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "reasonClause")]
+    comment := "Consultant: the teacher doesn't want Yaw to pass the exam, so he will repeat the exam."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_42 : LinguisticExample :=
+  { id := "grubicrenansduah2019_42"
+    source := ⟨"grubic-renans-duah-2019", "(42)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Kàjà=i fárì kì gárgù, kè kàjà àyàbà."
+    discourseSegments := []
+    glossedTokens := [("Kàjà=i", "buy.PFV=BM"), ("fárì", "watermelon"), ("kì", "at"), ("gárgù,", "village"), ("kè", "also"), ("kàjà", "buy.PFV"), ("àyàbà.", "banana")]
+    translation := "She bought a watermelon in the village, and she also bought a banana."
+    context := "What did Burba buy in the village?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_43a1 : LinguisticExample :=
+  { id := "grubicrenansduah2019_43a1"
+    source := ⟨"grubic-renans-duah-2019", "(43A1)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Bàǹkú nì Kòfí yè nyɛ̀. Nì àmádàá hú Kòfí yè nyɛ̀."
+    discourseSegments := []
+    glossedTokens := [("Bàǹkú", "Banku"), ("nì", "PRT"), ("Kòfí", "Kofi"), ("yè", "eat"), ("nyɛ̀.", "yesterday"), ("Nì", "and"), ("àmádàá", "plantain"), ("hú", "also"), ("Kòfí", "Kofi"), ("yè", "eat"), ("nyɛ̀.", "yesterday")]
+    translation := "It was banku that Kofi ate yesterday. And he also ate plantain yesterday."
+    context := "What did Kofi eat yesterday?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_43a2 : LinguisticExample :=
+  { id := "grubicrenansduah2019_43a2"
+    source := ⟨"grubic-renans-duah-2019", "(43A2)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Kòfí yè bàǹkú nyɛ̀. Nì Kòfí yé àmádàá hú nyɛ̀."
+    discourseSegments := []
+    glossedTokens := [("Kòfí", "Kofi"), ("yè", "eat"), ("bàǹkú", "banku"), ("nyɛ̀.", "yesterday"), ("Nì", "and"), ("Kòfí", "Kofi"), ("yé", "eat"), ("àmádàá", "plantain"), ("hú", "also"), ("nyɛ̀.", "yesterday")]
+    translation := "Kofi ate banku yesterday. And Kofi ate also plantain yesterday."
+    context := "What did Kofi eat yesterday?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_44a1 : LinguisticExample :=
+  { id := "grubicrenansduah2019_44a1"
+    source := ⟨"grubic-renans-duah-2019", "(44A1)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Àtààdéɛ́ nà mè-tɔ́-ɔ̀ɛ́ ɛ́nà mè-tɔ̀-ɔ̀ m̀pàbòá ńsó."
+    discourseSegments := []
+    glossedTokens := [("Àtààdéɛ́", "shirt"), ("nà", "PRT"), ("mè-tɔ́-ɔ̀ɛ́", "1SG-buy-COMPL"), ("ɛ́nà", "and"), ("mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"), ("m̀pàbòá", "shoes"), ("ńsó.", "also")]
+    translation := "It was a shirt that I bought and I bought shoes also."
+    context := "What did you buy?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_44a2 : LinguisticExample :=
+  { id := "grubicrenansduah2019_44a2"
+    source := ⟨"grubic-renans-duah-2019", "(44A2)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Mè-tɔ̀-ɔ̀ àtààdéɛ́ ɛ́nà mè-tɔ̀-ɔ̀ m̀pàbòá ńsó"
+    discourseSegments := []
+    glossedTokens := [("Mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"), ("àtààdéɛ́", "shirt"), ("ɛ́nà", "and"), ("mè-tɔ̀-ɔ̀", "1SG-buy-COMPL"), ("m̀pàbòá", "shoes"), ("ńsó", "also")]
+    translation := "I bought a shirt and I bought shoes also."
+    context := "What did you buy?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_45 : LinguisticExample :=
+  { id := "grubicrenansduah2019_45"
+    source := ⟨"grubic-renans-duah-2019", "(45)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Sàlko bànò=ì Dímzà, Umàr kè sàlkó bànò."
+    discourseSegments := []
+    glossedTokens := [("Sàlko", "build.PFV"), ("bànò=ì", "house=BM"), ("Dímzà,", "Dimza"), ("Umàr", "Umar"), ("kè", "also"), ("sàlkó", "build.PFV"), ("bànò.", "house")]
+    translation := "Dimza built a house, and Umar built a house, too."
+    context := "Who built a house?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_46 : LinguisticExample :=
+  { id := "grubicrenansduah2019_46"
+    source := ⟨"grubic-renans-duah-2019", "(46)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Felix nì káné wòlò nyɛ̀. Nì Kòfí hú káné wòlò nyɛ̀."
+    discourseSegments := []
+    glossedTokens := [("Felix", "Felix"), ("nì", "PRT"), ("káné", "read"), ("wòlò", "book"), ("nyɛ̀.", "yesterday"), ("Nì", "and"), ("Kòfí", "Kofi"), ("hú", "also"), ("káné", "read"), ("wòlò", "book"), ("nyɛ̀.", "yesterday")]
+    translation := "It was Felix who read a book yesterday. And Kofi also read a book yesterday."
+    context := "Who read a book?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_47 : LinguisticExample :=
+  { id := "grubicrenansduah2019_47"
+    source := ⟨"grubic-renans-duah-2019", "(47)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Nti nà ɔ̀-kɔ́-ɔ̀ sùkúù ɛ̀nórà. Ɛ́nà Yaw ńsó kɔ́-ɔ́ sùkúù."
+    discourseSegments := []
+    glossedTokens := [("Nti", "Nti"), ("nà", "PRT"), ("ɔ̀-kɔ́-ɔ̀", "3.SG.SBJ-go-COMPL"), ("sùkúù", "school"), ("ɛ̀nórà.", "yesterday"), ("Ɛ́nà", "and"), ("Yaw", "Yaw"), ("ńsó", "also"), ("kɔ́-ɔ́", "go-COMPL"), ("sùkúù.", "school")]
+    translation := "It was Nti who went to school. And Yaw also went to school."
+    context := "Who went to school yesterday?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "cancellation")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_48 : LinguisticExample :=
+  { id := "grubicrenansduah2019_48"
+    source := ⟨"grubic-renans-duah-2019", "(48)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "À bò'ytà járídà=ì ngô wòmmí'ì."
+    discourseSegments := []
+    glossedTokens := [("À", "3SG.HAB"), ("bò'ytà", "sell.HAB"), ("járídà=ì", "newspaper=BM"), ("ngô", "man"), ("wòmmí'ì.", "DEM")]
+    translation := "That man sells newspapers."
+    context := "The person asking wants to know the closest place to buy a newspaper. Who sells newspapers?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "mentionSome")]
+    comment := "Okay in a context where you just want to know the closest place to buy a newspaper."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_49 : LinguisticExample :=
+  { id := "grubicrenansduah2019_49"
+    source := ⟨"grubic-renans-duah-2019", "(49)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Kofi ni hɔ́ɔ̀ adafitswawoji."
+    discourseSegments := []
+    glossedTokens := [("Kofi", "Kofi"), ("ni", "PRT"), ("hɔ́ɔ̀", "sell"), ("adafitswawoji.", "newspapers")]
+    translation := "It is Kofi who sells newspapers."
+    context := "We're at Makola market. There are many people who sell newspapers here but I want to find the closest one. Who sells newspapers?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "mentionSome")]
+    comment := "Consultant: it sounds like it's only Kofi who sells newspapers at Makola."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_50a : LinguisticExample :=
+  { id := "grubicrenansduah2019_50a"
+    source := ⟨"grubic-renans-duah-2019", "(50A)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ama tɔ̀nè bì."
+    discourseSegments := []
+    glossedTokens := [("Ama", "Ama"), ("tɔ̀nè", "sell"), ("bì.", "some")]
+    translation := "Ama sells some (mangoes)."
+    context := "The person asking wants to know the closest place to buy mangoes. Who sells mangoes?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "mentionSome")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_50a1 : LinguisticExample :=
+  { id := "grubicrenansduah2019_50a1"
+    source := ⟨"grubic-renans-duah-2019", "(50A1)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ama nà ɔ̀-tɔ́nè bì"
+    discourseSegments := []
+    glossedTokens := [("Ama", "Ama"), ("nà", "PRT"), ("ɔ̀-tɔ́nè", "3SG.SBJ-sell"), ("bì", "some")]
+    translation := "It is Ama who sells some (mangoes)."
+    context := "The person asking wants to know the closest place to buy mangoes. Who sells mangoes?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "mentionSome")]
+    comment := "Consultant: the addressee will think that only Ama sells mangoes."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_54a : LinguisticExample :=
+  { id := "grubicrenansduah2019_54a"
+    source := ⟨"grubic-renans-duah-2019", "(54a)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Fred nì è-fɔ̀ nìnè è-tsé lɛ."
+    discourseSegments := []
+    glossedTokens := [("Fred", "Fred"), ("nì", "PRT"), ("è-fɔ̀", "3SG-throw"), ("nìnè", "hand"), ("è-tsé", "3SG-call"), ("lɛ.", "PRT")]
+    translation := "It was Fred she invited."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "projection"), ("inference", "if she invited Fred, then she didn't invite anybody else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_54b : LinguisticExample :=
+  { id := "grubicrenansduah2019_54b"
+    source := ⟨"grubic-renans-duah-2019", "(54b)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Jèèè Fred nì è-fɔ̀ nìnè è-tsé lɛ."
+    discourseSegments := []
+    glossedTokens := [("Jèèè", "NEG"), ("Fred", "Fred"), ("nì", "PRT"), ("è-fɔ̀", "3SG-throw"), ("nìnè", "hand"), ("è-tsé", "3SG-call"), ("lɛ.", "PRT")]
+    translation := "It wasn't Fred she invited."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "projection"), ("inference", "if she invited Fred, then she didn't invite anybody else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_55a : LinguisticExample :=
+  { id := "grubicrenansduah2019_55a"
+    source := ⟨"grubic-renans-duah-2019", "(55a)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Amo nà ɔ̀-frɛ́-ɛ̀ nó."
+    discourseSegments := []
+    glossedTokens := [("Amo", "Amo"), ("nà", "PRT"), ("ɔ̀-frɛ́-ɛ̀", "3SG.SBJ-call-COMPL"), ("nó.", "3SG.OBJ")]
+    translation := "It was Amo that he called/invited."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "projection"), ("inference", "if he invited Amo, then he didn't invite anybody else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_55b : LinguisticExample :=
+  { id := "grubicrenansduah2019_55b"
+    source := ⟨"grubic-renans-duah-2019", "(55b)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ɛ̀-ǹ-yɛ́ Amo nà ɔ̀-frɛ́-ɛ̀ nó."
+    discourseSegments := []
+    glossedTokens := [("Ɛ̀-ǹ-yɛ́", "3SG.SBJ.INA-NEG-be"), ("Amo", "Amo"), ("nà", "PRT"), ("ɔ̀-frɛ́-ɛ̀", "3SG.SBJ-call-COMPL"), ("nó.", "3SG.OBJ")]
+    translation := "It wasn't Amo he invited."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "projection"), ("inference", "if he invited Amo, then he didn't invite anybody else")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_59a : LinguisticExample :=
+  { id := "grubicrenansduah2019_59a"
+    source := ⟨"grubic-renans-duah-2019", "(59a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Èshà=i ngô bù nzònò."
+    discourseSegments := []
+    glossedTokens := [("Èshà=i", "call.PFV=BM"), ("ngô", "person"), ("bù", "NEG"), ("nzònò.", "yesterday")]
+    translation := "He called nobody yesterday."
+    context := "Who did Njelu call yesterday?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_59b : LinguisticExample :=
+  { id := "grubicrenansduah2019_59b"
+    source := ⟨"grubic-renans-duah-2019", "(59b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Èshá nzònò=ì ngô bù."
+    discourseSegments := []
+    glossedTokens := [("Èshá", "call.PFV"), ("nzònò=ì", "yesterday=BM"), ("ngô", "person"), ("bù.", "NEG")]
+    translation := "He called nobody yesterday."
+    context := "Who did Njelu call yesterday?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_59c : LinguisticExample :=
+  { id := "grubicrenansduah2019_59c"
+    source := ⟨"grubic-renans-duah-2019", "(59c)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Ngò=ì yò Njèlù èshá nzònò=ì ngô bù."
+    discourseSegments := []
+    glossedTokens := [("Ngò=ì", "person=LINK"), ("yò", "REL"), ("Njèlù", "Njelu"), ("èshá", "call.PFV"), ("nzònò=ì", "yesterday=DET"), ("ngô", "person"), ("bù.", "NEG")]
+    translation := "The one that Njelu called was nobody."
+    context := "Who did Njelu call yesterday?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "pseudocleft"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_60a : LinguisticExample :=
+  { id := "grubicrenansduah2019_60a"
+    source := ⟨"grubic-renans-duah-2019", "(60a)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ɔ̀-à-m̀-frɛ́ òbíárá."
+    discourseSegments := []
+    glossedTokens := [("Ɔ̀-à-m̀-frɛ́", "3.SG.SBJ-COMPL-NEG-invite"), ("òbíárá.", "everybody/anybody")]
+    translation := "He did not invite anybody."
+    context := "Who did Kofi invite to the party?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_60b : LinguisticExample :=
+  { id := "grubicrenansduah2019_60b"
+    source := ⟨"grubic-renans-duah-2019", "(60b)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ɛ̀-ǹ-yɛ́ òbíárá nà ɔ̀-frɛ́-èɛ́"
+    discourseSegments := []
+    glossedTokens := [("Ɛ̀-ǹ-yɛ́", "3SG.INA.SBJ-NEG-be"), ("òbíárá", "everybody/anyone"), ("nà", "PRT"), ("ɔ̀-frɛ́-èɛ́", "3SG.SBJ-invite-COMPL")]
+    translation := "It was nobody that he invited."
+    context := "Who did Kofi invite to the party?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_61a : LinguisticExample :=
+  { id := "grubicrenansduah2019_61a"
+    source := ⟨"grubic-renans-duah-2019", "(61a)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Kòfí tsɛ́-ɛɛ mòkò mòkò."
+    discourseSegments := []
+    glossedTokens := [("Kòfí", "Kofi"), ("tsɛ́-ɛɛ", "call-NEG"), ("mòkò", "somebody"), ("mòkò.", "somebody")]
+    translation := "Kofi called nobody."
+    context := "Who did Kofi call yesterday?"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_61b : LinguisticExample :=
+  { id := "grubicrenansduah2019_61b"
+    source := ⟨"grubic-renans-duah-2019", "(61b)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Jèèè mòkò mòkò nì Kòfí tsɛ́."
+    discourseSegments := []
+    glossedTokens := [("Jèèè", "NEG"), ("mòkò", "something"), ("mòkò", "something"), ("nì", "PRT"), ("Kòfí", "Kofi"), ("tsɛ́.", "call")]
+    translation := "It was nobody that Kofi called."
+    context := "Who did Kofi call yesterday?"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "negativeQuantifier")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_64a : LinguisticExample :=
+  { id := "grubicrenansduah2019_64a"
+    source := ⟨"grubic-renans-duah-2019", "(64a)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "kìká èshá Sàmá bù nzònò..."
+    discourseSegments := []
+    glossedTokens := [("kìká", "because"), ("èshá", "call.PFV"), ("Sàmá", "Sama"), ("bù", "NEG"), ("nzònò...", "yesterday")]
+    translation := "because he didn't call Sama yesterday,..."
+    context := "Njelu hates calling, but his father forces him to call one family member per day. Sometimes, his father is not around, so Njelu doesn't call anybody. Did Njelu call somebody yesterday? I don't think so..."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "unmarked"), ("diagnostic", "uncommittedContext")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_64b : LinguisticExample :=
+  { id := "grubicrenansduah2019_64b"
+    source := ⟨"grubic-renans-duah-2019", "(64b)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "kìká éshá=í Sámá bù nzònò..."
+    discourseSegments := []
+    glossedTokens := [("kìká", "because"), ("éshá=í", "call.PFV=BM"), ("Sámá", "Sama"), ("bù", "NEG"), ("nzònò...", "yesterday")]
+    translation := "because he didn't call Sama yesterday,..."
+    context := "Njelu hates calling, but his father forces him to call one family member per day. Sometimes, his father is not around, so Njelu doesn't call anybody. Did Njelu call somebody yesterday? I don't think so..."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "uncommittedContext")]
+    comment := "The existence inference here arises from the negation's association with focus under a positive QUD, not from the marker."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_75 : LinguisticExample :=
+  { id := "grubicrenansduah2019_75"
+    source := ⟨"grubic-renans-duah-2019", "(75)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Kòfí ní sélé lɛ."
+    discourseSegments := []
+    glossedTokens := [("Kòfí", "Kofi"), ("ní", "PRT"), ("sélé", "swim"), ("lɛ.", "DET")]
+    translation := "It is Kofi who swam"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "analysis"), ("inference", "Kofi swam"), ("inference", "if Kofi swam, then nobody else swam"), ("inference", "somebody swam")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_76 : LinguisticExample :=
+  { id := "grubicrenansduah2019_76"
+    source := ⟨"grubic-renans-duah-2019", "(76)"⟩
+    reportedIn := none
+    language := "akan1250"
+    primaryText := "Ama nà ɔ̀-dá-àɛ́."
+    discourseSegments := []
+    glossedTokens := [("Ama", "Ama"), ("nà", "PRT"), ("ɔ̀-dá-àɛ́.", "3SG.SBJ-sleep-COMPL")]
+    translation := "It was Ama who slept."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "analysis"), ("inference", "Ama slept"), ("inference", "if Ama slept, then nobody else slept"), ("inference", "somebody slept")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_77 : LinguisticExample :=
+  { id := "grubicrenansduah2019_77"
+    source := ⟨"grubic-renans-duah-2019", "(77)"⟩
+    reportedIn := none
+    language := "gaaa1244"
+    primaryText := "Bàǹkú nì Kòfí yè nyɛ̀."
+    discourseSegments := []
+    glossedTokens := [("Bàǹkú", "Banku"), ("nì", "PRT"), ("Kòfí", "Kofi"), ("yè", "eat"), ("nyɛ̀.", "yesterday")]
+    translation := "It was banku that Kofi ate yesterday."
+    context := "It was banku and plantain that Kofi ate yesterday."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "analysis")]
+    comment := "Banku was not the maximal thing Kofi ate, so the conditional presupposition fails."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def ex_78 : LinguisticExample :=
+  { id := "grubicrenansduah2019_78"
+    source := ⟨"grubic-renans-duah-2019", "(78)"⟩
+    reportedIn := none
+    language := "ngam1282"
+    primaryText := "Mámmádì ònkò=ì àgóggò kì Dímzâ."
+    discourseSegments := []
+    glossedTokens := [("Mámmádì", "Mammadi"), ("ònkò=ì", "give.PFV=PRT"), ("àgóggò", "watch"), ("kì", "to"), ("Dímzâ.", "Dimza")]
+    translation := "Mammadi gave a watch to Dimza."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "marked"), ("diagnostic", "analysis"), ("inference", "Mammadi gave a watch to Dimza"), ("inference", "that Mammadi gave or might have given something to Dimza is salient")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [ex_36a, ex_36b, ex_37a, ex_37b, ex_38a, ex_38b, ex_39a, ex_39b, ex_40a, ex_40b, ex_41a, ex_41b, ex_42, ex_43a1, ex_43a2, ex_44a1, ex_44a2, ex_45, ex_46, ex_47, ex_48, ex_49, ex_50a, ex_50a1, ex_54a, ex_54b, ex_55a, ex_55b, ex_59a, ex_59b, ex_59c, ex_60a, ex_60b, ex_61a, ex_61b, ex_64a, ex_64b, ex_75, ex_76, ex_77, ex_78]
+
+end GrubicRenansDuah2019.Examples

--- a/Linglib/Studies/GrubicRenansDuah2019.lean
+++ b/Linglib/Studies/GrubicRenansDuah2019.lean
@@ -5,120 +5,109 @@ Authors: Robert Hawkins
 -/
 import Linglib.Semantics.Focus.Control
 import Linglib.Pragmatics.Expressives.Basic
+import Linglib.Data.Examples.GrubicRenansDuah2019
+import Mathlib.Data.Set.Lattice
 
 /-!
-# Graded exhaustivity in Akan, Ga and Ngamo
+# Grubic, Renans, and Duah (2019): Focus, Exhaustivity and Existence in Akan, Ga and Ngamo
 
-Formalises [grubic-renans-duah-2019]: the exhaustive inference of a
-morphosyntactically marked focus construction is *not asserted* in
-any of the three languages — it is presupposed in Akan and Ga
-(cleft-like, with an existence presupposition) and merely
-conversationally implicated in Ngamo (whose marker contributes
-background salience, a definiteness component kept as prose here;
-their §7). The three analyses are three placements of exhaustivity
-across the two meaning dimensions: at-issue ([kiss-1998]-style
-*only*-semantics, rejected for these constructions), `ci`
-(presupposed), or neither (implicated).
+This file formalizes the analysis in section 8 of [grubic-renans-duah-2019], "Focus,
+exhaustivity and existence in Akan, Ga and Ngamo", of the three languages' marked
+focus/background constructions, whose data, rows of `Data.Examples.GrubicRenansDuah2019`, the
+paper collects in sections 5 and 6. In none of the three is the exhaustive inference asserted:
+negating the construction targets the prejacent, so an additive continuation loses its antecedent,
+(36) to (38), where negating overt *only* keeps it (`negated_only_licenses_also`). The Akan *nà*
+and Ga *ni* constructions are clefts, (75) and (76): they assert the prejacent and presuppose the
+conditional exhaustivity of Büring (2011), that if the prejacent holds no other alternative does,
+together with existence (`cleft`). The conditional form is what projects through negation, (54):
+the negated cleft is defined when another alternative holds instead (`cleft_neg_of_alt`), while
+the unnegated one cannot be cancelled by a further alternative, (43), (44), and (77)
+(`cleft_exhaustive`), and is undefined where no alternative holds, (60) and (61)
+(`cleft_existence`). The Ngamo *=i/ye* construction, (78), only presupposes that its
+background is salient: its exhaustive inference is a cancellable implicature, (42) and (45)
+(`marked_exhaustivity_cancellable`), and it carries no existence presupposition, (59)
+(`marked_of_not_exists`).
 
-The §5.2.1 diagnostic — negation plus an additive continuation — is
-derived: negating overt *only* keeps the prejacent and negates
-exhaustivity, so *also* finds its anaphoric antecedent
-((36b)/(37b)); negating the marked constructions targets the
-prejacent and removes it ((36a)/(37a), the `#also` judgments). Their
-§4 contrast findings (Akan/Ga contrastive, Ngamo felicitous all-new)
-connect to the `Focus.Use` layer and are left as a TODO.
+## Implementation notes
+
+Constructions are two-dimensional meanings over an arbitrary set of alternatives containing the
+prejacent, so the theorems are general rather than checked on a two-world model. The background
+of (78) is the existential closure of the alternatives, and its salience an abstract predicate on
+propositions. Section 4's contrast finding, which the paper concludes is pragmatic rather than
+conventional, and section 7's argument that salience is not givenness are not formalized.
+
+## References
+
+* [grubic-renans-duah-2019]
+* [kiss-1998]
 -/
 
 namespace GrubicRenansDuah2019
 
-open Pragmatics.Expressives (TwoDimProp)
-open Focus (onlyVia)
+open Pragmatics.Expressives Focus
 
-/-- Who Njelu phoned ((36)). -/
-structure CallWorld where
-  sama  : Bool
-  hawwa : Bool
-  deriving DecidableEq, Repr
+variable {W : Type*} (alts : Set (Set W)) (p : Set W)
 
-def calledSama : Set CallWorld := {w | w.sama}
-def calledHawwa : Set CallWorld := {w | w.hawwa}
+/-- Overt *only*, (36b) and (37b): the prejacent projects and exhaustivity is at issue. -/
+def onlyStyle : TwoDimProp W := .withCI (· ∈ onlyVia alts p) (· ∈ p)
 
-/-- The alternative phoning propositions. -/
-def alts : Focus.Interpretation.PropFocusValue CallWorld :=
-  {calledSama, calledHawwa}
+/-- The Akan *nà* and Ga *ni* constructions, (75) and (76): the prejacent is asserted, and
+conditional exhaustivity together with existence is presupposed. -/
+def cleft : TwoDimProp W :=
+  .withCI (· ∈ p) λ w => (w ∈ p → w ∈ onlyVia alts p) ∧ w ∈ ⋃₀ alts
 
-/-- Exhaustivity of the prejacent over the alternatives — the
-strong-theory *only* condition. -/
-def exh : Set CallWorld := onlyVia alts calledSama
+/-- The Ngamo *=i/ye* construction, (78): the prejacent is asserted, and the salience of the
+background, the existential closure of the alternatives, is presupposed. -/
+def marked (salient : Set W → Prop) : TwoDimProp W := .withCI (· ∈ p) λ _ => salient (⋃₀ alts)
 
-/-- Some alternative holds. -/
-def existencePresup : Set CallWorld :=
-  {w | w ∈ calledSama ∨ w ∈ calledHawwa}
+/-! ### The exhaustive inference is not asserted, section 5.2.1 -/
 
-private theorem calledHawwa_ne_calledSama : calledHawwa ≠ calledSama := by
-  intro h
-  have hmem : (⟨false, true⟩ : CallWorld) ∈ calledHawwa := rfl
-  rw [h] at hmem
-  exact absurd hmem Bool.false_ne_true
+/-- Negating overt *only* keeps the prejacent and denies exhaustivity, so some other alternative
+holds and *also* has its antecedent, (36b) and (37b). -/
+theorem negated_only_licenses_also {w : W} (h : (onlyStyle alts p).neg.atIssue w)
+    (hp : (onlyStyle alts p).neg.ci w) : w ∈ p ∧ ∃ q ∈ alts, q ≠ p ∧ w ∈ q := by
+  refine ⟨hp, ?_⟩
+  by_contra hno
+  push Not at hno
+  exact h λ q hq hwq => by_contra λ hne => hno q hq hne hwq
 
-/-- The Akan/Ga marked construction: prejacent at issue; exhaustivity
-and existence presupposed (§5.2.3, §6). -/
-def cleftLike : TwoDimProp CallWorld :=
-  .withCI (· ∈ calledSama) (fun w => w ∈ exh ∧ w ∈ existencePresup)
+/-- Negating a marked construction targets the prejacent, so *also* lacks its antecedent, (36a)
+to (38a). -/
+theorem negated_cleft_atIssue {w : W} (h : (cleft alts p).neg.atIssue w) : w ∉ p := h
 
-/-- The Ngamo marked construction: prejacent at issue; no exhaustivity
-or existence presupposition (§5.2.2, §6.1). -/
-def backgroundMarked : TwoDimProp CallWorld :=
-  .withCI (· ∈ calledSama) (fun _ => True)
+/-! ### Implicature in Ngamo, presupposition in Akan and Ga, section 5.2.2 -/
 
-/-- Overt *only* ((36b)/(37b)): prejacent projects, exhaustivity is
-at issue. -/
-def onlyStyle : TwoDimProp CallWorld :=
-  .withCI (· ∈ exh) (· ∈ calledSama)
+/-- (42) and (45): the Ngamo construction is satisfied, presupposition included, at a world where
+another alternative holds too; its exhaustive inference is cancellable. -/
+theorem marked_exhaustivity_cancellable {salient : Set W → Prop} {q : Set W} {w : W}
+    (hs : salient (⋃₀ alts)) (hq : q ∈ alts) (hne : q ≠ p) (hw : w ∈ p ∩ q) :
+    (marked alts p salient).atIssue w ∧ (marked alts p salient).ci w ∧ w ∉ onlyVia alts p :=
+  ⟨hw.1, hs, λ h => hne (h q hq hw.2)⟩
 
-/-- Negating overt *only* licenses the additive continuation: with the
-prejacent projected and exhaustivity negated, some distinct
-alternative held — *also* has its antecedent ((36b)/(37b)). -/
-theorem negated_only_licenses_also (w : CallWorld)
-    (hne : ¬ onlyStyle.atIssue w) (hp : w ∈ calledSama) :
-    w ∈ calledHawwa := by
-  by_contra hh
-  exact hne fun q hq hwq => by
-    rcases hq with rfl | rfl
-    · rfl
-    · exact absurd hwq hh
+/-- (43), (44), and (77): the cleft, wherever it is defined and true, is exhaustive; a further
+true alternative makes it undefined, so it cannot answer a mention-some question, (49) and
+(50). -/
+theorem cleft_exhaustive {w : W} (ha : (cleft alts p).atIssue w) (hc : (cleft alts p).ci w) :
+    w ∈ onlyVia alts p :=
+  hc.1 ha
 
-/-- Negating the marked constructions targets the prejacent, removing
-the additive particle's antecedent — the `#also` judgments of
-(36a)/(37a). Exhaustivity is not asserted (§5.2.1), against a
-[kiss-1998]-style *only*-semantics for these constructions. -/
-theorem negated_marked_blocks_also (w : CallWorld)
-    (h : ¬ cleftLike.atIssue w) : w ∉ calledSama := h
+/-- (54): the conditional presupposition projects. A negated cleft is defined at a world where
+the prejacent fails and another alternative holds, so *it wasn't Fred she invited* is compatible
+with her inviting Peter and Paul. -/
+theorem cleft_neg_of_alt {q : Set W} {w : W} (hq : q ∈ alts) (hw : w ∈ q) (hp : w ∉ p) :
+    (cleft alts p).neg.atIssue w ∧ (cleft alts p).neg.ci w :=
+  ⟨hp, λ h => absurd h hp, q, hq, hw⟩
 
-/-- Ngamo's exhaustive inference is cancellable — a conversational
-implicature (§5.2.2): the construction's full content is consistent
-with a non-exhaustive world. -/
-theorem ngamo_exhaustivity_cancellable :
-    ∃ w, backgroundMarked.atIssue w ∧ backgroundMarked.ci w ∧ w ∉ exh :=
-  ⟨⟨true, true⟩, rfl, trivial,
-    fun h => calledHawwa_ne_calledSama (h calledHawwa (Or.inr rfl) rfl)⟩
+/-! ### Existence, section 6 -/
 
-/-- Akan/Ga exhaustivity projects and cannot be cancelled — a
-presupposition (§5.2.3): no world satisfies the construction while
-falsifying exhaustivity. -/
-theorem cleft_exhaustivity_uncancellable :
-    ¬ ∃ w, cleftLike.atIssue w ∧ cleftLike.ci w ∧ w ∉ exh :=
-  fun ⟨_, _, ⟨hexh, _⟩, hnot⟩ => hnot hexh
+/-- (60) and (61): the cleft presupposes that some alternative holds, so a focused negative
+quantifier clashes with it. -/
+theorem cleft_existence {w : W} (hc : (cleft alts p).ci w) : w ∈ ⋃₀ alts := hc.2
 
-/-- Ngamo triggers no existence presupposition; Akan and Ga do (§6):
-the Ngamo construction is defined at a world where no alternative
-holds, the cleft-like one is not. -/
-theorem existence_contrast :
-    (∃ w, backgroundMarked.ci w ∧ w ∉ existencePresup) ∧
-    (∀ w, cleftLike.ci w → w ∈ existencePresup) :=
-  ⟨⟨⟨false, false⟩, trivial,
-      fun h => h.elim (absurd · Bool.false_ne_true)
-        (absurd · Bool.false_ne_true)⟩,
-    fun _ h => h.2⟩
+/-- (59): the Ngamo construction is defined at a world where no alternative holds; it carries
+no existence presupposition. -/
+theorem marked_of_not_exists {salient : Set W → Prop} (hs : salient (⋃₀ alts)) {w : W}
+    (_ : w ∉ ⋃₀ alts) : (marked alts p salient).ci w :=
+  hs
 
 end GrubicRenansDuah2019

--- a/references.bib
+++ b/references.bib
@@ -31702,7 +31702,7 @@
   url       = {https://www.jstor.org/stable/417867},
   subfield  = {semantics/focus},
   role      = {cited},
-  sources   = {Studies/Kiss1998.lean}
+  sources   = {Studies/GrubicRenansDuah2019.lean;Studies/Kiss1998.lean;Studies/MartinezVera2026.lean}
 }
 
 % REF: Jaggar & Green (2003). Ex-situ and in-situ focus in Hausa: syntax, semantics and discourse.
@@ -41664,7 +41664,7 @@
   doi       = {10.1515/ling-2018-0035},
   subfield  = {semantics},
   role      = {formalized},
-  sources   = {Studies/GrubicRenansDuah2019.lean}
+  sources   = {Data/Examples/GrubicRenansDuah2019.json;Studies/GrubicRenansDuah2019.lean}
 }
 
 % REF: Assmann, Büring, Jordanoska & Prüller (2023). Towards a theory of morphosyntactic focus marking. NLLT 41:1349-1396.


### PR DESCRIPTION
Deep cleanse of GrubicRenansDuah2019 against the paper (the authors' preprint, whose example numbers the study follows; Akan and Ga forms transcribed from page images): the section 8 analyses stated as the paper states them, over arbitrary alternatives.

- `cleft` now carries the paper's conditional exhaustivity presupposition (Büring 2011's "if she invited Fred, she invited nobody else", (53d)/(75b)/(76b)) rather than the unconditional exhaustivity the paper rejects for failing projection, plus existence; `marked` carries the Ngamo salience presupposition of (78b); `onlyStyle` keeps the prejacent presupposed. Theorems: `negated_only_licenses_also` (36b)/(37b), `negated_cleft_atIssue` (36a)–(38a), `marked_exhaustivity_cancellable` (42)/(45), `cleft_exhaustive` (43)/(44)/(77) and the mention-some cases, `cleft_neg_of_alt` (54), `cleft_existence` (60)/(61), `marked_of_not_exists` (59), all general over `alts`.
- New `Data/Examples/GrubicRenansDuah2019.json` (41 glossed rows across Ngamo, Ga, and Akan: negation-plus-*also*, reason clauses, cancellation, mention-some, projection, negative quantifiers, uncommitted contexts, and the section 8 analyses).
- Cut: the two-world `CallWorld` model and its `Bool` fields; header rewritten in register with the contrast and salience-versus-givenness sections noted as not formalized.
