### PR TITLE
refactor(Syntax/Category/Verb): frame classification and clausal Props

### DIFF
--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -679,32 +679,24 @@ theorem sorgen_is_uncertainty :
 /-- Non-CP-selecting verbs cannot take clausal complements.
     Their only frame is `Frame.np`. -/
 theorem nonCPSelecting_profile :
-    beenden.toVerb.canTakeClausalComplement = false ∧
-    streichen.toVerb.canTakeClausalComplement = false ∧
-    uebereilen.toVerb.canTakeClausalComplement = false ∧
-    entwickeln.toVerb.canTakeClausalComplement = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
+    ¬ beenden.toVerb.TakesClausal ∧ ¬ streichen.toVerb.TakesClausal ∧
+    ¬ uebereilen.toVerb.TakesClausal ∧ ¬ entwickeln.toVerb.TakesClausal := by
+  decide
 
 /-- CP-and-DP-selecting verbs can take clausal complements.
     Their `frames` include a `Frame.finiteClause` alternate. -/
 theorem cpSelecting_profile :
-    veranlassen.toVerb.canTakeClausalComplement = true ∧
-    vergessen.toVerb.canTakeClausalComplement = true ∧
-    erwarten.toVerb.canTakeClausalComplement = true ∧
-    beschliessen.toVerb.canTakeClausalComplement = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
+    veranlassen.toVerb.TakesClausal ∧ vergessen.toVerb.TakesClausal ∧
+    erwarten.toVerb.TakesClausal ∧ beschliessen.toVerb.TakesClausal := by
+  decide
 
 /-- All 8 experimental verbs can take nominal (DP) complements. -/
 theorem all_experimental_select_dp :
-    beenden.toVerb.canTakeNominalComplement = true ∧
-    streichen.toVerb.canTakeNominalComplement = true ∧
-    uebereilen.toVerb.canTakeNominalComplement = true ∧
-    entwickeln.toVerb.canTakeNominalComplement = true ∧
-    veranlassen.toVerb.canTakeNominalComplement = true ∧
-    vergessen.toVerb.canTakeNominalComplement = true ∧
-    erwarten.toVerb.canTakeNominalComplement = true ∧
-    beschliessen.toVerb.canTakeNominalComplement = true :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+    beenden.toVerb.TakesNominal ∧ streichen.toVerb.TakesNominal ∧
+    uebereilen.toVerb.TakesNominal ∧ entwickeln.toVerb.TakesNominal ∧
+    veranlassen.toVerb.TakesNominal ∧ vergessen.toVerb.TakesNominal ∧
+    erwarten.toVerb.TakesNominal ∧ beschliessen.toVerb.TakesNominal := by
+  decide
 
 -- ============================================================================
 -- § 11: Cross-Linguistic Bridge Theorems

--- a/Linglib/Studies/Schwarzer2026.lean
+++ b/Linglib/Studies/Schwarzer2026.lean
@@ -120,44 +120,44 @@ theorem german_vfinal_grounds_preverbal :
 -- ============================================================================
 
 /-! Each experimental verb is classified as CP-selecting or non-CP-selecting
-    by deriving the classification from its `complementType` and
-    `altComplementType` fields in the German fragment lexicon. -/
+    by deriving the classification from its frames in the German fragment
+    lexicon (`Verb.TakesClausal`). -/
 
 -- Non-CP-selecting verbs: DP complement only
 
 /-- *beenden* "end" does not take a *dass*-clause complement. -/
 theorem beenden_nonselecting :
-    beenden.toVerb.canTakeClausalComplement = false := rfl
+    ¬ beenden.toVerb.TakesClausal := by decide
 
 /-- *streichen* "cancel" does not take a *dass*-clause complement. -/
 theorem streichen_nonselecting :
-    streichen.toVerb.canTakeClausalComplement = false := rfl
+    ¬ streichen.toVerb.TakesClausal := by decide
 
 /-- *übereilen* "rush" does not take a *dass*-clause complement. -/
 theorem uebereilen_nonselecting :
-    uebereilen.toVerb.canTakeClausalComplement = false := rfl
+    ¬ uebereilen.toVerb.TakesClausal := by decide
 
 /-- *entwickeln* "develop" does not take a *dass*-clause complement. -/
 theorem entwickeln_nonselecting :
-    entwickeln.toVerb.canTakeClausalComplement = false := rfl
+    ¬ entwickeln.toVerb.TakesClausal := by decide
 
 -- CP-and-DP-selecting verbs
 
 /-- *veranlassen* "induce" takes both DP and *dass*-clause. -/
 theorem veranlassen_selecting :
-    veranlassen.toVerb.canTakeClausalComplement = true := rfl
+    veranlassen.toVerb.TakesClausal := by decide
 
 /-- *vergessen* "forget" takes both DP and *dass*-clause. -/
 theorem vergessen_selecting :
-    vergessen.toVerb.canTakeClausalComplement = true := rfl
+    vergessen.toVerb.TakesClausal := by decide
 
 /-- *erwarten* "expect" takes both DP and *dass*-clause. -/
 theorem erwarten_selecting :
-    erwarten.toVerb.canTakeClausalComplement = true := rfl
+    erwarten.toVerb.TakesClausal := by decide
 
 /-- *beschließen* "decide" takes both DP and *dass*-clause. -/
 theorem beschliessen_selecting :
-    beschliessen.toVerb.canTakeClausalComplement = true := rfl
+    beschliessen.toVerb.TakesClausal := by decide
 
 -- ============================================================================
 -- § 3: Competing Analyses & Structural Predictions
@@ -416,15 +416,13 @@ def nonSelectingVerbs : List GermanVerbEntry :=
 def selectingVerbs : List GermanVerbEntry :=
   [veranlassen, vergessen, erwarten, beschliessen]
 
-/-- All non-selecting verbs lack clausal complement capability. -/
-theorem nonSelecting_all_false :
-    nonSelectingVerbs.all
-      (λ v => !v.toVerb.canTakeClausalComplement) = true := by native_decide
+/-- No non-selecting verb takes a clausal complement. -/
+theorem nonSelecting_all_false : ∀ v ∈ nonSelectingVerbs, ¬ v.toVerb.TakesClausal := by
+  decide
 
-/-- All selecting verbs have clausal complement capability. -/
-theorem selecting_all_true :
-    selectingVerbs.all
-      (λ v => v.toVerb.canTakeClausalComplement) = true := by native_decide
+/-- Every selecting verb takes a clausal complement. -/
+theorem selecting_all_true : ∀ v ∈ selectingVerbs, v.toVerb.TakesClausal := by
+  decide
 
 /-- No verb is in both lists. -/
 theorem selecting_nonselecting_disjoint :

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -178,22 +178,6 @@ def Verb.isENTrigger (v : Verb) : Bool :=
 def Verb.isPreferentialAttitude (v : Verb) : Bool :=
   v.preferentialValence.isSome
 
-/-- Can this verb take a clausal (CP) complement?
-
-    Checks both primary and alternate complement frames. Used to classify
-    verbs as CP-selecting vs non-CP-selecting for coordination studies
-    ([schwarzer-2026]). -/
-def Verb.canTakeClausalComplement (v : Verb) : Bool :=
-  v.complementType.isClausal ||
-  match v.altComplementType with | some ct => ct.isClausal | none => false
-
-/-- Can this verb take a nominal (DP) complement?
-
-    Checks both primary and alternate complement frames. -/
-def Verb.canTakeNominalComplement (v : Verb) : Bool :=
-  v.complementType.isNominal ||
-  match v.altComplementType with | some ct => ct.isNominal | none => false
-
 /-- Look up a verb core by citation form and sense tag. -/
 def lookupSense (verbs : List Verb) (form : String) (tag : SenseTag := .default) :
     Option Verb :=

--- a/Linglib/Syntax/Category/Verb/Complement/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Complement/Basic.lean
@@ -7,17 +7,21 @@ import Linglib.Semantics.Mood.Defs
 A predicate's complement frame as a list of typed
 `Complement.Position`s: nominal, adpositional, or clausal, the clausal
 case carrying the axes the predicate selects for. The flat
-`ComplementType` enum survives as a round-trip view
-(`ComplementType.toFrame` / `Frame.toComplementType`).
+`ComplementType` enum survives as a classification of frames
+(`Frame.complementType?`) with `ComplementType.toFrame` as its section.
 
 ## Main definitions
 
 * `Complement.Position` — one complement position; a clausal position
   carries its selectional axes by construction
+* `Complement.Position.IsClausal`, `IsNominal`, `Frame.HasClausal`,
+  `Frame.HasNominal` — category of a position, and of some position of a
+  frame
 * `Frame` + `Frame.np`, `Frame.finiteClause`, … — a frame is a list of
   complement positions; the flat enum cells as smart constructors
-* `ComplementType` + `toFrame` / `Frame.toComplementType` — the flat
-  enum and its round-trip view
+* `ComplementType` + `toFrame` / `Frame.complementType?` — the flat enum,
+  its cell frames, and the classification of a frame by the axes of its
+  clausal position (`none` on frames outside the enum's shapes)
 * `ComplementType.toCoding` + `codings_toFrame` — the enum's
   [noonan-2007] coding and its agreement with the typed frames
 
@@ -68,6 +72,22 @@ def embeddedSubject? : Position → Option Clause.EmbeddedSubject
   | clausal _ _ es => es
   | _ => none
 
+/-- The position is clausal. -/
+def IsClausal : Position → Prop
+  | clausal _ _ _ => True
+  | _ => False
+
+instance : DecidablePred IsClausal := fun p => by
+  cases p <;> unfold IsClausal <;> infer_instance
+
+/-- The position is nominal. -/
+def IsNominal : Position → Prop
+  | nominal => True
+  | _ => False
+
+instance : DecidablePred IsNominal := fun p => by
+  cases p <;> unfold IsNominal <;> infer_instance
+
 end Position
 
 end Complement
@@ -90,6 +110,18 @@ def hasForce (fr : Frame) (f : Mood.Illocutionary) : Prop :=
 
 instance (fr : Frame) (f : Mood.Illocutionary) :
     Decidable (fr.hasForce f) :=
+  inferInstanceAs (Decidable (∃ p ∈ fr, _))
+
+/-- Some position of the frame is clausal. -/
+def HasClausal (fr : Frame) : Prop := ∃ p ∈ fr, p.IsClausal
+
+instance (fr : Frame) : Decidable fr.HasClausal :=
+  inferInstanceAs (Decidable (∃ p ∈ fr, _))
+
+/-- Some position of the frame is nominal. -/
+def HasNominal (fr : Frame) : Prop := ∃ p ∈ fr, p.IsNominal
+
+instance (fr : Frame) : Decidable fr.HasNominal :=
   inferInstanceAs (Decidable (∃ p ∈ fr, _))
 
 /-! ### Smart constructors — the flat `ComplementType` cells -/
@@ -192,23 +224,48 @@ def ComplementType.toFrame : ComplementType → Frame
   | .smallClause => Frame.smallClause
   | .question => Frame.question
 
-/-- Partial inverse of `ComplementType.toFrame`: the flat enum cell a
-    frame instantiates, `none` on frames richer than any cell. -/
-def Frame.toComplementType (fr : Frame) : Option ComplementType :=
-  [ComplementType.none, .np, .np_np, .np_pp, .finiteClause, .infinitival,
-    .gerund, .smallClause, .question].find? (·.toFrame == fr)
+/-- The clausal cell a clausal position with axes `c`, `f` instantiates:
+    interrogative force is an embedded question, otherwise the coding
+    decides, and a position recording no axis is a small clause. -/
+private def clausalCell (c : Option Complement.Coding) (f : Option Mood.Illocutionary) :
+    ComplementType :=
+  if f = some .interrogative then .question
+  else match c with
+    | some .indicative | some .subjunctive | some .paratactic => .finiteClause
+    | some .infinitive => .infinitival
+    | some .nominalized | some .participle => .gerund
+    | none => .smallClause
 
-/-- The enum view round-trips over the smart-constructor cells. -/
+/-- The flat enum cell a frame instantiates: the nominal shapes by their
+    positions, a single clausal position by its axes, and `none` on the
+    shapes the enum has no cell for. -/
+def Frame.complementType? : Frame → Option ComplementType
+  | [] => some .none
+  | [.nominal] => some .np
+  | [.nominal, .nominal] => some .np_np
+  | [.nominal, .adpositional] => some .np_pp
+  | [.clausal c f _] => some (clausalCell c f)
+  | _ => none
+
+/-- `ComplementType.toFrame` is a section of the classification. -/
 @[simp]
-theorem toComplementType_toFrame (ct : ComplementType) :
-    ct.toFrame.toComplementType = some ct := by cases ct <;> rfl
+theorem Frame.complementType?_toFrame (ct : ComplementType) :
+    ct.toFrame.complementType? = some ct := by cases ct <;> rfl
 
 theorem ComplementType.toFrame_injective :
-    Function.Injective ComplementType.toFrame := by
-  intro a b h
-  have ha := toComplementType_toFrame a
-  rw [h, toComplementType_toFrame b] at ha
-  exact (Option.some.inj ha).symm
+    Function.Injective ComplementType.toFrame := fun a b h =>
+  Option.some_injective _
+    (by rw [← Frame.complementType?_toFrame, h, Frame.complementType?_toFrame])
+
+/-- A cell's frame has a clausal position exactly when the cell is clausal. -/
+@[simp]
+theorem Frame.hasClausal_toFrame (ct : ComplementType) :
+    ct.toFrame.HasClausal ↔ ct.isClausal = true := by cases ct <;> decide
+
+/-- A cell's frame has a nominal position exactly when the cell is nominal. -/
+@[simp]
+theorem Frame.hasNominal_toFrame (ct : ComplementType) :
+    ct.toFrame.HasNominal ↔ ct.isNominal = true := by cases ct <;> decide
 
 /-- The [noonan-2007] coding of a complement frame: `none` for
 non-clausal frames, for small clauses (outside the coding inventory),

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -313,16 +313,15 @@ Flat readers over `Verb.frames`/`Verb.readings`, preserving the flat
 enum-based call syntax: the citation frame's complement/control type and
 the alternate frame's, when present. -/
 
-/-- The citation (first) frame's flat `ComplementType` cell. -/
+/-- The citation (first) frame's flat `ComplementType` cell; `.none` for an
+    intransitive and for a frame shape the enum has no cell for. -/
 def Verb.complementType (v : Verb) : ComplementType :=
-  (v.frames.head?.bind Frame.toComplementType).getD .none
+  (v.frames.head?.bind Frame.complementType?).getD .none
 
-/-- The alternate (second) frame's flat `ComplementType` cell. A second
-    frame richer than any enum cell reads as `none` — Buryat *hanaxa*'s
-    genitive-subject nominalized frame has `altComplementType = none`
-    despite a recorded second frame. -/
+/-- The alternate (second) frame's flat `ComplementType` cell, `none` when
+    there is no second frame or it has a shape outside the enum. -/
 def Verb.altComplementType (v : Verb) : Option ComplementType :=
-  v.frames[1]?.bind Frame.toComplementType
+  v.frames[1]?.bind Frame.complementType?
 
 /-- The control type of the reading keyed to the citation frame. -/
 def Verb.controlType (v : Verb) : ControlType :=
@@ -360,3 +359,16 @@ instance (v : Verb) (f : Mood.Illocutionary) :
     rogatives: know, wonder, ask). Derived from `frames`. -/
 def Verb.takesQuestionBase (v : Verb) : Bool :=
   decide (v.takesForce .interrogative)
+
+/-- Some frame of the verb has a clausal position: the verb selects a CP or
+    reduced clause ([schwarzer-2026]'s CP-selecting verbs). -/
+def Verb.TakesClausal (v : Verb) : Prop := ∃ fr ∈ v.frames, fr.HasClausal
+
+instance (v : Verb) : Decidable v.TakesClausal :=
+  inferInstanceAs (Decidable (∃ fr ∈ v.frames, _))
+
+/-- Some frame of the verb has a nominal position: the verb selects a DP. -/
+def Verb.TakesNominal (v : Verb) : Prop := ∃ fr ∈ v.frames, fr.HasNominal
+
+instance (v : Verb) : Decidable v.TakesNominal :=
+  inferInstanceAs (Decidable (∃ fr ∈ v.frames, _))


### PR DESCRIPTION
The flat `ComplementType` view recognized a frame only by exact equality with one of nine cell frames, so any frame carrying an extra axis (Gã's overt-subject infinitival, Buryat's genitive-subject nominalization, an indicative interrogative) read as `.none`, and `canTakeClausalComplement` returned `false` for verbs that plainly embed clauses.

- `Frame.complementType?` classifies a frame by its shape and, for a clausal position, by its axes (interrogative force, then coding); `ComplementType.toFrame` is its section and injectivity follows
- `Complement.Position.IsClausal`/`IsNominal`, `Frame.HasClausal`/`HasNominal`, `Verb.TakesClausal`/`TakesNominal` are decidable `Prop`s read directly off positions; the Bool `canTake*` accessors are gone
- Schwarzer2026's two `native_decide` list checks become `∀ v ∈ …` by `decide`