### PR TITLE
refactor(Studies/Klein1980): header in register, forward references cut

### DIFF
--- a/Linglib/Studies/Klein1980.lean
+++ b/Linglib/Studies/Klein1980.lean
@@ -3,103 +3,68 @@ import Linglib.Studies.Kamp1975
 
 /-!
 # Klein (1980): A Semantics for Positive and Comparative Adjectives
-[klein-1980]
 
-*Linguistics and Philosophy* 4(1): 1–45.
+This file formalizes [klein-1980]'s degree-free semantics of gradable adjectives: an adjective
+is a predicate whose extension is fixed relative to a comparison class, the comparative is
+derived from the positive by quantifying over comparison classes, and degrees, where they are
+wanted, are recovered as equivalence classes rather than posited. The substrate's delineation
+vocabulary (`Degree.Delineation`) supplies comparison classes, the induced ordering,
+monotonicity and the modifiers *very* and *fairly*; this file adds the paper's claims about
+that apparatus. A delineation that switches criterion with the comparison class, the paper's
+nonlinear adjective *clever*, orders two entities each above the other, which monotonicity
+forbids (`clever_nonlinear`, `monotone_not_nonlinear`). *Very* narrows the comparison class to
+the positive extension, entailing the base adjective for measure-induced delineations while the
+converse fails (`measureDelineation_very_entails_base`, `very_strictly_stronger`). Degrees are
+the classes of nondistinct entities and agree with measure equality (`kleinDegree`,
+`kleinDegree_measureDelineation`), a non-trivial delineation discriminates in every comparison
+class with two members (`IsNontrivialDelineation`), and under monotonicity the ordering is a
+strict weak order, asymmetric and negatively transitive, from which transitivity and almost
+connectedness follow (`klein_strict_weak_order`, `klein_transitivity_derived`,
+`klein_almost_connected`). Klein's *as … as* is [kamp-1975]'s *at least as* over all
+completions (`kleinPreorder_eq_kampPreorder`).
 
-## Overview
+## Implementation notes
 
-The foundational "degreeless" alternative to degree semantics. Gradable
-adjectives are simple predicates (type `⟨e,t⟩`) whose extension is
-determined relative to a **comparison class** — a contextually supplied
-set of entities. The comparative is derived FROM the positive via
-existential quantification over comparison classes, not the other way
-around (contra Cresswell's degree theory).
+* The measure-induced delineation, its monotonicity and its ordering-to-degree equivalence are
+  substrate (`measureDelineation`, `ordering_iff_degree`); the study states what the paper
+  adds on top of them.
 
-## Core Contributions Formalized
+## References
 
-1. **Nonlinear delineation** (§ 1): concrete witness showing that non-monotone
-   delineations ("clever") produce cyclic orderings — the hallmark of
-   nonlinear adjectives
-2. **Monotone → not nonlinear** (§ 1): monotonicity excludes cyclic orderings
-3. **Very as CC-narrower** (§ 2): `very A → A` for measure-induced
-   delineations (by transitivity of `<`, not domain restriction)
-4. **Klein's degree definition** (§ 3): degrees as equivalence classes under
-   nondistinctness (eq 62), shown equivalent to measure equality
-5. **Non-triviality condition** (§ 5): delineations must discriminate in
-   any CC with ≥2 members
-6. **Main theorem: strict weak order** (§ 6): under monotonicity, the ordering
-   is asymmetric + negatively transitive — a strict weak order. Transitivity
-   and almost-connectedness follow as corollaries.
-7. **Kamp→Klein bridge** (§ 7): `kleinPreorder` = `kampPreorder` over Set.univ
-
-The measure-induced delineation bridge (monotonicity, ordering↔degree
-equivalence) lives in the theory layer: `Delineation.lean` §10.
-
-## Connections
-
-- **Theory layer**: `Semantics/Degree/Delineation.lean`
-  (comparison classes, ordering, monotonicity, very/fairly, less/as)
-- **Kamp (1975)**: `Studies/Kamp1975.lean` §3 (Kamp→Klein lineage,
-  `kampPreorder` = `kleinPreorder` over Set.univ)
-- **Fine (1975)**: `Studies/Fine1975.lean` (supervaluation ↔ delineation duality)
-- **Kennedy (2007)**: `Studies/Kennedy2007.lean` (degree-based alternative)
-- **Morphisms**: `Semantics/Degree/Hom.lean` (Klein ← Kennedy ← Measurement)
-- **Bochnak (2015)**: `Studies/Bochnak2015.lean` — typological attestation that
-  the Klein-style degree-free type ⟨e, t⟩ is realized by a natural language
-  (Washo, Hokan), not just a notational alternative for English-style data.
+* [klein-1980]
+* [kamp-1975]
 -/
 
 namespace Klein1980
 
 open Degree.Delineation
 
--- ════════════════════════════════════════════════════
--- § 1. Nonlinear Delineation Witness
--- ════════════════════════════════════════════════════
+/-! ### Linear and nonlinear adjectives (§2.2, §3.3)
 
-/-! Klein's distinction between LINEAR and NONLINEAR adjectives
-    (§2.2, §3.3): "tall" induces a total ordering (single criterion,
-    monotone delineation), while "clever" can produce cycles (multiple
-    criteria, non-monotone delineation).
+*Tall* is linear, a single criterion and a monotone delineation, while *clever* can produce
+cycles: which of two entities counts as clever depends on which criterion the comparison class
+makes salient. -/
 
-    We construct a minimal witness: two entities whose "cleverness"
-    depends on which criterion is salient, determined by which other
-    entities are present in the comparison class. -/
+/-- Two entities, Jude and Mona. -/
+inductive Clever2
+  | j
+  | m
 
-inductive Clever2 | j | m  -- Jude, Mona
-
-/-- A non-monotone delineation modeling "clever" with two conflicting
-    criteria: j (Jude) is clever when m (Mona) is absent from the CC
-    (math criterion dominates), m is clever when j is absent (social
-    criterion dominates). When both are present, criteria conflict
-    and neither is classified as clever. -/
+/-- A non-monotone delineation for *clever* with two conflicting criteria: Jude is clever when
+Mona is absent from the comparison class, Mona when Jude is, and neither when both are present.
+-/
 def cleverDel : ComparisonClass Clever2 → Clever2 → Prop
   | C, .j => Clever2.m ∉ C
   | C, .m => Clever2.j ∉ C
 
-/-- The clever delineation is nonlinear: both `j >_{cc} m` and
-    `m >_{cc} j` hold for cc = {j, m}. This is Klein's key
-    prediction for multi-criteria adjectives. -/
-theorem clever_nonlinear :
-    IsNonlinearDelineation cleverDel := by
-  refine ⟨{Clever2.j, Clever2.m}, Clever2.j, Clever2.m, ?_, ?_⟩
-  · -- j > m: take X = {j}. j is clever in {j} (m absent), m is not (j absent? no, j present)
-    refine ⟨{Clever2.j}, Set.singleton_subset_iff.mpr (Set.mem_insert _ _), ?_, ?_⟩
-    · show Clever2.m ∉ ({Clever2.j} : Set Clever2)
-      simp [Set.mem_singleton_iff]
-    · show ¬(Clever2.j ∉ ({Clever2.j} : Set Clever2))
-      simp
-  · -- m > j: take X = {m}
-    refine ⟨{Clever2.m}, Set.singleton_subset_iff.mpr (Set.mem_insert_of_mem _ rfl), ?_, ?_⟩
-    · show Clever2.j ∉ ({Clever2.m} : Set Clever2)
-      simp [Set.mem_singleton_iff]
-    · show ¬(Clever2.m ∉ ({Clever2.m} : Set Clever2))
-      simp
+/-- The clever delineation is nonlinear: in the class of both, each is ordered above the other.
+-/
+theorem clever_nonlinear : IsNonlinearDelineation cleverDel :=
+  ⟨{Clever2.j, Clever2.m}, Clever2.j, Clever2.m,
+    ⟨{Clever2.j}, by simp, by simp [cleverDel], by simp [cleverDel]⟩,
+    ⟨{Clever2.m}, by simp, by simp [cleverDel], by simp [cleverDel]⟩⟩
 
-/-- Monotone delineations cannot be nonlinear. This connects Klein's
-    monotonicity constraint to the linear/nonlinear typology: requiring
-    monotonicity is exactly what forces a total ordering. -/
+/-- Monotone delineations cannot be nonlinear: monotonicity is what forces a total ordering. -/
 theorem monotone_not_nonlinear {Entity : Type*}
     (delineation : ComparisonClass Entity → Entity → Prop)
     (hmono : IsMonotoneDelineation delineation Set.univ)
@@ -107,54 +72,15 @@ theorem monotone_not_nonlinear {Entity : Type*}
   obtain ⟨_, u, u', ⟨X₁, _, hu₁, hnu'₁⟩, ⟨X₂, _, hu'₂, hnu₂⟩⟩ := hnn
   exact hnu₂ (hmono X₁ X₂ (Set.mem_univ _) (Set.mem_univ _) u u' hu₁ hnu'₁ hu'₂)
 
--- ════════════════════════════════════════════════════
--- § 2. Very as CC-Narrower: Concrete Bridge
--- ════════════════════════════════════════════════════
+/-! ### *Very* narrows the comparison class (eq. 42)
 
-/-! Klein's `very` (eq 42) narrows the comparison class to the positive
-    extension. Under the degree correspondence, this is equivalent to
-    raising the threshold. We verify this for a measure-induced
-    delineation: if x is very-tall, then x exceeds some entity that is
-    ITSELF taller than some entity — a transitive chain witnessing a
-    higher effective threshold.
+*Very* narrows the comparison class to the positive extension. The substrate's
+`very_entails_base` needs Klein's domain restriction, that a delineation classifies only members
+of its class; measure-induced delineations lack it, yet `very A → A` holds for them by
+transitivity of the measure order, while being tall does not make one very tall. -/
 
-    The entailment `very A → A` is proved in the theory layer
-    (`Delineation.very_entails_base`). Here we show the converse fails:
-    being tall does not entail being very tall. -/
-
-/-- Very-tall does NOT entail tall-among-the-tall vacuously: there
-    exist entities that are tall but not very tall. This is the
-    "fairly tall" zone — tall relative to everyone, but not tall
-    relative to the tall people. -/
-theorem very_strictly_stronger :
-    ∃ (E : Type) (del : ComparisonClass E → E → Prop)
-      (C : ComparisonClass E) (x : E),
-      del C x ∧ ¬ veryDelineation del C x := by
-  refine ⟨Fin 3,
-    fun C x => ∃ y ∈ C, (y : Fin 3) < x,
-    Set.univ,
-    (1 : Fin 3),
-    ⟨0, Set.mem_univ _, by omega⟩,
-    ?_⟩
-  intro ⟨y, hy, hlt⟩
-  simp only [Set.mem_ofPred_eq] at hy
-  obtain ⟨z, _, hlt_z⟩ := hy
-  omega
-
--- ════════════════════════════════════════════════════
--- § 3. Very → Base for Measure-Induced Delineations
--- ════════════════════════════════════════════════════
-
-/-! The theory-layer `very_entails_base` requires Klein's domain
-    restriction (delineation only classifies CC members).
-    Measure-induced delineations do NOT satisfy this restriction
-    (entities outside C can be classified), but `very → base` holds
-    anyway: if x exceeds some member of {tall people}, and that
-    member exceeds some member of C, then by transitivity of `<`,
-    x exceeds some member of C. -/
-
-/-- `very A → A` for measure-induced delineations: the witness
-    chain `z ∈ C, μ z < μ y, μ y < μ x` gives `μ z < μ x`. -/
+/-- `very A → A` for measure-induced delineations: the witness chain `z ∈ C`, `μ z < μ y`,
+`μ y < μ x` gives `μ z < μ x`. -/
 theorem measureDelineation_very_entails_base {E D : Type*} [LinearOrder D]
     (μ : E → D) (C : ComparisonClass E) (x : E)
     (hv : veryDelineation (measureDelineation μ) C x) :
@@ -163,52 +89,48 @@ theorem measureDelineation_very_entails_base {E D : Type*} [LinearOrder D]
   obtain ⟨z, hz, hlt'⟩ := hy
   exact ⟨z, hz, lt_trans hlt' hlt⟩
 
--- ════════════════════════════════════════════════════
--- § 4. Klein's Degree Definition (§4.2, eq 62)
--- ════════════════════════════════════════════════════
+/-- The converse fails: an entity tall relative to everyone need not be tall relative to the
+tall, the zone of *fairly tall*. -/
+theorem very_strictly_stronger :
+    ∃ (E : Type) (del : ComparisonClass E → E → Prop) (C : ComparisonClass E) (x : E),
+      del C x ∧ ¬ veryDelineation del C x := by
+  refine ⟨Fin 3, λ C x => ∃ y ∈ C, (y : Fin 3) < x, Set.univ, (1 : Fin 3),
+    ⟨0, Set.mem_univ _, by omega⟩, ?_⟩
+  intro ⟨y, hy, hlt⟩
+  simp only [Set.mem_ofPred_eq] at hy
+  obtain ⟨z, _, hlt_z⟩ := hy
+  omega
 
-/-! Klein §4.2 shows that degrees are DISPENSABLE but RECOVERABLE:
-    the degree of u in c is the equivalence class of entities that
-    are nondistinct from u. For linear adjectives (where nondistinct
-    = equivalent), this yields: `degree(u) = {u' : u ≈_{c,ζ} u'}`.
+/-! ### Degrees recovered (§4.2, eq. 62)
 
-    Degrees thus EMERGE from comparison classes rather than being
-    primitive. Cresswell (1976) goes the other way: degrees are
-    primitive and the comparative is defined in terms of them. Klein
-    shows both directions are available: the delineation framework
-    can reconstruct degrees whenever it needs them. -/
+Degrees are dispensable but recoverable: the degree of `u` in a comparison class is the class
+of entities nondistinct from `u`, so degrees emerge from comparison classes rather than being
+primitive. -/
 
-/-- Klein's degree of u at comparison class cc (eq 62):
-    the set of entities nondistinct from u. For measure-induced
-    delineations, this reduces to `{u' : μ(u') = μ(u)}` — the
-    usual notion of "same degree". -/
-def kleinDegree {E : Type*}
-    (delineation : ComparisonClass E → E → Prop)
+/-- Klein's degree of `u` at a comparison class: the entities nondistinct from `u`. -/
+def kleinDegree {E : Type*} (delineation : ComparisonClass E → E → Prop)
     (cc : ComparisonClass E) (u : E) : Set E :=
   {u' | nondistinct delineation cc u u'}
 
-/-- Klein's degree agrees with measure equality: for measure-induced
-    delineations, two entities have the same Klein degree iff they
-    have the same measure value. -/
+/-- For measure-induced delineations, two entities share a Klein degree iff they share a
+measure value. -/
 theorem kleinDegree_measureDelineation {E D : Type*} [LinearOrder D]
-    (μ : E → D) (cc : ComparisonClass E) (a b : E)
-    (ha : a ∈ cc) (hb : b ∈ cc) :
+    (μ : E → D) (cc : ComparisonClass E) (a b : E) (ha : a ∈ cc) (hb : b ∈ cc) :
     b ∈ kleinDegree (measureDelineation μ) cc a ↔ μ a = μ b := by
   simp only [kleinDegree, Set.mem_ofPred_eq, nondistinct, measureDelineation]
   constructor
   · intro h
     by_contra hne
     rcases lt_or_gt_of_ne hne with hlt | hgt
-    · -- μ a < μ b: witness ∃ y ∈ {a,b}, μ y < μ b (y=a), derive ∃ y ∈ {a,b}, μ y < μ a
-      have := (h {a, b} (by intro x hx; rcases hx with rfl | rfl <;> assumption)
+    · have := (h {a, b} (by intro x hx; rcases hx with rfl | rfl <;> assumption)
         (Set.mem_insert _ _) (Set.mem_insert_of_mem _ rfl)).mpr ⟨a, Set.mem_insert _ _, hlt⟩
       obtain ⟨y, hy, hlt_y⟩ := this
       rcases hy with rfl | rfl
       · exact absurd hlt_y (lt_irrefl _)
       · exact absurd hlt_y (not_lt.mpr (le_of_lt hlt))
-    · -- μ b < μ a: witness ∃ y ∈ {a,b}, μ y < μ a (y=b), derive ∃ y ∈ {a,b}, μ y < μ b
-      have := (h {a, b} (by intro x hx; rcases hx with rfl | rfl <;> assumption)
-        (Set.mem_insert _ _) (Set.mem_insert_of_mem _ rfl)).mp ⟨b, Set.mem_insert_of_mem _ rfl, hgt⟩
+    · have := (h {a, b} (by intro x hx; rcases hx with rfl | rfl <;> assumption)
+        (Set.mem_insert _ _) (Set.mem_insert_of_mem _ rfl)).mp
+          ⟨b, Set.mem_insert_of_mem _ rfl, hgt⟩
       obtain ⟨y, hy, hlt_y⟩ := this
       rcases hy with rfl | rfl
       · exact absurd hlt_y (not_lt.mpr (le_of_lt hgt))
@@ -216,113 +138,61 @@ theorem kleinDegree_measureDelineation {E D : Type*} [LinearOrder D]
   · intro heq X _ _ _
     simp [heq]
 
--- ════════════════════════════════════════════════════
--- § 5. Non-Triviality Condition
--- ════════════════════════════════════════════════════
+/-! ### Non-triviality (§5) -/
 
-/-! Klein requires delineation functions to be **non-trivial**: for any
-    comparison class with at least two members, the delineation must
-    actually discriminate — some entities are positive and some are not.
-    This prevents degenerate delineations where everything (or nothing)
-    is in the positive extension. -/
-
-/-- Klein's non-triviality: for any CC with ≥2 members, there exist
-    entities that the delineation separates. -/
+/-- A delineation is non-trivial when it discriminates in every comparison class with at least
+two members: some member is positive and some is not. -/
 def IsNontrivialDelineation {Entity : Type*}
     (delineation : ComparisonClass Entity → Entity → Prop) : Prop :=
-  ∀ C : ComparisonClass Entity,
-    (∃ a b : Entity, a ∈ C ∧ b ∈ C ∧ a ≠ b) →
+  ∀ C : ComparisonClass Entity, (∃ a b : Entity, a ∈ C ∧ b ∈ C ∧ a ≠ b) →
     ∃ u v : Entity, u ∈ C ∧ v ∈ C ∧ delineation C u ∧ ¬ delineation C v
 
--- ════════════════════════════════════════════════════
--- § 6. Klein's Main Theorem: Strict Weak Order
--- ════════════════════════════════════════════════════
+/-! ### The ordering is a strict weak order (§6)
 
-/-! Klein's central structural result: under monotonicity, the
-    context-relative ordering is a **strict weak order** — asymmetric
-    and negatively transitive. This is what licenses his claim that
-    degrees are dispensable: monotone delineations induce the SAME
-    ordering structure as degree scales, without positing degrees
-    in the ontology.
+Under monotonicity the context-relative ordering is asymmetric and negatively transitive, the
+same ordering structure a degree scale would give without degrees in the ontology; transitivity
+and almost connectedness follow. -/
 
-    The two defining properties:
-    - **Asymmetry** (from monotonicity): if u > v, then v ≯ u
-    - **Negative transitivity** (unconditional): if u > w, then
-      for any v, either u > v or v > w
-
-    From these, all other strict weak order properties follow:
-    - Transitivity (from asymmetry + negative transitivity)
-    - Almost connected (incomparability → nondistinctness)
-    - Nondistinctness is a partial equivalence relation -/
-
-/-- Klein's main theorem: under monotonicity, the ordering is a strict
-    weak order (asymmetric + negatively transitive). These two properties
-    fully characterize the ordering structure of linear adjectives and
-    justify the dispensability of degrees. -/
+/-- Klein's main theorem: under monotonicity the ordering is a strict weak order. -/
 theorem klein_strict_weak_order {Entity : Type*}
     (delineation : ComparisonClass Entity → Entity → Prop)
-    (hmono : IsMonotoneDelineation delineation Set.univ)
-    (cc : ComparisonClass Entity) :
-    -- (i) Asymmetric
+    (hmono : IsMonotoneDelineation delineation Set.univ) (cc : ComparisonClass Entity) :
     (∀ u v, ordering delineation cc u v → ¬ ordering delineation cc v u) ∧
-    -- (ii) Negatively transitive
-    (∀ u v w, ordering delineation cc u w →
-      ordering delineation cc u v ∨ ordering delineation cc v w) :=
-  ⟨fun _ _ => ordering_asymm delineation hmono,
-   fun _ _ _ => ordering_neg_trans delineation⟩
+      (∀ u v w, ordering delineation cc u w →
+        ordering delineation cc u v ∨ ordering delineation cc v w) :=
+  ⟨λ _ _ => ordering_asymm delineation hmono, λ _ _ _ => ordering_neg_trans delineation⟩
 
-/-- Transitivity as a corollary of the strict weak order properties:
-    asymmetry + negative transitivity → transitivity. This shows the
-    two properties in `klein_strict_weak_order` are sufficient. -/
+/-- Transitivity from asymmetry and negative transitivity. -/
 theorem klein_transitivity_derived {Entity : Type*}
     (delineation : ComparisonClass Entity → Entity → Prop)
-    (hmono : IsMonotoneDelineation delineation Set.univ)
-    (cc : ComparisonClass Entity) (u v w : Entity) :
-    ordering delineation cc u v → ordering delineation cc v w →
+    (hmono : IsMonotoneDelineation delineation Set.univ) (cc : ComparisonClass Entity)
+    (u v w : Entity) (huv : ordering delineation cc u v) (hvw : ordering delineation cc v w) :
     ordering delineation cc u w := by
-  intro huv hvw
-  -- Apply negative transitivity on v > w with u as the middle entity:
-  -- gives v > u ∨ u > w
   rcases ordering_neg_trans (v := u) delineation hvw with h | h
   · exact absurd h (ordering_asymm delineation hmono huv)
   · exact h
 
-/-- Almost connected: incomparable entities are nondistinct. Combined
-    with `klein_strict_weak_order`, this shows every pair of entities
-    in a comparison class falls into one of three exclusive categories:
-    u > v, v > u, or u ≈ v. -/
+/-- Almost connected: two entities are ordered one way or the other or nondistinct. -/
 theorem klein_almost_connected {Entity : Type*}
-    (delineation : ComparisonClass Entity → Entity → Prop)
-    (cc : ComparisonClass Entity) (u v : Entity) :
-    ordering delineation cc u v ∨
-    ordering delineation cc v u ∨
-    nondistinct delineation cc u v := by
+    (delineation : ComparisonClass Entity → Entity → Prop) (cc : ComparisonClass Entity)
+    (u v : Entity) :
+    ordering delineation cc u v ∨ ordering delineation cc v u ∨
+      nondistinct delineation cc u v := by
   by_cases h1 : ordering delineation cc u v
   · exact Or.inl h1
   · by_cases h2 : ordering delineation cc v u
     · exact Or.inr (Or.inl h2)
     · exact Or.inr (Or.inr (nondistinct_of_incomparable h1 h2))
 
--- ════════════════════════════════════════════════════
--- § 7. Bridge: kleinPreorder = kampPreorder (over Set.univ)
--- ════════════════════════════════════════════════════
+/-! ### *As … as* and Kamp's *at least as* (§5.3)
 
-/-! Klein's `as...as` (§5.3) and Kamp's `at least as` (definition 12)
-    are the SAME relation stated in different vocabularies:
+Both quantify universally over ways of making the predicate precise, completions for Kamp and
+comparison classes for Klein, so over all completions the two preorders coincide. -/
 
-    - Kamp: `∀ completions c ∈ S, ext(c)(u') → ext(c)(u)`
-    - Klein: `∀ comparison classes C, tall(u', C) → tall(u, C)`
-
-    Completions = comparison classes; both quantify universally over
-    ways of making the predicate precise. When S = Set.univ, the two
-    preorders coincide. -/
-
-/-- Klein's preorder is exactly Kamp's preorder (over all completions)
-    when both use the same extension function. -/
+/-- Klein's preorder is Kamp's over all completions of the same extension function. -/
 theorem kleinPreorder_eq_kampPreorder {E : Type*}
     (delineation : ComparisonClass E → E → Prop) (u u' : E) :
-    (kleinPreorder delineation).le u u' ↔
-    (Kamp1975.kampPreorder delineation Set.univ).le u u' :=
-  ⟨fun h c _ => h c, fun h c => h c (Set.mem_univ _)⟩
+    (kleinPreorder delineation).le u u' ↔ (Kamp1975.kampPreorder delineation Set.univ).le u u' :=
+  ⟨λ h c _ => h c, λ h c => h c (Set.mem_univ _)⟩
 
 end Klein1980


### PR DESCRIPTION
Light cleanse of Klein1980 (no PDF obtainable: L&P 4 is Springer-paywalled); theorems unchanged in substance.
- header in mathlib register; the Kennedy2007, Bochnak2015 and morphism forward references and the raw Cresswell citation dropped
- section banners as doc headers, `fun` to `λ`, the nonlinear witness proof closed by `simp`