### PR TITLE
refactor(ConstructionMorphology): productive schemas, Pi decidability

### DIFF
--- a/Linglib/Core/Data/Fintype/Order.lean
+++ b/Linglib/Core/Data/Fintype/Order.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fintype.Defs
+import Mathlib.Order.Basic
+
+/-!
+# Decidable order on finite Pi types
+
+The pointwise order on `∀ i, α i` is decidable when the index type is finite and each
+coordinate order is, since `f ≤ g` is `∀ i, f i ≤ g i`; the strict order follows as for any
+preorder with a decidable `≤`, as `Finsupp.decidableLE` and `Finsupp.decidableLT` do.
+
+`[UPSTREAM]` candidate for `Mathlib/Data/Fintype/Defs.lean`, beside
+`Fintype.decidablePiFintype`.
+-/
+
+namespace Pi
+
+variable {ι : Type*} {α : ι → Type*} [Fintype ι]
+
+instance decidableLE [∀ i, LE (α i)] [∀ i, DecidableLE (α i)] : DecidableLE (∀ i, α i) :=
+  λ f g => inferInstanceAs (Decidable (∀ i, f i ≤ g i))
+
+instance decidableLT [∀ i, Preorder (α i)] [∀ i, DecidableLE (α i)] :
+    DecidableLT (∀ i, α i) :=
+  decidableLTOfDecidableLE
+
+end Pi

--- a/Linglib/Morphology/ConstructionMorphology/Schema.lean
+++ b/Linglib/Morphology/ConstructionMorphology/Schema.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Data.Fintype.Order
 import Linglib.Core.Data.Sum.Basic
 import Linglib.Core.Order.PartialUnify
 import Mathlib.Order.Lattice
@@ -46,9 +47,10 @@ variables (`Schema.instantiates_iff_instantiation_of_forall_isMax`).
 * `Schema.InstantiatesAt`, `Schema.instantiatesAt_iff`: instantiation at positions through a
   subscripting, as instantiation of the pulled-back description together with agreement at
   coindexed positions.
-* `Schema.Relates`, `Schema.Generates`, `Schema.IsProductive`: the two roles of a schema and
-  productivity; `Schema.generates_iff_mem_pi`: what a schema generates is the product of its
-  slotwise fillers.
+* `Schema.productive`, `Schema.Relates`, `Schema.Generates`, `Schema.IsProductive`: the schema
+  with every variable open, the two roles of a schema, and productivity;
+  `Schema.generates_iff_mem_pi`: what a schema generates is the product of its slotwise
+  fillers.
 * `Instantiation`, `Contrast`: the relational links, same except at a set of positions.
 * `Schema.instantiates_inf_iff`, `Schema.instantiates_iff_of_unify_eq_some`: the meet of two
   items is their least general generalization, the Structural Intersection of Relational
@@ -86,12 +88,15 @@ structure Schema (V α : Type*) where
 namespace Schema
 
 section PartialOrder
-variable [PartialOrder α] {s t : Schema V α} {w w₁ w₂ : V → α} {Λ Λ' : Set (V → α)}
-  {v : V}
+variable [PartialOrder α] {s t : Schema V α} {w w₁ w₂ : V → α}
 
 /-- An item `w` instantiates a schema `s` if the description of `s` lies below `w` slot by slot:
 each constant is matched and each variable is filled freely. -/
 def Instantiates (s : Schema V α) (w : V → α) : Prop := s.body ≤ w
+
+instance decidablePredInstantiates [DecidableLE (V → α)] (s : Schema V α) :
+    DecidablePred s.Instantiates :=
+  λ w => inferInstanceAs (Decidable (s.body ≤ w))
 
 /-- A schema instantiates its own description. -/
 theorem instantiates_body (s : Schema V α) : s.Instantiates s.body := le_rfl
@@ -213,6 +218,21 @@ theorem instantiatesAt_elim_swap :
     funext λ p => by cases p <;> rfl
   rw [h₁, h₂]
 
+/-- Through injective subscriptings that coincide exactly off `S`, a paired instantiation is
+two instances of the pulled-back descriptions that are the same except at `S`. -/
+theorem instantiatesAt_elim_iff_eqOn {pos₁ pos₂ : P → V} {w₁ w₂ : P → α} {S : Set P}
+    (h₁ : pos₁.Injective) (h₂ : pos₂.Injective)
+    (h : ∀ a b, pos₁ a = pos₂ b ↔ a = b ∧ a ∉ S) :
+    s.InstantiatesAt (Sum.elim pos₁ pos₂) (Sum.elim w₁ w₂) ↔
+      (s.comap pos₁).Instantiates w₁ ∧ (s.comap pos₂).Instantiates w₂ ∧
+        Set.EqOn w₁ w₂ Sᶜ := by
+  rw [instantiatesAt_elim_iff]
+  refine and_congr_right λ _ => and_congr_right λ _ => ⟨λ hc a ha => ?_, λ he => ?_⟩
+  · exact hc.2.2 a a ((h a a).2 ⟨rfl, ha⟩)
+  · refine ⟨h₁.factorsThrough _, h₂.factorsThrough _, λ a b hab => ?_⟩
+    obtain ⟨rfl, ha⟩ := (h a b).1 hab
+    exact he ha
+
 end Positions
 
 /-! ### The relational role -/
@@ -263,6 +283,15 @@ theorem instantiates_inf_iff [SemilatticeInf α] {s : Schema V α} {w₁ w₂ : 
 section OrderBot
 variable [PartialOrder α] [OrderBot α] {s : Schema V α} {w : V → α} {Λ Λ' : Set (V → α)}
 
+/-- The schema with description `body` and every variable open. -/
+def productive (body : V → α) : Schema V α := ⟨body, {v | body v = ⊥}⟩
+
+@[simp] theorem productive_body (body : V → α) : (productive body).body = body := rfl
+
+@[simp] theorem productive_opens (body : V → α) :
+    (productive body).opens = {v | body v = ⊥} :=
+  rfl
+
 /-- A schema `s` generates an item `w` over a lexicon `Λ` if `w` instantiates `s` and every closed
 variable of `s`, a slot at `⊥` not marked open, takes in `w` a filler attested in `Λ`: the
 generative role of a schema, licensing possibly novel items. -/
@@ -282,8 +311,8 @@ theorem generates_iff_mem_pi : s.Generates Λ w ↔ w ∈ Set.pi Set.univ (s.fil
   exact ⟨λ h v => ⟨h.1 v, h.2 v⟩, λ h => ⟨λ v => (h v).1, λ v => (h v).2⟩⟩
 
 /-- Where every value other than `⊥` is maximal, a constant admits only itself. -/
-theorem fillers_of_ne_bot (hα : ∀ a : α, a ≠ ⊥ → IsMax a) {v : V}
-    (hv : s.body v ≠ ⊥) :
+theorem fillers_eq_singleton_of_forall_isMax (hα : ∀ a : α, a ≠ ⊥ → IsMax a)
+    {v : V} (hv : s.body v ≠ ⊥) :
     s.fillers Λ v = {s.body v} := by
   ext a
   simp only [fillers, Set.mem_ofPred_eq, Set.mem_singleton_iff]
@@ -304,6 +333,8 @@ theorem Generates.mono (h : Λ ⊆ Λ') (hw : s.Generates Λ w) : s.Generates Λ
 /-- A schema is productive if every variable, every slot at `⊥`, is open. -/
 def IsProductive (s : Schema V α) : Prop := ∀ v, s.body v = ⊥ → v ∈ s.opens
 
+theorem isProductive_productive (body : V → α) : (productive body).IsProductive := λ _ h => h
+
 /-- A productive schema generates exactly its instances. -/
 theorem IsProductive.generates_iff (hs : s.IsProductive) :
     s.Generates Λ w ↔ s.Instantiates w :=
@@ -316,6 +347,13 @@ theorem isProductive_iff_generates_empty : s.IsProductive ↔ s.Generates ∅ s.
   by_contra hvo
   obtain ⟨w, ⟨hw, -⟩, -⟩ := h.2 v hv hvo
   exact hw
+
+/-- A schema generates every instance over every lexicon exactly when it is productive. -/
+theorem isProductive_iff_forall_generates_iff :
+    s.IsProductive ↔
+      ∀ (Λ : Set (V → α)) (w : V → α), s.Generates Λ w ↔ s.Instantiates w :=
+  ⟨λ hs _ _ => hs.generates_iff,
+    λ h => isProductive_iff_generates_empty.2 ((h ∅ _).2 s.instantiates_body)⟩
 
 end OrderBot
 
@@ -365,9 +403,11 @@ theorem contrast_iff_of_forall_isMax (hα : ∀ a : α, a ≠ ⊥ → IsMax a) :
       Set.EqOn f g Sᶜ ∧ ∀ p ∈ S, f p ≠ ⊥ ∧ g p ≠ ⊥ ∧ f p ≠ g p :=
   and_congr_right' (forall₂_congr λ _ _ => not_compat_iff_of_forall_isMax hα)
 
+namespace Schema
+
 /-- On a flat carrier, a filled item instantiates a schema exactly when it is the schema's
 description, the same except at the variables. -/
-theorem Schema.instantiates_iff_instantiation_of_forall_isMax
+theorem instantiates_iff_instantiation_of_forall_isMax
     (hα : ∀ a : α, a ≠ ⊥ → IsMax a) {s : Schema P α} {w : P → α}
     (hw : ∀ p, w p ≠ ⊥) :
     s.Instantiates w ↔ Instantiation s.body w {p | s.body p = ⊥} := by
@@ -378,6 +418,8 @@ theorem Schema.instantiates_iff_instantiation_of_forall_isMax
     show s.body p < w p
     rw [hp]
     exact bot_lt_iff_ne_bot.2 (hw p)
+
+end Schema
 
 end OrderBot
 

--- a/Linglib/Studies/Audring2019.lean
+++ b/Linglib/Studies/Audring2019.lean
@@ -55,7 +55,7 @@ def word (b a : String) : Fin 2 → Flat String := ![↑b, ↑a]
 /-! ### The *-ish* family: sister links and their mother -/
 
 /-- The mother schema `[N -ish]A` of (8): the affix pinned, the base an open variable. -/
-def ishSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ish"], {0}⟩
+def ishSchema : Schema (Fin 2) (Flat String) := Schema.productive ![⊥, ↑"ish"]
 
 /-- The stored family of (8). -/
 def ishFamily : Set (Fin 2 → Flat String) :=
@@ -108,11 +108,7 @@ theorem ishSchema_relates {w : Fin 2 → Flat String} (hw : w ∈ ishFamily) :
   rcases hw with rfl | rfl | rfl <;> exact ishSchema_instantiates (by decide)
 
 /-- The mother is productive: its one variable is open. -/
-theorem ishSchema_isProductive : ishSchema.IsProductive := by
-  intro i h
-  fin_cases i
-  · exact Set.mem_singleton_iff.2 rfl
-  · exact absurd h (by decide)
+theorem ishSchema_isProductive : ishSchema.IsProductive := Schema.isProductive_productive _
 
 /-- The mother generates the novel *Trumpish* with nothing stored. -/
 theorem ishSchema_generates_trumpish : ishSchema.Generates ∅ Forms.trumpish.slots :=

--- a/Linglib/Studies/Booij2010.lean
+++ b/Linglib/Studies/Booij2010.lean
@@ -53,7 +53,7 @@ affix slot is lexically fixed as `-ness` and whose base slot is an open
 
 /-- The `-ness` schema over the two slots of a `-ness` noun, base and affix: the affix slot
 pinned to `-ness`, the base slot an open deadjectival variable (`⊥`). -/
-def nessSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ness"], {0}⟩
+def nessSchema : Schema (Fin 2) (Flat String) := Schema.productive ![⊥, ↑"ness"]
 
 /-- Any filling whose affix slot is `-ness` instantiates the schema: the base slot
 is open, the affix slot's constraint is met. -/
@@ -82,11 +82,7 @@ def nessLexicon : Set (Fin 2 → Flat String) :=
   {Forms.baldness.slots, Forms.awareness.slots}
 
 /-- The `-ness` schema is productive: its one variable, the base slot, is open. -/
-theorem nessSchema_isProductive : nessSchema.IsProductive := by
-  intro i h
-  fin_cases i
-  · exact Set.mem_singleton_iff.2 rfl
-  · exact absurd h (by decide)
+theorem nessSchema_isProductive : nessSchema.IsProductive := Schema.isProductive_productive _
 
 /-- The schema licenses the novel coin `carlessness` over the stored nouns: the
 open base slot takes the unlisted adjective, and the affix slot is a constant.
@@ -136,11 +132,6 @@ def compoundFamily : CompoundNode → Schema CompoundVar (Flat String)
   | .vn => compoundSubschema "V"
   | .an => compoundSubschema "A"
   | .pn => compoundSubschema "P"
-
-instance : DecidableLE (CompoundVar → Flat String) := λ _ _ => Fintype.decidableForallFintype
-
-instance : DecidableLT (CompoundVar → Flat String) :=
-  λ _ _ => decidable_of_iff _ lt_iff_le_not_ge.symm
 
 /-- The hierarchical constructicon of English compounds, derived from the schemas. -/
 def compoundHierarchy : Hierarchy CompoundNode := .ofFamily compoundFamily (by decide)

--- a/Linglib/Studies/Bybee1995.lean
+++ b/Linglib/Studies/Bybee1995.lean
@@ -18,13 +18,13 @@ over stored forms and the productivity of a schema is determined by two things: 
 frequency, the number of distinct forms instantiating it, and the openness of its variables.
 Token frequency does the opposite work, strengthening an individual form's own entry. Over a
 corpus of tokens, a schema's type frequency counts the distinct forms it relates and its token
-frequency counts every occurrence (`typeFrequency_le_tokenFrequency`); what a schema
-generates depends on the corpus only through its types, so repetition of a stored form leaves
-its generative capacity unchanged (`generates_iff_of_toFinset_eq`), and a more general schema
-has the larger type frequency (`typeFrequency_mono`). Openness is the other determinant: a
-schema generates every instance whatever is stored exactly when all of its variables are open
-(`generates_iff_instantiates_forall_iff_isProductive`), which is what makes the English past in
-*-ed* fully productive (`edSchema_isProductive`).
+frequency counts every occurrence (`typeFrequency_le_tokenFrequency`), and a more general
+schema has the larger type frequency (`typeFrequency_mono`). What a schema generates depends
+on the corpus only through its types, since the lexicon of its roles is the corpus's set of
+types, so repetition of a stored form leaves its generative capacity unchanged. Openness is the
+other determinant: a schema generates every instance whatever is stored exactly when all of
+its variables are open (`Schema.isProductive_iff_forall_generates_iff`), which is what makes
+the English past in *-ed* fully productive (`edSchema_isProductive`).
 
 Schemas are product-oriented: generalizations over the derived forms themselves, not over
 pairs of base and derived form. The class of *strung* is the shape of its past tenses, and the
@@ -60,55 +60,37 @@ variable [DecidableEq (P → α)]
 it. -/
 def typeFrequency (s : Schema P α) [DecidablePred s.Instantiates] (c : Multiset (P → α)) :
     ℕ :=
-  (c.toFinset.filter s.Instantiates).card
+  c.dedup.countP s.Instantiates
 
 /-- The token frequency of a schema over a corpus: the number of occurrences of forms
 instantiating it. -/
 def tokenFrequency (s : Schema P α) [DecidablePred s.Instantiates] (c : Multiset (P → α)) :
     ℕ :=
-  Multiset.card (c.filter s.Instantiates)
+  c.countP s.Instantiates
 
 /-- Types are at most tokens. -/
 theorem typeFrequency_le_tokenFrequency (s : Schema P α) [DecidablePred s.Instantiates]
-    (c : Multiset (P → α)) : typeFrequency s c ≤ tokenFrequency s c := by
-  unfold typeFrequency tokenFrequency
-  rw [← Multiset.toFinset_filter]
-  exact Multiset.toFinset_card_le _
+    (c : Multiset (P → α)) : typeFrequency s c ≤ tokenFrequency s c :=
+  Multiset.countP_le_of_le _ (Multiset.dedup_le c)
 
 /-- A more general schema has the larger type frequency. -/
 theorem typeFrequency_mono {s t : Schema P α} [DecidablePred s.Instantiates]
     [DecidablePred t.Instantiates] (h : t.body ≤ s.body) (c : Multiset (P → α)) :
-    typeFrequency s c ≤ typeFrequency t c :=
-  Finset.card_le_card
-    (Finset.monotone_filter_right _ λ _ _ hw => Schema.body_le_body_iff.1 h hw)
-
-/-- What a schema generates depends on a corpus only through its types: repeating a stored
-form, raising its token frequency, changes nothing. -/
-theorem generates_iff_of_toFinset_eq [OrderBot α] (s : Schema P α) {c c' : Multiset (P → α)}
-    (h : c.toFinset = c'.toFinset) {w : P → α} :
-    s.Generates ↑c.toFinset w ↔ s.Generates ↑c'.toFinset w := by
-  rw [h]
+    typeFrequency s c ≤ typeFrequency t c := by
+  unfold typeFrequency
+  rw [Multiset.countP_eq_card_filter, Multiset.countP_eq_card_filter]
+  exact Multiset.card_le_card
+    (Multiset.monotone_filter_right _ λ _ hw => Schema.body_le_body_iff.1 h hw)
 
 end Frequency
 
 /-! ### Openness -/
 
-/-- A schema generates every instance over every lexicon exactly when all its variables are
-open: only a totally open schema attains full productivity. -/
-theorem generates_iff_instantiates_forall_iff_isProductive [OrderBot α] (s : Schema P α) :
-    (∀ (Λ : Set (P → α)) w, s.Generates Λ w ↔ s.Instantiates w) ↔ s.IsProductive :=
-  ⟨λ h => Schema.isProductive_iff_generates_empty.2 ((h ∅ _).2 s.instantiates_body),
-    λ hs _ _ => hs.generates_iff⟩
+/-- The English past in *-ed*, over a base slot and an affix slot: the base open, so totally
+open in the sense of `Schema.isProductive_iff_forall_generates_iff`. -/
+def edSchema : Schema (Fin 2) (Flat String) := Schema.productive ![⊥, ↑"ed"]
 
-/-- The English past in *-ed*, over a base slot and an affix slot: the base open. -/
-def edSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ed"], {0}⟩
-
-/-- The regular past is totally open. -/
-theorem edSchema_isProductive : edSchema.IsProductive := by
-  intro i h
-  fin_cases i
-  · exact Set.mem_singleton_iff.2 rfl
-  · exact absurd h (by decide)
+theorem edSchema_isProductive : edSchema.IsProductive := Schema.isProductive_productive _
 
 /-! ### The product-oriented class of *strung* -/
 
@@ -124,7 +106,7 @@ def strungClass : Set (Fin 3 → Flat String) :=
 theorem struck_instantiates :
     strungSchema.Instantiates Forms.struck.slots ∧ strungSchema.Instantiates Forms.snuck.slots ∧
       strungSchema.Instantiates Forms.drug.slots := by
-  refine ⟨λ i => ?_, λ i => ?_, λ i => ?_⟩ <;> fin_cases i <;> decide
+  decide
 
 /-- The variables of a source-oriented pairing of base and past: the shared onset and coda,
 and the two nuclei. -/

--- a/Linglib/Studies/JackendoffAudring2020.lean
+++ b/Linglib/Studies/JackendoffAudring2020.lean
@@ -375,24 +375,23 @@ def singSang : Schema NucleusVar (Flat String) := nucleusPair ↑"ɪ" ↑"æ"
 /-- The *string*/*strung* subschema, (26) with /ʌ/ for /æ/. -/
 def stringStrung : Schema NucleusVar (Flat String) := nucleusPair ↑"ɪ" ↑"ʌ"
 
+/-- A syllable instantiates a nucleus pair's stem side exactly when its nucleus is the pinned
+one. -/
+theorem comap_stemSub_instantiates_iff {v w : Flat String} {s : Fin 3 → Flat String} :
+    ((nucleusPair v w).comap stemSub).Instantiates s ↔ v ≤ s 1 :=
+  ⟨λ h => h 1, λ h i => by fin_cases i <;> first | exact bot_le | exact h⟩
+
+theorem comap_pastSub_instantiates_iff {v w : Flat String} {p : Fin 3 → Flat String} :
+    ((nucleusPair v w).comap pastSub).Instantiates p ↔ w ≤ p 1 :=
+  ⟨λ h => h 1, λ h i => by fin_cases i <;> first | exact bot_le | exact h⟩
+
 /-- A paired instantiation of a nucleus pair is a stem and a past that are the same except at
 the nucleus, with the pinned nuclei. -/
 theorem nucleusPair_iff {v w : Flat String} {s p : Fin 3 → Flat String} :
     (nucleusPair v w).InstantiatesAt (Sum.elim stemSub pastSub) (Sum.elim s p) ↔
       v ≤ s 1 ∧ w ≤ p 1 ∧ Set.EqOn s p {1}ᶜ := by
-  rw [Schema.instantiatesAt_elim_iff]
-  constructor
-  · rintro ⟨hs, hp, -, -, h⟩
-    refine ⟨hs 1, hp 1, λ q hq => h q q ?_⟩
-    fin_cases q <;> first | rfl | exact (hq rfl).elim
-  · rintro ⟨hv, hw, h⟩
-    refine ⟨λ q => ?_, λ q => ?_, λ a b hab => ?_, λ a b hab => ?_, λ a b hab => ?_⟩
-    · fin_cases q <;> first | exact bot_le | exact hv
-    · fin_cases q <;> first | exact bot_le | exact hw
-    · fin_cases a <;> fin_cases b <;> first | rfl | exact absurd hab (by decide)
-    · fin_cases a <;> fin_cases b <;> first | rfl | exact absurd hab (by decide)
-    · fin_cases a <;> fin_cases b <;>
-        first | exact absurd hab (by decide) | exact h (by simp)
+  rw [Schema.instantiatesAt_elim_iff_eqOn (S := {1}) (by decide) (by decide) (by decide),
+    comap_stemSub_instantiates_iff, comap_pastSub_instantiates_iff]
 
 /-- (25) pairs exactly the stems and pasts that are the same except at the nucleus. -/
 theorem ablaut_pairs_iff {s p : Fin 3 → Flat String} :
@@ -605,7 +604,7 @@ theorem walk_syncretism :
 
 /-- The schema (6) over the two slots of an *-ish* adjective, base and affix: the affix pinned,
 the base a variable. -/
-def ishSchema : Schema (Fin 2) (Flat String) := ⟨![⊥, ↑"ish"], {0}⟩
+def ishSchema : Schema (Fin 2) (Flat String) := Schema.productive ![⊥, ↑"ish"]
 
 /-- Structural Intersection constructs the schema: the description of (6) is the meet of the
 three sisters of (5), keeping what they share and leaving a variable where they differ. -/


### PR DESCRIPTION
Follows a mathlib-reviewer pass on the Construction Morphology substrate.

- `Core/Data/Fintype/Order.lean`: `Pi.decidableLE`/`Pi.decidableLT` for a finite index type (mathlib has none; mirrors `Finsupp`'s, `[UPSTREAM]`), plus `Schema.decidablePredInstantiates`. The local instances in `Booij2010` go; `Instantiates` facts on `Fin n → Flat String` close by `decide`.
- `Schema.productive body := ⟨body, {v | body v = ⊥}⟩` with `isProductive_productive`: the four affix schemas (`-ness`, `-ish` twice, `-ed`) and their four `fin_cases` productivity proofs become one-liners.
- `instantiatesAt_elim_iff_eqOn`: for injective subscriptings coinciding exactly off `S`, a paired instantiation is two instances of the pulled-back descriptions that agree off `S`; `JackendoffAudring2020.nucleusPair_iff` shrinks from 15 lines to a rewrite.
- `isProductive_iff_forall_generates_iff` moves into the substrate from `Bybee1995`, whose frequencies are now `Multiset.countP`/`dedup` and whose `rw [h]` theorem is retired to prose; `fillers_eq_singleton_of_forall_isMax` renamed, unused binders dropped, the dotted theorem placed in its namespace.