### PR TITLE
refactor(Core/Data/Sum): factoring through a sum of functions

### DIFF
--- a/Linglib/Core/Data/Sum/Basic.lean
+++ b/Linglib/Core/Data/Sum/Basic.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Sum.Basic
+import Mathlib.Logic.Function.Basic
+
+/-!
+# Factoring through a sum of functions
+
+`Sum.elim g₁ g₂` factors through `Sum.elim f₁ f₂` exactly when each component factors
+through its own and the two agree wherever `f₁` and `f₂` coincide: the factoring counterpart
+of `Function.Injective.sumElim`.
+
+`[UPSTREAM]` candidate for `Mathlib/Data/Sum/Basic.lean`, beside `Function.Injective.sumElim`.
+-/
+
+open Sum
+
+namespace Function
+
+variable {α β γ δ : Type*} {f₁ : α → γ} {f₂ : β → γ} {g₁ : α → δ} {g₂ : β → δ}
+
+theorem FactorsThrough.sumElim (h₁ : g₁.FactorsThrough f₁)
+    (h₂ : g₂.FactorsThrough f₂) (h : ∀ a b, f₁ a = f₂ b → g₁ a = g₂ b) :
+    (Sum.elim g₁ g₂).FactorsThrough (Sum.elim f₁ f₂)
+  | inl _, inl _, e => h₁ e
+  | inl _, inr _, e => h _ _ e
+  | inr _, inl _, e => (h _ _ e.symm).symm
+  | inr _, inr _, e => h₂ e
+
+/-- The sum of two functions factors through the sum of two others exactly when each factors
+through its own and the two agree wherever the latter coincide. -/
+theorem factorsThrough_sumElim_iff :
+    (Sum.elim g₁ g₂).FactorsThrough (Sum.elim f₁ f₂) ↔
+      g₁.FactorsThrough f₁ ∧ g₂.FactorsThrough f₂ ∧
+        ∀ a b, f₁ a = f₂ b → g₁ a = g₂ b :=
+  ⟨λ h => ⟨λ _ _ e => @h (inl _) (inl _) e, λ _ _ e => @h (inr _) (inr _) e,
+    λ _ _ e => @h (inl _) (inr _) e⟩, λ ⟨h₁, h₂, h⟩ => h₁.sumElim h₂ h⟩
+
+end Function

--- a/Linglib/Core/Data/Sum/Basic.lean
+++ b/Linglib/Core/Data/Sum/Basic.lean
@@ -20,7 +20,8 @@ open Sum
 
 namespace Function
 
-variable {α β γ δ : Type*} {f₁ : α → γ} {f₂ : β → γ} {g₁ : α → δ} {g₂ : β → δ}
+variable {α β γ δ : Type*} {f₁ : α → γ} {f₂ : β → γ}
+  {g₁ : α → δ} {g₂ : β → δ}
 
 theorem FactorsThrough.sumElim (h₁ : g₁.FactorsThrough f₁)
     (h₂ : g₂.FactorsThrough f₂) (h : ∀ a b, f₁ a = f₂ b → g₁ a = g₂ b) :

--- a/Linglib/Morphology/Construction/Schema.lean
+++ b/Linglib/Morphology/Construction/Schema.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Data.Sum.Basic
 import Linglib.Core.Order.PartialUnify
 import Mathlib.Order.Lattice
 
@@ -56,20 +57,6 @@ Marking a constant slot as open has no effect.
 * [plotkin-1970]
 * [albright-hayes-2003]
 -/
-
-/-- The sum of two functions factors through the sum of two others exactly when each factors
-through its own and the two agree wherever the subscripts coincide. -/
-theorem Function.factorsThrough_sum_elim_iff {α β γ δ : Type*} {f₁ : α → γ}
-    {f₂ : β → γ} {g₁ : α → δ} {g₂ : β → δ} :
-    (Sum.elim g₁ g₂).FactorsThrough (Sum.elim f₁ f₂) ↔
-      g₁.FactorsThrough f₁ ∧ g₂.FactorsThrough f₂ ∧
-        ∀ a b, f₁ a = f₂ b → g₁ a = g₂ b := by
-  simp only [Function.FactorsThrough, Sum.forall, forall_and, Sum.elim_inl, Sum.elim_inr]
-  constructor
-  · rintro ⟨⟨h₁, -⟩, h, h₂⟩
-    exact ⟨h₁, h₂, h⟩
-  · rintro ⟨h₁, h₂, h⟩
-    exact ⟨⟨h₁, λ b a hab => (h a b hab.symm).symm⟩, h, h₂⟩
 
 namespace Morphology.Construction
 
@@ -196,7 +183,7 @@ theorem instantiatesAt_elim_iff :
       (s.comap pos₁).Instantiates w₁ ∧ (s.comap pos₂).Instantiates w₂ := by
     simp only [Instantiates, comap_body, Sum.comp_elim, Pi.le_def, Sum.forall, Sum.elim_inl,
       Sum.elim_inr]
-  rw [instantiatesAt_iff, Function.factorsThrough_sum_elim_iff, h, and_assoc]
+  rw [instantiatesAt_iff, Function.factorsThrough_sumElim_iff, h, and_assoc]
 
 /-- A paired instantiation is symmetric: the sister relation has no direction. -/
 theorem instantiatesAt_elim_swap :


### PR DESCRIPTION
Moves the `Sum.elim` factoring lemma out of `Morphology/Construction/Schema.lean` into `Core/Data/Sum/Basic.lean`, mirroring where mathlib keeps `Function.Injective.sumElim`.

- `Function.FactorsThrough.sumElim` by constructor matching, exactly as `Injective.sumElim`; `factorsThrough_sumElim_iff` derived from it; camel-case name as in current mathlib; marked `[UPSTREAM]`.
- `Schema.lean` imports the new module; no statement changes downstream.