### PR TITLE
refactor(Studies/Partee1987): the inverse pairs and the natural functors

### DIFF
--- a/Linglib/Studies/Partee1987.lean
+++ b/Linglib/Studies/Partee1987.lean
@@ -1,59 +1,104 @@
 import Linglib.Semantics.Composition.TypeShifting
-import Linglib.Fragments.English.Toy
 
 /-!
 # Partee (1987): Noun Phrase Interpretation and Type-shifting Principles
 
-This file formalizes the treatment of the copula in [partee-1987]: among the type-shifting
-principles that let a noun phrase denote an entity, a predicate, or a generalized quantifier
-as its environment demands, English *be* is the functor `BE` that lowers a generalized
-quantifier to a predicate, so that *John is a teacher* reduces to the predication of
-*teacher* of John and, on a proper-name subject, to the identity shift `ident` (`be_sem`,
-`be_transparent`).
+This file formalizes the type-shifting principles of [partee-1987]. A noun phrase may denote
+an entity, a predicate, or a generalized quantifier as its environment demands, and the
+mappings between the three types come in inverse pairs, the paper's Figure 1: `lift`, the
+substrate's `Quantification.individual`, and `lower`, the total injection of an entity into
+its principal ultrafilter and its partial inverse; `ident` and `iota`, the singleton property
+of an entity and the unique member of a property; and `nom` and `pred`, the correlates of
+properties and entities after [chierchia-1984] (`lower_lift`, `iota_ident`, `nom_pred`). The
+definite article has a partial entity meaning, `iota`, and a total quantifier meaning, `THE`,
+related by `THE(king') = lift(iota(king'))` whenever the latter is defined, and the
+predicative reading of *the king* is `BE(THE(king'))`, so that the three readings of Figure 2
+cohere, `BE(THE(king')) = ident(iota(king'))`, and coincide with the common noun when there
+is exactly one king, which is why the article can be dropped in *John is (the) president*
+(`THE_eq_lift_iota`, `lower_THE`, `BE_THE`, `BE_THE_eq_of_unique`). The functor `BE`,
+Montague's translation of *be* reconceived as a type shifter, is a homomorphism of the
+Boolean structures, Fact 1 of §3.3, the substrate's `Quantification.BE_hom`, and the unique
+homomorphism making Figure 3 commute, `BE(lift(j)) = ident(j)`, Fact 2 (`BE_lift`,
+`BE_natural`); the indefinite article `A` is natural as its inverse, `BE(A(P)) = P`, so *be a
+man* comes out as *man* (`BE_A`). English *be* itself is then predicate application, the
+predicative reading having moved into the noun phrase.
 
 ## Implementation notes
 
-The shifts live in `Semantics/Composition/TypeShifting`. Only the copula section of the paper
-is formalized, and its sketch is explicitly about English, so it licenses no cross-linguistic
-predictions.
+The setting is extensional over a listed domain, so `pred` is `ident` and `nom` is `iota`,
+and `THE` is the partial composite `lift ∘ iota` the paper offers as the alternative to its
+total, presuppositionless quantifier meaning. The mappings to and from kinds of §3.4 onward
+and the analysis of the Williams counterexample are not formalized.
 
 ## References
 
 * [partee-1987]
+* [chierchia-1984]
+* [keenan-faltz-1985]
 -/
 
 namespace Partee1987
 
-open Quantification (BE individual)
-open Semantics.Composition.TypeShifting (ident BE_individual_eq_ident)
-open Semantics.Composition (Denot Ty)
+open Quantification Semantics.Composition.TypeShifting
 
-variable {E W : Type}
+variable {E : Type} (domain : List E) (j : E) (P : E → Prop)
 
-/-- ⟦be⟧ = BE: the copula IS the type-shifting functor, taking a
-    generalized quantifier to a predicate. -/
-abbrev be_sem (E W : Type) : Denot E W Ty.ett → Denot E W Ty.et := BE
+/-! ### Figure 1: three inverse pairs -/
 
-/-- The copula is semantically transparent for proper names.
-    "John is a teacher" with `⟦John⟧ = individual(j)`:
-    `BE(individual(j)) = ident(j) = λx. [j = x]`. -/
-theorem be_transparent (j : Denot E W .e) :
-    be_sem E W (individual j) = ident j :=
+/-- `lower(lift(j)) = j`: `lower` inverts the total injection `lift`. -/
+theorem lower_lift [DecidableEq E] (hmem : j ∈ domain) (hnd : domain.Nodup) :
+    lower domain (individual j) = some j :=
+  lower_individual domain j hmem hnd
+
+/-- `iota(ident(j)) = j`: `iota` inverts the singleton map `ident`. -/
+theorem iota_ident [DecidableEq E] (hmem : j ∈ domain) (hnd : domain.Nodup) :
+    iota domain (ident j) = some j :=
+  Semantics.Composition.TypeShifting.iota_ident domain j hmem hnd
+
+/-- `nom(pred(j)) = j`: the extensional correlates of [chierchia-1984] are inverses. -/
+theorem nom_pred [DecidableEq E] (hmem : j ∈ domain) (hnd : domain.Nodup) :
+    NOM domain (pred j) = some j :=
+  NOM_pred domain j hmem hnd
+
+/-! ### Figure 2: *the king* in three types (§3.2) -/
+
+/-- Whenever `iota` is defined, `THE(king') = lift(iota(king'))`. -/
+theorem THE_eq_lift_iota (h : iota domain P = some j) : THE domain P = some (individual j) := by
+  simp [THE, h]
+
+/-- Whenever `iota` is defined, `lower(THE(king')) = iota(king')`. -/
+theorem lower_THE [DecidableEq E] (hmem : j ∈ domain) (hnd : domain.Nodup)
+    (h : iota domain P = some j) :
+    (THE domain P).bind (lower domain) = some j := by
+  simp [THE_eq_lift_iota domain j P h, lower_lift domain j hmem hnd]
+
+/-- The predicative reading `BE(THE(king'))` is `ident(iota(king'))`: the diagram commutes. -/
+theorem BE_THE (h : iota domain P = some j) : ∃ Q ∈ THE domain P, BE Q = ident j :=
+  ⟨individual j, by simp [THE, h], BE_individual_eq_ident j⟩
+
+/-- With exactly one king the predicative *the king* is the common noun *king*, the
+equivalence that lets the article drop in *John is (the) president* (12). -/
+theorem BE_THE_eq_of_unique (h : iota domain P = some j) (hP : ∀ x, P x ↔ x = j) :
+    ∃ Q ∈ THE domain P, BE Q = P := by
+  refine ⟨individual j, by simp [THE, h], ?_⟩
+  rw [BE_individual_eq_ident]
+  funext x
+  exact propext (eq_comm.trans (hP x).symm)
+
+/-! ### `A` and `BE` as natural functors (§3.3) -/
+
+/-- Figure 3 commutes: `BE(lift(j)) = ident(j)`. -/
+theorem BE_lift : BE (individual j) = ident j :=
   BE_individual_eq_ident j
 
-/-! ### Toy-fragment examples -/
+/-- Fact 2: `BE` is the unique Boolean homomorphism making Figure 3 commute; Fact 1, that it
+is one, is `Quantification.BE_hom`. -/
+theorem BE_natural [Fintype E] [DecidableEq E] (f : BoundedLatticeHom (Quantifier E) (E → Prop))
+    (hcomm : ∀ j : E, f (individual j) = ident j) (Q : Quantifier E) : f Q = BE Q :=
+  BE_unique f hcomm Q
 
-section ToyExamples
-
-open Semantics.Montague (ToyEntity)
-open Semantics.Montague.ToyLexicon (john_sem sleeps_sem)
-
-example : individual (α := ToyEntity) john_sem sleeps_sem :=
-  show sleeps_sem john_sem from trivial
-
-example : BE (E := ToyEntity) (individual john_sem) = ident john_sem :=
-  BE_individual_eq_ident john_sem
-
-end ToyExamples
+/-- `A` is an inverse of `BE`: `BE(A(man')) = man'`, so *be a man* is *man*. -/
+theorem BE_A (hcomplete : ∀ x : E, x ∈ domain) : BE (A domain P) = P :=
+  BE_A_id domain P hcomplete
 
 end Partee1987

--- a/references.bib
+++ b/references.bib
@@ -27089,7 +27089,7 @@
   doi       = {10.4324/9781315459097},
   subfield  = {semantics/syntax},
   role      = {formalized},
-  sources   = {Semantics/Composition/TypeShifting.lean;Studies/Chierchia1984.lean;Studies/McNallyDeSwart2011.lean;Studies/Roussou2010.lean}
+  sources   = {Semantics/Composition/TypeShifting.lean;Studies/Chierchia1984.lean;Studies/McNallyDeSwart2011.lean;Studies/Partee1987.lean;Studies/Roussou2010.lean}
 }
 @inproceedings{mcnally-deswart-2011,
   author    = {McNally, Louise and de Swart, Henri{\"e}tte},
@@ -41276,7 +41276,7 @@
   subfield  = {semantics/compositional},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Composition/TypeShifting.lean}
+  sources   = {Semantics/Composition/TypeShifting.lean;Studies/Partee1987.lean}
 }
 
 % REF: Wilder, C. (2008). Shared constituents and linearization. In K. Johnson (ed.), Topics in Ellipsis. CUP.


### PR DESCRIPTION
Deep pass on Partee1987 against the paper (OCR of the scanned chapter).

- the three inverse pairs of Figure 1, the three readings of the king of Figure 2, and the naturalness facts about BE and A of section 3.3, each stated over the substrate's shifters
- the toy-fragment examples and the copula-only framing dropped