### PR TITLE
feat(Data/Forms): CLDF word forms with a generator, Booij2019 on it

### DIFF
--- a/Linglib/Data/Forms/Booij2019.json
+++ b/Linglib/Data/Forms/Booij2019.json
@@ -1,0 +1,239 @@
+{
+  "FormTable": [
+    {
+      "ID": "booij2019_xabbaaz",
+      "Language_ID": "nort3139",
+      "Parameter_ID": "baker",
+      "Form": "xabbaaz",
+      "Segments": ["x", "a", "b", "b", "aa", "z"],
+      "Comment": "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment",
+      "Source": ["booij-2019[(1)]"]
+    },
+    {
+      "ID": "booij2019_xaddaam",
+      "Language_ID": "nort3139",
+      "Parameter_ID": "servant",
+      "Form": "xaddaam",
+      "Segments": ["x", "a", "d", "d", "aa", "m"],
+      "Comment": "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment",
+      "Source": ["booij-2019[(1)]"]
+    },
+    {
+      "ID": "booij2019_bawwaab",
+      "Language_ID": "nort3139",
+      "Parameter_ID": "doorkeeper",
+      "Form": "bawwaab",
+      "Segments": ["b", "a", "w", "w", "aa", "b"],
+      "Comment": "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment",
+      "Source": ["booij-2019[(1)]"]
+    },
+    {
+      "ID": "booij2019_sammaak",
+      "Language_ID": "nort3139",
+      "Parameter_ID": "fish_seller",
+      "Form": "sammaak",
+      "Segments": ["s", "a", "m", "m", "aa", "k"],
+      "Comment": "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment",
+      "Source": ["booij-2019[(1)]"]
+    },
+    {
+      "ID": "booij2019_tamu",
+      "Language_ID": "java1254",
+      "Parameter_ID": "guest",
+      "Form": "tamu",
+      "Segments": ["t", "amu"],
+      "Comment": "base of the reduplication (13); the residue after the initial consonant is one segment, the paper's variable y",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_tetamu",
+      "Language_ID": "java1254",
+      "Parameter_ID": "to_visit",
+      "Form": "tətamu",
+      "Segments": ["t", "ə", "t", "amu"],
+      "Comment": "partial reduplication (13): the initial consonant copied, then the schwa",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_jawah",
+      "Language_ID": "java1254",
+      "Parameter_ID": "rain",
+      "Form": "jawah",
+      "Segments": ["j", "awah"],
+      "Comment": "base of the reduplication (13)",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_jejawah",
+      "Language_ID": "java1254",
+      "Parameter_ID": "to_play_in_the_rain",
+      "Form": "jəjawah",
+      "Segments": ["j", "ə", "j", "awah"],
+      "Comment": "partial reduplication (13)",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_geni",
+      "Language_ID": "java1254",
+      "Parameter_ID": "fire",
+      "Form": "gəni",
+      "Segments": ["g", "əni"],
+      "Comment": "base of the reduplication (13)",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_gegeni",
+      "Language_ID": "java1254",
+      "Parameter_ID": "to_warm_oneself_by_the_fire",
+      "Form": "gəgəni",
+      "Segments": ["g", "ə", "g", "əni"],
+      "Comment": "partial reduplication (13)",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_kibiir",
+      "Language_ID": "egyp1253",
+      "Parameter_ID": "big",
+      "Form": "kibiir",
+      "Segments": ["k", "i", "b", "ii", "r"],
+      "Comment": "adjective of the template C₁VC₂VC₃ (16)",
+      "Source": ["booij-2019[(15)]"]
+    },
+    {
+      "ID": "booij2019_akbar",
+      "Language_ID": "egyp1253",
+      "Parameter_ID": "bigger",
+      "Form": "akbar",
+      "Segments": ["a", "k", "b", "a", "r"],
+      "Comment": "comparative of the template aC₁C₂aC₃ (16)",
+      "Source": ["booij-2019[(15)]"]
+    },
+    {
+      "ID": "booij2019_tixiin",
+      "Language_ID": "egyp1253",
+      "Parameter_ID": "fat",
+      "Form": "tixiin",
+      "Segments": ["t", "i", "x", "ii", "n"],
+      "Comment": "adjective of the template C₁VC₂VC₃ (16)",
+      "Source": ["booij-2019[(15)]"]
+    },
+    {
+      "ID": "booij2019_atxan",
+      "Language_ID": "egyp1253",
+      "Parameter_ID": "fatter",
+      "Form": "atxan",
+      "Segments": ["a", "t", "x", "a", "n"],
+      "Comment": "comparative of the template aC₁C₂aC₃ (16)",
+      "Source": ["booij-2019[(15)]"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "baker",
+      "Name": "baker",
+      "Description": ""
+    },
+    {
+      "ID": "servant",
+      "Name": "servant",
+      "Description": ""
+    },
+    {
+      "ID": "doorkeeper",
+      "Name": "doorkeeper",
+      "Description": ""
+    },
+    {
+      "ID": "fish_seller",
+      "Name": "fish seller",
+      "Description": ""
+    },
+    {
+      "ID": "guest",
+      "Name": "guest",
+      "Description": ""
+    },
+    {
+      "ID": "to_visit",
+      "Name": "to visit",
+      "Description": ""
+    },
+    {
+      "ID": "rain",
+      "Name": "rain",
+      "Description": ""
+    },
+    {
+      "ID": "to_play_in_the_rain",
+      "Name": "to play in the rain",
+      "Description": ""
+    },
+    {
+      "ID": "fire",
+      "Name": "fire",
+      "Description": ""
+    },
+    {
+      "ID": "to_warm_oneself_by_the_fire",
+      "Name": "to warm oneself by the fire",
+      "Description": ""
+    },
+    {
+      "ID": "big",
+      "Name": "big",
+      "Description": ""
+    },
+    {
+      "ID": "bigger",
+      "Name": "bigger",
+      "Description": ""
+    },
+    {
+      "ID": "fat",
+      "Name": "fat",
+      "Description": ""
+    },
+    {
+      "ID": "fatter",
+      "Name": "fatter",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": [
+    {
+      "ID": "booij2019_tamu_tetamu",
+      "Form_ID": "booij2019_tamu",
+      "Target_ID": "booij2019_tetamu",
+      "Relation": "reduplication",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_jawah_jejawah",
+      "Form_ID": "booij2019_jawah",
+      "Target_ID": "booij2019_jejawah",
+      "Relation": "reduplication",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_geni_gegeni",
+      "Form_ID": "booij2019_geni",
+      "Target_ID": "booij2019_gegeni",
+      "Relation": "reduplication",
+      "Source": ["booij-2019[(12)]"]
+    },
+    {
+      "ID": "booij2019_kibiir_akbar",
+      "Form_ID": "booij2019_kibiir",
+      "Target_ID": "booij2019_akbar",
+      "Relation": "comparative",
+      "Source": ["booij-2019[(15)]"]
+    },
+    {
+      "ID": "booij2019_tixiin_atxan",
+      "Form_ID": "booij2019_tixiin",
+      "Target_ID": "booij2019_atxan",
+      "Relation": "comparative",
+      "Source": ["booij-2019[(15)]"]
+    }
+  ]
+}

--- a/Linglib/Data/Forms/Booij2019.lean
+++ b/Linglib/Data/Forms/Booij2019.lean
@@ -1,0 +1,207 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `Booij2019` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/Booij2019.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace Booij2019.Forms`.
+-/
+
+namespace Booij2019.Forms
+
+open Data.Forms
+
+def xabbaaz : Form :=
+  { id := "booij2019_xabbaaz"
+    languageId := "nort3139"
+    parameterId := "baker"
+    form := "xabbaaz"
+    segments := ["x", "a", "b", "b", "aa", "z"]
+    comment := "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment"
+    source := [
+      ⟨"booij-2019", "(1)"⟩
+    ] }
+
+def xaddaam : Form :=
+  { id := "booij2019_xaddaam"
+    languageId := "nort3139"
+    parameterId := "servant"
+    form := "xaddaam"
+    segments := ["x", "a", "d", "d", "aa", "m"]
+    comment := "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment"
+    source := [
+      ⟨"booij-2019", "(1)"⟩
+    ] }
+
+def bawwaab : Form :=
+  { id := "booij2019_bawwaab"
+    languageId := "nort3139"
+    parameterId := "doorkeeper"
+    form := "bawwaab"
+    segments := ["b", "a", "w", "w", "aa", "b"]
+    comment := "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment"
+    source := [
+      ⟨"booij-2019", "(1)"⟩
+    ] }
+
+def sammaak : Form :=
+  { id := "booij2019_sammaak"
+    languageId := "nort3139"
+    parameterId := "fish_seller"
+    form := "sammaak"
+    segments := ["s", "a", "m", "m", "aa", "k"]
+    comment := "occupation noun of the template C₁aC₂C₂aaC₃ (2); a long vowel is one segment"
+    source := [
+      ⟨"booij-2019", "(1)"⟩
+    ] }
+
+def tamu : Form :=
+  { id := "booij2019_tamu"
+    languageId := "java1254"
+    parameterId := "guest"
+    form := "tamu"
+    segments := ["t", "amu"]
+    comment := "base of the reduplication (13); the residue after the initial consonant is one segment, the paper's variable y"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def tetamu : Form :=
+  { id := "booij2019_tetamu"
+    languageId := "java1254"
+    parameterId := "to_visit"
+    form := "tətamu"
+    segments := ["t", "ə", "t", "amu"]
+    comment := "partial reduplication (13): the initial consonant copied, then the schwa"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def jawah : Form :=
+  { id := "booij2019_jawah"
+    languageId := "java1254"
+    parameterId := "rain"
+    form := "jawah"
+    segments := ["j", "awah"]
+    comment := "base of the reduplication (13)"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def jejawah : Form :=
+  { id := "booij2019_jejawah"
+    languageId := "java1254"
+    parameterId := "to_play_in_the_rain"
+    form := "jəjawah"
+    segments := ["j", "ə", "j", "awah"]
+    comment := "partial reduplication (13)"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def geni : Form :=
+  { id := "booij2019_geni"
+    languageId := "java1254"
+    parameterId := "fire"
+    form := "gəni"
+    segments := ["g", "əni"]
+    comment := "base of the reduplication (13)"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def gegeni : Form :=
+  { id := "booij2019_gegeni"
+    languageId := "java1254"
+    parameterId := "to_warm_oneself_by_the_fire"
+    form := "gəgəni"
+    segments := ["g", "ə", "g", "əni"]
+    comment := "partial reduplication (13)"
+    source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] }
+
+def kibiir : Form :=
+  { id := "booij2019_kibiir"
+    languageId := "egyp1253"
+    parameterId := "big"
+    form := "kibiir"
+    segments := ["k", "i", "b", "ii", "r"]
+    comment := "adjective of the template C₁VC₂VC₃ (16)"
+    source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] }
+
+def akbar : Form :=
+  { id := "booij2019_akbar"
+    languageId := "egyp1253"
+    parameterId := "bigger"
+    form := "akbar"
+    segments := ["a", "k", "b", "a", "r"]
+    comment := "comparative of the template aC₁C₂aC₃ (16)"
+    source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] }
+
+def tixiin : Form :=
+  { id := "booij2019_tixiin"
+    languageId := "egyp1253"
+    parameterId := "fat"
+    form := "tixiin"
+    segments := ["t", "i", "x", "ii", "n"]
+    comment := "adjective of the template C₁VC₂VC₃ (16)"
+    source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] }
+
+def atxan : Form :=
+  { id := "booij2019_atxan"
+    languageId := "egyp1253"
+    parameterId := "fatter"
+    form := "atxan"
+    segments := ["a", "t", "x", "a", "n"]
+    comment := "comparative of the template aC₁C₂aC₃ (16)"
+    source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] }
+
+def all : List Form := [xabbaaz, xaddaam, bawwaab, sammaak, tamu, tetamu, jawah, jejawah, geni, gegeni, kibiir, akbar, tixiin, atxan]
+
+def parameters : List Parameter := [
+  { id := "baker", name := "baker", description := "" },
+  { id := "servant", name := "servant", description := "" },
+  { id := "doorkeeper", name := "doorkeeper", description := "" },
+  { id := "fish_seller", name := "fish seller", description := "" },
+  { id := "guest", name := "guest", description := "" },
+  { id := "to_visit", name := "to visit", description := "" },
+  { id := "rain", name := "rain", description := "" },
+  { id := "to_play_in_the_rain", name := "to play in the rain", description := "" },
+  { id := "fire", name := "fire", description := "" },
+  { id := "to_warm_oneself_by_the_fire", name := "to warm oneself by the fire", description := "" },
+  { id := "big", name := "big", description := "" },
+  { id := "bigger", name := "bigger", description := "" },
+  { id := "fat", name := "fat", description := "" },
+  { id := "fatter", name := "fatter", description := "" }
+]
+
+def relations : List FormRelation := [
+  { id := "booij2019_tamu_tetamu", formId := "booij2019_tamu", targetId := "booij2019_tetamu", relation := "reduplication", source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] },
+  { id := "booij2019_jawah_jejawah", formId := "booij2019_jawah", targetId := "booij2019_jejawah", relation := "reduplication", source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] },
+  { id := "booij2019_geni_gegeni", formId := "booij2019_geni", targetId := "booij2019_gegeni", relation := "reduplication", source := [
+      ⟨"booij-2019", "(12)"⟩
+    ] },
+  { id := "booij2019_kibiir_akbar", formId := "booij2019_kibiir", targetId := "booij2019_akbar", relation := "comparative", source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] },
+  { id := "booij2019_tixiin_atxan", formId := "booij2019_tixiin", targetId := "booij2019_atxan", relation := "comparative", source := [
+      ⟨"booij-2019", "(15)"⟩
+    ] }
+]
+
+end Booij2019.Forms

--- a/Linglib/Data/Forms/Schema.lean
+++ b/Linglib/Data/Forms/Schema.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Data.Examples.Schema
+import Linglib.Core.Order.Flat
+
+/-!
+# CLDF word forms
+
+Substrate types for word-level data, aligned with the Wordlist module of the Cross-Linguistic
+Data Formats ([forkel-etal-2018]), version 1.3 ([forkel-etal-2024]): a `Form` is a row of the
+`FormTable` (a form of a language expressing a concept,
+with its segmentation), and a `Parameter` is a row of the `ParameterTable` (the concept). The
+sentence-level `LinguisticExample` of `Data/Examples/` is the Examples component; this is its
+counterpart for morphology, where the datum is a word and its parts rather than an utterance
+and its gloss.
+
+Per-paper data lives in `Linglib/Data/Forms/{AuthorYear}.json`, an object whose keys are CLDF
+table names holding arrays of rows under the CLDF column names, and is compiled by
+`scripts/gen_forms.py` into `Linglib/Data/Forms/{AuthorYear}.lean`, declaring
+`namespace {AuthorYear}.Forms`.
+
+`FormRelation` is a linglib extension table, `FormRelationTable`, for the paradigmatic pairs a
+paper asserts between forms (a stem and its past, an adjective and its comparative, a base
+and its reduplicant); CLDF has no standard component for these and permits custom tables.
+
+## Implementation notes
+
+* `Language_ID` is a Glottocode rather than a foreign key into a `LanguageTable`, as in
+  `Data/Examples/`. `Source` follows the CLDF reference syntax `bibkey[label]` in JSON and is
+  parsed into `SourceRef` values.
+* `Segments` is the paper's own tokenization of the form, which may be coarser than a
+  phonemic segmentation: a long vowel as one segment, or a residue the paper treats as one
+  variable. `Form.slots` reads the segments as a slot-indexed item on the flat carrier, the
+  shape the schema substrate consumes.
+* Identifiers follow the CLDF `id` format `[a-zA-Z0-9_-]+`, enforced by the generator.
+
+## References
+
+* [forkel-etal-2018]
+* [forkel-etal-2024]
+-/
+
+namespace Data.Forms
+
+open Data.Examples
+
+/-- A row of a CLDF `FormTable`: a word form of a language expressing a concept, with its
+segmentation. -/
+structure Form where
+  /-- `ID`: a stable, paper-keyed identifier. -/
+  id : String
+  /-- `Language_ID`: the Glottocode of the language. -/
+  languageId : Glottocode
+  /-- `Parameter_ID`: the concept the form expresses. -/
+  parameterId : String
+  /-- `Form`: the written form. -/
+  form : String
+  /-- `Segments`: the form's segmentation. -/
+  segments : List String
+  /-- `Comment`. -/
+  comment : String := ""
+  /-- `Source`: the references, each a bibkey with a locator. -/
+  source : List SourceRef := []
+  deriving DecidableEq, Repr
+
+/-- The segments of a form as a slot-indexed item on the flat carrier. -/
+def Form.slots (f : Form) (i : Fin f.segments.length) : Flat String := ↑(f.segments.get i)
+
+/-- A row of a CLDF `ParameterTable`: a concept forms express. -/
+structure Parameter where
+  /-- `ID`. -/
+  id : String
+  /-- `Name`. -/
+  name : String
+  /-- `Description`. -/
+  description : String := ""
+  deriving DecidableEq, Repr
+
+/-- A row of the `FormRelationTable`: a paradigmatic relation a paper asserts from one form to
+another, named by the paper's term for it. -/
+structure FormRelation where
+  /-- `ID`. -/
+  id : String
+  /-- `Form_ID`: the first form. -/
+  formId : String
+  /-- `Target_ID`: the second form. -/
+  targetId : String
+  /-- `Relation`: the paper's name for the relation. -/
+  relation : String
+  /-- `Source`. -/
+  source : List SourceRef := []
+  deriving DecidableEq, Repr
+
+end Data.Forms

--- a/Linglib/Data/README.md
+++ b/Linglib/Data/README.md
@@ -5,6 +5,7 @@ Three sibling directories at this level:
 | Subdir | Purpose | Source format | Generated Lean |
 |---|---|---|---|
 | `Examples/` | Per-paper typed examples (`LinguisticExample` schema) | JSON, one file per paper | Inserted into study files via marker-block generator |
+| `Forms/` | Per-paper CLDF word forms (`FormTable`, `ParameterTable`, custom `FormRelationTable`) | JSON, one file per paper | `Forms/{AuthorYear}.lean` |
 | `PHOIBLE/` | Cross-linguistic phonological inventories | CSV (raw under `PHOIBLE/raw/`) | `Inventories/{Lang}.lean` |
 | `WALS/` | World Atlas of Language Structures | CSV (raw under `WALS/raw/`) | `Features/F*.lean`, `Languages.lean` |
 
@@ -34,6 +35,19 @@ Linglib/Data/
 See [`Examples/README.md`](Examples/README.md). Per-paper JSON; generator
 inserts into Studies files via marker blocks. JSON (not CSV) because the
 schema has nested fields.
+
+### Forms — CLDF word-level data
+
+Per-paper word forms in the Cross-Linguistic Data Formats Wordlist shape: a
+`FormTable` (form, language, concept, segmentation, source), a
+`ParameterTable` (the concepts), and a linglib extension `FormRelationTable`
+for the paradigmatic pairs a paper asserts (stem and past, adjective and
+comparative, base and reduplicant). The morphological counterpart of
+`Examples/`, whose datum is a sentence and its gloss.
+
+- **Schema**: `Linglib/Data/Forms/Schema.lean`
+- **Generator**: `scripts/gen_forms.py` (`--check` verifies sync, `--fmt` canonical JSON)
+- **Input/Output**: `Linglib/Data/Forms/{AuthorYear}.json` → `{AuthorYear}.lean`
 
 ### UD dependency length by language
 

--- a/Linglib/Studies/Booij2019.lean
+++ b/Linglib/Studies/Booij2019.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Data.Forms.Booij2019
 import Linglib.Morphology.Construction.Schema
 import Linglib.Morphology.Morphotactics.CVTemplate
-import Linglib.Core.Order.Flat
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
 
@@ -30,8 +30,9 @@ an adjective with the comparative template over the same three consonants
 
 ## Implementation notes
 
-* Slots are `Fin n` positions and items are slot-indexed segments on a flat carrier. A variable
-  standing for a sequence of sounds, the paper's `y`, is one slot valued in the residue.
+* The words are the CLDF forms of `Data/Forms/Booij2019.json`, read as slot-indexed segments
+  on the flat carrier by `Data.Forms.Form.slots`; slots are `Fin n` positions. A variable
+  standing for a sequence of sounds, the paper's `y`, is one segment holding the residue.
 * The higher-order schema for Dutch *-er* and the affixoid discussion are not formalized.
 
 ## References
@@ -46,41 +47,25 @@ open Morphology Morphology.Construction
 
 /-! ### The occupation template `C₁aC₂C₂aaC₃` -/
 
-/-- The Arabic segments cited: the consonants of (1) and (15) and the vowels. -/
-inductive ArSeg
-  | x | b | z | d | m | w | s | k | r | t | n
-  | a | aa | i | ii
-  deriving DecidableEq
-
 /-- The parts of the occupation template (2): three root consonants and two vowel constants. -/
 inductive OccPart
   | c1 | c2 | c3 | a | aa
   deriving DecidableEq
 
 /-- The occupation schema (2): the vowels pinned, the root consonants open. -/
-def occupation : Schema OccPart (Flat ArSeg) :=
-  ⟨λ | .a => ↑ArSeg.a | .aa => ↑ArSeg.aa | _ => ⊥, {.c1, .c2, .c3}⟩
+def occupation : Schema OccPart (Flat String) :=
+  ⟨λ | .a => ↑"a" | .aa => ↑"aa" | _ => ⊥, {.c1, .c2, .c3}⟩
 
 /-- The six slots of `C₁aC₂C₂aaC₃` subscripted by parts: the second consonant occupies
 two. -/
 def occupationSub : Fin 6 → OccPart := ![.c1, .a, .c2, .c2, .aa, .c3]
 
-/-- The occupation nouns (1). -/
-def xabbaaz : Fin 6 → Flat ArSeg :=
-  ![↑ArSeg.x, ↑ArSeg.a, ↑ArSeg.b, ↑ArSeg.b, ↑ArSeg.aa, ↑ArSeg.z]
-def xaddaam : Fin 6 → Flat ArSeg :=
-  ![↑ArSeg.x, ↑ArSeg.a, ↑ArSeg.d, ↑ArSeg.d, ↑ArSeg.aa, ↑ArSeg.m]
-def bawwaab : Fin 6 → Flat ArSeg :=
-  ![↑ArSeg.b, ↑ArSeg.a, ↑ArSeg.w, ↑ArSeg.w, ↑ArSeg.aa, ↑ArSeg.b]
-def sammaak : Fin 6 → Flat ArSeg :=
-  ![↑ArSeg.s, ↑ArSeg.a, ↑ArSeg.m, ↑ArSeg.m, ↑ArSeg.aa, ↑ArSeg.k]
-
 /-- An item instantiates the occupation schema exactly when its vowels are the template's and
 the two slots of the second consonant are filled alike: gemination is a subscripting that is
 not injective. -/
-theorem occupation_instantiatesAt_iff {w : Fin 6 → Flat ArSeg} :
+theorem occupation_instantiatesAt_iff {w : Fin 6 → Flat String} :
     occupation.InstantiatesAt occupationSub w ↔
-      w 1 = ↑ArSeg.a ∧ w 4 = ↑ArSeg.aa ∧ w 2 = w 3 := by
+      w 1 = ↑"a" ∧ w 4 = ↑"aa" ∧ w 2 = w 3 := by
   rw [Schema.instantiatesAt_iff]
   constructor
   · rintro ⟨hc, hf⟩
@@ -93,17 +78,17 @@ theorem occupation_instantiatesAt_iff {w : Fin 6 → Flat ArSeg} :
 
 /-- The nouns of (1) instantiate the template. -/
 theorem occupation_nouns :
-    occupation.InstantiatesAt occupationSub xabbaaz ∧
-      occupation.InstantiatesAt occupationSub xaddaam ∧
-        occupation.InstantiatesAt occupationSub bawwaab ∧
-          occupation.InstantiatesAt occupationSub sammaak := by
+    occupation.InstantiatesAt occupationSub Forms.xabbaaz.slots ∧
+      occupation.InstantiatesAt occupationSub Forms.xaddaam.slots ∧
+        occupation.InstantiatesAt occupationSub Forms.bawwaab.slots ∧
+          occupation.InstantiatesAt occupationSub Forms.sammaak.slots := by
   simp only [occupation_instantiatesAt_iff]
   decide
 
 /-- A form with distinct medial consonants matches the vowels but not the gemination. -/
 theorem not_occupation_of_ne_medial :
     ¬ occupation.InstantiatesAt occupationSub
-      ![↑ArSeg.x, ↑ArSeg.a, ↑ArSeg.b, ↑ArSeg.d, ↑ArSeg.aa, ↑ArSeg.z] := by
+      ![↑"x", ↑"a", ↑"b", ↑"d", ↑"aa", ↑"z"] := by
   rw [occupation_instantiatesAt_iff]
   decide
 
@@ -114,9 +99,9 @@ def occupationTemplate : CVTemplate := ⟨[.C, .V, .C, .C, .V, .C]⟩
 
 /-- *xabbaaz* as the association of the root /x b z/ and the vocalism /a aa/ to the template:
 the second root consonant is associated to two slots. -/
-def xabbaazMatch : TemplateMatch ArSeg where
-  root := ⟨[.x, .b, .z]⟩
-  vocalism := [.a, .aa]
+def xabbaazMatch : TemplateMatch String where
+  root := ⟨["x", "b", "z"]⟩
+  vocalism := ["a", "aa"]
   template := occupationTemplate
   associations :=
     [⟨.root, 0, 0⟩, ⟨.vocalism, 0, 1⟩, ⟨.root, 1, 2⟩, ⟨.root, 1, 3⟩,
@@ -128,7 +113,7 @@ def xabbaazAssoc (i : Fin 6) : Option (AssocSource × Nat) :=
 
 /-- The association lines spell out *xabbaaz*. -/
 theorem xabbaazMatch_spellout :
-    xabbaazMatch.spellout.map ((↑) : ArSeg → Flat ArSeg) = List.ofFn xabbaaz := by
+    xabbaazMatch.spellout.map ((↑) : String → Flat String) = List.ofFn Forms.xabbaaz.slots := by
   decide
 
 /-- The subscripting and the association agree: two slots carry the same part exactly when
@@ -139,12 +124,6 @@ theorem occupationSub_eq_iff_assoc_eq (i j : Fin 6) :
 
 /-! ### Javanese partial reduplication -/
 
-/-- The pieces of the Javanese words (12): the initial consonants, the schwa, and the residues
-the paper's variable `y` stands for. -/
-inductive JvPiece
-  | t | j | g | schwa | amu | awah | eni
-  deriving DecidableEq
-
 /-- The parts of the reduplication schema (13): the copied consonant, the schwa constant, and
 the residue. -/
 inductive RedPart
@@ -152,8 +131,8 @@ inductive RedPart
   deriving DecidableEq
 
 /-- The reduplication schema (13): the schwa pinned, the consonant and the residue open. -/
-def reduplication : Schema RedPart (Flat JvPiece) :=
-  ⟨λ | .schwa => ↑JvPiece.schwa | _ => ⊥, {.c1, .y}⟩
+def reduplication : Schema RedPart (Flat String) :=
+  ⟨λ | .schwa => ↑"ə" | _ => ⊥, {.c1, .y}⟩
 
 /-- The reduplicant `C₁əC₁y`: the initial consonant occupies two slots. -/
 def redSub : Fin 4 → RedPart := ![.c1, .schwa, .c1, .y]
@@ -163,9 +142,9 @@ def baseSub : Fin 2 → RedPart := ![.c1, .y]
 
 /-- A reduplicant and a base are a paired instantiation of (13) exactly when the reduplicant
 has the schwa, copies its initial consonant, and shares consonant and residue with the base. -/
-theorem reduplication_pairs_iff {r : Fin 4 → Flat JvPiece} {b : Fin 2 → Flat JvPiece} :
+theorem reduplication_pairs_iff {r : Fin 4 → Flat String} {b : Fin 2 → Flat String} :
     reduplication.InstantiatesAt (Sum.elim redSub baseSub) (Sum.elim r b) ↔
-      r 1 = ↑JvPiece.schwa ∧ r 0 = r 2 ∧ r 0 = b 0 ∧ r 3 = b 1 := by
+      r 1 = ↑"ə" ∧ r 0 = r 2 ∧ r 0 = b 0 ∧ r 3 = b 1 := by
   rw [Schema.instantiatesAt_elim_iff]
   constructor
   · rintro ⟨hr, -, hf, -, h⟩
@@ -183,14 +162,11 @@ theorem reduplication_pairs_iff {r : Fin 4 → Flat JvPiece} {b : Fin 2 → Flat
 /-- The verbs of (12) with their bases. -/
 theorem reduplication_verbs :
     reduplication.InstantiatesAt (Sum.elim redSub baseSub)
-        (Sum.elim ![↑JvPiece.t, ↑JvPiece.schwa, ↑JvPiece.t, ↑JvPiece.amu]
-          ![↑JvPiece.t, ↑JvPiece.amu]) ∧
+        (Sum.elim Forms.tetamu.slots Forms.tamu.slots) ∧
       reduplication.InstantiatesAt (Sum.elim redSub baseSub)
-        (Sum.elim ![↑JvPiece.j, ↑JvPiece.schwa, ↑JvPiece.j, ↑JvPiece.awah]
-          ![↑JvPiece.j, ↑JvPiece.awah]) ∧
+        (Sum.elim Forms.jejawah.slots Forms.jawah.slots) ∧
       reduplication.InstantiatesAt (Sum.elim redSub baseSub)
-        (Sum.elim ![↑JvPiece.g, ↑JvPiece.schwa, ↑JvPiece.g, ↑JvPiece.eni]
-          ![↑JvPiece.g, ↑JvPiece.eni]) := by
+        (Sum.elim Forms.gegeni.slots Forms.geni.slots) := by
   simp only [reduplication_pairs_iff]
   decide
 
@@ -203,8 +179,8 @@ inductive CmpPart
   deriving DecidableEq
 
 /-- The comparative schema (16): the comparative vowel pinned, all else open. -/
-def comparative : Schema CmpPart (Flat ArSeg) :=
-  ⟨λ | .a => ↑ArSeg.a | _ => ⊥, {.c1, .c2, .c3, .v1, .v2}⟩
+def comparative : Schema CmpPart (Flat String) :=
+  ⟨λ | .a => ↑"a" | _ => ⊥, {.c1, .c2, .c3, .v1, .v2}⟩
 
 /-- The adjective template `C₁VC₂VC₃`. -/
 def adjSub : Fin 5 → CmpPart := ![.c1, .v1, .c2, .v2, .c3]
@@ -214,9 +190,9 @@ def cmpSub : Fin 5 → CmpPart := ![.a, .c1, .c2, .a, .c3]
 
 /-- An adjective and a comparative are a paired instantiation of (16) exactly when the
 comparative has its vowels and the two share their three consonants. -/
-theorem comparative_pairs_iff {p q : Fin 5 → Flat ArSeg} :
+theorem comparative_pairs_iff {p q : Fin 5 → Flat String} :
     comparative.InstantiatesAt (Sum.elim adjSub cmpSub) (Sum.elim p q) ↔
-      q 0 = ↑ArSeg.a ∧ q 3 = ↑ArSeg.a ∧ p 0 = q 1 ∧ p 2 = q 2 ∧ p 4 = q 4 := by
+      q 0 = ↑"a" ∧ q 3 = ↑"a" ∧ p 0 = q 1 ∧ p 2 = q 2 ∧ p 4 = q 4 := by
   rw [Schema.instantiatesAt_elim_iff]
   constructor
   · rintro ⟨-, hq, -, -, h⟩
@@ -232,17 +208,14 @@ theorem comparative_pairs_iff {p q : Fin 5 → Flat ArSeg} :
     · fin_cases i <;> fin_cases j <;>
         first | exact h01 | exact h22 | exact h44 | exact absurd hij (by decide)
 
-/-- The pairs of (15). -/
-def kibiir : Fin 5 → Flat ArSeg := ![↑ArSeg.k, ↑ArSeg.i, ↑ArSeg.b, ↑ArSeg.ii, ↑ArSeg.r]
-def akbar : Fin 5 → Flat ArSeg := ![↑ArSeg.a, ↑ArSeg.k, ↑ArSeg.b, ↑ArSeg.a, ↑ArSeg.r]
-def tixiin : Fin 5 → Flat ArSeg := ![↑ArSeg.t, ↑ArSeg.i, ↑ArSeg.x, ↑ArSeg.ii, ↑ArSeg.n]
-def atxan : Fin 5 → Flat ArSeg := ![↑ArSeg.a, ↑ArSeg.t, ↑ArSeg.x, ↑ArSeg.a, ↑ArSeg.n]
-
 /-- *kibiir* pairs with *akbar* and *tixiin* with *atxan*, and *kibiir* not with *atxan*. -/
 theorem comparative_pairs :
-    comparative.InstantiatesAt (Sum.elim adjSub cmpSub) (Sum.elim kibiir akbar) ∧
-      comparative.InstantiatesAt (Sum.elim adjSub cmpSub) (Sum.elim tixiin atxan) ∧
-        ¬ comparative.InstantiatesAt (Sum.elim adjSub cmpSub) (Sum.elim kibiir atxan) := by
+    comparative.InstantiatesAt (Sum.elim adjSub cmpSub)
+        (Sum.elim Forms.kibiir.slots Forms.akbar.slots) ∧
+      comparative.InstantiatesAt (Sum.elim adjSub cmpSub)
+        (Sum.elim Forms.tixiin.slots Forms.atxan.slots) ∧
+        ¬ comparative.InstantiatesAt (Sum.elim adjSub cmpSub)
+          (Sum.elim Forms.kibiir.slots Forms.atxan.slots) := by
   simp only [comparative_pairs_iff]
   decide
 

--- a/references.bib
+++ b/references.bib
@@ -32839,6 +32839,31 @@
   sources   = {Studies/Audring2019.lean;Studies/Booij2019.lean}
 }
 
+@article{forkel-etal-2018,
+  author    = {Forkel, Robert and List, Johann-Mattis and Greenhill, Simon J. and Rzymski, Christoph and Bank, Sebastian and Cysouw, Michael and Hammarstr{\"o}m, Harald and Haspelmath, Martin and Kaiping, Gereon A. and Gray, Russell D.},
+  year      = {2018},
+  title     = {Cross-{Linguistic} {Data} {Formats}, advancing data sharing and re-use in comparative linguistics},
+  journal   = {Scientific Data},
+  volume    = {5},
+  pages     = {180205},
+  doi       = {10.1038/sdata.2018.205},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Data/Forms/Schema.lean}
+}
+
+@misc{forkel-etal-2024,
+  author    = {Forkel, Robert and Cysouw, Michael and List, Johann-Mattis and Rzymski, Christoph and Greenhill, Simon J. and Moran, Steven and Mossel, Arjan and Kaiping, Gereon and Havighorst, Tarik},
+  year      = {2024},
+  title     = {cldf/cldf: {CLDF} 1.3},
+  publisher = {Zenodo},
+  note      = {Version 1.3.1, Cross-Linguistic Data Formats specification},
+  doi       = {10.5281/zenodo.10579537},
+  subfield  = {typology},
+  role      = {cited},
+  sources   = {Data/Forms/Schema.lean}
+}
+
 @article{booij-2010-compass,
   author    = {Booij, Geert},
   year      = {2010},

--- a/scripts/gen_forms.py
+++ b/scripts/gen_forms.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Generate Lean 4 CLDF form modules from per-paper JSON files.
+
+Usage:
+    python3 scripts/gen_forms.py <AuthorYear>
+    python3 scripts/gen_forms.py --all                # regenerate every paper
+    python3 scripts/gen_forms.py --check [<AuthorYear>]  # verify sync, no writes
+    python3 scripts/gen_forms.py --fmt [<AuthorYear>]    # canonical JSON format
+
+Reads   Linglib/Data/Forms/<AuthorYear>.json
+Writes  Linglib/Data/Forms/<AuthorYear>.lean, a standalone auto-generated
+module declaring `namespace <AuthorYear>.Forms`.
+
+JSON file format: an object whose keys are CLDF table names, each holding an
+array of rows keyed by the CLDF column names:
+
+  {
+    "FormTable": [
+      {"ID": "booij2019_xabbaaz", "Language_ID": "nort3139",
+       "Parameter_ID": "baker", "Form": "xabbaaz",
+       "Segments": ["x", "a", "b", "b", "aa", "z"],
+       "Comment": "", "Source": ["booij-2019[(1)]"]}
+    ],
+    "ParameterTable": [
+      {"ID": "baker", "Name": "baker", "Description": ""}
+    ],
+    "FormRelationTable": [                 // linglib extension, optional
+      {"ID": "booij2019_kibiir_akbar", "Form_ID": "booij2019_kibiir",
+       "Target_ID": "booij2019_akbar", "Relation": "comparative",
+       "Source": ["booij-2019[(15)]"]}
+    ]
+  }
+
+`Source` entries use the CLDF reference syntax `bibkey[label]`; a bare
+`bibkey` is accepted with an empty label.
+
+Behavior mirrors scripts/gen_examples.py: errors out on malformed input,
+idempotent, `--check` exits 1 on drift, `--fmt` rewrites JSON canonically
+and refuses to write if the data would change. The `Linglib.lean` root
+import is not touched.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT     = Path(__file__).resolve().parent.parent
+JSON_DIR = ROOT / "Linglib" / "Data" / "Forms"
+
+TABLES = ["FormTable", "ParameterTable", "FormRelationTable"]
+FORM_KEYS = ["ID", "Language_ID", "Parameter_ID", "Form", "Segments", "Comment", "Source"]
+PARAM_KEYS = ["ID", "Name", "Description"]
+REL_KEYS = ["ID", "Form_ID", "Target_ID", "Relation", "Source"]
+
+SOURCE_RE = re.compile(r"^\s*([^\[\]\s]+)\s*(?:\[(.*)\])?\s*$")
+ID_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")  # CLDF 1.3 `id` format
+
+
+def lean_string(s: str) -> str:
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def lean_identifier(row_id: str, author_year_lower: str) -> str:
+    prefix = author_year_lower + "_"
+    local = row_id[len(prefix):] if row_id.lower().startswith(prefix) else row_id
+    local = "".join(c if c.isalnum() or c == "_" else "_" for c in local)
+    if not local or not local[0].isalpha():
+        local = "f_" + local
+    return local
+
+
+def req(row: dict, key: str, where: str) -> str:
+    v = row.get(key)
+    if not isinstance(v, str) or not v.strip():
+        raise ValueError(f"{where}: {key} is required and non-empty")
+    return v.strip()
+
+
+def req_id(row: dict, key: str, where: str) -> str:
+    v = req(row, key, where)
+    if not ID_RE.match(v):
+        raise ValueError(f"{where}: {key} {v!r} violates the CLDF id format [a-zA-Z0-9_-]+")
+    return v
+
+
+def opt(row: dict, key: str) -> str:
+    v = row.get(key)
+    return v if isinstance(v, str) else ""
+
+
+def emit_sources(xs, where: str, indent: str) -> str:
+    """Emit a `List SourceRef` with each reference on its own line, so the
+    bracketed bibkeys are not mistaken for `[key]` citations."""
+    if xs is None:
+        return "[]"
+    if not isinstance(xs, list) or not all(isinstance(x, str) for x in xs):
+        raise ValueError(f"{where}: Source must be a list of strings")
+    items = []
+    for x in xs:
+        m = SOURCE_RE.match(x)
+        if not m:
+            raise ValueError(f"{where}: bad Source reference {x!r}; expected bibkey[label]")
+        items.append(f"⟨{lean_string(m.group(1))}, {lean_string(m.group(2) or '')}⟩")
+    if not items:
+        return "[]"
+    return "[\n" + ",\n".join(indent + "  " + it for it in items) + "\n" + indent + "]"
+
+
+def emit_segments(xs, where: str) -> str:
+    if not isinstance(xs, list) or not xs or not all(isinstance(x, str) and x for x in xs):
+        raise ValueError(f"{where}: Segments must be a non-empty list of non-empty strings")
+    return "[" + ", ".join(lean_string(x) for x in xs) + "]"
+
+
+def emit_form(row: dict, ay: str) -> tuple[str, str]:
+    rid = req_id(row, "ID", "FormTable row")
+    where = f"form {rid!r}"
+    local = lean_identifier(rid, ay)
+    text = f"""def {local} : Form :=
+  {{ id := {lean_string(rid)}
+    languageId := {lean_string(req(row, "Language_ID", where))}
+    parameterId := {lean_string(req(row, "Parameter_ID", where))}
+    form := {lean_string(req(row, "Form", where))}
+    segments := {emit_segments(row.get("Segments"), where)}
+    comment := {lean_string(opt(row, "Comment"))}
+    source := {emit_sources(row.get("Source"), where, "    ")} }}"""
+    return local, text
+
+
+def emit_parameter(row: dict) -> str:
+    rid = req_id(row, "ID", "ParameterTable row")
+    where = f"parameter {rid!r}"
+    return (f"  {{ id := {lean_string(rid)}, name := {lean_string(req(row, 'Name', where))}, "
+            f"description := {lean_string(opt(row, 'Description'))} }}")
+
+
+def emit_relation(row: dict) -> str:
+    rid = req_id(row, "ID", "FormRelationTable row")
+    where = f"relation {rid!r}"
+    return (f"  {{ id := {lean_string(rid)}, formId := {lean_string(req(row, 'Form_ID', where))}, "
+            f"targetId := {lean_string(req(row, 'Target_ID', where))}, "
+            f"relation := {lean_string(req(row, 'Relation', where))}, "
+            f"source := {emit_sources(row.get('Source'), where, '    ')} }}")
+
+
+def emit_list(name: str, ty: str, items: list[str]) -> str:
+    if not items:
+        return f"def {name} : List {ty} := []"
+    return f"def {name} : List {ty} :=\n" + ",\n".join(items) + "\n]"
+
+
+def emit_module(author_year: str, data: dict) -> str:
+    ay = author_year.lower()
+    forms = data.get("FormTable") or []
+    params = data.get("ParameterTable") or []
+    rels = data.get("FormRelationTable") or []
+    for t in data:
+        if t not in TABLES:
+            raise ValueError(f"unknown table {t!r}; expected one of {TABLES}")
+    form_ids = {req_id(r, "ID", "FormTable row") for r in forms}
+    param_ids = {req_id(r, "ID", "ParameterTable row") for r in params}
+    for r in forms:
+        if r.get("Parameter_ID") not in param_ids:
+            raise ValueError(f"form {r.get('ID')!r}: Parameter_ID not in ParameterTable")
+    for r in rels:
+        for k in ("Form_ID", "Target_ID"):
+            if r.get(k) not in form_ids:
+                raise ValueError(f"relation {r.get('ID')!r}: {k} not in FormTable")
+    locals_and_defs = [emit_form(r, ay) for r in forms]
+    body = "\n\n".join(t for _, t in locals_and_defs)
+    all_def = "def all : List Form := [" + ", ".join(l for l, _ in locals_and_defs) + "]"
+    params_def = emit_list("parameters", "Parameter", [emit_parameter(r) for r in params])
+    rels_def = emit_list("relations", "FormRelation", [emit_relation(r) for r in rels])
+    if params:
+        params_def = params_def.replace(":=\n", ":= [\n", 1)
+    if rels:
+        rels_def = rels_def.replace(":=\n", ":= [\n", 1)
+    return f"""import Linglib.Data.Forms.Schema
+
+/-!
+# `{author_year}` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/{author_year}.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace {author_year}.Forms`.
+-/
+
+namespace {author_year}.Forms
+
+open Data.Forms
+
+{body}
+
+{all_def}
+
+{params_def}
+
+{rels_def}
+
+end {author_year}.Forms
+"""
+
+
+def load(author_year: str) -> dict:
+    json_path = JSON_DIR / f"{author_year}.json"
+    if not json_path.exists():
+        sys.stderr.write(f"FATAL: JSON not found at {json_path.relative_to(ROOT)}\n")
+        sys.exit(1)
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"FATAL: {json_path.relative_to(ROOT)}: invalid JSON: {e}\n")
+        sys.exit(1)
+    if not isinstance(data, dict):
+        sys.stderr.write(f"FATAL: {json_path.relative_to(ROOT)}: top level must be an object of tables\n")
+        sys.exit(1)
+    return data
+
+
+def process(author_year: str, check: bool) -> bool:
+    data = load(author_year)
+    json_path = JSON_DIR / f"{author_year}.json"
+    try:
+        module_text = emit_module(author_year, data)
+    except ValueError as e:
+        sys.stderr.write(f"FATAL: {json_path.relative_to(ROOT)}: {e}\n")
+        sys.exit(1)
+    module_path = JSON_DIR / f"{author_year}.lean"
+    rel_module = module_path.relative_to(ROOT)
+    in_sync = module_path.exists() and module_path.read_text(encoding="utf-8") == module_text
+    if check:
+        if in_sync:
+            sys.stdout.write(f"[check] {rel_module} in sync\n")
+        else:
+            sys.stderr.write(f"[check] DRIFT: {rel_module}; run scripts/gen_forms.py {author_year}\n")
+        return in_sync
+    if in_sync:
+        sys.stdout.write(f"[gen] {rel_module} unchanged\n")
+    else:
+        module_path.write_text(module_text, encoding="utf-8")
+        n = len(data.get("FormTable") or [])
+        sys.stdout.write(f"[gen] {rel_module} ← {json_path.relative_to(ROOT)} ({n} form{'s' if n != 1 else ''})\n")
+    return True
+
+
+def _j(v) -> str:
+    return json.dumps(v, ensure_ascii=False)
+
+
+def _fmt_row(row: dict, keys: list[str], indent: str) -> str:
+    ks = [k for k in keys if k in row] + [k for k in row if k not in keys]
+    return "{\n" + ",\n".join(f"{indent}  {_j(k)}: {_j(row[k])}" for k in ks) + f"\n{indent}}}"
+
+
+def format_data(data: dict) -> str:
+    keyorder = {"FormTable": FORM_KEYS, "ParameterTable": PARAM_KEYS, "FormRelationTable": REL_KEYS}
+    tables = [t for t in TABLES if t in data] + [t for t in data if t not in TABLES]
+    out = ["{"]
+    for ti, t in enumerate(tables):
+        rows = data[t]
+        comma = "," if ti < len(tables) - 1 else ""
+        if not rows:
+            out.append(f"  {_j(t)}: []{comma}")
+            continue
+        out.append(f"  {_j(t)}: [")
+        for ri, row in enumerate(rows):
+            rc = "," if ri < len(rows) - 1 else ""
+            out.append("    " + _fmt_row(row, keyorder.get(t, []), "    ") + rc)
+        out.append(f"  ]{comma}")
+    out.append("}")
+    return "\n".join(out) + "\n"
+
+
+def fmt(author_year: str) -> bool:
+    data = load(author_year)
+    json_path = JSON_DIR / f"{author_year}.json"
+    text = format_data(data)
+    if json.loads(text) != data:
+        sys.stderr.write(f"[fmt] REFUSING {json_path.relative_to(ROOT)}: round-trip mismatch\n")
+        return False
+    if json_path.read_text(encoding="utf-8") == text:
+        sys.stdout.write(f"[fmt] {json_path.relative_to(ROOT)} unchanged\n")
+    else:
+        json_path.write_text(text, encoding="utf-8")
+        sys.stdout.write(f"[fmt] {json_path.relative_to(ROOT)} reformatted\n")
+    return True
+
+
+def main():
+    args = sys.argv[1:]
+    check = "--check" in args
+    do_fmt = "--fmt" in args
+    args = [a for a in args if a not in ("--check", "--fmt")]
+    if args == ["--all"] or (not args and (check or do_fmt)):
+        papers = sorted(p.stem for p in JSON_DIR.glob("*.json"))
+    elif len(args) == 1 and not args[0].startswith("-"):
+        papers = [args[0]]
+    else:
+        sys.stderr.write(
+            "Usage: python3 scripts/gen_forms.py <AuthorYear> | --all\n"
+            "       python3 scripts/gen_forms.py --check [<AuthorYear>]\n"
+            "       python3 scripts/gen_forms.py --fmt [<AuthorYear>]\n")
+        sys.exit(1)
+    if do_fmt:
+        if not all([fmt(p) for p in papers]):
+            sys.exit(1)
+        return
+    if not all([process(p, check) for p in papers]):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Word-level data in the CLDF 1.3 Wordlist shape (Zenodo 10.5281/zenodo.10579537): `FormTable` and `ParameterTable` rows under the CLDF column names, plus a documented custom `FormRelationTable` for the paradigmatic pairs a paper asserts.

- `Data/Forms/Schema.lean` (`Form`, `Parameter`, `FormRelation`, `Form.slots` onto the flat carrier), `scripts/gen_forms.py` mirroring `gen_examples.py` (`--all`, `--check`, `--fmt`, CLDF id-format validation, `bibkey[label]` sources), bib entries for CLDF 1.3 and the 2018 paper.
- `Booij2019` migrated: its words are `Forms.*.slots` on `Flat String`; the per-study segment inductives are gone; all theorems unchanged.
- `Linglib.lean` untouched.