### PR TITLE
docs(Studies/Merchant2013): sections and examples verified

### DIFF
--- a/Linglib/Studies/Merchant2013.lean
+++ b/Linglib/Studies/Merchant2013.lean
@@ -14,11 +14,6 @@ dative, middle, or prepositional, is tolerated under any ellipsis, the heads reg
 all sitting at or below v and hence inside every deletion domain. Every judgment is derived
 from the substrate's deletion-domain predicate, with German and Greek data beside English.
 
-## TODO
-
-The paper is not on file; section locators are transcribed from an earlier version of this
-file and are UNVERIFIED.
-
 ## References
 
 * [merchant-2013]


### PR DESCRIPTION
Locators verified against the text now in Zotero; unverified markers removed.