### PR TITLE
refactor(Fragments/Ga): pronoun entries, finiteness off complementizer

### DIFF
--- a/Linglib/Fragments/Ga/Basic.lean
+++ b/Linglib/Fragments/Ga/Basic.lean
@@ -3,162 +3,92 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Features.Number.Basic
-import Linglib.Features.Person.Basic
+import Linglib.Syntax.Category.Pronoun.Basic
 import Linglib.Syntax.Category.Complementizer.Basic
 import Linglib.Syntax.Category.Verb.Complement.Basic
 
 /-!
-# Gã Fragment
-[allotey-2021]
+# Gã fragment
 
-Language data for Gã (ISO: gaa), a Kwa (Niger-Congo) language spoken in
-Greater Accra, Ghana, covering what [allotey-2021] ("Overt Pronouns of
-Infinitival Predicates of Gã") needs for the obligatory-control facts:
-pronoun paradigm, TAM marking, complementizer inventory, and embedded
-clause typology.
+This file records the Gã (ISO 639-3 `gaa`; Kwa, Ghana) data of [allotey-2021]:
+the pronoun paradigm of Table 3 as `PersonalPronoun` entries, the three
+complementizers as `Complementizer` entries, the three-way embedded clause
+typology they head together with the complement `Frame` each type records, and
+the pro-drop profile. The complement-taking verbs are in
+`Fragments/Ga/Predicates`.
 
-## Coverage
+## Implementation notes
 
-- Pronouns by person, number and case (the paper's Table 3)
-- TAM prefixes (future, progressive, perfective) and the irrealis
-  marker `á`, realized in embedded control clauses as high tone on
-  the subject pronoun
-- Complementizer inventory (`akɛ`, `kɛji`, `ni`) as `Complementizer`
-  entries; `ni` is optionally overt with some control verbs (*tao*
-  'want', [allotey-2021] ex 34) and obligatory with others
-  (*hiɛ-kã-nɔ* 'hope', ex 35)
-- Embedded clause typology (three-way: `finiteAke`, `finiteKeji`,
-  `irrealisNi`), each type with its complementizer and its complement
-  `Frame`; the complement-taking verbs live in `Fragments/Ga/Predicates`
-- Pro-drop profile
-
-## Identifier policy
-
-Lean 4 does not accept the IPA characters `ɛ` (U+025B) or `ŋ` (U+014B)
-as identifier characters. Constructor and definition names use plain
-Latin orthography (`ake`, `keji`, `nye`), while the IPA form is
-preserved in the corresponding `String` value.
-
-## What is NOT covered (deliberately)
-
-The verb-movement/negation-placement diagnostic ([allotey-2021]'s fifth
-non-finiteness argument, after [pollock-1989]: finite verbs raise past
-the suffixal negation `-ee`, `-ŋ`, `-ko`, while irrealis embedded clauses
-show a free preverbal negator `ka`, exx 120–125). Formalizing the raising
-argument needs phrase-structure substrate beyond this fragment's
-clause-typology schema; the finiteness split it diagnoses is already
-carried by `ClauseProperties.unrestrictedTAM`.
+The paper's finiteness diagnostics (tense restriction, focus fronting, NPI
+licensing, negation placement; exx 104–125) all split the `ni`-clause from the
+other two, so they are not stored as clause properties: finiteness is read off
+the complementizer (`Complementizer.IsFinite`), and each diagnostic is a theorem
+over the paper's rows in `Studies/Allotey2021`. The verb-movement diagnostic
+(exx 120–125, after [pollock-1989]) needs phrase-structure substrate this
+fragment does not carry. Lean does not accept `ɛ` or `ŋ` in identifiers, so
+names use plain Latin (`ake`, `keji`, `nye`) and the IPA orthography lives in
+`form`.
 
 ## References
 
 * [allotey-2021]
-* [landau-2004]
 * [noonan-2007]
 * [pollock-1989]
 -/
 
 namespace Ga
 
-/-! ### Pronoun paradigm -/
+/-! ### Pronouns -/
 
-/-- The three case forms of Gã pronouns ([allotey-2021] Table 3). -/
-inductive PronounCase where
-  | subjective
-  | objective
-  | possessive
-  deriving DecidableEq, Repr
+/-- The pronoun paradigm of [allotey-2021]'s Table 3. Each person–number cell has
+    one elsewhere form realizing the subjective (nominative) and possessive
+    columns; only the second and third person singular add a dedicated objective
+    form (*bo*, *lɛ*).
+    Subject pronouns are proclitics on the inflected verb and cannot be dropped.
+    Not recorded: the clipped past-tense 1SG variant *ĩ* and the impersonal
+    subject *a*. -/
+def pronouns : List PersonalPronoun :=
+  [{ form := "mi", person := some .first, number := some .singular },
+   { form := "o", person := some .second, number := some .singular },
+   { form := "bo", person := some .second, number := some .singular, case_ := some .acc },
+   { form := "e", person := some .third, number := some .singular },
+   { form := "lɛ", person := some .third, number := some .singular, case_ := some .acc },
+   { form := "wɔ", person := some .first, number := some .plural },
+   { form := "nyɛ", person := some .second, number := some .plural },
+   { form := "amɛ", person := some .third, number := some .plural }]
 
-/-- Pronoun forms by person, number and case ([allotey-2021] Table 3); `none`
-    outside the 3 × 2 paradigm. Subject pronouns are proclitics on the
-    inflected verb and cannot be dropped; only second and third person
-    singular distinguish subjective from objective forms, and the possessive
-    always matches the subjective. Not covered: the clipped past-tense 1SG
-    variant *ĩ* and the impersonal subject pronoun *a*. -/
-def pronoun : Person → Number → PronounCase → Option String
-  | .first,  .singular, _           => some "mi"
-  | .second, .singular, .objective  => some "bo"
-  | .second, .singular, _           => some "o"
-  | .third,  .singular, .objective  => some "lɛ"
-  | .third,  .singular, _           => some "e"
-  | .first,  .plural,   _           => some "wɔ"
-  | .second, .plural,   _           => some "nyɛ"
-  | .third,  .plural,   _           => some "amɛ"
-  | _,       _,         _           => none
-
-/-- Subject proclitic forms (the subjective column of Table 3). In
-    [allotey-2021]'s OC examples the embedded subject of a controlled
-    `ni`-clause is one of these, never silent; merged with the irrealis marker
-    the 1SG proclitic surfaces as the portmanteau *má*. -/
-def subjectProclitic (p : Person) (n : Number) : Option String := pronoun p n .subjective
-
-/-! ### TAM marking -/
-
-/-- Prefixal TAM categories of the Gã verb (bare root = default past).
-
-    [allotey-2021] uses the future, progressive, and perfective prefixes
-    to argue that embedded clauses introduced by `akɛ` and `kɛji` allow
-    the full TAM paradigm (finite), while clauses introduced by `ni`
-    prohibit tense/aspect marking of any kind and are restricted to
-    irrealis (her exx 118–119, tense-restriction diagnostic). -/
-inductive TAM where
-  /-- Future prefix `baa-` (historically the ingressive deictic `bà`
-      plus the irrealis marker `á`) -/
-  | future
-  /-- Progressive prefix `mii-` -/
-  | progressive
-  /-- Perfective prefix `é-` (high tone) -/
-  | perfective
-  /-- Irrealis marker `á`: no independent verbal prefix in embedded
-      control clauses; realized as high tone on the subject pronoun
-      (portmanteau *má* for 1SG). True subjunctives double it — high
-      tone on pronoun AND verb ([allotey-2021] Table 4). -/
-  | irrealis
-  deriving DecidableEq, Repr
-
-/-- Segmental exponent of a TAM category; `none` for the irrealis, whose
-    marking in embedded control clauses is tonal (on the subject
-    pronoun) rather than prefixal. -/
-def TAM.exponent : TAM → Option String
-  | .future      => some "baa-"
-  | .progressive => some "mii-"
-  | .perfective  => some "é-"
-  | .irrealis    => none
-
-/-- Whether this TAM is part of the unrestricted (finite) paradigm.
-
-    Per [allotey-2021], finite embedded clauses (introduced by
-    `akɛ` or `kɛji`) freely host any of the four TAM categories;
-    `ni`-clauses are restricted to `.irrealis`. -/
-def TAM.isFinite : TAM → Bool
-  | .irrealis => false
-  | _         => true
+/-- The subject proclitic of a person–number cell: its elsewhere form. In the
+    paper's control examples the embedded subject of a controlled `ni`-clause is
+    one of these, never silent; merged with the irrealis high tone the 1SG
+    proclitic surfaces as the portmanteau *má* (exx 88, 100). -/
+def subjectProclitic? (p : Person) (n : Number) : Option PersonalPronoun :=
+  pronouns.find? λ q ↦ q.person == some p && q.number == some n && q.case_ != some .acc
 
 /-! ### Complementizers -/
 
-/-- *akɛ* — the finite declarative complementizer, typing the complements
-    of utterance and attitude verbs ([allotey-2021] exx 47–49, 89a). -/
+/-- *akɛ* — the finite declarative complementizer, typing the complements of
+    utterance and attitude verbs ([allotey-2021] exx 47–49, 89a). -/
 def ake : Complementizer where
   morphs := [.free "akɛ"]
   coding := some .indicative
   force := some .declarative
   verbForm := some .Fin
 
-/-- *kɛji* — the finite complementizer of conditional clauses (ex 97a) and,
-    under *le* 'know', of polar and alternative questions ('know if they
-    will come', 'know whether you or he bought it', exx 104, 108); glossed
-    COND throughout the paper. -/
+/-- *kɛji* — the finite complementizer of conditional clauses (ex 97a) and, under
+    *le* 'know', of polar and alternative questions ('know if they will come',
+    'know whether you or he bought it', exx 104, 108); glossed COND throughout
+    the paper. -/
 def keji : Complementizer where
   morphs := [.free "kɛji"]
   coding := some .indicative
   force := some .interrogative
   verbForm := some .Fin
 
-/-- *ni* — the irrealis complementizer of controlled clauses, glossed C and
-    the complement's verb INF: a weak CP with no focus fronting and no
-    independent tense (exx 107–109). Optionally overt with some control
-    verbs (*tao* 'want', ex 34) and obligatory with others (*hiɛ-kã-nɔ*
-    'hope', ex 35); homophonous with the focus marker (ex 27). -/
+/-- *ni* — the irrealis complementizer of controlled clauses, glossed C with the
+    complement's verb glossed INF: a weak CP with no focus fronting and no
+    independent tense (exx 107–109). Optionally overt with some control verbs
+    (*tao* 'want', ex 34) and obligatory with others (*hiɛ-kã-nɔ* 'hope', ex 35);
+    homophonous with the focus marker (ex 27). -/
 def ni : Complementizer where
   morphs := [.free "ni"]
   coding := some .infinitive
@@ -169,73 +99,49 @@ def complementizers : List Complementizer := [ake, keji, ni]
 
 /-! ### Embedded clause typology -/
 
-/-- Three embedded clause types in Gã, distinguished by complementizer
-    and TAM properties ([allotey-2021]).
+/-- The finite interrogative frame `kɛji` types. -/
+def kejiFrame : Frame :=
+  [.clausal (coding := some .indicative) (force := some .interrogative)]
 
-    Note: Gã `irrealisNi` clauses always carry an OVERT subject proclitic
-    in controlled contexts — there is no null-PRO option. The OC
-    properties hold of this overt-subject configuration. -/
-inductive EmbeddedClauseType where
-  /-- Finite `akɛ`-clause: full TAM, free subject reference, no OC -/
-  | finiteAke
-  /-- Finite `kɛji`-clause: full TAM, free subject reference, no OC -/
-  | finiteKeji
-  /-- The controlled irrealis `ni`-clause: irrealis only, obligatory
-      coreference, OC. The complementizer `ni` itself may be optional or
-      obligatory depending on the matrix verb; the irrealis tone marking
-      and OC behavior are constant. NOT every `ni`-headed clause is of
-      this type: `ni` also introduces true subjunctives with lexical
-      subjects (*Osa kplɛnɔ ni Taki á-tsɛ́ Momo*, ex 105) and, with
-      *dwɛŋ* 'think', finite low-tone complements (exx 110–111). -/
-  | irrealisNi
-  deriving DecidableEq, Repr
-
-/-- Properties distinguishing the three clause types ([allotey-2021] §5.5). -/
-structure ClauseProperties where
-  /-- All four TAM categories available (exx 110–111 vs 118–119). -/
-  unrestrictedTAM : Bool
-  /-- Tense independent of the matrix clause ([landau-2004]'s `[±T]`):
-      finite complements host past/progressive/future freely, while
-      `ni`-clauses have only "the tense of a possible future" (ex 109). -/
-  independentTense : Bool
-  /-- Noncoreferential embedded subject possible (exx 110 vs 112). -/
-  noncoreferentialSubject : Bool
-  /-- Matrix negation licenses an embedded NPI across this clause's
-      boundary (exx 116 vs 117). -/
-  npiTransparent : Bool
-  /-- Focus fronting inside the clause (exx 107–108). -/
-  focusFronting : Bool
-  /-- Negation precedes the verb (the free negator *ka*, exx 122, 125)
-      rather than following it as a suffix (exx 121, 124). -/
-  preverbalNegation : Bool
-  deriving DecidableEq, Repr
-
-def clauseProperties : EmbeddedClauseType → ClauseProperties
-  | .finiteAke   => ⟨true,  true,  true,  false, true,  false⟩
-  | .finiteKeji  => ⟨true,  true,  true,  false, true,  false⟩
-  | .irrealisNi  => ⟨false, false, false, true,  false, true⟩
-
-/-- The complementizer heading each clause type. -/
-def clauseComplementizer : EmbeddedClauseType → Complementizer
-  | .finiteAke   => ake
-  | .finiteKeji  => keji
-  | .irrealisNi  => ni
-
-/-- The complement frame a verb selecting each clause type records: a finite
-    declarative for `akɛ`, a finite interrogative for `kɛji`, and for `ni` an
-    infinitival whose subject is an overt proclitic in the subjective
-    (nominative) form of Table 3 — never null and never a lexical DP
+/-- The controlled irrealis frame `ni` types: [noonan-2007]-infinitival, the
+    paper's own term, with a subject that is an overt proclitic in the
+    subjective (nominative) form of Table 3 — never null and never a lexical DP
     (exx 40–42). -/
-def EmbeddedClauseType.frame : EmbeddedClauseType → Frame
-  | .finiteAke  => Frame.finiteClause
-  | .finiteKeji => [.clausal (coding := some .indicative) (force := some .interrogative)]
-  | .irrealisNi =>
-    [.clausal (coding := some .infinitive) (embeddedSubject := some (.overt (some .nom)))]
+def niFrame : Frame :=
+  [.clausal (coding := some .infinitive) (embeddedSubject := some (.overt (some .nom)))]
+
+/-- The three embedded clause types of [allotey-2021], named by the
+    complementizer heading them (§5.5.1). The `ni` type is the controlled
+    irrealis clause; `ni` also introduces true subjunctives with lexical subjects
+    (ex 105) and, under *dwɛŋ* 'think', finite low-tone complements
+    (exx 110–111), which are not of this type. -/
+inductive EmbeddedClauseType where
+  | ake
+  | keji
+  | ni
+  deriving DecidableEq, Repr
+
+namespace EmbeddedClauseType
+
+/-- The complementizer heading the clause type. -/
+def complementizer : EmbeddedClauseType → Complementizer
+  | ake => Ga.ake
+  | keji => Ga.keji
+  | ni => Ga.ni
+
+/-- The complement frame a verb selecting the clause type records; `akɛ` types
+    the generic finite declarative. -/
+def frame : EmbeddedClauseType → Frame
+  | ake => Frame.finiteClause
+  | keji => kejiFrame
+  | ni => niFrame
+
+end EmbeddedClauseType
 
 /-! ### Typological profile -/
 
-/-- Gã does NOT allow null pronominal subjects in matrix clauses:
-    every clause requires an overt subject proclitic ([allotey-2021]). -/
+/-- Gã does not allow null pronominal subjects in matrix clauses: every clause
+    requires an overt subject proclitic ([allotey-2021]). -/
 def allowsProDrop : Bool := false
 
 end Ga

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -10,7 +10,7 @@ import Linglib.Syntax.Category.Verb.Complement.Takes
 # Gã complement-taking verbs
 
 This file records the Gã verbs of [allotey-2021] that embed clauses, as `Verb`
-entries whose frames are the clause types of `Fragments/Ga/Basic` and whose
+entries whose frames are the clause frames of `Fragments/Ga/Basic` and whose
 `ni`-frame reading carries the control relation. Several verbs alternate between
 frames: *kai* 'remember' takes the controlled `ni`-clause (ex 43) or a finite
 `akɛ`-clause (ex 89a), *kɛɛ* 'say' takes `akɛ` (exx 47–49) or an
@@ -36,11 +36,9 @@ in `form`.
 
 namespace Ga
 
-open EmbeddedClauseType
-
 /-- The reading of the controlled `ni`-frame under control relation `c`. -/
 def niReading (c : ControlType) : Verb.Reading :=
-  { frame := irrealisNi.frame, control := some c }
+  { frame := niFrame, control := some c }
 
 /-! ### Subject control -/
 
@@ -49,7 +47,7 @@ def niReading (c : ControlType) : Verb.Reading :=
     *má* (exx 88, 100). -/
 def tao : Verb where
   form := "tao"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *sumɔ* 'like' — subject control, with no complementizer under negation
@@ -57,7 +55,7 @@ def tao : Verb where
     `ni` in the future (ex 92); the embedded pronoun cannot be obviative. -/
 def sumo : Verb where
   form := "sumɔ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *hiɛ-kã-nɔ* 'hope' (lit. 'face-place-upon') — subject control; `ni`
@@ -65,7 +63,7 @@ def sumo : Verb where
     school one day'). -/
 def hiekano : Verb where
   form := "hiɛ-kã-nɔ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *hiɛ-kpa-nɔ* 'forget' (lit. 'face-stop-upon') — subject control; `ni`
@@ -75,7 +73,7 @@ def hiekano : Verb where
     carries the irrealis marker (exx 102–103). -/
 def hiekpano : Verb where
   form := "hiɛ-kpa-nɔ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
   implicative := some .negative
 
@@ -83,7 +81,7 @@ def hiekpano : Verb where
     obligatory (exx 36, 60a: 'I tried to close the door'). -/
 def miamihie : Verb where
   form := "mia-mi-hiɛ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *kai* 'remember' — subject control in the `ni`-frame (exx 42–43: *Mi kai ni
@@ -93,7 +91,7 @@ def miamihie : Verb where
     keeps it (ex 117a). -/
 def kai : Verb where
   form := "kai"
-  frames := [irrealisNi.frame, finiteAke.frame]
+  frames := [niFrame, Frame.finiteClause]
   readings := [niReading .subjectControl]
   implicative := some .positive
 
@@ -103,7 +101,7 @@ def kai : Verb where
     outside the three-way clause typology. -/
 def nye : Verb where
   form := "nyɛ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
   implicative := some .positive
 
@@ -112,14 +110,14 @@ def nye : Verb where
     complement, 'agree that' (ex 105: *Osa kplɛnɔ ni/akɛ Taki á-tsɛ́ Momo*). -/
 def kpleno : Verb where
   form := "kplɛnɔ"
-  frames := [irrealisNi.frame, finiteAke.frame]
+  frames := [niFrame, Frame.finiteClause]
   readings := [niReading .subjectControl]
 
 /-- *kpaŋ* 'plan, decide' — subject control; only `ni` introduces the complement
     (ex 106) and the irrealis marker is obligatory (ex 89d). -/
 def kpang : Verb where
   form := "kpaŋ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *kpã-gbɛ* 'expect' — subject control (ex 53: *Ajele kpã-gbɛ ni e-ye
@@ -127,7 +125,7 @@ def kpang : Verb where
     not self-ascribe winning: the *de se* diagnostic). -/
 def kpagbe : Verb where
   form := "kpã-gbɛ"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .subjectControl]
 
 /-- *dwɛŋ* 'think' — a finite complement with a low-tone, freely referring
@@ -136,7 +134,7 @@ def kpagbe : Verb where
     subject (ex 112: 'Aku thought to buy a book'). -/
 def dweng : Verb where
   form := "dwɛŋ"
-  frames := [finiteAke.frame, irrealisNi.frame]
+  frames := [Frame.finiteClause, niFrame]
   readings := [niReading .subjectControl]
   attitude := some (.doxastic .nonVeridical)
 
@@ -147,20 +145,20 @@ def dweng : Verb where
     literature after [karttunen-1971]; left unclassified. -/
 def wa : Verb where
   form := "wa"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .objectControl]
 
 /-- *kenya* 'urge, encourage' — object control (exx 55, 60b). -/
 def kenya : Verb where
   form := "kenya"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .objectControl]
 
 /-- *dai* 'force' — object control (ex 56: 'I forced Kofi to go to school'); a
     coercive causative whose complement is entailed ([nadathur-lauer-2020]). -/
 def dai : Verb where
   form := "dai"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .objectControl]
   implicative := some .positive
   causative := some .force
@@ -169,13 +167,13 @@ def dai : Verb where
     (exx 57–58). -/
 def laka : Verb where
   form := "laka"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .objectControl]
 
 /-- *bi* 'ask' — object control (ex 59: 'I asked Ayele to tell me a story'). -/
 def bi : Verb where
   form := "bi"
-  frames := [irrealisNi.frame]
+  frames := [niFrame]
   readings := [niReading .objectControl]
 
 /-- *kɛɛ* 'say, tell' — the paper's utterance-verb exemplar with a finite
@@ -184,7 +182,7 @@ def bi : Verb where
     ni é he noko-noko* 'John didn't tell Mary to buy anything'). -/
 def kee : Verb where
   form := "kɛɛ"
-  frames := [finiteAke.frame, irrealisNi.frame]
+  frames := [Frame.finiteClause, niFrame]
   readings := [niReading .objectControl]
   speechActVerb := true
 
@@ -195,7 +193,7 @@ def kee : Verb where
     book'). -/
 def le : Verb where
   form := "le"
-  frames := [finiteKeji.frame]
+  frames := [kejiFrame]
   attitude := some (.doxastic .veridical)
 
 /-- The clause-embedding verbs attested in the paper's examples. -/

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -8,9 +8,10 @@ import Linglib.Data.Examples.Allotey2021
 /-!
 # Allotey (2021): overt pronouns of infinitival predicates of Gã
 
-Obligatory control into Gã irrealis `ni`-clauses requires an overt subject
-proclitic: null PRO is ungrammatical, a lexical subject is ungrammatical, and
-the proclitic shows the whole OC signature (Table 2). The controlled clause is
+This file formalizes [allotey-2021]. Obligatory control into Gã irrealis
+`ni`-clauses requires an overt subject proclitic: null PRO is ungrammatical, a
+lexical subject is ungrammatical, and the proclitic shows the whole OC signature
+(Table 2). The controlled clause is
 non-finite and irrealis rather than subjunctive — it bars tense and aspect,
 focus fronting and obviation, licenses NPIs across its boundary, negates
 preverbally, and carries the irrealis marker only as a high tone on its
@@ -18,10 +19,11 @@ subject (Table 4). The pronoun is overt because that tone needs a segmental
 host.
 
 The OC signature is read off the Fragment's clause typology through
-[landau-2013]'s profile, complementizer selection off the Fragment's verb
-frames through `Verb.takes`, and the finiteness diagnostics off the Fragment's
-clause properties; the example rows check each claim, including the implicative
-contrast of (89) against the verbs' Karttunen classes. The Movement Theory of
+[landau-2013]'s profile and complementizer selection off the Fragment's verb
+frames through `Verb.takes`; every finiteness diagnostic is a theorem over the
+example rows conditioned on the complementizer's finiteness alone, which is the
+paper's convergence argument. The rows also check the implicative contrast of
+(89) against the verbs' Karttunen classes. The Movement Theory of
 Control is refuted by the lexical-subject rows, and the tone-hosting
 requirement derives the overt pronoun from the minimal-pronoun inventory.
 
@@ -35,6 +37,7 @@ requirement derives the overt pronoun from the minimal-pronoun inventory.
 * [satik-2019]
 * [karttunen-1971]
 * [noonan-2007]
+* [rizzi-1997]
 -/
 
 namespace Allotey2021
@@ -43,27 +46,28 @@ open Minimalist.MinimalPronoun Control Ga Data.Examples
 
 /-! ### Pronouns (Table 3) -/
 
-/-- Only second and third person singular distinguish a subjective from an
-    objective form. -/
-theorem objective_distinct_iff (p : Person) (n : Number) :
-    pronoun p n .objective ≠ pronoun p n .subjective ↔
+/-- Only second and third person singular have a dedicated objective form. -/
+theorem objective_form_iff (p : Person) (n : Number) :
+    (∃ q ∈ pronouns, q.person = some p ∧ q.number = some n ∧ q.case_ = some .acc) ↔
       n = .singular ∧ (p = .second ∨ p = .third) := by
   cases p <;> cases n <;> decide
 
-/-- The possessive always matches the subjective form. -/
-theorem possessive_eq_subjective (p : Person) (n : Number) :
-    pronoun p n .possessive = pronoun p n .subjective := by
-  cases p <;> cases n <;> rfl
+/-- No dedicated possessive form: the possessive column of Table 3 is the
+    elsewhere form. -/
+theorem no_possessive_form : ∀ q ∈ pronouns, q.case_ ≠ some .gen := by
+  decide
 
 /-! ### OC by clause type -/
 
-/-- The control profile of a Gã clause type, from its noncoreference flag. -/
+/-- The control profile of a Gã clause type: the finite clauses license a
+    noncoreferential subject (exx 110 vs 112). -/
 def gaProfile (c : EmbeddedClauseType) : Profile Landau2013.Clause74 :=
-  Landau2013.ofNoncoreferential (clauseProperties c).noncoreferentialSubject
+  Landau2013.ofNoncoreferential (decide c.complementizer.IsFinite)
 
-/-- OC status is read off the complementizer's finiteness. -/
+/-- OC status is the complementizer's non-finiteness: [szabolcsi-2009]'s
+    long-distance Agree reaches the embedded subject across the weak CP only. -/
 theorem obligatory_iff_not_finite (c : EmbeddedClauseType) :
-    (gaProfile c).IsObligatory ↔ (clauseComplementizer c).verbForm ≠ some .Fin := by
+    (gaProfile c).IsObligatory ↔ ¬ c.complementizer.IsFinite := by
   cases c <;> decide
 
 /-! ### Complementizer selection (§5.5.1) -/
@@ -71,7 +75,7 @@ theorem obligatory_iff_not_finite (c : EmbeddedClauseType) :
 /-- The three-way clause typology is the selection relation: each clause type's
     frame takes exactly its own complementizer. -/
 theorem frame_takes_iff (c d : EmbeddedClauseType) :
-    c.frame.Takes (clauseComplementizer d) ↔ c = d := by
+    c.frame.Takes d.complementizer ↔ c = d := by
   cases c <;> cases d <;> decide
 
 /-- A verb takes `ni` exactly when some frame of it is controlled. -/
@@ -101,12 +105,12 @@ def overtPronoun (r : Table2Row) : Bool := r != .longDistanceAntecedent
     under [landau-2013]'s signature: nothing. -/
 theorem signature_rows :
     (overtPronoun .cCommandedByAntecedent ↔
-      Diagnostic.nonCCommandingControl ∉ (gaProfile .irrealisNi).admits) ∧
+      Diagnostic.nonCCommandingControl ∉ (gaProfile .ni).admits) ∧
     (overtPronoun .longDistanceAntecedent ↔
-      Diagnostic.longDistanceControl ∈ (gaProfile .irrealisNi).admits) ∧
-    (overtPronoun .sloppyOnly ↔ Diagnostic.strictEllipsis ∉ (gaProfile .irrealisNi).admits) ∧
+      Diagnostic.longDistanceControl ∈ (gaProfile .ni).admits) ∧
+    (overtPronoun .sloppyOnly ↔ Diagnostic.strictEllipsis ∉ (gaProfile .ni).admits) ∧
     (overtPronoun .boundVariable ↔
-      Diagnostic.strictUnderOnly ∉ (gaProfile .irrealisNi).admits) := by
+      Diagnostic.strictUnderOnly ∉ (gaProfile .ni).admits) := by
   decide
 
 /-- The two control rows are the verb inventory. -/
@@ -121,7 +125,7 @@ theorem control_rows :
     [satik-2019]'s form-invariant Ewe *yè*. -/
 theorem controlled_form_covaries :
     overtPronoun .hasPhiFeatures ↔
-      subjectProclitic .second .singular ≠ subjectProclitic .second .plural := by
+      subjectProclitic? .second .singular ≠ subjectProclitic? .second .plural := by
   decide
 
 /-! ### Minimal-pronoun inventory -/
@@ -140,9 +144,9 @@ def verbOf (row : LinguisticExample) : Option Verb :=
 
 /-- The clause type a complementizer feature names. -/
 def clauseOf : String → Option EmbeddedClauseType
-  | "ni" => some .irrealisNi
-  | "ake" => some .finiteAke
-  | "keji" => some .finiteKeji
+  | "ni" => some .ni
+  | "ake" => some .ake
+  | "keji" => some .keji
   | _ => none
 
 /-- The clause type of a row: its complement's, or the finite type for a
@@ -150,14 +154,14 @@ def clauseOf : String → Option EmbeddedClauseType
 def clauseTypeOf (row : LinguisticExample) : Option EmbeddedClauseType :=
   match row.feature? "complementizer", row.feature? "clauseType" with
   | some c, _ => clauseOf c
-  | none, some "finite" => some .finiteAke
+  | none, some "finite" => some .ake
   | _, _ => none
 
 /-- The complementizer inside an alternative form. -/
 def clauseOfForm (s : String) : Option EmbeddedClauseType :=
-  if " ni ".toList <:+: s.toList then some .irrealisNi
-  else if " akɛ ".toList <:+: s.toList then some .finiteAke
-  else if " kɛji ".toList <:+: s.toList then some .finiteKeji
+  if " ni ".toList <:+: s.toList then some .ni
+  else if " akɛ ".toList <:+: s.toList then some .ake
+  else if " kɛji ".toList <:+: s.toList then some .keji
   else none
 
 /-- The realized form of a row's embedded subject. -/
@@ -188,40 +192,41 @@ theorem c_selection_rows :
     ∀ row ∈ Examples.all, row.feature? "diagnostic" = some "cSelection" →
       ∀ v ∈ verbOf row,
         (∀ c ∈ clauseTypeOf row,
-          (row.judgment = .acceptable ↔ v.takes (clauseComplementizer c))) ∧
+          (row.judgment = .acceptable ↔ v.takes c.complementizer)) ∧
         ∀ alt ∈ row.alternatives, ∀ c ∈ clauseOfForm alt.1,
-          (alt.2 = .acceptable ↔ v.takes (clauseComplementizer c)) := by
+          (alt.2 = .acceptable ↔ v.takes c.complementizer) := by
   decide +kernel
 
-/-- Overt tense or aspect in the complement is grammatical exactly in the
-    clause types with unrestricted TAM (exx 101, 111). -/
+/-- Overt tense or aspect in the complement is grammatical exactly in the finite
+    clause types (exx 101, 111). -/
 theorem tam_rows :
     ∀ row ∈ Examples.all, ∀ c ∈ clauseTypeOf row, ∀ t ∈ row.feature? "embeddedTAM",
-      t ≠ "none" → (row.judgment = .acceptable ↔ (clauseProperties c).unrestrictedTAM) := by
+      t ≠ "none" → (row.judgment = .acceptable ↔ c.complementizer.IsFinite) := by
   decide +kernel
 
-/-- Focus fronting (exx 107–108) and NPI licensing by matrix negation (exx
-    116–117) follow the clause properties. -/
+/-- Focus fronting, [rizzi-1997]'s strong-CP diagnostic, is available exactly in
+    the finite clauses (exx 107–108); matrix negation licenses an embedded NPI
+    exactly across the non-finite one (exx 116–117). -/
 theorem focus_npi_rows :
     ∀ row ∈ Examples.all, ∀ c ∈ clauseTypeOf row,
       (row.feature? "diagnostic" = some "focus" →
-        (row.judgment = .acceptable ↔ (clauseProperties c).focusFronting)) ∧
+        (row.judgment = .acceptable ↔ c.complementizer.IsFinite)) ∧
       (row.feature? "diagnostic" = some "npi" → row.feature? "negation" = some "matrix" →
-        (row.judgment = .acceptable ↔ (clauseProperties c).npiTransparent)) := by
+        (row.judgment = .acceptable ↔ ¬ c.complementizer.IsFinite)) := by
   decide +kernel
 
-/-- Negation precedes the verb exactly in the irrealis clause (exx 121–122,
+/-- Negation precedes the verb exactly in the non-finite clause (exx 121–122,
     124). -/
 theorem negation_rows :
     ∀ row ∈ Examples.all, ∀ c ∈ clauseTypeOf row, ∀ p ∈ row.feature? "negationPosition",
-      (p = "preverbal") = (clauseProperties c).preverbalNegation := by
+      (p = "preverbal" ↔ ¬ c.complementizer.IsFinite) := by
   decide +kernel
 
 /-- The embedded subject bears the irrealis high tone exactly in the `ni`-clause
     (exx 110–112, 118). -/
 theorem subject_tone_rows :
     ∀ row ∈ Examples.all, row.judgment = .acceptable → ∀ c ∈ clauseTypeOf row,
-      ∀ t ∈ row.feature? "subjectTone", (t = "high") = (c = .irrealisNi) := by
+      ∀ t ∈ row.feature? "subjectTone", (t = "high") = (c = .ni) := by
   decide +kernel
 
 /-! ### The irrealis marker -/
@@ -248,9 +253,10 @@ theorem implicative_rows :
 /-! ### Landau's scale -/
 
 /-- Gã clause types on [landau-2004]'s finiteness scale — a scale position, not
-    a mood claim. -/
+    a mood claim. Unrestricted TAM and independent tense both coincide with the
+    complementizer's finiteness (exx 109–111, 118–119). -/
 def gaToLandau (c : EmbeddedClauseType) : ClauseClass :=
-  .ofFiniteness (clauseProperties c).unrestrictedTAM (clauseProperties c).independentTense
+  .ofFiniteness (decide c.complementizer.IsFinite) (decide c.complementizer.IsFinite)
 
 /-- No Gã clause type is a tensed-but-controlled F-subjunctive. -/
 theorem ga_no_fSubjunctive (c : EmbeddedClauseType) : gaToLandau c ≠ .fSubjunctive := by
@@ -261,27 +267,6 @@ theorem ga_no_fSubjunctive (c : EmbeddedClauseType) : gaToLandau c ≠ .fSubjunc
 theorem landau_predicts_control (c : EmbeddedClauseType) (agr : Bool) :
     (gaProfile c).IsObligatory ↔ (gaToLandau c).HasOC agr := by
   cases c <;> cases agr <;> decide
-
-/-! ### CP strength -/
-
-/-- A strong CP in [rizzi-1997]'s sense: focus features and independent tense. -/
-def StrongCP (c : EmbeddedClauseType) : Prop :=
-  (clauseProperties c).focusFronting ∧ (clauseProperties c).independentTense
-
-instance : DecidablePred StrongCP :=
-  λ _ ↦ inferInstanceAs (Decidable (_ ∧ _))
-
-/-- `akɛ` and `kɛji` head strong CPs, `ni` a weak one. -/
-theorem strongCP_iff_finite (c : EmbeddedClauseType) :
-    StrongCP c ↔ (clauseComplementizer c).verbForm = some .Fin := by
-  cases c <;> decide
-
-/-- Long-distance Agree ([szabolcsi-2009]) reaches the embedded subject across
-    the weak CP only: the controlled clauses are the weak ones, and they are
-    the NPI-transparent ones. -/
-theorem weakCP_iff_obligatory (c : EmbeddedClauseType) :
-    ¬ StrongCP c ↔ (gaProfile c).IsObligatory ∧ (clauseProperties c).npiTransparent := by
-  cases c <;> decide
 
 /-! ### Table 4 -/
 

--- a/Linglib/Syntax/Category/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Category/Complementizer/Basic.lean
@@ -23,6 +23,8 @@ Uyghur *de*.
 * `Complementizer.Licenser` — adnominal vs adverbal licensing category
 * `Complementizer.form` — the surface form with boundary notation
 * `Complementizer.IsBound` — affixal status, read off the morphs
+* `Complementizer.IsFinite` — finiteness of the typed clause, read off the
+  verb form
 * `Complementizer.toWord` — the `SCONJ` word a free complementizer
   projects
 
@@ -84,6 +86,12 @@ def IsBound (c : Complementizer) : Prop := ∀ m ∈ c.morphs, m.kind ≠ .free
 
 instance : DecidablePred IsBound := fun c => by
   unfold IsBound; infer_instance
+
+/-- Finite: the clause the morpheme types has a finite verb form. -/
+def IsFinite (c : Complementizer) : Prop := c.verbForm = some .Fin
+
+instance : DecidablePred IsFinite := fun c =>
+  inferInstanceAs (Decidable (c.verbForm = some .Fin))
 
 /-- The `SCONJ` word a free complementizer projects; `none` for bound
 clause-typers. -/


### PR DESCRIPTION
Deep cleanse of `Fragments/Ga/Basic.lean`: the pronoun paradigm, TAM enum, and seven-flag clause-property table were local re-stipulations, and every diagnostic flag was the complementizer's finiteness or its negation.

- Table 3 as `PersonalPronoun` entries (elsewhere form plus the two dedicated objective forms); `subjectProclitic?` is a lookup, and the study's Table 3 facts are theorems over the entries
- `ClauseProperties` and `TAM` deleted; `Complementizer.IsFinite` added to the substrate, and each finiteness diagnostic in `Studies/Allotey2021` is now a row theorem conditioned on it, which is the paper's convergence argument
- Clause types renamed `ake | keji | ni` with `complementizer` and `frame` as dot-members; CP-strength section folded into the focus and OC theorems