### PR TITLE
refactor(Studies/Mirrazi2024): cut stipulated scope records

### DIFF
--- a/Linglib/Studies/Mirrazi2024.lean
+++ b/Linglib/Studies/Mirrazi2024.lean
@@ -1,333 +1,73 @@
 import Linglib.Semantics.Quantification.ChoiceFunction
-import Linglib.Semantics.Attitudes.NegRaising
 import Linglib.Fragments.Farsi.Determiners
 
 /-!
-# Indefinites in Negated Intensional Contexts [mirrazi-2024]
+# Mirrazi (2024): Indefinites in Negated Intensional Contexts
 
-Semantics & Pragmatics 17, Article 7: 1–44.
+This file formalizes the argument of [mirrazi-2024] from Farsi indefinites under negated
+intensional operators. *Rodica does not think that Carl read some of the books* has a
+reading on which the indefinite scopes above the negation but below *think*, de dicto: no
+syntactic position is at once above the negation and below the attitude, so movement cannot
+derive it, and neg-raising cannot either, since it leaves the indefinite below the negation
+and the reading also arises under predicates that do not raise negation. The paper derives
+the reading from in-situ choice functions whose existential closure sits above the negation
+while the function carries a world variable bound by the attitude (`widePseudoDeDictoTC`,
+against the de re construal `wideDeReTC`). The world variable is what separates the two:
+when the noun's extension and the function are rigid across the belief worlds the truth
+conditions coincide (`deRe_eq_pseudoDeDicto_when_rigid`), the fixed-set problem, and the
+Farsi indefinites, choice-functional with a world variable, are predicted to have the
+reading (`farsi_indefinites_pseudo`).
 
-## The Scope Paradox
+## Implementation notes
 
-Farsi indefinites under negated intensional operators (*think*, *necessary*,
-*can*) yield "wide pseudo-scope de dicto" readings. The indefinite appears
-to take **wide scope over negation** but **narrow scope (de dicto) under
-the intensional operator**:
+The choice-function apparatus, its world-skolemized variant, and the classification of
+indefinites by type and world variable live in `Semantics/Quantification/ChoiceFunction`;
+the Farsi determiners are the fragment's. Universal quantifiers, which lack the reading,
+enter only through that classification.
 
-  (1) Rodica does not think that Carl read some of the books.
-      Attested: think ≫ INDEF ≫ ¬
-      = Rodica thinks there are some books Carl didn't read
-        (but she doesn't know which ones)
+## References
 
-This is paradoxical: there is no syntactic position that is simultaneously
-above negation and below *think*. Under movement-based approaches, the
-indefinite would have to move above negation, but any such landing site
-unavoidably outscopes the intensional operator — yielding a de re (not
-de dicto) construal. This is the "fourth reading" problem ([percus-2000],
-[von-fintel-heim-2011], [keshet-schwarz-2019]).
-
-## Choice Functions Solve It
-
-In-situ choice function accounts separate the existential quantification
-(∃f) from the descriptive content. The ∃-closure over the choice function
-sits above negation (giving wide scope), while the CF's world variable,
-bound by the intensional operator, keeps the restrictor de dicto.
-
-## World-Skolemized Choice Functions
-
-Standard intensional CFs ([heim-1994], [winter-1997]) run into
-the **fixed-set problem**: when the NP extension is rigid across worlds,
-`f(⟨s, ⟨e,t⟩⟩)` returns the same individual everywhere. World-skolemized
-CFs `f(w', NP(w'))` solve this: the CF takes a world argument, so it can
-pick different individuals in different worlds even from the same set.
-
-## Cross-Linguistic Variation
-
-Wide pseudo-scope de dicto is available in Farsi and Japanese, marginal in
-English, and absent in German and French. [schwarz-2012] proposes that
-determiners vary in whether they carry an independent world variable. Farsi
-indefinites (*ye*, *čand-ta*, *do-ta*) carry one; German/French do not.
-
-## Indefinite/Universal Asymmetry
-
-Universal quantifiers (*hame* "all") under the same negated intensional
-operators do NOT get wide pseudo-scope de dicto readings. This follows
-because universal quantifiers are genuine scope-takers (GQs), not choice
-functions — they cannot separate their quantificational force from their
-descriptive content.
+* [mirrazi-2024]
 -/
 
 namespace Mirrazi2024
 
 open Quantification.ChoiceFunction
-open Doxastic (BoxAt)
-open NegRaising (NegRaisesAt)
-open Farsi.Determiners (ye candTa doTa PlainIndefiniteEntry)
-
--- ============================================================================
--- §1 The Scope Paradox: Three Readings
--- ============================================================================
-
-/-- The three logically possible scope configurations for an indefinite
-    under a negated intensional operator: ¬ INT_OP [INDEF VP]. -/
-inductive ScopeConfig where
-  /-- NEG ≫ INT ≫ INDEF: narrow scope (under both). -/
-  | narrow
-  /-- INDEF ≫ NEG ≫ INT: wide scope de re (above both). -/
-  | wideDeRe
-  /-- INT ≫ INDEF ≫ NEG: wide pseudo-scope de dicto. -/
-  | widePseudoDeDicto
-  deriving DecidableEq, Repr
-
-/-- The kind of scope-taker. -/
-inductive ScopeTakerKind where
-  /-- An indefinite (choice function semantics). -/
-  | indefinite
-  /-- A genuine generalized quantifier (every, all). -/
-  | universal
-  deriving DecidableEq, Repr
-
--- ============================================================================
--- §1.2 Neg-Raising Does Not Explain the Paradox
--- ============================================================================
-
-/-- Under neg-raising, ¬THINK(p) is strengthened to THINK(¬p).
-
-    [mirrazi-2024] §1.2 ex. (5)–(6): if neg-raising applies to (1),
-    the resulting interpretation is THINK(¬[Carl read some of the books]).
-    This puts the indefinite UNDER negation (inside the think-complement),
-    giving think ≫ ¬ ≫ INDEF — NOT the attested think ≫ INDEF ≫ ¬.
-
-    Moreover, the same readings arise with non-neg-raising predicates
-    (*necessary*, *can*), so neg-raising cannot be the explanation. -/
-structure NegRaisingCounterargument where
-  /-- A neg-raising predicate produces think ≫ ¬ ≫ INDEF, not the
-      attested think ≫ INDEF ≫ ¬. The indefinite ends up below negation. -/
-  negRaising_wrong_scope : ScopeConfig
-  /-- Non-neg-raising predicates (necessary, can) also yield the reading,
-      so neg-raising is neither necessary nor sufficient. -/
-  nonNegRaiser_also_works : Bool
-
-/-- The neg-raising hypothesis yields the wrong scope configuration.
-    Under neg-raising: ¬think(p) → think(¬p), and the indefinite stays
-    inside ¬p, giving narrow scope — the opposite of what's attested.
-    [mirrazi-2024] §1.2 exx. (5)–(10). -/
-def negRaisingFails : NegRaisingCounterargument where
-  negRaising_wrong_scope := .narrow  -- think ≫ ¬ ≫ INDEF, not think ≫ INDEF ≫ ¬
-  nonNegRaiser_also_works := true    -- necessary, can also yield the reading
-
-/-- Neg-raising yields the wrong scope order for the indefinite. -/
-theorem negRaising_yields_narrow :
-    negRaisingFails.negRaising_wrong_scope = .narrow := rfl
-
-/-- Neg-raising is not needed: non-neg-raising operators also yield
-    wide pseudo-scope de dicto. -/
-theorem nonNegRaiser_suffices :
-    negRaisingFails.nonNegRaiser_also_works = true := rfl
-
-/-- Structural verification: *think* supports neg-raising via the
-    doxastic infrastructure. This connects to the library's `NegRaisesAt`
-    without claiming neg-raising explains the scope paradox. -/
-theorem think_does_neg_raise {W E : Type*} (R : E → W → W → Prop)
-    (agent : E) (worlds : List W) (p : W → Prop) (w : W)
-    (hNeg : ¬ BoxAt R agent w worlds p)
-    (hExclMiddle : NegRaisesAt R agent worlds p w) :
-    BoxAt R agent w worlds (λ w' => ¬ p w') :=
-  hExclMiddle hNeg
-
--- ============================================================================
--- §2 Truth Conditions
--- ============================================================================
+open Farsi.Determiners
 
 section TruthConditions
 
-variable (W : Type*) (E : Type*)
+variable (W E : Type*) (f : SkolemCF W E) (R : E → W → W → Prop) (agent : E) (worlds : List W)
+  (nounProp : W → E → Prop) (vp : E → W → Prop) (w₀ : W)
 
-/-- The truth conditions for the wide pseudo-scope de dicto reading,
-    derived from CF semantics.
+/-- The wide pseudo-scope de dicto reading: in every belief world the individual the function
+picks from that world's extension of the noun fails the predicate. -/
+def widePseudoDeDictoTC : Prop :=
+  ∀ w' ∈ worlds, R agent w₀ w' → ¬ vp (f.applyIntensionAt .bound w' w₀ nounProp) w'
 
-    [mirrazi-2024] ex. (44):
-    ∀w'' ∈ Beliefs(Rodica,w₀): ¬read_{w''}(Carl, f(w'', book(w'')))
+/-- The wide-scope de re reading: the function's world argument is free, so the individual is
+fixed across the belief worlds. -/
+def wideDeReTC : Prop :=
+  ∀ w' ∈ worlds, R agent w₀ w' → ¬ vp (f.applyIntensionAt .free w' w₀ nounProp) w'
 
-    The ∃f sits above negation (wide scope), while f's world argument
-    is bound by the attitude verb (de dicto). The accessibility relation
-    `R` connects to the doxastic infrastructure in `Attitudes.Doxastic`. -/
-def widePseudoDeDictoTC
-    (f : SkolemCF W E)
-    (R : E → W → W → Prop) (agent : E) (worlds : List W)
-    (nounProp : W → E → Prop)
-    (vp : E → W → Prop)
-    (w₀ : W) : Prop :=
-  ∀ w' ∈ worlds, R agent w₀ w' →
-    ¬vp (f.applyIntensionAt .bound w' w₀ nounProp) w'
-
-/-- The truth conditions for the genuine wide scope de re reading.
-
-    [mirrazi-2024] ex. (41):
-    ∀w'' ∈ Beliefs(Rodica,w₀): ¬read_{w''}(Carl, f(book_{w₀}))
-
-    The CF's world variable is free (evaluated at w₀):
-    the individual is fixed across belief worlds. -/
-def wideDeReTC
-    (f : SkolemCF W E)
-    (R : E → W → W → Prop) (agent : E) (worlds : List W)
-    (nounProp : W → E → Prop)
-    (vp : E → W → Prop)
-    (w₀ : W) : Prop :=
-  ∀ w' ∈ worlds, R agent w₀ w' →
-    ¬vp (f.applyIntensionAt .free w' w₀ nounProp) w'
-
-/-- The key structural fact: de re and pseudo-de dicto differ exactly in
-    whether the CF's world argument is bound (varies with w') or free
-    (fixed at w₀). When `nounProp` is world-invariant and `f` is
-    world-invariant, they collapse — the two readings become equivalent.
-
-    This is the formal content of the fixed-set problem: when there is
-    no cross-world variation, world-skolemization adds nothing, and the
-    "pseudo-de dicto" reading reduces to plain de re. -/
-theorem deRe_eq_pseudoDeDicto_when_rigid
-    (f : SkolemCF W E)
-    (R : E → W → W → Prop) (agent : E) (worlds : List W)
-    (nounProp : W → E → Prop)
-    (vp : E → W → Prop) (w₀ : W)
-    (hRigidNP : ∀ w, nounProp w = nounProp w₀)
+/-- The two readings differ only in whether the function's world argument is bound, so with a
+rigid noun extension and a rigid function they coincide: the fixed-set problem of plain
+intensional choice functions. -/
+theorem deRe_eq_pseudoDeDicto_when_rigid (hRigidNP : ∀ w, nounProp w = nounProp w₀)
     (hRigidCF : ∀ w, f w = f w₀) :
     widePseudoDeDictoTC W E f R agent worlds nounProp vp w₀ ↔
-    wideDeReTC W E f R agent worlds nounProp vp w₀ := by
-  unfold widePseudoDeDictoTC wideDeReTC SkolemCF.applyIntensionAt
-    SkolemCF.applyIntension
+      wideDeReTC W E f R agent worlds nounProp vp w₀ := by
+  unfold widePseudoDeDictoTC wideDeReTC SkolemCF.applyIntensionAt SkolemCF.applyIntension
   constructor <;> intro h w' hw' hR
   · rw [← hRigidNP w', ← hRigidCF w']; exact h w' hw' hR
   · rw [hRigidNP w', hRigidCF w']; exact h w' hw' hR
 
 end TruthConditions
 
--- ============================================================================
--- §2.2 The Fourth Reading is Impossible Under Movement
--- ============================================================================
-
-/-- Under movement-based accounts, a DP that moves above an intensional
-    operator is necessarily interpreted de re (at its landing site).
-
-    [mirrazi-2024] §2.2, citing [percus-2000],
-    [von-fintel-heim-2011], [keshet-schwarz-2019]:
-
-    "According to all of these theories, a DP can only get a *de dicto*
-    reading when it is under the scope of an intensional operator. If a
-    DP moves in order to take wide scope with respect to the intensional
-    operator, it can no longer be construed *de dicto*."
-
-    This means: to scope above negation, the indefinite must move to a
-    position above NEG — but any such position is also above the
-    intensional operator, forcing de re. There is no landing site that
-    is simultaneously above NEG and below the intensional operator
-    (since NEG is syntactically below the operator). -/
-theorem movement_above_neg_forces_DeRe
-    {W E : Type*} (f : SkolemCF W E)
-    (R : E → W → W → Prop) (agent : E) (worlds : List W)
-    (nounProp : W → E → Prop) (vp : E → W → Prop) (w₀ : W) :
-    -- If the CF is "moved" (evaluated at w₀ for both its world and NP args),
-    -- the result is de re, not pseudo-de dicto.
-    (∀ w' ∈ worlds, R agent w₀ w' →
-      ¬vp (f w₀ (nounProp w₀)) w') ↔
-    wideDeReTC W E f R agent worlds nounProp vp w₀ := by
-  rfl
-
--- ============================================================================
--- §3 The Fixed-Set Problem and World-Skolemization
--- ============================================================================
-
-/-- The fixed-set problem: when the NP extension is rigid across worlds,
-    a non-world-skolemized CF returns the same individual everywhere.
-
-    [mirrazi-2024] §3: Consider a course on Covid-19 with exactly 5
-    books {A,B,C,D,E}. The extension of "book Carl has to read" is the same
-    set in every belief world. A plain intensional CF `f(⟨s,⟨e,t⟩⟩)` applied
-    to this rigid intension always returns the same book. -/
-theorem fixedSet_no_variation {W E : Type*}
-    (f : CF E)
-    (nounProp : E → Prop) :
-    ∀ (_ _ : W), f nounProp = f nounProp :=
-  λ _ _ => rfl
-
-/-- World-skolemization solves the fixed-set problem: `f(w', P)` can pick
-    different individuals at different worlds because `f` varies with `w'`.
-
-    [mirrazi-2024] ex. (45): f(w₁, {A,B,C,D,E}) = A,
-    f(w₂, {A,B,C,D,E}) = C, f(w₃, {A,B,C,D,E}) = E. -/
-theorem worldSkolem_allows_variation {W E : Type*}
-    (f : SkolemCF W E) (P : E → Prop) (w₁ w₂ : W)
-    (hVary : f w₁ P ≠ f w₂ P) :
-    ∃ (_ : W) (_ : W), f w₁ P ≠ f w₂ P :=
-  ⟨w₁, w₂, hVary⟩
-
--- ============================================================================
--- §4 Indefinite / Universal Asymmetry (Derived)
--- ============================================================================
-
-/-! Wide pseudo-scope de dicto requires CF semantics + world variable.
-
-[mirrazi-2024] §1.3: universal quantifiers (*hame* "all") under
-the same negated intensional operators do NOT get wide pseudo-scope
-de dicto readings. This follows because universals are genuine GQs
-— they cannot separate quantificational force from their descriptive content.
-
-The prediction is DERIVED from `IndefType.canPseudoDeDicto`:
-- Indefinite (CF + world var): ✓
-- Universal (GQ): ✗ regardless of world variable -/
-
-/-- ∃-quantifiers never yield pseudo-de dicto, regardless of world
-    variable. This is structural: ∃-quantifiers cannot separate their
-    quantificational force from their descriptive content, so there is
-    no mechanism to place ∃ above negation while keeping the restrictor
-    below the intensional operator. -/
-theorem existential_never_pseudo (b : Bool) :
-    IndefType.canPseudoDeDicto .existential b = false := rfl
-
--- ============================================================================
--- §5 Cross-Linguistic Variation (Structural)
--- ============================================================================
-
-/-! Cross-linguistic parameter: whether wide pseudo-scope de dicto is
-    available depends on whether the language's indefinite determiners
-    carry a world variable AND use CF semantics.
-
-    [mirrazi-2024] §3.1, [schwarz-2012]:
-
-    | Language | CF | World var | canPseudoDeDicto |
-    |----------|-----------|-----------|-----------------|
-    | Farsi    | ✓         | ✓         | ✓               |
-    | Japanese | ✓         | ✓         | ✓               |
-    | English  | ✓         | ✓/✗       | marginal        |
-    | German   | ?         | ✗         | ✗               |
-    | French   | ?         | ✗         | ✗               |
-
-    These two structural theorems derive the full typological pattern
-    from `canPseudoDeDicto`. -/
-
-/-- The world variable is necessary: without it, even CF indefinites
-    cannot get pseudo-de dicto (the CF has no world argument to bind). -/
-theorem worldVar_necessary_for_pseudo :
-    IndefType.canPseudoDeDicto .choiceFunction false = false := rfl
-
-/-- The world variable is sufficient (given CF): with it, the CF's
-    world argument can be bound by the intensional operator, yielding
-    de dicto construal while ∃-closure sits above negation. -/
-theorem worldVar_sufficient_for_pseudo :
-    IndefType.canPseudoDeDicto .choiceFunction true = true := rfl
-
--- ============================================================================
--- §6 Bridge: Farsi Indefinites (Structural)
--- ============================================================================
-
-/-- Any `PlainIndefiniteEntry` that is a choice function with a world
-    variable is predicted to support wide pseudo-scope de dicto.
-    This is the structurally general version — it applies to ye, čand-ta,
-    do-ta, and any future entry with the same properties. -/
-theorem plainIndef_pseudo_de_dicto (entry : PlainIndefiniteEntry)
-    (hCF : entry.indefType = .choiceFunction)
-    (hWV : entry.hasWorldVar = true) :
-    IndefType.canPseudoDeDicto entry.indefType entry.hasWorldVar = true := by
-  simp [hCF, hWV, IndefType.canPseudoDeDicto]
+/-- The Farsi indefinites *ye*, *čand-ta*, and *do-ta* are choice-functional with a world
+variable, so they support the wide pseudo-scope de dicto reading. -/
+theorem farsi_indefinites_pseudo :
+    ∀ e ∈ [ye, candTa, doTa], IndefType.canPseudoDeDicto e.indefType e.hasWorldVar = true := by
+  decide
 
 end Mirrazi2024

--- a/references.bib
+++ b/references.bib
@@ -6321,7 +6321,7 @@
   pages     = {128--144},
   subfield  = {semantics/compositional},
   role      = {formalized},
-  sources   = {Data/Examples/Heim1994b.json;Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Resolution.lean;Studies/Dayal2016.lean;Studies/Fox2018.lean;Studies/George2011.lean;Studies/Heim1994b.lean;Studies/Mirrazi2024.lean}
+  sources   = {Data/Examples/Heim1994b.json;Semantics/Questions/Exhaustivity.lean;Semantics/Questions/Resolution.lean;Studies/Dayal2016.lean;Studies/Fox2018.lean;Studies/George2011.lean;Studies/Heim1994b.lean}
 }% REF: Kearns, K. (2000). Semantics. New York: St. Martin's.
 @book{kearns-2000,
   author    = {Kearns, Kate},
@@ -9639,7 +9639,7 @@
   subfield  = {semantics/modality},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Composition/Tree.lean;Studies/Mirrazi2024.lean;Semantics/Intensional/Rigidity.lean}
+  sources   = {Semantics/Composition/Tree.lean;Semantics/Intensional/Rigidity.lean}
 }% REF: von Fintel, K. (2012). Subjunctive conditionals. In Russell & Fara, Routledge Companion to Philosophy of Language.
 @misc{von-fintel-2012,
   author    = {von Fintel, Kai},
@@ -17326,7 +17326,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Farsi/Determiners.lean;Studies/Mirrazi2024.lean;Semantics/Quantification/ChoiceFunction.lean}
+  sources   = {Fragments/Farsi/Determiners.lean;Semantics/Quantification/ChoiceFunction.lean}
 }% REF: Brasoveanu, A. (2010). Decomposing Modal Quantification. JoS 27(4).
 @article{brasoveanu-2010,
   author    = {Brasoveanu, Adrian},


### PR DESCRIPTION
Recut on the Semantics and Pragmatics text: the two truth conditions and their collapse under rigidity stay, and the Farsi determiners instantiate the classification.
- Cuts the Bool neg-raising record and its rfl theorems, the vacuous fixed-set and skolemization theorems, and the parenthesized open lists