### PR TITLE
docs(Studies/LevshinaEtAl2023): datasets verified

### DIFF
--- a/Linglib/Studies/LevshinaEtAl2023.lean
+++ b/Linglib/Studies/LevshinaEtAl2023.lean
@@ -21,9 +21,7 @@ and the Russian register proportions from Dataset6.
 
 ## TODO
 
-The rows are empirical data and belong in a generated `Data/WordOrder` module; the figure
-attributions are transcribed from an earlier version of this file and are UNVERIFIED pending
-a check against the paper.
+The rows are empirical data and belong in a generated `Data/WordOrder` module.
 
 ## References
 


### PR DESCRIPTION
Locators verified against the text now in Zotero; unverified markers removed.
- Datasets 1, 3, and 6 of the OSF directory carry the proportions, entropy and mutual information, and register proportions as recorded