### PR TITLE
docs(Studies/McKayVanInwagen1977): header in register, λ

### DIFF
--- a/Linglib/Studies/McKayVanInwagen1977.lean
+++ b/Linglib/Studies/McKayVanInwagen1977.lean
@@ -1,44 +1,33 @@
 import Linglib.Semantics.Conditionals.Counterfactual
 
 /-!
-# McKay & Van Inwagen 1977 [mckay-vaninwagen-1977]
+# McKay and van Inwagen (1977): Counterfactuals with Disjunctive Antecedents
 
-Counterfactuals with Disjunctive Antecedents.
-*Philosophical Studies* 31: 353–356.
+This file formalizes the defence in [mckay-vaninwagen-1977] of the variably strict
+conditional of [lewis-1973] against simplification of disjunctive antecedents, the inference
+from a counterfactual with a disjunctive antecedent to the counterfactual from either
+disjunct. Two arguments are stated on the substrate's universal counterfactual. The
+bumper-crop argument: the English sentence is false while the disjunctive-closure reading
+is true, so the sentence is regimented as the conjunction of the per-disjunct counterfactuals,
+which is false as required. The Spain counterexample: *If Spain had fought on the Axis side
+or the Allied side, Spain would have fought on the Axis side* is acceptable, yet
+simplification would yield the absurd counterfactual from the Allied disjunct.
 
-## Core Contribution
+## Implementation notes
 
-Defends [lewis-1973]'s variably strict conditional semantics against
-the claim that **Simplification of Disjunctive Antecedents (SDA)** should
-be valid:
+Both readings reduce to `Conditionals.Counterfactual.universalCounterfactual`, evaluated on
+the disjunction or conjoined over the disjuncts; worlds and predicates are propositions on
+enumerated world types.
 
-    SDA: [(A ∨ B) > C] ⊃ (B > C)
+## TODO
 
-Critics (Nute 1975, Fine 1975, Creary & Hill 1975) proposed SDA as a
-validity constraint on counterfactual logic. McKay & Van Inwagen refute
-this with two arguments:
+The paper is not on file; locators are transcribed from an earlier version of this file and
+are UNVERIFIED.
 
-1. **The bumper crop argument**: The English sentence "if good weather or
-   sun cold, bumper crop" is false, but [lewis-1973]'s
-   disjunctive-closure reading `(goodWeather ∨ sunCold) > bumperCrop` is
-   true. So the English sentence is NOT equivalent to the
-   disjunctive-closure reading. The correct regimentation is the
-   conjunction `(goodWeather > bumperCrop) ∧ (sunCold > bumperCrop)`,
-   which IS false — matching the English judgment.
+## References
 
-2. **The Spain counterexample**: "If Spain had fought on the Axis side or
-   the Allied side, Spain would have fought on the Axis side" is
-   acceptable, but SDA gives the absurd "If Spain had fought on the
-   Allied side, Spain would have fought on the Axis side."
-
-## Substrate consumption
-
-Both readings reduce to the canonical Lewis universal counterfactual
-operator `Conditionals.Counterfactual.universalCounterfactual`. The
-disjunctive-closure reading evaluates the operator on `A ∨ B`; the
-conjunction regimentation conjoins per-disjunct evaluations.
-Worlds and predicates are typed `Prop` (not `Bool`) — DecidablePred
-instances are auto-derived from `DecidableEq` on the world enums.
+* [mckay-vaninwagen-1977]
+* [lewis-1973]
 -/
 
 namespace McKayVanInwagen1977
@@ -46,10 +35,6 @@ namespace McKayVanInwagen1977
 open Conditionals (SimilarityOrdering)
 open Conditionals.Counterfactual (universalCounterfactual)
 
-
--- ════════════════════════════════════════════════════
--- The Bumper Crop Argument: S ≠ S*
--- ════════════════════════════════════════════════════
 
 /-!
 ## The Bumper Crop Argument
@@ -82,7 +67,7 @@ instance : Fintype CropWorld where
 /-- Good weather is much more similar to the actual world than the sun
     growing cold. -/
 def cropSim : SimilarityOrdering CropWorld := .ofBool
-  (fun _ w₁ w₂ => w₁ == w₂ || (w₁ == .goodWeather && w₂ == .sunCold))
+  (λ _ w₁ w₂ => w₁ == w₂ || (w₁ == .goodWeather && w₂ == .sunCold))
   (by decide) (by decide)
 
 /-- "Good weather" world predicate. -/
@@ -92,16 +77,16 @@ def sunCold (w : CropWorld) : Prop := w = .sunCold
 /-- "Bumper crop" world predicate. True at the good-weather world. -/
 def bumperCrop (w : CropWorld) : Prop := w = .goodWeather
 
-instance : DecidablePred goodWeather := fun w => decEq w .goodWeather
-instance : DecidablePred sunCold := fun w => decEq w .sunCold
-instance : DecidablePred bumperCrop := fun w => decEq w .goodWeather
+instance : DecidablePred goodWeather := λ w => decEq w .goodWeather
+instance : DecidablePred sunCold := λ w => decEq w .sunCold
+instance : DecidablePred bumperCrop := λ w => decEq w .goodWeather
 
 /-- S* (Lewis disjunctive closure) is TRUE: the closest
     (goodWeather ∨ sunCold)-world is a good-weather world. This is
     premise (3) of the critics' argument. -/
 theorem bumperCrop_lewis_true :
     universalCounterfactual cropSim
-      (fun w => goodWeather w ∨ sunCold w) bumperCrop .actual := by decide
+      (λ w => goodWeather w ∨ sunCold w) bumperCrop .actual := by decide
 
 /-- The conjunction regimentation is FALSE:
     "if the sun grew cold, we'd have a bumper crop" is false.
@@ -117,16 +102,12 @@ theorem bumperCrop_conjunction_false :
     S ≠ S*: premise (2) is false. -/
 theorem lewis_ne_conjunction :
     universalCounterfactual cropSim
-      (fun w => goodWeather w ∨ sunCold w) bumperCrop .actual ∧
+      (λ w => goodWeather w ∨ sunCold w) bumperCrop .actual ∧
     ¬ (universalCounterfactual cropSim goodWeather bumperCrop .actual ∧
        universalCounterfactual cropSim sunCold bumperCrop .actual) :=
   ⟨bumperCrop_lewis_true, bumperCrop_conjunction_false⟩
 
 end BumperCrop
-
--- ════════════════════════════════════════════════════
--- The Spain Counterexample to SDA
--- ════════════════════════════════════════════════════
 
 /-!
 ## The Spain Example
@@ -153,7 +134,7 @@ instance : Fintype SpainWorld where
 
 /-- Axis is closer to actual than Allies (Spain's ideological alignment). -/
 def spainSim : SimilarityOrdering SpainWorld := .ofBool
-  (fun _ w₁ w₂ => w₁ == w₂ || (w₁ == .axis && w₂ == .allies))
+  (λ _ w₁ w₂ => w₁ == w₂ || (w₁ == .axis && w₂ == .allies))
   (by decide) (by decide)
 
 /-- "Spain fought with the Axis" world predicate. -/
@@ -161,8 +142,8 @@ def foughtAxis (w : SpainWorld) : Prop := w = .axis
 /-- "Spain fought with the Allies" world predicate. -/
 def foughtAllies (w : SpainWorld) : Prop := w = .allies
 
-instance : DecidablePred foughtAxis := fun w => decEq w .axis
-instance : DecidablePred foughtAllies := fun w => decEq w .allies
+instance : DecidablePred foughtAxis := λ w => decEq w .axis
+instance : DecidablePred foughtAllies := λ w => decEq w .allies
 
 /-- Lewis's disjunctive-closure reading is TRUE: the closest
     (Axis ∨ Allies)-world is the Axis-world, which satisfies C.
@@ -170,7 +151,7 @@ instance : DecidablePred foughtAllies := fun w => decEq w .allies
     it would have been the Axis" is acceptable. -/
 theorem spain_lewis_true :
     universalCounterfactual spainSim
-      (fun w => foughtAxis w ∨ foughtAllies w) foughtAxis .actual := by
+      (λ w => foughtAxis w ∨ foughtAllies w) foughtAxis .actual := by
   decide
 
 /-- The absurd SDA simplification: "If Spain had fought on the Allied
@@ -196,7 +177,7 @@ theorem sda_invalid :
       (sim : SimilarityOrdering W) (A B C : W → Prop)
       (_ : DecidablePred A) (_ : DecidablePred B) (_ : DecidablePred C)
       (w : W),
-      universalCounterfactual sim (fun v => A v ∨ B v) C w ∧
+      universalCounterfactual sim (λ v => A v ∨ B v) C w ∧
       ¬ universalCounterfactual sim B C w :=
   ⟨SpainWorld, inferInstance, inferInstance, spainSim,
    foughtAxis, foughtAllies, foughtAxis,


### PR DESCRIPTION
Light pass (paper not on file): module docstring in mathlib register with locators marked UNVERIFIED, `fun` replaced by `λ`, section banners removed. Declarations unchanged.