### PR TITLE
refactor(Studies/Panagiotidis2015): cut the McNally–de Swart bridge

### DIFF
--- a/Linglib/Studies/Panagiotidis2015.lean
+++ b/Linglib/Studies/Panagiotidis2015.lean
@@ -1,135 +1,67 @@
 import Linglib.Data.UD.Basic
-import Linglib.Studies.McNallyDeSwart2011
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.Properties
 
 /-!
-# Panagiotidis (2015): categorial features and categorizers
+# Panagiotidis (2015): Categorial Features
 
-[panagiotidis-2015] (*Categorial Features*) treats word class as syntax:
-category-neutral roots ([marantz-1997]) enter the derivation by merging with
-a categorizer head (v, n, a) bearing substantive, LF-interpretable categorial
-features — [N] sortal perspective, [V] temporal perspective. Category-changing
-morphology is changing the categorizer.
+This file formalizes the theory of word class in [panagiotidis-2015]: lexical category is
+not a property of roots but of the categorizer heads *n*, *v*, and *a* that category-neutral
+roots merge with ([marantz-1997]), and the categorial features those heads bear are
+substantive and interpretable rather than diacritic, [N] imposing a sortal perspective and
+[V] a perspective extending into time on the root's concept. Nouns bear [N] only, verbs [V]
+only, adjectives both, and adpositions neither, the adposition being the default categorizer
+(`categorizer_features`, `isCategorizer_iff`). The functional heads of an extended projection
+carry uninterpretable copies of their categorizer's features, so a category's features are
+fixed by its family (`categorialFeatures_eq_iff`), and the diacritic features of
+[chomsky-1970] cut the categories into the same four classes, the substrate's
+`Minimalist.chomsky_panagiotidis_agree`. Category change is change of categorizer: an English
+root surfaces in all three categorized classes (`RootFamily`, `all_families_tricategorial`).
 
-## Main declarations
+## Implementation notes
 
-* `RootFamily` — a category-neutral root with its category-stamped surface
-  words; `allFamilies` is the English sample.
-* `producesReferential`, `producesPredicative` — the [N]/[V] interpretive
-  predictions of each categorizer.
-* `MdSBridge` — the §6.7.1 SWITCH-placement diagnostic applied to
-  [mcnally-deswart-2011]'s rivals for Dutch *het rode van X*.
+`categorialFeatures` and `catFeatures` live in the extended-projection substrate, which does
+not represent the difference between a categorizer's interpretable features and the copies on
+its functional heads, so the two feature systems are compared on the partitions they induce.
+The root families are the standard English illustrations of category-neutral roots from the
+Distributed Morphology literature rather than data from the book.
 
-## Main results
+## References
 
-* `referential_predicative_asymmetry` — nouns [N], verbs [V], adjectives both.
-* `all_families_match_all_categorizers` — every sample root family surfaces
-  in all three categorised classes.
-* `catFamily_from_chomsky`, `catFamily_from_panagiotidis` — [chomsky-1970]'s
-  diacritic [±V, ±N] and Panagiotidis's substantive [N]/[V] induce the same
-  category families.
+* [panagiotidis-2015]
+* [chomsky-1970]
+* [marantz-1997]
 -/
 
 namespace Panagiotidis2015
 
 open Minimalist
 
-/-! ### Feature predictions -/
-
-/-- Does a categorizer produce a category with sortal perspective?
-    Panagiotidis §4.3: [N] = sortal perspective / referentiality. Items bearing [N] have the capacity to introduce
-    discourse referents (nouns, adjectives) — items lacking [N] do not
-    (verbs). -/
-def producesReferential (c : Cat) : Bool :=
-  (categorialFeatures c).hasN
-
-/-- Does a categorizer produce a category with temporal perspective?
-    Panagiotidis §4.3: [V] = temporal perspective / eventivity. Items
-    bearing [V] can anchor to time/events (verbs, adjectives) — items
-    lacking [V] do not have temporal anchoring (nouns). -/
-def producesPredicative (c : Cat) : Bool :=
-  (categorialFeatures c).hasV
-
-/-- Nouns have sortal but not temporal perspective: n bears [N] only. -/
-theorem noun_referential_not_predicative :
-    producesReferential .n = true ∧ producesPredicative .n = false := by decide
-
-/-- Verbs have temporal but not sortal perspective: v bears [V] only. -/
-theorem verb_predicative_not_referential :
-    producesPredicative .v = true ∧ producesReferential .v = false := by decide
-
-/-- Adjectives have both sortal and temporal perspective: a bears [N, V]. -/
-theorem adjective_both :
-    producesReferential .a = true ∧ producesPredicative .a = true := by decide
-
-/-- The noun–verb asymmetry: nouns have sortal but not temporal perspective;
-    verbs have temporal but not sortal perspective. Adjectives have both.
-    This follows from the [N]/[V] feature distribution on categorizers. -/
-theorem referential_predicative_asymmetry :
-    -- Nouns: [N], not [V]
-    (categorialFeatures .n).hasN = true ∧ (categorialFeatures .n).hasV = false ∧
-    -- Verbs: [V], not [N]
-    (categorialFeatures .v).hasV = true ∧ (categorialFeatures .v).hasN = false ∧
-    -- Adjectives: [N] and [V]
-    (categorialFeatures .a).hasN = true ∧ (categorialFeatures .a).hasV = true := by
+/-- The features of the lexical categorizers: *n* bears [N], *v* bears [V], *a* both, and the
+adposition, the default categorizer, neither. -/
+theorem categorizer_features :
+    categorialFeatures .n = ⟨true, false⟩ ∧ categorialFeatures .v = ⟨false, true⟩ ∧
+      categorialFeatures .a = ⟨true, true⟩ ∧ categorialFeatures .P = ⟨false, false⟩ := by
   decide
 
-/-! ### EP well-formedness -/
+/-- The categorizers are exactly *v*, *n*, and *a*; the categorized lexical heads are not
+categorizers but root-plus-categorizer complexes. -/
+theorem isCategorizer_iff (c : Cat) : isCategorizer c = true ↔ c = .v ∨ c = .n ∨ c = .a := by
+  cases c <;> decide
 
-/-- Each categorizer forms a well-formed EP with its lexical anchor:
-    V→v, N→n, A→a are all category-consistent and F-monotone. -/
-theorem all_categorizer_eps_wellformed :
-    (allCategoryConsistent [Cat.V, Cat.v] = true ∧ allFMonotone [Cat.V, Cat.v] = true) ∧
-    (allCategoryConsistent [Cat.N, Cat.n] = true ∧ allFMonotone [Cat.N, Cat.n] = true) ∧
-    (allCategoryConsistent [Cat.A, Cat.a] = true ∧ allFMonotone [Cat.A, Cat.a] = true) := by
-  decide
+/-- Features are fixed by the extended-projection family: every head of a projection carries
+its categorizer's [N] and [V] specification. -/
+theorem categorialFeatures_eq_iff (c₁ c₂ : Cat) :
+    categorialFeatures c₁ = categorialFeatures c₂ ↔ catFamily c₁ = catFamily c₂ := by
+  cases c₁ <;> cases c₂ <;> decide
 
-/-- The F-level jump from lexical head to categorizer is exactly 1 in all cases.
-    The uniformity of categorization is Panagiotidis's prediction (§4.4–§4.5);
-    the F-value encoding is [grimshaw-2005]'s EP architecture. -/
-theorem categorization_uniform_fstep :
-    fValue .v - fValue .V = 1 ∧
-    fValue .n - fValue .N = 1 ∧
-    fValue .a - fValue .A = 1 := by decide
-
-/-! ### Categorizer parallelism -/
-
-/-- All categorizers sit at exactly F1 (in Grimshaw's system), parallel
-    across families. Panagiotidis's core claim: v, n, a are structurally
-    parallel — they differ only in which interpretable features they bear. -/
-theorem categorizers_parallel_at_f1 :
-    fValue .v = 1 ∧ fValue .n = 1 ∧ fValue .a = 1 := by decide
-
-/-- The categorizers are in their respective families. -/
-theorem categorizers_in_own_families :
-    catFamily .v = .verbal ∧ catFamily .n = .nominal ∧ catFamily .a = .adjectival := by
-  decide
-
-/-- Category-changing morphology = changing the categorizer.
-    The same root under different categorizers yields items in
-    different EP families — this is what it means to "change category." -/
-theorem different_categorizers_different_families :
-    catFamily .v ≠ catFamily .n ∧
-    catFamily .n ≠ catFamily .a ∧
-    catFamily .v ≠ catFamily .a := by decide
-
-/-! ### English root families ([panagiotidis-2015] §5.2, [marantz-1997])
-
-Standard examples from the Distributed Morphology literature: roots that
-surface as nouns, verbs, and adjectives via different morphological
-processes. -/
-
-/-- A root family ([marantz-1997]): the surface words a single
-category-neutral root projects across lexical categories, each stamped with
-its UD category. The root determines none of them — category comes from the
-categorising environment. -/
+/-- A category-neutral root with the surface words it projects across the lexical categories,
+each stamped with its Universal Dependencies category ([marantz-1997]). -/
 structure RootFamily where
-  /-- A label for the root (approximate; roots are sub-morphemic). -/
+  /-- A label for the root; roots themselves are sub-morphemic. -/
   rootLabel : String
-  /-- The surface forms with their UD categories. -/
+  /-- The surface forms with their categories. -/
   forms : List (String × UD.UPOS)
-  deriving Repr
 
 /-- The family has a surface form in category `c`. -/
 def RootFamily.HasCategory (rf : RootFamily) (c : UD.UPOS) : Prop :=
@@ -138,364 +70,34 @@ def RootFamily.HasCategory (rf : RootFamily) (c : UD.UPOS) : Prop :=
 instance (rf : RootFamily) (c : UD.UPOS) : Decidable (rf.HasCategory c) :=
   List.decidableBEx _ rf.forms
 
-/-- √DESTROY: destroy (V), destruction (N), destructive (A) -/
-def destroy : RootFamily := ⟨"DESTROY",
-  [("destroy", .VERB), ("destruction", .NOUN), ("destructive", .ADJ)]⟩
+/-- √DESTROY: destroy, destruction, destructive. -/
+def destroy : RootFamily :=
+  ⟨"DESTROY", [("destroy", .VERB), ("destruction", .NOUN), ("destructive", .ADJ)]⟩
 
-/-- √BEAUTY: beautify (V), beauty (N), beautiful (A) -/
-def beauty : RootFamily := ⟨"BEAUTY",
-  [("beautify", .VERB), ("beauty", .NOUN), ("beautiful", .ADJ)]⟩
+/-- √BEAUTY: beautify, beauty, beautiful. -/
+def beauty : RootFamily :=
+  ⟨"BEAUTY", [("beautify", .VERB), ("beauty", .NOUN), ("beautiful", .ADJ)]⟩
 
-/-- √CLEAR: clear (V), clarity (N), clear (A) -/
-def clear : RootFamily := ⟨"CLEAR",
-  [("clear", .VERB), ("clarity", .NOUN), ("clear", .ADJ)]⟩
+/-- √CLEAR: clear, clarity, clear. -/
+def clear : RootFamily := ⟨"CLEAR", [("clear", .VERB), ("clarity", .NOUN), ("clear", .ADJ)]⟩
 
-/-- √PRODUCE: produce (V), product/production (N), productive (A) -/
-def produce : RootFamily := ⟨"PRODUCE",
-  [("produce", .VERB), ("production", .NOUN), ("productive", .ADJ)]⟩
+/-- √PRODUCE: produce, production, productive. -/
+def produce : RootFamily :=
+  ⟨"PRODUCE", [("produce", .VERB), ("production", .NOUN), ("productive", .ADJ)]⟩
 
-/-- √CREATE: create (V), creation (N), creative (A) -/
-def create : RootFamily := ⟨"CREATE",
-  [("create", .VERB), ("creation", .NOUN), ("creative", .ADJ)]⟩
+/-- √CREATE: create, creation, creative. -/
+def create : RootFamily :=
+  ⟨"CREATE", [("create", .VERB), ("creation", .NOUN), ("creative", .ADJ)]⟩
 
-/-- √ACT: act (V), action (N), active (A) -/
-def act : RootFamily := ⟨"ACT",
-  [("act", .VERB), ("action", .NOUN), ("active", .ADJ)]⟩
+/-- √ACT: act, action, active. -/
+def act : RootFamily := ⟨"ACT", [("act", .VERB), ("action", .NOUN), ("active", .ADJ)]⟩
 
-/-- All sample root families. -/
-def allFamilies : List RootFamily :=
-  [destroy, beauty, clear, produce, create, act]
+/-- The sample root families. -/
+def allFamilies : List RootFamily := [destroy, beauty, clear, produce, create, act]
 
-/-- Every root family in the sample has a form for each categorizer's
-category — English makes all three categorizers available, so roots surface
-tricategorially. -/
-theorem all_families_match_all_categorizers :
-    ∀ rf ∈ allFamilies,
-      rf.HasCategory .VERB ∧ rf.HasCategory .NOUN ∧ rf.HasCategory .ADJ := by
+/-- Every root in the sample surfaces under each of the three categorizers. -/
+theorem all_families_tricategorial :
+    ∀ rf ∈ allFamilies, rf.HasCategory .VERB ∧ rf.HasCategory .NOUN ∧ rf.HasCategory .ADJ := by
   decide
-
-/-! ### Cross-framework bridge to [mcnally-deswart-2011] -/
-
-/-! ## Bridge: §6.7.1 modifier-distribution diagnostic ↔ M&deS §2.3 (13)
-
-[panagiotidis-2015] §6.7.1 (35)–(36) deploys a *modifier-distribution*
-diagnostic for SWITCH placement in mixed projections, with Dutch examples
-adapted from Ackema & Neeleman (2004:173):
-
-* (35) `dat [stiekem succesvolle liedjes jatten]` — adverb `stiekem`
-  sits BELOW the SWITCH (in the verbal/adjectival subtree)
-* (36) `dat stiekeme [succesvolle liedjes jatten]` — adjective `stiekeme`
-  sits ABOVE the SWITCH (in the nominal subtree)
-
-Per Panagiotidis p. 146, the SWITCH's complement is *recategorised* by
-its [N] feature. So a constituent dominated by a SWITCH projects
-nominally and takes adjectival modifiers; a constituent below the
-SWITCH retains its verbal/adjectival categorial identity and takes
-adverbial modifiers. The diagnostic gives SWITCH placement: where the
-modifier-category transition occurs is where the SWITCH sits.
-
-[mcnally-deswart-2011] §2.3 (13) makes a *similar* modifier-
-distribution observation about the inflected adjective in `het rode
-van X`: M&deS observe `het intens/*intense rode` (adverbial-only) and
-conclude that `rode` remains adjectival, with `het` carrying the
-type-shift.
-
-**Methodological lineage, not independent rediscovery.** Both M&deS and
-Panagiotidis cite Ackema & Neeleman 2004 (Beyond Morphology) as the
-source of the modifier-as-domain diagnostic. The convergence below is a
-shared-source consequence, not two independent frameworks landing on the
-same test. The bridge formalises *that* the two frameworks make
-predictions of the same shape on the same data.
-
-**Caveat.** Panagiotidis nowhere specifically analyses Dutch *het* as a
-SWITCH; §6.6 covers V→N SWITCHes only (Korean *-um*, Basque *-te/tze*,
-Turkish *-dIk* and *-AcAk*) and §6.9 covers Dutch nominalised infinitives.
-Mapping `het` to a Panagiotidis-style SWITCH on the inflected adjective
-is the formaliser's extrapolation. The bridge below identifies the
-M&deS rivals with SWITCH-position commitments (low/high) and reads off
-predictions geometrically; it does not claim Panagiotidis himself
-analyses M&deS's data. -/
-
-namespace MdSBridge
-
-open McNallyDeSwart2011
-
-/-- The structural commitment each `InflectedAnalysis` rival makes about
-    SWITCH placement, modelling Panagiotidis §6.7.1's geometric reasoning
-    over the rivals' defining proposals. This is the substantive content
-    each rival commits to: *where* in the structure of `het rode van X`
-    is the categorising head sitting? -/
-inductive SwitchPosition where
-  /-- SWITCH is at the inflected-form level (the `-e` morpheme is the
-      SWITCH; the inflected `rode` is the categorised constituent). -/
-  | low
-  /-- No SWITCH; regular adjectival projection (e.g., normal AP modifying
-      a noun, where the noun is elided). -/
-  | none
-  /-- SWITCH is at the DP edge (`het` is the SWITCH; the AP `rode` is
-      the SWITCH's complement). -/
-  | high
-  deriving DecidableEq, Repr
-
-/-- Each rival's defining commitment about SWITCH placement.
-
-    * `nominalisation`: -e itself is the SWITCH/categoriser. SWITCH = low.
-    * `ellipsis`: regular AP-modifying-N structure with elided N; *no*
-      SWITCH/categoriser intervenes between modifier and `rode` (the
-      adjectival projection is intact pre-ellipsis). SWITCH = none.
-    * `hetAsCap`: het carries the categorising operation. SWITCH = high. -/
-def switchPosition : InflectedAnalysis → SwitchPosition
-  | .nominalisation => .low
-  | .ellipsis       => .none
-  | .hetAsCap       => .high
-
-/-- Per [panagiotidis-2015] p. 146 + §6.7.1: the SWITCH's complement
-    is recategorised by [N], so a constituent dominated by a SWITCH
-    projects nominally (takes adjectival modifiers) while a constituent
-    below the SWITCH retains its adjectival identity (takes adverbial
-    modifiers). For the inflected form `rode`, the diagnostic is read
-    by asking *where is `rode` relative to the SWITCH*:
-
-    * SWITCH = low (`-e` IS the SWITCH): `rode` IS the SWITCH-headed
-      constituent → projects nominally → predicts ADJECTIVAL
-      modification of `rode`.
-    * SWITCH = high (`het` is the SWITCH, `rode` is its AP-complement):
-      `rode` is BELOW the SWITCH → retains adjectival identity → predicts
-      ADVERBIAL modification of `rode`.
-
-    For `ellipsis` (no SWITCH), the surface AP is intact, so adverbial
-    modification of `rode` is licensed just as any adjective licenses it.
-
-    `panagiotidisPredictsAdverbialMod a` is now *derived* from
-    `switchPosition a`: the geometric prediction is "no low SWITCH
-    dominating `rode`", i.e. the modifier-attachment site is below or
-    independent of any SWITCH. -/
-def panagiotidisPredictsAdverbialMod (a : InflectedAnalysis) : Prop :=
-  switchPosition a ≠ .low
-
-instance : DecidablePred panagiotidisPredictsAdverbialMod :=
-  fun a => by unfold panagiotidisPredictsAdverbialMod; exact inferInstance
-
-/-- The Panagiotidis prediction matches the [mcnally-deswart-2011]
-    prediction on every rival. Both predicates encode the same modifier-
-    distribution diagnostic (which they both inherit from Ackema &
-    Neeleman 2004); the agreement is shared-methodology consequence, not
-    independent rediscovery. The substance of the bridge: *the geometric
-    SWITCH-placement reasoning derives the same predictions as M&deS's
-    case-by-case `PredictsAdverbialModOnly`*. -/
-theorem mcnally_panagiotidis_diagnostics_agree :
-    ∀ a : InflectedAnalysis,
-      a.PredictsAdverbialModOnly ↔ panagiotidisPredictsAdverbialMod a := by
-  intro a
-  cases a <;>
-    (unfold InflectedAnalysis.PredictsAdverbialModOnly
-            panagiotidisPredictsAdverbialMod switchPosition
-     decide)
-
-/-- The `nominalisation` rival fails the joint prediction:
-    Panagiotidis's geometric diagnostic over its low-SWITCH commitment
-    predicts the inflected form should admit adjectival modification
-    (because `rode` would be SWITCH-dominated and project nominally);
-    [mcnally-deswart-2011] (13) shows the inflected form REJECTS
-    adjectival modification. The combined refutation routes through
-    `switchPosition .nominalisation = .low → ¬panagiotidisPredictsAdverbialMod`
-    and the M&deS data point. -/
-theorem panagiotidis_refutes_nominalisation :
-    switchPosition .nominalisation = .low
-    ∧ ¬ panagiotidisPredictsAdverbialMod .nominalisation
-    ∧ ¬ Form.inflected.AdmitsAdjectivalModification := by
-  refine ⟨rfl, ?_, id⟩
-  unfold panagiotidisPredictsAdverbialMod switchPosition; decide
-
-/-- Conversely, the `hetAsCap` rival passes: high-SWITCH commitment +
-    `rode` below SWITCH → adverbial modification predicted, matching
-    M&deS data. -/
-theorem hetAsCap_panagiotidis_compatible :
-    switchPosition .hetAsCap = .high
-    ∧ panagiotidisPredictsAdverbialMod .hetAsCap
-    ∧ ¬ Form.inflected.AdmitsAdjectivalModification := by
-  refine ⟨rfl, ?_, id⟩
-  unfold panagiotidisPredictsAdverbialMod switchPosition; decide
-
-/-- The `ellipsis` rival also passes: no-SWITCH commitment means
-    surface AP is intact and adverbial modification is licensed in the
-    standard way. -/
-theorem ellipsis_panagiotidis_compatible :
-    switchPosition .ellipsis = .none
-    ∧ panagiotidisPredictsAdverbialMod .ellipsis := by
-  refine ⟨rfl, ?_⟩
-  unfold panagiotidisPredictsAdverbialMod switchPosition; decide
-
-/-- Categoriser identification at the *surface* head level. Under each
-    rival, what is the lexical category of the inflected form `rode` as
-    it is projected at the surface?
-
-    * `nominalisation`: `-e` categorises `rode` as a noun → `Cat.n`.
-    * `ellipsis`: surface `rode` is an adjective; the n is the elided
-      null noun, structurally elsewhere → `Cat.a` (the visible head).
-    * `hetAsCap`: `rode` remains adjectival; `het` is the SWITCH
-      → `Cat.a` at the surface head.
-
-    The frameworks-divergence is captured: only `nominalisation`
-    promotes the surface category to nominal. The other two leave the
-    surface adjectival. -/
-def surfaceCategorizer : InflectedAnalysis → Cat
-  | .nominalisation => Cat.n   -- -e changes A → N
-  | .ellipsis       => Cat.a   -- visible A; n is elided elsewhere
-  | .hetAsCap       => Cat.a   -- het carries SWITCH; rode stays A
-
-/-- The surface categoriser distinguishes nominalisation from the other
-    two rivals — exactly the M&deS §2.3 distinction of "is the inflected
-    form a noun?". This is a real per-rival commitment, not a constant. -/
-theorem nominalisation_uniquely_promotes_to_n :
-    surfaceCategorizer .nominalisation = Cat.n ∧
-    surfaceCategorizer .ellipsis       = Cat.a ∧
-    surfaceCategorizer .hetAsCap       = Cat.a := ⟨rfl, rfl, rfl⟩
-
-/-- The Panagiotidis-side referential prediction follows the surface
-    categoriser: `nominalisation` predicts the inflected form is
-    referential (per `noun_referential_not_predicative` above);
-    `ellipsis` and `hetAsCap` predict it remains predicative-bearing
-    (per `adjective_both`). -/
-theorem nominalisation_predicts_referential :
-    producesReferential (surfaceCategorizer .nominalisation) = true ∧
-    producesReferential (surfaceCategorizer .ellipsis)       = true ∧
-    producesReferential (surfaceCategorizer .hetAsCap)       = true := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
-
-end MdSBridge
-
-/-! ### Categorial features: [chomsky-1970] vs [panagiotidis-2015]
-
-Two theories of what makes a noun a noun and a verb a verb:
-
-1. **[chomsky-1970]**: [±V, ±N] as arbitrary binary diacritics that cross-classify
-   the four lexical categories. Adopted by [grimshaw-2005] for Extended Projections.
-   Implemented in `CatFeatures`.
-
-2. **[panagiotidis-2015]**: [N] and [V] as substantive, LF-interpretable features:
-   - [N] = sortal perspective / referentiality
-   - [V] = temporal perspective / eventivity (§4.3)
-   On categorizers (v, n, a), these are *interpretable*; on functional heads
-   (T, C, D, etc.), they are *uninterpretable* copies (§5.8).
-   Implemented in `CategorialFeatures`.
-
-## Key Agreement
-
-The two systems produce the same four equivalence classes — {verbal}, {nominal},
-{adjectival}, {adpositional} — and therefore agree on all EP-consistency judgments
-(`chomsky_panagiotidis_agree`).
-
-## Key Disagreement
-
-The status of **P** (prepositions/adpositions):
-
-- Chomsky: P *actively bears* [-V, -N] — two negative feature values
-- Panagiotidis: P is the **default** categorizer, lacking both [N] and [V]
-
-This matters for the theory of features: in Chomsky's system, [-V] and [-N] are
-just as "real" as [+V] and [+N]. In Panagiotidis's system, the absence of [N] and
-[V] is genuinely the absence of categorial content — P is the elsewhere case. This
-predicts that P should be the most promiscuous category (appearing in the most
-diverse syntactic environments), which Panagiotidis argues is borne out.
-
-## Adjectives
-
-Both systems agree that A shares properties with both N and V:
-- Chomsky: A = [+V, +N], the only category with both positive values
-- Panagiotidis: A = [N, V], bearing both substantive features
-
-The difference: for Panagiotidis, this is *explanatory* — adjectives have temporal
-anchoring (because [V]) and sortal perspective (because [N]). For Chomsky,
-the co-presence of [+V] and [+N] is a notational fact without semantic content.
--/
-
-/-! ### Internal structure of each system -/
-
-/-- In Chomsky's system, every category has at least one positive feature
-    except P (which has [-V, -N] = ⟨false, false⟩). -/
-theorem chomsky_p_has_no_positive_feature :
-    (catFeatures .P).plusV = false ∧ (catFeatures .P).plusN = false := by decide
-
-/-- In Panagiotidis's system, P is the default: no categorial features. -/
-theorem panagiotidis_p_is_default :
-    (categorialFeatures .P).hasN = false ∧ (categorialFeatures .P).hasV = false := by decide
-
-/-- These are extensionally identical — but the theories *interpret* ⟨false, false⟩
-    differently: Chomsky reads it as "actively [-V, -N]"; Panagiotidis reads it
-    as "absence of both [N] and [V]" (the elsewhere case). -/
-theorem p_same_values :
-    catFeatures .P = ⟨false, false⟩ ∧ categorialFeatures .P = ⟨false, false⟩ := by decide
-
-/-- Adjectives bear both features in both systems. -/
-theorem adjective_both_features :
-    catFeatures .A = ⟨true, true⟩ ∧ categorialFeatures .A = ⟨true, true⟩ := by decide
-
-/-! ### Feature semantics -/
-
-/-- [N] = sortal perspective / referentiality. Every category in the nominal
-    EP bears [N] (interpretable on n, uninterpretable on Num/Q/D; §5.8). -/
-theorem nominal_ep_has_n :
-    (categorialFeatures .N).hasN ∧ (categorialFeatures .n).hasN ∧
-    (categorialFeatures .Num).hasN ∧ (categorialFeatures .Q).hasN ∧
-    (categorialFeatures .D).hasN := by decide
-
-/-- [V] = temporal perspective / eventivity. Every category in the verbal
-    EP bears [V] (interpretable on v, uninterpretable on T/C; §5.8). -/
-theorem verbal_ep_has_v :
-    (categorialFeatures .V).hasV ∧ (categorialFeatures .v).hasV ∧
-    (categorialFeatures .T).hasV ∧ (categorialFeatures .C).hasV := by decide
-
-/-- Adjectives bear both [N] (sortal perspective) and [V] (temporal perspective).
-    This explains why adjectives can be nominalized (via [N]) and
-    have temporal anchoring (via [V]). -/
-theorem adjective_referential_and_predicative :
-    (categorialFeatures .A).hasN ∧ (categorialFeatures .A).hasV := by decide
-
-/-- The adjectival categorizer *a* inherits [N, V] from A. -/
-theorem a_categorizer_referential_and_predicative :
-    (categorialFeatures .a).hasN ∧ (categorialFeatures .a).hasV := by decide
-
-/-- P bears neither [N] nor [V] — the default/elsewhere categorizer.
-    This predicts P is the most syntactically promiscuous category. -/
-theorem p_neither_referential_nor_predicative :
-    ¬(categorialFeatures .P).hasN ∧ ¬(categorialFeatures .P).hasV := by decide
-
-/-! ### Categorizers as a natural class -/
-
-/-- The three categorizers (v, n, a) form a natural class at F1
-    (Grimshaw's system). Each bears the interpretable categorial features
-    of its EP family. Note: Panagiotidis (§4.5) argues categorizers are
-    lexical, not functional, despite being placed at F1 in the EP. -/
-theorem categorizers_are_f1 :
-    isCategorizer .v ∧ isCategorizer .n ∧ isCategorizer .a ∧
-    fValue .v = 1 ∧ fValue .n = 1 ∧ fValue .a = 1 := by decide
-
-/-- Lexical heads (V, N, A, P) are not categorizers. In Panagiotidis's
-    system, these represent *categorized* items (√+categorizer), not
-    the categorizers themselves. -/
-theorem lexical_heads_not_categorizers :
-    isCategorizer .V = false ∧ isCategorizer .N = false ∧
-    isCategorizer .A = false ∧ isCategorizer .P = false := by decide
-
-/-- Each categorizer bears the *interpretable* features of its family:
-    v bears [V] (temporal), n bears [N] (sortal), a bears [N, V] (both). -/
-theorem categorizer_features :
-    categorialFeatures .v = ⟨false, true⟩ ∧
-    categorialFeatures .n = ⟨true, false⟩ ∧
-    categorialFeatures .a = ⟨true, true⟩ := by decide
-
-/-! ### `CatFamily` as theory-neutral ground -/
-
-/-- CatFamily is the theory-neutral representation: it records which
-    categories group together without committing to the mechanism.
-    Both Chomsky and Panagiotidis produce the same CatFamily partition. -/
-theorem catFamily_from_chomsky (c1 c2 : Cat) :
-    (catFeatures c1 == catFeatures c2) = (catFamily c1 == catFamily c2) := by
-  cases c1 <;> cases c2 <;> decide
-
-theorem catFamily_from_panagiotidis (c1 c2 : Cat) :
-    (categorialFeatures c1 == categorialFeatures c2) = (catFamily c1 == catFamily c2) := by
-  cases c1 <;> cases c2 <;> decide
 
 end Panagiotidis2015

--- a/Linglib/Studies/Wood2023.lean
+++ b/Linglib/Studies/Wood2023.lean
@@ -378,9 +378,8 @@ says uniform [N] feature. Applied to [mcnally-deswart-2011]'s
 `InflectedAnalysis` rivals (which all involve some `n` head), they
 diverge on what additional commitment is required.
 
-This is the cross-framework divergence the [mcnally-deswart-2011]
-bridge in `Panagiotidis2015.lean` (`namespace MdSBridge`) noted as
-*open* — addressed here. -/
+This is the cross-framework divergence between the two accounts of the
+*n* head on [mcnally-deswart-2011]'s Dutch data — addressed here. -/
 
 namespace MdSPanaDivergence
 
@@ -457,9 +456,8 @@ dialogue on Dutch nominalisation morphology:
 
 * `McNallyDeSwart2011`: provides the data (`het rode van X`, modifier
   distribution) and the trope analysis (Moltmann 2004).
-* `Panagiotidis2015`: applies §6.7.1 modifier-distribution diagnostic
-  geometrically; agrees with M&deS on each rival's predictions
-  (shared Ackema & Neeleman 2004 lineage).
+* `Panagiotidis2015`: the categorizer theory on which every *n* head
+  bears the same interpretable [N] feature.
 * `Wood2023`: requires alloseme commitment per rival; identifies a
   framework gap (no "trope" Nominalizer.Alloseme), making the divergence with
   Panagiotidis (uniform [N], no allosemes) substantive.

--- a/references.bib
+++ b/references.bib
@@ -14158,7 +14158,7 @@
   subfield  = {syntax/minimalism},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/Icelandic/Predicates.lean;Studies/Wood2015.lean;Syntax/Minimalist/Verbal/Voice.lean;Studies/Coon2019.lean}
+  sources   = {Fragments/Icelandic/Predicates.lean;Studies/Coon2019.lean;Studies/Wood2015.lean;Studies/Wood2023.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }
 @book{wood-2023,
   author    = {Wood, Jim},
@@ -18572,7 +18572,7 @@
   doi       = {10.1017/CBO9781139811927},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/Panagiotidis2015.lean}
+  sources   = {Studies/Panagiotidis2015.lean;Studies/Wood2023.lean}
 }
 @book{borer-2005,
   author    = {Borer, Hagit},
@@ -27048,7 +27048,7 @@
   subfield  = {semantics/morphology},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/McNallyDeSwart2011.lean}
+  sources   = {Studies/McNallyDeSwart2011.lean;Studies/Wood2023.lean}
 }
 @article{kennedy-mcnally-2010,
   author    = {Kennedy, Christopher and McNally, Louise},
@@ -27076,7 +27076,7 @@
   subfield  = {semantics/reference},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/McNallyDeSwart2011.lean}
+  sources   = {Studies/McNallyDeSwart2011.lean;Studies/Wood2023.lean}
 }
 @phdthesis{zamparelli-1995,
   author    = {Zamparelli, Roberto},


### PR DESCRIPTION
Header in register; the §6.7.1 diagnostic applied to McNally–de Swart's rivals was editorial (the book never cites them), and the F-value numerology and duplicate feature theorems fold into three general statements.
- `categorialFeatures_eq_iff`: features are fixed by the extended-projection family
- Wood2023 prose no longer points at the deleted namespace