### PR TITLE
refactor(Studies/Pietraszko2026): subject movement as one derivation

### DIFF
--- a/Linglib/Studies/Pietraszko2026.lean
+++ b/Linglib/Studies/Pietraszko2026.lean
@@ -1,576 +1,291 @@
-import Linglib.Syntax.Minimalist.Verbal.Voice
-import Linglib.Syntax.Minimalist.Features
-import Linglib.Syntax.Minimalist.Agree.Basic
-import Linglib.Syntax.Minimalist.Phase.Basic
-import Linglib.Syntax.Minimalist.Probe.Profile
-import Linglib.Studies.CoonMateoPedroPreminger2014
+import Linglib.Syntax.Minimalist.Defs
 
 /-!
-# Pietraszko 2026: In defense of the clause-internal phase (Ndebele)
+# Pietraszko (2026): In Defense of the Clause-Internal Phase
 
-[pietraszko-2026]
+This file formalizes the argument of [pietraszko-2026] that VoiceP in Zimbabwean Ndebele is
+a phase, from its opacity to A-movement and φ-agreement rather than from footprints of
+successive-cyclic movement. A subject may move to Spec,TP and control agreement on T (5), or
+stay in situ under default agreement (6); of the three sources of a missing probe–goal
+relation (8), the account is locality: T always bears EPP and φ, VoiceP is a phase under the
+strong Phase Impenetrability Condition of [chomsky-2000], and Voice bears EPP optionally (9),
+(10). A subject that reaches Spec,VoiceP is visible to every head above and, operations being
+obligatory when possible with an unchecked EPP tolerated as in [preminger-2014], moves on to
+Spec,TP; a subject left in the phase's complement is invisible to them all. Hence movement and
+agreement go together (11)–(14) (`simple_clause`); auxiliary constructions agree on every head
+or on none and admit no intermediate landing site (16)–(21) (`auxV_uniform`,
+`auxV_no_partial`); a reduced clause whose highest head is Asp lets Asp attract the subject on
+its own (34)–(42) (`reduced_clause`); a subject that leaves its VoiceP has agreed with T on the
+way (25)–(28) (`agrees_of_lt_landing`); and hyperraising yields the four subject positions of
+(77) from the EPP of the phase heads alone, the VP-internal one included (69), (76)
+(`hyperraising_sites`). The general form is phase-delimited movement (79): movement within a
+phase is obligatory (`phase_internal_obligatory`), and a phase head without EPP freezes the
+subject below it (`cross_phasal_frozen`). The account with an optional [EPP, φ] on T of
+[carstens-mletshe-2015] admits the unattested partial patterns (30), (31) and default
+agreement on a T the subject has crossed (25) (`optional_T_overgenerates`), where the phasal
+account excludes them.
 
-VoiceP in Zimbabwean Ndebele is a clause-internal phase, diagnosed by
-**operational opacity** for A-movement and φ-agreement (not by
-successive-cyclic footprints). Mechanism: Voice optionally bears EPP;
-when it does, the in-vP subject vacates to the phase edge (Spec,VoiceP)
-and is visible to T's probes; when it does not, the subject is trapped
-in the phase complement and T defaults to class-15 *ku-* agreement.
+## Implementation notes
 
-## Main results
+A clause is the list of heads above the subject's base position, bottom-up, each with its
+category and whether it bears EPP, a φ-probe, and heads a phase; one bottom-up pass computes
+the subject's landing site and the heads it is accessible to: an EPP head attracts an
+accessible subject to its specifier and a phase head without EPP freezes it in its complement
+(`stateAt`, `landing`, `Accessible`). The rival account is the same derivation with Voice
+non-phasal and [EPP, φ] optional on T and Asp. The expletive-pro account of [halpert-2015]
+(§3.2), the antifocus account of [zeller-2015] (§4), the modification of [henderson-2006],
+object dislocation (55) and the information-structural properties of the two orders are prose;
+the substrate's tree-level `Phase.Impenetrable` is the same condition at the level of syntactic
+objects.
 
-- §1-§2: Tree-derived PIC accessibility (`subject_inSitu_inaccessible`,
-  `subject_atEdge_accessible`) — the load-bearing structural derivations.
-- §3-§5: Bidirectional movement-agreement, Aux-V uniformity,
-  phase-delimited movement.
-- §6: Convergence with [erlewine-sommerlot-2025] (Malayic
-  VoiceP-as-phase) — `voice_phase_attested_in_two_families`.
-- §7: Four-cell `(flavor.defaultPhasal × phaseOverride)` typology
-  witnessed by Pietraszko + E&S + [coon-2019] +
-  [coon-mateo-pedro-preminger-2014].
-- §8: Study-local horizon-based reduction (`pietraszkoNdebeleConfig`)
-  for side-by-side comparison with [keine-2020]'s framework.
-- §3.1.1, §3.1.3, §3.2: Empirical theorems for raising-to-object,
-  reduced-clause AspP test (with morphological exponent functions),
-  and object-dislocation entails subject accessibility.
+## References
 
-## See also: substrate, sibling Studies, deferred work
-
-See module-internal `Notes` block (after the namespace) for: methodology
-caveats (single-consultant data; novel allomorphy split); cross-framework
-positions vs Keine 2020; alternative analyses ruled out (Carstens &
-Mletshe, Halpert, Zeller); IS-syntax interface deliberately bracketed;
-deferred work (multi-clause hyperraising; per-paper alternative models
-as formalized siblings; bibliography backlog).
+* [pietraszko-2026]
+* [chomsky-2000]
+* [preminger-2014]
+* [carstens-mletshe-2015]
+* [halpert-2015]
+* [zeller-2015]
+* [henderson-2006]
 -/
 
 namespace Pietraszko2026
 
-open Minimalist Minimalist.Voice SyntacticObject
+open Minimalist
 
-/-! ## Notes
+/-! ### Clauses and the derivation (§2.2) -/
 
-**Methodology caveat.** All Ndebele data are from a single native
-consultant ([pietraszko-2026], fn 1: a 60-year-old speaker who
-grew up in Bulawayo). The class-1 */u/* (T) vs */e/* (Perf/Asp)
-allomorphy split (encoded in `class1Allomorph` below) is novel to this
-paper and not yet corroborated against published Ndebele grammars.
+/-- A head of the clausal spine as subject movement sees it: its category, and whether it
+bears EPP, a φ-probe, and heads a phase. -/
+structure Head where
+  cat : Cat
+  epp : Bool
+  phi : Bool
+  phase : Bool
+  deriving DecidableEq, Repr
 
-**Alternative analyses ruled out empirically** (Pietraszko §3, §4 —
-none yet formalized in linglib):
-- Optional [EPP,φ] on T (Carstens & Mletshe 2015 for Xhosa) — falsified
-  by §3.1.1 raising-to-object and §3.1.2 Aux-V uniformity.
-- Expletive *pro* (Halpert 2015 + Buell 2005, 2007 for Zulu) — falsified
-  by §3.2 topicalization across the expletive.
-- Antifocus feature (Zeller 2008, 2015) — falsified by §4 hyperraising
-  (ex 73-76); not formalized here.
+/-- A clause: the heads above the subject's base position, bottom-up. -/
+abbrev Spine := List Head
 
-**Information-structural conditioning bracketed.** Bantu VS order is
-paradigmatically focus / discourse-newness conditioned (Buell 2005,
-Zerbian 2006). Pietraszko 2026 treats the optionality as syntactic.
-Binary focus marking (`Semantics/Focus/Marking.lean`) exists but is not
-consumed by this file.
+/-- The derivational state of the subject: its height, 0 in situ and `i + 1` in the specifier
+of the head at index `i`, and whether it is frozen in a phase's complement. -/
+structure State where
+  height : ℕ
+  frozen : Bool
+  deriving DecidableEq, Repr
 
-**Deferrals** (next-session candidates):
-- §4 hyperraising-to-VP (ex 73-76) — multi-clause derivations.
-- Per-paper alternative models (CM, Halpert, Zeller) as formalized
-  sibling accounts whose distinct predictions can be refuted by explicit
-  theorem rather than by docstring claim.
-- A `Fragments/Ndebele/` graduation once a second Ndebele paper lands.
-- A cross-Bantu agreement typology hub under `Typology/`.
-- Typeclass-based phasehood-attestation registry (per the audit's
-  "obvious next move"): would let convergence with E&S 2025 be
-  true-by-construction via `instance` declarations.
-- Bibliography: ~25 missing entries with publisher-verified DOIs.
--/
+/-- Merging the head at index `i`: an EPP head attracts an accessible subject to its specifier,
+a phase head without EPP freezes an accessible subject in its complement, and otherwise the
+subject stays where it is. -/
+def step (i : ℕ) (h : Head) (s : State) : State :=
+  if s.frozen then s else if h.epp then ⟨i + 1, false⟩ else if h.phase then ⟨s.height, true⟩
+  else s
 
-/-! ## §1. Lexical sample (Ndebele Aux-V structure) -/
+/-- The state after merging the first `n` heads. -/
+def stateAt (sp : Spine) : ℕ → State
+  | 0 => ⟨0, false⟩
+  | n + 1 =>
+    match sp[n]? with
+    | some h => step n h (stateAt sp n)
+    | none => stateAt sp n
 
-namespace Sample
+/-- The subject's landing site: its height once the clause is built. -/
+def landing (sp : Spine) : ℕ := (stateAt sp sp.length).height
 
-/-- Voice with EPP feature (Pietraszko 2026): triggers subject movement
-    to Spec,VoiceP. VoiceP is always phasal in Ndebele
-    (`phaseOverride := some true`); the variation is on the EPP feature. -/
-def voiceWithEPP : Head :=
-  { flavor := .agentive, hasD := true, phaseOverride := some true
-  , features := .ofGramFeatures [.valued (.epp true)] }
+/-- The subject is accessible to the head at index `i`: not frozen when that head is merged. -/
+def Accessible (sp : Spine) (i : ℕ) : Prop := (stateAt sp i).frozen = false
 
-/-- Voice without EPP: subject trapped in vP, invisible to higher probes
-    via PIC at the Voice phase boundary. -/
-def voiceWithoutEPP : Head :=
-  { flavor := .agentive, hasD := true, phaseOverride := some true
-  , features := ⊥ }
+instance (sp : Spine) (i : ℕ) : Decidable (Accessible sp i) := inferInstanceAs (Decidable (_ = _))
 
-/-- Token id namespace (each lexical position in the derivation
-    gets a distinct id; needed because `LIToken` distinguishes
-    `id`-tagged copies). -/
-def idT : Nat := 1
-def idAsp : Nat := 2
-def idVoice : Nat := 3
-def idV : Nat := 4
-def idSubject : Nat := 5
-def idObject : Nat := 6
-def idSubjectTrace : Nat := 7
+/-- The head at index `i` agrees with the subject: it bears a φ-probe and the subject is
+accessible to it. -/
+def Agrees (sp : Spine) (i : ℕ) : Prop :=
+  match sp[i]? with
+  | some h => h.phi = true ∧ Accessible sp i
+  | none => False
 
-/-- A T head bearing [φ, EPP]. -/
-def tToken : LIToken :=
-  { item := LexicalItem.simple .T [.Asp]
-  , id := idT }
+instance (sp : Spine) (i : ℕ) : Decidable (Agrees sp i) := by
+  unfold Agrees; cases sp[i]? <;> infer_instance
 
-/-- An Asp head also bearing [φ, EPP] (per [baker-2003],
-    [baker-2008], [collins-2004], [carstens-2005]:
-    in Bantu, φ-probes occur only on heads with EPP, so each
-    inflectional head above Voice carries the same probe profile). -/
-def aspToken : LIToken :=
-  { item := LexicalItem.simple .Asp [.Voice]
-  , id := idAsp }
+/-! ### The heads of Ndebele -/
 
-/-- A Voice head (the lexical leaf; Voice's phasehood and EPP are
-    metadata on the corresponding `Head`, not on the LIToken). -/
-def voiceToken : LIToken :=
-  { item := LexicalItem.simple .Voice [.v]
-  , id := idVoice }
+/-- T, with EPP and φ. -/
+def T : Head := ⟨.T, true, true, false⟩
 
-/-- A v / V head (lexical verb stem, here "phek-" 'cook'). -/
-def vToken : LIToken :=
-  { item := LexicalItem.simple .v []
-  , id := idV }
+/-- Asp, with EPP and φ (§2.4, §3.1.3). -/
+def Asp : Head := ⟨.Asp, true, true, false⟩
 
-/-- The subject DP's LIToken (class 1, uZondi). -/
-def subjectToken : LIToken :=
-  { item := LexicalItem.simple .D [], id := idSubject }
+/-- Voice, a phase head, with EPP `e` (§2.2). -/
+def Voice (e : Bool) : Head := ⟨.Voice, e, false, true⟩
 
-/-- A trace LIToken at the base position after movement (distinct LIToken,
-    indistinguishable to PIC since the interior membership check tests
-    structural containment, not LI equality). -/
-def subjectTraceToken : LIToken :=
-  { item := LexicalItem.simple .D [], id := idSubjectTrace }
+/-- C, a phase head, with EPP `e` (§4). -/
+def C (e : Bool) : Head := ⟨.C, e, false, true⟩
 
-/-- The subject DP at its base position (Spec,vP). Class 1 (uZondi). -/
-def subjectAtBase : SyntacticObject := leaf subjectToken
+/-- The matrix V of a raising verb, with EPP (§4). -/
+def raisingV : Head := ⟨.V, true, false, false⟩
 
-/-- The subject DP after movement to Spec,VoiceP (a fresh copy, since
-    each `LIToken` in copy theory is a distinct token). -/
-def subjectAtSpecVoiceP : SyntacticObject := leaf subjectToken
+/-- A simple clause (9), (10). -/
+def simple (e : Bool) : Spine := [Voice e, T]
 
-/-- A trace at the base position after movement (distinct LIToken). -/
-def subjectTrace : SyntacticObject := leaf subjectTraceToken
+/-- An auxiliary construction (17), (19): Asp and T above Voice. -/
+def auxV (e : Bool) : Spine := [Voice e, Asp, T]
 
-/-! The trees below are built **ordered**, as products of tokens coerced to syntactic
-    objects, because the smart Merge
-    `SyntacticObject.merge` is
-    noncomputable; planar construction keeps the `decide` PIC proofs
-    reducing. -/
+/-- A reduced clause (40): Asp is the highest head. -/
+def reduced (e : Bool) : Spine := [Voice e, Asp]
 
-/-- The Voice projection with NO Spec,VoiceP — subject remains in vP.
-    Structure: `voice (subject v)`. Voice is the phase; its complement
-    is the entire vP, which contains the subject. -/
-def voiceP_noSpec : PlanarSyntacticObject :=
-   (voiceToken * (subjectToken * vToken))
+/-- Hyperraising (77): the embedded Voice and T, C, the matrix raising verb, and the matrix
+Voice and T. -/
+def hyperraising (e₁ e₂ e₃ : Bool) : Spine := [Voice e₃, T, C e₂, raisingV, Voice e₁, T]
 
-/-- The Voice projection with subject at Spec,VoiceP (phase edge).
-    Structure: `subject (voice (trace v))`. The OUTER node is not the
-    phase; the inner `voice (trace v)` is the phase, and the subject
-    (sister to it) is at the edge. -/
-def voiceP_withSpec : PlanarSyntacticObject :=
-   (subjectToken * (voiceToken * (subjectTraceToken * vToken)))
+/-! ### Predictions (§2.3, §2.4, §3.1.3, §4) -/
 
-/-- The Voice phase for `voiceP_noSpec`: phase head `voiceToken`, tree
-    `voiceP_noSpec`. Its interior (= the head's c-command domain, the
-    spelled-out vP) and edge are **derived** from the selection head
-    (MCB §1.14), not stipulated. The subject sits in the interior. -/
-def voicePhase_noSpec : Phase :=
-  { tree := voiceP_noSpec, head := voiceToken }
+/-- Prediction 1 (11)–(14): the subject moves to Spec,TP exactly when T agrees with it, both
+exactly when Voice bears EPP. -/
+theorem simple_clause (e : Bool) :
+    (landing (simple e) = 2 ↔ e) ∧ (Agrees (simple e) 1 ↔ e) ∧ (landing (simple e) = 0 ↔ ¬ e) := by
+  cases e <;> decide
 
-/-- The Voice phase for `voiceP_withSpec`: phase head `voiceToken`, whose maximal
-    projection is the inner VoiceP. The derived interior is the post-movement vP;
-    the moved subject at Spec,VoiceP is on the derived edge. -/
-def voicePhase_withSpec : Phase :=
-  { tree := voiceP_withSpec, head := voiceToken }
+/-- Prediction 2 (16)–(20): in an auxiliary construction every head above Voice agrees with the
+subject or none does. -/
+theorem auxV_uniform (e : Bool) :
+    (Agrees (auxV e) 1 ∧ Agrees (auxV e) 2) ∨ (¬ Agrees (auxV e) 1 ∧ ¬ Agrees (auxV e) 2) := by
+  cases e <;> decide
 
-/-- The full Aux-V tree (T > Asp > Voice > vP) with subject in situ. -/
-def auxVTree_inSitu : PlanarSyntacticObject :=
-   (tToken * (aspToken * (voiceToken * (subjectToken * vToken))))
+/-- (21): the subject is in situ or in Spec,TP, never in an intermediate specifier. -/
+theorem auxV_no_partial (e : Bool) : landing (auxV e) = 0 ∨ landing (auxV e) = 3 := by
+  cases e <;> decide
 
-/-- The full Aux-V tree with subject moved to Spec,VoiceP. T's probe will
-    additionally attract the subject to Spec,TP — that movement is the
-    derivational step we don't model here; the salient question is just
-    whether T's probe *finds* the subject under PIC. -/
-def auxVTree_subjectMoved : PlanarSyntacticObject :=
-   (tToken * (aspToken * (subjectToken * (voiceToken * (subjectTraceToken * vToken)))))
+/-- Reduced clauses (41), (42): with Asp the highest head, the subject lands in Spec,AspP
+exactly when Voice bears EPP, and Asp agrees with it exactly then. -/
+theorem reduced_clause (e : Bool) :
+    (landing (reduced e) = 2 ↔ e) ∧ (Agrees (reduced e) 1 ↔ e) := by
+  cases e <;> decide
 
-end Sample
+/-- Hyperraising (77): the subject stays in situ when the embedded Voice lacks EPP, stops in
+the embedded Spec,TP when C lacks EPP, in the matrix VP when the matrix Voice lacks EPP (69),
+(76), and reaches the matrix Spec,TP otherwise. -/
+theorem hyperraising_sites (e₁ e₂ e₃ : Bool) :
+    landing (hyperraising e₁ e₂ e₃)
+      = if ¬ e₃ then 0 else if ¬ e₂ then 2 else if ¬ e₁ then 4 else 6 := by
+  cases e₁ <;> cases e₂ <;> cases e₃ <;> decide
 
-/-! ## §2. Phase-bounded accessibility (derived from PIC)
+/-! ### Phase-delimited movement (79) -/
 
-The substantive content of Pietraszko 2026's analysis is that the
-*subject's accessibility to a higher probe* is determined by whether
-the subject sits inside the Voice-phase complement. We derive this
-from the MCB-grounded `Phase.Impenetrable` (the interior = complement,
-eq 1.14.3) rather than stipulate it. -/
+theorem stateAt_succ_of_getElem? {sp : Spine} {n : ℕ} {h : Head} (hn : sp[n]? = some h) :
+    stateAt sp (n + 1) = step n h (stateAt sp n) := by
+  simp [stateAt, hn]
 
-open Sample
+/-- A frozen subject stays frozen at the same height. -/
+theorem frozen_stateAt_succ {sp : Spine} {n : ℕ} (hf : (stateAt sp n).frozen = true) :
+    stateAt sp (n + 1) = stateAt sp n := by
+  simp only [stateAt]
+  cases sp[n]? <;> simp [step, hf]
 
-/-- The subject is accessible to a probe above the Voice phase iff it is NOT
-    frozen in the phase interior (= the spelled-out complement, PIC). This is the
-    negation of the MCB-derived `Phase.Impenetrable` — no stipulated complement. -/
-def IsSubjectAccessibleAcross (voicePhase : Phase) (subj : SyntacticObject) : Prop :=
-  ¬ voicePhase.Impenetrable subj
+theorem frozen_stateAt_of_le {sp : Spine} {m n : ℕ} (hmn : m ≤ n)
+    (hf : (stateAt sp m).frozen = true) : stateAt sp n = stateAt sp m := by
+  induction n with
+  | zero => rw [Nat.le_zero.1 hmn]
+  | succ n ih =>
+    rcases Nat.le_succ_iff.1 hmn with hmn | rfl
+    · rw [frozen_stateAt_succ (by rw [ih hmn]; exact hf), ih hmn]
+    · rfl
 
-instance (vp : Phase) (s : SyntacticObject) :
-    Decidable (IsSubjectAccessibleAcross vp s) :=
-  inferInstanceAs (Decidable (¬ vp.Impenetrable s))
+theorem height_step_le {i : ℕ} {h : Head} {s : State} (hs : s.height ≤ i) :
+    (step i h s).height ≤ i + 1 := by
+  unfold step
+  by_cases hf : s.frozen = true <;> by_cases he : h.epp = true <;>
+    by_cases hp : h.phase = true <;> simp [hf, he, hp] <;> omega
 
-/-- When subject is in situ (in vP, the Voice-phase complement), it is
-    NOT accessible across the phase. Derived from `voicePhase_noSpec`'s
-    `complement` field via `contains`. -/
-theorem subject_inSitu_inaccessible :
-    ¬ IsSubjectAccessibleAcross voicePhase_noSpec subjectAtBase := by decide
+theorem height_le_height_step {i : ℕ} {h : Head} {s : State} (hs : s.height ≤ i) :
+    s.height ≤ (step i h s).height := by
+  unfold step
+  by_cases hf : s.frozen = true <;> by_cases he : h.epp = true <;>
+    by_cases hp : h.phase = true <;> simp [hf, he, hp] <;> omega
 
-/-- When subject is at Spec,VoiceP (the phase edge), it IS accessible
-    across the phase — the trace inside vP is a distinct LIToken
-    (different `id`), so `contains` correctly returns false on the
-    moved-subject copy, and accessibility holds.
+/-- The subject never sits above the heads merged so far. -/
+theorem height_stateAt_le (sp : Spine) (n : ℕ) : (stateAt sp n).height ≤ n := by
+  induction n with
+  | zero => exact le_rfl
+  | succ n ih =>
+    simp only [stateAt]
+    cases sp[n]? with
+    | none => exact ih.trans (Nat.le_succ n)
+    | some h => exact height_step_le ih
 
-    PIC encoding choice: traces use distinct ids (`idSubjectTrace = 7`
-    vs `idSubject = 5`); a substrate move to true copy theory (where
-    a chain is one entity with deletion at PF) would require revisiting
-    this representation. The current encoding is sound for `contains`
-    PIC checking but is not faithful to chain-based copy theory. -/
-theorem subject_atEdge_accessible :
-    IsSubjectAccessibleAcross voicePhase_withSpec subjectAtSpecVoiceP := by
+/-- The subject never moves down. -/
+theorem height_stateAt_mono (sp : Spine) {m n : ℕ} (hmn : m ≤ n) :
+    (stateAt sp m).height ≤ (stateAt sp n).height := by
+  induction n with
+  | zero => rw [Nat.le_zero.1 hmn]
+  | succ n ih =>
+    rcases Nat.le_succ_iff.1 hmn with hmn | rfl
+    · refine Nat.le_trans (ih hmn) ?_
+      simp only [stateAt]
+      cases sp[n]? with
+      | none => exact le_rfl
+      | some h => exact height_le_height_step (height_stateAt_le sp n)
+    · exact le_rfl
+
+/-- Phase-internal movement is obligatory (79i): a head bearing EPP attracts the subject
+whenever it is accessible, so the subject lands at least in its specifier. -/
+theorem phase_internal_obligatory {sp : Spine} {i : ℕ} {h : Head} (hi : sp[i]? = some h)
+    (he : h.epp = true) (ha : Accessible sp i) : i + 1 ≤ landing sp := by
+  obtain ⟨hlen, -⟩ := List.getElem?_eq_some_iff.1 hi
+  have hstep : stateAt sp (i + 1) = ⟨i + 1, false⟩ := by
+    rw [stateAt_succ_of_getElem? hi, step, if_neg (by simpa [Accessible] using ha), if_pos he]
+  calc i + 1 = (stateAt sp (i + 1)).height := by rw [hstep]
+    _ ≤ landing sp := height_stateAt_mono sp hlen
+
+/-- Cross-phasal movement needs EPP on the phase head (79ii): a phase head without EPP freezes
+an accessible subject in its complement, so the subject lands below it and no higher head can
+reach it. -/
+theorem cross_phasal_frozen {sp : Spine} {i : ℕ} {h : Head} (hi : sp[i]? = some h)
+    (hp : h.phase = true) (he : h.epp = false) (ha : Accessible sp i) :
+    landing sp ≤ i ∧ ∀ j, i < j → ¬ Accessible sp j := by
+  have hstep : stateAt sp (i + 1) = ⟨(stateAt sp i).height, true⟩ := by
+    rw [stateAt_succ_of_getElem? hi, step, if_neg (by simpa [Accessible] using ha),
+      if_neg (by simp [he]), if_pos hp]
+  obtain ⟨hlen, -⟩ := List.getElem?_eq_some_iff.1 hi
+  refine ⟨?_, λ j hij hj => ?_⟩
+  · rw [landing, frozen_stateAt_of_le hlen (by rw [hstep]), hstep]
+    exact height_stateAt_le sp i
+  · have := frozen_stateAt_of_le (m := i + 1) hij (by rw [hstep])
+    simp [Accessible, this, hstep] at hj
+
+/-- Movement past a φ-bearing head requires agreement with it (25)–(28): a subject that
+lands above a head was accessible to it. -/
+theorem agrees_of_lt_landing {sp : Spine} {i : ℕ} {h : Head} (hi : sp[i]? = some h)
+    (hphi : h.phi = true) (hlt : i < landing sp) : Agrees sp i := by
+  have ha : Accessible sp i := by
+    by_contra hna
+    have hf : (stateAt sp i).frozen = true := by simpa [Accessible] using hna
+    obtain ⟨hlen, -⟩ := List.getElem?_eq_some_iff.1 hi
+    have := height_stateAt_le sp i
+    rw [landing, frozen_stateAt_of_le hlen.le hf] at hlt
+    omega
+  simp [Agrees, hi, hphi, ha]
+
+/-! ### The optional [EPP, φ] on T (§3.1) -/
+
+/-- The account of [carstens-mletshe-2015]: Voice is not a phase and each inflectional head
+bears [EPP, φ] optionally, Asp with `a` and T with `t`. -/
+def optionalT (a t : Bool) : Spine :=
+  [⟨.Voice, false, false, false⟩, ⟨.Asp, a, a, false⟩, ⟨.T, t, t, false⟩]
+
+/-- Raising to object on that account: an embedded T optionally without [EPP, φ] below C and a
+raising verb. -/
+def optionalTRaising (t : Bool) : Spine :=
+  [⟨.Voice, false, false, false⟩, ⟨.T, t, t, false⟩, ⟨.C, true, false, true⟩, raisingV]
+
+/-- The optional-probe account overgenerates: Asp alone may attract and agree with the subject
+(30), T alone may (31), and the subject may raise to object across a non-agreeing T (25),
+the patterns the phasal account excludes. -/
+theorem optional_T_overgenerates :
+    (landing (optionalT true false) = 2 ∧ Agrees (optionalT true false) 1 ∧
+      ¬ Agrees (optionalT true false) 2) ∧
+    (landing (optionalT false true) = 3 ∧ ¬ Agrees (optionalT false true) 1 ∧
+      Agrees (optionalT false true) 2) ∧
+    (landing (optionalTRaising false) = 4 ∧ ¬ Agrees (optionalTRaising false) 1) := by
   decide
-
-/-! ## §3. Prediction 1 — bidirectional movement-agreement covariation
-
-Pietraszko §2.3: subject movement to Spec,TP and φ-agreement on T covary
-perfectly. **Honest framing**: in copy-theory PIC, "subject moved" and
-"T agrees" are the same structural condition (subject is OUTSIDE the
-Voice-phase complement). The bidirectional theorem in this file
-therefore reduces to `rfl` modulo `decide` — its content is structural
-(the *single* PIC condition has the *two* observable consequences),
-not a coincidence between independent measurements. The load-bearing
-derivation lives in §2 (`subject_inSitu_inaccessible`,
-`subject_atEdge_accessible`).
-
-A typeclass-based reformulation (per the prior mathlib audit's "obvious
-next move") would let convergence with E&S 2025 register as `instance`
-declarations and the bidirectional become true-by-construction.
-Deferred. -/
-
-/-- Surface phenomenon — both routes coincide: T's probe finds an
-    accessible subject ↔ the subject has vacated the Voice phase
-    complement. Derived from PIC via the tree's Voice phase. -/
-def voicePhaseFor (tree : SyntacticObject) : Option Phase :=
-  if tree = auxVTree_inSitu then some voicePhase_noSpec
-  else if tree = auxVTree_subjectMoved then some voicePhase_withSpec
-  else none
-
-/-- Subject's accessibility to a higher probe in a given Aux-V tree.
-    The single observable; both surface phenomena (movement + agreement)
-    are derived from this. Defaults to inaccessible for unrecognized
-    tree shapes. -/
-def IsSubjectAccessibleInTree (tree : SyntacticObject) : Prop :=
-  match voicePhaseFor tree with
-  | some ph => IsSubjectAccessibleAcross ph subjectAtSpecVoiceP
-  | none => False
-
-instance (t : SyntacticObject) : Decidable (IsSubjectAccessibleInTree t) := by
-  unfold IsSubjectAccessibleInTree
-  cases voicePhaseFor t <;> infer_instance
-
-/-- **Prediction 1 (bidirectional)**: surface movement-and-agreement
-    coincide on the named trees because both reflect the same
-    `IsSubjectAccessibleInTree` structural condition. -/
-theorem bidirectional_movement_agreement :
-    IsSubjectAccessibleInTree auxVTree_subjectMoved ∧
-    ¬ IsSubjectAccessibleInTree auxVTree_inSitu := by decide
-
-/-! ## §4. Prediction 2 — Aux-V uniformity
-
-In an Aux-V chain `[T > Asp > Voice > vP]`, every functional head above
-Voice carries the same φ + EPP probe (per the Bantu Baker generalization:
-[baker-2003], [baker-2008], [collins-2004],
-[carstens-2005]). Each probe independently checks accessibility
-across the Voice phase. Because they share the same accessibility
-condition, they uniformly succeed or uniformly fail.
-
-Modeled here without per-head parameterization: every above-Voice probe
-reads `IsSubjectAccessibleInTree`, so uniformity follows by construction.
-A more articulated model with per-head probes would consult an
-`InflectionalHost` enum and run independent `applyAgree` calls; both
-would still derive uniformity from the shared accessibility condition. -/
-
-/-- **Prediction 2 (Aux-V uniformity)**: every functional head above
-    Voice agrees iff the subject is accessible across the Voice phase.
-    The theorem is structural: the SAME predicate
-    `IsSubjectAccessibleInTree` answers for all such probes, so
-    uniformity is by definition. The empirical content is in the
-    concrete witness theorem below — all heads jointly agree or jointly
-    default on the named trees. -/
-theorem auxV_agreement_is_uniform (tree : SyntacticObject) :
-    -- T's success ↔ Asp's success ↔ Voice's success — same predicate
-    IsSubjectAccessibleInTree tree ↔ IsSubjectAccessibleInTree tree :=
-  Iff.rfl
-
-/-- Concrete witness: T and Asp uniformly agree on the moved tree, both
-    fail on the in-situ tree. -/
-theorem auxV_uniformity_on_named_trees :
-    IsSubjectAccessibleInTree auxVTree_subjectMoved ∧
-    ¬ IsSubjectAccessibleInTree auxVTree_inSitu := by decide
-
-/-! ## §5. Phase-delimited movement (§4 ex 78-79)
-
-Pietraszko 2026's generalization: A-movement is obligatory within a
-phase; optional across phases. The Voice-phase boundary is the locus
-of optionality — once the subject vacates the phase via Spec,VoiceP,
-movement to Spec,TP is forced. -/
-
-/-- Phase-internal A-movement is obligatory: a subject inside vP cannot
-    be reached by T (PIC blocks it), so the only way for T to agree is
-    for the subject to be at the phase edge. -/
-theorem phase_internal_movement_obligatory_for_agreement :
-    IsSubjectAccessibleInTree auxVTree_subjectMoved ∧
-    ¬ IsSubjectAccessibleInTree auxVTree_inSitu := by decide
-
-/-- Cross-phasal A-movement is optional: independent voice variants can
-    give either visible (with EPP) or invisible (without EPP) — the
-    optionality lives at the Voice phase boundary. -/
-theorem cross_phasal_movement_optional :
-    ∃ tree₁ tree₂ : SyntacticObject,
-      IsSubjectAccessibleInTree tree₁ ∧ ¬ IsSubjectAccessibleInTree tree₂ :=
-  ⟨auxVTree_subjectMoved, auxVTree_inSitu, by decide, by decide⟩
-
-/-! ## §6. Convergence with [erlewine-sommerlot-2025]
-
-Both papers commit Voice to be phasal via `phaseOverride := some true`,
-on disjoint empirical domains. The convergence is now machine-checked
-rather than docstring-asserted. -/
-
-/-- The Malayic passive Voice of [erlewine-sommerlot-2025], which heads a phase in every
-    clause type (their VoiceP is always a phase, in *di-* passives and bare passives alike),
-    as a `Voice.Head`: passive flavour with the phase override set. -/
-def malayicPassiveVoice : Minimalist.Voice.Head :=
-  { flavor := .passive, hasD := true, phaseOverride := some true }
-
-/-- Voice phasehood is attested in two unrelated families via the same
-    `phaseOverride := some true` carrier: Pietraszko 2026 (Ndebele,
-    Bantu) and Erlewine & Sommerlot 2025 (Malayic, Austronesian). -/
-theorem voice_phase_attested_in_two_families :
-    Sample.voiceWithEPP.IsPhasal ∧
-    Sample.voiceWithoutEPP.IsPhasal ∧
-    malayicPassiveVoice.IsPhasal := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
-
-/-! ## §7. Four-cell phase-override typology
-
-Three concrete clients now exhaust the `(Flavor.defaultPhasal ×
-phaseOverride : Option Bool)` typology cells:
-
-- agentive + default-phasal (no override): Collins/Chomsky baseline
-  — `Minimalist.Voice.agentive`
-- agentive + override-true: Pietraszko 2026, this file —
-  `Sample.voiceWithEPP`
-- agentive + override-false: [coon-2019] (Chol intransitive),
-  [coon-mateo-pedro-preminger-2014] (Q'anjob'al Agent Focus)
-- passive + override-true: [erlewine-sommerlot-2025] (Malayic
-  di-passive, bare passive)
-
-The typology theorem witnesses each cell with a concrete Head. -/
-
-/-- **Cell 1**: agentive flavor + no override = Collins/Chomsky baseline
-    (`Minimalist.Voice.agentive`). Inherits `IsPhasal` from `defaultPhasal`. -/
-theorem typology_cell_default_agentive :
-    Minimalist.Voice.agentive.flavor = Flavor.agentive ∧
-    Minimalist.Voice.agentive.phaseOverride = none ∧
-    Minimalist.Voice.agentive.IsPhasal := by decide
-
-/-- **Cell 2**: agentive flavor + `phaseOverride := some true` =
-    Pietraszko 2026's Voice-with-EPP (this file's `Sample.voiceWithEPP`).
-    Same observable phasehood as Cell 1 but with explicit override
-    documenting the per-paper commitment. -/
-theorem typology_cell_pietraszko :
-    Sample.voiceWithEPP.flavor = Flavor.agentive ∧
-    Sample.voiceWithEPP.phaseOverride = some true ∧
-    Sample.voiceWithEPP.IsPhasal := by decide
-
-/-- **Cell 3**: agentive flavor + `phaseOverride := some false` =
-    Q'anjob'al Agent Focus ([coon-mateo-pedro-preminger-2014]). Override forces
-    non-phasal against the agentive flavor default. -/
-theorem typology_cell_agent_focus :
-    CoonMateoPedroPreminger2014.voiceAF.flavor = Flavor.agentive ∧
-    CoonMateoPedroPreminger2014.voiceAF.phaseOverride = some false ∧
-    ¬ CoonMateoPedroPreminger2014.voiceAF.IsPhasal := by decide
-
-/-- **Cell 4**: passive flavor + `phaseOverride := some true` =
-    Malayic *di-* passive in [erlewine-sommerlot-2025]. Override
-    forces phasal against the passive flavor default (which Collins-style
-    treats as non-phasal). -/
-theorem typology_cell_erlewine_sommerlot :
-    malayicPassiveVoice.flavor = Flavor.passive ∧
-    malayicPassiveVoice.phaseOverride = some true ∧
-    malayicPassiveVoice.IsPhasal := by decide
-
--- The four cells stand alone as named theorems above; each can be
--- broken individually by a substrate edit, signaling exactly which
--- typological commitment is at stake. No aggregator theorem is offered
--- — `typology_cell_*` collectively are the typology witness.
-
-/-! ## §8. Divergence from [keine-2020]: study-local probe config
-
-Pietraszko 2026 §3.1.2 + §3.1.3 argue that probe-based locality
-([keine-2020]'s horizons) cannot derive Aux-V uniformity. Below
-is a study-local Keine-style probe configuration intended to model
-Pietraszko's data using the horizon framework — included for
-side-by-side comparison, not as the substrate's preferred encoding.
-
-Per linglib layer discipline, this lives here (study-local) rather
-than as a row in `Syntax/Minimalist/Probe.lean`'s
-`LanguageProbeConfig` table. -/
-
-/-- The horizon-based reduction of Pietraszko's account: Voice is the
-    horizon for both φ and A-movement probes. Topicalization (Ā) and
-    wh-licensing are unbounded (Pietraszko §3.2 ex 28: A-bar movement
-    crosses VoiceP without difficulty even when subject is in situ). -/
-def pietraszkoNdebeleConfig : Minimalist.LanguageProbeConfig :=
-  { phi   := ⟨.T, some .Voice⟩
-  , aMove := ⟨.T, some .Voice⟩
-  , wh    := ⟨.C, none⟩
-  , ābar  := ⟨.C, none⟩ }
-
-/-- The configuration's φ-probe correctly classifies as A-level (not Ā). -/
-theorem pietraszkoConfig_phi_isA :
-    pietraszkoNdebeleConfig.phi.isAProbe := by decide
-
-/-- A and Ā probes differ in horizon: A is bounded by Voice, Ā is
-    unbounded. This is what permits A′-movement out of VoiceP even when
-    A-movement is blocked (Pietraszko §3.2 ex 55: object dislocation
-    requires subject movement, A and A′ asymmetry resolved). -/
-theorem ndebele_a_vs_aBar_horizon_differ :
-    pietraszkoNdebeleConfig.aMove.horizon = some .Voice ∧
-    pietraszkoNdebeleConfig.ābar.horizon = none := ⟨rfl, rfl⟩
-
-/-! ## §9. Empirical predictions deferred to substrate extension
-
-The following empirical theorems are marked here as the natural next
-formalization steps. Each requires substrate that is either present
-but underused (raising-to-object: cross-clausal `applyAgree`) or
-genuinely missing (hyperraising: multi-clause `Derivation` model;
-reduced-clause AspP test: `LIToken` allomorph exponent function). -/
-
-/-! ### §3.1.1 raising-to-object
-
-Pietraszko §3.1.1 ex 25-27: `Ngi-funa uZondi {a/*ku}-pheke` "I want
-Zondi to cook". The embedded subject *uZondi* raises to matrix object
-position; the embedded T's class-1 *a-* (matching agreement) is forced,
-default *ku-* is *. This falsifies Carstens & Mletshe's optional-T-EPP
-analysis: if T optionally lacked [EPP,φ], default agreement should be
-possible even while raising. The phasal-Voice account predicts
-obligatoriness: raising requires the subject to vacate VoiceP, and
-once vacated, T's probe necessarily finds it. -/
-
-/-- The conditional: subject accessibility (the precondition for both
-    raising-to-object licensing and embedded T agreement) is the single
-    structural condition; either both hold or neither does. -/
-theorem raising_to_object_forces_matching_agreement :
-    IsSubjectAccessibleInTree auxVTree_subjectMoved := by decide
-
-/-- Concrete contrast: in the in-situ tree, raising can't happen
-    and matching agreement is also unavailable. -/
-theorem raising_unavailable_when_subject_in_situ :
-    ¬ IsSubjectAccessibleInTree auxVTree_inSitu := by decide
-
-/-! ### §3.1.3 reduced-clause AspP test
-
-Pietraszko §3.1.3 ex 34-42: in `Ngi-khulume, ubaba e/*u-si-dla` "I spoke
-while father eating", the adjunct clause is *reduced* (no T layer).
-Subject-agreement uses the */e/* allomorph (Asp) not */u/* (T),
-confirming the agreement is on Asp. This argues T always has EPP — were
-T's EPP optional, the adjunct could lack T entirely AND still show *u-*
-on a hypothetical T head, but in fact only Asp's */e/* appears.
-
-We formalize the morphological exponent function and the empirical
-contrast directly. -/
-
-/-- The inflectional host of an agreement morpheme above Voice. Used by
-    `class1Allomorph` and the AspP test. -/
-inductive InflectionalHost | T | Asp deriving DecidableEq, Repr
-
-/-- The class-1 agreement allomorph by host. Pietraszko §3.1.3:
-    distinct exponents (`u_` on T, `e_` on Asp) — the morphological
-    diagnostic that the agreement target in reduced clauses is Asp,
-    not a hypothetical T head. -/
-inductive Class1Exponent | u_ | e_ deriving DecidableEq, Repr
-
-def class1Allomorph : InflectionalHost → Class1Exponent
-  | .T   => .u_
-  | .Asp => .e_
-
-/-- Default class-15 agreement is uniformly *ku-*, regardless of host.
-    A constant function — the host argument is empirically vacuous,
-    which is itself the diagnostic content. -/
-def defaultAllomorph : InflectionalHost → String := fun _ => "ku-"
-
-/-- The reduced-clause AspP test: in adjunct contexts where the highest
-    head is Asp (not T), the class-1 prefix is *e-* not *u-*. The
-    contrast is morphological proof that the agreement target in such
-    contexts is genuinely Asp, supporting Pietraszko's claim that T
-    always has EPP and that the optionality lives lower in the spine. -/
-theorem aspP_test_class1_distinguishes_hosts :
-    class1Allomorph .Asp = .e_ ∧
-    class1Allomorph .T = .u_ ∧
-    class1Allomorph .Asp ≠ class1Allomorph .T := ⟨rfl, rfl, by decide⟩
-
-/-- The default *ku-* prefix is host-uniform: identical on T and Asp.
-    This morphological identity is what makes Aux-V uniformity
-    (§3.1.2) detectable as a single observable. -/
-theorem default_ku_uniform_across_hosts :
-    defaultAllomorph .T = defaultAllomorph .Asp := rfl
-
-/-- Combined morphological prediction: matching agreement differs by host;
-    default agreement is host-uniform. -/
-theorem morphological_prediction_combined :
-    class1Allomorph .T ≠ class1Allomorph .Asp ∧
-    defaultAllomorph .T = defaultAllomorph .Asp := ⟨by decide, rfl⟩
-
-/-! ### §3.2 object-dislocation entails subject movement (ex 55)
-
-Pietraszko §3.2: "in Ndebele, if the subject cannot move out of VoiceP,
-neither can the object." A/A′ convergence — when Voice lacks EPP, both
-A-probes (T's φ) and the object-dislocation-licensing operation are
-blocked. We formalize the entailment as a Bool implication on the tree
-state. -/
-
-/-- Object dislocation requires its own phase-edge licensing: the object
-    must escape the Voice phase complement to reach a dislocation
-    position above. Routed through `voicePhaseFor` so the entailment
-    theorem below is not a definitional alias of subject accessibility,
-    even though the two share the Voice-EPP precondition. -/
-def CanObjectDislocate (tree : SyntacticObject) : Prop :=
-  match voicePhaseFor tree with
-  | some _ph => IsSubjectAccessibleInTree tree
-  | none => False
-
-instance (t : SyntacticObject) : Decidable (CanObjectDislocate t) := by
-  unfold CanObjectDislocate
-  cases voicePhaseFor t <;> infer_instance
-
-/-- **§3.2 ex 55 entailment**: object dislocation is licensed only when
-    the subject is also accessible across the Voice phase. The two
-    operations share the Voice-EPP precondition; *neither* can apply
-    when Voice lacks EPP. -/
-theorem object_dislocation_entails_subject_accessibility
-    (tree : SyntacticObject) :
-    CanObjectDislocate tree → IsSubjectAccessibleInTree tree := by
-  intro h
-  unfold CanObjectDislocate at h
-  split at h
-  · exact h
-  · exact h.elim
-
-/-- Contrapositive: when subject is inaccessible (in situ), object
-    dislocation is impossible. -/
-theorem no_object_dislocation_when_subject_in_situ :
-    ¬ CanObjectDislocate auxVTree_inSitu := by decide
 
 end Pietraszko2026

--- a/references.bib
+++ b/references.bib
@@ -18270,7 +18270,7 @@
     subfield  = {syntax},
   validated = {true},
   role      = {cited},
-  sources   = {Features/Slot.lean;Studies/BakerVinokurova2010.lean;Studies/BejarRezac2003.lean;Studies/FoxPesetsky2005.lean;Studies/LiuYip2026.lean;Studies/Scott2023.lean;Studies/Zeijlstra2012.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
+  sources   = {Features/Slot.lean;Studies/BakerVinokurova2010.lean;Studies/BejarRezac2003.lean;Studies/FoxPesetsky2005.lean;Studies/LiuYip2026.lean;Studies/Pietraszko2026.lean;Studies/Scott2023.lean;Studies/Zeijlstra2012.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Case/Dependent.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
 }
 @incollection{chomsky-2001,
   author    = {Chomsky, Noam},
@@ -19024,7 +19024,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Features/Person/Decomposition.lean;Fragments/Basque/Agreement.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Params.lean;Studies/CoonKeine2021.lean;Studies/Halpert2012.lean;Studies/Hewett2026.lean;Studies/Just2024.lean;Studies/Kalin2018.lean;Studies/Marantz1991.lean;Studies/Newman2024.lean;Studies/Preminger2014.lean;Studies/Scott2023.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Agree/Checking.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phi/Geometry.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
+  sources   = {Features/Person/Decomposition.lean;Fragments/Basque/Agreement.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Params.lean;Studies/CoonKeine2021.lean;Studies/Halpert2012.lean;Studies/Hewett2026.lean;Studies/Just2024.lean;Studies/Kalin2018.lean;Studies/Marantz1991.lean;Studies/Newman2024.lean;Studies/Pietraszko2026.lean;Studies/Preminger2014.lean;Studies/Scott2023.lean;Syntax/Minimalist/Agree/Basic.lean;Syntax/Minimalist/Agree/Checking.lean;Syntax/Minimalist/Features.lean;Syntax/Minimalist/Phi/Geometry.lean;Syntax/Minimalist/Probe/Basic.lean;Syntax/Minimalist/Probe/Phi.lean;Syntax/Minimalist/Probe/Transmission.lean}
 }
 @article{just-2024,
   author    = {Just, Erika},
@@ -19969,7 +19969,7 @@
   subfield  = {syntax},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/ErlewineSommerlot2025.json;Studies/ErlewineSommerlot2025.lean;Studies/Pietraszko2026.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Verbal/Voice.lean}
+  sources   = {Data/Examples/ErlewineSommerlot2025.json;Studies/ErlewineSommerlot2025.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }
 @inproceedings{jeoung-2017,
   author    = {Jeoung, Helen},
@@ -21998,7 +21998,7 @@
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Egressy2026.lean;Studies/Keine2019.lean;Studies/Keine2020.lean;Studies/Pietraszko2026.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Profile.lean}
+  sources   = {Studies/Egressy2026.lean;Studies/Keine2019.lean;Studies/Keine2020.lean;Syntax/Minimalist/Defs.lean;Syntax/Minimalist/ExtendedProjection/Basic.lean;Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean;Syntax/Minimalist/ExtendedProjection/Properties.lean;Syntax/Minimalist/Phase/Basic.lean;Syntax/Minimalist/Phase/Domain.lean;Syntax/Minimalist/Probe/Profile.lean}
 }% REF: Keine, S. (2019). "Selective Opacity"
 @article{keine-2019,
   author    = {Keine, Stefan},
@@ -22985,7 +22985,7 @@
   subfield  = {semantics/events},
   validated = {true},
   role      = {formalized},
-  sources   = {Data/Examples/Coon2019.json;Fragments/Mayan/Chuj/RootClasses.lean;Fragments/Mayan/Chuj/VoiceSystem.lean;Semantics/ArgumentStructure/SalienceClass.lean;Semantics/ArgumentStructure/Valency.lean;Semantics/Root/Defs.lean;Studies/BeaversEtAl2021.lean;Studies/Coon2019.lean;Studies/Lucy1994.lean;Studies/Pietraszko2026.lean;Syntax/Clause/Arguments.lean;Syntax/Minimalist/Verbal/Voice.lean}
+  sources   = {Data/Examples/Coon2019.json;Fragments/Mayan/Chuj/RootClasses.lean;Fragments/Mayan/Chuj/VoiceSystem.lean;Semantics/ArgumentStructure/SalienceClass.lean;Semantics/ArgumentStructure/Valency.lean;Semantics/Root/Defs.lean;Studies/BeaversEtAl2021.lean;Studies/Coon2019.lean;Studies/Lucy1994.lean;Syntax/Clause/Arguments.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }% ══════════════════════════════════════════════════════════════════════════════
 @book{karlsson-2017,
   author    = {Karlsson, Fred},
@@ -23994,7 +23994,7 @@
   subfield  = {syntax},
   role      = {formalized},
   validated = {true},
-  sources   = {Data/Examples/CoonMateoPedroPreminger2014.json;Fragments/Mayan/Chol/Agreement.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Params.lean;Fragments/Mayan/Qanjobal/Agreement.lean;Fragments/Mayan/Qanjobal/Extraction.lean;Studies/CoonMateoPedroPreminger2014.lean;Studies/Erlewine2016.lean;Studies/Imanishi2014.lean;Studies/Imanishi2020.lean;Studies/Pietraszko2026.lean;Syntax/Minimalist/Verbal/Voice.lean}
+  sources   = {Data/Examples/CoonMateoPedroPreminger2014.json;Fragments/Mayan/Chol/Agreement.lean;Fragments/Mayan/Kaqchikel/Agreement.lean;Fragments/Mayan/Params.lean;Fragments/Mayan/Qanjobal/Agreement.lean;Fragments/Mayan/Qanjobal/Extraction.lean;Studies/CoonMateoPedroPreminger2014.lean;Studies/Erlewine2016.lean;Studies/Imanishi2014.lean;Studies/Imanishi2020.lean;Syntax/Minimalist/Verbal/Voice.lean}
 }% REF: Imanishi, Y. (2014). Default Ergative. PhD diss., MIT.
 @phdthesis{imanishi-2014,
   author    = {Imanishi, Yusuke},
@@ -44386,4 +44386,65 @@
   subfield  = {semantics/questions},
   role      = {cited},
   sources   = {Studies/Heim1994.lean}
+}
+% REF: Pietraszko, A. (2026). "In defense of the clause-internal phase"
+@article{pietraszko-2026,
+  author    = {Pietraszko, Asia},
+  year      = {2026},
+  title     = {In Defense of the Clause-Internal Phase: Evidence from Operational Opacity in {N}debele},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {44},
+  doi       = {10.1007/s11049-026-09710-x},
+  subfield  = {syntax},
+  role      = {formalized},
+  sources   = {Studies/Pietraszko2026.lean}
+}
+% REF: Carstens, V. & Mletshe, L. (2015). "Radical defectivity"
+@article{carstens-mletshe-2015,
+  author    = {Carstens, Vicki and Mletshe, Loyiso},
+  year      = {2015},
+  title     = {Radical Defectivity: Implications of {X}hosa Expletive Constructions},
+  journal   = {Linguistic Inquiry},
+  volume    = {46},
+  number    = {2},
+  pages     = {187--242},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Pietraszko2026.lean}
+}
+% REF: Halpert, C. (2015). "Argument licensing and agreement"
+@book{halpert-2015,
+  author    = {Halpert, Claire},
+  year      = {2015},
+  title     = {Argument Licensing and Agreement},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Pietraszko2026.lean}
+}
+% REF: Zeller, J. (2015). "Argument prominence and agreement"
+@article{zeller-2015,
+  author    = {Zeller, Jochen},
+  year      = {2015},
+  title     = {Argument Prominence and Agreement: Explaining an Unexpected Object Asymmetry in {Z}ulu},
+  journal   = {Lingua},
+  volume    = {156},
+  pages     = {17--39},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Pietraszko2026.lean}
+}
+% REF: Henderson, B. (2006). "Multiple agreement and inversion in Bantu"
+@article{henderson-2006,
+  author    = {Henderson, Brent},
+  year      = {2006},
+  title     = {Multiple Agreement and Inversion in {B}antu},
+  journal   = {Syntax},
+  volume    = {9},
+  number    = {3},
+  pages     = {275--289},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Pietraszko2026.lean}
 }


### PR DESCRIPTION
Rebuild the Ndebele clause-internal-phase study as one bottom-up derivation over a clause spine: an EPP head attracts an accessible subject, a phase head without EPP freezes it, and every prediction is a theorem about that derivation.
- `simple_clause`, `auxV_uniform`, `auxV_no_partial`, `reduced_clause`, `hyperraising_sites` (the four positions of (77)), all for every EPP assignment
- general theorems: `phase_internal_obligatory`, `cross_phasal_frozen` (79), `agrees_of_lt_landing` (movement past T requires agreement)
- the optional-[EPP, φ]-on-T account as the same derivation with other parameters, admitting (30), (31) and default agreement under raising (`optional_T_overgenerates`); cut the tree-level named-tree checks, the E&S typology cells, the Keine config, the allomorphy constants, and the notes; bib entries added for the paper and the rival accounts