### PR TITLE
docs(Studies/Hale2001): header in register, asymmetry locator fixed

### DIFF
--- a/Linglib/Studies/Hale2001.lean
+++ b/Linglib/Studies/Hale2001.lean
@@ -7,43 +7,36 @@ import Linglib.Processing.Expectation.PrefixProbability
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 /-!
-# Hale (2001): a probabilistic Earley parser as a psycholinguistic model
+# Hale (2001): A Probabilistic Earley Parser as a Psycholinguistic Model
 
-[hale-2001] (NAACL 2001) proposes that cognitive load is the total probability
-of the structural analyses disconfirmed by the input so far (§4): for a
-consistent grammar, the effort for a prefix is one minus its prefix
-probability, and word-by-word reading time is proportional to
-`log (αₙ₋₁ / αₙ)` — the word's surprisal — where `α` is [stolcke-1995]'s
-prefix probability, computed by a probabilistic Earley parser that is
-strong-competence, frequency-sensitive, and eager (Principles 1–3). The
-parser is a *total-parallelism* theory (§3): garden-pathing needs no
-reanalysis — it happens exactly at words where the disconfirmed analyses
-comprise most of the probability mass (§6.1: at "fell" in *the horse raced
-past the barn fell*, grammar (1) puts the pre-word prefix probability more
-than ten times the post-word one), and the subject/object relative asymmetry
-falls out the same way (§7).
-
-## Main definitions
-
-* `surprisal` — the word-level linking hypothesis, in the paper's
-  log-of-ratio form.
-* `disconfirmed` — the prefix-level load: total mass of disconfirmed analyses.
-
-## Main results
-
-* `surprisal_eq_neg_log_nextProb` — the ratio form is the conditional-word-
-  probability form (the identity [levy-2008] later grounds in relative
-  entropy).
-* `surprisal_eq_log_one_add`, `log_le_surprisal` — surprisal grows with the
-  ratio of disconfirmed to surviving mass: the paper's account of
-  garden-pathing, stated for any generative process.
+This file formalizes the linking hypothesis of [hale-2001]. Cognitive load is the total
+probability of the structural analyses the input so far has disconfirmed (section 4): for a
+consistent grammar, the effort spent on a prefix is one minus its prefix probability,
+`disconfirmed`, and word-by-word reading time is proportional to the log of the ratio of the
+prefix probability before the word to the one after it, the word's surprisal, `surprisal`,
+where the prefix probability is [stolcke-1995]'s, computed by a probabilistic Earley parser that
+is strong-competence, frequency-sensitive, and eager (Principles 1 to 3). The parser computes
+every parse, so the theory is one of total parallelism (section 3): garden-pathing needs no
+reanalysis and happens exactly at words where the disconfirmed analyses comprise most of the
+probability mass, `log_le_surprisal`, which is how the paper reads the spike at *fell* in *the
+horse raced past the barn fell*, where grammar (1) puts the prefix probability before the word
+at more than ten times the one after it (section 6.1), and the subject and object relative
+asymmetry of grammar (3) (section 6.3). The ratio form of surprisal is the negative log
+conditional probability of the word, `surprisal_eq_neg_log_nextProb`, the form [levy-2008]
+later grounds in relative entropy.
 
 ## Implementation notes
 
-The demonstrations' numerics (grammars (1)–(3), Figs. 3–8) require Stolcke's
-Earley chart over recursive PCFGs; they are cited in prose above and their
-formalization awaits an Earley substrate. The theorems here are the
-grammar-independent content of the linking hypothesis.
+The demonstrations' numerics, grammars (1) to (3) and the reading-time figures, require
+Stolcke's Earley chart over recursive probabilistic context-free grammars and await an Earley
+substrate; the theorems here are the grammar-independent content of the linking hypothesis,
+stated for any generative process with string yields.
+
+## References
+
+* [hale-2001]
+* [stolcke-1995]
+* [levy-2008]
 -/
 
 namespace Hale2001
@@ -53,13 +46,13 @@ open scoped ENNReal
 
 variable {T W : Type*} (P : PMF T) (str : T → List W) (ws : List W) (w : W)
 
-/-- Word-level cognitive load (§4): the log of the ratio of the prefix
-    probability before the word to the prefix probability after it. -/
+/-- Word-level cognitive load (section 4): the log of the ratio of the prefix probability
+before the word to the prefix probability after it. -/
 noncomputable def surprisal : ℝ :=
   Real.log ((prefixMass P str ws).toReal / (prefixMass P str (ws ++ [w])).toReal)
 
-/-- Prefix-level cognitive load (§4): the total probability of the analyses
-    the prefix has disconfirmed. -/
+/-- Prefix-level cognitive load (section 4): the total probability of the analyses the prefix
+has disconfirmed. -/
 noncomputable def disconfirmed : ℝ≥0∞ :=
   1 - prefixMass P str ws
 
@@ -67,15 +60,14 @@ noncomputable def disconfirmed : ℝ≥0∞ :=
 @[simp] theorem disconfirmed_nil : disconfirmed P str [] = 0 := by
   rw [disconfirmed, prefixMass_nil, tsub_self]
 
-/-- The paper's ratio form of surprisal is the negative log conditional
-    probability of the word — the form [levy-2008] derives as the relative
-    entropy of the belief update. -/
+/-- The paper's ratio form of surprisal is the negative log conditional probability of the
+word, the form [levy-2008] derives as the relative entropy of the belief update. -/
 theorem surprisal_eq_neg_log_nextProb :
     surprisal P str ws w = -Real.log (nextProb P str ws w).toReal := by
   rw [surprisal, nextProb, ENNReal.toReal_div, ← Real.log_inv, inv_div]
 
-/-- Surprisal in disconfirmation form: the log of one plus the ratio of the
-    mass disconfirmed at the word to the mass surviving it. -/
+/-- Surprisal in disconfirmation form: the log of one plus the ratio of the mass disconfirmed
+at the word to the mass surviving it. -/
 theorem surprisal_eq_log_one_add
     (ha : 0 < (prefixMass P str (ws ++ [w])).toReal) :
     surprisal P str ws w =
@@ -87,10 +79,9 @@ theorem surprisal_eq_log_one_add
   field_simp
   ring
 
-/-- **Garden-pathing** (§6.1): if the mass disconfirmed at a word is at least
-    `k` times the surviving mass, the word's surprisal is at least
-    `log (1 + k)` — difficulty spikes exactly where the disconfirmable
-    analyses comprise a great amount of probability. -/
+/-- Garden-pathing (section 6.1): if the mass disconfirmed at a word is at least `k` times
+the surviving mass, the word's surprisal is at least `log (1 + k)`; difficulty spikes exactly
+where the disconfirmable analyses comprise a great amount of probability. -/
 theorem log_le_surprisal {k : ℝ} (hk : 0 ≤ k)
     (ha : 0 < (prefixMass P str (ws ++ [w])).toReal)
     (hdis : k * (prefixMass P str (ws ++ [w])).toReal ≤

--- a/references.bib
+++ b/references.bib
@@ -28003,7 +28003,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/PaapeVasishth2026.lean;Studies/Hale2001.lean}
+  sources   = {Processing/Expectation/PrefixProbability.lean;Studies/Hale2001.lean;Studies/Levy2008.lean;Studies/PaapeVasishth2026.lean}
 }
 @article{van-schijndel-linzen-2021,
   author    = {van Schijndel, Marten and Linzen, Tal},


### PR DESCRIPTION
Deep cleanse of Hale2001 against the NAACL paper: the theorems were already the paper's linking hypothesis, so only the header changes.

- Header rewritten in register; the subject and object relative asymmetry is section 6.3 with grammar (3), not a section 7, which the paper does not have.
- Verified: Principles 1 to 3, the section 4 definition of cognitive load and its log-ratio word form, total parallelism (section 3), and the more-than-ten-times drop at *fell* (section 6.1).
