### PR TITLE
refactor(Studies/Lucy1994): attestations from CLDF form relations

### DIFF
--- a/Linglib/Data/Forms/Lucy1994.json
+++ b/Linglib/Data/Forms/Lucy1994.json
@@ -1,0 +1,1114 @@
+{
+  "FormTable": [
+    {
+      "ID": "lucy1994_AFCT",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "AFCT",
+      "Form": "=t",
+      "Segments": ["=t"],
+      "Comment": "the affective suffix, transitivising an agent-salient root",
+      "Source": ["lucy-1994[(1a)]"]
+    },
+    {
+      "ID": "lucy1994_ROOT",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "ROOT",
+      "Form": "=∅",
+      "Segments": ["=∅"],
+      "Comment": "zero derivation: the root alone supports a transitive stem",
+      "Source": ["lucy-1994[(1b)]"]
+    },
+    {
+      "ID": "lucy1994_CAUS",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "CAUS",
+      "Form": "=s",
+      "Segments": ["=s"],
+      "Comment": "the causative suffix, transitivising a patient-salient root",
+      "Source": ["lucy-1994[(1c)]"]
+    },
+    {
+      "ID": "lucy1994_POS",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "POS",
+      "Form": "=lah",
+      "Segments": ["=lah"],
+      "Comment": "the positional derivation, =tal in the imperfective",
+      "Source": ["lucy-1994[(5)]"]
+    },
+    {
+      "ID": "lucy1994_siit",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "jump",
+      "Form": "síit'",
+      "Segments": ["síit'"],
+      "Comment": "",
+      "Source": ["lucy-1994[(1a)]"]
+    },
+    {
+      "ID": "lucy1994_siit_t",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "jump-over",
+      "Form": "síit'=t",
+      "Segments": ["síit'", "=t"],
+      "Comment": "",
+      "Source": ["lucy-1994[(1a)]"]
+    },
+    {
+      "ID": "lucy1994_tziib",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "write",
+      "Form": "¢'iib'",
+      "Segments": ["¢'iib'"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_miis",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "sweep",
+      "Form": "mìis",
+      "Segments": ["mìis"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_cheh",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "smile",
+      "Form": "čé'eh",
+      "Segments": ["čé'eh"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_paak",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "weed",
+      "Form": "páak",
+      "Segments": ["páak"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_kuc",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "carry",
+      "Form": "kuč",
+      "Segments": ["kuč"],
+      "Comment": "",
+      "Source": ["lucy-1994[(1b)]"]
+    },
+    {
+      "ID": "lucy1994_kuc_0",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "carry-tr",
+      "Form": "kuč=∅",
+      "Segments": ["kuč", "=∅"],
+      "Comment": "",
+      "Source": ["lucy-1994[(1b)]"]
+    },
+    {
+      "ID": "lucy1994_kos",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cut",
+      "Form": "k'os",
+      "Segments": ["k'os"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_pis",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "measure",
+      "Form": "p'is",
+      "Segments": ["p'is"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_hats",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "whip",
+      "Form": "ha¢",
+      "Segments": ["ha¢"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_los",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "punch",
+      "Form": "loš",
+      "Segments": ["loš"],
+      "Comment": "",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_ah",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "awaken",
+      "Form": "'ah",
+      "Segments": ["'ah"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_ah_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "wake-someone",
+      "Form": "'ah=s",
+      "Segments": ["'ah", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_wen",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "fall-asleep",
+      "Form": "wen",
+      "Segments": ["wen"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_wen_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "put-to-sleep",
+      "Form": "ween=s",
+      "Segments": ["ween", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_siih",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "be-born",
+      "Form": "siih",
+      "Segments": ["siih"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_siih_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "give-birth",
+      "Form": "siih=s",
+      "Segments": ["siih", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kiim",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "die",
+      "Form": "kíim",
+      "Segments": ["kíim"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kiim_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "kill",
+      "Form": "kíim=s",
+      "Segments": ["kíim", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_tuub",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "forget",
+      "Form": "tú'ub'",
+      "Segments": ["tú'ub'"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_tuub_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "distract",
+      "Form": "tú'ub'=s",
+      "Segments": ["tú'ub'", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kaah",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "remember",
+      "Form": "k'a'ah",
+      "Segments": ["k'a'ah"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kaah_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "remind",
+      "Form": "k'á'ah=s",
+      "Segments": ["k'á'ah", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chuun",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "begin-activity",
+      "Form": "ču'un",
+      "Segments": ["ču'un"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chuun_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cause-to-begin",
+      "Form": "ču'un=s",
+      "Segments": ["ču'un", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chen",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "stop",
+      "Form": "č'en",
+      "Segments": ["č'en"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chen_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cause-to-stop",
+      "Form": "č'en=s",
+      "Segments": ["č'en", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_hoop",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "begin",
+      "Form": "hó'op'",
+      "Segments": ["hó'op'"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_hoop_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cause-to-start",
+      "Form": "hó'op'=s",
+      "Segments": ["hó'op'", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_haaw",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cease",
+      "Form": "háaw",
+      "Segments": ["háaw"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_haaw_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "revoke",
+      "Form": "háaw=s",
+      "Segments": ["háaw", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_heel",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "rest",
+      "Form": "hé'el",
+      "Segments": ["hé'el"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_heel_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "rest-tr",
+      "Form": "hé'e(l)=s",
+      "Segments": ["hé'e(l)", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_paat",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "remain",
+      "Form": "p'át",
+      "Segments": ["p'át"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_paat_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "abandon",
+      "Form": "p'át=s",
+      "Segments": ["p'át", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_maan",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "pass-by",
+      "Form": "máan",
+      "Segments": ["máan"],
+      "Comment": "marked # in (4): lacks the -Vl imperfective",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_maan_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "transport",
+      "Form": "maan=s",
+      "Segments": ["maan", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_peek",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "move",
+      "Form": "péek",
+      "Segments": ["péek"],
+      "Comment": "marked # in (4): lacks the -Vl imperfective",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_peek_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "cause-to-move",
+      "Form": "pek=s",
+      "Segments": ["pek", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_bin",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "go",
+      "Form": "b'in",
+      "Segments": ["b'in"],
+      "Comment": "marked # in (4): lacks the -Vl imperfective",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_bin_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "take",
+      "Form": "bi(n)=s",
+      "Segments": ["bi(n)", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_taal",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "come",
+      "Form": "tàal",
+      "Segments": ["tàal"],
+      "Comment": "marked # in (4): lacks the -Vl imperfective",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_taal_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "bring",
+      "Form": "taa(l)=s",
+      "Segments": ["taa(l)", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_uul",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "arrive-here",
+      "Form": "'ú'ul",
+      "Segments": ["'ú'ul"],
+      "Comment": "marked # in (4): lacks the -Vl imperfective",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_uul_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "bring-here",
+      "Form": "'u'uh=s",
+      "Segments": ["'u'uh", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_ok",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "enter",
+      "Form": "'ok",
+      "Segments": ["'ok"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_ok_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "move-in",
+      "Form": "'ook=s",
+      "Segments": ["'ook", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_luub",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "fall",
+      "Form": "lúub'",
+      "Segments": ["lúub'"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_luub_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "fell",
+      "Form": "luub'=s",
+      "Segments": ["luub'", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_liik",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "rise",
+      "Form": "líik'",
+      "Segments": ["líik'"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_liik_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "raise",
+      "Form": "lii(k)'=s",
+      "Segments": ["lii(k)'", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_naak",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "ascend",
+      "Form": "ná'ak",
+      "Segments": ["ná'ak"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_naak_s",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "raise-2",
+      "Form": "na'ak=s",
+      "Segments": ["na'ak", "=s"],
+      "Comment": "",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_cin",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "bend",
+      "Form": "čin",
+      "Segments": ["čin"],
+      "Comment": "",
+      "Source": ["lucy-1994[(5)]"]
+    },
+    {
+      "ID": "lucy1994_cin_0",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "bend-tr",
+      "Form": "čin=∅",
+      "Segments": ["čin", "=∅"],
+      "Comment": "",
+      "Source": ["lucy-1994[(6)]"]
+    },
+    {
+      "ID": "lucy1994_cin_lah",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "become-bent",
+      "Form": "čin=lah",
+      "Segments": ["čin", "=lah"],
+      "Comment": "=tal in the imperfective (5a)",
+      "Source": ["lucy-1994[(5c)]"]
+    },
+    {
+      "ID": "lucy1994_cil",
+      "Language_ID": "yuca1254",
+      "Parameter_ID": "lie-down",
+      "Form": "čil",
+      "Segments": ["čil"],
+      "Comment": "",
+      "Source": ["lucy-1994[(7)]"]
+    }
+  ],
+  "ParameterTable": [
+    {
+      "ID": "AFCT",
+      "Name": "affective derivation",
+      "Description": ""
+    },
+    {
+      "ID": "ROOT",
+      "Name": "root transitive",
+      "Description": ""
+    },
+    {
+      "ID": "CAUS",
+      "Name": "causative derivation",
+      "Description": ""
+    },
+    {
+      "ID": "POS",
+      "Name": "positional derivation",
+      "Description": ""
+    },
+    {
+      "ID": "jump",
+      "Name": "jump",
+      "Description": ""
+    },
+    {
+      "ID": "jump-over",
+      "Name": "jump (over)",
+      "Description": ""
+    },
+    {
+      "ID": "write",
+      "Name": "write",
+      "Description": ""
+    },
+    {
+      "ID": "sweep",
+      "Name": "sweep",
+      "Description": ""
+    },
+    {
+      "ID": "smile",
+      "Name": "smile",
+      "Description": ""
+    },
+    {
+      "ID": "weed",
+      "Name": "weed",
+      "Description": ""
+    },
+    {
+      "ID": "carry",
+      "Name": "carry",
+      "Description": ""
+    },
+    {
+      "ID": "carry-tr",
+      "Name": "carry (someone)",
+      "Description": ""
+    },
+    {
+      "ID": "cut",
+      "Name": "cut",
+      "Description": ""
+    },
+    {
+      "ID": "measure",
+      "Name": "measure",
+      "Description": ""
+    },
+    {
+      "ID": "whip",
+      "Name": "whip",
+      "Description": ""
+    },
+    {
+      "ID": "punch",
+      "Name": "punch",
+      "Description": ""
+    },
+    {
+      "ID": "awaken",
+      "Name": "(a)wake(n)",
+      "Description": ""
+    },
+    {
+      "ID": "wake-someone",
+      "Name": "wake (someone)",
+      "Description": ""
+    },
+    {
+      "ID": "fall-asleep",
+      "Name": "(fall a)sleep",
+      "Description": ""
+    },
+    {
+      "ID": "put-to-sleep",
+      "Name": "put to sleep",
+      "Description": ""
+    },
+    {
+      "ID": "be-born",
+      "Name": "be born",
+      "Description": ""
+    },
+    {
+      "ID": "give-birth",
+      "Name": "give birth, bear",
+      "Description": ""
+    },
+    {
+      "ID": "die",
+      "Name": "die",
+      "Description": ""
+    },
+    {
+      "ID": "kill",
+      "Name": "kill",
+      "Description": ""
+    },
+    {
+      "ID": "forget",
+      "Name": "forget",
+      "Description": ""
+    },
+    {
+      "ID": "distract",
+      "Name": "distract, cause to forget",
+      "Description": ""
+    },
+    {
+      "ID": "remember",
+      "Name": "remember",
+      "Description": ""
+    },
+    {
+      "ID": "remind",
+      "Name": "remind, mention, invoke",
+      "Description": ""
+    },
+    {
+      "ID": "begin-activity",
+      "Name": "begin activity",
+      "Description": ""
+    },
+    {
+      "ID": "cause-to-begin",
+      "Name": "cause to begin",
+      "Description": ""
+    },
+    {
+      "ID": "stop",
+      "Name": "stop, cease",
+      "Description": ""
+    },
+    {
+      "ID": "cause-to-stop",
+      "Name": "cause to stop, suspend",
+      "Description": ""
+    },
+    {
+      "ID": "begin",
+      "Name": "begin, start",
+      "Description": ""
+    },
+    {
+      "ID": "cause-to-start",
+      "Name": "cause to begin",
+      "Description": ""
+    },
+    {
+      "ID": "cease",
+      "Name": "stop, cease, heal",
+      "Description": ""
+    },
+    {
+      "ID": "revoke",
+      "Name": "stop, revoke, medicate",
+      "Description": ""
+    },
+    {
+      "ID": "rest",
+      "Name": "rest, stop at",
+      "Description": ""
+    },
+    {
+      "ID": "rest-tr",
+      "Name": "rest",
+      "Description": ""
+    },
+    {
+      "ID": "remain",
+      "Name": "remain",
+      "Description": ""
+    },
+    {
+      "ID": "abandon",
+      "Name": "abandon",
+      "Description": ""
+    },
+    {
+      "ID": "pass-by",
+      "Name": "pass by",
+      "Description": ""
+    },
+    {
+      "ID": "transport",
+      "Name": "pass, transfer, transport",
+      "Description": ""
+    },
+    {
+      "ID": "move",
+      "Name": "move, vibrate",
+      "Description": ""
+    },
+    {
+      "ID": "cause-to-move",
+      "Name": "cause to move, vibrate",
+      "Description": ""
+    },
+    {
+      "ID": "go",
+      "Name": "go",
+      "Description": ""
+    },
+    {
+      "ID": "take",
+      "Name": "take",
+      "Description": ""
+    },
+    {
+      "ID": "come",
+      "Name": "come (here)",
+      "Description": ""
+    },
+    {
+      "ID": "bring",
+      "Name": "bring",
+      "Description": ""
+    },
+    {
+      "ID": "arrive-here",
+      "Name": "arrive (here)",
+      "Description": ""
+    },
+    {
+      "ID": "bring-here",
+      "Name": "bring it to here",
+      "Description": ""
+    },
+    {
+      "ID": "enter",
+      "Name": "enter, intrude",
+      "Description": ""
+    },
+    {
+      "ID": "move-in",
+      "Name": "move it in(to)",
+      "Description": ""
+    },
+    {
+      "ID": "fall",
+      "Name": "fall",
+      "Description": ""
+    },
+    {
+      "ID": "fell",
+      "Name": "fell",
+      "Description": ""
+    },
+    {
+      "ID": "rise",
+      "Name": "(a)rise, ascend",
+      "Description": ""
+    },
+    {
+      "ID": "raise",
+      "Name": "raise, lift, put away",
+      "Description": ""
+    },
+    {
+      "ID": "ascend",
+      "Name": "(a)rise, ascend",
+      "Description": ""
+    },
+    {
+      "ID": "raise-2",
+      "Name": "raise",
+      "Description": ""
+    },
+    {
+      "ID": "bend",
+      "Name": "bow, bend down, bend over",
+      "Description": ""
+    },
+    {
+      "ID": "bend-tr",
+      "Name": "bend (something)",
+      "Description": ""
+    },
+    {
+      "ID": "become-bent",
+      "Name": "become bent down",
+      "Description": ""
+    },
+    {
+      "ID": "lie-down",
+      "Name": "lie down, lying down",
+      "Description": ""
+    }
+  ],
+  "FormRelationTable": [
+    {
+      "ID": "lucy1994_siit_t",
+      "Form_ID": "lucy1994_siit",
+      "Target_ID": "lucy1994_siit_t",
+      "Relation": "affective",
+      "Source": ["lucy-1994[(1a)]"]
+    },
+    {
+      "ID": "lucy1994_tziib_t",
+      "Form_ID": "lucy1994_tziib",
+      "Target_ID": "lucy1994_AFCT",
+      "Relation": "affective",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_miis_t",
+      "Form_ID": "lucy1994_miis",
+      "Target_ID": "lucy1994_AFCT",
+      "Relation": "affective",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_cheh_t",
+      "Form_ID": "lucy1994_cheh",
+      "Target_ID": "lucy1994_AFCT",
+      "Relation": "affective",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_paak_t",
+      "Form_ID": "lucy1994_paak",
+      "Target_ID": "lucy1994_AFCT",
+      "Relation": "affective",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_kuc_0",
+      "Form_ID": "lucy1994_kuc",
+      "Target_ID": "lucy1994_kuc_0",
+      "Relation": "root",
+      "Source": ["lucy-1994[(1b)]"]
+    },
+    {
+      "ID": "lucy1994_kos_0",
+      "Form_ID": "lucy1994_kos",
+      "Target_ID": "lucy1994_ROOT",
+      "Relation": "root",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_pis_0",
+      "Form_ID": "lucy1994_pis",
+      "Target_ID": "lucy1994_ROOT",
+      "Relation": "root",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_hats_0",
+      "Form_ID": "lucy1994_hats",
+      "Target_ID": "lucy1994_ROOT",
+      "Relation": "root",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_los_0",
+      "Form_ID": "lucy1994_los",
+      "Target_ID": "lucy1994_ROOT",
+      "Relation": "root",
+      "Source": ["lucy-1994[p. 629]"]
+    },
+    {
+      "ID": "lucy1994_ah_s",
+      "Form_ID": "lucy1994_ah",
+      "Target_ID": "lucy1994_ah_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_wen_s",
+      "Form_ID": "lucy1994_wen",
+      "Target_ID": "lucy1994_wen_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_siih_s",
+      "Form_ID": "lucy1994_siih",
+      "Target_ID": "lucy1994_siih_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kiim_s",
+      "Form_ID": "lucy1994_kiim",
+      "Target_ID": "lucy1994_kiim_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_tuub_s",
+      "Form_ID": "lucy1994_tuub",
+      "Target_ID": "lucy1994_tuub_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_kaah_s",
+      "Form_ID": "lucy1994_kaah",
+      "Target_ID": "lucy1994_kaah_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chuun_s",
+      "Form_ID": "lucy1994_chuun",
+      "Target_ID": "lucy1994_chuun_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_chen_s",
+      "Form_ID": "lucy1994_chen",
+      "Target_ID": "lucy1994_chen_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_hoop_s",
+      "Form_ID": "lucy1994_hoop",
+      "Target_ID": "lucy1994_hoop_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_haaw_s",
+      "Form_ID": "lucy1994_haaw",
+      "Target_ID": "lucy1994_haaw_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_heel_s",
+      "Form_ID": "lucy1994_heel",
+      "Target_ID": "lucy1994_heel_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_paat_s",
+      "Form_ID": "lucy1994_paat",
+      "Target_ID": "lucy1994_paat_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(2)]"]
+    },
+    {
+      "ID": "lucy1994_maan_s",
+      "Form_ID": "lucy1994_maan",
+      "Target_ID": "lucy1994_maan_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_peek_s",
+      "Form_ID": "lucy1994_peek",
+      "Target_ID": "lucy1994_peek_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_bin_s",
+      "Form_ID": "lucy1994_bin",
+      "Target_ID": "lucy1994_bin_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_taal_s",
+      "Form_ID": "lucy1994_taal",
+      "Target_ID": "lucy1994_taal_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_uul_s",
+      "Form_ID": "lucy1994_uul",
+      "Target_ID": "lucy1994_uul_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_ok_s",
+      "Form_ID": "lucy1994_ok",
+      "Target_ID": "lucy1994_ok_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_luub_s",
+      "Form_ID": "lucy1994_luub",
+      "Target_ID": "lucy1994_luub_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_liik_s",
+      "Form_ID": "lucy1994_liik",
+      "Target_ID": "lucy1994_liik_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_naak_s",
+      "Form_ID": "lucy1994_naak",
+      "Target_ID": "lucy1994_naak_s",
+      "Relation": "causative",
+      "Source": ["lucy-1994[(4)]"]
+    },
+    {
+      "ID": "lucy1994_cin_0",
+      "Form_ID": "lucy1994_cin",
+      "Target_ID": "lucy1994_cin_0",
+      "Relation": "root",
+      "Source": ["lucy-1994[(6)]"]
+    },
+    {
+      "ID": "lucy1994_cin_lah",
+      "Form_ID": "lucy1994_cin",
+      "Target_ID": "lucy1994_cin_lah",
+      "Relation": "positional",
+      "Source": ["lucy-1994[(5c)]"]
+    },
+    {
+      "ID": "lucy1994_cil_lah",
+      "Form_ID": "lucy1994_cil",
+      "Target_ID": "lucy1994_POS",
+      "Relation": "positional",
+      "Source": ["lucy-1994[(7)]"]
+    }
+  ]
+}

--- a/Linglib/Data/Forms/Lucy1994.lean
+++ b/Linglib/Data/Forms/Lucy1994.lean
@@ -1,0 +1,870 @@
+import Linglib.Data.Forms.Schema
+
+/-!
+# `Lucy1994` — CLDF form data
+
+Auto-generated from `Linglib/Data/Forms/Lucy1994.json` by
+`scripts/gen_forms.py`. Do not edit by hand; edit the JSON and re-run the
+generator. Consumers import this module; declarations live in
+`namespace Lucy1994.Forms`.
+-/
+
+namespace Lucy1994.Forms
+
+open Data.Forms
+
+def AFCT : Form :=
+  { id := "lucy1994_AFCT"
+    languageId := "yuca1254"
+    parameterId := "AFCT"
+    form := "=t"
+    segments := ["=t"]
+    comment := "the affective suffix, transitivising an agent-salient root"
+    source := [
+      ⟨"lucy-1994", "(1a)"⟩
+    ] }
+
+def ROOT : Form :=
+  { id := "lucy1994_ROOT"
+    languageId := "yuca1254"
+    parameterId := "ROOT"
+    form := "=∅"
+    segments := ["=∅"]
+    comment := "zero derivation: the root alone supports a transitive stem"
+    source := [
+      ⟨"lucy-1994", "(1b)"⟩
+    ] }
+
+def CAUS : Form :=
+  { id := "lucy1994_CAUS"
+    languageId := "yuca1254"
+    parameterId := "CAUS"
+    form := "=s"
+    segments := ["=s"]
+    comment := "the causative suffix, transitivising a patient-salient root"
+    source := [
+      ⟨"lucy-1994", "(1c)"⟩
+    ] }
+
+def POS : Form :=
+  { id := "lucy1994_POS"
+    languageId := "yuca1254"
+    parameterId := "POS"
+    form := "=lah"
+    segments := ["=lah"]
+    comment := "the positional derivation, =tal in the imperfective"
+    source := [
+      ⟨"lucy-1994", "(5)"⟩
+    ] }
+
+def siit : Form :=
+  { id := "lucy1994_siit"
+    languageId := "yuca1254"
+    parameterId := "jump"
+    form := "síit'"
+    segments := ["síit'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(1a)"⟩
+    ] }
+
+def siit_t : Form :=
+  { id := "lucy1994_siit_t"
+    languageId := "yuca1254"
+    parameterId := "jump-over"
+    form := "síit'=t"
+    segments := ["síit'", "=t"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(1a)"⟩
+    ] }
+
+def tziib : Form :=
+  { id := "lucy1994_tziib"
+    languageId := "yuca1254"
+    parameterId := "write"
+    form := "¢'iib'"
+    segments := ["¢'iib'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def miis : Form :=
+  { id := "lucy1994_miis"
+    languageId := "yuca1254"
+    parameterId := "sweep"
+    form := "mìis"
+    segments := ["mìis"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def cheh : Form :=
+  { id := "lucy1994_cheh"
+    languageId := "yuca1254"
+    parameterId := "smile"
+    form := "čé'eh"
+    segments := ["čé'eh"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def paak : Form :=
+  { id := "lucy1994_paak"
+    languageId := "yuca1254"
+    parameterId := "weed"
+    form := "páak"
+    segments := ["páak"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def kuc : Form :=
+  { id := "lucy1994_kuc"
+    languageId := "yuca1254"
+    parameterId := "carry"
+    form := "kuč"
+    segments := ["kuč"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(1b)"⟩
+    ] }
+
+def kuc_0 : Form :=
+  { id := "lucy1994_kuc_0"
+    languageId := "yuca1254"
+    parameterId := "carry-tr"
+    form := "kuč=∅"
+    segments := ["kuč", "=∅"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(1b)"⟩
+    ] }
+
+def kos : Form :=
+  { id := "lucy1994_kos"
+    languageId := "yuca1254"
+    parameterId := "cut"
+    form := "k'os"
+    segments := ["k'os"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def pis : Form :=
+  { id := "lucy1994_pis"
+    languageId := "yuca1254"
+    parameterId := "measure"
+    form := "p'is"
+    segments := ["p'is"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def hats : Form :=
+  { id := "lucy1994_hats"
+    languageId := "yuca1254"
+    parameterId := "whip"
+    form := "ha¢"
+    segments := ["ha¢"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def los : Form :=
+  { id := "lucy1994_los"
+    languageId := "yuca1254"
+    parameterId := "punch"
+    form := "loš"
+    segments := ["loš"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] }
+
+def ah : Form :=
+  { id := "lucy1994_ah"
+    languageId := "yuca1254"
+    parameterId := "awaken"
+    form := "'ah"
+    segments := ["'ah"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def ah_s : Form :=
+  { id := "lucy1994_ah_s"
+    languageId := "yuca1254"
+    parameterId := "wake-someone"
+    form := "'ah=s"
+    segments := ["'ah", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def wen : Form :=
+  { id := "lucy1994_wen"
+    languageId := "yuca1254"
+    parameterId := "fall-asleep"
+    form := "wen"
+    segments := ["wen"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def wen_s : Form :=
+  { id := "lucy1994_wen_s"
+    languageId := "yuca1254"
+    parameterId := "put-to-sleep"
+    form := "ween=s"
+    segments := ["ween", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def siih : Form :=
+  { id := "lucy1994_siih"
+    languageId := "yuca1254"
+    parameterId := "be-born"
+    form := "siih"
+    segments := ["siih"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def siih_s : Form :=
+  { id := "lucy1994_siih_s"
+    languageId := "yuca1254"
+    parameterId := "give-birth"
+    form := "siih=s"
+    segments := ["siih", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def kiim : Form :=
+  { id := "lucy1994_kiim"
+    languageId := "yuca1254"
+    parameterId := "die"
+    form := "kíim"
+    segments := ["kíim"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def kiim_s : Form :=
+  { id := "lucy1994_kiim_s"
+    languageId := "yuca1254"
+    parameterId := "kill"
+    form := "kíim=s"
+    segments := ["kíim", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def tuub : Form :=
+  { id := "lucy1994_tuub"
+    languageId := "yuca1254"
+    parameterId := "forget"
+    form := "tú'ub'"
+    segments := ["tú'ub'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def tuub_s : Form :=
+  { id := "lucy1994_tuub_s"
+    languageId := "yuca1254"
+    parameterId := "distract"
+    form := "tú'ub'=s"
+    segments := ["tú'ub'", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def kaah : Form :=
+  { id := "lucy1994_kaah"
+    languageId := "yuca1254"
+    parameterId := "remember"
+    form := "k'a'ah"
+    segments := ["k'a'ah"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def kaah_s : Form :=
+  { id := "lucy1994_kaah_s"
+    languageId := "yuca1254"
+    parameterId := "remind"
+    form := "k'á'ah=s"
+    segments := ["k'á'ah", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def chuun : Form :=
+  { id := "lucy1994_chuun"
+    languageId := "yuca1254"
+    parameterId := "begin-activity"
+    form := "ču'un"
+    segments := ["ču'un"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def chuun_s : Form :=
+  { id := "lucy1994_chuun_s"
+    languageId := "yuca1254"
+    parameterId := "cause-to-begin"
+    form := "ču'un=s"
+    segments := ["ču'un", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def chen : Form :=
+  { id := "lucy1994_chen"
+    languageId := "yuca1254"
+    parameterId := "stop"
+    form := "č'en"
+    segments := ["č'en"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def chen_s : Form :=
+  { id := "lucy1994_chen_s"
+    languageId := "yuca1254"
+    parameterId := "cause-to-stop"
+    form := "č'en=s"
+    segments := ["č'en", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def hoop : Form :=
+  { id := "lucy1994_hoop"
+    languageId := "yuca1254"
+    parameterId := "begin"
+    form := "hó'op'"
+    segments := ["hó'op'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def hoop_s : Form :=
+  { id := "lucy1994_hoop_s"
+    languageId := "yuca1254"
+    parameterId := "cause-to-start"
+    form := "hó'op'=s"
+    segments := ["hó'op'", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def haaw : Form :=
+  { id := "lucy1994_haaw"
+    languageId := "yuca1254"
+    parameterId := "cease"
+    form := "háaw"
+    segments := ["háaw"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def haaw_s : Form :=
+  { id := "lucy1994_haaw_s"
+    languageId := "yuca1254"
+    parameterId := "revoke"
+    form := "háaw=s"
+    segments := ["háaw", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def heel : Form :=
+  { id := "lucy1994_heel"
+    languageId := "yuca1254"
+    parameterId := "rest"
+    form := "hé'el"
+    segments := ["hé'el"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def heel_s : Form :=
+  { id := "lucy1994_heel_s"
+    languageId := "yuca1254"
+    parameterId := "rest-tr"
+    form := "hé'e(l)=s"
+    segments := ["hé'e(l)", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def paat : Form :=
+  { id := "lucy1994_paat"
+    languageId := "yuca1254"
+    parameterId := "remain"
+    form := "p'át"
+    segments := ["p'át"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def paat_s : Form :=
+  { id := "lucy1994_paat_s"
+    languageId := "yuca1254"
+    parameterId := "abandon"
+    form := "p'át=s"
+    segments := ["p'át", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] }
+
+def maan : Form :=
+  { id := "lucy1994_maan"
+    languageId := "yuca1254"
+    parameterId := "pass-by"
+    form := "máan"
+    segments := ["máan"]
+    comment := "marked # in (4): lacks the -Vl imperfective"
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def maan_s : Form :=
+  { id := "lucy1994_maan_s"
+    languageId := "yuca1254"
+    parameterId := "transport"
+    form := "maan=s"
+    segments := ["maan", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def peek : Form :=
+  { id := "lucy1994_peek"
+    languageId := "yuca1254"
+    parameterId := "move"
+    form := "péek"
+    segments := ["péek"]
+    comment := "marked # in (4): lacks the -Vl imperfective"
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def peek_s : Form :=
+  { id := "lucy1994_peek_s"
+    languageId := "yuca1254"
+    parameterId := "cause-to-move"
+    form := "pek=s"
+    segments := ["pek", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def bin : Form :=
+  { id := "lucy1994_bin"
+    languageId := "yuca1254"
+    parameterId := "go"
+    form := "b'in"
+    segments := ["b'in"]
+    comment := "marked # in (4): lacks the -Vl imperfective"
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def bin_s : Form :=
+  { id := "lucy1994_bin_s"
+    languageId := "yuca1254"
+    parameterId := "take"
+    form := "bi(n)=s"
+    segments := ["bi(n)", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def taal : Form :=
+  { id := "lucy1994_taal"
+    languageId := "yuca1254"
+    parameterId := "come"
+    form := "tàal"
+    segments := ["tàal"]
+    comment := "marked # in (4): lacks the -Vl imperfective"
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def taal_s : Form :=
+  { id := "lucy1994_taal_s"
+    languageId := "yuca1254"
+    parameterId := "bring"
+    form := "taa(l)=s"
+    segments := ["taa(l)", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def uul : Form :=
+  { id := "lucy1994_uul"
+    languageId := "yuca1254"
+    parameterId := "arrive-here"
+    form := "'ú'ul"
+    segments := ["'ú'ul"]
+    comment := "marked # in (4): lacks the -Vl imperfective"
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def uul_s : Form :=
+  { id := "lucy1994_uul_s"
+    languageId := "yuca1254"
+    parameterId := "bring-here"
+    form := "'u'uh=s"
+    segments := ["'u'uh", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def ok : Form :=
+  { id := "lucy1994_ok"
+    languageId := "yuca1254"
+    parameterId := "enter"
+    form := "'ok"
+    segments := ["'ok"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def ok_s : Form :=
+  { id := "lucy1994_ok_s"
+    languageId := "yuca1254"
+    parameterId := "move-in"
+    form := "'ook=s"
+    segments := ["'ook", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def luub : Form :=
+  { id := "lucy1994_luub"
+    languageId := "yuca1254"
+    parameterId := "fall"
+    form := "lúub'"
+    segments := ["lúub'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def luub_s : Form :=
+  { id := "lucy1994_luub_s"
+    languageId := "yuca1254"
+    parameterId := "fell"
+    form := "luub'=s"
+    segments := ["luub'", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def liik : Form :=
+  { id := "lucy1994_liik"
+    languageId := "yuca1254"
+    parameterId := "rise"
+    form := "líik'"
+    segments := ["líik'"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def liik_s : Form :=
+  { id := "lucy1994_liik_s"
+    languageId := "yuca1254"
+    parameterId := "raise"
+    form := "lii(k)'=s"
+    segments := ["lii(k)'", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def naak : Form :=
+  { id := "lucy1994_naak"
+    languageId := "yuca1254"
+    parameterId := "ascend"
+    form := "ná'ak"
+    segments := ["ná'ak"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def naak_s : Form :=
+  { id := "lucy1994_naak_s"
+    languageId := "yuca1254"
+    parameterId := "raise-2"
+    form := "na'ak=s"
+    segments := ["na'ak", "=s"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] }
+
+def cin : Form :=
+  { id := "lucy1994_cin"
+    languageId := "yuca1254"
+    parameterId := "bend"
+    form := "čin"
+    segments := ["čin"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(5)"⟩
+    ] }
+
+def cin_0 : Form :=
+  { id := "lucy1994_cin_0"
+    languageId := "yuca1254"
+    parameterId := "bend-tr"
+    form := "čin=∅"
+    segments := ["čin", "=∅"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(6)"⟩
+    ] }
+
+def cin_lah : Form :=
+  { id := "lucy1994_cin_lah"
+    languageId := "yuca1254"
+    parameterId := "become-bent"
+    form := "čin=lah"
+    segments := ["čin", "=lah"]
+    comment := "=tal in the imperfective (5a)"
+    source := [
+      ⟨"lucy-1994", "(5c)"⟩
+    ] }
+
+def cil : Form :=
+  { id := "lucy1994_cil"
+    languageId := "yuca1254"
+    parameterId := "lie-down"
+    form := "čil"
+    segments := ["čil"]
+    comment := ""
+    source := [
+      ⟨"lucy-1994", "(7)"⟩
+    ] }
+
+def all : List Form := [AFCT, ROOT, CAUS, POS, siit, siit_t, tziib, miis, cheh, paak, kuc, kuc_0, kos, pis, hats, los, ah, ah_s, wen, wen_s, siih, siih_s, kiim, kiim_s, tuub, tuub_s, kaah, kaah_s, chuun, chuun_s, chen, chen_s, hoop, hoop_s, haaw, haaw_s, heel, heel_s, paat, paat_s, maan, maan_s, peek, peek_s, bin, bin_s, taal, taal_s, uul, uul_s, ok, ok_s, luub, luub_s, liik, liik_s, naak, naak_s, cin, cin_0, cin_lah, cil]
+
+def parameters : List Parameter := [
+  { id := "AFCT", name := "affective derivation", description := "" },
+  { id := "ROOT", name := "root transitive", description := "" },
+  { id := "CAUS", name := "causative derivation", description := "" },
+  { id := "POS", name := "positional derivation", description := "" },
+  { id := "jump", name := "jump", description := "" },
+  { id := "jump-over", name := "jump (over)", description := "" },
+  { id := "write", name := "write", description := "" },
+  { id := "sweep", name := "sweep", description := "" },
+  { id := "smile", name := "smile", description := "" },
+  { id := "weed", name := "weed", description := "" },
+  { id := "carry", name := "carry", description := "" },
+  { id := "carry-tr", name := "carry (someone)", description := "" },
+  { id := "cut", name := "cut", description := "" },
+  { id := "measure", name := "measure", description := "" },
+  { id := "whip", name := "whip", description := "" },
+  { id := "punch", name := "punch", description := "" },
+  { id := "awaken", name := "(a)wake(n)", description := "" },
+  { id := "wake-someone", name := "wake (someone)", description := "" },
+  { id := "fall-asleep", name := "(fall a)sleep", description := "" },
+  { id := "put-to-sleep", name := "put to sleep", description := "" },
+  { id := "be-born", name := "be born", description := "" },
+  { id := "give-birth", name := "give birth, bear", description := "" },
+  { id := "die", name := "die", description := "" },
+  { id := "kill", name := "kill", description := "" },
+  { id := "forget", name := "forget", description := "" },
+  { id := "distract", name := "distract, cause to forget", description := "" },
+  { id := "remember", name := "remember", description := "" },
+  { id := "remind", name := "remind, mention, invoke", description := "" },
+  { id := "begin-activity", name := "begin activity", description := "" },
+  { id := "cause-to-begin", name := "cause to begin", description := "" },
+  { id := "stop", name := "stop, cease", description := "" },
+  { id := "cause-to-stop", name := "cause to stop, suspend", description := "" },
+  { id := "begin", name := "begin, start", description := "" },
+  { id := "cause-to-start", name := "cause to begin", description := "" },
+  { id := "cease", name := "stop, cease, heal", description := "" },
+  { id := "revoke", name := "stop, revoke, medicate", description := "" },
+  { id := "rest", name := "rest, stop at", description := "" },
+  { id := "rest-tr", name := "rest", description := "" },
+  { id := "remain", name := "remain", description := "" },
+  { id := "abandon", name := "abandon", description := "" },
+  { id := "pass-by", name := "pass by", description := "" },
+  { id := "transport", name := "pass, transfer, transport", description := "" },
+  { id := "move", name := "move, vibrate", description := "" },
+  { id := "cause-to-move", name := "cause to move, vibrate", description := "" },
+  { id := "go", name := "go", description := "" },
+  { id := "take", name := "take", description := "" },
+  { id := "come", name := "come (here)", description := "" },
+  { id := "bring", name := "bring", description := "" },
+  { id := "arrive-here", name := "arrive (here)", description := "" },
+  { id := "bring-here", name := "bring it to here", description := "" },
+  { id := "enter", name := "enter, intrude", description := "" },
+  { id := "move-in", name := "move it in(to)", description := "" },
+  { id := "fall", name := "fall", description := "" },
+  { id := "fell", name := "fell", description := "" },
+  { id := "rise", name := "(a)rise, ascend", description := "" },
+  { id := "raise", name := "raise, lift, put away", description := "" },
+  { id := "ascend", name := "(a)rise, ascend", description := "" },
+  { id := "raise-2", name := "raise", description := "" },
+  { id := "bend", name := "bow, bend down, bend over", description := "" },
+  { id := "bend-tr", name := "bend (something)", description := "" },
+  { id := "become-bent", name := "become bent down", description := "" },
+  { id := "lie-down", name := "lie down, lying down", description := "" }
+]
+
+def relations : List FormRelation := [
+  { id := "lucy1994_siit_t", formId := "lucy1994_siit", targetId := "lucy1994_siit_t", relation := "affective", source := [
+      ⟨"lucy-1994", "(1a)"⟩
+    ] },
+  { id := "lucy1994_tziib_t", formId := "lucy1994_tziib", targetId := "lucy1994_AFCT", relation := "affective", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_miis_t", formId := "lucy1994_miis", targetId := "lucy1994_AFCT", relation := "affective", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_cheh_t", formId := "lucy1994_cheh", targetId := "lucy1994_AFCT", relation := "affective", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_paak_t", formId := "lucy1994_paak", targetId := "lucy1994_AFCT", relation := "affective", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_kuc_0", formId := "lucy1994_kuc", targetId := "lucy1994_kuc_0", relation := "root", source := [
+      ⟨"lucy-1994", "(1b)"⟩
+    ] },
+  { id := "lucy1994_kos_0", formId := "lucy1994_kos", targetId := "lucy1994_ROOT", relation := "root", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_pis_0", formId := "lucy1994_pis", targetId := "lucy1994_ROOT", relation := "root", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_hats_0", formId := "lucy1994_hats", targetId := "lucy1994_ROOT", relation := "root", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_los_0", formId := "lucy1994_los", targetId := "lucy1994_ROOT", relation := "root", source := [
+      ⟨"lucy-1994", "p. 629"⟩
+    ] },
+  { id := "lucy1994_ah_s", formId := "lucy1994_ah", targetId := "lucy1994_ah_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_wen_s", formId := "lucy1994_wen", targetId := "lucy1994_wen_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_siih_s", formId := "lucy1994_siih", targetId := "lucy1994_siih_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_kiim_s", formId := "lucy1994_kiim", targetId := "lucy1994_kiim_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_tuub_s", formId := "lucy1994_tuub", targetId := "lucy1994_tuub_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_kaah_s", formId := "lucy1994_kaah", targetId := "lucy1994_kaah_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_chuun_s", formId := "lucy1994_chuun", targetId := "lucy1994_chuun_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_chen_s", formId := "lucy1994_chen", targetId := "lucy1994_chen_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_hoop_s", formId := "lucy1994_hoop", targetId := "lucy1994_hoop_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_haaw_s", formId := "lucy1994_haaw", targetId := "lucy1994_haaw_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_heel_s", formId := "lucy1994_heel", targetId := "lucy1994_heel_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_paat_s", formId := "lucy1994_paat", targetId := "lucy1994_paat_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(2)"⟩
+    ] },
+  { id := "lucy1994_maan_s", formId := "lucy1994_maan", targetId := "lucy1994_maan_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_peek_s", formId := "lucy1994_peek", targetId := "lucy1994_peek_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_bin_s", formId := "lucy1994_bin", targetId := "lucy1994_bin_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_taal_s", formId := "lucy1994_taal", targetId := "lucy1994_taal_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_uul_s", formId := "lucy1994_uul", targetId := "lucy1994_uul_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_ok_s", formId := "lucy1994_ok", targetId := "lucy1994_ok_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_luub_s", formId := "lucy1994_luub", targetId := "lucy1994_luub_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_liik_s", formId := "lucy1994_liik", targetId := "lucy1994_liik_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_naak_s", formId := "lucy1994_naak", targetId := "lucy1994_naak_s", relation := "causative", source := [
+      ⟨"lucy-1994", "(4)"⟩
+    ] },
+  { id := "lucy1994_cin_0", formId := "lucy1994_cin", targetId := "lucy1994_cin_0", relation := "root", source := [
+      ⟨"lucy-1994", "(6)"⟩
+    ] },
+  { id := "lucy1994_cin_lah", formId := "lucy1994_cin", targetId := "lucy1994_cin_lah", relation := "positional", source := [
+      ⟨"lucy-1994", "(5c)"⟩
+    ] },
+  { id := "lucy1994_cil_lah", formId := "lucy1994_cil", targetId := "lucy1994_POS", relation := "positional", source := [
+      ⟨"lucy-1994", "(7)"⟩
+    ] }
+]
+
+end Lucy1994.Forms

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -1,52 +1,39 @@
 import Linglib.Semantics.Root.Defs
 import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Morphology.Exponence.Select
+import Linglib.Data.Forms.Lucy1994
 
 /-!
 # Lucy (1994): The Role of Semantic Value in Lexical Comparison
 
-This file formalizes the morpho-distributional diagnostic of [lucy-1994], who argues that
-lexical classes must be identified
-*morpho-distributionally*, not denotationally: the notional class "motion
-verbs", assembled by English intuition, coincides with no morphologically
-defined Yucatec class. The diagnostic is which derivation a root requires
-to form a transitive stem:
-
-| Derivation | Predicate root class (p. 630) | Size (p. 629) |
-|------------|-------------------------------|----------------|
-| `=t` (affective) | agent salient          | well over 100  |
-| `=∅` (zero)      | agent-patient salient  | some 500       |
-| `=s` (causative) | patient salient        | fewer than 75  |
-
-Positional roots (over 100) fall outside this three-way cut: they take the
-positional derivation `=lah` (incompletive `=tal`) and are formally
-interstitial — *čin* 'bend' also zero-derives a transitive (ex. (6)).
-Notional motion roots land in the *smallest* predicate class, patient
-salient (ex. (4)); at best the five `#`-marked roots lacking the `-Vl`
-imperfective form "a formal class of 'motion verbs'" (p. 641), a
-distinction invisible to the entailment grid.
+This file formalizes the morpho-distributional diagnostic of [lucy-1994]: the lexical classes
+of a language are to be identified by their morphology rather than by notional content, and
+the notional class of motion verbs, assembled from English intuition, coincides with no
+morphologically defined class of Yucatec. The diagnostic is the derivation a root requires to
+form a transitive stem, the affective suffix *=t* for agent-salient roots, no derivation for
+agent-patient-salient roots, and the causative suffix *=s* for patient-salient roots
+(`affectiveT`, `zeroDeriv`, `causativeS`), salience being a set of default semantic values in
+a root that influence case marking. Roots are encoded by their entailment signature and their
+valency after [beavers-koontz-garboden-2020] and [coon-2019], the classifier is the substrate's
+`ArgumentStructure.SalienceClass.ofKinds`, and the derivations predicted from the encoding
+reproduce every derivation the paper attests (`predicted_matches_attested`), the attestations
+being the form relations of `Data/Forms/Lucy1994`. Notional motion roots land in the
+patient-salient class, each classified as *kíim* 'die' is (`motion_roots_not_separate_class`);
+at best the roots lacking the *-Vl* imperfective form a formal class of motion verbs, a
+distinction invisible to the entailment grid (`hash_not_signature_definable`). Positional
+roots, which take the positional derivation *=lah*, cross-cut the transitiviser classes, *čin*
+'bend' also zero-deriving a transitive (`positional_crosscuts_transitiviser_classes`), and each
+class's derivation adds the complement of its underived stem's valency
+(`transitiviser_adds_compl`).
 
 ## Implementation notes
 
-The reconstruction is two-dimensional — B&K-G kind signature × root
-valency ([beavers-koontz-garboden-2020]; [coon-2019]; both postdate Lucy
-and serve as project-canonical substrate). Valency carries the
-agent-patient class: Lucy's `=∅` roots "require two arguments" (p. 629)
-and are not signature-homogeneous (*p'is* 'measure' is manner-only,
-*k'os* 'cut' manner+result), so no feature configuration could carry the
-class. The
-signature separates the two intransitive classes, matching the Sapir 1917
-~ Fillmore 1968 ~ Perlmutter 1978 unaccusativity lineage Lucy cites
-(p. 630). "Salience" is Lucy's term for "a set of default semantic values
-in a root or stem that influence an overt case marking" (p. 628). Root
-name strings follow Lucy's orthography. The `=t` class is inflated by
-denominal and loanword verbalization (p. 629), so `=t` applicability is a
-weaker signal of manner entailments than `=∅` or `=s` are of theirs.
-
-The salience classes and the pair-level classifier
-(`ArgumentStructure.SalienceClass.ofKinds`) are substrate
-(`Semantics/ArgumentStructure/SalienceClass.lean`); this file supplies the
-Yucatec roots, diagnostic operators, and attested derivations.
+The agent-patient class is carried by valency rather than by a signature, since its roots
+share none: *p'is* 'measure' is manner-only and *k'os* 'cut' manner and result. The affective
+class is inflated by denominal and loanword verbalization, so *=t* is a weaker signal of manner
+entailments than the other two derivations are of theirs. Root spellings are the paper's, read
+from the form rows; the class sizes and the two-way split of intransitives the paper aligns
+with the unaccusativity tradition are described in prose.
 
 ## References
 
@@ -57,170 +44,165 @@ Yucatec roots, diagnostic operators, and attested derivations.
 
 namespace Lucy1994
 
-open Semantics ArgumentStructure Morphology
+open Semantics ArgumentStructure Morphology Data.Forms
 
-/-! ### Agent-salient roots (p. 629, ex. (1a)) -/
+/-- A root of the sample: a form's spelling with its entailment signature. -/
+private def ofForm (f : Form) (entailments : Finset Root.Entailment) : Root :=
+  { name := f.form, entailments := entailments }
 
-/-- síit' 'jump' (ex. (1a)). -/
-def siit : Root := { name := "síit'", entailments := {.manner "jumping"} }
+/-! ### Agent-salient roots ((1a), p. 629) -/
+
+/-- síit' 'jump' (1a). -/
+def siit : Root := ofForm Forms.siit {.manner "jumping"}
 
 /-- ¢'iib' 'write' (p. 629). -/
-def tziib : Root := { name := "¢'iib'", entailments := {.manner "writing"} }
+def tziib : Root := ofForm Forms.tziib {.manner "writing"}
 
-/-- mìis 'sweep' (p. 629); denominal from 'broom'. -/
-def miis : Root := { name := "mìis", entailments := {.manner "sweeping"} }
+/-- mìis 'sweep' (p. 629), denominal from 'broom'. -/
+def miis : Root := ofForm Forms.miis {.manner "sweeping"}
 
 /-- čé'eh 'smile' (p. 629). -/
-def cheh : Root := { name := "čé'eh", entailments := {.manner "smiling"} }
+def cheh : Root := ofForm Forms.cheh {.manner "smiling"}
 
 /-- páak 'weed' (p. 629). -/
-def paak : Root := { name := "páak", entailments := {.manner "weeding"} }
+def paak : Root := ofForm Forms.paak {.manner "weeding"}
 
-/-! ### Agent-patient salient roots (p. 629, ex. (1b))
+/-! ### Agent-patient-salient roots ((1b), p. 629)
 
-Root transitives. They carry no uniform signature: *kuč*, *p'is*, *ha¢*,
-*loš* are manner-only (surface contact without entailed result, B&K-G's
-*hit* type), while *k'os* 'cut' is manner+result (their *cut* type). -/
+Root transitives, carrying no uniform signature: *kuč*, *p'is*, *ha¢* and *loš* are manner-only,
+surface contact without an entailed result, while *k'os* 'cut' is manner and result. -/
 
-/-- kuč 'carry' (ex. (1b)). -/
-def kuc : Root := { name := "kuč", entailments := {.manner "carrying"} }
+/-- kuč 'carry' (1b). -/
+def kuc : Root := ofForm Forms.kuc {.manner "carrying"}
 
-/-- k'os 'cut' (p. 629); manner+result. -/
-def kos : Root :=
-  { name := "k'os", entailments := {.manner "cutting", .result "cut"} }
+/-- k'os 'cut' (p. 629), manner and result. -/
+def kos : Root := ofForm Forms.kos {.manner "cutting", .result "cut"}
 
-/-- p'is 'measure' (p. 629); no entailed change of state. -/
-def pis : Root := { name := "p'is", entailments := {.manner "measuring"} }
+/-- p'is 'measure' (p. 629), no entailed change of state. -/
+def pis : Root := ofForm Forms.pis {.manner "measuring"}
 
 /-- ha¢ 'whip' (p. 629). -/
-def hats : Root := { name := "ha¢", entailments := {.manner "whipping"} }
+def hats : Root := ofForm Forms.hats {.manner "whipping"}
 
-/-- loš 'punch' (p. 629); surface contact without entailed result. -/
-def los : Root := { name := "loš", entailments := {.manner "striking"} }
+/-- loš 'punch' (p. 629), surface contact without an entailed result. -/
+def los : Root := ofForm Forms.los {.manner "striking"}
 
-/-! ### Patient-salient roots (ex. (2), pp. 629–630)
+/-! ### Patient-salient roots ((2), pp. 629–630)
 
-Lucy's list (2) is arranged in antonym pairs "listed in vertical
-adjacency" (fn. 7): 'ah ~ wen, siih ~ kíim, tú'ub' ~ k'a'ah, ču'un ~
-č'en, hó'op' ~ háaw. The order below is the list's. -/
+List (2) is arranged in antonym pairs listed in vertical adjacency: 'ah ~ wen, siih ~ kíim,
+tú'ub' ~ k'a'ah, ču'un ~ č'en, hó'op' ~ háaw. The order below is the list's. -/
 
-/-- 'ah '(a)wake(n)' ('ah=s 'wake (someone)'). -/
-def ah : Root := { name := "'ah", entailments := {.result "awake"} }
+/-- 'ah '(a)wake(n)', 'ah=s 'wake (someone)'. -/
+def ah : Root := ofForm Forms.ah {.result "awake"}
 
-/-- wen '(fall a)sleep' (ween=s 'put to sleep'); fn. 7 flags it as also
-    denoting continuation in the state. -/
-def wen : Root := { name := "wen", entailments := {.result "asleep"} }
+/-- wen '(fall a)sleep', ween=s 'put to sleep'; fn. 7 flags it as also denoting continuation in
+the state. -/
+def wen : Root := ofForm Forms.wen {.result "asleep"}
 
-/-- siih 'be born' (siih=s 'give birth, bear'). -/
-def siih : Root := { name := "siih", entailments := {.result "born"} }
+/-- siih 'be born', siih=s 'give birth, bear'. -/
+def siih : Root := ofForm Forms.siih {.result "born"}
 
-/-- kíim 'die' (ex. (1c); kíim=s 'kill'). -/
-def kiim : Root := { name := "kíim", entailments := {.result "dead"} }
+/-- kíim 'die' (1c), kíim=s 'kill'. -/
+def kiim : Root := ofForm Forms.kiim {.result "dead"}
 
-/-- tú'ub' 'forget' (tú'ub'=s 'distract, cause to forget'). -/
-def tuub : Root := { name := "tú'ub'", entailments := {.result "forgotten"} }
+/-- tú'ub' 'forget', tú'ub'=s 'distract, cause to forget'. -/
+def tuub : Root := ofForm Forms.tuub {.result "forgotten"}
 
-/-- k'a'ah 'remember' (k'á'ah=s 'remind, mention, invoke'). -/
-def kaah : Root := { name := "k'a'ah", entailments := {.result "remembered"} }
+/-- k'a'ah 'remember', k'á'ah=s 'remind, mention, invoke'. -/
+def kaah : Root := ofForm Forms.kaah {.result "remembered"}
 
-/-- ču'un 'begin activity' (ču'un=s 'cause to begin'). -/
-def chuun : Root := { name := "ču'un", entailments := {.result "begun"} }
+/-- ču'un 'begin activity', ču'un=s 'cause to begin'. -/
+def chuun : Root := ofForm Forms.chuun {.result "begun"}
 
-/-- č'en 'stop, cease' (č'en=s 'cause to stop, suspend'). -/
-def chen : Root := { name := "č'en", entailments := {.result "ceased"} }
+/-- č'en 'stop, cease', č'en=s 'cause to stop, suspend'. -/
+def chen : Root := ofForm Forms.chen {.result "ceased"}
 
-/-- hó'op' 'begin, start' (hó'op'=s 'cause to begin'). -/
-def hoop : Root := { name := "hó'op'", entailments := {.result "started"} }
+/-- hó'op' 'begin, start', hó'op'=s 'cause to begin'. -/
+def hoop : Root := ofForm Forms.hoop {.result "started"}
 
-/-- háaw 'stop, cease, heal' (háaw=s 'stop, revoke, medicate'). -/
-def haaw : Root := { name := "háaw", entailments := {.result "stopped"} }
+/-- háaw 'stop, cease, heal', háaw=s 'stop, revoke, medicate'. -/
+def haaw : Root := ofForm Forms.haaw {.result "stopped"}
 
-/-- hé'el 'rest, stop at' (hé'e(l)=s 'rest'). -/
-def heel : Root := { name := "hé'el", entailments := {.result "rested"} }
+/-- hé'el 'rest, stop at', hé'e(l)=s 'rest'. -/
+def heel : Root := ofForm Forms.heel {.result "rested"}
 
-/-- p'át 'remain' (p'át=s 'abandon'). -/
-def paat : Root := { name := "p'át", entailments := {.result "remaining"} }
+/-- p'át 'remain', p'át=s 'abandon'. -/
+def paat : Root := ofForm Forms.paat {.result "remaining"}
 
-/-! ### Motion roots (ex. (4), p. 640)
+/-! ### Motion roots ((4), p. 640)
 
-"Locational-spatial state-change predicates": notionally motion, formally
-plain members of the patient-salient class. The five `#`-marked roots
-"do not — and CANNOT — take the `-Vl` suffix in the imperfective"; fn. 17
-adds that *péek* and *'ú'ul* are also irregular in their agent-focused
-perfective forms, "where they pattern like agent-salient roots". -/
+Locational-spatial state-change predicates: notionally motion, formally plain members of the
+patient-salient class. The five roots marked `#` do not, and cannot, take the *-Vl* suffix in
+the imperfective; fn. 17 adds that *péek* and *'ú'ul* are also irregular in their agent-focused
+perfective forms, where they pattern like agent-salient roots. -/
 
-/-- máan 'pass by' (`#`; máan=s 'pass, transfer, transport'). -/
-def maan : Root := { name := "máan", entailments := {.result "past"} }
+/-- máan 'pass by' (`#`), maan=s 'pass, transfer, transport'. -/
+def maan : Root := ofForm Forms.maan {.result "past"}
 
-/-- péek 'move, vibrate' (`#`; pek=s 'cause to move, vibrate'). -/
-def peek : Root := { name := "péek", entailments := {.result "in-motion"} }
+/-- péek 'move, vibrate' (`#`), pek=s 'cause to move, vibrate'. -/
+def peek : Root := ofForm Forms.peek {.result "in-motion"}
 
-/-- b'in 'go' (`#`; bi(n)=s 'take'). -/
-def bin : Root := { name := "b'in", entailments := {.result "gone"} }
+/-- b'in 'go' (`#`), bi(n)=s 'take'. -/
+def bin : Root := ofForm Forms.bin {.result "gone"}
 
-/-- tàal 'come (here)' (`#`; tàa(l)=s 'bring'). -/
-def taal : Root := { name := "tàal", entailments := {.result "come"} }
+/-- tàal 'come (here)' (`#`), taa(l)=s 'bring'. -/
+def taal : Root := ofForm Forms.taal {.result "come"}
 
-/-- 'ú'ul 'arrive (here)' (`#`; 'ú'uh=s 'bring it to here'). -/
-def uul : Root := { name := "'ú'ul", entailments := {.result "arrived"} }
+/-- 'ú'ul 'arrive (here)' (`#`), 'u'uh=s 'bring it to here'. -/
+def uul : Root := ofForm Forms.uul {.result "arrived"}
 
-/-- 'ok 'enter, intrude' ('òok=s 'move it in(to)'). -/
-def ok : Root := { name := "'ok", entailments := {.result "inside"} }
+/-- 'ok 'enter, intrude', 'ook=s 'move it in(to)'. -/
+def ok : Root := ofForm Forms.ok {.result "inside"}
 
-/-- lúub' 'fall' (lúub'=s 'fell'). -/
-def luub : Root := { name := "lúub'", entailments := {.result "fallen"} }
+/-- lúub' 'fall', luub'=s 'fell'. -/
+def luub : Root := ofForm Forms.luub {.result "fallen"}
 
-/-- líik' '(a)rise, ascend' (lii(k)'=s 'raise, lift, put away'). -/
-def liik : Root := { name := "líik'", entailments := {.result "risen"} }
+/-- líik' '(a)rise, ascend', lii(k)'=s 'raise, lift, put away'. -/
+def liik : Root := ofForm Forms.liik {.result "risen"}
 
-/-- ná'ak '(a)rise, ascend' (ná'ak=s 'raise'); distinct from náak
-    'arrive, reach, hit', not sampled here. -/
-def naak : Root := { name := "ná'ak", entailments := {.result "ascended"} }
+/-- ná'ak '(a)rise, ascend', na'ak=s 'raise'; distinct from náak 'arrive, reach, hit', not
+sampled here. -/
+def naak : Root := ofForm Forms.naak {.result "ascended"}
 
-/-! ### Positional roots (ex. (7), p. 643) -/
+/-! ### Positional roots ((5) to (7), pp. 642–644) -/
 
-/-- čin 'bow, bend down, bend over' (ex. (5)–(7)); zero-derives a
-    transitive, ex. (6) 'I bent it'. -/
-def cin : Root := { name := "čin", entailments := {.state "bent"} }
+/-- čin 'bow, bend down, bend over' ((5) to (7)); zero-derives a transitive, (6) 'I bent it'. -/
+def cin : Root := ofForm Forms.cin {.state "bent"}
 
-/-- kul 'sit' (p. 645, fn. 24: relational 'x is-seated [on y]'). -/
-def kul : Root := { name := "kul", entailments := {.state "seated"} }
+/-- čil 'lie down, lying down' (7). -/
+def cil : Root := ofForm Forms.cil {.state "lying"}
 
 /-! ### Valency and class lists -/
 
-/-- Roots attested forming a transitive stem by zero derivation: the
-    sampled `=∅` predicate roots (p. 629) plus the positional *čin*
-    (ex. (6)). -/
+/-- The roots attested forming a transitive stem by zero derivation: the sampled `=∅` predicate
+roots (p. 629) and the positional *čin* (6). -/
 def rootTransitives : List Root := [kuc, kos, pis, hats, los, cin]
 
-/-- Root valency for the sample ([coon-2019]'s √TV as `{.internal}`):
-    zero-derivers introduce their internal argument; every other sampled
-    root introduces none. Sample-local — the assignment defaults to `∅`
-    off the sample. -/
+/-- Root valency for the sample, [coon-2019]'s √TV as `{.internal}`: zero-derivers introduce
+their internal argument, every other sampled root none. -/
 def valency (r : Root) : Valency :=
   if r ∈ rootTransitives then {.internal} else ∅
 
 /-- The sampled agent-salient roots. -/
 def agentSalientRoots : List Root := [siit, tziib, miis, cheh, paak]
 
-/-- The sampled agent-patient salient (`=∅` predicate) roots. -/
+/-- The sampled agent-patient-salient roots. -/
 def agentPatientSalientRoots : List Root := [kuc, kos, pis, hats, los]
 
-/-- The sampled patient-salient roots of list (2), in Lucy's order. -/
+/-- The sampled patient-salient roots of list (2), in the list's order. -/
 def patientSalientRoots : List Root :=
   [ah, wen, siih, kiim, tuub, kaah, chuun, chen, hoop, haaw, heel, paat]
 
-/-- The sampled motion roots of ex. (4). -/
+/-- The sampled motion roots of (4). -/
 def motionRoots : List Root :=
   [maan, peek, bin, taal, uul, ok, luub, liik, naak]
 
-/-- The `#`-marked subset of ex. (4): the roots lacking the `-Vl`
-    imperfective — for Lucy, the only candidate "formal class of 'motion
-    verbs'" (p. 641). -/
+/-- The `#`-marked subset of (4), the roots lacking the *-Vl* imperfective: for the paper, the
+only candidate formal class of motion verbs (p. 641). -/
 def hashMarked : List Root := [maan, peek, bin, taal, uul]
 
 /-- The sampled positional roots. -/
-def positionalRoots : List Root := [cin, kul]
+def positionalRoots : List Root := [cin, cil]
 
 /-- Every sampled root. -/
 def sampledRoots : List Root :=
@@ -229,16 +211,13 @@ def sampledRoots : List Root :=
 
 /-! ### Diagnostic operators -/
 
-/-- A diagnostic derivational operator: exponent plus structural
-    applicability condition, with bundled decidability so profiles
-    compute (the inventory holds heterogeneous conditions, so a
-    per-operator instance cannot serve). Selection machinery comes from
-    the `Morphology.Exponence.Rule` instance. -/
+/-- A diagnostic derivational operator: its exponent, the core-argument positions it adds, and
+its structural applicability condition with bundled decidability, since the inventory holds
+heterogeneous conditions. Selection comes from the `Morphology.Exponence.Rule` instance. -/
 structure DiagOp where
-  /-- The suffix, in Lucy's orthography. -/
+  /-- The suffix, in the paper's orthography. -/
   exponent : String
-  /-- The core-argument positions the derivation adds
-      (`transitiviser_adds_compl`). -/
+  /-- The core-argument positions the derivation adds (`transitiviser_adds_compl`). -/
   adds : Valency
   /-- The structural condition on the root. -/
   Applies : Root → Prop
@@ -255,61 +234,48 @@ instance : DecidableRel (Exponence.Applies : DiagOp → Root → Prop) :=
 @[simp] theorem applies_iff (op : DiagOp) (r : Root) :
     Exponence.Applies op r ↔ op.Applies r := Iff.rfl
 
-/-- Affective `=t`: transitivises an agent-salient root by adding a
-    patient argument. -/
+/-- Affective *=t*: transitivises an agent-salient root by adding a patient argument. -/
 def affectiveT : DiagOp :=
   ⟨"=t", {.internal}, λ r => IsAgentSalient r.kinds (valency r), inferInstance⟩
 
-/-- Zero derivation `=∅`: the root alone supports a transitive stem. -/
+/-- Zero derivation *=∅*: the root alone supports a transitive stem. -/
 def zeroDeriv : DiagOp :=
   ⟨"=∅", ∅, λ r => .internal ∈ valency r, inferInstance⟩
 
-/-- Causative `=s`: transitivises a patient-salient root by adding an
-    agent argument. -/
+/-- Causative *=s*: transitivises a patient-salient root by adding an agent argument. -/
 def causativeS : DiagOp :=
   ⟨"=s", {.external}, λ r => IsPatientSalient r.kinds (valency r), inferInstance⟩
 
-/-- Positional derivation, realized `=lah` ~ `=tal` by status (the
-    `=tal` incompletive is the anomalous member, apparently compounding
-    with *tàal* 'come'). -/
+/-- The positional derivation, realized *=lah* ~ *=tal* by status, the *=tal* incompletive
+apparently compounding with *tàal* 'come' (p. 643). -/
 def positionalLah : DiagOp :=
   ⟨"=lah", ∅, λ r => IsPositional r.kinds, inferInstance⟩
 
-/-- The diagnostic inventory, in the order of Lucy's presentation:
-    the three transitivisers of ex. (1), then the positional. -/
+/-- The diagnostic inventory, in the paper's order: the three transitivisers of (1), then the
+positional derivation. -/
 def inventory : List DiagOp :=
   [affectiveT, zeroDeriv, causativeS, positionalLah]
 
-/-- The exponents of the inventory's applicable operators at `r`, in
-    inventory order — the root's predicted derivational behaviour. -/
+/-- The exponents of the inventory's applicable operators at `r`, in inventory order: the root's
+predicted derivational behaviour. -/
 def predictedExponents (r : Root) : List String :=
   (Exponence.applicable inventory r).map DiagOp.exponent
 
-/-! ### Predicted vs attested derivations -/
+/-! ### Predicted against attested derivations -/
 
-/-- The derivations Lucy attests per sampled root: `=t` for the p. 629
-    activity roots, `=∅` for the root transitives, `=s` for lists (2)
-    and (4), `=lah` for positionals — with *čin* attested for both `=∅`
-    (ex. (6)) and `=lah` (ex. (5)). -/
-def attestations : List (Root × List String) :=
-  [ (siit, ["=t"]), (tziib, ["=t"]), (miis, ["=t"]), (cheh, ["=t"]),
-    (paak, ["=t"]),
-    (kuc, ["=∅"]), (kos, ["=∅"]), (pis, ["=∅"]), (hats, ["=∅"]),
-    (los, ["=∅"]),
-    (ah, ["=s"]), (wen, ["=s"]), (siih, ["=s"]), (kiim, ["=s"]),
-    (tuub, ["=s"]), (kaah, ["=s"]), (chuun, ["=s"]), (chen, ["=s"]),
-    (hoop, ["=s"]), (haaw, ["=s"]), (heel, ["=s"]), (paat, ["=s"]),
-    (maan, ["=s"]), (peek, ["=s"]), (bin, ["=s"]), (taal, ["=s"]),
-    (uul, ["=s"]), (ok, ["=s"]), (luub, ["=s"]), (liik, ["=s"]),
-    (naak, ["=s"]),
-    (cin, ["=∅", "=lah"]), (kul, ["=lah"]) ]
+/-- The form row with a given identifier. -/
+def form? (id : String) : Option Form := Forms.all.find? (·.id == id)
 
-/-- The derivations predicted from (signature × valency) reproduce every
-    derivation Lucy attests. Unlike the classifier theorems below, this
-    check is against a column transcribed from the paper, independent of
-    the encoding. -/
-theorem predicted_matches_attested :
-    ∀ p ∈ attestations, predictedExponents p.1 = p.2 := by decide
+/-- The derivations the paper attests for a root: the final segment of each form the root's row
+is related to, a derived stem or the bare derivational morpheme. -/
+def attested (r : Root) : List String :=
+  (Forms.relations.filter λ rel => (form? rel.formId).any (·.form == r.name)).filterMap
+    λ rel => (form? rel.targetId).bind (·.segments.getLast?)
+
+/-- The derivations predicted from signature and valency reproduce every derivation the paper
+attests. -/
+theorem predicted_matches_attested : ∀ r ∈ sampledRoots, predictedExponents r = attested r := by
+  decide
 
 /-! ### The derived classification -/
 
@@ -323,10 +289,9 @@ def exponentOf : SalienceClass → String
   | .agentPatient => "=∅"
   | .patient => "=s"
 
-/-- Predicted derivational behaviour decomposes as the class's
-    transitiviser followed by the positional derivation when the
-    signature licenses it — the applicability profile *is* the
-    classification, plus the cross-cutting positional diagnostic. -/
+/-- Predicted derivational behaviour decomposes as the class's transitiviser followed by the
+positional derivation when the signature licenses it: the applicability profile is the
+classification, plus the cross-cutting positional diagnostic. -/
 theorem predictedExponents_eq (r : Root) :
     predictedExponents r =
       (predictedClass r).toList.map exponentOf ++
@@ -344,42 +309,35 @@ theorem agentSalient_class :
     ∀ r ∈ agentSalientRoots, predictedClass r = some .agent := by decide
 
 theorem agentPatientSalient_class :
-    ∀ r ∈ agentPatientSalientRoots,
-      predictedClass r = some .agentPatient := by decide
+    ∀ r ∈ agentPatientSalientRoots, predictedClass r = some .agentPatient := by decide
 
 theorem patientSalient_class :
     ∀ r ∈ patientSalientRoots, predictedClass r = some .patient := by decide
 
-/-- The `=∅` class is not signature-homogeneous (*p'is* manner-only vs
-    *k'os* manner+result) — root transitivity is carried by valency, not
-    by any feature configuration. -/
+/-- The `=∅` class is not signature-homogeneous, *p'is* manner-only against *k'os* manner and
+result: root transitivity is carried by valency, not by any feature configuration. -/
 theorem rootTransitives_not_signature_uniform :
-    ∃ r ∈ agentPatientSalientRoots, ∃ r' ∈ agentPatientSalientRoots,
-      r.kinds ≠ r'.kinds := by decide
+    ∃ r ∈ agentPatientSalientRoots, ∃ r' ∈ agentPatientSalientRoots, r.kinds ≠ r'.kinds := by
+  decide
 
-/-! ### The "motion verbs" non-class -/
+/-! ### The motion-verb non-class -/
 
-/-- Lucy's central typological point: notional motion roots do not form
-    their own salience class — each is classified exactly as the plain
-    state-change root *kíim* 'die'. -/
+/-- The paper's central typological point: notional motion roots form no salience class of their
+own, each being classified exactly as the plain state-change root *kíim* 'die'. -/
 theorem motion_roots_not_separate_class :
     ∀ r ∈ motionRoots, predictedClass r = predictedClass kiim := by decide
 
-/-- The `#` subclass — Lucy's only candidate formal motion class — is
-    not a function of the entailment grid: *péek* (`#`) and *lúub'*
-    (plain) agree in signature and valency. The class is carried by an
-    idiosyncratic morphological gap, not by lexical semantics. -/
+/-- The `#` subclass, the paper's only candidate formal motion class, is not a function of the
+entailment grid: *péek* (`#`) and *lúub'* (plain) agree in signature and valency. The class is
+carried by a morphological gap, not by lexical semantics. -/
 theorem hash_not_signature_definable :
     ∃ r ∈ hashMarked, ∃ r' ∈ motionRoots,
       r' ∉ hashMarked ∧ r.kinds = r'.kinds ∧ valency r = valency r' := by
   decide
 
-/-- **The transitiviser system is complementation in the valency
-    lattice**: each class's required derivation adds exactly the Boolean
-    complement of its underived stem's valency — `=t` supplies the
-    patient the unergative agent stem lacks, `=s` the agent the
-    unaccusative patient stem lacks, `=∅` nothing, the root-transitive
-    stem being already complete. -/
+/-- The transitiviser system is complementation in the valency lattice: each class's required
+derivation adds the Boolean complement of its underived stem's valency, *=t* the patient the
+agent stem lacks, *=s* the agent the patient stem lacks, *=∅* nothing. -/
 theorem transitiviser_adds_compl :
     affectiveT.adds = (SalienceClass.stemValency .agent)ᶜ ∧
     zeroDeriv.adds = (SalienceClass.stemValency .agentPatient)ᶜ ∧
@@ -387,18 +345,17 @@ theorem transitiviser_adds_compl :
 
 /-! ### Positional interstitiality -/
 
-/-- The positional diagnostic cross-cuts the transitiviser cut: *čin* is
-    positional yet zero-derives a transitive (agent-patient salient),
-    while *kul* is positional and outside the cut altogether. Lucy's
-    classes are diagnostics, not a partition. -/
+/-- The positional diagnostic cross-cuts the transitiviser cut: *čin* is positional yet
+zero-derives a transitive, while *čil* is positional and outside the cut altogether. The
+paper's classes are diagnostics, not a partition. -/
 theorem positional_crosscuts_transitiviser_classes :
     IsPositional cin.kinds ∧ predictedClass cin = some .agentPatient ∧
-    IsPositional kul.kinds ∧ predictedClass kul = none := by decide
+    IsPositional cil.kinds ∧ predictedClass cil = none := by decide
 
 /-! ### Closure robustness -/
 
-/-- For cause-free roots — every root in this sample — collocational
-    closure does not change the predicted class. -/
+/-- For cause-free roots, every root in this sample, collocational closure does not change the
+predicted class. -/
 theorem predictedClass_closure_invariant (r : Root) (h : Root.Kind.cause ∉ r.kinds) :
     SalienceClass.ofKinds r.closedKinds (valency r) = predictedClass r :=
   SalienceClass.ofKinds_close r.kinds (valency r) h


### PR DESCRIPTION
Deep pass on Lucy1994 against the paper text.

- the paper's roots, derived stems, and derivations become Data/Forms/Lucy1994 (CLDF FormTable and FormRelationTable); the study reads root spellings and attested derivations from the rows instead of a hand-typed table
- kul replaced by the listed positional čil of (7); page and example locators verified; header in register