### PR TITLE
refactor(Studies/Hansson2010): anticipatory harmony map, Navajo rows

### DIFF
--- a/Linglib/Data/Examples/Hansson2010.json
+++ b/Linglib/Data/Examples/Hansson2010.json
@@ -1,0 +1,835 @@
+[
+  {
+    "id": "hansson2010_ex3a-i",
+    "source": {
+      "bibkey": "sapir-hoijer-1967",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "ʃiłį́ːʔ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "my horse",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃi-łį́ːʔ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "No sibilant in the stem: the prefix surfaces in its underlying postalveolar shape.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(3a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex3a-ii",
+    "source": {
+      "bibkey": "sapir-hoijer-1967",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "ʃitaːʔ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "my father",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃi-taːʔ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "No sibilant in the stem: the prefix surfaces in its underlying postalveolar shape.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(3a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex3b",
+    "source": {
+      "bibkey": "sapir-hoijer-1967",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "ʃítʃį́ːh",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "my nose",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃí-tʃį́ːh"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "A postalveolar stem sibilant: the prefix keeps its postalveolar.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(3b)"
+    }
+  },
+  {
+    "id": "hansson2010_ex3c-i",
+    "source": {
+      "bibkey": "sapir-hoijer-1967",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "sitsʼaːʔ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "my basket",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃi-tsʼaːʔ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "An alveolar stem sibilant: the prefix sibilant assimilates to it.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(3c)"
+    }
+  },
+  {
+    "id": "hansson2010_ex3c-ii",
+    "source": {
+      "bibkey": "sapir-hoijer-1967",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "sizid",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "my scar",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃi-zid"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "An alveolar stem sibilant: the prefix sibilant assimilates to it.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(3c)"
+    }
+  },
+  {
+    "id": "hansson2010_ex4a",
+    "source": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(4a)"
+    },
+    "language": "nava1243",
+    "primaryText": "dʒidibáːh",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "he (4th person) starts off to war",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dʒi-di-báːh"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "No sibilant follows: the fourth-person prefix surfaces as postalveolar /dʒi-/.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hansson2010_ex4b",
+    "source": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(4b)"
+    },
+    "language": "nava1243",
+    "primaryText": "dziztʼį́",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "he (4th person) is lying",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dʒi-s-tʼį́"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The perfective /s-/, voiced to [z] here, makes the preceding prefix alveolar.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hansson2010_ex4c",
+    "source": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(4c)"
+    },
+    "language": "nava1243",
+    "primaryText": "dʒiʒɣiʃ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "he (4th person) is stooped over",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dʒi-s-ɣiːʃ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The stem sibilant determines both prefix sibilants; the intervening [ɣ] is transparent.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hansson2010_ex6a-i",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "jismas",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I'm rolling along",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.4.1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "j-iʃ-mas"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The root sibilant makes the first-person subject prefix alveolar.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(6a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex6a-ii",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "ʃidʒéːʔ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "they lie (slender stiff objects)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.4.1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "si-dʒéːʔ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The root sibilant makes the prefix sibilant postalveolar.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(6a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex6b-i",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "sisná",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "he carried me",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.4.1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "ʃ-is-ná"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "A prefix sibilant triggers assimilation in the prefix sibilant before it.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(6b)"
+    }
+  },
+  {
+    "id": "hansson2010_ex6b-ii",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "dʒiʃtaːl",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I kick him [below the belt]",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.4.1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dz-iʃ-l-taːl"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "A prefix sibilant triggers assimilation in the prefix sibilant before it.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(6b)"
+    }
+  },
+  {
+    "id": "hansson2010_ex6c",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "dzistsʼin",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I hit him [below the belt]",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.4.1.1"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dz-iʃ-l-tsʼin"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The root sibilant determines both prefix sibilants.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(6c)"
+    }
+  },
+  {
+    "id": "hansson2010_ex11a-i",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "dzizdá",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "he sat down",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dʒ-i-z-dá"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The perfective prefix triggers harmony in the earlier fourth-person prefix.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(11a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex11a-ii",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "dʒiʃhaːl",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I tumble into the water (imperfective)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dz-iʃ-ł-haːl"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The first-person subject prefix triggers harmony in the earlier adverbial prefix.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(11a)"
+    }
+  },
+  {
+    "id": "hansson2010_ex11b",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "dzistsʼin",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I hit him below [the belt]",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "dz-iʃ-ł-tsʼin"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "The stem sibilant affects all preceding prefix sibilants.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(11b)"
+    }
+  },
+  {
+    "id": "hansson2010_ex12",
+    "source": {
+      "bibkey": "faltz-1998",
+      "paperLabel": "p. 74"
+    },
+    "language": "nava1243",
+    "primaryText": "sis-",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "first-person singular subject, s-perfective",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {
+        "form": "ʃiʃ-",
+        "judgment": "unacceptable"
+      }
+    ],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "s-iʃ-"
+      ],
+      [
+        "directionality",
+        "perseveratory"
+      ]
+    ],
+    "comment": "The conjugation marker /s(i)-/ makes the following first-person /(i)ʃ-/ alveolar: perseveratory assimilation rather than the expected anticipatory harmony.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(12)"
+    }
+  },
+  {
+    "id": "hansson2010_ex13",
+    "source": {
+      "bibkey": "faltz-1998",
+      "paperLabel": "p. 383"
+    },
+    "language": "nava1243",
+    "primaryText": "ʃiʃ-",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "first-person singular subject, s-imperfective",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "s-iʃ-"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "In the imperfective paradigm the same prefix sequence harmonizes anticipatorily.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(13)"
+    }
+  },
+  {
+    "id": "hansson2010_ex14-i",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "sisxé",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I'm killing it (imperfective)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "s-iʃ-ł-jé"
+      ],
+      [
+        "directionality",
+        "perseveratory"
+      ]
+    ],
+    "comment": "The s-destruct prefix makes the following first-person prefix alveolar.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(14)"
+    }
+  },
+  {
+    "id": "hansson2010_ex14-ii",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "sisdlí",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I froze to death (perfective)",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "s-iʃ-dlí"
+      ],
+      [
+        "directionality",
+        "perseveratory"
+      ]
+    ],
+    "comment": "The s-destruct prefix makes the following first-person prefix alveolar.",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(14)"
+    }
+  },
+  {
+    "id": "hansson2010_ex15",
+    "source": {
+      "bibkey": "mcdonough-1991",
+      "paperLabel": ""
+    },
+    "language": "nava1243",
+    "primaryText": "ʃiʃʒeːʔ",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "phenomenon",
+        "sibilantHarmony"
+      ],
+      [
+        "underlying",
+        "s-iʃ-l-ʒeːʔ"
+      ],
+      [
+        "directionality",
+        "anticipatory"
+      ]
+    ],
+    "comment": "Anticipatory harmony from the root overrides the perseveratory prefix assimilation of (12) and (14).",
+    "lgrConformance": "",
+    "reportedIn": {
+      "bibkey": "hansson-2010",
+      "paperLabel": "(15)"
+    }
+  }
+]

--- a/Linglib/Data/Examples/Hansson2010.lean
+++ b/Linglib/Data/Examples/Hansson2010.lean
@@ -1,0 +1,396 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Hansson2010` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Hansson2010.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Hansson2010.Examples`.
+-/
+
+namespace Hansson2010.Examples
+
+open Data.Examples
+
+def ex3a_i : LinguisticExample :=
+  { id := "hansson2010_ex3a-i"
+    source := ⟨"sapir-hoijer-1967", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(3a)"⟩
+    language := "nava1243"
+    primaryText := "ʃiłį́ːʔ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "my horse"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃi-łį́ːʔ"), ("directionality", "anticipatory")]
+    comment := "No sibilant in the stem: the prefix surfaces in its underlying postalveolar shape."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3a_ii : LinguisticExample :=
+  { id := "hansson2010_ex3a-ii"
+    source := ⟨"sapir-hoijer-1967", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(3a)"⟩
+    language := "nava1243"
+    primaryText := "ʃitaːʔ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "my father"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃi-taːʔ"), ("directionality", "anticipatory")]
+    comment := "No sibilant in the stem: the prefix surfaces in its underlying postalveolar shape."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3b : LinguisticExample :=
+  { id := "hansson2010_ex3b"
+    source := ⟨"sapir-hoijer-1967", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(3b)"⟩
+    language := "nava1243"
+    primaryText := "ʃítʃį́ːh"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "my nose"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃí-tʃį́ːh"), ("directionality", "anticipatory")]
+    comment := "A postalveolar stem sibilant: the prefix keeps its postalveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3c_i : LinguisticExample :=
+  { id := "hansson2010_ex3c-i"
+    source := ⟨"sapir-hoijer-1967", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(3c)"⟩
+    language := "nava1243"
+    primaryText := "sitsʼaːʔ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "my basket"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃi-tsʼaːʔ"), ("directionality", "anticipatory")]
+    comment := "An alveolar stem sibilant: the prefix sibilant assimilates to it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3c_ii : LinguisticExample :=
+  { id := "hansson2010_ex3c-ii"
+    source := ⟨"sapir-hoijer-1967", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(3c)"⟩
+    language := "nava1243"
+    primaryText := "sizid"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "my scar"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃi-zid"), ("directionality", "anticipatory")]
+    comment := "An alveolar stem sibilant: the prefix sibilant assimilates to it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4a : LinguisticExample :=
+  { id := "hansson2010_ex4a"
+    source := ⟨"hansson-2010", "(4a)"⟩
+    reportedIn := none
+    language := "nava1243"
+    primaryText := "dʒidibáːh"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "he (4th person) starts off to war"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "dʒi-di-báːh"), ("directionality", "anticipatory")]
+    comment := "No sibilant follows: the fourth-person prefix surfaces as postalveolar /dʒi-/."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4b : LinguisticExample :=
+  { id := "hansson2010_ex4b"
+    source := ⟨"hansson-2010", "(4b)"⟩
+    reportedIn := none
+    language := "nava1243"
+    primaryText := "dziztʼį́"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "he (4th person) is lying"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "dʒi-s-tʼį́"), ("directionality", "anticipatory")]
+    comment := "The perfective /s-/, voiced to [z] here, makes the preceding prefix alveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4c : LinguisticExample :=
+  { id := "hansson2010_ex4c"
+    source := ⟨"hansson-2010", "(4c)"⟩
+    reportedIn := none
+    language := "nava1243"
+    primaryText := "dʒiʒɣiʃ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "he (4th person) is stooped over"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "dʒi-s-ɣiːʃ"), ("directionality", "anticipatory")]
+    comment := "The stem sibilant determines both prefix sibilants; the intervening [ɣ] is transparent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6a_i : LinguisticExample :=
+  { id := "hansson2010_ex6a-i"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(6a)"⟩
+    language := "nava1243"
+    primaryText := "jismas"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I'm rolling along"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.4.1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "j-iʃ-mas"), ("directionality", "anticipatory")]
+    comment := "The root sibilant makes the first-person subject prefix alveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6a_ii : LinguisticExample :=
+  { id := "hansson2010_ex6a-ii"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(6a)"⟩
+    language := "nava1243"
+    primaryText := "ʃidʒéːʔ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "they lie (slender stiff objects)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.4.1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "si-dʒéːʔ"), ("directionality", "anticipatory")]
+    comment := "The root sibilant makes the prefix sibilant postalveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6b_i : LinguisticExample :=
+  { id := "hansson2010_ex6b-i"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(6b)"⟩
+    language := "nava1243"
+    primaryText := "sisná"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "he carried me"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.4.1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "ʃ-is-ná"), ("directionality", "anticipatory")]
+    comment := "A prefix sibilant triggers assimilation in the prefix sibilant before it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6b_ii : LinguisticExample :=
+  { id := "hansson2010_ex6b-ii"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(6b)"⟩
+    language := "nava1243"
+    primaryText := "dʒiʃtaːl"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I kick him [below the belt]"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.4.1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "dz-iʃ-l-taːl"), ("directionality", "anticipatory")]
+    comment := "A prefix sibilant triggers assimilation in the prefix sibilant before it."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6c : LinguisticExample :=
+  { id := "hansson2010_ex6c"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(6c)"⟩
+    language := "nava1243"
+    primaryText := "dzistsʼin"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I hit him [below the belt]"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.4.1.1"), ("phenomenon", "sibilantHarmony"), ("underlying", "dz-iʃ-l-tsʼin"), ("directionality", "anticipatory")]
+    comment := "The root sibilant determines both prefix sibilants."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11a_i : LinguisticExample :=
+  { id := "hansson2010_ex11a-i"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(11a)"⟩
+    language := "nava1243"
+    primaryText := "dzizdá"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "he sat down"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "dʒ-i-z-dá"), ("directionality", "anticipatory")]
+    comment := "The perfective prefix triggers harmony in the earlier fourth-person prefix."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11a_ii : LinguisticExample :=
+  { id := "hansson2010_ex11a-ii"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(11a)"⟩
+    language := "nava1243"
+    primaryText := "dʒiʃhaːl"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I tumble into the water (imperfective)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "dz-iʃ-ł-haːl"), ("directionality", "anticipatory")]
+    comment := "The first-person subject prefix triggers harmony in the earlier adverbial prefix."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex11b : LinguisticExample :=
+  { id := "hansson2010_ex11b"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(11b)"⟩
+    language := "nava1243"
+    primaryText := "dzistsʼin"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I hit him below [the belt]"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "dz-iʃ-ł-tsʼin"), ("directionality", "anticipatory")]
+    comment := "The stem sibilant affects all preceding prefix sibilants."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex12 : LinguisticExample :=
+  { id := "hansson2010_ex12"
+    source := ⟨"faltz-1998", "p. 74"⟩
+    reportedIn := some ⟨"hansson-2010", "(12)"⟩
+    language := "nava1243"
+    primaryText := "sis-"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "first-person singular subject, s-perfective"
+    context := ""
+    judgment := .acceptable
+    alternatives := [("ʃiʃ-", .unacceptable)]
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "s-iʃ-"), ("directionality", "perseveratory")]
+    comment := "The conjugation marker /s(i)-/ makes the following first-person /(i)ʃ-/ alveolar: perseveratory assimilation rather than the expected anticipatory harmony."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13 : LinguisticExample :=
+  { id := "hansson2010_ex13"
+    source := ⟨"faltz-1998", "p. 383"⟩
+    reportedIn := some ⟨"hansson-2010", "(13)"⟩
+    language := "nava1243"
+    primaryText := "ʃiʃ-"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "first-person singular subject, s-imperfective"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "s-iʃ-"), ("directionality", "anticipatory")]
+    comment := "In the imperfective paradigm the same prefix sequence harmonizes anticipatorily."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14_i : LinguisticExample :=
+  { id := "hansson2010_ex14-i"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(14)"⟩
+    language := "nava1243"
+    primaryText := "sisxé"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I'm killing it (imperfective)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "s-iʃ-ł-jé"), ("directionality", "perseveratory")]
+    comment := "The s-destruct prefix makes the following first-person prefix alveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14_ii : LinguisticExample :=
+  { id := "hansson2010_ex14-ii"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(14)"⟩
+    language := "nava1243"
+    primaryText := "sisdlí"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I froze to death (perfective)"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "s-iʃ-dlí"), ("directionality", "perseveratory")]
+    comment := "The s-destruct prefix makes the following first-person prefix alveolar."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex15 : LinguisticExample :=
+  { id := "hansson2010_ex15"
+    source := ⟨"mcdonough-1991", ""⟩
+    reportedIn := some ⟨"hansson-2010", "(15)"⟩
+    language := "nava1243"
+    primaryText := "ʃiʃʒeːʔ"
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("phenomenon", "sibilantHarmony"), ("underlying", "s-iʃ-l-ʒeːʔ"), ("directionality", "anticipatory")]
+    comment := "Anticipatory harmony from the root overrides the perseveratory prefix assimilation of (12) and (14)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex3a_i, ex3a_ii, ex3b, ex3c_i, ex3c_ii, ex4a, ex4b, ex4c, ex6a_i, ex6a_ii, ex6b_i, ex6b_ii, ex6c, ex11a_i, ex11a_ii, ex11b, ex12, ex13, ex14_i, ex14_ii, ex15]
+
+end Hansson2010.Examples

--- a/Linglib/Studies/Hansson2010.lean
+++ b/Linglib/Studies/Hansson2010.lean
@@ -1,267 +1,312 @@
-/-
-Copyright (c) 2026 Robert Hawkins. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Robert Hawkins
--/
 import Linglib.Phonology.Subregular.Sibilant
 import Linglib.Phonology.Subregular.Agree
 import Linglib.Phonology.Subregular.Multitier
+import Linglib.Phonology.Subregular.Harmony
+import Linglib.Data.Examples.Hansson2010
 
 /-!
-# Hansson (2010) [hansson-2010]
+# Hansson (2010): Consonant Harmony: Long-Distance Interaction in Phonology
 
-Consonant Harmony: Long-Distance Interaction in Phonology. *University
-of California Publications in Linguistics* 145.
+This file formalizes the Navajo sibilant harmony with which [hansson-2010] opens its survey of
+consonant harmony (section 1.1, and the case study of section 2.4.1.1): the alveolar and
+postalveolar sibilant series cannot co-occur, and when morpheme concatenation juxtaposes them
+the rightmost sibilant determines the anteriority of every sibilant before it, across any
+vowels and non-sibilant consonants in between (3), (4), (6). The harmony is the map
+`anticipatory` over the substrate's sibilant tier alphabet, whose fixed points are exactly the
+words of the tier-based strictly 2-local agree language, `mem_language_iff_anticipatory_eq`;
+it leaves the trigger and everything off the tier in place and neutralizes the contrast in the
+sibilants it targets, the three characteristics the book draws from (4). It is the substrate's
+harmony `System`, [rose-walker-2011]'s decomposition shared with the vowel harmonies of the
+fragments, run from the right, `anticipatory_eq_transduceWord`. The book's own qualification
+(section 3.1.2) is the perseveratory assimilation of the first-person subject prefix after the
+s-perfective and s-destruct prefixes (12), (14), which the anticipatory map mispredicts,
+`perseveratory_rows`, while harmony from the root still overrides it (15). The examples are
+the rows of `Data.Examples.Hansson2010`, whose tier strings the theorems read off the
+transcriptions.
 
-[hansson-2010] surveys ~175 cases of long-distance consonant
-agreement across >130 languages, organized by harmonizing property
-(coronal/sibilant, dorsal, labial, secondary-articulation, nasal,
-liquid, stricture, laryngeal). The formal analysis is a modified
-Agreement-by-Correspondence model after [rose-walker-2004], with
-two theoretical refinements: (a) C-C correspondence is construed as
-directionally asymmetric (strictly anticipatory), and (b) the relevant
-agreement constraints are formulated as *targeted* constraints in the
-Wilson sense.
+## Implementation notes
 
-## What this file formalizes (and what it does not)
+An affricate contributes its fricative release as its tier symbol, and voicing and
+glottalization are not read, so the [ʒ] of (4c), voiced under a condition the book sets aside,
+is the postalveolar class. The book's correspondence-theoretic analysis (chapters 4 and 5), its
+typological survey (chapter 2), and its speech-error account (chapter 6) are not formalized;
+[rose-walker-2004]'s Agreement by Correspondence is in `Studies/RoseWalker2004.lean`.
 
-We do **not** formalize Hansson's correspondence apparatus, his
-targeted-constraint architecture, or his speech-error / palatal-bias
-arguments — those live in the OT layer and the speech-planning
-literature. What we formalize here is the *surface stringset* of one
-of the leading case studies — Navajo sibilant harmony, prominently
-featured in [hansson-2010]'s introduction (§1.1) and discussed
-in detail in §2.4.1.1 — as a tier-based strictly 2-local language.
+## References
 
-The framing is the same as in `RoseWalker2004.lean`: the ABC-style
-analysis *derives* the surface generalization; the TSL_2 description
-*characterizes* the surface stringset. The two analyses operate at
-different levels and are not in competition for the same explanatory
-work.
-
-Sibilant harmony is a *symmetric* dissimilation-style phonotactic — the
-forbidden pair is "tier-adjacent and *unequal*" — so this study is the
-canonical instance of the AGREE specialization in
-`Phonology/Subregular/Agree.lean`, the non-identity dual of the
-OCP ([goldsmith-1976], [mccarthy-1986]). The Kikongo case in
-`RoseWalker2004.lean` is *asymmetric* and instantiates the generic
-forbidden-pair constructor directly rather than via AGREE.
-
-## Design boundary
-
-Things this formalization is silent on, by design:
-1. **Directionality**: [hansson-2010] argues consonant harmony is
-   strictly anticipatory (right-to-left). The TSL_2 description with
-   symmetric forbidden pairs licenses the surface stringset regardless
-   of which segment "triggered" the harmony — the directional
-   derivation lives in the OT/ABC layer.
-2. **Stem control / trigger-target asymmetry**: the targeted-constraint
-   architecture distinguishes the feature source from its target.
-   Single-tier TSL with a fixed predicate has no notion of source vs
-   target.
-3. **Similarity scaling**: in ABC, the CORR-C↔C constraint family is
-   scaled by featural similarity and distance ([hansson-2010]
-   §4.2.1.1) — only sufficiently similar consonants enter into
-   correspondence. The TSL_2 stringset is sharp.
-4. **Speech-error parallels (palatal bias)**: [hansson-2010]'s
-   chapter 6 argues that consonant harmony has its roots in
-   speech-planning errors, with the palatal bias as the central
-   diagnostic. This is an extragrammatical claim outside any synchronic
-   surface description.
-5. **Similarity-graded transparency vs opacity**: [hansson-2010]'s
-   chapter 3 reviews cases where intervening segments behave
-   differently depending on how similar they are to the harmonizing
-   pair. Single-tier TSL with a fixed tier predicate cannot express
-   this — see the design-boundary docstring on `tierProject`
-   non-monotonicity in `ForbiddenPairs.lean`, and the load-bearing
-   gradient-OCP instance in
-   `Studies/FrischPierrehumbertBroe2004.lean`,
-   which formalises [frisch-pierrehumbert-broe-2004]'s
-   natural-classes similarity metric (eq. 7) and proves that no
-   two-valued categorical predictor fits its worked root types.
-   Closely related: the autosegmental/feature-geometry tradition
-   ([sagey-1986]) treats the harmonizing feature itself as a
-   tier-resident object; that representational layer is upstream of
-   the surface stringset characterized here.
-
-## Function-level subregular classification (cross-reference)
-
-The TSL_2 description here characterizes the **stringset** of Navajo
-sibilant harmony — the language that the harmony filter accepts. The
-**function** that maps an underlying form to its surface realization
-admits a separate subregular classification per
-the subregular function classes: long-distance consonant
-agreement is generally **Tier-Subsequential** (not ISL or OSL — those
-require a *contiguous* k-window), and per [hansson-2010]'s
-strictly-anticipatory directionality argument it is specifically
-**Right-Tier-Subsequential**. We do not encode the function-level
-classification here; the language-level TSL_2 statement is the cleaner
-unit because the directionality is upstream and the surface filter is
-direction-symmetric.
-
-## Navajo sibilant harmony — the leading case
-
-Navajo (Athapaskan; [hansson-2010] §1.1, §2.4.1.1) has two
-contrasting sibilant series: an alveolar series {s, z, ts, tsʼ, dz}
-and a postalveolar series {ʃ, ʒ, tʃ, tʃʼ, dʒ}. A sibilant in the
-verb root determines the realization of all sibilants in preceding
-"conjunct" prefixes. For example (data from McDonough 1991, cited
-as Hansson's example (6)): underlying /si-dʒéːʔ/ surfaces as
-[ʃidʒéːʔ] 'they lie (slender stiff objects)' — the alveolar /s/ in
-the prefix harmonizes to the postalveolar place of the root /dʒ/;
-underlying /ʃ-is-ná/ surfaces as [sisná] 'he carried me' — the
-postalveolar /ʃ/ in the prefix harmonizes to the alveolar place of
-the root /s/.
-
-The surface generalization: **no two sibilants of differing place
-(anterior vs posterior) may co-occur within the harmonic domain**.
-Equivalently, every tier-adjacent pair of sibilants must *agree* in
-place — the TSL_2 instance of `TierStrictlyLocalGrammar.agree`.
+* [hansson-2010]
+* [rose-walker-2011]
+* [rose-walker-2004]
+* [mcdonough-1991]
+* [sapir-hoijer-1967]
 -/
 
-namespace Phonology.Studies.Hansson2010
+namespace Hansson2010
 
-open Subregular Phonology
+open Subregular Subregular.Harmony Phonology.Harmony Data.Examples
 
--- ============================================================================
--- § 1: A toy Navajo segmental alphabet
--- ============================================================================
+/-! ### Transcriptions and the tier alphabet -/
 
-/-- A minimal alphabet sufficient to demonstrate Navajo sibilant harmony as
-a TSL_2 stringset. We do **not** model the full Navajo inventory — just
-enough segment classes to distinguish the relevant natural classes (the
-two sibilant series, non-sibilant consonants, vowels). -/
-inductive NSeg where
-  /-- An anterior (alveolar) sibilant: /s, z, ts, tsʼ, dz/. -/
-  | antSib
-  /-- A posterior (postalveolar) sibilant: /ʃ, ʒ, tʃ, tʃʼ, dʒ/. -/
-  | postSib
-  /-- A non-sibilant consonant — transparent for sibilant harmony. -/
-  | neutralC
-  /-- A vowel — transparent for sibilant harmony. -/
-  | vowel
-  deriving DecidableEq, Repr
+/-- The sibilant class of a transcription symbol: the alveolar series by its *s* or *z*, the
+postalveolar by its *ʃ* or *ʒ*, everything else off the tier. -/
+def classify (c : Char) : Sibilant :=
+  if c = 's' ∨ c = 'z' then .anterior else if c = 'ʃ' ∨ c = 'ʒ' then .posterior else .neutral
 
-/-- `NSeg`'s sibilant class, grounding the tier predicate in the shared
-`Subregular.Sibilant` substrate: the two sibilant series map to `anterior` and
-`posterior`, the transparent material (non-sibilant consonants, vowels) to `neutral`. -/
-@[reducible] def NSeg.toSibilant : NSeg → Sibilant
-  | .antSib => .anterior
-  | .postSib => .posterior
-  | .neutralC | .vowel => .neutral
+/-- The tier string of a transcription. -/
+def tierOf (s : String) : List Sibilant := s.toList.map classify
 
-/-- The harmonizing-class tier predicate: only sibilants project; non-sibilant
-consonants and vowels are transparent (off-tier). Grounded in `Sibilant.onTier`
-through `NSeg.toSibilant` rather than re-stipulated, so the tier choice — the
-substantive theoretical commitment — lives in one place. -/
-@[reducible] def NSeg.onTier (s : NSeg) : Prop := Sibilant.onTier s.toSibilant
+/-- The underlying form of a row, from its `underlying` feature. -/
+def ur (e : LinguisticExample) : List Sibilant := tierOf ((e.feature? "underlying").getD "")
 
-instance : DecidablePred NSeg.onTier :=
-  fun s => inferInstanceAs (Decidable (Sibilant.onTier s.toSibilant))
+/-- The surface form of a row. -/
+def sr (e : LinguisticExample) : List Sibilant := tierOf e.primaryText
 
--- ============================================================================
--- § 2: The TSL_2 grammar — instance of the AGREE specialization
--- ============================================================================
+/-- The sibilants of a word, in order. -/
+abbrev sibilants (w : List Sibilant) : List Sibilant := tierProject Sibilant.onTier w
 
-/-- The Navajo sibilant-harmony grammar as a tier-based strictly 2-local
-language: project to the sibilant tier (anterior + posterior sibilants),
-forbid any tier-adjacent disagreeing pair. Symmetric forbidden-pair
-relation = `(· ≠ ·)` restricted to on-tier elements, so the grammar is
-exactly the AGREE specialization `TierStrictlyLocalGrammar.agree NSeg.onTier`. -/
-@[reducible] def navajoSibilantHarmony : TierStrictlyLocalGrammar 2 NSeg :=
-  TierStrictlyLocalGrammar.agree NSeg.onTier
+theorem mem_sibilants_onTier {w : List Sibilant} {s : Sibilant} (h : s ∈ sibilants w) :
+    s.onTier := by
+  rw [sibilants, tierProject_eq_filter, List.mem_filter] at h
+  exact of_decide_eq_true h.2
 
--- ============================================================================
--- § 3: Concrete data — pre-harmony vs post-harmony surface forms
--- ============================================================================
+theorem mem_sibilants {w : List Sibilant} {s : Sibilant} (hs : s ∈ w) (h : s.onTier) :
+    s ∈ sibilants w := by
+  rw [sibilants, tierProject_eq_filter, List.mem_filter]
+  exact ⟨hs, decide_eq_true h⟩
 
-/-- A pre-harmony underlying form analogous to /si-dʒéːʔ/: an anterior
-sibilant prefix preceding a postalveolar sibilant in the root, across
-an intervening vowel. The two disagreeing sibilants are tier-adjacent
-under the sibilant projection. -/
-@[reducible] def preSiDze : List NSeg :=
-  [.antSib, .vowel, .postSib, .vowel, .neutralC]
+/-! ### The surface language -/
 
-/-- The post-harmony surface form analogous to [ʃidʒéːʔ]: the prefix
-sibilant has been realized as postalveolar to agree with the root. -/
-@[reducible] def postShiDze : List NSeg :=
-  [.postSib, .vowel, .postSib, .vowel, .neutralC]
+/-- The surface phonotactic (section 2.4.1.1): on the sibilant tier, adjacent sibilants agree
+in class, the tier-based strictly 2-local agree language. -/
+abbrev navajoSibilantHarmony : TierStrictlyLocalGrammar 2 Sibilant :=
+  TierStrictlyLocalGrammar.agree Sibilant.onTier
 
-/-- A control form analogous to [sisná]: only anterior sibilants in the
-word, with intervening vowels and a non-sibilant consonant. -/
-@[reducible] def controlOnlyAnterior : List NSeg :=
-  [.antSib, .vowel, .antSib, .neutralC, .vowel]
+theorem isTierStrictlyLocal : Language.IsTierStrictlyLocal 2 navajoSibilantHarmony.language :=
+  ⟨_, rfl⟩
 
-/-- A control form with no sibilants at all — vacuously legal, since the
-tier projection is empty. -/
-@[reducible] def controlNoSibilants : List NSeg :=
-  [.neutralC, .vowel, .neutralC, .vowel, .neutralC]
+theorem isBTSL : Language.IsBTSL 2 navajoSibilantHarmony.language :=
+  isTierStrictlyLocal.toIsBTSL
 
--- ============================================================================
--- § 4: Theorems — TSL_2 captures the surface phonotactic
--- ============================================================================
+/-- A word is harmonic iff its sibilants are all of one class. -/
+theorem mem_language_iff (w : List Sibilant) :
+    w ∈ navajoSibilantHarmony.language ↔ (sibilants w).IsChain (· = ·) := by
+  rw [navajoSibilantHarmony, TierStrictlyLocalGrammar.agree,
+    mem_ofForbiddenPairs_language_iff_filter_isChain, sibilants, tierProject_eq_filter]
+  simp only [ne_eq, not_not]
 
-/-- **Navajo sibilant harmony stringset is TSL_2** (Hansson 2010 §2.4.1.1).
-Explicit `IsTierStrictlyLocal 2` typing of the implicit complexity claim
-made by the `navajoSibilantHarmony : TierStrictlyLocalGrammar 2 NSeg` grammar — the
-co-extensiveness of "the surface phonotactic" and "TSL_2 stringset" was
-asserted in the file docstring; this theorem types that assertion. -/
-theorem navajoSibilantHarmony_lang_isTSL2 :
-    Language.IsTierStrictlyLocal 2
-      navajoSibilantHarmony.language :=
-  ⟨navajoSibilantHarmony, rfl⟩
+/-! ### Anticipatory harmony, section 1.1 -/
 
-/-- **BTSL_2 corollary** (via the PR-4 bridge `IsTierStrictlyLocal.toIsBTSL`
-in `Subregular.Multitier`): the Navajo sibilant harmony
-stringset lies in the multitier (Boolean) closure of strictly local languages —
-immediate from the TSL_2 result. -/
-theorem navajoSibilantHarmony_lang_isBTSL2 :
-    Language.IsBTSL 2 navajoSibilantHarmony.language :=
-  navajoSibilantHarmony_lang_isTSL2.toIsBTSL
+/-- The trigger: the rightmost sibilant of a word. -/
+def trigger (w : List Sibilant) : Option Sibilant := (sibilants w).getLast?
 
-/-- The pre-harmony underlying form is **rejected**: it contains a
-tier-adjacent disagreeing-sibilant pair. -/
-theorem preSiDze_violates : preSiDze ∉ navajoSibilantHarmony.language := by
-  unfold navajoSibilantHarmony TierStrictlyLocalGrammar.agree; decide
+/-- A sibilant takes the trigger's class; anything off the tier is untouched. -/
+def harmonize (t : Option Sibilant) (s : Sibilant) : Sibilant :=
+  if s.onTier then t.getD s else s
 
-/-- The post-harmony surface form is **accepted**: every tier-adjacent
-sibilant pair agrees in place. -/
-theorem postShiDze_legal : postShiDze ∈ navajoSibilantHarmony.language := by
-  unfold navajoSibilantHarmony TierStrictlyLocalGrammar.agree; decide
+/-- Anticipatory sibilant harmony: every sibilant takes the class of the rightmost one. -/
+def anticipatory (w : List Sibilant) : List Sibilant := w.map (harmonize (trigger w))
 
-/-- A form with only anterior sibilants is **accepted** — the AGREE
-constraint forbids disagreement, not co-occurrence. -/
-theorem controlOnlyAnterior_legal :
-    controlOnlyAnterior ∈ navajoSibilantHarmony.language := by
-  unfold navajoSibilantHarmony TierStrictlyLocalGrammar.agree; decide
+theorem harmonize_of_not_onTier {t : Option Sibilant} {s : Sibilant} (h : ¬ s.onTier) :
+    harmonize t s = s :=
+  if_neg h
 
-/-- Forms with no sibilants are vacuously accepted — the tier projection
-is empty, so there are no tier-adjacent pairs to check. -/
-theorem controlNoSibilants_legal :
-    controlNoSibilants ∈ navajoSibilantHarmony.language := by
-  unfold navajoSibilantHarmony TierStrictlyLocalGrammar.agree; decide
+theorem harmonize_some_of_onTier {t s : Sibilant} (h : s.onTier) : harmonize (some t) s = t :=
+  if_pos h
 
--- ============================================================================
--- § 5: OT-side bridge — markedness constraint co-extensive with the language
--- ============================================================================
+theorem trigger_onTier {w : List Sibilant} {t : Sibilant} (h : trigger w = some t) :
+    t.onTier := by
+  obtain ⟨l, hl⟩ := List.getLast?_eq_some_iff.mp h
+  exact mem_sibilants_onTier (hl ▸ List.mem_append_right l (List.mem_singleton_self t))
 
-/-- The OT markedness constraint corresponding to the Navajo
-sibilant-harmony phonotactic: AGREE-style markedness penalizing each
-tier-adjacent disagreeing sibilant pair on the sibilant tier. The OT-side
-counterpart of `navajoSibilantHarmony` — same tier predicate, packaged as
-a `Constraint` via the `mkAgreeOnTier` specialization. The TSL
-grammar characterizes the *language*; this constraint *evaluates* it. -/
-def navajoAgree : Constraints.Constraint (List NSeg) :=
-  Constraints.mkAgreeOnTier
-    (TierProjection.byClass NSeg.onTier) id
+theorem onTier_harmonize {t : Option Sibilant} (ht : ∀ s ∈ t, s.onTier) (s : Sibilant) :
+    (harmonize t s).onTier ↔ s.onTier := by
+  cases t with
+  | none => simp [harmonize]
+  | some t =>
+    by_cases hs : s.onTier
+    · simp [harmonize, hs, ht t rfl]
+    · simp [harmonize, hs]
 
-/-- **Bridge**: `navajoAgree` evaluates to zero on a candidate iff the
-candidate is in the TSL_2 language. The "OT-side" and "subregular-side"
-characterizations of the same Navajo phonotactic coincide — making the
-co-extensiveness of the two analyses true by construction rather than a
-separately-proved equivalence. -/
-theorem navajoAgree_zero_iff_in_TSL (c : List NSeg) :
-    navajoAgree c = 0 ↔ c ∈ navajoSibilantHarmony.language :=
-  mkAgreeOnTier_zero_iff_in_agree_language NSeg.onTier id c
+theorem sibilants_map_harmonize {t : Option Sibilant} (ht : ∀ s ∈ t, s.onTier)
+    (w : List Sibilant) : sibilants (w.map (harmonize t)) = (sibilants w).map (harmonize t) := by
+  simp only [sibilants, tierProject_eq_filter, List.filter_map]
+  congr 1
+  exact List.filter_congr λ s _ => by simp [onTier_harmonize ht]
 
-end Phonology.Studies.Hansson2010
+theorem sibilants_anticipatory (w : List Sibilant) :
+    sibilants (anticipatory w) = (sibilants w).map (harmonize (trigger w)) :=
+  sibilants_map_harmonize (λ _ h => trigger_onTier h) w
+
+/-- A word is harmonic iff each of its sibilants is of the trigger's class. -/
+theorem mem_language_iff_trigger (w : List Sibilant) :
+    w ∈ navajoSibilantHarmony.language ↔ ∀ s ∈ sibilants w, trigger w = some s := by
+  rw [mem_language_iff]
+  constructor
+  · intro h s hs
+    rw [List.isChain_eq_iff_eq_replicate] at h
+    rcases hh : (sibilants w).head? with _ | a
+    · exact absurd hs (by simp [List.head?_eq_none_iff.mp hh])
+    · have hrep := h a hh
+      obtain ⟨n, hn⟩ := Nat.exists_eq_succ_of_ne_zero (List.length_pos_of_mem hs).ne'
+      rw [hn] at hrep
+      have hsa : s = a := List.eq_of_mem_replicate (n := n + 1) (by rwa [hrep] at hs)
+      rw [hsa, trigger, hrep, List.replicate_succ']
+      simp
+  · intro h
+    exact List.Pairwise.isChain (List.pairwise_of_forall_mem_list λ a ha b hb =>
+      Option.some_inj.mp ((h a ha).symm.trans (h b hb)))
+
+/-- The trigger is left in place: the rightmost sibilant determines the rest. -/
+theorem trigger_anticipatory (w : List Sibilant) : trigger (anticipatory w) = trigger w := by
+  rw [trigger, sibilants_anticipatory, List.getLast?_map, ← trigger]
+  rcases ht : trigger w with _ | t
+  · rfl
+  · simp [harmonize_some_of_onTier (trigger_onTier ht)]
+
+/-- The harmonized word is harmonic. -/
+theorem anticipatory_mem_language (w : List Sibilant) :
+    anticipatory w ∈ navajoSibilantHarmony.language := by
+  rw [mem_language_iff_trigger, trigger_anticipatory, sibilants_anticipatory]
+  intro s hs
+  obtain ⟨u, hu, rfl⟩ := List.mem_map.mp hs
+  rcases ht : trigger w with _ | t
+  · have : sibilants w = [] := List.getLast?_eq_none_iff.mp (by simpa [trigger] using ht)
+    simp [this] at hu
+  · rw [harmonize_some_of_onTier (mem_sibilants_onTier hu)]
+
+/-- A harmonic word is a fixed point of the harmony. -/
+theorem anticipatory_eq_self_of_mem {w : List Sibilant}
+    (h : w ∈ navajoSibilantHarmony.language) : anticipatory w = w := by
+  rw [mem_language_iff_trigger] at h
+  refine (List.map_congr_left λ s hs => ?_).trans (List.map_id w)
+  by_cases hon : s.onTier
+  · rw [h s (mem_sibilants hs hon)]
+    exact harmonize_some_of_onTier hon
+  · exact harmonize_of_not_onTier hon
+
+/-- The surface language is exactly the set of fixed points of anticipatory harmony: the
+stringset the tier-based grammar recognizes and the map the harmony computes are one object. -/
+theorem mem_language_iff_anticipatory_eq (w : List Sibilant) :
+    w ∈ navajoSibilantHarmony.language ↔ anticipatory w = w :=
+  ⟨anticipatory_eq_self_of_mem, λ h => h ▸ anticipatory_mem_language w⟩
+
+/-- Neutralization (4): prefixes differing only in the class of a sibilant surface alike once a
+sibilant follows. -/
+theorem anticipatory_cons_eq {a b : Sibilant} {w : List Sibilant} (ha : a.onTier)
+    (hb : b.onTier) {t : Sibilant} (ht : trigger w = some t) :
+    anticipatory (a :: w) = anticipatory (b :: w) := by
+  have htr : ∀ c : Sibilant, c.onTier → trigger (c :: w) = some t := λ c hc => by
+    have hc' : sibilants (c :: w) = c :: sibilants w := by
+      simp [sibilants, tierProject_eq_filter, hc]
+    rw [trigger, hc', List.getLast?_cons, ← trigger, ht]
+    rfl
+  simp only [anticipatory, List.map_cons, htr a ha, htr b hb, harmonize_some_of_onTier ha,
+    harmonize_some_of_onTier hb]
+
+/-! ### The examples -/
+
+/-- The anticipatory examples of (3), (4), (6), (11), (13), and (15): the map takes each
+underlying form to its surface sibilants. -/
+theorem anticipatory_rows :
+    ∀ e ∈ Examples.all, e.feature? "directionality" = some "anticipatory" →
+      sibilants (anticipatory (ur e)) = sibilants (sr e) := by
+  decide
+
+/-- The book's qualification (section 3.1.2): the s-perfective (12) and s-destruct (14)
+prefixes assimilate the following first-person prefix perseveratively, which the anticipatory
+map mispredicts. -/
+theorem perseveratory_rows :
+    ∀ e ∈ Examples.all, e.feature? "directionality" = some "perseveratory" →
+      sibilants (anticipatory (ur e)) ≠ sibilants (sr e) := by
+  decide
+
+/-- The underlying form of (6a) is disharmonic. -/
+theorem ur_ex6a_ii_violates : ur Examples.ex6a_ii ∉ navajoSibilantHarmony.language := by
+  rw [mem_language_iff_anticipatory_eq]
+  decide
+
+/-- Its surface form is harmonic. -/
+theorem sr_ex6a_ii_legal : sr Examples.ex6a_ii ∈ navajoSibilantHarmony.language := by
+  rw [mem_language_iff_anticipatory_eq]
+  decide
+
+/-! ### The harmony system -/
+
+/-- Anteriority as the harmonic value. -/
+def value : Sibilant → Option Bool
+  | .anterior => some true
+  | .posterior => some false
+  | .neutral => none
+
+/-- Write an anteriority value. -/
+def write (v : Bool) (_ : Sibilant) : Sibilant := if v then .anterior else .posterior
+
+/-- Navajo sibilant harmony as a harmony `System`: both sibilant series participate, all
+else is transparent, nothing blocks, and the direction is leftward. -/
+def navajo : System Sibilant where
+  pattern :=
+    { value := value
+      participation := λ s => if s.onTier then .participating else .transparent
+      direction := .leftward }
+  targetIsContext := Sibilant.onTier
+  isTarget := Sibilant.onTier
+  write := write
+  value_write := λ v _ => by cases v <;> rfl
+
+theorem pattern_onTier_iff (s : Sibilant) : navajo.pattern.OnTier s ↔ s.onTier := by
+  cases s <;> simp [navajo, Pattern.OnTier]
+
+/-- The leftmost sibilant of a word. -/
+def first (w : List Sibilant) : Option Sibilant := (sibilants w).head?
+
+theorem windowOutput_nil (x : Sibilant) : navajo.spreadRule.windowOutput [] x = [x] := by
+  simp [System.spreadRule, System.isBlocker, navajo]
+
+theorem windowOutput_singleton {t : Sibilant} (ht : t.onTier) {x : Sibilant} (hx : x.onTier) :
+    navajo.spreadRule.windowOutput [t] x = [t] := by
+  cases t <;> cases x <;> simp_all [System.spreadRule, System.isBlocker, navajo, value, write]
+
+theorem applyOnTierAux_eq (t : Option Sibilant) (ht : ∀ s ∈ t, s.onTier) (xs : List Sibilant) :
+    navajo.spreadRule.applyOnTierAux navajo.pattern.OnTier t.toList xs =
+      xs.map (harmonize (t.or (first xs))) := by
+  induction xs generalizing t with
+  | nil => rfl
+  | cons x xs ih =>
+    by_cases hx : x.onTier
+    · rw [OSLRule.applyOnTierAux, if_pos ((pattern_onTier_iff x).mpr hx)]
+      have hfirst : first (x :: xs) = some x := by
+        simp [first, sibilants, tierProject_eq_filter, List.filter_cons_of_pos, hx]
+      cases t with
+      | none =>
+        have := ih (some x) (λ s hs => Option.mem_some_iff.mp hs ▸ hx)
+        simp only [Option.toList] at this
+        simp only [Option.toList, List.nil_append, windowOutput_nil, List.rtake,
+          List.length_singleton, Nat.reduceSub, Nat.sub_self, List.drop_zero, this, hfirst]
+        simp [Option.or, harmonize_some_of_onTier hx]
+      | some t =>
+        have := ih (some t) ht
+        simp only [Option.toList] at this
+        simp only [Option.toList, windowOutput_singleton (ht t rfl) hx, List.rtake,
+          List.singleton_append, List.length_cons, List.length_nil, Nat.reduceAdd,
+          Nat.reduceSub, List.drop_succ_cons, List.drop_zero, this]
+        simp [Option.or, harmonize_some_of_onTier hx]
+    · rw [OSLRule.applyOnTierAux, if_neg ((pattern_onTier_iff x).not.mpr hx), ih t ht]
+      simp [first, sibilants, tierProject_eq_filter, List.filter_cons_of_neg, hx,
+        harmonize_of_not_onTier hx]
+
+/-- The substrate's progressive harmony over the Navajo system: every sibilant takes the
+class of the leftmost one. -/
+theorem transduceWord_eq (w : List Sibilant) :
+    navajo.transduceWord w = w.map (harmonize (first w)) := by
+  simpa [System.transduceWord, OSLRule.applyOnTier, Option.or] using
+    applyOnTierAux_eq none (by simp) w
+
+/-- Anticipatory harmony is the substrate's harmony system run from the right. -/
+theorem anticipatory_eq_transduceWord (w : List Sibilant) :
+    anticipatory w = (navajo.transduceWord w.reverse).reverse := by
+  rw [transduceWord_eq, List.map_reverse, List.reverse_reverse, anticipatory]
+  congr 1
+  simp [first, trigger, sibilants, tierProject_eq_filter, List.filter_reverse,
+    List.head?_reverse]
+
+end Hansson2010

--- a/Linglib/Studies/McMullin2016.lean
+++ b/Linglib/Studies/McMullin2016.lean
@@ -39,7 +39,7 @@ is formalised here.
 
 namespace McMullin2016
 
-open Subregular Phonology.Studies.Hansson2010
+open Subregular Hansson2010
 
 /-! ### Transparent harmony: Navajo is SP_2 as well as TSL_2 -/
 
@@ -48,24 +48,24 @@ language `Studies/Hansson2010.lean` builds as TSL_2, not a parallel SP stipulati
 the two classifications are of one stringset by construction. -/
 theorem navajoSibilantHarmony_lang_isSP2 :
     navajoSibilantHarmony.language.IsStrictlyPiecewise 2 :=
-  TierStrictlyLocalGrammar.agree_language_isStrictlyPiecewise NSeg.onTier
+  TierStrictlyLocalGrammar.agree_language_isStrictlyPiecewise Sibilant.onTier
 
 /-- The tier-based and subsequence-based grammars for Navajo generate the same
-language — the instance at `NSeg.onTier` of `TierStrictlyLocalGrammar.agree_language_eq_sp`. -/
+language — the instance at `Sibilant.onTier` of `TierStrictlyLocalGrammar.agree_language_eq_sp`. -/
 theorem navajoSibilantHarmony_language_eq_sp :
-    navajoSibilantHarmony.language = (StrictlyPiecewiseGrammar.agree NSeg.onTier).language 2 :=
-  TierStrictlyLocalGrammar.agree_language_eq_sp NSeg.onTier
+    navajoSibilantHarmony.language = (StrictlyPiecewiseGrammar.agree Sibilant.onTier).language 2 :=
+  TierStrictlyLocalGrammar.agree_language_eq_sp Sibilant.onTier
 
 /-- [hansson-2010]'s minimal pair under the SP_2 description: the pre-harmony
 /si-dʒéːʔ/ is rejected and the surface [ʃidʒéːʔ] accepted. Both transfer along the
 equality of languages rather than being recomputed. -/
-theorem preSiDze_violates_sp :
-    preSiDze ∉ (StrictlyPiecewiseGrammar.agree NSeg.onTier).language 2 :=
-  navajoSibilantHarmony_language_eq_sp ▸ preSiDze_violates
+theorem ur_ex6a_ii_violates_sp :
+    ur Examples.ex6a_ii ∉ (StrictlyPiecewiseGrammar.agree Sibilant.onTier).language 2 :=
+  navajoSibilantHarmony_language_eq_sp ▸ ur_ex6a_ii_violates
 
-theorem postShiDze_legal_sp :
-    postShiDze ∈ (StrictlyPiecewiseGrammar.agree NSeg.onTier).language 2 :=
-  navajoSibilantHarmony_language_eq_sp ▸ postShiDze_legal
+theorem sr_ex6a_ii_legal_sp :
+    sr Examples.ex6a_ii ∈ (StrictlyPiecewiseGrammar.agree Sibilant.onTier).language 2 :=
+  navajoSibilantHarmony_language_eq_sp ▸ sr_ex6a_ii_legal
 
 /-! ### Opaque harmony: blocking is strictly piecewise at no width -/
 

--- a/references.bib
+++ b/references.bib
@@ -3882,7 +3882,7 @@
   doi       = {10.1023/B:NALA.0000005557.78535.3c},
   subfield  = {phonology/ocp},
   role      = {primary},
-  sources   = {Data/Examples/FrischPierrehumbertBroe2004.json;Phonology/OCP.lean;Studies/FrischPierrehumbertBroe2004.lean;Studies/Hansson2010.lean}
+  sources   = {Data/Examples/FrischPierrehumbertBroe2004.json;Phonology/OCP.lean;Studies/FrischPierrehumbertBroe2004.lean}
 }% REF: Gunlogson, C. (2003). *True to Form*. Routledge.
 ,
   year      = {2003},
@@ -11632,7 +11632,7 @@
   doi       = {10.1353/lan.2004.0144},
   subfield  = {phonology},
   role      = {primary},
-  sources   = {Studies/RoseWalker2004.lean}
+  sources   = {Phonology/Subregular/Harmony.lean;Studies/Hansson2010.lean;Studies/RoseWalker2004.lean;Studies/SandeClemDabkowski2026.lean}
 }
 
 % REF: Hansson, G. Ó. (2010). Consonant Harmony: Long-Distance Interaction in Phonology. UC Publications in Linguistics 145.
@@ -11648,7 +11648,7 @@
   url       = {https://escholarship.org/uc/item/2qs7r1mw},
   subfield  = {phonology},
   role      = {primary},
-  sources   = {Studies/Hansson2010.lean;Studies/McMullin2016.lean}
+  sources   = {Data/Examples/Hansson2010.json;Phonology/Subregular/ForbiddenPairs.lean;Studies/Hansson2010.lean;Studies/Lambert2026.lean;Studies/McMullin2016.lean;Studies/RoseWalker2004.lean}
 }
 
 % REF: McMullin, K. J. (2016). Tier-based locality in long-distance phonotactics: Learnability and typology. PhD thesis, University of British Columbia.
@@ -11675,7 +11675,7 @@
   subfield  = {phonology},
   role      = {primary},
   validated = {true},
-  sources   = {Fragments/Turkish/VowelHarmony.lean;Fragments/Finnish/VowelHarmony.lean;Fragments/Hungarian/VowelHarmony.lean;Phonology/Subregular/Harmony.lean;Phonology/OptimalityTheory/Correspondence.lean}
+  sources   = {Fragments/Finnish/VowelHarmony.lean;Fragments/Hungarian/VowelHarmony.lean;Phonology/Subregular/Harmony.lean;Studies/Hansson2010.lean;Studies/SiptarTorkenczy2000.lean}
 }
 
 % REF: Siptár, P. & Törkenczy, M. (2000). The Phonology of Hungarian. Oxford University Press.
@@ -23041,7 +23041,7 @@
   subfield  = {phonology},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Finnish/VowelHarmony.lean;Morphology/Morphotactics/CVTemplate.lean;Phonology/Autosegmental/AR.lean;Phonology/Autosegmental/Floating.lean;Phonology/Autosegmental/Junction.lean;Phonology/Autosegmental/NonCrossing.lean;Phonology/Constraints/Basic.lean;Phonology/OCP.lean;Phonology/Subregular/Harmony.lean;Phonology/Subregular/OCP.lean;Phonology/Subregular/TierProjection.lean;Phonology/Subregular/TierRule.lean;Phonology/Tone/Basic.lean;Studies/Belth2026.lean;Studies/Faust2026.lean;Studies/Hansson2010.lean;Studies/Rolle2018.lean;Studies/Sagey1986.lean}
+  sources   = {Fragments/Finnish/VowelHarmony.lean;Morphology/Morphotactics/CVTemplate.lean;Phonology/Autosegmental/AR.lean;Phonology/Autosegmental/Floating.lean;Phonology/Autosegmental/Junction.lean;Phonology/Autosegmental/NonCrossing.lean;Phonology/Constraints/Basic.lean;Phonology/OCP.lean;Phonology/Subregular/Harmony.lean;Phonology/Subregular/OCP.lean;Phonology/Subregular/TierProjection.lean;Phonology/Subregular/TierRule.lean;Phonology/Tone/Basic.lean;Studies/Belth2026.lean;Studies/Faust2026.lean;Studies/Rolle2018.lean;Studies/Sagey1986.lean}
 }% REF: Rizzi, L. (1978). A restructuring rule in Italian syntax. In Keyser (ed.), Recent Transformational Studies in European L
 @article{rizzi-1978,
   author    = {Rizzi, Luigi},
@@ -24213,7 +24213,7 @@
     subfield  = {phonology},
   validated = {true},
   role      = {cited},
-  sources   = {Core/Order/Interval.lean;Features/Phi/Geometry.lean;Phonology/Autosegmental/NonCrossing.lean;Phonology/FeatureGeometry.lean;Phonology/Segmental/FeatureClass.lean;Studies/HalleVauxWolfe2000.lean;Studies/Hansson2010.lean;Studies/Sagey1986.lean}
+  sources   = {Core/Order/Interval.lean;Features/Phi/Geometry.lean;Phonology/Autosegmental/NonCrossing.lean;Phonology/FeatureGeometry.lean;Phonology/Segmental/FeatureClass.lean;Studies/HalleVauxWolfe2000.lean;Studies/Sagey1986.lean}
 }
 @incollection{stojkovic-2026,
   author    = {Stojkovi{\'c}, Jelena},
@@ -31732,7 +31732,7 @@
   journal   = {Linguistic Inquiry},
   subfield  = {phonology},
   role      = {foundational},
-  sources   = {Phonology/Constraints/Basic.lean;Phonology/OCP.lean;Phonology/Subregular/ForbiddenPairs.lean;Phonology/Subregular/OCP.lean;Studies/Berent2026.lean;Studies/FrischPierrehumbertBroe2004.lean;Studies/Hansson2010.lean}
+  sources   = {Phonology/Constraints/Basic.lean;Phonology/OCP.lean;Phonology/Subregular/ForbiddenPairs.lean;Phonology/Subregular/OCP.lean;Studies/Berent2026.lean;Studies/FrischPierrehumbertBroe2004.lean}
 }
 
 % REF: Thue (1906). The classical theory of square-free words.
@@ -39021,7 +39021,8 @@
   publisher = {University of California Press},
   address   = {Berkeley, CA},
   subfield  = {descriptive-grammar},
-  role      = {cited}
+  role      = {cited},
+  sources   = {Data/Examples/Hansson2010.json;Studies/Hansson2010.lean}
 }
 
 % REF: Cook (1978). Palatalizations and related rules in Sarcee. In Linguistic
@@ -43892,4 +43893,26 @@
   subfield  = {semantics},
   role      = {cited},
   sources   = {Fragments/Washo/PropertyConcepts.lean}
+}
+
+@inproceedings{mcdonough-1991,
+  author    = {McDonough, Joyce},
+  year      = {1991},
+  title     = {On the representation of consonant harmony in {N}avajo},
+  booktitle = {Proceedings of the Tenth West Coast Conference on Formal Linguistics (WCCFL 10)},
+  pages     = {319--335},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Data/Examples/Hansson2010.json;Studies/Hansson2010.lean}
+}
+
+@book{faltz-1998,
+  author    = {Faltz, Leonard M.},
+  year      = {1998},
+  title     = {The {N}avajo verb: A grammar for students and scholars},
+  publisher = {University of New Mexico Press},
+  address   = {Albuquerque},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Data/Examples/Hansson2010.json}
 }


### PR DESCRIPTION
Recut Hansson2010 around the anticipatory harmony map rather than a toy alphabet.

- `anticipatory` on the substrate's sibilant tier alphabet; its fixed points are exactly the TSL_2 agree language (`mem_language_iff_anticipatory_eq`), the trigger stays put, and prefix contrasts neutralize (4)
- Navajo is the substrate's harmony `System` run from the right (`anticipatory_eq_transduceWord`), the same object as the Turkish, Finnish, and Hungarian vowel harmonies
- 21 Navajo rows from sections 1.1, 2.4.1.1, and 3.1.2 with underlying forms; the theorems read tier strings off the transcriptions, reproduce every anticipatory row, and show the map mispredicts the book's own perseveratory s-perfective and s-destruct cases; McMullin2016 repointed at the derived examples
