### PR TITLE
refactor(Studies/HeKaiserIskarous2025): derive the four RSA models

### DIFF
--- a/Linglib/Core/Analysis/SpecialFunctions/Sigmoid.lean
+++ b/Linglib/Core/Analysis/SpecialFunctions/Sigmoid.lean
@@ -4,7 +4,7 @@ import Mathlib.Analysis.SpecialFunctions.Sigmoid
 # The logistic function as a two-term softmax
 
 The share of one of two exponentials in their sum is the logistic function of the difference
-of their exponents.
+of their exponents, and the logistic function inverts the log-odds.
 -/
 
 namespace Real
@@ -15,5 +15,13 @@ theorem exp_div_add_exp_eq_sigmoid (x y : ℝ) : exp x / (exp x + exp y) = sigmo
   have hy := exp_pos y
   rw [sigmoid_def, neg_sub, exp_sub]
   field_simp
+
+/-- The logistic function at the log-odds of a level in `(0, 1)` is that level. -/
+theorem sigmoid_log_div_one_sub {t : ℝ} (ht0 : 0 < t) (ht1 : t < 1) :
+    sigmoid (log (t / (1 - t))) = t := by
+  have h1t : 0 < 1 - t := sub_pos.2 ht1
+  rw [sigmoid_def, ← log_inv, exp_log (inv_pos.2 (div_pos ht0 h1t)), inv_div]
+  field_simp
+  ring
 
 end Real

--- a/Linglib/Data/Examples/HeKaiserIskarous2025.json
+++ b/Linglib/Data/Examples/HeKaiserIskarous2025.json
@@ -1,0 +1,258 @@
+[
+  {
+    "id": "hekaiseriskarous2025_house_no_bathroom",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§1"
+    },
+    "language": "stan1293",
+    "primaryText": "The house doesn't have a bathroom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1"
+      ],
+      [
+        "polarity",
+        "negative"
+      ],
+      [
+        "statePrior",
+        "low"
+      ]
+    ],
+    "comment": "A negative sentence about a low-prior state: houses usually have bathrooms.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_house_ballroom",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§1"
+    },
+    "language": "stan1293",
+    "primaryText": "The house has a ballroom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1"
+      ],
+      [
+        "polarity",
+        "positive"
+      ],
+      [
+        "statePrior",
+        "low"
+      ]
+    ],
+    "comment": "A positive sentence about a low-prior state, similarly informative to the negative one but cheaper under the standard model.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_house_no_ballroom",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§1"
+    },
+    "language": "stan1293",
+    "primaryText": "The house doesn't have a ballroom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1"
+      ],
+      [
+        "polarity",
+        "negative"
+      ],
+      [
+        "statePrior",
+        "high"
+      ]
+    ],
+    "comment": "Presupposes the possibility of a ballroom, which the listener must accommodate before the update.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_exp1_pos",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§3.2"
+    },
+    "language": "stan1293",
+    "primaryText": "The house has a bathroom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Emma visited a friend's house yesterday.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "polarity",
+        "positive"
+      ],
+      [
+        "experiment",
+        "1"
+      ]
+    ],
+    "comment": "Experiment 1 item: participants rated how likely Emma would be to mention the fact.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_exp1_neg",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§3.2"
+    },
+    "language": "stan1293",
+    "primaryText": "The house doesn't have a bathroom.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Emma visited a friend's house yesterday.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "polarity",
+        "negative"
+      ],
+      [
+        "experiment",
+        "1"
+      ]
+    ],
+    "comment": "Experiment 1 item, the negative counterpart of the same part-whole relation.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_classroom_no_board",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§3.2"
+    },
+    "language": "stan1293",
+    "primaryText": "The classroom doesn't have a board.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "polarity",
+        "negative"
+      ],
+      [
+        "statePrior",
+        "low"
+      ]
+    ],
+    "comment": "A low-prior negative-polarity situation, rated more likely to be communicated than a positive one of similar prior.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_classroom_stove",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§3.2"
+    },
+    "language": "stan1293",
+    "primaryText": "The classroom has a stove.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.2"
+      ],
+      [
+        "polarity",
+        "positive"
+      ],
+      [
+        "statePrior",
+        "low"
+      ]
+    ],
+    "comment": "A low-prior positive-polarity situation, rated less likely to be communicated than the negative one above.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "hekaiseriskarous2025_exp2",
+    "source": {
+      "bibkey": "he-kaiser-iskarous-2025",
+      "paperLabel": "§3.3"
+    },
+    "language": "stan1293",
+    "primaryText": "“The house has a bathroom,” Emma told her partner.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.3"
+      ],
+      [
+        "polarity",
+        "positive"
+      ],
+      [
+        "experiment",
+        "2"
+      ]
+    ],
+    "comment": "Experiment 2 item: the fact statement in direct speech; participants rated how typical a house the house is.",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/HeKaiserIskarous2025.lean
+++ b/Linglib/Data/Examples/HeKaiserIskarous2025.lean
@@ -1,0 +1,162 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `HeKaiserIskarous2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/HeKaiserIskarous2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace HeKaiserIskarous2025.Examples`.
+-/
+
+namespace HeKaiserIskarous2025.Examples
+
+open Data.Examples
+
+def house_no_bathroom : LinguisticExample :=
+  { id := "hekaiseriskarous2025_house_no_bathroom"
+    source := ⟨"he-kaiser-iskarous-2025", "§1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The house doesn't have a bathroom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1"), ("polarity", "negative"), ("statePrior", "low")]
+    comment := "A negative sentence about a low-prior state: houses usually have bathrooms."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def house_ballroom : LinguisticExample :=
+  { id := "hekaiseriskarous2025_house_ballroom"
+    source := ⟨"he-kaiser-iskarous-2025", "§1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The house has a ballroom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1"), ("polarity", "positive"), ("statePrior", "low")]
+    comment := "A positive sentence about a low-prior state, similarly informative to the negative one but cheaper under the standard model."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def house_no_ballroom : LinguisticExample :=
+  { id := "hekaiseriskarous2025_house_no_ballroom"
+    source := ⟨"he-kaiser-iskarous-2025", "§1"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The house doesn't have a ballroom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1"), ("polarity", "negative"), ("statePrior", "high")]
+    comment := "Presupposes the possibility of a ballroom, which the listener must accommodate before the update."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def exp1_pos : LinguisticExample :=
+  { id := "hekaiseriskarous2025_exp1_pos"
+    source := ⟨"he-kaiser-iskarous-2025", "§3.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The house has a bathroom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Emma visited a friend's house yesterday."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("polarity", "positive"), ("experiment", "1")]
+    comment := "Experiment 1 item: participants rated how likely Emma would be to mention the fact."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def exp1_neg : LinguisticExample :=
+  { id := "hekaiseriskarous2025_exp1_neg"
+    source := ⟨"he-kaiser-iskarous-2025", "§3.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The house doesn't have a bathroom."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Emma visited a friend's house yesterday."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("polarity", "negative"), ("experiment", "1")]
+    comment := "Experiment 1 item, the negative counterpart of the same part-whole relation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def classroom_no_board : LinguisticExample :=
+  { id := "hekaiseriskarous2025_classroom_no_board"
+    source := ⟨"he-kaiser-iskarous-2025", "§3.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The classroom doesn't have a board."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("polarity", "negative"), ("statePrior", "low")]
+    comment := "A low-prior negative-polarity situation, rated more likely to be communicated than a positive one of similar prior."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def classroom_stove : LinguisticExample :=
+  { id := "hekaiseriskarous2025_classroom_stove"
+    source := ⟨"he-kaiser-iskarous-2025", "§3.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The classroom has a stove."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.2"), ("polarity", "positive"), ("statePrior", "low")]
+    comment := "A low-prior positive-polarity situation, rated less likely to be communicated than the negative one above."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def exp2 : LinguisticExample :=
+  { id := "hekaiseriskarous2025_exp2"
+    source := ⟨"he-kaiser-iskarous-2025", "§3.3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "“The house has a bathroom,” Emma told her partner."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.3"), ("polarity", "positive"), ("experiment", "2")]
+    comment := "Experiment 2 item: the fact statement in direct speech; participants rated how typical a house the house is."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [house_no_bathroom, house_ballroom, house_no_ballroom, exp1_pos, exp1_neg, classroom_no_board, classroom_stove, exp2]
+
+end HeKaiserIskarous2025.Examples

--- a/Linglib/Studies/HeKaiserIskarous2025.lean
+++ b/Linglib/Studies/HeKaiserIskarous2025.lean
@@ -1,432 +1,784 @@
-import Linglib.Semantics.Composition.Ty
-import Linglib.Logic.Natural.Additivity
-import Linglib.Logic.Natural.Basic
-import Mathlib.Data.Rat.Defs
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.FinEnum
+import Linglib.Core.Probability.UniformOn
+import Linglib.Data.Examples.HeKaiserIskarous2025
+import Linglib.Pragmatics.RSA.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Sentence Polarity Asymmetries
-[he-kaiser-iskarous-2025]
+# He, Kaiser and Iskarous (2025): Modeling sentence polarity asymmetries
 
-Empirical data and domain types for modeling sentence polarity asymmetries
-with fuzzy interpretations in a possibly wonky world.
+This file formalizes the rational speech act models of [he-kaiser-iskarous-2025] for a
+speaker who says of a whole that it has a part, that it lacks it, or nothing. `Setting.speaker`
+is the standard speaker of (1)–(4) on the kernel pipeline of `RSA.speaker`, under the Boolean
+meaning of (2) or the fuzzy meaning `fuzzy` of (11)–(13), whose positive sentence holds at its
+state to a sigmoid degree of that state's prior. `Setting.wonkyListener` is the wonky-world
+listener of (14)–(16), the family listener over the measured and the uniform prior, with
+`Setting.wonkiness` its posterior probability of the wonky world and the expected typicality
+of (17) the marginal of the state over the worlds; the funky model of (18)–(22) is the same
+listener under the fuzzy meaning.
 
-## Key Phenomena
+Under the Boolean meaning the likelihood of each polarity is a logistic function of the cost
+saved by silence and the log prior of its state (`Setting.likelihood_boolean`): it falls as
+the prior rises, and at equal priors the positive polarity is the likelier exactly when it is
+the cheaper, the two coinciding at equal costs. The fuzzy positive sentence informs the
+literal listener exactly when its degree exceeds one half, which the sigmoid degree does
+above a threshold prior; below it the speaker prefers silence to the positive sentence, where
+the Boolean speaker prefers the sentence at every prior below the exponential of the cost
+saved. The wonky listener's wonkiness rises above its prior exactly when the described
+state's prior exceeds one half, whatever the costs, and its expected typicality moves the
+state's prior toward one half by the wonkiness.
 
-Two asymmetries between positive and negative polarity:
+## Implementation notes
 
-1. **Cost asymmetry**: Negation elicits higher production cost than positive polarity
-2. **Presupposition asymmetry**: Negation presupposes prominence of its positive
-   counterpart in common ground, but not vice versa
+* The sigmoid of (13) in the wonky world takes that world's prior of the positive state, one
+  half; the paper does not say which prior it takes there.
+* The wonkiness of the Boolean wonky listener depends on the polarity only through the cost
+  (`Setting.wonkiness_boolean`), so the polarities coincide at equal costs; the paper's costs
+  differ, and its remark that the model does not differentiate the polarities holds of the
+  direction of the wonkiness update, not of its size.
 
-## Domain
+## TODO
 
-Part-whole relations (e.g., house-bathroom, classroom-stove):
-- States: s_pos (A has B), s_neg (A doesn't have B)
-- Utterances: u_pos, u_neg, u_null
-- Costs: Cost(u_null)=0, Cost(u_pos)=1, Cost(u_neg)=2
+* The best-fit predictions of Figures 4, 5 and 7 and the mean squared errors of §4.2 and §5.2.
+* The funky listener's typicality difference between the polarities (§6.2).
 
-## Models
+## References
 
-| Model | Description |
-|-------|-------------|
-| Standard RSA | Baseline with Boolean semantics |
-| fuzzyRSA | Soft semantics with polarity-specific interpretation |
-| wonkyRSA | Complex prior for common ground update |
-| funkyRSA | Combination of fuzzy + wonky |
-
+* [he-kaiser-iskarous-2025]
+* [frank-goodman-2012]
+* [degen-etal-2015]
+* [cremers-wilcox-spector-2023]
+* [degen-etal-2020]
+* [horn-1989]
 -/
 
 namespace HeKaiserIskarous2025
 
--- State Model
+open MeasureTheory ProbabilityTheory RSA
+open scoped ENNReal
 
-/-- Two states for part-whole relations.
+/-! ### States, utterances and meanings -/
 
-    - `pos`: The positive state (A has B)
-    - `neg`: The negative state (A doesn't have B) -/
-inductive HKIState where
-  | pos : HKIState  -- A has B
-  | neg : HKIState  -- A doesn't have B
-  deriving DecidableEq, Repr, Inhabited
+/-- The two states: the whole has the part, or lacks it. -/
+inductive State where
+  | pos
+  | neg
+  deriving DecidableEq, Fintype, Nonempty
 
-instance : Fintype HKIState where
-  elems := {.pos, .neg}
-  complete := λ x => by cases x <;> simp
+instance : MeasurableSpace State := ⊤
 
-instance : FinEnum HKIState :=
-  FinEnum.ofList [.pos, .neg] (λ x => by cases x <;> simp)
+/-- The three utterances: the positive sentence, its negation, and silence. -/
+inductive Utterance where
+  | pos
+  | neg
+  | null
+  deriving DecidableEq, Fintype, Nonempty
 
-/-- All states -/
-def allStates : List HKIState := [.pos, .neg]
+instance : MeasurableSpace Utterance := ⊤
 
-theorem allStates_length : allStates.length = 2 := rfl
+/-- The sentence describing a state: the one of the state's polarity. -/
+def State.utterance : State → Utterance
+  | .pos => .pos
+  | .neg => .neg
 
--- Utterance Types
+section Sums
 
-/-- Three utterances for part-whole communication.
+variable {β : Type*} [AddCommMonoid β]
 
-    - `uPos`: "A has B" (positive polarity, cost 1)
-    - `uNeg`: "A doesn't have B" (negative polarity, cost 2)
-    - `uNull`: Say nothing (cost 0) -/
-inductive HKIUtterance where
-  | uPos : HKIUtterance   -- "A has B"
-  | uNeg : HKIUtterance   -- "A doesn't have B"
-  | uNull : HKIUtterance  -- Say nothing
-  deriving DecidableEq, Repr, Inhabited
+theorem sum_state (f : State → β) : ∑ st, f st = f .pos + f .neg := by
+  rw [show ∑ st, f st = f .pos + (f .neg + 0) from rfl, add_zero]
 
-instance : Fintype HKIUtterance where
-  elems := {.uPos, .uNeg, .uNull}
-  complete := λ x => by cases x <;> simp
+end Sums
 
-instance : FinEnum HKIUtterance :=
-  FinEnum.ofList [.uPos, .uNeg, .uNull] (λ x => by cases x <;> simp)
+/-- A graded meaning: the degree to which an utterance holds at a state. -/
+abbrev Meaning := Utterance → State → ℝ
 
-/-- All utterances -/
-def allUtterances : List HKIUtterance := [.uPos, .uNeg, .uNull]
+/-- The Boolean meaning of (2): each sentence holds at its state alone, silence everywhere. -/
+def boolean : Meaning
+  | .pos, .pos => 1
+  | .pos, .neg => 0
+  | .neg, .neg => 1
+  | .neg, .pos => 0
+  | .null, _ => 1
 
-theorem allUtterances_length : allUtterances.length = 3 := rfl
+/-- The fuzzy meaning of (11) and (12): the negative sentence holds at its state to the degree
+`n` and the positive sentence to the degree `σ`, each to the complementary degree at the
+other state; silence holds everywhere. -/
+def fuzzy (n σ : ℝ) : Meaning
+  | .pos, .pos => σ
+  | .pos, .neg => 1 - σ
+  | .neg, .neg => n
+  | .neg, .pos => 1 - n
+  | .null, _ => 1
 
-/-- Sentence polarity -/
-inductive Polarity where
-  | positive : Polarity
-  | negative : Polarity
-  | null : Polarity
-  deriving DecidableEq, Repr
+theorem boolean_nonneg (u : Utterance) (st : State) : 0 ≤ boolean u st := by
+  cases u <;> cases st <;> simp [boolean]
 
-/-- Get polarity of an utterance -/
-def HKIUtterance.polarity : HKIUtterance → Polarity
-  | .uPos => .positive
-  | .uNeg => .negative
-  | .uNull => .null
+theorem fuzzy_nonneg {n σ : ℝ} (hn0 : 0 ≤ n) (hn1 : n ≤ 1) (hσ0 : 0 ≤ σ) (hσ1 : σ ≤ 1)
+    (u : Utterance) (st : State) : 0 ≤ fuzzy n σ u st := by
+  cases u <;> cases st <;> simp [fuzzy] <;> linarith
 
--- Cost Structure
+/-- The Boolean meaning is the fuzzy meaning of full degrees. -/
+theorem fuzzy_one_one : fuzzy 1 1 = boolean := by
+  funext u st; cases u <;> cases st <;> simp [fuzzy, boolean]
 
-/-- Utterance costs from the paper.
+/-- The parameters of the sigmoid of (13): its height, steepness, midpoint and offset. -/
+structure Sigmoid where
+  /-- The height. -/
+  L : ℝ
+  /-- The steepness. -/
+  k : ℝ
+  /-- The midpoint. -/
+  x0 : ℝ
+  /-- The offset. -/
+  c : ℝ
 
-    Cost(u_null) = 0
-    Cost(u_pos) = 1
-    Cost(u_neg) = 2
+namespace Sigmoid
 
-    Negation has higher cost due to marked form / longer linguistic realization. -/
-def utteranceCost : HKIUtterance → ℚ
-  | .uNull => 0
-  | .uPos => 1
-  | .uNeg => 2
+variable (θ : Sigmoid)
 
-/-- Negative utterances cost more than positive (Asymmetry Hypothesis 1) -/
-theorem neg_costs_more : utteranceCost .uNeg > utteranceCost .uPos := by
-  native_decide
+/-- The sigmoid of (13): the degree of the positive sentence at its state, as a function of
+that state's prior. -/
+noncomputable def eval (x : ℝ) : ℝ := θ.L * Real.sigmoid (θ.k * (x - θ.x0)) + θ.c
 
--- Literal Semantics (Boolean)
+/-- The prior below which the sigmoid degree is below one half. -/
+noncomputable def threshold : ℝ :=
+  θ.x0 + Real.log ((1 / 2 - θ.c) / (θ.L + θ.c - 1 / 2)) / θ.k
 
-/-- Boolean literal semantics: which utterance is true in which state.
+/-- A rising sigmoid whose range straddles one half is below one half exactly below its
+threshold prior. -/
+theorem eval_lt_half_iff (hk : 0 < θ.k) (hL : 0 < θ.L) (hc : θ.c < 1 / 2)
+    (hLc : 1 / 2 < θ.L + θ.c) (x : ℝ) : θ.eval x < 1 / 2 ↔ x < θ.threshold := by
+  have ht0 : 0 < (1 / 2 - θ.c) / θ.L := div_pos (by linarith) hL
+  have ht1 : (1 / 2 - θ.c) / θ.L < 1 := (div_lt_one hL).2 (by linarith)
+  have key : (1 / 2 - θ.c) / θ.L / (1 - (1 / 2 - θ.c) / θ.L) =
+      (1 / 2 - θ.c) / (θ.L + θ.c - 1 / 2) := by
+    have h1 : θ.L + θ.c - 1 / 2 ≠ 0 := by linarith
+    field_simp
+    ring
+  rw [eval, ← lt_sub_iff_add_lt, ← lt_div_iff₀' hL, ← Real.sigmoid_log_div_one_sub ht0 ht1,
+    Real.sigmoid_lt_iff, key, ← lt_div_iff₀' hk, sub_lt_iff_lt_add', threshold]
 
-    - u_pos is true only in s_pos
-    - u_neg is true only in s_neg
-    - u_null is true in both (vacuously) -/
-def literalTruth : HKIState → HKIUtterance → Bool
-  | .pos, .uPos => true
-  | .pos, .uNeg => false
-  | .pos, .uNull => true
-  | .neg, .uPos => false
-  | .neg, .uNeg => true
-  | .neg, .uNull => true
+end Sigmoid
 
--- Wonky World Types
+/-- The best-fit sigmoid of §4.2. -/
+noncomputable def bestFit : Sigmoid := ⟨7 / 10, 6, 7 / 20, 3 / 10⟩
 
-/-- World types for wonkyRSA.
+/-- The best-fit degree of the negative sentence at its state, §4.2. -/
+noncomputable def bestFitNeg : ℝ := 4 / 5
 
-    - `normal`: Prior reflects actual world knowledge
-    - `wonky`: Uniform prior (speaker's utterance choice is "odd") -/
-inductive WorldType where
-  | normal : WorldType
-  | wonky : WorldType
-  deriving DecidableEq, Repr, Inhabited
+/-- The threshold prior of the best-fit sigmoid, about `0.197`. -/
+theorem bestFit_threshold : bestFit.threshold = 7 / 20 - Real.log (5 / 2) / 6 := by
+  rw [Sigmoid.threshold, show (1 / 2 - bestFit.c) / (bestFit.L + bestFit.c - 1 / 2) = (5 / 2)⁻¹ by
+    norm_num [bestFit], Real.log_inv]
+  norm_num [bestFit]
+  ring
 
-/-- All world types -/
-def allWorldTypes : List WorldType := [.normal, .wonky]
+/-! ### Priors and costs -/
 
-theorem allWorldTypes_length : allWorldTypes.length = 2 := rfl
+/-- The parameters of a model: the prior probability of the positive state, the rationality
+`α`, and the costs. -/
+structure Setting where
+  /-- The prior probability of the positive state. -/
+  p : ℝ
+  /-- The rationality. -/
+  α : ℝ
+  /-- The cost of an utterance. -/
+  cost : Utterance → ℝ
+  /-- The positive state is possible. -/
+  p_pos : 0 < p
+  /-- The negative state is possible. -/
+  p_lt_one : p < 1
+  /-- The rationality is positive. -/
+  α_pos : 0 < α
 
--- Prior Structure
+/-- The costs of §3.2: silence is free, the positive sentence costs one and its negation two,
+the marked form being the costlier. -/
+noncomputable def markednessCost : Utterance → ℝ
+  | .pos => 1
+  | .neg => 2
+  | .null => 0
 
-/-- Prior probability over states.
+namespace Setting
 
-    In the He et al. study, priors were normed empirically for
-    81 part-whole pairs (e.g., house-bathroom has high prior,
-    classroom-stove has low prior). -/
-structure HKIPrior where
-  /-- P(s_pos) - probability of positive state -/
-  p_pos : ℚ
-  /-- Non-negative -/
-  h_pos_nonneg : 0 ≤ p_pos
-  /-- At most 1 -/
-  h_pos_le_one : p_pos ≤ 1
+variable (s : Setting)
 
-/-- P(s_neg) = 1 - P(s_pos) -/
-def HKIPrior.p_neg (prior : HKIPrior) : ℚ := 1 - prior.p_pos
+/-- The prior probability of a state. -/
+def statePrior : State → ℝ
+  | .pos => s.p
+  | .neg => 1 - s.p
 
-/-- Get prior probability of a state -/
-def HKIPrior.prob (prior : HKIPrior) : HKIState → ℚ
-  | .pos => prior.p_pos
-  | .neg => prior.p_neg
+theorem statePrior_pos (st : State) : 0 < s.statePrior st := by
+  cases st
+  · exact s.p_pos
+  · exact sub_pos.2 s.p_lt_one
 
-/-- Uniform prior: P(s_pos) = P(s_neg) = 0.5 -/
-def uniformPrior : HKIPrior where
-  p_pos := 1/2
-  h_pos_nonneg := by native_decide
-  h_pos_le_one := by native_decide
+/-- The measured prior over states. -/
+noncomputable def prior : Measure State :=
+  ∑ st, ENNReal.ofReal (s.statePrior st) • Measure.dirac st
 
-/-- High prior: P(s_pos) = 0.9 (typical part, e.g., house-bathroom) -/
-def highPrior : HKIPrior where
-  p_pos := 9/10
-  h_pos_nonneg := by native_decide
-  h_pos_le_one := by native_decide
+theorem prior_apply_singleton (st : State) : s.prior {st} = ENNReal.ofReal (s.statePrior st) :=
+  Measure.sum_smul_dirac_apply_singleton _ st
 
-/-- Low prior: P(s_pos) = 0.1 (atypical part, e.g., classroom-stove) -/
-def lowPrior : HKIPrior where
-  p_pos := 1/10
-  h_pos_nonneg := by native_decide
-  h_pos_le_one := by native_decide
+theorem prior_real_singleton (st : State) : s.prior.real {st} = s.statePrior st := by
+  rw [measureReal_def, prior_apply_singleton, ENNReal.toReal_ofReal (s.statePrior_pos st).le]
 
--- Fuzzy Semantics Parameters
+theorem prior_ne_zero (st : State) : s.prior {st} ≠ 0 := by
+  rw [prior_apply_singleton]
+  exact (ENNReal.ofReal_pos.2 (s.statePrior_pos st)).ne'
 
-/-- Parameters for fuzzy interpretation functions.
+instance : IsProbabilityMeasure s.prior :=
+  ⟨by
+    rw [← Finset.coe_univ, ← sum_measure_singleton, sum_state, prior_apply_singleton,
+      prior_apply_singleton, ← ENNReal.ofReal_add (s.statePrior_pos _).le (s.statePrior_pos _).le]
+    simp [statePrior]⟩
 
-    For negative utterances: constant probability n
-    For positive utterances: sigmoid function with parameters (L, k, x0, c) -/
-structure FuzzyParams where
-  /-- Negative interpretation: [[u_neg]](s_neg) = n -/
-  n : ℚ
-  /-- Sigmoid maximum value -/
-  L : ℚ
-  /-- Sigmoid steepness -/
-  k : ℚ
-  /-- Sigmoid midpoint -/
-  x0 : ℚ
-  /-- Sigmoid vertical shift -/
-  c : ℚ
-  /-- n in [0,1] -/
-  h_n_valid : 0 ≤ n ∧ n ≤ 1
+/-- The cost factor of an utterance: the exponential of its cost scaled by the rationality. -/
+noncomputable def costFactor (u : Utterance) : ℝ≥0∞ :=
+  ENNReal.ofReal (Real.exp (-(s.α * s.cost u)))
 
-/-- Best-fit parameters from the paper (Section 4.2).
+theorem costFactor_ne_zero (u : Utterance) : s.costFactor u ≠ 0 :=
+  (ENNReal.ofReal_pos.2 (Real.exp_pos _)).ne'
 
-    n = 0.8, α = 1, θ = {L=0.7, k=6, x0=0.35, c=0.3} -/
-def bestFitFuzzyParams : FuzzyParams where
-  n := 4/5        -- 0.8
-  L := 7/10       -- 0.7
-  k := 6
-  x0 := 7/20      -- 0.35
-  c := 3/10       -- 0.3
-  h_n_valid := by constructor <;> native_decide
+theorem costFactor_ne_top (u : Utterance) : s.costFactor u ≠ ∞ := ENNReal.ofReal_ne_top
 
--- Model Configuration
+theorem costFactor_toReal (u : Utterance) :
+    (s.costFactor u).toReal = Real.exp (-(s.α * s.cost u)) :=
+  ENNReal.toReal_ofReal (Real.exp_pos _).le
 
-/-- Configuration for RSA model instances -/
-structure HKIConfig where
-  /-- Prior over states -/
-  prior : HKIPrior
-  /-- Rationality parameter -/
-  alpha : ℕ := 1
-  /-- Wonkiness prior P(wonky) for wonkyRSA -/
-  p_wonky : ℚ := 1/2
-  /-- Fuzzy parameters for fuzzyRSA -/
-  fuzzyParams : FuzzyParams := bestFitFuzzyParams
+end Setting
 
-/-- Default configuration with uniform prior -/
-def defaultConfig : HKIConfig where
-  prior := uniformPrior
+/-! ### The literal listener and the speaker, (1) to (3) -/
 
-/-- High-prior configuration (typical parts like house-bathroom) -/
-def highPriorConfig : HKIConfig where
-  prior := highPrior
+section Listener
 
-/-- Low-prior configuration (atypical parts like classroom-stove) -/
-def lowPriorConfig : HKIConfig where
-  prior := lowPrior
+variable (P : Measure State) (m : Meaning)
 
--- Key Theoretical Claims
+/-- The literal listener of (1): the prior reweighted by the meaning. -/
+noncomputable def L0 : Kernel Utterance State :=
+  literalListener P λ u st => ENNReal.ofReal (m u st)
 
-/-- Asymmetry Hypothesis 1: Negation has higher production cost.
+theorem L0_le_one (u : Utterance) (st : State) : L0 P m u {st} ≤ 1 :=
+  literalListener_apply_le_one _ _ _ _
 
-    Marked forms like negation use more complex structures and longer
-    linguistic forms, eliciting higher production cost. -/
-def asymmetryHypothesis1 : String :=
-  "Marked forms like negation elicit higher production cost than " ++
-  "their unmarked positive-polarity counterparts."
+theorem L0_ne_top (u : Utterance) (st : State) : L0 P m u {st} ≠ ∞ :=
+  ne_top_of_le_ne_top ENNReal.one_ne_top (L0_le_one P m u st)
 
-/-- Asymmetry Hypothesis 2: Negation presupposes positive prominence.
+theorem L0_eq_zero {u : Utterance} {st : State} (h : m u st = 0) : L0 P m u {st} = 0 := by
+  rw [L0, literalListener_apply_singleton, h, ENNReal.ofReal_zero, zero_mul, ENNReal.zero_div]
 
-    Negation presupposes that its positive-polarity counterpart is
-    relevant or prominent in common ground, but not vice versa. -/
-def asymmetryHypothesis2 : String :=
-  "Negation presupposes that its positive-polarity counterpart is " ++
-  "relevant or prominent in the common ground, not the other way around."
+variable [IsFiniteMeasure P] (hm : ∀ u st, 0 ≤ m u st)
+include hm
 
--- ============================================================================
--- Part II: RSA Compositional Grounding
--- ============================================================================
+/-- The literal listener at a state, on reals: the prior weighted by the meaning, normalized
+over the row. -/
+theorem L0_real (u : Utterance) (st : State) :
+    (L0 P m u {st}).toReal = m u st * P.real {st} / ∑ st', m u st' * P.real {st'} := by
+  rw [L0, literalListener_apply_singleton, ENNReal.toReal_div, ENNReal.toReal_mul,
+    ENNReal.toReal_ofReal (hm u st), ENNReal.toReal_sum λ st' _ =>
+      ENNReal.mul_ne_top ENNReal.ofReal_ne_top (measure_ne_top _ _), measureReal_def]
+  congr 1
+  exact Finset.sum_congr rfl λ st' _ => by
+    rw [ENNReal.toReal_mul, ENNReal.toReal_ofReal (hm u st'), measureReal_def]
 
-/-- Simple sigmoid approximation using rational arithmetic. -/
-def sigmoidApprox (x : ℚ) (L k x0 c : ℚ) : ℚ :=
-  let threshold := if k > 0 then 1 / k else 1/10
-  if x < x0 - threshold then
-    c
-  else if x > x0 + threshold then
-    L + c
-  else
-    let slope := L / (2 * threshold)
-    let midpoint := c + L / 2
-    midpoint + slope * (x - x0)
+omit hm in
+theorem L0_ne_zero {u : Utterance} {st : State} (h : 0 < m u st) (hst : P {st} ≠ 0) :
+    L0 P m u {st} ≠ 0 := by
+  rw [L0, literalListener_apply_singleton]
+  exact (ENNReal.div_pos_iff.2 ⟨mul_ne_zero (ENNReal.ofReal_pos.2 h).ne' hst,
+    ENNReal.sum_ne_top.2 λ st' _ =>
+      ENNReal.mul_ne_top ENNReal.ofReal_ne_top (measure_ne_top _ _)⟩).ne'
 
-/-- Fuzzy interpretation for negative utterances.
-    [[u_neg]](s_neg) = n (constant)
-    [[u_neg]](s_pos) = 1 - n -/
-def fuzzyNegInterpretation (n : ℚ) : HKIState → ℚ
-  | .neg => n
-  | .pos => 1 - n
+end Listener
 
-/-- Fuzzy interpretation for positive utterances. -/
-def fuzzyPosInterpretation (p_pos : ℚ) (params : FuzzyParams) : HKIState → ℚ :=
-  let sig := sigmoidApprox p_pos params.L params.k params.x0 params.c
-  λ s => match s with
-    | .pos => sig
-    | .neg => 1 - sig
+section Speaker
 
-/-- Fuzzy interpretation for null utterance (no information). -/
-def fuzzyNullInterpretation : HKIState → ℚ
-  | _ => 1
+variable (P : Measure State) (m : Meaning) (s : Setting)
 
-/-- Combined fuzzy meaning function for fuzzyRSA. -/
-def fuzzyMeaning (cfg : HKIConfig) (u : HKIUtterance) (s : HKIState) : ℚ :=
-  match u with
-  | .uNeg => fuzzyNegInterpretation cfg.fuzzyParams.n s
-  | .uPos => fuzzyPosInterpretation cfg.prior.p_pos cfg.fuzzyParams s
-  | .uNull => fuzzyNullInterpretation s
+/-- The speaker of (3): the power-weight best response to the literal listener, with the
+rationality as exponent and the cost factors as weights. -/
+noncomputable def speaker : Kernel State Utterance := RSA.speaker s.α s.costFactor (L0 P m)
 
-/-- World-conditioned prior for wonkyRSA. -/
-def worldConditionedPrior (cfg : HKIConfig) : WorldType → HKIState → ℚ
-  | .wonky, _ => 1/2
-  | .normal, s => cfg.prior.prob s
+instance : IsFiniteKernel (speaker P m s) := inferInstanceAs (IsFiniteKernel (RSA.speaker _ _ _))
 
-/-- Goal projection for wonkyRSA. -/
-def wonkyGoalProject : WorldType → HKIState → HKIState → Bool
-  | _, s1, s2 => s1 == s2
+theorem weight_ne_top (u : Utterance) (st : State) :
+    L0 P m u {st} ^ s.α * s.costFactor u ≠ ∞ :=
+  ENNReal.mul_ne_top (weight_rpow_ne_top s.α_pos.le (L0_le_one P m u st)) (s.costFactor_ne_top u)
 
-/-- Standard scenario has correct dimensions. -/
-theorem standard_dimensions :
-    allUtterances.length = 3 ∧
-    allStates.length = 2 :=
-  ⟨rfl, rfl⟩
+theorem weight_eq_zero {u : Utterance} {st : State} (h : m u st = 0) :
+    L0 P m u {st} ^ s.α * s.costFactor u = 0 := by
+  rw [L0_eq_zero P m h, ENNReal.zero_rpow_of_pos s.α_pos, zero_mul]
 
-/-- wonkyRSA has 2 goals (normal, wonky). -/
-theorem wonky_dimensions :
-    allWorldTypes.length = 2 :=
+/-- An utterance not holding at a state is never used there. -/
+theorem speaker_eq_zero {u : Utterance} {st : State} (h : m u st = 0) :
+    speaker P m s st {u} = 0 :=
+  RSA.speaker_apply_singleton_eq_zero s.α_pos (L0_eq_zero P m h)
+
+theorem speaker_real_eq_zero {u : Utterance} {st : State} (h : m u st = 0) :
+    (speaker P m s st).real {u} = 0 := by
+  rw [measureReal_def, speaker_eq_zero P m s h, ENNReal.toReal_zero]
+
+variable [IsFiniteMeasure P]
+
+theorem weight_ne_zero {u : Utterance} {st : State} (h : 0 < m u st) (hst : P {st} ≠ 0) :
+    L0 P m u {st} ^ s.α * s.costFactor u ≠ 0 :=
+  mul_ne_zero (weight_rpow_ne_zero s.α_pos.le (L0_ne_zero P m h hst)) (s.costFactor_ne_zero u)
+
+/-- The weight of an utterance holding at a state, on reals: the exponential of the scaled
+utility of (3). -/
+theorem weight_toReal {u : Utterance} {st : State} (h : 0 < m u st) (hst : P {st} ≠ 0) :
+    (L0 P m u {st} ^ s.α * s.costFactor u).toReal =
+      Real.exp (s.α * (Real.log (L0 P m u {st}).toReal - s.cost u)) := by
+  rw [ENNReal.toReal_mul, ← ENNReal.toReal_rpow, Real.rpow_def_of_pos
+    (ENNReal.toReal_pos (L0_ne_zero P m h hst) (L0_ne_top P m u st)), Setting.costFactor_toReal,
+    ← Real.exp_add]
+  congr 1; ring
+
+/-- An utterance holding at a state is used there. -/
+theorem speaker_ne_zero {u : Utterance} {st : State} (h : 0 < m u st) (hst : P {st} ≠ 0) :
+    speaker P m s st {u} ≠ 0 :=
+  RSA.speaker_apply_singleton_ne_zero s.α_pos.le s.costFactor_ne_zero s.costFactor_ne_top
+    (λ v => L0_le_one P m v st) (L0_ne_zero P m h hst)
+
+theorem speaker_real_pos {u : Utterance} {st : State} (h : 0 < m u st) (hst : P {st} ≠ 0) :
+    0 < (speaker P m s st).real {u} :=
+  ENNReal.toReal_pos (speaker_ne_zero P m s h hst) (measure_ne_top _ _)
+
+/-- Between two utterances holding at a state, the speaker prefers the one of higher
+utility. -/
+theorem speaker_real_lt_iff {u v : Utterance} {st : State} (hu : 0 < m u st) (hv : 0 < m v st)
+    (hst : P {st} ≠ 0) :
+    (speaker P m s st).real {u} < (speaker P m s st).real {v} ↔
+      Real.log (L0 P m u {st}).toReal - s.cost u < Real.log (L0 P m v {st}).toReal - s.cost v := by
+  rw [speaker, RSA.speaker_real_singleton_lt_iff s.α_pos.le s.costFactor_ne_top
+      (λ v => L0_le_one P m v st) ⟨u, weight_ne_zero P m s hu hst⟩,
+    ← ENNReal.toReal_lt_toReal (weight_ne_top P m s u st) (weight_ne_top P m s v st),
+    weight_toReal P m s hu hst, weight_toReal P m s hv hst, Real.exp_lt_exp,
+    mul_lt_mul_iff_of_pos_left s.α_pos]
+
+/-- When exactly two utterances hold at a state, the speaker's use of one is the logistic
+function of the scaled utility difference. -/
+theorem speaker_real_of_pair (hm : ∀ u st, 0 ≤ m u st) {u v : Utterance} {st : State}
+    (huv : u ≠ v) (hu : 0 < m u st) (hv : 0 < m v st) (hsupp : ∀ x, 0 < m x st → x = u ∨ x = v)
+    (hst : P {st} ≠ 0) :
+    (speaker P m s st).real {u} =
+      Real.sigmoid (s.α * ((Real.log (L0 P m u {st}).toReal - s.cost u) -
+        (Real.log (L0 P m v {st}).toReal - s.cost v))) := by
+  rw [speaker, RSA.speaker, Kernel.ofWeights_real_singleton_of_pair st huv
+      (λ x => weight_ne_top P m s x st) (λ x hx => hsupp x
+        (lt_of_le_of_ne (hm x st) (Ne.symm (mt (weight_eq_zero P m s) hx)))),
+    weight_toReal P m s hu hst, weight_toReal P m s hv hst, Real.exp_div_add_exp_eq_sigmoid]
+  congr 1; ring
+
+end Speaker
+
+/-! ### Closed forms under the Boolean meaning -/
+
+section Boolean
+
+variable (P : Measure State) [IsProbabilityMeasure P] (hP : ∀ st, P {st} ≠ 0) (s : Setting)
+
+theorem sum_real_singleton : ∑ st, P.real {st} = 1 := by
+  rw [sum_measureReal_singleton, Finset.coe_univ, probReal_univ]
+
+/-- Silence leaves the literal listener at the prior, under any meaning where it holds
+everywhere. -/
+theorem L0_null_real (m : Meaning) (hm : ∀ u st, 0 ≤ m u st) (hnull : ∀ st, m .null st = 1)
+    (st : State) : (L0 P m .null {st}).toReal = P.real {st} := by
+  rw [L0_real P m hm]
+  simp only [hnull, one_mul, sum_real_singleton, div_one]
+
+include hP
+
+/-- The sentence of a state puts the Boolean literal listener at that state. -/
+theorem L0_boolean_utterance_real (st : State) :
+    (L0 P boolean st.utterance {st}).toReal = 1 := by
+  rw [L0_real P boolean boolean_nonneg, sum_state]
+  cases st <;> simp only [boolean, State.utterance, one_mul, zero_mul, add_zero, zero_add] <;>
+    exact div_self (ENNReal.toReal_pos (hP _) (measure_ne_top _ _)).ne'
+
+/-- The Boolean speaker's use of a state's sentence at that state: the logistic function of
+the cost saved by silence less the log prior of the state, scaled by the rationality. -/
+theorem speaker_boolean_real (st : State) :
+    (speaker P boolean s st).real {st.utterance} =
+      Real.sigmoid (s.α * (s.cost .null - s.cost st.utterance - Real.log (P.real {st}))) := by
+  rw [speaker_real_of_pair P boolean s boolean_nonneg (v := .null) (by cases st <;> decide)
+      (by cases st <;> simp [boolean, State.utterance]) (by simp [boolean])
+      (λ x hx => by cases st <;> cases x <;> simp_all [boolean, State.utterance]) (hP st),
+    L0_boolean_utterance_real P hP st, L0_null_real P boolean boolean_nonneg (λ _ => rfl) st,
+    Real.log_one]
+  congr 1; ring
+
+end Boolean
+
+/-! ### The standard model (§3.2) and the fuzzy model (§4) -/
+
+namespace Setting
+
+variable (s : Setting)
+
+/-- The speaker under the measured prior. -/
+noncomputable abbrev speaker (m : Meaning) : Kernel State Utterance :=
+  HeKaiserIskarous2025.speaker s.prior m s
+
+/-- The utterance likelihood of a polarity: the speaker's use of a state's sentence at that
+state. -/
+noncomputable def likelihood (m : Meaning) (st : State) : ℝ := (s.speaker m st).real {st.utterance}
+
+/-- Under the Boolean meaning, the likelihood of a polarity is the logistic function of the
+cost saved by silence less the log prior of its state, scaled by the rationality. -/
+theorem likelihood_boolean (st : State) :
+    s.likelihood boolean st =
+      Real.sigmoid (s.α * (s.cost .null - s.cost st.utterance - Real.log (s.statePrior st))) := by
+  rw [likelihood, speaker, speaker_boolean_real s.prior s.prior_ne_zero s st, prior_real_singleton]
+
+/-- The main effect of the state prior: the Boolean likelihood of a polarity falls as its
+state's prior rises. -/
+theorem likelihood_boolean_lt {s' : Setting} (hα : s.α = s'.α) (hc : s.cost = s'.cost)
+    {st : State} (h : s.statePrior st < s'.statePrior st) :
+    s'.likelihood boolean st < s.likelihood boolean st := by
+  rw [likelihood_boolean, likelihood_boolean, ← hα, ← hc]
+  exact Real.sigmoid_lt (mul_lt_mul_of_pos_left
+    (by linarith [Real.log_lt_log (s.statePrior_pos st) h]) s.α_pos)
+
+/-- The main effect of polarity: at equal state priors, rationality and costs, the negative
+polarity is the less likely exactly when its sentence is the costlier. -/
+theorem likelihood_boolean_neg_lt_pos_iff {s' : Setting} (hα : s.α = s'.α) (hc : s.cost = s'.cost)
+    (hp : s'.statePrior .neg = s.statePrior .pos) :
+    s'.likelihood boolean .neg < s.likelihood boolean .pos ↔ s.cost .pos < s.cost .neg := by
+  rw [likelihood_boolean, likelihood_boolean, ← hα, ← hc, hp, Real.sigmoid_lt_iff,
+    mul_lt_mul_iff_of_pos_left s.α_pos]
+  simp only [State.utterance]
+  constructor <;> intro h <;> linarith
+
+/-- At equal costs the two polarities are equally likely at equal state priors (the paper's
+second simulation). -/
+theorem likelihood_boolean_neg_eq_pos {s' : Setting} (hα : s.α = s'.α) (hc : s.cost = s'.cost)
+    (hp : s'.statePrior .neg = s.statePrior .pos) (hcost : s.cost .pos = s.cost .neg) :
+    s'.likelihood boolean .neg = s.likelihood boolean .pos := by
+  rw [likelihood_boolean, likelihood_boolean, ← hα, ← hc, hp]
+  simp only [State.utterance, hcost]
+
+/-- The Boolean speaker prefers silence to the positive sentence at the positive state exactly
+when the state's prior exceeds the exponential of the cost saved by silence. -/
+theorem speaker_boolean_pos_lt_null_iff :
+    (s.speaker boolean .pos).real {.pos} < (s.speaker boolean .pos).real {.null} ↔
+      Real.exp (s.cost .null - s.cost .pos) < s.p := by
+  have h1 := L0_boolean_utterance_real s.prior s.prior_ne_zero .pos
+  simp only [State.utterance] at h1
+  rw [speaker, speaker_real_lt_iff s.prior boolean s (by simp [boolean])
+      (by simp [boolean]) (s.prior_ne_zero _), h1,
+    L0_null_real s.prior boolean boolean_nonneg (λ _ => rfl), Real.log_one, prior_real_singleton,
+    statePrior, ← Real.lt_log_iff_exp_lt s.p_pos]
+  constructor <;> intro h <;> linarith
+
+/-- An utterance holding at a state and its complement to degrees summing to one informs the
+literal listener about the state exactly when its degree there exceeds one half. -/
+theorem statePrior_lt_L0_real_iff {m : Meaning} (hm : ∀ u st, 0 ≤ m u st) {u : Utterance}
+    (hsum : m u .pos + m u .neg = 1) (st : State) :
+    s.statePrior st < (L0 s.prior m u {st}).toReal ↔ 1 / 2 < m u st := by
+  rw [L0_real s.prior m hm, sum_state]
+  simp only [prior_real_singleton]
+  have hp := s.p_pos
+  have hp1 := s.p_lt_one
+  have ha := hm u .pos
+  have hb : m u .neg = 1 - m u .pos := by linarith
+  have hpp := mul_pos hp (sub_pos.2 hp1)
+  rw [hb]
+  cases st <;> simp only [statePrior]
+  · have hden : 0 < m u .pos * s.p + (1 - m u .pos) * (1 - s.p) := by
+      nlinarith [mul_nonneg ha (sq_nonneg s.p),
+        mul_nonneg (sub_nonneg.2 (show m u .pos ≤ 1 by linarith [hm u .neg])) (sq_nonneg (1 - s.p))]
+    rw [lt_div_iff₀ hden]
+    constructor <;> intro h <;> nlinarith
+  · have hden : 0 < m u .pos * s.p + (1 - m u .pos) * (1 - s.p) := by
+      nlinarith [mul_nonneg ha (sq_nonneg s.p),
+        mul_nonneg (sub_nonneg.2 (show m u .pos ≤ 1 by linarith [hm u .neg])) (sq_nonneg (1 - s.p))]
+    rw [lt_div_iff₀ hden]
+    constructor <;> intro h <;> nlinarith
+
+/-- The fuzzy positive sentence informs the literal listener about the positive state exactly
+when its degree there exceeds one half. -/
+theorem p_lt_L0_fuzzy_pos_iff {n σ : ℝ} (hn0 : 0 ≤ n) (hn1 : n ≤ 1) (hσ0 : 0 ≤ σ) (hσ1 : σ ≤ 1) :
+    s.p < (L0 s.prior (fuzzy n σ) .pos {.pos}).toReal ↔ 1 / 2 < σ :=
+  s.statePrior_lt_L0_real_iff (fuzzy_nonneg hn0 hn1 hσ0 hσ1) (u := .pos) (by simp [fuzzy]) .pos
+
+/-- The fuzzy negative sentence informs the literal listener about the negative state exactly
+when its degree there exceeds one half, at every prior. -/
+theorem one_sub_p_lt_L0_fuzzy_neg_iff {n σ : ℝ} (hn0 : 0 ≤ n) (hn1 : n ≤ 1) (hσ0 : 0 ≤ σ)
+    (hσ1 : σ ≤ 1) :
+    1 - s.p < (L0 s.prior (fuzzy n σ) .neg {.neg}).toReal ↔ 1 / 2 < n :=
+  s.statePrior_lt_L0_real_iff (fuzzy_nonneg hn0 hn1 hσ0 hσ1) (u := .neg) (by simp [fuzzy]) .neg
+
+/-- At the positive state, the fuzzy speaker prefers silence to a positive sentence of degree
+at most one half whenever the sentence costs more than silence. -/
+theorem speaker_fuzzy_pos_lt_null {n σ : ℝ} (hn0 : 0 ≤ n) (hn1 : n ≤ 1) (hσ0 : 0 < σ)
+    (hσ : σ ≤ 1 / 2) (hc : s.cost .null < s.cost .pos) :
+    (s.speaker (fuzzy n σ) .pos).real {.pos} < (s.speaker (fuzzy n σ) .pos).real {.null} := by
+  have hm := fuzzy_nonneg hn0 hn1 hσ0.le (by linarith : σ ≤ 1)
+  rw [speaker, speaker_real_lt_iff s.prior (fuzzy n σ) s (u := .pos) (v := .null) (st := .pos)
+      hσ0 (by simp [fuzzy]) (s.prior_ne_zero _), L0_null_real s.prior (fuzzy n σ) hm (λ _ => rfl),
+    prior_real_singleton]
+  have hle : (L0 s.prior (fuzzy n σ) .pos {.pos}).toReal ≤ s.p :=
+    not_lt.1 λ h =>
+      absurd ((s.p_lt_L0_fuzzy_pos_iff hn0 hn1 hσ0.le (by linarith)).1 h) (not_lt.2 hσ)
+  have hpos : 0 < (L0 s.prior (fuzzy n σ) .pos {.pos}).toReal :=
+    ENNReal.toReal_pos (L0_ne_zero s.prior (fuzzy n σ) hσ0 (s.prior_ne_zero _)) (L0_ne_top _ _ _ _)
+  simp only [statePrior]
+  linarith [Real.log_le_log hpos hle]
+
+/-- The fuzzy meaning of §4.1: the negative sentence of degree `n`, the positive sentence of
+the sigmoid degree at the measured prior of the positive state. -/
+noncomputable def fuzzyMeaning (θ : Sigmoid) (n : ℝ) : Meaning := fuzzy n (θ.eval s.p)
+
+/-- Below the threshold prior, the fuzzy speaker prefers silence to the positive sentence at
+the positive state: the sigmoid degree disincentivizes the communication of low-prior positive
+states (§4.1). -/
+theorem speaker_fuzzyMeaning_pos_lt_null (θ : Sigmoid) {n : ℝ} (hn0 : 0 ≤ n) (hn1 : n ≤ 1)
+    (hk : 0 < θ.k) (hL : 0 < θ.L) (hc0 : 0 ≤ θ.c) (hc : θ.c < 1 / 2) (hLc : 1 / 2 < θ.L + θ.c)
+    (hp : s.p < θ.threshold) (hcost : s.cost .null < s.cost .pos) :
+    (s.speaker (s.fuzzyMeaning θ n) .pos).real {.pos} <
+      (s.speaker (s.fuzzyMeaning θ n) .pos).real {.null} :=
+  s.speaker_fuzzy_pos_lt_null hn0 hn1
+    (add_pos_of_pos_of_nonneg (mul_pos hL (Real.sigmoid_pos _)) hc0)
+    ((θ.eval_lt_half_iff hk hL hc hLc s.p).2 hp).le hcost
+
+end Setting
+
+/-! ### The wonky-world listener (§5) and the funky listener (§6) -/
+
+/-- The two worlds of the complex prior of (5): the normal world with the measured prior and
+the wonky world with the uniform one. -/
+inductive World where
+  | normal
+  | wonky
+  deriving DecidableEq, Fintype, Nonempty
+
+instance : MeasurableSpace World := ⊤
+
+theorem sum_world {β : Type*} [AddCommMonoid β] (f : World → β) :
+    ∑ w, f w = f .normal + f .wonky := by
+  rw [show ∑ w, f w = f .normal + (f .wonky + 0) from rfl, add_zero]
+
+/-- The weight of a world under a wonkiness: the wonky world with the wonkiness. -/
+def wonkinessWeight (ω : ℝ) : World → ℝ
+  | .normal => 1 - ω
+  | .wonky => ω
+
+/-- The prior over worlds. -/
+noncomputable def wonkinessPrior (ω : ℝ) : Measure World :=
+  ∑ w, ENNReal.ofReal (wonkinessWeight ω w) • Measure.dirac w
+
+theorem wonkinessPrior_apply_singleton (ω : ℝ) (w : World) :
+    wonkinessPrior ω {w} = ENNReal.ofReal (wonkinessWeight ω w) :=
+  Measure.sum_smul_dirac_apply_singleton _ w
+
+instance (ω : ℝ) : IsFiniteMeasure (wonkinessPrior ω) :=
+  ⟨by
+    rw [← Finset.coe_univ, ← sum_measure_singleton]
+    exact ENNReal.sum_lt_top.2 λ w _ => by
+      rw [wonkinessPrior_apply_singleton]; exact ENNReal.ofReal_lt_top⟩
+
+namespace Setting
+
+variable (s : Setting)
+
+/-- The prior over states in a world: measured in the normal world, uniform in the wonky
+one. -/
+noncomputable def worldPrior : World → Measure State
+  | .normal => s.prior
+  | .wonky => uniformOn Set.univ
+
+instance (w : World) : IsProbabilityMeasure (s.worldPrior w) := by
+  cases w
+  · exact inferInstanceAs (IsProbabilityMeasure s.prior)
+  · exact isProbabilityMeasure_uniformOn Set.finite_univ Set.univ_nonempty
+
+theorem worldPrior_ne_zero (w : World) (st : State) : s.worldPrior w {st} ≠ 0 := by
+  cases w
+  · exact s.prior_ne_zero st
+  · exact uniformOn_univ_singleton_ne_zero st
+
+theorem worldPrior_real_normal (st : State) : (s.worldPrior .normal).real {st} = s.statePrior st :=
+  s.prior_real_singleton st
+
+theorem worldPrior_real_wonky (st : State) : (s.worldPrior .wonky).real {st} = 1 / 2 := by
+  rw [worldPrior, uniformOn_univ_real_singleton, show Fintype.card State = 2 from rfl]
+  norm_num
+
+/-- The wonky speaker of (14) and (15): in each world, the speaker under that world's prior
+and meaning, the world riding in the state. -/
+noncomputable def wonkySpeaker (m : World → Meaning) : Kernel (State × World) Utterance :=
+  familySpeaker (λ w => L0 (s.worldPrior w) (m w)) s.α s.costFactor
+
+theorem wonkySpeaker_apply (m : World → Meaning) (st : State) (w : World) :
+    s.wonkySpeaker m (st, w) = HeKaiserIskarous2025.speaker (s.worldPrior w) (m w) s st := rfl
+
+instance (m : World → Meaning) : IsFiniteKernel (s.wonkySpeaker m) :=
+  inferInstanceAs (IsFiniteKernel (familySpeaker _ _ _))
+
+/-- The prior of (16): the measured prior over states, independent of the wonkiness. -/
+noncomputable def wonkyJoint (ω : ℝ) : Measure (State × World) := s.prior.prod (wonkinessPrior ω)
+
+instance (ω : ℝ) : IsFiniteMeasure (s.wonkyJoint ω) :=
+  inferInstanceAs (IsFiniteMeasure (s.prior.prod (wonkinessPrior ω)))
+
+theorem wonkyJoint_apply_singleton (ω : ℝ) (st : State) (w : World) :
+    s.wonkyJoint ω {(st, w)} =
+      ENNReal.ofReal (s.statePrior st) * ENNReal.ofReal (wonkinessWeight ω w) := by
+  rw [wonkyJoint, ← Set.singleton_prod_singleton, Measure.prod_prod, prior_apply_singleton,
+    wonkinessPrior_apply_singleton]
+
+theorem wonkyJoint_real_singleton {ω : ℝ} (hω0 : 0 ≤ ω) (hω1 : ω ≤ 1) (st : State) (w : World) :
+    (s.wonkyJoint ω).real {(st, w)} = s.statePrior st * wonkinessWeight ω w := by
+  rw [measureReal_def, wonkyJoint_apply_singleton, ENNReal.toReal_mul,
+    ENNReal.toReal_ofReal (s.statePrior_pos st).le, ENNReal.toReal_ofReal]
+  cases w
+  · exact sub_nonneg.2 hω1
+  · exact hω0
+
+/-- The wonky listener of (16): the Bayesian inverse of the wonky speaker over states and
+worlds against the prior of (16). -/
+noncomputable def wonkyListener (m : World → Meaning) (ω : ℝ) : Kernel Utterance (State × World) :=
+  familyListener (λ w => L0 (s.worldPrior w) (m w)) s.α s.costFactor (s.wonkyJoint ω)
+
+theorem wonkyListener_eq (m : World → Meaning) (ω : ℝ) :
+    s.wonkyListener m ω = (s.wonkySpeaker m)†(s.wonkyJoint ω) := rfl
+
+instance (m : World → Meaning) (ω : ℝ) : IsMarkovKernel (s.wonkyListener m ω) :=
+  inferInstanceAs (IsMarkovKernel ((s.wonkySpeaker m)†(s.wonkyJoint ω)))
+
+/-- The posterior wonkiness after the sentence of a state. -/
+noncomputable def wonkiness (m : World → Meaning) (ω : ℝ) (st : State) : ℝ :=
+  (s.wonkyListener m ω st.utterance).snd.real {.wonky}
+
+/-- The expected typicality of (17): the prior of a state in each world, weighted by the
+posterior over worlds after the state's sentence. -/
+noncomputable def expectedTypicality (m : World → Meaning) (ω : ℝ) (st : State) : ℝ :=
+  ∑ w, (s.wonkyListener m ω st.utterance).snd.real {w} * (s.worldPrior w).real {st}
+
+/-- The expected typicality moves the state's prior toward one half by the wonkiness. -/
+theorem expectedTypicality_eq (m : World → Meaning) (ω : ℝ) (st : State) :
+    s.expectedTypicality m ω st =
+      s.statePrior st + s.wonkiness m ω st * (1 / 2 - s.statePrior st) := by
+  have h1 : (s.wonkyListener m ω st.utterance).snd.real {.normal} +
+      (s.wonkyListener m ω st.utterance).snd.real {.wonky} = 1 := by
+    rw [← sum_world (λ w => (s.wonkyListener m ω st.utterance).snd.real {w}),
+      sum_measureReal_singleton, Finset.coe_univ, probReal_univ]
+  rw [expectedTypicality, sum_world, worldPrior_real_normal, worldPrior_real_wonky, wonkiness]
+  linear_combination s.statePrior st * h1
+
+/-- The posterior wonkiness of the Boolean wonky listener after a state's sentence: the
+wonkiness-weighted share of the wonky speaker's use of the sentence against the normal
+speaker's. -/
+theorem wonkiness_boolean {ω : ℝ} (hω0 : 0 < ω) (hω1 : ω < 1) (st : State) :
+    s.wonkiness (λ _ => boolean) ω st =
+      ω * (HeKaiserIskarous2025.speaker (s.worldPrior .wonky) boolean s st).real {st.utterance} /
+        (ω * (HeKaiserIskarous2025.speaker (s.worldPrior .wonky) boolean s st).real {st.utterance} +
+          (1 - ω) *
+            (HeKaiserIskarous2025.speaker (s.worldPrior .normal) boolean s st).real
+              {st.utterance}) := by
+  have hb : 0 < boolean st.utterance st := by cases st <;> simp [boolean, State.utterance]
+  have hpos : ∀ w, 0 < (HeKaiserIskarous2025.speaker (s.worldPrior w) boolean s st).real
+      {st.utterance} := λ w =>
+    speaker_real_pos _ boolean s hb (s.worldPrior_ne_zero w st)
+  have hu : (s.wonkySpeaker (λ _ => boolean) ∘ₘ s.wonkyJoint ω) {st.utterance} ≠ 0 :=
+    comp_familySpeaker_ne_zero (w := st) (l := World.wonky)
+      (by
+        rw [wonkyJoint_apply_singleton]
+        exact mul_ne_zero (ENNReal.ofReal_pos.2 (s.statePrior_pos st)).ne'
+          (ENNReal.ofReal_pos.2 hω0).ne')
+      (speaker_ne_zero _ boolean s hb (s.worldPrior_ne_zero _ st))
+  have hx := s.statePrior_pos st
+  have h1ω := sub_pos.2 hω1
+  rw [wonkiness, wonkyListener_eq, posterior_snd_real_singleton _ _ hu,
+    Measure.comp_real_singleton, Fintype.sum_prod_type]
+  simp only [sum_state, sum_world, wonkySpeaker_apply, s.wonkyJoint_real_singleton hω0.le hω1.le,
+    wonkinessWeight]
+  cases st
+  · simp only [State.utterance] at hpos ⊢
+    rw [speaker_real_eq_zero _ boolean s (u := .pos) (st := .neg) rfl,
+      speaker_real_eq_zero _ boolean s (u := .pos) (st := .neg) rfl]
+    simp only [mul_zero, add_zero]
+    have := hpos .wonky
+    have := hpos .normal
+    rw [div_eq_div_iff (by positivity) (by positivity)]
+    ring
+  · simp only [State.utterance] at hpos ⊢
+    rw [speaker_real_eq_zero _ boolean s (u := .neg) (st := .pos) rfl,
+      speaker_real_eq_zero _ boolean s (u := .neg) (st := .pos) rfl]
+    simp only [mul_zero, add_zero, zero_add]
+    have := hpos .wonky
+    have := hpos .normal
+    rw [div_eq_div_iff (by positivity) (by positivity)]
+    ring
+
+theorem wonkiness_boolean_pos {ω : ℝ} (hω0 : 0 < ω) (hω1 : ω < 1) (st : State) :
+    0 < s.wonkiness (λ _ => boolean) ω st := by
+  have hb : 0 < boolean st.utterance st := by cases st <;> simp [boolean, State.utterance]
+  have hpos : ∀ w, 0 < (HeKaiserIskarous2025.speaker (s.worldPrior w) boolean s st).real
+      {st.utterance} := λ w =>
+    speaker_real_pos _ boolean s hb (s.worldPrior_ne_zero w st)
+  have h1ω := sub_pos.2 hω1
+  rw [wonkiness_boolean s hω0 hω1]
+  have := hpos .wonky
+  have := hpos .normal
+  positivity
+
+/-- The wonky listener's wonkiness rises above its prior after a state's sentence exactly
+when that state's prior exceeds one half, whatever the costs (§5.3, Figure 6). -/
+theorem lt_wonkiness_iff {ω : ℝ} (hω0 : 0 < ω) (hω1 : ω < 1) (st : State) :
+    ω < s.wonkiness (λ _ => boolean) ω st ↔ 1 / 2 < s.statePrior st := by
+  rw [wonkiness_boolean s hω0 hω1,
+    speaker_boolean_real (s.worldPrior .wonky) (s.worldPrior_ne_zero .wonky) s st,
+    speaker_boolean_real (s.worldPrior .normal) (s.worldPrior_ne_zero .normal) s st,
+    worldPrior_real_wonky, worldPrior_real_normal]
+  set Sw := Real.sigmoid (s.α * (s.cost .null - s.cost st.utterance - Real.log (1 / 2))) with hSw
+  set Sn := Real.sigmoid (s.α * (s.cost .null - s.cost st.utterance - Real.log (s.statePrior st)))
+    with hSn
+  have hSw0 : 0 < Sw := Real.sigmoid_pos _
+  have hSn0 : 0 < Sn := Real.sigmoid_pos _
+  have h1ω := sub_pos.2 hω1
+  have hden : 0 < ω * Sw + (1 - ω) * Sn := by positivity
+  have key : ω * (ω * Sw + (1 - ω) * Sn) < ω * Sw ↔ Sn < Sw := by
+    constructor <;> intro h <;> nlinarith [mul_pos hω0 h1ω]
+  rw [lt_div_iff₀ hden, key, hSw, hSn, Real.sigmoid_lt_iff, mul_lt_mul_iff_of_pos_left s.α_pos,
+    sub_lt_sub_iff_left, Real.log_lt_log_iff (by norm_num) (s.statePrior_pos st)]
+
+/-- Typicality and atypicality inferences in both polarities (§5.3, Figure 5): after a state's
+sentence, the Boolean wonky listener's expected typicality of the state exceeds its prior
+exactly when the prior is below one half. -/
+theorem statePrior_lt_expectedTypicality_iff {ω : ℝ} (hω0 : 0 < ω) (hω1 : ω < 1) (st : State) :
+    s.statePrior st < s.expectedTypicality (λ _ => boolean) ω st ↔ s.statePrior st < 1 / 2 := by
+  rw [expectedTypicality_eq, lt_add_iff_pos_right,
+    mul_pos_iff_of_pos_left (s.wonkiness_boolean_pos hω0 hω1 st), sub_pos]
+
+/-- The wonkiness after a sentence depends on its polarity only through its cost: at equal
+state priors, rationality and costs, the two polarities update it alike. -/
+theorem wonkiness_boolean_neg_eq_pos {s' : Setting} {ω : ℝ} (hω0 : 0 < ω) (hω1 : ω < 1)
+    (hα : s.α = s'.α) (hc : s.cost = s'.cost) (hp : s'.statePrior .neg = s.statePrior .pos)
+    (hcost : s.cost .pos = s.cost .neg) :
+    s'.wonkiness (λ _ => boolean) ω .neg = s.wonkiness (λ _ => boolean) ω .pos := by
+  rw [wonkiness_boolean s' hω0 hω1, wonkiness_boolean s hω0 hω1,
+    speaker_boolean_real (s'.worldPrior .wonky) (s'.worldPrior_ne_zero .wonky) s',
+    speaker_boolean_real (s'.worldPrior .normal) (s'.worldPrior_ne_zero .normal) s',
+    speaker_boolean_real (s.worldPrior .wonky) (s.worldPrior_ne_zero .wonky) s,
+    speaker_boolean_real (s.worldPrior .normal) (s.worldPrior_ne_zero .normal) s,
+    worldPrior_real_wonky, worldPrior_real_wonky, worldPrior_real_normal, worldPrior_real_normal,
+    ← hα, ← hc, hp]
+  simp only [State.utterance, hcost]
+
+/-- The meaning of the funky listener of (18) to (20) in a world: the fuzzy meaning at that
+world's prior of the positive state. -/
+noncomputable def funkyMeaning (θ : Sigmoid) (n : ℝ) (w : World) : Meaning :=
+  fuzzy n (θ.eval ((s.worldPrior w).real {.pos}))
+
+/-- In the normal world the funky speaker is the fuzzy speaker, so the two models agree on
+utterance likelihood (§6.2). -/
+theorem wonkySpeaker_funkyMeaning_normal (θ : Sigmoid) (n : ℝ) (st : State) :
+    s.wonkySpeaker (s.funkyMeaning θ n) (st, .normal) = s.speaker (s.fuzzyMeaning θ n) st := by
+  rw [wonkySpeaker_apply, funkyMeaning, worldPrior_real_normal]
   rfl
 
-/-- Negative utterances have higher cost in our model. -/
-theorem neg_higher_cost :
-    utteranceCost .uNeg > utteranceCost .uPos := by
-  native_decide
-
-/-- fuzzyRSA with low prior: positive utterance becomes less reliable. -/
-theorem fuzzy_low_prior_effect :
-    fuzzyMeaning lowPriorConfig .uPos .pos <
-    fuzzyMeaning highPriorConfig .uPos .pos := by
-  native_decide
-
-/-- Negative interpretation is constant regardless of prior. -/
-theorem neg_interpretation_constant :
-    fuzzyMeaning lowPriorConfig .uNeg .neg =
-    fuzzyMeaning highPriorConfig .uNeg .neg :=
-  rfl
-
-/-- Map He et al.'s sentence polarity to compositional context polarity. -/
-def toContextPolarity : Polarity → NaturalLogic.ContextPolarity
-  | .positive => .upward
-  | .negative => .downward
-  | .null => .upward
-
-/-- Cost aligns with UE/DE distinction: DE costs more. -/
-theorem cost_reflects_polarity :
-    utteranceCost .uPos < utteranceCost .uNeg := by
-  native_decide
-
--- ============================================================================
--- § Compositional Analysis of He et al. Sentences
--- ============================================================================
-
-section CompositionalGrounding
-
-/-- A simple model for part-whole relations. -/
-inductive PWEntity where
-  | house | classroom | bathroom | stove
-  deriving DecidableEq, Repr
-
-/-- The "has" relation: which containers have which parts. -/
-def has_sem : PWEntity → PWEntity → Prop :=
-  λ part container => match container, part with
-    | .house, .bathroom => True
-    | .classroom, .stove => False
-    | _, _ => False
-
-/-- Positive sentence meaning: "A has B". -/
-def posMeaning (container part : PWEntity) : Prop :=
-  has_sem part container
-
-/-- Negative sentence meaning: "A doesn't have B". -/
-def negMeaning (container part : PWEntity) : Prop :=
-  ¬ posMeaning container part
-
-theorem house_has_bathroom : posMeaning .house .bathroom := trivial
-theorem house_doesnt_have_bathroom : ¬ negMeaning .house .bathroom := fun h => h trivial
-theorem classroom_doesnt_have_stove : negMeaning .classroom .stove := id
-
-/-- Lift He et al. sentences to world-indexed propositions. -/
-def liftToWorlds (s : HKIState) : (HKIState → Bool) :=
-  λ w => w == s
-
-/-- Negative sentence meaning as world-indexed proposition.
-    ⟦"A doesn't have B"⟧ = !⟦"A has B"⟧ pointwise. -/
-def negMeaningW : (HKIState → Bool) :=
-  fun w => !(liftToWorlds .pos) w
-
-/-- Negation reverses entailment (DE property). -/
-theorem not_reverses_entailment_HKI (p q : (HKIState → Bool))
-    (h : ∀ w, p w = true → q w = true) :
-    ∀ w, (!q w) = true → (!p w) = true := by
-  intro w hq
-  cases hp : p w
-  · rfl
-  · exact absurd (h w hp) (by simpa using hq)
-
-/-- Negative sentences are downward-entailing: complementation is
-    antitone. -/
-theorem neg_sentence_is_de : Antitone (compl : Set (Fin 4) → Set (Fin 4)) :=
-  NaturalLogic.antitone_compl
-
-/-- Positive sentences are upward-entailing: the identity context. -/
-theorem pos_sentence_is_ue : Monotone (id : Set (Fin 4) → Set (Fin 4)) :=
-  monotone_id
-
-/-- Structural complexity: count of functional heads in the derivation. -/
-def structuralComplexity : HKIUtterance → ℕ
-  | .uNull => 0
-  | .uPos => 1
-  | .uNeg => 2
-
-/-- Utterance cost equals structural complexity. -/
-theorem cost_from_structure :
-    ∀ u : HKIUtterance, utteranceCost u = structuralComplexity u := by
-  intro u
-  cases u <;> rfl
-
-/-- Negation adds exactly one unit of complexity (the Neg functional head). -/
-theorem negation_adds_one_head :
-    structuralComplexity .uNeg = structuralComplexity .uPos + 1 := rfl
-
-end CompositionalGrounding
+end Setting
 
 end HeKaiserIskarous2025

--- a/references.bib
+++ b/references.bib
@@ -297,7 +297,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Core/Probability/Softmax.lean;Pragmatics/Bidirectional.lean;Pragmatics/RSA/Basic.lean;Pragmatics/RSA/Canonical.lean;Pragmatics/RSA/Gibbs.lean;Pragmatics/RSA/Operators.lean;Studies/Anderson2021.lean;Studies/BellerGerstenberg2025.lean;Studies/BergenGoodman2015.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/CremersWilcoxSpector2023.lean;Studies/DegenEtAl2020.lean;Studies/FrankGoodman2012.lean;Studies/FrankeBergen2020.lean;Studies/GoodmanStuhlmuller2013.lean;Studies/HardingGerstenbergIcard2025.lean;Studies/KaoEtAl2014PMFMetaphor.lean;Studies/Kennedy2015.lean;Studies/Kennedy2015PMF.lean;Studies/LassiterGoodman2017.lean;Studies/QingFranke2015.lean;Studies/SikosEtAl2021.lean;Studies/SumersEtAl2023.lean;Studies/TesslerGoodman2019.lean;Studies/Thomas2026.lean}
+  sources   = {Core/Probability/Softmax.lean;Pragmatics/Bidirectional.lean;Pragmatics/RSA/Basic.lean;Pragmatics/RSA/Canonical.lean;Pragmatics/RSA/Gibbs.lean;Pragmatics/RSA/Operators.lean;Studies/Anderson2021.lean;Studies/BellerGerstenberg2025.lean;Studies/BergenGoodman2015.lean;Studies/ChampollionAlsopGrosu2019.lean;Studies/CremersWilcoxSpector2023.lean;Studies/DegenEtAl2020.lean;Studies/FrankGoodman2012.lean;Studies/FrankeBergen2020.lean;Studies/GoodmanStuhlmuller2013.lean;Studies/HardingGerstenbergIcard2025.lean;Studies/HeKaiserIskarous2025.lean;Studies/KaoEtAl2014PMFMetaphor.lean;Studies/Kennedy2015.lean;Studies/Kennedy2015PMF.lean;Studies/LassiterGoodman2017.lean;Studies/QingFranke2015.lean;Studies/SikosEtAl2021.lean;Studies/SumersEtAl2023.lean;Studies/TesslerGoodman2019.lean;Studies/Thomas2026.lean}
 }
 @article{sikos-etal-2021,
   author    = {Sikos, Les and Venhuizen, Noortje J. and Drenhaus, Heiner and Crocker, Matthew W.},
@@ -927,7 +927,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Pragmatics/RSA/Incremental.lean;Studies/DegenEtAl2020.lean;Studies/GilesEtAl2026.lean;Studies/KursatDegen2021.lean;Studies/SchlotterbeckWang2023.lean;Studies/WaldonDegen2021.lean;Studies/WesterbeekKoolenMaes2015.lean}
+  sources   = {Pragmatics/RSA/Incremental.lean;Studies/DegenEtAl2020.lean;Studies/GilesEtAl2026.lean;Studies/HeKaiserIskarous2025.lean;Studies/KursatDegen2021.lean;Studies/SchlotterbeckWang2023.lean;Studies/WaldonDegen2021.lean;Studies/WesterbeekKoolenMaes2015.lean}
 }
 @article{westerbeek-koolen-maes-2015,
   author    = {Westerbeek, Hans and Koolen, Ruud and Maes, Alfons},
@@ -1239,7 +1239,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/CremersWilcoxSpector2023.lean}
+  sources   = {Studies/CremersWilcoxSpector2023.lean;Studies/HeKaiserIskarous2025.lean}
 }
 @inproceedings{degen-etal-2015,
   author    = {Degen, Judith and Tessler, Michael Henry and Goodman, Noah D.},
@@ -1249,7 +1249,7 @@
   url       = {https://cocolab.stanford.edu/papers/DegenEtAl2015-Cogsci.pdf},
     subfield  = {pragmatics/rsa},
   role      = {cited},
-  sources   = {}
+  sources   = {Studies/CremersWilcoxSpector2023.lean;Studies/HeKaiserIskarous2025.lean}
 }
 @article{dale-reiter-1995,
   author    = {Dale, Robert and Reiter, Ehud},
@@ -1406,7 +1406,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/HeKaiserIskarous2025.lean}
+  sources   = {Data/Examples/HeKaiserIskarous2025.json;Studies/HeKaiserIskarous2025.lean}
 }
 @article{nouwen-2024,
   author    = {Nouwen, Rick},
@@ -5277,7 +5277,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Features/Antonymy.lean;Pragmatics/NeoGricean/Basic.lean;Semantics/Degree/Antonymy.lean;Studies/AlexandropoulouGotzner2024a.lean;Studies/AlexandropoulouGotzner2024b.lean;Studies/BaleEtAl2025.lean;Studies/Gajewski2011.lean;Studies/KirkGiannini2024.lean;Studies/Krifka2007.lean}
+  sources   = {Features/Antonymy.lean;Pragmatics/NeoGricean/Basic.lean;Semantics/Degree/Antonymy.lean;Studies/AlexandropoulouGotzner2024a.lean;Studies/AlexandropoulouGotzner2024b.lean;Studies/BaleEtAl2025.lean;Studies/Gajewski2011.lean;Studies/HeKaiserIskarous2025.lean;Studies/KirkGiannini2024.lean;Studies/Krifka2007.lean}
 }% REF: Kratzer, A. (1989). An investigation of the lumps of thought.
 @article{kratzer-1989,
   author    = {Kratzer, Angelika},


### PR DESCRIPTION
Recut the He, Kaiser and Iskarous (2025) study onto the kernel RSA pipeline: the standard, fuzzy, wonky and funky models as `RSA.speaker` and `RSA.familyListener` instances, with the paper's qualitative predictions derived rather than transcribed.

- Boolean model: each polarity's likelihood is a logistic function of cost and log prior, so it falls with the state prior and the positive polarity leads exactly when cheaper (equal at equal costs, the paper's second simulation).
- Fuzzy model: the sigmoid degree of (13) is below one half exactly below a closed-form threshold prior (`0.35 − log(2.5)/6` at the best fit), where the speaker prefers silence to the positive sentence; the wonky listener's wonkiness rises above its prior exactly when the described state's prior exceeds one half, whatever the costs, and the expected typicality of (17) moves the prior toward one half.
- Drops the string-valued hypotheses, count theorems, `native_decide` proofs and the piecewise sigmoid stand-in; adds `Real.sigmoid_log_div_one_sub` to the Core sigmoid file and 8 example rows.
