### PR TITLE
feat(Semantics/Reference): ContextLike and Kaplan's tenets

### DIFF
--- a/Linglib/Semantics/Reference/Context/Basic.lean
+++ b/Linglib/Semantics/Reference/Context/Basic.lean
@@ -17,10 +17,16 @@ which validates *I am here now*. The world and time of a context form its index 
 shift to an alternative situation that keeps the agent fixed, used to quantify a concept
 across a believer's alternatives.
 
+Contexts may also be taken as primitive, with functions returning their coordinates
+[schlenker-2011]: a type is *context-like* when it maps to the canonical tuple
+(`ContextLike`), on the pattern of `SetLike` and `FunLike`, and the indexical lexicon and
+Kaplan's tenets are stated for any such type. `Context` itself is the terminal instance.
+
 ## References
 
 * [kaplan-1989]
 * [speas-tenny-2003]
+* [schlenker-2011]
 -/
 
 namespace Reference
@@ -65,5 +71,42 @@ variable (s : Index W T)
 @[simp] theorem shiftWorldTime_toIndex : (c.shiftWorldTime s).toIndex = s := rfl
 
 end Context
+
+/-- A type whose elements carry the coordinates of a context of utterance, through a map to
+the canonical tuple. -/
+class ContextLike (C : Type*) (W E P T : outParam Type*) where
+  /-- The context an element determines. -/
+  toContext : C → Context W E P T
+
+namespace ContextLike
+
+variable {C W E P T : Type*} [ContextLike C W E P T]
+
+instance : ContextLike (Context W E P T) W E P T := ⟨id⟩
+
+@[simp] theorem toContext_self (c : Context W E P T) : toContext c = c := rfl
+
+/-- The agent of a context-like element. -/
+def agent (c : C) : E := (toContext c).agent
+
+/-- The addressee of a context-like element. -/
+def addressee (c : C) : E := (toContext c).addressee
+
+/-- The world of a context-like element. -/
+def world (c : C) : W := (toContext c).world
+
+/-- The time of a context-like element. -/
+def time (c : C) : T := (toContext c).time
+
+/-- The position of a context-like element. -/
+def position (c : C) : P := (toContext c).position
+
+@[simp] theorem agent_context (c : Context W E P T) : agent c = c.agent := rfl
+@[simp] theorem addressee_context (c : Context W E P T) : addressee c = c.addressee := rfl
+@[simp] theorem world_context (c : Context W E P T) : world c = c.world := rfl
+@[simp] theorem time_context (c : Context W E P T) : time c = c.time := rfl
+@[simp] theorem position_context (c : Context W E P T) : position c = c.position := rfl
+
+end ContextLike
 
 end Reference

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -7,11 +7,19 @@ import Linglib.Semantics.Reference.Character
 import Linglib.Semantics.Reference.Context.Shifts
 
 /-!
-# Pure indexicals and monsters
+# Kaplan's theory of indexicality
 
-The English pure indexicals of [kaplan-1989] read a coordinate of the speech-act context:
-as access patterns on the context tower they are `AccessPattern.origin` of a coordinate
-(`Kaplan.I`, `Kaplan.you`, `Kaplan.now`, `Kaplan.here`, `Kaplan.actually`), hence invariant
+The three tenets of [kaplan-1989] as [schlenker-2011] states them. Interpretation is
+relativized to a context, so a sentence's character holds at a context when its content is
+true at that context's world (`Character.HoldsAt`), and a character is *a priori* when it
+holds at every context (`Character.IsAPriori`) and *necessary* when its content is true at
+every world (`Character.IsNecessary`); the two come apart because contexts are finer than
+worlds, and on a type whose contexts are all proper (`ContextLike.Proper`) *I exist* is a
+priori (`isAPriori_exists_agent`) without being necessary (`not_isNecessary_exists_agent`),
+as is *I am here now* on a located type (`isAPriori_located_agent`). The English pure
+indexicals read a coordinate of the speech-act context: as access patterns on the context
+tower they are `AccessPattern.origin` of a coordinate (`Kaplan.I`, `Kaplan.you`,
+`Kaplan.now`, `Kaplan.here`, `Kaplan.actually`), for any context-like type, hence invariant
 under every embedding shift (`AccessPattern.stable_origin`), which is Kaplan's thesis for
 English. An access pattern is a character over towers with rigid content
 (`AccessPattern.toCharacter`), and an origin pattern at a root tower is `Character.dthat` of
@@ -30,6 +38,7 @@ speaker (`ContextShift.isMonster_attitudeShift`).
 ## References
 
 * [kaplan-1989]
+* [schlenker-2011]
 * [schlenker-2003]
 * [anand-nevins-2004]
 -/
@@ -37,6 +46,68 @@ speaker (`ContextShift.isMonster_attitudeShift`).
 namespace Reference
 
 variable {C R W E P T : Type*}
+
+/-! ### A priori and necessary truth -/
+
+namespace Character
+
+variable [ContextLike C W E P T]
+
+/-- A character holds at a context when its content is true at the world of that context:
+the evaluation of a root sentence. -/
+def HoldsAt (χ : Character C W Prop) (c : C) : Prop := χ c (ContextLike.world c)
+
+/-- A character is a priori when it holds at every context. -/
+def IsAPriori (χ : Character C W Prop) : Prop := ∀ c, χ.HoldsAt c
+
+/-- A character is necessary when its content is true at every world of every context. -/
+def IsNecessary (χ : Character C W Prop) : Prop := ∀ (c : C) (w : W), χ c w
+
+theorem IsNecessary.isAPriori {χ : Character C W Prop} (h : χ.IsNecessary) : χ.IsAPriori :=
+  λ c => h c _
+
+end Character
+
+/-- A context-like type is proper for an existence predicate when the agent of every element
+exists at its world: Kaplan's coherence constraint on contexts. -/
+class ContextLike.Proper (C : Type*) {W E P T : Type*} [ContextLike C W E P T]
+    (exists_ : E → W → Prop) : Prop where
+  proper : ∀ c : C, (ContextLike.toContext c).Proper exists_
+
+/-- A context-like type is located for a location predicate when the agent of every element
+is at its position at its time in its world. -/
+class ContextLike.Located (C : Type*) {W E P T : Type*} [ContextLike C W E P T]
+    (located : E → P → T → W → Prop) : Prop where
+  located : ∀ c : C, (ContextLike.toContext c).Located located
+
+section Tenets
+
+variable [ContextLike C W E P T] (exists_ : E → W → Prop) (located : E → P → T → W → Prop)
+
+/-- The character of *I exist*: the agent of the context exists at the world of evaluation. -/
+def Kaplan.existsAgent : Character C W Prop := λ c w => exists_ (ContextLike.agent c) w
+
+/-- The character of *I am here now*: the agent of the context is at its position at its
+time in the world of evaluation. -/
+def Kaplan.locatedAgent : Character C W Prop :=
+  λ c w => located (ContextLike.agent c) (ContextLike.position c) (ContextLike.time c) w
+
+/-- *I exist* is a priori on a proper type. -/
+theorem isAPriori_exists_agent [ContextLike.Proper C exists_] :
+    (Kaplan.existsAgent (C := C) exists_).IsAPriori :=
+  ContextLike.Proper.proper
+
+/-- *I exist* is not necessary once some agent fails to exist at some world. -/
+theorem not_isNecessary_exists_agent {c : C} {w : W} (h : ¬ exists_ (ContextLike.agent c) w) :
+    ¬ (Kaplan.existsAgent (C := C) exists_).IsNecessary :=
+  λ hn => h (hn c w)
+
+/-- *I am here now* is a priori on a located type. -/
+theorem isAPriori_located_agent [ContextLike.Located C located] :
+    (Kaplan.locatedAgent (C := C) located).IsAPriori :=
+  ContextLike.Located.located
+
+end Tenets
 
 /-! ### Monsters -/
 
@@ -121,20 +192,22 @@ theorem ContextShift.isMonster_iff_not_stable_innermost_id (σ : ContextShift C)
 
 namespace Kaplan
 
+variable [ContextLike C W E P T]
+
 /-- *I*: the agent of the speech-act context. -/
-def I : AccessPattern (Context W E P T) E := .origin Context.agent
+def I : AccessPattern C E := .origin ContextLike.agent
 
 /-- *you*: the addressee of the speech-act context. -/
-def you : AccessPattern (Context W E P T) E := .origin Context.addressee
+def you : AccessPattern C E := .origin ContextLike.addressee
 
 /-- *now*: the time of the speech-act context. -/
-def now : AccessPattern (Context W E P T) T := .origin Context.time
+def now : AccessPattern C T := .origin ContextLike.time
 
 /-- *here*: the position of the speech-act context. -/
-def here : AccessPattern (Context W E P T) P := .origin Context.position
+def here : AccessPattern C P := .origin ContextLike.position
 
 /-- *actually*: the world of the speech-act context. -/
-def actually : AccessPattern (Context W E P T) W := .origin Context.world
+def actually : AccessPattern C W := .origin ContextLike.world
 
 end Kaplan
 

--- a/references.bib
+++ b/references.bib
@@ -10471,6 +10471,23 @@
   validated = {true},
   sources   = {Studies/Schlenker2004b.lean}
 }
+@incollection{schlenker-2011,
+  author    = {Schlenker, Philippe},
+  year      = {2011},
+  title     = {Indexicality and De Se Reports},
+  booktitle = {Semantics: An International Handbook of Natural Language Meaning},
+  editor    = {von Heusinger, Klaus and Maienborn, Claudia and Portner, Paul},
+  volume    = {2},
+  series    = {Handb{\"u}cher zur Sprach- und Kommunikationswissenschaft},
+  number    = {33.2},
+  pages     = {1561--1604},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  subfield  = {semantics/reference},
+  role      = {cited},
+  validated = {true},
+  sources   = {Semantics/Reference/Context/Basic.lean;Semantics/Reference/Kaplan.lean}
+}
 @article{schlenker-2004a,
   author    = {Schlenker, Philippe},
   year      = {2004},


### PR DESCRIPTION
Contexts taken as primitive, in mathlib's `-Like` shape (follow-up to #3323).
- `ContextLike C W E P T` maps a type to the canonical `Context` tuple, on the pattern of `SetLike`/`FunLike`, with derived coordinate projections and `Context` as the terminal instance; the English pure indexicals `Kaplan.I`, `you`, `now`, `here`, `actually` are now access patterns on any context-like type (Schlenker 2003's `rfl` proofs go through the instance unchanged).
- Kaplan's tenets as [schlenker-2011] states them: `Character.HoldsAt` (root evaluation at the context's world), `IsAPriori` and `IsNecessary`, the classes `ContextLike.Proper` and `ContextLike.Located` for Kaplan's coherence constraints, and the theorems that *I exist* is a priori on a proper type but not necessary, and *I am here now* a priori on a located type.
- Bib entry `schlenker-2011` (the handbook chapter; no DOI recorded).