### PR TITLE
fix(Studies/Preminger2014): lSpellout compares against VerbForm

### DIFF
--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -494,7 +494,7 @@ theorem ch7_arg5_zulu_parallel :
     ¬ Halpert2012.LicensingOk [⟨1, true⟩, ⟨5, false⟩] ∧
     -- both probes' failures converge with default morphology
     afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" ∧
-    Halpert2012.lSpellout [] = "ya-" := by
+    Halpert2012.lSpellout [] = .disjoint := by
   decide
 
 end Preminger2014


### PR DESCRIPTION
Repair main: #2925 retyped `Halpert2012.lSpellout` to `VerbForm`, and Preminger2014 still compared it to a string.
