### PR TITLE
refactor(Studies/HuangSpelkeSnedeker2013): the covered-box task

### DIFF
--- a/Linglib/Data/Examples/HuangSpelkeSnedeker2013.json
+++ b/Linglib/Data/Examples/HuangSpelkeSnedeker2013.json
@@ -1,0 +1,626 @@
+[
+  {
+    "id": "huang2013_ex1",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(1)"
+    },
+    "language": "stan1293",
+    "primaryText": "A bicycle has two wheels, while a tricycle has three.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "reading",
+        "exact"
+      ]
+    ],
+    "comment": "Based on Horn (1989).",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex2",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(2)"
+    },
+    "language": "stan1293",
+    "primaryText": "Bonnie: I need to borrow two chairs. Do you know where I could get them? David: Sure, I've got two chairs in my office.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "reading",
+        "lower-bounded"
+      ]
+    ],
+    "comment": "Adapted from Kadmon (2001): true and felicitous with five chairs in the office.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex3",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(3)"
+    },
+    "language": "stan1293",
+    "primaryText": "Henry: I ate some of the ice cream.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "reading",
+        "some but not all"
+      ],
+      [
+        "implicature",
+        "calculated"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex4",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(4)"
+    },
+    "language": "stan1293",
+    "primaryText": "Eva: Did anyone try the lutefisk? Karl: Yeah, Leif ate some of it. In fact, he ate all of it.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "reading",
+        "lower-bounded"
+      ],
+      [
+        "implicature",
+        "cancelled"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex5",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(5)"
+    },
+    "language": "stan1293",
+    "primaryText": "Henry: I ate all of the ice cream.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.1"
+      ],
+      [
+        "term",
+        "all"
+      ],
+      [
+        "role",
+        "stronger alternative to (3)"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex6",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(6)"
+    },
+    "language": "stan1293",
+    "primaryText": "Everyone who ate some of their berries felt fine.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.2"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "environment",
+        "restrictor of a universal"
+      ],
+      [
+        "reading",
+        "lower-bounded"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex7",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(7)"
+    },
+    "language": "stan1293",
+    "primaryText": "Everyone who ate two of their berries felt fine.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.2"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "environment",
+        "restrictor of a universal"
+      ],
+      [
+        "reading",
+        "exact"
+      ]
+    ],
+    "comment": "Breheny (2008): the numeral stays exact where the scalar goes lower-bounded.",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_ex8",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "(8)"
+    },
+    "language": "stan1293",
+    "primaryText": "Everybody came to Allison's party.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "1.2"
+      ],
+      [
+        "term",
+        "everybody"
+      ],
+      [
+        "phenomenon",
+        "implicit domain restriction"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp1_some",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 1, scalar condition"
+    },
+    "language": "stan1293",
+    "primaryText": "Give me the box where Cookie Monster has some of the cookies.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Two open boxes showing Cookie Monster's and Big Bird's shares of a set of cookies, and a covered box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.1.2"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "task",
+        "covered box"
+      ],
+      [
+        "trials",
+        "some(NONE,SOME), some(SOME,ALL), some(NONE,ALL)"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp1_two",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 1, number condition"
+    },
+    "language": "stan1293",
+    "primaryText": "Give me the box with two fish.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Two open boxes containing sets of fish, and a covered box.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "2.1.2"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "task",
+        "covered box"
+      ],
+      [
+        "trials",
+        "two(1,2), two(2,3V5), two(1,3V5)"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp2_giveN_some",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 2, pretest"
+    },
+    "language": "stan1293",
+    "primaryText": "Put some of the fish into the pond.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "task",
+        "Give-N"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp2_giveN_all",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 2, pretest"
+    },
+    "language": "stan1293",
+    "primaryText": "Put all of the fish into the pond.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "3.1.2"
+      ],
+      [
+        "term",
+        "all"
+      ],
+      [
+        "task",
+        "Give-N"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp3_all",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 3"
+    },
+    "language": "stan1293",
+    "primaryText": "Give me the box where Cookie Monster has all of the cookies.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "4.1.2"
+      ],
+      [
+        "term",
+        "all"
+      ],
+      [
+        "task",
+        "covered box"
+      ],
+      [
+        "trials",
+        "all(NONE,ALL), all(SOME,ALL), all(SOME,NONE)"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp4_two",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "Exp. 4, two(1,3)"
+    },
+    "language": "stan1293",
+    "primaryText": "Give me the box where Cookie Monster has two of the cookies.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "Cookie Monster has 1 of 4 cookies in one open box and 3 of 4 in the other; the third box is covered.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "5.1.2"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "task",
+        "covered box"
+      ],
+      [
+        "trials",
+        "two(1,3)"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_exp4_fn2",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "fn. 2"
+    },
+    "language": "stan1293",
+    "primaryText": "Give me the box where Cookie Monster has two of the cookies.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "The displays of the some trials, with Cookie Monster holding 0 of 4 or 4 of 4 cookies.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "5.2"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "task",
+        "covered box"
+      ],
+      [
+        "displays",
+        "of the some(NONE,ALL) trials"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_s62_some",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "§6.2"
+    },
+    "language": "stan1293",
+    "primaryText": "Point to the girl that has some of the socks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "A girl with 2 of 4 socks and a girl with 3 of 3 soccer balls.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "6.2"
+      ],
+      [
+        "term",
+        "some"
+      ],
+      [
+        "task",
+        "visual world"
+      ],
+      [
+        "ambiguity",
+        "some of the soc-"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_s62_three",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "§6.2"
+    },
+    "language": "stan1293",
+    "primaryText": "Point to the girl that has three of the socks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "A girl with 3 socks and a girl with 2 soccer balls.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "6.2"
+      ],
+      [
+        "term",
+        "three"
+      ],
+      [
+        "task",
+        "visual world"
+      ],
+      [
+        "role",
+        "lower-bound control"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  },
+  {
+    "id": "huang2013_s62_two",
+    "source": {
+      "bibkey": "huang-spelke-snedeker-2013",
+      "paperLabel": "§6.2"
+    },
+    "language": "stan1293",
+    "primaryText": "Point to the girl that has two of the socks.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "A girl with 2 socks and a girl with 3 soccer balls.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "section",
+        "6.2"
+      ],
+      [
+        "term",
+        "two"
+      ],
+      [
+        "task",
+        "visual world"
+      ],
+      [
+        "role",
+        "upper-bound probe"
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/HuangSpelkeSnedeker2013.lean
+++ b/Linglib/Data/Examples/HuangSpelkeSnedeker2013.lean
@@ -1,0 +1,342 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `HuangSpelkeSnedeker2013` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/HuangSpelkeSnedeker2013.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace HuangSpelkeSnedeker2013.Examples`.
+-/
+
+namespace HuangSpelkeSnedeker2013.Examples
+
+open Data.Examples
+
+def huang2013_ex1 : LinguisticExample :=
+  { id := "huang2013_ex1"
+    source := ⟨"huang-spelke-snedeker-2013", "(1)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "A bicycle has two wheels, while a tricycle has three."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1"), ("term", "two"), ("reading", "exact")]
+    comment := "Based on Horn (1989)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex2 : LinguisticExample :=
+  { id := "huang2013_ex2"
+    source := ⟨"huang-spelke-snedeker-2013", "(2)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Bonnie: I need to borrow two chairs. Do you know where I could get them? David: Sure, I've got two chairs in my office."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1"), ("term", "two"), ("reading", "lower-bounded")]
+    comment := "Adapted from Kadmon (2001): true and felicitous with five chairs in the office."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex3 : LinguisticExample :=
+  { id := "huang2013_ex3"
+    source := ⟨"huang-spelke-snedeker-2013", "(3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Henry: I ate some of the ice cream."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("term", "some"), ("reading", "some but not all"), ("implicature", "calculated")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex4 : LinguisticExample :=
+  { id := "huang2013_ex4"
+    source := ⟨"huang-spelke-snedeker-2013", "(4)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Eva: Did anyone try the lutefisk? Karl: Yeah, Leif ate some of it. In fact, he ate all of it."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("term", "some"), ("reading", "lower-bounded"), ("implicature", "cancelled")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex5 : LinguisticExample :=
+  { id := "huang2013_ex5"
+    source := ⟨"huang-spelke-snedeker-2013", "(5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Henry: I ate all of the ice cream."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.1"), ("term", "all"), ("role", "stronger alternative to (3)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex6 : LinguisticExample :=
+  { id := "huang2013_ex6"
+    source := ⟨"huang-spelke-snedeker-2013", "(6)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everyone who ate some of their berries felt fine."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.2"), ("term", "some"), ("environment", "restrictor of a universal"), ("reading", "lower-bounded")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex7 : LinguisticExample :=
+  { id := "huang2013_ex7"
+    source := ⟨"huang-spelke-snedeker-2013", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everyone who ate two of their berries felt fine."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.2"), ("term", "two"), ("environment", "restrictor of a universal"), ("reading", "exact")]
+    comment := "Breheny (2008): the numeral stays exact where the scalar goes lower-bounded."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_ex8 : LinguisticExample :=
+  { id := "huang2013_ex8"
+    source := ⟨"huang-spelke-snedeker-2013", "(8)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Everybody came to Allison's party."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "1.2"), ("term", "everybody"), ("phenomenon", "implicit domain restriction")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp1_some : LinguisticExample :=
+  { id := "huang2013_exp1_some"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 1, scalar condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Give me the box where Cookie Monster has some of the cookies."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Two open boxes showing Cookie Monster's and Big Bird's shares of a set of cookies, and a covered box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.1.2"), ("term", "some"), ("task", "covered box"), ("trials", "some(NONE,SOME), some(SOME,ALL), some(NONE,ALL)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp1_two : LinguisticExample :=
+  { id := "huang2013_exp1_two"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 1, number condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Give me the box with two fish."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Two open boxes containing sets of fish, and a covered box."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "2.1.2"), ("term", "two"), ("task", "covered box"), ("trials", "two(1,2), two(2,3V5), two(1,3V5)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp2_giveN_some : LinguisticExample :=
+  { id := "huang2013_exp2_giveN_some"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 2, pretest"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put some of the fish into the pond."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("term", "some"), ("task", "Give-N")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp2_giveN_all : LinguisticExample :=
+  { id := "huang2013_exp2_giveN_all"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 2, pretest"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Put all of the fish into the pond."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "3.1.2"), ("term", "all"), ("task", "Give-N")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp3_all : LinguisticExample :=
+  { id := "huang2013_exp3_all"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 3"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Give me the box where Cookie Monster has all of the cookies."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "4.1.2"), ("term", "all"), ("task", "covered box"), ("trials", "all(NONE,ALL), all(SOME,ALL), all(SOME,NONE)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp4_two : LinguisticExample :=
+  { id := "huang2013_exp4_two"
+    source := ⟨"huang-spelke-snedeker-2013", "Exp. 4, two(1,3)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Give me the box where Cookie Monster has two of the cookies."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "Cookie Monster has 1 of 4 cookies in one open box and 3 of 4 in the other; the third box is covered."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.1.2"), ("term", "two"), ("task", "covered box"), ("trials", "two(1,3)")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_exp4_fn2 : LinguisticExample :=
+  { id := "huang2013_exp4_fn2"
+    source := ⟨"huang-spelke-snedeker-2013", "fn. 2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Give me the box where Cookie Monster has two of the cookies."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "The displays of the some trials, with Cookie Monster holding 0 of 4 or 4 of 4 cookies."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.2"), ("term", "two"), ("task", "covered box"), ("displays", "of the some(NONE,ALL) trials")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_s62_some : LinguisticExample :=
+  { id := "huang2013_s62_some"
+    source := ⟨"huang-spelke-snedeker-2013", "§6.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Point to the girl that has some of the socks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "A girl with 2 of 4 socks and a girl with 3 of 3 soccer balls."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "6.2"), ("term", "some"), ("task", "visual world"), ("ambiguity", "some of the soc-")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_s62_three : LinguisticExample :=
+  { id := "huang2013_s62_three"
+    source := ⟨"huang-spelke-snedeker-2013", "§6.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Point to the girl that has three of the socks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "A girl with 3 socks and a girl with 2 soccer balls."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "6.2"), ("term", "three"), ("task", "visual world"), ("role", "lower-bound control")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def huang2013_s62_two : LinguisticExample :=
+  { id := "huang2013_s62_two"
+    source := ⟨"huang-spelke-snedeker-2013", "§6.2"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Point to the girl that has two of the socks."
+    discourseSegments := []
+    glossedTokens := []
+    translation := ""
+    context := "A girl with 2 socks and a girl with 3 soccer balls."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "6.2"), ("term", "two"), ("task", "visual world"), ("role", "upper-bound probe")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [huang2013_ex1, huang2013_ex2, huang2013_ex3, huang2013_ex4, huang2013_ex5, huang2013_ex6, huang2013_ex7, huang2013_ex8, huang2013_exp1_some, huang2013_exp1_two, huang2013_exp2_giveN_some, huang2013_exp2_giveN_all, huang2013_exp3_all, huang2013_exp4_two, huang2013_exp4_fn2, huang2013_s62_some, huang2013_s62_three, huang2013_s62_two]
+
+end HuangSpelkeSnedeker2013.Examples

--- a/Linglib/Studies/HuangSpelkeSnedeker2013.lean
+++ b/Linglib/Studies/HuangSpelkeSnedeker2013.lean
@@ -1,145 +1,218 @@
+import Linglib.Pragmatics.Implicature.SomeAll
+import Linglib.Semantics.Quantification.Numerals.Basic
+
 /-!
-# [huang-snedeker-2013] — Covered-Box Paradigm
-[huang-snedeker-2013] [musolino-2004] [wynn-1992]
+# Huang, Spelke and Snedeker (2013): What exactly do numbers mean?
 
-"What Exactly do Numbers Mean?"
-Language Learning and Development 9(2): 105-129
+This file formalizes the covered-box task of [huang-spelke-snedeker-2013], which asks whether
+number words have exact or lower-bounded semantics by cancelling the scalar implicature that
+would otherwise supply the upper bound. A trial offers two visible boxes and a covered one, and
+the instruction is a definite description, *the box with two fish*; under a reading `R` of the
+term the referent is the visible box satisfying `R` when exactly one does, the covered box when
+none does, and no box at all when both do (`choice`). In the critical trials a lower-bounded
+match is visible and an exact one is not: an exact *two* sends the participant to the covered
+box and a lower-bounded *two* to the visible box (`choice_bareMeaning_covered`,
+`choice_atLeastMeaning_visible`), while for *some* the literal meaning picks the box where
+Cookie Monster has all of the cookies and the strengthened meaning the covered box. Adults and
+two- to three-year-olds took the total set for *some* and the covered box for *two*.
 
-## Design
+Two-knowers, children who give one and two but a handful for larger numerals in Wynn's Give-N
+task ([wynn-1992]), are the population for which the lower-bounded account has no implicature
+to offer, the developmental strategy of [musolino-2004]: exhaustifying *two* against the count
+list a child knows leaves the lower bound untouched when *two* is its top (`exhKnown_last`),
+and only a known stronger numeral makes it exact (`exhKnown_of_lt`). Section 6.1's residual
+route, an implicit alternative *more than two*, does recover exactness
+(`atLeast_not_moreThan_iff_bare`).
 
-The covered-box task cancels scalar implicatures by embedding the target term
-in a definite description ("the box with two fish") and providing three options:
-a visible mismatch, a visible lower-bounded match, and a covered (hidden) box.
-When no exact match is visible, choosing the covered box implies the participant
-requires an exact match (rejecting the LB-compatible visible option).
+## Implementation notes
 
-The task is validated by a scalar control: "some" in the same paradigm yields
-lower-bounded readings (adults accept ALL as "some"), confirming that implicatures
-are successfully cancelled.
+* Scalar trials are typed by the shared `SomeAllWorld`, a box showing Cookie Monster's share of
+  the cookies; number trials by the cardinality of a box.
+* The choice proportions and the statistics stay in prose: the paradigm's predictions are
+  categorical, and the paper's argument is that the majority choice identifies the reading.
 
-## Key Empirical Findings
+## References
 
-Across 4 experiments with adults and two-knower children (ages 2;6–3;7):
-
-1. **"some" control**: lower-bounded when implicature cancelled — adults accept
-   the total set (87% Exp 1, 60% Exp 4), children accept it (83–90%)
-2. **"two" critical**: exact under the same conditions — both adults (92–100%)
-   and two-knowers (80–95%) reject the 3-fish box, choose covered
-3. **Scalar–numeral divergence**: "some" and "two" pattern differently in the
-   same implicature-cancelling context; scalars go LB, numerals stay exact
-4. **Two-knower specificity**: children who know "one" and "two" but NOT "three"
-   still give exact readings for "two"
-
+* [huang-spelke-snedeker-2013]
+* [wynn-1992]
+* [musolino-2004]
 -/
 
 namespace HuangSpelkeSnedeker2013
 
--- ============================================================================
--- Section 1: Task and Measures
--- ============================================================================
+open Numerals
 
-/-- Choice in the covered-box paradigm. -/
-inductive BoxChoice where
-  | mismatch     -- visible box incompatible with description
-  | lowerBounded -- visible box satisfying LB but not exact reading
-  | covered      -- hidden box (inferred to contain exact match)
-  deriving Repr, DecidableEq
+/-! ### The covered-box task -/
 
--- ============================================================================
--- Section 2: Covered-Box Data
--- ============================================================================
+/-- A covered-box trial: two visible boxes with contents of type `α`, and a covered box. -/
+structure Trial (α : Type*) where
+  left : α
+  right : α
 
-/-- A critical trial result. -/
-structure CoveredBoxDatum where
-  experiment : Nat
-  population : String
-  term : String
-  /-- Cardinalities in the visible boxes -/
-  visibleCounts : List Nat
-  /-- Percentage selecting the covered box -/
-  coveredPct : Nat
-  /-- Percentage selecting the lower-bounded visible match -/
-  lbPct : Nat
-  note : String
-  deriving Repr
+/-- What the participant hands over. -/
+inductive Choice (α : Type*) where
+  | visible (x : α)
+  | covered
+  deriving DecidableEq
 
--- Number word critical trials (no exact match visible)
+variable {α : Type*} (R : α → Prop) [DecidablePred R] (t : Trial α)
 
-def exp1_adults_two : CoveredBoxDatum :=
-  { experiment := 1, population := "adults (N=60)"
-    term := "two", visibleCounts := [1, 3]
-    coveredPct := 100, lbPct := 0
-    note := "two(1,3V5): unanimous covered-box selection" }
+/-- The referent of the definite description under a reading `R` of the term: the visible box
+satisfying `R` when exactly one does, the covered box when none does, and no box when both do,
+since the description presupposes a unique referent. -/
+def choice : Option (Choice α) :=
+  if R t.left then if R t.right then none else some (.visible t.left)
+  else if R t.right then some (.visible t.right) else some .covered
 
-def exp2_twoKnowers_two : CoveredBoxDatum :=
-  { experiment := 2, population := "two-knowers (N=10, ages 2;6–3;5)"
-    term := "two", visibleCounts := [1, 3]
-    coveredPct := 95, lbPct := 0
-    note := "two(1,3V5): two-knowers strongly prefer covered box" }
+theorem choice_eq_none_iff : choice R t = none ↔ R t.left ∧ R t.right := by
+  unfold choice; split_ifs <;> simp_all
 
-def exp4_children_two : CoveredBoxDatum :=
-  { experiment := 4, population := "two-knowers (N=20, ages 2;6–3;7)"
-    term := "two", visibleCounts := [1, 3]
-    coveredPct := 80, lbPct := 10
-    note := "two(1,3): replicated with two-character displays" }
+/-- The covered box is chosen exactly when no visible box satisfies the description. -/
+theorem choice_eq_covered_iff : choice R t = some .covered ↔ ¬ R t.left ∧ ¬ R t.right := by
+  unfold choice; split_ifs <;> simp_all
 
-def exp4_adults_two : CoveredBoxDatum :=
-  { experiment := 4, population := "adults (N=50, MTurk)"
-    term := "two", visibleCounts := [1, 3]
-    coveredPct := 92, lbPct := 7
-    note := "two(1,3): MTurk replication confirms pattern" }
+theorem choice_eq_visible_left_iff :
+    choice R t = some (.visible t.left) ↔ R t.left ∧ ¬ R t.right := by
+  unfold choice
+  split_ifs with h₁ h₂ h₂ <;> simp only [h₁, h₂, Option.some.injEq, Choice.visible.injEq,
+    reduceCtorEq, not_true_eq_false, not_false_eq_true, and_self, and_false, false_and, iff_false]
+  exact λ h => h₁ (h ▸ h₂)
 
--- Scalar control trials (validates implicature cancellation)
+theorem choice_eq_visible_right_iff :
+    choice R t = some (.visible t.right) ↔ ¬ R t.left ∧ R t.right := by
+  unfold choice
+  split_ifs with h₁ h₂ h₂ <;> simp only [h₁, h₂, Option.some.injEq, Choice.visible.injEq,
+    reduceCtorEq, not_true_eq_false, not_false_eq_true, and_self, and_false, false_and, iff_false]
+  exact λ h => h₂ (h ▸ h₁)
 
-def exp1_adults_some : CoveredBoxDatum :=
-  { experiment := 1, population := "adults (N=60)"
-    term := "some", visibleCounts := [0, 4]
-    coveredPct := 13, lbPct := 87
-    note := "some(NONE,ALL): adults accept total set → LB reading" }
+/-- Strengthening the reading can only move the referent to the covered box or resolve a tie:
+the design of Section 1.4. -/
+theorem choice_covered_of_le {R' : α → Prop} [DecidablePred R'] (h : ∀ x, R' x → R x)
+    (hc : choice R t = some .covered) : choice R' t = some .covered := by
+  rw [choice_eq_covered_iff] at hc ⊢
+  exact ⟨mt (h _) hc.1, mt (h _) hc.2⟩
 
-def exp2_twoKnowers_some : CoveredBoxDatum :=
-  { experiment := 2, population := "two-knowers (N=10, ages 2;6–3;5)"
-    term := "some", visibleCounts := [0, 4]
-    coveredPct := 7, lbPct := 83
-    note := "some(NONE,ALL): children accept total set, no implicature" }
+/-! ### Number trials -/
 
-def exp4_adults_some : CoveredBoxDatum :=
-  { experiment := 4, population := "adults (N=50, MTurk)"
-    term := "some", visibleCounts := [0, 4]
-    coveredPct := 31, lbPct := 60
-    note := "some(NONE,ALL): lower rate than Exp 1, still majority LB" }
+/-- The critical trials show a smaller and a larger set: an exact numeral has no visible
+referent, so the covered box is chosen. -/
+theorem choice_bareMeaning_covered {m a b : ℕ} (ha : a < m) (hb : m < b) :
+    choice (bareMeaning m) ⟨a, b⟩ = some .covered :=
+  (choice_eq_covered_iff _ _).2 ⟨by simp; omega, by simp; omega⟩
 
--- ============================================================================
--- Section 3: Two-Knower Scale Knowledge
--- ============================================================================
+/-- A lower-bounded numeral refers to the larger set. -/
+theorem choice_atLeastMeaning_visible {m a b : ℕ} (ha : a < m) (hb : m ≤ b) :
+    choice (atLeastMeaning m) ⟨a, b⟩ = some (.visible b) :=
+  (choice_eq_visible_right_iff _ _).2 ⟨by simp; omega, by simp; omega⟩
 
-/-- Knower level in the [wynn-1992] acquisition sequence.
+/-- The lower-bounded numeral strengthened against the full number scale chooses like the exact
+one, so the critical trials separate the two semantics only where the implicature is
+cancelled. -/
+theorem choice_exhNumeral_covered {m a b : ℕ} (ha : a < m) (hb : m < b) :
+    choice (exhNumeral m) ⟨a, b⟩ = some .covered :=
+  (choice_eq_covered_iff _ _).2
+    ⟨by simp only [exhNumeral_iff_bare, bareMeaning_def]; omega,
+      by simp only [exhNumeral_iff_bare, bareMeaning_def]; omega⟩
 
-An empirical classification: children master numeral meanings one at a time.
-A two-knower gives 1 for "one", 2 for "two", and random handfuls for higher
-numbers in the Give-N task. -/
-inductive KnowerLevel where
-  | oneKnower
-  | twoKnower
-  | threeKnower
-  | cpKnower
-  deriving Repr, DecidableEq
+/-- two(1,2): with an exact match visible against a smaller set, both readings pick it. -/
+theorem choice_one_two_bare : choice (bareMeaning 2) ⟨1, 2⟩ = some (.visible 2) := by decide
 
-/-- Whether a child at a given knower level knows the meaning of a numeral. -/
-def knowsNumeral : KnowerLevel → Nat → Bool
-  | .oneKnower,   1 => true
-  | .twoKnower,   1 => true
-  | .twoKnower,   2 => true
-  | .threeKnower, 1 => true
-  | .threeKnower, 2 => true
-  | .threeKnower, 3 => true
-  | .cpKnower,    _ => true
-  | _,            _ => false
+theorem choice_one_two_atLeast : choice (atLeastMeaning 2) ⟨1, 2⟩ = some (.visible 2) := by
+  decide
 
-/-- Two-knowers know "two" but not "three".
-This is the empirical fact that makes their exact "two" readings informative:
-they cannot have derived exactness via scalar implicature against "three". -/
-theorem two_knower_knows_two : knowsNumeral .twoKnower 2 = true := rfl
-theorem two_knower_lacks_three : knowsNumeral .twoKnower 3 = false := rfl
+/-- two(2,3∨5): against a larger set the lower-bounded reading leaves the description without
+a unique referent, and it is the implicature that restores the exact match. -/
+theorem choice_two_three_bare : choice (bareMeaning 2) ⟨2, 3⟩ = some (.visible 2) := by decide
+
+theorem choice_two_three_atLeast : choice (atLeastMeaning 2) ⟨2, 3⟩ = none := by decide
+
+theorem choice_two_three_exh : choice (exhNumeral 2) ⟨2, 3⟩ = some (.visible 2) := by decide
+
+/-- two(1,3∨5), the critical trials: adults and two-knowers chose the covered box. -/
+theorem choice_one_three_bare : choice (bareMeaning 2) ⟨1, 3⟩ = some .covered :=
+  choice_bareMeaning_covered (by omega) (by omega)
+
+theorem choice_one_three_atLeast : choice (atLeastMeaning 2) ⟨1, 3⟩ = some (.visible 3) :=
+  choice_atLeastMeaning_visible (by omega) (by omega)
+
+theorem choice_one_five_atLeast : choice (atLeastMeaning 2) ⟨1, 5⟩ = some (.visible 5) :=
+  choice_atLeastMeaning_visible (by omega) (by omega)
+
+/-! ### Scalar trials -/
+
+open SomeAllWorld
+
+/-- *Some* strengthened by its implicature: some but not all. -/
+def someStrengthened (w : SomeAllWorld) : Prop := atLeastOne w ∧ notUniversal w
+
+instance : DecidablePred someStrengthened := λ _ => inferInstanceAs (Decidable (_ ∧ _))
+
+/-- some(NONE,SOME): the subset under either reading. -/
+theorem some_none_some : choice atLeastOne ⟨.none, .someNotAll⟩ = some (.visible .someNotAll) := by
+  decide
+
+/-- some(SOME,ALL): the literal meaning fits both visible boxes and the implicature selects
+the subset, which adults chose and children split on. -/
+theorem some_some_all_literal : choice atLeastOne ⟨.someNotAll, .all⟩ = Option.none := by decide
+
+theorem some_some_all_strengthened :
+    choice someStrengthened ⟨.someNotAll, .all⟩ = some (.visible .someNotAll) := by decide
+
+/-- some(NONE,ALL), the control for implicature cancellation: the literal meaning picks the
+total set, which adults and children chose, and the strengthened meaning the covered box. -/
+theorem some_none_all_literal : choice atLeastOne ⟨.none, .all⟩ = some (.visible .all) := by
+  decide
+
+theorem some_none_all_strengthened : choice someStrengthened ⟨.none, .all⟩ = some .covered := by
+  decide
+
+/-- Experiment 3: *all* selects the total set when visible and the covered box otherwise, so
+the children's choices tracked the quantifier rather than the character. -/
+theorem all_none_all : choice universal ⟨.none, .all⟩ = some (.visible .all) := by decide
+
+theorem all_some_all : choice universal ⟨.someNotAll, .all⟩ = some (.visible .all) := by decide
+
+theorem all_some_none : choice universal ⟨.someNotAll, .none⟩ = some .covered := by decide
+
+/-! ### Two-knowers -/
+
+/-- A child at knower level `k` has the numerals up to `k` as a count list; the numeral `i` of
+that list exhaustified against its known stronger alternatives. -/
+def exhKnown (k : ℕ) (i : Fin (k + 1)) (n : ℕ) : Prop :=
+  Exhaustification.exhChain (λ j : Fin (k + 1) => atLeastMeaning j) i n
+
+instance (k : ℕ) (i : Fin (k + 1)) : DecidablePred (exhKnown k i) := λ _ =>
+  inferInstanceAs (Decidable (Exhaustification.exhChain _ _ _))
+
+/-- The top of the count list has no stronger known alternative, so exhaustification leaves its
+lower-bounded meaning as it is. -/
+theorem exhKnown_last (k n : ℕ) : exhKnown k (Fin.last k) n ↔ atLeastMeaning k n :=
+  ⟨λ h => h.1, λ h => ⟨h, λ j hj => absurd hj (not_lt.2 (Fin.le_last j))⟩⟩
+
+/-- A numeral below the top is exhaustified to its exact meaning. -/
+theorem exhKnown_of_lt {k : ℕ} {i : Fin (k + 1)} (hi : i < Fin.last k) (n : ℕ) :
+    exhKnown k i n ↔ bareMeaning i n := by
+  have hs : (i : ℕ) + 1 < k + 1 := by have := Fin.lt_def.1 hi; simp at this; omega
+  rw [exhKnown, Exhaustification.exhChain_iff_succ (s := ⟨i + 1, hs⟩)
+    (λ j k hjk n hk => by simp only [atLeastMeaning_def] at hk ⊢; exact le_trans hjk hk)
+    (Fin.lt_def.2 (Nat.lt_succ_self _))
+    (λ j hj => Fin.le_def.2 (Nat.succ_le_of_lt (Fin.lt_def.1 hj)))]
+  simp only [atLeastMeaning_def, bareMeaning_def]
+  omega
+
+/-- A two-knower's count list is *one*, *two*: under lower-bounded semantics, *two* stays
+lower-bounded and the child should hand over the visible box with three fish, contrary to the
+covered-box choices of Experiments 2 and 4. -/
+theorem twoKnower_lowerBounded : choice (exhKnown 2 (Fin.last 2)) ⟨1, 3⟩ = some (.visible 3) := by
+  decide
+
+/-- A three-knower could reach the covered box through the implicature. -/
+theorem threeKnower_exact : choice (exhKnown 3 2) ⟨1, 3⟩ = some .covered := by decide
+
+/-- Section 6.1: an implicit alternative *more than two* would exhaustify *two* to its exact
+meaning, the route the paper leaves logically open. -/
+theorem atLeast_not_moreThan_iff_bare (m n : ℕ) :
+    atLeastMeaning m n ∧ ¬ moreThanMeaning m n ↔ bareMeaning m n := by
+  simp only [atLeastMeaning_def, moreThanMeaning_def, bareMeaning_def]; omega
 
 end HuangSpelkeSnedeker2013

--- a/references.bib
+++ b/references.bib
@@ -7764,7 +7764,7 @@
   role      = {cited},
   sources   = {Syntax/Negation.lean}
 }% REF: Huang, Y.T., Spelke, E., & Snedeker, J. (2013). What exactly do numbers mean? *Language Learning and Development* 9(2), 
-@article{huang-snedeker-2013,
+@article{huang-spelke-snedeker-2013,
   author    = {Huang, Yi Ting and Spelke, Elizabeth and Snedeker, Jesse},
   year      = {2013},
   title     = {What Exactly Do Numbers Mean?},
@@ -7776,7 +7776,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/HuangSpelkeSnedeker2013.lean}
+  sources   = {Data/Examples/HuangSpelkeSnedeker2013.json;Studies/HuangSpelkeSnedeker2013.lean}
 }% REF: Iggesen, O. A. (2013). Number of Cases. In Dryer, M. S. & Haspelmath, M. (eds.), WALS Online (v2020). Ch. 49.
 @incollection{iggesen-2013,
   author    = {Iggesen, Oliver A.},
@@ -14820,7 +14820,7 @@
   subfield  = {semantics/lexical},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/HuangSpelkeSnedeker2013.lean}
+  sources   = {Studies/HuangSpelkeSnedeker2013.lean;Studies/ScontrasPearl2021.lean}
 }% REF: Zwarts, J. (2005). Prepositional aspect and the algebra of paths. *Linguistics and Philosophy* 28, 739–779.
 @article{zwarts-2005,
   author    = {Zwarts, Joost},


### PR DESCRIPTION
Recut the Huang, Spelke and Snedeker (2013) study from hand-typed percentage tables with `String` fields into the covered-box paradigm itself.

- `choice` computes the referent of the definite description under a reading of the term: the unique visible box satisfying it, the covered box when none does, and no box when both do; `choice_bareMeaning_covered` and `choice_atLeastMeaning_visible` are the critical-trial predictions of exact and lower-bounded numerals, and the scalar trials run on the shared `SomeAllWorld` with the literal and the strengthened *some* and with *all* (Experiment 3).
- Two-knowers via `exhKnown`, exhaustification against the count list a child knows on `Exhaustification.exhChain`: the top of the list stays lower-bounded (`exhKnown_last`) and a known stronger numeral makes it exact (`exhKnown_of_lt`), so lower-bounded semantics predicts the visible box for a two-knower and exact semantics the covered box; Section 6.1's implicit *more than two* alternative is recorded as the route that recovers exactness.
- Bib key renamed to `huang-spelke-snedeker-2013` (three authors); 18 example rows from the paper's numbered examples and the experiments' instructions.
