### PR TITLE
refactor(Syntax/Category/Verb): selection as flat-order unification

### DIFF
--- a/Linglib/Core/Order/PartialUnify.lean
+++ b/Linglib/Core/Order/PartialUnify.lean
@@ -242,6 +242,11 @@ theorem Compat.mono [Preorder α] {a b c d : α} (h₁ : a ≤ b) (h₂ : c ≤ 
 theorem compat_self [Preorder α] (a : α) : Compat a a :=
   Compat.of_le le_rfl le_rfl
 
+/-- Compatibility on a Pi type is pointwise. -/
+theorem compat_pi_iff {F : Type*} {S : F → Type*} [∀ t, Preorder (S t)] {f g : ∀ t, S t} :
+    Compat f g ↔ ∀ t, Compat (f t) (g t) := by
+  simp only [Compat, bddAbove_pi, Set.image_pair]
+
 /-- `⊥` is a wildcard: compatible with everything. -/
 theorem bot_compat [Preorder α] [OrderBot α] (a : α) : Compat (⊥ : α) a :=
   Compat.of_le bot_le le_rfl

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -32,13 +32,20 @@ in `form`.
 * [allotey-2021]
 * [karttunen-1971]
 * [nadathur-lauer-2020]
+* [wurmbrand-lohninger-2023]
+* [wurmbrand-2024]
 -/
 
 namespace Ga
 
-/-- The reading of the controlled `ni`-frame under control relation `c`. -/
-def niReading (c : ControlType) : Verb.Reading :=
-  { frame := niFrame, control := some c }
+/-- The reading of the controlled `ni`-frame under control relation `c`, with
+    the complement's [wurmbrand-lohninger-2023] sort where [wurmbrand-2024]
+    classes the verb. -/
+def niReading (c : ControlType) (size : Option Clause.Size := none) : Verb.Reading :=
+  { frame := niFrame, control := some c, size }
+
+/-- The reading of a finite `akɛ`-frame: a proposition. -/
+def akeReading : Verb.Reading := { frame := Frame.finiteClause, size := some .proposition }
 
 /-! ### Subject control -/
 
@@ -48,7 +55,7 @@ def niReading (c : ControlType) : Verb.Reading :=
 def tao : Verb where
   form := "tao"
   frames := [niFrame]
-  readings := [niReading .subjectControl]
+  readings := [niReading .subjectControl (some .situation)]
 
 /-- *sumɔ* 'like' — subject control, with no complementizer under negation
     (ex 3a: *Dida sumɔ-ɔɔ e-na bo* 'Father is reluctant to see you') and with
@@ -82,7 +89,7 @@ def hiekpano : Verb where
 def miamihie : Verb where
   form := "mia-mi-hiɛ"
   frames := [niFrame]
-  readings := [niReading .subjectControl]
+  readings := [niReading .subjectControl (some .event)]
 
 /-- *kai* 'remember' — subject control in the `ni`-frame (exx 42–43: *Mi kai ni
     ma he wolo* 'I remembered to buy a book'), positive implicative. Alternates
@@ -118,7 +125,7 @@ def kpleno : Verb where
 def kpang : Verb where
   form := "kpaŋ"
   frames := [niFrame]
-  readings := [niReading .subjectControl]
+  readings := [niReading .subjectControl (some .situation)]
 
 /-- *kpã-gbɛ* 'expect' — subject control (ex 53: *Ajele kpã-gbɛ ni e-ye
     jweremɔ lɛ* 'Ajele expects to win the prize', infelicitous when Ajele does
@@ -126,7 +133,7 @@ def kpang : Verb where
 def kpagbe : Verb where
   form := "kpã-gbɛ"
   frames := [niFrame]
-  readings := [niReading .subjectControl]
+  readings := [niReading .subjectControl (some .situation)]
 
 /-- *dwɛŋ* 'think' — a finite complement with a low-tone, freely referring
     subject (exx 110–111: 'Aku thought s/he bought the book', under `akɛ` or a
@@ -135,7 +142,7 @@ def kpagbe : Verb where
 def dweng : Verb where
   form := "dwɛŋ"
   frames := [Frame.finiteClause, niFrame]
-  readings := [niReading .subjectControl]
+  readings := [akeReading, niReading .subjectControl]
   attitude := some (.doxastic .nonVeridical)
 
 /-! ### Object control -/
@@ -183,7 +190,7 @@ def bi : Verb where
 def kee : Verb where
   form := "kɛɛ"
   frames := [Frame.finiteClause, niFrame]
-  readings := [niReading .objectControl]
+  readings := [akeReading, niReading .objectControl]
   speechActVerb := true
 
 /-! ### Finite complements only -/

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -38,6 +38,8 @@ requirement derives the overt pronoun from the minimal-pronoun inventory.
 * [karttunen-1971]
 * [noonan-2007]
 * [rizzi-1997]
+* [wurmbrand-lohninger-2023]
+* [wurmbrand-2024]
 -/
 
 namespace Allotey2021
@@ -81,6 +83,14 @@ theorem frame_takes_iff (c d : EmbeddedClauseType) :
 /-- A verb takes `ni` exactly when some frame of it is controlled. -/
 theorem takes_ni_iff_control :
     ∀ v ∈ verbs, v.takes ni ↔ ∃ r ∈ v.readings, r.control.isSome := by
+  decide
+
+/-- [wurmbrand-lohninger-2023]'s hierarchy at Gã's granularity: a proposition
+    complement is exactly one whose frame takes a finite complementizer;
+    situations and events share the infinitival `ni`-frame. -/
+theorem proposition_iff_finite :
+    ∀ v ∈ verbs, ∀ r ∈ v.readings, ∀ s ∈ r.size,
+      (s = .proposition ↔ ∃ z ∈ complementizers, r.frame.Takes z ∧ z.IsFinite) := by
   decide
 
 /-! ### Table 2 -/

--- a/Linglib/Syntax/Category/Verb/Complement/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Complement/Basic.lean
@@ -1,6 +1,7 @@
 import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Semantics.Mood.Defs
+import Linglib.Core.Order.Flat
 
 /-! # Complement frames — typed complement positions
 
@@ -14,6 +15,9 @@ case carrying the axes the predicate selects for. The flat
 
 * `Complement.Position` — one complement position; a clausal position
   carries its selectional axes by construction
+* `Complement.Axis`, `Complement.Axes`, `Complement.Position.axes` — the
+  axes a position and a clause-typer share, as a bundle of partial values
+  in the flat order
 * `Complement.Position.IsClausal`, `IsNominal`, `Frame.HasClausal`,
   `Frame.HasNominal` — category of a position, and of some position of a
   frame
@@ -89,6 +93,31 @@ instance : DecidablePred IsNominal := fun p => by
   cases p <;> unfold IsNominal <;> infer_instance
 
 end Position
+
+/-- The selectional axes a clausal position and a clause-typer share:
+    [noonan-2007] coding and illocutionary force. -/
+inductive Axis where
+  | coding
+  | force
+  deriving DecidableEq, Fintype, Repr
+
+/-- The value type of an axis. -/
+def Axis.Val : Axis → Type
+  | coding => Coding
+  | force => Mood.Illocutionary
+
+instance : ∀ a : Axis, DecidableEq a.Val
+  | .coding => inferInstanceAs (DecidableEq Coding)
+  | .force => inferInstanceAs (DecidableEq Mood.Illocutionary)
+
+/-- A bundle of partial axis values, ordered pointwise by extension:
+    unification is `PartialUnify.unify`, consistency is `Compat`. -/
+abbrev Axes := ∀ a : Axis, Flat a.Val
+
+/-- The axes a position records; a non-clausal position records nothing. -/
+def Position.axes (p : Position) : Axes
+  | .coding => p.coding?
+  | .force => p.force?
 
 end Complement
 

--- a/Linglib/Syntax/Category/Verb/Complement/Takes.lean
+++ b/Linglib/Syntax/Category/Verb/Complement/Takes.lean
@@ -1,28 +1,31 @@
 import Linglib.Syntax.Category.Verb.Defs
 import Linglib.Syntax.Category.Complementizer.Basic
-import Linglib.Core.Data.Option.Compatible
 
 /-!
 # Verb–complementizer compatibility
 
 The hom between the `Verb` and `Complementizer` entry APIs: which
-clause-typers a predicate takes. One relation, lifted twice: a position
-takes a typer when their recorded axes — [noonan-2007]'s coding axis
-and the force axis — are `Option.Compatible` throughout and
-`Option.Agrees` somewhere; a frame or verb takes a typer when some
-position or frame does. All decidable. Non-clausal positions record no
-axes, so positive evidence already excludes them; the
-subject-requirement axis (`Complement.Position.embeddedSubject?`) is
-object-side and not matched: typers record no subject requirement.
+clause-typers a predicate takes. A clausal position and a clause-typer
+each record a bundle of partial axis values (`Complement.Axes`, the
+[noonan-2007] coding and the illocutionary force) in the flat order, and
+a position takes a typer when the two bundles unify (`Compat`) with some
+axis actually agreeing (a non-`⊥` meet). One relation, lifted twice: a
+frame or verb takes a typer when some position or frame does. All
+decidable. Non-clausal positions record no axes, so positive evidence
+already excludes them; the subject-requirement axis
+(`Complement.Position.embeddedSubject?`) is object-side and not matched:
+typers record no subject requirement.
 
 ## Main definitions
 
+- `Complementizer.axes` — the typer's bundle
 - `Complement.Position.Takes`, `Frame.Takes`, `Verb.takes` — the
   relation and its lifts
 - `Verb.typers` — the typers of a verb within an inventory
 
 ## Main results
 
+- `Complement.Position.takes_iff` — the relation axis by axis
 - `Complement.Position.not_takes_of_blank`,
   `Complement.Position.blank_not_takes` — matching needs positive
   evidence on both sides
@@ -34,31 +37,46 @@ Consistency checks against Fragment data live in Studies
 (e.g. `Bondarenko2022.hanaxa_typers`).
 -/
 
-/-- The position takes clause-typer `z`: every recorded axis
-    compatible, some axis agreeing. Matching needs positive evidence,
-    so a typer or position recording nothing — in particular any
-    non-clausal position — takes nothing. -/
-def Complement.Position.Takes (p : Complement.Position)
-    (z : Complementizer) : Prop :=
-  p.coding?.Compatible z.coding ∧ p.force?.Compatible z.force ∧
-    (p.coding?.Agrees z.coding ∨ p.force?.Agrees z.force)
+/-- The axes a clause-typer records. -/
+def Complementizer.axes (z : Complementizer) : Complement.Axes
+  | .coding => z.coding
+  | .force => z.force
 
-instance (p : Complement.Position) (z : Complementizer) :
-    Decidable (p.Takes z) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+namespace Complement.Position
+
+variable {p : Complement.Position} {z : Complementizer}
+
+/-- The position takes clause-typer `z`: the two bundles unify and some
+    axis agrees. Matching needs positive evidence, so a typer or position
+    recording nothing — in particular any non-clausal position — takes
+    nothing. -/
+def Takes (p : Complement.Position) (z : Complementizer) : Prop :=
+  Compat p.axes z.axes ∧ p.axes ⊓ z.axes ≠ ⊥
+
+/-- The relation axis by axis: every axis compatible, some axis agreeing. -/
+theorem takes_iff :
+    p.Takes z ↔
+      (∀ a, Compat (p.axes a) (z.axes a)) ∧ ∃ a, p.axes a ⊓ z.axes a ≠ ⊥ := by
+  rw [Takes, compat_pi_iff]
+  simp only [ne_eq, funext_iff, Pi.inf_apply, Pi.bot_apply, not_forall]
+
+instance : Decidable (p.Takes z) := decidable_of_iff _ takes_iff.symm
 
 /-- A typer recording neither axis takes nothing. -/
-theorem Complement.Position.not_takes_of_blank
-    {p : Complement.Position} {z : Complementizer}
-    (hc : z.coding = none) (hf : z.force = none) : ¬ p.Takes z := by
-  simp [Position.Takes, hc, hf]
+theorem not_takes_of_blank (hc : z.coding = none) (hf : z.force = none) : ¬ p.Takes z := by
+  rw [takes_iff]
+  rintro ⟨-, a, ha⟩
+  cases a <;> simp [Complementizer.axes, hc, hf, Flat.none_eq_bot] at ha
 
 /-- A position recording neither axis takes nothing: matching needs
     positive evidence. -/
-theorem Complement.Position.blank_not_takes {z : Complementizer}
-    {e : Option Clause.EmbeddedSubject} :
+theorem blank_not_takes {e : Option Clause.EmbeddedSubject} :
     ¬ (Complement.Position.clausal none none e).Takes z := by
-  simp [Position.Takes, Position.coding?, Position.force?]
+  rw [takes_iff]
+  rintro ⟨-, a, ha⟩
+  cases a <;> simp [axes, coding?, force?, Flat.none_eq_bot] at ha
+
+end Complement.Position
 
 /-- The frame takes `z`: some position does. -/
 def Frame.Takes (fr : Frame) (z : Complementizer) : Prop :=
@@ -87,10 +105,14 @@ theorem Frame.finiteClause_takes {z : Complementizer}
     (hc : z.coding = some .indicative)
     (hf : z.force = none ∨ z.force = some .declarative) :
     Frame.finiteClause.Takes z := by
-  refine ⟨_, List.mem_singleton_self _, ?_⟩
-  rcases hf with hf | hf <;>
-    simp [Complement.Position.Takes, Complement.Position.coding?,
-      Complement.Position.force?, hc, hf]
+  refine ⟨_, List.mem_singleton_self _,
+    Complement.Position.takes_iff.mpr ⟨λ a => ?_, .coding, ?_⟩⟩
+  · rcases hf with hf | hf <;> cases a <;>
+      simp only [Complement.Position.axes, Complementizer.axes, Complement.Position.coding?,
+        Complement.Position.force?, hc, hf, Flat.none_eq_bot] <;>
+      first | exact compat_self _ | exact compat_bot _
+  · simp [Complement.Position.axes, Complementizer.axes, Complement.Position.coding?, hc,
+      Flat.some_eq_coe]
 
 /-- The verb takes `z`: some frame does. -/
 def Verb.takes (v : Verb) (z : Complementizer) : Prop :=

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -251,6 +251,9 @@ structure Reading where
   opaqueContext : Option Bool := none
   /-- Control type for this frame. -/
   control : Option ControlType := none
+  /-- The semantic sort of the complement on this frame
+      ([wurmbrand-lohninger-2023]). -/
+  size : Option Clause.Size := none
   deriving DecidableEq, Repr
 
 /-- Attitudinal and intensional properties: attitude classification, opacity,

--- a/Linglib/Syntax/Clause/Basic.lean
+++ b/Linglib/Syntax/Clause/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Case.Basic
+import Mathlib.Order.Basic
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -13,6 +14,9 @@ complementation and particle APIs.
   frames record (`Syntax/Category/Verb/Complement/Basic.lean`)
 * `Clause.EmbeddingContext` — where a clause token occurs, the
   [bhatt-dayal-2020] embedding cells
+* `Clause.Size` — the semantic sort of a complement clause and the minimal
+  structure it needs, [wurmbrand-lohninger-2023]'s implicational
+  complementation hierarchy
 -/
 
 namespace Clause
@@ -40,5 +44,25 @@ inductive EmbeddingContext where
   | quasiSubordinated
   | quotation
   deriving DecidableEq, Repr, Fintype
+
+/-- The semantic sort of a complement clause, which fixes the minimal
+    structure it needs ([wurmbrand-lohninger-2023]'s implicational
+    complementation hierarchy, reviewed in [wurmbrand-2024]): an event needs
+    only the thematic domain, a situation adds the tense–mood–aspect domain,
+    a proposition adds the operator domain. Ordered by containment. -/
+inductive Size where
+  | event
+  | situation
+  | proposition
+  deriving DecidableEq, Repr, Fintype
+
+/-- Position on the containment order. -/
+def Size.rank : Size → Nat
+  | .event => 0
+  | .situation => 1
+  | .proposition => 2
+
+instance : LinearOrder Size :=
+  .lift' Size.rank λ a b => by cases a <;> cases b <;> simp [Size.rank]
 
 end Clause

--- a/references.bib
+++ b/references.bib
@@ -39416,6 +39416,18 @@
   role      = {cited},
   sources   = {Studies/LiuYip2026.lean}
 }
+@article{wurmbrand-2024,
+  author    = {Wurmbrand, Susanne},
+  year      = {2024},
+  title     = {The Size of Clausal Complements},
+  journal   = {Annual Review of Linguistics},
+  volume    = {10},
+  pages     = {59--83},
+  doi       = {10.1146/annurev-linguistics-031522-103802},
+  subfield  = {syntax/complementation},
+  role      = {cited},
+  sources   = {Syntax/Clause/Basic.lean;Fragments/Ga/Predicates.lean;Studies/Allotey2021.lean}
+}
 
 @unpublished{pesetsky-2021,
   author    = {Pesetsky, David},


### PR DESCRIPTION
`Complement.Position.Takes` matched coding and force with a bespoke `Option.Compatible`/`Agrees` pair; a position and a clause-typer are two partial feature bundles, so the relation is unification in the library's own flat order.

- `Complement.Axis`/`Axes`, `Position.axes`, `Complementizer.axes`: the shared axes as a Pi of `Flat` slots; `Takes` is `Compat` plus a non-`⊥` meet, with `takes_iff` (via a new `compat_pi_iff` in `Core/Order/PartialUnify`) giving the axis-by-axis form and the decidability instance
- `Clause.Size` (event < situation < proposition), Wurmbrand–Lohninger's implicational complementation hierarchy as reviewed in Wurmbrand 2024, recorded per frame on `Verb.Reading.size`; Gã readings classed where that review classes the verb, and `Allotey2021.proposition_iff_finite` shows propositions are exactly the frames taking a finite complementizer
- Adds `wurmbrand-2024` to the bibliography