### PR TITLE
refactor(Semantics/Reference): shifts as Function.End acting on contexts

### DIFF
--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -113,11 +113,9 @@ quantification over situations is a separate semantic step. The tower
 version tracks depth for depth-sensitive operations (presupposition,
 tense indexing). -/
 
-/-- The mood-labeled context shift to the introduced situation's world
-and time. -/
+/-- The context shift to the introduced situation's world and time. -/
 def subjShift {E P : Type*} (newWorld : W) (newTime : T) :
-    ContextShift (Context W E P T) where
-  apply := λ c => { c with world := newWorld, time := newTime }
-  label := .mood
+    ContextShift (Context W E P T) :=
+  λ c => { c with world := newWorld, time := newTime }
 
 end Mood

--- a/Linglib/Semantics/Reference/Context/Shifts.lean
+++ b/Linglib/Semantics/Reference/Context/Shifts.lean
@@ -1,15 +1,18 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Reference.Context.Tower
 
 /-!
-# Standard Context Shifts
+# Standard context shifts
 
-Shift constructors for `Context` that correspond to specific linguistic operations:
-attitude embedding, temporal shift, and the identity (no-op) shift. Each preserves or
-changes specific coordinates, with theorems documenting the preservation pattern.
-
-These are the building blocks for tower-based composition. An attitude verb pushes
-`attitudeShift`, a sequence-of-tense embedding pushes `temporalShift`, and Kaplan-compliant
-English attitude verbs push `identityShift`.
+The shifts of `Context` that embedding operators push: an attitude verb makes the holder the
+agent and an accessible world the world (`attitudeShift`, [schlenker-2003]), and a
+sequence-of-tense embedding moves the time to the matrix event time (`temporalShift`,
+[von-stechow-2009]); a Kaplan-compliant English attitude verb pushes the identity `1`. The
+lemmas record which coordinates each shift changes and which it preserves.
 
 ## References
 
@@ -19,93 +22,49 @@ English attitude verbs push `identityShift`.
 
 namespace Reference
 
+variable {W E P T : Type*} (c : Context W E P T)
 
-section ContextShifts
+/-- The attitude shift: the holder becomes the agent and the attitude world the world;
+addressee, time and position are preserved. -/
+def attitudeShift (holder : E) (attWorld : W) : ContextShift (Context W E P T) :=
+  λ c => { c with agent := holder, world := attWorld }
 
-variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
+/-- The temporal shift: the time moves to `newTime`; every other coordinate is preserved. -/
+def temporalShift (newTime : T) : ContextShift (Context W E P T) :=
+  λ c => { c with time := newTime }
 
-/-- Attitude shift: changes agent (to the attitude holder) and world
-    (to an attitude-accessible world). Addressee, time, and position
-    are preserved.
+section attitudeShift
 
-    [schlenker-2003]: "John said that I am happy" — under the monster
-    analysis, the attitude verb shifts agent to John. Under Kaplan's
-    thesis, English uses `identityShift` instead. -/
-def attitudeShift (holder : E) (attWorld : W) : ContextShift (Context W E P T) where
-  apply := λ c => { c with agent := holder, world := attWorld }
-  label := .attitude
+variable (holder : E) (attWorld : W)
 
-/-- Temporal shift: changes time only. Used for sequence of tense,
-    where embedded tense is evaluated relative to the matrix event time.
+@[simp] theorem attitudeShift_agent :
+    (attitudeShift (P := P) (T := T) holder attWorld c).agent = holder := rfl
+@[simp] theorem attitudeShift_world :
+    (attitudeShift (P := P) (T := T) holder attWorld c).world = attWorld := rfl
+@[simp] theorem attitudeShift_addressee :
+    (attitudeShift (P := P) (T := T) holder attWorld c).addressee = c.addressee := rfl
+@[simp] theorem attitudeShift_time :
+    (attitudeShift (P := P) (T := T) holder attWorld c).time = c.time := rfl
+@[simp] theorem attitudeShift_position :
+    (attitudeShift (P := P) (T := T) holder attWorld c).position = c.position := rfl
 
-    [von-stechow-2009]: the attitude verb transmits its event time to
-    the embedded clause's perspective time. -/
-def temporalShift (newTime : T) : ContextShift (Context W E P T) where
-  apply := λ c => { c with time := newTime }
-  label := .temporal
+end attitudeShift
 
-/-- Identity shift: no change to the context. Kaplan's thesis for English
-    says attitude verbs push identity shifts — embedding happens without
-    shifting the context of utterance. -/
-def identityShift : ContextShift (Context W E P T) where
-  apply := id
-  label := .generic
+section temporalShift
 
--- ════════════════════════════════════════════════════════════════
--- § Attitude Shift Preservation
--- ════════════════════════════════════════════════════════════════
+variable (newTime : T)
 
-@[simp] theorem attitudeShift_preserves_addressee (holder : E) (attWorld : W)
-    (c : Context W E P T) :
-    ((attitudeShift holder attWorld).apply c).addressee = c.addressee := rfl
+@[simp] theorem temporalShift_time :
+    (temporalShift (W := W) (E := E) (P := P) newTime c).time = newTime := rfl
+@[simp] theorem temporalShift_agent :
+    (temporalShift (W := W) (E := E) (P := P) newTime c).agent = c.agent := rfl
+@[simp] theorem temporalShift_world :
+    (temporalShift (W := W) (E := E) (P := P) newTime c).world = c.world := rfl
+@[simp] theorem temporalShift_addressee :
+    (temporalShift (W := W) (E := E) (P := P) newTime c).addressee = c.addressee := rfl
+@[simp] theorem temporalShift_position :
+    (temporalShift (W := W) (E := E) (P := P) newTime c).position = c.position := rfl
 
-@[simp] theorem attitudeShift_preserves_time (holder : E) (attWorld : W)
-    (c : Context W E P T) :
-    ((attitudeShift holder attWorld).apply c).time = c.time := rfl
-
-@[simp] theorem attitudeShift_preserves_position (holder : E) (attWorld : W)
-    (c : Context W E P T) :
-    ((attitudeShift holder attWorld).apply c).position = c.position := rfl
-
-@[simp] theorem attitudeShift_changes_agent (holder : E) (attWorld : W)
-    (c : Context W E P T) :
-    ((attitudeShift holder attWorld).apply c).agent = holder := rfl
-
-@[simp] theorem attitudeShift_changes_world (holder : E) (attWorld : W)
-    (c : Context W E P T) :
-    ((attitudeShift holder attWorld).apply c).world = attWorld := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § Temporal Shift Preservation
--- ════════════════════════════════════════════════════════════════
-
-@[simp] theorem temporalShift_preserves_agent (newTime : T) (c : Context W E P T) :
-    ((temporalShift newTime).apply c).agent = c.agent := rfl
-
-@[simp] theorem temporalShift_preserves_world (newTime : T) (c : Context W E P T) :
-    ((temporalShift newTime).apply c).world = c.world := rfl
-
-@[simp] theorem temporalShift_preserves_addressee (newTime : T) (c : Context W E P T) :
-    ((temporalShift newTime).apply c).addressee = c.addressee := rfl
-
-@[simp] theorem temporalShift_preserves_position (newTime : T) (c : Context W E P T) :
-    ((temporalShift newTime).apply c).position = c.position := rfl
-
-@[simp] theorem temporalShift_changes_time (newTime : T) (c : Context W E P T) :
-    ((temporalShift newTime).apply c).time = newTime := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § Identity Shift
--- ════════════════════════════════════════════════════════════════
-
-@[simp] theorem identityShift_apply (c : Context W E P T) :
-    (identityShift (W := W) (E := E) (P := P) (T := T)).apply c = c := rfl
-
-/-- Pushing an identity shift doesn't change the innermost context. -/
-theorem push_identityShift_innermost (t : ContextTower (Context W E P T)) :
-    (t.push identityShift).innermost = t.innermost := by
-  rw [ContextTower.push_innermost, identityShift_apply]
-
-end ContextShifts
+end temporalShift
 
 end Reference

--- a/Linglib/Semantics/Reference/Context/Tower.lean
+++ b/Linglib/Semantics/Reference/Context/Tower.lean
@@ -1,170 +1,108 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Semantics.Reference.Context.Basic
 import Linglib.Semantics.Reference.Rigidity
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.Algebra.BigOperators.Group.List.Basic
 
 /-!
-# Context Tower
-[abusch-1997] [anand-nevins-2004] [cumming-2026] [schlenker-2003]
+# Context towers
 
-A depth-indexed stack of context shifts unifying the codebase's context-manipulation
-mechanisms: Kaplanian indexicals (origin access), shifted indexicals (local access),
-De Bruijn temporal indexing (depth-relative access), situation introduction (mood),
-and domain expansion (branching time).
+A depth-indexed stack of context shifts over an origin, the one carrier for the
+context-manipulation mechanisms of [abusch-1997], [anand-nevins-2004], [cumming-2026] and
+[schlenker-2003]: Kaplanian indexicals read the origin, shifted indexicals the innermost
+context, De Bruijn temporal indexing a relative depth. A *shift* is an endomorphism of the
+context type, an element of the monoid `Function.End C` acting on contexts, and a tower is an
+origin, Kaplan's speech-act context, with its shifts from outermost to innermost
+(`ContextTower`). The context at depth `k` is the product of the first `k` shifts acting on
+the origin (`ContextTower.contextAt`), saturating at the innermost context
+(`ContextTower.innermost`), and pushing a shift multiplies it in (`ContextTower.push`,
+`push_innermost`). An access pattern reads a coordinate of the context at a depth given
+relative to the tower (`AccessPattern`, `DepthSpec`); `AccessPattern.origin` reads the
+speech-act context and `AccessPattern.innermost` the innermost one, and a pattern is *stable*
+under a shift when pushing it changes nothing (`AccessPattern.Stable`), which every origin
+pattern is (`AccessPattern.stable_origin`).
 
-The tower is parametric over any context type `C`. `Context` serves as the canonical
-instantiation — it represents what a single context layer looks like. The tower wraps
-it with a stack of shifts.
+## References
 
-## Main definitions
-
-- `ContextTower.origin`, `ContextTower.innermost`, `ContextTower.contextAt`,
-  `ContextTower.push`, `ContextTower.root`.
-- `AccessPattern`: a depth specification plus a projection, resolved against a tower;
-  `AccessPattern.origin` and `AccessPattern.innermost` read a coordinate of the speech-act
-  context and of the innermost context respectively.
-- `AccessPattern.Stable`: invariance of an access pattern under a shift.
-
+* [kaplan-1989]
+* [schlenker-2003]
+* [anand-nevins-2004]
+* [abusch-1997]
+* [cumming-2026]
 -/
 
 namespace Reference
 
--- ════════════════════════════════════════════════════════════════
--- § Shift Labels
--- ════════════════════════════════════════════════════════════════
+/-- A context shift: an endomorphism of the context type, the action of an embedding
+operator on the context of utterance. -/
+abbrev ContextShift (C : Type*) := Function.End C
 
-/-- Classification of context shifts by their linguistic source. -/
-inductive ShiftLabel where
-  | attitude    -- attitude verb embedding (believe, say, want)
-  | temporal    -- temporal shift (sequence of tense, historical present)
-  | evidential  -- evidential perspective shift ([cumming-2026])
-  | mood        -- mood operator (SUBJ situation introduction)
-  | perspective -- full perspective shift (agent + time + world)
-  | quotation   -- direct quotation
-  | clauseChain -- clause chain scope (final verb TAM scopes over medial clauses)
-  | roleShift   -- sign language Role Shift (viewpoint + perspective shift)
-  | generic     -- unclassified shift
-  deriving DecidableEq, Repr, Inhabited
-
--- ════════════════════════════════════════════════════════════════
--- § Context Shift
--- ════════════════════════════════════════════════════════════════
-
-/-- A single context shift: a function transforming a context, tagged with
-    its linguistic source. -/
-structure ContextShift (C : Type*) where
-  /-- The context transformation -/
-  apply : C → C
-  /-- What kind of linguistic operation introduced this shift -/
-  label : ShiftLabel
-
--- ════════════════════════════════════════════════════════════════
--- § Context Tower
--- ════════════════════════════════════════════════════════════════
-
-/-- A context tower: an origin context with a stack of shifts.
-
-    The origin is the speech-act context (Kaplan's c*). Each shift corresponds
-    to an embedding operator (attitude verb, temporal shift, mood operator).
-    Contexts at each depth are computed by folding shifts over the origin —
-    the path condition holds by construction. -/
+/-- A context tower: an origin with a stack of shifts, from outermost to innermost. -/
 structure ContextTower (C : Type*) where
-  /-- The root context (speech-act context) -/
+  /-- The root context, the speech-act context. -/
   origin : C
-  /-- Shifts from outermost to innermost. `shifts[0]` is the first embedding
-      (e.g., the matrix attitude verb); the last element is the deepest. -/
+  /-- The shifts, the first being the outermost embedding. -/
   shifts : List (ContextShift C)
 
 namespace ContextTower
 
-variable {C : Type*}
+variable {C : Type*} (t : ContextTower C) (σ : ContextShift C) (c : C) {k : ℕ}
 
-/-- Embedding depth (number of shifts). -/
-def depth (t : ContextTower C) : ℕ := t.shifts.length
+/-- The embedding depth: the number of shifts. -/
+def depth : ℕ := t.shifts.length
 
-/-- The context at depth k, computed by folding the first k shifts over
-    the origin. Saturates at tower depth: `contextAt k` for `k ≥ depth`
-    returns the innermost context.
+/-- The context at depth `k`: the first `k` shifts acting on the origin, saturating at the
+innermost context. -/
+def contextAt (k : ℕ) : C := (t.shifts.take k).reverse.prod • t.origin
 
-    - `contextAt 0` = origin
-    - `contextAt depth` = innermost -/
-def contextAt (t : ContextTower C) (k : ℕ) : C :=
-  (t.shifts.take k).foldl (λ c σ => σ.apply c) t.origin
+/-- The innermost context: every shift acting on the origin. -/
+def innermost : C := t.shifts.reverse.prod • t.origin
 
-/-- The innermost (most deeply embedded) context: fold all shifts over origin. -/
-def innermost (t : ContextTower C) : C :=
-  t.shifts.foldl (λ c σ => σ.apply c) t.origin
-
-/-- Trivial tower with no shifts. -/
+/-- The trivial tower over a context. -/
 def root (c : C) : ContextTower C := ⟨c, []⟩
 
-/-- Push a new shift onto the tower (embed one level deeper). -/
-def push (t : ContextTower C) (σ : ContextShift C) : ContextTower C :=
-  ⟨t.origin, t.shifts ++ [σ]⟩
+/-- Embed one level deeper. -/
+def push : ContextTower C := ⟨t.origin, t.shifts ++ [σ]⟩
 
--- ════════════════════════════════════════════════════════════════
--- § Algebraic Properties
--- ════════════════════════════════════════════════════════════════
+@[simp] theorem root_origin : (root c).origin = c := rfl
+@[simp] theorem root_innermost : (root c).innermost = c := one_smul _ _
+@[simp] theorem root_depth : (root c).depth = 0 := rfl
+@[simp] theorem root_contextAt : (root c).contextAt k = c := by simp [root, contextAt]
+@[simp] theorem contextAt_zero : t.contextAt 0 = t.origin := one_smul _ _
+@[simp] theorem push_origin : (t.push σ).origin = t.origin := rfl
+@[simp] theorem push_depth : (t.push σ).depth = t.depth + 1 := by simp [push, depth]
 
-@[simp] theorem root_origin (c : C) : (root c).origin = c := rfl
+@[simp] theorem contextAt_depth : t.contextAt t.depth = t.innermost := by
+  simp [contextAt, innermost, depth]
 
-@[simp] theorem root_innermost (c : C) : (root c).innermost = c := rfl
+/-- Past the tower depth, `contextAt` saturates at the innermost context. -/
+theorem contextAt_saturates (hk : t.depth ≤ k) : t.contextAt k = t.innermost := by
+  simp [contextAt, innermost, List.take_of_length_le hk]
 
-@[simp] theorem contextAt_zero (t : ContextTower C) : t.contextAt 0 = t.origin := rfl
-
-@[simp] theorem contextAt_depth (t : ContextTower C) :
-    t.contextAt t.depth = t.innermost := by
-  simp only [contextAt, innermost, depth, List.take_length]
-
-/-- Past the tower depth, `contextAt` saturates at the innermost context.
-    This is because `List.take k` on a list shorter than `k` returns the
-    whole list. -/
-theorem contextAt_saturates (t : ContextTower C) (k : ℕ) (hk : t.depth ≤ k) :
-    t.contextAt k = t.innermost := by
-  simp only [contextAt, innermost, depth] at *
-  rw [List.take_of_length_le hk]
-
-@[simp] theorem push_origin (t : ContextTower C) (σ : ContextShift C) :
-    (t.push σ).origin = t.origin := rfl
-
-@[simp] theorem root_depth (c : C) : (root c).depth = 0 := rfl
-
-@[simp] theorem push_depth (t : ContextTower C) (σ : ContextShift C) :
-    (t.push σ).depth = t.depth + 1 := by
-  simp [push, depth]
-
-@[simp] theorem root_contextAt (c : C) (k : ℕ) : (root c).contextAt k = c := by
-  simp [root, contextAt]
-
-/-- Pushing a shift updates the innermost context. -/
-@[simp] theorem push_innermost (t : ContextTower C) (σ : ContextShift C) :
-    (t.push σ).innermost = σ.apply t.innermost := by
-  simp only [push, innermost, List.foldl_append, List.foldl_cons, List.foldl_nil]
+/-- Pushing a shift lets it act on the innermost context. -/
+@[simp] theorem push_innermost : (t.push σ).innermost = σ • t.innermost := by
+  simp [push, innermost, mul_smul]
 
 /-- Below the tower depth, a push leaves the context at each depth unchanged. -/
-theorem push_contextAt_of_le (t : ContextTower C) (σ : ContextShift C) {k : ℕ}
-    (hk : k ≤ t.depth) : (t.push σ).contextAt k = t.contextAt k := by
+theorem push_contextAt_of_le (hk : k ≤ t.depth) : (t.push σ).contextAt k = t.contextAt k := by
   simp only [contextAt, push]
   rw [List.take_append_of_le_length hk]
 
 /-- Beyond the tower depth, a push saturates at the shifted innermost context. -/
-theorem push_contextAt_of_lt (t : ContextTower C) (σ : ContextShift C) {k : ℕ}
-    (hk : t.depth < k) : (t.push σ).contextAt k = σ.apply t.innermost := by
-  rw [← push_innermost, contextAt_saturates _ _ (by rw [push_depth]; exact hk)]
+theorem push_contextAt_of_lt (hk : t.depth < k) : (t.push σ).contextAt k = σ • t.innermost := by
+  rw [← push_innermost, contextAt_saturates _ (by rw [push_depth]; exact hk)]
 
-@[simp] theorem push_contextAt_succ_depth (t : ContextTower C) (σ : ContextShift C) :
-    (t.push σ).contextAt (t.depth + 1) = σ.apply t.innermost :=
+@[simp] theorem push_contextAt_succ_depth : (t.push σ).contextAt (t.depth + 1) = σ • t.innermost :=
   push_contextAt_of_lt _ _ (Nat.lt_succ_self _)
 
 end ContextTower
 
--- ════════════════════════════════════════════════════════════════
--- § Depth Specification
--- ════════════════════════════════════════════════════════════════
-
-/-- Which depth to read from in a tower.
-
-    - `.origin`: always read from depth 0 (speech-act context)
-    - `.local`: always read from the innermost context
-    - `.relative k`: read from depth k -/
+/-- Which depth of a tower an expression reads: the origin, the innermost context, or a fixed
+depth. -/
 inductive DepthSpec where
   | origin
   | local
@@ -173,7 +111,7 @@ inductive DepthSpec where
 
 namespace DepthSpec
 
-/-- Resolve to a concrete depth index given the tower depth. -/
+/-- The depth read at a tower of the given depth. -/
 def resolve (d : DepthSpec) (towerDepth : ℕ) : ℕ :=
   match d with
   | .origin => 0
@@ -186,87 +124,77 @@ def resolve (d : DepthSpec) (towerDepth : ℕ) : ℕ :=
 
 end DepthSpec
 
--- ════════════════════════════════════════════════════════════════
--- § Access Patterns
--- ════════════════════════════════════════════════════════════════
-
-/-- An access pattern: a depth specification plus a projection from context
-    to value.
-
-    This is how context-dependent expressions specify what they read:
-    - `depth` says which tower layer to read from
-    - `project` says which coordinate to extract
-
-    English "I" = `⟨.origin, Context.agent⟩`
-    Amharic "I" = `⟨.local, Context.agent⟩`
-    English "now" = `⟨.origin, Context.time⟩` -/
+/-- An access pattern: a depth specification and a projection, what a context-dependent
+expression reads. English *I* is `origin Context.agent`; Amharic *I* is
+`innermost Context.agent`. -/
 structure AccessPattern (C : Type*) (R : Type*) where
-  /-- Which depth to read from -/
+  /-- Which depth to read from. -/
   depth : DepthSpec
-  /-- Which coordinate to extract -/
+  /-- Which coordinate to extract. -/
   project : C → R
 
 namespace AccessPattern
 
-variable {C R S : Type*}
+universe u
+
+variable {C R : Type*} (ap : AccessPattern C R) (t : ContextTower C) (f : C → R)
+  (σ : ContextShift C)
 
 /-- Resolve an access pattern against a tower. -/
-def resolve (ap : AccessPattern C R) (t : ContextTower C) : R :=
-  ap.project (t.contextAt (ap.depth.resolve t.depth))
+def resolve : R := ap.project (t.contextAt (ap.depth.resolve t.depth))
 
-/-- Map a function over the projected result. -/
-def map (ap : AccessPattern C R) (f : R → S) : AccessPattern C S :=
-  ⟨ap.depth, f ∘ ap.project⟩
+instance : Functor (AccessPattern C) where
+  map f ap := ⟨ap.depth, f ∘ ap.project⟩
 
-/-- Origin access is invariant under push. This is the formal content of
-    Kaplan's thesis: expressions reading from the speech-act context are
-    unaffected by embedding operators. -/
-theorem origin_stable (ap : AccessPattern C R) (hd : ap.depth = .origin)
-    (t : ContextTower C) (σ : ContextShift C) :
-    ap.resolve (t.push σ) = ap.resolve t := by
-  simp only [resolve, hd, DepthSpec.origin_resolve,
-             ContextTower.contextAt_zero, ContextTower.push_origin]
+instance : LawfulFunctor (AccessPattern C) where
+  map_const := rfl
+  id_map _ := rfl
+  comp_map _ _ _ := rfl
 
-/-- Local access updates with push: the innermost projection tracks the
-    new shift. -/
-theorem local_updates (ap : AccessPattern C R) (hd : ap.depth = .local)
-    (t : ContextTower C) (σ : ContextShift C) :
-    ap.resolve (t.push σ) = ap.project (σ.apply t.innermost) := by
-  simp only [resolve, hd, DepthSpec.local_resolve, ContextTower.push_depth]
-  rw [← ContextTower.push_depth, ContextTower.contextAt_depth,
-      ContextTower.push_innermost]
+section map
 
-/-- An access pattern is *stable* under a shift when pushing that shift onto any
-    tower leaves its resolution unchanged. This relation underlies both
-    Kaplan-compliance (`Reference/Kaplan.lean`: an expression stable under
-    *every* shift) and monsterhood (a shift that destabilizes *some* expression),
-    the two being its ∀-over-shifts and ∃-over-expressions projections. -/
-def Stable (ap : AccessPattern C R) (σ : ContextShift C) : Prop :=
-  ∀ t, ap.resolve (t.push σ) = ap.resolve t
+variable {R S : Type u} (ap : AccessPattern C R) (g : R → S)
 
-/-- Origin-depth access is stable under every shift — the access-pattern form
-    of `origin_stable`, and the sufficient condition for Kaplan-compliance. -/
-theorem stable_of_depth_origin (ap : AccessPattern C R) (hd : ap.depth = .origin)
-    (σ : ContextShift C) : ap.Stable σ :=
-  fun t => origin_stable ap hd t σ
+@[simp] theorem map_depth : (g <$> ap).depth = ap.depth := rfl
+@[simp] theorem map_project : (g <$> ap).project = g ∘ ap.project := rfl
+@[simp] theorem resolve_map : (g <$> ap).resolve t = g (ap.resolve t) := rfl
 
-/-- Read the coordinate `f` of the speech-act context: the access pattern of a Kaplanian
-pure indexical. -/
-def origin (f : C → R) : AccessPattern C R := ⟨.origin, f⟩
+end map
 
-/-- Read the coordinate `f` of the innermost context: the access pattern of a shifted
-indexical. -/
-def innermost (f : C → R) : AccessPattern C R := ⟨.local, f⟩
+/-- Read the coordinate `f` of the speech-act context: a Kaplanian pure indexical. -/
+def origin : AccessPattern C R := ⟨.origin, f⟩
 
-@[simp] theorem origin_resolve (f : C → R) (t : ContextTower C) :
-    (origin f).resolve t = f t.origin := rfl
+/-- Read the coordinate `f` of the innermost context: a shifted indexical. -/
+def innermost : AccessPattern C R := ⟨.local, f⟩
 
-@[simp] theorem innermost_resolve (f : C → R) (t : ContextTower C) :
-    (innermost f).resolve t = f t.innermost := by
+@[simp] theorem origin_resolve : (origin f).resolve t = f t.origin := by simp [origin, resolve]
+
+@[simp] theorem innermost_resolve : (innermost f).resolve t = f t.innermost := by
   simp [innermost, resolve]
 
-theorem stable_origin (f : C → R) (σ : ContextShift C) : (origin f).Stable σ :=
-  stable_of_depth_origin _ rfl σ
+/-- An access pattern is stable under a shift when pushing the shift onto any tower leaves its
+resolution unchanged. Kaplan-compliance is stability under every shift and monsterhood
+instability of some pattern (`Reference/Kaplan.lean`). -/
+def Stable : Prop := ∀ t, ap.resolve (t.push σ) = ap.resolve t
+
+/-- Origin access is invariant under push: Kaplan's thesis for expressions reading the
+speech-act context. -/
+theorem origin_stable (ap : AccessPattern C R) (hd : ap.depth = .origin) (t : ContextTower C)
+    (σ : ContextShift C) : ap.resolve (t.push σ) = ap.resolve t := by
+  simp only [resolve, hd, DepthSpec.origin_resolve, ContextTower.contextAt_zero,
+    ContextTower.push_origin]
+
+theorem stable_of_depth_origin (ap : AccessPattern C R) (hd : ap.depth = .origin)
+    (σ : ContextShift C) : ap.Stable σ :=
+  λ t => ap.origin_stable hd t σ
+
+theorem stable_origin : (origin f).Stable σ := stable_of_depth_origin _ rfl σ
+
+/-- Innermost access tracks the pushed shift. -/
+theorem local_updates (ap : AccessPattern C R) (hd : ap.depth = .local) (t : ContextTower C)
+    (σ : ContextShift C) : ap.resolve (t.push σ) = ap.project (σ • t.innermost) := by
+  simp only [resolve, hd, DepthSpec.local_resolve, ContextTower.push_depth,
+    ContextTower.push_contextAt_succ_depth]
 
 end AccessPattern
 

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -31,7 +31,7 @@ of evaluation. A shift that is no monster leaves every access pattern stable
 (`AccessPattern.stable_of_not_isMonster`), and a monster is exactly a shift under which the
 innermost context itself is unstable (`ContextShift.isMonster_iff_not_stable_innermost_id`). The
 identity shift that Kaplan's thesis assigns to English attitude verbs is no monster
-(`ContextShift.not_isMonster_identityShift`); the attitude shift of [schlenker-2003] and [anand-
+(`ContextShift.not_isMonster_one`); the attitude shift of [schlenker-2003] and [anand-
 nevins-2004], which makes the holder the agent, is one whenever the holder is not the speaker
 (`ContextShift.isMonster_attitudeShift`).
 
@@ -106,17 +106,15 @@ end Kaplan
 
 /-! ### Monsters -/
 
-/-- A context shift is a monster when it moves some context. -/
-def ContextShift.IsMonster (σ : ContextShift C) : Prop := σ.apply ≠ id
+/-- A context shift is a monster when it is not the identity: it moves some context. -/
+def ContextShift.IsMonster (σ : ContextShift C) : Prop := σ ≠ 1
 
 namespace ContextShift
 
-theorem isMonster_iff (σ : ContextShift C) : σ.IsMonster ↔ ∃ c, σ.apply c ≠ c :=
-  Function.ne_iff
+theorem isMonster_iff (σ : ContextShift C) : σ.IsMonster ↔ ∃ c : C, σ • c ≠ c :=
+  show (σ : C → C) ≠ id ↔ _ from Function.ne_iff
 
-theorem not_isMonster_identityShift :
-    ¬ (identityShift : ContextShift (Context W E P T)).IsMonster :=
-  λ h => h rfl
+theorem not_isMonster_one : ¬ (1 : ContextShift C).IsMonster := λ h => h rfl
 
 /-- An attitude shift to a holder other than some context's agent moves that context. -/
 theorem isMonster_attitudeShift (holder : E) (w' : W) (c : Context W E P T)
@@ -130,7 +128,8 @@ namespace AccessPattern
 /-- A shift that is no monster leaves every access pattern stable. -/
 theorem stable_of_not_isMonster (ap : AccessPattern C R) {σ : ContextShift C}
     (h : ¬ σ.IsMonster) : ap.Stable σ := by
-  have hσ : σ.apply = id := not_not.mp h
+  have hσ : σ = 1 := not_not.mp h
+  subst hσ
   intro t
   obtain ⟨d, f⟩ := ap
   simp only [resolve]
@@ -139,15 +138,14 @@ theorem stable_of_not_isMonster (ap : AccessPattern C R) {σ : ContextShift C}
   | origin => simp
   | «local» =>
     rw [DepthSpec.local_resolve, DepthSpec.local_resolve, ContextTower.push_depth,
-      ContextTower.push_contextAt_of_lt _ _ (Nat.lt_succ_self _), hσ, ContextTower.contextAt_depth]
-    rfl
+      ContextTower.push_contextAt_succ_depth, one_smul, ContextTower.contextAt_depth]
   | relative k =>
     rcases le_or_gt k t.depth with hk | hk
     · rw [DepthSpec.relative_resolve, DepthSpec.relative_resolve,
         ContextTower.push_contextAt_of_le _ _ hk]
     · rw [DepthSpec.relative_resolve, DepthSpec.relative_resolve,
-        ContextTower.push_contextAt_of_lt _ _ hk, hσ, ContextTower.contextAt_saturates _ _ hk.le]
-      rfl
+        ContextTower.push_contextAt_of_lt _ _ hk, one_smul,
+        ContextTower.contextAt_saturates _ hk.le]
 
 /-- An access pattern as a character over towers: at each tower, the rigid content at its
 value. -/
@@ -172,7 +170,7 @@ theorem origin_toCharacter_root (f : C → R) (c : C) :
 def IsKaplanCompliant (ap : AccessPattern C R) : Prop := ∀ σ, ap.Stable σ
 
 theorem isKaplanCompliant_origin (f : C → R) : (origin f).IsKaplanCompliant :=
-  stable_origin f
+  λ σ => stable_origin f σ
 
 end AccessPattern
 

--- a/Linglib/Studies/SarvasyAikhenvald2025.lean
+++ b/Linglib/Studies/SarvasyAikhenvald2025.lean
@@ -441,9 +441,8 @@ def finalCtx : ChainCtx :=
 
 /-- A clauseChain shift: changes agent and time for a medial clause.
     The medial clause has its own subject and event time. -/
-def chainShift (newAgent : ChainAgent) (eventTime : ℤ) : ContextShift ChainCtx where
-  apply := λ c => { c with agent := newAgent, time := eventTime }
-  label := .clauseChain
+def chainShift (newAgent : ChainAgent) (eventTime : ℤ) : ContextShift ChainCtx :=
+  λ c => { c with agent := newAgent, time := eventTime }
 
 -- ============================================================================
 -- § Tower Depth = Chain Length
@@ -573,20 +572,5 @@ theorem sr_languages_use_tower_agent_tracking :
 /-- Non-SR languages don't track agent continuity morphologically. -/
 theorem nonsr_languages_no_agent_tracking :
     [korean, turkish].all (λ p => !p.hasSR) = true := by native_decide
-
--- ============================================================================
--- § Chain Label = clauseChain
--- ============================================================================
-
-/-- The chain shift carries the `.clauseChain` label, connecting it to the
-    `ShiftLabel` taxonomy in Tower.lean. -/
-theorem chain_shift_label :
-    (chainShift .subjectB (-3)).label = ShiftLabel.clauseChain := rfl
-
-/-- Chain shifts are distinct from attitude shifts (subordination). This
-    reflects the cosubordination ≠ subordination distinction: clause chaining
-    uses a different shift label than attitude embedding. -/
-theorem chain_is_not_attitude :
-    (chainShift .subjectB (-3)).label ≠ ShiftLabel.attitude := by decide
 
 end SarvasyAikhenvald2025

--- a/Linglib/Studies/SchlenkerEtAl2026.lean
+++ b/Linglib/Studies/SchlenkerEtAl2026.lean
@@ -170,10 +170,8 @@ def resolveViewpoint
     The viewpoint consequence is indirect: since π* reads the agent's
     viewpoint via `resolveViewpoint`, changing the agent changes what
     π* denotes. -/
-def roleShiftCtx (character : E) (rsWorld : W) :
-    ContextShift (Context W E P T) where
-  apply := (attitudeShift (P := P) (T := T) character rsWorld).apply
-  label := .roleShift
+def roleShiftCtx (character : E) (rsWorld : W) : ContextShift (Context W E P T) :=
+  attitudeShift character rsWorld
 
 /-- Role Shift is a monster (non-identity context shift), connecting
     to the Kaplan/Schlenker monster debate in `Reference/Kaplan.lean`:

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -349,7 +349,7 @@ theorem von_stechow_tower_innermost
     (t : ContextTower (Context W E P T)) (newTime : T) :
     (t.push (temporalShift newTime)).innermost.time = newTime := by
   rw [ContextTower.push_innermost]
-  simp only [temporalShift]
+  rfl
 
 end TemporalBridge
 


### PR DESCRIPTION
The tower restated over mathlib's monoid of endomorphisms (the class-worthy structure identified after #3327).
- `ContextShift C` is `Function.End C`; a tower's `innermost` and `contextAt` are the product of its shifts acting on the origin, so `push_innermost` and the `push_contextAt_*` lemmas are `mul_smul`/`one_smul`, `ContextShift.IsMonster σ` is `σ ≠ 1`, and the identity shift is `1`. `ShiftLabel`, a tag on the shift read only by one `rfl` theorem, is gone; `attitudeShift`/`temporalShift` are plain endomorphisms with their coordinate lemmas in application form (mathlib's `Function.End.smul_def` rewrites `•` to application first).
- `AccessPattern C` is a `LawfulFunctor` in its result type, replacing the ad hoc `map`.
- Consumers: Sarvasy & Aikhenvald 2025's `chainShift`, Mood's `subjShift` and Schlenker et al. 2026's `roleShiftCtx` (now literally the attitude shift) drop their labels; von Stechow 2009 closes one goal by `rfl`.