### PR TITLE
refactor(Studies): morphology studies read their words from Data/Forms

### DIFF
--- a/Linglib/Data/Forms/Audring2019.json
+++ b/Linglib/Data/Forms/Audring2019.json
@@ -1,0 +1,134 @@
+{
+  "FormTable": [
+    {
+      "ID": "audring2019_boyish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_boy",
+      "Form": "boyish",
+      "Segments": ["boy", "ish"],
+      "Comment": "the [N -ish]A family (8)",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_foolish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_fool",
+      "Form": "foolish",
+      "Segments": ["fool", "ish"],
+      "Comment": "the [N -ish]A family (8)",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_childish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_child",
+      "Form": "childish",
+      "Segments": ["child", "ish"],
+      "Comment": "the [N -ish]A family (8)",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_trumpish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_trump",
+      "Form": "Trumpish",
+      "Segments": ["Trump", "ish"],
+      "Comment": "novel formation showing the base variable is open",
+      "Source": ["audring-2019[4.1]"]
+    },
+    {
+      "ID": "audring2019_careful",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "careful",
+      "Form": "careful",
+      "Segments": ["care", "ful"],
+      "Comment": "the [N -ful]A schema of the second-order schema (14)",
+      "Source": ["audring-2019[5]"]
+    },
+    {
+      "ID": "audring2019_careless",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "careless",
+      "Form": "careless",
+      "Segments": ["care", "less"],
+      "Comment": "the [N -less]A schema of the second-order schema (14)",
+      "Source": ["audring-2019[5]"]
+    },
+    {
+      "ID": "audring2019_clueless",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "clueless",
+      "Form": "clueless",
+      "Segments": ["clue", "less"],
+      "Comment": "an [N -less]A word with no [N -ful]A sister",
+      "Source": ["audring-2019[4.2.2]"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "like_a_boy",
+      "Name": "like a boy",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_fool",
+      "Name": "like a fool",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_child",
+      "Name": "like a child",
+      "Description": ""
+    },
+    {
+      "ID": "like_trump",
+      "Name": "like Trump",
+      "Description": ""
+    },
+    {
+      "ID": "careful",
+      "Name": "careful",
+      "Description": ""
+    },
+    {
+      "ID": "careless",
+      "Name": "careless",
+      "Description": ""
+    },
+    {
+      "ID": "clueless",
+      "Name": "clueless",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": [
+    {
+      "ID": "audring2019_boyish_foolish",
+      "Form_ID": "audring2019_boyish",
+      "Target_ID": "audring2019_foolish",
+      "Relation": "same_affix",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_boyish_childish",
+      "Form_ID": "audring2019_boyish",
+      "Target_ID": "audring2019_childish",
+      "Relation": "same_affix",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_foolish_childish",
+      "Form_ID": "audring2019_foolish",
+      "Target_ID": "audring2019_childish",
+      "Relation": "same_affix",
+      "Source": ["audring-2019[(8)]"]
+    },
+    {
+      "ID": "audring2019_careful_careless",
+      "Form_ID": "audring2019_careful",
+      "Target_ID": "audring2019_careless",
+      "Relation": "second_order_schema",
+      "Source": ["audring-2019[(14)]"]
+    }
+  ]
+}

--- a/Linglib/Data/Forms/Audring2019.lean
+++ b/Linglib/Data/Forms/Audring2019.lean
@@ -1,0 +1,120 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `Audring2019` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/Audring2019.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace Audring2019.Forms`.
+-/
+
+namespace Audring2019.Forms
+
+open Data.Forms
+
+def boyish : Form :=
+  { id := "audring2019_boyish"
+    languageId := "stan1293"
+    parameterId := "like_a_boy"
+    form := "boyish"
+    segments := ["boy", "ish"]
+    comment := "the [N -ish]A family (8)"
+    source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] }
+
+def foolish : Form :=
+  { id := "audring2019_foolish"
+    languageId := "stan1293"
+    parameterId := "like_a_fool"
+    form := "foolish"
+    segments := ["fool", "ish"]
+    comment := "the [N -ish]A family (8)"
+    source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] }
+
+def childish : Form :=
+  { id := "audring2019_childish"
+    languageId := "stan1293"
+    parameterId := "like_a_child"
+    form := "childish"
+    segments := ["child", "ish"]
+    comment := "the [N -ish]A family (8)"
+    source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] }
+
+def trumpish : Form :=
+  { id := "audring2019_trumpish"
+    languageId := "stan1293"
+    parameterId := "like_trump"
+    form := "Trumpish"
+    segments := ["Trump", "ish"]
+    comment := "novel formation showing the base variable is open"
+    source := [
+      ⟨"audring-2019", "4.1"⟩
+    ] }
+
+def careful : Form :=
+  { id := "audring2019_careful"
+    languageId := "stan1293"
+    parameterId := "careful"
+    form := "careful"
+    segments := ["care", "ful"]
+    comment := "the [N -ful]A schema of the second-order schema (14)"
+    source := [
+      ⟨"audring-2019", "5"⟩
+    ] }
+
+def careless : Form :=
+  { id := "audring2019_careless"
+    languageId := "stan1293"
+    parameterId := "careless"
+    form := "careless"
+    segments := ["care", "less"]
+    comment := "the [N -less]A schema of the second-order schema (14)"
+    source := [
+      ⟨"audring-2019", "5"⟩
+    ] }
+
+def clueless : Form :=
+  { id := "audring2019_clueless"
+    languageId := "stan1293"
+    parameterId := "clueless"
+    form := "clueless"
+    segments := ["clue", "less"]
+    comment := "an [N -less]A word with no [N -ful]A sister"
+    source := [
+      ⟨"audring-2019", "4.2.2"⟩
+    ] }
+
+def all : List Form := [boyish, foolish, childish, trumpish, careful, careless, clueless]
+
+def parameters : List Parameter := [
+  { id := "like_a_boy", name := "like a boy", description := "" },
+  { id := "like_a_fool", name := "like a fool", description := "" },
+  { id := "like_a_child", name := "like a child", description := "" },
+  { id := "like_trump", name := "like Trump", description := "" },
+  { id := "careful", name := "careful", description := "" },
+  { id := "careless", name := "careless", description := "" },
+  { id := "clueless", name := "clueless", description := "" }
+]
+
+def relations : List FormRelation := [
+  { id := "audring2019_boyish_foolish", formId := "audring2019_boyish", targetId := "audring2019_foolish", relation := "same_affix", source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] },
+  { id := "audring2019_boyish_childish", formId := "audring2019_boyish", targetId := "audring2019_childish", relation := "same_affix", source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] },
+  { id := "audring2019_foolish_childish", formId := "audring2019_foolish", targetId := "audring2019_childish", relation := "same_affix", source := [
+      ⟨"audring-2019", "(8)"⟩
+    ] },
+  { id := "audring2019_careful_careless", formId := "audring2019_careful", targetId := "audring2019_careless", relation := "second_order_schema", source := [
+      ⟨"audring-2019", "(14)"⟩
+    ] }
+]
+
+end Audring2019.Forms

--- a/Linglib/Data/Forms/Booij2010.json
+++ b/Linglib/Data/Forms/Booij2010.json
@@ -1,0 +1,49 @@
+{
+  "FormTable": [
+    {
+      "ID": "booij2010_carlessness",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "carlessness",
+      "Form": "carlessness",
+      "Segments": ["carless", "ness"],
+      "Comment": "the paper's novel coin (Time, October 5, 2009)",
+      "Source": ["booij-2010-compass"]
+    },
+    {
+      "ID": "booij2010_baldness",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "baldness",
+      "Form": "baldness",
+      "Segments": ["bald", "ness"],
+      "Comment": "a stored deadjectival noun of the opening word set",
+      "Source": ["booij-2010-compass"]
+    },
+    {
+      "ID": "booij2010_awareness",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "awareness",
+      "Form": "awareness",
+      "Segments": ["aware", "ness"],
+      "Comment": "the paper's example of an existing deadjectival noun",
+      "Source": ["booij-2010-compass"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "carlessness",
+      "Name": "the state of being without a car",
+      "Description": ""
+    },
+    {
+      "ID": "baldness",
+      "Name": "baldness",
+      "Description": ""
+    },
+    {
+      "ID": "awareness",
+      "Name": "awareness",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": []
+}

--- a/Linglib/Data/Forms/Booij2010.lean
+++ b/Linglib/Data/Forms/Booij2010.lean
@@ -1,0 +1,59 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `Booij2010` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/Booij2010.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace Booij2010.Forms`.
+-/
+
+namespace Booij2010.Forms
+
+open Data.Forms
+
+def carlessness : Form :=
+  { id := "booij2010_carlessness"
+    languageId := "stan1293"
+    parameterId := "carlessness"
+    form := "carlessness"
+    segments := ["carless", "ness"]
+    comment := "the paper's novel coin (Time, October 5, 2009)"
+    source := [
+      ⟨"booij-2010-compass", ""⟩
+    ] }
+
+def baldness : Form :=
+  { id := "booij2010_baldness"
+    languageId := "stan1293"
+    parameterId := "baldness"
+    form := "baldness"
+    segments := ["bald", "ness"]
+    comment := "a stored deadjectival noun of the opening word set"
+    source := [
+      ⟨"booij-2010-compass", ""⟩
+    ] }
+
+def awareness : Form :=
+  { id := "booij2010_awareness"
+    languageId := "stan1293"
+    parameterId := "awareness"
+    form := "awareness"
+    segments := ["aware", "ness"]
+    comment := "the paper's example of an existing deadjectival noun"
+    source := [
+      ⟨"booij-2010-compass", ""⟩
+    ] }
+
+def all : List Form := [carlessness, baldness, awareness]
+
+def parameters : List Parameter := [
+  { id := "carlessness", name := "the state of being without a car", description := "" },
+  { id := "baldness", name := "baldness", description := "" },
+  { id := "awareness", name := "awareness", description := "" }
+]
+
+def relations : List FormRelation := []
+
+end Booij2010.Forms

--- a/Linglib/Data/Forms/JackendoffAudring2020.json
+++ b/Linglib/Data/Forms/JackendoffAudring2020.json
@@ -1,0 +1,169 @@
+{
+  "FormTable": [
+    {
+      "ID": "jackendoffaudring2020_sing",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "sing",
+      "Form": "sing",
+      "Segments": ["s", "ɪ", "ŋ"],
+      "Comment": "stem; onset, nucleus, coda",
+      "Source": ["jackendoff-audring-2020[(24)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_sang",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "sing_past",
+      "Form": "sang",
+      "Segments": ["s", "æ", "ŋ"],
+      "Comment": "past tense; onset, nucleus, coda",
+      "Source": ["jackendoff-audring-2020[(24)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_string",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "string",
+      "Form": "string",
+      "Segments": ["str", "ɪ", "ŋ"],
+      "Comment": "stem; the onset cluster is one segment",
+      "Source": ["jackendoff-audring-2020[(26)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_strung",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "string_past",
+      "Form": "strung",
+      "Segments": ["str", "ʌ", "ŋ"],
+      "Comment": "past tense",
+      "Source": ["jackendoff-audring-2020[(26)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_sprech",
+      "Language_ID": "stan1295",
+      "Parameter_ID": "speak_stem",
+      "Form": "sprech-",
+      "Segments": ["ʃpr", "ɛ", "x"],
+      "Comment": "default stem of sprechen",
+      "Source": ["jackendoff-audring-2020[(43)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_sprich",
+      "Language_ID": "stan1295",
+      "Parameter_ID": "speak_stem_present_2_3_sg",
+      "Form": "sprich-",
+      "Segments": ["ʃpr", "ɪ", "x"],
+      "Comment": "special stem of the present 2nd and 3rd singular",
+      "Source": ["jackendoff-audring-2020[(43)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_piggish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_pig",
+      "Form": "piggish",
+      "Segments": ["pig", "ish"],
+      "Comment": "the -ish sisters of Section 7.8.1",
+      "Source": ["jackendoff-audring-2020[7.8.1 (5)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_childish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_child",
+      "Form": "childish",
+      "Segments": ["child", "ish"],
+      "Comment": "the -ish sisters of Section 7.8.1",
+      "Source": ["jackendoff-audring-2020[7.8.1 (5)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_sluggish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_slug",
+      "Form": "sluggish",
+      "Segments": ["slug", "ish"],
+      "Comment": "the -ish sisters of Section 7.8.1",
+      "Source": ["jackendoff-audring-2020[7.8.1 (5)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_foolish",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "like_a_fool",
+      "Form": "foolish",
+      "Segments": ["fool", "ish"],
+      "Comment": "the newly encountered sister of Section 7.8.1",
+      "Source": ["jackendoff-audring-2020[7.8.1]"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "sing",
+      "Name": "sing",
+      "Description": ""
+    },
+    {
+      "ID": "sing_past",
+      "Name": "sing (past)",
+      "Description": ""
+    },
+    {
+      "ID": "string",
+      "Name": "string",
+      "Description": ""
+    },
+    {
+      "ID": "string_past",
+      "Name": "string (past)",
+      "Description": ""
+    },
+    {
+      "ID": "speak_stem",
+      "Name": "speak (stem)",
+      "Description": ""
+    },
+    {
+      "ID": "speak_stem_present_2_3_sg",
+      "Name": "speak (present 2nd and 3rd singular stem)",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_pig",
+      "Name": "like a pig",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_child",
+      "Name": "like a child",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_slug",
+      "Name": "like a slug",
+      "Description": ""
+    },
+    {
+      "ID": "like_a_fool",
+      "Name": "like a fool",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": [
+    {
+      "ID": "jackendoffaudring2020_sing_sang",
+      "Form_ID": "jackendoffaudring2020_sing",
+      "Target_ID": "jackendoffaudring2020_sang",
+      "Relation": "past",
+      "Source": ["jackendoff-audring-2020[(24)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_string_strung",
+      "Form_ID": "jackendoffaudring2020_string",
+      "Target_ID": "jackendoffaudring2020_strung",
+      "Relation": "past",
+      "Source": ["jackendoff-audring-2020[(26)]"]
+    },
+    {
+      "ID": "jackendoffaudring2020_sprech_sprich",
+      "Form_ID": "jackendoffaudring2020_sprech",
+      "Target_ID": "jackendoffaudring2020_sprich",
+      "Relation": "present_2_3_sg_stem",
+      "Source": ["jackendoff-audring-2020[(45)]"]
+    }
+  ]
+}

--- a/Linglib/Data/Forms/JackendoffAudring2020.lean
+++ b/Linglib/Data/Forms/JackendoffAudring2020.lean
@@ -1,0 +1,153 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `JackendoffAudring2020` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/JackendoffAudring2020.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace JackendoffAudring2020.Forms`.
+-/
+
+namespace JackendoffAudring2020.Forms
+
+open Data.Forms
+
+def sing : Form :=
+  { id := "jackendoffaudring2020_sing"
+    languageId := "stan1293"
+    parameterId := "sing"
+    form := "sing"
+    segments := ["s", "ɪ", "ŋ"]
+    comment := "stem; onset, nucleus, coda"
+    source := [
+      ⟨"jackendoff-audring-2020", "(24)"⟩
+    ] }
+
+def sang : Form :=
+  { id := "jackendoffaudring2020_sang"
+    languageId := "stan1293"
+    parameterId := "sing_past"
+    form := "sang"
+    segments := ["s", "æ", "ŋ"]
+    comment := "past tense; onset, nucleus, coda"
+    source := [
+      ⟨"jackendoff-audring-2020", "(24)"⟩
+    ] }
+
+def string : Form :=
+  { id := "jackendoffaudring2020_string"
+    languageId := "stan1293"
+    parameterId := "string"
+    form := "string"
+    segments := ["str", "ɪ", "ŋ"]
+    comment := "stem; the onset cluster is one segment"
+    source := [
+      ⟨"jackendoff-audring-2020", "(26)"⟩
+    ] }
+
+def strung : Form :=
+  { id := "jackendoffaudring2020_strung"
+    languageId := "stan1293"
+    parameterId := "string_past"
+    form := "strung"
+    segments := ["str", "ʌ", "ŋ"]
+    comment := "past tense"
+    source := [
+      ⟨"jackendoff-audring-2020", "(26)"⟩
+    ] }
+
+def sprech : Form :=
+  { id := "jackendoffaudring2020_sprech"
+    languageId := "stan1295"
+    parameterId := "speak_stem"
+    form := "sprech-"
+    segments := ["ʃpr", "ɛ", "x"]
+    comment := "default stem of sprechen"
+    source := [
+      ⟨"jackendoff-audring-2020", "(43)"⟩
+    ] }
+
+def sprich : Form :=
+  { id := "jackendoffaudring2020_sprich"
+    languageId := "stan1295"
+    parameterId := "speak_stem_present_2_3_sg"
+    form := "sprich-"
+    segments := ["ʃpr", "ɪ", "x"]
+    comment := "special stem of the present 2nd and 3rd singular"
+    source := [
+      ⟨"jackendoff-audring-2020", "(43)"⟩
+    ] }
+
+def piggish : Form :=
+  { id := "jackendoffaudring2020_piggish"
+    languageId := "stan1293"
+    parameterId := "like_a_pig"
+    form := "piggish"
+    segments := ["pig", "ish"]
+    comment := "the -ish sisters of Section 7.8.1"
+    source := [
+      ⟨"jackendoff-audring-2020", "7.8.1 (5)"⟩
+    ] }
+
+def childish : Form :=
+  { id := "jackendoffaudring2020_childish"
+    languageId := "stan1293"
+    parameterId := "like_a_child"
+    form := "childish"
+    segments := ["child", "ish"]
+    comment := "the -ish sisters of Section 7.8.1"
+    source := [
+      ⟨"jackendoff-audring-2020", "7.8.1 (5)"⟩
+    ] }
+
+def sluggish : Form :=
+  { id := "jackendoffaudring2020_sluggish"
+    languageId := "stan1293"
+    parameterId := "like_a_slug"
+    form := "sluggish"
+    segments := ["slug", "ish"]
+    comment := "the -ish sisters of Section 7.8.1"
+    source := [
+      ⟨"jackendoff-audring-2020", "7.8.1 (5)"⟩
+    ] }
+
+def foolish : Form :=
+  { id := "jackendoffaudring2020_foolish"
+    languageId := "stan1293"
+    parameterId := "like_a_fool"
+    form := "foolish"
+    segments := ["fool", "ish"]
+    comment := "the newly encountered sister of Section 7.8.1"
+    source := [
+      ⟨"jackendoff-audring-2020", "7.8.1"⟩
+    ] }
+
+def all : List Form := [sing, sang, string, strung, sprech, sprich, piggish, childish, sluggish, foolish]
+
+def parameters : List Parameter := [
+  { id := "sing", name := "sing", description := "" },
+  { id := "sing_past", name := "sing (past)", description := "" },
+  { id := "string", name := "string", description := "" },
+  { id := "string_past", name := "string (past)", description := "" },
+  { id := "speak_stem", name := "speak (stem)", description := "" },
+  { id := "speak_stem_present_2_3_sg", name := "speak (present 2nd and 3rd singular stem)", description := "" },
+  { id := "like_a_pig", name := "like a pig", description := "" },
+  { id := "like_a_child", name := "like a child", description := "" },
+  { id := "like_a_slug", name := "like a slug", description := "" },
+  { id := "like_a_fool", name := "like a fool", description := "" }
+]
+
+def relations : List FormRelation := [
+  { id := "jackendoffaudring2020_sing_sang", formId := "jackendoffaudring2020_sing", targetId := "jackendoffaudring2020_sang", relation := "past", source := [
+      ⟨"jackendoff-audring-2020", "(24)"⟩
+    ] },
+  { id := "jackendoffaudring2020_string_strung", formId := "jackendoffaudring2020_string", targetId := "jackendoffaudring2020_strung", relation := "past", source := [
+      ⟨"jackendoff-audring-2020", "(26)"⟩
+    ] },
+  { id := "jackendoffaudring2020_sprech_sprich", formId := "jackendoffaudring2020_sprech", targetId := "jackendoffaudring2020_sprich", relation := "present_2_3_sg_stem", source := [
+      ⟨"jackendoff-audring-2020", "(45)"⟩
+    ] }
+]
+
+end JackendoffAudring2020.Forms

--- a/Linglib/Studies/Audring2019.lean
+++ b/Linglib/Studies/Audring2019.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Data.Forms.Audring2019
 import Linglib.Morphology.Construction.Schema
-import Linglib.Core.Order.Flat
+import Linglib.Core.Relation.FactorsThroughOn
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
 
 /-!
 # Audring (2019): Mothers or sisters? The encoding of morphological knowledge
@@ -22,15 +25,16 @@ specified word generates nothing but itself (`word_generates_iff`).
 
 The second-order schema `[N -ful]A ≈ [N -less]A` of (14) is a sister link between mother
 schemas, one description over a shared base variable read through two subscriptings. The
-coindexed base pairs *careful* with *careless* and not with *hopeless*
-(`careful_careless_pairs`, `not_careful_hopeless_pairs`). A mother of the two schemas would be
+coindexed base pairs *careful* with *careless* and not with *clueless*
+(`careful_careless_pairs`, `not_careful_clueless_pairs`). A mother of the two schemas would be
 the meet of their descriptions, which over these slots is empty (`fulLess_mother_eq_bot`) and
 so is instantiated by every word (`fulLess_mother_instantiates`): it states nothing the sisters
 do not, and cannot state the pairing they do.
 
 ## Implementation notes
 
-* Words are descriptions over a base slot and an affix slot on a flat carrier, one tier of the
+* The words are the CLDF forms of `Data/Forms/Audring2019.json`, read as slot-indexed segments
+  by `Data.Forms.Form.slots`: a base slot and an affix slot on the flat carrier, one tier of the
   paper's three; the same subscripting mechanism coindexes across tiers. The paper's remaining
   cases for a mother, an antonymic scale and the feature matrix of an inflectional paradigm,
   are not formalized.
@@ -45,42 +49,25 @@ namespace Audring2019
 
 open Morphology.Construction
 
-/-- The bases and affixes of the words cited: the *-ish* family of (8) with the novel base
-*Trump*, and the *-ful* and *-less* words of (14). -/
-inductive Atom
-  | boy
-  | fool
-  | child
-  | trump
-  | care
-  | hope
-  | ish
-  | ful
-  | less
-  deriving DecidableEq
-
-/-- The slots of a suffixed word. -/
-inductive Slot
-  | base
-  | affix
-  deriving DecidableEq
-
-/-- The fully specified word with base `b` and affix `a`. -/
-def word (b a : Atom) : Slot → Flat Atom
-  | .base => ↑b
-  | .affix => ↑a
+/-- A word with base `b` and affix `a` over the two slots base and affix. -/
+def word (b a : String) : Fin 2 → Flat String := ![↑b, ↑a]
 
 /-! ### The *-ish* family: sister links and their mother -/
 
 /-- The mother schema `[N -ish]A` of (8): the affix pinned, the base an open variable. -/
-def ishSchema : Schema Slot (Flat Atom) := ⟨λ | .base => ⊥ | .affix => ↑Atom.ish, {.base}⟩
+def ishSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ish"], {0}⟩
 
 /-- The stored family of (8). -/
-def ishFamily : Set (Slot → Flat Atom) := {word .boy .ish, word .fool .ish, word .child .ish}
+def ishFamily : Set (Fin 2 → Flat String) :=
+  {Forms.boyish.slots, Forms.foolish.slots, Forms.childish.slots}
 
-theorem ishSchema_instantiates (b : Atom) : ishSchema.Instantiates (word b .ish)
-  | .base => bot_le
-  | .affix => le_rfl
+/-- Any word whose affix is *-ish* instantiates the mother. -/
+theorem ishSchema_instantiates {w : Fin 2 → Flat String} (h : w 1 = ↑"ish") :
+    ishSchema.Instantiates w := by
+  intro i
+  fin_cases i
+  · exact bot_le
+  · exact h.ge
 
 /-- The variables of a sister link coindexing the affixes of two words. -/
 inductive AffixLink
@@ -90,10 +77,7 @@ inductive AffixLink
   deriving DecidableEq
 
 /-- The sister link at the affix: the two affix slots share a variable, the bases do not. -/
-def affixLink : Slot ⊕ Slot → AffixLink
-  | .inl .base => .base₁
-  | .inr .base => .base₂
-  | _ => .affix
+def affixLink : Fin 2 ⊕ Fin 2 → AffixLink := Sum.elim ![.base₁, .affix] ![.base₂, .affix]
 
 /-- The variables of a sister link coindexing the bases of two words. -/
 inductive BaseLink
@@ -103,46 +87,46 @@ inductive BaseLink
   deriving DecidableEq
 
 /-- The sister link at the base: the two base slots share a variable, the affixes do not. -/
-def baseLink : Slot ⊕ Slot → BaseLink
-  | .inl .affix => .affix₁
-  | .inr .affix => .affix₂
-  | _ => .base
+def baseLink : Fin 2 ⊕ Fin 2 → BaseLink := Sum.elim ![.base, .affix₁] ![.base, .affix₂]
 
-/-- Two *-ish* words are sisters at the affix: the pair factors through the link. -/
-theorem ish_affix_sisters (b b' : Atom) :
-    (Sum.elim (word b .ish) (word b' .ish)).FactorsThrough affixLink := by
-  rintro (p | p) (q | q) h <;> cases p <;> cases q <;> first | rfl | simp [affixLink] at h
+/-- *boyish* and *childish* are sisters at the affix: the pair factors through the link. -/
+theorem ish_affix_sisters :
+    (Sum.elim Forms.boyish.slots Forms.childish.slots).FactorsThrough affixLink := by
+  decide
 
-/-- Two *-ish* words with different bases cannot be coindexed at the base: the relation between
-*boy* and *child* is equivalence of function, not sameness, and no sister link states it. -/
-theorem not_base_sisters {b b' : Atom} (h : b ≠ b') :
-    ¬ (Sum.elim (word b .ish) (word b' .ish)).FactorsThrough baseLink :=
-  λ hf => h (Flat.coe_injective (@hf (.inl .base) (.inr .base) rfl))
+/-- *boyish* and *childish* cannot be coindexed at the base: the relation between *boy* and
+*child* is equivalence of function, not sameness, and no sister link states it. -/
+theorem not_base_sisters :
+    ¬ (Sum.elim Forms.boyish.slots Forms.childish.slots).FactorsThrough baseLink := by
+  decide
 
 /-- The mother relates every member of the family through its one variable. -/
-theorem ishSchema_relates {w : Slot → Flat Atom} (hw : w ∈ ishFamily) :
+theorem ishSchema_relates {w : Fin 2 → Flat String} (hw : w ∈ ishFamily) :
     ishSchema.Relates ishFamily w := by
   refine ⟨hw, ?_⟩
   simp only [ishFamily, Set.mem_insert_iff, Set.mem_singleton_iff] at hw
-  rcases hw with rfl | rfl | rfl <;> exact ishSchema_instantiates _
+  rcases hw with rfl | rfl | rfl <;> exact ishSchema_instantiates (by decide)
 
 /-- The mother is productive: its one variable is open. -/
 theorem ishSchema_isProductive : ishSchema.IsProductive := by
-  rintro (_ | _) h
-  exacts [Set.mem_singleton _, absurd h (by decide)]
+  intro i h
+  fin_cases i
+  · exact Set.mem_singleton_iff.2 rfl
+  · exact absurd h (by decide)
 
 /-- The mother generates the novel *Trumpish* with nothing stored. -/
-theorem ishSchema_generates_trumpish : ishSchema.Generates ∅ (word .trump .ish) :=
-  ishSchema_isProductive.generates_iff.2 (ishSchema_instantiates _)
+theorem ishSchema_generates_trumpish : ishSchema.Generates ∅ Forms.trumpish.slots :=
+  ishSchema_isProductive.generates_iff.2 (ishSchema_instantiates (by decide))
 
 /-- A fully specified word, taken as a schema, generates nothing but itself: a sister link
 between stored words licenses no novel word, and productivity needs a mother's variable. -/
-theorem word_generates_iff (b a : Atom) {Λ : Set (Slot → Flat Atom)} {w : Slot → Flat Atom} :
-    (⟨word b a, ∅⟩ : Schema Slot (Flat Atom)).Generates Λ w ↔ w = word b a := by
-  have hmax : ∀ v, IsMax (word b a v) := λ v => by cases v <;> exact Flat.isMax_coe _
+theorem word_generates_iff (b a : String) {Λ : Set (Fin 2 → Flat String)}
+    {w : Fin 2 → Flat String} :
+    (⟨word b a, ∅⟩ : Schema (Fin 2) (Flat String)).Generates Λ w ↔ w = word b a := by
+  have hmax : ∀ v, IsMax (word b a v) := λ v => by fin_cases v <;> exact Flat.isMax_coe _
   refine ⟨λ h => (Schema.instantiates_iff_eq_of_forall_isMax hmax).1 h.instantiates, ?_⟩
   rintro rfl
-  exact ⟨le_rfl, λ v hv _ => by cases v <;> exact absurd hv Flat.coe_ne_bot⟩
+  exact ⟨le_rfl, λ v hv _ => by fin_cases v <;> exact absurd hv Flat.coe_ne_bot⟩
 
 /-! ### The second-order schema `[N -ful]A ≈ [N -less]A` -/
 
@@ -154,54 +138,50 @@ inductive FulLessVar
   deriving DecidableEq
 
 /-- (14): the two schemas with their coindexed base as one description. -/
-def fulLess : Schema FulLessVar (Flat Atom) :=
-  ⟨λ | .base => ⊥ | .ful => ↑Atom.ful | .less => ↑Atom.less, {.base}⟩
+def fulLess : Schema FulLessVar (Flat String) :=
+  ⟨λ | .base => ⊥ | .ful => ↑"ful" | .less => ↑"less", {.base}⟩
 
 /-- The subscripting of the slots of `[N -ful]A` by the variables of (14). -/
-def fulSub : Slot → FulLessVar
-  | .base => .base
-  | .affix => .ful
+def fulSub : Fin 2 → FulLessVar := ![.base, .ful]
 
 /-- The subscripting of the slots of `[N -less]A` by the variables of (14). -/
-def lessSub : Slot → FulLessVar
-  | .base => .base
-  | .affix => .less
+def lessSub : Fin 2 → FulLessVar := ![.base, .less]
 
 /-- `[N -ful]A`: the description of (14) read at its own slots. -/
-def fulSchema : Schema Slot (Flat Atom) := fulLess.comap fulSub
+def fulSchema : Schema (Fin 2) (Flat String) := fulLess.comap fulSub
 
 /-- `[N -less]A`: the description of (14) read at its own slots. -/
-def lessSchema : Schema Slot (Flat Atom) := fulLess.comap lessSub
+def lessSchema : Schema (Fin 2) (Flat String) := fulLess.comap lessSub
 
 /-- The variables of (14) filled by base `b`. -/
-def fulLessWord (b : Atom) : FulLessVar → Flat Atom
+def fulLessWord (b : String) : FulLessVar → Flat String
   | .base => ↑b
-  | .ful => ↑Atom.ful
-  | .less => ↑Atom.less
+  | .ful => ↑"ful"
+  | .less => ↑"less"
 
 /-- *careful* and *careless* are a paired instantiation of (14): same base, sister affixes. -/
 theorem careful_careless_pairs :
     fulLess.InstantiatesAt (Sum.elim fulSub lessSub)
-      (Sum.elim (word .care .ful) (word .care .less)) :=
-  ⟨fulLessWord .care, λ v => by cases v <;> first | exact bot_le | exact le_rfl,
-    funext λ p => by rcases p with p | p <;> cases p <;> rfl⟩
+      (Sum.elim Forms.careful.slots Forms.careless.slots) :=
+  ⟨fulLessWord "care", λ v => by cases v <;> first | exact bot_le | exact le_rfl,
+    funext λ p => by rcases p with p | p <;> fin_cases p <;> decide⟩
 
-/-- *careful* and *hopeless* are not: the coindexed base is filled differently. -/
-theorem not_careful_hopeless_pairs :
+/-- *careful* and *clueless* are not: the coindexed base is filled differently. -/
+theorem not_careful_clueless_pairs :
     ¬ fulLess.InstantiatesAt (Sum.elim fulSub lessSub)
-      (Sum.elim (word .care .ful) (word .hope .less)) :=
-  λ h => by
-    simpa [word] using (Schema.instantiatesAt_elim_iff.1 h).2.2.2.2 .base .base rfl
+      (Sum.elim Forms.careful.slots Forms.clueless.slots) :=
+  λ h => absurd ((Schema.instantiatesAt_elim_iff.1 h).2.2.2.2 0 0 rfl) (by decide)
 
 /-- A mother of the two schemas would be the meet of their descriptions, which over these slots
 is empty: nothing but the categories, which the slots do not record. -/
 theorem fulLess_mother_eq_bot : fulSchema.body ⊓ lessSchema.body = ⊥ := by
   funext v
-  cases v <;> decide
+  fin_cases v <;> decide
 
 /-- The mother is instantiated by every word: it states nothing the sisters do not. -/
-theorem fulLess_mother_instantiates (w : Slot → Flat Atom) :
-    (⟨fulSchema.body ⊓ lessSchema.body, ∅⟩ : Schema Slot (Flat Atom)).Instantiates w := by
+theorem fulLess_mother_instantiates (w : Fin 2 → Flat String) :
+    (⟨fulSchema.body ⊓ lessSchema.body, ∅⟩ : Schema (Fin 2) (Flat String)).Instantiates
+      w := by
   show fulSchema.body ⊓ lessSchema.body ≤ w
   rw [fulLess_mother_eq_bot]
   exact bot_le

--- a/Linglib/Studies/Booij2010.lean
+++ b/Linglib/Studies/Booij2010.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Data.Forms.Booij2010
 import Linglib.Morphology.Construction.Schema
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
 import Linglib.Morphology.Construction.Inheritance
 import Linglib.Core.Order.Flat
 
@@ -45,76 +48,56 @@ affix slot is lexically fixed as `-ness` and whose base slot is an open
 (deadjectival) variable. A concrete adjective unified into the base slot yields a
 `-ness` noun. -/
 
-/-- The morphs and (deadjectival) bases the `-ness` schema handles. -/
-inductive Atom | ness | aware | carless | bald
-  deriving DecidableEq, Fintype
-
-/-- The two slots of the `-ness` construction. -/
-inductive NessSlot | base | affix
-  deriving DecidableEq, Fintype
-
-/-- The `-ness` schema: the affix slot pinned to `-ness`, the base slot an open
-deadjectival variable (`⊥`). -/
-def nessSchema : Schema NessSlot (Flat Atom) where
-  body
-    | .base => ⊥
-    | .affix => ↑Atom.ness
-  opens := {.base}
-
-/-- `carlessness`: the paper's novel coin (Time, October 5, 2009), the
-adjective `carless` unified into the base slot. -/
-def carlessness : NessSlot → Flat Atom
-  | .base => ↑Atom.carless
-  | .affix => ↑Atom.ness
-
-/-- `baldness`: a stored `-ness` noun of the paper's opening word set. -/
-def baldness : NessSlot → Flat Atom
-  | .base => ↑Atom.bald
-  | .affix => ↑Atom.ness
-
-/-- `awareness`: the paper's example of an existing deadjectival noun, stored. -/
-def awareness : NessSlot → Flat Atom
-  | .base => ↑Atom.aware
-  | .affix => ↑Atom.ness
+/-- The `-ness` schema over the two slots of a `-ness` noun, base and affix: the affix slot
+pinned to `-ness`, the base slot an open deadjectival variable (`⊥`). -/
+def nessSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ness"], {0}⟩
 
 /-- Any filling whose affix slot is `-ness` instantiates the schema: the base slot
 is open, the affix slot's constraint is met. -/
-theorem ness_instantiates {w : NessSlot → Flat Atom} (h : w .affix = ↑Atom.ness) :
+theorem ness_instantiates {w : Fin 2 → Flat String} (h : w 1 = ↑"ness") :
     nessSchema.Instantiates w := by
-  intro i; cases i
+  intro i
+  fin_cases i
   · exact bot_le
-  · rw [h]; exact le_rfl
+  · exact h.ge
 
-/-- `carlessness` instantiates the `-ness` schema. -/
-theorem carlessness_instantiates : nessSchema.Instantiates carlessness :=
-  ness_instantiates rfl
+/-- `carlessness`, the paper's novel coin (Time, October 5, 2009), instantiates the
+`-ness` schema. -/
+theorem carlessness_instantiates : nessSchema.Instantiates Forms.carlessness.slots :=
+  ness_instantiates (by decide)
 
 /-- Instantiation as unification: unifying the schema description with
 `carlessness` returns `carlessness` — [booij-2010-compass]'s worked example. -/
 theorem carlessness_unifies :
-    PartialUnify.unify nessSchema.body carlessness = some carlessness :=
+    PartialUnify.unify nessSchema.body Forms.carlessness.slots =
+      some Forms.carlessness.slots :=
   nessSchema.instantiates_iff_unify.mp carlessness_instantiates
 
-/-- The stored `-ness` nouns, feeding the schema's two roles. -/
-def nessLexicon : Set (NessSlot → Flat Atom) := {baldness, awareness}
+/-- The stored `-ness` nouns of the paper's opening word set, feeding the schema's two
+roles. -/
+def nessLexicon : Set (Fin 2 → Flat String) :=
+  {Forms.baldness.slots, Forms.awareness.slots}
 
 /-- The `-ness` schema is productive: its one variable, the base slot, is open. -/
 theorem nessSchema_isProductive : nessSchema.IsProductive := by
-  rintro (_ | _) h
-  exacts [Set.mem_singleton _, absurd h (by decide)]
+  intro i h
+  fin_cases i
+  · exact Set.mem_singleton_iff.2 rfl
+  · exact absurd h (by decide)
 
 /-- The schema licenses the novel coin `carlessness` over the stored nouns: the
 open base slot takes the unlisted adjective, and the affix slot is a constant.
 Being productive, the schema generates every instance whatever is stored. -/
-theorem carlessness_generates : nessSchema.Generates nessLexicon carlessness :=
+theorem carlessness_generates :
+    nessSchema.Generates nessLexicon Forms.carlessness.slots :=
   nessSchema_isProductive.generates_iff.2 carlessness_instantiates
 
 /-- The relational role over the same schema: `awareness` is listed and
 instantiates it — the paper's two functions of a schema, expressing the
 predictable properties of existing words and coining new ones, on one
 schema and one lexicon. -/
-theorem awareness_related : nessSchema.Relates nessLexicon awareness :=
-  ⟨Set.mem_insert_of_mem _ rfl, ness_instantiates rfl⟩
+theorem awareness_related : nessSchema.Relates nessLexicon Forms.awareness.slots :=
+  ⟨Set.mem_insert_of_mem _ rfl, ness_instantiates (by decide)⟩
 
 /-! ### The compound hierarchy
 

--- a/Linglib/Studies/JackendoffAudring2020.lean
+++ b/Linglib/Studies/JackendoffAudring2020.lean
@@ -344,7 +344,8 @@ theorem ablaut_words :
         (Sum.elim Forms.sprech.slots Forms.sprich.slots) := by
   simp only [singSang, stringStrung, ablaut, nucleusPair_iff]
   refine ⟨⟨by decide, by decide, ?_⟩, ⟨by decide, by decide, ?_⟩,
-    ⟨bot_le, bot_le, ?_⟩⟩ <;> intro q hq <;> fin_cases q <;> first | decide | exact (hq rfl).elim
+    ⟨bot_le, bot_le, ?_⟩⟩
+  all_goals intro q hq; fin_cases q <;> first | decide | exact (hq rfl).elim
 
 /-! ### The present-tense cells of (45) as a morphome -/
 

--- a/Linglib/Studies/JackendoffAudring2020.lean
+++ b/Linglib/Studies/JackendoffAudring2020.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.Examples.JackendoffAudring2020
+import Linglib.Data.Forms.JackendoffAudring2020
 import Linglib.Morphology.Construction.Schema
 import Linglib.Morphology.Construction.SameExcept
 import Linglib.Morphology.Construction.Inheritance
@@ -6,6 +7,8 @@ import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Core.Order.Flat
 import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
 
 /-!
 # Jackendoff and Audring (2020): The Texture of the Lexicon
@@ -48,6 +51,9 @@ common (`instantiates_ishSchema_iff`), and absorbs a newly encountered sister
 * The cycle theorem renders the paradox of Objection 10 through the well-foundedness of an
   inheritance hierarchy; the book argues from the above-and-below paradox and makes no
   well-foundedness claim.
+* The syllables and the *-ish* adjectives are the CLDF forms of
+  `Data/Forms/JackendoffAudring2020.json`, read as slot-indexed segments by
+  `Data.Forms.Form.slots`; a syllable's positions are onset, nucleus and coda.
 * The correspondence between a schema's variable coindices and the constant coindices of its
   instances, left unformalized in Section 4.13.2, is the subscripting of
   `Morphology.Construction.Schema.InstantiatesAt`; a productive variable is one marked open
@@ -243,34 +249,6 @@ theorem ismist_pairs (b : B) (i : I) :
 
 /-! ### Ablaut as a link off the nucleus -/
 
-/-- Syllable positions. -/
-inductive Pos
-  | onset
-  | nucleus
-  | coda
-  deriving DecidableEq
-
-/-- Phonological material of the verbs cited: the onsets *s-*, *str-*, *spr-*, the nuclei /ɪ/,
-/æ/, /ʌ/, /ɛ/, /a/ and the codas /ŋ/, /x/. -/
-inductive Seg
-  | s
-  | str
-  | shpr
-  | ih
-  | ae
-  | uh
-  | eh
-  | ah
-  | ng
-  | x
-  deriving DecidableEq
-
-/-- A monosyllable: its onset, nucleus and coda. -/
-def syllable (o n c : Seg) : Pos → Flat Seg
-  | .onset => ↑o
-  | .nucleus => ↑n
-  | .coda => ↑c
-
 /-- The variables of the ablaut schemas: the onset and the coda, shared by stem and past, and
 the two nuclei. -/
 inductive NucleusVar
@@ -280,98 +258,93 @@ inductive NucleusVar
   | past
   deriving DecidableEq
 
-/-- The subscripting of the stem's positions by the variables of the ablaut schemas. -/
-def stemSub : Pos → NucleusVar
-  | .onset => .onset
-  | .nucleus => .stem
-  | .coda => .coda
+/-- The subscripting of the stem's three positions, onset, nucleus and coda, by the variables
+of the ablaut schemas. -/
+def stemSub : Fin 3 → NucleusVar := ![.onset, .stem, .coda]
 
 /-- The subscripting of the past's positions by the variables of the ablaut schemas. -/
-def pastSub : Pos → NucleusVar
-  | .onset => .onset
-  | .nucleus => .past
-  | .coda => .coda
+def pastSub : Fin 3 → NucleusVar := ![.onset, .past, .coda]
 
 /-- Two syllables linked at every position but the nucleus, whose description pins the nuclei
 `v` and `w`, `⊥` for an open nucleus: the shape of the ablaut schemas (25) and (26) and of the
 German present-tense schema (45). -/
-def nucleusPair (v w : Flat Seg) : Schema NucleusVar (Flat Seg) :=
+def nucleusPair (v w : Flat String) : Schema NucleusVar (Flat String) :=
   ⟨λ | .stem => v | .past => w | _ => ⊥, {.onset, .coda}⟩
 
 /-- The general ablaut schema (25): both nuclei open. -/
-def ablaut : Schema NucleusVar (Flat Seg) := nucleusPair ⊥ ⊥
+def ablaut : Schema NucleusVar (Flat String) := nucleusPair ⊥ ⊥
 
 /-- The *sing*/*sang* subschema (26): /ɪ/ in the stem, /æ/ in the past. -/
-def singSang : Schema NucleusVar (Flat Seg) := nucleusPair ↑Seg.ih ↑Seg.ae
+def singSang : Schema NucleusVar (Flat String) := nucleusPair ↑"ɪ" ↑"æ"
 
 /-- The *string*/*strung* subschema, (26) with /ʌ/ for /æ/. -/
-def stringStrung : Schema NucleusVar (Flat Seg) := nucleusPair ↑Seg.ih ↑Seg.uh
+def stringStrung : Schema NucleusVar (Flat String) := nucleusPair ↑"ɪ" ↑"ʌ"
 
 /-- A paired instantiation of a nucleus pair is a stem and a past that are the same except at
 the nucleus, with the pinned nuclei. -/
-theorem nucleusPair_iff {v w : Flat Seg} {s p : Pos → Flat Seg} :
+theorem nucleusPair_iff {v w : Flat String} {s p : Fin 3 → Flat String} :
     (nucleusPair v w).InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p) ↔
-      v ≤ s .nucleus ∧ w ≤ p .nucleus ∧ SameExcept s p {.nucleus} := by
+      v ≤ s 1 ∧ w ≤ p 1 ∧ SameExcept s p {1} := by
   rw [Schema.instantiatesAt_elim_iff]
   constructor
   · rintro ⟨hs, hp, -, -, h⟩
-    refine ⟨hs .nucleus, hp .nucleus, λ q hq => h q q ?_⟩
-    cases q <;> first | rfl | simp at hq
+    refine ⟨hs 1, hp 1, λ q hq => h q q ?_⟩
+    fin_cases q <;> first | rfl | exact (hq rfl).elim
   · rintro ⟨hv, hw, h⟩
     refine ⟨λ q => ?_, λ q => ?_, λ a b hab => ?_, λ a b hab => ?_, λ a b hab => ?_⟩
-    · cases q <;> simp [nucleusPair, stemSub, hv]
-    · cases q <;> simp [nucleusPair, pastSub, hw]
-    · cases a <;> cases b <;> first | rfl | exact absurd hab (by decide)
-    · cases a <;> cases b <;> first | rfl | exact absurd hab (by decide)
-    · cases a <;> cases b <;> first | exact absurd hab (by decide) | exact h (by simp)
+    · fin_cases q <;> first | exact bot_le | exact hv
+    · fin_cases q <;> first | exact bot_le | exact hw
+    · fin_cases a <;> fin_cases b <;> first | rfl | exact absurd hab (by decide)
+    · fin_cases a <;> fin_cases b <;> first | rfl | exact absurd hab (by decide)
+    · fin_cases a <;> fin_cases b <;>
+        first | exact absurd hab (by decide) | exact h (by simp)
 
 /-- (25) pairs exactly the stems and pasts that are the same except at the nucleus. -/
-theorem ablaut_pairs_iff {s p : Pos → Flat Seg} :
-    ablaut.InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p) ↔
-      SameExcept s p {.nucleus} := by
+theorem ablaut_pairs_iff {s p : Fin 3 → Flat String} :
+    ablaut.InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p) ↔ SameExcept s p {1} := by
   simp [ablaut, nucleusPair_iff]
 
 /-- A subschema with pinned nuclei is a special case of the general ablaut schema: every pair
 of (26) is a pair of (25). -/
-theorem ablaut_pairs_of_nucleusPair {v w : Flat Seg} {s p : Pos → Flat Seg}
+theorem ablaut_pairs_of_nucleusPair {v w : Flat String} {s p : Fin 3 → Flat String}
     (h : (nucleusPair v w).InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p)) :
     ablaut.InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p) :=
   ablaut_pairs_iff.2 (nucleusPair_iff.1 h).2.2
 
 /-- A pair under a subschema with distinct pinned nuclei is a nucleus contrast: the same
 except at the nucleus, where both are present and differ. -/
-theorem contrast_of_nucleusPair {v w : Seg} (hvw : v ≠ w) {s p : Pos → Flat Seg}
+theorem contrast_of_nucleusPair {v w : String} (hvw : v ≠ w) {s p : Fin 3 → Flat String}
     (h : (nucleusPair ↑v ↑w).InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p)) :
-    Contrast s p {.nucleus} := by
+    Contrast s p {1} := by
   obtain ⟨hv, hw, hs⟩ := nucleusPair_iff.1 h
   rw [Flat.coe_le_iff] at hv hw
   refine ⟨hs, λ q hq => ?_⟩
   rw [Set.mem_singleton_iff] at hq
   subst hq
   rw [hv, hw]
-  exact ⟨Option.some_ne_none v, Option.some_ne_none w, λ h => hvw (Flat.coe_injective h)⟩
+  exact ⟨Flat.coe_ne_bot, Flat.coe_ne_bot, λ h => hvw (Flat.coe_injective h)⟩
 
 /-- Two syllables differing only in their nucleus are a paired instantiation of the subschema
 pinning those nuclei. -/
-theorem syllable_pairs (o v w c : Seg) :
+theorem syllable_pairs (o v w c : String) :
     (nucleusPair ↑v ↑w).InstantiatesAt (Sum.elim stemSub pastSub)
-      (Sum.elim (syllable o v c) (syllable o w c)) := by
+      (Sum.elim ![↑o, ↑v, ↑c] ![↑o, ↑w, ↑c]) := by
   rw [nucleusPair_iff]
   refine ⟨le_rfl, le_rfl, λ q hq => ?_⟩
-  simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hq
-  cases q <;> simp_all [syllable]
+  fin_cases q <;> first | rfl | exact (hq rfl).elim
 
 /-- *sing*/*sang*, (24), under (26); *string*/*strung* under its subschema; and the German
 *sprech-*/*sprich-* of (43) under the shape of (45). -/
-example :
+theorem ablaut_words :
     singSang.InstantiatesAt (Sum.elim stemSub pastSub)
-        (Sum.elim (syllable .s .ih .ng) (syllable .s .ae .ng)) ∧
+        (Sum.elim Forms.sing.slots Forms.sang.slots) ∧
       stringStrung.InstantiatesAt (Sum.elim stemSub pastSub)
-        (Sum.elim (syllable .str .ih .ng) (syllable .str .uh .ng)) ∧
+        (Sum.elim Forms.string.slots Forms.strung.slots) ∧
       ablaut.InstantiatesAt (Sum.elim stemSub pastSub)
-        (Sum.elim (syllable .shpr .eh .x) (syllable .shpr .ih .x)) :=
-  ⟨syllable_pairs .., syllable_pairs ..,
-    ablaut_pairs_of_nucleusPair (syllable_pairs .shpr .eh .ih .x)⟩
+        (Sum.elim Forms.sprech.slots Forms.sprich.slots) := by
+  simp only [singSang, stringStrung, ablaut, nucleusPair_iff]
+  refine ⟨⟨by decide, by decide, ?_⟩, ⟨by decide, by decide, ?_⟩,
+    ⟨bot_le, bot_le, ?_⟩⟩ <;> intro q hq <;> fin_cases q <;> first | decide | exact (hq rfl).elim
 
 /-! ### The present-tense cells of (45) as a morphome -/
 
@@ -533,54 +506,32 @@ theorem walk_syncretism :
 
 /-! ### Structural Intersection -/
 
-/-- The bases and the affix of the *-ish* adjectives (5) of Section 7.8.1, with *fool* for the
-newly encountered sister. -/
-inductive IshAtom
-  | pig
-  | child
-  | slug
-  | fool
-  | ish
-  deriving DecidableEq
-
-/-- The slots of an *-ish* adjective. -/
-inductive IshSlot
-  | base
-  | affix
-  deriving DecidableEq
-
-/-- The *-ish* adjective on base `b`. -/
-def ishWord (b : IshAtom) : IshSlot → Flat IshAtom
-  | .base => ↑b
-  | .affix => ↑IshAtom.ish
-
-/-- The schema (6): the affix pinned, the base a variable. -/
-def ishSchema : Schema IshSlot (Flat IshAtom) :=
-  ⟨λ | .base => ⊥ | .affix => ↑IshAtom.ish, {.base}⟩
+/-- The schema (6) over the two slots of an *-ish* adjective, base and affix: the affix pinned,
+the base a variable. -/
+def ishSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ish"], {0}⟩
 
 /-- Structural Intersection constructs the schema: the description of (6) is the meet of the
 three sisters of (5), keeping what they share and leaving a variable where they differ. -/
 theorem ishSchema_body_eq_inf :
-    ishSchema.body = ishWord .pig ⊓ ishWord .child ⊓ ishWord .slug := by
+    ishSchema.body = Forms.piggish.slots ⊓ Forms.childish.slots ⊓ Forms.sluggish.slots := by
   funext v
-  cases v <;> decide
+  fin_cases v <;> decide
 
 /-- The schema is the most the sisters have in common: a description is instantiated by all
 three exactly when it is instantiated by the schema's description. -/
-theorem instantiates_ishSchema_iff {s : Schema IshSlot (Flat IshAtom)} :
+theorem instantiates_ishSchema_iff {s : Schema (Fin 2) (Flat String)} :
     s.Instantiates ishSchema.body ↔
-      s.Instantiates (ishWord .pig) ∧ s.Instantiates (ishWord .child) ∧
-        s.Instantiates (ishWord .slug) := by
+      s.Instantiates Forms.piggish.slots ∧ s.Instantiates Forms.childish.slots ∧
+        s.Instantiates Forms.sluggish.slots := by
   rw [ishSchema_body_eq_inf, Schema.instantiates_inf_iff, Schema.instantiates_inf_iff,
     and_assoc]
 
-theorem ishSchema_le_foolish : ishSchema.body ≤ ishWord .fool
-  | .base => bot_le
-  | .affix => le_rfl
+theorem ishSchema_le_foolish : ishSchema.body ≤ Forms.foolish.slots := λ i => by
+  fin_cases i <;> decide
 
 /-- A newly encountered sister intersected with the schema yields the schema again, the
 Minimal Generalization Learner's fixed point. -/
-theorem ishSchema_inf_foolish : ishSchema.body ⊓ ishWord .fool = ishSchema.body :=
+theorem ishSchema_inf_foolish : ishSchema.body ⊓ Forms.foolish.slots = ishSchema.body :=
   inf_eq_left.2 ishSchema_le_foolish
 
 end JackendoffAudring2020

--- a/references.bib
+++ b/references.bib
@@ -32767,7 +32767,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Data/Examples/JackendoffAudring2020.json;Morphology/Construction/Inheritance.lean;Morphology/Construction/SameExcept.lean;Morphology/Construction/Schema.lean;Studies/ChanShen2026.lean;Studies/JackendoffAudring2020.lean;Syntax/Category/WhModifier.lean}
+  sources   = {Data/Examples/JackendoffAudring2020.json;Morphology/Construction/Inheritance.lean;Morphology/Construction/SameExcept.lean;Morphology/Construction/Schema.lean;Studies/ChanShen2026.lean;Studies/JackendoffAudring2020.lean;Syntax/Category/WhModifier.lean;Data/Forms/JackendoffAudring2020.json}
 }
 
 @incollection{plotkin-1970,
@@ -32822,7 +32822,7 @@
   doi       = {10.3366/word.2019.0150},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Studies/Audring2019.lean}
+  sources   = {Studies/Audring2019.lean;Data/Forms/Audring2019.json}
 }
 
 @article{booij-2019,
@@ -32875,7 +32875,7 @@
   doi       = {10.1111/j.1749-818X.2010.00213.x},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Schema.lean;Studies/Booij2010.lean}
+  sources   = {Morphology/Construction/Schema.lean;Studies/Booij2010.lean;Data/Forms/Booij2010.json}
 }
 
 @book{blevins-2016,


### PR DESCRIPTION
Migrates the three remaining morphology studies onto the CLDF `Data/Forms/` datasets introduced in #3046.

- `Booij2010`: the *-ness* nouns; `Audring2019`: the *-ish* family, *Trumpish*, *careful*/*careless*/*clueless* (the negative pair now uses the paper's own *clueless*); `JackendoffAudring2020`: the six ablaut syllables and the four *-ish* adjectives of Section 7.8.1.
- Slots are `Fin n` positions and words are `Forms.*.slots` on `Flat String`; every per-study segment inductive is gone, every theorem keeps its statement. Sister-link facts in `Audring2019` are now closed by `decide` through the `FactorsThrough` instance.
- Not migrated, by design: the *assassin* and *-ism*/*-ist* entries and Haspelmath's *hammer* items are multi-tier descriptions with semantics and category, not `FormTable` rows.