### PR TITLE
refactor(Morphology/Construction): schema roles over variables

### DIFF
--- a/Linglib/Morphology/Construction/Schema.lean
+++ b/Linglib/Morphology/Construction/Schema.lean
@@ -9,48 +9,66 @@ import Mathlib.Order.Lattice
 /-!
 # Constructional schemas
 
-A schema in the sense of [jackendoff-audring-2020] is a lexical entry with
-variables: a slot-indexed description `body : V → α` over a bundle of typed
-slots, together with the subset `opens` of slots marked open. A slot pinned
-above `⊥` is a constant; a slot at `⊥` is a variable, open (freely fillable)
-or closed (a learned list of fillers). Instantiation is domination in the
-pointwise order (`Schema.Instantiates`), which is unification against the
-description (`instantiates_iff_unify`, wiring to `Core.Order.PartialUnify`).
+This file defines the schemas of Relational Morphology ([jackendoff-audring-2020]): lexical
+entries with variables. A schema is a slot-indexed description `body : V → α` over a partial
+order with a bottom, together with the set `opens` of slots marked as open variables. A slot
+pinned above `⊥` is a constant; a slot at `⊥` is a variable, open (freely fillable) or closed
+(filled only from a learned list). An item instantiates a schema when the description
+dominates it pointwise (`Schema.Instantiates`), so the instances of a schema are the principal
+upper set `Set.Ici s.body` of the Pi order, and instantiation is unification against the
+description (`Schema.instantiates_iff_unify`).
 
-The relational and generative roles a schema can play ([jackendoff-audring-2020]
-§2.11) are lexicon-relative: over a stored lexicon `Λ`, `Relates` records a
-schema motivating a stored item, `Generates` licenses a possibly-novel item
-whose closed slots stay within the fillers `attested` in `Λ`. A closed
-variable's filler list is not a second stipulated field — it is derived from
-`Λ`, since nonproductive schemas have all their instances listed in the lexicon.
-`generates_relates_insert` is the memory-collapse step of that section's
-argument: a generated word, once committed to memory, falls under the schema's
-relational role.
+The two roles of a schema are relative to a stored lexicon `Λ`. In its relational role
+(`Schema.Relates`) a schema motivates an item already stored; in its generative role
+(`Schema.Generates`) it licenses a possibly novel item whose closed variables take only fillers
+attested in `Λ` (`Schema.attested`). A closed variable's filler list is derived from the lexicon
+rather than stipulated, since a nonproductive schema has all its instances listed. The
+Relational Hypothesis of [jackendoff-audring-2020] is then a chain of inclusions: a related
+item is generated (`Schema.Relates.generates`), a generated item is related once committed to
+memory (`Schema.Generates.relates_insert`), and a schema is productive, every variable open,
+exactly when it generates its own description from an empty lexicon
+(`Schema.isProductive_iff_generates_empty`).
 
-Structural intersection is the pointwise meet (`instantiates_inf`); the least
-general generalization of a filler set is the dual of unification
-([plotkin-1970]'s lgg, [albright-hayes-2003]'s minimal generalization),
-recorded here as the order-theoretic content without minting new algebra.
+Two order-theoretic facts carry the constructional operations of [booij-2010-compass].
+Unifying two descriptions gives the schema whose instances are exactly the common instances
+(`Schema.instantiates_iff_of_unify_eq_some`). A schema is instantiated by the pointwise meet of
+two items exactly when it is instantiated by both (`Schema.instantiates_inf_iff`), which makes
+the meet their least general generalization ([plotkin-1970]; the minimal generalization of
+[albright-hayes-2003]).
 
 ## Main declarations
 
-- `Schema` — a slot-indexed description with an open-variable set
-- `Schema.Instantiates`, `instantiates_iff_unify` — domination as unification
-- `Schema.attested`, `Schema.Relates`, `Schema.Generates` — lexicon-relative roles
-- `Schema.instantiates_relates_insert`, `Schema.generates_relates_insert` — the
-  memory-collapse step
-- `Schema.IsProductive`, `Schema.IsProductive.generates_of_instantiates` — a
-  fully open schema generates any instance
-- `Schema.instantiates_inf` — structural intersection is instantiated by each conjunct
+* `Schema`: a slot-indexed description with a set of open variables.
+* `Schema.Instantiates`, `Schema.instantiates_iff_unify`: instantiation as pointwise
+  domination, equivalently as unification.
+* `Schema.Relates`, `Schema.Generates`, `Schema.attested`: the lexicon-relative roles.
+* `Schema.IsProductive`, `Schema.isProductive_iff_generates_empty`: productivity as generation
+  from an empty lexicon.
+
+## Implementation notes
+
+Productivity is a property of variables rather than of a schema as a whole, and
+`Schema.IsProductive` is the derived case in which every variable is open. Constants are exempt
+from the attestation condition of `Schema.Generates`, so a schema whose variables are all open
+generates over any lexicon, the empty one included. Marking a constant slot as open is
+harmless: the slot is not a variable, so it is never subject to attestation.
+
+## References
+
+* [jackendoff-audring-2020]
+* [booij-2010-compass]
+* [plotkin-1970]
+* [albright-hayes-2003]
 -/
 
 namespace Morphology.Construction
 
 variable {V α : Type*}
 
-/-- A schema: a slot-indexed description `body`, with `opens` the slots marked as
-open variables. A slot at `⊥` is a variable; a slot above `⊥` is a constant. -/
-structure Schema (V : Type*) (α : Type*) [PartialOrder α] where
+/-- A schema: a slot-indexed description `body` together with the slots `opens` marked as open
+variables. A slot at `⊥` is a variable; a slot above `⊥` is a constant. -/
+@[ext]
+structure Schema (V α : Type*) where
   /-- The slot-indexed description. -/
   body : V → α
   /-- The slots marked as open variables. -/
@@ -59,87 +77,127 @@ structure Schema (V : Type*) (α : Type*) [PartialOrder α] where
 namespace Schema
 
 section PartialOrder
-variable [PartialOrder α]
+variable [PartialOrder α] {s t : Schema V α} {w w₁ w₂ : V → α} {Λ Λ' : Set (V → α)}
+  {v : V}
 
-/-- A schema is instantiated by a filling `w` when its description dominates `w`
-slot-by-slot: every pinned slot's constraint is met and variables are free. -/
+/-- An item `w` instantiates a schema when the description dominates `w` slot by slot: each
+constant is matched and each variable is filled freely. -/
 def Instantiates (s : Schema V α) (w : V → α) : Prop := s.body ≤ w
 
-/-- Instantiation is unification against the description: `w` instantiates `s`
-exactly when unifying the description with `w` succeeds and returns `w`. -/
-theorem instantiates_iff_unify [Fintype V] [PartialUnify α] {s : Schema V α}
-    {w : V → α} : s.Instantiates w ↔ PartialUnify.unify s.body w = some w := by
+/-- A schema instantiates its own description. -/
+theorem instantiates_body (s : Schema V α) : s.Instantiates s.body := le_rfl
+
+/-- The instances of a schema are closed upward. -/
+theorem Instantiates.trans_le (h : s.Instantiates w₁) (hw : w₁ ≤ w₂) :
+    s.Instantiates w₂ :=
+  h.trans hw
+
+/-- A schema dominated by another is instantiated by everything the other is: the subschema
+relation is pointwise domination of descriptions. -/
+theorem body_le_body_iff :
+    t.body ≤ s.body ↔ ∀ ⦃w⦄, s.Instantiates w → t.Instantiates w :=
+  ⟨λ h _ hw => h.trans hw, λ h => h s.instantiates_body⟩
+
+/-- Instantiation is unification against the description: `w` instantiates `s` exactly when
+unifying the description with `w` succeeds and returns `w`. -/
+theorem instantiates_iff_unify [Fintype V] [PartialUnify α] :
+    s.Instantiates w ↔ PartialUnify.unify s.body w = some w := by
   rw [PartialUnify.unify_eq_some_iff_isLUB]
-  refine ⟨fun h => ⟨?_, ?_⟩, fun h => h.1 (Set.mem_insert _ _)⟩
+  refine ⟨λ h => ⟨?_, ?_⟩, λ h => h.1 (Set.mem_insert _ _)⟩
   · rintro x (rfl | rfl)
     exacts [h, le_rfl]
-  · exact fun _ hu => hu (Set.mem_insert_of_mem _ rfl)
+  · exact λ _ hu => hu (Set.mem_insert_of_mem _ rfl)
 
-/-- The fillers attested at a slot: the values a stored instance of `s` in `Λ`
-takes there. A closed variable's filler list, derived from storage rather than
-stipulated separately. -/
-def attested (s : Schema V α) (Λ : Set (V → α)) (v : V) : Set α :=
-  {a | ∃ w ∈ Λ, s.Instantiates w ∧ w v = a}
+/-- Unifying two descriptions gives the schema whose instances are exactly the common
+instances of the two. -/
+theorem instantiates_iff_of_unify_eq_some [Fintype V] [PartialUnify α] {u : Schema V α}
+    (h : PartialUnify.unify s.body t.body = some u.body) :
+    u.Instantiates w ↔ s.Instantiates w ∧ t.Instantiates w := by
+  rw [Instantiates, isLUB_le_iff (PartialUnify.isLUB_of_unify_eq_some h),
+    PartialUnify.mem_upperBounds_pair]
+  rfl
 
-/-- The relational role ([jackendoff-audring-2020] §2.11): `s` motivates the
-stored item `w`. -/
+/-! ### The relational role -/
+
+/-- The relational role: `s` motivates the item `w` stored in `Λ`. -/
 def Relates (s : Schema V α) (Λ : Set (V → α)) (w : V → α) : Prop :=
   w ∈ Λ ∧ s.Instantiates w
 
-/-- The generative role ([jackendoff-audring-2020] §2.11): `s` licenses a
-possibly-novel item `w` whose closed slots take only attested fillers. -/
-def Generates (s : Schema V α) (Λ : Set (V → α)) (w : V → α) : Prop :=
-  s.Instantiates w ∧ ∀ v ∉ s.opens, w v ∈ s.attested Λ v
+theorem Relates.instantiates (h : s.Relates Λ w) : s.Instantiates w := h.2
 
-/-- Any instance, once added to the lexicon, is related by the schema. -/
-theorem instantiates_relates_insert {s : Schema V α} {Λ : Set (V → α)} {w : V → α}
-    (h : s.Instantiates w) : s.Relates (insert w Λ) w :=
+theorem Relates.mono (h : Λ ⊆ Λ') (hw : s.Relates Λ w) : s.Relates Λ' w := ⟨h hw.1, hw.2⟩
+
+/-- Any instance, once stored, is related by the schema. -/
+theorem Instantiates.relates_insert (h : s.Instantiates w) : s.Relates (insert w Λ) w :=
   ⟨Set.mem_insert _ _, h⟩
 
-/-- The memory-collapse step of [jackendoff-audring-2020]'s §2.11 argument: a
-generated word, once committed to memory, falls under the schema's relational
-role. -/
-theorem generates_relates_insert {s : Schema V α} {Λ : Set (V → α)} {w : V → α}
-    (h : s.Generates Λ w) : s.Relates (insert w Λ) w :=
-  instantiates_relates_insert h.1
+/-- The fillers attested at slot `v`: the values the stored instances of `s` take there. A
+closed variable's filler list, derived from the lexicon rather than stipulated. -/
+def attested (s : Schema V α) (Λ : Set (V → α)) (v : V) : Set α :=
+  {a | ∃ w, s.Relates Λ w ∧ w v = a}
 
-/-- A schema is productive when every slot is open — a fully general pattern
-with no learned filler lists. -/
-def IsProductive (s : Schema V α) : Prop := ∀ v, v ∈ s.opens
+@[simp]
+theorem mem_attested {a : α} : a ∈ s.attested Λ v ↔ ∃ w, s.Relates Λ w ∧ w v = a :=
+  Iff.rfl
 
-/-- A productive schema generates every instance ([jackendoff-audring-2020]: a
-productive schema has "gone viral"), since it has no closed slots to confine. -/
-theorem IsProductive.generates_of_instantiates {s : Schema V α} {Λ : Set (V → α)}
-    {w : V → α} (hp : s.IsProductive) (h : s.Instantiates w) : s.Generates Λ w :=
-  ⟨h, fun v hv => absurd (hp v) hv⟩
+theorem Relates.apply_mem_attested (h : s.Relates Λ w) (v : V) : w v ∈ s.attested Λ v :=
+  ⟨w, h, rfl⟩
+
+theorem attested_mono (h : Λ ⊆ Λ') (v : V) : s.attested Λ v ⊆ s.attested Λ' v := by
+  rintro a ⟨w, hw, rfl⟩
+  exact ⟨w, hw.mono h, rfl⟩
 
 end PartialOrder
 
-/-- Structural intersection is instantiated by each conjunct: the pointwise meet
-of two fillers is a schema they both instantiate — the lower-bound face of the
-least general generalization. -/
-theorem instantiates_inf [SemilatticeInf α] {w₁ w₂ : V → α} {opens : Set V} :
-    Instantiates ⟨w₁ ⊓ w₂, opens⟩ w₁ :=
-  inf_le_left
+/-- A schema is instantiated by the pointwise meet of two items exactly when it is instantiated
+by both: the meet is the least general generalization of the two. -/
+theorem instantiates_inf_iff [SemilatticeInf α] {s : Schema V α} {w₁ w₂ : V → α} :
+    s.Instantiates (w₁ ⊓ w₂) ↔ s.Instantiates w₁ ∧ s.Instantiates w₂ :=
+  le_inf_iff
 
-/-! ### Productivity is a genuine restriction
+/-! ### The generative role -/
 
-A schema with a closed slot relates its stored instance but cannot generate a
-fresh filler for that slot. Generation over the function type `V → α` is an
-existential with no `Decidable` instance, so nonproductivity is witnessed
-structurally. -/
+section OrderBot
+variable [PartialOrder α] [OrderBot α] {s : Schema V α} {w : V → α} {Λ Λ' : Set (V → α)}
 
-/-- A stored instance is related by the schema. -/
-example : (⟨fun _ => (0 : ℕ), ∅⟩ : Schema Unit ℕ).Relates {fun _ => 0} (fun _ => 0) :=
-  ⟨rfl, le_rfl⟩
+/-- The generative role: `s` licenses a possibly novel item `w` whose closed variables, the
+slots at `⊥` not marked open, take only fillers attested in `Λ`. -/
+def Generates (s : Schema V α) (Λ : Set (V → α)) (w : V → α) : Prop :=
+  s.Instantiates w ∧ ∀ v, s.body v = ⊥ → v ∉ s.opens → w v ∈ s.attested Λ v
 
-/-- The same closed-slot schema does not generate an unattested filler. -/
-example : ¬ (⟨fun _ => (0 : ℕ), ∅⟩ : Schema Unit ℕ).Generates {fun _ => 0} (fun _ => 1) := by
-  rintro ⟨-, hgen⟩
-  have h := hgen () (by simp)
-  simp only [attested, Set.mem_ofPred_eq, Set.mem_singleton_iff] at h
-  obtain ⟨w, rfl, -, hwv⟩ := h
-  simp at hwv
+theorem Generates.instantiates (h : s.Generates Λ w) : s.Instantiates w := h.1
+
+/-- A stored instance is generated: it attests its own fillers. -/
+theorem Relates.generates (h : s.Relates Λ w) : s.Generates Λ w :=
+  ⟨h.2, λ v _ _ => h.apply_mem_attested v⟩
+
+/-- The memory-collapse step of the Relational Hypothesis: a generated item, once committed to
+memory, falls under the schema's relational role. -/
+theorem Generates.relates_insert (h : s.Generates Λ w) : s.Relates (insert w Λ) w :=
+  h.instantiates.relates_insert
+
+/-- Generation grows with the lexicon. -/
+theorem Generates.mono (h : Λ ⊆ Λ') (hw : s.Generates Λ w) : s.Generates Λ' w :=
+  ⟨hw.1, λ v hv hvo => attested_mono h v (hw.2 v hv hvo)⟩
+
+/-- A schema is productive when every variable is open. Productivity is a property of
+variables rather than of the schema as a whole; this is the fully open case. -/
+def IsProductive (s : Schema V α) : Prop := ∀ v, s.body v = ⊥ → v ∈ s.opens
+
+/-- A productive schema generates every instance, having no closed variable to confine. -/
+theorem IsProductive.generates_iff (hs : s.IsProductive) :
+    s.Generates Λ w ↔ s.Instantiates w :=
+  ⟨Generates.instantiates, λ h => ⟨h, λ v hv hvo => absurd (hs v hv) hvo⟩⟩
+
+/-- A schema is productive exactly when it generates its own description from an empty
+lexicon: with nothing stored, no closed variable can be filled. -/
+theorem isProductive_iff_generates_empty : s.IsProductive ↔ s.Generates ∅ s.body := by
+  refine ⟨λ hs => ⟨le_rfl, λ v hv hvo => absurd (hs v hv) hvo⟩, λ h v hv => ?_⟩
+  by_contra hvo
+  obtain ⟨w, ⟨hw, -⟩, -⟩ := h.2 v hv hvo
+  exact hw
+
+end OrderBot
 
 end Schema
 

--- a/Linglib/Morphology/Construction/Sister.lean
+++ b/Linglib/Morphology/Construction/Sister.lean
@@ -87,7 +87,7 @@ variable {V₁ V₂ α : Type*}
 
 /-- Two schemas with coindexed variables: `link v₁ v₂` marks a variable of `fst`
 as the same as a variable of `snd`. -/
-structure Sister (V₁ V₂ α : Type*) [PartialOrder α] where
+structure Sister (V₁ V₂ α : Type*) where
   /-- The first schema. -/
   fst : Schema V₁ α
   /-- The second schema. -/

--- a/Linglib/Studies/Booij2010.lean
+++ b/Linglib/Studies/Booij2010.lean
@@ -29,8 +29,9 @@ unification (`on-` prefixation composed with `V-baar`).
   Head Rule) yet override locally (NN allows a recursive modifier, AN does not)
 * `werkbaar_overrides` — the CxM default-inheritance demand site: `werkbaar`
   overrides the `-baar` schema's transitivity default
-* `onbaar_unifies` — two word-formation schemas unify into `on-V-baar`, no listed
-  intermediate required
+* `onbaar_unifies`, `onbaarSchema_instantiates_iff` — two word-formation schemas
+  unify into `on-V-baar`, whose instances are exactly their common instances, no
+  listed intermediate required
 -/
 
 namespace Booij2010
@@ -97,16 +98,16 @@ theorem carlessness_unifies :
 /-- The stored `-ness` nouns, feeding the schema's two roles. -/
 def nessLexicon : Set (NessSlot → Flat Atom) := {baldness, awareness}
 
-/-- The schema licenses the novel coin `carlessness`: the open base slot takes
-the unlisted adjective, and the pinned affix slot takes only its attested
-filler `-ness`. The affix slot is not open, so this is `Generates`, not full
-productivity. -/
-theorem carlessness_generates : nessSchema.Generates nessLexicon carlessness := by
-  refine ⟨ness_instantiates rfl, ?_⟩
-  intro v hv
-  cases v with
-  | base => exact absurd rfl hv
-  | affix => exact ⟨baldness, Set.mem_insert _ _, ness_instantiates rfl, rfl⟩
+/-- The `-ness` schema is productive: its one variable, the base slot, is open. -/
+theorem nessSchema_isProductive : nessSchema.IsProductive := by
+  rintro (_ | _) h
+  exacts [Set.mem_singleton _, absurd h (by decide)]
+
+/-- The schema licenses the novel coin `carlessness` over the stored nouns: the
+open base slot takes the unlisted adjective, and the affix slot is a constant.
+Being productive, the schema generates every instance whatever is stored. -/
+theorem carlessness_generates : nessSchema.Generates nessLexicon carlessness :=
+  nessSchema_isProductive.generates_iff.2 carlessness_instantiates
 
 /-- The relational role over the same schema: `awareness` is listed and
 instantiates it — the paper's two functions of a schema, expressing the
@@ -216,27 +217,40 @@ inductive BaarAtom | on | baar
 inductive OnbaarSlot | pre | base | suf
   deriving DecidableEq, Fintype
 
-/-- The `on-A` schema body: prefix pinned to `on-`, base open. -/
-def onBody : OnbaarSlot → Flat BaarAtom
-  | .pre => ↑BaarAtom.on
-  | .base => ⊥
-  | .suf => ⊥
+/-- The `on-A` schema: prefix pinned to `on-`, base open. -/
+def onSchema : Schema OnbaarSlot (Flat BaarAtom) where
+  body
+    | .pre => ↑BaarAtom.on
+    | .base => ⊥
+    | .suf => ⊥
+  opens := {.base}
 
-/-- The `V-baar` schema body: suffix pinned to `-baar`, base open. -/
-def baarBody : OnbaarSlot → Flat BaarAtom
-  | .pre => ⊥
-  | .base => ⊥
-  | .suf => ↑BaarAtom.baar
+/-- The `V-baar` schema: suffix pinned to `-baar`, base open. -/
+def baarSchema : Schema OnbaarSlot (Flat BaarAtom) where
+  body
+    | .pre => ⊥
+    | .base => ⊥
+    | .suf => ↑BaarAtom.baar
+  opens := {.base}
 
-/-- The unified `on-V-baar` schema body: both affixes pinned, base open. -/
-def onbaarBody : OnbaarSlot → Flat BaarAtom
-  | .pre => ↑BaarAtom.on
-  | .base => ⊥
-  | .suf => ↑BaarAtom.baar
+/-- The unified `on-V-baar` schema: both affixes pinned, base open. -/
+def onbaarSchema : Schema OnbaarSlot (Flat BaarAtom) where
+  body
+    | .pre => ↑BaarAtom.on
+    | .base => ⊥
+    | .suf => ↑BaarAtom.baar
+  opens := {.base}
 
-/-- The `on-` and `V-baar` schema bodies unify into the `on-V-baar` body — the
+/-- The `on-` and `V-baar` descriptions unify into the `on-V-baar` description — the
 schema unification `(16)`, with no intermediate `V-baar` word required. -/
-theorem onbaar_unifies : PartialUnify.unify onBody baarBody = some onbaarBody := by decide
+theorem onbaar_unifies :
+    PartialUnify.unify onSchema.body baarSchema.body = some onbaarSchema.body := by decide
+
+/-- The unified schema's instances are exactly the words that are at once `on-`
+prefixed and `-baar` suffixed: the content of coining `onbedwingbaar` directly. -/
+theorem onbaarSchema_instantiates_iff {w : OnbaarSlot → Flat BaarAtom} :
+    onbaarSchema.Instantiates w ↔ onSchema.Instantiates w ∧ baarSchema.Instantiates w :=
+  Schema.instantiates_iff_of_unify_eq_some onbaar_unifies
 
 /-! ### Further constructional phenomena (prose)
 

--- a/references.bib
+++ b/references.bib
@@ -32822,7 +32822,7 @@
   doi       = {10.1111/j.1749-818X.2010.00213.x},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Studies/Booij2010.lean}
+  sources   = {Morphology/Construction/Schema.lean;Studies/Booij2010.lean}
 }
 
 @book{blevins-2016,


### PR DESCRIPTION
Deep audit of `Morphology/Construction/Schema.lean`: the generative role now distinguishes constants from closed variables, as the book does, and the file gains the order-theoretic content of schema unification and least general generalization.

- `Schema` drops its unused `PartialOrder` binder (also on `Sister`) and gets `@[ext]`; `Generates` and `IsProductive` quantify over variables (slots at `⊥`), with `Relates ⊆ Generates`, the memory-collapse step, lexicon monotonicity, and `isProductive_iff_generates_empty`.
- New `instantiates_iff_of_unify_eq_some` (instances of a unified schema are the common instances) and `instantiates_inf_iff` (the meet as lgg), replacing the phantom-`opens` `instantiates_inf` and the two trailing examples.
- `Booij2010`: `-ness` is now provably productive and `carlessness_generates` is a corollary; the `on-V-baar` bodies become schemas with `onbaarSchema_instantiates_iff`.