### PR TITLE
style(Semantics/Plurality): type variable α, not Atom

### DIFF
--- a/Linglib/Semantics/Plurality/Basic.lean
+++ b/Linglib/Semantics/Plurality/Basic.lean
@@ -5,13 +5,15 @@ import Mathlib.Data.Finset.Powerset
 # Plural predication over sets of atoms
 
 This file defines the distribution operators shared by the accounts of plural predication in
-this directory, over pluralities `x : Finset Atom` and world-indexed predicates
-`P : Atom → W → Prop`, together with the tolerance relations of [kriz-spector-2021] that
-govern how far a reading may fall short of the whole plurality.
+this directory. Individuals are the elements of a type `α` and pluralities their finite sets
+`x : Finset α`, so the atoms of the lattice of pluralities are the singletons and nothing
+about atomicity has to be assumed; predicates `P : α → W → Prop` are world-indexed. The
+tolerance relations of [kriz-spector-2021] govern how far a reading may fall short of the whole
+plurality.
 
 ## Definitions
 
-* `Plurality.Tolerance Atom`: a reflexive relation `⪯` on `Finset Atom` contained in `⊆`;
+* `Plurality.Tolerance α`: a reflexive relation `⪯` on `Finset α` contained in `⊆`;
   `y ⪯ x` says `y` is close enough to `x` for current purposes. `Plurality.Tolerance.identity`
   and `Plurality.Tolerance.trivial` are the two extremes.
 * `Plurality.distMaximal P x w`: every atom of `x` satisfies `P` at `w`.
@@ -25,51 +27,51 @@ govern how far a reading may fall short of the whole plurality.
 
 namespace Plurality
 
-variable {Atom W : Type*}
+variable {α W : Type*}
 
 /-- A tolerance relation: `y ⪯ x` when the subplurality `y` is close enough to `x` for current
 purposes. Reflexive and contained in `⊆`. -/
-structure Tolerance (Atom : Type*) where
+structure Tolerance (α : Type*) where
   /-- `rel y x`: `y` is close enough to `x`. -/
-  rel : Finset Atom → Finset Atom → Prop
+  rel : Finset α → Finset α → Prop
   refl : ∀ x, rel x x
   subset_of_rel : ∀ {x y}, rel x y → x ⊆ y
 
 namespace Tolerance
 
 /-- Only `x` itself is close enough to `x`. -/
-def identity : Tolerance Atom where
+def identity : Tolerance α where
   rel x y := x = y
   refl _ := rfl
   subset_of_rel h := h ▸ Finset.Subset.refl _
 
 /-- Every subplurality of `x` is close enough to `x`. -/
-def trivial : Tolerance Atom where
+def trivial : Tolerance α where
   rel x y := x ⊆ y
   refl _ := Finset.Subset.refl _
   subset_of_rel h := h
 
-instance [DecidableEq Atom] : DecidableRel (identity (Atom := Atom)).rel :=
+instance [DecidableEq α] : DecidableRel (identity (α := α)).rel :=
   λ x y => inferInstanceAs (Decidable (x = y))
 
-instance [DecidableEq Atom] : DecidableRel (trivial (Atom := Atom)).rel :=
+instance [DecidableEq α] : DecidableRel (trivial (α := α)).rel :=
   λ x y => inferInstanceAs (Decidable (x ⊆ y))
 
 end Tolerance
 
 /-- Maximal distribution: every atom of `x` satisfies `P` at `w`. -/
-def distMaximal (P : Atom → W → Prop) (x : Finset Atom) (w : W) : Prop :=
+def distMaximal (P : α → W → Prop) (x : Finset α) (w : W) : Prop :=
   ∀ a ∈ x, P a w
 
-instance (P : Atom → W → Prop) [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
+instance (P : α → W → Prop) [∀ a w, Decidable (P a w)] (x : Finset α) (w : W) :
     Decidable (distMaximal P x w) := by
   unfold distMaximal; infer_instance
 
 /-- No atom of `x` satisfies `P` at `w`. -/
-def noneSatisfy (P : Atom → W → Prop) (x : Finset Atom) (w : W) : Prop :=
+def noneSatisfy (P : α → W → Prop) (x : Finset α) (w : W) : Prop :=
   ∀ a ∈ x, ¬ P a w
 
-instance (P : Atom → W → Prop) [∀ a w, Decidable (P a w)] (x : Finset Atom) (w : W) :
+instance (P : α → W → Prop) [∀ a w, Decidable (P a w)] (x : Finset α) (w : W) :
     Decidable (noneSatisfy P x w) := by
   unfold noneSatisfy; infer_instance
 

--- a/Linglib/Semantics/Plurality/Distributivity.lean
+++ b/Linglib/Semantics/Plurality/Distributivity.lean
@@ -37,15 +37,15 @@ namespace Plurality.Distributivity
 
 open _root_.Plurality _root_.Plurality.Algebra
 
-variable {Atom W : Type*} {P : Atom → W → Prop} {x : Finset Atom} {w : W}
+variable {α W : Type*} {P : α → W → Prop} {x : Finset α} {w : W}
 
 /-- Tolerant distribution: some nonempty subplurality `z ⪯ x` has every atom satisfying `P` at
 `w`. -/
-def distTolerant (P : Atom → W → Prop) (tol : Tolerance Atom) (x : Finset Atom) (w : W) : Prop :=
+def distTolerant (P : α → W → Prop) (tol : Tolerance α) (x : Finset α) (w : W) : Prop :=
   ∃ z ⊆ x, z.Nonempty ∧ tol.rel z x ∧ ∀ a ∈ z, P a w
 
-instance (P : Atom → W → Prop) [∀ a w, Decidable (P a w)] (tol : Tolerance Atom)
-    [DecidableRel tol.rel] (x : Finset Atom) (w : W) : Decidable (distTolerant P tol x w) := by
+instance (P : α → W → Prop) [∀ a w, Decidable (P a w)] (tol : Tolerance α)
+    [DecidableRel tol.rel] (x : Finset α) (w : W) : Decidable (distTolerant P tol x w) := by
   unfold distTolerant; infer_instance
 
 theorem distMaximal_iff_identity (hne : x.Nonempty) :
@@ -54,21 +54,21 @@ theorem distMaximal_iff_identity (hne : x.Nonempty) :
   rintro ⟨z, -, -, rfl, hz⟩
   exact hz
 
-theorem distTolerant_trivial_of_mem {a : Atom} (ha : a ∈ x) (hPa : P a w) :
+theorem distTolerant_trivial_of_mem {a : α} (ha : a ∈ x) (hPa : P a w) :
     distTolerant P Tolerance.trivial x w :=
   ⟨{a}, Finset.singleton_subset_iff.2 ha, Finset.singleton_nonempty a,
     Finset.singleton_subset_iff.2 ha, λ _ hb => (Finset.mem_singleton.1 hb) ▸ hPa⟩
 
 @[simp]
-theorem distMaximal_singleton (a : Atom) : distMaximal P {a} w ↔ P a w := by
+theorem distMaximal_singleton (a : α) : distMaximal P {a} w ↔ P a w := by
   simp [distMaximal]
 
-theorem distMaximal_pair [DecidableEq Atom] (a b : Atom) :
+theorem distMaximal_pair [DecidableEq α] (a b : α) :
     distMaximal P {a, b} w ↔ P a w ∧ P b w := by
   simp [distMaximal]
 
 /-- On a singleton every tolerance reduces to the predicate itself. -/
-theorem distTolerant_singleton (tol : Tolerance Atom) (a : Atom) :
+theorem distTolerant_singleton (tol : Tolerance α) (a : α) :
     distTolerant P tol {a} w ↔ P a w := by
   constructor
   · rintro ⟨z, hz, ⟨b, hb⟩, -, hall⟩
@@ -79,8 +79,8 @@ theorem distTolerant_singleton (tol : Tolerance Atom) (a : Atom) :
 
 /-- Maximal distribution on a nonempty plurality is Link's `*` of the predicate's atoms, taken
 as singletons ([link-1983]). -/
-theorem distMaximal_iff_star [DecidableEq Atom] (hne : x.Nonempty) :
-    distMaximal P x w ↔ star (· ∈ ({·} : Atom → Finset Atom) '' {a | P a w}) x := by
+theorem distMaximal_iff_star [DecidableEq α] (hne : x.Nonempty) :
+    distMaximal P x w ↔ star (· ∈ ({·} : α → Finset α) '' {a | P a w}) x := by
   rw [star_image_singleton, and_iff_right hne]
   exact Iff.rfl
 


### PR DESCRIPTION
Follow-up to #3341: the type variable in `Plurality/Basic.lean` and `Distributivity.lean` was named `Atom`, suggesting a constraint that nothing enforces or needs.

- Renamed to `α` per mathlib convention; the header now says that individuals are the elements of `α` and pluralities their finite sets, so the atoms of the lattice are the singletons by construction.
- Consumers bind their own type variables and are unaffected; all eight importers rebuilt.