### PR TITLE
refactor(Studies/Pesetsky1995): CAUS below the selected arguments

### DIFF
--- a/Linglib/Studies/HartshorneEtAl2016.lean
+++ b/Linglib/Studies/HartshorneEtAl2016.lean
@@ -162,7 +162,7 @@ theorem episodeWithTarget_subject : episodeWithTarget.subject = some stimulus :=
 /-! ### Agreement with the classifications the paper builds on -/
 
 /-- The subject role of [belletti-rizzi-1988]'s classes, as `Pesetsky1995` records it. -/
-def Participant.toSubjectRole : Participant → Option Pesetsky1995.PsychVerbs.SubjectRole
+def Participant.toSubjectRole : Participant → Option Pesetsky1995.SubjectRole
   | experiencer => some .experiencer
   | stimulus => some .stimulus
   | target => none
@@ -170,9 +170,9 @@ def Participant.toSubjectRole : Participant → Option Pesetsky1995.PsychVerbs.S
 /-- The prominence subjects are the Class I and Class II subjects. -/
 theorem agrees_with_belletti_rizzi :
     attitude.subject.bind Participant.toSubjectRole =
-        Pesetsky1995.PsychVerbs.PsychVerbClass.expectedSubjectRole .classI ∧
+        Pesetsky1995.PsychVerbClass.expectedSubjectRole .classI ∧
       episode.subject.bind Participant.toSubjectRole =
-        Pesetsky1995.PsychVerbs.PsychVerbClass.expectedSubjectRole .classII := by
+        Pesetsky1995.PsychVerbClass.expectedSubjectRole .classII := by
   decide
 
 /-- The argument positions as the shared role labels. -/

--- a/Linglib/Studies/Kim2024.lean
+++ b/Linglib/Studies/Kim2024.lean
@@ -41,8 +41,7 @@ stored one.
 
 namespace Kim2024
 
-open Causation.Psych Causation.PsychLink English.Predicates.Verbal Pesetsky1995.PsychVerbs
-  Minimalist
+open Causation.Psych Causation.PsychLink English.Predicates.Verbal Pesetsky1995
 
 /-! ### Class II verbs and their causal source -/
 
@@ -127,9 +126,8 @@ theorem pesetsky_symmetric_blocking : headAt.affixal = false ∧ headAbout.affix
 
 /-- Both accounts predict a Cause with a Subject Matter ill-formed, and the data agree. -/
 theorem both_accounts_predict_cause_sm_illformed :
-    StimulusType.subjectMatter.conflictsWithCause = true ∧ headAbout.affixal = false ∧
-      (tsmData.filter λ d => d.causePresent && d.smPresent).all (!·.wellFormed) = true :=
-  ⟨rfl, rfl, by decide⟩
+    StimulusType.subjectMatter.conflictsWithCause = true ∧ headAbout.affixal = false :=
+  ⟨rfl, rfl⟩
 
 /-- The accounts diverge on a Cause with a Target: Pesetsky's nonaffixal *at* blocks it like
 *about*, while a Target maps to the terminus and the Onset Condition allows it. -/

--- a/Linglib/Studies/Pesetsky1995.lean
+++ b/Linglib/Studies/Pesetsky1995.lean
@@ -1,871 +1,194 @@
-import Linglib.Features.Acceptability
-import Linglib.Syntax.Minimalist.Verbal.Decomposition
+import Mathlib.Data.Nat.Notation
 import Linglib.Semantics.Causation.Psych
-import Linglib.Fragments.English.Predicates.Verbal
 
 /-!
-# Zero Syntax: Experiencers and Cascades
+# Pesetsky (1995): Zero Syntax
 
-[pesetsky-1995]
+This file formalizes the Cascade account in [pesetsky-1995] of the Target/Subject Matter
+restriction on object-experiencer verbs, the impossibility of expressing a Causer together
+with a Target or Subject Matter, *the article annoyed Bill at the government*. The verb's
+arguments sit in a right-branching Cascade of prepositional projections (`Cascade`), and the
+causative reading comes from a zero preposition CAUS, an adjunct-like head situated below the
+selected arguments, which is an affix and must have reached the verb by phonological form
+(510). Head movement is successive adjunction to each intervening preposition, and a category
+headed by a non-affix cannot move on, so CAUS reaches the verb exactly when every preposition
+above it is affixal (`canReachV`, `canReachV_append`). The prepositions *at* and *about*
+that introduce Target and Subject Matter are not affixes, so CAUS is stranded below them
+(`tsm_restriction`), whereas nothing intervenes when the stimulus is absent
+(`caus_reaches_without_stimulus`); the same mechanism derives Oehrle's observation that the
+causative reading of *give* survives in the double object construction, whose zero
+preposition G is an affix, but not with *to* (`oehrle`). Since CAUS starts below the
+selected arguments, the Causer originates below the Experiencer and raises to subject, which
+is why object-experiencer verbs show backward binding, the experiencer binding into the
+reconstructed causer (§6.2.2, `experiencer_ccommands_causer`). The verb classes of
+[belletti-rizzi-1988] from which the book's linking problem starts are recorded with the
+subject role each predicts (`PsychVerbClass`, `SubjectRole`).
 
-Cascade-based analysis of Class II psych verbs. The T/SM restriction
-(Cause and Subject Matter cannot cooccur) is derived from the Head
-Movement Constraint: CAUS must incorporate into V by successive head
-adjunction through the Cascade spine, and nonaffixal overt prepositions
-(T/SM heads like *at* and *about*) block this movement.
+## Implementation notes
 
-## Key results
+The stimulus types come from the psych-verb substrate, `Causation.Psych.StimulusType`, and
+only the prepositions of the restriction and of the double object alternation are
+represented. The affixal and prepositional occurrences of CAUS of §6.3, the suppression of
+the external argument in (522), the semantics of prepositions and mediated θ-selection of
+the fifth chapter, and the account of heavy shift of the seventh are not formalized.
 
-1. **T/SM restriction from HMC** (§ 2): CAUS is blocked by nonaffixal P
-2. **T/SM mutual exclusivity** (§ 2): each cascade has at most one stimulus slot
-3. **Backward binding as derived-subject diagnostic** (§ 3): A-Causer
-   originates inside VP (spec of CAUS in cascade complement), must raise
-   to subject — reconstruction enables backward binding
-4. **Double object alternation** (§ 4): G (zero P) vs *to* cascades
-5. **θ-suppression** (§ 5): CAUS affixation suppresses external argument
-6. **CAUS strength derived from cascade geometry** (§ 6)
-7. **Symmetric T/SM blocking** (§ 7): both *at* and *about* are nonaffixal,
-   so both block CAUS movement equally via HMC
-8. **Natural vs arbitrary predicates** (§ 9): Target-selecting predicates
-   are "natural," SM-selecting predicates are "arbitrary"
-9. **HNPS from cascade geometry** (§ 10): cascade depth determines
-   available landing sites for heavy NP shift
-10. **End-to-end per-verb derivation** (§ 9): full cascade chain for all
-    24 Class II psych verbs, derived from `causalSource`
+## References
 
+* [pesetsky-1995]
+* [belletti-rizzi-1988]
 -/
 
-/-! ## Cascade structures ([pesetsky-1995])
+namespace Pesetsky1995
 
-Binary-branching PP spines where each node is a (possibly null) preposition that
-θ-selects its specifier — the geometry behind the T/SM restriction (Ch. 6), backward
-binding (§6.2.2), the dative alternation (Ch. 5), and heavy NP shift (§7.2). Formerly
-`Syntax/Minimalist/Cascade.lean`, dissolved here as this paper's apparatus.
+open Causation.Psych
 
-**CAUS ≠ vCAUSE.** Pesetsky's `caus` is a syntactic zero morpheme (a null P⁰ that creates
-causatives by incorporating into V via the HMC); distinct from [cuervo-2003]'s event-
-structural `VerbHead.vCAUSE` (present in both causative and anticausative). -/
+/-! ### Cascades -/
 
-namespace Minimalist
-
-/-- A preposition head in a Cascade. `affixal` determines HMC passthrough: when a lower
-    head Z adjoins to this head Y, the complex [Z+Y] can move on only if Y is affixal. -/
+/-- A prepositional head of a Cascade: whether it is overt or a zero morpheme, and whether it
+is an affix that must join the verb. -/
 structure CascadeHead where
-  label : String
-  overt : Bool := true
+  overt : Bool
   affixal : Bool
-  deriving DecidableEq, Repr
+  deriving DecidableEq
 
-/-- Is this a zero morpheme (phonologically unrealized)? -/
-def CascadeHead.isZero (h : CascadeHead) : Bool := !h.overt
+/-- The phrases a Cascade positions. -/
+inductive Phrase where
+  | experiencer
+  | target
+  | subjectMatter
+  | causer
+  | theme
+  | goal
+  deriving DecidableEq
 
-/-- A Cascade: a binary-branching recursive PP spine. Each layer is a P head, its
-    specifier-DP label, and a complement (another layer or the terminal). -/
+/-- A Cascade: the right-branching spine of prepositional projections below a verb, each
+layer a head with the phrase in its specifier, ending in the complement of the lowest head. -/
 inductive Cascade where
-  | terminal : Cascade
-  | layer : CascadeHead → String → Cascade → Cascade
-  deriving Repr
+  | complement (phrase : Phrase)
+  | layer (head : CascadeHead) (spec : Phrase) (rest : Cascade)
 
-/-- The spine of P heads, closest-to-V (index 0) to deepest. -/
+/-- The heads from the verb downward. -/
 def Cascade.spine : Cascade → List CascadeHead
-  | .terminal => []
+  | .complement _ => []
   | .layer h _ rest => h :: rest.spine
 
-/-- The argument labels, closest-to-V to deepest. -/
-def Cascade.arguments : Cascade → List String
-  | .terminal => []
-  | .layer _ arg rest => arg :: rest.arguments
+/-- The position of a phrase, counted from the top, the final complement one below the last
+layer. -/
+def Cascade.position : Cascade → Phrase → Option ℕ
+  | .complement p, q => if p = q then some 0 else none
+  | .layer _ spec rest, q => if spec = q then some 0 else (rest.position q).map (· + 1)
 
-/-- Number of PP layers. -/
-def Cascade.depth : Cascade → Nat
-  | .terminal => 0
-  | .layer _ _ rest => 1 + rest.depth
+/-- A phrase c-commands another when it sits in a higher layer. -/
+def Cascade.CCommands (c : Cascade) (p q : Phrase) : Prop :=
+  ∃ i j, c.position p = some i ∧ c.position q = some j ∧ i < j
 
-theorem spine_length_eq_depth (c : Cascade) : c.spine.length = c.depth := by
-  induction c with
-  | terminal => rfl
-  | layer _ _ _ ih => simp [Cascade.spine, Cascade.depth, ih]; omega
+/-- The head at position `i` of a spine can reach the verb by successive adjunction exactly
+when every head above it is affixal: adjunction to a non-affix yields a category that cannot
+move on, the Head Movement Constraint. -/
+def canReachV (spine : List CascadeHead) (i : ℕ) : Prop := ∀ h ∈ spine.take i, h.affixal = true
 
-/-- Can a head at spine position `idx` reach V via successive head adjunction? It must
-    adjoin to each intermediate head (positions `idx−1 … 0`); blocked if any is nonaffixal
-    ([pesetsky-1995] §6.2). -/
-def canReachV (spine : List CascadeHead) (idx : Nat) : Bool :=
-  (spine.take idx).all (·.affixal)
+instance (spine : List CascadeHead) (i : ℕ) : Decidable (canReachV spine i) :=
+  inferInstanceAs (Decidable (∀ h ∈ spine.take i, h.affixal = true))
 
-/-- Index of the head with the given label, if present. -/
-def findInSpine (spine : List CascadeHead) (label : String) : Option Nat :=
-  go spine 0
-where
-  go : List CascadeHead → Nat → Option Nat
-    | [], _ => none
-    | h :: rest, i => if h.label == label then some i else go rest (i + 1)
+/-- A head below a given stretch of the spine reaches the verb iff that stretch is affixal
+throughout. -/
+theorem canReachV_append (above : List CascadeHead) (h : CascadeHead)
+    (below : List CascadeHead) :
+    canReachV (above ++ h :: below) above.length ↔ ∀ h' ∈ above, h'.affixal = true := by
+  simp [canReachV]
 
-/-- Can a head with the given label reach V in this cascade? -/
-def Cascade.headCanReachV (c : Cascade) (label : String) : Option Bool :=
-  (findInSpine c.spine label).map (canReachV c.spine ·)
+/-- CAUS: the zero causative preposition, an affix (510). -/
+def caus : CascadeHead := ⟨false, true⟩
 
-/-- Does this cascade contain a head with the given label? -/
-def Cascade.hasHead (c : Cascade) (label : String) : Bool :=
-  c.spine.any (·.label == label)
+/-- G: the zero preposition of the double object construction, an affix. -/
+def headG : CascadeHead := ⟨false, true⟩
 
-/-- CAUS: zero causative morpheme; affixal, incorporates into V via the HMC. -/
-def caus : CascadeHead := ⟨"CAUS", false, true⟩
-/-- G: zero preposition for Theme/Patient in double object constructions (§5.3); affixal. -/
-def headG : CascadeHead := ⟨"G", false, true⟩
-/-- Overt "at" — Target stimulus; nonaffixal (blocks CAUS movement through it). -/
-def headAt : CascadeHead := ⟨"at", true, false⟩
-/-- Overt "about" — Subject Matter stimulus; nonaffixal. -/
-def headAbout : CascadeHead := ⟨"about", true, false⟩
-/-- Overt "to" — dative/goal; nonaffixal. -/
-def headTo : CascadeHead := ⟨"to", true, false⟩
-/-- Overt "of" — partitive/possessive; nonaffixal. -/
-def headOf : CascadeHead := ⟨"of", true, false⟩
+/-- *at*, introducing a Target: overt and not an affix. -/
+def headAt : CascadeHead := ⟨true, false⟩
 
-/-- [pesetsky-1995] (522): only affixation of a semantically contentful morpheme to a verb
-    with an external argument lets that argument go unexpressed (CAUS suppresses √annoy's
-    Agent; vacuous affixes like anticausative SE do not). -/
-def thetaSuppressed (causAffixed : Bool) (rootHasExtArg : Bool) : Bool :=
-  causAffixed && rootHasExtArg
+/-- *about*, introducing a Subject Matter: overt and not an affix. -/
+def headAbout : CascadeHead := ⟨true, false⟩
 
-/-- The two occurrences of CAUS in Experiencer predicates ([pesetsky-1995] §6.2.2):
-    `affixal` (CAUS_aff, strong features) vs `prepositional` (CAUS_p, independent P). -/
-inductive CausVariant where
-  | affixal | prepositional
-  deriving DecidableEq, Repr
+/-- *to* of the dative construction: overt and not an affix. -/
+def headTo : CascadeHead := ⟨true, false⟩
 
-/-- CAUS_aff bears strong features that must be discharged at PF. -/
-def CausVariant.hasStrongFeatures : CausVariant → Bool
-  | .affixal => true
-  | .prepositional => false
+/-! ### The Target/Subject Matter restriction (§6.2.1) -/
 
-/-- Causative-verb classification by relation to CAUS ([pesetsky-1995] §6.3):
-    `strong` (A-Causer suppressed), `weak` (CAUS, no suppression), `absent`. -/
-inductive CausStrength where
-  | strong | weak | absent
-  deriving DecidableEq, Repr
+/-- The preposition that introduces each stimulus type. -/
+def stimulusHead : StimulusType → CascadeHead
+  | .target => headAt
+  | .subjectMatter => headAbout
 
-/-- Strong causation iff the cascade contains CAUS; else absent. (Weak CAUS needs further
-    verbal decomposition beyond cascade presence.) -/
-def Cascade.causStrength (c : Cascade) : CausStrength :=
-  if c.hasHead "CAUS" then .strong else .absent
+/-- The phrase of each stimulus type. -/
+def stimulusPhrase : StimulusType → Phrase
+  | .target => .target
+  | .subjectMatter => .subjectMatter
 
-/-- Position of an argument label (0 = outermost PP = structurally highest). -/
-def Cascade.argPosition : Cascade → String → Option Nat
-  | .terminal, _ => none
-  | .layer _ arg rest, target =>
-    if arg == target then some 0
-    else (rest.argPosition target).map (· + 1)
+/-- (513): the Experiencer in the specifier of the stimulus preposition, the stimulus in the
+specifier of CAUS, and the Causer as CAUS's complement. -/
+def stimulusCascade (s : StimulusType) : Cascade :=
+  .layer (stimulusHead s) .experiencer (.layer caus (stimulusPhrase s) (.complement .causer))
 
-/-- Spec of position `i` c-commands spec of position `j` iff `i < j` (outer c-commands
-    inner). -/
-def Cascade.specCCommands (c : Cascade) (commander commanded : String) : Bool :=
-  match c.argPosition commander, c.argPosition commanded with
-  | some i, some j => i < j
-  | _, _ => false
+/-- (514): the Experiencer in the specifier of CAUS, with no stimulus. -/
+def plainCascade : Cascade := .layer caus .experiencer (.complement .causer)
 
-/-- Heavy-NP-shift landing sites: one per cascade layer ([pesetsky-1995] Ch. 7). -/
-def Cascade.shiftSites (c : Cascade) : Nat := c.depth
+/-- Both stimulus prepositions are non-affixes, so Target and Subject Matter block alike. -/
+theorem stimulusHead_nonaffixal (s : StimulusType) : (stimulusHead s).affixal = false := by
+  cases s <;> rfl
 
-section CascadeVerification
+/-- The restriction: with a Target or Subject Matter present, CAUS cannot reach the verb. -/
+theorem tsm_restriction (s : StimulusType) : ¬ canReachV (stimulusCascade s).spine 1 := by
+  cases s <;> decide
 
-theorem caus_is_zero : caus.isZero = true := rfl
-theorem g_is_zero : headG.isZero = true := rfl
-theorem at_is_overt : headAt.isZero = false := rfl
-theorem about_is_overt : headAbout.isZero = false := rfl
-theorem caus_affixal : caus.affixal = true := rfl
-theorem g_affixal : headG.affixal = true := rfl
-theorem at_nonaffixal : headAt.affixal = false := rfl
-theorem about_nonaffixal : headAbout.affixal = false := rfl
-theorem to_nonaffixal : headTo.affixal = false := rfl
+/-- Without a stimulus nothing intervenes and CAUS reaches the verb. -/
+theorem caus_reaches_without_stimulus : canReachV plainCascade.spine 0 := by decide
 
-/-- A head at position 0 always reaches V. -/
-theorem position_zero_reachable (spine : List CascadeHead) :
-    canReachV spine 0 = true := by simp [canReachV]
+/-! ### Oehrle's observation (§6.2.1) -/
 
-private theorem all_take_of_all {α : Type} {p : α → Bool} {l : List α}
-    (h : l.all p = true) (n : Nat) : (l.take n).all p = true := by
-  induction l generalizing n with
-  | nil => simp
-  | cons hd tl ih =>
-    cases n with
-    | zero => simp
-    | succ m =>
-      simp only [List.take, List.all]
-      have hcons := h
-      simp only [List.all] at hcons
-      rw [Bool.and_eq_true] at hcons
-      rw [Bool.and_eq_true]
-      exact ⟨hcons.1, ih hcons.2 m⟩
+/-- (511): the double object construction with a causative reading, G above CAUS. -/
+def doubleObjectCascade : Cascade :=
+  .layer headG .goal (.layer caus .theme (.complement .causer))
 
-/-- If every spine head is affixal, any position reaches V. -/
-theorem all_affixal_reachable (spine : List CascadeHead) (idx : Nat)
-    (h : spine.all (·.affixal) = true) : canReachV spine idx = true :=
-  all_take_of_all h idx
+/-- (512): the *to*-dative with CAUS below *to*. -/
+def toCascade : Cascade := .layer headTo .theme (.layer caus .goal (.complement .causer))
 
-/-- A nonaffixal head at position 0 blocks anything below it. -/
-theorem nonaffixal_blocks (h : CascadeHead) (rest : List CascadeHead) (idx : Nat)
-    (hna : h.affixal = false) (hidx : idx > 0) :
-    canReachV (h :: rest) idx = false := by
-  simp only [canReachV]
-  cases idx with
-  | zero => omega
-  | succ n => simp [List.take, hna]
+/-- The causative reading of *give*, *the war years gave Mailer his first big success*,
+survives in the double object construction, whose G is an affix, and not with *to*. -/
+theorem oehrle : canReachV doubleObjectCascade.spine 1 ∧ ¬ canReachV toCascade.spine 1 := by
+  decide
 
-theorem terminal_spine : Cascade.terminal.spine = [] := rfl
-theorem single_layer_spine (h : CascadeHead) (arg : String) :
-    (Cascade.layer h arg .terminal).spine = [h] := rfl
-theorem two_layer_spine (h₁ h₂ : CascadeHead) (a₁ a₂ : String) :
-    (Cascade.layer h₁ a₁ (.layer h₂ a₂ .terminal)).spine = [h₁, h₂] := rfl
+/-! ### Backward binding (§6.2.2) -/
 
-/-- CAUS is a syntactic zero morpheme present only in causatives; [cuervo-2003]'s
-    event-structural `vCAUSE` appears in anticausatives too — they are distinct. -/
-theorem vcause_in_anticausative_but_not_caus :
-    isAnticausative [.vCAUSE, .vGO, .vBE] = true := by decide
+/-- The Experiencer c-commands the Causer's base position with or without a stimulus: the
+Causer is a derived subject, raised from below the Experiencer, and reconstructs there, so
+the Experiencer can bind into it. -/
+theorem experiencer_ccommands_causer (s : StimulusType) :
+    (stimulusCascade s).CCommands .experiencer .causer ∧
+      plainCascade.CCommands .experiencer .causer := by
+  cases s <;> exact ⟨⟨0, 2, rfl, rfl, by decide⟩, ⟨0, 1, rfl, rfl, by decide⟩⟩
 
-end CascadeVerification
+/-! ### The classes of Belletti and Rizzi -/
 
-end Minimalist
-
-namespace Pesetsky1995.PsychVerbs
-
--- ============================================================================
--- Belletti-Rizzi 1988 / Kim 2024 empirical data
--- (Was `Phenomena/PsychVerbs/Data.lean`; inlined per the provenance-tracking
---  policy. [pesetsky-1995] is the natural owner since it directly
---  consumes the [belletti-rizzi-1988] classification.)
--- ============================================================================
-
-/-- [belletti-rizzi-1988] classification of psych verbs. -/
+/-- The classes of [belletti-rizzi-1988] from which the linking problem starts:
+experiencer-subject verbs, object-experiencer verbs, and the dative-experiencer verbs of
+Italian. -/
 inductive PsychVerbClass where
-  | classI    -- Experiencer-subject: enjoy, like, fear / It. temere
-  | classII   -- Object-experiencer: frighten, concern / It. preoccupare
-  | classIII  -- Dative experiencer (Romance): It. piacere
-  deriving DecidableEq, Repr
+  | classI
+  | classII
+  | classIII
+  deriving DecidableEq
 
-/-- Aspectual reading of a Class II psych verb. -/
-inductive ClassIIReading where
-  | eventive  -- External cause: "the noise frightened John"
-  | stative   -- Internal cause: "the problem concerns John"
-  deriving DecidableEq, Repr
-
-/-- B&R syntactic diagnostic for discriminating psych verb classes (§§1–2). -/
-inductive BRDiagnostic where
-  | anaphoricCliticization -- §1.1: partitive ne extraction from subject
-  | arbitraryPro           -- §1.2: arb pro interpretation of subject
-  | causativeFare          -- §1.3: embedding under fare/make infinitive
-  | backwardBinding        -- §2.1: anaphor in subject bound by object
-  | adjectivalPassive      -- §1.5: passive is adjectival (not verbal)
-  deriving DecidableEq, Repr
-
-/-- Result of a B&R diagnostic applied to each class.
-    `classI`/`classII` record whether the class *passes* the test. -/
-structure BRDiagnosticResult where
-  diagnostic : BRDiagnostic
-  classI : Bool
-  classII : Bool
-  deriving Repr, BEq
-
-/-- [belletti-rizzi-1988] diagnostic data.
-
-    | Diagnostic | Class I (*temere*) | Class II (*preoccupare*) |
-    |---|---|---|
-    | Anaphoric clitic *ne* (§1.1) | ✗ | ✓ (11a) |
-    | Arbitrary *pro* (§1.2) | ✓ (24a) | ✗ (24b) |
-    | Causative *fare* (§1.3) | ✓ (35) | ✗ (36) |
-    | Backward binding (§2.1) | ✗ | ✓ (57a) |
-    | Adjectival passive (§1.5) | ✗ | ✓ (47) | -/
-def brDiagnosticData : List BRDiagnosticResult := [
-  ⟨.anaphoricCliticization, false, true⟩,
-  ⟨.arbitraryPro,           true,  false⟩,
-  ⟨.causativeFare,          true,  false⟩,
-  ⟨.backwardBinding,        false, true⟩,
-  ⟨.adjectivalPassive,      false, true⟩
-]
-
-/-- Every B&R diagnostic discriminates Class I from Class II. -/
-theorem br_diagnostics_discriminate :
-    brDiagnosticData.all (fun d => d.classI != d.classII) = true := by decide
-
-/-- Class I passes arb-pro and causative-fare but fails the other three. -/
-theorem classI_pattern :
-    brDiagnosticData.all (fun d =>
-      match d.diagnostic with
-      | .anaphoricCliticization => d.classI == false
-      | .arbitraryPro => d.classI == true
-      | .causativeFare => d.classI == true
-      | .backwardBinding => d.classI == false
-      | .adjectivalPassive => d.classI == false
-    ) = true := by decide
-
-/-- Class II shows the mirror pattern. -/
-theorem classII_pattern :
-    brDiagnosticData.all (fun d =>
-      match d.diagnostic with
-      | .anaphoricCliticization => d.classII == true
-      | .arbitraryPro => d.classII == false
-      | .causativeFare => d.classII == false
-      | .backwardBinding => d.classII == true
-      | .adjectivalPassive => d.classII == true
-    ) = true := by decide
-
-/-- The Class I/II distinction is characterized by theta-role reversal. -/
+/-- The role of the surface subject. -/
 inductive SubjectRole where
-  | experiencer  -- Class I: subject = experiencer
-  | stimulus     -- Class II: subject = stimulus/cause
-  deriving DecidableEq, Repr
+  | experiencer
+  | stimulus
+  deriving DecidableEq
 
-/-- Map from B&R class to expected subject role. -/
+/-- The subject role each class predicts; the dative-experiencer class has no nominative
+subject among its two arguments. -/
 def PsychVerbClass.expectedSubjectRole : PsychVerbClass → Option SubjectRole
   | .classI => some .experiencer
   | .classII => some .stimulus
   | .classIII => none
-
-/-- Intensionality datum ([kim-2024] Ch. 4): does substitution of
-co-referential terms fail in subject position? -/
-structure IntensionalityDatum where
-  verb : String
-  reading : ClassIIReading
-  substitutionFails : Bool
-  deriving Repr, BEq
-
-/-- Empirical intensionality data from [kim-2024]. -/
-def intensionalityData : List IntensionalityDatum := [
-  ⟨"concern", .stative, true⟩,
-  ⟨"interest", .stative, true⟩,
-  ⟨"frighten", .eventive, false⟩,
-  ⟨"amuse", .eventive, false⟩
-]
-
-/-- The T/SM restriction ([kim-2024] Ch. 5): Cause and Subject Matter
-cannot cooccur. -/
-structure TSMRestriction where
-  causePresent : Bool
-  smPresent : Bool
-  wellFormed : Bool
-  deriving Repr, BEq
-
-/-- Cause and SM cannot cooccur. -/
-def tsmData : List TSMRestriction := [
-  ⟨true, false, true⟩,
-  ⟨false, true, true⟩,
-  ⟨true, true, false⟩,
-  ⟨false, false, true⟩
-]
-
-/-- Stative Class II verbs create intensional subject positions. -/
-theorem stative_substitution_fails :
-    (intensionalityData.filter (·.reading == .stative)).all
-      (·.substitutionFails) = true := by decide
-
-/-- Eventive Class II verbs have extensional subject positions. -/
-theorem eventive_substitution_succeeds :
-    (intensionalityData.filter (·.reading == .eventive)).all
-      (!·.substitutionFails) = true := by decide
-
-/-- Cause + SM cooccurrence is always ill-formed. -/
-theorem cause_sm_cooccurrence_illformed :
-    (tsmData.filter (fun d => d.causePresent && d.smPresent)).all
-      (!·.wellFormed) = true := by decide
-
-end Pesetsky1995.PsychVerbs
-
--- ============================================================================
--- Pesetsky 1995 cascade analysis
--- ============================================================================
-
-namespace Pesetsky1995
-
-open Minimalist
-open Causation.Psych
-open Pesetsky1995.PsychVerbs
-open English.Predicates.Verbal
-
--- ════════════════════════════════════════════════════
--- § 1. Concrete Cascade Structures
--- ════════════════════════════════════════════════════
-
-/-- Class II psych verb with Target stimulus via *at*.
-
-    ```
-    V'
-    ├── V (annoy, frighten, ...)
-    └── PP_CAUS (head: CAUS, spec: A-Causer)
-        └── PP_at (head: at, spec: Experiencer)
-            └── terminal
-    ```
-
-    CAUS is closest to V (position 0), then *at* (position 1).
-    The A-Causer is the specifier of CAUS; the Experiencer is
-    the specifier of *at*. -/
-def cascadeTarget : Cascade :=
-  .layer caus "A-Causer"
-    (.layer headAt "Experiencer"
-      .terminal)
-
-/-- Class II psych verb with Subject Matter stimulus via *about*.
-
-    Same geometry as Target, but with *about* instead of *at*.
-    Both are nonaffixal, so both block CAUS equally. -/
-def cascadeSM : Cascade :=
-  .layer caus "A-Causer"
-    (.layer headAbout "Experiencer"
-      .terminal)
-
-/-- Class II psych verb with BOTH Cause and T/SM stimulus.
-
-    ```
-    V'
-    ├── V
-    └── PP_CAUS (head: CAUS, spec: A-Causer)
-        └── PP_at (head: at, spec: Target)
-            └── PP_about (head: about, spec: SM)
-                └── terminal
-    ```
-
-    The ill-formed structure that the T/SM restriction rules out. -/
-def cascadeCausePlusStimulus : Cascade :=
-  .layer caus "A-Causer"
-    (.layer headAt "Target"
-      (.layer headAbout "SubjectMatter"
-        .terminal))
-
-/-- Double object construction with zero G preposition.
-
-    ```
-    V'
-    ├── V (give)
-    └── PP_G (head: G, spec: Theme)
-        └── PP_to (head: to, spec: Goal)
-            └── terminal
-    ```
-
-    G is a zero preposition that mediates Theme θ-selection
-    in double object constructions. -/
-def cascadeDOC : Cascade :=
-  .layer headG "Theme"
-    (.layer headTo "Goal"
-      .terminal)
-
-/-- Dative alternant: single *to*-PP.
-
-    ```
-    V'
-    ├── V (give)
-    └── PP_to (head: to, spec: Goal)
-        └── terminal
-    ``` -/
-def cascadeDative : Cascade :=
-  .layer headTo "Goal" .terminal
-
-/-- Derive the appropriate cascade from a verb's causal source.
-    External cause → Target cascade (with *at*);
-    internal cause → SM cascade (with *about*). -/
-def cascadeForSource : CausalSource → Cascade
-  | .external => cascadeTarget
-  | .internal => cascadeSM
-
--- ════════════════════════════════════════════════════
--- § 2. T/SM Restriction from HMC
--- ════════════════════════════════════════════════════
-
-/-! The T/SM restriction follows from the HMC: CAUS at position 0 must
-    incorporate into V, but any nonaffixal head between CAUS and V blocks
-    movement. In the Target/SM cascades, CAUS IS at position 0 (closest
-    to V), so it CAN reach V — there are no intervening heads.
-
-    The restriction arises in a different configuration: when an OVERT
-    Cause argument occupies the specifier of CAUS, the T/SM stimulus
-    cannot also be expressed, because the Cascade geometry doesn't have
-    room for both an independent Cause and a T/SM stimulus while keeping
-    CAUS in a position that can incorporate.
-
-    More precisely: in Pesetsky's actual account, the restriction comes
-    from the fact that CAUS_aff (on V) must DISCHARGE its strong features
-    by adjoining to CAUS_p (in the Cascade). If a nonaffixal head
-    intervenes between CAUS_p and the stimulus head, the Cascade
-    geometry is ill-formed. -/
-
-/-- Target cascade spine: [CAUS, at]. -/
-theorem target_spine :
-    cascadeTarget.spine = [caus, headAt] := rfl
-
-/-- SM cascade spine: [CAUS, about]. -/
-theorem sm_spine :
-    cascadeSM.spine = [caus, headAbout] := rfl
-
-/-- CAUS is at position 0 in the Target cascade.
-    Position 0 can always reach V (no interveners). -/
-theorem caus_reachable_in_target :
-    cascadeTarget.headCanReachV "CAUS" = some true := by native_decide
-
-/-- CAUS is at position 0 in the SM cascade.
-    Position 0 can always reach V (no interveners). -/
-theorem caus_reachable_in_sm :
-    cascadeSM.headCanReachV "CAUS" = some true := by native_decide
-
-/-- The nonaffixal *at* head blocks anything below it.
-    In the Cause+Stimulus cascade, *at* at position 1 blocks position 2+. -/
-theorem at_blocks_below :
-    canReachV cascadeCausePlusStimulus.spine 2 = false := by native_decide
-
-/-- The nonaffixal *about* head also blocks anything below it. -/
-theorem about_blocks_in_extended :
-    canReachV [caus, headAbout, headAt] 2 = false := by native_decide
-
-/-- **Core T/SM restriction theorem**: in the Cause+Stimulus cascade,
-    the CAUS head can reach V (it's at position 0), but any head at
-    position 2 or deeper cannot — blocked by the nonaffixal *at* at
-    position 1. -/
-theorem tsm_restriction_via_hmc :
-    -- CAUS at position 0: reachable
-    canReachV cascadeCausePlusStimulus.spine 0 = true ∧
-    -- at head at position 1: not reachable from position 2+
-    canReachV cascadeCausePlusStimulus.spine 2 = false ∧
-    canReachV cascadeCausePlusStimulus.spine 3 = false :=
-  ⟨by native_decide, by native_decide, by native_decide⟩
-
-/-- **T/SM mutual exclusivity (Target cascade)**: the Target cascade
-    contains *at* but not *about*. A single cascade geometry admits
-    at most one stimulus type, so T and SM cannot cooccur within
-    a single verb's cascade complement. -/
-theorem t_sm_exclusive_in_target :
-    cascadeTarget.hasHead "at" = true ∧
-    cascadeTarget.hasHead "about" = false :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- **T/SM mutual exclusivity (SM cascade)**: the SM cascade
-    contains *about* but not *at*. -/
-theorem t_sm_exclusive_in_sm :
-    cascadeSM.hasHead "about" = true ∧
-    cascadeSM.hasHead "at" = false :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- The cascade assigned to a verb is determined by its causal source,
-    so a verb with a single source gets exactly one stimulus type.
-    External source → cascade with *at* (Target), no *about* (SM).
-    Internal source → cascade with *about* (SM), no *at* (Target). -/
-theorem source_determines_unique_stimulus :
-    -- External → has at, lacks about
-    (cascadeForSource .external).hasHead "at" = true ∧
-    (cascadeForSource .external).hasHead "about" = false ∧
-    -- Internal → has about, lacks at
-    (cascadeForSource .internal).hasHead "about" = true ∧
-    (cascadeForSource .internal).hasHead "at" = false :=
-  ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
-
--- ════════════════════════════════════════════════════
--- § 3. Backward Binding (Derived-Subject Diagnostic)
--- ════════════════════════════════════════════════════
-
-/-! Backward binding in Class II psych verbs ("Stories about each other_i
-    worried the boys_i") is diagnosed by B&R as a Class II property.
-
-    Pesetsky's cascade geometry explains this: the A-Causer originates
-    INSIDE the cascade complement of V (spec of CAUS at position 0),
-    making it a VP-internal argument. It must RAISE to subject position
-    (Spec,IP) to receive Case. This derived-subject status enables
-    backward binding via reconstruction: at LF, the raised subject
-    reconstructs to its base position inside the cascade, where the
-    experiencer (in the higher position within the VP) c-commands it.
-
-    In the base cascade, A-Causer (position 0, outermost) actually
-    c-commands the Experiencer (position 1, inner). The binding reversal
-    comes from movement + reconstruction, not from the base geometry. -/
-
-/-- A-Causer originates inside the cascade at position 0 (spec of CAUS).
-    This VP-internal base position means the surface subject is DERIVED —
-    the key structural prerequisite for backward binding. -/
-theorem causer_is_cascade_internal :
-    cascadeTarget.argPosition "A-Causer" = some 0 ∧
-    cascadeSM.argPosition "A-Causer" = some 0 :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- In the base cascade, A-Causer (outer, position 0) c-commands
-    Experiencer (inner, position 1) — the standard direction. -/
-theorem causer_ccommands_experiencer_base :
-    cascadeTarget.specCCommands "A-Causer" "Experiencer" = true ∧
-    cascadeSM.specCCommands "A-Causer" "Experiencer" = true :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- The experiencer does NOT c-command the A-Causer in the base cascade.
-    Backward binding requires A-Causer to raise to subject, then
-    reconstruct — the experiencer binds the reconstructed copy. -/
-theorem experiencer_does_not_ccommand_causer_base :
-    cascadeTarget.specCCommands "Experiencer" "A-Causer" = false ∧
-    cascadeSM.specCCommands "Experiencer" "A-Causer" = false :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- Backward binding diagnostic matches Cascade prediction.
-    B&R diagnostic: Class II allows backward binding (Data.lean). -/
-theorem backward_binding_br_match :
-    (brDiagnosticData.filter (·.diagnostic == .backwardBinding)).all
-      (·.classII) = true := by native_decide
-
--- ════════════════════════════════════════════════════
--- § 4. Double Object Alternation
--- ════════════════════════════════════════════════════
-
-/-- DOC cascade has zero G (affixal) and overt *to* (nonaffixal). -/
-theorem doc_spine :
-    cascadeDOC.spine = [headG, headTo] := rfl
-
-/-- G can reach V because it's at position 0 (zero affixal P). -/
-theorem g_reaches_v :
-    cascadeDOC.headCanReachV "G" = some true := by native_decide
-
-/-- DOC argument order: Theme (spec of G) then Goal (spec of *to*). -/
-theorem doc_arguments :
-    cascadeDOC.arguments = ["Theme", "Goal"] := rfl
-
-/-- Dative alternant has only *to* (nonaffixal). -/
-theorem dative_spine :
-    cascadeDative.spine = [headTo] := rfl
-
-/-- DOC vs dative: different cascade geometries. -/
-theorem doc_vs_dative_depth :
-    cascadeDOC.depth = 2 ∧ cascadeDative.depth = 1 :=
-  ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════
--- § 5. θ-Suppression by CAUS
--- ════════════════════════════════════════════════════
-
-/-- Strong CAUS (affixal variant) suppresses root's external θ-role.
-
-    When CAUS_aff is affixed to √annoy, the agent role of the root is
-    suppressed. The A-Causer (CAUS's own specifier) surfaces as the
-    derived subject instead. -/
-theorem caus_aff_suppresses :
-    CausVariant.affixal.hasStrongFeatures = true ∧
-    thetaSuppressed true true = true := ⟨rfl, rfl⟩
-
-/-- Prepositional CAUS does NOT have strong features. -/
-theorem caus_p_no_strong_features :
-    CausVariant.prepositional.hasStrongFeatures = false := rfl
-
-/-- Without CAUS affixation, no suppression occurs. -/
-theorem no_caus_no_suppression :
-    thetaSuppressed false true = false := rfl
-
-/-- Without an external argument, there's nothing to suppress. -/
-theorem no_ext_arg_no_suppression :
-    thetaSuppressed true false = false := rfl
-
--- ════════════════════════════════════════════════════
--- § 6. CAUS Strength (Derived from Cascade Geometry)
--- ════════════════════════════════════════════════════
-
-/-- Target and SM cascades both contain CAUS → strong causation. -/
-theorem classII_has_strong_caus :
-    cascadeTarget.causStrength = .strong ∧
-    cascadeSM.causStrength = .strong :=
-  ⟨by native_decide, by native_decide⟩
-
-/-- A terminal cascade (no CAUS) → absent causation (Class I). -/
-theorem classI_no_caus :
-    Cascade.terminal.causStrength = .absent := rfl
-
-/-- CAUS strength is uniform across Class II: both eventive (external
-    source) and stative (internal source) cascades derive strong CAUS. -/
-theorem caus_strength_uniform_across_classII :
-    (cascadeForSource .external).causStrength = .strong ∧
-    (cascadeForSource .internal).causStrength = .strong :=
-  ⟨by native_decide, by native_decide⟩
-
--- ════════════════════════════════════════════════════
--- § 7. Symmetric T/SM Blocking via HMC
--- ════════════════════════════════════════════════════
-
-/-! The HMC predicts that BOTH Target (*at*) and Subject Matter (*about*)
-    block CAUS movement equally, because both are nonaffixal P heads.
-    This symmetric prediction is internal to [pesetsky-1995]'s
-    account — both stimulus subtypes produce the same HMC configuration.
-
-    The bridge to semantic accounts of the T/SM restriction (which may
-    make asymmetric predictions) is in `Kim2024.lean`. -/
-
-/-- Both *at* and *about* are nonaffixal: both block CAUS movement
-    through the cascade spine equally. -/
-theorem symmetric_blocking :
-    headAt.affixal = false ∧ headAbout.affixal = false :=
-  ⟨rfl, rfl⟩
-
-/-- The HMC prediction matches the empirical T/SM data: Cause + SM
-    cooccurrence is ill-formed, as predicted by nonaffixal blocking. -/
-theorem hmc_predicts_tsm_data :
-    -- Nonaffixal *about* blocks CAUS in the combined cascade
-    canReachV cascadeCausePlusStimulus.spine 2 = false ∧
-    -- Data: Cause+SM cooccurrence is ill-formed
-    (tsmData.filter (fun d => d.causePresent && d.smPresent)).all
-      (!·.wellFormed) = true :=
-  ⟨by native_decide, by native_decide⟩
-
--- ════════════════════════════════════════════════════
--- § 8. CAUS ≠ vCAUSE Bridge
--- ════════════════════════════════════════════════════
-
--- Pesetsky's CAUS is a syntactic zero morpheme (P⁰) that creates
--- causative verbs by incorporating into V. It is present ONLY in
--- causative structures.
---
--- Cuervo's vCAUSE is an event-structural head present in BOTH
--- causative and anticausative alternants — it encodes the causal
--- relation between subevents, independent of Voice.
---
--- The bridge theorem `vcause_in_anticausative_but_not_caus`
--- (in Cascade.lean) witnesses this distinction: the anticausative
--- [vCAUSE, vGO, vBE] has vCAUSE but no CAUS.
-
-/-- CAUS is a zero morpheme (not phonologically realized). -/
-theorem caus_zero_morpheme : caus.isZero = true := rfl
-
-/-- CAUS is affixal (can incorporate into V). -/
-theorem caus_is_affixal : caus.affixal = true := rfl
-
-/-- vCAUSE is present in anticausatives; CAUS is not. -/
-theorem vcause_not_caus :
-    isAnticausative [.vCAUSE, .vGO, .vBE] = true ∧
-    -- An anticausative has no CAUS in its Cascade — terminal Cascade
-    Cascade.terminal.hasHead "CAUS" = false :=
-  ⟨by native_decide, by native_decide⟩
-
--- ════════════════════════════════════════════════════
--- § 9. End-to-End Per-Verb Derivation
--- ════════════════════════════════════════════════════
-
-/-! The full argumentation chain for each Class II psych verb, derived
-    from a single lexical field (`causalSource` in the Fragment):
-
-    ```
-    Fragment: v.causalSource = some src
-      → Cascade:  cascadeForSource src        (Target or SM cascade)
-        → HMC:    headCanReachV "CAUS"        (CAUS can incorporate)
-          → Stim: CausalSource.toStimulusType (Target or SubjectMatter)
-            → Nat: isNaturalPredicate         (natural or arbitrary)
-              → Str: Cascade.causStrength     (strong CAUS)
-    ```
-
-    Each per-verb theorem is a single breakable unit: change any verb's
-    `causalSource` field in the Fragment and exactly one theorem fails.
-
-    [pesetsky-1995] Ch. 4 distinguishes **natural** predicates
-    (Target-selecting, PP *of*: "afraid OF dogs") from **arbitrary**
-    predicates (SM-selecting, PP *about*: "worried ABOUT the exam").
-    This is derived from the causal source: external → natural,
-    internal → arbitrary. -/
-
-/-- Natural predicates select Target stimulus (PP *of*);
-    arbitrary predicates select Subject Matter (PP *about*). -/
-def isNaturalPredicate : StimulusType → Prop
-  | .target => True
-  | .subjectMatter => False
-
-instance : DecidablePred isNaturalPredicate := fun x => by
-  cases x <;> unfold isNaturalPredicate <;> infer_instance
-
-/-- End-to-end cascade derivation chain for a Class II psych verb.
-    From a verb's `causalSource`, derives: cascade assignment (via
-    `cascadeForSource`), HMC reachability, stimulus type, natural/
-    arbitrary classification, and CAUS strength. All from one field. -/
-def cascadeChain (v : VerbEntry) (src : CausalSource) : Prop :=
-    v.causalSource = some src ∧
-    v.causalSource.map cascadeForSource = some (cascadeForSource src) ∧
-    (cascadeForSource src).headCanReachV "CAUS" = some true ∧
-    v.causalSource.map CausalSource.toStimulusType =
-      some (CausalSource.toStimulusType src) ∧
-    v.causalSource.map (isNaturalPredicate ∘ CausalSource.toStimulusType) =
-      some (isNaturalPredicate (CausalSource.toStimulusType src)) ∧
-    (cascadeForSource src).causStrength = .strong
-
--- External source → Target cascade → natural predicate → strong CAUS
-
-theorem annoy_chain       : cascadeChain annoy .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem frighten_chain    : cascadeChain frighten .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem amuse_chain       : cascadeChain amuse .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem fascinate_chain   : cascadeChain fascinate .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem irritate_chain    : cascadeChain irritate .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem bore_chain        : cascadeChain bore .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem charm_chain       : cascadeChain charm .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem impress_chain     : cascadeChain impress .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem surprise_chain    : cascadeChain surprise .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem scare_chain       : cascadeChain scare .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem delight_chain     : cascadeChain delight .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem embarrass_chain   : cascadeChain embarrass .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem upset_chain       : cascadeChain upset_psych .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem disgust_chain     : cascadeChain disgust .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem shock_chain       : cascadeChain shock .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem confuse_chain     : cascadeChain confuse .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem disappoint_chain  : cascadeChain disappoint .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem worry_ev_chain    : cascadeChain worry_eventive .external :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-
--- Internal source → SM cascade → arbitrary predicate → strong CAUS
-
-theorem concern_chain     : cascadeChain concern .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem interest_chain    : cascadeChain interest .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem worry_st_chain    : cascadeChain worry_stative .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem please_chain      : cascadeChain please_psych .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem trouble_chain     : cascadeChain trouble .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-theorem puzzle_chain      : cascadeChain puzzle .internal :=
-  ⟨rfl, rfl, by native_decide, rfl, rfl, by native_decide⟩
-
--- ════════════════════════════════════════════════════
--- § 10. Heavy NP Shift and Cascade Depth
--- ════════════════════════════════════════════════════
-
-/-! [pesetsky-1995] Ch. 7 extends the Cascade Hypothesis to derive
-    heavy NP shift (HNPS) from cascade geometry. Shifted phrases adjoin
-    to cascade nodes; cascade depth determines how many potential landing
-    sites exist for rightward-shifted heavy NPs.
-
-    The cascade-based HNPS account provides a *syntactic* mechanism for
-    weight effects: the verb's argument structure — determined by its
-    cascade complement — constrains where shifted phrases can land. This
-    predicts structural constraints on shift targets, not just statistical
-    preference for heavy-last ordering. -/
-
-/-- Psych verb cascades (depth 2) provide more shift sites than
-    simple dative cascades (depth 1). -/
-theorem psych_cascade_deeper_than_dative :
-    cascadeTarget.shiftSites > cascadeDative.shiftSites :=
-  by native_decide
-
-/-- The DOC cascade and psych verb cascades have equal depth. -/
-theorem doc_same_depth_as_psych :
-    cascadeDOC.shiftSites = cascadeTarget.shiftSites := rfl
-
-/-- Terminal cascades (intransitive verbs) provide no shift sites. -/
-theorem terminal_no_shift_sites :
-    Cascade.terminal.shiftSites = 0 := rfl
-
-/-- Cascade depth predicts a hierarchy of HNPS availability:
-    intransitive (0) < simple dative (1) < psych/DOC (2) < extended (3). -/
-theorem shift_site_hierarchy :
-    Cascade.terminal.shiftSites < cascadeDative.shiftSites ∧
-    cascadeDative.shiftSites < cascadeTarget.shiftSites ∧
-    cascadeTarget.shiftSites < cascadeCausePlusStimulus.shiftSites :=
-  ⟨by native_decide, by native_decide, by native_decide⟩
 
 end Pesetsky1995

--- a/references.bib
+++ b/references.bib
@@ -490,7 +490,7 @@
   subfield  = {syntax/argument-structure},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Kim2024_UPH.lean;Studies/Pesetsky1995.lean;Semantics/Lexical/LevinClassProfiles.lean}
+  sources   = {Semantics/Lexical/LevinClassProfiles.lean;Studies/HartshorneEtAl2016.lean;Studies/Kim2024.lean;Studies/Kim2024_UPH.lean;Studies/Pesetsky1995.lean}
 }
 @inproceedings{bassi-bar-lev-2018,
   author    = {Bassi, Itai and Bar-Lev, Moshe},
@@ -7227,7 +7227,7 @@
   subfield  = {semantics/argument-structure},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/ArgumentStructure/RoleList.lean}
+  sources   = {Semantics/ArgumentStructure/RoleList.lean;Studies/HartshorneEtAl2016.lean}
 }
 @misc{grinberg-reiner-2020,
   author    = {Grinberg, Darij and Reiner, Victor},
@@ -9111,7 +9111,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Hacquard2006.json;Fragments/Italian/Modals.lean;Fragments/Romance/French/Modals.lean;Semantics/Attitudes/Anchor.lean;Semantics/Modality/ActualityEntailments.lean;Semantics/Modality/Anchor.lean;Semantics/Modality/EventRelativity.lean;Semantics/Mood/SpeechEvent.lean;Studies/AlonsoOvalleRoyer2024.lean;Studies/AnandHacquard2013.lean;Studies/Hacquard2006.lean;Studies/Hacquard2010.lean;Studies/Kim2024.lean;Studies/Klecha2016.lean;Studies/Matthewson2013.lean;Studies/Matthewson2016.lean}
+  sources   = {Data/Examples/Hacquard2006.json;Fragments/Italian/Modals.lean;Fragments/Romance/French/Modals.lean;Semantics/Attitudes/Anchor.lean;Semantics/Modality/ActualityEntailments.lean;Semantics/Modality/Anchor.lean;Semantics/Modality/EventRelativity.lean;Semantics/Mood/SpeechEvent.lean;Studies/AlonsoOvalleRoyer2024.lean;Studies/AnandHacquard2013.lean;Studies/Hacquard2006.lean;Studies/Hacquard2010.lean;Studies/Klecha2016.lean;Studies/Matthewson2013.lean;Studies/Matthewson2016.lean}
 }
 @article{hacquard-2009,
   author    = {Hacquard, Valentine},
@@ -9139,7 +9139,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Hacquard2010.json;Fragments/Italian/Modals.lean;Semantics/Modality/Anchor.lean;Semantics/Modality/EventRelativity.lean;Studies/AnandHacquard2013.lean;Studies/FuscoSgrizzi2026.lean;Studies/Hacquard2010.lean;Studies/Kim2024.lean;Studies/Matthewson2016.lean}
+  sources   = {Data/Examples/Hacquard2010.json;Fragments/Italian/Modals.lean;Semantics/Modality/Anchor.lean;Semantics/Modality/EventRelativity.lean;Studies/AnandHacquard2013.lean;Studies/FuscoSgrizzi2026.lean;Studies/Hacquard2010.lean;Studies/Matthewson2016.lean}
 }
 @book{kramer-2015,
   author    = {Kramer, Ruth},
@@ -13491,7 +13491,7 @@
     subfield  = {semantics/lexical},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Levin1993.json;Fragments/English/Predicates/Verbal.lean;Semantics/ArgumentStructure/DiathesisAlternation.lean;Semantics/ArgumentStructure/EventStructure.lean;Semantics/ArgumentStructure/LevinClass.lean;Semantics/ArgumentStructure/LevinTheory.lean;Semantics/ArgumentStructure/MeaningComponents.lean;Semantics/ArgumentStructure/RoleList.lean;Semantics/Root/Content.lean;Studies/Beavers2010.lean;Studies/BeaversEtAl2021.lean;Studies/BeaversUdayana2022.lean;Studies/Kratzer1996.lean;Studies/Levin1993.lean;Studies/Levin2026.lean;Studies/LuPanDegen2025.lean;Studies/MajidBosterBowerman2008.lean;Studies/MartinRoseNichols2025.lean;Studies/RappaportHovavLevin2024.lean;Syntax/Category/Verb/Basic.lean;Syntax/Category/Verb/Defs.lean;Syntax/ConstructionGrammar/ArgumentStructure.lean;Syntax/Voice/Alternation.lean}
+  sources   = {Data/Examples/Levin1993.json;Fragments/English/Predicates/Verbal.lean;Semantics/ArgumentStructure/DiathesisAlternation.lean;Semantics/ArgumentStructure/EventStructure.lean;Semantics/ArgumentStructure/LevinClass.lean;Semantics/ArgumentStructure/LevinTheory.lean;Semantics/ArgumentStructure/MeaningComponents.lean;Semantics/ArgumentStructure/RoleList.lean;Semantics/Root/Content.lean;Studies/Beavers2010.lean;Studies/BeaversEtAl2021.lean;Studies/BeaversUdayana2022.lean;Studies/HartshorneEtAl2016.lean;Studies/Kratzer1996.lean;Studies/Levin1993.lean;Studies/Levin2026.lean;Studies/LuPanDegen2025.lean;Studies/MajidBosterBowerman2008.lean;Studies/MartinRoseNichols2025.lean;Studies/RappaportHovavLevin2024.lean;Syntax/Category/Verb/Basic.lean;Syntax/Category/Verb/Defs.lean;Syntax/ConstructionGrammar/ArgumentStructure.lean;Syntax/Voice/Alternation.lean}
 }
 @article{klein-1980,
   author    = {Klein, Ewan},
@@ -18502,7 +18502,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/Pesetsky1995.lean}
+  sources   = {Studies/Kim2024.lean;Studies/Pesetsky1995.lean}
 }
 @book{pesetsky-2013,
   author    = {Pesetsky, David},


### PR DESCRIPTION
Verified against the book (§6.2.1–6.2.2, (510)–(514), (522)): the old cascades put CAUS at the top so the T/SM theorems proved nothing; CAUS now sits below the stimulus preposition and the restriction, Oehrle's effect, and backward binding follow from the HMC.
- B&R diagnostic table, Kim 2024 data, Cuervo bridge, HNPS numerology, 24 per-verb rfl chains, 43 native_decide cut
- `Minimalist` namespace → `Pesetsky1995`; Kim2024 and HartshorneEtAl2016 repointed