### PR TITLE
refactor(Studies/QingFranke2015): model family on the kernel pipeline

### DIFF
--- a/Linglib/Studies/QingFranke2015.lean
+++ b/Linglib/Studies/QingFranke2015.lean
@@ -1,582 +1,546 @@
-import Linglib.Core.Probability.Scores
-import Linglib.Pragmatics.GriceanMaxims
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Linglib.Pragmatics.RSA.Basic
+import Linglib.Core.Probability.Kernel.Posterior
+import Mathlib.Analysis.Complex.ExponentialBounds
 
 /-!
-# [qing-franke-2015]
-[frank-goodman-2012] [grice-1975] [dale-reiter-1995]
+# Qing and Franke (2015): Variations on a Bayesian Theme
 
-Variations on a Bayesian theme: comparing Bayesian models of referential
-reasoning. In *Bayesian Natural Language Semantics and Pragmatics*, 91–117.
-
-One referential game (green square, green circle, blue circle; Fig. 1) and
-a family of models decomposed along three design dimensions: the speaker's
-goal (belief-oriented log-informativity, eq. 10, vs action-oriented raw
-informativity, eq. 9), the speaker's belief about the literal listener
-(uniform vs salience prior), and the listener's own prior (eqs. 12–13).
-Utterance cost is a constant `c` on adjectives (eq. 11), marginalized over
-`(−0.4, 0.4)` in the paper's model comparison.
-
-## Main results
-
-The belief-oriented chain is stated parametrically in the **cost factor**
-`k = exp(−c)` (`k < 1` ↔ a noun preference `c > 0`), so each prediction
-carries its exact validity region:
-
-* `speaker_prefers_unique_shape` (k < 2) / `speaker_prefers_unique_color`
-  (k > 1/2, i.e. c < ln 2) / `cost_breaks_symmetry` (k < 1) /
-  `no_cost_symmetry` (k = 1): σ_bU matches all three Table-1 directions on
-  the whole noun-preference regime 1/2 < k < 1
-  (`σ_bU_matches_speaker_data`).
-* `salience_reversal_circle` / `salience_reversal_green`: at **every**
-  k > 0, the uniform-prior listener follows pragmatic narrowing while the
-  salience-prior listener follows salience — the reversals are pure prior
-  effects, needing no cost regime at all.
-* `σ_bS_blue_circ_iff` (k vs 139/169) / `σ_bS_green_circ_iff` (k vs
-  101/169): the salience-belief speaker's predictions flip *inside* the
-  paper's cost support — thresholds, not directions, are that model's
-  content.
-* `σ_aU_blue_circ_threshold` (c < 1/2) vs `σ_bU_blue_circ_threshold`
-  (c < ln 2): the goal dimension shifts the blue-circle boundary; the σ_aU
-  tie at c = 1/2 is the boundary case.
-* `beliefGoal_gt_iff` / `actionGoal_gt_iff`: speaker rankings are
-  λ-independent — the paper's rejection of λ = 1 affects fit, not
-  direction.
-* `speakerData_matches_model` / `listenerData_circle_matches_salience` /
-  `listenerData_green_matches_pragmatic`: Tables 1–2, with "green"
-  following the pragmatic direction against salience (p. 212).
-* `zeroCost_beliefGoal_eq`: at zero cost the belief-oriented score is
-  [frank-goodman-2012]'s scoring rule.
-* `cost_is_q2`: the cost dimension is [grice-1975]'s Q2 sub-maxim, which
-  [dale-reiter-1995]'s Incremental Algorithm drops.
+This file formalizes [qing-franke-2015]'s family of models of the referential game of
+[frank-goodman-2012], the rational speech act model decomposed along its design choices (§3):
+the speaker's belief about the literal listener, a uniform prior or the empirically measured
+salience prior; the speaker's goal, the belief-oriented log probability of the referent or the
+action-oriented probability itself; a cost on adjectives (11); and for the listener, its own
+prior and whether it acts on its posterior by a further soft maximization (14). The context is
+the paper's Fig. 3, a square and a circle of one colour and a circle of the other. Speaker
+preference is a threshold on the cost: the speakers that ignore salience prefer the unique word
+at the two objects that have one for every cost within `log 2` of zero in the belief-oriented
+and within `1/2` in the action-oriented model, bounds beyond the paper's cost support of
+`(-0.4, 0.4)`, and prefer the noun at the object with both features shared exactly when nouns
+are cheaper (`belief_blue_lt_iff`, `action_blue_lt_iff`, `belief_shared_lt_iff`), the majority
+directions of Table 1; the salience-belief speaker's threshold at the blue circle,
+`log (169 / 139)`, lies inside the support (`salience_blue_lt_iff`, `salience_threshold_lt`).
+The uniform-prior listener follows pragmatic narrowing on both ambiguous words at every
+rationality
+(`uniform_listener_circle`, `uniform_listener_green`). The salience-prior listener that embeds
+the original speaker follows salience on *circle* below a threshold on the embedded rationality
+and narrowing on *green* only above one (`salience_listener_circle_iff`,
+`salience_listener_green_iff`), the two directions of Table 2; at rationality one it mispredicts
+*green* (`rsa_listener_green`), the model-side face of the paper's rejection of `λ = 1`, and it
+matches both directions on a window of rationalities above one (`salience_listener_window`).
+Acting on the posterior preserves its order (`actionListener_lt_iff`).
 
 ## Implementation notes
 
-At λ = 1 the belief-oriented weight is `L0 · k`, so the chain is rational
-in `k` and every prediction is symbolic algebra over
-`PMF.normalizeOrUniform` — no transcendental atoms; `c` re-enters only
-through the threshold identities (`k = 1/2` ↔ `c = ln 2`).
+The speakers are score speakers over the literal listener's real mass, the action-oriented one
+gated to true words as in the paper's fn. 13, and listeners are posteriors of a speaker against
+a prior. Only the salience condition of Table 2 enters the models, as the salience prior; the
+counts of Tables 1 and 2 are not restated, and the Bayesian model comparison of §5 is not
+formalized.
+
+## References
+
+* [qing-franke-2015]
+* [frank-goodman-2012]
 -/
 
+open MeasureTheory ProbabilityTheory RSA Real
 open scoped ENNReal
-open Real (exp log exp_lt_exp)
 
 namespace QingFranke2015
 
-/-- The three objects in the reference game context (Fig. 1): unique shape,
-unique color, and both features shared. -/
-inductive Object where
-  | green_square | blue_circle | green_circle
-  deriving DecidableEq, Repr, Inhabited, Fintype
+/-! ### The context (Fig. 3) -/
 
-instance : Nonempty Object := ⟨.green_square⟩
+/-- The three objects: the square and the circle sharing a colour, and the circle of the other
+colour. -/
+inductive Object
+  | greenSquare | greenCircle | blueCircle
+  deriving DecidableEq, Fintype, Repr, Inhabited
 
-/-- The four single-word utterances (feature predicates). -/
-inductive Utterance where
-  | square | circle | green | blue
-  deriving DecidableEq, Repr, Inhabited, Fintype
+instance : MeasurableSpace Object := ⊤
+instance : DiscreteMeasurableSpace Object := ⟨λ _ => trivial⟩
+instance : MeasurableSingletonClass Object := DiscreteMeasurableSpace.toMeasurableSingletonClass
 
-instance : Nonempty Utterance := ⟨.square⟩
+/-- The four words. -/
+inductive Word
+  | green | circle | square | blue
+  deriving DecidableEq, Fintype, Repr, Inhabited
 
-/-- Boolean semantics ⟦utterance⟧(object) (Fig. 1b). -/
-def Utterance.appliesTo : Utterance → Object → Bool
-  | .square, .green_square => true
-  | .circle, .blue_circle  => true
-  | .circle, .green_circle => true
-  | .green,  .green_square => true
-  | .green,  .green_circle => true
-  | .blue,   .blue_circle  => true
-  | _, _ => false
+instance : MeasurableSpace Word := ⊤
+instance : DiscreteMeasurableSpace Word := ⟨λ _ => trivial⟩
+instance : MeasurableSingletonClass Word := DiscreteMeasurableSpace.toMeasurableSingletonClass
 
-/-- "square" and "blue" each denote a single object; "circle" and "green"
-are two-ways ambiguous. -/
-theorem extension_characterization (w : Object) :
-    (Utterance.appliesTo .square w = true ↔ w = .green_square) ∧
-    (Utterance.appliesTo .blue w = true ↔ w = .blue_circle) ∧
-    (Utterance.appliesTo .circle w = true ↔ w ≠ .green_square) ∧
-    (Utterance.appliesTo .green w = true ↔ w ≠ .blue_circle) := by
-  cases w <;> decide
+/-- The word describes the object (Fig. 1b). -/
+def Word.AppliesTo : Word → Object → Prop
+  | .green, .greenSquare | .green, .greenCircle | .circle, .greenCircle | .circle, .blueCircle
+  | .square, .greenSquare | .blue, .blueCircle => True
+  | _, _ => False
 
-/-! ### Empirical data (Tables 1–2) -/
+instance : DecidableRel Word.AppliesTo := λ u t => by
+  cases u <;> cases t <;> unfold Word.AppliesTo <;> infer_instance
 
-/-- Speaker production data (Table 1, N = 144 per target). -/
-def speakerData : Object → Utterance → Nat
-  | .green_square, .square => 135
-  | .green_square, .green  => 9
-  | .blue_circle,  .blue   => 119
-  | .blue_circle,  .circle => 25
-  | .green_circle, .circle => 81
-  | .green_circle, .green  => 63
-  | _, _                    => 0
+/-- The extension of a word. -/
+def Word.extension (u : Word) : Set Object := {t | u.AppliesTo t}
 
-/-- Listener comprehension data (Table 2, N = 180 per ambiguous utterance). -/
-def listenerData : Utterance → Object → Nat
-  | .circle, .blue_circle  => 117
-  | .circle, .green_circle => 62
-  | .circle, .green_square => 1
-  | .green,  .green_square => 65
-  | .green,  .green_circle => 115
-  | _, _                    => 0
+instance (u : Word) : DecidablePred (· ∈ u.extension) := λ t =>
+  inferInstanceAs (Decidable (u.AppliesTo t))
 
-/-- Salience prior: the salience condition of Table 2 (N = 240), the
-paper's empirical estimate of `S(t)`. -/
-def saliencePrior : Object → ℝ
-  | .green_square => 71
-  | .blue_circle  => 139
-  | .green_circle => 30
+/-- The cost (11): `c` on the colour adjectives, nothing on the shape nouns. -/
+def Word.cost (c : ℝ) : Word → ℝ
+  | .green | .blue => c
+  | .circle | .square => 0
 
-/-- Uniform prior. -/
-def uniformPrior : Object → ℝ
-  | _ => 1
+/-! ### Priors -/
 
-/-- Speaker data sums to N = 144 per target. -/
-theorem speakerData_consistent :
-    speakerData .green_square .square + speakerData .green_square .green = 144 ∧
-    speakerData .blue_circle .blue + speakerData .blue_circle .circle = 144 ∧
-    speakerData .green_circle .circle + speakerData .green_circle .green = 144 :=
-  ⟨rfl, rfl, rfl⟩
+/-- The prior determined by a weighting of the objects. -/
+noncomputable def priorOf (w : Object → ℕ) : Measure Object :=
+  ∑ t, (w t : ℝ≥0∞) • Measure.dirac t
 
-/-- Listener data sums to N = 180 per ambiguous utterance. -/
-theorem listenerData_consistent :
-    listenerData .circle .blue_circle + listenerData .circle .green_circle
-      + listenerData .circle .green_square = 180 ∧
-    listenerData .green .green_square + listenerData .green .green_circle = 180 :=
-  ⟨rfl, rfl⟩
+@[simp] theorem priorOf_singleton (w : Object → ℕ) (t : Object) : priorOf w {t} = w t :=
+  Measure.sum_smul_dirac_apply_singleton (λ t => (w t : ℝ≥0∞)) t
 
-/-! ### Speaker goal types
+theorem priorOf_apply (w : Object → ℕ) (s : Set Object) [DecidablePred (· ∈ s)] :
+    priorOf w s = ∑ t, if t ∈ s then (w t : ℝ≥0∞) else 0 := by
+  simp only [priorOf, Measure.finsetSum_apply, Measure.smul_apply, smul_eq_mul,
+    Measure.dirac_apply' _ MeasurableSet.of_discrete, Set.indicator_apply, Pi.one_apply, mul_ite,
+    mul_one, mul_zero]
 
-The goal dimension (eqs. 9–10), generic in the literal listener and λ. -/
+instance (w : Object → ℕ) : IsFiniteMeasure (priorOf w) :=
+  ⟨by
+    rw [priorOf_apply w Set.univ]
+    exact ENNReal.sum_lt_top.mpr λ t _ => by simp⟩
 
-/-- Adjective cost (eq. 11): shape words cost 0, color words cost `c`. -/
-noncomputable def adjCost (c : ℝ) : Utterance → ℝ
-  | .square | .circle => 0
-  | .green  | .blue   => c
+/-- The uniform prior `U`. -/
+noncomputable abbrev uniform : Measure Object := priorOf λ _ => 1
 
-/-- Belief-oriented S1 score (eq. 10): `exp (λ (log L0 − Cost))`, gated at
-false utterances (Lean's `log 0 = 0` would otherwise leak mass). -/
-noncomputable def beliefGoalScore (cost : Utterance → ℝ)
-    (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) : ℝ :=
-  if l0 u w = 0 then 0 else exp (α * (log (l0 u w) - cost u))
+/-- The salience condition of Table 2, the paper's estimate of the salience prior `S`. -/
+def salienceCount : Object → ℕ
+  | .greenSquare => 71
+  | .greenCircle => 30
+  | .blueCircle => 139
 
-/-- Action-oriented S1 score (eq. 9): `exp (λ (L0 − Cost))` — positive even
-on false utterances (the paper's fn. 7 restricts comparisons to truthful
-ones). -/
-noncomputable def actionGoalScore (cost : Utterance → ℝ)
-    (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) : ℝ :=
-  exp (α * (l0 u w - cost u))
+/-- The salience prior. -/
+noncomputable abbrev salience : Measure Object := priorOf salienceCount
 
-/-- Belief-oriented ranking is λ-independent: it compares `log L0 − cost`. -/
-theorem beliefGoal_gt_iff (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
-    (u₁ u₂ : Utterance) (w : Object) {α : ℝ} (hα : 0 < α)
-    (h1 : l0 u₁ w ≠ 0) (h2 : l0 u₂ w ≠ 0) :
-    beliefGoalScore cost l0 α w u₁ > beliefGoalScore cost l0 α w u₂ ↔
-    log (l0 u₁ w) - cost u₁ > log (l0 u₂ w) - cost u₂ := by
-  simp only [beliefGoalScore, if_neg h1, if_neg h2]
-  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) hα.le,
-         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
+/-! ### The literal listener and the speakers (§3) -/
 
-/-- Action-oriented ranking is λ-independent: it compares `L0 − cost`. -/
-theorem actionGoal_gt_iff (cost : Utterance → ℝ) (l0 : Utterance → Object → ℝ)
-    (u₁ u₂ : Utterance) (w : Object) {α : ℝ} (hα : 0 < α) :
-    actionGoalScore cost l0 α w u₁ > actionGoalScore cost l0 α w u₂ ↔
-    l0 u₁ w - cost u₁ > l0 u₂ w - cost u₂ := by
-  simp only [actionGoalScore]
-  exact ⟨fun h => lt_of_mul_lt_mul_left (exp_lt_exp.mp h) hα.le,
-         fun h => exp_lt_exp.mpr (mul_lt_mul_of_pos_left h hα)⟩
+/-- The literal listener at a prior (1): the prior conditioned on the word's extension. -/
+noncomputable def L0 (μ : Measure Object) : Kernel Word Object :=
+  literalListener μ λ u => u.extension.indicator 1
 
-/-! ### The belief-oriented chain, parametric in the cost factor
+theorem L0_real_of_mem (w : Object → ℕ) {u : Word} {t : Object} (h : t ∈ u.extension) :
+    (L0 (priorOf w) u).real {t} = (w t : ℝ) / (priorOf w u.extension).toReal := by
+  rw [L0, measureReal_def, literalListener_indicator_apply_singleton _ _ h, ENNReal.toReal_mul,
+    ENNReal.toReal_inv, priorOf_singleton, ENNReal.toReal_natCast, div_eq_inv_mul]
 
-At λ = 1, `exp (log L0 − c) = L0 · exp (−c)`, so the whole σ_b chain is
-rational in the cost factor `k = exp (−c)`: `k = 1` is zero cost, `k < 1`
-a noun preference, and thresholds in `k` translate back to cost bounds
-(`k > 1/2` ↔ `c < ln 2`). -/
+/-- The literal listener at the uniform prior: the reciprocal of the extension's size. -/
+theorem L0_uniform_real_of_mem {u : Word} {t : Object} (h : t ∈ u.extension) :
+    (L0 uniform u).real {t} = 1 / (Finset.univ.filter (· ∈ u.extension)).card := by
+  rw [L0_real_of_mem _ h, priorOf_apply]
+  simp only [Nat.cast_one]
+  rw [← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul, mul_one, ENNReal.toReal_natCast]
 
-/-- Multiplicative cost factor: `1` on shape words, `k` on color words. -/
-def cf (k : ℝ) : Utterance → ℝ
-  | .square | .circle => 1
-  | .green  | .blue   => k
+/-- The literal listener at the salience prior conditions the salience counts. -/
+theorem L0_salience_real_of_mem {u : Word} {t : Object} (h : t ∈ u.extension) :
+    (L0 salience u).real {t} =
+      (salienceCount t : ℝ) /
+        ∑ t' ∈ Finset.univ.filter (· ∈ u.extension), (salienceCount t' : ℝ) := by
+  rw [L0_real_of_mem _ h, priorOf_apply, ← Finset.sum_filter,
+    ENNReal.toReal_sum λ _ _ => ENNReal.natCast_ne_top _]
+  simp only [ENNReal.toReal_natCast]
 
-/-- Literal listener at prior `p` (eq. 1): prior conditioned on the
-extension. -/
-noncomputable def l0 (p : Object → ℝ) (u : Utterance) (w : Object) : ℝ :=
-  (if u.appliesTo w then p w else 0) /
-    ∑ w', if u.appliesTo w' then p w' else 0
+/-- The speaker's goal: the belief-oriented log probability of the referent (10) or the
+action-oriented probability itself (9). -/
+inductive Goal
+  | belief | action
+  deriving DecidableEq, Repr
 
-/-- Belief-oriented speaker weight at λ = 1: `L0 · k^cost`. -/
-noncomputable def sbScore (p : Object → ℝ) (k : ℝ) (w : Object)
-    (u : Utterance) : ℝ :=
-  l0 p u w * cf k u
+/-- The goal's measure of the literal listener's probability of the referent. -/
+noncomputable def Goal.value : Goal → ℝ → ℝ
+  | .belief => log
+  | .action => id
 
-/-- Belief-oriented speaker (eq. 10). -/
-noncomputable def s1 (p : Object → ℝ) (k : ℝ) (w : Object) : PMF Utterance :=
-  PMF.normalizeOrUniform fun u => ENNReal.ofReal (sbScore p k w u)
+/-- The utility of a word at an object: the goal's value of the literal listener's probability
+less the cost, scaled by the rationality; a false word is never used (fn. 13). -/
+noncomputable def score (g : Goal) (μ : Measure Object) (lam c : ℝ) (t : Object) (u : Word) :
+    EReal :=
+  if t ∈ u.extension then ((lam * (g.value ((L0 μ u).real {t}) - u.cost c) : ℝ) : EReal) else ⊥
 
-/-- Pragmatic-listener score (eqs. 12–13): the listener's own prior times
-the σ_bU speaker (the paper's best-supported speaker model). -/
-noncomputable def l1Score (prior : Object → ℝ) (k : ℝ) (u : Utterance)
-    (w : Object) : ℝ :=
-  prior w * (sbScore uniformPrior k w u / ∑ u', sbScore uniformPrior k w u')
+/-- The speaker models `σ_xy` of (9) and (10): the score speaker at goal `x` and belief
+prior `y`. -/
+noncomputable def speaker (g : Goal) (μ : Measure Object) (lam c : ℝ) : Kernel Object Word :=
+  speakerOfScore (score g μ lam c)
 
-/-- Pragmatic listener (eq. 6). -/
-noncomputable def l1 (prior : Object → ℝ) (k : ℝ) (u : Utterance) :
-    PMF Object :=
-  PMF.normalizeOrUniform fun w => ENNReal.ofReal (l1Score prior k u w)
+instance (g : Goal) (μ : Measure Object) (lam c : ℝ) : IsFiniteKernel (speaker g μ lam c) :=
+  inferInstanceAs (IsFiniteKernel (speakerOfScore _))
 
-private theorem sumU (f : Utterance → ℝ) :
-    ∑ u, f u = f .square + f .circle + f .green + f .blue := by
-  rw [show (Finset.univ : Finset Utterance) = {.square, .circle, .green, .blue}
-      from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
+theorem score_ne_top (g : Goal) (μ : Measure Object) (lam c : ℝ) (t : Object) (u : Word) :
+    score g μ lam c t u ≠ ⊤ := by
+  unfold score
+  split
+  · exact EReal.coe_ne_top _
+  · exact bot_ne_top
 
-private theorem sumO (f : Object → ℝ) :
-    ∑ w, f w = f .green_square + f .blue_circle + f .green_circle := by
-  rw [show (Finset.univ : Finset Object)
-      = {.green_square, .blue_circle, .green_circle} from rfl,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_singleton]
-  ring
+theorem score_of_mem (g : Goal) (μ : Measure Object) (lam c : ℝ) {t : Object} {u : Word}
+    (h : t ∈ u.extension) :
+    score g μ lam c t u = ((lam * (g.value ((L0 μ u).real {t}) - u.cost c) : ℝ) : EReal) := by
+  unfold score
+  rw [if_pos h]
 
-section Parametric
+theorem score_ne_bot (g : Goal) (μ : Measure Object) (lam c : ℝ) {t : Object} {u : Word}
+    (h : t ∈ u.extension) : score g μ lam c t u ≠ ⊥ := by
+  rw [score_of_mem g μ lam c h]
+  exact EReal.coe_ne_bot _
 
-variable {k : ℝ}
+theorem score_of_notMem (g : Goal) (μ : Measure Object) (lam c : ℝ) {t : Object} {u : Word}
+    (h : t ∉ u.extension) : score g μ lam c t u = ⊥ := by
+  unfold score
+  rw [if_neg h]
 
-/-- The σ_bU weights, symbolically in k. -/
-private theorem sbScore_values :
-    sbScore uniformPrior k .green_square .square = 1 ∧
-    sbScore uniformPrior k .green_square .green = k/2 ∧
-    sbScore uniformPrior k .green_square .circle = 0 ∧
-    sbScore uniformPrior k .green_square .blue = 0 ∧
-    sbScore uniformPrior k .green_circle .circle = 1/2 ∧
-    sbScore uniformPrior k .green_circle .green = k/2 ∧
-    sbScore uniformPrior k .green_circle .square = 0 ∧
-    sbScore uniformPrior k .green_circle .blue = 0 ∧
-    sbScore uniformPrior k .blue_circle .blue = k ∧
-    sbScore uniformPrior k .blue_circle .circle = 1/2 ∧
-    sbScore uniformPrior k .blue_circle .square = 0 ∧
-    sbScore uniformPrior k .blue_circle .green = 0 := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
-    · simp only [sbScore, l0, cf, uniformPrior, sumO, Utterance.appliesTo]
-      norm_num
-      try ring
+/-- Every object has a true word. -/
+theorem exists_score_ne_bot (g : Goal) (μ : Measure Object) (lam c : ℝ) (t : Object) :
+    ∃ u, score g μ lam c t u ≠ ⊥ := by
+  cases t
+  · exact ⟨.square, score_ne_bot g μ lam c (by decide)⟩
+  · exact ⟨.circle, score_ne_bot g μ lam c (by decide)⟩
+  · exact ⟨.blue, score_ne_bot g μ lam c (by decide)⟩
 
-private theorem sbScore_nonneg (hk : 0 ≤ k) (p : Object → ℝ)
-    (hp : ∀ w, 0 ≤ p w) (w : Object) (u : Utterance) :
-    0 ≤ sbScore p k w u := by
-  refine mul_nonneg (div_nonneg ?_ (Finset.sum_nonneg fun w' _ => ?_)) ?_
-  · split
-    exacts [hp _, le_rfl]
-  · split
-    exacts [hp _, le_rfl]
-  · cases u <;> simp only [cf] <;> first | exact zero_le_one | exact hk
+/-- Speaker preference at an object is utility comparison. -/
+theorem speaker_lt_iff (g : Goal) (μ : Measure Object) (lam c : ℝ) (t : Object) (u u' : Word) :
+    (speaker g μ lam c t).real {u} < (speaker g μ lam c t).real {u'} ↔
+      score g μ lam c t u < score g μ lam c t u' :=
+  speakerOfScore_real_singleton_lt_iff (score_ne_top g μ lam c t)
+    (exists_score_ne_bot g μ lam c t)
 
-/-- Same-target speaker comparison: reduces to the raw weights. -/
-private theorem s1_lt (p : Object → ℝ) (hk : 0 ≤ k) (hp : ∀ w, 0 ≤ p w)
-    {w : Object} {u₁ u₂ : Utterance}
-    (hpos : 0 < ∑ u, sbScore p k w u)
-    (h : sbScore p k w u₁ < sbScore p k w u₂) :
-    s1 p k w u₁ < s1 p k w u₂ := by
-  unfold s1
-  exact PMF.normalizeOrUniform_ofReal_lt_cross (sbScore_nonneg hk p hp w)
-    (sbScore_nonneg hk p hp w) hpos hpos (div_lt_div_of_pos_right h hpos)
+/-- The share of a word at an object with two true words is the logistic function of the utility
+difference. -/
+theorem speaker_real_of_pair (g : Goal) (μ : Measure Object) (lam c : ℝ) {t : Object}
+    {u u' : Word} (huu' : u ≠ u') (hu : t ∈ u.extension) (hu' : t ∈ u'.extension)
+    (hsupp : ∀ v, t ∈ v.extension → v = u ∨ v = u') :
+    (speaker g μ lam c t).real {u} =
+      sigmoid ((score g μ lam c t u).toReal - (score g μ lam c t u').toReal) :=
+  speakerOfScore_real_singleton_of_pair huu' (score_ne_bot g μ lam c hu)
+    (score_ne_bot g μ lam c hu') (score_ne_top g μ lam c t)
+    λ v hv => hsupp v (by
+      by_contra h
+      exact hv (score_of_notMem g μ lam c h))
 
-private theorem l1Score_nonneg (hk : 0 ≤ k) (prior : Object → ℝ)
-    (hp : ∀ w, 0 ≤ prior w) (u : Utterance) (w : Object) :
-    0 ≤ l1Score prior k u w :=
-  mul_nonneg (hp w) (div_nonneg
-    (sbScore_nonneg hk uniformPrior (fun _ => zero_le_one) w u)
-    (Finset.sum_nonneg fun u' _ =>
-      sbScore_nonneg hk uniformPrior (fun _ => zero_le_one) w u'))
+/-! ### Speaker thresholds (Table 1) -/
 
-/-- Same-utterance listener comparison: reduces to the scores. -/
-private theorem l1_lt (prior : Object → ℝ) (hk : 0 ≤ k)
-    (hp : ∀ w, 0 ≤ prior w) {u : Utterance} {w₁ w₂ : Object}
-    (hpos : 0 < ∑ w, l1Score prior k u w)
-    (h : l1Score prior k u w₁ < l1Score prior k u w₂) :
-    l1 prior k u w₁ < l1 prior k u w₂ := by
-  unfold l1
-  exact PMF.normalizeOrUniform_ofReal_lt_cross (l1Score_nonneg hk prior hp u)
-    (l1Score_nonneg hk prior hp u) hpos hpos (div_lt_div_of_pos_right h hpos)
+section Uniform
 
-/-! ### Speaker predictions (Table 1 directions) -/
+private theorem l0u_half {u : Word} {t : Object} (h : t ∈ u.extension)
+    (hc : (Finset.univ.filter (· ∈ u.extension)).card = 2) : (L0 uniform u).real {t} = 1 / 2 := by
+  rw [L0_uniform_real_of_mem h, hc, Nat.cast_ofNat]
 
-/-- For the green square, σ_bU prefers the unique "square" over the
-ambiguous "green" at every cost factor k < 2 (135/144 speakers, Table 1). -/
-theorem speaker_prefers_unique_shape (hk : 0 ≤ k) (hk2 : k < 2) :
-    s1 uniformPrior k .green_square .green <
-      s1 uniformPrior k .green_square .square := by
-  obtain ⟨h1, h2, h3, h4, -⟩ := sbScore_values (k := k)
-  exact s1_lt uniformPrior hk (fun _ => zero_le_one)
-    (by rw [sumU, h1, h2, h3, h4]; linarith) (by rw [h1, h2]; linarith)
+private theorem l0u_one {u : Word} {t : Object} (h : t ∈ u.extension)
+    (hc : (Finset.univ.filter (· ∈ u.extension)).card = 1) : (L0 uniform u).real {t} = 1 := by
+  rw [L0_uniform_real_of_mem h, hc, Nat.cast_one, div_one]
 
-/-- For the blue circle, σ_bU prefers the unique "blue" over "circle" once
-the cost factor exceeds 1/2 (c < ln 2); 119/144 speakers chose "blue". -/
-theorem speaker_prefers_unique_color (hk : 1/2 < k) :
-    s1 uniformPrior k .blue_circle .circle <
-      s1 uniformPrior k .blue_circle .blue := by
-  obtain ⟨-, -, -, -, -, -, -, -, h9, h10, h11, h12⟩ := sbScore_values (k := k)
-  exact s1_lt uniformPrior (by linarith) (fun _ => zero_le_one)
-    (by rw [sumU, h9, h10, h11, h12]; linarith) (by rw [h9, h10]; linarith)
+variable {lam c : ℝ}
 
-/-- For the green circle, cost is the tiebreaker: any noun preference
-(k < 1) favors "circle" over "green" (81 vs 63, Table 1, n.s.). -/
-theorem cost_breaks_symmetry (hk : 0 < k) (hk1 : k < 1) :
-    s1 uniformPrior k .green_circle .green <
-      s1 uniformPrior k .green_circle .circle := by
-  obtain ⟨-, -, -, -, h5, h6, h7, h8, -⟩ := sbScore_values (k := k)
-  exact s1_lt uniformPrior hk.le (fun _ => zero_le_one)
-    (by rw [sumU, h5, h6, h7, h8]; linarith) (by rw [h5, h6]; linarith)
-
-/-- Without cost (k = 1) the green-circle tie is unbroken: Q1 alone cannot
-distinguish two equally informative words. -/
-theorem no_cost_symmetry :
-    sbScore uniformPrior 1 .green_circle .circle =
-      sbScore uniformPrior 1 .green_circle .green := by
-  simp only [sbScore, l0, cf, uniformPrior, sumO, Utterance.appliesTo]
-  norm_num
-
-/-- σ_bU with any noun preference in (1/2, 1) — covering the paper's whole
-positive-cost support c ∈ (0, 0.4] — matches all three Table-1 majority
-directions. -/
-theorem σ_bU_matches_speaker_data (hk : 1/2 < k) (hk1 : k < 1) :
-    (s1 uniformPrior k .green_square .green <
-      s1 uniformPrior k .green_square .square) ∧
-    (s1 uniformPrior k .blue_circle .circle <
-      s1 uniformPrior k .blue_circle .blue) ∧
-    (s1 uniformPrior k .green_circle .green <
-      s1 uniformPrior k .green_circle .circle) :=
-  ⟨speaker_prefers_unique_shape (by linarith) (by linarith),
-   speaker_prefers_unique_color hk, cost_breaks_symmetry (by linarith) hk1⟩
-
-/-! ### Listener predictions: the salience reversal (Tables 2 and 4)
-
-Both listeners embed the same σ_bU speaker and differ only in their prior
-(eqs. 12–13). The reversals hold at **every** k > 0: they are pure prior
-effects, independent of the cost regime. -/
-
-/-- The listener scores at the contested cells, symbolically in k. -/
-private theorem l1Score_values (hk : 0 < k) :
-    l1Score uniformPrior k .circle .green_circle = 1/(1 + k) ∧
-    l1Score uniformPrior k .circle .blue_circle = 1/(1 + 2*k) ∧
-    l1Score saliencePrior k .circle .green_circle = 30/(1 + k) ∧
-    l1Score saliencePrior k .circle .blue_circle = 139/(1 + 2*k) ∧
-    l1Score uniformPrior k .green .green_square = k/(2 + k) ∧
-    l1Score uniformPrior k .green .green_circle = k/(1 + k) ∧
-    l1Score saliencePrior k .green .green_square = 71*k/(2 + k) ∧
-    l1Score saliencePrior k .green .green_circle = 30*k/(1 + k) := by
-  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12⟩ :=
-    sbScore_values (k := k)
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
-    · unfold l1Score
-      rw [sumU]
-      first
-        | rw [h5, h6, h7, h8] | rw [h9, h10, h11, h12] | rw [h1, h2, h3, h4]
-      simp only [uniformPrior, saliencePrior]
-      rw [mul_div_assoc', div_eq_div_iff (by linarith) (by linarith)]
-      ring
-
-/-- Uniform-prior listener, "circle": pragmatic narrowing favors the green
-circle (a blue-circle speaker had "blue"), at every k > 0. -/
-theorem uniform_circle_green_circ (hk : 0 < k) :
-    l1 uniformPrior k .circle .blue_circle <
-      l1 uniformPrior k .circle .green_circle := by
-  obtain ⟨h1, h2, -⟩ := l1Score_values hk
-  have hgs : (0:ℝ) ≤ l1Score uniformPrior k .circle .green_square :=
-    l1Score_nonneg hk.le _ (fun _ => zero_le_one) _ _
-  refine l1_lt uniformPrior hk.le (fun _ => zero_le_one) ?_ ?_
-  · rw [sumO, h1, h2]
-    have : (0:ℝ) < 1/(1 + k) := by positivity
-    have : (0:ℝ) < 1/(1 + 2*k) := by positivity
-    linarith
-  · rw [h1, h2, div_lt_div_iff₀ (by linarith) (by linarith)]
-    linarith
-
-/-- Salience-prior listener, "circle": salience (139 vs 30) overrides the
-pragmatic direction, at every k > 0. Matches Table 2 (117/180 blue). -/
-theorem salience_circle_blue_circ (hk : 0 < k) :
-    l1 saliencePrior k .circle .green_circle <
-      l1 saliencePrior k .circle .blue_circle := by
-  obtain ⟨-, -, h3, h4, -⟩ := l1Score_values hk
-  have hp : ∀ w, 0 ≤ saliencePrior w := by
-    intro w; cases w <;> simp [saliencePrior]
-  have hgs : (0:ℝ) ≤ l1Score saliencePrior k .circle .green_square :=
-    l1Score_nonneg hk.le _ hp _ _
-  refine l1_lt saliencePrior hk.le hp ?_ ?_
-  · rw [sumO, h3, h4]
-    have : (0:ℝ) < 30/(1 + k) := by positivity
-    have : (0:ℝ) < 139/(1 + 2*k) := by positivity
-    linarith
-  · rw [h3, h4, div_lt_div_iff₀ (by linarith) (by linarith)]
-    nlinarith
-
-/-- Finding 5: the salience reversal for "circle", at every k > 0. The
-human data follow the salience direction. -/
-theorem salience_reversal_circle (hk : 0 < k) :
-    (l1 uniformPrior k .circle .blue_circle <
-      l1 uniformPrior k .circle .green_circle) ∧
-    (l1 saliencePrior k .circle .green_circle <
-      l1 saliencePrior k .circle .blue_circle) :=
-  ⟨uniform_circle_green_circ hk, salience_circle_blue_circ hk⟩
-
-/-- Uniform-prior listener, "green": pragmatic narrowing favors the green
-circle (a green-square speaker had "square"), at every k > 0. -/
-theorem uniform_green_green_circ (hk : 0 < k) :
-    l1 uniformPrior k .green .green_square <
-      l1 uniformPrior k .green .green_circle := by
-  obtain ⟨-, -, -, -, h5, h6, -⟩ := l1Score_values hk
-  have hbc : (0:ℝ) ≤ l1Score uniformPrior k .green .blue_circle :=
-    l1Score_nonneg hk.le _ (fun _ => zero_le_one) _ _
-  refine l1_lt uniformPrior hk.le (fun _ => zero_le_one) ?_ ?_
-  · rw [sumO, h5, h6]
-    have : (0:ℝ) < k/(2 + k) := by positivity
-    have : (0:ℝ) < k/(1 + k) := by positivity
-    linarith
-  · rw [h5, h6, div_lt_div_iff₀ (by linarith) (by linarith)]
-    nlinarith
-
-/-- Salience-prior listener, "green": salience (71 vs 30) overrides the
-pragmatic direction, at every k > 0. Here the humans go the *other* way
-(115/180 green circle, Table 2; p. 212). -/
-theorem salience_green_green_sq (hk : 0 < k) :
-    l1 saliencePrior k .green .green_circle <
-      l1 saliencePrior k .green .green_square := by
-  obtain ⟨-, -, -, -, -, -, h7, h8⟩ := l1Score_values hk
-  have hp : ∀ w, 0 ≤ saliencePrior w := by
-    intro w; cases w <;> simp [saliencePrior]
-  have hbc : (0:ℝ) ≤ l1Score saliencePrior k .green .blue_circle :=
-    l1Score_nonneg hk.le _ hp _ _
-  refine l1_lt saliencePrior hk.le hp ?_ ?_
-  · rw [sumO, h7, h8]
-    have : (0:ℝ) < 71*k/(2 + k) := by positivity
-    have : (0:ℝ) < 30*k/(1 + k) := by positivity
-    linarith
-  · rw [h7, h8, div_lt_div_iff₀ (by linarith) (by linarith)]
-    nlinarith
-
-/-- Finding 6: the salience reversal for "green", at every k > 0. The human
-data follow the *pragmatic* direction — no single listener prior gets both
-"circle" and "green" right. -/
-theorem salience_reversal_green (hk : 0 < k) :
-    (l1 uniformPrior k .green .green_square <
-      l1 uniformPrior k .green .green_circle) ∧
-    (l1 saliencePrior k .green .green_circle <
-      l1 saliencePrior k .green .green_square) :=
-  ⟨uniform_green_green_circ hk, salience_green_green_sq hk⟩
-
-/-! ### The salience-belief speaker: thresholds inside the cost support
-
-σ_bS replaces the speaker's literal-listener prior with the salience data
-(eq. 7). Its blue-circle and green-circle predictions flip at k = 139/169
-and k = 101/169 — both *inside* the paper's cost support (c ∈ (0, 0.4) is
-k ∈ (0.67, 1)) — so that model's content is a pair of thresholds, not
-directions. -/
-
-/-- σ_bS weights at the contested cells: `L0` conditions the salience
-prior on the extension. -/
-private theorem sbS_values :
-    sbScore saliencePrior k .blue_circle .blue = k ∧
-    sbScore saliencePrior k .blue_circle .circle = 139/169 ∧
-    sbScore saliencePrior k .green_circle .green = 30/101 * k ∧
-    sbScore saliencePrior k .green_circle .circle = 30/169 := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;>
-    · simp only [sbScore, l0, cf, saliencePrior, sumO, Utterance.appliesTo]
-      norm_num
-
-/-- σ_bS prefers "blue" at the blue circle iff k > 139/169. -/
-theorem σ_bS_blue_circ_iff :
-    sbScore saliencePrior k .blue_circle .circle <
-      sbScore saliencePrior k .blue_circle .blue ↔ 139/169 < k := by
-  obtain ⟨h1, h2, -⟩ := sbS_values (k := k)
-  rw [h1, h2]
-
-/-- σ_bS prefers "green" at the green circle iff k > 101/169. -/
-theorem σ_bS_green_circ_iff :
-    sbScore saliencePrior k .green_circle .circle <
-      sbScore saliencePrior k .green_circle .green ↔ 101/169 < k := by
-  obtain ⟨-, -, h3, h4⟩ := sbS_values (k := k)
-  rw [h3, h4]
+/-- The belief-oriented speaker prefers the unique *blue* to the ambiguous *circle* at the blue
+circle exactly when the adjective costs less than `log 2`. -/
+theorem belief_blue_lt_iff (hlam : 0 < lam) :
+    (speaker .belief uniform lam c .blueCircle).real {.circle}
+      < (speaker .belief uniform lam c .blueCircle).real {.blue} ↔ c < log 2 := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_one (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, one_div, log_inv, log_one]
   constructor <;> intro h <;> nlinarith
 
-end Parametric
+/-- It prefers the unique *square* to *green* at the green square exactly when the adjective
+costs more than `-log 2`. -/
+theorem belief_square_lt_iff (hlam : 0 < lam) :
+    (speaker .belief uniform lam c .greenSquare).real {.green}
+      < (speaker .belief uniform lam c .greenSquare).real {.square} ↔ -log 2 < c := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_one (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, one_div, log_inv, log_one]
+  constructor <;> intro h <;> nlinarith
 
-/-! ### Cost thresholds across the goal dimension
+/-- At the object with both features shared the two words are equally informative, and the
+noun wins exactly when it is cheaper. -/
+theorem belief_shared_lt_iff (hlam : 0 < lam) :
+    (speaker .belief uniform lam c .greenCircle).real {.green}
+      < (speaker .belief uniform lam c .greenCircle).real {.circle} ↔ 0 < c := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_half (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost]
+  constructor <;> intro h <;> nlinarith
 
-The blue-circle boundary separates the goal types: action-oriented scoring
-flips at c = 1/2, belief-oriented at c = ln 2 ≈ 0.693 — the log transform
-amplifies informativity differences, widening the viable cost range.
-Figure 3's posterior over c peaks well below both. -/
+/-- The action-oriented speaker's threshold at the blue circle is `1/2`. -/
+theorem action_blue_lt_iff (hlam : 0 < lam) :
+    (speaker .action uniform lam c .blueCircle).real {.circle}
+      < (speaker .action uniform lam c .blueCircle).real {.blue} ↔ c < 1 / 2 := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_one (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, id]
+  constructor <;> intro h <;> nlinarith
 
-/-- σ_aU threshold: "blue" > "circle" at the blue circle iff c < 1/2; the
-σ_aU tie at c = 1/2 is the boundary case. -/
-theorem σ_aU_blue_circ_threshold
-    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
-    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2) :
-    actionGoalScore (adjCost c) l0 α .blue_circle .blue >
-    actionGoalScore (adjCost c) l0 α .blue_circle .circle ↔ c < 1/2 := by
-  rw [actionGoal_gt_iff _ _ _ _ _ hα]
-  simp only [hbl, hci, adjCost]
-  constructor <;> intro h <;> linarith
+/-- Its threshold at the green square is `-1/2`. -/
+theorem action_square_lt_iff (hlam : 0 < lam) :
+    (speaker .action uniform lam c .greenSquare).real {.green}
+      < (speaker .action uniform lam c .greenSquare).real {.square} ↔ -(1 / 2) < c := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_one (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, id]
+  constructor <;> intro h <;> nlinarith
 
-/-- σ_bU threshold: "blue" > "circle" at the blue circle iff c < ln 2 —
-the exponentiated form of `speaker_prefers_unique_color`'s k > 1/2. -/
-theorem σ_bU_blue_circ_threshold
-    {l0 : Utterance → Object → ℝ} {c : ℝ} {α : ℝ} (hα : 0 < α)
-    (hbl : l0 .blue .blue_circle = 1) (hci : l0 .circle .blue_circle = 1/2)
-    (hbl_ne : l0 .blue .blue_circle ≠ 0) (hci_ne : l0 .circle .blue_circle ≠ 0) :
-    beliefGoalScore (adjCost c) l0 α .blue_circle .blue >
-    beliefGoalScore (adjCost c) l0 α .blue_circle .circle ↔ c < log 2 := by
-  rw [beliefGoal_gt_iff _ _ _ _ _ hα hbl_ne hci_ne]
-  simp only [hbl, hci, adjCost, Real.log_one]
-  have hlog : log ((1:ℝ) / 2) = -log 2 := by rw [one_div, Real.log_inv]
-  rw [hlog]
-  constructor <;> intro h <;> linarith
+/-- At the shared object the action-oriented speaker too follows the sign of the cost. -/
+theorem action_shared_lt_iff (hlam : 0 < lam) :
+    (speaker .action uniform lam c .greenCircle).real {.green}
+      < (speaker .action uniform lam c .greenCircle).real {.circle} ↔ 0 < c := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0u_half (by decide) (by decide), l0u_half (by decide) (by decide), EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, id]
+  constructor <;> intro h <;> nlinarith
 
-/-! ### Data–model match -/
+end Uniform
 
-/-- Speaker majority choices match the σ_bU rankings (Table 1). -/
-theorem speakerData_matches_model :
-    speakerData .green_square .square > speakerData .green_square .green ∧
-    speakerData .blue_circle .blue > speakerData .blue_circle .circle ∧
-    speakerData .green_circle .circle > speakerData .green_circle .green :=
-  ⟨by decide, by decide, by decide⟩
+/-- Both thresholds for the unique words lie beyond the paper's cost support `(-0.4, 0.4)`. -/
+theorem support_lt_thresholds : (0.4 : ℝ) < 1 / 2 ∧ (1 / 2 : ℝ) < log 2 :=
+  ⟨by norm_num, by linarith [log_two_gt_d9]⟩
 
-/-- For "circle", the listener majority follows the salience direction
-(117 vs 62). -/
-theorem listenerData_circle_matches_salience :
-    listenerData .circle .blue_circle > listenerData .circle .green_circle := by
-  decide
+section Salience
 
-/-- For "green", the listener majority follows the pragmatic direction, not
-salience (115 vs 65; p. 212). -/
-theorem listenerData_green_matches_pragmatic :
-    listenerData .green .green_circle > listenerData .green .green_square := by
-  decide
+private theorem l0s_circle_blueCircle :
+    (L0 salience .circle).real {.blueCircle} = (169 / 139)⁻¹ := by
+  rw [L0_salience_real_of_mem (by decide),
+    show Finset.univ.filter (· ∈ Word.circle.extension) = {.greenCircle, .blueCircle} by decide,
+    Finset.sum_pair (by decide)]
+  simp only [salienceCount, Nat.cast_ofNat]
+  norm_num
 
-/-! ### Bridges -/
+private theorem l0s_blue_blueCircle : (L0 salience .blue).real {.blueCircle} = 1 := by
+  rw [L0_salience_real_of_mem (by decide),
+    show Finset.univ.filter (· ∈ Word.blue.extension) = {.blueCircle} by decide,
+    Finset.sum_singleton]
+  simp only [salienceCount, Nat.cast_ofNat]
+  norm_num
 
-/-- At zero cost the belief-oriented score is [frank-goodman-2012]'s
-scoring rule — σ_bU generalizes FG2012 by the cost dimension. -/
-theorem zeroCost_beliefGoal_eq
-    (l0 : Utterance → Object → ℝ) (α : ℝ) (w : Object) (u : Utterance) :
-    beliefGoalScore (fun _ => (0 : ℝ)) l0 α w u =
-    if l0 u w = 0 then 0 else exp (α * log (l0 u w)) := by
-  simp [beliefGoalScore, sub_zero]
+private theorem l0s_circle_greenCircle :
+    (L0 salience .circle).real {.greenCircle} = 30 / 101 * (169 / 101)⁻¹ := by
+  rw [L0_salience_real_of_mem (by decide),
+    show Finset.univ.filter (· ∈ Word.circle.extension) = {.greenCircle, .blueCircle} by decide,
+    Finset.sum_pair (by decide)]
+  simp only [salienceCount, Nat.cast_ofNat]
+  norm_num
 
-open Pragmatics.GriceanMaxims in
-/-- The cost dimension is [grice-1975]'s Q2 sub-maxim (brevity): without
-cost the equally-informative words tie (Q1 alone cannot break it), any
-noun preference breaks it, and zero cost drops brevity as
-[dale-reiter-1995]'s Incremental Algorithm does, independently of Q1. -/
-theorem cost_is_q2 :
-    (sbScore uniformPrior 1 .green_circle .circle =
-      sbScore uniformPrior 1 .green_circle .green) ∧
-    (∀ k : ℝ, 0 < k → k < 1 →
-      s1 uniformPrior k .green_circle .green <
-        s1 uniformPrior k .green_circle .circle) ∧
-    QuantityViolation.underInformative.submaxim ≠
-    QuantityViolation.overInformative.submaxim :=
-  ⟨no_cost_symmetry, fun _ hk hk1 => cost_breaks_symmetry hk hk1,
-   violations_independent⟩
+private theorem l0s_green_greenCircle : (L0 salience .green).real {.greenCircle} = 30 / 101 := by
+  rw [L0_salience_real_of_mem (by decide),
+    show Finset.univ.filter (· ∈ Word.green.extension) = {.greenSquare, .greenCircle} by decide,
+    Finset.sum_pair (by decide)]
+  simp only [salienceCount, Nat.cast_ofNat]
+  norm_num
+
+variable {lam c : ℝ}
+
+/-- The salience-belief speaker (7) prefers *blue* to *circle* at the blue circle exactly when the
+adjective costs less than `log (169 / 139)`. -/
+theorem salience_blue_lt_iff (hlam : 0 < lam) :
+    (speaker .belief salience lam c .blueCircle).real {.circle}
+      < (speaker .belief salience lam c .blueCircle).real {.blue} ↔ c < log (169 / 139) := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0s_circle_blueCircle, l0s_blue_blueCircle, EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost, log_inv, log_one]
+  constructor <;> intro h <;> nlinarith
+
+/-- At the shared object it prefers the adjective *green* for every cost below
+`log (169 / 101)`, the whole of the paper's support. -/
+theorem salience_shared_lt_iff (hlam : 0 < lam) :
+    (speaker .belief salience lam c .greenCircle).real {.circle}
+      < (speaker .belief salience lam c .greenCircle).real {.green} ↔ c < log (169 / 101) := by
+  rw [speaker_lt_iff, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    l0s_circle_greenCircle, l0s_green_greenCircle, EReal.coe_lt_coe_iff]
+  simp only [Goal.value, Word.cost]
+  rw [log_mul (by norm_num) (by norm_num), log_inv]
+  constructor <;> intro h <;> nlinarith
+
+end Salience
+
+/-- The salience-belief speaker's threshold lies inside the paper's cost support. -/
+theorem salience_threshold_lt : log (169 / 139) < (0.4 : ℝ) := by
+  rw [log_lt_iff_lt_exp (by norm_num)]
+  linarith [add_one_lt_exp (by norm_num : (0.4 : ℝ) ≠ 0)]
+
+/-! ### Listeners (§3), (12) to (15) -/
+
+/-- The belief-oriented listener (15): the posterior of a speaker against the listener's prior. -/
+noncomputable def listener (ν : Measure Object) [IsFiniteMeasure ν] (σ : Kernel Object Word)
+    [IsFiniteKernel σ] : Kernel Word Object :=
+  σ†ν
+
+/-- The action-oriented listener (14): the soft maximization of a posterior. -/
+noncomputable def actionListener (lamL : ℝ) (ρ : Kernel Word Object) : Kernel Word Object :=
+  speakerOfScore λ u t => ((lamL * (ρ u).real {t} : ℝ) : EReal)
+
+/-- Acting on the posterior preserves its order. -/
+theorem actionListener_lt_iff {lamL : ℝ} (hlamL : 0 < lamL) (ρ : Kernel Word Object) (u : Word)
+    (t t' : Object) :
+    (actionListener lamL ρ u).real {t} < (actionListener lamL ρ u).real {t'} ↔
+      (ρ u).real {t} < (ρ u).real {t'} := by
+  rw [actionListener, speakerOfScore_real_singleton_lt_iff
+    (score := λ u t => ((lamL * (ρ u).real {t} : ℝ) : EReal)) (w := u)
+    (λ _ => EReal.coe_ne_top _) ⟨t, EReal.coe_ne_bot _⟩, EReal.coe_lt_coe_iff]
+  constructor <;> intro h <;> nlinarith
+
+/-- Listener preference between two objects is prior-weighted speaker preference. -/
+theorem listener_lt_iff (ν : Measure Object) [IsFiniteMeasure ν] (σ : Kernel Object Word)
+    [IsFiniteKernel σ] {u : Word} (hu : (σ ∘ₘ ν) {u} ≠ 0) (t t' : Object) :
+    (listener ν σ u).real {t} < (listener ν σ u).real {t'} ↔
+      ν.real {t} * (σ t).real {u} < ν.real {t'} * (σ t').real {u} := by
+  have h := posterior_real_finset_lt_iff σ ν hu {t} {t'}
+  simp only [Finset.coe_singleton, Finset.sum_singleton] at h
+  exact h
+
+section BeliefUniform
+
+variable {lam c : ℝ}
+
+private theorem supp_blueCircle (v : Word) (hv : Object.blueCircle ∈ v.extension) :
+    v = .circle ∨ v = .blue := by
+  cases v <;> simp_all [Word.extension, Word.AppliesTo]
+
+private theorem supp_greenCircle (v : Word) (hv : Object.greenCircle ∈ v.extension) :
+    v = .green ∨ v = .circle := by
+  cases v <;> simp_all [Word.extension, Word.AppliesTo]
+
+private theorem supp_greenSquare (v : Word) (hv : Object.greenSquare ∈ v.extension) :
+    v = .green ∨ v = .square := by
+  cases v <;> simp_all [Word.extension, Word.AppliesTo]
+
+/-- The share of *circle* at the blue circle under the original speaker. -/
+theorem circle_at_blueCircle :
+    (speaker .belief uniform lam c .blueCircle).real {.circle} = sigmoid (lam * (c - log 2)) := by
+  rw [speaker_real_of_pair _ _ _ _ (u := .circle) (u' := .blue) (by decide) (by decide) (by decide)
+      supp_blueCircle, score_of_mem _ _ _ _ (by decide), score_of_mem _ _ _ _ (by decide),
+    EReal.toReal_coe, EReal.toReal_coe, l0u_half (by decide) (by decide),
+    l0u_one (by decide) (by decide)]
+  simp only [Goal.value, Word.cost, one_div, log_inv, log_one]
+  ring_nf
+
+/-- The share of *circle* at the green circle. -/
+theorem circle_at_greenCircle :
+    (speaker .belief uniform lam c .greenCircle).real {.circle} = sigmoid (lam * c) := by
+  rw [speaker_real_of_pair _ _ _ _ (u := .circle) (u' := .green) (by decide) (by decide)
+      (by decide) (λ v hv => (supp_greenCircle v hv).symm), score_of_mem _ _ _ _ (by decide),
+    score_of_mem _ _ _ _ (by decide), EReal.toReal_coe, EReal.toReal_coe,
+    l0u_half (by decide) (by decide), l0u_half (by decide) (by decide)]
+  simp only [Goal.value, Word.cost]
+  ring_nf
+
+/-- The share of *green* at the green square. -/
+theorem green_at_greenSquare :
+    (speaker .belief uniform lam c .greenSquare).real {.green} =
+      sigmoid (lam * (-log 2 - c)) := by
+  rw [speaker_real_of_pair _ _ _ _ (u := .green) (u' := .square) (by decide) (by decide)
+      (by decide) supp_greenSquare, score_of_mem _ _ _ _ (by decide),
+    score_of_mem _ _ _ _ (by decide), EReal.toReal_coe, EReal.toReal_coe,
+    l0u_half (by decide) (by decide), l0u_one (by decide) (by decide)]
+  simp only [Goal.value, Word.cost, one_div, log_inv, log_one]
+  ring_nf
+
+/-- The share of *green* at the green circle. -/
+theorem green_at_greenCircle :
+    (speaker .belief uniform lam c .greenCircle).real {.green} = sigmoid (-(lam * c)) := by
+  rw [speaker_real_of_pair _ _ _ _ (u := .green) (u' := .circle) (by decide) (by decide)
+      (by decide) supp_greenCircle, score_of_mem _ _ _ _ (by decide),
+    score_of_mem _ _ _ _ (by decide), EReal.toReal_coe, EReal.toReal_coe,
+    l0u_half (by decide) (by decide), l0u_half (by decide) (by decide)]
+  simp only [Goal.value, Word.cost]
+  ring_nf
+
+/-- Every word is heard with positive probability under the original speaker at any prior with
+positive mass everywhere. -/
+theorem comp_speaker_ne_zero (w : Object → ℕ) (hw : ∀ t, w t ≠ 0) (u : Word) :
+    (speaker .belief uniform lam c ∘ₘ priorOf w) {u} ≠ 0 := by
+  have key : ∀ t, t ∈ u.extension → (speaker .belief uniform lam c ∘ₘ priorOf w) {u} ≠ 0 :=
+    λ t ht => comp_apply_singleton_ne_zero _ _ (by rw [priorOf_singleton]; exact_mod_cast hw t)
+      (speakerOfScore_apply_singleton_ne_zero (score_ne_bot _ _ _ _ ht) (score_ne_top _ _ _ _ t))
+  cases u
+  · exact key .greenSquare (by decide)
+  · exact key .greenCircle (by decide)
+  · exact key .greenSquare (by decide)
+  · exact key .blueCircle (by decide)
+
+/-- The uniform-prior listener hearing *circle* prefers the green circle: a blue-circle speaker
+had *blue*. -/
+theorem uniform_listener_circle (hlam : 0 < lam) :
+    (listener uniform (speaker .belief uniform lam c) .circle).real {.blueCircle}
+      < (listener uniform (speaker .belief uniform lam c) .circle).real {.greenCircle} := by
+  rw [listener_lt_iff _ _ (comp_speaker_ne_zero _ (λ _ => one_ne_zero) _), circle_at_blueCircle,
+    circle_at_greenCircle, measureReal_def, measureReal_def, priorOf_singleton, priorOf_singleton]
+  simp only [Nat.cast_one, ENNReal.toReal_one, one_mul]
+  exact sigmoid_lt (by nlinarith [log_pos (by norm_num : (1 : ℝ) < 2)])
+
+/-- Hearing *green* it prefers the green circle: a green-square speaker had *square*. -/
+theorem uniform_listener_green (hlam : 0 < lam) :
+    (listener uniform (speaker .belief uniform lam c) .green).real {.greenSquare}
+      < (listener uniform (speaker .belief uniform lam c) .green).real {.greenCircle} := by
+  rw [listener_lt_iff _ _ (comp_speaker_ne_zero _ (λ _ => one_ne_zero) _), green_at_greenSquare,
+    green_at_greenCircle, measureReal_def, measureReal_def, priorOf_singleton, priorOf_singleton]
+  simp only [Nat.cast_one, ENNReal.toReal_one, one_mul]
+  exact sigmoid_lt (by nlinarith [log_pos (by norm_num : (1 : ℝ) < 2)])
+
+private theorem exp_shift (lam c : ℝ) :
+    exp (-(lam * (c - log 2))) = exp (-(lam * c)) * (2 : ℝ) ^ lam := by
+  rw [rpow_def_of_pos (by norm_num), ← exp_add]
+  congr 1
+  ring
+
+private theorem exp_shift' (lam c : ℝ) :
+    exp (-(lam * (-log 2 - c))) = exp (lam * c) * (2 : ℝ) ^ lam := by
+  rw [rpow_def_of_pos (by norm_num), ← exp_add]
+  congr 1
+  ring
+
+/-- The salience-prior listener hearing *circle* prefers the salient blue circle, the direction of
+Table 2, exactly when `30 (1 + e^{-λc} 2^λ) < 139 (1 + e^{-λc})`. -/
+theorem salience_listener_circle_iff :
+    (listener salience (speaker .belief uniform lam c) .circle).real {.greenCircle}
+      < (listener salience (speaker .belief uniform lam c) .circle).real {.blueCircle} ↔
+      30 * (1 + exp (-(lam * c)) * (2 : ℝ) ^ lam) < 139 * (1 + exp (-(lam * c))) := by
+  rw [listener_lt_iff _ _ (comp_speaker_ne_zero _ (by decide) _), circle_at_blueCircle,
+    circle_at_greenCircle, measureReal_def, measureReal_def, priorOf_singleton, priorOf_singleton]
+  simp only [salienceCount, Nat.cast_ofNat, ENNReal.toReal_ofNat, sigmoid_def, exp_shift]
+  have hx := exp_pos (-(lam * c))
+  have hy : (0 : ℝ) < (2 : ℝ) ^ lam := rpow_pos_of_pos (by norm_num) _
+  rw [← div_eq_mul_inv, ← div_eq_mul_inv, div_lt_div_iff₀ (by positivity) (by positivity)]
+
+/-- Hearing *green* it prefers the green circle, again the direction of Table 2, exactly when
+`71 (1 + e^{λc}) < 30 (1 + e^{λc} 2^λ)`. -/
+theorem salience_listener_green_iff :
+    (listener salience (speaker .belief uniform lam c) .green).real {.greenSquare}
+      < (listener salience (speaker .belief uniform lam c) .green).real {.greenCircle} ↔
+      71 * (1 + exp (lam * c)) < 30 * (1 + exp (lam * c) * (2 : ℝ) ^ lam) := by
+  rw [listener_lt_iff _ _ (comp_speaker_ne_zero _ (by decide) _), green_at_greenSquare,
+    green_at_greenCircle, measureReal_def, measureReal_def, priorOf_singleton, priorOf_singleton]
+  simp only [salienceCount, Nat.cast_ofNat, ENNReal.toReal_ofNat, sigmoid_def, exp_shift',
+    neg_neg]
+  have hx := exp_pos (lam * c)
+  have hy : (0 : ℝ) < (2 : ℝ) ^ lam := rpow_pos_of_pos (by norm_num) _
+  rw [← div_eq_mul_inv, ← div_eq_mul_inv, div_lt_div_iff₀ (by positivity) (by positivity)]
+
+end BeliefUniform
+
+/-- The original model `ρ_bS(σ_bU)` at rationality one and no cost mispredicts *green*: the
+salient green square wins. -/
+theorem rsa_listener_green :
+    ¬ (listener salience (speaker .belief uniform 1 0) .green).real {.greenSquare}
+      < (listener salience (speaker .belief uniform 1 0) .green).real {.greenCircle} := by
+  rw [salience_listener_green_iff]
+  norm_num
+
+/-- Without cost, the salience listener matches both directions of Table 2 exactly on the window
+`112/30 < 2^λ < 248/30` of embedded rationalities. -/
+theorem salience_listener_window (lam : ℝ) :
+    ((listener salience (speaker .belief uniform lam 0) .circle).real {.greenCircle}
+        < (listener salience (speaker .belief uniform lam 0) .circle).real {.blueCircle} ∧
+      (listener salience (speaker .belief uniform lam 0) .green).real {.greenSquare}
+        < (listener salience (speaker .belief uniform lam 0) .green).real {.greenCircle}) ↔
+      112 / 30 < (2 : ℝ) ^ lam ∧ (2 : ℝ) ^ lam < 248 / 30 := by
+  rw [salience_listener_circle_iff, salience_listener_green_iff]
+  simp only [mul_zero, neg_zero, exp_zero, one_mul]
+  constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
 
 end QingFranke2015

--- a/references.bib
+++ b/references.bib
@@ -1262,7 +1262,7 @@
   doi       = {10.1016/0364-0213(95)90018-7},
   subfield  = {pragmatics},
   role      = {formalized},
-  sources   = {Studies/DaleReiter1995.lean;Studies/QingFranke2015.lean;Studies/WesterbeekKoolenMaes2015.lean}
+  sources   = {Studies/DaleReiter1995.lean;Studies/WesterbeekKoolenMaes2015.lean}
 }
 @article{dambrosio-hedden-2024,
   author    = {D'Ambrosio, Justin and Hedden, Brian},
@@ -9475,7 +9475,7 @@
   subfield  = {semantics/modality},
   role      = {cited},
   validated = {true},
-  sources   = {Pragmatics/GriceanMaxims.lean;Pragmatics/Implicature/Diagnostics.lean;Studies/AhnKocabDavidson2026.lean;Studies/DaleReiter1995.lean;Studies/EngelhardtEtAl2006.lean;Studies/QingFranke2015.lean}
+  sources   = {Pragmatics/GriceanMaxims.lean;Pragmatics/Implicature/Diagnostics.lean;Studies/AhnKocabDavidson2026.lean;Studies/DaleReiter1995.lean;Studies/EngelhardtEtAl2006.lean}
 }% REF: Grove, J. (2022). Presupposition projection as a scope phenomenon.
 @article{grove-2022,
   author    = {Grove, Julian},


### PR DESCRIPTION
Cleanse of Qing and Franke (2015): the belief/action × uniform/salience speaker family and the belief/action listeners as `RSA.speakerOfScore` kernels and posteriors, with the paper's qualitative predictions as threshold theorems symbolic in the rationality and cost.
- speaker thresholds `log 2`, `1/2`, `log (169/139)` located relative to the paper's cost support; the salience listener's `λ = 1` failure on *green* and the rationality window matching both Table 2 directions
- drops the PMF chain, the count-data checks, and the editorial Gricean bridge