### PR TITLE
refactor(Semantics/Plurality): reciprocal schemes on mathlib primitives

### DIFF
--- a/Linglib/Semantics/Plurality/Reciprocal.lean
+++ b/Linglib/Semantics/Plurality/Reciprocal.lean
@@ -5,39 +5,57 @@ import Linglib.Semantics.Plurality.Cumulativity
 /-!
 # Reciprocal predicates
 
-The interpretation schemes of reciprocal sentences, as conditions on a relation `R` and a
-plurality `X`: Strong, Intermediate and Weak Reciprocity from [langendoen-1978], Partitioned
-Strong Reciprocity from [fiengo-lasnik-1973], Inclusive Alternative Ordering from
-[kanski-1987], and One-way Weak Reciprocity from [dalrymple-et-al-1998], whose survey fixes the
-definitions used here. The schemes form an entailment lattice on pluralities of two or more
-(`strong_imp_partitionedStrong`, `partitionedStrong_imp_weak`, `strong_imp_intermediate`,
-`intermediate_imp_weak`, `weak_imp_oneWay`, `oneWay_imp_inclusiveAlternative`), and Weak
-Reciprocity is definitionally the cumulation `**` of the relation with non-identity conjoined
-into it (`weakReciprocity_iff_cumulative_strict`).
+This file defines the interpretation schemes of reciprocal sentences. A scheme is a predicate on
+a relation `R : A → A → Prop` and a finite set `X : Finset A` saying how much of `R` must hold
+among the members of `X` for *the Xs R each other* to be true, from every distinct pair down to
+one link in either direction. It also defines the configurations a mutual event can take, as
+conditions fixing the extension of `R` on `X`, and locates each in the lattice of schemes.
 
-The second half is the configurational typology of [evans-et-al-2011b] and [majid-et-al-2011]:
-the pairwise, chain, ring, radial and melee shapes of a mutual event, as exact-extension
-conditions on `(R, X)`, with their symmetry and participant-exhaustiveness as theorems
-locating each shape in the lattice.
+## Definitions
+
+* `Reciprocal.StrongReciprocity R X`: any two distinct members of `X` are `R`-related.
+* `Reciprocal.PartitionedStrongReciprocity R X`: `X` has a `Finpartition` into cells of two or
+  more members, each strongly reciprocal.
+* `Reciprocal.IntermediateReciprocity R X`: any two distinct members are joined by an `R`-chain
+  within `X`.
+* `Reciprocal.WeakReciprocity R X`: every member is `R`-related to a distinct member as subject
+  and as object. `Reciprocal.OneWayWeakReciprocity R X` asks for the subject direction only,
+  `Reciprocal.InclusiveAlternativeOrdering R X` for either.
+* `Reciprocal.PairwiseConfig`, `Reciprocal.ChainConfig`, `Reciprocal.RingConfig`,
+  `Reciprocal.RadialConfig`, `Reciprocal.MeleeConfig`: `R` pairs the members of `X` off, lines
+  them up, closes the line into a cycle, radiates from one member, or leaves a member out.
+
+## Main results
+
+* `Reciprocal.strong_imp_weak`, `Reciprocal.intermediate_imp_weak`,
+  `Reciprocal.partitionedStrong_imp_weak`, `Reciprocal.oneWay_imp_inclusiveAlternative`: the
+  schemes are ordered by entailment on sets of two or more members.
+* `Reciprocal.weakReciprocity_iff_cumulative_strict`: weak reciprocity is the cumulation of `R`
+  with non-identity conjoined in.
+* `Reciprocal.PairwiseConfig.partitionedStrong`, `Reciprocal.RingConfig.oneWayWeak`,
+  `Reciprocal.ChainConfig.inclusiveAlternativeOrdering`: the place of each configuration in the
+  lattice. The chain, ring and radial configurations are not symmetric.
 
 ## Implementation notes
 
-* Intermediate Reciprocity is `Relation.TransGen` of `R` restricted to `X`; Partitioned Strong
-  Reciprocity is a `Finpartition` of `X` into cells of two or more; adjacency in a chain or ring
-  is a pair of consecutive positions in a duplicate-free list.
-* The two-member condition that [dalrymple-et-al-1998] build into each scheme is a hypothesis
-  of the entailments rather than a conjunct of the definitions.
-
-## TODO
-
-* The Alternative schemes SAR and IAR, and the Strongest Meaning Hypothesis as an operator
-  selecting among schemes.
+Adjacency in a chain or ring is a pair of consecutive positions in a duplicate-free list
+(`Reciprocal.Consecutive`). The two-member condition that [dalrymple-et-al-1998] build into each
+scheme is a hypothesis of the entailments rather than a conjunct of the definitions.
 
 ## References
 
-* [langendoen-1978], [fiengo-lasnik-1973], [kanski-1987], [dalrymple-et-al-1998]
-* [beck-2001], [sternefeld-1998]
-* [evans-et-al-2011b], [majid-et-al-2011]
+* [D. T. Langendoen, *The logic of reciprocity* (1978)][langendoen-1978]
+* [R. Fiengo and H. Lasnik, *The logical structure of reciprocal sentences in English*
+  (1973)][fiengo-lasnik-1973]
+* [Z. Kański, *Logical symmetry and natural language reciprocals* (1987)][kanski-1987]
+* [M. Dalrymple, M. Kanazawa, Y. Kim, S. A. Mchombo and S. Peters, *Reciprocal expressions and
+  the concept of reciprocity* (1998)][dalrymple-et-al-1998]
+* [S. Beck, *Reciprocals are definites* (2001)][beck-2001]
+* [W. Sternefeld, *Reciprocity and cumulative predication* (1998)][sternefeld-1998]
+* [N. Evans, S. C. Levinson, A. Gaby and A. Majid, *Introduction: Reciprocals and semantic
+  typology* (2011)][evans-et-al-2011b]
+* [A. Majid, N. Evans, A. Gaby and S. C. Levinson, *The semantics of reciprocal constructions
+  across languages: An extensional approach* (2011)][majid-et-al-2011]
 -/
 
 namespace Reciprocal
@@ -162,12 +180,10 @@ theorem weakReciprocity_imp_cumulative (R : A → A → Prop) (X : Finset A)
   ⟨λ x hx => let ⟨y, hy, hRxy, _⟩ := hWR.1 x hx; ⟨y, hy, hRxy⟩,
    λ y hy => let ⟨x, hx, hRxy, _⟩ := hWR.2 y hy; ⟨x, hx, hRxy⟩⟩
 
-/-! ### Configurational typology
+/-! ### Configurations
 
-The event configurations of [evans-et-al-2011b] and [majid-et-al-2011], as exact-extension
-conditions on `(R, X)`. Pairwise strengthens to Partitioned Strong Reciprocity, ring yields
-One-way Weak Reciprocity, chain and radial yield Inclusive Alternative Ordering, and melee is
-by definition the failure of Inclusive Alternative Ordering. -/
+The event configurations of [evans-et-al-2011b] and [majid-et-al-2011], as conditions fixing the
+extension of `R` on `X`. -/
 
 /-- `y` immediately follows `x` in `l`. -/
 def Consecutive (l : List A) (x y : A) : Prop := ∃ i, l[i]? = some x ∧ l[i + 1]? = some y

--- a/Linglib/Semantics/Plurality/Reciprocal.lean
+++ b/Linglib/Semantics/Plurality/Reciprocal.lean
@@ -1,90 +1,54 @@
-import Mathlib.Data.List.Chain
-import Linglib.Semantics.Plurality.Basic
+import Mathlib.Logic.Relation
+import Mathlib.Order.Partition.Finpartition
 import Linglib.Semantics.Plurality.Cumulativity
 
 /-!
-# Reciprocal Predicates
+# Reciprocal predicates
 
-Substrate for the reciprocal-meaning typology. The six interpretation
-schemes originate in [langendoen-1978] (Strong Reciprocity SR,
-Intermediate Reciprocity IR, Weak Reciprocity WR), [kanski-1987]
-(Inclusive Alternative Ordering IAO), [fiengo-lasnik-1973]
-(Partitioned Strong Reciprocity PartSR), and [dalrymple-et-al-1998]
-(the **Alternative** variants SAR/IAR plus One-way Weak Reciprocity
-OWR). DKMPK organise them along two axes — **quantification
-strength** (∀∀ / ∃-chain / ∃∃) and **directionality** (one-way vs
-alternative `R x y ∨ R y x`) — and proposes the **Strongest Meaning
-Hypothesis** (SMH): interpretation selects the strongest scheme
-consistent with context. The substrate here exposes the six schemes,
-the entailment lattice between the bivalent versions, and a bridge to
-`Cumulativity.Cumulative` for WR. SMH itself is left as a Todo.
+The interpretation schemes of reciprocal sentences, as conditions on a relation `R` and a
+plurality `X`: Strong, Intermediate and Weak Reciprocity from [langendoen-1978], Partitioned
+Strong Reciprocity from [fiengo-lasnik-1973], Inclusive Alternative Ordering from
+[kanski-1987], and One-way Weak Reciprocity from [dalrymple-et-al-1998], whose survey fixes the
+definitions used here. The schemes form an entailment lattice on pluralities of two or more
+(`strong_imp_partitionedStrong`, `partitionedStrong_imp_weak`, `strong_imp_intermediate`,
+`intermediate_imp_weak`, `weak_imp_oneWay`, `oneWay_imp_inclusiveAlternative`), and Weak
+Reciprocity is definitionally the cumulation `**` of the relation with non-identity conjoined
+into it (`weakReciprocity_iff_cumulative_strict`).
 
-## Main declarations
-
-* `Scheme` — the six-cell typology, named.
-* `StrongReciprocity` — every distinct pair satisfies `R`.
-* `PartitionedStrongReciprocity` — there is a partition of `X` such
-  that SR holds within each cell.
-* `IntermediateReciprocity` — every distinct pair is connected by an
-  `R`-chain.
-* `WeakReciprocity` — every member is `R`-related to a distinct other
-  *in both directions*.
-* `OneWayWeakReciprocity` — only the first direction of WR.
-* `InclusiveAlternativeOrdering` — every member participates in `R`
-  either as subject or as object of a distinct other.
-* `strong_imp_weak`, `weak_imp_oneWay`, `oneWay_imp_inclusiveAlternative`,
-  `strong_imp_inclusiveAlternative` — the entailment lattice
-  ([beck-2001] eq 28 right-hand spine).
-* `weakReciprocity_iff_cumulative_strict` — WR factors through
-  `Cumulative` of the strict-distinct relation (Beck eq 120 /
-  [sternefeld-1998] eq 26b, bivalent collapse).
+The second half is the configurational typology of [evans-et-al-2011b] and [majid-et-al-2011]:
+the pairwise, chain, ring, radial and melee shapes of a mutual event, as exact-extension
+conditions on `(R, X)`, with their symmetry and participant-exhaustiveness as theorems
+locating each shape in the lattice.
 
 ## Implementation notes
 
-The standard [dalrymple-et-al-1998] / [langendoen-1978] form of WR requires both
-`∃y ∈ X. y ≠ x ∧ R x y` AND `∃y ∈ X. y ≠ x ∧ R y x` for each
-`x ∈ X` — i.e., each member must be both an `R`-subject and an
-`R`-object of some distinct other. The single-conjunct version (here:
-`OneWayWeakReciprocity`) is empirically too weak; [beck-2001] §4.4
-reanalyses apparent OWR as WR plus cover-licensed exceptions.
+* Intermediate Reciprocity is `Relation.TransGen` of `R` restricted to `X`; Partitioned Strong
+  Reciprocity is a `Finpartition` of `X` into cells of two or more; adjacency in a chain or ring
+  is a pair of consecutive positions in a duplicate-free list.
+* The two-member condition that [dalrymple-et-al-1998] build into each scheme is a hypothesis
+  of the entailments rather than a conjunct of the definitions.
 
-`IntermediateReciprocity` uses `List.IsChain` on a list of atoms in `X`
-to express "connected by an `R`-chain"; `PartitionedStrongReciprocity`
-uses `Finset (Finset α)` for the partition witness.
+## TODO
 
-## Todo
+* The Alternative schemes SAR and IAR, and the Strongest Meaning Hypothesis as an operator
+  selecting among schemes.
 
-* Strong/Weak/Intermediate **Alternative** schemes (`R y x ∨ R x y`
-  variants): SAR, IAR.
-* Strongest Meaning Hypothesis as an interpretation operator selecting
-  among schemes given context.
+## References
+
+* [langendoen-1978], [fiengo-lasnik-1973], [kanski-1987], [dalrymple-et-al-1998]
+* [beck-2001], [sternefeld-1998]
+* [evans-et-al-2011b], [majid-et-al-2011]
 -/
 
 namespace Reciprocal
 
-open _root_.Plurality
 open _root_.Plurality.Cumulativity
 
-variable {A : Type*}
+variable {A : Type*} {R : A → A → Prop} {X : Finset A}
 
-/-- The six reciprocal interpretation schemes. SR/IR/WR originate in
-    [langendoen-1978]; IAO in [kanski-1987]; Partitioned SR in
-    [fiengo-lasnik-1973]; the **Alternative** variants (SAR, IAR) in
-    [dalrymple-et-al-1998]. -/
-inductive Scheme where
-  | strong                  -- Strong Reciprocity (SR)
-  | partitionedStrong       -- Partitioned Strong Reciprocity (PartSR)
-  | intermediate            -- Intermediate Reciprocity (IR)
-  | weak                    -- Weak Reciprocity (WR)
-  | oneWayWeak              -- One-way Weak Reciprocity (OWR)
-  | inclusiveAlternative    -- Inclusive Alternative Ordering (IAO)
-  deriving DecidableEq, Repr
+/-! ### The interpretation schemes -/
 
-/-! ### Strong Reciprocity -/
-
-/-- **Strong Reciprocity**: every distinct pair in `X` satisfies `R`.
-    "The students all know each other": every student knows every
-    other student. -/
+/-- Strong Reciprocity: every distinct pair in `X` satisfies `R`. -/
 def StrongReciprocity (R : A → A → Prop) (X : Finset A) : Prop :=
   ∀ x ∈ X, ∀ y ∈ X, y ≠ x → R x y
 
@@ -92,42 +56,21 @@ instance [DecidableEq A] (R : A → A → Prop) [DecidableRel R] (X : Finset A) 
     Decidable (StrongReciprocity R X) := by
   unfold StrongReciprocity; infer_instance
 
-/-! ### Partitioned Strong Reciprocity -/
+theorem strongReciprocity_iff_pairwise : StrongReciprocity R X ↔ (X : Set A).Pairwise R :=
+  ⟨λ h _ hx _ hy hxy => h _ hx _ hy hxy.symm, λ h _ hx _ hy hyx => h hx hy hyx.symm⟩
 
-/-- **Partitioned Strong Reciprocity** ([fiengo-lasnik-1973]): there is
-    a partition of `X` such that SR holds within each cell. "The men are hitting each other" can be
-    true if the men
-    team up in pairs that stand in the hit-relation. -/
-def PartitionedStrongReciprocity (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∃ PART : Finset (Finset A),
-    (∀ Y ∈ PART, Y ⊆ X) ∧
-    (∀ a ∈ X, ∃ Y ∈ PART, a ∈ Y) ∧
-    (∀ Y ∈ PART, ∀ x ∈ Y, ∀ y ∈ Y, y ≠ x → R x y)
+/-- Partitioned Strong Reciprocity ([fiengo-lasnik-1973]): `X` splits into disjoint cells of two
+or more within each of which Strong Reciprocity holds. -/
+def PartitionedStrongReciprocity [DecidableEq A] (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ P : Finpartition X, ∀ c ∈ P.parts, 2 ≤ c.card ∧ StrongReciprocity R c
 
-/-! ### Intermediate Reciprocity -/
-
-/-- **Intermediate Reciprocity** ([langendoen-1978]): any two distinct
-    members of `X` are connected by an `R`-chain through `X`. "Five
-    Boston pitchers sat alongside each other": each pitcher has an
-    `R`-chain to every other pitcher.
-
-    Uses `List.Chain'` over a non-empty list of `X`-elements whose head
-    is `x` and whose last element is `y`. -/
+/-- Intermediate Reciprocity ([langendoen-1978]): any two distinct members of `X` are
+connected by an `R`-chain through `X`. -/
 def IntermediateReciprocity (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∀ x ∈ X, ∀ y ∈ X, y ≠ x →
-    ∃ chain : List A, chain.head? = some x ∧ chain.getLast? = some y ∧
-      (∀ z ∈ chain, z ∈ X) ∧ chain.IsChain R
+  ∀ x ∈ X, ∀ y ∈ X, y ≠ x → Relation.TransGen (λ a b => a ∈ X ∧ b ∈ X ∧ R a b) x y
 
-/-! ### Weak Reciprocity -/
-
-/-- **Weak Reciprocity** ([langendoen-1978]; [dalrymple-et-al-1998]): every member of
-    `X` is `R`-related to at least one distinct other member **in both
-    directions** — as `R`-subject and as `R`-object. "The boys are
-    stacked on top of each other": each boy has *some* other boy on
-    top of him AND is on top of *some* other boy.
-
-    Definitionally identical to `Cumulative (R ∧ ≠) X X` (see
-    `weakReciprocity_iff_cumulative_strict`). -/
+/-- Weak Reciprocity ([langendoen-1978]): every member of `X` is `R`-related to a distinct
+other member in both directions, as subject and as object. -/
 def WeakReciprocity (R : A → A → Prop) (X : Finset A) : Prop :=
   (∀ x ∈ X, ∃ y ∈ X, R x y ∧ x ≠ y) ∧ (∀ y ∈ X, ∃ x ∈ X, R x y ∧ x ≠ y)
 
@@ -135,12 +78,8 @@ instance [DecidableEq A] (R : A → A → Prop) [DecidableRel R] (X : Finset A) 
     Decidable (WeakReciprocity R X) := by
   unfold WeakReciprocity; infer_instance
 
-/-! ### One-way Weak Reciprocity -/
-
-/-- **One-way Weak Reciprocity** ([dalrymple-et-al-1998]): only the
-    first direction of WR is required. "The pirates are
-    staring at each other" — pirate 6 is not stared at by anybody, but
-    everyone stares at someone. -/
+/-- One-way Weak Reciprocity ([dalrymple-et-al-1998]): the first direction of Weak
+Reciprocity. -/
 def OneWayWeakReciprocity (R : A → A → Prop) (X : Finset A) : Prop :=
   ∀ x ∈ X, ∃ y ∈ X, R x y ∧ x ≠ y
 
@@ -148,13 +87,8 @@ instance [DecidableEq A] (R : A → A → Prop) [DecidableRel R] (X : Finset A) 
     Decidable (OneWayWeakReciprocity R X) := by
   unfold OneWayWeakReciprocity; infer_instance
 
-/-! ### Inclusive Alternative Ordering -/
-
-/-- **Inclusive Alternative Ordering** ([kanski-1987]):
-    each member of `X` participates in `R` as either first or second
-    argument of a distinct other. "The plates are stacked on top of
-    each other" — each plate is on top of one or has one on top of
-    itself. -/
+/-- Inclusive Alternative Ordering ([kanski-1987]): each member of `X` is `R`-related to a
+distinct other member in one direction or the other. -/
 def InclusiveAlternativeOrdering (R : A → A → Prop) (X : Finset A) : Prop :=
   ∀ x ∈ X, ∃ y ∈ X, x ≠ y ∧ (R x y ∨ R y x)
 
@@ -162,372 +96,250 @@ instance [DecidableEq A] (R : A → A → Prop) [DecidableRel R] (X : Finset A) 
     Decidable (InclusiveAlternativeOrdering R X) := by
   unfold InclusiveAlternativeOrdering; infer_instance
 
-/-! ### Entailment lattice (Beck 2001 eq 28, right-hand spine) -/
+/-! ### The entailment lattice -/
 
-/-- Strong Reciprocity entails Weak Reciprocity, on pluralities of
-    cardinality ≥ 2 (so a distinct witness exists). -/
-theorem strong_imp_weak [DecidableEq A]
-    (R : A → A → Prop) (X : Finset A)
-    (hcard : 2 ≤ X.card) (hSR : StrongReciprocity R X) :
+theorem strong_imp_partitionedStrong [DecidableEq A] (hcard : 2 ≤ X.card)
+    (hSR : StrongReciprocity R X) : PartitionedStrongReciprocity R X :=
+  ⟨Finpartition.indiscrete (Finset.card_pos.1 (by omega)).ne_empty, λ c hc => by
+    rw [Finpartition.indiscrete, Finset.mem_singleton] at hc
+    exact hc ▸ ⟨hcard, hSR⟩⟩
+
+theorem partitionedStrong_imp_weak [DecidableEq A] (h : PartitionedStrongReciprocity R X) :
     WeakReciprocity R X := by
-  refine ⟨?_, ?_⟩
-  · intro x hx
-    obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
-    exact ⟨y, hy, hSR x hx y hy hyx, hyx.symm⟩
-  · intro x hx
-    obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
-    exact ⟨y, hy, hSR y hy x hx hyx.symm, hyx⟩
+  obtain ⟨P, hP⟩ := h
+  refine ⟨λ x hx => ?_, λ x hx => ?_⟩ <;>
+  · obtain ⟨c, hc, hxc⟩ := P.exists_mem hx
+    obtain ⟨hcard, hSR⟩ := hP c hc
+    obtain ⟨y, hy, hyx⟩ := c.exists_mem_ne hcard x
+    first
+      | exact ⟨y, P.le hc hy, hSR x hxc y hy hyx, hyx.symm⟩
+      | exact ⟨y, P.le hc hy, hSR y hy x hxc hyx.symm, hyx⟩
 
-/-- Weak Reciprocity entails One-way Weak Reciprocity (projection on
-    the first conjunct). -/
-theorem weak_imp_oneWay (R : A → A → Prop) (X : Finset A)
-    (hWR : WeakReciprocity R X) : OneWayWeakReciprocity R X :=
+theorem strong_imp_intermediate (hSR : StrongReciprocity R X) : IntermediateReciprocity R X :=
+  λ x hx y hy hyx => .single ⟨hx, hy, hSR x hx y hy hyx⟩
+
+private theorem exists_rel_ne_of_transGen {r : A → A → Prop} {x y : A}
+    (h : Relation.TransGen r x y) (hyx : y ≠ x) : ∃ z, z ≠ x ∧ r x z := by
+  induction h with
+  | single h => exact ⟨_, hyx, h⟩
+  | @tail b c _ hbc ih =>
+    by_cases hbx : b = x
+    · exact ⟨c, hyx, hbx ▸ hbc⟩
+    · exact ih hbx
+
+theorem intermediate_imp_weak [DecidableEq A] (hcard : 2 ≤ X.card)
+    (h : IntermediateReciprocity R X) : WeakReciprocity R X := by
+  refine ⟨λ x hx => ?_, λ x hx => ?_⟩
+  · obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
+    obtain ⟨z, hzx, -, hz, hR⟩ := exists_rel_ne_of_transGen (h x hx y hy hyx) hyx
+    exact ⟨z, hz, hR, hzx.symm⟩
+  · obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
+    have := (h y hy x hx hyx.symm).swap
+    obtain ⟨z, hzx, hz, -, hR⟩ := exists_rel_ne_of_transGen this hyx
+    exact ⟨z, hz, hR, hzx⟩
+
+theorem strong_imp_weak [DecidableEq A] (hcard : 2 ≤ X.card) (hSR : StrongReciprocity R X) :
+    WeakReciprocity R X :=
+  intermediate_imp_weak hcard (strong_imp_intermediate hSR)
+
+theorem weak_imp_oneWay (hWR : WeakReciprocity R X) : OneWayWeakReciprocity R X :=
   hWR.1
 
-/-- One-way Weak Reciprocity entails Inclusive Alternative Ordering. -/
-theorem oneWay_imp_inclusiveAlternative (R : A → A → Prop) (X : Finset A)
-    (hOWR : OneWayWeakReciprocity R X) :
-    InclusiveAlternativeOrdering R X := by
-  intro x hx
-  obtain ⟨y, hy, hRxy, hxy⟩ := hOWR x hx
-  exact ⟨y, hy, hxy, Or.inl hRxy⟩
+theorem oneWay_imp_inclusiveAlternative (hOWR : OneWayWeakReciprocity R X) :
+    InclusiveAlternativeOrdering R X := λ x hx =>
+  let ⟨y, hy, hRxy, hxy⟩ := hOWR x hx
+  ⟨y, hy, hxy, Or.inl hRxy⟩
 
-/-- Composition: SR entails IAO via the right-hand spine
-    `SR → WR → OWR → IAO`. -/
-theorem strong_imp_inclusiveAlternative [DecidableEq A]
-    (R : A → A → Prop) (X : Finset A) (hcard : 2 ≤ X.card)
-    (hSR : StrongReciprocity R X) :
-    InclusiveAlternativeOrdering R X :=
-  oneWay_imp_inclusiveAlternative R X
-    (weak_imp_oneWay R X (strong_imp_weak R X hcard hSR))
+/-! ### Cumulation -/
 
-/-! ### Cumulativity bridge -/
+/-- Weak Reciprocity is `**` of the relation with non-identity conjoined into it, the bivalent
+common ground of [beck-2001] and [sternefeld-1998]. -/
+theorem weakReciprocity_iff_cumulative_strict (R : A → A → Prop) (X : Finset A) :
+    WeakReciprocity R X ↔ Cumulative (λ a b => R a b ∧ a ≠ b) X X := Iff.rfl
 
-/-- **Weak Reciprocity factors through `Cumulative`**: Beck-Sauerland's
-    `**` applied to the strict-distinct verb relation
-    `λ a b. R a b ∧ a ≠ b` on `(X, X)` recovers Weak Reciprocity
-    definitionally. This is the substrate-level form of
-    [beck-2001] eq 120 / [sternefeld-1998] eq 26b (bivalent
-    collapse). The Beck/Sternefeld trivalent disagreement is invisible
-    here — both reduce to the same proposition under bivalent
-    encoding. -/
-theorem weakReciprocity_iff_cumulative_strict
-    (R : A → A → Prop) (X : Finset A) :
-    WeakReciprocity R X ↔
-    Cumulative (fun a b => R a b ∧ a ≠ b) X X := Iff.rfl
-
-/-- Forward weakening: WR truth conditions entail bare
-    `Cumulative R X X` (dropping the strict-distinct conjunct). This
-    is *strictly weaker* than either Beck eq 120 or Sternefeld eq 26b,
-    both of which keep the distinctness clause inside the relation
-    argument. -/
-theorem weakReciprocity_imp_cumulative
-    (R : A → A → Prop) (X : Finset A)
-    (hWR : WeakReciprocity R X) :
-    Cumulative R X X := by
-  refine ⟨?_, ?_⟩
-  · intro x hx
-    obtain ⟨y, hy, hRxy, _⟩ := hWR.1 x hx
-    exact ⟨y, hy, hRxy⟩
-  · intro y hy
-    obtain ⟨x, hx, hRxy, _⟩ := hWR.2 y hy
-    exact ⟨x, hx, hRxy⟩
+theorem weakReciprocity_imp_cumulative (R : A → A → Prop) (X : Finset A)
+    (hWR : WeakReciprocity R X) : Cumulative R X X :=
+  ⟨λ x hx => let ⟨y, hy, hRxy, _⟩ := hWR.1 x hx; ⟨y, hy, hRxy⟩,
+   λ y hy => let ⟨x, hx, hRxy, _⟩ := hWR.2 y hy; ⟨x, hx, hRxy⟩⟩
 
 /-! ### Configurational typology
 
-The event-configuration typology of [evans-et-al-2011b] and
-[majid-et-al-2011]: six shapes of mutual relation (strong, pairwise,
-chain, radial, melee, ring) used in the video-stimulus elicitation
-studies. Each is rendered as an exact-extension condition on `(R, X)` —
-the relation coincides with the named configuration — so symmetry and
-participant-exhaustiveness are theorems rather than stipulations, and
-the shapes plug into the entailment lattice above: pairwise strengthens
-to `PartitionedStrongReciprocity`, ring yields `OneWayWeakReciprocity`,
-chain and radial yield `InclusiveAlternativeOrdering`, and melee is
-definitionally the failure of `InclusiveAlternativeOrdering` (some
-activity, but not everyone participates). The strong configuration is
-`StrongReciprocity` itself. -/
+The event configurations of [evans-et-al-2011b] and [majid-et-al-2011], as exact-extension
+conditions on `(R, X)`. Pairwise strengthens to Partitioned Strong Reciprocity, ring yields
+One-way Weak Reciprocity, chain and radial yield Inclusive Alternative Ordering, and melee is
+by definition the failure of Inclusive Alternative Ordering. -/
 
 /-- `y` immediately follows `x` in `l`. -/
-def Consecutive (l : List A) (x y : A) : Prop := (x, y) ∈ l.zip l.tail
+def Consecutive (l : List A) (x y : A) : Prop := ∃ i, l[i]? = some x ∧ l[i + 1]? = some y
 
-private lemma consecutive_cons {a : A} {l : List A} {x y : A}
-    (h : Consecutive l x y) : Consecutive (a :: l) x y := by
-  cases l with
-  | nil => simp [Consecutive] at h
-  | cons b t => exact List.mem_cons_of_mem _ h
+theorem Consecutive.mem_left {l : List A} {x y : A} (h : Consecutive l x y) : x ∈ l :=
+  let ⟨_, hx, _⟩ := h
+  List.mem_of_getElem? hx
 
-private lemma consecutive_mem {l : List A} {x y : A} (h : Consecutive l x y) :
-    x ∈ l ∧ y ∈ l :=
-  ⟨(List.of_mem_zip h).1, List.mem_of_mem_tail (List.of_mem_zip h).2⟩
+theorem Consecutive.mem_right {l : List A} {x y : A} (h : Consecutive l x y) : y ∈ l :=
+  let ⟨_, _, hy⟩ := h
+  List.mem_of_getElem? hy
 
-private lemma consecutive_ne {l : List A} (hnd : l.Nodup) {x y : A}
-    (h : Consecutive l x y) : x ≠ y := by
-  induction l with
-  | nil => simp [Consecutive] at h
-  | cons a t ih =>
-    cases t with
-    | nil => simp [Consecutive] at h
-    | cons b t' =>
-      have h' : (x, y) = (a, b) ∨ Consecutive (b :: t') x y := by
-        simpa [Consecutive] using h
-      rcases h' with heq | h'
-      · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
-        intro hab
-        apply (List.nodup_cons.mp hnd).1
-        rw [hab]
-        exact List.mem_cons_self ..
-      · exact ih (List.nodup_cons.mp hnd).2 h'
+theorem Consecutive.ne {l : List A} (hnd : l.Nodup) {x y : A} (h : Consecutive l x y) :
+    x ≠ y := by
+  obtain ⟨i, hx, hy⟩ := h
+  rintro rfl
+  have hi : i < l.length := (List.getElem?_eq_some_iff.1 hx).1
+  have := (List.getElem?_inj hi hnd).1 (hx.trans hy.symm)
+  omega
 
-private lemma consecutive_asymm {l : List A} (hnd : l.Nodup) {x y : A}
-    (hxy : Consecutive l x y) : ¬ Consecutive l y x := by
-  induction l with
-  | nil => simp [Consecutive] at hxy
-  | cons a t ih =>
-    cases t with
-    | nil => simp [Consecutive] at hxy
-    | cons b t' =>
-      intro hyx
-      have hxy' : (x, y) = (a, b) ∨ Consecutive (b :: t') x y := by
-        simpa [Consecutive] using hxy
-      have hyx' : (y, x) = (a, b) ∨ Consecutive (b :: t') y x := by
-        simpa [Consecutive] using hyx
-      rcases hxy' with heq | hxy'
-      · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq
-        rcases hyx' with heq' | hyx'
-        · obtain ⟨h1, -⟩ := Prod.mk.inj heq'
-          apply (List.nodup_cons.mp hnd).1
-          rw [← h1]
-          exact List.mem_cons_self ..
-        · exact (List.nodup_cons.mp hnd).1 (consecutive_mem hyx').2
-      · rcases hyx' with heq' | hyx'
-        · obtain ⟨rfl, rfl⟩ := Prod.mk.inj heq'
-          exact (List.nodup_cons.mp hnd).1 (consecutive_mem hxy').2
-        · exact ih (List.nodup_cons.mp hnd).2 hxy' hyx'
+theorem Consecutive.asymm {l : List A} (hnd : l.Nodup) {x y : A} (hxy : Consecutive l x y) :
+    ¬ Consecutive l y x := by
+  rintro ⟨j, hy', hx'⟩
+  obtain ⟨i, hx, hy⟩ := hxy
+  have hi : i < l.length := (List.getElem?_eq_some_iff.1 hx).1
+  have h₁ := (List.getElem?_inj hi hnd).1 (hx.trans hx'.symm)
+  have h₂ := (List.getElem?_inj (List.getElem?_eq_some_iff.1 hy).1 hnd).1 (hy.trans hy'.symm)
+  omega
 
-private lemma getLast?_mem : ∀ {l : List A} {x : A}, l.getLast? = some x → x ∈ l
-  | [], _, h => by simp at h
-  | [a], x, h => by
-    obtain rfl : a = x := by simpa using h
-    simp
-  | _ :: b :: t, x, h => by
-    rw [List.getLast?_cons_cons] at h
-    exact List.mem_cons_of_mem _ (getLast?_mem h)
-
-private lemma mem_consecutive_or_getLast {l : List A} {x : A} (hx : x ∈ l) :
+theorem exists_consecutive_or_getLast {l : List A} {x : A} (hx : x ∈ l) :
     (∃ y, Consecutive l x y) ∨ l.getLast? = some x := by
-  induction l with
-  | nil => cases hx
-  | cons a t ih =>
-    cases t with
-    | nil =>
-      right
-      obtain rfl := List.mem_singleton.mp hx
-      simp
-    | cons b t' =>
-      rcases List.mem_cons.mp hx with rfl | hx'
-      · exact Or.inl ⟨b, by simp [Consecutive]⟩
-      · rcases ih hx' with ⟨y, hy⟩ | hlast
-        · exact Or.inl ⟨y, consecutive_cons hy⟩
-        · right; rw [List.getLast?_cons_cons]; exact hlast
+  obtain ⟨i, hi⟩ := List.mem_iff_getElem?.1 hx
+  have hlt : i < l.length := (List.getElem?_eq_some_iff.1 hi).1
+  by_cases h : i + 1 < l.length
+  · exact Or.inl ⟨l[i + 1], i, hi, List.getElem?_eq_getElem h⟩
+  · right
+    rw [List.getLast?_eq_getElem?]
+    convert hi using 2
+    omega
 
-private lemma getLast?_consecutive : ∀ {l : List A}, 2 ≤ l.length →
-    ∀ {x : A}, l.getLast? = some x → ∃ y, Consecutive l y x
-  | [], hlen, _, _ => by simp at hlen
-  | [_], hlen, _, _ => by simp at hlen
-  | [a, b], _, x, hx => by
-    obtain rfl : b = x := by simpa using hx
-    exact ⟨a, by simp [Consecutive]⟩
-  | a :: b :: c :: t, _, x, hx => by
-    rw [List.getLast?_cons_cons] at hx
-    obtain ⟨y, hy⟩ :=
-      getLast?_consecutive (by simp only [List.length_cons]; omega) hx
-    exact ⟨y, consecutive_cons hy⟩
+theorem exists_consecutive_of_getLast {l : List A} (hlen : 2 ≤ l.length) {x : A}
+    (hx : l.getLast? = some x) : ∃ y, Consecutive l y x := by
+  rw [List.getLast?_eq_getElem?] at hx
+  refine ⟨l[l.length - 2], l.length - 2, List.getElem?_eq_getElem (by omega), ?_⟩
+  convert hx using 2
+  omega
 
 /-- `R` is symmetric within `X`: every realized pair is mutual. -/
 def PairSymmetricOn (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∀ x ∈ X, ∀ y ∈ X, R x y → R y x
+  (X : Set A).Pairwise λ x y => R x y → R y x
 
-/-- **Pairwise configuration** ([majid-et-al-2011]): the participants
-    split into two-member cells, and `R` holds exactly within cells
-    ("The people at the dinner party were married to one another"). -/
-def PairwiseConfig (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∃ P : Finset (Finset A),
-    (∀ c ∈ P, c.card = 2 ∧ c ⊆ X) ∧
-    (∀ a ∈ X, ∃ c ∈ P, a ∈ c) ∧
-    (∀ x y, R x y ↔ ∃ c ∈ P, x ∈ c ∧ y ∈ c ∧ x ≠ y)
+/-- Pairwise configuration ([majid-et-al-2011]): the participants split into two-member cells
+and `R` holds exactly within cells. -/
+def PairwiseConfig [DecidableEq A] (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ P : Finpartition X, (∀ c ∈ P.parts, c.card = 2) ∧
+    ∀ x y, R x y ↔ ∃ c ∈ P.parts, x ∈ c ∧ y ∈ c ∧ x ≠ y
 
-/-- **Chain configuration** ([majid-et-al-2011]): the participants form
-    a line and `R` holds exactly between adjacent members, directed
-    ("The graduating students followed one another up onto the stage"). -/
-def ChainConfig (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∃ l : List A, l.Nodup ∧ (∀ z, z ∈ l ↔ z ∈ X) ∧ 2 ≤ l.length ∧
-    ∀ x y, R x y ↔ Consecutive l x y
+/-- Chain configuration ([majid-et-al-2011]): the participants form a line and `R` holds
+exactly from each member to the next. -/
+def ChainConfig [DecidableEq A] (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ l : List A, l.Nodup ∧ l.toFinset = X ∧ 2 ≤ l.length ∧ ∀ x y, R x y ↔ Consecutive l x y
 
-/-- **Ring configuration** ([majid-et-al-2011]): a chain whose last
-    member acts on the first ("The children chased each other round in
-    a ring"). -/
-def RingConfig (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∃ l : List A, l.Nodup ∧ (∀ z, z ∈ l ↔ z ∈ X) ∧ 3 ≤ l.length ∧
-    ∀ x y, R x y ↔
-      (Consecutive l x y ∨ (l.getLast? = some x ∧ l.head? = some y))
+/-- Ring configuration ([majid-et-al-2011]): a chain whose last member acts on the first. -/
+def RingConfig [DecidableEq A] (R : A → A → Prop) (X : Finset A) : Prop :=
+  ∃ l : List A, l.Nodup ∧ l.toFinset = X ∧ 3 ≤ l.length ∧
+    ∀ x y, R x y ↔ Consecutive l x y ∨ (l.getLast? = some x ∧ l.head? = some y)
 
-/-- **Radial configuration** ([majid-et-al-2011]): one central
-    participant acts (asymmetrically) on each of the others ("The
-    teacher and her pupils intimidated one another"). -/
+/-- Radial configuration ([majid-et-al-2011]): one central participant acts on each of the
+others. -/
 def RadialConfig (R : A → A → Prop) (X : Finset A) : Prop :=
-  ∃ c ∈ X, 2 ≤ X.card ∧ ∀ x y, R x y ↔ (x = c ∧ y ∈ X ∧ y ≠ c)
+  ∃ c ∈ X, 2 ≤ X.card ∧ ∀ x y, R x y ↔ x = c ∧ y ∈ X ∧ y ≠ c
 
-/-- **Melee configuration** ([majid-et-al-2011]): multiple asymmetrical
-    interactions without full saturation ("The drunks in the pub were
-    punching one another") — some activity, but participation fails to
-    be exhaustive, i.e. even `InclusiveAlternativeOrdering` (the weakest
-    scheme in the lattice above) fails. -/
+/-- Melee configuration ([majid-et-al-2011]): some interaction, but participation is not
+exhaustive. -/
 def MeleeConfig (R : A → A → Prop) (X : Finset A) : Prop :=
   (∃ x ∈ X, ∃ y ∈ X, x ≠ y ∧ R x y) ∧ ¬ InclusiveAlternativeOrdering R X
 
-/-! #### Symmetry theorems -/
+/-! #### Symmetry -/
 
-/-- Strong reciprocity is symmetric on its plurality. -/
-theorem StrongReciprocity.pairSymmetricOn {R : A → A → Prop} {X : Finset A}
-    (h : StrongReciprocity R X) : PairSymmetricOn R X := by
-  intro x hx y hy hR
-  by_cases hxy : x = y
-  · exact hxy ▸ hR
-  · exact h y hy x hx hxy
+theorem StrongReciprocity.pairSymmetricOn (h : StrongReciprocity R X) : PairSymmetricOn R X :=
+  λ _ hx _ hy hxy _ => h _ hy _ hx hxy
 
-/-- The pairwise configuration is symmetric: partners are mutual. -/
-theorem PairwiseConfig.pairSymmetricOn {R : A → A → Prop} {X : Finset A}
-    (h : PairwiseConfig R X) : PairSymmetricOn R X := by
-  obtain ⟨P, -, -, hiff⟩ := h
-  intro x _ y _ hR
-  obtain ⟨c, hc, hxc, hyc, hne⟩ := (hiff x y).mp hR
-  exact (hiff y x).mpr ⟨c, hc, hyc, hxc, hne.symm⟩
+theorem PairwiseConfig.pairSymmetricOn [DecidableEq A] (h : PairwiseConfig R X) :
+    PairSymmetricOn R X := by
+  obtain ⟨P, -, hiff⟩ := h
+  intro x _ y _ _ hR
+  obtain ⟨c, hc, hxc, hyc, hne⟩ := (hiff x y).1 hR
+  exact (hiff y x).2 ⟨c, hc, hyc, hxc, hne.symm⟩
 
-/-- The chain configuration is not symmetric: followers are not
-    followed back ([majid-et-al-2011]'s directed line). -/
-theorem ChainConfig.not_pairSymmetricOn {R : A → A → Prop} {X : Finset A}
-    (h : ChainConfig R X) : ¬ PairSymmetricOn R X := by
-  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
-  obtain - | ⟨a, - | ⟨b, t⟩⟩ := l
-  · simp at hlen
-  · simp at hlen
-  · intro hsym
-    have hcons : Consecutive (a :: b :: t) a b := by simp [Consecutive]
-    have haX : a ∈ X := (hmem a).mp (consecutive_mem hcons).1
-    have hbX : b ∈ X := (hmem b).mp (consecutive_mem hcons).2
-    exact consecutive_asymm hnd hcons
-      ((hiff b a).mp (hsym a haX b hbX ((hiff a b).mpr hcons)))
+theorem ChainConfig.not_pairSymmetricOn [DecidableEq A] (h : ChainConfig R X) :
+    ¬ PairSymmetricOn R X := by
+  obtain ⟨l, hnd, rfl, hlen, hiff⟩ := h
+  obtain ⟨b, hb⟩ := exists_consecutive_of_getLast hlen
+    (List.getLast?_eq_getElem?.trans (List.getElem?_eq_getElem (by omega)))
+  intro hsym
+  exact hb.asymm hnd ((hiff _ _).1 (hsym (List.mem_toFinset.2 hb.mem_left)
+    (List.mem_toFinset.2 hb.mem_right) (hb.ne hnd) ((hiff _ _).2 hb)))
 
-/-- The ring configuration is not symmetric (for genuine rings of three
-    or more): the cycle is directed. -/
-theorem RingConfig.not_pairSymmetricOn {R : A → A → Prop} {X : Finset A}
-    (h : RingConfig R X) : ¬ PairSymmetricOn R X := by
-  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
-  obtain - | ⟨a, - | ⟨b, - | ⟨c, t⟩⟩⟩ := l
-  · simp at hlen
-  · simp at hlen
-  · simp at hlen
-  · intro hsym
-    have hcons : Consecutive (a :: b :: c :: t) a b := by simp [Consecutive]
-    have haX : a ∈ X := (hmem a).mp (consecutive_mem hcons).1
-    have hbX : b ∈ X := (hmem b).mp (consecutive_mem hcons).2
-    rcases (hiff b a).mp
-        (hsym a haX b hbX ((hiff a b).mpr (Or.inl hcons))) with hba | ⟨hlast, -⟩
-    · exact consecutive_asymm hnd hcons hba
-    · rw [List.getLast?_cons_cons, List.getLast?_cons_cons] at hlast
-      exact (List.nodup_cons.mp (List.nodup_cons.mp hnd).2).1
-        (getLast?_mem hlast)
+theorem RingConfig.not_pairSymmetricOn [DecidableEq A] (h : RingConfig R X) :
+    ¬ PairSymmetricOn R X := by
+  obtain ⟨l, hnd, rfl, hlen, hiff⟩ := h
+  obtain ⟨b, hb⟩ := exists_consecutive_of_getLast (by omega : 2 ≤ l.length)
+    (List.getLast?_eq_getElem?.trans (List.getElem?_eq_getElem (by omega)))
+  intro hsym
+  rcases (hiff _ _).1 (hsym (List.mem_toFinset.2 hb.mem_left) (List.mem_toFinset.2 hb.mem_right)
+      (hb.ne hnd) ((hiff _ _).2 (Or.inl hb))) with hba | ⟨-, hhead⟩
+  · exact hb.asymm hnd hba
+  · obtain ⟨i, hi, hi'⟩ := hb
+    have hi₁ : i + 1 < l.length := (List.getElem?_eq_some_iff.1 hi').1
+    have e₁ := (List.getElem?_inj hi₁ hnd).1
+      (hi'.trans (List.getElem?_eq_getElem (by omega)).symm)
+    rw [List.head?_eq_getElem?] at hhead
+    have e₂ := (List.getElem?_inj (by omega : 0 < l.length) hnd).1 (hhead.trans hi.symm)
+    omega
 
-/-- The radial configuration is not symmetric: the center acts on the
-    periphery, never conversely ([majid-et-al-2011]). -/
-theorem RadialConfig.not_pairSymmetricOn [DecidableEq A]
-    {R : A → A → Prop} {X : Finset A}
-    (h : RadialConfig R X) : ¬ PairSymmetricOn R X := by
+theorem RadialConfig.not_pairSymmetricOn [DecidableEq A] (h : RadialConfig R X) :
+    ¬ PairSymmetricOn R X := by
   obtain ⟨c, hc, hcard, hiff⟩ := h
   obtain ⟨y, hy, hyc⟩ := X.exists_mem_ne hcard c
   intro hsym
-  exact hyc ((hiff y c).mp
-    (hsym c hc y hy ((hiff c y).mpr ⟨rfl, hy, hyc⟩))).1
+  exact hyc ((hiff y c).1 (hsym hc hy hyc.symm ((hiff c y).2 ⟨rfl, hy, hyc⟩))).1
 
-/-! #### Exhaustiveness theorems
+/-! #### Exhaustiveness
 
-Participant-exhaustiveness is `InclusiveAlternativeOrdering` — the
-weakest scheme in the lattice. Every configuration except melee entails
-it (the strong configuration via `strong_imp_inclusiveAlternative`);
-melee denies it by definition. -/
+Participant-exhaustiveness is Inclusive Alternative Ordering, the weakest scheme; every
+configuration but melee entails it, and melee denies it by definition. -/
 
-/-- Everyone at a pairwise event has a partner. -/
-theorem PairwiseConfig.inclusiveAlternativeOrdering [DecidableEq A]
-    {R : A → A → Prop} {X : Finset A}
-    (h : PairwiseConfig R X) : InclusiveAlternativeOrdering R X := by
-  obtain ⟨P, hcells, hcover, hiff⟩ := h
+theorem PairwiseConfig.partitionedStrong [DecidableEq A] (h : PairwiseConfig R X) :
+    PartitionedStrongReciprocity R X :=
+  let ⟨P, hcells, hiff⟩ := h
+  ⟨P, λ c hc => ⟨(hcells c hc).ge, λ x hx y hy hne => (hiff x y).2 ⟨c, hc, hx, hy, hne.symm⟩⟩⟩
+
+theorem PairwiseConfig.inclusiveAlternativeOrdering [DecidableEq A] (h : PairwiseConfig R X) :
+    InclusiveAlternativeOrdering R X :=
+  oneWay_imp_inclusiveAlternative (partitionedStrong_imp_weak h.partitionedStrong).1
+
+theorem ChainConfig.inclusiveAlternativeOrdering [DecidableEq A] (h : ChainConfig R X) :
+    InclusiveAlternativeOrdering R X := by
+  obtain ⟨l, hnd, rfl, hlen, hiff⟩ := h
   intro x hx
-  obtain ⟨c, hc, hxc⟩ := hcover x hx
-  have h2 : c.card = 2 := (hcells c hc).1
-  obtain ⟨y, hyc, hyx⟩ := c.exists_mem_ne (by omega) x
-  exact ⟨y, (hcells c hc).2 hyc, hyx.symm,
-    Or.inl ((hiff x y).mpr ⟨c, hc, hxc, hyc, hyx.symm⟩)⟩
+  rcases exists_consecutive_or_getLast (List.mem_toFinset.1 hx) with ⟨y, hy⟩ | hlast
+  · exact ⟨y, List.mem_toFinset.2 hy.mem_right, hy.ne hnd, Or.inl ((hiff x y).2 hy)⟩
+  · obtain ⟨y, hy⟩ := exists_consecutive_of_getLast hlen hlast
+    exact ⟨y, List.mem_toFinset.2 hy.mem_left, (hy.ne hnd).symm, Or.inr ((hiff y x).2 hy)⟩
 
-/-- Everyone in a chain follows or is followed. -/
-theorem ChainConfig.inclusiveAlternativeOrdering
-    {R : A → A → Prop} {X : Finset A}
-    (h : ChainConfig R X) : InclusiveAlternativeOrdering R X := by
-  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
+theorem RingConfig.oneWayWeak [DecidableEq A] (h : RingConfig R X) :
+    OneWayWeakReciprocity R X := by
+  obtain ⟨l, hnd, rfl, hlen, hiff⟩ := h
   intro x hx
-  rcases mem_consecutive_or_getLast ((hmem x).mpr hx) with ⟨y, hy⟩ | hlast
-  · exact ⟨y, (hmem y).mp (consecutive_mem hy).2,
-      consecutive_ne hnd hy, Or.inl ((hiff x y).mpr hy)⟩
-  · obtain ⟨y, hy⟩ := getLast?_consecutive hlen hlast
-    exact ⟨y, (hmem y).mp (consecutive_mem hy).1,
-      (consecutive_ne hnd hy).symm, Or.inr ((hiff y x).mpr hy)⟩
+  rcases exists_consecutive_or_getLast (List.mem_toFinset.1 hx) with ⟨y, hy⟩ | hlast
+  · exact ⟨y, List.mem_toFinset.2 hy.mem_right, (hiff x y).2 (Or.inl hy), hy.ne hnd⟩
+  · have hhead : l.head? = some l[0] :=
+      List.head?_eq_getElem?.trans (List.getElem?_eq_getElem (by omega))
+    refine ⟨l[0], List.mem_toFinset.2 (List.getElem_mem _),
+      (hiff x _).2 (Or.inr ⟨hlast, hhead⟩), λ hx0 => ?_⟩
+    rw [List.getLast?_eq_getElem?, hx0] at hlast
+    have := (List.getElem?_inj (by omega : l.length - 1 < l.length) hnd).1
+      (hlast.trans (List.getElem?_eq_getElem (by omega)).symm)
+    omega
 
-/-- Everyone in a ring chases someone: the ring configuration yields
-    `OneWayWeakReciprocity` (which a chain does not — its last member
-    acts on nobody). -/
-theorem RingConfig.oneWayWeak {R : A → A → Prop} {X : Finset A}
-    (h : RingConfig R X) : OneWayWeakReciprocity R X := by
-  obtain ⟨l, hnd, hmem, hlen, hiff⟩ := h
-  intro x hx
-  rcases mem_consecutive_or_getLast ((hmem x).mpr hx) with ⟨y, hy⟩ | hlast
-  · exact ⟨y, (hmem y).mp (consecutive_mem hy).2,
-      (hiff x y).mpr (Or.inl hy), consecutive_ne hnd hy⟩
-  · obtain - | ⟨a, t⟩ := l
-    · simp at hlen
-    · refine ⟨a, (hmem a).mp (List.mem_cons_self ..),
-        (hiff x a).mpr (Or.inr ⟨hlast, rfl⟩), fun hxa => ?_⟩
-      obtain - | ⟨b, t'⟩ := t
-      · simp at hlen
-      · rw [hxa, List.getLast?_cons_cons] at hlast
-        exact (List.nodup_cons.mp hnd).1 (getLast?_mem hlast)
+theorem RingConfig.inclusiveAlternativeOrdering [DecidableEq A] (h : RingConfig R X) :
+    InclusiveAlternativeOrdering R X :=
+  oneWay_imp_inclusiveAlternative h.oneWayWeak
 
-/-- The ring configuration participates everyone. -/
-theorem RingConfig.inclusiveAlternativeOrdering
-    {R : A → A → Prop} {X : Finset A}
-    (h : RingConfig R X) : InclusiveAlternativeOrdering R X :=
-  oneWay_imp_inclusiveAlternative R X h.oneWayWeak
-
-/-- Radial events participate everyone: the center acts on each
-    peripheral member. -/
-theorem RadialConfig.inclusiveAlternativeOrdering [DecidableEq A]
-    {R : A → A → Prop} {X : Finset A}
-    (h : RadialConfig R X) : InclusiveAlternativeOrdering R X := by
+theorem RadialConfig.inclusiveAlternativeOrdering [DecidableEq A] (h : RadialConfig R X) :
+    InclusiveAlternativeOrdering R X := by
   obtain ⟨c, hc, hcard, hiff⟩ := h
   intro x hx
   by_cases hxc : x = c
   · subst hxc
     obtain ⟨y, hy, hyx⟩ := X.exists_mem_ne hcard x
-    exact ⟨y, hy, hyx.symm, Or.inl ((hiff x y).mpr ⟨rfl, hy, hyx⟩)⟩
-  · exact ⟨c, hc, hxc, Or.inr ((hiff c x).mpr ⟨rfl, hx, hxc⟩)⟩
-
-/-! #### Lattice connections -/
-
-/-- The pairwise configuration realizes Partitioned Strong Reciprocity:
-    the pairing is the partition witness. -/
-theorem PairwiseConfig.partitionedStrong {R : A → A → Prop} {X : Finset A}
-    (h : PairwiseConfig R X) : PartitionedStrongReciprocity R X := by
-  obtain ⟨P, hcells, hcover, hiff⟩ := h
-  exact ⟨P, fun Y hY => (hcells Y hY).2, hcover,
-    fun Y hY x hx y hy hne => (hiff x y).mpr ⟨Y, hY, hx, hy, hne.symm⟩⟩
+    exact ⟨y, hy, hyx.symm, Or.inl ((hiff x y).2 ⟨rfl, hy, hyx⟩)⟩
+  · exact ⟨c, hc, hxc, Or.inr ((hiff c x).2 ⟨rfl, hx, hxc⟩)⟩
 
 end Reciprocal

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -308,7 +308,7 @@ inductive ReciprocityType where
     `RadialConfig.inclusiveAlternativeOrdering`, melee failing
     `InclusiveAlternativeOrdering` by definition, …), not stipulated
     features of the labels. -/
-def ReciprocityType.Realizes {A : Type*} :
+def ReciprocityType.Realizes {A : Type*} [DecidableEq A] :
     ReciprocityType → (A → A → Prop) → Finset A → Prop
   | .strong,   R, X => Reciprocal.StrongReciprocity R X
   | .pairwise, R, X => Reciprocal.PairwiseConfig R X


### PR DESCRIPTION
Plurality substrate cleanse, slice 2: `Reciprocal.lean` restated on mathlib's objects, with the DKMPK definitions checked against the paper.

- Partitioned Strong Reciprocity is a `Finpartition` into cells of two or more (the old `Finset (Finset A)` witness required neither disjointness nor cell size); Intermediate Reciprocity is `Relation.TransGen` of the `X`-restricted relation; chain adjacency is a pair of consecutive positions, so the private list-induction lemmas reduce to `List.getElem?_inj`.
- The entailment lattice is now complete (SR → PartSR → WR, SR → IR → WR, WR → OWR → IAO) and `StrongReciprocity` is bridged to `Set.Pairwise`; the unused `Scheme` enumeration is gone.
- Nordlinger2023 gains the `DecidableEq` the finpartition needs; every importer rebuilt.