### PR TITLE
docs(Studies/Levin2026): locators verified against the paper

### DIFF
--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -31,11 +31,6 @@ verb and adjective entries come from the English fragments, the alternation judg
 independent-source tightness of the causal substrate. The construction-level licensing of an
 alternation the verb lacks is stated for this case only.
 
-## TODO
-
-The paper is not on file; section and example locators are transcribed from an earlier
-version of this file and are UNVERIFIED.
-
 ## References
 
 * [levin-2026]


### PR DESCRIPTION
Locators verified against the text now in Zotero; unverified markers removed.
- Eleven example numbers and the section references checked; the class numbers are Levin 1993's