### PR TITLE
refactor(Studies/PrasertsonSmithCulbertson2026): entropies from tables

### DIFF
--- a/Linglib/Core/InformationTheory/Entropy.lean
+++ b/Linglib/Core/InformationTheory/Entropy.lean
@@ -39,6 +39,8 @@ conditioning reduces entropy.
 * `measureMutualInfo_eq_toReal_klDiv`, `measureMutualInfo_nonneg`,
   `measureMutualInfo_parallelComp_id_comp_le` (data processing).
 * `chain_rule`, `mutualInfo_eq_entropy_sub_condEntropy`, `condEntropy_le_entropy`.
+* `condEntropy_uniformOn_univ`: on a finite population under the uniform measure, conditional
+  entropy is a formula in counts.
 
 ## References
 
@@ -330,5 +332,42 @@ theorem condEntropy_le_entropy : H[X | Y ; μ] ≤ H[X ; μ] :=
   sub_nonneg.mp (mutualInfo_eq_entropy_sub_condEntropy hX hY μ ▸ mutualInfo_nonneg hX hY μ)
 
 end entropy
+
+/-! ### Empirical entropies of a finite population
+
+Under the uniform measure on a finite type, entropies are counts. -/
+
+section Empirical
+
+variable {Ω : Type*} [MeasurableSpace Ω] [MeasurableSingletonClass Ω]
+
+/-- Conditioning the uniform measure on a finite type by a set restricts it to the set. -/
+theorem uniformOn_univ_cond [Finite Ω] (A : Set Ω) :
+    (uniformOn (Set.univ : Set Ω))[|A] = uniformOn A := by
+  rw [uniformOn, uniformOn, cond_cond_eq_cond_inter' .univ (Set.toFinite A).measurableSet
+    (Measure.count_apply_lt_top.2 Set.finite_univ).ne, Set.univ_inter]
+
+/-- The conditional entropy of one attribute of a finite population given another, under the
+uniform measure: each fibre of `Y` weighted by its share of the population, with the entropy of
+the distribution of `X` on the fibre, all as counts. -/
+theorem condEntropy_uniformOn_univ [Fintype Ω] {S T : Type*} [MeasurableSpace S]
+    [MeasurableSingletonClass S] [Fintype S] [DecidableEq S] [MeasurableSpace T]
+    [MeasurableSingletonClass T] [Fintype T] [DecidableEq T] (X : Ω → S) (Y : Ω → T) :
+    H[X | Y ; uniformOn (Set.univ : Set Ω)]
+      = ∑ y, ((Finset.univ.filter (Y · = y)).card / Fintype.card Ω : ℝ)
+          * ∑ x, negMulLog (((Finset.univ.filter λ ω => Y ω = y ∧ X ω = x).card
+              / (Finset.univ.filter (Y · = y)).card : ℝ)) := by
+  have hY : ∀ y, (Y ⁻¹' {y}).ncard = (Finset.univ.filter (Y · = y)).card := λ y => by
+    rw [← Set.ncard_coe_finset]; congr; ext; simp
+  have hXY : ∀ y x, (Y ⁻¹' {y} ∩ X ⁻¹' {x}).ncard
+      = (Finset.univ.filter λ ω => Y ω = y ∧ X ω = x).card := λ y x => by
+    rw [← Set.ncard_coe_finset]; congr; ext; simp
+  rw [condEntropy_eq_sum X (measurable_of_finite Y)]
+  refine Finset.sum_congr rfl λ y _ => ?_
+  rw [uniformOn_univ_cond, entropy_eq_sum (measurable_of_finite X), uniformOn_real_apply,
+    Set.univ_inter, Set.ncard_univ, Nat.card_eq_fintype_card]
+  simp_rw [uniformOn_real_apply, hY, hXY]
+
+end Empirical
 
 end InformationTheory

--- a/Linglib/Studies/PrasertsonSmithCulbertson2026.lean
+++ b/Linglib/Studies/PrasertsonSmithCulbertson2026.lean
@@ -1,376 +1,259 @@
-import Linglib.Syntax.Category.Classifier.Basic
-import Linglib.Features.Prominence
+import Linglib.Core.InformationTheory.Entropy
 import Linglib.Studies.Aikhenvald2000
 
 /-!
-# Prasertsom, Smith & Culbertson (2026)
-[prasertsom-smith-culbertson-2026]
+# Prasertsom, Smith and Culbertson (2026): Domain-General Categorisation Explains Constrained Cross-Linguistic Variation in Noun Classification
 
-Domain-general categorisation explains constrained cross-linguistic
-variation in noun classification. Cognition 271, 106411.
+This file formalizes the two formal claims of [prasertsom-smith-culbertson-2026]. The paper asks
+why animacy, but never colour, serves as a basis for noun classification although both are
+perceptually salient, and answers with a domain-general principle: a good category is one whose
+defining feature predicts the other features of its members, and animacy predicts more than
+colour. The typological premise is read off [aikhenvald-2000]'s sample of noun categorization
+devices, where animacy is a basic semantic parameter and colour is none of any device's
+(`animacy_not_colour`). The predictive-power manipulation of Experiments 3a and 3b rests on two
+sixteen-stimulus sets, Tables 4 and 5 (`predictiveAnimacy`, `predictiveColour`), built so that
+the conditional entropy of horn type, body shape, and appendage shape is lower given the
+predictive dimension than given the other, and so that exchanging the animacy and colour columns
+of one set gives the other (`mirror_images`). The six entropy orderings of Table 6 that the
+design promises are proved from the tables under the uniform measure over the stimuli
+(`predictiveAnimacy_horn`, `predictiveColour_horn`, and their shape and appendage siblings).
 
-## Key Claims
+## Implementation notes
 
-[prasertsom-smith-culbertson-2026] ask why animacy — but not colour —
-appears in noun classification systems, despite colour being perceptually
-salient. They argue the answer lies in a domain-general categorisation
-principle: features with higher **predictive power** (the ability to predict
-other features of category members) yield more compact, more distinct
-categories, which are easier to learn. Animacy is more predictive than
-colour, explaining its cross-linguistic prevalence via cultural transmission
-amplification ([griffiths-kalish-2007], [kirby-et-al-2007],
-[smith-2011]).
+Each stimulus set has exactly one stimulus per animacy–colour pair, so a set is a function from
+the pair to the three remaining dimensions and its stimuli are the sixteen cells of the grid.
+Conditional entropy is the substrate's `H[X | Y ; μ]` under the uniform measure on the grid,
+reduced to counts by `condEntropy_uniformOn_univ`; each ordering then comes to a positive multiple
+of `negMulLog (1/2)`, the entropy of the evenly split fibres that only the non-predictive
+dimension has. The learning and sorting results of Experiments 1a to 3b and the corpus measures
+of §4.1, which are means over participants and word embeddings, are not formalized.
 
-## Argument Chain
+## TODO
 
-1. **Typological observation** (§1): Animacy is universal in noun
-   categorization ([aikhenvald-2000]); colour is absent from every
-   attested system — despite high perceptual salience.
-2. **Learning bias** (Exp 1a–b): Participants learn animacy-based artificial
-   noun classes better than colour-based ones.
-3. **Domain generality** (Exp 2a–c): Non-linguistic sorting also shows
-   animacy preference, ruling out grammar-specific mechanisms.
-4. **Mechanism** (§4.1, Table 6): Predictive power — animacy predicts other
-   features (shape, horn, appendages) better than colour does, yielding
-   more compact categories (Table 2) and higher classifier accuracy (Table 3).
-5. **Causal evidence** (Exp 3a–b): Manipulating predictive power modulates
-   sorting preferences, though the effect on noun class learning is indirect
-   — participants who notice colour's predictive structure and sort by
-   colour learn animacy-based noun classes *worse*.
+The paper's reason for the mirror design, that animacy in one set has exactly the predictive
+power of colour in the other, is the invariance of conditional entropy under a relabelling of
+the population and of the conditioning variable; the substrate has no such lemma yet, so the
+predictive-colour orderings are computed directly rather than transferred from the
+predictive-animacy ones through `mirror_images`.
 
-## Formalization
+## References
 
-The typological observation (§1) connects to existing `Classifier`
-infrastructure. Predictive power is formalized via Table 6's conditional
-entropy data from the experimental stimuli. The connection to
-`Features.Prominence.AnimacyLevel` — the Silverstein hierarchy —
-makes explicit that animacy's grammatical privilege spans both case marking
-and noun classification.
-
+* [prasertsom-smith-culbertson-2026]
+* [aikhenvald-2000]
 -/
+
+open InformationTheory MeasureTheory ProbabilityTheory Real
+open scoped ProbabilityTheory
 
 namespace PrasertsonSmithCulbertson2026
 
-open Classifier
+/-! ### The typological premise (§1) -/
 
--- ============================================================================
--- §1: The Animacy–Colour Asymmetry (derived from typological data)
--- ============================================================================
+/-- Every noun class or numeral classifier device of the sample has animacy, humanness, or sex
+among its basic semantic parameters, and none has colour. -/
+theorem animacy_not_colour :
+    ∀ d ∈ Aikhenvald2000.allDevices,
+      d.kind = some .nounClass ∨ d.kind = some .numeralClassifier →
+        (∃ p ∈ d.semantics, p = .animacy ∨ p = .humanness ∨ p = .sex) ∧ .colour ∉ d.semantics :=
+  λ d hd hk => ⟨Aikhenvald2000.animacy_basic d hd hk, Aikhenvald2000.colour_never d hd⟩
 
-/-- Whether a semantic parameter is attested in any system in our typology.
-    Derived from `allDevices` data rather than stipulated. -/
-def isAttestedInTypology (p : Parameter) : Bool :=
-  Aikhenvald2000.allDevices.any (λ sys =>
-    sys.semantics.any (· == p))
+/-! ### The stimulus dimensions (§4.2.2, Fig. 10) -/
 
-/-- Animacy is attested in the typological data. -/
-theorem animacy_attested : isAttestedInTypology .animacy = true := by decide
+/-- The animacy dimension: two kinds of animate, with crescent or round eyes, and two of
+inanimate, dots forming a line or a triangle. -/
+inductive Animacy where
+  | crescentEyed
+  | roundEyed
+  | line
+  | triangle
+  deriving DecidableEq, Repr, Fintype
 
-/-- Humanness is attested in the typological data. -/
-theorem humanness_attested : isAttestedInTypology .humanness = true := by decide
+/-- The colour dimension: two warm and two cool colours. -/
+inductive Colour where
+  | red
+  | orange
+  | blue
+  | teal
+  deriving DecidableEq, Repr, Fintype
 
-/-- Shape is attested in the typological data. -/
-theorem shape_attested : isAttestedInTypology .shape = true := by decide
+/-- Horn type. -/
+inductive Horn where
+  | crescent
+  | jagged
+  deriving DecidableEq, Repr, Fintype
 
-/-- Colour is NOT attested in any system in our typology. -/
-theorem colour_not_attested : isAttestedInTypology .colour = false := by decide
+/-- Body shape. -/
+inductive Shape where
+  | circle
+  | inkblot
+  deriving DecidableEq, Repr, Fintype
 
-/-- The central asymmetry: animacy is attested, colour is not. -/
-theorem animacy_colour_asymmetry :
-    isAttestedInTypology .animacy = true ∧
-    isAttestedInTypology .colour = false := ⟨by decide, by decide⟩
+/-- Appendage shape. -/
+inductive Appendages where
+  | wavy
+  | round
+  deriving DecidableEq, Repr, Fintype
 
--- ============================================================================
--- §2: Predictive Power — Conditional Entropy (Table 6)
--- ============================================================================
+instance : MeasurableSpace Animacy := ⊤
+instance : MeasurableSpace Colour := ⊤
+instance : MeasurableSpace Horn := ⊤
+instance : MeasurableSpace Shape := ⊤
+instance : MeasurableSpace Appendages := ⊤
 
-/-- Features in the experimental stimuli (Fig. 10, Tables 4–5). -/
-inductive StimulusFeature where
-  | animacy | colour | horn | shape_ | appendages
+section sums
+
+variable {M : Type*} [AddCommMonoid M]
+
+theorem Animacy.sum_univ (f : Animacy → M) :
+    ∑ v, f v = f .crescentEyed + f .roundEyed + f .line + f .triangle := by
+  rw [show (Finset.univ : Finset Animacy) = {.crescentEyed, .roundEyed, .line, .triangle} by decide]
+  simp [Finset.sum_insert, add_assoc]
+
+theorem Colour.sum_univ (f : Colour → M) : ∑ v, f v = f .red + f .orange + f .blue + f .teal := by
+  rw [show (Finset.univ : Finset Colour) = {.red, .orange, .blue, .teal} by decide]
+  simp [Finset.sum_insert, add_assoc]
+
+theorem Horn.sum_univ (f : Horn → M) : ∑ v, f v = f .crescent + f .jagged := by
+  rw [show (Finset.univ : Finset Horn) = {.crescent, .jagged} by decide]
+  simp [Finset.sum_insert]
+
+theorem Shape.sum_univ (f : Shape → M) : ∑ v, f v = f .circle + f .inkblot := by
+  rw [show (Finset.univ : Finset Shape) = {.circle, .inkblot} by decide]
+  simp [Finset.sum_insert]
+
+theorem Appendages.sum_univ (f : Appendages → M) : ∑ v, f v = f .wavy + f .round := by
+  rw [show (Finset.univ : Finset Appendages) = {.wavy, .round} by decide]
+  simp [Finset.sum_insert]
+
+end sums
+
+/-- The three dimensions of a stimulus that its animacy and colour may predict. -/
+structure Body where
+  horn : Horn
+  shape : Shape
+  appendages : Appendages
   deriving DecidableEq, Repr
 
-/-- Conditional entropy H(row|col) from Table 6.
-    Lower values mean the column feature is more predictive of the row feature.
-    Values are in bits; the maximum for a binary feature is 1.0,
-    for a 4-valued feature is 2.0. -/
-structure ConditionalEntropy where
-  row : StimulusFeature
-  col : StimulusFeature
-  /-- H(row|col) in bits, scaled ×1000 for exact rational arithmetic -/
-  hBits_x1000 : Nat
-  deriving Repr
+/-! ### The stimulus sets (Tables 4 and 5) -/
 
-/-- Table 6 data, predictive-animacy stimulus set.
-    In this set, animacy is the predictive feature: knowing animacy reduces
-    uncertainty about horn/shape/appendages more than knowing colour does.
-    H(Horn|Animacy) = 0.406 < H(Horn|Colour) = 0.906. -/
-def table6_horn_given_animacy : ConditionalEntropy :=
-  ⟨.horn, .animacy, 406⟩   -- H(horn|animacy) = 0.406
-def table6_horn_given_colour : ConditionalEntropy :=
-  ⟨.horn, .colour, 906⟩    -- H(horn|colour) = 0.906
-def table6_shape_given_animacy : ConditionalEntropy :=
-  ⟨.shape_, .animacy, 406⟩  -- H(shape|animacy) = 0.406
-def table6_shape_given_colour : ConditionalEntropy :=
-  ⟨.shape_, .colour, 906⟩   -- H(shape|colour) = 0.906
-def table6_appendages_given_animacy : ConditionalEntropy :=
-  ⟨.appendages, .animacy, 406⟩ -- H(appendages|animacy) = 0.406
-def table6_appendages_given_colour : ConditionalEntropy :=
-  ⟨.appendages, .colour, 906⟩  -- H(appendages|colour) = 0.906
+/-- The predictive-animacy set (Table 4): the body of the stimulus in each animacy–colour cell.
+The eight animates are alike; among the inanimates each body dimension departs once per kind
+of inanimate from its inanimate value. -/
+def predictiveAnimacy : Animacy × Colour → Body
+  | (.crescentEyed, _) | (.roundEyed, _) => ⟨.crescent, .circle, .wavy⟩
+  | (.line, .red) => ⟨.crescent, .inkblot, .round⟩
+  | (.line, .orange) => ⟨.jagged, .circle, .round⟩
+  | (.line, .blue) => ⟨.jagged, .inkblot, .wavy⟩
+  | (.line, .teal) => ⟨.jagged, .inkblot, .round⟩
+  | (.triangle, .red) => ⟨.jagged, .inkblot, .wavy⟩
+  | (.triangle, .orange) => ⟨.jagged, .inkblot, .round⟩
+  | (.triangle, .blue) => ⟨.jagged, .circle, .round⟩
+  | (.triangle, .teal) => ⟨.crescent, .inkblot, .round⟩
 
-/-- Table 6: animacy is more predictive of horn than colour is.
-    H(horn|animacy) = 0.406 < H(horn|colour) = 0.906. -/
-theorem animacy_predicts_horn_better :
-    table6_horn_given_animacy.hBits_x1000 <
-    table6_horn_given_colour.hBits_x1000 := by decide
+/-- The predictive-colour set (Table 5). -/
+def predictiveColour : Animacy × Colour → Body
+  | (_, .red) | (_, .orange) => ⟨.crescent, .circle, .wavy⟩
+  | (.crescentEyed, .blue) => ⟨.crescent, .inkblot, .round⟩
+  | (.crescentEyed, .teal) => ⟨.jagged, .inkblot, .wavy⟩
+  | (.roundEyed, .blue) => ⟨.jagged, .circle, .round⟩
+  | (.roundEyed, .teal) => ⟨.jagged, .inkblot, .round⟩
+  | (.line, .blue) => ⟨.jagged, .inkblot, .wavy⟩
+  | (.line, .teal) => ⟨.jagged, .circle, .round⟩
+  | (.triangle, .blue) => ⟨.jagged, .inkblot, .round⟩
+  | (.triangle, .teal) => ⟨.crescent, .inkblot, .round⟩
 
-/-- Table 6: animacy is more predictive of shape than colour is. -/
-theorem animacy_predicts_shape_better :
-    table6_shape_given_animacy.hBits_x1000 <
-    table6_shape_given_colour.hBits_x1000 := by decide
+/-- The colour that stands in for a kind of animacy when the two columns are exchanged: the
+animates for the warm colours, the inanimates for the cool ones. -/
+def Animacy.toColour : Animacy → Colour
+  | .crescentEyed => .red
+  | .roundEyed => .orange
+  | .line => .blue
+  | .triangle => .teal
 
-/-- Table 6: animacy is more predictive of appendages than colour is. -/
-theorem animacy_predicts_appendages_better :
-    table6_appendages_given_animacy.hBits_x1000 <
-    table6_appendages_given_colour.hBits_x1000 := by decide
+/-- The kind of animacy that stands in for a colour. -/
+def Colour.toAnimacy : Colour → Animacy
+  | .red => .crescentEyed
+  | .orange => .roundEyed
+  | .blue => .line
+  | .teal => .triangle
 
-/-- Table 6, "Both stimulus sets" column (reverse direction):
-    Horn/shape/appendages predict animacy better than they predict colour.
-    H(Animacy|Horn) = 1.451 < H(Colour|Horn) = 1.951.
-    This is consistent: predictive power is symmetric — if animacy predicts
-    horn well, horn also predicts animacy well. -/
-def table6_animacy_given_horn : ConditionalEntropy :=
-  ⟨.animacy, .horn, 1451⟩   -- H(animacy|horn) = 1.451
-def table6_colour_given_horn : ConditionalEntropy :=
-  ⟨.colour, .horn, 1951⟩    -- H(colour|horn) = 1.951
+/-- The exchange of the animacy and colour columns. -/
+def mirror : Animacy × Colour → Animacy × Colour
+  | (a, c) => (c.toAnimacy, a.toColour)
 
-theorem horn_predicts_animacy_better_than_colour :
-    table6_animacy_given_horn.hBits_x1000 <
-    table6_colour_given_horn.hBits_x1000 := by decide
+/-- The two sets are mirror images of each other: each is the other with the animacy and colour
+columns exchanged. -/
+theorem mirror_images :
+    ∀ p, predictiveColour (mirror p) = predictiveAnimacy p
+      ∧ predictiveAnimacy (mirror p) = predictiveColour p := by
+  decide
 
--- ============================================================================
--- §3: Corpus Evidence — Category Compactness (Table 2)
--- ============================================================================
+/-! ### Predictive power (Table 6) -/
 
-/-- Semantic basis for categorization (both experimental and typological). -/
-inductive SemanticBasis where
-  | animacy | colour
-  deriving DecidableEq, Repr
+private theorem card_grid : Fintype.card (Animacy × Colour) = 16 := rfl
 
-/-- Intra-category similarity from Word2Vec embeddings of 472 frequent
-    physical nouns from CHILDES (§4.1.1). Higher InSim means category members
-    are more similar to each other in distributional semantic space. -/
-structure CategoryCompactness where
-  basis : SemanticBasis
-  category : String
-  /-- Mean cosine similarity × 1000 (for exact arithmetic) -/
-  inSim_x1000 : Nat
-  deriving Repr
+private theorem negMulLog_half_pos : 0 < negMulLog (1 / 2 : ℝ) := by
+  rw [negMulLog, show (1 / 2 : ℝ) = 2⁻¹ by norm_num, Real.log_inv]
+  nlinarith [Real.log_pos (by norm_num : (1 : ℝ) < 2)]
 
--- Table 2 data
-def compactness_animate   : CategoryCompactness := ⟨.animacy, "animate",   179⟩
-def compactness_inanimate : CategoryCompactness := ⟨.animacy, "inanimate", 137⟩
-def compactness_warm      : CategoryCompactness := ⟨.colour,  "warm",      151⟩
-def compactness_cool      : CategoryCompactness := ⟨.colour,  "cool",      126⟩
+/-- In the predictive-animacy set, animacy predicts horn type better than colour does. -/
+theorem predictiveAnimacy_horn :
+    H[Body.horn ∘ predictiveAnimacy | Prod.fst ; uniformOn Set.univ]
+      < H[Body.horn ∘ predictiveAnimacy | Prod.snd ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Horn.sum_univ, Function.comp_apply, predictiveAnimacy]
+  norm_num
+  linarith [negMulLog_half_pos]
 
-/-- InSim(Avg) × 1000: weighted average across categories.
-    Animacy: 0.149, Colour: 0.147. -/
-def inSimAvg_animacy_x1000 : Nat := 149
-def inSimAvg_colour_x1000  : Nat := 147
+/-- In the predictive-animacy set, animacy predicts body shape better than colour does. -/
+theorem predictiveAnimacy_shape :
+    H[Body.shape ∘ predictiveAnimacy | Prod.fst ; uniformOn Set.univ]
+      < H[Body.shape ∘ predictiveAnimacy | Prod.snd ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Shape.sum_univ, Function.comp_apply, predictiveAnimacy]
+  norm_num
+  linarith [negMulLog_half_pos]
 
-/-- Animacy-based categories are more compact on average (Table 2).
-    InSim(Avg) animacy (0.149) > InSim(Avg) colour (0.147). -/
-theorem animacy_categories_more_compact :
-    inSimAvg_animacy_x1000 > inSimAvg_colour_x1000 := by decide
+/-- In the predictive-animacy set, animacy predicts appendage shape better than colour does. -/
+theorem predictiveAnimacy_appendages :
+    H[Body.appendages ∘ predictiveAnimacy | Prod.fst ; uniformOn Set.univ]
+      < H[Body.appendages ∘ predictiveAnimacy | Prod.snd ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Appendages.sum_univ, Function.comp_apply, predictiveAnimacy]
+  norm_num
+  linarith [negMulLog_half_pos]
 
-/-- The animate category is the most compact single category. -/
-theorem animate_most_compact :
-    compactness_animate.inSim_x1000 > compactness_inanimate.inSim_x1000 ∧
-    compactness_animate.inSim_x1000 > compactness_warm.inSim_x1000 ∧
-    compactness_animate.inSim_x1000 > compactness_cool.inSim_x1000 := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+/-- In the predictive-colour set, colour predicts horn type better than animacy does. -/
+theorem predictiveColour_horn :
+    H[Body.horn ∘ predictiveColour | Prod.snd ; uniformOn Set.univ]
+      < H[Body.horn ∘ predictiveColour | Prod.fst ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Horn.sum_univ, Function.comp_apply, predictiveColour]
+  norm_num
+  linarith [negMulLog_half_pos]
 
--- ============================================================================
--- §4: Corpus Evidence — Classifier Learnability (Table 3)
--- ============================================================================
+/-- In the predictive-colour set, colour predicts body shape better than animacy does. -/
+theorem predictiveColour_shape :
+    H[Body.shape ∘ predictiveColour | Prod.snd ; uniformOn Set.univ]
+      < H[Body.shape ∘ predictiveColour | Prod.fst ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Shape.sum_univ, Function.comp_apply, predictiveColour]
+  norm_num
+  linarith [negMulLog_half_pos]
 
-/-- 5-fold cross-validated logistic classifier accuracy from normalised
-    Word2Vec embeddings (§4.1.2, Table 3). -/
-structure ClassifierAccuracy where
-  basis : SemanticBasis
-  /-- Mean accuracy × 1000 -/
-  accuracy_x1000 : Nat
-  deriving Repr
-
-def logistic_animacy : ClassifierAccuracy := ⟨.animacy, 858⟩  -- 0.858
-def logistic_colour  : ClassifierAccuracy := ⟨.colour,  742⟩  -- 0.742
-
-/-- Animacy categories are easier for a classifier to learn (Table 3). -/
-theorem animacy_classifier_more_accurate :
-    logistic_animacy.accuracy_x1000 > logistic_colour.accuracy_x1000 := by decide
-
--- ============================================================================
--- §5: Experimental Data — Noun Class Learning (Experiments 1a–b)
--- ============================================================================
-
-/-- Result of a noun class learning experiment. -/
-structure LearningResult where
-  basis : SemanticBasis
-  /-- Mean proportion correct × 1000 -/
-  accuracy_x1000 : Nat
-  deriving Repr
-
-/-- Experiment 1a: Ease of learning (§2.1).
-    Animacy condition: 0.915 mean accuracy.
-    Colour condition: 0.841 mean accuracy.
-    β_SemanticBasis = 1.859, p = 0.023. -/
-def exp1a_animacy : LearningResult := ⟨.animacy, 915⟩
-def exp1a_colour  : LearningResult := ⟨.colour,  841⟩
-
-theorem exp1a_animacy_learned_better :
-    exp1a_animacy.accuracy_x1000 > exp1a_colour.accuracy_x1000 := by decide
-
-/-- Experiment 1b: Extrapolation from ambiguous data (§2.2).
-    When animacy and colour are confounded in training, 77.5% of participants
-    (62/80) generalise to animacy-based classification at test. -/
-def exp1b_animacy_generalizers : Nat := 62
-def exp1b_total_participants   : Nat := 80
-
-theorem exp1b_above_chance :
-    exp1b_animacy_generalizers * 2 > exp1b_total_participants := by decide
-
--- ============================================================================
--- §6: Experimental Data — Non-Linguistic Sorting (Experiments 2a–c)
--- ============================================================================
-
-/-- Result of an image sorting experiment (§3). Participants sort 16 images
-    into two groups; sorting strategy is inferred from AMI with reference sorts.
-    Proportions are expressed as parts per thousand. -/
-structure SortingResult where
-  /-- Proportion ×1000 who sorted by animacy -/
-  animacy_x1000 : Nat
-  /-- Proportion ×1000 who sorted by colour -/
-  colour_x1000 : Nat
-  /-- Proportion ×1000 who sorted by another strategy -/
-  other_x1000 : Nat
-  deriving Repr
-
-/-- Exp 2a: original stimuli (same as Exp 1). -/
-def exp2a : SortingResult := ⟨875, 25, 100⟩
-/-- Exp 2b: increased within-category colour similarity. -/
-def exp2b : SortingResult := ⟨683, 150, 167⟩
-/-- Exp 2c: further decreased within-category animacy similarity. -/
-def exp2c : SortingResult := ⟨617, 183, 200⟩
-
-theorem exp2a_animacy_preferred : exp2a.animacy_x1000 > exp2a.colour_x1000 := by decide
-theorem exp2b_animacy_preferred : exp2b.animacy_x1000 > exp2b.colour_x1000 := by decide
-theorem exp2c_animacy_preferred : exp2c.animacy_x1000 > exp2c.colour_x1000 := by decide
-
-/-- The animacy bias persists even when visual similarity is manipulated
-    to favour colour-based sorting (Exp 2b, 2c). -/
-theorem sorting_bias_robust :
-    exp2a.animacy_x1000 > exp2a.colour_x1000 ∧
-    exp2b.animacy_x1000 > exp2b.colour_x1000 ∧
-    exp2c.animacy_x1000 > exp2c.colour_x1000 :=
-  ⟨by decide, by decide, by decide⟩
-
-/-- The bias weakens as colour similarity increases — evidence that
-    it is not absolute but can be modulated. -/
-theorem bias_weakens_with_manipulation :
-    exp2a.animacy_x1000 > exp2b.animacy_x1000 ∧
-    exp2b.animacy_x1000 > exp2c.animacy_x1000 := by
-  constructor <;> decide
-
--- ============================================================================
--- §7: Predictive Power Manipulation (Experiments 3a–b)
--- ============================================================================
-
-/-- Experiment 3a results (§4.2): predictive power manipulation had a
-    main effect of semantic basis (β = 1.251, p = 0.003) but the
-    interaction with predictive feature was NOT significant
-    (β = 0.276, p = 0.519). The prediction was "not straightforwardly
-    confirmed."
-
-    However, the sorting strategy × semantic basis interaction WAS
-    significant (β = 1.058, p < 0.001): participants who sorted by
-    animacy learned animacy-based noun classes better. -/
-structure Exp3Result where
-  /-- Accuracy ×1000 for animacy-basis condition -/
-  animacyBasis_x1000 : Nat
-  /-- Accuracy ×1000 for colour-basis condition -/
-  colourBasis_x1000 : Nat
-  deriving Repr
-
-/-- Exp 3b (§4.3): among participants who sorted by colour (successful
-    manipulation), there was NO significant difference between animacy-based
-    and colour-based noun class learning (0.800 vs 0.803).
-    β = −0.510, p = 0.314. -/
-def exp3b_animacyBasis_x1000 : Nat := 800
-def exp3b_colourBasis_x1000  : Nat := 803
-
-/-- Exp 3b: when the animacy bias is neutralised by selecting colour-sorters,
-    the learning advantage for animacy disappears. This is consistent with
-    the domain-general account — the bias is in categorisation, not in grammar. -/
-theorem exp3b_no_animacy_advantage :
-    exp3b_colourBasis_x1000 ≥ exp3b_animacyBasis_x1000 := by decide
-
--- ============================================================================
--- §8: Connection to Silverstein Hierarchy (Features.Prominence)
--- ============================================================================
-
-/-- The animacy hierarchy that governs noun classification
-    ([aikhenvald-2000], [silverstein-1976]) is the same hierarchy
-    that governs differential argument marking (`Features.Prominence`).
-
-    [prasertsom-smith-culbertson-2026] provide a domain-general
-    explanation for WHY animacy is grammatically privileged in both domains:
-    animacy is highly predictive of other referent features, making it a
-    good basis for categorization in general.
-
-    This theorem connects the prominence hierarchy to the noun categorization
-    typology: the levels of `AnimacyLevel` correspond to the
-    `Classifier.Parameter.animacy` / `.humanness` distinction. -/
-theorem prominence_encodes_categorization_parameters :
-    -- The prominence hierarchy distinguishes human vs animate vs inanimate
-    Features.Prominence.AnimacyLevel.human.rank >
-    Features.Prominence.AnimacyLevel.animate.rank ∧
-    Features.Prominence.AnimacyLevel.animate.rank >
-    Features.Prominence.AnimacyLevel.inanimate.rank ∧
-    -- These correspond to the top two semantic parameters in noun categorization
-    isAttestedInTypology .animacy = true ∧
-    isAttestedInTypology .humanness = true := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
-
--- ============================================================================
--- §9: The Full Argument Chain
--- ============================================================================
-
-/-- The paper's core argument, assembled from the evidence above:
-
-    1. Colour is absent from all attested noun categorization systems
-    2. Animacy is present in all attested systems
-    3. Animacy is more predictive of other features than colour (Table 6)
-    4. Animacy-based categories are more compact in distributional space (Table 2)
-    5. Animacy-based categories are easier for classifiers to learn (Table 3)
-    6. Humans learn animacy-based noun classes better (Exp 1a)
-    7. Humans prefer animacy-based sorting even non-linguistically (Exp 2a–c)
-
-    The connection is: predictive power → compactness → learnability →
-    typological prevalence (via cultural transmission). -/
-theorem argument_chain :
-    -- Typological observation
-    isAttestedInTypology .colour = false ∧
-    isAttestedInTypology .animacy = true ∧
-    -- Predictive power (Table 6: animacy predicts other features better)
-    table6_horn_given_animacy.hBits_x1000 <
-      table6_horn_given_colour.hBits_x1000 ∧
-    -- Category compactness (Table 2)
-    inSimAvg_animacy_x1000 > inSimAvg_colour_x1000 ∧
-    -- Classifier learnability (Table 3)
-    logistic_animacy.accuracy_x1000 > logistic_colour.accuracy_x1000 ∧
-    -- Human learning (Exp 1a)
-    exp1a_animacy.accuracy_x1000 > exp1a_colour.accuracy_x1000 ∧
-    -- Non-linguistic sorting (Exp 2a)
-    exp2a.animacy_x1000 > exp2a.colour_x1000 := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> native_decide
+/-- In the predictive-colour set, colour predicts appendage shape better than animacy does. -/
+theorem predictiveColour_appendages :
+    H[Body.appendages ∘ predictiveColour | Prod.snd ; uniformOn Set.univ]
+      < H[Body.appendages ∘ predictiveColour | Prod.fst ; uniformOn Set.univ] := by
+  rw [condEntropy_uniformOn_univ, condEntropy_uniformOn_univ, card_grid]
+  simp only [Finset.card_filter, Fintype.sum_prod_type, Animacy.sum_univ, Colour.sum_univ,
+    Appendages.sum_univ, Function.comp_apply, predictiveColour]
+  norm_num
+  linarith [negMulLog_half_pos]
 
 end PrasertsonSmithCulbertson2026

--- a/references.bib
+++ b/references.bib
@@ -222,7 +222,7 @@
   subfield  = {pragmatics/rsa},
   validated = {true},
   role      = {cited},
-  sources   = {Pragmatics/InformationTheory/ChannelCapacity.lean}
+  sources   = {Core/InformationTheory/Entropy.lean;Pragmatics/InformationTheory/ChannelCapacity.lean}
 }
 @article{macuch-silva-etal-2024,
   author    = {Macuch Silva, Vinicius and Lorson, Alexandra and Franke, Michael and Cummins, Chris and Winter, Bodo},
@@ -24787,7 +24787,7 @@
   subfield  = {typology/alignment},
   validated = {true},
   role      = {cited},
-  sources   = {Pragmatics/SocialMeaning/IndexicalField.lean;Studies/Comrie1989.lean;Studies/Dixon1994.lean;Studies/Ochs1992.lean;Studies/PrasertsonSmithCulbertson2026.lean}
+  sources   = {Pragmatics/SocialMeaning/IndexicalField.lean;Studies/Comrie1989.lean;Studies/Dixon1994.lean;Studies/Ochs1992.lean}
 }
 @article{silverstein-2003,
   author    = {Silverstein, Michael},


### PR DESCRIPTION
Rewrite the study around what the paper actually claims: the typological premise from Aikhenvald2000's theorems, Tables 4 and 5 as functions on the animacy–colour grid, and the six Table 6 orderings proved under the uniform measure.
- New substrate lemma `condEntropy_uniformOn_univ` reduces conditional entropy on a finite population to counts.
- `mirror_images` verifies the two stimulus sets are column exchanges of each other.
- The typed-in experiment means, the `native_decide` checks, and the Prominence bridge are cut.