### PR TITLE
refactor(Studies/Pantcheva2011): possible syncretisms respect the seam

### DIFF
--- a/Linglib/Studies/Pantcheva2011.lean
+++ b/Linglib/Studies/Pantcheva2011.lean
@@ -7,23 +7,26 @@ import Linglib.Syntax.Case.Order
 This file formalizes the syncretism typology of the ninth chapter of [pantcheva-2011]. The
 directional heads Place, Goal, Source, and Route form the containment sequence of
 `Case.PathDir`, and a syncretism pattern over the four is a paradigm over that sequence
-(`Pattern`). Two constraints cut the fifteen set-partitions of the four roles to the four
-attested patterns, Types 1 to 4 (`Possible`, `possible_syncretisms`): the *ABA generalization
-of Bobaljik ([bobaljik-2012], then circulating in manuscript), on which a syncretism targets
-only adjacent heads of the sequence, the same contiguity that governs nominal case in
+(`Pattern`). Two constraints restrict the patterns: the *ABA generalization of Bobaljik
+([bobaljik-2012], then circulating in manuscript), on which a syncretism targets only
+adjacent heads of the sequence, the same contiguity that governs nominal case in
 [caha-2009] (`Morphology.IsContiguous`); and *A&¬A, on which Goal and Source never share a
 marker, because the Source head is the locus of a reversal of the Goal path (§5.4), so one
 marker for both would be contradictory (`GoalSourceMerged`, `goalSource_distinct_denotation`).
-Seven of the eleven excluded patterns fall to *ABA and the other four to *A&¬A, the
-chapter's Table 9.3 (`aba_excluded`, `ana_excluded`). The containment itself is visible where
-the Source marker contains the Goal marker, as in Imbabura Quechua *-man* against *-man-da*
-(Table 4.2, `source_contains_goal`), and Georgian instantiates Type 3, with Location and Goal
-syncretic (Table 9.1, `georgian_loc_goal_possible`).
+Together they say exactly that no syncretism crosses the seam between Goal and Source
+(`possible_iff_respectsSeam`), which cuts the fifteen set-partitions of the four roles to the
+four attested patterns, Types 1 to 4 of Table 9.2: Place and Goal may merge, Source and Route
+may merge, and nothing else (`possible_syncretisms`). Seven of the eleven excluded patterns
+fall to *ABA and the other four to *A&¬A, Table 9.3 (`aba_excluded`, `ana_excluded`). The
+containment itself is visible where the Source marker contains the Goal marker, as in
+Imbabura Quechua *-man* against *-man-da* (Table 4.2, `source_contains_goal`), and Georgian
+instantiates Type 3, with Location and Goal syncretic (Table 9.1, `georgian_loc_goal_possible`).
 
 ## Implementation notes
 
 The patterns are restricted-growth strings over the four positions, one representative per
-set-partition; the attested lexicalization patterns of §9.3.1 are described in prose.
+set-partition; the seam characterization is proved for every pattern, and the enumerations
+are its corollaries. The attested lexicalization patterns of §9.3.1 are described in prose.
 
 ## References
 
@@ -36,89 +39,100 @@ namespace Pantcheva2011
 
 open Morphology
 
-/-- A syncretism pattern over the four path roles, in containment order
-    [Place, Goal, Source, Route], as form-class indices: the n = 4
-    instance of `Morphology.Paradigm`. -/
-abbrev Pattern := Morphology.Paradigm 4 ℕ
+/-- A syncretism pattern over the four path roles, in containment order Place, Goal, Source,
+Route, as form-class indices: the four-cell instance of `Morphology.Paradigm`. -/
+abbrev Pattern := Paradigm 4 ℕ
 
-/-- The 15 canonical syncretism patterns — restricted-growth strings over
-    four positions, i.e. the set-partitions of {Place, Goal, Source,
-    Route} up to relabeling. -/
+/-- The fifteen syncretism patterns up to relabeling: the restricted-growth strings over four
+positions, one per set-partition of the four roles. -/
 def allPatterns : List Pattern :=
   [![0, 0, 0, 0], ![0, 0, 0, 1], ![0, 0, 1, 0], ![0, 0, 1, 1], ![0, 0, 1, 2],
    ![0, 1, 0, 0], ![0, 1, 0, 1], ![0, 1, 0, 2], ![0, 1, 1, 0], ![0, 1, 1, 1],
    ![0, 1, 1, 2], ![0, 1, 2, 0], ![0, 1, 2, 1], ![0, 1, 2, 2], ![0, 1, 2, 3]]
 
-/-- **\*A&¬A**: Goal (position 1) and Source (position 2) share a form
-    class. Forbidden — Source is the reversal of Goal, so a Goal=Source
-    marker is contradictory ([pantcheva-2011] §9.2.2). -/
+/-- *A&¬A: Goal and Source share a form class. -/
 def GoalSourceMerged (p : Pattern) : Prop := p 1 = p 2
 
-instance (p : Pattern) : Decidable (GoalSourceMerged p) :=
-  inferInstanceAs (Decidable (_ = _))
+instance (p : Pattern) : Decidable (GoalSourceMerged p) := inferInstanceAs (Decidable (_ = _))
 
-/-- A syncretism pattern is **possible** iff it is contiguous (\*ABA, via
-    the shared `Morphology.Containment` object) and keeps Goal distinct
-    from Source (\*A&¬A). -/
-def Possible (p : Pattern) : Prop :=
-  IsContiguous p ∧ ¬ GoalSourceMerged p
+/-- A pattern is possible iff it is contiguous, *ABA, and keeps Goal distinct from Source,
+*A&¬A. -/
+def Possible (p : Pattern) : Prop := IsContiguous p ∧ ¬ GoalSourceMerged p
 
-instance (p : Pattern) : Decidable (Possible p) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+instance (p : Pattern) : Decidable (Possible p) := inferInstanceAs (Decidable (_ ∧ _))
 
-/-- **The syncretism typology** ([pantcheva-2011] Tables 9.2/9.3): of the
-    15 logically possible patterns, exactly four are attested — the
-    contiguous ones keeping Goal and Source distinct. These are her
-    Types 1–4: all-distinct (Type 1, English), Place=Goal (Type 3,
-    Georgian), Source=Route (Type 2), and Place=Goal with Source=Route
-    (Type 4). -/
+/-- A pattern respects the seam when no form class straddles Goal and Source: cells that share
+a form lie on the same side of the seam. -/
+def RespectsSeam (p : Pattern) : Prop := ∀ i j, p i = p j → (i ≤ 1 ↔ j ≤ 1)
+
+/-- Under contiguity, distinct Goal and Source forms keep every form on one side of the
+seam. -/
+private theorem ne_of_seam {p : Pattern} (hc : IsContiguous p) (hgs : ¬ GoalSourceMerged p)
+    {i j : Fin 4} (hi : i ≤ 1) (hj : 2 ≤ j) : p i ≠ p j := λ h =>
+  hgs ((hc hi (le_trans (by decide) hj) h).symm.trans (hc (le_trans hi (by decide)) hj h))
+
+/-- The two constraints together say exactly that no syncretism crosses the Goal–Source
+seam. -/
+theorem possible_iff_respectsSeam (p : Pattern) : Possible p ↔ RespectsSeam p := by
+  constructor
+  · rintro ⟨hc, hgs⟩ i j h
+    constructor
+    · intro hi; by_contra hj
+      exact ne_of_seam hc hgs hi (by omega) h
+    · intro hj; by_contra hi
+      exact ne_of_seam hc hgs hj (by omega) h.symm
+  · intro hs
+    refine ⟨λ i j k hij hjk hik => ?_, λ h => by simpa using hs 1 2 h⟩
+    rcases eq_or_lt_of_le hij with rfl | hlt
+    · rfl
+    · have hs' := hs i k hik
+      have hjk' : j = k := by
+        by_cases hi : i ≤ 1
+        · have := hs'.mp hi; omega
+        · have : ¬ k ≤ 1 := λ hk => hi (hs'.mpr hk); omega
+      subst hjk'; exact hik
+
+/-- The syncretism typology (Table 9.2): of the fifteen patterns, exactly four respect the
+seam, Types 1 to 4: all distinct (English), Place=Goal (Georgian), Source=Route, and both. -/
 theorem possible_syncretisms :
     allPatterns.filter (λ p => Possible p) =
-      [![0, 0, 1, 1], ![0, 0, 1, 2], ![0, 1, 2, 2], ![0, 1, 2, 3]] := by decide
+      [![0, 0, 1, 1], ![0, 0, 1, 2], ![0, 1, 2, 2], ![0, 1, 2, 3]] := by
+  decide
 
-/-- Seven of the eleven excluded patterns violate \*ABA (non-contiguous —
-    a syncretism spanning non-adjacent path roles). -/
+/-- Table 9.3, Types 5 to 11: the seven patterns excluded by *ABA, a syncretism spanning
+non-adjacent roles. -/
 theorem aba_excluded :
-    (allPatterns.filter (λ p => ¬ IsContiguous p)).length = 7 := by decide
+    allPatterns.filter (λ p => ¬ IsContiguous p) =
+      [![0, 0, 1, 0], ![0, 1, 0, 0], ![0, 1, 0, 1], ![0, 1, 0, 2], ![0, 1, 1, 0],
+       ![0, 1, 2, 0], ![0, 1, 2, 1]] := by
+  decide
 
-/-- The remaining four excluded patterns are contiguous but merge Goal
-    with Source — the \*A&¬A constraint, unique to the directional domain
-    (the nominal Caha containment has no analogue). -/
+/-- Table 9.3, Types 12 to 15: the four contiguous patterns excluded by *A&¬A alone, the
+constraint peculiar to the directional domain. -/
 theorem ana_excluded :
-    (allPatterns.filter
-      (λ p => IsContiguous p ∧ GoalSourceMerged p)).length = 4 := by
+    allPatterns.filter (λ p => IsContiguous p ∧ GoalSourceMerged p) =
+      [![0, 0, 0, 0], ![0, 0, 0, 1], ![0, 1, 1, 1], ![0, 1, 1, 2]] := by
   decide
 
 /-! ### Morphological containment (Table 4.2)
 
-The Source structure contains the Goal structure, visible where the
-Source marker contains the Goal marker (Quechua `-man` ⊂ `-man-da`).
-This is the shell containment of the shared `PathDir` object — not a
-fact re-stipulated here, but read off `Case.PathDir.shells`. -/
+The Source structure contains the Goal structure, visible where the Source marker contains the
+Goal marker, as in Quechua *-man* against *-man-da*: the shell containment of `PathDir`. -/
 
-/-- Source contains Goal contains Place, as shell-stack inclusion — the
-    morphological-containment fact, from the substrate decomposition. -/
+/-- Source contains Goal contains Place, as shell-stack inclusion. -/
 theorem source_contains_goal :
     Case.PathDir.place.shells ⊂ Case.PathDir.goal.shells ∧
-    Case.PathDir.goal.shells ⊂ Case.PathDir.source.shells ∧
-    Case.PathDir.source.shells ⊂ Case.PathDir.route.shells := by
+      Case.PathDir.goal.shells ⊂ Case.PathDir.source.shells ∧
+      Case.PathDir.source.shells ⊂ Case.PathDir.route.shells := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
-/-- Georgian's Location=Goal syncretism ([pantcheva-2011] Table 9.1) is
-    one of the four possible patterns (Type 3). -/
+/-- Georgian's Location=Goal syncretism (Table 9.1) is Type 3. -/
 theorem georgian_loc_goal_possible : Possible ![0, 0, 1, 2] := by decide
 
-/-! ### The *A&¬A constraint, grounded in the denotation (Ch. 5)
+/-! ### The semantic ground of *A&¬A (§5.4) -/
 
-The Goal=Source exclusion (`GoalSourceMerged`) is not a stipulation: it
-follows from the directional *interpretation*. Source denotes the
-**reversal** of Goal (`PathDir.source_denote_eq_goal_reverse`, §5.4), so
-Goal and Source have distinct, in fact opposite, denotations — a single
-marker for both would be semantically contradictory. -/
-
-/-- Goal and Source have distinct denotations (Source reverses Goal), so a
-    Goal=Source marker would be contradictory — the semantic ground of the
-    *A&¬A constraint that excludes `GoalSourceMerged` patterns. -/
+/-- Goal and Source have distinct denotations, Source reversing Goal, so a single marker for
+both would be contradictory: the ground of the *A&¬A constraint. -/
 theorem goalSource_distinct_denotation :
     Case.PathDir.goal.denote ≠ Case.PathDir.source.denote := by decide
 


### PR DESCRIPTION
*ABA and *A&¬A together say exactly that no syncretism crosses the Goal–Source seam, proved for every pattern (`possible_iff_respectsSeam`); the Table 9.2/9.3 enumerations become corollaries stated as exact lists.
- `four_possible` count cut