### PR TITLE
refactor(Studies/Sternefeld1998): derive readings from closure-form **

### DIFF
--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -153,6 +153,11 @@ theorem algClosure_mono {Q : α → Prop} (h : ∀ x, P x → Q x) :
   | base hp => exact .base (h _ hp)
   | sum _ _ ih₁ ih₂ => exact .sum ih₁ ih₂
 
+/-- `*P` contains the sum of every nonempty finite family from `*P`. -/
+theorem algClosure_finsetSup' {ι : Type*} {s : Finset ι} (hs : s.Nonempty) {f : ι → α}
+    (hf : ∀ i ∈ s, AlgClosure P (f i)) : AlgClosure P (s.sup' hs f) :=
+  SupClosed.finsetSup'_mem algClosure_cum hs hf
+
 /-- Every element of `*P` has a `P`-element below it. -/
 theorem algClosure_has_base {x : α} (h : AlgClosure P x) : ∃ a, P a ∧ a ≤ x := by
   induction h with

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -42,10 +42,9 @@ mathlib's `SupHom` and could be folded into it (Todo).
 
 ## Todo
 
-* Bridge to `Distributivity.distMaximal`: the Finset-side operator is
-  the join-prime atom specialisation of `distr_atom_part`. Currently
-  prose-only (§6 below); a formal `distMaximal_iff_star_atoms` theorem
-  requires aligning `Finset Atom` with `Type*`-lattice carriers.
+* Bridge to `Distributivity.distMaximal`: on `Finset` carriers `star_image_singleton`
+  gives `*P = D P` for a `P` true of individuals only; the world-indexed
+  `distMaximal` is its pointwise form.
 -/
 
 namespace Plurality.Algebra
@@ -259,6 +258,36 @@ theorem properPlural_not_base {P : E → Prop}
   fun hPx => distr_disjoint_properPlural hDistr hPx hPP
 
 end Theorems
+
+/-! ### Sets of individuals
+
+On [schwarzschild-1996]'s set-based ontology, adopted by [sternefeld-1998], pluralities are
+finite sets of individuals, an individual is its singleton, and sum is union. -/
+
+section Finset
+variable {α : Type*} [DecidableEq α]
+
+/-- `*` of a set of individuals, taken as singletons, holds of exactly its nonempty subsets:
+`*P = D P` for a `P` true of individuals only ([sternefeld-1998], (15)). -/
+theorem star_image_singleton (S : Set α) (x : Finset α) :
+    star (· ∈ ({·} : α → Finset α) '' S) x ↔ x.Nonempty ∧ ↑x ⊆ S := by
+  constructor
+  · intro h
+    induction h with
+    | base h => obtain ⟨a, ha, rfl⟩ := h; exact ⟨Finset.singleton_nonempty a, by simpa⟩
+    | sum _ _ ih ih' =>
+      refine ⟨ih.1.mono Finset.subset_union_left, ?_⟩
+      rw [Finset.sup_eq_union, Finset.coe_union]
+      exact Set.union_subset ih.2 ih'.2
+  · rintro ⟨hx, hS⟩
+    have key : x.sup' hx (λ a => ({a} : Finset α)) = x :=
+      le_antisymm ((Finset.sup'_le_iff _ _).2 λ a ha => Finset.singleton_subset_iff.2 ha)
+        (Finset.subset_iff.2 λ a ha =>
+          Finset.singleton_subset_iff.1 (Finset.le_sup' (λ a => ({a} : Finset α)) ha))
+    rw [← key]
+    exact algClosure_finsetSup' hx λ a ha => .base ⟨a, hS ha, rfl⟩
+
+end Finset
 
 /-! ### Distributive inference (join-prime atoms) -/
 

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -287,6 +287,23 @@ theorem star_image_singleton (S : Set α) (x : Finset α) :
     rw [← key]
     exact algClosure_finsetSup' hx λ a ha => .base ⟨a, hS ha, rfl⟩
 
+/-- `*` of a predicate true of individuals only holds of the nonempty pluralities all of
+whose members satisfy it. -/
+theorem star_iff_of_subset_range_singleton {P : Finset α → Prop}
+    (hP : {x | P x} ⊆ Set.range ({·} : α → Finset α)) (x : Finset α) :
+    star P x ↔ x.Nonempty ∧ ∀ a ∈ x, P {a} := by
+  have : P = (· ∈ ({·} : α → Finset α) '' {a | P {a}}) := by
+    ext s
+    constructor
+    · intro hs
+      obtain ⟨a, rfl⟩ := hP hs
+      exact ⟨a, hs, rfl⟩
+    · rintro ⟨a, ha, rfl⟩
+      exact ha
+  conv_lhs => rw [this]
+  rw [star_image_singleton]
+  exact Iff.rfl
+
 end Finset
 
 /-! ### Distributive inference (join-prime atoms) -/

--- a/Linglib/Semantics/Plurality/Cumulativity.lean
+++ b/Linglib/Semantics/Plurality/Cumulativity.lean
@@ -1,29 +1,29 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Logic.Relation
+import Linglib.Semantics.Mereology
 
 /-!
 # Cumulative Predication
-[krifka-1989] [sternefeld-1998] [beck-sauerland-2000]
+[krifka-1986] [krifka-1989] [sternefeld-1998] [beck-sauerland-2000]
 
-Formalises the cumulative operator `**` in the bidirectional-coverage
-form. The operator originates with [krifka-1989] §3 (the SUM
-property `D.29` for binary relations); [sternefeld-1998] §3.1
-generalises to an n-ary closure operation (`***`); the
-bidirectional-coverage reformulation `(∀a∈x. ∃b∈y. R(a,b)) ∧
-(∀b∈y. ∃a∈x. R(a,b))` used here is from [beck-sauerland-2000].
-The two formulations are equivalent on Quine-innovation domains;
-`Studies/Sternefeld1998.lean::sternefeldStarStar_implies_cumulative`
-proves the forward direction.
+Formalises the cumulative operator `**` in its two forms. The closure form of [krifka-1986],
+adopted by [sternefeld-1998], takes the smallest relation containing `R` and closed under
+componentwise sum: Link's `*` on the product semilattice (`Cumulation`). The
+bidirectional-coverage form of [beck-sauerland-2000] asks that every atom of `x` be `R`-related
+to some atom of `y` and conversely (`Cumulative`). On finite sets of individuals the two agree
+away from the empty pair (`cumulation_map_singleton`).
 
 ## Main declarations
 
 * `Cumulative R x y` — bidirectional-coverage cumulative predication.
 * `LeftCoverage`, `RightCoverage` — the two conjuncts; their conjunction
   IS `Cumulative` (`cumulative_iff_coverages`).
-* `cumulative_left_universal`, `cumulative_right_universal` —
-  per-argument distributive consequences.
+* `Cumulative.union` — coverage is closed under componentwise union.
 * `singleton_right_cumulative` — `**` on a singleton right argument
   collapses to universal distribution.
+* `Cumulation R x y` — the closure form `**R` on any pair of join-semilattices.
+* `cumulation_map_singleton` — the closure and coverage forms agree on nonempty finite sets.
 
 ## Implementation notes
 
@@ -31,12 +31,11 @@ Link's `CUM` (`Mereology.CUM`) is a *property* of denotations:
 `P(x) ∧ P(y) → P(x ⊔ y)`. The `**` operator here takes a two-place
 predicate and returns a new predicate with cumulative truth conditions;
 the output of `**` applied to a non-cumulative predicate is itself
-cumulative.
+cumulative (`cumulation_iff_of_cum` is the fixed-point statement).
 
 ## Todo
 
-* n-ary `***` (Sternefeld 1998 §3.1) currently lives in
-  `Studies/Sternefeld1998.lean`; promote when ≥ 2 consumers.
+* n-ary `***` ([sternefeld-1998] §3.1) is not formalised.
 * Schein (1993) *Plurals and Events* (bib entry pending) — the
   event-quantification alternative to the `**`-relational treatment
   of cumulativity — is not yet formalised.
@@ -100,6 +99,27 @@ theorem cumulative_right_universal (R : A → B → Prop) (x : Finset A) (y : Fi
     ∃ a ∈ x, R a b :=
   h.2 b hb
 
+@[simp]
+theorem cumulative_singleton (R : A → B → Prop) (a : A) (b : B) :
+    Cumulative R {a} {b} ↔ R a b := by
+  simp [Cumulative]
+
+/-- Bidirectional coverage is closed under componentwise union. -/
+theorem Cumulative.union [DecidableEq A] [DecidableEq B] {R : A → B → Prop}
+    {x x' : Finset A} {y y' : Finset B} (h : Cumulative R x y) (h' : Cumulative R x' y') :
+    Cumulative R (x ∪ x') (y ∪ y') := by
+  refine ⟨λ a ha => ?_, λ b hb => ?_⟩
+  · rcases Finset.mem_union.1 ha with ha | ha
+    · obtain ⟨b, hb, hab⟩ := h.1 a ha
+      exact ⟨b, Finset.mem_union_left _ hb, hab⟩
+    · obtain ⟨b, hb, hab⟩ := h'.1 a ha
+      exact ⟨b, Finset.mem_union_right _ hb, hab⟩
+  · rcases Finset.mem_union.1 hb with hb | hb
+    · obtain ⟨a, ha, hab⟩ := h.2 b hb
+      exact ⟨a, Finset.mem_union_left _ ha, hab⟩
+    · obtain ⟨a, ha, hab⟩ := h'.2 b hb
+      exact ⟨a, Finset.mem_union_right _ ha, hab⟩
+
 /-- Left coverage with singleton right argument reduces to universal quantification.
 
     When the right plurality has exactly one element y, left coverage
@@ -132,5 +152,92 @@ theorem singleton_right_cumulative (R : A → B → Prop) (x : Finset A) (y : B)
   rw [Finset.mem_singleton.mp hb]
   obtain ⟨a, ha⟩ := hne
   exact ⟨a, ha, h a ha⟩
+
+/-! ### Closure form
+
+Krifka's `**R` is Link's `*` applied to `R` as a predicate on the product semilattice: the
+smallest relation containing `R` and closed under componentwise sum. -/
+
+section Closure
+
+open Mereology
+
+variable {α β : Type*} [SemilatticeSup α] [SemilatticeSup β] {R S : α → β → Prop}
+  {x x' : α} {y y' : β}
+
+/-- The cumulation `**R` of a relation ([krifka-1986]; [sternefeld-1998]): the closure of `R`
+under componentwise sum, `Mereology.AlgClosure` on the product semilattice. -/
+def Cumulation (R : α → β → Prop) (x : α) (y : β) : Prop :=
+  AlgClosure (Function.uncurry R) (x, y)
+
+theorem Cumulation.of_rel (h : R x y) : Cumulation R x y := AlgClosure.base h
+
+theorem Cumulation.sup (h : Cumulation R x y) (h' : Cumulation R x' y') :
+    Cumulation R (x ⊔ x') (y ⊔ y') :=
+  AlgClosure.sum h h'
+
+theorem Cumulation.mono (hRS : ∀ x y, R x y → S x y) (h : Cumulation R x y) :
+    Cumulation S x y :=
+  algClosure_mono (P := Function.uncurry R) (λ p => hRS p.1 p.2) _ h
+
+/-- A cumulative relation is its own cumulation. -/
+theorem cumulation_iff_of_cum (hR : CUM (Function.uncurry R)) : Cumulation R x y ↔ R x y :=
+  algClosure_of_cum hR
+
+end Closure
+
+/-! ### Sets of individuals -/
+
+section Finset
+
+open Mereology
+
+variable {A B : Type*} [DecidableEq A] [DecidableEq B]
+
+/-- On finite sets, `**` of a relation between individuals, taken as singletons, is
+bidirectional coverage of a nonempty pair: the closure form of [krifka-1986] and the coverage
+form of [beck-sauerland-2000] agree away from the empty pair. -/
+theorem cumulation_map_singleton (R : A → B → Prop) (x : Finset A) (y : Finset B) :
+    Cumulation (Relation.Map R ({·}) ({·})) x y ↔ x.Nonempty ∧ Cumulative R x y := by
+  constructor
+  · suffices ∀ p : Finset A × Finset B,
+        AlgClosure (Function.uncurry (Relation.Map R ({·}) ({·}))) p →
+          p.1.Nonempty ∧ Cumulative R p.1 p.2 from this (x, y)
+    intro p h
+    induction h with
+    | @base p h =>
+      obtain ⟨x, y⟩ := p
+      change ∃ a b, R a b ∧ ({a} : Finset A) = x ∧ ({b} : Finset B) = y at h
+      obtain ⟨a, b, hab, rfl, rfl⟩ := h
+      exact ⟨Finset.singleton_nonempty a, (cumulative_singleton R a b).2 hab⟩
+    | sum _ _ ih ih' => exact ⟨ih.1.mono Finset.subset_union_left, ih.2.union ih'.2⟩
+  · rintro ⟨hx, hl, hr⟩
+    have : Nonempty B := hx.elim λ a ha => (hl a ha).elim λ b _ => ⟨b⟩
+    have : Nonempty A := hx.elim λ a _ => ⟨a⟩
+    choose! f hf hRf using hl
+    choose! g hg hRg using hr
+    have hy : y.Nonempty := hx.elim λ a ha => ⟨f a, hf a ha⟩
+    have key : x.sup' hx (λ a => ({a}, {f a})) ⊔ y.sup' hy (λ b => ({g b}, {b})) = (x, y) := by
+      refine le_antisymm (sup_le ((Finset.sup'_le_iff _ _).2 λ a ha => ?_)
+        ((Finset.sup'_le_iff _ _).2 λ b hb => ?_))
+        (Prod.le_def.2 ⟨Finset.subset_iff.2 λ a ha => ?_, Finset.subset_iff.2 λ b hb => ?_⟩)
+      · exact Prod.le_def.2
+          ⟨Finset.singleton_subset_iff.2 ha, Finset.singleton_subset_iff.2 (hf a ha)⟩
+      · exact Prod.le_def.2
+          ⟨Finset.singleton_subset_iff.2 (hg b hb), Finset.singleton_subset_iff.2 hb⟩
+      · have hle :=
+          Prod.le_def.1 (Finset.le_sup' (λ a => (({a} : Finset A), ({f a} : Finset B))) ha)
+        rw [Prod.fst_sup, Finset.sup_eq_union]
+        exact Finset.mem_union_left _ (Finset.singleton_subset_iff.1 hle.1)
+      · have hle :=
+          Prod.le_def.1 (Finset.le_sup' (λ b => (({g b} : Finset A), ({b} : Finset B))) hb)
+        rw [Prod.snd_sup, Finset.sup_eq_union]
+        exact Finset.mem_union_right _ (Finset.singleton_subset_iff.1 hle.2)
+    show AlgClosure _ (x, y)
+    rw [← key]
+    exact AlgClosure.sum (algClosure_finsetSup' hx λ a ha => .base ⟨a, f a, hRf a ha, rfl, rfl⟩)
+      (algClosure_finsetSup' hy λ b hb => .base ⟨g b, b, hRg b hb, rfl, rfl⟩)
+
+end Finset
 
 end Plurality.Cumulativity

--- a/Linglib/Studies/Beck2001.lean
+++ b/Linglib/Studies/Beck2001.lean
@@ -35,8 +35,8 @@ The six-scheme entailment lattice ((28)) and the WR-as-cumulation identity ((120
 `weakReciprocity_iff_cumulative_strict`) live in `Plurality/Reciprocal.lean` and are
 consumed here. The convergence with [haug-dalrymple-2020] on presuppositional
 distinctness is housed in `Studies/HaugDalrymple2020.lean` (the later paper draws the
-comparison); the trivalent divergence from [sternefeld-1998] in
-`Studies/Sternefeld1998.lean`.
+comparison); the trivalent divergence from [sternefeld-1998] is noted at
+`SituationWeakReciprocity`.
 
 ## References
 

--- a/Linglib/Studies/Sternefeld1998.lean
+++ b/Linglib/Studies/Sternefeld1998.lean
@@ -17,9 +17,10 @@ jointly.
 
 ## Implementation notes
 
-* A relation over pluralities is D-based when it holds only between singletons (§2.3); its
-  restriction to individuals is `R {a} {b}`, and Langendoen's formulae are the substrate
-  schemes `Reciprocal.WeakReciprocity` and `Reciprocal.StrongReciprocity` of that restriction.
+* A relation between individuals enters the set-based ontology as its image under singleton
+  formation, `Relation.Map R ({·}) ({·})`; this is the paper's D-based case (§2.3), and
+  Langendoen's formulae are the substrate schemes `Reciprocal.WeakReciprocity` and
+  `Reciprocal.StrongReciprocity` of `R` itself.
 * Denotations are nonempty, so the equivalences carry the nonemptiness, or for strong
   reciprocity the two-member, hypothesis that `*` and `**` build in and Langendoen's formulae
   leave vacuous.
@@ -41,64 +42,39 @@ open Mereology Plurality.Algebra Plurality.Cumulativity Reciprocal
 
 variable {α β : Type*}
 
-/-! ### D-based relations -/
+/-! ### Relations between individuals -/
 
-/-- A relation over pluralities is D-based when it holds only between individuals, that is
-between singletons (§2.3). -/
-def DBased (R : Finset α → Finset β → Prop) : Prop :=
-  ∀ ⦃x y⦄, R x y → ∃ a b, x = {a} ∧ y = {b}
+@[simp]
+theorem map_singleton_singleton (R : α → β → Prop) (a : α) (b : β) :
+    Relation.Map R ({·}) ({·}) ({a} : Finset α) ({b} : Finset β) ↔ R a b := by
+  simp [Relation.Map, Finset.singleton_inj]
 
-theorem DBased.apply {R : Finset α → Finset β → Prop} (hR : DBased R) (x : Finset α) :
-    ∀ ⦃y⦄, R x y → ∃ b, y = {b} := λ _ h =>
-  let ⟨_, b, _, hb⟩ := hR h
-  ⟨b, hb⟩
+/-- `*` of a relation between individuals, in its second argument, holds of the nonempty
+pluralities all of whose members are related to the first. -/
+theorem star_map_iff [DecidableEq β] (R : α → β → Prop) (a : α) (B : Finset β) :
+    star (Relation.Map R ({·}) ({·}) ({a} : Finset α)) B ↔ B.Nonempty ∧ ∀ b ∈ B, R a b := by
+  rw [star_iff_of_subset_range_singleton]
+  · simp only [map_singleton_singleton]
+  · rintro _ ⟨_, b, _, _, rfl⟩
+    exact ⟨b, rfl⟩
 
-/-- `*` of a D-based relation's second argument is D-based in the first. -/
-theorem DBased.star [DecidableEq β] {R : Finset α → Finset β → Prop} (hR : DBased R)
-    (B : Finset α → Finset β) : ∀ ⦃x⦄, star (R x) (B x) → ∃ a, x = {a} :=
+private theorem star_map_subset_range [DecidableEq β] (R : α → β → Prop)
+    (B : Finset α → Finset β) :
+    {x : Finset α | star (Relation.Map R ({·}) ({·}) x) (B x)} ⊆
+      Set.range ({·} : α → Finset α) :=
   λ _ h =>
     let ⟨_, hy, _⟩ := algClosure_has_base h
-    let ⟨a, _, ha, _⟩ := hR hy
+    let ⟨a, _, _, ha, _⟩ := hy
     ⟨a, ha⟩
-
-/-- A D-based relation is the singleton image of its restriction to individuals. -/
-theorem DBased.eq_map {R : Finset α → Finset β → Prop} (h : DBased R) :
-    R = Relation.Map (λ a b => R {a} {b}) ({·}) ({·}) := by
-  ext x y
-  constructor
-  · intro hxy
-    obtain ⟨a, b, rfl, rfl⟩ := h hxy
-    exact ⟨a, b, hxy, rfl, rfl⟩
-  · rintro ⟨a, b, hab, rfl, rfl⟩
-    exact hab
 
 variable [DecidableEq α] [DecidableEq β]
 
-/-- `*` of a predicate true of individuals only is the distributive `D` (15): it holds of the
-nonempty pluralities all of whose members satisfy it. -/
-theorem star_iff_of_dBased {P : Finset α → Prop} (hP : ∀ ⦃x⦄, P x → ∃ a, x = {a})
-    {x : Finset α} : star P x ↔ x.Nonempty ∧ ∀ a ∈ x, P {a} := by
-  have : P = (· ∈ ({·} : α → Finset α) '' {a | P {a}}) := by
-    ext s
-    constructor
-    · intro hs
-      obtain ⟨a, rfl⟩ := hP hs
-      exact ⟨a, hs, rfl⟩
-    · rintro ⟨a, ha, rfl⟩
-      exact ha
-  conv_lhs => rw [this]
-  rw [star_image_singleton]
-  exact Iff.rfl
-
 /-! ### Weak distributivity and weak reciprocity -/
 
-/-- Weak distributivity (2b) is `⟨A, B⟩ ∈ **R` (26a) for a D-based `R` between nonempty
-pluralities. -/
-theorem cumulation_iff_cumulative {R : Finset α → Finset β → Prop} (hR : DBased R)
-    {A : Finset α} (hA : A.Nonempty) (B : Finset β) :
-    Cumulation R A B ↔ Cumulative (λ a b => R {a} {b}) A B := by
-  conv_lhs => rw [hR.eq_map]
-  rw [cumulation_map_singleton, and_iff_right hA]
+/-- Weak distributivity (2b) is `⟨A, B⟩ ∈ **R` (26a) between nonempty pluralities. -/
+theorem cumulation_map_iff (R : α → β → Prop) {A : Finset α} (hA : A.Nonempty) (B : Finset β) :
+    Cumulation (Relation.Map R ({·}) ({·})) A B ↔ Cumulative R A B :=
+  (cumulation_map_singleton R A B).trans (and_iff_right hA)
 
 /-- Weak reciprocity (6), (26b): the reciprocal NP denotes the others, and non-identity is
 conjoined into the relation before cumulation. -/
@@ -115,12 +91,19 @@ theorem wr_of_weakReciprocity {R : Finset α → Finset α → Prop} {A : Finset
   rintro x y ⟨a, b, ⟨hab, hne⟩, rfl, rfl⟩
   exact ⟨hab, Finset.singleton_injective.ne hne⟩
 
-/-- For a D-based `R`, (26b) is Langendoen's (25b): weak reciprocity between individuals. -/
-theorem wr_iff {R : Finset α → Finset α → Prop} (hR : DBased R) {A : Finset α}
-    (hA : A.Nonempty) : WR R A ↔ WeakReciprocity (λ a b => R {a} {b}) A := by
-  have hR' : DBased (λ x y => R x y ∧ x ≠ y) := λ x y h => hR h.1
-  rw [WR, cumulation_iff_cumulative hR' hA, weakReciprocity_iff_cumulative_strict]
-  simp only [ne_eq, Finset.singleton_inj]
+/-- For a relation between individuals, (26b) is Langendoen's (25b). -/
+theorem wr_map_iff (R : α → α → Prop) {A : Finset α} (hA : A.Nonempty) :
+    WR (Relation.Map R ({·}) ({·})) A ↔ WeakReciprocity R A := by
+  have : (λ x y : Finset α => Relation.Map R ({·}) ({·}) x y ∧ x ≠ y) =
+      Relation.Map (λ a b => R a b ∧ a ≠ b) ({·}) ({·}) := by
+    ext x y
+    constructor
+    · rintro ⟨⟨a, b, hab, rfl, rfl⟩, hne⟩
+      exact ⟨a, b, ⟨hab, Finset.singleton_injective.ne_iff.1 hne⟩, rfl, rfl⟩
+    · rintro ⟨a, b, ⟨hab, hne⟩, rfl, rfl⟩
+      exact ⟨⟨a, b, hab, rfl, rfl⟩, Finset.singleton_injective.ne hne⟩
+  rw [WR, this, cumulation_map_singleton, and_iff_right hA,
+    weakReciprocity_iff_cumulative_strict]
 
 /-! ### Langendoen's model
 
@@ -134,9 +117,13 @@ def langendoenModel (x y : Finset (Fin 3)) : Prop :=
 instance : DecidableRel langendoenModel := λ _ _ => by
   unfold langendoenModel; infer_instance
 
-theorem not_dBased_langendoenModel : ¬ DBased langendoenModel := by
+/-- Langendoen's relation is not a relation between individuals. -/
+theorem langendoenModel_ne_map (R : Fin 3 → Fin 3 → Prop) :
+    langendoenModel ≠ Relation.Map R ({·}) ({·}) := by
   intro h
-  obtain ⟨a, -, ha, -⟩ := h (Or.inl ⟨rfl, rfl⟩)
+  have hL : langendoenModel {0, 1} {2} := Or.inl ⟨rfl, rfl⟩
+  rw [h] at hL
+  obtain ⟨a, -, -, ha, -⟩ := hL
   revert a
   decide
 
@@ -158,32 +145,28 @@ theorem not_weakReciprocity_langendoenModel :
 /-! ### Strong distributivity and strong reciprocity by iterated `*` -/
 
 /-- Strong distributivity by iterated `*` (7): `A ∈ *{x : B ∈ *{y : R(x, y)}}`. -/
-def SD (R : Finset α → Finset β → Prop) (A : Finset α) (B : Finset β) : Prop :=
-  star (λ x => star (R x) B) A
+def SD (R : α → β → Prop) (A : Finset α) (B : Finset β) : Prop :=
+  star (λ x : Finset α => star (Relation.Map R ({·}) ({·}) x) B) A
 
 /-- Strong reciprocity by iterated `*` (48b): `A ∈ *λx[{y : y ∈ A ∧ y ≠ x} ∈ *λy.R(x, y)]`,
 the reciprocal interpreted in situ as one NP. -/
-def SR (R : Finset α → Finset α → Prop) (A : Finset α) : Prop :=
-  star (λ x => star (R x) (A.filter λ b => ({b} : Finset α) ≠ x)) A
+def SR (R : α → α → Prop) (A : Finset α) : Prop :=
+  star (λ x : Finset α =>
+    star (Relation.Map R ({·}) ({·}) x) (A.filter λ b => ({b} : Finset α) ≠ x)) A
 
-/-- For a D-based `R`, (7) is Langendoen's strong distributivity (2a) between nonempty
-pluralities. -/
-theorem sd_iff {R : Finset α → Finset β → Prop} (hR : DBased R) {A : Finset α} {B : Finset β}
-    (hA : A.Nonempty) (hB : B.Nonempty) : SD R A B ↔ ∀ a ∈ A, ∀ b ∈ B, R {a} {b} := by
-  have hout : ∀ ⦃x⦄, star (R x) B → ∃ a, x = {a} := hR.star _
-  rw [SD, star_iff_of_dBased hout, and_iff_right hA]
-  refine forall₂_congr λ a _ => ?_
-  rw [star_iff_of_dBased (hR.apply _), and_iff_right hB]
+/-- (7) is Langendoen's strong distributivity (2a) between nonempty pluralities. -/
+theorem sd_iff (R : α → β → Prop) {A : Finset α} {B : Finset β} (hA : A.Nonempty)
+    (hB : B.Nonempty) : SD R A B ↔ ∀ a ∈ A, ∀ b ∈ B, R a b := by
+  rw [SD, star_iff_of_subset_range_singleton (star_map_subset_range R λ _ => B),
+    and_iff_right hA]
+  exact forall₂_congr λ a _ => (star_map_iff R a B).trans (and_iff_right hB)
 
-/-- For a D-based `R`, (48b) is Langendoen's strong reciprocity (3a) on a plurality of two or
-more. -/
-theorem sr_iff {R : Finset α → Finset α → Prop} (hR : DBased R) {A : Finset α} :
-    SR R A ↔ 2 ≤ A.card ∧ StrongReciprocity (λ a b => R {a} {b}) A := by
-  have hout : ∀ ⦃x⦄, star (R x) (A.filter λ b => ({b} : Finset α) ≠ x) → ∃ a, x = {a} :=
-    hR.star _
-  rw [SR, star_iff_of_dBased hout]
-  simp only [star_iff_of_dBased (hR.apply _), Finset.mem_filter, ne_eq,
-    Finset.singleton_inj, Finset.filter_nonempty_iff, StrongReciprocity]
+/-- (48b) is Langendoen's strong reciprocity (3a) on a plurality of two or more. -/
+theorem sr_iff (R : α → α → Prop) {A : Finset α} :
+    SR R A ↔ 2 ≤ A.card ∧ StrongReciprocity R A := by
+  rw [SR, star_iff_of_subset_range_singleton (star_map_subset_range R _)]
+  simp only [star_map_iff, Finset.mem_filter, ne_eq, Finset.singleton_inj,
+    Finset.filter_nonempty_iff, StrongReciprocity]
   constructor
   · rintro ⟨⟨a, ha⟩, h⟩
     obtain ⟨⟨b, hb, hba⟩, -⟩ := h a ha

--- a/Linglib/Studies/Sternefeld1998.lean
+++ b/Linglib/Studies/Sternefeld1998.lean
@@ -1,288 +1,197 @@
-import Mathlib.Data.Finset.Card
-import Linglib.Semantics.Plurality.Cumulativity
+import Linglib.Semantics.Plurality.Algebra
 import Linglib.Semantics.Plurality.Reciprocal
-import Linglib.Studies.Beck2001
 
 /-!
-# Sternefeld (1998): Reciprocity and Cumulative Predication
-[sternefeld-1998]
+# Sternefeld (1998): Reciprocity and cumulative predication
 
-*Natural Language Semantics* 6(3): 303–337. doi:10.1023/A:1008352502939.
+This file formalizes [sternefeld-1998]'s derivation of the readings of plural and reciprocal
+sentences from the placement of Link's `*` and Krifka's `**` at Logical Form, on
+[schwarzschild-1996]'s set-based ontology: pluralities are finite sets of individuals, an
+individual is its singleton, and sum is union. Weak distributivity is `**R` and weak
+reciprocity is `**` of the relation with non-identity conjoined into it, so the reciprocal
+carries no quantifier of its own; strong distributivity and strong reciprocity are iterated
+`*`. We prove that for a relation between individuals each form is the corresponding formula
+of [langendoen-1978], that Langendoen's weak reciprocity always entails the cumulation form,
+and that the converse fails in Langendoen's model where two individuals relate to a third only
+jointly.
 
-[sternefeld-1998] extends [langendoen-1978]'s
-reciprocity-as-cumulativity insight into a fully compositional theory.
-Distinct readings of plural and reciprocal sentences arise from
-different placements of the pluralization operators (`*` and `**`) at
-Logical Form. The reciprocal NP itself denotes "the others", with the
-non-identity statement injected into the LF as semantic glue.
+## Implementation notes
 
-## Headline analysis (paper §3, eq 26b)
+* A relation over pluralities is D-based when it holds only between singletons (§2.3); its
+  restriction to individuals is `R {a} {b}`, and Langendoen's formulae are the substrate
+  schemes `Reciprocal.WeakReciprocity` and `Reciprocal.StrongReciprocity` of that restriction.
+* Denotations are nonempty, so the equivalences carry the nonemptiness, or for strong
+  reciprocity the two-member, hypothesis that `*` and `**` build in and Langendoen's formulae
+  leave vacuous.
+* The n-ary `***` (§3.1), dependent plurals (§3.2–3.3), LF movement (§3.4), the Geach–Kaplan
+  sentence (§3.6) and the cover pragmatics of §4 are not formalized.
 
-Sternefeld's WR analysis: `⟨A, A⟩ ∈ **λxy[R(x, y) ∧ x ≠ y]`. The
-distinctness condition `x ≠ y` is **inside** the `**`'s relation
-argument — NOT a separate asserted clause as some readings of the
-literature suggest.
+## References
 
-In bivalent semantics this is structurally identical to
-[beck-2001]'s eq 120 (`**(λxλy.[R(x,y) ∧ @(x ≠ y)])(A,A)`). The
-two analyses agree on the bivalent predicate — `Reciprocal.WeakReciprocity`
-— and diverge only on:
-
-1. **Status of distinctness**: Sternefeld asserts; Beck presupposes
-   (`@`). Visible only in trivalent semantics (truth-value gap when R
-   holds with x = y).
-2. **Status of SR**: [sternefeld-1998] §3.5 argues SR is
-   *expressible* in his framework but defends in §3.6 (the
-   Geach-Kaplan sentence) that SR is "probably a special case of WR"
-   plus *only*-focus on the non-identity statement. [beck-2001]
-   takes SR as a basic reading.
-3. **`**` operator shape**: [sternefeld-1998] eq 5 uses
-   [krifka-1989]'s closure form (smallest relation closed under
-   `⟨a,b⟩+⟨c,d⟩ → ⟨a∪c, b∪d⟩`); [beck-sauerland-2000] use
-   bidirectional coverage (`(∀a∈x. ∃b∈y. R(a,b)) ∧ (∀b∈y. ∃a∈x. R(a,b))`).
-   Equivalent on Quine-innovation domains where individuals are
-   identified with singletons.
-
-## What is formalized
-
-| Paper §  | Topic                                                    | Lean encoding              |
-|----------|----------------------------------------------------------|----------------------------|
-| §2 eq 5  | `**` operator ([krifka-1989] closure form)          | `sternefeldStarStar` (inductive) |
-| §2.4 eq 12 | WD analysis (Scha 1981 cumulative)                     | (deferred)                 |
-| §3 eq 26b | WR analysis (distinctness inside relation)              | `sternefeldWR`             |
-| §3 eq 25b | Langendoen-style WR (existence-witnessed)               | `langendoenWR`             |
-| §3.5 eq 48b | SR expressed as iterated `*` distribution             | `sternefeldSR_iff_stronglyReciprocal` |
-
-The `**` closure-form ↔ bidirectional-coverage equivalence is proved
-in the easy direction (`sternefeldStarStar_implies_cumulative`).
-The reverse direction is a substantial inductive argument that would
-properly belong in `Semantics/Plurality/Cumulativity.lean` as
-substrate justification for treating the two `**` formulations as
-interchangeable; not in this study file.
-
-## Out of scope
-
-- §2.5 Plural Predication at LF (Augmented Logical Forms with
-  freely-inserted `*` operators) — purely representational; would
-  require Tree.lean syntactic-tree machinery.
-- §3.1 Three-place relations (`***` operator, paper eq 29) — small
-  extension of `**`; substrate-deferred.
-- §3.2–3.3 dependent plurals + Heim's inner/outer indices — would
-  require inner/outer-index distinction substrate.
-- §3.4 LF-movement crossover constraint — syntax, not semantics.
-- §3.6 Geach-Kaplan sentence with [rooth-1985] focus — would
-  require Focus substrate; the SR-derivation step is recorded in
-  prose but not as a Lean theorem.
-- §4.1–4.2 [schwarzschild-1996] covers as pragmatic supplement —
-  substrate exists in `Plurality.Cover`; the closure-of-`**` ↔
-  Schwarzschild-PPart(PCov) reduction is a separate effort.
-
-## Connection to [beck-2001] and [haug-dalrymple-2020]
-
-[beck-2001] cites Sternefeld 1998 as the immediate predecessor
-and at one point characterises Sternefeld's analysis as bare-`**(R)(A,A)`
-(i.e., without distinctness in the relation). Reading Sternefeld 1998
-directly: bare `**(R)(A,A)` does NOT appear in his analysis; his
-actual eq 26b *has* distinctness inside the relation. The
-Beck-vs-Sternefeld difference is therefore presupposition-vs-assertion
-of the distinctness clause, not structural placement.
-
-[haug-dalrymple-2020] consumes the same `**` machinery via the
-PPCDRT bridge `groupIdentityCond_iff_cumulative_eq`. The three-paper
-convergence on `**`-cumulation as the heart of reciprocity is the
-linglib interconnection-density payoff: Sternefeld's WR ↔ Beck's
-eq 120 ↔ H&D's group identity all factor through
-`Plurality.Cumulativity.Cumulative`.
+* [sternefeld-1998]
+* [langendoen-1978]
+* [krifka-1986]
+* [link-1983]
+* [schwarzschild-1996]
 -/
 
 namespace Sternefeld1998
 
-open Plurality.Cumulativity
-open Reciprocal
+open Mereology Plurality.Algebra Plurality.Cumulativity Reciprocal
 
-variable {α : Type*} [DecidableEq α]
+variable {α β : Type*}
 
--- ════════════════════════════════════════════════════════════════
--- § 1: Sternefeld's `**` Operator (paper eq 5, [krifka-1989])
--- ════════════════════════════════════════════════════════════════
+/-! ### D-based relations -/
 
-/-- **Sternefeld eq 5 / [krifka-1989]**: the smallest relation
-    `Q` over `Finset α × Finset α` such that `R ⊆ Q` (lifted to
-    singletons) and `Q` is closed under `⟨a,b⟩ + ⟨c,d⟩ → ⟨a∪c, b∪d⟩`.
+/-- A relation over pluralities is D-based when it holds only between individuals, that is
+between singletons (§2.3). -/
+def DBased (R : Finset α → Finset β → Prop) : Prop :=
+  ∀ ⦃x y⦄, R x y → ∃ a b, x = {a} ∧ y = {b}
 
-    On Quine-innovation domains, this is equivalent to
-    [beck-sauerland-2000]'s bidirectional-coverage `Cumulative`
-    — see `sternefeldStarStar_implies_cumulative` for the easy
-    direction. The reverse direction holds on nonempty pluralities
-    but the inductive proof is non-trivial; substrate-deferred. -/
-inductive sternefeldStarStar (R : α → α → Prop) : Finset α → Finset α → Prop
-  | base {a b : α} (h : R a b) : sternefeldStarStar R {a} {b}
-  | union {a b c d : Finset α}
-      (hab : sternefeldStarStar R a b) (hcd : sternefeldStarStar R c d) :
-      sternefeldStarStar R (a ∪ c) (b ∪ d)
+theorem DBased.apply {R : Finset α → Finset β → Prop} (hR : DBased R) (x : Finset α) :
+    ∀ ⦃y⦄, R x y → ∃ b, y = {b} := λ _ h =>
+  let ⟨_, b, _, hb⟩ := hR h
+  ⟨b, hb⟩
 
-/-- **Sternefeld closure form `**` entails [beck-sauerland-2000]
-    bidirectional coverage** (the easy direction of the equivalence
-    `sternefeldStarStar R x y ↔ Cumulative R x y`).
+/-- `*` of a D-based relation's second argument is D-based in the first. -/
+theorem DBased.star [DecidableEq β] {R : Finset α → Finset β → Prop} (hR : DBased R)
+    (B : Finset α → Finset β) : ∀ ⦃x⦄, star (R x) (B x) → ∃ a, x = {a} :=
+  λ _ h =>
+    let ⟨_, hy, _⟩ := algClosure_has_base h
+    let ⟨a, _, ha, _⟩ := hR hy
+    ⟨a, ha⟩
 
-    Proof: induction on the closure derivation. Base case
-    `⟨{a},{b}⟩` from `R a b`: both quantifiers reduce to the witness
-    pair. Union case: bidirectional coverage of `⟨a∪c, b∪d⟩` follows
-    from coverage of `⟨a,b⟩` and `⟨c,d⟩` by case-splitting on the
-    union membership. -/
-theorem sternefeldStarStar_implies_cumulative
-    (R : α → α → Prop) (x y : Finset α)
-    (h : sternefeldStarStar R x y) :
-    Cumulative R x y := by
-  induction h with
-  | base hab =>
-    refine ⟨?_, ?_⟩
-    · intro p hp
-      rw [Finset.mem_singleton] at hp
-      subst hp
-      exact ⟨_, Finset.mem_singleton_self _, hab⟩
-    · intro q hq
-      rw [Finset.mem_singleton] at hq
-      subst hq
-      exact ⟨_, Finset.mem_singleton_self _, hab⟩
-  | @union a b c d _ _ ihab ihcd =>
-    refine ⟨?_, ?_⟩
-    · intro p hp
-      rw [Finset.mem_union] at hp
-      cases hp with
-      | inl hpa =>
-        obtain ⟨q, hqb, hRpq⟩ := ihab.1 p hpa
-        exact ⟨q, Finset.mem_union_left d hqb, hRpq⟩
-      | inr hpc =>
-        obtain ⟨q, hqd, hRpq⟩ := ihcd.1 p hpc
-        exact ⟨q, Finset.mem_union_right b hqd, hRpq⟩
-    · intro q hq
-      rw [Finset.mem_union] at hq
-      cases hq with
-      | inl hqb =>
-        obtain ⟨p, hpa, hRpq⟩ := ihab.2 q hqb
-        exact ⟨p, Finset.mem_union_left c hpa, hRpq⟩
-      | inr hqd =>
-        obtain ⟨p, hpc, hRpq⟩ := ihcd.2 q hqd
-        exact ⟨p, Finset.mem_union_right a hpc, hRpq⟩
+/-- A D-based relation is the singleton image of its restriction to individuals. -/
+theorem DBased.eq_map {R : Finset α → Finset β → Prop} (h : DBased R) :
+    R = Relation.Map (λ a b => R {a} {b}) ({·}) ({·}) := by
+  ext x y
+  constructor
+  · intro hxy
+    obtain ⟨a, b, rfl, rfl⟩ := h hxy
+    exact ⟨a, b, hxy, rfl, rfl⟩
+  · rintro ⟨a, b, hab, rfl, rfl⟩
+    exact hab
 
--- ════════════════════════════════════════════════════════════════
--- § 2: Sternefeld's WR Analysis (paper §3, eq 26b)
--- ════════════════════════════════════════════════════════════════
+variable [DecidableEq α] [DecidableEq β]
 
-/-- **Sternefeld 1998 eq 26b**: WR truth conditions are
-    `⟨A, A⟩ ∈ **λxy[R(x, y) ∧ x ≠ y]`. The distinctness clause is
-    INSIDE the `**`'s relation argument, NOT a separate asserted
-    clause.
+/-- `*` of a predicate true of individuals only is the distributive `D` (15): it holds of the
+nonempty pluralities all of whose members satisfy it. -/
+theorem star_iff_of_dBased {P : Finset α → Prop} (hP : ∀ ⦃x⦄, P x → ∃ a, x = {a})
+    {x : Finset α} : star P x ↔ x.Nonempty ∧ ∀ a ∈ x, P {a} := by
+  have : P = (· ∈ ({·} : α → Finset α) '' {a | P {a}}) := by
+    ext s
+    constructor
+    · intro hs
+      obtain ⟨a, rfl⟩ := hP hs
+      exact ⟨a, hs, rfl⟩
+    · rintro ⟨a, ha, rfl⟩
+      exact ha
+  conv_lhs => rw [this]
+  rw [star_image_singleton]
+  exact Iff.rfl
 
-    Encoding choice: we use [beck-sauerland-2000]'s bidirectional
-    coverage `Cumulative` for `**` (see
-    `sternefeldStarStar_implies_cumulative` for the connection to
-    Sternefeld's closure-form `**`).
+/-! ### Weak distributivity and weak reciprocity -/
 
-    In bivalent semantics this is structurally identical to
-    `Reciprocal.WeakReciprocity` (and to Beck eq 120). The
-    two analyses diverge only on the trivalent assertion-vs-
-    presupposition status of `x ≠ y` (Sternefeld asserts;
-    [beck-2001] eq 120 presupposes via `@`). -/
-def sternefeldWR (A : Finset α) (R : α → α → Prop) : Prop :=
-  Cumulative (fun x y => R x y ∧ x ≠ y) A A
+/-- Weak distributivity (2b) is `⟨A, B⟩ ∈ **R` (26a) for a D-based `R` between nonempty
+pluralities. -/
+theorem cumulation_iff_cumulative {R : Finset α → Finset β → Prop} (hR : DBased R)
+    {A : Finset α} (hA : A.Nonempty) (B : Finset β) :
+    Cumulation R A B ↔ Cumulative (λ a b => R {a} {b}) A B := by
+  conv_lhs => rw [hR.eq_map]
+  rw [cumulation_map_singleton, and_iff_right hA]
 
-instance sternefeldWR.instDecidable
-    (A : Finset α) (R : α → α → Prop) [∀ a b, Decidable (R a b)] :
-    Decidable (sternefeldWR A R) := by
-  unfold sternefeldWR; infer_instance
+/-- Weak reciprocity (6), (26b): the reciprocal NP denotes the others, and non-identity is
+conjoined into the relation before cumulation. -/
+def WR (R : Finset α → Finset α → Prop) (A : Finset α) : Prop :=
+  Cumulation (λ x y => R x y ∧ x ≠ y) A A
 
-/-- **Sternefeld 1998 ↔ Beck 2001 (bivalent collapse)**: in bivalent
-    encoding, the two reciprocity analyses produce identical
-    predicates. The cumulation-with-distinctness shape is the
-    *common ground* of both papers; they only diverge at the
-    trivalent (presupposition projection) layer. Substrate form
-    `Reciprocal.WeakReciprocity`. -/
-theorem sternefeldWR_iff_WeakReciprocity
-    (A : Finset α) (R : α → α → Prop) :
-    sternefeldWR A R ↔ WeakReciprocity R A :=
-  (weakReciprocity_iff_cumulative_strict R A).symm
+/-- Langendoen's weak reciprocity (25b) between individuals entails (26b), for any relation
+over pluralities. -/
+theorem wr_of_weakReciprocity {R : Finset α → Finset α → Prop} {A : Finset α}
+    (hA : A.Nonempty) (h : WeakReciprocity (λ a b => R {a} {b}) A) : WR R A := by
+  have := (cumulation_map_singleton (λ a b => R {a} {b} ∧ a ≠ b) A A).2
+    ⟨hA, (weakReciprocity_iff_cumulative_strict _ _).1 h⟩
+  refine this.mono ?_
+  rintro x y ⟨a, b, ⟨hab, hne⟩, rfl, rfl⟩
+  exact ⟨hab, Finset.singleton_injective.ne hne⟩
 
--- ════════════════════════════════════════════════════════════════
--- § 3: Langendoen-style WR (paper §1, eq 25b — equivalent on
--- nonempty A but historically attributed to [langendoen-1978])
--- ════════════════════════════════════════════════════════════════
+/-- For a D-based `R`, (26b) is Langendoen's (25b): weak reciprocity between individuals. -/
+theorem wr_iff {R : Finset α → Finset α → Prop} (hR : DBased R) {A : Finset α}
+    (hA : A.Nonempty) : WR R A ↔ WeakReciprocity (λ a b => R {a} {b}) A := by
+  have hR' : DBased (λ x y => R x y ∧ x ≠ y) := λ x y h => hR h.1
+  rw [WR, cumulation_iff_cumulative hR' hA, weakReciprocity_iff_cumulative_strict]
+  simp only [ne_eq, Finset.singleton_inj]
 
-/-- **[langendoen-1978] WR** (paper eq 25b): for each `x ∈ A`,
-    there are `y, z ∈ A` with `x ≠ y`, `x ≠ z`, `xRy`, `zRx`. This is
-    the existence-witnessed form Sternefeld attributes to Langendoen.
+/-! ### Langendoen's model
 
-    Sternefeld notes (paper p. 316) that this form does not entail his
-    eq 26b for non-D-based relations; in particular, in the
-    "problematic situation" `f(R) = {⟨⟨a,b⟩, c⟩, ⟨c, a⟩, ⟨c, b⟩}`,
-    eq 25b cannot apply but eq 26b is still true. For D-based
-    relations on Quine-innovation domains, the two coincide and both
-    reduce to `Reciprocal.WeakReciprocity`. -/
-def langendoenWR (A : Finset α) (R : α → α → Prop) : Prop :=
-  ∀ x ∈ A, ∃ y ∈ A, ∃ z ∈ A,
-    x ≠ y ∧ x ≠ z ∧ R x y ∧ R z x
+`A = {a, b, c}` and `R = {⟨{a, b}, c⟩, ⟨c, a⟩, ⟨c, b⟩}` (§3): the As relate to each other,
+but no individual relates to `c` on its own, so (25b) fails while (26b) holds. -/
 
-instance langendoenWR.instDecidable
-    (A : Finset α) (R : α → α → Prop) [∀ a b, Decidable (R a b)] :
-    Decidable (langendoenWR A R) := by
-  unfold langendoenWR; infer_instance
+/-- Langendoen's relation: `a` and `b` relate to `c` jointly, and `c` relates to each. -/
+def langendoenModel (x y : Finset (Fin 3)) : Prop :=
+  (x = {0, 1} ∧ y = {2}) ∨ (x = {2} ∧ y = {0}) ∨ (x = {2} ∧ y = {1})
 
-/-- For symmetric, distinctness-bearing R, [langendoen-1978] WR
-    entails `Reciprocal.WeakReciprocity`: the existence-
-    witnesses on each side are the y and z of the Langendoen formula. -/
-theorem langendoenWR_implies_WeakReciprocity
-    (A : Finset α) (R : α → α → Prop)
-    (h : langendoenWR A R) :
-    WeakReciprocity R A := by
-  refine ⟨?_, ?_⟩
-  · intro x hx
-    obtain ⟨y, hy, _, _, hxy, _, hRxy, _⟩ := h x hx
-    exact ⟨y, hy, hRxy, hxy⟩
-  · intro x hx
-    obtain ⟨_, _, z, hz, _, hxz, _, hRzx⟩ := h x hx
-    exact ⟨z, hz, hRzx, hxz.symm⟩
+instance : DecidableRel langendoenModel := λ _ _ => by
+  unfold langendoenModel; infer_instance
 
--- ════════════════════════════════════════════════════════════════
--- § 4: Strong Reciprocity Expressibility (paper §3.5, eq 48b)
--- ════════════════════════════════════════════════════════════════
+theorem not_dBased_langendoenModel : ¬ DBased langendoenModel := by
+  intro h
+  obtain ⟨a, -, ha, -⟩ := h (Or.inl ⟨rfl, rfl⟩)
+  revert a
+  decide
 
-/-- **Sternefeld §3.5 eq 48b** (SR via iterated distribution):
-    `A ∈ *λx[{y: y ∈ A ∧ y ≠ x} ∈ *λy.R(x, y)]`. The outer `*`
-    distributes over A; the inner `*` quantifies universally over
-    `{y ∈ A : y ≠ x}`. Assuming R is D-based (applies only to atoms),
-    this unfolds to `∀x ∈ A. ∀y ∈ A. y ≠ x → R(x,y)` — exactly
-    `Reciprocal.StrongReciprocity`.
+/-- (26b) holds in Langendoen's model. -/
+theorem wr_langendoenModel : WR langendoenModel Finset.univ := by
+  have h₁ : ({0, 1} : Finset (Fin 3)) ⊔ ({2} ⊔ {2}) = Finset.univ := by decide
+  have h₂ : ({2} : Finset (Fin 3)) ⊔ ({0} ⊔ {1}) = Finset.univ := by decide
+  have h := (Cumulation.of_rel (R := λ x y => langendoenModel x y ∧ x ≠ y)
+      (x := {0, 1}) (y := {2}) (by decide)).sup
+    ((Cumulation.of_rel (x := {2}) (y := {0}) (by decide)).sup
+      (Cumulation.of_rel (x := {2}) (y := {1}) (by decide)))
+  simpa only [WR, h₁, h₂] using h
 
-    Sternefeld's point (paper §3.5–3.6): SR is *expressible* in his
-    framework but is not a basic reading; it falls out of more
-    general WR + focus mechanisms (the Geach-Kaplan analysis,
-    paper §3.6). This contrasts with [beck-2001], who takes SR
-    as a basic reading. -/
-theorem sternefeldSR_iff_StrongReciprocity
-    (A : Finset α) (R : α → α → Prop) :
-    (∀ x ∈ A, ∀ y ∈ A, y ≠ x → R x y) ↔
-    StrongReciprocity R A := Iff.rfl
+/-- (25b) fails in Langendoen's model. -/
+theorem not_weakReciprocity_langendoenModel :
+    ¬ WeakReciprocity (λ a b => langendoenModel {a} {b}) Finset.univ := by
+  decide
 
--- ════════════════════════════════════════════════════════════════
--- § 5: Cross-paper Cumulation Bridges
--- ════════════════════════════════════════════════════════════════
+/-! ### Strong distributivity and strong reciprocity by iterated `*` -/
 
-/-- **Sternefeld 1998 ↔ [beck-2001] ↔ [haug-dalrymple-2020]
-    (bivalent)**: chain `sternefeldWR → Cumulative` via the substrate
-    `WeakReciprocity` bridge — the meeting point of all three analyses
-    at the cumulation substrate.
+/-- Strong distributivity by iterated `*` (7): `A ∈ *{x : B ∈ *{y : R(x, y)}}`. -/
+def SD (R : Finset α → Finset β → Prop) (A : Finset α) (B : Finset β) : Prop :=
+  star (λ x => star (R x) B) A
 
-    The three-paper convergence makes
-    `Plurality.Cumulativity.Cumulative` the substrate consumed by all
-    three Studies files; the implementation choice (BS form vs Krifka
-    closure form) is invisible from the consumer side modulo the
-    easy-direction equivalence `sternefeldStarStar_implies_cumulative`. -/
-theorem sternefeldWR_implies_cumulative_R
-    (A : Finset α) (R : α → α → Prop)
-    (hWR : sternefeldWR A R) :
-    Cumulative R A A := by
-  rw [sternefeldWR_iff_WeakReciprocity] at hWR
-  exact weakReciprocity_imp_cumulative R A hWR
+/-- Strong reciprocity by iterated `*` (48b): `A ∈ *λx[{y : y ∈ A ∧ y ≠ x} ∈ *λy.R(x, y)]`,
+the reciprocal interpreted in situ as one NP. -/
+def SR (R : Finset α → Finset α → Prop) (A : Finset α) : Prop :=
+  star (λ x => star (R x) (A.filter λ b => ({b} : Finset α) ≠ x)) A
+
+/-- For a D-based `R`, (7) is Langendoen's strong distributivity (2a) between nonempty
+pluralities. -/
+theorem sd_iff {R : Finset α → Finset β → Prop} (hR : DBased R) {A : Finset α} {B : Finset β}
+    (hA : A.Nonempty) (hB : B.Nonempty) : SD R A B ↔ ∀ a ∈ A, ∀ b ∈ B, R {a} {b} := by
+  have hout : ∀ ⦃x⦄, star (R x) B → ∃ a, x = {a} := hR.star _
+  rw [SD, star_iff_of_dBased hout, and_iff_right hA]
+  refine forall₂_congr λ a _ => ?_
+  rw [star_iff_of_dBased (hR.apply _), and_iff_right hB]
+
+/-- For a D-based `R`, (48b) is Langendoen's strong reciprocity (3a) on a plurality of two or
+more. -/
+theorem sr_iff {R : Finset α → Finset α → Prop} (hR : DBased R) {A : Finset α} :
+    SR R A ↔ 2 ≤ A.card ∧ StrongReciprocity (λ a b => R {a} {b}) A := by
+  have hout : ∀ ⦃x⦄, star (R x) (A.filter λ b => ({b} : Finset α) ≠ x) → ∃ a, x = {a} :=
+    hR.star _
+  rw [SR, star_iff_of_dBased hout]
+  simp only [star_iff_of_dBased (hR.apply _), Finset.mem_filter, ne_eq,
+    Finset.singleton_inj, Finset.filter_nonempty_iff, StrongReciprocity]
+  constructor
+  · rintro ⟨⟨a, ha⟩, h⟩
+    obtain ⟨⟨b, hb, hba⟩, -⟩ := h a ha
+    exact ⟨Finset.one_lt_card.2 ⟨a, ha, b, hb, Ne.symm hba⟩,
+      λ x hx y hy hyx => (h x hx).2 y ⟨hy, hyx⟩⟩
+  · rintro ⟨hcard, h⟩
+    refine ⟨Finset.card_pos.1 (by omega), λ a ha => ⟨?_, λ b ⟨hb, hba⟩ => h a ha b hb hba⟩⟩
+    obtain ⟨b, hb, hba⟩ := A.exists_mem_ne hcard a
+    exact ⟨b, hb, hba⟩
 
 end Sternefeld1998

--- a/references.bib
+++ b/references.bib
@@ -14477,6 +14477,17 @@
   pages     = {180--203},
   sources   = {Fragments/Dutch/Nouns.lean;Semantics/Genericity/NominalMappingParameter.lean;Semantics/Genericity/SortedOntology.lean;Studies/Krifka2003.lean;Studies/LeBruynDeSwart2022.lean}
 }
+@phdthesis{krifka-1986,
+  author    = {Krifka, Manfred},
+  year      = {1986},
+  title     = {Nominalreferenz und Zeitkonstitution: Zur Semantik von Massentermen, Pluraltermen und Aspektklassen},
+  school    = {Universit{\"a}t M{\"u}nchen},
+  address   = {Munich},
+  note      = {Published Munich: Wilhelm Fink, 1989},
+  subfield  = {semantics/plurality},
+  role      = {cited},
+  sources   = {Semantics/Plurality/Cumulativity.lean;Studies/Sternefeld1998.lean}
+}
 @incollection{krifka-1989,
   author    = {Krifka, Manfred},
   year      = {1989},


### PR DESCRIPTION
Deep audit of the Sternefeld 1998 study: the paper's readings are now derived from Krifka's closure-form `**`, added to the Plurality substrate as Link's `*` on the product semilattice, instead of transcribed onto Beck–Sauerland coverage.

- `Cumulation` (closure form) with `cumulation_map_singleton` proving both directions of the closure/coverage equivalence the study and `Cumulativity.lean` had deferred; `star_image_singleton` gives `*P = DP` for predicates of individuals.
- Study now states WD, WR, SD, SR as the paper does (iterated `*`, non-identity inside `**`), proves each collapses to Langendoen's formula for D-based relations, and checks Langendoen's model as the positive/negative witness; the newer-paper comparisons (Beck 2001, Haug & Dalrymple 2020) and the Beck2001 import are removed per chronology.
- Bib: `krifka-1986` (the dissertation the paper cites for `**`); equation locators verified against the NLS PDF.