### PR TITLE
docs(Studies/Middleton2026): register header

### DIFF
--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -5,61 +5,39 @@ import Linglib.Fragments.Taos.Agreement
 import Linglib.Fragments.Basque.Postsyntax
 
 /-!
-# Middleton (2026) — Ordering of Impoverishment Rules in Taos and Basque
-[middleton-2026] [arregi-nevins-2012] [halle-marantz-1993]
-[harbour-2014] [harbour-2016] [kontak-kunkel-1987]
-[watkins-1984] [harbour-middleton-2026]
+# Middleton (2026): Ordering of Impoverishment Rules in Taos and Basque
 
-This file formalises the architectural argument of [middleton-2026].
-Working within Distributed Morphology ([halle-marantz-1993]),
-[arregi-nevins-2012] propose a strict modular postsyntax in
-which paradigmatic Impoverishment applies *as a block* before
-syntagmatic Impoverishment, and Metathesis follows all
-Impoverishment. Middleton shows from Taos verbal agreement that the
-second claim survives but the first does not (§§4.2.1–§4.2.5);
-the Basque half of the paper (§3.1) re-establishes the second
-claim — metathesis after impoverishment — using a different
-language and different rule shapes (whole-terminal deletion +
-adjacent-terminal swap).
+This file formalizes the architectural argument of [middleton-2026] within Distributed
+Morphology ([halle-marantz-1993]). [arregi-nevins-2012] propose a strictly modular
+postsyntax in which paradigmatic impoverishment applies as a block before syntagmatic
+impoverishment and metathesis follows all impoverishment; Taos verbal agreement shows that
+the second claim survives but the first does not, a syntagmatic rule having to feed a
+paradigmatic one, and the Basque half re-establishes the second claim with whole-terminal
+deletion and adjacent-terminal metathesis. A schematic pair of rules exhibits the divergence
+at a Taos-shaped witness (`paraAtomicRule`, `synMinimalRule`), the strict pipeline is shown
+strictly less expressive than the interleaved one whenever a syntagmatic rule must feed a
+paradigmatic one (`runStrict_forces_paraSyn_order`, `runInterleaved_admits_synPara`), a
+small vocabulary demonstrates insertion by the subset principle, and the Basque rules are
+stated on the domain-level rule shapes with the Ondarru divergence witness.
 
-## Scope
+## Implementation notes
 
-The full Taos paradigm involves dozens of Vocabulary Insertion rules
-and a large family of impoverishment / metathesis rules. We do not
-re-derive the entire paradigm. What lives here:
+The conditioning features come from the decomposition of [harbour-2014]; the rules are
+minimal witnesses to the ordering interaction, not literal transcriptions, and the full Taos
+paradigm, the containment constraints on feature bundles, and real vocabulary competition
+are not represented.
 
-* This file gives one **schematic** pair of rules
-  `paraAtomicRule` / `synMinimalRule` that exhibits the divergence
-  predicted by the paper at a real-shaped Taos witness neighborhood.
-  The conditioning features (`[+author]`, `[+atomic]`, `[+minimal]`)
-  are drawn from the Harbour decomposition the paper uses, but the
-  rules themselves are not literal transcriptions of paper rules —
-  they are minimal witnesses to the para-vs-syn ordering interaction
-  in [middleton-2026] §4.2.1–§4.2.4.
-* The general claim — that `runStrict` is strictly less expressive
-  than `runInterleaved` whenever a syntagmatic rule needs to feed a
-  paradigmatic one — is `runStrict_forces_paraSyn_order` /
-  `runInterleaved_admits_synPara`; instantiated on the witness below.
-* A small VI set demonstrates how the postsyntactic output feeds
-  Vocabulary Insertion (Subset Principle, [halle-marantz-1993]),
-  again schematically.
-* The Basque half of the paper requires *whole terminal* deletion
-  (Participant Dissimilation, rule 16) and *adjacent terminal* swap
-  (Ergative Metathesis, rule 13) — operations the focus-level Taos
-  sections cannot express. The domain-level rule shapes are
-  `DistributedMorphology.ObliterationRule` and
-  `DistributedMorphology.TerminalMetathesisRule` (`Spellout.lean`);
-  the bundles live in `Fragments/Basque/Postsyntax.lean`; the rules
-  and the Ondarru `s-endu-n` (17a) divergence witness are stated here.
+## TODO
 
-What is **not** modeled:
+The paper is not on file; section and rule numbers are transcribed from an earlier version
+of this file and are UNVERIFIED.
 
-* The full Taos paradigm and the literal rule statements of
-  [middleton-2026] (rule numbers and conditioning environments
-  vary across the four §4.2 cases).
-* Harbour's Reciprocal Containment constraints on feature bundles.
-* Real Taos VI competition — only enough VIs to demonstrate the
-  pipeline.
+## References
+
+* [middleton-2026]
+* [arregi-nevins-2012]
+* [halle-marantz-1993]
+* [harbour-2014]
 -/
 
 namespace Middleton2026

--- a/references.bib
+++ b/references.bib
@@ -22977,7 +22977,7 @@
   doi       = {10.7551/mitpress/9780262034739.001.0001},
   subfield  = {morphology},
   role      = {formalized},
-  sources   = {Features/ContainmentPair.lean;Features/Gender/Basic.lean;Features/Number/Decomposition.lean;Features/Person/Basic.lean;Features/Person/Decomposition.lean;Features/Person/Interp.lean;Fragments/Basque/Postsyntax.lean;Fragments/Mayan/Mam/Agreement.lean;Fragments/Mayan/Mam/Pronouns.lean;Fragments/Taos/Agreement.lean;Semantics/Presupposition/PhiFeatures.lean;Studies/AckemaNeeleman2018.lean;Studies/AdamsonAnagnostopoulou2025.lean;Studies/Harbour2016.lean;Studies/Middleton2026.lean;Studies/Toosarvandani2023.lean;Studies/Wang2023.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phi/Lattice.lean;Syntax/Minimalist/Phi/Recursion.lean}
+  sources   = {Features/ContainmentPair.lean;Features/Gender/Basic.lean;Features/Number/Decomposition.lean;Features/Person/Basic.lean;Features/Person/Decomposition.lean;Features/Person/Interp.lean;Fragments/Basque/Postsyntax.lean;Fragments/Mayan/Mam/Agreement.lean;Fragments/Mayan/Mam/Pronouns.lean;Fragments/Taos/Agreement.lean;Semantics/Presupposition/PhiFeatures.lean;Studies/AckemaNeeleman2018.lean;Studies/AdamsonAnagnostopoulou2025.lean;Studies/Harbour2016.lean;Studies/Toosarvandani2023.lean;Studies/Wang2023.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phi/Lattice.lean;Syntax/Minimalist/Phi/Recursion.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 
 @article{harley-2014,
@@ -31566,7 +31566,7 @@
   note      = {Manuscript, Queen Mary University of London and Mirima Dawang Woorlab-gerring Language and Culture Centre},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Studies/Middleton2026.lean}
+  sources   = {}
 }
 
 @article{harris-halle-2005,
@@ -31589,7 +31589,7 @@
   note      = {Manuscript},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Fragments/Taos/Agreement.lean;Studies/Middleton2026.lean}
+  sources   = {Fragments/Taos/Agreement.lean}
 }
 
 @book{watkins-1984,
@@ -31600,7 +31600,7 @@
   address   = {Lincoln},
   subfield  = {morphology},
   role      = {cited},
-  sources   = {Fragments/Taos/Agreement.lean;Studies/Middleton2026.lean}
+  sources   = {Fragments/Taos/Agreement.lean}
 }
 
 @incollection{harrington-1916,


### PR DESCRIPTION
Light cleanse: mathlib-register module docstring, λ binders, section banners removed.
- Paper not on file; locators marked UNVERIFIED in the TODO section