### PR TITLE
refactor(Morphology/FragmentGrammars): halt prior as per-slot Pólya urn

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/Weighted.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Weighted.lean
@@ -27,6 +27,9 @@ future weighted-CFG consumer share one definition.
 
 - `ContextFreeGrammar.RulesWithLHS G a` — subtype of grammar rules
   whose left-hand side equals `a`.
+- `Symbol.IsNonterminal` — the predicate picking out nonterminal symbols.
+- `ContextFreeRule.NonterminalPos r` — subtype of right-hand-side positions
+  of `r` holding a nonterminal, the index for any per-slot analysis.
 - `WeightedCFG G W` — per-rule weight in `W`, nonnegative, no
   normalization constraint.
 -/
@@ -44,6 +47,36 @@ abbrev RulesWithLHS (a : G.NT) :=
   { r : ContextFreeRule T G.NT // r ∈ G.rules.filter (·.input = a) }
 
 end ContextFreeGrammar
+
+namespace Symbol
+
+variable {T N : Type*}
+
+/-- `s.IsNonterminal` holds when the symbol `s` is a nonterminal. -/
+def IsNonterminal : Symbol T N → Prop
+  | terminal _ => False
+  | nonterminal _ => True
+
+instance : DecidablePred (IsNonterminal : Symbol T N → Prop)
+  | terminal _ => isFalse id
+  | nonterminal _ => isTrue trivial
+
+@[simp] theorem isNonterminal_nonterminal (n : N) :
+    (nonterminal n : Symbol T N).IsNonterminal := trivial
+
+@[simp] theorem not_isNonterminal_terminal (t : T) :
+    ¬ (terminal t : Symbol T N).IsNonterminal := id
+
+end Symbol
+
+namespace ContextFreeRule
+
+/-- The positions on the right-hand side of `r` that hold a nonterminal: the slots at which a
+derivation from `r` branches, and the index for any analysis carried out per slot. -/
+abbrev NonterminalPos {T N : Type*} (r : ContextFreeRule T N) : Type :=
+  {i : Fin r.output.length // r.output[i].IsNonterminal}
+
+end ContextFreeRule
 
 /--
 A *weighted CFG* over `G` with weights in `W`: per-rule weight

--- a/Linglib/Core/Probability/PolyaUrn.lean
+++ b/Linglib/Core/Probability/PolyaUrn.lean
@@ -67,6 +67,7 @@ for such a bridge) is also deferred.
 
 - `PolyaUrn α` — pseudo-counts on `α` (the Dirichlet hyperparameters).
 - `PolyaUrn.total` — the sum `Σ π_i`.
+- `PolyaUrn.posterior` — the conjugate update by observed counts.
 - `PolyaUrn.seqProb` — closed-form per-sequence likelihood
   ([odonnell-2015] §3.1.3, depending only on counts).
 - `PolyaUrn.countVec` — the count vector of a draw sequence, the urn's sufficient statistic;
@@ -100,6 +101,27 @@ structure PolyaUrn (α : Type*) where
   pseudo_pos : ∀ i, 0 < pseudo i
 
 namespace PolyaUrn
+
+section Posterior
+
+variable {α : Type*} (u : PolyaUrn α)
+
+/-- The conjugate update of the urn by observed counts `x`: each colour's pseudo-count grows by
+its count. The Dirichlet mixing measure stays Dirichlet under categorical data, so the update
+stays inside `PolyaUrn α`. -/
+def posterior (x : α → ℕ) : PolyaUrn α where
+  pseudo i := u.pseudo i + x i
+  pseudo_pos i := add_pos_of_pos_of_nonneg (u.pseudo_pos i) (Nat.cast_nonneg _)
+
+@[simp] theorem posterior_zero : u.posterior 0 = u := by
+  ext i
+  simp [posterior]
+
+theorem posterior_add (x y : α → ℕ) : u.posterior (x + y) = (u.posterior x).posterior y := by
+  ext i
+  simp [posterior, add_assoc]
+
+end Posterior
 
 variable {α : Type*} [Fintype α] (u : PolyaUrn α)
 

--- a/Linglib/Morphology/FragmentGrammars/FragmentGrammar.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentGrammar.lean
@@ -1,338 +1,108 @@
 import Linglib.Morphology.FragmentGrammars.AdaptorGrammar
 
 /-!
-# Fragment grammars (FG) — the central proposal
+# Fragment grammars
 
-[odonnell-2015]
+This file defines fragment grammars, the model of [odonnell-2015]: an adaptor grammar in which
+every nonterminal on the right-hand side of every rule carries a Pólya urn over the two outcomes
+`recurse` and `halt`, together with the corpus probability of §3.1.8 given the latent table and
+halt-count assignments.
 
-The "inference-based" model of [odonnell-2015] §2.4.4 / §3.1.8,
-and the central theoretical proposal of the book. A `FragmentGrammar`
-extends an `AdaptorGrammar` by adding a *per-rule-RHS-position
-beta-binomial halt prior*: at each nonterminal slot in each rule's
-right-hand side, a Beta-distributed weight `ν` controls the
-probability of recursing (productively expanding the slot) vs.
-halting (storing the slot as an open NT in a memoized fragment).
-
-This generalizes both DMPCFG (`ν → 1` everywhere: always recurse,
-fragments are depth-one) and MAG (`ν` decided once per nonterminal,
-not per slot: fragments are full subtrees). FG learns a separate
-recursion probability per (rule, position), letting fragments be
-arbitrary partial trees with selective open NT slots — the
-distinguishing feature of the book's account of productivity-and-
-reuse.
-
-Per [odonnell-2015] §3.1.8 the corpus probability factorizes as
-
-```
-fg(X, Y, Z; F) = ∏_{A ∈ V} [DMPCFG-factor on X^A] · [PYP-factor on Y^A]
-              · ∏_{r ∈ R_G} ∏_{B ∈ rhs(r)}
-                  B(ψ_B + z_{r,B}^↻, ψ'_B + z_{r,B}^⊥) /
-                  B(ψ_B, ψ'_B)
-```
-
-where `Z = z_{r,B}^{↻/⊥}` is the corpus-aggregate count of recurse/
-halt decisions at each (rule, RHS-position) pair, and `B(·,·)` is
-the Beta function (here written as a ratio of Γ-products to avoid
-a dependency on `Mathlib.Probability.Distributions.Beta`).
-
-## Why corpus probability is `(D, Y, Z) → ℝ`
-
-`Z` is latent — the recurse/halt assignment per fragment is part of
-the MAP analysis, not the observed corpus. Same situation as `Y` in
-`AdaptorGrammar`. Marginalizing over `(Y, Z)` is the MH inference
-target distribution of [odonnell-2015] §3.2 — out of scope
-per the Processing-scope rule.
-
-## What we inherit from `AdaptorGrammar`
-
-`FragmentGrammar G extends AdaptorGrammar G`, so the entire DMPCFG
-+ PYP infrastructure is inherited: `pseudo`, `pseudo_pos`, `lhsUrn`,
-`lhsCounts`, `lhsFactor`, `pyp`, `pypFactor`,
-`corpusProbGivenTables`, all the positivity proofs. FG only adds
-the beta-binomial halt prior and the per-(rule, position) factor.
+Expanding a rule `r`, a fragment grammar decides at each right-hand-side nonterminal `B` whether
+to expand `B` productively or to halt and leave `B` an open slot of the fragment being stored.
+The decision is a biased coin whose weight `ν_{r,B}` has a beta prior with pseudo-counts
+`ψ_{r,B}`; integrating out `ν_{r,B}` turns the decisions taken at that slot into a two-colour
+Pólya urn, which is the representation the book computes with. Recursing everywhere recovers the
+Dirichlet–multinomial PCFG (`DMPCFG`), and deciding once per nonterminal rather than once per slot
+recovers the adaptor grammar (`AdaptorGrammar`); a fragment grammar stores partial trees with
+arbitrary open slots.
 
 ## Main definitions
 
-- `FragmentGrammar G` — extends `AdaptorGrammar G` with per-(rule,
-  RHS-position) beta-binomial pseudo-counts (`haltPriorRecurse`,
-  `haltPriorHalt`).
-- `FragmentGrammar.HaltCounts` — abbrev for the latent recurse/halt
-  count assignment.
-- `FragmentGrammar.fgFactor` — per-(rule, position) beta-binomial
-  factor.
-- `FragmentGrammar.corpusProbGivenStorage` — eq from §3.1.8,
-  conditional on table assignment `Y` and halt counts `Z`.
+* `FragmentGrammar G`: an `AdaptorGrammar G` with an urn `halt r i : PolyaUrn Decision` at each
+  nonterminal position `i` of each rule `r`.
+* `FragmentGrammar.HaltCounts G`: the latent count `Z` of recurse and halt decisions per slot.
+* `FragmentGrammar.corpusProbGivenStorage D Y Z`: the corpus probability of §3.1.8 given tables
+  `Y` and halt counts `Z`, the adaptor-grammar factor times one `PolyaUrn.seqProb` per slot.
+* `FragmentGrammar.posterior D Z`: the conjugate update by a corpus and its halt counts.
 
-## §2.3.7 vs §3.1.8 — sampler vs distribution
+## Implementation notes
 
-This file is the **distribution** side: `corpusProbGivenStorage` is the
-density `fg(F; F)` of [odonnell-2015] §3.1.8 (p. 94). The
-**sampler** that draws from this density is in the sibling file
-`FragmentLambda.lean`, scaffolding [odonnell-2015] §2.3.7's
-Church macro `(fragment-lambda args body)` (Figure 2.21, p. 71). The
-two are linked by the soundness contract
-`fragmentLambdaDepth_marginalises_to_fg`, which equates the sampler's
-output marginal with the §3.1.8 density.
-
-Per [odonnell-2015] §3.1.8 (p. 92) the substrate here implements
-the actual model used in the rest of the book — biased halt coin
-`BINOMIAL(ν)` with `ν` itself drawn from a Beta prior — not the
-fair-coin presentation of §2.3.6. The §2.3.7 fair-coin macro is
-recovered as the `haltPriorRecurse = haltPriorHalt = 1` special case
-(Beta(1,1) = Uniform).
+`Z` is latent for the same reason `Y` is: marginalising over `(Y, Z)` is the inference problem
+of §3.2. The book writes the halt count at slot `B` of rule `r` as `x_r - z_{r,B}`, so a `Z`
+consistent with the corpus has `Z r i .recurse + Z r i .halt` equal to the corpus count of `r`;
+as for `TableAssignment`, that consistency is a hypothesis of the caller.
 
 ## References
 
-- [odonnell-2015] §2.4.4, §3.1.8.
+* [odonnell-2015] §2.3.6, §3.1.8.
 -/
 
 namespace Morphology.FragmentGrammars
 
-open Real
+open ProbabilityTheory
 
-/--
-A *fragment grammar* over `G`: an adaptor grammar augmented with a
-per-(rule, RHS-position) beta-binomial halt prior. At each
-nonterminal slot in each rule's right-hand side, the weight `ν` of
-recursing-vs-halting is Beta-distributed with pseudo-counts
-`(haltPriorRecurse r i, haltPriorHalt r i)`.
+/-- The outcome of the lazy coin at a nonterminal slot: `recurse` expands the slot productively,
+`halt` leaves it open in the stored fragment. -/
+inductive FragmentGrammar.Decision
+  | recurse
+  | halt
+  deriving DecidableEq, Fintype, Inhabited
 
-Allowing per-slot halt decisions (rather than per-nonterminal as in
-MAG) lets fragments be arbitrary partial trees — the central
-theoretical commitment of [odonnell-2015].
--/
+/-- A fragment grammar over `G`: an adaptor grammar with, at each nonterminal position of each
+rule, a Pólya urn over `recurse`/`halt` decisions whose pseudo-counts are the beta parameters
+`ψ_{r,B}` of [odonnell-2015]. -/
 @[ext]
 structure FragmentGrammar {T : Type} [DecidableEq T] (G : ContextFreeGrammar T)
     [DecidableEq G.NT] extends AdaptorGrammar G where
-  /-- Beta pseudo-count for "recurse" outcome at (rule, RHS position). -/
-  haltPriorRecurse : ContextFreeRule T G.NT → ℕ → ℝ
-  /-- Beta pseudo-count for "halt" outcome at (rule, RHS position). -/
-  haltPriorHalt : ContextFreeRule T G.NT → ℕ → ℝ
-  /-- Recurse pseudo-counts are strictly positive. -/
-  haltPriorRecurse_pos : ∀ r i, 0 < haltPriorRecurse r i
-  /-- Halt pseudo-counts are strictly positive. -/
-  haltPriorHalt_pos : ∀ r i, 0 < haltPriorHalt r i
+  /-- The urn over `recurse`/`halt` decisions at nonterminal position `i` of rule `r`. -/
+  halt : (r : ContextFreeRule T G.NT) → r.NonterminalPos → PolyaUrn FragmentGrammar.Decision
 
 namespace FragmentGrammar
 
 variable {T : Type} [DecidableEq T] {G : ContextFreeGrammar T} [DecidableEq G.NT]
 
-/--
-A *halt-count assignment* gives, for each rule `r` and each
-RHS-position `i`, the corpus-aggregate counts of "recurse" and
-"halt" decisions at that slot. This is the latent variable `Z` in
-[odonnell-2015] §3.1.8.
-
-Consistency between `Z`, `Y` (table assignment), and the observed
-corpus `D` is the responsibility of the caller (or of the MAP
-inference step we do not formalize).
--/
+/-- The latent variable `Z` of §3.1.8: at each nonterminal position of each rule, the number of
+`recurse` and of `halt` decisions taken there across the corpus. -/
 abbrev HaltCounts (G : ContextFreeGrammar T) : Type :=
-  ContextFreeRule T G.NT → ℕ → ℕ × ℕ
+  (r : ContextFreeRule T G.NT) → r.NonterminalPos → Decision → ℕ
 
 variable (M : FragmentGrammar G)
 
-/--
-Per-(rule, position) beta-binomial factor in the eq from §3.1.8.
-For pseudo-counts `α = haltPriorRecurse r i`, `β = haltPriorHalt r i`,
-and observed counts `(zr, zh) = Z r i`,
+/-- The corpus probability of §3.1.8 given a table assignment `Y` and halt counts `Z`: the
+adaptor-grammar factor `AdaptorGrammar.corpusProbGivenTables` times, at each nonterminal slot,
+the urn likelihood `B(ψ + z↻, ψ' + z⊥) / B(ψ, ψ')` of the decisions taken there. -/
+noncomputable def corpusProbGivenStorage (D : Multiset (DerivationTree T G.NT))
+    (Y : AdaptorGrammar.TableAssignment G) (Z : HaltCounts G) : ℝ :=
+  M.corpusProbGivenTables D Y * ∏ r ∈ G.rules, ∏ i, (M.halt r i).seqProb (Z r i)
 
-```
-B(α + zr, β + zh) / B(α, β)
-  = Γ(α+zr)·Γ(β+zh)·Γ(α+β) / (Γ(α+β+zr+zh)·Γ(α)·Γ(β)) .
-```
+theorem corpusProbGivenStorage_nonneg (D : Multiset (DerivationTree T G.NT))
+    (Y : AdaptorGrammar.TableAssignment G) (Z : HaltCounts G) :
+    0 ≤ M.corpusProbGivenStorage D Y Z :=
+  mul_nonneg (M.corpusProbGivenTables_nonneg D Y) <| Finset.prod_nonneg λ r _ =>
+    Finset.prod_nonneg λ i _ => ((M.halt r i).seqProb_pos _).le
 
-Inlined via `Real.Gamma` rather than mathlib's
-`ProbabilityTheory.beta` to avoid pulling in
-`Mathlib.Probability.Distributions.Beta`.
--/
-noncomputable def fgFactor (r : ContextFreeRule T G.NT) (i : ℕ)
-    (z : ℕ × ℕ) : ℝ :=
-  Gamma (M.haltPriorRecurse r i + z.1) *
-  Gamma (M.haltPriorHalt r i + z.2) *
-  Gamma (M.haltPriorRecurse r i + M.haltPriorHalt r i) /
-  (Gamma (M.haltPriorRecurse r i + M.haltPriorHalt r i +
-          (z.1 : ℝ) + (z.2 : ℝ)) *
-   Gamma (M.haltPriorRecurse r i) *
-   Gamma (M.haltPriorHalt r i))
-
-/--
-FG corpus probability conditional on a table assignment `Y` and a
-halt-count assignment `Z`. Per [odonnell-2015] §3.1.8:
-
-```
-fg(X, Y, Z; F) = ag(X, Y; A) · ∏_r ∏_i fgFactor r i (Z r i)
-```
-
-The AG part is inherited from `AdaptorGrammar.corpusProbGivenTables`
-(via `extends`); FG adds only the per-(rule, position) Beta-
-binomial factors.
--/
-noncomputable def corpusProbGivenStorage
-    (D : Multiset (DerivationTree T G.NT))
-    (Y : AdaptorGrammar.TableAssignment G)
-    (Z : HaltCounts G) : ℝ :=
-  M.toAdaptorGrammar.corpusProbGivenTables D Y *
-  ∏ r ∈ G.rules, ∏ i ∈ Finset.range r.output.length,
-    M.fgFactor r i (Z r i)
-
-/-- The per-(rule, position) factor is strictly positive. -/
-theorem fgFactor_pos (r : ContextFreeRule T G.NT) (i : ℕ) (z : ℕ × ℕ) :
-    0 < M.fgFactor r i z := by
-  have h_α_pos : 0 < M.haltPriorRecurse r i := M.haltPriorRecurse_pos r i
-  have h_β_pos : 0 < M.haltPriorHalt r i := M.haltPriorHalt_pos r i
-  have h_zr_nn : (0 : ℝ) ≤ (z.1 : ℝ) := Nat.cast_nonneg _
-  have h_zh_nn : (0 : ℝ) ≤ (z.2 : ℝ) := Nat.cast_nonneg _
-  have h_α_zr_pos : 0 < M.haltPriorRecurse r i + (z.1 : ℝ) := by linarith
-  have h_β_zh_pos : 0 < M.haltPriorHalt r i + (z.2 : ℝ) := by linarith
-  have h_αβ_pos : 0 < M.haltPriorRecurse r i + M.haltPriorHalt r i := by linarith
-  have h_αβ_z_pos :
-      0 < M.haltPriorRecurse r i + M.haltPriorHalt r i +
-          (z.1 : ℝ) + (z.2 : ℝ) := by linarith
-  unfold fgFactor
-  refine div_pos ?_ ?_
-  · refine mul_pos (mul_pos ?_ ?_) ?_
-    · exact Gamma_pos_of_pos h_α_zr_pos
-    · exact Gamma_pos_of_pos h_β_zh_pos
-    · exact Gamma_pos_of_pos h_αβ_pos
-  · refine mul_pos (mul_pos ?_ ?_) ?_
-    · exact Gamma_pos_of_pos h_αβ_z_pos
-    · exact Gamma_pos_of_pos h_α_pos
-    · exact Gamma_pos_of_pos h_β_pos
-
-/-- FG corpus probability is nonnegative on any storage assignment. -/
-theorem corpusProbGivenStorage_nonneg
-    (D : Multiset (DerivationTree T G.NT))
-    (Y : AdaptorGrammar.TableAssignment G)
-    (Z : HaltCounts G) : 0 ≤ M.corpusProbGivenStorage D Y Z := by
-  unfold corpusProbGivenStorage
-  refine mul_nonneg ?_ ?_
-  · exact M.toAdaptorGrammar.corpusProbGivenTables_nonneg D Y
-  · apply Finset.prod_nonneg
-    intro r _
-    apply Finset.prod_nonneg
-    intro i _
-    exact (M.fgFactor_pos r i (Z r i)).le
-
-/-- The "empty" halt-count assignment: zero recurse-decisions and
-    zero halt-decisions at every (rule, position) pair. The
-    corresponding `fgFactor` evaluates to `1` because the Beta-
-    binomial ratio is `B(α, β) / B(α, β) = 1`. -/
-def emptyHaltCounts (G : ContextFreeGrammar T) : HaltCounts G :=
-  fun _ _ => (0, 0)
-
-/-- The per-(rule, position) factor at zero counts is `1`: the
-    Beta-binomial ratio degenerates to `B(α, β) / B(α, β)`. -/
-@[simp]
-theorem fgFactor_zero (r : ContextFreeRule T G.NT) (i : ℕ) :
-    M.fgFactor r i (0, 0) = 1 := by
-  unfold fgFactor
-  have h_Γα : 0 < Gamma (M.haltPriorRecurse r i) :=
-    Gamma_pos_of_pos (M.haltPriorRecurse_pos r i)
-  have h_Γβ : 0 < Gamma (M.haltPriorHalt r i) :=
-    Gamma_pos_of_pos (M.haltPriorHalt_pos r i)
-  have h_Γαβ : 0 < Gamma (M.haltPriorRecurse r i + M.haltPriorHalt r i) :=
-    Gamma_pos_of_pos (by
-      linarith [M.haltPriorRecurse_pos r i, M.haltPriorHalt_pos r i])
-  simp only [Nat.cast_zero, add_zero]
-  field_simp
-
-/-- FG corpus probability is `1` on the empty corpus paired with
-    the empty table assignment and empty halt-count assignment.
-    Each `fgFactor` is `1`, the AG factor is `1`, so the overall
-    product is `1`. -/
+/-- The empty corpus with empty tables and no decisions has probability `1`. -/
 @[simp]
 theorem corpusProbGivenStorage_empty :
-    M.corpusProbGivenStorage (0 : Multiset (DerivationTree T G.NT))
-      (AdaptorGrammar.emptyTables G) (emptyHaltCounts G) = 1 := by
-  unfold corpusProbGivenStorage
-  rw [show M.toAdaptorGrammar.corpusProbGivenTables 0 (AdaptorGrammar.emptyTables G) = 1
-      from M.toAdaptorGrammar.corpusProbGivenTables_empty]
-  rw [one_mul]
-  apply Finset.prod_eq_one
-  intro r _
-  apply Finset.prod_eq_one
-  intro i _
-  show M.fgFactor r i ((emptyHaltCounts G) r i) = 1
-  unfold emptyHaltCounts
-  exact M.fgFactor_zero r i
+    M.corpusProbGivenStorage 0 (AdaptorGrammar.emptyTables G) 0 = 1 := by
+  simp only [corpusProbGivenStorage, AdaptorGrammar.corpusProbGivenTables_empty, one_mul]
+  exact Finset.prod_eq_one λ r _ => Finset.prod_eq_one λ i _ => (M.halt r i).seqProb_zero
 
-/-! ## Bridge: FragmentGrammar → MultinomialPCFG via posterior MAP
+/-- The conjugate update by a corpus `D` and its halt counts `Z`: the adaptor-grammar component
+absorbs the rule counts of `D`, and the urn at each slot absorbs the decisions taken there. -/
+noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) (Z : HaltCounts G) :
+    FragmentGrammar G where
+  toAdaptorGrammar := M.toAdaptorGrammar.posterior D
+  halt r i := (M.halt r i).posterior (Z r i)
 
-FG = AG + per-(rule, RHS-position) beta-binomial halt prior. Like
-PYP in AG, the halt-prior factor is multiplicative in
-`corpusProbGivenStorage` and does not enter per-LHS rule-weight
-inference. So FG's posterior MAP rule weights factor through AG
-which factors through DMPCFG.
-
-The "tower equality" `FG.posteriorMAP D = AG.posteriorMAP D =
-DMPCFG.posteriorMAP D` is structural — every layer above DMPCFG in
-the prior tower is purely additive on rule-weight inference. This
-is the architectural payoff: the family-of-priors structure
-(`extends` chain) is genuinely "richer hyperparameter sets," not
-"different rule-weight semantics." -/
-
-/-- The Dirichlet posterior MAP collapse for FG. Same one-liner as
-    AG, factoring transitively through `extends`: FG → AG → DMPCFG.
-    The beta-binomial halt prior contributes a multiplicative factor
-    to corpus probability but does not alter rule-weight inference. -/
-noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) : MultinomialPCFG G :=
-  M.toAdaptorGrammar.posteriorMAP D
-
-/-- **Coherence (one step).** FG's posterior-MAP agrees with AG's
-    posterior-MAP. Holds by `rfl` — FG only adds halt priors on top
-    of AG; rule-weight inference is unchanged. -/
-theorem posteriorMAP_eq_toAdaptorGrammar
-    [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) :
-    M.posteriorMAP D = M.toAdaptorGrammar.posteriorMAP D := rfl
-
-/-- **Coherence (two steps).** FG's posterior-MAP agrees with the
-    underlying DMPCFG's posterior-MAP. The "prior tower" of length
-    three collapses to a single canonical MultinomialPCFG by `rfl`. -/
-theorem posteriorMAP_eq_toDMPCFG
-    [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) :
-    M.posteriorMAP D = M.toAdaptorGrammar.toDMPCFG.posteriorMAP D := rfl
-
-/-! ## Conjugacy decomposition (mirror of AG / DMPCFG)
-
-FG's posterior delegates through AG which delegates through DMPCFG.
-Halt-prior pseudo-counts are unchanged by corpus updates (the
-beta-binomial layer doesn't see corpus rule counts). Mode delegates
-to the underlying DMPCFG. The decomposition holds by `rfl` at all
-three layers, witnessing the rfl-tower discovery (the prior tower's
-extends-chain is structurally orthogonal to rule-weight inference). -/
-
-/-- FG's posterior update: bump the underlying AG/DMPCFG, leave
-    halt-prior pseudo-counts unchanged. -/
-noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : FragmentGrammar G :=
-  { M with toAdaptorGrammar := M.toAdaptorGrammar.posterior D }
-
-/-- FG's mode in `MultinomialPCFG`-space: delegates through AG to
-    DMPCFG. Halt-prior pseudo-counts contribute no rule-weight mass. -/
-noncomputable def mode [∀ a : G.NT, Nonempty (G.RulesWithLHS a)] :
-    MultinomialPCFG G :=
-  M.toAdaptorGrammar.mode
-
-/-- Empty corpus = identity update (delegated to `AG.posterior_zero`). -/
 @[simp]
-theorem posterior_zero : M.posterior 0 = M := by
-  ext1 <;> simp [posterior, AdaptorGrammar.posterior_zero]
+theorem posterior_zero : M.posterior 0 0 = M := by
+  ext1 <;> simp [posterior]
 
-/-- Incrementality at the FG layer. -/
-theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
-    M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
-  ext1 <;> simp [posterior, AdaptorGrammar.posterior_add]
-
-/-- **The conjugacy decomposition at FG layer.** `posteriorMAP =
-    mode ∘ posterior`, holding by `rfl` because all FG operations
-    delegate through DMPCFG. -/
-theorem posteriorMAP_eq_mode_posterior [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) :
-    M.posteriorMAP D = (M.posterior D).mode :=
-  M.toAdaptorGrammar.toDMPCFG.posteriorMAP_eq_mode_posterior D
+theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) (Z₁ Z₂ : HaltCounts G) :
+    M.posterior (D₁ + D₂) (Z₁ + Z₂) = (M.posterior D₁ Z₁).posterior D₂ Z₂ := by
+  ext1 <;> simp [posterior, AdaptorGrammar.posterior_add, PolyaUrn.posterior_add]
 
 end FragmentGrammar
 

--- a/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
@@ -852,7 +852,9 @@ noncomputable def samplesToCorpusCounts
     CorpusCounts T G :=
   (tree.toCFGTree?.elim 0 ({·} : DerivationTree T G.NT → Multiset _),
    fun A => slotToFinpartition (finalState.slots A),
-   fun r i => tree.collectHaltCounts r i)
+   fun r i d => match d with
+     | .recurse => (tree.collectHaltCounts r i).1
+     | .halt => (tree.collectHaltCounts r i).2)
 
 /-- Depth-0 base case for the un-memoised unfold: returns
 `PMF.pure (.fragment start)`. -/
@@ -889,7 +891,7 @@ equal to `1`.
 
 A `.fragment` leaf has no branches, so `collectHaltCounts` returns the
 zero pair for every `(rule, position)`, making `samplesToCorpusCounts.Z`
-extensionally equal to `emptyHaltCounts G`. The depth-0 sample mass is
+the zero halt count. The depth-0 sample mass is
 `1` (PMF.pure), and the empty-corpus density is `1` by
 `corpusProbGivenStorage_empty`; equality holds.
 
@@ -909,14 +911,11 @@ theorem fragmentLambdaDepth_zero_marginalises
           (samplesToCorpusCounts (.fragment start) (PYPState.empty hyper)).1
           (samplesToCorpusCounts (.fragment start) (PYPState.empty hyper)).2.1
           (samplesToCorpusCounts (.fragment start) (PYPState.empty hyper)).2.2) := by
-  -- The Z-component is `fun r i => (0, 0)` — extensionally `emptyHaltCounts`.
   have h_Z : (samplesToCorpusCounts (.fragment start)
                 (PYPState.empty hyper : PYPState G.NT
-                  (LazyTree G.NT T (ContextFreeRule T G.NT)))).2.2
-              = FragmentGrammar.emptyHaltCounts G := by
-    funext r i
-    simp only [samplesToCorpusCounts, LazyTree.collectHaltCounts_fragment,
-               FragmentGrammar.emptyHaltCounts]
+                  (LazyTree G.NT T (ContextFreeRule T G.NT)))).2.2 = 0 := by
+    funext r i d
+    cases d <;> simp [samplesToCorpusCounts]
   rw [fragmentLambdaDepth_zero]
   show (PMF.pure _) _ = _
   rw [PMF.pure_apply]
@@ -982,7 +981,7 @@ The proof requires:
 3. Identifying the limit's marginal at `(D, Y, Z)` with the §3.1.8
    product formula — induction matching each PYP draw to its AG-factor
    contribution and each biased-coin flip to its beta-binomial-ratio
-   contribution to `M.fgFactor`.
+   contribution to the slot urn's `PolyaUrn.seqProb`.
 
 Step 1 needs probabilistic-fixed-point machinery for monotone PMF-valued
 recursions (Knaster–Tarski / Kleene fixed point on ω-CPPOs of sub-


### PR DESCRIPTION
Deep audit of `Morphology/FragmentGrammars/FragmentGrammar.lean`: the beta-binomial halt prior of [odonnell-2015] §3.1.8 is the two-colour Pólya urn the book itself computes with, so the file now imports it instead of re-deriving it.

- `FragmentGrammar.halt r i : PolyaUrn Decision` indexed by `ContextFreeRule.NonterminalPos` (new, Core), replacing two ℝ-valued fields, two positivity fields and a hand-rolled Γ-ratio; positivity and the empty-corpus lemma come from `PolyaUrn.seqProb_pos`/`seqProb_zero`
- `posterior D Z` is now the genuine conjugate update (new `PolyaUrn.posterior` in Core) instead of one that left the halt pseudo-counts unchanged; the `rfl` façades `posteriorMAP`/`mode` and their coherence theorems are removed
- `FragmentLambda` adapted to the `Decision`-indexed halt counts; docstring cut to mathlib length