### PR TITLE
refactor(Fragments/Ga): type complement-taking verbs as Verb entries

### DIFF
--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Features.Number.Basic
 import Linglib.Features.Person.Basic
+import Linglib.Syntax.Category.Complementizer.Basic
+import Linglib.Syntax.Category.Verb.Complement.Basic
 
 /-!
 # Gã Fragment
@@ -22,12 +24,13 @@ clause typology.
 - TAM prefixes (future, progressive, perfective) and the irrealis
   marker `á`, realized in embedded control clauses as high tone on
   the subject pronoun
-- Complementizer inventory (`akɛ`, `kɛji`, `ni`) with finite vs.
-  irrealis distinction; `ni` is optionally overt with some
-  control verbs (*tao* 'want', [allotey-2021] ex 34) and
-  obligatory with others (*hiɛ-kã-nɔ* 'hope', ex 35)
+- Complementizer inventory (`akɛ`, `kɛji`, `ni`) as `Complementizer`
+  entries; `ni` is optionally overt with some control verbs (*tao*
+  'want', [allotey-2021] ex 34) and obligatory with others
+  (*hiɛ-kã-nɔ* 'hope', ex 35)
 - Embedded clause typology (three-way: `finiteAke`, `finiteKeji`,
-  `irrealisNi`)
+  `irrealisNi`), each type with its complementizer and its complement
+  `Frame`; the complement-taking verbs live in `Fragments/Ga/Predicates`
 - Pro-drop profile
 
 ## Identifier policy
@@ -42,10 +45,17 @@ preserved in the corresponding `String` value.
 The verb-movement/negation-placement diagnostic ([allotey-2021]'s fifth
 non-finiteness argument, after [pollock-1989]: finite verbs raise past
 the suffixal negation `-ee`, `-ŋ`, `-ko`, while irrealis embedded clauses
-show a free preverbal negator `ka`, her exx 120–125). Formalizing the raising
+show a free preverbal negator `ka`, exx 120–125). Formalizing the raising
 argument needs phrase-structure substrate beyond this fragment's
 clause-typology schema; the finiteness split it diagnoses is already
 carried by `ClauseProperties.unrestrictedTAM`.
+
+## References
+
+* [allotey-2021]
+* [landau-2004]
+* [noonan-2007]
+* [pollock-1989]
 -/
 
 namespace Ga
@@ -126,31 +136,36 @@ def TAM.isFinite : TAM → Bool
 
 /-! ### Complementizers -/
 
-/-- The three complementizers [allotey-2021] discusses. -/
-inductive Complementizer where
-  /-- `akɛ` — finite complementizer for declarative complements
-      (typically utterance and propositional attitude verbs) -/
-  | ake
-  /-- `kɛji` — finite complementizer for conditional and
-      conditional-like complements -/
-  | keji
-  /-- `ni` — irrealis complementizer; introduces controlled clauses
-      (a weak CP: no focus fronting, no independent tense,
-      [allotey-2021] exx 107–109). Optionally overt with some control
-      verbs (*tao* 'want', ex 34) and obligatory with others
-      (*hiɛ-kã-nɔ* 'hope', ex 35). -/
-  | ni
-  deriving DecidableEq, Repr
+/-- *akɛ* — the finite declarative complementizer, typing the complements
+    of utterance and attitude verbs ([allotey-2021] exx 47–49, 89a). -/
+def ake : Complementizer where
+  morphs := [.free "akɛ"]
+  coding := some .indicative
+  force := some .declarative
+  verbForm := some .Fin
 
-def Complementizer.form : Complementizer → String
-  | .ake  => "akɛ"
-  | .keji => "kɛji"
-  | .ni   => "ni"
+/-- *kɛji* — the finite complementizer of conditional clauses (ex 97a) and,
+    under *le* 'know', of polar and alternative questions ('know if they
+    will come', 'know whether you or he bought it', exx 104, 108); glossed
+    COND throughout the paper. -/
+def keji : Complementizer where
+  morphs := [.free "kɛji"]
+  coding := some .indicative
+  force := some .interrogative
+  verbForm := some .Fin
 
-/-- Whether the complementizer projects a finite (full-TAM) clause. -/
-def Complementizer.isFinite : Complementizer → Bool
-  | .ni   => false
-  | _     => true
+/-- *ni* — the irrealis complementizer of controlled clauses, glossed C and
+    the complement's verb INF: a weak CP with no focus fronting and no
+    independent tense (exx 107–109). Optionally overt with some control
+    verbs (*tao* 'want', ex 34) and obligatory with others (*hiɛ-kã-nɔ*
+    'hope', ex 35); homophonous with the focus marker (ex 27). -/
+def ni : Complementizer where
+  morphs := [.free "ni"]
+  coding := some .infinitive
+  verbForm := some .Inf
+
+/-- The three clause introducers that can head an embedded C (§5.5.1). -/
+def complementizers : List Complementizer := [ake, keji, ni]
 
 /-! ### Embedded clause typology -/
 
@@ -185,8 +200,6 @@ structure ClauseProperties where
   independentTense : Bool
   /-- Noncoreferential embedded subject possible (exx 110 vs 112). -/
   noncoreferentialSubject : Bool
-  /-- Selects one of the finite complementizers (`akɛ`, `kɛji`). -/
-  finiteComplementizer : Bool
   /-- Matrix negation licenses an embedded NPI across this clause's
       boundary (exx 116 vs 117). -/
   npiTransparent : Bool
@@ -198,20 +211,26 @@ structure ClauseProperties where
   deriving DecidableEq, Repr
 
 def clauseProperties : EmbeddedClauseType → ClauseProperties
-  | .finiteAke   => ⟨true,  true,  true,  true,  false, true,  false⟩
-  | .finiteKeji  => ⟨true,  true,  true,  true,  false, true,  false⟩
-  | .irrealisNi  => ⟨false, false, false, false, true,  false, true⟩
+  | .finiteAke   => ⟨true,  true,  true,  false, true,  false⟩
+  | .finiteKeji  => ⟨true,  true,  true,  false, true,  false⟩
+  | .irrealisNi  => ⟨false, false, false, true,  false, true⟩
 
+/-- The complementizer heading each clause type. -/
 def clauseComplementizer : EmbeddedClauseType → Complementizer
-  | .finiteAke   => .ake
-  | .finiteKeji  => .keji
-  | .irrealisNi  => .ni
+  | .finiteAke   => ake
+  | .finiteKeji  => keji
+  | .irrealisNi  => ni
 
--- The complementizer's finiteness equals the clause's
--- `finiteComplementizer` flag — by construction, not bridge.
-theorem complementizer_isFinite_eq_finiteFlag (c : EmbeddedClauseType) :
-    (clauseComplementizer c).isFinite = (clauseProperties c).finiteComplementizer := by
-  cases c <;> rfl
+/-- The complement frame a verb selecting each clause type records: a finite
+    declarative for `akɛ`, a finite interrogative for `kɛji`, and for `ni` an
+    infinitival whose subject is an overt proclitic in the subjective
+    (nominative) form of Table 3 — never null and never a lexical DP
+    (exx 40–42). -/
+def EmbeddedClauseType.frame : EmbeddedClauseType → Frame
+  | .finiteAke  => Frame.finiteClause
+  | .finiteKeji => [.clausal (coding := some .indicative) (force := some .interrogative)]
+  | .irrealisNi =>
+    [.clausal (coding := some .infinitive) (embeddedSubject := some (.overt (some .nom)))]
 
 /-! ### Typological profile -/
 

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -4,146 +4,203 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Fragments.Ga.Basic
-import Linglib.Syntax.Clause.Complementation
-import Linglib.Semantics.Causation.VerbClass
+import Linglib.Syntax.Category.Verb.Complement.Takes
 
 /-!
-# Gã Complement-Taking Predicates
-[allotey-2021]
+# Gã complement-taking verbs
 
-Inventory of Gã verbs that take embedded clausal complements, classified
-by the clause types they are attested with, the control relation of
-their `ni`-frame, and Karttunen implicativity. Several verbs alternate
-between frames — *kai* 'remember' takes the controlled irrealis
-`ni`-clause (ex 43) or a finite `akɛ`-clause (ex 89a), *kɛɛ* 'say/tell'
-takes `akɛ` (exx 47–49) or an object-control `ni`-clause (ex 117b) —
-and this C-selection is [allotey-2021]'s first non-finiteness
-diagnostic (§5.5.1, exx 104–108), so `selects` is list-valued. All
-entries are attested in her example data, cited by example number.
+This file records the Gã verbs of [allotey-2021] that embed clauses, as `Verb`
+entries whose frames are the clause types of `Fragments/Ga/Basic` and whose
+`ni`-frame reading carries the control relation. Several verbs alternate between
+frames: *kai* 'remember' takes the controlled `ni`-clause (ex 43) or a finite
+`akɛ`-clause (ex 89a), *kɛɛ* 'say' takes `akɛ` (exx 47–49) or an
+object-controlled `ni`-clause (ex 117b). Complementizer selection is the paper's
+first non-finiteness diagnostic (§5.5.1, exx 104–108); the selection relation
+itself is `Verb.takes` over `Ga.complementizers`.
 
-## Identifier policy
+## Implementation notes
 
-ASCII identifiers; IPA orthography lives in `.form` strings.
-See `Fragments/Ga/Basic.lean` for rationale.
+Karttunen implicativity (`Verb.implicative`) is recorded where it is textbook
+([karttunen-1971]); the paper uses it for the contrast of ex 89, where the
+irrealis marker is absent exactly under the implicatives, but does not classify
+the verbs itself. Vendler class stays unset, the convention for clause-embedding
+verbs. Identifiers are ASCII (see `Fragments/Ga/Basic`); the IPA orthography is
+in `form`.
+
+## References
+
+* [allotey-2021]
+* [karttunen-1971]
+* [nadathur-lauer-2020]
 -/
 
 namespace Ga
 
+open EmbeddedClauseType
 
-/-- A Gã complement-taking predicate: form, gloss, the embedded clause
-    types it is attested with, the control relation of its `ni`-frame
-    (`ControlType.none` exactly for verbs without one), and its
-    Karttunen implicativity ([karttunen-1971]: `positive` = complement
-    entailed realized, `negative` = entailed unrealized, `none` =
-    non-implicative). Implicativity has a grammatical reflex in Gã:
-    implicatives alternate into realis complement frames, where the
-    irrealis marker is impossible (`Studies/Allotey2021.lean`). -/
-structure CTP where
-  form    : String
-  gloss   : String
-  /-- Embedded clause types attested with this verb. -/
-  selects : List EmbeddedClauseType
-  /-- The control relation of the verb's irrealis `ni`-frame. -/
-  control : ControlType
-  /-- Karttunen implicative class; `none` for non-implicatives. -/
-  implicative : Option Implicative
-  deriving Repr, DecidableEq
+/-- The reading of the controlled `ni`-frame under control relation `c`. -/
+def niReading (c : ControlType) : Verb.Reading :=
+  { frame := irrealisNi.frame, control := some c }
 
-/-! ### Subject-control verbs (irrealis `ni`-clause) -/
+/-! ### Subject control -/
 
-/-- 'want' — subject control; `ni` optionally overt ([allotey-2021]
-    ex 34: *Mi-i tao (ni) ma na bo* 'I want to see you'; the embedded
-    1SG is the irrealis portmanteau *má*, exx 88, 100). -/
-def tao : CTP := ⟨"tao", "want", [.irrealisNi], .subjectControl, none⟩
+/-- *tao* 'want' — subject control; `ni` optionally overt (ex 34: *Mi-i tao (ni)
+    ma na bo* 'I want to see you'); the embedded 1SG is the irrealis portmanteau
+    *má* (exx 88, 100). -/
+def tao : Verb where
+  form := "tao"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'hope' (lit. 'face-place-upon') — subject control; `ni` obligatory
-    ([allotey-2021] ex 35: *Mi hiɛ-kã-nɔ ni ma ya skul gbi ko*
-    'I hope to go to school one day'). -/
-def hiekano : CTP := ⟨"hiɛ-kã-nɔ", "hope", [.irrealisNi], .subjectControl, none⟩
+/-- *sumɔ* 'like' — subject control, with no complementizer under negation
+    (ex 3a: *Dida sumɔ-ɔɔ e-na bo* 'Father is reluctant to see you') and with
+    `ni` in the future (ex 92); the embedded pronoun cannot be obviative. -/
+def sumo : Verb where
+  form := "sumɔ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'forget' (lit. 'face-stop-upon') — subject control; `ni` obligatory
-    ([allotey-2021] exx 37–38: *O hiɛ-kpa-nɔ ni o kɔ aspaatere lɛ*
-    'You forgot to pick up the shoe'). Negative implicative (*forget to*
-    entails the complement unrealized — textbook [karttunen-1971], not
-    her classification), and its `ni`-clause duly carries the irrealis
-    marker (exx 102–103: *ó*, *é*). -/
-def hiekpano : CTP := ⟨"hiɛ-kpa-nɔ", "forget", [.irrealisNi], .subjectControl, some .negative⟩
+/-- *hiɛ-kã-nɔ* 'hope' (lit. 'face-place-upon') — subject control; `ni`
+    obligatory (ex 35: *Mi hiɛ-kã-nɔ ni ma ya skul gbi ko* 'I hope to go to
+    school one day'). -/
+def hiekano : Verb where
+  form := "hiɛ-kã-nɔ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'try' (lit. 'squeeze-my-face') — subject control; `ni` obligatory
-    ([allotey-2021] exx 36, 60a: 'I tried to close the door'). -/
-def miamihie : CTP := ⟨"mia-mi-hiɛ", "try", [.irrealisNi], .subjectControl, none⟩
+/-- *hiɛ-kpa-nɔ* 'forget' (lit. 'face-stop-upon') — subject control; `ni`
+    obligatory (exx 37–38: *O hiɛ-kpa-nɔ ni o kɔ aspaatere lɛ* 'You forgot to
+    pick up the shoe'). Negative implicative by the textbook classification
+    (*forget to* entails the complement unrealized), and its `ni`-clause duly
+    carries the irrealis marker (exx 102–103). -/
+def hiekpano : Verb where
+  form := "hiɛ-kpa-nɔ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
+  implicative := some .negative
 
-/-- 'remember' — subject control in the `ni`-frame ([allotey-2021]
-    exx 42–43: *Mi kai ni ma he wolo* 'I remembered to buy a book');
-    positive implicative. Alternates into a finite `akɛ`-frame
-    'remember that' whose realis past complement excludes the irrealis
-    marker (ex 89a: *Mi kai akɛ mi/\*má he wolo lɛ*); under matrix
-    negation the `ni`-frame carries the marker (ex 117a: *é*). -/
-def kai : CTP := ⟨"kai", "remember", [.irrealisNi, .finiteAke], .subjectControl, some .positive⟩
+/-- *mia-mi-hiɛ* 'try' (lit. 'squeeze-my-face') — subject control; `ni`
+    obligatory (exx 36, 60a: 'I tried to close the door'). -/
+def miamihie : Verb where
+  form := "mia-mi-hiɛ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'manage / be able to' — subject control; `ni` optionally overt
-    ([allotey-2021] ex 39: 'The children managed to buy a home');
-    positive implicative. Also attested with a bare complementizer-less
-    realis past complement where the irrealis marker is excluded
-    (ex 89b: *Mi nyɛ mi/\*má sha tsensii lɛ*); the zero-frame is not a
-    member of the three-way clause typology and is recorded only in
-    `Studies/Allotey2021.lean`'s marker data. -/
-def nye : CTP := ⟨"nyɛ", "manage", [.irrealisNi], .subjectControl, some .positive⟩
+/-- *kai* 'remember' — subject control in the `ni`-frame (exx 42–43: *Mi kai ni
+    ma he wolo* 'I remembered to buy a book'), positive implicative. Alternates
+    into a finite `akɛ`-frame 'remember that', whose realis past complement
+    excludes the irrealis marker (ex 89a); under matrix negation the `ni`-frame
+    keeps it (ex 117a). -/
+def kai : Verb where
+  form := "kai"
+  frames := [irrealisNi.frame, finiteAke.frame]
+  readings := [niReading .subjectControl]
+  implicative := some .positive
 
-/-- 'agree' — subject control; the `ni`-frame requires the irrealis
-    marker ([allotey-2021] exx 52, 89c: *\*mi/má*; also 109, 122a).
-    Alternates into `akɛ` with a true subjunctive complement
-    ('agree that…', ex 105: *Osa kplɛnɔ ni/akɛ Taki á-tsɛ́ Momo*). -/
-def kpleno : CTP := ⟨"kplɛnɔ", "agree", [.irrealisNi, .finiteAke], .subjectControl, none⟩
+/-- *nyɛ* 'manage' — subject control; `ni` optionally overt (ex 39: 'The children
+    managed to buy a home'), positive implicative. Also attested with a bare
+    realis past complement that excludes the irrealis marker (ex 89b), a frame
+    outside the three-way clause typology. -/
+def nye : Verb where
+  form := "nyɛ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
+  implicative := some .positive
 
-/-- 'plan / decide' — subject control; only `ni` — never `akɛ` or
-    `kɛji` — introduces the complement ([allotey-2021] ex 106), and the
-    irrealis marker is obligatory (ex 89d: *\*mi/má*). -/
-def kpang : CTP := ⟨"kpaŋ", "plan", [.irrealisNi], .subjectControl, none⟩
+/-- *kplɛnɔ* 'agree' — subject control; the `ni`-frame requires the irrealis
+    marker (exx 52, 89c, 109, 122a). Alternates into `akɛ` with a subjunctive
+    complement, 'agree that' (ex 105: *Osa kplɛnɔ ni/akɛ Taki á-tsɛ́ Momo*). -/
+def kpleno : Verb where
+  form := "kplɛnɔ"
+  frames := [irrealisNi.frame, finiteAke.frame]
+  readings := [niReading .subjectControl]
 
-/-! ### Object-control verbs (irrealis `ni`-clause) -/
+/-- *kpaŋ* 'plan, decide' — subject control; only `ni` introduces the complement
+    (ex 106) and the irrealis marker is obligatory (ex 89d). -/
+def kpang : Verb where
+  form := "kpaŋ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'help' — object control ([allotey-2021] exx 44, 54: *Mi wa Ama ni
-    e-ya skul* 'I helped Ama to go to school'). Whether *help* is
-    (partially) implicative is contested in the post-Karttunen
-    literature; left unclassified. -/
-def wa : CTP := ⟨"wa", "help", [.irrealisNi], .objectControl, none⟩
+/-- *kpã-gbɛ* 'expect' — subject control (ex 53: *Ajele kpã-gbɛ ni e-ye
+    jweremɔ lɛ* 'Ajele expects to win the prize', infelicitous when Ajele does
+    not self-ascribe winning: the *de se* diagnostic). -/
+def kpagbe : Verb where
+  form := "kpã-gbɛ"
+  frames := [irrealisNi.frame]
+  readings := [niReading .subjectControl]
 
-/-- 'urge / encourage' — object control ([allotey-2021] exx 55, 60b). -/
-def kenya : CTP := ⟨"kenya", "urge", [.irrealisNi], .objectControl, none⟩
+/-- *dwɛŋ* 'think' — a finite complement with a low-tone, freely referring
+    subject (exx 110–111: 'Aku thought s/he bought the book', under `akɛ` or a
+    low-tone `ni`), and a controlled `ni`-clause with the high-tone anaphoric
+    subject (ex 112: 'Aku thought to buy a book'). -/
+def dweng : Verb where
+  form := "dwɛŋ"
+  frames := [finiteAke.frame, irrealisNi.frame]
+  readings := [niReading .subjectControl]
+  attitude := some (.doxastic .nonVeridical)
 
-/-- 'force' — object control ([allotey-2021] ex 56). Coded positive
-    implicative: forcing entails the forced event realized, though
-    two-place coercives postdate [karttunen-1971]'s one-place
-    inventory. -/
-def dai : CTP := ⟨"dai", "force", [.irrealisNi], .objectControl, some .positive⟩
+/-! ### Object control -/
 
-/-- 'persuade / coax / deceive' (context-dependent, the paper's fn 4) —
-    object control ([allotey-2021] exx 57–58). -/
-def laka : CTP := ⟨"laka", "persuade", [.irrealisNi], .objectControl, none⟩
+/-- *wa* 'help' — object control (exx 44, 54: *Mi wa Ama ni e-ya skul* 'I helped
+    Ama to go to school'). Whether *help* is implicative is contested in the
+    literature after [karttunen-1971]; left unclassified. -/
+def wa : Verb where
+  form := "wa"
+  frames := [irrealisNi.frame]
+  readings := [niReading .objectControl]
 
-/-- 'ask' — object control ([allotey-2021] ex 59: 'I asked Ayele to
-    tell me a story'). -/
-def bi : CTP := ⟨"bi", "ask", [.irrealisNi], .objectControl, none⟩
+/-- *kenya* 'urge, encourage' — object control (exx 55, 60b). -/
+def kenya : Verb where
+  form := "kenya"
+  frames := [irrealisNi.frame]
+  readings := [niReading .objectControl]
 
-/-- 'say / tell' — finite `akɛ`-clause as the paper's standard
-    utterance-verb exemplar ([allotey-2021] exx 47–49: *Jojo kɛɛ akɛ …*
-    'Jojo said that …'), and object control in the `ni`-frame ('tell
-    someone to …', ex 117b: *John é-kee-ee Mary ni é he noko-noko*
-    'John didn't tell Mary to buy anything'; *tell* is on her
-    object-control predicate list). -/
-def kee : CTP := ⟨"kɛɛ", "say", [.finiteAke, .irrealisNi], .objectControl, none⟩
+/-- *dai* 'force' — object control (ex 56: 'I forced Kofi to go to school'); a
+    coercive causative whose complement is entailed ([nadathur-lauer-2020]). -/
+def dai : Verb where
+  form := "dai"
+  frames := [irrealisNi.frame]
+  readings := [niReading .objectControl]
+  implicative := some .positive
+  causative := some .force
 
-/-! ### Finite-complement-only verbs -/
+/-- *laka* 'persuade, coax, deceive' (context-dependent, fn 4) — object control
+    (exx 57–58). -/
+def laka : Verb where
+  form := "laka"
+  frames := [irrealisNi.frame]
+  readings := [niReading .objectControl]
 
-/-- 'know' — selects a finite `kɛji`-clause for if/whether complements
-    ([allotey-2021] exx 104, 108: 'know if they will be coming',
-    'doesn't know whether you or he bought the book'). -/
-def le : CTP := ⟨"le", "know", [.finiteKeji], .none, none⟩
+/-- *bi* 'ask' — object control (ex 59: 'I asked Ayele to tell me a story'). -/
+def bi : Verb where
+  form := "bi"
+  frames := [irrealisNi.frame]
+  readings := [niReading .objectControl]
 
-/-- The attested complement-taking predicate inventory. -/
-def gaCTPs : List CTP :=
-  [tao, hiekano, hiekpano, miamihie, kai, nye, kpleno, kpang,
+/-- *kɛɛ* 'say, tell' — the paper's utterance-verb exemplar with a finite
+    `akɛ`-clause (exx 47–49: *Jojo kɛɛ akɛ …* 'Jojo said that …'), and object
+    control in the `ni`-frame, 'tell someone to' (ex 117b: *John é-kee-ee Mary
+    ni é he noko-noko* 'John didn't tell Mary to buy anything'). -/
+def kee : Verb where
+  form := "kɛɛ"
+  frames := [finiteAke.frame, irrealisNi.frame]
+  readings := [niReading .objectControl]
+  speechActVerb := true
+
+/-! ### Finite complements only -/
+
+/-- *le* 'know' — a finite `kɛji`-clause for if/whether complements (exx 104,
+    108: 'know if they will be coming', 'know whether you or he bought the
+    book'). -/
+def le : Verb where
+  form := "le"
+  frames := [finiteKeji.frame]
+  attitude := some (.doxastic .veridical)
+
+/-- The clause-embedding verbs attested in the paper's examples. -/
+def verbs : List Verb :=
+  [tao, sumo, hiekano, hiekpano, miamihie, kai, nye, kpleno, kpang, kpagbe, dweng,
    wa, kenya, dai, laka, bi, kee, le]
 
 end Ga

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -1,4 +1,5 @@
 import Linglib.Fragments.Ga.Predicates
+import Linglib.Syntax.Category.Verb.Basic
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Control.Head
 import Linglib.Studies.Landau2013
@@ -17,9 +18,9 @@ subject (Table 4). The pronoun is overt because that tone needs a segmental
 host.
 
 The OC signature is read off the Fragment's clause typology through
-[landau-2013]'s profile, the complement frames off the Fragment's verb
-inventory, and the finiteness diagnostics off the Fragment's clause
-properties; the example rows check each claim, including the implicative
+[landau-2013]'s profile, complementizer selection off the Fragment's verb
+frames through `Verb.takes`, and the finiteness diagnostics off the Fragment's
+clause properties; the example rows check each claim, including the implicative
 contrast of (89) against the verbs' Karttunen classes. The Movement Theory of
 Control is refuted by the lexical-subject rows, and the tone-hosting
 requirement derives the overt pronoun from the minimal-pronoun inventory.
@@ -61,13 +62,21 @@ def gaProfile (c : EmbeddedClauseType) : Profile Landau2013.Clause74 :=
   Landau2013.ofNoncoreferential (clauseProperties c).noncoreferentialSubject
 
 /-- OC status is read off the complementizer's finiteness. -/
-theorem obligatory_iff_not_isFinite (c : EmbeddedClauseType) :
-    (gaProfile c).IsObligatory ↔ (clauseComplementizer c).isFinite = false := by
+theorem obligatory_iff_not_finite (c : EmbeddedClauseType) :
+    (gaProfile c).IsObligatory ↔ (clauseComplementizer c).verbForm ≠ some .Fin := by
   cases c <;> decide
 
-/-- A verb has a `ni`-frame exactly when it is a control verb. -/
-theorem control_iff_selects_ni :
-    ∀ v ∈ gaCTPs, .irrealisNi ∈ v.selects ↔ v.control ≠ .none := by
+/-! ### Complementizer selection (§5.5.1) -/
+
+/-- The three-way clause typology is the selection relation: each clause type's
+    frame takes exactly its own complementizer. -/
+theorem frame_takes_iff (c d : EmbeddedClauseType) :
+    c.frame.Takes (clauseComplementizer d) ↔ c = d := by
+  cases c <;> cases d <;> decide
+
+/-- A verb takes `ni` exactly when some frame of it is controlled. -/
+theorem takes_ni_iff_control :
+    ∀ v ∈ verbs, v.takes ni ↔ ∃ r ∈ v.readings, r.control.isSome := by
   decide
 
 /-! ### Table 2 -/
@@ -102,8 +111,10 @@ theorem signature_rows :
 
 /-- The two control rows are the verb inventory. -/
 theorem control_rows :
-    (overtPronoun .subjectControl ↔ ∃ v ∈ gaCTPs, v.control = .subjectControl) ∧
-    (overtPronoun .objectControl ↔ ∃ v ∈ gaCTPs, v.control = .objectControl) := by
+    (overtPronoun .subjectControl ↔
+      ∃ v ∈ verbs, ∃ r ∈ v.readings, r.control = some .subjectControl) ∧
+    (overtPronoun .objectControl ↔
+      ∃ v ∈ verbs, ∃ r ∈ v.readings, r.control = some .objectControl) := by
   decide
 
 /-- The controlled form φ-covaries with its controller (exx 37–39), unlike
@@ -124,8 +135,8 @@ def gaInventory : MinPronInventory PronForm where
 /-! ### Rows -/
 
 /-- The Fragment entry for a row's matrix verb. -/
-def ctpOf (row : LinguisticExample) : Option CTP :=
-  (row.feature? "verb").bind λ v ↦ gaCTPs.find? (·.form = v)
+def verbOf (row : LinguisticExample) : Option Verb :=
+  (row.feature? "verb").bind (lookupSense verbs ·)
 
 /-- The clause type a complementizer feature names. -/
 def clauseOf : String → Option EmbeddedClauseType
@@ -172,13 +183,14 @@ theorem lexical_subject_rows :
   decide +kernel
 
 /-- Complementizer selection (exx 104–106), over each row and its alternatives:
-    grammatical exactly when the Fragment records the frame for the verb. -/
+    grammatical exactly when the verb takes the complementizer. -/
 theorem c_selection_rows :
     ∀ row ∈ Examples.all, row.feature? "diagnostic" = some "cSelection" →
-      ∀ v ∈ ctpOf row,
-        (∀ c ∈ clauseTypeOf row, (row.judgment = .acceptable ↔ c ∈ v.selects)) ∧
+      ∀ v ∈ verbOf row,
+        (∀ c ∈ clauseTypeOf row,
+          (row.judgment = .acceptable ↔ v.takes (clauseComplementizer c))) ∧
         ∀ alt ∈ row.alternatives, ∀ c ∈ clauseOfForm alt.1,
-          (alt.2 = .acceptable ↔ c ∈ v.selects) := by
+          (alt.2 = .acceptable ↔ v.takes (clauseComplementizer c)) := by
   decide +kernel
 
 /-- Overt tense or aspect in the complement is grammatical exactly in the
@@ -229,7 +241,7 @@ theorem marker_rows :
     realized ([karttunen-1971]). -/
 theorem implicative_rows :
     ∀ row ∈ Examples.all, row.feature? "diagnostic" = some "implicative" →
-      ∀ v ∈ ctpOf row,
+      ∀ v ∈ verbOf row,
         (row.feature? "irrealisMarker" = some "absent" ↔ v.implicative = some .positive) := by
   decide +kernel
 
@@ -260,8 +272,8 @@ instance : DecidablePred StrongCP :=
   λ _ ↦ inferInstanceAs (Decidable (_ ∧ _))
 
 /-- `akɛ` and `kɛji` head strong CPs, `ni` a weak one. -/
-theorem strongCP_iff_isFinite (c : EmbeddedClauseType) :
-    StrongCP c ↔ (clauseComplementizer c).isFinite := by
+theorem strongCP_iff_finite (c : EmbeddedClauseType) :
+    StrongCP c ↔ (clauseComplementizer c).verbForm = some .Fin := by
   cases c <;> decide
 
 /-- Long-distance Agree ([szabolcsi-2009]) reaches the embedded subject across
@@ -361,14 +373,10 @@ theorem deSe_witness :
 
 /-! ### Typological placement -/
 
-/-- Gã complements in [noonan-2007]'s typology; `.infinitive` is the paper's
-    own term for the bare-root `ni`-complement. -/
-def gaToNoonan : EmbeddedClauseType → Complement.Coding
-  | .finiteAke => .indicative
-  | .finiteKeji => .indicative
-  | .irrealisNi => .infinitive
-
-/-- The control complement is reduced in Noonan's terms. -/
-theorem ni_complement_reduced : (gaToNoonan .irrealisNi).isReduced = true := rfl
+/-- In [noonan-2007]'s typology the controlled complement is the reduced one:
+    `.infinitive`, the paper's own term for the bare-root `ni`-complement. -/
+theorem reduced_iff_obligatory (c : EmbeddedClauseType) :
+    (∀ cd ∈ c.frame.codings, cd.isReduced = true) ↔ (gaProfile c).IsObligatory := by
+  cases c <;> decide
 
 end Allotey2021


### PR DESCRIPTION
Random-file deep audit of `Fragments/Ga/Predicates.lean`: the local `CTP` record and `Complementizer` enum re-stipulated the theory-layer `Verb` and `Complementizer` entry APIs, so Gã was invisible to `Verb.takes`.

- `akɛ`, `kɛji`, `ni` are `Complementizer` entries; each clause type has a `Frame` (the `ni`-frame records the overt nominative subject) and complementizer selection is `Verb.takes`, with `frame_takes_iff` showing the typology is the selection relation
- Control is per frame on `Verb.Reading`, fixing *kai*/*kɛɛ* whose finite frame is not controlled; *sumɔ*, *kpã-gbɛ*, *dwɛŋ* added from the paper's rows
- Drops the redundant `finiteComplementizer` flag; finiteness is the complementizer's `verbForm`; Noonan reduction is derived from the frame's coding