### PR TITLE
feat(Studies/Hale2001): surprisal telescopes to sentence prefix mass

### DIFF
--- a/Linglib/Studies/Hale2001.lean
+++ b/Linglib/Studies/Hale2001.lean
@@ -23,7 +23,9 @@ horse raced past the barn fell*, where grammar (1) puts the prefix probability b
 at more than ten times the one after it (section 6.1), and the subject and object relative
 asymmetry of grammar (3) (section 6.3). The ratio form of surprisal is the negative log
 conditional probability of the word, `surprisal_eq_neg_log_nextProb`, the form [levy-2008]
-later grounds in relative entropy.
+later grounds in relative entropy; and the two levels of the linking hypothesis agree, since
+prefix-level load only grows along a sentence, `disconfirmed_mono`, and word-level surprisals
+telescope to the negative log of the sentence's prefix mass, `totalSurprisal_nil_eq`.
 
 ## Implementation notes
 
@@ -59,6 +61,53 @@ noncomputable def disconfirmed : ℝ≥0∞ :=
 /-- No analysis has been disconfirmed before any input is seen. -/
 @[simp] theorem disconfirmed_nil : disconfirmed P str [] = 0 := by
   rw [disconfirmed, prefixMass_nil, tsub_self]
+
+/-- Disconfirmed mass grows along a sentence: an extension has disconfirmed at least what its
+prefix has, so prefix-level load never decreases. -/
+theorem disconfirmed_mono {ws ws' : List W} (h : ws <+: ws') :
+    disconfirmed P str ws ≤ disconfirmed P str ws' :=
+  tsub_le_tsub_left (prefixMass_anti P str h) 1
+
+/-- The surprisals of the words of `rest`, read one by one after the prefix `acc`. -/
+noncomputable def totalSurprisal : List W → List W → ℝ
+  | _, [] => 0
+  | acc, w :: rest => surprisal P str acc w + totalSurprisal (acc ++ [w]) rest
+
+/-- A prefix of a prefix with positive mass has positive mass. -/
+private theorem prefixMass_pos_of_prefix {ws ws' : List W} (h : ws <+: ws')
+    (hpos : 0 < (prefixMass P str ws').toReal) : 0 < (prefixMass P str ws).toReal :=
+  lt_of_lt_of_le hpos <| ENNReal.toReal_mono
+    (ne_top_of_le_ne_top ENNReal.one_ne_top
+      (prefixMass_nil P str ▸ prefixMass_anti P str (List.nil_prefix)))
+    (prefixMass_anti P str h)
+
+/-- Word surprisals telescope: reading `rest` after `acc` costs the log of the ratio of the
+masses before and after, whenever the whole string has positive mass. -/
+theorem totalSurprisal_eq {acc rest : List W}
+    (hpos : 0 < (prefixMass P str (acc ++ rest)).toReal) :
+    totalSurprisal P str acc rest =
+      Real.log (prefixMass P str acc).toReal
+        - Real.log (prefixMass P str (acc ++ rest)).toReal := by
+  induction rest generalizing acc with
+  | nil => simp [totalSurprisal]
+  | cons w rest ih =>
+    rw [totalSurprisal]
+    have hpos' : 0 < (prefixMass P str (acc ++ [w] ++ rest)).toReal := by
+      rwa [List.append_assoc, List.singleton_append]
+    have h₁ : 0 < (prefixMass P str (acc ++ [w])).toReal :=
+      prefixMass_pos_of_prefix P str (List.prefix_append _ rest) hpos'
+    have h₀ : 0 < (prefixMass P str acc).toReal :=
+      prefixMass_pos_of_prefix P str (List.prefix_append acc [w]) h₁
+    rw [ih hpos', List.append_assoc, List.singleton_append, surprisal,
+      Real.log_div h₀.ne' h₁.ne']
+    ring
+
+/-- The linking hypothesis at the sentence level (section 4): the total surprisal of a sentence
+is the negative log of its prefix mass, the whole disconfirmed mass paid out word by word. -/
+theorem totalSurprisal_nil_eq {ws : List W} (hpos : 0 < (prefixMass P str ws).toReal) :
+    totalSurprisal P str [] ws = -Real.log (prefixMass P str ws).toReal := by
+  rw [totalSurprisal_eq P str (by simpa using hpos), prefixMass_nil]
+  simp
 
 /-- The paper's ratio form of surprisal is the negative log conditional probability of the
 word, the form [levy-2008] derives as the relative entropy of the belief update. -/


### PR DESCRIPTION
Deeper cleanse of Hale2001: the two levels of the paper's linking hypothesis connected as theorems.

- `disconfirmed_mono`: prefix-level load never decreases along a sentence, from the substrate's antitone prefix mass.
- `totalSurprisal_eq` and `totalSurprisal_nil_eq`: word surprisals telescope, so the total surprisal of a sentence is the negative log of its prefix mass, the whole disconfirmed mass paid out word by word, for any sentence of positive mass.
