### PR TITLE
refactor(Studies/PoesioEtAl2004): parameters as substrate instantiations

### DIFF
--- a/Linglib/Data/Examples/PoesioEtAl2004.json
+++ b/Linglib/Data/Examples/PoesioEtAl2004.json
@@ -1,0 +1,157 @@
+[
+  {
+    "id": "poesioetal2004_ex5",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(5)"},
+    "language": "stan1293",
+    "primaryText": "John walked toward the house. The door was open.",
+    "discourseSegments": [
+      "John walked toward the house.",
+      "The door was open."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "realization"],
+      ["section", "2.4.2"]
+    ],
+    "comment": "The house is realized in the second utterance only indirectly, by the associative reference the door."
+  },
+  {
+    "id": "poesioetal2004_ex7",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(7)"},
+    "language": "stan1293",
+    "primaryText": "You should not use PRODUCT-Z if you are pregnant or breast-feeding. Whilst you are receiving PRODUCT-Z ...",
+    "discourseSegments": [
+      "You should not use PRODUCT-Z",
+      "if you are pregnant or breast-feeding.",
+      "Whilst you are receiving PRODUCT-Z ..."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "cfFilter"],
+      ["parameter", "previousUtterance"],
+      ["section", "2.4.2"]
+    ],
+    "comment": "Neither the second nor the third utterance has a CB unless the second-person pronoun introduces a CF; treating the if-clause as embedded makes the first utterance the previous utterance of the third."
+  },
+  {
+    "id": "poesioetal2004_ex9",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(9)"},
+    "language": "stan1293",
+    "primaryText": "These \"egg vases\" are of exceptional quality: basketwork bases support egg-shaped bodies and bundles of straw form the handles, while small eggs resting in straw nests serve as the finial for each lid. Each vase is decorated with inlaid decoration: ...",
+    "discourseSegments": [
+      "These \"egg vases\" are of exceptional quality:",
+      "basketwork bases support egg-shaped bodies",
+      "and bundles of straw form the handles,",
+      "while small eggs resting in straw nests serve as the finial for each lid.",
+      "Each vase is decorated with inlaid decoration: ..."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "utterance"],
+      ["parameter", "realization"],
+      ["section", "4.1.1"]
+    ],
+    "comment": "With finite clauses as utterances only the last clause refers to the egg vases; identifying utterances with sentences or allowing indirect realization removes the Strong Constraint 1 violations."
+  },
+  {
+    "id": "poesioetal2004_ex10",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(10)"},
+    "language": "stan1293",
+    "primaryText": "The drawing of the corner cupboard, or more probably an engraving of it, must have caught Branicki's attention. Dubois was commissioned through a Warsaw dealer to construct the cabinet for the Polish aristocrat.",
+    "discourseSegments": [
+      "The drawing of the corner cupboard, or more probably an engraving of it, must have caught Branicki's attention.",
+      "Dubois was commissioned through a Warsaw dealer to construct the cabinet for the Polish aristocrat."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "rank"],
+      ["section", "4.1.1"]
+    ],
+    "comment": "The corner cupboard (np-compl) and Branicki (gen) tie under grammatical-function ranking and are both realized in the next utterance, so both are its CB."
+  },
+  {
+    "id": "poesioetal2004_ex14",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(14)"},
+    "language": "stan1293",
+    "primaryText": "John woke up when Bill rang the door. He had forgotten the appointment.",
+    "discourseSegments": [
+      "John woke up",
+      "when Bill rang the door.",
+      "He had forgotten the appointment."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "previousUtterance"],
+      ["section", "4.2.5"]
+    ],
+    "comment": "Kameyama-style the previous utterance of the third clause is the when-clause; Suri and McCoy-style it is the first clause."
+  },
+  {
+    "id": "poesioetal2004_ex16",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(16)"},
+    "language": "stan1293",
+    "primaryText": "Do not use scissors as you may damage the patch inside. Take out the patch.",
+    "discourseSegments": [
+      "Do not use scissors",
+      "as you may damage the patch inside.",
+      "Take out the patch."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["parameter", "previousUtterance"],
+      ["section", "4.2.5"]
+    ],
+    "comment": "The adjunct clause introduces the patch, so treating it as embedded loses the CB of the third clause."
+  },
+  {
+    "id": "poesioetal2004_ex23",
+    "source": {"bibkey": "poesio-stevenson-eugenio-hitzeman-2004", "paperLabel": "(23)"},
+    "language": "stan1293",
+    "primaryText": "This leaflet is a summary of the important information about Product A. If you have any questions or are not sure about anything to do with your treatment, ask your doctor or your pharmacist.",
+    "discourseSegments": [
+      "This leaflet is a summary of the important information about Product A.",
+      "If you have any questions or are not sure about anything to do with your treatment,",
+      "ask your doctor or your pharmacist."
+    ],
+    "glossedTokens": [],
+    "translation": "",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["section", "5.2.2"]
+    ],
+    "comment": "Successive utterances mention no common entity; the connection is made by the connectives."
+  }
+]

--- a/Linglib/Data/Examples/PoesioEtAl2004.lean
+++ b/Linglib/Data/Examples/PoesioEtAl2004.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `PoesioEtAl2004` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/PoesioEtAl2004.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace PoesioEtAl2004.Examples`.
+-/
+
+namespace PoesioEtAl2004.Examples
+
+open Data.Examples
+
+def ex5 : LinguisticExample :=
+  { id := "poesioetal2004_ex5"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(5)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John walked toward the house. The door was open."
+    discourseSegments := ["John walked toward the house.", "The door was open."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "realization"), ("section", "2.4.2")]
+    comment := "The house is realized in the second utterance only indirectly, by the associative reference the door."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex7 : LinguisticExample :=
+  { id := "poesioetal2004_ex7"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(7)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "You should not use PRODUCT-Z if you are pregnant or breast-feeding. Whilst you are receiving PRODUCT-Z ..."
+    discourseSegments := ["You should not use PRODUCT-Z", "if you are pregnant or breast-feeding.", "Whilst you are receiving PRODUCT-Z ..."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "cfFilter"), ("parameter", "previousUtterance"), ("section", "2.4.2")]
+    comment := "Neither the second nor the third utterance has a CB unless the second-person pronoun introduces a CF; treating the if-clause as embedded makes the first utterance the previous utterance of the third."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex9 : LinguisticExample :=
+  { id := "poesioetal2004_ex9"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(9)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "These \"egg vases\" are of exceptional quality: basketwork bases support egg-shaped bodies and bundles of straw form the handles, while small eggs resting in straw nests serve as the finial for each lid. Each vase is decorated with inlaid decoration: ..."
+    discourseSegments := ["These \"egg vases\" are of exceptional quality:", "basketwork bases support egg-shaped bodies", "and bundles of straw form the handles,", "while small eggs resting in straw nests serve as the finial for each lid.", "Each vase is decorated with inlaid decoration: ..."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "utterance"), ("parameter", "realization"), ("section", "4.1.1")]
+    comment := "With finite clauses as utterances only the last clause refers to the egg vases; identifying utterances with sentences or allowing indirect realization removes the Strong Constraint 1 violations."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex10 : LinguisticExample :=
+  { id := "poesioetal2004_ex10"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(10)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The drawing of the corner cupboard, or more probably an engraving of it, must have caught Branicki's attention. Dubois was commissioned through a Warsaw dealer to construct the cabinet for the Polish aristocrat."
+    discourseSegments := ["The drawing of the corner cupboard, or more probably an engraving of it, must have caught Branicki's attention.", "Dubois was commissioned through a Warsaw dealer to construct the cabinet for the Polish aristocrat."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "rank"), ("section", "4.1.1")]
+    comment := "The corner cupboard (np-compl) and Branicki (gen) tie under grammatical-function ranking and are both realized in the next utterance, so both are its CB."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14 : LinguisticExample :=
+  { id := "poesioetal2004_ex14"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(14)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "John woke up when Bill rang the door. He had forgotten the appointment."
+    discourseSegments := ["John woke up", "when Bill rang the door.", "He had forgotten the appointment."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "previousUtterance"), ("section", "4.2.5")]
+    comment := "Kameyama-style the previous utterance of the third clause is the when-clause; Suri and McCoy-style it is the first clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex16 : LinguisticExample :=
+  { id := "poesioetal2004_ex16"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(16)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Do not use scissors as you may damage the patch inside. Take out the patch."
+    discourseSegments := ["Do not use scissors", "as you may damage the patch inside.", "Take out the patch."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("parameter", "previousUtterance"), ("section", "4.2.5")]
+    comment := "The adjunct clause introduces the patch, so treating it as embedded loses the CB of the third clause."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex23 : LinguisticExample :=
+  { id := "poesioetal2004_ex23"
+    source := ⟨"poesio-stevenson-eugenio-hitzeman-2004", "(23)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "This leaflet is a summary of the important information about Product A. If you have any questions or are not sure about anything to do with your treatment, ask your doctor or your pharmacist."
+    discourseSegments := ["This leaflet is a summary of the important information about Product A.", "If you have any questions or are not sure about anything to do with your treatment,", "ask your doctor or your pharmacist."]
+    glossedTokens := []
+    translation := ""
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("section", "5.2.2")]
+    comment := "Successive utterances mention no common entity; the connection is made by the connectives."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex5, ex7, ex9, ex10, ex14, ex16, ex23]
+
+end PoesioEtAl2004.Examples

--- a/Linglib/Discourse/Centering/Transition.lean
+++ b/Linglib/Discourse/Centering/Transition.lean
@@ -50,10 +50,10 @@ theorem retaining_gt_shifting :
 
 variable {E R : Type*} [DecidableEq E]
 
-/-- Internal classifier given both Cbs: equal Cbs continue/retain
-    by Cp alignment; unequal Cbs shift. -/
-private def classifyTransitionInternal
-    (curCb : E) (curCp : Option E) (prevCb : E) : Transition :=
+/-- The transition of an utterance with center `curCb` and preferred center `curCp` after an
+utterance with center `prevCb`: the center is kept and is the preferred center (continuation),
+kept but not preferred (retaining), or changed (shifting). -/
+def Transition.ofCenters (curCb : E) (curCp : Option E) (prevCb : E) : Transition :=
   if prevCb = curCb then
     if curCp = some curCb then .continuation else .retaining
   else .shifting
@@ -67,7 +67,7 @@ def classifyTransitionStrict
   match cb prev cur, prevCb with
   | none, _      => some .shifting
   | _, none      => none  -- segment-initial: paper Def 4 is silent
-  | some curCb, some pcb => some (classifyTransitionInternal curCb cur.cp pcb)
+  | some curCb, some pcb => some (Transition.ofCenters curCb cur.cp pcb)
 
 /-- Extended classification: applies the worked-example convention
     for the segment-initial case (treats missing prior Cb as if equal
@@ -77,7 +77,7 @@ def classifyTransitionExtended
   match cb prev cur with
   | none => .shifting
   | some curCb =>
-    classifyTransitionInternal curCb cur.cp (prevCb.getD curCb)
+    Transition.ofCenters curCb cur.cp (prevCb.getD curCb)
 
 /-- The two classifications agree whenever the strict variant is
     defined. -/

--- a/Linglib/Features/Givenness.lean
+++ b/Linglib/Features/Givenness.lean
@@ -22,10 +22,9 @@ categorical view of givenness.
   A-givenness = `isAGiven` in `Studies/KratzerSelkirk2020.lean`);
   a consumer meaning another axis (e.g. discourse-status) should say so.
 
-Sibling GHZ-6 scales: Ariel's 18-tier
-`Discourse.AccessibilityLevel` and Centering's
-[strube-hahn-1999] `StrubeHahnInfoStatus.ofGivenness` (its `mediated`
-tier drawn from `uniquelyIdentifiable`/`referential`). [ariel-2001]
+Sibling scales: Ariel's 18-tier `Discourse.AccessibilityLevel` and
+Centering's [strube-hahn-1999] three information-status tiers
+(`PoesioEtAl2004.InfoStatus`). [ariel-2001]
 argues AccessibilityLevel is better grounded — the lower GHZ tiers lack
 independent scalar support — but GHZ-6 is retained as the literature's
 canonical scalar scale and is small enough for `decide`. See also

--- a/Linglib/Studies/PoesioEtAl2004.lean
+++ b/Linglib/Studies/PoesioEtAl2004.lean
@@ -1,861 +1,395 @@
-import Linglib.Discourse.Centering.Basic
-import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Transition
-import Linglib.Discourse.Coherence
+import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
-import Linglib.Studies.Sidner1983
-import Linglib.Studies.Beaver2004
-import Linglib.Discourse.Centering.Defs
-import Linglib.Features.Givenness
-import Mathlib.Order.Basic
+import Linglib.Data.Examples.PoesioEtAl2004
+import Mathlib.Data.Finset.Card
 
 /-!
-# [poesio-stevenson-eugenio-hitzeman-2004]: Centering as a Parametric Theory
+# Poesio, Stevenson, Di Eugenio and Hitzeman (2004): Centering: A Parametric Theory and Its Instantiations
 
-Poesio, Stevenson, Di Eugenio & Hitzeman (2004), "Centering: A
-Parametric Theory and Its Instantiations." *Computational Linguistics*
-30(3): 309–363. URL https://aclanthology.org/J04-3003/.
+This file formalizes the parametric reading of centering theory in
+[poesio-stevenson-eugenio-hitzeman-2004]. The claims of [grosz-joshi-weinstein-1995], Constraint
+1 on the uniqueness of the backward-looking center, Rule 1 on its pronominalization, and Rule 2
+on the preference among transitions, can only be evaluated once the notions they quantify over
+are fixed, and the literature has fixed them in several ways: what an utterance is, which
+utterance counts as the previous one, when an entity is realized, which noun phrases introduce
+forward-looking centers, how the centers are ranked, and which pronouns Rule 1 governs. Each
+setting is an instantiation of the theory, and the paper's corpus study finds that different
+instantiations make different claims true.
 
-PSDH's headline contribution: **Centering is not a single theory; it
-is a parameter family.** The variants of CB definition, utterance
-unit, "previous utterance," realization, CF filter, ranking, "pronoun"
-filter, and segmentation that have been proposed in the literature
-since [grosz-joshi-weinstein-1995] are *parameters* of the
-framework. Different parameter settings make different empirical
-claims true.
+The instantiations are the substrate's plug-ins: the realization relation is the `Realizes`
+instance, the ranking is the `CfRankerOf` instance, the CF filter is `cfFilter`, the utterance
+unit is `merge`, and the previous utterance is the argument of `cb`. The paper's illustrations
+of each parameter are worked as such: the associative reference of (5) is a `Bridged`
+realization (`ex5`), the second-person pronoun of (7) a filtered forward-looking center (`ex7`),
+the egg vases of (9) recovered either by sentence units or by indirect realization (`ex9`), the
+tie of (10) two backward-looking centers under grammatical-function ranking and one under its
+linear disambiguation (`ex10`), and the adjunct clauses of (14) and (16) the two definitions of
+the previous utterance pulling in opposite directions (`ex14`, `ex16`). Constraint 1 is
+unpacked into CB uniqueness and entity continuity (`strong_iff`), uniqueness holds under any
+ranking that separates the previous utterance's realizations (`cbAll_length_le_one`), the three
+forms of Rule 1 are ordered (`CbPronominalized.rule1Original`), and the four-way transition
+classification of [brennan-friedman-pollard-1987] refines the three-way one with its
+preference order (`bfp_toTransition`, `toTransition_mono`).
 
-## The 8 parameter axes (PSDH §3.4 p. 326)
+## Implementation notes
 
-| Parameter | Substrate location | Variants formalized in linglib |
-|---|---|---|
-| `CBdef` (which definition of CB) | `Centering/Basic.lean` `cb` | Constraint 3 (the canonical Cb-via-highest-Cf-realized definition) |
-| `uttdef` (sentence vs finite clause vs verbed clause) | `Centering/Defs.lean` `Utterance` | sentence-level only (no clause-decomposition substrate) |
-| `previous utterance` (Kameyama vs Suri-McCoy adjunct treatment) | not formalized | – |
-| `realization` (direct vs indirect/bridging) | `Realizes` typeclass | direct only (`utteranceRealizes`); bridging not formalized |
-| `CF-filter` (1st/2nd person, predicative NPs) | not formalized | – |
-| `rank` (CfRanker choice) | `CfRankerOf E R` typeclass | `GrammaticalRole` (Kameyama 1986), `StrubeHahnInfoStatus` (Strube-Hahn 1999, projecting from `Features.GivennessStatus` per the post-Krifka substrate); LinearOrder (Rambow 1993) deferred — substrate gap (Realization lacks position field) |
-| `prodef` (which "pronouns" count for Rule 1) | `Pronominalizes` typeclass | utterance's `isPronoun` flag |
-| `segmentation` | not formalized | – |
+The corpus statistics of Tables 1 to 15, the statistical tests, and the trade-off they reveal
+between Rule 1 on the one hand and Constraint 1 and Rule 2 on the other are not formalized; the
+examples carry the mechanisms the statistics measure. Utterance identification, segmentation,
+and the Walker heuristics are corpus-operational choices and are represented only by the way
+the examples are cut into utterances.
 
-The 4 axes the substrate plugs into via typeclasses (`CBdef`,
-`Realizes`, `Pronominalizes`, `CfRankerOf`) ARE the parametric story
-in Lean form — different instances of these typeclasses produce
-different `cb`/`cbAll`/Rule-1-satisfaction predictions on the same
-data. The 4 axes left unformalized are corpus-operational choices
-(sentence-segmentation rules, NP-filter rules) — we mention them in
-prose, not as Lean parameters, per the audit's "formalize the
-type-changing axes, not the bookkeeping ones" recommendation.
+## References
 
-## What this file mechanizes
-
-1. **PSDH §4.1.1 example (10)** — the corner-cupboard / Branicki
-   utterance pair where partial GF ranking yields **two CBs**
-   (since two NPs tie at the lowest grammatical-function rank
-   among realized entities). This is the load-bearing example for
-   `cbAll` — `cb` returns just the first, `cbAll` returns the
-   complete tied-at-top set, exposing the weak-Constraint-1
-   violation.
-
-2. **`Sidner1983` partial-GF witness** (not a structural bridge —
-   per audit) — PSDH §5.3.4 (p. 358) say two-CB-under-partial-GF
-   configurations are "reminiscent of" the examples that led
-   [sidner-1979] to argue for two foci. Our witness theorem
-   (`psdh_two_cb_witnesses_sidner_two_foci`) establishes that the
-   PSDH (10) configuration AND a constructed Sidner-side encoding
-   both exhibit "two-ness" — two CBs vs two distinct foci. The
-   structural translation function `centeringToSidner` that would
-   derive the Sidner state from the Centering data is deferred
-   (see §5 future work).
-
-3. **PSDH §5.2.2 entity-coherence dissociability witness** —
-   PSDH §5.2.2 (p. 353) argue entity coherence (Centering's
-   domain) and relational coherence (Hobbs/Kehler/RST) are
-   *dissociable*: entity coherence can be ABSENT while a
-   discourse remains locally coherent through relational
-   connections. PSDH (23) (the Product A pharmaceutical
-   leaflet, p. 354) is the canonical example: every adjacent
-   utterance pair has `cb = none` (NULL transition under any
-   vanilla instantiation), but the discourse is coherent via
-   instructional connectives ("If you have any questions ...
-   ask your doctor"). Our witness theorem establishes the
-   "every transition NULL" property on this discourse; the
-   relational-coherence side is in prose since `Coherence.lean`'s
-   bridge doesn't model instructional/temporal connectives.
-
-## What this file deliberately does NOT formalize
-
-- **PSDH's GNOME corpus statistics** (Tables 1-15). We don't have
-  access to the corpus; encoding their reported percentages as
-  opaque `Nat × Nat` data adds code without deriving content.
-  Cited in prose; deferred to a possible future commit.
-
-- **The full BFP 87 4-way Transition** as substrate primitive. The
-  4-way `private structure BFPTransition` lives below as a
-  study-file-local definition per the audit's "extract on second
-  consumer" discipline. Will promote to `Centering/Transition.lean`
-  when a second consumer (Walker 1989, Brennan 1995, etc.) lands.
-
-- **The `CenteringConfig` bundled record.** Per the mathlib audit,
-  PSDH's "8 parameters" map onto typeclass instances + variant
-  predicates, not a `CenteringConfig` structure. The fact that
-  "GJW95 = `[CfRanker GrammaticalRole]` + `PronominalizationConstraint` + `pairRank`"
-  is documented in prose, not as a structure-typed value. (Mathlib
-  precedent: `Mathlib.Analysis.Calculus` has `FDeriv`/`Deriv`/
-  `HasDerivAt`/`HasFDerivAt`/`lineDeriv` as separate definitions
-  with cross-implications, not a `DerivativeConfig` bundling them.)
-
-- **The OT-bridge to `OptimalityTheory.Tableau.optimal`** per
-  Beaver 2004. PSDH §3.1 fn 12 endorse Beaver's OT reformulation
-  of Centering, but the bridge theorem belongs in
-  `Studies/Beaver2004.lean` (queued as a
-  separate commit), per mathlib's `PMF` vs `Measure` precedent.
+* [poesio-stevenson-eugenio-hitzeman-2004]
+* [grosz-joshi-weinstein-1995]
+* [brennan-friedman-pollard-1987]
+* [strube-hahn-1999]
 -/
-
-/-!### Centering — Information-Status Cf Ranking
-[strube-hahn-1999] [prince-1981]
-[gundel-hedberg-zacharski-1993]
-
-Strube-Hahn's 3-tier information-status ranker (HEARER-OLD > MEDIATED
-> HEARER-NEW) as a `CfRanker` instance. `ofGivenness` projects GHZ's
-6-tier `GivennessStatus` onto the Strube-Hahn tiers.
--/
-
-namespace Discourse.Centering
-
-open Features (GivennessStatus)
-
-/-- Strube-Hahn's information-status 3-tier taxonomy. -/
-inductive StrubeHahnInfoStatus where
-  /-- Discourse-old or unused/evoked. Highest salience. -/
-  | hearerOld
-  /-- Inferable, containing-inferable, or anchored-brand-new. -/
-  | mediated
-  /-- Brand-new entity. Lowest salience. -/
-  | hearerNew
-  deriving DecidableEq, Repr, Fintype, Inhabited
-
-/-- Strube-Hahn IS rank on `Nat`: HEARER-OLD = 2 (highest Centering
-    rank, matching `≺ = more salient`), MEDIATED = 1, HEARER-NEW = 0. -/
-def StrubeHahnInfoStatus.rank : StrubeHahnInfoStatus → Nat
-  | .hearerOld  => 2
-  | .mediated   => 1
-  | .hearerNew  => 0
-
-/-- The Strube-Hahn Cf-ranker instance — sibling of `GrammaticalRole`,
-    enabling the parametric Centering story PSDH §4.4 evaluate. -/
-instance : CfRanker StrubeHahnInfoStatus where
-  rank := StrubeHahnInfoStatus.rank
-
-/-- Total order via the rank pullback, mirroring the `LinearOrder
-    GrammaticalRole` instance in the sibling file. -/
-instance : LinearOrder StrubeHahnInfoStatus := CfRanker.toLinearOrder _
-
-/-- Project GHZ's 6-tier `GivennessStatus` onto Strube-Hahn's 3-tier
-    information status, via the GHZ → Prince → Strube-Hahn chain. -/
-def StrubeHahnInfoStatus.ofGivenness :
-    GivennessStatus → StrubeHahnInfoStatus
-  | .inFocus              => .hearerOld
-  | .activated            => .hearerOld
-  | .familiar             => .hearerOld
-  | .uniquelyIdentifiable => .mediated
-  | .referential          => .mediated
-  | .typeIdentifiable     => .hearerNew
-
-/-- MEDIATED is reachable via `uniquelyIdentifiable` (and `referential`). -/
-theorem mediated_reachable :
-    ∃ g : GivennessStatus, StrubeHahnInfoStatus.ofGivenness g = .mediated :=
-  ⟨.uniquelyIdentifiable, rfl⟩
-
-/-- The projection is rank-monotone: more activated GHZ tiers map to
-    higher Strube-Hahn ranks. -/
-theorem ofGivenness_monotone (a b : GivennessStatus) :
-    a.rank ≥ b.rank →
-    (StrubeHahnInfoStatus.ofGivenness a).rank ≥
-      (StrubeHahnInfoStatus.ofGivenness b).rank := by
-  cases a <;> cases b <;> decide
-
-end Discourse.Centering
-
-
-/-!### Centering Theory — Constraint 1
-[poesio-stevenson-eugenio-hitzeman-2004] [grosz-joshi-weinstein-1995]
-PSDH §5.3.2's decomposition of GJW's Constraint 1 into CB Uniqueness
-(at most one CB) and Entity Continuity (at least one CB). Strong C1 =
-their conjunction (exactly one CB).
--/
-namespace Discourse.Centering
-variable {E R : Type*}
-/-! ### CB Uniqueness, Entity Continuity, Strong C1 -/
-/-- CB Uniqueness: the utterance pair has at most one CB. -/
-def CBUniqueness [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) : Prop :=
-  (cbAll prev cur).length ≤ 1
-/-- Entity Continuity: the utterance pair shares at least one CF entity. -/
-def EntityContinuity [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) : Prop :=
-  (cbAll prev cur).length ≥ 1
-/-- Strong Constraint 1: exactly one CB (Uniqueness ∧ Continuity). -/
-def Constraint1Strong [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) : Prop :=
-  (cbAll prev cur).length = 1
-/-! ### Decidability -/
-instance CBUniqueness.decidable [DecidableEq E] [CfRankerOf E R] {U : Type*}
-    [Realizes U E] (prev : Utterance E R) (cur : U) :
-    Decidable (CBUniqueness prev cur) :=
-  inferInstanceAs (Decidable ((cbAll prev cur).length ≤ 1))
-instance EntityContinuity.decidable [DecidableEq E] [CfRankerOf E R] {U : Type*}
-    [Realizes U E] (prev : Utterance E R) (cur : U) :
-    Decidable (EntityContinuity prev cur) :=
-  inferInstanceAs (Decidable ((cbAll prev cur).length ≥ 1))
-instance Constraint1Strong.decidable [DecidableEq E] [CfRankerOf E R] {U : Type*}
-    [Realizes U E] (prev : Utterance E R) (cur : U) :
-    Decidable (Constraint1Strong prev cur) :=
-  inferInstanceAs (Decidable ((cbAll prev cur).length = 1))
-/-! ### PSDH §5.3.2 decomposition theorem -/
-/-- PSDH §5.3.2 decomposition: Strong C1 ↔ CB Uniqueness ∧ Continuity. -/
-theorem strongC1_iff_uniqueness_and_continuity
-    [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
-    (prev : Utterance E R) (cur : U) :
-    Constraint1Strong prev cur ↔ CBUniqueness prev cur ∧ EntityContinuity prev cur := by
-  unfold Constraint1Strong CBUniqueness EntityContinuity
-  omega
-/-- Strong implies Weak: a unique CB implies at most one CB. -/
-theorem strong_implies_uniqueness [DecidableEq E] [CfRankerOf E R] {U : Type*}
-    [Realizes U E] {prev : Utterance E R} {cur : U}
-    (h : Constraint1Strong prev cur) : CBUniqueness prev cur := by
-  unfold Constraint1Strong at h
-  unfold CBUniqueness
-  omega
-end Discourse.Centering
-
 
 namespace PoesioEtAl2004
 
 open Discourse.Centering
 
-/-! Throughout, examples use `String` entities for readability and
-    `Utterance String GrammaticalRole` from the substrate. The IS
-    ranker (Strube-Hahn) is illustrated separately. -/
-
-abbrev Utt : Type := Utterance String GrammaticalRole
-
--- ════════════════════════════════════════════════════
--- § 1. Example (10): partial GF ranking → two CBs
--- ════════════════════════════════════════════════════
-
-/-! [poesio-stevenson-eugenio-hitzeman-2004] §4.1.1 (p. 329)
-    cite their corpus example (10) where partial grammatical-function
-    ranking yields *two* CBs. The XML annotation in the paper has
-    `the corner cupboard` (np-compl) and `Branicki` (gen) tied at
-    the same grammatical-function rank — both rank lower than the
-    matrix subject `the drawing of …`, but neither outranks the
-    other. When both are realized in the next utterance (u229),
-    both qualify as the CB.
-
-    PSDH note (p. 329): "This problem with the vanilla instantiation
-    can also be 'fixed' by requiring the ranking function to be a
-    total order, which is easily done by adding a disambiguation
-    factor such as linear order, as done by Strube and Hahn." -/
-
-/-- (u227 simplified) "The drawing of the corner cupboard, or more
-    probably an engraving of it, must have caught Branicki's
-    attention." Two non-subject NPs tied at GR rank: `corner_cupboard`
-    (the postcopular NP) and `Branicki` (genitive). Modeled here as
-    two `.other` realizations (since GrammaticalRole's three-way
-    coarsens both np-compl and gen to OTHER). -/
-def u227 : Utt :=
-  ⟨[⟨"the_drawing", .subject, false⟩,
-    ⟨"corner_cupboard", .other, false⟩,
-    ⟨"Branicki", .other, false⟩]⟩
-
-/-- (u229 simplified) "Dubois was commissioned through a Warsaw
-    dealer to construct the cabinet for the Polish aristocrat."
-    Both `corner_cupboard` (the cabinet) and `Branicki` (the Polish
-    aristocrat) are realized. -/
-def u229 : Utt :=
-  ⟨[⟨"Dubois", .subject, false⟩,
-    ⟨"corner_cupboard", .object, false⟩,
-    ⟨"Branicki", .other, false⟩]⟩
-
-/-- The single-CB function returns just one of the two tied
-    candidates (whichever comes first in `prev.cf`'s sorted order;
-    `cfInsert`'s `foldr`-based implementation places equal-rank
-    realizations in reverse insertion order, so `Branicki` precedes
-    `corner_cupboard` in `cf u227` despite their tied .other rank). -/
-theorem u227_to_u229_cb : cb u227 u229 = some "Branicki" := by decide
-
-/-- **Both candidates qualify as CBs** under partial GR ranking:
-    `cbAll` returns both `corner_cupboard` and `Branicki` because
-    they tie at the maximum rank among realized entities (both `.other`
-    in u227, both realized in u229). This is the **PSDH §4.1.1
-    multi-CB case** that motivates `cbAll` as a substrate operator. -/
-theorem u227_to_u229_cbAll :
-    (cbAll u227 u229).length = 2 := by decide
-
-/-- **CB Uniqueness fails** on this pair: more than one candidate CB
-    exists. PSDH §4.1.1 (p. 329 prose) report 11 utterances (1.1%)
-    in their corpus exhibit this multi-CB pattern under partial GR
-    ranking. -/
-theorem u227_to_u229_violates_cb_uniqueness :
-    ¬ CBUniqueness u227 u229 := by decide
-
-/-- **Entity Continuity holds**: at least one candidate CB exists. -/
-theorem u227_to_u229_satisfies_continuity :
-    EntityContinuity u227 u229 := by decide
-
-/-- **Strong C1 fails** because of the uniqueness clause. By the
-    decomposition theorem `strongC1_iff_uniqueness_and_continuity`
-    (`Centering/Constraints.lean`), Strong C1 = Uniqueness ∧
-    Continuity, so failing uniqueness fails Strong C1. -/
-theorem u227_to_u229_violates_strong_c1 :
-    ¬ Constraint1Strong u227 u229 := by decide
-
--- ════════════════════════════════════════════════════
--- § 2. Bridge to Sidner1983: the two-CB case is two-focus territory
--- ════════════════════════════════════════════════════
-
-/-! [poesio-stevenson-eugenio-hitzeman-2004] §5.3.4 (p. 358):
-
-    > [These] examples are reminiscent of the examples that led
-    > [sidner-1979] to argue for two foci — sentences with one
-    > animate entity (typically in agent position) and an inanimate
-    > one (typically in theme position), like *Mortimer sold the book
-    > for 10 cents* or *Mary took a nickel from her toy bank yesterday*.
-
-    PSDH note that the same configurations producing two CBs under
-    partial GF ranking are precisely the configurations Sidner's
-    two-focus account handles directly: an animate entity (actor
-    focus) co-occurring with an inanimate one (discourse focus).
-
-    The `Sidner1983.FocusState` two-slot architecture (discourse focus
-    + actor focus) at `Studies/Sidner1983.lean`
-    accommodates exactly these cases — they're not "two CBs" in
-    Sidner's framework, they're "the AF and the DF, which by Sidner's
-    architecture can coincide or differ." -/
-
-/-- **PSDH §5.3.4 ↔ Sidner1983 bridge**: configurations where partial
-    GF ranking yields two CBs are configurations where Sidner's
-    two-focus state has *non-equal* discourse focus and actor focus.
-    Witnessed on a synthesized example modeling the corner-cupboard
-    case in Sidner's encoding: `Branicki` is the agent (actor focus
-    candidate), `corner_cupboard` is the inanimate theme (discourse
-    focus candidate). The bridge claim PSDH leave informal becomes
-    the existence of a Sidner state where DF ≠ AF on the same data
-    that yields multi-CB under partial GF.
-
-    This is one of the cross-framework theorems linglib's
-    interconnection-density discipline aims to make visible: PSDH's
-    parametric-centering observation and Sidner's two-focus
-    architecture are answering different questions about the same
-    empirical configuration. -/
-def sidnerSentenceForCornerCupboard : Sidner1983.Sentence String :=
-  { form := .normal
-    phrases :=
-      [⟨"Branicki", .agent, .agent, false⟩,
-       ⟨"corner_cupboard", .theme, .nonAgent, false⟩] }
-
-/-- Sidner's two-slot state for the corner-cupboard configuration:
-    `Branicki` (agent) is the actor focus; `corner_cupboard` (theme)
-    is the discourse focus. The two slots are *distinct* —
-    exactly the configuration PSDH §5.3.4 say motivated Sidner's
-    two-focus architecture. -/
-def sidnerStateForCornerCupboard : Sidner1983.FocusState String :=
-  Sidner1983.updateState Sidner1983.FocusState.empty sidnerSentenceForCornerCupboard
-
-theorem sidner_distinguishes_actor_from_discourse :
-    sidnerStateForCornerCupboard.actorFocus ≠ sidnerStateForCornerCupboard.discourseFocus := by decide
-
-/-- Sidner's discourse focus matches one PSDH-CB candidate
-    (the theme — the inanimate entity, `corner_cupboard`). -/
-theorem sidner_df_matches_psdh_cb_candidate :
-    sidnerStateForCornerCupboard.discourseFocus = some "corner_cupboard" := by decide
-
-/-- Sidner's actor focus matches the OTHER PSDH-CB candidate
-    (the agent — the animate entity, `Branicki`). -/
-theorem sidner_af_matches_psdh_cb_candidate :
-    sidnerStateForCornerCupboard.actorFocus = some "Branicki" := by decide
-
-/-- **Witness theorem** (NOT a structural bridge): on the constructed
-    Sidner sentence modeling PSDH (10), Sidner's actor focus and
-    discourse focus are distinct, AND `cbAll u227 u229` has length 2.
-    The two facts are independently established by `decide` on
-    independently constructed inputs (`u227`/`u229` for the Centering
-    side; `sidnerSentenceForCornerCupboard` for the Sidner side); no
-    function `centeringToSidner : Utterance → Sidner1983.Sentence`
-    derives one from the other.
-
-    PSDH §5.3.4 (p. 358) say only "reminiscent of the examples that
-    led Sidner to argue for two foci" — an analogy, not an
-    equivalence. The theorem name was previously `psdh_two_cb_iff_sidner_two_foci`
-    suggesting biconditional / structural equivalence; renamed per
-    audit to reflect that this is a witness on a constructed
-    example, not a `↔`. The structural translation function and
-    derived bridge theorem are queued as follow-up work (see §5
-    deferred items). -/
-theorem psdh_two_cb_witnesses_sidner_two_foci :
-    (cbAll u227 u229).length = 2 ∧
-    sidnerStateForCornerCupboard.actorFocus ≠ sidnerStateForCornerCupboard.discourseFocus :=
-  ⟨by decide, by decide⟩
-
--- ════════════════════════════════════════════════════
--- § 3. PSDH §5.2.2: entity-coherence dissociability — Example (23)
--- ════════════════════════════════════════════════════
-
-/-! [poesio-stevenson-eugenio-hitzeman-2004] §5.2.2 (p. 353-354):
-
-    > One clear conclusion suggested by our results is that
-    > entity-based accounts of coherence need to be supplemented by
-    > accounts of other factors that induce coherence at the local
-    > level. … in the pharmaceutical subdomain many examples in
-    > which successive utterances do not mention the same entities,
-    > but the connection between clauses is explicitly indicated by
-    > connectives, as in (23):
-
-    > (23) (u1) This leaflet is a summary of the important
-    >          information about Product A.
-    >      (u2) If you have any questions or are not sure about
-    >          anything to do with your treatment,
-    >      (u3) ask your doctor or your pharmacist.
-
-    PSDH's argument is that **entity coherence is *dissociable* from
-    local coherence** — the discourse is coherent (it instructs the
-    reader) but no entity carries through (the leaflet, your
-    questions, your doctor are pairwise disjoint as discourse
-    referents). Centering predicts NULL transitions throughout; the
-    coherence comes from elsewhere (instructional/temporal
-    connectives, Hobbs/Kehler relational coherence, RST elaboration).
-
-    We mechanize the **entity-coherence-side** of the argument: every
-    adjacent pair in (23) has `cb = none`, so under PSDH's BFP-style
-    transition labelling all transitions are NULL. The relational-
-    coherence side cannot be mechanized in the existing substrate
-    — `Centering/Coherence.lean` formalizes a Kehler 2002 1-to-1
-    mapping `CoherenceRelation → Transition`, but doesn't model the
-    instructional/temporal connectives that carry (23)'s coherence.
-    A future commit could extend the substrate or add a
-    `Studies/Knott2001.lean` to formalize PSDH's
-    cited finding that relational accounts converge with entity
-    coherence rather than displacing it. -/
-
-namespace D23
-
-/-- (23 u1) "This leaflet is a summary of the important information
-    about Product A." Three discourse entities. -/
-def u1 : Utt :=
-  ⟨[⟨"leaflet", .subject, false⟩,
-    ⟨"summary", .other, false⟩,
-    ⟨"info", .other, false⟩,
-    ⟨"product_A", .other, false⟩]⟩
-
-/-- (23 u2) "If you have any questions or are not sure about anything
-    to do with your treatment." Disjoint discourse entities from u1
-    (you, questions, treatment). -/
-def u2 : Utt :=
-  ⟨[⟨"reader_you", .subject, false⟩,
-    ⟨"questions", .object, false⟩,
-    ⟨"treatment", .other, false⟩]⟩
-
-/-- (23 u3) "ask your doctor or your pharmacist." Yet another
-    disjoint set (you, doctor, pharmacist). -/
-def u3 : Utt :=
-  ⟨[⟨"reader_you", .subject, false⟩,
-    ⟨"doctor", .object, false⟩,
-    ⟨"pharmacist", .other, false⟩]⟩
-
-end D23
-
-/-- **u1 → u2 has no CB**: Cf(u1) is `[leaflet, summary, info, product_A]`,
-    none realized in u2. NULL transition. -/
-theorem d23_u1_to_u2_cb_none : cb D23.u1 D23.u2 = none := by decide
-
-/-- **u2 → u3 has CB = "reader_you"**: u2 and u3 share the second-person
-    referent. (Strong C1 violations of the kind PSDH study would also
-    flag this — second-person pronouns count as CFs only under PSDH's
-    PRO2 instantiation; under their default vanilla instantiation
-    second-person pronouns do not introduce CFs and this transition
-    too is NULL.) -/
-theorem d23_u2_to_u3_cb_some : cb D23.u2 D23.u3 = some "reader_you" := by decide
-
-/-- **PSDH §5.2.2 entity-coherence dissociability witness**: in PSDH
-    (23), the u1 → u2 transition has *no* CB at all, yet the discourse
-    is coherent (the leaflet's u2 is the conditional clause introducing
-    u3's instruction). PSDH argue that local coherence must therefore
-    have a non-entity-based source.
-
-    The theorem is honest about scope: it witnesses the entity-side
-    *absence* (cb is none); the relational coherence that PSDH say
-    fills the gap is not mechanizable in the current substrate without
-    extending `Coherence.lean` to model instructional/temporal
-    connectives. (Compare to my prior overclaiming `centering_vs_kehler_bridge_diverge`
-    — that previous theorem was true but didn't engage what PSDH
-    actually argue.) -/
-theorem psdh_5_2_2_entity_coherence_dissociable_on_23 :
-    cb D23.u1 D23.u2 = none := d23_u1_to_u2_cb_none
-
--- ════════════════════════════════════════════════════
--- § 4. Sample IS-ranker example (Strube-Hahn 1999)
--- ════════════════════════════════════════════════════
-
-/-! Demonstrates that the `InformationStatus` Cf-ranker (`Centering/Instances/InformationStatus.lean`)
-    produces a *different* Cf order from `GrammaticalRole` on the
-    same realizations — the parametric story PSDH §4.4.3 evaluate.
-
-    The IS ranker uses `StrubeHahnInfoStatus` (HEARER-OLD / MEDIATED
-    / HEARER-NEW) directly as the role type. On a sentence where the
-    grammatical subject is HEARER-NEW (a freshly introduced entity)
-    and the object is HEARER-OLD (already in the discourse), the two
-    rankers disagree on which entity has the highest Cf rank. -/
-
-abbrev IsUtt : Type := Utterance String StrubeHahnInfoStatus
-
-/-- A two-NP utterance where the subject is HEARER-NEW and the object
-    is HEARER-OLD. Under the Strube-Hahn IS ranker, the object outranks
-    the subject (HEARER-OLD ≺ HEARER-NEW means lower IS rank ≺ more
-    salient ⇒ higher Centering rank); under GR, the subject would
-    outrank (SUBJ > OBJ). The two rankers' Cp predictions diverge —
-    the parametric story PSDH §4.4.3 evaluate. -/
-def is_example_utt : IsUtt :=
-  ⟨[⟨"new_subject", .hearerNew, false⟩,
-    ⟨"old_object", .hearerOld, false⟩]⟩
-
-/-- The Strube-Hahn IS ranker picks the HEARER-OLD entity as Cp,
-    contrary to the GR ranker which would pick the subject. -/
-theorem is_ranker_picks_hearerOld_as_cp :
-    is_example_utt.cp = some "old_object" := by decide
-
--- ════════════════════════════════════════════════════
--- § 5. Beaver 2004 OT bridge → see Beaver2004.lean
--- ════════════════════════════════════════════════════
-
-/-! [poesio-stevenson-eugenio-hitzeman-2004] §3.1 fn 12 cite
-    [beaver-2004] ("The Optimization of Discourse Anaphora,"
-    *Linguistics and Philosophy* 27(1):3-56) as the canonical
-    optimality-theoretic reformulation of Centering. The full bridge
-    formalization — six ranked OT constraints (AGREE > DISJOINT >
-    PRO-TOP > FAM-DEF > COHERE > ALIGN), Beaver Theorem (20)
-    BFP-equivalence witnesses on his examples (12) and (2), and the
-    PRO-TOP demotion (Beaver §4.1) that fixes the BFP Rule-1
-    overprediction PSDH §3.1 fn 12 explicitly cite — lives in
-    `Studies/Beaver2004.lean`.
-
-    Three of Beaver's six constraints are LITERAL RESTATEMENTS of
-    existing Centering primitives (PRO-TOP via `CbPronominalized`,
-    COHERE via `cb`, ALIGN via `cb`+`cp`); see Beaver2004.lean §2.
-    The deep-reuse design makes Theorem (20) partly structural — the
-    OT-vs-BFP equivalence on those 3 clauses follows by definition. -/
-
-/-! ## §5.1 Two totalizers for PSDH (10): Strube-Hahn vs Beaver
-
-    PSDH at p. 329 (§4.1.1, fn 21) raise the multi-CB problem on
-    `u227`/`u229` and explicitly endorse one fix: **adding a
-    disambiguation factor such as linear order, as done by Strube and
-    Hahn**. They return to the issue at §5.3.4, considering whether
-    to keep CB uniqueness (via a totalizer like Strube-Hahn's) or
-    abandon it (Givón 1983, Gundel 1998). The §3.1 fn 12 endorsement
-    of [beaver-2004] is for a *different* problem — Beaver's COT
-    fixes BFP 87's hard-vs-soft confusion of Rule 1, not the
-    partial-ranking → multi-CB tie. So PSDH effectively pose two
-    totalizers in different sections of the same paper:
-
-    1. **Strube-Hahn linear-order** (PSDH p. 329 fn 21): break ties by
-       surface position. Resolves `u227`'s ne547 ↔ ne551 tie
-       parametrically only in the surface-string of `u227`.
-
-    2. **Beaver's COT lex-min** (PSDH §5.3.3, mentioning Beaver-style
-       constraint stacking; Beaver §3.2's COHERE/ALIGN over `cb`):
-       break ties by lex-min over a constraint hierarchy that
-       references `priorTopic`. Resolves the tie parametrically in
-       `priorTopic` — itself a slot the previous utterance underdetermines
-       on this example.
-
-    Mechanically applied to PSDH (10), Beaver's totalizer is
-    **sensitive to the priorTopic parameter** in a way Strube-Hahn's is
-    not. Different choices of "the prior topic" produce different
-    optima under Beaver's lex-min; under Strube-Hahn linear-order, the
-    surface-position fact alone fixes the answer. The cross-framework
-    finding is not "Beaver can't see PSDH's tie" (true of any single-`cb`
-    framework — banal) but **"Beaver's totalizer propagates PSDH's
-    underdetermination via priorTopic, while Strube-Hahn's positional
-    totalizer resolves it"** — a structural-faithfulness comparison
-    PSDH's two endorsements implicitly invite.
-
-    The Strube-Hahn side is partly formalized at §4 of this file
-    (`StrubeHahnInfoStatus` ranker); the linear-order positional
-    primitive Strube-Hahn use as a tiebreaker is not yet substrate
-    (`Realization` lacks a `position : Nat` field — see §6 deferred
-    items). The Beaver side is concrete here. -/
-
-open Beaver2004 (cohere align)
-
-/-- Wrap u229 as a Beaver COT candidate. Since u229 contains no
-    pronouns whose resolution is in question (both `corner_cupboard`
-    and `Branicki` are realized by definite NPs in PSDH (10)),
-    the substrate-gap flags are irrelevant — set them all `true`
-    so that the only constraints that can fire are the ones built
-    on Centering primitives (COHERE, ALIGN, PRO-TOP). -/
-def cand_u229 : Beaver2004.Candidate String GrammaticalRole :=
-  ⟨u229, true, true, true⟩
-
-/-- Beaver's `cb`, applied to PSDH (10), returns ONE entity (Branicki),
-    chosen by `find?`-on-sort-order — not a set. The `Option E` typing
-    of `cb` discards the tie information `cbAll` exposes. -/
-theorem beaver_cb_picks_branicki_on_psdh10 :
-    Discourse.Centering.cb u227 u229 = some "Branicki" := by decide
-
-/-- **The substrate gap**: on PSDH (10), `cbAll` reports a two-element
-    tie containing both candidates, but Beaver's `cb` reports only
-    Branicki (first by sort order). Composes from the named cb-witness
-    + the cbAll fact. The third conjunct from the previous version
-    (`cb ≠ some "corner_cupboard"`) followed from the first by
-    `Option.some.injEq` — dropped per audit. -/
-theorem beaver_cb_silent_on_psdh10_tie :
-    Discourse.Centering.cb u227 u229 = some "Branicki" ∧
-    "corner_cupboard" ∈ Discourse.Centering.cbAll u227 u229 :=
-  ⟨beaver_cb_picks_branicki_on_psdh10, by decide⟩
-
-/-- **COHERE depends on the choice of priorTopic** — Beaver's totalizer
-    propagates PSDH (10)'s tie. If we feed Beaver's COHERE the
-    `Branicki`-side as priorTopic, COHERE is satisfied (eval = 0). If
-    we feed it the `corner_cupboard`-side, COHERE fires (eval = 1).
-    Beaver's lex-min on the same `cand_u229` produces opposite
-    verdicts depending on which member of the PSDH tie the previous
-    utterance "really" had as topic — a slot PSDH's parametric
-    analysis says is underdetermined.
-
-    By contrast, a **Strube-Hahn linear-order totalizer** would resolve
-    the tie purely from `u227`'s surface-position ordering of ne547
-    (corner_cupboard, before) vs ne551 (Branicki's, after) — that
-    answer is a fact about `u227` alone and doesn't depend on a
-    further priorTopic parameter. The two totalizers don't agree on
-    which of `Branicki`/`corner_cupboard` is "the" CB of u227. -/
-theorem beaver_cohere_sensitive_to_psdh10_tie_choice :
-    (cohere u227 (some "Branicki")) cand_u229 = 0 ∧
-    (cohere u227 (some "corner_cupboard")) cand_u229 = 1 := by
-  refine ⟨?_, ?_⟩ <;> decide
-
-/-- **ALIGN fires regardless** of which tie-member is fed in: u229's
-    Cp is `Dubois` (the new SUBJ), and `cb u227 u229 = some Branicki`
-    is in OBJ position, not subject. So under Beaver's machinery,
-    PSDH (10) shows a CB-not-in-subject-position pattern — typical
-    RETAIN/SHIFT territory. The Strube-Hahn-vs-Beaver totalizer
-    contrast lives entirely in COHERE's sensitivity to priorTopic;
-    ALIGN is constant across the choice. -/
-theorem beaver_align_fires_on_psdh10 :
-    (align u227) cand_u229 = 1 := by decide
-
-/-- **`beaver_lex_min_on_psdh_10`** — the cross-framework headline.
-    Beaver's COT lex-min, applied to PSDH (10), produces strictly
-    different total-violation counts depending on which member of
-    PSDH's tie is supplied as `priorTopic`:
-
-    - **Branicki-as-prior** (matches Beaver's own `cb u227`): COHERE
-      satisfied, ALIGN violated. Total = 1 violation.
-    - **corner_cupboard-as-prior** (the alternative `cbAll` member):
-      COHERE violated, ALIGN violated. Total = 2 violations.
-
-    Under the COHERE > ALIGN ranking, the Branicki-prior interpretation
-    strictly dominates. So Beaver's lex-min "picks" Branicki — but only
-    by silently agreeing with the choice `cb u227 u229` already made by
-    sort order. The lex-min mechanism contributes no new information
-    about which member of PSDH's tie deserves to be the unique CB; it
-    inherits and amplifies the sort-order decision.
-
-    By contrast, Strube-Hahn's linear-order totalizer would pick the
-    *earlier-in-surface-order* member of the tie — `corner_cupboard`
-    (ne547, before Branicki's ne551 in u227). The two totalizers
-    therefore *disagree* on which entity of PSDH's tie is the unique
-    CB. PSDH p. 329 endorse Strube-Hahn's choice; Beaver's totalizer
-    inverts it. -/
-theorem beaver_lex_min_on_psdh_10 :
-    -- Branicki-as-prior interpretation: only ALIGN fires
-    (cohere u227 (some "Branicki")) cand_u229 +
-      (align u227) cand_u229 = 1 ∧
-    -- corner_cupboard-as-prior interpretation: COHERE + ALIGN both fire
-    (cohere u227 (some "corner_cupboard")) cand_u229 +
-      (align u227) cand_u229 = 2 ∧
-    -- Branicki-prior strictly dominates corner_cupboard-prior (lex-min picks Branicki)
-    ((cohere u227 (some "Branicki")) cand_u229 +
-      (align u227) cand_u229) <
-    ((cohere u227 (some "corner_cupboard")) cand_u229 +
-      (align u227) cand_u229) := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
-
-/-! ## §5.1.1 The structural underpinning
-
-    The four `decide`-checked theorems above verify Beaver's COT on
-    PSDH (10) at the level of literal Nat comparisons. They are
-    corollaries of the substrate-level structural-faithfulness
-    theorems landed in `Beaver2004.lean §2a`:
-
-    - `Beaver2004.cohere_factors_through_cb`: COHERE's evaluation is
-      determined by `cb prev c.utt` and `priorTopic` only.
-    - `Beaver2004.align_factors_through_cb_and_cp`: ALIGN's evaluation
-      is determined by `cb prev c.utt` and `c.utt.cp` only.
-
-    The cross-framework story therefore decomposes into:
-
-    1. **Cb-blindness on the candidate side** (proved structurally in
-       Beaver2004): for a fixed (prev, priorTopic), Beaver's COHERE
-       is invariant across cb-equivalent candidates. PSDH (10)'s
-       multi-CB tie cannot enter through the candidate slot.
-    2. **PriorTopic-sensitivity on the parameter side** (proved on the
-       worked example here, via `decide`): COHERE's verdict varies
-       across the two members of PSDH's tie when fed as priorTopic.
-       The tie enters through the parameter slot, not the candidate
-       slot.
-    3. **The lex-min picks the cb-internal choice**
-       (`beaver_lex_min_on_psdh_10`): under COHERE > ALIGN, Beaver's
-       optimum agrees with `cb`'s sort-order choice (Branicki),
-       inverting Strube-Hahn's positional choice (corner_cupboard,
-       earlier in surface order).
-
-    The structural theorems make explicit that (1) is a property of
-    Beaver's substrate, not of PSDH (10) specifically; the
-    per-example facts (2)+(3) are the kernel-checked instances. -/
-
-/-- **Substrate-corollary form**: any candidate `c` whose `cb` agrees
-    with `cand_u229`'s on `u227` gets the SAME COHERE evaluation as
-    `cand_u229`, for any priorTopic. This is the abstract version of
-    "Beaver cannot recover the discarded tie member from candidate-side
-    information"; the per-example `beaver_cohere_sensitive_to_psdh10_tie_choice`
-    above is the witness that priorTopic-side variation is the only
-    route by which the PSDH tie can enter Beaver's verdict. -/
-theorem beaver_cohere_invariant_under_cb_equiv_candidates
-    (priorTopic : Option String) (c : Beaver2004.Candidate String GrammaticalRole)
-    (h : Discourse.Centering.cb u227 c.utt = Discourse.Centering.cb u227 u229) :
-    (cohere u227 priorTopic) c = (cohere u227 priorTopic) cand_u229 :=
-  Beaver2004.cohere_factors_through_cb u227 priorTopic c cand_u229 h
-
--- ════════════════════════════════════════════════════
--- § 6. Future work / deferred items
--- ════════════════════════════════════════════════════
-
-/-! ## Items deferred from this commit
-
-    - **`LinearOrder` ranker** (Rambow 1993, surface position): the
-      existing `Realization E R` structure carries `entity / role /
-      isPronoun` but no explicit `position` field; without per-
-      realization position info, a linear-order `CfRankerOf` instance
-      cannot be expressed cleanly. Adding `position : Nat` to
-      `Realization` is a substrate change that would cascade to all
-      anonymous-constructor call sites in study files. Deferred to a
-      separate commit.
-
-    - **BFP 87 4-way `BFPTransition` (CON | RET | SSH | RSH)**: the
-      Smooth-Shift / Rough-Shift refinement requires a 4-way enum.
-      Per the audit's "extract on second consumer" discipline, the
-      4-way stays study-file-local until a second consumer (Walker
-      1989, Brennan 1995, Tetreault 2001) motivates promotion.
-      A `private structure` form would land here when an empirical
-      contrast requiring SSH/RSH discrimination gets formalized.
-
-    - **PSDH GNOME corpus statistics** (Tables 1-15): encoding the
-      reported per-instantiation violation percentages (~25% Strong
-      C1 violations at vanilla, dropping to ~22% under best
-      instantiation; Rule 1 (GJW 95) ≤8% violations across all
-      instantiations). The corpus data isn't accessible to us; the
-      statistics would have to be encoded as opaque `Nat` values
-      with PSDH-table citations — defensible for paper replication
-      but adds significant code without deriving content. Deferred.
-
-    - **Full Beaver 2004 substrate-level OT-Centering bridge**: a
-      *general* substrate theorem `cbAll prev cur = (centeringAsTableau prev cur).optimal.image (·.entity)`
-      requires constructing the full `Tableau` (Finset candidates +
-      Nonempty proof + ViolationProfile mapping). `Beaver2004.lean`
-      lands the per-example witnesses (with the full 6-constraint
-      ranking and Theorem (20) verification on Beaver's own (12) and
-      (2) examples); the general substrate-level theorem is still
-      queued.
-
-    - **Structural `centeringToSidner` translation**: the §2 Sidner
-      bridge (`psdh_two_cb_witnesses_sidner_two_foci`) is currently a
-      witness on independently constructed inputs, not a structural
-      identity. A function `centeringToSidner : Utterance E R →
-      Sidner1983.Sentence E` mapping `.subject ↦ .agent/.agent`,
-      `.object ↦ .theme/.nonAgent`, `.other ↦ .otherNonAgent/.nonAgent`
-      would let the bridge be PROVEN over the IMAGE of `u227`/`u229`
-      under that map, replacing stipulation with derivation. Queued
-      as a separate commit.
-
-    - **`HasGivenness`-typed IS ranker**: currently the Strube-Hahn
-      ranker is `instance : CfRanker StrubeHahnInfoStatus` (role-
-      typed). The deeper move is `instance [HasGivenness E] :
-      CfRankerOf E R` — ranking ANY entity-typed thing whose
-      givenness can be projected, decoupled from `R`. Lets non-
-      English fragments use IS ranking without changing their role
-      type. Awaits the per-axis `HasGivenness` typeclass deferred
-      from the post-Krifka substrate redesign.
-
-    - **Hybrid Continuity** (PSDH §5.3.3): the disjunction of entity
-      coherence ∨ rhetorical relation ∨ temporal coherence as the
-      generalized "local coherence" notion. Aspirational; PSDH
-      themselves leave it as a sketch.
-
-    - **`Variety` principle** (PSDH §5.3.5): only ~50% of CBs are R1
-      pronouns; CBs hardly ever continued for >2-3 utterances.
-      PSDH suggest "ensuring variety" as an additional principle in
-      discourse production. Speaker-side claim, less amenable to
-      substrate formalization. -/
-
-/-! ### Centering ↔ Coherence bridge
-
-PSDH's parametric framework includes the [kehler-2002] coherence-
-relation axis. The mapping below was previously hosted in
-`Discourse/Centering/Coherence.lean` and `Rule2Coherence.lean`; per
-the audit's anchoring rule, that bridge content belongs in this study
-file (its sole consumer). -/
-
-open Discourse.Centering
-open Discourse.Coherence
-
-/-- The transition pattern that the given coherence relation most
-    naturally licenses (predictions, not entailments). -/
-def CoherenceRelation.preferredTransition : CoherenceRelation → Transition
-  | .elaboration  => .continuation
-  | .explanation  => .continuation
-  | .result       => .continuation
-  | .violatedExpectation => .continuation  -- cause–effect, by analogy
-  | .occasion     => .retaining
-  | .parallel     => .retaining
-  | .contrast     => .shifting
-  | .correction   => .shifting
-  -- SDRT additions, by analogy:
-  | .background   => .continuation
-  | .consequence  => .continuation
-  | .alternation  => .shifting
-
-theorem causeEffect_continuation :
-    CoherenceRelation.preferredTransition .explanation = .continuation ∧
-    CoherenceRelation.preferredTransition .result = .continuation := ⟨rfl, rfl⟩
-
-theorem substitution_shifts :
-    CoherenceRelation.preferredTransition .contrast = .shifting ∧
-    CoherenceRelation.preferredTransition .correction = .shifting := ⟨rfl, rfl⟩
-
-theorem coherence_respects_rule2 :
-    (CoherenceRelation.preferredTransition .explanation).rank >
-      (CoherenceRelation.preferredTransition .occasion).rank ∧
-    (CoherenceRelation.preferredTransition .occasion).rank >
-      (CoherenceRelation.preferredTransition .contrast).rank := by
-  refine ⟨?_, ?_⟩ <;> decide
-
-/-- Rule-2 score for a pair of consecutive coherence relations. -/
-def coherencePairScore (r₁ r₂ : CoherenceRelation) : Nat :=
-  pairRank (CoherenceRelation.preferredTransition r₁)
-           (CoherenceRelation.preferredTransition r₂)
-
-theorem causal_pair_max_score :
-    coherencePairScore .explanation .result =
-    pairRank .continuation .continuation := rfl
-
-theorem substitution_pair_min_score :
-    coherencePairScore .contrast .correction =
-    pairRank .shifting .shifting := rfl
-
-/-- Causal/elaborative coherence pairs are Rule-2-preferred over
-    substitution coherence pairs. -/
-theorem causal_pair_preferred_over_substitution :
-    coherencePairScore .explanation .result >
-    coherencePairScore .contrast .correction := by decide
+variable {E R : Type*}
+
+/-! ### Constraint 1 unpacked (§5.3.2, §5.3.4) -/
+
+section Constraint1
+
+variable [DecidableEq E] [CfRankerOf E R] {U : Type*} [Realizes U E]
+
+/-- CB uniqueness: at most one backward-looking center, the weak form of Constraint 1. -/
+def CBUniqueness (prev : Utterance E R) (cur : U) : Prop := (cbAll prev cur).length ≤ 1
+
+/-- Entity continuity: the utterance realizes some forward-looking center of the previous one. -/
+def EntityContinuity (prev : Utterance E R) (cur : U) : Prop := 1 ≤ (cbAll prev cur).length
+
+/-- The strong form of Constraint 1: exactly one backward-looking center. -/
+def Constraint1Strong (prev : Utterance E R) (cur : U) : Prop := (cbAll prev cur).length = 1
+
+instance (prev : Utterance E R) (cur : U) : Decidable (CBUniqueness prev cur) :=
+  inferInstanceAs (Decidable (_ ≤ _))
+
+instance (prev : Utterance E R) (cur : U) : Decidable (EntityContinuity prev cur) :=
+  inferInstanceAs (Decidable (_ ≤ _))
+
+instance (prev : Utterance E R) (cur : U) : Decidable (Constraint1Strong prev cur) :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- Strong Constraint 1 is CB uniqueness together with entity continuity. -/
+theorem strong_iff (prev : Utterance E R) (cur : U) :
+    Constraint1Strong prev cur ↔ CBUniqueness prev cur ∧ EntityContinuity prev cur := by
+  unfold Constraint1Strong CBUniqueness EntityContinuity
+  omega
+
+/-- CB uniqueness holds under any ranking that separates the realizations of the previous
+utterance, which a partial ranking such as grammatical function becomes once a disambiguating
+factor such as linear order is added. -/
+theorem cbAll_length_le_one (prev : Utterance E R) (cur : U)
+    (h : ∀ r₁ ∈ prev.realizations, ∀ r₂ ∈ prev.realizations,
+      CfRankerOf.rank r₁ = CfRankerOf.rank r₂ → r₁.entity = r₂.entity) :
+    (cbAll prev cur).length ≤ 1 := by
+  dsimp only [cbAll]
+  split
+  · simp
+  next top hm =>
+    have htop : top ∈ prev.realizations :=
+      List.mem_of_mem_filter (List.argmax_mem (Option.mem_def.2 hm))
+    rw [← List.card_toFinset]
+    refine (Finset.card_le_card λ e he => Finset.mem_singleton.2 ?_).trans
+      (Finset.card_singleton top.entity).le
+    obtain ⟨r, hr, rfl⟩ := List.mem_map.1 (List.mem_toFinset.1 he)
+    obtain ⟨hr₁, hr₂⟩ := List.mem_filter.1 hr
+    exact h r (List.mem_of_mem_filter hr₁) top htop (by simpa using hr₂)
+
+end Constraint1
+
+/-! ### Rule 1 in its three forms (§2.3.2) -/
+
+section Rule1
+
+variable [CfRankerOf E R] {U : Type*} [Realizes U E] [Pronominalizes U E]
+
+/-- Rule 1 in its original form: a backward-looking center kept from the previous utterance is
+pronominalized. The form of [grosz-joshi-weinstein-1995] is `PronominalizationConstraint`, and
+the unconditional form is `CbPronominalized`. -/
+def Rule1Original (prev : Utterance E R) (cur : U) (prevCb : Option E) : Prop :=
+  (∃ c, cb prev cur = some c ∧ prevCb = some c) → CbPronominalized prev cur
+
+/-- The unconditional form implies the original one, as it implies the 1995 form. -/
+theorem CbPronominalized.rule1Original {prev : Utterance E R} {cur : U} (prevCb : Option E)
+    (h : CbPronominalized prev cur) : Rule1Original prev cur prevCb :=
+  λ _ => h
+
+end Rule1
+
+/-! ### Transitions (§2.2.3, §2.3.3) -/
+
+/-- The four transitions of [brennan-friedman-pollard-1987]: the center is kept, or the previous
+utterance had none, and is the preferred center (continue) or not (retain); or the center
+changes and is the preferred center (smooth shift) or not (rough shift). -/
+inductive BFPTransition where
+  | continue
+  | retain
+  | smoothShift
+  | roughShift
+  deriving DecidableEq, Repr, Fintype
+
+/-- Rule 2 on single transitions: continue over retain over smooth shift over rough shift. -/
+def BFPTransition.rank : BFPTransition → ℕ
+  | .continue => 3
+  | .retain => 2
+  | .smoothShift => 1
+  | .roughShift => 0
+
+instance : LinearOrder BFPTransition := LinearOrder.lift' BFPTransition.rank (by decide)
+
+/-- The three-way transition each four-way one refines. -/
+def BFPTransition.toTransition : BFPTransition → Transition
+  | .continue => .continuation
+  | .retain => .retaining
+  | .smoothShift | .roughShift => .shifting
+
+/-- The four-way preference order refines the three-way one. -/
+theorem toTransition_mono {t₁ t₂ : BFPTransition} (h : t₁ ≤ t₂) :
+    t₁.toTransition ≤ t₂.toTransition := by
+  revert t₁ t₂; decide
+
+section Transitions
+
+variable [DecidableEq E] [CfRankerOf E R]
+
+/-- The four-way classification of an utterance after an utterance with center `prevCb`, `none`
+for an utterance with no center. -/
+def bfp (prev cur : Utterance E R) (prevCb : Option E) : Option BFPTransition :=
+  (cb prev cur).map λ c =>
+    if prevCb = some c ∨ prevCb = none then
+      if cur.cp = some c then .continue else .retain
+    else if cur.cp = some c then .smoothShift else .roughShift
+
+/-- An utterance is unclassified exactly when it has no backward-looking center: the null and
+zeroing transitions of a segment. -/
+theorem bfp_eq_none_iff (prev cur : Utterance E R) (prevCb : Option E) :
+    bfp prev cur prevCb = none ↔ cb prev cur = none := by
+  simp [bfp]
+
+/-- The four-way classification refines the three-way one. -/
+theorem bfp_toTransition {prev cur : Utterance E R} {prevCb : Option E} {t : BFPTransition}
+    (h : bfp prev cur prevCb = some t) :
+    t.toTransition = classifyTransitionExtended prev cur prevCb := by
+  unfold bfp classifyTransitionExtended at *
+  rcases hc : cb prev cur with _ | c
+  · simp [hc] at h
+  · rw [hc] at h
+    simp only [Option.map_some, Option.some.injEq] at h
+    subst h
+    rcases prevCb with _ | p
+    · by_cases hcp : cur.cp = some c <;>
+        simp [hcp, Transition.ofCenters, BFPTransition.toTransition]
+    · by_cases hp : p = c <;> by_cases hcp : cur.cp = some c <;>
+        simp [hp, hcp, Transition.ofCenters, BFPTransition.toTransition]
+
+end Transitions
+
+/-! ### The parameters (§2.4, §3.4) -/
+
+/-- The CF filter: only the entities satisfying `p` introduce forward-looking centers, as when
+first- and second-person pronouns or predicative noun phrases are excluded. -/
+def cfFilter (p : E → Bool) (u : Utterance E R) : Utterance E R :=
+  ⟨u.realizations.filter λ r => p r.entity⟩
+
+/-- The utterance unit: clauses merged into one sentence-sized utterance. -/
+def merge (us : List (Utterance E R)) : Utterance E R := ⟨(us.map (·.realizations)).flatten⟩
+
+/-- An utterance with the anchors of its associative references, each mention paired with the
+entity it indirectly realizes. -/
+structure Bridged (E R : Type*) where
+  utt : Utterance E R
+  anchors : List (E × E)
+
+/-- Indirect realization: an entity is realized when mentioned or when anchored by a mention. -/
+instance [DecidableEq E] : Realizes (Bridged E R) E where
+  Rel b e := realizes b.utt e ∨ ∃ a ∈ b.anchors, a.2 = e ∧ realizes b.utt a.1
+  decRel _ _ := inferInstance
+
+/-- Grammatical function with linear-order disambiguation: the role together with the surface
+position, an earlier mention outranking a later one of the same function. -/
+abbrev GFLin (n : ℕ) := GrammaticalRole × Fin n
+
+instance (n : ℕ) : CfRanker (GFLin n) where
+  rank r := r.1.rank * n + (n - 1 - r.2)
+
+/-- The three tiers of information status of [strube-hahn-1999], the ranking of §4.4.3. -/
+inductive InfoStatus where
+  | hearerOld
+  | mediated
+  | hearerNew
+  deriving DecidableEq, Repr, Fintype
+
+/-- Hearer-old entities outrank mediated ones, which outrank hearer-new ones. -/
+def InfoStatus.rank : InfoStatus → ℕ
+  | .hearerOld => 2
+  | .mediated => 1
+  | .hearerNew => 0
+
+instance : CfRanker InfoStatus where
+  rank := InfoStatus.rank
+
+/-! ### The illustrations -/
+
+section Examples
+
+/-- The entities of (5). -/
+inductive Ent5 where
+  | john
+  | house
+  | door
+  deriving DecidableEq, Repr
+
+/-- (5): *John walked toward the house. The door was open.* Under direct realization the second
+utterance has no backward-looking center; with the door anchored to the house it has one. -/
+theorem ex5 :
+    let u1 : Utterance Ent5 GrammaticalRole := ⟨[⟨.john, .subject, false⟩, ⟨.house, .other, false⟩]⟩
+    let u2 : Utterance Ent5 GrammaticalRole := ⟨[⟨.door, .subject, false⟩]⟩
+    cb u1 u2 = none ∧
+      cb u1 (⟨u2, [(.door, .house)]⟩ : Bridged Ent5 GrammaticalRole) = some .house := by
+  decide
+
+/-- The entities of (7). -/
+inductive Ent7 where
+  | you
+  | productZ
+  deriving DecidableEq, Repr
+
+/-- (7): with the second-person pronoun introducing a forward-looking center every utterance has
+one; without it the if-clause has none, and the third utterance has one only when the
+if-clause is treated as embedded and the first utterance is its previous utterance. -/
+theorem ex7 :
+    let u1 : Utterance Ent7 GrammaticalRole :=
+      ⟨[⟨.you, .subject, true⟩, ⟨.productZ, .object, false⟩]⟩
+    let u2 : Utterance Ent7 GrammaticalRole := ⟨[⟨.you, .subject, true⟩]⟩
+    let u3 : Utterance Ent7 GrammaticalRole :=
+      ⟨[⟨.you, .subject, true⟩, ⟨.productZ, .object, false⟩]⟩
+    let f := cfFilter (· != Ent7.you)
+    (cb u1 u2 = some .you ∧ cb u2 u3 = some .you) ∧
+      cb (f u1) (f u2) = none ∧ cb (f u2) (f u3) = none ∧ cb (f u1) (f u3) = some .productZ := by
+  decide
+
+/-- The entities of (9). -/
+inductive Ent9 where
+  | vases
+  | bases
+  | bodies
+  | straw
+  | handles
+  | eggs
+  | nests
+  | finial
+  | lid
+  deriving DecidableEq, Repr
+
+/-- (9): with finite clauses as utterances none of the four clauses after the first has a
+backward-looking center; with sentences as utterances the second sentence continues the egg
+vases, as does the second clause once its bases and bodies are anchored to the vases. -/
+theorem ex9 :
+    let u1 : Utterance Ent9 GrammaticalRole := ⟨[⟨.vases, .subject, false⟩]⟩
+    let u2 : Utterance Ent9 GrammaticalRole :=
+      ⟨[⟨.bases, .subject, false⟩, ⟨.bodies, .object, false⟩]⟩
+    let u3 : Utterance Ent9 GrammaticalRole :=
+      ⟨[⟨.straw, .subject, false⟩, ⟨.handles, .object, false⟩]⟩
+    let u4 : Utterance Ent9 GrammaticalRole :=
+      ⟨[⟨.eggs, .subject, false⟩, ⟨.nests, .other, false⟩, ⟨.finial, .other, false⟩,
+        ⟨.lid, .other, false⟩]⟩
+    let u5 : Utterance Ent9 GrammaticalRole := ⟨[⟨.vases, .subject, false⟩]⟩
+    (cb u1 u2 = none ∧ cb u2 u3 = none ∧ cb u3 u4 = none ∧ cb u4 u5 = none) ∧
+      cb (merge [u1, u2, u3, u4]) u5 = some .vases ∧
+      cb u1 (⟨u2, [(.bases, .vases), (.bodies, .vases)]⟩ : Bridged Ent9 GrammaticalRole)
+        = some .vases := by
+  decide
+
+/-- The entities of (10). -/
+inductive Ent10 where
+  | drawing
+  | cupboard
+  | branicki
+  | dubois
+  | dealer
+  deriving DecidableEq, Repr
+
+/-- (10): the corner cupboard and Branicki tie under grammatical-function ranking, so both are
+backward-looking centers of the next utterance, against CB uniqueness; with linear-order
+disambiguation the earlier mention, the cupboard, is the unique one. -/
+theorem ex10 :
+    let u227 : Utterance Ent10 GrammaticalRole :=
+      ⟨[⟨.drawing, .subject, false⟩, ⟨.cupboard, .other, false⟩, ⟨.branicki, .other, false⟩]⟩
+    let u229 : Utterance Ent10 GrammaticalRole :=
+      ⟨[⟨.dubois, .subject, false⟩, ⟨.dealer, .other, false⟩, ⟨.cupboard, .object, false⟩,
+        ⟨.branicki, .other, false⟩]⟩
+    let v227 : Utterance Ent10 (GFLin 4) :=
+      ⟨[⟨.drawing, (.subject, 0), false⟩, ⟨.cupboard, (.other, 1), false⟩,
+        ⟨.branicki, (.other, 2), false⟩]⟩
+    let v229 : Utterance Ent10 (GFLin 4) :=
+      ⟨[⟨.dubois, (.subject, 0), false⟩, ⟨.dealer, (.other, 1), false⟩,
+        ⟨.cupboard, (.object, 2), false⟩, ⟨.branicki, (.other, 3), false⟩]⟩
+    (cbAll u227 u229).length = 2 ∧ ¬ CBUniqueness u227 u229 ∧ EntityContinuity u227 u229 ∧
+      cbAll v227 v229 = [.cupboard] := by
+  decide
+
+/-- The entities of (14) and (16). -/
+inductive Ent14 where
+  | john
+  | bill
+  | door
+  | appointment
+  | scissors
+  | you
+  | patch
+  deriving DecidableEq, Repr
+
+/-- (14) and (16): the two definitions of the previous utterance of a clause after an adjunct
+clause pull in opposite directions. In (14) the main clause supplies the center *John* that the
+when-clause lacks, in (16) the adjunct clause supplies the center *the patch* that the main
+clause lacks. -/
+theorem ex14_ex16 :
+    let u1 : Utterance Ent14 GrammaticalRole := ⟨[⟨.john, .subject, false⟩]⟩
+    let u2 : Utterance Ent14 GrammaticalRole :=
+      ⟨[⟨.bill, .subject, false⟩, ⟨.door, .object, false⟩]⟩
+    let u3 : Utterance Ent14 GrammaticalRole :=
+      ⟨[⟨.john, .subject, true⟩, ⟨.appointment, .object, false⟩]⟩
+    let v1 : Utterance Ent14 GrammaticalRole := ⟨[⟨.scissors, .object, false⟩]⟩
+    let v2 : Utterance Ent14 GrammaticalRole :=
+      ⟨[⟨.you, .subject, true⟩, ⟨.patch, .object, false⟩]⟩
+    let v3 : Utterance Ent14 GrammaticalRole := ⟨[⟨.patch, .object, false⟩]⟩
+    (cb u2 u3 = none ∧ cb u1 u3 = some .john) ∧ (cb v2 v3 = some .patch ∧ cb v1 v3 = none) := by
+  decide
+
+/-- The entities of (23). -/
+inductive Ent23 where
+  | leaflet
+  | summary
+  | info
+  | productA
+  | questions
+  | treatment
+  | doctor
+  | pharmacist
+  deriving DecidableEq, Repr
+
+/-- (23): with the second-person pronoun excluded, no utterance realizes a forward-looking
+center of the previous one, so entity coherence is absent throughout a coherent text. -/
+theorem ex23 :
+    let u1 : Utterance Ent23 GrammaticalRole :=
+      ⟨[⟨.leaflet, .subject, false⟩, ⟨.summary, .other, false⟩, ⟨.info, .other, false⟩,
+        ⟨.productA, .other, false⟩]⟩
+    let u2 : Utterance Ent23 GrammaticalRole :=
+      ⟨[⟨.questions, .object, false⟩, ⟨.treatment, .other, false⟩]⟩
+    let u3 : Utterance Ent23 GrammaticalRole :=
+      ⟨[⟨.doctor, .object, false⟩, ⟨.pharmacist, .other, false⟩]⟩
+    cb u1 u2 = none ∧ cb u2 u3 = none := by
+  decide
+
+end Examples
 
 end PoesioEtAl2004

--- a/references.bib
+++ b/references.bib
@@ -6849,7 +6849,7 @@
   url       = {https://aclanthology.org/P87-1022/},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Discourse/Centering/Transition.lean;Studies/Beaver2004.lean;Studies/GroszJoshiWeinstein1995.lean}
+  sources   = {Discourse/Centering/Transition.lean;Studies/Beaver2004.lean;Studies/GroszJoshiWeinstein1995.lean;Studies/PoesioEtAl2004.lean}
 }
 @article{strube-hahn-1999,
   author    = {Strube, Michael and Hahn, Udo},
@@ -6862,7 +6862,7 @@
   url       = {https://aclanthology.org/J99-3001/},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Studies/PoesioEtAl2004.lean}
+  sources   = {Features/Givenness.lean;Studies/PoesioEtAl2004.lean}
 }
 @inproceedings{strube-1998,
   author    = {Strube, Michael},
@@ -6873,7 +6873,7 @@
   url       = {https://aclanthology.org/P98-2204/},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Discourse/Centering/Rule2.lean}
+  sources   = {Discourse/Centering/Rule2.lean;Discourse/Centering/Transition.lean}
 }
 @inproceedings{rambow-1993,
   author    = {Rambow, Owen},
@@ -6906,7 +6906,7 @@
   address     = {Cambridge, MA},
   subfield    = {semantics/reference},
   role        = {cited},
-  sources   = {Data/Examples/GroszJoshiWeinstein1995.json;Discourse/Centering/Defs.lean;Discourse/Centering/Instances/GrammaticalRole.lean;Studies/PoesioEtAl2004.lean;Studies/Sidner1983.lean}
+  sources   = {Data/Examples/GroszJoshiWeinstein1995.json;Discourse/Centering/Defs.lean;Discourse/Centering/Instances/GrammaticalRole.lean;Studies/Sidner1983.lean}
 }
 @incollection{sidner-1983,
   author    = {Sidner, Candace L.},
@@ -11203,7 +11203,7 @@
   subfield  = {semantics/focus},
   role      = {cited},
   validated = {true},
-  sources   = {Studies/KratzerSelkirk2020.lean}
+  sources   = {Features/Givenness.lean;Studies/KratzerSelkirk2020.lean}
 }
 @article{krifka-2008,
   author    = {Krifka, Manfred},
@@ -11227,7 +11227,7 @@
   isbn      = {9780199642670},
   subfield  = {semantics/focus},
   role      = {foundational},
-  sources   = {Features/Givenness.lean}
+  sources   = {}
 }
 @incollection{chafe-1987,
   author    = {Chafe, Wallace L.},
@@ -11304,7 +11304,7 @@
   doi       = {10.1023/B:LING.0000010796.76522.7a},
   subfield  = {semantics/reference},
   role      = {formalized},
-  sources   = {Discourse/Centering/Basic.lean;Studies/Beaver2004.lean;Studies/PoesioEtAl2004.lean}
+  sources   = {Discourse/Centering/Basic.lean;Studies/Beaver2004.lean}
 }% REF: Beaver, D. et al. (2007). When semantics meets phonetics. Language 83: 245-276.
 @article{beaver-2007,
   author    = {Beaver, David and Clark, Brady Zack and Flemming, Edward and Jaeger, T. Florian and Wolters, Maria},
@@ -17216,7 +17216,7 @@
   validated = {true},
   subfield  = {semantics/dynamic},
   role      = {cited},
-  sources   = {Studies/ArnoldEtAl2000.lean;Studies/PoesioEtAl2004.lean;Features/Givenness.lean}
+  sources   = {Features/Givenness.lean;Studies/ArnoldEtAl2000.lean}
 }% REF: Prince, E.F. (1992). The ZPG Letter: Subjects, Definiteness, and Information-status.
 @incollection{prince-1992,
   author    = {Prince, Ellen F.},
@@ -19442,7 +19442,7 @@
   doi       = {10.1075/hcp.8.04ari},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Studies/Ariel2001.lean;Studies/KwonLee2026.lean}
+  sources   = {Features/Givenness.lean;Studies/Ariel2001.lean;Studies/KwonLee2026.lean}
 }
 @article{kwon-lee-2026,
   author    = {Kwon, Nayoung and Lee, So Young},
@@ -19525,7 +19525,7 @@
   doi       = {10.2307/416535},
   subfield  = {semantics/reference},
   role      = {cited},
-  sources   = {Studies/Ariel2001.lean}
+  sources   = {Features/Givenness.lean;Studies/Ariel2001.lean}
 }
 @article{hahn-degen-futrell-2021,
   author    = {Hahn, Michael and Degen, Judith and Futrell, Richard},


### PR DESCRIPTION
Rebuild PoesioEtAl2004 as the paper's parametric reading of centering: each instantiation is a substrate plug-in (Realizes instance for indirect realization, CfRankerOf for grammatical function with linear disambiguation and for information status, a CF filter, merged utterance units, the previous-utterance argument of cb), and the paper's illustrations (5), (7), (9), (10), (14), (16), (23) are worked as such.
- general theorems: Strong Constraint 1 = uniqueness + continuity; cbAll has at most one element under a separating ranking; Rule 1 forms ordered; the BFP four-way classification refines the three-way one and its Rule 2 order
- substrate: Transition.ofCenters exposed (was private); Givenness docstring pointer updated
- cuts the Sidner and Beaver bridges, the Kehler coherence table, the GHZ projection, and the deferred-items essay