### PR TITLE
refactor(Studies/Pancheva2003): cut the Kiparsky bridge

### DIFF
--- a/Linglib/Studies/Pancheva2003.lean
+++ b/Linglib/Studies/Pancheva2003.lean
@@ -1,61 +1,41 @@
 import Linglib.Data.Examples.Schema
 import Linglib.Semantics.Aspect.Basic
-import Linglib.Studies.Kiparsky2002
 import Linglib.Data.Examples.Pancheva2003
 
 /-!
-# Pancheva (2003): The Aspectual Makeup of Perfect Participles
-[pancheva-2003] [kiparsky-2002] [iatridou-anagnostopoulou-izvorski-2001]
+# Pancheva (2003): Aspectual Makeup of Perfect Participles and the Interpretations of the Perfect
 
-Pancheva (in *Perfect Explorations*, Alexiadou-Rathert-von Stechow
-eds., 2003) argues that the three perfect interpretations
-(Universal, Experiential, Resultative) arise from the aspectual makeup
-of the perfect participle — specifically the interaction of
-Aktionsart with grammatical aspect (perfective vs imperfective)
-inside the participial VP.
+This file formalizes the account in [pancheva-2003] of the three interpretations of the
+perfect, universal, experiential, and resultative, as arising from the aspectual makeup of
+the participle rather than from an ambiguous perfect: the perfect is one interval-level
+operator (`PERF_P`) over a participial phrase whose inner viewpoint is the non-strict
+imperfective, the neutral viewpoint requiring only initial overlap, or the bounded
+perfective (`INIT_OVERLAP`, `BOUNDED`), and the three readings are the three
+compositions (`universalPerfect`, `experientialPerfect`, `resultativePerfect`). The
+universal and resultative readings depend on the participial aspect and the experiential
+does not: states and progressives yield the universal or experiential reading,
+non-progressive activities the experiential only, and non-progressive telic predicates the
+resultative or experiential, since only a telic event has a lexically inherent result state,
+so *I have run* lacks the resultative reading that *I have lost my glasses* has. Greek
+perfect participles are obligatorily perfective and Greek accordingly lacks the universal
+perfect, while Bulgarian admits non-perfective participles and has it.
 
-## Verified content (vs PDF; § refs from the paper)
+## Implementation notes
 
-- **Three perfect types** (§1, ex 1): Universal (U), Experiential
-  (EXP), Resultative (RES). EXP and RES are commonly grouped under
-  the EXISTENTIAL umbrella (McCawley 1971, Mittwoch 1988).
-- **Aspectual makeup determines reading availability** (§2 thesis):
-  Universal and Resultative interpretations depend on participial
-  aspect, Experiential does not. States/progressives → U or EXP;
-  non-progressive activities → EXP only; non-progressive telic →
-  RES or EXP.
-- **Resultative requires telic predicates** (§2, ex 5–6, citing
-  Kratzer 1994): only telic events have a natural (lexically
-  inherent) result state. *I have run* (5a, atelic) lacks RES; *I
-  have lost my glasses* (6a, telic) has both EXP and RES.
-- **Cross-linguistic aspectual restrictions** (§2): Greek perfect
-  participles are obligatorily perfective → no Universal perfect;
-  Bulgarian allows non-perfective participles → Universal possible.
+The framework is the perfect time span of [iatridou-anagnostopoulou-izvorski-2001], and
+the non-strict imperfective is the substrate's `Aspect.UNBOUNDED`; the result state of the
+paper's resultative composition is not represented, the resultative reading being the
+perfect over the bounded viewpoint alone.
 
-## Relation to companion files
+## References
 
-- `Studies/IatridouEtAl2001.lean` — Pancheva builds on IAI 2001's
-  PTS framework and U/E distinction. Her contribution is the
-  participle-aspect mechanism.
-- `Studies/Kiparsky2002.lean` — Kiparsky's event-structure account
-  is an independent proposal for the same polysemy. The
-  `toKiparsky` bridge below embeds Pancheva's 3-type taxonomy into
-  Kiparsky's 4-reading enum (Kiparsky adds present-state, which
-  Pancheva does not distinguish).
-
-The operators of (7b) and (9b), the inner viewpoints NEUTRAL (`INIT_OVERLAP`)
-and BOUNDED and the interval-level PERFECT (`PERF_P`), and the three perfect
-readings they compose to (`universalPerfect`, `experientialPerfect`,
-`resultativePerfect`), are this file's; the non-strict imperfective UNBOUNDED
-is shared substrate, `Aspect.UNBOUNDED`.
-
+* [pancheva-2003]
+* [iatridou-anagnostopoulou-izvorski-2001]
 -/
 
 namespace Pancheva2003
 
-open Data.Examples (LinguisticExample)
 open Aspect
-open Kiparsky2002 (PerfectReading)
 
 /-! ### The aspectual makeup of the participle, (7) and (9) -/
 
@@ -101,32 +81,5 @@ abbrev experientialPerfect (P : W → Event T → Prop) : IntervalPred W T :=
 
 /-- The resultative perfect, (15): PERFECT over BOUNDED, without the result state of p. 288. -/
 abbrev resultativePerfect (P : W → Event T → Prop) : IntervalPred W T := PERF_P (BOUNDED P)
-
-/-! ### The readings in Kiparsky's terms -/
-
-/-- Map [pancheva-2003]'s perfect types to Kiparsky's readings.
-    - experiential → existential (Pancheva's EXP and Kiparsky's
-      existential both denote ∃-event-in-PTS without a result-state
-      requirement)
-    - universal → universal
-    - resultative → resultative -/
-def toKiparsky : PerfectType → PerfectReading
-  | .experiential => .existential
-  | .universal => .universal
-  | .resultative => .resultative
-
-/-- Pancheva's classification embeds into Kiparsky's: every Pancheva
-    type maps to a distinct Kiparsky reading. -/
-theorem pancheva_injective :
-    Function.Injective toKiparsky := by
-  intro a b h
-  cases a <;> cases b <;> simp_all [toKiparsky]
-
-/-- Pancheva's types are a proper subset of Kiparsky's: Kiparsky adds
-    the present-state reading which Pancheva does not distinguish. -/
-theorem pancheva_subset_kiparsky :
-    ∀ pt : PerfectType, toKiparsky pt ∈
-      [PerfectReading.existential, .universal, .resultative, .presentState] := by
-  intro pt; cases pt <;> simp [toKiparsky]
 
 end Pancheva2003

--- a/references.bib
+++ b/references.bib
@@ -12256,7 +12256,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {cited},
-  sources   = {Semantics/Aspect/SubeventStructure.lean;Semantics/Reference/Context/Basic.lean;Semantics/Tense/Defs.lean;Semantics/Tense/Reichenbach.lean;Studies/Kiparsky2002.lean;Studies/Pancheva2003.lean}
+  sources   = {Semantics/Aspect/SubeventStructure.lean;Semantics/Reference/Context/Basic.lean;Semantics/Tense/Defs.lean;Semantics/Tense/Reichenbach.lean;Studies/Kiparsky2002.lean}
 }
 @article{mendes-2025,
   author    = {Mendes, Am\'{e}lia},


### PR DESCRIPTION
Header in register; the Kiparsky-2002 reading map was an editorial bridge the paper never draws.
- verified examples (1), (5)–(7), (9), (11), (12), (15) against the paper