### PR TITLE
refactor(Studies/MitrovicSauerland2016): header, triadic witness

### DIFF
--- a/Linglib/Studies/MitrovicSauerland2016.lean
+++ b/Linglib/Studies/MitrovicSauerland2016.lean
@@ -7,62 +7,40 @@ import Linglib.Fragments.Latin.Coordination
 import Linglib.Fragments.Korean.Coordination
 
 /-!
-# Mitrović & Sauerland (2016): Two conjunctions are better than one
-[mitrovic-sauerland-2016] [mitrovic-sauerland-2014] [mitrovic-2021]
-[haspelmath-2007]
+# Mitrović and Sauerland (2016): Two Conjunctions Are Better Than One
 
-Moreno Mitrović & Uli Sauerland. "Two conjunctions are better than one."
-*Acta Linguistica Hungarica* 63 (2016) 4, 471–494.
-DOI: 10.1556/064.2016.63.4.5
-
-The paper proposes a universal **J-μ system** for DP coordination: μ is an
-e-type head (combines with a single individual) and J is a t-type head
-(combines two truth-value-typed arguments). Languages parametrise which
-heads are overtly pronounced; the predictions are:
-
-- **J-type coordinators** (e.g. English *and*) have propositional uses, do not
-  double, and lack additive/quantificational uses.
-- **μ-type coordinators** (e.g. Japanese *mo*) combine DPs, can double, and
-  may have additive/quantificational uses.
-- Some languages overtly realise both heads, giving triadic exponency
-  (J + two μ): [mitrovic-sauerland-2016] §3.1 lists SE Macedonian,
-  Hungarian, and Avar as their attested cases (with SerBo-Croatian
-  approaching the pattern with adversative J).
-
-## Main declarations
-
-* `hasAllThreeStrategies` — propositional predicate for triadic exponency.
-* `mu_additive_generalization` — every language with a μ morpheme has a μ
-  morpheme that also serves as the additive particle (§3).
-* `j_is_universal` — every M&S focus language has a J-only strategy (§1).
-* `all_three_is_rare` — within the focus sample, only Hungarian and Georgian
-  show triadic exponency; the paper's own sample uses SE Macedonian, Avar,
-  Hungarian (none of SE Macedonian / Avar / SerBo-Croatian is encoded here,
-  so the formalised claim is restricted to the M&S focus sub-sample).
-* `mu_kind_asymmetry` — Georgian μ is bound, Hungarian μ is free; [bill-etal-2025]
-  link this morphological asymmetry to acquisition difficulty.
+This file formalizes the universal two-head system for nominal coordination proposed by
+[mitrovic-sauerland-2016]. The head μ combines with a single individual and the head J with
+two arguments of truth-value type, and languages differ in which heads they pronounce.
+Coordinators of the J kind, such as English *and*, have propositional uses, do not double,
+and lack additive and quantificational uses; coordinators of the μ kind, such as Japanese
+*mo*, combine noun phrases, double, and serve as additive particles. Some languages realize
+both heads at once, triadic exponency, which the paper attests in Southeastern Macedonian,
+Hungarian, and Avar (`hasAllThreeStrategies`, `hungarian_triadic`). The generalizations
+stated over the sample are that every language has a J-only strategy (`j_is_universal`) and
+that every μ morpheme is also the language's additive particle
+(`mu_additive_generalization`).
 
 ## Implementation notes
 
-* The language records (`english`, `japanese`, `hungarian`, `georgian`, `latin`,
-  `korean`, `slovenian`) carry the J/μ classification of each language's
-  conjunction morphemes; the morphemes are the Fragment entries. The
-  triadic-exponency classification of Georgian and the Korean and Slovenian
-  records follow [mitrovic-2021]; [mitrovic-sauerland-2016] itself
-  does not include Georgian.
-* The original paper's languages SE Macedonian, Avar, and SerBo-Croatian
-  are not yet in the sample.
+The language records carry the J and μ classification of each language's coordinators,
+which are the fragment entries; Georgian, Korean, and Slovenian follow [mitrovic-2021],
+and Southeastern Macedonian, Avar, and Serbo-Croatian are not in the sample.
+
+## References
+
+* [mitrovic-sauerland-2016]
+* [mitrovic-sauerland-2014]
+* [mitrovic-2021]
+* [haspelmath-2007]
 -/
 
 namespace MitrovicSauerland2016
 
 open Syntax.Coordination
 
-/-! ### The language records -/
-
-/-- English only has J ("and"). "Both...and" is sometimes analyzed as J-MU,
-    but "both" is not productively used as an additive particle (*"John both
-    slept") and English lacks MU-only conjunction (*"John both Mary both slept"). -/
+/-- English has only J, *and*: *both … and* is not productively additive, and there is no
+μ-only conjunction. -/
 def english : ConjunctionSystem :=
   { language := "English"
   , morphemes := [ { entry := English.Coordination.and_ } ]
@@ -70,8 +48,8 @@ def english : ConjunctionSystem :=
   , patterns := [.a_co_b]
   , iso := "eng" }
 
-/-- Japanese conjunction uses "to" (J) and "mo" (MU).
-    "to" derives from the comitative marker. "mo" is also the additive particle. -/
+/-- Japanese *to* is J, from the comitative marker, and *mo* is μ, also the additive
+particle. -/
 def japanese : ConjunctionSystem :=
   { language := "Japanese"
   , morphemes :=
@@ -83,10 +61,9 @@ def japanese : ConjunctionSystem :=
   , patterns := [.a'co_b, .a'co_b'co]
   , iso := "jpn" }
 
-/-- Hungarian: "és" (J, free, prepositive), "is" (MU, free, postpositive).
-    "is" is also the additive focus particle ("also"). One of the languages
-    exhibiting triadic exponency, all three of two μ heads and a J head,
-    [mitrovic-sauerland-2016] (28). -/
+/-- Hungarian *és* is J, free and prepositive, and *is* is μ, free and postpositive, also
+the additive focus particle; the language realizes J and two μ heads at once, the paper's
+triadic exponency. -/
 def hungarian : ConjunctionSystem :=
   { language := "Hungarian"
   , morphemes :=
@@ -97,11 +74,8 @@ def hungarian : ConjunctionSystem :=
   , patterns := [.a_co_b, .a'co_b'co]
   , iso := "hun" }
 
-/-- Georgian: "da" (J, free), "-c" (MU, bound clitic).
-    "-c" is also the additive/focus particle. Classified as exhibiting all
-    three strategies per [mitrovic-2021]; [mitrovic-sauerland-2016]
-    itself uses SE Macedonian, Hungarian, and Avar as the triadic-exponency
-    languages. -/
+/-- Georgian *da* is J, free, and *-c* is μ, a bound clitic and the additive particle; the
+triadic classification follows [mitrovic-2021]. -/
 def georgian : ConjunctionSystem :=
   { language := "Georgian"
   , morphemes :=
@@ -112,8 +86,7 @@ def georgian : ConjunctionSystem :=
   , patterns := [.a_co_b, .a'co_b'co]
   , iso := "kat" }
 
-/-- Latin: "et" (J, free, prepositive) and "-que" (MU, bound enclitic, postpositive).
-    Three patterns: A et B, A B-que, et A B-que. -/
+/-- Latin *et* is J, free and prepositive, and *-que* is μ, a bound enclitic. -/
 def latin : ConjunctionSystem :=
   { language := "Latin"
   , morphemes :=
@@ -124,8 +97,8 @@ def latin : ConjunctionSystem :=
   , patterns := [.a_co_b, .a_b'co, .co'a_b'co]
   , iso := "lat" }
 
-/-- Korean: "-(i)rang" (J, bound, postpositive) and "-to" (MU, bound, additive);
-    classification follows [mitrovic-2021]. -/
+/-- Korean *-(i)rang* is J, bound and postpositive, and *-to* is μ, bound and additive,
+following [mitrovic-2021]. -/
 def korean : ConjunctionSystem :=
   { language := "Korean"
   , morphemes :=
@@ -136,7 +109,7 @@ def korean : ConjunctionSystem :=
   , patterns := [.a'co_b, .a'co_b'co]
   , iso := "kor" }
 
-/-- Slovenian: "in" (J, free, prepositive). Primarily J-only. -/
+/-- Slovenian *in* is J, free and prepositive. -/
 def slovenian : ConjunctionSystem :=
   { language := "Slovenian"
   , morphemes :=
@@ -149,49 +122,23 @@ def slovenian : ConjunctionSystem :=
 def msLanguages : List ConjunctionSystem :=
   [english, japanese, hungarian, georgian, latin, korean, slovenian]
 
-/-! ### Triadic-exponency predicate -/
-
-/-- A language exhibits **triadic exponency** when all three M&S strategies
-    (J-only, MU-only, J-MU) are attested. The paper's strongest synchronic
-    typological observation (§3.1). -/
+/-- Triadic exponency: the J-only, μ-only, and J-with-μ strategies are all attested. -/
 def hasAllThreeStrategies (sys : ConjunctionSystem) : Prop :=
   sys.hasStrategy .jOnly ∧ sys.hasStrategy .muOnly ∧ sys.hasStrategy .jMu
 
 instance (sys : ConjunctionSystem) : Decidable (hasAllThreeStrategies sys) := by
   unfold hasAllThreeStrategies; infer_instance
 
-/-! ### M&S 2016 generalisations -/
+/-- Hungarian realizes all three strategies, *Kati is (és) Mari is*. -/
+theorem hungarian_triadic : hasAllThreeStrategies hungarian := by decide
 
-/-- **MU is additive.** Every language with a MU conjunction particle uses
-    the same morpheme as its additive ("also/too") particle ([mitrovic-sauerland-2016]
-    §3). MU is a single lexical item with subset semantics that appears in
-    both conjunction and additive contexts. -/
+/-- Every language with a μ coordinator uses the same morpheme as its additive particle. -/
 theorem mu_additive_generalization :
-    ∀ sys ∈ msLanguages,
-      (∃ m ∈ sys.morphemes, m.entry.role = .mu) → sys.muIsAdditive := by
+    ∀ sys ∈ msLanguages, (∃ m ∈ sys.morphemes, m.entry.role = .mu) → sys.muIsAdditive := by
   decide
 
-/-- **J is universal in the M&S focus sample.** Every M&S-classified language
-    has at least the J-only strategy ([mitrovic-sauerland-2016] §3). -/
+/-- Every language in the sample has a J-only strategy. -/
 theorem j_is_universal : ∀ sys ∈ msLanguages, sys.hasStrategy .jOnly := by
-  decide
-
-/-- **Triadic exponency is rare.** Within the seven-language sample, the only
-    languages exhibiting all three M&S strategies (J, MU, J-MU) are Hungarian
-    and Georgian (iso codes "hun", "kat"). The biconditional pins which
-    languages have the rare pattern and which do not. -/
-theorem all_three_is_rare :
-    ∀ sys ∈ msLanguages,
-      hasAllThreeStrategies sys ↔ sys.iso = "kat" ∨ sys.iso = "hun" := by
-  decide
-
-/-- **MU attachment asymmetry.** Georgian MU (*-c*) is a bound enclitic;
-    Hungarian MU (*is*) is free. [bill-etal-2025] (with [mitrovic-2021])
-    propose this morphological difference may explain the acquisition
-    asymmetry: bound morphemes are harder to segment. -/
-theorem mu_kind_asymmetry :
-    georgian.muKind = some (.bound .after .clitic) ∧
-    hungarian.muKind = some .free := by
   decide
 
 end MitrovicSauerland2016

--- a/references.bib
+++ b/references.bib
@@ -21774,7 +21774,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/BillEtAl2025.lean}
+  sources   = {Studies/BillEtAl2025.lean;Studies/MitrovicSauerland2016.lean}
 }% REF: Chomsky, N. (2015). "Problems of Projection: Extensions"
 @article{collins-stabler-2016,
   author    = {Collins, Chris and Stabler, Edward},


### PR DESCRIPTION
Header in register against the paper text; Hungarian witnesses triadic exponency.
- Cuts the sample-relative rarity biconditional over ISO strings and the μ-attachment theorem framed by the later Bill et al. paper, which states it itself