### PR TITLE
refactor(Studies/PhillipsBrown2025): constraints as general theorems

### DIFF
--- a/Linglib/Semantics/Attitudes/Desire/BestWorlds.lean
+++ b/Linglib/Semantics/Attitudes/Desire/BestWorlds.lean
@@ -59,7 +59,13 @@ theorem Want.not_compl [Finite W] (h : bel.Nonempty) (hp : Want G bel p) :
   let ⟨w, hw, hu⟩ := exists_undominated G bel h
   hnp w hw hu (hp w hw hu)
 
+/-- Closure under doxastic entailment: what is wanted is wanted under every consequence the
+agent believes it to have, the doxastic-closure problem of [villalta-2008]. -/
+theorem Want.mono_on {q : Set W} (hpq : ∀ w ∈ bel, w ∈ p → w ∈ q) (h : Want G bel p) :
+    Want G bel q :=
+  fun w hw hu => hpq w hw (h w hw hu)
+
 theorem Want.mono {q : Set W} (hpq : p ⊆ q) (h : Want G bel p) : Want G bel q :=
-  fun w hw hu => hpq (h w hw hu)
+  h.mono_on fun _ _ hw => hpq hw
 
 end Desire.BestWorlds

--- a/Linglib/Semantics/Attitudes/Desire/QuestionBased.lean
+++ b/Linglib/Semantics/Attitudes/Desire/QuestionBased.lean
@@ -13,7 +13,10 @@ metasemantic constraints — `IsConsidered` (every answer settles `p`), `IsDiver
 itself settled; [condoravdi-2002]), `IsBelSensitive` (the beliefs discriminate among the
 answers; [yalcin-2018]) — bundled as `Defined` and as the presupposition of `toPartialProp`,
 under which the ascription is Strawson upward monotone (`toPartialProp_strawsonEntails`).
-On the finest question the semantics is the best-worlds one (`want_finest_iff`).
+Diversity is what blocks vacuous falsity and truth (`not_want_of_not_exists`,
+`want_of_isConsidered_of_not_exists`). The question raised by a list of issues, the coarsest
+relative to which each is considered, is `ofIssues`. On the finest question the semantics is
+the best-worlds one (`want_finest_iff`).
 -/
 
 namespace Desire.QuestionBased
@@ -92,6 +95,57 @@ variable {G N Q bel p}
 
 theorem Want.mono {q : Set W} (hpq : p ⊆ q) (h : Want G Q bel p) : Want G Q bel q :=
   fun a ha hl hb w hw => hpq (h a ha hl hb w hw)
+
+/-! ### Best answers and diversity -/
+
+/-- A best live answer exists whenever some answer is live. -/
+theorem exists_best (h : ∃ a ∈ Q, Live bel a) :
+    ∃ a ∈ Q, Live bel a ∧ ∀ a' ∈ Q, Live bel a' → le G a' a → le G a a' := by
+  let _ : Preorder (Finset W) := Preorder.ofCriteria (fun a s : Finset W => a ⊆ s) {s | s ∈ G}
+  obtain ⟨a, ha⟩ := Set.Finite.exists_minimal
+    ((List.finite_toSet Q).subset fun a (ha : a ∈ Q ∧ Live bel a) => ha.1)
+    (let ⟨a, haQ, hl⟩ := h; ⟨a, haQ, hl⟩)
+  exact ⟨a, ha.1.1, ha.1.2, fun a' ha' hl' hle => ha.2 ⟨ha', hl'⟩ hle⟩
+
+/-- Without a `p`-answer the ascription is false as soon as some answer is live: the
+diversity constraint against vacuous falsity. -/
+theorem not_want_of_not_exists (hlive : ∃ a ∈ Q, Live bel a)
+    (hp : ¬ ∃ a ∈ Q, ∀ w ∈ a, w ∈ p) : ¬ Want G Q bel p := fun hw =>
+  let ⟨a, haQ, hl, hbest⟩ := exists_best (G := G) hlive
+  hp ⟨a, haQ, hw a haQ hl hbest⟩
+
+/-- With every answer settling `p` and no `¬p`-answer the ascription is true: the diversity
+constraint against vacuous truth. -/
+theorem want_of_isConsidered_of_not_exists (hc : IsConsidered Q p)
+    (hnp : ¬ ∃ a ∈ Q, ∀ w ∈ a, w ∉ p) : Want G Q bel p := fun a ha _ _ w hw =>
+  ((hc a ha).resolve_right fun h => hnp ⟨a, ha, h⟩) w hw
+
+/-! ### The question raised by a list of issues -/
+
+/-- The question raised by a list of issues: the nonempty cells of the partition by which of
+the issues hold. -/
+def ofIssues [Fintype W] [DecidableEq W] : List (Finset W) → List (Finset W)
+  | [] => [Finset.univ]
+  | p :: ps => ((ofIssues ps).flatMap fun a => [a ∩ p, a \ p]).filter (·.Nonempty)
+
+/-- Each issue is considered relative to the question it raises. -/
+theorem isConsidered_ofIssues [Fintype W] [DecidableEq W] {ps : List (Finset W)}
+    {p : Finset W} (hp : p ∈ ps) : IsConsidered (ofIssues ps) (↑p : Set W) := by
+  induction ps with
+  | nil => simp at hp
+  | cons q ps ih =>
+    intro a ha
+    simp only [ofIssues, List.mem_filter, List.mem_flatMap, List.mem_cons, List.not_mem_nil,
+      or_false] at ha
+    obtain ⟨⟨b, hb, rfl | rfl⟩, -⟩ := ha
+    · rcases List.mem_cons.1 hp with rfl | hp'
+      · exact Or.inl fun w hw => (Finset.mem_inter.1 hw).2
+      · exact (ih hp' b hb).imp (fun h w hw => h w (Finset.mem_inter.1 hw).1)
+          (fun h w hw => h w (Finset.mem_inter.1 hw).1)
+    · rcases List.mem_cons.1 hp with rfl | hp'
+      · exact Or.inr fun w hw => (Finset.mem_sdiff.1 hw).2
+      · exact (ih hp' b hb).imp (fun h w hw => h w (Finset.mem_sdiff.1 hw).1)
+          (fun h w hw => h w (Finset.mem_sdiff.1 hw).1)
 
 /-- Strawson upward monotonicity: where both ascriptions are defined, `want p` entails
 `want q` for `p ⊆ q`. -/

--- a/Linglib/Studies/PhillipsBrown2025.lean
+++ b/Linglib/Studies/PhillipsBrown2025.lean
@@ -1,604 +1,214 @@
 import Linglib.Semantics.Attitudes.Desire.QuestionBased
 import Linglib.Semantics.Attitudes.Desire.Conditional
-import Linglib.Semantics.Attitudes.Desire.Preferential
-import Linglib.Semantics.Attitudes.Desire.ExpectedValue
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.Fintype.Powerset
 
 /-!
-# [phillips-brown-2025] — Some-Things-Considered Desire
+# Phillips-Brown (2025): Some-Things-Considered Desire
 
-Question-based semantics for desire ascriptions: ⟦S wants p⟧^c is true
-relative to a contextual question Q_c iff every undominated answer in
-Q_c-Bel_S entails p. The proposal handles conflicting-desire cases —
-"S wants p" + "S wants ¬p" — by varying Q_c.
+This file formalizes the question-based semantics of desire ascriptions of
+[phillips-brown-2025]. Conflicting ascriptions, *you want to take a nap* and *you don't want to
+take a nap* both true, falsify the belief-based semantics of [heim-1992] and [von-fintel-1999],
+which evaluate the agent's preferences over her whole belief set with no context sensitivity
+(§2.1) (`vonFintel_no_conflict`, `heim_no_conflict`); a context-sensitive preference relation
+predicts them but, valuing whole worlds, predicts *you want to fail the exam* wherever *Nap* is
+true (§2.2), an instance of the closure under doxastic equivalence of [villalta-2008] (§4.1)
+(`closure_under_doxastic_equivalence`, `cpr_overgenerates`). The proposal evaluates an
+ascription against a contextual question (§3): the answers compatible with the beliefs are
+ranked by the desires they entail, *S wants p* holds when every best answer entails *p*, and the
+ascription is defined only if *p* is considered relative to the question (§3.6), the question
+is diverse and does not stack the deck (§3.7), and the beliefs are sensitive to it (§4.2).
+*Nap* is true considering whether one naps and whether one feels rested, *Not-nap* considering
+whether one naps and whether one passes, and in the former context *Fail* is undefined, the
+outcome of the exam being ignored (`act_true`, `not_act_true`, `cost_undefined`); the lobster
+case, *Lobster*, *Not-lobster* and *Die*, is the same model. The deck-stacked question of Lu's
+case would make *Lu wants it not to rain* true and is excluded by the anti-deckstacking
+constraint, which the level playing field satisfies (`not_rain_deckstacked`,
+`deckstacked_excluded`); an agent whose beliefs are insensitive to every question that
+considers *p*, William III and nuclear war, has *S wants p* undefined in every context
+(`undefined_of_insensitive`), which leaves the semantics Strawson upward monotone
+(`Desire.QuestionBased.toPartialProp_strawsonEntails`).
 
-This study file replicates the Nap, Lobster, Lu/Happy/Rain
-(deck-stacking), and William-III/nuclear-war scenarios of
-[phillips-brown-2025], plus a §11 cross-paper bridge to
-[condoravdi-lauer-2016] (an effective-preferential alternative
-that refuses simultaneous `want(p)` and `want(¬p)`).
+## Implementation notes
 
-The substrate is `Semantics/Attitudes/Desire/`. All theorems
-here either compute by `decide` over an 8-world model (3 binary
-dimensions: `nap × rested × pass` = `lobster × gustatory × ¬die`) or
-delegate to the substrate's general theorems
-(`BestWorlds.Want.not_compl`,
-`toPartialProp_strawsonEntails`, …).
+The act, its benefit and its cost are the three issues of the nap and lobster cases (nap,
+feeling rested, failing the exam; eating the lobster, the gustatory experience, dying), the
+beliefs tying benefit and cost to the act, and the desires being the benefit and not the cost;
+a question is a list of answers, the question raised by a list of issues being the nonempty
+cells of their joint partition. The Anti-deckstacking Constraint quantifies over all
+propositions; read so, it admits only questions whose answers are singletons
+(`antiDeckstacking_univ_singleton`), so the substrate restricts it to a list of salient
+propositions, here the issues of each case. Heim's semantics is the conditional one of
+`Desire/Conditional`, and the diversity constraint's role, blocking vacuous truth and falsity,
+is `Desire.QuestionBased.not_want_of_not_exists` and `want_of_isConsidered_of_not_exists`.
+Levinson's expected-value comparison, the sufficient-desirability semantics of §2.4, the Heimian
+question-based semantics of footnote 16, and the finest-question simulation of §3.4
+(`Desire.QuestionBased.want_finest_iff`) are prose.
 
-## §-by-§ map
+## References
 
-| Paper | Study file |
-|-------|-----------|
-| §2.1 vF no-go | §5 (`vf_cannot_predict_both`, delegates to general) |
-| §3.3 Q-relative belief | §3, §4 |
-| §3.4 finest=vF | §8 |
-| §3.5 best-answer semantics | §3, §4 |
-| §3.6 Considering | §3, §4 |
-| §3.7 Diversity, Anti-deckstacking | §3, §7 |
-| §4.1 doxastic-closure blocking | §6 |
-| §4.2 Belief-sensitivity | §10 |
-| §5 cross-framework | §11 (CondoravdiLauer bridge) |
-
-## Parallel discovery: Cariani 2013 `isVisible`
-
-PB's `IsConsidered` (§3.6) is the same predicate as [cariani-2013]'s
-`isVisible` (§4 p.545–546): both require every cell of the
-partition/option-set to settle the prejacent. PB doesn't cite Cariani;
-Cariani doesn't anticipate PB. The identification is exposed in
-`Studies/Cariani2013.lean`, where Cariani's
-`isVisible` is defined as `abbrev isVisible rc p := IsConsidered
-rc.options p` and the bridge theorem `isVisible_iff_IsConsidered`
-reduces to `Iff.rfl`. The agreement is independent reinvention across
-the desire/deontic-modality boundary, surfaced by the substrate sharing
-a common predicate.
+* [phillips-brown-2025]
+* [heim-1992]
+* [von-fintel-1999]
+* [villalta-2008]
+* [yalcin-2018]
 -/
 
 namespace PhillipsBrown2025
 
 open Desire Desire.QuestionBased
 
-/-! ## §1. Eight-world model
-
-3 binary dimensions: `d₁ × d₂ × d₃`. For Nap: `d₁ = nap`, `d₂ = rested`,
-`d₃ = pass`. For Lobster (paper §2.2): `d₁ = lobster`, `d₂ = gustatory`,
-`d₃ = ¬die`. The Lobster scenario reuses the Nap dimensions via
-`abbrev` — see `lobster := nap`, `gustatory := rested`, `die := fail`
-below; the structural isomorphism is documented and not coincidental
-(`lobster_true := nap_true` is the same theorem under renaming). -/
-
-inductive W where
-  | w0 | w1 | w2 | w3 | w4 | w5 | w6 | w7
-  deriving DecidableEq, Fintype, Repr, Inhabited
-
-/-! ## §2. Propositions
-
-| World | nap | rested | pass |
-|-------|-----|--------|------|
-| w0    | T   | T      | T    |
-| w1    | T   | T      | F    |
-| w2    | T   | F      | T    |
-| w3    | T   | F      | F    |
-| w4    | F   | T      | T    |
-| w5    | F   | T      | F    |
-| w6    | F   | F      | T    |
-| w7    | F   | F      | F    |
--/
-
-def nap : Set W | .w0 | .w1 | .w2 | .w3 => True | _ => False
-def rested : Set W | .w0 | .w1 | .w4 | .w5 => True | _ => False
-def pass : Set W | .w0 | .w2 | .w4 | .w6 => True | _ => False
-def fail : Set W := passᶜ
-
-instance : DecidablePred (· ∈ nap) := fun w => by
-  cases w <;> first | exact isTrue trivial | exact isFalse id
-instance : DecidablePred (· ∈ rested) := fun w => by
-  cases w <;> first | exact isTrue trivial | exact isFalse id
-instance : DecidablePred (· ∈ pass) := fun w => by
-  cases w <;> first | exact isTrue trivial | exact isFalse id
-instance : DecidablePred (· ∈ fail) := inferInstanceAs (DecidablePred (· ∈ passᶜ))
-
-/-- The natural propositions of the model (basic dimensions), used to
-    feed `IsAntiDeckstacking`. AD's quantifier is restricted to this
-    test set — see `IsAntiDeckstacking`. -/
-def naturalProps : List (Finset W) :=
-  [Finset.univ.filter (· ∈ nap), Finset.univ.filter (· ∈ rested), Finset.univ.filter (· ∈ pass)]
-
-/-! ## §3. Nap scenario -/
-
-/-- Q' = partition by nap × rested (4 cells). -/
-def qNapRest : List (Finset W) :=
-  [Finset.univ.filter (fun w => w ∈ nap ∧ w ∈ rested),
-   Finset.univ.filter (fun w => w ∈ nap ∧ w ∉ rested),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∈ rested),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∉ rested)]
-
-/-- Q'' = partition by nap × pass (4 cells). -/
-def qNapPass : List (Finset W) :=
-  [Finset.univ.filter (fun w => w ∈ nap ∧ w ∈ pass),
-   Finset.univ.filter (fun w => w ∈ nap ∧ w ∉ pass),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∈ pass),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∉ pass)]
-
-/-- Beliefs for Nap: nap ↔ rested. Bel = {w0, w1, w6, w7}. -/
-def belNapRest : Set W := {w | if w ∈ nap then w ∈ rested else w ∉ rested}
-instance : DecidablePred (· ∈ belNapRest) :=
-  fun w => inferInstanceAs (Decidable (if w ∈ nap then w ∈ rested else w ∉ rested))
-
-/-- Beliefs for Not-nap: pass ↔ ¬nap. Bel = {w1, w3, w4, w6}. -/
-def belNapPass : Set W := {w | if w ∈ nap then w ∉ pass else w ∈ pass}
-instance : DecidablePred (· ∈ belNapPass) :=
-  fun w => inferInstanceAs (Decidable (if w ∈ nap then w ∉ pass else w ∈ pass))
-
-def desRest : List (Finset W) := [Finset.univ.filter (· ∈ rested)]
-def desPass : List (Finset W) := [Finset.univ.filter (· ∈ pass)]
-
-/-- **Nap is true** relative to Q' with beliefs nap↔rested, desires [rested]. -/
-theorem nap_true : Want desRest qNapRest belNapRest nap := by decide +kernel
-
-/-- **Not-nap is true** relative to Q'' with beliefs pass↔¬nap, desires [pass]. -/
-theorem not_nap_true :
-    Want desPass qNapPass belNapPass napᶜ := by decide +kernel
-
-/-- Fail is NOT considered relative to Q'. -/
-theorem fail_not_considered : ¬ IsConsidered qNapRest fail := by decide +kernel
-
-/-- Fail is also not predicted true. -/
-theorem fail_not_true :
-    ¬ Want desRest qNapRest belNapRest fail := by decide +kernel
-
-/-- Q' is diverse w.r.t. nap. -/
-theorem nap_diverse : IsDiverse qNapRest nap := by decide +kernel
-
-/-! ## §4. Lobster scenario (paper §2.2)
-
-The Lobster scenario reuses the Nap dimensions via `abbrev`:
-`lobster := nap`, `gustatory := rested`, `die := fail`. The two paper
-arguments use *different* questions over these dimensions — Q_{c''}
-(`qLobGus`) ignores death, Q_{c'''} (`qLobDie`) ignores taste. -/
-
-abbrev lobster : Set W := nap
-abbrev gustatory : Set W := rested
-abbrev die : Set W := fail
-
-/-- Q_{c''} = partition by lobster × gustatory (= `qNapRest`). -/
-abbrev qLobGus : List (Finset W) := qNapRest
-
-/-- Q_{c'''} = partition by lobster × die. -/
-def qLobDie : List (Finset W) :=
-  [Finset.univ.filter (fun w => w ∈ nap ∧ w ∈ fail),
-   Finset.univ.filter (fun w => w ∈ nap ∧ w ∉ fail),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∈ fail),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∉ fail)]
-
-/-- Beliefs: die ↔ eat lobster. Bel = {w1, w3, w4, w6}. -/
-def belLobDie : Set W := {w | if w ∈ nap then w ∈ fail else w ∉ fail}
-instance : DecidablePred (· ∈ belLobDie) :=
-  fun w => inferInstanceAs (Decidable (if w ∈ nap then w ∈ fail else w ∉ fail))
-
-def desNotDie : List (Finset W) := [Finset.univ.filter (· ∉ fail)]
-
-/-- **Lobster is true** in c'' (considering taste, ignoring death). -/
-theorem lobster_true :
-    Want desRest qLobGus belNapRest lobster := nap_true
-
-/-- **Die is undefined in the Lobster context c''** (paper §2.2): in
-    `qLobGus = qNapRest`, no cell settles `die`, so the Considering
-    presupposition fails. -/
-theorem die_not_considered_in_qLobGus :
-    ¬ IsConsidered qLobGus die := fail_not_considered
-
-/-- **Not-lobster is true** in c''' (considering death, ignoring taste). -/
-theorem not_lobster_true :
-    Want desNotDie qLobDie belLobDie napᶜ := by decide +kernel
-
-/-- **Not-die is also true** in c''' (best answer entails both ¬lobster and ¬die). -/
-theorem not_die_true :
-    Want desNotDie qLobDie belLobDie failᶜ := by decide +kernel
-
-/-! ## §5. Von Fintel comparison and the no-go theorem
-
-The paper's central argument against belief-based semantics: vF cannot
-predict both `want p` and `want ¬p` simultaneously. Specialised here
-for the Nap example, then derived from the substrate's general
-`BestWorlds.Want.not_compl`. -/
-
-theorem vf_nap_true : BestWorlds.Want desRest belNapRest nap := by decide +kernel
-
-theorem vf_not_nap_false :
-    ¬ BestWorlds.Want desRest belNapRest napᶜ := by decide +kernel
-
-/-- vF cannot predict both Nap and Not-nap with the same parameter set
-    (specific instance). -/
-theorem vf_cannot_predict_both :
-    ¬(BestWorlds.Want desRest belNapRest nap ∧
-      BestWorlds.Want desRest belNapRest napᶜ) := by
-  intro ⟨_, h⟩; exact vf_not_nap_false h
-
-/-- vF cannot predict both Nap and Not-nap (general no-go, delegates
-    to the substrate). The witness is any belS-world that is
-    Pareto-undominated under the desire ordering. -/
-theorem vf_no_conflict_nap :
-    ¬ (BestWorlds.Want desRest belNapRest nap ∧
-       BestWorlds.Want desRest belNapRest napᶜ) :=
-  fun ⟨hp, hnp⟩ => hp.not_compl ⟨.w0, by decide⟩ hnp
-
-/-! ## §6. Doxastic closure blocking (paper §4.1)
-
-[villalta-2008] identified the doxastic-closure problem for
-belief-based semantics: any proposition true at all best belief-worlds
-is predicted wanted, over-generating for coincidental propositions.
-
-The question-based approach makes `fail` UNDEFINED rather than merely
-false: `fail` is not settled by Q' (the nap × rested partition), so the
-Considering presupposition blocks ⟦want(fail)⟧^{Q'} at definedness.
-With Q'' (the nap × pass partition), `fail` is settled — and the
-contrast is exactly the paper's point. -/
-
-theorem nap_considered_in_qNapPass :
-    IsConsidered qNapPass nap := by decide +kernel
-
-theorem fail_considered_in_qNapPass :
-    IsConsidered qNapPass fail := by decide +kernel
-
-/-! ## §7. Anti-deckstacking (paper §3.7)
-
-Lu is unsure if it will rain, but is sure he'll feel happy no matter
-what. Q'''' (deck-stacked) = `{r, ¬r∧h, ¬r∧¬h}` asymmetrically
-cross-cuts rain with happiness; the `r` cell ignores `h` while the
-others distinguish it. Cell `¬r∧h` predetermines `h` (entails it), but
-`h` is not considered by the question. AD fails on `qDeckstacked` with
-test set `[r, h]`.
-
-Q''''' (level playing field) = partition by `rain × happy` (4 cells).
-AD passes for the same `[r, h]` test set. -/
-
-def happy : Set W | .w0 | .w1 | .w4 | .w5 => True | _ => False
-def rain : Set W | .w0 | .w1 | .w2 | .w3 => True | _ => False
-
-instance : DecidablePred (· ∈ happy) := fun w => by
-  cases w <;> first | exact isTrue trivial | exact isFalse id
-instance : DecidablePred (· ∈ rain) := fun w => by
-  cases w <;> first | exact isTrue trivial | exact isFalse id
-
-/-- Test set of natural propositions for the Lu scenario. -/
-def naturalPropsLu : List (Finset W) :=
-  [Finset.univ.filter (· ∈ rain), Finset.univ.filter (· ∈ happy)]
-
-/-- Q'''' (deck-stacked): {r, ¬r∧h, ¬r∧¬h}. -/
-def qDeckstacked : List (Finset W) :=
-  [Finset.univ.filter (· ∈ rain),
-   Finset.univ.filter (fun w => w ∉ rain ∧ w ∈ happy),
-   Finset.univ.filter (fun w => w ∉ rain ∧ w ∉ happy)]
-
-/-- Lu's beliefs: happy unconditionally. -/
-def belLu : Set W := happy
-instance : DecidablePred (· ∈ belLu) := inferInstanceAs (DecidablePred (· ∈ happy))
-
-def desHappy : List (Finset W) := [Finset.univ.filter (· ∈ happy)]
-
-/-- `happy` is not considered in the deck-stacked Q'''' (the `rain`
-    cell contains both happy and unhappy worlds). -/
-theorem happy_not_considered_deckstacked :
-    ¬ IsConsidered qDeckstacked happy := by decide +kernel
-
-/-- A `happy`-answer exists in qDeckstacked (the `¬r∧h` cell entails
-    `happy`) — the deck is stacked in favor of ¬rain. -/
-theorem happy_answer_exists_deckstacked :
-    ∃ a ∈ qDeckstacked, ∀ w ∈ a, w ∈ happy := by decide +kernel
-
-/-- Without the constraint, the question-based semantics wrongly
-    predicts Not-rain. -/
-theorem not_rain_deckstacked_true :
-    Want desHappy qDeckstacked belLu rainᶜ := by decide +kernel
-
-/-- Q''''' (level playing field): partition by rain × happy. -/
-def qRainHappy : List (Finset W) :=
-  [Finset.univ.filter (fun w => w ∈ rain ∧ w ∈ happy),
-   Finset.univ.filter (fun w => w ∈ rain ∧ w ∉ happy),
-   Finset.univ.filter (fun w => w ∉ rain ∧ w ∈ happy),
-   Finset.univ.filter (fun w => w ∉ rain ∧ w ∉ happy)]
-
-theorem happy_considered_fair :
-    IsConsidered qRainHappy happy := by decide +kernel
-
-/-- With the fair question, Not-rain is correctly predicted false. -/
-theorem not_rain_false_fair :
-    ¬ Want desHappy qRainHappy belLu rainᶜ := by decide +kernel
-
-/-- The deck-stacked question fails Anti-deckstacking on test set
-    `[r, h]` (`h` is predetermined by the `¬r∧h` cell but not
-    considered by Q''''). -/
-theorem qDeckstacked_fails_antideckstacking :
-    ¬ IsAntiDeckstacking naturalPropsLu qDeckstacked := by decide +kernel
-
-/-- The fair (cross-product) question satisfies Anti-deckstacking —
-    every basic proposition is settled by every cell. -/
-theorem qRainHappy_satisfies_antideckstacking :
-    IsAntiDeckstacking naturalPropsLu qRainHappy := by decide +kernel
-
-/-- Q' (`qNapRest`) satisfies Anti-deckstacking on the natural-prop
-    test set `[nap, rested, pass]` — the cross-product over `nap` and
-    `rested` settles `nap` and `rested`; no cell entails `pass`, so
-    AD's antecedent is vacuous for `pass`. -/
-theorem qNapRest_satisfies_antideckstacking :
-    IsAntiDeckstacking naturalProps qNapRest := by decide +kernel
-
-/-! ## §8. Finest-question simulation (paper §3.4)
-
-When Q_c is the finest partition (singleton cells = individual worlds),
-the question-based semantics reduces to vF. The substrate provides
-`finest : List W → List (Finset W)`; here we instantiate it
-on the explicit world list of the model. -/
-
-def allWorldsW : List W := [.w0, .w1, .w2, .w3, .w4, .w5, .w6, .w7]
-
-def qFinest : List (Finset W) := finest allWorldsW
-
-/-- The 8-world list `allWorldsW` covers `W`. Hypothesis required by the
-    substrate's general `want_finest_iff`. -/
-theorem allWorldsW_complete : ∀ w : W, w ∈ allWorldsW := by
-  intro w; cases w <;> decide
-
-/-- With the finest question, question-based want = standard vF want
-    for `nap`. Derived from the substrate's general
-    `want_finest_iff`, not by `decide`. -/
-theorem finest_simulates_vf_nap :
-    Want desRest qFinest belNapRest nap ↔
-    BestWorlds.Want desRest belNapRest nap :=
-  want_finest_iff allWorldsW_complete
-
-/-- With the finest question, question-based want = standard vF want
-    for `¬nap`. -/
-theorem finest_simulates_vf_not_nap :
-    Want desRest qFinest belNapRest napᶜ ↔
-    BestWorlds.Want desRest belNapRest napᶜ :=
-  want_finest_iff allWorldsW_complete
-
-/-- With the finest question, question-based want = standard vF want
-    for `¬lobster` in the Lobster context. -/
-theorem finest_simulates_vf_not_lobster :
-    Want desNotDie qFinest belLobDie napᶜ ↔
-    BestWorlds.Want desNotDie belLobDie napᶜ :=
-  want_finest_iff allWorldsW_complete
-
-/-! ## §9. Definedness via PartialProp (paper §3.6) -/
-
-theorem nap_defined_in_qNapRest :
-    Defined naturalProps qNapRest belNapRest nap := by decide +kernel
-
-theorem fail_not_defined_in_qNapRest :
-    ¬ Defined naturalProps qNapRest belNapRest fail := by decide +kernel
-
-theorem nap_prprop_holds :
-    (toPartialProp desRest naturalProps qNapRest belNapRest nap).presup .w0 ∧
-    (toPartialProp desRest naturalProps qNapRest belNapRest nap).assertion .w0 := by
-  refine ⟨?_, ?_⟩ <;> simp only [toPartialProp] <;> decide +kernel
-
-theorem fail_prprop_undefined :
-    ¬(toPartialProp desRest naturalProps qNapRest belNapRest fail).presup .w0 := by
-  simp only [toPartialProp]; decide +kernel
-
-/-! ## §10. Belief-sensitivity: William III / nuclear war (paper §4.2)
-
-William III wanted to avoid war. Avoiding war entails avoiding nuclear
-war. But we cannot conclude William III wanted to avoid nuclear war —
-he lacked the conceptual resources to grasp nuclear war.
-
-Mechanism: William's beliefs are NOT sensitive to Q_nuc that
-distinguishes nuclear from conventional war. All Q_nuc answers are
-compatible with his beliefs (total uncertainty), so `IsBelSensitive`
-returns false and `Defined` blocks the inference. A modern person
-whose beliefs rule out nuclear war DOES have belief-sensitive context,
-so the inference goes through.
-
-Strawson upward monotonicity is the closure principle at issue;
-[phillips-brown-2025] §4.2 argues that question-based semantics
-must be Strawson-but-not-naively upward monotonic, with definedness
-gating the inference. The substrate's
-`toPartialProp_strawsonEntails` captures the licit
-direction. -/
-
-def avoidWar : Set W := nap
-def avoidNuclearWar : Set W := nap ∪ rested
-
-instance : DecidablePred (· ∈ avoidWar) := inferInstanceAs (DecidablePred (· ∈ nap))
-instance : DecidablePred (· ∈ avoidNuclearWar) := inferInstanceAs (DecidablePred (· ∈ nap ∪ rested))
-
-def qNuclear : List (Finset W) :=
-  [Finset.univ.filter (· ∈ nap),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∈ rested),
-   Finset.univ.filter (fun w => w ∉ nap ∧ w ∉ rested)]
-
-/-- Natural-prop test set for the nuclear-war scenario. The Nap-vs-war
-    distinction (`nap`) and the war-of-any-kind distinction
-    (`avoidNuclearWar`) are the salient dimensions; `rested` and
-    `pass` are not part of this scenario's vocabulary. -/
-def naturalPropsNuclear : List (Finset W) :=
-  [Finset.univ.filter (· ∈ nap), Finset.univ.filter (· ∈ avoidNuclearWar)]
-
-theorem avoidWar_entails_avoidNuclearWar :
-    avoidWar ⊆ avoidNuclearWar := Set.subset_union_left
-
-theorem avoidNuclearWar_considered :
-    IsConsidered qNuclear avoidNuclearWar := by decide +kernel
-
-/-- William III: total uncertainty (all worlds compatible). -/
-def belWilliam : Set W := Set.univ
-instance : DecidablePred (· ∈ belWilliam) := fun _ => isTrue trivial
-
-theorem william_insensitive :
-    ¬ IsBelSensitive qNuclear belWilliam := by decide +kernel
-
-theorem avoidNuclearWar_not_defined_william :
-    ¬ Defined naturalPropsNuclear qNuclear belWilliam avoidNuclearWar := by decide +kernel
-
-/-- Modern person: beliefs rule out nuclear war (peace ∨ conventional). -/
-def belModern : Set W := nap ∪ rested
-instance : DecidablePred (· ∈ belModern) := inferInstanceAs (DecidablePred (· ∈ nap ∪ rested))
-
-theorem modern_sensitive :
-    IsBelSensitive qNuclear belModern := by decide +kernel
-
-theorem avoidNuclearWar_defined_modern :
-    Defined naturalPropsNuclear qNuclear belModern avoidNuclearWar := by decide +kernel
-
-def desAvoidWar : List (Finset W) := [Finset.univ.filter (· ∈ nap)]
-
-theorem modern_wants_avoidNuclearWar :
-    Want desAvoidWar qNuclear belModern avoidNuclearWar := by decide +kernel
-
-/-! ## §11. Cross-paper bridge: [condoravdi-lauer-2016]
-
-[condoravdi-lauer-2016]'s exact-match want over an *effective* —
-pointwise consistent — preferential background is jointly
-belief-consistent (`PreferenceStructure.Consistent.inter_inter_nonempty_of_mem_maxElts`):
-if both `Preferential.Want P a φ w` and `Preferential.Want P a ψ w` hold, then
-`(φ ∩ ψ) ∩ B(a, w) ≠ ∅`. Specialized to `ψ = φᶜ`, the conclusion
-becomes `∅ ∩ B(a, w) ≠ ∅`, which is contradictory. So C&L *forbids*
-simultaneous `want(p)` and `want(¬p)` against a single belief state and
-preference structure.
-
-[phillips-brown-2025] resolves the conflict by varying the
-contextual question Q_c (and the contextually-relevant `belS`) per
-ascription. C&L resolves it by varying the preference structure (per
-reading: `Preferential.Want` / `WantSufficient` / `WantNecessary`). The two
-resolutions are orthogonal — both can coexist in a unified theory of
-desire, but they make non-overlapping claims. -/
-
-/-- C&L's joint-belief-consistency, specialized to `ψ = φᶜ`: no single
-    exact-match want over a consistent background can hold of both `φ`
-    and `¬φ` simultaneously, since their intersection is empty.
-
-    This is a *paper-level* contrast with PB §3: PB makes both
-    `nap_true` and `not_nap_true` work by varying Q_c and `belS`; the
-    C&L analysis would need a different background per ascription to
-    reproduce the contrast. -/
-theorem condoravdiLauer_blocks_simultaneous_pq_and_negpq
-    {Agent W : Type} {B : Agent → W → Set W}
-    (P : Agent → W → PreferenceStructure W)
-    (hC : ∀ a w, (P a w).Consistent (B a w))
-    (a : Agent) (φ : Set W) (w : W)
-    (hφ : Preferential.Want P a φ w) (hnegφ : Preferential.Want P a φᶜ w) :
-    False :=
-  ((hC a w).inter_inter_nonempty_of_mem_maxElts hφ hnegφ).ne_empty
-    (by rw [Set.inter_compl_self, Set.inter_empty])
-
-/-! ### The belief-based class and its no-go (paper §2)
-
-The paper's §2 thesis is class-level: conflicting desire ascriptions
-falsify *every* semantics on the orthodox belief-based approach —
-[heim-1992], [von-fintel-1999], Levinson 2003, and their descendants.
-`BeliefBasedDesireSemantics` formalizes the class: a desire-semantic
-device over (Bel_S, parameters, evaluation world, proposition) with no
-contextual question parameter outside that shape. Both von Fintel and
-Heim are instances (`vonFintelSemantics`, `heimSemantics`), each proved
-conflict-blocking by delegation to the substrate's per-account no-go
-theorems (`BestWorlds.Want.not_compl`, `Conditional.Want.not_compl`).
-
-PB's `QuestionBased.Want` *evades* the no-go by selecting from
-`Q-Bel_S` rather than directly from `Bel_S` — it is *not* an
-instance of `BeliefBasedDesireSemantics` (the question parameter
-`answers` plays a non-trivial role outside the shape). -/
-
-/-- A belief-based desire semantics on world type `W`: `defined` is the
-    presuppositional definedness condition, `want` the truth condition.
-    Decidability inside instances is supplied classically — the
-    structure is for Prop-level reasoning, not for `decide`. -/
-structure BeliefBasedDesireSemantics (W : Type*) where
-  /-- Type of additional parameters (desire list for von Fintel,
-      similarity + pref for Heim, etc.). -/
-  Param : Type*
-  /-- Definedness condition: the presupposition that ⟦S wants p⟧^c is
-      defined at the configuration. -/
-  defined : Set W → Param → Set W → Prop
-  /-- Truth condition: when defined, the prediction of ⟦S wants p⟧^c. -/
-  want : Set W → Param → W → Set W → Prop
-
-/-- A semantics is **conflict-blocking** if no parameters/world make
-    `want(p)` and `want(¬p)` both true when both are defined — the
-    paper's §2 no-go in slogan form. -/
-def BeliefBasedDesireSemantics.IsConflictBlocking
-    {W : Type*} (F : BeliefBasedDesireSemantics W) : Prop :=
-  ∀ belS Param w_eval (p : Set W),
-    F.defined belS Param p → F.defined belS Param pᶜ →
-    ¬ (F.want belS Param w_eval p ∧ F.want belS Param w_eval pᶜ)
-
-/-- von Fintel as a `BeliefBasedDesireSemantics` instance. `defined`
-    requires both p- and ¬p-witnesses in belS — strong enough that some
-    belS-world is necessarily undominated, which the no-go needs. -/
-def vonFintelSemantics {W : Type*} : BeliefBasedDesireSemantics W where
-  Param := List (Finset W)
-  defined belS _ p := Conditional.Defined belS p
-  want belS GS _ p := BestWorlds.Want GS belS p
-
-/-- Heim as a `BeliefBasedDesireSemantics` instance: definedness is her
-    (40) amendment. -/
-def heimSemantics {W : Type*} : BeliefBasedDesireSemantics W where
-  Param := Conditional.Frame W
-  defined belS _ p := Conditional.Defined belS p
-  want belS F w_eval p := Conditional.Want F belS w_eval p
-
-/-- von Fintel is **conflict-blocking** (`BestWorlds.Want.not_compl`). -/
-theorem vonFintelSemantics_IsConflictBlocking {W : Type*} [Finite W] :
-    (vonFintelSemantics (W := W)).IsConflictBlocking :=
-  fun _ _ _ _ hDef _ ⟨hp, hnp⟩ => hp.not_compl (let ⟨w, hw⟩ := hDef.1; ⟨w, hw.1⟩) hnp
-
-/-- Heim is **conflict-blocking** at any frame and evaluation world with
-    antisymmetric desirability (`Conditional.Want.not_compl`). -/
-theorem heimSemantics_IsConflictBlocking {W : Type*} [Finite W] (F : Conditional.Frame W)
-    (w_eval : W)
-    [Std.Antisymm (F.pref w_eval)] :
-    ∀ belS (p : Set W),
-      (heimSemantics (W := W)).defined belS F p →
-      (heimSemantics (W := W)).defined belS F pᶜ →
-      ¬ ((heimSemantics (W := W)).want belS F w_eval p ∧
-         (heimSemantics (W := W)).want belS F w_eval pᶜ) :=
-  fun _ _ hDef _ ⟨hp, hnp⟩ => hp.not_compl hDef hnp
-
-/-- **[lassiter-2017] also evades the no-go but via numerical
-    threshold + graded value rather than question-sensitivity.** The
-    Lassiter substrate's `exists_want_and_want_compl` exhibits a
-    concrete configuration where both `want(p)` and `want(¬p)` fire on
-    a single `(belS, pr, V, θ)` — falsifying `IsConflictBlocking`.
-
-    Lassiter and PB are now formalized as *two distinct* non-instances
-    of `BeliefBasedDesireSemantics`. PB's escape route: question
-    parameter outside the BBS shape. Lassiter's: numerical threshold
-    on graded expected value. The cross-paper picture: the typology
-    correctly excludes both, and they evade via genuinely different
-    mechanisms. -/
-theorem lassiter_evades_no_go_via_grading :
-    ∃ (W : Type) (_ : Fintype W) (pr V : W → ℚ) (θ : ℚ) (bel p : Set W)
-      (_ : DecidablePred (· ∈ bel)) (_ : DecidablePred (· ∈ p)),
-      ExpectedValue.Want pr V θ bel p ∧ ExpectedValue.Want pr V θ bel pᶜ :=
-  ExpectedValue.exists_want_and_want_compl
-
-/-! ## Summary
-
-The 8-world model verifies all of the paper's quantitative predictions
-that fit the 3-binary-dimension encoding (Nap, Lobster-via-isomorphism,
-Lu/deck-stacking, William-III). The substrate carries the *general*
-arguments (no-go for vF, no-go for Heim, Strawson upward monotonicity,
-and the universal finest-question identity
-`want_finest_iff`); the
-belief-based-class typology — the paper's own §2 packaging — is
-formalized above. The §11 bridge makes the disagreement with C&L explicit;
-`heimSemantics_IsConflictBlocking` shows the no-go covers Heim as well.
-
-What's deferred:
-
-* The Lobster scenario reuses Nap's dimensions via `abbrev` — a
-  4-dimension model would let `qLobGus` and `qLobDie` be genuinely
-  distinct in their underlying worlds. The current encoding is honest
-  (`qLobGus := qNapRest`) and adequate for the structural argument.
-
-* [crnic-2014] is the acknowledged precursor of the question-based
-  semantics; a Crnič-2011 study file is the natural next paper.
-
-* The CPR overgeneration argument (paper §2.2) is handled here via
-  `die_not_considered_in_qLobGus`. A separate CPR formalization (paper
-  §2.4) is not yet in linglib.
--/
+/-! ### The nap and lobster cases (§2.1, §2.2) -/
+
+/-- A state: whether the act is done, whether its benefit obtains, whether its cost obtains. -/
+structure World where
+  act : Bool
+  benefit : Bool
+  cost : Bool
+  deriving DecidableEq
+
+instance : Fintype World :=
+  Fintype.ofEquiv (Bool × Bool × Bool)
+    ⟨λ p => ⟨p.1, p.2.1, p.2.2⟩, λ w => (w.act, w.benefit, w.cost), λ _ => rfl, λ _ => rfl⟩
+
+/-- The act: napping, eating the lobster. -/
+def act : Finset World := Finset.univ.filter (·.act)
+
+/-- Its benefit: feeling rested, the gustatory experience. -/
+def benefit : Finset World := Finset.univ.filter (·.benefit)
+
+/-- Its cost: failing the exam, dying of anaphylactic shock. -/
+def cost : Finset World := Finset.univ.filter (·.cost)
+
+/-- The beliefs: the benefit and the cost each come exactly with the act. -/
+def bel : Set World := {w | w.benefit = w.act ∧ w.cost = w.act}
+
+instance : DecidablePred (· ∈ bel) :=
+  λ w => inferInstanceAs (Decidable (w.benefit = w.act ∧ w.cost = w.act))
+
+/-- The desires: the benefit, and not the cost. -/
+def desires : List (Finset World) := [benefit, costᶜ]
+
+/-- Von Fintel's semantics cannot make *Nap* and *Not-nap* both true, whatever the desires:
+some belief-world is best, and it settles the act one way. -/
+theorem vonFintel_no_conflict (G : List (Finset World)) :
+    ¬ (BestWorlds.Want G bel ↑act ∧ BestWorlds.Want G bel (↑act : Set World)ᶜ) :=
+  λ ⟨h, h'⟩ => h.not_compl ⟨⟨true, true, true⟩, by decide⟩ h'
+
+/-- Neither can Heim's, under her definedness amendment and antisymmetric desirability. -/
+theorem heim_no_conflict (F : Conditional.Frame World) (w : World) [Std.Antisymm (F.pref w)]
+    (hd : Conditional.Defined bel ↑act) :
+    ¬ (Conditional.Want F bel w ↑act ∧ Conditional.Want F bel w (↑act : Set World)ᶜ) :=
+  λ ⟨h, h'⟩ => h.not_compl hd h'
+
+/-- Closure under doxastic equivalence (§4.1): on a belief-based semantics, the cost being
+believed to come exactly with the act, wanting the act is wanting the cost, *Nap* entailing
+*Fail*. -/
+theorem closure_under_doxastic_equivalence (G : List (Finset World))
+    (h : BestWorlds.Want G bel ↑act) : BestWorlds.Want G bel ↑cost :=
+  h.mono_on (by decide +kernel)
+
+/-- A context-sensitive preference relation overgenerates (§2.2): the value of feeling rested
+makes *Nap* true, and with it *Fail*. -/
+theorem cpr_overgenerates :
+    BestWorlds.Want [benefit] bel ↑act ∧ BestWorlds.Want [benefit] bel ↑cost :=
+  ⟨by decide, closure_under_doxastic_equivalence _ (by decide +kernel)⟩
+
+/-! ### Some-things-considered desire (§3) -/
+
+/-- The question considering whether the act is done and whether its benefit obtains
+(Figure 3). -/
+def qBenefit : List (Finset World) := ofIssues [act, benefit]
+
+/-- The question considering whether the act is done and whether its cost obtains
+(Figure 5). -/
+def qCost : List (Finset World) := ofIssues [act, cost]
+
+/-- The salient propositions of the case, the test set of the anti-deckstacking constraint. -/
+def issues : List (Finset World) := [act, benefit, cost]
+
+/-- *Nap*, *Lobster*: considering the act and its benefit, the ascription is defined and true. -/
+theorem act_true : Defined issues qBenefit bel ↑act ∧ Want desires qBenefit bel ↑act := by
+  decide +kernel
+
+/-- *Fail*, *Die*: in that context the cost is ignored, so the ascription is undefined
+(§3.6), which blocks the inference from *Nap* to *Fail* (§4.1). -/
+theorem cost_undefined : ¬ IsConsidered qBenefit ↑cost := by decide
+
+/-- *Not-nap*, *Not-lobster*: considering the act and its cost, not doing the act is wanted,
+and so is avoiding the cost, *Not-die*. -/
+theorem not_act_true :
+    Defined issues qCost bel (↑act : Set World)ᶜ ∧ Want desires qCost bel (↑act : Set World)ᶜ ∧
+      Want desires qCost bel (↑cost : Set World)ᶜ := by
+  decide +kernel
+
+/-! ### Deck-stacking (§3.7) -/
+
+/-- A state of Lu's case: whether it rains, whether Lu is happy. -/
+structure LuWorld where
+  rain : Bool
+  happy : Bool
+  deriving DecidableEq
+
+instance : Fintype LuWorld :=
+  Fintype.ofEquiv (Bool × Bool)
+    ⟨λ p => ⟨p.1, p.2⟩, λ w => (w.rain, w.happy), λ _ => rfl, λ _ => rfl⟩
+
+/-- It rains tomorrow. -/
+def rain : Finset LuWorld := Finset.univ.filter (·.rain)
+
+/-- Lu is happy tomorrow. -/
+def happy : Finset LuWorld := Finset.univ.filter (·.happy)
+
+/-- Lu's beliefs: happy whatever the weather. -/
+def belLu : Set LuWorld := {w | w.happy = true}
+
+instance : DecidablePred (· ∈ belLu) := λ w => inferInstanceAs (Decidable (w.happy = true))
+
+/-- The deck-stacked question (Figure 7): whether it rains, and if not, whether Lu is happy. -/
+def qStacked : List (Finset LuWorld) := [rain, rainᶜ ∩ happy, rainᶜ \ happy]
+
+/-- The level playing field (Figure 9). -/
+def qFair : List (Finset LuWorld) := ofIssues [rain, happy]
+
+/-- Without the constraint the deck-stacked question makes *Lu wants it not to rain* true,
+though Lu is indifferent to the weather; the level playing field makes it false. -/
+theorem not_rain_deckstacked :
+    Want [happy] qStacked belLu (↑rain : Set LuWorld)ᶜ ∧
+      ¬ Want [happy] qFair belLu (↑rain : Set LuWorld)ᶜ := by
+  decide +kernel
+
+/-- The deck-stacked question violates the constraint at *happy*, which one answer entails and
+another leaves open, while the level playing field satisfies it for every proposition. -/
+theorem deckstacked_excluded :
+    ¬ IsAntiDeckstacking [happy] qStacked ∧
+      ∀ q : Finset LuWorld, (∃ a ∈ qFair, a ⊆ q) → IsConsidered qFair ↑q := by
+  decide +kernel
+
+/-- Read with `q` ranging over all propositions, the Anti-deckstacking Constraint admits, among
+questions with two disjoint answers, only those whose answers are singletons: with two states
+in an answer, the union of another answer with one of them is entailed by an answer and settled
+by none. -/
+theorem antiDeckstacking_univ_singleton {W : Type*} [DecidableEq W] {Q : List (Finset W)}
+    (h : ∀ q : Finset W, (∃ a ∈ Q, a ⊆ q) → IsConsidered Q (↑q : Set W)) {a a' : Finset W}
+    (ha : a ∈ Q) (ha' : a' ∈ Q) (hd : Disjoint a a') {w₁ w₂ : W} (h₁ : w₁ ∈ a) (h₂ : w₂ ∈ a) :
+    w₁ = w₂ := by
+  by_contra hne
+  rcases h (a' ∪ a.erase w₂) ⟨a', ha', Finset.subset_union_left⟩ a ha with hall | hnone
+  · rcases Finset.mem_union.1 (hall w₂ h₂) with h | h
+    · exact Finset.disjoint_left.1 hd h₂ h
+    · exact (Finset.mem_erase.1 h).1 rfl
+  · exact hnone w₁ h₁ (Finset.mem_union_right _ (Finset.mem_erase.2 ⟨hne, h₁⟩))
+
+/-! ### Belief-sensitivity (§4.2) -/
+
+/-- An agent whose beliefs are insensitive to every question relative to which `p` is
+considered, William III and England avoiding nuclear war with France, has *S wants p* undefined
+in every context: where `p` is considered the beliefs are insensitive, and where they are
+sensitive `p` is not considered. -/
+theorem undefined_of_insensitive {W : Type*} {bel p : Set W}
+    (h : ∀ Q : List (Finset W), IsConsidered Q p → ¬ IsBelSensitive Q bel)
+    (N Q : List (Finset W)) : ¬ Defined N Q bel p :=
+  λ hd => h Q hd.1 hd.2.2.2
 
 end PhillipsBrown2025

--- a/references.bib
+++ b/references.bib
@@ -8770,7 +8770,7 @@
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
-  sources   = {Studies/PhillipsBrown2025.lean;Semantics/Attitudes/Desire.lean}
+  sources   = {Semantics/Attitudes/Desire.lean;Semantics/Attitudes/Desire/QuestionBased.lean;Studies/PhillipsBrown2025.lean}
 }
 @article{aloni-2022,
   author    = {Aloni, Maria},
@@ -11358,7 +11358,7 @@
   subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Logic/Natural/Strawson/Basic.lean;Semantics/Focus/Particles.lean;Studies/PhillipsBrown2025.lean}
+  sources   = {Logic/Natural/Strawson/Basic.lean;Semantics/Focus/Particles.lean}
 }% REF: Ahn (2015). The Semantics of Additive Either.
 @inproceedings{ahn-2015,
   author    = {Ahn, Dorothy},
@@ -16056,7 +16056,7 @@
   role      = {cited},
   doi       = {10.1007/s10988-008-9046-x},
   validated = {true},
-  sources   = {Semantics/Attitudes/BuilderProperties.lean;Semantics/Attitudes/Preferential.lean}
+  sources   = {Semantics/Attitudes/BuilderProperties.lean;Semantics/Attitudes/Desire/BestWorlds.lean;Semantics/Attitudes/Preferential.lean;Studies/PhillipsBrown2025.lean}
 }% REF: Simons, M., Tonhauser, J., Beaver, D. & Roberts, C. (2010). What projects and why. SALT 20.
 @incollection{diessel-2013,
   author    = {Diessel, Holger},
@@ -34147,7 +34147,7 @@
   subfield  = {semantics},
   role      = {cited},
   validated = {false},
-  sources   = {Semantics/Attitudes/Desire.lean}
+  sources   = {Semantics/Attitudes/Desire.lean;Semantics/Attitudes/Desire/QuestionBased.lean;Studies/PhillipsBrown2025.lean}
 }
 
 @phdthesis{lassiter-2011,


### PR DESCRIPTION
Rebuild the some-things-considered desire study on general theorems: one act–benefit–cost model for the nap and lobster cases, the constraints' consequences proved in the substrate.
- `Desire.QuestionBased.ofIssues` (the question raised by a list of issues), `exists_best`, the diversity consequences `not_want_of_not_exists` / `want_of_isConsidered_of_not_exists`; `BestWorlds.Want.mono_on` (doxastic closure)
- belief-based no-go instances, closure under doxastic equivalence deriving the CPR overgeneration, Lu's deck-stacked question, William III as a general insensitivity theorem
- the literal Anti-deckstacking Constraint forces singleton answers (`antiDeckstacking_univ_singleton`); cut the Cariani, Condoravdi–Lauer and Lassiter bridges and the belief-based-class typology