### PR TITLE
refactor(Syntax/Minimalist): spine extension order

### DIFF
--- a/Linglib/Studies/Keine2019.lean
+++ b/Linglib/Studies/Keine2019.lean
@@ -10,8 +10,9 @@ is on the searches of probes, each terminated by a category of its own, its hori
 rather than on domains or on the moving element. With category inheritance within an extended
 projection ((43)) a clause's label collects the categories it projects, so a clause is opaque to a
 probe exactly when its label contains the horizon, and Upward Entailment ((40)), that larger
-clauses are at least as opaque, is the Horizon Inheritance Theorem ((45), (46)):
-`upward_entailment`. The Hindi probes of (48) and (57), φ-agreement and A-movement on T⁰ with
+clauses are at least as opaque, is the Horizon Inheritance Theorem ((45), (46)), transparency
+antitone in the extension order of clause sizes (`sizes_le`). The Hindi probes of (48) and (57),
+φ-agreement and A-movement on T⁰ with
 horizon T, wh-licensing on C⁰ with horizon C and Ā-movement on C⁰ without one, derive the
 transparency table (58) with its three locality types (`transparency_table`) and with it the
 generalizations (21) and (23) on long-distance agreement; English hyperraising is A-movement
@@ -51,13 +52,11 @@ def vpLabel : List Cat := ClauseSpine.vP.projectedHeads
 
 /-! ### Horizons and Upward Entailment (Section 4.1) -/
 
-/-- (45), (46): Upward Entailment follows from category inheritance. A probe blocked by a clause
-is blocked by every larger one, whatever its horizon, since the larger clause's label extends the
-smaller one's. -/
-theorem upward_entailment (p : Probe.Profile) :
-    (p.transparentToLabel vpLabel = false → p.transparentToLabel tpLabel = false) ∧
-      (p.transparentToLabel tpLabel = false → p.transparentToLabel cpLabel = false) :=
-  ⟨upward_entailment_label p _ _ (by decide), upward_entailment_label p _ _ (by decide)⟩
+/-- (45), (46): Upward Entailment follows from category inheritance. The three clause sizes
+stand in the extension order, TP extending vP and CP extending TP, and transparency is antitone
+in that order for every probe (`Probe.Profile.transparentToLabel_antitone`), so a probe blocked
+by a clause is blocked by every larger one. -/
+theorem sizes_le : ClauseSpine.vP ≤ .tP ∧ ClauseSpine.tP ≤ .cP := by decide
 
 /-! ### The Hindi probes (Section 4.2) -/
 

--- a/Linglib/Studies/Keine2020.lean
+++ b/Linglib/Studies/Keine2020.lean
@@ -7,7 +7,8 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 This file formalizes the horizons theory of [keine-2020] as it parameterizes probes across
 languages. A probe's search terminates at its horizon category ((33)); labels are bilateral within
 an extended projection, so a clause is opaque to a probe exactly when its label contains the
-horizon, and Upward Entailment holds for every probe (`upward_entailment`). Hindi's four clause
+horizon, and Upward Entailment holds for every probe, transparency being antitone in the
+extension order of clause sizes (`sizes_le`). Hindi's four clause
 sizes ((168)) follow from the probes of (219), with NmlzP and CP incomparable, the one transparent
 to wh-licensing and the other to Ā-movement (`hindi_table`, `nmlzP_cP_incomparable`), and the
 A-Movement–Agreement Generalization ((231)) from the two probes on T⁰ sharing a horizon. English
@@ -47,21 +48,13 @@ def row (sizes : List ClauseSpine) (p : Probe.Profile) : List Bool :=
 
 /-! ### Upward Entailment -/
 
-/-- Larger clauses are at least as opaque, for every probe, since a clause's label extends the
-labels of the smaller clauses of its extended projection: TP extends vP, CP and NmlzP extend
-TP, ForceP extends CP. -/
-theorem upward_entailment (p : Probe.Profile) :
-    (p.transparentToLabel ClauseSpine.vP.projectedHeads = false →
-        p.transparentToLabel ClauseSpine.tP.projectedHeads = false) ∧
-      (p.transparentToLabel ClauseSpine.tP.projectedHeads = false →
-        p.transparentToLabel ClauseSpine.cP.projectedHeads = false ∧
-          p.transparentToLabel ClauseSpine.nmlzP.projectedHeads = false) ∧
-      (p.transparentToLabel ClauseSpine.cP.projectedHeads = false →
-        p.transparentToLabel ClauseSpine.forceP.projectedHeads = false) :=
-  ⟨upward_entailment_label p _ _ (by decide),
-    λ h => ⟨upward_entailment_label p _ _ (by decide) h,
-      upward_entailment_label p _ _ (by decide) h⟩,
-    upward_entailment_label p _ _ (by decide)⟩
+/-- The book's clause sizes in the extension order: TP extends vP, CP and NmlzP extend TP,
+ForceP extends CP. Transparency is antitone in this order for every probe
+(`Probe.Profile.transparentToLabel_antitone`), which is Upward Entailment. -/
+theorem sizes_le :
+    ClauseSpine.vP ≤ .tP ∧ ClauseSpine.tP ≤ .cP ∧ ClauseSpine.tP ≤ .nmlzP ∧
+      ClauseSpine.cP ≤ .forceP := by
+  decide
 
 /-! ### Hindi (Chapters 2 and 3) -/
 

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
@@ -71,6 +71,16 @@ def ClauseSpine.extend (spine : ClauseSpine) (heads : List Cat) : ClauseSpine :=
 def ClauseSpine.above (spine : ClauseSpine) (c : Cat) : List Cat :=
   (spine.projectedHeads.reverse.takeWhile (· != c)).reverse
 
+/-- The extension order: a spine lies below another when the other projects every head it
+does, as the clause sizes of one extended projection do ([keine-2020]'s bilateral labels). -/
+instance : Preorder ClauseSpine where
+  le s t := s.projectedHeads ⊆ t.projectedHeads
+  le_refl _ := List.Subset.refl _
+  le_trans _ _ _ := List.Subset.trans
+
+instance (s t : ClauseSpine) : Decidable (s ≤ t) :=
+  decidable_of_iff (∀ c ∈ s.projectedHeads, c ∈ t.projectedHeads) Iff.rfl
+
 -- ============================================================================
 -- § 3: Named Spines
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Probe/Profile.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Profile.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Syntax.Minimalist.Probe.Basic
+import Mathlib.Order.Monotone.Defs
 
 /-!
 # Probe Profiles ([keine-2019], [keine-2020])
@@ -503,6 +504,15 @@ theorem upward_entailment_label (p : Probe.Profile)
     rw [List.any_eq_true] at h_opaque ⊢
     obtain ⟨x, hx_mem, hx_eq⟩ := h_opaque
     exact ⟨x, h_sub x hx_mem, hx_eq⟩
+
+/-- Upward Entailment: for every probe, transparency is antitone in the extension order of
+clause spines, since a spine's label contains the horizon whenever a spine below it does. -/
+theorem Probe.Profile.transparentToLabel_antitone (p : Probe.Profile) :
+    Antitone λ s : ClauseSpine => p.transparentToLabel s.projectedHeads :=
+  λ s _ h => Bool.le_iff_imp.mpr λ ht => by
+    cases hs : p.transparentToLabel s.projectedHeads
+    · exact absurd (upward_entailment_label p _ _ h hs) (by simp [ht])
+    · exact hs
 
 -- ============================================================================
 -- § 8: Height-Locality Connection ([keine-2020] (20)/(33))


### PR DESCRIPTION
Upward Entailment stated once, as an order fact: `ClauseSpine` gets the extension preorder (`s ≤ t` when `t` projects every head `s` does, with a `decide`-able instance) and `Probe.Profile.transparentToLabel_antitone` says transparency is antitone in it for every probe. Keine2019 and Keine2020 then record only which of their clause sizes extend which (`sizes_le`, by `decide`) in place of the hand-enumerated implication lists.