### PR TITLE
docs(Studies/Marantz1991): page locator corrected

### DIFF
--- a/Linglib/Studies/Marantz1991.lean
+++ b/Linglib/Studies/Marantz1991.lean
@@ -24,11 +24,6 @@ Default case, the last resort of the hierarchy, is not modelled apart from unmar
 the evidential series of Georgian is a morphological property of its inflection and outside
 the algorithm. [baker-2015] later develops the hierarchy into a cross-linguistic algorithm.
 
-## TODO
-
-The paper is not on file; locators are transcribed from an earlier version of this file and
-are UNVERIFIED.
-
 ## References
 
 * [marantz-1991]
@@ -288,7 +283,7 @@ private def getCase! (label : String) (results : List (NP × Valuation)) : Case 
 
     - Abstract ACC → morphological DAT (dative and accusative
       morphological case have fallen together in Georgian into what
-      is called "the dative case" — [marantz-1991] p. 12)
+      is called "the dative case" — [marantz-1991] p. 234)
     - Abstract ABS → morphological NOM (unmarked surface form)
     - Abstract ERG → morphological ERG -/
 def georgianSpellout : Case → Case

--- a/references.bib
+++ b/references.bib
@@ -20986,7 +20986,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/AckemaNeeleman2018.lean;Studies/Harley2014.lean;Studies/MarcoRasin2026.lean}
+  sources   = {Studies/AckemaNeeleman2018.lean;Studies/Harley2014.lean;Studies/Marantz1991.lean;Studies/MarcoRasin2026.lean}
 }% REF: Bobaljik, J. D. & Wurmbrand, S. (2005). The domain of agreement. NLLT 23(4):809-865.
 @article{bobaljik-wurmbrand-2005,
   author    = {Bobaljik, Jonathan David and Wurmbrand, Susi},


### PR DESCRIPTION
Locators verified against the text now in Zotero; unverified markers removed.
- The dative-case quotation is on the first page of the paper, p. 234 of the proceedings, not p. 12