### PR TITLE
refactor(Semantics/Mereology): atoms of a closure are members, for any P

### DIFF
--- a/Linglib/Semantics/Mereology.lean
+++ b/Linglib/Semantics/Mereology.lean
@@ -266,11 +266,17 @@ theorem IsPlural.algClosure (h : IsPlural P x) : AlgClosure P x := h.1
 theorem not_isPlural_of_subsingleton (h : ∀ a b, P a → P b → a = b) (x : α) : ¬ IsPlural P x :=
   fun ⟨_, _, _, _, _, ha, hb, hne⟩ => hne (h _ _ ha hb)
 
-/-- An atom in the closure of a predicate holding only of atoms is one of its members. -/
-theorem of_algClosure_of_atom (hP : ∀ ⦃a⦄, P a → Atom a) (hx : AlgClosure P x) (h : Atom x) :
-    P x :=
-  let ⟨_, ha, hle⟩ := algClosure_has_base hx
-  h.eq hle (hP ha).not_isBot ▸ ha
+/-- An atom in the closure of a predicate is one of its members: an atom is not a proper sum. -/
+theorem of_algClosure_of_atom (hx : AlgClosure P x) (h : Atom x) : P x := by
+  induction hx with
+  | base hp => exact hp
+  | @sum a b _ _ iha ihb =>
+    by_cases ha : IsBot a
+    · rw [sup_eq_right.mpr (ha _)] at h ⊢
+      exact ihb h
+    · have heq := h.eq le_sup_left ha
+      rw [← heq] at h ⊢
+      exact iha h
 
 /-- For a predicate holding only of atoms, a plurality is a non-atomic element of the closure. -/
 theorem isPlural_iff_of_atom (hP : ∀ ⦃a⦄, P a → Atom a) :
@@ -287,7 +293,7 @@ theorem isPlural_iff_of_atom (hP : ∀ ⦃a⦄, P a → Atom a) :
       · by_cases haz : Atom z
         · refine ⟨y, lt_of_le_of_ne le_sup_left fun h => hne (by rw [← h]; exact hay),
             z, lt_of_le_of_ne le_sup_right fun h => hne (by rw [← h]; exact haz),
-            of_algClosure_of_atom hP hy hay, of_algClosure_of_atom hP hz haz, fun h => hne ?_⟩
+            of_algClosure_of_atom hy hay, of_algClosure_of_atom hz haz, fun h => hne ?_⟩
           subst h
           rwa [sup_idem]
         · obtain ⟨a, ha, b, hb, hPa, hPb, hab⟩ := ihz haz

--- a/Linglib/Semantics/Plurality/Algebra.lean
+++ b/Linglib/Semantics/Plurality/Algebra.lean
@@ -138,20 +138,9 @@ end Constitution
 
 /-! ### Link's theorems -/
 
-theorem of_star_of_atom (hx : Atom x) (h : star P x) : P x := by
-  induction h with
-  | base hp => exact hp
-  | @sum a b _ _ iha ihb =>
-    by_cases ha : IsBot a
-    · rw [sup_eq_right.mpr (ha _)] at hx ⊢
-      exact ihb hx
-    · have heq := hx.eq le_sup_left ha
-      rw [← heq] at hx ⊢
-      exact iha hx
-
 /-- On an atom, `*P` and `P` agree (T.8). -/
 theorem star_iff_of_atom (hx : Atom x) : star P x ↔ P x :=
-  ⟨of_star_of_atom hx, .base⟩
+  ⟨(of_algClosure_of_atom · hx), .base⟩
 
 /-- No element of a distributive predicate is a proper plural (T.6). -/
 theorem IsDistr.not_properPlural (hP : IsDistr P) (hx : P x) : ¬ properPlural P x :=

--- a/Linglib/Studies/DelPrete2013.lean
+++ b/Linglib/Studies/DelPrete2013.lean
@@ -95,7 +95,7 @@ variable {linear τ}
 theorem isPlural_of_large {V₀ : E → Prop} (hV₀ : ∀ ⦃e⦄, V₀ e → Atom e) {s : S}
     (hL : Large linear τ V₀ s) {b : S} (hb : Branch linear b s) {e : E}
     (he : AlgClosure V₀ e) (hbe : b ≤ τ e) : IsPlural V₀ e :=
-  (isPlural_iff_of_atom hV₀).2 ⟨he, λ ha => hL b hb e (of_algClosure_of_atom hV₀ he ha) hbe⟩
+  (isPlural_iff_of_atom hV₀).2 ⟨he, λ ha => hL b hb e (of_algClosure_of_atom he ha) hbe⟩
 
 /-- PROG, §5: over a small reference situation, a single singular event whose trace covers the
 expanded situation verifies the same denotation. -/


### PR DESCRIPTION
Follow-up to #3345: `Mereology.of_algClosure_of_atom` no longer assumes the predicate holds of atoms only. An atom is not a proper sum, so an atom in `*P` is a member of `P` for every `P`; the proof is the induction that lived in `Plurality/Algebra.lean` as `of_star_of_atom`, which is deleted.

- `isPlural_iff_of_atom` and DelPrete2013 drop the now-unneeded argument at their call sites.
- All 32 importers of Mereology and Algebra rebuilt.