### PR TITLE
refactor(Semantics/Reference): tenets over projections, ContextLike out

### DIFF
--- a/Linglib/Semantics/Reference/Context/Basic.lean
+++ b/Linglib/Semantics/Reference/Context/Basic.lean
@@ -18,9 +18,8 @@ shift to an alternative situation that keeps the agent fixed, used to quantify a
 across a believer's alternatives.
 
 Contexts may also be taken as primitive, with functions returning their coordinates
-[schlenker-2011]: a type is *context-like* when it maps to the canonical tuple
-(`ContextLike`), on the pattern of `SetLike` and `FunLike`, and the indexical lexicon and
-Kaplan's tenets are stated for any such type. `Context` itself is the terminal instance.
+[schlenker-2011]: Kaplan's tenets in `Reference/Kaplan.lean` take the coordinate projections
+as arguments, and `Context` supplies them.
 
 ## References
 
@@ -71,42 +70,5 @@ variable (s : Index W T)
 @[simp] theorem shiftWorldTime_toIndex : (c.shiftWorldTime s).toIndex = s := rfl
 
 end Context
-
-/-- A type whose elements carry the coordinates of a context of utterance, through a map to
-the canonical tuple. -/
-class ContextLike (C : Type*) (W E P T : outParam Type*) where
-  /-- The context an element determines. -/
-  toContext : C → Context W E P T
-
-namespace ContextLike
-
-variable {C W E P T : Type*} [ContextLike C W E P T]
-
-instance : ContextLike (Context W E P T) W E P T := ⟨id⟩
-
-@[simp] theorem toContext_self (c : Context W E P T) : toContext c = c := rfl
-
-/-- The agent of a context-like element. -/
-def agent (c : C) : E := (toContext c).agent
-
-/-- The addressee of a context-like element. -/
-def addressee (c : C) : E := (toContext c).addressee
-
-/-- The world of a context-like element. -/
-def world (c : C) : W := (toContext c).world
-
-/-- The time of a context-like element. -/
-def time (c : C) : T := (toContext c).time
-
-/-- The position of a context-like element. -/
-def position (c : C) : P := (toContext c).position
-
-@[simp] theorem agent_context (c : Context W E P T) : agent c = c.agent := rfl
-@[simp] theorem addressee_context (c : Context W E P T) : addressee c = c.addressee := rfl
-@[simp] theorem world_context (c : Context W E P T) : world c = c.world := rfl
-@[simp] theorem time_context (c : Context W E P T) : time c = c.time := rfl
-@[simp] theorem position_context (c : Context W E P T) : position c = c.position := rfl
-
-end ContextLike
 
 end Reference

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -9,31 +9,31 @@ import Linglib.Semantics.Reference.Context.Shifts
 /-!
 # Kaplan's theory of indexicality
 
-The three tenets of [kaplan-1989] as [schlenker-2011] states them. Interpretation is
-relativized to a context, so a sentence's character holds at a context when its content is
-true at that context's world (`Character.HoldsAt`), and a character is *a priori* when it
-holds at every context (`Character.IsAPriori`) and *necessary* when its content is true at
-every world (`Character.IsNecessary`); the two come apart because contexts are finer than
-worlds, and on a type whose contexts are all proper (`ContextLike.Proper`) *I exist* is a
-priori (`isAPriori_exists_agent`) without being necessary (`not_isNecessary_exists_agent`),
-as is *I am here now* on a located type (`isAPriori_located_agent`). The English pure
-indexicals read a coordinate of the speech-act context: as access patterns on the context
-tower they are `AccessPattern.origin` of a coordinate (`Kaplan.I`, `Kaplan.you`,
-`Kaplan.now`, `Kaplan.here`, `Kaplan.actually`), for any context-like type, hence invariant
-under every embedding shift (`AccessPattern.stable_origin`), which is Kaplan's thesis for
+The three tenets of [kaplan-1989] as [schlenker-2011] states them, over any context type with its
+coordinates given as projections. Interpretation is relativized to a context, so a sentence's
+character holds at a context when its content is true at that context's world (`Character.HoldsAt`),
+and a character is *a priori* when it holds at every context (`Character.IsAPriori`) and *necessary*
+when its content is true at every world (`Character.IsNecessary`); the two come apart because
+contexts are finer than worlds: when every context is proper, its agent existing at its world, *I
+exist* is a priori (`Kaplan.isAPriori_existsAgent`) without being necessary
+(`Kaplan.not_isNecessary_existsAgent`), and when every context is located *I am here now* is a
+priori (`Kaplan.isAPriori_locatedAgent`). The English pure indexicals read a coordinate of the
+speech-act context: as access patterns on the context tower they are `AccessPattern.origin` of a
+coordinate (`Kaplan.I`, `Kaplan.you`, `Kaplan.now`, `Kaplan.here`, `Kaplan.actually`), hence
+invariant under every embedding shift (`AccessPattern.stable_origin`), which is Kaplan's thesis for
 English. An access pattern is a character over towers with rigid content
-(`AccessPattern.toCharacter`), and an origin pattern at a root tower is `Character.dthat` of
-its coordinate (`AccessPattern.origin_toCharacter_root`): the tower analysis at depth zero is
-Kaplan's. An access pattern stable under every shift is *Kaplan-compliant*
+(`AccessPattern.toCharacter`), and an origin pattern at a root tower is `Character.dthat` of its
+coordinate (`AccessPattern.origin_toCharacter_root`): the tower analysis at depth zero is Kaplan's.
+An access pattern stable under every shift is *Kaplan-compliant*
 (`AccessPattern.IsKaplanCompliant`); a shift that moves some context is a *monster*
-(`ContextShift.IsMonster`), an operator on the context of utterance rather than on the
-circumstance of evaluation. A shift that is no monster leaves every access pattern stable
+(`ContextShift.IsMonster`), an operator on the context of utterance rather than on the circumstance
+of evaluation. A shift that is no monster leaves every access pattern stable
 (`AccessPattern.stable_of_not_isMonster`), and a monster is exactly a shift under which the
 innermost context itself is unstable (`ContextShift.isMonster_iff_not_stable_innermost_id`). The
 identity shift that Kaplan's thesis assigns to English attitude verbs is no monster
-(`ContextShift.not_isMonster_identityShift`); the attitude shift of [schlenker-2003] and
-[anand-nevins-2004], which makes the holder the agent, is one whenever the holder is not the
-speaker (`ContextShift.isMonster_attitudeShift`).
+(`ContextShift.not_isMonster_identityShift`); the attitude shift of [schlenker-2003] and [anand-
+nevins-2004], which makes the holder the agent, is one whenever the holder is not the speaker
+(`ContextShift.isMonster_attitudeShift`).
 
 ## References
 
@@ -51,63 +51,58 @@ variable {C R W E P T : Type*}
 
 namespace Character
 
-variable [ContextLike C W E P T]
+variable (world : C → W)
 
 /-- A character holds at a context when its content is true at the world of that context:
 the evaluation of a root sentence. -/
-def HoldsAt (χ : Character C W Prop) (c : C) : Prop := χ c (ContextLike.world c)
+def HoldsAt (χ : Character C W Prop) (c : C) : Prop := χ c (world c)
 
 /-- A character is a priori when it holds at every context. -/
-def IsAPriori (χ : Character C W Prop) : Prop := ∀ c, χ.HoldsAt c
+def IsAPriori (χ : Character C W Prop) : Prop := ∀ c, χ.HoldsAt world c
 
 /-- A character is necessary when its content is true at every world of every context. -/
 def IsNecessary (χ : Character C W Prop) : Prop := ∀ (c : C) (w : W), χ c w
 
-theorem IsNecessary.isAPriori {χ : Character C W Prop} (h : χ.IsNecessary) : χ.IsAPriori :=
+theorem IsNecessary.isAPriori {χ : Character C W Prop} (h : χ.IsNecessary) :
+    χ.IsAPriori world :=
   λ c => h c _
 
 end Character
 
-/-- A context-like type is proper for an existence predicate when the agent of every element
-exists at its world: Kaplan's coherence constraint on contexts. -/
-class ContextLike.Proper (C : Type*) {W E P T : Type*} [ContextLike C W E P T]
-    (exists_ : E → W → Prop) : Prop where
-  proper : ∀ c : C, (ContextLike.toContext c).Proper exists_
+namespace Kaplan
 
-/-- A context-like type is located for a location predicate when the agent of every element
-is at its position at its time in its world. -/
-class ContextLike.Located (C : Type*) {W E P T : Type*} [ContextLike C W E P T]
-    (located : E → P → T → W → Prop) : Prop where
-  located : ∀ c : C, (ContextLike.toContext c).Located located
-
-section Tenets
-
-variable [ContextLike C W E P T] (exists_ : E → W → Prop) (located : E → P → T → W → Prop)
+variable (agent : C → E) (world : C → W) (position : C → P) (time : C → T)
+  (exists_ : E → W → Prop) (located : E → P → T → W → Prop)
 
 /-- The character of *I exist*: the agent of the context exists at the world of evaluation. -/
-def Kaplan.existsAgent : Character C W Prop := λ c w => exists_ (ContextLike.agent c) w
+def existsAgent : Character C W Prop := λ c w => exists_ (agent c) w
 
 /-- The character of *I am here now*: the agent of the context is at its position at its
 time in the world of evaluation. -/
-def Kaplan.locatedAgent : Character C W Prop :=
-  λ c w => located (ContextLike.agent c) (ContextLike.position c) (ContextLike.time c) w
+def locatedAgent : Character C W Prop := λ c w => located (agent c) (position c) (time c) w
 
-/-- *I exist* is a priori on a proper type. -/
-theorem isAPriori_exists_agent [ContextLike.Proper C exists_] :
-    (Kaplan.existsAgent (C := C) exists_).IsAPriori :=
-  ContextLike.Proper.proper
+/-- *I exist* is a priori when every context is proper, its agent existing at its world:
+Kaplan's coherence constraint on contexts. -/
+theorem isAPriori_existsAgent (h : ∀ c, exists_ (agent c) (world c)) :
+    (existsAgent agent exists_).IsAPriori world :=
+  h
 
 /-- *I exist* is not necessary once some agent fails to exist at some world. -/
-theorem not_isNecessary_exists_agent {c : C} {w : W} (h : ¬ exists_ (ContextLike.agent c) w) :
-    ¬ (Kaplan.existsAgent (C := C) exists_).IsNecessary :=
+theorem not_isNecessary_existsAgent {c : C} {w : W} (h : ¬ exists_ (agent c) w) :
+    ¬ (existsAgent agent exists_).IsNecessary :=
   λ hn => h (hn c w)
 
-/-- *I am here now* is a priori on a located type. -/
-theorem isAPriori_located_agent [ContextLike.Located C located] :
-    (Kaplan.locatedAgent (C := C) located).IsAPriori :=
-  ContextLike.Located.located
+/-- *I am here now* is a priori when every context is located. -/
+theorem isAPriori_locatedAgent (h : ∀ c, located (agent c) (position c) (time c) (world c)) :
+    (locatedAgent agent position time located).IsAPriori world :=
+  h
 
-end Tenets
+/-- On the canonical tuple, properness of every context is `Context.Proper`. -/
+theorem isAPriori_existsAgent_of_proper (h : ∀ c : Context W E P T, c.Proper exists_) :
+    (existsAgent (C := Context W E P T) Context.agent exists_).IsAPriori Context.world :=
+  h
+
+end Kaplan
 
 /-! ### Monsters -/
 
@@ -192,22 +187,20 @@ theorem ContextShift.isMonster_iff_not_stable_innermost_id (σ : ContextShift C)
 
 namespace Kaplan
 
-variable [ContextLike C W E P T]
-
 /-- *I*: the agent of the speech-act context. -/
-def I : AccessPattern C E := .origin ContextLike.agent
+def I : AccessPattern (Context W E P T) E := .origin Context.agent
 
 /-- *you*: the addressee of the speech-act context. -/
-def you : AccessPattern C E := .origin ContextLike.addressee
+def you : AccessPattern (Context W E P T) E := .origin Context.addressee
 
 /-- *now*: the time of the speech-act context. -/
-def now : AccessPattern C T := .origin ContextLike.time
+def now : AccessPattern (Context W E P T) T := .origin Context.time
 
 /-- *here*: the position of the speech-act context. -/
-def here : AccessPattern C P := .origin ContextLike.position
+def here : AccessPattern (Context W E P T) P := .origin Context.position
 
 /-- *actually*: the world of the speech-act context. -/
-def actually : AccessPattern C W := .origin ContextLike.world
+def actually : AccessPattern (Context W E P T) W := .origin Context.world
 
 end Kaplan
 


### PR DESCRIPTION
Reverses the class design of #3325 while keeping its theorems. A context is a value with projections, not a type with a canonical instance, so mathlib's device here is an explicit function argument, not a `-Like` class.
- `ContextLike` and its `Proper`/`Located` classes are deleted; `Character.HoldsAt`, `IsAPriori` take the world projection as an argument, and Kaplan's *I exist* / *I am here now* theorems take the coherence constraint as a hypothesis over explicit `agent`/`world`/`position`/`time` projections, with `isAPriori_existsAgent_of_proper` specializing to `Context.Proper` on the tuple.
- The English lexicon `Kaplan.I`, `you`, `now`, `here`, `actually` is back on `Context W E P T`, the general form being `AccessPattern.origin f`.