### PR TITLE
refactor(Core): derivation trees as rose trees over symbols

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/Dirichlet.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Dirichlet.lean
@@ -54,7 +54,7 @@ namespace DirichletPCFG
 
 variable {T : Type*} [DecidableEq T] {G : ContextFreeGrammar T} [DecidableEq G.NT]
 
-open DerivationTree (corpusRuleCount corpusRuleCount_zero corpusRuleCount_add)
+open RoseTree (corpusRuleCount corpusRuleCount_zero corpusRuleCount_add)
 
 variable (M : DirichletPCFG G)
 
@@ -64,16 +64,16 @@ noncomputable def lhsUrn (a : G.NT) : PolyaUrn (G.RulesWithLHS a) where
   pseudo_pos := λ ⟨r, hr⟩ => M.pseudo_pos r (Finset.mem_filter.mp hr).1
 
 /-- The corpus counts of the rules with left-hand side `a`. -/
-def lhsCounts (a : G.NT) (D : Multiset (DerivationTree T G.NT)) : G.RulesWithLHS a → ℕ :=
+def lhsCounts (a : G.NT) (D : Multiset (RoseTree (Symbol T G.NT))) : G.RulesWithLHS a → ℕ :=
   λ ⟨r, _⟩ => corpusRuleCount r D
 
 /-- The Pólya-urn likelihood of the corpus counts at nonterminal `a`. -/
-noncomputable def lhsFactor (a : G.NT) (D : Multiset (DerivationTree T G.NT)) : ℝ :=
+noncomputable def lhsFactor (a : G.NT) (D : Multiset (RoseTree (Symbol T G.NT))) : ℝ :=
   (M.lhsUrn a).seqProb (lhsCounts a D)
 
 /-- The probability of a corpus with the rule weights integrated out: the product over the
 nonterminals the grammar expands of the Pólya-urn likelihood there. -/
-noncomputable def corpusProb (D : Multiset (DerivationTree T G.NT)) : ℝ :=
+noncomputable def corpusProb (D : Multiset (RoseTree (Symbol T G.NT))) : ℝ :=
   ∏ a ∈ G.rules.image (·.input), M.lhsFactor a D
 
 omit [DecidableEq T] in
@@ -83,11 +83,11 @@ theorem nonempty_rulesWithLHS_of_mem_image {a : G.NT} (ha : a ∈ G.rules.image 
   ⟨r, Finset.mem_filter.mpr ⟨hr, hra⟩⟩
 
 theorem lhsFactor_pos {a : G.NT} (ha : a ∈ G.rules.image (·.input))
-    (D : Multiset (DerivationTree T G.NT)) : 0 < M.lhsFactor a D :=
+    (D : Multiset (RoseTree (Symbol T G.NT))) : 0 < M.lhsFactor a D :=
   have := nonempty_rulesWithLHS_of_mem_image ha
   (M.lhsUrn a).seqProb_pos _
 
-theorem corpusProb_nonneg (D : Multiset (DerivationTree T G.NT)) : 0 ≤ M.corpusProb D :=
+theorem corpusProb_nonneg (D : Multiset (RoseTree (Symbol T G.NT))) : 0 ≤ M.corpusProb D :=
   Finset.prod_nonneg λ _ ha => (M.lhsFactor_pos ha D).le
 
 @[simp]
@@ -109,7 +109,7 @@ theorem corpusProb_zero : M.corpusProb 0 = 1 :=
 /-! ### Conjugate update -/
 
 /-- The posterior given a corpus: each rule's pseudo-count grows by its corpus count. -/
-noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : DirichletPCFG G where
+noncomputable def posterior (D : Multiset (RoseTree (Symbol T G.NT))) : DirichletPCFG G where
   pseudo r := M.pseudo r + corpusRuleCount r D
   pseudo_pos r hr := add_pos_of_pos_of_nonneg (M.pseudo_pos r hr) (Nat.cast_nonneg _)
 
@@ -118,7 +118,7 @@ theorem posterior_zero : M.posterior 0 = M := by
   ext r
   simp [posterior]
 
-theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
+theorem posterior_add (D₁ D₂ : Multiset (RoseTree (Symbol T G.NT))) :
     M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
   ext r
   simp [posterior, corpusRuleCount_add, add_assoc]
@@ -127,13 +127,14 @@ theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
 
 /-- The posterior predictive probability of rule `r` at its left-hand side given a corpus, the
 posterior mean of its weight: its posterior pseudo-count over the total at that nonterminal. -/
-noncomputable def predictive (r : ContextFreeRule T G.NT) (D : Multiset (DerivationTree T G.NT)) :
+noncomputable def predictive (r : ContextFreeRule T G.NT)
+    (D : Multiset (RoseTree (Symbol T G.NT))) :
     ℝ :=
   (M.pseudo r + corpusRuleCount r D) /
     ∑ r' ∈ G.rules.filter (·.input = r.input), (M.pseudo r' + corpusRuleCount r' D)
 
 theorem predictive_denom_pos {a : G.NT} [hne : Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) :
+    (D : Multiset (RoseTree (Symbol T G.NT))) :
     0 < ∑ r' ∈ G.rules.filter (·.input = a), (M.pseudo r' + (corpusRuleCount r' D : ℝ)) := by
   obtain ⟨⟨r₀, hr₀⟩⟩ := hne
   have hpos : ∀ r' ∈ G.rules.filter (·.input = a), 0 < M.pseudo r' + (corpusRuleCount r' D : ℝ) :=
@@ -142,13 +143,13 @@ theorem predictive_denom_pos {a : G.NT} [hne : Nonempty (G.RulesWithLHS a)]
   exact Finset.sum_pos' (λ r' hr' => (hpos r' hr').le) ⟨r₀, hr₀, hpos r₀ hr₀⟩
 
 theorem predictive_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (DerivationTree T G.NT)) : 0 < M.predictive r D :=
+    (D : Multiset (RoseTree (Symbol T G.NT))) : 0 < M.predictive r D :=
   have : Nonempty (G.RulesWithLHS r.input) := ⟨⟨r, Finset.mem_filter.mpr ⟨hr, rfl⟩⟩⟩
   div_pos (add_pos_of_pos_of_nonneg (M.pseudo_pos r hr) (Nat.cast_nonneg _))
     (M.predictive_denom_pos D)
 
 theorem predictive_nonneg {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (DerivationTree T G.NT)) : 0 ≤ M.predictive r D :=
+    (D : Multiset (RoseTree (Symbol T G.NT))) : 0 ≤ M.predictive r D :=
   (M.predictive_pos hr D).le
 
 /-- With no data the predictive probability is the normalised prior pseudo-count. -/
@@ -159,7 +160,7 @@ theorem predictive_zero (r : ContextFreeRule T G.NT) :
 
 /-- At a shared left-hand side, predictive probabilities order rules by posterior pseudo-count. -/
 theorem predictive_lt_iff_of_same_lhs {r r' : ContextFreeRule T G.NT} (hr' : r' ∈ G.rules)
-    (h : r.input = r'.input) {D : Multiset (DerivationTree T G.NT)} :
+    (h : r.input = r'.input) {D : Multiset (RoseTree (Symbol T G.NT))} :
     M.predictive r D < M.predictive r' D ↔
       M.pseudo r + corpusRuleCount r D < M.pseudo r' + corpusRuleCount r' D := by
   have : Nonempty (G.RulesWithLHS r'.input) := ⟨⟨r', Finset.mem_filter.mpr ⟨hr', rfl⟩⟩⟩
@@ -168,14 +169,14 @@ theorem predictive_lt_iff_of_same_lhs {r r' : ContextFreeRule T G.NT} (hr' : r' 
   exact div_lt_div_iff_of_pos_right (M.predictive_denom_pos D)
 
 theorem sum_predictive_eq_one {a : G.NT} [Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) :
+    (D : Multiset (RoseTree (Symbol T G.NT))) :
     ∑ r ∈ G.rules.filter (·.input = a), M.predictive r D = 1 := by
   rw [Finset.sum_congr rfl λ r hr => by
         rw [predictive, (Finset.mem_filter.mp hr).2], ← Finset.sum_div]
   exact div_self (M.predictive_denom_pos D).ne'
 
 /-- The posterior predictive PCFG: the predictive probability of each rule of the grammar. -/
-noncomputable def predictivePCFG (D : Multiset (DerivationTree T G.NT)) : PCFG G where
+noncomputable def predictivePCFG (D : Multiset (RoseTree (Symbol T G.NT))) : PCFG G where
   weight r := if r ∈ G.rules then ENNReal.ofReal (M.predictive r D) else 0
   weight_nonneg _ := zero_le
   weight_eq_zero_of_not_mem _ hr := if_neg hr
@@ -186,13 +187,13 @@ noncomputable def predictivePCFG (D : Multiset (DerivationTree T G.NT)) : PCFG G
       M.sum_predictive_eq_one D, ENNReal.ofReal_one]
 
 theorem predictivePCFG_weight {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (DerivationTree T G.NT)) :
+    (D : Multiset (RoseTree (Symbol T G.NT))) :
     (M.predictivePCFG D).weight r = ENNReal.ofReal (M.predictive r D) :=
   if_pos hr
 
 /-- Conditioning on a corpus and then taking the prior predictive is taking the posterior
 predictive. -/
-theorem predictivePCFG_posterior (D : Multiset (DerivationTree T G.NT)) :
+theorem predictivePCFG_posterior (D : Multiset (RoseTree (Symbol T G.NT))) :
     (M.posterior D).predictivePCFG 0 = M.predictivePCFG D := by
   ext r
   simp [predictivePCFG, predictive, posterior]
@@ -206,29 +207,29 @@ Where it is defined it orders rules exactly as the predictive probability does. 
 /-- The mode of the posterior Dirichlet weight of rule `r`, `0` by the division convention
 outside the interior regime `M.PosteriorModeInterior r.input D`. -/
 noncomputable def posteriorMode (r : ContextFreeRule T G.NT)
-    (D : Multiset (DerivationTree T G.NT)) : ℝ :=
+    (D : Multiset (RoseTree (Symbol T G.NT))) : ℝ :=
   (M.pseudo r + corpusRuleCount r D - 1) /
     ∑ r' ∈ G.rules.filter (·.input = r.input), (M.pseudo r' + corpusRuleCount r' D - 1)
 
 /-- The posterior mode at nonterminal `a` lies in the interior of the simplex: every posterior
 pseudo-count there exceeds `1`. -/
-def PosteriorModeInterior (a : G.NT) (D : Multiset (DerivationTree T G.NT)) : Prop :=
+def PosteriorModeInterior (a : G.NT) (D : Multiset (RoseTree (Symbol T G.NT))) : Prop :=
   ∀ r ∈ G.rules.filter (·.input = a), 1 < M.pseudo r + corpusRuleCount r D
 
 theorem posteriorMode_denom_pos {a : G.NT} [hne : Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (DerivationTree T G.NT)) (h : M.PosteriorModeInterior a D) :
+    (D : Multiset (RoseTree (Symbol T G.NT))) (h : M.PosteriorModeInterior a D) :
     0 < ∑ r' ∈ G.rules.filter (·.input = a), (M.pseudo r' + (corpusRuleCount r' D : ℝ) - 1) := by
   obtain ⟨⟨r₀, hr₀⟩⟩ := hne
   exact Finset.sum_pos' (λ r' hr' => by linarith [h r' hr']) ⟨r₀, hr₀, by linarith [h r₀ hr₀]⟩
 
 theorem posteriorMode_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (DerivationTree T G.NT)) (h : M.PosteriorModeInterior r.input D) :
+    (D : Multiset (RoseTree (Symbol T G.NT))) (h : M.PosteriorModeInterior r.input D) :
     0 < M.posteriorMode r D :=
   have : Nonempty (G.RulesWithLHS r.input) := ⟨⟨r, Finset.mem_filter.mpr ⟨hr, rfl⟩⟩⟩
   div_pos (by linarith [h r (Finset.mem_filter.mpr ⟨hr, rfl⟩)]) (M.posteriorMode_denom_pos D h)
 
 theorem posteriorMode_lt_iff_of_same_lhs {r r' : ContextFreeRule T G.NT} (hr' : r' ∈ G.rules)
-    (h : r.input = r'.input) {D : Multiset (DerivationTree T G.NT)}
+    (h : r.input = r'.input) {D : Multiset (RoseTree (Symbol T G.NT))}
     (hint : M.PosteriorModeInterior r'.input D) :
     M.posteriorMode r D < M.posteriorMode r' D ↔
       M.pseudo r + corpusRuleCount r D < M.pseudo r' + corpusRuleCount r' D := by
@@ -240,7 +241,7 @@ theorem posteriorMode_lt_iff_of_same_lhs {r r' : ContextFreeRule T G.NT} (hr' : 
 /-- Where the posterior mode is defined, it orders rules at a shared left-hand side exactly as
 the predictive probability does. -/
 theorem predictive_lt_iff_posteriorMode_lt {r r' : ContextFreeRule T G.NT} (hr' : r' ∈ G.rules)
-    (h : r.input = r'.input) {D : Multiset (DerivationTree T G.NT)}
+    (h : r.input = r'.input) {D : Multiset (RoseTree (Symbol T G.NT))}
     (hint : M.PosteriorModeInterior r'.input D) :
     M.predictive r D < M.predictive r' D ↔ M.posteriorMode r D < M.posteriorMode r' D := by
   rw [M.predictive_lt_iff_of_same_lhs hr' h, M.posteriorMode_lt_iff_of_same_lhs hr' h hint]

--- a/Linglib/Core/Computability/ContextFreeGrammar/Measure.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Measure.lean
@@ -9,27 +9,27 @@ import Linglib.Core.Probability.BranchingProcess.GaltonWatson
 /-!
 # The derivation measure of a probabilistic context-free grammar
 
-A PCFG is a multitype Galton–Watson process: the types are the nonterminals, the marks are the
-terminals, and the offspring kernel at `A` is the right-hand side of a rule at `A` chosen with
-its weight. The law of the family tree is the law of the derivation tree, and the product of rule
+A PCFG is a multitype Galton–Watson process whose types are the symbols: a terminal has no
+offspring, and a nonterminal's offspring is the right-hand side of a rule at it chosen with its
+weight. The law of the family tree is the law of the derivation tree, and the product of rule
 weights `PCFG.derivProb` is the Galton–Watson weight of the tree, so it is derived from the
 generation process rather than stipulated. Total mass one is tightness in the sense of
 [booth-thompson-1973] and [chi-1999], consistency in older terminology: the grammar almost surely
-produces a finite derivation from every nonterminal.
+produces a finite derivation from every symbol.
 
 ## Main definitions
 
 * `PCFG.galtonWatson`: the offspring kernel of a PCFG.
-* `PCFG.derivationMeasure`: the law of the derivation tree at each nonterminal, as a kernel.
-* `PCFG.IsTight`: total mass one at every nonterminal.
+* `PCFG.derivationMeasure`: the law of the derivation tree at each symbol, as a kernel.
+* `PCFG.IsTight`: total mass one at every symbol.
 
 ## Main results
 
 * `PCFG.galtonWatson_weight`: the Galton–Watson weight of a tree is `derivProb`.
 * `PCFG.isMarkovKernel_galtonWatson`: when every nonterminal has a rule, the offspring kernel is
   Markov.
-* `PCFG.derivationMeasure_singleton`: a tree rooted at `A` has probability `derivProb` under the
-  derivation measure at `A`, and trees rooted elsewhere have probability `0`.
+* `PCFG.derivationMeasure_singleton`: a tree rooted at `s` has probability `derivProb` under the
+  derivation measure at `s`, and trees rooted elsewhere have probability `0`.
 * `PCFG.derivationMeasure_apply_univ_le_one`: the derivation measure is a sub-probability
   kernel; `PCFG.isTight_iff` says it is Markov exactly when the grammar is tight.
 
@@ -40,14 +40,13 @@ produces a finite derivation from every nonterminal.
 * [kozen-1981]
 -/
 
-open MeasureTheory ProbabilityTheory
+open MeasureTheory ProbabilityTheory RoseTree
 open scoped ENNReal
 
 instance {T N : Type*} : MeasurableSpace (ContextFreeRule T N) := ⊤
+instance {T N : Type*} : MeasurableSpace (Symbol T N) := ⊤
 
 namespace PCFG
-
-open DerivationTree GaltonWatson
 
 variable {T : Type*} {G : ContextFreeGrammar T} [DecidableEq G.NT] (W : PCFG G)
 
@@ -59,100 +58,101 @@ theorem ruleMeasure_apply (A : G.NT) (s : Set (ContextFreeRule T G.NT)) :
     W.ruleMeasure A s = ∑ r ∈ G.rules.filter (·.input = A), W.weight r * s.indicator 1 r := by
   simp [ruleMeasure, Measure.finsetSum_apply, Measure.dirac_apply' _ .of_discrete]
 
-variable [Countable G.NT] [MeasurableSpace G.NT] [MeasurableSingletonClass G.NT]
+/-- The offspring of a symbol: none at a terminal, and at a nonterminal the right-hand side of a
+rule chosen with its weight. -/
+noncomputable def offspring : Symbol T G.NT → Measure (List (Symbol T G.NT))
+  | .terminal _ => Measure.dirac []
+  | .nonterminal A => (W.ruleMeasure A).map ContextFreeRule.output
 
-/-- The offspring kernel of a PCFG: an individual of type `A` has as offspring the right-hand
-side of a rule at `A`, chosen with the rule's weight. -/
-noncomputable def galtonWatson : Kernel G.NT (List (Symbol T G.NT)) :=
-  (Kernel.ofFunOfCountable W.ruleMeasure).map ContextFreeRule.output
-
-theorem galtonWatson_apply (A : G.NT) :
-    W.galtonWatson A = (W.ruleMeasure A).map ContextFreeRule.output :=
-  Kernel.map_apply _ .of_discrete _
-
-theorem galtonWatson_apply_singleton (A : G.NT) (syms : List (Symbol T G.NT)) :
-    W.galtonWatson A {syms} = W.weight ⟨A, syms⟩ := by
+theorem offspring_singleton (s : Symbol T G.NT) (syms : List (Symbol T G.NT)) :
+    W.offspring s {syms} = W.symbolWeight s syms := by
   classical
-  rw [galtonWatson_apply, Measure.map_apply .of_discrete .of_discrete, ruleMeasure_apply,
-    Finset.sum_congr rfl fun r hr =>
-      show W.weight r * (ContextFreeRule.output ⁻¹' {syms}).indicator 1 r =
-        if r = ⟨A, syms⟩ then W.weight r else 0 from ?_, Finset.sum_ite_eq']
-  · split_ifs with h
-    · rfl
-    · rw [W.weight_eq_zero_of_not_mem _ fun h' => h (Finset.mem_filter.mpr ⟨h', rfl⟩)]
-  · obtain ⟨-, rfl⟩ := Finset.mem_filter.mp hr
-    by_cases hs : r.output = syms
-    · rw [Set.indicator_of_mem (by simpa using hs), if_pos (by cases r; simp_all)]
-      simp
-    · rw [Set.indicator_of_notMem (by simpa using hs),
-        if_neg fun h => hs (congrArg ContextFreeRule.output h)]
-      simp
+  cases s with
+  | terminal a =>
+    cases syms <;> simp [offspring, Measure.dirac_apply' _ .of_discrete]
+  | nonterminal A =>
+    rw [offspring, Measure.map_apply .of_discrete .of_discrete, ruleMeasure_apply,
+      symbolWeight_nonterminal,
+      Finset.sum_congr rfl fun r hr =>
+        show W.weight r * (ContextFreeRule.output ⁻¹' {syms}).indicator 1 r =
+          if r = ⟨A, syms⟩ then W.weight r else 0 from ?_, Finset.sum_ite_eq']
+    · split_ifs with h
+      · rfl
+      · rw [W.weight_eq_zero_of_not_mem _ fun h' => h (Finset.mem_filter.mpr ⟨h', rfl⟩)]
+    · obtain ⟨-, rfl⟩ := Finset.mem_filter.mp hr
+      by_cases hs : r.output = syms
+      · rw [Set.indicator_of_mem (by simpa using hs), if_pos (by cases r; simp_all)]
+        simp
+      · rw [Set.indicator_of_notMem (by simpa using hs),
+          if_neg fun h => hs (congrArg ContextFreeRule.output h)]
+        simp
 
-theorem galtonWatson_apply_univ (A : G.NT) :
-    W.galtonWatson A Set.univ = ∑ r ∈ G.rules.filter (·.input = A), W.weight r := by
-  rw [galtonWatson_apply, Measure.map_apply .of_discrete .univ, Set.preimage_univ,
-    ruleMeasure_apply]
+theorem offspring_nonterminal_univ (A : G.NT) :
+    W.offspring (.nonterminal A) Set.univ = ∑ r ∈ G.rules.filter (·.input = A), W.weight r := by
+  rw [offspring, Measure.map_apply .of_discrete .univ, Set.preimage_univ, ruleMeasure_apply]
   simp
 
-theorem galtonWatson_apply_univ_le_one (A : G.NT) : W.galtonWatson A Set.univ ≤ 1 :=
-  (W.galtonWatson_apply_univ A).trans_le (W.sum_weight_le_one A)
+theorem offspring_univ_le_one (s : Symbol T G.NT) : W.offspring s Set.univ ≤ 1 := by
+  cases s with
+  | terminal a => simp [offspring]
+  | nonterminal A => exact (W.offspring_nonterminal_univ A).trans_le (W.sum_weight_le_one A)
+
+variable [Countable T] [Countable G.NT]
+
+/-- The branching process of a PCFG: the offspring kernel on symbols. -/
+noncomputable def galtonWatson : Kernel (Symbol T G.NT) (List (Symbol T G.NT)) :=
+  Kernel.ofFunOfCountable W.offspring
+
+@[simp] theorem galtonWatson_apply (s : Symbol T G.NT) : W.galtonWatson s = W.offspring s := rfl
 
 /-- A grammar with a rule at every nonterminal has a Markov offspring kernel. -/
 theorem isMarkovKernel_galtonWatson (h : ∀ A, A ∈ G.rules.image (·.input)) :
     IsMarkovKernel W.galtonWatson :=
-  ⟨fun A => ⟨(W.galtonWatson_apply_univ A).trans (W.sum_weight A (h A))⟩⟩
+  ⟨fun s => ⟨by
+    cases s with
+    | terminal a => simp [offspring]
+    | nonterminal A => exact (W.offspring_nonterminal_univ A).trans (W.sum_weight A (h A))⟩⟩
 
-mutual
 /-- The Galton–Watson weight of a derivation tree is the product of its rule weights. -/
-theorem galtonWatson_weight :
-    ∀ t : DerivationTree T G.NT, weight W.galtonWatson t = W.derivProb t
-  | .leaf t => by rw [weight, derivProb]
-  | .node A cs => by
-    rw [weight, derivProb, galtonWatson_apply_singleton, galtonWatson_weightList cs]
+theorem galtonWatson_weight (t : RoseTree (Symbol T G.NT)) :
+    GaltonWatson.weight W.galtonWatson t = W.derivProb t := by
+  simp only [GaltonWatson.weight, derivProb, galtonWatson_apply, offspring_singleton]
 
-theorem galtonWatson_weightList :
-    ∀ cs : List (DerivationTree T G.NT), weightList W.galtonWatson cs = W.derivProbList cs
-  | [] => rfl
-  | c :: cs => by
-    rw [weightList, derivProbList, galtonWatson_weight c, galtonWatson_weightList cs]
-end
+/-- The law of the derivation tree at each symbol: the law of the family tree of the grammar's
+branching process. -/
+noncomputable def derivationMeasure : Kernel (Symbol T G.NT) (RoseTree (Symbol T G.NT)) :=
+  GaltonWatson.law W.galtonWatson
 
-variable [Countable T]
+theorem derivationMeasure_singleton_value (t : RoseTree (Symbol T G.NT)) :
+    W.derivationMeasure t.value {t} = W.derivProb t :=
+  (GaltonWatson.law_singleton_value W.galtonWatson t).trans (W.galtonWatson_weight t)
 
-/-- The law of the derivation tree at each nonterminal: the law of the family tree of the
-grammar's branching process. -/
-noncomputable def derivationMeasure : Kernel G.NT (DerivationTree T G.NT) :=
-  law W.galtonWatson
-
-theorem derivationMeasure_singleton_node (A : G.NT) (cs : List (DerivationTree T G.NT)) :
-    W.derivationMeasure A {node A cs} = W.derivProb (node A cs) :=
-  (law_singleton_node W.galtonWatson A cs).trans (W.galtonWatson_weight _)
-
-theorem derivationMeasure_singleton_of_ne {t : DerivationTree T G.NT} {A : G.NT}
-    (h : t.rootSymbol ≠ .nonterminal A) : W.derivationMeasure A {t} = 0 :=
-  law_singleton_of_ne W.galtonWatson h
+theorem derivationMeasure_singleton_of_ne {t : RoseTree (Symbol T G.NT)} {s : Symbol T G.NT}
+    (h : t.value ≠ s) : W.derivationMeasure s {t} = 0 :=
+  GaltonWatson.law_singleton_of_ne W.galtonWatson h
 
 open scoped Classical in
-/-- Under the derivation measure at `A`, a tree has probability `derivProb` when rooted at `A`
+/-- Under the derivation measure at `s`, a tree has probability `derivProb` when rooted at `s`
 and `0` otherwise. -/
-theorem derivationMeasure_singleton (t : DerivationTree T G.NT) (A : G.NT) :
-    W.derivationMeasure A {t} = if t.rootSymbol = .nonterminal A then W.derivProb t else 0 := by
-  rw [derivationMeasure, law_singleton, galtonWatson_weight]
+theorem derivationMeasure_singleton (t : RoseTree (Symbol T G.NT)) (s : Symbol T G.NT) :
+    W.derivationMeasure s {t} = if t.value = s then W.derivProb t else 0 := by
+  rw [derivationMeasure, GaltonWatson.law_singleton, galtonWatson_weight]
   split_ifs <;> rfl
 
-/-- The derivation measure is a sub-probability measure at every nonterminal. -/
-theorem derivationMeasure_apply_univ_le_one (A : G.NT) : W.derivationMeasure A Set.univ ≤ 1 :=
-  law_univ_le_one W.galtonWatson_apply_univ_le_one A
+/-- The derivation measure is a sub-probability measure at every symbol. -/
+theorem derivationMeasure_apply_univ_le_one (s : Symbol T G.NT) :
+    W.derivationMeasure s Set.univ ≤ 1 :=
+  GaltonWatson.law_univ_le_one W.offspring_univ_le_one s
 
 instance : IsFiniteKernel W.derivationMeasure :=
   ⟨⟨1, ENNReal.one_lt_top, W.derivationMeasure_apply_univ_le_one⟩⟩
 
-/-- A PCFG is tight when the derivation measure has total mass one at every nonterminal: the
-grammar almost surely produces a finite derivation from every nonterminal. Booth and Thompson
-call this consistency. -/
-def IsTight : Prop := ∀ A, extinctionProb W.galtonWatson A = 1
+/-- A PCFG is tight when the derivation measure has total mass one at every symbol: the grammar
+almost surely produces a finite derivation from every nonterminal. Booth and Thompson call this
+consistency. -/
+def IsTight : Prop := ∀ s, GaltonWatson.extinctionProb W.galtonWatson s = 1
 
 theorem isTight_iff : W.IsTight ↔ IsMarkovKernel W.derivationMeasure :=
-  ⟨fun h => ⟨fun A => ⟨h A⟩⟩, fun h A => (h.isProbabilityMeasure A).measure_univ⟩
+  ⟨fun h => ⟨fun s => ⟨h s⟩⟩, fun h s => (h.isProbabilityMeasure s).measure_univ⟩
 
 end PCFG

--- a/Linglib/Core/Computability/ContextFreeGrammar/Probabilistic.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Probabilistic.lean
@@ -18,7 +18,8 @@ of the rule weight raised to the corpus count of that rule.
 
 * `PCFG G`: a `WeightedCFG G ℝ≥0∞` vanishing off the grammar and normalised at each nonterminal
   the grammar expands.
-* `PCFG.derivProb`, `PCFG.corpusProb`: the probability of a derivation tree and of a corpus.
+* `PCFG.derivProb`, `PCFG.corpusProb`: the probability of a derivation tree, a
+  `RoseTree (Symbol T G.NT)`, and of a corpus.
 * `PCFG.uniform`: the uniform rule distribution at every nonterminal.
 
 ## Main results
@@ -58,21 +59,35 @@ variable {T : Type*} {G : ContextFreeGrammar T} [DecidableEq G.NT] (W : PCFG G)
 
 attribute [simp] weight_eq_zero_of_not_mem
 
-mutual
-/-- The probability of a derivation tree: the product of the weights of the rules applied at its
-internal nodes. -/
-noncomputable def derivProb : DerivationTree T G.NT → ℝ≥0∞
-  | .leaf _ => 1
-  | .node nt cs => W.weight ⟨nt, cs.map DerivationTree.rootSymbol⟩ * derivProbList cs
+/-- The weight of a node from its symbol and the symbols of its children: the rule weight at a
+nonterminal, `1` at a childless terminal and `0` at a terminal with children. -/
+noncomputable def symbolWeight : Symbol T G.NT → List (Symbol T G.NT) → ℝ≥0∞
+  | .nonterminal A, syms => W.weight ⟨A, syms⟩
+  | .terminal _, [] => 1
+  | .terminal _, _ :: _ => 0
 
-/-- The product of the probabilities of a list of derivation trees. -/
-noncomputable def derivProbList : List (DerivationTree T G.NT) → ℝ≥0∞
-  | [] => 1
-  | t :: ts => derivProb t * derivProbList ts
-end
+@[simp] theorem symbolWeight_nonterminal (A : G.NT) (syms : List (Symbol T G.NT)) :
+    W.symbolWeight (.nonterminal A) syms = W.weight ⟨A, syms⟩ := rfl
+
+@[simp] theorem symbolWeight_terminal_nil (a : T) : W.symbolWeight (.terminal a) [] = 1 := rfl
+
+@[simp] theorem symbolWeight_terminal_cons (a : T) (s : Symbol T G.NT)
+    (syms : List (Symbol T G.NT)) : W.symbolWeight (.terminal a) (s :: syms) = 0 := rfl
+
+/-- The probability of a derivation tree: the product over its nodes of the weight of the rule
+applied there. -/
+noncomputable def derivProb (t : RoseTree (Symbol T G.NT)) : ℝ≥0∞ :=
+  (t.offspring.map fun p => W.symbolWeight p.1 p.2).prod
+
+theorem derivProb_node (s : Symbol T G.NT) (cs : List (RoseTree (Symbol T G.NT))) :
+    W.derivProb (RoseTree.node s cs) =
+      W.symbolWeight s (cs.map RoseTree.value) * (cs.map W.derivProb).prod := by
+  simp only [derivProb, RoseTree.offspring_node, List.map_cons, List.prod_cons, List.map_flatten,
+    List.prod_flatten, List.map_map, Function.comp_def]
+  rfl
 
 /-- The probability of a corpus: the product of the probabilities of its derivation trees. -/
-noncomputable def corpusProb (D : Multiset (DerivationTree T G.NT)) : ℝ≥0∞ :=
+noncomputable def corpusProb (D : Multiset (RoseTree (Symbol T G.NT))) : ℝ≥0∞ :=
   (D.map W.derivProb).prod
 
 @[simp]
@@ -81,7 +96,7 @@ theorem corpusProb_zero : W.corpusProb 0 = 1 := by
 
 /-- Corpus probability is multiplicative over disjoint corpora: derivation trees are independent
 under a PCFG, in contrast to `DirichletPCFG.corpusProb`. -/
-theorem corpusProb_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
+theorem corpusProb_add (D₁ D₂ : Multiset (RoseTree (Symbol T G.NT))) :
     W.corpusProb (D₁ + D₂) = W.corpusProb D₁ * W.corpusProb D₂ := by
   simp [corpusProb]
 
@@ -98,35 +113,36 @@ variable [DecidableEq T]
 
 /-- The probability of a valid derivation tree is the product over the grammar's rules of the
 rule weight raised to the number of applications of that rule in the tree. -/
-theorem derivProb_eq_prod_pow_ruleCount {t : DerivationTree T G.NT} (ht : t.ValidFor G) :
-    W.derivProb t = ∏ r ∈ G.rules, W.weight r ^ DerivationTree.ruleCount r t := by
+theorem derivProb_eq_prod_pow_ruleCount {t : RoseTree (Symbol T G.NT)} (ht : t.ValidFor G) :
+    W.derivProb t = ∏ r ∈ G.rules, W.weight r ^ RoseTree.ruleCount r t := by
   induction ht with
-  | leaf t => simp [derivProb, DerivationTree.ruleCount]
-  | node nt cs hrule hvalid ih =>
-    simp only [derivProb, DerivationTree.ruleCount, pow_add, Finset.prod_mul_distrib, pow_ite,
-      pow_one, pow_zero, Finset.prod_ite_eq', if_pos hrule]
+  | terminal a => simp [RoseTree.leaf, derivProb_node, RoseTree.ruleCount_node_terminal]
+  | nonterminal A cs hrule hcs ih =>
+    simp only [derivProb_node, RoseTree.ruleCount_node_nonterminal, pow_add,
+      Finset.prod_mul_distrib, pow_ite, pow_one, pow_zero, Finset.prod_ite_eq', if_pos hrule,
+      symbolWeight_nonterminal]
     congr 1
-    clear hrule hvalid
+    clear hrule hcs
     induction cs with
-    | nil => simp [derivProbList, DerivationTree.ruleCountList]
+    | nil => simp
     | cons c cs ihl =>
-      simp only [derivProbList, DerivationTree.ruleCountList, pow_add, Finset.prod_mul_distrib]
+      simp only [List.map_cons, List.prod_cons, List.sum_cons, pow_add, Finset.prod_mul_distrib]
       rw [ih c (List.mem_cons_self ..), ihl λ c' hc' => ih c' (List.mem_cons_of_mem _ hc')]
 
 /-- Over valid derivation trees, corpus probability is the product over the grammar's rules of
 the rule weight raised to the corpus count of that rule. -/
-theorem corpusProb_eq_prod_pow_count (D : Multiset (DerivationTree T G.NT))
+theorem corpusProb_eq_prod_pow_count (D : Multiset (RoseTree (Symbol T G.NT)))
     (h : ∀ t ∈ D, t.ValidFor G) :
-    W.corpusProb D = ∏ r ∈ G.rules, W.weight r ^ DerivationTree.corpusRuleCount r D := by
+    W.corpusProb D = ∏ r ∈ G.rules, W.weight r ^ RoseTree.corpusRuleCount r D := by
   induction D using Multiset.induction_on with
   | empty => simp
   | cons t D ih =>
     rw [← Multiset.singleton_add, corpusProb_add,
       ih λ t' ht' => h t' (Multiset.mem_cons_of_mem ht')]
     simp only [corpusProb, Multiset.map_singleton, Multiset.prod_singleton,
-      DerivationTree.corpusRuleCount_add, pow_add, Finset.prod_mul_distrib,
+      RoseTree.corpusRuleCount_add, pow_add, Finset.prod_mul_distrib,
       W.derivProb_eq_prod_pow_ruleCount (h t (Multiset.mem_cons_self t D)),
-      DerivationTree.corpusRuleCount_singleton]
+      RoseTree.corpusRuleCount_singleton]
 
 /-- The uniform PCFG: at every nonterminal, the uniform distribution over its rules. -/
 noncomputable def uniform : PCFG G where

--- a/Linglib/Core/Computability/ContextFreeGrammar/Pumping.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Pumping.lean
@@ -1,351 +1,161 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Computability.ContextFreeGrammar.Tree
 
 /-!
-# CFL Pumping Lemma
+# The pumping lemma for context-free languages
 
-The CFL pumping property (`HasCFLPumpingProperty`) is defined over mathlib's
-`Language α` (= `Set (List α)`).
+Every context-free language has the pumping property: beyond the pumping constant of a grammar,
+every word splits as `u ++ v ++ x ++ y ++ z` with `v ++ x ++ y` short, `v ++ y` nonempty, and
+every `u ++ vⁱ ++ x ++ yⁱ ++ z` in the language.
 
-## Key Results
+The proof is the textbook one through derivation trees. A word longer than
+`maxBranch ^ (rules.card + 1)` has a valid tree of height above `rules.card`
+(`RoseTree.ValidFor.length_yield_le`); a longest path in a tree of least size passes two nodes
+with the same nonterminal (`RoseTree.ValidFor.exists_repeat`); replacing the lower by the upper
+would shrink the tree unless it adds terminals, and grafting the lower into the upper repeatedly
+pumps them (`RoseTree.ValidFor.replaceAt`, `RoseTree.ValidFor.derives`).
 
-- `cfl_pumping_lemma : L.IsContextFree → HasCFLPumpingProperty L` — fully proved
-- `not_isContextFree_of_not_pumpable` — contrapositive
+## Main definitions
 
-## Proof Structure
+* `HasCFLPumpingProperty`: the pumping property of a language.
 
-The proof follows the standard textbook argument via derivation trees:
+## Main results
 
-1. **`exists_valid_tree`** ✓ (in `DerivationTree.lean`)
-2. **`yield_length_le_of_height`** ✓ (in `DerivationTree.lean`)
-3. **`pumping_from_tall_tree`** ✓: pigeonhole + subtree replacement +
-   `validFor_derives`
+* `cfl_pumping_lemma`: every context-free language has the pumping property.
+* `not_isContextFree_of_not_pumpable`: a language without it is not context-free.
 -/
-/-- The CFL pumping property for a language.
 
-    Every context-free language satisfies this property — the pumping lemma
-    for CFLs. Showing a language lacks it proves it is not context-free. -/
+open RoseTree
+
+/-- The pumping property of a language: beyond some length, every word splits as
+`u ++ v ++ x ++ y ++ z` with `v ++ x ++ y` no longer than that length, `v ++ y` nonempty, and every
+`u ++ vⁱ ++ x ++ yⁱ ++ z` in the language. -/
 def HasCFLPumpingProperty {α : Type*} (L : Language α) : Prop :=
-    ∃ p : Nat, p > 0 ∧
-    ∀ w : List α, w ∈ L → w.length ≥ p →
-      ∃ u v x y z : List α,
-        w = u ++ v ++ x ++ y ++ z ∧
-        (v ++ x ++ y).length ≤ p ∧
-        (v.length + y.length) ≥ 1 ∧
-        ∀ i : Nat, (u ++ List.flatten (List.replicate i v) ++ x ++
-                    List.flatten (List.replicate i y) ++ z) ∈ L
+  ∃ p : ℕ, 0 < p ∧ ∀ w ∈ L, p ≤ w.length →
+    ∃ u v x y z : List α, w = u ++ v ++ x ++ y ++ z ∧ (v ++ x ++ y).length ≤ p ∧
+      1 ≤ v.length + y.length ∧
+      ∀ i : ℕ, u ++ (List.replicate i v).flatten ++ x ++ (List.replicate i y).flatten ++ z ∈ L
 
-private theorem flatten_replicate_succ_right {T : Type*} (l : List T) (n : Nat) :
+namespace ContextFreeGrammar
+
+variable {T : Type*} {g : ContextFreeGrammar T}
+
+private theorem flatten_replicate_succ (l : List T) (n : ℕ) :
     (List.replicate (n + 1) l).flatten = (List.replicate n l).flatten ++ l := by
-  induction n with
-  | zero => simp
-  | succ k ih =>
-    conv_lhs => rw [List.replicate_succ, List.flatten_cons, ih]
-    conv_rhs => rw [List.replicate_succ, List.flatten_cons]
-    rw [List.append_assoc]
+  rw [List.replicate_succ', List.flatten_append, List.flatten_cons, List.flatten_nil,
+    List.append_nil]
 
-set_option maxHeartbeats 800000 in
-theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
-    (t : DerivationTree T g.NT) (ht : t.ValidFor g)
-    (hroot : t.rootSymbol = .nonterminal g.initial)
-    (hyield_long : t.yield.length ≥ g.pumpingConstant) :
-    ∃ u v x y z : List T,
-      t.yield = u ++ v ++ x ++ y ++ z ∧
-      (v ++ x ++ y).length ≤ g.pumpingConstant ∧
-      (v.length + y.length) ≥ 1 ∧
-      ∀ i : Nat, (u ++ List.flatten (List.replicate i v) ++ x ++
-                  List.flatten (List.replicate i y) ++ z) ∈ g.language := by
+/-- A valid tree from the start symbol whose yield reaches the pumping constant pumps. -/
+theorem pumping_from_tall_tree {t : RoseTree (Symbol T g.NT)} (ht : t.ValidFor g)
+    (hroot : t.value = .nonterminal g.initial) (hlong : g.pumpingConstant ≤ t.yield.length) :
+    ∃ u v x y z : List T, t.yield = u ++ v ++ x ++ y ++ z ∧
+      (v ++ x ++ y).length ≤ g.pumpingConstant ∧ 1 ≤ v.length + y.length ∧
+      ∀ i : ℕ, u ++ (List.replicate i v).flatten ++ x ++ (List.replicate i y).flatten ++ z ∈
+        g.language := by
   classical
-  -- Step 1: Pick min-size valid tree with same yield and root
-  obtain ⟨t_min, ht_min_v, ht_min_y, ht_min_r, ht_min_minimal⟩ :=
-    DerivationTree.exists_min_size_tree t ht
-  -- Step 2: Establish t_min.height > g.rules.card
-  have htmin_tall : t_min.height > g.rules.card := by
+  have hb : 1 < g.maxBranch := g.two_le_maxBranch
+  -- a valid tree of least size with the same yield and root
+  obtain ⟨t₁, ht₁, hy₁, hr₁, hmin⟩ := ht.exists_min_numNodes
+  -- it is taller than the number of rules
+  have htall : g.rules.card < t₁.height := by
     by_contra hle
-    simp only [not_lt] at hle
-    have hbound := yield_length_le_of_height g t_min ht_min_v
-    have h1 : g.maxBranch ^ t_min.height ≤ g.maxBranch ^ g.rules.card :=
-      Nat.pow_le_pow_right (by have := g.maxBranch_ge_two; omega) hle
-    have h2 : g.maxBranch ^ g.rules.card < g.maxBranch ^ (g.rules.card + 1) :=
-      Nat.pow_lt_pow_right (by have := g.maxBranch_ge_two; omega) (by omega)
-    have hyl : t_min.yield.length ≥ g.pumpingConstant := by
-      rw [ht_min_y]; exact hyield_long
-    unfold ContextFreeGrammar.pumpingConstant at hyl
+    have h1 := ht₁.length_yield_le
+    have h2 : g.maxBranch ^ t₁.height ≤ g.maxBranch ^ g.rules.card :=
+      Nat.pow_le_pow_right (by omega) (not_lt.mp hle)
+    have h3 : g.maxBranch ^ g.rules.card < g.maxBranch ^ (g.rules.card + 1) :=
+      Nat.pow_lt_pow_right hb (by omega)
+    rw [hy₁] at h1
+    unfold pumpingConstant at hlong
     omega
-  -- Step 3: Max-descent path of length t_min.height - 1
-  obtain ⟨p, hp_len, hpath⟩ :=
-    DerivationTree.exists_pos_max_descent t_min (t_min.height - 1) (by omega)
-  -- Step 4: Restricted pigeonhole. Use Finset.range (#rules + 1) with shift.
-  -- offset = p.length - #rules. Indices in [offset, offset + #rules].
-  have hoffset_le : p.length - g.rules.card + g.rules.card = p.length := by omega
-  -- Define f on shifted range
-  let offset := p.length - g.rules.card
-  -- Helper: get the rule at depth k for k ≤ p.length, with proof of NT match
-  have hroot_at : ∀ k, k ≤ p.length →
-      ∃ nt children, t_min.subtreeAt? (p.take k) = some (.node nt children) := by
-    intro k hk_le
-    obtain ⟨sub, hsub_at, hsub_h⟩ := hpath k (by omega)
-    have hsub_h_ge : sub.height ≥ 1 := by rw [hsub_h]; omega
-    match sub, hsub_h_ge with
-    | .node nt children, _ => exact ⟨nt, children, hsub_at⟩
-  let f : Nat → ContextFreeRule T g.NT := fun k =>
-    (DerivationTree.ruleAt? t_min (p.take (k + offset))).getD ⟨g.initial, []⟩
-  have hf_in : ∀ k ∈ Finset.range (g.rules.card + 1), f k ∈ g.rules := by
-    intro k hk
-    simp at hk
-    have hk_off_le : k + offset ≤ p.length := by simp [offset]; omega
-    obtain ⟨nt, children, hsub_k⟩ := hroot_at (k + offset) hk_off_le
-    obtain ⟨hrule_eq, hrule_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
-      (p.take (k + offset)) nt children hsub_k
-    show f k ∈ g.rules
-    simp only [f, hrule_eq, Option.getD_some]
-    exact hrule_in
-  have hcard : g.rules.card < (Finset.range (g.rules.card + 1)).card := by
-    simp [Finset.card_range]
-  obtain ⟨a₀, ha₀, b₀, hb₀, hne₀, hfeq₀⟩ :=
-    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hcard hf_in
-  simp at ha₀ hb₀
-  -- Reduce to a < b
-  obtain ⟨a, b, ha, hb, hab, hfeq⟩ : ∃ a b,
-      a < g.rules.card + 1 ∧ b < g.rules.card + 1 ∧ a < b ∧ f a = f b := by
-    rcases Nat.lt_or_ge a₀ b₀ with h | h
-    · exact ⟨a₀, b₀, ha₀, hb₀, h, hfeq₀⟩
-    · exact ⟨b₀, a₀, hb₀, ha₀, lt_of_le_of_ne h hne₀.symm, hfeq₀.symm⟩
-  -- Step 5: Set up t_outer, t_inner via the pigeonhole pair
-  let i := a + offset
-  let j := b + offset
-  have hi_le : i ≤ p.length := by simp [i, offset]; omega
-  have hj_le : j ≤ p.length := by simp [j, offset]; omega
-  have hij : i < j := by simp [i, j]; omega
-  have hi_ge_off : i ≥ offset := by simp [i]
-  -- Get the subtrees and rules at i, j
-  obtain ⟨nt_o, ch_o, hsub_o⟩ := hroot_at i hi_le
-  obtain ⟨nt_i, ch_i, hsub_i⟩ := hroot_at j hj_le
-  obtain ⟨hrule_o, hrule_o_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
-    (p.take i) nt_o ch_o hsub_o
-  obtain ⟨hrule_i, hrule_i_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
-    (p.take j) nt_i ch_i hsub_i
-  have hfa : f a = ⟨nt_o, ch_o.map DerivationTree.rootSymbol⟩ := by
-    change (DerivationTree.ruleAt? t_min (p.take i)).getD _ = _
-    rw [hrule_o]; rfl
-  have hfb : f b = ⟨nt_i, ch_i.map DerivationTree.rootSymbol⟩ := by
-    change (DerivationTree.ruleAt? t_min (p.take j)).getD _ = _
-    rw [hrule_i]; rfl
-  have hroot_eq : nt_o = nt_i := by
-    have hh : (⟨nt_o, ch_o.map DerivationTree.rootSymbol⟩ : ContextFreeRule T g.NT) =
-        ⟨nt_i, ch_i.map DerivationTree.rootSymbol⟩ := by rw [← hfa, ← hfb, hfeq]
-    exact ContextFreeRule.mk.injEq _ _ _ _ |>.mp hh |>.1
-  -- t_outer = .node nt_o ch_o, t_inner = .node nt_i ch_i
-  -- t_outer has same root nonterminal as t_inner
-  set t_outer : DerivationTree T g.NT := .node nt_o ch_o with ht_outer_def
-  set t_inner : DerivationTree T g.NT := .node nt_i ch_i with ht_inner_def
-  have hroot_o_eq_i : t_outer.rootSymbol = t_inner.rootSymbol := by
-    show DerivationTree.rootSymbol (.node nt_o ch_o) = DerivationTree.rootSymbol (.node nt_i ch_i)
-    show Symbol.nonterminal nt_o = Symbol.nonterminal nt_i
-    rw [hroot_eq]
-  -- Bound on t_outer.height
-  have ht_outer_h : t_outer.height = t_min.height - i := by
-    obtain ⟨sub_o, hsub_o', hsub_o_h⟩ := hpath i (by omega)
-    rw [hsub_o] at hsub_o'
-    have : t_outer = sub_o := by injection hsub_o'
-    rw [this, hsub_o_h]
-  have ht_outer_h_le : t_outer.height ≤ g.rules.card + 1 := by
-    rw [ht_outer_h]; simp [i, offset]; omega
-  -- t_inner is a subtree of t_outer at relative path
-  have hsubtree_path_eq : p.take j = p.take i ++ (p.take j).drop i := by
-    conv_lhs => rw [← List.take_append_drop i (p.take j)]
-    congr 1; rw [List.take_take, min_eq_left (by omega)]
-  let p_outer := p.take i
-  let p_inner_rel := (p.take j).drop i
-  have hp_inner_compose : t_min.subtreeAt? (p_outer ++ p_inner_rel) = some t_inner := by
-    show t_min.subtreeAt? (p.take i ++ (p.take j).drop i) = _
-    rw [← hsubtree_path_eq]; exact hsub_i
-  have hsub_inner_in_outer : t_outer.subtreeAt? p_inner_rel = some t_inner := by
-    rw [DerivationTree.subtreeAt?_append] at hp_inner_compose
-    rw [show t_min.subtreeAt? p_outer = some t_outer from hsub_o] at hp_inner_compose
-    simpa using hp_inner_compose
-  -- Step 6: Yield decomposition
-  obtain ⟨u, z, hyield_t, hreplace_t⟩ :=
-    DerivationTree.yield_replaceAt_decomp t_min p_outer t_outer hsub_o
-  obtain ⟨v, y, hyield_outer, hreplace_outer⟩ :=
-    DerivationTree.yield_replaceAt_decomp t_outer p_inner_rel t_inner hsub_inner_in_outer
-  -- x := t_inner.yield
-  let x := t_inner.yield
-  -- t.yield = u ++ v ++ x ++ y ++ z (via t_min)
-  have hyield_decomp : t.yield = u ++ v ++ x ++ y ++ z := by
-    rw [← ht_min_y, hyield_t, hyield_outer]
-    show u ++ (v ++ t_inner.yield ++ y) ++ z = u ++ v ++ x ++ y ++ z
-    show u ++ (v ++ x ++ y) ++ z = u ++ v ++ x ++ y ++ z
-    simp [List.append_assoc]
-  -- Step 7: |vxy| ≤ pumpingConstant
-  have hvxy_bound : (v ++ x ++ y).length ≤ g.pumpingConstant := by
-    have ht_outer_yield_eq : t_outer.yield = v ++ x ++ y := by
-      rw [hyield_outer]
-    rw [← ht_outer_yield_eq]
-    have hbound := yield_length_le_of_height g t_outer
-      (DerivationTree.subtreeAt?_validFor t_min ht_min_v p_outer t_outer hsub_o)
-    have hpow_le : g.maxBranch ^ t_outer.height ≤ g.maxBranch ^ (g.rules.card + 1) :=
-      Nat.pow_le_pow_right (by have := g.maxBranch_ge_two; omega) ht_outer_h_le
-    unfold ContextFreeGrammar.pumpingConstant
+  -- a longest path, and the window of its last `g.rules.card + 1` nodes
+  obtain ⟨p, hp, hpath⟩ := exists_subtreeAt_height_sub t₁ (t₁.height - 1) (by omega)
+  set off := t₁.height - 1 - g.rules.card with hoff
+  obtain ⟨t₀, ht₀, hh₀⟩ := hpath off (by omega)
+  set q := p.drop off with hq
+  have hql : q.length = g.rules.card := by simp [q, hp]; omega
+  have hpq : p = p.take off ++ q := (List.take_append_drop off p).symm
+  obtain ⟨e, he, heh⟩ := hpath p.length hp.le
+  rw [List.take_length, hpq, subtreeAt_append, ht₀, Option.bind_some] at he
+  obtain ⟨i, j, hij, hjK, A, csᵢ, csⱼ, hi, hj⟩ :=
+    (ht₁.subtreeAt ht₀).exists_repeat he (by omega) hql.ge
+  -- the outer and inner repeats, and their addresses
+  set outer := node (Symbol.nonterminal A) csᵢ with houter
+  set inner := node (Symbol.nonterminal A) csⱼ with hinner
+  set po := p.take off ++ q.take i with hpo
+  have hpo_sub : t₁.subtreeAt po = some outer := by
+    rw [hpo, subtreeAt_append, ht₀, Option.bind_some, hi]
+  set pr := (q.take j).drop i with hpr
+  have hqj : q.take j = q.take i ++ pr := by
+    conv_lhs => rw [← List.take_append_drop i (q.take j)]
+    rw [List.take_take, min_eq_left hij.le]
+  have hpr_sub : outer.subtreeAt pr = some inner := by
+    rw [hqj, subtreeAt_append, hi, Option.bind_some] at hj; exact hj
+  have hpr_ne : pr ≠ [] := by
+    intro h
+    have := congrArg List.length h
+    simp [pr, hql] at this
     omega
-  -- Step 8: |vy| ≥ 1 via minimality
-  have hvy_pos : v.length + y.length ≥ 1 := by
-    by_contra hcontra
-    push Not at hcontra
-    have hv_empty : v = [] :=
-      List.eq_nil_of_length_eq_zero (by omega)
-    have hy_empty : y = [] :=
-      List.eq_nil_of_length_eq_zero (by omega)
-    -- If v = y = ε, then yield(t_outer) = yield(t_inner)
-    have ht_outer_yield_eq_inner : t_outer.yield = t_inner.yield := by
-      rw [hyield_outer, hv_empty, hy_empty]; simp
-    -- Replace t_outer with t_inner in t_min: same yield, but smaller size
-    let t_replaced := t_min.replaceAt p_outer t_inner
-    have hyield_replaced : t_replaced.yield = t_min.yield := by
-      show (t_min.replaceAt p_outer t_inner).yield = t_min.yield
-      rw [hreplace_t t_inner, hyield_t, ht_outer_yield_eq_inner]
-    have hvalid_replaced : t_replaced.ValidFor g := by
-      apply DerivationTree.validFor_replaceAt t_min p_outer t_outer t_inner hsub_o
-        hroot_o_eq_i.symm ht_min_v
-      exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
-    have hroot_replaced : t_replaced.rootSymbol = t_min.rootSymbol := by
-      show (t_min.replaceAt p_outer t_inner).rootSymbol = t_min.rootSymbol
-      cases hp_outer_eq : p_outer with
-      | nil =>
-        have hto_eq_tmin : t_outer = t_min := by
-          have h0 : t_min.subtreeAt? [] = some t_outer := by rw [← hp_outer_eq]; exact hsub_o
-          simp [DerivationTree.subtreeAt?] at h0; exact h0.symm
-        simp [DerivationTree.replaceAt]
-        rw [← hroot_o_eq_i, ← hto_eq_tmin]
-      | cons hh tt =>
-        exact DerivationTree.rootSymbol_replaceAt_cons t_min hh tt t_inner
-    -- size strict decrease
-    have hsize_lt : t_replaced.size < t_min.size := by
-      have hi_size_lt : t_inner.size < t_outer.size := by
-        have hp_inner_rel_nonempty : p_inner_rel ≠ [] := by
-          intro hempty
-          have : (p.take j).drop i = [] := hempty
-          have hlen_eq : (p.take j).length ≤ i := by
-            have := congr_arg List.length this; simp at this; omega
-          have : j ≤ i := by
-            have h1 : (p.take j).length = min j p.length := by simp
-            rw [h1] at hlen_eq; omega
-          omega
-        obtain ⟨idx, rest, hp_eq⟩ : ∃ idx rest, p_inner_rel = idx :: rest := by
-          rcases p_inner_rel with _ | ⟨a, b⟩
-          · exact absurd rfl hp_inner_rel_nonempty
-          · exact ⟨a, b, rfl⟩
-        have hsub' : t_outer.subtreeAt? (idx :: rest) = some t_inner := by
-          rw [← hp_eq]; exact hsub_inner_in_outer
-        exact DerivationTree.size_subtreeAt?_lt_of_cons t_outer idx rest t_inner hsub'
-      exact DerivationTree.size_replaceAt_lt t_min p_outer t_outer t_inner hsub_o hi_size_lt
-    -- Apply minimality
-    have := ht_min_minimal t_replaced hvalid_replaced
-      (by rw [hyield_replaced]; exact ht_min_y)
-      (by rw [hroot_replaced]; exact ht_min_r)
+  have houter_h : outer.height ≤ g.rules.card + 1 := by
+    obtain ⟨s, hs, hsh⟩ := hpath (off + i) (by omega)
+    rw [List.take_add, ← hq, ← hpo, hpo_sub, Option.some.injEq] at hs
+    rw [hs, hsh]; omega
+  have houter_v : outer.ValidFor g := ht₁.subtreeAt hpo_sub
+  have hinner_v : inner.ValidFor g := houter_v.subtreeAt hpr_sub
+  -- yield decompositions
+  obtain ⟨u, z, hyu, hyu'⟩ := yield_replaceAt hpo_sub
+  obtain ⟨v, y, hyv, hyv'⟩ := yield_replaceAt hpr_sub
+  refine ⟨u, v, inner.yield, y, z, ?_, ?_, ?_, fun k => ?_⟩
+  · rw [← hy₁, hyu, hyv]; simp only [List.append_assoc]
+  · rw [← hyv]
+    exact houter_v.length_yield_le.trans (Nat.pow_le_pow_right (by omega) houter_h)
+  · -- `v ++ y` is nonempty, by minimality
+    by_contra hvy
+    have hv : v = [] := List.eq_nil_of_length_eq_zero (by omega)
+    have hy : y = [] := List.eq_nil_of_length_eq_zero (by omega)
+    obtain ⟨i', rest, hpr'⟩ := List.exists_cons_of_ne_nil hpr_ne
+    have hlt : (t₁.replaceAt po inner).numNodes < t₁.numNodes :=
+      numNodes_replaceAt_lt hpo_sub (numNodes_lt_of_subtreeAt_cons (hpr' ▸ hpr_sub))
+    have := hmin _ (ht₁.replaceAt hpo_sub hinner_v rfl)
+      (by rw [hyu' inner, ← hy₁, hyu, hyv, hv, hy]; simp)
+      (by rw [value_replaceAt (new := inner) hpo_sub rfl, hr₁])
     omega
-  -- Step 9: Pumping iteration
-  refine ⟨u, v, x, y, z, hyield_decomp, hvxy_bound, hvy_pos, ?_⟩
-  -- For ∀ i, prove the pumped string is in g.language
-  -- Define pumpInner : Nat → DerivationTree, with yield = v^i ++ x ++ y^i
-  intro k
-  -- pumpInner k: replace t_inner with itself k times (giving v^k ++ x ++ y^k yield in t_outer's slot)
-  -- Then graft into t_min at p_outer.
-  -- For brevity, define recursively and prove by induction.
-  let pumpInner : Nat → DerivationTree T g.NT := fun n => Nat.rec t_inner
-    (fun _ prev => t_outer.replaceAt p_inner_rel prev) n
-  have hpump_yield : ∀ n, (pumpInner n).yield =
-      List.flatten (List.replicate n v) ++ x ++ List.flatten (List.replicate n y) := by
-    intro n
-    induction n with
-    | zero => simp [pumpInner, x]
-    | succ m ih =>
-      show (t_outer.replaceAt p_inner_rel (pumpInner m)).yield = _
-      rw [hreplace_outer (pumpInner m), ih]
-      conv_rhs =>
-        rw [show List.replicate (m + 1) v = v :: List.replicate m v from rfl,
-            List.flatten_cons, flatten_replicate_succ_right]
-      simp only [List.append_assoc]
-  have hpump_root : ∀ n, (pumpInner n).rootSymbol = t_inner.rootSymbol := by
-    intro n
-    induction n with
-    | zero => rfl
-    | succ m ih =>
-      show (t_outer.replaceAt p_inner_rel (pumpInner m)).rootSymbol = _
-      cases hp_rel_eq : p_inner_rel with
-      | nil =>
-        simp [DerivationTree.replaceAt]
-        exact ih
-      | cons hh tt =>
-        exact (DerivationTree.rootSymbol_replaceAt_cons t_outer hh tt (pumpInner m)).trans hroot_o_eq_i
-  have hpump_valid : ∀ n, (pumpInner n).ValidFor g := by
-    intro n
-    induction n with
-    | zero =>
-      show t_inner.ValidFor g
-      exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
-    | succ m ih =>
-      show (t_outer.replaceAt p_inner_rel (pumpInner m)).ValidFor g
-      apply DerivationTree.validFor_replaceAt t_outer p_inner_rel t_inner (pumpInner m)
-        hsub_inner_in_outer
-      · -- (pumpInner m).rootSymbol = t_inner.rootSymbol
-        exact hpump_root m
-      · exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hsub_o
-      · exact ih
-  -- Final pumped tree
-  let final := t_min.replaceAt p_outer (pumpInner k)
-  have hfinal_yield : final.yield =
-      u ++ List.flatten (List.replicate k v) ++ x ++ List.flatten (List.replicate k y) ++ z := by
-    show (t_min.replaceAt p_outer (pumpInner k)).yield = _
-    rw [hreplace_t (pumpInner k), hpump_yield k]
-    simp [List.append_assoc]
-  have hfinal_valid : final.ValidFor g := by
-    apply DerivationTree.validFor_replaceAt t_min p_outer t_outer (pumpInner k) hsub_o
-    · exact (hpump_root k).trans hroot_o_eq_i.symm
-    · exact ht_min_v
-    · exact hpump_valid k
-  have hfinal_root : final.rootSymbol = .nonterminal g.initial := by
-    show (t_min.replaceAt p_outer (pumpInner k)).rootSymbol = .nonterminal g.initial
-    cases hp_outer_eq : p_outer with
-    | nil =>
-      have hto_eq_tmin : t_outer = t_min := by
-        have h0 : t_min.subtreeAt? [] = some t_outer := by rw [← hp_outer_eq]; exact hsub_o
-        simp [DerivationTree.subtreeAt?] at h0; exact h0.symm
-      simp [DerivationTree.replaceAt]
-      rw [hpump_root k, ← hroot_o_eq_i, hto_eq_tmin, ht_min_r, hroot]
-    | cons hh tt =>
-      exact (DerivationTree.rootSymbol_replaceAt_cons t_min hh tt (pumpInner k)).trans
-        (by rw [ht_min_r, hroot])
-  -- Conclude: final.yield ∈ g.language
-  show (u ++ List.flatten (List.replicate k v) ++ x ++
-        List.flatten (List.replicate k y) ++ z) ∈ g.language
-  rw [← hfinal_yield]
-  have h := DerivationTree.validFor_derives final hfinal_valid
-  rw [hfinal_root] at h
-  exact h
+  · -- pumping: graft the inner tree into the outer one `k` times, then into the tree
+    let pump : ℕ → RoseTree (Symbol T g.NT) := fun n =>
+      Nat.rec inner (fun _ prev => outer.replaceAt pr prev) n
+    have hpump : ∀ n, (pump n).yield =
+          (List.replicate n v).flatten ++ inner.yield ++ (List.replicate n y).flatten ∧
+        (pump n).value = inner.value ∧ (pump n).ValidFor g := fun n => by
+      induction n with
+      | zero => exact ⟨by show inner.yield = _; simp, rfl, hinner_v⟩
+      | succ n ih =>
+        refine ⟨?_, ?_, houter_v.replaceAt hpr_sub ih.2.2 ih.2.1⟩
+        · show (outer.replaceAt pr (pump n)).yield = _
+          rw [hyv' (pump n), ih.1, List.replicate_succ, List.flatten_cons, flatten_replicate_succ]
+          simp only [List.append_assoc]
+        · exact (value_replaceAt hpr_sub ih.2.1).trans rfl
+    have hfinal := ht₁.replaceAt hpo_sub (hpump k).2.2 (hpump k).2.1
+    rw [mem_language_iff, ← hroot, ← hr₁, ← value_replaceAt hpo_sub (hpump k).2.1,
+      show u ++ (List.replicate k v).flatten ++ inner.yield ++ (List.replicate k y).flatten ++ z =
+        (t₁.replaceAt po (pump k)).yield by rw [hyu' (pump k), (hpump k).1]; simp]
+    exact hfinal.derives
 
-/-- **The CFL pumping lemma.** Every context-free language satisfies
-    `HasCFLPumpingProperty`.
+end ContextFreeGrammar
 
-    Proof: given a CFG g generating L, set p = g.pumpingConstant.
-    For any w ∈ L with |w| ≥ p:
-    1. `exists_valid_tree`: w has a valid derivation tree t.
-    2. `yield_length_le_of_height` (contrapositive): |w| ≥ p = b^(k+1)
-       forces t.height > k = g.rules.card.
-    3. `pumping_from_tall_tree`: the tall tree yields the decomposition. -/
-theorem cfl_pumping_lemma {T : Type*} (L : Language T)
-    (hcf : L.IsContextFree) : HasCFLPumpingProperty L := by
+/-- **The pumping lemma for context-free languages.** -/
+theorem cfl_pumping_lemma {T : Type*} (L : Language T) (hcf : L.IsContextFree) :
+    HasCFLPumpingProperty L := by
   obtain ⟨g, rfl⟩ := hcf
-  refine ⟨g.pumpingConstant, g.pumpingConstant_pos, ?_⟩
-  intro w hw hlen
-  obtain ⟨t, hvalid, hyield, hroot⟩ := exists_valid_tree g w hw
-  have hyield_long : t.yield.length ≥ g.pumpingConstant := hyield ▸ hlen
+  refine ⟨g.pumpingConstant, g.pumpingConstant_pos, fun w hw hlen => ?_⟩
+  obtain ⟨t, hvalid, hyield, hroot⟩ := g.exists_valid_tree hw
   obtain ⟨u, v, x, y, z, hdecomp, hvxy, hvy, hpump⟩ :=
-    pumping_from_tall_tree g t hvalid hroot hyield_long
+    ContextFreeGrammar.pumping_from_tall_tree hvalid hroot (hyield ▸ hlen)
   exact ⟨u, v, x, y, z, hyield ▸ hdecomp, hvxy, hvy, hpump⟩
 
-/-- Contrapositive of the CFL pumping lemma: if a language lacks the pumping
-    property, it is not context-free. -/
+/-- A language without the pumping property is not context-free. -/
 theorem not_isContextFree_of_not_pumpable {T : Type*} (L : Language T)
     (h : ¬ HasCFLPumpingProperty L) : ¬ L.IsContextFree :=
   fun hcf => h (cfl_pumping_lemma L hcf)
-

--- a/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
@@ -1,1293 +1,465 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Computability.ContextFreeGrammar
+import Linglib.Core.Data.RoseTree.Get
+import Linglib.Core.Data.RoseTree.Countable
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
-import Linglib.Core.Order.Branching
-import Mathlib.Data.W.Basic
-import Mathlib.Logic.Encodable.Basic
-import Mathlib.Data.Countable.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.List
+import Mathlib.Algebra.Order.Group.Nat
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Nat.Find
 
 /-!
-# Derivation Trees for Context-Free Grammars
+# Derivation trees of a context-free grammar
 
-`DerivationTree T N` is a derivation tree whose leaves hold terminal symbols of type `T`
-and whose internal nodes hold a nonterminal of type `N` together with a list of
-children. The file provides:
+A derivation tree of a context-free grammar is a rose tree over its symbols,
+`RoseTree (Symbol T N)`. It is valid for a grammar when every terminal node is a leaf and every
+nonterminal node, read with the symbols of its children, is a rule. The yield of a tree is the
+list of terminals at its leaves, left to right.
 
-* `ValidFor g`: validity — every internal node matches a production rule in `g`.
-* `yield` / `yieldList`: the terminal frontier, left-to-right.
-* `subtreeAt?` / `replaceAt`: position-based subtree access and replacement.
-* `validFor_derives`: soundness — a valid tree derives its yield from its root.
-* `exists_valid_tree`: tree existence, with height–yield bounds.
-* `size`: the size measure, with minimality and a pigeonhole on derivation paths.
-* `map`: relabelling of nonterminals, commuting with `yield`, `height` and `subtreeAt?`.
-* A `Countable` instance for countable `T` and `N`, by an injection into a W-type.
+## Main definitions
+
+* `RoseTree.yield`: the terminal frontier.
+* `RoseTree.ValidFor g`: validity for the grammar `g`.
+* `RoseTree.ruleCount`, `RoseTree.corpusRuleCount`: the number of applications of a rule in a
+  tree and in a corpus of trees.
+* `RoseTree.ruleAt?`: the rule applied at a Gorn address.
+* `ContextFreeGrammar.maxBranch`, `ContextFreeGrammar.pumpingConstant`: the branching bound and
+  the pumping constant of a grammar.
+
+## Main results
+
+* `RoseTree.ValidFor.derives`: a valid tree derives its yield from its root symbol.
+* `ContextFreeGrammar.exists_valid_tree`: every word of the language has a valid derivation tree
+  from the start symbol.
+* `RoseTree.ValidFor.length_yield_le`: a valid tree of height `h` has at most `maxBranch ^ h`
+  terminals.
+* `RoseTree.ValidFor.replaceAt`, `RoseTree.ValidFor.exists_repeat`: replacing a subtree by one
+  with the same root symbol preserves validity, and a long enough path in a valid tree passes two
+  nodes with the same nonterminal; together with `RoseTree.numNodes_replaceAt_lt` these are the
+  ingredients of the pumping lemma.
 -/
-/-- A derivation tree for a context-free grammar.
-    Leaves hold terminal symbols; internal nodes hold a nonterminal
-    and a list of children (matching a production rule's RHS). -/
-inductive DerivationTree (T N : Type*) where
-  | leaf (t : T) : DerivationTree T N
-  | node (nt : N) (children : List (DerivationTree T N)) : DerivationTree T N
 
-namespace DerivationTree
+/-- The terminal at a symbol, if it is one. -/
+def Symbol.terminal? {T N : Type*} : Symbol T N → Option T
+  | .terminal a => some a
+  | .nonterminal _ => none
 
-variable {T N : Type*}
+@[simp] theorem Symbol.terminal?_terminal {T N : Type*} (a : T) :
+    (Symbol.terminal a : Symbol T N).terminal? = some a := rfl
 
-/-- The root symbol of a subtree. -/
-def rootSymbol : DerivationTree T N → Symbol T N
-  | .leaf t => .terminal t
-  | .node nt _ => .nonterminal nt
+@[simp] theorem Symbol.terminal?_nonterminal {T N : Type*} (A : N) :
+    (Symbol.nonterminal A : Symbol T N).terminal? = none := rfl
 
-@[simp] theorem rootSymbol_leaf (t : T) :
-    (leaf t : DerivationTree T N).rootSymbol = .terminal t := rfl
+/-- Relabel the nonterminals of a symbol. -/
+def Symbol.mapNonterminal {T N N' : Type*} (f : N → N') : Symbol T N → Symbol T N'
+  | .terminal a => .terminal a
+  | .nonterminal A => .nonterminal (f A)
 
-@[simp] theorem rootSymbol_node (nt : N) (children : List (DerivationTree T N)) :
-    (node nt children).rootSymbol = .nonterminal nt := rfl
+@[simp] theorem Symbol.mapNonterminal_terminal {T N N' : Type*} (f : N → N') (a : T) :
+    Symbol.mapNonterminal f (Symbol.terminal a : Symbol T N) = .terminal a := rfl
 
-mutual
-/-- The terminal frontier (yield) of a derivation tree, read left to right. -/
-def yield : DerivationTree T N → List T
-  | .leaf t => [t]
-  | .node _ children => yieldList children
+@[simp] theorem Symbol.mapNonterminal_nonterminal {T N N' : Type*} (f : N → N') (A : N) :
+    Symbol.mapNonterminal f (Symbol.nonterminal A : Symbol T N) = .nonterminal (f A) := rfl
 
-/-- Concatenate yields of a list of subtrees. -/
-def yieldList : List (DerivationTree T N) → List T
-  | [] => []
-  | t :: ts => t.yield ++ yieldList ts
-end
+@[simp] theorem Symbol.terminal?_mapNonterminal {T N N' : Type*} (f : N → N') (s : Symbol T N) :
+    (s.mapNonterminal f).terminal? = s.terminal? := by cases s <;> rfl
 
-mutual
-/-- The height: 0 for leaves, 1 + max child height for nodes. -/
-def height : DerivationTree T N → Nat
-  | .leaf _ => 0
-  | .node _ children => 1 + heightMax children
-
-/-- Maximum height among a list of subtrees. -/
-def heightMax : List (DerivationTree T N) → Nat
-  | [] => 0
-  | t :: ts => max t.height (heightMax ts)
-end
-
-/-! ### Relabelling nonterminals -/
-
-section Map
-variable {N' : Type*}
-
-mutual
-/-- Relabel every nonterminal by `f`, keeping leaves and shape. -/
-def map (f : N → N') : DerivationTree T N → DerivationTree T N'
-  | .leaf t => .leaf t
-  | .node nt children => .node (f nt) (mapList f children)
-
-/-- `map` on a list of subtrees. -/
-def mapList (f : N → N') : List (DerivationTree T N) → List (DerivationTree T N')
-  | [] => []
-  | t :: ts => map f t :: mapList f ts
-end
-
-@[simp] theorem map_leaf (f : N → N') (t : T) :
-    map f (.leaf t : DerivationTree T N) = .leaf t := rfl
-
-@[simp] theorem map_node (f : N → N') (nt : N) (children : List (DerivationTree T N)) :
-    map f (.node nt children) = .node (f nt) (mapList f children) := rfl
-
-@[simp] theorem mapList_nil (f : N → N') : mapList f ([] : List (DerivationTree T N)) = [] := rfl
-
-@[simp] theorem mapList_cons (f : N → N') (t : DerivationTree T N)
-    (ts : List (DerivationTree T N)) :
-    mapList f (t :: ts) = map f t :: mapList f ts := rfl
-
-theorem mapList_eq_map (f : N → N') (ts : List (DerivationTree T N)) :
-    mapList f ts = ts.map (map f) := by
-  induction ts with
-  | nil => rfl
-  | cons t ts ih => simp [ih]
-
-mutual
-/-- Relabelling preserves the yield. -/
-theorem yield_map (f : N → N') : ∀ t : DerivationTree T N, (map f t).yield = t.yield
-  | .leaf _ => rfl
-  | .node _ children => by simp only [map, yield, yieldList_mapList f children]
-
-theorem yieldList_mapList (f : N → N') :
-    ∀ ts : List (DerivationTree T N), yieldList (mapList f ts) = yieldList ts
-  | [] => rfl
-  | t :: ts => by simp only [mapList, yieldList, yield_map f t, yieldList_mapList f ts]
-end
-
-mutual
-/-- Relabelling preserves the height. -/
-theorem height_map (f : N → N') : ∀ t : DerivationTree T N, (map f t).height = t.height
-  | .leaf _ => rfl
-  | .node _ children => by simp only [map, height, heightMax_mapList f children]
-
-theorem heightMax_mapList (f : N → N') :
-    ∀ ts : List (DerivationTree T N), heightMax (mapList f ts) = heightMax ts
-  | [] => rfl
-  | t :: ts => by simp only [mapList, heightMax, height_map f t, heightMax_mapList f ts]
-end
-
-end Map
-
-/-- A derivation tree is valid for a CFG if every internal node (A, children)
-    corresponds to a rule A → [rootSymbol c₁, ..., rootSymbol cₖ], and all
-    children are themselves valid. -/
-inductive ValidFor (g : ContextFreeGrammar T) : DerivationTree T g.NT → Prop where
-  | leaf (t : T) : ValidFor g (.leaf t)
-  | node (nt : g.NT) (children : List (DerivationTree T g.NT))
-    (hrule : ⟨nt, children.map rootSymbol⟩ ∈ g.rules)
-    (hchildren : ∀ c ∈ children, ValidFor g c) :
-    ValidFor g (.node nt children)
-
-section RuleCount
-
-variable [DecidableEq T] [DecidableEq N]
-
-mutual
-/-- Number of times rule `r` is applied at internal nodes of the
-    derivation tree `t`. A leaf contributes nothing; a node `(nt, cs)`
-    contributes 1 if its instantiated rule `⟨nt, cs.map rootSymbol⟩`
-    matches `r`, plus the count over its children. Substrate primitive
-    used by any weighted-CFG analysis (PCFG corpus probability,
-    Dirichlet posterior, etc.). -/
-def ruleCount (r : ContextFreeRule T N) :
-    DerivationTree T N → ℕ
-  | .leaf _ => 0
-  | .node nt cs =>
-      (if r = ⟨nt, cs.map rootSymbol⟩ then 1 else 0) + ruleCountList r cs
-
-/-- List version of `ruleCount` (mutual companion). -/
-def ruleCountList (r : ContextFreeRule T N) :
-    List (DerivationTree T N) → ℕ
-  | [] => 0
-  | t :: ts => ruleCount r t + ruleCountList r ts
-end
-
-/-- Total number of times rule `r` is used across a corpus `D` of
-    derivation trees. -/
-def corpusRuleCount (r : ContextFreeRule T N)
-    (D : Multiset (DerivationTree T N)) : ℕ :=
-  (D.map (ruleCount r)).sum
-
-/-- Empty corpus contributes no rule applications. -/
-@[simp]
-theorem corpusRuleCount_zero (r : ContextFreeRule T N) :
-    corpusRuleCount r (0 : Multiset (DerivationTree T N)) = 0 := by
-  simp [corpusRuleCount]
-
-@[simp]
-theorem corpusRuleCount_singleton (r : ContextFreeRule T N) (t : DerivationTree T N) :
-    corpusRuleCount r {t} = ruleCount r t := by
-  simp [corpusRuleCount]
-
-/-- Corpus rule counts add over disjoint corpora. -/
-theorem corpusRuleCount_add (r : ContextFreeRule T N)
-    (D₁ D₂ : Multiset (DerivationTree T N)) :
-    corpusRuleCount r (D₁ + D₂) = corpusRuleCount r D₁ + corpusRuleCount r D₂ := by
-  unfold corpusRuleCount
-  rw [Multiset.map_add, Multiset.sum_add]
-
-end RuleCount
-
-end DerivationTree
-
--- ============================================================================
--- CFL Pumping Lemma — Helper Lemmas
--- ============================================================================
-
-private theorem DerivationTree.height_le_heightMax {T N : Type*}
-    {t : DerivationTree T N} {ts : List (DerivationTree T N)}
-    (ht : t ∈ ts) : t.height ≤ DerivationTree.heightMax ts := by
-  induction ts with
-  | nil => simp at ht
-  | cons s ss ih =>
-    simp only [DerivationTree.heightMax]
-    rcases List.mem_cons.mp ht with rfl | h
-    · exact le_max_left _ _
-    · exact le_trans (ih h) (le_max_right _ _)
-
-private theorem le_foldl_max_init (l : List Nat) (init : Nat) :
-    init ≤ l.foldl max init := by
-  induction l generalizing init with
-  | nil => exact le_refl _
-  | cons a as ih =>
-    simp only [List.foldl_cons]
-    exact le_trans (le_max_left init a) (ih _)
-
-private theorem le_foldl_max_of_mem (l : List Nat) (x : Nat) (init : Nat) (hx : x ∈ l) :
-    x ≤ l.foldl max init := by
-  induction l generalizing init with
-  | nil => simp at hx
-  | cons a as ih =>
-    simp only [List.foldl_cons]
-    rcases List.mem_cons.mp hx with rfl | h
-    · exact le_trans (le_max_right init x) (le_foldl_max_init as _)
-    · exact ih _ h
-
--- ============================================================================
--- CFL Pumping Lemma — Grammar Properties
--- ============================================================================
-
-/-- Maximum rule RHS length in a grammar (at least 2).
-
-    We take the max over all rules' output lengths, floored at 2 to ensure
-    the branching factor is nontrivial (a tree of branching ≥ 2 and height h
-    has at most b^h leaves). -/
-noncomputable def ContextFreeGrammar.maxBranch {T : Type*}
-    (g : ContextFreeGrammar T) : Nat :=
-  max 2 (g.rules.val.toList.map (·.output.length) |>.foldl max 0)
-
-/-- The pumping constant for a CFG: b^(k+1) where b = maxBranch ≥ 2
-    and k = number of rules (upper bound on distinct nonterminals). -/
-noncomputable def ContextFreeGrammar.pumpingConstant {T : Type*}
-    (g : ContextFreeGrammar T) : Nat :=
-  g.maxBranch ^ (g.rules.card + 1)
-
-/-- maxBranch is at least 2. -/
-theorem ContextFreeGrammar.maxBranch_ge_two {T : Type*}
-    (g : ContextFreeGrammar T) : g.maxBranch ≥ 2 := le_max_left _ _
-
-/-- The pumping constant is positive (b ≥ 2 so b^(k+1) ≥ 2). -/
-theorem ContextFreeGrammar.pumpingConstant_pos {T : Type*}
-    (g : ContextFreeGrammar T) : g.pumpingConstant > 0 :=
-  Nat.pos_of_ne_zero (by
-    unfold pumpingConstant
-    exact ne_of_gt (Nat.lt_of_lt_of_le Nat.zero_lt_one
-      (Nat.one_le_pow _ _ (by have := g.maxBranch_ge_two; omega))))
-
-/-- Any rule's RHS length is at most `maxBranch`. -/
-private theorem ContextFreeGrammar.maxBranch_ge_output {T : Type*} (g : ContextFreeGrammar T)
-    (r : ContextFreeRule T g.NT) (hr : r ∈ g.rules) :
-    r.output.length ≤ g.maxBranch := by
-  unfold maxBranch
-  apply le_trans _ (le_max_right _ _)
-  apply le_foldl_max_of_mem
-  exact List.mem_map.mpr
-    ⟨r, Multiset.mem_toList.mpr (Finset.mem_val.mpr hr), rfl⟩
-
-/-- Sum of children's yields is at most `|children| * b ^ heightMax`. -/
-private theorem DerivationTree.yieldList_le {T N : Type*} (b : Nat) (_hb : b ≥ 2)
-    (ts : List (DerivationTree T N))
-    (hbound : ∀ c ∈ ts, c.yield.length ≤ b ^ c.height) :
-    (DerivationTree.yieldList ts).length ≤ ts.length * b ^ DerivationTree.heightMax ts := by
-  induction ts with
-  | nil => simp [DerivationTree.yieldList, DerivationTree.heightMax]
-  | cons t rest ih =>
-    simp only [DerivationTree.yieldList, List.length_append, List.length_cons, DerivationTree.heightMax]
-    have ht := hbound t (List.mem_cons_self ..)
-    have hrest := ih (fun c hc => hbound c (List.mem_cons_of_mem t hc))
-    have hle_t : b ^ t.height ≤ b ^ (max t.height (DerivationTree.heightMax rest)) :=
-      Nat.pow_le_pow_right (by omega) (le_max_left _ _)
-    have hle_rest : b ^ (DerivationTree.heightMax rest) ≤
-        b ^ (max t.height (DerivationTree.heightMax rest)) :=
-      Nat.pow_le_pow_right (by omega) (le_max_right _ _)
-    set p := b ^ (max t.height (DerivationTree.heightMax rest))
-    have h1 : t.yield.length ≤ p := le_trans ht hle_t
-    have h2 : (DerivationTree.yieldList rest).length ≤ rest.length * p :=
-      le_trans hrest (Nat.mul_le_mul_left _ hle_rest)
-    have h3 : (rest.length + 1) * p = p + rest.length * p := by
-      rw [Nat.add_mul, Nat.one_mul, Nat.add_comm]
-    omega
-
--- ============================================================================
--- Tree Existence — Helper Lemmas
--- ============================================================================
-
-namespace ContextFreeGrammar
-
-variable {T : Type*} {g : ContextFreeGrammar T}
-
-/-- A rewriting step at any position: applying a rule's RHS in place. -/
-private theorem Rewrites.at_position {r : ContextFreeRule T g.NT}
-    (p q : List (Symbol T g.NT)) :
-    r.Rewrites (p ++ [Symbol.nonterminal r.input] ++ q) (p ++ r.output ++ q) := by
-  induction p with
-  | nil =>
-    simp only [List.nil_append]
-    exact .head q
-  | cons x xs ih =>
-    have h1 : (x :: xs) ++ [Symbol.nonterminal r.input] ++ q =
-              x :: (xs ++ [Symbol.nonterminal r.input] ++ q) := by simp
-    have h2 : (x :: xs) ++ r.output ++ q = x :: (xs ++ r.output ++ q) := by simp
-    rw [h1, h2]
-    exact .cons x ih
-
-set_option maxHeartbeats 400000 in
-/-- A `Rewrites` step on a concatenated list happens in one of the two halves. -/
-private theorem Rewrites.append_split {r : ContextFreeRule T g.NT}
-    {u₁ u₂ v : List (Symbol T g.NT)} (h : r.Rewrites (u₁ ++ u₂) v) :
-    (∃ v₁, v = v₁ ++ u₂ ∧ r.Rewrites u₁ v₁) ∨
-    (∃ v₂, v = u₁ ++ v₂ ∧ r.Rewrites u₂ v₂) := by
-  obtain ⟨p, q, hpq, hv⟩ := h.exists_parts
-  rw [List.append_assoc] at hpq
-  rcases List.append_eq_append_iff.mp hpq with ⟨e, hp_eq, hu₂⟩ | ⟨e, hu₁, hrest⟩
-  · -- nonterminal in u₂
-    right
-    have hu₂' : u₂ = e ++ [Symbol.nonterminal r.input] ++ q := by
-      rw [hu₂]; simp [List.append_assoc]
-    refine ⟨e ++ r.output ++ q, ?_, ?_⟩
-    · subst hp_eq; rw [hv]; simp [List.append_assoc]
-    · rw [hu₂']; exact Rewrites.at_position e q
-  · rcases e with _ | ⟨e_head, e_tail⟩
-    · -- u₁ = p, nonterminal at start of u₂
-      simp at hu₁
-      simp only [List.nil_append] at hrest
-      right
-      refine ⟨r.output ++ q, ?_, ?_⟩
-      · subst hu₁; rw [hv]; simp [List.append_assoc]
-      · rw [← hrest]
-        simp only [List.singleton_append]
-        exact .head q
-    · -- nonterminal in u₁
-      simp only [List.nil_append, List.cons_append] at hrest
-      rw [List.cons_eq_cons] at hrest
-      obtain ⟨he_head, h_tail⟩ := hrest
-      left
-      refine ⟨p ++ r.output ++ e_tail, ?_, ?_⟩
-      · rw [hv, h_tail]; simp [List.append_assoc]
-      · rw [hu₁]
-        rw [show p ++ e_head :: e_tail = p ++ [e_head] ++ e_tail by simp]
-        rw [he_head.symm]
-        exact Rewrites.at_position p e_tail
-
-/-- A `Produces` step on a concatenated list happens in one of the two halves. -/
-private theorem Produces.append_split {u₁ u₂ v : List (Symbol T g.NT)}
-    (h : g.Produces (u₁ ++ u₂) v) :
-    (∃ v₁, v = v₁ ++ u₂ ∧ g.Produces u₁ v₁) ∨
-    (∃ v₂, v = u₁ ++ v₂ ∧ g.Produces u₂ v₂) := by
-  obtain ⟨r, hr, hrew⟩ := h
-  rcases Rewrites.append_split hrew with ⟨v₁, hv, hpr⟩ | ⟨v₂, hv, hpr⟩
-  · exact .inl ⟨v₁, hv, r, hr, hpr⟩
-  · exact .inr ⟨v₂, hv, r, hr, hpr⟩
-
-/-- A `Derives` chain on a concatenated list decomposes into chains for each half. -/
-private theorem Derives.append_split {u₁ u₂ v : List (Symbol T g.NT)}
-    (h : g.Derives (u₁ ++ u₂) v) :
-    ∃ v₁ v₂, v = v₁ ++ v₂ ∧ g.Derives u₁ v₁ ∧ g.Derives u₂ v₂ := by
-  induction h with
-  | refl => exact ⟨u₁, u₂, rfl, .refl _, .refl _⟩
-  | tail _ h_step ih =>
-    obtain ⟨m₁, m₂, hmid, hd₁, hd₂⟩ := ih
-    rw [hmid] at h_step
-    rcases Produces.append_split h_step with ⟨v₁, hv, hp⟩ | ⟨v₂, hv, hp⟩
-    · exact ⟨v₁, m₂, hv, hd₁.trans_produces hp, hd₂⟩
-    · exact ⟨m₁, v₂, hv, hd₁, hd₂.trans_produces hp⟩
-
-/-- A terminal symbol can never be rewritten (productions only replace nonterminals). -/
-private theorem Derives.of_terminal {t : T} {v : List (Symbol T g.NT)}
-    (h : g.Derives [Symbol.terminal t] v) : v = [Symbol.terminal t] := by
-  induction h with
-  | refl => rfl
-  | tail _ h_step ih =>
-    rw [ih] at h_step
-    obtain ⟨r, _, hrew⟩ := h_step
-    obtain ⟨p, q, hpq, _⟩ := hrew.exists_parts
-    have hmem : (Symbol.nonterminal r.input : Symbol T g.NT) ∈
-        ([Symbol.terminal t] : List _) := by
-      rw [hpq]; simp
-    simp at hmem
-
-/-- The yield of a list of leaves is the original list of terminals. -/
-private theorem yieldList_leaves (w : List T) :
-    DerivationTree.yieldList (w.map (DerivationTree.leaf : T → DerivationTree T g.NT)) = w := by
-  induction w with
-  | nil => rfl
-  | cons t ts ih =>
-    simp only [List.map_cons, DerivationTree.yieldList, DerivationTree.yield, List.singleton_append, ih]
-
-/-- `yieldList` distributes over list concatenation. -/
-private theorem yieldList_append {N : Type*} (xs ys : List (DerivationTree T N)) :
-    DerivationTree.yieldList (xs ++ ys) = DerivationTree.yieldList xs ++ DerivationTree.yieldList ys := by
-  induction xs with
-  | nil => simp [DerivationTree.yieldList]
-  | cons x xs ih =>
-    simp only [List.cons_append, DerivationTree.yieldList, ih, List.append_assoc]
-
-set_option maxHeartbeats 800000 in
-/-- **Forest existence.** For any sentential form `sf` deriving a terminal string `w`,
-    there exists a list of trees whose roots match `sf`, are all valid, and whose
-    concatenated yields equal `w`. -/
-private theorem forest_exists {sf : List (Symbol T g.NT)} {w : List T}
-    (h : g.Derives sf (w.map Symbol.terminal)) :
-    ∃ trees : List (DerivationTree T g.NT),
-      trees.map DerivationTree.rootSymbol = sf ∧
-      (∀ t ∈ trees, t.ValidFor g) ∧
-      DerivationTree.yieldList trees = w := by
-  induction h using Relation.ReflTransGen.head_induction_on with
-  | refl =>
-    refine ⟨w.map (DerivationTree.leaf : T → DerivationTree T g.NT), ?_, ?_, ?_⟩
-    · simp [List.map_map, Function.comp_def, DerivationTree.rootSymbol]
-    · intro t ht
-      simp only [List.mem_map] at ht
-      obtain ⟨_, _, rfl⟩ := ht
-      exact .leaf _
-    · exact yieldList_leaves w
-  | head h_step _ ih =>
-    obtain ⟨forest_c, hroot, hvalid, hyield⟩ := ih
-    obtain ⟨r, hr, hrew⟩ := h_step
-    obtain ⟨p, q, hsf, hc⟩ := hrew.exists_parts
-    let pLen := p.length
-    let outLen := r.output.length
-    let prefix' := forest_c.take pLen
-    let middle := (forest_c.drop pLen).take outLen
-    let suffix := forest_c.drop (pLen + outLen)
-    let new_node : DerivationTree T g.NT := .node r.input middle
-    let new_forest := prefix' ++ [new_node] ++ suffix
-    have hprefix_root : prefix'.map DerivationTree.rootSymbol = p := by
-      have h1 : (forest_c.take pLen).map DerivationTree.rootSymbol =
-          (forest_c.map DerivationTree.rootSymbol).take pLen := by rw [List.map_take]
-      rw [show prefix' = forest_c.take pLen from rfl, h1, hroot, hc]
-      simp [pLen]
-    have hmiddle_root : middle.map DerivationTree.rootSymbol = r.output := by
-      have h1 : ((forest_c.drop pLen).take outLen).map DerivationTree.rootSymbol =
-          ((forest_c.map DerivationTree.rootSymbol).drop pLen).take outLen := by
-        rw [List.map_take, List.map_drop]
-      rw [show middle = (forest_c.drop pLen).take outLen from rfl, h1, hroot, hc]
-      simp [pLen, outLen, List.append_assoc]
-    have hsuffix_root : suffix.map DerivationTree.rootSymbol = q := by
-      have h1 : (forest_c.drop (pLen + outLen)).map DerivationTree.rootSymbol =
-          (forest_c.map DerivationTree.rootSymbol).drop (pLen + outLen) := by
-        rw [List.map_drop]
-      rw [show suffix = forest_c.drop (pLen + outLen) from rfl, h1, hroot, hc]
-      simp [pLen, outLen, List.append_assoc]
-    refine ⟨new_forest, ?_, ?_, ?_⟩
-    · rw [hsf]
-      show (prefix' ++ [new_node] ++ suffix).map DerivationTree.rootSymbol =
-           p ++ [Symbol.nonterminal r.input] ++ q
-      simp only [List.map_append, List.map_cons, List.map_nil]
-      rw [hprefix_root, hsuffix_root]
-      show p ++ [new_node.rootSymbol] ++ q = p ++ [Symbol.nonterminal r.input] ++ q
-      rfl
-    · intro t ht
-      simp only [new_forest, List.mem_append, List.mem_singleton] at ht
-      rcases ht with (ht | ht) | ht
-      · exact hvalid t (List.mem_of_mem_take ht)
-      · subst ht
-        refine .node r.input middle ?_ ?_
-        · rw [hmiddle_root]; exact hr
-        · intro c hc
-          have : c ∈ forest_c := by
-            have := List.mem_of_mem_take hc
-            exact List.mem_of_mem_drop this
-          exact hvalid c this
-      · exact hvalid t (List.mem_of_mem_drop ht)
-    · show DerivationTree.yieldList new_forest = w
-      have h_decomp : forest_c = prefix' ++ middle ++ suffix := by
-        show forest_c = forest_c.take pLen ++ (forest_c.drop pLen).take outLen ++
-                        forest_c.drop (pLen + outLen)
-        conv_lhs => rw [← List.take_append_drop pLen forest_c,
-                        ← List.take_append_drop outLen (forest_c.drop pLen),
-                        List.drop_drop]
-        rw [List.append_assoc]
-      have hy_orig : DerivationTree.yieldList (prefix' ++ middle ++ suffix) = w := by
-        rw [← h_decomp]; exact hyield
-      rw [yieldList_append, yieldList_append] at hy_orig
-      show DerivationTree.yieldList (prefix' ++ [new_node] ++ suffix) = w
-      rw [yieldList_append, yieldList_append]
-      have h_node_yield : DerivationTree.yieldList [new_node] = DerivationTree.yieldList middle := by
-        show DerivationTree.yieldList [new_node] = DerivationTree.yieldList middle
-        simp [DerivationTree.yieldList, DerivationTree.yield, new_node]
-      rw [h_node_yield]
-      exact hy_orig
-
-end ContextFreeGrammar
-
-/-- **Tree existence.** Every word in a CFG's language has a valid derivation
-    tree rooted at the start symbol.
-
-    Proof: applies `forest_exists` to the start nonterminal `[g.initial]`,
-    which yields a singleton forest containing the desired tree. The
-    `forest_exists` lemma generalizes to all sentential forms by induction
-    on the derivation, with each `Produces` step "folding" the children of
-    the rewritten nonterminal back into a single node tree. -/
-theorem exists_valid_tree {T : Type*} (g : ContextFreeGrammar T)
-    (w : List T) (hw : w ∈ g.language) :
-    ∃ t : DerivationTree T g.NT,
-      t.ValidFor g ∧ t.yield = w ∧ t.rootSymbol = .nonterminal g.initial := by
-  have hd : g.Derives [Symbol.nonterminal g.initial] (w.map Symbol.terminal) := hw
-  obtain ⟨trees, hroot, hvalid, hyield⟩ := ContextFreeGrammar.forest_exists hd
-  have hlen : trees.length = 1 := by
-    have := congr_arg List.length hroot
-    simp at this; exact this
-  match trees, hlen with
-  | [t], _ =>
-    refine ⟨t, ?_, ?_, ?_⟩
-    · exact hvalid t (List.mem_singleton.mpr rfl)
-    · have hy : DerivationTree.yieldList [t] = w := hyield
-      simp only [DerivationTree.yieldList, List.append_nil] at hy
-      exact hy
-    · have hr : [t].map DerivationTree.rootSymbol = [Symbol.nonterminal g.initial] := hroot
-      simp at hr; exact hr
-
-set_option maxHeartbeats 400000 in
-/-- **Height–yield bound.** A valid derivation tree of height h has at most
-    b^h terminal leaves, where b is the max branching factor.
-
-    Proof: well-founded recursion on tree size. A leaf has height 0 and
-    1 = b⁰ leaves. A node with children c₁...cₖ (k ≤ b) has
-    |yield| = Σᵢ |yield(cᵢ)| ≤ k · b^(max heights) ≤ b · b^(h-1) = b^h. -/
-theorem yield_length_le_of_height {T : Type*} (g : ContextFreeGrammar T)
-    (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
-    t.yield.length ≤ g.maxBranch ^ t.height := by
-  match t, ht with
-  | .leaf _, _ => simp [DerivationTree.yield, DerivationTree.height]
-  | .node nt children, .node _ _ hrule hvalid =>
-    simp only [DerivationTree.yield, DerivationTree.height]
-    have hchildren_bound : ∀ c ∈ children, c.yield.length ≤ g.maxBranch ^ c.height :=
-      fun c hc => yield_length_le_of_height g c (hvalid c hc)
-    have hlist := DerivationTree.yieldList_le g.maxBranch g.maxBranch_ge_two children hchildren_bound
-    have hlen : children.length ≤ g.maxBranch := by
-      have heq : children.length = (children.map DerivationTree.rootSymbol).length := by simp
-      rw [heq]
-      show (children.map DerivationTree.rootSymbol).length ≤ g.maxBranch
-      have : (children.map DerivationTree.rootSymbol).length =
-          (ContextFreeRule.mk nt (children.map DerivationTree.rootSymbol)).output.length := rfl
-      rw [this]
-      exact g.maxBranch_ge_output ⟨nt, children.map DerivationTree.rootSymbol⟩ hrule
-    set b := g.maxBranch
-    set hm := DerivationTree.heightMax children
-    have h1 : children.length * b ^ hm ≤ b * b ^ hm := Nat.mul_le_mul_right _ hlen
-    have h2 : b * b ^ hm = b ^ (1 + hm) := by
-      rw [show 1 + hm = hm + 1 from by omega, Nat.pow_succ']
-    omega
-termination_by sizeOf t
--- ============================================================================
--- Pumping Infrastructure: Position-based Subtree Access
--- ============================================================================
-
-namespace DerivationTree
-
-variable {T N : Type*}
-
-/-- A position in a tree: list of child indices to follow from the root. -/
-abbrev Pos := List Nat
-
-/-- Subtree at a given position. Returns `none` if the path is invalid. -/
-def subtreeAt? : DerivationTree T N → Pos → Option (DerivationTree T N)
-  | t, [] => some t
-  | .leaf _, _ :: _ => none
-  | .node _ children, i :: rest =>
-    children[i]?.bind (·.subtreeAt? rest)
-
-/-- Replace the subtree at a given position. If the path is invalid, returns the
-    original tree unchanged. -/
-def replaceAt : DerivationTree T N → Pos → DerivationTree T N → DerivationTree T N
-  | _, [], new => new
-  | .leaf t, _ :: _, _ => .leaf t
-  | .node nt children, i :: rest, new =>
-    if h : i < children.length then
-      .node nt (children.set i (children[i].replaceAt rest new))
-    else
-      .node nt children
-
-/-- Replacing a subtree at a non-root position preserves the root symbol. -/
-theorem rootSymbol_replaceAt_cons (t : DerivationTree T N) (i : Nat) (rest : Pos)
-    (new : DerivationTree T N) :
-    (t.replaceAt (i :: rest) new).rootSymbol = t.rootSymbol := by
-  match t with
-  | .leaf _ => rfl
-  | .node _ children =>
-    by_cases hi : i < children.length
-    · simp [replaceAt, hi, rootSymbol]
-    · simp [replaceAt, hi, rootSymbol]
-
-/-- Yield decomposition: replacing a subtree at position `p` produces yield
-    `pre ++ new.yield ++ post`, where `pre`/`post` are the surrounding context. -/
-theorem yield_replaceAt_decomp (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
-    (h : t.subtreeAt? p = some sub) :
-    ∃ pre post : List T,
-      t.yield = pre ++ sub.yield ++ post ∧
-      ∀ new : DerivationTree T N, (t.replaceAt p new).yield = pre ++ new.yield ++ post := by
-  induction p generalizing t with
-  | nil =>
-    simp [subtreeAt?] at h
-    subst h
-    refine ⟨[], [], ?_, ?_⟩
-    · simp
-    · intro new; simp [replaceAt]
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?] at h
-    | .node nt children =>
-      simp only [subtreeAt?] at h
-      rcases hi : children[i]? with _ | child
-      · simp [hi] at h
-      · simp [hi] at h
-        obtain ⟨pre_inner, post_inner, hyield_inner, hreplace_inner⟩ := ih child h
-        have hi_lt : i < children.length := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.1
-        have hget : children[i] = child := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.2
-        have hsplit_orig : children = children.take i ++ child :: children.drop (i+1) := by
-          calc children
-              = children.take i ++ children.drop i := (List.take_append_drop _ _).symm
-            _ = children.take i ++ children[i] :: children.drop (i+1) := by
-                congr 1; exact List.drop_eq_getElem_cons hi_lt
-            _ = children.take i ++ child :: children.drop (i+1) := by rw [hget]
-        have hsplit_set : ∀ new : DerivationTree T N,
-            children.set i new = children.take i ++ new :: children.drop (i+1) := by
-          intro new
-          clear hsplit_orig hget hi h hyield_inner hreplace_inner ih
-          induction children generalizing i with
-          | nil => simp at hi_lt
-          | cons c cs ih_cs =>
-            cases i with
-            | zero => simp [List.set]
-            | succ k =>
-              simp only [List.length_cons] at hi_lt
-              have hk_lt : k < cs.length := by omega
-              simp [List.set, ih_cs k hk_lt]
-        refine ⟨yieldList (children.take i) ++ pre_inner,
-                post_inner ++ yieldList (children.drop (i+1)), ?_, ?_⟩
-        · show yieldList children = _
-          conv_lhs => rw [hsplit_orig]
-          rw [ContextFreeGrammar.yieldList_append]
-          show _ = (yieldList (children.take i) ++ pre_inner) ++ sub.yield ++
-              (post_inner ++ yieldList (children.drop (i+1)))
-          have hcons_eq : yieldList (child :: children.drop (i+1)) =
-              child.yield ++ yieldList (children.drop (i+1)) := by
-            simp [yieldList]
-          rw [hcons_eq, hyield_inner]
-          simp [List.append_assoc]
-        · intro new
-          have hreplace_unfolds :
-              replaceAt (.node nt children) (i :: rest) new =
-              .node nt (children.set i (child.replaceAt rest new)) := by
-            simp only [replaceAt, hi_lt, ↓reduceDIte, hget]
-          rw [hreplace_unfolds]
-          show yieldList (children.set i (child.replaceAt rest new)) = _
-          rw [hsplit_set, ContextFreeGrammar.yieldList_append]
-          show _ = (yieldList (children.take i) ++ pre_inner) ++ new.yield ++
-              (post_inner ++ yieldList (children.drop (i+1)))
-          have hcons_eq2 : yieldList (child.replaceAt rest new :: children.drop (i+1)) =
-              (child.replaceAt rest new).yield ++ yieldList (children.drop (i+1)) := by
-            simp [yieldList]
-          rw [hcons_eq2, hreplace_inner new]
-          simp [List.append_assoc]
-
-/-- Replacing a subtree of the same root symbol preserves validity. -/
-theorem validFor_replaceAt {g : ContextFreeGrammar T}
-    (t : DerivationTree T g.NT) (p : Pos) (sub new : DerivationTree T g.NT)
-    (h : t.subtreeAt? p = some sub)
-    (hroot : new.rootSymbol = sub.rootSymbol)
-    (ht_valid : t.ValidFor g) (hnew_valid : new.ValidFor g) :
-    (t.replaceAt p new).ValidFor g := by
-  induction p generalizing t with
-  | nil =>
-    simp [subtreeAt?] at h
-    subst h
-    simp [replaceAt]
-    exact hnew_valid
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?] at h
-    | .node nt children =>
-      simp only [subtreeAt?] at h
-      rcases hi : children[i]? with _ | child
-      · simp [hi] at h
-      · simp [hi] at h
-        have hi_lt : i < children.length := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.1
-        have hget : children[i] = child := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.2
-        have hreplace_unfolds :
-            replaceAt (.node nt children) (i :: rest) new =
-            .node nt (children.set i (child.replaceAt rest new)) := by
-          simp only [replaceAt, hi_lt, ↓reduceDIte, hget]
-        rw [hreplace_unfolds]
-        match ht_valid with
-        | .node _ _ hrule hchildren =>
-          have hchild_valid : child.ValidFor g := hchildren child (by
-            rw [show child = children[i] from hget.symm]
-            exact List.getElem_mem _)
-          have hchild_replace_valid : (child.replaceAt rest new).ValidFor g :=
-            ih child h hchild_valid
-          have hchild_replace_root :
-              (child.replaceAt rest new).rootSymbol = child.rootSymbol := by
-            cases rest with
-            | nil =>
-              simp [replaceAt]
-              simp [subtreeAt?] at h
-              subst h
-              exact hroot
-            | cons _ _ => exact rootSymbol_replaceAt_cons _ _ _ _
-          refine .node nt _ ?_ ?_
-          · have hmap_eq : (children.set i (child.replaceAt rest new)).map rootSymbol =
-                children.map rootSymbol := by
-              rw [List.map_set, hchild_replace_root, ← hget]
-              have h_map_lt : i < (children.map rootSymbol).length := by
-                rw [List.length_map]; exact hi_lt
-              rw [show children[i].rootSymbol = (children.map rootSymbol)[i]'h_map_lt from
-                (List.getElem_map _).symm]
-              exact List.set_getElem_self _
-            rw [hmap_eq]; exact hrule
-          · intro c hc_mem
-            rcases List.mem_or_eq_of_mem_set hc_mem with hc_orig | hc_eq
-            · exact hchildren c hc_orig
-            · subst hc_eq; exact hchild_replace_valid
-
-/-- Among a nonempty list of trees, there is one with maximum height. -/
-private theorem exists_max_height (c : DerivationTree T N) (cs : List (DerivationTree T N)) :
-    ∃ c_max ∈ (c :: cs : List (DerivationTree T N)),
-      ∀ c' ∈ (c :: cs : List (DerivationTree T N)), c'.height ≤ c_max.height := by
-  induction cs generalizing c with
-  | nil =>
-    refine ⟨c, List.mem_singleton.mpr rfl, ?_⟩
-    intro c' hc'
-    rw [List.mem_singleton.mp hc']
-  | cons d ds ih =>
-    obtain ⟨m, hm_mem, hm_max⟩ := ih c
-    by_cases hgt : d.height > m.height
-    · refine ⟨d, by simp, ?_⟩
-      intro c' hc'
-      simp only [List.mem_cons] at hc'
-      rcases hc' with hcc | hcd | hcds
-      · subst hcc
-        have := hm_max c' (List.mem_cons_self ..)
-        omega
-      · subst hcd; exact le_refl _
-      · have := hm_max c' (by simp [hcds]); omega
-    · refine ⟨m, ?_, ?_⟩
-      · simp only [List.mem_cons] at hm_mem ⊢
-        rcases hm_mem with hmc | hmds
-        · left; exact hmc
-        · right; right; exact hmds
-      · intro c' hc'
-        simp only [List.mem_cons] at hc'
-        rcases hc' with hcc | hcd | hcds
-        · subst hcc; exact hm_max c' (List.mem_cons_self ..)
-        · subst hcd; push Not at hgt; exact hgt
-        · exact hm_max c' (by simp [hcds])
-
--- ============================================================================
--- Spine extraction & pigeonhole
--- ============================================================================
-
-/-- For a max-height list, find the max-height element. -/
-private theorem exists_max_height_child (c : DerivationTree T N) (cs : List (DerivationTree T N)) :
-    ∃ c_max ∈ (c :: cs : List (DerivationTree T N)),
-      c_max.height = heightMax (c :: cs) := by
-  induction cs generalizing c with
-  | nil => exact ⟨c, by simp, by simp [heightMax]⟩
-  | cons d ds ih =>
-    obtain ⟨m, hm_mem, hm_eq⟩ := ih c
-    have hc_le_m : c.height ≤ m.height := by
-      have : heightMax (c :: ds) = max c.height (heightMax ds) := by simp [heightMax]
-      rw [this] at hm_eq; omega
-    have hds_le_m : heightMax ds ≤ m.height := by
-      have : heightMax (c :: ds) = max c.height (heightMax ds) := by simp [heightMax]
-      rw [this] at hm_eq; omega
-    by_cases hgt : d.height > m.height
-    · refine ⟨d, by simp, ?_⟩
-      have h1 : heightMax (c :: d :: ds) = max c.height (max d.height (heightMax ds)) := by
-        simp [heightMax]
-      rw [h1, max_eq_left (le_of_lt (by omega : heightMax ds < d.height)),
-          max_eq_right (by omega : c.height ≤ d.height)]
-    · push Not at hgt
-      refine ⟨m, ?_, ?_⟩
-      · simp at hm_mem ⊢
-        rcases hm_mem with hmc | hmds
-        · left; exact hmc
-        · right; right; exact hmds
-      · have h1 : heightMax (c :: d :: ds) = max c.height (max d.height (heightMax ds)) := by
-          simp [heightMax]
-        rw [h1]
-        apply le_antisymm
-        · have hm_eq' : m.height = max c.height (heightMax ds) := by
-            have : heightMax (c :: ds) = max c.height (heightMax ds) := by simp [heightMax]
-            rw [this] at hm_eq; exact hm_eq
-          rw [hm_eq']
-          exact max_le_max (le_refl _) (le_max_right _ _)
-        · exact max_le hc_le_m (max_le hgt hds_le_m)
-
-/-- For a tree of height ≥ k+1, there exists a position list of length k
-    such that the subtree at that position has height ≥ 1 (i.e., is a `.node`). -/
-theorem exists_pos_of_height (t : DerivationTree T N) (k : Nat) (h : t.height ≥ k + 1) :
-    ∃ p : Pos, p.length = k ∧ ∃ sub, t.subtreeAt? p = some sub ∧ sub.height ≥ 1 := by
-  induction k generalizing t with
-  | zero => exact ⟨[], rfl, t, rfl, h⟩
-  | succ n ih =>
-    match t with
-    | .leaf _ => simp [height] at h
-    | .node nt children =>
-      have hmax : heightMax children ≥ n + 1 := by simp [height] at h; omega
-      match hcs : children with
-      | [] => simp [heightMax] at hmax
-      | c :: cs =>
-        obtain ⟨c_max, hmem, heq⟩ := exists_max_height_child c cs
-        have hc_height : c_max.height ≥ n + 1 := by rw [heq]; exact hmax
-        rcases List.mem_iff_get.mp hmem with ⟨⟨k_idx, hk_lt⟩, hk_get⟩
-        obtain ⟨p_inner, hp_len, sub, hsub, hsub_h⟩ := ih c_max hc_height
-        refine ⟨k_idx :: p_inner, ?_, sub, ?_, hsub_h⟩
-        · simp [hp_len]
-        · simp only [subtreeAt?]
-          rw [show (c :: cs)[k_idx]? = some c_max from
-            List.getElem?_eq_some_iff.mpr ⟨hk_lt, hk_get⟩]
-          simp [hsub]
-
-/-- Stronger: extract a max-descent path of length k, with subtree at depth i
-    having height = t.height - i. -/
-theorem exists_pos_max_descent (t : DerivationTree T N) (k : Nat) (h : t.height ≥ k + 1) :
-    ∃ p : Pos, p.length = k ∧
-      ∀ i, i ≤ k → ∃ sub, t.subtreeAt? (p.take i) = some sub ∧ sub.height = t.height - i := by
-  induction k generalizing t with
-  | zero =>
-    refine ⟨[], rfl, ?_⟩
-    intro i hi
-    have : i = 0 := by omega
-    subst this
-    refine ⟨t, rfl, ?_⟩
-    simp
-  | succ n ih =>
-    match t with
-    | .leaf _ => simp [height] at h
-    | .node nt children =>
-      have hmax : heightMax children ≥ n + 1 := by simp [height] at h; omega
-      match hcs : children with
-      | [] => simp [heightMax] at hmax
-      | c :: cs =>
-        obtain ⟨c_max, hmem, heq⟩ := exists_max_height_child c cs
-        have hc_height_ge : c_max.height ≥ n + 1 := by rw [heq]; exact hmax
-        rcases List.mem_iff_get.mp hmem with ⟨⟨k_idx, hk_lt⟩, hk_get⟩
-        obtain ⟨p_inner, hp_len, hsub_at⟩ := ih c_max hc_height_ge
-        refine ⟨k_idx :: p_inner, by simp [hp_len], ?_⟩
-        intro i hi
-        subst hcs
-        cases i with
-        | zero =>
-          simp only [List.take_zero, subtreeAt?]
-          refine ⟨.node nt (c :: cs), rfl, ?_⟩
-          simp
-        | succ k' =>
-          simp only [List.take_succ_cons]
-          have hk'_le_n : k' ≤ n := by omega
-          obtain ⟨sub, hsub_at_inner, hsub_h⟩ := hsub_at k' hk'_le_n
-          refine ⟨sub, ?_, ?_⟩
-          · simp only [subtreeAt?]
-            rw [show (c :: cs)[k_idx]? = some c_max from
-              List.getElem?_eq_some_iff.mpr ⟨hk_lt, hk_get⟩]
-            simpa using hsub_at_inner
-          · rw [hsub_h, heq]
-            simp [height]
-            omega
-
-/-- subtreeAt? splits along path concatenation. -/
-theorem subtreeAt?_append (t : DerivationTree T N) (p1 p2 : Pos) :
-    t.subtreeAt? (p1 ++ p2) = (t.subtreeAt? p1).bind (·.subtreeAt? p2) := by
-  induction p1 generalizing t with
-  | nil => simp [subtreeAt?]
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?]
-    | .node _ children =>
-      simp only [List.cons_append, subtreeAt?]
-      rcases hi : children[i]? with _ | child
-      · simp
-      · simp [ih]
-
-/-- Relabelling commutes with subtree access. -/
-theorem subtreeAt?_map {N' : Type*} (f : N → N') (t : DerivationTree T N) (p : Pos) :
-    (map f t).subtreeAt? p = (t.subtreeAt? p).map (map f) := by
-  induction p generalizing t with
-  | nil => simp [subtreeAt?]
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?]
-    | .node nt children =>
-      simp only [map_node, subtreeAt?, mapList_eq_map, List.getElem?_map]
-      rcases children[i]? with _ | child
-      · simp
-      · simp [ih]
-
-/-- For a valid tree and a path that descends, each prefix subtree is a `.node`. -/
-theorem spine_node_at_prefix (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
-    (hsub : t.subtreeAt? p = some sub) (hsub_h : sub.height ≥ 1)
-    (k : Nat) (hk : k < p.length + 1) :
-    ∃ nt children, t.subtreeAt? (p.take k) = some (.node nt children) := by
-  induction p generalizing t k with
-  | nil =>
-    simp at hk; subst hk
-    simp [subtreeAt?] at hsub
-    subst hsub
-    match t, hsub_h with
-    | .node nt children, _ => exact ⟨nt, children, rfl⟩
-  | cons i rest ih =>
-    cases k with
-    | zero =>
-      simp [subtreeAt?]
-      match t with
-      | .leaf _ => simp [subtreeAt?] at hsub
-      | .node nt children => exact ⟨nt, children, rfl⟩
-    | succ k' =>
-      simp only [List.take_succ_cons]
-      simp only [List.length_cons] at hk
-      have hk' : k' < rest.length + 1 := by omega
-      match t with
-      | .leaf _ => simp [subtreeAt?] at hsub
-      | .node nt children =>
-        simp only [subtreeAt?] at hsub ⊢
-        rcases hi : children[i]? with _ | child
-        · simp [hi] at hsub
-        · simp [hi] at hsub
-          exact ih child hsub k' hk'
-
-/-- Validity propagates through subtreeAt?. -/
-theorem subtreeAt?_validFor {g : ContextFreeGrammar T} (t : DerivationTree T g.NT)
-    (ht : t.ValidFor g) (p : Pos) (sub : DerivationTree T g.NT)
-    (hsub : t.subtreeAt? p = some sub) : sub.ValidFor g := by
-  induction p generalizing t with
-  | nil => simp [subtreeAt?] at hsub; subst hsub; exact ht
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?] at hsub
-    | .node nt children =>
-      simp only [subtreeAt?] at hsub
-      rcases hi : children[i]? with _ | child
-      · simp [hi] at hsub
-      · simp [hi] at hsub
-        match ht with
-        | .node _ _ _ hchildren =>
-          have hi_lt : i < children.length := by
-            rw [List.getElem?_eq_some_iff] at hi; exact hi.1
-          have hchild_in : child ∈ children := by
-            rw [show child = children[i] from by
-              rw [List.getElem?_eq_some_iff] at hi; exact hi.2.symm]
-            exact List.getElem_mem _
-          exact ih child (hchildren child hchild_in) hsub
-
-/-- Extract the rule used at a position (option-valued). -/
-def ruleAt? {g : ContextFreeGrammar T} (t : DerivationTree T g.NT) (p : Pos) :
-    Option (ContextFreeRule T g.NT) :=
-  match t.subtreeAt? p with
-  | some (.node nt children) => some ⟨nt, children.map rootSymbol⟩
-  | _ => none
-
-/-- For a valid tree at a `.node` subtree, ruleAt? returns the matching rule in g.rules. -/
-theorem ruleAt?_mem_rules {g : ContextFreeGrammar T} (t : DerivationTree T g.NT)
-    (ht : t.ValidFor g) (p : Pos) (nt : g.NT) (children : List (DerivationTree T g.NT))
-    (hsub : t.subtreeAt? p = some (.node nt children)) :
-    ruleAt? t p = some ⟨nt, children.map rootSymbol⟩ ∧
-    ⟨nt, children.map rootSymbol⟩ ∈ g.rules := by
-  refine ⟨?_, ?_⟩
-  · simp [ruleAt?, hsub]
-  · have hsub_valid : (DerivationTree.node nt children).ValidFor g :=
-      subtreeAt?_validFor t ht p (.node nt children) hsub
-    match hsub_valid with
-    | .node _ _ hrule _ => exact hrule
-
--- ============================================================================
--- Tree size measure (for minimality argument)
--- ============================================================================
-
-mutual
-def size : DerivationTree T N → Nat
-  | .leaf _ => 1
-  | .node _ children => 1 + sizeList children
-
-def sizeList : List (DerivationTree T N) → Nat
-  | [] => 0
-  | t :: ts => t.size + sizeList ts
-end
-
-theorem size_pos (t : DerivationTree T N) : t.size ≥ 1 := by
-  match t with
-  | .leaf _ => simp [size]
-  | .node _ _ => simp [size]
-
-theorem sizeList_le_of_mem {t : DerivationTree T N} {ts : List (DerivationTree T N)} (h : t ∈ ts) :
-    t.size ≤ sizeList ts := by
-  induction ts with
-  | nil => simp at h
-  | cons s ss ih =>
-    simp only [sizeList]
-    rcases List.mem_cons.mp h with rfl | h
-    · omega
-    · have := ih h; omega
-
-theorem size_subtreeAt?_le (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
-    (h : t.subtreeAt? p = some sub) : sub.size ≤ t.size := by
-  induction p generalizing t with
-  | nil =>
-    have hsub : sub = t := (by simpa [subtreeAt?] using h : t = sub).symm
-    rw [hsub]
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?] at h
-    | .node _ children =>
-      simp only [subtreeAt?] at h
-      rcases hi : children[i]? with _ | child
-      · simp [hi] at h
-      · simp [hi] at h
-        have hi_lt := (List.getElem?_eq_some_iff.mp hi).1
-        have hget := (List.getElem?_eq_some_iff.mp hi).2
-        have := ih child h
-        have := sizeList_le_of_mem (hget ▸ List.getElem_mem hi_lt)
-        simp [size]; omega
-
-theorem size_subtreeAt?_lt_of_cons (t : DerivationTree T N) (i : Nat) (rest : Pos)
-    (sub : DerivationTree T N) (h : t.subtreeAt? (i :: rest) = some sub) :
-    sub.size < t.size := by
-  match t with
-  | .leaf _ => simp [subtreeAt?] at h
-  | .node _ children =>
-    simp only [subtreeAt?] at h
-    rcases hi : children[i]? with _ | child
-    · simp [hi] at h
-    · simp [hi] at h
-      have hi_lt := (List.getElem?_eq_some_iff.mp hi).1
-      have hget := (List.getElem?_eq_some_iff.mp hi).2
-      have := size_subtreeAt?_le child rest sub h
-      have := sizeList_le_of_mem (hget ▸ List.getElem_mem hi_lt)
-      simp [size]; omega
-
-theorem sizeList_set (l : List (DerivationTree T N)) (i : Nat) (x : DerivationTree T N) (hi : i < l.length) :
-    sizeList (l.set i x) + l[i].size = sizeList l + x.size := by
-  induction l generalizing i with
-  | nil => simp at hi
-  | cons h t ih =>
-    cases i with
-    | zero => simp [List.set, sizeList]; omega
-    | succ k =>
-      simp only [List.length_cons] at hi
-      have hk_lt : k < t.length := by omega
-      simp only [List.set, sizeList, List.getElem_cons_succ]
-      have := ih k hk_lt
-      omega
-
-/-- Replacing a subtree with a strictly smaller one gives a strictly smaller tree. -/
-theorem size_replaceAt_lt (t : DerivationTree T N) (p : Pos) (sub new : DerivationTree T N)
-    (h : t.subtreeAt? p = some sub) (hlt : new.size < sub.size) :
-    (t.replaceAt p new).size < t.size := by
-  induction p generalizing t with
-  | nil =>
-    simp [subtreeAt?] at h; subst h; simp [replaceAt]; exact hlt
-  | cons i rest ih =>
-    match t with
-    | .leaf _ => simp [subtreeAt?] at h
-    | .node nt children =>
-      simp only [subtreeAt?] at h
-      rcases hi : children[i]? with _ | child
-      · simp [hi] at h
-      · simp [hi] at h
-        have hi_lt : i < children.length := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.1
-        have hget : children[i] = child := by
-          rw [List.getElem?_eq_some_iff] at hi; exact hi.2
-        have hreplace_unfolds :
-            replaceAt (.node nt children) (i :: rest) new =
-            .node nt (children.set i (child.replaceAt rest new)) := by
-          simp only [replaceAt, hi_lt, ↓reduceDIte, hget]
-        rw [hreplace_unfolds]
-        simp only [size]
-        have hchild_lt : (child.replaceAt rest new).size < child.size := ih child h
-        have hset := sizeList_set children i (child.replaceAt rest new) hi_lt
-        rw [hget] at hset
-        omega
-
-/-- Existence of minimum-size valid tree with given yield and root. -/
-theorem exists_min_size_tree {g : ContextFreeGrammar T} (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
-    ∃ t_min : DerivationTree T g.NT,
-      t_min.ValidFor g ∧
-      t_min.yield = t.yield ∧
-      t_min.rootSymbol = t.rootSymbol ∧
-      ∀ t' : DerivationTree T g.NT,
-        t'.ValidFor g → t'.yield = t.yield →
-        t'.rootSymbol = t.rootSymbol →
-        t_min.size ≤ t'.size := by
-  classical
-  let P : Nat → Prop := fun n => ∃ t' : DerivationTree T g.NT,
-    t'.ValidFor g ∧ t'.yield = t.yield ∧ t'.rootSymbol = t.rootSymbol ∧ t'.size = n
-  have hP_ne : ∃ n, P n := ⟨t.size, t, ht, rfl, rfl, rfl⟩
-  obtain ⟨t_min, ht_min_v, ht_min_y, ht_min_r, ht_min_s⟩ := Nat.find_spec hP_ne
-  refine ⟨t_min, ht_min_v, ht_min_y, ht_min_r, ?_⟩
-  intro t' ht'_v ht'_y ht'_r
-  have hP_t' : P t'.size := ⟨t', ht'_v, ht'_y, ht'_r, rfl⟩
-  have hle : Nat.find hP_ne ≤ t'.size := Nat.find_le hP_t'
-  omega
-
-/-- Pigeonhole: along a long-enough valid path, two prefixes have same root nonterminal. -/
-theorem exists_repeat_root {g : ContextFreeGrammar T}
-    (t : DerivationTree T g.NT) (ht : t.ValidFor g)
-    (p : Pos) (sub : DerivationTree T g.NT)
-    (hsub : t.subtreeAt? p = some sub) (hsub_h : sub.height ≥ 1)
-    (hlen : p.length ≥ g.rules.card) :
-    ∃ i j : Nat, i < j ∧ j ≤ p.length ∧
-      ∃ ntᵢ children_i ntⱼ children_j,
-        t.subtreeAt? (p.take i) = some (.node ntᵢ children_i) ∧
-        t.subtreeAt? (p.take j) = some (.node ntⱼ children_j) ∧
-        ntᵢ = ntⱼ := by
-  classical
-  let f : Nat → ContextFreeRule T g.NT := fun k =>
-    (ruleAt? t (p.take k)).getD ⟨g.initial, []⟩
-  have hf_in : ∀ k ∈ Finset.range (p.length + 1), f k ∈ g.rules := by
-    intro k hk
-    simp at hk
-    obtain ⟨nt, children, hsub_k⟩ := spine_node_at_prefix t p sub hsub hsub_h k hk
-    obtain ⟨hrule_eq, hrule_in⟩ := ruleAt?_mem_rules t ht (p.take k) nt children hsub_k
-    show f k ∈ g.rules
-    simp only [f, hrule_eq, Option.getD_some]
-    exact hrule_in
-  have hcard : g.rules.card < (Finset.range (p.length + 1)).card := by
-    simp [Finset.card_range]; omega
-  obtain ⟨a, ha, b, hb, hne, hfeq⟩ :=
-    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hcard hf_in
-  simp at ha hb
-  rcases Nat.lt_or_ge a b with hab | hab
-  · obtain ⟨nt_a, children_a, hsub_a⟩ := spine_node_at_prefix t p sub hsub hsub_h a ha
-    obtain ⟨nt_b, children_b, hsub_b⟩ := spine_node_at_prefix t p sub hsub hsub_h b hb
-    obtain ⟨hrule_a, _⟩ := ruleAt?_mem_rules t ht (p.take a) nt_a children_a hsub_a
-    obtain ⟨hrule_b, _⟩ := ruleAt?_mem_rules t ht (p.take b) nt_b children_b hsub_b
-    have h_fa : f a = ⟨nt_a, children_a.map rootSymbol⟩ := by
-      simp only [f, hrule_a, Option.getD_some]
-    have h_fb : f b = ⟨nt_b, children_b.map rootSymbol⟩ := by
-      simp only [f, hrule_b, Option.getD_some]
-    have : nt_a = nt_b := by
-      have : (⟨nt_a, children_a.map rootSymbol⟩ : ContextFreeRule T g.NT) =
-          ⟨nt_b, children_b.map rootSymbol⟩ := by rw [← h_fa, ← h_fb, hfeq]
-      exact ContextFreeRule.mk.injEq _ _ _ _ |>.mp this |>.1
-    exact ⟨a, b, hab, by omega, nt_a, children_a, nt_b, children_b, hsub_a, hsub_b, this⟩
-  · have hba : b < a := lt_of_le_of_ne hab (Ne.symm hne)
-    obtain ⟨nt_a, children_a, hsub_a⟩ := spine_node_at_prefix t p sub hsub hsub_h a ha
-    obtain ⟨nt_b, children_b, hsub_b⟩ := spine_node_at_prefix t p sub hsub hsub_h b hb
-    obtain ⟨hrule_a, _⟩ := ruleAt?_mem_rules t ht (p.take a) nt_a children_a hsub_a
-    obtain ⟨hrule_b, _⟩ := ruleAt?_mem_rules t ht (p.take b) nt_b children_b hsub_b
-    have h_fa : f a = ⟨nt_a, children_a.map rootSymbol⟩ := by
-      simp only [f, hrule_a, Option.getD_some]
-    have h_fb : f b = ⟨nt_b, children_b.map rootSymbol⟩ := by
-      simp only [f, hrule_b, Option.getD_some]
-    have : nt_b = nt_a := by
-      have : (⟨nt_b, children_b.map rootSymbol⟩ : ContextFreeRule T g.NT) =
-          ⟨nt_a, children_a.map rootSymbol⟩ := by rw [← h_fa, ← h_fb, hfeq]
-      exact ContextFreeRule.mk.injEq _ _ _ _ |>.mp this |>.1
-    exact ⟨b, a, hba, by omega, nt_b, children_b, nt_a, children_a, hsub_b, hsub_a, this⟩
-
--- ============================================================================
--- Soundness: valid tree ⇒ grammar derives its yield
--- ============================================================================
-
-private theorem derives_yieldList {T : Type*} {g : ContextFreeGrammar T}
-    (ts : List (DerivationTree T g.NT))
-    (hvalid : ∀ t ∈ ts, g.Derives [t.rootSymbol] (t.yield.map Symbol.terminal)) :
-    g.Derives (ts.map DerivationTree.rootSymbol) ((DerivationTree.yieldList ts).map Symbol.terminal) := by
-  induction ts with
-  | nil => exact Relation.ReflTransGen.refl
-  | cons c cs ih =>
-    simp only [List.map_cons, DerivationTree.yieldList, List.map_append]
-    show g.Derives ([c.rootSymbol] ++ cs.map DerivationTree.rootSymbol)
-      (c.yield.map Symbol.terminal ++ (DerivationTree.yieldList cs).map Symbol.terminal)
-    exact ((hvalid c (List.mem_cons_self ..)).append_right _).trans
-      ((ih (fun t ht => hvalid t (List.mem_cons_of_mem _ ht))).append_left _)
-
-theorem validFor_derives {T : Type*} {g : ContextFreeGrammar T}
-    (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
-    g.Derives [t.rootSymbol] (t.yield.map Symbol.terminal) := by
-  match t, ht with
-  | .leaf _, _ => exact Relation.ReflTransGen.refl
-  | .node nt children, .node _ _ hrule hchildren =>
-    exact (ContextFreeGrammar.Produces.single
-      ⟨⟨nt, children.map DerivationTree.rootSymbol⟩, hrule,
-       ContextFreeRule.Rewrites.input_output⟩).trans
-      (derives_yieldList children (fun c hc => validFor_derives c (hchildren c hc)))
-termination_by t
-
-end DerivationTree
-
-/-! ### Rose-tree interface instances
-
-`DerivationTree.Pos` is the Gorn address — exactly
-`Core.Order.TreePath.toList` — so the generic
-`Core.Order.Branching.subtreeAt` walks the same positions as
-`subtreeAt?`. The structural `size`/`height`/`yield` above remain the
-kernel-computable specializations of the generic API. -/
-
-namespace DerivationTree
-
-variable {T N : Type*}
-
-instance : Core.Order.Branching (DerivationTree T N) where
-  children
-    | .leaf _ => []
-    | .node _ cs => cs
-
-@[simp] theorem branching_children_leaf (t : T) :
-    Core.Order.Branching.children (DerivationTree.leaf (N := N) t) = [] := rfl
-
-@[simp] theorem branching_children_node (nt : N) (cs : List (DerivationTree T N)) :
-    Core.Order.Branching.children (DerivationTree.node nt cs) = cs := rfl
-
-instance : Core.Order.IsFiniteBranching (DerivationTree T N) :=
-  .ofMeasure sizeOf fun {c t} hc => by
-    cases t with
-    | leaf _ => simp at hc
-    | node nt cs =>
-      simp only [branching_children_node] at hc
-      have := List.sizeOf_lt_of_mem hc
-      simp only [DerivationTree.node.sizeOf_spec]
-      omega
-
-/-! ### Countability -/
-
-instance _root_.Symbol.instCountable [Countable T] [Countable N] : Countable (Symbol T N) :=
+instance Symbol.instCountable {T N : Type*} [Countable T] [Countable N] : Countable (Symbol T N) :=
   Function.Injective.countable (f := fun s : Symbol T N => match s with
     | .terminal t => Sum.inl t
     | .nonterminal n => Sum.inr n) fun s s' h => by
     cases s <;> cases s' <;> simp_all
 
-/-- Branching signature of the W-type encoding: leaves and the empty list have no children, a
-node has one child (its list of children), a cons cell has two. -/
-private def wArity : Option (T ⊕ (N ⊕ Unit)) → Type
-  | some (.inl _) => Empty
-  | some (.inr (.inl _)) => Unit
-  | none => Empty
-  | some (.inr (.inr _)) => Bool
+namespace RoseTree
 
-mutual
-private def toW : DerivationTree T N → WType (wArity (T := T) (N := N))
-  | .leaf t => ⟨some (.inl t), Empty.elim⟩
-  | .node n cs => ⟨some (.inr (.inl n)), fun _ => toWList cs⟩
-private def toWList : List (DerivationTree T N) → WType (wArity (T := T) (N := N))
-  | [] => ⟨none, Empty.elim⟩
-  | c :: cs => ⟨some (.inr (.inr ())), fun b => bif b then toW c else toWList cs⟩
-end
+variable {T N : Type*}
 
-mutual
-private theorem toW_injective : ∀ {t t' : DerivationTree T N}, toW t = toW t' → t = t'
-  | .leaf _, .leaf _, h => by
-    obtain ⟨h1, -⟩ := WType.mk.inj h
-    cases h1; rfl
-  | .leaf _, .node _ _, h => by exact absurd (WType.mk.inj h).1 (by simp)
-  | .node _ _, .leaf _, h => by exact absurd (WType.mk.inj h).1 (by simp)
-  | .node n cs, .node n' cs', h => by
-    obtain ⟨h1, h2⟩ := WType.mk.inj h
-    cases h1
-    rw [toWList_injective (congr_fun (eq_of_heq h2) ())]
-private theorem toWList_injective :
-    ∀ {cs cs' : List (DerivationTree T N)}, toWList cs = toWList cs' → cs = cs'
-  | [], [], _ => rfl
-  | [], _ :: _, h => by exact absurd (WType.mk.inj h).1 (by simp)
-  | _ :: _, [], h => by exact absurd (WType.mk.inj h).1 (by simp)
-  | c :: cs, c' :: cs', h => by
-    obtain ⟨-, h2⟩ := WType.mk.inj h
-    have h3 := congr_fun (eq_of_heq h2)
-    rw [toW_injective (t := c) (t' := c') (by simpa using h3 true),
-      toWList_injective (cs := cs) (cs' := cs') (by simpa using h3 false)]
-end
+/-! ### The yield -/
 
-instance [Countable T] [Countable N] : Countable (DerivationTree T N) := by
+/-- The terminal frontier of a tree: the terminals among its leaves, left to right. -/
+def yield (t : RoseTree (Symbol T N)) : List T := t.leafList.filterMap Symbol.terminal?
+
+@[simp] theorem yield_node_nil (s : Symbol T N) : yield (node s []) = s.terminal?.toList := by
+  cases s <;> simp [yield]
+
+@[simp] theorem yield_leaf (s : Symbol T N) : yield (leaf s) = s.terminal?.toList :=
+  yield_node_nil s
+
+theorem yield_node_of_ne_nil (s : Symbol T N) {cs : List (RoseTree (Symbol T N))} (h : cs ≠ []) :
+    yield (node s cs) = (cs.map yield).flatten := by
+  rw [yield, leafList_node_of_ne_nil _ h, List.filterMap_flatten, List.map_map]
+  rfl
+
+@[simp] theorem yield_node_cons (s : Symbol T N) (c : RoseTree (Symbol T N))
+    (cs : List (RoseTree (Symbol T N))) :
+    yield (node s (c :: cs)) = ((c :: cs).map yield).flatten :=
+  yield_node_of_ne_nil s (List.cons_ne_nil c cs)
+
+@[simp] theorem yield_node_nonterminal (A : N) (cs : List (RoseTree (Symbol T N))) :
+    yield (node (.nonterminal A) cs) = (cs.map yield).flatten := by
+  cases cs with
+  | nil => simp
+  | cons c cs => exact yield_node_cons _ c cs
+
+@[simp] theorem yield_map {N' : Type*} (f : N → N') (t : RoseTree (Symbol T N)) :
+    (t.map (Symbol.mapNonterminal f)).yield = t.yield := by
+  simp only [yield, leafList_map, List.filterMap_map, Function.comp_def,
+    Symbol.terminal?_mapNonterminal]
+
+/-- Replacing inside the tree splits the yield into the terminals left of the address, the yield
+of the subtree there, and the terminals to its right. -/
+theorem yield_replaceAt {t s : RoseTree (Symbol T N)} {p : List ℕ} (h : t.subtreeAt p = some s) :
+    ∃ pre post : List T, t.yield = pre ++ s.yield ++ post ∧
+      ∀ new : RoseTree (Symbol T N), (t.replaceAt p new).yield = pre ++ new.yield ++ post := by
+  obtain ⟨pre, post, hy, hy'⟩ := leafList_replaceAt h
+  exact ⟨pre.filterMap Symbol.terminal?, post.filterMap Symbol.terminal?,
+    by simp [yield, hy, List.filterMap_append],
+    fun new => by simp [yield, hy', List.filterMap_append]⟩
+
+/-! ### Validity -/
+
+/-- A derivation tree is valid for a grammar when every terminal node is a leaf and every
+nonterminal node, with the symbols of its children, is a rule of the grammar. -/
+inductive ValidFor (g : ContextFreeGrammar T) : RoseTree (Symbol T g.NT) → Prop
+  | terminal (a : T) : ValidFor g (leaf (.terminal a))
+  | nonterminal (A : g.NT) (cs : List (RoseTree (Symbol T g.NT)))
+      (hrule : ⟨A, cs.map value⟩ ∈ g.rules) (hcs : ∀ c ∈ cs, ValidFor g c) :
+      ValidFor g (node (.nonterminal A) cs)
+
+namespace ValidFor
+
+variable {g : ContextFreeGrammar T}
+
+theorem of_mem {s : Symbol T g.NT} {cs : List (RoseTree (Symbol T g.NT))}
+    (h : ValidFor g (node s cs)) {c : RoseTree (Symbol T g.NT)} (hc : c ∈ cs) : ValidFor g c := by
+  cases h with
+  | terminal => simp at hc
+  | nonterminal _ _ _ hcs => exact hcs c hc
+
+theorem rule_mem {A : g.NT} {cs : List (RoseTree (Symbol T g.NT))}
+    (h : ValidFor g (node (.nonterminal A) cs)) : ⟨A, cs.map value⟩ ∈ g.rules := by
+  cases h with
+  | nonterminal _ _ hrule => exact hrule
+
+theorem eq_nil_of_terminal {a : T} {cs : List (RoseTree (Symbol T g.NT))}
+    (h : ValidFor g (node (.terminal a) cs)) : cs = [] := by
+  cases h; rfl
+
+/-- A node with children is a nonterminal node. -/
+theorem exists_nonterminal_of_ne_nil {s : Symbol T g.NT} {cs : List (RoseTree (Symbol T g.NT))}
+    (h : ValidFor g (node s cs)) (hcs : cs ≠ []) : ∃ A, s = .nonterminal A := by
+  cases h with
+  | terminal => exact absurd rfl hcs
+  | nonterminal A => exact ⟨A, rfl⟩
+
+theorem subtreeAt {t : RoseTree (Symbol T g.NT)} (ht : ValidFor g t) {p : List ℕ}
+    {s : RoseTree (Symbol T g.NT)} (hs : t.subtreeAt p = some s) : ValidFor g s := by
+  induction p generalizing t with
+  | nil => exact Option.some.inj hs ▸ ht
+  | cons i p ih =>
+    obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp hs
+    cases t with
+    | node s cs => exact ih (ht.of_mem (List.mem_of_getElem? hc)) hcs
+
+/-- Replacing a subtree by a valid tree with the same root symbol preserves validity. -/
+theorem replaceAt {t : RoseTree (Symbol T g.NT)} (ht : ValidFor g t) {p : List ℕ}
+    {s : RoseTree (Symbol T g.NT)} (hs : t.subtreeAt p = some s)
+    {new : RoseTree (Symbol T g.NT)} (hnew : ValidFor g new) (hv : new.value = s.value) :
+    ValidFor g (t.replaceAt p new) := by
+  induction p generalizing t with
+  | nil => rw [replaceAt_nil]; exact hnew
+  | cons i p ih =>
+    obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp hs
+    cases t with
+    | node s₀ cs =>
+      rw [children_node] at hc
+      rw [replaceAt_cons_of_getElem? (by simpa using hc), value_node, children_node]
+      have hval : (c.replaceAt p new).value = c.value := by
+        cases p with
+        | nil => rw [replaceAt_nil, hv, Option.some.inj hcs]
+        | cons j p => exact value_replaceAt_cons c j p new
+      obtain ⟨A, rfl⟩ := ht.exists_nonterminal_of_ne_nil
+        (List.ne_nil_of_mem (List.mem_of_getElem? hc))
+      refine nonterminal A _ ?_ fun d hd => ?_
+      · obtain ⟨hi, rfl⟩ := List.getElem?_eq_some_iff.mp hc
+        have h := List.set_getElem_self (as := cs.map value) (i := i) (by simpa using hi)
+        rw [List.getElem_map] at h
+        rw [List.map_set, hval, h]
+        exact ht.rule_mem
+      · rcases List.mem_or_eq_of_mem_set hd with hd | rfl
+        · exact ht.of_mem hd
+        · exact ih (ht.of_mem (List.mem_of_getElem? hc)) hcs
+
+end ValidFor
+
+/-! ### Rule counts -/
+
+section RuleCount
+
+variable [DecidableEq T] [DecidableEq N]
+
+/-- The number of applications of the rule `r` in a tree: the nonterminal nodes whose symbol and
+children's symbols spell out `r`. -/
+def ruleCount (r : ContextFreeRule T N) (t : RoseTree (Symbol T N)) : ℕ :=
+  t.offspring.count (.nonterminal r.input, r.output)
+
+theorem ruleCount_node_nonterminal (r : ContextFreeRule T N) (A : N)
+    (cs : List (RoseTree (Symbol T N))) :
+    ruleCount r (node (.nonterminal A) cs) =
+      (if r = ⟨A, cs.map value⟩ then 1 else 0) + (cs.map (ruleCount r)).sum := by
+  simp only [ruleCount, offspring_node, List.count_cons, List.count_flatten, List.map_map,
+    Function.comp_def, beq_iff_eq, Prod.mk.injEq, Symbol.nonterminal.injEq]
+  rw [add_comm]
+  congr 1
+  cases r
+  simp [ContextFreeRule.mk.injEq, eq_comm]
+
+theorem ruleCount_node_terminal (r : ContextFreeRule T N) (a : T)
+    (cs : List (RoseTree (Symbol T N))) :
+    ruleCount r (node (.terminal a) cs) = (cs.map (ruleCount r)).sum := by
+  simp only [ruleCount, offspring_node, List.count_cons, List.count_flatten, List.map_map,
+    Function.comp_def, beq_iff_eq, Prod.mk.injEq, reduceCtorEq, false_and, if_false, add_zero]
+  rfl
+
+/-- The number of applications of the rule `r` in a corpus of trees. -/
+def corpusRuleCount (r : ContextFreeRule T N) (D : Multiset (RoseTree (Symbol T N))) : ℕ :=
+  (D.map (ruleCount r)).sum
+
+@[simp] theorem corpusRuleCount_zero (r : ContextFreeRule T N) :
+    corpusRuleCount r (0 : Multiset (RoseTree (Symbol T N))) = 0 := by
+  simp [corpusRuleCount]
+
+@[simp] theorem corpusRuleCount_singleton (r : ContextFreeRule T N) (t : RoseTree (Symbol T N)) :
+    corpusRuleCount r {t} = ruleCount r t := by
+  simp [corpusRuleCount]
+
+theorem corpusRuleCount_add (r : ContextFreeRule T N) (D₁ D₂ : Multiset (RoseTree (Symbol T N))) :
+    corpusRuleCount r (D₁ + D₂) = corpusRuleCount r D₁ + corpusRuleCount r D₂ := by
+  simp [corpusRuleCount]
+
+end RuleCount
+
+/-! ### The rule at an address -/
+
+/-- The rule applied at a Gorn address: the nonterminal there with the symbols of its children,
+`none` off the tree or at a terminal. -/
+def ruleAt? {g : ContextFreeGrammar T} (t : RoseTree (Symbol T g.NT)) (p : List ℕ) :
+    Option (ContextFreeRule T g.NT) :=
+  (t.subtreeAt p).bind fun s => match s.value with
+    | .nonterminal A => some ⟨A, s.children.map value⟩
+    | .terminal _ => none
+
+theorem ruleAt?_eq_some {g : ContextFreeGrammar T} {t : RoseTree (Symbol T g.NT)} {p : List ℕ}
+    {A : g.NT} {cs : List (RoseTree (Symbol T g.NT))}
+    (h : t.subtreeAt p = some (node (.nonterminal A) cs)) :
+    ruleAt? t p = some ⟨A, cs.map value⟩ := by
+  simp [ruleAt?, h]
+
+/-- Along an address into a valid tree, every proper prefix ends at a nonterminal node, and so
+does the address itself when the subtree there has children. -/
+theorem ValidFor.exists_subtreeAt_take {g : ContextFreeGrammar T} {t : RoseTree (Symbol T g.NT)}
+    (ht : ValidFor g t) {p : List ℕ} {s : RoseTree (Symbol T g.NT)} (hs : t.subtreeAt p = some s)
+    (hh : 0 < s.height) {k : ℕ} (hk : k ≤ p.length) :
+    ∃ A cs, t.subtreeAt (p.take k) = some (node (.nonterminal A) cs) := by
+  obtain ⟨u, hu⟩ := Option.isSome_iff_exists.mp (subtreeAt_take_isSome hs k)
+  obtain ⟨s₀, cs, rfl⟩ : ∃ s₀ cs, u = node s₀ cs := by cases u; exact ⟨_, _, rfl⟩
+  have hne : cs ≠ [] := by
+    rcases Nat.lt_or_ge k p.length with hlt | hge
+    · rw [← List.take_append_drop k p, subtreeAt_append, hu, Option.bind_some,
+        List.drop_eq_getElem_cons hlt] at hs
+      obtain ⟨c, hc, -⟩ := subtreeAt_cons_eq_some_iff.mp hs
+      exact List.ne_nil_of_mem (List.mem_of_getElem? hc)
+    · rw [List.take_of_length_le (le_antisymm hk hge ▸ le_rfl), hs] at hu
+      obtain rfl := Option.some.inj hu
+      obtain ⟨c, hc, -⟩ := exists_mem_children_height_add_one hh
+      exact List.ne_nil_of_mem hc
+  obtain ⟨A, rfl⟩ := (ht.subtreeAt hu).exists_nonterminal_of_ne_nil hne
+  exact ⟨A, cs, hu⟩
+
+/-- Pigeonhole along an address: a path of at least `g.rules.card` steps through a valid tree,
+ending at a node with children, passes two nodes with the same nonterminal. -/
+theorem ValidFor.exists_repeat {g : ContextFreeGrammar T} {t : RoseTree (Symbol T g.NT)}
+    (ht : ValidFor g t) {p : List ℕ} {s : RoseTree (Symbol T g.NT)} (hs : t.subtreeAt p = some s)
+    (hh : 0 < s.height) (hlen : g.rules.card ≤ p.length) :
+    ∃ i j, i < j ∧ j ≤ p.length ∧ ∃ A csᵢ csⱼ,
+      t.subtreeAt (p.take i) = some (node (.nonterminal A) csᵢ) ∧
+      t.subtreeAt (p.take j) = some (node (.nonterminal A) csⱼ) := by
   classical
-  let _ := Encodable.ofCountable T
-  let _ := Encodable.ofCountable N
-  have _ : ∀ a, Fintype (wArity (T := T) (N := N) a) := fun a => by
-    rcases a with _ | (_ | (_ | _))
-    · exact inferInstanceAs (Fintype Empty)
-    · exact inferInstanceAs (Fintype Empty)
-    · exact inferInstanceAs (Fintype Unit)
-    · exact inferInstanceAs (Fintype Bool)
-  have _ : ∀ a, Encodable (wArity (T := T) (N := N) a) := fun a => by
-    rcases a with _ | (_ | (_ | _))
-    · exact inferInstanceAs (Encodable Empty)
-    · exact inferInstanceAs (Encodable Empty)
-    · exact inferInstanceAs (Encodable Unit)
-    · exact inferInstanceAs (Encodable Bool)
-  exact Function.Injective.countable fun _ _ h => toW_injective h
+  let f : ℕ → ContextFreeRule T g.NT := fun k => (ruleAt? t (p.take k)).getD ⟨g.initial, []⟩
+  have hf : ∀ k ∈ Finset.range (p.length + 1), f k ∈ g.rules := fun k hk => by
+    obtain ⟨A, cs, hA⟩ :=
+      ht.exists_subtreeAt_take hs hh (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk))
+    simp only [f, ruleAt?_eq_some hA, Option.getD_some]
+    exact (ht.subtreeAt hA).rule_mem
+  obtain ⟨a, ha, b, hb, hne, hfeq⟩ := Finset.exists_ne_map_eq_of_card_lt_of_maps_to
+    (by simp only [Finset.card_range]; omega) hf
+  wlog hab : a < b generalizing a b
+  · exact this b hb a ha hne.symm hfeq.symm (lt_of_le_of_ne (not_lt.mp hab) hne.symm)
+  rw [Finset.mem_range] at ha hb
+  obtain ⟨A, csₐ, hA⟩ := ht.exists_subtreeAt_take hs hh (Nat.lt_succ_iff.mp ha)
+  obtain ⟨B, cs_b, hB⟩ := ht.exists_subtreeAt_take hs hh (Nat.lt_succ_iff.mp hb)
+  have : A = B := by
+    have h := hfeq
+    simp only [f, ruleAt?_eq_some hA, ruleAt?_eq_some hB, Option.getD_some,
+      ContextFreeRule.mk.injEq] at h
+    exact h.1
+  subst this
+  exact ⟨a, b, hab, Nat.lt_succ_iff.mp hb, A, csₐ, cs_b, hA, hB⟩
 
-end DerivationTree
+/-- Among the valid trees with a given yield and root symbol there is one of least size. -/
+theorem ValidFor.exists_min_numNodes {g : ContextFreeGrammar T} {t : RoseTree (Symbol T g.NT)}
+    (ht : ValidFor g t) :
+    ∃ t' : RoseTree (Symbol T g.NT), ValidFor g t' ∧ t'.yield = t.yield ∧ t'.value = t.value ∧
+      ∀ t'' : RoseTree (Symbol T g.NT), ValidFor g t'' → t''.yield = t.yield →
+        t''.value = t.value → t'.numNodes ≤ t''.numNodes := by
+  classical
+  let P : ℕ → Prop := fun n => ∃ t' : RoseTree (Symbol T g.NT),
+    ValidFor g t' ∧ t'.yield = t.yield ∧ t'.value = t.value ∧ t'.numNodes = n
+  have hP : ∃ n, P n := ⟨t.numNodes, t, ht, rfl, rfl, rfl⟩
+  obtain ⟨t', h₁, h₂, h₃, h₄⟩ := Nat.find_spec hP
+  exact ⟨t', h₁, h₂, h₃, fun t'' hv hy hr => h₄ ▸ Nat.find_le ⟨t'', hv, hy, hr, rfl⟩⟩
+
+end RoseTree
+
+namespace ContextFreeGrammar
+
+variable {T : Type*} (g : ContextFreeGrammar T)
+
+/-! ### The branching bound -/
+
+/-- The branching bound of a grammar: the longest right-hand side, and at least `2`. -/
+noncomputable def maxBranch : ℕ := max 2 (g.rules.sup fun r => r.output.length)
+
+/-- The pumping constant `maxBranch ^ (rules.card + 1)`: a valid tree with more terminals has a
+path through two nodes with the same nonterminal. -/
+noncomputable def pumpingConstant : ℕ := g.maxBranch ^ (g.rules.card + 1)
+
+theorem two_le_maxBranch : 2 ≤ g.maxBranch := le_max_left _ _
+
+theorem pumpingConstant_pos : 0 < g.pumpingConstant :=
+  Nat.pow_pos (by have := g.two_le_maxBranch; omega)
+
+theorem length_output_le_maxBranch {r : ContextFreeRule T g.NT} (hr : r ∈ g.rules) :
+    r.output.length ≤ g.maxBranch :=
+  le_trans (Finset.le_sup (f := fun r : ContextFreeRule T g.NT => r.output.length) hr)
+    (le_max_right _ _)
+
+variable {g}
+
+/-- A valid tree of height `h` has at most `maxBranch ^ h` terminals. -/
+theorem _root_.RoseTree.ValidFor.length_yield_le {t : RoseTree (Symbol T g.NT)}
+    (ht : t.ValidFor g) : t.yield.length ≤ g.maxBranch ^ t.height := by
+  induction ht with
+  | terminal a => simp [RoseTree.leaf]
+  | nonterminal A cs hrule _ ih =>
+    cases cs with
+    | nil => simp
+    | cons c cs =>
+      set h := (RoseTree.node (.nonterminal A) (c :: cs)).height with hh
+      have hpos : 0 < h :=
+        Nat.lt_of_le_of_lt (Nat.zero_le _) (RoseTree.height_lt_of_mem (c := c) (by simp))
+      have hb : 0 < g.maxBranch := by have := g.two_le_maxBranch; omega
+      rw [RoseTree.yield_node_nonterminal, List.length_flatten, List.map_map]
+      calc ((c :: cs).map (List.length ∘ RoseTree.yield)).sum
+          ≤ ((c :: cs).map fun _ => g.maxBranch ^ (h - 1)).sum := by
+            refine List.sum_le_sum fun d hd => ?_
+            refine (ih d hd).trans (Nat.pow_le_pow_right hb ?_)
+            have := RoseTree.height_lt_of_mem (t := RoseTree.node (.nonterminal A) (c :: cs)) hd
+            omega
+        _ = (c :: cs).length * g.maxBranch ^ (h - 1) := by
+            rw [List.map_const', List.sum_const_nat]
+        _ ≤ g.maxBranch * g.maxBranch ^ (h - 1) :=
+            Nat.mul_le_mul_right _ (by simpa using g.length_output_le_maxBranch hrule)
+        _ = g.maxBranch ^ h := by rw [← Nat.pow_succ']; congr 1; omega
+
+/-! ### Soundness and completeness -/
+
+private theorem derives_flatten_yield {cs : List (RoseTree (Symbol T g.NT))}
+    (h : ∀ c ∈ cs, g.Derives [c.value] (c.yield.map Symbol.terminal)) :
+    g.Derives (cs.map RoseTree.value) ((cs.map RoseTree.yield).flatten.map Symbol.terminal) := by
+  induction cs with
+  | nil => exact Relation.ReflTransGen.refl
+  | cons c cs ih =>
+    rw [List.map_cons, List.map_cons, List.flatten_cons, List.map_append, ← List.singleton_append]
+    exact ((h c (List.mem_cons_self ..)).append_right _).trans
+      ((ih fun d hd => h d (List.mem_cons_of_mem _ hd)).append_left _)
+
+/-- **Soundness.** A valid tree derives its yield from its root symbol. -/
+theorem _root_.RoseTree.ValidFor.derives {t : RoseTree (Symbol T g.NT)} (ht : t.ValidFor g) :
+    g.Derives [t.value] (t.yield.map Symbol.terminal) := by
+  induction ht with
+  | terminal a => simp [RoseTree.leaf]; exact Relation.ReflTransGen.refl
+  | nonterminal A cs hrule _ ih =>
+    rw [RoseTree.value_node, RoseTree.yield_node_nonterminal]
+    exact (Produces.single ⟨⟨A, cs.map RoseTree.value⟩, hrule,
+      ContextFreeRule.Rewrites.input_output⟩).trans (derives_flatten_yield ih)
+
+/-- A rewriting step at any position. -/
+private theorem Rewrites.at_position {r : ContextFreeRule T g.NT} (p q : List (Symbol T g.NT)) :
+    r.Rewrites (p ++ [Symbol.nonterminal r.input] ++ q) (p ++ r.output ++ q) := by
+  induction p with
+  | nil => simpa using ContextFreeRule.Rewrites.head q
+  | cons x xs ih => simpa using ContextFreeRule.Rewrites.cons x ih
+
+/-- **Forest existence.** A sentential form deriving a word is the list of root symbols of a
+list of valid trees whose yields concatenate to the word. -/
+private theorem exists_forest {sf : List (Symbol T g.NT)} {w : List T}
+    (h : g.Derives sf (w.map Symbol.terminal)) :
+    ∃ ts : List (RoseTree (Symbol T g.NT)), ts.map RoseTree.value = sf ∧
+      (∀ t ∈ ts, t.ValidFor g) ∧ (ts.map RoseTree.yield).flatten = w := by
+  induction h using Relation.ReflTransGen.head_induction_on with
+  | refl =>
+    refine ⟨w.map fun a => RoseTree.leaf (.terminal a), ?_, ?_, ?_⟩
+    · simp [Function.comp_def, RoseTree.leaf]
+    · rintro t ht
+      obtain ⟨a, -, rfl⟩ := List.mem_map.mp ht
+      exact .terminal a
+    · induction w <;> simp_all
+  | head hstep _ ih =>
+    obtain ⟨ts, hroot, hvalid, hyield⟩ := ih
+    obtain ⟨r, hr, hrew⟩ := hstep
+    obtain ⟨p, q, hsf, hc⟩ := hrew.exists_parts
+    subst hsf hc
+    have hlen : p.length + r.output.length ≤ ts.length := by
+      have := congrArg List.length hroot; simp at this; omega
+    refine ⟨ts.take p.length ++ [RoseTree.node (.nonterminal r.input)
+      ((ts.drop p.length).take r.output.length)] ++ ts.drop (p.length + r.output.length),
+      ?_, ?_, ?_⟩
+    · have h1 : (ts.take p.length).map RoseTree.value = p := by
+        rw [List.map_take, hroot]; simp
+      have h2 : ((ts.drop p.length).take r.output.length).map RoseTree.value = r.output := by
+        rw [List.map_take, List.map_drop, hroot]; simp
+      have h3 : (ts.drop (p.length + r.output.length)).map RoseTree.value = q := by
+        rw [List.map_drop, hroot]; simp
+      simp only [List.map_append, List.map_cons, List.map_nil, RoseTree.value_node, h1, h3]
+    · intro t ht
+      simp only [List.mem_append, List.mem_singleton] at ht
+      rcases ht with (ht | rfl) | ht
+      · exact hvalid t (List.mem_of_mem_take ht)
+      · refine .nonterminal r.input _ ?_ fun c hc =>
+          hvalid c (List.mem_of_mem_drop (List.mem_of_mem_take hc))
+        rw [List.map_take, List.map_drop, hroot]; simpa using hr
+      · exact hvalid t (List.mem_of_mem_drop ht)
+    · have hsplit : ts = ts.take p.length ++ (ts.drop p.length).take r.output.length ++
+          ts.drop (p.length + r.output.length) := by
+        rw [List.append_assoc, ← List.drop_drop, List.take_append_drop, List.take_append_drop]
+      conv_rhs => rw [← hyield, hsplit]
+      simp only [List.map_append, List.flatten_append, List.map_cons, List.map_nil,
+        List.flatten_cons, List.flatten_nil, List.append_nil, RoseTree.yield_node_nonterminal]
+
+/-- **Completeness.** Every word of the language has a valid derivation tree from the start
+symbol. -/
+theorem exists_valid_tree (g : ContextFreeGrammar T) {w : List T} (hw : w ∈ g.language) :
+    ∃ t : RoseTree (Symbol T g.NT), t.ValidFor g ∧ t.yield = w ∧
+      t.value = .nonterminal g.initial := by
+  obtain ⟨ts, hroot, hvalid, hyield⟩ := exists_forest (g := g) hw
+  obtain ⟨t, rfl⟩ : ∃ t, ts = [t] := by
+    rcases ts with _ | ⟨t, _ | ⟨_, _⟩⟩ <;> simp at hroot
+    exact ⟨t, rfl⟩
+  exact ⟨t, hvalid t (List.mem_singleton_self t), by simpa using hyield, by simpa using hroot⟩
+
+end ContextFreeGrammar

--- a/Linglib/Core/Data/RoseTree/Basic.lean
+++ b/Linglib/Core/Data/RoseTree/Basic.lean
@@ -278,6 +278,54 @@ theorem length_values (t : RoseTree α) : t.values.length = t.numNodes := by
       List.map_congr_left ih]
     omega
 
+/-- The value at each node paired with the values of its children, in preorder: the local
+branching structure of the tree, one entry per node. -/
+def offspring : RoseTree α → List (α × List α)
+  | .node a cs => (a, cs.map value) :: (cs.map fun c => offspring c).flatten
+termination_by t => sizeOf t
+decreasing_by exact sizeOf_lt_of_mem ‹_›
+
+@[simp] theorem offspring_node (a : α) (cs : List (RoseTree α)) :
+    offspring (node a cs) = (a, cs.map value) :: (cs.map offspring).flatten := by
+  rw [offspring]
+
+theorem length_offspring (t : RoseTree α) : t.offspring.length = t.numNodes := by
+  induction t with
+  | node a cs ih =>
+    simp only [offspring_node, numNodes_node, List.length_cons, List.length_flatten,
+      List.map_map, Function.comp_def]
+    rw [show (cs.map fun c => c.offspring.length) = cs.map numNodes from
+      List.map_congr_left ih]
+    omega
+
+/-- The leaf values from left to right: the ordered frontier. -/
+def leafList : RoseTree α → List α :=
+  fold fun a ls => match ls with
+    | [] => [a]
+    | ls => ls.flatten
+
+@[simp] theorem leafList_leaf (a : α) : leafList (node a []) = [a] := by
+  simp only [leafList, fold_node, List.map_nil]
+
+theorem leafList_node_of_ne_nil (a : α) {cs : List (RoseTree α)} (h : cs ≠ []) :
+    leafList (node a cs) = (cs.map leafList).flatten := by
+  obtain ⟨c, cs, rfl⟩ := List.exists_cons_of_ne_nil h
+  simp only [leafList, fold_node, List.map_cons]
+
+@[simp] theorem leafList_node_cons (a : α) (c : RoseTree α) (cs : List (RoseTree α)) :
+    leafList (node a (c :: cs)) = ((c :: cs).map leafList).flatten :=
+  leafList_node_of_ne_nil a (List.cons_ne_nil c cs)
+
+theorem leafList_ne_nil (t : RoseTree α) : t.leafList ≠ [] := by
+  induction t with
+  | node a cs ih =>
+    cases cs with
+    | nil => simp
+    | cons c cs =>
+      rw [leafList_node_cons]
+      exact List.flatten_ne_nil_iff.2 ⟨c.leafList, List.mem_map_of_mem (List.mem_cons_self ..),
+        ih c (List.mem_cons_self ..)⟩
+
 /-- The number of leaves (childless nodes). A single leaf counts as `1`. -/
 def numLeaves : RoseTree α → ℕ :=
   fold fun _ ns => max 1 ns.sum
@@ -413,6 +461,25 @@ theorem map_leaf (f : α → β) (a : α) : map f (leaf a) = leaf (f a) := rfl
   | node a cs ih =>
     simp only [map_node, height_node, List.map_map]
     exact congrArg (List.foldr max 0) (List.map_congr_left fun c hc => congrArg (· + 1) (ih c hc))
+
+@[simp] theorem offspring_map (f : α → β) (t : RoseTree α) :
+    (map f t).offspring = t.offspring.map fun p => (f p.1, p.2.map f) := by
+  induction t with
+  | node a cs ih =>
+    simp only [map_node, offspring_node, List.map_map, List.map_cons, List.map_flatten]
+    refine congrArg₂ _ ?_ (congrArg List.flatten (List.map_congr_left fun c hc => ih c hc))
+    exact congrArg _ (List.map_congr_left fun c _ => by cases c; rfl)
+
+@[simp] theorem leafList_map (f : α → β) (t : RoseTree α) :
+    (map f t).leafList = t.leafList.map f := by
+  induction t with
+  | node a cs ih =>
+    cases cs with
+    | nil => simp
+    | cons c cs =>
+      simp only [map_node, List.map_cons, leafList_node_cons, List.map_flatten, List.map_map]
+      exact congrArg List.flatten (congrArg₂ _ (ih c (List.mem_cons_self ..))
+        (List.map_congr_left fun d hd => ih d (List.mem_cons_of_mem _ hd)))
 
 /-! ### Instances -/
 

--- a/Linglib/Core/Data/RoseTree/Countable.lean
+++ b/Linglib/Core/Data/RoseTree/Countable.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Data.RoseTree.Basic
+import Mathlib.Data.W.Basic
+import Mathlib.Logic.Encodable.Basic
+import Mathlib.Data.Countable.Basic
+
+/-!
+# Countability of rose trees
+
+A rose tree over a countable type is countable: it injects into the W-type over the countable
+label type `Option (Option α)`, where `some (some a)` is a node whose one child is its list of
+children, `none` the empty list and `some none` a cons cell with two children.
+-/
+
+namespace RoseTree
+
+variable {α : Type*}
+
+/-- The branching signature of the W-type encoding. -/
+private def wArity : Option (Option α) → Type
+  | some (some _) => Unit
+  | none => Empty
+  | some none => Bool
+
+mutual
+private def toW : RoseTree α → WType (wArity (α := α))
+  | .node a cs => ⟨some (some a), fun _ => toWList cs⟩
+private def toWList : List (RoseTree α) → WType (wArity (α := α))
+  | [] => ⟨none, Empty.elim⟩
+  | c :: cs => ⟨some none, fun b => bif b then toW c else toWList cs⟩
+end
+
+mutual
+private theorem toW_injective : ∀ {t t' : RoseTree α}, toW t = toW t' → t = t'
+  | .node _ cs, .node _ cs', h => by
+    obtain ⟨h1, h2⟩ := WType.mk.inj h
+    cases h1
+    rw [toWList_injective (congr_fun (eq_of_heq h2) ())]
+private theorem toWList_injective :
+    ∀ {cs cs' : List (RoseTree α)}, toWList cs = toWList cs' → cs = cs'
+  | [], [], _ => rfl
+  | [], _ :: _, h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | _ :: _, [], h => by exact absurd (WType.mk.inj h).1 (by simp)
+  | c :: cs, c' :: cs', h => by
+    obtain ⟨-, h2⟩ := WType.mk.inj h
+    have h3 := congr_fun (eq_of_heq h2)
+    rw [toW_injective (t := c) (t' := c') (by simpa using h3 true),
+      toWList_injective (cs := cs) (cs' := cs') (by simpa using h3 false)]
+end
+
+instance [Countable α] : Countable (RoseTree α) := by
+  classical
+  let _ := Encodable.ofCountable α
+  have _ : ∀ a, Fintype (wArity (α := α) a) := fun a => by
+    rcases a with _ | (_ | _)
+    · exact inferInstanceAs (Fintype Empty)
+    · exact inferInstanceAs (Fintype Bool)
+    · exact inferInstanceAs (Fintype Unit)
+  have _ : ∀ a, Encodable (wArity (α := α) a) := fun a => by
+    rcases a with _ | (_ | _)
+    · exact inferInstanceAs (Encodable Empty)
+    · exact inferInstanceAs (Encodable Bool)
+    · exact inferInstanceAs (Encodable Unit)
+  exact Function.Injective.countable fun _ _ h => toW_injective h
+
+end RoseTree

--- a/Linglib/Core/Data/RoseTree/Get.lean
+++ b/Linglib/Core/Data/RoseTree/Get.lean
@@ -57,4 +57,214 @@ def getD (t : RoseTree α) (path : List ℕ) (v : α) : α :=
 
 @[simp] theorem getD_nil (t : RoseTree α) (v : α) : t.getD [] v = t.value := rfl
 
+theorem subtreeAt_cons_eq_some_iff {t s : RoseTree α} {i : ℕ} {p : List ℕ} :
+    t.subtreeAt (i :: p) = some s ↔ ∃ c, t.children[i]? = some c ∧ c.subtreeAt p = some s := by
+  simp [Option.bind_eq_some_iff]
+
+/-- Relabelling commutes with subtree access. -/
+theorem subtreeAt_map {β : Type*} (f : α → β) (t : RoseTree α) (p : List ℕ) :
+    (map f t).subtreeAt p = (t.subtreeAt p).map (map f) := by
+  induction p generalizing t with
+  | nil => rfl
+  | cons i p ih =>
+    cases t with
+    | node a cs =>
+      simp only [map_node, subtreeAt_cons, children_node, List.getElem?_map]
+      cases cs[i]? with
+      | none => rfl
+      | some c => simp [ih]
+
+/-- Every prefix of an address inside the tree is inside the tree. -/
+theorem subtreeAt_take_isSome {t s : RoseTree α} {p : List ℕ} (h : t.subtreeAt p = some s)
+    (k : ℕ) : (t.subtreeAt (p.take k)).isSome := by
+  rw [← List.take_append_drop k p, subtreeAt_append] at h
+  cases hk : t.subtreeAt (p.take k) with
+  | none => rw [hk] at h; simp at h
+  | some _ => rfl
+
+/-! ### Height and size along addresses -/
+
+private theorem le_foldr_max_of_mem {l : List ℕ} {x : ℕ} (h : x ∈ l) : x ≤ l.foldr max 0 := by
+  induction l with
+  | nil => simp at h
+  | cons y l ih =>
+    rcases List.mem_cons.mp h with rfl | h
+    · exact Nat.le_max_left _ _
+    · exact Nat.le_trans (ih h) (Nat.le_max_right _ _)
+
+private theorem foldr_max_le {l : List ℕ} {m : ℕ} (h : ∀ x ∈ l, x ≤ m) : l.foldr max 0 ≤ m := by
+  induction l with
+  | nil => exact Nat.zero_le m
+  | cons y l ih =>
+    exact Nat.max_le.2 ⟨h y (List.mem_cons_self ..), ih fun x hx => h x (List.mem_cons_of_mem _ hx)⟩
+
+private theorem exists_mem_eq_foldr_max {l : List ℕ} (h : l ≠ []) : ∃ x ∈ l, x = l.foldr max 0 := by
+  induction l with
+  | nil => exact absurd rfl h
+  | cons y l ih =>
+    cases l with
+    | nil => exact ⟨y, List.mem_cons_self .., (Nat.max_eq_left (Nat.zero_le y)).symm⟩
+    | cons z l =>
+      obtain ⟨x, hx, hxe⟩ := ih (List.cons_ne_nil z l)
+      rw [List.foldr_cons, ← hxe]
+      rcases Nat.le_total y x with hyx | hxy
+      · exact ⟨x, List.mem_cons_of_mem _ hx, (Nat.max_eq_right hyx).symm⟩
+      · exact ⟨y, List.mem_cons_self .., (Nat.max_eq_left hxy).symm⟩
+
+private theorem le_sum_of_mem {l : List ℕ} {x : ℕ} (h : x ∈ l) : x ≤ l.sum := by
+  induction l with
+  | nil => simp at h
+  | cons y l ih =>
+    rw [List.sum_cons]
+    rcases List.mem_cons.mp h with rfl | h
+    · exact Nat.le_add_right _ _
+    · exact Nat.le_trans (ih h) (Nat.le_add_left _ _)
+
+theorem height_lt_of_mem {t c : RoseTree α} (h : c ∈ t.children) : c.height < t.height := by
+  cases t with
+  | node a cs =>
+    rw [height_node]
+    exact le_foldr_max_of_mem (List.mem_map_of_mem (List.mem_map_of_mem h))
+
+/-- A node of positive height has a child one shorter. -/
+theorem exists_mem_children_height_add_one {t : RoseTree α} (h : 0 < t.height) :
+    ∃ c ∈ t.children, c.height + 1 = t.height := by
+  cases t with
+  | node a cs =>
+    rw [height_node] at h ⊢
+    have hcs : cs ≠ [] := by rintro rfl; simp at h
+    obtain ⟨x, hx, hxe⟩ := exists_mem_eq_foldr_max
+      (l := (cs.map height).map (· + 1)) (by simpa using hcs)
+    obtain ⟨y, hy, rfl⟩ := List.mem_map.mp hx
+    obtain ⟨c, hc, rfl⟩ := List.mem_map.mp hy
+    exact ⟨c, hc, hxe⟩
+
+/-- A maximal descent of length `k` from a tree of height at least `k`: the subtree at the
+prefix of length `i` has height `t.height - i`. -/
+theorem exists_subtreeAt_height_sub (t : RoseTree α) (k : ℕ) (hk : k ≤ t.height) :
+    ∃ p : List ℕ, p.length = k ∧
+      ∀ i ≤ k, ∃ s, t.subtreeAt (p.take i) = some s ∧ s.height = t.height - i := by
+  induction k generalizing t with
+  | zero =>
+    exact ⟨[], rfl, fun i hi => by obtain rfl := Nat.le_zero.mp hi; exact ⟨t, rfl, by simp⟩⟩
+  | succ k ih =>
+    obtain ⟨c, hc, hch⟩ := exists_mem_children_height_add_one (Nat.lt_of_lt_of_le k.succ_pos hk)
+    obtain ⟨j, hj⟩ := List.getElem?_of_mem hc
+    obtain ⟨p, hp, hsub⟩ := ih c (by omega)
+    refine ⟨j :: p, by simp [hp], fun i hi => ?_⟩
+    cases i with
+    | zero => exact ⟨t, rfl, by simp⟩
+    | succ i =>
+      obtain ⟨s, hs, hsh⟩ := hsub i (Nat.le_of_succ_le_succ hi)
+      exact ⟨s, by simp only [List.take_succ_cons, subtreeAt_cons, hj, Option.bind_some, hs],
+        by omega⟩
+
+theorem numNodes_lt_of_mem {t c : RoseTree α} (h : c ∈ t.children) : c.numNodes < t.numNodes := by
+  cases t with
+  | node a cs =>
+    rw [children_node] at h
+    rw [numNodes_node]
+    have := le_sum_of_mem (List.mem_map_of_mem (f := numNodes) h)
+    omega
+
+theorem numNodes_le_of_subtreeAt {t s : RoseTree α} {p : List ℕ} (h : t.subtreeAt p = some s) :
+    s.numNodes ≤ t.numNodes := by
+  induction p generalizing t with
+  | nil => exact (Option.some.inj h).symm ▸ Nat.le_refl _
+  | cons i p ih =>
+    obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp h
+    exact Nat.le_trans (ih hcs) (Nat.le_of_lt (numNodes_lt_of_mem (List.mem_of_getElem? hc)))
+
+theorem numNodes_lt_of_subtreeAt_cons {t s : RoseTree α} {i : ℕ} {p : List ℕ}
+    (h : t.subtreeAt (i :: p) = some s) : s.numNodes < t.numNodes := by
+  obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp h
+  exact Nat.lt_of_le_of_lt (numNodes_le_of_subtreeAt hcs)
+    (numNodes_lt_of_mem (List.mem_of_getElem? hc))
+
+/-! ### Replacement at an address -/
+
+/-- Replace the subtree at a Gorn address; an address outside the tree leaves it unchanged. -/
+def replaceAt : RoseTree α → List ℕ → RoseTree α → RoseTree α
+  | _, [], new => new
+  | node a cs, i :: p, new => node a (cs.modify i (·.replaceAt p new))
+
+@[simp] theorem replaceAt_nil (t new : RoseTree α) : t.replaceAt [] new = new := by
+  cases t; rfl
+
+theorem replaceAt_cons (a : α) (cs : List (RoseTree α)) (i : ℕ) (p : List ℕ)
+    (new : RoseTree α) :
+    (node a cs).replaceAt (i :: p) new = node a (cs.modify i (·.replaceAt p new)) := rfl
+
+@[simp] theorem value_replaceAt_cons (t : RoseTree α) (i : ℕ) (p : List ℕ) (new : RoseTree α) :
+    (t.replaceAt (i :: p) new).value = t.value := by
+  cases t; rfl
+
+/-- Replacing a subtree by one with the same root value keeps the root value. -/
+theorem value_replaceAt {t s : RoseTree α} {p : List ℕ} (h : t.subtreeAt p = some s)
+    {new : RoseTree α} (hv : new.value = s.value) : (t.replaceAt p new).value = t.value := by
+  cases p with
+  | nil => rw [replaceAt_nil, hv, Option.some.inj h]
+  | cons i p => exact value_replaceAt_cons t i p new
+
+theorem replaceAt_cons_of_getElem? {t c : RoseTree α} {i : ℕ} (hc : t.children[i]? = some c)
+    (p : List ℕ) (new : RoseTree α) :
+    t.replaceAt (i :: p) new = node t.value (t.children.set i (c.replaceAt p new)) := by
+  cases t with
+  | node a cs =>
+    have : Inhabited (RoseTree α) := ⟨c⟩
+    rw [children_node] at hc
+    rw [replaceAt_cons, List.modify_eq_set, hc, Option.getD_some, value_node, children_node]
+
+private theorem eq_take_append_cons_drop {cs : List (RoseTree α)} {i : ℕ} {c : RoseTree α}
+    (hc : cs[i]? = some c) : cs = cs.take i ++ c :: cs.drop (i + 1) := by
+  obtain ⟨hi, rfl⟩ := List.getElem?_eq_some_iff.mp hc
+  rw [← List.drop_eq_getElem_cons hi, List.take_append_drop]
+
+private theorem set_eq_take_append_cons_drop {cs : List (RoseTree α)} {i : ℕ} {c : RoseTree α}
+    (hc : cs[i]? = some c) (x : RoseTree α) : cs.set i x = cs.take i ++ x :: cs.drop (i + 1) := by
+  rw [List.set_eq_take_append_cons_drop, if_pos (List.getElem?_eq_some_iff.mp hc).1]
+
+/-- Replacing inside the tree splits the frontier into the leaves left of the address, the
+frontier of the subtree there, and the leaves to its right. -/
+theorem leafList_replaceAt {t s : RoseTree α} {p : List ℕ} (h : t.subtreeAt p = some s) :
+    ∃ pre post : List α, t.leafList = pre ++ s.leafList ++ post ∧
+      ∀ new : RoseTree α, (t.replaceAt p new).leafList = pre ++ new.leafList ++ post := by
+  induction p generalizing t with
+  | nil => exact ⟨[], [], by simp [Option.some.inj h], fun new => by simp⟩
+  | cons i p ih =>
+    obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp h
+    obtain ⟨pre, post, hy, hy'⟩ := ih hcs
+    cases t with
+    | node a cs =>
+      rw [children_node] at hc
+      refine ⟨((cs.take i).map leafList).flatten ++ pre,
+        post ++ ((cs.drop (i + 1)).map leafList).flatten, ?_, fun new => ?_⟩
+      · conv_lhs => rw [eq_take_append_cons_drop hc]
+        rw [leafList_node_of_ne_nil _ (List.append_ne_nil_of_right_ne_nil _ (List.cons_ne_nil _ _)),
+          List.map_append, List.map_cons, List.flatten_append, List.flatten_cons, hy]
+        simp only [List.append_assoc]
+      · rw [replaceAt_cons_of_getElem? (by simpa using hc), value_node, children_node,
+          set_eq_take_append_cons_drop hc,
+          leafList_node_of_ne_nil _ (List.append_ne_nil_of_right_ne_nil _ (List.cons_ne_nil _ _)),
+          List.map_append, List.map_cons, List.flatten_append, List.flatten_cons, hy']
+        simp only [List.append_assoc]
+
+/-- Replacing a subtree by a strictly smaller one shrinks the tree. -/
+theorem numNodes_replaceAt_lt {t s : RoseTree α} {p : List ℕ} (h : t.subtreeAt p = some s)
+    {new : RoseTree α} (hlt : new.numNodes < s.numNodes) :
+    (t.replaceAt p new).numNodes < t.numNodes := by
+  induction p generalizing t with
+  | nil => rw [replaceAt_nil, Option.some.inj h]; exact hlt
+  | cons i p ih =>
+    obtain ⟨c, hc, hcs⟩ := subtreeAt_cons_eq_some_iff.mp h
+    cases t with
+    | node a cs =>
+      rw [children_node] at hc
+      rw [replaceAt_cons_of_getElem? (by simpa using hc), value_node, children_node,
+        set_eq_take_append_cons_drop hc, numNodes_node]
+      conv_rhs => rw [eq_take_append_cons_drop hc, numNodes_node]
+      simp only [List.map_append, List.map_cons, List.sum_append, List.sum_cons]
+      have := ih hcs
+      omega
+
 end RoseTree

--- a/Linglib/Core/MeasureTheory/Constructions/List.lean
+++ b/Linglib/Core/MeasureTheory/Constructions/List.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.MeasureTheory.Measure.GiryMonad
+import Mathlib.MeasureTheory.Measure.WithDensity
+
+/-!
+# Measures on lists
+
+Lists carry the discrete σ-algebra, so every function out of a list type is measurable and, over
+a countable type, every measure on lists is s-finite. `Measure.listProd` is the law of a list of
+independent draws, one from each measure in a list of measures: the `List`-indexed product
+measure, built from the binary product.
+
+## Main definitions
+
+* `MeasureTheory.Measure.listProd`: the product of a list of measures.
+
+## Main results
+
+* `MeasureTheory.Measure.listProd_cons_singleton_cons`: the product measure of a singleton list is
+  the product of the singleton measures.
+* `MeasureTheory.Measure.ωScottContinuous_listProd`: the product is ω-Scott-continuous in each
+  factor.
+
+## Implementation notes
+
+The discrete σ-algebra is the only reasonable choice on lists over a countable discrete type,
+which is the case of interest for derivation trees and branching processes; it is registered
+globally here as the library's convention.
+-/
+
+open MeasureTheory OmegaCompletePartialOrder
+open scoped ENNReal
+
+instance {α : Type*} : MeasurableSpace (List α) := ⊤
+
+namespace MeasureTheory.Measure
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- The law of a list of independent draws, one from each measure in the list. -/
+noncomputable def listProd : List (Measure α) → Measure (List α)
+  | [] => dirac []
+  | μ :: μs => (μ.prod (listProd μs)).map (Function.uncurry List.cons)
+
+@[simp] theorem listProd_nil : listProd ([] : List (Measure α)) = dirac [] := rfl
+
+theorem listProd_cons (μ : Measure α) (μs : List (Measure α)) :
+    listProd (μ :: μs) = (μ.prod (listProd μs)).map (Function.uncurry List.cons) := rfl
+
+@[simp] theorem listProd_nil_singleton_cons (x : α) (xs : List α) :
+    listProd ([] : List (Measure α)) {x :: xs} = 0 := by
+  rw [listProd_nil, dirac_apply' _ .of_discrete]
+  simp
+
+variable [Countable α] [MeasurableSingletonClass α]
+
+theorem isProbabilityMeasure_listProd {μs : List (Measure α)}
+    (h : ∀ μ ∈ μs, IsProbabilityMeasure μ) : IsProbabilityMeasure (listProd μs) := by
+  induction μs with
+  | nil => rw [listProd_nil]; infer_instance
+  | cons μ μs ih =>
+    have := ih fun ν hν => h ν (List.mem_cons_of_mem _ hν)
+    have := h μ (List.mem_cons_self ..)
+    rw [listProd_cons]
+    exact isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
+
+theorem listProd_univ_le_one {μs : List (Measure α)} (h : ∀ μ ∈ μs, μ Set.univ ≤ 1) :
+    listProd μs Set.univ ≤ 1 := by
+  induction μs with
+  | nil => simp
+  | cons μ μs ih =>
+    rw [listProd_cons, map_apply .of_discrete .univ, Set.preimage_univ, ← Set.univ_prod_univ,
+      prod_prod]
+    exact mul_le_one' (h μ (List.mem_cons_self ..)) (ih fun ν hν => h ν (List.mem_cons_of_mem _ hν))
+
+@[simp] theorem listProd_cons_singleton_nil (μ : Measure α) (μs : List (Measure α)) :
+    listProd (μ :: μs) {[]} = 0 := by
+  rw [listProd_cons, map_apply .of_discrete .of_discrete]
+  convert measure_empty (μ := μ.prod (listProd μs))
+  ext ⟨_, _⟩
+  simp
+
+@[simp] theorem listProd_cons_singleton_cons (μ : Measure α) (μs : List (Measure α)) (x : α)
+    (xs : List α) : listProd (μ :: μs) {x :: xs} = μ {x} * listProd μs {xs} := by
+  rw [listProd_cons, map_apply .of_discrete .of_discrete, ← prod_prod]
+  congr 1
+  ext ⟨_, _⟩
+  simp
+
+variable {γ : Type*} [OmegaCompletePartialOrder γ]
+
+theorem ωScottContinuous_listProd {ι : Type*} {F : ι → γ → Measure α} {l : List ι}
+    (hF : ∀ i ∈ l, ωScottContinuous (F i)) :
+    ωScottContinuous fun x => listProd (l.map fun i => F i x) := by
+  induction l with
+  | nil => exact ωScottContinuous.const
+  | cons i l ih =>
+    simp only [List.map_cons, listProd_cons]
+    exact ωScottContinuous_map (ωScottContinuous_prod (hF i (List.mem_cons_self ..))
+      (ih fun j hj => hF j (List.mem_cons_of_mem _ hj))) .of_discrete
+
+end MeasureTheory.Measure

--- a/Linglib/Core/Order/Branching.lean
+++ b/Linglib/Core/Order/Branching.lean
@@ -34,10 +34,9 @@ class + `Is…` Prop mixin, like `RootedTree` + `IsPredArchimedean`).
 
 Known instance candidates across the library (2026-06-06 audit):
 `Syntax.Tree` (constituency), `NanoTree` (Nanosyntax features),
-`DerivationTree` (CFG derivations — `subtreeAt` is classical Gorn
-addressing), `RoseTree` (Hopf-algebra
-trees), `FreeMagma` (bare phrase structure), Dependency-Grammar
-positions.
+`RoseTree` (CFG derivation trees and Hopf-algebra trees; `subtreeAt`
+is classical Gorn addressing), `FreeMagma` (bare phrase structure),
+Dependency-Grammar positions.
 -/
 
 namespace Core.Order

--- a/Linglib/Core/Probability/BranchingProcess/GaltonWatson.lean
+++ b/Linglib/Core/Probability/BranchingProcess/GaltonWatson.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.ContextFreeGrammar.Tree
-import Linglib.Core.MeasureTheory.Measure.GiryMonad
+import Linglib.Core.Data.RoseTree.Countable
+import Linglib.Core.Data.RoseTree.Get
+import Linglib.Core.MeasureTheory.Constructions.List
 import Linglib.Core.Order.IterateFixedPoint
 import Linglib.Core.Probability.Kernel.Basic
 import Linglib.Core.Probability.Kernel.Composition.Lemmas
@@ -13,16 +14,16 @@ import Mathlib.Probability.Kernel.IonescuTulcea.Traj
 /-!
 # Multitype Galton–Watson processes
 
-A multitype Galton–Watson process with types `ι` and marks `T` is an offspring kernel
-`ξ : Kernel ι (List (Symbol T ι))`. An individual of type `i` draws its offspring from `ξ i`, an
-ordered list of types and marks; each type among them founds an independent copy of the process
-and each mark is a leaf. The family tree of an individual is the plane tree of [neveu-1986]; its
-law on finite trees is the least fixed point of the one-generation operator on the Giry monad,
-and the missing mass is the probability of surviving forever.
+A multitype Galton–Watson process with types `ι` is an offspring kernel `ξ : Kernel ι (List ι)`:
+an individual of type `i` has offspring drawn from `ξ i`, an ordered list of types, each of which
+founds an independent copy of the process. The family tree of an individual is the plane tree of
+[neveu-1986], a `RoseTree ι`; its law on finite trees is the least fixed point of the
+one-generation operator on the Giry monad, and the missing mass is the probability of surviving
+forever.
 
-A probabilistic context-free grammar is the instance whose types are the nonterminals, whose
-marks are the terminals, and whose offspring at `A` is the right-hand side of a rule chosen with
-its weight; see `PCFG.galtonWatson`.
+A probabilistic context-free grammar is the instance whose types are the symbols: a terminal has
+no offspring, and a nonterminal's offspring is the right-hand side of a rule chosen with its
+weight; see `PCFG.galtonWatson`.
 
 ## Main definitions
 
@@ -32,8 +33,8 @@ its weight; see `PCFG.galtonWatson`.
   generation.
 * `GaltonWatson.expand`: one generation from a single hole followed by filling, and
   `GaltonWatson.law`: its least fixed point, the law of the finite family tree at each type.
-* `GaltonWatson.weight`: the probability of a finite family tree, the product over its internal
-  nodes of the offspring probability there.
+* `GaltonWatson.weight`: the probability of a finite family tree, the product over its nodes of
+  the offspring probability there.
 * `GaltonWatson.extinctionProb`: the total mass of `law`, the probability that the family tree
   is finite.
 * `GaltonWatson.chainKernel`, `GaltonWatson.trajectory`: with Markov offspring, the generation
@@ -57,15 +58,15 @@ its weight; see `PCFG.galtonWatson`.
 
 ## Implementation notes
 
-Family trees are `DerivationTree T ι`, with marks as leaves and types as internal labels, and
-partial trees are `DerivationTree (Symbol T ι) ι`, whose leaves are marks or holes. Both, and
-lists of them, carry the discrete σ-algebra `⊤`, so every function out of them is measurable and,
-with `ι` and `T` countable, every measure on them is s-finite and every kernel between them is an
-s-finite kernel; Fubini then needs no finiteness hypotheses. The offspring kernel is not
-required to be Markov: sub-probability offspring model killing, and the grammar instance
-produces the zero measure at a nonterminal no rule expands. The extinction probability is the
-least fixed point of the offspring generating function and equals one exactly when the mean
-matrix is subcritical or critical ([athreya-ney-1972]); that theorem is not proved here.
+Trees and lists carry the discrete σ-algebra `⊤`, so every function out of them is measurable
+and, with `ι` countable, every measure on them is s-finite and every kernel between them is an
+s-finite kernel; Fubini then needs no finiteness hypotheses. Partial trees are
+`RoseTree (ι ⊕ ι)`, a hole of type `i` being a leaf `Sum.inl i` and an expanded individual a node
+`Sum.inr i`. The offspring kernel is not required to be Markov: sub-probability offspring model
+killing, and the grammar instance produces the zero measure at a nonterminal no rule expands. The
+extinction probability is the least fixed point of the offspring generating function and equals
+one exactly when the mean matrix is subcritical or critical ([athreya-ney-1972]); that theorem is
+not proved here.
 
 ## References
 
@@ -73,149 +74,100 @@ matrix is subcritical or critical ([athreya-ney-1972]); that theorem is not prov
 * [athreya-ney-1972]
 -/
 
-open MeasureTheory OmegaCompletePartialOrder ProbabilityTheory Kernel Finset Preorder
+open MeasureTheory OmegaCompletePartialOrder ProbabilityTheory Kernel Finset Preorder RoseTree
 open scoped ENNReal
 
-instance {T N : Type*} : MeasurableSpace (DerivationTree T N) := ⊤
-instance {T N : Type*} : MeasurableSpace (List (DerivationTree T N)) := ⊤
-instance {T N : Type*} : MeasurableSpace (List (Symbol T N)) := ⊤
+instance {α : Type*} : MeasurableSpace (RoseTree α) := ⊤
 
 namespace ProbabilityTheory.GaltonWatson
 
-open DerivationTree
+variable {ι : Type*} [MeasurableSpace ι]
 
-variable {ι T : Type*} [MeasurableSpace ι]
+/-- Partial family trees: a leaf `Sum.inl i` is a hole of type `i`, yet to be expanded, and a
+node `Sum.inr i` is an individual of type `i` whose offspring is known. -/
+abbrev PartialTree (ι : Type*) := RoseTree (ι ⊕ ι)
 
-/-- Partial family trees: a leaf is a mark `Symbol.terminal t` or a hole `Symbol.nonterminal i`
-of type `i`, yet to be expanded. -/
-abbrev PartialTree (ι T : Type*) := DerivationTree (Symbol T ι) ι
+/-- The hole of type `i`. -/
+abbrev hole (i : ι) : PartialTree ι := leaf (.inl i)
 
 /-! ### Filling the holes -/
 
 section Fill
 
-variable (κ : Kernel ι (DerivationTree T ι))
-
-mutual
-private noncomputable def fillFun : PartialTree ι T → Measure (DerivationTree T ι)
-  | .leaf (.terminal t) => Measure.dirac (leaf t)
-  | .leaf (.nonterminal i) => κ i
-  | .node i cs => (fillListFun cs).map (node i)
-private noncomputable def fillListFun : List (PartialTree ι T) → Measure (List (DerivationTree T ι))
-  | [] => Measure.dirac []
-  | s :: ss => ((fillFun s).prod (fillListFun ss)).map (Function.uncurry List.cons)
-end
+variable (κ : Kernel ι (RoseTree ι))
 
 /-- Fill the holes of a partial tree with independent draws from the laws `κ`. -/
-noncomputable def fill : Kernel (PartialTree ι T) (DerivationTree T ι) := ⟨fillFun κ, .of_discrete⟩
+noncomputable def fill : Kernel (PartialTree ι) (RoseTree ι) :=
+  ⟨fold fun s μs => match s with
+    | .inl i => κ i
+    | .inr i => (Measure.listProd μs).map (node i), .of_discrete⟩
 
 /-- Fill the holes of a list of partial trees independently. -/
-noncomputable def fillList : Kernel (List (PartialTree ι T)) (List (DerivationTree T ι)) :=
-  ⟨fillListFun κ, .of_discrete⟩
+noncomputable def fillList : Kernel (List (PartialTree ι)) (List (RoseTree ι)) :=
+  ⟨fun ss => Measure.listProd (ss.map (fill κ)), .of_discrete⟩
 
-@[simp] theorem fill_leaf_terminal (t : T) : fill κ (leaf (.terminal t)) = Measure.dirac (leaf t) :=
-  rfl
+@[simp] theorem fill_inl (i : ι) (cs : List (PartialTree ι)) : fill κ (node (.inl i) cs) = κ i := by
+  simp only [fill, coe_mk, fold_node]
 
-@[simp] theorem fill_leaf_nonterminal (i : ι) : fill κ (leaf (.nonterminal i)) = κ i := rfl
+@[simp] theorem fill_hole (i : ι) : fill κ (hole i) = κ i := fill_inl κ i []
 
-theorem fill_node (i : ι) (cs : List (PartialTree ι T)) :
-    fill κ (node i cs) = (fillList κ cs).map (node i) := rfl
+theorem fill_inr (i : ι) (cs : List (PartialTree ι)) :
+    fill κ (node (.inr i) cs) = (fillList κ cs).map (node i) := by
+  simp only [fill, fillList, coe_mk, fold_node]
 
-@[simp] theorem fillList_nil : fillList κ [] = Measure.dirac [] := rfl
+@[simp] theorem fillList_apply (ss : List (PartialTree ι)) :
+    fillList κ ss = Measure.listProd (ss.map (fill κ)) := rfl
 
-theorem fillList_cons (s : PartialTree ι T) (ss : List (PartialTree ι T)) :
-    fillList κ (s :: ss) = ((fill κ s).prod (fillList κ ss)).map (Function.uncurry List.cons) :=
-  rfl
+variable {κ} [Countable ι]
 
-variable {κ}
+theorem fill_univ_le_one (hκ : ∀ i, κ i Set.univ ≤ 1) (s : PartialTree ι) :
+    fill κ s Set.univ ≤ 1 := by
+  induction s using RoseTree.rec' with
+  | node s cs ih =>
+    cases s with
+    | inl i => rw [fill_inl]; exact hκ i
+    | inr i =>
+      rw [fill_inr, Measure.map_apply .of_discrete .univ, Set.preimage_univ, fillList_apply]
+      exact Measure.listProd_univ_le_one fun μ hμ => by
+        obtain ⟨c, hc, rfl⟩ := List.mem_map.mp hμ
+        exact ih c hc
 
-@[simp]
-theorem fillList_nil_singleton_cons (c : DerivationTree T ι) (cs : List (DerivationTree T ι)) :
-    fillList κ [] {c :: cs} = 0 := by
-  rw [fillList_nil, Measure.dirac_apply' _ .of_discrete]
-  simp
-
-mutual
-theorem fill_univ_le_one [Countable ι] [Countable T] (hκ : ∀ i, κ i Set.univ ≤ 1) :
-    ∀ s : PartialTree ι T, fill κ s Set.univ ≤ 1
-  | .leaf (.terminal _) => by simp
-  | .leaf (.nonterminal i) => hκ i
-  | .node _ cs => by
-    rw [fill_node, Measure.map_apply .of_discrete .univ, Set.preimage_univ]
-    exact fillList_univ_le_one hκ cs
-theorem fillList_univ_le_one [Countable ι] [Countable T] (hκ : ∀ i, κ i Set.univ ≤ 1) :
-    ∀ ss : List (PartialTree ι T), fillList κ ss Set.univ ≤ 1
-  | [] => by simp
-  | s :: ss => by
-    rw [fillList_cons, Measure.map_apply .of_discrete .univ, Set.preimage_univ,
-      ← Set.univ_prod_univ, Measure.prod_prod]
-    exact mul_le_one' (fill_univ_le_one hκ s) (fillList_univ_le_one hκ ss)
-end
-
-mutual
-theorem isProbabilityMeasure_fill [Countable ι] [Countable T] [IsMarkovKernel κ] :
-    ∀ s : PartialTree ι T, IsProbabilityMeasure (fill κ s)
-  | .leaf (.terminal _) => by rw [fill_leaf_terminal]; infer_instance
-  | .leaf (.nonterminal i) => by rw [fill_leaf_nonterminal]; infer_instance
-  | .node _ cs => by
-    have := isProbabilityMeasure_fillList cs
-    rw [fill_node]
-    exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
-theorem isProbabilityMeasure_fillList [Countable ι] [Countable T] [IsMarkovKernel κ] :
-    ∀ ss : List (PartialTree ι T), IsProbabilityMeasure (fillList κ ss)
-  | [] => by rw [fillList_nil]; infer_instance
-  | s :: ss => by
-    have := isProbabilityMeasure_fill s
-    have := isProbabilityMeasure_fillList ss
-    rw [fillList_cons]
-    exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
-end
-
-variable [Countable ι] [Countable T]
+theorem isProbabilityMeasure_fill [IsMarkovKernel κ] (s : PartialTree ι) :
+    IsProbabilityMeasure (fill κ s) := by
+  induction s using RoseTree.rec' with
+  | node s cs ih =>
+    cases s with
+    | inl i => rw [fill_inl]; infer_instance
+    | inr i =>
+      have := Measure.isProbabilityMeasure_listProd fun μ hμ => by
+        obtain ⟨c, hc, rfl⟩ := List.mem_map.mp hμ
+        exact ih c hc
+      rw [fill_inr, fillList_apply]
+      exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
 
 instance [IsMarkovKernel κ] : IsMarkovKernel (fill κ) := ⟨isProbabilityMeasure_fill⟩
 
-instance [IsMarkovKernel κ] : IsMarkovKernel (fillList κ) := ⟨isProbabilityMeasure_fillList⟩
+instance [IsMarkovKernel κ] : IsMarkovKernel (fillList κ) :=
+  ⟨fun ss => Measure.isProbabilityMeasure_listProd fun μ hμ => by
+    obtain ⟨c, -, rfl⟩ := List.mem_map.mp hμ
+    exact isProbabilityMeasure_fill c⟩
 
-@[simp]
-theorem fillList_cons_singleton_cons (s : PartialTree ι T) (ss : List (PartialTree ι T))
-    (c : DerivationTree T ι) (cs : List (DerivationTree T ι)) :
-    fillList κ (s :: ss) {c :: cs} = fill κ s {c} * fillList κ ss {cs} := by
-  rw [fillList_cons, Measure.map_apply .of_discrete .of_discrete, ← Measure.prod_prod]
-  congr 1
-  ext ⟨_, _⟩
-  simp
-
-@[simp]
-theorem fillList_cons_singleton_nil (s : PartialTree ι T) (ss : List (PartialTree ι T)) :
-    fillList κ (s :: ss) {[]} = 0 := by
-  rw [fillList_cons, Measure.map_apply .of_discrete .of_discrete]
-  convert measure_empty (μ := (fill κ s).prod (fillList κ ss))
-  ext ⟨_, _⟩
-  simp
-
-/-- A list of subtrees whose root symbols do not spell out the holes has mass `0`, for any family
+/-- A list of subtrees whose root types do not spell out the holes has mass `0`, for any family
 of laws concentrated on trees of the right type. -/
-theorem fillList_map_leaf_singleton_of_ne
-    (hκ : ∀ i (c : DerivationTree T ι), c.rootSymbol ≠ .nonterminal i → κ i {c} = 0) :
-    ∀ (syms : List (Symbol T ι)) (cs : List (DerivationTree T ι)),
-      cs.map rootSymbol ≠ syms → fillList κ (syms.map leaf) {cs} = 0
+theorem fillList_map_hole_singleton_of_ne
+    (hκ : ∀ i (c : RoseTree ι), c.value ≠ i → κ i {c} = 0) :
+    ∀ (js : List ι) (cs : List (RoseTree ι)), cs.map value ≠ js →
+      fillList κ (js.map hole) {cs} = 0
   | [], [], h => absurd rfl h
-  | [], _ :: _, _ => fillList_nil_singleton_cons _ _
-  | _ :: _, [], _ => fillList_cons_singleton_nil _ _
-  | .terminal t :: rest, c :: cs, h => by
-    rw [List.map_cons, fillList_cons_singleton_cons, fill_leaf_terminal, Measure.dirac_apply]
-    by_cases hc : c = leaf t
-    · subst hc
-      simp only [List.map_cons, rootSymbol_leaf, ne_eq, List.cons.injEq, true_and] at h
-      rw [fillList_map_leaf_singleton_of_ne hκ rest cs h, mul_zero]
-    · simp [Ne.symm hc]
-  | .nonterminal i :: rest, c :: cs, h => by
-    rw [List.map_cons, fillList_cons_singleton_cons, fill_leaf_nonterminal]
-    by_cases hc : c.rootSymbol = .nonterminal i
+  | [], _ :: _, _ => by simp
+  | _ :: _, [], _ => by simp
+  | j :: rest, c :: cs, h => by
+    rw [fillList_apply, List.map_cons, List.map_cons, Measure.listProd_cons_singleton_cons,
+      fill_hole]
+    by_cases hc : c.value = j
     · simp only [List.map_cons, hc, ne_eq, List.cons.injEq, true_and] at h
-      rw [fillList_map_leaf_singleton_of_ne hκ rest cs h, mul_zero]
-    · rw [hκ i c hc, zero_mul]
+      rw [← fillList_apply, fillList_map_hole_singleton_of_ne hκ rest cs h, mul_zero]
+    · rw [hκ j c hc, zero_mul]
 
 end Fill
 
@@ -223,120 +175,111 @@ end Fill
 
 section Generation
 
-variable (ξ : Kernel ι (List (Symbol T ι)))
-
-mutual
-private noncomputable def generationFun : PartialTree ι T → Measure (PartialTree ι T)
-  | .leaf (.terminal t) => Measure.dirac (leaf (.terminal t))
-  | .leaf (.nonterminal i) => (ξ i).map fun syms => node i (syms.map leaf)
-  | .node i cs => (generationListFun cs).map (node i)
-private noncomputable def generationListFun :
-    List (PartialTree ι T) → Measure (List (PartialTree ι T))
-  | [] => Measure.dirac []
-  | s :: ss => ((generationFun s).prod (generationListFun ss)).map (Function.uncurry List.cons)
-end
+variable (ξ : Kernel ι (List ι))
 
 /-- One synchronous generation: every hole draws its offspring and becomes a node whose children
-are fresh holes and marks. -/
-noncomputable def generation : Kernel (PartialTree ι T) (PartialTree ι T) :=
-  ⟨generationFun ξ, .of_discrete⟩
+are fresh holes. -/
+noncomputable def generation : Kernel (PartialTree ι) (PartialTree ι) :=
+  ⟨fold fun s μs => match s with
+    | .inl i => (ξ i).map fun js => node (.inr i) (js.map hole)
+    | .inr i => (Measure.listProd μs).map (node (.inr i)), .of_discrete⟩
 
 /-- One synchronous generation on a list of partial trees. -/
-noncomputable def generationList : Kernel (List (PartialTree ι T)) (List (PartialTree ι T)) :=
-  ⟨generationListFun ξ, .of_discrete⟩
+noncomputable def generationList : Kernel (List (PartialTree ι)) (List (PartialTree ι)) :=
+  ⟨fun ss => Measure.listProd (ss.map (generation ξ)), .of_discrete⟩
 
-@[simp] theorem generation_leaf_terminal (t : T) :
-    generation ξ (leaf (.terminal t)) = Measure.dirac (leaf (.terminal t)) := rfl
+@[simp] theorem generation_inl (i : ι) (cs : List (PartialTree ι)) :
+    generation ξ (node (.inl i) cs) = (ξ i).map fun js => node (.inr i) (js.map hole) := by
+  simp only [generation, coe_mk, fold_node]
 
-@[simp] theorem generation_leaf_nonterminal (i : ι) :
-    generation ξ (leaf (.nonterminal i)) = (ξ i).map fun syms => node i (syms.map leaf) := rfl
+@[simp] theorem generation_hole (i : ι) :
+    generation ξ (hole i) = (ξ i).map fun js => node (.inr i) (js.map hole) :=
+  generation_inl ξ i []
 
-theorem generation_node (i : ι) (cs : List (PartialTree ι T)) :
-    generation ξ (node i cs) = (generationList ξ cs).map (node i) := rfl
+theorem generation_inr (i : ι) (cs : List (PartialTree ι)) :
+    generation ξ (node (.inr i) cs) = (generationList ξ cs).map (node (.inr i)) := by
+  simp only [generation, generationList, coe_mk, fold_node]
 
-@[simp] theorem generationList_nil : generationList ξ [] = Measure.dirac [] := rfl
+@[simp] theorem generationList_apply (ss : List (PartialTree ι)) :
+    generationList ξ ss = Measure.listProd (ss.map (generation ξ)) := rfl
 
-theorem generationList_cons (s : PartialTree ι T) (ss : List (PartialTree ι T)) :
-    generationList ξ (s :: ss) =
-      ((generation ξ s).prod (generationList ξ ss)).map (Function.uncurry List.cons) := rfl
+variable [Countable ι]
 
-mutual
-theorem isProbabilityMeasure_generation [Countable ι] [Countable T] [IsMarkovKernel ξ] :
-    ∀ s : PartialTree ι T, IsProbabilityMeasure (generation ξ s)
-  | .leaf (.terminal _) => by rw [generation_leaf_terminal]; infer_instance
-  | .leaf (.nonterminal i) => by
-    rw [generation_leaf_nonterminal]
-    exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
-  | .node _ cs => by
-    have := isProbabilityMeasure_generationList cs
-    rw [generation_node]
-    exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
-theorem isProbabilityMeasure_generationList [Countable ι] [Countable T] [IsMarkovKernel ξ] :
-    ∀ ss : List (PartialTree ι T), IsProbabilityMeasure (generationList ξ ss)
-  | [] => by rw [generationList_nil]; infer_instance
-  | s :: ss => by
-    have := isProbabilityMeasure_generation s
-    have := isProbabilityMeasure_generationList ss
-    rw [generationList_cons]
-    exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
-end
+theorem isProbabilityMeasure_generation [IsMarkovKernel ξ] (s : PartialTree ι) :
+    IsProbabilityMeasure (generation ξ s) := by
+  induction s using RoseTree.rec' with
+  | node s cs ih =>
+    cases s with
+    | inl i =>
+      rw [generation_inl]
+      exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
+    | inr i =>
+      have := Measure.isProbabilityMeasure_listProd fun μ hμ => by
+        obtain ⟨c, hc, rfl⟩ := List.mem_map.mp hμ
+        exact ih c hc
+      rw [generation_inr, generationList_apply]
+      exact Measure.isProbabilityMeasure_map Measurable.of_discrete.aemeasurable
 
-instance [Countable ι] [Countable T] [IsMarkovKernel ξ] : IsMarkovKernel (generation ξ) :=
-  ⟨isProbabilityMeasure_generation ξ⟩
+instance [IsMarkovKernel ξ] : IsMarkovKernel (generation ξ) := ⟨isProbabilityMeasure_generation ξ⟩
 
-instance [Countable ι] [Countable T] [IsMarkovKernel ξ] : IsMarkovKernel (generationList ξ) :=
-  ⟨isProbabilityMeasure_generationList ξ⟩
+instance [IsMarkovKernel ξ] : IsMarkovKernel (generationList ξ) :=
+  ⟨fun ss => Measure.isProbabilityMeasure_listProd fun μ hμ => by
+    obtain ⟨c, -, rfl⟩ := List.mem_map.mp hμ
+    exact isProbabilityMeasure_generation ξ c⟩
 
-variable [Countable ι] [MeasurableSingletonClass ι]
+/-- Filling a list of partial trees after one generation on each. -/
+theorem fillList_comp_generationList {κ : Kernel ι (RoseTree ι)} (ss : List (PartialTree ι)) :
+    fillList κ ∘ₘ generationList ξ ss =
+      Measure.listProd (ss.map fun s => fill κ ∘ₘ generation ξ s) := by
+  induction ss with
+  | nil =>
+    rw [generationList_apply, List.map_nil, Measure.listProd_nil,
+      Measure.dirac_bind (Kernel.measurable _), fillList_apply, List.map_nil, List.map_nil,
+      Measure.listProd_nil]
+  | cons s ss ih =>
+    rw [List.map_cons, Measure.listProd_cons, ← ih, generationList_apply, List.map_cons,
+      Measure.listProd_cons, ← generationList_apply, ← Measure.parallelComp_comp_prod,
+      Measure.map_comp _ _ .of_discrete, Measure.bind_map .of_discrete (Kernel.measurable _)]
+    congr 1
+    funext ⟨s', ss'⟩
+    rw [Function.comp_apply, Function.uncurry_apply_pair, fillList_apply, List.map_cons,
+      Measure.listProd_cons, ← fillList_apply, Kernel.map_apply _ .of_discrete, parallelComp_apply]
+
+variable [MeasurableSingletonClass ι]
 
 /-- One generation from a type `i`: a single hole of type `i` draws its offspring, and each type
 among them grows a family tree with law `κ`. -/
-noncomputable def expand (κ : Kernel ι (DerivationTree T ι)) : Kernel ι (DerivationTree T ι) :=
-  (fill κ ∘ₖ generation ξ).comap (fun i => leaf (.nonterminal i)) .of_discrete
+noncomputable def expand (κ : Kernel ι (RoseTree ι)) : Kernel ι (RoseTree ι) :=
+  (fill κ ∘ₖ generation ξ).comap hole .of_discrete
 
-variable {ξ} {κ : Kernel ι (DerivationTree T ι)}
+variable {ξ} {κ : Kernel ι (RoseTree ι)}
 
 @[simp]
-theorem expand_apply (i : ι) : expand ξ κ i = fill κ ∘ₘ generation ξ (leaf (.nonterminal i)) := by
+theorem expand_apply (i : ι) : expand ξ κ i = fill κ ∘ₘ generation ξ (hole i) := by
   rw [expand, comap_apply, comp_apply]
-
-theorem expand_apply' (i : ι) (s : Set (DerivationTree T ι)) :
-    expand ξ κ i s = ∫⁻ syms, fillList κ (syms.map leaf) (node i ⁻¹' s) ∂ξ i := by
-  rw [expand_apply, Measure.bind_apply .of_discrete (Kernel.aemeasurable _),
-    generation_leaf_nonterminal, lintegral_map (Kernel.measurable_coe _ .of_discrete) .of_discrete]
-  simp_rw [fill_node, Measure.map_apply .of_discrete .of_discrete]
-
-mutual
-/-- Filling with one more generation is one generation followed by filling. -/
-theorem fill_expand_apply [Countable T] :
-    ∀ s : PartialTree ι T, fill (expand ξ κ) s = fill κ ∘ₘ generation ξ s
-  | .leaf (.terminal t) => by
-    rw [fill_leaf_terminal, generation_leaf_terminal, Measure.dirac_bind (Kernel.measurable _),
-      fill_leaf_terminal]
-  | .leaf (.nonterminal i) => by rw [fill_leaf_nonterminal, expand_apply]
-  | .node i cs => by
-    rw [fill_node, generation_node, fillList_expand_apply cs,
-      Measure.map_bind (Kernel.measurable _) .of_discrete,
-      Measure.bind_map .of_discrete (Kernel.measurable _)]
-    rfl
-theorem fillList_expand_apply [Countable T] :
-    ∀ ss : List (PartialTree ι T), fillList (expand ξ κ) ss = fillList κ ∘ₘ generationList ξ ss
-  | [] => by
-    rw [fillList_nil, generationList_nil, Measure.dirac_bind (Kernel.measurable _), fillList_nil]
-  | s :: ss => by
-    rw [fillList_cons, generationList_cons, fill_expand_apply s, fillList_expand_apply ss,
-      ← Measure.parallelComp_comp_prod, Measure.map_comp _ _ .of_discrete,
-      Measure.bind_map .of_discrete (Kernel.measurable _)]
-    congr 1
-    funext ⟨s', ss'⟩
-    rw [Function.comp_apply, Function.uncurry_apply_pair, fillList_cons,
-      Kernel.map_apply _ .of_discrete, parallelComp_apply]
-end
-
-variable [Countable T]
 
 instance [IsMarkovKernel ξ] [IsMarkovKernel κ] : IsMarkovKernel (expand ξ κ) := by
   rw [expand]; infer_instance
+
+theorem expand_apply' (i : ι) (s : Set (RoseTree ι)) :
+    expand ξ κ i s = ∫⁻ js, fillList κ (js.map hole) (node i ⁻¹' s) ∂ξ i := by
+  rw [expand_apply, Measure.bind_apply .of_discrete (Kernel.aemeasurable _), generation_hole,
+    lintegral_map (Kernel.measurable_coe _ .of_discrete) .of_discrete]
+  simp_rw [fill_inr, Measure.map_apply .of_discrete .of_discrete]
+
+/-- Filling with one more generation is one generation followed by filling. -/
+theorem fill_expand_apply (s : PartialTree ι) : fill (expand ξ κ) s = fill κ ∘ₘ generation ξ s := by
+  induction s using RoseTree.rec' with
+  | node s cs ih =>
+    cases s with
+    | inl i => rw [fill_inl, expand_apply, generation_hole, generation_inl]
+    | inr i =>
+      rw [fill_inr, fillList_apply, List.map_congr_left ih, ← fillList_comp_generationList,
+        generation_inr, Measure.map_bind (Kernel.measurable _) .of_discrete,
+        Measure.bind_map .of_discrete (Kernel.measurable _)]
+      congr 1
+      funext a
+      rw [Function.comp_apply, fill_inr]
 
 /-- Filling with one more generation is one generation followed by filling. -/
 theorem fill_expand : fill (expand ξ κ) = fill κ ∘ₖ generation ξ :=
@@ -348,19 +291,17 @@ end Generation
 
 section Weight
 
-variable (ξ : Kernel ι (List (Symbol T ι)))
+variable (ξ : Kernel ι (List ι))
 
-mutual
-/-- The probability of a finite family tree: the product over its internal nodes of the
-offspring probability of the list of symbols below that node. -/
-noncomputable def weight : DerivationTree T ι → ℝ≥0∞
-  | .leaf _ => 1
-  | .node i cs => ξ i {cs.map rootSymbol} * weightList cs
-/-- The product of the weights of a list of family trees. -/
-noncomputable def weightList : List (DerivationTree T ι) → ℝ≥0∞
-  | [] => 1
-  | c :: cs => weight c * weightList cs
-end
+/-- The probability of a finite family tree: the product over its nodes of the offspring
+probability of the list of types below that node. -/
+noncomputable def weight (t : RoseTree ι) : ℝ≥0∞ := (t.offspring.map fun p => ξ p.1 {p.2}).prod
+
+theorem weight_node (i : ι) (cs : List (RoseTree ι)) :
+    weight ξ (node i cs) = ξ i {cs.map value} * (cs.map (weight ξ)).prod := by
+  simp only [weight, offspring_node, List.map_cons, List.prod_cons, List.map_flatten,
+    List.prod_flatten, List.map_map, Function.comp_def]
+  rfl
 
 end Weight
 
@@ -368,45 +309,34 @@ end Weight
 
 section Law
 
-variable (ξ : Kernel ι (List (Symbol T ι))) [Countable ι] [MeasurableSingletonClass ι]
+variable (ξ : Kernel ι (List ι)) [Countable ι] [MeasurableSingletonClass ι]
 
-mutual
-theorem ωScottContinuous_fill [Countable T] (s : PartialTree ι T) :
-    ωScottContinuous fun κ : ι → Measure (DerivationTree T ι) => fill (ofFunOfCountable κ) s := by
-  cases s with
-  | leaf s =>
+theorem ωScottContinuous_fill (s : PartialTree ι) :
+    ωScottContinuous fun κ : ι → Measure (RoseTree ι) => fill (ofFunOfCountable κ) s := by
+  induction s using RoseTree.rec' with
+  | node s cs ih =>
     cases s with
-    | terminal t => exact ωScottContinuous.const
-    | nonterminal i => exact ωScottContinuous.apply i
-  | node i cs => exact Measure.ωScottContinuous_map (ωScottContinuous_fillList cs) .of_discrete
-theorem ωScottContinuous_fillList [Countable T] (ss : List (PartialTree ι T)) :
-    ωScottContinuous fun κ : ι → Measure (DerivationTree T ι) =>
-      fillList (ofFunOfCountable κ) ss := by
-  cases ss with
-  | nil => exact ωScottContinuous.const
-  | cons s ss =>
-    exact Measure.ωScottContinuous_map
-      (Measure.ωScottContinuous_prod (ωScottContinuous_fill s) (ωScottContinuous_fillList ss))
-      .of_discrete
-end
-
-variable [Countable T]
+    | inl i => exact ωScottContinuous.apply i
+    | inr i =>
+      simp only [fill_inr, fillList_apply]
+      exact Measure.ωScottContinuous_map
+        (Measure.ωScottContinuous_listProd (F := fun c κ => fill (ofFunOfCountable κ) c) ih)
+        .of_discrete
 
 theorem ωScottContinuous_expand :
-    ωScottContinuous fun κ : ι → Measure (DerivationTree T ι) => ⇑(expand ξ (ofFunOfCountable κ)) :=
+    ωScottContinuous fun κ : ι → Measure (RoseTree ι) => ⇑(expand ξ (ofFunOfCountable κ)) :=
   ωScottContinuous.of_apply₂ fun i => by
     simp only [expand_apply]
     exact Measure.ωScottContinuous_bind_right (fun s => ωScottContinuous_fill s) fun _ =>
       Kernel.measurable _
 
 /-- The generation operator on families of laws indexed by type, as an order homomorphism. -/
-noncomputable def expandHom :
-    (ι → Measure (DerivationTree T ι)) →o (ι → Measure (DerivationTree T ι)) :=
+noncomputable def expandHom : (ι → Measure (RoseTree ι)) →o (ι → Measure (RoseTree ι)) :=
   ⟨fun κ => ⇑(expand ξ (ofFunOfCountable κ)), (ωScottContinuous_expand ξ).monotone⟩
 
 /-- The law of the family tree of an individual of each type, on finite trees: the least fixed
 point of the generation operator. Its total mass is the extinction probability. -/
-noncomputable def law : Kernel ι (DerivationTree T ι) := ofFunOfCountable (expandHom ξ).lfp
+noncomputable def law : Kernel ι (RoseTree ι) := ofFunOfCountable (expandHom ξ).lfp
 
 theorem expand_law : expand ξ (law ξ) = law ξ :=
   Kernel.ext fun i => congrFun (expandHom ξ).map_lfp i
@@ -422,7 +352,7 @@ theorem law_eq_iSup_iterate : ⇑(law ξ) = ⨆ n, ⇑((expand ξ)^[n] 0) := by
   simp_rw [coe_iterate_expand]
   exact OrderHom.lfp_eq_iSup_iterate _ fun c => by
     show ⇑(expand ξ (ofFunOfCountable (⨆ n, c n))) = ⨆ n, ⇑(expand ξ (ofFunOfCountable (c n)))
-    rw [← Pi.ωSup_eq_iSup (L := fun _ => Measure (DerivationTree T ι)) c,
+    rw [← Pi.ωSup_eq_iSup (L := fun _ => Measure (RoseTree ι)) c,
       (ωScottContinuous_expand ξ).map_ωSup, Pi.ωSup_eq_iSup]
     rfl
 
@@ -430,73 +360,67 @@ theorem monotone_iterate_expand : Monotone fun n => ⇑((expand ξ)^[n] 0) := by
   simp_rw [coe_iterate_expand]
   exact (expandHom ξ).iterate_bot_mono
 
-theorem law_singleton_of_ne {t : DerivationTree T ι} {i : ι} (h : t.rootSymbol ≠ .nonterminal i) :
-    law ξ i {t} = 0 := by
+theorem law_singleton_of_ne {t : RoseTree ι} {i : ι} (h : t.value ≠ i) : law ξ i {t} = 0 := by
   rw [← expand_law, expand_apply']
-  have : node i ⁻¹' ({t} : Set (DerivationTree T ι)) = ∅ := by
+  have : node i ⁻¹' ({t} : Set (RoseTree ι)) = ∅ := by
     ext cs
     simp only [Set.mem_preimage, Set.mem_singleton_iff, Set.mem_empty_iff_false, iff_false]
     rintro rfl
     exact h rfl
   simp [this]
 
-mutual
+/-- A list of family trees has probability the product of their weights below the holes it
+spells out, given the singleton law for each of them. -/
+theorem fillList_law_map_hole_singleton {cs : List (RoseTree ι)}
+    (h : ∀ c ∈ cs, law ξ c.value {c} = weight ξ c) :
+    fillList (law ξ) ((cs.map value).map hole) {cs} = (cs.map (weight ξ)).prod := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih =>
+    rw [List.map_cons, List.map_cons, fillList_apply, List.map_cons,
+      Measure.listProd_cons_singleton_cons, fill_hole, h c (List.mem_cons_self ..), List.map_cons,
+      List.prod_cons, ← fillList_apply, ih fun d hd => h d (List.mem_cons_of_mem _ hd)]
+
 /-- A family tree of an individual of type `i` has probability `weight` under the law at `i`. -/
-theorem law_singleton_node (i : ι) (cs : List (DerivationTree T ι)) :
-    law ξ i {node i cs} = weight ξ (node i cs) := by
-  rw [← expand_law, expand_apply', weight]
-  have hpre : node i ⁻¹' ({node i cs} : Set (DerivationTree T ι)) = {cs} := by ext; simp
-  have hind : (fun syms => fillList (law ξ) (syms.map leaf) {cs}) =
-      ({cs.map rootSymbol} : Set (List (Symbol T ι))).indicator fun _ => weightList ξ cs := by
-    funext syms
-    by_cases hs : cs.map rootSymbol = syms
-    · subst hs
-      rw [fillList_law_singleton cs, Set.indicator_of_mem (Set.mem_singleton _)]
-    · rw [fillList_map_leaf_singleton_of_ne (fun _ _ => law_singleton_of_ne ξ) _ _ hs,
-        Set.indicator_of_notMem (by simpa using Ne.symm hs)]
-  rw [hpre, hind, lintegral_indicator_const .of_discrete, mul_comm]
-/-- A list of family trees has probability `weightList` below the holes it spells out. -/
-theorem fillList_law_singleton (cs : List (DerivationTree T ι)) :
-    fillList (law ξ) ((cs.map rootSymbol).map leaf) {cs} = weightList ξ cs := by
-  cases cs with
-  | nil => simp [weightList]
-  | cons c cs =>
-    cases c with
-    | leaf t =>
-      rw [List.map_cons, List.map_cons, fillList_cons_singleton_cons, fillList_law_singleton cs,
-        weightList, rootSymbol_leaf, fill_leaf_terminal, weight]
-      simp
-    | node i cs' =>
-      rw [List.map_cons, List.map_cons, fillList_cons_singleton_cons, fillList_law_singleton cs,
-        weightList, rootSymbol, fill_leaf_nonterminal, law_singleton_node i cs']
-end
+theorem law_singleton_value (t : RoseTree ι) : law ξ t.value {t} = weight ξ t := by
+  induction t using RoseTree.rec' with
+  | node i cs ih =>
+    rw [value_node, ← expand_law, expand_apply', weight_node]
+    have hpre : node i ⁻¹' ({node i cs} : Set (RoseTree ι)) = {cs} := by ext; simp
+    have hind : (fun js => fillList (law ξ) (js.map hole) {cs}) =
+        ({cs.map value} : Set (List ι)).indicator fun _ => (cs.map (weight ξ)).prod := by
+      funext js
+      by_cases hs : cs.map value = js
+      · subst hs
+        rw [fillList_law_map_hole_singleton ξ ih, Set.indicator_of_mem (Set.mem_singleton _)]
+      · rw [fillList_map_hole_singleton_of_ne (fun _ _ => law_singleton_of_ne ξ) _ _ hs,
+          Set.indicator_of_notMem (by simpa using Ne.symm hs)]
+    rw [hpre, hind, lintegral_indicator_const .of_discrete, mul_comm]
+
+theorem law_singleton_node (i : ι) (cs : List (RoseTree ι)) :
+    law ξ i {node i cs} = weight ξ (node i cs) :=
+  law_singleton_value ξ (node i cs)
 
 open scoped Classical in
 /-- Under the law at `i`, a finite tree has probability `weight` when its root has type `i`
 and `0` otherwise. -/
-theorem law_singleton (t : DerivationTree T ι) (i : ι) :
-    law ξ i {t} = if t.rootSymbol = .nonterminal i then weight ξ t else 0 := by
+theorem law_singleton (t : RoseTree ι) (i : ι) :
+    law ξ i {t} = if t.value = i then weight ξ t else 0 := by
   split_ifs with h
-  · cases t with
-    | leaf t => simp at h
-    | node j cs =>
-      obtain rfl : i = j := (by simpa using h.symm)
-      exact law_singleton_node ξ i cs
+  · exact h ▸ law_singleton_value ξ t
   · exact law_singleton_of_ne ξ h
 
 /-! ### Extinction -/
 
 variable {ξ}
 
-theorem expand_univ_le_one (hξ : ∀ i, ξ i Set.univ ≤ 1) {κ : Kernel ι (DerivationTree T ι)}
+theorem expand_univ_le_one (hξ : ∀ i, ξ i Set.univ ≤ 1) {κ : Kernel ι (RoseTree ι)}
     (hκ : ∀ i, κ i Set.univ ≤ 1) (i : ι) : expand ξ κ i Set.univ ≤ 1 := by
   rw [expand_apply, Measure.bind_apply .univ (Kernel.aemeasurable _)]
-  calc ∫⁻ s, fill κ s Set.univ ∂generation ξ (leaf (.nonterminal i))
-      ≤ ∫⁻ _, 1 ∂generation ξ (leaf (.nonterminal i)) :=
-        lintegral_mono fun s => fill_univ_le_one hκ s
+  calc ∫⁻ s, fill κ s Set.univ ∂generation ξ (hole i)
+      ≤ ∫⁻ _, 1 ∂generation ξ (hole i) := lintegral_mono fun s => fill_univ_le_one hκ s
     _ = ξ i Set.univ := by
-      rw [lintegral_one, generation_leaf_nonterminal, Measure.map_apply .of_discrete .univ,
-        Set.preimage_univ]
+      rw [lintegral_one, generation_hole, Measure.map_apply .of_discrete .univ, Set.preimage_univ]
     _ ≤ 1 := hξ i
 
 theorem iterate_expand_univ_le_one (hξ : ∀ i, ξ i Set.univ ≤ 1) :
@@ -532,9 +456,9 @@ theorem fill_iterate : ∀ n : ℕ, fill ((expand ξ)^[n] 0) = fill 0 ∘ₖ (ge
 /-- The law of the family tree at type `i` is the supremum over `n` of the completed part of
 `n` synchronous generations from a single hole of type `i`. -/
 theorem law_eq_iSup_generation (i : ι) :
-    law ξ i = ⨆ n, fill 0 ∘ₘ (generation ξ ^ n) (leaf (.nonterminal i)) := by
+    law ξ i = ⨆ n, fill 0 ∘ₘ (generation ξ ^ n) (hole i) := by
   rw [law_eq_iSup_iterate, iSup_apply]
-  exact iSup_congr fun n => by rw [← fill_leaf_nonterminal, fill_iterate, comp_apply]
+  exact iSup_congr fun n => by rw [← fill_hole, fill_iterate, comp_apply]
 
 end Law
 
@@ -542,74 +466,73 @@ end Law
 
 section Chain
 
-variable (ξ : Kernel ι (List (Symbol T ι)))
+variable (ξ : Kernel ι (List ι)) [Countable ι]
 
 /-- The generation chain in Ionescu–Tulcea form: the state at time `n + 1` depends on the
 trajectory up to time `n` only through its last coordinate. -/
 noncomputable def chainKernel (n : ℕ) :
-    Kernel (Π i : Iic n, (fun _ : ℕ => PartialTree ι T) i)
-      ((fun _ : ℕ => PartialTree ι T) (n + 1)) :=
+    Kernel (Π i : Iic n, (fun _ : ℕ => PartialTree ι) i) ((fun _ : ℕ => PartialTree ι) (n + 1)) :=
   (generation ξ).comap (fun x => x ⟨n, mem_Iic.2 le_rfl⟩) (measurable_pi_apply _)
 
-variable [Countable ι] [Countable T] [IsMarkovKernel ξ]
+variable [IsMarkovKernel ξ]
 
 instance (n : ℕ) : IsMarkovKernel (chainKernel ξ n) := IsMarkovKernel.comap _ _
 
 /-- The Ionescu–Tulcea trajectory kernel of the generation chain. -/
 noncomputable def chainTraj (n : ℕ) :
-    Kernel (Π i : Iic n, (fun _ : ℕ => PartialTree ι T) i) (ℕ → PartialTree ι T) :=
-  traj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) n
+    Kernel (Π i : Iic n, (fun _ : ℕ => PartialTree ι) i) (ℕ → PartialTree ι) :=
+  traj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) n
 
 /-- The law of the whole trajectory of generations started at a partial tree. -/
-noncomputable def trajectory (s : PartialTree ι T) : Measure (ℕ → PartialTree ι T) :=
+noncomputable def trajectory (s : PartialTree ι) : Measure (ℕ → PartialTree ι) :=
   chainTraj ξ 0 fun _ => s
 
-instance (s : PartialTree ι T) : IsProbabilityMeasure (trajectory ξ s) :=
+instance (s : PartialTree ι) : IsProbabilityMeasure (trajectory ξ s) :=
   inferInstanceAs (IsProbabilityMeasure
-    (traj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) 0 _))
+    (traj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) 0 _))
 
 /-- At time `n` the generation chain is distributed as `n` synchronous generations. -/
-theorem trajectory_map_eval (s : PartialTree ι T) :
+theorem trajectory_map_eval (s : PartialTree ι) :
     ∀ n : ℕ, (trajectory ξ s).map (fun ω => ω n) = (generation ξ ^ n) s
   | 0 => by
-    have h := traj_map_frestrictLe_apply (X := fun _ : ℕ => PartialTree ι T) (κ := chainKernel ξ)
+    have h := traj_map_frestrictLe_apply (X := fun _ : ℕ => PartialTree ι) (κ := chainKernel ξ)
       0 0 (fun _ => s)
     rw [partialTraj_self, Kernel.id_apply] at h
     show (trajectory ξ s).map (fun ω => ω 0) = Measure.dirac s
     have hm : (trajectory ξ s).map (fun ω => ω 0) = ((trajectory ξ s).map (frestrictLe 0)).map
-        (fun x : Π i : Iic 0, (fun _ : ℕ => PartialTree ι T) i => x ⟨0, mem_Iic.2 le_rfl⟩) :=
+        (fun x : Π i : Iic 0, (fun _ : ℕ => PartialTree ι) i => x ⟨0, mem_Iic.2 le_rfl⟩) :=
       (Measure.map_map (μ := trajectory ξ s) (measurable_pi_apply (⟨0, mem_Iic.2 le_rfl⟩ : Iic 0))
         (measurable_frestrictLe 0)).symm
     rw [hm, show (trajectory ξ s).map (frestrictLe 0) = Measure.dirac (fun _ => s) from h]
     exact Measure.map_dirac _
   | n + 1 => by
-    have hpt : ∀ x : Π i : Iic n, (fun _ : ℕ => PartialTree ι T) i,
-        (traj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) n x).map (fun ω => ω (n + 1)) =
+    have hpt : ∀ x : Π i : Iic n, (fun _ : ℕ => PartialTree ι) i,
+        (traj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) n x).map (fun ω => ω (n + 1)) =
           generation ξ (x ⟨n, mem_Iic.2 le_rfl⟩) := fun x => by
-      rw [← Kernel.map_apply (traj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) n)
+      rw [← Kernel.map_apply (traj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) n)
           (measurable_pi_apply (n + 1)) x,
-        map_traj_succ_self (X := fun _ : ℕ => PartialTree ι T) (κ := chainKernel ξ), chainKernel,
+        map_traj_succ_self (X := fun _ : ℕ => PartialTree ι) (κ := chainKernel ξ), chainKernel,
         comap_apply]
     have hmarg : (trajectory ξ s).map (fun ω => ω n) =
-        (partialTraj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) 0 n (fun _ => s)).map
-          (fun x : Π i : Iic n, (fun _ : ℕ => PartialTree ι T) i => x ⟨n, mem_Iic.2 le_rfl⟩) := by
-      rw [← traj_map_frestrictLe_apply (X := fun _ : ℕ => PartialTree ι T) (κ := chainKernel ξ) 0 n
+        (partialTraj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) 0 n (fun _ => s)).map
+          (fun x : Π i : Iic n, (fun _ : ℕ => PartialTree ι) i => x ⟨n, mem_Iic.2 le_rfl⟩) := by
+      rw [← traj_map_frestrictLe_apply (X := fun _ : ℕ => PartialTree ι) (κ := chainKernel ξ) 0 n
         (fun _ => s)]
       exact (Measure.map_map (μ := trajectory ξ s)
         (measurable_pi_apply (⟨n, mem_Iic.2 le_rfl⟩ : Iic n)) (measurable_frestrictLe n)).symm
-    have hcomp := traj_comp_partialTraj (X := fun _ : ℕ => PartialTree ι T) (κ := chainKernel ξ)
+    have hcomp := traj_comp_partialTraj (X := fun _ : ℕ => PartialTree ι) (κ := chainKernel ξ)
       (Nat.zero_le n)
     calc (trajectory ξ s).map (fun ω => ω (n + 1))
-        = ((partialTraj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) 0 n (fun _ => s)).bind
-            (traj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) n)).map
+        = ((partialTraj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) 0 n (fun _ => s)).bind
+            (traj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) n)).map
               (fun ω => ω (n + 1)) := by
           rw [trajectory, chainTraj, ← hcomp, comp_apply]
-      _ = (partialTraj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) 0 n (fun _ => s)).bind
+      _ = (partialTraj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) 0 n (fun _ => s)).bind
             fun x => generation ξ (x ⟨n, mem_Iic.2 le_rfl⟩) := by
           rw [Measure.map_bind (Kernel.measurable _) (measurable_pi_apply _)]
           simp_rw [hpt]
-      _ = ((partialTraj (X := fun _ : ℕ => PartialTree ι T) (chainKernel ξ) 0 n (fun _ => s)).map
-            (fun x : Π i : Iic n, (fun _ : ℕ => PartialTree ι T) i => x ⟨n, mem_Iic.2 le_rfl⟩)).bind
+      _ = ((partialTraj (X := fun _ : ℕ => PartialTree ι) (chainKernel ξ) 0 n (fun _ => s)).map
+            (fun x : Π i : Iic n, (fun _ : ℕ => PartialTree ι) i => x ⟨n, mem_Iic.2 le_rfl⟩)).bind
               (generation ξ) :=
           (Measure.bind_map (measurable_pi_apply _) (Kernel.measurable _)).symm
       _ = generation ξ ∘ₘ (generation ξ ^ n) s := by rw [← hmarg, trajectory_map_eval s n]

--- a/Linglib/Studies/BresnanEtAl1982.lean
+++ b/Linglib/Studies/BresnanEtAl1982.lean
@@ -42,7 +42,7 @@ conditions on f-structures, and functional control derives the cross-serial asso
 
 namespace BresnanEtAl1982
 
-open DerivationTree Symbol
+open RoseTree Symbol
 
 /-- Leaf classes: a noun phrase or a verb. -/
 inductive Word | np | v
@@ -55,60 +55,61 @@ inductive Cat | S | VP | vBar
 /-! ### The trees -/
 
 /-- The verb cluster of `m + 1` verbs: the right-branching V′ of (22), by V′ → V (V′). -/
-def cluster : ℕ → DerivationTree Word Cat
-  | 0 => .node .vBar [.leaf .v]
-  | m + 1 => .node .vBar [.leaf .v, cluster m]
+def cluster : ℕ → RoseTree (Symbol Word Cat)
+  | 0 => node (nonterminal .vBar) [leaf (terminal .v)]
+  | m + 1 => node (nonterminal .vBar) [leaf (terminal .v), cluster m]
 
 /-- The embedded VP spine of `k + 1` object NPs, by VP → (NP)(VP). -/
-def spine : ℕ → DerivationTree Word Cat
-  | 0 => .node .VP [.leaf .np]
-  | k + 1 => .node .VP [.leaf .np, spine k]
+def spine : ℕ → RoseTree (Symbol Word Cat)
+  | 0 => node (nonterminal .VP) [leaf (terminal .np)]
+  | k + 1 => node (nonterminal .VP) [leaf (terminal .np), spine k]
 
 /-- The VP of (22): the first object, the spine of the remaining `k` objects, and the cluster. -/
-def topVP : ℕ → ℕ → DerivationTree Word Cat
-  | 0, m => .node .VP [.leaf .np, cluster m]
-  | k + 1, m => .node .VP [.leaf .np, spine k, cluster m]
+def topVP : ℕ → ℕ → RoseTree (Symbol Word Cat)
+  | 0, m => node (nonterminal .VP) [leaf (terminal .np), cluster m]
+  | k + 1, m => node (nonterminal .VP) [leaf (terminal .np), spine k, cluster m]
 
 /-- The c-structure (22) of a clause with a subject, `k + 1` object NPs and `m + 1` verbs. -/
-def tree (k m : ℕ) : DerivationTree Word Cat := .node .S [.leaf .np, topVP k m]
+def tree (k m : ℕ) : RoseTree (Symbol Word Cat) :=
+  node (nonterminal .S) [leaf (terminal .np), topVP k m]
 
 /-- The well-formed trees: `n + 1` objects and `n + 2` verbs, each non-final verb with its object.
 (1) is `dutch 0`, (26) is `dutch 1`, (3) is `dutch 2`. -/
-def dutch (n : ℕ) : DerivationTree Word Cat := tree n (n + 1)
+def dutch (n : ℕ) : RoseTree (Symbol Word Cat) := tree n (n + 1)
 
 @[simp] theorem yield_cluster (m : ℕ) : (cluster m).yield = List.replicate (m + 1) .v := by
   induction m with
   | zero => rfl
-  | succ m ih => simp [cluster, yield, yieldList, ih, List.replicate_succ]
+  | succ m ih => simp [cluster, ih, List.replicate_succ]
 
 @[simp] theorem yield_spine (k : ℕ) : (spine k).yield = List.replicate (k + 1) .np := by
   induction k with
   | zero => rfl
-  | succ k ih => simp [spine, yield, yieldList, ih, List.replicate_succ]
+  | succ k ih => simp [spine, ih, List.replicate_succ]
 
 @[simp] theorem yield_topVP (k m : ℕ) :
     (topVP k m).yield = List.replicate (k + 1) .np ++ List.replicate (m + 1) .v := by
-  cases k <;> simp [topVP, yield, yieldList, List.replicate_succ]
+  cases k <;> simp [topVP, List.replicate_succ]
 
 @[simp] theorem yield_tree (k m : ℕ) :
     (tree k m).yield = List.replicate (k + 2) .np ++ List.replicate (m + 1) .v := by
-  simp [tree, yield, yieldList, List.replicate_succ]
+  simp [tree, List.replicate_succ]
 
 theorem yield_dutch (n : ℕ) :
     (dutch n).yield = List.replicate (n + 2) .np ++ List.replicate (n + 2) .v := by
   simp [dutch]
 
-@[simp] theorem rootSymbol_cluster (m : ℕ) : (cluster m).rootSymbol = .nonterminal .vBar := by
+@[simp] theorem value_cluster (m : ℕ) : (cluster m).value = nonterminal .vBar := by
   cases m <;> rfl
 
-@[simp] theorem rootSymbol_spine (k : ℕ) : (spine k).rootSymbol = .nonterminal .VP := by
+@[simp] theorem value_spine (k : ℕ) : (spine k).value = nonterminal .VP := by
   cases k <;> rfl
 
-@[simp] theorem rootSymbol_topVP (k m : ℕ) : (topVP k m).rootSymbol = .nonterminal .VP := by
+@[simp] theorem value_topVP (k m : ℕ) : (topVP k m).value = nonterminal .VP := by
   cases k <;> rfl
 
-theorem cluster_height_pos (m : ℕ) : 1 ≤ (cluster m).height := by
-  cases m <;> simp [cluster, height]
+theorem cluster_height_pos (m : ℕ) : 0 < (cluster m).height := by
+  cases m <;> simp [cluster, leaf]
 
 /-! ### The c-structure grammar -/
 
@@ -129,39 +130,39 @@ def cStructure : ContextFreeGrammar Word where
 theorem cluster_validFor (m : ℕ) : (cluster m).ValidFor cStructure := by
   induction m with
   | zero =>
-    refine .node _ _ (by simp [cStructure]) ?_
-    simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq]; exact .leaf _
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
+    simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq]; exact .terminal _
   | succ m ih =>
-    refine .node _ _ (by simp [cStructure]) ?_
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
     simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
-    exact ⟨.leaf _, ih⟩
+    exact ⟨.terminal _, ih⟩
 
 theorem spine_validFor (k : ℕ) : (spine k).ValidFor cStructure := by
   induction k with
   | zero =>
-    refine .node _ _ (by simp [cStructure]) ?_
-    simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq]; exact .leaf _
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
+    simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq]; exact .terminal _
   | succ k ih =>
-    refine .node _ _ (by simp [cStructure]) ?_
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
     simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
-    exact ⟨.leaf _, ih⟩
+    exact ⟨.terminal _, ih⟩
 
 theorem topVP_validFor (k m : ℕ) : (topVP k m).ValidFor cStructure := by
   cases k with
   | zero =>
-    refine .node _ _ (by simp [cStructure]) ?_
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
     simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
-    exact ⟨.leaf _, cluster_validFor m⟩
+    exact ⟨.terminal _, cluster_validFor m⟩
   | succ k =>
-    refine .node _ _ (by simp [cStructure]) ?_
+    refine .nonterminal _ _ (by simp [cStructure]) ?_
     simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
-    exact ⟨.leaf _, spine_validFor k, cluster_validFor m⟩
+    exact ⟨.terminal _, spine_validFor k, cluster_validFor m⟩
 
 /-- The c-structure grammar generates every tree, whatever its counts of objects and verbs. -/
 theorem tree_validFor_cStructure (k m : ℕ) : (tree k m).ValidFor cStructure := by
-  refine .node _ _ (by simp [cStructure]) ?_
+  refine .nonterminal _ _ (by simp [cStructure]) ?_
   simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
-  exact ⟨.leaf _, topVP_validFor k m⟩
+  exact ⟨.terminal _, topVP_validFor k m⟩
 
 /-! ### The f-structure and its well-formedness -/
 
@@ -173,7 +174,7 @@ structure Spine where
   verbs : ℕ
 
 /-- The spine of a tree: its object NPs (all but the subject) and its verbs. -/
-def Spine.ofTree (t : DerivationTree Word Cat) : Spine :=
+def Spine.ofTree (t : RoseTree (Symbol Word Cat)) : Spine :=
   ⟨t.yield.count .np - 1, t.yield.count .v⟩
 
 @[simp] theorem Spine.ofTree_tree (k m : ℕ) : Spine.ofTree (tree k m) = ⟨k + 1, m + 1⟩ := by
@@ -277,27 +278,27 @@ theorem yield_dutch_mem_weakGrammar (n : ℕ) : (dutch n).yield ∈ weakGrammar.
 /-! ### Strong non-context-freeness -/
 
 /-- The derivation trees of `g` from its start symbol. -/
-def trees (g : ContextFreeGrammar Word) : Set (DerivationTree Word g.NT) :=
-  {t | t.ValidFor g ∧ t.rootSymbol = .nonterminal g.initial}
+def trees (g : ContextFreeGrammar Word) : Set (RoseTree (Symbol Word g.NT)) :=
+  {t | t.ValidFor g ∧ t.value = nonterminal g.initial}
 
 /-- The path from the root down the verb cluster: into the VP, into the V′, then `L` steps along
 the cluster. -/
-def path (L : ℕ) : Pos := 1 :: 2 :: List.replicate L 1
+def path (L : ℕ) : List ℕ := 1 :: 2 :: List.replicate L 1
 
 theorem cluster_subtreeAt_replicate (m r : ℕ) :
-    (cluster (m + r)).subtreeAt? (List.replicate r 1) = some (cluster m) := by
+    (cluster (m + r)).subtreeAt (List.replicate r 1) = some (cluster m) := by
   induction r with
   | zero => rfl
   | succ r ih =>
-    show (cluster (m + r + 1)).subtreeAt? (1 :: List.replicate r 1) = some (cluster m)
-    simp [cluster, subtreeAt?, ih]
+    show (cluster (m + r + 1)).subtreeAt (1 :: List.replicate r 1) = some (cluster m)
+    simp [cluster, ih]
 
 theorem dutch_subtreeAt_take (n L r : ℕ) (hr : r ≤ L) (hL : L ≤ n + 2) :
-    (dutch (n + 1)).subtreeAt? ((path L).take (r + 2)) = some (cluster (n + 2 - r)) := by
+    (dutch (n + 1)).subtreeAt ((path L).take (r + 2)) = some (cluster (n + 2 - r)) := by
   have hp : (path L).take (r + 2) = [1, 2] ++ List.replicate r 1 := by
     simp [path, List.take_replicate, Nat.min_eq_left hr]
-  rw [hp, subtreeAt?_append]
-  have h1 : (dutch (n + 1)).subtreeAt? [1, 2] = some (cluster (n + 2)) := rfl
+  rw [hp, subtreeAt_append]
+  have h1 : (dutch (n + 1)).subtreeAt [1, 2] = some (cluster (n + 2)) := rfl
   rw [h1, Option.bind_some]
   have := cluster_subtreeAt_replicate (n + 2 - r) r
   rwa [Nat.sub_add_cancel (by omega)] at this
@@ -314,78 +315,78 @@ nonterminals to the categories S, VP, V′ — so no finite feature decoration h
 replacing the lower repeat by the upper one gives a valid tree of the same root with more verbs than
 noun phrases, which no `dutch n` has. -/
 theorem not_strongly_contextFree (g : ContextFreeGrammar Word) (ℓ : g.NT → Cat) :
-    map ℓ '' trees g ≠ Set.range dutch := by
+    map (Symbol.mapNonterminal ℓ) '' trees g ≠ Set.range dutch := by
   intro hEq
   set L := g.rules.card with hL
-  have hmem : dutch (L + 1) ∈ map ℓ '' trees g := by rw [hEq]; exact Set.mem_range_self _
+  have hmem : dutch (L + 1) ∈ map (Symbol.mapNonterminal ℓ) '' trees g := by
+    rw [hEq]; exact Set.mem_range_self _
   obtain ⟨t, ⟨ht, hroot⟩, htℓ⟩ := hmem
   -- the subtrees of `t` along the cluster path relabel to clusters
-  have hsub : ∀ r ≤ L, ∃ s, t.subtreeAt? ((path L).take (r + 2)) = some s ∧
-      map ℓ s = cluster (L + 2 - r) := by
+  have hsub : ∀ r ≤ L, ∃ s, t.subtreeAt ((path L).take (r + 2)) = some s ∧
+      map (Symbol.mapNonterminal ℓ) s = cluster (L + 2 - r) := by
     intro r hr
     have h := dutch_subtreeAt_take L L r hr (by omega)
-    rw [← htℓ, subtreeAt?_map] at h
+    rw [← htℓ, subtreeAt_map] at h
     exact Option.map_eq_some_iff.mp h
   -- the category of the subtree of `t` at each depth along the path
-  have hcat : ∀ k ≤ L + 2, ∀ nt cs, t.subtreeAt? ((path L).take k) = some (.node nt cs) →
-      ℓ nt = catAt k := by
+  have hcat : ∀ k ≤ L + 2, ∀ nt cs,
+      t.subtreeAt ((path L).take k) = some (node (nonterminal nt) cs) → ℓ nt = catAt k := by
     intro k hk nt cs h
-    have hm := congrArg (Option.map (map ℓ)) h
-    rw [← subtreeAt?_map, htℓ] at hm
-    have key : ∀ d : DerivationTree Word Cat,
-        (dutch (L + 1)).subtreeAt? ((path L).take k) = some d →
-          d.rootSymbol = .nonterminal (catAt k) := by
+    have hm := congrArg (Option.map (map (Symbol.mapNonterminal ℓ))) h
+    rw [← subtreeAt_map, htℓ] at hm
+    have key : ∀ d : RoseTree (Symbol Word Cat),
+        (dutch (L + 1)).subtreeAt ((path L).take k) = some d →
+          d.value = nonterminal (catAt k) := by
       match k, hk with
       | 0, _ =>
         intro d hd
-        simp only [List.take_zero, subtreeAt?, Option.some.injEq] at hd
+        simp only [List.take_zero, subtreeAt_nil, Option.some.injEq] at hd
         subst hd; rfl
       | 1, _ =>
         intro d hd
-        have h1 : (dutch (L + 1)).subtreeAt? ((path L).take 1) = some (topVP (L + 1) (L + 2)) :=
+        have h1 : (dutch (L + 1)).subtreeAt ((path L).take 1) = some (topVP (L + 1) (L + 2)) :=
           rfl
         rw [h1, Option.some.injEq] at hd
-        subst hd; exact rootSymbol_topVP _ _
+        subst hd; exact value_topVP _ _
       | r + 2, hk =>
         intro d hd
         rw [dutch_subtreeAt_take L L r (by omega) (by omega), Option.some.injEq] at hd
-        subst hd; exact rootSymbol_cluster _
+        subst hd; exact value_cluster _
     simpa using key _ hm
   -- pigeonhole along the cluster path
   obtain ⟨sL, hsL, hsLℓ⟩ := hsub L le_rfl
   have hpath : (path L).take (L + 2) = path L := List.take_of_length_le (by simp [path])
   rw [hpath] at hsL
-  have hsLh : sL.height ≥ 1 := by rw [← height_map ℓ, hsLℓ]; exact cluster_height_pos _
-  obtain ⟨i, j, hij, hjle, ntᵢ, cᵢ, ntⱼ, cⱼ, hi, hj, hnt⟩ :=
-    exists_repeat_root t ht (path L) sL hsL hsLh
-      (by simp only [path, List.length_cons, List.length_replicate]; omega)
+  have hsLh : 0 < sL.height := by
+    rw [← height_map (Symbol.mapNonterminal ℓ), hsLℓ]; exact cluster_height_pos _
+  obtain ⟨i, j, hij, hjle, A, cᵢ, cⱼ, hi, hj⟩ :=
+    ht.exists_repeat hsL hsLh (by simp only [path, List.length_cons, List.length_replicate]; omega)
   simp only [path, List.length_cons, List.length_replicate] at hjle
   -- both repeats lie in the cluster
-  have hcati := hcat i (by omega) ntᵢ cᵢ hi
-  have hcatj := hcat j (by omega) ntⱼ cⱼ hj
+  have hcati := hcat i (by omega) A cᵢ hi
+  have hcatj := hcat j (by omega) A cⱼ hj
   have hi2 : 2 ≤ i := by
-    have hc : catAt i = catAt j := by rw [← hcati, ← hcatj, hnt]
+    have hc : catAt i = catAt j := by rw [← hcati, ← hcatj]
     rcases i with _ | _ | i <;> rcases j with _ | _ | j <;> simp [catAt] at hc <;> omega
   -- the pumped tree
-  set t' := t.replaceAt ((path L).take j) (.node ntᵢ cᵢ) with ht'
-  have hvalid : t'.ValidFor g :=
-    validFor_replaceAt t _ _ _ hj (by simp [rootSymbol, hnt]) ht (subtreeAt?_validFor t ht _ _ hi)
-  have hroot' : t'.rootSymbol = .nonterminal g.initial := by
+  set t' := t.replaceAt ((path L).take j) (node (nonterminal A) cᵢ) with ht'
+  have hvalid : t'.ValidFor g := ht.replaceAt hj (ht.subtreeAt hi) rfl
+  have hroot' : t'.value = nonterminal g.initial := by
     obtain ⟨j', rfl⟩ : ∃ j', j = j' + 1 := ⟨j - 1, by omega⟩
-    rw [ht', path, List.take_succ_cons, rootSymbol_replaceAt_cons]; exact hroot
-  have hmem' : map ℓ t' ∈ Set.range dutch := by
+    rw [ht', path, List.take_succ_cons, value_replaceAt_cons]; exact hroot
+  have hmem' : map (Symbol.mapNonterminal ℓ) t' ∈ Set.range dutch := by
     rw [← hEq]; exact Set.mem_image_of_mem _ ⟨hvalid, hroot'⟩
   obtain ⟨m, hm⟩ := hmem'
   -- yields: the pumped tree has `j - i` more verbs than noun phrases
-  obtain ⟨pre, post, hy, hy'⟩ := yield_replaceAt_decomp t _ _ hj
+  obtain ⟨pre, post, hy, hy'⟩ := yield_replaceAt hj
   obtain ⟨sᵢ, hsᵢ, hsᵢℓ⟩ := hsub (i - 2) (by omega)
   obtain ⟨sⱼ, hsⱼ, hsⱼℓ⟩ := hsub (j - 2) (by omega)
   rw [show i - 2 + 2 = i by omega, hi, Option.some.injEq] at hsᵢ
   rw [show j - 2 + 2 = j by omega, hj, Option.some.injEq] at hsⱼ
   subst hsᵢ hsⱼ
-  have hyi : (DerivationTree.node ntᵢ cᵢ).yield = List.replicate (L + 2 - (i - 2) + 1) .v := by
+  have hyi : (node (nonterminal A) cᵢ).yield = List.replicate (L + 2 - (i - 2) + 1) .v := by
     rw [← yield_map ℓ, hsᵢℓ, yield_cluster]
-  have hyj : (DerivationTree.node ntⱼ cⱼ).yield = List.replicate (L + 2 - (j - 2) + 1) .v := by
+  have hyj : (node (nonterminal A) cⱼ).yield = List.replicate (L + 2 - (j - 2) + 1) .v := by
     rw [← yield_map ℓ, hsⱼℓ, yield_cluster]
   have hyt : t.yield = List.replicate (L + 3) .np ++ List.replicate (L + 3) .v := by
     rw [← yield_map ℓ, htℓ, yield_dutch]
@@ -393,8 +394,8 @@ theorem not_strongly_contextFree (g : ContextFreeGrammar Word) (ℓ : g.NT → C
     rw [← yield_map ℓ, ← hm, yield_dutch]
   have hnp := congrArg (List.count Word.np) hy
   have hv := congrArg (List.count Word.v) hy
-  have hnp' := congrArg (List.count Word.np) (hy' (.node ntᵢ cᵢ))
-  have hv' := congrArg (List.count Word.v) (hy' (.node ntᵢ cᵢ))
+  have hnp' := congrArg (List.count Word.np) (hy' (node (nonterminal A) cᵢ))
+  have hv' := congrArg (List.count Word.v) (hy' (node (nonterminal A) cᵢ))
   rw [hyt, hyj] at hnp hv
   rw [← ht', hyt', hyi] at hnp' hv'
   simp [List.count_replicate] at hnp hv hnp' hv'

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -170,11 +170,11 @@ noncomputable def pypFactor (a : G.NT) (Y : TableAssignment G) : ℝ :=
 
 /-- The corpus probability given a table assignment: at each nonterminal the grammar expands,
 the Dirichlet PCFG factor times the Pitman–Yor factor. -/
-noncomputable def corpusProbGivenTables (D : Multiset (DerivationTree T G.NT))
+noncomputable def corpusProbGivenTables (D : Multiset (RoseTree (Symbol T G.NT)))
     (Y : TableAssignment G) : ℝ :=
   ∏ a ∈ G.rules.image (·.input), M.toDirichletPCFG.lhsFactor a D * M.pypFactor a Y
 
-theorem corpusProbGivenTables_nonneg (D : Multiset (DerivationTree T G.NT))
+theorem corpusProbGivenTables_nonneg (D : Multiset (RoseTree (Symbol T G.NT)))
     (Y : TableAssignment G) : 0 ≤ M.corpusProbGivenTables D Y :=
   Finset.prod_nonneg λ a ha => mul_nonneg (M.toDirichletPCFG.lhsFactor_pos ha D).le
     ((M.pyp a).partitionProb_nonneg _)
@@ -197,14 +197,14 @@ theorem corpusProbGivenTables_empty : M.corpusProbGivenTables 0 (emptyTables G) 
 
 /-- The conjugate update of the Dirichlet component by a corpus; the Pitman–Yor
 hyperparameters are unchanged. -/
-noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : AdaptorGrammar G :=
+noncomputable def posterior (D : Multiset (RoseTree (Symbol T G.NT))) : AdaptorGrammar G :=
   { M with toDirichletPCFG := M.toDirichletPCFG.posterior D }
 
 @[simp]
 theorem posterior_zero : M.posterior 0 = M := by
   ext1 <;> simp [posterior]
 
-theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
+theorem posterior_add (D₁ D₂ : Multiset (RoseTree (Symbol T G.NT))) :
     M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
   ext1 <;> simp [posterior, DirichletPCFG.posterior_add]
 
@@ -248,11 +248,11 @@ variable (M : FragmentGrammar G)
 /-- The corpus probability given a table assignment `Y` and halt counts `Z`: the
 adaptor-grammar factor times, at each nonterminal slot, the urn likelihood of the decisions
 taken there. -/
-noncomputable def corpusProbGivenStorage (D : Multiset (DerivationTree T G.NT))
+noncomputable def corpusProbGivenStorage (D : Multiset (RoseTree (Symbol T G.NT)))
     (Y : AdaptorGrammar.TableAssignment G) (Z : HaltCounts G) : ℝ :=
   M.corpusProbGivenTables D Y * ∏ r ∈ G.rules, ∏ i, (M.halt r i).seqProb (Z r i)
 
-theorem corpusProbGivenStorage_nonneg (D : Multiset (DerivationTree T G.NT))
+theorem corpusProbGivenStorage_nonneg (D : Multiset (RoseTree (Symbol T G.NT)))
     (Y : AdaptorGrammar.TableAssignment G) (Z : HaltCounts G) :
     0 ≤ M.corpusProbGivenStorage D Y Z :=
   mul_nonneg (M.corpusProbGivenTables_nonneg D Y) <| Finset.prod_nonneg λ r _ =>
@@ -266,7 +266,7 @@ theorem corpusProbGivenStorage_empty :
 
 /-- The conjugate update by a corpus `D` and its halt counts `Z`: the adaptor-grammar component
 absorbs the rule counts of `D`, and the urn at each slot absorbs the decisions taken there. -/
-noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) (Z : HaltCounts G) :
+noncomputable def posterior (D : Multiset (RoseTree (Symbol T G.NT))) (Z : HaltCounts G) :
     FragmentGrammar G where
   toAdaptorGrammar := M.toAdaptorGrammar.posterior D
   halt r i := (M.halt r i).posterior (Z r i)
@@ -275,7 +275,7 @@ noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) (Z : HaltCoun
 theorem posterior_zero : M.posterior 0 0 = M := by
   ext1 <;> simp [posterior]
 
-theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) (Z₁ Z₂ : HaltCounts G) :
+theorem posterior_add (D₁ D₂ : Multiset (RoseTree (Symbol T G.NT))) (Z₁ Z₂ : HaltCounts G) :
     M.posterior (D₁ + D₂) (Z₁ + Z₂) = (M.posterior D₁ Z₁).posterior D₂ Z₂ := by
   ext1 <;> simp [posterior, AdaptorGrammar.posterior_add, PolyaUrn.posterior_add]
 
@@ -415,13 +415,13 @@ theorem suffixPrior_pseudo_respects_productivity
     than the pseudo-count gap of `1` ranks `rIon` above `rNess`, against
     `moreProductiveThan ness ion`. The CELEX token gap is an order of magnitude larger than the
     hypothesis requires. -/
-theorem suffixPrior_predictive_lt_of_count_gap (D : Multiset (DerivationTree Sym SuffixNT))
-    (h : DerivationTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
-         DerivationTree.corpusRuleCount (N := SuffixNT) rIon D) :
+theorem suffixPrior_predictive_lt_of_count_gap (D : Multiset (RoseTree (Symbol Sym SuffixNT)))
+    (h : RoseTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
+         RoseTree.corpusRuleCount (N := SuffixNT) rIon D) :
     suffixPrior.predictive rNess D < suffixPrior.predictive rIon D := by
   refine (suffixPrior.predictive_lt_iff_of_same_lhs (r := rNess) (r' := rIon) (by decide) rfl).2 ?_
-  have h' : (DerivationTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) + 1 <
-      DerivationTree.corpusRuleCount (N := SuffixNT) rIon D := by exact_mod_cast h
+  have h' : (RoseTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) + 1 <
+      RoseTree.corpusRuleCount (N := SuffixNT) rIon D := by exact_mod_cast h
   show pseudoVal rNess + _ < pseudoVal rIon + _
   rw [pseudoVal_rNess, pseudoVal_rIon]
   linarith
@@ -433,8 +433,8 @@ theorem suffixPrior_predictive_prior_lt :
     suffixPrior.predictive rIon 0 < suffixPrior.predictive rNess 0 := by
   refine (suffixPrior.predictive_lt_iff_of_same_lhs (r := rIon) (r' := rNess) (by decide) rfl).2 ?_
   show pseudoVal rIon + _ < pseudoVal rNess + _
-  rw [pseudoVal_rIon, pseudoVal_rNess, DerivationTree.corpusRuleCount_zero,
-    DerivationTree.corpusRuleCount_zero]
+  rw [pseudoVal_rIon, pseudoVal_rNess, RoseTree.corpusRuleCount_zero,
+    RoseTree.corpusRuleCount_zero]
   norm_num
 
 /-- The same prior comparison as a fact about the predictive PCFG, the point estimate the
@@ -449,9 +449,9 @@ theorem suffixPrior_predictivePCFG_prior_lt :
 /-- The Chapter 7 critique of the Dirichlet PCFG in one theorem: right without data, wrong once
     `-ion` tokens dominate. The fix the book proposes, the fragment grammar, gives a posterior
     that does not collapse productivity into raw frequency. -/
-theorem suffixPrior_prior_and_posterior_disagree (D : Multiset (DerivationTree Sym SuffixNT))
-    (h : DerivationTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
-         DerivationTree.corpusRuleCount (N := SuffixNT) rIon D) :
+theorem suffixPrior_prior_and_posterior_disagree (D : Multiset (RoseTree (Symbol Sym SuffixNT)))
+    (h : RoseTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
+         RoseTree.corpusRuleCount (N := SuffixNT) rIon D) :
     suffixPrior.predictive rIon 0 < suffixPrior.predictive rNess 0 ∧
       suffixPrior.predictive rNess D < suffixPrior.predictive rIon D :=
   ⟨suffixPrior_predictive_prior_lt, suffixPrior_predictive_lt_of_count_gap D h⟩


### PR DESCRIPTION
`DerivationTree T N` is dissolved into `RoseTree (Symbol T N)`, so derivation trees, Galton–Watson family trees and the existing rose-tree API are one type.

- `Tree.lean`: `yield`, `ValidFor`, `ruleCount`, `ruleAt?`, soundness/completeness and the pumping ingredients on `RoseTree (Symbol T N)`; generic structure (`offspring`, `leafList`, `replaceAt`, Gorn-address height/size lemmas, `Countable`) moves to `Core/Data/RoseTree/`
- Galton–Watson over types only: `ξ : Kernel ι (List ι)`, family trees `RoseTree ι`, `weight` as a product over `offspring`, no `mutual` blocks; `Measure.listProd` and the discrete σ-algebra on lists in `Core/MeasureTheory/Constructions/List.lean`
- PCFG instance takes `ι := Symbol T G.NT` (terminals have offspring `dirac []`), `derivProb` is the same product, `derivationMeasure` a kernel on symbols; pumping lemma and BresnanEtAl1982 ported