### PR TITLE
refactor(Studies/Osborne2019): catena and valency facts as lemmas

### DIFF
--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -12,20 +12,25 @@ import Linglib.Syntax.DependencyGrammar.Basic
 # Osborne (2019): A Dependency Grammar of English
 
 This file formalizes the parts of the dependency grammar of [osborne-2019] that the English
-fragment lexicon supports. Each verb's valency, the sixth chapter's notion, is derived from
-the fragment's complement type, and concrete trees are checked against those valencies, a
-spurious object or a missing one violating the frame; the passive valency is derived from
-the transitive one by the lexical rule for passive participles (`passive_derives_valency`).
-Catenae, the fourth chapter's unit, come apart from constituents, a verb with its subject
-being a catena but not a constituent; control and raising lose their embedded subject in the
-basic tree and recover it in the enhanced graph; and gapping elides a catena of the
-antecedent clause that is not one of its constituents.
+fragment lexicon supports. A verb's valency frame (sixth chapter) is a lexical property, read
+here off the fragment's complement type, and the passive participle's frame is not listed but
+derived by a lexical rule that removes the object slot and adds an optional *by*-phrase
+(`passive_valency`); trees over fragment words satisfy their frames, and a spurious or a
+missing object violates them. The catena (fourth chapter), any set of words connected by
+dominance, is the unit that constituents do not always match: every constituent is a catena,
+a head with one of its dependents is always a catena, and it is never a constituent when the
+head has another dependent, so a verb with its subject but not its object is a catena and not
+a constituent (`IsConstituent.isCatena`, `isCatena_pair`, `not_isConstituent_pair`); that is
+the material gapping elides (§12.7). Control and raising (§6.8, §6.9) share one basic tree,
+whose embedded verb lacks a subject; the enhanced graph adds the subject arc, which the basic
+tree cannot carry without ceasing to be a tree (`hasUnrepresentedArg_enhance`,
+`Graph.not_isTree_enhance`).
 
 ## Implementation notes
 
-The trees are Universal Dependencies graphs over fragment words, and the enhanced graph is
-the basic tree with the recovered subject arc added; the sections are those of the book
-after [tesniere-1959].
+The trees are Universal Dependencies graphs over fragment words after [tesniere-1959], and
+the enhanced graph is the basic tree with the recovered subject arc added; the general lemmas
+live in the dependency-grammar substrate and are instantiated here on the fragment trees.
 
 ## References
 
@@ -60,25 +65,12 @@ private abbrev seems := English.Predicates.Verbal.seem.toWord3sg
 private abbrev sleep_ := English.Predicates.Verbal.sleep.toWordBase
 private abbrev run_ := English.Predicates.Verbal.run.toWordBase
 
-/-! ### Valencies derived from the Fragment (Ch. 6) -/
+/-! ### Valency frames from the Fragment (sixth chapter) -/
 
-theorem sleep_valency_from_fragment :
-    English.Predicates.Verbal.sleep.complementType.valency =
-      some Valency.intransitive := rfl
-
-theorem devour_valency_from_fragment :
-    English.Predicates.Verbal.devour.complementType.valency =
-      some Valency.transitive := rfl
-
-theorem give_valency_from_fragment :
-    English.Predicates.Verbal.give.complementType.valency =
-      some Valency.ditransitive := rfl
-
-theorem kick_valency_from_fragment :
-    English.Predicates.Verbal.kick.complementType.valency =
-      some Valency.transitive := rfl
-
-/-! ### Grammatical trees satisfy their valencies -/
+/-- The frame of a tree whose verb at position `i` is the fragment entry `v`: the valency its
+complement type determines. -/
+private def frameOf {n : ℕ} (v : English.Predicates.Verbal.VerbEntry) (i : Fin n) : Frames n :=
+  .ofList [(i, (v.complementType.valency).getD [])]
 
 def intransTree : Graph 2 := .ofArcs [john, sleeps] 1 [(1, 0, .nsubj)]
 
@@ -86,109 +78,109 @@ def transTree : Graph 3 :=
   .ofArcs [john, devours, pizza] 1 [(1, 0, .nsubj), (1, 2, .obj)]
 
 def ditransTree : Graph 4 :=
-  .ofArcs [john, gives, mary, book] 1
-    [(1, 0, .nsubj), (1, 2, .iobj), (1, 3, .obj)]
+  .ofArcs [john, gives, mary, book] 1 [(1, 0, .nsubj), (1, 2, .iobj), (1, 3, .obj)]
 
-example : intransTree.SatisfiesFrames (.ofList [(1, Valency.intransitive)]) := by
-  decide
-example : transTree.SatisfiesFrames (.ofList [(1, Valency.transitive)]) := by decide
-example : ditransTree.SatisfiesFrames (.ofList [(1, Valency.ditransitive)]) := by
-  decide
+example : intransTree.SatisfiesFrames (frameOf English.Predicates.Verbal.sleep 1) := by decide
+example : transTree.SatisfiesFrames (frameOf English.Predicates.Verbal.devour 1) := by decide
+example : ditransTree.SatisfiesFrames (frameOf English.Predicates.Verbal.give 1) := by decide
 
-/-! ### Ungrammatical trees violate them -/
-
-/-- "*John sleeps book": intransitive with a spurious object. -/
+/-- *John sleeps book: an intransitive with a spurious object. -/
 def intransWithObj : Graph 3 :=
   .ofArcs [john, sleeps, book] 1 [(1, 0, .nsubj), (1, 2, .obj)]
 
-/-- "*John devours": transitive missing its object. -/
+/-- *John devours: a transitive missing its object. -/
 def transNoObj : Graph 2 := .ofArcs [john, devours] 1 [(1, 0, .nsubj)]
 
-example : ¬ intransWithObj.SatisfiesFrames (.ofList [(1, Valency.intransitive)]) := by
+example : ¬ intransWithObj.SatisfiesFrames (frameOf English.Predicates.Verbal.sleep 1) := by
   decide
-example : ¬ transNoObj.SatisfiesFrames (.ofList [(1, Valency.transitive)]) := by
+example : ¬ transNoObj.SatisfiesFrames (frameOf English.Predicates.Verbal.devour 1) := by
   decide
 
 /-! ### The passive valency is rule-derived (§6.6) -/
 
+/-- The lexical entry of *kicked*, its valency from the fragment. -/
 private def lexKicked : LexEntry :=
   { form := kicked.form, cat := .VERB, features := kicked.features
-    valency := Valency.transitive }
+    valency := (English.Predicates.Verbal.kick.complementType.valency).getD [] }
 
-theorem passive_derives_valency :
+/-- The passive rule applies to *kicked* and yields the passive valency. -/
+theorem passive_valency :
     passiveRule.applies lexKicked = true ∧
-    (passiveRule.transform lexKicked).valency = Valency.passiveTransitive := ⟨rfl, rfl⟩
+      (passiveRule.transform lexKicked).valency = Valency.passiveTransitive :=
+  passiveRule_transitive lexKicked rfl (by decide) rfl
 
-/-- "The ball was kicked (by John)": the passive tree satisfies the
-    rule-derived valency. -/
+/-- *The ball was kicked (by John)* satisfies the rule-derived valency. -/
 def passiveTree : Graph 4 :=
-  .ofArcs [the_, ball, was_, kickedPass] 3
-    [(1, 0, .det), (3, 1, .nsubj), (3, 2, .auxPass)]
+  .ofArcs [the_, ball, was_, kickedPass] 3 [(1, 0, .det), (3, 1, .nsubj), (3, 2, .auxPass)]
 
 def longPassiveTree : Graph 6 :=
   .ofArcs [the_, ball, was_, kickedPass, by_, john] 3
     [(1, 0, .det), (3, 1, .nsubj), (3, 2, .auxPass), (3, 5, .obl), (5, 4, .case_)]
 
-example : passiveTree.SatisfiesFrames (.ofList [(3, Valency.passiveTransitive)]) := by
+example :
+    passiveTree.SatisfiesFrames (.ofList [(3, (passiveRule.transform lexKicked).valency)]) := by
   decide
 example :
-    longPassiveTree.SatisfiesFrames (.ofList [(3, Valency.passiveTransitive)]) := by
+    longPassiveTree.SatisfiesFrames
+      (.ofList [(3, (passiveRule.transform lexKicked).valency)]) := by
   decide
 
-/-- "*The ball was kicked the pizza": passive with a leftover object. -/
+/-- *The ball was kicked the pizza: a passive with a leftover object. -/
 def passiveWithObj : Graph 6 :=
   .ofArcs [the_, ball, was_, kickedPass, the_, pizza] 3
     [(1, 0, .det), (3, 1, .nsubj), (3, 2, .auxPass), (3, 5, .obj), (5, 4, .det)]
 
 example :
-    ¬ passiveWithObj.SatisfiesFrames (.ofList [(3, Valency.passiveTransitive)]) := by
+    ¬ passiveWithObj.SatisfiesFrames
+      (.ofList [(3, (passiveRule.transform lexKicked).valency)]) := by
   decide
 
-/-! ### Catenae vs constituents (Ch. 4)
+/-! ### Catenae against constituents (fourth chapter, §12.7)
 
-In "John devours pizza", the verb with its subject {0, 1} is a catena but
-not a constituent; each dominance cone is both. -/
+In *John devours pizza* the verb with its subject is a catena, being a head with a dependent,
+but not a constituent, since the verb has another dependent; the whole clause and the object
+are constituents and therefore catenae. The verb with its subject is what gapping elides in
+*John devours pizza and Mary wine*. -/
 
-example : IsCatena transTree {0, 1} := by decide
-example : ¬ IsConstituent transTree {0, 1} := by decide
-example : IsCatena transTree {0, 1, 2} := by decide
-example : IsConstituent transTree {0, 1, 2} := by decide
-example : IsConstituent transTree {2} := by decide
+example : IsCatena transTree {1, 0} := isCatena_pair transTree (by decide) (by decide)
+
+example : ¬ IsConstituent transTree {1, 0} :=
+  not_isConstituent_pair (u := 2) (by decide) (by decide) (by decide) (by decide)
+
+example : IsCatena transTree {0, 1, 2} :=
+  (show IsConstituent transTree {0, 1, 2} by decide).isCatena
+
+example : IsCatena transTree {2} := (show IsConstituent transTree {2} by decide).isCatena
+
 example : ¬ IsCatena transTree {0, 2} := by decide
 
-/-! ### Control and raising (§§6.8–6.9): the basic tree loses the
-embedded subject; the enhanced graph recovers it -/
+/-! ### Control and raising (§6.8, §6.9)
 
-/-- "John manages to sleep" — subject control, basic tree. -/
+The basic tree of *John manages to sleep*, *John persuaded Mary to run*, and *John seems to
+sleep* leaves the embedded verb without a subject; control and raising differ thematically,
+not structurally. The enhanced graph recovers the subject arc, an argument relation the
+basic tree does not carry and cannot, since a second head breaks the tree. -/
+
 def subjControl : Graph 4 :=
-  .ofArcs [john, manages, to_, sleep_] 1
-    [(1, 0, .nsubj), (1, 3, .xcomp), (3, 2, .mark)]
+  .ofArcs [john, manages, to_, sleep_] 1 [(1, 0, .nsubj), (1, 3, .xcomp), (3, 2, .mark)]
 
-/-- "John persuaded Mary to run" — object control, basic tree. -/
 def objControl : Graph 5 :=
   .ofArcs [john, persuaded, mary, to_, run_] 1
     [(1, 0, .nsubj), (1, 2, .obj), (1, 4, .xcomp), (4, 3, .mark)]
 
-/-- "John seems to sleep" — raising: same basic geometry as subject
-    control; the difference is thematic, not structural. -/
 def raising : Graph 4 :=
-  .ofArcs [john, seems, to_, sleep_] 1
-    [(1, 0, .nsubj), (1, 3, .xcomp), (3, 2, .mark)]
+  .ofArcs [john, seems, to_, sleep_] 1 [(1, 0, .nsubj), (1, 3, .xcomp), (3, 2, .mark)]
 
-example : HasUnrepresentedArg subjControl (subjControl.enhance [(3, 0, .nsubj)]) 0 := by
-  decide
-example : HasUnrepresentedArg objControl (objControl.enhance [(4, 2, .nsubj)]) 2 := by
-  decide
-example : HasUnrepresentedArg raising (raising.enhance [(3, 0, .nsubj)]) 0 := by decide
-example : ¬ (subjControl.enhance [(3, 0, .nsubj)]).IsTree := by decide
+example : HasUnrepresentedArg subjControl (subjControl.enhance [(3, 0, .nsubj)]) 0 :=
+  hasUnrepresentedArg_enhance _ (x := 3) .nsubj _ (by simp) (by decide)
 
-/-! ### Gapping elides a catena that is not a constituent (§12.7)
+example : HasUnrepresentedArg objControl (objControl.enhance [(4, 2, .nsubj)]) 2 :=
+  hasUnrepresentedArg_enhance _ (x := 4) .nsubj _ (by simp) (by decide)
 
-In gapping ("John devours pizza and Mary ___ wine"), the elided material —
-the verb with its subject slot but without its object — is a catena of the
-antecedent clause that is not one of its constituents. -/
+example : HasUnrepresentedArg raising (raising.enhance [(3, 0, .nsubj)]) 0 :=
+  hasUnrepresentedArg_enhance _ (x := 3) .nsubj _ (by simp) (by decide)
 
-example : IsCatena transTree {1, 0} := by decide
-example : ¬ IsConstituent transTree {1, 0} := by decide
+example : ¬ (subjControl.enhance [(3, 0, .nsubj)]).IsTree :=
+  Graph.not_isTree_enhance (v := 1) (w := 0) (x := 3) (by decide) (by decide) .nsubj _ (by simp)
 
 end Osborne2019

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -193,4 +193,11 @@ instance {n : ℕ} (b e : Graph n) (w : Fin n) :
     Decidable (HasUnrepresentedArg b e w) :=
   inferInstanceAs (Decidable (∃ _, _))
 
+/-- An arc that enhancement adds to a position lacking it in the basic graph is an
+unrepresented argument relation. -/
+theorem hasUnrepresentedArg_enhance {n : ℕ} (g : Graph n) {x w : Fin n} (r : UD.DepRel)
+    (extra : List (Fin n × Fin n × UD.DepRel)) (hmem : (x, w, r) ∈ extra) (h : ¬ g.Adj x w) :
+    HasUnrepresentedArg g (g.enhance extra) w :=
+  ⟨x, Graph.enhance_adj.mpr (Or.inr ⟨r, hmem⟩), h⟩
+
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Catena.lean
+++ b/Linglib/Syntax/DependencyGrammar/Catena.lean
@@ -59,6 +59,29 @@ theorem IsConstituent.isCatena {g : Graph n} {s : Finset (Fin n)}
   rw [IsCatena, show (↑s : Set (Fin n)) = {x | Dominates g v x} from Set.ext hv]
   exact connected_induce_cone g v
 
+/-- A head with one of its dependents is a catena. -/
+theorem isCatena_pair (g : Graph n) {v w : Fin n} (h : g.Adj v w) (hne : v ≠ w) :
+    IsCatena g {v, w} := by
+  refine (SimpleGraph.connected_iff_exists_forall_reachable _).mpr ⟨⟨v, by simp⟩, ?_⟩
+  rintro ⟨u, hu⟩
+  rcases Finset.mem_insert.mp (Finset.mem_coe.mp hu) with rfl | hu'
+  · exact .rfl
+  · rw [Finset.mem_singleton] at hu'; subst hu'
+    exact SimpleGraph.Adj.reachable ⟨hne, Or.inl h⟩
+
+/-- In a tree, a head with one of its dependents is not a constituent when the head has
+another dependent: the head's cone contains the other dependent, and the dependent's cone
+does not contain the head. -/
+theorem not_isConstituent_pair {g : Graph n} (hT : g.IsTree) {v w u : Fin n} (hw : g.Adj v w)
+    (hu : g.Adj v u) (huw : u ≠ w) : ¬ IsConstituent g {v, w} := by
+  rintro ⟨c, hc⟩
+  rcases Finset.mem_insert.mp ((hc c).2 Relation.ReflTransGen.refl) with rfl | hcw
+  · rcases Finset.mem_insert.mp ((hc u).2 (Relation.ReflTransGen.single hu)) with rfl | hu'
+    · exact hT.acyclic u (Relation.TransGen.single hu)
+    · exact huw (Finset.mem_singleton.mp hu')
+  · rw [Finset.mem_singleton] at hcw; subst hcw
+    exact not_adj_dominates hT.acyclic hw ((hc v).1 (by simp))
+
 /-- The whole sentence is a constituent: the root's dominance cone. -/
 theorem isConstituent_univ {g : Graph n} (hT : g.IsTree) :
     IsConstituent g Finset.univ :=

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -119,6 +119,14 @@ theorem Graph.IsTree.leftUnique_adj (hT : g.IsTree) :
   obtain ⟨z, _, hz⟩ := hT.existsUnique_adj y hy
   exact (hz u hu).trans (hz u' hu').symm
 
+/-- Adding a second head for a position breaks tree-hood: the enhanced graph of a control or
+raising structure, whose embedded verb gains the matrix subject, is not a tree. -/
+theorem Graph.not_isTree_enhance {x : Fin n} (hv : g.Adj v w) (hx : x ≠ v) (r : UD.DepRel)
+    (extra : List (Fin n × Fin n × UD.DepRel)) (hmem : (x, w, r) ∈ extra) :
+    ¬ (g.enhance extra).IsTree := λ hT' =>
+  hx (hT'.leftUnique_adj (Graph.enhance_adj.mpr (Or.inr ⟨r, hmem⟩))
+    (Graph.enhance_adj.mpr (Or.inl hv)))
+
 /-- No arc closes a dominance cycle, on acyclic graphs. -/
 theorem not_adj_dominates (hacyc : ∀ v, ¬ TransGen g.Adj v v)
     (hadj : g.Adj v w) (hdom : Dominates g w v) : False :=

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -86,6 +86,17 @@ def passiveRule : LexRule :=
         features := { e.features with voice := some .Pass }
         valency := e.valency.filter (·.depType != .obj) ++ [⟨.obl, .right, false⟩] } }
 
+/-- The passive rule on an active transitive verb entry: it applies, and the derived entry
+carries the passive valency, the object slot removed and an optional *by*-phrase added. -/
+theorem passiveRule_transitive (e : LexEntry) (hc : e.cat = .VERB)
+    (hv : e.features.voice ≠ some .Pass) (h : e.valency = Valency.transitive) :
+    passiveRule.applies e = true ∧
+      (passiveRule.transform e).valency = Valency.passiveTransitive := by
+  refine ⟨?_, ?_⟩
+  · simp [passiveRule, hc, hv, h, Valency.transitive]
+  · show e.valency.filter (·.depType != .obj) ++ [⟨.obl, .right, false⟩] = _
+    rw [h]; rfl
+
 -- ============================================================================
 -- Applying Lexical Rules
 -- ============================================================================

--- a/references.bib
+++ b/references.bib
@@ -18827,7 +18827,7 @@
   isbn      = {9780226674469},
   subfield  = {syntax},
   role      = {foundational},
-  sources   = {Syntax/HPSG/Basic.lean}
+  sources   = {Syntax/HPSG/Basic.lean;Syntax/WordGrammar/LexicalRules.lean}
 }
 @phdthesis{richter-2000,
   author    = {Richter, Frank},
@@ -21247,7 +21247,7 @@
   subfield  = {syntax},
   role      = {cited},
   validated = {true},
-  sources   = {Data/Treebank/Coverage/Kuhlmann2013.json;Data/Treebank/Coverage/Schema.lean;Studies/Kuhlmann2013.lean}
+  sources   = {Data/Treebank/Coverage/Kuhlmann2013.json;Data/Treebank/Coverage/Schema.lean;Studies/Kuhlmann2013.lean;Syntax/DependencyGrammar/Basic.lean}
 }
 @incollection{kuo-yu-2012,
   author    = {Kuo, Grace C.-H. and Yu, Kristine M.},


### PR DESCRIPTION
The decide-only examples now instantiate general substrate lemmas: a head with a dependent is a catena and not a constituent when the head has another dependent, an enhancement arc is an unrepresented argument and breaks tree-hood, and the passive rule on any transitive entry yields the passive valency.
- frames are read off the fragment's complement type instead of restated
- new lemmas in DependencyGrammar/{Basic,Dominance,Catena} and WordGrammar/LexicalRules