### PR TITLE
refactor(Semantics/Plurality): group model on plain finsets

### DIFF
--- a/Linglib/Semantics/Plurality/Groups.lean
+++ b/Linglib/Semantics/Plurality/Groups.lean
@@ -1,36 +1,44 @@
-import Linglib.Semantics.Mereology
+import Mathlib.Data.Finset.Grade
 import Mathlib.Logic.Equiv.Finset
+import Linglib.Semantics.Mereology
 
 /-!
-# Group formation and dissolution
+# Group formation
 
-[landman-1989] [landman-2000]
+This file defines Landman's group operators on a join-semilattice `E` of individuals or events.
+Formation `up` packs a plural sum into an atom, the group, and dissolution `down` recovers the
+sum ([landman-1989]; [landman-2000]). The carrier is any `SemilatticeSup`, so the operators
+serve the domain of individuals and the domain of events alike; in the event domain, a
+symmetric verb's atomic event dissolves into the sum of its directional sub-events
+([siloni-2012]). A model on finite sets shows the two laws consistent.
 
-Landman's group operators over a part-of domain: `up` packs a plural sum
-into a group atom — *the committee* as a singular entity over its
-members — and `down` dissolves the group back into the underlying sum.
-The carrier is any `SemilatticeSup`, so the operators serve the domain of
-individuals and the domain of events alike ([landman-2000]); in the event
-domain, a symmetric verb's atomic event dissolves into the sum of its
-directional sub-events ([siloni-2012] §4.1).
+## Definitions
 
-## Main declarations
+* `Plurality.GroupStructure E`: `up` and `down`, with a group an atom and dissolution the
+  inverse of formation.
+* `Plurality.GroupStructure.finsetModel β`: the model on `Finset (β ⊕ ℕ)`, packing a plurality
+  into the singleton of a fresh marker indexed by its code.
 
-* `GroupStructure` — `up`/`down` with the atomicity and dissolution laws.
-* `GroupStructure.up_injective` — distinct sums form distinct groups.
+## Main results
+
+* `Plurality.GroupStructure.up_injective`: distinct sums form distinct groups.
+
+## References
+
+* [F. Landman, *Groups, I* (1989)][landman-1989]
+* [F. Landman, *Events and plurality* (2000)][landman-2000]
+* [T. Siloni, *Reciprocal verbs and symmetry* (2012)][siloni-2012]
 -/
 
 namespace Plurality
 
-/-- Landman's group structure: `up` packs a sum into a group atom, `down`
-    recovers the underlying sum. The two laws are the operative core of
-    [landman-1989]'s postulates. -/
+/-- Landman's group structure: `up` packs a sum into a group atom and `down` recovers the sum. -/
 structure GroupStructure (E : Type*) [SemilatticeSup E] where
-  /-- Group formation (Landman's `↑`). -/
+  /-- Group formation. -/
   up : E → E
-  /-- Group dissolution (Landman's `↓`). -/
+  /-- Group dissolution. -/
   down : E → E
-  /-- A group is an atom: it has no proper parts. -/
+  /-- A group is an atom. -/
   atom_up (x : E) : Mereology.Atom (up x)
   /-- Dissolution inverts formation. -/
   down_up (x : E) : down (up x) = x
@@ -39,68 +47,35 @@ namespace GroupStructure
 
 variable {E : Type*} [SemilatticeSup E] (G : GroupStructure E)
 
-/-- Distinct sums form distinct group atoms. -/
 theorem up_injective : Function.Injective G.up :=
   Function.LeftInverse.injective G.down_up
 
 /-! ### A model
 
-Nonempty finite subsets of `β ⊕ ℕ`, with sum as union: the `β`-singletons
-are the ordinary atoms, and packing recruits a fresh `ℕ`-marked singleton
-for each plurality, so groups are atoms of the same domain. -/
-
-instance {α : Type*} [DecidableEq α] :
-    SemilatticeSup {F : Finset α // F.Nonempty} :=
-  Subtype.semilatticeSup fun _ _ hx _ => hx.mono Finset.subset_union_left
-
-@[simp] theorem coe_sup {α : Type*} [DecidableEq α]
-    (x y : {F : Finset α // F.Nonempty}) :
-    (↑(x ⊔ y) : Finset α) = ↑x ∪ ↑y :=
-  Finset.sup_eq_union ..
+Finite subsets of `β ⊕ ℕ` under union: the `β`-singletons are the ordinary atoms, and packing
+recruits the singleton of a fresh `ℕ`-marker for each plurality, so groups are atoms of the same
+domain. -/
 
 variable {β : Type*} [Encodable β]
 
-instance {α : Type*} : DecidablePred (fun F : Finset α => F.Nonempty) :=
-  fun _ => Finset.decidableNonempty
+/-- Group formation in the model: the singleton of the marker indexed by the plurality's
+code. -/
+def modelUp (x : Finset (β ⊕ ℕ)) : Finset (β ⊕ ℕ) :=
+  {Sum.inr (Encodable.encode x)}
 
-/-- Group formation in the model: the fresh marker singleton indexed by
-    the plurality's code. -/
-def modelUp (x : {F : Finset (β ⊕ ℕ) // F.Nonempty}) :
-    {F : Finset (β ⊕ ℕ) // F.Nonempty} :=
-  ⟨{Sum.inr (Encodable.encode x)}, Finset.singleton_nonempty _⟩
+theorem modelUp_injective : Function.Injective (modelUp (β := β)) := λ _ _ h =>
+  Encodable.encode_injective (Sum.inr.inj (Finset.singleton_injective h))
 
-theorem modelUp_injective :
-    Function.Injective (modelUp (β := β)) := fun x y h => by
-  have h' : ({Sum.inr (Encodable.encode x)} : Finset (β ⊕ ℕ)) =
-      {Sum.inr (Encodable.encode y)} := congrArg Subtype.val h
-  exact Encodable.encode_injective (Sum.inr.inj
-    (Finset.singleton_injective h'))
-
-instance : Nonempty {F : Finset (β ⊕ ℕ) // F.Nonempty} :=
-  ⟨⟨{Sum.inr 0}, Finset.singleton_nonempty _⟩⟩
-
-/-- Landman's group operators are consistent: the nonempty finite subsets
-    of `β ⊕ ℕ` carry a `GroupStructure`, with dissolution the left inverse
-    of formation. -/
+/-- The finite sets of `β ⊕ ℕ` carry a group structure, with dissolution the left inverse of
+formation. -/
 noncomputable def finsetModel (β : Type*) [DecidableEq β] [Encodable β] :
-    GroupStructure {F : Finset (β ⊕ ℕ) // F.Nonempty} where
+    GroupStructure (Finset (β ⊕ ℕ)) where
   up := modelUp
   down := Function.invFun modelUp
-  atom_up x := by
-    refine ⟨fun h => ?_, fun z _ hz => ?_⟩
-    · have h0 := Sum.inr.inj (Finset.mem_singleton.mp (Finset.singleton_subset_iff.mp
-        (h ⟨{Sum.inr 0}, Finset.singleton_nonempty _⟩)))
-      have h1 := Sum.inr.inj (Finset.mem_singleton.mp (Finset.singleton_subset_iff.mp
-        (h ⟨{Sum.inr 1}, Finset.singleton_nonempty _⟩)))
-      omega
-    have hsub : z.val ⊆ {Sum.inr (Encodable.encode x)} := hz
-    rcases Finset.subset_singleton_iff.mp hsub with hempty | hsingle
-    · exact absurd hempty (Finset.nonempty_iff_ne_empty.mp z.2)
-    · exact le_of_eq (Subtype.ext hsingle.symm)
+  atom_up _ := Mereology.atom_iff_isAtom.2 (Finset.isAtom_singleton _)
   down_up := Function.leftInverse_invFun modelUp_injective
 
-@[simp] theorem finsetModel_up [DecidableEq β]
-    (x : {F : Finset (β ⊕ ℕ) // F.Nonempty}) :
+@[simp] theorem finsetModel_up [DecidableEq β] (x : Finset (β ⊕ ℕ)) :
     (finsetModel β).up x = modelUp x := rfl
 
 end GroupStructure

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -708,21 +708,18 @@ inductive Kisser where
   | rina
   deriving DecidableEq, Repr
 
-/-- The event domain: nonempty finite sets of atomic event markers, the
-    left summand for directional kissings and the right for group
-    atoms. -/
-abbrev KissEvent : Type := {F : Finset (ℕ ⊕ ℕ) // F.Nonempty}
+/-- The event domain: finite sets of atomic event markers, the left summand
+    for directional kissings and the right for group atoms. -/
+abbrev KissEvent : Type := Finset (ℕ ⊕ ℕ)
 
 noncomputable def kissGroups : GroupStructure KissEvent :=
   GroupStructure.finsetModel ℕ
 
 /-- The `i`-th directional kissing event. -/
-def directional (i : ℕ) : KissEvent :=
-  ⟨{Sum.inl i}, Finset.singleton_nonempty _⟩
+def directional (i : ℕ) : KissEvent := {Sum.inl i}
 
 theorem directional_injective : Function.Injective directional :=
-  fun _ _ h => Sum.inl.inj (Finset.singleton_injective
-    (congrArg Subtype.val h))
+  λ _ _ h => Sum.inl.inj (Finset.singleton_injective h)
 
 /-- Round `j` kisses in both directions: Dan's is event `2j`, Rina's is
     event `2j + 1`. -/
@@ -771,8 +768,7 @@ theorem mutualEvent_injective : Function.Injective mutualEvent := by
   have hv : ({Sum.inl (2 * (j : ℕ))} ∪ {Sum.inl (2 * (j : ℕ) + 1)}
       : Finset (ℕ ⊕ ℕ)) =
       {Sum.inl (2 * (j' : ℕ))} ∪ {Sum.inl (2 * (j' : ℕ) + 1)} := by
-    simpa [directional, GroupStructure.coe_sup] using
-      congrArg Subtype.val h2
+    simpa [directional, Finset.sup_eq_union] using h2
   have hmem : (Sum.inl (2 * (j : ℕ)) : ℕ ⊕ ℕ) ∈
       ({Sum.inl (2 * (j' : ℕ))} ∪ {Sum.inl (2 * (j' : ℕ) + 1)}
         : Finset (ℕ ⊕ ℕ)) := by
@@ -813,8 +809,8 @@ theorem card_accumulated : (Finset.univ.image accumulated).card = 5 := by
     have hmem : (Sum.inl (2 * (j : ℕ)) : ℕ ⊕ ℕ) ∈
         ({Sum.inl (2 * (j' : ℕ))} ∪ {Sum.inl (2 * (j' : ℕ) + 1)}
           : Finset (ℕ ⊕ ℕ)) := by
-      have hv := congrArg Subtype.val h
-      simp only [accumulated, GroupStructure.coe_sup, directional] at hv
+      have hv := h
+      simp only [accumulated, Finset.sup_eq_union, directional] at hv
       rw [← hv]; simp
     simp only [Finset.mem_union, Finset.mem_singleton, Sum.inl.injEq] at hmem
     exact Fin.ext (by omega)


### PR DESCRIPTION
`Groups.lean` register pass and removal of its orphan instance.

- The consistency model for Landman's `up`/`down` now lives on `Finset (β ⊕ ℕ)`, which is already a `SemilatticeSup`; singletons are atoms there via `Finset.isAtom_singleton` and `Mereology.atom_iff_isAtom`, so the global `SemilatticeSup {F : Finset α // F.Nonempty}` instance, `coe_sup`, and the `Nonempty` instance are gone.
- Header in mathlib register; docstrings single sentences; `fun` → `λ`.
- Siloni2012, the one consumer of the model, drops its `Subtype` wrappers and `congrArg Subtype.val` steps; the other two importers use `GroupStructure` abstractly and are unchanged.