### PR TITLE
feat(Core): Giry bind interchange lemmas; countable derivation trees

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
@@ -1,6 +1,8 @@
 import Mathlib.Computability.ContextFreeGrammar
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Linglib.Core.Order.Branching
+import Mathlib.Data.W.Basic
+import Mathlib.Logic.Encodable.Basic
 
 /-!
 # Derivation Trees for Context-Free Grammars
@@ -16,6 +18,7 @@ children. The file provides:
 * `exists_valid_tree`: tree existence, with height–yield bounds.
 * `size`: the size measure, with minimality and a pigeonhole on derivation paths.
 * `map`: relabelling of nonterminals, commuting with `yield`, `height` and `subtreeAt?`.
+* A `Countable` instance for countable `T` and `N`, by an injection into a W-type.
 -/
 /-- A derivation tree for a context-free grammar.
     Leaves hold terminal symbols; internal nodes hold a nonterminal
@@ -1219,5 +1222,65 @@ instance : Core.Order.IsFiniteBranching (DerivationTree T N) :=
       have := List.sizeOf_lt_of_mem hc
       simp only [DerivationTree.node.sizeOf_spec]
       omega
+
+/-! ### Countability -/
+
+/-- Branching signature of the W-type encoding: leaves and the empty list have no children, a
+node has one child (its list of children), a cons cell has two. -/
+private def wArity : Option (T ⊕ (N ⊕ Unit)) → Type
+  | some (.inl _) => Empty
+  | some (.inr (.inl _)) => Unit
+  | none => Empty
+  | some (.inr (.inr _)) => Bool
+
+mutual
+private def toW : DerivationTree T N → WType (wArity (T := T) (N := N))
+  | .leaf t => ⟨some (.inl t), Empty.elim⟩
+  | .node n cs => ⟨some (.inr (.inl n)), fun _ => toWList cs⟩
+private def toWList : List (DerivationTree T N) → WType (wArity (T := T) (N := N))
+  | [] => ⟨none, Empty.elim⟩
+  | c :: cs => ⟨some (.inr (.inr ())), fun b => bif b then toW c else toWList cs⟩
+end
+
+mutual
+private theorem toW_injective : ∀ {t t' : DerivationTree T N}, toW t = toW t' → t = t'
+  | .leaf _, .leaf _, h => by
+    obtain ⟨h1, -⟩ := WType.mk.inj h
+    cases h1; rfl
+  | .leaf _, .node _ _, h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | .node _ _, .leaf _, h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | .node n cs, .node n' cs', h => by
+    obtain ⟨h1, h2⟩ := WType.mk.inj h
+    cases h1
+    rw [toWList_injective (congr_fun (eq_of_heq h2) ())]
+private theorem toWList_injective :
+    ∀ {cs cs' : List (DerivationTree T N)}, toWList cs = toWList cs' → cs = cs'
+  | [], [], _ => rfl
+  | [], _ :: _, h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | _ :: _, [], h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | c :: cs, c' :: cs', h => by
+    obtain ⟨-, h2⟩ := WType.mk.inj h
+    have h3 := congr_fun (eq_of_heq h2)
+    rw [toW_injective (t := c) (t' := c') (by simpa using h3 true),
+      toWList_injective (cs := cs) (cs' := cs') (by simpa using h3 false)]
+end
+
+instance [Countable T] [Countable N] : Countable (DerivationTree T N) := by
+  classical
+  let _ := Encodable.ofCountable T
+  let _ := Encodable.ofCountable N
+  have _ : ∀ a, Fintype (wArity (T := T) (N := N) a) := fun a => by
+    rcases a with _ | (_ | (_ | _))
+    · exact inferInstanceAs (Fintype Empty)
+    · exact inferInstanceAs (Fintype Empty)
+    · exact inferInstanceAs (Fintype Unit)
+    · exact inferInstanceAs (Fintype Bool)
+  have _ : ∀ a, Encodable (wArity (T := T) (N := N) a) := fun a => by
+    rcases a with _ | (_ | (_ | _))
+    · exact inferInstanceAs (Encodable Empty)
+    · exact inferInstanceAs (Encodable Empty)
+    · exact inferInstanceAs (Encodable Unit)
+    · exact inferInstanceAs (Encodable Bool)
+  exact Function.Injective.countable fun _ _ h => toW_injective h
 
 end DerivationTree

--- a/Linglib/Core/MeasureTheory/Measure/GiryMonad.lean
+++ b/Linglib/Core/MeasureTheory/Measure/GiryMonad.lean
@@ -7,6 +7,7 @@ import Mathlib.MeasureTheory.Measure.GiryMonad
 import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
 import Mathlib.MeasureTheory.Integral.Lebesgue.Add
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
+import Mathlib.MeasureTheory.Measure.Prod
 import Linglib.Core.Order.CompleteLattice
 import Linglib.Core.Order.OmegaCompletePartialOrder
 
@@ -29,6 +30,9 @@ recursive probabilistic programs of [kozen-1981], stated on the monad of [giry-1
   suprema of measures.
 * `MeasureTheory.Measure.iSup_bind_of_monotone`, `MeasureTheory.Measure.bind_iSup_of_monotone`:
   `bind` commutes with monotone suprema in each argument.
+* `MeasureTheory.Measure.bind_map`, `MeasureTheory.Measure.map_bind`,
+  `MeasureTheory.Measure.bind_comm`: `bind` and `map` interchange, and two independent `bind`s
+  commute (Fubini).
 * `MeasureTheory.Measure.ωScottContinuous_bind`, `MeasureTheory.Measure.ωScottContinuous_map`:
   `bind` is ω-Scott-continuous jointly in the measure and the kernel, and `map` in the measure,
   so operators built from them have Kleene least fixed points.
@@ -134,6 +138,50 @@ theorem bind_iSup_of_monotone {μ : Measure α} {f : ℕ → α → Measure β}
   simp_rw [bind_apply hs (hf _).aemeasurable, hpt _ hs]
   exact lintegral_iSup (fun n => (measurable_coe hs).comp (hf n))
     fun m n h a => le_iff'.1 (hmono h a) s
+
+/-! ### Interchange -/
+
+section Interchange
+
+variable {γ : Type*} [MeasurableSpace γ]
+
+theorem bind_map {μ : Measure α} {f : α → β} {g : β → Measure γ} (hf : Measurable f)
+    (hg : Measurable g) : (μ.map f).bind g = μ.bind (g ∘ f) := by
+  ext s hs
+  rw [bind_apply hs hg.aemeasurable, bind_apply hs (hg.comp hf).aemeasurable]
+  exact lintegral_map ((measurable_coe hs).comp hg) hf
+
+theorem map_bind {μ : Measure α} {f : α → Measure β} {g : β → γ} (hf : Measurable f)
+    (hg : Measurable g) : (μ.bind f).map g = μ.bind fun a => (f a).map g := by
+  ext s hs
+  rw [map_apply hg hs, bind_apply (hg hs) hf.aemeasurable,
+    bind_apply (f := fun a => (f a).map g) hs ((measurable_map _ hg).comp hf).aemeasurable]
+  simp_rw [map_apply hg hs]
+
+/-- Two independent `bind`s commute: Fubini on the Giry monad. -/
+theorem bind_comm {μ : Measure α} {ν : Measure β} [SFinite μ] [SFinite ν]
+    {f : α → β → Measure γ} (hf : Measurable (Function.uncurry f)) :
+    μ.bind (fun a => ν.bind (f a)) = ν.bind fun b => μ.bind (f · b) := by
+  have hfs : ∀ s, MeasurableSet s → Measurable (Function.uncurry fun a b => f a b s) :=
+    fun s hs => (measurable_coe hs).comp hf
+  have hl : ∀ a, AEMeasurable (f a) ν := fun a =>
+    (hf.comp measurable_prodMk_left : Measurable (f a)).aemeasurable
+  have hr : ∀ b, AEMeasurable (f · b) μ := fun b =>
+    (hf.comp measurable_prodMk_right : Measurable (f · b)).aemeasurable
+  have h1 : Measurable fun a => ν.bind (f a) :=
+    measurable_of_measurable_coe _ fun s hs => by
+      simp_rw [fun a => bind_apply hs (hl a)]
+      exact (hfs s hs).lintegral_prod_right'
+  have h2 : Measurable fun b => μ.bind (f · b) :=
+    measurable_of_measurable_coe _ fun s hs => by
+      simp_rw [fun b => bind_apply hs (hr b)]
+      exact (hfs s hs).lintegral_prod_left'
+  ext s hs
+  rw [bind_apply hs h1.aemeasurable, bind_apply hs h2.aemeasurable]
+  simp_rw [fun a => bind_apply hs (hl a), fun b => bind_apply hs (hr b)]
+  exact lintegral_lintegral_swap (hfs s hs).aemeasurable
+
+end Interchange
 
 /-! ### ω-Scott continuity -/
 


### PR DESCRIPTION
Prerequisites for identifying the Galton–Watson law with the absorbed part of the Ionescu–Tulcea trajectory measure.

- `Measure.bind_map`, `Measure.map_bind` (bind/map interchange) and `Measure.bind_comm` (two independent binds commute; Fubini on the Giry monad, for s-finite measures and a jointly measurable kernel) in `Core/MeasureTheory/Measure/GiryMonad.lean`; none exist in mathlib
- `Countable (DerivationTree T N)` for countable `T`, `N`, by an injection into a W-type over `Option (T ⊕ (N ⊕ Unit))` with arities `Empty`/`Unit`/`Bool`; mathlib's `Countable` deriving handler does not accept the nested inductive