### PR TITLE
refactor(Studies/Pustejovsky1995): coercion over a lattice and qualia

### DIFF
--- a/Linglib/Studies/Pustejovsky1995.lean
+++ b/Linglib/Studies/Pustejovsky1995.lean
@@ -1,60 +1,102 @@
+import Mathlib.Order.Basic
+import Mathlib.Tactic.DeriveFintype
+
 /-!
-# Pustejovsky (1995): Generative Lexicon — qualia-derived complement coercion
-[pustejovsky-1995]
+# Pustejovsky (1995): The Generative Lexicon
 
-GL §7.1 introduces *type coercion*: a semantic operation that
-converts an argument to the type expected by a function, "where it
-would otherwise result in a type error" (paper p. 111, def. 16). The
-coercion is selected from a set `Σ_α` of shifting operators
-*available for the source expression α*, derived from the noun's
-qualia structure (TELIC, AGENTIVE: paper §6.2).
+This file formalizes the type coercion of the seventh chapter of [pustejovsky-1995]. Type
+coercion (16) converts an argument to the type a function expects where application would
+otherwise fail, and function application with coercion (17) applies a function either
+directly, when the argument has the selected type, or through one of the shifting operators
+available to the argument, and otherwise produces a type error (`Shifter`, `Applies`). The
+available operators are of two kinds. Subtype coercion (23) follows the inferences of a
+single type lattice, the one of Figure 6.1 extended by the chains of §7.1.2, so that *drive*
+accepts *a Honda* through Honda ≤ car ≤ vehicle (`SemType`, `subtype_readings`,
+`subtype_within_lattice`). True complement coercion (§7.1.3) instead
+reaches through the qualia: *begin* selects an event, *a book* is a dot object of
+information and physical object whose telic and agentive qualia name reading and writing
+events (29), and the two event readings of *John began a book* (27) are exactly the two
+qualia projections (`begin_book_readings`), each leaving the type lattice
+(`book_qualia_leave_lattice`). The coerced complement embeds the noun phrase in the event
+expression (31), and on a model where a reading of the book is not a writing of it the two
+readings differ (`telic_ne_agentive`). Where the noun has no event-typed alias, *Mary began
+the rock* of the fourth chapter, coercion fails (`begin_rock_no_reading`).
 
-**Why not Lean `Coe`.** Lean's `Coe` matches GL's *subtype coercion*
-(§7.1.2: Honda ≤ car ≤ vehicle) but not *true complement coercion*
-(§7.1.3). Three reasons it would be wrong here:
+## Implementation notes
 
-1. *Multiple shifters per noun.* `begin a book` admits BOTH the
-   TELIC reading (begin reading) AND the AGENTIVE reading (begin
-   writing) — paper p. 86. A single Coe instance commits prematurely
-   to one. The verb selects among the available shifters; coercion
-   is genuinely ambiguous before selection.
-
-2. *Meaning-changing.* Pustejovsky distinguishes complement coercion
-   from subsumption: the source value is *mapped to a different
-   entity* (book ↦ reading-event), not viewed as a member of a
-   supertype. The coercion must be visible in proofs, not implicitly
-   inserted.
-
-3. *Σ_α as first-class data.* Theorems quantify over the available
-   shifters for a noun (e.g., "any noun with a non-trivial TELIC
-   admits a use-event coercion"). Lean instance databases are not
-   introspectable; we need `Σ : NounMeaning → Finset Shifter` as
-   data.
-
-## Main definitions
-
-* `Qualia`, `NounMeaning`: paper §6.2 (eq. 31 for `book`).
-* `Shifter`: a qualia-source-tagged coercion from a noun to a
-  target type. Concrete shifters are derived from TELIC and AGENTIVE.
-* `complementCoerce`: explicit application of a shifter (not
-  Lean-native Coe — coercion is meaning-changing and must be
-  visible).
-* `bookMeaning`: paper §6.2 eq. 31 (CONST=pages, FORMAL=physobj,
-  TELIC=read, AGENTIVE=write).
-* Paradigm theorems exposing BOTH TELIC and AGENTIVE readings of
-  "John began a book" (paper p. 86).
+Types are the sorts of the paper's examples with an explicit ancestor list each, the dot
+object *book* inheriting from both information and physical object; a quale enters coercion
+by the type it projects, its relational content only in the model of (31), and the formal and
+constitutive qualia project no alias. The *want* and *believe* paradigms of §7.1 and the
+aspectual coercion of the ninth chapter are not formalized.
 
 ## References
 
-* [pustejovsky-1995] §6.2 (qualia structure), §7.1.3
-  (true complement coercion), p. 86 (book's two coercion readings).
+* [pustejovsky-1995]
 -/
 
 namespace Pustejovsky1995
 
-/-! ### Paper §6.2: qualia structure -/
+/-! ### The type lattice (Figure 6.1, §7.1.2) -/
 
-/-- The four qualia roles (paper §6.1 "Modes of Explanation"). -/
+/-- The types of Figure 6.1 and of the examples of §7.1: the top `nomrqs` above entity, event,
+and proposition; abstract, physical object, and information below entity; the chains of
+(19), vehicle above car above Honda and text above book above the *Tractatus*, book being a
+dot object of information and physical object; and rock, a plain physical object. -/
+inductive SemType where
+  | nomrqs
+  | entity
+  | event
+  | proposition
+  | abstract
+  | physObj
+  | information
+  | vehicle
+  | car
+  | honda
+  | text
+  | book
+  | tractatus
+  | rock
+  deriving DecidableEq, Repr, Fintype
+
+/-- A type with its ancestors in the lattice, itself first. -/
+def SemType.ancestors : SemType → List SemType
+  | .nomrqs => [.nomrqs]
+  | .entity => [.entity, .nomrqs]
+  | .event => [.event, .nomrqs]
+  | .proposition => [.proposition, .nomrqs]
+  | .abstract => [.abstract, .entity, .nomrqs]
+  | .physObj => [.physObj, .entity, .nomrqs]
+  | .information => [.information, .entity, .nomrqs]
+  | .vehicle => [.vehicle, .physObj, .entity, .nomrqs]
+  | .car => [.car, .vehicle, .physObj, .entity, .nomrqs]
+  | .honda => [.honda, .car, .vehicle, .physObj, .entity, .nomrqs]
+  | .text => [.text, .information, .entity, .nomrqs]
+  | .book => [.book, .text, .information, .physObj, .entity, .nomrqs]
+  | .tractatus => [.tractatus, .book, .text, .information, .physObj, .entity, .nomrqs]
+  | .rock => [.rock, .physObj, .entity, .nomrqs]
+
+/-- Subtyping: `a ≤ b` when `b` is an ancestor of `a`. -/
+instance : PartialOrder SemType where
+  le a b := b ∈ a.ancestors
+  le_refl := by decide
+  le_trans := by decide
+  le_antisymm := by decide
+
+instance : DecidableRel (α := SemType) (· ≤ ·) :=
+  λ a b => inferInstanceAs (Decidable (b ∈ a.ancestors))
+
+/-- The chains of (19) and (24): a Honda is a car is a vehicle, and the *Tractatus* is a book
+is a text. -/
+theorem chains :
+    SemType.honda ≤ .car ∧ SemType.car ≤ .vehicle ∧ SemType.honda ≤ .vehicle ∧
+      SemType.tractatus ≤ .book ∧ SemType.book ≤ .text := by
+  decide
+
+/-! ### Qualia and shifting operators -/
+
+/-- The four qualia roles (§6.1). -/
 inductive QualeRole where
   | constitutive
   | formal
@@ -62,131 +104,139 @@ inductive QualeRole where
   | agentive
   deriving DecidableEq, Repr
 
-/-- A qualia structure: each role maps to a "logical parameter"
-    (paper p. 76). Here flattened to a target type per role; the
-    paper's relational forms (e.g., TELIC = read(P,w,x)) collapse
-    to the target-type-of-the-relation at this fidelity. `none`
-    means the role is unspecified (paper §6.2: not all nouns
-    instantiate all four). -/
-structure Qualia where
-  constitutive : Option Type
-  formal       : Option Type
-  telic        : Option Type
-  agentive     : Option Type
+/-- A lexical entry as coercion sees it: its type, and the type each quale projects where the
+quale is specified. -/
+structure Entry where
+  type : SemType
+  quale : QualeRole → Option SemType
 
-/-- A noun lexical entry under GL: extension + qualia (paper §5.1
-    "Levels of Representation"). -/
-structure NounMeaning where
-  extension : Type
-  qualia    : Qualia
+/-- *book* (29): a dot object whose telic quale, *read*, and agentive quale, *write*, both name
+events. -/
+def book : Entry :=
+  ⟨.book, λ | .telic => some .event | .agentive => some .event | _ => none⟩
 
-/-! ### Paper §6.2 eq. 31: book
+/-- *Honda* (21): a car whose telic quale is driving and whose agentive quale is its creation. -/
+def honda : Entry :=
+  ⟨.honda, λ | .telic => some .event | .agentive => some .event | _ => none⟩
 
-`book` = ⟨ARG1 = x:information, ARG2 = y:phys_obj⟩ with qualia
-CONST=pages, FORMAL=hold(y,x), TELIC=read(e,w,x,y), AGENTIVE=write(e',v,x,y).
-At our fidelity: TELIC = reading-event, AGENTIVE = writing-event. -/
+/-- The *Tractatus*: a book. -/
+def tractatus : Entry :=
+  ⟨.tractatus, λ | .telic => some .event | .agentive => some .event | _ => none⟩
 
-inductive Book where | warAndPeace | hamlet | mobyDick
+/-- *rock*: a physical object naming no event in its qualia. -/
+def rock : Entry := ⟨.rock, λ _ => none⟩
+
+/-- A shifting operator available to an expression, the paper's Σ_α: the subtype coercion
+(23) to a type of the lattice, or the projection of a quale. -/
+inductive Shifter where
+  | subtype (target : SemType)
+  | quale (r : QualeRole)
   deriving DecidableEq, Repr
 
-inductive ReadingEvent where | reading : Book → ReadingEvent
-  deriving DecidableEq, Repr
+/-- The type a shifter yields on an entry, where it applies: a subtype coercion yields its target
+when the entry's type lies below it, and a quale its projected type. -/
+def Shifter.result (α : Entry) : Shifter → Option SemType
+  | .subtype t => if α.type ≤ t then some t else none
+  | .quale r => α.quale r
 
-inductive WritingEvent where | writing : Book → WritingEvent
-  deriving DecidableEq, Repr
+/-- An alias of type `t` is available to `α` when some shifter yields it. -/
+def Alias (α : Entry) (t : SemType) : Prop := ∃ σ : Shifter, σ.result α = some t
 
-/-- Paper eq. 31 for `book`. -/
-def bookMeaning : NounMeaning where
-  extension := Book
-  qualia :=
-    { constitutive := none      -- "pages" (informational composition); not modelled
-      formal       := some Book
-      telic        := some ReadingEvent
-      agentive     := some WritingEvent }
+/-- Function application with coercion (17): a function of type ⟨a, b⟩ applies to `α` directly
+when `α` has type `a`, or through a shifter yielding `a`; each route is a reading. -/
+def Applies (f : SemType × SemType) (α : Entry) : Option Shifter → Prop
+  | none => α.type = f.1
+  | some σ => σ.result α = some f.1
 
-/-! ### Shifters: qualia-derived coercions
+instance (f : SemType × SemType) (α : Entry) : DecidablePred (Applies f α) := λ σ => by
+  cases σ <;> unfold Applies <;> infer_instance
 
-A `Shifter` records both the target type and the qualia role that
-*licenses* the coercion. Paper's Σ_α is the set of shifters derived
-from α's qualia. -/
+/-- A coerced reading exists exactly when an alias of the selected type is available, the
+condition on which the paper makes coercion succeed. -/
+theorem exists_coerced_iff_alias (f : SemType × SemType) (α : Entry) :
+    (∃ σ, Applies f α (some σ)) ↔ Alias α f.1 :=
+  Iff.rfl
 
-/-- A coercion shifter: target type plus the qualia role that
-    licenses it. -/
-structure Shifter (N : NounMeaning) where
-  role   : QualeRole
-  target : Type
-  shift  : N.extension → target
+/-- A subtype coercion never leaves the lattice: its result lies above the entry's type. -/
+theorem subtype_within_lattice (α : Entry) {t t' : SemType}
+    (h : (Shifter.subtype t).result α = some t') : α.type ≤ t' := by
+  by_cases hle : α.type ≤ t
+  · simp [Shifter.result, hle] at h
+    exact h ▸ hle
+  · simp [Shifter.result, hle] at h
 
-/-- The set of shifters derived from a noun's qualia (paper FAC's
-    Σ_α). For each role with a defined quale-target, there is one
-    shifter (the structural projection onto that quale). The actual
-    quale-projection function (e.g., `Book → ReadingEvent`) is
-    declared per-noun, since the relationship is lexical, not
-    structural. -/
-def Qualia.targets (q : Qualia) : List (QualeRole × Type) :=
-  let opt (r : QualeRole) (t : Option Type) : List (QualeRole × Type) :=
-    match t with | none => [] | some τ => [(r, τ)]
-  opt .constitutive q.constitutive ++
-  opt .formal       q.formal       ++
-  opt .telic        q.telic        ++
-  opt .agentive     q.agentive
+/-! ### Subtype coercion (§7.1.2) and true complement coercion (§7.1.3) -/
 
-/-- The TELIC shifter for `book`: book ↦ reading-event (paper §7.1.3
-    "begin a novel" = begin reading a novel, p. 84 eq. 19). -/
-def bookTelicShifter : Shifter bookMeaning where
-  role   := .telic
-  target := ReadingEvent
-  shift  := ReadingEvent.reading
+/-- *drive* selects a vehicle. -/
+def drive : SemType × SemType := (.vehicle, .proposition)
 
-/-- The AGENTIVE shifter for `book`: book ↦ writing-event (paper
-    p. 86: book has TWO event types via TELIC and AGENTIVE; either
-    is available for a coerce-to-event verb). -/
-def bookAgentiveShifter : Shifter bookMeaning where
-  role   := .agentive
-  target := WritingEvent
-  shift  := WritingEvent.writing
+/-- *read* selects a text. -/
+def read : SemType × SemType := (.text, .proposition)
 
-/-! ### Explicit complement-coercion application
+/-- *begin* selects an event (28). -/
+def begin : SemType × SemType := (.event, .proposition)
 
-Coercion is meaning-changing (paper §7.1.3) and must be visible in
-the term, NOT silently inserted by the elaborator. Hence `complementCoerce`
-is an explicit function, not a Lean `Coe` instance. -/
+/-- (19) and (24): *drive a Honda* and *read the Tractatus* have exactly one reading each, the
+subtype coercion along the chain. -/
+theorem subtype_readings :
+    (∀ σ, Applies drive honda σ ↔ σ = some (.subtype .vehicle)) ∧
+      ∀ σ, Applies read tractatus σ ↔ σ = some (.subtype .text) := by
+  refine ⟨λ σ => ?_, λ σ => ?_⟩ <;> cases σ with
+  | none => decide
+  | some σ => cases σ with
+    | subtype t => cases t <;> decide
+    | quale r => cases r <;> decide
 
-/-- Apply a shifter to a value of the noun's extension. The result
-    lives in the shifter's target type. -/
-def complementCoerce {N : NounMeaning} (σ : Shifter N) (a : N.extension) : σ.target :=
-  σ.shift a
+/-- (27), (29): *John began a book* has exactly two readings, the telic and the agentive
+projections of the qualia of *book*, reading it and writing it. -/
+theorem begin_book_readings (σ : Option Shifter) :
+    Applies begin book σ ↔ σ = some (.quale .telic) ∨ σ = some (.quale .agentive) := by
+  cases σ with
+  | none => decide
+  | some σ => cases σ with
+    | subtype t => cases t <;> decide
+    | quale r => cases r <;> decide
 
-/-! ### Paradigm: "John began a book" (paper p. 86)
+/-- The qualia projections of *book* leave the type lattice: an event lies above neither book
+nor any of its supertypes, which is what distinguishes true complement coercion from subtype
+coercion. -/
+theorem book_qualia_leave_lattice (r : QualeRole) {t : SemType}
+    (h : (Shifter.quale r).result book = some t) : ¬ book.type ≤ t := by
+  cases r <;> simp [Shifter.result, book] at h <;> subst h <;> decide
 
-The paper's central case: `begin` expects an event-typed argument;
-`a book` is a Book; the type mismatch triggers FAC; book's qualia
-offer BOTH TELIC (reading) AND AGENTIVE (writing) shifters, so the
-sentence is **genuinely ambiguous** between two readings. The verb
-or context resolves. -/
+/-- With no event in its qualia, *began the rock* is a type error, clause (iii) of (17). -/
+theorem begin_rock_no_reading (σ : Option Shifter) : ¬ Applies begin rock σ := by
+  cases σ with
+  | none => decide
+  | some σ => cases σ with
+    | subtype t => cases t <;> decide
+    | quale r => cases r <;> decide
 
-def begin_read : ReadingEvent → Prop := fun _ => True
-def begin_write : WritingEvent → Prop := fun _ => True
+/-! ### The coerced complement (31) -/
 
-/-- TELIC reading: `begin a book` = begin reading a book. -/
-theorem began_book_telic_reading :
-    begin_read (complementCoerce bookTelicShifter Book.warAndPeace) :=
-  trivial
+/-- A model of the coerced complement: events, individuals, and the reading and writing
+relations the qualia of *book* name. -/
+structure Model where
+  Event : Type
+  Entity : Type
+  read : Event → Entity → Entity → Prop
+  write : Event → Entity → Entity → Prop
 
-/-- AGENTIVE reading: `begin a book` = begin writing a book. -/
-theorem began_book_agentive_reading :
-    begin_write (complementCoerce bookAgentiveShifter Book.warAndPeace) :=
-  trivial
+/-- *a book* coerced through its telic quale, λx λe [read(e, x, a_book)] (31). -/
+def Model.telicReading (M : Model) (b : M.Entity) : M.Entity → M.Event → Prop :=
+  λ x e => M.read e x b
 
-/-- **Paper p. 86 thesis**: `book` admits at least two distinct
-    qualia-derived shifters (TELIC and AGENTIVE), one targeting
-    reading-events and one targeting writing-events. Both readings
-    are available for `begin a book`; pragmatic context resolves. -/
-theorem book_admits_two_shifters :
-    bookTelicShifter.role = QualeRole.telic ∧
-    bookAgentiveShifter.role = QualeRole.agentive ∧
-    bookTelicShifter.target = ReadingEvent ∧
-    bookAgentiveShifter.target = WritingEvent :=
-  ⟨rfl, rfl, rfl, rfl⟩
+/-- *a book* coerced through its agentive quale, λx λe [write(e, x, a_book)]. -/
+def Model.agentiveReading (M : Model) (b : M.Entity) : M.Entity → M.Event → Prop :=
+  λ x e => M.write e x b
+
+/-- On a model with an event that is a reading of the book by `x` and not a writing of it, the
+two readings of *began a book* are distinct predicates: the ambiguity is genuine. -/
+theorem telic_ne_agentive (M : Model) {b x : M.Entity} {e : M.Event} (h : M.read e x b)
+    (h' : ¬ M.write e x b) : M.telicReading b ≠ M.agentiveReading b := by
+  intro heq
+  have := congrFun (congrFun heq x) e
+  simp only [Model.telicReading, Model.agentiveReading] at this
+  exact h' (this ▸ h)
 
 end Pustejovsky1995


### PR DESCRIPTION
Deep pass on Pustejovsky1995 against the book's seventh chapter.

- the type lattice of Figure 6.1 with the chains of section 7.1.2 as a partial order, and function application with coercion (17) as a reading relation over the subtype and qualia shifters
- drive a Honda has one reading, began a book exactly the telic and agentive ones, began the rock none; the qualia shifters are shown to leave the lattice where subtype coercion stays inside it
- the two readings of the coerced complement (31) proved distinct on a model, replacing the trivial stubs and Option Type fields