### PR TITLE
refactor(Semantics/Reference): KContext becomes Reference.Context

### DIFF
--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -17,7 +17,7 @@ classes and direction of fit).
 namespace Discourse
 
 /-- The two fundamental discourse participants. `.addressee` matches
-    `KContext.addressee` (not `.listener` as in `DynamicSemantics`). -/
+    `Context.addressee` (not `.listener` as in `DynamicSemantics`). -/
 inductive Role where
   | speaker
   | addressee
@@ -25,9 +25,9 @@ inductive Role where
 
 namespace Role
 
-open Semantics.Context
+open Reference
 
-variable {W E P T : Type*} (tower : ContextTower (KContext W E P T))
+variable {W E P T : Type*} (tower : ContextTower (Context W E P T))
 
 /-- Resolve a discourse role to a concrete entity via a `ContextTower`,
     reading from the origin (speech-act context).
@@ -42,7 +42,7 @@ theorem resolve_addressee : resolve tower .addressee = tower.origin.addressee :=
 
 /-- Discourse role resolution is invariant under tower push: discourse
     roles reflect speech-act participants (from origin), not embedded ones. -/
-theorem resolve_push (σ : ContextShift (KContext W E P T)) (r : Role) :
+theorem resolve_push (σ : ContextShift (Context W E P T)) (r : Role) :
     resolve (tower.push σ) r = resolve tower r := by
   cases r <;> simp only [resolve, ContextTower.push_origin]
 

--- a/Linglib/Semantics/Aspect/Basic.lean
+++ b/Linglib/Semantics/Aspect/Basic.lean
@@ -206,7 +206,7 @@ theorem progressivePrediction_eq_accept_iff (c : VendlerClass) :
 abbrev IntervalPred (W T : Type*) [LinearOrder T] := W → NonemptyInterval T → Prop
 
 /-- A predicate over world-time points, the output of the perfect and the input to tense. -/
-abbrev PointPred (W T : Type*) := Semantics.Context.Index W T → Prop
+abbrev PointPred (W T : Type*) := Reference.Index W T → Prop
 
 /-- The viewpoints: the four relations of [klein-1994] between the topic time and the situation
 time, and the neutral viewpoint of [smith-1997], the default in the absence of aspect

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -35,7 +35,7 @@ d-causes without producing anything.
 
 namespace Causation.ProductionDependence
 
-open Semantics.Context (Index)
+open Reference
 
 open Features
 

--- a/Linglib/Semantics/Causation/Progressive.lean
+++ b/Linglib/Semantics/Causation/Progressive.lean
@@ -35,7 +35,7 @@ checks type-level sufficiency (`BoolSEM.causallySufficient`);
 
 namespace Causation.Progressive
 
-open Semantics.Context (Index)
+open Reference
 open Causation Causation.Mechanism Causation.SEM
 
 /-! ### Causal Process -/

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -40,7 +40,7 @@ in mixed scenarios:
 
 namespace Conditionals.Counterfactual
 
-open Semantics.Context (Index)
+open Reference
 
 open _root_.Conditionals
 open Trivalent (ProjectionType dist)

--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -279,8 +279,8 @@ end DynamicSemantics
 `Mood/Dynamic.lean`): a `Possibility` whose world coordinate is the
 current evaluation index and whose `ℕ`-registered drefs are also
 world-time indices. Contexts are plain level-0 states
-(`Set (Semantics.Context.Index.Possibility W T)`), so the update
+(`Set (Reference.Index.Possibility W T)`), so the update
 spine of `Semantics/Dynamic/Update.lean` applies directly. -/
-abbrev Semantics.Context.Index.Possibility (W T : Type*) :=
-  DynamicSemantics.Possibility (Semantics.Context.Index W T) ℕ
-    (Semantics.Context.Index W T)
+abbrev Reference.Index.Possibility (W T : Type*) :=
+  DynamicSemantics.Possibility (Reference.Index W T) ℕ
+    (Reference.Index W T)

--- a/Linglib/Semantics/Evidential/Epistemicity.lean
+++ b/Linglib/Semantics/Evidential/Epistemicity.lean
@@ -8,7 +8,7 @@ import Linglib.Semantics.Reference.Context.Tower
 
 Connective layer bundling evidential source, epistemic authority (egophoricity),
 and mirativity into a unified `EpistemicProfile`. Bridges these feature-geometric
-dimensions to the model-theoretic level (`KContext` / `ContextTower`).
+dimensions to the model-theoretic level (`Context` / `ContextTower`).
 
 ## Motivation
 
@@ -39,7 +39,7 @@ namespace Epistemicity
 
 open Evidential
 open Features.Mirativity
-open Semantics.Context
+open Reference
 
 /-- Epistemic authority: WHO has privileged access to the propositional content.
     Egophoric systems ([tournadre-2008], [floyd-2018], Gawne & Spronck glossary 2)
@@ -69,7 +69,7 @@ structure EpistemicProfile where
     speech-act participants: ego if the knower is the speaker, allocutive
     if the knower is the addressee, nonparticipant otherwise. -/
 def epistemicAuthority {W E P T : Type*} [DecidableEq E]
-    (tower : ContextTower (KContext W E P T)) (knower : E) : EpistemicAuthority :=
+    (tower : ContextTower (Context W E P T)) (knower : E) : EpistemicAuthority :=
   let ctx := tower.origin
   if knower == ctx.agent then .ego
   else if knower == ctx.addressee then .allocutive
@@ -99,7 +99,7 @@ def allocutiveProfile (s : CoarseSource) : EpistemicProfile :=
 /-- Epistemic authority is invariant under tower push: egophoric marking
     reflects speech-act participants (from origin), not embedded ones. -/
 theorem epistemicAuthority_shift_invariant {W E P T : Type*} [DecidableEq E]
-    (tower : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T))
+    (tower : ContextTower (Context W E P T)) (σ : ContextShift (Context W E P T))
     (knower : E) :
     epistemicAuthority (tower.push σ) knower = epistemicAuthority tower knower := by
   simp only [epistemicAuthority, ContextTower.push_origin]

--- a/Linglib/Semantics/Modality/Exclusion.lean
+++ b/Linglib/Semantics/Modality/Exclusion.lean
@@ -46,7 +46,7 @@ distinguish live from non-live possibilities.
 
 namespace Modality.Exclusion
 
-open Semantics.Context (KContext ContextTower temporalShift)
+open Reference
 open Mood (subjShift)
 
 /-! ### ExclF: the exclusion feature -/
@@ -73,7 +73,7 @@ This is a predicate over context towers: `ExclF dim tower` holds iff
 the relevant coordinate of the innermost context (topic) differs from
 the origin context (speaker). At a root tower innermost and origin
 coincide, so neither dimension's feature holds. -/
-def ExclF (dim : ExclDimension) (tower : ContextTower (KContext W E P T)) : Prop :=
+def ExclF (dim : ExclDimension) (tower : ContextTower (Context W E P T)) : Prop :=
   match dim with
   | .temporal => tower.innermost.time ≠ tower.origin.time
   | .modal    => tower.innermost.world ≠ tower.origin.world
@@ -86,7 +86,7 @@ When a subjunctive clause introduces a new world that differs from the
 origin, the resulting tower has modal ExclF. This is the tower-level
 formalization of [iatridou-2000]'s claim that counterfactual
 morphology signals world exclusion. -/
-theorem subjShift_produces_modal_exclF (c : KContext W E P T) (w' : W) (t' : T)
+theorem subjShift_produces_modal_exclF (c : Context W E P T) (w' : W) (t' : T)
     (h : w' ≠ c.world) :
     ExclF .modal ((ContextTower.root c).push (subjShift w' t')) :=
   h
@@ -95,7 +95,7 @@ theorem subjShift_produces_modal_exclF (c : KContext W E P T) (w' : W) (t' : T)
 
 When an embedding shifts the evaluation time away from the speech time,
 the resulting tower has temporal ExclF. This is ordinary temporal past. -/
-theorem temporalShift_produces_temporal_exclF (c : KContext W E P T) (t' : T)
+theorem temporalShift_produces_temporal_exclF (c : Context W E P T) (t' : T)
     (h : t' ≠ c.time) :
     ExclF .temporal ((ContextTower.root c).push (temporalShift t')) :=
   h
@@ -103,7 +103,7 @@ theorem temporalShift_produces_temporal_exclF (c : KContext W E P T) (t' : T)
 /-- Two shifts → both ExclFs: a subjunctive (world) shift followed by a
 temporal one yields modal and temporal exclusion together — the PastCF
 configuration of [iatridou-2000] (two past layers). -/
-theorem two_shifts_two_exclFs (c : KContext W E P T) (w' : W) (t' t'' : T)
+theorem two_shifts_two_exclFs (c : Context W E P T) (w' : W) (t' t'' : T)
     (hw : w' ≠ c.world) (ht : t'' ≠ c.time) :
     ExclF .modal (((ContextTower.root c).push (subjShift w' t')).push (temporalShift t'')) ∧
       ExclF .temporal (((ContextTower.root c).push (subjShift w' t')).push (temporalShift t'')) :=

--- a/Linglib/Semantics/Modality/HistoricalAlternatives.lean
+++ b/Linglib/Semantics/Modality/HistoricalAlternatives.lean
@@ -40,7 +40,7 @@ perfectly match it in matters of particular fact up to that time
   (`N P ∨ N ¬P`) — settled-*whether* (bilateral), the analogue of `oSettled`, not `IsInevitable`.
 -/
 
-open Semantics.Context (Index)
+open Reference
 
 /-- Historical-alternatives relation: given a ⟨world, time⟩ index, returns the
     worlds that agree with that world up to that time. This is the basis for the

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -53,7 +53,7 @@ dref *and* moves the evaluation index to the introduced situation.
 
 namespace Mood
 
-open Semantics.Context (Index)
+open Reference
 open HistoricalAlternatives DynamicSemantics
 open DynamicSemantics.CCP (IsEliminative)
 open DynamicSemantics.Update (test closure)

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -29,7 +29,7 @@ clause retrieves for temporal anchoring (`conditionalSF`).
 
 namespace Mood
 
-open Semantics.Context (Index)
+open Reference
 open HistoricalAlternatives
 
 /-- A situation predicate, relating a described situation to its anchor. -/
@@ -116,7 +116,7 @@ tense indexing). -/
 /-- The mood-labeled context shift to the introduced situation's world
 and time. -/
 def subjShift {E P : Type*} (newWorld : W) (newTime : T) :
-    Semantics.Context.ContextShift (Semantics.Context.KContext W E P T) where
+    ContextShift (Context W E P T) where
   apply := λ c => { c with world := newWorld, time := newTime }
   label := .mood
 

--- a/Linglib/Semantics/Reference/Acquaintance.lean
+++ b/Linglib/Semantics/Reference/Acquaintance.lean
@@ -16,7 +16,7 @@ cover identifies it at `p`.
 
 Instantiated at an assignment–witness pair as `Idx` and `Res := E` this is the
 cover-relative belief system of [dekker-2012].
-Instantiated at `Idx := KContext W E P T`, `Res := T` this is
+Instantiated at `Idx := Context W E P T`, `Res := T` this is
 [heim-1994-comments]'s time-concept; [abusch-1997]'s own de re rule, through an
 acquaintance relation rather than a cover, is `Acquaintance.deRe`
 (`Semantics/Attitudes/Acquaintance.lean`).
@@ -38,7 +38,7 @@ open Reference (IsRigid isRigid_const)
     identifying" values of type `Res`.
 
     [heim-1994-comments]'s time-concepts are the instance with
-    `Idx := KContext W E P T`, `Res := T`. -/
+    `Idx := Context W E P T`, `Res := T`. -/
 abbrev Cover (Idx Res : Type*) : Type _ := Set (Idx → Res)
 
 /-- A cover is exhaustive on a domain when, at every index, every value

--- a/Linglib/Semantics/Reference/Basic.lean
+++ b/Linglib/Semantics/Reference/Basic.lean
@@ -10,7 +10,6 @@ These mechanisms are independent: a term can exhibit any subset.
 
 ## Key Definitions
 
-- `Context`: Kaplanian context of utterance (agent, world)
 - `Character`: Two-stage semantics — context → content
 - `ReferringExpression`: Bundles character + referential profile
 - `isDirectlyReferential`: Content is rigid at every context
@@ -25,18 +24,7 @@ namespace Reference.Basic
 
 open Reference (IsRigid isRigid_const)
 
-/-! ## Context and Character -/
-
-/-- A Kaplanian context of utterance.
-
-Contexts supply the parameters that indexicals depend on: who is speaking,
-what world is actual, etc. Following [kaplan-1989], characters are functions
-from contexts to contents. -/
-structure Context (W : Type*) (E : Type*) where
-  /-- The agent of the context (the speaker) -/
-  agent : E
-  /-- The world of the context (the actual world) -/
-  world : W
+/-! ## Character -/
 
 /-- A Kaplanian character: a function from contexts to contents (intensions).
 
@@ -148,16 +136,5 @@ theorem properNames_corefer_coextensional {C W E : Type*} (e₁ e₂ : E) (c : C
       (properName (W := W) e₂).character c w) :
     (properName (C := C) (W := W) e₁).character c = (properName (W := W) e₂).character c :=
   (isRigid_const e₁).eq_of_apply_eq (isRigid_const e₂) h
-
-/-! ## Bridge to KContext -/
-
-/-- Lift a simple `Context W E` to a full `KContext W E P T` by supplying
-trivial time and position.
-
-This allows existing code using the two-component context to interoperate
-with the full Kaplanian context. -/
-def Context.toKContext {W E P T : Type*} (c : Context W E) (addr : E) (p : P) (t : T) :
-    Semantics.Context.KContext W E P T :=
-  ⟨c.agent, addr, c.world, t, p⟩
 
 end Reference.Basic

--- a/Linglib/Semantics/Reference/Context/Basic.lean
+++ b/Linglib/Semantics/Reference/Context/Basic.lean
@@ -9,22 +9,18 @@ The full context tuple ⟨agent, world, time, position⟩ from [kaplan-1989]
 "Demonstratives" §XVIII. Framework-agnostic infrastructure used by reference
 theory, tense semantics, mood, and RSA.
 
-The simple `Context W E` (agent + world) in `Reference/Basic.lean` is a
-projection; `KContext` is the full Kaplanian structure.
-
 -/
 
 open Tense
 
-namespace Semantics.Context
+namespace Reference
 
-open Semantics.Context (Index)
 
 /-- Full Kaplanian context of utterance: ⟨agent, world, time, position⟩.
 
 [kaplan-1989] §XVIII: "A context is a tuple ⟨cₐ, cw, ct, cp⟩ where cₐ is
 the agent, cw the world, ct the time, and cp the position." -/
-structure KContext (W : Type*) (E : Type*) (P : Type*) (T : Type*) where
+structure Context (W : Type*) (E : Type*) (P : Type*) (T : Type*) where
   /-- The agent (speaker) of the context -/
   agent : E
   /-- The addressee (hearer) of the context -/
@@ -41,58 +37,57 @@ structure KContext (W : Type*) (E : Type*) (P : Type*) (T : Type*) where
 
 [kaplan-1989] §XVIII Remark 3: contexts are proper only if the agent exists
 at the world of the context. This validates ⊨ Exist I. -/
-def ProperContext {W E P T : Type*} (c : KContext W E P T)
-    (exists_ : E → W → Prop) : Prop :=
+def Context.Proper {W E P T : Type*} (c : Context W E P T) (exists_ : E → W → Prop) : Prop :=
   exists_ c.agent c.world
 
 /-- Located context: the agent is at the context's position at the context's
 time in the context's world.
 
 Validates ⊨ N(Located(I, Here)). -/
-def LocatedContext {W E P T : Type*} (c : KContext W E P T)
+def Context.Located {W E P T : Type*} (c : Context W E P T)
     (located : E → P → T → W → Prop) : Prop :=
   located c.agent c.position c.time c.world
 
-/-- Project a KContext to a `Index` (world + time pair). -/
-def KContext.toIndex {W E P T : Type*} (c : KContext W E P T) :
+/-- Project a Context to a `Index` (world + time pair). -/
+def Context.toIndex {W E P T : Type*} (c : Context W E P T) :
     Index W T :=
   ⟨c.world, c.time⟩
 
-/-- Replace the world and time of a KContext with those of a `Index`,
+/-- Replace the world and time of a Context with those of a `Index`,
     preserving agent / addressee / position. The natural "shift to alternative
     situation" operation: an agent at an evaluation context can hold the same
     centered identity (`agent`) while considering an alternative ⟨world, time⟩.
     Used by centered-world de re semantics to quantify the time-concept across
     a believer's doxastic or metaphysical alternative situations. -/
-def KContext.shiftWorldTime {W E P T : Type*} (c : KContext W E P T)
-    (s : Index W T) : KContext W E P T :=
+def Context.shiftWorldTime {W E P T : Type*} (c : Context W E P T)
+    (s : Index W T) : Context W E P T :=
   { c with world := s.world, time := s.time }
 
-@[simp] theorem KContext.shiftWorldTime_world {W E P T : Type*}
-    (c : KContext W E P T) (s : Index W T) :
+@[simp] theorem Context.shiftWorldTime_world {W E P T : Type*}
+    (c : Context W E P T) (s : Index W T) :
     (c.shiftWorldTime s).world = s.world := rfl
 
-@[simp] theorem KContext.shiftWorldTime_time {W E P T : Type*}
-    (c : KContext W E P T) (s : Index W T) :
+@[simp] theorem Context.shiftWorldTime_time {W E P T : Type*}
+    (c : Context W E P T) (s : Index W T) :
     (c.shiftWorldTime s).time = s.time := rfl
 
-@[simp] theorem KContext.shiftWorldTime_agent {W E P T : Type*}
-    (c : KContext W E P T) (s : Index W T) :
+@[simp] theorem Context.shiftWorldTime_agent {W E P T : Type*}
+    (c : Context W E P T) (s : Index W T) :
     (c.shiftWorldTime s).agent = c.agent := rfl
 
-@[simp] theorem KContext.shiftWorldTime_toIndex {W E P T : Type*}
-    (c : KContext W E P T) (s : Index W T) :
+@[simp] theorem Context.shiftWorldTime_toIndex {W E P T : Type*}
+    (c : Context W E P T) (s : Index W T) :
     (c.shiftWorldTime s).toIndex = s := rfl
 
-/-- Project a KContext into a root-clause ReichenbachFrame.
+/-- Project a Context into a root-clause ReichenbachFrame.
     Speech time S = context time; perspective time P = S (root clause
     default, [kiparsky-2002]); R and E are supplied per clause. -/
-def KContext.toReichenbachFrame {W E P T : Type*}
-    (c : KContext W E P T) (R Ev : T) :
+def Context.toReichenbachFrame {W E P T : Type*}
+    (c : Context W E P T) (R Ev : T) :
     ReichenbachFrame T where
   speechTime := c.time
   perspectiveTime := c.time  -- root clause default: P = S
   referenceTime := R
   eventTime := Ev
 
-end Semantics.Context
+end Reference

--- a/Linglib/Semantics/Reference/Context/Index.lean
+++ b/Linglib/Semantics/Reference/Context/Index.lean
@@ -3,7 +3,7 @@ import Mathlib.Tactic.TypeStar
 /-!
 # Indices of evaluation
 
-A `Semantics.Context.Index` is a (world, time) pair used as a context of
+A `Index` is a (world, time) pair used as a context of
 evaluation for intensional, dynamic, modal, and tense semantics — the
 Lewis/Kaplan "index of evaluation", with world and temporal coordinates
 only. It is *not* the Kratzer parthood-structured situation (a preordered type, as in
@@ -11,7 +11,7 @@ only. It is *not* the Kratzer parthood-structured situation (a preordered type, 
 (`Causation.Situation`).
 -/
 
-namespace Semantics.Context
+namespace Reference
 
 /-- A world–time index: a (world, time) pair used as a context of
     evaluation in intensional, dynamic, modal, and tense semantics.
@@ -25,4 +25,4 @@ structure Index (W T : Type*) where
   time : T
   deriving Repr
 
-end Semantics.Context
+end Reference

--- a/Linglib/Semantics/Reference/Context/Rich.lean
+++ b/Linglib/Semantics/Reference/Context/Rich.lean
@@ -6,8 +6,8 @@ import Linglib.Semantics.Evidential.Source
 # Rich Context
 [aikhenvald-2004] [condoravdi-2002] [cumming-2026] [iatridou-2000]
 
-`RichContext` extends `KContext` with a domain of accessible worlds and an
-evidential source. This supports two phenomena that plain `KContext` cannot
+`RichContext` extends `Context` with a domain of accessible worlds and an
+evidential source. This supports two phenomena that plain `Context` cannot
 express:
 
 1. **Domain expansion** ([condoravdi-2002], Mizuno): backward temporal shifts
@@ -20,16 +20,15 @@ express:
 
 ## Key Types
 
-- `RichContext W E P T` — KContext + `domain : Set W` + `evidence : CoarseSource`
-- `KContext.toRich` — lift with trivial domain (`Set.univ`) and default evidence
+- `RichContext W E P T` — Context + `domain : Set W` + `evidence : CoarseSource`
+- `Context.toRich` — lift with trivial domain (`Set.univ`) and default evidence
 - `DomainExpanding` — property of a shift: it expands the domain
 - `hpShift` — historical present temporal shift (backward time + domain expansion)
 
 -/
 
-namespace Semantics.Context
+namespace Reference
 
-open Semantics.Context (KContext ContextTower ContextShift)
 open Evidential
 
 -- ════════════════════════════════════════════════════════════════
@@ -48,7 +47,7 @@ open Evidential
     connecting to [cumming-2026]'s tense-evidential constraints. -/
 structure RichContext (W : Type*) (E : Type*) (P : Type*) (T : Type*) where
   /-- The underlying Kaplanian context -/
-  base : KContext W E P T
+  base : Context W E P T
   /-- The set of accessible worlds (modal domain) -/
   domain : Set W
   /-- The evidential source for the current assertion -/
@@ -58,8 +57,8 @@ section RichContextOps
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
-/-- Project back to a KContext (forget domain and evidence). -/
-def RichContext.toKContext (rc : RichContext W E P T) : KContext W E P T := rc.base
+/-- Project back to a Context (forget domain and evidence). -/
+def RichContext.toContext (rc : RichContext W E P T) : Context W E P T := rc.base
 
 /-- Agent of the rich context. -/
 def RichContext.agent (rc : RichContext W E P T) : E := rc.base.agent
@@ -77,27 +76,27 @@ def RichContext.addressee (rc : RichContext W E P T) : E := rc.base.addressee
 def RichContext.position (rc : RichContext W E P T) : P := rc.base.position
 
 /-- Project a RichContext to a `Index` (world + time pair). -/
-def RichContext.toIndex (rc : RichContext W E P T) : Semantics.Context.Index W T :=
+def RichContext.toIndex (rc : RichContext W E P T) : Index W T :=
   rc.base.toIndex
 
 -- ════════════════════════════════════════════════════════════════
--- § KContext Lift
+-- § Context Lift
 -- ════════════════════════════════════════════════════════════════
 
-/-- Lift a `KContext` to a `RichContext` with the trivial (universal) domain
+/-- Lift a `Context` to a `RichContext` with the trivial (universal) domain
     and default direct evidence. This is the root-clause default: no modal
     restriction, speaker has direct evidence. -/
-def KContext.toRich (c : KContext W E P T) : RichContext W E P T where
+def Context.toRich (c : Context W E P T) : RichContext W E P T where
   base := c
   domain := Set.univ
   evidence := .direct
 
 /-- The trivial lift has universal domain. -/
-theorem KContext.toRich_domain (c : KContext W E P T) :
+theorem Context.toRich_domain (c : Context W E P T) :
     c.toRich.domain = Set.univ := rfl
 
 /-- The trivial lift preserves the base context. -/
-theorem KContext.toRich_base (c : KContext W E P T) :
+theorem Context.toRich_base (c : Context W E P T) :
     c.toRich.base = c := rfl
 
 -- ════════════════════════════════════════════════════════════════
@@ -220,4 +219,4 @@ theorem coarseSourceShift_preserves_domain
 
 end RichContextOps
 
-end Semantics.Context
+end Reference

--- a/Linglib/Semantics/Reference/Context/Shifts.lean
+++ b/Linglib/Semantics/Reference/Context/Shifts.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Reference.Context.Tower
 /-!
 # Standard Context Shifts
 
-Shift constructors for `KContext` that correspond to specific linguistic operations:
+Shift constructors for `Context` that correspond to specific linguistic operations:
 attitude embedding, temporal shift, and the identity (no-op) shift. Each preserves or
 changes specific coordinates, with theorems documenting the preservation pattern.
 
@@ -12,11 +12,10 @@ These are the building blocks for tower-based composition. An attitude verb push
 English attitude verbs push `identityShift`.
 -/
 
-namespace Semantics.Context
+namespace Reference
 
-open Semantics.Context (KContext)
 
-section KContextShifts
+section ContextShifts
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
@@ -27,7 +26,7 @@ variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
     [schlenker-2003]: "John said that I am happy" — under the monster
     analysis, the attitude verb shifts agent to John. Under Kaplan's
     thesis, English uses `identityShift` instead. -/
-def attitudeShift (holder : E) (attWorld : W) : ContextShift (KContext W E P T) where
+def attitudeShift (holder : E) (attWorld : W) : ContextShift (Context W E P T) where
   apply := λ c => { c with agent := holder, world := attWorld }
   label := .attitude
 
@@ -36,14 +35,14 @@ def attitudeShift (holder : E) (attWorld : W) : ContextShift (KContext W E P T) 
 
     [von-stechow-2009]: the attitude verb transmits its event time to
     the embedded clause's perspective time. -/
-def temporalShift (newTime : T) : ContextShift (KContext W E P T) where
+def temporalShift (newTime : T) : ContextShift (Context W E P T) where
   apply := λ c => { c with time := newTime }
   label := .temporal
 
 /-- Identity shift: no change to the context. Kaplan's thesis for English
     says attitude verbs push identity shifts — embedding happens without
     shifting the context of utterance. -/
-def identityShift : ContextShift (KContext W E P T) where
+def identityShift : ContextShift (Context W E P T) where
   apply := id
   label := .generic
 
@@ -52,56 +51,56 @@ def identityShift : ContextShift (KContext W E P T) where
 -- ════════════════════════════════════════════════════════════════
 
 @[simp] theorem attitudeShift_preserves_addressee (holder : E) (attWorld : W)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     ((attitudeShift holder attWorld).apply c).addressee = c.addressee := rfl
 
 @[simp] theorem attitudeShift_preserves_time (holder : E) (attWorld : W)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     ((attitudeShift holder attWorld).apply c).time = c.time := rfl
 
 @[simp] theorem attitudeShift_preserves_position (holder : E) (attWorld : W)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     ((attitudeShift holder attWorld).apply c).position = c.position := rfl
 
 @[simp] theorem attitudeShift_changes_agent (holder : E) (attWorld : W)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     ((attitudeShift holder attWorld).apply c).agent = holder := rfl
 
 @[simp] theorem attitudeShift_changes_world (holder : E) (attWorld : W)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     ((attitudeShift holder attWorld).apply c).world = attWorld := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § Temporal Shift Preservation
 -- ════════════════════════════════════════════════════════════════
 
-@[simp] theorem temporalShift_preserves_agent (newTime : T) (c : KContext W E P T) :
+@[simp] theorem temporalShift_preserves_agent (newTime : T) (c : Context W E P T) :
     ((temporalShift newTime).apply c).agent = c.agent := rfl
 
-@[simp] theorem temporalShift_preserves_world (newTime : T) (c : KContext W E P T) :
+@[simp] theorem temporalShift_preserves_world (newTime : T) (c : Context W E P T) :
     ((temporalShift newTime).apply c).world = c.world := rfl
 
-@[simp] theorem temporalShift_preserves_addressee (newTime : T) (c : KContext W E P T) :
+@[simp] theorem temporalShift_preserves_addressee (newTime : T) (c : Context W E P T) :
     ((temporalShift newTime).apply c).addressee = c.addressee := rfl
 
-@[simp] theorem temporalShift_preserves_position (newTime : T) (c : KContext W E P T) :
+@[simp] theorem temporalShift_preserves_position (newTime : T) (c : Context W E P T) :
     ((temporalShift newTime).apply c).position = c.position := rfl
 
-@[simp] theorem temporalShift_changes_time (newTime : T) (c : KContext W E P T) :
+@[simp] theorem temporalShift_changes_time (newTime : T) (c : Context W E P T) :
     ((temporalShift newTime).apply c).time = newTime := rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § Identity Shift
 -- ════════════════════════════════════════════════════════════════
 
-@[simp] theorem identityShift_apply (c : KContext W E P T) :
+@[simp] theorem identityShift_apply (c : Context W E P T) :
     (identityShift (W := W) (E := E) (P := P) (T := T)).apply c = c := rfl
 
 /-- Pushing an identity shift doesn't change the innermost context. -/
-theorem push_identityShift_innermost (t : ContextTower (KContext W E P T)) :
+theorem push_identityShift_innermost (t : ContextTower (Context W E P T)) :
     (t.push identityShift).innermost = t.innermost := by
   rw [ContextTower.push_innermost, identityShift_apply]
 
-end KContextShifts
+end ContextShifts
 
-end Semantics.Context
+end Reference

--- a/Linglib/Semantics/Reference/Context/Tower.lean
+++ b/Linglib/Semantics/Reference/Context/Tower.lean
@@ -10,7 +10,7 @@ mechanisms: Kaplanian indexicals (origin access), shifted indexicals (local acce
 De Bruijn temporal indexing (depth-relative access), situation introduction (mood),
 and domain expansion (branching time).
 
-The tower is parametric over any context type `C`. `KContext` serves as the canonical
+The tower is parametric over any context type `C`. `Context` serves as the canonical
 instantiation — it represents what a single context layer looks like. The tower wraps
 it with a stack of shifts.
 
@@ -30,7 +30,7 @@ as a reader parameter — `ContextTower C →...` is the enriched meaning type.
 
 -/
 
-namespace Semantics.Context
+namespace Reference
 
 -- ════════════════════════════════════════════════════════════════
 -- § Shift Labels
@@ -187,9 +187,9 @@ end DepthSpec
     - `depth` says which tower layer to read from
     - `project` says which coordinate to extract
 
-    English "I" = `⟨.origin, KContext.agent⟩`
-    Amharic "I" = `⟨.local, KContext.agent⟩`
-    English "now" = `⟨.origin, KContext.time⟩` -/
+    English "I" = `⟨.origin, Context.agent⟩`
+    Amharic "I" = `⟨.local, Context.agent⟩`
+    English "now" = `⟨.origin, Context.time⟩` -/
 structure AccessPattern (C : Type*) (R : Type*) where
   /-- Which depth to read from -/
   depth : DepthSpec
@@ -275,4 +275,4 @@ theorem root_origin_eq_local (ap₁ ap₂ : AccessPattern C R)
 
 end AccessPattern
 
-end Semantics.Context
+end Reference

--- a/Linglib/Semantics/Reference/Demonstratives.lean
+++ b/Linglib/Semantics/Reference/Demonstratives.lean
@@ -28,7 +28,6 @@ import Linglib.Semantics.Reference.Nominal
 namespace Reference.Demonstratives
 
 open Reference (IsRigid isRigid_const)
-open Semantics.Context (KContext)
 open _root_.Reference.Basic (ReferringExpression isDirectlyReferential)
 
 /-! ## Demonstrations -/

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -23,7 +23,6 @@ namespace Reference.Kaplan
 
 open Reference (IsRigid isRigid_const)
 open _root_.Reference.Basic
-open Semantics.Context (KContext)
 
 /-! ## Indexicals -/
 
@@ -32,26 +31,23 @@ names), but its content at each context is rigid.
 
 Example: "I" has a different content when uttered by Alice vs Bob,
 but once we fix the context, the content rigidly picks out the agent. -/
-def indexical {W E : Type*} (charFn : Context W E → E) : ReferringExpression (Context W E) W E :=
+def indexical {W E P T : Type*} (charFn : Context W E P T → E) :
+    ReferringExpression (Context W E P T) W E :=
   { character := λ c => fun _ => charFn c
   , profile := ⟨true, true, false⟩ }
 
 /-- "I": picks out the agent of the context. -/
-def pronI {W E : Type*} : ReferringExpression (Context W E) W E :=
-  indexical (λ c => c.agent)
+def pronI {W E P T : Type*} : ReferringExpression (Context W E P T) W E :=
+  indexical (·.agent)
 
 /-- "I" is directly referential: at every context, its content is rigid. -/
-theorem pronI_directlyReferential {W E : Type*} :
-    isDirectlyReferential (pronI (W := W) (E := E)).character :=
+theorem pronI_directlyReferential {W E P T : Type*} :
+    isDirectlyReferential (pronI (W := W) (E := E) (P := P) (T := T)).character :=
   λ _ => isRigid_const _
 
-/-- "You": picks out the addressee of the context (Speas & Tenny's HEARER).
-
-    Parallel to `pronI` but uses the full `KContext` (which has `addressee`)
-    rather than the simple `Context` (which only has `agent` and `world`). -/
-def pronYou {W E P T : Type*} : ReferringExpression (KContext W E P T) W E :=
-  { character := λ c => fun _ => c.addressee
-  , profile := ⟨true, true, false⟩ }
+/-- "You": picks out the addressee of the context (Speas & Tenny's HEARER). -/
+def pronYou {W E P T : Type*} : ReferringExpression (Context W E P T) W E :=
+  indexical (·.addressee)
 
 /-- "You" is directly referential: at every context, its content is rigid. -/
 theorem pronYou_directlyReferential {W E P T : Type*} :
@@ -61,9 +57,9 @@ theorem pronYou_directlyReferential {W E P T : Type*} :
 /-- Indexicals have non-constant character (in general).
 
 "I" said by Alice ≠ "I" said by Bob: the character varies. -/
-theorem indexical_character_varies {W E : Type*} [Inhabited W]
-    (charFn : Context W E → E)
-    (c₁ c₂ : Context W E) (h : charFn c₁ ≠ charFn c₂) :
+theorem indexical_character_varies {W E P T : Type*} [Inhabited W]
+    (charFn : Context W E P T → E)
+    (c₁ c₂ : Context W E P T) (h : charFn c₁ ≠ charFn c₂) :
     (indexical charFn).character c₁ ≠ (indexical charFn).character c₂ := by
   intro heq
   have : (indexical charFn).character c₁ default = (indexical charFn).character c₂ default :=
@@ -130,10 +126,10 @@ at every context, the content is true at the world of the context.
 It is NOT necessary — there are worlds where the agent is elsewhere.
 This distinguishes logical truth (true at every context) from
 necessity (true at every world). -/
-theorem i_am_here_now_logically_true {W E : Type*}
-    (here : Context W E → E → W → Prop)
-    (hCtx : ∀ c : Context W E, here c c.agent c.world) :
-    ∀ c : Context W E, here c c.agent c.world :=
+theorem i_am_here_now_logically_true {W E P T : Type*}
+    (here : Context W E P T → E → W → Prop)
+    (hCtx : ∀ c : Context W E P T, here c c.agent c.world) :
+    ∀ c : Context W E P T, here c c.agent c.world :=
   hCtx
 
 /-! ## Indexicals as Tower Access Patterns
@@ -145,7 +141,6 @@ are invariant under embedding operators becomes a corollary of `origin_stable`. 
 
 section TowerIndexicals
 
-open Semantics.Context
 
 variable {W' : Type*} {E' : Type*} {P' : Type*} {T' : Type*}
 
@@ -157,36 +152,36 @@ variable {W' : Type*} {E' : Type*} {P' : Type*} {T' : Type*}
 
     [kaplan-1989]: the character of "I" is the function that maps every
     context to the agent of that context. In tower terms, "I" reads from
-    the origin (depth 0), projecting `KContext.agent`. -/
-def pronI_access : AccessPattern (KContext W' E' P' T') E' :=
-  ⟨.origin, KContext.agent⟩
+    the origin (depth 0), projecting `Context.agent`. -/
+def pronI_access : AccessPattern (Context W' E' P' T') E' :=
+  ⟨.origin, Context.agent⟩
 
 /-- "you" — second person pronoun. Reads the addressee from the speech-act context.
 
     Following [speas-tenny-2003], the addressee is a coordinate of the
-    Kaplanian context. "You" reads from the origin, projecting `KContext.addressee`. -/
-def pronYou_access : AccessPattern (KContext W' E' P' T') E' :=
-  ⟨.origin, KContext.addressee⟩
+    Kaplanian context. "You" reads from the origin, projecting `Context.addressee`. -/
+def pronYou_access : AccessPattern (Context W' E' P' T') E' :=
+  ⟨.origin, Context.addressee⟩
 
 /-- "now" — temporal indexical. Reads the time from the speech-act context.
 
     [kaplan-1989] §VI: N (now) is a content operator that shifts the
     evaluation time to the context time. As an access pattern, "now"
-    reads `KContext.time` from the origin. -/
-def opNow_access : AccessPattern (KContext W' E' P' T') T' :=
-  ⟨.origin, KContext.time⟩
+    reads `Context.time` from the origin. -/
+def opNow_access : AccessPattern (Context W' E' P' T') T' :=
+  ⟨.origin, Context.time⟩
 
 /-- "here" — spatial indexical. Reads the position from the speech-act context. -/
-def opHere_access : AccessPattern (KContext W' E' P' T') P' :=
-  ⟨.origin, KContext.position⟩
+def opHere_access : AccessPattern (Context W' E' P' T') P' :=
+  ⟨.origin, Context.position⟩
 
 /-- "actually" — modal indexical. Reads the world from the speech-act context.
 
     [kaplan-1989] §VI: A (actually) shifts the evaluation world to the
-    context world. As an access pattern, "actually" reads `KContext.world`
+    context world. As an access pattern, "actually" reads `Context.world`
     from the origin. -/
-def opActually_access : AccessPattern (KContext W' E' P' T') W' :=
-  ⟨.origin, KContext.world⟩
+def opActually_access : AccessPattern (Context W' E' P' T') W' :=
+  ⟨.origin, Context.world⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § Depth Verification
@@ -217,31 +212,31 @@ def opActually_access : AccessPattern (KContext W' E' P' T') W' :=
 
     "John said that I am happy" => "I" = the actual speaker, not John. -/
 theorem pronI_shift_invariant
-    (t : ContextTower (KContext W' E' P' T')) (σ : ContextShift (KContext W' E' P' T')) :
+    (t : ContextTower (Context W' E' P' T')) (σ : ContextShift (Context W' E' P' T')) :
     pronI_access.resolve (t.push σ) = pronI_access.resolve t :=
   AccessPattern.origin_stable pronI_access rfl t σ
 
 /-- "you" is invariant under any tower push. -/
 theorem pronYou_shift_invariant
-    (t : ContextTower (KContext W' E' P' T')) (σ : ContextShift (KContext W' E' P' T')) :
+    (t : ContextTower (Context W' E' P' T')) (σ : ContextShift (Context W' E' P' T')) :
     pronYou_access.resolve (t.push σ) = pronYou_access.resolve t :=
   AccessPattern.origin_stable pronYou_access rfl t σ
 
 /-- "now" is invariant under any tower push. -/
 theorem opNow_shift_invariant
-    (t : ContextTower (KContext W' E' P' T')) (σ : ContextShift (KContext W' E' P' T')) :
+    (t : ContextTower (Context W' E' P' T')) (σ : ContextShift (Context W' E' P' T')) :
     opNow_access.resolve (t.push σ) = opNow_access.resolve t :=
   AccessPattern.origin_stable opNow_access rfl t σ
 
 /-- "here" is invariant under any tower push. -/
 theorem opHere_shift_invariant
-    (t : ContextTower (KContext W' E' P' T')) (σ : ContextShift (KContext W' E' P' T')) :
+    (t : ContextTower (Context W' E' P' T')) (σ : ContextShift (Context W' E' P' T')) :
     opHere_access.resolve (t.push σ) = opHere_access.resolve t :=
   AccessPattern.origin_stable opHere_access rfl t σ
 
 /-- "actually" is invariant under any tower push. -/
 theorem opActually_shift_invariant
-    (t : ContextTower (KContext W' E' P' T')) (σ : ContextShift (KContext W' E' P' T')) :
+    (t : ContextTower (Context W' E' P' T')) (σ : ContextShift (Context W' E' P' T')) :
     opActually_access.resolve (t.push σ) = opActually_access.resolve t :=
   AccessPattern.origin_stable opActually_access rfl t σ
 
@@ -288,23 +283,23 @@ theorem kaplansThesisTower :
 -- ════════════════════════════════════════════════════════════════
 
 /-- In a root tower, "I" resolves to the context's agent. -/
-theorem pronI_root (c : KContext W' E' P' T') :
+theorem pronI_root (c : Context W' E' P' T') :
     pronI_access.resolve (ContextTower.root c) = c.agent := rfl
 
 /-- In a root tower, "you" resolves to the context's addressee. -/
-theorem pronYou_root (c : KContext W' E' P' T') :
+theorem pronYou_root (c : Context W' E' P' T') :
     pronYou_access.resolve (ContextTower.root c) = c.addressee := rfl
 
 /-- In a root tower, "now" resolves to the context's time. -/
-theorem opNow_root (c : KContext W' E' P' T') :
+theorem opNow_root (c : Context W' E' P' T') :
     opNow_access.resolve (ContextTower.root c) = c.time := rfl
 
 /-- In a root tower, "here" resolves to the context's position. -/
-theorem opHere_root (c : KContext W' E' P' T') :
+theorem opHere_root (c : Context W' E' P' T') :
     opHere_access.resolve (ContextTower.root c) = c.position := rfl
 
 /-- In a root tower, "actually" resolves to the context's world. -/
-theorem opActually_root (c : KContext W' E' P' T') :
+theorem opActually_root (c : Context W' E' P' T') :
     opActually_access.resolve (ContextTower.root c) = c.world := rfl
 
 end TowerIndexicals

--- a/Linglib/Semantics/Reference/KaplanLD.lean
+++ b/Linglib/Semantics/Reference/KaplanLD.lean
@@ -27,8 +27,6 @@ import Linglib.Semantics.Reference.Basic
 namespace Reference.KaplanLD
 
 open Reference (IsRigid isRigid_const)
-open Semantics.Context (KContext ProperContext LocatedContext)
-open _root_.Reference.Basic (Context Character Content)
 
 /-! ## LD Structure -/
 
@@ -67,9 +65,9 @@ structure LDStructure where
       This validates ⊨ Exist I. -/
   proper : ∀ c : C, exists_ (cAgent c) (cWorld c)
 
-/-- Extract a `KContext` from an LD structure at a context index. -/
-def LDStructure.toKContext (ld : LDStructure) (c : ld.C) :
-    KContext ld.W ld.U ld.P ld.T :=
+/-- Extract a `Context` from an LD structure at a context index. -/
+def LDStructure.toContext (ld : LDStructure) (c : ld.C) :
+    Context ld.W ld.U ld.P ld.T :=
   ⟨ld.cAgent c, ld.cAddressee c, ld.cWorld c, ld.cTime c, ld.cPosition c⟩
 
 /-! ## Dthat Operator (§XII) -/

--- a/Linglib/Semantics/Reference/Monsters.lean
+++ b/Linglib/Semantics/Reference/Monsters.lean
@@ -33,7 +33,6 @@ monster *predicate* and Kaplan's thesis, not the operator.
 
 namespace Reference.Monsters
 
-open Semantics.Context
 
 -- ════════════════════════════════════════════════════════════════
 -- § Tower Monster
@@ -80,12 +79,12 @@ theorem identityShift_not_monster {W : Type*} {E : Type*} {P : Type*} {T : Type*
 /-- An attitude shift is a monster when the holder differs from some
     context's agent. -/
 theorem attitudeShift_is_monster {W : Type*} {E : Type*} {P : Type*} {T : Type*}
-    (holder : E) (attWorld : W) (c : KContext W E P T)
+    (holder : E) (attWorld : W) (c : Context W E P T)
     (hAgent : c.agent ≠ holder) :
     IsTowerMonster (attitudeShift (P := P) (T := T) holder attWorld) := by
   rw [isTowerMonster_iff_exists]
   refine ⟨c, fun h => hAgent ?_⟩
-  simpa using (congrArg KContext.agent h).symm
+  simpa using (congrArg Context.agent h).symm
 
 -- ════════════════════════════════════════════════════════════════
 -- § Kaplan's Thesis (Tower Formulation)

--- a/Linglib/Semantics/Reference/PersonFeatures.lean
+++ b/Linglib/Semantics/Reference/PersonFeatures.lean
@@ -33,7 +33,6 @@ the referent is the agent of an embedded context but NOT the actual speaker.
 
 namespace Reference.PersonFeatures
 
-open Semantics.Context
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
@@ -53,12 +52,12 @@ structure PersonFeature (W E P T : Type*) where
   /-- Which tower depth the feature refers to -/
   depth : DepthSpec
   /-- The constraint: does entity x satisfy the feature relative to context c? -/
-  check : E → KContext W E P T → Bool
+  check : E → Context W E P T → Bool
 
 /-- Evaluate a person feature against a tower: resolve the depth to a
     concrete context layer and check the constraint. -/
 def PersonFeature.eval (f : PersonFeature W E P T)
-    (x : E) (t : ContextTower (KContext W E P T)) : Bool :=
+    (x : E) (t : ContextTower (Context W E P T)) : Bool :=
   f.check x (t.contextAt (f.depth.resolve t.depth))
 
 -- ════════════════════════════════════════════════════════════════
@@ -103,7 +102,7 @@ def hearerStar [BEq E] : PersonFeature W E P T := hearerAt .origin
     This formalizes the key insight: logophoric pronouns are derived from
     the interaction of two person features — one referring to an embedded
     context variable, one to the utterance context. -/
-def isLogophoric [BEq E] (x : E) (t : ContextTower (KContext W E P T))
+def isLogophoric [BEq E] (x : E) (t : ContextTower (Context W E P T))
     (embeddedDepth : DepthSpec) : Bool :=
   (authorAt embeddedDepth).eval x t &&
   !(authorStar (W := W) (P := P) (T := T)).eval x t
@@ -113,7 +112,7 @@ def isLogophoric [BEq E] (x : E) (t : ContextTower (KContext W E P T))
 -- ════════════════════════════════════════════════════════════════
 
 /-- In a root tower, +author* checks against the origin agent. -/
-@[simp] theorem authorStar_root [BEq E] (x : E) (c : KContext W E P T) :
+@[simp] theorem authorStar_root [BEq E] (x : E) (c : Context W E P T) :
     (authorStar (W := W) (P := P) (T := T)).eval x
       (ContextTower.root c) = (x == c.agent) := rfl
 
@@ -121,7 +120,7 @@ def isLogophoric [BEq E] (x : E) (t : ContextTower (KContext W E P T))
     attitude holder. -/
 theorem authorLocal_shifted [BEq E] [LawfulBEq E]
     (holder : E) (w' : W)
-    (t : ContextTower (KContext W E P T)) :
+    (t : ContextTower (Context W E P T)) :
     (authorAt (W := W) (P := P) (T := T) .local).eval holder
       (t.push (attitudeShift holder w')) = true := by
   simp only [authorAt, PersonFeature.eval, DepthSpec.local_resolve,
@@ -137,7 +136,7 @@ theorem authorLocal_shifted [BEq E] [LawfulBEq E]
     not the actual speaker). -/
 theorem logophoric_refers_to_holder [BEq E] [LawfulBEq E]
     (holder : E) (w' : W)
-    (t : ContextTower (KContext W E P T))
+    (t : ContextTower (Context W E P T))
     (hDiff : (holder == t.origin.agent) = false) :
     isLogophoric holder (t.push (attitudeShift holder w')) .local = true := by
   unfold isLogophoric
@@ -152,7 +151,7 @@ theorem logophoric_refers_to_holder [BEq E] [LawfulBEq E]
     This is why logophoric pronouns are restricted to embedded contexts —
     the actual speaker cannot be logophoric in their own utterance. -/
 theorem speaker_not_logophoric [BEq E] [LawfulBEq E]
-    (t : ContextTower (KContext W E P T)) (d : DepthSpec) :
+    (t : ContextTower (Context W E P T)) (d : DepthSpec) :
     isLogophoric t.origin.agent t d = false := by
   simp only [isLogophoric, authorStar, authorAt, PersonFeature.eval,
     DepthSpec.origin_resolve, ContextTower.contextAt_zero,

--- a/Linglib/Semantics/Reference/ShiftedIndexicals.lean
+++ b/Linglib/Semantics/Reference/ShiftedIndexicals.lean
@@ -11,7 +11,7 @@ person shifts but time does not.
 
 ## Key Definitions
 
-- `amharic_pronI`: Amharic first person — `⟨.local, KContext.agent⟩`
+- `amharic_pronI`: Amharic first person — `⟨.local, Context.agent⟩`
 - `UniformShiftParam`: [anand-nevins-2004] constraint — all shifted
   indexicals in a language read from the same depth
 - `MixedShiftLexicon`: [deal-2020] — person shifts but time doesn't (Nez Perce)
@@ -22,7 +22,6 @@ person shifts but time does not.
 
 namespace Reference.ShiftedIndexicals
 
-open Semantics.Context
 open _root_.Reference.Kaplan
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
@@ -40,14 +39,14 @@ variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
     [schlenker-2003]: Amharic attitude verbs are context-shifting operators
     (monsters). Under the tower analysis, the monster pushes an attitude
     shift, and the shifted "I" reads from `.local` rather than `.origin`. -/
-def amharic_pronI : AccessPattern (KContext W E P T) E :=
-  ⟨.local, KContext.agent⟩
+def amharic_pronI : AccessPattern (Context W E P T) E :=
+  ⟨.local, Context.agent⟩
 
 /-- Amharic "here": reads position from the local (shifted) context.
     Under attitude shift, this yields the location of the attitude holder's
     reported speech act, not the actual speaker's location. -/
-def amharic_opHere : AccessPattern (KContext W E P T) P :=
-  ⟨.local, KContext.position⟩
+def amharic_opHere : AccessPattern (Context W E P T) P :=
+  ⟨.local, Context.position⟩
 
 @[simp] theorem amharic_pronI_depth :
     (amharic_pronI (W := W) (E := E) (P := P) (T := T)).depth = .local := rfl
@@ -65,7 +64,7 @@ def amharic_opHere : AccessPattern (KContext W E P T) P :=
     Kaplan's thesis: the SAME lexical item ("I") receives different
     interpretations cross-linguistically because of a depth parameter. -/
 theorem schlenker_counterexample
-    (c : KContext W E P T) (holder : E) (attWorld : W)
+    (c : Context W E P T) (holder : E) (attWorld : W)
     (hDistinct : c.agent ≠ holder) :
     let t := ContextTower.root c
     let σ := attitudeShift holder attWorld
@@ -78,7 +77,7 @@ theorem schlenker_counterexample
 
 /-- In a root tower (no embedding), English and Amharic "I" agree:
     both return the context's agent. -/
-theorem no_shift_agreement (c : KContext W E P T) :
+theorem no_shift_agreement (c : Context W E P T) :
     pronI_access.resolve (ContextTower.root c) =
     amharic_pronI.resolve (ContextTower.root c) := by
   simp only [pronI_access, amharic_pronI, AccessPattern.resolve,
@@ -115,13 +114,13 @@ def english : UniformShiftParam :=
 
 /-- Generate the first person access pattern from a uniform shift parameter. -/
 def UniformShiftParam.pronI (u : UniformShiftParam) :
-    AccessPattern (KContext W E P T) E :=
-  ⟨u.personDepth, KContext.agent⟩
+    AccessPattern (Context W E P T) E :=
+  ⟨u.personDepth, Context.agent⟩
 
 /-- Generate the second person access pattern from a uniform shift parameter. -/
 def UniformShiftParam.pronYou (u : UniformShiftParam) :
-    AccessPattern (KContext W E P T) E :=
-  ⟨u.personDepth, KContext.addressee⟩
+    AccessPattern (Context W E P T) E :=
+  ⟨u.personDepth, Context.addressee⟩
 
 /-- Uniformity: first and second person share the same depth. -/
 theorem uniform_depth (u : UniformShiftParam) :
@@ -160,13 +159,13 @@ def nezPerce : MixedShiftLexicon :=
 
 /-- Generate the first person access pattern from a mixed shift lexicon. -/
 def MixedShiftLexicon.pronI (m : MixedShiftLexicon) :
-    AccessPattern (KContext W E P T) E :=
-  ⟨m.personDepth, KContext.agent⟩
+    AccessPattern (Context W E P T) E :=
+  ⟨m.personDepth, Context.agent⟩
 
 /-- Generate the temporal indexical from a mixed shift lexicon. -/
 def MixedShiftLexicon.opNow (m : MixedShiftLexicon) :
-    AccessPattern (KContext W E P T) T :=
-  ⟨m.temporalDepth, KContext.time⟩
+    AccessPattern (Context W E P T) T :=
+  ⟨m.temporalDepth, Context.time⟩
 
 /-- In Nez Perce, person and time have different depths. -/
 theorem nezPerce_mixed :

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -16,7 +16,7 @@ cells behind the update spine's test filter.
 
 namespace Tense
 
-open Semantics.Context (Index)
+open Reference
 
 variable {W T : Type*} [LinearOrder T]
 

--- a/Linglib/Semantics/Tense/DeRe.lean
+++ b/Linglib/Semantics/Tense/DeRe.lean
@@ -17,11 +17,11 @@ centered context — together with a base-world condition, the temporal instance
 ## Implementation notes
 
 Time-concepts are intensions from the centered Kaplanian
-context `Semantics.Context.KContext`
+context `Reference.Context`
 (`Semantics/Reference/Context/Basic.lean`) — Abusch's `⟨x_self, t_now, w⟩`
 is a three-field projection of the richer context the rest of linglib
 commits to. Rigidity across alternatives is `IsRigidOn` after
-`KContext.shiftWorldTime`; the alternative set is a bare
+`Context.shiftWorldTime`; the alternative set is a bare
 `Set (Index W T)`, so doxastic (Hintikka belief alternatives,
 the Abusch-canonical case) and metaphysical ([klecha-2016] DOX via
 `HistoricalAlternatives.actualHistoryBase`) modal bases are call-site
@@ -30,9 +30,9 @@ instantiations (`doxasticAlternatives`, `metaphysicalAlternatives`).
 
 namespace Tense.DeRe
 
-open Semantics.Context (Index)
+open Reference
 open Reference (IsRigid IsRigidOn)
-open Semantics.Context (KContext)
+open Reference
 open HistoricalAlternatives (actualHistoryBase)
 
 /-! ### Time-concepts -/
@@ -43,7 +43,7 @@ open HistoricalAlternatives (actualHistoryBase)
     centered-proposition framework (§3 develops it for individuals via
     the acquaintance relation `R₁ : eeiwt`, eq. 12; §4 applies it to
     times). -/
-abbrev TimeConcept (W E P T : Type*) := (KContext W E P T) → T
+abbrev TimeConcept (W E P T : Type*) := (Context W E P T) → T
 
 /-! ### Temporal de re reading -/
 
@@ -60,7 +60,7 @@ structure TemporalDeReReading (W E P T : Type*) where
       [abusch-1997] §7 ULC, `holderContext.time` is the holder's now —
       the perspective time for embedded tense evaluation, *not* the
       outer speaker's speech time. -/
-  holderContext : KContext W E P T
+  holderContext : Context W E P T
 
 namespace TemporalDeReReading
 

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -48,7 +48,7 @@ Sibling of `Tense/Compositional.lean` (the static operators) and
 
 namespace Tense
 
-open Semantics.Context (Index)
+open Reference
 open DynamicSemantics
 open DynamicSemantics.Update (test closure)
 

--- a/Linglib/Semantics/Tense/Pronoun.lean
+++ b/Linglib/Semantics/Tense/Pronoun.lean
@@ -18,7 +18,7 @@ temporal instantiation of `Assignment`; all update laws are mathlib's
 `Function.update` lemmas.
 -/
 
-open Semantics.Context (Index)
+open Reference
 
 namespace Tense
 

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -38,7 +38,7 @@ import Linglib.Semantics.Quantification.Basic
 
 namespace Tense.TenseAspectComposition
 
-open Semantics.Context (Index)
+open Reference
 
 open Aspect
 

--- a/Linglib/Studies/AnandNevins2004.lean
+++ b/Linglib/Studies/AnandNevins2004.lean
@@ -34,14 +34,14 @@ pair verbs with operator options.
 
 namespace AnandNevins2004
 
-open Data.Examples Semantics.Context
+open Data.Examples Reference
 
 variable {W E P T : Type*}
 
 /-! ### Two parameters of the same type -/
 
 /-- Kaplan's context and index, both of context type (§3.1). -/
-abbrev Params (W E P T : Type*) := KContext W E P T × KContext W E P T
+abbrev Params (W E P T : Type*) := Context W E P T × Context W E P T
 
 /-- An expression interpreted relative to the two parameters. -/
 abbrev Expr (W E P T : Type*) (R : Type*) := Params W E P T → R
@@ -77,13 +77,13 @@ def Op.act : Op → Params W E P T → Params W E P T
 
 /-- (23b): an attitude verb quantifies over the indices compatible with the attitude and
 leaves the context parameter untouched. -/
-def attitude (acc : E → KContext W E P T → Set (KContext W E P T)) (x : E)
+def attitude (acc : E → Context W E P T → Set (Context W E P T)) (x : E)
     (φ : Expr W E P T Prop) : Expr W E P T Prop :=
   fun p => ∀ j ∈ acc x p.2, φ (p.1, j)
 
 /-- (26)–(28): with `all` as sister of *say*, the complement is evaluated at the reported
 context alone, so every indexical in it shifts together. -/
-theorem attitude_all (acc : E → KContext W E P T → Set (KContext W E P T)) (x : E)
+theorem attitude_all (acc : E → Context W E P T → Set (Context W E P T)) (x : E)
     (φ : Expr W E P T Prop) (p : Params W E P T) :
     attitude acc x (φ ∘ Op.all.act) p ↔ ∀ j ∈ acc x p.2, φ (j, j) := Iff.rfl
 
@@ -115,16 +115,16 @@ def slaveSay : Entry := [.auth]
 
 /-- The values an expression takes under a report with context `c` and reported context `j`,
 one per operator option. -/
-def readings {R : Type*} (e : Entry) (φ : Expr W E P T R) (c j : KContext W E P T) : List R :=
+def readings {R : Type*} (e : Entry) (φ : Expr W E P T R) (c j : Context W E P T) : List R :=
   e.map fun o => φ (o.act (c, j))
 
 /-- (13): the first and second person under *vano* read from the same context — the two mixed
 pairs are not among the readings. -/
-theorem readings_vano_I_you (c j : KContext W E P T) :
+theorem readings_vano_I_you (c j : Context W E P T) :
     readings vano (fun p => (I p, you p)) c j = [(c.agent, c.addressee), (j.agent, j.addressee)] :=
   rfl
 
-theorem mixed_notMem_readings_vano {c j : KContext W E P T} (ha : c.agent ≠ j.agent)
+theorem mixed_notMem_readings_vano {c j : Context W E P T} (ha : c.agent ≠ j.agent)
     (hb : c.addressee ≠ j.addressee) :
     (c.agent, j.addressee) ∉ readings vano (fun p => (I p, you p)) c j ∧
       (j.agent, c.addressee) ∉ readings vano (fun p => (I p, you p)) c j := by
@@ -132,16 +132,16 @@ theorem mixed_notMem_readings_vano {c j : KContext W E P T} (ha : c.agent ≠ j.
 
 /-- (17), (38b): under Slave SAY the first person is the reported author and the second the
 utterance addressee, obligatorily. -/
-theorem readings_slaveSay (c j : KContext W E P T) :
+theorem readings_slaveSay (c j : Context W E P T) :
     readings slaveSay (fun p => (I p, you p)) c j = [(j.agent, c.addressee)] := rfl
 
 /-- (36): under Slave TELL both persons shift together. -/
-theorem readings_slaveTell (c j : KContext W E P T) :
+theorem readings_slaveTell (c j : Context W E P T) :
     readings slaveTell (fun p => (I p, you p)) c j =
       [(c.agent, c.addressee), (j.agent, j.addressee)] := rfl
 
 /-- (37), (38a): under Slave WANT the first person shifts optionally and the second never. -/
-theorem readings_slaveWant (c j : KContext W E P T) :
+theorem readings_slaveWant (c j : Context W E P T) :
     readings slaveWant (fun p => (I p, you p)) c j =
       [(c.agent, c.addressee), (j.agent, c.addressee)] := rfl
 
@@ -149,24 +149,24 @@ theorem readings_slaveWant (c j : KContext W E P T) :
 
 /-- Overwriting loses the utterance context (§3.4): after `all`, the context no longer depends
 on what it was. -/
-theorem opAll_forgets (c c' j : KContext W E P T) :
+theorem opAll_forgets (c c' j : Context W E P T) :
     (Op.all.act (c, j)).1 = (Op.all.act (c', j)).1 := rfl
 
 /-- Two stacked reports with reported contexts `j₁` (intermediate) and `j₂` (lowest): the
 values of an expression in the lowest clause, one per pair of operator options. -/
-def readings₂ {R : Type*} (e₁ e₂ : Entry) (φ : Expr W E P T R) (c j₁ j₂ : KContext W E P T) :
+def readings₂ {R : Type*} (e₁ e₂ : Entry) (φ : Expr W E P T R) (c j₁ j₂ : Context W E P T) :
     List R :=
   e₁.flatMap fun o₁ => e₂.map fun o₂ => φ (o₂.act ((o₁.act (c, j₁)).1, j₂))
 
 /-- (33): with nothing forcing a shift in the intermediate clause, the lowest first person may
 read the utterance author. -/
-theorem readings₂_vano_I (c j₁ j₂ : KContext W E P T) :
+theorem readings₂_vano_I (c j₁ j₂ : Context W E P T) :
     readings₂ vano vano I c j₁ j₂ = [c.agent, j₂.agent, j₁.agent, j₂.agent] := rfl
 
 /-- (32): a shifted second person in the intermediate clause diagnoses `all` there, after
 which the lowest first person can only be the intermediate or the lowest reported author —
 never the utterance author. -/
-theorem lowerI_of_shifted_you {c j₁ j₂ : KContext W E P T} {o₁ o₂ : Op} (h₁ : o₁ ∈ vano)
+theorem lowerI_of_shifted_you {c j₁ j₂ : Context W E P T} {o₁ o₂ : Op} (h₁ : o₁ ∈ vano)
     (h₂ : o₂ ∈ vano) (hyou : you (o₁.act (c, j₁)) = j₁.addressee)
     (hne : c.addressee ≠ j₁.addressee) :
     I (o₂.act ((o₁.act (c, j₁)).1, j₂)) ∈ [j₁.agent, j₂.agent] := by
@@ -179,7 +179,7 @@ theorem lowerI_of_shifted_you {c j₁ j₂ : KContext W E P T} {o₁ o₂ : Op} 
 
 /-- Whether an operator makes a coordinate read the reported context: the coordinate's value
 after the operator on the distinguishing pair of contexts. -/
-def Op.shifts (o : Op) (coord : KContext Bool Bool Bool Bool → Bool) : Bool :=
+def Op.shifts (o : Op) (coord : Context Bool Bool Bool Bool → Bool) : Bool :=
   coord (o.act (⟨false, false, false, false, false⟩, ⟨true, true, true, true, true⟩)).1
 
 def Entry.ofString? : String → Option Entry
@@ -190,11 +190,11 @@ def Entry.ofString? : String → Option Entry
   | "slave_say" => some slaveSay
   | _ => none
 
-def coordOfString? : String → Option (KContext Bool Bool Bool Bool → Bool)
-  | "I" => some KContext.agent
-  | "you" => some KContext.addressee
-  | "here" => some KContext.position
-  | "now" => some KContext.time
+def coordOfString? : String → Option (Context Bool Bool Bool Bool → Bool)
+  | "I" => some Context.agent
+  | "you" => some Context.addressee
+  | "here" => some Context.position
+  | "now" => some Context.time
   | _ => none
 
 /-- Every recorded reading of a single embedded indexical is available exactly when some

--- a/Linglib/Studies/Heim1994a.lean
+++ b/Linglib/Studies/Heim1994a.lean
@@ -41,7 +41,6 @@ Licensing Condition `TLC` with the definition (67) of "in the domain of" license
 
 namespace Heim1994a
 
-open Semantics.Context (Index)
 open NonemptyInterval
 
 variable {T : Type*} [LinearOrder T]
@@ -106,14 +105,14 @@ and the world–time pairs compatible with a holder's beliefs at a world and tim
 structure Model (V D A W T : Type*) [LinearOrder T] where
   ext : V → NonemptyInterval T → W → Prop
   desc : D → W → NonemptyInterval T
-  dox : A → W → NonemptyInterval T → Set (Index W (NonemptyInterval T))
+  dox : A → W → NonemptyInterval T → Set (Reference.Index W (NonemptyInterval T))
 
 /-- A context: its world and utterance time and the suitable time-concept it supplies (33), a
 function from world–time pairs to times. -/
 structure Context (W T : Type*) [LinearOrder T] where
   world : W
   time : NonemptyInterval T
-  concept : Index W (NonemptyInterval T) → NonemptyInterval T
+  concept : Reference.Index W (NonemptyInterval T) → NonemptyInterval T
 
 variable {V D A W : Type*} (M : Model V D A W T) (c : Context W T)
 
@@ -191,7 +190,8 @@ theorem def_res :
 
 /-- A concept that locates a later time at some alternative, as "the next time the lights go
 out" does, fails the presupposition of (32). -/
-theorem not_def_res_of_precedes {s : Index W (NonemptyInterval T)} (hs : s ∈ M.dox x w (g 1))
+theorem not_def_res_of_precedes {s : Reference.Index W (NonemptyInterval T)}
+    (hs : s ∈ M.dox x w (g 1))
     (h : s.time.precedes (c.concept s)) :
     ¬ Def M c (.believeRes x (.PAST 1) .past (.PAST 2) 3 (.pred v (.trace 3) .nonpast)) g w :=
   λ hd => ((def_res M c x v g w).1 hd).2.2.2 s hs h

--- a/Linglib/Studies/Iatridou2000.lean
+++ b/Linglib/Studies/Iatridou2000.lean
@@ -40,7 +40,7 @@ subjunctive, keeps the past indicative (`antecedent_french`).
 namespace Iatridou2000
 
 open Modality.Exclusion
-open Semantics.Context (KContext ContextTower temporalShift)
+open Reference
 open Mood (subjShift)
 
 /-! ### The exclusion feature -/
@@ -83,7 +83,7 @@ theorem Claim.excludes_situation_iff (c : Claim X) :
 
 /-- The library's exclusion feature on a context tower is the feature at a point-sized topic:
 the innermost coordinate against the origin's. -/
-theorem exclF_iff_excludes {W E P T : Type*} (tower : ContextTower (KContext W E P T)) :
+theorem exclF_iff_excludes {W E P T : Type*} (tower : ContextTower (Context W E P T)) :
     (ExclF .temporal tower ↔ Excludes {tower.innermost.time} {tower.origin.time}) ∧
       (ExclF .modal tower ↔ Excludes {tower.innermost.world} {tower.origin.world}) :=
   ⟨Set.disjoint_singleton.symm, Set.disjoint_singleton.symm⟩
@@ -149,14 +149,14 @@ theorem pastCF_notMem_readings (a : Aktionsart) : .pastCF ∉ readings a := by
 
 /-- The one-feature conditionals: a subjunctive shift alone excludes on worlds and, keeping
 the time, not on times. -/
-theorem one_feature {W E P T : Type*} (c : KContext W E P T) {w' : W} (hw : w' ≠ c.world) :
+theorem one_feature {W E P T : Type*} (c : Context W E P T) {w' : W} (hw : w' ≠ c.world) :
     ExclF .modal ((ContextTower.root c).push (subjShift w' c.time)) ∧
       ¬ ExclF .temporal ((ContextTower.root c).push (subjShift w' c.time)) :=
   ⟨subjShift_produces_modal_exclF c w' c.time hw, λ h => h rfl⟩
 
 /-- The pluperfect's two layers: a subjunctive shift and a temporal shift exclude on both
 dimensions, the past counterfactual. -/
-theorem two_features {W E P T : Type*} (c : KContext W E P T) {w' : W} {t' : T}
+theorem two_features {W E P T : Type*} (c : Context W E P T) {w' : W} {t' : T}
     (hw : w' ≠ c.world) (ht : t' ≠ c.time) :
     ExclF .modal (((ContextTower.root c).push (subjShift w' c.time)).push (temporalShift t')) ∧
       ExclF .temporal

--- a/Linglib/Studies/Klecha2016.lean
+++ b/Linglib/Studies/Klecha2016.lean
@@ -38,7 +38,7 @@ verdicts (`rows_readings`).
 
 namespace Klecha2016
 
-open Tense HistoricalAlternatives Features Semantics.Context English.Predicates.Verbal
+open Tense HistoricalAlternatives Features Reference English.Predicates.Verbal
 
 variable {W T : Type*}
 

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -42,7 +42,7 @@ namespace Levin2026
 
 open Verb
 open Semantics
-open Semantics.Context (Index)
+open Reference
 
 open ArgumentStructure
 open LevinClass (pushPull hit wipe)

--- a/Linglib/Studies/Lewis1973.lean
+++ b/Linglib/Studies/Lewis1973.lean
@@ -31,7 +31,7 @@ treatment of preemption is not represented.
 
 namespace Lewis1973
 
-open Semantics.Context (Index)
+open Reference
 open Causation Causation.Mechanism Causation.SEM
 
 /-- The but-for counterfactual: had the cause not occurred, the effect would not have

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -29,7 +29,7 @@ The dynamic mood and tense operators are `Semantics/Mood/Dynamic` and
 
 namespace Mendes2025
 
-open Semantics.Context (Index)
+open Reference
 open HistoricalAlternatives
 open DynamicSemantics
 open DynamicSemantics.CCP (IsEliminative)

--- a/Linglib/Studies/Mizuno2024.lean
+++ b/Linglib/Studies/Mizuno2024.lean
@@ -48,7 +48,7 @@ namespace Mizuno2024
 open Modality.Exclusion (MarkingStrategy XMarkingExponent)
 open Conditionals (strictImp mem_strictImp_of_subset not_subset_of_mem_strictImp)
 open HistoricalAlternatives (histEquiv_mono)
-open Semantics.Context (Index)
+open Reference
 open Data.Examples (LinguisticExample Glottocode)
 
 /-! ### The per-language strategy record (§2–§4.2) -/

--- a/Linglib/Studies/Ogihara1989.lean
+++ b/Linglib/Studies/Ogihara1989.lean
@@ -23,7 +23,7 @@ open Tense
 
 namespace Ogihara1989
 
-open Semantics.Context
+open Reference
 
 /-- The Priorean `PAST` operator, applied at a referentially determined
     time g(n), decomposes into the conjunction of (1) the referential

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -28,7 +28,7 @@ open Tense
 
 namespace Partee1973
 
-open Semantics.Context
+open Reference
 
 /-- *I didn't turn off the stove*: negation over a past tense that refers to the salient time
 the assignment supplies for variable `n`. -/

--- a/Linglib/Studies/Percus2000.lean
+++ b/Linglib/Studies/Percus2000.lean
@@ -40,7 +40,7 @@ Generalization X from counterfactuals (40) is not formalized.
 
 namespace Percus2000
 
-open Semantics.Context
+open Reference
 
 /-- An assignment of situations to variable indices. -/
 abbrev SituationAssignment (W T : Type*) := Assignment (Index W T)

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -491,7 +491,7 @@ end Discourse
 
 namespace Roberts2023
 
-open Semantics.Context (Index)
+open Reference
 open Discourse (forceLinkingPrinciple defaultSemanticType Scoreboard)
 open Mood.Illocutionary (sincerityCondition)
 open Mood (State Component Illocutionary HasTarget)
@@ -505,7 +505,7 @@ abbrev World := Fin 4
 
 Roberts's "circumstance" ⟨w, t⟩ (eq. 45), SameHistory (47), and FUT
 (48) all instantiate the canonical world-time substrate in
-`Semantics.Context.Index` and `HistoricalAlternatives`:
+`Reference.Index` and `HistoricalAlternatives`:
 
   Roberts                        Linglib substrate
   ────────────────────────────   ────────────────────────────

--- a/Linglib/Studies/SarvasyAikhenvald2025.lean
+++ b/Linglib/Studies/SarvasyAikhenvald2025.lean
@@ -421,7 +421,7 @@ theorem ds_agreement_universal :
 -- Part II: ContextTower Derivation
 -- ============================================================================
 
-open Semantics.Context
+open Reference
 
 -- ============================================================================
 -- § Chain Context Type
@@ -432,7 +432,7 @@ open Semantics.Context
 inductive ChainAgent where | subjectA | subjectB | subjectC
   deriving DecidableEq, Repr
 
-abbrev ChainCtx := KContext Unit ChainAgent Unit ℤ
+abbrev ChainCtx := Context Unit ChainAgent Unit ℤ
 
 /-- The final verb's context: subject A speaking at time 0.
     This is the "root" of the chain — the final verb's TAM values. -/
@@ -498,13 +498,13 @@ theorem medial_has_own_time_2 :
     (`tenseFromFinalVerb = true`). The medial verb inherits tense from
     the final verb's context. -/
 def originTenseAccess : AccessPattern ChainCtx ℤ :=
-  { depth := .origin, project := KContext.time }
+  { depth := .origin, project := Context.time }
 
 /-- Local access pattern: reads tense from the medial verb's own context.
     This models languages like Turkish where medial verbs retain some
     tense distinctions. -/
 def localTenseAccess : AccessPattern ChainCtx ℤ :=
-  { depth := .local, project := KContext.time }
+  { depth := .local, project := Context.time }
 
 /-- In a Nungon-style chain (tenseFromFinalVerb = true), medial verb
     reads final verb's tense (0) via origin access. -/

--- a/Linglib/Studies/Schlenker2003.lean
+++ b/Linglib/Studies/Schlenker2003.lean
@@ -47,7 +47,7 @@ derive logophoric pronouns.
 
 namespace Schlenker2003
 
-open Semantics.Context
+open Reference
 open Doxastic (BoxAt)
 
 variable {W E P T : Type*}
@@ -58,32 +58,32 @@ variable {W E P T : Type*}
     the attitude shift onto the tower and read the innermost context —
     the holder becomes the agent, the accessible world the world, and
     the remaining coordinates are inherited. -/
-def reportedContext (t : ContextTower (KContext W E P T)) (holder : E)
-    (w' : W) : KContext W E P T :=
+def reportedContext (t : ContextTower (Context W E P T)) (holder : E)
+    (w' : W) : Context W E P T :=
   (t.push (attitudeShift holder w')).innermost
 
 @[simp] theorem reportedContext_world
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     (reportedContext t holder w').world = w' := by
   simp [reportedContext, attitudeShift]
 
 @[simp] theorem reportedContext_agent
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     (reportedContext t holder w').agent = holder := by
   simp [reportedContext, attitudeShift]
 
 @[simp] theorem reportedContext_time
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     (reportedContext t holder w').time = t.innermost.time := by
   simp [reportedContext, attitudeShift]
 
 @[simp] theorem reportedContext_position
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     (reportedContext t holder w').position = t.innermost.position := by
   simp [reportedContext, attitudeShift]
 
 @[simp] theorem reportedContext_addressee
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     (reportedContext t holder w').addressee = t.innermost.addressee := by
   simp [reportedContext, attitudeShift]
 
@@ -95,13 +95,13 @@ def reportedContext (t : ContextTower (KContext W E P T)) (holder : E)
     contexts, with the finite `worlds` list as the decidable rendering
     of the quantification (cf. `BoxAt`). -/
 def ContextBox (R : E → W → W → Prop) (holder : E)
-    (φ : KContext W E P T → Prop)
-    (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) : Prop :=
+    (φ : Context W E P T → Prop)
+    (t : ContextTower (Context W E P T)) (w : W) (worlds : List W) : Prop :=
   ∀ w' ∈ worlds, R holder w w' → φ (reportedContext t holder w')
 
 instance (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
-    (holder : E) (φ : KContext W E P T → Prop) [DecidablePred φ]
-    (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
+    (holder : E) (φ : Context W E P T → Prop) [DecidablePred φ]
+    (t : ContextTower (Context W E P T)) (w : W) (worlds : List W) :
     Decidable (ContextBox R holder φ t w worlds) :=
   inferInstanceAs (Decidable (∀ w' ∈ worlds, _))
 
@@ -110,7 +110,7 @@ instance (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     a special case of [schlenker-2003]'s. -/
 theorem contextBox_world_only
     (R : E → W → W → Prop) (holder : E) (p : W → Prop)
-    (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
+    (t : ContextTower (Context W E P T)) (w : W) (worlds : List W) :
     ContextBox R holder (fun c => p c.world) t w worlds ↔
     BoxAt R holder w worlds p := by
   simp only [ContextBox, BoxAt, reportedContext_world]
@@ -122,7 +122,7 @@ theorem contextBox_world_only
 theorem doxastic_holdsAt_iff_contextBox
     (V : Doxastic.DoxasticPredicate W E) (agent : E)
     (p : W → Prop) (w : W) (worlds : List W)
-    (t : ContextTower (KContext W E P T)) :
+    (t : ContextTower (Context W E P T)) :
     V.HoldsAt agent p w worlds ↔
     (Doxastic.VeridicalityHolds V.veridicality p w ∧
      ContextBox V.access agent (fun c => p c.world) t w worlds) := by
@@ -138,8 +138,8 @@ theorem doxastic_holdsAt_iff_contextBox
     tower configuration. It holds of every meaning of a monster-free
     language and fails for the shift-reading meanings of the paper's
     monster-friendly logics (Appendix B). -/
-def SatisfiesFixity (φ : ContextTower (KContext W E P T) → W → Prop) : Prop :=
-  ∀ (t₁ t₂ : ContextTower (KContext W E P T)) (w : W), φ t₁ w ↔ φ t₂ w
+def SatisfiesFixity (φ : ContextTower (Context W E P T) → W → Prop) : Prop :=
+  ∀ (t₁ t₂ : ContextTower (Context W E P T)) (w : W), φ t₁ w ↔ φ t₂ w
 
 /-- World-only meanings satisfy the Fixity Thesis. -/
 theorem fixity_world_only (p : W → Prop) :
@@ -155,7 +155,7 @@ open Reference.Kaplan (pronI_access pronI_shift_invariant)
     `ContextBox` — it resolves to the origin agent (the actual
     speaker), not the attitude holder. -/
 theorem english_I_invariant
-    (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
+    (t : ContextTower (Context W E P T)) (holder : E) (w' : W) :
     pronI_access.resolve (t.push (attitudeShift holder w')) =
     pronI_access.resolve t :=
   pronI_shift_invariant t (attitudeShift holder w')
@@ -174,7 +174,7 @@ inductive Person | alice | bob
 inductive World | w0 | w1
   deriving DecidableEq, Repr
 
-abbrev Ctx := KContext World Person Unit Unit
+abbrev Ctx := Context World Person Unit Unit
 
 /-- Speech-act context: Alice speaking to Bob at world w0. -/
 def speechCtx : Ctx :=

--- a/Linglib/Studies/Schlenker2004a.lean
+++ b/Linglib/Studies/Schlenker2004a.lean
@@ -22,15 +22,14 @@ alone, and replacing the sorted variables by simple ones (`Formula.strip`) prese
 (`realize_strip`) and removes every source of failure (`defined_strip`).
 
 Free Indirect Discourse and the Historical Present are the two ways in which exactly one of the
-two contexts coincides with the actual context (`Mode.of`). In *Tomorrow was Monday* (1), a
-past tense under a Context-of-Thought adverbial is defined only when the thought precedes the
-utterance (`defined_lamPast_iff`), so against a single context the sentence is contradictory
-(`not_defined_lamPast_self`), and Free Indirect Discourse places the character's thought in the
-narrator's past (`freeIndirect_time_lt`). In *Fifty eight years ago ... the Germans attack
-Vercors* (2), a present tense under the adverbial is defined only when the Context of Utterance
-lies fifty-eight years before the Context of Thought (`defined_lamPres_iff`), so the Historical
-Present sets the utterance in the past (`historicalPresent_time_eq`), and a first person pronoun
-in the same passage makes that past context improper (`not_properContext_of_defined`).
+two contexts is the actual one. In *Tomorrow was Monday* (1), a past tense under an adverbial of
+the Context of Thought is defined only when the thought precedes the utterance
+(`defined_lamPast_iff`), so against a single context the sentence is contradictory
+(`not_defined_lamPast_self`) and the two contexts must differ (`ne_of_defined_lamPast`). In
+*Fifty eight years ago ... the Germans attack Vercors* (2), a present tense under the adverbial
+is defined only when the Context of Utterance lies fifty-eight years before the Context of
+Thought (`defined_lamPres_iff`), and a first person pronoun in the same passage makes that past
+context improper (`not_proper_of_defined_lamPres`).
 
 ## Implementation notes
 
@@ -41,9 +40,9 @@ in the same passage makes that past context improper (`not_properContext_of_defi
   `Formula.Realize` is *true*, read with the junk-value convention where the paper leaves truth
   undefined. A λ-abstraction whose argument fails is weird, which the appendix leaves implicit.
 * The rows of `Data/Examples/Schlenker2004a.json` are the paper's (1) and (2); the schemas
-  `lamPast` and `lamPres` are their logical forms with the predicate left open. Banfield's
-  Priority of SPEAKER and the interpretation of gender features are discussed in the paper
-  without a formal proposal and are not formalized.
+  `Formula.lamPast` and `Formula.lamPres` are their logical forms with the predicate left open.
+  Banfield's Priority of SPEAKER and the interpretation of gender features are discussed in the
+  paper without a formal proposal and are not formalized.
 
 ## References
 
@@ -54,7 +53,7 @@ in the same passage makes that past context improper (`not_properContext_of_defi
 
 namespace Schlenker2004a
 
-open Semantics.Context
+open Reference
 open scoped Assignment
 
 /-! ### Terms -/
@@ -108,44 +107,47 @@ def name (a : α) : Term C α := indexical λ _ => a
 @[simp] theorem defined_strip (t : Term C α) : t.strip.Defined s cu := by
   cases t <;> trivial
 
+end Term
+
+variable {W E P T : Type*} {sE : Assignment E} {sT : Assignment T} {c cu ct : Context W E P T}
+  {k : ℕ}
+
 /-! ### The lexicon of (20) and (21)
 
 Pronouns and tenses are sorted variables whose domains are read off the Context of Utterance;
 the remaining indexicals are functions of the Context of Thought. -/
 
-section KContext
-
-variable {W E P T : Type*} {sE : Assignment E} {sT : Assignment T} {c : KContext W E P T}
+namespace Term
 
 /-- First person: an individual variable restricted to the speaker of the Context of
 Utterance. -/
-def I (k : ℕ) : Term (KContext W E P T) E := sorted k λ cu e => e = cu.agent
+def I (k : ℕ) : Term (Context W E P T) E := sorted k λ cu e => e = cu.agent
 
 /-- Second person: an individual variable restricted to the addressee of the Context of
 Utterance. -/
-def you (k : ℕ) : Term (KContext W E P T) E := sorted k λ cu e => e = cu.addressee
+def you (k : ℕ) : Term (Context W E P T) E := sorted k λ cu e => e = cu.addressee
 
 /-- Third person of a `gender`: an individual variable restricted to the individuals of that
 gender, at the time and in the world of the Context of Utterance, who are neither its speaker
 nor its addressee. -/
-def third (gender : E → T → W → Prop) (k : ℕ) : Term (KContext W E P T) E :=
+def third (gender : E → T → W → Prop) (k : ℕ) : Term (Context W E P T) E :=
   sorted k λ cu e => gender e cu.time cu.world ∧ e ≠ cu.agent ∧ e ≠ cu.addressee
 
 /-- Present tense: a time variable restricted to the time of the Context of Utterance. -/
-def pres (k : ℕ) : Term (KContext W E P T) T := sorted k λ cu t => t = cu.time
+def pres (k : ℕ) : Term (Context W E P T) T := sorted k λ cu t => t = cu.time
 
 /-- Past tense: a time variable restricted to the times before the Context of Utterance. -/
-def past [LT T] (k : ℕ) : Term (KContext W E P T) T := sorted k λ cu t => t < cu.time
+def past [LT T] (k : ℕ) : Term (Context W E P T) T := sorted k λ cu t => t < cu.time
 
 /-- A time indexical: `f` applied to the time of the Context of Thought. *Now* is the identity,
 *tomorrow* the day successor, *fifty eight years ago* the subtraction of fifty-eight years. -/
-def timeIndexical (f : T → T) : Term (KContext W E P T) T := indexical λ ct => f ct.time
+def timeIndexical (f : T → T) : Term (Context W E P T) T := indexical λ ct => f ct.time
 
-@[simp] theorem defined_I : (I k : Term (KContext W E P T) E).Defined sE c ↔ sE k = c.agent :=
+@[simp] theorem defined_I : (I k : Term (Context W E P T) E).Defined sE c ↔ sE k = c.agent :=
   Iff.rfl
 
 @[simp] theorem defined_you :
-    (you k : Term (KContext W E P T) E).Defined sE c ↔ sE k = c.addressee :=
+    (you k : Term (Context W E P T) E).Defined sE c ↔ sE k = c.addressee :=
   Iff.rfl
 
 @[simp] theorem defined_third (gender : E → T → W → Prop) :
@@ -153,28 +155,26 @@ def timeIndexical (f : T → T) : Term (KContext W E P T) T := indexical λ ct =
       gender (sE k) c.time c.world ∧ sE k ≠ c.agent ∧ sE k ≠ c.addressee :=
   Iff.rfl
 
-@[simp] theorem defined_pres : (pres k : Term (KContext W E P T) T).Defined sT c ↔ sT k = c.time :=
+@[simp] theorem defined_pres : (pres k : Term (Context W E P T) T).Defined sT c ↔ sT k = c.time :=
   Iff.rfl
 
 @[simp] theorem defined_past [LT T] :
-    (past k : Term (KContext W E P T) T).Defined sT c ↔ sT k < c.time :=
+    (past k : Term (Context W E P T) T).Defined sT c ↔ sT k < c.time :=
   Iff.rfl
 
 @[simp] theorem defined_timeIndexical (f : T → T) :
-    (timeIndexical f : Term (KContext W E P T) T).Defined sT c :=
+    (timeIndexical f : Term (Context W E P T) T).Defined sT c :=
   trivial
 
-@[simp] theorem value_I : (I k : Term (KContext W E P T) E).value sE c = sE k := rfl
-@[simp] theorem value_you : (you k : Term (KContext W E P T) E).value sE c = sE k := rfl
+@[simp] theorem value_I : (I k : Term (Context W E P T) E).value sE c = sE k := rfl
+@[simp] theorem value_you : (you k : Term (Context W E P T) E).value sE c = sE k := rfl
 @[simp] theorem value_third (gender : E → T → W → Prop) : (third gender k).value sE c = sE k := rfl
-@[simp] theorem value_pres : (pres k : Term (KContext W E P T) T).value sT c = sT k := rfl
-@[simp] theorem value_past [LT T] : (past k : Term (KContext W E P T) T).value sT c = sT k := rfl
+@[simp] theorem value_pres : (pres k : Term (Context W E P T) T).value sT c = sT k := rfl
+@[simp] theorem value_past [LT T] : (past k : Term (Context W E P T) T).value sT c = sT k := rfl
 
 @[simp] theorem value_timeIndexical (f : T → T) :
-    (timeIndexical f : Term (KContext W E P T) T).value sT c = f c.time :=
+    (timeIndexical f : Term (Context W E P T) T).value sT c = f c.time :=
   rfl
-
-end KContext
 
 end Term
 
@@ -184,22 +184,19 @@ end Term
 world argument is *actually*; λ-abstraction over an individual or a time variable applied to a
 term; and the Boolean connectives. -/
 inductive Formula (W E P T : Type*)
-  | atom₀ (R : T → W → Prop) (t : Term (KContext W E P T) T)
-  | atom₁ (Q : E → T → W → Prop) (i : Term (KContext W E P T) E) (t : Term (KContext W E P T) T)
-  | lamE (i : Term (KContext W E P T) E) (k : ℕ) (φ : Formula W E P T)
-  | lamT (t : Term (KContext W E P T) T) (k : ℕ) (φ : Formula W E P T)
+  | atom₀ (R : T → W → Prop) (t : Term (Context W E P T) T)
+  | atom₁ (Q : E → T → W → Prop) (i : Term (Context W E P T) E) (t : Term (Context W E P T) T)
+  | lamE (i : Term (Context W E P T) E) (k : ℕ) (φ : Formula W E P T)
+  | lamT (t : Term (Context W E P T) T) (k : ℕ) (φ : Formula W E P T)
   | not (φ : Formula W E P T)
   | and (φ ψ : Formula W E P T)
   | or (φ ψ : Formula W E P T)
 
 namespace Formula
 
-variable {W E P T : Type*} {sE : Assignment E} {sT : Assignment T} {c cu ct : KContext W E P T}
-  {k : ℕ}
-
 /-- Truth at an assignment and a Context of Thought. The Context of Utterance plays no role:
 this signature is the paper's Elimination of the Context of Utterance. -/
-def Realize : Formula W E P T → Assignment E → Assignment T → KContext W E P T → Prop
+def Realize : Formula W E P T → Assignment E → Assignment T → Context W E P T → Prop
   | atom₀ R t, _, sT, ct => R (t.value sT ct) ct.world
   | atom₁ Q i t, sE, sT, ct => Q (i.value sE ct) (t.value sT ct) ct.world
   | lamE i k φ, sE, sT, ct => φ.Realize (sE[k ↦ i.value sE ct]) sT ct
@@ -212,7 +209,7 @@ def Realize : Formula W E P T → Assignment E → Assignment T → KContext W E
 and a Context of Thought: every sorted variable, under the values the abstractions bind, lies
 in its domain at the Context of Utterance. -/
 def Defined : Formula W E P T → Assignment E → Assignment T →
-    KContext W E P T → KContext W E P T → Prop
+    Context W E P T → Context W E P T → Prop
   | atom₀ _ t, _, sT, cu, _ => t.Defined sT cu
   | atom₁ _ i t, sE, sT, cu, _ => i.Defined sE cu ∧ t.Defined sT cu
   | lamE i k φ, sE, sT, cu, ct => i.Defined sE cu ∧ φ.Defined (sE[k ↦ i.value sE ct]) sT cu ct
@@ -246,156 +243,87 @@ theorem realize_strip (φ : Formula W E P T) (sE : Assignment E) (sT : Assignmen
 
 /-- (28c): a past and a present tense under one time abstraction cannot both be defined, so the
 choice of tense in a passage must be consistent. -/
-theorem not_defined_lamT_and_past_pres [Preorder T] (t : Term (KContext W E P T) T)
+theorem not_defined_lamT_and_past_pres [Preorder T] (t : Term (Context W E P T) T)
     (R R' : T → W → Prop) :
-    ¬ (lamT t k (and (atom₀ R (Term.past k)) (atom₀ R' (Term.pres k)))).Defined sE sT cu ct := by
+    ¬ (lamT t k (.and (.atom₀ R (.past k)) (.atom₀ R' (.pres k)))).Defined sE sT cu ct := by
   simp only [Defined, Term.defined_past, Term.defined_pres, Function.update_self]
   rintro ⟨-, hlt, heq⟩
   exact lt_irrefl _ (heq ▸ hlt)
 
-end Formula
-
-/-! ### Narrative modes -/
-
-/-- Which of the two contexts is presented as the actual context: both (ordinary discourse),
-the Context of Utterance alone (Free Indirect Discourse), the Context of Thought alone (the
-Historical Present), or neither (the use of words in a pair of shifted contexts that the
-paper's conclusion likens to quotation). -/
-inductive Mode
-  | ordinary
-  | freeIndirect
-  | historicalPresent
-  | shifted
-  deriving DecidableEq
-
-namespace Mode
-
-variable {W E P T : Type*} [DecidableEq (KContext W E P T)] {c cu ct : KContext W E P T}
-
-/-- The narrative mode of a Context of Utterance `cu` and a Context of Thought `ct` relative to
-the actual context `c`. -/
-def of (c cu ct : KContext W E P T) : Mode :=
-  if cu = c then if ct = c then .ordinary else .freeIndirect
-  else if ct = c then .historicalPresent else .shifted
-
-theorem of_eq_ordinary_iff : of c cu ct = .ordinary ↔ cu = c ∧ ct = c := by
-  unfold of; split_ifs <;> simp [*]
-
-theorem of_eq_freeIndirect_iff : of c cu ct = .freeIndirect ↔ cu = c ∧ ct ≠ c := by
-  unfold of; split_ifs <;> simp [*]
-
-theorem of_eq_historicalPresent_iff : of c cu ct = .historicalPresent ↔ cu ≠ c ∧ ct = c := by
-  unfold of; split_ifs <;> simp [*]
-
-theorem of_eq_shifted_iff : of c cu ct = .shifted ↔ cu ≠ c ∧ ct ≠ c := by
-  unfold of; split_ifs <;> simp [*]
-
-end Mode
-
 /-! ### Free Indirect Discourse: a past tense under an adverbial of the Context of Thought -/
 
-section FreeIndirect
-
-open Formula Term
-
-variable {W E P T : Type*} {sE : Assignment E} {sT : Assignment T} {c cu ct : KContext W E P T}
-  {k : ℕ} {R : T → W → Prop}
+variable {f : T → T} {R : T → W → Prop}
 
 /-- The logical form of (1), *Tomorrow was Monday* (`Examples.ex1`), and of the appendix's
 *Now it was raining*: a time indexical `f` of the Context of Thought abstracted over the time
 argument of a past-tense predication. -/
 def lamPast [LT T] (f : T → T) (R : T → W → Prop) (k : ℕ) : Formula W E P T :=
-  lamT (timeIndexical f) k (atom₀ R (past k))
-
-variable {f : T → T}
+  .lamT (.timeIndexical f) k (.atom₀ R (.past k))
 
 /-- (1) is defined exactly when the adverbial's time precedes the Context of Utterance. -/
 @[simp] theorem defined_lamPast_iff [LT T] :
     (lamPast f R k).Defined sE sT cu ct ↔ f ct.time < cu.time := by
-  simp [lamPast, Formula.Defined]
+  simp [lamPast, Defined]
 
 /-- (1) is true exactly when the predicate holds at the adverbial's time in the world of the
 Context of Thought; the Context of Utterance has been eliminated. -/
 @[simp] theorem realize_lamPast_iff [LT T] :
     (lamPast f R k).Realize sE sT ct ↔ R (f ct.time) ct.world := by
-  simp [lamPast, Formula.Realize]
+  simp [lamPast, Realize]
 
-/-- (9b): against a single context, a past tense under *now* or *tomorrow* is contradictory,
-so Free Indirect Discourse requires two contexts. -/
+/-- (9b): against a single context, a past tense under *now* or *tomorrow* is contradictory. -/
 theorem not_defined_lamPast_self [Preorder T] (hf : ∀ t, t ≤ f t) :
     ¬ (lamPast f R k).Defined sE sT c c := by
   rw [defined_lamPast_iff]
   exact not_lt_of_ge (hf c.time)
 
-/-- A felicitous (1) is not ordinary discourse. -/
-theorem of_ne_ordinary_of_defined_lamPast [Preorder T] [DecidableEq (KContext W E P T)]
-    (hf : ∀ t, t ≤ f t) (hd : (lamPast f R k).Defined sE sT cu ct) :
-    Mode.of c cu ct ≠ .ordinary := by
-  rw [Ne, Mode.of_eq_ordinary_iff]
-  rintro ⟨rfl, rfl⟩
+/-- A felicitous (1) is evaluated against two distinct contexts, the paper's decisive argument
+for the Context of Thought: in Free Indirect Discourse the Context of Utterance is the actual
+one and the character's thought lies in its past, in the Historical Present the Context of
+Thought is the actual one and the utterance is set in the past. -/
+theorem ne_of_defined_lamPast [Preorder T] (hf : ∀ t, t ≤ f t)
+    (hd : (lamPast f R k).Defined sE sT cu ct) : cu ≠ ct := by
+  rintro rfl
   exact not_defined_lamPast_self hf hd
-
-/-- In Free Indirect Discourse the Context of Utterance is the actual context, so (1) places
-the character's thought in the narrator's past. -/
-theorem freeIndirect_time_lt [LT T] [DecidableEq (KContext W E P T)]
-    (h : Mode.of c cu ct = .freeIndirect) (hd : (lamPast f R k).Defined sE sT cu ct) :
-    f ct.time < c.time := by
-  rw [Mode.of_eq_freeIndirect_iff] at h
-  exact h.1 ▸ defined_lamPast_iff.1 hd
-
-end FreeIndirect
 
 /-! ### The Historical Present: a present tense under an adverbial of the Context of Thought -/
 
-section HistoricalPresent
-
-open Formula Term
-
-variable {W E P T : Type*} {sE : Assignment E} {sT : Assignment T} {c cu ct : KContext W E P T}
-  {k : ℕ} {Q : E → T → W → Prop} {i : Term (KContext W E P T) E} {f : T → T}
+variable {Q : E → T → W → Prop} {i : Term (Context W E P T) E}
 
 /-- The logical form of (2), *Fifty eight years ago ... the Germans attack Vercors*
 (`Examples.ex2`): a time indexical `f` of the Context of Thought abstracted over the time
 argument of a present-tense predication of the individual term `i`. -/
-def lamPres (f : T → T) (Q : E → T → W → Prop) (i : Term (KContext W E P T) E) (k : ℕ) :
+def lamPres (f : T → T) (Q : E → T → W → Prop) (i : Term (Context W E P T) E) (k : ℕ) :
     Formula W E P T :=
-  lamT (timeIndexical f) k (atom₁ Q i (pres k))
+  .lamT (.timeIndexical f) k (.atom₁ Q i (.pres k))
 
 /-- (29c): (2) is defined exactly when the individual term is and the Context of Utterance is
 at the adverbial's time. -/
 @[simp] theorem defined_lamPres_iff :
     (lamPres f Q i k).Defined sE sT cu ct ↔ i.Defined sE cu ∧ f ct.time = cu.time := by
-  simp [lamPres, Formula.Defined]
+  simp [lamPres, Defined]
 
 /-- (29c): (2) is true exactly when the predicate holds of the individual at the adverbial's
 time in the world of the Context of Thought. -/
 @[simp] theorem realize_lamPres_iff :
     (lamPres f Q i k).Realize sE sT ct ↔ Q (i.value sE ct) (f ct.time) ct.world := by
-  simp [lamPres, Formula.Realize]
+  simp [lamPres, Realize]
 
 /-- Against a single context, a present tense under an adverbial that moves the time is
 contradictory. -/
 theorem not_defined_lamPres_name_self (hf : ∀ t, f t ≠ t) (a : E) :
-    ¬ (lamPres f Q (name a) k).Defined sE sT c c := by
+    ¬ (lamPres f Q (.name a) k).Defined sE sT c c := by
   simpa using hf c.time
-
-/-- In the Historical Present the Context of Thought is the actual context, so (2) sets the
-Context of Utterance at the adverbial's time in the past. -/
-theorem historicalPresent_time_eq [DecidableEq (KContext W E P T)]
-    (h : Mode.of c cu ct = .historicalPresent) (hd : (lamPres f Q i k).Defined sE sT cu ct) :
-    cu.time = f c.time := by
-  rw [Mode.of_eq_historicalPresent_iff] at h
-  exact h.2 ▸ (defined_lamPres_iff.1 hd).2.symm
 
 /-- The necessity of improper contexts (31): a first person pronoun in the Historical Present
 denotes the speaker of the Context of Utterance, so when that speaker is not alive at its time
 in its world the context is improper in the sense of [kaplan-1989]. -/
-theorem not_properContext_of_defined (alive : E → T → W → Prop) {j : ℕ}
-    (hd : (lamPres f Q (I j) k).Defined sE sT cu ct) (h : ¬ alive (sE j) cu.time cu.world) :
-    ¬ ProperContext cu (alive · cu.time ·) := by
+theorem not_proper_of_defined_lamPres (alive : E → T → W → Prop) {j : ℕ}
+    (hd : (lamPres f Q (.I j) k).Defined sE sT cu ct) (h : ¬ alive (sE j) cu.time cu.world) :
+    ¬ cu.Proper (alive · cu.time ·) := by
   rw [(defined_lamPres_iff.1 hd).1] at h
   exact h
 
-end HistoricalPresent
+end Formula
 
 end Schlenker2004a

--- a/Linglib/Studies/Schlenker2004b.lean
+++ b/Linglib/Studies/Schlenker2004b.lean
@@ -43,9 +43,9 @@ The general-indexicals content of [schlenker-2003] lives at
 ## Derivation Chain
 
 ```
-Semantics.Context.Tower (ContextTower, push, innermost, origin)
+Reference/Context/Tower.lean (ContextTower, push, innermost, origin)
     ↓
-Semantics.Context.Shifts (temporalShift: changes time, preserves agent/world)
+Reference/Context/Shifts.lean (temporalShift: changes time, preserves agent/world)
     ↓
 This file: tower operations produce the Reichenbach frames of the SOT diagnostics
 (matrixSaid, embeddedSickSimultaneous, etc.)
@@ -67,14 +67,14 @@ open Tense
 
 namespace Schlenker2004b
 
-open Semantics.Context
+open Reference
 
 -- ============================================================================
 -- § Tower-Based Tense Model
 -- ============================================================================
 
 /-- A minimal tense context: world, agent, position, and time (as ℤ). -/
-abbrev TenseCtx := KContext Unit Unit Unit ℤ
+abbrev TenseCtx := Context Unit Unit Unit ℤ
 
 /-- The speech-act context: time = 0 (speech time). -/
 def speechCtx : TenseCtx :=
@@ -166,7 +166,7 @@ theorem simultaneous_perspective_match :
     Tower model: the embedded present uses `DepthSpec.origin` for its
     temporal coordinate, reading time = 0 from the origin. -/
 def presentAccess : AccessPattern TenseCtx ℤ :=
-  { depth := .origin, project := KContext.time }
+  { depth := .origin, project := Context.time }
 
 /-- Present-under-past reads speech time (0), not matrix event time (-2). -/
 theorem double_access_reads_speech_time :
@@ -186,7 +186,7 @@ theorem double_access_matches_data :
     the LOCAL (innermost) context. The embedded past tense evaluates its
     reference time relative to the shifted perspective time. -/
 def shiftedAccess : AccessPattern TenseCtx ℤ :=
-  { depth := .local, project := KContext.time }
+  { depth := .local, project := Context.time }
 
 /-- Shifted reading reads matrix event time (-2) from the innermost context. -/
 theorem shifted_reads_matrix_time :
@@ -246,7 +246,7 @@ theorem nested_double_access :
 /-! Substrate-level bridge from [schlenker-2004b]'s tower-shift
     framework to the `TimeConcept` substrate
     (`Semantics/Tense/DeRe.lean`). Both formalisms resolve
-    against the same `KContext` substrate (= `TenseCtx`); the
+    against the same `Context` substrate (= `TenseCtx`); the
     substrate's `IsRigid` predicate distinguishes
     Kaplan-stable readings (Schlenker's `presentAccess`, origin depth)
     from shifted readings (`shiftedAccess`, local depth).

--- a/Linglib/Studies/SchlenkerEtAl2026.lean
+++ b/Linglib/Studies/SchlenkerEtAl2026.lean
@@ -45,7 +45,7 @@ namespace SchlenkerEtAl2026
 
 open Semantics.Iconic
 open Reference.Monsters (IsTowerMonster attitudeShift_is_monster isTowerMonster_congr)
-open Semantics.Context
+open Reference
 open ASL (SigningSpace)
 
 -- ════════════════════════════════════════════════════════════════
@@ -172,7 +172,7 @@ def resolveViewpoint
     viewpoint via `resolveViewpoint`, changing the agent changes what
     π* denotes. -/
 def roleShiftCtx (character : E) (rsWorld : W) :
-    ContextShift (KContext W E P T) where
+    ContextShift (Context W E P T) where
   apply := (attitudeShift (P := P) (T := T) character rsWorld).apply
   label := .roleShift
 
@@ -183,7 +183,7 @@ def roleShiftCtx (character : E) (rsWorld : W) :
     `attitudeShift`'s `apply`, and monsterhood depends only on `apply`. -/
 theorem roleShift_is_monster
     (character : E) (rsWorld : W)
-    (c : KContext W E P T)
+    (c : Context W E P T)
     (hAgent : c.agent ≠ character) :
     IsTowerMonster (roleShiftCtx (P := P) (T := T) character rsWorld) :=
   (isTowerMonster_congr (σ := roleShiftCtx (P := P) (T := T) character rsWorld)

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -37,8 +37,8 @@ the content.
 
 ## Connections
 
-- **Semantics/Context/Tower.lean**: `KContext.agent` = SPEAKER,
-  `KContext.addressee` = HEARER; P-roles resolve through the canonical
+- **Reference/Context/Tower.lean**: `Context.agent` = SPEAKER,
+  `Context.addressee` = HEARER; P-roles resolve through the canonical
   `Discourse.Role.resolve` over a `ContextTower`.
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP is the highest phase.
 - **ExtendedProjection/Basic.lean**: `fValue .SA = 7 > fValue .C = 6`.
@@ -58,7 +58,7 @@ formaliser's modernization.
 namespace SpeasTenny2003
 
 open Minimalist
-open Semantics.Context (KContext ContextTower ContextShift)
+open Reference
 open Mood (Illocutionary ClauseType)
 open Epistemicity
 
@@ -215,22 +215,22 @@ theorem seatOfKnowledge_agrees_with_authority_off_imperative
     reusing the canonical `Discourse.Role.resolve` (which reads from the
     speech-act origin). SEAT OF KNOWLEDGE resolves through its default
     discourse role; use `resolvePRoleInMood` for mood-sensitive resolution. -/
-def resolvePRole {W E P T : Type*} (tower : ContextTower (KContext W E P T)) (r : PRole) : E :=
+def resolvePRole {W E P T : Type*} (tower : ContextTower (Context W E P T)) (r : PRole) : E :=
   Discourse.Role.resolve tower r.toRole
 
 /-- Mood-sensitive role resolution: SEAT OF KNOWLEDGE is resolved through
     `seatOfKnowledge` before mapping to a participant. -/
-def resolvePRoleInMood {W E P T : Type*} (tower : ContextTower (KContext W E P T))
+def resolvePRoleInMood {W E P T : Type*} (tower : ContextTower (Context W E P T))
     (m : SAPMood) : PRole → E
   | .seatOfKnowledge => resolvePRole tower (seatOfKnowledge m)
   | r => resolvePRole tower r
 
 /-- SPEAKER resolves to the speech-act origin's agent. -/
-theorem resolvePRole_speaker {W E P T : Type*} (tower : ContextTower (KContext W E P T)) :
+theorem resolvePRole_speaker {W E P T : Type*} (tower : ContextTower (Context W E P T)) :
     resolvePRole tower .speaker = tower.origin.agent := rfl
 
 /-- HEARER resolves to the speech-act origin's addressee. -/
-theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (KContext W E P T)) :
+theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (Context W E P T)) :
     resolvePRole tower .hearer = tower.origin.addressee := rfl
 
 /-- **Key Claim 4 as a theorem.** P-roles are resolved from the SPEECH-ACT
@@ -238,25 +238,25 @@ theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (KContext W 
     context shift / embedding — inherited from
     `Discourse.Role.resolve_push`. -/
 theorem resolvePRole_shift_invariant {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) (σ : ContextShift (KContext W E P T))
+    (tower : ContextTower (Context W E P T)) (σ : ContextShift (Context W E P T))
     (r : PRole) :
     resolvePRole (tower.push σ) r = resolvePRole tower r := by
   simp only [resolvePRole, Discourse.Role.resolve_push]
 
 /-- In declaratives the seat of knowledge resolves to the speaker (agent). -/
 theorem seatOfKnowledge_declarative_resolves {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
+    (tower : ContextTower (Context W E P T)) :
     resolvePRoleInMood tower .declarative .seatOfKnowledge = tower.origin.agent := rfl
 
 /-- In interrogatives the seat of knowledge resolves to the hearer (addressee). -/
 theorem seatOfKnowledge_interrogative_resolves {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
+    (tower : ContextTower (Context W E P T)) :
     resolvePRoleInMood tower .interrogative .seatOfKnowledge = tower.origin.addressee := rfl
 
 /-- In imperatives the seat of knowledge resolves to the hearer (addressee) —
     the corrected value (p.335), where the hearer realizes the proposition. -/
 theorem seatOfKnowledge_imperative_resolves {W E P T : Type*}
-    (tower : ContextTower (KContext W E P T)) :
+    (tower : ContextTower (Context W E P T)) :
     resolvePRoleInMood tower .imperative .seatOfKnowledge = tower.origin.addressee := rfl
 
 /-! ### SAP as a phase, and the F-hierarchy -/

--- a/Linglib/Studies/StapsRooryck2024.lean
+++ b/Linglib/Studies/StapsRooryck2024.lean
@@ -55,7 +55,7 @@ and `VendlerClass`, connecting to the affectedness hierarchy
 
 namespace StapsRooryck2024
 
-open Semantics.Context (Index)
+open Reference
 
 open Presupposition
 open French.Predicates

--- a/Linglib/Studies/Tay2024.lean
+++ b/Linglib/Studies/Tay2024.lean
@@ -48,7 +48,7 @@ Connects:
 
 namespace Tay2024
 
-open Semantics.Context (Index)
+open Reference
 
 open Causation.Resultatives
 open Morphology

--- a/Linglib/Studies/TsiliaZhao2026.lean
+++ b/Linglib/Studies/TsiliaZhao2026.lean
@@ -37,7 +37,7 @@ tolerates present-under-future.
 namespace TsiliaZhao2026
 
 open Tense Tense.Perspective
-open Semantics.Context (KContext)
+open Reference
 
 /-! ### Shift together -/
 
@@ -183,7 +183,7 @@ theorem past_relative_shift_unique :
 structure InterpParams (W E P T : Type*) where
   /-- Context parameter c = ⟨c_s, c_a, c_t, c_w⟩ — for indexicals
       (I, now, here) -/
-  context : KContext W E P T
+  context : Context W E P T
   /-- Temporal perspective π — for tense (PRES, PAST, ⌈then⌉).
       Defaults to c_t in root clauses; shifted by OP_π under attitude
       verbs. -/
@@ -198,7 +198,7 @@ def InterpParams.shiftPerspective (ip : InterpParams W E P T) (newPi : T) :
 
 /-- OP_c on the interpretation parameter tuple: shift c, preserve π. -/
 def InterpParams.shiftContext (ip : InterpParams W E P T)
-    (newC : KContext W E P T) : InterpParams W E P T :=
+    (newC : Context W E P T) : InterpParams W E P T :=
   { ip with context := newC }
 
 /-- OP_π preserves the context parameter (including c_t): tense shift does
@@ -210,12 +210,12 @@ theorem InterpParams.shiftPerspective_preserves_context
 /-- OP_c preserves the temporal perspective: indexical shift does not entail
     tense shift. -/
 theorem InterpParams.shiftContext_preserves_perspective
-    (ip : InterpParams W E P T) (newC : KContext W E P T) :
+    (ip : InterpParams W E P T) (newC : Context W E P T) :
     (ip.shiftContext newC).perspective = ip.perspective := rfl
 
 /-- In root clauses, π defaults to c_t: the Truth Convention evaluates
     ⟦φ⟧ relative to c and π = c_t. -/
-def InterpParams.rootDefault (c : KContext W E P T) : InterpParams W E P T where
+def InterpParams.rootDefault (c : Context W E P T) : InterpParams W E P T where
   context := c
   perspective := c.time
 

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -120,7 +120,7 @@ The complement type of *believe* shifts from `W → Prop` to
 predicates over `Index W T`, and doxastic alternatives become world–time pairs:
 ⟦x believes p⟧(w,t) = ∀(w',t') ∈ Dox_x(w,t). p(w',t'). -/
 
-open Semantics.Context (Index)
+open Reference
 open Doxastic (Veridicality DoxasticPredicate BoxAt VeridicalityHolds)
 
 variable {W T E : Type*}
@@ -266,8 +266,7 @@ pushing a `temporalShift` onto the tower. -/
 
 section TemporalBridge
 
-open Semantics.Context (KContext ContextTower ContextShift AccessPattern DepthSpec
-  temporalShift)
+open Reference
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
@@ -277,13 +276,13 @@ variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
     embedding's time. Abusch's variable indices ARE tower depth indices for
     the temporal coordinate. -/
 def tensePronounAccessPattern (tp : TensePronoun) :
-    AccessPattern (KContext W E P T) T where
+    AccessPattern (Context W E P T) T where
   depth := .relative tp.evalTimeIndex
-  project := KContext.time
+  project := Context.time
 
 /-- A temporal assignment that faithfully represents a tower: `g k` returns
     the time coordinate at tower depth `k`. -/
-def towerFaithful (g : TemporalAssignment T) (t : ContextTower (KContext W E P T)) : Prop :=
+def towerFaithful (g : TemporalAssignment T) (t : ContextTower (Context W E P T)) : Prop :=
   ∀ (k : ℕ), g k = (t.contextAt k).time
 
 /-- When the temporal assignment encodes tower time coordinates,
@@ -291,7 +290,7 @@ def towerFaithful (g : TemporalAssignment T) (t : ContextTower (KContext W E P T
     the `tensePronounAccessPattern` against the tower. -/
 theorem tense_tower_bridge
     (tp : TensePronoun) (g : TemporalAssignment T)
-    (t : ContextTower (KContext W E P T))
+    (t : ContextTower (Context W E P T))
     (hFaithful : towerFaithful (W := W) (E := E) (P := P) g t) :
     tp.evalTime g = (tensePronounAccessPattern (W := W) (E := E) (P := P) tp).resolve t := by
   simp only [TensePronoun.evalTime, interpTense,
@@ -303,7 +302,7 @@ theorem tense_tower_bridge
     time — root-clause temporal evaluation is origin access, Kaplan's
     thesis for time. -/
 theorem tense_root_bridge
-    (tp : TensePronoun) (c : KContext W E P T)
+    (tp : TensePronoun) (c : Context W E P T)
     (hEval : tp.evalTimeIndex = 0)
     (g : TemporalAssignment T)
     (hFaithful : towerFaithful (W := W) (E := E) (P := P) g (ContextTower.root c)) :
@@ -317,7 +316,7 @@ theorem tense_root_bridge
     resolves to depth 0, the origin. -/
 theorem tensePronounAccessPattern_root_resolves
     (tp : TensePronoun) (hEval : tp.evalTimeIndex = 0)
-    (c : KContext W E P T) :
+    (c : Context W E P T) :
     (tensePronounAccessPattern (W := W) (E := E) (P := P) tp).resolve
       (ContextTower.root c) = c.time := by
   simp only [tensePronounAccessPattern, AccessPattern.resolve, hEval,
@@ -328,14 +327,14 @@ theorem tensePronounAccessPattern_root_resolves
     onto the tower: the updated assignment at the tower depth yields the
     new time. -/
 theorem von_stechow_tower
-    (g : TemporalAssignment T) (t : ContextTower (KContext W E P T))
+    (g : TemporalAssignment T) (t : ContextTower (Context W E P T))
     (newTime : T) :
     updateTemporal g t.depth newTime t.depth = newTime :=
   Function.update_self t.depth newTime g
 
 /-- Under faithful encoding, layers below the push point are preserved. -/
 theorem von_stechow_tower_preserves
-    (g : TemporalAssignment T) (t : ContextTower (KContext W E P T))
+    (g : TemporalAssignment T) (t : ContextTower (Context W E P T))
     (newTime : T)
     (hFaithful : towerFaithful g t)
     (k : ℕ) (hk : k < t.depth) :
@@ -347,7 +346,7 @@ theorem von_stechow_tower_preserves
 /-- Pushing a temporal shift assigns `newTime` to the new depth in
     the extended tower, mirroring `von_stechow_tower` on the assignment side. -/
 theorem von_stechow_tower_innermost
-    (t : ContextTower (KContext W E P T)) (newTime : T) :
+    (t : ContextTower (Context W E P T)) (newTime : T) :
     (t.push (temporalShift newTime)).innermost.time = newTime := by
   rw [ContextTower.push_innermost]
   simp only [temporalShift]


### PR DESCRIPTION
Follow-up to #3314: the Kaplanian context is the main type of `Semantics/Reference/`, so it is named plainly and owned by its program.
- `KContext` becomes `Reference.Context`; the directory-path namespace `Semantics.Context` is dissolved into `Reference` (43 `open` lines swept), `ProperContext`/`LocatedContext` become the dot-members `Context.Proper`/`Context.Located`.
- The two-field `Reference.Basic.Context` is folded into the full type; Kaplan's `pronI` and `pronYou` are now both `indexical` over it.
- `Studies/Schlenker2004a`: `Mode` cut in favour of `ne_of_defined_lamPast`, schemas written with dot constructors, one hoisted `variable` block.