### PR TITLE
refactor(Semantics/Reference): drop the ContextShift alias

### DIFF
--- a/Linglib/Discourse/Roles.lean
+++ b/Linglib/Discourse/Roles.lean
@@ -42,7 +42,7 @@ theorem resolve_addressee : resolve tower .addressee = tower.origin.addressee :=
 
 /-- Discourse role resolution is invariant under tower push: discourse
     roles reflect speech-act participants (from origin), not embedded ones. -/
-theorem resolve_push (σ : ContextShift (Context W E P T)) (r : Role) :
+theorem resolve_push (σ : Function.End (Context W E P T)) (r : Role) :
     resolve (tower.push σ) r = resolve tower r := by
   cases r <;> simp only [resolve, ContextTower.push_origin]
 

--- a/Linglib/Semantics/Evidential/Epistemicity.lean
+++ b/Linglib/Semantics/Evidential/Epistemicity.lean
@@ -99,7 +99,7 @@ def allocutiveProfile (s : CoarseSource) : EpistemicProfile :=
 /-- Epistemic authority is invariant under tower push: egophoric marking
     reflects speech-act participants (from origin), not embedded ones. -/
 theorem epistemicAuthority_shift_invariant {W E P T : Type*} [DecidableEq E]
-    (tower : ContextTower (Context W E P T)) (σ : ContextShift (Context W E P T))
+    (tower : ContextTower (Context W E P T)) (σ : Function.End (Context W E P T))
     (knower : E) :
     epistemicAuthority (tower.push σ) knower = epistemicAuthority tower knower := by
   simp only [epistemicAuthority, ContextTower.push_origin]

--- a/Linglib/Semantics/Mood/Situation.lean
+++ b/Linglib/Semantics/Mood/Situation.lean
@@ -115,7 +115,7 @@ tense indexing). -/
 
 /-- The context shift to the introduced situation's world and time. -/
 def subjShift {E P : Type*} (newWorld : W) (newTime : T) :
-    ContextShift (Context W E P T) :=
+    Function.End (Context W E P T) :=
   λ c => { c with world := newWorld, time := newTime }
 
 end Mood

--- a/Linglib/Semantics/Reference/Context/Shifts.lean
+++ b/Linglib/Semantics/Reference/Context/Shifts.lean
@@ -26,11 +26,11 @@ variable {W E P T : Type*} (c : Context W E P T)
 
 /-- The attitude shift: the holder becomes the agent and the attitude world the world;
 addressee, time and position are preserved. -/
-def attitudeShift (holder : E) (attWorld : W) : ContextShift (Context W E P T) :=
+def attitudeShift (holder : E) (attWorld : W) : Function.End (Context W E P T) :=
   λ c => { c with agent := holder, world := attWorld }
 
 /-- The temporal shift: the time moves to `newTime`; every other coordinate is preserved. -/
-def temporalShift (newTime : T) : ContextShift (Context W E P T) :=
+def temporalShift (newTime : T) : Function.End (Context W E P T) :=
   λ c => { c with time := newTime }
 
 section attitudeShift

--- a/Linglib/Semantics/Reference/Context/Tower.lean
+++ b/Linglib/Semantics/Reference/Context/Tower.lean
@@ -37,20 +37,16 @@ pattern is (`AccessPattern.stable_origin`).
 
 namespace Reference
 
-/-- A context shift: an endomorphism of the context type, the action of an embedding
-operator on the context of utterance. -/
-abbrev ContextShift (C : Type*) := Function.End C
-
 /-- A context tower: an origin with a stack of shifts, from outermost to innermost. -/
 structure ContextTower (C : Type*) where
   /-- The root context, the speech-act context. -/
   origin : C
   /-- The shifts, the first being the outermost embedding. -/
-  shifts : List (ContextShift C)
+  shifts : List (Function.End C)
 
 namespace ContextTower
 
-variable {C : Type*} (t : ContextTower C) (σ : ContextShift C) (c : C) {k : ℕ}
+variable {C : Type*} (t : ContextTower C) (σ : Function.End C) (c : C) {k : ℕ}
 
 /-- The embedding depth: the number of shifts. -/
 def depth : ℕ := t.shifts.length
@@ -138,7 +134,7 @@ namespace AccessPattern
 universe u
 
 variable {C R : Type*} (ap : AccessPattern C R) (t : ContextTower C) (f : C → R)
-  (σ : ContextShift C)
+  (σ : Function.End C)
 
 /-- Resolve an access pattern against a tower. -/
 def resolve : R := ap.project (t.contextAt (ap.depth.resolve t.depth))
@@ -180,19 +176,19 @@ def Stable : Prop := ∀ t, ap.resolve (t.push σ) = ap.resolve t
 /-- Origin access is invariant under push: Kaplan's thesis for expressions reading the
 speech-act context. -/
 theorem origin_stable (ap : AccessPattern C R) (hd : ap.depth = .origin) (t : ContextTower C)
-    (σ : ContextShift C) : ap.resolve (t.push σ) = ap.resolve t := by
+    (σ : Function.End C) : ap.resolve (t.push σ) = ap.resolve t := by
   simp only [resolve, hd, DepthSpec.origin_resolve, ContextTower.contextAt_zero,
     ContextTower.push_origin]
 
 theorem stable_of_depth_origin (ap : AccessPattern C R) (hd : ap.depth = .origin)
-    (σ : ContextShift C) : ap.Stable σ :=
+    (σ : Function.End C) : ap.Stable σ :=
   λ t => ap.origin_stable hd t σ
 
 theorem stable_origin : (origin f).Stable σ := stable_of_depth_origin _ rfl σ
 
 /-- Innermost access tracks the pushed shift. -/
 theorem local_updates (ap : AccessPattern C R) (hd : ap.depth = .local) (t : ContextTower C)
-    (σ : ContextShift C) : ap.resolve (t.push σ) = ap.project (σ • t.innermost) := by
+    (σ : Function.End C) : ap.resolve (t.push σ) = ap.project (σ • t.innermost) := by
   simp only [resolve, hd, DepthSpec.local_resolve, ContextTower.push_depth,
     ContextTower.push_contextAt_succ_depth]
 

--- a/Linglib/Semantics/Reference/Kaplan.lean
+++ b/Linglib/Semantics/Reference/Kaplan.lean
@@ -26,14 +26,14 @@ English. An access pattern is a character over towers with rigid content
 coordinate (`AccessPattern.origin_toCharacter_root`): the tower analysis at depth zero is Kaplan's.
 An access pattern stable under every shift is *Kaplan-compliant*
 (`AccessPattern.IsKaplanCompliant`); a shift that moves some context is a *monster*
-(`ContextShift.IsMonster`), an operator on the context of utterance rather than on the circumstance
+(`IsMonster`), an operator on the context of utterance rather than on the circumstance
 of evaluation. A shift that is no monster leaves every access pattern stable
 (`AccessPattern.stable_of_not_isMonster`), and a monster is exactly a shift under which the
-innermost context itself is unstable (`ContextShift.isMonster_iff_not_stable_innermost_id`). The
+innermost context itself is unstable (`isMonster_iff_not_stable_innermost_id`). The
 identity shift that Kaplan's thesis assigns to English attitude verbs is no monster
-(`ContextShift.not_isMonster_one`); the attitude shift of [schlenker-2003] and [anand-
+(`not_isMonster_one`); the attitude shift of [schlenker-2003] and [anand-
 nevins-2004], which makes the holder the agent, is one whenever the holder is not the speaker
-(`ContextShift.isMonster_attitudeShift`).
+(`isMonster_attitudeShift`).
 
 ## References
 
@@ -107,27 +107,24 @@ end Kaplan
 /-! ### Monsters -/
 
 /-- A context shift is a monster when it is not the identity: it moves some context. -/
-def ContextShift.IsMonster (σ : ContextShift C) : Prop := σ ≠ 1
+def IsMonster (σ : Function.End C) : Prop := σ ≠ 1
 
-namespace ContextShift
-
-theorem isMonster_iff (σ : ContextShift C) : σ.IsMonster ↔ ∃ c : C, σ • c ≠ c :=
+theorem isMonster_iff (σ : Function.End C) : IsMonster σ ↔ ∃ c : C, σ • c ≠ c :=
   show (σ : C → C) ≠ id ↔ _ from Function.ne_iff
 
-theorem not_isMonster_one : ¬ (1 : ContextShift C).IsMonster := λ h => h rfl
+theorem not_isMonster_one : ¬ IsMonster (1 : Function.End C) := λ h => h rfl
 
 /-- An attitude shift to a holder other than some context's agent moves that context. -/
 theorem isMonster_attitudeShift (holder : E) (w' : W) (c : Context W E P T)
-    (h : c.agent ≠ holder) : (attitudeShift (P := P) (T := T) holder w').IsMonster :=
+    (h : c.agent ≠ holder) : IsMonster (attitudeShift (P := P) (T := T) holder w') :=
   (isMonster_iff _).2 ⟨c, λ e => h (by simpa using (congrArg Context.agent e).symm)⟩
 
-end ContextShift
 
 namespace AccessPattern
 
 /-- A shift that is no monster leaves every access pattern stable. -/
-theorem stable_of_not_isMonster (ap : AccessPattern C R) {σ : ContextShift C}
-    (h : ¬ σ.IsMonster) : ap.Stable σ := by
+theorem stable_of_not_isMonster (ap : AccessPattern C R) {σ : Function.End C}
+    (h : ¬ IsMonster σ) : ap.Stable σ := by
   have hσ : σ = 1 := not_not.mp h
   subst hσ
   intro t
@@ -175,8 +172,8 @@ theorem isKaplanCompliant_origin (f : C → R) : (origin f).IsKaplanCompliant :=
 end AccessPattern
 
 /-- A shift is a monster iff the innermost context is unstable under it. -/
-theorem ContextShift.isMonster_iff_not_stable_innermost_id (σ : ContextShift C) :
-    σ.IsMonster ↔ ¬ (AccessPattern.innermost id).Stable σ := by
+theorem isMonster_iff_not_stable_innermost_id (σ : Function.End C) :
+    IsMonster σ ↔ ¬ (AccessPattern.innermost id).Stable σ := by
   simp only [isMonster_iff, AccessPattern.Stable, AccessPattern.innermost_resolve,
     ContextTower.push_innermost, id_eq, not_forall]
   exact ⟨λ ⟨c, hc⟩ => ⟨ContextTower.root c, by simpa using hc⟩, λ ⟨t, ht⟩ => ⟨t.innermost, ht⟩⟩

--- a/Linglib/Studies/SarvasyAikhenvald2025.lean
+++ b/Linglib/Studies/SarvasyAikhenvald2025.lean
@@ -441,7 +441,7 @@ def finalCtx : ChainCtx :=
 
 /-- A clauseChain shift: changes agent and time for a medial clause.
     The medial clause has its own subject and event time. -/
-def chainShift (newAgent : ChainAgent) (eventTime : ℤ) : ContextShift ChainCtx :=
+def chainShift (newAgent : ChainAgent) (eventTime : ℤ) : Function.End ChainCtx :=
   λ c => { c with agent := newAgent, time := eventTime }
 
 -- ============================================================================

--- a/Linglib/Studies/SchlenkerEtAl2026.lean
+++ b/Linglib/Studies/SchlenkerEtAl2026.lean
@@ -170,7 +170,7 @@ def resolveViewpoint
     The viewpoint consequence is indirect: since π* reads the agent's
     viewpoint via `resolveViewpoint`, changing the agent changes what
     π* denotes. -/
-def roleShiftCtx (character : E) (rsWorld : W) : ContextShift (Context W E P T) :=
+def roleShiftCtx (character : E) (rsWorld : W) : Function.End (Context W E P T) :=
   attitudeShift character rsWorld
 
 /-- Role Shift is a monster (non-identity context shift), connecting
@@ -180,8 +180,8 @@ theorem roleShift_is_monster
     (character : E) (rsWorld : W)
     (c : Context W E P T)
     (hAgent : c.agent ≠ character) :
-    (roleShiftCtx (P := P) (T := T) character rsWorld).IsMonster :=
-  ContextShift.isMonster_attitudeShift character rsWorld c hAgent
+    IsMonster (roleShiftCtx (P := P) (T := T) character rsWorld) :=
+  isMonster_attitudeShift character rsWorld c hAgent
 
 /-- Under Role Shift, π* resolves to the character's viewpoint. -/
 theorem contextBound_under_roleShift

--- a/Linglib/Studies/SpeasTenny2003.lean
+++ b/Linglib/Studies/SpeasTenny2003.lean
@@ -238,7 +238,7 @@ theorem resolvePRole_hearer {W E P T : Type*} (tower : ContextTower (Context W E
     context shift / embedding — inherited from
     `Discourse.Role.resolve_push`. -/
 theorem resolvePRole_shift_invariant {W E P T : Type*}
-    (tower : ContextTower (Context W E P T)) (σ : ContextShift (Context W E P T))
+    (tower : ContextTower (Context W E P T)) (σ : Function.End (Context W E P T))
     (r : PRole) :
     resolvePRole (tower.push σ) r = resolvePRole tower r := by
   simp only [resolvePRole, Discourse.Role.resolve_push]


### PR DESCRIPTION
`ContextShift C` was a bare alias of `Function.End C` after #3328, adding no structure and naming an argument that need not be a context. Mathlib writes the underlying type in that case.
- `ContextTower.shifts : List (Function.End C)`; the six consumers write `Function.End (Context W E P T)`.
- `Reference.IsMonster (σ : Function.End C)` is a predicate on endomorphisms beside `IsRigid` on functions, with `isMonster_iff`, `not_isMonster_one`, `isMonster_attitudeShift` and `stable_of_not_isMonster` renamed off the alias's namespace.