### PR TITLE
refactor(Studies/Pasternak2019): comparatives of greatest states

### DIFF
--- a/Linglib/Semantics/Degree/Quantifier.lean
+++ b/Linglib/Semantics/Degree/Quantifier.lean
@@ -126,6 +126,43 @@ theorem maxComparative_eq_iff (μ : α → D) (xa xb : α) :
     maxComparative (· = xa) (· = xb) μ ↔ μ xb < μ xa :=
   maxComparative_unique rfl (fun _ h => h) rfl (fun _ h => h)
 
+/-- A greatest than-witness under a measure monotone on the witnesses makes its measure the
+greatest than-clause degree. -/
+theorem isGreatest_thanDegrees_of_isGreatest [Preorder α] {Pthan : α → Prop} {μ : α → D}
+    {xb : α} (hb : IsGreatest {x | Pthan x} xb) (hμ : MonotoneOn μ {x | Pthan x}) :
+    IsGreatest (thanDegrees Pthan μ) (μ xb) :=
+  ⟨⟨xb, hb.1, le_refl _⟩, λ _ ⟨_, hx, hle⟩ => hle.trans (hμ hx hb.1 (hb.2 hx))⟩
+
+/-- With greatest witnesses on both sides and measures monotone on each side, the
+max-quantified comparative compares the greatest witnesses' measures. -/
+theorem maxComparative_of_isGreatest [Preorder α] {Pmatrix Pthan : α → Prop} {μ : α → D}
+    {xa xb : α} (ha : IsGreatest {x | Pmatrix x} xa) (hμa : MonotoneOn μ {x | Pmatrix x})
+    (hb : IsGreatest {x | Pthan x} xb) (hμb : MonotoneOn μ {x | Pthan x}) :
+    maxComparative Pmatrix Pthan μ ↔ μ xb < μ xa := by
+  constructor
+  · rintro ⟨δ, hδ, x, hx, hlt⟩
+    exact lt_of_le_of_lt (hδ.2 ⟨xb, hb.1, le_refl _⟩)
+      (lt_of_lt_of_le hlt (hμa hx ha.1 (ha.2 hx)))
+  · exact λ hlt => ⟨μ xb, isGreatest_thanDegrees_of_isGreatest hb hμb, xa, ha.1, hlt⟩
+
+/-- The than-clause degree set with the scale's zero degree added ([pasternak-2019]): its
+maximum exists even without a than-witness. -/
+def thanDegreesZero [Zero D] (Pthan : α → Prop) (μ : α → D) : Set D :=
+  insert 0 (thanDegrees Pthan μ)
+
+/-- The max-quantified comparative over `thanDegreesZero`: the than-clause positive is not
+entailed. -/
+def maxComparativeZero [Zero D] (Pmatrix Pthan : α → Prop) (μ : α → D) : Prop :=
+  ∃ δ, IsGreatest (thanDegreesZero Pthan μ) δ ∧ ∃ x, Pmatrix x ∧ δ < μ x
+
+/-- With no than-witness measuring above zero, the comparative holds of any matrix witness
+measuring above zero: *Dee ran more than Evan did; in fact, Evan didn't run at all*. -/
+theorem maxComparativeZero_of_forall_le_zero [Zero D] {Pmatrix Pthan : α → Prop} {μ : α → D}
+    {x : α} (hx : Pmatrix x) (hpos : 0 < μ x) (hthan : ∀ y, Pthan y → μ y ≤ 0) :
+    maxComparativeZero Pmatrix Pthan μ :=
+  ⟨0, ⟨Set.mem_insert _ _, λ _ hd => (Set.mem_insert_iff.1 hd).elim le_of_eq
+    λ ⟨y, hy, hle⟩ => hle.trans (hthan y hy)⟩, x, hx, hpos⟩
+
 /-- Grounding in the S-comparative: when the than-clause degree set has a
 maximum, a matrix witness clears it iff it clears the whole set
 (`Comparison.gt.overSet`, via `gtOverSet_eq_singleton_of_isGreatest`). -/

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -6,28 +6,37 @@ import Linglib.Semantics.Mereology
 # Pasternak (2019): A Lot of Hatred and a Ton of Desire
 
 This file formalizes the account in [pasternak-2019] of intensity as a monotonic measure
-function on mental states: a more intense state is bigger along a part-whole dimension, so
-*Ann hates Bill more than Matt hates Jeff* is a verbal comparative of the same shape as
-*more snow* and *ran more* ([wellwood-2015]), its measure obeying the monotonicity constraint
-([schwarzschild-2006]) that pseudopartitives, *out the wazoo*, adverbial measure phrases and
-nominal and verbal comparatives all impose (`Degree.admissibleMeasure`). A mental-state verb
-carries its predicate and its intensity measure (`MentalStateVerb`), thematic roles come
-from a `ThematicFrame`, the degree-relative entry *α V x at degree d* is `holdsAtDegree`,
-and the intensity comparative is `Degree.maxComparative` with matrix and than-clause
-predicates that may differ in experiencer and theme (`intensityComparative`). The
-comparative entails the matrix positive (`intensityComparative.exists_matrix`) but not the
-than-clause positive — *Jack admires the chairman more than Jill does; in fact, Jill doesn't
-admire him at all* — which the paper secures by adding a zero degree to the than-clause set
-(`intensityComparativeZero_of_none`). Mental-state predicates are homogeneous, closed under
-parts; the paper's biconditional form of homogeneity is `Mereology.DIV` (`div_iff`). Under
-unique witnesses on both sides the comparative reduces to comparing the two intensities
-(`intensityComparative_unique`), a simplification the paper does not adopt.
+function on mental states. *Ann hates Bill more than Matt hates Jeff* is a verbal comparative
+of the same shape as *more snow* and *ran more* ([wellwood-2015]): the matrix and than-clause
+predicates are the verb's eventualities with their experiencers and themes (`themed`), and
+the comparative is `Degree.maxComparative` under the intensity measure
+(`intensityComparative`), carrying the presupposition that the measure is monotonic on the
+salient part-whole relation among the verb's states, the monotonicity of
+[schwarzschild-2006] that pseudopartitives, *out the wazoo*, adverbial measure phrases, and
+nominal and verbal comparatives all impose (`Monotonic`). The comparative entails the matrix
+positive but not the than-clause positive, *Jack admires the chairman more than Jill does; in
+fact, Jill doesn't admire him at all*, which the zero degree in the than-clause set secures
+(`intensityComparative.exists_matrix`, `intensityComparativeZero_of_none`), and under the
+presupposition it compares the maximal states, Ann's hating Bill against Matt's hating Jeff
+(`intensityComparative_of_greatest`). Mental-state predicates are homogeneous, a state being a
+state of Ann hating Bill iff all its substates are, the biconditional form of `Mereology.DIV`
+(`div_iff`); the closure under parts supplies the strips of a state whose sums make intensity
+monotonic.
+
+## Implementation notes
+
+The zero-degree amendment to the than-clause set and the reduction of a comparative to its
+greatest witnesses under a monotone measure live in `Semantics/Degree/Quantifier`
+(`maxComparativeZero`, `maxComparative_of_isGreatest`); the part-whole order on eventualities
+is the event mereology of `Semantics/Events/Basic`. The two-dimensional state ontology that
+grounds the salient part-whole relation, the Mandarin data, and the desire predicates are not
+formalized.
 
 ## TODO
 
 * Mandarin *duō* / *hěn duō (de)*, which needs Fragment entries.
 * The two-dimensional state ontology with its vertical axis and the fineness ordering.
-* The desire predicates *want*, *wish* and *regret* over point-states.
+* The desire predicates *want*, *wish*, and *regret* over point-states.
 
 ## References
 
@@ -41,8 +50,8 @@ namespace Pasternak2019
 open Degree
 open ArgumentStructure (ThematicFrame)
 
-/-- A mental-state verb: its predicate on eventualities and its intensity measure `μ_int`;
-thematic roles are assigned by a `ThematicFrame` at use sites. -/
+/-- A mental-state verb: its predicate on eventualities and its intensity measure; thematic
+roles are assigned by a `ThematicFrame` at use sites. -/
 structure MentalStateVerb (T D : Type*) [LinearOrder T] where
   /-- The verb's predicate on eventualities. -/
   predicate : Event T → Prop
@@ -60,19 +69,22 @@ def themed (α x : Entity) (e : Event T) : Prop :=
 def MentalStateVerb.holdsAtDegree (α x : Entity) (d : D) (e : Event T) : Prop :=
   themed v frame α x e ∧ d ≤ v.μint e
 
-/-- The than-clause degrees of *β V y* are the degrees at which *β V y* holds. -/
-theorem thanDegrees_themed (β y : Entity) :
-    thanDegrees (themed v frame β y) v.μint = {d | ∃ e, v.holdsAtDegree frame β y d e} :=
-  rfl
-
 /-- The intensity comparative *α V x more than β V y*: `Degree.maxComparative` with the two
-sides differing in experiencer and theme, measured by `μ_int`. -/
+sides differing in experiencer and theme, measured by the intensity measure (56a). -/
 def intensityComparative (α β x y : Entity) : Prop :=
   maxComparative (themed v frame α x) (themed v frame β y) v.μint
 
+/-- The states of the verb with theme `x`, whatever their experiencer: the domain of the
+monotonicity presupposition. -/
+def statesOf (x : Entity) : Set (Event T) := {e | v.predicate e ∧ frame.theme x e}
+
+/-- The monotonicity presupposition (56b), the paper's (4) on the salient part-whole
+relation: a proper part of a state of the verb with theme `x` is strictly less intense. -/
+def Monotonic [Event.Mereology T] (x : Entity) : Prop := StrictMonoOn v.μint (statesOf v frame x)
+
 variable {v frame} {α β x y : Entity}
 
-/-- The comparative entails the matrix positive. -/
+/-- The positive entailment: the comparative entails the matrix positive. -/
 theorem intensityComparative.exists_matrix (h : intensityComparative v frame α β x y) :
     ∃ e, themed v frame α x e :=
   let ⟨_, _, e, he, _⟩ := h; ⟨e, he⟩
@@ -84,33 +96,38 @@ theorem intensityComparative_unique {ea eb : Event T} (ha : themed v frame α x 
     intensityComparative v frame α β x y ↔ v.μint eb < v.μint ea :=
   maxComparative_unique ha ha' hb hb'
 
+/-- Under the presupposition on both sides, the comparative compares the maximal states: with
+`ea` Ann's state of hating Bill and `eb` Matt's of hating Jeff, the sentence holds iff `ea`
+is the more intense. -/
+theorem intensityComparative_of_greatest [Event.Mereology T] {ea eb : Event T}
+    (hx : Monotonic v frame x) (hy : Monotonic v frame y)
+    (ha : IsGreatest {e | themed v frame α x e} ea)
+    (hb : IsGreatest {e | themed v frame β y e} eb) :
+    intensityComparative v frame α β x y ↔ v.μint eb < v.μint ea :=
+  maxComparative_of_isGreatest ha (hx.monotoneOn.mono λ _ he => ⟨he.2.1, he.2.2⟩) hb
+    (hy.monotoneOn.mono λ _ he => ⟨he.2.1, he.2.2⟩)
+
 section Zero
 
 variable [Zero D] (v frame)
 
-/-- The than-clause degree set with a zero degree added, so that its maximum exists when
-there is no `β`-eventuality. -/
-def thanDegreesZero (β y : Entity) : Set D :=
-  insert 0 (thanDegrees (themed v frame β y) v.μint)
-
-/-- The intensity comparative over `thanDegreesZero`. -/
+/-- The intensity comparative with the zero degree added to the than-clause set (62). -/
 def intensityComparativeZero (α β x y : Entity) : Prop :=
-  ∃ e, themed v frame α x e ∧ ∃ δ, IsGreatest (thanDegreesZero v frame β y) δ ∧ δ < v.μint e
+  maxComparativeZero (themed v frame α x) (themed v frame β y) v.μint
 
 variable {v frame}
 
-/-- With the zero degree, the comparative is consistent with there being no `β`-eventuality
-at all: *Jack admires the chairman more than Jill does; in fact, Jill doesn't admire him*. -/
+/-- The than-clause positive is not entailed (63): with the zero degree the comparative is
+consistent with there being no `β`-eventuality at all. -/
 theorem intensityComparativeZero_of_none {e : Event T} (he : themed v frame α x e)
     (hpos : 0 < v.μint e) (hβ : ∀ e', themed v frame β y e' → v.μint e' ≤ 0) :
     intensityComparativeZero v frame α β x y :=
-  ⟨e, he, 0, ⟨Set.mem_insert _ _, λ _ hd => (Set.mem_insert_iff.1 hd).elim le_of_eq
-    λ ⟨e', he', hle⟩ => hle.trans (hβ e' he')⟩, hpos⟩
+  maxComparativeZero_of_forall_le_zero he hpos hβ
 
 end Zero
 
-/-- Pasternak's homogeneity of mental-state predicates, closed under parts, in his
-biconditional form: a `Mereology.DIV` predicate holds of `e` iff it holds of every part. -/
+/-- Mental state homogeneity (55): a predicate closed under parts holds of `e` iff it holds of
+every part of `e`. -/
 theorem div_iff {α : Type*} [Preorder α] {P : α → Prop} (h : Mereology.DIV P) (e : α) :
     P e ↔ ∀ e' ≤ e, P e' :=
   ⟨λ he _ hle => h hle he, λ hall => hall e le_rfl⟩

--- a/references.bib
+++ b/references.bib
@@ -4961,7 +4961,7 @@
   role      = {cited},
   doi       = {10.1093/jos/3.1-2.1},
   validated = {true},
-  sources   = {Semantics/Degree/Comparative.lean;Semantics/Degree/ThanClause.lean}
+  sources   = {Semantics/Degree/Comparative.lean;Semantics/Degree/Quantifier.lean;Semantics/Degree/ThanClause.lean}
 }% REF: Alchourrón, C. E., Gärdenfors, P. & Makinson, D. (1985). On the logic of theory change. JSL 50(2): 510–530.
 @article{alchouron-gardenfors-makinson-1985,
   author    = {Alchourrón, Carlos E. and Gärdenfors, Peter and Makinson, David},
@@ -5105,7 +5105,7 @@
     subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Degree/Superlative.lean;Studies/Heim2001.lean}
+  sources   = {Semantics/Degree/Quantifier.lean;Semantics/Degree/Superlative.lean;Studies/Heim2001.lean}
 }% REF: van Benthem (1986). Essays in Logical Semantics.
 @article{van-benthem-1989,
   author    = {van Benthem, Johan},
@@ -6310,7 +6310,7 @@
   url       = {https://semanticsarchive.net/Archive/TI1MTlhZ/Superlative.pdf},
   subfield  = {semantics/compositional},
   role      = {cited},
-  sources   = {Semantics/Degree/Superlative.lean;Studies/Heim2001.lean}
+  sources   = {Semantics/Degree/Quantifier.lean;Semantics/Degree/Superlative.lean;Studies/Heim2001.lean}
 }% REF: Heim, I. (1994). Interrogative semantics and Karttunen's semantics for know. IATL 1.
 @inproceedings{heim-1994,
   author    = {Heim, Irene},
@@ -13892,7 +13892,7 @@
   subfield  = {semantics/lexical},
   validated = {true},
   role      = {cited},
-  sources   = {Data/Examples/Heim2001.json;Studies/BhattPancheva2004.lean;Studies/Heim2001.lean;Syntax/Minimalist/Movement/HeimKennedy.lean}
+  sources   = {Data/Examples/Heim2001.json;Semantics/Degree/Quantifier.lean;Studies/BhattPancheva2004.lean;Studies/Heim2001.lean;Syntax/Minimalist/Movement/HeimKennedy.lean}
 }
 @article{schwarzschild-2008,
   author    = {Schwarzschild, Roger},
@@ -34056,7 +34056,7 @@
   doi       = {10.1007/s10988-018-9247-x},
   subfield  = {semantics/attitudes},
   role      = {cited},
-  sources   = {Studies/Pasternak2019.lean}
+  sources   = {Semantics/Degree/Quantifier.lean;Studies/Pasternak2019.lean}
 }
 
 @article{schwarzschild-2006,


### PR DESCRIPTION
The monotonicity presupposition (56b) is `StrictMonoOn` over the event mereology, and under it the comparative compares the maximal states (`intensityComparative_of_greatest`); the zero-degree amendment moves to the substrate.
- `Degree.maxComparativeZero`, `maxComparative_of_isGreatest`, `isGreatest_thanDegrees_of_isGreatest` added to Semantics/Degree/Quantifier