### PR TITLE
refactor(Studies/Katzir2007): the paper's examples out of the substrate

### DIFF
--- a/Linglib/Semantics/Alternatives/Structural.lean
+++ b/Linglib/Semantics/Alternatives/Structural.lean
@@ -4,56 +4,34 @@ import Linglib.Syntax.Tree.Cat
 import Linglib.Semantics.Alternatives.Source
 
 /-!
-# Structurally-Defined Alternatives
-[katzir-2007]
+# Structurally-defined alternatives
 
-Katzir, R. (2007). Structurally-defined alternatives.
-Linguistics and Philosophy, 30(6), 669–690.
+The alternatives of a parse tree in [katzir-2007]: the trees obtainable from it by deletion,
+contraction, and substitution of a constituent by a same-category item of the substitution
+source, the lexicon together with the tree's own subtrees. `StructOp` is one such operation,
+`atMostAsComplex` its reflexive-transitive closure, the complexity preorder of the paper's
+definition (19), `equalComplexity` its equivalence kernel, and `structuralAlternatives` the set
+of trees at most as complex as the given one, definition (20); `katzirSource` packages it as an
+`Alternatives.Source` for the competition principles of `Alternatives.Competition`.
 
-Scalar alternatives are not stipulated via Horn scales but generated
-structurally. The alternatives to a sentence φ are all parse trees
-obtainable from φ by three operations — deletion, contraction, and
-substitution — using items from the substitution source L(φ).
+Two general facts serve the paper's examples, which live in `Studies/Katzir2007.lean`. No
+operation introduces a category absent from the tree and the source
+(`category_preservation`), which is what excludes the symmetric alternatives; and substituting
+one lexical item for another of the same category throughout a tree, a Horn-scale alternative,
+is a chain of substitutions (`horn_alternatives_are_structural`), so scalar alternatives are a
+special case.
 
-## Key Definitions
+## Implementation notes
 
-- **Substitution source** (def 41): L(φ) = lexicon ∪ subtrees(φ)
-- **Structural complexity** (def 19): ψ ≲ φ iff φ can be transformed
-  to ψ by deletion, contraction, and substitution with items from L(φ).
-  Also: φ ∼ ψ (equal complexity) and ψ < φ (strictly less complex).
-- **Structural alternatives** (def 20): A_str(φ) := {ψ : ψ ≲ φ}
-- **Conversational principle** (def 21): do not assert φ if ∃ φ' ∈ A_str(φ)
-  with ⟦φ'⟧ ⊂ ⟦φ⟧ and φ' weakly assertable
+`atMostAsComplex` is reachability, not an operation count, so `equalComplexity`, mutual
+reachability, is coarser than the paper's equal complexity, and `strictlyLessComplex` is
+reachability-strict. The `inBind` constructor extends the operations into the body of a
+binder, which the paper's trees lack.
 
-## The Symmetry Problem
+## References
 
-The naïve conversational principle says: don't assert φ if there is a
-stronger alternative φ'. The symmetry problem (Kroch 1972; von Fintel
-& Heim class notes; see p. 673) is that for any stronger φ', there
-exists a symmetric alternative φ'' = φ ∧ ¬φ' which is also stronger,
-licensing the opposite inference.
-
-Katzir's solution: restrict alternatives to those obtainable by
-structural operations. For φ = "John ate some of the cake":
-- φ' = "John ate all of the cake" ∈ A_str(φ) — by substituting
-  the Det leaf "some" with "all" (both in the lexicon, same category)
-- φ'' = "John ate some but not all" ∉ A_str(φ) — requires ConjP/NegP
-  structure not available in L(φ)
-
-## Tree Type
-
-Uses the unified `Tree C W` from `Syntax`. All definitions are
-parameterized over the category type `C`, so they work with UD-grounded
-`Cat`, framework-specific categories, or any `C` with `BEq`/`DecidableEq`.
-
-## Connection to Linglib
-
-- **Horn scales subsumed**: Lexical substitution of same-category items
-  is a special case of structural alternatives (§8)
-- **Fills truthmaker gap**: `Studies/Santorio2018.lean`'s
-  `truthmakers` takes ALT_S computed via structural alternative generation
-- **Economy connection**: [katzir-singh-2015]'s complexity ordering
-  in `KatzirSingh2015.lean` is based on structural complexity (def 19)
+* [katzir-2007]
+* [fox-katzir-2011]
 -/
 
 namespace Alternatives.Structural
@@ -220,141 +198,9 @@ theorem equalComplexity_terminal_subst {C W : Type}
   ⟨Relation.ReflTransGen.single (StructOp.subst rfl h_old),
    Relation.ReflTransGen.single (StructOp.subst rfl h_new)⟩
 
--- The `≲`-direction lift through `inChild` navigation now exists in §8 as
--- `lift_at_position` (single position) and `mapChildren_reachable` (all
--- positions), built from `Relation.ReflTransGen` + list-set API exactly as
--- once sketched here. Still genuinely deferred: `equalComplexity_inChild`,
--- the *both-directions* wrapper that would let a consumer lift an
--- `equalComplexity` (not just a one-way `atMostAsComplex`) chain through a
--- tree path — it pairs two `lift_at_position` calls. Deferred until a
--- consumer needs it (`Studies/BaleKhanjian2014.lean` currently hand-rolls
--- the navigation it would replace).
-
 -- ═══════════════════════════════════════════════════════════════════════
--- §4  Worked Example: Some/All (§4.1)
+-- §4  Category preservation
 -- ═══════════════════════════════════════════════════════════════════════
-
-/-- Vocabulary for the worked examples. -/
-inductive ExWord where
-  | john | ate | some_ | all_ | cake
-  | apple | pear | or_ | and_
-  | tall | man
-  | but_ | not_
-  deriving DecidableEq, Repr
-
-section SomeAll
-
-open Cat ExWord
-
-/-- Minimal lexicon: terminal items available for substitution. -/
-def exLexicon : List (Tree Cat ExWord) :=
-  [.terminal .N .john, .terminal .V .ate,
-   .terminal .Det .some_, .terminal .Det .all_,
-   .terminal .N .cake, .terminal .N .apple, .terminal .N .pear,
-   .terminal .Conj .or_, .terminal .Conj .and_,
-   .terminal .Adj .tall, .terminal .N .man]
-
-/-- φ = "John ate some cake" (simplified parse tree). -/
-def someSentence : Tree Cat ExWord :=
-  .node .S [
-    .terminal .N .john,
-    .node .VP [.terminal .V .ate, .terminal .Det .some_, .terminal .N .cake]]
-
-/-- φ' = "John ate all cake" — the scalar alternative. -/
-def allSentence : Tree Cat ExWord :=
-  .node .S [
-    .terminal .N .john,
-    .node .VP [.terminal .V .ate, .terminal .Det .all_, .terminal .N .cake]]
-
-/-- Leaf substitution of "some" → "all" produces the expected tree. -/
-theorem leafSubst_some_all :
-    someSentence.leafSubst .some_ .all_ .Det = allSentence := by rfl
-
-/-- φ' is a structural alternative to φ: substitute Det leaf "some"
-with "all" from the lexicon (both Det, same category).
-
-This is the paper's ex. (25): φ = "John ate some of the cake",
-φ' = "John ate all of the cake". Since "all" and "some" are both
-in the lexicon and both Det, substitution yields φ' ∼ φ, so
-φ' ∈ A_str(φ). -/
-theorem all_is_alternative_to_some :
-    allSentence ∈ structuralAlternatives exLexicon someSentence := by
-  unfold structuralAlternatives atMostAsComplex
-  apply Relation.ReflTransGen.single
-  apply StructOp.inChild ⟨1, by simp⟩
-  apply StructOp.inChild ⟨1, by simp⟩
-  apply StructOp.subst
-  · rfl
-  · simp [substitutionSource, exLexicon]
-
-/-- Equal complexity: "some" ↔ "all" by mutual substitution (same
-number of operations in each direction). φ' ∼ φ in the sense of def 19:
-both φ ≲ φ' and φ' ≲ φ hold (each obtained from the other by one
-leaf substitution). -/
-theorem some_all_equal_complexity :
-    equalComplexity (substitutionSource exLexicon someSentence)
-      someSentence allSentence := by
-  constructor
-  · -- someSentence ≲ allSentence: substitute "all" back to "some"
-    apply Relation.ReflTransGen.single
-    apply StructOp.inChild ⟨1, by simp⟩
-    apply StructOp.inChild ⟨1, by simp⟩
-    apply StructOp.subst
-    · rfl
-    · simp [substitutionSource, exLexicon]
-  · -- allSentence ≲ someSentence
-    apply Relation.ReflTransGen.single
-    apply StructOp.inChild ⟨1, by simp⟩
-    apply StructOp.inChild ⟨1, by simp⟩
-    apply StructOp.subst
-    · rfl
-    · simp [substitutionSource, exLexicon]
-
-end SomeAll
-
--- ═══════════════════════════════════════════════════════════════════════
--- §5  Symmetry Problem Solved (§4.1)
--- ═══════════════════════════════════════════════════════════════════════
-
-section SymmetryProblem
-
-open Cat ExWord
-
-/-- φ'' = "John ate some but not all cake" — the symmetric alternative
-that the naïve principle cannot exclude.
-
-Under the naïve principle, φ'' is stronger than φ (⟦φ''⟧ ⊂ ⟦φ⟧) and
-should block assertion of φ. But it licenses the inference that John
-ate ALL of the cake — the opposite of the correct implicature.
-Katzir's structural approach excludes φ'' because it requires ConjP
-and NegP structure not derivable from L(φ). -/
-def someButNotAllSentence : Tree Cat ExWord :=
-  .node .S [
-    .terminal .N .john,
-    .node .VP [
-      .terminal .V .ate,
-      .node .ConjP [
-        .terminal .Det .some_,
-        .terminal .Conj .but_,
-        .node .NegP [.terminal .Neg .not_, .terminal .Det .all_]],
-      .terminal .N .cake]]
-
-/-- φ'' contains ConjP — a category absent from φ and L(φ). -/
-theorem symmetric_has_conjp :
-    ContainsCat .ConjP someButNotAllSentence := by decide
-
-/-- φ does not contain ConjP. -/
-theorem some_lacks_conjp :
-    ¬ ContainsCat .ConjP someSentence := by decide
-
-/-- No item in L(someSentence) contains ConjP: the lexicon consists
-of terminal leaves (which have no internal structure) and the subtrees
-of φ are {S[...], N(john), VP[...], V(ate), Det(some), N(cake)} —
-none contain ConjP. -/
-theorem source_lacks_conjp :
-    ∀ t ∈ substitutionSource exLexicon someSentence, ¬ ContainsCat .ConjP t := by decide
-
--- ── Single-step preservation (subtrees-based, via `Tree.ContainsCat`) ──
 
 private theorem structOp_preserves_no_cat {C W : Type} [DecidableEq C]
     (source : List (Tree C W)) (c : C)
@@ -367,13 +213,13 @@ private theorem structOp_preserves_no_cat {C W : Type} [DecidableEq C]
   | subst _ h_src => exact h_source _ h_src
   | @delete cat cs i =>
     rw [Tree.containsCat_node_iff] at h_φ ⊢; push Not at h_φ ⊢
-    exact ⟨h_φ.1, fun t ht => h_φ.2 t ((List.eraseIdx_sublist cs i).subset ht)⟩
+    exact ⟨h_φ.1, λ t ht => h_φ.2 t ((List.eraseIdx_sublist cs i).subset ht)⟩
   | @contract cat cs child h_mem _ =>
     rw [Tree.containsCat_node_iff] at h_φ; push Not at h_φ; exact h_φ.2 child h_mem
   | @inChild cat cs i ψ_child _ ih =>
     rw [Tree.containsCat_node_iff] at h_φ ⊢; push Not at h_φ ⊢
     have hih := ih (h_φ.2 (cs.get i) (List.get_mem cs i))
-    refine ⟨h_φ.1, fun t ht => ?_⟩
+    refine ⟨h_φ.1, λ t ht => ?_⟩
     rcases List.mem_or_eq_of_mem_set ht with ht' | rfl
     · exact h_φ.2 t ht'
     · exact hih
@@ -409,155 +255,8 @@ theorem category_preservation {C W : Type} [DecidableEq C]
   | tail _ h_last ih =>
     exact structOp_preserves_no_cat source c _ _ h_source ih h_last
 
-/-- The symmetric alternative φ'' is NOT a structural alternative to φ.
-
-Proof sketch: L(φ) contains no item with category ConjP
-(`source_lacks_conjp`), and φ itself lacks ConjP (`some_lacks_conjp`),
-so by `category_preservation` every tree in A_str(φ) lacks ConjP.
-But φ'' contains ConjP (`symmetric_has_conjp`) — contradiction.
-
-This exhibits the symmetry solution on the paper's canonical example:
-structure alone excludes the symmetric alternative, no lexical
-stipulation of which alternatives are "good." Scope note: [katzir-2007]
-excludes φ'' because it is *strictly more complex* / unreachable; the
-proof here uses a *sufficient* witness — φ'' needs a phrasal category
-(ConjP) absent from L(φ), and `category_preservation` shows the
-operations never introduce a novel category. The category-absence proxy
-coincides with Katzir's criterion whenever the symmetric alternative
-requires new structure (true here), but is narrower than the general
-strict-complexity exclusion, which `atMostAsComplex` (bare reachability,
-not graded operation-count) does not formalize. The general result is
-the target of `Studies/FoxKatzir2011.lean`. -/
-theorem symmetry_problem_solved :
-    someButNotAllSentence ∉ structuralAlternatives exLexicon
-      someSentence := by
-  intro h
-  exact category_preservation
-    (substitutionSource exLexicon someSentence) .ConjP
-    someSentence someButNotAllSentence
-    source_lacks_conjp some_lacks_conjp h symmetric_has_conjp
-
-end SymmetryProblem
-
 -- ═══════════════════════════════════════════════════════════════════════
--- §6  Disjunction: Or/And (§4.2)
--- ═══════════════════════════════════════════════════════════════════════
-
-section Disjunction
-
-open Cat ExWord
-
-/-- φ = "John ate the apple or the pear" (ex. 26a). -/
-def orSentence : Tree Cat ExWord :=
-  .node .S [
-    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]],
-    .terminal .Conj .or_,
-    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]]
-
-/-- φ' = "John ate the apple and the pear" (ex. 26b).
-Obtained by substituting Conj "or" with "and". -/
-def andSentence : Tree Cat ExWord :=
-  .node .S [
-    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]],
-    .terminal .Conj .and_,
-    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]]
-
-/-- Leaf substitution of "or" → "and" produces the conjunction. -/
-theorem leafSubst_or_and :
-    orSentence.leafSubst .or_ .and_ .Conj = andSentence := by rfl
-
-/-- "and" alternative obtainable by one substitution step. -/
-theorem and_is_alternative_to_or :
-    andSentence ∈ structuralAlternatives exLexicon orSentence := by
-  unfold structuralAlternatives atMostAsComplex
-  apply Relation.ReflTransGen.single
-  apply StructOp.inChild ⟨1, by simp⟩
-  apply StructOp.subst
-  · rfl
-  · simp [substitutionSource, exLexicon]
-
-/-- The left disjunct "John ate the apple" is an alternative to the
-disjunction — obtainable by deletion of the right disjunct and the
-conjunction.
-
-This derives the effect of Sauerland's L operator (which returns
-the left argument of a binary connective) from structural operations
-alone, without stipulating L as a primitive. The paper (p. 683) notes
-that L and R are "somewhat stipulative" and that structural
-alternatives derive the same predictions. -/
-def leftDisjunct : Tree Cat ExWord :=
-  .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]]
-
-theorem left_disjunct_is_alternative :
-    leftDisjunct ∈ structuralAlternatives exLexicon orSentence := by
-  unfold structuralAlternatives atMostAsComplex
-  -- Two steps: delete child 2 (right disjunct), then delete child 1 (Conj)
-  apply Relation.ReflTransGen.head
-  · exact StructOp.delete ⟨2, by simp⟩
-  apply Relation.ReflTransGen.head
-  · exact StructOp.delete ⟨1, by simp [List.eraseIdx]⟩
-  -- Now we have .node .S [leftDisjunct] — need contraction
-  apply Relation.ReflTransGen.single
-  apply StructOp.contract
-  · exact List.Mem.head _
-  · rfl
-
-/-- The right disjunct is also an alternative (Sauerland's R operator). -/
-def rightDisjunct : Tree Cat ExWord :=
-  .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]
-
-theorem right_disjunct_is_alternative :
-    rightDisjunct ∈ structuralAlternatives exLexicon orSentence := by
-  unfold structuralAlternatives atMostAsComplex
-  apply Relation.ReflTransGen.head
-  · exact StructOp.delete ⟨0, by simp⟩
-  apply Relation.ReflTransGen.head
-  · exact StructOp.delete ⟨0, by simp [List.eraseIdx]⟩
-  apply Relation.ReflTransGen.single
-  apply StructOp.contract
-  · exact List.Mem.head _
-  · rfl
-
-end Disjunction
-
--- ═══════════════════════════════════════════════════════════════════════
--- §7  Deletion Alternatives (§4.3)
--- ═══════════════════════════════════════════════════════════════════════
-
-section Deletion
-
-open Cat ExWord
-
-/-- "A tall man" parse tree (ex. 29a). -/
-def tallMan : Tree Cat ExWord :=
-  .node .NP [.terminal .Adj .tall, .terminal .N .man]
-
-/-- "A man" — obtained by deleting the Adj modifier (ex. 29b). -/
-def justMan : Tree Cat ExWord :=
-  .node .NP [.terminal .N .man]
-
-/-- Deletion produces a simpler alternative: "a man" ∈ A_str("a tall man").
-
-Under the structural approach, any modifier can be deleted to produce
-an alternative. Since the modified NP entails the bare NP ("a tall man
-came" → "a man came"), the bare NP is a stronger alternative in
-upward-entailing contexts, triggering no implicature. In DE contexts,
-entailment reverses and deletion alternatives generate inferences
-(§4.3, exx. 30–32). -/
-theorem deletion_produces_alternative :
-    justMan ∈ structuralAlternatives exLexicon tallMan := by
-  unfold structuralAlternatives atMostAsComplex
-  apply Relation.ReflTransGen.single
-  exact StructOp.delete ⟨0, by simp⟩
-
-/-- Deletion reduces tree size. -/
-theorem deletion_reduces_size :
-    justMan.size < tallMan.size := by decide
-
-end Deletion
-
--- ═══════════════════════════════════════════════════════════════════════
--- §8  Bridge: Horn Scales ⊆ Structural Alternatives
+-- §5  Horn scales are structural alternatives
 -- ═══════════════════════════════════════════════════════════════════════
 
 /-- Lift a ReflTransGen chain at position i through inChild. -/
@@ -584,8 +283,8 @@ private theorem lift_bind {C W : Type} {source : List (Tree C W)}
     {n : Nat} {cat : C} {body body' : Tree C W}
     (h : Relation.ReflTransGen (StructOp source) body body') :
     Relation.ReflTransGen (StructOp source) (.bind n cat body) (.bind n cat body') :=
-  Relation.ReflTransGen.lift (fun t => Tree.bind n cat t)
-    (fun _ _ h => StructOp.inBind h) body body' h
+  Relation.ReflTransGen.lift (λ t => Tree.bind n cat t)
+    (λ _ _ h => StructOp.inBind h) body body' h
 
 /-- leafSubstList is just List.map. -/
 private theorem leafSubstList_eq_map {C W : Type} [BEq C] [BEq W]
@@ -658,8 +357,8 @@ private theorem leafSubst_reachable {C W : Type} [BEq C] [LawfulBEq C] [BEq W]
     (φ : Tree C W) :
     Relation.ReflTransGen (StructOp source) φ (φ.leafSubst α β c) := by
   refine Tree.rec
-    (motive_1 := fun φ => Relation.ReflTransGen (StructOp source) φ (φ.leafSubst α β c))
-    (motive_2 := fun cs => ∀ (i : Nat) (hi : i < cs.length),
+    (motive_1 := λ φ => Relation.ReflTransGen (StructOp source) φ (φ.leafSubst α β c))
+    (motive_2 := λ cs => ∀ (i : Nat) (hi : i < cs.length),
       Relation.ReflTransGen (StructOp source) cs[i] ((cs[i]).leafSubst α β c))
     ?_ ?_ ?_ ?_ ?_ ?_ φ
   · -- terminal case

--- a/Linglib/Studies/FoxKatzir2011.lean
+++ b/Linglib/Studies/FoxKatzir2011.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Alternatives.Symmetric
-import Linglib.Semantics.Alternatives.Structural
+import Linglib.Studies.Katzir2007
 import Linglib.Semantics.Exhaustification.InnocentExclusion
 import Linglib.Logic.Modal.Defs
 import Linglib.Data.Examples.FoxKatzir2011
@@ -77,7 +77,8 @@ theorem mem_formalAlternatives_of_salient {ψ : Tree C V} (hψ : ψ ∈ salient)
 /-- The symmetric *some but not all* is not a structural alternative of *some*, but it becomes a
 formal alternative once it is salient. -/
 theorem someButNotAll_mem_formalAlternatives :
-    someButNotAllSentence ∈ formalAlternatives exLexicon someSentence [someButNotAllSentence] :=
+    Katzir2007.someButNotAllSentence ∈ formalAlternatives Katzir2007.lexicon
+      Katzir2007.someSentence [Katzir2007.someButNotAllSentence] :=
   mem_formalAlternatives_of_salient _ _ _ (List.mem_singleton_self _) rfl
 
 end Formal

--- a/Linglib/Studies/Katzir2007.lean
+++ b/Linglib/Studies/Katzir2007.lean
@@ -1,177 +1,248 @@
-import Linglib.Syntax.Tree.Cat
-import Linglib.Semantics.Composition.Tree
-import Linglib.Fragments.English.Toy
-import Linglib.Semantics.Quantification.Quantifier
 import Linglib.Semantics.Alternatives.Structural
+import Linglib.Semantics.Alternatives.Competition
 
 /-!
-# Katzir 2007: Structurally-Defined Alternatives (End-to-End)
-[katzir-2007]
+# Katzir (2007): Structurally-Defined Alternatives
 
-Katzir, R. (2007). Structurally-defined alternatives.
-Linguistics and Philosophy, 30(6), 669–690.
+This file formalizes the worked examples of [katzir-2007], which replaces the Horn scales of
+neo-Gricean pragmatics by alternatives defined on parse trees: the alternatives of a sentence
+are the trees obtainable from it by deletion, contraction, and substitution of constituents by
+same-category items of the substitution source, the lexicon together with the sentence's own
+subtrees (its definitions (19) to (21) and (41), the substrate `Alternatives.Structural`).
+The conversational principle (21) then forbids asserting a sentence when a structural
+alternative is strictly stronger and weakly assertable, the substrate's
+`Alternatives.violatesConversationalPrinciple` at the source `katzirSource`.
 
-## Unified Tree Demonstration
+The examples are the paper's Section 4 and 5 sentences over a small lexicon. For (25),
+*all of the cake* is an alternative of the same complexity as *some of the cake*
+(`all_mem_alternatives`), so a speaker obeying (21) implicates that it is not weakly assertable
+(`primary_implicature_some`), while the symmetric *some but not all* is no alternative, since no
+operation introduces the conjunction it needs (`someButNotAll_not_mem_alternatives`). For the
+disjunction (26), the conjunction and each disjunct are alternatives (`and_mem_alternatives`,
+`leftDisjunct_mem_alternatives`, `rightDisjunct_mem_alternatives`), which yields the primary
+inferences (28) without the L and R connectives of [sauerland-2004]
+(`primary_inferences_or`). Deleting a modifier gives a strictly simpler alternative, (29)
+(`justMan_mem_alternatives`), and the subtree clause of the substitution source (41) makes
+*a little bit more than warm* substitutable for *warm* in (40), so that the more complex
+sentence is an alternative of the simpler (`moreThanWarmYesterday_mem_alternatives`).
 
-This file demonstrates that a single `Tree Cat String` supports both:
-- **Structural operations** (PF-level): `leafSubst` generates scalar
-  alternatives by same-category word substitution
-- **Compositional interpretation** (LF-level): `evalTree` computes
-  truth conditions via FA, PM, and Predicate Abstraction
+## Implementation notes
 
-One tree, two interfaces — the Y-model made concrete.
+The truth conditions the paper takes for granted enter as meaning functions on three-way and
+four-way world types; trees the paper does not interpret denote the contradiction, which
+never witnesses the principle. Determiners inside the noun phrases are omitted from the trees,
+and the symmetric alternative places the conjunction of quantifiers at the determiner.
 
-## The Argument
+## References
 
-1. Build φ = "some student sleeps" as `Tree Cat String` with QR
-2. Generate φ' = "every student sleeps" via `leafSubst` and prove it is a
-   genuine structural alternative (`φ' ∈ structuralAlternatives`) through
-   the `Alternatives.Structural` substrate
-3. Interpret both: ⟦φ⟧ = true, ⟦φ'⟧ = false → asserting φ implicates ¬φ'
-4. Prove the symmetric "some but not all" (a ConjP) is NOT a structural
-   alternative via the substrate's `category_preservation`
-
-This is Katzir's solution to the symmetry problem: structural
-constraints on alternatives prevent the symmetric alternative
-from being generated, licensing the scalar implicature. The
-alternative-generation and exclusion claims are stated about the
-canonical `Alternatives.Structural` operators, not re-derived locally.
+* [katzir-2007]
+* [sauerland-2004], [kroch-1972]
 -/
+
+open Syntax Alternatives Alternatives.Structural
 
 namespace Katzir2007
 
-open Syntax
-open Semantics.Composition.Tree
-open Alternatives.Structural
-open Semantics.Montague (ToyEntity)
-open Semantics.Montague.ToyLexicon (sleeps_sem student_sem)
-open Quantification (some_sem every_sem)
+/-- The vocabulary of the paper's examples. -/
+inductive Word
+  | john | ate | some_ | all_ | cake | apple | pear | or_ | and_ | but_ | not_ | tall | man
+  | it | was | is | warm | yesterday | today | aLittleBitMoreThan
+  deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════════════════════
--- § Source Tree
--- ════════════════════════════════════════════════════════════════════
+/-- The lexicon: the terminal items available for substitution. -/
+def lexicon : List (Tree Cat Word) :=
+  [.terminal .N .john, .terminal .V .ate, .terminal .Det .some_, .terminal .Det .all_,
+    .terminal .N .cake, .terminal .N .apple, .terminal .N .pear, .terminal .Conj .or_,
+    .terminal .Conj .and_, .terminal .Adj .tall, .terminal .N .man, .terminal .Pron .it,
+    .terminal .Aux .was, .terminal .Aux .is, .terminal .Adj .warm, .terminal .Adv .yesterday,
+    .terminal .Adv .today]
 
-/-- "Some student sleeps" after QR, with UD-grounded categories:
-```
-[S [DP [Det some] [N student]] [₁ [S [t₁:NP] [VP [V sleeps]]]]]
-``` -/
-def φ : Tree Cat String :=
+/-! ### Some, all, some but not all (Section 4.1) -/
+
+/-- (25a) *John ate some of the cake*. -/
+def someSentence : Tree Cat Word :=
+  .node .S [.terminal .N .john,
+    .node .VP [.terminal .V .ate, .terminal .Det .some_, .terminal .N .cake]]
+
+/-- (25b) *John ate all of the cake*. -/
+def allSentence : Tree Cat Word :=
+  .node .S [.terminal .N .john,
+    .node .VP [.terminal .V .ate, .terminal .Det .all_, .terminal .N .cake]]
+
+/-- (25c) *John ate some but not all of the cake*, the symmetric alternative. -/
+def someButNotAllSentence : Tree Cat Word :=
+  .node .S [.terminal .N .john,
+    .node .VP [.terminal .V .ate,
+      .node .ConjP [.terminal .Det .some_, .terminal .Conj .but_,
+        .node .NegP [.terminal .Neg .not_, .terminal .Det .all_]],
+      .terminal .N .cake]]
+
+/-- (25b) is (25a) with *all* substituted for *some*. -/
+theorem leafSubst_some_all : someSentence.leafSubst .some_ .all_ .Det = allSentence := rfl
+
+/-- (25b) is a structural alternative of (25a): the determiners are same-category items of the
+lexicon. -/
+theorem all_mem_alternatives : allSentence ∈ structuralAlternatives lexicon someSentence :=
+  leafSubst_some_all ▸ horn_alternatives_are_structural lexicon someSentence .some_ .all_ .Det
+    (by simp [lexicon]) (by simp [lexicon])
+
+/-- The two are of equal complexity: each is one substitution from the other. -/
+theorem some_all_equalComplexity :
+    equalComplexity (substitutionSource lexicon someSentence) someSentence allSentence := by
+  constructor <;>
+  · apply Relation.ReflTransGen.single
+    apply StructOp.inChild ⟨1, by simp⟩
+    apply StructOp.inChild ⟨1, by simp⟩
+    apply StructOp.subst
+    · rfl
+    · simp [substitutionSource, lexicon]
+
+/-- No item of the substitution source of (25a) contains a conjunction phrase. -/
+theorem source_lacks_conjP :
+    ∀ t ∈ substitutionSource lexicon someSentence, ¬ t.ContainsCat Cat.ConjP := by decide
+
+/-- The symmetric alternative is no structural alternative: the operations never introduce
+the conjunction phrase it needs, so the symmetry problem does not arise. -/
+theorem someButNotAll_not_mem_alternatives :
+    someButNotAllSentence ∉ structuralAlternatives lexicon someSentence := λ h =>
+  category_preservation _ Cat.ConjP someSentence someButNotAllSentence source_lacks_conjP
+    (by decide) h (by decide)
+
+/-- How much of the cake John ate. -/
+inductive Cake
+  | none | part | whole
+  deriving DecidableEq, Repr
+
+/-- The truth conditions the paper assumes for (25): *some* holds of any eating, *all* of the
+whole, *some but not all* of a part; the other trees are not interpreted. -/
+def cakeMeaning (t : Tree Cat Word) (c : Cake) : Prop :=
+  (t = someSentence ∧ c ≠ .none) ∨ (t = allSentence ∧ c = .whole) ∨
+    (t = someButNotAllSentence ∧ c = .part)
+
+/-- If *all* is weakly assertable, asserting *some* violates the conversational principle. -/
+theorem violates_of_weaklyAssertable_all {wa : Tree Cat Word → Prop} (h : wa allSentence) :
+    violatesConversationalPrinciple (katzirSource lexicon) cakeMeaning someSentence wa :=
+  ⟨allSentence, all_mem_alternatives,
+    λ c hc => by simp_all [cakeMeaning, someSentence, allSentence, someButNotAllSentence],
+    ⟨.part, by simp [cakeMeaning], by simp [cakeMeaning, someSentence, allSentence,
+      someButNotAllSentence]⟩, h⟩
+
+/-- The primary implicature of (25a): a speaker who obeys the principle has *all* not weakly
+assertable; the symmetric alternative, being no alternative, licenses nothing. -/
+theorem primary_implicature_some {wa : Tree Cat Word → Prop}
+    (h : ¬ violatesConversationalPrinciple (katzirSource lexicon) cakeMeaning someSentence wa) :
+    ¬ wa allSentence :=
+  λ hwa => h (violates_of_weaklyAssertable_all hwa)
+
+/-! ### Disjunction (Section 4.2) -/
+
+/-- (26a) *John ate the apple or the pear*. -/
+def orSentence : Tree Cat Word :=
   .node .S [
-    .node .DP [.terminal .Det "some", .terminal .N "student"],
-    .bind 1 .S
-      (.node .S [.trace 1 .NP, .node .VP [.terminal .V "sleeps"]])]
+    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]],
+    .terminal .Conj .or_,
+    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]]
 
--- ════════════════════════════════════════════════════════════════════
--- § Structural Alternative Generation
--- ════════════════════════════════════════════════════════════════════
-
-/-- Scalar alternative: substitute "some" → "every" at Det position.
-This is Katzir's core operation (def 19, substitution): replace a
-terminal with a same-category item from the substitution source.
-Both "some" and "every" are Det terminals in the lexicon. -/
-def φ' : Tree Cat String := φ.leafSubst "some" "every" .Det
-
-/-- The lexicon for this fragment: the Det scale-mates plus the content
-words of φ, as `Tree Cat String` terminals. Feeds the substitution
-source `L(φ) = katzirLex ∪ subtrees(φ)`. -/
-def katzirLex : List (Tree Cat String) :=
-  [.terminal .Det "some", .terminal .Det "every",
-   .terminal .N "student", .terminal .V "sleeps"]
-
-/-- φ' is a genuine **structural** alternative to φ, derived through the
-[katzir-2007] substrate (`Alternatives.Structural`): leaf substitution of
-the Det scale-mate "every" (in `katzirLex`) is a chain of `StructOp.subst`
-steps, so `φ' ∈ A_str(φ)` by `horn_alternatives_are_structural`. This
-states the study's alternative-generation claim about the canonical
-`structuralAlternatives`, not a local re-encoding. -/
-theorem φ'_is_structural_alternative :
-    φ' ∈ structuralAlternatives katzirLex φ :=
-  horn_alternatives_are_structural katzirLex φ "some" "every" .Det
-    (by simp [katzirLex]) (by simp [katzirLex])
-
--- ════════════════════════════════════════════════════════════════════
--- § Compositional Interpretation (on the same trees)
--- ════════════════════════════════════════════════════════════════════
-
-/-- "Some student sleeps" is true: John is a student and sleeps.
-
-    With `interpTy .t = Prop`, we state the truth condition directly at
-    the Prop level rather than via `evalTree` (which requires a blanket
-    `Decidable` instance for all propositions). -/
-theorem some_student_sleeps :
-    some_sem student_sem sleeps_sem :=
-  ⟨ToyEntity.john, trivial, trivial⟩
-
-/-- The scalar alternative "every student sleeps" is false:
-Mary is a student but doesn't sleep. -/
-theorem every_student_sleeps :
-    ¬ every_sem student_sem sleeps_sem := by
-  intro h; exact h ToyEntity.mary trivial
-
-/-- The two readings differ: genuine scalar inference.
-Asserting "some" when "every" was available implicates ¬"every".
-The asymmetry is witnessed: "some" is satisfiable (John), while
-"every" is refuted (Mary is a student who doesn't sleep). -/
-theorem readings_differ :
-    some_sem student_sem sleeps_sem ∧
-    ¬ every_sem student_sem sleeps_sem :=
-  ⟨some_student_sleeps, every_student_sleeps⟩
-
--- ════════════════════════════════════════════════════════════════════
--- § Symmetry Breaking
--- ════════════════════════════════════════════════════════════════════
-
-/-! The symmetry problem: for any stronger alternative φ' = "every",
-there exists a symmetric alternative φ'' = "some but not all" which
-is also stronger. Naïve exhaustivity would predict no implicature.
-
-Katzir's solution: φ'' requires ConjP and NegP structure, which
-cannot be generated from L(φ) = lexicon ∪ subtrees(φ) because
-the source tree φ contains neither category. We discharge this through
-the substrate's `category_preservation`, not by raw `containsCat`
-assertions — the same mechanism that proves
-`Alternatives.Structural.symmetry_problem_solved`, here on the
-QR-structured `Tree Cat String`. -/
-
-/-- The symmetric alternative φ'' = "some but not all student sleeps",
-with the Det position filled by a ConjP. -/
-def φ'' : Tree Cat String :=
+/-- (26b) *John ate the apple and the pear*. -/
+def andSentence : Tree Cat Word :=
   .node .S [
-    .node .DP [
-      .node .ConjP [
-        .terminal .Det "some",
-        .terminal .Conj "but",
-        .node .NegP [.terminal .Neg "not", .terminal .Det "every"]],
-      .terminal .N "student"],
-    .bind 1 .S
-      (.node .S [.trace 1 .NP, .node .VP [.terminal .V "sleeps"]])]
+    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]],
+    .terminal .Conj .and_,
+    .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]]
 
-/-- φ contains no ConjP anywhere in its structure. -/
-theorem no_conjp : ¬ φ.ContainsCat Cat.ConjP := by decide
+/-- (27a) *John ate the apple*, the left disjunct. -/
+def leftDisjunct : Tree Cat Word :=
+  .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .apple]]
 
-/-- φ contains no NegP anywhere in its structure. -/
-theorem no_negp : ¬ φ.ContainsCat Cat.NegP := by decide
+/-- (27b) *John ate the pear*, the right disjunct. -/
+def rightDisjunct : Tree Cat Word :=
+  .node .S [.terminal .N .john, .node .VP [.terminal .V .ate, .terminal .N .pear]]
 
-/-- No item in `L(φ) = katzirLex ∪ subtrees(φ)` contains ConjP: the
-lexicon is flat Det/N/V terminals and φ's subtrees are ConjP-free. -/
-theorem source_lacks_conjp :
-    ∀ t ∈ substitutionSource katzirLex φ, ¬ t.ContainsCat Cat.ConjP := by decide
+theorem leafSubst_or_and : orSentence.leafSubst .or_ .and_ .Conj = andSentence := rfl
 
-/-- φ'' does contain ConjP. -/
-theorem φ''_has_conjp : φ''.ContainsCat Cat.ConjP := by decide
+/-- The conjunction is an alternative of the disjunction by substitution. -/
+theorem and_mem_alternatives : andSentence ∈ structuralAlternatives lexicon orSentence :=
+  leafSubst_or_and ▸ horn_alternatives_are_structural lexicon orSentence .or_ .and_ .Conj
+    (by simp [lexicon]) (by simp [lexicon])
 
-/-- **The symmetry problem, solved through the substrate.** φ'' is NOT a
-structural alternative to φ: by `category_preservation`, every tree in
-`A_str(φ)` lacks ConjP (no source item introduces it), but φ'' contains
-ConjP. So the scalar implicature ¬"every" is licensed — no symmetric
-alternative blocks it. This consumes
-`Alternatives.Structural.category_preservation` rather than re-deriving
-the argument from `containsCat`. -/
-theorem symmetric_not_structural :
-    φ'' ∉ structuralAlternatives katzirLex φ := by
-  intro h
-  exact category_preservation
-    (substitutionSource katzirLex φ) Cat.ConjP φ φ''
-    source_lacks_conjp no_conjp h φ''_has_conjp
+/-- The left disjunct is an alternative of the disjunction: delete the right disjunct and the
+connective, then contract; the effect of the L connective of [sauerland-2004]. -/
+theorem leftDisjunct_mem_alternatives :
+    leftDisjunct ∈ structuralAlternatives lexicon orSentence := by
+  refine Relation.ReflTransGen.head (StructOp.delete ⟨2, by simp⟩) ?_
+  refine Relation.ReflTransGen.head (StructOp.delete ⟨1, by simp [List.eraseIdx]⟩) ?_
+  exact Relation.ReflTransGen.single (StructOp.contract (List.Mem.head _) rfl)
+
+/-- The right disjunct likewise, the effect of R. -/
+theorem rightDisjunct_mem_alternatives :
+    rightDisjunct ∈ structuralAlternatives lexicon orSentence := by
+  refine Relation.ReflTransGen.head (StructOp.delete ⟨0, by simp⟩) ?_
+  refine Relation.ReflTransGen.head (StructOp.delete ⟨0, by simp [List.eraseIdx]⟩) ?_
+  exact Relation.ReflTransGen.single (StructOp.contract (List.Mem.head _) rfl)
+
+/-- Which of the two fruits John ate. -/
+abbrev Fruits := Bool × Bool
+
+/-- The truth conditions of (26) and (27): the disjunction, the conjunction, and each
+disjunct. -/
+def fruitMeaning (t : Tree Cat Word) (f : Fruits) : Prop :=
+  (t = orSentence ∧ (f.1 ∨ f.2)) ∨ (t = andSentence ∧ f.1 ∧ f.2) ∨
+    (t = leftDisjunct ∧ f.1) ∨ (t = rightDisjunct ∧ f.2)
+
+/-- The primary inferences (28): a speaker of the disjunction who obeys the principle has the
+conjunction and each disjunct not weakly assertable. -/
+theorem primary_inferences_or {wa : Tree Cat Word → Prop}
+    (h : ¬ violatesConversationalPrinciple (katzirSource lexicon) fruitMeaning orSentence wa) :
+    ¬ wa andSentence ∧ ¬ wa leftDisjunct ∧ ¬ wa rightDisjunct := by
+  refine ⟨λ hwa => h ⟨andSentence, and_mem_alternatives, ?_, ⟨(true, false), ?_, ?_⟩, hwa⟩,
+    λ hwa => h ⟨leftDisjunct, leftDisjunct_mem_alternatives, ?_, ⟨(false, true), ?_, ?_⟩, hwa⟩,
+    λ hwa => h ⟨rightDisjunct, rightDisjunct_mem_alternatives, ?_, ⟨(true, false), ?_, ?_⟩,
+      hwa⟩⟩ <;>
+  simp_all [fruitMeaning, orSentence, andSentence, leftDisjunct, rightDisjunct]
+
+/-! ### Strictly simpler alternatives (Section 4.3) -/
+
+/-- (29a) *a tall man*, without its determiner. -/
+def tallMan : Tree Cat Word := .node .NP [.terminal .Adj .tall, .terminal .N .man]
+
+/-- (29b) *a man*. -/
+def justMan : Tree Cat Word := .node .NP [.terminal .N .man]
+
+/-- Deleting the modifier gives an alternative, strictly simpler; in an upward-entailing
+context it is entailed and yields no inference, under a downward-entailing operator it does,
+(30) to (32). -/
+theorem justMan_mem_alternatives : justMan ∈ structuralAlternatives lexicon tallMan :=
+  Relation.ReflTransGen.single (StructOp.delete ⟨0, by simp⟩)
+
+/-! ### The subtrees of the sentence as substitution source (Section 5) -/
+
+/-- *a little bit more than warm*, an adjective phrase. -/
+def moreThanWarm : Tree Cat Word :=
+  .node .AdjP [.terminal .Adv .aLittleBitMoreThan, .terminal .Adj .warm]
+
+/-- *it is a little bit more than warm today*. -/
+def moreThanWarmToday : Tree Cat Word :=
+  .node .S [.terminal .Pron .it, .terminal .Aux .is, moreThanWarm, .terminal .Adv .today]
+
+/-- (40a) *It was warm yesterday, and it is a little bit more than warm today*. -/
+def warmYesterday : Tree Cat Word :=
+  .node .S [
+    .node .S [.terminal .Pron .it, .terminal .Aux .was, .node .AdjP [.terminal .Adj .warm],
+      .terminal .Adv .yesterday],
+    .terminal .Conj .and_, moreThanWarmToday]
+
+/-- (40b) *It was a little bit more than warm yesterday, and it is a little bit more than warm
+today*. -/
+def moreThanWarmYesterday : Tree Cat Word :=
+  .node .S [
+    .node .S [.terminal .Pron .it, .terminal .Aux .was, moreThanWarm, .terminal .Adv .yesterday],
+    .terminal .Conj .and_, moreThanWarmToday]
+
+/-- Matsumoto's (40b) is an alternative of (40a) although more complex: the adjective phrase it
+needs is a subtree of (40a), hence in the substitution source (41). -/
+theorem moreThanWarmYesterday_mem_alternatives :
+    moreThanWarmYesterday ∈ structuralAlternatives lexicon warmYesterday :=
+  Relation.ReflTransGen.single (StructOp.inChild ⟨0, by simp⟩
+    (StructOp.inChild ⟨2, by simp⟩ (StructOp.subst rfl (by decide))))
 
 end Katzir2007

--- a/references.bib
+++ b/references.bib
@@ -2690,7 +2690,7 @@
   subfield    = {pragmatics/neogricean},
   validated   = {true},
   role        = {cited},
-  sources   = {Semantics/Alternatives/Symmetric.lean;Studies/FoxKatzir2011.lean}
+  sources   = {Semantics/Alternatives/Symmetric.lean;Studies/FoxKatzir2011.lean;Studies/Katzir2007.lean}
 }
 @phdthesis{kroch-1974,
   author    = {Kroch, Anthony},
@@ -2899,7 +2899,7 @@
   subfield  = {pragmatics/neogricean},
   validated = {true},
   role      = {cited},
-  sources   = {Data/Examples/FoxKatzir2011.json;Pragmatics/NeoGricean/Basic.lean;Studies/Ahn2015.lean;Studies/Fox2007.lean;Studies/FoxKatzir2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Kennedy2015.lean;Studies/Ronai2024.lean;Studies/Sauerland2004.lean;Studies/VanTielEtAl2016.lean}
+  sources   = {Data/Examples/FoxKatzir2011.json;Pragmatics/NeoGricean/Basic.lean;Studies/Ahn2015.lean;Studies/Fox2007.lean;Studies/FoxKatzir2011.lean;Studies/GeurtsPouscoulous2009.lean;Studies/Kennedy2015.lean;Studies/Ronai2024.lean;Studies/Sauerland2004.lean;Studies/VanTielEtAl2016.lean;Studies/Katzir2007.lean}
 }
 @inproceedings{fox-2018,
   author    = {Fox, Danny},


### PR DESCRIPTION
Deep recut of Katzir2007 against the paper (Zotero 6EFRCMRJ): the worked examples of Sections 4 and 5 move out of `Semantics/Alternatives/Structural.lean` into the study, leaving the substrate with the general machinery (operations, complexity preorder, `category_preservation`, the Horn-scale lemma).
- The study states the conversational principle (21) on `Alternatives.violatesConversationalPrinciple` at `katzirSource`: the primary implicature for (25), the primary inferences (28) for disjunction without Sauerland's L and R, deletion alternatives (29), and Matsumoto's (40) through the subtree clause (41).
- The old QR-tree duplicate with the Toy lexicon is gone; FoxKatzir2011 now imports the study for the shared sentences.