### PR TITLE
docs(Studies/Magri2009): locators verified against the paper

### DIFF
--- a/Linglib/Studies/Magri2009.lean
+++ b/Linglib/Studies/Magri2009.lean
@@ -30,11 +30,6 @@ mandatoriness of the exhaustivity operator in matrix clauses is an external assu
 `BPSWorld` type below concerns bare plural subjects, not the presuppositional
 exhaustification of the same abbreviation elsewhere in the library.
 
-## TODO
-
-The paper is not on file; equation and section locators are transcribed from an earlier
-version of this file and are UNVERIFIED.
-
 ## References
 
 * [magri-2009]


### PR DESCRIPTION
Locators verified against the text now in Zotero; unverified markers removed.
- Thirteen equation numbers and the section references checked; the section numbers above ten are the file's own