### PR TITLE
feat(Studies): Bybee1995, type frequency and openness of schemas

### DIFF
--- a/Linglib/Data/Forms/Bybee1995.json
+++ b/Linglib/Data/Forms/Bybee1995.json
@@ -1,0 +1,190 @@
+{
+  "FormTable": [
+    {
+      "ID": "bybee1995_strung",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "string_past",
+      "Form": "strung",
+      "Segments": ["str", "ʌ", "ŋ"],
+      "Comment": "central member of the product-oriented class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_stung",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "sting_past",
+      "Form": "stung",
+      "Segments": ["st", "ʌ", "ŋ"],
+      "Comment": "member of the product-oriented class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_flung",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "fling_past",
+      "Form": "flung",
+      "Segments": ["fl", "ʌ", "ŋ"],
+      "Comment": "member of the product-oriented class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_hung",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "hang_past",
+      "Form": "hung",
+      "Segments": ["h", "ʌ", "ŋ"],
+      "Comment": "member of the product-oriented class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_strike",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "strike",
+      "Form": "strike",
+      "Segments": ["str", "aɪ", "k"],
+      "Comment": "base of a dialectal new member; its vowel is not /ɪ/",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_struck",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "strike_past",
+      "Form": "struck",
+      "Segments": ["str", "ʌ", "k"],
+      "Comment": "dialectal new member of the class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_sneak",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "sneak",
+      "Form": "sneak",
+      "Segments": ["sn", "i", "k"],
+      "Comment": "base of a dialectal new member; its vowel is not /ɪ/",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_snuck",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "sneak_past",
+      "Form": "snuck",
+      "Segments": ["sn", "ʌ", "k"],
+      "Comment": "dialectal new member of the class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_drag",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "drag",
+      "Form": "drag",
+      "Segments": ["dr", "æ", "g"],
+      "Comment": "base of a dialectal new member; its vowel is not /ɪ/",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_drug",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "drag_past",
+      "Form": "drug",
+      "Segments": ["dr", "ʌ", "g"],
+      "Comment": "dialectal new member of the class",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_string",
+      "Language_ID": "stan1293",
+      "Parameter_ID": "string",
+      "Form": "string",
+      "Segments": ["str", "ɪ", "ŋ"],
+      "Comment": "base of strung",
+      "Source": ["bybee-1995[2]"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "string_past",
+      "Name": "string (past)",
+      "Description": ""
+    },
+    {
+      "ID": "sting_past",
+      "Name": "sting (past)",
+      "Description": ""
+    },
+    {
+      "ID": "fling_past",
+      "Name": "fling (past)",
+      "Description": ""
+    },
+    {
+      "ID": "hang_past",
+      "Name": "hang (past)",
+      "Description": ""
+    },
+    {
+      "ID": "strike",
+      "Name": "strike",
+      "Description": ""
+    },
+    {
+      "ID": "strike_past",
+      "Name": "strike (past)",
+      "Description": ""
+    },
+    {
+      "ID": "sneak",
+      "Name": "sneak",
+      "Description": ""
+    },
+    {
+      "ID": "sneak_past",
+      "Name": "sneak (past)",
+      "Description": ""
+    },
+    {
+      "ID": "drag",
+      "Name": "drag",
+      "Description": ""
+    },
+    {
+      "ID": "drag_past",
+      "Name": "drag (past)",
+      "Description": ""
+    },
+    {
+      "ID": "string",
+      "Name": "string",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": [
+    {
+      "ID": "bybee1995_string_strung",
+      "Form_ID": "bybee1995_string",
+      "Target_ID": "bybee1995_strung",
+      "Relation": "past",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_strike_struck",
+      "Form_ID": "bybee1995_strike",
+      "Target_ID": "bybee1995_struck",
+      "Relation": "past",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_sneak_snuck",
+      "Form_ID": "bybee1995_sneak",
+      "Target_ID": "bybee1995_snuck",
+      "Relation": "past",
+      "Source": ["bybee-1995[2]"]
+    },
+    {
+      "ID": "bybee1995_drag_drug",
+      "Form_ID": "bybee1995_drag",
+      "Target_ID": "bybee1995_drug",
+      "Relation": "past",
+      "Source": ["bybee-1995[2]"]
+    }
+  ]
+}

--- a/Linglib/Data/Forms/Bybee1995.lean
+++ b/Linglib/Data/Forms/Bybee1995.lean
@@ -1,0 +1,168 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `Bybee1995` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/Bybee1995.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace Bybee1995.Forms`.
+-/
+
+namespace Bybee1995.Forms
+
+open Data.Forms
+
+def strung : Form :=
+  { id := "bybee1995_strung"
+    languageId := "stan1293"
+    parameterId := "string_past"
+    form := "strung"
+    segments := ["str", "ʌ", "ŋ"]
+    comment := "central member of the product-oriented class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def stung : Form :=
+  { id := "bybee1995_stung"
+    languageId := "stan1293"
+    parameterId := "sting_past"
+    form := "stung"
+    segments := ["st", "ʌ", "ŋ"]
+    comment := "member of the product-oriented class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def flung : Form :=
+  { id := "bybee1995_flung"
+    languageId := "stan1293"
+    parameterId := "fling_past"
+    form := "flung"
+    segments := ["fl", "ʌ", "ŋ"]
+    comment := "member of the product-oriented class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def hung : Form :=
+  { id := "bybee1995_hung"
+    languageId := "stan1293"
+    parameterId := "hang_past"
+    form := "hung"
+    segments := ["h", "ʌ", "ŋ"]
+    comment := "member of the product-oriented class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def strike : Form :=
+  { id := "bybee1995_strike"
+    languageId := "stan1293"
+    parameterId := "strike"
+    form := "strike"
+    segments := ["str", "aɪ", "k"]
+    comment := "base of a dialectal new member; its vowel is not /ɪ/"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def struck : Form :=
+  { id := "bybee1995_struck"
+    languageId := "stan1293"
+    parameterId := "strike_past"
+    form := "struck"
+    segments := ["str", "ʌ", "k"]
+    comment := "dialectal new member of the class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def sneak : Form :=
+  { id := "bybee1995_sneak"
+    languageId := "stan1293"
+    parameterId := "sneak"
+    form := "sneak"
+    segments := ["sn", "i", "k"]
+    comment := "base of a dialectal new member; its vowel is not /ɪ/"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def snuck : Form :=
+  { id := "bybee1995_snuck"
+    languageId := "stan1293"
+    parameterId := "sneak_past"
+    form := "snuck"
+    segments := ["sn", "ʌ", "k"]
+    comment := "dialectal new member of the class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def drag : Form :=
+  { id := "bybee1995_drag"
+    languageId := "stan1293"
+    parameterId := "drag"
+    form := "drag"
+    segments := ["dr", "æ", "g"]
+    comment := "base of a dialectal new member; its vowel is not /ɪ/"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def drug : Form :=
+  { id := "bybee1995_drug"
+    languageId := "stan1293"
+    parameterId := "drag_past"
+    form := "drug"
+    segments := ["dr", "ʌ", "g"]
+    comment := "dialectal new member of the class"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def string : Form :=
+  { id := "bybee1995_string"
+    languageId := "stan1293"
+    parameterId := "string"
+    form := "string"
+    segments := ["str", "ɪ", "ŋ"]
+    comment := "base of strung"
+    source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+
+def all : List Form := [strung, stung, flung, hung, strike, struck, sneak, snuck, drag, drug, string]
+
+def parameters : List Parameter := [
+  { id := "string_past", name := "string (past)", description := "" },
+  { id := "sting_past", name := "sting (past)", description := "" },
+  { id := "fling_past", name := "fling (past)", description := "" },
+  { id := "hang_past", name := "hang (past)", description := "" },
+  { id := "strike", name := "strike", description := "" },
+  { id := "strike_past", name := "strike (past)", description := "" },
+  { id := "sneak", name := "sneak", description := "" },
+  { id := "sneak_past", name := "sneak (past)", description := "" },
+  { id := "drag", name := "drag", description := "" },
+  { id := "drag_past", name := "drag (past)", description := "" },
+  { id := "string", name := "string", description := "" }
+]
+
+def relations : List FormRelation := [
+  { id := "bybee1995_string_strung", formId := "bybee1995_string", targetId := "bybee1995_strung", relation := "past", source := [
+      ⟨"bybee-1995", "2"⟩
+    ] },
+  { id := "bybee1995_strike_struck", formId := "bybee1995_strike", targetId := "bybee1995_struck", relation := "past", source := [
+      ⟨"bybee-1995", "2"⟩
+    ] },
+  { id := "bybee1995_sneak_snuck", formId := "bybee1995_sneak", targetId := "bybee1995_snuck", relation := "past", source := [
+      ⟨"bybee-1995", "2"⟩
+    ] },
+  { id := "bybee1995_drag_drug", formId := "bybee1995_drag", targetId := "bybee1995_drug", relation := "past", source := [
+      ⟨"bybee-1995", "2"⟩
+    ] }
+]
+
+end Bybee1995.Forms

--- a/Linglib/Studies/Bybee1995.lean
+++ b/Linglib/Studies/Bybee1995.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Data.Forms.Bybee1995
+import Linglib.Morphology.ConstructionMorphology.Schema
+import Mathlib.Data.Multiset.Filter
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
+
+/-!
+# Bybee (1995): Regular morphology and the lexicon
+
+This file formalizes [bybee-1995]'s network model of productivity, in which schemas emerge
+over stored forms and the productivity of a schema is determined by two things: its type
+frequency, the number of distinct forms instantiating it, and the openness of its variables.
+Token frequency does the opposite work, strengthening an individual form's own entry. Over a
+corpus of tokens, a schema's type frequency counts the distinct forms it relates and its token
+frequency counts every occurrence (`typeFrequency_le_tokenFrequency`); what a schema
+generates depends on the corpus only through its types, so repetition of a stored form leaves
+its generative capacity unchanged (`generates_iff_of_toFinset_eq`), and a more general schema
+has the larger type frequency (`typeFrequency_mono`). Openness is the other determinant: a
+schema generates every instance whatever is stored exactly when all of its variables are open
+(`generates_iff_instantiates_forall_iff_isProductive`), which is what makes the English past in
+*-ed* fully productive (`edSchema_isProductive`).
+
+Schemas are product-oriented: generalizations over the derived forms themselves, not over
+pairs of base and derived form. The class of *strung* is the shape of its past tenses, and the
+dialectal new members *struck*, *snuck* and *drug* fit that shape (`struck_instantiates`) while
+their bases lack the vowel a source-oriented pairing from *string* would demand
+(`not_sourceOriented_pairs`), the finding of [bybee-moder-1983].
+
+## Implementation notes
+
+* A corpus is a multiset of forms; the lexicon of a schema's roles is its set of types.
+* The counts of Table 8.1, the French conjugations children overgeneralize by type rather than
+  token frequency, and the German participle and plural cases are not formalized.
+
+## References
+
+* [bybee-1995]
+* [bybee-2007]
+* [bybee-moder-1983]
+-/
+
+namespace Bybee1995
+
+open ConstructionMorphology
+
+variable {P α : Type*} [PartialOrder α]
+
+/-! ### Type frequency and token frequency -/
+
+section Frequency
+variable [DecidableEq (P → α)]
+
+/-- The type frequency of a schema over a corpus: the number of distinct forms instantiating
+it. -/
+def typeFrequency (s : Schema P α) [DecidablePred s.Instantiates] (c : Multiset (P → α)) :
+    ℕ :=
+  (c.toFinset.filter s.Instantiates).card
+
+/-- The token frequency of a schema over a corpus: the number of occurrences of forms
+instantiating it. -/
+def tokenFrequency (s : Schema P α) [DecidablePred s.Instantiates] (c : Multiset (P → α)) :
+    ℕ :=
+  Multiset.card (c.filter s.Instantiates)
+
+/-- Types are at most tokens. -/
+theorem typeFrequency_le_tokenFrequency (s : Schema P α) [DecidablePred s.Instantiates]
+    (c : Multiset (P → α)) : typeFrequency s c ≤ tokenFrequency s c := by
+  unfold typeFrequency tokenFrequency
+  rw [← Multiset.toFinset_filter]
+  exact Multiset.toFinset_card_le _
+
+/-- A more general schema has the larger type frequency. -/
+theorem typeFrequency_mono {s t : Schema P α} [DecidablePred s.Instantiates]
+    [DecidablePred t.Instantiates] (h : t.body ≤ s.body) (c : Multiset (P → α)) :
+    typeFrequency s c ≤ typeFrequency t c :=
+  Finset.card_le_card
+    (Finset.monotone_filter_right _ λ _ _ hw => Schema.body_le_body_iff.1 h hw)
+
+/-- What a schema generates depends on a corpus only through its types: repeating a stored
+form, raising its token frequency, changes nothing. -/
+theorem generates_iff_of_toFinset_eq [OrderBot α] (s : Schema P α) {c c' : Multiset (P → α)}
+    (h : c.toFinset = c'.toFinset) {w : P → α} :
+    s.Generates ↑c.toFinset w ↔ s.Generates ↑c'.toFinset w := by
+  rw [h]
+
+end Frequency
+
+/-! ### Openness -/
+
+/-- A schema generates every instance over every lexicon exactly when all its variables are
+open: only a totally open schema attains full productivity. -/
+theorem generates_iff_instantiates_forall_iff_isProductive [OrderBot α] (s : Schema P α) :
+    (∀ (Λ : Set (P → α)) w, s.Generates Λ w ↔ s.Instantiates w) ↔ s.IsProductive :=
+  ⟨λ h => Schema.isProductive_iff_generates_empty.2 ((h ∅ _).2 s.instantiates_body),
+    λ hs _ _ => hs.generates_iff⟩
+
+/-- The English past in *-ed*, over a base slot and an affix slot: the base open. -/
+def edSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ed"], {0}⟩
+
+/-- The regular past is totally open. -/
+theorem edSchema_isProductive : edSchema.IsProductive := by
+  intro i h
+  fin_cases i
+  · exact Set.mem_singleton_iff.2 rfl
+  · exact absurd h (by decide)
+
+/-! ### The product-oriented class of *strung* -/
+
+/-- The product-oriented schema of the *strung* class over onset, nucleus and coda: the
+nucleus pinned to /ʌ/, the onset open, the coda a closed variable filled from the class. -/
+def strungSchema : Schema (Fin 3) (Flat String) := ⟨![⊥, ↑"ʌ", ⊥], {0}⟩
+
+/-- The stored members of the class. -/
+def strungClass : Set (Fin 3 → Flat String) :=
+  {Forms.strung.slots, Forms.stung.slots, Forms.flung.slots, Forms.hung.slots}
+
+/-- The dialectal new members fit the shape of the class. -/
+theorem struck_instantiates :
+    strungSchema.Instantiates Forms.struck.slots ∧ strungSchema.Instantiates Forms.snuck.slots ∧
+      strungSchema.Instantiates Forms.drug.slots := by
+  refine ⟨λ i => ?_, λ i => ?_, λ i => ?_⟩ <;> fin_cases i <;> decide
+
+/-- The variables of a source-oriented pairing of base and past: the shared onset and coda,
+and the two nuclei. -/
+inductive PairVar
+  | onset
+  | coda
+  | base
+  | past
+  deriving DecidableEq
+
+/-- A source-oriented schema pairing a base in /ɪ/ with a past in /ʌ/ over a shared onset and
+coda: the generalization over pairs such as *string*, *strung*. -/
+def sourceOriented : Schema PairVar (Flat String) :=
+  ⟨λ | .base => ↑"ɪ" | .past => ↑"ʌ" | _ => ⊥, {.onset, .coda}⟩
+
+/-- The subscripting of the base's positions. -/
+def baseSub : Fin 3 → PairVar := ![.onset, .base, .coda]
+
+/-- The subscripting of the past's positions. -/
+def pastSub : Fin 3 → PairVar := ![.onset, .past, .coda]
+
+/-- *string* and *strung* are a paired instantiation of the source-oriented schema. -/
+theorem string_strung_pairs :
+    sourceOriented.InstantiatesAt (Sum.elim baseSub pastSub)
+      (Sum.elim Forms.string.slots Forms.strung.slots) :=
+  ⟨λ | .onset => ↑"str" | .coda => ↑"ŋ" | .base => ↑"ɪ" | .past => ↑"ʌ",
+    λ v => by cases v <;> decide,
+    funext λ p => by rcases p with p | p <;> fin_cases p <;> decide⟩
+
+/-- The new members are not: their bases lack /ɪ/, so no source-oriented schema pairs them,
+while the product-oriented schema admits them. -/
+theorem not_sourceOriented_pairs :
+    ¬ sourceOriented.InstantiatesAt (Sum.elim baseSub pastSub)
+        (Sum.elim Forms.strike.slots Forms.struck.slots) ∧
+      ¬ sourceOriented.InstantiatesAt (Sum.elim baseSub pastSub)
+        (Sum.elim Forms.sneak.slots Forms.snuck.slots) ∧
+      ¬ sourceOriented.InstantiatesAt (Sum.elim baseSub pastSub)
+        (Sum.elim Forms.drag.slots Forms.drug.slots) := by
+  refine ⟨λ h => ?_, λ h => ?_, λ h => ?_⟩ <;>
+    exact absurd (Flat.coe_le_iff.1 ((Schema.instantiatesAt_elim_iff.1 h).1 1)) (by decide)
+
+end Bybee1995

--- a/references.bib
+++ b/references.bib
@@ -23199,6 +23199,32 @@
   sources   = {Studies/AlbrightHayes2003.lean}
 }
 % REF: Bybee, J. L. (1985). *Morphology: A Study of the Relation between Meaning and Form*. Benjamins.
+@article{bybee-1995,
+  author    = {Bybee, Joan},
+  year      = {1995},
+  title     = {Regular morphology and the lexicon},
+  journal   = {Language and Cognitive Processes},
+  volume    = {10},
+  number    = {5},
+  pages     = {425--455},
+  doi       = {10.1080/01690969508407111},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Bybee1995.lean;Data/Forms/Bybee1995.json}
+}
+
+@book{bybee-2007,
+  author    = {Bybee, Joan},
+  year      = {2007},
+  title     = {Frequency of Use and the Organization of Language},
+  publisher = {Oxford University Press},
+  address   = {New York},
+  doi       = {10.1093/acprof:oso/9780195301571.001.0001},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Bybee1995.lean}
+}
+
 @book{bybee-1985,
   author    = {Bybee, Joan},
   year      = {1985},


### PR DESCRIPTION
Formalizes Bybee 1995 (Language and Cognitive Processes 10(5); reprinted as ch. 8 of Bybee 2007, the text verified) on the schema API.

- Type frequency and token frequency of a schema over a corpus (a multiset of forms): types ≤ tokens; a more general schema has the larger type frequency; what a schema generates depends on the corpus only through its types, so token frequency does not feed productivity.
- Openness: a schema generates every instance over every lexicon iff all its variables are open (`IsProductive` characterization), the sense in which only the totally open *-ed* attains full productivity.
- The product-oriented *strung* class: *struck*, *snuck*, *drug* fit the past-tense shape while a source-oriented pairing from an /ɪ/ base rejects them (Bybee & Moder 1983); 11 CLDF rows.
- Bib: `bybee-1995` (Crossref-verified), `bybee-2007` (book added to Zotero with PDF).