### PR TITLE
refactor(Morphology): rename Construction to ConstructionMorphology

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1274,8 +1274,6 @@ import Linglib.Fragments.Yoruba.Phonology
 import Linglib.Fragments.Yoruba.Relativization
 import Linglib.Fragments.ZarmaSonrai.Negation
 import Linglib.Fragments.Zulu.Phonology
-import Linglib.Morphology.Construction.Inheritance
-import Linglib.Morphology.Construction.Schema
 import Linglib.Morphology.DistributedMorphology.Allosemy
 import Linglib.Morphology.DistributedMorphology.Basic
 import Linglib.Morphology.DistributedMorphology.Categorizer.Basic

--- a/Linglib/Morphology/ConstructionMorphology/Inheritance.lean
+++ b/Linglib/Morphology/ConstructionMorphology/Inheritance.lean
@@ -43,7 +43,7 @@ its multi-parent default-inheritance form lives in
 - `Hierarchy.parent_asymm` — no 2-cycle: nodes cannot be each other's parent
 -/
 
-namespace Morphology.Construction
+namespace ConstructionMorphology
 
 variable {ι β : Type*} {parent : ι → Option ι} {att : ι → Option β}
 
@@ -248,4 +248,4 @@ private def flies : Animal → Option Bool
 example : animalHierarchy.value flies .ostrich = some false ∧
     animalHierarchy.value flies .canary = some true := by decide
 
-end Morphology.Construction
+end ConstructionMorphology

--- a/Linglib/Morphology/ConstructionMorphology/Schema.lean
+++ b/Linglib/Morphology/ConstructionMorphology/Schema.lean
@@ -69,7 +69,7 @@ Marking a constant slot as open has no effect.
 * [albright-hayes-2003]
 -/
 
-namespace Morphology.Construction
+namespace ConstructionMorphology
 
 variable {V P Q P₁ P₂ α : Type*}
 
@@ -364,4 +364,4 @@ end OrderBot
 
 end RelationalLinks
 
-end Morphology.Construction
+end ConstructionMorphology

--- a/Linglib/Studies/Audring2019.lean
+++ b/Linglib/Studies/Audring2019.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Data.Forms.Audring2019
-import Linglib.Morphology.Construction.Schema
+import Linglib.Morphology.ConstructionMorphology.Schema
 import Linglib.Core.Relation.FactorsThroughOn
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
@@ -47,7 +47,7 @@ do not, and cannot state the pairing they do.
 
 namespace Audring2019
 
-open Morphology.Construction
+open ConstructionMorphology
 
 /-- A word with base `b` and affix `a` over the two slots base and affix. -/
 def word (b a : String) : Fin 2 → Flat String := ![↑b, ↑a]

--- a/Linglib/Studies/Booij2010.lean
+++ b/Linglib/Studies/Booij2010.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Data.Forms.Booij2010
-import Linglib.Morphology.Construction.Schema
+import Linglib.Morphology.ConstructionMorphology.Schema
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
-import Linglib.Morphology.Construction.Inheritance
+import Linglib.Morphology.ConstructionMorphology.Inheritance
 import Linglib.Core.Order.Flat
 
 /-!
@@ -15,7 +15,7 @@ import Linglib.Core.Order.Flat
 
 [booij-2010-compass] analyzes complex words as constructions — pairings of form
 and meaning — licensed by constructional schemas in a hierarchical lexicon. This
-file instantiates the `Morphology/Construction/` substrate as that CxM engine
+file instantiates the `Morphology/ConstructionMorphology/` substrate as that CxM engine
 over small `Flat` carriers: the deadjectival `-ness` schema and its
 unification-instantiation (`carless` unified with the schema is `carlessness`),
 generation of a novel `-ness` noun, the compound hierarchy with right-headed
@@ -39,7 +39,7 @@ unification (`on-` prefixation composed with `V-baar`).
 
 namespace Booij2010
 
-open Morphology.Construction
+open ConstructionMorphology
 
 /-! ### The deadjectival `-ness` schema
 

--- a/Linglib/Studies/Booij2019.lean
+++ b/Linglib/Studies/Booij2019.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Data.Forms.Booij2019
-import Linglib.Morphology.Construction.Schema
+import Linglib.Morphology.ConstructionMorphology.Schema
 import Linglib.Morphology.Morphotactics.CVTemplate
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Tactic.FinCases
@@ -43,7 +43,7 @@ an adjective with the comparative template over the same three consonants
 
 namespace Booij2019
 
-open Morphology Morphology.Construction
+open Morphology ConstructionMorphology
 
 /-! ### The occupation template `C₁aC₂C₂aaC₃` -/
 

--- a/Linglib/Studies/Haspelmath2025Root.lean
+++ b/Linglib/Studies/Haspelmath2025Root.lean
@@ -1,7 +1,7 @@
 import Mathlib.Order.WithBot
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Data.UD.Basic
-import Linglib.Morphology.Construction.Schema
+import Linglib.Morphology.ConstructionMorphology.Schema
 import Linglib.Morphology.Root.Basic
 import Linglib.Morphology.Root.Consonantal
 
@@ -23,7 +23,7 @@ sharing the skeleton k-t-b are four roots (`arabic_four_roots`) and the German a
 §6 adopts the heterosemy view: `hammer` (noun) and `hammer` (verb) are two roots with one
 shape (`hammer_two_roots`), related by the sister schemas of (21) (`nounVerb`, one
 description over shared variables read through two subscriptings,
-`Morphology.Construction.Schema.InstantiatesAt`), which the pair instantiates
+`ConstructionMorphology.Schema.InstantiatesAt`), which the pair instantiates
 (`hammer_sisters`) and
 `hammer`/`dance` does not.
 
@@ -301,7 +301,7 @@ inductive RootVar
 
 /-- (21): the sister schemas `X (noun)` and `X (verb)` as one description over their
 variables, the categories pinned, the meanings and the shared shape open. -/
-def nounVerb : Construction.Schema RootVar Slot where
+def nounVerb : ConstructionMorphology.Schema RootVar Slot where
   body
     | .nounCategory => ↑(Value.category .object)
     | .verbCategory => ↑(Value.category .action)
@@ -321,10 +321,10 @@ def verbSub : Tier → RootVar
   | .phonology => .shape
 
 /-- (21a) `X (noun)`: an object meaning related to `X`, a noun, with the open shape `Y`. -/
-def nounSchema : Construction.Schema Tier Slot := nounVerb.comap nounSub
+def nounSchema : ConstructionMorphology.Schema Tier Slot := nounVerb.comap nounSub
 
 /-- (21b) `X (verb)`: doing in relation to `X`, a verb, with the open shape `Y`. -/
-def verbSchema : Construction.Schema Tier Slot := nounVerb.comap verbSub
+def verbSchema : ConstructionMorphology.Schema Tier Slot := nounVerb.comap verbSub
 
 /-- (20a): `hammer` (noun). -/
 def hammerNoun : Tier → Slot
@@ -365,6 +365,6 @@ theorem hammer_dance_not_sisters :
     ¬ nounVerb.InstantiatesAt (Sum.elim nounSub verbSub) (Sum.elim hammerNoun danceVerb) :=
   λ h => by
     simpa [hammerNoun, danceVerb] using
-      (Construction.Schema.instantiatesAt_elim_iff.1 h).2.2.2.2 .phonology .phonology rfl
+      (ConstructionMorphology.Schema.instantiatesAt_elim_iff.1 h).2.2.2.2 .phonology .phonology rfl
 
 end Haspelmath2025Root

--- a/Linglib/Studies/JackendoffAudring2020.lean
+++ b/Linglib/Studies/JackendoffAudring2020.lean
@@ -1,7 +1,7 @@
 import Linglib.Data.Examples.JackendoffAudring2020
 import Linglib.Data.Forms.JackendoffAudring2020
-import Linglib.Morphology.Construction.Schema
-import Linglib.Morphology.Construction.Inheritance
+import Linglib.Morphology.ConstructionMorphology.Schema
+import Linglib.Morphology.ConstructionMorphology.Inheritance
 import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Core.Order.Flat
@@ -43,7 +43,7 @@ common (`instantiates_ishSchema_iff`), and absorbs a newly encountered sister
 * Lexical entries and schemas are slot-indexed descriptions over a flat carrier, a constant
   above `⊥` and a variable at `⊥`; a relational coindex is a variable subscripting a slot of
   each entry, which a paired instantiation fills alike
-  (`Morphology.Construction.Schema.InstantiatesAt`). The containment of
+  (`ConstructionMorphology.Schema.InstantiatesAt`). The containment of
   the semantics of *assassinate* in that of *assassin*, (41), is rendered as a shared slot.
 * The zero exponence of the present and the infinitive of *walk*, (19), the double
   coindexation of Section 4.3, appears as a syncretism of the paradigm (`walk_syncretism`).
@@ -55,7 +55,7 @@ common (`instantiates_ishSchema_iff`), and absorbs a newly encountered sister
   `Data.Forms.Form.slots`; a syllable's positions are onset, nucleus and coda.
 * The correspondence between a schema's variable coindices and the constant coindices of its
   instances, left unformalized in Section 4.13.2, is the subscripting of
-  `Morphology.Construction.Schema.InstantiatesAt`; a productive variable is one marked open
+  `ConstructionMorphology.Schema.InstantiatesAt`; a productive variable is one marked open
   over and above its attested fillers.
 
 ## References
@@ -69,7 +69,7 @@ common (`instantiates_ishSchema_iff`), and absorbs a newly encountered sister
 
 namespace JackendoffAudring2020
 
-open Morphology Morphology.Construction
+open Morphology ConstructionMorphology
 
 /-! ### Sister words -/
 

--- a/references.bib
+++ b/references.bib
@@ -32767,7 +32767,7 @@
   subfield  = {morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Data/Examples/JackendoffAudring2020.json;Morphology/Construction/Inheritance.lean;Morphology/Construction/Schema.lean;Studies/ChanShen2026.lean;Studies/JackendoffAudring2020.lean;Syntax/Category/WhModifier.lean;Data/Forms/JackendoffAudring2020.json}
+  sources   = {Data/Examples/JackendoffAudring2020.json;Morphology/ConstructionMorphology/Inheritance.lean;Morphology/ConstructionMorphology/Schema.lean;Studies/ChanShen2026.lean;Studies/JackendoffAudring2020.lean;Syntax/Category/WhModifier.lean;Data/Forms/JackendoffAudring2020.json}
 }
 
 @incollection{plotkin-1970,
@@ -32781,7 +32781,7 @@
   pages     = {153--163},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Schema.lean}
+  sources   = {Morphology/ConstructionMorphology/Schema.lean}
 }
 
 @article{culicover-jackendoff-2012,
@@ -32795,7 +32795,7 @@
   doi       = {10.1353/lan.2012.0031},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Schema.lean}
+  sources   = {Morphology/ConstructionMorphology/Schema.lean}
 }
 
 @book{booij-2010,
@@ -32808,7 +32808,7 @@
   isbn      = {978-0-19-957192-5},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Schema.lean;Studies/JackendoffAudring2020.lean}
+  sources   = {Morphology/ConstructionMorphology/Schema.lean;Studies/JackendoffAudring2020.lean}
 }
 
 @article{audring-2019,
@@ -32875,7 +32875,7 @@
   doi       = {10.1111/j.1749-818X.2010.00213.x},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Schema.lean;Studies/Booij2010.lean;Data/Forms/Booij2010.json}
+  sources   = {Morphology/ConstructionMorphology/Schema.lean;Studies/Booij2010.lean;Data/Forms/Booij2010.json}
 }
 
 @book{blevins-2016,
@@ -32901,7 +32901,7 @@
   url       = {https://aclanthology.org/J96-2002/},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Inheritance.lean}
+  sources   = {Morphology/ConstructionMorphology/Inheritance.lean}
 }
 
 @book{brown-hippisley-2012,
@@ -32914,7 +32914,7 @@
   isbn      = {978-1-107-00574-7},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Morphology/Construction/Inheritance.lean}
+  sources   = {Morphology/ConstructionMorphology/Inheritance.lean}
 }
 
 % REF: Huang, C.-T. James and Masao Ochi. 2004. Syntax of the hell: Two types


### PR DESCRIPTION
`Morphology/Construction/` read as a directory of constructions; the theory directories are named for the theory (`DistributedMorphology/`, `Nanosyntax/`). Moves `Schema.lean` and `Inheritance.lean` to `Morphology/ConstructionMorphology/` under the root namespace `ConstructionMorphology`, mirroring `DistributedMorphology`.

- Five studies re-imported and re-opened; bib `sources` updated; the two old `Linglib.lean` lines dropped (moved modules), none added.
- No content change.