### PR TITLE
refactor(Core/Computability): cleanse the CFG closure proofs

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/InterRegular.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/InterRegular.lean
@@ -1,866 +1,335 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Computability.ContextFreeGrammar
 import Linglib.Core.Computability.ContextFreeGrammar.Map
 import Mathlib.Computability.DFA
-import Mathlib.Data.Fintype.Pi
 
 /-!
-# Closure of `IsContextFree` under intersection with regular languages
+# Context-free languages are closed under intersection with regular languages
 
-The intersection of a context-free language `L` with a regular language `R` is
-context-free. Headline theorem in [hopcroft-motwani-ullman-2000]
-Theorem 7.27 (p. 286); originally proved in [bar-hillel-perles-shamir-1961].
+The intersection of a context-free language with a regular language is context-free
+([bar-hillel-perles-shamir-1961]). The construction is the triple product: the nonterminals of
+the product grammar are the nonterminals of `G` annotated with an entry and an exit state of the
+automaton `M`, and a rule of `G` yields one product rule for every way of threading the states
+of `M` through its right-hand side. A fresh start symbol rewrites to the start nonterminal of `G`
+between the start state and each accepting state of `M`.
 
-Two textbook constructions exist for this theorem:
+## Main definitions
 
-1. **PDA-product** (HMU 2000 §7.3.4): take a PDA `P` for `L` and a DFA `A` for
-   `R`, build a single PDA `P'` with state set `Q_P × Q_A` running them in
-   lockstep. Cleaner and shorter than (2), but requires PDA infrastructure
-   (PDA type + bidirectional CFG↔PDA equivalence) which mathlib does not
-   currently have.
+* `ContextFreeGrammar.Annotates`: `Annotates M p l out q` says that the sentential form `l` of
+  the product grammar is `out` with its nonterminals annotated so that the states of `M` thread
+  from `p` to `q`.
+* `ContextFreeGrammar.product`: the product of a grammar with a finite automaton.
 
-2. **Grammar-level Bar-Hillel triple-product** (BPS 1961, the original):
-   build a new CFG `G'` directly from `G` and `A`, with state-pair-annotated
-   nonterminals `Q × V × Q ⊕ Unit`. Heavier construction (more rules, more
-   bookkeeping) but reachable from mathlib's `ContextFreeGrammar` substrate
-   without adding PDAs. **This file mechanizes (2).** If mathlib later gains
-   `Mathlib.Computability.PushdownAutomaton`, an alternate proof via (1)
-   becomes available; this construction stays as the direct grammar-level
-   proof.
+## Main results
 
-The (2) construction:
-* **Start rules**: for each accepting state `qf ∈ F`, a rule
-  `inr () → [.nonterminal (.inl (q₀, S, qf))]`. The `inr ()` start symbol
-  branches into "the input must drive M from `q₀` to some accepting `qf`."
-* **Derivation rules**: for each `G`-rule `A → β` and each path of intermediate
-  states `q₀, q₁, ..., qₖ` through the nonterminals of `β`, a rule
-  `(p, A, q) → annotate β` where the annotated body tracks state transitions
-  through terminals (deterministic) and nonterminals (chosen path).
+* `ContextFreeGrammar.product_language`: the product generates the intersection.
+* `Language.IsContextFree.inter_isRegular`: closure under intersection with a regular language,
+  and its contrapositives `Language.not_isContextFree_of_inter_regular_not` and the proof
+  schema `Language.not_isContextFree_via_witness` of [shieber-1985], which first pushes the
+  language through a string homomorphism.
 
-Owns the `ContextFreeGrammar.product` definition and proves
-`Language.IsContextFree.inter_isRegular`, together with the contrapositives that
-non-context-freeness arguments use: `Language.not_isContextFree_of_inter_regular_not`,
-and, with the homomorphism closure of `Map.lean`, the Bar-Hillel proof schema
-`Language.not_isContextFree_via_witness` of [shieber-1985].
+## References
+
+* [bar-hillel-perles-shamir-1961]
+* [hopcroft-motwani-ullman-2000]
+* [shieber-1985]
 -/
-
-universe u
-
-variable {T : Type u}
-
--- ============================================================================
--- The Bar-Hillel construction: product of a CFG with a DFA
--- ============================================================================
 
 open scoped Classical
 
 namespace ContextFreeGrammar
 
-variable {σ : Type}
+variable {T : Type*} {σ : Type} {G : ContextFreeGrammar T} (M : DFA T σ)
 
-/-- The product nonterminal type: state-pair-annotated G-nonterminals plus a
-    fresh start symbol `inr ()`. Defined as `def` (not `abbrev`) to keep the
-    type display stable through `(G.product M).NT` projections. -/
-def productNT (G : ContextFreeGrammar T) (σ : Type) : Type := σ × G.NT × σ ⊕ Unit
+/-- The nonterminals of the product grammar: a nonterminal of `G` between an entry and an exit
+state of the automaton, or the fresh start symbol `none`. -/
+abbrev ProductNT (G : ContextFreeGrammar T) (σ : Type) := Option (σ × G.NT × σ)
 
-/-- Count the number of nonterminal symbols in a list of symbols. -/
-def nonterminalCount {N : Type*} (out : List (Symbol T N)) : ℕ :=
-  out.countP (fun s => match s with | .nonterminal _ => true | _ => false)
+/-- `Annotates M p l out q`: the sentential form `l` of the product grammar is `out` with every
+nonterminal `A` replaced by some `some (p', A, q')`, the states threading from `p` to `q`: a
+terminal advances the automaton, and an annotated nonterminal jumps from its entry state to its
+exit state. -/
+inductive Annotates : σ → List (Symbol T (ProductNT G σ)) → List (Symbol T G.NT) → σ → Prop
+  | nil (p : σ) : Annotates p [] [] p
+  | terminal {p q : σ} (a : T) {l : List (Symbol T (ProductNT G σ))} {out : List (Symbol T G.NT)}
+      (h : Annotates (M.step p a) l out q) : Annotates p (.terminal a :: l) (.terminal a :: out) q
+  | nonterminal {p p' q : σ} (A : G.NT) {l : List (Symbol T (ProductNT G σ))}
+      {out : List (Symbol T G.NT)} (h : Annotates p' l out q) :
+      Annotates p (.nonterminal (some (p, A, p')) :: l) (.nonterminal A :: out) q
 
-/-- Annotate `out` from start state `start`, using `path` as the chosen exit
-    states for nonterminals (in order). Returns the end state and annotated
-    output. If `path` is too short, falls back to `start` for missing exit
-    states (those configurations don't produce well-formed Bar-Hillel rules and
-    are filtered out by the rule-generation enumeration). -/
-def annotateOutput {G : ContextFreeGrammar T} (M : DFA T σ) :
-    σ → List (Symbol T G.NT) → List σ →
-    σ × List (Symbol T (productNT G σ))
-  | start, [], _ => (start, [])
-  | start, .terminal a :: rest, path =>
-    let res := annotateOutput M (M.step start a) rest path
-    (res.1, .terminal a :: res.2)
-  | start, .nonterminal A :: rest, q :: path_rest =>
-    let res := annotateOutput M q rest path_rest
-    (res.1, .nonterminal (.inl (start, A, q)) :: res.2)
-  | start, .nonterminal A :: rest, [] =>
-    let res := annotateOutput M start rest []
-    (res.1, .nonterminal (.inl (start, A, start)) :: res.2)
+namespace Annotates
 
-/-- The G' rule for a chosen `(start, path)` of state choices applied to a
-    G-rule `r`. -/
-def generatedRule {G : ContextFreeGrammar T} (M : DFA T σ) (r : ContextFreeRule T G.NT)
-    (start : σ) (path : List σ) : ContextFreeRule T (productNT G σ) :=
-  let res := annotateOutput M start r.output path
-  { input := .inl (start, r.input, res.1), output := res.2 }
+variable {M} {p q r : σ} {l l₁ l₂ : List (Symbol T (ProductNT G σ))}
+  {out out₁ out₂ : List (Symbol T G.NT)}
 
-/-- All G' rules generated from a single G-rule. Enumerates over all
-    `(start, path)` with `path` a list of length `nonterminalCount r.output`. -/
-noncomputable def rulesFromRule {G : ContextFreeGrammar T} (M : DFA T σ)
-    [Fintype σ] [DecidableEq σ] (r : ContextFreeRule T G.NT) :
-    Finset (ContextFreeRule T (productNT G σ)) :=
-  (Finset.univ : Finset (σ × (Fin (nonterminalCount r.output) → σ))).image fun sp =>
-    generatedRule M r sp.1 (List.ofFn sp.2)
-
-/-- The start rules: for each accepting state `qf`, branch the start symbol
-    `.inr ()` into `[.nonterminal (.inl (M.start, G.initial, qf))]`. -/
-noncomputable def startRules (M : DFA T σ) [Fintype σ] (G : ContextFreeGrammar T) :
-    Finset (ContextFreeRule T (productNT G σ)) :=
-  ((Finset.univ : Finset σ).filter (· ∈ M.accept)).image fun qf =>
-    { input := .inr (),
-      output := [.nonterminal (.inl (M.start, G.initial, qf))] }
-
-/-- The Bar-Hillel triple-product CFG: generates `G.language ∩ M.accepts`. -/
-noncomputable def product [Fintype σ] [DecidableEq σ]
-    (G : ContextFreeGrammar T) (M : DFA T σ) :
-    ContextFreeGrammar T where
-  NT := productNT G σ
-  initial := .inr ()
-  rules := startRules M G ∪ G.rules.biUnion (rulesFromRule M)
-
-end ContextFreeGrammar
-
--- ============================================================================
--- Projects: G' symbol-list projects to G symbol-list.
--- Used in the forward direction to recover the underlying G-derivation.
--- ============================================================================
-
-/-- A G' symbol-list `s'` projects to a G symbol-list `s` if every `.terminal`
-    matches and every `.nonterminal (.inl (_, A, _))` projects to
-    `.nonterminal A`. The constructor doesn't allow `.nonterminal (.inr ())`,
-    enforcing that projection is only defined for "post-start" sentential
-    forms. -/
-inductive Projects {G : ContextFreeGrammar T} {σ : Type} :
-    List (Symbol T (ContextFreeGrammar.productNT G σ)) →
-    List (Symbol T G.NT) → Prop
-  | nil : Projects [] []
-  | terminal {a : T} {rest : List _} {rest' : List _} (h : Projects rest rest') :
-      Projects (.terminal a :: rest) (.terminal a :: rest')
-  | nonterminal {p : σ} {A : G.NT} {q : σ} {rest : List _} {rest' : List _}
-      (h : Projects rest rest') :
-      Projects (.nonterminal (.inl (p, A, q)) :: rest) (.nonterminal A :: rest')
-
-namespace Projects
-
-variable {G : ContextFreeGrammar T} {σ : Type}
-
-/-- Projection respects concatenation. -/
-lemma append {s'₁ s'₂ : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    {s₁ s₂ : List (Symbol T G.NT)}
-    (h₁ : Projects s'₁ s₁) (h₂ : Projects s'₂ s₂) :
-    Projects (s'₁ ++ s'₂) (s₁ ++ s₂) := by
+theorem append (h₁ : Annotates M p l₁ out₁ q) (h₂ : Annotates M q l₂ out₂ r) :
+    Annotates M p (l₁ ++ l₂) (out₁ ++ out₂) r := by
   induction h₁ with
-  | nil => simpa using h₂
-  | terminal _ ih => exact .terminal ih
-  | nonterminal _ ih => exact .nonterminal ih
-
-/-- A projection of `s'` to a concatenation `s₁ ++ s₂` decomposes accordingly. -/
-lemma split_right {s' : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    {s₁ s₂ : List (Symbol T G.NT)} (h : Projects s' (s₁ ++ s₂)) :
-    ∃ s'₁ s'₂, s' = s'₁ ++ s'₂ ∧ Projects s'₁ s₁ ∧ Projects s'₂ s₂ := by
-  induction s₁ generalizing s' with
-  | nil => exact ⟨[], s', by simp, .nil, by simpa using h⟩
-  | cons head s₁_rest ih =>
-    rw [List.cons_append] at h
-    cases h with
-    | @terminal a rest rest' h_rest =>
-      obtain ⟨s'₁, s'₂, hs'_eq, hp₁, hp₂⟩ := ih h_rest
-      refine ⟨.terminal a :: s'₁, s'₂, ?_, .terminal hp₁, hp₂⟩
-      simp [hs'_eq]
-    | @nonterminal p A q rest rest' h_rest =>
-      obtain ⟨s'₁, s'₂, hs'_eq, hp₁, hp₂⟩ := ih h_rest
-      refine ⟨.nonterminal (.inl (p, A, q)) :: s'₁, s'₂, ?_, .nonterminal hp₁, hp₂⟩
-      simp [hs'_eq]
-
-/-- A projection from a concatenation `s'₁ ++ s'₂` to `s` decomposes the target
-    correspondingly. -/
-lemma split_left {s : List (Symbol T G.NT)}
-    {s'₁ s'₂ : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    (h : Projects (s'₁ ++ s'₂) s) :
-    ∃ s₁ s₂, s = s₁ ++ s₂ ∧ Projects s'₁ s₁ ∧ Projects s'₂ s₂ := by
-  induction s'₁ generalizing s with
-  | nil =>
-    refine ⟨[], s, by simp, .nil, ?_⟩
-    simpa using h
-  | cons head s'₁_rest ih =>
-    rw [List.cons_append] at h
-    cases h with
-    | @terminal a rest rest' h_rest =>
-      obtain ⟨s₁, s₂, hs_eq, hp₁, hp₂⟩ := ih h_rest
-      refine ⟨.terminal a :: s₁, s₂, ?_, .terminal hp₁, hp₂⟩
-      simp [hs_eq]
-    | @nonterminal p A q rest rest' h_rest =>
-      obtain ⟨s₁, s₂, hs_eq, hp₁, hp₂⟩ := ih h_rest
-      refine ⟨.nonterminal A :: s₁, s₂, ?_, .nonterminal hp₁, hp₂⟩
-      simp [hs_eq]
-
-/-- The projection of a list of terminals (G'-side) to the same list of terminals (G-side). -/
-lemma map_terminal (w : List T) :
-    Projects (w.map (Symbol.terminal (N := ContextFreeGrammar.productNT G σ)))
-             (w.map (Symbol.terminal (N := G.NT))) := by
-  induction w with
-  | nil => exact .nil
-  | cons a w' ih => exact .terminal ih
-
-/-- If `s'` projects to `w.map .terminal`, then `s'` is itself a list of
-    terminals (matching `w`). -/
-lemma eq_map_terminal_of_projects {s' : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    {w : List T} (h : Projects s' (w.map .terminal)) :
-    s' = w.map .terminal := by
-  induction w generalizing s' with
-  | nil =>
-    cases h
-    rfl
-  | cons a w' ih =>
-    rw [List.map_cons] at h
-    cases h with
-    | terminal h_rest =>
-      rw [List.map_cons]
-      simp [ih h_rest]
-
-end Projects
-
--- ============================================================================
--- Consistent: a G' symbol-list traces a DFA path from `p` to `q`.
--- ============================================================================
-
-/-- A G' symbol-list is `Consistent M p s' q` if walking through it from state
-    `p` (advancing via `M.step` for terminals, jumping via the nonterminal's
-    annotated state pair) ends at state `q`. -/
-inductive Consistent {G : ContextFreeGrammar T} {σ : Type} (M : DFA T σ) :
-    σ → List (Symbol T (ContextFreeGrammar.productNT G σ)) → σ → Prop
-  | nil (p : σ) : Consistent M p [] p
-  | terminal {p q : σ} (a : T) {rest : List _}
-      (h : Consistent M (M.step p a) rest q) :
-      Consistent M p (.terminal a :: rest) q
-  | nonterminal {p p' q : σ} (A : G.NT) {rest : List _}
-      (h : Consistent M p' rest q) :
-      Consistent M p (.nonterminal (.inl (p, A, p')) :: rest) q
-
-namespace Consistent
-
-variable {G : ContextFreeGrammar T} {σ : Type} {M : DFA T σ}
-
-/-- Consistency composes along concatenation. -/
-lemma append {p q r : σ}
-    {s'₁ s'₂ : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    (h₁ : Consistent M p s'₁ q) (h₂ : Consistent M q s'₂ r) :
-    Consistent M p (s'₁ ++ s'₂) r := by
-  induction h₁ with
-  | nil _ => simpa using h₂
+  | nil => exact h₂
   | terminal a _ ih => exact .terminal a (ih h₂)
   | nonterminal A _ ih => exact .nonterminal A (ih h₂)
 
-/-- Consistency splits along concatenation. -/
-lemma split {p r : σ}
-    {s'₁ s'₂ : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    (h : Consistent M p (s'₁ ++ s'₂) r) :
-    ∃ q, Consistent M p s'₁ q ∧ Consistent M q s'₂ r := by
-  induction s'₁ generalizing p with
-  | nil => exact ⟨p, .nil p, by simpa using h⟩
-  | cons head s'₁_rest ih =>
-    rw [List.cons_append] at h
+/-- An annotation of a concatenation splits at the concatenation. -/
+theorem split_out (h : Annotates M p l (out₁ ++ out₂) r) :
+    ∃ l₁ l₂ q, l = l₁ ++ l₂ ∧ Annotates M p l₁ out₁ q ∧ Annotates M q l₂ out₂ r := by
+  induction out₁ generalizing l p with
+  | nil => exact ⟨[], l, p, rfl, .nil p, h⟩
+  | cons s out₁ ih =>
     cases h with
-    | terminal a h_rest =>
-      obtain ⟨q, h₁, h₂⟩ := ih h_rest
-      exact ⟨q, .terminal a h₁, h₂⟩
-    | nonterminal A h_rest =>
-      obtain ⟨q, h₁, h₂⟩ := ih h_rest
-      exact ⟨q, .nonterminal A h₁, h₂⟩
+    | terminal a h =>
+      obtain ⟨l₁, l₂, q, rfl, h₁, h₂⟩ := ih h
+      exact ⟨_ :: l₁, l₂, q, rfl, .terminal a h₁, h₂⟩
+    | nonterminal A h =>
+      obtain ⟨l₁, l₂, q, rfl, h₁, h₂⟩ := ih h
+      exact ⟨_ :: l₁, l₂, q, rfl, .nonterminal A h₁, h₂⟩
 
-/-- A list of terminals is consistent from `p` to `M.evalFrom p w`. -/
-lemma map_terminal (p : σ) (w : List T) :
-    Consistent (G := G) M p (w.map .terminal) (M.evalFrom p w) := by
+/-- An annotation that is a concatenation annotates a concatenation. -/
+theorem split (h : Annotates M p (l₁ ++ l₂) out r) :
+    ∃ out₁ out₂ q, out = out₁ ++ out₂ ∧ Annotates M p l₁ out₁ q ∧ Annotates M q l₂ out₂ r := by
+  induction l₁ generalizing out p with
+  | nil => exact ⟨[], out, p, rfl, .nil p, h⟩
+  | cons s l₁ ih =>
+    cases h with
+    | terminal a h =>
+      obtain ⟨out₁, out₂, q, rfl, h₁, h₂⟩ := ih h
+      exact ⟨_ :: out₁, out₂, q, rfl, .terminal a h₁, h₂⟩
+    | nonterminal A h =>
+      obtain ⟨out₁, out₂, q, rfl, h₁, h₂⟩ := ih h
+      exact ⟨_ :: out₁, out₂, q, rfl, .nonterminal A h₁, h₂⟩
+
+theorem map_terminal (p : σ) (w : List T) :
+    Annotates (G := G) M p (w.map .terminal) (w.map .terminal) (M.evalFrom p w) := by
   induction w generalizing p with
   | nil => exact .nil p
-  | cons a w' ih =>
-    rw [List.map_cons, DFA.evalFrom_cons]
-    exact .terminal a (ih (M.step p a))
+  | cons a w ih => exact .terminal a (ih (M.step p a))
 
-/-- If a list of terminals is consistent from `p` to `q`, then `q = M.evalFrom p w`. -/
-lemma eval_of_terminal {p q : σ} {w : List T}
-    (h : Consistent (G := G) M p (w.map .terminal) q) :
-    q = M.evalFrom p w := by
-  induction w generalizing p with
-  | nil => cases h; rfl
-  | cons a w' ih =>
-    rw [List.map_cons] at h
+/-- A word annotates only itself, and ends where the automaton ends. -/
+theorem eq_of_map_terminal_right {w : List T} (h : Annotates M p l (w.map .terminal) q) :
+    l = w.map .terminal ∧ q = M.evalFrom p w := by
+  induction w generalizing l p with
+  | nil => cases h; exact ⟨rfl, rfl⟩
+  | cons a w ih =>
     cases h with
-    | terminal _ h_rest =>
-      rw [DFA.evalFrom_cons]
-      exact ih h_rest
+    | terminal _ h => obtain ⟨rfl, rfl⟩ := ih h; exact ⟨rfl, rfl⟩
 
-end Consistent
+/-- A word is annotated only by itself, and ends where the automaton ends. -/
+theorem eq_of_map_terminal_left {w : List T} (h : Annotates M p (w.map .terminal) out q) :
+    out = w.map .terminal ∧ q = M.evalFrom p w := by
+  induction w generalizing out p with
+  | nil => cases h; exact ⟨rfl, rfl⟩
+  | cons a w ih =>
+    cases h with
+    | terminal _ h => obtain ⟨rfl, rfl⟩ := ih h; exact ⟨rfl, rfl⟩
 
--- ============================================================================
--- Properties of annotateOutput and generatedRule
--- ============================================================================
+theorem eq_of_singleton_right {A : G.NT} (h : Annotates M p l [.nonterminal A] q) :
+    l = [.nonterminal (some (p, A, q))] := by
+  cases h with
+  | nonterminal _ h => cases h; rfl
 
-namespace ContextFreeGrammar
+theorem eq_of_singleton_left {p₀ q₀ : σ} {A : G.NT}
+    (h : Annotates M p [.nonterminal (some (p₀, A, q₀))] out q) :
+    out = [.nonterminal A] ∧ p₀ = p ∧ q₀ = q := by
+  cases h with
+  | nonterminal _ h => cases h; exact ⟨rfl, rfl, rfl⟩
 
-variable {G : ContextFreeGrammar T} {σ : Type} {M : DFA T σ}
-
-/-- The annotated output projects back to the original output. -/
-lemma annotateOutput_projects (start : σ) (out : List (Symbol T G.NT)) (path : List σ) :
-    Projects (annotateOutput M start out path).2 out := by
-  induction out generalizing start path with
-  | nil => exact .nil
-  | cons head rest ih =>
-    cases head with
-    | terminal a =>
-      simp [annotateOutput]
-      exact .terminal (ih (M.step start a) path)
-    | nonterminal A =>
-      cases path with
-      | nil =>
-        simp [annotateOutput]
-        exact .nonterminal (ih start [])
-      | cons q path_rest =>
-        simp [annotateOutput]
-        exact .nonterminal (ih q path_rest)
-
-/-- The annotated output is consistent from the start state to the returned end
-    state. -/
-lemma annotateOutput_consistent (start : σ) (out : List (Symbol T G.NT))
-    (path : List σ) :
-    Consistent (G := G) M start (annotateOutput M start out path).2
-                                (annotateOutput M start out path).1 := by
-  induction out generalizing start path with
-  | nil => exact .nil _
-  | cons head rest ih =>
-    cases head with
-    | terminal a =>
-      simp [annotateOutput]
-      exact .terminal a (ih (M.step start a) path)
-    | nonterminal A =>
-      cases path with
-      | nil =>
-        simp [annotateOutput]
-        exact .nonterminal A (ih start [])
-      | cons q path_rest =>
-        simp [annotateOutput]
-        exact .nonterminal A (ih q path_rest)
-
-/-- A generated rule has the expected input shape. -/
-@[simp] lemma generatedRule_input (r : ContextFreeRule T G.NT) (start : σ)
-    (path : List σ) :
-    (generatedRule M r start path).input =
-      .inl (start, r.input, (annotateOutput M start r.output path).1) := rfl
-
-/-- A generated rule has the expected output shape. -/
-@[simp] lemma generatedRule_output (r : ContextFreeRule T G.NT) (start : σ)
-    (path : List σ) :
-    (generatedRule M r start path).output =
-      (annotateOutput M start r.output path).2 := rfl
-
-/-- Membership in `startRules`: every start rule is parametrized by some
-    `qf ∈ M.accept`. -/
-lemma mem_startRules [Fintype σ] {r : ContextFreeRule T (productNT G σ)} :
-    r ∈ startRules M G ↔
-      ∃ qf : σ, qf ∈ M.accept ∧
-      r = { input := .inr (),
-            output := [.nonterminal (.inl (M.start, G.initial, qf))] } := by
-  simp only [startRules, Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and]
-  constructor
-  · rintro ⟨qf, hqf, rfl⟩; exact ⟨qf, hqf, rfl⟩
-  · rintro ⟨qf, hqf, rfl⟩; exact ⟨qf, hqf, rfl⟩
-
-/-- Membership in `rulesFromRule`: every derivation rule is parametrized by
-    some `(start, path)` choice. -/
-lemma mem_rulesFromRule [Fintype σ] [DecidableEq σ]
-    {r : ContextFreeRule T G.NT} {r' : ContextFreeRule T (productNT G σ)} :
-    r' ∈ rulesFromRule M r ↔
-      ∃ (start : σ) (path_fn : Fin (nonterminalCount r.output) → σ),
-      r' = generatedRule M r start (List.ofFn path_fn) := by
-  simp only [rulesFromRule, Finset.mem_image, Finset.mem_univ, true_and]
-  constructor
-  · rintro ⟨⟨start, path_fn⟩, h⟩; exact ⟨start, path_fn, h.symm⟩
-  · rintro ⟨start, path_fn, rfl⟩; exact ⟨⟨start, path_fn⟩, rfl⟩
-
-end ContextFreeGrammar
-
-namespace Projects
-
-variable {G : ContextFreeGrammar T} {σ : Type}
-
-/-- A projected G' symbol-list contains no `.nonterminal (.inr _)` symbols. -/
-lemma not_inr_mem {s' : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    {s : List (Symbol T G.NT)} (h : Projects s' s) (u : Unit) :
-    Symbol.nonterminal (.inr u) ∉ s' := by
+theorem none_notMem (h : Annotates M p l out q) : Symbol.nonterminal none ∉ l := by
   induction h with
-  | nil => intro hmem; exact List.not_mem_nil hmem
-  | terminal _ ih =>
-    intro hmem
-    rcases List.mem_cons.mp hmem with heq | hmem'
-    · cases heq
-    · exact ih hmem'
-  | nonterminal _ ih =>
-    intro hmem
-    rcases List.mem_cons.mp hmem with heq | hmem'
-    · injection heq with hsym
-      cases hsym
-    · exact ih hmem'
+  | nil => simp
+  | terminal _ _ ih => simpa using ih
+  | nonterminal _ _ ih => simpa using ih
 
-/-- A G' symbol-list projecting to a singleton G-nonterminal is itself a
-    singleton (with appropriate state annotation). -/
-lemma singleton_nonterminal {s' : List (Symbol T (ContextFreeGrammar.productNT G σ))}
-    {A : G.NT} (h : Projects s' [.nonterminal A]) :
-    ∃ p q : σ, s' = [.nonterminal (.inl (p, A, q))] := by
-  cases h with
-  | nonterminal h_rest =>
-    cases h_rest
-    refine ⟨_, _, rfl⟩
+end Annotates
 
-/-- The dual: a singleton .nonterminal (.inl ...) on the left projects to
-    the corresponding .nonterminal A. -/
-lemma of_singleton_nonterminal {p q : σ} {A : G.NT} {s : List (Symbol T G.NT)}
-    (h : Projects [.nonterminal (.inl (p, A, q))] s) :
-    s = [.nonterminal A] := by
-  cases h with
-  | nonterminal h_rest =>
-    cases h_rest
-    rfl
+variable [Fintype σ]
 
-/-- If a list of terminals on the left projects to `s`, then `s` is the same
-    list of terminals on the G side. -/
-lemma eq_of_map_terminal_left {w : List T} {s : List (Symbol T G.NT)}
-    (h : Projects (w.map (Symbol.terminal (N := ContextFreeGrammar.productNT G σ))) s) :
-    s = w.map .terminal := by
-  induction w generalizing s with
-  | nil => cases h; rfl
-  | cons a w' ih =>
-    rw [List.map_cons] at h
-    cases h with
-    | terminal h_rest =>
-      rw [List.map_cons, ih h_rest]
+/-- The annotations of `out` from state `p`, each with its exit state. -/
+noncomputable def annotations :
+    σ → List (Symbol T G.NT) → Finset (σ × List (Symbol T (ProductNT G σ)))
+  | p, [] => {(p, [])}
+  | p, .terminal a :: out => (annotations (M.step p a) out).image fun x => (x.1, .terminal a :: x.2)
+  | p, .nonterminal A :: out => Finset.univ.biUnion fun p' =>
+      (annotations p' out).image fun x => (x.1, .nonterminal (some (p, A, p')) :: x.2)
 
-end Projects
-
--- ============================================================================
--- Forward direction: G' language ⊆ G ⊓ M
--- ============================================================================
-
-namespace ContextFreeGrammar
-
-variable {G : ContextFreeGrammar T} {σ : Type} [Fintype σ] [DecidableEq σ] {M : DFA T σ}
-
-/-- One step of the G' Produces relation lifts to a one-step G Produces, given
-    a Projects + Consistent annotation of the source. The target inherits the
-    annotation. -/
-lemma product_produces_lift {s' t' : List (Symbol T (productNT G σ))}
-    {s : List (Symbol T G.NT)} {p q : σ}
-    (step : (G.product M).Produces s' t')
-    (hp : Projects s' s) (hc : Consistent M p s' q) :
-    ∃ t, G.Produces s t ∧ Projects t' t ∧ Consistent M p t' q := by
-  obtain ⟨r', hr'_mem, hrw⟩ := step
-  -- Type-coerce r' so we work consistently in the productNT type.
-  let r'' : ContextFreeRule T (productNT G σ) := r'
-  have hrw'' : r''.Rewrites s' t' := hrw
-  have hr''_mem : r'' ∈ startRules M G ∪ G.rules.biUnion (rulesFromRule M) := hr'_mem
-  rw [Finset.mem_union, Finset.mem_biUnion] at hr''_mem
-  rcases hr''_mem with h_start | ⟨r, hr_mem, h_in_rules⟩
-  · -- Start rule case: contradiction with Projects (no .inr ()).
-    rw [mem_startRules] at h_start
-    obtain ⟨qf, _hqf, hr''_eq⟩ := h_start
-    exfalso
-    have h_input : r''.input = .inr () := by rw [hr''_eq]
-    have hmem : Symbol.nonterminal r''.input ∈ s' := hrw''.nonterminal_input_mem
-    rw [h_input] at hmem
-    exact hp.not_inr_mem () hmem
-  · -- Derivation rule case.
-    rw [mem_rulesFromRule] at h_in_rules
-    obtain ⟨start, path_fn, hr''_eq⟩ := h_in_rules
-    set path := List.ofFn path_fn with hpath_def
-    set ann := (annotateOutput M start r.output path).2 with hann_def
-    set end_st := (annotateOutput M start r.output path).1 with hend_def
-    have hr_input : r''.input = .inl (start, r.input, end_st) := by
-      rw [hr''_eq]; rfl
-    have hr_output : r''.output = ann := by
-      rw [hr''_eq]; rfl
-    obtain ⟨pre, post, hs'_eq, ht'_eq⟩ := hrw''.exists_parts
-    -- hs'_eq : s' = pre ++ [.nonterminal r''.input] ++ post
-    -- ht'_eq : t' = pre ++ r''.output ++ post
-    -- Substitute r''.input and r''.output.
-    rw [hr_input] at hs'_eq
-    rw [hr_output] at ht'_eq
-    -- Decompose Projects via the source split.
-    rw [hs'_eq] at hp
-    obtain ⟨pre_mid_g, post_g, hs_eq, hp_pre_mid, hp_post⟩ := Projects.split_left hp
-    obtain ⟨pre_g, mid_g, hpre_mid_eq, hp_pre, hp_mid⟩ := Projects.split_left hp_pre_mid
-    have hmid_eq := hp_mid.of_singleton_nonterminal
-    -- Decompose Consistent. The list is (pre ++ [.nonterminal ...]) ++ post
-    -- (left-assoc), so the first split separates that, the second splits pre vs middle.
-    rw [hs'_eq] at hc
-    obtain ⟨p'', hc_pre_mid, hc_post⟩ := hc.split
-    obtain ⟨p', hc_pre, hc_mid⟩ := hc_pre_mid.split
-    cases hc_mid with
-    | @nonterminal _ _ _ A _ h_inner =>
-      cases h_inner
-      refine ⟨pre_g ++ r.output ++ post_g, ?_, ?_, ?_⟩
-      · refine ⟨r, hr_mem, ?_⟩
-        rw [hs_eq, hpre_mid_eq, hmid_eq]
-        exact ContextFreeRule.rewrites_of_exists_parts r pre_g post_g
-      · rw [ht'_eq]
-        refine (hp_pre.append (?_ : Projects ann r.output)).append hp_post
-        exact annotateOutput_projects start r.output path
-      · rw [ht'_eq, List.append_assoc]
-        refine hc_pre.append (?_ : Consistent M start (ann ++ post) q)
-        refine (annotateOutput_consistent start r.output path).append ?_
-        exact hc_post
-
-/-- Multi-step lift: given Projects + Consistent annotation, lift any G'
-    derivation to a G derivation, preserving annotations. -/
-lemma product_derives_lift {s' t' : List (Symbol T (productNT G σ))}
-    (hd : (G.product M).Derives s' t') {s : List (Symbol T G.NT)} {p q : σ}
-    (hp : Projects s' s) (hc : Consistent M p s' q) :
-    ∃ t, G.Derives s t ∧ Projects t' t ∧ Consistent M p t' q := by
-  induction hd with
-  | refl => exact ⟨s, .refl _, hp, hc⟩
-  | tail _ step ih =>
-    obtain ⟨t_mid, hd_mid, hp_mid, hc_mid⟩ := ih
-    obtain ⟨t, hp_step, hp_t, hc_t⟩ :=
-      product_produces_lift step hp_mid hc_mid
-    exact ⟨t, hd_mid.trans_produces hp_step, hp_t, hc_t⟩
-
-/-- **Forward inclusion** (Bar-Hillel): every word generated by `G.product M`
-    is in `G.language ⊓ M.accepts`. -/
-theorem product_language_le (G : ContextFreeGrammar T) (M : DFA T σ) :
-    (G.product M).language ≤ G.language ⊓ M.accepts := by
-  intro w hw
-  -- hw : (G.product M).Derives [.nonterminal (.inr ())] (w.map .terminal)
-  show w ∈ G.language ∧ w ∈ M.accepts
-  -- The first step must apply a start rule.
-  rcases hw.eq_or_head with heq | ⟨v, hstep, hrest⟩
-  · -- refl: [.nonterminal (.inr ())] = w.map .terminal — impossible.
-    exfalso
-    cases w with
-    | nil => simp [show ((G.product M).initial : productNT G σ) = .inr () from rfl] at heq
-    | cons a w' => simp at heq
-  · -- The first step is a Produces.
-    obtain ⟨r', hr'_mem, hrw⟩ := hstep
-    -- (G.product M).rules definitionally equals startRules ∪ G.rules.biUnion rulesFromRule.
-    -- Explicit retyping is needed because r' has type ContextFreeRule T (G.product M).NT
-    -- but (productNT G σ) is the projected element type of the union.
-    let r'' : ContextFreeRule T (productNT G σ) := r'
-    have hr'_mem' : r'' ∈ startRules M G ∪ G.rules.biUnion (rulesFromRule M) := hr'_mem
-    rw [Finset.mem_union, Finset.mem_biUnion] at hr'_mem'
-    rcases hr'_mem' with h_start | ⟨r, hr_mem, h_in_rules⟩
-    · -- Start rule case (the expected branch).
-      rw [mem_startRules] at h_start
-      obtain ⟨qf, hqf, rfl⟩ := h_start
-      -- The rewrite turns [.nonterminal (.inr ())] into [.nonterminal (.inl (M.start, G.initial, qf))].
-      -- After: v = [.nonterminal (.inl (M.start, G.initial, qf))].
-      have hv_eq : v = [.nonterminal (.inl (M.start, G.initial, qf))] := by
-        obtain ⟨pre, post, hs_eq, ht_eq⟩ := hrw.exists_parts
-        -- pre ++ [.nonterminal r'.input] ++ post = [.nonterminal (G.product M).initial]
-        -- Both sides equal [.nonterminal (.inr ())]; this forces pre = post = [].
-        have hlen := congr_arg List.length hs_eq
-        simp only [List.length_append, List.length_cons, List.length_nil] at hlen
-        have hpre : pre = [] := List.length_eq_zero_iff.mp (by omega)
-        have hpost : post = [] := List.length_eq_zero_iff.mp (by omega)
-        rw [hpre, hpost, List.nil_append, List.append_nil] at ht_eq
-        exact ht_eq
-      subst hv_eq
-      -- Now apply product_derives_lift on the rest.
-      have hp : Projects (G := G) (σ := σ)
-                  [.nonterminal (.inl (M.start, G.initial, qf))]
-                  [.nonterminal G.initial] := by
-        exact .nonterminal .nil
-      have hc : Consistent (G := G) M M.start
-                  [.nonterminal (.inl (M.start, G.initial, qf))] qf := by
-        exact .nonterminal _ (.nil _)
-      obtain ⟨t, hG_d, hp_t, hc_t⟩ := product_derives_lift hrest hp hc
-      have ht_eq : t = w.map .terminal := hp_t.eq_of_map_terminal_left
-      refine ⟨?_, ?_⟩
-      · -- w ∈ G.language: G.Derives [.nonterminal G.initial] (w.map .terminal).
-        show G.Derives [.nonterminal G.initial] (w.map .terminal)
-        rw [← ht_eq]; exact hG_d
-      · -- w ∈ M.accepts: M.eval w ∈ M.accept.
-        show M.eval w ∈ M.accept
-        have : qf = M.evalFrom M.start w := hc_t.eval_of_terminal
-        rw [DFA.eval, ← this]; exact hqf
-    · -- Derivation rule case: contradiction (start step must rewrite .inr ()).
-      exfalso
-      rw [mem_rulesFromRule] at h_in_rules
-      obtain ⟨start, path_fn, hr''_eq⟩ := h_in_rules
-      have hr_input : r''.input = .inl (start, r.input,
-          (annotateOutput M start r.output (List.ofFn path_fn)).1) := by
-        rw [hr''_eq]; rfl
-      have hrw'' : r''.Rewrites [.nonterminal (.inr ())] v := by
-        show r''.Rewrites _ _
-        change r''.Rewrites [.nonterminal (G.product M).initial] v
-        exact hrw
-      have hmem : Symbol.nonterminal r''.input ∈
-          ([.nonterminal (.inr ())] : List (Symbol T (productNT G σ))) :=
-        hrw''.nonterminal_input_mem
-      rw [hr_input] at hmem
-      simp only [List.mem_singleton, Symbol.nonterminal.injEq] at hmem
-      cases hmem
-
-end ContextFreeGrammar
-
--- ============================================================================
--- Backward direction: G ⊓ M ⊆ G' language
--- ============================================================================
-
-namespace ContextFreeGrammar
-
--- Lemmas in this section don't need finiteness on σ; introduce Fintype/DecidableEq
--- below, after the path-extraction substrate.
-variable {G : ContextFreeGrammar T} {σ : Type} {M : DFA T σ}
-
-/-- Extract the list of nonterminal "exit states" from a G' symbol-list, in
-    order. Used to invert `annotateOutput` — given a consistent annotation,
-    the path of exit-state choices is recoverable. -/
-private def extractPath : List (Symbol T (productNT G σ)) → List σ
-  | [] => []
-  | .terminal _ :: rest => extractPath rest
-  | .nonterminal (.inl (_, _, q)) :: rest => q :: extractPath rest
-  | .nonterminal (.inr _) :: rest => extractPath rest
-
-private lemma extractPath_length_of_projects {β' : List (Symbol T (productNT G σ))}
-    {out : List (Symbol T G.NT)} (hp : Projects β' out) :
-    (extractPath β').length = nonterminalCount out := by
-  induction hp with
-  | nil => rfl
-  | terminal h ih =>
-    simp only [extractPath, nonterminalCount, List.countP_cons]
-    rw [ih]
-    simp [nonterminalCount]
-  | nonterminal h ih =>
-    simp only [extractPath, List.length_cons, nonterminalCount,
-               List.countP_cons]
-    rw [ih]
-    simp [nonterminalCount]
-
-/-- Reconstruction lemma: given a `Projects + Consistent` annotation `β'` of
-    `out`, walking `annotateOutput` along the extracted path recovers `β'` and
-    the end state. -/
-private lemma annotateOutput_reconstruct
-    {p q : σ} {out : List (Symbol T G.NT)}
-    {β' : List (Symbol T (productNT G σ))}
-    (hp : Projects β' out) (hc : Consistent M p β' q) :
-    annotateOutput M p out (extractPath β') = (q, β') := by
-  induction hp generalizing p with
+theorem mem_annotations {p : σ} {out : List (Symbol T G.NT)}
+    {x : σ × List (Symbol T (ProductNT G σ))} :
+    x ∈ annotations M p out ↔ Annotates M p x.2 out x.1 := by
+  induction out generalizing p x with
   | nil =>
-    cases hc
-    rfl
-  | @terminal a rest rest' h ih =>
-    cases hc with
-    | terminal _ hc' =>
-      simp only [extractPath, annotateOutput]
-      rw [ih hc']
-  | @nonterminal p₀ A q₀ rest rest' h ih =>
-    cases hc with
-    | @nonterminal p p' q' A _ hc' =>
-      simp only [extractPath, annotateOutput]
-      rw [ih hc']
+    obtain ⟨q, l⟩ := x
+    simp only [annotations, Finset.mem_singleton, Prod.mk.injEq]
+    constructor
+    · rintro ⟨rfl, rfl⟩; exact .nil _
+    · rintro ⟨⟩; exact ⟨rfl, rfl⟩
+  | cons s out ih =>
+    obtain ⟨q, l⟩ := x
+    cases s with
+    | terminal a =>
+      simp only [annotations, Finset.mem_image, Prod.mk.injEq]
+      constructor
+      · rintro ⟨⟨q', l'⟩, h, rfl, rfl⟩; exact .terminal a (ih.mp h)
+      · intro h
+        cases h with
+        | terminal _ h => exact ⟨(q, _), ih.mpr h, rfl, rfl⟩
+    | nonterminal A =>
+      simp only [annotations, Finset.mem_biUnion, Finset.mem_univ, true_and, Finset.mem_image,
+        Prod.mk.injEq]
+      constructor
+      · rintro ⟨p', ⟨q', l'⟩, h, rfl, rfl⟩; exact .nonterminal A (ih.mp h)
+      · intro h
+        cases h with
+        | nonterminal _ h => exact ⟨_, (q, _), ih.mpr h, rfl, rfl⟩
 
-/-- Any consistent annotation corresponds to an `(start, path_fn)` choice in
-    the rule-generation enumeration. -/
-private lemma exists_path_fn_of_consistent {r : ContextFreeRule T G.NT}
-    {p q : σ} {β' : List (Symbol T (productNT G σ))}
-    (hp : Projects β' r.output) (hc : Consistent M p β' q) :
-    ∃ path_fn : Fin (nonterminalCount r.output) → σ,
-      generatedRule M r p (List.ofFn path_fn) =
-        { input := .inl (p, r.input, q), output := β' } := by
-  have hlen : (extractPath β').length = nonterminalCount r.output :=
-    extractPath_length_of_projects hp
-  refine ⟨fun i => (extractPath β').get (i.cast hlen.symm), ?_⟩
-  have h_ofFn : List.ofFn (fun i : Fin (nonterminalCount r.output) =>
-      (extractPath β').get (i.cast hlen.symm)) = extractPath β' := by
-    apply List.ext_get
-    · simp only [List.length_ofFn, hlen]
-    · intro i hi₁ hi₂
-      simp only [List.get_ofFn, Fin.cast_mk]
-  rw [h_ofFn]
-  unfold generatedRule
-  rw [annotateOutput_reconstruct hp hc]
+/-- The start rule of the product for an accepting state `q`. -/
+def startRule (G : ContextFreeGrammar T) (q : σ) : ContextFreeRule T (ProductNT G σ) :=
+  ⟨none, [.nonterminal (some (M.start, G.initial, q))]⟩
 
--- From here on, finiteness on σ is needed for `Finset.mem_*` and the rule-set
--- membership proofs.
-variable [Fintype σ] [DecidableEq σ]
+/-- The rules of the product: a start rule for each accepting state, and each rule of `G` in
+every annotation of its right-hand side. -/
+noncomputable def productRules (G : ContextFreeGrammar T) :
+    Finset (ContextFreeRule T (ProductNT G σ)) :=
+  (Finset.univ.filter (· ∈ M.accept)).image (startRule M G) ∪
+    G.rules.biUnion fun r => Finset.univ.biUnion fun p =>
+      (annotations M p r.output).image fun x => ⟨some (p, r.input, x.1), x.2⟩
 
-/-- The G' rule corresponding to any consistent annotation of a G-rule's body
-    is in `(G.product M).rules`. -/
-lemma mem_rules_of_consistent {r : ContextFreeRule T G.NT}
-    (hr_mem : r ∈ G.rules) {p q : σ} {β' : List (Symbol T (productNT G σ))}
-    (hp : Projects β' r.output) (hc : Consistent M p β' q) :
-    ({ input := .inl (p, r.input, q), output := β' } :
-        ContextFreeRule T (productNT G σ)) ∈
-      (G.product M).rules := by
-  show _ ∈ (startRules M G ∪ G.rules.biUnion (rulesFromRule M))
-  rw [Finset.mem_union]
-  right
-  rw [Finset.mem_biUnion]
-  refine ⟨r, hr_mem, ?_⟩
-  rw [mem_rulesFromRule]
-  obtain ⟨path_fn, h_eq⟩ := exists_path_fn_of_consistent hp hc
-  exact ⟨p, path_fn, h_eq.symm⟩
+theorem mem_productRules {r' : ContextFreeRule T (ProductNT G σ)} :
+    r' ∈ productRules M G ↔ (∃ q ∈ M.accept, r' = startRule M G q) ∨
+      ∃ r ∈ G.rules, ∃ p q, r'.input = some (p, r.input, q) ∧
+        Annotates M p r'.output r.output q := by
+  simp only [productRules, Finset.mem_union, Finset.mem_image, Finset.mem_filter,
+    Finset.mem_univ, true_and, Finset.mem_biUnion, mem_annotations]
+  refine or_congr (exists_congr fun q => and_congr_right fun _ => eq_comm)
+    (exists_congr fun r => and_congr_right fun _ => ?_)
+  constructor
+  · rintro ⟨p, ⟨q, l⟩, h, rfl⟩; exact ⟨p, q, rfl, h⟩
+  · rintro ⟨p, q, hi, h⟩; exact ⟨p, (q, r'.output), h, by cases r'; cases hi; rfl⟩
 
-/-- The start rule for an accepting state `qf` is in `(G.product M).rules`. -/
-lemma start_rule_mem (G : ContextFreeGrammar T) (M : DFA T σ) {qf : σ}
-    (hqf : qf ∈ M.accept) :
-    ({ input := .inr (),
-       output := [.nonterminal (.inl (M.start, G.initial, qf))] } :
-        ContextFreeRule T (productNT G σ)) ∈
-      (G.product M).rules := by
-  show _ ∈ (startRules M G ∪ G.rules.biUnion (rulesFromRule M))
-  rw [Finset.mem_union]
-  left
-  rw [mem_startRules]
-  exact ⟨qf, hqf, rfl⟩
+theorem startRule_mem_productRules {q : σ} (hq : q ∈ M.accept) :
+    startRule M G q ∈ productRules M G :=
+  (mem_productRules M).mpr (.inl ⟨q, hq, rfl⟩)
 
--- ============================================================================
--- Backward main lemma: lift any G derivation to G' via head induction.
--- ============================================================================
--- (Same `namespace ContextFreeGrammar` continues from above — no re-opening.)
+theorem mem_productRules_of_annotates {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules) {p q : σ}
+    {l : List (Symbol T (ProductNT G σ))} (h : Annotates M p l r.output q) :
+    (⟨some (p, r.input, q), l⟩ : ContextFreeRule T (ProductNT G σ)) ∈ productRules M G :=
+  (mem_productRules M).mpr (.inr ⟨r, hr, p, q, rfl, h⟩)
 
-/-- **Annotation-existence lemma** (the heart of the backward direction).
-    For any G derivation of `s` to `(w.map .terminal)`, and any starting
-    DFA state `p`, there exists a Projects+Consistent annotation `s'` of `s`
-    such that `(G.product M).Derives s' (w.map .terminal)`.
+/-- The product of a grammar with a finite automaton: the nonterminals are annotated with entry
+and exit states, each rule of `G` appears in every annotation of its right-hand side, and the
+fresh start symbol rewrites to the start nonterminal of `G` between the start state and each
+accepting state. -/
+noncomputable def product (G : ContextFreeGrammar T) (M : DFA T σ) : ContextFreeGrammar T where
+  NT := ProductNT G σ
+  initial := none
+  rules := productRules M G
 
-    Proved by `head_induction_on` on the G derivation: the refl case takes
-    `s' = w.map .terminal`; the head case constructs the annotation by
-    extracting a Projects+Consistent decomposition of the IH's annotation
-    of `mid` (the post-step sentential form), then applies the corresponding
-    G' rule (which exists by `mem_rules_of_consistent`). -/
-lemma exists_annotation_of_derives {s : List (Symbol T G.NT)} {w : List T}
-    (h_drv : G.Derives s (w.map .terminal)) (p : σ) :
-    ∃ s' : List (Symbol T (productNT G σ)),
-      Projects s' s ∧ Consistent M p s' (M.evalFrom p w) ∧
-      (G.product M).Derives s' (w.map .terminal) := by
-  induction h_drv using Relation.ReflTransGen.head_induction_on with
-  | refl =>
-    -- s = w.map .terminal. Take s' to be the same list at the productNT level.
-    refine ⟨w.map .terminal, Projects.map_terminal w, Consistent.map_terminal p w, ?_⟩
-    exact .refl _
-  | @head s mid step rest ih =>
-    -- step : G.Produces s mid; rest : G.Derives mid (w.map .terminal); ih : ∃ ann of mid.
-    obtain ⟨mid', hp_mid, hc_mid, hd_mid⟩ := ih
-    -- The step rewrites s to mid via some rule r ∈ G.rules.
-    obtain ⟨r, hr_mem, hrw⟩ := step
-    obtain ⟨pre, post, hs_eq, hmid_eq⟩ := hrw.exists_parts
-    -- mid = pre ++ r.output ++ post.
-    rw [hmid_eq] at hp_mid
-    -- Decompose mid' along this 3-way concat (parsed as (pre ++ r.output) ++ post).
-    obtain ⟨pre_ann, post', hmid'_eq, hp_pre_ann, hp_post⟩ := Projects.split_right hp_mid
-    obtain ⟨pre', ann_r_output, hpre_ann_eq, hp_pre, hp_ann⟩ := Projects.split_right hp_pre_ann
-    -- Decompose Consistent the same way: rewrite hc_mid using mid' decomposition.
-    rw [hmid'_eq, hpre_ann_eq] at hc_mid
-    obtain ⟨p_right, hc_pre_ann, hc_post⟩ := hc_mid.split
-    obtain ⟨p_left, hc_pre, hc_ann⟩ := hc_pre_ann.split
-    -- Construct s' = pre' ++ [.nonterminal (.inl (p_left, r.input, p_right))] ++ post'.
-    refine ⟨pre' ++ [.nonterminal (.inl (p_left, r.input, p_right))] ++ post', ?_, ?_, ?_⟩
-    · -- Projects s' s.
-      rw [hs_eq]
-      exact (hp_pre.append (.nonterminal .nil)).append hp_post
-    · -- Consistent M p s' (M.evalFrom p w).
-      exact (hc_pre.append (.nonterminal _ (.nil _))).append hc_post
-    · -- (G.product M).Derives s' (w.map .terminal).
-      -- Step: G' Produces s' mid' via rule {input := .inl (p_left, r.input, p_right), output := ann_r_output}.
-      have h_rule_mem :
-          ({ input := .inl (p_left, r.input, p_right), output := ann_r_output } :
-              ContextFreeRule T (productNT G σ)) ∈ (G.product M).rules :=
-        mem_rules_of_consistent hr_mem hp_ann hc_ann
-      have h_rewrite : ({ input := .inl (p_left, r.input, p_right),
-                          output := ann_r_output } :
-              ContextFreeRule T (productNT G σ)).Rewrites
-            (pre' ++ [.nonterminal (.inl (p_left, r.input, p_right))] ++ post')
-            (pre' ++ ann_r_output ++ post') :=
-        ContextFreeRule.rewrites_of_exists_parts _ pre' post'
-      have h_step : (G.product M).Produces
-            (pre' ++ [.nonterminal (.inl (p_left, r.input, p_right))] ++ post')
-            (pre' ++ ann_r_output ++ post') :=
-        ⟨_, h_rule_mem, h_rewrite⟩
-      -- mid' = pre' ++ ann_r_output ++ post' by hmid'_eq + hpre_ann_eq.
-      have h_mid' : mid' = pre' ++ ann_r_output ++ post' := by
-        rw [hmid'_eq, hpre_ann_eq]
-      rw [h_mid'] at hd_mid
-      exact h_step.trans_derives hd_mid
+@[simp] theorem product_initial : (G.product M).initial = (none : ProductNT G σ) := rfl
 
-/-- **Backward inclusion** (Bar-Hillel): every word in `G.language ⊓ M.accepts`
-    is generated by `G.product M`. -/
-theorem le_product_language (G : ContextFreeGrammar T) (M : DFA T σ) :
-    G.language ⊓ M.accepts ≤ (G.product M).language := by
+/-! ### The product generates the intersection -/
+
+variable {M}
+
+/-- A step of the product on an annotated form is a step of `G` on the form it annotates. -/
+theorem Produces.of_product {l' t' : List (Symbol T (ProductNT G σ))}
+    (step : (G.product M).Produces l' t') {p q : σ} {out : List (Symbol T G.NT)}
+    (h : Annotates M p l' out q) : ∃ out', G.Produces out out' ∧ Annotates M p t' out' q := by
+  obtain ⟨r', hr', hrw⟩ := step
+  obtain ⟨pre, post, rfl, rfl⟩ := hrw.exists_parts
+  rcases (mem_productRules M).mp hr' with ⟨q₀, -, rfl⟩ | ⟨r, hr, p₀, q₀, hi, hbody⟩
+  · exact absurd (by simp [startRule]) h.none_notMem
+  · obtain ⟨out₁, out₃, p₂, rfl, h₁₂, h₃⟩ := h.split
+    obtain ⟨out₁, out₂, p₁, rfl, h₁, h₂⟩ := h₁₂.split
+    rw [hi] at h₂
+    obtain ⟨rfl, rfl, rfl⟩ := h₂.eq_of_singleton_left
+    exact ⟨out₁ ++ r.output ++ out₃, ⟨r, hr, ContextFreeRule.rewrites_of_exists_parts r out₁ out₃⟩,
+      (h₁.append hbody).append h₃⟩
+
+/-- A derivation of the product from an annotated form is a derivation of `G` from the form it
+annotates. -/
+theorem Derives.of_product {l' t' : List (Symbol T (ProductNT G σ))}
+    (hd : (G.product M).Derives l' t') {p q : σ} {out : List (Symbol T G.NT)}
+    (h : Annotates M p l' out q) : ∃ out', G.Derives out out' ∧ Annotates M p t' out' q := by
+  induction hd with
+  | refl => exact ⟨out, .refl _, h⟩
+  | tail _ step ih =>
+    obtain ⟨out', hd', h'⟩ := ih
+    obtain ⟨out'', hp, h''⟩ := step.of_product h'
+    exact ⟨out'', hd'.trans_produces hp, h''⟩
+
+theorem product_language_le : (G.product M).language ≤ G.language ⊓ M.accepts := by
+  intro w hw
+  rcases ((mem_language_iff _ _).mp hw).eq_or_head with heq | ⟨v, ⟨r', hr', hrw⟩, hrest⟩
+  · cases w <;> simp at heq
+  · have hin : r'.input = none := by simpa using hrw.nonterminal_input_mem
+    obtain ⟨pre, post, hl, rfl⟩ := hrw.exists_parts
+    have hpre : pre = [] :=
+      List.eq_nil_of_length_eq_zero (by have := congrArg List.length hl; simp at this; omega)
+    have hpost : post = [] :=
+      List.eq_nil_of_length_eq_zero (by have := congrArg List.length hl; simp at this; omega)
+    subst hpre hpost
+    simp only [List.nil_append, List.append_nil] at hrest
+    rcases (mem_productRules M).mp hr' with ⟨qf, hqf, rfl⟩ | ⟨r, -, p₀, q₀, hi, -⟩
+    · obtain ⟨out, hd, h⟩ := hrest.of_product (Annotates.nonterminal (M := M) (p := M.start)
+        G.initial (.nil qf))
+      obtain ⟨rfl, hq⟩ := h.eq_of_map_terminal_left
+      exact ⟨(mem_language_iff _ _).mpr hd, M.mem_accepts.mpr (by rw [DFA.eval, ← hq]; exact hqf)⟩
+    · rw [hin] at hi
+      simp at hi
+
+/-- Every derivation of `G` of a word is the projection of a derivation of the product from an
+annotation of its start, for any entry state. -/
+theorem exists_annotates_of_derives {out : List (Symbol T G.NT)} {w : List T}
+    (hd : G.Derives out (w.map .terminal)) (p : σ) :
+    ∃ l, Annotates M p l out (M.evalFrom p w) ∧ (G.product M).Derives l (w.map .terminal) := by
+  induction hd using Relation.ReflTransGen.head_induction_on with
+  | refl => exact ⟨_, .map_terminal p w, .refl _⟩
+  | head step _ ih =>
+    obtain ⟨l, hl, hd⟩ := ih
+    obtain ⟨r, hr, hrw⟩ := step
+    obtain ⟨pre, post, rfl, rfl⟩ := hrw.exists_parts
+    obtain ⟨l₁, l₃, p₂, rfl, h₁₂, h₃⟩ := hl.split_out
+    obtain ⟨l₁, l₂, p₁, rfl, h₁, h₂⟩ := h₁₂.split_out
+    exact ⟨l₁ ++ [.nonterminal (some (p₁, r.input, p₂))] ++ l₃,
+      (h₁.append (.nonterminal r.input (.nil p₂))).append h₃,
+      (Produces.single ⟨_, mem_productRules_of_annotates M hr h₂,
+        ContextFreeRule.rewrites_of_exists_parts _ l₁ l₃⟩).trans hd⟩
+
+theorem le_product_language : G.language ⊓ M.accepts ≤ (G.product M).language := by
   rintro w ⟨hG, hM⟩
-  -- hG : G.Derives [.nonterminal G.initial] (w.map .terminal)
-  -- hM : M.eval w ∈ M.accept
-  show (G.product M).Derives [.nonterminal (G.product M).initial] (w.map .terminal)
-  -- (G.product M).initial = .inr ()
-  -- Apply the start rule {input := .inr (), output := [.nonterminal (.inl (M.start, G.initial, qf))]}
-  -- with qf = M.eval w.
-  set qf := M.eval w with hqf_def
-  have hqf : qf ∈ M.accept := hM
-  -- Step 1: start rule application.
-  have h_start_mem :
-      ({ input := .inr (),
-         output := [.nonterminal (.inl (M.start, G.initial, qf))] } :
-            ContextFreeRule T (productNT G σ)) ∈ (G.product M).rules :=
-    start_rule_mem G M hqf
-  have h_start_rewrite :
-      ({ input := .inr (),
-         output := [.nonterminal (.inl (M.start, G.initial, qf))] } :
-            ContextFreeRule T (productNT G σ)).Rewrites
-        [.nonterminal (.inr ())] [.nonterminal (.inl (M.start, G.initial, qf))] := by
-    have := ContextFreeRule.rewrites_of_exists_parts
-      ({ input := .inr (),
-         output := [.nonterminal (.inl (M.start, G.initial, qf))] } :
-            ContextFreeRule T (productNT G σ)) [] []
-    simpa using this
-  have h_step : (G.product M).Produces
-        ([.nonterminal (.inr ())] : List (Symbol T (productNT G σ)))
-        [.nonterminal (.inl (M.start, G.initial, qf))] :=
-    ⟨_, h_start_mem, h_start_rewrite⟩
-  -- Step 2: lift the G derivation [.nonterminal G.initial] ⇒* (w.map .terminal) to G'.
-  obtain ⟨s', hp_s', hc_s', hd_s'⟩ := exists_annotation_of_derives hG M.start
-  -- s' annotates [.nonterminal G.initial]; by Projects.singleton, it's a single .nonterminal.
-  obtain ⟨p₀, q₀, hs'_eq⟩ := hp_s'.singleton_nonterminal
-  subst hs'_eq
-  -- s' = [.nonterminal (.inl (p₀, G.initial, q₀))].
-  -- From Consistent: [.nonterminal (.inl (p₀, G.initial, q₀))] is consistent from M.start to M.evalFrom M.start w.
-  -- This forces p₀ = M.start and q₀ = M.evalFrom M.start w = qf.
-  cases hc_s' with
-  | @nonterminal _ _ _ A _ h_inner =>
-    cases h_inner
-    -- Now p₀ = M.start, q₀ = qf (by def).
-    -- hd_s' : (G.product M).Derives [.nonterminal (.inl (M.start, G.initial, qf))] (w.map .terminal).
-    -- Combine: start step + derivation.
-    show (G.product M).Derives [.nonterminal (.inr ())] (w.map .terminal)
-    exact h_step.trans_derives hd_s'
+  obtain ⟨l, hl, hd⟩ :=
+    exists_annotates_of_derives (M := M) ((mem_language_iff _ _).mp hG) M.start
+  rw [hl.eq_of_singleton_right] at hd
+  have hstep : (G.product M).Produces [.nonterminal (G.product M).initial]
+      (startRule M G (M.eval w)).output :=
+    ⟨startRule M G (M.eval w), startRule_mem_productRules M (M.mem_accepts.mp hM),
+      ContextFreeRule.Rewrites.input_output⟩
+  exact (mem_language_iff _ _).mpr (hstep.trans_derives hd)
 
-/-- **Bar-Hillel theorem**: `(G.product M).language = G.language ⊓ M.accepts`. -/
+/-- **Bar-Hillel**: the product generates the intersection. -/
 theorem product_language (G : ContextFreeGrammar T) (M : DFA T σ) :
     (G.product M).language = G.language ⊓ M.accepts :=
-  le_antisymm (product_language_le G M) (le_product_language G M)
+  le_antisymm product_language_le le_product_language
 
 end ContextFreeGrammar
-
--- ============================================================================
--- Headline: closure of `IsContextFree` under intersection with regular languages.
--- ============================================================================
 
 namespace Language.IsContextFree
 
-/-- **CFL closure under intersection with a regular language**
-    ([bar-hillel-perles-shamir-1961]; [hopcroft-motwani-ullman-2000]
-    Theorem 7.27): if `L` is context-free and `R` is regular, then `L ∩ R` is
-    context-free. -/
-theorem inter_isRegular {α : Type*} {L R : Language α}
-    (hL : L.IsContextFree) (hR : R.IsRegular) : (L ⊓ R).IsContextFree := by
+/-- Context-free languages are closed under intersection with regular languages. -/
+theorem inter_isRegular {α : Type*} {L R : Language α} (hL : L.IsContextFree) (hR : R.IsRegular) :
+    (L ⊓ R).IsContextFree := by
   obtain ⟨G, rfl⟩ := hL
-  -- R is regular: by `Language.IsRegular`, ∃ σ : Type (Type 0), Fintype σ, M : DFA, M.accepts = R.
-  obtain ⟨σ, _hFin, M, hM⟩ := hR
-  classical
-  refine ⟨G.product M, ?_⟩
-  rw [ContextFreeGrammar.product_language, hM]
+  obtain ⟨σ, _, M, rfl⟩ := hR
+  exact ⟨G.product M, ContextFreeGrammar.product_language G M⟩
 
 /-- If `L ∩ R` is not context-free for a regular `R`, then `L` is not context-free. -/
 theorem _root_.Language.not_isContextFree_of_inter_regular_not {α : Type*} {L R : Language α}
     (hR : R.IsRegular) (h : ¬ (L ⊓ R).IsContextFree) : ¬ L.IsContextFree :=
   fun hL => h (hL.inter_isRegular hR)
 
-/-- The Bar-Hillel proof schema of [shieber-1985]: if the homomorphic image of `L` intersected
-with a regular language is not context-free, then `L` is not context-free. -/
+/-- The proof schema of [shieber-1985]: if the image of `L` under a string homomorphism,
+intersected with a regular language, is not context-free, then `L` is not context-free. -/
 theorem _root_.Language.not_isContextFree_via_witness {α β : Type*} (f : α → List β)
     (R : Language β) {L : Language α} (hR : R.IsRegular)
     (h : ¬ (Language.stringMap f L ⊓ R).IsContextFree) : ¬ L.IsContextFree :=

--- a/Linglib/Core/Computability/ContextFreeGrammar/Map.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Map.lean
@@ -1,41 +1,41 @@
-import Mathlib.Computability.ContextFreeGrammar
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Computability.ContextFreeGrammar
 
 /-!
-# Closure of `IsContextFree` under string homomorphism
+# Context-free languages are closed under string homomorphisms
 
-The image of a context-free language under a string homomorphism — induced by a
-per-symbol map `f : T → List T'` — is context-free. Construction: replace each
-terminal `a` in each grammar rule's output with the symbol-list `(f a).map .terminal`.
-Nonterminals are unchanged.
+A map `f : T → List T'` on letters extends to a monoid homomorphism on words, `List.flatMap f`,
+and to a semiring homomorphism `Language.stringMap f` on languages. The image of a context-free
+language under it is context-free: replace every terminal `a` in every rule by the string `f a`
+([hopcroft-motwani-ullman-2000]).
 
 ## Main definitions
 
-* `Language.stringMap f : Language T →+* Language T'`: image under the string
-  homomorphism. Since `List α = FreeMonoid α`, the action `List.flatMap f` is the
-  free-monoid lift `FreeMonoid.lift f`; bundled as a semiring hom mirroring mathlib's
-  `Language.map`, of which the letter-to-letter case is the special case
-  `Language.stringMap_letterMap`.
+* `Language.stringMap`: the image of a language under a string homomorphism.
+* `Symbol.applyHom`, `ContextFreeRule.applyHom`, `ContextFreeGrammar.applyHom`: a string
+  homomorphism applied to a symbol, a rule and a grammar.
 
-## Main theorems
+## Main results
 
-* `Language.IsContextFree.stringMap`: context-free languages are closed under
-  string homomorphism.
-* `ContextFreeGrammar.applyHom_language`: the grammar construction realizes `stringMap`.
+* `ContextFreeGrammar.applyHom_language`: the image grammar generates the image language.
+* `Language.IsContextFree.stringMap`: closure under string homomorphisms, with its
+  contrapositive `Language.not_isContextFree_of_stringMap_not`.
 
-[hopcroft-motwani-ullman-2000] (homomorphism-closure construction).
+## References
+
+* [hopcroft-motwani-ullman-2000]
 -/
 
 open scoped Classical
 
-universe u v
+variable {T T' N : Type*}
 
-variable {T : Type u} {T' : Type v}
-
-/-- The image of a language under the string homomorphism induced by a per-symbol
-    map `f : T → List T'`. On a word the action is `List.flatMap f` — i.e. the
-    free-monoid lift `FreeMonoid.lift f`, since `List α = FreeMonoid α`. Bundled as a
-    semiring hom mirroring mathlib's `Language.map`; the letter-to-letter map is the
-    special case `Language.stringMap_letterMap`. -/
+/-- The image of a language under the string homomorphism induced by `f : T → List T'`, the
+monoid homomorphism `List.flatMap f` on words; `Language.map` is the case of one-letter images. -/
 def Language.stringMap (f : T → List T') : Language T →+* Language T' where
   toFun := Set.image (List.flatMap f)
   map_zero' := Set.image_empty _
@@ -46,367 +46,172 @@ def Language.stringMap (f : T → List T') : Language T →+* Language T' where
 @[simp] theorem Language.mem_stringMap {f : T → List T'} {L : Language T} {w : List T'} :
     w ∈ Language.stringMap f L ↔ ∃ v ∈ L, List.flatMap f v = w := Iff.rfl
 
-/-- **Bridge to mathlib's `Language.map`.** The letter-to-letter map `f : T → T'`
-    (singleton outputs) is the special case of `stringMap` that collapses to mathlib's
-    `Language.map f`, so `stringMap` genuinely generalizes the existing letter image. -/
-@[simp] theorem Language.stringMap_letterMap (f : T → T') (L : Language T) :
+theorem Language.stringMap_singleton (f : T → T') (L : Language T) :
     Language.stringMap (fun a => [f a]) L = Language.map f L := by
-  have hfun : (List.flatMap (fun a => [f a]) : List T → List T') = List.map f :=
-    funext fun _ => List.map_eq_flatMap.symm
-  show Set.image (List.flatMap fun a => [f a]) L = Set.image (List.map f) L
-  rw [hfun]
+  show Set.image _ L = Set.image _ L
+  simp [← List.map_eq_flatMap]
+
+namespace Symbol
+
+/-- A string homomorphism on terminals applied to a symbol: a terminal becomes the string of
+terminals it maps to, a nonterminal stays. -/
+def applyHom (h : T → List T') : Symbol T N → List (Symbol T' N)
+  | terminal a => (h a).map terminal
+  | nonterminal A => [nonterminal A]
+
+@[simp] theorem applyHom_terminal (h : T → List T') (a : T) :
+    applyHom h (terminal a : Symbol T N) = (h a).map terminal := rfl
+
+@[simp] theorem applyHom_nonterminal (h : T → List T') (A : N) :
+    applyHom h (nonterminal A : Symbol T N) = [nonterminal A] := rfl
+
+theorem flatMap_applyHom_map_terminal (h : T → List T') (w : List T) :
+    (w.map (terminal (N := N))).flatMap (applyHom h) = (w.flatMap h).map terminal := by
+  induction w with
+  | nil => rfl
+  | cons a w ih => simp [ih]
+
+/-- A word of the image grammar comes from a word of the source. -/
+theorem eq_map_terminal_of_flatMap_applyHom {h : T → List T'} :
+    ∀ {l : List (Symbol T N)} {w' : List T'}, l.flatMap (applyHom h) = w'.map terminal →
+      ∃ w : List T, l = w.map terminal ∧ w.flatMap h = w'
+  | [], w', heq => ⟨[], rfl, by simpa using (List.map_eq_nil_iff.mp heq.symm).symm⟩
+  | nonterminal _ :: _, w', heq => by cases w' <;> simp at heq
+  | terminal a :: l, w', heq => by
+    rw [List.flatMap_cons, applyHom_terminal, eq_comm, List.map_eq_append_iff] at heq
+    obtain ⟨w₁, w₂, rfl, h₁, h₂⟩ := heq
+    obtain rfl := (List.map_injective_iff.mpr fun _ _ h => terminal.inj h) h₁
+    obtain ⟨w, rfl, rfl⟩ := eq_map_terminal_of_flatMap_applyHom h₂.symm
+    exact ⟨a :: w, rfl, by simp⟩
+
+/-- A nonterminal in the image of a sentential form comes from the same nonterminal in the
+source. -/
+theorem exists_eq_of_flatMap_applyHom {h : T → List T'} :
+    ∀ {l : List (Symbol T N)} {p q : List (Symbol T' N)} {X : N},
+      l.flatMap (applyHom h) = p ++ [nonterminal X] ++ q →
+      ∃ l₁ l₂, l = l₁ ++ [nonterminal X] ++ l₂ ∧
+        l₁.flatMap (applyHom h) = p ∧ l₂.flatMap (applyHom h) = q
+  | [], p, q, X, heq => by simp at heq
+  | nonterminal Y :: l, [], q, X, heq => by
+    simp only [List.flatMap_cons, applyHom_nonterminal, List.nil_append, List.singleton_append,
+      List.cons.injEq, nonterminal.injEq] at heq
+    obtain ⟨rfl, rfl⟩ := heq
+    exact ⟨[], l, rfl, rfl, rfl⟩
+  | nonterminal Y :: l, s :: p, q, X, heq => by
+    simp only [List.flatMap_cons, applyHom_nonterminal, List.cons_append, List.cons.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    obtain ⟨l₁, l₂, rfl, rfl, rfl⟩ := exists_eq_of_flatMap_applyHom heq
+    exact ⟨nonterminal Y :: l₁, l₂, rfl, by simp, rfl⟩
+  | terminal a :: l, p, q, X, heq => by
+    rw [List.flatMap_cons, applyHom_terminal, List.append_assoc, List.append_eq_append_iff] at heq
+    rcases heq with ⟨p', rfl, heq⟩ | ⟨c, hc, heq⟩
+    · obtain ⟨l₁, l₂, rfl, rfl, rfl⟩ :=
+        exists_eq_of_flatMap_applyHom (List.append_assoc _ _ _ ▸ heq)
+      exact ⟨terminal a :: l₁, l₂, rfl, by simp, rfl⟩
+    · obtain ⟨w₁, w₂, -, -, rfl⟩ := List.map_eq_append_iff.mp hc
+      cases w₂ with
+      | nil =>
+        rw [List.map_nil, List.nil_append] at heq
+        obtain ⟨l₁, l₂, rfl, h₁, rfl⟩ := exists_eq_of_flatMap_applyHom (l := l) (p := [])
+          (by simpa only [List.nil_append] using heq.symm)
+        exact ⟨terminal a :: l₁, l₂, rfl, by simpa [h₁] using hc, rfl⟩
+      | cons b w₂ => simp at heq
+
+end Symbol
 
 namespace ContextFreeRule
 
-variable {N : Type*}
-
-/-- Apply a string homomorphism `h : T → List T'` to a single `Symbol`,
-    producing a symbol-list. Terminals are substituted; nonterminals are
-    preserved as singletons. -/
-def Symbol.applyHom (h : T → List T') : Symbol T N → List (Symbol T' N)
-  | .terminal a => (h a).map .terminal
-  | .nonterminal X => [.nonterminal X]
-
-/-- Apply a string homomorphism `h : T → List T'` to a symbol list (free
-    monoid functoriality). -/
-def applyHomList (h : T → List T') : List (Symbol T N) → List (Symbol T' N) :=
-  List.flatMap (Symbol.applyHom h)
-
-@[simp] theorem applyHomList_nil (h : T → List T') :
-    applyHomList h ([] : List (Symbol T N)) = [] := rfl
-
-@[simp] theorem applyHomList_cons (h : T → List T') (s : Symbol T N)
-    (ss : List (Symbol T N)) :
-    applyHomList h (s :: ss) = Symbol.applyHom h s ++ applyHomList h ss := by
-  simp [applyHomList, List.flatMap_cons]
-
-theorem applyHomList_append (h : T → List T') (xs ys : List (Symbol T N)) :
-    applyHomList h (xs ++ ys) = applyHomList h xs ++ applyHomList h ys :=
-  List.flatMap_append
-
-@[simp] theorem applyHomList_singleton_terminal (h : T → List T') (a : T) :
-    applyHomList h ([Symbol.terminal a] : List (Symbol T N)) = (h a).map .terminal := by
-  simp [applyHomList, Symbol.applyHom]
-
-@[simp] theorem applyHomList_singleton_nonterminal (h : T → List T') (X : N) :
-    applyHomList h ([Symbol.nonterminal X] : List (Symbol T N)) = [.nonterminal X] := by
-  simp [applyHomList, Symbol.applyHom]
-
-/-- For a list of terminals, `applyHomList` becomes `flatMap h` followed by
-    re-wrapping as terminals. -/
-theorem applyHomList_map_terminal (h : T → List T') (w : List T) :
-    applyHomList h (w.map (Symbol.terminal (N := N))) =
-    (List.flatMap h w).map .terminal := by
-  induction w with
-  | nil => rfl
-  | cons a as ih =>
-    simp only [List.map_cons, applyHomList_cons, Symbol.applyHom, ih,
-               List.flatMap_cons, List.map_append]
-
-/-- Apply a string homomorphism to a CFG rule. -/
-def applyHom (h : T → List T') (r : ContextFreeRule T N) : ContextFreeRule T' N where
-  input := r.input
-  output := applyHomList h r.output
+/-- A string homomorphism applied to a rule. -/
+def applyHom (h : T → List T') (r : ContextFreeRule T N) : ContextFreeRule T' N :=
+  ⟨r.input, r.output.flatMap (Symbol.applyHom h)⟩
 
 @[simp] theorem applyHom_input (h : T → List T') (r : ContextFreeRule T N) :
     (r.applyHom h).input = r.input := rfl
 
 @[simp] theorem applyHom_output (h : T → List T') (r : ContextFreeRule T N) :
-    (r.applyHom h).output = applyHomList h r.output := rfl
+    (r.applyHom h).output = r.output.flatMap (Symbol.applyHom h) := rfl
 
-/-- A single rule's `Rewrites` relation lifts under `applyHom`. -/
-theorem Rewrites.applyHom (h : T → List T') {r : ContextFreeRule T N}
-    {u v : List (Symbol T N)} (hr : r.Rewrites u v) :
-    (r.applyHom h).Rewrites (applyHomList h u) (applyHomList h v) := by
+theorem Rewrites.applyHom (h : T → List T') {r : ContextFreeRule T N} {u v : List (Symbol T N)}
+    (hr : r.Rewrites u v) :
+    (r.applyHom h).Rewrites (u.flatMap (Symbol.applyHom h)) (v.flatMap (Symbol.applyHom h)) := by
   obtain ⟨p, q, rfl, rfl⟩ := hr.exists_parts
-  simp only [applyHomList_append, applyHomList_singleton_nonterminal]
-  exact rewrites_of_exists_parts (r.applyHom h)
-    (applyHomList h p) (applyHomList h q)
+  simpa [List.flatMap_append] using rewrites_of_exists_parts (r.applyHom h)
+    (p.flatMap (Symbol.applyHom h)) (q.flatMap (Symbol.applyHom h))
 
 end ContextFreeRule
 
 namespace ContextFreeGrammar
 
-/-- Apply a string homomorphism to a CFG: substitute terminals in every rule.
-    Noncomputable due to `Finset.image` requiring decidable equality on rules
-    (provided classically). -/
-noncomputable def applyHom (h : T → List T') (G : ContextFreeGrammar T) : ContextFreeGrammar T' where
-  NT := G.NT
-  initial := G.initial
-  rules := G.rules.image (ContextFreeRule.applyHom h)
+variable (h : T → List T') {G : ContextFreeGrammar T}
 
-@[simp] theorem applyHom_NT (h : T → List T') (G : ContextFreeGrammar T) :
-    (G.applyHom h).NT = G.NT := rfl
+/-- A string homomorphism applied to a grammar: every terminal in every rule is replaced by its
+image. -/
+noncomputable def applyHom (G : ContextFreeGrammar T) : ContextFreeGrammar T' :=
+  ⟨G.NT, G.initial, G.rules.image (ContextFreeRule.applyHom h)⟩
 
-@[simp] theorem applyHom_initial (h : T → List T') (G : ContextFreeGrammar T) :
-    (G.applyHom h).initial = G.initial := rfl
+@[simp] theorem applyHom_NT : (G.applyHom h).NT = G.NT := rfl
 
-theorem applyHom_rules (h : T → List T') (G : ContextFreeGrammar T) :
-    (G.applyHom h).rules = G.rules.image (ContextFreeRule.applyHom h) := rfl
+@[simp] theorem applyHom_initial : (G.applyHom h).initial = G.initial := rfl
 
-/-- `Produces` lifts under `applyHom`. -/
-theorem Produces.applyHom (h : T → List T') {G : ContextFreeGrammar T}
-    {u v : List (Symbol T G.NT)} (huv : G.Produces u v) :
-    (G.applyHom h).Produces
-      (ContextFreeRule.applyHomList h u) (ContextFreeRule.applyHomList h v) := by
-  obtain ⟨r, hr_mem, hrw⟩ := huv
-  refine ⟨r.applyHom h, ?_, hrw.applyHom h⟩
-  rw [applyHom_rules]
-  exact Finset.mem_image.mpr ⟨r, hr_mem, rfl⟩
+theorem mem_applyHom_rules {r' : ContextFreeRule T' G.NT} :
+    r' ∈ (G.applyHom h).rules ↔ ∃ r ∈ G.rules, r.applyHom h = r' :=
+  Finset.mem_image
 
-/-- `Derives` lifts under `applyHom`. -/
-theorem Derives.applyHom (h : T → List T') {G : ContextFreeGrammar T}
-    {u v : List (Symbol T G.NT)} (huv : G.Derives u v) :
-    (G.applyHom h).Derives
-      (ContextFreeRule.applyHomList h u) (ContextFreeRule.applyHomList h v) := by
+theorem Produces.applyHom {u v : List (Symbol T G.NT)} (huv : G.Produces u v) :
+    (G.applyHom h).Produces (u.flatMap (Symbol.applyHom h)) (v.flatMap (Symbol.applyHom h)) :=
+  let ⟨r, hr, hrw⟩ := huv
+  ⟨r.applyHom h, (mem_applyHom_rules h).mpr ⟨r, hr, rfl⟩, hrw.applyHom h⟩
+
+theorem Derives.applyHom {u v : List (Symbol T G.NT)} (huv : G.Derives u v) :
+    (G.applyHom h).Derives (u.flatMap (Symbol.applyHom h)) (v.flatMap (Symbol.applyHom h)) := by
   induction huv with
-  | refl => exact Relation.ReflTransGen.refl
-  | tail _ hstep ih => exact ih.tail (hstep.applyHom h)
+  | refl => exact .refl _
+  | tail _ step ih => exact ih.trans_produces (step.applyHom h)
 
-end ContextFreeGrammar
+/-- A step of the image grammar from the image of a sentential form is the image of a step of
+the source grammar. -/
+theorem Produces.of_applyHom {l : List (Symbol T G.NT)} {t' : List (Symbol T' G.NT)}
+    (hp : (G.applyHom h).Produces (l.flatMap (Symbol.applyHom h)) t') :
+    ∃ t, G.Produces l t ∧ t.flatMap (Symbol.applyHom h) = t' := by
+  obtain ⟨r', hr', hrw⟩ := hp
+  obtain ⟨r, hr, rfl⟩ := (mem_applyHom_rules h).mp hr'
+  obtain ⟨p, q, hl, rfl⟩ := hrw.exists_parts
+  obtain ⟨l₁, l₂, rfl, rfl, rfl⟩ := Symbol.exists_eq_of_flatMap_applyHom (N := G.NT) hl
+  exact ⟨l₁ ++ r.output ++ l₂, ⟨r, hr, ContextFreeRule.rewrites_of_exists_parts r l₁ l₂⟩,
+    by simp [List.flatMap_append]⟩
 
--- ============================================================================
--- Language equality
--- ============================================================================
-
-namespace ContextFreeGrammar
-
-/-- Forward inclusion: every `(G.applyHom h)`-generated string is in
-    `Language.stringMap h G.language`. -/
-theorem applyHom_language_subset (h : T → List T') (G : ContextFreeGrammar T) :
-    Language.stringMap h G.language ≤ (G.applyHom h).language := by
-  intro w' hw'
-  obtain ⟨w, hw, rfl⟩ := Language.mem_stringMap.mp hw'
-  show (G.applyHom h).Derives [.nonterminal G.initial]
-        ((List.flatMap h w).map .terminal)
-  have hd := Derives.applyHom h hw
-  convert hd using 1
-  · simp [ContextFreeRule.Symbol.applyHom]
-  · simp [ContextFreeRule.applyHomList_map_terminal]
-
--- ============================================================================
--- Backward direction helpers (private to this file)
--- ============================================================================
-
-/-- If a terminal-only prefix `ts.map .terminal` is followed by `R` and the
-    whole equals `p ++ [.nonterminal X] ++ q`, then `ts.map .terminal` is a
-    prefix of `p`. -/
-private lemma terminal_prefix_split {N : Type*} (ts : List T') :
-    ∀ {R : List (Symbol T' N)} {p : List (Symbol T' N)} {X : N}
-      {q : List (Symbol T' N)},
-    ts.map (Symbol.terminal (N := N)) ++ R = p ++ [Symbol.nonterminal X] ++ q →
-    ∃ p_rest, p = ts.map .terminal ++ p_rest ∧
-              R = p_rest ++ [Symbol.nonterminal X] ++ q := by
-  induction ts with
-  | nil =>
-    intro R p X q heq
-    refine ⟨p, by simp, ?_⟩
-    simpa using heq
-  | cons t ts' ih =>
-    intro R p X q heq
-    rw [List.map_cons, List.cons_append] at heq
-    cases p with
-    | nil =>
-      rw [List.nil_append, List.singleton_append, List.cons.injEq] at heq
-      cases heq.1
-    | cons ph pt =>
-      rw [List.cons_append, List.cons_append, List.cons.injEq] at heq
-      obtain ⟨hph, hrest⟩ := heq
-      obtain ⟨p_rest, hpt_eq, hR_eq⟩ := ih hrest
-      refine ⟨p_rest, ?_, hR_eq⟩
-      rw [List.map_cons, List.cons_append, ← hph, hpt_eq]
-
-/-- If a terminal-only prefix `ts.map .terminal` is followed by `R` and the
-    whole equals `w'.map .terminal`, then `ts` is a prefix of `w'`. -/
-private lemma terminal_map_prefix {N : Type*} (ts : List T') :
-    ∀ {R : List (Symbol T' N)} {w' : List T'},
-    ts.map (Symbol.terminal (N := N)) ++ R = w'.map .terminal →
-    ∃ w'_rest, w' = ts ++ w'_rest ∧ R = w'_rest.map .terminal := by
-  induction ts with
-  | nil =>
-    intro R w' heq
-    refine ⟨w', by simp, ?_⟩
-    simpa using heq
-  | cons t ts' ih =>
-    intro R w' heq
-    rw [List.map_cons, List.cons_append] at heq
-    cases w' with
-    | nil =>
-      rw [List.map_nil] at heq
-      cases heq
-    | cons w ws =>
-      rw [List.map_cons, List.cons.injEq] at heq
-      obtain ⟨hwt, hrest⟩ := heq
-      injection hwt with htw
-      obtain ⟨w'_rest, hws_eq, hR_eq⟩ := ih hrest
-      refine ⟨w'_rest, ?_, hR_eq⟩
-      rw [List.cons_append, hws_eq, htw]
-
-/-- Decompose an `applyHomList` equation: if `applyHomList h m = p ++
-    [.nonterminal X] ++ q`, then there exist `pm`, `qm` on the G-side with
-    `m = pm ++ [.nonterminal X] ++ qm` whose images recover `p` and `q`.
-    The load-bearing lemma for lifting G'-derivations to G-derivations. -/
-private lemma decompose_applyHomList {h : T → List T'} {N : Type*}
-    (m : List (Symbol T N)) :
-    ∀ {p : List (Symbol T' N)} {X : N} {q : List (Symbol T' N)},
-    ContextFreeRule.applyHomList h m = p ++ [Symbol.nonterminal X] ++ q →
-    ∃ pm qm : List (Symbol T N),
-      m = pm ++ [Symbol.nonterminal X] ++ qm ∧
-      ContextFreeRule.applyHomList h pm = p ∧
-      ContextFreeRule.applyHomList h qm = q := by
-  induction m with
-  | nil =>
-    intro p X q heq
-    rw [ContextFreeRule.applyHomList_nil] at heq
-    exfalso
-    have hl := congr_arg List.length heq
-    simp at hl
-  | cons s rest ih =>
-    intro p X q heq
-    rw [ContextFreeRule.applyHomList_cons] at heq
-    cases s with
-    | nonterminal Y =>
-      simp only [ContextFreeRule.Symbol.applyHom, List.singleton_append] at heq
-      cases p with
-      | nil =>
-        rw [List.nil_append, List.singleton_append, List.cons.injEq] at heq
-        obtain ⟨hYX, hreq⟩ := heq
-        injection hYX with hYX'
-        refine ⟨[], rest, ?_, rfl, hreq⟩
-        rw [List.nil_append, List.singleton_append, hYX']
-      | cons ph pt =>
-        rw [List.cons_append, List.cons_append, List.cons.injEq] at heq
-        obtain ⟨hph, hrest⟩ := heq
-        obtain ⟨pm', qm', hrest_eq, hpm', hqm'⟩ := ih hrest
-        refine ⟨.nonterminal Y :: pm', qm', ?_, ?_, hqm'⟩
-        · rw [List.cons_append, List.cons_append, hrest_eq]
-        · rw [ContextFreeRule.applyHomList_cons]
-          simp only [ContextFreeRule.Symbol.applyHom, List.singleton_append]
-          rw [hpm', hph]
-    | terminal a =>
-      simp only [ContextFreeRule.Symbol.applyHom] at heq
-      obtain ⟨p_rest, hp_eq, hR_eq⟩ := terminal_prefix_split (h a) heq
-      obtain ⟨pm', qm', hrest_eq, hpm', hqm'⟩ := ih hR_eq
-      refine ⟨.terminal a :: pm', qm', ?_, ?_, hqm'⟩
-      · rw [List.cons_append, List.cons_append, hrest_eq]
-      · rw [ContextFreeRule.applyHomList_cons]
-        simp only [ContextFreeRule.Symbol.applyHom]
-        rw [hpm']
-        exact hp_eq.symm
-
-/-- Lift a one-step `Produces` of `G.applyHom h` to a one-step `Produces` of
-    `G`, given a preimage `s` of the source. -/
-private lemma producesLift {h : T → List T'} {G : ContextFreeGrammar T}
-    {m' t' : List (Symbol T' G.NT)} (hp : (G.applyHom h).Produces m' t')
-    {s : List (Symbol T G.NT)} (hs : ContextFreeRule.applyHomList h s = m') :
-    ∃ t : List (Symbol T G.NT),
-      G.Produces s t ∧ ContextFreeRule.applyHomList h t = t' := by
-  obtain ⟨r', hr'_mem, hrw⟩ := hp
-  rw [ContextFreeGrammar.applyHom_rules] at hr'_mem
-  obtain ⟨r, hr_mem, hr_eq⟩ := Finset.mem_image.mp hr'_mem
-  subst hr_eq
-  obtain ⟨p, q, hm'_eq, ht'_eq⟩ := hrw.exists_parts
-  rw [ContextFreeRule.applyHom_input] at hm'_eq
-  rw [ContextFreeRule.applyHom_output] at ht'_eq
-  rw [← hs] at hm'_eq
-  obtain ⟨ps, qs, hs_eq, hps, hqs⟩ := decompose_applyHomList s hm'_eq
-  refine ⟨ps ++ r.output ++ qs, ?_, ?_⟩
-  · refine ⟨r, hr_mem, ?_⟩
-    rw [hs_eq]
-    exact ContextFreeRule.rewrites_of_exists_parts r ps qs
-  · rw [ContextFreeRule.applyHomList_append, ContextFreeRule.applyHomList_append,
-        hps, hqs]
-    exact ht'_eq.symm
-
-/-- Lift a multi-step `Derives` of `G.applyHom h` to a `Derives` of `G`,
-    given a preimage `s` of the source. -/
-private lemma derivesLift {h : T → List T'} {G : ContextFreeGrammar T}
-    {m' t' : List (Symbol T' G.NT)} (hd : (G.applyHom h).Derives m' t') :
-    ∀ {s : List (Symbol T G.NT)}, ContextFreeRule.applyHomList h s = m' →
-    ∃ t : List (Symbol T G.NT),
-      G.Derives s t ∧ ContextFreeRule.applyHomList h t = t' := by
+theorem Derives.of_applyHom {l : List (Symbol T G.NT)} {t' : List (Symbol T' G.NT)}
+    (hd : (G.applyHom h).Derives (l.flatMap (Symbol.applyHom h)) t') :
+    ∃ t, G.Derives l t ∧ t.flatMap (Symbol.applyHom h) = t' := by
   induction hd with
-  | refl =>
-    intro s hs
-    exact ⟨s, Relation.ReflTransGen.refl, hs⟩
-  | tail _ hstep ih =>
-    intro s hs
-    obtain ⟨m_lift, hG_m_lift, hm_lift_eq⟩ := ih hs
-    obtain ⟨t_lift, hstep_lift, ht_lift_eq⟩ := producesLift hstep hm_lift_eq
-    exact ⟨t_lift, hG_m_lift.tail hstep_lift, ht_lift_eq⟩
+  | refl => exact ⟨l, .refl _, rfl⟩
+  | tail _ step ih =>
+    obtain ⟨t, hd, rfl⟩ := ih
+    obtain ⟨t', hp, ht'⟩ := step.of_applyHom
+    exact ⟨t', hd.trans_produces hp, ht'⟩
 
-/-- Recover a terminal preimage `w` from an `applyHomList` of a
-    G-side symbol-list `t` that produces an all-terminal G'-side string
-    `w'.map .terminal`. -/
-private lemma liftMapTerminal {h : T → List T'} {N : Type*} :
-    ∀ {t : List (Symbol T N)} {w' : List T'},
-    ContextFreeRule.applyHomList h t = w'.map (Symbol.terminal (N := N)) →
-    ∃ w : List T, t = w.map .terminal ∧ List.flatMap h w = w' := by
-  intro t
-  induction t with
-  | nil =>
-    intro w' heq
-    rw [ContextFreeRule.applyHomList_nil] at heq
-    have hw' : w' = [] := List.map_eq_nil_iff.mp heq.symm
-    refine ⟨[], rfl, ?_⟩
-    rw [hw']; rfl
-  | cons s rest ih =>
-    intro w' heq
-    rw [ContextFreeRule.applyHomList_cons] at heq
-    cases s with
-    | nonterminal Y =>
-      simp only [ContextFreeRule.Symbol.applyHom, List.singleton_append] at heq
-      cases w' with
-      | nil =>
-        rw [List.map_nil] at heq
-        cases heq
-      | cons w ws =>
-        rw [List.map_cons, List.cons.injEq] at heq
-        cases heq.1
-    | terminal a =>
-      simp only [ContextFreeRule.Symbol.applyHom] at heq
-      obtain ⟨w'_rest, hw'_eq, hR_eq⟩ := terminal_map_prefix (h a) heq
-      obtain ⟨w_rest, hrest_eq, happly⟩ := ih hR_eq
-      refine ⟨a :: w_rest, ?_, ?_⟩
-      · rw [List.map_cons, hrest_eq]
-      · rw [hw'_eq, ← happly]
-        rfl
-
-/-- Backward inclusion: every `(G.applyHom h)`-generated string is the image
-    of some `G`-generated preimage under `h`. The construction lifts
-    G'-derivations to G-derivations step-by-step using `decompose_applyHomList`
-    and `liftMapTerminal`. Standard textbook construction
-    ([hopcroft-motwani-ullman-2000] Theorem 7.24 part 4 (p. 284-285, homomorphism case)). -/
-theorem applyHom_language_subset_inv (h : T → List T') (G : ContextFreeGrammar T) :
-    (G.applyHom h).language ≤ Language.stringMap h G.language := by
-  intro w' hw'
-  -- hw' : (G.applyHom h).Derives [.nonterminal G.initial] (w'.map .terminal)
-  have hlift : ContextFreeRule.applyHomList h
-                 ([Symbol.nonterminal G.initial] : List (Symbol T G.NT)) =
-               [Symbol.nonterminal G.initial] := by
-    simp [ContextFreeRule.applyHomList, ContextFreeRule.Symbol.applyHom]
-  obtain ⟨t, hGt, ht_eq⟩ := derivesLift hw' hlift
-  obtain ⟨w, hw_term, hw_apply⟩ := liftMapTerminal ht_eq
-  refine Language.mem_stringMap.mpr ⟨w, ?_, hw_apply⟩
-  show G.Derives [.nonterminal G.initial] (w.map .terminal)
-  rw [← hw_term]; exact hGt
-
-theorem applyHom_language (h : T → List T') (G : ContextFreeGrammar T) :
-    (G.applyHom h).language = Language.stringMap h G.language :=
-  le_antisymm (applyHom_language_subset_inv h G) (applyHom_language_subset h G)
+/-- The image grammar generates the image language. -/
+theorem applyHom_language (G : ContextFreeGrammar T) :
+    (G.applyHom h).language = Language.stringMap h G.language := by
+  ext w'
+  rw [mem_language_iff, Language.mem_stringMap]
+  constructor
+  · intro hd
+    obtain ⟨t, hdG, ht⟩ := Derives.of_applyHom (l := [.nonterminal G.initial]) h (by simpa using hd)
+    obtain ⟨w, rfl, rfl⟩ := Symbol.eq_map_terminal_of_flatMap_applyHom ht
+    exact ⟨w, (mem_language_iff _ _).mpr hdG, rfl⟩
+  · rintro ⟨w, hw, rfl⟩
+    simpa [Symbol.flatMap_applyHom_map_terminal] using ((mem_language_iff _ _).mp hw).applyHom h
 
 end ContextFreeGrammar
 
-namespace Language.IsContextFree
-
-theorem stringMap (f : T → List T') {L : Language T}
-    (hL : L.IsContextFree) : (Language.stringMap f L).IsContextFree := by
-  obtain ⟨G, rfl⟩ := hL
-  exact ⟨G.applyHom f, ContextFreeGrammar.applyHom_language f G⟩
+/-- Context-free languages are closed under string homomorphisms. -/
+theorem Language.IsContextFree.stringMap (f : T → List T') {L : Language T}
+    (hL : L.IsContextFree) : (Language.stringMap f L).IsContextFree :=
+  let ⟨G, hG⟩ := hL
+  ⟨G.applyHom f, by rw [ContextFreeGrammar.applyHom_language, hG]⟩
 
 /-- If the homomorphic image of `L` is not context-free, then `L` is not context-free. -/
-theorem _root_.Language.not_isContextFree_of_stringMap_not (f : T → List T') {L : Language T}
+theorem Language.not_isContextFree_of_stringMap_not (f : T → List T') {L : Language T}
     (h : ¬ (Language.stringMap f L).IsContextFree) : ¬ L.IsContextFree :=
   fun hL => h (hL.stringMap f)
-
-end Language.IsContextFree

--- a/Linglib/Core/Computability/ContextFreeGrammar/Probabilistic.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Probabilistic.lean
@@ -31,9 +31,10 @@ of the rule weight raised to the corpus count of that rule.
 ## Implementation notes
 
 Weights are `ℝ≥0∞`, the scalar of `MeasureTheory.Measure`, and a rule outside the grammar has
-weight `0`, so a tree applying such a rule has probability `0`. Whether the tree probabilities
-of a PCFG sum to one, tightness in the sense of [booth-thompson-1973] and [chi-1999], is not
-addressed here: `derivProb` is a weight on trees, not yet a measure.
+weight `0`, so a tree applying such a rule has probability `0`. `derivProb` is a weight on
+trees; the measure it is the singleton mass of, and tightness in the sense of
+[booth-thompson-1973] and [chi-1999], are in
+`Linglib.Core.Computability.ContextFreeGrammar.Measure`.
 
 ## References
 


### PR DESCRIPTION
Deep cleanse of the two closure proofs in the context-free-grammar directory; the other files were rewritten in #3295 and #3297.

- `InterRegular.lean` (934 → 337 lines): one `Annotates M p l out q` relation replaces `Projects` and `Consistent`; the product rules are enumerated by a `Finset` of annotations with `mem_annotations` as the only characterisation, so the path-vector, `List.ofFn`, `nonterminalCount` and reconstruction machinery is gone; the start symbol is `none : Option (σ × G.NT × σ)`
- `Map.lean` (412 → 217 lines): `Symbol.applyHom` in the right namespace, `List.flatMap` instead of `applyHomList`, the six private lifting lemmas collapsed into two `Symbol` lemmas and `Produces.of_applyHom`/`Derives.of_applyHom`
- `Probabilistic.lean` implementation note points at the measure file