### PR TITLE
refactor(Studies/OsborneLi2023): the constraint as a violation predicate

### DIFF
--- a/Linglib/Data/Examples/OsborneLi2023.json
+++ b/Linglib/Data/Examples/OsborneLi2023.json
@@ -1,7 +1,10 @@
 [
   {
     "id": "osborneli2023_ex2a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(2a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(2a)"
+    },
     "language": "stan1293",
     "primaryText": "Max and Lucie talked about him.",
     "discourseSegments": [],
@@ -11,15 +14,36 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "him = Max (co-valued)", "judgment": "questionable"},
-      {"name": "him = external referent", "judgment": "acceptable"}
+      {
+        "name": "him = Max (co-valued)",
+        "judgment": "questionable"
+      },
+      {
+        "name": "him = external referent",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "him;Max"],
-      ["paperSection", "1"],
-      ["paperMeanScore", "2.38"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "him;Max"
+      ],
+      [
+        "paperSection",
+        "1"
+      ],
+      [
+        "paperMeanScore",
+        "2.38"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (2a), p. ~632. Crowdsourced mean 2.38 → `??` per paper p. 630 fn. 3 threshold table (1.65–2.29 = ?, 2.30–2.94 = ??, 2.95–4.00 = *).",
     "metaLanguage": "stan1293",
@@ -27,25 +51,49 @@
   },
   {
     "id": "osborneli2023_ex3a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(3a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(3a)"
+    },
     "language": "stan1293",
     "primaryText": "John and Mary talked about himself.",
     "discourseSegments": [],
     "glossedTokens": [],
     "translation": "John and Mary talked about himself.",
     "context": "Coordinate subject; reflexive in PP complement. Co-valuing `himself` with `John` (a conjunct valent of the subject) is marginal — the reflexive cannot find a fully matching antecedent in the local domain but is licensed by the conjunct valent.",
-    "judgment": "marginal",
+    "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "himself = John", "judgment": "marginal"}
+      {
+        "name": "himself = John",
+        "judgment": "marginal"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "himself;John"],
-      ["anaphorType", "reflexive"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "2.15"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "himself;John"
+      ],
+      [
+        "anaphorType",
+        "reflexive"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "2.15"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (3a). Mean 2.15 → `?` per threshold table. CRDC predicts marginality (full reflexive of conjunct antecedent); some speakers tolerate semantic-plural agreement, others not.",
     "metaLanguage": "stan1293",
@@ -53,7 +101,10 @@
   },
   {
     "id": "osborneli2023_ex3b",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(3b)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(3b)"
+    },
     "language": "stan1293",
     "primaryText": "John and Mary talked about him.",
     "discourseSegments": [],
@@ -63,14 +114,32 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "him = John (co-valued)", "judgment": "questionable"}
+      {
+        "name": "him = John (co-valued)",
+        "judgment": "questionable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "him;John"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "2.43"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "him;John"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "2.43"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (3b). Mean 2.43 → `??`.",
     "metaLanguage": "stan1293",
@@ -78,25 +147,49 @@
   },
   {
     "id": "osborneli2023_ex5a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(5a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(5a)"
+    },
     "language": "stan1293",
     "primaryText": "Both John and Mary love him.",
     "discourseSegments": [],
     "glossedTokens": [],
     "translation": "Both John and Mary love him.",
     "context": "`both ... and ...` coordinator; pronoun as object of a symmetric predicate (`love`). Co-valuing `him` with `John` instantiates the CRDC configuration: `him` is a full valent, `John` is a conjunct of the coordinate subject.",
-    "judgment": "questionable",
+    "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [
-      {"name": "him = John", "judgment": "questionable"}
+      {
+        "name": "him = John",
+        "judgment": "questionable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coordinator", "both...and"],
-      ["coVValuedPair", "him;John"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "UNVERIFIED"],
-      ["paperNRespondents", "UNVERIFIED"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coordinator",
+        "both...and"
+      ],
+      [
+        "coVValuedPair",
+        "him;John"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "3.20"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (5a). CRDC predicts marginality (`.questionable`). Mean score and respondent count not verified against the paper PDF; the paired-coordinator variant pairs with a bare-`and` baseline that the paper itself uses to argue the symmetric-predicate `love` is the locus of the contrast, not the `both`-coordinator. Re-check both the score and the analytic attribution on next audit pass.",
     "metaLanguage": "stan1293",
@@ -104,7 +197,10 @@
   },
   {
     "id": "osborneli2023_ex6a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(6a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(6a)"
+    },
     "language": "stan1293",
     "primaryText": "Bill and Mary consider him to be ready for a raise.",
     "discourseSegments": [],
@@ -114,15 +210,36 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "him = Bill", "judgment": "questionable"}
+      {
+        "name": "him = Bill",
+        "judgment": "questionable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["construction", "raising-to-object"],
-      ["coVValuedPair", "him;Bill"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "2.42"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "construction",
+        "raising-to-object"
+      ],
+      [
+        "coVValuedPair",
+        "him;Bill"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "2.42"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (6a). Mean 2.42 → `??`. Raising-to-object case strengthens the empirical base for CRDC over coordinate-subject configurations.",
     "metaLanguage": "stan1293",
@@ -130,7 +247,10 @@
   },
   {
     "id": "osborneli2023_ex9a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(9a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(9a)"
+    },
     "language": "stan1293",
     "primaryText": "Max talked about himself.",
     "discourseSegments": [],
@@ -140,14 +260,32 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "himself = Max", "judgment": "acceptable"}
+      {
+        "name": "himself = Max",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "false"],
-      ["coVValuedPair", "himself;Max"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "1.28"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "false"
+      ],
+      [
+        "coVValuedPair",
+        "himself;Max"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "1.28"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (9a). Mean 1.28 → no indicator (acceptable). Non-coordinate baseline; CRDC says nothing because there is no coordination.",
     "metaLanguage": "stan1293",
@@ -155,7 +293,10 @@
   },
   {
     "id": "osborneli2023_ex9b",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(9b)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(9b)"
+    },
     "language": "stan1293",
     "primaryText": "Max talked about him.",
     "discourseSegments": [],
@@ -165,15 +306,36 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "him = Max", "judgment": "questionable"},
-      {"name": "him = external referent", "judgment": "acceptable"}
+      {
+        "name": "him = Max",
+        "judgment": "questionable"
+      },
+      {
+        "name": "him = external referent",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "false"],
-      ["coVValuedPair", "him;Max"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "2.92"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "false"
+      ],
+      [
+        "coVValuedPair",
+        "him;Max"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "2.92"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (9b). Mean 2.92 → `??`. The marginality here comes from Condition B (local pronoun bound by subject), not CRDC.",
     "metaLanguage": "stan1293",
@@ -181,7 +343,10 @@
   },
   {
     "id": "osborneli2023_ex11a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(11a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(11a)"
+    },
     "language": "stan1293",
     "primaryText": "Max and Lucie talked about his work.",
     "discourseSegments": [],
@@ -191,15 +356,36 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "his = Max", "judgment": "acceptable"}
+      {
+        "name": "his = Max",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "his;Max"],
-      ["anaphorType", "possessive"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "1.20"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "his;Max"
+      ],
+      [
+        "anaphorType",
+        "possessive"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "1.20"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (11a). Mean 1.20 → no indicator. Embedding the pronoun inside a possessive DP defuses CRDC.",
     "metaLanguage": "stan1293",
@@ -207,7 +393,10 @@
   },
   {
     "id": "osborneli2023_ex11e",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(11e)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(11e)"
+    },
     "language": "stan1293",
     "primaryText": "Max and Lucie talked about Max.",
     "discourseSegments": [],
@@ -217,16 +406,40 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "object Max ≠ subject Max", "judgment": "acceptable"},
-      {"name": "object Max = subject Max (same individual)", "judgment": "marginal"}
+      {
+        "name": "object Max ≠ subject Max",
+        "judgment": "acceptable"
+      },
+      {
+        "name": "object Max = subject Max (same individual)",
+        "judgment": "marginal"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "Max;Max"],
-      ["anaphorType", "R-expression"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "1.47"],
-      ["paperNRespondents", "100"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "Max;Max"
+      ],
+      [
+        "anaphorType",
+        "R-expression"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "1.47"
+      ],
+      [
+        "paperNRespondents",
+        "100"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (11e). Mean 1.47 → no indicator. R-expressions skirt CRDC because they need no antecedent.",
     "metaLanguage": "stan1293",
@@ -234,7 +447,10 @@
   },
   {
     "id": "osborneli2023_ex20b",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(20b)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(20b)"
+    },
     "language": "stan1293",
     "primaryText": "Hank and Hillary appear to her to be good friends.",
     "discourseSegments": [],
@@ -244,15 +460,36 @@
     "judgment": "questionable",
     "alternatives": [],
     "readings": [
-      {"name": "her = Hillary", "judgment": "questionable"}
+      {
+        "name": "her = Hillary",
+        "judgment": "questionable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["construction", "raising-with-experiencer"],
-      ["coVValuedPair", "her;Hillary"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "2.68"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "construction",
+        "raising-with-experiencer"
+      ],
+      [
+        "coVValuedPair",
+        "her;Hillary"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "2.68"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (20b). Mean 2.68 → `??`. Raising-with-experiencer pattern: CRDC continues to apply across the raising chain.",
     "metaLanguage": "stan1293",
@@ -260,7 +497,10 @@
   },
   {
     "id": "osborneli2023_ex24a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(24a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(24a)"
+    },
     "language": "stan1293",
     "primaryText": "John talked about himself and his mother.",
     "discourseSegments": [],
@@ -270,14 +510,32 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "himself = John", "judgment": "acceptable"}
+      {
+        "name": "himself = John",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateObject", "true"],
-      ["coVValuedPair", "himself;John"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "1.14"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateObject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "himself;John"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "1.14"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (24a). Mean 1.14 → no indicator. Key directionality test: conjunct anaphor of full-valent antecedent is fine; only the full-anaphor-of-conjunct direction triggers CRDC marginality.",
     "metaLanguage": "stan1293",
@@ -285,7 +543,10 @@
   },
   {
     "id": "osborneli2023_ex25c",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(25c)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(25c)"
+    },
     "language": "stan1293",
     "primaryText": "Jane defended her.",
     "discourseSegments": [],
@@ -295,14 +556,32 @@
     "judgment": "ungrammatical",
     "alternatives": [],
     "readings": [
-      {"name": "her = Jane", "judgment": "ungrammatical"}
+      {
+        "name": "her = Jane",
+        "judgment": "ungrammatical"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "false"],
-      ["coVValuedPair", "her;Jane"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "3.20"],
-      ["paperNRespondents", "40"]
+      [
+        "coordinateSubject",
+        "false"
+      ],
+      [
+        "coVValuedPair",
+        "her;Jane"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "3.20"
+      ],
+      [
+        "paperNRespondents",
+        "40"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (25c). Mean 3.20 → `*`. Standard Condition B violation; cited to contrast with the coordinate-object licensing in (24a).",
     "metaLanguage": "stan1293",
@@ -310,7 +589,10 @@
   },
   {
     "id": "osborneli2023_ex28d",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(28d)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(28d)"
+    },
     "language": "stan1293",
     "primaryText": "John expected Mary and him to be able to leave soon.",
     "discourseSegments": [],
@@ -320,15 +602,36 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "him = John", "judgment": "acceptable"}
+      {
+        "name": "him = John",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateObject", "true"],
-      ["construction", "raising-to-object"],
-      ["coVValuedPair", "him;John"],
-      ["paperSection", "3"],
-      ["paperMeanScore", "1.40"],
-      ["paperNRespondents", "60"]
+      [
+        "coordinateObject",
+        "true"
+      ],
+      [
+        "construction",
+        "raising-to-object"
+      ],
+      [
+        "coVValuedPair",
+        "him;John"
+      ],
+      [
+        "paperSection",
+        "3"
+      ],
+      [
+        "paperMeanScore",
+        "1.40"
+      ],
+      [
+        "paperNRespondents",
+        "60"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (28d). Mean 1.40 → no indicator. Confirms the directionality asymmetry: conjunct anaphor of full antecedent is fine even with raising-to-object.",
     "metaLanguage": "stan1293",
@@ -336,7 +639,10 @@
   },
   {
     "id": "osborneli2023_ex55a",
-    "source": {"bibkey": "osborne-li-2023", "paperLabel": "(55a)"},
+    "source": {
+      "bibkey": "osborne-li-2023",
+      "paperLabel": "(55a)"
+    },
     "language": "stan1293",
     "primaryText": "Sophy and Edgar voted for her.",
     "discourseSegments": [],
@@ -346,15 +652,36 @@
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [
-      {"name": "her = Sophy", "judgment": "acceptable"}
+      {
+        "name": "her = Sophy",
+        "judgment": "acceptable"
+      }
     ],
     "paperFeatures": [
-      ["coordinateSubject", "true"],
-      ["coVValuedPair", "her;Sophy"],
-      ["paperSection", "6"],
-      ["isCounterexample", "true"],
-      ["paperMeanScore", "1.43"],
-      ["paperNRespondents", "40"]
+      [
+        "coordinateSubject",
+        "true"
+      ],
+      [
+        "coVValuedPair",
+        "her;Sophy"
+      ],
+      [
+        "paperSection",
+        "6"
+      ],
+      [
+        "isCounterexample",
+        "true"
+      ],
+      [
+        "paperMeanScore",
+        "1.43"
+      ],
+      [
+        "paperNRespondents",
+        "40"
+      ]
     ],
     "comment": "Osborne & Li 2023 ex (55a). Mean 1.43 → no indicator. Section 6 counterexample: predicates like `vote for` allow `her` to pick out an individual outside the coordination (a third party), making CRDC's prediction empirically wrong here. Flagged in `paperFeatures.isCounterexample`.",
     "metaLanguage": "stan1293",

--- a/Linglib/Data/Examples/OsborneLi2023.lean
+++ b/Linglib/Data/Examples/OsborneLi2023.lean
@@ -41,7 +41,7 @@ def ex3a : LinguisticExample :=
     glossedTokens := []
     translation := "John and Mary talked about himself."
     context := "Coordinate subject; reflexive in PP complement. Co-valuing `himself` with `John` (a conjunct valent of the subject) is marginal — the reflexive cannot find a fully matching antecedent in the local domain but is licensed by the conjunct valent."
-    judgment := .marginal
+    judgment := .questionable
     alternatives := []
     readings := [("himself = John", .marginal)]
     paperFeatures := [("coordinateSubject", "true"), ("coVValuedPair", "himself;John"), ("anaphorType", "reflexive"), ("paperSection", "3"), ("paperMeanScore", "2.15"), ("paperNRespondents", "60")]
@@ -77,10 +77,10 @@ def ex5a : LinguisticExample :=
     glossedTokens := []
     translation := "Both John and Mary love him."
     context := "`both ... and ...` coordinator; pronoun as object of a symmetric predicate (`love`). Co-valuing `him` with `John` instantiates the CRDC configuration: `him` is a full valent, `John` is a conjunct of the coordinate subject."
-    judgment := .questionable
+    judgment := .ungrammatical
     alternatives := []
     readings := [("him = John", .questionable)]
-    paperFeatures := [("coordinateSubject", "true"), ("coordinator", "both...and"), ("coVValuedPair", "him;John"), ("paperSection", "3"), ("paperMeanScore", "UNVERIFIED"), ("paperNRespondents", "UNVERIFIED")]
+    paperFeatures := [("coordinateSubject", "true"), ("coordinator", "both...and"), ("coVValuedPair", "him;John"), ("paperSection", "3"), ("paperMeanScore", "3.20"), ("paperNRespondents", "60")]
     comment := "Osborne & Li 2023 ex (5a). CRDC predicts marginality (`.questionable`). Mean score and respondent count not verified against the paper PDF; the paired-coordinator variant pairs with a bare-`and` baseline that the paper itself uses to argue the symmetric-predicate `love` is the locus of the contrast, not the `both`-coordinator. Re-check both the score and the analytic attribution on next audit pass."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }

--- a/Linglib/Studies/OsborneLi2023.lean
+++ b/Linglib/Studies/OsborneLi2023.lean
@@ -1,37 +1,36 @@
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Data.UD.Basic
-import Linglib.Data.Examples.Schema
 import Linglib.Morphology.Word.Basic
 import Linglib.Data.Examples.OsborneLi2023
 
 /-!
 # Osborne and Li (2023): Coordination and Referential Dependencies
 
-This file formalizes the Conjunct Referential Dependency Constraint of [osborne-li-2023]: a
-referentially dependent conjunct valent can be co-valued with a full co-valent, but a
-referentially dependent full valent can hardly be co-valued with a conjunct co-valent. The
-constraint governs only configurations in which one of the two positions sits inside a
-coordinate structure, non-coordinate binding falling under the binding conditions on which
-the paper is silent, and its empirical content is graded: the paper's crowdsourced
-acceptability scale maps the constraint's prediction to the double question mark, the
-library's questionable judgment (`crdcPredictedJudgment`). Each stimulus is built as a
-dependency tree from the paper's examples and the prediction compared with the recorded
-judgment, equal wherever the constraint is the operative principle and diverging on the
-reflexive baseline whose marginality is Condition B's; the constraint is asymmetric on the
-coordinate-subject stimulus (`direction_asymmetry`).
+This file formalizes the Conjunct Referential Dependency Constraint of [osborne-li-2023],
+the descriptive generalization of the paper's fifth section: a referentially dependent
+conjunct valent can be co-valued with a full co-valent, but a referentially dependent full
+valent can hardly be co-valued with a conjunct co-valent. A conjunct valent of a predicate is
+a conjunct of a coordinate structure that is a valent of the predicate, and a full valent is
+a valent that is not a conjunct valent (`IsConjunctValent`, `IsFullValent`); the constraint is
+violated when a pronoun that is a full valent takes a conjunct co-valent as its antecedent
+(`Violates`), so it is silent where no coordinate structure is present
+(`not_violates_of_no_conjuncts`), and since a conjunct valent is never a full valent no pair
+violates it in both directions (`Violates.not_symm`). The paper's judgments are crowdsourced
+mean scores on a scale from 1, the co-valued reading easily possible, to 4, impossible, the
+double question mark marking the strongly marginal middle, the library's questionable
+judgment. Each stimulus is a dependency tree over one of the paper's examples, and over the
+stimuli a violation is never acceptable while a coordinate stimulus without a violation is
+acceptable (`violation_degraded`, `no_violation_acceptable`), the non-coordinate baselines
+falling under Condition B, on which the paper is silent. The *vote* answer of (55a) is the
+paper's own counterexample, a violation judged acceptable (`vote_counterexample`).
 
 ## Implementation notes
 
 A valent is a direct valency-relation dependent of the predicate, a simplification of the
-paper's catena-based notion that the example set does not exercise; the first conjunct
-heads the coordinate structure in the Universal Dependencies convention.
-
-## TODO
-
-The paper is not on file; the page locators of the constraint and of the acceptability
-scale are transcribed from an earlier version of this file and are UNVERIFIED. The sixth
-section's counterexamples, such as the *vote*-predicate identity split, need a third-party
-referent treatment.
+paper's catena-based notion that the example set does not exercise; the first conjunct heads
+the coordinate structure in the Universal Dependencies convention, and referential
+dependence is being a pronoun. The rows of `Data/Examples/OsborneLi2023` carry the paper's
+respondent counts and mean scores.
 
 ## References
 
@@ -40,152 +39,209 @@ referent treatment.
 
 namespace OsborneLi2023
 
-open DependencyGrammar
+open DependencyGrammar Data.Examples
 open Features (Judgment)
 open Morphology (Word)
 
-/-! ### Predicate-valent type -/
+/-! ### Conjunct and full valents -/
 
-/-- The conjuncts of the coordinate structure headed at `c`: the head
-    (the first conjunct, per UD) plus its `.conj` dependents. -/
-def allConjuncts {n : ℕ} (g : Graph n) (c : Fin n) : Finset (Fin n) :=
+section Valents
+
+variable {n : ℕ} (g : Graph n)
+
+/-- The conjuncts of the coordinate structure headed at `c`: the head, the first conjunct, and
+its `conj` dependents. -/
+def allConjuncts (c : Fin n) : Finset (Fin n) :=
   insert c {w ∈ g.children c | g.label c w = some .conj}
 
 /-- Position `c` heads a coordinate structure: it has a `conj` dependent. -/
-def HasConjuncts {n : ℕ} (g : Graph n) (c : Fin n) : Prop :=
+def HasConjuncts (c : Fin n) : Prop :=
   ∃ w ∈ g.children c, g.label c w = some .conj
 
-instance {n : ℕ} (g : Graph n) (c : Fin n) : Decidable (HasConjuncts g c) :=
+instance (c : Fin n) : Decidable (HasConjuncts g c) := Finset.decidableExistsAndFinset
+
+/-- `valent` is a conjunct valent of `pred`: a conjunct of a coordinate structure that fills a
+valency role of `pred`. -/
+def IsConjunctValent (pred valent : Fin n) : Prop :=
+  ∃ c ∈ g.children pred, ∃ r ∈ g.label pred c, r.isValencyArg ∧
+    HasConjuncts g c ∧ valent ∈ allConjuncts g c
+
+instance (pred valent : Fin n) : Decidable (IsConjunctValent g pred valent) :=
   Finset.decidableExistsAndFinset
 
-/-- Word `valentIdx` is a *conjunct valent* of predicate `predIdx`: a
-    conjunct of a coordinate structure that fills a valency role of
-    `predIdx`. -/
-def IsConjunctValent {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) : Prop :=
-  ∃ c ∈ g.children predIdx, ∃ r ∈ g.label predIdx c, r.isValencyArg
-    ∧ HasConjuncts g c ∧ valentIdx ∈ allConjuncts g c
+/-- `valent` is a full valent of `pred`: a valent that is complete, that is, not a conjunct
+valent. -/
+def IsFullValent (pred valent : Fin n) : Prop :=
+  (∃ r ∈ g.label pred valent, r.isValencyArg) ∧ ¬ IsConjunctValent g pred valent
 
-instance {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) :
-    Decidable (IsConjunctValent g predIdx valentIdx) :=
-  Finset.decidableExistsAndFinset
-
-/-- Word `valentIdx` is a *full valent* of `predIdx`: a valent that is
-    not a conjunct valent — the paper's definition (p. 651): "a valent
-    of a given predicate is a full valent thereof if it is complete,
-    that is, it is *not* a conjunct valent." -/
-def IsFullValent {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) : Prop :=
-  (∃ r ∈ g.label predIdx valentIdx, r.isValencyArg)
-    ∧ ¬ IsConjunctValent g predIdx valentIdx
-
-instance {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) :
-    Decidable (IsFullValent g predIdx valentIdx) :=
+instance (pred valent : Fin n) : Decidable (IsFullValent g pred valent) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-! ### CRDC prediction -/
+/-- The constraint is violated when the pronoun `ana`, a full valent of `pred`, is co-valued
+with a conjunct valent `ante` of the same predicate. -/
+def Violates (pred ana ante : Fin n) : Prop :=
+  (g.words ana).cat = .PRON ∧ IsFullValent g pred ana ∧ IsConjunctValent g pred ante
 
-/-- The CRDC's predicted judgment for co-valuing anaphor `anaIdx` with
-    antecedent `anteIdx` under predicate `predIdx`: `.questionable`
-    exactly when the anaphor is a full valent and the antecedent a
-    conjunct valent of the same predicate; `.acceptable` otherwise —
-    the CRDC is silent, and other binding principles may still apply. -/
-def crdcPredictedJudgment {n : ℕ}
-    (t : Graph n) (predIdx anaIdx anteIdx : Fin n) : Judgment :=
-  if IsFullValent t predIdx anaIdx ∧ IsConjunctValent t predIdx anteIdx then
-    .questionable
-  else
-    .acceptable
+instance (pred ana ante : Fin n) : Decidable (Violates g pred ana ante) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
-/-! ### CRDC predictions against the data rows -/
+variable {g}
 
-/-- Ex (2a): "Max and Lucie talked about him."
-    `Max(0) and(1) Lucie(2) talked(3) about(4) him(5)`. -/
-def coordSubject : Graph 6 :=
-  .ofArcs
+/-- A conjunct valent is not a full valent, so no pair violates the constraint in both
+directions: the permitted direction is the reverse of the forbidden one. -/
+theorem Violates.not_symm {pred ana ante : Fin n} (h : Violates g pred ana ante) :
+    ¬ Violates g pred ante ana :=
+  λ h' => h'.2.1.2 h.2.2
+
+/-- Without a coordinate structure the constraint is silent. -/
+theorem not_violates_of_no_conjuncts (h : ∀ c, ¬ HasConjuncts g c) (pred ana ante : Fin n) :
+    ¬ Violates g pred ana ante :=
+  λ ⟨_, _, c, _, _, _, _, hc, _⟩ => h c hc
+
+end Valents
+
+/-! ### The stimuli -/
+
+/-- A stimulus: the dependency tree of an example, its predicate, the referentially dependent
+expression and its intended antecedent, and the example's row. -/
+structure Stimulus where
+  n : ℕ
+  tree : Graph n
+  pred : Fin n
+  ana : Fin n
+  ante : Fin n
+  row : LinguisticExample
+
+/-- The stimulus violates the constraint. -/
+def Stimulus.Violates (s : Stimulus) : Prop := OsborneLi2023.Violates s.tree s.pred s.ana s.ante
+
+instance : DecidablePred Stimulus.Violates :=
+  λ s => inferInstanceAs (Decidable (Violates s.tree s.pred s.ana s.ante))
+
+/-- The stimulus contains a coordinate structure. -/
+def Stimulus.Coordinate (s : Stimulus) : Prop := ∃ c, HasConjuncts s.tree c
+
+instance : DecidablePred Stimulus.Coordinate := λ _ => Fintype.decidableExistsFintype
+
+/-- (2a) *Max and Lucie talked about him*: a full-valent pronoun with a conjunct antecedent. -/
+def ex2a : Stimulus :=
+  ⟨6, .ofArcs
     [Word.mk' "Max" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Lucie" .PROPN,
      Word.mk' "talked" .VERB, Word.mk' "about" .ADP, Word.mk' "him" .PRON]
-    3
-    [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_)]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_)],
+   3, 5, 0, Examples.ex2a⟩
 
-/-- Full-valent `him` over conjunct-valent `Max`: the CRDC fires and
-    matches the observed `??`. -/
-theorem coordSubject_matches_data :
-    crdcPredictedJudgment coordSubject 3 5 0 = Examples.ex2a.judgment := by decide
+/-- (3a) *John and Mary talked about himself*: the reflexive fares no better. -/
+def ex3a : Stimulus :=
+  ⟨6, .ofArcs
+    [Word.mk' "John" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN,
+     Word.mk' "talked" .VERB, Word.mk' "about" .ADP, Word.mk' "himself" .PRON]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_)],
+   3, 5, 0, Examples.ex3a⟩
 
-/-- Ex (9a): "Max talked about himself." — non-coordinate baseline. -/
-def reflexiveBaseline : Graph 4 :=
-  .ofArcs
-    [Word.mk' "Max" .PROPN, Word.mk' "talked" .VERB,
-     Word.mk' "about" .ADP, Word.mk' "himself" .PRON]
-    1
-    [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_)]
+/-- (5a) *Both John and Mary love him*: the paired coordinator forces distribution, and the
+sentence is judged worse than the constraint alone predicts. -/
+def ex5a : Stimulus :=
+  ⟨6, .ofArcs
+    [Word.mk' "Both" .CCONJ, Word.mk' "John" .PROPN, Word.mk' "and" .CCONJ,
+     Word.mk' "Mary" .PROPN, Word.mk' "love" .VERB, Word.mk' "him" .PRON]
+    4 [(4, 1, .nsubj), (1, 0, .cc), (1, 2, .cc), (1, 3, .conj), (4, 5, .obj)],
+   4, 5, 1, Examples.ex5a⟩
 
-theorem reflexiveBaseline_matches_data :
-    crdcPredictedJudgment reflexiveBaseline 1 3 0 = Examples.ex9a.judgment := by decide
+/-- (9a) *Max talked about himself*: the non-coordinate reflexive baseline. -/
+def ex9a : Stimulus :=
+  ⟨4, .ofArcs
+    [Word.mk' "Max" .PROPN, Word.mk' "talked" .VERB, Word.mk' "about" .ADP,
+     Word.mk' "himself" .PRON]
+    1 [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_)],
+   1, 3, 0, Examples.ex9a⟩
 
-/-- Ex (9b): "Max talked about him." — non-coordinate Condition B context. The
-    CRDC is silent; the row's marginality is Condition B's
-    contribution, so prediction and row diverge by design. -/
-def pronounBaseline : Graph 4 :=
-  .ofArcs
-    [Word.mk' "Max" .PROPN, Word.mk' "talked" .VERB,
-     Word.mk' "about" .ADP, Word.mk' "him" .PRON]
-    1
-    [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_)]
+/-- (9b) *Max talked about him*: the non-coordinate pronoun baseline, marginal by Condition B,
+on which the constraint is silent. -/
+def ex9b : Stimulus :=
+  ⟨4, .ofArcs
+    [Word.mk' "Max" .PROPN, Word.mk' "talked" .VERB, Word.mk' "about" .ADP,
+     Word.mk' "him" .PRON]
+    1 [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_)],
+   1, 3, 0, Examples.ex9b⟩
 
-theorem pronounBaseline_crdc_silent :
-    crdcPredictedJudgment pronounBaseline 1 3 0 = .acceptable ∧
-    Examples.ex9b.judgment = .questionable := by decide
+/-- (11a) *Max and Lucie talked about his work*: the possessive is no valent of the verb. -/
+def ex11a : Stimulus :=
+  ⟨7, .ofArcs
+    [Word.mk' "Max" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Lucie" .PROPN,
+     Word.mk' "talked" .VERB, Word.mk' "about" .ADP, Word.mk' "his" .PRON,
+     Word.mk' "work" .NOUN]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 6, .obl), (6, 4, .case_),
+       (6, 5, .nmod)],
+   3, 5, 0, Examples.ex11a⟩
 
-/-- Ex (24a): "John talked about himself and his mother." — coordinate *object*;
-    `himself` heads the coordination, so it is a conjunct valent and
-    `John` a full valent: the CRDC's permitted direction. -/
-def coordObject : Graph 7 :=
-  .ofArcs
+/-- (11e) *Max and Lucie talked about Max*: a name is not referentially dependent. -/
+def ex11e : Stimulus :=
+  ⟨6, .ofArcs
+    [Word.mk' "Max" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Lucie" .PROPN,
+     Word.mk' "talked" .VERB, Word.mk' "about" .ADP, Word.mk' "Max" .PROPN]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_)],
+   3, 5, 0, Examples.ex11e⟩
+
+/-- (20b) *Hank and Hillary appear to her to be good friends*: the experiencer of a raising
+predicate is a full valent. -/
+def ex20b : Stimulus :=
+  ⟨10, .ofArcs
+    [Word.mk' "Hank" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Hillary" .PROPN,
+     Word.mk' "appear" .VERB, Word.mk' "to" .ADP, Word.mk' "her" .PRON,
+     Word.mk' "to" .PART, Word.mk' "be" .AUX, Word.mk' "good" .ADJ,
+     Word.mk' "friends" .NOUN]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_),
+       (3, 9, .xcomp), (9, 6, .mark), (9, 7, .cop), (9, 8, .amod)],
+   3, 5, 2, Examples.ex20b⟩
+
+/-- (24a) *John talked about himself and his mother*: the reflexive heads the coordinate object,
+so it is a conjunct valent and *John* a full valent, the permitted direction. -/
+def ex24a : Stimulus :=
+  ⟨7, .ofArcs
     [Word.mk' "John" .PROPN, Word.mk' "talked" .VERB, Word.mk' "about" .ADP,
      Word.mk' "himself" .PRON, Word.mk' "and" .CCONJ, Word.mk' "his" .PRON,
      Word.mk' "mother" .NOUN]
-    1
-    [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_),
-     (3, 4, .cc), (3, 6, .conj), (6, 5, .nmod)]
+    1 [(1, 0, .nsubj), (1, 3, .obl), (3, 2, .case_), (3, 4, .cc), (3, 6, .conj),
+       (6, 5, .nmod)],
+   1, 3, 0, Examples.ex24a⟩
 
-theorem coordObject_matches_data :
-    crdcPredictedJudgment coordObject 1 3 0 = Examples.ex24a.judgment := by decide
-
-/-- Ex (5a): "Both John and Mary love him." — coordinate subject with paired
-    coordinator; pronoun in object position. The CRDC fires and matches
-    the observed `??`. -/
-def pairedCoordSubject : Graph 6 :=
-  .ofArcs
-    [Word.mk' "Both" .CCONJ, Word.mk' "John" .PROPN, Word.mk' "and" .CCONJ,
-     Word.mk' "Mary" .PROPN, Word.mk' "love" .VERB, Word.mk' "him" .PRON]
-    4
-    [(4, 1, .nsubj), (1, 0, .cc), (1, 2, .cc), (1, 3, .conj), (4, 5, .obj)]
-
-theorem pairedCoordSubject_matches_data :
-    crdcPredictedJudgment pairedCoordSubject 4 5 1 = Examples.ex5a.judgment := by decide
-
-/-- Ex (28d): "John expected Mary and him to be able to leave soon." —
-    coordinate object under raising-to-object: `him` is a conjunct
-    valent, so the CRDC is silent on co-valuing it with `John`. -/
-def raisingCoordObject : Graph 8 :=
-  .ofArcs
+/-- (28d) *John expected Mary and him to be able to leave soon*: the pronoun is a conjunct of
+the raised object. -/
+def ex28d : Stimulus :=
+  ⟨8, .ofArcs
     [Word.mk' "John" .PROPN, Word.mk' "expected" .VERB, Word.mk' "Mary" .PROPN,
      Word.mk' "and" .CCONJ, Word.mk' "him" .PRON, Word.mk' "to" .PART,
      Word.mk' "leave" .VERB, Word.mk' "soon" .ADV]
-    1
-    [(1, 0, .nsubj), (1, 2, .obj), (2, 3, .cc), (2, 4, .conj),
-     (1, 6, .xcomp), (6, 5, .mark), (6, 7, .advmod)]
+    1 [(1, 0, .nsubj), (1, 2, .obj), (2, 3, .cc), (2, 4, .conj), (1, 6, .xcomp),
+       (6, 5, .mark), (6, 7, .advmod)],
+   1, 4, 0, Examples.ex28d⟩
 
-theorem raisingCoordObject_matches_data :
-    crdcPredictedJudgment raisingCoordObject 1 4 0 = Examples.ex28d.judgment := by decide
+/-- The stimuli of the paper's third section. -/
+def stimuli : List Stimulus :=
+  [ex2a, ex3a, ex5a, ex9a, ex9b, ex11a, ex11e, ex20b, ex24a, ex28d]
 
-/-! ### Directionality -/
+/-- A violation of the constraint is never judged acceptable. -/
+theorem violation_degraded : ∀ s ∈ stimuli, s.Violates → s.row.judgment ≠ .acceptable := by
+  decide
 
-/-- The CRDC is asymmetric: on ex2a's tree, only the full-anaphor-of-
-    conjunct-antecedent direction fires; swapping anaphor and antecedent
-    leaves the CRDC silent. -/
-theorem direction_asymmetry :
-    crdcPredictedJudgment coordSubject 3 5 0 = .questionable ∧
-    crdcPredictedJudgment coordSubject 3 0 5 = .acceptable := by decide
+/-- A coordinate stimulus that does not violate the constraint is judged acceptable. -/
+theorem no_violation_acceptable :
+    ∀ s ∈ stimuli, s.Coordinate → ¬ s.Violates → s.row.judgment = .acceptable := by
+  decide
+
+/-! ### The counterexample of the sixth section -/
+
+/-- (55a) *Who voted for Sophy? Sophy and Edgar voted for her*: a violation the informants
+accept, which the paper attributes to an identity split between the candidate and the
+voter. -/
+def ex55a : Stimulus :=
+  ⟨6, .ofArcs
+    [Word.mk' "Sophy" .PROPN, Word.mk' "and" .CCONJ, Word.mk' "Edgar" .PROPN,
+     Word.mk' "voted" .VERB, Word.mk' "for" .ADP, Word.mk' "her" .PRON]
+    3 [(3, 0, .nsubj), (0, 1, .cc), (0, 2, .conj), (3, 5, .obl), (5, 4, .case_)],
+   3, 5, 0, Examples.ex55a⟩
+
+theorem vote_counterexample : ex55a.Violates ∧ ex55a.row.judgment = .acceptable := by decide
 
 end OsborneLi2023


### PR DESCRIPTION
Deep pass on OsborneLi2023 against the paper text.

- the constraint as a violation predicate over dependency trees, with its asymmetry and its silence outside coordination as general lemmas
- ten of the paper's stimuli as trees, the judgments checked in bulk, and the paper's own vote counterexample stated
- rows: (5a) carries its verified score and star; (3a) its double question mark