### PR TITLE
refactor(Studies/Miestamo2005): language types derived from fragments

### DIFF
--- a/Linglib/Fragments/Slavic/Czech/Negation.lean
+++ b/Linglib/Fragments/Slavic/Czech/Negation.lean
@@ -33,11 +33,6 @@ open Syntax.Negation
 def ne : Marker :=
   { morphs := [.pref "ne"] }
 
-/-- Legacy String accessor for the prefix. Kept for back-compat with
-    `Studies/Miestamo2005.lean`. New consumers should
-    use `ne.form`. -/
-def negPrefix : String := ne.form
-
 /-- A Czech negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Slavic/Russian/Negation.lean
+++ b/Linglib/Fragments/Slavic/Russian/Negation.lean
@@ -19,8 +19,7 @@ The lexical-reactive side — `никто`, `ничего`, `никогда`, `�
 lives in `Fragments/Russian/PolarityItems.lean` per the operator/lexical-
 reactive split documented in `Core/Lexical/NegMarker.lean`. The
 `NegConcordExample` data below illustrates the marker's NC behavior at
-the sentence level, which is operator-side typology consumed by
-`Studies/Miestamo2005.lean`.
+the sentence level, which is operator-side typology.
 -/
 
 namespace Russian.Negation

--- a/Linglib/Studies/Miestamo2005.lean
+++ b/Linglib/Studies/Miestamo2005.lean
@@ -1,440 +1,190 @@
-import Linglib.Syntax.Negation
-import Linglib.Data.WALS.Features.F112A
 import Linglib.Data.WALS.Features.F113A
-import Linglib.Data.WALS.Features.F114A
 import Linglib.Fragments.Finnish.Negation
-import Linglib.Fragments.Italian.Negation
-import Linglib.Fragments.German.Negation
 import Linglib.Fragments.Japanese.Negation
 import Linglib.Fragments.Turkish.Negation
-import Linglib.Fragments.Romance.French.Negation
 import Linglib.Fragments.Burmese.Negation
-import Linglib.Fragments.Spanish.Negation
 import Linglib.Fragments.Mandarin.Negation
 import Linglib.Fragments.English.Negation
-import Linglib.Fragments.Slavic.Russian.Negation
-import Linglib.Fragments.Slavic.Czech.Negation
 import Linglib.Fragments.Maori.Negation
 import Linglib.Fragments.Hixkaryana.Negation
-import Linglib.Fragments.Quechua.Negation
 
 /-!
 # Miestamo (2005): Standard Negation
 
-Negating a declarative verbal main clause may do nothing but add a marker,
-or it may restructure the clause as well. [miestamo-2005] splits that
-second case along two orthogonal dimensions. **Constructional** asymmetry
-changes the structure of the negative clause — Finnish adds a finite
-negative auxiliary and demotes the lexical verb to a nonfinite
-connegative (A/Fin), Turkish replaces the aorist suffix (A/Cat).
-**Paradigmatic** asymmetry changes which distinctions remain available —
-Burmese collapses three TAM distinctions to one, English loses the
-periphrastic emphatic (A/Emph), Imbabura Quechua forces the *-chu*
-validator and thereby displaces the others (A/NonReal). The dimensions
-cross: Finnish is constructional only, Imbabura Quechua paradigmatic
-only, Burmese both.
+This file formalizes the typology of [miestamo-2005]. The negation of a declarative verbal
+main clause is symmetric when the negative merely adds a marker to the affirmative and
+asymmetric when further structural changes accompany it, and the distinction applies to
+constructions and to paradigms separately: a paradigm is symmetric when its affirmative and
+negative members correspond one to one (`IsSymmetricParadigm`) and neutralizes when
+distinct affirmative forms share a negative counterpart (`Neutralizes`). A language is of
+type Sym when neither its constructions nor its paradigms show asymmetry, of type Asy when
+every construction is asymmetric, and of type SymAsy otherwise (`languageType`), so the
+definitional cells of the book's fourth table follow (`languageType_eq_symmetric_iff`,
+`languageType_eq_asymmetric_iff`). The subtypes of asymmetry (`AsymmetrySubtype`) are
+instantiated on the fragments: the Finnish negative auxiliary inflects for every
+person–number cell and is the finite element, the Japanese lexical verb loses its tense
+marking, Mandarin and Turkish mix symmetric and asymmetric constructions, Maori and
+Hixkaryana negate only asymmetrically, Burmese neutralizes its three postverbal
+tense–aspect markers into one negative form, and English, whose auxiliary construction is
+symmetric with the emphatic affirmative, neutralizes the emphatic distinction of the
+simple tenses in the paradigm.
 
-Formalized here: the book's Appendix III coding for fifteen languages,
-its agreement with the later WALS chapters, and the Fragment paradigms
-that witness each asymmetry. In the 179-language representative sample
-symmetric negation is the more common (Table 3: Sym 72, SymAsy 76, Asy
-31), and among subtypes A/Cat leads and A/Emph trails (Table 5: A/Cat
-59, A/Fin 45, A/NonReal 23, A/Emph 4).
+## Implementation notes
 
-A language showing several asymmetries may have one *derived* from
-another rather than from negation directly — Imbabura Quechua's ban on
-other validators follows from its *-chu* requirement, since only one
-validator may occur per clause. Derivedness relates asymmetries to each
-other, so it is noted per datum rather than carried as a field.
-
-Codings follow Appendix III and agree with the later, same-author WALS
-chapters everywhere except English, which the book analyses as symmetric
-AUX+*not* with paradigmatic A/Emph where WALS Ch 114A codes A/Cat. Czech
-is in neither the book's sample nor the WALS negation chapters; its row
-applies the book's criteria.
+A construction's symmetry is a judgment recorded on the fragment entries, so the derived
+content is the paradigmatic level and the language type. The English fragment codes the
+do-support constructions as asymmetric, the atlas's reading; the book compares the
+simple-tense negatives with the emphatic affirmatives and locates the asymmetry in the
+paradigm, and `englishSimpleTenses` follows the book. The representative sample, its
+frequency tables, and the further subtypes of the finiteness and category asymmetries are
+not represented.
 
 ## References
 
-* [miestamo-2005], Ch 4, Tables 3 and 5, Appendix III
-* [miestamo-2013], WALS Ch 113A, 114A
+* [miestamo-2005]
 -/
+
 namespace Miestamo2005
 
-open Syntax.Negation (asymmetrySubtypeOfISO)
-open Data.WALS
+variable {α β : Type*}
 
-/-! ### Asymmetry dimensions and subtypes -/
-
-/-- The domain an asymmetric negative construction departs in
-([miestamo-2005] Table 2). WALS Ch 114A codes the same distinctions
-except A/Emph, which the book separates and the atlas folds into
-A/Cat. -/
+/-- The domains of asymmetry: the finiteness of verbal elements, the marking of a
+non-realized category, the marking of emphasis, and other grammatical categories. -/
 inductive AsymmetrySubtype where
-  | finiteness
-  | realityStatus
-  | emphasis
-  | otherCategories
-  | finAndNonReal
-  | finAndEmph
-  | finAndCat
-  | nonRealAndCat
-  | emphAndCat
-  /-- The language has only symmetric negation. -/
-  | nonAssignable
-  deriving DecidableEq, BEq, Repr
+  | fin
+  | nonReal
+  | emph
+  | cat
+  deriving DecidableEq
 
-/-- The book's subtype recorded by a WALS Ch 114A value. -/
-def AsymmetrySubtype.ofWALS114A :
-    F114A.AsymmetricNegationSubtype → AsymmetrySubtype
-  | .aFin => .finiteness
-  | .aNonreal => .realityStatus
-  | .aCat => .otherCategories
-  | .aFinAndANonreal => .finAndNonReal
-  | .aFinAndACat => .finAndCat
-  | .aNonrealAndACat => .nonRealAndCat
-  | .nonAssignable => .nonAssignable
+/-- A paradigm of affirmative–negative pairs is symmetric when its members correspond one to
+one: distinct affirmative forms have distinct negative counterparts. -/
+def IsSymmetricParadigm (p : List α) (aff neg : α → β) : Prop :=
+  ∀ e₁ ∈ p, ∀ e₂ ∈ p, neg e₁ = neg e₂ → aff e₁ = aff e₂
 
-/-- [miestamo-2005]'s two dimensions of asymmetry. WALS Ch 113 collapses
-    these into a single symmetric/asymmetric distinction; Miestamo decomposes
-    asymmetry into two independent dimensions. Local to this study file
-    because the dimensions are framework-distinctive. -/
-inductive AsymmetryDimension where
-  /-- The negative clause differs structurally from the affirmative beyond
-      the negation marker: added finite elements (A/Fin) or marker
-      replacement (replacement asymmetry is constructional A/Cat). -/
-  | constructional
-  /-- The negative paradigm makes different formal distinctions than the
-      affirmative: neutralization (Burmese TAM, English A/Emph) or
-      displacement (Quechua validators). -/
-  | paradigmatic
-  deriving DecidableEq, BEq, Repr
+/-- Paradigmatic neutralization: distinct affirmative forms with one negative counterpart. -/
+def Neutralizes (p : List α) (aff neg : α → β) : Prop :=
+  ∃ e₁ ∈ p, ∃ e₂ ∈ p, aff e₁ ≠ aff e₂ ∧ neg e₁ = neg e₂
 
-/-! ### The Appendix III coding -/
+instance [DecidableEq β] (p : List α) (aff neg : α → β) :
+    Decidable (IsSymmetricParadigm p aff neg) :=
+  inferInstanceAs (Decidable (∀ e₁ ∈ p, ∀ e₂ ∈ p, neg e₁ = neg e₂ → aff e₁ = aff e₂))
 
-/-- A Miestamo-style negation datum: the WALS-chapter classification plus
-    the book's constructional/paradigmatic dimension coding (Appendix III). -/
-structure MiestamoDatum where
-  language : String
-  /-- ISO 639-3 code; the key for the WALS-consistency checks. -/
-  iso : String
-  /-- WALS Ch 112: morpheme type -/
-  morphemeType : F112A.NegativeMorphemeType
-  /-- WALS Ch 113: symmetric/asymmetric/both -/
-  symmetry : F113A.NegationSymmetry
-  /-- WALS Ch 114: asymmetry subtype -/
-  asymmetrySubtype : AsymmetrySubtype
-  /-- Which dimensions of asymmetry are present (Appendix III C/P columns) -/
-  asymmetryDimensions : List AsymmetryDimension
-  /-- The negation marker forms, read off the language's Fragment. -/
-  negMarkers : List String
-  deriving Repr, BEq
+instance [DecidableEq β] (p : List α) (aff neg : α → β) : Decidable (Neutralizes p aff neg) :=
+  inferInstanceAs (Decidable (∃ e₁ ∈ p, ∃ e₂ ∈ p, aff e₁ ≠ aff e₂ ∧ neg e₁ = neg e₂))
 
-/-! ### Per-language rows -/
+theorem neutralizes_iff_not_isSymmetricParadigm (p : List α) (aff neg : α → β) :
+    Neutralizes p aff neg ↔ ¬ IsSymmetricParadigm p aff neg := by
+  unfold Neutralizes IsSymmetricParadigm
+  push Not
+  exact ⟨λ ⟨e₁, h₁, e₂, h₂, ha, hn⟩ => ⟨e₁, h₁, e₂, h₂, hn, ha⟩,
+    λ ⟨e₁, h₁, e₂, h₂, hn, ha⟩ => ⟨e₁, h₁, e₂, h₂, ha, hn⟩⟩
 
-/-- Finnish: constructional A/Fin/NegVerb. The negative auxiliary is the
-    finite element; the lexical verb appears as a nonfinite connegative.
-    Forms derived from `Finnish.Negation.negParadigm`. -/
-def finnish : MiestamoDatum :=
-  { language := "Finnish"
-  , iso := "fin"
-  , morphemeType := .negativeAuxiliaryVerb
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := Finnish.Negation.negParadigm.map (·.form) }
+/-- The three types of language, from the symmetry of each construction and whether some
+paradigm is asymmetric: symmetric negation when no asymmetry is found, asymmetric when every
+construction is asymmetric, and both otherwise. -/
+def languageType (constructions : List Bool) (paradigmAsymmetric : Prop)
+    [Decidable paradigmAsymmetric] : Data.WALS.F113A.NegationSymmetry :=
+  if constructions.all id ∧ ¬ paradigmAsymmetric then .symmetric
+  else if constructions.all (!·) then .asymmetric
+  else .both
 
-/-- German: symmetric. Particle *nicht*.
-    Form derived from `German.Negation.nicht.form`. -/
-def german : MiestamoDatum :=
-  { language := "German"
-  , iso := "deu"
-  , morphemeType := .negativeParticle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [German.Negation.nicht.form] }
+section LanguageType
 
-/-- Japanese: constructional A/Fin + A/Cat. Plain *-nai* adjectivalizes
-    the verb (A/Fin/Neg-LV); the polite nonpast replaces TAM material
-    (A/Cat/TAM); the polite past adds a finite element. Appendix III codes
-    all three constructions as constructional, with no paradigmatic row.
-    Form derived from `Japanese.Negation.negSuffix.form`. -/
-def japanese : MiestamoDatum :=
-  { language := "Japanese"
-  , iso := "jpn"
-  , morphemeType := .negativeAffix
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finAndCat
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := [Japanese.Negation.negSuffix.form] }
+variable (cs : List Bool) (P : Prop) [Decidable P]
 
-/-- Turkish: SymAsy with constructional A/Cat/TAM in the aorist only.
-    The aorist suffix changes to *-z* in the 2nd/3rd persons and is
-    omitted in the 1st (Appendix II ex. 260); negation is symmetric
-    elsewhere. Form derived from `Turkish.Negation.negSuffix.form`. -/
-def turkish : MiestamoDatum :=
-  { language := "Turkish"
-  , iso := "tur"
-  , morphemeType := .negativeAffix
-  , symmetry := .both
-  , asymmetrySubtype := .otherCategories
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := [Turkish.Negation.negSuffix.form] }
+theorem languageType_eq_symmetric_iff :
+    languageType cs P = .symmetric ↔ (∀ c ∈ cs, c = true) ∧ ¬ P := by
+  unfold languageType
+  split_ifs with h₁ h₂ <;> simp_all [List.all_eq_true]
 
-/-- French: symmetric. Bipartite *ne...pas* introduces no structural change.
-    Forms derived from `French.Negation`. -/
-def french : MiestamoDatum :=
-  { language := "French"
-  , iso := "fra"
-  , morphemeType := .negativeParticle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [French.Negation.neClitic,
-                    French.Negation.pasReinforcer] }
+/-- A language with only asymmetric constructions is of type Asy whatever its paradigms. -/
+theorem languageType_eq_asymmetric_iff (hne : cs ≠ []) :
+    languageType cs P = .asymmetric ↔ ∀ c ∈ cs, c = false := by
+  unfold languageType
+  obtain ⟨c, cs, rfl⟩ := List.exists_cons_of_ne_nil hne
+  split_ifs with h₁ h₂ <;> simp_all [List.all_eq_true]
 
-/-- Burmese: constructional + paradigmatic A/Cat, in one construction
-    (Appendix III type B): the circumfix replaces the TAM slot and
-    neutralizes the actual/potential distinction (A/Cat/TAM/Neutr).
-    Forms derived from `Burmese.Negation`. -/
-def burmese : MiestamoDatum :=
-  { language := "Burmese"
-  , iso := "mya"
-  , morphemeType := .doubleNegation
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .otherCategories
-  , asymmetryDimensions := [.constructional, .paradigmatic]
-  , negMarkers := [Burmese.Negation.negPrefix,
-                    Burmese.Negation.negSuffix] }
+/-- Type SymAsy has a symmetric construction by definition, together with some asymmetry. -/
+theorem languageType_eq_both_iff :
+    languageType cs P = .both ↔ (∃ c ∈ cs, c = true) ∧ ((∃ c ∈ cs, c = false) ∨ P) := by
+  unfold languageType
+  split_ifs with h₁ h₂ <;> simp_all [List.all_eq_true]
+  exact (em (false ∈ cs)).elim Or.inl (λ hf => Or.inr (h₁ hf))
 
-/-- Italian: symmetric. Particle *non*, no structural change.
-    Form derived from `Italian.Negation.non.form`. -/
-def italian : MiestamoDatum :=
-  { language := "Italian"
-  , iso := "ita"
-  , morphemeType := .negativeParticle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [Italian.Negation.non.form] }
+end LanguageType
 
-/-- Spanish: symmetric. Particle *no*, no structural change.
-    Form derived from `Spanish.Negation.no.form`. -/
-def spanish : MiestamoDatum :=
-  { language := "Spanish"
-  , iso := "spa"
-  , morphemeType := .negativeParticle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [Spanish.Negation.no.form] }
+/-! ### Finiteness asymmetry: Finnish, Japanese, Maori, Hixkaryana -/
 
-/-- Mandarin Chinese: SymAsy with constructional A/Fin.
-    Non-perfectives negated by *bù* (symmetric). Perfectives negated by
-    *méi(yǒu)*: the existential verb *yǒu* is introduced as the finite
-    element (A/Fin/Neg-FE); when *méi* occurs without *yǒu*, it functions
-    as a negative existential verb (A/Fin/NegVerb). [miestamo-2005]
-    pp. 90-91, example (51). Forms derived from `Mandarin.Negation`. -/
-def mandarin : MiestamoDatum :=
-  { language := "Mandarin Chinese"
-  , iso := "cmn"
-  , morphemeType := .negativeParticle
-  , symmetry := .both
-  , asymmetrySubtype := .finiteness
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := [Mandarin.Negation.bu.form,
-                    Mandarin.Negation.mei.form] }
-
-/-- English: SymAsy with paradigmatic A/Emph/Neutr. Appendix III codes
-    AUX+*not* as symmetric (with *do* as the finite AUX host) and locates
-    the asymmetry in the paradigm: the periphrastic emphatic (*I DO eat*)
-    is unavailable in negatives. WALS Ch 114A instead codes English A/Cat;
-    see `english_subtype_diverges_from_wals`.
-    Form derived from `English.Negation.not.form`. -/
-def english : MiestamoDatum :=
-  { language := "English"
-  , iso := "eng"
-  , morphemeType := .negativeParticle
-  , symmetry := .both
-  , asymmetrySubtype := .emphasis
-  , asymmetryDimensions := [.paradigmatic]
-  , negMarkers := [English.Negation.not.form] }
-
-/-- Russian: symmetric. Particle *не* (*ne*), no structural change.
-    Form derived from `Russian.Negation.ne.form`. -/
-def russian : MiestamoDatum :=
-  { language := "Russian"
-  , iso := "rus"
-  , morphemeType := .negativeParticle
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [Russian.Negation.ne.form] }
-
-/-- Czech: symmetric. Prefix *ne-*, no structural change. Not in the
-    book's RS (nor the WALS Ch 113A-115A samples); coded here by applying
-    the book's criteria to symmetric *ne-* prefixation.
-    Form derived from `Czech.Negation.negPrefix`. -/
-def czech : MiestamoDatum :=
-  { language := "Czech"
-  , iso := "ces"
-  , morphemeType := .negativeAffix
-  , symmetry := .symmetric
-  , asymmetrySubtype := .nonAssignable
-  , asymmetryDimensions := []
-  , negMarkers := [Czech.Negation.negPrefix] }
-
-/-- Maori: constructional A/Fin/NegVerb. *Kāhore* is the finite element
-    and the lexical clause is subordinated. WALS Ch 112A codes the
-    morpheme type as wordUnclear.
-    Form derived from `Maori.Negation.kahore.form`. -/
-def maori : MiestamoDatum :=
-  { language := "Maori"
-  , iso := "mri"
-  , morphemeType := .negativeWordUnclearIfVerbOrParticle
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := [Maori.Negation.kahore.form] }
-
-/-- Hixkaryana: constructional A/Fin/Neg-LV. Suffix *-hɨra* deverbalizes
-    the verb; a copula becomes the finite element.
-    Form derived from `Hixkaryana.Negation.hira.form`. -/
-def hixkaryana : MiestamoDatum :=
-  { language := "Hixkaryana"
-  , iso := "hix"
-  , morphemeType := .negativeAffix
-  , symmetry := .asymmetric
-  , asymmetrySubtype := .finiteness
-  , asymmetryDimensions := [.constructional]
-  , negMarkers := [Hixkaryana.Negation.hira.form] }
-
-/-- Imbabura Quechua: SymAsy with paradigmatic A/NonReal/Displc.
-    *Mana* constructions are symmetric; negatives require the validator
-    enclitic *-chu*, which also marks interrogatives. Since only one
-    validator may occur per sentence, the further ban on other validators
-    is an asymmetry the book classifies as *derived* from this one
-    (p. 158). Form derived from `Quechua.Negation.mana.form`. -/
-def imbaburaQuechua : MiestamoDatum :=
-  { language := "Quechua (Imbabura)"
-  , iso := "qvi"
-  , morphemeType := .negativeParticle
-  , symmetry := .both
-  , asymmetrySubtype := .realityStatus
-  , asymmetryDimensions := [.paradigmatic]
-  , negMarkers := [Quechua.Negation.mana.form] }
-
-def allData : List MiestamoDatum :=
-  [finnish, german, japanese, turkish, french, burmese, italian, spanish,
-   mandarin, english, russian, czech, maori, hixkaryana, imbaburaQuechua]
-
-/-! ### Agreement with WALS -/
-
-/-- English is the sample's only book-vs-atlas disagreement: WALS Ch 114A
-    is Miestamo's own chapter, so the two codings otherwise coincide. -/
-theorem subtype_matches_wals_except_english :
-    allData.all (fun d =>
-      d.iso == "eng" ||
-      ((asymmetrySubtypeOfISO d.iso).map AsymmetrySubtype.ofWALS114A).all
-        (· == d.asymmetrySubtype)) = true := by
+/-- The Finnish negative auxiliary inflects for every person–number cell, so it is the finite
+element of the negative clause and the lexical verb is nonfinite, the negative-verb variety of
+the finiteness asymmetry. -/
+theorem finnish_negVerb :
+    ∀ p ∈ [1, 2, 3], ∀ n ∈ ["sg", "pl"],
+      ∃ f ∈ Finnish.Negation.negParadigm, f.person = p ∧ f.number = n := by
   decide
 
-/-- The book vs WALS on English: Appendix III codes English SN as
-    symmetric AUX+*not* with paradigmatic A/Emph/Neutr asymmetry; WALS
-    Ch 114A codes English A/Cat. -/
-theorem english_subtype_diverges_from_wals :
-    english.asymmetrySubtype = .emphasis ∧
-    asymmetrySubtypeOfISO english.iso = some .aCat :=
-  ⟨rfl, by decide⟩
-
-/-! ### The Fragment paradigms behind the codings -/
-
-/-- Japanese Fragment distribution shows the tense shift from stem to
-    suffix that Appendix III codes as constructional replacement
-    (A/Cat/TAM) alongside the A/Fin adjectivalization. -/
-theorem japanese_distribution_confirms_asymmetry :
-    let dist := Japanese.Negation.japaneseNegDistribution
-    dist.affirmativeOnStem.contains .tense = true ∧
-    dist.negativeOnStem.contains .tense = false ∧
-    dist.negativeOnSuffix.contains .tense = true ∧
-    japanese.asymmetryDimensions.contains .constructional := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
-
-/-- Turkish Fragment confirms SymAsy: the aorist is the only asymmetric
-    construction in the *gelmek* paradigm. -/
-theorem turkish_fragment_confirms_symasy :
-    (Turkish.Negation.gelParadigm.filter (fun e => !e.symmetric)).map
-      (·.formLabel) = ["aorist"] ∧
-    turkish.symmetry == .both :=
-  ⟨Turkish.Negation.aorist_asymmetric, rfl⟩
-
-/-- Burmese Fragment confirms paradigmatic asymmetry: TAM neutralized
-    (3 affirmative distinctions → 1 negative form). -/
-theorem burmese_fragment_confirms_paradigmatic :
-    Burmese.Negation.burmeseTAM.affirmativeTAM.length = 3 ∧
-    Burmese.Negation.burmeseTAM.negativeTAM.length = 1 ∧
-    burmese.asymmetryDimensions.contains .paradigmatic :=
-  ⟨rfl, rfl, by decide⟩
-
-/-- Mandarin Fragment confirms SymAsy: the example set contains both
-    symmetric (bù) and asymmetric (méi) constructions. -/
-theorem mandarin_fragment_confirms_symasy :
-    Mandarin.Negation.allExamples.any (·.symmetric) = true ∧
-    Mandarin.Negation.allExamples.any (fun e => !e.symmetric) = true ∧
-    mandarin.symmetry == .both := by
-  refine ⟨?_, ?_, rfl⟩ <;> decide
-
-/-- English do-support is exactly the asymmetric constructions in the
-    Fragment's construction-level coding. The book instead treats AUX+not
-    as symmetric and locates English asymmetry in the emphatic paradigm
-    (see `english`); the fragment fact is stable under either construal. -/
-theorem english_dosupport_is_asymmetry :
-    English.Negation.allExamples.all
-      (fun e => e.symmetric == !e.doSupport) = true := by
+/-- Under negation the Japanese lexical verb loses its tense marking to the adjectival negative
+suffix, the lexical-verb variety of the finiteness asymmetry. -/
+theorem japanese_tense_leaves_stem :
+    .tense ∈ Japanese.Negation.japaneseNegDistribution.affirmativeOnStem ∧
+      .tense ∉ Japanese.Negation.japaneseNegDistribution.negativeOnStem := by
   decide
 
-/-- Maori Fragment confirms asymmetric: all constructions are A/Fin. -/
-theorem maori_fragment_confirms_asymmetric :
-    Maori.Negation.allExamples.all (fun e => !e.symmetric) = true ∧
-    maori.asymmetryDimensions.contains .constructional := by
-  refine ⟨?_, ?_⟩ <;> decide
+/-- The asymmetry is constructional only: the Japanese paradigm is symmetric. -/
+theorem japanese_paradigm_symmetric :
+    IsSymmetricParadigm Japanese.Negation.taberuParadigm (·.affirmative) (·.negative) := by
+  decide
 
-/-- Hixkaryana Fragment confirms asymmetric A/Fin with copula finite. -/
-theorem hixkaryana_fragment_confirms_asymmetric :
-    Hixkaryana.Negation.allExamples.all (fun e => !e.symmetric) = true ∧
-    Hixkaryana.Negation.allExamples.all (·.copulaFinite) = true ∧
-    hixkaryana.asymmetryDimensions.contains .constructional := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+/-- Maori negates only with the finite negative verb, so it is of type Asy. -/
+theorem maori_asymmetric :
+    languageType (Maori.Negation.allExamples.map (·.symmetric)) False = .asymmetric := by
+  decide
 
-/-- Imbabura Quechua Fragment confirms SymAsy, with the *-chu*
-    requirement marking exactly the asymmetric constructions. -/
-theorem imbaburaQuechua_chu_is_asymmetry :
-    Quechua.Negation.allExamples.any (·.symmetric) = true ∧
-    Quechua.Negation.allExamples.all
-      (fun e => e.symmetric == !e.requiresChu) = true ∧
-    imbaburaQuechua.symmetry == .both := by
-  refine ⟨?_, ?_, rfl⟩ <;> decide
+/-- Hixkaryana negates only by deverbalizing the lexical verb under a copula that carries the
+finite inflection, so it is of type Asy. -/
+theorem hixkaryana_asymmetric :
+    languageType (Hixkaryana.Negation.allExamples.map (·.symmetric)) False = .asymmetric ∧
+      ∀ e ∈ Hixkaryana.Negation.allExamples, e.copulaFinite = true := by
+  decide
 
-/-! ### The negative auxiliary -/
+/-! ### Mixed languages: Mandarin and Turkish -/
 
-section NegAuxBridge
+/-- Mandarin negates non-perfectives symmetrically with *bù* and perfectives with *méi*, which
+introduces the existential verb as the finite element or is itself the finite negative verb,
+so it is of type SymAsy. -/
+theorem mandarin_both :
+    languageType (Mandarin.Negation.allExamples.map (·.symmetric)) False = .both := by
+  decide
 
-open Syntax.Negation (Strategy)
+/-- Turkish negation is symmetric except in the aorist, whose marker changes or drops in the
+negative, a category asymmetry; the paradigm stays one to one. -/
+theorem turkish_both :
+    languageType (Turkish.Negation.gelParadigm.map (·.symmetric))
+      (Neutralizes Turkish.Negation.gelParadigm (·.affirmative) (·.negative)) = .both := by
+  decide
 
-/-- The auxiliary literature's negative-verb strategy and this study's
-    auxiliary-verb morpheme type pick out the same Finnish phenomenon: an
-    inflecting negative auxiliary. -/
-theorem finnish_strategy_morpheme_consistent :
-    Strategy.negVerb.morphemeType = finnish.morphemeType := rfl
+/-! ### Paradigmatic neutralization: Burmese and English -/
 
-/-- Verbal negation strategy implies constructional asymmetry in both
-    the auxiliary literature (creates an AVC) and the negation typology
-    (A/Fin). -/
-theorem neg_verb_implies_avc_and_afin :
-    Strategy.negVerb.IsVerbal ∧
-    finnish.asymmetryDimensions.contains .constructional :=
-  ⟨trivial, by decide⟩
+/-- The Burmese negative suffix replaces the postverbal tense–aspect markers, so one negative
+form corresponds to three affirmative forms. -/
+theorem burmese_neutralizes :
+    Neutralizes Burmese.Negation.saParadigm (·.affirmative) (·.negative) := by
+  decide
 
-end NegAuxBridge
+/-- The English simple tenses with their emphatic periphrastic affirmatives: the negative is
+symmetric with the emphatic affirmative, and the paradigm loses the emphatic distinction. -/
+def englishSimpleTenses : List (String × String) :=
+  [(English.Negation.lexicalPresent.affirmative, English.Negation.lexicalPresent.negative),
+   ("he does eat", English.Negation.lexicalPresent.negative),
+   (English.Negation.lexicalPast.affirmative, English.Negation.lexicalPast.negative),
+   ("he did eat", English.Negation.lexicalPast.negative)]
+
+/-- English negation is symmetric in construction and asymmetric in paradigm, of the emphasis
+subtype, so it is of type SymAsy. -/
+theorem english_both :
+    Neutralizes englishSimpleTenses Prod.fst Prod.snd ∧
+      languageType [true] (Neutralizes englishSimpleTenses Prod.fst Prod.snd) = .both := by
+  decide
 
 end Miestamo2005

--- a/references.bib
+++ b/references.bib
@@ -7312,7 +7312,7 @@
   role      = {cited},
   doi       = {10.1515/9783110197631},
   validated = {true},
-  sources   = {Fragments/Finnish/Negation.lean;Studies/Miestamo2005.lean}
+  sources   = {Fragments/Finnish/Negation.lean;Fragments/Slavic/Czech/Negation.lean;Fragments/Slavic/Russian/Negation.lean;Studies/Miestamo2005.lean}
 }% REF: Schwarzschild, R. (2005). Measure phrases as modifiers of adjectives. *Recherches Linguistiques de Vincennes* 34: 207-22
 @article{schwarzschild-2005,
   author    = {Schwarzschild, Roger},
@@ -7777,7 +7777,7 @@
   url       = {https://wals.info/chapter/115},
   subfield  = {semantics/compositional},
   role      = {cited},
-  sources   = {Syntax/Negation.lean}
+  sources   = {Fragments/Slavic/Czech/Negation.lean;Fragments/Slavic/Russian/Negation.lean;Syntax/Negation.lean}
 }% REF: Huang, Y.T., Spelke, E., & Snedeker, J. (2013). What exactly do numbers mean? *Language Learning and Development* 9(2), 
 @article{huang-spelke-snedeker-2013,
   author    = {Huang, Yi Ting and Spelke, Elizabeth and Snedeker, Jesse},


### PR DESCRIPTION
Recut on the book: paradigm symmetry and neutralization as one-to-one correspondence, the three language types with the definitional cells of Table 4, and per-language theorems over fragment data.
- Cuts the WALS-agreement check, the fifteen hand-typed rows, the fragment count checks, and the negative-auxiliary bridge
- Drops the Czech legacy negPrefix accessor and the Russian docstring's reference to the study