### PR TITLE
docs(Studies/Major2024): example locators verified against the paper

### DIFF
--- a/Linglib/Studies/Major2024.lean
+++ b/Linglib/Studies/Major2024.lean
@@ -20,11 +20,6 @@ The case-theoretic consequences for Sakha *dien* and the accusative subjects of
 [baker-vinokurova-2010] are not represented; the examples are rows of
 `Data/Examples/Major2024.json`.
 
-## TODO
-
-The paper is not on file; example and section locators are transcribed from an earlier
-version of this file and are UNVERIFIED.
-
 ## References
 
 * [major-2024]
@@ -38,18 +33,18 @@ open Morphology (Morph)
 
 /-! ### Merge modes read off the morphology (§2)
 
-Converbial -(I)p clauses adjoin at two heights (his 4): VP-level
+Converbial -(I)p clauses adjoin at two heights (4): VP-level
 -(I)p is a manner modifier interpreted under matrix aspect (his
-10–13), answers *qandaq* 'how' (his 15–16), and sits below the matrix
-accusative position (his 19); TP-level -(I)p precedes the whole matrix
-clause (his 29), tolerates aspect and voice mismatches (his 12, 30),
-and merges at (at least) TP (his 31). Dep clauses replicate both
-profiles (his 37–38, 52–56). -/
+10–13), answers *qandaq* 'how' (15)–(16), and sits below the matrix
+accusative position (19); TP-level -(I)p precedes the whole matrix
+clause (29), tolerates aspect and voice mismatches (12), (30),
+and merges at (at least) TP (31). Dep clauses replicate both
+profiles (37)–(38), (52)–(56). -/
 
 /-- Structural positions at issue for an embedded clause: the two
-converb adjunction heights (his 4) and the two argument positions the
-paper tests — complement of V (his 59a, 61a, 73) and grammatical
-subject (his 49). -/
+converb adjunction heights (4) and the two argument positions the
+paper tests — complement of V (59a), (61a), (73) and grammatical
+subject (49). -/
 inductive ClausePosition where
   | complementOfV
   | subject
@@ -70,17 +65,17 @@ instance : DecidablePred ClausePosition.isArgument
   | .tpAdjunct     => isFalse id
 
 /-- How a clause-forming morpheme merges the clause it heads: a
-converb builds an adjunct to a verbal projection (his 4); a
+converb builds an adjunct to a verbal projection (4); a
 nominalizer builds a case-bearing nominal that saturates an argument
-position (his 49a, 59a). -/
+position (49a), (59a). -/
 inductive MergeMode where
   | converbAdjunction
   | nominalArgument
   deriving DecidableEq, Repr
 
 /-- Converbial adjuncts modify, never saturate ("dep clauses are never
-internal arguments", §3.2; subject ban his 49b); nominalized clauses
-saturate. Oblique case-marked participial adjuncts (his 50b) go
+internal arguments", §3.2; subject ban (49b); nominalized clauses
+saturate. Oblique case-marked participial adjuncts (50b) go
 through case morphology, outside this position set. -/
 def MergeMode.admits : MergeMode → ClausePosition → Prop
   | .converbAdjunction, pos => ¬ pos.isArgument
@@ -103,8 +98,8 @@ def mergeMode (c : Complementizer) : Option MergeMode :=
 
 /-- A clause headed by `c` is licensed in `pos` iff `c`'s merge mode
 admits it. No matrix-verb parameter: dep clauses appear regardless of
-matrix transitivity (his 44a *söz qil-* vs. unaccusative 44b *söz
-bol-*) and with unaccusative 'be surprised' (his 50c). -/
+matrix transitivity (44a) *söz qil-* vs. unaccusative 44b *söz
+bol-*) and with unaccusative 'be surprised' (50c). -/
 def licensedIn (c : Complementizer) (pos : ClausePosition) : Prop :=
   match mergeMode c with
   | some m => m.admits pos
@@ -116,10 +111,10 @@ instance (c : Complementizer) (pos : ClausePosition) : Decidable (licensedIn c p
   | none   => decidable_of_iff False (by unfold licensedIn; rw [hm])
 
 /-- The say-root heads no clause of its own — the linker is the
-converb, not 'say' (his 2–3). -/
+converb, not 'say' (2)–(3). -/
 theorem de_no_mergeMode : mergeMode Uyghur.de = none := rfl
 
-/-! ### The say-converb witness (his 2–3, 9) -/
+/-! ### The say-converb witness (2)–(3), (9) -/
 
 /-- A say-converb re-analysis of an apparent complementizer
 ([major-2024]; cf. `Bondarenko2022.ContAnalysis` for the rival
@@ -127,7 +122,7 @@ Cont-exponence carving): the linker decomposes into a say-root and a
 converbial suffix drawn from the language's inventory, and the
 say-root is the independently attested main verb 'say' — one lexical
 item, so main-verb properties persist inside the adjunct by
-construction (his 39–41). A structure, not a class: rival frameworks
+construction (39)–(41). A structure, not a class: rival frameworks
 construct rival witnesses. -/
 structure SayConverbAnalysis where
   /-- The fragment inventory analyzed. -/
@@ -143,8 +138,8 @@ structure SayConverbAnalysis where
   /-- Morphology at face value: the linker is a converb. -/
   converb_conv : converb.verbForm = some UD.VerbForm.Conv
   /-- 'say' is transitive with an obligatory internal argument
-      (his 39a, 40a), a requirement that persists inside the adjunct
-      (his 41: `*(birnémi-ler-ni) de-p warqiri-di`). -/
+      (39a), (40a), a requirement that persists inside the adjunct
+      (41): `*(birnémi-ler-ni) de-p warqiri-di`). -/
   say_transitive : say.complementType ≠ ComplementType.none ∧ say.implicitObj = none
 
 /-- The complex linker: the say-root's morphs followed by the converb's
@@ -159,7 +154,7 @@ theorem SayConverbAnalysis.mergeMode_converb (a : SayConverbAnalysis) :
   simp [mergeMode, a.converb_conv]
 
 /-- Any say-converb analysis licenses the say-clause at both
-adjunction heights (his 4, 51, 56). -/
+adjunction heights (4), (51), (56). -/
 theorem SayConverbAnalysis.adjoins (a : SayConverbAnalysis) :
     licensedIn a.converb .vpAdjunct ∧ licensedIn a.converb .tpAdjunct := by
   unfold licensedIn
@@ -175,7 +170,7 @@ theorem SayConverbAnalysis.argument_ban (a : SayConverbAnalysis)
   rw [a.mergeMode_converb]
   exact λ hn => hn h
 
-/-- The Uyghur witness: *dep* = *de* 'say' + -(I)p (his 2–3), over the
+/-- The Uyghur witness: *dep* = *de* 'say' + -(I)p (2)–(3), over the
 fragment inventory. -/
 def depAnalysis : SayConverbAnalysis where
   inventory := Uyghur.complementizers
@@ -189,30 +184,30 @@ def depAnalysis : SayConverbAnalysis where
 
 example : depAnalysis.linker = [.root "de", .suff "(I)p"] := rfl
 
-/-- Dep clauses adjoin at VP and TP (his 4, 37, 51, 56). -/
+/-- Dep clauses adjoin at VP and TP (4), (37), (51), (56). -/
 theorem dep_adjoins_vp_and_tp :
     licensedIn Uyghur.ip .vpAdjunct ∧ licensedIn Uyghur.ip .tpAdjunct :=
   depAnalysis.adjoins
 
-/-- The argument ban (subject: his 49b; internal argument: §3.2):
+/-- The argument ban (subject: (49b); internal argument: §3.2):
 derived from -(I)p's converb morphology, and independent of the matrix
 verb — dep clauses occur in clearly unselected environments, as
-reasons or excuses (his 5, 53). -/
+reasons or excuses (5), (53). -/
 theorem dep_never_argument (pos : ClausePosition) (h : pos.isArgument) :
     ¬ licensedIn Uyghur.ip pos :=
   depAnalysis.argument_ban pos h
 
-/-- His (49b): a dep clause cannot be the grammatical subject of
-'make surprised' — unlike the participial clause (his 49a). -/
+/-- (49b): a dep clause cannot be the grammatical subject of
+'make surprised' — unlike the participial clause (49a). -/
 theorem dep_not_subject : ¬ licensedIn Uyghur.ip .subject :=
   dep_never_argument .subject trivial
 
 /-- The participial strategy is the mirror image: nominalized clauses
-are licensed exactly in argument positions — subject (his 49a) and
-complement of V (his 59a, 61a) — never at the converb adjunction
+are licensed exactly in argument positions — subject (49a) and
+complement of V (59a), (61a) — never at the converb adjunction
 sites. Dep clauses also fail N-complement constituency: the head noun
-scrambles away from a dep clause (his 45–46) but never from a genuine
-N-complement (his 47–48). -/
+scrambles away from a dep clause (45)–(46) but never from a genuine
+N-complement (47)–(48). -/
 theorem participial_licensed_iff_argument :
     ∀ pos, licensedIn Uyghur.lik pos ↔ pos.isArgument := by decide
 
@@ -222,9 +217,9 @@ The persistence claim is carried by `depAnalysis` housing the single
 lexical entry `Uyghur.deVerb`: whatever the fragment records of
 main-verb 'say' holds of 'say' inside dep clauses. The same holds of
 any converb-suffixed verb — 'think' imposes its own frame inside an
-adjunct (his 42) — so the persistence is converbial, not dep-magic. -/
+adjunct (42) — so the persistence is converbial, not dep-magic. -/
 
-/-- His (38)–(41): *warqira-* 'scream' has no complement frame (his
+/-- (38)–(41): *warqira-* 'scream' has no complement frame (his
 39b, 40b), yet 'scream' + dep reports propositional content — the
 content sits in the obligatory complement of *de-* inside the
 VP-adjoined say-clause, which "coerces it into a verb of speech"
@@ -235,12 +230,12 @@ theorem coerced_speech_reading :
     licensedIn Uyghur.ip .vpAdjunct :=
   ⟨rfl, depAnalysis.say_transitive.1, dep_adjoins_vp_and_tp.1⟩
 
-/-! ### The two heights diagnosed (his 54–55) -/
+/-! ### The two heights diagnosed (54)–(55) -/
 
 /-- Positions inside the matrix clausemate domain for NCI licensing:
-Uyghur *héch-* items need clausemate negation (his 20). Everything
+Uyghur *héch-* items need clausemate negation (20). Everything
 merged below matrix T is in the domain; the TP-adjunct, which precedes
-the entire matrix clause (his 29, 31), is outside. -/
+the entire matrix clause (29), (31), is outside. -/
 def ClausePosition.clausemateWithMatrixNeg : ClausePosition → Prop
   | .tpAdjunct => False
   | _ => True
@@ -251,15 +246,15 @@ instance : DecidablePred ClausePosition.clausemateWithMatrixNeg
   | .vpAdjunct     => isTrue trivial
   | .tpAdjunct     => isFalse id
 
-/-- His (54): matrix negation licenses an NCI inside a dep clause
+/-- (54): matrix negation licenses an NCI inside a dep clause
 exactly at the VP site — replicating the bare -(I)p contrast (his
 22–26) — so NCI licensing diagnoses a dep clause's attachment height.
-The *shundaq*-anaphora contrast (his 55) draws the same line. -/
+The *shundaq*-anaphora contrast (55) draws the same line. -/
 theorem dep_nci_diagnoses_height :
     ∀ pos, licensedIn Uyghur.ip pos →
       (pos.clausemateWithMatrixNeg ↔ pos = .vpAdjunct) := by decide
 
-/-! ### The factivity alternation, derived (his 61–65) -/
+/-! ### The factivity alternation, derived (61)–(65) -/
 
 /-- Positions feeding a factive predicate's presupposition: only its
 complement — "factive interpretations arise from predicates taking a
@@ -280,17 +275,17 @@ instance : DecidablePred ClausePosition.feedsFactivity
 theorem feedsFactivity_isArgument :
     ∀ pos : ClausePosition, pos.feedsFactivity → pos.isArgument := by decide
 
-/-- 'know' + dep is non-factive (his 61b) across the whole factive
-class (his 63), and 'forget' + dep loses the forget-that reading (his
+/-- 'know' + dep is non-factive (61b) across the whole factive
+class (63), and 'forget' + dep loses the forget-that reading (his
 65): a dep clause can occupy no factivity-feeding position — a
 corollary of the argument ban, contra a per-verb homophony account the
 paper rejects (§3.2; 'know' stays presuppositional about its own
-object even with dep present, his 62). -/
+object even with dep present, (62). -/
 theorem dep_never_feeds_factivity (pos : ClausePosition)
     (h : licensedIn Uyghur.ip pos) : ¬ pos.feedsFactivity :=
   λ hf => dep_never_argument pos (feedsFactivity_isArgument pos hf) h
 
-/-- The participial contrast (his 61a, 63a–b): the nominalized clause
+/-- The participial contrast (61a), (63a–b): the nominalized clause
 sits in complement position, where factivity is fed. -/
 theorem participial_feeds_factivity :
     licensedIn Uyghur.lik .complementOfV ∧


### PR DESCRIPTION
Deep-pass verification of Major2024 against the paper text.

- every example number checked; the unverified-locator TODO removed
- possessive locators rewritten as bare example numbers