### PR TITLE
refactor(Studies/Heim1983): context change potentials and every

### DIFF
--- a/Linglib/Data/Examples/Heim1983.json
+++ b/Linglib/Data/Examples/Heim1983.json
@@ -1,0 +1,322 @@
+[
+  {
+    "id": "heim1983_ex1",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(1)"
+    },
+    "language": "stan1293",
+    "primaryText": "The king has a son.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "0"
+      ],
+      [
+        "presupposes",
+        "there is a king"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex2",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(2)"
+    },
+    "language": "stan1293",
+    "primaryText": "The king's son is bald.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "0"
+      ],
+      [
+        "presupposes",
+        "the king has a son"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex3",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(3)"
+    },
+    "language": "stan1293",
+    "primaryText": "If the king has a son, the king's son is bald.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "0"
+      ],
+      [
+        "presupposes",
+        "there is a king"
+      ],
+      [
+        "filtered",
+        "the king has a son"
+      ]
+    ],
+    "comment": "Inherits the presupposition both constituents carry, not the one the consequent adds.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex5",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(5)"
+    },
+    "language": "stan1293",
+    "primaryText": "If John has children, then Mary will not like his twins.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "marginal",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.2"
+      ],
+      [
+        "presupposes",
+        "someone with children has twins"
+      ],
+      [
+        "gazdar",
+        "nothing"
+      ],
+      [
+        "kp",
+        "as reported"
+      ]
+    ],
+    "comment": "Slightly strange out of context; Karttunen and Peters predict this, Gazdar the opposite.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex6",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(6)"
+    },
+    "language": "stan1293",
+    "primaryText": "If John has twins, then Mary will not like his children.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.2"
+      ],
+      [
+        "presupposes",
+        "nothing"
+      ],
+      [
+        "gazdar",
+        "John has children"
+      ],
+      [
+        "kp",
+        "nothing"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex7",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(7)"
+    },
+    "language": "stan1293",
+    "primaryText": "Every nation cherishes its king.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.3"
+      ],
+      [
+        "presupposes",
+        "every nation has a king"
+      ],
+      [
+        "kp",
+        "every nation has a king"
+      ]
+    ],
+    "comment": "Derived from (21) and (22) in §3.2.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex16",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(16)"
+    },
+    "language": "stan1293",
+    "primaryText": "The king of France didn't come.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.3"
+      ],
+      [
+        "global",
+        "France has a king"
+      ],
+      [
+        "local",
+        "either France has no king or he didn't come"
+      ]
+    ],
+    "comment": "Global accommodation is preferred; the local option is taken when the speaker continues with 'because France doesn't have a king'.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex23",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(23)"
+    },
+    "language": "stan1293",
+    "primaryText": "Everyone who serves his king will be rewarded.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "presupposes",
+        "everyone has a king"
+      ],
+      [
+        "kp",
+        "nothing"
+      ]
+    ],
+    "comment": "A presupposition in the restrictor; Heim's prediction differs from Karttunen and Peters's.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex24",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(24)"
+    },
+    "language": "stan1293",
+    "primaryText": "No nation cherishes its king.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "cooper",
+        "every nation has a king"
+      ],
+      [
+        "lernerZimmermann",
+        "some nation has a king"
+      ]
+    ],
+    "comment": "The paper sides with Cooper, barring local accommodation; the CCP of 'no' is not given.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "heim1983_ex25",
+    "source": {
+      "bibkey": "heim-1983",
+      "paperLabel": "(25)"
+    },
+    "language": "stan1293",
+    "primaryText": "A fat man was pushing his bicycle.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.3"
+      ],
+      [
+        "kp",
+        "some fat man had a bicycle"
+      ],
+      [
+        "presupposes",
+        "every fat man had a bicycle, unless accommodated"
+      ]
+    ],
+    "comment": "The universal presupposition is avoided by accommodating that the fat man in question had a bicycle in the course of the update.",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/Heim1983.lean
+++ b/Linglib/Data/Examples/Heim1983.lean
@@ -1,0 +1,198 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Heim1983` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Heim1983.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Heim1983.Examples`.
+-/
+
+namespace Heim1983.Examples
+
+open Data.Examples
+
+def ex1 : LinguisticExample :=
+  { id := "heim1983_ex1"
+    source := ⟨"heim-1983", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The king has a son."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "0"), ("presupposes", "there is a king")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2 : LinguisticExample :=
+  { id := "heim1983_ex2"
+    source := ⟨"heim-1983", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The king's son is bald."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "0"), ("presupposes", "the king has a son")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3 : LinguisticExample :=
+  { id := "heim1983_ex3"
+    source := ⟨"heim-1983", "(3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If the king has a son, the king's son is bald."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "0"), ("presupposes", "there is a king"), ("filtered", "the king has a son")]
+    comment := "Inherits the presupposition both constituents carry, not the one the consequent adds."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex5 : LinguisticExample :=
+  { id := "heim1983_ex5"
+    source := ⟨"heim-1983", "(5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If John has children, then Mary will not like his twins."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.2"), ("presupposes", "someone with children has twins"), ("gazdar", "nothing"), ("kp", "as reported")]
+    comment := "Slightly strange out of context; Karttunen and Peters predict this, Gazdar the opposite."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6 : LinguisticExample :=
+  { id := "heim1983_ex6"
+    source := ⟨"heim-1983", "(6)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "If John has twins, then Mary will not like his children."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.2"), ("presupposes", "nothing"), ("gazdar", "John has children"), ("kp", "nothing")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex7 : LinguisticExample :=
+  { id := "heim1983_ex7"
+    source := ⟨"heim-1983", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every nation cherishes its king."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.3"), ("presupposes", "every nation has a king"), ("kp", "every nation has a king")]
+    comment := "Derived from (21) and (22) in §3.2."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16 : LinguisticExample :=
+  { id := "heim1983_ex16"
+    source := ⟨"heim-1983", "(16)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The king of France didn't come."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.3"), ("global", "France has a king"), ("local", "either France has no king or he didn't come")]
+    comment := "Global accommodation is preferred; the local option is taken when the speaker continues with 'because France doesn't have a king'."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex23 : LinguisticExample :=
+  { id := "heim1983_ex23"
+    source := ⟨"heim-1983", "(23)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everyone who serves his king will be rewarded."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("presupposes", "everyone has a king"), ("kp", "nothing")]
+    comment := "A presupposition in the restrictor; Heim's prediction differs from Karttunen and Peters's."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex24 : LinguisticExample :=
+  { id := "heim1983_ex24"
+    source := ⟨"heim-1983", "(24)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No nation cherishes its king."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("cooper", "every nation has a king"), ("lernerZimmermann", "some nation has a king")]
+    comment := "The paper sides with Cooper, barring local accommodation; the CCP of 'no' is not given."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex25 : LinguisticExample :=
+  { id := "heim1983_ex25"
+    source := ⟨"heim-1983", "(25)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A fat man was pushing his bicycle."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.3"), ("kp", "some fat man had a bicycle"), ("presupposes", "every fat man had a bicycle, unless accommodated")]
+    comment := "The universal presupposition is avoided by accommodating that the fat man in question had a bicycle in the course of the update."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex1, ex2, ex3, ex5, ex6, ex7, ex16, ex23, ex24, ex25]
+
+end Heim1983.Examples

--- a/Linglib/Studies/Heim1983.lean
+++ b/Linglib/Studies/Heim1983.lean
@@ -1,162 +1,299 @@
-import Linglib.Semantics.Presupposition.Basic
 import Linglib.Semantics.Dynamic.Partial
 import Linglib.Studies.Karttunen1973
+import Linglib.Data.Examples.Heim1983
 
 /-!
-# Heim (1983): Projection and Partial Context Change
-[heim-1983] [karttunen-1973]
+# Heim (1983): On the Projection Problem for Presuppositions
 
-The classic King and factive-verb examples, their `PartialProp` denotations,
-and the filtering predictions derived from partial context change potentials.
+This file formalizes [heim-1983]: a context admits a sentence when the sentence's context
+change potential is defined on it, a sentence presupposes what every admitting context
+entails (12), and the heritage properties that [karttunen-peters-1979] stipulate for *if*
+and *not* are read off the potentials (14) and (15): a context admits "If A, B" iff it admits
+A and its update by A admits B, and negation is a hole. The King example (1)–(3) is worked as
+the paper does (`king_admits_iff`), the two ways of accommodating a presupposition under
+negation are (16)'s global and local readings (`globalNeg_entails`, `localNeg_entails`), and
+contexts as sets of sequence–world pairs (§3) carry the potentials for open sentences and
+for *every* (21): under the novelty stipulation (22), "Every nation cherishes its king"
+presupposes that every nation has a king (`every_nation_presupposes`), a presupposition in
+the restrictor projects universally (23), and an indefinite's presupposition projects
+universally unless it is accommodated in the course of the update (§3.3).
 
-## Main declarations
+## Implementation notes
 
-- `kingExists`, `kingBald`, `ifKingThenBald`: the King example, with
-  `ifKingThenBald_no_presup` showing conditional filtering.
-- `johnKnowsRaining`: the factive example.
-- `conditional_admitted_everywhere` / `bare_consequent_not_admitted`:
-  conditional filtering derived from `CCP.Partial` admittance rather than
-  stipulated.
-- `admits_seq_iff_conj`: [karttunen-1973]'s conjunction filter, relativized to
-  the context as its set of background assumptions, is admittance of the
-  sequenced update.
+The propositional part (§2) uses the substrate's partial context change potentials over a
+type of worlds: `ofPartialProp` for an atomic sentence with a presupposition, `cond` for
+(14), `neg` for (15), and `admits` for definedness, so that the heritage properties are the
+substrate's `admits_cond` and `admits_neg`. The file part (§3) uses the same potentials over
+pairs of a sequence `ℕ → M` and a world, with `atom`, `atomP`, and `every` stated here as
+(19)–(21) and entailment by a context read as inclusion. The paper gives no potential for
+*no* (24), so that sentence is a row only.
+
+## References
+
+* [heim-1983]
+* [karttunen-1973]
+* [karttunen-1974]
+* [karttunen-peters-1979]
+* [gazdar-1979]
+* [lewis-1979]
 -/
-
 
 namespace Heim1983
 
-open Presupposition
+open DynamicSemantics CCP.Partial Presupposition
 
-/--
-World type for the king example.
+/-! ### Admittance and presupposition (§2.1–§2.2) -/
 
-Two possible states:
-- kingExists: There is a (unique) king in this world
-- noKing: There is no king in this world
--/
-inductive KingWorld where
-  | kingExists : KingWorld
-  | noKing : KingWorld
-  deriving DecidableEq, Repr, Inhabited
+section Propositional
 
-/--
-"The king exists" — a presuppositionless assertion.
+variable {W : Type*}
 
-This sentence has:
-- No presupposition (trivially true)
-- Assertion: the king exists
--/
-def kingExists : PartialProp KingWorld :=
-  { presup := λ _ => True
-  , assertion := λ w => match w with
-      | .kingExists => True
-      | .noKing => False
-  }
+/-- An atomic sentence with presupposition `pre` and content `q`: its update is defined on a
+    context iff the context entails `pre`, and then intersects with `q`. -/
+def atomic (pre q : W → Prop) : CCP.Partial W := ofPartialProp ⟨pre, q⟩
 
-/--
-"The king is bald" — presupposes king exists.
+/-- (12): `S` presupposes `p` iff every context that admits `S` entails `p`. -/
+def Presupposes (φ : CCP.Partial W) (p : W → Prop) : Prop := ∀ c, φ.admits c → ∀ w ∈ c, p w
 
-This sentence has:
-- Presupposition: the king exists
-- Assertion: the king is bald (true when king exists)
--/
-def kingBald : PartialProp KingWorld :=
-  { presup := λ w => match w with
-      | .kingExists => True
-      | .noKing => False
-  , assertion := λ _ => True
-  }
+/-- (13): `S` is true in `w` with respect to `c` iff the context `c` updated by `S` is true
+    in `w`; defined only when `c` admits `S`. -/
+def TrueWrt (φ : CCP.Partial W) (c : Set W) (w : W) : Prop := ∃ h : φ.admits c, w ∈ (φ c).get h
 
-/--
-"If the king exists, the king is bald" — using filtering implication.
+/-- The content property is derivable from the potential: with respect to a context that is
+    true in `w` and admits it, an atomic sentence is true in `w` iff its content holds. -/
+theorem trueWrt_atomic {pre q : W → Prop} {c : Set W} {w : W} (hw : w ∈ c)
+    (h : (atomic pre q).admits c) : TrueWrt (atomic pre q) c w ↔ q w :=
+  ⟨λ ⟨_, hm⟩ => hm.2, λ hq => ⟨h, hw, hq⟩⟩
 
-Demonstrates presupposition filtering: the antecedent's assertion
-satisfies the consequent's presupposition.
--/
-def ifKingThenBald : PartialProp KingWorld :=
-  PartialProp.impFilter kingExists kingBald
+variable (king son bald : W → Prop)
 
-/--
-"If the king exists, the king is bald" has no presupposition.
+/-- (1) "The king has a son": presupposes a king, asserts that he has a son. -/
+def kingHasSon : CCP.Partial W := atomic king son
 
-This demonstrates presupposition filtering.
--/
-theorem ifKingThenBald_no_presup : ifKingThenBald.presup = λ _ => True := by
-  funext w
-  simp only [ifKingThenBald, PartialProp.impFilter, kingExists, kingBald]
-  cases w <;> simp
+/-- (2) "The king's son is bald": presupposes a king with a son. -/
+def kingsSonBald : CCP.Partial W := atomic (λ w => king w ∧ son w) bald
 
-/--
-World type for factive verb examples.
+/-- (3) "If the king has a son, the king's son is bald", by (14). -/
+def ifKingHasSon : CCP.Partial W := cond (kingHasSon king son) (kingsSonBald king son bald)
 
-Models whether it's raining and whether John believes it.
--/
-inductive RainWorld where
-  | rainingBelieved    -- It's raining and John believes it
-  | rainingNotBelieved -- It's raining but John doesn't believe it
-  | notRaining         -- It's not raining
-  deriving DecidableEq, Repr, Inhabited
+variable {king son bald}
 
-/--
-"John knows that it's raining" — factive presupposition.
+/-- §2.1: a context admits (3) iff it entails that there is a king: it must admit (1), and
+    its update by (1) then admits (2) automatically. -/
+theorem king_admits_iff (c : Set W) :
+    (ifKingHasSon king son bald).admits c ↔ ∀ w ∈ c, king w := by
+  constructor
+  · rintro ⟨h, -⟩
+    exact h
+  · intro h
+    exact ⟨h, λ w hw => ⟨h w hw.1, hw.2⟩⟩
 
-Presupposes: it's raining
-Asserts: John believes it's raining
--/
-def johnKnowsRaining : PartialProp RainWorld :=
-  { presup := λ w => match w with
-      | .rainingBelieved => True
-      | .rainingNotBelieved => True
-      | .notRaining => False
-  , assertion := λ w => match w with
-      | .rainingBelieved => True
-      | .rainingNotBelieved => False
-      | .notRaining => False
-  }
+/-- (3) presupposes that there is a king. -/
+theorem king_presupposes : Presupposes (ifKingHasSon king son bald) king :=
+  λ _ h => (king_admits_iff _).1 h
 
-/-! ### Filtering derived from partial CCPs
+/-- (3) does not presuppose that the king has a son, as soon as some world has a sonless
+    king. -/
+theorem not_presupposes_son (h : ∃ w, king w ∧ ¬ son w) :
+    ¬ Presupposes (ifKingHasSon king son bald) son := by
+  obtain ⟨w, hk, hs⟩ := h
+  intro hp
+  exact hs (hp {w} ((king_admits_iff _).2 λ _ hv => hv ▸ hk) w rfl)
 
-[heim-1983]'s actual machinery: sentences denote *partial* context change
-potentials (`DynamicSemantics.CCP.Partial`), and admittance does the
-projection work. The conditional's CCP is admitted by every context — the
-antecedent's update satisfies the consequent's king-presupposition — while
-the bare consequent's CCP is not admitted by the full context. -/
+/-! ### Accommodation (§2.3) -/
 
-open DynamicSemantics in
-/-- Every context admits ⟦if the king exists, the king is bald⟧: the
-    antecedent's update filters the consequent's presupposition
-    ([heim-1983]'s conditional CCP). -/
-theorem conditional_admitted_everywhere (c : Set KingWorld) :
-    (CCP.Partial.cond (CCP.Partial.ofPartialProp kingExists)
-      (CCP.Partial.ofPartialProp kingBald)).admits c := by
-  refine ⟨fun w _ => trivial, ?_⟩
-  rintro w ⟨_, ha⟩
-  cases w
-  · trivial
-  · exact ha
+variable (φ : CCP.Partial W) (p : Set W)
 
-open DynamicSemantics in
-/-- The bare consequent ⟦the king is bald⟧ is NOT admitted by the full
-    context: the `noKing` world fails the presupposition, which therefore
-    projects. -/
-theorem bare_consequent_not_admitted :
-    ¬ (CCP.Partial.ofPartialProp kingBald).admits Set.univ := by
-  intro h
-  exact h (Set.mem_univ .noKing)
+/-- (A) The global option: to evaluate "Not S" in a context that does not admit `S`, amend the
+    context to `c ∩ p` and compute `(c ∩ p) + Not S`. -/
+def globalNeg : CCP.Partial W := λ c => neg φ (c ∩ p)
 
-open DynamicSemantics CCP.Partial in
-/-- [karttunen-1973]'s filter for conjunction, relativized to the context itself as the set of
-background assumptions (his §9), is admittance of the sequenced update. -/
+/-- (B) The local option: amend the context to `c ∩ p` only to compute `(c ∩ p) + S`, and
+    subtract that from `c` itself. -/
+def localNeg : CCP.Partial W := λ c => (φ (c ∩ p)).map (c \ ·)
+
+variable {φ p}
+
+/-- Both options make the update defined once the amended context admits `S`. -/
+theorem globalNeg_admits {c : Set W} (h : φ.admits (c ∩ p)) : (globalNeg φ p).admits c := h
+
+theorem localNeg_admits {c : Set W} (h : φ.admits (c ∩ p)) : (localNeg φ p).admits c := h
+
+/-- The global option's result entails the accommodated presupposition: (16) read in
+    isolation has France with a king. -/
+theorem globalNeg_entails {c c' : Set W} (h : c' ∈ globalNeg φ p c) : c' ⊆ p :=
+  λ _ hw => ((neg_eliminative φ h) hw).2
+
+/-- The local option's result is the context minus the amended update: (16) continued with
+    "because France doesn't have a king" entails only that either France has no king or he
+    did not come. -/
+theorem localNeg_entails {came : W → Prop} {c c' : Set W}
+    (h : c' ∈ localNeg (atomic (· ∈ p) came) p c) : c' = {w ∈ c | w ∉ p ∨ ¬ came w} := by
+  obtain ⟨t, ht, rfl⟩ := (Part.mem_map_iff _).1 h
+  rw [atomic, ofPartialProp, Part.mem_mk_iff] at ht
+  obtain ⟨-, rfl⟩ := ht
+  ext w
+  simp only [Set.mem_sdiff, Set.mem_ofPred_eq, Set.mem_inter_iff]
+  tauto
+
+/-- The local option is what a continuation denying the presupposition needs: the global
+    result cannot contain a world without the presupposition, the local one can. -/
+theorem globalNeg_disjoint {c c' : Set W} (h : c' ∈ globalNeg φ p c) : c' ∩ pᶜ = ∅ :=
+  Set.eq_empty_of_forall_notMem λ _ ⟨hw, hn⟩ => hn (globalNeg_entails h hw)
+
+end Propositional
+
+/-! ### Files: contexts as sets of sequence–world pairs (§3) -/
+
+section Files
+
+variable {M W : Type*}
+
+/-- A file: a set of pairs of a sequence of individuals and a world (§3.1). -/
+abbrev File (M W : Type*) := Set ((ℕ → M) × W)
+
+/-- (17): the proposition a file determines. -/
+def File.prop (c : File M W) : Set W := {w | ∃ g, (g, w) ∈ c}
+
+/-- (18): a file is true in a world when some sequence fits it there. -/
+def File.TrueIn (c : File M W) (w : W) : Prop := ∃ g, (g, w) ∈ c
+
+/-- (19): the update by an open sentence `P xᵢ` without presupposition. -/
+def atom (P : M → W → Prop) (i : ℕ) : CCP.Partial ((ℕ → M) × W) :=
+  ofTotal λ c => {gw ∈ c | P (gw.1 i) gw.2}
+
+/-- (20): an open sentence `P xᵢ` presupposing `pre xᵢ` is admitted by a file iff every pair
+    in it satisfies the presupposition at the `i`-th member. -/
+def atomP (pre P : M → W → Prop) (i : ℕ) : CCP.Partial ((ℕ → M) × W) :=
+  λ c => ⟨∀ gw ∈ c, pre (gw.1 i) gw.2, λ _ => {gw ∈ c | P (gw.1 i) gw.2}⟩
+
+/-- (21): `c + Every xᵢ, A, B` keeps the pairs of `c` each of whose `i`-variants in `c + A`
+    survives in `c + A + B`; defined iff `c + A` and `c + A + B` are. -/
+def every (i : ℕ) (A B : CCP.Partial ((ℕ → M) × W)) : CCP.Partial ((ℕ → M) × W) :=
+  λ c => (A c).bind λ cA => (B cA).map λ cAB =>
+    {gw ∈ c | ∀ a, (Function.update gw.1 i a, gw.2) ∈ cA → (Function.update gw.1 i a, gw.2) ∈ cAB}
+
+/-- (22): the file does not yet distinguish the `i`-th member of a sequence, the lexical
+    novelty requirement of *every* and of an indefinite indexed `i`. -/
+def File.NovelIn (c : File M W) (i : ℕ) : Prop :=
+  ∀ g w a, (g, w) ∈ c ↔ (Function.update g i a, w) ∈ c
+
+theorem atom_admits (P : M → W → Prop) (i : ℕ) (c : File M W) : (atom P i).admits c := trivial
+
+theorem atomP_admits_iff (pre P : M → W → Prop) (i : ℕ) (c : File M W) :
+    (atomP pre P i).admits c ↔ ∀ gw ∈ c, pre (gw.1 i) gw.2 := Iff.rfl
+
+/-- The heritage of *every*: `c` admits `Every xᵢ, A, B` iff it admits `A` and `c + A` admits
+    `B`. -/
+theorem every_admits_iff (i : ℕ) (A B : CCP.Partial ((ℕ → M) × W)) (c : File M W) :
+    (every i A B).admits c ↔ ∃ h : A.admits c, B.admits ((A c).get h) :=
+  Iff.rfl
+
+/-- (ii) of §3.2: with a presupposition-free restrictor `A xᵢ` and a nuclear scope
+    presupposing `pre xᵢ`, the file must satisfy `pre` at the `i`-th member of every pair
+    that survives `A`. -/
+theorem every_atom_admits_iff (i : ℕ) (A pre B : M → W → Prop) (c : File M W) :
+    (every i (atom A i) (atomP pre B i)).admits c ↔
+      ∀ gw ∈ c, A (gw.1 i) gw.2 → pre (gw.1 i) gw.2 :=
+  ⟨λ ⟨_, h⟩ gw hgw hA => h gw ⟨hgw, hA⟩, λ h => ⟨trivial, λ gw hgw => h gw hgw.1 hgw.2⟩⟩
+
+/-- **(7) presupposes that every nation has a king.** Under (22) the condition of
+    `every_atom_admits_iff` holds iff, in every world of the file's proposition, every
+    individual satisfying the restrictor satisfies the presupposition: the novelty
+    stipulation is what makes the universal presupposition necessary, not only sufficient. -/
+theorem every_nation_presupposes (i : ℕ) (nation hasKing cherishes : M → W → Prop)
+    {c : File M W} (hc : c.NovelIn i) :
+    (every i (atom nation i) (atomP hasKing cherishes i)).admits c ↔
+      ∀ w ∈ c.prop, ∀ a, nation a w → hasKing a w := by
+  rw [every_atom_admits_iff]
+  constructor
+  · rintro h w ⟨g, hg⟩ a hn
+    have := h (Function.update g i a, w) ((hc g w a).1 hg)
+    simp only [Function.update_self] at this
+    exact this hn
+  · rintro h ⟨g, w⟩ hgw hn
+    exact h w ⟨g, hgw⟩ _ hn
+
+/-- (23): a presupposition in the restrictor projects universally too: "Everyone who serves
+    his king will be rewarded" presupposes that everyone has a king, where
+    [karttunen-peters-1979] predict no presupposition. -/
+theorem every_restrictor_presupposes (i : ℕ) (hasKing serves rewarded : M → W → Prop)
+    {c : File M W} (hc : c.NovelIn i) :
+    (every i (atomP hasKing serves i) (atom rewarded i)).admits c ↔
+      ∀ w ∈ c.prop, ∀ a, hasKing a w := by
+  constructor
+  · rintro ⟨h, -⟩ w ⟨g, hg⟩ a
+    simpa using h (Function.update g i a, w) ((hc g w a).1 hg)
+  · rintro h
+    exact ⟨λ gw hgw => h gw.2 ⟨gw.1, hgw⟩ _, trivial⟩
+
+/-! ### Indefinites (§3.3) -/
+
+/-- (26)–(27): "A fat man was pushing his bicycle" is the sequence of two open sentences,
+    the second presupposing that `xᵢ` has a bicycle. -/
+def fatManBicycle (i : ℕ) (fatMan hasBicycle pushing : M → W → Prop) :
+    CCP.Partial ((ℕ → M) × W) :=
+  seq (atom fatMan i) (atomP hasBicycle pushing i)
+
+/-- Without accommodation, (25) carries the universal presupposition that every fat man had
+    a bicycle, by (22): prima facie too strong. -/
+theorem fatManBicycle_admits_iff (i : ℕ) (fatMan hasBicycle pushing : M → W → Prop)
+    {c : File M W} (hc : c.NovelIn i) :
+    (fatManBicycle i fatMan hasBicycle pushing).admits c ↔
+      ∀ w ∈ c.prop, ∀ a, fatMan a w → hasBicycle a w := by
+  constructor
+  · rintro ⟨_, h⟩ w ⟨g, hg⟩ a hf
+    have := h (Function.update g i a, w) ⟨(hc g w a).1 hg, by simpa using hf⟩
+    simpa using this
+  · rintro h
+    exact ⟨trivial, λ gw hgw => h gw.2 ⟨gw.1, hgw.1⟩ _ hgw.2⟩
+
+/-- Accommodation in the course of the update: `c + "xᵢ is a fat man"` is amended with
+    "xᵢ has a bicycle" before the second sentence is evaluated. -/
+def fatManBicycleAcc (i : ℕ) (fatMan hasBicycle pushing : M → W → Prop) :
+    CCP.Partial ((ℕ → M) × W) :=
+  λ c => atomP hasBicycle pushing i {gw ∈ c | fatMan (gw.1 i) gw.2 ∧ hasBicycle (gw.1 i) gw.2}
+
+/-- The accommodated update is always defined, and its result entails that `xᵢ` was a fat
+    man, had a bicycle, and was pushing it. -/
+theorem fatManBicycleAcc_admits (i : ℕ) (fatMan hasBicycle pushing : M → W → Prop)
+    (c : File M W) : (fatManBicycleAcc i fatMan hasBicycle pushing).admits c :=
+  λ _ hgw => hgw.2.2
+
+theorem fatManBicycleAcc_entails (i : ℕ) (fatMan hasBicycle pushing : M → W → Prop)
+    {c c' : File M W} (h : c' ∈ fatManBicycleAcc i fatMan hasBicycle pushing c) :
+    ∀ gw ∈ c', fatMan (gw.1 i) gw.2 ∧ hasBicycle (gw.1 i) gw.2 ∧ pushing (gw.1 i) gw.2 := by
+  rw [fatManBicycleAcc, atomP, Part.mem_mk_iff] at h
+  obtain ⟨-, rfl⟩ := h
+  exact λ gw hgw => ⟨hgw.1.2.1, hgw.1.2.2, hgw.2⟩
+
+/-- The accommodated result entails nothing about fat men in general: in a two-individual
+    model where only one fat man has a bicycle, the update is defined and non-empty. -/
+theorem fatManBicycleAcc_not_universal :
+    ∃ (c' : File Bool Unit), c' ∈ fatManBicycleAcc 0 (λ _ _ => True) (λ a _ => a = true)
+        (λ _ _ => True) Set.univ ∧ c'.TrueIn () ∧
+      ¬ ∀ w ∈ c'.prop, ∀ a : Bool, a = true := by
+  refine ⟨_, Part.get_mem (fatManBicycleAcc_admits _ _ _ _ _), ⟨λ _ => true, ?_⟩, ?_⟩
+  · exact ⟨⟨Set.mem_univ _, trivial, rfl⟩, trivial⟩
+  · intro h
+    exact Bool.false_ne_true (h () ⟨λ _ => true, ⟨Set.mem_univ _, trivial, rfl⟩, trivial⟩ false)
+
+end Files
+
+/-! ### The conjunction filter of Karttunen (1973) -/
+
+/-- [karttunen-1973]'s filter for conjunction, relativized to the context itself as the set
+    of background assumptions, is admittance of the sequenced update. -/
 theorem admits_seq_iff_conj {W : Type*} (c : Set W) (p q : PartialProp W) :
     (seq (ofPartialProp p) (ofPartialProp q)).admits c ↔
       ∀ w ∈ c, (Karttunen1973.conj c p q).presup w := by
   rw [admits_seq_ofPartialProp]
   constructor
   · intro h w hw
-    exact ⟨(h w hw).1, fun hne => absurd (fun v hv ha => (h v hv).2 ha) hne⟩
+    exact ⟨(h w hw).1, λ hne => absurd (λ v hv ha => (h v hv).2 ha) hne⟩
   · intro h w hw
-    refine ⟨(h w hw).1, fun ha => ?_⟩
+    refine ⟨(h w hw).1, λ ha => ?_⟩
     by_contra hq
-    exact hq ((h w hw).2 fun he => hq (he w hw ha))
+    exact hq ((h w hw).2 λ he => hq (he w hw ha))
 
 end Heim1983

--- a/references.bib
+++ b/references.bib
@@ -4652,7 +4652,7 @@
   address   = {New York},
   subfield  = {pragmatics/implicature},
   role      = {cited},
-  sources   = {Data/Examples/FoxSpector2018.json;Studies/DegenTonhauser2022.lean;Studies/FillmoreKayOConnor1988.lean}
+  sources   = {Data/Examples/FoxSpector2018.json;Studies/DegenTonhauser2022.lean;Studies/FillmoreKayOConnor1988.lean;Studies/Heim1983.lean}
 }% REF: Hobbs, J. R. (1979). Coherence and Coreference. *Cognitive Science* 3, 67–90.
 @article{hobbs-1979,
   author    = {Hobbs, Jerry R.},
@@ -11096,7 +11096,7 @@
   subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Conditionals/Presupposition.lean;Semantics/Focus/Particles.lean;Semantics/Presupposition/Trivalent.lean;Studies/Francescotti1995.lean;Studies/Lahiri1998.lean;Studies/Yagi2025.lean}
+  sources   = {Semantics/Conditionals/Presupposition.lean;Semantics/Focus/Particles.lean;Semantics/Presupposition/Trivalent.lean;Studies/Francescotti1995.lean;Studies/Heim1983.lean;Studies/Lahiri1998.lean;Studies/Yagi2025.lean}
 }% REF: Rooth, M. (1985). Association with Focus. PhD Dissertation.
 @phdthesis{rooth-1985,
   author    = {Rooth, Mats},
@@ -12680,7 +12680,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Karttunen1974.json;Fragments/Dutch/TemporalConnectives.lean;Fragments/English/TemporalExpressions.lean;Fragments/Finnish/TemporalConnectives.lean;Fragments/Icelandic/TemporalConnectives.lean;Logic/PIP/Felicity.lean;Studies/AbneyKeshet2025.lean;Studies/Giannakidou2002.lean;Studies/Karttunen1974.lean;Studies/Rett2020.lean}
+  sources   = {Data/Examples/Karttunen1974.json;Fragments/Dutch/TemporalConnectives.lean;Fragments/English/TemporalExpressions.lean;Fragments/Finnish/TemporalConnectives.lean;Fragments/Icelandic/TemporalConnectives.lean;Logic/PIP/Felicity.lean;Studies/AbneyKeshet2025.lean;Studies/Giannakidou2002.lean;Studies/Heim1983.lean;Studies/Karttunen1974.lean;Studies/Rett2020.lean}
 }
 @article{anscombe-1964,
   author    = {Anscombe, G. E. M.},
@@ -15664,7 +15664,7 @@
   subfield  = {semantics/presupposition},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Dynamic/FileChange.lean;Semantics/Dynamic/Partial.lean;Semantics/Dynamic/Update.lean;Semantics/Presupposition/Accommodation.lean;Semantics/Presupposition/Basic.lean;Semantics/Presupposition/Context.lean;Semantics/Presupposition/Defs.lean;Studies/DegenTonhauser2022.lean;Studies/Grove2022.lean;Studies/Heim1983.lean;Studies/OgiharaSteinertThrelkeld2024.lean;Studies/RobertsSimons2024.lean;Studies/ScontrasTonhauser2025.lean;Studies/SolstadBott2024.lean;Studies/TonhauserEtAl2013.lean}
+  sources   = {Data/Examples/Heim1983.json;Semantics/Dynamic/FileChange.lean;Semantics/Dynamic/Partial.lean;Semantics/Dynamic/Update.lean;Semantics/Presupposition/Accommodation.lean;Semantics/Presupposition/Basic.lean;Semantics/Presupposition/Context.lean;Semantics/Presupposition/Defs.lean;Studies/DegenTonhauser2022.lean;Studies/Grove2022.lean;Studies/Heim1983.lean;Studies/OgiharaSteinertThrelkeld2024.lean;Studies/RobertsSimons2024.lean;Studies/ScontrasTonhauser2025.lean;Studies/SolstadBott2024.lean;Studies/TonhauserEtAl2013.lean}
 }
 @article{schlenker-2009,
   author    = {Schlenker, Philippe},
@@ -16698,7 +16698,7 @@
   subfield  = {semantics/dynamic},
   validated = {true},
   role      = {foundational},
-  sources   = {Semantics/Modality/HistoricalAlternatives.lean;Semantics/Presupposition/Accommodation.lean;Semantics/Presupposition/Context.lean}
+  sources   = {Semantics/Presupposition/Accommodation.lean;Semantics/Presupposition/Context.lean;Studies/Heim1983.lean;Studies/Roberts2023.lean}
 }
 @incollection{kamp-1981,
   author    = {Kamp, Hans},
@@ -17107,7 +17107,7 @@
   subfield  = {semantics/dynamic},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Karttunen1973.lean;Studies/Heim1983.lean}
+  sources   = {Semantics/Presupposition/Basic.lean;Semantics/Presupposition/Context.lean;Studies/Heim1983.lean;Studies/Karttunen1973.lean;Studies/Maier2015.lean;Studies/Yagi2025.lean;Syntax/Category/Verb/Defs.lean}
 }% REF: Clark, H. (1975). Bridging. Theoretical Issues in Natural Language Processing.
 @incollection{prince-1981,
   author    = {Prince, Ellen F.},


### PR DESCRIPTION
Recut against the paper (Zotero PDF, page images for the formulas): the old file was two toy world types with `PartialProp` records and three theorems; the paper's account is now derived.

- §2: `atomic`, `Presupposes` (12), `TrueWrt` (13) with the content property recovered from the potential; the King example (1)–(3) as `king_admits_iff`/`king_presupposes`/`not_presupposes_son` over the substrate's `cond` (14), with negation's hole-hood the substrate's `admits_neg`; §2.3's global and local accommodation as `globalNeg`/`localNeg` with (16)'s two readings derived.
- §3: files as sets of sequence–world pairs, `atom` (19), `atomP` (20), `every` (21), `NovelIn` (22); `every_nation_presupposes` derives that (7) presupposes every nation has a king, with (22) supplying necessity, `every_restrictor_presupposes` (23) against Karttunen and Peters, and §3.3's indefinite: the universal presupposition without accommodation and the in-course accommodation that avoids it (`fatManBicycleAcc_not_universal`).
- Karttunen (1973)'s conjunction filter theorem kept. 10 rows for (1)–(3), (5)–(7), (16), (23)–(25) with each theory's predicted presupposition.
