### PR TITLE
refactor(Studies/PaapeVasishth2026): processing tree as a mixture

### DIFF
--- a/Linglib/Studies/PaapeVasishth2026.lean
+++ b/Linglib/Studies/PaapeVasishth2026.lean
@@ -1,760 +1,236 @@
-import Linglib.Processing.Cost.Profile
-import Linglib.Semantics.Definiteness.Basic
-import Linglib.Semantics.Definiteness.Maximality
-import Linglib.Semantics.Presupposition.Basic
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.NormNum
 
 /-!
-# Paape & Vasishth (2026) [paape-vasishth-2026]
+# Paape and Vasishth (2026): Context Ameliorates but Does Not Eliminate Garden-Pathing
 
-Context ameliorates but does not eliminate garden-pathing: Novel insights
-from latent-process modeling. *Journal of Memory and Language* 148, 104748.
+This file formalizes the latent-process model of [paape-vasishth-2026], a replication of the
+complement-clause/relative-clause study of [altmann-garnham-dennis-1992] in which referential
+context, one or two candidate referents for a definite, is crossed with disambiguation
+towards the complement clause, the relative clause, or an unambiguous relative clause
+(`Disambiguation`, `ReferentialContext`, `Condition.IsMatch`). Reading times at the
+disambiguating region are a mixture over the leaves of a multinomial processing tree: an
+inattentive reader guesses, an attentive one is garden-pathed with some probability, a
+garden-pathed reader triages or reanalyses, reanalysis is overt, a regression, or covert and
+in situ, covert reanalysis may be postponed to the spillover region, and either kind may fail
+(`Outcome`, `Params.prob`). The leaf probabilities sum to one and the marginal probabilities
+of garden-pathing, of a regression, and of acceptance are the products the tree prescribes
+(`Params.prob_sum`, `Params.mass_gardenPathed`, `Params.mass_regression`,
+`Params.accept_eq`). The reason for the mixture is that a comparison of condition means
+cannot separate an effect of context on first-pass attachment from an effect on reanalysis
+cost: two parameterizations differing in exactly those two quantities have the same mean
+reading time and different mixing proportions (`mean_not_identifiable`).
 
-## Overview
+The fitted model without triage predicts held-out data better than factorial models and than
+surprisal from four language models, and its estimates support three conclusions:
+relative-clause disambiguation is garden-pathed more often than complement-clause
+disambiguation in both contexts; a supporting context lowers the relative-clause garden-path
+rate without eliminating it, while raising the complement-clause rate; and covert reanalysis
+is costlier for the relative clause than for the complement clause and costlier under
+mismatch than under match, so context acts on attachment and on reanalysis alike.
 
-The paper replicates [altmann-garnham-dennis-1992]'s CC/RC × referential
-context design (3×2: {amb-CC, amb-RC, unamb-RC} × {unique, non-unique referents})
-with N = 319 using masked bidirectional self-paced reading (BSPR). The central
-contribution is a **multinomial processing tree (MPT)** model that decomposes
-reading time distributions into latent cognitive processes: attention, first-pass
-attachment (garden-pathing), optional triage, covert/overt reanalysis, and
-success/failure.
+## Implementation notes
 
-## Key Findings
+Parameters and costs are rational and unconstrained, since the tree's identities do not need
+them to lie in the unit interval. The posterior estimates, the Bayes factors of the factorial
+analysis, and the cross-validation ranking are reported in prose only, and the inattentive
+reader's acceptance bias is a parameter of the tree rather than the value the paper fixes
+from its earlier work.
 
-The MPT decomposition yields three conclusions (p. 11) unavailable from
-standard factorial comparison of means:
+## References
 
-I.  Regardless of context, RC disambiguation results in a higher probability
-    of garden-pathing (choosing an incorrect first-pass parse).
-II. Contextual match decreases but does not eliminate the first-pass anti-RC bias.
-III. The cost of in-situ reanalysis is higher for RC than for CC disambiguation,
-     and is lower but still non-zero in cases of context match versus mismatch.
-
-## MPT vs. Surprisal
-
-The no-triage MPT outperforms LLM surprisal-based models (GPT-2, LLaMA-2,
-Mistral, Falcon) and standard factorial models in cross-validated predictive
-fit (PSIS-LOO elpd). The key architectural difference: the MPT assumes reading
-times at disambiguation are *mixture distributions* — bimodal with garden-pathed
-(slow) and non-garden-pathed (fast) components. Surprisal-based models assume
-unimodal distributions shifted by surprisal value, which cannot capture this
-bimodality ([van-schijndel-linzen-2021], [huang-etal-2024]).
-
-## Connections
-
-- `Processing.Cost.Profile`: ordinal profile bridge (§ 7)
-- `Semantics/Lexical/Determiner/Definite.lean`: Uniqueness
-  presupposition of `the_uniq` grounds the context manipulation — bare
-  definites fail uniqueness in non-unique contexts, motivating RC modifiers (§ 9)
-- `Studies/SedivyEtAl1999.lean`: Shared mechanism —
-  modifier informativity given a contrast set drives both contrastive
-  inference (Sedivy) and context-sensitive attachment (§ 9)
+* [paape-vasishth-2026]
+* [altmann-garnham-dennis-1992]
 -/
 
 namespace PaapeVasishth2026
 
--- ════════════════════════════════════════════════════
--- § 0. CC/RC Temporary Ambiguity
--- ════════════════════════════════════════════════════
+/-! ### The design -/
 
-/-! ### The complement clause / relative clause ambiguity
-
-In [altmann-garnham-dennis-1992]'s design, the substring *the woman that
-he'd risked his life for* is temporarily ambiguous between a CC complement
-of *told* and an RC modifying *the woman*. The parser commits before the
-disambiguating material arrives; an incorrect commitment yields a
-garden-path effect at disambiguation.
-
-Two hypotheses frame the debate: **context-sensitive attachment** (discourse
-context modulates first-pass parsing, predicting a context × disambiguation
-interaction) vs. **context-insensitive attachment** (purely syntactic
-first-pass preferences, predicting a disambiguation main effect with no
-interaction). The paper's answer is a graded compromise — "the answer is
-both." -/
-
-/-- The two readings of a temporarily ambiguous CC/RC string. -/
+/-- The three disambiguations of the temporarily ambiguous string, *told the woman that he'd
+risked his life for ...*. -/
 inductive Disambiguation where
-  /-- Complement clause: *told the woman [that he'd risked his life for many people]* -/
   | complementClause
-  /-- Relative clause: *told [the woman that he'd risked his life for] to install ...* -/
   | relativeClause
-  deriving DecidableEq, Repr
+  | unambiguousRelativeClause
+  deriving DecidableEq
 
-/-- Referential context: whether the discourse makes the definite NP's
-    referent uniquely identifiable without a modifier. -/
+/-- The disambiguation resolves to a relative clause. -/
+def Disambiguation.IsRelative : Disambiguation → Prop
+  | .complementClause => False
+  | .relativeClause | .unambiguousRelativeClause => True
+
+instance : DecidablePred Disambiguation.IsRelative
+  | .complementClause => .isFalse id
+  | .relativeClause | .unambiguousRelativeClause => .isTrue trivial
+
+/-- Whether the discourse offers the definite one candidate referent or two. -/
 inductive ReferentialContext where
-  /-- Only one possible referent (e.g., *a man and a woman*) —
-      a bare definite *the woman* suffices, so an RC modifier is
-      pragmatically unnecessary. -/
   | uniqueReferent
-  /-- Multiple possible referents (e.g., *two women*) —
-      a bare definite *the woman* violates uniqueness, so an RC
-      modifier is pragmatically licensed. -/
   | nonUniqueReferents
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
-/-- Whether the referential context supports the disambiguation type.
-    Non-unique referents support RC (the modifier is needed to identify
-    the referent); unique referents support CC (no modifier needed). -/
-def contextSupports : ReferentialContext → Disambiguation → Bool
-  | .nonUniqueReferents, .relativeClause   => true
-  | .uniqueReferent,     .complementClause => true
-  | _,                   _                 => false
+/-- A context supports the relative clause when the bare definite cannot pick out its referent
+and the complement clause when it can. -/
+def ReferentialContext.Supports : ReferentialContext → Disambiguation → Prop
+  | .nonUniqueReferents, d => d.IsRelative
+  | .uniqueReferent, d => ¬ d.IsRelative
 
-/-- An experimental condition in the CC/RC × context design. -/
+instance : ∀ (r : ReferentialContext) (d : Disambiguation), Decidable (r.Supports d)
+  | .nonUniqueReferents, d => inferInstanceAs (Decidable d.IsRelative)
+  | .uniqueReferent, d => inferInstanceAs (Decidable (¬ d.IsRelative))
+
+/-- A cell of the three-by-two design. -/
 structure Condition where
   disambiguation : Disambiguation
   context : ReferentialContext
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
-/-- Whether disambiguation and context match (context supports the
-    actual disambiguation). -/
-def Condition.isMatch (c : Condition) : Bool :=
-  contextSupports c.context c.disambiguation
+/-- Context and disambiguation match. -/
+def Condition.IsMatch (c : Condition) : Prop := c.context.Supports c.disambiguation
 
-open ProcessingModel in
-/-- RC disambiguation is harder than CC on the processing profile:
-    the RC requires crossing a clause boundary (the relative clause)
-    and involves a filler-gap dependency that increases locality. -/
-def disambiguationProfile : Disambiguation → ProcessingProfile
-  | .relativeClause =>
-    { locality := 3       -- filler-gap dependency within the RC
-      boundaries := 1     -- RC clause boundary
-      referentialLoad := 1 -- definite NP referent must be resolved
-      ease := 0 }
-  | .complementClause =>
-    { locality := 1       -- short attachment to matrix verb
-      boundaries := 0     -- no additional clause boundary
-      referentialLoad := 0
-      ease := 1 }         -- CC is the default/preferred analysis
+instance (c : Condition) : Decidable c.IsMatch :=
+  inferInstanceAs (Decidable (c.context.Supports c.disambiguation))
 
-open ProcessingModel in
-/-- RC is Pareto-harder than CC. -/
-theorem rc_pareto_harder :
-    (disambiguationProfile .relativeClause).compare
-    (disambiguationProfile .complementClause) = .harder := by native_decide
+/-- The crossover of the design: two referents support the relative clause and one the
+complement clause. -/
+theorem match_cells :
+    (⟨.relativeClause, .nonUniqueReferents⟩ : Condition).IsMatch ∧
+      ¬ (⟨.relativeClause, .uniqueReferent⟩ : Condition).IsMatch ∧
+      (⟨.complementClause, .uniqueReferent⟩ : Condition).IsMatch ∧
+      ¬ (⟨.complementClause, .nonUniqueReferents⟩ : Condition).IsMatch := by
+  decide
 
--- ════════════════════════════════════════════════════
--- § 1. Multinomial Processing Tree
--- ════════════════════════════════════════════════════
+/-! ### The processing tree -/
 
-/-! ### MPT Structure (Fig. 1)
-
-The MPT models each trial as a cascade of probabilistic binary decisions.
-Each path through the tree yields a distinct combination of processing
-stages and a corresponding reading time distribution.
-
-The full MPT includes a **triage** path (garden-pathed readers sometimes
-reject immediately without reanalysis). The best-fitting model variant
-(no-triage MPT) drops this path, but we include it in the type for
-completeness. -/
-
-/-- Outcome of a single trial through the processing cascade.
-
-Each constructor corresponds to a leaf node in the MPT (Fig. 1),
-determining which processing costs accumulate and whether the
-sentence is ultimately accepted or rejected. -/
-inductive TrialOutcome where
-  /-- Inattentive trial: biased guess (accept with p_bias ≈ 0.79).
-      Fast reading time, no garden-path processing. -/
+/-- The leaves of the tree: each is a path of latent decisions and determines the costs paid,
+whether a regression is observed, and the response. -/
+inductive Outcome where
   | inattentive
-  /-- Attentive, correct first-pass parse: no garden-pathing. -/
   | correctFirstPass
-  /-- Garden-pathed, triaged: reader rejects immediately without
-      attempting reanalysis. Present in the full MPT but dropped
-      in the best-fitting no-triage variant. -/
   | triage
-  /-- Garden-pathed, overt reanalysis (regression to earlier material),
-      reanalysis succeeds. -/
   | overtSuccess
-  /-- Garden-pathed, overt reanalysis (regression), fails → reject. -/
   | overtFail
-  /-- Garden-pathed, covert (in-situ) reanalysis, immediate, succeeds. -/
   | covertImmediateSuccess
-  /-- Garden-pathed, covert reanalysis, immediate, fails → reject. -/
   | covertImmediateFail
-  /-- Garden-pathed, covert reanalysis, postponed to spillover, succeeds. -/
   | covertPostponedSuccess
-  /-- Garden-pathed, covert reanalysis, postponed to spillover, fails → reject. -/
   | covertPostponedFail
-  deriving DecidableEq, Repr
-
-/-- Whether a trial outcome involves garden-pathing. -/
-def TrialOutcome.isGardenPathed : TrialOutcome → Bool
-  | .inattentive       => false
-  | .correctFirstPass  => false
-  | _                  => true
-
-/-- Whether a trial outcome results in sentence acceptance. -/
-def TrialOutcome.accepted : TrialOutcome → Bool
-  | .inattentive              => true   -- biased guess (≈79% accept)
-  | .correctFirstPass         => true
-  | .covertImmediateSuccess   => true
-  | .covertPostponedSuccess   => true
-  | .overtSuccess             => true
-  | _                         => false
-
-/-- Whether a trial outcome involves a first-pass regression
-    (rereading earlier material). In the MPT, regressions occur only
-    on the overt reanalysis path. Covert reanalysis is signaled by
-    in-situ reading slowdown, not regression. -/
-def TrialOutcome.hasRegression : TrialOutcome → Bool
-  | .overtSuccess => true
-  | .overtFail    => true
-  | _             => false
-
--- ════════════════════════════════════════════════════
--- § 2. MPT Parameters
--- ════════════════════════════════════════════════════
-
-/-! ### Process Probabilities
-
-Each branching node in the MPT has a probability parameter. Some parameters
-are affected by the experimental manipulation; the predictor structure is:
-
-- `p_gp ~ context + disambiguation + context : disambiguation`
-- `p_covert_success ~ disambiguation + match`
-- `p_overt_success ~ disambiguation + match`
-- `covert_reanalysis_cost ~ disambiguation + match`
-
-Parameters `p_attentive`, `p_covert`, `p_postpone` can vary between
-participants but are not assumed to vary by condition.
-
-Estimated via Bayesian inference in Stan (4 MCMC chains × 2000 iterations,
-1000 burn-in each). -/
-
-/-- The probability parameters of the MPT model.
-    Values are stored as percentages (0–100). -/
-structure MPTParams where
-  pAttentive : Nat        -- Prob. of reading attentively
-  pGardenPath : Nat       -- Prob. of incorrect first-pass parse
-  pCovert : Nat           -- Prob. covert (vs overt) reanalysis
-  pPostpone : Nat         -- Prob. of postponing covert reanalysis
-  pCovertSuccess : Nat    -- Prob. covert reanalysis succeeds
-  pOvertSuccess : Nat     -- Prob. overt reanalysis succeeds
-  deriving Repr
-
--- ════════════════════════════════════════════════════
--- § 3. Experimental Design and Conditions
--- ════════════════════════════════════════════════════
-
-/-! ### Study Design
-
-Replication of [altmann-garnham-dennis-1992] with N = 319 English
-speakers (Prolific) via masked BSPR with end-of-sentence acceptability
-judgments. 36 stimulus sentences adapted from the original (replacing
-*told* with varied verbs per [staub-etal-2018]), crossed with
-2-level context (unique vs. non-unique referents). -/
-
-/-- Experimental conditions in the 3 × 2 design. -/
-inductive ExpCondition where
-  | ambCC_unique         -- ambiguous CC, unique referent (man and woman)
-  | ambCC_nonUnique      -- ambiguous CC, non-unique referents (two women)
-  | ambRC_unique         -- ambiguous RC, unique referent
-  | ambRC_nonUnique      -- ambiguous RC, non-unique referents
-  | unambRC_unique       -- unambiguous RC, unique referent
-  | unambRC_nonUnique    -- unambiguous RC, non-unique referents
-  deriving DecidableEq, Repr
-
-/-- Map experimental conditions to the abstract Condition type. -/
-def ExpCondition.toCondition : ExpCondition → Condition
-  | .ambCC_unique       => ⟨.complementClause, .uniqueReferent⟩
-  | .ambCC_nonUnique    => ⟨.complementClause, .nonUniqueReferents⟩
-  | .ambRC_unique       => ⟨.relativeClause, .uniqueReferent⟩
-  | .ambRC_nonUnique    => ⟨.relativeClause, .nonUniqueReferents⟩
-  | .unambRC_unique     => ⟨.relativeClause, .uniqueReferent⟩
-  | .unambRC_nonUnique  => ⟨.relativeClause, .nonUniqueReferents⟩
-
-/-- Matching conditions verified. -/
-theorem ambRC_nonUnique_matches :
-    (ExpCondition.ambRC_nonUnique.toCondition).isMatch = true := by native_decide
-
-theorem ambCC_unique_matches :
-    (ExpCondition.ambCC_unique.toCondition).isMatch = true := by native_decide
-
-theorem ambRC_unique_mismatches :
-    (ExpCondition.ambRC_unique.toCondition).isMatch = false := by native_decide
-
-theorem ambCC_nonUnique_mismatches :
-    (ExpCondition.ambCC_nonUnique.toCondition).isMatch = false := by native_decide
-
--- ════════════════════════════════════════════════════
--- § 4. Bayesian Factorial Analysis (Tables 2–3)
--- ════════════════════════════════════════════════════
-
-/-! ### Bayesian Analysis Results
-
-Standard Bayesian linear mixed-effects analysis using brms, with sum
-contrasts for CONTEXT (unique = −1, non-unique = +1) and treatment
-contrasts for DISAMBIGUATION (amb-RC = baseline). Lognormal likelihood
-for first-pass reading times (FPRT), Bernoulli for first-pass regressions.
-
-BF10 values > 3 indicate evidence for the alternative hypothesis. We record
-the critical region effects, which are the earliest measures potentially
-affected by garden-pathing. -/
-
-/-- Bayes factor (BF10) for key effects at the critical disambiguating region.
-    BF10 > 3 indicates evidence; values >1000 are decisive. -/
-structure CriticalRegionBF where
-  label : String
-  bf10 : Nat              -- BF10 (truncated to Nat; >1000 stored as 1000)
-  deriving Repr
-
-/-- Key Bayesian analysis results from Table 2 (critical region). -/
-def bayesianResults : List CriticalRegionBF :=
-  [ ⟨"context (FPRT)",                1000⟩   -- BF10 > 1000
-  , ⟨"CC vs RC (FPRT)",               467⟩    -- BF10 = 467.40
-  , ⟨"unambRC vs RC (FPRT)",          611⟩    -- BF10 = 611.36
-  , ⟨"context × CC (FPRT)",           1000⟩   -- BF10 > 1000
-  , ⟨"context × unambRC (FPRT)",      4⟩      -- BF10 = 4.73
-  , ⟨"context (regressions)",         46⟩     -- BF10 = 46.68
-  , ⟨"context × CC (regressions)",    10⟩     -- BF10 = 10.57
-  ]
-
-/-- All recorded Bayes factors exceed the evidence threshold of 3. -/
-theorem all_effects_evidenced :
-    bayesianResults.all (·.bf10 > 3) = true := by native_decide
-
--- ════════════════════════════════════════════════════
--- § 5. MPT Parameter Estimates (No-Triage Model)
--- ════════════════════════════════════════════════════
-
-/-! ### Parameter Estimates
-
-The no-triage MPT model achieves the best cross-validated predictive fit
-(Fig. 6). The following estimates are approximate posterior medians
-from Fig. 8–10. The intercept corresponds to the mean probability in
-the ambiguous RC condition across matching and mismatching contexts. -/
-
-/-- Baseline MPT parameters (ambiguous RC, averaged over contexts).
-    Approximate posterior medians from the no-triage model. -/
-def baselineParams : MPTParams :=
-  { pAttentive    := 75   -- ~75% of trials are attentive
-    pGardenPath   := 75   -- ~75% of amb-RC trials are garden-pathed
-    pCovert       := 60   -- ~60% covert (vs. 40% overt)
-    pPostpone     := 25   -- ~25% of covert reanalysis postponed
-    pCovertSuccess := 85  -- ~85% covert reanalysis succeeds
-    pOvertSuccess  := 60  -- ~60% overt reanalysis succeeds
-  }
-
-/-! ### Garden-Path Probability by Condition
-
-Approximate cell estimates derived from the intercept + slope posteriors
-(Figs. 8–9). The slopes are on the logit scale; back-transformed
-estimates are approximate.
-
-Key constraints from the paper (p. 8):
-- Amb-RC average across contexts ≈ 75%
-- Non-unique referents decrease RC GP by ~15 pp
-- Non-unique referents increase CC GP by ~40 pp
-- Unamb-RC is reduced by ~35 pp relative to amb-RC -/
-
-/-- Garden-path probability estimates (percent) by condition.
-
-These are approximate back-transformed posterior medians for p_gp
-from the no-triage MPT model, constructed to satisfy the paper's
-stated constraints. -/
-def gardenPathRate : ExpCondition → Nat
-  | .ambRC_unique       => 82   -- mismatching context → higher GP
-  | .ambRC_nonUnique    => 67   -- matching context → reduced by ~15 pp
-  | .ambCC_unique       => 10   -- matching context → low GP (CC preferred)
-  | .ambCC_nonUnique    => 50   -- mismatching context → increased by ~40 pp
-  | .unambRC_unique     => 45   -- unamb-RC: ~35 pp below amb-RC
-  | .unambRC_nonUnique  => 35   -- unamb-RC with support
-
-/-- Amb-RC cell estimates average to approximately 75%. -/
-theorem ambRC_averages_near_75 :
-    (gardenPathRate .ambRC_unique + gardenPathRate .ambRC_nonUnique) / 2 = 74 := by
-  native_decide
-
--- ════════════════════════════════════════════════════
--- § 6. Key Findings as Theorems
--- ════════════════════════════════════════════════════
-
-/-! ### Finding I: RC always harder (p. 11)
-
-"Regardless of context, RC disambiguation results in a higher
-probability of garden-pathing, that is, choosing an incorrect
-first-pass attachment." -/
-
-theorem finding_I_rc_harder_than_cc :
-    gardenPathRate .ambRC_unique > gardenPathRate .ambCC_unique ∧
-    gardenPathRate .ambRC_nonUnique > gardenPathRate .ambCC_nonUnique := by
-  constructor <;> native_decide
-
-/-! ### Finding II: Context reduces but does not eliminate (p. 11)
-
-"Contextual match decreases but does not eliminate the first-pass
-anti-RC bias." -/
-
-/-- Context reduces RC garden-pathing. -/
-theorem finding_II_context_reduces_rc :
-    gardenPathRate .ambRC_nonUnique < gardenPathRate .ambRC_unique := by
-  native_decide
-
-/-- Context does not eliminate RC garden-pathing — the rate with
-    supporting context still far exceeds the CC baseline. -/
-theorem finding_II_not_eliminated :
-    gardenPathRate .ambRC_nonUnique > gardenPathRate .ambCC_unique := by
-  native_decide
-
-/-- Context × disambiguation crossover: non-unique referents help RC
-    but hurt CC. This is the interaction predicted by the context-sensitive
-    attachment hypothesis. -/
-theorem context_crossover :
-    gardenPathRate .ambRC_nonUnique < gardenPathRate .ambRC_unique ∧
-    gardenPathRate .ambCC_nonUnique > gardenPathRate .ambCC_unique := by
-  constructor <;> native_decide
-
-/-- The results support a graded version of context-sensitive attachment:
-    context affects first-pass parsing (there IS an interaction), but
-    the bias is not fully overridden (there IS a main effect of
-    disambiguation). Neither hypothesis alone suffices. -/
-theorem graded_context_sensitivity :
-    -- There is an interaction (context-sensitive prediction)
-    (gardenPathRate .ambRC_nonUnique < gardenPathRate .ambRC_unique) ∧
-    -- There is a main effect (context-insensitive prediction)
-    (gardenPathRate .ambRC_nonUnique > gardenPathRate .ambCC_nonUnique) := by
-  constructor <;> native_decide
-
-/-! ### Finding III: Reanalysis cost is separable (p. 11)
-
-"The cost of in-situ reanalysis is higher for RC than for CC
-disambiguation, and is lower but still non-zero in cases of
-context–disambiguation match versus mismatch." -/
-
-/-- Processing cost structure from posterior estimates (Fig. 10).
-    All values in milliseconds. -/
-structure ProcessingCosts where
-  gardenPathCost : Nat       -- pure GP cost (small: ~10–20ms)
-  attentionCost : Nat        -- cost of paying attention (~5ms)
-  regressionCost : Nat       -- cost of launching a regression
-  covertReanalysisCost : Nat -- in-situ reanalysis cost
-  deriving Repr
-
-/-- Baseline costs for RC disambiguation (intercept posteriors, Fig. 10). -/
-def rcCosts : ProcessingCosts :=
-  { gardenPathCost       := 15    -- ~10–20ms
-    attentionCost        := 5     -- ~2.5–10ms
-    regressionCost       := 275   -- ~225–300ms
-    covertReanalysisCost := 400   -- ~350–450ms
-  }
-
-/-- CC disambiguation costs: covert reanalysis is ~150–200ms cheaper
-    than RC (Fig. 10 CC vs RC slope centered around -150 to -200ms). -/
-def ccCosts : ProcessingCosts :=
-  { gardenPathCost       := 15
-    attentionCost        := 5
-    regressionCost       := 275
-    covertReanalysisCost := 225   -- ~400 - 175 = ~225ms
-  }
-
-/-- Finding III: RC covert reanalysis is costlier than CC. -/
-theorem finding_III_rc_costlier :
-    rcCosts.covertReanalysisCost > ccCosts.covertReanalysisCost := by
-  native_decide
-
-/-- Finding III (second part): covert reanalysis cost is non-trivial
-    even for CC disambiguation (i.e., still non-zero). -/
-theorem finding_III_cc_still_costly :
-    ccCosts.covertReanalysisCost > 0 := by native_decide
-
-/-- Pure garden-pathing cost is small relative to reanalysis cost.
-    This is a key MPT insight: the cost of *being* garden-pathed is
-    tiny; the cost comes from reanalysis. -/
-theorem gp_cost_small_relative_to_reanalysis :
-    rcCosts.gardenPathCost * 10 < rcCosts.covertReanalysisCost := by
-  native_decide
-
--- ════════════════════════════════════════════════════
--- § 7. Bridge: MPT vs. Surprisal
--- ════════════════════════════════════════════════════
-
-/-! ### Why the MPT outperforms surprisal
-
-Surprisal theory ([hale-2001], [levy-2008]) predicts that
-processing difficulty is proportional to the negative log probability
-of a word in context. For garden-path sentences, surprisal at the
-disambiguating region should be higher for less expected continuations.
-
-The MPT outperforms all four LLM surprisal models and the standard
-factorial model in cross-validated predictive fit. The key architectural
-difference is the **mixture assumption**: reading times at disambiguation
-are generated by a mixture of latent populations (garden-pathed vs. not),
-each with distinct cost distributions. Single-stage surprisal models
-predict a unimodal distribution shifted by the surprisal value.
-
-This is structurally analogous to the limitation identified by
-[van-schijndel-linzen-2021] and [huang-etal-2024]: single-stage
-surprisal models underestimate the magnitude of garden-path effects
-because they lack a distinct, costly reanalysis mechanism. -/
-
-/-- Model rankings from cross-validated predictive fit (PSIS-LOO elpd,
-    Fig. 6). Higher rank = better fit. Rank 1 = best.
-
-    The ranking shows that even the simplest MPT model (mpt-simple)
-    outperforms the best surprisal model, and adding an inattention
-    component to a factorial model (factorial-inattention) only barely
-    exceeds mpt-simple. -/
-inductive ModelVariant where
-  | factorial            -- standard factorial model
-  | factorialInattention -- factorial + inattention mixture
-  | gpt2Surprisal        -- GPT-2 surprisal
-  | llamaSurprisal       -- LLaMA-2 surprisal
-  | mistralSurprisal     -- Mistral surprisal
-  | falconSurprisal      -- Falcon surprisal
-  | gpt2Inattention      -- GPT-2 + inattention
-  | mptSimple            -- MPT: garden-pathing + reanalysis only
-  | mptNoTriage          -- MPT without triage (best model)
-  | mptFull              -- full MPT with triage
-  deriving DecidableEq, Repr
-
-/-- Cross-validated predictive fit ranking (1 = best). -/
-def modelRank : ModelVariant → Nat
-  | .mptNoTriage          => 1
-  | .mptFull              => 2
-  | .mptSimple            => 3
-  | .gpt2Inattention      => 4
-  | .factorialInattention => 5
-  | .falconSurprisal      => 6
-  | .mistralSurprisal     => 7
-  | .llamaSurprisal       => 8
-  | .gpt2Surprisal        => 9
-  | .factorial            => 10
-
-/-- All MPT variants outperform all surprisal models. -/
-theorem mpt_beats_surprisal :
-    modelRank .mptSimple < modelRank .gpt2Surprisal ∧
-    modelRank .mptSimple < modelRank .llamaSurprisal ∧
-    modelRank .mptSimple < modelRank .mistralSurprisal ∧
-    modelRank .mptSimple < modelRank .falconSurprisal := by
-  constructor <;> first | constructor <;> native_decide | native_decide
-
-/-- The no-triage variant beats the full MPT — triage is not needed. -/
-theorem noTriage_beats_full :
-    modelRank .mptNoTriage < modelRank .mptFull := by native_decide
-
--- ════════════════════════════════════════════════════
--- § 8. Bridge: Processing Profile Consistency
--- ════════════════════════════════════════════════════
-
-/-! ### From ordinal to quantitative
-
-The `ProcessingProfile` from `Processing.Cost.Profile` captures the ordinal
-claim that RC is harder than CC (`rc_pareto_harder`, § 0).
-The MPT *explains* this ordering by decomposing it into quantitative
-components: RC has higher garden-path probability, higher reanalysis cost,
-and lower reanalysis success rate. The ordinal profile is the observable
-consequence; the MPT is the latent mechanism. -/
-
-/-- The MPT decomposition is consistent with the Pareto ordering:
-    every quantitative measure points in the same direction. -/
-theorem mpt_consistent_with_pareto :
-    gardenPathRate .ambRC_unique > gardenPathRate .ambCC_unique ∧
-    rcCosts.covertReanalysisCost > ccCosts.covertReanalysisCost := by
-  constructor <;> native_decide
-
--- ════════════════════════════════════════════════════
--- § 9. Bridge: Uniqueness Presupposition Grounds Context Effect
--- ════════════════════════════════════════════════════
-
-/-! ### Uniqueness presupposition grounds referential context
-
-The experimental manipulation of referential context (unique vs. non-unique
-referents) is grounded in the **uniqueness presupposition** of definite
-descriptions (`the_uniq` in `Semantics/Lexical/Determiner/Definite.lean`).
-
-In the non-unique condition (*He was introduced to two women. He told the
-woman that...*), a bare definite "the woman" fails uniqueness because two
-entities satisfy the restrictor. An RC modifier ("the woman that he'd risked
-his life for") intersects the restrictor with the RC predicate, narrowing
-to a single entity and rescuing uniqueness.
-
-This makes the RC pragmatically *necessary* in non-unique contexts — the same
-mechanism underlying [sedivy-etal-1999]'s contrastive inference: a
-modifier is informative when a contrast set is available. In Sedivy et al.'s
-visual-world paradigm, the contrast set is perceptual (tall glass vs. short
-glass); here, it is discourse-referential (woman₁ vs. woman₂). Both are
-instances of modifier informativity increasing with the availability of
-alternatives.
-
-The argument chain:
-1. `the_uniq` presupposes exactly one restrictor-satisfier
-2. Non-unique context → presupposition fails for bare NP
-3. RC modifier narrows restrictor → presupposition can succeed
-4. Therefore RC is pragmatically licensed in non-unique contexts
-5. This matches `contextSupports .nonUniqueReferents .relativeClause = true`
-6. Parser is biased toward RC → less garden-pathing (Finding II)
--/
-
-section UniquenessBridge
-
-open Definiteness
-open Presupposition
-open Presupposition.PartialProp
-open Definiteness
-
-/-- Toy discourse entity for the uniqueness worked example. -/
-inductive DiscEntity where
-  | woman1   -- the woman he risked his life for
-  | woman2   -- a second woman
-  | man
-  deriving DecidableEq, Repr
-
-/-- Non-unique context domain: a man and two women. -/
-def nonUniqueDomain : List DiscEntity := [.woman1, .woman2, .man]
-
-/-- Unique context domain: a man and one woman. -/
-def uniqueDomain : List DiscEntity := [.woman1, .man]
-
-/-- Restrictor predicate: "woman". -/
-def isWoman : DiscEntity → Bool
-  | .woman1 => true | .woman2 => true | .man => false
-
-/-- RC modifier predicate: "that he'd risked his life for". -/
-def rcModifier : DiscEntity → Bool
-  | .woman1 => true | _ => false
-
-/-- Trivial scope for the worked example. -/
-def toldScope : DiscEntity → Bool := fun _ => true
-
-/-- File-local convenience: the uniqueness-based definite as a `PartialProp Unit`,
-    built from the canonical `presupOfReferent` combinator with
-    `russellIotaList` as the per-context referent selector. -/
-private def thePresup (domain : List DiscEntity) (restrictor scope : DiscEntity → Bool) :
-    PartialProp Unit :=
-  presupOfReferent (fun _ : Unit => russellIotaList domain restrictor)
-                   (fun e _ => scope e = true)
-
-/-- In non-unique context, bare "the woman" FAILS uniqueness:
-    two entities satisfy the restrictor, so referent selection returns
-    `none` and the presupposition fails. -/
-theorem bare_fails_nonunique :
-    ¬(thePresup nonUniqueDomain isWoman toldScope).presup () := by
-  simp only [thePresup, presupOfReferent_presup, russellIotaList,
-    nonUniqueDomain, List.filter, isWoman]; decide
-
-/-- In non-unique context, modified "the woman that he'd risked his
-    life for" SUCCEEDS: the RC modifier narrows to one entity. -/
-theorem modified_succeeds_nonunique :
-    (thePresup nonUniqueDomain
-      (fun e => isWoman e && rcModifier e) toldScope).presup () := by
-  simp only [thePresup, presupOfReferent_presup, russellIotaList,
-    nonUniqueDomain, List.filter, isWoman, rcModifier,
-    Bool.and_false, Bool.and_true, Option.isSome_some]
-
-/-- In unique context, bare "the woman" already SUCCEEDS:
-    only one entity satisfies the restrictor, so no modifier needed. -/
-theorem bare_succeeds_unique :
-    (thePresup uniqueDomain isWoman toldScope).presup () := by
-  simp only [thePresup, presupOfReferent_presup, russellIotaList,
-    uniqueDomain, List.filter, isWoman, Option.isSome_some]
-
-/-- The full argument chain: uniqueness presupposition grounds
-    `contextSupports` (§ 0).
-
-    1. Non-unique context → bare definite fails → RC modifier needed
-    2. This is exactly `contextSupports .nonUniqueReferents .relativeClause`
-    3. Unique context → bare definite succeeds → no modifier needed
-    4. This is exactly `contextSupports .uniqueReferent .complementClause` -/
-theorem uniqueness_grounds_context_supports :
-    -- Non-unique: bare fails, modified succeeds, RC is supported
-    ¬(thePresup nonUniqueDomain isWoman toldScope).presup () ∧
-    (thePresup nonUniqueDomain (fun e => isWoman e && rcModifier e)
-      toldScope).presup () ∧
-    contextSupports .nonUniqueReferents .relativeClause = true ∧
-    -- Unique: bare succeeds, CC is supported
-    (thePresup uniqueDomain isWoman toldScope).presup () ∧
-    contextSupports .uniqueReferent .complementClause = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
-  · simp only [thePresup, presupOfReferent_presup, russellIotaList,
-      nonUniqueDomain, List.filter, isWoman]; decide
-  · simp only [thePresup, presupOfReferent_presup, russellIotaList,
-      nonUniqueDomain, List.filter, isWoman, rcModifier,
-      Bool.and_false, Bool.and_true, Option.isSome_some]
-  · native_decide
-  · simp only [thePresup, presupOfReferent_presup, russellIotaList,
-      uniqueDomain, List.filter, isWoman, Option.isSome_some]
-  · native_decide
-
--- ────────────────────────────────────────────────────
--- § 9b. Formal Shared Mechanism: modifierNecessary
--- ────────────────────────────────────────────────────
-
-/-! ### Shared mechanism with contrastive inference
-
-`modifierNecessary` (defined in `Definite.lean`) captures the abstract
-predicate: a modifier rescues a failed uniqueness presupposition. Both
-Paape & Vasishth's context-sensitive attachment and [sedivy-etal-1999]'s
-contrastive inference are instances of the same predicate — the modifier
-type differs (RC vs. scalar adjective) but the referential mechanism is
-identical. -/
-
-/-- In non-unique context, the RC modifier is referentially necessary:
-    bare "the woman" is ambiguous, modified "the woman that P" is unique. -/
-theorem pv_modifier_necessary :
-    modifierNecessary nonUniqueDomain isWoman rcModifier = true := by
-  native_decide
-
-/-- In unique context, the RC modifier is unnecessary:
-    bare "the woman" already uniquely identifies. -/
-theorem pv_modifier_unnecessary :
-    modifierNecessary uniqueDomain isWoman rcModifier = false := by
-  native_decide
-
--- Sedivy et al. (1999) visual-world scenario
-
-/-- Toy visual-world entity for the [sedivy-etal-1999] scenario. -/
-inductive SedivyEntity where
-  | tallGlass    -- target
-  | shortGlass   -- same-category competitor
-  | ball         -- distractor
-  | key          -- distractor
-  deriving DecidableEq, Repr
-
-/-- Contrast display: two glasses (tall and short) plus distractors. -/
-def contrastDisplay : List SedivyEntity :=
-  [.tallGlass, .shortGlass, .ball, .key]
-
-/-- No-contrast display: one glass plus distractors. -/
-def noContrastDisplay : List SedivyEntity :=
-  [.tallGlass, .ball, .key]
-
-/-- Restrictor predicate: "glass". -/
-def isGlass : SedivyEntity → Bool
-  | .tallGlass => true | .shortGlass => true | _ => false
-
-/-- Modifier predicate: "tall". -/
-def isTall : SedivyEntity → Bool
-  | .tallGlass => true | _ => false
-
-/-- With a contrast set (two glasses), "tall" is referentially necessary:
-    bare "the glass" is ambiguous, "the tall glass" is unique. -/
-theorem sedivy_modifier_necessary :
-    modifierNecessary contrastDisplay isGlass isTall = true := by
-  native_decide
-
-/-- Without a contrast set (one glass), "tall" is unnecessary:
-    bare "the glass" already uniquely identifies. -/
-theorem sedivy_modifier_unnecessary :
-    modifierNecessary noContrastDisplay isGlass isTall = false := by
-  native_decide
-
-/-- **Structural identity**: the same `modifierNecessary` predicate governs
-    both phenomena. When alternatives are available, the modifier is
-    necessary; when the referent is already unique, the modifier is
-    redundant. The modifier type is irrelevant — RC (Paape & Vasishth)
-    and scalar adjective (Sedivy et al.) behave identically at this
-    level of abstraction. -/
-theorem shared_mechanism :
-    -- Both: modifier necessary when alternatives present
-    modifierNecessary nonUniqueDomain isWoman rcModifier = true ∧
-    modifierNecessary contrastDisplay isGlass isTall = true ∧
-    -- Both: modifier unnecessary when referent unique
-    modifierNecessary uniqueDomain isWoman rcModifier = false ∧
-    modifierNecessary noContrastDisplay isGlass isTall = false := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
-
-end UniquenessBridge
+  deriving DecidableEq
+
+/-- The leaves. -/
+def Outcome.all : List Outcome :=
+  [.inattentive, .correctFirstPass, .triage, .overtSuccess, .overtFail,
+    .covertImmediateSuccess, .covertImmediateFail, .covertPostponedSuccess,
+    .covertPostponedFail]
+
+theorem Outcome.mem_all (o : Outcome) : o ∈ Outcome.all := by cases o <;> simp [Outcome.all]
+
+/-- The trial was garden-pathed. -/
+def Outcome.IsGardenPathed (o : Outcome) : Prop := o ≠ .inattentive ∧ o ≠ .correctFirstPass
+
+/-- The trial shows a first-pass regression: only overt reanalysis rereads earlier material. -/
+def Outcome.HasRegression (o : Outcome) : Prop := o = .overtSuccess ∨ o = .overtFail
+
+/-- The attentive reader arrives at the correct analysis. -/
+def Outcome.IsSuccess (o : Outcome) : Prop :=
+  o = .correctFirstPass ∨ o = .overtSuccess ∨ o = .covertImmediateSuccess ∨
+    o = .covertPostponedSuccess
+
+instance : DecidablePred Outcome.IsGardenPathed := λ _ => inferInstanceAs (Decidable (_ ∧ _))
+instance : DecidablePred Outcome.HasRegression := λ _ => inferInstanceAs (Decidable (_ ∨ _))
+instance : DecidablePred Outcome.IsSuccess := λ _ => inferInstanceAs (Decidable (_ ∨ _))
+
+/-- The branching probabilities: attentive reading, garden-pathing, triage rather than
+reanalysis, covert rather than overt reanalysis, postponement of covert reanalysis, success of
+each kind of reanalysis, and the inattentive reader's bias towards acceptance. -/
+structure Params where
+  attentive : ℚ
+  gardenPath : ℚ
+  triage : ℚ
+  covert : ℚ
+  postpone : ℚ
+  covertSuccess : ℚ
+  overtSuccess : ℚ
+  bias : ℚ
+
+namespace Params
+
+variable (p : Params)
+
+/-- The probability of a garden-pathed trial that is reanalysed. -/
+def reanalysed : ℚ := p.attentive * p.gardenPath * (1 - p.triage)
+
+/-- The probability of a leaf: the product of the branch probabilities on its path. -/
+def prob : Outcome → ℚ
+  | .inattentive => 1 - p.attentive
+  | .correctFirstPass => p.attentive * (1 - p.gardenPath)
+  | .triage => p.attentive * p.gardenPath * p.triage
+  | .overtSuccess => p.reanalysed * (1 - p.covert) * p.overtSuccess
+  | .overtFail => p.reanalysed * (1 - p.covert) * (1 - p.overtSuccess)
+  | .covertImmediateSuccess => p.reanalysed * p.covert * (1 - p.postpone) * p.covertSuccess
+  | .covertImmediateFail => p.reanalysed * p.covert * (1 - p.postpone) * (1 - p.covertSuccess)
+  | .covertPostponedSuccess => p.reanalysed * p.covert * p.postpone * p.covertSuccess
+  | .covertPostponedFail => p.reanalysed * p.covert * p.postpone * (1 - p.covertSuccess)
+
+/-- The probability of the leaves satisfying a predicate. -/
+def mass (P : Outcome → Prop) [DecidablePred P] : ℚ :=
+  (Outcome.all.map λ o => if P o then p.prob o else 0).sum
+
+/-- The leaf probabilities sum to one. -/
+theorem prob_sum : (Outcome.all.map p.prob).sum = 1 := by
+  simp [Outcome.all, prob, reanalysed]; ring
+
+/-- The probability of garden-pathing: attentive reading times the garden-path probability. -/
+theorem mass_gardenPathed : p.mass Outcome.IsGardenPathed = p.attentive * p.gardenPath := by
+  simp [mass, Outcome.all, Outcome.IsGardenPathed, prob, reanalysed]; ring
+
+/-- The probability of a regression: reanalysis that is overt. -/
+theorem mass_regression : p.mass Outcome.HasRegression = p.reanalysed * (1 - p.covert) := by
+  simp [mass, Outcome.all, Outcome.HasRegression, prob]; ring
+
+/-- The probability of acceptance: the inattentive guess, the correct first pass, and the
+successful reanalyses, postponement being immaterial to success. -/
+def accept : ℚ := p.prob .inattentive * p.bias + p.mass Outcome.IsSuccess
+
+theorem accept_eq :
+    p.accept = (1 - p.attentive) * p.bias + p.attentive * (1 - p.gardenPath) +
+      p.reanalysed * ((1 - p.covert) * p.overtSuccess + p.covert * p.covertSuccess) := by
+  simp [accept, mass, Outcome.all, Outcome.IsSuccess, prob]; ring
+
+end Params
+
+/-! ### Reading times as a mixture -/
+
+/-- The costs at the disambiguating region: attending, being garden-pathed, reanalysing in
+situ, and launching a regression; postponed covert reanalysis is paid at the spillover region
+instead. -/
+structure Costs where
+  attention : ℚ
+  gardenPath : ℚ
+  covert : ℚ
+  regression : ℚ
+
+/-- The cost a leaf pays at the disambiguating region, above non-decision time. -/
+def Costs.at (k : Costs) : Outcome → ℚ
+  | .inattentive => 0
+  | .correctFirstPass => k.attention
+  | .triage => k.attention + k.gardenPath
+  | .overtSuccess | .overtFail => k.attention + k.gardenPath + k.regression
+  | .covertImmediateSuccess | .covertImmediateFail => k.attention + k.gardenPath + k.covert
+  | .covertPostponedSuccess | .covertPostponedFail => k.attention + k.gardenPath
+
+/-- The mean reading time at the disambiguating region: the mixture of the leaf costs. -/
+def mean (p : Params) (k : Costs) : ℚ := (Outcome.all.map λ o => p.prob o * k.at o).sum
+
+/-- A condition mean cannot tell an effect on first-pass attachment from an effect on
+reanalysis cost: two parameterizations with different garden-path probabilities and different
+covert reanalysis costs have the same mean but different mixing proportions. -/
+theorem mean_not_identifiable :
+    ∃ (p p' : Params) (k k' : Costs), p.gardenPath ≠ p'.gardenPath ∧ k.covert ≠ k'.covert ∧
+      mean p k = mean p' k' ∧
+      p.prob .covertImmediateSuccess ≠ p'.prob .covertImmediateSuccess :=
+  ⟨⟨1, 1/2, 0, 1, 0, 1, 1, 1⟩, ⟨1, 1/4, 0, 1, 0, 1, 1, 1⟩, ⟨0, 0, 400, 0⟩, ⟨0, 0, 800, 0⟩,
+    by norm_num, by norm_num, by norm_num [mean, Outcome.all, Params.prob, Params.reanalysed,
+      Costs.at], by norm_num [Params.prob, Params.reanalysed]⟩
 
 end PaapeVasishth2026

--- a/references.bib
+++ b/references.bib
@@ -2545,7 +2545,7 @@
   doi       = {10.1016/S0010-0277(99)00025-6},
   subfield  = {pragmatics/rsa},
   role      = {cited},
-  sources   = {Semantics/Definiteness/Basic.lean;Studies/PaapeVasishth2026.lean;Studies/RonderosEtAl2024.lean;Studies/SedivyEtAl1999.lean}
+  sources   = {Semantics/Definiteness/Basic.lean;Studies/RonderosEtAl2024.lean;Studies/SedivyEtAl1999.lean}
 }
 @article{sedivy-2007,
   author    = {Sedivy, Julie C.},
@@ -28053,7 +28053,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Core/InformationTheory/KullbackLeibler/Cond.lean;Core/Probability/Constructions.lean;Processing/Expectation/Defs.lean;Processing/Expectation/InformationValue.lean;Processing/Expectation/LanguageModel.lean;Processing/Expectation/PrefixProbability.lean;Studies/GiulianelliEtAl2026.lean;Studies/Hale2001.lean;Studies/Levy2008.lean;Studies/PaapeVasishth2026.lean}
+  sources   = {Core/InformationTheory/KullbackLeibler/Cond.lean;Core/Probability/Constructions.lean;Processing/Expectation/Defs.lean;Processing/Expectation/InformationValue.lean;Processing/Expectation/LanguageModel.lean;Processing/Expectation/PrefixProbability.lean;Studies/GiulianelliEtAl2026.lean;Studies/Hale2001.lean;Studies/Levy2008.lean}
 }
 @article{smith-levy-2013,
   author    = {Smith, Nathaniel J. and Levy, Roger},
@@ -28131,7 +28131,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Processing/Expectation/PrefixProbability.lean;Studies/Hale2001.lean;Studies/Levy2008.lean;Studies/PaapeVasishth2026.lean}
+  sources   = {Processing/Expectation/PrefixProbability.lean;Studies/Hale2001.lean;Studies/Levy2008.lean}
 }
 @article{van-schijndel-linzen-2021,
   author    = {van Schijndel, Marten and Linzen, Tal},
@@ -28145,7 +28145,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/PaapeVasishth2026.lean}
+  sources   = {}
 }
 @article{huang-etal-2024,
   author    = {Huang, Kuan-Jung and Arehalli, Suhas and Kugemoto, Mari and Muxica, Christian and Prasad, Grusha and Dillon, Brian and Linzen, Tal},
@@ -28158,7 +28158,7 @@
   subfield  = {psycholinguistics/processing},
   validated = {true},
   role      = {cited},
-  sources   = {Studies/PaapeVasishth2026.lean}
+  sources   = {}
 }
 @article{kirk-giannini-2024,
   author    = {Kirk-Giannini, Cameron Domenico},


### PR DESCRIPTION
The stipulated garden-path rates, cost tables, Bayes-factor table, model ranking, and the uniqueness/Sedivy bridges are cut; the tree's leaf probabilities, marginals, and the non-identifiability of condition means are proved.
- the old ranking contradicted the paper (factorial+inattention sits above the simplest MPT)
- the old `pCovert` had overt/covert reversed (paper: 60% overt)